### PR TITLE
fix(chat): kill foreground shell on force-send (#110)

### DIFF
--- a/src/engines/SessionCore/control/sessionTimelineBoundary.test.ts
+++ b/src/engines/SessionCore/control/sessionTimelineBoundary.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CANCEL_REASON } from "@src/api/tauri/agent";
 
 import {
+  BOUNDARY_EFFECTS,
+  type TimelineBoundaryReason,
   beginStopBoundary,
   cancelTurnForTimelineBoundary,
   isTimelineInterruptInFlight,
@@ -170,6 +172,108 @@ describe("sessionTimelineBoundary", () => {
       pid: 123,
       sessionId: "session-1",
     });
+  });
+
+  it("kills the running foreground shell for force-send boundaries (#110)", async () => {
+    interruptSpy.mockResolvedValue(undefined);
+    storeGetSpy.mockReturnValue(
+      new Map([
+        [
+          "session-1",
+          new Map([
+            [
+              777,
+              {
+                pid: 777,
+                sessionId: "session-1",
+                command: "sleep 45",
+                status: "running",
+                startedAt: Date.now(),
+              },
+            ],
+          ]),
+        ],
+      ])
+    );
+
+    await cancelTurnForTimelineBoundary("session-1", "force-send");
+    await Promise.resolve();
+
+    expect(killAgentShellProcessSpy).toHaveBeenCalledWith({
+      pid: 777,
+      sessionId: "session-1",
+    });
+  });
+
+  it("spares background shells on force-send boundaries (#110)", async () => {
+    interruptSpy.mockResolvedValue(undefined);
+    storeGetSpy.mockReturnValue(
+      new Map([
+        [
+          "session-1",
+          new Map([
+            [
+              888,
+              {
+                pid: 888,
+                sessionId: "session-1",
+                command: "npm run dev",
+                status: "background",
+                startedAt: Date.now(),
+              },
+            ],
+          ]),
+        ],
+      ])
+    );
+
+    await cancelTurnForTimelineBoundary("session-1", "force-send");
+    await Promise.resolve();
+
+    expect(killAgentShellProcessSpy).not.toHaveBeenCalled();
+  });
+
+  it("kills no shell processes for rewind boundaries", async () => {
+    storeGetSpy.mockImplementation((atom: { debugLabel?: string }) => {
+      if (atom.debugLabel === "isSessionActive") return true;
+      if (atom.debugLabel === "sessionRuntimeStatus") return "running";
+      if (atom.debugLabel === "session/sortedEvents") return [];
+      return new Map([
+        [
+          "session-1",
+          new Map([
+            [
+              999,
+              {
+                pid: 999,
+                sessionId: "session-1",
+                command: "sleep 45",
+                status: "running",
+                startedAt: Date.now(),
+              },
+            ],
+          ]),
+        ],
+      ]);
+    });
+    interruptSpy.mockResolvedValue(undefined);
+
+    await cancelTurnForTimelineBoundary("session-1", "rewind");
+    await Promise.resolve();
+
+    expect(killAgentShellProcessSpy).not.toHaveBeenCalled();
+  });
+
+  it("declares a boundary effect for every TimelineBoundaryReason", () => {
+    // Table-completeness guard: every boundary reason must have an explicit
+    // policy. `Record<TimelineBoundaryReason, …>` enforces this at the type
+    // level; this asserts it at runtime so a future reason cannot ship without
+    // declaring its shell-kill / FSM behavior (the #110 latent-discipline gap).
+    const reasons: TimelineBoundaryReason[] = ["stop", "force-send", "rewind"];
+    for (const reason of reasons) {
+      expect(BOUNDARY_EFFECTS[reason]).toBeDefined();
+    }
+    expect(Object.keys(BOUNDARY_EFFECTS).sort()).toEqual([...reasons].sort());
   });
 
   it("closes local running events for Stop boundaries", async () => {

--- a/src/engines/SessionCore/control/sessionTimelineBoundary.ts
+++ b/src/engines/SessionCore/control/sessionTimelineBoundary.ts
@@ -25,6 +25,49 @@ import { streamingDeltaContentAtom } from "../core/atoms";
 
 export type TimelineBoundaryReason = "stop" | "force-send" | "rewind";
 
+/**
+ * Which OS shell processes a boundary terminates.
+ *  - "none":       leave all shells running (rewind: the timeline is being
+ *                  rewritten, not stopped).
+ *  - "foreground": kill running foreground shells, keep background workers
+ *                  (force-send: interrupt the current work but let long-running
+ *                  background processes / dev servers survive the follow-up).
+ *  - "all":        kill foreground + background (stop: user wants everything
+ *                  this session spawned to halt).
+ */
+type ShellKillScope = "none" | "foreground" | "all";
+
+interface TimelineBoundaryEffect {
+  /** Drive the FSM to "stopping" (interrupt) vs "idle" (rewind rewrite). */
+  forcesIdle: boolean;
+  /** Explicit user Stop — parks the queue and sets the cancel atoms. */
+  isUserStop: boolean;
+  /** Which OS shell processes to terminate at this boundary. */
+  shellKill: ShellKillScope;
+}
+
+/**
+ * Single source of truth for every boundary's side-effects. Mirrors the
+ * backend's `CancelReason::boundary_effect()` struct: a new
+ * `TimelineBoundaryReason` cannot compile without declaring its policy here,
+ * so it can never silently inherit the wrong shell-kill / FSM behavior. That
+ * latent-discipline gap (an inline `if (isUserStop)` that only Stop satisfied)
+ * is exactly what let force-send leave a blocking foreground shell alive and
+ * swallow the follow-up message (issue #110).
+ */
+export const BOUNDARY_EFFECTS: Record<
+  TimelineBoundaryReason,
+  TimelineBoundaryEffect
+> = {
+  stop: { forcesIdle: false, isUserStop: true, shellKill: "all" },
+  "force-send": {
+    forcesIdle: false,
+    isUserStop: false,
+    shellKill: "foreground",
+  },
+  rewind: { forcesIdle: true, isUserStop: false, shellKill: "none" },
+};
+
 const log = createLogger("sessionTimelineBoundary");
 
 const interruptInFlightByBoundary = new Set<string>();
@@ -54,9 +97,11 @@ export function clearLiveStreamingForSession(sessionId: string): void {
   });
 }
 
