### PR TITLE
fix(dev): stabilize Linux Tauri startup

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,8 +29,12 @@
         // Also hide before DOMContentLoaded in case it fires too late
         document.documentElement.dataset.noSplash = "1";
         var storedTheme = localStorage.getItem("theme") || "github-light";
-        var isDarkTheme = /dark|abyss|tomorrowNightBlue|orgii_dark/.test(storedTheme);
-        document.documentElement.dataset.preflightTheme = isDarkTheme ? "dark" : "light";
+        var isDarkTheme = /dark|abyss|tomorrowNightBlue|orgii_dark/.test(
+          storedTheme
+        );
+        document.documentElement.dataset.preflightTheme = isDarkTheme
+          ? "dark"
+          : "light";
       }
     </script>
     <script nonce="orgii-codemirror-style">
@@ -39,10 +43,12 @@
         var html = document.documentElement;
         var winVal, pageVal;
         if (ua.indexOf("windows") !== -1) {
-          winVal = "8px"; pageVal = "8px";
+          winVal = "8px";
+          pageVal = "8px";
           html.dataset.hostDesktop = "windows";
         } else if (ua.indexOf("linux") !== -1 && ua.indexOf("android") === -1) {
-          winVal = "12px"; pageVal = "12px";
+          winVal = "12px";
+          pageVal = "12px";
           html.dataset.hostDesktop = "linux";
         } else {
           html.dataset.hostDesktop = "macos";
@@ -68,31 +74,150 @@
       // the app is alive. Whichever happens first wins.
       // ---------------------------------------------------------------------
       (function () {
+        function isLocalDevOrigin() {
+          return (
+            window.location.protocol === "http:" &&
+            /^(localhost|127\.0\.0\.1)$/.test(window.location.hostname)
+          );
+        }
+
+        var isLocalDev = isLocalDevOrigin();
+        window.__ORGII_STARTUP_TIMING_START__ = performance.now();
+        if (isLocalDev) {
+          window.__ORGII_STARTUP_TIMINGS__ = [];
+        }
+
+        function markStartup(label, details) {
+          if (!isLocalDev) return;
+          var elapsedMs = Math.round(
+            performance.now() - window.__ORGII_STARTUP_TIMING_START__
+          );
+          var entry = { elapsedMs: elapsedMs, label: label, details: details };
+          window.__ORGII_STARTUP_TIMINGS__.push(entry);
+          console.info(
+            "[Startup +" + elapsedMs + "ms] " + label,
+            details || ""
+          );
+          var splashText = document.getElementById("splash-text");
+          if (splashText) {
+            splashText.textContent =
+              "Initializing - " + label + " (+" + elapsedMs + "ms)";
+          }
+        }
+
+        markStartup("index.html startup watchdog installed");
+        window.__ORGII_STARTUP_MARK__ = markStartup;
+
+        var diagnosticProbeTimerId = null;
+        if (isLocalDev) {
+          window.addEventListener(
+            "error",
+            function (event) {
+              var target = event.target;
+              if (
+                target instanceof HTMLScriptElement ||
+                target instanceof HTMLLinkElement
+              ) {
+                markStartup("startup resource load error", {
+                  tag: target.tagName,
+                  url: target.src || target.href || "",
+                });
+              }
+            },
+            true
+          );
+
+          diagnosticProbeTimerId = setTimeout(function () {
+            markStartup("startup script tags", {
+              scripts: Array.prototype.slice
+                .call(document.scripts || [])
+                .map(function (script) {
+                  return script.src || "inline";
+                }),
+            });
+
+            fetch("/main.js", { cache: "no-store" })
+              .then(function (response) {
+                markStartup("main.js fetch probe", {
+                  ok: response.ok,
+                  status: response.status,
+                });
+              })
+              .catch(function (error) {
+                markStartup("main.js fetch probe failed", {
+                  message:
+                    error && error.message ? error.message : String(error),
+                });
+              });
+          }, 5000);
+        }
+
         // Secondary windows (/windows/*) never show the splash.
         if (window.location.pathname.indexOf("/windows/") === 0) {
           window.__ORGII_SPLASH_DONE__ = function () {};
           return;
         }
 
-        // Default 20s. An E2E/test harness may shorten this by setting
+        // Default 20s for packaged/static startup. Local dev server startup can
+        // be substantially slower on Linux WebKitGTK/software rendering even
+        // after webpack has completed its first compile, so allow more time
+        // before showing the manual reload panel.
+        var DEFAULT_WATCHDOG_MS = isLocalDevOrigin() ? 60000 : 20000;
+
+        // An E2E/test harness may shorten this by setting
         // window.__ORGII_WATCHDOG_MS_OVERRIDE__ before the bundle runs; the
         // override only ever shortens the wait and never ships in normal use.
         var WATCHDOG_MS =
           typeof window.__ORGII_WATCHDOG_MS_OVERRIDE__ === "number"
             ? window.__ORGII_WATCHDOG_MS_OVERRIDE__
-            : 20000;
+            : DEFAULT_WATCHDOG_MS;
         var settled = false;
 
         function showStartupError(force) {
+          markStartup("splash watchdog fired", {
+            force: !!force,
+            watchdogMs: WATCHDOG_MS,
+            href: window.location.href,
+          });
           if (settled && !force) return;
           var splash = document.getElementById("splash");
           if (!splash || splash.style.display === "none") return;
+          var recentTimings = "";
+          if (isLocalDev && Array.isArray(window.__ORGII_STARTUP_TIMINGS__)) {
+            recentTimings = window.__ORGII_STARTUP_TIMINGS__
+              .slice(-8)
+              .map(function (entry) {
+                var details = entry.details
+                  ? " " +
+                    JSON.stringify(entry.details)
+                      .replace(/[<>&]/g, "")
+                      .slice(0, 160)
+                  : "";
+                return (
+                  '<div style="display:flex;justify-content:space-between;gap:16px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11px;color:#9ca3af">' +
+                  '<span style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap">' +
+                  String(entry.label).replace(/[<>&]/g, "") +
+                  details +
+                  "</span>" +
+                  "<span>+" +
+                  String(entry.elapsedMs).replace(/[<>&]/g, "") +
+                  "ms</span>" +
+                  "</div>"
+                );
+              })
+              .join("");
+          }
           // Replace splash content in place with an actionable panel.
           splash.innerHTML =
-            '<div style="display:flex;flex-direction:column;align-items:center;gap:20px;max-width:420px;text-align:center;padding:32px;font-family:-apple-system,BlinkMacSystemFont,\'Segoe UI\',Roboto,sans-serif">' +
+            "<div style=\"display:flex;flex-direction:column;align-items:center;gap:20px;max-width:420px;text-align:center;padding:32px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif\">" +
             '<div style="font-size:44px">⏳</div>' +
             '<div style="color:#fff;font-size:17px;font-weight:600">Startup is taking too long</div>' +
             '<div style="color:#9ca3af;font-size:13px;line-height:1.6">The app could not finish loading. This is usually a one-off — try reloading. If it keeps happening, quit and reopen, or check the logs at <span style="color:#d1d5db">~/.orgii/logs/</span>.</div>' +
+            (recentTimings
+              ? '<div style="width:100%;display:flex;flex-direction:column;gap:6px;border:1px solid #1f2937;border-radius:8px;padding:10px;background:#111827;text-align:left">' +
+                recentTimings +
+                "</div>"
+              : "") +
             '<div style="display:flex;gap:12px;margin-top:4px">' +
             '<button id="orgii-splash-reload" style="background:#3b82f6;color:#fff;border:none;padding:10px 20px;border-radius:8px;font-size:13px;font-weight:500;cursor:pointer">Reload</button>' +
             '<button id="orgii-splash-clear" style="background:transparent;color:#9ca3af;border:1px solid #374151;padding:10px 20px;border-radius:8px;font-size:13px;font-weight:500;cursor:pointer">Clear data &amp; reload</button>' +
@@ -124,6 +249,9 @@
         // the reload circuit-breaker when it takes over the splash itself.
         window.__ORGII_SPLASH_DONE__ = function () {
           settled = true;
+          if (diagnosticProbeTimerId !== null) {
+            clearTimeout(diagnosticProbeTimerId);
+          }
           clearTimeout(timerId);
         };
 
@@ -161,7 +289,9 @@
         user-select: text !important;
         -webkit-user-select: text !important;
       }
-      html, body, #root {
+      html,
+      body,
+      #root {
         height: 100%;
         background: #0d0d0d;
         border-radius: var(--border-radius-window);
@@ -216,7 +346,9 @@
         right: 0;
         text-align: center;
         color: #ffffff;
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+          "Helvetica Neue", Arial, sans-serif;
         font-size: 13px;
         font-weight: 400;
         letter-spacing: 0.5px;
@@ -227,9 +359,17 @@
         text-align: left;
       }
       @keyframes dots {
-        0%, 20% { content: "."; }
-        40% { content: ".."; }
-        60%, 100% { content: "..."; }
+        0%,
+        20% {
+          content: ".";
+        }
+        40% {
+          content: "..";
+        }
+        60%,
+        100% {
+          content: "...";
+        }
       }
       #splash-text .dots::after {
         content: ".";
@@ -249,11 +389,91 @@
       >
         <rect x="98" y="98" width="828" height="828" rx="414" fill="black" />
         <circle cx="512" cy="512" r="330" fill="#171717" fill-opacity="0.55" />
-        <path d="M677.545 271.5C680.015 271.5 681.959 272.117 683.282 273.44C684.605 274.764 685.223 276.708 685.223 279.178C685.223 282.322 683.704 285.183 680.78 287.756C677.865 290.321 673.526 292.627 667.802 294.688L667.794 294.69C662.196 296.594 658.023 299.829 655.242 304.39C652.456 308.959 651.043 314.899 651.043 322.244V701.639C651.043 709.099 652.456 715.155 655.245 719.84C658.027 724.514 662.2 727.86 667.794 729.876L668.851 730.244C674.054 732.097 678.038 734.165 680.771 736.461C683.696 738.917 685.223 741.667 685.223 744.705C685.223 747.175 684.605 749.119 683.282 750.442C681.959 751.766 680.015 752.383 677.545 752.383H561.676C559.314 752.383 557.452 751.762 556.187 750.434C554.926 749.11 554.34 747.169 554.34 744.705C554.34 741.667 555.867 738.917 558.791 736.461C561.707 734.012 566.045 731.822 571.769 729.876C577.364 727.86 581.537 724.541 584.318 719.923C587.106 715.295 588.52 709.325 588.52 701.98V322.244C588.52 314.899 587.107 308.959 584.32 304.39C581.539 299.829 577.366 296.594 571.769 294.69L571.761 294.688C566.036 292.627 561.697 290.321 558.782 287.756C555.858 285.183 554.34 282.322 554.34 279.178C554.34 276.708 554.957 274.764 556.28 273.44C557.603 272.117 559.548 271.5 562.018 271.5H677.545Z" fill="white" stroke="#040303" />
-        <path d="M461.705 271.5C464.175 271.5 466.119 272.117 467.442 273.44C468.766 274.764 469.383 276.708 469.383 279.178C469.383 282.322 467.864 285.183 464.94 287.756C462.025 290.321 457.687 292.627 451.962 294.688L451.954 294.69C446.357 296.594 442.183 299.829 439.402 304.39C436.616 308.959 435.203 314.899 435.203 322.244V701.639C435.203 709.099 436.616 715.155 439.405 719.84C442.188 724.514 446.36 727.86 451.954 729.876L453.011 730.244C458.214 732.097 462.198 734.165 464.932 736.461C467.856 738.917 469.383 741.667 469.383 744.705C469.383 747.175 468.766 749.119 467.442 750.442C466.119 751.766 464.175 752.383 461.705 752.383H345.836C343.474 752.383 341.612 751.762 340.347 750.434C339.086 749.11 338.5 747.169 338.5 744.705C338.5 741.667 340.027 738.917 342.951 736.461C345.867 734.012 350.205 731.822 355.929 729.876C361.524 727.86 365.697 724.541 368.479 719.923C371.266 715.295 372.68 709.325 372.68 701.98V322.244C372.68 314.899 371.267 308.959 368.48 304.39C365.699 299.829 361.526 296.594 355.929 294.69L355.921 294.688C350.196 292.627 345.858 290.321 342.942 287.756C340.019 285.183 338.5 282.322 338.5 279.178C338.5 276.708 339.117 274.764 340.44 273.44C341.764 272.117 343.708 271.5 346.178 271.5H461.705Z" fill="white" stroke="#040303" />
+        <path
+          d="M677.545 271.5C680.015 271.5 681.959 272.117 683.282 273.44C684.605 274.764 685.223 276.708 685.223 279.178C685.223 282.322 683.704 285.183 680.78 287.756C677.865 290.321 673.526 292.627 667.802 294.688L667.794 294.69C662.196 296.594 658.023 299.829 655.242 304.39C652.456 308.959 651.043 314.899 651.043 322.244V701.639C651.043 709.099 652.456 715.155 655.245 719.84C658.027 724.514 662.2 727.86 667.794 729.876L668.851 730.244C674.054 732.097 678.038 734.165 680.771 736.461C683.696 738.917 685.223 741.667 685.223 744.705C685.223 747.175 684.605 749.119 683.282 750.442C681.959 751.766 680.015 752.383 677.545 752.383H561.676C559.314 752.383 557.452 751.762 556.187 750.434C554.926 749.11 554.34 747.169 554.34 744.705C554.34 741.667 555.867 738.917 558.791 736.461C561.707 734.012 566.045 731.822 571.769 729.876C577.364 727.86 581.537 724.541 584.318 719.923C587.106 715.295 588.52 709.325 588.52 701.98V322.244C588.52 314.899 587.107 308.959 584.32 304.39C581.539 299.829 577.366 296.594 571.769 294.69L571.761 294.688C566.036 292.627 561.697 290.321 558.782 287.756C555.858 285.183 554.34 282.322 554.34 279.178C554.34 276.708 554.957 274.764 556.28 273.44C557.603 272.117 559.548 271.5 562.018 271.5H677.545Z"
+          fill="white"
+          stroke="#040303"
+        />
+        <path
+          d="M461.705 271.5C464.175 271.5 466.119 272.117 467.442 273.44C468.766 274.764 469.383 276.708 469.383 279.178C469.383 282.322 467.864 285.183 464.94 287.756C462.025 290.321 457.687 292.627 451.962 294.688L451.954 294.69C446.357 296.594 442.183 299.829 439.402 304.39C436.616 308.959 435.203 314.899 435.203 322.244V701.639C435.203 709.099 436.616 715.155 439.405 719.84C442.188 724.514 446.36 727.86 451.954 729.876L453.011 730.244C458.214 732.097 462.198 734.165 464.932 736.461C467.856 738.917 469.383 741.667 469.383 744.705C469.383 747.175 468.766 749.119 467.442 750.442C466.119 751.766 464.175 752.383 461.705 752.383H345.836C343.474 752.383 341.612 751.762 340.347 750.434C339.086 749.11 338.5 747.169 338.5 744.705C338.5 741.667 340.027 738.917 342.951 736.461C345.867 734.012 350.205 731.822 355.929 729.876C361.524 727.86 365.697 724.541 368.479 719.923C371.266 715.295 372.68 709.325 372.68 701.98V322.244C372.68 314.899 371.267 308.959 368.48 304.39C365.699 299.829 361.526 296.594 355.929 294.69L355.921 294.688C350.196 292.627 345.858 290.321 342.942 287.756C340.019 285.183 338.5 282.322 338.5 279.178C338.5 276.708 339.117 274.764 340.44 273.44C341.764 272.117 343.708 271.5 346.178 271.5H461.705Z"
+          fill="white"
+          stroke="#040303"
+        />
       </svg>
       <div id="splash-text">Initializing<span class="dots"></span></div>
     </div>
     <div id="root"></div>
+    <script nonce="orgii-codemirror-style">
+      (function () {
+        var retryMainScriptLoad =
+          "<%= htmlWebpackPlugin.options.retryMainScriptLoad ? 'true' : 'false' %>" ===
+          "true";
+
+        if (!retryMainScriptLoad) {
+          return;
+        }
+
+        if (
+          window.location.protocol !== "http:" ||
+          !/^(localhost|127\.0\.0\.1)$/.test(window.location.hostname)
+        ) {
+          return;
+        }
+
+        var maxAttempts = 30;
+        var attempt = 0;
+        var retryDelayMs = 250;
+        var markStartup =
+          window.__ORGII_STARTUP_MARK__ ||
+          function (label, details) {
+            console.info("[Startup] " + label, details || "");
+          };
+
+        function loadMainScript() {
+          attempt += 1;
+          markStartup("main.js loader attempt", { attempt: attempt });
+
+          var script = document.createElement("script");
+          script.src = "/main.js?orgii_startup_attempt=" + attempt;
+          script.async = false;
+          script.onload = function () {
+            markStartup("main.js loader loaded", {
+              attempt: attempt,
+              mode: "external-retry",
+            });
+          };
+          script.onerror = function () {
+            markStartup("main.js loader failed", { attempt: attempt });
+            script.remove();
+            fetch("/main.js", { cache: "no-store" })
+              .then(function (response) {
+                markStartup("main.js fetch after script failure", {
+                  attempt: attempt,
+                  ok: response.ok,
+                  status: response.status,
+                });
+              })
+              .catch(function (error) {
+                markStartup("main.js fetch after script failure failed", {
+                  attempt: attempt,
+                  message:
+                    error && error.message ? error.message : String(error),
+                });
+              });
+            if (attempt >= maxAttempts) {
+              if (typeof window.__ORGII_SHOW_STARTUP_ERROR__ === "function") {
+                window.__ORGII_SHOW_STARTUP_ERROR__(true);
+              }
+              return;
+            }
+            setTimeout(loadMainScript, retryDelayMs);
+            retryDelayMs = Math.min(retryDelayMs * 1.5, 2000);
+          };
+          document.body.appendChild(script);
+        }
+
+        loadMainScript();
+      })();
+    </script>
   </body>
 </html>

--- a/scripts/dev/startup-watchdog.test.cjs
+++ b/scripts/dev/startup-watchdog.test.cjs
@@ -1,0 +1,203 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const html = fs.readFileSync("public/index.html", "utf8");
+const tauriLibSource = fs.readFileSync("src-tauri/src/lib.rs", "utf8");
+const firstPaintSignalSource = fs.readFileSync(
+  "src/app/root/useFirstPaintSignal.ts",
+  "utf8"
+);
+const scriptMatch = html.match(
+  /<script nonce="orgii-codemirror-style">\s*\/\/ -+\s*\/\/ Splash hard-timeout watchdog[\s\S]*?\(function \(\) \{([\s\S]*?)\}\)\(\);\s*<\/script>/
+);
+
+function evaluateWatchdogMs({ protocol, hostname }) {
+  assert.ok(scriptMatch, "startup watchdog script should be present");
+
+  let timeoutMs;
+  const context = {
+    console: {
+      info: () => {},
+      warn: () => {},
+    },
+    document: {
+      documentElement: {},
+      getElementById: () => null,
+    },
+    performance: {
+      now: () => 100,
+    },
+    setTimeout: (_callback, ms) => {
+      timeoutMs = ms;
+      return 1;
+    },
+    fetch: () =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+      }),
+    HTMLLinkElement: class HTMLLinkElement {},
+    HTMLScriptElement: class HTMLScriptElement {},
+    window: {
+      addEventListener: () => {},
+      location: {
+        hostname,
+        pathname: "/",
+        protocol,
+      },
+    },
+  };
+
+  vm.createContext(context);
+  vm.runInContext(`(function () {${scriptMatch[1]}})();`, context);
+
+  return timeoutMs;
+}
+
+function evaluateClearedTimeoutsAfterSplashDone({ protocol, hostname }) {
+  assert.ok(scriptMatch, "startup watchdog script should be present");
+
+  let nextTimerId = 0;
+  const scheduledTimers = [];
+  const clearedTimers = [];
+  const context = {
+    console: {
+      info: () => {},
+      warn: () => {},
+    },
+    clearTimeout: (timerId) => {
+      clearedTimers.push(timerId);
+    },
+    document: {
+      documentElement: {},
+      getElementById: () => null,
+    },
+    performance: {
+      now: () => 100,
+    },
+    setTimeout: (_callback, ms) => {
+      nextTimerId += 1;
+      scheduledTimers.push({ id: nextTimerId, ms });
+      return nextTimerId;
+    },
+    fetch: () =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+      }),
+    HTMLLinkElement: class HTMLLinkElement {},
+    HTMLScriptElement: class HTMLScriptElement {},
+    window: {
+      addEventListener: () => {},
+      location: {
+        hostname,
+        pathname: "/",
+        protocol,
+      },
+    },
+  };
+
+  vm.createContext(context);
+  vm.runInContext(`(function () {${scriptMatch[1]}})();`, context);
+  context.window.__ORGII_SPLASH_DONE__();
+
+  return { scheduledTimers, clearedTimers };
+}
+
+test("startup watchdog gives localhost dev server more time", () => {
+  assert.equal(
+    evaluateWatchdogMs({ protocol: "http:", hostname: "127.0.0.1" }),
+    60000
+  );
+  assert.equal(
+    evaluateWatchdogMs({ protocol: "http:", hostname: "localhost" }),
+    60000
+  );
+});
+
+test("startup watchdog keeps packaged/static startup timeout short", () => {
+  assert.equal(
+    evaluateWatchdogMs({ protocol: "tauri:", hostname: "localhost" }),
+    20000
+  );
+  assert.equal(
+    evaluateWatchdogMs({ protocol: "https:", hostname: "example.test" }),
+    20000
+  );
+});
+
+test("startup success cancels the watchdog and diagnostic probe timers", () => {
+  const { scheduledTimers, clearedTimers } =
+    evaluateClearedTimeoutsAfterSplashDone({
+      protocol: "http:",
+      hostname: "localhost",
+    });
+
+  assert.deepEqual(
+    scheduledTimers.map((timer) => timer.ms),
+    [5000, 60000]
+  );
+  assert.deepEqual(clearedTimers, [1, 2]);
+});
+
+test("startup success only has the watchdog timer outside local dev", () => {
+  const { scheduledTimers, clearedTimers } =
+    evaluateClearedTimeoutsAfterSplashDone({
+      protocol: "tauri:",
+      hostname: "localhost",
+    });
+
+  assert.deepEqual(
+    scheduledTimers.map((timer) => timer.ms),
+    [20000]
+  );
+  assert.deepEqual(clearedTimers, [1]);
+});
+
+test("retrying main script loader runs after the root element exists", () => {
+  const retryLoaderIndex = html.indexOf("retryMainScriptLoad");
+  const rootIndex = html.indexOf('<div id="root"></div>');
+
+  assert.notEqual(retryLoaderIndex, -1);
+  assert.notEqual(rootIndex, -1);
+  assert.ok(
+    rootIndex < retryLoaderIndex,
+    "retrying loader should run after #root is parsed"
+  );
+  const loaderSource = html.slice(retryLoaderIndex);
+  assert.match(loaderSource, /orgii_startup_attempt=/);
+  assert.doesNotMatch(loaderSource, /script\.textContent\s*=/);
+});
+
+test("automatic last-window exit is only prevented on macOS or release builds", () => {
+  const exitRequestedArm = tauriLibSource.match(
+    /tauri::RunEvent::ExitRequested[\s\S]*?=> \{([\s\S]*?)\n\s*\}\n\s*_ =>/
+  );
+
+  assert.ok(exitRequestedArm, "ExitRequested handler should be present");
+  assert.match(
+    exitRequestedArm[1],
+    /#\[cfg\(any\(target_os = "macos", not\(debug_assertions\)\)\)\][\s\S]*_?api\.prevent_exit\(\);/
+  );
+  assert.match(
+    exitRequestedArm[1],
+    /code\.is_some\(\)[\s\S]*cfg!\(all\(debug_assertions, not\(target_os = "macos"\)\)\)/
+  );
+});
+
+test("first-paint startup logging is gated behind dev startup debug", () => {
+  assert.match(
+    tauriLibSource,
+    /if dev_startup_debug_enabled\(\) \{\s*app\.listen\("orgii-startup-first-paint"/
+  );
+});
+
+test("frontend first-paint metric emit is gated to local dev", () => {
+  assert.match(firstPaintSignalSource, /function isLocalDevOrigin\(\)/);
+  assert.match(
+    firstPaintSignalSource,
+    /if \(!isLocalDevOrigin\(\)\) \{\s*return;\s*\}/
+  );
+});

--- a/scripts/dev/tauri-dev-processes.cjs
+++ b/scripts/dev/tauri-dev-processes.cjs
@@ -1,0 +1,150 @@
+const http = require("node:http");
+const https = require("node:https");
+
+function createTauriArgs({ features = [], devUrl } = {}) {
+  const args = ["dev"];
+  if (features.length > 0) {
+    args.push("--features", features.join(","));
+  }
+
+  const buildConfig = {
+    beforeDevCommand: "",
+  };
+  if (devUrl) {
+    buildConfig.devUrl = devUrl;
+  }
+
+  args.push(
+    "--config",
+    JSON.stringify({
+      build: buildConfig,
+    })
+  );
+
+  return args;
+}
+
+function createFrontendScriptName({ lightDev = false } = {}) {
+  return lightDev ? "dev:frontend:light" : "dev:frontend";
+}
+
+function createDevUrl(env = process.env) {
+  const port = env.WEBPACK_DEV_SERVER_PORT || env.PORT || "1998";
+  return `http://localhost:${port}`;
+}
+
+function stripAnsi(line) {
+  return String(line)
+    .replace(/\x1b\[[0-9;]*[mGKJH]/g, "")
+    .trim();
+}
+
+function isInitialWebpackReadyLine(line) {
+  return stripAnsi(line).startsWith("WEBPACK_STATUS:done_initial");
+}
+
+function isBenignWebKitGtkInternalErrorLine(line) {
+  const clean = stripAnsi(line);
+  return (
+    clean ===
+      "ERROR: WebKit encountered an internal error. This is a WebKit bug." ||
+    clean.includes("WebLoaderStrategy.cpp(618)") ||
+    clean.includes("internallyFailedLoadTimerFired()")
+  );
+}
+
+function formatElapsedMs(ms) {
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+const STARTUP_METRIC_KEYS = [
+  "webpackStart",
+  "webpackDone",
+  "mainJsReady",
+  "rustStart",
+  "rustDone",
+  "tauriStart",
+  "appLaunched",
+  "backendReady",
+];
+
+function formatStartupMetricsTsv({ startedAtIso, pid, lightDev, milestones }) {
+  return [
+    startedAtIso,
+    pid,
+    lightDev,
+    ...STARTUP_METRIC_KEYS.map((key) => milestones[key] ?? ""),
+  ].join("\t");
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function fetchHttpAsset(url) {
+  return new Promise((resolve) => {
+    const parsedUrl = new URL(url);
+    const client = parsedUrl.protocol === "https:" ? https : http;
+    const request = client.get(
+      parsedUrl,
+      {
+        headers: {
+          "Cache-Control": "no-cache",
+          Pragma: "no-cache",
+        },
+        timeout: 2000,
+      },
+      (response) => {
+        response.resume();
+        resolve(response.statusCode === 200);
+      }
+    );
+
+    request.on("timeout", () => {
+      request.destroy();
+      resolve(false);
+    });
+    request.on("error", () => {
+      resolve(false);
+    });
+  });
+}
+
+async function waitForDevServerAsset(
+  url,
+  {
+    timeoutMs = 15000,
+    retryDelayMs = 100,
+    fetchAsset = fetchHttpAsset,
+    delay: wait = delay,
+  } = {}
+) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError;
+
+  while (Date.now() <= deadline) {
+    try {
+      if (await fetchAsset(url)) {
+        return;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+    await wait(retryDelayMs);
+  }
+
+  const suffix = lastError && lastError.message ? `: ${lastError.message}` : "";
+  throw new Error(`Dev server asset did not become ready: ${url}${suffix}`);
+}
+
+module.exports = {
+  createDevUrl,
+  createFrontendScriptName,
+  createTauriArgs,
+  formatElapsedMs,
+  formatStartupMetricsTsv,
+  isBenignWebKitGtkInternalErrorLine,
+  isInitialWebpackReadyLine,
+  stripAnsi,
+  waitForDevServerAsset,
+};

--- a/scripts/dev/tauri-dev-processes.test.cjs
+++ b/scripts/dev/tauri-dev-processes.test.cjs
@@ -1,0 +1,128 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  createDevUrl,
+  createTauriArgs,
+  formatElapsedMs,
+  formatStartupMetricsTsv,
+  isBenignWebKitGtkInternalErrorLine,
+  isInitialWebpackReadyLine,
+  waitForDevServerAsset,
+} = require("./tauri-dev-processes.cjs");
+
+test("recognizes only the initial successful webpack compile as ready", () => {
+  assert.equal(
+    isInitialWebpackReadyLine("WEBPACK_STATUS:done_initial 1234ms"),
+    true
+  );
+  assert.equal(isInitialWebpackReadyLine("WEBPACK_STATUS:done 150ms"), false);
+  assert.equal(
+    isInitialWebpackReadyLine("WEBPACK_STATUS:done_warnings 150ms"),
+    false
+  );
+  assert.equal(isInitialWebpackReadyLine("WEBPACK_STATUS:error"), false);
+});
+
+test("tauri args disable beforeDevCommand after wrapper starts webpack", () => {
+  assert.deepEqual(createTauriArgs({ features: [], lightDev: false }), [
+    "dev",
+    "--config",
+    '{"build":{"beforeDevCommand":""}}',
+  ]);
+});
+
+test("tauri args preserve features and devUrl override", () => {
+  assert.deepEqual(
+    createTauriArgs({
+      features: ["webdriver"],
+      lightDev: true,
+      devUrl: "http://127.0.0.1:1998",
+    }),
+    [
+      "dev",
+      "--features",
+      "webdriver",
+      "--config",
+      '{"build":{"beforeDevCommand":"","devUrl":"http://127.0.0.1:1998"}}',
+    ]
+  );
+});
+
+test("dev URL defaults to the same localhost origin as Tauri config", () => {
+  assert.equal(createDevUrl({}), "http://localhost:1998");
+  assert.equal(
+    createDevUrl({ WEBPACK_DEV_SERVER_PORT: "3000" }),
+    "http://localhost:3000"
+  );
+});
+
+test("waits for the dev server asset after webpack reports ready", async () => {
+  const attempts = [];
+  const delays = [];
+
+  await waitForDevServerAsset("http://localhost:1998/main.js", {
+    timeoutMs: 1000,
+    retryDelayMs: 25,
+    fetchAsset: async (url) => {
+      attempts.push(url);
+      return attempts.length >= 3;
+    },
+    delay: async (ms) => {
+      delays.push(ms);
+    },
+  });
+
+  assert.deepEqual(attempts, [
+    "http://localhost:1998/main.js",
+    "http://localhost:1998/main.js",
+    "http://localhost:1998/main.js",
+  ]);
+  assert.deepEqual(delays, [25, 25]);
+});
+
+test("classifies known WebKitGTK internal loader errors as suppressible", () => {
+  assert.equal(
+    isBenignWebKitGtkInternalErrorLine(
+      "ERROR: WebKit encountered an internal error. This is a WebKit bug."
+    ),
+    true
+  );
+  assert.equal(
+    isBenignWebKitGtkInternalErrorLine(
+      "./Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp(618) : void WebKit::WebLoaderStrategy::internallyFailedLoadTimerFired()"
+    ),
+    true
+  );
+  assert.equal(
+    isBenignWebKitGtkInternalErrorLine("ERROR: failed to load main.js"),
+    false
+  );
+});
+
+test("formats startup elapsed durations for milestone logs", () => {
+  assert.equal(formatElapsedMs(0), "0.00s");
+  assert.equal(formatElapsedMs(325), "0.33s");
+  assert.equal(formatElapsedMs(12_345), "12.35s");
+});
+
+test("formats startup metrics as stable TSV", () => {
+  assert.equal(
+    formatStartupMetricsTsv({
+      startedAtIso: "2026-06-24T10:00:00.000Z",
+      pid: 123,
+      lightDev: true,
+      milestones: {
+        webpackStart: 1,
+        webpackDone: 2000,
+        mainJsReady: 2100,
+        rustStart: 2,
+        rustDone: 10_000,
+        tauriStart: 10_100,
+        appLaunched: 11_000,
+        backendReady: 11_500,
+      },
+    }),
+    "2026-06-24T10:00:00.000Z\t123\ttrue\t1\t2000\t2100\t2\t10000\t10100\t11000\t11500"
+  );
+});

--- a/scripts/dev/tauri.js
+++ b/scripts/dev/tauri.js
@@ -11,11 +11,22 @@
  */
 
 const { spawn, execSync } = require("child_process");
+const fs = require("fs");
 const path = require("path");
 const { tauriFeatureList } = require("../tauri/features.cjs");
 const {
   applyDefaultDiagnosticsEndpoint,
 } = require("../tauri/diagnostics-endpoint.cjs");
+const {
+  createDevUrl,
+  createFrontendScriptName,
+  createTauriArgs,
+  formatElapsedMs,
+  formatStartupMetricsTsv,
+  isBenignWebKitGtkInternalErrorLine,
+  isInitialWebpackReadyLine,
+  waitForDevServerAsset,
+} = require("./tauri-dev-processes.cjs");
 const readline = require("readline");
 
 const rootDir = path.join(__dirname, "..", "..");
@@ -37,6 +48,17 @@ const LAST_COUNT = {
 let statusBarActive = false;
 let appLaunchPrinted = false;
 let serviceReadyPrinted = false;
+let devStartupStartedAt = Date.now();
+let startupMetrics = createStartupMetrics();
+
+function createStartupMetrics() {
+  return {
+    startedAtIso: new Date().toISOString(),
+    pid: process.pid,
+    lightDev: process.env.ORGII_LIGHT_DEV === "true",
+    milestones: {},
+  };
+}
 
 const STYLE = {
   reset: "\x1b[0m",
@@ -128,6 +150,30 @@ function printLog(line) {
   writeStatusBar();
 }
 
+function recordStartupMetric(key) {
+  if (key) {
+    startupMetrics.milestones[key] = Date.now() - devStartupStartedAt;
+  }
+}
+
+function appendStartupMetrics() {
+  try {
+    fs.appendFileSync(
+      "/tmp/orgii-tauri-dev-startup.tsv",
+      `${formatStartupMetricsTsv(startupMetrics)}\n`
+    );
+  } catch (_error) {
+    // Metrics are best-effort diagnostics.
+  }
+}
+
+function printStartupMilestone(label, key) {
+  recordStartupMetric(key);
+  printLog(
+    `[DevStartup +${formatElapsedMs(Date.now() - devStartupStartedAt)}] ${label}`
+  );
+}
+
 function setRustStatus(text) {
   STATUS.rust = text;
   writeStatusBar();
@@ -158,6 +204,8 @@ function shouldSuppressLine(clean) {
     clean.includes(
       "tauri_plugin_updater::updater: update endpoint did not respond with a successful status code"
     ) ||
+    (process.env.ORGII_LIGHT_DEV === "true" &&
+      isBenignWebKitGtkInternalErrorLine(clean)) ||
     clean.startsWith("📚 Git API:") ||
     clean.startsWith("🔍 Search API:") ||
     clean.startsWith("📄 File API:") ||
@@ -192,6 +240,7 @@ function routeLine(line) {
   if (clean.startsWith("Running `/") && clean.endsWith("/org2`")) {
     if (!appLaunchPrinted) {
       appLaunchPrinted = true;
+      printStartupMilestone("Tauri app binary launched", "appLaunched");
       printLog("🖥️  Tauri app launched");
     }
     setRustStatus("app running");
@@ -201,6 +250,8 @@ function routeLine(line) {
   if (clean.startsWith("🚀 Unified IDE server starting on")) {
     if (!serviceReadyPrinted) {
       serviceReadyPrinted = true;
+      printStartupMilestone("backend HTTP server ready", "backendReady");
+      appendStartupMetrics();
       printLog(clean);
     }
     return;
@@ -261,6 +312,7 @@ function routeLine(line) {
       const timeMatch = clean.match(/in\s+([\d.]+s)/);
       const time = timeMatch ? timeMatch[1] : "";
       const parts = [LAST_COUNT.rust, time].filter(Boolean);
+      recordStartupMetric("rustDone");
       setRustStatus(
         `\x1b[32mFinished\x1b[0m${parts.length ? " " + parts.join(" | ") : ""}`
       );
@@ -334,29 +386,103 @@ function cleanChildEnv() {
   return applyDefaultDiagnosticsEndpoint(env);
 }
 
-function startTauriDev(features) {
-  const args = ["dev"];
-  if (features.length > 0) {
-    args.push("--features", features.join(","));
-  }
-  if (process.env.ORGII_LIGHT_DEV === "true") {
-    args.push(
-      "--config",
-      JSON.stringify({
-        build: {
-          beforeDevCommand: "pnpm run dev:frontend:light",
-        },
-      })
-    );
-  }
-
+function createBinPath(name) {
   const isWindows = process.platform === "win32";
-  const tauriBin = path.join(
+  const localPath = path.join(
     rootDir,
     "node_modules",
     ".bin",
-    isWindows ? "tauri.cmd" : "tauri"
+    isWindows ? `${name}.cmd` : name
   );
+  return fs.existsSync(localPath) ? localPath : name;
+}
+
+function pipeProcessLines(childProcess, onLine) {
+  function handleStream(stream) {
+    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+    rl.on("line", onLine);
+  }
+
+  handleStream(childProcess.stdout);
+  handleStream(childProcess.stderr);
+}
+
+function startFrontendDev() {
+  const scriptName = createFrontendScriptName({
+    lightDev: process.env.ORGII_LIGHT_DEV === "true",
+  });
+  const pnpmBin = createBinPath("pnpm");
+  const isWindows = process.platform === "win32";
+
+  setWebpackStatus("starting dev server...");
+  printStartupMilestone("starting webpack dev server", "webpackStart");
+
+  const frontendProcess = spawn(pnpmBin, ["run", scriptName], {
+    stdio: ["inherit", "pipe", "pipe"],
+    cwd: rootDir,
+    env: cleanChildEnv(),
+    ...(isWindows ? { shell: true } : {}),
+  });
+
+  const ready = new Promise((resolve, reject) => {
+    let settled = false;
+    let probingAsset = false;
+
+    pipeProcessLines(frontendProcess, (line) => {
+      routeLine(line);
+      if (!settled && !probingAsset && isInitialWebpackReadyLine(line)) {
+        probingAsset = true;
+        printStartupMilestone("webpack initial compile done", "webpackDone");
+        setWebpackStatus("verifying /main.js...");
+        waitForDevServerAsset(`${createDevUrl()}/main.js`)
+          .then(() => {
+            if (!settled) {
+              settled = true;
+              setWebpackStatus("\x1b[32mHTTP ready\x1b[0m /main.js");
+              printStartupMilestone("main.js HTTP ready", "mainJsReady");
+              resolve();
+            }
+          })
+          .catch((error) => {
+            if (!settled) {
+              settled = true;
+              reject(error);
+            }
+          });
+      }
+    });
+
+    frontendProcess.on("exit", (code) => {
+      if (!settled) {
+        settled = true;
+        reject(
+          new Error(
+            `Frontend dev server exited before initial compile (${code})`
+          )
+        );
+      }
+    });
+
+    frontendProcess.on("error", (error) => {
+      if (!settled) {
+        settled = true;
+        reject(error);
+      }
+    });
+  });
+
+  return { process: frontendProcess, ready };
+}
+
+function startTauriDev(features) {
+  const args = createTauriArgs({
+    features,
+    devUrl: createDevUrl(),
+  });
+  const tauriBin = createBinPath("tauri");
+  const isWindows = process.platform === "win32";
+  recordStartupMetric("rustStart");
+  printStartupMilestone("starting Tauri dev process", "tauriStart");
   const tauriProcess = spawn(tauriBin, args, {
     stdio: ["inherit", "pipe", "pipe"],
     cwd: rootDir,
@@ -367,62 +493,112 @@ function startTauriDev(features) {
   // Initialize status bar once the process starts
   writeStatusBar();
 
-  function handleStream(stream) {
-    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
-    rl.on("line", routeLine);
+  pipeProcessLines(tauriProcess, routeLine);
+
+  return tauriProcess;
+}
+
+function shutdownProcesses(processes, signal) {
+  console.log(`\n🛑 Shutting down (${signal})...`);
+  for (const childProcess of processes) {
+    if (childProcess?.pid) {
+      killDescendants(childProcess.pid);
+    }
   }
-
-  handleStream(tauriProcess.stdout);
-  handleStream(tauriProcess.stderr);
-
-  tauriProcess.on("exit", (code) => {
-    if (isTTY && statusBarActive) {
-      process.stdout.write("\x1b[3A\x1b[0J");
-    }
-    process.exit(code || 0);
-  });
-
-  tauriProcess.on("error", (error) => {
-    console.error("❌ Failed to start Tauri:", error.message);
-    process.exit(1);
-  });
-
-  let shuttingDown = false;
-  function shutdown(signal) {
-    if (shuttingDown) return;
-    shuttingDown = true;
-    console.log(`\n🛑 Shutting down (${signal})...`);
-    if (tauriProcess.pid) {
-      killDescendants(tauriProcess.pid);
-    }
-    // Force exit after 3s in case children don't terminate
-    setTimeout(() => {
-      if (tauriProcess.pid) {
+  setTimeout(() => {
+    for (const childProcess of processes) {
+      if (childProcess?.pid) {
         try {
-          process.kill(tauriProcess.pid, "SIGKILL");
+          process.kill(childProcess.pid, "SIGKILL");
         } catch (_err) {
           /* already dead */
         }
       }
-      process.exit(1);
-    }, 3000).unref();
+    }
+    process.exit(1);
+  }, 3000).unref();
+}
+
+async function startDev(features) {
+  devStartupStartedAt = Date.now();
+  startupMetrics = createStartupMetrics();
+
+  // Initialize status bar before the frontend process starts emitting progress.
+  writeStatusBar();
+
+  const managedProcesses = [];
+  let shuttingDown = false;
+
+  function shutdown(signal) {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    shutdownProcesses(managedProcesses, signal);
   }
 
   process.on("SIGINT", () => shutdown("SIGINT"));
   process.on("SIGTERM", () => shutdown("SIGTERM"));
 
-  return tauriProcess;
+  const frontend = startFrontendDev();
+  managedProcesses.push(frontend.process);
+
+  frontend.ready
+    .then(() => {
+      if (shuttingDown) return;
+
+      printStartupMilestone("frontend ready; opening WebView");
+      const tauriProcess = startTauriDev(features);
+      managedProcesses.push(tauriProcess);
+
+      frontend.process.on("exit", (code) => {
+        if (!shuttingDown) {
+          shuttingDown = true;
+          console.error(`❌ Frontend dev server exited (${code})`);
+          shutdownProcesses([tauriProcess], "frontend exited");
+        }
+      });
+
+      tauriProcess.on("error", (error) => {
+        if (!shuttingDown) {
+          shuttingDown = true;
+          console.error("❌ Failed to start Tauri:", error.message);
+          shutdownProcesses([frontend.process], "tauri failed");
+        }
+      });
+
+      tauriProcess.on("exit", (code) => {
+        if (isTTY && statusBarActive) {
+          process.stdout.write("\x1b[3A\x1b[0J");
+        }
+        if (!shuttingDown) {
+          shuttingDown = true;
+          if (frontend.process.pid) {
+            killDescendants(frontend.process.pid);
+          }
+          process.exit(code || 0);
+        }
+      });
+    })
+    .catch((error) => {
+      if (!shuttingDown) {
+        shuttingDown = true;
+        console.error("❌ Dev startup failed:", error.message);
+        shutdownProcesses(managedProcesses, "startup failed");
+      }
+    });
 }
 
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
-function main() {
+async function main() {
   const features = tauriFeatureList();
 
   printBanner(features);
 
   cleanupOrphanedProcesses();
-  startTauriDev(features);
+  await startDev(features);
 }
 
-main();
+main().catch((error) => {
+  console.error("❌ Failed to start dev mode:", error.message);
+  process.exit(1);
+});

--- a/scripts/dev/webpack-config-light.test.cjs
+++ b/scripts/dev/webpack-config-light.test.cjs
@@ -1,0 +1,78 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const createWebpackConfig = require("../../webpack.config.js");
+
+function withEnv(overrides, fn) {
+  const previous = {};
+  for (const key of Object.keys(overrides)) {
+    previous[key] = process.env[key];
+    if (overrides[key] == null) {
+      delete process.env[key];
+    } else {
+      process.env[key] = overrides[key];
+    }
+  }
+
+  try {
+    return fn();
+  } finally {
+    for (const key of Object.keys(overrides)) {
+      if (previous[key] == null) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previous[key];
+      }
+    }
+  }
+}
+
+test("light dev disables webpack dev-server browser client", () => {
+  const config = withEnv(
+    {
+      ORGII_LIGHT_DEV: "true",
+      FAST_DEV: "true",
+      DEV_SOURCEMAPS: "false",
+      ORGII_RETRY_MAIN_SCRIPT_LOAD: "false",
+    },
+    () => createWebpackConfig({}, { mode: "development" })
+  );
+
+  assert.equal(config.devServer.hot, false);
+  assert.equal(config.devServer.liveReload, false);
+  assert.equal(config.devServer.client, false);
+
+  const htmlPlugin = config.plugins.find(
+    (plugin) => plugin.constructor?.name === "HtmlWebpackPlugin"
+  );
+  assert.equal(htmlPlugin?.userOptions?.inject, "body");
+  assert.equal(htmlPlugin?.userOptions?.retryMainScriptLoad, false);
+});
+
+test("retrying main script loader disables static HTML injection in dev", () => {
+  const config = withEnv(
+    {
+      ORGII_RETRY_MAIN_SCRIPT_LOAD: "true",
+    },
+    () => createWebpackConfig({}, { mode: "development" })
+  );
+  const htmlPlugin = config.plugins.find(
+    (plugin) => plugin.constructor?.name === "HtmlWebpackPlugin"
+  );
+  assert.equal(htmlPlugin?.userOptions?.inject, false);
+  assert.equal(htmlPlugin?.userOptions?.retryMainScriptLoad, true);
+});
+
+test("production keeps default HTML script injection", () => {
+  const config = withEnv(
+    {
+      ORGII_RETRY_MAIN_SCRIPT_LOAD: "true",
+    },
+    () => createWebpackConfig({}, { mode: "production" })
+  );
+  const htmlPlugin = config.plugins.find(
+    (plugin) => plugin.constructor?.name === "HtmlWebpackPlugin"
+  );
+  assert.equal(htmlPlugin?.userOptions?.inject, "body");
+  assert.equal(htmlPlugin?.userOptions?.retryMainScriptLoad, false);
+});

--- a/scripts/dev/webpack-server.js
+++ b/scripts/dev/webpack-server.js
@@ -88,10 +88,12 @@ try {
 // Suppress webpack-dev-server built-in progress (we provide our own)
 // ============================================
 if (config.devServer) {
-  config.devServer.client = {
-    ...(config.devServer.client || {}),
-    progress: false,
-  };
+  if (config.devServer.client !== false) {
+    config.devServer.client = {
+      ...(config.devServer.client || {}),
+      progress: false,
+    };
+  }
 }
 
 // ============================================
@@ -169,9 +171,49 @@ try {
 // ============================================
 // Configure Dev Server Options
 // ============================================
+function shouldLogDevRequest(url = "") {
+  if (process.env.ORGII_DEV_STARTUP_DEBUG !== "true") {
+    return false;
+  }
+
+  return (
+    url === "/" ||
+    url.startsWith("/main.js") ||
+    url.startsWith("/index.html") ||
+    url.startsWith("/ws") ||
+    url.includes(".hot-update.") ||
+    url.includes("webpack")
+  );
+}
+
 const devServerOptions = {
   ...config.devServer,
   open: false, // Don't auto-open browser
+  setupMiddlewares: (middlewares, devServer) => {
+    middlewares.unshift({
+      name: "orgii-dev-request-diagnostics",
+      middleware: (req, res, next) => {
+        if (shouldLogDevRequest(req.url)) {
+          const startedAt = Date.now();
+          res.on("finish", () => {
+            const ua = String(req.headers["user-agent"] || "")
+              .replace(/\s+/g, " ")
+              .slice(0, 120);
+            process.stdout.write(
+              `[WDS_REQUEST] ${req.method} ${req.url} -> ${res.statusCode} ${Date.now() - startedAt}ms ua="${ua}"\n`
+            );
+          });
+        }
+        next();
+      },
+    });
+
+    if (typeof config.devServer?.setupMiddlewares === "function") {
+      return config.devServer.setupMiddlewares(middlewares, devServer);
+    }
+
+    return middlewares;
+  },
 };
 
 // ============================================

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,7 +40,7 @@
 //! They are grouped by area in that file (e.g. browser, search, agents).
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
-use tauri::Manager;
+use tauri::{Listener, Manager};
 
 #[cfg(unix)]
 fn write_panic_report_to_stderr(report: &str) {
@@ -52,6 +52,10 @@ fn write_panic_report_to_stderr(report: &str) {
 #[cfg(not(unix))]
 fn write_panic_report_to_stderr(report: &str) {
     let _ = std::io::Write::write_all(&mut std::io::stderr().lock(), report.as_bytes());
+}
+
+fn dev_startup_debug_enabled() -> bool {
+    std::env::var("ORGII_DEV_STARTUP_DEBUG").as_deref() == Ok("true")
 }
 
 // ============================================
@@ -284,13 +288,13 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_drag::init())
-        .on_window_event(|window, event| {
+        .on_window_event(|_window, _event| {
             #[cfg(target_os = "macos")]
-            match event {
+            match _event {
                 tauri::WindowEvent::ScaleFactorChanged { .. }
                 | tauri::WindowEvent::ThemeChanged(_)
                 | tauri::WindowEvent::Focused(true) => {
-                    if let Some(webview_window) = window.app_handle().get_webview_window(window.label()) {
+                    if let Some(webview_window) = _window.app_handle().get_webview_window(_window.label()) {
                         app_window::set_traffic_light_position(
                             &webview_window,
                             app_window::TRAFFIC_LIGHT_X,
@@ -324,6 +328,12 @@ pub fn run() {
             {
                 use tauri::Manager;
                 if let Some(main_window) = app.handle().get_webview_window("main") {
+                    #[cfg(not(target_os = "macos"))]
+                    {
+                        let _ = main_window.show();
+                        let _ = main_window.set_focus();
+                    }
+
                     #[cfg(target_os = "macos")]
                     {
                         app_window::apply_window_background_color(&main_window);
@@ -774,22 +784,53 @@ pub fn run() {
                 }
             }
 
+            if dev_startup_debug_enabled() {
+                app.listen("orgii-startup-first-paint", |event| {
+                    println!("[TauriStartup] frontend first paint ready {}", event.payload());
+                    tracing::info!(payload = event.payload(), "[TauriStartup] frontend first paint ready");
+                });
+            }
+
             // tauri_plugin_log removed — tracing_subscriber handles file logging.
             Ok(())
         })
-        // macOS: hide the main window on close (red traffic light) instead of destroying it.
-        // This keeps the process alive so the dock icon can reopen it.
-        .on_window_event(|window, event| {
-            if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+        // Release keeps the historical behavior: closing the main window hides it so
+        // tray/dock entry points can reopen it. Debug Linux/Windows exits normally
+        // so dev runs do not leave hidden app processes behind.
+        .on_window_event(|_window, _event| {
+            if let tauri::WindowEvent::CloseRequested { api: _api, .. } = _event {
                 // Only hide the "main" window — let auxiliary windows close normally
-                if window.label() == "main" {
-                    api.prevent_close();
-                    let _ = window.hide();
+                if _window.label() == "main" {
+                    #[cfg(any(target_os = "macos", not(debug_assertions)))]
+                    {
+                        _api.prevent_close();
+                        let _ = _window.hide();
+                    }
                 }
             }
         })
         .on_page_load(|webview, payload| {
             use tauri::webview::PageLoadEvent;
+            if webview.label() == "main" {
+                let event_label = match payload.event() {
+                    PageLoadEvent::Started => "started",
+                    PageLoadEvent::Finished => "finished",
+                };
+                if dev_startup_debug_enabled() {
+                    println!(
+                        "[TauriPageLoad] label={} event={} url={}",
+                        webview.label(),
+                        event_label,
+                        payload.url()
+                    );
+                    tracing::info!(
+                        label = webview.label(),
+                        event = event_label,
+                        url = %payload.url(),
+                        "[TauriPageLoad]"
+                    );
+                }
+            }
             if webview.label() == "main" && matches!(payload.event(), PageLoadEvent::Started) {
                 let app = webview.app_handle().clone();
                 match browser::inline::close_all_inline_webviews(app) {
@@ -829,13 +870,21 @@ pub fn run() {
                         }
                     }
                 }
-                // Keep the process alive when all windows are hidden (red traffic light hides, not destroys).
-                // Without this, Tauri exits the run loop when no visible windows remain.
+                // Release keeps the process alive when all windows are hidden.
+                // Debug Linux/Windows exits normally when the last window closes.
                 // code.is_none() means it's an automatic exit (last window closed), not an explicit exit(0).
-                tauri::RunEvent::ExitRequested { api, code, .. } => {
+                tauri::RunEvent::ExitRequested {
+                    api: _api, code, ..
+                } => {
+                    #[cfg(any(target_os = "macos", not(debug_assertions)))]
                     if code.is_none() {
-                        api.prevent_exit();
-                    } else {
+                        _api.prevent_exit();
+                        return;
+                    }
+
+                    if code.is_some()
+                        || cfg!(all(debug_assertions, not(target_os = "macos")))
+                    {
                         // Explicit exit — mark active orchestrator workflows as interrupted
                         agent_core::coordination::work_item_recovery::mark_all_interrupted_sync();
                         // Release computer-use lock if held

--- a/src/app/root/useFirstPaintSignal.ts
+++ b/src/app/root/useFirstPaintSignal.ts
@@ -21,6 +21,37 @@ import { useLayoutEffect, useRef } from "react";
 import { resetChunkReloadCount } from "@src/util/core/init/chunkReload";
 import { signalFirstPaintComplete } from "@src/util/core/init/deferredInit";
 
+function getStartupElapsedMs(): number | null {
+  const start = (
+    window as unknown as { __ORGII_STARTUP_TIMING_START__?: unknown }
+  ).__ORGII_STARTUP_TIMING_START__;
+  if (typeof start !== "number") {
+    return null;
+  }
+  return Math.round(performance.now() - start);
+}
+
+function isLocalDevOrigin(): boolean {
+  return (
+    window.location.protocol === "http:" &&
+    /^(localhost|127\.0\.0\.1)$/.test(window.location.hostname)
+  );
+}
+
+function emitFirstPaintMetric(): void {
+  if (!isLocalDevOrigin()) {
+    return;
+  }
+
+  void import("@tauri-apps/api/event")
+    .then(({ emit }) =>
+      emit("orgii-startup-first-paint", {
+        elapsedMs: getStartupElapsedMs(),
+      })
+    )
+    .catch(() => undefined);
+}
+
 export function useFirstPaintSignal(): void {
   const hasSignaledFirstPaint = useRef(false);
 
@@ -35,6 +66,7 @@ export function useFirstPaintSignal(): void {
 
         hasSignaledFirstPaint.current = true;
         signalFirstPaintComplete();
+        emitFirstPaintMetric();
 
         // The app committed its first paint — cancel the pre-bundle splash
         // watchdog (index.html) and clear the chunk-reload retry budget so a

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,6 +30,11 @@ module.exports = (env, argv) => {
     !isProduction && (isLightDev || process.env.FAST_DEV === "true");
   const useDevSourceMaps =
     !isProduction && !isLightDev && process.env.DEV_SOURCEMAPS !== "false";
+  const retryMainScriptLoad =
+    !isProduction &&
+    (process.env.ORGII_RETRY_MAIN_SCRIPT_LOAD === "true" ||
+      (process.env.ORGII_RETRY_MAIN_SCRIPT_LOAD !== "false" &&
+        process.platform === "linux"));
 
   // FAST_PROD=true: use esbuild for transpilation + minification in production.
   // Saves ~30-40s vs the SWC+Terser path. Trades some dead-code elimination
@@ -460,6 +465,11 @@ module.exports = (env, argv) => {
         template: "./public/index.html",
         chunks: ["main"],
         filename: "index.html",
+        // Linux WebKitGTK can internally fail a static <script src="/main.js">
+        // load even after the dev server is ready; a failed script is not
+        // retried, so Linux dev uses the retrying external loader below.
+        inject: retryMainScriptLoad ? false : "body",
+        retryMainScriptLoad,
       }),
       // NOTE: HotModuleReplacementPlugin is automatically added by webpack-dev-server when hot: true
       // ReactRefreshWebpackPlugin works with SWC's refresh: true option to enable
@@ -496,8 +506,10 @@ module.exports = (env, argv) => {
     devServer: {
       port: devServerPort,
       hot: !isLightDev,
-      // Light dev uses full page reloads to avoid HMR runtime overhead.
-      liveReload: isLightDev,
+      // Light dev avoids the webpack-dev-server browser client entirely.
+      // WebKitGTK can trip internal loader errors around the injected
+      // liveReload websocket path, and Tauri dev does not need it here.
+      liveReload: !isLightDev,
       historyApiFallback: true,
       // Disable static file watching to prevent full page reloads during HMR.
       // Default behavior watches public/ directory, which can race with HMR
@@ -506,16 +518,18 @@ module.exports = (env, argv) => {
         directory: path.resolve(__dirname, "public"),
         watch: false,
       },
-      client: {
-        overlay: false,
-        // Reconnect settings for better HMR recovery
-        reconnect: 5,
-        webSocketURL: {
-          hostname: "localhost",
-          pathname: "/ws",
-          port: devServerPort,
-        },
-      },
+      client: isLightDev
+        ? false
+        : {
+            overlay: false,
+            // Reconnect settings for better HMR recovery
+            reconnect: 5,
+            webSocketURL: {
+              hostname: "localhost",
+              pathname: "/ws",
+              port: devServerPort,
+            },
+          },
       open: false,
       headers: {
         "Cross-Origin-Embedder-Policy": "credentialless",


### PR DESCRIPTION
## Summary
- start the frontend dev server from the ORGII dev wrapper, wait for the initial webpack compile signal, and probe `/main.js` before launching Tauri for both `tauri:dev` and `tauri:dev:light`
- enable a Linux dev-only external retry loader for `/main.js` by default so WebKitGTK script-load failures can recover without inline script execution or CSP changes
- keep startup diagnostics local-dev/debug gated: detailed splash timings and `/main.js` probes only run on localhost dev origins, and Tauri first-paint logging only runs with `ORGII_DEV_STARTUP_DEBUG=true`
- in debug builds on Linux/Windows, closing the main window exits the dev app to avoid hidden stale processes; release behavior is unchanged and still hides/prevents exit

## Context
On Ubuntu/WebKitGTK, the WebView can report an internal WebKit loader failure for `/main.js` even when a later fetch of the same asset returns 200. Waiting for webpack readiness removes the early dev-server race, and the external retry loader handles the remaining WebKitGTK script-load flake without relaxing CSP.

## Test plan
- `node --check scripts/dev/tauri.js`
- `node --check scripts/dev/tauri-dev-processes.cjs`
- `node --check scripts/dev/webpack-server.js`
- `node --check webpack.config.js`
- `node --test scripts/dev/tauri-dev-processes.test.cjs scripts/dev/startup-watchdog.test.cjs scripts/dev/webpack-config-light.test.cjs`
- `pnpm exec prettier --check public/index.html webpack.config.js scripts/dev/tauri.js scripts/dev/tauri-dev-processes.cjs scripts/dev/tauri-dev-processes.test.cjs scripts/dev/startup-watchdog.test.cjs scripts/dev/webpack-config-light.test.cjs scripts/dev/webpack-server.js src/index.tsx src/app/root/useFirstPaintSignal.ts`
- `pnpm exec eslint src/index.tsx src/app/root/useFirstPaintSignal.ts --ext .ts,.tsx`
- `rustfmt --edition 2021 --check --config skip_children=true src-tauri/src/lib.rs`
- `cargo check`
- amend commit hook passed `lint-staged`, scoped TypeScript check, and scoped `cargo clippy`
- manually repeated `pnpm run tauri:dev:light` on Ubuntu with WebKit/software-rendering env flags