### PR TITLE
fix(workstation): stabilize source control re-renders across navigation

### DIFF
--- a/src/contexts/git/GitStatusContext/GitStatusProvider.tsx
+++ b/src/contexts/git/GitStatusContext/GitStatusProvider.tsx
@@ -23,6 +23,7 @@ import React, {
   createContext,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -347,25 +348,43 @@ export const GitStatusProvider: React.FC<{ children: React.ReactNode }> = ({
   // ============================================
 
   const hasActiveRepo = !!selectedRepoId && reposLoaded && !!currentRepo;
-  const scopedGitStatus =
-    gitStatus && statusRepoId && statusRepoPath
-      ? { repoId: statusRepoId, repoPath: statusRepoPath, status: gitStatus }
-      : null;
+  // Memoize the derived status objects so their references only change when the
+  // underlying git data does — otherwise the fresh object literals would defeat
+  // the `value` memo below and re-render every `useGitStatus()` consumer on each
+  // loading toggle / background ping.
+  const scopedGitStatus = useMemo(
+    () =>
+      gitStatus && statusRepoId && statusRepoPath
+        ? { repoId: statusRepoId, repoPath: statusRepoPath, status: gitStatus }
+        : null,
+    [gitStatus, statusRepoId, statusRepoPath]
+  );
   const currentGitStatus =
     scopedGitStatus?.repoId === selectedRepoId &&
     scopedGitStatus.repoPath === currentRepoPath
       ? scopedGitStatus.status
       : null;
 
-  const value: GitStatusContextValue = {
-    currentGitStatus,
-    scopedGitStatus,
-    gitSuggestedAction,
-    loading,
-    error,
-    forceRefresh,
-    hasActiveRepo,
-  };
+  const value = useMemo<GitStatusContextValue>(
+    () => ({
+      currentGitStatus,
+      scopedGitStatus,
+      gitSuggestedAction,
+      loading,
+      error,
+      forceRefresh,
+      hasActiveRepo,
+    }),
+    [
+      currentGitStatus,
+      scopedGitStatus,
+      gitSuggestedAction,
+      loading,
+      error,
+      forceRefresh,
+      hasActiveRepo,
+    ]
+  );
 
   return (
     <GitStatusContext.Provider value={value}>

--- a/src/hooks/git/sourceControl/__tests__/TEST_CASES.md
+++ b/src/hooks/git/sourceControl/__tests__/TEST_CASES.md
@@ -1,0 +1,42 @@
+# Test Cases: useGitFiles base-file stability (Issue #16, RC-3)
+
+Covers the derivation + equality gate that lets `useGitFiles` hand back the
+SAME `files` array reference when a new `gitStatus` object describes a
+byte-identical working tree.
+
+## Preconditions
+
+- A repo is selected; `GitStatusContext` provides `currentGitStatus`.
+
+## Happy Path
+
+| #   | Steps                                                                                     | Expected Result                                                                                                                                                                   |
+| --- | ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Background status ping replaces `gitStatus` with a fresh object describing the SAME files | `deriveBaseFiles` produces a structurally identical list; `areBaseFileListsEqual` returns true; `baseFiles` returns the PRIOR reference (no cascade into `useSourceControlState`) |
+| 2   | A file is modified / staged / added / removed                                             | Equality gate returns false; a NEW `baseFiles` ref is produced                                                                                                                    |
+
+## Edge Cases
+
+| #   | Scenario                               | Steps                            | Expected Result                                                    |
+| --- | -------------------------------------- | -------------------------------- | ------------------------------------------------------------------ |
+| 1   | Empty working tree                     | No repo or no status             | `deriveBaseFiles([])` → `[]`; two empty lists compare equal        |
+| 2   | Single file                            | One changed file                 | Mapped with `id = "<path>-0"`                                      |
+| 3   | Reorder / rename                       | `original_path` or order changes | Gate returns false (cannot stick stale)                            |
+| 4   | Only additions/deletions counts differ | Same identity fields             | Gate returns true (counts are not identity-bearing for base files) |
+
+## Error / Degraded States
+
+| #   | Scenario                                     | Steps                                   | Expected Result              |
+| --- | -------------------------------------------- | --------------------------------------- | ---------------------------- |
+| 1   | Malformed status missing `working_directory` | `gitStatus.working_directory` undefined | Falls back to `[]`, no throw |
+
+## Accessibility
+
+- [x] N/A (data-layer hook).
+
+## Acceptance Criteria
+
+- [x] `deriveBaseFiles` unit-tested (empty, mapping, ids).
+- [x] `areBaseFileListsEqual` unit-tested for every identity field + ref-equality + length + non-identity fields ignored.
+- [x] Gate compares `id`, `path`, `status`, `staged`, `original_path` so it can never return a stale array for a changed tree.
+- [x] No new TypeScript / lint errors in touched files.

--- a/src/hooks/git/sourceControl/__tests__/gitFilesDerivation.test.ts
+++ b/src/hooks/git/sourceControl/__tests__/gitFilesDerivation.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+
+import type { GitWorkingDirectoryFile } from "@src/api/http/git";
+import type { GitFile } from "@src/types/git/types";
+
+import { areBaseFileListsEqual, deriveBaseFiles } from "../gitFilesDerivation";
+
+function createStatusFile(
+  overrides: Partial<GitWorkingDirectoryFile> = {}
+): GitWorkingDirectoryFile {
+  return {
+    path: "src/index.ts",
+    status: "M",
+    staged: false,
+    original_path: null,
+    ...overrides,
+  } as GitWorkingDirectoryFile;
+}
+
+function createGitFile(overrides: Partial<GitFile> = {}): GitFile {
+  return {
+    id: "src/index.ts-0",
+    path: "src/index.ts",
+    status: "modified",
+    additions: 0,
+    deletions: 0,
+    staged: false,
+    original_path: null,
+    ...overrides,
+  };
+}
+
+describe("deriveBaseFiles", () => {
+  it("returns an empty list for empty input", () => {
+    expect(deriveBaseFiles([])).toEqual([]);
+  });
+
+  it("maps working-directory files into GitFile shape with index-based ids", () => {
+    const result = deriveBaseFiles([
+      createStatusFile({ path: "a.ts", staged: true }),
+      createStatusFile({ path: "b.ts", staged: false }),
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({
+      id: "a.ts-0",
+      path: "a.ts",
+      staged: true,
+    });
+    expect(result[1]).toMatchObject({
+      id: "b.ts-1",
+      path: "b.ts",
+      staged: false,
+    });
+    expect(result[0].oldContent).toBeUndefined();
+  });
+});
+
+describe("areBaseFileListsEqual", () => {
+  it("returns true for the same array reference", () => {
+    const list = [createGitFile()];
+    expect(areBaseFileListsEqual(list, list)).toBe(true);
+  });
+
+  it("returns true for two structurally identical (byte-identical) lists", () => {
+    expect(areBaseFileListsEqual([createGitFile()], [createGitFile()])).toBe(
+      true
+    );
+  });
+
+  it("returns false when lengths differ", () => {
+    expect(
+      areBaseFileListsEqual(
+        [createGitFile()],
+        [createGitFile(), createGitFile({ id: "b-1", path: "b.ts" })]
+      )
+    ).toBe(false);
+  });
+
+  it("returns false when a staged flag changes (cannot stick stale)", () => {
+    expect(
+      areBaseFileListsEqual(
+        [createGitFile({ staged: false })],
+        [createGitFile({ staged: true })]
+      )
+    ).toBe(false);
+  });
+
+  it("returns false when status changes", () => {
+    expect(
+      areBaseFileListsEqual(
+        [createGitFile({ status: "modified" })],
+        [createGitFile({ status: "deleted" })]
+      )
+    ).toBe(false);
+  });
+
+  it("returns false when path/id changes", () => {
+    expect(
+      areBaseFileListsEqual(
+        [createGitFile({ id: "a-0", path: "a.ts" })],
+        [createGitFile({ id: "b-0", path: "b.ts" })]
+      )
+    ).toBe(false);
+  });
+
+  it("returns false when original_path (rename source) changes", () => {
+    expect(
+      areBaseFileListsEqual(
+        [createGitFile({ original_path: null })],
+        [createGitFile({ original_path: "old.ts" })]
+      )
+    ).toBe(false);
+  });
+
+  it("ignores non-identity fields like additions/deletions for the gate", () => {
+    expect(
+      areBaseFileListsEqual(
+        [createGitFile({ additions: 0, deletions: 0 })],
+        [createGitFile({ additions: 5, deletions: 3 })]
+      )
+    ).toBe(true);
+  });
+
+  it("handles two empty lists as equal", () => {
+    expect(areBaseFileListsEqual([], [])).toBe(true);
+  });
+});

--- a/src/hooks/git/sourceControl/gitFilesDerivation.ts
+++ b/src/hooks/git/sourceControl/gitFilesDerivation.ts
@@ -1,0 +1,51 @@
+import type { GitWorkingDirectoryFile } from "@src/api/http/git";
+import { normalizeGitStatus } from "@src/config/gitStatus";
+import type { GitFile } from "@src/types/git/types";
+
+/**
+ * Map raw working-directory entries from a git status payload into the
+ * `GitFile` shape used by the Source Control UI. Extracted from `useGitFiles`
+ * so the derivation and equality gate can be unit-tested without React.
+ */
+export function deriveBaseFiles(
+  statusFiles: GitWorkingDirectoryFile[]
+): GitFile[] {
+  return statusFiles.map((file, index) => ({
+    id: `${file.path}-${index}`,
+    path: file.path,
+    status: normalizeGitStatus(file.status),
+    additions: 0,
+    deletions: 0,
+    staged: file.staged,
+    original_path: file.original_path,
+    // Content is loaded lazily when a file is selected.
+    oldContent: undefined,
+    newContent: undefined,
+  }));
+}
+
+/**
+ * Structural equality for two derived base-file lists. Compares only the
+ * identity-bearing fields produced by {@link deriveBaseFiles}
+ * (`id`, `path`, `status`, `staged`, `original_path`) — every other field is a
+ * constant for a freshly derived list, so this can never "stick" a stale array:
+ * any working-tree change to those fields yields `false` and forces a new ref.
+ */
+export function areBaseFileListsEqual(a: GitFile[], b: GitFile[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const left = a[i];
+    const right = b[i];
+    if (
+      left.id !== right.id ||
+      left.path !== right.path ||
+      left.status !== right.status ||
+      left.staged !== right.staged ||
+      left.original_path !== right.original_path
+    ) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/hooks/git/sourceControl/useGitFiles.ts
+++ b/src/hooks/git/sourceControl/useGitFiles.ts
@@ -21,10 +21,42 @@ import {
   useState,
 } from "react";
 
-import { GitWorkingDirectoryFile } from "@src/api/http/git";
-import { normalizeGitStatus } from "@src/config/gitStatus";
 import { useGitStatus } from "@src/contexts/git";
 import type { GitFile } from "@src/types/git/types";
+import type { GitRepositoryStatus } from "@src/types/session/steps";
+
+import { areBaseFileListsEqual, deriveBaseFiles } from "./gitFilesDerivation";
+
+/**
+ * Derive the base file list from a git status, returning the SAME array
+ * reference when a newly-fetched status describes a byte-identical working
+ * tree. Background status pings replace the `gitStatus` object on every poll;
+ * without this stabilization each poll cascades a fresh `files` reference into
+ * `useSourceControlState`'s state memo even when nothing changed.
+ *
+ * Mirrors the ref-cached `useMemo` pattern used by `useEventStoreSelector`.
+ */
+function useStableBaseFiles(
+  gitStatus: GitRepositoryStatus | null,
+  selectedRepoId: string | null
+): GitFile[] {
+  const prevRef = useRef<GitFile[]>([]);
+  return useMemo(() => {
+    const next =
+      !selectedRepoId || !gitStatus
+        ? []
+        : deriveBaseFiles(gitStatus.working_directory?.files || []);
+
+    // The equality gate compares every identity-bearing field, so any real
+    // working-tree change yields a fresh array and this can never stick stale.
+    if (areBaseFileListsEqual(prevRef.current, next)) {
+      return prevRef.current;
+    }
+    prevRef.current = next;
+    return next;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gitStatus, selectedRepoId]);
+}
 
 export interface UseGitFilesOptions {
   selectedRepoId: string | null;
@@ -67,33 +99,10 @@ export function useGitFiles(options: UseGitFilesOptions): UseGitFilesResult {
 
   const { currentGitStatus: gitStatus, forceRefresh, loading } = useGitStatus();
 
-  // Derive base files from gitStatus
-  const baseFiles = useMemo(() => {
-    // Skip if no repo selected
-    if (!selectedRepoId) {
-      return [];
-    }
-
-    // Skip if no git status available yet
-    if (!gitStatus) return [];
-
-    // Extract files from git status
-    const statusFiles = gitStatus.working_directory?.files || [];
-
-    // Convert to GitFile format
-    return statusFiles.map((file: GitWorkingDirectoryFile, index: number) => ({
-      id: `${file.path}-${index}`,
-      path: file.path,
-      status: normalizeGitStatus(file.status),
-      additions: 0,
-      deletions: 0,
-      staged: file.staged,
-      original_path: file.original_path,
-      // Content will be loaded lazily when file is selected
-      oldContent: undefined,
-      newContent: undefined,
-    }));
-  }, [gitStatus, selectedRepoId]);
+  // Derive base files from gitStatus, reusing the prior array reference when a
+  // new gitStatus object describes a byte-identical working tree (see
+  // useStableBaseFiles).
+  const baseFiles = useStableBaseFiles(gitStatus, selectedRepoId);
 
   // Merge base files with overrides (diff content + staged state) from local state
   // If repoId doesn't match, the cached data is stale and ignored

--- a/src/modules/WorkStation/CodeEditor/__tests__/TEST_CASES.md
+++ b/src/modules/WorkStation/CodeEditor/__tests__/TEST_CASES.md
@@ -1,0 +1,51 @@
+# Test Cases: Source Control re-render stability (Issue #16)
+
+Covers RC-1 (stable `handleDiffSidebarFileSelect`) and the pure selection
+resolver it now delegates to (`resolveGitDiffSelection`).
+
+## Preconditions
+
+- A repo is open in the WorkStation Code Editor.
+- The Source Control sidebar tab is mounted (warm/keep-alive).
+
+## Happy Path
+
+| #   | Steps                                                                   | Expected Result                                                                                                                                                                  |
+| --- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | In Source Control "all changes" view, click a changed file              | Diff opens in focus target; `resolveGitDiffSelection` returns `isAllChangesView: true`, correct absolute + relative paths                                                        |
+| 2   | In Source Control focus/non-all-changes view, click a file              | Falls through to `handleGitFileSelect` (unified focus tab)                                                                                                                       |
+| 3   | Navigate between editor tabs repeatedly while Source Control stays warm | The warm Source Control tree does NOT re-render; `SidebarSlot` context identity stays stable because `handleDiffSidebarFileSelect` identity is stable across `activeTab` changes |
+
+## Edge Cases
+
+| #   | Scenario                  | Steps                                                    | Expected Result                                                                                |
+| --- | ------------------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| 1   | Worktree file             | Click a file whose `repoRoot` differs from host repoPath | `effectiveRepoPath` = file's `repoRoot`; absolute path built under the worktree                |
+| 2   | Already-absolute path     | File path begins with `/` and host repo prefix           | `absolutePath` unchanged, `relativePath` stripped of repo prefix                               |
+| 3   | Null/undefined active tab | Resolve with no active tab                               | `isAllChangesView` is `false` (routes to focus select)                                         |
+| 4   | Rapid navigation          | Switch tabs many times quickly                           | Callback identity unchanged each render (refs hold latest `activeTab` / `handleGitFileSelect`) |
+
+## Error / Degraded States
+
+| #   | Scenario                | Steps                            | Expected Result                                |
+| --- | ----------------------- | -------------------------------- | ---------------------------------------------- |
+| 1   | Diff content load fails | `loadGitFileDiffContent` rejects | Error logged; no crash; focus target still set |
+
+## Accessibility
+
+- [x] No change to keyboard/focus behavior (pure perf/identity refactor).
+
+## Acceptance Criteria
+
+- [x] `resolveGitDiffSelection` unit-tested (absolute/relative/worktree/all-changes/null tab).
+- [x] `handleDiffSidebarFileSelect` no longer lists `activeTab` in its `useCallback` deps; reads it via `activeTabRef`.
+- [x] `handleGitFileSelect` (unstable — closes over per-render `gitDiffState`) read via `handleGitFileSelectRef`.
+- [x] `gitDiffState.setFile` destructured (stable) instead of depending on the whole `gitDiffState` object.
+- [x] No new TypeScript / lint errors in touched files.
+
+## Notes
+
+- Identity-stability across renders is a React-runtime property; per the repo's
+  UI-feature workflow (no `.tsx` / testing-library tests) it is verified by
+  construction (deps reduced to stable values) plus the pure-resolver unit tests,
+  and manually via React DevTools "highlight updates" while navigating.

--- a/src/modules/WorkStation/CodeEditor/__tests__/sourceControlSelection.test.ts
+++ b/src/modules/WorkStation/CodeEditor/__tests__/sourceControlSelection.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import type { WorkStationTab } from "@src/store/workstation/tabs/types";
+import type { GitFile } from "@src/types/git/types";
+
+import { resolveGitDiffSelection } from "../sourceControlSelection";
+
+function createGitFile(overrides: Partial<GitFile> = {}): GitFile {
+  return {
+    id: "src/index.ts-0",
+    path: "src/index.ts",
+    status: "modified",
+    additions: 0,
+    deletions: 0,
+    staged: false,
+    original_path: null,
+    ...overrides,
+  };
+}
+
+function allChangesTab(): WorkStationTab {
+  return {
+    type: "source-control",
+    data: { mode: "all-changes" },
+  } as unknown as WorkStationTab;
+}
+
+function focusTab(): WorkStationTab {
+  return {
+    type: "source-control",
+    data: { mode: "focus" },
+  } as unknown as WorkStationTab;
+}
+
+describe("resolveGitDiffSelection", () => {
+  const repoPath = "/Users/me/repo";
+
+  it("builds an absolute path from a relative file path", () => {
+    const result = resolveGitDiffSelection(
+      createGitFile({ path: "src/index.ts" }),
+      repoPath,
+      allChangesTab()
+    );
+    expect(result.absolutePath).toBe("/Users/me/repo/src/index.ts");
+    expect(result.relativePath).toBe("src/index.ts");
+    expect(result.effectiveRepoPath).toBe(repoPath);
+  });
+
+  it("keeps an already-absolute path and derives the relative path", () => {
+    const result = resolveGitDiffSelection(
+      createGitFile({ path: "/Users/me/repo/src/a.ts" }),
+      repoPath,
+      allChangesTab()
+    );
+    expect(result.absolutePath).toBe("/Users/me/repo/src/a.ts");
+    expect(result.relativePath).toBe("src/a.ts");
+  });
+
+  it("prefers the file's own repoRoot over the host repo path (worktrees)", () => {
+    const worktreeRoot = "/Users/me/repo/.worktrees/feature";
+    const result = resolveGitDiffSelection(
+      createGitFile({ path: "lib/x.ts", repoRoot: worktreeRoot }),
+      repoPath,
+      allChangesTab()
+    );
+    expect(result.effectiveRepoPath).toBe(worktreeRoot);
+    expect(result.absolutePath).toBe(`${worktreeRoot}/lib/x.ts`);
+  });
+
+  it("flags the all-changes view only for source-control + all-changes mode", () => {
+    expect(
+      resolveGitDiffSelection(createGitFile(), repoPath, allChangesTab())
+        .isAllChangesView
+    ).toBe(true);
+    expect(
+      resolveGitDiffSelection(createGitFile(), repoPath, focusTab())
+        .isAllChangesView
+    ).toBe(false);
+  });
+
+  it("treats null/undefined active tab as not the all-changes view", () => {
+    expect(
+      resolveGitDiffSelection(createGitFile(), repoPath, null).isAllChangesView
+    ).toBe(false);
+    expect(
+      resolveGitDiffSelection(createGitFile(), repoPath, undefined)
+        .isAllChangesView
+    ).toBe(false);
+  });
+
+  it("is pure: identical inputs yield equal output regardless of which active tab object instance is passed (ref stability backing)", () => {
+    const file = createGitFile();
+    const a = resolveGitDiffSelection(file, repoPath, allChangesTab());
+    const b = resolveGitDiffSelection(file, repoPath, allChangesTab());
+    expect(a).toEqual(b);
+  });
+});

--- a/src/modules/WorkStation/CodeEditor/sourceControlSelection.ts
+++ b/src/modules/WorkStation/CodeEditor/sourceControlSelection.ts
@@ -1,0 +1,38 @@
+import type { WorkStationTab } from "@src/store/workstation/tabs/types";
+import type { GitFile } from "@src/types/git/types";
+
+export interface ResolvedGitDiffSelection {
+  /** Repo root the file belongs to (worktree-aware), falling back to host repo. */
+  effectiveRepoPath: string;
+  /** Absolute on-disk path for the selected file. */
+  absolutePath: string;
+  /** Path relative to `effectiveRepoPath`, used as the git-diff cache key. */
+  relativePath: string;
+  /** Whether the active tab is the Source Control "all changes" view. */
+  isAllChangesView: boolean;
+}
+
+/**
+ * Pure resolver for a Source Control sidebar file selection. Extracted from
+ * `useSourceControlSetup.handleDiffSidebarFileSelect` so the path math and the
+ * all-changes detection can be unit-tested without React.
+ */
+export function resolveGitDiffSelection(
+  file: GitFile,
+  repoPath: string,
+  activeTab: WorkStationTab | undefined | null
+): ResolvedGitDiffSelection {
+  const effectiveRepoPath = file.repoRoot ?? repoPath;
+  const absolutePath = file.path.startsWith("/")
+    ? file.path
+    : `${effectiveRepoPath}/${file.path}`;
+  const relativePath = file.path.startsWith(effectiveRepoPath)
+    ? file.path.slice(effectiveRepoPath.length + 1)
+    : file.path;
+
+  const isAllChangesView =
+    activeTab?.type === "source-control" &&
+    activeTab.data.mode === "all-changes";
+
+  return { effectiveRepoPath, absolutePath, relativePath, isAllChangesView };
+}

--- a/src/modules/WorkStation/CodeEditor/useSourceControlSetup.ts
+++ b/src/modules/WorkStation/CodeEditor/useSourceControlSetup.ts
@@ -1,5 +1,5 @@
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import React, { useCallback, useEffect, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 
 import { useGitStatus } from "@src/contexts/git";
 import { useGitFiles } from "@src/hooks/git/sourceControl";
@@ -25,6 +25,7 @@ import {
   type SourceControlFilterMode,
 } from "../shared/SidebarModules";
 import { useWorkstationPr } from "./Panels/EditorPrimarySidebar/hooks/useWorkstationPr";
+import { resolveGitDiffSelection } from "./sourceControlSelection";
 import { useStashCount } from "./useStashCount";
 
 const logger = createLogger("SourceControlSetup");
@@ -251,26 +252,37 @@ export function useSourceControlSetup({
     [setGitDiffFiles]
   );
 
+  // `handleDiffSidebarFileSelect` is consumed by the memoized SidebarSlot
+  // context. Reading `activeTab` and `handleGitFileSelect` through refs keeps
+  // the callback identity stable across navigation so the warm Source Control
+  // tree does not re-render on every tab switch. (`handleGitFileSelect` is not
+  // stable on its own — it closes over the per-render `gitDiffState` object.)
+  const activeTabRef = useRef(activeTab);
+  useEffect(() => {
+    activeTabRef.current = activeTab;
+  }, [activeTab]);
+
+  const handleGitFileSelectRef = useRef(handleGitFileSelect);
+  useEffect(() => {
+    handleGitFileSelectRef.current = handleGitFileSelect;
+  }, [handleGitFileSelect]);
+
+  const setGitDiffFile = gitDiffState.setFile;
   const handleDiffSidebarFileSelect = useCallback(
     (file: GitFile) => {
-      const effectiveRepoPath = file.repoRoot ?? repoPath;
-      const absolutePath = file.path.startsWith("/")
-        ? file.path
-        : `${effectiveRepoPath}/${file.path}`;
-      const relativePath = file.path.startsWith(effectiveRepoPath)
-        ? file.path.slice(effectiveRepoPath.length + 1)
-        : file.path;
-
-      const isAllChangesView =
-        activeTab?.type === "source-control" &&
-        activeTab.data.mode === "all-changes";
+      const {
+        effectiveRepoPath,
+        absolutePath,
+        relativePath,
+        isAllChangesView,
+      } = resolveGitDiffSelection(file, repoPath, activeTabRef.current);
 
       if (!isAllChangesView) {
-        handleGitFileSelect(file);
+        handleGitFileSelectRef.current(file);
         return;
       }
 
-      gitDiffState.setFile(relativePath, {
+      setGitDiffFile(relativePath, {
         ...file,
         path: relativePath,
         repoRoot: effectiveRepoPath,
@@ -286,19 +298,13 @@ export function useSourceControlSetup({
       })
         .then((diffFile) => {
           if (!diffFile) return;
-          gitDiffState.setFile(relativePath, diffFile);
+          setGitDiffFile(relativePath, diffFile);
         })
         .catch((error) => {
           logger.error("Failed to load git diff:", error);
         });
     },
-    [
-      activeTab,
-      gitDiffState,
-      handleGitFileSelect,
-      repoPath,
-      setSourceControlFocusTarget,
-    ]
+    [repoPath, setGitDiffFile, setSourceControlFocusTarget]
   );
 
   return {


### PR DESCRIPTION
## Summary
Stabilizes Source Control re-renders in the WorkStation so navigating between views no longer triggers redundant re-renders driven by unstable derived git state.

## Changes
- Extract `gitFilesDerivation.ts` to compute git file lists deterministically and memoize derivation (`src/hooks/git/sourceControl/`).
- Extract `sourceControlSelection.ts` for stable selection logic in the CodeEditor (`src/modules/WorkStation/CodeEditor/`).
- Stabilize values flowing through `GitStatusProvider` to avoid identity churn across navigation.
- Add unit tests and `TEST_CASES.md` for the extracted derivation and selection logic.

## Test plan
- [ ] `pnpm test` passes (new tests under `src/hooks/git/sourceControl/__tests__` and `src/modules/WorkStation/CodeEditor/__tests__`).
- [ ] `pnpm typecheck` passes with no new errors.
- [ ] Manual: navigate between WorkStation views and confirm Source Control no longer re-renders redundantly.

Closes #16