### PR TITLE
fix(chat-history): expand scrollable chat hit area

### DIFF
--- a/src/engines/ChatPanel/ChatHistory/index.tsx
+++ b/src/engines/ChatPanel/ChatHistory/index.tsx
@@ -1053,9 +1053,7 @@ const ChatHistory: React.FC<ChatHistoryProps> = ({
               ref={scrollAreaRef}
               className="absolute inset-0 overflow-hidden"
             >
-              <div
-                className={`mx-auto h-full w-full ${DETAIL_PANEL_TOKENS.contentMaxWidth}`}
-              >
+              <div className="h-full w-full">
                 {optimizedChatHistory.length > 0 ? (
                   <>
                     <PlanningIndicatorBridge


### PR DESCRIPTION
## Summary
 
Fixes #139
 
Expands the chat history scrollable surface so the middle content panel can be scrolled from the side areas, not only from the centered message column.
 
## Root Cause
 
The chat history scroll area contained an extra inner wrapper using the shared detail-panel max-width token. That wrapper visually centered the entire scrollable body and limited the active scroll/hit area to the same max-width as the chat content.
 
As a result, the side areas inside the middle panel looked like part of the chat area but did not behave like the scrollable chat surface.
 
## Fix
 
Removed the redundant max-width wrapper around the chat virtualized body.
 
The outer scroll area now fills the available middle panel width, while the existing row/message renderers continue to keep message content visually centered.
 
## Verification
 
- Ran `pnpm run lint`
- Ran `pnpm run check:circular`
- Ran `git diff --check`
- Confirmed manually that the chat history can now be scrolled from the side areas of the middle content panel