### PR TITLE
fix(chat): continue original request after switching to Plan mode (#168)

### DIFF
--- a/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/suggest_mode_switch.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/suggest_mode_switch.rs
@@ -204,9 +204,23 @@ impl Tool for SuggestModeSwitchTool {
 
         match choice {
             ModeSwitchChoice::Switch(mode) => {
+                // The `SWITCH_ACCEPTED_PREFIX` is the only load-bearing part for
+                // the CURRENT (Build) turn: `single.rs` matches the prefix and
+                // ends the turn immediately with an empty continuation, so this
+                // turn's LLM never reads the prose below.
+                //
+                // The prose IS read by the NEXT turn — the frontend resumes the
+                // session in the new mode (content="", is_resume=true), and that
+                // resume turn's LLM sees this tool_result at the tail of history.
+                // It must therefore instruct the agent to CARRY ON with the
+                // original request under the new mode, not to stop. A prior
+                // "Stop now." wording stranded the resume turn: the agent read it
+                // and halted after merely acknowledging the switch (GH #168).
                 Ok(format!(
-                    "{}{}. The mode change will take effect on the next message. Stop now.",
-                    SWITCH_ACCEPTED_PREFIX, mode
+                    "{}{}. You are now in {} mode. Continue with the user's \
+                     original request under the new mode now — do not stop to \
+                     ask for confirmation.",
+                    SWITCH_ACCEPTED_PREFIX, mode, mode
                 ))
             }
             ModeSwitchChoice::Skip => {

--- a/src/engines/ChatPanel/InputArea/ModeSwitchCard/useModeSwitchActions.test.ts
+++ b/src/engines/ChatPanel/InputArea/ModeSwitchCard/useModeSwitchActions.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { switchMode } from "./useModeSwitchActions";
+
+const storeGetSpy = vi.hoisted(() => vi.fn());
+const sendMessageSpy = vi.hoisted(() => vi.fn());
+const respondModeSwitchSpy = vi.hoisted(() => vi.fn());
+const rpcPatchSpy = vi.hoisted(() => vi.fn());
+const updateByIdSpy = vi.hoisted(() => vi.fn());
+const getSnapshotSpy = vi.hoisted(() => vi.fn());
+const upsertSessionSpy = vi.hoisted(() => vi.fn());
+const beginOptimisticTurnSpy = vi.hoisted(() => vi.fn());
+const isAgentSessionSpy = vi.hoisted(() => vi.fn());
+const isCursorIdeSessionSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("@src/util/core/state/instrumentedStore", () => ({
+  getInstrumentedStore: () => ({ get: storeGetSpy }),
+}));
+
+vi.mock("@src/engines/SessionCore/services/SessionService", () => ({
+  SessionService: { sendMessage: sendMessageSpy },
+}));
+
+vi.mock("@src/api/tauri/agent", () => ({
+  respondModeSwitch: respondModeSwitchSpy,
+}));
+
+vi.mock("@src/api/tauri/cursorBridge", () => ({
+  cursorBridgeSetMode: vi.fn(),
+}));
+
+vi.mock("@src/api/tauri/rpc", () => ({
+  rpc: { sessionAggregate: { patch: rpcPatchSpy } },
+}));
+
+vi.mock("@src/engines/SessionCore/control/optimisticTurnStatus", () => ({
+  beginOptimisticTurn: beginOptimisticTurnSpy,
+  failOptimisticTurn: vi.fn(),
+}));
+
+vi.mock("@src/engines/SessionCore/core/atoms", () => ({
+  eventsAtom: { __tag: "eventsAtom" },
+}));
+
+vi.mock("@src/engines/SessionCore/core/store/EventStoreProxy", () => ({
+  eventStoreProxy: {
+    updateById: updateByIdSpy,
+    getLatestSessionSnapshot: getSnapshotSpy,
+  },
+}));
+
+vi.mock("@src/store/session/creatorDefaultModelAtom", () => ({
+  creatorDefaultModelSelectionAtom: {
+    __tag: "creatorDefaultModelSelectionAtom",
+  },
+}));
+
+vi.mock("@src/store/session/cursorModeOverrideAtom", () => ({
+  cursorModeOverrideAtomFamily: () => ({ __tag: "cursorModeOverride" }),
+}));
+
+vi.mock("@src/store/session/sessionAtom", () => ({
+  sessionByIdAtom: (id: string) => ({ __tag: "sessionByIdAtom", id }),
+  upsertSession: upsertSessionSpy,
+}));
+
+vi.mock("@src/store/session/viewAtom", () => ({
+  activeSessionIdAtom: { __tag: "activeSessionIdAtom" },
+}));
+
+vi.mock("@src/util/session/resolveModelForMessage", () => ({
+  resolveModelForMessage: () => ({ model: "test-model", accountId: "acct-1" }),
+}));
+
+vi.mock("@src/util/session/sessionDispatch", () => ({
+  composerIdFromSessionId: () => "composer-1",
+  isAgentSession: isAgentSessionSpy,
+  isCursorIdeSession: isCursorIdeSessionSpy,
+}));
+
+const SESSION_ID = "agent-builtin:sde-abc";
+
+function setupStore(opts: { lastUserText?: string; agentExecMode?: string }) {
+  const sessionRow = {
+    id: SESSION_ID,
+    agentExecMode: opts.agentExecMode ?? "build",
+    model: "test-model",
+    accountId: "acct-1",
+  };
+  storeGetSpy.mockImplementation((atom: { __tag?: string }) => {
+    if (atom?.__tag === "activeSessionIdAtom") return SESSION_ID;
+    if (atom?.__tag === "sessionByIdAtom") return sessionRow;
+    if (atom?.__tag === "creatorDefaultModelSelectionAtom") return undefined;
+    return undefined;
+  });
+  getSnapshotSpy.mockReturnValue({
+    events: opts.lastUserText
+      ? [{ source: "user", displayText: opts.lastUserText }]
+      : [],
+  });
+}
+
+describe("switchMode → switchAgentMode resume", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isCursorIdeSessionSpy.mockReturnValue(false);
+    isAgentSessionSpy.mockReturnValue(true);
+    delete (window as { __ORGII_E2E_MODE_SWITCH_MOCK__?: boolean })
+      .__ORGII_E2E_MODE_SWITCH_MOCK__;
+    sendMessageSpy.mockResolvedValue(undefined);
+    respondModeSwitchSpy.mockResolvedValue(undefined);
+    rpcPatchSpy.mockResolvedValue(undefined);
+    updateByIdSpy.mockResolvedValue(undefined);
+  });
+
+  it("resumes the turn even when the user's message opens with switch-style wording", async () => {
+    // Regression: this command-style prompt previously matched the deleted
+    // text guard (`/切.*模式/`) and the resume was skipped, stranding the turn.
+    setupStore({
+      lastUserText: "切模式检查，你找到 root cause 写个修复 plan 给我",
+    });
+
+    await switchMode("event-1", "plan");
+
+    expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+    expect(sendMessageSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: SESSION_ID,
+        content: "",
+        isResume: true,
+        mode: "plan",
+      })
+    );
+    expect(beginOptimisticTurnSpy).toHaveBeenCalledWith(SESSION_ID);
+  });
+
+  it("resumes the turn for an ordinary task prompt", async () => {
+    setupStore({ lastUserText: "add a unit test for the parser" });
+
+    await switchMode("event-2", "plan");
+
+    expect(sendMessageSpy).toHaveBeenCalledTimes(1);
+    expect(sendMessageSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ content: "", isResume: true, mode: "plan" })
+    );
+  });
+
+  it("does not resume when there is no prior user message to anchor on", async () => {
+    setupStore({ lastUserText: undefined });
+
+    await switchMode("event-3", "plan");
+
+    expect(sendMessageSpy).not.toHaveBeenCalled();
+    expect(beginOptimisticTurnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/engines/ChatPanel/InputArea/ModeSwitchCard/useModeSwitchActions.ts
+++ b/src/engines/ChatPanel/InputArea/ModeSwitchCard/useModeSwitchActions.ts
@@ -93,26 +93,6 @@ async function markModeSwitchEventResolved(
   );
 }
 
-/**
- * Patterns that indicate the user's message was itself a mode-switch command
- * rather than a real task. Re-sending these into the new mode would trigger
- * another suggest_mode_switch call and create an infinite loop.
- */
-const MODE_SWITCH_COMMAND_PATTERNS = [
-  /switch\s*(to\s*)?(plan|build|debug|ask|review)\s*mode?/i,
-  /enter\s*(plan|build|debug|ask|review)\s*mode?/i,
-  /go\s+to\s*(plan|build|debug|ask|review)\s*mode?/i,
-  /use\s*(plan|build|debug|ask|review)\s*mode?/i,
-  /切换.*mode/i,
-  /切.*plan/i,
-  /进入.*mode/i,
-  /切.*模式/i,
-];
-
-function isModeSwitchCommand(text: string): boolean {
-  return MODE_SWITCH_COMMAND_PATTERNS.some((re) => re.test(text));
-}
-
 function getLastUserText(sessionId: string): string {
   // Prefer the per-session snapshot cache so we always read the correct
   // session's events even when the global eventsAtom hasn't settled yet
@@ -149,9 +129,12 @@ async function switchCursorIdeMode(
   await cursorBridgeSetMode({ agentId: composerId, modeId: targetMode });
 
   const lastUserText = getLastUserText(sessionId);
-  // Bug-fix: same guard as switchAgentMode — skip resend when the user's
-  // last message was itself a mode-switch command to avoid an infinite loop.
-  if (!lastUserText || isModeSwitchCommand(lastUserText)) return;
+  // Only skip the resend when there is no prior user message to anchor on.
+  // A loop is impossible by construction: every read-only mode (Plan, Ask,
+  // Debug, Review) denies `suggest_mode_switch` via `read_only_deny_base`,
+  // so the tool is absent from the LLM's toolset after the switch and cannot
+  // re-trigger another mode-switch.
+  if (!lastUserText) return;
 
   // No beginOptimisticTurn here: Cursor IDE sessions have no turn lifecycle
   // (the CDP stream emits no terminal event), so an optimistic `running`
@@ -195,11 +178,16 @@ async function switchAgentMode(
   await respondModeSwitch(sessionId, "switch", targetMode);
 
   const lastUserText = getLastUserText(sessionId);
-  // Do not continue if there is no prior user message, or if the last user
-  // message was itself a mode-switch command. Re-running a request to switch
-  // into Plan mode would trigger another suggest_mode_switch call and
-  // create an infinite switching loop.
-  if (!lastUserText || isModeSwitchCommand(lastUserText)) return;
+  // Only skip the resume when there is no prior user message to anchor the
+  // re-run on. We deliberately do NOT inspect the message text: a user's real
+  // task can legitimately open with switch-style wording (e.g. "切模式检查…
+  // 写个修复 plan 给我"), and dropping the resume in that case strands the turn
+  // — the round flips to Plan but the agent never continues (the reported bug).
+  // An infinite switch loop is impossible by construction: every read-only mode
+  // (Plan, Ask, Debug, Review) denies `suggest_mode_switch` via
+  // `read_only_deny_base`, so the tool is absent from the LLM's toolset after
+  // the switch and cannot re-trigger another mode-switch.
+  if (!lastUserText) return;
 
   // Re-run the SAME request under the new mode WITHOUT persisting a new
   // visible user message. The frontend groups chat history into rounds by


### PR DESCRIPTION
Accepting the "Switch to Plan?" card flipped the round to Plan but the agent stopped after merely acknowledging the switch ("已切到 Plan mode.") instead of producing the plan the user asked for.

Two independent defects combined to strand the resume turn:

1. The `suggest_mode_switch` tool result said "...take effect on the next message. Stop now." That prose is only meant for the CURRENT (Build) turn, which actually ends via the `MODE_SWITCH_ACCEPTED:` sentinel in `single.rs` — the Build turn's LLM never reads it. But the string persists in history, so the RESUME turn's LLM (content="", is_resume=true, now in Plan mode) reads "Stop now" at the tail and halts. Rewrite the Switch-arm result to instruct the resume turn to carry on with the user's original request under the new mode. The load-bearing `MODE_SWITCH_ACCEPTED:` prefix is preserved.

2. `switchAgentMode`/`switchCursorIdeMode` skipped the resume entirely when the user's last message matched a mode-switch text heuristic (`isModeSwitchCommand`, e.g. "切模式…"). A real task can legitimately open with switch-style wording, so dropping the resume stranded the turn. Remove the blocklist-style guard and its patterns: an infinite switch loop is impossible by construction because every read-only mode (Plan, Ask, Debug, Review) denies `suggest_mode_switch` via `read_only_deny_base`, so the tool is absent from the toolset after the switch and cannot re-trigger.

Resume still uses content="" + isResume=true (GH #91) so the new-mode run stays inside the original round.

Verification:
- Live repro (sessions.db): after the fix the resume turn keeps a single user_message (same round) and the agent proceeds past the switch ack.
- vitest useModeSwitchActions.test.ts (3/3) covers command-style prompts triggering the resume and the no-prior-message skip.
- cargo check -p agent_core passes.

Pre-commit hook ran. Total eslint: 0, total circular: 0

this is the PR for https://github.com/yorgai/ORG2/issues/168

## Summary

-

## Test plan

- [ ] I ran the checks relevant to the changed files, or explained why they were not run.

## Contributor checklist

- [ ] The PR title uses scoped Conventional Commits format, such as `feat(scope): summary` or `fix(scope): summary`.
- [ ] All commits use scoped Conventional Commits format.
- [ ] I did not skip pre-commit, pre-push, lint-staged, or other repository hooks.
- [ ] The PR is scoped to one issue, feature, or fix.
- [ ] I have signed the CLA if prompted by the CLA Assistant bot.
- [ ] A human actively participated in the design and implementation process, and reviewed the contribution before submission.
- [ ] I did not include secrets, private configuration, generated build output, or unrelated formatting changes.
- [ ] I updated documentation for behavior, setup, or architecture changes where needed.
- [ ] I updated all supported locale files for new UI text where needed.
