### PR TITLE
Prepare external history fork composer

### DIFF
--- a/src/engines/ChatPanel/ChatHistory/AgentTurnContext.tsx
+++ b/src/engines/ChatPanel/ChatHistory/AgentTurnContext.tsx
@@ -46,7 +46,7 @@ export interface AgentTurnContextValue {
   isLastItemInGroup: boolean;
   /** Regenerate the current turn by re-sending its originating user
    *  message through the truncate-and-resend pipeline. */
-  onRegenerate: () => void;
+  onRegenerate?: () => void;
   /** Optional sender label for group-chat merged streams. */
   groupSenderName?: string | null;
 }

--- a/src/engines/ChatPanel/ChatHistory/components/ChatHistoryList.tsx
+++ b/src/engines/ChatPanel/ChatHistory/components/ChatHistoryList.tsx
@@ -316,10 +316,10 @@ interface ChatHistoryListProps {
   onAtBottomStateChange: (atBottom: boolean) => void;
   onRangeChanged: (range: { startIndex: number; endIndex: number }) => void;
   onEndReached: () => void;
-  onRegenerate: (groupIndex: number) => void;
+  onRegenerate?: (groupIndex: number) => void;
   onSubmit: (eventId: string, answers: Record<string, string>) => void;
   onSkip: (eventId: string) => void;
-  onEditUserMessage: (
+  onEditUserMessage?: (
     header: OptimizedChatItem,
     text: string,
     images?: string[]

--- a/src/engines/ChatPanel/ChatHistory/index.tsx
+++ b/src/engines/ChatPanel/ChatHistory/index.tsx
@@ -246,9 +246,11 @@ interface ChatHistoryProps {
   groupChatViewActive?: boolean;
   /** Toggle handler for the group chat view entry. */
   onGroupChatViewToggle?: (active: boolean) => void;
+  mutationActionsDisabled?: boolean;
   /**
    * Drive the "Planning next step…" footer from a specific session's
    * snapshot channel instead of the global active-session atoms. REQUIRED
+
    * for session-scoped instances (subagent monitor cells): without it the
    * footer reads the parent session's state and is structurally dead or
    * wrong. `isLive` should be false while the surface shows a replay
@@ -281,6 +283,7 @@ const ChatHistory: React.FC<ChatHistoryProps> = ({
   groupChatViewAvailable = false,
   groupChatViewActive = false,
   onGroupChatViewToggle,
+  mutationActionsDisabled = false,
   planningIndicatorScope = null,
 }) => {
   const { t } = useTranslation();
@@ -827,7 +830,6 @@ const ChatHistory: React.FC<ChatHistoryProps> = ({
       | undefined;
     void currentHandleEditUserMessage(header, originalText, images);
   }, []);
-
   const memoizedSubmit = useCallback(
     (eventId: string, answers: Record<string, string>) => {
       const reply = Object.values(answers).join("\n");
@@ -878,9 +880,12 @@ const ChatHistory: React.FC<ChatHistoryProps> = ({
     collapseTailWhenIdle,
     hideUserMessage: hideGroupUserMessage,
     turnCollapseInteractionAtRef,
-    onEditSubmit: handleEditUserMessage,
-    onRestoreCheckpoint: handleHeaderRestoreCheckpoint,
+    onEditSubmit: mutationActionsDisabled ? undefined : handleEditUserMessage,
+    onRestoreCheckpoint: mutationActionsDisabled
+      ? undefined
+      : handleHeaderRestoreCheckpoint,
   });
+
   const showPinnedTurnHeader =
     turnPaginationEnabled && !turnPageListOpen && !agentOrgOverviewOpen;
   const showTurnContextRow =
@@ -926,8 +931,12 @@ const ChatHistory: React.FC<ChatHistoryProps> = ({
       collapseTailWhenIdle={collapseTailWhenIdle}
       hideUserMessage={hideGroupUserMessage}
       turnCollapseInteractionAtRef={turnCollapseInteractionAtRef}
-      onEditSubmit={handlePinnedEditSubmit}
-      onRestoreCheckpoint={handleHeaderRestoreCheckpoint}
+      onEditSubmit={
+        mutationActionsDisabled ? undefined : handlePinnedEditSubmit
+      }
+      onRestoreCheckpoint={
+        mutationActionsDisabled ? undefined : handleHeaderRestoreCheckpoint
+      }
     />
   );
 
@@ -1073,10 +1082,18 @@ const ChatHistory: React.FC<ChatHistoryProps> = ({
                       onAtBottomStateChange={handleAtBottomStateChange}
                       onRangeChanged={handleRangeChanged}
                       onEndReached={handleTurnPageEndReached}
-                      onRegenerate={handleRegenerateGroup}
+                      onRegenerate={
+                        mutationActionsDisabled
+                          ? undefined
+                          : handleRegenerateGroup
+                      }
                       onSubmit={memoizedSubmit}
                       onSkip={stableHandleIgnoreQuestion}
-                      onEditUserMessage={handleEditUserMessage}
+                      onEditUserMessage={
+                        mutationActionsDisabled
+                          ? undefined
+                          : handleEditUserMessage
+                      }
                       virtualScrollerRef={virtuosoScrollerRef}
                       staticScrollerRef={staticScrollerRef}
                       newEventDividerLabel={newEventDividerLabel}

--- a/src/engines/ChatPanel/ChatHistory/renderers/GroupItemRenderer.tsx
+++ b/src/engines/ChatPanel/ChatHistory/renderers/GroupItemRenderer.tsx
@@ -292,10 +292,10 @@ export interface GroupItemRendererProps {
   isWpGeneWorking: boolean;
   isExploring: boolean;
   codeBlockContainerWidth?: number;
-  onRegenerate: (groupIndex: number) => void;
+  onRegenerate?: (groupIndex: number) => void;
   onSubmit: (eventId: string, answers: Record<string, string>) => void;
   onSkip: (eventId: string) => void;
-  onEditUserMessage: (
+  onEditUserMessage?: (
     item: OptimizedChatItem,
     newText: string,
     imageDataUrls?: string[]
@@ -417,9 +417,11 @@ export const GroupItemRenderer: React.FC<GroupItemRendererProps> = memo(
         lastAssistantFlatIndex,
         isLastGroup,
         isLastItemInGroup,
-        onRegenerate: isWpGeneWorking
-          ? () => Message.info("Workspace is working!")
-          : () => onRegenerate(groupIndex),
+        onRegenerate: onRegenerate
+          ? isWpGeneWorking
+            ? () => Message.info("Workspace is working!")
+            : () => onRegenerate(groupIndex)
+          : undefined,
         groupSenderName:
           groupChat?.enabled && event && !usesGroupChatMessageBubble
             ? groupChat.resolveSenderName(event)

--- a/src/engines/ChatPanel/ChatSessionContext.ts
+++ b/src/engines/ChatPanel/ChatSessionContext.ts
@@ -1,5 +1,7 @@
 import { createContext, useContext } from "react";
 
+export const CHAT_SESSION_CONTEXT_NONE = "__orgii_chat_session_none__";
+
 /**
  * Provides the active session ID to descendant chat blocks.
  * Used by useEventBlockHeader to scope "collapse all" per session.

--- a/src/engines/ChatPanel/ChatView.tsx
+++ b/src/engines/ChatPanel/ChatView.tsx
@@ -36,6 +36,7 @@ import {
   type CoreSessionSummary,
   getOrgtrackSessionSummary,
 } from "@src/api/tauri/lineage";
+import { DETAIL_PANEL_TOKENS } from "@src/config/detailPanelTokens";
 import { useShowInteractArea } from "@src/contexts/workspace/ChatContext";
 import { AgentMessageClampProvider } from "@src/engines/ChatPanel/blocks";
 import { GroupChatPausedBanner } from "@src/engines/ChatPanel/components/ChatStatusBanners";
@@ -76,6 +77,8 @@ import {
 } from "@src/store/ui/simulatorAtom";
 import { getFileName } from "@src/util/file/pathUtils";
 import {
+  isClaudeCodeHistorySession,
+  isCodexAppSession,
   isCursorIdeSession,
   isExternalHistorySession,
 } from "@src/util/session/sessionDispatch";
@@ -85,7 +88,11 @@ import ChatHistory, { type ScrollNavState } from "./ChatHistory";
 import { GroupChatProvider } from "./ChatHistory/GroupChatView/GroupChatContext";
 import { AgentEventsTap } from "./ChatHistory/GroupChatView/useGroupChatMergedEvents";
 import { ChatHistoryOverrideContext } from "./ChatHistoryOverrideContext";
-import { ChatSessionContext } from "./ChatSessionContext";
+import {
+  CHAT_SESSION_CONTEXT_NONE,
+  ChatSessionContext,
+} from "./ChatSessionContext";
+import InputArea from "./InputArea";
 import AgentOrgOverviewPanel from "./InputArea/components/AgentOrgOverviewPanel";
 import type { FileChangesResult } from "./InputArea/components/CompactFileChanges";
 import GitDiffActionsMenu from "./InputArea/components/GitDiffActionsMenu";
@@ -306,6 +313,14 @@ const ChatView: React.FC<ChatViewProps> = memo(
     // dispatch).
 
     const showInteractArea = useShowInteractArea();
+    const showExternalHistoryForkComposer =
+      isCodexAppSession(sessionId) || isClaudeCodeHistorySession(sessionId);
+    const historyBottomInset =
+      showInteractArea && !isReadOnlySurface
+        ? CHAT_FLOATING_COMPOSER_FALLBACK_INSET_PX
+        : showExternalHistoryForkComposer
+          ? CHAT_FLOATING_COMPOSER_FALLBACK_INSET_PX
+          : 0;
     const {
       showFollowAgent,
       followAgentLabel,
@@ -692,6 +707,7 @@ const ChatView: React.FC<ChatViewProps> = memo(
                       currentAgentOrgMember?.memberId ?? null
                     }
                     agentOrgMembers={agentOrgRunView?.members ?? []}
+                    mutationActionsDisabled={isReadOnlySurface}
                     agentOrgOverviewPanel={
                       agentOrgRunView || agentOrgRunViewError ? (
                         <AgentOrgOverviewPanel
@@ -710,11 +726,7 @@ const ChatView: React.FC<ChatViewProps> = memo(
                     displayMode={displayMode}
                     turnPaginationEnabled={turnPaginationEnabled}
                     pinnedHeaderPortalHost={pinnedHeaderHost}
-                    bottomInset={
-                      showInteractArea && !isReadOnlySurface
-                        ? CHAT_FLOATING_COMPOSER_FALLBACK_INSET_PX
-                        : 0
-                    }
+                    bottomInset={historyBottomInset}
                     groupChatViewAvailable={groupChatViewAvailable}
                     groupChatViewActive={groupChatViewActive}
                     onGroupChatViewToggle={handleGroupChatViewToggle}
@@ -723,6 +735,25 @@ const ChatView: React.FC<ChatViewProps> = memo(
               </GroupChatProvider>
             </ChatHistoryOverrideContext.Provider>
           </div>
+          {showExternalHistoryForkComposer && (
+            <div className="absolute bottom-0 left-0 right-0 z-50 flex w-full flex-shrink-0 flex-col items-center px-2 pb-2 pt-1">
+              <div className="pointer-events-none absolute inset-x-0 bottom-0 top-[-28px] bg-gradient-to-t from-chat-pane via-chat-pane/90 to-transparent" />
+              <div
+                className={`${DETAIL_PANEL_TOKENS.contentMaxWidth} relative z-10 w-full`}
+              >
+                <ChatSessionContext.Provider value={CHAT_SESSION_CONTEXT_NONE}>
+                  <InputArea
+                    omitChatHeader
+                    chatPanelPosition={position}
+                    sessionScope="none"
+                    onSubmitOverride={() => Promise.resolve(true)}
+                    submitDisabled
+                    bottomAnchored
+                  />
+                </ChatSessionContext.Provider>
+              </div>
+            </div>
+          )}
           {showInteractArea && !isReadOnlySurface && (
             <ChatFloatingComposer
               composerRef={floatingComposerRef}

--- a/src/engines/ChatPanel/InputArea/components/InputActions.tsx
+++ b/src/engines/ChatPanel/InputArea/components/InputActions.tsx
@@ -47,6 +47,7 @@ interface InputActionsProps {
   onInterrupt: () => Promise<void>;
   onResume: () => Promise<void>;
   tone?: "primary" | "warning";
+  submitDisabled?: boolean;
 }
 
 const InputActions: React.FC<InputActionsProps> = memo(
@@ -62,6 +63,7 @@ const InputActions: React.FC<InputActionsProps> = memo(
     onInterrupt,
     onResume,
     tone = "primary",
+    submitDisabled = false,
   }) => {
     const { t } = useTranslation();
     const suppressSubmitClickUntilRef = useRef(0);
@@ -81,6 +83,9 @@ const InputActions: React.FC<InputActionsProps> = memo(
 
     const handleClick = async () => {
       if (showSubmit) {
+        if (submitDisabled) {
+          return;
+        }
         if (Date.now() < suppressSubmitClickUntilRef.current) {
           return;
         }
@@ -107,7 +112,7 @@ const InputActions: React.FC<InputActionsProps> = memo(
       }
     };
 
-    const isActive = showSubmit || showRetry;
+    const isActive = (showSubmit && !submitDisabled) || showRetry;
 
     // Hover variants use a brand-shade swap (paint-only) rather than
     // `opacity-80`. See INPUT_AREA_BUTTONS.iconButtonActive for the
@@ -124,7 +129,9 @@ const InputActions: React.FC<InputActionsProps> = memo(
         : INPUT_AREA_BUTTONS.iconButtonInactive;
 
     const stateClass = showSubmit
-      ? activeButtonClass
+      ? submitDisabled
+        ? inactiveButtonClass
+        : activeButtonClass
       : showStop
         ? canStopAgent
           ? "cursor-pointer border-none bg-text-2 text-white hover:bg-text-1"
@@ -144,7 +151,8 @@ const InputActions: React.FC<InputActionsProps> = memo(
         : undefined;
 
     // Button is only disabled for the "working and cannot stop" dead-end.
-    const disabled = showStop && !canStopAgent;
+    const disabled =
+      (showStop && !canStopAgent) || (showSubmit && submitDisabled);
 
     const sendState =
       showStop && !showSubmit

--- a/src/engines/ChatPanel/InputArea/components/InputComposerBars.tsx
+++ b/src/engines/ChatPanel/InputArea/components/InputComposerBars.tsx
@@ -276,6 +276,7 @@ interface NormalComposerContentProps extends SharedComposerBarProps {
   isSessionTerminal: boolean;
   voiceFeatureEnabled: boolean;
   dropTargetId: string;
+  submitDisabled?: boolean;
 }
 
 export const NormalComposerContent: React.FC<NormalComposerContentProps> = ({
@@ -329,6 +330,7 @@ export const NormalComposerContent: React.FC<NormalComposerContentProps> = ({
   isSessionTerminal,
   voiceFeatureEnabled,
   dropTargetId,
+  submitDisabled,
 }) => {
   const { t } = useTranslation("sessions");
 
@@ -428,6 +430,7 @@ export const NormalComposerContent: React.FC<NormalComposerContentProps> = ({
                 onSubmit={onSubmit}
                 onInterrupt={onInterrupt}
                 onResume={onResume}
+                submitDisabled={submitDisabled}
               />
             </div>
           }

--- a/src/engines/ChatPanel/InputArea/index.tsx
+++ b/src/engines/ChatPanel/InputArea/index.tsx
@@ -61,6 +61,8 @@ interface InputAreaProps {
   statusBanners?: React.ReactNode;
   composerShellRef?: React.Ref<HTMLDivElement>;
   disableStopWhenEmpty?: boolean;
+  submitDisabled?: boolean;
+  sessionScope?: "active" | "none";
   /**
    * Set by the bottom-anchored floating composer so its + / slash / @ menus
    * open upward even in queue-edit mode (there is no room beneath it).
@@ -93,6 +95,8 @@ const InputArea: React.FC<InputAreaProps> = memo(
     statusBanners,
     composerShellRef,
     disableStopWhenEmpty = false,
+    submitDisabled = false,
+    sessionScope = "active",
     bottomAnchored = false,
   }) => {
     const { t } = useTranslation("sessions");
@@ -168,6 +172,8 @@ const InputArea: React.FC<InputAreaProps> = memo(
     } = useInputArea({
       placeholder,
       sessionId: propSessionId,
+      sessionScope,
+      submitDisabled,
       onSubmitOverride,
       customMentionOptions: mergedCustomMentionOptions,
     });
@@ -469,6 +475,7 @@ const InputArea: React.FC<InputAreaProps> = memo(
                 isSessionTerminal={isSessionTerminal}
                 voiceFeatureEnabled={voiceFeatureEnabled}
                 dropTargetId={dropTargetId}
+                submitDisabled={submitDisabled}
               />
             )}
           </ComposerShell>

--- a/src/engines/ChatPanel/hooks/useInputArea/index.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/index.ts
@@ -100,6 +100,8 @@ export function useInputArea(
     customMentionOptions,
     onSubmitOverride,
     sessionId: propSessionId,
+    sessionScope = "active",
+    submitDisabled = false,
   } = options;
 
   // ============================================
@@ -128,21 +130,24 @@ export function useInputArea(
     isHosted,
     canStopAgent,
     canResume,
-  } = useWorkspaceChat({ sessionId: propSessionId });
+  } = useWorkspaceChat({ sessionId: propSessionId, sessionScope });
 
   // ============================================
   // Atoms (Global State)
   // ============================================
 
   const wpReadOnly = useAtomValue(wpReadOnlyAtom);
-  const isSessionActive = useAtomValue(isSessionActiveAtom);
-  const isPendingCancel = useAtomValue(isPendingCancelAtom);
+  const rawIsSessionActive = useAtomValue(isSessionActiveAtom);
+  const rawIsPendingCancel = useAtomValue(isPendingCancelAtom);
   const runtimeStatus = useAtomValue(sessionRuntimeStatusAtom);
+  const isSessionless = sessionScope === "none";
+  const isSessionActive = isSessionless ? false : rawIsSessionActive;
+  const isPendingCancel = isSessionless ? false : rawIsPendingCancel;
 
   const sessionEvents = useAtomValue(sortedEventsAtom);
   // Retry is only meaningful for `failed` runs. A user-initiated cancel should
   // never surface the orange retry button — the user stopped on purpose.
-  const isSessionTerminal = runtimeStatus === "failed";
+  const isSessionTerminal = !isSessionless && runtimeStatus === "failed";
 
   // ============================================
   // Sub-hooks
@@ -180,7 +185,10 @@ export function useInputArea(
   const { sessionId: resolvedActiveSessionId } = useSessionId({
     propSessionId,
   });
-  const activeSessionId = propSessionId ?? resolvedActiveSessionId;
+  const activeSessionId =
+    sessionScope === "none"
+      ? undefined
+      : (propSessionId ?? resolvedActiveSessionId);
   const draftSessionId = activeSessionId ?? "";
   const hasComposerStopBlockingWork = activeSessionId
     ? sessionHasComposerStopBlockingWork(
@@ -450,6 +458,7 @@ export function useInputArea(
     citeCode,
     handleSessChatSubmit,
     onSubmitOverride,
+    submitDisabled,
   });
 
   // ============================================

--- a/src/engines/ChatPanel/hooks/useInputArea/types.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/types.ts
@@ -39,6 +39,8 @@ export interface UseInputAreaOptions {
   placeholder?: string;
   /** Explicit session ID for the chat surface using this composer. */
   sessionId?: string;
+  sessionScope?: "active" | "none";
+  submitDisabled?: boolean;
   onSubmitOverride?: (input: SubmitOverrideInput) => Promise<boolean>;
   customMentionOptions?: ReadonlyArray<CustomMentionOption>;
 }

--- a/src/engines/ChatPanel/hooks/useInputArea/useSubmitMessage.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/useSubmitMessage.ts
@@ -90,6 +90,7 @@ export interface UseSubmitMessageOptions {
     imageDataUrls?: string[]
   ) => Promise<void>;
   onSubmitOverride?: (input: SubmitOverrideInput) => Promise<boolean>;
+  submitDisabled?: boolean;
 }
 
 // ============================================================================
@@ -106,6 +107,7 @@ export function useSubmitMessage({
   citeCode,
   handleSessChatSubmit,
   onSubmitOverride,
+  submitDisabled = false,
 }: UseSubmitMessageOptions): (options?: SubmitMessageOptions) => Promise<void> {
   const { t } = useTranslation("sessions");
   const store = useStore();
@@ -114,6 +116,8 @@ export function useSubmitMessage({
 
   return useCallback(
     async (options: SubmitMessageOptions = {}) => {
+      if (submitDisabled) return;
+
       if (wpReadOnly) {
         Message.warning(t("chat.noActiveSession"));
         return;
@@ -428,6 +432,7 @@ export function useSubmitMessage({
       replyTargetEventId,
       clearReplyTarget,
       onSubmitOverride,
+      submitDisabled,
     ]
   );
 }

--- a/src/engines/ChatPanel/hooks/useWorkspaceChat/useWorkspaceChat.ts
+++ b/src/engines/ChatPanel/hooks/useWorkspaceChat/useWorkspaceChat.ts
@@ -114,23 +114,27 @@ function stableSubmitHash(value: string): string {
 
 interface UseWorkspaceChatOptions {
   sessionId?: string;
+  sessionScope?: "active" | "none";
 }
 
 const useWorkspaceChat = (options: UseWorkspaceChatOptions = {}) => {
-  const { sessionId: propSessionId } = options;
+  const { sessionId: propSessionId, sessionScope = "active" } = options;
   const { t } = useTranslation("sessions");
   const [searchParams] = useSearchParams();
   const store = useStore();
 
-  const isHosted = useMemo(
+  const rawIsHosted = useMemo(
     () => isHostedFromSearchParams(searchParams),
     [searchParams]
   );
+  const isSessionless = sessionScope === "none";
+  const isHosted = isSessionless ? false : rawIsHosted;
 
   // ============================================
   // Atoms
   // ============================================
-  const isWpGeneWorking = useAtomValue(isSessionActiveAtom);
+  const rawIsWpGeneWorking = useAtomValue(isSessionActiveAtom);
+  const isWpGeneWorking = isSessionless ? false : rawIsWpGeneWorking;
   const setUserInitiatedCancel = useSetAtom(userInitiatedCancelAtom);
   const setLastUserMessage = useSetAtom(lastUserMessageAtom);
   // SessionCore engine-level session ID — always tracks the currently
@@ -182,6 +186,7 @@ const useWorkspaceChat = (options: UseWorkspaceChatOptions = {}) => {
   // Session ID Helper
   // ============================================
   const getSessionId = useCallback((): string | null => {
+    if (sessionScope === "none") return null;
     return (
       propSessionId ||
       coreSessionId ||
@@ -192,6 +197,7 @@ const useWorkspaceChat = (options: UseWorkspaceChatOptions = {}) => {
     );
   }, [
     propSessionId,
+    sessionScope,
     coreSessionId,
     resolvedSessionId,
     activeSessionId,
@@ -481,7 +487,9 @@ const useWorkspaceChat = (options: UseWorkspaceChatOptions = {}) => {
   // ============================================
   // Derived State
   // ============================================
-  const effectiveSessionId = resolvedSessionId || coreSessionId;
+  const effectiveSessionId = isSessionless
+    ? null
+    : resolvedSessionId || coreSessionId;
 
   const canStopAgent = useMemo(
     () =>

--- a/src/engines/SessionCore/hooks/session/useSessionId.ts
+++ b/src/engines/SessionCore/hooks/session/useSessionId.ts
@@ -18,7 +18,10 @@
 import { useAtomValue } from "jotai";
 import { useMemo } from "react";
 
-import { useChatSessionId } from "@src/engines/ChatPanel/ChatSessionContext";
+import {
+  CHAT_SESSION_CONTEXT_NONE,
+  useChatSessionId,
+} from "@src/engines/ChatPanel/ChatSessionContext";
 import { activeSessionIdAtom } from "@src/store/session";
 
 export interface UseSessionIdOptions {
@@ -44,6 +47,10 @@ export function useSessionId(
   return useMemo(() => {
     if (propSessionId) {
       return { sessionId: propSessionId, source: "prop" as const };
+    }
+
+    if (chatContextSessionId === CHAT_SESSION_CONTEXT_NONE) {
+      return { sessionId: undefined, source: "none" as const };
     }
 
     if (chatContextSessionId) {


### PR DESCRIPTION
## Summary

This PR prepares the frontend for forking/imported external history sessions by adding a real ORGII composer shell to Codex App / Claude Code imported history views, while keeping those views read-only until the backend fork/session-initialization flow is ready.

The new composer intentionally reuses the existing `InputArea` implementation instead of introducing a fake UI. It supports the real composer layout, model pill, model selector, voice input, and text editing behavior, but it runs in a sessionless/no-submit mode for now.

## What changed

### External imported history gets a real bottom composer shell

For Codex App and Claude Code history sessions, `ChatView` now renders a bottom-anchored `InputArea`.

Current behavior:

- Uses the real ORGII composer UI.
- Keeps the real model pill / model selector path.
- Keeps the real voice input path.
- Allows typing into the composer.
- Reserves bottom inset space so the history list is not covered.
- Does not submit yet.
- Does not initialize or bind to a session yet.

This is intended as the frontend-ready state for the later backend fork/session initialization flow.

### Added explicit sessionless composer mode

`InputArea`, `useInputArea`, and `useWorkspaceChat` now support:

```ts
sessionScope?: "active" | "none";
```

When `sessionScope="none"`:

- The composer does not resolve/fallback to the active session.
- It does not bind drafts to the imported history session.
- It does not read the current active session as its target.
- It suppresses active-session runtime state such as working / pending cancel / failed.
- It does not expose stop/resume behavior from the current active session.

This lets the imported-history composer exist as a real UI shell without accidentally operating on the currently active ORGII session.

### Added submit-disabled plumbing

`InputArea`, `useInputArea`, `InputActions`, and `useSubmitMessage` now support:

```ts
submitDisabled?: boolean;
```

This disables submission at both layers:

- UI layer: submit button appears inactive/disabled and click is ignored.
- submit source layer: `useSubmitMessage` returns early, so Enter / keyboard submit paths do not send or clear input.

This prevents the temporary frontend shell from swallowing user input before backend fork support exists.

### Added explicit no-session chat context

`ChatSessionContext` now exports `CHAT_SESSION_CONTEXT_NONE`. `useSessionId` recognizes this value and returns no session instead of falling back to the global active session.

This is used around the imported-history composer to make the no-session intent explicit for child components.

### Read-only imported history no longer receives mutation callbacks

`ChatHistory` now accepts `mutationActionsDisabled?: boolean`.

For read-only external history surfaces, mutation callbacks are omitted:

- regenerate / resend historical turn
- edit user message and resubmit
- restore checkpoint

Downstream types were updated so these callbacks can be optional.

This prevents imported Codex/Claude history from modifying or replaying the original history session.

## How it works

The imported-history view now has two separate concepts:

1. The displayed history remains read-only.
2. The bottom composer is a real ORGII composer, but sessionless.

`ChatView` detects Codex App / Claude Code imported-history sessions and renders:

```tsx
<ChatSessionContext.Provider value={CHAT_SESSION_CONTEXT_NONE}>
  <InputArea
    omitChatHeader
    chatPanelPosition={position}
    sessionScope="none"
    onSubmitOverride={() => Promise.resolve(true)}
    submitDisabled
    bottomAnchored
  />
</ChatSessionContext.Provider>
```

The important pieces are:

- `CHAT_SESSION_CONTEXT_NONE` prevents fallback to the active session.
- `sessionScope="none"` prevents `useInputArea` / `useWorkspaceChat` from binding runtime state or session IDs.
- `submitDisabled` prevents all current submit paths.
- `onSubmitOverride` is currently inert and exists only as a placeholder until backend support is added.

## Future backend integration notes

When backend support for external-history fork/session initialization is ready, the main integration point should be the bottom `InputArea` in `ChatView`.

Likely flow:

1. User types into the external-history composer.
2. User submits.
3. Frontend calls the backend to create/fork a new ORGII session from the imported external history.
4. The typed prompt becomes the first user message or initial continuation message in that new session.
5. The UI navigates/binds to the newly created session.

Things to watch when wiring this up:

- Remove or conditionally disable `submitDisabled` only after the real fork submit handler exists.
- Replace the inert `onSubmitOverride={() => Promise.resolve(true)}` with the real external-history fork submit handler.
- Preserve input if backend session initialization fails.
- Decide whether drafts typed into this sessionless composer should persist per imported-history session before fork creation.
- Decide whether model selection should continue writing to creator-default or become local to this external-history composer.
- Ensure the new session gets a real `sessionId` before normal active-session composer behavior is enabled.
- Keep original imported history read-only; fork/resend should operate on the newly created ORGII session, not mutate the imported history surface.

## Verification

- Rebasing onto latest `upstream/develop` succeeded.
- Targeted ESLint passed for all changed files.
  - Existing warning remains in `ChatHistoryList.tsx` around TanStack Virtual / React Compiler incompatible library.
- `pnpm exec tsc --noEmit --pretty false` still fails due to existing unrelated repository errors, including:
  - `session.test.ts` fixture `tags`
  - `FileTreeHoverPreview` ref type
  - `ChatPanelEmptyContent` benchmark builder props
  - `useSessionActions` existing strictness/lib issues
  - several WorkStation / replay / sidebar type errors

No TypeScript errors from this PR's changed files remain after rebase.
