### PR TITLE
fix(chat): prevent pinned skill pills from overlapping

### DIFF
--- a/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.tsx
+++ b/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.tsx
@@ -80,6 +80,7 @@ const ActionPill: React.FC<ActionPillProps> = memo(
         itemType="file"
         as="div"
         display="inline-block"
+        className="shrink-0"
       >
         {button}
       </FileTreeHoverPreview>


### PR DESCRIPTION
## Summary
 
- Fixes #55
- Prevent pinned skill pills from shrinking through their `FileTreeHoverPreview` wrapper.
- Keep skill actions like `manage-skills` and `manage-agents-and-orgs` from visually overlapping when the composer narrows.
 
## Screenshot
 
<img width="405" height="227" alt="Screenshot 2026-06-21 at 10 33 34 PM" src="https://github.com/user-attachments/assets/2052afeb-9fc0-499b-a64f-2686a45bec01" />
 
## Root Cause
 
Skill action pills render inside `FileTreeHoverPreview` so hovering can show the skill file preview. The inner button was already non-shrinking, but the wrapper itself remained shrinkable as the actual flex item. When the composer became narrow, the wrapper could collapse while the button overflowed into neighboring pills.
 
## Fix
 
Added `className="shrink-0"` to the `FileTreeHoverPreview` wrapper in `src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.tsx`.
 
## Verification
 
- `pnpm run lint`
- `pnpm run check:circular`
- Manual UI verification confirmed `manage-skills` and `manage-agents-and-orgs` no longer overlap when narrowing the window.
