### PR TITLE
fix(settings): refresh team member counts after save

### DIFF
--- a/src/modules/MainApp/AgentOrgs/index.tsx
+++ b/src/modules/MainApp/AgentOrgs/index.tsx
@@ -43,6 +43,7 @@ import { builtInAgentsAtom } from "./store/builtInAgentsAtom";
 import type { AgentDefinition, AvailableCliAgent, OrgMember } from "./types";
 
 const logger = createLogger("AgentOrgs");
+const AGENT_ORGS_CHANGED_EVENT = "orgii-agent-orgs-changed";
 
 const TABLE_TABS: Array<{
   key: AgentOrgsTabSegment;
@@ -179,6 +180,19 @@ const AgentOrgsPage: React.FC = () => {
       });
     return () => {
       cancelled = true;
+    };
+  }, [loadOrgs]);
+
+  useEffect(() => {
+    const handleOrgsChanged = () => {
+      void loadOrgs()
+        .then(setOrgs)
+        .catch(() => setOrgs([]));
+    };
+
+    window.addEventListener(AGENT_ORGS_CHANGED_EVENT, handleOrgsChanged);
+    return () => {
+      window.removeEventListener(AGENT_ORGS_CHANGED_EVENT, handleOrgsChanged);
     };
   }, [loadOrgs]);
 

--- a/src/modules/WorkStation/TabContent/renderers/agentConfig.tsx
+++ b/src/modules/WorkStation/TabContent/renderers/agentConfig.tsx
@@ -51,6 +51,7 @@ import { confirmDestructiveAction } from "@src/util/dialogs/confirmDestructiveAc
 import type { UnifiedTabContentProps } from "../types";
 
 const logger = createLogger("AgentConfigTab");