-async function killActiveShellProcessesForStop(
-  sessionId: string
+async function killShellProcessesForBoundary(
+  sessionId: string,
+  scope: ShellKillScope
 ): Promise<void> {
+  if (scope === "none") return;
   const processes = getInstrumentedStore()
     .get(shellProcessMapAtom)
     .get(sessionId);
@@ -64,9 +109,10 @@ async function killActiveShellProcessesForStop(
 
   await Promise.allSettled(
     [...processes.values()]
-      .filter(
-        (process) =>
-          process.status === "running" || process.status === "background"
+      .filter((process) =>
+        scope === "all"
+          ? process.status === "running" || process.status === "background"
+          : process.status === "running"
       )
       .map((process) => killAgentShellProcess({ pid: process.pid, sessionId }))
   );
@@ -112,22 +158,22 @@ export function beginTimelineBoundary(
   reason: TimelineBoundaryReason
 ): void {
   const store = getInstrumentedStore();
-  const isUserStop = reason === "stop";
+  const effect = BOUNDARY_EFFECTS[reason];
 
   // Drive the turn-lifecycle FSM first so any submit/dispatch racing this
   // boundary already observes the new phase.
-  // - stop / force-send: the turn stays blocked ("stopping") until the
-  //   provider confirms the cancel with a terminal (bounded by the FSM's
-  //   stopping dead-man).
-  // - rewind: the timeline is being rewritten — force idle immediately and
-  //   invalidate any in-flight terminal of the overridden turn.
-  if (reason === "rewind") {
+  // - stop / force-send (forcesIdle:false): the turn stays blocked
+  //   ("stopping") until the provider confirms the cancel with a terminal
+  //   (bounded by the FSM's stopping dead-man).
+  // - rewind (forcesIdle:true): the timeline is being rewritten — force idle
+  //   immediately and invalidate any in-flight terminal of the overridden turn.
+  if (effect.forcesIdle) {
     forceTurnIdle(sessionId);
   } else {
     beginTurnStopping(sessionId);
   }
 
-  if (isUserStop) {
+  if (effect.isUserStop) {
     store.set(userInitiatedCancelAtom, true);
     store.set(isPendingCancelAtom, true);
     // Stop parks every queued follow-up of this session: the natural drain
@@ -139,14 +185,20 @@ export function beginTimelineBoundary(
   }
 
   clearLiveStreamingForSession(sessionId);
-  if (isUserStop) {
-    void killActiveShellProcessesForStop(sessionId).catch((error) => {
+  // Shell-kill scope is declared per-boundary in BOUNDARY_EFFECTS:
+  //   stop="all", force-send="foreground", rewind="none". Killing the
+  //   blocking foreground shell on force-send is the #110 fix — it lets the
+  //   provider deliver the cancelled terminal promptly so the FSM flips idle
+  //   and the queued Send-Now message dispatches, instead of stalling until
+  //   the command finishes on its own.
+  void killShellProcessesForBoundary(sessionId, effect.shellKill).catch(
+    (error) => {
       log.warn(
-        "[sessionTimelineBoundary] failed to kill active shell processes",
+        "[sessionTimelineBoundary] failed to kill shell processes",
         error
       );
-    });
-  }
+    }
+  );
   // All boundary causes close the interrupted turn's running events. For
   // force-send this is what clears stale `displayStatus:"running"` rows that
   // would otherwise keep `anyRunning` true in usePlanningIndicator and

--- a/tests/e2e/specs/core/session-controls-ui.spec.mjs
+++ b/tests/e2e/specs/core/session-controls-ui.spec.mjs
@@ -19,6 +19,7 @@ import {
   runBurstQueueSendNowOrderingScenario,
   runChaosControlFlowScenario,
   runForceSendScenario,
+  runForceSendWhileShellRunningScenario,
   runFreshStopImageRestoreScenario,
   runFreshStopRollbackScenario,
   runIntermediateStreamingScenario,
@@ -153,6 +154,7 @@ const CONTROL_SCENARIO_NAMES = [
   "stop-double-click-no-resubmit",
   "stop-bg-subagent-next-message",
   "force-send",
+  "force-send-while-shell-running",
   "rewind",
   "restore-checkpoint",
   "plan-build-direct",
@@ -169,6 +171,9 @@ const RUST_AGENT_EXEC_MODE_SCENARIOS = new Set([
   "fresh-stop",
   "fresh-stop-image",
   "stop-bg-subagent-next-message",
+  // #110 needs a real `exec` foreground shell, which only the rust-agent
+  // harness owns — gate it to rust-agent configs.
+  "force-send-while-shell-running",
   "queue-edit-image-upload",
   "plan-build-direct",
   "plan-update",
@@ -342,6 +347,15 @@ describe("ORGII force-send queued follow-up behavior", function () {
   it("force-sends coherent follow-ups through Rust and CLI agents", async function () {
     this.timeout(1_200_000);
     await runScenario("force-send", runForceSendScenario, this);
+  });
+
+  it("force-sends a follow-up that lands promptly while a foreground shell command is still running (#110)", async function () {
+    this.timeout(1_200_000);
+    await runScenario(
+      "force-send-while-shell-running",
+      runForceSendWhileShellRunningScenario,
+      this
+    );
   });
 
   it("rewinds agent file edits through the rendered Undo All control across Rust and CLI agents", async function () {

--- a/tests/e2e/support/core/session/agentQueuedControlScenarios.mjs
+++ b/tests/e2e/support/core/session/agentQueuedControlScenarios.mjs
@@ -945,6 +945,19 @@ function repoExplorationPromptForConfig(config, waitSeconds = 20) {
   ].join(" ");
 }
 
+// Issue #110 pin: forces the agent to block the turn inside a REAL foreground
+// shell command (not the generic LLM "wait N seconds" prompt, which a provider
+// can satisfy with internal latency). Only a genuinely-running foreground shell
+// reproduces the swallowed-force-send path, because force-send must physically
+// kill that process for the cancelled terminal to land and release the queue.
+function blockingShellPromptForConfig(config, sleepSeconds = 45) {
+  return [
+    `Run a single blocking foreground shell command for ${config.label}:`,
+    `execute exactly \`sleep ${sleepSeconds}\` in the terminal and wait for it to finish.`,
+    "Do not run it in the background. After it completes, reply with a short confirmation.",
+  ].join(" ");
+}
+
 async function runFreshStopRollbackScenario(config) {
   const firstPrompt = longRunningPromptForConfig(config);
 
@@ -1996,6 +2009,97 @@ async function runForceSendScenario(config) {
   );
 }
 
+// Issue #110 regression: Force Send swallowed while a foreground terminal
+// command is running. Unlike runForceSendScenario (which uses a generic LLM
+// "wait ~20s" prompt that a provider can satisfy with internal latency), this
+// scenario forces the agent to block the turn inside a REAL `sleep 45`
+// foreground shell command. Before the fix, force-send left that process alive,
+// so the cancelled terminal never landed promptly: the FSM stopping dead-man
+// (~10s) fired, the FE dispatched the marker message, but the backend scheduler
+// worker stayed blocked on turn #1 until `sleep 45` finished — the marker reply
+// only arrived ~45s later (the "swallowed" symptom). With the table-driven
+// boundary effects (force-send => shellKill:"foreground"), the foreground shell
+// is killed, `exec` returns, the turn loop observes cancel_flag, and the marker
+// turn lands well before the 45s command would have completed.
+//
+// Gated to configs that own a real `exec`/shell foreground tool (rust-agent).
+// Configs whose harness cannot run a blocking foreground shell are skipped by
+// the spec via config.supportsForegroundShell.
+async function runForceSendWhileShellRunningScenario(config) {
+  const SLEEP_SECONDS = 45;
+  const marker = `QUEUE_FORCE_SEND_SHELL_${config.label.replace(/[^a-zA-Z0-9]/g, "_")}_${Date.now()}`;
+  const firstPrompt = blockingShellPromptForConfig(config, SLEEP_SECONDS);
+  const followupPrompt = `Stop whatever is currently running and reply with exactly this marker and nothing else: ${marker}`;
+
+  await configureScenario(config);
+  const inputSelector = await waitForChatInput();
+  await typeAndClickSend(inputSelector, firstPrompt);
+  await waitForChatLaunched(firstPrompt);
+  await waitForWorkingTurn(config.label);
+
+  // Wait until a foreground shell tool call is actually rendered as running for
+  // this session — otherwise we'd race the force-send against tool dispatch and
+  // could pass without ever exercising the blocking-shell path.
+  await browser.waitUntil(
+    async () => {
+      const state = await inspectChatState(`${config.label}-force-send-shell`);
+      return (state.rawEvents ?? []).some(
+        (event) =>
+          event &&
+          event.actionType === "tool_call" &&
+          event.displayStatus === "running" &&
+          /shell|exec|terminal|run_shell/i.test(
+            `${event.functionName ?? ""} ${event.uiCanonical ?? ""}`
+          )
+      );
+    },
+    {
+      timeout: 30_000,
+      interval: 500,
+      timeoutMsg: `${config.label} never rendered a running foreground shell tool call for the blocking command; state=${JSON.stringify(summarizeChatState(await invokeE2E("inspectChatState")))}`,
+    }
+  );
+
+  const chatInputSelector = await waitForChatInput();
+  await typeAndClickSend(chatInputSelector, followupPrompt);
+  await waitForQueuedOrForceSentFollowup(marker);
+
+  const forceSendAtMs = Date.now();
+  await clickSendNowForQueuedMarker(marker);
+
+  // The core #110 assertion: the marker reply must arrive well before the 45s
+  // blocking command would have finished on its own. We give a generous margin
+  // (interrupt + provider terminal + redispatch + reply round-trip) but cap it
+  // far below SLEEP_SECONDS so a regression that waits for the command to drain
+  // naturally fails loudly instead of passing slowly.
+  const MAX_MARKER_LATENCY_MS = 30_000;
+  await waitForMarkerReply(marker, config.label);
+  const markerLatencyMs = Date.now() - forceSendAtMs;
+  if (markerLatencyMs >= SLEEP_SECONDS * 1_000) {
+    throw new Error(
+      `${config.label} Force Send was swallowed (regression #110): marker reply took ${markerLatencyMs}ms, i.e. the turn waited for the ${SLEEP_SECONDS}s foreground command to finish instead of force-send killing it.`
+    );
+  }
+  if (markerLatencyMs >= MAX_MARKER_LATENCY_MS) {
+    throw new Error(
+      `${config.label} Force Send marker reply was slow (${markerLatencyMs}ms >= ${MAX_MARKER_LATENCY_MS}ms): the foreground shell may not have been killed promptly on force-send.`
+    );
+  }
+  await waitForIdleSendButton(config.label);
+
+  const active = unwrap(
+    await invokeE2E("getActiveSessionId"),
+    "getActiveSessionId"
+  );
+  if (!active.sessionId) {
+    throw new Error(`${config.label} produced no active session id`);
+  }
+  expect(active.sessionId).toMatch(config.sessionIdPattern);
+  console.log(
+    `[queued-followup] ${config.label} force-send-while-shell session=${active.sessionId} marker=${marker} latencyMs=${markerLatencyMs}`
+  );
+}
+
 export {
   assertStationSurfacesConsistent,
   hasAuthoritativeRunningTurn,
@@ -2004,6 +2108,7 @@ export {
   runBurstQueueSendNowOrderingScenario,
   runChaosControlFlowScenario,
   runForceSendScenario,
+  runForceSendWhileShellRunningScenario,
   runFreshStopImageRestoreScenario,
   runFreshStopRollbackScenario,
   runQueueAutodispatchesAfterNaturalCompletionScenario,

--- a/tests/e2e/support/core/session/agentQueuedFollowupScenarios.mjs
+++ b/tests/e2e/support/core/session/agentQueuedFollowupScenarios.mjs
@@ -21,6 +21,7 @@ export {
   runBurstQueueSendNowOrderingScenario,
   runChaosControlFlowScenario,
   runForceSendScenario,
+  runForceSendWhileShellRunningScenario,
   runFreshStopImageRestoreScenario,
   runFreshStopRollbackScenario,
   runQueueAutodispatchesAfterNaturalCompletionScenario,


### PR DESCRIPTION
Force Send was swallowed while the agent was blocked inside a long- running foreground terminal command. Only the Stop boundary killed the running shell, so force-send left the blocking foreground process alive; the provider's cancelled terminal never landed promptly, the FSM stopping dead-man fired, and the queued Send-Now message stalled in the backend until the command finished on its own.

Replace the ad-hoc per-reason if-branches in beginTimelineBoundary with a table-driven BOUNDARY_EFFECTS map (stop=all, force-send=foreground, rewind=none) mirroring the backend CancelReason::boundary_effect struct, so a new boundary reason cannot silently inherit the wrong shell-kill policy. force-send now kills only foreground (running) shells, sparing background workers / dev servers to match the backend's cancel_background_workers:false semantics.

Frontend-only; backend ForceSend already used discard_queued_messages :false so the message was never lost, only stalled.

Tests: 14 unit tests (foreground-kill, background-survive, rewind no-kill, table-completeness) plus a new e2e scenario that blocks the turn in a real `sleep 45` foreground shell and asserts the marker reply lands well before the command would finish.

Pre-commit hook ran. Total eslint: 2, total circular: 0

## Summary

-

## Test plan

- [ ] I ran the checks relevant to the changed files, or explained why they were not run.

## Contributor checklist

- [ ] The PR title uses scoped Conventional Commits format, such as `feat(scope): summary` or `fix(scope): summary`.
- [ ] All commits use scoped Conventional Commits format.
- [ ] I did not skip pre-commit, pre-push, lint-staged, or other repository hooks.
- [ ] The PR is scoped to one issue, feature, or fix.
- [ ] I have signed the CLA if prompted by the CLA Assistant bot.
- [ ] A human actively participated in the design and implementation process, and reviewed the contribution before submission.
- [ ] I did not include secrets, private configuration, generated build output, or unrelated formatting changes.
- [ ] I updated documentation for behavior, setup, or architecture changes where needed.
- [ ] I updated all supported locale files for new UI text where needed.
