### PR TITLE
Fix Feishu typing reactions and media handling

### DIFF
--- a/src-tauri/crates/agent-core/src/core/session/gateway_pipeline.rs
+++ b/src-tauri/crates/agent-core/src/core/session/gateway_pipeline.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use tracing::{info, warn};
 
 use crate::bus::{InboundMessage, OutboundMessage};
+use crate::foundation::persistence::images::load_image_as_data_url;
 
 use crate::session::persistence as unified_persistence;
 use crate::session::IdeContext;
@@ -109,15 +110,35 @@ pub async fn process_gateway_message(
         }
     }
 
+    let images = if msg.media.is_empty() {
+        None
+    } else {
+        let data_urls: Vec<String> = msg
+            .media
+            .iter()
+            .filter_map(|m| {
+                if m.starts_with("data:") {
+                    Some(m.clone())
+                } else {
+                    load_image_as_data_url(m).or_else(|| {
+                        warn!("[agent-loop] media is not loadable as image data URL: {}", m);
+                        None
+                    })
+                }
+            })
+            .collect();
+        if data_urls.is_empty() {
+            None
+        } else {
+            Some(data_urls)
+        }
+    };
+
     let input = super::turn::TurnInput {
         content: msg.content.clone(),
         display_text: None,
         agent_mode: None,
-        images: if msg.media.is_empty() {
-            None
-        } else {
-            Some(msg.media.clone())
-        },
+        images,
         ide_context: ide_context.cloned(),
         is_resume: false,
         channel: Some(msg.channel.clone()),
@@ -201,7 +222,14 @@ pub async fn process_gateway_message(
 
     match result {
         Ok(processing_result) => {
-            let content = &processing_result.content;
+            let content = crate::session::status_bar::append_status_bar_for_channel(
+                &msg.channel,
+                processing_result.content.clone(),
+                &session,
+                processing_result.total_tokens,
+                processing_result.context_tokens,
+            )
+            .await;
             let out_preview: String = crate::utils::safe_truncate_chars_to_string(&content, 80);
             info!(
                 "[agent-loop] Response for {}:{}: {}...",
@@ -210,7 +238,7 @@ pub async fn process_gateway_message(
             Ok(Some(OutboundMessage::new(
                 &msg.channel,
                 &msg.chat_id,
-                content,
+                &content,
             )))
         }
         Err(err) => {

--- a/src-tauri/crates/agent-core/src/foundation/persistence/db_helpers/messages/load_llm.rs
+++ b/src-tauri/crates/agent-core/src/foundation/persistence/db_helpers/messages/load_llm.rs
@@ -301,7 +301,30 @@ fn reconstruct(messages: &[AgentMessageRow]) -> Vec<serde_json::Value> {
         result.append(tool_results);
     };
 
-    for msg in messages {
+    // Avoid resending every historical image on every turn: base64 image
+    // payloads are large and can exceed gateway/body limits quickly. Preserve
+    // multimodal content for the most recent image-bearing user message, and
+    // render older image messages as text-only history.
+    let last_image_msg_index = messages
+        .iter()
+        .enumerate()
+        .rev()
+        .find_map(|(idx, msg)| {
+            if msg.role == message_role::USER
+                && msg
+                    .images
+                    .as_deref()
+                    .and_then(|s| serde_json::from_str::<Vec<String>>(s).ok())
+                    .map(|refs| !refs.is_empty())
+                    .unwrap_or(false)
+            {
+                Some(idx)
+            } else {
+                None
+            }
+        });
+
+    for (msg_idx, msg) in messages.iter().enumerate() {
         match msg.role.as_str() {
             message_role::SYSTEM => {
                 flush_pending(
@@ -321,9 +344,10 @@ fn reconstruct(messages: &[AgentMessageRow]) -> Vec<serde_json::Value> {
                     &mut pending_tool_results,
                 );
 
-                if let Some(images_json) = &msg.images {
-                    if let Ok(image_refs) = serde_json::from_str::<Vec<String>>(images_json) {
-                        if !image_refs.is_empty() {
+                if last_image_msg_index == Some(msg_idx) {
+                    if let Some(images_json) = &msg.images {
+                        if let Ok(image_refs) = serde_json::from_str::<Vec<String>>(images_json) {
+                            if !image_refs.is_empty() {
                             result.push(serde_json::json!({
                                 "role": message_role::USER,
                                 "content": build_multimodal_content(&msg.content, &image_refs),
@@ -331,6 +355,7 @@ fn reconstruct(messages: &[AgentMessageRow]) -> Vec<serde_json::Value> {
                             continue;
                         }
                     }
+                }
                 }
                 result.push(serde_json::json!({
                     "role": message_role::USER,

--- a/src-tauri/crates/agent-core/src/integrations/channels/feishu/api.rs
+++ b/src-tauri/crates/agent-core/src/integrations/channels/feishu/api.rs
@@ -135,6 +135,183 @@ pub(super) async fn send_feishu_message(
 
 // ── Media Upload/Download ───────────────────────────────────────────────
 
+fn image_ext_from_bytes(bytes: &[u8]) -> &'static str {
+    if bytes.starts_with(&[0xFF, 0xD8, 0xFF]) {
+        "jpg"
+    } else if bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
+        "png"
+    } else if bytes.starts_with(b"RIFF") && bytes.get(8..12) == Some(b"WEBP") {
+        "webp"
+    } else if bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a") {
+        "gif"
+    } else {
+        "bin"
+    }
+}
+
+/// Download an image from Feishu by image_key. Returns raw bytes.
+pub(super) async fn download_image(
+    auth: &FeishuAuth,
+    image_key: &str,
+) -> Result<Vec<u8>, ChannelError> {
+    let token = auth.get_token().await?;
+    let url = format!("{}/im/v1/images/{}", auth.api_base(), image_key);
+
+    let res = auth
+        .client()
+        .get(&url)
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .map_err(|err| ChannelError::Other(format!("Download image failed: {}", err)))?;
+
+    if !res.status().is_success() {
+        return Err(ChannelError::Other(format!(
+            "Download image HTTP {}: {}",
+            res.status(),
+            image_key
+        )));
+    }
+
+    res.bytes()
+        .await
+        .map(|b| b.to_vec())
+        .map_err(|err| ChannelError::Other(format!("Read image bytes failed: {}", err)))
+}
+
+/// Download an image resource from a specific Feishu message. Rich-text/post
+/// image elements are message resources, and `/im/v1/images/{image_key}` can
+/// reject them with 400.
+pub(super) async fn download_message_image(
+    auth: &FeishuAuth,
+    message_id: &str,
+    image_key: &str,
+) -> Result<Vec<u8>, ChannelError> {
+    let token = auth.get_token().await?;
+    let url = format!(
+        "{}/im/v1/messages/{}/resources/{}?type=image",
+        auth.api_base(),
+        message_id,
+        image_key
+    );
+
+    let res = auth
+        .client()
+        .get(&url)
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .map_err(|err| ChannelError::Other(format!("Download message image failed: {}", err)))?;
+
+    if !res.status().is_success() {
+        return Err(ChannelError::Other(format!(
+            "Download message image HTTP {}: message_id={}, image_key={}",
+            res.status(),
+            message_id,
+            image_key
+        )));
+    }
+
+    res.bytes()
+        .await
+        .map(|b| b.to_vec())
+        .map_err(|err| ChannelError::Other(format!("Read message image bytes failed: {}", err)))
+}
+
+/// Download a file from Feishu by file_key. Returns raw bytes.
+pub(super) async fn download_file(
+    auth: &FeishuAuth,
+    file_key: &str,
+) -> Result<Vec<u8>, ChannelError> {
+    let token = auth.get_token().await?;
+    let url = format!("{}/im/v1/files/{}", auth.api_base(), file_key);
+
+    let res = auth
+        .client()
+        .get(&url)
+        .header("Authorization", format!("Bearer {}", token))
+        .send()
+        .await
+        .map_err(|err| ChannelError::Other(format!("Download file failed: {}", err)))?;
+
+    if !res.status().is_success() {
+        return Err(ChannelError::Other(format!(
+            "Download file HTTP {}: {}",
+            res.status(),
+            file_key
+        )));
+    }
+
+    res.bytes()
+        .await
+        .map(|b| b.to_vec())
+        .map_err(|err| ChannelError::Other(format!("Read file bytes failed: {}", err)))
+}
+
+/// Resolve `feishu:image:{key}` / `feishu:file:{key}` media references in an
+/// InboundMessage to local file paths by downloading from Feishu API and
+/// persisting to `~/.orgii/session-images/`.
+pub(super) async fn resolve_feishu_media(
+    auth: &FeishuAuth,
+    media: &mut Vec<String>,
+) {
+    let images_dir = app_paths::session_images_dir();
+    let _ = std::fs::create_dir_all(&images_dir);
+    tracing::info!("[feishu:debug] resolve_feishu_media entered, media_count={}, dir={}", media.len(), images_dir.display());
+
+    for entry in media.iter_mut() {
+        if let Some(image_ref) = entry.strip_prefix("feishu:image:") {
+            let image_ref = image_ref.to_string();
+            let download_result = if let Some((message_id, image_key)) = image_ref.split_once(':') {
+                download_message_image(auth, message_id, image_key).await
+            } else {
+                download_image(auth, &image_ref).await
+            };
+            match download_result {
+                Ok(bytes) => {
+                    let hash = sha256_hex(&bytes);
+                    let ext = image_ext_from_bytes(&bytes);
+                    let filename = format!("{}.{}", &hash[..16], ext);
+                    let path = images_dir.join(&filename);
+                    if !path.exists() {
+                        if let Err(err) = std::fs::write(&path, &bytes) {
+                            warn!("[feishu] Failed to persist image {}: {}", image_ref, err);
+                            continue;
+                        }
+                    }
+                    *entry = path.to_string_lossy().to_string();
+                }
+                Err(err) => {
+                    warn!("[feishu] Failed to download image {}: {}", image_ref, err);
+                }
+            }
+        } else if let Some(file_key) = entry.strip_prefix("feishu:file:") {
+            let file_key = file_key.to_string();
+            match download_file(auth, &file_key).await {
+                Ok(bytes) => {
+                    let hash = sha256_hex(&bytes);
+                    let filename = format!("{}.bin", &hash[..16]);
+                    let path = images_dir.join(&filename);
+                    if !path.exists() {
+                        if let Err(err) = std::fs::write(&path, &bytes) {
+                            warn!("[feishu] Failed to persist file {}: {}", file_key, err);
+                            continue;
+                        }
+                    }
+                    *entry = path.to_string_lossy().to_string();
+                }
+                Err(err) => {
+                    warn!("[feishu] Failed to download file {}: {}", file_key, err);
+                }
+            }
+        }
+    }
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    crate::foundation::persistence::images::sha256_hex(data)
+}
+
 /// Upload an image to Feishu and return the image_key.
 pub(super) async fn upload_image(
     auth: &FeishuAuth,

--- a/src-tauri/crates/agent-core/src/integrations/channels/feishu/channel.rs
+++ b/src-tauri/crates/agent-core/src/integrations/channels/feishu/channel.rs
@@ -190,6 +190,7 @@ impl Channel for FeishuChannel {
         let app_secret = self.config.app_secret.clone();
         let api_base = self.auth.api_base().to_string();
         let http_client = self.auth.client().clone();
+        let auth = self.auth.clone();
 
         let handle = tokio::spawn(async move {
             ws::feishu_ws_loop(
@@ -205,6 +206,7 @@ impl Channel for FeishuChannel {
                 inbound_tx,
                 channel_name,
                 event_config,
+                auth,
             )
             .await;
         });
@@ -264,7 +266,7 @@ impl Channel for FeishuChannel {
         _chat_id: &str,
         message_id: &str,
     ) -> Result<(), ChannelError> {
-        api::add_reaction(&self.auth, message_id, "PROCESSING").await
+        api::add_reaction(&self.auth, message_id, "Typing").await
     }
 
     async fn on_processing_end(
@@ -272,7 +274,7 @@ impl Channel for FeishuChannel {
         _chat_id: &str,
         message_id: &str,
     ) -> Result<(), ChannelError> {
-        api::remove_reaction(&self.auth, message_id, "PROCESSING").await
+        api::remove_reaction(&self.auth, message_id, "Typing").await
     }
 
     async fn update_message(&self, message_id: &str, content: &str) -> Result<(), ChannelError> {

--- a/src-tauri/crates/agent-core/src/integrations/channels/feishu/event.rs
+++ b/src-tauri/crates/agent-core/src/integrations/channels/feishu/event.rs
@@ -2,7 +2,7 @@
 
 use serde_json::Value;
 use std::collections::HashSet;
-use tracing::info;
+use tracing::{debug, info};
 
 use crate::bus::InboundMessage;
 use crate::integrations::channels::config::AccessPolicy;
@@ -78,6 +78,7 @@ pub(super) fn parse_feishu_event(
         .get("message_type")
         .and_then(|m| m.as_str())
         .unwrap_or("text");
+    tracing::info!("[feishu:debug] message_type={:?} raw_content_preview", message_type);
     let sender_id = sender
         .get("sender_id")
         .and_then(|s| s.get("open_id"))
@@ -139,6 +140,13 @@ pub(super) fn parse_feishu_event(
                 if !config.allow_from.is_empty()
                     && !config.allow_from.iter().any(|a| a == sender_id)
                 {
+                    // 这次 debug 最大的坑：allowlist 用错 open_id（per-app 不同）会静默吞消息。
+                    // 加日志：拒绝时打印 sender open_id，方便对照 allow_from 配置。
+                    debug!(
+                        "[feishu] DM rejected by allowlist: sender open_id={} not in allow_from (size={})",
+                        sender_id,
+                        config.allow_from.len()
+                    );
                     return None;
                 }
             }
@@ -173,12 +181,26 @@ pub(super) fn parse_feishu_event(
 
     // Store image/file keys in media vec
     if message_type == "image" {
+        tracing::info!("[feishu:debug] image msg raw_content={}", raw_content);
         if let Some(key) = parse_content_json(raw_content).and_then(|v| {
             v.get("image_key")
                 .and_then(|k| k.as_str())
                 .map(|s| s.to_string())
         }) {
-            inbound.media.push(format!("feishu:image:{}", key));
+            tracing::info!("[feishu:debug] extracted image_key, media push");
+            inbound.media.push(format!("feishu:image:{}:{}", message_id, key));
+        } else {
+            tracing::warn!("[feishu:debug] FAILED to extract image_key from raw_content");
+        }
+    } else if message_type == "post" {
+        // Rich-text (post) messages can embed images as `img` elements
+        // carrying an `image_key`. Collect them so they get downloaded too.
+        if let Some(parsed) = parse_content_json(raw_content) {
+            let mut keys = Vec::new();
+            collect_post_image_keys(&parsed, &mut keys);
+            for key in keys {
+                inbound.media.push(format!("feishu:image:{}:{}", message_id, key));
+            }
         }
     } else if message_type == "file" {
         if let Some(key) = parse_content_json(raw_content).and_then(|v| {
@@ -233,6 +255,34 @@ fn extract_text_content(raw_content: &str, message_type: &str) -> String {
 fn parse_content_json(raw: &str) -> Option<Value> {
     serde_json::from_str(raw).ok()
 }
+
+/// Walk a Feishu "post" content tree and collect all embedded `img` element
+/// `image_key`s (locale roots zh_cn/en_us/ja_jp, then paragraphs of elements).
+fn collect_post_image_keys(parsed: &Value, out: &mut Vec<String>) {
+    let content_root = parsed
+        .get("zh_cn")
+        .or_else(|| parsed.get("en_us"))
+        .or_else(|| parsed.get("ja_jp"))
+        .unwrap_or(parsed);
+
+    if let Some(paragraphs) = content_root.get("content").and_then(|c| c.as_array()) {
+        for paragraph in paragraphs {
+            if let Some(elements) = paragraph.as_array() {
+                for element in elements {
+                    let tag = element.get("tag").and_then(|t| t.as_str()).unwrap_or("");
+                    if tag == "img" {
+                        if let Some(key) =
+                            element.get("image_key").and_then(|k| k.as_str())
+                        {
+                            out.push(key.to_string());
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 
 /// Flatten Feishu "post" rich text to plain text.
 fn flatten_post_content(parsed: &Value) -> String {

--- a/src-tauri/crates/agent-core/src/integrations/channels/tests/feishu_event_tests.rs
+++ b/src-tauri/crates/agent-core/src/integrations/channels/tests/feishu_event_tests.rs
@@ -367,7 +367,41 @@ fn image_message_extracts_media_key() {
     let msg = parse_feishu_event(&payload, "test", &config, &mut dedup, &mut dedup_order).unwrap();
     assert_eq!(msg.content, "[image]");
     assert_eq!(msg.media.len(), 1);
-    assert_eq!(msg.media[0], "feishu:image:img-v2-abc");
+    assert_eq!(msg.media[0], "feishu:image:msg_img_1:img-v2-abc");
+}
+
+#[test]
+fn post_message_extracts_embedded_image_keys() {
+    let config = default_config();
+    let mut dedup = HashSet::new();
+    let mut dedup_order = Vec::new();
+    let payload = json!({
+        "header": { "event_type": "im.message.receive_v1" },
+        "event": {
+            "message": {
+                "message_id": "msg_post_1",
+                "chat_id": "chat_1",
+                "chat_type": "p2p",
+                "message_type": "post",
+                "content": json!({
+                    "zh_cn": {
+                        "content": [[
+                            {"tag": "text", "text": "看图"},
+                            {"tag": "img", "image_key": "img-post-abc"}
+                        ]]
+                    }
+                }).to_string(),
+            },
+            "sender": {
+                "sender_type": "user",
+                "sender_id": { "open_id": "user_1" },
+            }
+        }
+    });
+    let msg = parse_feishu_event(&payload, "test", &config, &mut dedup, &mut dedup_order).unwrap();
+    assert_eq!(msg.content.trim(), "看图[image]");
+    assert_eq!(msg.media.len(), 1);
+    assert_eq!(msg.media[0], "feishu:image:msg_post_1:img-post-abc");
 }
 
 #[test]

--- a/src-tauri/crates/agent-core/src/integrations/gateway/workers.rs
+++ b/src-tauri/crates/agent-core/src/integrations/gateway/workers.rs
@@ -4,6 +4,7 @@
 //! entry point stays focused on wiring rather than per-task logic.
 
 use std::sync::atomic::{AtomicBool, Ordering};
+use serde_json::Value;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 use tracing::{error, info, warn};
@@ -125,18 +126,52 @@ async fn handle_ready_message(
             .and_then(|mgr| mgr.typing_refresh_interval_for(&msg.channel))
     };
 
+    let message_id = msg
+        .metadata
+        .get("message_id")
+        .or_else(|| msg.metadata.get("source_message_id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let reaction_channel = msg
+        .metadata
+        .get("source_channel")
+        .and_then(|v| v.as_str())
+        .unwrap_or(&msg.channel)
+        .to_string();
+    let reaction_chat_id = msg
+        .metadata
+        .get("source_chat_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or(&msg.chat_id)
+        .to_string();
+
+    if !message_id.is_empty() {
+        info!(
+            channel = %reaction_channel,
+            chat_id = %reaction_chat_id,
+            message_id = %message_id,
+            "[gateway] processing reaction start"
+        );
+        let cm_lock = channel_manager.lock().await;
+        if let Some(ref mgr) = *cm_lock {
+            mgr.notify_processing_start(&reaction_channel, &reaction_chat_id, &message_id)
+                .await;
+        }
+    }
+
     let typing_task: Option<tokio::task::JoinHandle<()>> = typing_interval.map(|interval| {
         let cm = channel_manager.clone();
-        let channel_name = msg.channel.clone();
-        let chat_id = msg.chat_id.clone();
-        let message_id = msg
-            .metadata
-            .get("message_id")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
+        let channel_name = reaction_channel.clone();
+        let chat_id = reaction_chat_id.clone();
+        let message_id = message_id.clone();
         tokio::spawn(async move {
             loop {
+                tokio::time::sleep(interval).await;
+                if message_id.is_empty() {
+                    continue;
+                }
                 {
                     let cm_lock = cm.lock().await;
                     if let Some(ref mgr) = *cm_lock {
@@ -144,25 +179,53 @@ async fn handle_ready_message(
                             .await;
                     }
                 }
-                tokio::time::sleep(interval).await;
             }
         })
     });
 
+    let mut remove_processing_on_handler_done = true;
+
     match handler.handle_message(msg.clone()).await {
-        Ok(Some(response)) => {
+        Ok(Some(mut response)) => {
+            if !message_id.is_empty() {
+                response.metadata.insert(
+                    "processing_reaction_chat_id".to_string(),
+                    Value::String(reaction_chat_id.clone()),
+                );
+                response.metadata.insert(
+                    "processing_reaction_message_id".to_string(),
+                    Value::String(message_id.clone()),
+                );
+                remove_processing_on_handler_done = false;
+            }
             let bus_lock = bus.lock().await;
             bus_lock.publish_outbound(response);
         }
-        Ok(None) => {}
+        Ok(None) => {
+            if !message_id.is_empty() && msg.metadata.contains_key("source_message_id") {
+                remove_processing_on_handler_done = false;
+            }
+        }
         Err(err_msg) => {
             error!("[gateway] Error processing message: {}", err_msg);
-            let bus_lock = bus.lock().await;
-            bus_lock.publish_outbound(OutboundMessage::new(
+            let mut response = OutboundMessage::new(
                 &msg.channel,
                 &msg.chat_id,
                 &format!("Sorry, I encountered an error: {}", err_msg),
-            ));
+            );
+            if !message_id.is_empty() {
+                response.metadata.insert(
+                    "processing_reaction_chat_id".to_string(),
+                    Value::String(reaction_chat_id.clone()),
+                );
+                response.metadata.insert(
+                    "processing_reaction_message_id".to_string(),
+                    Value::String(message_id.clone()),
+                );
+                remove_processing_on_handler_done = false;
+            }
+            let bus_lock = bus.lock().await;
+            bus_lock.publish_outbound(response);
         }
     }
 
@@ -170,15 +233,18 @@ async fn handle_ready_message(
         task.abort();
     }
 
-    let message_id = msg
-        .metadata
-        .get("message_id")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-    let cm_lock = channel_manager.lock().await;
-    if let Some(ref mgr) = *cm_lock {
-        mgr.notify_processing_end(&msg.channel, &msg.chat_id, message_id)
-            .await;
+    if remove_processing_on_handler_done && !message_id.is_empty() {
+        let cm_lock = channel_manager.lock().await;
+        if let Some(ref mgr) = *cm_lock {
+            info!(
+                channel = %reaction_channel,
+                chat_id = %reaction_chat_id,
+                message_id = %message_id,
+                "[gateway] processing reaction end after handler"
+            );
+            mgr.notify_processing_end(&reaction_channel, &reaction_chat_id, &message_id)
+                .await;
+        }
     }
 }
 
@@ -224,6 +290,20 @@ pub(super) async fn spawn_outbound_dispatcher(
                         crate::utils::safe_truncate_chars_to_string(&outbound_msg.content, 60)
                     );
 
+                    let processing_reaction = outbound_msg
+                        .metadata
+                        .get("processing_reaction_message_id")
+                        .and_then(|v| v.as_str())
+                        .map(|message_id| {
+                            let chat_id = outbound_msg
+                                .metadata
+                                .get("processing_reaction_chat_id")
+                                .and_then(|v| v.as_str())
+                                .unwrap_or(&outbound_msg.chat_id)
+                                .to_string();
+                            (chat_id, message_id.to_string())
+                        });
+
                     let cm_lock = channel_manager.lock().await;
                     if let Some(ref manager) = *cm_lock {
                         if let Err(err) = manager.send_to_with_delivery(&outbound_msg).await {
@@ -231,6 +311,17 @@ pub(super) async fn spawn_outbound_dispatcher(
                                 "[gateway] Failed to deliver to channel {}: {}",
                                 outbound_msg.channel, err
                             );
+                        }
+                        if let Some((chat_id, message_id)) = processing_reaction {
+                            info!(
+                                channel = %outbound_msg.channel,
+                                chat_id = %chat_id,
+                                message_id = %message_id,
+                                "[gateway] processing reaction end after delivery"
+                            );
+                            manager
+                                .notify_processing_end(&outbound_msg.channel, &chat_id, &message_id)
+                                .await;
                         }
                     }
                     drop(cm_lock);

--- a/src-tauri/crates/agent-core/src/state/commands/channel_handler/dispatch.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/channel_handler/dispatch.rs
@@ -10,6 +10,7 @@ use tracing::{info, warn};
 
 use crate::bus::{InboundMessage, OutboundMessage};
 use crate::definitions::{os_agent, OS_AGENT_ID};
+use crate::definitions::prefix_lookup::SDE_SESSION_PREFIX;
 use crate::gateway::{parse_command, InboundMessageHandler, InboundProcessorDeps, SessionKey};
 use crate::interaction::permission::AgentPermissionManager;
 use crate::interaction::question::QuestionManager;
@@ -83,6 +84,16 @@ impl InboundMessageHandler for GatewayInboundHandler {
                      caller must set it before publishing to REINJECT_CHANNEL"
                     .to_string());
             };
+            // Re-injected messages (e.g. after media download) target an
+            // already-derived OS session id. The original buffering path may
+            // have minted a fresh -v{n} id without registering it yet, so the
+            // subsequent `init_channel_session` lookup would fail with
+            // "channel session '…' not registered". Mirror Branch 3 and ensure
+            // OS sessions are registered before dispatch. (SDE sessions manage
+            // their own lifecycle and are skipped.)
+            if !target_session_id.starts_with(SDE_SESSION_PREFIX) {
+                ensure_os_session_registered(&state, &target_session_id).await;
+            }
             return dispatch_to_session(
                 &state,
                 account_id.as_deref(),
@@ -198,6 +209,12 @@ impl InboundMessageHandler for GatewayInboundHandler {
             "source_chat_id".to_string(),
             serde_json::Value::String(msg.chat_id.clone()),
         );
+        if let Some(message_id) = msg.metadata.get("message_id").and_then(|v| v.as_str()) {
+            inbound.metadata.insert(
+                "source_message_id".to_string(),
+                serde_json::Value::String(message_id.to_string()),
+            );
+        }
         inbound.media = msg.media.clone();
 
         let sender = {
@@ -272,8 +289,6 @@ async fn dispatch_to_session(
     _question_manager: &Arc<QuestionManager>,
     _permission_manager: &Arc<AgentPermissionManager>,
 ) -> Result<Option<OutboundMessage>, String> {
-    use crate::definitions::prefix_lookup::SDE_SESSION_PREFIX;
-
     let (gw_account, gw_model) = resolve_gateway_model_and_account(state).await;
     let effective_account = account_id.or(gw_account.as_deref());
 


### PR DESCRIPTION
# Proposed PR summary for ORG2 official

## Title
Fix Feishu typing reactions and media handling

## Summary
This PR fixes several Feishu/Lark channel edge cases:

- Use the valid Feishu typing reaction key `Typing` instead of invalid `PROCESSING`.
- Keep typing reaction visible across gateway reinject flow until the final outbound reply is delivered.
- Preserve original Feishu `message_id` across reinject via `source_message_id`.
- Parse and download post/rich-text embedded images through message resource API.
- Convert channel-downloaded local images into model-compatible data URLs before model input.
- Avoid retaining too many historical images in model requests.

## Validation
- Manual Feishu tests: typing reaction stays until reply delivery, then clears.
- Manual Feishu image/post tests pass.
- `cargo check -p agent_core`
- `cargo test -p agent_core feishu -- --nocapture`
- `cargo check -p org2`


Related issues: #181, #182, #183.

Validation run on PR branch:

```text
cargo test -p agent_core feishu -- --nocapture
# 32 passed
```
