### PR TITLE
fix(chat panel): allow wider panel on ultrawide screens

### DIFF
--- a/src/engines/ChatPanel/config.ts
+++ b/src/engines/ChatPanel/config.ts
@@ -10,6 +10,34 @@ export const MIN_WIDTH = 420;
 export const MAX_WIDTH = 800;
 export const MIN_CENTER_WIDTH = 400; // Minimum width for center content area
 export const LEFT_PANEL_WIDTH = 64; // Navigation sidebar width
+export const CHAT_PANEL_VIEWPORT_MARGIN = 20;
+
+export const getMaxWidthForContainer = (containerWidth: number): number =>
+  Math.max(
+    MIN_WIDTH,
+    containerWidth - MIN_CENTER_WIDTH - CHAT_PANEL_VIEWPORT_MARGIN
+  );
+
+export const getCurrentMaxWidth = (): number =>
+  typeof window === "undefined"
+    ? MAX_WIDTH
+    : getMaxWidthForContainer(window.innerWidth - LEFT_PANEL_WIDTH);
+
+export const clampWidthForViewport = (width: number): number => {
+  if (width <= 0) return width;
+  return Math.min(Math.max(width, MIN_WIDTH), getCurrentMaxWidth());
+};
+
+export const clampWidthForContainer = (
+  width: number,
+  containerWidth: number
+): number => {
+  if (width <= 0) return width;
+  return Math.min(
+    Math.max(width, MIN_WIDTH),
+    getMaxWidthForContainer(containerWidth)
+  );
+};
 
 // Timing constants
 export const RAPID_CLICK_THRESHOLD_MS = 300;

--- a/src/engines/ChatPanel/hooks/useChatPanelResize.ts
+++ b/src/engines/ChatPanel/hooks/useChatPanelResize.ts
@@ -30,16 +30,12 @@ import { DEFAULT_CHAT_WIDTH, chatWidthAtom } from "@src/store/ui/chatPanelAtom";
 
 import {
   CHAT_WIDTH_CSS_VAR,
-  LEFT_PANEL_WIDTH,
-  MAX_WIDTH,
-  MIN_CENTER_WIDTH,
   MIN_WIDTH,
   RAPID_CLICK_THRESHOLD_MS,
+  clampWidthForContainer,
+  clampWidthForViewport,
+  getMaxWidthForContainer,
 } from "../config";
-
-// Clamp a width value to [0, MAX_WIDTH] (0 is the valid "hidden" sentinel).
-const clampChatWidth = (value: number): number =>
-  value > 0 ? Math.min(value, MAX_WIDTH) : value;
 
 export interface UseChatPanelResizeOptions {
   /** Whether using external width control */
@@ -59,14 +55,14 @@ export interface UseChatPanelResizeResult {
   handleMouseDown: (event: ReactMouseEvent) => void;
 }
 
-// Helper to get current width from CSS variable, clamped to MAX_WIDTH.
+// Helper to get current width from CSS variable, clamped to the current viewport.
 const getChatWidthFromCSS = (): number => {
   if (typeof document === "undefined") return DEFAULT_CHAT_WIDTH;
   const cssValue =
     document.documentElement.style.getPropertyValue(CHAT_WIDTH_CSS_VAR);
   if (cssValue) {
     const parsed = parseInt(cssValue, 10);
-    if (!isNaN(parsed)) return clampChatWidth(parsed);
+    if (!isNaN(parsed)) return clampWidthForViewport(parsed);
   }
   return DEFAULT_CHAT_WIDTH;
 };
@@ -153,6 +149,11 @@ export function useChatPanelResize(
         ) as HTMLElement | null;
       }
 
