### PR TITLE
Fix Markdown emphasis markers in URL reference cards

### DIFF
--- a/src/engines/ChatPanel/blocks/MessageReferenceCards.helpers.ts
+++ b/src/engines/ChatPanel/blocks/MessageReferenceCards.helpers.ts
@@ -5,7 +5,6 @@ import { createSessionIdTextPattern } from "@src/util/session/sessionDispatch";
 import { normalizeHttpUrlCandidate } from "@src/util/url/validation";
 
 const WEB_URL_PATTERN = /https?:\/\/[^\s<>"'`\])}]+/gi;
-const TRAILING_REFERENCE_PUNCTUATION_PATTERN = /[.,;:!?]+$/;
 const MAX_REFERENCE_CARDS = 4;
 
 export type MessageReferenceKind =
@@ -43,9 +42,7 @@ function stripFencedCodeBlocks(content: string): string {
 }
 
 function normalizeUrlCandidate(candidate: string): string | null {
-  return normalizeHttpUrlCandidate(
-    candidate.replace(TRAILING_REFERENCE_PUNCTUATION_PATTERN, "")
-  );
+  return normalizeHttpUrlCandidate(candidate, { stripTextBoundaries: true });
 }
 
 function isUrlCitedInParentheses(

--- a/src/engines/ChatPanel/blocks/ToolCallBlock/helpers/__tests__/resultParsers.test.ts
+++ b/src/engines/ChatPanel/blocks/ToolCallBlock/helpers/__tests__/resultParsers.test.ts
@@ -6,6 +6,7 @@
  */
 import { describe, expect, it } from "vitest";
 
+import { parseWebsiteCardResult } from "../cardParsers";
 import {
   buildWorkspaceInfoRows,
   extractResultText,
@@ -14,6 +15,20 @@ import {
   parseManageWorkspaceResult,
   parseSearchFilesResult,
 } from "../resultParsers";
+
+// ── parseWebsiteCardResult ───────────────────────────────────────────────────
+
+describe("parseWebsiteCardResult", () => {
+  it("rejects malformed URL card data", () => {
+    const card = parseWebsiteCardResult(
+      "browser",
+      { url: "https://exa*mple.com/docs" },
+      {}
+    );
+
+    expect(card).toBeNull();
+  });
+});
 
 // ── extractResultText ─────────────────────────────────────────────────────────
 

--- a/src/engines/ChatPanel/blocks/__tests__/MessageReferenceCards.test.ts
+++ b/src/engines/ChatPanel/blocks/__tests__/MessageReferenceCards.test.ts
@@ -135,6 +135,22 @@ staged file lint stats
     });
   });
 
