### PR TITLE
fix(windows): unify custom chrome and dev startup

### DIFF
--- a/scripts/dev/cleanup-orphans.cjs
+++ b/scripts/dev/cleanup-orphans.cjs
@@ -15,11 +15,13 @@ const quiet = process.argv.includes("--quiet");
 
 function runWindowsCleanup() {
   const patterns = [
-  { label: "build watchers", match: "build.js --watch" },
-  { label: "esbuild services", match: "esbuild --service" },
-  { label: "ORG2 Dev", match: "ORG2 Dev" },
-  { label: "orphaned cargo run", match: "cargo run" },
-];
+    { label: "webpack dev server", match: "scripts/dev/webpack-server.js" },
+    { label: "webpack dev server", match: "scripts\\dev\\webpack-server.js" },
+    { label: "build watchers", match: "build.js --watch" },
+    { label: "esbuild services", match: "esbuild --service" },
+    { label: "ORG2 Dev", match: "ORG2 Dev" },
+    { label: "orphaned cargo run", match: "cargo run" },
+  ];
 
   const killed = [];
 

--- a/scripts/dev/tauri.js
+++ b/scripts/dev/tauri.js
@@ -10,7 +10,7 @@
  *   [Webpack] building (43%) 4/5 entries           (or "idle")
  */
 