+      const resizeContainer = embedded
+        ? cachedChatWrapper?.parentElement
+        : cachedMainContent;
+      const containerWidth = resizeContainer?.clientWidth ?? window.innerWidth;
+
       const handleMouseMove = (moveEvent: globalThis.MouseEvent) => {
         // Only start "dragging" mode after first actual movement
         if (!hasDraggedRef.current) {
@@ -164,16 +165,7 @@ export function useChatPanelResize(
           document.body.style.userSelect = "none";
         }
 
-        // Calculate dynamic max width based on available space. Guard
-        // against undersized viewports where `availableWidth - MIN_CENTER_WIDTH`
-        // would fall below MIN_WIDTH and make the `Math.min` below try to
-        // shrink the panel past its minimum — we always want a valid
-        // non-collapsing range.
-        const availableWidth = window.innerWidth - LEFT_PANEL_WIDTH - 20;
-        const dynamicMaxWidth = Math.max(
-          MIN_WIDTH,
-          Math.min(MAX_WIDTH, availableWidth - MIN_CENTER_WIDTH)
-        );
+        const dynamicMaxWidth = getMaxWidthForContainer(containerWidth);
 
         // Calculate new width with constraints. Minimum is enforced as the
         // LAST step so nothing (negative delta, NaN, subzero dynamicMax, …)
@@ -235,10 +227,11 @@ export function useChatPanelResize(
           // coerce it up to MIN_WIDTH here so the persisted width never
           // collapses the panel.
           const rawFinal = pendingWidthRef.current;
-          const finalWidth = clampChatWidth(
+          const finalWidth = clampWidthForContainer(
             Number.isFinite(rawFinal) && rawFinal >= MIN_WIDTH
               ? rawFinal
-              : MIN_WIDTH
+              : MIN_WIDTH,
+            containerWidth
           );
 
           if (embedded) {

--- a/src/engines/ChatPanel/index.tsx
+++ b/src/engines/ChatPanel/index.tsx
@@ -10,8 +10,9 @@ import {
 } from "@src/config/mainAppPaths";
 import { useRouteViewMode } from "@src/config/routeViewModeConfig";
 import {
-  MAX_WIDTH as CHAT_MAX_WIDTH,
   MIN_WIDTH as CHAT_MIN_WIDTH,
+  clampWidthForViewport,
+  getCurrentMaxWidth,
 } from "@src/engines/ChatPanel/config";
 import {
   clearSessionAtom,
@@ -177,8 +178,7 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
       () => getChatPanelBackgroundStyle(backgroundConfig.pageOpacity),
       [backgroundConfig.pageOpacity]
     );
-    const chatWidth =
-      rawChatWidth > 0 ? Math.min(rawChatWidth, CHAT_MAX_WIDTH) : rawChatWidth;
+    const chatWidth = clampWidthForViewport(rawChatWidth);
     const { isDragging, panelRef, handleMouseDown } = useChatPanelResize({
       useExternalWidth,
       embedded,
@@ -592,7 +592,7 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
       ? t("chat.showWorkstation")
       : t("chat.maximizeChatPanel");
     const useFullScreenCreator =
-      isChatFocus || useExternalWidth || chatWidth >= CHAT_MAX_WIDTH;
+      isChatFocus || useExternalWidth || chatWidth >= getCurrentMaxWidth();
     const creatorVariant = useFullScreenCreator ? "fullScreen" : "default";
     const creatorClassName = "min-h-0 flex-1";
     const emptyChatContent = (

--- a/src/modules/shared/layouts/AppLayout.tsx
+++ b/src/modules/shared/layouts/AppLayout.tsx
@@ -25,7 +25,7 @@ import { sendAdeActionResult } from "@src/api/tauri/agent";
 import { ChatProvider } from "@src/contexts/workspace/ChatContext";
 import { DataProvider } from "@src/contexts/workspace/DataContext";
 import ChatPanel from "@src/engines/ChatPanel";
-import { MAX_WIDTH as CHAT_MAX_WIDTH } from "@src/engines/ChatPanel/config";
+import { clampWidthForViewport } from "@src/engines/ChatPanel/config";
 import type { SessionLaunchSuccessInfo } from "@src/engines/SessionCore/hooks/session/useSessionCreator/useSessionLaunch/types";
 import { pendingSessionProposal } from "@src/engines/SessionCore/hooks/useAgentADEActions";
 import SessionSyncProvider from "@src/engines/SessionCore/sync/SessionSyncProvider";
@@ -179,10 +179,7 @@ const AppLayoutComponent: React.FC<AppLayoutProps> = ({
   const isSettingsSlot = chatPanelMode === "settings";
   const effectiveRawWidth =
     rawChatWidth > 0 ? rawChatWidth : isSettingsSlot ? DEFAULT_CHAT_WIDTH : 0;
-  const chatWidth =
-    effectiveRawWidth > 0
-      ? Math.min(effectiveRawWidth, CHAT_MAX_WIDTH)
-      : effectiveRawWidth;
+  const chatWidth = clampWidthForViewport(effectiveRawWidth);
   const sidebarCollapsed = useAtomValue(sidebarCollapsedAtom);
   const isChatOnLeft = chatPosition === "left";
   const isCompact = chatLayout === "compact";

--- a/src/store/ui/chatPanelAtom.ts
+++ b/src/store/ui/chatPanelAtom.ts
@@ -2,10 +2,7 @@ import { type WritableAtom, atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import { z } from "zod/v4";
 
-import {
-  MAX_WIDTH as CHAT_MAX_WIDTH,
-  MIN_WIDTH as CHAT_MIN_WIDTH,
-} from "@src/engines/ChatPanel/config";
+import { clampWidthForViewport } from "@src/engines/ChatPanel/config";
 import {
   settingsAtom,
   updateSettingAtom,
@@ -36,12 +33,9 @@ const CHAT_WIDTH_SAVE_DELAY = 300; // ms
 
 // CSS variable name for direct DOM updates
 const CHAT_WIDTH_CSS_VAR = "--orgii-chat-width";
-// Clamp persisted widths to [MIN_WIDTH, MAX_WIDTH]; preserve the 0
+// Clamp persisted widths to the current viewport; preserve the 0
 // sentinel which means "chat panel hidden".
-const ChatWidthSchema = z.number().transform((value) => {
-  if (value <= 0) return 0;
-  return Math.min(Math.max(value, CHAT_MIN_WIDTH), CHAT_MAX_WIDTH);
-});
+const ChatWidthSchema = z.number().transform(clampWidthForViewport);
 const StationChatVisibilitySchema = z.object({
   "my-station": z.boolean(),
   "agent-station": z.boolean(),
@@ -51,8 +45,9 @@ export type StationChatVisibility = z.infer<typeof StationChatVisibilitySchema>;
 export type ChatStationMode = keyof StationChatVisibility;
 
 // Load initial value from localStorage (only once at startup).
-// Clamp to MAX_WIDTH so values persisted from wider viewports don't overflow,
-// and immediately write the clamped value back so the next reload is clean.
+// Clamp to the current viewport so values persisted from wider viewports
+// don't overflow, and immediately write the clamped value back so the next
+// reload is clean.
 const getInitialChatWidth = (): number => {
   if (typeof window === "undefined") return DEFAULT_CHAT_WIDTH;
   try {
@@ -94,8 +89,7 @@ chatWidthBaseAtom.debugLabel = "chatWidthBaseAtom";
 export const chatWidthAtom = atom(
   (get) => get(chatWidthBaseAtom),
   (_get, set, newWidth: number) => {
-    const clampedWidth =
-      newWidth > 0 ? Math.min(newWidth, CHAT_MAX_WIDTH) : newWidth;
+    const clampedWidth = clampWidthForViewport(newWidth);
 
     set(chatWidthBaseAtom, clampedWidth);
 


### PR DESCRIPTION
## Summary

Fixes #155

Allows the chat panel to expand wider on ultrawide screens without jumping when dragged to the screen edge.

## Root Cause

The chat panel width was still effectively constrained by fixed-width logic in multiple layout paths. The previous `800px` cap prevented ultrawide users from expanding the panel meaningfully.

After removing that fixed cap, the drag path also needed to account for the actual resize container, not just the full browser window. When the right-side panel was dragged to the screen edge, the proposed width could exceed what the current layout container could hold, causing React layout to snap the panel back left.

## Fix

- Replaced fixed `800px` chat width clamping in the active chat layout path with viewport-aware clamping.
- Added container-aware resize bounds for drag interactions.
- Clamped persisted, rendered, and drag-committed chat widths consistently.
- Preserved the hidden-width sentinel and minimum panel width.
- Kept enough workspace/content area visible while allowing wider chat panels on ultrawide displays.

## Verification

- `pnpm run lint`
- `pnpm run check:circular`
- Husky pre-commit hook passed
- Manual: launched the dev app and dragged the right-side chat/kanban boundary to the screen edge; confirmed it no longer jumps left.

## Screenshots
<img width="2555" height="1436" alt="Screenshot 2026-06-25 at 10 25 21 PM" src="https://github.com/user-attachments/assets/f176bed5-149f-4b78-83c4-c216c229ffb2" />
<img width="2555" height="1436" alt="Screenshot 2026-06-25 at 10 25 10 PM" src="https://github.com/user-attachments/assets/9a021a66-22a1-4bab-9f2c-b347754b526e" />


