### PR TITLE
fix: compact away presence pill label

### DIFF
--- a/src/i18n/locales/de/navigation.json
+++ b/src/i18n/locales/de/navigation.json
@@ -178,7 +178,6 @@
       "iAmOnline": "Ich bin online",
       "iAmInvisible": "Ich bin unsichtbar",
       "iAmAway": "Ich bin abwesend",
-      "backInShort": "zurück in {{value}}",
       "awayDurationHeading": "Ich bin zurück in…",
       "duration15m": "15 Minuten",
       "duration30m": "30 Minuten",

--- a/src/i18n/locales/en/navigation.json
+++ b/src/i18n/locales/en/navigation.json
@@ -206,7 +206,6 @@
       "iAmOnline": "I am Online",
       "iAmInvisible": "I am Invisible",
       "iAmAway": "I am Away",
-      "backInShort": "back in {{value}}",
       "awayDurationHeading": "I'll be back in…",
       "duration15m": "15 minutes",
       "duration30m": "30 minutes",

--- a/src/i18n/locales/es/navigation.json
+++ b/src/i18n/locales/es/navigation.json
@@ -178,7 +178,6 @@
       "iAmOnline": "Estoy en línea",
       "iAmInvisible": "Estoy invisible",
       "iAmAway": "Estoy ausente",
-      "backInShort": "vuelvo en {{value}}",
       "awayDurationHeading": "Volveré en…",
       "duration15m": "15 minutos",
       "duration30m": "30 minutos",

--- a/src/i18n/locales/fr/navigation.json
+++ b/src/i18n/locales/fr/navigation.json
@@ -178,7 +178,6 @@
       "iAmOnline": "Je suis en ligne",
       "iAmInvisible": "Je suis invisible",
       "iAmAway": "Je suis absent",
-      "backInShort": "retour dans {{value}}",
       "awayDurationHeading": "Je reviens dans…",
       "duration15m": "15 minutes",
       "duration30m": "30 minutes",

--- a/src/i18n/locales/ja/navigation.json
+++ b/src/i18n/locales/ja/navigation.json
@@ -176,7 +176,6 @@
       "iAmOnline": "オンライン中",
       "iAmInvisible": "オフライン表示中",
       "iAmAway": "離席中です",
-      "backInShort": "{{value}} 後に戻る",
       "awayDurationHeading": "戻るまでの時間…",
       "duration15m": "15 分",
       "duration30m": "30 分",

--- a/src/i18n/locales/ko/navigation.json
+++ b/src/i18n/locales/ko/navigation.json
@@ -176,7 +176,6 @@
       "iAmOnline": "온라인 상태",
       "iAmInvisible": "숨김 상태",
       "iAmAway": "자리비움 상태",
-      "backInShort": "{{value}} 후 돌아옴",
       "awayDurationHeading": "돌아오기까지…",
       "duration15m": "15 분",
       "duration30m": "30 분",

--- a/src/i18n/locales/pl/navigation.json
+++ b/src/i18n/locales/pl/navigation.json
@@ -176,7 +176,6 @@
       "iAmOnline": "Jestem online",
       "iAmInvisible": "Jestem niewidoczny",
       "iAmAway": "Jestem z dala",
-      "backInShort": "wracam za {{value}}",
       "awayDurationHeading": "Wracam za…",
       "duration15m": "15 minut",
       "duration30m": "30 minut",

--- a/src/i18n/locales/pt/navigation.json
+++ b/src/i18n/locales/pt/navigation.json
@@ -178,7 +178,6 @@
       "iAmOnline": "Estou online",
       "iAmInvisible": "Estou invisível",
       "iAmAway": "Estou ausente",
-      "backInShort": "volto em {{value}}",
       "awayDurationHeading": "Volto em…",
       "duration15m": "15 minutos",
       "duration30m": "30 minutos",

--- a/src/i18n/locales/ru/navigation.json
+++ b/src/i18n/locales/ru/navigation.json
@@ -176,7 +176,6 @@
       "iAmOnline": "Я в сети",
       "iAmInvisible": "Я невидим",
       "iAmAway": "Я отошёл",
