### PR TITLE
fix: show planning footer during idle running tools

### DIFF
--- a/src/engines/SessionCore/core/runningEventGate.ts
+++ b/src/engines/SessionCore/core/runningEventGate.ts
@@ -66,8 +66,9 @@ export function isLiveRuntimeResourceEvent(event: SessionEvent): boolean {
  * deliberately excluded: a pinned background process is not a reason to
  * hide "the agent is thinking".
  *
- * Within the current turn the gate keeps its meaning: a genuinely running
- * row paints its own shimmer, so the footer stays hidden.
+ * Within the current turn this only answers whether a live row exists; the
+ * planning footer may still show after the row has been idle long enough, but
+ * the watchdog must not force-complete the session while this returns true.
  *
  * `await_output` is exempt: it polls/blocks waiting for OTHER jobs (shell
  * processes, subagents) and renders as a subtle TitleOnlyBlock whose

--- a/src/engines/SessionCore/hooks/replay/usePlanningIndicator.test.ts
+++ b/src/engines/SessionCore/hooks/replay/usePlanningIndicator.test.ts
@@ -48,13 +48,13 @@ describe("shouldShowPlanningIndicator", () => {
     ).toBe(true);
   });
 
-  it("hides while a visible running row is painted", () => {
+  it("shows while a running tool row is idle long enough", () => {
     expect(
       shouldShowPlanningIndicator({
         ...baseInput,
         anyRunning: true,
       })
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it("shows during the parent gap when a background subagent is still running", () => {
@@ -69,7 +69,7 @@ describe("shouldShowPlanningIndicator", () => {
     ).toBe(true);
   });
 
-  it("does not show on a live subagent if a visible running row is already painted", () => {
+  it("shows on a live subagent after a running row becomes idle", () => {
     expect(
       shouldShowPlanningIndicator({
         ...baseInput,
@@ -77,6 +77,6 @@ describe("shouldShowPlanningIndicator", () => {
         hasLiveSubagent: true,
         anyRunning: true,
       })
-    ).toBe(false);
+    ).toBe(true);
   });
 });

--- a/src/engines/SessionCore/hooks/replay/usePlanningIndicator.ts
+++ b/src/engines/SessionCore/hooks/replay/usePlanningIndicator.ts
@@ -4,7 +4,6 @@
  * Shows a single "Planning next step..." line in the chat panel when:
  * 1. Any session type is actively working (code / cloud / OS agent)
  * 2. No store mutations for IDLE_THRESHOLD_MS (1 second)
- * 3. No event currently has displayStatus === "running"
  *
  * The indicator stays visible until new events arrive or the session ends.
  *
@@ -29,6 +28,8 @@
  * Rust pushes StreamingSnapshot which has no `events` field, causing eventsAtom
  * to return []. Both snapshot types now carry `hasRunningEvent` (computed
  * against ALL events, including non-chat-visible ones like thinking deltas).
+ * Running events are used only to keep the watchdog from force-completing a
+ * legitimate long tool call; they do not suppress the idle footer.
  *
  * Uses snapshot `version` as the activity token — it bumps on every store
  * mutation (upsert, append, merge), including streaming deltas for thinking
@@ -110,7 +111,6 @@ export function shouldShowPlanningIndicator({
   isSessionActive,
   isPendingCancel,
   hasAwaitingUserInteraction,
-  anyRunning,
   coldStartVisible,
   idleAfterVersion,
   version,
@@ -127,7 +127,6 @@ export function shouldShowPlanningIndicator({
     isSessionActive &&
     !isPendingCancel &&
     !hasAwaitingUserInteraction &&
-    !anyRunning &&
     (coldStartVisible || idleAfterVersion === version)
   );
 }
@@ -289,7 +288,7 @@ export function usePlanningIndicator(
     };
   }, [isSessionActive, version, activationVersion]);
 
-  // Visible when: session active, no running event, not pending cancel, AND either
+  // Visible when: session active, not pending cancel, AND either
   //   (a) cold-start — version hasn't bumped since activation yet, OR
   //   (b) warm — IDLE_THRESHOLD_MS elapsed since last mutation.
   //
@@ -358,7 +357,8 @@ export function usePlanningIndicator(
   // `agent:subagent_job_changed` terminal event is the real completion
   // signal, not a 60s wall clock.
   useEffect(() => {
-    if (scoped || !visible || !sessionId || hasLiveSubagent) return;
+    if (scoped || !visible || !sessionId || hasLiveSubagent || anyRunning)
+      return;
     const timerId = window.setTimeout(() => {
       log.warn(
         `[usePlanningIndicator] watchdog: planning indicator stuck for ${PLANNING_WATCHDOG_MS}ms — ` +
@@ -374,7 +374,14 @@ export function usePlanningIndicator(
     return () => {
       window.clearTimeout(timerId);
     };
-  }, [scoped, visible, sessionId, hasLiveSubagent, setSessionRuntimeStatus]);
+  }, [
+    scoped,
+    visible,
+    sessionId,
+    hasLiveSubagent,
+    anyRunning,
+    setSessionRuntimeStatus,
+  ]);
 
   // Re-roll the variant index on every hidden → visible transition.
   // Using a large random integer and letting the consumer mod by the


### PR DESCRIPTION
Pre-commit hook ran. Total eslint: 0, total circular: 0
This PR is to fix 
https://github.com/yorgai/ORG2/issues/180
shows while a running tool row is idle long enough

## Summary
- Allow the planning footer to appear after an idle gap even while the latest turn has a running tool row
- Keep running tool rows as watchdog protection so long-running tools are not force-completed
- Update planning indicator expectations for running-tool and live-subagent gaps

Mention #180

## Verification
- pnpm eslint src/engines/SessionCore/hooks/replay/usePlanningIndicator.ts src/engines/SessionCore/hooks/replay/usePlanningIndicator.test.ts src/engines/SessionCore/core/runningEventGate.ts
- pnpm vitest run src/engines/SessionCore/hooks/replay/usePlanningIndicator.test.ts src/engines/SessionCore/rendering/props/__tests__/propsNormalizer.test.ts
- Live visual checks: silent running shell, intermittent output, stdout burst, background await_output, failing tool, large edit_file input