### PR TITLE
feat(browser): complete Windows internal WebView automation v1

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -80,6 +80,7 @@ dependencies = [
  "backoff",
  "base64 0.22.1",
  "blake3",
+ "browser",
  "bytes",
  "chrono",
  "chrono-tz",

--- a/src-tauri/crates/agent-core/Cargo.toml
+++ b/src-tauri/crates/agent-core/Cargo.toml
@@ -27,6 +27,7 @@ core_types = { path = "../types" }
 app_paths = { path = "../app-paths" }
 app_platform = { path = "../app-platform" }
 app_utils = { path = "../app-utils" }
+browser = { path = "../browser" }
 
 # Runtime infrastructure agent_core composes against (no back-edges from
 # any of these crates into agent_core — IoC slots inside agent_core

--- a/src-tauri/crates/agent-core/src/core/definitions/builtin/os.rs
+++ b/src-tauri/crates/agent-core/src/core/definitions/builtin/os.rs
@@ -2,7 +2,7 @@
 //!
 //! The OS agent specializes in desktop automation tasks:
 //! - Desktop control through the bundled Peekaboo CLI
-//! - Browser automation through bundled browser control CLIs
+//! - Browser automation through bundled browser control CLIs and the internal WebView
 //!
 //! It uses a singleton session model (one global session).
 
@@ -25,7 +25,7 @@ pub const OS_AGENT_ID: &str = "builtin:os";
 ///
 /// Capabilities:
 /// - Desktop automation through the bundled Peekaboo CLI
-/// - Browser automation through bundled browser control CLIs
+/// - Browser automation through bundled browser control CLIs and the internal WebView
 ///
 /// Session Model:
 /// - Singleton (single global session)
@@ -41,7 +41,7 @@ pub fn os_agent() -> AgentDefinition {
         desktop: Some(DesktopCapability { enabled: true }),
         browser: Some(BrowserCapability {
             external: true,
-            internal: false,
+            internal: true,
         }),
         coding: None,
         gateway: None,
@@ -169,6 +169,28 @@ mod tests {
         assert!(
             caps.desktop.is_some(),
             "OS Agent's desktop capability must stay on"
+        );
+    }
+
+    #[test]
+    fn os_agent_has_browser_automation_capability() {
+        let caps = os_agent().capabilities.expect("OS Agent declares caps");
+        let browser = caps.browser.expect("OS Agent declares browser capability");
+        assert!(
+            browser.external,
+            "OS Agent should keep external browser automation available"
+        );
+        assert!(
+            browser.internal,
+            "OS Agent should expose internal WebView browser automation"
+        );
+        assert!(
+            !os_agent()
+                .tools
+                .excluded_tools
+                .iter()
+                .any(|tool| tool == tool_names::CONTROL_INTERNAL_BROWSER),
+            "OS Agent must not exclude control_internal_browser"
         );
     }
 

--- a/src-tauri/crates/agent-core/src/core/tools/builtin_tools/table/web.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/builtin_tools/table/web.rs
@@ -41,12 +41,15 @@ const AGENT_BROWSER_CLI_ACTIONS: &[ActionEntry] = &[
 
 const INTERNAL_BROWSER_ACTION_ICONS: &[(&str, &str)] = &[
     ("list", "list"),
-    ("is_ready", "circle-check"),
-    ("get_state", "scan-eye"),
+    ("is_ready", "check-circle-2"),
+    ("get_state", "eye"),
     ("click", "mouse-pointer-click"),
     ("input", "text-cursor-input"),
     ("select", "list-filter"),
     ("scroll", "move-vertical"),
+    ("show_mask", "shield"),
+    ("hide_mask", "shield-off"),
+    ("clean_up", "sparkle"),
 ];
 
 const INTERNAL_BROWSER_ACTIONS: &[ActionEntry] = &[
@@ -57,6 +60,9 @@ const INTERNAL_BROWSER_ACTIONS: &[ActionEntry] = &[
     action_sub!("input", "Input text into an indexed element in the internal browser", SubInternalBrowser, labels: "tools.internalBrowserInputRunning", "tools.internalBrowserInputDone", "tools.internalBrowserInputFailed"),
     action_sub!("select", "Select an option in the internal browser", SubInternalBrowser, labels: "tools.internalBrowserSelectRunning", "tools.internalBrowserSelectDone", "tools.internalBrowserSelectFailed"),
     action_sub!("scroll", "Scroll the internal browser viewport", SubInternalBrowser, labels: "tools.internalBrowserScrollRunning", "tools.internalBrowserScrollDone", "tools.internalBrowserScrollFailed"),
+    action_sub!("show_mask", "Show the internal browser element mask", SubInternalBrowser, labels: "tools.internalBrowserShowMaskRunning", "tools.internalBrowserShowMaskDone", "tools.internalBrowserShowMaskFailed"),
+    action_sub!("hide_mask", "Hide the internal browser element mask", SubInternalBrowser, labels: "tools.internalBrowserHideMaskRunning", "tools.internalBrowserHideMaskDone", "tools.internalBrowserHideMaskFailed"),
+    action_sub!("clean_up", "Clean up internal browser overlays", SubInternalBrowser, labels: "tools.internalBrowserCleanUpRunning", "tools.internalBrowserCleanUpDone", "tools.internalBrowserCleanUpFailed"),
 ];
 
 const PLAYWRIGHT_CLI_ACTIONS: &[ActionEntry] = &[
@@ -207,7 +213,7 @@ pub(super) static TOOLS: &[ToolEntry] = &[
     ToolEntry {
         name: tool_names::CONTROL_INTERNAL_BROWSER,
         description: "Inspect and control the currently visible ORGII internal Browser WebView.",
-        description_detail: "Targets the active internal browser-session WebView tracked by the frontend lifecycle. Exposes list, is_ready, get_state, click, input, select, and scroll through the embedded Tauri/WebView Page Agent rather than external Chrome or Playwright, and never accepts arbitrary WebView labels from the model.",
+        description_detail: "Targets the active internal browser-session WebView tracked by the frontend lifecycle. Exposes list, is_ready, get_state, click, input, select, scroll, show_mask, hide_mask, and clean_up through the embedded Tauri/WebView Page Agent rather than external Chrome or Playwright, and never accepts arbitrary WebView labels from the model. Call get_state before indexed actions; element indexes are snapshots and can become stale after DOM changes, scrolling, or navigation.",
         category: tool_categories::WEB,
         icon_id: "mouse-pointer-click",
         simulator_app: AppBrowser,

--- a/src-tauri/crates/agent-core/src/core/tools/builtin_tools/table/web.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/builtin_tools/table/web.rs
@@ -47,9 +47,6 @@ const INTERNAL_BROWSER_ACTION_ICONS: &[(&str, &str)] = &[
     ("input", "text-cursor-input"),
     ("select", "list-filter"),
     ("scroll", "move-vertical"),
-    ("show_mask", "eye"),
-    ("hide_mask", "eye-off"),
-    ("clean_up", "sparkles"),
 ];
 
 const INTERNAL_BROWSER_ACTIONS: &[ActionEntry] = &[
@@ -60,9 +57,6 @@ const INTERNAL_BROWSER_ACTIONS: &[ActionEntry] = &[
     action_sub!("input", "Input text into an indexed element in the internal browser", SubInternalBrowser, labels: "tools.internalBrowserInputRunning", "tools.internalBrowserInputDone", "tools.internalBrowserInputFailed"),
     action_sub!("select", "Select an option in the internal browser", SubInternalBrowser, labels: "tools.internalBrowserSelectRunning", "tools.internalBrowserSelectDone", "tools.internalBrowserSelectFailed"),
     action_sub!("scroll", "Scroll the internal browser viewport", SubInternalBrowser, labels: "tools.internalBrowserScrollRunning", "tools.internalBrowserScrollDone", "tools.internalBrowserScrollFailed"),
-    action_sub!("show_mask", "Show the internal browser element mask", SubInternalBrowser, labels: "tools.internalBrowserShowMaskRunning", "tools.internalBrowserShowMaskDone", "tools.internalBrowserShowMaskFailed"),
-    action_sub!("hide_mask", "Hide the internal browser element mask", SubInternalBrowser, labels: "tools.internalBrowserHideMaskRunning", "tools.internalBrowserHideMaskDone", "tools.internalBrowserHideMaskFailed"),
-    action_sub!("clean_up", "Clean up internal browser overlays", SubInternalBrowser, labels: "tools.internalBrowserCleanUpRunning", "tools.internalBrowserCleanUpDone", "tools.internalBrowserCleanUpFailed"),
 ];
 
 const PLAYWRIGHT_CLI_ACTIONS: &[ActionEntry] = &[
@@ -212,8 +206,8 @@ pub(super) static TOOLS: &[ToolEntry] = &[
     },
     ToolEntry {
         name: tool_names::CONTROL_INTERNAL_BROWSER,
-        description: "Inspect the currently visible ORGII internal Browser WebView.",
-        description_detail: "Targets the active internal browser-session WebView tracked by the frontend lifecycle. This read-only stage exposes list, is_ready, and get_state through the embedded Tauri/WebView Page Agent rather than external Chrome or Playwright, and never accepts arbitrary WebView labels from the model.",
+        description: "Inspect and control the currently visible ORGII internal Browser WebView.",
+        description_detail: "Targets the active internal browser-session WebView tracked by the frontend lifecycle. Exposes list, is_ready, get_state, click, input, select, and scroll through the embedded Tauri/WebView Page Agent rather than external Chrome or Playwright, and never accepts arbitrary WebView labels from the model.",
         category: tool_categories::WEB,
         icon_id: "mouse-pointer-click",
         simulator_app: AppBrowser,

--- a/src-tauri/crates/agent-core/src/core/tools/builtin_tools/table/web.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/builtin_tools/table/web.rs
@@ -40,6 +40,8 @@ const AGENT_BROWSER_CLI_ACTIONS: &[ActionEntry] = &[
 ];
 
 const INTERNAL_BROWSER_ACTION_ICONS: &[(&str, &str)] = &[
+    ("list", "list"),
+    ("is_ready", "circle-check"),
     ("get_state", "scan-eye"),
     ("click", "mouse-pointer-click"),
     ("input", "text-cursor-input"),
@@ -51,6 +53,8 @@ const INTERNAL_BROWSER_ACTION_ICONS: &[(&str, &str)] = &[
 ];
 
 const INTERNAL_BROWSER_ACTIONS: &[ActionEntry] = &[
+    action_sub!("list", "List internal browser targets", SubInternalBrowser, labels: "tools.internalBrowserRunning", "tools.internalBrowserDone", "tools.internalBrowserFailed"),
+    action_sub!("is_ready", "Check whether the active internal browser Page Agent is ready", SubInternalBrowser, labels: "tools.internalBrowserRunning", "tools.internalBrowserDone", "tools.internalBrowserFailed"),
     action_sub!("get_state", "Read the internal browser state", SubInternalBrowser, labels: "tools.internalBrowserGetStateRunning", "tools.internalBrowserGetStateDone", "tools.internalBrowserGetStateFailed"),
     action_sub!("click", "Click an indexed element in the internal browser", SubInternalBrowser, labels: "tools.internalBrowserClickRunning", "tools.internalBrowserClickDone", "tools.internalBrowserClickFailed"),
     action_sub!("input", "Input text into an indexed element in the internal browser", SubInternalBrowser, labels: "tools.internalBrowserInputRunning", "tools.internalBrowserInputDone", "tools.internalBrowserInputFailed"),
@@ -208,8 +212,8 @@ pub(super) static TOOLS: &[ToolEntry] = &[
     },
     ToolEntry {
         name: tool_names::CONTROL_INTERNAL_BROWSER,
-        description: "Internal browser automation is currently unavailable to agents.",
-        description_detail: "Agents should use the selected external browser CLI provider tool for browser automation, or ask the user to use the Workstation Browser UI. Frontend/Tauri Workstation Browser commands remain available outside the agent tool runtime.",
+        description: "Inspect the currently visible ORGII internal Browser WebView.",
+        description_detail: "Targets the active internal browser-session WebView tracked by the frontend lifecycle. This read-only stage exposes list, is_ready, and get_state through the embedded Tauri/WebView Page Agent rather than external Chrome or Playwright, and never accepts arbitrary WebView labels from the model.",
         category: tool_categories::WEB,
         icon_id: "mouse-pointer-click",
         simulator_app: AppBrowser,

--- a/src-tauri/crates/agent-core/src/core/tools/defaults.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/defaults.rs
@@ -116,8 +116,8 @@ pub fn supported_agents_for(tool_name: &str) -> Vec<AgentKind> {
 /// grant SDE workers app/session administration. Result:
 ///
 /// - **OS Agent** (`coding: None`, `desktop: Some`, `browser: Some`):
-///   excludes coding tools (edit_file, query_lsp, manage_lsp)
-///   and internal browser automation. Keeps desktop, external browser, core.
+///   excludes coding tools (edit_file, query_lsp, manage_lsp). Keeps desktop,
+///   external browser, internal browser, core.
 /// - **SDE Agent** (`coding: Some`, all others None): excludes the 15
 ///   desktop tools and browser tools. Keeps coding,
 ///   core, orchestration.
@@ -210,7 +210,7 @@ mod tests {
         use crate::definitions::capabilities::{
             BrowserCapability, CapabilitySet, DesktopCapability, ManagementCapability,
         };
-        let os_caps = CapabilitySet {
+        let os_caps_without_internal_browser = CapabilitySet {
             desktop: Some(DesktopCapability { enabled: true }),
             browser: Some(BrowserCapability {
                 external: true,
@@ -221,7 +221,7 @@ mod tests {
             data: None,
             management: Some(ManagementCapability {}),
         };
-        let excluded = default_excluded_tools_for_capabilities(&os_caps);
+        let excluded = default_excluded_tools_for_capabilities(&os_caps_without_internal_browser);
 
         // Coding tools must be excluded.
         assert!(
@@ -248,7 +248,7 @@ mod tests {
         );
         assert!(
             excluded.contains(&tool_names::CONTROL_INTERNAL_BROWSER.to_string()),
-            "OS should exclude internal browser automation by default"
+            "capabilities with browser.internal=false should exclude internal browser automation"
         );
 
         // Core tools (read_file, etc.) always satisfied.

--- a/src-tauri/crates/agent-core/src/core/tools/impls/web/control_internal_browser.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/web/control_internal_browser.rs
@@ -361,13 +361,7 @@ impl InternalBrowserTool {
         let direction = params
             .direction
             .ok_or_else(|| ToolError::InvalidParams("scroll requires direction".to_string()))?;
-        if let Some(pages) = params.pages {
-            if !pages.is_finite() || pages <= 0.0 {
-                return Err(ToolError::InvalidParams(
-                    "scroll pages must be a positive finite number".to_string(),
-                ));
-            }
-        }
+        validate_scroll_pages(params.pages)?;
         if let Some(element_index) = params.element_index {
             validate_index(element_index, "elementIndex")?;
         }
@@ -406,6 +400,17 @@ fn validate_index(index: i64, field: &str) -> Result<(), ToolError> {
         return Err(ToolError::InvalidParams(format!(
             "{field} must be greater than or equal to 0"
         )));
+    }
+    Ok(())
+}
+
+fn validate_scroll_pages(pages: Option<f64>) -> Result<(), ToolError> {
+    if let Some(pages) = pages {
+        if !pages.is_finite() || pages <= 0.0 {
+            return Err(ToolError::InvalidParams(
+                "scroll pages must be a positive finite number".to_string(),
+            ));
+        }
     }
     Ok(())
 }
@@ -580,5 +585,30 @@ mod tests {
         };
 
         assert!(required_index(&params, "click").is_err());
+    }
+
+    #[test]
+    fn validates_scroll_pages() {
+        assert!(validate_scroll_pages(None).is_ok());
+        assert!(validate_scroll_pages(Some(1.0)).is_ok());
+        assert!(validate_scroll_pages(Some(0.0)).is_err());
+        assert!(validate_scroll_pages(Some(f64::NAN)).is_err());
+    }
+
+    #[test]
+    fn maps_scroll_direction_for_page_agent() {
+        assert_eq!(InternalBrowserScrollDirection::Up.as_page_agent_str(), "up");
+        assert_eq!(
+            InternalBrowserScrollDirection::Down.as_page_agent_str(),
+            "down"
+        );
+        assert_eq!(
+            InternalBrowserScrollDirection::Left.as_page_agent_str(),
+            "left"
+        );
+        assert_eq!(
+            InternalBrowserScrollDirection::Right.as_page_agent_str(),
+            "right"
+        );
     }
 }

--- a/src-tauri/crates/agent-core/src/core/tools/impls/web/control_internal_browser.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/web/control_internal_browser.rs
@@ -7,8 +7,9 @@
 use async_trait::async_trait;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
-use tauri::AppHandle;
+use serde_json::{json, Value};
+use tauri::{AppHandle, Emitter};
+use tokio::time::{sleep, Duration, Instant};
 
 use crate::tools::categories as tool_categories;
 use crate::tools::names as tool_names;
@@ -16,6 +17,8 @@ use crate::tools::traits::{params_schema, parse_params_described, Tool, ToolErro
 
 const INTERNAL_BROWSER_NOT_READY_MESSAGE: &str =
     "Internal browser automation requires a running Tauri app handle.";
+const ACTION_URL_REFRESH_TIMEOUT_MS: u64 = 700;
+const ACTION_URL_REFRESH_POLL_MS: u64 = 100;
 
 #[derive(Debug, Clone, Copy, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -34,6 +37,12 @@ enum InternalBrowserAction {
     Select,
     /// Scroll the active page or an indexed scrollable element.
     Scroll,
+    /// Show the Page Agent mask in the active internal browser.
+    ShowMask,
+    /// Hide the Page Agent mask in the active internal browser.
+    HideMask,
+    /// Clean up Page Agent highlights and overlays in the active internal browser.
+    CleanUp,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -43,6 +52,13 @@ enum InternalBrowserScrollDirection {
     Down,
     Left,
     Right,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UrlRefreshMode {
+    None,
+    Immediate,
+    WaitForChange,
 }
 
 impl InternalBrowserScrollDirection {
@@ -140,6 +156,11 @@ struct InternalBrowserActionResponse {
     success: bool,
     action: &'static str,
     target: InternalBrowserToolTarget,
+    before_url: String,
+    actual_url: String,
+    actual_url_changed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    url_refresh_error: Option<String>,
     result: browser::InternalBrowserActionResult,
     message: String,
 }
@@ -304,17 +325,11 @@ impl InternalBrowserTool {
     async fn execute_click(&self, params: &InternalBrowserParams) -> Result<String, ToolError> {
         let index = required_index(params, "click")?;
         let (app, target) = self.resolve_ready_target().await?;
-        let result = browser::internal_browser_click(app, target.label.clone(), index)
+        let result = browser::internal_browser_click(app.clone(), target.label.clone(), index)
             .await
             .map_err(|err| ToolError::ExecutionFailed(format!("Failed to click element: {err}")))?;
-        let response = InternalBrowserActionResponse {
-            success: result.success,
-            action: "click",
-            target,
-            message: result.message.clone(),
-            result,
-        };
-        Self::response_text(&response)
+        self.action_response(app, "click", target, result, UrlRefreshMode::WaitForChange)
+            .await
     }
 
     async fn execute_input(&self, params: &InternalBrowserParams) -> Result<String, ToolError> {
@@ -324,17 +339,14 @@ impl InternalBrowserTool {
             .clone()
             .ok_or_else(|| ToolError::InvalidParams("input requires text".to_string()))?;
         let (app, target) = self.resolve_ready_target().await?;
-        let result = browser::internal_browser_input(app, target.label.clone(), index, text)
+        let result =
+            browser::internal_browser_input(app.clone(), target.label.clone(), index, text)
+                .await
+                .map_err(|err| {
+                    ToolError::ExecutionFailed(format!("Failed to input text: {err}"))
+                })?;
+        self.action_response(app, "input", target, result, UrlRefreshMode::Immediate)
             .await
-            .map_err(|err| ToolError::ExecutionFailed(format!("Failed to input text: {err}")))?;
-        let response = InternalBrowserActionResponse {
-            success: result.success,
-            action: "input",
-            target,
-            message: result.message.clone(),
-            result,
-        };
-        Self::response_text(&response)
     }
 
     async fn execute_select(&self, params: &InternalBrowserParams) -> Result<String, ToolError> {
@@ -344,17 +356,14 @@ impl InternalBrowserTool {
             .clone()
             .ok_or_else(|| ToolError::InvalidParams("select requires option".to_string()))?;
         let (app, target) = self.resolve_ready_target().await?;
-        let result = browser::internal_browser_select(app, target.label.clone(), index, option)
+        let result =
+            browser::internal_browser_select(app.clone(), target.label.clone(), index, option)
+                .await
+                .map_err(|err| {
+                    ToolError::ExecutionFailed(format!("Failed to select option: {err}"))
+                })?;
+        self.action_response(app, "select", target, result, UrlRefreshMode::Immediate)
             .await
-            .map_err(|err| ToolError::ExecutionFailed(format!("Failed to select option: {err}")))?;
-        let response = InternalBrowserActionResponse {
-            success: result.success,
-            action: "select",
-            target,
-            message: result.message.clone(),
-            result,
-        };
-        Self::response_text(&response)
     }
 
     async fn execute_scroll(&self, params: &InternalBrowserParams) -> Result<String, ToolError> {
@@ -368,7 +377,7 @@ impl InternalBrowserTool {
 
         let (app, target) = self.resolve_ready_target().await?;
         let result = browser::internal_browser_scroll(
-            app,
+            app.clone(),
             target.label.clone(),
             direction.as_page_agent_str().to_string(),
             params.pages,
@@ -376,14 +385,143 @@ impl InternalBrowserTool {
         )
         .await
         .map_err(|err| ToolError::ExecutionFailed(format!("Failed to scroll: {err}")))?;
+        self.action_response(app, "scroll", target, result, UrlRefreshMode::Immediate)
+            .await
+    }
+
+    async fn execute_show_mask(&self) -> Result<String, ToolError> {
+        let (app, target) = self.resolve_ready_target().await?;
+        let result = browser::internal_browser_show_mask(app.clone(), target.label.clone())
+            .await
+            .map_err(|err| ToolError::ExecutionFailed(format!("Failed to show mask: {err}")))?;
+        self.action_response(app, "show_mask", target, result, UrlRefreshMode::None)
+            .await
+    }
+
+    async fn execute_hide_mask(&self) -> Result<String, ToolError> {
+        let (app, target) = self.resolve_ready_target().await?;
+        let result = browser::internal_browser_hide_mask(app.clone(), target.label.clone())
+            .await
+            .map_err(|err| ToolError::ExecutionFailed(format!("Failed to hide mask: {err}")))?;
+        self.action_response(app, "hide_mask", target, result, UrlRefreshMode::None)
+            .await
+    }
+
+    async fn execute_clean_up(&self) -> Result<String, ToolError> {
+        let (app, target) = self.resolve_ready_target().await?;
+        let result = browser::internal_browser_clean_up(app.clone(), target.label.clone())
+            .await
+            .map_err(|err| {
+                ToolError::ExecutionFailed(format!("Failed to clean up overlays: {err}"))
+            })?;
+        self.action_response(app, "clean_up", target, result, UrlRefreshMode::None)
+            .await
+    }
+
+    async fn action_response(
+        &self,
+        app: AppHandle,
+        action: &'static str,
+        target: InternalBrowserToolTarget,
+        result: browser::InternalBrowserActionResult,
+        refresh_url: UrlRefreshMode,
+    ) -> Result<String, ToolError> {
+        let before_url = target.url.clone();
+        let mut actual_url = before_url.clone();
+        let mut actual_title: Option<String> = None;
+        let mut url_refresh_error = None;
+
+        match Self::refresh_location_after_action(
+            app.clone(),
+            target.label.clone(),
+            &before_url,
+            refresh_url,
+        )
+        .await
+        {
+            Ok(Some(location)) => {
+                actual_url = location.url;
+                actual_title = Some(location.title);
+            }
+            Ok(None) => {}
+            Err(err) => {
+                url_refresh_error = Some(err);
+            }
+        }
+
+        let actual_url_changed = actual_url != before_url;
+        if actual_url_changed {
+            let _ = app.emit(
+                "internal-browser:url-changed",
+                json!({
+                    "browserSessionId": target.browser_session_id.clone(),
+                    "label": target.label.clone(),
+                    "url": actual_url.clone(),
+                    "title": actual_title.clone(),
+                    "source": "agent-dom-action"
+                }),
+            );
+        }
+
         let response = InternalBrowserActionResponse {
             success: result.success,
-            action: "scroll",
+            action,
             target,
+            before_url,
+            actual_url,
+            actual_url_changed,
+            url_refresh_error,
             message: result.message.clone(),
             result,
         };
         Self::response_text(&response)
+    }
+
+    async fn refresh_location_after_action(
+        app: AppHandle,
+        label: String,
+        before_url: &str,
+        mode: UrlRefreshMode,
+    ) -> Result<Option<browser::InternalBrowserLocation>, String> {
+        match mode {
+            UrlRefreshMode::None => Ok(None),
+            UrlRefreshMode::Immediate => browser::internal_browser_get_location(app, label)
+                .await
+                .map(Some),
+            UrlRefreshMode::WaitForChange => {
+                let deadline =
+                    Instant::now() + Duration::from_millis(ACTION_URL_REFRESH_TIMEOUT_MS);
+                let mut last_location = None;
+                let mut last_error = None;
+
+                loop {
+                    match browser::internal_browser_get_location(app.clone(), label.clone()).await {
+                        Ok(location) => {
+                            if location.url != before_url {
+                                return Ok(Some(location));
+                            }
+                            last_location = Some(location);
+                        }
+                        Err(err) => {
+                            last_error = Some(err);
+                        }
+                    }
+
+                    if Instant::now() >= deadline {
+                        return if let Some(location) = last_location {
+                            Ok(Some(location))
+                        } else {
+                            Err(last_error.unwrap_or_else(|| {
+                                "Timed out refreshing internal browser URL after action."
+                                    .to_string()
+                            }))
+                        };
+                    }
+
+                    sleep(Duration::from_millis(ACTION_URL_REFRESH_POLL_MS)).await;
+                }
+            }
+        }
     }
 }
 
@@ -461,7 +599,7 @@ impl Tool for InternalBrowserTool {
     }
 
     fn description(&self) -> &str {
-        "Inspect and control the currently visible ORGII internal Browser WebView. Resolves only the active internal browser target and supports list, is_ready, get_state, click, input, select, and scroll."
+        "Inspect and control the currently visible ORGII internal Browser WebView. Resolves only the active internal browser target and supports list, is_ready, get_state, click, input, select, scroll, show_mask, hide_mask, and clean_up. Call get_state before indexed actions; indexes are page-state snapshots and may become stale after DOM changes, scrolling, or navigation."
     }
 
     fn is_ready(&self) -> bool {
@@ -477,7 +615,7 @@ impl Tool for InternalBrowserTool {
     }
 
     fn search_hint(&self) -> &str {
-        "internal browser webview tauri webview2 dom page agent get_state click input select scroll is_ready"
+        "internal browser webview tauri webview2 dom page agent get_state click input select scroll show_mask hide_mask clean_up is_ready"
     }
 
     fn parameters(&self) -> Value {
@@ -498,6 +636,9 @@ impl Tool for InternalBrowserTool {
             InternalBrowserAction::Input => self.execute_input(&params).await,
             InternalBrowserAction::Select => self.execute_select(&params).await,
             InternalBrowserAction::Scroll => self.execute_scroll(&params).await,
+            InternalBrowserAction::ShowMask => self.execute_show_mask().await,
+            InternalBrowserAction::HideMask => self.execute_hide_mask().await,
+            InternalBrowserAction::CleanUp => self.execute_clean_up().await,
         }
     }
 
@@ -610,5 +751,19 @@ mod tests {
             InternalBrowserScrollDirection::Right.as_page_agent_str(),
             "right"
         );
+    }
+
+    #[test]
+    fn parses_overlay_actions() {
+        for (action, expected) in [
+            ("show_mask", InternalBrowserAction::ShowMask),
+            ("hide_mask", InternalBrowserAction::HideMask),
+            ("clean_up", InternalBrowserAction::CleanUp),
+        ] {
+            let params: InternalBrowserParams =
+                serde_json::from_value(serde_json::json!({ "action": action }))
+                    .expect("overlay action should parse");
+            assert_eq!(params.action, expected);
+        }
     }
 }

--- a/src-tauri/crates/agent-core/src/core/tools/impls/web/control_internal_browser.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/web/control_internal_browser.rs
@@ -26,13 +26,59 @@ enum InternalBrowserAction {
     IsReady,
     /// Read the active internal browser DOM state.
     GetState,
+    /// Click an indexed element in the active internal browser.
+    Click,
+    /// Replace text in an indexed input, textarea, or contenteditable element.
+    Input,
+    /// Select an option by visible text in an indexed select element.
+    Select,
+    /// Scroll the active page or an indexed scrollable element.
+    Scroll,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum InternalBrowserScrollDirection {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
+impl InternalBrowserScrollDirection {
+    fn as_page_agent_str(self) -> &'static str {
+        match self {
+            Self::Up => "up",
+            Self::Down => "down",
+            Self::Left => "left",
+            Self::Right => "right",
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct InternalBrowserParams {
-    /// Read-only internal browser action to perform.
+    /// Internal browser action to perform.
     action: InternalBrowserAction,
+    /// Highlight index from get_state. Required for click, input, and select.
+    #[serde(default)]
+    index: Option<i64>,
+    /// Text to write into the target element. Required for input.
+    #[serde(default)]
+    text: Option<String>,
+    /// Visible option text to select. Required for select.
+    #[serde(default)]
+    option: Option<String>,
+    /// Direction to scroll. Required for scroll.
+    #[serde(default)]
+    direction: Option<InternalBrowserScrollDirection>,
+    /// Number of viewport pages to scroll. Defaults to 1.0.
+    #[serde(default)]
+    pages: Option<f64>,
+    /// Optional highlight index of a scrollable element. Omit to scroll the page.
+    #[serde(default)]
+    element_index: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
@@ -88,6 +134,16 @@ struct InternalBrowserStateResponse {
     message: String,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InternalBrowserActionResponse {
+    success: bool,
+    action: &'static str,
+    target: InternalBrowserToolTarget,
+    result: browser::InternalBrowserActionResult,
+    message: String,
+}
+
 pub struct InternalBrowserTool {
     app_handle: Option<AppHandle>,
 }
@@ -109,6 +165,33 @@ impl InternalBrowserTool {
                 "Failed to serialize internal browser response: {err}"
             ))
         })
+    }
+
+    async fn resolve_ready_target(
+        &self,
+    ) -> Result<(AppHandle, InternalBrowserToolTarget), ToolError> {
+        let app = self.app_handle()?;
+        let targets = browser::list_internal_browser_targets(app.clone()).map_err(|err| {
+            ToolError::ExecutionFailed(format!("Failed to list internal browser targets: {err}"))
+        })?;
+        let Some(target) = resolvable_active_target(&targets) else {
+            return Err(ToolError::ExecutionFailed(inactive_target_message(
+                &targets,
+            )));
+        };
+
+        let ready = browser::internal_browser_is_ready(app.clone(), target.label.clone())
+            .await
+            .map_err(|err| {
+                ToolError::ExecutionFailed(format!("Failed to check Page Agent readiness: {err}"))
+            })?;
+        if !ready {
+            return Err(ToolError::ExecutionFailed(
+                "Page Agent is not ready in the active internal browser.".to_string(),
+            ));
+        }
+
+        Ok((app, target))
     }
 
     async fn execute_list(&self) -> Result<String, ToolError> {
@@ -217,6 +300,114 @@ impl InternalBrowserTool {
         };
         Self::response_text(&response)
     }
+
+    async fn execute_click(&self, params: &InternalBrowserParams) -> Result<String, ToolError> {
+        let index = required_index(params, "click")?;
+        let (app, target) = self.resolve_ready_target().await?;
+        let result = browser::internal_browser_click(app, target.label.clone(), index)
+            .await
+            .map_err(|err| ToolError::ExecutionFailed(format!("Failed to click element: {err}")))?;
+        let response = InternalBrowserActionResponse {
+            success: result.success,
+            action: "click",
+            target,
+            message: result.message.clone(),
+            result,
+        };
+        Self::response_text(&response)
+    }
+
+    async fn execute_input(&self, params: &InternalBrowserParams) -> Result<String, ToolError> {
+        let index = required_index(params, "input")?;
+        let text = params
+            .text
+            .clone()
+            .ok_or_else(|| ToolError::InvalidParams("input requires text".to_string()))?;
+        let (app, target) = self.resolve_ready_target().await?;
+        let result = browser::internal_browser_input(app, target.label.clone(), index, text)
+            .await
+            .map_err(|err| ToolError::ExecutionFailed(format!("Failed to input text: {err}")))?;
+        let response = InternalBrowserActionResponse {
+            success: result.success,
+            action: "input",
+            target,
+            message: result.message.clone(),
+            result,
+        };
+        Self::response_text(&response)
+    }
+
+    async fn execute_select(&self, params: &InternalBrowserParams) -> Result<String, ToolError> {
+        let index = required_index(params, "select")?;
+        let option = params
+            .option
+            .clone()
+            .ok_or_else(|| ToolError::InvalidParams("select requires option".to_string()))?;
+        let (app, target) = self.resolve_ready_target().await?;
+        let result = browser::internal_browser_select(app, target.label.clone(), index, option)
+            .await
+            .map_err(|err| ToolError::ExecutionFailed(format!("Failed to select option: {err}")))?;
+        let response = InternalBrowserActionResponse {
+            success: result.success,
+            action: "select",
+            target,
+            message: result.message.clone(),
+            result,
+        };
+        Self::response_text(&response)
+    }
+
+    async fn execute_scroll(&self, params: &InternalBrowserParams) -> Result<String, ToolError> {
+        let direction = params
+            .direction
+            .ok_or_else(|| ToolError::InvalidParams("scroll requires direction".to_string()))?;
+        if let Some(pages) = params.pages {
+            if !pages.is_finite() || pages <= 0.0 {
+                return Err(ToolError::InvalidParams(
+                    "scroll pages must be a positive finite number".to_string(),
+                ));
+            }
+        }
+        if let Some(element_index) = params.element_index {
+            validate_index(element_index, "elementIndex")?;
+        }
+
+        let (app, target) = self.resolve_ready_target().await?;
+        let result = browser::internal_browser_scroll(
+            app,
+            target.label.clone(),
+            direction.as_page_agent_str().to_string(),
+            params.pages,
+            params.element_index,
+        )
+        .await
+        .map_err(|err| ToolError::ExecutionFailed(format!("Failed to scroll: {err}")))?;
+        let response = InternalBrowserActionResponse {
+            success: result.success,
+            action: "scroll",
+            target,
+            message: result.message.clone(),
+            result,
+        };
+        Self::response_text(&response)
+    }
+}
+
+fn required_index(params: &InternalBrowserParams, action: &str) -> Result<i64, ToolError> {
+    let index = params
+        .index
+        .ok_or_else(|| ToolError::InvalidParams(format!("{action} requires index")))?;
+    validate_index(index, "index")?;
+    Ok(index)
+}
+
+fn validate_index(index: i64, field: &str) -> Result<(), ToolError> {
+    if index < 0 {
+        return Err(ToolError::InvalidParams(format!(
+            "{field} must be greater than or equal to 0"
+        )));
+    }
+    Ok(())
 }
 
 fn active_target(
@@ -265,7 +456,7 @@ impl Tool for InternalBrowserTool {
     }
 
     fn description(&self) -> &str {
-        "Inspect the currently visible ORGII internal Browser WebView. This read-only step supports list, is_ready, and get_state; DOM actions are added separately."
+        "Inspect and control the currently visible ORGII internal Browser WebView. Resolves only the active internal browser target and supports list, is_ready, get_state, click, input, select, and scroll."
     }
 
     fn is_ready(&self) -> bool {
@@ -281,7 +472,7 @@ impl Tool for InternalBrowserTool {
     }
 
     fn search_hint(&self) -> &str {
-        "internal browser webview tauri webview2 dom page agent get_state is_ready"
+        "internal browser webview tauri webview2 dom page agent get_state click input select scroll is_ready"
     }
 
     fn parameters(&self) -> Value {
@@ -298,11 +489,11 @@ impl Tool for InternalBrowserTool {
             InternalBrowserAction::List => self.execute_list().await,
             InternalBrowserAction::IsReady => self.execute_is_ready().await,
             InternalBrowserAction::GetState => self.execute_get_state().await,
+            InternalBrowserAction::Click => self.execute_click(&params).await,
+            InternalBrowserAction::Input => self.execute_input(&params).await,
+            InternalBrowserAction::Select => self.execute_select(&params).await,
+            InternalBrowserAction::Scroll => self.execute_scroll(&params).await,
         }
-    }
-
-    fn is_read_only(&self) -> bool {
-        true
     }
 
     fn priority(&self) -> ToolPriority {
@@ -359,5 +550,35 @@ mod tests {
 
         assert!(resolvable_active_target(&targets).is_none());
         assert!(inactive_target_message(&targets).contains("No active"));
+    }
+
+    #[test]
+    fn validates_required_action_index() {
+        let params = InternalBrowserParams {
+            action: InternalBrowserAction::Click,
+            index: None,
+            text: None,
+            option: None,
+            direction: None,
+            pages: None,
+            element_index: None,
+        };
+
+        assert!(required_index(&params, "click").is_err());
+    }
+
+    #[test]
+    fn rejects_negative_action_index() {
+        let params = InternalBrowserParams {
+            action: InternalBrowserAction::Click,
+            index: Some(-1),
+            text: None,
+            option: None,
+            direction: None,
+            pages: None,
+            element_index: None,
+        };
+
+        assert!(required_index(&params, "click").is_err());
     }
 }

--- a/src-tauri/crates/agent-core/src/core/tools/impls/web/control_internal_browser.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/web/control_internal_browser.rs
@@ -1,24 +1,256 @@
-//! Agent-facing internal browser tool stub.
+//! Agent-facing internal browser tool.
 //!
-//! Frontend/Tauri inline webview commands remain available through their
-//! runtime command surfaces. Agents must use `control_external_browser` for
-//! browser automation until internal browser automation is implemented for the
-//! agent tool runtime.
+//! The tool only resolves the currently visible ORGII internal browser
+//! WebView. Agents do not provide arbitrary labels; all actions go through the
+//! active target tracked by the frontend-owned BrowserSessionWebview lifecycle.
 
 use async_trait::async_trait;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tauri::AppHandle;
 
 use crate::tools::categories as tool_categories;
 use crate::tools::names as tool_names;
-use crate::tools::traits::{Tool, ToolError};
+use crate::tools::traits::{params_schema, parse_params_described, Tool, ToolError, ToolPriority};
 
-const INTERNAL_BROWSER_UNAVAILABLE_MESSAGE: &str = "Internal browser automation is currently unavailable to agents. Use control_external_browser for browser automation, or ask the user to use the Workstation Browser UI.";
+const INTERNAL_BROWSER_NOT_READY_MESSAGE: &str =
+    "Internal browser automation requires a running Tauri app handle.";
 
-pub struct InternalBrowserTool;
+#[derive(Debug, Clone, Copy, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum InternalBrowserAction {
+    /// List known internal browser targets and the currently active target.
+    List,
+    /// Check whether the active internal browser Page Agent is ready.
+    IsReady,
+    /// Read the active internal browser DOM state.
+    GetState,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct InternalBrowserParams {
+    /// Read-only internal browser action to perform.
+    action: InternalBrowserAction,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct InternalBrowserToolTarget {
+    browser_session_id: String,
+    label: String,
+    url: String,
+    active_webview_exists: bool,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+struct InternalBrowserTargetSummary {
+    label: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    browser_session_id: Option<String>,
+    is_active: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InternalBrowserListResponse {
+    success: bool,
+    action: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    active: Option<InternalBrowserToolTarget>,
+    active_webview_exists: bool,
+    webviews: Vec<InternalBrowserTargetSummary>,
+    message: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InternalBrowserReadyResponse {
+    success: bool,
+    action: &'static str,
+    ready: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target: Option<InternalBrowserToolTarget>,
+    message: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InternalBrowserStateResponse {
+    success: bool,
+    action: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target: Option<InternalBrowserToolTarget>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    state: Option<browser::InternalBrowserState>,
+    message: String,
+}
+
+pub struct InternalBrowserTool {
+    app_handle: Option<AppHandle>,
+}
 
 impl InternalBrowserTool {
-    pub fn new() -> Self {
-        Self
+    pub fn new(app_handle: Option<AppHandle>) -> Self {
+        Self { app_handle }
+    }
+
+    fn app_handle(&self) -> Result<AppHandle, ToolError> {
+        self.app_handle
+            .clone()
+            .ok_or_else(|| ToolError::ExecutionFailed(INTERNAL_BROWSER_NOT_READY_MESSAGE.into()))
+    }
+
+    fn response_text<T: Serialize>(response: &T) -> Result<String, ToolError> {
+        serde_json::to_string_pretty(response).map_err(|err| {
+            ToolError::ExecutionFailed(format!(
+                "Failed to serialize internal browser response: {err}"
+            ))
+        })
+    }
+
+    async fn execute_list(&self) -> Result<String, ToolError> {
+        let app = self.app_handle()?;
+        let targets = browser::list_internal_browser_targets(app).map_err(|err| {
+            ToolError::ExecutionFailed(format!("Failed to list internal browser targets: {err}"))
+        })?;
+        let active = active_target(&targets);
+        let response = InternalBrowserListResponse {
+            success: true,
+            action: "list",
+            active,
+            active_webview_exists: targets.active_webview_exists,
+            webviews: targets
+                .webviews
+                .into_iter()
+                .map(|target| InternalBrowserTargetSummary {
+                    label: target.label,
+                    browser_session_id: target.browser_session_id,
+                    is_active: target.is_active,
+                })
+                .collect(),
+            message: "Listed internal browser targets.".to_string(),
+        };
+        Self::response_text(&response)
+    }
+
+    async fn execute_is_ready(&self) -> Result<String, ToolError> {
+        let app = self.app_handle()?;
+        let targets = browser::list_internal_browser_targets(app.clone()).map_err(|err| {
+            ToolError::ExecutionFailed(format!("Failed to list internal browser targets: {err}"))
+        })?;
+        let Some(target) = resolvable_active_target(&targets) else {
+            let response = InternalBrowserReadyResponse {
+                success: false,
+                action: "is_ready",
+                ready: false,
+                target: active_target(&targets),
+                message: inactive_target_message(&targets),
+            };
+            return Self::response_text(&response);
+        };
+
+        let ready = browser::internal_browser_is_ready(app, target.label.clone())
+            .await
+            .map_err(|err| {
+                ToolError::ExecutionFailed(format!("Failed to check Page Agent readiness: {err}"))
+            })?;
+        let response = InternalBrowserReadyResponse {
+            success: true,
+            action: "is_ready",
+            ready,
+            target: Some(target),
+            message: if ready {
+                "Page Agent is ready in the active internal browser.".to_string()
+            } else {
+                "Page Agent is not ready in the active internal browser.".to_string()
+            },
+        };
+        Self::response_text(&response)
+    }
+
+    async fn execute_get_state(&self) -> Result<String, ToolError> {
+        let app = self.app_handle()?;
+        let targets = browser::list_internal_browser_targets(app.clone()).map_err(|err| {
+            ToolError::ExecutionFailed(format!("Failed to list internal browser targets: {err}"))
+        })?;
+        let Some(target) = resolvable_active_target(&targets) else {
+            let response = InternalBrowserStateResponse {
+                success: false,
+                action: "get_state",
+                target: active_target(&targets),
+                state: None,
+                message: inactive_target_message(&targets),
+            };
+            return Self::response_text(&response);
+        };
+
+        let ready = browser::internal_browser_is_ready(app.clone(), target.label.clone())
+            .await
+            .map_err(|err| {
+                ToolError::ExecutionFailed(format!("Failed to check Page Agent readiness: {err}"))
+            })?;
+        if !ready {
+            let response = InternalBrowserStateResponse {
+                success: false,
+                action: "get_state",
+                target: Some(target),
+                state: None,
+                message: "Page Agent is not ready in the active internal browser.".to_string(),
+            };
+            return Self::response_text(&response);
+        }
+
+        let state = browser::internal_browser_get_state(app, target.label.clone())
+            .await
+            .map_err(|err| {
+                ToolError::ExecutionFailed(format!("Failed to read internal browser state: {err}"))
+            })?;
+        let response = InternalBrowserStateResponse {
+            success: true,
+            action: "get_state",
+            target: Some(target),
+            state: Some(state),
+            message: "Read active internal browser state.".to_string(),
+        };
+        Self::response_text(&response)
+    }
+}
+
+fn active_target(
+    targets: &browser::InternalBrowserTargetList,
+) -> Option<InternalBrowserToolTarget> {
+    targets
+        .active
+        .as_ref()
+        .map(|active| InternalBrowserToolTarget {
+            browser_session_id: active.browser_session_id.clone(),
+            label: active.label.clone(),
+            url: active.url.clone(),
+            active_webview_exists: targets.active_webview_exists,
+        })
+}
+
+fn resolvable_active_target(
+    targets: &browser::InternalBrowserTargetList,
+) -> Option<InternalBrowserToolTarget> {
+    if !targets.active_webview_exists {
+        return None;
+    }
+    active_target(targets)
+}
+
+fn inactive_target_message(targets: &browser::InternalBrowserTargetList) -> String {
+    if targets.active.is_none() {
+        "No active internal browser WebView is available. Open an internal Browser tab first."
+            .to_string()
+    } else if !targets.active_webview_exists {
+        "The tracked active internal browser WebView no longer exists. Activate a Browser tab again."
+            .to_string()
+    } else {
+        "No resolvable active internal browser WebView is available.".to_string()
     }
 }
 
@@ -33,24 +265,99 @@ impl Tool for InternalBrowserTool {
     }
 
     fn description(&self) -> &str {
-        INTERNAL_BROWSER_UNAVAILABLE_MESSAGE
+        "Inspect the currently visible ORGII internal Browser WebView. This read-only step supports list, is_ready, and get_state; DOM actions are added separately."
+    }
+
+    fn is_ready(&self) -> bool {
+        self.app_handle.is_some()
+    }
+
+    fn not_ready_reason(&self) -> Option<&str> {
+        if self.app_handle.is_some() {
+            None
+        } else {
+            Some(INTERNAL_BROWSER_NOT_READY_MESSAGE)
+        }
+    }
+
+    fn search_hint(&self) -> &str {
+        "internal browser webview tauri webview2 dom page agent get_state is_ready"
     }
 
     fn parameters(&self) -> Value {
-        serde_json::json!({
-            "type": "object",
-            "properties": {},
-            "additionalProperties": false
-        })
+        params_schema::<InternalBrowserParams>()
     }
 
     async fn execute_text(
         &self,
-        _params: Value,
+        params: Value,
         _ctx: &crate::tools::traits::CallContext,
     ) -> Result<String, ToolError> {
-        Err(ToolError::ExecutionFailed(
-            INTERNAL_BROWSER_UNAVAILABLE_MESSAGE.to_string(),
-        ))
+        let params: InternalBrowserParams = parse_params_described(params)?;
+        match params.action {
+            InternalBrowserAction::List => self.execute_list().await,
+            InternalBrowserAction::IsReady => self.execute_is_ready().await,
+            InternalBrowserAction::GetState => self.execute_get_state().await,
+        }
+    }
+
+    fn is_read_only(&self) -> bool {
+        true
+    }
+
+    fn priority(&self) -> ToolPriority {
+        ToolPriority::Always
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn active_state(session_id: &str) -> browser::ActiveInternalBrowserState {
+        browser::ActiveInternalBrowserState {
+            browser_session_id: session_id.to_string(),
+            label: format!("browser-session-{session_id}"),
+            url: "https://example.com".to_string(),
+            visible: true,
+            updated_at: 10,
+        }
+    }
+
+    fn target_list(
+        active: Option<browser::ActiveInternalBrowserState>,
+        active_webview_exists: bool,
+    ) -> browser::InternalBrowserTargetList {
+        browser::InternalBrowserTargetList {
+            active,
+            active_webview_exists,
+            webviews: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn resolves_active_target_only_when_webview_exists() {
+        let targets = target_list(Some(active_state("abc")), true);
+        let target = resolvable_active_target(&targets).expect("target should resolve");
+
+        assert_eq!(target.browser_session_id, "abc");
+        assert_eq!(target.label, "browser-session-abc");
+        assert!(target.active_webview_exists);
+    }
+
+    #[test]
+    fn refuses_stale_active_target_without_webview() {
+        let targets = target_list(Some(active_state("abc")), false);
+
+        assert!(resolvable_active_target(&targets).is_none());
+        assert!(inactive_target_message(&targets).contains("no longer exists"));
+    }
+
+    #[test]
+    fn reports_missing_active_target() {
+        let targets = target_list(None, false);
+
+        assert!(resolvable_active_target(&targets).is_none());
+        assert!(inactive_target_message(&targets).contains("No active"));
     }
 }

--- a/src-tauri/crates/agent-core/src/core/tools/registration/web.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/registration/web.rs
@@ -51,5 +51,9 @@ pub async fn register(registry: &mut ToolRegistry, deps: &ToolDeps, disabled: &H
         }
     }
 
-    register_if_enabled(registry, Box::new(InternalBrowserTool::new()), disabled);
+    register_if_enabled(
+        registry,
+        Box::new(InternalBrowserTool::new(deps.app_handle.clone())),
+        disabled,
+    );
 }

--- a/src-tauri/crates/browser/src/internal_browser_commands.rs
+++ b/src-tauri/crates/browser/src/internal_browser_commands.rs
@@ -3,10 +3,17 @@
 //! Direct frontend access to internal browser automation for testing and debugging.
 //! These commands expose the `window.__PAGE_AGENT__` API injected into inline webviews.
 
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use serde_json::json;
 use tauri::{AppHandle, Manager};
+use tokio::time::{Duration, Instant};
+use uuid::Uuid;
 
 use super::logging::eval_js_with_result;
+
+const PAGE_AGENT_PENDING_RESULT: &str = "__ORGII_PAGE_AGENT_PENDING__";
+const PAGE_AGENT_POLL_INTERVAL_MS: u64 = 50;
 
 // ============================================================================
 // Types
@@ -29,6 +36,113 @@ pub struct InternalBrowserActionResult {
     pub message: String,
 }
 
+/// Lightweight browser location state, without rebuilding the Page Agent DOM tree.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct InternalBrowserLocation {
+    pub url: String,
+    pub title: String,
+}
+
+fn page_agent_missing_action() -> serde_json::Value {
+    json!({
+        "success": false,
+        "message": "Page Agent not initialized"
+    })
+}
+
+async fn eval_browser_call<T>(
+    webview: &tauri::Webview,
+    expression: String,
+    timeout_ms: u64,
+) -> Result<T, String>
+where
+    T: DeserializeOwned,
+{
+    let call_id = Uuid::new_v4().to_string();
+    let call_id_literal = serde_json::to_string(&call_id)
+        .map_err(|err| format!("Failed to encode browser eval call id: {err}"))?;
+
+    let script = format!(
+        r#"
+        (async () => {{
+            const callId = {call_id_literal};
+            window.__PAGE_AGENT_RESULTS__ = window.__PAGE_AGENT_RESULTS__ || {{}};
+            try {{
+                window.__PAGE_AGENT_RESULTS__[callId] = await ({expression});
+            }} catch (error) {{
+                window.__PAGE_AGENT_RESULTS__[callId] = {{
+                    success: false,
+                    message: `Browser eval failed: ${{error?.message || String(error)}}`
+                }};
+            }}
+        }})();
+        "#
+    );
+
+    webview
+        .eval(&script)
+        .map_err(|err| format!("Failed to evaluate browser script: {err}"))?;
+
+    let pending_literal = serde_json::to_string(PAGE_AGENT_PENDING_RESULT)
+        .map_err(|err| format!("Failed to encode browser eval pending marker: {err}"))?;
+    let read_script = format!(
+        r#"
+        (() => {{
+            const callId = {call_id_literal};
+            const store = window.__PAGE_AGENT_RESULTS__;
+            if (!store || !Object.prototype.hasOwnProperty.call(store, callId)) {{
+                return {pending_literal};
+            }}
+            const value = store[callId];
+            delete store[callId];
+            return JSON.stringify(value);
+        }})()
+        "#
+    );
+
+    let deadline = Instant::now() + Duration::from_millis(timeout_ms);
+    loop {
+        let result = eval_js_with_result(webview, &read_script, PAGE_AGENT_PENDING_RESULT).await;
+        if result != PAGE_AGENT_PENDING_RESULT {
+            return serde_json::from_str(&result)
+                .map_err(|err| format!("Failed to parse browser eval result: {err}"));
+        }
+
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "Timed out waiting for browser eval result after {timeout_ms}ms"
+            ));
+        }
+
+        tokio::time::sleep(Duration::from_millis(PAGE_AGENT_POLL_INTERVAL_MS)).await;
+    }
+}
+
+async fn eval_page_agent_call<T>(
+    webview: &tauri::Webview,
+    expression: String,
+    missing_value: serde_json::Value,
+    timeout_ms: u64,
+) -> Result<T, String>
+where
+    T: DeserializeOwned,
+{
+    let missing_literal = serde_json::to_string(&missing_value)
+        .map_err(|err| format!("Failed to encode Page Agent fallback: {err}"))?;
+    let guarded_expression = format!(
+        r#"
+        (async () => {{
+            if (!window.__PAGE_AGENT__) {{
+                return {missing_literal};
+            }}
+            return await ({expression});
+        }})()
+        "#
+    );
+
+    eval_browser_call(webview, guarded_expression, timeout_ms).await
+}
+
 // ============================================================================
 // Commands
 // ============================================================================
@@ -45,28 +159,47 @@ pub async fn internal_browser_get_state(
         .get_webview(&label)
         .ok_or_else(|| format!("Webview '{}' not found", label))?;
 
-    // Execute the getBrowserState function
-    let _ = webview.eval(
+    eval_browser_call(
+        &webview,
         r#"
-        if (window.__PAGE_AGENT__) {
-            window.__PAGE_AGENT_RESULT__ = JSON.stringify(window.__PAGE_AGENT__.getBrowserState());
-        } else {
-            window.__PAGE_AGENT_RESULT__ = JSON.stringify({
-                url: window.location.href,
-                title: document.title,
-                header: "Page Agent not initialized",
-                content: "",
-                footer: ""
-            });
-        }
-        "#,
-    );
+        (async () => {
+            if (!window.__PAGE_AGENT__) {
+                return {
+                    url: window.location.href,
+                    title: document.title || "",
+                    header: "Page Agent not initialized",
+                    content: "",
+                    footer: ""
+                };
+            }
+            return window.__PAGE_AGENT__.getBrowserState();
+        })()
+        "#
+        .to_string(),
+        2_000,
+    )
+    .await
+}
 
-    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+/// Get the current URL/title without invoking the Page Agent DOM snapshot path.
+pub async fn internal_browser_get_location(
+    app: AppHandle,
+    label: String,
+) -> Result<InternalBrowserLocation, String> {
+    let webview = app
+        .get_webview(&label)
+        .ok_or_else(|| format!("Webview '{}' not found", label))?;
 
-    let result = eval_js_with_result(&webview, "window.__PAGE_AGENT_RESULT__ || '{}'", "{}").await;
-
-    serde_json::from_str(&result).map_err(|e| format!("Failed to parse result: {}", e))
+    eval_browser_call(
+        &webview,
+        r#"(() => ({
+            url: window.location.href,
+            title: document.title || ""
+        }))()"#
+            .to_string(),
+        1_000,
+    )
+    .await
 }
 
 /// Click an element by its highlight index.
@@ -80,28 +213,13 @@ pub async fn internal_browser_click(
         .get_webview(&label)
         .ok_or_else(|| format!("Webview '{}' not found", label))?;
 
-    let script = format!(
-        r#"
-        (async () => {{
-            if (window.__PAGE_AGENT__) {{
-                window.__PAGE_AGENT_RESULT__ = JSON.stringify(await window.__PAGE_AGENT__.clickElement({}));
-            }} else {{
-                window.__PAGE_AGENT_RESULT__ = JSON.stringify({{
-                    success: false,
-                    message: "Page Agent not initialized"
-                }});
-            }}
-        }})();
-        "#,
-        index
-    );
-
-    let _ = webview.eval(&script);
-    tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
-
-    let result = eval_js_with_result(&webview, "window.__PAGE_AGENT_RESULT__ || '{}'", "{}").await;
-
-    serde_json::from_str(&result).map_err(|e| format!("Failed to parse result: {}", e))
+    eval_page_agent_call(
+        &webview,
+        format!("window.__PAGE_AGENT__.clickElement({index})"),
+        page_agent_missing_action(),
+        2_000,
+    )
+    .await
 }
 
 /// Input text into an element by its highlight index.
@@ -116,35 +234,16 @@ pub async fn internal_browser_input(
         .get_webview(&label)
         .ok_or_else(|| format!("Webview '{}' not found", label))?;
 
-    // Escape the text for JavaScript
-    let escaped_text = text
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r");
+    let text_literal = serde_json::to_string(&text)
+        .map_err(|err| format!("Failed to encode input text: {err}"))?;
 
-    let script = format!(
-        r#"
-        (async () => {{
-            if (window.__PAGE_AGENT__) {{
-                window.__PAGE_AGENT_RESULT__ = JSON.stringify(await window.__PAGE_AGENT__.inputText({}, "{}"));
-            }} else {{
-                window.__PAGE_AGENT_RESULT__ = JSON.stringify({{
-                    success: false,
-                    message: "Page Agent not initialized"
-                }});
-            }}
-        }})();
-        "#,
-        index, escaped_text
-    );
-
-    let _ = webview.eval(&script);
-    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
-
-    let result = eval_js_with_result(&webview, "window.__PAGE_AGENT_RESULT__ || '{}'", "{}").await;
-
-    serde_json::from_str(&result).map_err(|e| format!("Failed to parse result: {}", e))
+    eval_page_agent_call(
+        &webview,
+        format!("window.__PAGE_AGENT__.inputText({index}, {text_literal})"),
+        page_agent_missing_action(),
+        2_000,
+    )
+    .await
 }
 
 /// Select an option from a dropdown by its highlight index.
@@ -159,30 +258,16 @@ pub async fn internal_browser_select(
         .get_webview(&label)
         .ok_or_else(|| format!("Webview '{}' not found", label))?;
 
-    let escaped_option = option.replace('\\', "\\\\").replace('"', "\\\"");
+    let option_literal = serde_json::to_string(&option)
+        .map_err(|err| format!("Failed to encode option text: {err}"))?;
 
-    let script = format!(
-        r#"
-        (async () => {{
-            if (window.__PAGE_AGENT__) {{
-                window.__PAGE_AGENT_RESULT__ = JSON.stringify(await window.__PAGE_AGENT__.selectOption({}, "{}"));
-            }} else {{
-                window.__PAGE_AGENT_RESULT__ = JSON.stringify({{
-                    success: false,
-                    message: "Page Agent not initialized"
-                }});
-            }}
-        }})();
-        "#,
-        index, escaped_option
-    );
-
-    let _ = webview.eval(&script);
-    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
-
-    let result = eval_js_with_result(&webview, "window.__PAGE_AGENT_RESULT__ || '{}'", "{}").await;
-
-    serde_json::from_str(&result).map_err(|e| format!("Failed to parse result: {}", e))
+    eval_page_agent_call(
+        &webview,
+        format!("window.__PAGE_AGENT__.selectOption({index}, {option_literal})"),
+        page_agent_missing_action(),
+        2_000,
+    )
+    .await
 }
 
 /// Scroll the page or an element.
@@ -203,83 +288,85 @@ pub async fn internal_browser_scroll(
         Some(idx) => idx.to_string(),
         None => "null".to_string(),
     };
+    let direction_literal = serde_json::to_string(&direction)
+        .map_err(|err| format!("Failed to encode scroll direction: {err}"))?;
 
-    let script = format!(
-        r#"
-        (async () => {{
-            if (window.__PAGE_AGENT__) {{
-                window.__PAGE_AGENT_RESULT__ = JSON.stringify(await window.__PAGE_AGENT__.scroll("{}", {}, {}));
-            }} else {{
-                window.__PAGE_AGENT_RESULT__ = JSON.stringify({{
-                    success: false,
-                    message: "Page Agent not initialized"
-                }});
-            }}
-        }})();
-        "#,
-        direction, pages_val, element_arg
-    );
-
-    let _ = webview.eval(&script);
-    tokio::time::sleep(tokio::time::Duration::from_millis(400)).await;
-
-    let result = eval_js_with_result(&webview, "window.__PAGE_AGENT_RESULT__ || '{}'", "{}").await;
-
-    serde_json::from_str(&result).map_err(|e| format!("Failed to parse result: {}", e))
+    eval_page_agent_call(
+        &webview,
+        format!("window.__PAGE_AGENT__.scroll({direction_literal}, {pages_val}, {element_arg})"),
+        page_agent_missing_action(),
+        2_000,
+    )
+    .await
 }
 
 /// Show the user takeover mask (blocks user interaction).
 #[tauri::command]
-pub async fn internal_browser_show_mask(app: AppHandle, label: String) -> Result<(), String> {
+pub async fn internal_browser_show_mask(
+    app: AppHandle,
+    label: String,
+) -> Result<InternalBrowserActionResult, String> {
     let webview = app
         .get_webview(&label)
         .ok_or_else(|| format!("Webview '{}' not found", label))?;
 
-    let _ = webview.eval(
-        r#"
-        if (window.__PAGE_AGENT__) {
+    eval_page_agent_call(
+        &webview,
+        r#"(() => {
             window.__PAGE_AGENT__.showMask();
-        }
-        "#,
-    );
-
-    Ok(())
+            return { success: true, message: "Showed the Page Agent mask." };
+        })()"#
+            .to_string(),
+        page_agent_missing_action(),
+        2_000,
+    )
+    .await
 }
 
 /// Hide the user takeover mask (allows user interaction).
 #[tauri::command]
-pub async fn internal_browser_hide_mask(app: AppHandle, label: String) -> Result<(), String> {
+pub async fn internal_browser_hide_mask(
+    app: AppHandle,
+    label: String,
+) -> Result<InternalBrowserActionResult, String> {
     let webview = app
         .get_webview(&label)
         .ok_or_else(|| format!("Webview '{}' not found", label))?;
 
-    let _ = webview.eval(
-        r#"
-        if (window.__PAGE_AGENT__) {
+    eval_page_agent_call(
+        &webview,
+        r#"(() => {
             window.__PAGE_AGENT__.hideMask();
-        }
-        "#,
-    );
-
-    Ok(())
+            return { success: true, message: "Hid the Page Agent mask." };
+        })()"#
+            .to_string(),
+        page_agent_missing_action(),
+        2_000,
+    )
+    .await
 }
 
 /// Clean up element highlights.
 #[tauri::command]
-pub async fn internal_browser_clean_up(app: AppHandle, label: String) -> Result<(), String> {
+pub async fn internal_browser_clean_up(
+    app: AppHandle,
+    label: String,
+) -> Result<InternalBrowserActionResult, String> {
     let webview = app
         .get_webview(&label)
         .ok_or_else(|| format!("Webview '{}' not found", label))?;
 
-    let _ = webview.eval(
-        r#"
-        if (window.__PAGE_AGENT__) {
+    eval_page_agent_call(
+        &webview,
+        r#"(() => {
             window.__PAGE_AGENT__.cleanUpHighlights();
-        }
-        "#,
-    );
-
-    Ok(())
+            return { success: true, message: "Cleaned up Page Agent highlights and overlays." };
+        })()"#
+            .to_string(),
+        page_agent_missing_action(),
+        2_000,
+    )
+    .await
 }
 
 /// Check if Page Agent is initialized in a webview.
@@ -289,16 +376,11 @@ pub async fn internal_browser_is_ready(app: AppHandle, label: String) -> Result<
         .get_webview(&label)
         .ok_or_else(|| format!("Webview '{}' not found", label))?;
 
-    let _ = webview.eval(
-        r#"
-        window.__PAGE_AGENT_READY__ = (typeof window.__PAGE_AGENT__ !== 'undefined').toString();
-        "#,
-    );
-
-    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-
-    let result =
-        eval_js_with_result(&webview, "window.__PAGE_AGENT_READY__ || 'false'", "false").await;
-
-    Ok(result == "true")
+    eval_page_agent_call(
+        &webview,
+        "(typeof window.__PAGE_AGENT__ !== 'undefined')".to_string(),
+        json!(false),
+        1_000,
+    )
+    .await
 }

--- a/src-tauri/crates/browser/src/internal_browser_state.rs
+++ b/src-tauri/crates/browser/src/internal_browser_state.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager};
 
 const BROWSER_SESSION_LABEL_PREFIX: &str = "browser-session-";
+const ABOUT_BLANK_URL: &str = "about:blank";
 
 static ACTIVE_INTERNAL_BROWSER: OnceLock<Mutex<Option<ActiveInternalBrowserState>>> =
     OnceLock::new();
@@ -59,7 +60,8 @@ fn validate_active_state(state: &ActiveInternalBrowserState) -> Result<(), Strin
     if !state.visible {
         return Err("active internal browser state must be visible".to_string());
     }
-    if state.url.trim().is_empty() || state.url.trim().eq_ignore_ascii_case("about:blank") {
+    let normalized_url = state.url.trim().to_ascii_lowercase();
+    if normalized_url.is_empty() || normalized_url.starts_with(ABOUT_BLANK_URL) {
         return Err("active internal browser url must be navigable".to_string());
     }
     Ok(())
@@ -232,6 +234,17 @@ mod tests {
         invalid.label = "browser-session-other".to_string();
 
         assert!(validate_active_state(&invalid).is_err());
+    }
+
+    #[test]
+    fn rejects_blank_active_browser_urls() {
+        let mut empty = state("abc", 1);
+        empty.url = "   ".to_string();
+        assert!(validate_active_state(&empty).is_err());
+
+        let mut about_blank = state("abc", 1);
+        about_blank.url = "about:blank#blocked".to_string();
+        assert!(validate_active_state(&about_blank).is_err());
     }
 
     #[test]

--- a/src/engines/BrowserCore/BrowserSessionWebview.tsx
+++ b/src/engines/BrowserCore/BrowserSessionWebview.tsx
@@ -5,8 +5,9 @@
  * Keeps the webview mounted but hidden when not active.
  */
 import { invoke } from "@tauri-apps/api/core";
+import { type UnlistenFn, listen } from "@tauri-apps/api/event";
 import { useAtomValue } from "jotai";
-import React, { useEffect, useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 
 import { createLogger } from "@src/hooks/logger";
 import { useInlineWebview } from "@src/hooks/platform/useInlineWebview";
@@ -37,6 +38,23 @@ interface ActiveInternalBrowserSync {
   browserSessionId: string;
   label: string;
   updatedAt: number;
+}
+
+interface InternalBrowserUrlChangedPayload {
+  browserSessionId?: string;
+  label?: string;
+  url: string;
+  title?: string;
+}
+
+function isInternalBrowserUrlChangedPayload(
+  payload: unknown
+): payload is InternalBrowserUrlChangedPayload {
+  return (
+    !!payload &&
+    typeof payload === "object" &&
+    typeof (payload as InternalBrowserUrlChangedPayload).url === "string"
+  );
 }
 
 function clearActiveInternalBrowserState(
@@ -102,6 +120,41 @@ const BrowserSessionWebview: React.FC<BrowserSessionWebviewProps> = ({
   );
   const hasNavigableUrl = !isBlankBrowserUrl(session.url);
 
+  const handleSessionNavigation = useCallback(
+    (url: string, titleOverride?: string) => {
+      if (!isBlankBrowserUrl(url) && url !== session.url) {
+        const title = titleOverride?.trim() || getTitleFromUrl(url);
+        const newHistory = [
+          ...session.history.slice(0, session.historyIndex + 1),
+          url,
+        ];
+
+        onSessionUpdate(session.id, {
+          url,
+          title,
+          history: newHistory,
+          historyIndex: newHistory.length - 1,
+          historyEntries: [
+            ...(session.historyEntries ?? []),
+            { url, title, visitedAt: Date.now() },
+          ],
+          isLoading: false,
+        });
+      } else {
+        // URL didn't change (same page reload or navigation complete).
+        onSessionUpdate(session.id, { isLoading: false });
+      }
+    },
+    [
+      onSessionUpdate,
+      session.history,
+      session.historyEntries,
+      session.historyIndex,
+      session.id,
+      session.url,
+    ]
+  );
+
   const webviewConfig = useMemo(() => {
     const shouldActivateWebview = hasNavigableUrl && isActive && isTabActive;
 
@@ -145,27 +198,7 @@ const BrowserSessionWebview: React.FC<BrowserSessionWebviewProps> = ({
         activeInternalBrowserSyncRef.current = null;
       },
       onNavigate: (url: string) => {
-        if (!isBlankBrowserUrl(url) && url !== session.url) {
-          const newHistory = [
-            ...session.history.slice(0, session.historyIndex + 1),
-            url,
-          ];
-
-          onSessionUpdate(session.id, {
-            url,
-            title: getTitleFromUrl(url),
-            history: newHistory,
-            historyIndex: newHistory.length - 1,
-            historyEntries: [
-              ...(session.historyEntries ?? []),
-              { url, title: getTitleFromUrl(url), visitedAt: Date.now() },
-            ],
-            isLoading: false,
-          });
-        } else {
-          // URL didn't change (same page reload or navigation complete)
-          onSessionUpdate(session.id, { isLoading: false });
-        }
+        handleSessionNavigation(url);
       },
       onNewWindow: (url: string) => {
         if (onNewTab) {
@@ -176,11 +209,9 @@ const BrowserSessionWebview: React.FC<BrowserSessionWebviewProps> = ({
   }, [
     containerRef,
     hasNavigableUrl,
+    handleSessionNavigation,
     session.id,
     session.url,
-    session.history,
-    session.historyIndex,
-    session.historyEntries,
     session.incognito,
     isActive,
     isTabActive,
@@ -196,6 +227,52 @@ const BrowserSessionWebview: React.FC<BrowserSessionWebviewProps> = ({
     isWebviewAvailable,
     isWebviewCreated,
   } = useInlineWebview(webviewConfig);
+
+  useEffect(() => {
+    if (!isWebviewAvailable) return;
+
+    let cancelled = false;
+    let unlisten: UnlistenFn | null = null;
+
+    void listen<InternalBrowserUrlChangedPayload>(
+      "internal-browser:url-changed",
+      (event) => {
+        const payload = event.payload;
+        if (!isInternalBrowserUrlChangedPayload(payload)) return;
+        if (
+          payload.browserSessionId !== session.id &&
+          payload.label !== webviewLabel
+        ) {
+          return;
+        }
+
+        handleSessionNavigation(
+          payload.url,
+          typeof payload.title === "string" ? payload.title : undefined
+        );
+      }
+    )
+      .then((listener) => {
+        if (cancelled) {
+          listener();
+          return;
+        }
+        unlisten = listener;
+      })
+      .catch((error) => {
+        log.warn(
+          "[BrowserSessionWebview] Failed to listen for internal browser URL changes:",
+          error
+        );
+      });
+
+    return () => {
+      cancelled = true;
+      if (unlisten) {
+        unlisten();
+      }
+    };
+  }, [handleSessionNavigation, isWebviewAvailable, session.id, webviewLabel]);
 
   useEffect(() => {
     if (!isWebviewAvailable) {

--- a/src/engines/BrowserCore/BrowserSessionWebview.tsx
+++ b/src/engines/BrowserCore/BrowserSessionWebview.tsx
@@ -40,9 +40,13 @@ interface ActiveInternalBrowserSync {
 }
 
 function clearActiveInternalBrowserState(
-  sync: ActiveInternalBrowserSync,
+  sync: ActiveInternalBrowserSync | null,
   reason: string
 ): void {
+  if (!sync) {
+    return;
+  }
+
   void invoke("clear_active_internal_browser_state", {
     label: sync.label,
     browserSessionId: sync.browserSessionId,
@@ -123,10 +127,22 @@ const BrowserSessionWebview: React.FC<BrowserSessionWebviewProps> = ({
       },
       onError: (error: string | Error) => {
         log.error("[BrowserSessionWebview] WebView error:", error);
+        clearActiveInternalBrowserState(
+          activeInternalBrowserSyncRef.current,
+          "browser-session-webview-error"
+        );
+        activeInternalBrowserSyncRef.current = null;
         onSessionUpdate(session.id, {
           error: typeof error === "string" ? error : error.message,
           isLoading: false,
         });
+      },
+      onDestroyed: () => {
+        clearActiveInternalBrowserState(
+          activeInternalBrowserSyncRef.current,
+          "browser-session-webview-destroyed"
+        );
+        activeInternalBrowserSyncRef.current = null;
       },
       onNavigate: (url: string) => {
         if (!isBlankBrowserUrl(url) && url !== session.url) {
@@ -183,6 +199,11 @@ const BrowserSessionWebview: React.FC<BrowserSessionWebviewProps> = ({
 
   useEffect(() => {
     if (!isWebviewAvailable) {
+      clearActiveInternalBrowserState(
+        activeInternalBrowserSyncRef.current,
+        "browser-session-webview-unavailable"
+      );
+      activeInternalBrowserSyncRef.current = null;
       return;
     }
 

--- a/src/modules/WorkStation/Browser/SessionReplay/BrowserSidebar.tsx
+++ b/src/modules/WorkStation/Browser/SessionReplay/BrowserSidebar.tsx
@@ -6,6 +6,7 @@
  * owns category switching.
  */
 import {
+  CheckCircle2,
   Chrome,
   Compass,
   FileSymlink,
@@ -89,6 +90,12 @@ function getNativeActionIcon(
   const stroke = 1.75;
 
   switch (action) {
+    case "list":
+      return <ListTree size={size} strokeWidth={stroke} className={color} />;
+    case "is_ready":
+      return (
+        <CheckCircle2 size={size} strokeWidth={stroke} className={color} />
+      );
     case "get_state":
       return <ListTree size={size} strokeWidth={stroke} className={color} />;
     case "click":

--- a/src/modules/WorkStation/Browser/SessionReplay/__tests__/config.test.ts
+++ b/src/modules/WorkStation/Browser/SessionReplay/__tests__/config.test.ts
@@ -58,4 +58,38 @@ describe("deriveBrowserState", () => {
     expect(state.activeEntry?.title).toBe("Snapshot Page");
     expect(state.activeEntry?.subtitle).toBe("snapshot");
   });
+
+  it("keeps internal browser entries without the legacy webview arg", () => {
+    const event = makeEvent({
+      functionName: "control_internal_browser",
+      uiCanonical: "control_internal_browser",
+      args: { action: "click", index: 3 },
+      result: JSON.stringify({
+        success: true,
+        action: "click",
+        target: {
+          browserSessionId: "session-browser-1",
+          label: "browser-session-session-browser-1",
+        },
+        beforeUrl: "https://example.com",
+        actualUrl: "https://example.com/next",
+        actualUrlChanged: true,
+        message: "Clicked Next",
+        result: {
+          success: true,
+          message: "Clicked Next",
+        },
+      }) as unknown as Record<string, unknown>,
+    });
+
+    const state = deriveBrowserState([event], event.id);
+    const entry = state.activeInternalEntry;
+
+    expect(state.activeSubtool).toBe("internal_browser");
+    expect(state.internalBrowserEntries).toHaveLength(1);
+    expect(entry?.webviewLabel).toBe("browser-session-session-browser-1");
+    expect(entry?.browserSessionId).toBe("session-browser-1");
+    expect(entry?.success).toBe(true);
+    expect(entry?.actualUrlChanged).toBe(true);
+  });
 });

--- a/src/modules/WorkStation/Browser/SessionReplay/config.ts
+++ b/src/modules/WorkStation/Browser/SessionReplay/config.ts
@@ -53,6 +53,58 @@ function getEventArgs(event: SessionEvent): Record<string, unknown> {
     : {};
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseJsonRecord(value: unknown): Record<string, unknown> | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trimStart();
+  if (!trimmed.startsWith("{")) return null;
+  try {
+    const parsed = JSON.parse(trimmed);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function getRecordField(
+  record: Record<string, unknown> | null | undefined,
+  key: string
+): Record<string, unknown> | null {
+  const value = record?.[key];
+  return isRecord(value) ? value : null;
+}
+
+function getStringField(
+  record: Record<string, unknown> | null | undefined,
+  key: string
+): string | undefined {
+  const value = record?.[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function getBooleanField(
+  record: Record<string, unknown> | null | undefined,
+  key: string
+): boolean | undefined {
+  const value = record?.[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function extractToolResultObject(event: SessionEvent): Record<string, unknown> {
+  const parsedDirect = parseJsonRecord(event.result);
+  if (parsedDirect) return parsedDirect;
+
+  const direct = isRecord(event.result) ? event.result : {};
+  for (const field of ["output", "content", "observation"] as const) {
+    const parsed = parseJsonRecord(direct[field]);
+    if (parsed) return parsed;
+  }
+  return direct;
+}
+
 function getBrowserEntrySubtitle(
   event: SessionEvent,
   args: Record<string, unknown>
@@ -179,20 +231,35 @@ function buildInternalBrowserEntry(
   event: SessionEvent,
   currentEventId: string | null
 ): InternalBrowserEntry | null {
-  const args = event.args as Record<string, unknown> | undefined;
-  const result = event.result as Record<string, unknown> | undefined;
+  const args = getEventArgs(event);
+  const result = extractToolResultObject(event);
 
   const action = args?.action;
   if (typeof action !== "string") return null;
 
-  const webviewLabel = args?.webview;
-  if (typeof webviewLabel !== "string") return null;
+  const target = getRecordField(result, "target");
+  const active = getRecordField(result, "active");
+  const nestedResult = getRecordField(result, "result");
+  const webviewLabel =
+    getStringField(args, "webview") ||
+    getStringField(args, "label") ||
+    getStringField(target, "label") ||
+    getStringField(active, "label") ||
+    "internal-browser";
+  const browserSessionId =
+    getStringField(args, "browserSessionId") ||
+    getStringField(args, "browser_session_id") ||
+    getStringField(target, "browserSessionId") ||
+    getStringField(target, "browser_session_id") ||
+    getStringField(active, "browserSessionId") ||
+    getStringField(active, "browser_session_id");
 
   return {
     entryId: event.id,
     event,
     action: action as InternalBrowserAction,
     webviewLabel,
+    browserSessionId,
     timestamp: event.createdAt,
     isCurrent: event.id === currentEventId,
     index: typeof args?.index === "number" ? args.index : undefined,
@@ -200,8 +267,15 @@ function buildInternalBrowserEntry(
     option: typeof args?.option === "string" ? args.option : undefined,
     direction: typeof args?.direction === "string" ? args.direction : undefined,
     pages: typeof args?.pages === "number" ? args.pages : undefined,
-    success: typeof result?.success === "boolean" ? result.success : undefined,
-    message: typeof result?.message === "string" ? result.message : undefined,
+    success:
+      getBooleanField(result, "success") ??
+      getBooleanField(nestedResult, "success"),
+    message:
+      getStringField(result, "message") ??
+      getStringField(nestedResult, "message"),
+    beforeUrl: getStringField(result, "beforeUrl"),
+    actualUrl: getStringField(result, "actualUrl"),
+    actualUrlChanged: getBooleanField(result, "actualUrlChanged"),
   };
 }
 

--- a/src/modules/WorkStation/Browser/SessionReplay/types.ts
+++ b/src/modules/WorkStation/Browser/SessionReplay/types.ts
@@ -28,6 +28,8 @@ export interface BrowserEntry {
 
 /** Action types for control_internal_browser tool */
 export type InternalBrowserAction =
+  | "list"
+  | "is_ready"
   | "get_state"
   | "click"
   | "input"
@@ -43,6 +45,7 @@ export interface InternalBrowserEntry {
   event: SessionEvent;
   action: InternalBrowserAction;
   webviewLabel: string;
+  browserSessionId?: string;
   timestamp: string;
   isCurrent: boolean;
   // Action-specific data
@@ -54,6 +57,9 @@ export interface InternalBrowserEntry {
   // Result data
   success?: boolean;
   message?: string;
+  beforeUrl?: string;
+  actualUrl?: string;
+  actualUrlChanged?: boolean;
 }
 
 // ============================================

--- a/src/test/vitest.setup.ts
+++ b/src/test/vitest.setup.ts
@@ -76,6 +76,7 @@ const BUILTIN_SIMULATOR_APP_FIXTURE: Map<string, AppType> = new Map([
   ["control_browser_with_agent_browser", AppType.BROWSER],
   ["control_browser_with_playwright", AppType.BROWSER],
   ["control_external_browser", AppType.BROWSER],
+  ["control_internal_browser", AppType.BROWSER],
   ["control_desktop_with_peekaboo", AppType.BROWSER],
 
   // Agent/Channels tools → CHANNELS
@@ -131,6 +132,7 @@ const BUILTIN_SUBTOOL_FIXTURE: Map<string, AppSubtool> = new Map([
   ["control_browser_with_agent_browser", "browser"],
   ["control_browser_with_playwright", "browser"],
   ["control_external_browser", "browser"],
+  ["control_internal_browser", "internal_browser"],
   ["control_desktop_with_peekaboo", "browser"],
 
   // Agent/Channels tools
@@ -188,6 +190,8 @@ function actionInfo(
 }
 
 const INTERNAL_BROWSER_ACTION_NAMES = [
+  "list",
+  "is_ready",
   "get_state",
   "click",
   "input",
@@ -202,6 +206,8 @@ const INTERNAL_BROWSER_ACTION_LABEL_KEYS: Record<
   (typeof INTERNAL_BROWSER_ACTION_NAMES)[number],
   LabelKeySet
 > = {
+  list: labelKeys("internalBrowser"),
+  is_ready: labelKeys("internalBrowser"),
   get_state: labelKeys("internalBrowserGetState"),
   click: labelKeys("internalBrowserClick"),
   input: labelKeys("internalBrowserInput"),


### PR DESCRIPTION
## Summary

Completes the first Windows internal browser automation path for ORGII's embedded Tauri/WebView browser.

This PR focuses only on the internal Tauri/WebView2 browser path. It does not change external Chrome, Playwright, or Agent Browser CLI automation.

## What changed

- Exposes `control_internal_browser` actions for the internal Browser WebView:
  - `list`
  - `is_ready`
  - `get_state`
  - `click`
  - `input`
  - `select`
  - `scroll`
  - `show_mask`
  - `hide_mask`
  - `clean_up`
- Routes Page Agent calls through per-call result IDs instead of a shared global result slot.
- Uses JSON encoding for text/options passed into injected JS.
- Syncs URL changes from DOM actions back into the frontend Browser session.
- Keeps SessionReplay entries for internal browser tool calls even when legacy `webview` args are absent.
- Makes OS Agent the built-in agent that can use internal WebView browser automation.
- Leaves ADE Manager focused on ADE/UI management rather than browser automation.

## Validation

- Manual Windows internal WebView test passed:
  - internal Browser tab opens
  - `list`
  - `is_ready`
  - `get_state`
  - `click`
  - `input`
  - `scroll`
  - `show_mask`
  - `hide_mask`
  - `clean_up`
- Commit hook ran successfully:
  - `Pre-commit hook ran. Total eslint: 21, total circular: 0`
- `npx lint-staged --diff=HEAD~1..HEAD` passed.
- `npx commitlint --from HEAD~1 --to HEAD --verbose` passed.
- `npx vitest run src/modules/WorkStation/Browser/SessionReplay/__tests__/config.test.ts` passed.
- `cargo clippy --lib --message-format=short -p agent_core -p browser` passed with existing warnings.
- Dev app compiled and launched from `E:\cargo-target\ORG2`.

## Notes

- This PR intentionally does not touch external browser automation.
- ADE Manager can still be used to control ORGII UI, but `control_internal_browser` is exposed through OS Agent, which owns desktop/browser automation.
- A full `npx tsc --noEmit --incremental --tsBuildInfoFile .git/.tsbuildinfo` currently reports existing unrelated errors in files not changed by this PR:
  - `src/modules/MainApp/Settings/SettingsSlot.tsx`
  - `src/modules/WorkStation/TabContent/renderers/githubIssueDetail.tsx`
  - `src/services/context/appUiSnapshot.ts`