### PR TITLE
fix(spotlight): route branch switching through guarded checkout flow

### DIFF
--- a/src/hooks/git/useRepoSelection/useBranchCheckout.ts
+++ b/src/hooks/git/useRepoSelection/useBranchCheckout.ts
@@ -5,8 +5,9 @@ import { useAtom, useAtomValue } from "jotai";
 import { useCallback, useEffect, useState } from "react";
 import { flushSync } from "react-dom";
 
-import { gitApi } from "@src/api/http/git";
+import { CheckoutConflictDialog } from "@src/components/GitDialogs/CheckoutConflictDialog";
 import { createLogger } from "@src/hooks/logger";
+import { runGuardedCheckout } from "@src/services/git/operations/guardedCheckout";
 import {
   REPO_KIND,
   currentBranchAtom,
@@ -79,33 +80,31 @@ export function useBranchCheckout(): UseBranchCheckoutReturn {
         setCurrentBranch(branch);
       });
       try {
-        const result = await gitApi.gitCheckout({
-          repo_id: selectedRepoId,
-          repo_path: repoPath,
+        const result = await runGuardedCheckout({
+          repoId: selectedRepoId,
+          repoPath,
           ref: branch,
+          onConflict: (name) =>
+            CheckoutConflictDialog.open({ branchName: name }),
         });
 
         if (result.success) {
-          // Branch checkout successful
+          // Optimistic value already reflects the new branch (the stash/force
+          // recovery checked out the same ref), so keep it as-is.
+          if (result.outcome !== "checked-out" && result.message) {
+            showGitActionDialogSafely(result.message, "info");
+          }
         } else {
-          // Rollback on failure
+          // Rollback: nothing was checked out (error or user cancellation).
           setCurrentBranch(previousBranch);
-          log.error(
-            `[useBranchCheckout] Failed to checkout branch "${branch}":`,
-            result.error,
-            `errorType: ${result.errorType}`
-          );
-
-          if (result.errorType === "uncommitted_changes") {
-            await handleUncommittedChanges(
-              branch,
-              selectedRepoId,
-              repoPath,
-              setCurrentBranch
+          if (result.outcome !== "cancelled") {
+            log.error(
+              `[useBranchCheckout] Failed to checkout branch "${branch}":`,
+              result.message,
+              `errorType: ${result.errorType}`
             );
-          } else {
             showGitActionDialogSafely(
-              result.error || `Failed to checkout branch "${branch}"`,
+              result.message || `Failed to checkout branch "${branch}"`,
               "error"
             );
           }
@@ -131,96 +130,4 @@ export function useBranchCheckout(): UseBranchCheckoutReturn {
     checkoutLoading,
     selectBranch,
   };
-}
-
-/**
- * Handle uncommitted changes conflict during checkout
- */
-async function handleUncommittedChanges(
-  branch: string,
-  repoId: string,
-  repoPath: string,
-  setCurrentBranch: (branch: string) => void
-) {
-  const { CheckoutConflictDialog } = await import("@src/components/GitDialogs");
-  const choice = await CheckoutConflictDialog.open({
-    branchName: branch,
-  });
-
-  if (choice === "stash") {
-    await handleStashAndCheckout(branch, repoId, repoPath, setCurrentBranch);
-  } else if (choice === "force") {
-    await handleForceCheckout(branch, repoId, repoPath, setCurrentBranch);
-  }
-  // choice === "cancel" - do nothing
-}
-
-async function handleStashAndCheckout(
-  branch: string,
-  repoId: string,
-  repoPath: string,
-  setCurrentBranch: (branch: string) => void
-) {
-  try {
-    const stashResult = await gitApi.gitStashPush({
-      repo_id: repoId,
-      repo_path: repoPath,
-      message: `Auto-stash before switching to ${branch}`,
-      include_untracked: true,
-    });
-
-    if (!stashResult) {
-      showGitActionDialogSafely("Failed to stash changes", "error");
-      return;
-    }
-
-    const checkoutResult = await gitApi.gitCheckout({
-      repo_id: repoId,
-      repo_path: repoPath,
-      ref: branch,
-    });
-
-    if (checkoutResult.success) {
-      setCurrentBranch(branch);
-      showGitActionDialogSafely(
-        `Switched to ${branch}. Changes stashed.`,
-        "info"
-      );
-    } else {
-      showGitActionDialogSafely(
-        checkoutResult.error || "Failed to checkout after stash",
-        "error"
-      );
-    }
-  } catch {
-    showGitActionDialogSafely("Failed to stash and checkout", "error");
-  }
-}
-
-async function handleForceCheckout(
-  branch: string,
-  repoId: string,
-  repoPath: string,
-  setCurrentBranch: (branch: string) => void
-) {
-  try {
-    const forceResult = await gitApi.gitCheckout({
-      repo_id: repoId,
-      repo_path: repoPath,
-      ref: branch,
-      force: true,
-    });
-
-    if (forceResult.success) {
-      setCurrentBranch(branch);
-      showGitActionDialogSafely(`Switched to ${branch}`, "info");
-    } else {
-      showGitActionDialogSafely(
-        forceResult.error || "Failed to force checkout",
-        "error"
-      );
-    }
-  } catch {
-    showGitActionDialogSafely("Failed to force checkout", "error");
-  }
 }

--- a/src/scaffold/GlobalSpotlight/__tests__/TEST_CASES.md
+++ b/src/scaffold/GlobalSpotlight/__tests__/TEST_CASES.md
@@ -1,0 +1,62 @@
+# Test Cases: Spotlight branch switching via guarded checkout (Issue #17)
+
+Routes Spotlight branch operations through the canonical guarded checkout
+(`useRepoSelection().selectBranch` → `useBranchCheckout.selectBranch`) so a dirty
+working tree surfaces the `CheckoutConflictDialog` (stash / discard / cancel).
+
+> Pure logic covered by Vitest: the `uncommitted_changes` classifier for the
+> `checkout` operation lives in
+> `src/util/dialogs/__tests__/gitErrorDialogHelpers.test.ts`. The handler
+> orchestration below is integration-level (modal + git API) and is verified
+> manually / by the agent harness — the repo's UI-feature workflow forbids
+> `.tsx` / testing-library tests.
+
+## Preconditions
+
+- A git repo is selected in Spotlight; the Branch palette is open.
+
+## Happy Path
+
+| #   | Steps                                        | Expected Result                                                                                                                            |
+| --- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1   | Clean tree → pick an existing branch         | `selectBranch` checks out with no dialog; Spotlight closes AFTER checkout resolves                                                         |
+| 2   | Clean tree → type a new name → create branch | `gitCreateBranch({ checkout: false })`, then `selectBranch(name)` performs the guarded checkout; "created" toast shown; modal closes after |
+| 3   | Clean tree → "Checkout detached..."          | `selectBranch("HEAD")` runs the guarded checkout; detached-HEAD success toast shown; modal closes after                                    |
+
+## Edge Cases
+
+| #   | Scenario                                       | Steps                                                                                                                                       | Expected Result |
+| --- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | --------------- |
+| 1   | Dirty tree → pick branch                       | Checkout returns `uncommitted_changes` → `CheckoutConflictDialog` appears (stash/discard/cancel) BEFORE the modal closes (no teardown race) |
+| 2   | Dirty tree → conflict dialog → Cancel          | No checkout performed; branch state rolled back; modal still closes (await-before-close)                                                    |
+| 3   | Dirty tree → conflict dialog → Stash           | Changes stashed, branch checked out, success toast                                                                                          |
+| 4   | Dirty tree → conflict dialog → Discard (force) | Force checkout, success toast                                                                                                               |
+| 5   | Dirty tree → create-and-checkout               | Branch created (not checked out), then guarded `selectBranch` raises the conflict dialog on the dirty tree                                  |
+| 6   | Dirty tree → checkout detached                 | `selectBranch("HEAD")` raises the conflict dialog instead of bypassing it                                                                   |
+
+## Error / Degraded States
+
+| #   | Scenario                                                                                | Steps                           | Expected Result                                                                             |
+| --- | --------------------------------------------------------------------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------- |
+| 1   | No repo selected                                                                        | Invoke any handler              | "No repo selected" error toast; no git call                                                 |
+| 2   | Create branch fails                                                                     | `gitCreateBranch` returns false | "Failed to create branch" error toast; no checkout attempted                                |
+| 3   | Backend returns errorType "unknown" but message says "would be overwritten by checkout" | checkout op                     | `inferErrorTypeFromText` classifies `uncommitted_changes` (so the conflict dialog can fire) |
+
+## Accessibility
+
+- [x] No change to keyboard/focus model of the palette.
+
+## Acceptance Criteria
+
+- [x] Step 1: create-and-checkout uses `checkout: false` then `selectBranch`.
+- [x] Step 2: detached-HEAD routes through `selectBranch("HEAD")` (raw `gitCheckout` removed); success copy kept.
+- [x] Step 3: all three handlers `await selectBranch(...)` BEFORE `closeModal()`.
+- [x] Step 4: `gitErrorDialog` classifier detects `uncommitted_changes` for `checkout` (minimal fix; full ActionSystem reroute left as TODO).
+- [ ] Step 5 (OUT OF SCOPE): "commit changes" conflict option NOT added — existing flow is stash/discard/cancel only.
+
+## Notes / Follow-ups
+
+- The ActionSystem path (`gitBranchActions.zod.ts` → `branchOps.checkoutWithDialog`)
+  still uses its own dialog. Only the minimal classifier fix was applied; a full
+  reroute onto `selectBranch` would need to preserve the action's
+  `{ success, message, errorType }` result contract and is left as a TODO.

--- a/src/scaffold/GlobalSpotlight/__tests__/TEST_CASES.md
+++ b/src/scaffold/GlobalSpotlight/__tests__/TEST_CASES.md
@@ -51,12 +51,16 @@ working tree surfaces the `CheckoutConflictDialog` (stash / discard / cancel).
 - [x] Step 1: create-and-checkout uses `checkout: false` then `selectBranch`.
 - [x] Step 2: detached-HEAD routes through `selectBranch("HEAD")` (raw `gitCheckout` removed); success copy kept.
 - [x] Step 3: all three handlers `await selectBranch(...)` BEFORE `closeModal()`.
-- [x] Step 4: `gitErrorDialog` classifier detects `uncommitted_changes` for `checkout` (minimal fix; full ActionSystem reroute left as TODO).
+- [x] Step 4: `gitErrorDialog` classifier detects `uncommitted_changes` for `checkout`. Full ActionSystem reroute now done — `branchOps.checkoutWithDialog` routes through the shared `runGuardedCheckout` core (see `src/services/git/operations/__tests__/TEST_CASES.md`).
 - [ ] Step 5 (OUT OF SCOPE): "commit changes" conflict option NOT added — existing flow is stash/discard/cancel only.
 
 ## Notes / Follow-ups
 
 - The ActionSystem path (`gitBranchActions.zod.ts` → `branchOps.checkoutWithDialog`)
-  still uses its own dialog. Only the minimal classifier fix was applied; a full
-  reroute onto `selectBranch` would need to preserve the action's
-  `{ success, message, errorType }` result contract and is left as a TODO.
+  now shares the canonical guarded-checkout logic. The conflict-handling business
+  logic was extracted out of `useBranchCheckout` into the plain async core
+  `src/services/git/operations/guardedCheckout.ts` (`runGuardedCheckout`), which
+  both `useBranchCheckout.selectBranch` and `branchOps.checkoutWithDialog` call.
+  Both paths now surface the same `CheckoutConflictDialog`; the divergent
+  `showGitErrorDialog` checkout branch is gone. `checkoutWithDialog` maps the
+  core's result back onto the `{ success, message, errorType }` contract.

--- a/src/scaffold/GlobalSpotlight/index.tsx
+++ b/src/scaffold/GlobalSpotlight/index.tsx
@@ -164,8 +164,10 @@ const GlobalSpotlightInner: React.FC<
   );
 
   const handleBranchPickerSelect = useCallback(
-    (branchName: string) => {
-      void selectBranch(branchName);
+    async (branchName: string) => {
+      // Await the guarded checkout BEFORE tearing down the modal — otherwise
+      // closeModal() races the CheckoutConflictDialog selectBranch may open.
+      await selectBranch(branchName);
       setBranchPickerOpen(false);
       closeModal();
     },
@@ -179,12 +181,15 @@ const GlobalSpotlightInner: React.FC<
         return;
       }
 
+      // Create WITHOUT checking out, then route the checkout through
+      // selectBranch so a dirty working tree surfaces the CheckoutConflictDialog
+      // instead of the raw create+checkout bypassing the guard.
       const success = await gitApi.gitCreateBranch({
         repo_id: selectedRepoId,
         repo_path: currentRepo.path,
         name: branchName,
         start_point: startPoint ?? null,
-        checkout: true,
+        checkout: false,
       });
 
       if (!success) {
@@ -236,25 +241,16 @@ const GlobalSpotlightInner: React.FC<
       return;
     }
 
-    const result = await gitApi.gitCheckout({
-      repo_id: selectedRepoId,
-      repo_path: currentRepo.path,
-      ref: "HEAD",
-    });
-
-    if (!result.success) {
-      showGitActionDialogSafely(
-        result.error ?? t("selectors.branch.actions.checkoutDetachedFailed"),
-        "error"
-      );
-      return;
-    }
+    // Route through the guarded checkout flow (selectBranch special-cases
+    // HEAD-style refs) so a dirty tree surfaces the CheckoutConflictDialog
+    // rather than bypassing it with a raw gitCheckout. selectBranch reports its
+    // own failures; we keep the detached-HEAD success copy.
+    await selectBranch("HEAD");
 
     showGitActionDialogSafely(
       t("selectors.branch.actions.checkoutDetachedSuccess"),
       "info"
     );
-    await selectBranch("HEAD");
     await refreshBranches();
     setBranchPickerOpen(false);
     closeModal();

--- a/src/services/git/operations/__tests__/TEST_CASES.md
+++ b/src/services/git/operations/__tests__/TEST_CASES.md
@@ -1,0 +1,58 @@
+# Test Cases: `runGuardedCheckout` (Issue #17 de-dup)
+
+The single guarded-checkout core shared by the hook path
+(`useBranchCheckout.selectBranch`) and the ActionSystem service path
+(`branchOps.checkoutWithDialog`). It checks out a ref and, when the working tree
+is dirty, surfaces the unified `CheckoutConflictDialog` (stash / discard /
+cancel) via an injected `onConflict` callback.
+
+> Pure logic covered by Vitest in `guardedCheckout.test.ts`. `gitApi` is mocked
+> with `vi.mock`; the conflict dialog is a `vi.fn()` passed as `onConflict`, so
+> no Tauri dialog or HTTP call runs. The repo's UI-feature workflow forbids
+> `.tsx` / testing-library tests, so the modal + atom orchestration in the hook
+> is verified manually / by the agent harness.
+
+## Preconditions
+
+- `gitApi.gitCheckout` / `gitApi.gitStashPush` are mocked.
+- `onConflict` resolves to `"stash" | "force" | "cancel"`.
+
+## Happy Path
+
+| #   | Scenario      | Steps                                      | Expected Result                                                                         |
+| --- | ------------- | ------------------------------------------ | --------------------------------------------------------------------------------------- |
+| 1   | Clean tree    | `gitCheckout` resolves `{ success: true }` | `{ success: true, outcome: "checked-out", errorType: "none" }`; `onConflict` not called |
+| 2   | `create` flag | Clean checkout with `create: true`         | `gitCheckout` called with `create: true`                                                |
+
+## Edge Cases — uncommitted_changes conflict
+
+| #   | Choice | Steps                                     | Expected Result                                                                                |
+| --- | ------ | ----------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| 1   | stash  | conflict → stash push ok → re-checkout ok | `{ success: true, outcome: "stashed", message: "Switched to … Changes stashed." }`             |
+| 2   | force  | conflict → force checkout ok              | `{ success: true, outcome: "forced", message: "Switched to …" }`; no stash call                |
+| 3   | cancel | conflict → user cancels                   | `{ success: false, outcome: "cancelled", errorType: "uncommitted_changes" }`; no recovery call |
+
+## Error / Degraded States
+
+| #   | Scenario                   | Steps                                                 | Expected Result                                                               |
+| --- | -------------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------------- |
+| 1   | Non-conflict failure       | `gitCheckout` → `{ success:false, branch_not_found }` | `{ success:false, outcome:"error", errorType:"branch_not_found" }`; no dialog |
+| 2   | Missing error message      | failure with no `error` field                         | message falls back to `Failed to checkout branch "<ref>"`                     |
+| 3   | Checkout throws            | `gitCheckout` rejects                                 | `{ success:false, outcome:"error", errorType:"other", message:<err> }`        |
+| 4   | Stash push returns nothing | conflict → stash → `undefined`                        | `{ success:false, outcome:"error", message:"Failed to stash changes" }`       |
+| 5   | Post-stash checkout fails  | conflict → stash ok → re-checkout fails               | `{ success:false, outcome:"error", message:<checkout error> }`                |
+| 6   | Stash push throws          | conflict → stash rejects                              | `{ success:false, outcome:"error", message:"Failed to stash and checkout" }`  |
+| 7   | Force checkout fails       | conflict → force checkout fails                       | `{ success:false, outcome:"error", message:<force error> }`                   |
+
+## Contract mapping (`branchOps.checkoutWithDialog`)
+
+- `runGuardedCheckout` result → `{ success, message, errorType }` `GitOperationResult`.
+- `errorType` mapped via `toGitErrorType`: `none → none`, `uncommitted_changes →
+uncommitted_changes`, everything else → `unknown`.
+
+## Acceptance Criteria
+
+- [x] All branch outcomes covered by Vitest.
+- [x] `onConflict` is the sole entry point to the conflict dialog (no direct UI import in the core).
+- [x] Core never throws; always resolves a normalized result.
+- [x] ActionSystem `{ success, message, errorType }` contract preserved.

--- a/src/services/git/operations/__tests__/guardedCheckout.test.ts
+++ b/src/services/git/operations/__tests__/guardedCheckout.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Unit tests for the shared guarded-checkout core (Issue #17 de-dup).
+ *
+ * Covers every branch outcome of `runGuardedCheckout`:
+ * success (clean tree), uncommitted_changes → stash / force / cancel, the
+ * recovery failure paths, non-conflict errors, and a thrown checkout.
+ * `gitApi` is mocked so no real git/HTTP calls happen.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runGuardedCheckout } from "../guardedCheckout";
+
+const gitCheckout = vi.fn();
+const gitStashPush = vi.fn();
+
+vi.mock("@src/api/http/git", () => ({
+  gitApi: {
+    gitCheckout: (...args: unknown[]) => gitCheckout(...args),
+    gitStashPush: (...args: unknown[]) => gitStashPush(...args),
+  },
+}));
+
+function conflict(choice: "stash" | "force" | "cancel") {
+  return vi.fn().mockResolvedValue(choice);
+}
+
+const BASE = {
+  repoId: "repo-1",
+  repoPath: "/tmp/repo",
+  ref: "feature",
+} as const;
+
+beforeEach(() => {
+  gitCheckout.mockReset();
+  gitStashPush.mockReset();
+});
+
+describe("runGuardedCheckout — clean tree", () => {
+  it("returns checked-out without invoking the conflict dialog", async () => {
+    gitCheckout.mockResolvedValueOnce({ success: true });
+    const onConflict = conflict("stash");
+
+    const result = await runGuardedCheckout({ ...BASE, onConflict });
+
+    expect(result).toEqual({
+      success: true,
+      outcome: "checked-out",
+      errorType: "none",
+    });
+    expect(onConflict).not.toHaveBeenCalled();
+    expect(gitStashPush).not.toHaveBeenCalled();
+  });
+
+  it("forwards the create flag to the checkout call", async () => {
+    gitCheckout.mockResolvedValueOnce({ success: true });
+
+    await runGuardedCheckout({
+      ...BASE,
+      create: true,
+      onConflict: conflict("cancel"),
+    });
+
+    expect(gitCheckout).toHaveBeenCalledWith({
+      repo_id: "repo-1",
+      repo_path: "/tmp/repo",
+      ref: "feature",
+      create: true,
+    });
+  });
+});
+
+describe("runGuardedCheckout — non-conflict failure", () => {
+  it("returns an error and never shows the conflict dialog", async () => {
+    gitCheckout.mockResolvedValueOnce({
+      success: false,
+      errorType: "branch_not_found",
+      error: "Branch not found.",
+    });
+    const onConflict = conflict("stash");
+
+    const result = await runGuardedCheckout({ ...BASE, onConflict });
+
+    expect(result).toEqual({
+      success: false,
+      outcome: "error",
+      errorType: "branch_not_found",
+      message: "Branch not found.",
+    });
+    expect(onConflict).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a default message when none is supplied", async () => {
+    gitCheckout.mockResolvedValueOnce({ success: false, errorType: "other" });
+
+    const result = await runGuardedCheckout({
+      ...BASE,
+      onConflict: conflict("cancel"),
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe('Failed to checkout branch "feature"');
+  });
+
+  it("returns an error when the checkout call throws", async () => {
+    gitCheckout.mockRejectedValueOnce(new Error("network down"));
+
+    const result = await runGuardedCheckout({
+      ...BASE,
+      onConflict: conflict("stash"),
+    });
+
+    expect(result).toEqual({
+      success: false,
+      outcome: "error",
+      errorType: "other",
+      message: "network down",
+    });
+  });
+});
+
+describe("runGuardedCheckout — uncommitted_changes → stash", () => {
+  it("stashes then re-checks out and reports stashed success", async () => {
+    gitCheckout
+      .mockResolvedValueOnce({
+        success: false,
+        errorType: "uncommitted_changes",
+      })
+      .mockResolvedValueOnce({ success: true });
+    gitStashPush.mockResolvedValueOnce({
+      success: true,
+      stash_ref: "stash@{0}",
+    });
+
+    const result = await runGuardedCheckout({
+      ...BASE,
+      onConflict: conflict("stash"),
+    });
+
+    expect(result).toEqual({
+      success: true,
+      outcome: "stashed",
+      errorType: "none",
+      message: "Switched to feature. Changes stashed.",
+    });
+    expect(gitStashPush).toHaveBeenCalledTimes(1);
+    expect(gitCheckout).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns an error when the stash push returns nothing", async () => {
+    gitCheckout.mockResolvedValueOnce({
+      success: false,
+      errorType: "uncommitted_changes",
+    });
+    gitStashPush.mockResolvedValueOnce(undefined);
+
+    const result = await runGuardedCheckout({
+      ...BASE,
+      onConflict: conflict("stash"),
+    });
+
+    expect(result).toEqual({
+      success: false,
+      outcome: "error",
+      errorType: "uncommitted_changes",
+      message: "Failed to stash changes",
+    });
+    expect(gitCheckout).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an error when the post-stash checkout fails", async () => {
+    gitCheckout
+      .mockResolvedValueOnce({
+        success: false,
+        errorType: "uncommitted_changes",
+      })
+      .mockResolvedValueOnce({
+        success: false,
+        errorType: "other",
+        error: "still dirty",
+      });
+    gitStashPush.mockResolvedValueOnce({ success: true });
+
+    const result = await runGuardedCheckout({
+      ...BASE,
+      onConflict: conflict("stash"),
+    });
+
+    expect(result).toEqual({
+      success: false,
+      outcome: "error",
+      errorType: "other",
+      message: "still dirty",
+    });
+  });
+
+  it("returns an error when the stash push throws", async () => {
+    gitCheckout.mockResolvedValueOnce({
+      success: false,
+      errorType: "uncommitted_changes",
+    });
+    gitStashPush.mockRejectedValueOnce(new Error("boom"));
+
+    const result = await runGuardedCheckout({
+      ...BASE,
+      onConflict: conflict("stash"),
+    });
+
+    expect(result).toEqual({
+      success: false,
+      outcome: "error",
+      errorType: "other",
+      message: "Failed to stash and checkout",
+    });
+  });
+});
+
+describe("runGuardedCheckout — uncommitted_changes → force", () => {
+  it("force-checks out and reports forced success", async () => {
+    gitCheckout
+      .mockResolvedValueOnce({
+        success: false,
+        errorType: "uncommitted_changes",
+      })
+      .mockResolvedValueOnce({ success: true });
+
+    const result = await runGuardedCheckout({
+      ...BASE,
+      onConflict: conflict("force"),
+    });
+
+    expect(result).toEqual({
+      success: true,
+      outcome: "forced",
+      errorType: "none",
+      message: "Switched to feature",
+    });
+    expect(gitStashPush).not.toHaveBeenCalled();
+    expect(gitCheckout).toHaveBeenLastCalledWith({
+      repo_id: "repo-1",
+      repo_path: "/tmp/repo",
+      ref: "feature",
+      force: true,
+    });
+  });
+
+  it("returns an error when the force checkout fails", async () => {
+    gitCheckout
+      .mockResolvedValueOnce({
+        success: false,
+        errorType: "uncommitted_changes",
+      })
+      .mockResolvedValueOnce({
+        success: false,
+        errorType: "other",
+        error: "cannot force",
+      });
+
+    const result = await runGuardedCheckout({
+      ...BASE,
+      onConflict: conflict("force"),
+    });
+
+    expect(result).toEqual({
+      success: false,
+      outcome: "error",
+      errorType: "other",
+      message: "cannot force",
+    });
+  });
+});
+
+describe("runGuardedCheckout — uncommitted_changes → cancel", () => {
+  it("reports a non-success cancelled outcome without any recovery call", async () => {
+    gitCheckout.mockResolvedValueOnce({
+      success: false,
+      errorType: "uncommitted_changes",
+    });
+
+    const result = await runGuardedCheckout({
+      ...BASE,
+      onConflict: conflict("cancel"),
+    });
+
+    expect(result).toEqual({
+      success: false,
+      outcome: "cancelled",
+      errorType: "uncommitted_changes",
+      message: 'Checkout of "feature" cancelled. Local changes were kept.',
+    });
+    expect(gitStashPush).not.toHaveBeenCalled();
+    expect(gitCheckout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/services/git/operations/branchOps.ts
+++ b/src/services/git/operations/branchOps.ts
@@ -2,9 +2,12 @@
  * Branch Operations — checkout, stash, stashPop, stashApply, stashDrop
  */
 import { gitApi } from "@src/api/http/git";
-import { showGitErrorAndHandle } from "@src/hooks/git/useGitErrorDialog";
+import type { CheckoutErrorType } from "@src/api/http/git/branchOps";
+import type { GitErrorType } from "@src/api/http/git/streaming";
+import { CheckoutConflictDialog } from "@src/components/GitDialogs/CheckoutConflictDialog";
 
 import { TerminalService } from "../../terminal";
+import { runGuardedCheckout } from "./guardedCheckout";
 import {
   type GitOperationResult,
   getRepoContext,
@@ -226,31 +229,48 @@ export async function stashDrop(
 // ============================================
 
 /**
- * Checkout with error dialog on failure.
+ * Map the guarded-checkout core's `CheckoutErrorType` onto the `GitErrorType`
+ * used by the `GitOperationResult` contract that ActionSystem callers consume.
+ */
+function toGitErrorType(errorType: CheckoutErrorType | "none"): GitErrorType {
+  if (errorType === "none") return "none";
+  if (errorType === "uncommitted_changes") return "uncommitted_changes";
+  // branch_not_found / merge_in_progress / rebase_in_progress / other have no
+  // dedicated GitErrorType — surface them as the generic failure bucket.
+  return "unknown";
+}
+
+/**
+ * Checkout with conflict handling (Issue #17 de-dup).
  *
- * TODO(#17 de-dup): this is a second checkout path with its own error dialog,
- * separate from the canonical `useBranchCheckout.selectBranch` flow that drives
- * the CheckoutConflictDialog (stash/discard/cancel). For now we only ensure the
- * shared classifier (`gitErrorDialog.inferErrorTypeFromText`) detects
- * `uncommitted_changes` for the `checkout` operation. A full reroute onto
- * `selectBranch` must preserve this function's `{ success, message, errorType }`
- * result contract for ActionSystem callers before it can be done safely.
+ * Routes the ActionSystem `GIT_CHECKOUT` path through the SAME guarded-checkout
+ * core as `useBranchCheckout.selectBranch`, so a dirty tree surfaces the unified
+ * `CheckoutConflictDialog` (stash/discard/cancel) instead of the old divergent
+ * `showGitErrorDialog` flow. The result is mapped back to the
+ * `{ success, message, errorType }` contract its callers depend on.
  */
 export async function checkoutWithDialog(
   branch: string,
   create?: boolean
 ): Promise<GitOperationResult> {
   const repoContext = getRepoContext();
-  const result = await checkout(branch, create);
 
-  if (!result.success && result.errorType !== "none") {
-    await showGitErrorAndHandle({
-      operation: "checkout",
-      repoId: repoContext?.repoId,
-      repoPath: repoContext?.repoPath,
-      errorType: result.errorType,
-      errorMessage: result.message || "Checkout failed",
-    });
+  if (!repoContext) {
+    // No repo context → fall back to the terminal-based checkout (no dialog).
+    return checkout(branch, create);
   }
-  return result;
+
+  const result = await runGuardedCheckout({
+    repoId: repoContext.repoId,
+    repoPath: repoContext.repoPath,
+    ref: branch,
+    create,
+    onConflict: (name) => CheckoutConflictDialog.open({ branchName: name }),
+  });
+
+  return {
+    success: result.success,
+    errorType: toGitErrorType(result.errorType),
+    message: result.message,
+  };
 }

--- a/src/services/git/operations/branchOps.ts
+++ b/src/services/git/operations/branchOps.ts
@@ -226,7 +226,15 @@ export async function stashDrop(
 // ============================================
 
 /**
- * Checkout with error dialog on failure
+ * Checkout with error dialog on failure.
+ *
+ * TODO(#17 de-dup): this is a second checkout path with its own error dialog,
+ * separate from the canonical `useBranchCheckout.selectBranch` flow that drives
+ * the CheckoutConflictDialog (stash/discard/cancel). For now we only ensure the
+ * shared classifier (`gitErrorDialog.inferErrorTypeFromText`) detects
+ * `uncommitted_changes` for the `checkout` operation. A full reroute onto
+ * `selectBranch` must preserve this function's `{ success, message, errorType }`
+ * result contract for ActionSystem callers before it can be done safely.
  */
 export async function checkoutWithDialog(
   branch: string,

--- a/src/services/git/operations/guardedCheckout.ts
+++ b/src/services/git/operations/guardedCheckout.ts
@@ -1,0 +1,193 @@
+/**
+ * Guarded checkout core (Issue #17 de-dup).
+ *
+ * The single source of truth for "checkout a ref, and when the working tree is
+ * dirty surface the stash/discard/cancel conflict flow". Extracted out of
+ * `useBranchCheckout` (a React hook) into a plain async function so BOTH the
+ * canonical hook path (`useBranchCheckout.selectBranch`) and the ActionSystem
+ * service path (`branchOps.checkoutWithDialog`) can share it without a service
+ * importing hook state.
+ *
+ * The conflict dialog is injected via `onConflict` so the core stays UI-free and
+ * testable; both call sites pass `CheckoutConflictDialog.open`.
+ */
+import { gitApi } from "@src/api/http/git";
+import type {
+  CheckoutErrorType,
+  GitCheckoutResult,
+} from "@src/api/http/git/branchOps";
+import type { CheckoutConflictResult } from "@src/components/GitDialogs/CheckoutConflictDialog";
+
+/**
+ * How a guarded checkout resolved.
+ * - `checked-out`: clean tree, direct checkout succeeded
+ * - `stashed`: dirty tree → stashed local changes → checkout succeeded
+ * - `forced`: dirty tree → discarded local changes (force) → checkout succeeded
+ * - `cancelled`: dirty tree → user cancelled the conflict dialog (no checkout)
+ * - `error`: checkout (or stash/force recovery) failed
+ */
+export type GuardedCheckoutOutcome =
+  | "checked-out"
+  | "stashed"
+  | "forced"
+  | "cancelled"
+  | "error";
+
+export interface GuardedCheckoutResult {
+  /** True only when the ref is now checked out (checked-out / stashed / forced). */
+  success: boolean;
+  outcome: GuardedCheckoutOutcome;
+  /** Original git-checkout error classification ("none" on success). */
+  errorType: CheckoutErrorType | "none";
+  /**
+   * Human-readable message. On success outcomes this is an info string suitable
+   * for a toast; otherwise it's the failure reason.
+   */
+  message?: string;
+}
+
+export interface GuardedCheckoutParams {
+  repoId: string;
+  repoPath?: string;
+  ref: string;
+  /** Create the branch as part of the checkout. */
+  create?: boolean;
+  /**
+   * Resolve the user's choice when the checkout fails because of uncommitted
+   * changes. Injected so the core never imports a dialog directly.
+   */
+  onConflict: (branch: string) => Promise<CheckoutConflictResult>;
+}
+
+function failure(
+  errorType: CheckoutErrorType | "none",
+  message: string
+): GuardedCheckoutResult {
+  return { success: false, outcome: "error", errorType, message };
+}
+
+async function stashAndCheckout(
+  repoId: string,
+  repoPath: string | undefined,
+  ref: string
+): Promise<GuardedCheckoutResult> {
+  try {
+    const stashResult = await gitApi.gitStashPush({
+      repo_id: repoId,
+      repo_path: repoPath,
+      message: `Auto-stash before switching to ${ref}`,
+      include_untracked: true,
+    });
+
+    if (!stashResult) {
+      return failure("uncommitted_changes", "Failed to stash changes");
+    }
+
+    const checkoutResult = await gitApi.gitCheckout({
+      repo_id: repoId,
+      repo_path: repoPath,
+      ref,
+    });
+
+    if (checkoutResult.success) {
+      return {
+        success: true,
+        outcome: "stashed",
+        errorType: "none",
+        message: `Switched to ${ref}. Changes stashed.`,
+      };
+    }
+
+    return failure(
+      checkoutResult.errorType ?? "other",
+      checkoutResult.error || "Failed to checkout after stash"
+    );
+  } catch {
+    return failure("other", "Failed to stash and checkout");
+  }
+}
+
+async function forceCheckout(
+  repoId: string,
+  repoPath: string | undefined,
+  ref: string
+): Promise<GuardedCheckoutResult> {
+  try {
+    const forceResult = await gitApi.gitCheckout({
+      repo_id: repoId,
+      repo_path: repoPath,
+      ref,
+      force: true,
+    });
+
+    if (forceResult.success) {
+      return {
+        success: true,
+        outcome: "forced",
+        errorType: "none",
+        message: `Switched to ${ref}`,
+      };
+    }
+
+    return failure(
+      forceResult.errorType ?? "other",
+      forceResult.error || "Failed to force checkout"
+    );
+  } catch {
+    return failure("other", "Failed to force checkout");
+  }
+}
+
+/**
+ * Checkout `ref`, surfacing the conflict dialog (stash/discard/cancel) when the
+ * working tree is dirty. Never throws — always resolves a normalized result.
+ */
+export async function runGuardedCheckout(
+  params: GuardedCheckoutParams
+): Promise<GuardedCheckoutResult> {
+  const { repoId, repoPath, ref, create, onConflict } = params;
+
+  let result: GitCheckoutResult;
+  try {
+    result = await gitApi.gitCheckout({
+      repo_id: repoId,
+      repo_path: repoPath,
+      ref,
+      create,
+    });
+  } catch (error) {
+    return failure(
+      "other",
+      error instanceof Error
+        ? error.message
+        : `Failed to checkout branch "${ref}"`
+    );
+  }
+
+  if (result.success) {
+    return { success: true, outcome: "checked-out", errorType: "none" };
+  }
+
+  if (result.errorType !== "uncommitted_changes") {
+    return failure(
+      result.errorType ?? "other",
+      result.error || `Failed to checkout branch "${ref}"`
+    );
+  }
+
+  const choice = await onConflict(ref);
+
+  if (choice === "stash") {
+    return stashAndCheckout(repoId, repoPath, ref);
+  }
+  if (choice === "force") {
+    return forceCheckout(repoId, repoPath, ref);
+  }
+
+  return {
+    success: false,
+    outcome: "cancelled",
+    errorType: "uncommitted_changes",
+    message: `Checkout of "${ref}" cancelled. Local changes were kept.`,
+  };
+}

--- a/src/util/dialogs/__tests__/gitErrorDialogHelpers.test.ts
+++ b/src/util/dialogs/__tests__/gitErrorDialogHelpers.test.ts
@@ -74,6 +74,28 @@ describe("buildGitErrorInfo — error type inference (errorType: 'unknown')", ()
     expect(info.errorType).toBe("uncommitted_changes");
   });
 
+  it("infers uncommitted_changes for checkout with 'would be overwritten by checkout'", () => {
+    const info = buildGitErrorInfo(
+      makeOptions({
+        operation: "checkout",
+        commandOutput:
+          "error: Your local changes to the following files would be overwritten by checkout:\n\tsrc/a.ts\nPlease commit your changes or stash them before you switch branches.",
+      })
+    );
+    expect(info.errorType).toBe("uncommitted_changes");
+  });
+
+  it("infers uncommitted_changes for checkout with 'please commit your changes or stash them'", () => {
+    const info = buildGitErrorInfo(
+      makeOptions({
+        operation: "checkout",
+        commandOutput:
+          "Please commit your changes or stash them before you switch branches.",
+      })
+    );
+    expect(info.errorType).toBe("uncommitted_changes");
+  });
+
   it("infers merge_conflicts for pull with 'automatic merge failed'", () => {
     const info = buildGitErrorInfo(
       makeOptions({

--- a/src/util/dialogs/gitErrorDialog.ts
+++ b/src/util/dialogs/gitErrorDialog.ts
@@ -183,7 +183,9 @@ function inferErrorTypeFromText(
   }
 
   if (
-    (normalizedOperation === "pull" || normalizedOperation === "sync") &&
+    (normalizedOperation === "pull" ||
+      normalizedOperation === "sync" ||
+      normalizedOperation === "checkout") &&
     includesAnyPattern(combinedText, UNCOMMITTED_CHANGES_PATTERNS)
   ) {
     return "uncommitted_changes";


### PR DESCRIPTION
## Summary
Routes Spotlight branch switching through the guarded checkout flow so branch changes from Spotlight honor the same safety checks (dirty-state handling, dedup) as the rest of the app, and extracts a shared guarded-checkout core to remove duplicated branch-switching logic.

## Changes
- Route Spotlight branch switching through the guarded checkout flow (`src/scaffold/GlobalSpotlight/`).
- Extract a shared guarded-checkout core (`src/services/git/operations/guardedCheckout.ts`) used by branch switching, deduplicating logic in `branchOps.ts` and `useBranchCheckout.ts`.
- Add unit tests and `TEST_CASES.md` for the guarded checkout core and Spotlight flow.

## Test plan
- [ ] `pnpm test` passes (new tests under `src/services/git/operations/__tests__` and `src/scaffold/GlobalSpotlight/__tests__`).
- [ ] `pnpm typecheck` passes with no new errors.
- [ ] Manual: switch branches from Spotlight with a dirty working tree and confirm the guard prompts/dedupes correctly.

Closes #17