### PR TITLE
fix(browser): disable page navigation in inspect mode

### DIFF
--- a/src-tauri/crates/browser/src/scripts/js/inspector-core.js
+++ b/src-tauri/crates/browser/src/scripts/js/inspector-core.js
@@ -20,6 +20,22 @@ const ORGII_PRIMARY_6 = "#1D8FFD";
 const ORGII_PRIMARY_6_RGBA_10 = "rgba(29, 143, 253, 0.1)";
 const ORGII_PRIMARY_6_SHADOW = "rgba(29, 143, 253, 0.35)";
 
+// Inspect mode owns page interaction while active. Use non-passive capture
+// listeners so links, SPA routers, buttons, forms, and drag handlers cannot
+// navigate or mutate the page before the inspector selects the target.
+const INSPECT_EVENT_OPTIONS = { capture: true, passive: false };
+
+const suppressInspectEvent = (e) => {
+  if (!inspectEnabled) return false;
+
+  e.preventDefault();
+  e.stopPropagation();
+  if (typeof e.stopImmediatePropagation === "function") {
+    e.stopImmediatePropagation();
+  }
+  return true;
+};
+
 // Create overlay elements
 const highlightOverlay = document.createElement("div");
 highlightOverlay.id = "__orgii_highlight_overlay__";

