### PR TITLE
fix(markdown): preserve copyable nested markdown fences

### DIFF
--- a/src/components/MarkDown/MarkDownImpl.tsx
+++ b/src/components/MarkDown/MarkDownImpl.tsx
@@ -36,6 +36,7 @@ import MermaidBlock from "./MermaidBlock";
 import "./index.scss";
 import {
   detectCodeType,
+  normalizeCopyableMarkdownDocumentFence,
   openFileInEditor,
   openUrlInBrowserApp,
   preprocessTextContent,
@@ -169,23 +170,26 @@ function splitIntoStableMarkdownBlocks(content: string): string[] {
 
   const blocks: string[] = [];
   let blockStart = 0;
-  let inFence = false;
+  let fenceLength = 0;
   let index = 0;
 
   while (index < content.length) {
-    if (
-      content[index] === "`" &&
-      index + 2 < content.length &&
-      content[index + 1] === "`" &&
-      content[index + 2] === "`"
-    ) {
-      inFence = !inFence;
-      index += 3;
-      continue;
+    if (content[index] === "`") {
+      const fenceMatch = /^`{3,}/.exec(content.slice(index));
+      if (fenceMatch) {
+        const currentFenceLength = fenceMatch[0].length;
+        if (fenceLength === 0) {
+          fenceLength = currentFenceLength;
+        } else if (currentFenceLength >= fenceLength) {
+          fenceLength = 0;
+        }
+        index += currentFenceLength;
+        continue;
+      }
     }
 
     if (
-      !inFence &&
+      fenceLength === 0 &&
       content[index] === "\n" &&
       index + 1 < content.length &&
       content[index + 1] === "\n"
@@ -651,10 +655,12 @@ const MarkdownComponent: React.FC<MarkdownProps> = ({
   // Preprocess text content to auto-detect and format code.
   // Skip the expensive regex pass when the caller guarantees the content is
   // already well-formed markdown (e.g., post-stream agent messages).
-  const processedContent = useMemo(
-    () => (skipPreprocess ? textContent : preprocessTextContent(textContent)),
-    [textContent, skipPreprocess]
-  );
+  const processedContent = useMemo(() => {
+    const content = skipPreprocess
+      ? textContent
+      : preprocessTextContent(textContent);
+    return normalizeCopyableMarkdownDocumentFence(content);
+  }, [textContent, skipPreprocess]);
 
   const streamingBlocks = useMemo(
     () => (streaming ? splitIntoStableMarkdownBlocks(processedContent) : null),

--- a/src/components/MarkDown/markdownUtils.test.ts
+++ b/src/components/MarkDown/markdownUtils.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeCopyableMarkdownDocumentFence } from "./markdownUtils";
+
+describe("normalizeCopyableMarkdownDocumentFence", () => {
+  it("uses a longer outer fence for markdown documents with nested fences", () => {
+    const input = [
+      "```md",
+      "## Summary",
+      "",
+      "## Verification",
+      "",
+      "```bash",
+      "pnpm run lint",
+      "```",
+      "```",
+    ].join("\n");
+
+    expect(normalizeCopyableMarkdownDocumentFence(input)).toBe(
+      [
+        "````md",
+        "## Summary",
+        "",
+        "## Verification",
+        "",
+        "```bash",
+        "pnpm run lint",
+        "```",
+        "````",
+      ].join("\n")
+    );
+  });
+
+  it("uses a fence longer than the longest nested fence", () => {
+    const input = [
+      "````markdown",
+      "Example:",
+      "````text",
+      "nested",
+      "````",
+      "````",
+    ].join("\n");
+
+    expect(normalizeCopyableMarkdownDocumentFence(input)).toBe(
+      ["`````markdown", "Example:", "````text", "nested", "````", "`````"].join(
+        "\n"
+      )
+    );
+  });
+
+  it("leaves non-document markdown unchanged", () => {
+    const input = [
+      "Before",
+      "",
+      "```md",
+      "## Summary",
+      "```",
+      "",
+      "After",
+    ].join("\n");
+
+    expect(normalizeCopyableMarkdownDocumentFence(input)).toBe(input);
+  });
+
+  it("leaves markdown documents without nested fences unchanged", () => {
+    const input = ["```md", "## Summary", "Plain text", "```"].join("\n");
+
+    expect(normalizeCopyableMarkdownDocumentFence(input)).toBe(input);
+  });
+});

