### PR TITLE
feat(browser): add selected element conversation capsule

### DIFF
--- a/src/engines/ChatPanel/ChatFloatingComposer.tsx
+++ b/src/engines/ChatPanel/ChatFloatingComposer.tsx
@@ -186,7 +186,10 @@ const ChatFloatingComposer: React.FC<ChatFloatingComposerProps> = memo(
 
     const hasLocalInlineSection =
       hasAnyInlineSection || fileChangeStats.count > 0;
-    const showTopRowPills = hasLocalInlineSection || scrollNav?.showFollowAgent;
+    const showTopRowPills =
+      hasLocalInlineSection ||
+      scrollNav?.showFollowAgent ||
+      scrollNav?.showAddToConversation;
     const trailingScrollButton = scrollNav?.showScrollToBottom ? (
       <Button
         variant="secondary"

--- a/src/engines/ChatPanel/ChatHistory/index.tsx
+++ b/src/engines/ChatPanel/ChatHistory/index.tsx
@@ -153,7 +153,15 @@ export interface FollowAgentNavState {
   onFollowAgent: () => void;
 }
 
-export interface ScrollNavState extends FollowAgentNavState {
+export interface BrowserAddToConversationNavState {
+  showAddToConversation: boolean;
+  addToConversationLabel: string;
+  addToConversationTooltipLabel: string;
+  onAddToConversation: () => void;
+}
+
+export interface ScrollNavState
+  extends FollowAgentNavState, BrowserAddToConversationNavState {
   showScrollToBottom: boolean;
   onScrollToBottom: () => void;
 }
@@ -165,6 +173,14 @@ const EMPTY_FOLLOW_AGENT_NAV: FollowAgentNavState = {
   followAgentShortcut: "",
   onFollowAgent: () => undefined,
 };
+
+const EMPTY_BROWSER_ADD_TO_CONVERSATION_NAV: BrowserAddToConversationNavState =
+  {
+    showAddToConversation: false,
+    addToConversationLabel: "",
+    addToConversationTooltipLabel: "",
+    onAddToConversation: () => undefined,
+  };
 
 interface ChatHistoryProps {
   /** Opaque background class for sticky headers. Must match the container surface. */
@@ -183,6 +199,7 @@ interface ChatHistoryProps {
   /** Called whenever scroll-nav visibility state changes. Used by ChatView to render buttons in the pill row. */
   onScrollNavChange?: (state: ScrollNavState) => void;
   followAgentNav?: FollowAgentNavState;
+  browserAddToConversationNav?: BrowserAddToConversationNavState;
   onRegisterSearchOpen?: (handler: (() => void) | null) => void;
   displayMode?: ChatHistoryDisplayMode;
   turnPaginationEnabled?: boolean;
@@ -269,6 +286,7 @@ const ChatHistory: React.FC<ChatHistoryProps> = ({
   onAgentOrgRunViewRefresh,
   onScrollNavChange,
   followAgentNav = EMPTY_FOLLOW_AGENT_NAV,
+  browserAddToConversationNav = EMPTY_BROWSER_ADD_TO_CONVERSATION_NAV,
   onRegisterSearchOpen,
   displayMode = "full",
   turnPaginationEnabled = true,
@@ -332,6 +350,12 @@ const ChatHistory: React.FC<ChatHistoryProps> = ({
     followAgentShortcut,
     onFollowAgent,
   } = followAgentNav;
+  const {
+    showAddToConversation,
+    addToConversationLabel,
+    addToConversationTooltipLabel,
+    onAddToConversation,
+  } = browserAddToConversationNav;
 
   const { hasPinnedContent: hasPinnedContentRaw } = usePinnedContent();
   // Subagent panes opt out of in-history pinned bars; they surface the same
@@ -776,6 +800,10 @@ const ChatHistory: React.FC<ChatHistoryProps> = ({
       followAgentTooltipLabel,
       followAgentShortcut,
       onFollowAgent,
+      showAddToConversation,
+      addToConversationLabel,
+      addToConversationTooltipLabel,
+      onAddToConversation,
     });
   }, [
     showScrollToBottom,
@@ -785,6 +813,10 @@ const ChatHistory: React.FC<ChatHistoryProps> = ({
     followAgentTooltipLabel,
     followAgentShortcut,
     onFollowAgent,
+    showAddToConversation,
+    addToConversationLabel,
+    addToConversationTooltipLabel,
+    onAddToConversation,
     onScrollNavChange,
   ]);
 

--- a/src/engines/ChatPanel/ChatView.tsx
+++ b/src/engines/ChatPanel/ChatView.tsx
@@ -106,6 +106,7 @@ import { useAgentOrgRunView } from "./InputArea/components/useAgentOrgRunView";
 import { useComposerSections } from "./InputArea/hooks/useComposerSections";
 import { useGitDiffActions } from "./InputArea/hooks/useGitDiffActions";
 import { useQueueEditMode } from "./InputArea/hooks/useQueueEditMode";
+import { useBrowserAddToConversationAction } from "./hooks/useBrowserAddToConversationAction";
 import { useFollowAgent } from "./hooks/useFollowAgent";
 
 const logger = createLogger("ChatView");
@@ -380,6 +381,7 @@ const ChatView: React.FC<ChatViewProps> = memo(
         handleFollowAgent,
       ]
     );
+    const browserAddToConversationNav = useBrowserAddToConversationAction();
     const stationMode = useAtomValue(stationModeAtom);
     const chatPanelMaximized = useAtomValue(chatPanelMaximizedAtom);
     const agentMessageClampEligible =
@@ -757,6 +759,7 @@ const ChatView: React.FC<ChatViewProps> = memo(
                     onAgentOrgRunViewRefresh={refreshAgentOrgRunView}
                     onScrollNavChange={handleScrollNavChange}
                     followAgentNav={followAgentNav}
+                    browserAddToConversationNav={browserAddToConversationNav}
                     onRegisterSearchOpen={onRegisterSearchOpen}
                     displayMode={displayMode}
                     turnPaginationEnabled={turnPaginationEnabled}

--- a/src/engines/ChatPanel/InputArea/components/CollapsedInlineRow.tsx
+++ b/src/engines/ChatPanel/InputArea/components/CollapsedInlineRow.tsx
@@ -5,10 +5,11 @@
  * (queue, processes, file changes). Always visible when any section has data.
  * Clicking a pill expands that section's card above.
  *
- * Also renders the follow-agent action pill immediately after the section pills.
+ * Also renders contextual action pills immediately after the section pills.
  *
  * Each pill shows icon + numeric count only. gap-1 between pills.
  */
+import { Plus } from "lucide-react";
 import React, { memo, useState } from "react";
 
 import Button from "@src/components/Button";
@@ -63,9 +64,11 @@ function getButtonClassName(section: InlineSection) {
 const CollapsedInlineRow: React.FC<CollapsedInlineRowProps> = memo(
   ({ sections, scrollNav }) => {
     const showFollowAgent = scrollNav?.showFollowAgent ?? false;
+    const showAddToConversation = scrollNav?.showAddToConversation ?? false;
     const [openMenuKey, setOpenMenuKey] = useState<string | null>(null);
 
-    if (sections.length === 0 && !showFollowAgent) return null;
+    if (sections.length === 0 && !showFollowAgent && !showAddToConversation)
+      return null;
 
     return (
       <div className="flex items-center gap-1 px-0.5">
@@ -139,6 +142,35 @@ const CollapsedInlineRow: React.FC<CollapsedInlineRowProps> = memo(
                 aria-label={scrollNav!.followAgentTooltipLabel}
               >
                 {scrollNav!.followAgentLabel}
+              </Button>
+            </span>
+          </Tooltip>
+        )}
+
+        {showAddToConversation && (
+          <Tooltip
+            content={
+              <KeyboardShortcutTooltipContent
+                label={scrollNav!.addToConversationTooltipLabel}
+              />
+            }
+            position="top"
+            mouseEnterDelay={250}
+            framedPanel
+          >
+            <span className="inline-flex">
+              <Button
+                variant="primary"
+                appearance="outline"
+                size="small"
+                shape="round"
+                icon={<Plus size={13} strokeWidth={2} />}
+                onClick={scrollNav!.onAddToConversation}
+                aria-label={scrollNav!.addToConversationTooltipLabel}
+                data-testid="browser-add-to-conversation-pill"
+                className="max-w-[190px]"
+              >
+                {scrollNav!.addToConversationLabel}
               </Button>
             </span>
           </Tooltip>

--- a/src/engines/ChatPanel/hooks/useBrowserAddToConversationAction.ts
+++ b/src/engines/ChatPanel/hooks/useBrowserAddToConversationAction.ts
@@ -1,0 +1,48 @@
+import { useAtomValue } from "jotai";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import {
+  browserStatusBarCallbacksAtom,
+  browserStatusBarStateAtom,
+} from "@src/store/ui/workStationAtom";
+
+export interface UseBrowserAddToConversationActionReturn {
+  showAddToConversation: boolean;
+  addToConversationLabel: string;
+  addToConversationTooltipLabel: string;
+  onAddToConversation: () => void;
+}
+
+const noop = () => undefined;
+
+export function useBrowserAddToConversationAction(): UseBrowserAddToConversationActionReturn {
+  const { t } = useTranslation("common");
+  const browserStatus = useAtomValue(browserStatusBarStateAtom);
+  const browserCallbacks = useAtomValue(browserStatusBarCallbacksAtom);
+
+  const addToConversationLabel = t("selectionMenu.addToChat");
+  const selectedElementLabel = browserStatus.browserSelectedElementLabel;
+  const onSendSelectedElementToChat =
+    browserCallbacks.onSendSelectedElementToChat;
+  const showAddToConversation =
+    browserStatus.browserHasSelectedElement === true &&
+    typeof onSendSelectedElementToChat === "function";
+
+  return useMemo(
+    () => ({
+      showAddToConversation,
+      addToConversationLabel,
+      addToConversationTooltipLabel: selectedElementLabel
+        ? `${addToConversationLabel}: ${selectedElementLabel}`
+        : addToConversationLabel,
+      onAddToConversation: onSendSelectedElementToChat ?? noop,
+    }),
+    [
+      showAddToConversation,
+      addToConversationLabel,
+      selectedElementLabel,
+      onSendSelectedElementToChat,
+    ]
+  );
+}


### PR DESCRIPTION
## Summary
- add a Chat composer capsule for the existing browser selected-element Add to Chat action
- reuse the existing browser status-bar selected-element state and callback instead of duplicating DOM serialization
- keep the existing bottom status bar action unchanged

Fixes #141.

Note: on Windows, the selected-element state depends on the WebView2 eval-result fix in #171 so this UI entry can appear reliably after an element is picked.

## Testing
- pnpm exec prettier --write src/engines/ChatPanel/hooks/useBrowserAddToConversationAction.ts src/engines/ChatPanel/ChatHistory/index.tsx src/engines/ChatPanel/ChatView.tsx src/engines/ChatPanel/ChatFloatingComposer.tsx src/engines/ChatPanel/InputArea/components/CollapsedInlineRow.tsx
- pnpm exec eslint src/engines/ChatPanel/hooks/useBrowserAddToConversationAction.ts src/engines/ChatPanel/ChatHistory/index.tsx src/engines/ChatPanel/ChatView.tsx src/engines/ChatPanel/ChatFloatingComposer.tsx src/engines/ChatPanel/InputArea/components/CollapsedInlineRow.tsx
- pnpm exec tsc --noEmit --incremental --tsBuildInfoFile .git/.tsbuildinfo (fails on existing repo-wide errors outside the changed files; staged-file hook type check passed)
- Husky pre-commit: lint-staged, scoped TypeScript check for staged files, commit stats