--- a/src-tauri/crates/browser/src/scripts/js/inspector-drag.js
+++ b/src-tauri/crates/browser/src/scripts/js/inspector-drag.js
@@ -132,6 +132,8 @@ const handleMouseMove = (e) => {
 const handleMouseDown = (e) => {
   if (!inspectEnabled) return;
 
+  suppressInspectEvent(e);
+
   const el = document.elementFromPoint(e.clientX, e.clientY);
   if (!el || isOverlayElement(el) || isUndraggable(el)) return;
 
@@ -151,6 +153,8 @@ const handleMouseDown = (e) => {
 const handleMouseUp = (e) => {
   if (!inspectEnabled) return;
 
+  suppressInspectEvent(e);
+
   if (isDragging && draggedElement) {
     // Complete the drag - move element
     const dropInfo = getDropPosition(e.clientX, e.clientY);
@@ -168,10 +172,7 @@ const handleMouseUp = (e) => {
 
 // Click handler (prevent default during inspect mode)
 const handleClick = (e) => {
-  if (!inspectEnabled) return;
-
-  e.preventDefault();
-  e.stopPropagation();
+  suppressInspectEvent(e);
 };
 
 // Keyboard handler (Escape to cancel)
@@ -179,6 +180,8 @@ const handleKeyDown = (e) => {
   if (!inspectEnabled) return;
 
   if (e.key === "Escape") {
+    suppressInspectEvent(e);
+
     // If dragging, cancel the drag instead of disabling inspect mode
     if (isDragging || draggedElement) {
       isDragging = false;
@@ -188,6 +191,8 @@ const handleKeyDown = (e) => {
       return;
     }
     window.__ORGII_DISABLE_INSPECT_MODE__();
+  } else if (e.key === "Enter" || e.key === " ") {
+    suppressInspectEvent(e);
   }
 };
 

--- a/src-tauri/crates/browser/src/scripts/js/inspector-mode.js
+++ b/src-tauri/crates/browser/src/scripts/js/inspector-mode.js
@@ -1,16 +1,39 @@
 // Element Inspector - Inspect Mode Control
 // Provides enable/disable/toggle functionality for the inspector
 
+const inspectBlockedEventNames = [
+  "dblclick",
+  "auxclick",
+  "contextmenu",
+  "dragstart",
+  "submit",
+];
+
+const handleBlockedInspectEvent = (e) => {
+  suppressInspectEvent(e);
+};
+
+const addInspectListener = (eventName, handler) => {
+  window.addEventListener(eventName, handler, INSPECT_EVENT_OPTIONS);
+};
+
+const removeInspectListener = (eventName, handler) => {
+  window.removeEventListener(eventName, handler, INSPECT_EVENT_OPTIONS);
+};
+
 // Enable inspect mode
 window.__ORGII_ENABLE_INSPECT_MODE__ = function () {
   if (inspectEnabled) return;
   inspectEnabled = true;
   document.body.style.cursor = "crosshair";
-  document.addEventListener("mousemove", handleMouseMove, true);
-  document.addEventListener("mousedown", handleMouseDown, true);
-  document.addEventListener("mouseup", handleMouseUp, true);
-  document.addEventListener("click", handleClick, true);
-  document.addEventListener("keydown", handleKeyDown, true);
+  addInspectListener("mousemove", handleMouseMove);
+  addInspectListener("mousedown", handleMouseDown);
+  addInspectListener("mouseup", handleMouseUp);
+  addInspectListener("click", handleClick);
+  addInspectListener("keydown", handleKeyDown);
+  inspectBlockedEventNames.forEach((eventName) => {
+    addInspectListener(eventName, handleBlockedInspectEvent);
+  });
 };
 
 // Disable inspect mode
@@ -18,11 +41,14 @@ window.__ORGII_DISABLE_INSPECT_MODE__ = function () {
   if (!inspectEnabled) return;
   inspectEnabled = false;
   document.body.style.cursor = "";
-  document.removeEventListener("mousemove", handleMouseMove, true);
-  document.removeEventListener("mousedown", handleMouseDown, true);
-  document.removeEventListener("mouseup", handleMouseUp, true);
-  document.removeEventListener("click", handleClick, true);
-  document.removeEventListener("keydown", handleKeyDown, true);
+  removeInspectListener("mousemove", handleMouseMove);
+  removeInspectListener("mousedown", handleMouseDown);
+  removeInspectListener("mouseup", handleMouseUp);
+  removeInspectListener("click", handleClick);
+  removeInspectListener("keydown", handleKeyDown);
+  inspectBlockedEventNames.forEach((eventName) => {
+    removeInspectListener(eventName, handleBlockedInspectEvent);
+  });
   highlightOverlay.style.display = "none";
   infoTooltip.style.display = "none";
   hideDropIndicator();

--- a/src-tauri/crates/browser/src/scripts/tests/inspector_tests.rs
+++ b/src-tauri/crates/browser/src/scripts/tests/inspector_tests.rs
@@ -32,3 +32,18 @@ fn element_inspector_script_includes_all_js_chunks() {
     assert!(script.contains("__ORGII_UNDO__"));
     assert!(script.contains("__ORGII_RESIZE_ELEMENT__"));
 }
+
+#[test]
+fn element_inspector_script_suppresses_page_actions_in_inspect_mode() {
+    let script = ELEMENT_INSPECTOR_SCRIPT;
+    assert!(script.contains("const INSPECT_EVENT_OPTIONS = { capture: true, passive: false }"));
+    assert!(script.contains("const suppressInspectEvent = (e) =>"));
+    assert!(script.contains("stopImmediatePropagation"));
+    assert!(script.contains("addInspectListener(\"mousedown\", handleMouseDown);"));
+    assert!(script.contains("addInspectListener(\"mouseup\", handleMouseUp);"));
+    assert!(script.contains("addInspectListener(\"click\", handleClick);"));
+    assert!(script.contains("\"auxclick\""));
+    assert!(script.contains("\"contextmenu\""));
+    assert!(script.contains("\"submit\""));
+    assert!(script.contains("e.key === \"Enter\" || e.key === \" \""));
+}


### PR DESCRIPTION
## Summary

- suppress page activation events while Web Inspection mode is active
- prevent links, buttons, forms, context menus, auxiliary clicks, and keyboard activation from navigating or mutating the inspected page before selection
- keep suppression scoped to active inspect mode so normal page interaction resumes after inspection is disabled

Closes #160

## Testing

- pre-commit hook ran via normal `git commit`
- lint-staged passed
- cargo clippy passed for the `browser` crate
- cargo fmt --check
- pnpm exec prettier --check src-tauri/crates/browser/src/scripts/js/inspector-core.js src-tauri/crates/browser/src/scripts/js/inspector-drag.js src-tauri/crates/browser/src/scripts/js/inspector-mode.js
- git diff --check
- manually verified in ORG2 desktop: inspect mode selects clicked elements without navigating, and normal interaction resumes after leaving inspect mode