--- a/src/components/MarkDown/markdownUtils.tsx
+++ b/src/components/MarkDown/markdownUtils.tsx
@@ -62,6 +62,9 @@ const CODE_PATTERNS = [
 ];
 
 const ASCII_DIAGRAM_HINT_PATTERN = /[│├─└┌┐┘┤┬┴┼┃╔╗╚╝╠╣╦╩╬━|+=\\]/;
+const COPYABLE_MARKDOWN_DOCUMENT_PATTERN =
+  /^(\s*)(`{3,})(md|markdown)([^\n]*)\n([\s\S]*?)\n(`{3,})(\s*)$/i;
+const FENCE_RUN_PATTERN = /`{3,}/g;
 const MAX_INLINE_CODE_CACHE_SIZE = 300;
 const inlineCodeTypeCache = new Map<string, InlineCodeType>();
 
@@ -155,6 +158,33 @@ function mayContainAsciiDiagram(text: string): boolean {
   if (secondNewline < 0) return false;
 
   return ASCII_DIAGRAM_HINT_PATTERN.test(text);
+}
+
+export function normalizeCopyableMarkdownDocumentFence(text: string): string {
+  const match = text.match(COPYABLE_MARKDOWN_DOCUMENT_PATTERN);
+  if (!match) return text;
+
+  const [
+    ,
+    leadingWhitespace,
+    openingFence,
+    language,
+    openingSuffix,
+    body,
+    closingFence,
+    trailingWhitespace,
+  ] = match;
+
+  if (openingFence.length !== closingFence.length) return text;
+  if (!body.includes(openingFence)) return text;
+
+  const maxFenceLength = Math.max(
+    openingFence.length,
+    ...Array.from(body.matchAll(FENCE_RUN_PATTERN), ([fence]) => fence.length)
+  );
+  const wrapperFence = "`".repeat(maxFenceLength + 1);
+
+  return `${leadingWhitespace}${wrapperFence}${language}${openingSuffix}\n${body}\n${wrapperFence}${trailingWhitespace}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #193

Preserve copyable Markdown document blocks when they contain nested fenced code blocks.

## Root Cause

Markdown fenced code blocks are closed by a fence with the same or greater number of backticks. The chat renderer displayed copyable PR descriptions as outer `md` code blocks using three backticks, but those PR descriptions can themselves contain inner fenced blocks such as `bash`.

When an inner three-backtick block appeared inside the outer three-backtick `md` block, the Markdown parser treated the inner fence as the end of the outer block. The rest of the PR description was then rendered as normal Markdown instead of remaining inside the copyable code block.

The streaming block splitter had the same assumption: it toggled fence state whenever it saw three backticks, so it did not understand longer outer fences.

## Fix

Normalize full-message `md` / `markdown` document fences before rendering. When the document body contains nested fences, the renderer now upgrades the outer fence to one backtick longer than the longest nested fence. This keeps the whole Markdown document inside a single valid fenced block without changing the copied document body.

The streaming Markdown splitter was also updated to track the active fence length, so shorter nested fences no longer prematurely close a longer outer fence during streaming rendering.

Focused unit tests cover:

- three-backtick Markdown documents containing nested code fences
- documents whose nested fence is already four backticks
- non-document Markdown that should remain unchanged
- Markdown documents without nested fences that should remain unchanged

## Verification

- `pnpm vitest run src/components/MarkDown/markdownUtils.test.ts`
- `pnpm run lint`
- `pnpm run check:circular`
- `git diff --check`
- Manual verification passed: a copyable PR description containing an inner `bash` fenced block remains one complete copyable Markdown block, and the copy button copies the full raw Markdown content.

## Screenshot
<img width="815" height="1008" alt="e528a5955b83314d258c0133b2887ed7" src="https://github.com/user-attachments/assets/bec5a5be-bca8-4ca5-9584-9003bc51f7f3" />
