### PR TITLE
fix(browser): support URL bar text selection

### DIFF
--- a/src/hooks/keyboard/__tests__/useTauriSelectAllShortcut.test.ts
+++ b/src/hooks/keyboard/__tests__/useTauriSelectAllShortcut.test.ts
@@ -172,4 +172,41 @@ describe("handleSelectAllEvent — guard conditions", () => {
     handleSelectAllEvent(event as never);
     expect(event.preventDefault).not.toHaveBeenCalled();
   });
+
+  it("falls back to document.activeElement when the key event target is not editable", () => {
+    const activeElement = makeInputTarget();
+    const savedDocument = globalThis.document;
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: { activeElement },
+    });
+
+    try {
+      const event = makeEvent({ metaKey: true, key: "a", target: {} });
+      handleSelectAllEvent(event as never);
+
+      expect(activeElement.select).toHaveBeenCalledTimes(1);
+      expect(event.preventDefault).toHaveBeenCalledTimes(1);
+      expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(globalThis, "document", {
+        configurable: true,
+        value: savedDocument,
+      });
+    }
+  });
+
+  it("does not prevent default when the focused input cannot be selected", () => {
+    const target = makeInputTarget();
+    target.select.mockImplementation(() => {
+      throw new Error("selection unsupported");
+    });
+
+    const event = makeEvent({ metaKey: true, key: "a", target });
+    handleSelectAllEvent(event as never);
+
+    expect(target.select).toHaveBeenCalledTimes(1);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopPropagation).not.toHaveBeenCalled();
+  });
 });

--- a/src/hooks/keyboard/useTauriSelectAllShortcut.ts
+++ b/src/hooks/keyboard/useTauriSelectAllShortcut.ts
@@ -70,6 +70,13 @@ function isEditableElement(
   );
 }
 
+function getEditableTarget(
+  target: EventTarget | null | undefined
+): EditableElement | null {
+  const normalizedTarget = target ?? null;
+  return isEditableElement(normalizedTarget) ? normalizedTarget : null;
+}
+
 /**
  * Returns a stable keydown handler that implements ⌘A / Ctrl+A
  * "select all text in the focused control" for Tauri webviews.
@@ -92,12 +99,21 @@ export function handleSelectAllEvent(event: SelectAllEventLike): void {
   if (event.shiftKey || event.altKey) return;
   if (event.key.toLowerCase() !== "a") return;
 
-  const target = event.target;
-  if (!isEditableElement(target)) return;
+  const target =
+    getEditableTarget(event.target) ??
+    getEditableTarget(
+      typeof document === "undefined" ? null : document.activeElement
+    );
+  if (!target) return;
+
+  try {
+    target.select();
+  } catch {
+    return;
+  }
 
   event.preventDefault();
   event.stopPropagation();
-  target.select();
 }
 
 /**
@@ -122,11 +138,10 @@ export function installGlobalTauriSelectAllShortcut(): void {
     (event) => {
       handleSelectAllEvent(event);
     },
-    // Bubble phase so React's root listener (which runs component-level
-    // `onKeyDown` handlers) gets first crack at the event. If a component
-    // already handled ⌘A and called `preventDefault`, our fallback bails
-    // via the `defaultPrevented` check.
-    false
+    // Capture phase so this fallback can run before parent capture shortcuts.
+    // It only claims Ctrl/Cmd+A for native text controls, so editors such as
+    // CodeMirror and xterm keep their own selection behavior.
+    true
   );
 }
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -416,6 +416,11 @@ select,
   user-select: text !important;
   -webkit-touch-callout: default;
 }
+
+[data-browser-url-bar-input]::selection {
+  background: color-mix(in srgb, var(--color-primary-6) 82%, black) !important;
+  color: white !important;
+}
 html {
   overscroll-behavior-x: none;
   background: var(--color-bg-2);

--- a/src/modules/WorkStation/AppShell/WorkstationTabHeader.tsx
+++ b/src/modules/WorkStation/AppShell/WorkstationTabHeader.tsx
@@ -45,7 +45,6 @@ const WorkstationTabHeader: React.FC = memo(() => {
     <div
       className="flex h-10 shrink-0 items-center gap-2 border-b border-border-2 pl-1.5 pr-2"
       data-tauri-drag-region
-      style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
     >
       <NoDragRegion className="flex shrink-0 items-center gap-px">
         <WorkStationSidebarToggleButton

--- a/src/modules/WorkStation/Browser/Panels/BrowserMainPane/components/WebUrlBar/index.tsx
+++ b/src/modules/WorkStation/Browser/Panels/BrowserMainPane/components/WebUrlBar/index.tsx
@@ -25,6 +25,7 @@ import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
 import { FaviconIcon } from "@src/components/FaviconIcon";
+import { useTauriSelectAllShortcut } from "@src/hooks/keyboard";
 import {
   type WorkstationTabHeaderHost,
   usePublishWorkstationTabHeader,
@@ -90,6 +91,15 @@ export interface WebUrlBarProps {
 /** After pointer leaves the URL toolbar, blur the input if still focused (inline webview does not take focus from the address field). */
 const AUTO_BLUR_MS_AFTER_LEAVE = 2000;
 const BROWSER_URL_BAR_FOCUS_EVENT = "browser-url-bar-focus";