+  it("strips trailing markdown emphasis markers from URL cards", () => {
+    const references = extractMessageReferences(
+      [
+        "Docs: **https://example.com/docs.**",
+        "Mirror: *https://mirror.example.com/path*",
+        "Old: ~~https://old.example.com/docs~~",
+      ].join("\n")
+    );
+
+    expect(references.map((item) => item.value)).toEqual([
+      "https://example.com/docs",
+      "https://mirror.example.com/path",
+      "https://old.example.com/docs",
+    ]);
+  });
+
   it("does not extract template placeholder hosts as URL cards", () => {
     const references = extractMessageReferences(
       "The server logs http://localhost:1998 and http://${host}/"

--- a/src/util/url/browserUrl.test.ts
+++ b/src/util/url/browserUrl.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeBrowserInput } from "./browserUrl";
+
+describe("normalizeBrowserInput", () => {
+  it("preserves valid trailing characters in explicit URLs", () => {
+    expect(normalizeBrowserInput("https://example.com/search?q=foo*")).toBe(
+      "https://example.com/search?q=foo*"
+    );
+  });
+
+  it("searches instead of navigating malformed explicit URLs", () => {
+    expect(normalizeBrowserInput("https://exa*mple.com")).toBe(
+      "https://www.google.com/search?q=https%3A%2F%2Fexa*mple.com"
+    );
+  });
+});

--- a/src/util/url/browserUrl.ts
+++ b/src/util/url/browserUrl.ts
@@ -1,3 +1,5 @@
+import { normalizeHttpUrlCandidate } from "./validation";
+
 const SEARCH_URL_PREFIX = "https://www.google.com/search?q=";
 
 const HTTP_PROTOCOL = "http:";
@@ -10,8 +12,11 @@ function toSearchUrl(query: string): string {
 }
 
 function parseHttpUrl(candidate: string): URL | null {
+  const normalized = normalizeHttpUrlCandidate(candidate);
+  if (!normalized) return null;
+
   try {
-    const parsedUrl = new URL(candidate);
+    const parsedUrl = new URL(normalized);
     if (
       (parsedUrl.protocol === HTTP_PROTOCOL ||
         parsedUrl.protocol === HTTPS_PROTOCOL) &&

--- a/src/util/url/validation.test.ts
+++ b/src/util/url/validation.test.ts
@@ -33,6 +33,28 @@ describe("normalizeHttpUrlCandidate", () => {
     ).toBe("https://example.com/$%7Bpath%7D?q={value}");
   });
 
+  it("preserves valid trailing URL characters by default", () => {
+    expect(normalizeHttpUrlCandidate("https://example.com/docs!")).toBe(
+      "https://example.com/docs!"
+    );
+    expect(normalizeHttpUrlCandidate("https://example.com/search?q=foo*")).toBe(
+      "https://example.com/search?q=foo*"
+    );
+  });
+
+  it("strips trailing markdown and sentence boundaries for text URL candidates", () => {
+    const options = { stripTextBoundaries: true };
+    expect(
+      normalizeHttpUrlCandidate("https://example.com/docs.**", options)
+    ).toBe("https://example.com/docs");
+    expect(
+      normalizeHttpUrlCandidate("https://example.com/docs*", options)
+    ).toBe("https://example.com/docs");
+    expect(
+      normalizeHttpUrlCandidate("https://example.com/docs~~", options)
+    ).toBe("https://example.com/docs");
+  });
+
   it("rejects non-HTTP schemes and template placeholder hosts", () => {
     expect(normalizeHttpUrlCandidate("file:///tmp/app.log")).toBeNull();
     expect(normalizeHttpUrlCandidate("http://${host}/")).toBeNull();
@@ -45,6 +67,8 @@ describe("normalizeHttpUrlCandidate", () => {
   it("rejects malformed or unsafe authorities", () => {
     expect(normalizeHttpUrlCandidate("https://example.com other")).toBeNull();
     expect(normalizeHttpUrlCandidate("https://exa mple.com")).toBeNull();
+    expect(normalizeHttpUrlCandidate("https://exa*mple.com")).toBeNull();
+    expect(normalizeHttpUrlCandidate("https://exa~mple.com")).toBeNull();
     expect(normalizeHttpUrlCandidate("http://example.com:99999")).toBeNull();
     expect(normalizeHttpUrlCandidate("http:///missing-host")).toBeNull();
   });

--- a/src/util/url/validation.ts
+++ b/src/util/url/validation.ts
@@ -1,5 +1,11 @@
-const INVALID_AUTHORITY_CHARACTER_PATTERN = /[$`{}<>"'\\\s]/;
+const INVALID_AUTHORITY_CHARACTER_PATTERN = /[$`{}<>"'\\\s*~]/;
 const IPV6_AUTHORITY_PATTERN = /^\[[0-9a-f:.]+\](?::\d+)?$/i;
+const TRAILING_TEXT_URL_BOUNDARY_PATTERN = /(?:[.,;:!?]+|\*+|_{2,}|~{2,})+$/;
+
+interface NormalizeHttpUrlCandidateOptions {
+  stripTextBoundaries?: boolean;
+}
+
 function getRawAuthority(candidate: string): string | null {
   const authorityMatch = candidate.match(/^https?:\/\/([^/?#]*)/i);
   return authorityMatch?.[1] ?? null;
@@ -21,8 +27,14 @@ function hasInvalidParsedPort(port: string): boolean {
   return !Number.isInteger(portNumber) || portNumber < 1 || portNumber > 65_535;
 }
 
-export function normalizeHttpUrlCandidate(candidate: string): string | null {
-  const trimmed = candidate.trim();
+export function normalizeHttpUrlCandidate(
+  candidate: string,
+  options: NormalizeHttpUrlCandidateOptions = {}
+): string | null {
+  const base = candidate.trim();
+  const trimmed = options.stripTextBoundaries
+    ? base.replace(TRAILING_TEXT_URL_BOUNDARY_PATTERN, "")
+    : base;
   if (!trimmed) return null;
 
   const rawAuthority = getRawAuthority(trimmed);


### PR DESCRIPTION
## Summary
- Trim trailing Markdown/sentence boundaries only for text-extracted URL reference cards
- Harden structured URL validation against malformed authorities
- Keep browser address-bar normalization preserving valid trailing URL characters

## Tests
- `vitest run src/engines/ChatPanel/blocks/__tests__/MessageReferenceCards.test.ts src/engines/ChatPanel/blocks/ToolCallBlock/helpers/__tests__/resultParsers.test.ts src/util/url/validation.test.ts src/util/url/browserUrl.test.ts`
- `eslint src/engines/ChatPanel/blocks/MessageReferenceCards.helpers.ts src/engines/ChatPanel/blocks/__tests__/MessageReferenceCards.test.ts src/engines/ChatPanel/blocks/ToolCallBlock/helpers/__tests__/resultParsers.test.ts src/util/url/validation.ts src/util/url/validation.test.ts src/util/url/browserUrl.ts src/util/url/browserUrl.test.ts`
- `git diff --check upstream/develop..HEAD`

Closes #199