### PR TITLE
fix(opencode): support OpenCode as a provider

### DIFF
--- a/src-tauri/crates/agent-core/src/core/providers/factory.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/factory.rs
@@ -301,12 +301,12 @@ fn spec_for_model_type(model_type: &ModelType) -> Option<&'static ProviderSpec> 
         ModelType::ZenmuxApi => provider_id::ZENMUX,
         ModelType::VllmApi => provider_id::VLLM,
         ModelType::AzureOpenaiApi => provider_id::AZURE_OPENAI,
+        ModelType::OpenCode => provider_id::OPENCODE,
         ModelType::CursorCli
         | ModelType::ClaudeCode
         | ModelType::Copilot
         | ModelType::Kiro
         | ModelType::KimiCli
-        | ModelType::OpenCode
         | ModelType::OrgiiOrchestrator => return None,
     };
     registry::find_by_name(provider_name)
@@ -939,6 +939,7 @@ mod tests {
     const ALL_PROVIDER_IDS: &[&str] = &[
         provider_id::OPENROUTER,
         provider_id::ZENMUX,
+        provider_id::OPENCODE,
         provider_id::ANTHROPIC,
         provider_id::OPENAI,
         provider_id::DEEPSEEK,
@@ -978,6 +979,7 @@ mod tests {
             provider_id::MOONSHOT,
             provider_id::OPENROUTER,
             provider_id::ZENMUX,
+            provider_id::OPENCODE,
             provider_id::VLLM,
             provider_id::AZURE_OPENAI,
         ];
@@ -995,6 +997,12 @@ mod tests {
         assert!(spec_for_model_type(&ModelType::ClaudeCode).is_none());
         assert!(spec_for_model_type(&ModelType::KimiCli).is_none());
         assert!(spec_for_model_type(&ModelType::Codex).is_some());
+        assert_eq!(
+            spec_for_model_type(&ModelType::OpenCode)
+                .expect("OpenCode Go can power Rust-native sessions")
+                .name,
+            provider_id::OPENCODE
+        );
         assert_eq!(
             spec_for_model_type(&ModelType::GeminiCli)
                 .expect("Gemini CLI can power Rust-native sessions")

--- a/src-tauri/crates/agent-core/src/core/providers/openai_compat/streaming/error_classify.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/openai_compat/streaming/error_classify.rs
@@ -217,6 +217,22 @@ mod tests {
     }
 
     #[test]
+    fn repairs_unquoted_absolute_path_value() {
+        let args = r#"{"pattern":"platform::Simulate|simulator","paths": /Users/shibosheng/Desktop/code/atomcode_src}"#;
+        match parse_streamed_tool_args(args) {
+            ParsedToolArgs::Ok(value) => {
+                assert_eq!(
+                    value.get("paths").and_then(|v| v.as_str()),
+                    Some("/Users/shibosheng/Desktop/code/atomcode_src")
+                );
+            }
+            ParsedToolArgs::Failed { cause, parse_err } => {
+                panic!("expected repaired JSON, got cause={cause} err={parse_err}")
+            }
+        }
+    }
+
+    #[test]
     fn classifies_double_encoded_string() {
         // Provider wrapped the actual object as a JSON string literal:
         //   "\"{\\\"path\\\":\\\"a.md\\\"}\""

--- a/src-tauri/crates/agent-core/src/core/providers/openai_compat/streaming/parse.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/openai_compat/streaming/parse.rs
@@ -59,6 +59,72 @@ pub(super) enum ParsedToolArgs {
     },
 }
 
+fn parse_with_quoted_absolute_paths(args_str: &str) -> Option<Value> {
+    let mut repaired = String::with_capacity(args_str.len() + 8);
+    let mut chars = args_str.char_indices().peekable();
+    let mut in_string = false;
+    let mut escaped = false;
+
+    while let Some((idx, ch)) = chars.next() {
+        repaired.push(ch);
+
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+        if ch == '"' {
+            in_string = !in_string;
+            continue;
+        }
+        if in_string || ch != ':' {
+            continue;
+        }
+
+        while let Some((_, ws)) = chars.peek().copied() {
+            if !ws.is_whitespace() {
+                break;
+            }
+            repaired.push(ws);
+            chars.next();
+        }
+
+        let Some((value_start, '/')) = chars.peek().copied() else {
+            continue;
+        };
+
+        let mut value_end = value_start;
+        while let Some((next_idx, next_ch)) = chars.peek().copied() {
+            if matches!(next_ch, ',' | '}' | ']') {
+                break;
+            }
+            value_end = next_idx + next_ch.len_utf8();
+            chars.next();
+        }
+
+        let raw_value = &args_str[value_start..value_end];
+        let trimmed = raw_value.trim_end();
+        if trimmed.is_empty() {
+            return None;
+        }
+        let quoted = serde_json::to_string(trimmed).ok()?;
+        repaired.push_str(&quoted);
+        repaired.push_str(&raw_value[trimmed.len()..]);
+
+        if value_end <= idx {
+            return None;
+        }
+    }
+
+    if repaired == args_str {
+        return None;
+    }
+    serde_json::from_str::<Value>(&repaired).ok()
+}
+
 /// Parse the accumulated `function.arguments` string for a streamed
 /// tool call. On failure, classifies the error so that callers (and
 /// log scrapers) can tell apart the four root-cause families we have
@@ -95,6 +161,9 @@ pub(super) fn parse_streamed_tool_args(args_str: &str) -> ParsedToolArgs {
     match serde_json::from_str::<Value>(args_str) {
         Ok(v) => ParsedToolArgs::Ok(v),
         Err(parse_err) => {
+            if let Some(repaired) = parse_with_quoted_absolute_paths(args_str) {
+                return ParsedToolArgs::Ok(repaired);
+            }
             let cause = super::error_classify::classify_invalid_args(args_str);
             ParsedToolArgs::Failed { cause, parse_err }
         }

--- a/src-tauri/crates/agent-core/src/core/providers/openai_compat/streaming/sse_stream.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/openai_compat/streaming/sse_stream.rs
@@ -32,6 +32,22 @@ use crate::providers::wire_sanitize::{
 };
 use crate::utils::http_retry::extract_retry_after_secs;
 
+fn finish_reason_after_incomplete_tool_calls(
+    finish_reason: String,
+    tool_call_count: usize,
+    incomplete_tool_call_count: usize,
+) -> (String, Option<StreamErrorKind>) {
+    if finish_reason == finish::TOOL_CALLS && tool_call_count == 0 && incomplete_tool_call_count > 0
+    {
+        (
+            finish::STREAM_ERROR.to_string(),
+            Some(StreamErrorKind::ProviderError),
+        )
+    } else {
+        (finish_reason, None)
+    }
+}
+
 // Mirrors the `LLMProvider::chat_streaming` trait signature (8 args). The
 // trait method itself triggers the same warning at the call site; allow
 // here so the free function shape stays 1:1 with the trait.
@@ -523,14 +539,16 @@ pub(super) async fn run_chat_streaming(
         });
     }
 
-    // Assemble final tool calls — discard incomplete entries from stream interruption
+    // Assemble final tool calls — treat incomplete entries as stream errors.
     let mut tool_calls: Vec<ToolCallRequest> = Vec::new();
+    let mut incomplete_tool_call_count = 0usize;
     let mut indices: Vec<usize> = tool_call_accumulators.keys().cloned().collect();
     indices.sort();
     for index in indices {
         if let Some((id, name, args_str, thought_signature)) = tool_call_accumulators.remove(&index)
         {
             if id.is_empty() || name.is_empty() {
+                incomplete_tool_call_count += 1;
                 warn!(
                     "Discarding incomplete tool call at index {} (missing id/name)",
                     index
@@ -574,6 +592,23 @@ pub(super) async fn run_chat_streaming(
         );
     }
 
+    let (resolved_finish_reason, malformed_tool_stream_kind) =
+        finish_reason_after_incomplete_tool_calls(
+            finish_reason.clone(),
+            tool_calls.len(),
+            incomplete_tool_call_count,
+        );
+    if let Some(kind) = malformed_tool_stream_kind {
+        warn!(
+            provider = this.provider_spec.name,
+            model = resolved_model,
+            incomplete_tool_call_count,
+            "OpenAI-compatible stream ended with only incomplete tool call(s)"
+        );
+        finish_reason = resolved_finish_reason;
+        stream_error_kind = Some(kind);
+    }
+
     // Send final delta with finish reason
     on_delta(StreamDelta {
         content: None,
@@ -612,4 +647,100 @@ pub(super) async fn run_chat_streaming(
         stream_error_kind,
         retry_after_ms: stream_retry_after_ms,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::registry::{find_by_name, provider_id};
+    use crate::providers::traits::{LLMProvider, ProviderConfig};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn malformed_only_tool_call_finish_becomes_stream_error() {
+        let (finish_reason, kind) =
+            finish_reason_after_incomplete_tool_calls(finish::TOOL_CALLS.to_string(), 0, 2);
+
+        assert_eq!(finish_reason, finish::STREAM_ERROR);
+        assert_eq!(kind, Some(StreamErrorKind::ProviderError));
+    }
+
+    #[test]
+    fn parsed_tool_calls_keep_tool_call_finish() {
+        let (finish_reason, kind) =
+            finish_reason_after_incomplete_tool_calls(finish::TOOL_CALLS.to_string(), 1, 1);
+
+        assert_eq!(finish_reason, finish::TOOL_CALLS);
+        assert_eq!(kind, None);
+    }
+
+    #[test]
+    fn non_tool_finish_ignores_incomplete_tool_count() {
+        let (finish_reason, kind) =
+            finish_reason_after_incomplete_tool_calls(finish::STOP.to_string(), 0, 1);
+
+        assert_eq!(finish_reason, finish::STOP);
+        assert_eq!(kind, None);
+    }
+
+    #[tokio::test]
+    async fn stream_with_only_incomplete_tool_calls_returns_stream_error_response() {
+        crate::test_support::install_crypto_provider_for_tests();
+
+        let server = MockServer::start().await;
+        let body = concat!(
+            "data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"{\\\"path\\\":\\\"src/main.rs\\\"}\"}}]},\"finish_reason\":null}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\n",
+            "data: [DONE]\n\n"
+        );
+        Mock::given(method("POST"))
+            .and(path("/chat/completions"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/event-stream")
+                    .set_body_string(body),
+            )
+            .mount(&server)
+            .await;
+
+        let spec = find_by_name(provider_id::OPENCODE).expect("opencode provider registered");
+        let client = OpenAICompatClient::new(
+            ProviderConfig {
+                api_key: "test-key".to_string(),
+                api_base: Some(server.uri()),
+                extra_headers: HashMap::new(),
+                is_azure: false,
+            },
+            spec,
+            "test-model".to_string(),
+        );
+
+        let response = client
+            .chat_streaming(
+                &[serde_json::json!({"role": "user", "content": "read the file"})],
+                Some(&[serde_json::json!({
+                    "type": "function",
+                    "function": {
+                        "name": "read_file",
+                        "parameters": {"type": "object", "properties": {}}
+                    }
+                })]),
+                "test-model",
+                1024,
+                0.0,
+                &|_| {},
+                None,
+            )
+            .await
+            .expect("stream should parse into a response");
+
+        assert_eq!(response.finish_reason, finish::STREAM_ERROR);
+        assert_eq!(
+            response.stream_error_kind,
+            Some(StreamErrorKind::ProviderError)
+        );
+        assert!(response.tool_calls.is_empty());
+        assert_eq!(response.content, None);
+    }
 }

--- a/src-tauri/crates/agent-core/src/core/providers/registry.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/registry.rs
@@ -20,6 +20,7 @@ pub mod provider_id {
     // Aggregators
     pub const OPENROUTER: &str = "openrouter";
     pub const ZENMUX: &str = "zenmux";
+    pub const OPENCODE: &str = "opencode";
 
     // Standard providers
     pub const ANTHROPIC: &str = "anthropic";
@@ -84,6 +85,17 @@ pub static PROVIDERS: &[ProviderSpec] = &[
         default_anthropic_api_base: Some("https://zenmux.ai/api/anthropic"),
         is_local: false,
         env_key: Some("ZENMUX_API_KEY"),
+    },
+    ProviderSpec {
+        name: provider_id::OPENCODE,
+        display_name: "OpenCode",
+        keywords: &[],
+        litellm_prefix: None,
+        skip_prefixes: &[],
+        default_api_base: Some("https://opencode.ai/zen/go/v1"),
+        default_anthropic_api_base: None,
+        is_local: false,
+        env_key: Some("OPENCODE_API_KEY"),
     },
     // ===== Standard Providers =====
     ProviderSpec {

--- a/src-tauri/crates/key-vault/src/auto_detect/mod.rs
+++ b/src-tauri/crates/key-vault/src/auto_detect/mod.rs
@@ -12,6 +12,7 @@ mod cursor;
 mod gemini;
 pub(crate) mod helpers;
 mod kiro;
+mod opencode;
 
 use serde::{Deserialize, Serialize};
 
@@ -83,6 +84,7 @@ pub async fn auto_detect_key(agent_type: &str) -> AutoDetectResult {
         ModelType::GeminiCli => gemini::detect_gemini_keys().await,
         ModelType::Copilot => copilot::detect_copilot_keys().await,
         ModelType::Kiro => kiro::detect_kiro_keys().await,
+        ModelType::OpenCode => opencode::detect_opencode_keys().await,
         // API key providers don't have auto-detect (keys are entered manually)
         _ => vec![],
     };

--- a/src-tauri/crates/key-vault/src/auto_detect/opencode.rs
+++ b/src-tauri/crates/key-vault/src/auto_detect/opencode.rs
@@ -1,0 +1,169 @@
+use std::env;
+use std::fs;
+
+use serde::Deserialize;
+
+use super::helpers::{create_detected_key, get_home_dir};
+use super::DetectedKey;
+use crate::commands::validate_opencode_key;
+
+const OPENCODE_ZEN_PROVIDER_ID: &str = "opencode";
+const OPENCODE_GO_PROVIDER_ID: &str = "opencode-go";
+const OPENCODE_ZEN_BASE_URL: &str = "https://opencode.ai/zen/v1";
+const OPENCODE_GO_BASE_URL: &str = "https://opencode.ai/zen/go/v1";
+
+#[derive(Debug, Deserialize)]
+struct OpenCodeAuthEntry {
+    #[serde(rename = "type")]
+    auth_type: String,
+    key: Option<String>,
+}
+
+pub(super) async fn detect_opencode_keys() -> Vec<DetectedKey> {
+    let mut keys = vec![];
+
+    if let Some(home) = get_home_dir() {
+        keys.extend(read_opencode_auth_config(&home.join(".local/share/opencode/auth.json")).await);
+    }
+
+    for (env_name, provider_id, base_url) in [
+        (
+            "OPENCODE_API_KEY",
+            OPENCODE_ZEN_PROVIDER_ID,
+            OPENCODE_ZEN_BASE_URL,
+        ),
+        (
+            "OPENCODE_GO_API_KEY",
+            OPENCODE_GO_PROVIDER_ID,
+            OPENCODE_GO_BASE_URL,
+        ),
+    ] {
+        if let Ok(api_key) = env::var(env_name) {
+            if api_key.is_empty()
+                || keys
+                    .iter()
+                    .any(|key| key.api_key.as_ref() == Some(&api_key))
+            {
+                continue;
+            }
+
+            let mut cred = create_detected_key(
+                &format!("env_{provider_id}"),
+                &format!("Environment Variable ({env_name})"),
+                "api_key",
+            );
+            cred.api_key = Some(api_key.clone());
+            cred.base_url = Some(base_url.to_string());
+
+            let validation = validate_opencode_key(&api_key, Some(base_url)).await;
+            cred.validated = Some(validation.valid);
+            cred.validation_message = Some(validation.message);
+            cred.available_models = Some(validation.models_available);
+
+            keys.push(cred);
+        }
+    }
+
+    keys
+}
+
+async fn read_opencode_auth_config(path: &std::path::Path) -> Vec<DetectedKey> {
+    let content = match fs::read_to_string(path) {
+        Ok(content) => content,
+        Err(_) => return vec![],
+    };
+
+    let entries: std::collections::HashMap<String, OpenCodeAuthEntry> =
+        match serde_json::from_str(&content) {
+            Ok(entries) => entries,
+            Err(_) => return vec![],
+        };
+
+    let mut keys = vec![];
+    for (provider_id, entry) in entries {
+        if entry.auth_type != "api" {
+            continue;
+        }
+        let Some(api_key) = entry.key.filter(|key| !key.is_empty()) else {
+            continue;
+        };
+        let Some(base_url) = opencode_base_url(&provider_id) else {
+            continue;
+        };
+
+        let mut cred = create_detected_key(
+            &format!("opencode_{provider_id}"),
+            &format!("OpenCode {}", opencode_provider_label(&provider_id)),
+            "api_key",
+        );
+        cred.api_key = Some(api_key.clone());
+        cred.base_url = Some(base_url.to_string());
+
+        let validation = validate_opencode_key(&api_key, Some(base_url)).await;
+        cred.validated = Some(validation.valid);
+        cred.validation_message = Some(validation.message);
+        cred.available_models = Some(validation.models_available);
+
+        keys.push(cred);
+    }
+
+    keys
+}
+
+fn opencode_base_url(provider_id: &str) -> Option<&'static str> {
+    match provider_id {
+        OPENCODE_ZEN_PROVIDER_ID => Some(OPENCODE_ZEN_BASE_URL),
+        OPENCODE_GO_PROVIDER_ID => Some(OPENCODE_GO_BASE_URL),
+        _ => None,
+    }
+}
+
+fn opencode_provider_label(provider_id: &str) -> &'static str {
+    match provider_id {
+        OPENCODE_GO_PROVIDER_ID => "Go",
+        _ => "Zen",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::install_crypto_provider_for_tests;
+
+    #[tokio::test]
+    async fn read_opencode_auth_config_detects_go_key() {
+        install_crypto_provider_for_tests();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth.json");
+        std::fs::write(
+            &path,
+            r#"{"opencode-go":{"type":"api","key":"opencode-test-key"}}"#,
+        )
+        .unwrap();
+
+        let keys = read_opencode_auth_config(&path).await;
+
+        assert_eq!(keys.len(), 1);
+        assert_eq!(keys[0].id, "opencode_opencode-go");
+        assert_eq!(keys[0].name, "OpenCode Go");
+        assert_eq!(keys[0].auth_method, "api_key");
+        assert_eq!(keys[0].api_key.as_deref(), Some("opencode-test-key"));
+        assert_eq!(keys[0].base_url.as_deref(), Some(OPENCODE_GO_BASE_URL));
+    }
+
+    #[tokio::test]
+    async fn read_opencode_auth_config_ignores_unknown_provider() {
+        install_crypto_provider_for_tests();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("auth.json");
+        std::fs::write(
+            &path,
+            r#"{"unknown":{"type":"api","key":"opencode-test-key"}}"#,
+        )
+        .unwrap();
+
+        let keys = read_opencode_auth_config(&path).await;
+
+        assert!(keys.is_empty());
+    }
+}

--- a/src-tauri/crates/key-vault/src/commands/validate.rs
+++ b/src-tauri/crates/key-vault/src/commands/validate.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::types::ValidationResult;
+
 use crate::providers::anthropic::AnthropicValidator;
 use crate::providers::azure_openai::AzureOpenAIValidator;
 use crate::providers::codex::CodexValidator;
@@ -8,7 +10,6 @@ use crate::providers::cursor::CursorValidator;
 use crate::providers::google::GoogleValidator;
 use crate::providers::kiro::KiroValidator;
 use crate::providers::openai::OpenAIValidator;
-use crate::types::ValidationResult;
 
 #[derive(Debug, Serialize)]
 pub struct TestModelResult {
@@ -31,6 +32,17 @@ struct ClaudeCodeOauthModelInfo {
 pub struct CodexOauthListModelsRequest {
     pub access_token: String,
     pub id_token: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenCodeModelsResponse {
+    #[serde(default)]
+    data: Vec<OpenCodeModelInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenCodeModelInfo {
+    id: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -65,6 +77,8 @@ use crate::provider_config::get_provider_config;
 const CLAUDE_CODE_OAUTH_MODELS_URL: &str = "https://api.anthropic.com/v1/models";
 const CLAUDE_CODE_OAUTH_BETA: &str = "oauth-2025-04-20";
 const CLAUDE_CODE_OAUTH_USER_AGENT: &str = "claude-cli/2.1.78 (orgii, cli)";
+const OPENCODE_ZEN_BASE_URL: &str = "https://opencode.ai/zen/v1";
+const OPENCODE_GO_BASE_URL: &str = "https://opencode.ai/zen/go/v1";
 
 const GEMINI_OAUTH_MODELS_URL: &str = "https://generativelanguage.googleapis.com/v1beta/models";
 
@@ -89,6 +103,49 @@ fn default_anthropic_base_url_for_provider(agent_type: &str) -> Option<String> {
         "zenmux_api" => Some("https://zenmux.ai/api/anthropic".to_string()),
         _ => None,
     }
+}
+
+/// Validate an OpenCode Zen/Go key by listing models without issuing a completion request.
+pub async fn validate_opencode_key(api_key: &str, base_url: Option<&str>) -> ValidationResult {
+    if api_key.is_empty() {
+        return ValidationResult::failure("No API key provided");
+    }
+
+    let result = fetch_opencode_models(api_key, base_url.unwrap_or(OPENCODE_GO_BASE_URL)).await;
+    match result {
+        Ok(models) => ValidationResult::success("API key valid").with_models(models),
+        Err(err) if err == "Invalid API key" || base_url.is_some() => {
+            ValidationResult::failure(&err)
+        }
+        Err(_) => match fetch_opencode_models(api_key, OPENCODE_ZEN_BASE_URL).await {
+            Ok(models) => ValidationResult::success("API key valid").with_models(models),
+            Err(err) => ValidationResult::failure(&err),
+        },
+    }
+}
+
+async fn fetch_opencode_models(api_key: &str, base_url: &str) -> Result<Vec<String>, String> {
+    let endpoint = format!("{}/models", base_url.trim_end_matches('/'));
+    let response = reqwest::Client::new()
+        .get(endpoint)
+        .header("Authorization", format!("Bearer {api_key}"))
+        .timeout(std::time::Duration::from_secs(15))
+        .send()
+        .await
+        .map_err(|err| format!("Request failed: {err}"))?;
+
+    if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+        return Err("Invalid API key".to_string());
+    }
+    if !response.status().is_success() {
+        return Err(format!("HTTP {}", response.status().as_u16()));
+    }
+
+    let models: OpenCodeModelsResponse = response
+        .json()
+        .await
+        .map_err(|err| format!("Failed to parse response: {err}"))?;
+    Ok(models.data.into_iter().map(|model| model.id).collect())
 }
 
 /// Validate a key for a given agent type (shared by Tauri and headless tools).
@@ -150,6 +207,8 @@ pub async fn run_validate_key(
             Ok(validator.validate(&api_key).await)
         }
 
+        "opencode" | "opencode_cli" => Ok(validate_opencode_key(&api_key, base_url.as_deref()).await),
+
         // Direct API key providers (matching _api suffix variants from frontend)
         "openai_api" => {
             let validator = OpenAIValidator::new();
@@ -210,7 +269,7 @@ pub async fn run_validate_key(
         }
 
         _ => Err(format!(
-            "Unknown agent type: {}. Supported: copilot, cursor_cli, openai, anthropic, google, gemini_cli, codex, claude_code, kiro, openai_api, anthropic_api, gemini_api, deepseek_api, groq_api, xai_api, zhipu_api, dashscope_api, moonshot_api, minimax_api, openrouter_api, vllm_api, azure_openai_api, azure_anthropic_api",
+            "Unknown agent type: {}. Supported: copilot, cursor_cli, openai, anthropic, google, gemini_cli, codex, claude_code, kiro, opencode, openai_api, anthropic_api, gemini_api, deepseek_api, groq_api, xai_api, zhipu_api, dashscope_api, moonshot_api, minimax_api, openrouter_api, zenmux_api, vllm_api, azure_openai_api, azure_anthropic_api",
             agent_type
         )),
     }
@@ -322,6 +381,15 @@ pub fn validate_token_format(agent_type: String, token: String) -> Result<(bool,
             let validator = KiroValidator::new();
             Ok(validator.validate_format(&token))
         }
+        "opencode" | "opencode_cli" => {
+            if token.is_empty() {
+                Ok((false, "API key is required".to_string()))
+            } else if token.len() < 8 {
+                Ok((false, "API key is too short".to_string()))
+            } else {
+                Ok((true, "Format OK".to_string()))
+            }
+        }
 
         // Direct API key providers (_api suffix variants)
         "openai_api" => {
@@ -392,6 +460,8 @@ pub async fn fetch_key_quota(
         | "codex"
         | "gemini_cli"
         | "kiro"
+        | "opencode"
+        | "opencode_cli"
         | "openai_api"
         | "anthropic_api"
         | "gemini_api"
@@ -927,6 +997,7 @@ mod tests {
             "google",
             "gemini_cli",
             "kiro",
+            "opencode",
         ] {
             let _ = ok_format(agent, "some-token-1234567890");
         }

--- a/src-tauri/crates/key-vault/src/key_store/agent_env_builder.rs
+++ b/src-tauri/crates/key-vault/src/key_store/agent_env_builder.rs
@@ -300,8 +300,12 @@ impl KeyService {
                 }
             }
             ModelType::OpenCode => {
-                // OpenCode manages provider credentials through its own config file.
-                // No env var injection needed — keys are configured via `opencode` CLI directly.
+                if let Some(ref key) = entry.api_key {
+                    env.insert("OPENCODE_API_KEY".to_string(), key.clone());
+                }
+                if let Some(ref url) = entry.base_url {
+                    env.insert("OPENCODE_BASE_URL".to_string(), url.clone());
+                }
             }
             // API key providers: store api_key under the provider's env var name
             ModelType::AnthropicApi

--- a/src-tauri/src/agent_sessions/cli/parsers/acp_common.rs
+++ b/src-tauri/src/agent_sessions/cli/parsers/acp_common.rs
@@ -87,6 +87,29 @@ pub trait AcpAgentAdapter: Send {
     fn handle_custom_notification(&mut self, _method: &str, _params: &Value) -> Vec<ActivityChunk> {
         vec![]
     }
+
+    fn map_tool_result_chunk(
+        &self,
+        _session_id: &str,
+        _cursor_name: &str,
+        _result_text: &str,
+        _is_error: bool,
+    ) -> Option<ActivityChunk> {
+        None
+    }
+
+    fn should_emit_tool_start(&self, _cursor_name: &str) -> bool {
+        true
+    }
+
+    fn should_emit_tool_result(
+        &self,
+        _cursor_name: &str,
+        _result_text: &str,
+        _is_error: bool,
+    ) -> bool {
+        true
+    }
 }
 
 // ============================================
@@ -670,23 +693,27 @@ impl<A: AcpAgentAdapter> AcpNotificationParser<A> {
             _ => raw_input.clone(),
         };
 
-        let mut chunk = ActivityChunk::new(&self.session_id, "tool_call", &cursor_name);
-        chunk.args = args;
-        chunk.result = serde_json::json!({ "call_id": tool_call_id, "status": "running" });
-
         let effective_path = if file_path.is_empty() && !title.is_empty() {
             title
         } else {
             file_path
         };
         self.pending_tools.insert(
-            tool_call_id,
+            tool_call_id.clone(),
             PendingToolCall {
-                cursor_name,
+                cursor_name: cursor_name.clone(),
                 file_path: effective_path,
                 raw_input,
             },
         );
+
+        if !self.adapter.should_emit_tool_start(&cursor_name) {
+            return vec![];
+        }
+
+        let mut chunk = ActivityChunk::new(&self.session_id, "tool_call", &cursor_name);
+        chunk.args = args;
+        chunk.result = serde_json::json!({ "call_id": tool_call_id, "status": "running" });
         vec![chunk]
     }
 
@@ -723,6 +750,24 @@ impl<A: AcpAgentAdapter> AcpNotificationParser<A> {
         }
         if let Some(obj) = result.as_object_mut() {
             obj.insert("call_id".to_string(), Value::String(tool_call_id));
+        }
+
+        if is_terminal {
+            if let Some(chunk) = self.adapter.map_tool_result_chunk(
+                &self.session_id,
+                &cursor_name,
+                &result_text,
+                is_error,
+            ) {
+                return vec![chunk];
+            }
+        }
+
+        if !self
+            .adapter
+            .should_emit_tool_result(&cursor_name, &result_text, is_error)
+        {
+            return vec![];
         }
 
         let mut chunk = ActivityChunk::new(&self.session_id, "tool_call", &cursor_name);

--- a/src-tauri/src/agent_sessions/cli/parsers/opencode.rs
+++ b/src-tauri/src/agent_sessions/cli/parsers/opencode.rs
@@ -10,6 +10,18 @@ use tokio::sync::mpsc;
 use super::acp_common::{self, AcpAgentAdapter, AcpSessionResult};
 use core_types::activity::ActivityChunk;
 
+fn extract_task_result(content: &str) -> Option<String> {
+    let start = content.find("<task_result>")? + "<task_result>".len();
+    let tail = &content[start..];
+    let end = tail.find("</task_result>").unwrap_or(tail.len());
+    let result = tail[..end].trim();
+    if result.is_empty() {
+        None
+    } else {
+        Some(result.to_string())
+    }
+}
+
 /// OpenCode adapter — maps OpenCode tool names to Cursor-normalized names.
 pub(crate) struct OpenCodeAdapter;
 
@@ -43,6 +55,39 @@ impl AcpAgentAdapter for OpenCodeAdapter {
             _ => kind,
         }
         .to_string()
+    }
+    fn map_tool_result_chunk(
+        &self,
+        session_id: &str,
+        cursor_name: &str,
+        result_text: &str,
+        is_error: bool,
+    ) -> Option<ActivityChunk> {
+        if is_error || cursor_name != "think" {
+            return None;
+        }
+
+        let task_result = extract_task_result(result_text)?;
+        let mut chunk = ActivityChunk::new(session_id, "assistant", "message");
+        chunk.result = serde_json::json!({
+            "content": task_result,
+            "observation": task_result,
+            "role": "assistant",
+        });
+        Some(chunk)
+    }
+
+    fn should_emit_tool_start(&self, cursor_name: &str) -> bool {
+        cursor_name != "think"
+    }
+
+    fn should_emit_tool_result(
+        &self,
+        cursor_name: &str,
+        result_text: &str,
+        is_error: bool,
+    ) -> bool {
+        is_error || cursor_name != "think" || !result_text.trim().is_empty()
     }
 }
 

--- a/src-tauri/src/agent_sessions/cli/parsers/tests/opencode_tests.rs
+++ b/src-tauri/src/agent_sessions/cli/parsers/tests/opencode_tests.rs
@@ -477,6 +477,123 @@ fn parse_update_unhandled_session_update_produces_no_chunk() {
 }
 
 #[test]
+fn parse_update_completed_think_task_result_maps_to_assistant_message() {
+    let mut parser = make_parser();
+
+    let start = session_update(
+        "tool_call",
+        json!({
+            "toolCallId": "tc-think-task",
+            "kind": "think",
+            "title": "",
+            "rawInput": {}
+        }),
+    );
+    let start_chunks = parser.parse_update(&start);
+    assert!(start_chunks.is_empty());
+
+    let update = session_update(
+        "tool_call_update",
+        json!({
+            "toolCallId": "tc-think-task",
+            "status": "completed",
+            "content": "<task id=\"ses_123\" state=\"completed\">\n<task_result>\nFinal answer from subagent.\n</task_result>\n</task>"
+        }),
+    );
+    let chunks = parser.parse_update(&update);
+
+    assert_eq!(chunks.len(), 1);
+    assert_eq!(chunks[0].action_type, "assistant");
+    assert_eq!(chunks[0].function, "message");
+    assert_eq!(chunks[0].result["content"], "Final answer from subagent.");
+    assert_eq!(chunks[0].result["role"], "assistant");
+}
+
+#[test]
+fn parse_update_failed_think_task_result_stays_tool_call() {
+    let mut parser = make_parser();
+
+    parser.parse_update(&session_update(
+        "tool_call",
+        json!({
+            "toolCallId": "tc-think-failed",
+            "kind": "think",
+            "title": "",
+            "rawInput": {}
+        }),
+    ));
+
+    let chunks = parser.parse_update(&session_update(
+        "tool_call_update",
+        json!({
+            "toolCallId": "tc-think-failed",
+            "status": "failed",
+            "content": "<task_result>not a successful answer</task_result>"
+        }),
+    ));
+
+    assert_eq!(chunks.len(), 1);
+    assert_eq!(chunks[0].action_type, "tool_call");
+    assert_eq!(chunks[0].function, "think");
+    assert!(chunks[0].result.get("error").is_some());
+}
+
+#[test]
+fn parse_update_plain_think_result_stays_tool_call() {
+    let mut parser = make_parser();
+
+    parser.parse_update(&session_update(
+        "tool_call",
+        json!({
+            "toolCallId": "tc-think-plain",
+            "kind": "think",
+            "title": "",
+            "rawInput": {}
+        }),
+    ));
+
+    let chunks = parser.parse_update(&session_update(
+        "tool_call_update",
+        json!({
+            "toolCallId": "tc-think-plain",
+            "status": "completed",
+            "content": "ordinary reasoning note"
+        }),
+    ));
+
+    assert_eq!(chunks.len(), 1);
+    assert_eq!(chunks[0].action_type, "tool_call");
+    assert_eq!(chunks[0].function, "think");
+    assert_eq!(chunks[0].result["content"], "ordinary reasoning note");
+}
+
+#[test]
+fn parse_update_successful_empty_think_result_is_suppressed() {
+    let mut parser = make_parser();
+
+    parser.parse_update(&session_update(
+        "tool_call",
+        json!({
+            "toolCallId": "tc-think-empty",
+            "kind": "think",
+            "title": "",
+            "rawInput": {}
+        }),
+    ));
+
+    let chunks = parser.parse_update(&session_update(
+        "tool_call_update",
+        json!({
+            "toolCallId": "tc-think-empty",
+            "status": "completed",
+            "content": ""
+        }),
+    ));
+
+    assert!(chunks.is_empty());
+}
+
+#[test]
 fn parse_update_agent_thought_chunk_plain_text() {
     let mut parser = make_parser();
     let update = session_update(

--- a/src/engines/SessionCore/hooks/session/useSessionCreator/useAdvancedConfig.ts
+++ b/src/engines/SessionCore/hooks/session/useSessionCreator/useAdvancedConfig.ts
@@ -104,7 +104,7 @@ export function useAdvancedConfig(): UseAdvancedConfigResult {
     const selectedSourceModelType = lastModelSelection.selectedSourceModelType;
     const nativeHarnessType =
       dispatchCategory === "rust_agent" &&
-      (selectedAccount?.canUseNativeHarness ||
+      (selectedAccount?.nativeHarnessType ||
         selectedSourceModelType === CLI_AGENT.CURSOR)
         ? (selectedAccount?.nativeHarnessType ?? NATIVE_HARNESS_TYPE.CURSOR)
         : undefined;

--- a/src/engines/SessionCore/sync/__tests__/sessionSyncStateHelpers.test.ts
+++ b/src/engines/SessionCore/sync/__tests__/sessionSyncStateHelpers.test.ts
@@ -97,6 +97,25 @@ describe("session sync state callbacks", () => {
     expect(eventStoreProxy.unpinSession).toHaveBeenCalledWith("session-1");
   });
 
+  it("does not clear live assistant content on thinking deltas", () => {
+    const actions = createActions();
+    actions.streamingMap.set("session-1", "partial answer");
+    const callbacks = createSessionEventHandlerCallbacks(
+      "session-1",
+      actions,
+      vi.fn()
+    );
+
+    callbacks.onStreamingDelta?.({
+      isStreaming: true,
+      isThinking: true,
+      content: "reasoning token",
+    });
+
+    expect(actions.streamingMap.get("session-1")).toBe("partial answer");
+    expect(actions.setStreamingDeltaContent).not.toHaveBeenCalled();
+  });
+
   it("marks terminal status changes as FSM turn terminals", () => {
     const actions = createActions();
     const callbacks = createSessionEventHandlerCallbacks(

--- a/src/engines/SessionCore/sync/sessionSyncStateHelpers.ts
+++ b/src/engines/SessionCore/sync/sessionSyncStateHelpers.ts
@@ -145,9 +145,11 @@ export function updateStreamingDeltaContent(
   info: StreamingDeltaInfo,
   setStreamingDeltaContent: SessionEventHandlerStateActions["setStreamingDeltaContent"]
 ): void {
+  if (info.isThinking) return;
+
   setStreamingDeltaContent((prev) => {
     const next = new Map(prev);
-    if (info.isStreaming && !info.isThinking) {
+    if (info.isStreaming) {
       next.set(sessionId, info.content);
     } else {
       next.delete(sessionId);

--- a/src/hooks/keyVault/useLocalKeys.ts
+++ b/src/hooks/keyVault/useLocalKeys.ts
@@ -247,12 +247,12 @@ export function useLocalKeys(
           return next;
         });
         return saved;
-      } catch {
+      } catch (err) {
         if (appliedOptimisticUpdate) {
           publishAllKeys(previousKeys);
           replaceModelAliasesFromKeys(previousKeys);
         }
-        return null;
+        throw err;
       }
     },
     []

--- a/src/hooks/keyVault/useLocalKeys.ts
+++ b/src/hooks/keyVault/useLocalKeys.ts
@@ -247,12 +247,12 @@ export function useLocalKeys(
           return next;
         });
         return saved;
-      } catch (err) {
+      } catch {
         if (appliedOptimisticUpdate) {
           publishAllKeys(previousKeys);
           replaceModelAliasesFromKeys(previousKeys);
         }
-        throw err;
+        return null;
       }
     },
     []

--- a/src/scaffold/WizardSystem/variants/KeyVault/components/ApiSetup.tsx
+++ b/src/scaffold/WizardSystem/variants/KeyVault/components/ApiSetup.tsx
@@ -145,6 +145,8 @@ const ApiSetup: React.FC<ApiSetupProps> = ({
   const hasPinnedSection = showCopilotPinned || showCursorPinned;
   const hideFooter = (isClaudeCode || isCodex) && hook.browserOpen;
 
+  const effectiveKeyValidated = hook.keyValidated || data.validated;
+
   const showValidationResults =
     !(hook.isCursor && hook.useGuidedSetup) &&
     !hook.isCopilot &&
@@ -155,7 +157,7 @@ const ApiSetup: React.FC<ApiSetupProps> = ({
   const showModelSections =
     !hook.browserOpen &&
     !!data.agent_type &&
-    (hook.keyValidated ||
+    (effectiveKeyValidated ||
       (hook.isCursor && data.validated) ||
       (hook.isOAuthAgent && data.validated) ||
       isLocalModelProvider);
@@ -361,7 +363,7 @@ const ApiSetup: React.FC<ApiSetupProps> = ({
               agentCategory={hook.agentCategory}
               isComplex={isComplex}
               setupMethod={data.setup_method}
-              keyValidated={hook.keyValidated}
+              keyValidated={effectiveKeyValidated}
               validatingKey={hook.validatingKey}
               validationError={hook.validationError}
               fetchedModels={hook.fetchedModels}
@@ -398,7 +400,7 @@ const ApiSetup: React.FC<ApiSetupProps> = ({
 
           {!!data.agent_type && showValidationResults && (
             <ValidationResults
-              keyValidated={hook.keyValidated}
+              keyValidated={effectiveKeyValidated}
               validationError={hook.validationError}
               agentCategory={hook.agentCategory}
               isApiProvider={hook.isApiProvider}
@@ -455,7 +457,7 @@ const ApiSetup: React.FC<ApiSetupProps> = ({
         <CopilotPinnedSection
           data={data}
           onChange={onChange}
-          keyValidated={hook.keyValidated}
+          keyValidated={effectiveKeyValidated}
           validatingKey={hook.validatingKey}
           validationError={hook.validationError}
           validateKey={hook.validateKey}

--- a/src/scaffold/WizardSystem/variants/KeyVault/hooks/useWizard.ts
+++ b/src/scaffold/WizardSystem/variants/KeyVault/hooks/useWizard.ts
@@ -259,11 +259,14 @@ export function useWizard(options: UseWizardOptions): UseWizardReturn {
           : undefined,
       default_variants:
         data.default_variants.length > 0 ? data.default_variants : undefined,
-      quota_info: data.quota_info as SaveKeyRequest["quota_info"],
       auth_method: isOAuth ? "oauth" : data.auth_method || "api_key",
       has_local_key: true,
       is_listed: false,
     };
+
+    if (data.quota_info) {
+      request.quota_info = data.quota_info as SaveKeyRequest["quota_info"];
+    }
 
     onSubmit(request);
   }, [data, existingAccountNames, getDefaultNameBase, onSubmit]);

--- a/src/util/session/__tests__/sessionSidebarRow.test.ts
+++ b/src/util/session/__tests__/sessionSidebarRow.test.ts
@@ -1,0 +1,46 @@
+import { FlaskConical } from "lucide-react";
+import { describe, expect, it } from "vitest";
+
+import { resolveAgentIcon } from "@src/config/agentIcons";
+import { resolveSessionRowIcon } from "@src/util/session/sessionSidebarRow";
+
+describe("resolveSessionRowIcon", () => {
+  it("uses the OpenCode CLI brand icon", () => {
+    expect(
+      resolveSessionRowIcon({
+        session_id: "cliagent-opencode",
+        cliAgentType: "opencode",
+      })
+    ).toBe(resolveAgentIcon("opencode"));
+  });
+
+  it("uses cliAgentType before stale agentIconId for CLI sessions", () => {
+    expect(
+      resolveSessionRowIcon({
+        session_id: "cliagent-opencode",
+        cliAgentType: "opencode",
+        agentIconId: "codex",
+      })
+    ).toBe(resolveAgentIcon("opencode"));
+  });
+
+  it("uses agentIconId for non-CLI agent sessions", () => {
+    expect(
+      resolveSessionRowIcon({
+        session_id: "sdeagent-custom",
+        agentIconId: "network",
+      })
+    ).toBe(resolveAgentIcon("network"));
+  });
+
+  it("keeps benchmark coordinator sessions on the benchmark icon", () => {
+    expect(
+      resolveSessionRowIcon({
+        session_id: "cliagent-benchmark",
+        user_input: "Benchmark run coordinator for OpenCode",
+        cliAgentType: "opencode",
+        agentIconId: "codex",
+      })
+    ).toBe(FlaskConical);
+  });
+});

--- a/src/util/session/sessionSidebarRow.ts
+++ b/src/util/session/sessionSidebarRow.ts
@@ -31,15 +31,13 @@ type SessionRowIconInput =
  *
  * Resolution priority (most specific → most generic):
  *
- *  1. **`agentIconId`** — explicit per-session brand assignment. Wins
- *     unconditionally because the launcher knew the answer at create
- *     time. Used by Rust agent definitions (built-in + custom), where the
- *     definition carries an `iconId`.
- *  2. **`cliAgentType`** → brand icon via `getIconProvider`. Covers all
+ *  1. **`cliAgentType`** → brand icon via `getIconProvider`. Covers all
  *     CLI sessions (Cursor CLI, Claude Code, Codex, Gemini, Copilot,
- *     Kiro, Kimi, OpenCode, Qwen) without depending on the launcher to
- *     have stamped `agentIconId`. Also catches legacy sessions written
- *     before brand stamping existed at the create-time path.
+ *     Kiro, Kimi, OpenCode, Qwen) and prevents stale `agentIconId` values
+ *     from overriding the CLI provider identity.
+ *  2. **`agentIconId`** — explicit per-session brand assignment. Used by
+ *     Rust agent definitions (built-in + custom), where the definition
+ *     carries an `iconId`.
  *  3. **Prefix-based** fallback (`resolveSessionIconId`) — last resort
  *     for sessions where neither of the above applies. Maps prefix →
  *     generic Lucide slug (e.g. `cursoride-` → `cursor`, `osagent-` →
@@ -56,11 +54,11 @@ export function resolveSessionRowIcon(input: SessionRowIconInput): LucideIcon {
     if (input.user_input?.startsWith("Benchmark run coordinator")) {
       return FlaskConical;
     }
-    if (input.agentIconId) {
-      return resolveAgentIcon(input.agentIconId);
-    }
     if (input.cliAgentType) {
       return resolveAgentIcon(getIconProvider(input.cliAgentType));
+    }
+    if (input.agentIconId) {
+      return resolveAgentIcon(input.agentIconId);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #94

Adds and completes OpenCode Go provider support across provider registration, Key Vault setup, streaming parsing, OpenCode ACP rendering, and session sidebar identity. Support using both Org2 harness and OpenCode harness.

## Root Cause

OpenCode Go was not fully integrated as an ORG2 provider. The app could miss OpenCode-specific config during setup, validation did not fully understand the provider shape, streamed tool-call arguments could arrive in malformed path structures, OpenCode ACP `think` / `<task_result>` updates could render as the wrong event type, and sidebar rows could show stale provider icons.

## Fix

- Added OpenCode Go provider registration and factory support.
- Added OpenCode Key Vault auto-detection and validation support.
- Preserved CLI provider identity through session sync.
- Normalized malformed streamed path arguments from OpenCode-compatible backends.
- Mapped successful OpenCode `<task_result>` output into assistant messages.
- Suppressed empty successful `think` results while preserving failed/plain think tool calls.
- Prioritized `cliAgentType` over stale `agentIconId` for session row icons.
- Added regression tests for session metadata, OpenCode parser behavior, and sidebar icon resolution.

## Verification

- `pnpm vitest run src/engines/SessionCore/sync/__tests__/sessionSyncStateHelpers.test.ts src/util/session/__tests__/sessionSidebarRow.test.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml agent_sessions::cli::parsers::opencode::tests --lib`
- `pnpm eslint src/engines/SessionCore/hooks/session/useSessionCreator/useAdvancedConfig.ts src/engines/SessionCore/sync/sessionSyncStateHelpers.ts src/engines/SessionCore/sync/__tests__/sessionSyncStateHelpers.test.ts src/scaffold/WizardSystem/variants/KeyVault/components/ApiSetup.tsx src/scaffold/WizardSystem/variants/KeyVault/hooks/useWizard.ts src/util/session/sessionSidebarRow.ts src/util/session/__tests__/sessionSidebarRow.test.ts`
- `cargo clippy --manifest-path src-tauri/Cargo.toml --lib`

## Screenshots

<img width="1846" height="1356" alt="image" src="https://github.com/user-attachments/assets/79420846-f823-4a94-b831-be08055e064f" />
