### PR TITLE
fix(diff): show cumulative session edits

### DIFF
--- a/src-tauri/crates/agent-core/src/core/turn_executor/file_tracker.rs
+++ b/src-tauri/crates/agent-core/src/core/turn_executor/file_tracker.rs
@@ -1,36 +1,59 @@
-//! File modification-time tracker for stale-edit detection
+//! File content tracker for stale-edit detection.
 //!
-//! After each tool call that writes a file, the turn executor records the
-//! file's `mtime`. On subsequent write calls, it checks whether the file has
-//! been modified externally since the last write and surfaces a warning if so.
+//! After a `read_file`, the tracker records a hash of the file's CONTENT.
+//! Before a file-modifying tool (`edit_file` / `apply_patch` / `delete_file`)
+//! runs, it checks the file's content hash still matches; if an external
+//! process changed the content, the edit is rejected with a re-read request.
+//!
+//! ## Why content hash, not mtime
+//!
+//! The previous implementation compared `mtime`. That produced **false stale
+//! rejections**: any process that merely touches a file (an editor save with
+//! no change, a backup/mirror copy, an `atime`/`mtime` bump, sub-second
+//! `SystemTime` precision jitter on a same-second read→write) advances `mtime`
+//! without changing content, so a strict `current > recorded` comparison fired
+//! even though the bytes were identical. mtime is only a *proxy* for "did the
+//! content change"; hashing the content answers that question directly — no
+//! tolerance window, no precision pitfalls, and it still catches genuine
+//! external edits (different bytes → different hash).
 
+use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
-use std::time::SystemTime;
+use std::hash::{Hash, Hasher};
 
 use serde_json::Value;
 
 use crate::tools::names as tool_names;
 
 // ============================================
-// FileTime Tracker
+// File content tracker
 // ============================================
 
-/// Tracks file modification times to detect stale edits.
+/// Tracks file content hashes to detect stale edits.
 ///
-/// When a file is read (via `read_file`), its mtime is recorded.
-/// Before a file-modifying tool (`edit_file`, `apply_patch`)
-/// executes, the tracker checks that the file hasn't been modified
-/// since the last read. If stale, the tool call is rejected with an
-/// error asking the agent to re-read the file.
+/// `read_file` records the content hash. Before a file-modifying tool runs,
+/// `assert_fresh` re-hashes the file and rejects the edit if the hash differs
+/// (content changed externally). Files never read always pass — the edit tool
+/// itself enforces read-before-edit via its description.
 #[derive(Debug, Clone, Default)]
 pub struct FileTimeTracker {
-    /// file_path → last-read mtime
-    read_times: HashMap<String, SystemTime>,
+    /// file_path → last-observed content hash (after read or our own write)
+    read_hashes: HashMap<String, u64>,
     /// Insertion order for FIFO eviction (HashMap iteration is unordered)
     insertion_order: Vec<String>,
 }
 
 const MAX_FILE_TRACKER_ENTRIES: usize = 500;
