### PR TITLE
fix(settings: models & keys):  model table overflow for long model names

### DIFF
--- a/src/components/Table/index.scss
+++ b/src/components/Table/index.scss
@@ -696,6 +696,7 @@
 // Fixed layout — forces columns to respect assigned widths
 // so fill columns truncate instead of expanding the table.
 .table-layout-fixed .table {
+  width: 100%;
   table-layout: fixed;
 }
 

--- a/src/modules/MainApp/Integrations/KeyVault/Models/Table/ModelsTableSection.tsx
+++ b/src/modules/MainApp/Integrations/KeyVault/Models/Table/ModelsTableSection.tsx
@@ -234,6 +234,7 @@ export default function ModelsTableSection({
                 <span className="inline-flex min-w-0 items-center gap-1.5">
                   <span
                     className={`${SETTINGS_TABLE_CELL.primary} truncate font-medium`}
+                    title={group.label}
                   >
                     {group.label}
                   </span>
@@ -265,7 +266,7 @@ export default function ModelsTableSection({
       {
         key: "status",
         label: <span className="sr-only">{t("common:labels.status")}</span>,
-        width: SETTINGS_TABLE_COL.hug,
+        width: INTEGRATIONS_MODELS_TABLE_COL_WIDTH.status,
         align: "right",
         sorter: (rowA, rowB) =>
           Number(groupSomeEnabled(rowB)) - Number(groupSomeEnabled(rowA)),
@@ -335,7 +336,7 @@ export default function ModelsTableSection({
       expandable={expandable}
       onRowClick={setSingleExpandedGroup}
       headerHeight="tall"
-      className="table-expanded-no-hover table-settings-expanded-compact"
+      className="table-expanded-no-hover table-settings-expanded-compact table-layout-fixed"
       searchBar={{
         searchValue: modelsSearchQuery,
         onSearchChange: setModelsSearchQuery,

--- a/src/modules/MainApp/Integrations/KeyVault/Models/Table/integrationsModelsTableWidths.ts
+++ b/src/modules/MainApp/Integrations/KeyVault/Models/Table/integrationsModelsTableWidths.ts
@@ -4,4 +4,5 @@
  */
 export const INTEGRATIONS_MODELS_TABLE_COL_WIDTH = {
   sources: "clamp(200px, 24vw, 320px)",
+  status: "88px",
 } as const;


### PR DESCRIPTION
## Summary
 
Fixes #83
 
This fixes the Integrations Models table layout when model names or model paths are too long.
 
The original issue was that long model names could expand the table instead of truncating inside the model column. While testing that behavior, we also found that the right-side status toggle could be pushed out of the visible area and require horizontal scrolling. This PR fixes both parts of the same layout problem: long model text now truncates properly, and the status toggle remains visible.
 
## Root Cause
 
The Models table did not use the fixed table layout behavior that other constrained tables rely on.
 
Because the table width and column widths were not fully constrained, long model labels could influence the table's overall width. The model column could grow too much, and the status/toggle column was using a very small "hug" width, which was not stable enough under fixed-width pressure.
 
As a result:
 
- Long model names could stretch the table instead of truncating cleanly.
- The status/toggle column could be pushed into the horizontal scroll area.
- Users could lose sight of the enable/disable toggle when model names were long.
 
## Fix
 
This PR makes the Integrations Models table use a more stable column layout:
 
- Enables the existing fixed table layout class on the Models table.
- Ensures fixed-layout tables fill their container width.
- Gives the status/toggle column a stable fixed width.
- Keeps the model column as the flexible fill column so long names truncate there.
- Adds a `title` attribute to truncated group labels so the full model group name remains available on hover.
 
The resulting layout is:
 
- Model column: flexible, truncates long text.
- Enabled Sources column: responsive bounded width.
- Status/toggle column: stable fixed width, stays visible on the right.
 
## Verification
 
- Ran `pnpm run lint`
  - Passed with 0 errors.
  - One existing warning remains in `ChatHistoryList.tsx` for `react-hooks/incompatible-library`.
 
- Ran `pnpm run check:circular`
  - Passed.
  - No circular dependency found.

- Manually verified the UI:
  - Long model names truncate instead of expanding the table.
  - The right-side status toggle remains visible.
  - The Models table no longer requires horizontal scrolling just to access the toggle.
  
- Screenshot:
<img width="984" height="308" alt="Screenshot 2026-06-23 at 2 00 00 PM" src="https://github.com/user-attachments/assets/0143a9ff-406a-49d9-880b-183d2efb6b58" />

  