### PR TITLE
fix: prevent browser webviews covering modals on Windows

### DIFF
--- a/src/modules/WorkStation/Browser/hooks/useGlobalBrowserWebviewLayering.ts
+++ b/src/modules/WorkStation/Browser/hooks/useGlobalBrowserWebviewLayering.ts
@@ -17,6 +17,7 @@ import { useEffect, useRef } from "react";
 
 import { createLogger } from "@src/hooks/logger";
 import { activeOverlayCountAtom } from "@src/store/ui/overlayLayerAtom";
+import { isMacOS } from "@src/util/platform/tauri";
 import { invokeTauri } from "@src/util/platform/tauri/init";
 
 const log = createLogger("useGlobalBrowserWebviewLayering");
@@ -26,6 +27,8 @@ export function useGlobalBrowserWebviewLayering(): void {
   const lastStateRef = useRef<"front" | "back" | null>(null);
 
   useEffect(() => {
+    if (!isMacOS()) return;
+
     const shouldBeBack = count > 0;
     const next = shouldBeBack ? "back" : "front";
     if (lastStateRef.current === next) return;

--- a/src/scaffold/ModalSystem/index.tsx
+++ b/src/scaffold/ModalSystem/index.tsx
@@ -23,6 +23,7 @@ import {
   PanelFooter,
   PanelHeader,
 } from "@src/modules/shared/layouts/blocks";
+import { useOverlayLayer } from "@src/store/ui/overlayLayerAtom";
 
 import "./index.scss";
 
@@ -119,6 +120,8 @@ const Modal: React.FC<ModalProps> = ({
   const modalRef = useRef<HTMLDivElement>(null);
   const previousActiveElement = useRef<HTMLElement | null>(null);
   const [okLoading, setOkLoading] = useState(false);
+
+  useOverlayLayer(visible);
 
   // Store the previously focused element
   useEffect(() => {

--- a/src/store/ui/__tests__/overlayAtom.test.ts
+++ b/src/store/ui/__tests__/overlayAtom.test.ts
@@ -1,0 +1,25 @@
+import { createStore } from "jotai/vanilla";
+import { vi } from "vitest";
+
+import { webviewOverlayBlockedAtom } from "../overlayAtom";
+import { activeOverlayCountAtom } from "../overlayLayerAtom";
+import { viewModeAtom } from "../viewModeAtom";
+
+vi.mock("@src/util/platform/tauri", () => ({
+  isMacOS: () => false,
+}));
+
+describe("webviewOverlayBlockedAtom", () => {
+  it("blocks native webviews for overlays when native layering is unavailable", () => {
+    const store = createStore();
+    store.set(viewModeAtom, "workStation");
+
+    expect(store.get(webviewOverlayBlockedAtom)).toBe(false);
+
+    store.set(activeOverlayCountAtom, 1);
+    expect(store.get(webviewOverlayBlockedAtom)).toBe(true);
+
+    store.set(activeOverlayCountAtom, 0);
+    expect(store.get(webviewOverlayBlockedAtom)).toBe(false);
+  });
+});

--- a/src/store/ui/overlayAtom.ts
+++ b/src/store/ui/overlayAtom.ts
@@ -1,5 +1,8 @@
 import { atom } from "jotai";
 
+import { isMacOS } from "@src/util/platform/tauri";
+
+import { activeOverlayCountAtom } from "./overlayLayerAtom";
 import { stationModeAtom } from "./simulatorAtom";
 import { spotlightOpenAtom } from "./uiAtom";
 import { viewModeAtom } from "./viewModeAtom";
@@ -71,6 +74,10 @@ locationSelectorOpenAtom.debugLabel = "locationSelectorOpenAtom";
  * Agent Station can host the same native browser without recreating it.
  */
 export const webviewOverlayBlockedAtom = atom((get) => {
+  // macOS can move native WKWebViews behind React overlays. Other platforms
+  // need a visibility fallback because inline webviews may paint above modals.
+  const hasNativeBlockingOverlay =
+    !isMacOS() && get(activeOverlayCountAtom) > 0;
   const hasGlobalError = get(hasGlobalErrorAtom);
   const isComponentIssueModalOpen = get(componentIssueModalOpenAtom);
   const isQuitConfirmationModalOpen = get(quitConfirmationModalOpenAtom);
@@ -81,6 +88,7 @@ export const webviewOverlayBlockedAtom = atom((get) => {
   const isNotInCodeView = viewMode !== "workStation";
 
   return (
+    hasNativeBlockingOverlay ||
     hasGlobalError ||
     isComponentIssueModalOpen ||
     isQuitConfirmationModalOpen ||


### PR DESCRIPTION
## Summary

Fixes #60.

This PR prevents inline/native browser WebViews from covering React modals on Windows. The reported issue happens when the browser WebView is visible in the agent console and the user opens the Export Session modal: the native WebView can paint above the React modal, so increasing CSS `z-index` is not reliable.

## What changed

- Register `ModalSystem` modals with the existing overlay layer counter via `useOverlayLayer(visible)`.
- Use `activeOverlayCountAtom` as a native WebView blocking signal on non-macOS platforms.
- Keep the existing macOS behavior: macOS continues to use native WebView z-order reordering instead of hiding the WebView.
- Avoid calling the macOS-only WebView layering command on Windows/Linux.
- Add a unit test covering the non-macOS overlay blocking behavior.

## Implementation details

The issue is caused by native WebView layering, not by normal DOM stacking. On Windows, the inline WebView can render above React portal content even when the modal has a high `z-index`.

The new flow is:

```text
Modal opens
-> ModalSystem calls useOverlayLayer(true)
-> activeOverlayCountAtom becomes > 0
-> webviewOverlayBlockedAtom becomes true on non-macOS platforms
-> SharedBrowserApp passes hidden=true to BrowserCore
-> inline native browser WebView is temporarily hidden/offscreen
-> React modal remains visible and interactive     