+const AGENT_ORGS_CHANGED_EVENT = "orgii-agent-orgs-changed";
 
 interface AgentConfigInnerProps {
   data: AgentConfigTabData;
@@ -182,6 +183,7 @@ const AgentConfigInner: React.FC<AgentConfigInnerProps> = ({ data }) => {
         }
         const refreshed = await loadOrgs();
         setOrgs(refreshed);
+        window.dispatchEvent(new Event(AGENT_ORGS_CHANGED_EVENT));
         Message.success(
           t(isUpdate ? "agentOrgs.orgUpdated" : "agentOrgs.orgCreated", {
             defaultValue: isUpdate ? "Team updated" : "Team created",
@@ -218,6 +220,7 @@ const AgentConfigInner: React.FC<AgentConfigInnerProps> = ({ data }) => {
         await rpc.agentOrgs.orgs.remove({ orgId });
         const refreshed = await loadOrgs();
         setOrgs(refreshed);
+        window.dispatchEvent(new Event(AGENT_ORGS_CHANGED_EVENT));
         Message.success(
           t("agentOrgs.orgDeleted", { defaultValue: "Team deleted" })
         );

--- a/tests/e2e/specs/core/agent-settings/org-detail-ui.spec.mjs
+++ b/tests/e2e/specs/core/agent-settings/org-detail-ui.spec.mjs
@@ -191,6 +191,8 @@ describe("Agent Org detail Settings UI", () => {
     const cancelledName = `E2E Cancelled Detail Org ${RUN_MARKER}`;
     const savedName = `E2E Saved Detail Org ${RUN_MARKER}`;
     const savedDescription = `Saved org detail description ${RUN_MARKER}`;
+    const addedMemberName = `E2E Detail Added ${RUN_MARKER}`;
+    const addedMemberRole = "Reviewer";
 
     try {
       await removeAgentOrgsByName(originalName);
@@ -242,6 +244,41 @@ describe("Agent Org detail Settings UI", () => {
         `${orgTabSelector} [data-testid="agent-orgs-org-detail"] [data-testid="agent-orgs-org-description-input"]`,
         savedDescription,
         "org detail saved description"
+      );
+      await pointerClick(
+        `${orgTabSelector} [data-testid="agent-orgs-member-add-member-button"]`,
+        "org detail add member button"
+      );
+      await waitForScript(
+        `return Array.from(document.querySelectorAll(arguments[0] + ' [data-testid^="agent-orgs-member-"][data-testid$="-name-input"]')).some((input) => input.value === '');`,
+        "new org detail member name input did not render",
+        30_000,
+        [orgTabSelector]
+      );
+      const addedMemberNameInputTestId = await browser.executeScript(
+        `
+          const inputs = Array.from(document.querySelectorAll(arguments[0] + ' [data-testid^="agent-orgs-member-"][data-testid$="-name-input"]'));
+          const nameInput = inputs.find((input) => input.value === '');
+          return nameInput?.getAttribute('data-testid') ?? null;
+        `,
+        [orgTabSelector]
+      );
+      if (!addedMemberNameInputTestId) {
+        throw new Error("new org detail member name input test id was not found");
+      }
+      const addedMemberRoleInputTestId = addedMemberNameInputTestId.replace(
+        "-name-input",
+        "-role-input"
+      );
+      await setTextInput(
+        `${orgTabSelector} [data-testid="${addedMemberNameInputTestId}"]`,
+        addedMemberName,
+        "org detail added member name"
+      );
+      await setTextInput(
+        `${orgTabSelector} [data-testid="${addedMemberRoleInputTestId}"]`,
+        addedMemberRole,
+        "org detail added member role"
       );
       let savedEditState = null;
       try {
@@ -296,11 +333,30 @@ describe("Agent Org detail Settings UI", () => {
       }
       const savedLead = (savedOrg.children ?? []).find((member) => member.name === leadName);
       const savedChild = savedLead?.children?.find((member) => member.name === childName);
-      if (!savedLead || !savedChild || savedOrg.hierarchyMode !== "strict") {
+      const savedAddedMember = (savedOrg.children ?? []).find(
+        (member) => member.name === addedMemberName
+      );
+      if (
+        !savedLead ||
+        !savedChild ||
+        !savedAddedMember ||
+        savedAddedMember.role !== addedMemberRole ||
+        savedOrg.hierarchyMode !== "strict"
+      ) {
         throw new Error(
           `Saved org detail clobbered topology: ${JSON.stringify(savedOrg)}`
         );
       }
+      unwrap(await invokeE2E("navigateTo", ORGS_ROUTE), "navigate to orgs after org detail save");
+      await waitForScript(
+        `
+          const row = document.querySelector('[data-testid="agent-orgs-org-row-' + arguments[0] + '"]');
+          return !!row && /\\b4\\b/.test(row.textContent || '');
+        `,
+        "org table member count did not refresh after detail save",
+        30_000,
+        [org.id]
+      );
     } finally {
       await removeAgentOrgsByName(originalName);
       await removeAgentOrgsByName(cancelledName);


### PR DESCRIPTION
## Summary
 
Fixes #84
 
Refresh the Agent Teams table member count immediately after saving team membership changes from the detail view.
 
## Root Cause
 
Agent Team detail edits saved correctly, but the save happened inside a WorkStation `agent-config` tab with its own local org state.
 
The Settings → Agent Teams table kept a separate `orgs` state and did not know that the team changed, so it continued rendering the previous member count until the settings view was reloaded or remounted.
 
## Fix
 
After a team is saved or deleted from the WorkStation detail tab, emit a local `orgii-agent-orgs-changed` event.
 
The Agent Teams Settings page listens for that event and reloads its table data, so the displayed member count updates immediately after a successful save.
 
The org detail E2E coverage now adds a member during save and verifies the table count refreshes.
 
## Manual Verification
 
Manually tested the fixed app on branch `fix/issue-84-refresh-team-member-count`.
 
Verified that after adding a member to an Agent Team from the detail view and saving, the Members count in Settings → Agent Teams updates immediately without refreshing or remounting the page.
 
## Verification
 
- `pnpm run lint`
- `pnpm run check:circular`
- `node --check tests/e2e/specs/core/agent-settings/org-detail-ui.spec.mjs`
- Husky pre-commit hook passed