### PR TITLE
fix(chat): hide planning footer on historical turn pages

### DIFF
--- a/src/engines/ChatPanel/ChatHistory/index.tsx
+++ b/src/engines/ChatPanel/ChatHistory/index.tsx
@@ -98,6 +98,7 @@ interface PlanningIndicatorBridgeProps extends Omit<
   "planningIndicatorCount" | "planningShowSlowHint" | "planningVariantIndex"
 > {
   planningIndicatorScope: { sessionId: string; isLive: boolean } | null;
+  planningIndicatorEnabled: boolean;
   /**
    * Called whenever the visible count (0 or 1) changes. Stable identity —
    * created once with `useCallback([], [])` in the orchestrator.
@@ -107,24 +108,26 @@ interface PlanningIndicatorBridgeProps extends Omit<
 
 const PlanningIndicatorBridge: React.FC<PlanningIndicatorBridgeProps> = ({
   planningIndicatorScope,
+  planningIndicatorEnabled,
   onPlanningIndicatorCount,
   ...chatHistoryListProps
 }) => {
   const { count, showSlowHint, variantIndex } = usePlanningIndicator(
     planningIndicatorScope
   );
+  const visibleCount = planningIndicatorEnabled ? count : 0;
 
   // Notify the orchestrator whenever the count flips so useChatFooterSpacer
   // can schedule a re-measurement.
   useEffect(() => {
-    onPlanningIndicatorCount(count);
-  }, [count, onPlanningIndicatorCount]);
+    onPlanningIndicatorCount(visibleCount);
+  }, [visibleCount, onPlanningIndicatorCount]);
 
   return (
     <ChatHistoryList
       {...chatHistoryListProps}
-      planningIndicatorCount={count}
-      planningShowSlowHint={showSlowHint}
+      planningIndicatorCount={visibleCount}
+      planningShowSlowHint={planningIndicatorEnabled && showSlowHint}
       planningVariantIndex={variantIndex}
     />
   );
@@ -538,6 +541,8 @@ const ChatHistory: React.FC<ChatHistoryProps> = ({
     // dead subagent session).
     mergeUserOnlyPages: hideGroupUserMessage,
   });
+  const planningIndicatorEnabled =
+    !turnPaginationEnabled || currentPageIndex >= pageCount - 1;
   const virtualListGroupShapeKey = displayGroupCounts.join(",");
   const virtualListDataKey = `${activeId ?? "no-session"}:${
     turnPaginationEnabled ? `page-${currentPageIndex}` : "all"
@@ -1046,6 +1051,7 @@ const ChatHistory: React.FC<ChatHistoryProps> = ({
                   <>
                     <PlanningIndicatorBridge
                       planningIndicatorScope={planningIndicatorScope}
+                      planningIndicatorEnabled={planningIndicatorEnabled}
                       onPlanningIndicatorCount={handlePlanningIndicatorCount}
                       flatItems={displayFlatItems}
                       groupCounts={displayGroupCounts}


### PR DESCRIPTION
## Summary
 
Fixes #37
 
Prevents the live planning/loading footer from appearing on older paginated chat rounds while a session is still active.
 
## Root Cause
 
The planning indicator is derived from session-level live state. In turn pagination mode, that live state was still passed into the currently displayed page even when the user navigated to an older finished round.
 
Because `ChatHistoryList` renders the planning footer inside the currently displayed list, older historical pages could incorrectly show "Loading" / "Thinking" even though only the latest round was active.
 
## Fix
 
Gate the planning indicator at the `ChatHistory` boundary so it is only visible when:
 
- turn pagination is disabled, or
- the selected turn page is the latest page
 
Older paginated turn pages now receive a zero visible planning count, so live loading UI stays attached only to the active tail turn.
 
## Screenshots
 
### Latest active round
 
<img width="944" height="814" alt="Latest active chat round with planning footer" src="https://github.com/user-attachments/assets/f26161e9-1733-440a-a4fe-d86987b79313" />
 
### Older historical round
 
<img width="944" height="814" alt="Older historical chat round without planning footer" src="https://github.com/user-attachments/assets/b8bc21a0-d804-4aac-acba-bd3490b9e948" />
 
## Verification
 
- `pnpm run lint`
- `pnpm run check:circular`
- Husky pre-commit hook passed