+const NO_DRAG_STYLE = { WebkitAppRegion: "no-drag" } as React.CSSProperties;
+const TEXT_DRAG_THRESHOLD_PX = 4;
+
+interface UrlInputPointerState {
+  startX: number;
+  startY: number;
+  moved: boolean;
+  wasFocused: boolean;
+}
 
 export function focusBrowserUrlBar(): void {
   requestAnimationFrame(() => {
@@ -128,10 +138,13 @@ export const WebUrlBar: React.FC<WebUrlBarProps> = memo(
   }) => {
     const { t } = useTranslation();
     const [inputValue, setInputValue] = useState(url);
-    const [isFocused, setIsFocused] = useState(false);
     const lastUrlRef = useRef(url);
     const inputRef = useRef<HTMLInputElement>(null);
     const autoBlurTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const isFocusedRef = useRef(false);
+    const pointerStateRef = useRef<UrlInputPointerState | null>(null);
+    const pointerFocusRef = useRef(false);
+    const tauriSelectAll = useTauriSelectAllShortcut();
 
     const clearAutoBlurTimer = useCallback(() => {
       if (autoBlurTimerRef.current !== null) {
@@ -150,7 +163,6 @@ export const WebUrlBar: React.FC<WebUrlBarProps> = memo(
 
     const focusAndSelectInput = useCallback(() => {
       clearAutoBlurTimer();
-      setIsFocused(true);
       const input = inputRef.current;
       if (!input) return;
       input.focus();
@@ -175,27 +187,75 @@ export const WebUrlBar: React.FC<WebUrlBarProps> = memo(
     useEffect(() => {
       if (url !== lastUrlRef.current) {
         lastUrlRef.current = url;
-        if (!isFocused) {
+        if (!isFocusedRef.current) {
           // Defer setState to avoid cascading renders within effect
           queueMicrotask(() => {
             setInputValue(url);
           });
         }
       }
-    }, [url, isFocused]);
+    }, [url]);
 
-    // Handle focus - select all text for easy replacement
+    // Handle focus - select all text for keyboard/programmatic focus. Pointer
+    // focus is handled on mouseup so drag-select can keep the native selection.
     const handleFocus = useCallback(() => {
       clearAutoBlurTimer();
-      setIsFocused(true);
+      isFocusedRef.current = true;
+      if (pointerFocusRef.current) return;
       selectInputText();
     }, [clearAutoBlurTimer, selectInputText]);
 
     // Handle blur - keep user's changes
     const handleBlur = useCallback(() => {
       clearAutoBlurTimer();
-      setIsFocused(false);
+      isFocusedRef.current = false;
+      pointerFocusRef.current = false;
+      pointerStateRef.current = null;
     }, [clearAutoBlurTimer]);
+
+    const handleInputMouseDown = useCallback(
+      (event: React.MouseEvent<HTMLInputElement>) => {
+        event.stopPropagation();
+        event.nativeEvent.stopImmediatePropagation();
+        clearAutoBlurTimer();
+        pointerFocusRef.current = true;
+        pointerStateRef.current = {
+          startX: event.clientX,
+          startY: event.clientY,
+          moved: false,
+          wasFocused: document.activeElement === event.currentTarget,
+        };
+      },
+      [clearAutoBlurTimer]
+    );
+
+    const handleInputMouseMove = useCallback(
+      (event: React.MouseEvent<HTMLInputElement>) => {
+        const pointerState = pointerStateRef.current;
+        if (!pointerState || pointerState.moved) return;
+
+        const deltaX = Math.abs(event.clientX - pointerState.startX);
+        const deltaY = Math.abs(event.clientY - pointerState.startY);
+        if (
+          deltaX > TEXT_DRAG_THRESHOLD_PX ||
+          deltaY > TEXT_DRAG_THRESHOLD_PX
+        ) {
+          pointerState.moved = true;
+        }
+      },
+      []
+    );
+
+    const handleInputMouseUp = useCallback(() => {
+      const pointerState = pointerStateRef.current;
+      pointerStateRef.current = null;
+      pointerFocusRef.current = false;
+
+      if (!pointerState) return;
+      if (!pointerState.wasFocused && !pointerState.moved) {
+        selectInputText();
+      }
+    }, [selectInputText]);
 
     const scheduleBlurAfterLeaveToolbar = useCallback(() => {
       clearAutoBlurTimer();
@@ -209,9 +269,9 @@ export const WebUrlBar: React.FC<WebUrlBarProps> = memo(
     }, [clearAutoBlurTimer]);
 
     const handleToolbarMouseLeave = useCallback(() => {
-      if (!isFocused) return;
+      if (!isFocusedRef.current) return;
       scheduleBlurAfterLeaveToolbar();
-    }, [isFocused, scheduleBlurAfterLeaveToolbar]);
+    }, [scheduleBlurAfterLeaveToolbar]);
 
     const handleToolbarMouseEnter = useCallback(() => {
       clearAutoBlurTimer();
@@ -238,19 +298,9 @@ export const WebUrlBar: React.FC<WebUrlBarProps> = memo(
           inputRef.current?.blur();
         }
 
-        // Cmd/Ctrl+A: select all text in the URL bar. Tauri's webview eats
-        // ⌘A at the native level (see `useTauriSelectAllShortcut`), so a
-        // plain `target.select()` is required. The URL bar additionally
-        // needs to clear the auto-blur timer and force the focused state so
-        // the selection sticks, so it owns this handler instead of using
-        // the shared hook.
-        if (
-          (event.metaKey || event.ctrlKey) &&
-          event.key.toLowerCase() === "a"
-        ) {
-          event.preventDefault();
-          event.stopPropagation();
-          focusAndSelectInput();
+        tauriSelectAll(event);
+        if (event.defaultPrevented) {
+          clearAutoBlurTimer();
           return;
         }
 
@@ -260,12 +310,11 @@ export const WebUrlBar: React.FC<WebUrlBarProps> = memo(
           event.stopPropagation();
         }
       },
-      [focusAndSelectInput, handleNavigate, url]
+      [clearAutoBlurTimer, handleNavigate, tauriSelectAll, url]
     );
 
-    const inputContainerClass = isFocused
-      ? "relative flex h-7 min-w-0 flex-1 cursor-text items-center rounded-lg border border-primary-6 bg-fill-2 shadow-[0_0_0_2px_color-mix(in_srgb,var(--color-primary-6)_15%,transparent)] transition-[border-color,box-shadow,background-color] duration-150"
-      : "relative flex h-7 min-w-0 flex-1 cursor-text items-center rounded-lg border border-transparent bg-transparent transition-[border-color,box-shadow,background-color] duration-150 hover:border-border-3 hover:bg-fill-2";
+    const inputContainerClass =
+      "relative flex h-7 min-w-0 flex-1 cursor-text items-center rounded-lg border border-transparent bg-transparent transition-[border-color,box-shadow,background-color] duration-150 hover:border-border-3 hover:bg-fill-2 focus-within:border-primary-6 focus-within:bg-fill-2 focus-within:shadow-[0_0_0_2px_color-mix(in_srgb,var(--color-primary-6)_15%,transparent)]";
     const reloadControlLabel = isLoading
       ? t("common:actions.stop")
       : t("common:actions.reload");
@@ -273,6 +322,9 @@ export const WebUrlBar: React.FC<WebUrlBarProps> = memo(
     const headerContent = (
       <div
         className="flex h-full min-w-0 flex-1 items-center gap-1.5"
+        data-tauri-drag-region="false"
+        style={NO_DRAG_STYLE}
+        onMouseUp={handleInputMouseUp}
         onMouseLeave={handleToolbarMouseLeave}
         onMouseEnter={handleToolbarMouseEnter}
       >
@@ -324,32 +376,17 @@ export const WebUrlBar: React.FC<WebUrlBarProps> = memo(
         {/* URL Input Container */}
         <div
           className={inputContainerClass}
+          data-tauri-drag-region="false"
+          style={NO_DRAG_STYLE}
           onClick={() => {
-            if (!isFocused) {
+            if (!isFocusedRef.current) {
               inputRef.current?.focus();
             }
           }}
         >
-          {/* Centered display when not focused and empty */}
-          {!isFocused && !inputValue && (
-            <div className="absolute inset-0 flex items-center justify-center gap-2 px-3">
-              {isLoading ? (
-                <Loader2
-                  size={14}
-                  className="shrink-0 animate-spin text-text-3"
-                />
-              ) : (
-                <Search size={14} className="shrink-0 text-text-3" />
-              )}
-              <span className="text-[14px] text-text-3">
-                {t("placeholders.enterUrlOrSearch")}
-              </span>
-            </div>
-          )}
-
-          {/* Centered display when not focused with content */}
-          {!isFocused && inputValue && (
-            <div className="absolute inset-0 flex items-center justify-center gap-2 px-3">
+          {/* Icon on left */}
+          <div className="pointer-events-none absolute left-3 flex items-center">
+            {inputValue ? (
               <FaviconIcon
                 url={inputValue}
                 isIncognito={false}
@@ -357,38 +394,36 @@ export const WebUrlBar: React.FC<WebUrlBarProps> = memo(
                 size={16}
                 fallbackColor="text-text-3"
               />
-              <span className="max-w-[400px] truncate text-[14px] text-text-1">
-                {inputValue}
-              </span>
-            </div>
-          )}
-
-          {/* Icon on left when focused */}
-          {isFocused && (
-            <div className="absolute left-3 flex items-center">
-              <FaviconIcon
-                url={inputValue}
-                isIncognito={false}
-                isLoading={isLoading}
-                size={16}
-                fallbackColor="text-text-3"
+            ) : isLoading ? (
+              <Loader2
+                size={14}
+                className="shrink-0 animate-spin text-text-3"
               />
-            </div>
-          )}
+            ) : (
+              <Search size={14} className="shrink-0 text-text-3" />
+            )}
+          </div>
 
-          {/* Input - always rendered but visually hidden when not focused */}
+          {/* Input - keep real text selectable in both focused and unfocused states. */}
           <input
             ref={inputRef}
             type="text"
             value={inputValue}
+            aria-label="Browser URL"
+            data-browser-url-bar-input
+            data-testid="browser-url-bar-input"
+            data-tauri-drag-region="false"
+            draggable={false}
             onChange={(event) => setInputValue(event.target.value)}
             onFocus={handleFocus}
             onBlur={handleBlur}
             onKeyDown={handleKeyDown}
+            onMouseDown={handleInputMouseDown}
+            onMouseMove={handleInputMouseMove}
+            onMouseUp={handleInputMouseUp}
             placeholder={t("placeholders.enterUrlOrSearch")}
-            className={`h-7 min-w-0 flex-1 border-none bg-transparent text-[14px] text-text-1 outline-none placeholder:text-text-3 ${
-              isFocused ? "pl-9 pr-3" : "opacity-0"
-            }`}
+            className="relative z-10 h-7 min-w-0 flex-1 select-text border-none bg-transparent pl-9 pr-3 text-[14px] text-text-1 outline-none placeholder:text-text-3"
+            style={NO_DRAG_STYLE}
             autoComplete="off"
             autoCorrect="off"
             autoCapitalize="off"

--- a/src/modules/WorkStation/shared/NoDragRegion.tsx
+++ b/src/modules/WorkStation/shared/NoDragRegion.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from "react";
 
-interface NoDragRegionProps {
+interface NoDragRegionProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;
   className?: string;
 }
@@ -8,8 +8,14 @@ interface NoDragRegionProps {
 const NO_DRAG_STYLE = { WebkitAppRegion: "no-drag" } as React.CSSProperties;
 
 export const NoDragRegion = forwardRef<HTMLDivElement, NoDragRegionProps>(
-  ({ children, className }, ref) => (
-    <div ref={ref} className={className} style={NO_DRAG_STYLE}>
+  ({ children, className, style, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={className}
+      {...props}
+      data-tauri-drag-region="false"
+      style={{ ...style, ...NO_DRAG_STYLE }}
+    >
       {children}
     </div>
   )

--- a/src/modules/WorkStation/shared/SessionReplay/SimulatorWorkstationTabHeader.tsx
+++ b/src/modules/WorkStation/shared/SessionReplay/SimulatorWorkstationTabHeader.tsx
@@ -51,7 +51,6 @@ const SimulatorWorkstationTabHeaderComponent: React.FC<
     <div
       className="flex h-10 shrink-0 items-center gap-2 border-b border-border-2 pl-1.5 pr-2"
       data-tauri-drag-region
-      style={{ WebkitAppRegion: "drag" } as React.CSSProperties}
     >
       <NoDragRegion className="flex w-7 shrink-0 items-center justify-center">
         {showSidebarToggle ? (

--- a/src/modules/WorkStation/shared/WorkstationTabHeaderSlotsView.tsx
+++ b/src/modules/WorkStation/shared/WorkstationTabHeaderSlotsView.tsx
@@ -2,6 +2,8 @@ import React, { memo } from "react";
 
 import type { WorkstationTabHeaderSlots } from "@src/store/workstation";
 
+import { NoDragRegion } from "./NoDragRegion";
+
 interface WorkstationTabHeaderSlotsViewProps {
   slots: WorkstationTabHeaderSlots | null;
 }
@@ -11,13 +13,17 @@ export const WorkstationTabHeaderSlotsView: React.FC<WorkstationTabHeaderSlotsVi
     return (
       <div className="flex min-w-0 flex-1 items-center">
         {slots?.leading && (
-          <div className="flex shrink-0 items-center">{slots.leading}</div>
+          <NoDragRegion className="flex shrink-0 items-center">
+            {slots.leading}
+          </NoDragRegion>
         )}
-        <div className="flex min-w-0 flex-1 items-center">{slots?.content}</div>
+        <NoDragRegion className="flex min-w-0 flex-1 items-center">
+          {slots?.content}
+        </NoDragRegion>
         {slots?.trailing && (
-          <div className="flex shrink-0 items-center gap-px">
+          <NoDragRegion className="flex shrink-0 items-center gap-px">
             {slots.trailing}
-          </div>
+          </NoDragRegion>
         )}
       </div>
     );


### PR DESCRIPTION
## Summary

Fixes #131.

This PR restores normal text selection behavior in the built-in browser URL bar:

- Ctrl+A / Cmd+A now selects the URL text.
- Dragging across the URL text now produces a visible text selection.
- The browser address field now behaves like a real browser address bar instead of an app header drag region.

## Root Cause

The browser URL bar is rendered into the shared Workstation tab header, not as a normal inline browser toolbar. That header was marked as a draggable Tauri/window chrome region.

There were multiple issues interacting with each other:

1. The URL bar previously showed a fake centered display layer while the real input was visually hidden when unfocused. Dragging the visible URL text therefore did not drag-select the actual input value.

2. The Workstation header used `WebkitAppRegion: "drag"`, which can override child input interaction on Windows/WebView2 and cause text drag gestures to be treated as window dragging.

3. Ctrl+A fallback handling depended on the keyboard event target being the input. In some desktop/webview paths, the focused element can still be the input while the event target is not.

4. The global text selection color is intentionally subtle, so URL bar selection could also appear invisible.

## What Changed

### Browser URL Bar

Updated `WebUrlBar` so the real `<input>` is always visible and selectable.

- Removed the fake centered display overlay.
- Kept the real input rendered and selectable in focused and unfocused states.
- Added pointer tracking so:
  - a normal click on an unfocused URL bar selects all text
  - an actual drag preserves native text selection
- Stopped URL input `mousedown` propagation, including the native event, so the header/window drag handler cannot consume text drag selection.
- Added URL bar test/debug attributes:
  - `data-browser-url-bar-input`
  - `data-testid="browser-url-bar-input"`

### Header Drag Region

Updated Workstation header chrome to avoid applying CSS app-region dragging over the URL bar.

- Removed `WebkitAppRegion: "drag"` from the shared Workstation tab header.
- Removed the same CSS app-region drag from the simulator Workstation tab header.
- Kept `data-tauri-drag-region` so actual draggable header space still works through Tauri.
- Updated shared `NoDragRegion` to consistently apply:
  - `WebkitAppRegion: "no-drag"`
  - `data-tauri-drag-region="false"`

### Ctrl+A / Cmd+A

Updated `useTauriSelectAllShortcut`:

- The global fallback now runs in capture phase so parent capture handlers do not consume Ctrl+A first.
- Selection falls back to `document.activeElement` when `event.target` is not the text input but the input is focused.
- `select()` failures are safely ignored without swallowing default browser behavior.

### Selection Visibility

Added URL-bar-specific `::selection` styling so selected URL text is visibly highlighted instead of blending into the app-wide subtle selection color.

## Files Changed

- `src/modules/WorkStation/Browser/Panels/BrowserMainPane/components/WebUrlBar/index.tsx`
- `src/modules/WorkStation/AppShell/WorkstationTabHeader.tsx`
- `src/modules/WorkStation/shared/SessionReplay/SimulatorWorkstationTabHeader.tsx`
- `src/modules/WorkStation/shared/NoDragRegion.tsx`
- `src/modules/WorkStation/shared/WorkstationTabHeaderSlotsView.tsx`
- `src/hooks/keyboard/useTauriSelectAllShortcut.ts`
- `src/hooks/keyboard/__tests__/useTauriSelectAllShortcut.test.ts`
- `src/index.scss`

## Verification

Passed:

- `pnpm eslint src/hooks/keyboard/useTauriSelectAllShortcut.ts src/hooks/keyboard/__tests__/useTauriSelectAllShortcut.test.ts src/modules/WorkStation/Browser/Panels/BrowserMainPane/components/WebUrlBar/index.tsx src/modules/WorkStation/AppShell/WorkstationTabHeader.tsx src/modules/WorkStation/shared/NoDragRegion.tsx src/modules/WorkStation/shared/WorkstationTabHeaderSlotsView.tsx src/modules/WorkStation/shared/SessionReplay/SimulatorWorkstationTabHeader.tsx`
- `pnpm vitest run src/hooks/keyboard/__tests__/useTauriSelectAllShortcut.test.ts`
- `git diff --check`

Manual verification:

- Built-in browser URL bar supports Ctrl+A / Cmd+A select-all.
- Built-in browser URL bar supports drag-selecting URL text.
- Selection highlight is visible.

Known unrelated issue:

- `pnpm tsc --noEmit --pretty false` still fails on existing repository type errors unrelated to this PR, including files such as:
  - `src/api/tauri/session/__tests__/session.test.ts`
  - `src/components/FileTreePreview/FileTreeHoverPreview.tsx`
  - `src/engines/ChatPanel/blocks/MessageReferenceCards.tsx`
  - `src/engines/ChatPanel/hooks/useWorkspaceChat/useSessionActions.ts`
  - `src/modules/WorkStation/CodeEditor/SessionReplay/orgtrackArtifacts.ts`
  - `src/services/git/operations/remoteOps.ts`