-      "backInShort": "вернусь через {{value}}",
       "awayDurationHeading": "Вернусь через…",
       "duration15m": "15 минут",
       "duration30m": "30 минут",

--- a/src/i18n/locales/tr/navigation.json
+++ b/src/i18n/locales/tr/navigation.json
@@ -176,7 +176,6 @@
       "iAmOnline": "Çevrimiçiyim",
       "iAmInvisible": "Görünmezim",
       "iAmAway": "Uzaktayım",
-      "backInShort": "{{value}} sonra dönerim",
       "awayDurationHeading": "Şu süre sonra dönerim…",
       "duration15m": "15 dakika",
       "duration30m": "30 dakika",

--- a/src/i18n/locales/vi/navigation.json
+++ b/src/i18n/locales/vi/navigation.json
@@ -176,7 +176,6 @@
       "iAmOnline": "Tôi đang trực tuyến",
       "iAmInvisible": "Tôi đang ẩn",
       "iAmAway": "Tôi đang đi vắng",
-      "backInShort": "trở lại sau {{value}}",
       "awayDurationHeading": "Sẽ quay lại sau…",
       "duration15m": "15 phút",
       "duration30m": "30 phút",

--- a/src/i18n/locales/zh-Hant/navigation.json
+++ b/src/i18n/locales/zh-Hant/navigation.json
@@ -176,7 +176,6 @@
       "iAmOnline": "我在線",
       "iAmInvisible": "我隱身",
       "iAmAway": "我離開",
-      "backInShort": "{{value}} 後回來",
       "awayDurationHeading": "我將在以下時間後回來…",
       "duration15m": "15 分鐘",
       "duration30m": "30 分鐘",

--- a/src/i18n/locales/zh/navigation.json
+++ b/src/i18n/locales/zh/navigation.json
@@ -176,7 +176,6 @@
       "iAmOnline": "我在线",
       "iAmInvisible": "我隐身",
       "iAmAway": "我离开",
-      "backInShort": "{{value}} 后回来",
       "awayDurationHeading": "我将在以下时间后回来…",
       "duration15m": "15 分钟",
       "duration30m": "30 分钟",

--- a/src/scaffold/NavigationSidebar/blocks/SidebarBottomBar.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarBottomBar.tsx
@@ -232,11 +232,8 @@ export const PresenceMenuButton: React.FC<PresenceMenuButtonProps> = ({
 
   const backLabel = useMemo(() => {
     if (mode !== USER_PRESENCE_MODE.AWAY || !presence.backAtMs) return null;
-    const formatted = formatBackAt(presence.backAtMs);
-    return formatted
-      ? t("sidebar.presence.backInShort", { value: formatted })
-      : null;
-  }, [mode, presence.backAtMs, t]);
+    return formatBackAt(presence.backAtMs) || null;
+  }, [mode, presence.backAtMs]);
   const pillLabel = backLabel ? `${modeLabel} · ${backLabel}` : modeLabel;
 
   // Single-segment PillGroup so the trigger matches the visual size and


### PR DESCRIPTION
## Summary

- Simplified the presence pill. For text like "away for 30m" changed to "30m" so that it would not cover other buttons.  
<img width="241" height="85" alt="截屏2026-06-23 14 03 10" src="https://github.com/user-attachments/assets/8d1e7ae1-0646-48cc-9547-816eb5bba831" />


## Test plan

- [X] I ran the checks relevant to the changed files, or explained why they were not run.

## Contributor checklist

- [X] The PR title uses scoped Conventional Commits format, such as `feat(scope): summary` or `fix(scope): summary`.
- [X] All commits use scoped Conventional Commits format.
- [X] I did not skip pre-commit, pre-push, lint-staged, or other repository hooks.
- [X] The PR is scoped to one issue, feature, or fix.
- [X] I have signed the CLA if prompted by the CLA Assistant bot.
- [X] A human actively participated in the design and implementation process, and reviewed the contribution before submission.
- [X] I did not include secrets, private configuration, generated build output, or unrelated formatting changes.
- [X] I updated documentation for behavior, setup, or architecture changes where needed.
- [X] I updated all supported locale files for new UI text where needed.
