### PR TITLE
fix(opencode): support OpenCode Go provider

### DIFF
--- a/src-tauri/crates/agent-core/src/core/providers/factory.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/factory.rs
@@ -301,12 +301,12 @@ fn spec_for_model_type(model_type: &ModelType) -> Option<&'static ProviderSpec> 
         ModelType::ZenmuxApi => provider_id::ZENMUX,
         ModelType::VllmApi => provider_id::VLLM,
         ModelType::AzureOpenaiApi => provider_id::AZURE_OPENAI,
+        ModelType::OpenCode => provider_id::OPENCODE,
         ModelType::CursorCli
         | ModelType::ClaudeCode
         | ModelType::Copilot
         | ModelType::Kiro
         | ModelType::KimiCli
-        | ModelType::OpenCode
         | ModelType::OrgiiOrchestrator => return None,
     };
     registry::find_by_name(provider_name)
@@ -939,6 +939,7 @@ mod tests {
     const ALL_PROVIDER_IDS: &[&str] = &[
         provider_id::OPENROUTER,
         provider_id::ZENMUX,
+        provider_id::OPENCODE,
         provider_id::ANTHROPIC,
         provider_id::OPENAI,
         provider_id::DEEPSEEK,
@@ -978,6 +979,7 @@ mod tests {
             provider_id::MOONSHOT,
             provider_id::OPENROUTER,
             provider_id::ZENMUX,
+            provider_id::OPENCODE,
             provider_id::VLLM,
             provider_id::AZURE_OPENAI,
         ];
@@ -995,6 +997,12 @@ mod tests {
         assert!(spec_for_model_type(&ModelType::ClaudeCode).is_none());
         assert!(spec_for_model_type(&ModelType::KimiCli).is_none());
         assert!(spec_for_model_type(&ModelType::Codex).is_some());
+        assert_eq!(
+            spec_for_model_type(&ModelType::OpenCode)
+                .expect("OpenCode Go can power Rust-native sessions")
+                .name,
+            provider_id::OPENCODE
+        );
         assert_eq!(
             spec_for_model_type(&ModelType::GeminiCli)
                 .expect("Gemini CLI can power Rust-native sessions")

--- a/src-tauri/crates/agent-core/src/core/providers/registry.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/registry.rs
@@ -20,6 +20,7 @@ pub mod provider_id {
     // Aggregators
     pub const OPENROUTER: &str = "openrouter";
     pub const ZENMUX: &str = "zenmux";
+    pub const OPENCODE: &str = "opencode";
 
     // Standard providers
     pub const ANTHROPIC: &str = "anthropic";
@@ -84,6 +85,17 @@ pub static PROVIDERS: &[ProviderSpec] = &[
         default_anthropic_api_base: Some("https://zenmux.ai/api/anthropic"),
         is_local: false,
         env_key: Some("ZENMUX_API_KEY"),
+    },
+    ProviderSpec {
+        name: provider_id::OPENCODE,
+        display_name: "OpenCode",
+        keywords: &[],
+        litellm_prefix: None,
+        skip_prefixes: &[],
+        default_api_base: Some("https://opencode.ai/zen/go/v1"),
+        default_anthropic_api_base: None,
+        is_local: false,
+        env_key: Some("OPENCODE_API_KEY"),
     },
     // ===== Standard Providers =====
     ProviderSpec {

--- a/src-tauri/crates/key-vault/src/auto_detect/mod.rs
+++ b/src-tauri/crates/key-vault/src/auto_detect/mod.rs
@@ -12,6 +12,7 @@ mod cursor;
 mod gemini;
 pub(crate) mod helpers;
 mod kiro;
+mod opencode;
 
 use serde::{Deserialize, Serialize};
 
@@ -83,6 +84,7 @@ pub async fn auto_detect_key(agent_type: &str) -> AutoDetectResult {
         ModelType::GeminiCli => gemini::detect_gemini_keys().await,
         ModelType::Copilot => copilot::detect_copilot_keys().await,
         ModelType::Kiro => kiro::detect_kiro_keys().await,
+        ModelType::OpenCode => opencode::detect_opencode_keys().await,
         // API key providers don't have auto-detect (keys are entered manually)
         _ => vec![],
     };

--- a/src-tauri/crates/key-vault/src/auto_detect/opencode.rs
+++ b/src-tauri/crates/key-vault/src/auto_detect/opencode.rs
@@ -1,0 +1,169 @@
+use std::env;
+use std::fs;
+
+use serde::Deserialize;
+
+use super::helpers::{create_detected_key, get_home_dir};
+use super::DetectedKey;
+use crate::commands::validate_opencode_key;
+
+const OPENCODE_ZEN_PROVIDER_ID: &str = "opencode";
+const OPENCODE_GO_PROVIDER_ID: &str = "opencode-go";
+const OPENCODE_ZEN_BASE_URL: &str = "https://opencode.ai/zen/v1";
+const OPENCODE_GO_BASE_URL: &str = "https://opencode.ai/zen/go/v1";
+
+#[derive(Debug, Deserialize)]
+struct OpenCodeAuthEntry {
+    #[serde(rename = "type")]
+    auth_type: String,
+    key: Option<String>,
+}
+
+pub(super) async fn detect_opencode_keys() -> Vec<DetectedKey> {
+    let mut keys = vec![];
+
+    if let Some(home) = get_home_dir() {
+        keys.extend(read_opencode_auth_config(&home.join(".local/share/opencode/auth.json")).await);
+    }
+
+    for (env_name, provider_id, base_url) in [
+        (
+            "OPENCODE_API_KEY",
+            OPENCODE_ZEN_PROVIDER_ID,
+            OPENCODE_ZEN_BASE_URL,
+        ),
+        (
+            "OPENCODE_GO_API_KEY",
+            OPENCODE_GO_PROVIDER_ID,
+            OPENCODE_GO_BASE_URL,
+        ),
+    ] {
+        if let Ok(api_key) = env::var(env_name) {
+            if api_key.is_empty()
+                || keys
+                    .iter()
+                    .any(|key| key.api_key.as_ref() == Some(&api_key))
+            {
+                continue;
+            }
+
+            let mut cred = create_detected_key(
+                &format!("env_{provider_id}"),
+                &format!("Environment Variable ({env_name})"),
+                "api_key",
+            );
+            cred.api_key = Some(api_key.clone());
+            cred.base_url = Some(base_url.to_string());
+
+            let validation = validate_opencode_key(&api_key, Some(base_url)).await;
+            cred.validated = Some(validation.valid);
+            cred.validation_message = Some(validation.message);
+            cred.available_models = Some(validation.models_available);
+
+            keys.push(cred);
+        }
+    }
+
+    keys
+}
+
+async fn read_opencode_auth_config(path: &std::path::Path) -> Vec<DetectedKey> {
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(_) => return vec![],
+    };
+
+    let entries: std::collections::HashMap<String, OpenCodeAuthEntry> =
+        match serde_json::from_str(&content) {
+            Ok(entries) => entries,
+            Err(_) => return vec![],
+        };
+
+    let mut keys = vec![];
+    for (provider_id, entry) in entries {
+        if entry.auth_type != "api" {
+            continue;
+        }
+        let Some(api_key) = entry.key.filter(|key| !key.is_empty()) else {
+            continue;
+        };
+        let Some(base_url) = opencode_base_url(&provider_id) else {
+            continue;
+        };
+
+        let mut cred = create_detected_key(
+            &format!("opencode_{provider_id}"),
+            &format!("OpenCode {}", opencode_provider_label(&provider_id)),
+            "api_key",
+        );
+        cred.api_key = Some(api_key.clone());
+        cred.base_url = Some(base_url.to_string());
+
+        let validation = validate_opencode_key(&api_key, Some(base_url)).await;
+        cred.validated = Some(validation.valid);
+        cred.validation_message = Some(validation.message);
+        cred.available_models = Some(validation.models_available);
+
+        keys.push(cred);
+    }
+
+    keys
+}
+
+fn opencode_base_url(provider_id: &str) -> Option<&'static str> {
+    match provider_id {
+        OPENCODE_ZEN_PROVIDER_ID => Some(OPENCODE_ZEN_BASE_URL),
+        OPENCODE_GO_PROVIDER_ID => Some(OPENCODE_GO_BASE_URL),
+        _ => None,
+    }
+}
+
+fn opencode_provider_label(provider_id: &str) -> &'static str {
+    match provider_id {
+        OPENCODE_GO_PROVIDER_ID => "Go",
+        _ => "Zen",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::install_crypto_provider_for_tests;
+
+    #[tokio::test]
+    async fn read_opencode_auth_config_detects_go_key() {
+        install_crypto_provider_for_tests();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth.json");
+        std::fs::write(
+            &path,
+            r#"{"opencode-go":{"type":"api","key":"opencode-test-key"}}"#,
+        )
+        .unwrap();
+
+        let keys = read_opencode_auth_config(&path).await;
+
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].id, "opencode_opencode-go");
+        assert_eq!(keys[0].name, "OpenCode Go");
+        assert_eq!(keys[0].auth_method, "api_key");
+        assert_eq!(keys[0].api_key.as_deref(), Some("opencode-test-key"));
+        assert_eq!(keys[0].base_url.as_deref(), Some(OPENCODE_GO_BASE_URL));
+    }
+
+    #[tokio::test]
+    async fn read_opencode_auth_config_ignores_unknown_provider() {
+        install_crypto_provider_for_tests();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth.json");
+        std::fs::write(
+            &path,
+            r#"{"unknown":{"type":"api","key":"opencode-test-key"}}"#,
+        )
+        .unwrap();
+
+        let keys = read_opencode_auth_config(&path).await;
+
+        assert!(keys.is_empty());
+    }
+}

--- a/src-tauri/crates/key-vault/src/commands/validate.rs
+++ b/src-tauri/crates/key-vault/src/commands/validate.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::types::ValidationResult;
+
 use crate::providers::anthropic::AnthropicValidator;
 use crate::providers::azure_openai::AzureOpenAIValidator;
 use crate::providers::codex::CodexValidator;
@@ -8,7 +10,6 @@ use crate::providers::cursor::CursorValidator;
 use crate::providers::google::GoogleValidator;
 use crate::providers::kiro::KiroValidator;
 use crate::providers::openai::OpenAIValidator;
-use crate::types::ValidationResult;
 
 #[derive(Debug, Serialize)]
 pub struct TestModelResult {
@@ -31,6 +32,17 @@ struct ClaudeCodeOauthModelInfo {
 pub struct CodexOauthListModelsRequest {
     pub access_token: String,
     pub id_token: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenCodeModelsResponse {
+    #[serde(default)]
+    data: Vec<OpenCodeModelInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenCodeModelInfo {
+    id: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -65,6 +77,8 @@ use crate::provider_config::get_provider_config;
 const CLAUDE_CODE_OAUTH_MODELS_URL: &str = "https://api.anthropic.com/v1/models";
 const CLAUDE_CODE_OAUTH_BETA: &str = "oauth-2025-04-20";
 const CLAUDE_CODE_OAUTH_USER_AGENT: &str = "claude-cli/2.1.78 (orgii, cli)";
+const OPENCODE_ZEN_BASE_URL: &str = "https://opencode.ai/zen/v1";
+const OPENCODE_GO_BASE_URL: &str = "https://opencode.ai/zen/go/v1";
 
 const GEMINI_OAUTH_MODELS_URL: &str = "https://generativelanguage.googleapis.com/v1beta/models";
 
@@ -89,6 +103,49 @@ fn default_anthropic_base_url_for_provider(agent_type: &str) -> Option<String> {
         "zenmux_api" => Some("https://zenmux.ai/api/anthropic".to_string()),
         _ => None,
     }
+}
+
+/// Validate an OpenCode Zen/Go key by listing models without issuing a completion request.
+pub async fn validate_opencode_key(api_key: &str, base_url: Option<&str>) -> ValidationResult {
+    if api_key.is_empty() {
+        return ValidationResult::failure("No API key provided");
+    }
+
+    let result = fetch_opencode_models(api_key, base_url.unwrap_or(OPENCODE_GO_BASE_URL)).await;
+    match result {
+        Ok(models) => ValidationResult::success("API key valid").with_models(models),
+        Err(err) if err == "Invalid API key" || base_url.is_some() => {
+            ValidationResult::failure(&err)
+        }
+        Err(_) => match fetch_opencode_models(api_key, OPENCODE_ZEN_BASE_URL).await {
+            Ok(models) => ValidationResult::success("API key valid").with_models(models),
+            Err(err) => ValidationResult::failure(&err),
+        },
+    }
+}
+
+async fn fetch_opencode_models(api_key: &str, base_url: &str) -> Result<Vec<String>, String> {
+    let endpoint = format!("{}/models", base_url.trim_end_matches('/'));
+    let response = reqwest::Client::new()
+        .get(endpoint)
+        .header("Authorization", format!("Bearer {api_key}"))
+        .timeout(std::time::Duration::from_secs(15))
+        .send()
+        .await
+        .map_err(|err| format!("Request failed: {err}"))?;
+
+    if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+        return Err("Invalid API key".to_string());
+    }
+    if !response.status().is_success() {
+        return Err(format!("HTTP {}", response.status().as_u16()));
+    }
+
+    let models: OpenCodeModelsResponse = response
+        .json()
+        .await
+        .map_err(|err| format!("Failed to parse response: {err}"))?;
+    Ok(models.data.into_iter().map(|model| model.id).collect())
 }
 
 /// Validate a key for a given agent type (shared by Tauri and headless tools).
@@ -150,6 +207,8 @@ pub async fn run_validate_key(
             Ok(validator.validate(&api_key).await)
         }
 
+        "opencode" | "opencode_cli" => Ok(validate_opencode_key(&api_key, base_url.as_deref()).await),
+
         // Direct API key providers (matching _api suffix variants from frontend)
         "openai_api" => {
             let validator = OpenAIValidator::new();
@@ -210,7 +269,7 @@ pub async fn run_validate_key(
         }
 
         _ => Err(format!(
-            "Unknown agent type: {}. Supported: copilot, cursor_cli, openai, anthropic, google, gemini_cli, codex, claude_code, kiro, openai_api, anthropic_api, gemini_api, deepseek_api, groq_api, xai_api, zhipu_api, dashscope_api, moonshot_api, minimax_api, openrouter_api, vllm_api, azure_openai_api, azure_anthropic_api",
+            "Unknown agent type: {}. Supported: copilot, cursor_cli, openai, anthropic, google, gemini_cli, codex, claude_code, kiro, opencode, openai_api, anthropic_api, gemini_api, deepseek_api, groq_api, xai_api, zhipu_api, dashscope_api, moonshot_api, minimax_api, openrouter_api, zenmux_api, vllm_api, azure_openai_api, azure_anthropic_api",
             agent_type
         )),
     }
@@ -322,6 +381,15 @@ pub fn validate_token_format(agent_type: String, token: String) -> Result<(bool,
             let validator = KiroValidator::new();
             Ok(validator.validate_format(&token))
         }
+        "opencode" | "opencode_cli" => {
+            if token.is_empty() {
+                Ok((false, "API key is required".to_string()))
+            } else if token.len() < 8 {
+                Ok((false, "API key is too short".to_string()))
+            } else {
+                Ok((true, "Format OK".to_string()))
+            }
+        }
 
         // Direct API key providers (_api suffix variants)
         "openai_api" => {
@@ -392,6 +460,8 @@ pub async fn fetch_key_quota(
         | "codex"
         | "gemini_cli"
         | "kiro"
+        | "opencode"
+        | "opencode_cli"
         | "openai_api"
         | "anthropic_api"
         | "gemini_api"
@@ -927,6 +997,7 @@ mod tests {
             "google",
             "gemini_cli",
             "kiro",
+            "opencode",
         ] {
             let _ = ok_format(agent, "some-token-1234567890");
         }

--- a/src-tauri/crates/key-vault/src/key_store/agent_env_builder.rs
+++ b/src-tauri/crates/key-vault/src/key_store/agent_env_builder.rs
@@ -300,8 +300,12 @@ impl KeyService {
                 }
             }
             ModelType::OpenCode => {
-                // OpenCode manages provider credentials through its own config file.
-                // No env var injection needed — keys are configured via `opencode` CLI directly.
+                if let Some(ref key) = entry.api_key {
+                    env.insert("OPENCODE_API_KEY".to_string(), key.clone());
+                }
+                if let Some(ref url) = entry.base_url {
+                    env.insert("OPENCODE_BASE_URL".to_string(), url.clone());
+                }
             }
             // API key providers: store api_key under the provider's env var name
             ModelType::AnthropicApi

--- a/src/engines/SessionCore/hooks/session/useSessionCreator/useAdvancedConfig.ts
+++ b/src/engines/SessionCore/hooks/session/useSessionCreator/useAdvancedConfig.ts
@@ -104,7 +104,7 @@ export function useAdvancedConfig(): UseAdvancedConfigResult {
     const selectedSourceModelType = lastModelSelection.selectedSourceModelType;
     const nativeHarnessType =
       dispatchCategory === "rust_agent" &&
-      (selectedAccount?.canUseNativeHarness ||
+      (selectedAccount?.nativeHarnessType ||
         selectedSourceModelType === CLI_AGENT.CURSOR)
         ? (selectedAccount?.nativeHarnessType ?? NATIVE_HARNESS_TYPE.CURSOR)
         : undefined;

--- a/src/hooks/keyVault/useLocalKeys.ts
+++ b/src/hooks/keyVault/useLocalKeys.ts
@@ -247,12 +247,12 @@ export function useLocalKeys(
           return next;
         });
         return saved;
-      } catch {
+      } catch (err) {
         if (appliedOptimisticUpdate) {
           publishAllKeys(previousKeys);
           replaceModelAliasesFromKeys(previousKeys);
         }
-        return null;
+        throw err;
       }
     },
     []

--- a/src/scaffold/WizardSystem/variants/KeyVault/components/ApiSetup.tsx
+++ b/src/scaffold/WizardSystem/variants/KeyVault/components/ApiSetup.tsx
@@ -145,6 +145,8 @@ const ApiSetup: React.FC<ApiSetupProps> = ({
   const hasPinnedSection = showCopilotPinned || showCursorPinned;
   const hideFooter = (isClaudeCode || isCodex) && hook.browserOpen;
 
+  const effectiveKeyValidated = hook.keyValidated || data.validated;
+
   const showValidationResults =
     !(hook.isCursor && hook.useGuidedSetup) &&
     !hook.isCopilot &&
@@ -155,7 +157,7 @@ const ApiSetup: React.FC<ApiSetupProps> = ({
   const showModelSections =
     !hook.browserOpen &&
     !!data.agent_type &&
-    (hook.keyValidated ||
+    (effectiveKeyValidated ||
       (hook.isCursor && data.validated) ||
       (hook.isOAuthAgent && data.validated) ||
       isLocalModelProvider);
@@ -361,7 +363,7 @@ const ApiSetup: React.FC<ApiSetupProps> = ({
               agentCategory={hook.agentCategory}
               isComplex={isComplex}
               setupMethod={data.setup_method}
-              keyValidated={hook.keyValidated}
+              keyValidated={effectiveKeyValidated}
               validatingKey={hook.validatingKey}
               validationError={hook.validationError}
               fetchedModels={hook.fetchedModels}
@@ -398,7 +400,7 @@ const ApiSetup: React.FC<ApiSetupProps> = ({
 
           {!!data.agent_type && showValidationResults && (
             <ValidationResults
-              keyValidated={hook.keyValidated}
+              keyValidated={effectiveKeyValidated}
               validationError={hook.validationError}
               agentCategory={hook.agentCategory}
               isApiProvider={hook.isApiProvider}
@@ -455,7 +457,7 @@ const ApiSetup: React.FC<ApiSetupProps> = ({
         <CopilotPinnedSection
           data={data}
           onChange={onChange}
-          keyValidated={hook.keyValidated}
+          keyValidated={effectiveKeyValidated}
           validatingKey={hook.validatingKey}
           validationError={hook.validationError}
           validateKey={hook.validateKey}

--- a/src/scaffold/WizardSystem/variants/KeyVault/hooks/useWizard.ts
+++ b/src/scaffold/WizardSystem/variants/KeyVault/hooks/useWizard.ts
@@ -259,11 +259,14 @@ export function useWizard(options: UseWizardOptions): UseWizardReturn {
           : undefined,
       default_variants:
         data.default_variants.length > 0 ? data.default_variants : undefined,
-      quota_info: data.quota_info as SaveKeyRequest["quota_info"],
       auth_method: isOAuth ? "oauth" : data.auth_method || "api_key",
       has_local_key: true,
       is_listed: false,
     };
+
+    if (data.quota_info) {
+      request.quota_info = data.quota_info as SaveKeyRequest["quota_info"];
+    }
 
     onSubmit(request);
   }, [data, existingAccountNames, getDefaultNameBase, onSubmit]);


### PR DESCRIPTION
## Summary
 
Fixes #94
 
Support OpenCode Go as a Rust-native provider so detected OpenCode Go keys can be validated, saved, and used to launch sessions.
 
## Root Cause
 
OpenCode Go was not registered as a complete provider across the provider registry, key vault, validation, and session launch paths.
 
As a result, OpenCode Go credentials could be detected or selected in some places but were not consistently resolved as a normal Rust-native provider. The frontend could also include a native harness type for OpenCode accounts, which incorrectly routed OpenCode through the Cursor native harness path instead of the OpenAI-compatible provider path.
 
## Fix
 
- Register OpenCode in the agent-core provider registry and provider factory.
- Add OpenCode/OpenCode Go key autodetection from local OpenCode auth config and environment variables.
- Add OpenCode key validation through the provider `/models` endpoint, defaulting to OpenCode Go and falling back to OpenCode Zen when no custom base URL is supplied.
- Inject the correct OpenCode API key and base URL into provider environments.
- Update key vault and wizard UI paths so OpenCode keys can be detected, saved, and reused.
- Prevent OpenCode accounts from sending an incorrect Cursor native harness type during session launch.
 
## Verification
 
- `pnpm run lint`
  - Passed with 0 errors.
  - Reported 2 warnings in unrelated pre-existing files.
- `pnpm run check:circular`
  - Passed with no circular dependencies.
- `cargo test -p key_vault auto_detect::opencode -- --nocapture`
  - Passed: 2 tests.
- `cargo test -p agent_core providers::factory::tests -- --nocapture`
  - Passed: 13 tests.
- Husky pre-commit hook passed.
- Manually verified OpenCode Go in the rebased dev app.

## Screenshots

<img width="923" height="678" alt="Screenshot 2026-06-25 at 10 35 58 AM" src="https://github.com/user-attachments/assets/f2c36b87-ce1b-4ea4-a184-9bc4200f6106" />
<img width="923" height="282" alt="Screenshot 2026-06-25 at 10 36 18 AM" src="https://github.com/user-attachments/assets/c1b71486-7342-4e33-8b61-da9bee2063fd" />
<img width="923" height="824" alt="Screenshot 2026-06-25 at 10 46 45 AM" src="https://github.com/user-attachments/assets/e599087c-282d-4f65-b0bd-51e657f83b47" />
<img width="1078" height="998" alt="Screenshot 2026-06-25 at 12 01 33 AM" src="https://github.com/user-attachments/assets/852faeb0-aae5-4f57-b351-ed7bc55e5474" />

