### PR TITLE
feat(chat-panel): streaming placeholder + pinned actions fade

### DIFF
--- a/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.tsx
+++ b/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.tsx
@@ -67,7 +67,7 @@ const ActionPill: React.FC<ActionPillProps> = memo(
       shape="round"
       title={action.name}
       onClick={(event) => onClick(action, event)}
-      className="max-w-[180px] select-none"
+      className="max-w-[180px] shrink-0 select-none"
     >
       {action.name}
     </Button>
@@ -245,44 +245,56 @@ const PinnedActionsBar: React.FC<PinnedActionsBarProps> = memo(
     );
 
     return (
-      <div className="relative flex min-w-0 items-center gap-1 overflow-x-auto scrollbar-hide">
-        {showPrPill && (
-          <Button
-            variant="secondary"
-            size="small"
-            shape="round"
-            title={t("input.pr.open", { defaultValue: "Open PR" })}
-            onClick={handleOpenPr}
-            loading={prIsCreating}
-            icon={
-              !prIsCreating ? (
-                <GitPullRequest size={12} strokeWidth={1.75} />
-              ) : undefined
-            }
-            className="max-w-[180px] select-none"
-          >
-            {prIsCreating
-              ? t("input.pr.creating", { defaultValue: "Creating PR…" })
-              : t("input.pr.open", { defaultValue: "Open PR" })}
-          </Button>
-        )}
+      <div className="relative flex min-w-0 flex-1 items-center gap-1">
+        <div className="relative min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-1 overflow-x-auto scrollbar-hide">
+            {showPrPill && (
+              <Button
+                variant="secondary"
+                size="small"
+                shape="round"
+                title={t("input.pr.open", { defaultValue: "Open PR" })}
+                onClick={handleOpenPr}
+                loading={prIsCreating}
+                icon={
+                  !prIsCreating ? (
+                    <GitPullRequest size={12} strokeWidth={1.75} />
+                  ) : undefined
+                }
+                className="max-w-[180px] shrink-0 select-none"
+              >
+                {prIsCreating
+                  ? t("input.pr.creating", { defaultValue: "Creating PR…" })
+                  : t("input.pr.open", { defaultValue: "Open PR" })}
+              </Button>
+            )}
 
-        {showCanvasPill && !isCanvasTabOpen && (
-          <UserActionButton
-            leftIcon={<Layout size={12} strokeWidth={1.75} />}
-            title="Canvas"
-            onClick={handleOpenCanvas}
-            onClose={handleClearCanvas}
-          />
-        )}
+            {showCanvasPill && !isCanvasTabOpen && (
+              <div className="shrink-0">
+                <UserActionButton
+                  leftIcon={<Layout size={12} strokeWidth={1.75} />}
+                  title="Canvas"
+                  onClick={handleOpenCanvas}
+                  onClose={handleClearCanvas}
+                />
+              </div>
+            )}
 
-        {pinnedActions.map((action) => (
-          <ActionPill
-            key={actionKey(action)}
-            action={action}
-            onClick={handlePillClick}
-          />
-        ))}
+            {pinnedActions.map((action) => (
+              <ActionPill
+                key={actionKey(action)}
+                action={action}
+                onClick={handlePillClick}
+              />
+            ))}
+          </div>
+          {hasLeadingPills && (
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-y-0 right-0 w-6 bg-gradient-to-l from-[var(--color-chat-input)] to-transparent"
+            />
+          )}
+        </div>
 
         <Button
           ref={moreButtonRef}

--- a/src/engines/ChatPanel/events/interactive_events/ask-question/index.tsx
+++ b/src/engines/ChatPanel/events/interactive_events/ask-question/index.tsx
@@ -309,6 +309,35 @@ const QuestionHistoryBlock: React.FC<{
 };
 
 // ============================================
+// Streaming placeholder — shown while `args.questions` hasn't streamed in yet
+// ============================================
+
+const QuestionStreamingPlaceholder: React.FC<{ eventId?: string }> = ({
+  eventId,
+}) => {
+  const lifecycle = useLifecycleLabels("ask_user_questions");
+  return (
+    <div
+      className={getEventBlockContainerClasses(false)}
+      data-tool-call-event-id={eventId}
+      data-tool-call-name="ask_user_questions"
+    >
+      <EventBlockHeader isCollapsed withHover={false}>
+        <EventBlockHeaderIcon
+          icon={STATUS_ICON.pending}
+          isCollapsed
+          isHeaderHovered={false}
+          hasContent={false}
+        />
+        <EventBlockHeaderTitle isLoading>
+          {lifecycle.running}
+        </EventBlockHeaderTitle>
+      </EventBlockHeader>
+    </div>
+  );
+};
+
+// ============================================
 // Main Component
 // ============================================
 
@@ -328,7 +357,20 @@ export const AskQuestionEvent: React.FC<AskQuestionEventProps> = (props) => {
     ((props as Record<string, unknown>).id as string | undefined);
 
   if (!normalizedProps) return null;
-  if (pairs.length === 0) return null;
+
+  const showActiveEventPainting =
+    normalizedProps.showActiveEventPainting ?? false;
+  const isStreaming =
+    rawStatus !== "completed" &&
+    rawStatus !== "failed" &&
+    showActiveEventPainting;
+
+  if (pairs.length === 0) {
+    if (isStreaming) {
+      return <QuestionStreamingPlaceholder eventId={eventId} />;
+    }
+    return null;
+  }
 
   const status = resolveDisplayStatus(rawStatus, isAnswered);
 
@@ -338,7 +380,7 @@ export const AskQuestionEvent: React.FC<AskQuestionEventProps> = (props) => {
       status={status}
       eventId={eventId}
       variant={props.variant}
-      showActiveEventPainting={normalizedProps.showActiveEventPainting ?? false}
+      showActiveEventPainting={showActiveEventPainting}
     />
   );
 };

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -106,6 +106,7 @@
     "closeSaved": "Close Saved",
     "openInNewWindow": "Open in New Window",
     "openInNewTab": "Open in New Tab",
+    "openOnGitHub": "Open on GitHub",
     "confirmDelete": "Confirm Delete",
     "confirmDeleteTitle": "Delete \"{{name}}\"?",
     "confirmDeleteMessage": "This will be permanently deleted. This action cannot be undone.",
@@ -339,6 +340,12 @@
     "gitHistory": "Git History",
     "noPullRequest": "No pull request",
     "pullRequest": "Pull request",
+    "prStatus": {
+      "open": "Open",
+      "merged": "Merged",
+      "closed": "Closed",
+      "draft": "Draft"
+    },
     "operationLog": "Operation Log",
     "gitDashboard": "Dashboard",
     "changedFiles": "Changed Files",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -106,6 +106,7 @@
     "closeSaved": "關閉已保存",
     "openInNewWindow": "在新窗口中打開",
     "openInNewTab": "在新標籤頁中打開",
+    "openOnGitHub": "在 GitHub 中開啟",
     "confirmDelete": "確認刪除",
     "confirmDeleteTitle": "刪除「{{name}}」？",
     "confirmDeleteMessage": "此操作將永久刪除，無法撤銷。",
@@ -335,6 +336,12 @@
     "gitHistory": "Git 歷史",
     "noPullRequest": "無 Pull Request",
     "pullRequest": "Pull Request",
+    "prStatus": {
+      "open": "開啟",
+      "merged": "已合併",
+      "closed": "已關閉",
+      "draft": "草稿"
+    },
     "operationLog": "操作日誌",
     "gitDashboard": "儀表盤",
     "changedFiles": "已更改的文件",

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -106,6 +106,7 @@
     "closeSaved": "关闭已保存",
     "openInNewWindow": "在新窗口中打开",
     "openInNewTab": "在新标签页中打开",
+    "openOnGitHub": "在 GitHub 中打开",
     "confirmDelete": "确认删除",
     "confirmDeleteTitle": "删除「{{name}}」？",
     "confirmDeleteMessage": "此操作将永久删除，无法撤销。",
@@ -335,6 +336,12 @@
     "gitHistory": "Git 历史",
     "noPullRequest": "无 Pull Request",
     "pullRequest": "Pull Request",
+    "prStatus": {
+      "open": "开启",
+      "merged": "已合并",
+      "closed": "已关闭",
+      "draft": "草稿"
+    },
     "operationLog": "操作日志",
     "gitDashboard": "仪表盘",
     "changedFiles": "已更改的文件",

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/__tests__/TEST_CASES.md
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/__tests__/TEST_CASES.md
@@ -1,0 +1,75 @@
+# Test Cases: PullRequestContent (Sidebar PR Summary Card)
+
+Covers the PR header card rendered at the top of the WorkStation primary
+sidebar's Pull-request view, plus its empty / create / loading / error states.
+Visual-only polish task — data flow, status parsing, click-to-open, the commit
+list, and the create/empty states are unchanged.
+
+## Preconditions
+
+- A repo is open in the WorkStation Code Editor.
+- The Pull-request sidebar view is selected (next to Git History).
+- For the "PR exists" cases, `workstationPrAtom.prUrl` resolves to a parseable
+  `https://github.com/<owner>/<repo>/pull/<n>` URL and the GitHub local API
+  returns PR detail + commits.
+
+## Happy Path
+
+| #   | Steps                                                       | Expected Result                                                                                                                                                                                           |
+| --- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Open the PR view for a branch with an **open** PR.          | Card shows a pill `● Open` (green dot + green pill), `#<number>` in muted tabular text, an `Open on GitHub` icon button on the trailing edge, a 1–2 line bold title, a branch chip, and a diff-stats row. |
+| 2   | Hover the `Open on GitHub` icon button.                     | Button shows the standard header hover surface (fill background, text steps to `text-1`); cursor is a link; `title`/`aria-label` = "Open on GitHub".                                                      |
+| 3   | Click the `Open on GitHub` icon button.                     | Opens `detail.htmlUrl` (falls back to `prUrl`) in a new tab (`target="_blank"`, `rel="noreferrer"`). No in-app navigation/regression.                                                                     |
+| 4   | Read the stats row for additions=104, deletions=45, files=3 | Shows `+104` (green) `-45` (red) in a subtle pill, then a `FileDiff` icon + "3 files".                                                                                                                    |
+| 5   | Select a commit in the list below.                          | Existing behavior unchanged — row highlights, `onHistorySelectionChange` fires with the commit selection.                                                                                                 |
+
+## Edge Cases
+
+| #   | Scenario                  | Steps                                                      | Expected Result                                                                                             |
+| --- | ------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| 1   | Status = merged           | PR detail has `merged: true`.                              | Pill `● Merged` uses primary color (`bg-primary-1 text-primary-6`, dot `bg-primary-6`).                     |
+| 2   | Status = closed           | PR `state: "closed"`, not merged.                          | Pill `● Closed` uses danger/red (`bg-danger-1 text-danger-6`).                                              |
+| 3   | Status = draft            | PR `state: "draft"`.                                       | Pill `● Draft` uses warning/amber (`bg-warning-1 text-warning-6`).                                          |
+| 4   | Unknown status            | PR `state: "pending_review"`.                              | Pill uses neutral fallback (`bg-fill-2 text-text-3`, dot `bg-text-3`); label = raw status, CSS-capitalized. |
+| 5   | Zero stats                | additions=0, deletions=0, files=0.                         | Shows `+0 -0` and "0 files" — never blank, never `NaN`.                                                     |
+| 6   | Huge stats                | additions=1234567.                                         | Renders with thousands separators: `+1,234,567`; numbers stay `tabular-nums`.                               |
+| 7   | Missing numeric fields    | API omits additions/deletions/changed_files (parsed as 0). | Stats render `+0 -0`, "0 files" (helper coerces non-finite → 0).                                            |
+| 8   | Very long title           | Title > 2 lines.                                           | Title clamps to 2 lines (`line-clamp-2`); full title available via `title` tooltip.                         |
+| 9   | Very long branch name     | Branch name is hundreds of chars.                          | Branch chip truncates with ellipsis (CSS `truncate` for width + 80-char hard cap); full name in tooltip.    |
+| 10  | Narrow sidebar width      | Drag sidebar to its minimum width.                         | Badge/number/button row stays single-line; title, branch chip, and stats wrap/truncate gracefully.          |
+| 11  | No branch name            | `branchName` undefined.                                    | Branch chip is omitted; rest of the card renders normally.                                                  |
+| 12  | No PR, eligible to create | `prUrl` absent, `readyToCreate` true.                      | "There is no pull request…" copy + "Create pull request" button (unchanged).                                |
+| 13  | No PR, not eligible       | `prUrl` absent, `readyToCreate` false.                     | Empty `Placeholder` "No pull request" (unchanged).                                                          |
+
+## Error / Degraded States
+
+| #   | Scenario              | Steps                                  | Expected Result                                                                 |
+| --- | --------------------- | -------------------------------------- | ------------------------------------------------------------------------------- |
+| 1   | Loading               | While PR detail/commits fetch.         | `Placeholder variant="loading"` in the body; header may render once detail set. |
+| 2   | GitHub re-auth needed | API throws `GitHubReAuthError`.        | Body shows the "Connect a GitHub account…" message; no crash.                   |
+| 3   | Generic fetch failure | API rejects with an Error.             | `Placeholder variant="error"` with the error message as subtitle.               |
+| 4   | Create PR failure     | `onCreatePr` returns a non-auth error. | Inline warning alert with the error text (unchanged).                           |
+
+## Accessibility
+
+- [ ] `Open on GitHub` control is a real anchor: keyboard-focusable (Tab),
+      activatable with Enter, with `aria-label` + `title` = "Open on GitHub".
+- [ ] Status dot is decorative (`aria-hidden`); the textual status label conveys
+      state to screen readers.
+- [ ] Title and branch chip expose full text via `title` when visually
+      truncated.
+- [ ] Color is not the only signal — each status also has a distinct text label.
+
+## Acceptance Criteria
+
+- [ ] All happy-path cases pass.
+- [ ] Each status (open / merged / closed / draft / unknown) renders the correct
+      semantic color via `getPrStatusVariant`.
+- [ ] Stats use `formatStatNumber` (separators, integer truncation, NaN→0).
+- [ ] Branch label uses `truncateBranchLabel` + CSS truncation + tooltip.
+- [ ] `pnpm test` passes for `prCardHelpers.test.ts` with no new failures.
+- [ ] No new TypeScript or lint warnings on touched files.
+- [ ] Behavior/data flow (status parsing, click-to-open, commit list, create /
+      empty states) is unchanged from before the polish.
+- [ ] Reduced motion: card uses only color/opacity hover transitions — no
+      motion-dependent affordances.

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/__tests__/prCardHelpers.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/__tests__/prCardHelpers.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatStatNumber,
+  getPrStatusVariant,
+  truncateBranchLabel,
+} from "../prCardHelpers";
+
+describe("getPrStatusVariant", () => {
+  it("maps each known status to its semantic badge + dot classes", () => {
+    expect(getPrStatusVariant("open")).toEqual({
+      badgeClass: "bg-success-1 text-success-6",
+      dotClass: "bg-success-6",
+    });
+    expect(getPrStatusVariant("merged")).toEqual({
+      badgeClass: "bg-primary-1 text-primary-6",
+      dotClass: "bg-primary-6",
+    });
+    expect(getPrStatusVariant("closed")).toEqual({
+      badgeClass: "bg-danger-1 text-danger-6",
+      dotClass: "bg-danger-6",
+    });
+    expect(getPrStatusVariant("draft")).toEqual({
+      badgeClass: "bg-warning-1 text-warning-6",
+      dotClass: "bg-warning-6",
+    });
+  });
+
+  it("falls back to a neutral variant for unknown states", () => {
+    expect(getPrStatusVariant("pending_review")).toEqual({
+      badgeClass: "bg-fill-2 text-text-3",
+      dotClass: "bg-text-3",
+    });
+  });
+
+  it("falls back to a neutral variant for an empty key", () => {
+    expect(getPrStatusVariant("")).toEqual({
+      badgeClass: "bg-fill-2 text-text-3",
+      dotClass: "bg-text-3",
+    });
+  });
+});
+
+describe("formatStatNumber", () => {
+  it("returns 0 for zero", () => {
+    expect(formatStatNumber(0)).toBe("0");
+  });
+
+  it("formats small numbers without separators", () => {
+    expect(formatStatNumber(45)).toBe("45");
+    expect(formatStatNumber(104)).toBe("104");
+    expect(formatStatNumber(999)).toBe("999");
+  });
+
+  it("inserts thousands separators for large numbers", () => {
+    expect(formatStatNumber(1000)).toBe("1,000");
+    expect(formatStatNumber(12345)).toBe("12,345");
+    expect(formatStatNumber(1000000)).toBe("1,000,000");
+  });
+
+  it("truncates fractional values to integers", () => {
+    expect(formatStatNumber(104.9)).toBe("104");
+    expect(formatStatNumber(-45.9)).toBe("-45");
+  });
+
+  it("preserves the sign for negative numbers", () => {
+    expect(formatStatNumber(-45)).toBe("-45");
+    expect(formatStatNumber(-12345)).toBe("-12,345");
+  });
+
+  it("collapses non-finite / NaN inputs to 0", () => {
+    expect(formatStatNumber(Number.NaN)).toBe("0");
+    expect(formatStatNumber(Number.POSITIVE_INFINITY)).toBe("0");
+    expect(formatStatNumber(Number.NEGATIVE_INFINITY)).toBe("0");
+  });
+});
+
+describe("truncateBranchLabel", () => {
+  it("returns short branch names unchanged", () => {
+    expect(truncateBranchLabel("test/pr-system-check")).toBe(
+      "test/pr-system-check"
+    );
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(truncateBranchLabel("  feat/x  ")).toBe("feat/x");
+  });
+
+  it("returns an empty string for empty / nullish input", () => {
+    expect(truncateBranchLabel("")).toBe("");
+    expect(truncateBranchLabel(undefined as unknown as string)).toBe("");
+  });
+
+  it("caps very long branch names with an ellipsis", () => {
+    const long = `feature/${"x".repeat(200)}`;
+    const result = truncateBranchLabel(long);
+    expect(result).toHaveLength(80);
+    expect(result.endsWith("…")).toBe(true);
+  });
+
+  it("respects a custom max length", () => {
+    expect(truncateBranchLabel("feature/long-branch", 8)).toBe("feature…");
+  });
+
+  it("returns just an ellipsis when max is degenerate", () => {
+    expect(truncateBranchLabel("anything", 1)).toBe("…");
+  });
+});

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/index.tsx
@@ -10,7 +10,13 @@
  * shows a "Create pull request" button instead.
  */
 import { useAtomValue } from "jotai";
-import { ExternalLink, Loader2, TriangleAlert } from "lucide-react";
+import {
+  ExternalLink,
+  FileDiff,
+  GitBranch,
+  Loader2,
+  TriangleAlert,
+} from "lucide-react";
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -22,6 +28,7 @@ import {
 import { SPINNER_TOKENS } from "@src/config/spinnerTokens";
 import { SURFACE_TOKENS } from "@src/config/surfaceTokens";
 import {
+  HEADER_BUTTON,
   PRIMARY_SIDEBAR_HOVER,
   TYPOGRAPHY,
 } from "@src/modules/WorkStation/shared/tokens";
@@ -33,12 +40,11 @@ import {
 import type { SourceControlHistorySelection } from "@src/store/workstation/tabs";
 import { formatRelativeTime } from "@src/util/time/formatRelativeTime";
 
-const PR_STATUS_COLORS: Record<string, string> = {
-  open: "bg-success-1 text-success-6",
-  merged: "bg-primary-1 text-primary-6",
-  closed: "bg-fill-3 text-text-3",
-  draft: "bg-warning-1 text-warning-6",
-};
+import {
+  formatStatNumber,
+  getPrStatusVariant,
+  truncateBranchLabel,
+} from "./prCardHelpers";
 
 const ROW_HEIGHT = 36;
 
@@ -266,48 +272,78 @@ const PullRequestContent: React.FC<PullRequestContentProps> = ({
 
   // ── Header (always shown when a PR exists) ──────────────────────────
   const statusKey = normalizeStatus(detail);
-  const statusClass = PR_STATUS_COLORS[statusKey] ?? "bg-fill-2 text-text-3";
+  const statusVariant = getPrStatusVariant(statusKey);
+  const prNumber = detail?.number ?? parsedPr.number;
+  const prTitle = detail?.title || t("labels.pullRequest", "Pull request");
+  const openLabel = t("actions.openOnGitHub", "Open on GitHub");
 
   const header = (
-    <div className="flex flex-col gap-1.5 px-3 pb-2 pt-3">
-      <div className="flex min-w-0 items-center gap-1.5">
+    <div className="flex flex-col gap-2 px-3 pb-3 pt-3">
+      {/* Status + PR number + open-on-GitHub affordance */}
+      <div className="flex min-w-0 items-center gap-2">
         <span
-          className={`shrink-0 rounded px-1.5 py-0.5 ${TYPOGRAPHY.badge} ${statusClass}`}
+          className={`inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 capitalize ${TYPOGRAPHY.badge} ${statusVariant.badgeClass}`}
         >
+          <span
+            className={`h-1.5 w-1.5 rounded-full ${statusVariant.dotClass}`}
+            aria-hidden
+          />
           {t(`labels.prStatus.${statusKey}`, statusKey)}
         </span>
-        <span className={`${TYPOGRAPHY.secondary} text-text-3`}>
-          #{detail?.number ?? parsedPr.number}
+        <span
+          className={`${TYPOGRAPHY.secondary} font-medium tabular-nums text-text-3`}
+        >
+          #{prNumber}
         </span>
         <a
           href={detail?.htmlUrl ?? prUrl ?? "#"}
           target="_blank"
           rel="noreferrer"
-          className="ml-auto inline-flex items-center text-text-3 transition-colors hover:text-primary-6"
-          title={t("actions.openInBrowser", "Open in browser")}
+          className={`${HEADER_BUTTON.action} ml-auto`}
+          aria-label={openLabel}
+          title={openLabel}
         >
-          <ExternalLink size={12} />
+          <ExternalLink size={14} />
         </a>
       </div>
-      <div className="min-w-0 text-[13px] font-medium leading-tight text-text-1">
-        {detail?.title || t("labels.pullRequest", "Pull request")}
+
+      {/* Title */}
+      <div
+        className="line-clamp-2 text-[13px] font-semibold leading-snug text-text-1"
+        title={prTitle}
+      >
+        {prTitle}
       </div>
+
+      {/* Head branch chip */}
       {branchName && (
-        <code
-          className={`truncate ${TYPOGRAPHY.secondary} text-text-3`}
+        <div
+          className="inline-flex max-w-full items-center gap-1 self-start rounded-md bg-fill-2 px-1.5 py-0.5 text-text-2"
           title={branchName}
         >
-          {branchName}
-        </code>
+          <GitBranch size={12} className="shrink-0 text-text-3" />
+          <span className={`truncate font-mono ${TYPOGRAPHY.secondary}`}>
+            {truncateBranchLabel(branchName)}
+          </span>
+        </div>
       )}
+
+      {/* Diff stats */}
       {detail && (
-        <div className={`flex gap-2 ${TYPOGRAPHY.secondary} text-text-3`}>
-          <span className="text-success-6">+{detail.additions}</span>
-          <span className="text-danger-6">−{detail.deletions}</span>
-          <span>
-            {t("labels.filesChanged", "{{count}} files", {
-              count: detail.changedFiles,
-            })}
+        <div className="flex flex-wrap items-center gap-2 text-[11px]">
+          <span className="inline-flex items-center gap-1.5 rounded-md bg-fill-2 px-1.5 py-0.5 font-medium tabular-nums">
+            <span className="text-success-6">
+              +{formatStatNumber(detail.additions)}
+            </span>
+            <span className="text-danger-6">
+              -{formatStatNumber(detail.deletions)}
+            </span>
+          </span>
+          <span className="inline-flex items-center gap-1 text-text-3">
+            <FileDiff size={12} className="shrink-0" />
+            <span className="tabular-nums">
+              {t("labels.fileCount", { count: detail.changedFiles })}
+            </span>
           </span>
         </div>
       )}

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/prCardHelpers.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/prCardHelpers.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure presentation helpers for the sidebar PR summary card.
+ *
+ * These are intentionally free of React / i18n so they can be unit-tested in
+ * isolation (see __tests__/prCardHelpers.test.ts). The component layer maps
+ * the returned class strings / labels onto design-system tokens and t(...).
+ */
+
+/** Visual variant (badge + status dot) for a normalized PR status. */
+export interface PrStatusVariant {
+  /** Tailwind classes for the badge pill background + text color. */
+  badgeClass: string;
+  /** Tailwind classes for the small leading status dot. */
+  dotClass: string;
+}
+
+/**
+ * Semantic colors per PR state. Kept in sync with the WorkItems `PrSection`
+ * mapping so PR status reads consistently across the app:
+ *   open → success (green), merged → primary, closed → danger (red),
+ *   draft → warning (amber).
+ */
+const PR_STATUS_VARIANTS: Record<string, PrStatusVariant> = {
+  open: { badgeClass: "bg-success-1 text-success-6", dotClass: "bg-success-6" },
+  merged: {
+    badgeClass: "bg-primary-1 text-primary-6",
+    dotClass: "bg-primary-6",
+  },
+  closed: { badgeClass: "bg-danger-1 text-danger-6", dotClass: "bg-danger-6" },
+  draft: {
+    badgeClass: "bg-warning-1 text-warning-6",
+    dotClass: "bg-warning-6",
+  },
+};
+
+/** Neutral fallback for unknown / custom states (e.g. "pending_review"). */
+const FALLBACK_STATUS_VARIANT: PrStatusVariant = {
+  badgeClass: "bg-fill-2 text-text-3",
+  dotClass: "bg-text-3",
+};
+
+/** Resolve a normalized status key to its badge + dot classes. */
+export function getPrStatusVariant(statusKey: string): PrStatusVariant {
+  return PR_STATUS_VARIANTS[statusKey] ?? FALLBACK_STATUS_VARIANT;
+}
+
+/**
+ * Format an additions / deletions / files count for display.
+ *
+ * - Truncates to an integer and inserts thousands separators.
+ * - Negative inputs keep their sign (callers add the leading +/- glyph).
+ * - Non-finite / NaN inputs collapse to "0" so the card never shows "NaN".
+ */
+export function formatStatNumber(value: number): string {
+  if (!Number.isFinite(value)) return "0";
+  const rounded = Math.trunc(value);
+  const sign = rounded < 0 ? "-" : "";
+  const abs = Math.abs(rounded).toString();
+  return sign + abs.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+/**
+ * Hard cap on a branch label's character length as a safety net for
+ * pathologically long names. Normal responsive truncation is handled by CSS
+ * (`truncate`); this prevents enormous DOM text nodes and keeps the full name
+ * available via the `title` tooltip.
+ */
+export function truncateBranchLabel(branch: string, max = 80): string {
+  const trimmed = (branch ?? "").trim();
+  if (trimmed.length <= max) return trimmed;
+  if (max <= 1) return "…";
+  return `${trimmed.slice(0, max - 1).trimEnd()}…`;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,7 +49,7 @@ module.exports = (env, argv) => {
     cache: {
       type: "filesystem",
       // Version the cache for faster invalidation
-      version: `${isProduction ? "prod" : "dev"}-5`,
+      version: `${isProduction ? "prod" : "dev"}-6`,
       buildDependencies: {
         config: [__filename],
       },
@@ -307,9 +307,14 @@ module.exports = (env, argv) => {
         "@codemirror/view": path.dirname(require.resolve("@codemirror/view")),
         // @a2ui/web_core exports ./v0_9 only under "default" condition, not "import"/"browser".
         // Webpack's package exports resolution omits "default"-only exports, so alias directly.
-        "@a2ui/web_core/v0_9": path.resolve(
-          __dirname,
-          "node_modules/@a2ui/web_core/src/v0_9/index.js"
+        // Point at the DIRECTORY (not index.js): webpack alias does prefix matching, so the bare
+        // import resolves via directory-index (src/v0_9/index.js) while subpath imports like
+        // "@a2ui/web_core/v0_9/basic_catalog" resolve to src/v0_9/basic_catalog (its index.js).
+        // The "." entry resolves to .../src/v0_8/index.js; walk up to src/ then into v0_9 so this
+        // stays correct under pnpm's symlinked store (matches the @codemirror/* pattern above).
+        "@a2ui/web_core/v0_9": path.join(
+          path.dirname(path.dirname(require.resolve("@a2ui/web_core"))),
+          "v0_9"
         ),
         // react-syntax-highlighter expects the v1 lowlight lib/core.js entry.
         // Resolve that nested dependency explicitly from the pnpm store when needed.


### PR DESCRIPTION
## Summary
- **ask-question**: renders a pending streaming placeholder block while `args.questions` haven't streamed in yet (only when active event painting is enabled).
- **PinnedActionsBar**: wraps pills in a `flex-1` horizontal scroll container, adds `shrink-0` to prevent pill squishing, and shows a right-edge gradient fade when pills overflow.

## Note
This PR is opened to validate the in-app PR system end-to-end (branch → commit → push → PR).