-const { spawn, execSync } = require("child_process");
+const { spawn, execFileSync, execSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 const { tauriFeatureList } = require("../tauri/features.cjs");
@@ -339,7 +339,7 @@ function routeLine(line) {
 function cleanupOrphanedProcesses() {
   try {
     const cleanupScript = path.join(__dirname, "cleanup-orphans.cjs");
-    execSync(`${process.execPath} "${cleanupScript}" --quiet`, {
+    execFileSync(process.execPath, [cleanupScript, "--quiet"], {
       stdio: "inherit",
       cwd: rootDir,
     });
@@ -351,6 +351,17 @@ function cleanupOrphanedProcesses() {
 // ─── Start Tauri dev ──────────────────────────────────────────────────────────
 
 function killDescendants(pid) {
+  if (process.platform === "win32") {
+    try {
+      execFileSync("taskkill", ["/PID", String(pid), "/T", "/F"], {
+        stdio: "ignore",
+      });
+    } catch (_err) {
+      // already dead
+    }
+    return;
+  }
+
   try {
     // Recursively find and kill all descendant processes
     const children = execSync(`pgrep -P ${pid} 2>/dev/null`, {
@@ -397,6 +408,81 @@ function createBinPath(name) {
   return fs.existsSync(localPath) ? localPath : name;
 }
 
+function createNodePackageCliCommand(packageName, binName, fallbackBinName) {
+  if (process.platform !== "win32") {
+    return {
+      command: createBinPath(fallbackBinName ?? binName),
+      argsPrefix: [],
+    };
+  }
+
+  const packageJsonPath = require.resolve(`${packageName}/package.json`, {
+    paths: [rootDir, __dirname],
+  });
+  const packageJson = require(packageJsonPath);
+  const bin =
+    typeof packageJson.bin === "string"
+      ? packageJson.bin
+      : packageJson.bin?.[binName];
+  if (!bin) {
+    throw new Error(`${packageName} does not expose a ${binName} CLI binary`);
+  }
+
+  return {
+    command: process.execPath,
+    argsPrefix: [path.resolve(path.dirname(packageJsonPath), bin)],
+  };
+}
+
+function createPackageCliCommand(packageName, binName) {
+  return createNodePackageCliCommand(packageName, binName);
+}
+
+function createPnpmCliCommand() {
+  if (process.platform !== "win32") {
+    return { command: createBinPath("pnpm"), argsPrefix: [] };
+  }
+
+  try {
+    return createNodePackageCliCommand("pnpm", "pnpm");
+  } catch (_error) {
+    // pnpm is commonly installed globally via Corepack/npm and is not listed as
+    // a project dependency. Avoid pnpm.cmd + shell:true by locating pnpm.cjs.
+  }
+
+  const candidates = [
+    process.env.PNPM_HOME && path.join(process.env.PNPM_HOME, "pnpm.cjs"),
+    process.env.APPDATA &&
+      path.join(
+        process.env.APPDATA,
+        "npm",
+        "node_modules",
+        "pnpm",
+        "bin",
+        "pnpm.cjs"
+      ),
+    process.env.LOCALAPPDATA &&
+      path.join(
+        process.env.LOCALAPPDATA,
+        "pnpm",
+        "global",
+        "5",
+        "node_modules",
+        "pnpm",
+        "bin",
+        "pnpm.cjs"
+      ),
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return { command: process.execPath, argsPrefix: [candidate] };
+    }
+  }
+
+  return { command: createBinPath("pnpm"), argsPrefix: [] };
+}
+
 function pipeProcessLines(childProcess, onLine) {
   function handleStream(stream) {
     const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
@@ -411,18 +497,20 @@ function startFrontendDev() {
   const scriptName = createFrontendScriptName({
     lightDev: process.env.ORGII_LIGHT_DEV === "true",
   });
-  const pnpmBin = createBinPath("pnpm");
-  const isWindows = process.platform === "win32";
+  const pnpmCli = createPnpmCliCommand();
 
   setWebpackStatus("starting dev server...");
   printStartupMilestone("starting webpack dev server", "webpackStart");
 
-  const frontendProcess = spawn(pnpmBin, ["run", scriptName], {
-    stdio: ["inherit", "pipe", "pipe"],
-    cwd: rootDir,
-    env: cleanChildEnv(),
-    ...(isWindows ? { shell: true } : {}),
-  });
+  const frontendProcess = spawn(
+    pnpmCli.command,
+    [...pnpmCli.argsPrefix, "run", scriptName],
+    {
+      stdio: ["inherit", "pipe", "pipe"],
+      cwd: rootDir,
+      env: cleanChildEnv(),
+    }
+  );
 
   const ready = new Promise((resolve, reject) => {
     let settled = false;
@@ -479,16 +567,18 @@ function startTauriDev(features) {
     features,
     devUrl: createDevUrl(),
   });
-  const tauriBin = createBinPath("tauri");
-  const isWindows = process.platform === "win32";
+  const tauriCli = createPackageCliCommand("@tauri-apps/cli", "tauri");
   recordStartupMetric("rustStart");
   printStartupMilestone("starting Tauri dev process", "tauriStart");
-  const tauriProcess = spawn(tauriBin, args, {
-    stdio: ["inherit", "pipe", "pipe"],
-    cwd: rootDir,
-    env: cleanChildEnv(),
-    ...(isWindows ? { shell: true } : {}),
-  });
+  const tauriProcess = spawn(
+    tauriCli.command,
+    [...tauriCli.argsPrefix, ...args],
+    {
+      stdio: ["inherit", "pipe", "pipe"],
+      cwd: rootDir,
+      env: cleanChildEnv(),
+    }
+  );
 
   // Initialize status bar once the process starts
   writeStatusBar();

--- a/scripts/tauri/build-fast-local.cjs
+++ b/scripts/tauri/build-fast-local.cjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const { spawnSync } = require("child_process");
+const fs = require("fs");
 const path = require("path");
 const { tauriFeatureString } = require("./features.cjs");
 const {
@@ -10,6 +11,93 @@ const {
 const rootDir = path.join(__dirname, "..", "..");
 const includeSemantic = process.argv.includes("--semantic");
 const featureString = tauriFeatureString({ semantic: includeSemantic });
+
+function createBinPath(name) {
+  const localPath = path.join(
+    rootDir,
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? `${name}.cmd` : name
+  );
+  return fs.existsSync(localPath) ? localPath : name;
+}
+
+function createNodePackageCliCommand(packageName, binName, fallbackBinName) {
+  if (process.platform !== "win32") {
+    return {
+      command: createBinPath(fallbackBinName ?? binName),
+      argsPrefix: [],
+    };
+  }
+
+  const packageJsonPath = require.resolve(`${packageName}/package.json`, {
+    paths: [rootDir, __dirname],
+  });
+  const packageJson = require(packageJsonPath);
+  const bin =
+    typeof packageJson.bin === "string"
+      ? packageJson.bin
+      : packageJson.bin?.[binName];
+  if (!bin) {
+    throw new Error(`${packageName} does not expose a ${binName} CLI binary`);
+  }
+
+  return {
+    command: process.execPath,
+    argsPrefix: [path.resolve(path.dirname(packageJsonPath), bin)],
+  };
+}
+
+function createPnpmCliCommand() {
+  if (process.platform !== "win32") {
+    return { command: createBinPath("pnpm"), argsPrefix: [] };
+  }
+
+  try {
+    return createNodePackageCliCommand("pnpm", "pnpm");
+  } catch (_error) {
+  }
+
+  const candidates = [
+    process.env.PNPM_HOME && path.join(process.env.PNPM_HOME, "pnpm.cjs"),
+    process.env.APPDATA &&
+      path.join(
+        process.env.APPDATA,
+        "npm",
+        "node_modules",
+        "pnpm",
+        "bin",
+        "pnpm.cjs"
+      ),
+    process.env.LOCALAPPDATA &&
+      path.join(
+        process.env.LOCALAPPDATA,
+        "pnpm",
+        "global",
+        "5",
+        "node_modules",
+        "pnpm",
+        "bin",
+        "pnpm.cjs"
+      ),
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return { command: process.execPath, argsPrefix: [candidate] };
+    }
+  }
+
+  return { command: createBinPath("pnpm"), argsPrefix: [] };
+}
+
+function createPnpmExecCommand(binaryName, args) {
+  const pnpmCli = createPnpmCliCommand();
+  return {
+    cmd: pnpmCli.command,
+    args: [...pnpmCli.argsPrefix, "exec", binaryName, ...args],
+  };
+}
 
 const configOverride = JSON.stringify({
   build: {
@@ -41,8 +129,8 @@ if (featureString.length > 0) {
 }
 args.push("--bundles", "app", "--config", configOverride, "--", "--profile", "dev-build");
 
-const tauriBin = path.join(rootDir, "node_modules/.bin/tauri");
-const result = spawnSync(tauriBin, args, {
+const tauriCommand = createPnpmExecCommand("tauri", args);
+const result = spawnSync(tauriCommand.cmd, tauriCommand.args, {
   stdio: "inherit",
   cwd: rootDir,
   env,

--- a/scripts/tauri/build-fast-open.cjs
+++ b/scripts/tauri/build-fast-open.cjs
@@ -11,6 +11,93 @@ const {
 const rootDir = path.join(__dirname, "..", "..");
 const includeSemantic = process.argv.includes("--semantic");
 const featureString = tauriFeatureString({ semantic: includeSemantic });
+
+function createBinPath(name) {
+  const localPath = path.join(
+    rootDir,
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? `${name}.cmd` : name
+  );
+  return fs.existsSync(localPath) ? localPath : name;
+}
+
+function createNodePackageCliCommand(packageName, binName, fallbackBinName) {
+  if (process.platform !== "win32") {
+    return {
+      command: createBinPath(fallbackBinName ?? binName),
+      argsPrefix: [],
+    };
+  }
+
+  const packageJsonPath = require.resolve(`${packageName}/package.json`, {
+    paths: [rootDir, __dirname],
+  });
+  const packageJson = require(packageJsonPath);
+  const bin =
+    typeof packageJson.bin === "string"
+      ? packageJson.bin
+      : packageJson.bin?.[binName];
+  if (!bin) {
+    throw new Error(`${packageName} does not expose a ${binName} CLI binary`);
+  }
+
+  return {
+    command: process.execPath,
+    argsPrefix: [path.resolve(path.dirname(packageJsonPath), bin)],
+  };
+}
+
+function createPnpmCliCommand() {
+  if (process.platform !== "win32") {
+    return { command: createBinPath("pnpm"), argsPrefix: [] };
+  }
+
+  try {
+    return createNodePackageCliCommand("pnpm", "pnpm");
+  } catch (_error) {
+  }
+
+  const candidates = [
+    process.env.PNPM_HOME && path.join(process.env.PNPM_HOME, "pnpm.cjs"),
+    process.env.APPDATA &&
+      path.join(
+        process.env.APPDATA,
+        "npm",
+        "node_modules",
+        "pnpm",
+        "bin",
+        "pnpm.cjs"
+      ),
+    process.env.LOCALAPPDATA &&
+      path.join(
+        process.env.LOCALAPPDATA,
+        "pnpm",
+        "global",
+        "5",
+        "node_modules",
+        "pnpm",
+        "bin",
+        "pnpm.cjs"
+      ),
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return { command: process.execPath, argsPrefix: [candidate] };
+    }
+  }
+
+  return { command: createBinPath("pnpm"), argsPrefix: [] };
+}
+
+function createPnpmExecCommand(binaryName, args) {
+  const pnpmCli = createPnpmCliCommand();
+  return {
+    cmd: pnpmCli.command,
+    args: [...pnpmCli.argsPrefix, "exec", binaryName, ...args],
+  };
+}
 function resolveCargoTargetDir() {
   const metadataResult = spawnSync("cargo", ["metadata", "--format-version", "1", "--no-deps"], {
     cwd: path.join(rootDir, "src-tauri"),
@@ -62,8 +149,8 @@ if (featureString.length > 0) {
 args.push("--bundles", "app", "--no-sign", "--config", configOverride, "--", "--profile", "dev-build");
 
 const env = applyDefaultDiagnosticsEndpoint({ ...process.env });
-const tauriBin = path.join(rootDir, "node_modules/.bin/tauri");
-const result = spawnSync(tauriBin, args, {
+const tauriCommand = createPnpmExecCommand("tauri", args);
+const result = spawnSync(tauriCommand.cmd, tauriCommand.args, {
   stdio: "inherit",
   cwd: rootDir,
   env,

--- a/scripts/tauri/build-fast-parallel.cjs
+++ b/scripts/tauri/build-fast-parallel.cjs
@@ -49,6 +49,93 @@ function prefix(tag, color) {
   };
 }
 
+function createBinPath(name) {
+  const localPath = path.join(
+    rootDir,
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? `${name}.cmd` : name
+  );
+  return fs.existsSync(localPath) ? localPath : name;
+}
+
+function createNodePackageCliCommand(packageName, binName, fallbackBinName) {
+  if (process.platform !== "win32") {
+    return {
+      command: createBinPath(fallbackBinName ?? binName),
+      argsPrefix: [],
+    };
+  }
+
+  const packageJsonPath = require.resolve(`${packageName}/package.json`, {
+    paths: [rootDir, __dirname],
+  });
+  const packageJson = require(packageJsonPath);
+  const bin =
+    typeof packageJson.bin === "string"
+      ? packageJson.bin
+      : packageJson.bin?.[binName];
+  if (!bin) {
+    throw new Error(`${packageName} does not expose a ${binName} CLI binary`);
+  }
+
+  return {
+    command: process.execPath,
+    argsPrefix: [path.resolve(path.dirname(packageJsonPath), bin)],
+  };
+}
+
+function createPnpmCliCommand() {
+  if (process.platform !== "win32") {
+    return { command: createBinPath("pnpm"), argsPrefix: [] };
+  }
+
+  try {
+    return createNodePackageCliCommand("pnpm", "pnpm");
+  } catch (_error) {
+  }
+
+  const candidates = [
+    process.env.PNPM_HOME && path.join(process.env.PNPM_HOME, "pnpm.cjs"),
+    process.env.APPDATA &&
+      path.join(
+        process.env.APPDATA,
+        "npm",
+        "node_modules",
+        "pnpm",
+        "bin",
+        "pnpm.cjs"
+      ),
+    process.env.LOCALAPPDATA &&
+      path.join(
+        process.env.LOCALAPPDATA,
+        "pnpm",
+        "global",
+        "5",
+        "node_modules",
+        "pnpm",
+        "bin",
+        "pnpm.cjs"
+      ),
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return { command: process.execPath, argsPrefix: [candidate] };
+    }
+  }
+
+  return { command: createBinPath("pnpm"), argsPrefix: [] };
+}
+
+function createPnpmExecCommand(binaryName, args) {
+  const pnpmCli = createPnpmCliCommand();
+  return {
+    cmd: pnpmCli.command,
+    args: [...pnpmCli.argsPrefix, "exec", binaryName, ...args],
+  };
+}
+
 function runParallel(commands) {
   return new Promise((resolve) => {
     const results = new Array(commands.length).fill(null);
@@ -103,7 +190,7 @@ function resolveOutputAppPath(outputPath) {
 }
 
 function copyBuiltApp(outputPath) {
-  if (!outputPath) return;
+  if (!outputPath || process.platform !== "darwin") return;
 
   const targetDir = resolveCargoTargetDir();
   const builtAppPath = path.join(targetDir, "dev-build", "bundle", "macos", "ORG2.app");
@@ -154,10 +241,10 @@ async function main() {
   // Point cargo at the src-tauri workspace root
   cargoArgs.push("--manifest-path", path.join(rootDir, "src-tauri", "Cargo.toml"));
 
+  const webpackCommand = createPnpmExecCommand("webpack", ["--mode", "production"]);
   const [webpackCode, cargoCode] = await runParallel([
     {
-      cmd: path.join(rootDir, "node_modules/.bin/webpack"),
-      args: ["--mode", "production"],
+      ...webpackCommand,
       // FAST_PROD=true: use esbuild for transpilation + minification
       // instead of SWC+Terser, saving ~30-40s on the webpack phase.
       opts: { env: { ...env, FAST_PROD: "true" } },
@@ -204,19 +291,20 @@ async function main() {
     },
   });
 
+  const bundleTarget = process.platform === "darwin" ? "app" : "nsis";
   const tauriArgs = ["build"];
   if (featureString.length > 0) {
     tauriArgs.push("--features", featureString);
   }
   tauriArgs.push(
-    "--bundles", "app",
+    "--bundles", bundleTarget,
     "--config", configOverride,
     "--",
     "--profile", "dev-build"
   );
 
-  const tauriBin = path.join(rootDir, "node_modules/.bin/tauri");
-  const result = spawnSync(tauriBin, tauriArgs, {
+  const tauriCommand = createPnpmExecCommand("tauri", tauriArgs);
+  const result = spawnSync(tauriCommand.cmd, tauriCommand.args, {
     stdio: "inherit",
     cwd: rootDir,
     env,

--- a/src-tauri/crates/agent-core/src/core/tools/impls/coding/exec/external.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/coding/exec/external.rs
@@ -32,10 +32,12 @@ pub fn launch(command: &str, working_dir: &Path) -> Result<ExternalTerminalLaunc
     launch_for_platform(command, working_dir)
 }
 
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn shell_single_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
 }
 
+#[cfg(any(target_os = "macos", target_os = "linux"))]
 fn command_with_cd(command: &str, working_dir: &Path) -> String {
     format!(
         "cd {} && {}",
@@ -240,6 +242,7 @@ pub fn format_launch_result(command: &str, launch: &ExternalTerminalLaunch) -> S
 mod tests {
     use super::*;
 
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     #[test]
     fn shell_single_quote_escapes_single_quotes() {
         assert_eq!(shell_single_quote("a'b"), "'a'\\''b'");

--- a/src-tauri/crates/agent-core/src/core/tools/impls/desktop/peekaboo_cli_tool.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/desktop/peekaboo_cli_tool.rs
@@ -826,17 +826,20 @@ fn run_tar_extract(archive: &Path, dest_dir: &Path) -> Result<(), String> {
     Ok(())
 }
 
+#[cfg(unix)]
 fn set_executable(path: &Path) -> Result<(), String> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let meta =
-            fs::metadata(path).map_err(|err| format!("metadata {}: {err}", path.display()))?;
-        let mut permissions = meta.permissions();
-        permissions.set_mode(permissions.mode() | 0o755);
-        fs::set_permissions(path, permissions)
-            .map_err(|err| format!("chmod {}: {err}", path.display()))?;
-    }
+    use std::os::unix::fs::PermissionsExt;
+
+    let meta = fs::metadata(path).map_err(|err| format!("metadata {}: {err}", path.display()))?;
+    let mut permissions = meta.permissions();
+    permissions.set_mode(permissions.mode() | 0o755);
+    fs::set_permissions(path, permissions)
+        .map_err(|err| format!("chmod {}: {err}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> Result<(), String> {
     Ok(())
 }
 

--- a/src-tauri/crates/git-api/src/extractors.rs
+++ b/src-tauri/crates/git-api/src/extractors.rs
@@ -25,9 +25,7 @@ fn strip_extended_length_prefix(path_str: &str) -> &str {
 
 pub(crate) fn has_windows_users_prefix(path_str: &str) -> bool {
     let bytes = path_str.as_bytes();
-    bytes.len() >= 9
-        && bytes[0].is_ascii_alphabetic()
-        && bytes.get(1..9) == Some(br":\Users\")
+    bytes.len() >= 9 && bytes[0].is_ascii_alphabetic() && bytes.get(1..9) == Some(br":\Users\")
 }
 
 /// Check whether `path` falls under a user-accessible directory.

--- a/src-tauri/crates/perf-utils/src/process_metrics.rs
+++ b/src-tauri/crates/perf-utils/src/process_metrics.rs
@@ -527,16 +527,8 @@ pub fn get_child_processes_memory() -> Vec<ChildProcessInfo> {
     guard.update_process_timestamp();
 
     let process_ids: Vec<Pid> = guard.system.processes().keys().copied().collect();
-    let first_webkit_start_time = {
-        #[cfg(target_os = "macos")]
-        {
-            first_macos_webkit_xpc_start_time_after(our_pid, &guard.system)
-        }
-        #[cfg(not(target_os = "macos"))]
-        {
-            None::<u64>
-        }
-    };
+    #[cfg(target_os = "macos")]
+    let first_webkit_start_time = first_macos_webkit_xpc_start_time_after(our_pid, &guard.system);
     let mut descendant_cache = HashSet::new();
     let mut children: Vec<ChildProcessInfo> = vec![];
 

--- a/src-tauri/src/setup/sidecar_setup.rs
+++ b/src-tauri/src/setup/sidecar_setup.rs
@@ -294,17 +294,21 @@ fn find_file_named(dir: &Path, name: &str) -> Option<PathBuf> {
     None
 }
 
+#[cfg(unix)]
 fn set_executable(path: &Path) -> Result<(), String> {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let meta =
-            std::fs::metadata(path).map_err(|err| format!("metadata {}: {err}", path.display()))?;
-        let mut perms = meta.permissions();
-        perms.set_mode(perms.mode() | 0o755);
-        std::fs::set_permissions(path, perms)
-            .map_err(|err| format!("chmod {}: {err}", path.display()))?;
-    }
+    use std::os::unix::fs::PermissionsExt;
+
+    let meta =
+        std::fs::metadata(path).map_err(|err| format!("metadata {}: {err}", path.display()))?;
+    let mut perms = meta.permissions();
+    perms.set_mode(perms.mode() | 0o755);
+    std::fs::set_permissions(path, perms)
+        .map_err(|err| format!("chmod {}: {err}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> Result<(), String> {
     Ok(())
 }
 

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,4 +1,23 @@
 {
+  "app": {
+    "windows": [
+      {
+        "label": "main",
+        "title": "ORG2",
+        "width": 1200,
+        "height": 800,
+        "minWidth": 450,
+        "minHeight": 300,
+        "resizable": true,
+        "maximized": true,
+        "fullscreen": false,
+        "decorations": false,
+        "hiddenTitle": true,
+        "backgroundColor": "#0d0d0d",
+        "transparent": false
+      }
+    ]
+  },
   "bundle": {
     "resources": {
       "resources/drag-icons/": "resources/drag-icons/"

--- a/src/components/WindowChrome/WindowsTopBar.tsx
+++ b/src/components/WindowChrome/WindowsTopBar.tsx
@@ -1,0 +1,346 @@
+import { LogicalPosition } from "@tauri-apps/api/dpi";
+import {
+  MenuItem,
+  PredefinedMenuItem,
+  Menu as TauriMenu,
+} from "@tauri-apps/api/menu";
+import { open } from "@tauri-apps/plugin-shell";
+import { Minus, Square, X } from "lucide-react";
+import React, { memo, useCallback } from "react";
+
+import { NoDragRegion } from "@src/modules/WorkStation/shared";
+import {
+  closeWindow,
+  maxWindow,
+  minWindow,
+} from "@src/util/platform/ipcRenderer";
+
+const TOP_BAR_HEIGHT = 36;
+const ICON_SIZE = 14;
+
+const MENU_BAR_CLASS = "flex h-full shrink-0 items-center gap-0.5 px-1";
+
+const MENU_BUTTON_CLASS =
+  "flex h-7 items-center rounded-md border-0 bg-transparent px-2 text-[13px] text-text-2 transition-colors hover:bg-fill-2 hover:text-text-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-6/30";
+
+const WINDOW_CONTROL_BUTTON_CLASS =
+  "flex h-full w-11 items-center justify-center border-0 bg-transparent p-0 text-text-2 transition-colors hover:bg-fill-2 hover:text-text-1 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-6/30";
+
+const CLOSE_BUTTON_CLASS =
+  "flex h-full w-11 items-center justify-center border-0 bg-transparent p-0 text-text-2 transition-colors hover:bg-danger-6 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger-6/30";
+
+type NativeMenuKey = "orgii" | "file" | "edit" | "view" | "window" | "help";
+
+type NativeMenuItem =
+  | {
+      type: "item";
+      text: string;
+      action: () => void | Promise<void>;
+      enabled?: boolean;
+      accelerator?: string;
+    }
+  | { type: "separator" };
+
+const MENU_LABELS: Array<{ key: NativeMenuKey; label: string }> = [
+  { key: "orgii", label: "ORGII" },
+  { key: "file", label: "File" },
+  { key: "edit", label: "Edit" },
+  { key: "view", label: "View" },
+  { key: "window", label: "Window" },
+  { key: "help", label: "Help" },
+];
+
+function emitMenuEvent(eventName: string) {
+  window.dispatchEvent(new CustomEvent(eventName));
+}
+
+function handleWindowAction(action: () => Promise<void>) {
+  void action();
+}
+
+function getMenuItems(menu: NativeMenuKey): NativeMenuItem[] {
+  switch (menu) {
+    case "orgii":
+      return [
+        {
+          type: "item",
+          text: "Quit ORGII",
+          accelerator: "Ctrl+Q",
+          action: () => emitMenuEvent("native-quit-confirmation-open"),
+        },
+      ];
+    case "file":
+      return [
+        {
+          type: "item",
+          text: "New Session",
+          accelerator: "Ctrl+N",
+          action: () => emitMenuEvent("menu-new-session"),
+        },
+        { type: "separator" },
+        {
+          type: "item",
+          text: "Open Folder...",
+          accelerator: "Ctrl+O",
+          action: () => emitMenuEvent("menu-file-open-folder"),
+        },
+        {
+          type: "item",
+          text: "Add Folder to Workspace...",
+          action: () => emitMenuEvent("menu-add-folder-to-workspace"),
+        },
+        { type: "separator" },
+        {
+          type: "item",
+          text: "Save Workspace As...",
+          action: () => emitMenuEvent("menu-save-workspace-as"),
+        },
+        { type: "separator" },
+        {
+          type: "item",
+          text: "Close Window",
+          accelerator: "Ctrl+Shift+W",
+          action: closeWindow,
+        },
+      ];
+    case "edit":
+      return [
+        {
+          type: "item",
+          text: "Undo",
+          action: () => document.execCommand("undo"),
+        },
+        {
+          type: "item",
+          text: "Redo",
+          action: () => document.execCommand("redo"),
+        },
+        { type: "separator" },
+        {
+          type: "item",
+          text: "Cut",
+          action: () => document.execCommand("cut"),
+        },
+        {
+          type: "item",
+          text: "Copy",
+          action: () => document.execCommand("copy"),
+        },
+        {
+          type: "item",
+          text: "Paste",
+          action: () => document.execCommand("paste"),
+        },
+        {
+          type: "item",
+          text: "Select All",
+          action: () => emitMenuEvent("menu-select-all"),
+        },
+      ];
+    case "view":
+      return [
+        {
+          type: "item",
+          text: "Command Palette",
+          action: () => emitMenuEvent("menu-toggle-spotlight"),
+        },
+        {
+          type: "item",
+          text: "Go to File...",
+          action: () => emitMenuEvent("menu-open-file-palette"),
+        },
+        {
+          type: "item",
+          text: "Select Model...",
+          accelerator: "Ctrl+/",
+          action: () => emitMenuEvent("menu-open-model-selector"),
+        },
+        {
+          type: "item",
+          text: "Switch Workspace...",
+          accelerator: "Ctrl+.",
+          action: () => emitMenuEvent("menu-open-workspace-selector"),
+        },
+        {
+          type: "item",
+          text: "Switch Branch...",
+          accelerator: "Ctrl+Alt+.",
+          action: () => emitMenuEvent("menu-open-branch-selector"),
+        },
+        {
+          type: "item",
+          text: "Switch Running Location...",
+          accelerator: "Ctrl+Shift+.",
+          action: () => emitMenuEvent("menu-open-location-selector"),
+        },
+        { type: "separator" },
+        {
+          type: "item",
+          text: "Settings...",
+          accelerator: "Ctrl+,",
+          action: () => emitMenuEvent("menu-open-settings"),
+        },
+        { type: "separator" },
+        {
+          type: "item",
+          text: "Zoom In",
+          action: () => emitMenuEvent("menu-zoom-in"),
+        },
+        {
+          type: "item",
+          text: "Zoom Out",
+          action: () => emitMenuEvent("menu-zoom-out"),
+        },
+        {
+          type: "item",
+          text: "Actual Size",
+          action: () => emitMenuEvent("menu-zoom-reset"),
+        },
+      ];
+    case "window":
+      return [
+        { type: "item", text: "Minimize", action: minWindow },
+        { type: "item", text: "Maximize / Restore", action: maxWindow },
+        {
+          type: "item",
+          text: "Maximize Workstation",
+          accelerator: "Ctrl+Shift+M",
+          action: () => emitMenuEvent("menu-maximize-work-station"),
+        },
+        { type: "separator" },
+        { type: "item", text: "Close Window", action: closeWindow },
+      ];
+    case "help":
+      return [
+        {
+          type: "item",
+          text: "Documentation",
+          action: () => open("https://github.com/YORG-AI/ORGII/wiki"),
+        },
+        {
+          type: "item",
+          text: "Report Issue",
+          action: () => open("https://github.com/YORG-AI/ORGII/issues"),
+        },
+      ];
+  }
+}
+
+async function showNativeStyleMenu(
+  menuKey: NativeMenuKey,
+  anchor: HTMLElement
+) {
+  const menuItems = await Promise.all(
+    getMenuItems(menuKey).map(async (item) => {
+      if (item.type === "separator") {
+        return PredefinedMenuItem.new({ item: "Separator" });
+      }
+
+      return MenuItem.new({
+        text: item.text,
+        enabled: item.enabled ?? true,
+        accelerator: item.accelerator,
+        action: item.action,
+      });
+    })
+  );
+
+  const menu = await TauriMenu.new({ items: menuItems });
+  const rect = anchor.getBoundingClientRect();
+
+  try {
+    await menu.popup(
+      new LogicalPosition(Math.round(rect.left), Math.round(rect.bottom))
+    );
+  } catch {
+    await menu.popup();
+  }
+}
+
+const WindowsTopBarComponent: React.FC = () => {
+  const handleMinimize = useCallback(() => {
+    handleWindowAction(minWindow);
+  }, []);
+
+  const handleMaximize = useCallback(() => {
+    handleWindowAction(maxWindow);
+  }, []);
+
+  const handleClose = useCallback(() => {
+    handleWindowAction(closeWindow);
+  }, []);
+
+  const handleOpenMenu = useCallback(
+    (menuKey: NativeMenuKey, event: React.MouseEvent<HTMLButtonElement>) => {
+      void showNativeStyleMenu(menuKey, event.currentTarget);
+    },
+    []
+  );
+
+  return (
+    <div
+      className="relative z-50 flex shrink-0 items-center border-b border-border-2 bg-bg-2 text-text-1"
+      data-windows-top-bar="true"
+      data-tauri-drag-region
+      style={
+        {
+          height: TOP_BAR_HEIGHT,
+          minHeight: TOP_BAR_HEIGHT,
+          WebkitAppRegion: "drag",
+        } as React.CSSProperties
+      }
+    >
+      <NoDragRegion className={MENU_BAR_CLASS}>
+        {MENU_LABELS.map((menu) => (
+          <button
+            key={menu.key}
+            type="button"
+            className={MENU_BUTTON_CLASS}
+            onClick={(event) => handleOpenMenu(menu.key, event)}
+            aria-label={`${menu.label} menu`}
+          >
+            {menu.label}
+          </button>
+        ))}
+      </NoDragRegion>
+
+      <div className="h-full min-w-0 flex-1" data-tauri-drag-region />
+
+      <div
+        className="flex h-full shrink-0 items-center"
+        style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
+      >
+        <button
+          type="button"
+          className={WINDOW_CONTROL_BUTTON_CLASS}
+          onClick={handleMinimize}
+          aria-label="Minimize window"
+          title="Minimize"
+        >
+          <Minus size={ICON_SIZE} strokeWidth={2} />
+        </button>
+        <button
+          type="button"
+          className={WINDOW_CONTROL_BUTTON_CLASS}
+          onClick={handleMaximize}
+          aria-label="Maximize or restore window"
+          title="Maximize / Restore"
+        >
+          <Square size={12} strokeWidth={2} />
+        </button>
+        <button
+          type="button"
+          className={CLOSE_BUTTON_CLASS}
+          onClick={handleClose}
+          aria-label="Close window"
+          title="Close"
+        >
+          <X size={ICON_SIZE} strokeWidth={2} />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export const WindowsTopBar = memo(WindowsTopBarComponent);
+WindowsTopBar.displayName = "WindowsTopBar";

--- a/src/components/WindowChrome/index.ts
+++ b/src/components/WindowChrome/index.ts
@@ -1,0 +1,1 @@
+export { WindowsTopBar } from "./WindowsTopBar";

--- a/src/engines/ChatPanel/ChatPanelHeader.tsx
+++ b/src/engines/ChatPanel/ChatPanelHeader.tsx
@@ -42,6 +42,7 @@ import {
   type ChatHistoryDisplayMode,
   type ChatPanelCreateTarget,
 } from "@src/store/ui/chatPanelAtom";
+import { isWindows } from "@src/util/platform/tauri";
 
 import {
   CHAT_PANEL_HEADER_DRAG_STYLE,
@@ -181,6 +182,7 @@ export function ChatPanelHeader({
   visibleRegionNotice,
 }: ChatPanelHeaderProps): React.ReactNode {
   const publishedHeaderSlots = useAtomValue(chatPanelHeaderSlotsAtom);
+  const windowsHost = isWindows();
   if (!showHeader) return null;
 
   const showStaticCollabCreateTitle =
@@ -452,13 +454,15 @@ export function ChatPanelHeader({
     <div
       className={`workspace-header header-tab-group relative flex flex-shrink-0 items-center gap-1.5 ${isCompactLayout ? "h-11 min-h-11 pl-2 pr-[7px] pt-2" : "h-9 min-h-9 px-2"}`}
       data-testid="chat-panel-header"
-      data-tauri-drag-region
+      data-tauri-drag-region={windowsHost ? undefined : true}
       style={
         {
           paddingLeft: shouldOffsetHeaderForCollapsedSidebar
             ? COLLAPSED_SIDEBAR_CHROME_OFFSET
             : undefined,
-          ...CHAT_PANEL_HEADER_DRAG_STYLE,
+          ...(windowsHost
+            ? CHAT_PANEL_HEADER_NO_DRAG_STYLE
+            : CHAT_PANEL_HEADER_DRAG_STYLE),
         } as React.CSSProperties
       }
     >

--- a/src/engines/ChatPanel/InputArea/openedTabMentionOptions.ts
+++ b/src/engines/ChatPanel/InputArea/openedTabMentionOptions.ts
@@ -2,6 +2,7 @@ import { hasNonEmptyTerminalBuffer } from "@src/components/TerminalInteractive/b
 import type { CustomMentionOption } from "@src/engines/ChatPanel/hooks/useInputArea/types";
 import type { MenuItemId } from "@src/scaffold/ContextMenu/config";
 import type { WorkStationTab } from "@src/store/workstation/tabs";
+import { getCompactPathLabel } from "@src/util/file/pathUtils";
 import { formatRepoPathForDisplay } from "@src/util/file/repoPathDisplay";
 
 const getStringData = (
@@ -11,12 +12,6 @@ const getStringData = (
   const value = tab.data[key];
   return typeof value === "string" && value.trim() ? value : undefined;
 };
-
-function getCompactPathLabel(path: string): string {
-  const normalizedPath = path.replace(/\\/g, "/");
-  const parts = normalizedPath.split("/").filter(Boolean);
-  return parts.slice(-3).join("/") || normalizedPath;
-}
 
 const isCustomMentionOption = (
   option: CustomMentionOption | null

--- a/src/engines/ChatPanel/blocks/ToolCallBlock/OutputContent.tsx
+++ b/src/engines/ChatPanel/blocks/ToolCallBlock/OutputContent.tsx
@@ -15,6 +15,7 @@ import {
 import React from "react";
 
 import FileTypeIcon from "@src/components/FileTypeIcon";
+import { getDirectory, getFileName } from "@src/util/file/pathUtils";
 import { formatRepoPathForDisplay } from "@src/util/file/repoPathDisplay";
 
 import {
@@ -251,9 +252,11 @@ const SearchFilesOutput: React.FC<{ files: string[]; repoPath?: string }> = ({
     renderItem={(filePath) => {
       const display = formatRepoPathForDisplay({ path: filePath, repoPath });
       const displayPath = display.displayPath || filePath;
-      const parts = displayPath.split("/");
-      const fileName = parts.pop() || displayPath;
-      const dir = parts.length > 0 ? parts.join("/") + "/" : "";
+      const fileName = getFileName(displayPath);
+      const dirPath = getDirectory(displayPath);
+      const dir = dirPath
+        ? `${dirPath}${displayPath.includes("\\") ? "\\" : "/"}`
+        : "";
 
       return (
         <ComposerStackListRow

--- a/src/engines/ChatPanel/blocks/ToolCallBlock/cards/FileCard.tsx
+++ b/src/engines/ChatPanel/blocks/ToolCallBlock/cards/FileCard.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 
 import FileTypeIcon from "@src/components/FileTypeIcon";
+import { formatPathForPlatformDisplay } from "@src/util/file/repoPathDisplay";
 import { openFileInEditor } from "@src/util/ui/openFileInEditor";
 
 import type { FileCardData } from "../types";
@@ -21,6 +22,8 @@ interface FileCardProps {
 const FileCard: React.FC<FileCardProps> = ({ card }) => {
   const { t } = useTranslation("sessions");
 
+  const displayPath = formatPathForPlatformDisplay(card.path);
+
   function handleOpen() {
     openFileInEditor(card.path);
   }
@@ -37,7 +40,7 @@ const FileCard: React.FC<FileCardProps> = ({ card }) => {
         </div>
         <div className="mt-0.5 flex items-center gap-1.5 text-text-4">
           <span className="chat-block-content truncate text-xs">
-            {card.path}
+            {displayPath}
           </span>
           {card.sizeBytes !== undefined && (
             <>

--- a/src/engines/ChatPanel/hooks/useInputArea/index.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/index.ts
@@ -47,6 +47,7 @@ import { sessionByIdAtom } from "@src/store/session/sessionAtom/atoms";
 import { wpReadOnlyAtom } from "@src/store/ui/chatPanelAtom";
 import { workspaceFoldersAtom } from "@src/store/ui/workspaceFoldersAtom";
 import { activeWorkspaceRootPathAtom } from "@src/store/workspace";
+import { getCompactPathLabel } from "@src/util/file/pathUtils";
 import { formatRepoPathForDisplay } from "@src/util/file/repoPathDisplay";
 import { useCurrentTheme } from "@src/util/ui/theme/themeUtils";
 
@@ -105,12 +106,6 @@ function getDraftRestoreSkipReason(draftText: string): string | null {
   }
 
   return null;
-}
-
-function getCompactPathLabel(path: string): string {
-  const normalizedPath = path.replace(/\\/g, "/");
-  const parts = normalizedPath.split("/").filter(Boolean);
-  return parts.slice(-3).join("/") || normalizedPath;
 }
 
 function getPlanMentionPath(event: SessionEvent): string | null {

--- a/src/index.scss
+++ b/src/index.scss
@@ -432,6 +432,16 @@ body {
   background: var(--color-bg-2);
 }
 
+html[data-host-desktop="windows"],
+html[data-host-desktop="windows"] body,
+html[data-host-desktop="windows"] #root {
+  background: var(--color-bg-2);
+}
+
+html[data-host-desktop="windows"] .sidebar-base {
+  background: var(--sidebar-bg);
+}
+
 // Ensure popup layers are not clipped by body's overflow: hidden
 
 // Override for header recently closed menu to ensure width is respected

--- a/src/modules/WorkStation/AppShell/WorkstationTabHeader.tsx
+++ b/src/modules/WorkStation/AppShell/WorkstationTabHeader.tsx
@@ -24,6 +24,7 @@ import React, { memo } from "react";
 import { activeStatusBarAppAtom } from "@src/store/ui/workStationLayout/statusBarAtoms";
 import { activeWorkstationTabHeaderAtom } from "@src/store/workstation";
 import { activeWorkStationTabAtom } from "@src/store/workstation/tabs";
+import { isWindows } from "@src/util/platform/tauri";
 
 import {
   NoDragRegion,
@@ -38,13 +39,14 @@ const WorkstationTabHeader: React.FC = memo(() => {
   const headerSlots = useAtomValue(activeWorkstationTabHeaderAtom);
   const activeApp = useAtomValue(activeStatusBarAppAtom);
   const activeTab = useAtomValue(activeWorkStationTabAtom);
+  const windowsHost = isWindows();
   const isSourceControlTab =
     activeApp === "code" && activeTab?.type === "source-control";
 
   return (
     <div
       className="flex h-10 shrink-0 items-center gap-2 border-b border-border-2 pl-1.5 pr-2"
-      data-tauri-drag-region
+      data-tauri-drag-region={windowsHost ? undefined : true}
     >
       <NoDragRegion className="flex shrink-0 items-center gap-px">
         <WorkStationSidebarToggleButton

--- a/src/modules/shared/components/BackgroundLayer/index.tsx
+++ b/src/modules/shared/components/BackgroundLayer/index.tsx
@@ -18,6 +18,7 @@ import {
   addToBackgroundCache,
   backgroundImageCache,
 } from "@src/util/core/init/backgroundInit";
+import { isWindows } from "@src/util/platform/tauri";
 
 import { AnimationComponents } from "./animations";
 
@@ -82,6 +83,16 @@ export const BackgroundLayer: React.FC<BackgroundLayerProps> = ({
 
   // Get animation component if animation is selected
   const AnimationComponent = animation ? AnimationComponents[animation] : null;
+
+  if (isWindows()) {
+    return (
+      <div
+        data-background-layer="true"
+        className="absolute left-0 top-0 z-0 bg-bg-2"
+        style={{ width: "100vw", height: "100vh" }}
+      />
+    );
+  }
 
   // Glass mode: render a 30% bg-2 tint behind the native glass effect
   if (glass != null) {

--- a/src/modules/shared/layouts/AppLayout.tsx
+++ b/src/modules/shared/layouts/AppLayout.tsx
@@ -22,6 +22,7 @@ import React, { memo, useCallback, useEffect, useMemo } from "react";
 
 import { ActionSystemProvider } from "@src/ActionSystem";
 import { sendAdeActionResult } from "@src/api/tauri/agent";
+import { WindowsTopBar } from "@src/components/WindowChrome";
 import { ChatProvider } from "@src/contexts/workspace/ChatContext";
 import { DataProvider } from "@src/contexts/workspace/DataContext";
 import ChatPanel from "@src/engines/ChatPanel";
@@ -44,6 +45,7 @@ import {
 import { sidebarCollapsedAtom } from "@src/store/ui/sidebarAtom";
 import type { ChatPanelPosition } from "@src/store/ui/workStationLayout/chatPositionAtoms";
 import { activeWorkspaceRootPathAtom } from "@src/store/workspace";
+import { isWindows } from "@src/util/platform/tauri";
 
 import { FocusedChatWorkstationRail } from "./FocusedChatWorkstationRail";
 import { GlobalModals } from "./GlobalModals";
@@ -424,21 +426,26 @@ const AppLayoutComponent: React.FC<AppLayoutProps> = ({
     </DataProvider>
   );
 
+  const windowsHost = isWindows();
+
   return (
-    <div className="relative z-10 flex h-full min-w-0 flex-1">
-      <HoverSidebar.Trigger />
-      {sidebar}
+    <div className="relative z-10 flex h-full min-w-0 flex-1 flex-col bg-bg-2">
+      {windowsHost && <WindowsTopBar />}
+      <div className="flex min-h-0 min-w-0 flex-1">
+        <HoverSidebar.Trigger />
+        {sidebar}
 
-      {floatingSidebar && (
-        <HoverSidebar.Container>{floatingSidebar}</HoverSidebar.Container>
-      )}
+        {floatingSidebar && (
+          <HoverSidebar.Container>{floatingSidebar}</HoverSidebar.Container>
+        )}
 
-      <div className="flex h-full min-w-0 flex-1 flex-col">
-        <MainContentArea className="relative min-h-0 flex-1">
-          {contentArea}
-        </MainContentArea>
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+          <MainContentArea className="relative min-h-0 flex-1">
+            {contentArea}
+          </MainContentArea>
 
-        <GlobalModals />
+          <GlobalModals />
+        </div>
       </div>
     </div>
   );

--- a/src/scaffold/GlobalSpotlight/forms/CloneRepo/CloneRepoForm.tsx
+++ b/src/scaffold/GlobalSpotlight/forms/CloneRepo/CloneRepoForm.tsx
@@ -22,6 +22,7 @@ import Input from "@src/components/Input";
 import Radio from "@src/components/Radio";
 import { buildIntegrationsPath } from "@src/config/mainAppPaths";
 import { PanelFooter, Placeholder } from "@src/modules/shared/layouts/blocks";
+import { joinPathForDisplay } from "@src/util/file/pathUtils";
 
 import { ICONS } from "../../config";
 import {
@@ -259,12 +260,15 @@ const CloneRepoForm: React.FC<CloneRepoFormProps> = ({
               <div className="mt-2 text-[12px] text-text-2">
                 {t("cloneForm.repoWillBeClonedTo")}{" "}
                 <span className="font-medium text-text-1">
-                  {localPath}/
-                  {subTab === "myGitHub"
-                    ? repositories.find((repo) => repo.id === selectedRepo)
-                        ?.name
-                    : repoUrl.match(/github\.com[:/]([^/]+)\/([^/.]+)/)?.[2] ||
-                      "repo"}
+                  {joinPathForDisplay(
+                    localPath,
+                    subTab === "myGitHub"
+                      ? (repositories.find((repo) => repo.id === selectedRepo)
+                          ?.name ?? "")
+                      : repoUrl.match(
+                          /github\.com[:/]([^/]+)\/([^/.]+)/
+                        )?.[2] || "repo"
+                  )}
                 </span>
               </div>
             )}

--- a/src/scaffold/GlobalSpotlight/forms/CloneRepo/CloneRepoGitHubForm.tsx
+++ b/src/scaffold/GlobalSpotlight/forms/CloneRepo/CloneRepoGitHubForm.tsx
@@ -22,6 +22,7 @@ import Input from "@src/components/Input";
 import Radio from "@src/components/Radio";
 import { buildIntegrationsPath } from "@src/config/mainAppPaths";
 import { PanelFooter, Placeholder } from "@src/modules/shared/layouts/blocks";
+import { joinPathForDisplay } from "@src/util/file/pathUtils";
 
 import { ICONS } from "../../config";
 import {
@@ -213,8 +214,11 @@ const CloneGitHubForm: React.FC<CloneGitHubFormProps> = ({
               <div className="mt-2 text-[12px] text-text-2">
                 {t("cloneForm.repoWillBeClonedTo")}{" "}
                 <span className="font-medium text-text-1">
-                  {localPath}/
-                  {repositories.find((repo) => repo.id === selectedRepo)?.name}
+                  {joinPathForDisplay(
+                    localPath,
+                    repositories.find((repo) => repo.id === selectedRepo)
+                      ?.name ?? ""
+                  )}
                 </span>
               </div>
             )}

--- a/src/scaffold/GlobalSpotlight/forms/CloneRepo/CloneRepoUrlForm.tsx
+++ b/src/scaffold/GlobalSpotlight/forms/CloneRepo/CloneRepoUrlForm.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 import Button from "@src/components/Button";
 import Input from "@src/components/Input";
 import { PanelFooter } from "@src/modules/shared/layouts/blocks";
+import { joinPathForDisplay } from "@src/util/file/pathUtils";
 
 import { ICONS } from "../../config";
 import {
@@ -128,7 +129,7 @@ const CloneUrlForm: React.FC<CloneUrlFormProps> = ({
               <div className="mt-2 text-[12px] text-text-2">
                 {t("cloneForm.repoWillBeClonedTo")}{" "}
                 <span className="font-medium text-text-1">
-                  {localPath}/{repoName}
+                  {joinPathForDisplay(localPath, repoName)}
                 </span>
               </div>
             )}

--- a/src/scaffold/GlobalSpotlight/forms/CreateWorkspaceFolder/CreateWorkspaceFolderForm.tsx
+++ b/src/scaffold/GlobalSpotlight/forms/CreateWorkspaceFolder/CreateWorkspaceFolderForm.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 
 import Input from "@src/components/Input";
 import { PanelFooter } from "@src/modules/shared/layouts/blocks";
+import { joinPathForDisplay } from "@src/util/file/pathUtils";
 
 import { ICONS } from "../../config";
 import {
@@ -138,7 +139,7 @@ const CreateWorkspaceFolderForm: React.FC<CreateWorkspaceFolderFormProps> = ({
             workspacePath && workspaceName ? (
               <span className="truncate text-[14px] text-text-1">
                 {t("selectors.repo.forms.createAt", {
-                  path: `${workspacePath}/${workspaceName}`,
+                  path: joinPathForDisplay(workspacePath, workspaceName),
                 })}
               </span>
             ) : undefined

--- a/src/scaffold/NavigationSidebar/SidebarBase.tsx
+++ b/src/scaffold/NavigationSidebar/SidebarBase.tsx
@@ -51,8 +51,10 @@ import type { SidebarBaseProps } from "./types";
 
 const log = createLogger("SidebarBase");
 
+const HOST_DESKTOP_KIND = resolveHostDesktop();
+const IS_WINDOWS_HOST = HOST_DESKTOP_KIND === HOST_DESKTOP.WINDOWS;
 const PLATFORM_SIDEBAR_RADIUS =
-  resolveHostDesktop() === HOST_DESKTOP.MACOS ? SIDEBAR_STYLE.borderRadius : 8;
+  HOST_DESKTOP_KIND === HOST_DESKTOP.MACOS ? SIDEBAR_STYLE.borderRadius : 8;
 
 const IDLE_SIDEBAR_RESIZE_HANDLE_CLASS_NAME =
   "h-full [&>div:first-child]:origin-right [&>div:first-child]:scale-x-50 [&>div:first-child]:transition-transform hover:[&>div:first-child]:scale-x-100";
@@ -230,22 +232,33 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
       if (!includeTrafficLightSpace) return null;
 
       // In fullscreen mode, traffic lights are hidden, so no padding needed
-      const trafficLightPadding = isFullscreen
-        ? 0
-        : SIDEBAR_STYLE.trafficLightsPadding;
+      const trafficLightPadding =
+        IS_WINDOWS_HOST || isFullscreen
+          ? 0
+          : SIDEBAR_STYLE.trafficLightsPadding;
+      const alignmentClassName = IS_WINDOWS_HOST
+        ? "justify-between pl-5 pr-2"
+        : "justify-end pr-2";
 
       return (
         <div
-          className="flex flex-nowrap items-center justify-end gap-1 pr-2"
+          className={`flex flex-nowrap items-center gap-1 ${alignmentClassName}`}
           data-tauri-drag-region
           style={
             {
               height: `${SIDEBAR_STYLE.topBarHeight}px`,
-              paddingLeft: `${trafficLightPadding}px`,
-              WebkitAppRegion: "drag",
+              paddingLeft: IS_WINDOWS_HOST
+                ? undefined
+                : `${trafficLightPadding}px`,
+              WebkitAppRegion: IS_WINDOWS_HOST ? "no-drag" : "drag",
             } as React.CSSProperties
           }
         >
+          {IS_WINDOWS_HOST ? (
+            <span className="select-none text-[13px] font-semibold tracking-wide text-text-2">
+              ORG2
+            </span>
+          ) : null}
           <div
             className={`flex items-center gap-1 ${sidebarTopChromeClassName}`}
           >
@@ -433,7 +446,7 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
     const sidebarBoxShadow =
       isCompactLayout && !shouldForceVisible ? "none" : "var(--sidebar-shadow)";
     const sidebarBackdropFilter =
-      shouldForceVisible || isCompactLayout
+      IS_WINDOWS_HOST || shouldForceVisible || isCompactLayout
         ? "none"
         : "var(--sidebar-backdrop)";
     const floatingSurfaceOverride: React.CSSProperties = shouldForceVisible
@@ -453,7 +466,9 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
           boxShadow: sidebarBoxShadow,
           backdropFilter: sidebarBackdropFilter,
           WebkitBackdropFilter: sidebarBackdropFilter,
-          ...(shouldForceVisible || solidSurface ? {} : sidebarOpacityStyle),
+          ...(IS_WINDOWS_HOST || shouldForceVisible || solidSurface
+            ? {}
+            : sidebarOpacityStyle),
           ...floatingSurfaceOverride,
         };
 
@@ -481,11 +496,14 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
       borderBottomWidth: 0,
       borderRightWidth: 1,
     } as const;
+    const sidebarOuterPaddingClass = isCompactLayout
+      ? ""
+      : IS_WINDOWS_HOST
+        ? "pb-2 pl-2"
+        : "pb-2 pl-2 pt-2";
     const wrappedContent = wrapInSurface ? (
       <div
-        className={`sidebar-base flex h-full w-full flex-col ${
-          isCompactLayout ? "" : "pb-2 pl-2 pt-2"
-        } ${innerClassName}`}
+        className={`sidebar-base flex h-full w-full flex-col ${sidebarOuterPaddingClass} ${innerClassName}`}
       >
         <div
           className={`flex flex-1 flex-col overflow-hidden ${

--- a/src/util/file/pathUtils.ts
+++ b/src/util/file/pathUtils.ts
@@ -111,6 +111,30 @@ export function getFileName(filePath: string): string {
   return parts[parts.length - 1] || filePath;
 }
 
+export function getPathSegments(filePath: string): string[] {
+  return filePath.replace(/\\/g, "/").split("/").filter(Boolean);
+}
+
+export function getCompactPathLabel(filePath: string, maxSegments = 3): string {
+  const segments = getPathSegments(filePath);
+  const separator = filePath.includes("\\") ? "\\" : "/";
+  return segments.slice(-maxSegments).join(separator) || filePath;
+}
+
+export function joinPathForDisplay(
+  parentPath: string,
+  childName: string
+): string {
+  const trimmedParent = parentPath.trim();
+  const trimmedChild = childName.trim();
+  const separator = trimmedParent.includes("\\") ? "\\" : "/";
+  if (!trimmedParent) return trimmedChild;
+  if (!trimmedChild) return trimmedParent;
+  return trimmedParent.endsWith("/") || trimmedParent.endsWith("\\")
+    ? `${trimmedParent}${trimmedChild}`
+    : `${trimmedParent}${separator}${trimmedChild}`;
+}
+
 export function normalizeDiffFilePath(filePath: string): string {
   let normalized = filePath.trim().replace(/\\/g, "/");
   if (normalized.startsWith('"') && normalized.endsWith('"')) {

--- a/src/util/file/repoPathDisplay.test.ts
+++ b/src/util/file/repoPathDisplay.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  formatPathForPlatformDisplay,
   formatRepoPathForDisplay,
   formatToolTargetPath,
   pickToolArgString,
@@ -13,14 +14,14 @@ describe("formatRepoPathForDisplay", () => {
         path: "/tmp/workspace-a/app/src/index.ts",
         repoPath: "/tmp/workspace-a/app",
       }).displayPath
-    ).toBe("workspace-a/app/src/index.ts");
+    ).toBe(formatPathForPlatformDisplay("workspace-a/app/src/index.ts"));
 
     expect(
       formatRepoPathForDisplay({
         path: "/tmp/workspace-b/app/src/index.ts",
         repoPath: "/tmp/workspace-b/app",
       }).displayPath
-    ).toBe("workspace-b/app/src/index.ts");
+    ).toBe(formatPathForPlatformDisplay("workspace-b/app/src/index.ts"));
   });
 
   it("keeps relative paths root-qualified when repo context exists", () => {
@@ -29,7 +30,9 @@ describe("formatRepoPathForDisplay", () => {
       repoPath: "/tmp/workspace-a/app",
     });
 
-    expect(display.displayPath).toBe("workspace-a/app/src/index.ts");
+    expect(display.displayPath).toBe(
+      formatPathForPlatformDisplay("workspace-a/app/src/index.ts")
+    );
     expect(display.title).toBe("/tmp/workspace-a/app/src/index.ts");
   });
 
@@ -39,16 +42,21 @@ describe("formatRepoPathForDisplay", () => {
       repoPath: "/tmp/repo",
     });
 
-    expect(display.displayPath).toBe("/tmp/repo-other/src/index.ts");
+    expect(display.displayPath).toBe(
+      formatPathForPlatformDisplay("/tmp/repo-other/src/index.ts")
+    );
   });
 
-  it("normalizes Windows separators for display", () => {
+  it("uses platform separators for Windows display", () => {
     const display = formatRepoPathForDisplay({
       path: "C:\\work\\repo\\src\\index.ts",
       repoPath: "C:\\work\\repo",
     });
 
-    expect(display.displayPath).toBe("work/repo/src/index.ts");
+    expect(display.displayPath).toBe(
+      formatPathForPlatformDisplay("work/repo/src/index.ts")
+    );
+    expect(display.normalizedPath).toBe("C:/work/repo/src/index.ts");
   });
 
   it("extracts nested tool arguments consistently", () => {
@@ -71,7 +79,7 @@ describe("formatRepoPathForDisplay", () => {
         repoPath: "/tmp/workspace-a/app",
         pathKeys: ["path"],
       })
-    ).toBe("workspace-b/app");
+    ).toBe(formatPathForPlatformDisplay("workspace-b/app"));
   });
 
   it("falls back to current repo when tool args omit a target", () => {
@@ -81,6 +89,6 @@ describe("formatRepoPathForDisplay", () => {
         repoPath: "/tmp/workspace-a/app",
         pathKeys: ["path"],
       })
-    ).toBe("workspace-a/app");
+    ).toBe(formatPathForPlatformDisplay("workspace-a/app"));
   });
 });

--- a/src/util/file/repoPathDisplay.ts
+++ b/src/util/file/repoPathDisplay.ts
@@ -1,3 +1,5 @@
+import { isWindows } from "@src/util/platform/tauri";
+
 import { getFileName } from "./pathUtils";
 
 export interface RepoPathDisplayInput {
@@ -28,6 +30,19 @@ const WINDOWS_ABSOLUTE_RE = /^[A-Za-z]:\//;
 
 export function normalizeDisplayPath(path: string | undefined): string {
   return (path ?? "").trim().replace(/\\/g, "/").replace(/\/+/g, "/");
+}
+
+export function getPlatformPathSeparator(): "/" | "\\" {
+  return isWindows() ? "\\" : "/";
+}
+
+export function formatPathForPlatformDisplay(
+  path: string | undefined,
+  separator: "/" | "\\" = getPlatformPathSeparator()
+): string {
+  if (!path) return "";
+  if (separator === "/") return path;
+  return path.replace(/\//g, "\\");
 }
 
 function nestedArgs(value: unknown): Record<string, unknown> | undefined {
@@ -141,6 +156,9 @@ export function formatRepoPathForDisplay(
   const rootLabel =
     input.rootLabel ||
     (normalizedRoot ? defaultRootLabel(normalizedRoot) : undefined);
+  const separator = getPlatformPathSeparator();
+  const toPlatformDisplay = (path: string) =>
+    formatPathForPlatformDisplay(path, separator);
 
   if (!normalizedPath) {
     return {
@@ -156,15 +174,16 @@ export function formatRepoPathForDisplay(
     const displayPath = rootLabel
       ? `${rootLabel}/${normalizedPath}`
       : normalizedPath;
+    const title = normalizedRoot
+      ? `${normalizedRoot}/${normalizedPath}`
+      : normalizedPath;
     return {
       normalizedPath,
       normalizedRoot,
       rootLabel,
       relativePath: normalizedPath,
-      displayPath,
-      title: normalizedRoot
-        ? `${normalizedRoot}/${normalizedPath}`
-        : normalizedPath,
+      displayPath: toPlatformDisplay(displayPath),
+      title,
     };
   }
 
@@ -182,8 +201,8 @@ export function formatRepoPathForDisplay(
       normalizedRoot,
       rootLabel,
       relativePath,
-      displayPath,
-      title: normalizedPath,
+      displayPath: toPlatformDisplay(displayPath),
+      title: toPlatformDisplay(normalizedPath),
     };
   }
 
@@ -192,8 +211,8 @@ export function formatRepoPathForDisplay(
     normalizedPath,
     normalizedRoot,
     rootLabel,
-    displayPath,
-    title: normalizedPath,
+    displayPath: toPlatformDisplay(displayPath),
+    title: toPlatformDisplay(normalizedPath),
   };
 }
 

--- a/src/util/platform/tauri/index.ts
+++ b/src/util/platform/tauri/index.ts
@@ -211,29 +211,35 @@ export const isTauriDesktop = () => {
   return true;
 };
 
-// Cache user agent once -- platform never changes at runtime
+// Cache platform signals once -- platform never changes at runtime
 const userAgent =
   typeof navigator !== "undefined" ? navigator.userAgent.toLowerCase() : "";
+const processPlatform =
+  typeof process !== "undefined" ? process.platform : undefined;
 
 /**
  * Check if running on macOS
  * @returns {boolean} Whether the app is running on macOS
  */
 export const isMacOS = (): boolean =>
-  userAgent.includes("macintosh") || userAgent.includes("mac os");
+  processPlatform === "darwin" ||
+  userAgent.includes("macintosh") ||
+  userAgent.includes("mac os");
 
 /**
  * Check if running on Windows
  * @returns {boolean} Whether the app is running on Windows
  */
-export const isWindows = (): boolean => userAgent.includes("windows");
+export const isWindows = (): boolean =>
+  processPlatform === "win32" || userAgent.includes("windows");
 
 /**
  * Check if running on Linux
  * @returns {boolean} Whether the app is running on Linux
  */
 export const isLinux = (): boolean =>
-  userAgent.includes("linux") && !userAgent.includes("android");
+  processPlatform === "linux" ||
+  (userAgent.includes("linux") && !userAgent.includes("android"));
 
 /**
  * Get Tauri version information


### PR DESCRIPTION
Add a Windows-only custom top bar with native-style menu popups, frameless non-transparent Tauri window configuration, and theme-aware solid surfaces so the app chrome remains readable on Windows.

Restore workstation/navigation controls to their owning layouts, keep the Navigation Sidebar title and actions aligned for Windows, and suppress conflicting drag regions where the unified chrome owns window dragging.

Theme-aware navigation controls.

Harden Windows dev startup by invoking Node-based CLI entrypoints directly, cleaning stale webpack processes on crashes, and avoiding shell quoting/deprecation issues when launching pnpm and Tauri.

Also clean up Windows-specific Rust cfg warnings and path display helpers used by workspace/clone flows.

Pre-commit hook ran. Total eslint: 0, total circular: 0

## Summary

<img width="239" height="218" alt="image" src="https://github.com/user-attachments/assets/2e576213-1a9d-4be1-a8c8-ef54de90970c" />

<img width="301" height="164" alt="image" src="https://github.com/user-attachments/assets/20865c4f-01be-4817-bd28-ef3a4dd32473" />


## Test plan

- [X] I ran the checks relevant to the changed files, or explained why they were not run.

## Contributor checklist

- [X] The PR title uses scoped Conventional Commits format, such as `feat(scope): summary` or `fix(scope): summary`.
- [X] All commits use scoped Conventional Commits format.
- [X] I did not skip pre-commit, pre-push, lint-staged, or other repository hooks.
- [X] The PR is scoped to one issue, feature, or fix.
- [X] I have signed the CLA if prompted by the CLA Assistant bot.
- [X] A human actively participated in the design and implementation process, and reviewed the contribution before submission.
- [X] I did not include secrets, private configuration, generated build output, or unrelated formatting changes.
- [X] I updated documentation for behavior, setup, or architecture changes where needed.
- [X] I updated all supported locale files for new UI text where needed.