+
+/// Hash a file's full content. `None` when the file cannot be read (missing,
+/// permission, or it is a directory). Callers treat `None` as "no trustworthy
+/// snapshot" and fail open rather than fabricating a stale signal.
+fn hash_file_content(file_path: &str) -> Option<u64> {
+    let bytes = std::fs::read(file_path).ok()?;
+    let mut hasher = DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    Some(hasher.finish())
+}
 
 impl FileTimeTracker {
     pub fn new() -> Self {
@@ -39,47 +62,60 @@ impl FileTimeTracker {
 
     /// Returns true if no files have been tracked.
     pub fn is_empty(&self) -> bool {
-        self.read_times.is_empty()
+        self.read_hashes.is_empty()
     }
 
     /// Returns the number of tracked files.
     pub fn len(&self) -> usize {
-        self.read_times.len()
+        self.read_hashes.len()
     }
 
-    /// Record the current mtime of a file after a successful read.
-    pub fn record_read(&mut self, file_path: &str) {
-        if let Ok(metadata) = std::fs::metadata(file_path) {
-            if let Ok(mtime) = metadata.modified() {
-                let is_new = !self.read_times.contains_key(file_path);
-                if is_new && self.read_times.len() >= MAX_FILE_TRACKER_ENTRIES {
-                    if let Some(oldest_key) = self.insertion_order.first().cloned() {
-                        self.read_times.remove(&oldest_key);
-                        self.insertion_order.remove(0);
-                    }
-                }
-                self.read_times.insert(file_path.to_string(), mtime);
-                if is_new {
-                    self.insertion_order.push(file_path.to_string());
-                }
+    /// Insert/refresh a file's content hash with FIFO eviction. Shared by the
+    /// read and write recording paths so eviction logic lives in one place.
+    fn upsert_hash(&mut self, file_path: &str, hash: u64) {
+        let is_new = !self.read_hashes.contains_key(file_path);
+        if is_new && self.read_hashes.len() >= MAX_FILE_TRACKER_ENTRIES {
+            if let Some(oldest_key) = self.insertion_order.first().cloned() {
+                self.read_hashes.remove(&oldest_key);
+                self.insertion_order.remove(0);
             }
+        }
+        self.read_hashes.insert(file_path.to_string(), hash);
+        if is_new {
+            self.insertion_order.push(file_path.to_string());
         }
     }
 
-    /// Check if a file has been modified since the last recorded read.
-    /// Returns Ok(()) if safe to edit, Err(message) if stale.
-    /// Files that were never read always pass (the edit tool itself
-    /// may enforce read-before-edit via its description).
+    /// Drop a file from tracking (e.g. its content could not be hashed after a
+    /// write). The next `assert_fresh` then takes the "never read → pass"
+    /// branch instead of comparing against a stale snapshot forever.
+    fn forget(&mut self, file_path: &str) {
+        if self.read_hashes.remove(file_path).is_some() {
+            self.insertion_order.retain(|p| p != file_path);
+        }
+    }
+
+    /// Record the current content hash of a file after a successful read.
+    pub fn record_read(&mut self, file_path: &str) {
+        if let Some(hash) = hash_file_content(file_path) {
+            self.upsert_hash(file_path, hash);
+        }
+    }
+
+    /// Check if a file's content changed since the last recorded read/write.
+    /// Returns Ok(()) if safe to edit, Err(message) if stale. Files never read
+    /// always pass; files we cannot re-hash also pass (fail open — we have no
+    /// trustworthy "changed" signal and must not block a legitimate edit).
     pub fn assert_fresh(&self, file_path: &str) -> Result<(), String> {
-        let Some(recorded_mtime) = self.read_times.get(file_path) else {
+        let Some(recorded_hash) = self.read_hashes.get(file_path) else {
             return Ok(()); // Never read — let the tool handle it
         };
 
-        let current_mtime = std::fs::metadata(file_path)
-            .and_then(|m| m.modified())
-            .map_err(|err| format!("Cannot stat {}: {}", file_path, err))?;
+        let Some(current_hash) = hash_file_content(file_path) else {
+            return Ok(()); // Cannot read content — fail open, don't fabricate stale
+        };
 
-        if current_mtime > *recorded_mtime {
+        if current_hash != *recorded_hash {
             return Err(format!(
                 "File was modified since you last read it: {}. Read it again before editing.",
                 file_path
@@ -89,11 +125,34 @@ impl FileTimeTracker {
         Ok(())
     }
 
-    /// Record a write — update the tracked mtime after a successful edit/write.
+    /// Record a write — refresh the tracked content hash after a successful
+    /// edit/write. If the file can no longer be hashed (e.g. it was deleted),
+    /// forget it so a stale snapshot never causes repeated false rejections.
     pub fn record_write(&mut self, file_path: &str) {
-        if let Ok(metadata) = std::fs::metadata(file_path) {
-            if let Ok(mtime) = metadata.modified() {
-                self.read_times.insert(file_path.to_string(), mtime);
+        match hash_file_content(file_path) {
+            Some(hash) => self.upsert_hash(file_path, hash),
+            None => self.forget(file_path),
+        }
+    }
+
+    /// Single entry point for recording a tool's file effects, called by BOTH
+    /// the sequential (`single.rs`) and concurrent (`parallel.rs`) execution
+    /// paths so the read/write bookkeeping can never drift between them.
+    ///
+    /// On a successful read tool we snapshot each path's content hash; on a
+    /// successful write tool we refresh it. Errored calls record nothing (the
+    /// file was not actually changed). Non-tracked tools are ignored.
+    pub fn record_tool_file_effects(&mut self, tool_name: &str, args: &Value, is_error: bool) {
+        if is_error {
+            return;
+        }
+        if FILE_READ_TOOLS.contains(&tool_name) {
+            for path in extract_file_paths(tool_name, args) {
+                self.record_read(&path);
+            }
+        } else if is_file_write_tool(tool_name) {
+            for path in extract_file_paths(tool_name, args) {
+                self.record_write(&path);
             }
         }
     }
@@ -199,5 +258,128 @@ mod gate_invariant_tests {
             // builds, so this test is the regression guard.
             let _ = extract_file_paths(tool, &Value::Null);
         }
+    }
+}
+
+/// Content-hash freshness behaviour: these pin the exact false-stale bug the
+/// content-hash design fixes (a mtime bump with identical bytes must NOT be
+/// reported stale) while preserving the real protection (changed bytes ARE
+/// reported stale).
+#[cfg(test)]
+mod content_hash_tests {
+    use super::*;
+    use std::io::Write;
+    use std::time::Duration;
+
+    /// Write `content` to a unique temp path and return it. Uses the process id
+    /// + a counter so parallel test threads never collide.
+    fn temp_file(content: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let mut path = std::env::temp_dir();
+        path.push(format!(
+            "orgii_file_tracker_test_{}_{}.txt",
+            std::process::id(),
+            n
+        ));
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        path
+    }
+
+    /// Force a later mtime without changing bytes — simulates an external
+    /// `touch` / mirror copy / editor save-with-no-change.
+    fn rewrite_same_bytes(path: &std::path::Path, content: &str) {
+        // Sleep a hair so the filesystem records a strictly-later mtime; the
+        // whole point is that the OLD mtime-based guard would have fired here.
+        std::thread::sleep(Duration::from_millis(5));
+        std::fs::write(path, content).unwrap();
+    }
+
+    #[test]
+    fn same_content_passes_even_after_mtime_bump() {
+        let path = temp_file("hello\nworld\n");
+        let p = path.to_str().unwrap();
+        let mut tracker = FileTimeTracker::new();
+        tracker.record_read(p);
+        // External process rewrites identical bytes → mtime advances, content
+        // unchanged. The old mtime guard false-rejected here; hashing passes.
+        rewrite_same_bytes(&path, "hello\nworld\n");
+        assert!(tracker.assert_fresh(p).is_ok());
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn changed_content_is_rejected() {
+        let path = temp_file("original\n");
+        let p = path.to_str().unwrap();
+        let mut tracker = FileTimeTracker::new();
+        tracker.record_read(p);
+        std::fs::write(&path, "tampered externally\n").unwrap();
+        assert!(tracker.assert_fresh(p).is_err());
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn same_second_read_then_write_then_recheck_passes() {
+        // Reproduces the reported bug: read → our own edit → next edit must NOT
+        // be falsely flagged stale. record_write refreshes the hash to the
+        // post-edit content so the following assert_fresh matches.
+        let path = temp_file("v1\n");
+        let p = path.to_str().unwrap();
+        let mut tracker = FileTimeTracker::new();
+        tracker.record_read(p);
+        std::fs::write(&path, "v2 edited\n").unwrap();
+        tracker.record_write(p);
+        assert!(tracker.assert_fresh(p).is_ok());
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn record_write_on_missing_file_forgets_entry() {
+        // A write whose file then can't be hashed (e.g. deleted) must forget
+        // the entry so the next assert_fresh takes the "never read → pass"
+        // branch instead of comparing against a stale snapshot forever.
+        let path = temp_file("content\n");
+        let p = path.to_str().unwrap().to_string();
+        let mut tracker = FileTimeTracker::new();
+        tracker.record_read(&p);
+        assert_eq!(tracker.len(), 1);
+        std::fs::remove_file(&path).ok();
+        tracker.record_write(&p); // file gone → forget
+        assert!(tracker.is_empty());
+        assert!(tracker.assert_fresh(&p).is_ok()); // never-read branch
+    }
+
+    #[test]
+    fn never_read_file_passes() {
+        let tracker = FileTimeTracker::new();
+        assert!(tracker.assert_fresh("/nonexistent/never/read.txt").is_ok());
+    }
+
+    #[test]
+    fn record_tool_file_effects_routes_read_and_write() {
+        let path = temp_file("alpha\n");
+        let p = path.to_str().unwrap();
+        let mut tracker = FileTimeTracker::new();
+        let read_args = serde_json::json!({ "path": p });
+        tracker.record_tool_file_effects(tool_names::READ_FILE, &read_args, false);
+        assert_eq!(tracker.len(), 1);
+
+        // External change → stale until a write refreshes the snapshot.
+        std::fs::write(&path, "beta\n").unwrap();
+        assert!(tracker.assert_fresh(p).is_err());
+
+        let edit_args = serde_json::json!({ "file_path": p });
+        tracker.record_tool_file_effects(tool_names::EDIT_FILE, &edit_args, false);
+        assert!(tracker.assert_fresh(p).is_ok());
+
+        // Errored tool calls record nothing.
+        std::fs::write(&path, "gamma\n").unwrap();
+        tracker.record_tool_file_effects(tool_names::EDIT_FILE, &edit_args, true);
+        assert!(tracker.assert_fresh(p).is_err());
+        std::fs::remove_file(&path).ok();
     }
 }

--- a/src-tauri/crates/agent-core/src/core/turn_executor/tool_execution/parallel.rs
+++ b/src-tauri/crates/agent-core/src/core/turn_executor/tool_execution/parallel.rs
@@ -276,11 +276,9 @@ pub(super) async fn execute_parallel_group(
         };
         let is_error = rich.is_none() || is_error_text(&raw_text);
 
-        if FILE_READ_TOOLS.contains(&call.name.as_str()) && !is_error {
-            for path in extract_file_paths(&call.name, &exec_result.effective_args) {
-                file_tracker.record_read(&path);
-            }
-        }
+        // Single entry point keeps read/write bookkeeping identical to the
+        // sequential path in `single.rs` (no drift).
+        file_tracker.record_tool_file_effects(&call.name, &exec_result.effective_args, is_error);
 
         let budget = tools.get(&call.name).map(|t| t.output_budget());
         let mut truncated = truncate_output(&raw_text, budget);

--- a/src-tauri/crates/agent-core/src/core/turn_executor/tool_execution/single.rs
+++ b/src-tauri/crates/agent-core/src/core/turn_executor/tool_execution/single.rs
@@ -245,16 +245,11 @@ pub(super) async fn execute_single_tool(
             let is_error = rich.is_none() || is_error_text(&raw_result);
             result_is_error = is_error;
 
-            if FILE_READ_TOOLS.contains(&tool_call.name.as_str()) && !is_error {
-                for path in extract_file_paths(&tool_call.name, &effective_args) {
-                    file_tracker.record_read(&path);
-                }
-            }
+            // Single entry point keeps read/write bookkeeping identical to the
+            // concurrent path in `parallel.rs` (no drift).
+            file_tracker.record_tool_file_effects(&tool_call.name, &effective_args, is_error);
             if is_file_write_tool(&tool_call.name) && !is_error {
                 let changed_paths = extract_file_paths(&tool_call.name, &effective_args);
-                for path in &changed_paths {
-                    file_tracker.record_write(path);
-                }
                 if !changed_paths.is_empty() {
                     handler.on_file_change(session_id, &tool_call.name, &changed_paths);
                 }

--- a/src-tauri/crates/orgtrack-core/src/edit_extraction.rs
+++ b/src-tauri/crates/orgtrack-core/src/edit_extraction.rs
@@ -121,38 +121,108 @@ pub fn final_diff_from_chunks(
     file_path: &str,
     chunks: &[SessionDiffChunkRecord],
 ) -> Option<SessionFinalDiffRecord> {
-    let baseline_chunk = chunks
+    let file_chunks: Vec<&SessionDiffChunkRecord> = chunks
         .iter()
         .filter(|chunk| chunk.file_path == file_path)
+        .collect();
+    let baseline_chunk = file_chunks
+        .iter()
+        .copied()
         .find(|chunk| chunk.old_content.is_some());
-    let final_chunk = chunks
+    let final_chunk = file_chunks.iter().copied().rev().find(|chunk| {
+        chunk.new_content.is_some() || chunk.old_content.is_some() || chunk.diff.is_some()
+    })?;
+
+    // A chunk's `old_content`/`new_content` is the LOCAL old_string/new_string
+    // fragment of that single edit, NOT a whole-file snapshot. Stitching the
+    // first chunk's old fragment to the last chunk's new fragment (the previous
+    // behaviour) diffs two unrelated fragments and collapses the cumulative
+    // numstat to a tiny, wrong value (issue: Diff panel shows +4 instead of
+    // +105). The authoritative cumulative diff is the union of every chunk's
+    // unified-diff hunks, merged by old-file line number with later edits
+    // winning on overlap — exactly what the frontend `mergeUnifiedDiffStrings`
+    // does. We compute the numstat from those merged hunks.
+    let raw_diffs: Vec<&str> = file_chunks
         .iter()
-        .rev()
-        .filter(|chunk| chunk.file_path == file_path)
-        .find(|chunk| {
-            chunk.new_content.is_some() || chunk.old_content.is_some() || chunk.diff.is_some()
-        });
-    let final_chunk = final_chunk?;
-    let old_content = baseline_chunk
-        .and_then(|chunk| chunk.old_content.clone())
-        .or_else(|| final_chunk.old_content.clone())
-        .or_else(|| final_chunk.new_content.as_ref().map(|_| String::new()));
-    let new_content = if final_chunk.is_deleted {
+        .filter_map(|chunk| chunk.diff.as_deref())
+        .filter(|diff| !diff.trim().is_empty())
+        .collect();
+
+    let summed_lines_added: i32 = file_chunks.iter().map(|chunk| chunk.lines_added).sum();
+    let summed_lines_removed: i32 = file_chunks.iter().map(|chunk| chunk.lines_removed).sum();
+
+    // Discriminator: if any chunk carries a unified-diff string we take the
+    // MERGE path (fragment edits: edit_file / edit_file_by_replace / apply_
+    // patch). Only when no chunk has a diff (create / delete / full overwrite,
+    // which carry whole-file content instead) do we fall back to whole-file
+    // content stitching, correct for that single-snapshot shape.
+    let has_fragment_diffs = !raw_diffs.is_empty();
+    // Whole-file old/new content is only trustworthy on the stitch path. On the
+    // merge path we never expose a fragment's content as if it were whole-file
+    // content -- the merged unified diff is the artifact.
+    let old_content = if has_fragment_diffs {
+        None
+    } else {
+        baseline_chunk
+            .and_then(|chunk| chunk.old_content.clone())
+            .or_else(|| final_chunk.new_content.as_ref().map(|_| String::new()))
+    };
+    let new_content = if has_fragment_diffs {
+        None
+    } else if final_chunk.is_deleted {
         Some(String::new())
     } else {
         final_chunk.new_content.clone()
     };
-    let diff = match (&old_content, &new_content) {
-        (Some(old_content), Some(new_content)) => {
-            let text_diff = similar::TextDiff::from_lines(old_content, new_content);
-            let unified_diff = text_diff.unified_diff().to_string();
-            if unified_diff.trim().is_empty() {
-                return None;
+
+    let (diff, final_numstat) = if has_fragment_diffs {
+        // Merge path: union every chunk's hunks; numstat from the merged diff.
+        match merge_unified_diff_hunks(&raw_diffs) {
+            Some((merged_diff, numstat)) => {
+                if numstat == (0, 0) {
+                    // Net-zero (an edit fully reverted by a later overlapping one).
+                    return None;
+                }
+                (Some(merged_diff), numstat)
             }
-            Some(unified_diff)
+            // Diffs present but unparseable -- fall back to the per-chunk stat
+            // sum so we never silently report zero impact.
+            None => {
+                if summed_lines_added == 0 && summed_lines_removed == 0 {
+                    return None;
+                }
+                (
+                    final_chunk.diff.clone(),
+                    (summed_lines_added, summed_lines_removed),
+                )
+            }
         }
-        _ => final_chunk.diff.clone(),
+    } else {
+        // Stitch path: whole-file content snapshot (create / delete / overwrite).
+        match (&old_content, &new_content) {
+            (Some(old_content), Some(new_content)) => {
+                let text_diff = similar::TextDiff::from_lines(old_content, new_content);
+                let unified_diff = text_diff.unified_diff().to_string();
+                if unified_diff.trim().is_empty() {
+                    return None;
+                }
+                let numstat = text_diff.iter_all_changes().fold(
+                    (0_i32, 0_i32),
+                    |(added, removed), change| match change.tag() {
+                        similar::ChangeTag::Insert => (added + 1, removed),
+                        similar::ChangeTag::Delete => (added, removed + 1),
+                        similar::ChangeTag::Equal => (added, removed),
+                    },
+                );
+                (Some(unified_diff), numstat)
+            }
+            _ => (
+                final_chunk.diff.clone(),
+                (final_chunk.lines_added, final_chunk.lines_removed),
+            ),
+        }
     };
+
     let quality = if old_content.is_some() && new_content.is_some() {
         ArtifactQuality::Exact
     } else if diff.is_some() {
@@ -160,31 +230,7 @@ pub fn final_diff_from_chunks(
     } else {
         ArtifactQuality::Inferred
     };
-    let summed_lines_added: i32 = chunks
-        .iter()
-        .filter(|chunk| chunk.file_path == file_path)
-        .map(|chunk| chunk.lines_added)
-        .sum();
-    let summed_lines_removed: i32 = chunks
-        .iter()
-        .filter(|chunk| chunk.file_path == file_path)
-        .map(|chunk| chunk.lines_removed)
-        .sum();
-    let final_numstat = old_content
-        .as_deref()
-        .zip(new_content.as_deref())
-        .map(|(old_content, new_content)| {
-            let diff = similar::TextDiff::from_lines(old_content, new_content);
-            diff.iter_all_changes()
-                .fold((0_i32, 0_i32), |(added, removed), change| {
-                    match change.tag() {
-                        similar::ChangeTag::Insert => (added + 1, removed),
-                        similar::ChangeTag::Delete => (added, removed + 1),
-                        similar::ChangeTag::Equal => (added, removed),
-                    }
-                })
-        })
-        .unwrap_or((final_chunk.lines_added, final_chunk.lines_removed));
+
     Some(SessionFinalDiffRecord {
         schema_version: ORGTRACK_SCHEMA_VERSION,
         record_id: record_id(&["final_diff", source, session_id, file_path]),
@@ -204,6 +250,106 @@ pub fn final_diff_from_chunks(
             || final_numstat.1 != summed_lines_removed,
         computed_at: Utc::now().to_rfc3339(),
     })
+}
+
+/// A single parsed unified-diff hunk: header line numbers plus the raw body
+/// lines (context / `+` / `-`), excluding the `@@` header itself.
+struct DiffHunk {
+    old_start: i64,
+    old_count: i64,
+    body: Vec<String>,
+}
+
+/// Parse the `@@ -a,b +c,d @@` header. `b`/`d` default to 1 when omitted,
+/// matching unified-diff conventions and the frontend `mergeUnifiedDiffStrings`.
+fn parse_hunk_header(line: &str) -> Option<(i64, i64, i64, i64)> {
+    let rest = line.strip_prefix("@@ -")?;
+    let (old_part, after_old) = rest.split_once(" +")?;
+    let new_part = after_old.split(" @@").next()?;
+    let parse_pair = |segment: &str| -> Option<(i64, i64)> {
+        match segment.split_once(',') {
+            Some((start, count)) => Some((start.trim().parse().ok()?, count.trim().parse().ok()?)),
+            None => Some((segment.trim().parse().ok()?, 1)),
+        }
+    };
+    let (old_start, old_count) = parse_pair(old_part)?;
+    let (new_start, new_count) = parse_pair(new_part)?;
+    Some((old_start, old_count, new_start, new_count))
+}
+
+/// Merge every chunk's unified-diff hunks into one cumulative diff and count
+/// its `+`/`-` lines. Hunks are sorted by old-file start line; a later hunk
+/// that overlaps an earlier one wins (edit-order / last-writer-wins), mirroring
+/// the frontend `mergeUnifiedDiffStrings` so the panel and the stored final
+/// diff agree. Returns the merged unified-diff string and its `(added, removed)`
+/// numstat, or `None` when there are no parseable hunks.
+fn merge_unified_diff_hunks(diffs: &[&str]) -> Option<(String, (i32, i32))> {
+    let mut hunks: Vec<DiffHunk> = Vec::new();
+    for diff in diffs {
+        let mut current: Option<DiffHunk> = None;
+        for line in diff.split('\n') {
+            if line.starts_with("---") || line.starts_with("+++") {
+                continue;
+            }
+            if line.starts_with("diff ") || line.starts_with("index ") {
+                continue;
+            }
+            if let Some((old_start, old_count, _new_start, _new_count)) = parse_hunk_header(line) {
+                if let Some(hunk) = current.take() {
+                    hunks.push(hunk);
+                }
+                current = Some(DiffHunk {
+                    old_start,
+                    old_count,
+                    body: Vec::new(),
+                });
+                continue;
+            }
+            if let Some(hunk) = current.as_mut() {
+                hunk.body.push(line.to_string());
+            }
+        }
+        if let Some(hunk) = current.take() {
+            hunks.push(hunk);
+        }
+    }
+
+    if hunks.is_empty() {
+        return None;
+    }
+
+    // Stable sort by old-file start so equal-start hunks keep edit order.
+    hunks.sort_by_key(|hunk| hunk.old_start);
+
+    // Drop earlier hunks fully overlapped by a later one (last writer wins).
+    let mut merged: Vec<DiffHunk> = Vec::new();
+    for hunk in hunks {
+        while let Some(prev) = merged.last() {
+            if prev.old_start + prev.old_count > hunk.old_start {
+                merged.pop();
+            } else {
+                break;
+            }
+        }
+        merged.push(hunk);
+    }
+
+    let mut added = 0_i32;
+    let mut removed = 0_i32;
+    let mut parts: Vec<String> = Vec::new();
+    for hunk in &merged {
+        for body_line in &hunk.body {
+            if body_line.starts_with('+') && !body_line.starts_with("+++") {
+                added += 1;
+            } else if body_line.starts_with('-') && !body_line.starts_with("---") {
+                removed += 1;
+            }
+        }
+        parts.push(format!("@@ -{},{} @@", hunk.old_start, hunk.old_count));
+        parts.extend(hunk.body.iter().cloned());
+    }
+
+    Some((parts.join("\n"), (added, removed)))
 }
 
 fn edit_quality(edit: &ExtractedEditData) -> ArtifactQuality {

--- a/src-tauri/crates/orgtrack-core/src/edit_extraction_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/edit_extraction_tests.rs
@@ -135,3 +135,126 @@ fn final_diff_counts_deleted_file_to_empty_final_content() {
     assert_eq!(final_diff.new_content.as_deref(), Some(""));
     assert!(matches!(final_diff.quality, ArtifactQuality::Exact));
 }
+
+// ---------------------------------------------------------------------------
+// Cumulative multi-edit numstat (the Diff-panel "+4 instead of +105" bug).
+//
+// Real edit_file / edit_file_by_replace / apply_patch chunks carry a LOCAL
+// old_string/new_string fragment plus a compact unified `diff`. The old
+// `final_diff_from_chunks` diffed the first chunk's old fragment against the
+// last chunk's new fragment, collapsing the cumulative numstat. These tests
+// build chunks the realistic way (via a `diff` string) and assert the merge
+// path recovers the true cumulative count.
+// ---------------------------------------------------------------------------
+
+fn diff_chunk(
+    sequence_index: i64,
+    file_path: &str,
+    diff: &str,
+    lines_added: i32,
+    lines_removed: i32,
+) -> crate::canonical::SessionDiffChunkRecord {
+    crate::canonical::SessionDiffChunkRecord {
+        schema_version: crate::privacy::ORGTRACK_SCHEMA_VERSION,
+        record_id: format!("chunk-{sequence_index}"),
+        edit_record_id: format!("edit-{sequence_index}"),
+        source: "test_source".to_string(),
+        session_id: "session-1".to_string(),
+        source_event_id: Some(format!("event-{sequence_index}")),
+        sequence_index,
+        chunk_index: 0,
+        file_path: file_path.to_string(),
+        old_start_line: None,
+        new_start_line: None,
+        // LOCAL fragments, deliberately unrelated to each other -- this is what
+        // made the old stitch path collapse to a tiny number.
+        old_content: Some("local old fragment".to_string()),
+        new_content: Some("local new fragment".to_string()),
+        diff: Some(diff.to_string()),
+        lines_added,
+        lines_removed,
+        is_deleted: false,
+        quality: ArtifactQuality::PatchReversible,
+    }
+}
+
+#[test]
+fn final_diff_sums_disjoint_fragment_edits_instead_of_stitching() {
+    let file_path = "tests/example.mjs";
+    // Three edits at disjoint line ranges: +1, +37, +1  => cumulative +39.
+    // The old behaviour stitched fragment-old vs fragment-new => a tiny wrong
+    // value (the real-world report was +4).
+    let chunks = vec![
+        diff_chunk(
+            0,
+            file_path,
+            "@@ -5,4 +5,5 @@\n ctxA\n ctxB\n+added near top\n ctxC\n ctxD",
+            1,
+            0,
+        ),
+        diff_chunk(
+            1,
+            file_path,
+            &format!(
+                "@@ -989,4 +989,41 @@\n }}\n \n{}\n ctxTail",
+                (0..37)
+                    .map(|i| format!("+inserted line {i}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            ),
+            37,
+            0,
+        ),
+        diff_chunk(
+            2,
+            file_path,
+            "@@ -2013,4 +2013,5 @@\n ctxX\n ctxY\n+added near bottom\n ctxZ\n ctxW",
+            1,
+            0,
+        ),
+    ];
+
+    let final_diff = final_diff_from_chunks("test_source", "session-1", file_path, &chunks)
+        .expect("cumulative final diff");
+
+    assert_eq!(
+        final_diff.lines_added, 39,
+        "disjoint fragment edits must sum (1+37+1), not collapse"
+    );
+    assert_eq!(final_diff.lines_removed, 0);
+    // Merge path never exposes fragment content as whole-file content.
+    assert!(final_diff.old_content.is_none());
+    assert!(final_diff.new_content.is_none());
+}
+
+#[test]
+fn final_diff_merge_path_lets_later_overlapping_edit_win() {
+    let file_path = "src/overlap.ts";
+    // Two edits to the SAME old-line range: the later one replaces the earlier.
+    // Cumulative count must reflect only the surviving (later) hunk, not the sum.
+    let chunks = vec![
+        diff_chunk(
+            0,
+            file_path,
+            "@@ -10,2 +10,3 @@\n keep\n+first attempt\n tail",
+            1,
+            0,
+        ),
+        diff_chunk(
+            1,
+            file_path,
+            "@@ -10,2 +10,4 @@\n keep\n+second attempt a\n+second attempt b\n tail",
+            2,
+            0,
+        ),
+    ];
+
+    let final_diff = final_diff_from_chunks("test_source", "session-1", file_path, &chunks)
+        .expect("overlap final diff");
+
+    // Later hunk (2 additions) wins over the earlier overlapping hunk (1).
+    assert_eq!(final_diff.lines_added, 2);
+    assert_eq!(final_diff.lines_removed, 0);
+    // Sum would have been 3; merge yields 2 -> differs flag set.
+    assert!(final_diff.differs_from_summed_chunks);
+}

--- a/src-tauri/src/orgtrack/mod.rs
+++ b/src-tauri/src/orgtrack/mod.rs
@@ -8,7 +8,7 @@ pub mod paths;
 pub mod types;
 
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -364,6 +364,14 @@ fn commit_link_to_submission_commit(
     }
 }
 
+fn is_temporary_diff_path(file_path: &str) -> bool {
+    let path = Path::new(file_path);
+    path.starts_with("/tmp")
+        || path
+            .components()
+            .any(|component| component.as_os_str() == "scratchpad")
+}
+
 #[tauri::command]
 pub async fn orgtrack_get_diff_replay_preview(
     source: Option<String>,
@@ -375,7 +383,11 @@ pub async fn orgtrack_get_diff_replay_preview(
     tokio::task::spawn_blocking(move || {
         let conn = get_connection().map_err(|err| err.to_string())?;
         let store = SqliteRecordStore::new(&conn);
-        let final_diffs = store.list_final_diffs(source.as_deref(), session_id.as_deref())?;
+        let final_diffs = store
+            .list_final_diffs(source.as_deref(), session_id.as_deref())?
+            .into_iter()
+            .filter(|diff| !is_temporary_diff_path(&diff.file_path))
+            .collect();
         let commit_links = store.list_commit_links()?;
         let commit_links = match session_id {
             Some(session_id) => commit_links
@@ -567,6 +579,25 @@ pub async fn orgtrack_get_checkpoint_file_states(
     })
     .await
     .map_err(|err| err.to_string())?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_temporary_diff_path;
+
+    #[test]
+    fn hides_tmp_and_scratchpad_diff_paths() {
+        assert!(is_temporary_diff_path("/tmp/stale_probe.txt"));
+        assert!(is_temporary_diff_path(
+            "/private/var/folders/sj/orgii-501/project/sdeagent-id/scratchpad/stale_probe.txt"
+        ));
+        assert!(!is_temporary_diff_path(
+            "/Users/vinceorz/Projects/ORG2/src/main.ts"
+        ));
+        assert!(!is_temporary_diff_path(
+            "/Users/vinceorz/Downloads/notes.txt"
+        ));
+    }
 }
 
 fn validate_tier(

--- a/src/modules/WorkStation/Diff/SessionReplay/useSubmissionsData.ts
+++ b/src/modules/WorkStation/Diff/SessionReplay/useSubmissionsData.ts
@@ -19,13 +19,14 @@
  * (session change → fetches kick off → derived rows resolve) read top to
  * bottom in one place.
  */
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { getGitCommitDiff, getGitCommits } from "@src/api/http/git";
 import type { CommitDiffResult, GitCommitInfo } from "@src/api/http/git/types";
 import { getPRLocal } from "@src/api/tauri/github";
 import {
   type OrgtrackSessionFinalDiff,
+  analyzeOrgtrackSessions,
   getOrgtrackDiffReplayPreview,
 } from "@src/api/tauri/lineage";
 import type { SessionEvent } from "@src/engines/SessionCore/core/types";
@@ -156,6 +157,12 @@ export function useSubmissionsData({
   const [orgtrackSubmissionCommits, setOrgtrackSubmissionCommits] = useState<
     SubmissionCommit[]
   >([]);
+  // One-shot guard: each sessionId may trigger at most one lazy rebuild of its
+  // orgtrack final diffs (to repair rows written before the cumulative-diff
+  // fix). Without this guard a session whose diffs are legitimately empty would
+  // re-request analysis on every render.
+  const rebuiltSessionsRef = useRef<Set<string>>(new Set());
+  const [rebuildNonce, setRebuildNonce] = useState(0);
 
   useEffect(() => {
     if (!sessionId) {
@@ -172,9 +179,30 @@ export function useSubmissionsData({
       repoPath: fallbackRepoContext.repoPath,
     })
       .then((preview) => {
-        if (!cancelled) {
-          setOrgtrackFinalDiffs(preview.finalDiffs);
-          setOrgtrackSubmissionCommits(preview.submissionCommits);
+        if (cancelled) return;
+        setOrgtrackFinalDiffs(preview.finalDiffs);
+        setOrgtrackSubmissionCommits(preview.submissionCommits);
+        // Lazily repair sessions whose final diffs were never extracted (or
+        // were written by the pre-fix collapsing path, surfacing as zero rows
+        // despite the session having edited files). Re-run analysis once, then
+        // re-fetch. Guarded per-session so it never loops.
+        if (
+          preview.finalDiffs.length === 0 &&
+          !rebuiltSessionsRef.current.has(sessionId)
+        ) {
+          rebuiltSessionsRef.current.add(sessionId);
+          void analyzeOrgtrackSessions({ sessionId, rebuild: true })
+            .then((stats) => {
+              if (!cancelled && stats.analyzedSessions > 0) {
+                setRebuildNonce((nonce) => nonce + 1);
+              }
+            })
+            .catch((err: unknown) => {
+              logger.warn("failed to rebuild orgtrack final diffs", {
+                err,
+                sessionId,
+              });
+            });
         }
       })
       .catch((err: unknown) => {
@@ -197,6 +225,7 @@ export function useSubmissionsData({
   }, [
     sessionId,
     diffRefreshNonce,
+    rebuildNonce,
     fallbackRepoContext.repoId,
     fallbackRepoContext.repoPath,
   ]);


### PR DESCRIPTION
Pre-commit hook ran. Total eslint: 0, total circular: 0

This is the fix for https://github.com/yorgai/ORG2/issues/167


## Summary

-

## Test plan

- [ ] I ran the checks relevant to the changed files, or explained why they were not run.

## Contributor checklist

- [ ] The PR title uses scoped Conventional Commits format, such as `feat(scope): summary` or `fix(scope): summary`.
- [ ] All commits use scoped Conventional Commits format.
- [ ] I did not skip pre-commit, pre-push, lint-staged, or other repository hooks.
- [ ] The PR is scoped to one issue, feature, or fix.
- [ ] I have signed the CLA if prompted by the CLA Assistant bot.
- [ ] A human actively participated in the design and implementation process, and reviewed the contribution before submission.
- [ ] I did not include secrets, private configuration, generated build output, or unrelated formatting changes.
- [ ] I updated documentation for behavior, setup, or architecture changes where needed.
- [ ] I updated all supported locale files for new UI text where needed.
