### PR TITLE
fix(sidebar): unify grouped load more row

### DIFF
--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/menuSectionBuilders.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/menuSectionBuilders.test.ts
@@ -6,14 +6,20 @@ import type { Session, SessionListCategory } from "@src/store/session";
 import {
   buildByAgentMenuItems,
   buildByTimeMenuItems,
+  buildByWorkspaceMenuItems,
 } from "../menuSectionBuilders";
 
-function makeSession(sessionId: string, updatedAt: string): Session {
+function makeSession(
+  sessionId: string,
+  updatedAt: string,
+  repoPath?: string
+): Session {
   return {
     session_id: sessionId,
     status: "completed",
     created_at: updatedAt,
     updated_at: updatedAt,
+    repoPath,
   };
 }
 
@@ -47,8 +53,8 @@ function appendGroupSessions(
 
 function appendTrailingLoadMoreItems(items: NavigationMenuItem[]): void {
   items.push({
-    id: "load-more-cursor_ide",
-    key: "load-more-cursor_ide",
+    id: "load-more-unified",
+    key: "load-more-unified",
     label: "Load more",
   });
 }
@@ -70,6 +76,43 @@ function getLoadMoreItemIds(items: readonly NavigationMenuItem[]): string[] {
 }
 
 describe("session menu section builders", () => {
+  it("appends one unified backend load-more row in the by-time view", () => {
+    const today = new Date().toISOString();
+    const items = buildByTimeMenuItems({
+      unpinnedSessions: [makeSession("cursoride-1", today)],
+      dateGroupLabels: {
+        today: "Today",
+        yesterday: "Yesterday",
+        thisWeek: "This Week",
+        older: "Older",
+      },
+      appendPinnedSessions,
+      appendGroupSessions,
+      appendTrailingLoadMoreItems,
+    });
+
+    expect(getLoadMoreItemIds(items)).toEqual(["load-more-unified"]);
+  });
+
+  it("appends one unified backend load-more row in the by-workspace view", () => {
+    const items = buildByWorkspaceMenuItems({
+      unpinnedSessions: [
+        makeSession(
+          "cursoride-1",
+          "2026-06-09T00:00:00.000Z",
+          "/workspace/orgii"
+        ),
+      ],
+      repoPathToName: new Map([["/workspace/orgii", "ORGII"]]),
+      noWorkspaceLabel: "No Workspace",
+      appendPinnedSessions,
+      appendGroupSessions,
+      appendTrailingLoadMoreItems,
+    });
+
+    expect(getLoadMoreItemIds(items)).toEqual(["load-more-unified"]);
+  });
+
   it("does not append a backend load-more row when a time group has local hidden sessions", () => {
     // Use the current day so the sessions always land in the "today" group
     // regardless of when the suite runs (a fixed past date would drift into
@@ -95,6 +138,29 @@ describe("session menu section builders", () => {
     expect(getLoadMoreItemIds(items)).toEqual(["load-more-group-time:today"]);
   });
 
+  it("does not append a backend load-more row when a workspace group has local hidden sessions", () => {
+    const sessions = Array.from({ length: 11 }, (_, index) =>
+      makeSession(
+        `cursoride-${index}`,
+        "2026-06-09T00:00:00.000Z",
+        "/workspace/orgii"
+      )
+    );
+
+    const items = buildByWorkspaceMenuItems({
+      unpinnedSessions: sessions,
+      repoPathToName: new Map([["/workspace/orgii", "ORGII"]]),
+      noWorkspaceLabel: "No Workspace",
+      appendPinnedSessions,
+      appendGroupSessions,
+      appendTrailingLoadMoreItems,
+    });
+
+    expect(getLoadMoreItemIds(items)).toEqual([
+      "load-more-group-workspace:/workspace/orgii",
+    ]);
+  });
+
   it("does not append a backend load-more row below an agent group with local hidden sessions", () => {
     const sessions = Array.from({ length: 11 }, (_, index) =>
       makeSession(`cursoride-${index}`, "2026-06-09T00:00:00.000Z")
@@ -112,7 +178,7 @@ describe("session menu section builders", () => {
     ]);
   });
 
-  it("appends the backend load-more row after local hidden sessions are expanded", () => {
+  it("appends the per-category backend load-more row in the by-agent view", () => {
     const sessions = Array.from({ length: 10 }, (_, index) =>
       makeSession(`cursoride-${index}`, "2026-06-09T00:00:00.000Z")
     );

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/paginationHelpers.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/paginationHelpers.test.ts
@@ -98,6 +98,7 @@ describe("unified backend load-more helpers", () => {
     expect(state).toEqual({
       visible: true,
       loading: false,
+      disabled: false,
       readyCategories: [firstCategory, secondCategory],
     });
   });
@@ -114,17 +115,42 @@ describe("unified backend load-more helpers", () => {
 
     expect(state.visible).toBe(true);
     expect(state.loading).toBe(true);
+    expect(state.disabled).toBe(false);
     expect(state.readyCategories).toEqual([readyCategory]);
   });
 
-  it("builds a disabled unified row while loading", () => {
-    const row = unifiedLoadMoreRow(true, "Loading");
+  it("keeps the unified row enabled while loading when categories are ready", () => {
+    const readyCategory = SESSION_LIST_CATEGORIES[0] as SessionListCategory;
+    const state = getUnifiedLoadMoreState(
+      makePagination({
+        [readyCategory]: { loaded: 10, hasMore: true, loading: false },
+        [SESSION_LIST_CATEGORIES[1] as SessionListCategory]: {
+          loaded: 10,
+          hasMore: true,
+          loading: true,
+        },
+      })
+    );
+    const row = unifiedLoadMoreRow(state, "Loading");
 
     expect(row.id).toBe(UNIFIED_LOAD_MORE_ID);
     expect(row.key).toBe(UNIFIED_LOAD_MORE_ID);
     expect(row.label).toBe("Loading");
-    expect(row.disabled).toBe(true);
+    expect(row.disabled).toBe(false);
     expect(row.trailingElement).toBeDefined();
+  });
+
+  it("disables the unified row when every remaining category is already loading", () => {
+    const loadingCategory = SESSION_LIST_CATEGORIES[0] as SessionListCategory;
+    const state = getUnifiedLoadMoreState(
+      makePagination({
+        [loadingCategory]: { loaded: 10, hasMore: true, loading: true },
+      })
+    );
+    const row = unifiedLoadMoreRow(state, "Loading");
+
+    expect(state.disabled).toBe(true);
+    expect(row.disabled).toBe(true);
   });
 
   it("only matches the unified backend load-more id", () => {

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/paginationHelpers.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/paginationHelpers.test.ts
@@ -1,9 +1,21 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/components/NavigationMenu/config";
-import type { Session } from "@src/store/session";
+import {
+  SESSION_LIST_CATEGORIES,
+  type Session,
+  type SessionListCategory,
+  type SessionPaginationMap,
+} from "@src/store/session";
 
-import { appendSessionGroup } from "../paginationHelpers";
+import {
+  UNIFIED_LOAD_MORE_ID,
+  appendSessionGroup,
+  getUnifiedLoadMoreState,
+  isUnifiedLoadMoreId,
+  loadUnifiedReadyCategories,
+  unifiedLoadMoreRow,
+} from "../paginationHelpers";
 
 function makeSession(sessionId: string): Session {
   return {
@@ -20,6 +32,21 @@ function buildSessionRow(session: Session): NavigationMenuItem {
     key: session.session_id,
     label: session.session_id,
   };
+}
+
+function makePagination(
+  overrides: Partial<SessionPaginationMap> = {}
+): SessionPaginationMap {
+  return Object.fromEntries(
+    SESSION_LIST_CATEGORIES.map((category) => [
+      category,
+      overrides[category] ?? {
+        loaded: 0,
+        hasMore: false,
+        loading: false,
+      },
+    ])
+  ) as SessionPaginationMap;
 }
 
 describe("appendSessionGroup", () => {
@@ -54,5 +81,94 @@ describe("appendSessionGroup", () => {
       "osagent-1",
       "load-more-group-time:today",
     ]);
+  });
+});
+
+describe("unified backend load-more helpers", () => {
+  it("returns all ready categories while exposing one visible unified state", () => {
+    const firstCategory = SESSION_LIST_CATEGORIES[0] as SessionListCategory;
+    const secondCategory = SESSION_LIST_CATEGORIES[1] as SessionListCategory;
+    const state = getUnifiedLoadMoreState(
+      makePagination({
+        [firstCategory]: { loaded: 10, hasMore: true, loading: false },
+        [secondCategory]: { loaded: 10, hasMore: true, loading: false },
+      })
+    );
+
+    expect(state).toEqual({
+      visible: true,
+      loading: false,
+      readyCategories: [firstCategory, secondCategory],
+    });
+  });
+
+  it("excludes loading categories from ready categories and marks unified state loading", () => {
+    const loadingCategory = SESSION_LIST_CATEGORIES[0] as SessionListCategory;
+    const readyCategory = SESSION_LIST_CATEGORIES[1] as SessionListCategory;
+    const state = getUnifiedLoadMoreState(
+      makePagination({
+        [loadingCategory]: { loaded: 10, hasMore: true, loading: true },
+        [readyCategory]: { loaded: 10, hasMore: true, loading: false },
+      })
+    );
+
+    expect(state.visible).toBe(true);
+    expect(state.loading).toBe(true);
+    expect(state.readyCategories).toEqual([readyCategory]);
+  });
+
+  it("builds a disabled unified row while loading", () => {
+    const row = unifiedLoadMoreRow(true, "Loading");
+
+    expect(row.id).toBe(UNIFIED_LOAD_MORE_ID);
+    expect(row.key).toBe(UNIFIED_LOAD_MORE_ID);
+    expect(row.label).toBe("Loading");
+    expect(row.disabled).toBe(true);
+    expect(row.trailingElement).toBeDefined();
+  });
+
+  it("only matches the unified backend load-more id", () => {
+    expect(isUnifiedLoadMoreId(UNIFIED_LOAD_MORE_ID)).toBe(true);
+    expect(isUnifiedLoadMoreId("load-more-cursor_ide")).toBe(false);
+  });
+
+  it("loads every ready category and skips loading categories", async () => {
+    const loadingCategory = SESSION_LIST_CATEGORIES[0] as SessionListCategory;
+    const firstReadyCategory =
+      SESSION_LIST_CATEGORIES[1] as SessionListCategory;
+    const secondReadyCategory =
+      SESSION_LIST_CATEGORIES[2] as SessionListCategory;
+    const loadCategory = vi.fn(() => Promise.resolve());
+
+    const result = loadUnifiedReadyCategories({
+      pagination: makePagination({
+        [loadingCategory]: { loaded: 10, hasMore: true, loading: true },
+        [firstReadyCategory]: { loaded: 10, hasMore: true, loading: false },
+        [secondReadyCategory]: { loaded: 10, hasMore: true, loading: false },
+      }),
+      loadCategory,
+    });
+
+    expect(result).toBeInstanceOf(Promise);
+    await result;
+    expect(loadCategory).toHaveBeenCalledTimes(2);
+    expect(loadCategory).toHaveBeenNthCalledWith(1, firstReadyCategory);
+    expect(loadCategory).toHaveBeenNthCalledWith(2, secondReadyCategory);
+  });
+
+  it("does not load categories when the unified row is disabled", () => {
+    const readyCategory = SESSION_LIST_CATEGORIES[0] as SessionListCategory;
+    const loadCategory = vi.fn(() => Promise.resolve());
+
+    const result = loadUnifiedReadyCategories({
+      disabled: true,
+      pagination: makePagination({
+        [readyCategory]: { loaded: 10, hasMore: true, loading: false },
+      }),
+      loadCategory,
+    });
+
+    expect(result).toBeNull();
+    expect(loadCategory).not.toHaveBeenCalled();
   });
 });

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/index.tsx
@@ -32,11 +32,12 @@ import {
   buildByWorkspaceMenuItems,
 } from "./menuSectionBuilders";
 import {
-  LOAD_MORE_CATEGORIES,
   appendSessionGroup,
   getLoadMoreGroupId,
+  getUnifiedLoadMoreState,
   isLoadMoreId,
   loadMoreRow,
+  unifiedLoadMoreRow,
 } from "./paginationHelpers";
 import type {
   UseSessionMenuItemsParams,
@@ -176,13 +177,13 @@ export function useSessionMenuItems({
 
   const trailingLoadMoreItems = useMemo<NavigationMenuItem[]>(() => {
     if (isFiltering) return [];
-    const rows: NavigationMenuItem[] = [];
-    for (const category of LOAD_MORE_CATEGORIES) {
-      const row = loadMoreRowFor(category);
-      if (row) rows.push(row);
-    }
-    return rows;
-  }, [isFiltering, loadMoreRowFor]);
+    const state = getUnifiedLoadMoreState(pagination);
+    if (!state.visible) return [];
+    const label = state.loading
+      ? tCommon("sessions:chat.loading")
+      : tCommon("common:actions.loadMore");
+    return [unifiedLoadMoreRow(state.loading, label)];
+  }, [isFiltering, pagination, tCommon]);
 
   const appendTrailingLoadMoreItems = useCallback(
     (items: NavigationMenuItem[]) => {

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/index.tsx
@@ -182,7 +182,7 @@ export function useSessionMenuItems({
     const label = state.loading
       ? tCommon("sessions:chat.loading")
       : tCommon("common:actions.loadMore");
-    return [unifiedLoadMoreRow(state.loading, label)];
+    return [unifiedLoadMoreRow(state, label)];
   }, [isFiltering, pagination, tCommon]);
 
   const appendTrailingLoadMoreItems = useCallback(

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/paginationHelpers.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/paginationHelpers.tsx
@@ -2,7 +2,11 @@ import { MoreHorizontal } from "lucide-react";
 
 import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/components/NavigationMenu/config";
 import { SESSION_LIST_CATEGORIES } from "@src/store/session";
-import type { Session, SessionListCategory } from "@src/store/session";
+import type {
+  Session,
+  SessionListCategory,
+  SessionPaginationMap,
+} from "@src/store/session";
 
 import { LOAD_MORE_GROUP_PREFIX, LOAD_MORE_PREFIX } from "../types";
 import { DEFAULT_GROUP_VISIBLE_COUNT } from "./dateGroupingHelpers";
@@ -11,6 +15,19 @@ import type { BuildSessionRow } from "./types";
 
 export const LOAD_MORE_CATEGORIES: readonly SessionListCategory[] =
   SESSION_LIST_CATEGORIES;
+export const UNIFIED_LOAD_MORE_ID = "load-more-unified";
+
+interface UnifiedLoadMoreState {
+  visible: boolean;
+  loading: boolean;
+  readyCategories: SessionListCategory[];
+}
+
+interface LoadUnifiedReadyCategoriesParams {
+  disabled?: boolean;
+  pagination: SessionPaginationMap;
+  loadCategory: (category: SessionListCategory) => Promise<void>;
+}
 
 export function loadMoreRow(
   category: SessionListCategory,
@@ -46,15 +63,69 @@ export function groupLoadMoreRow(
   };
 }
 
+export function unifiedLoadMoreRow(
+  loading: boolean,
+  label: string
+): NavigationMenuItem {
+  return {
+    id: UNIFIED_LOAD_MORE_ID,
+    key: UNIFIED_LOAD_MORE_ID,
+    label,
+    icon: MoreHorizontal,
+    iconName: "more-horizontal",
+    trailingElement: loading ? renderBreathingStatusDot() : undefined,
+    visualTone: "secondary",
+    disabled: loading,
+  };
+}
+
 export function isLoadMoreId(id: string): SessionListCategory | null {
   if (!id.startsWith(LOAD_MORE_PREFIX)) return null;
   const category = id.slice(LOAD_MORE_PREFIX.length) as SessionListCategory;
   return SESSION_LIST_CATEGORIES.includes(category) ? category : null;
 }
 
+export function isUnifiedLoadMoreId(id: string): boolean {
+  return id === UNIFIED_LOAD_MORE_ID;
+}
+
 export function getLoadMoreGroupId(id: string): string | null {
   if (!id.startsWith(LOAD_MORE_GROUP_PREFIX)) return null;
   return id.slice(LOAD_MORE_GROUP_PREFIX.length) || null;
+}
+
+export function getUnifiedLoadMoreState(
+  pagination: SessionPaginationMap
+): UnifiedLoadMoreState {
+  let visible = false;
+  let loading = false;
+  const readyCategories: SessionListCategory[] = [];
+
+  for (const category of LOAD_MORE_CATEGORIES) {
+    const state = pagination[category];
+    if (state.loading) {
+      visible = true;
+      loading = true;
+      continue;
+    }
+    if (state.hasMore) {
+      visible = true;
+      readyCategories.push(category);
+    }
+  }
+
+  return { visible, loading, readyCategories };
+}
+
+export function loadUnifiedReadyCategories({
+  disabled,
+  pagination,
+  loadCategory,
+}: LoadUnifiedReadyCategoriesParams): Promise<void[]> | null {
+  if (disabled) return null;
+  const { readyCategories } = getUnifiedLoadMoreState(pagination);
+  if (readyCategories.length === 0) return null;
+  return Promise.all(readyCategories.map((category) => loadCategory(category)));
 }
 
 interface AppendSessionGroupParams {

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/paginationHelpers.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/paginationHelpers.tsx
@@ -20,6 +20,7 @@ export const UNIFIED_LOAD_MORE_ID = "load-more-unified";
 interface UnifiedLoadMoreState {
   visible: boolean;
   loading: boolean;
+  disabled: boolean;
   readyCategories: SessionListCategory[];
 }
 
@@ -64,7 +65,7 @@ export function groupLoadMoreRow(
 }
 
 export function unifiedLoadMoreRow(
-  loading: boolean,
+  state: UnifiedLoadMoreState,
   label: string
 ): NavigationMenuItem {
   return {
@@ -73,9 +74,9 @@ export function unifiedLoadMoreRow(
     label,
     icon: MoreHorizontal,
     iconName: "more-horizontal",
-    trailingElement: loading ? renderBreathingStatusDot() : undefined,
+    trailingElement: state.loading ? renderBreathingStatusDot() : undefined,
     visualTone: "secondary",
-    disabled: loading,
+    disabled: state.disabled,
   };
 }
 
@@ -114,7 +115,12 @@ export function getUnifiedLoadMoreState(
     }
   }
 
-  return { visible, loading, readyCategories };
+  return {
+    visible,
+    loading,
+    disabled: readyCategories.length === 0,
+    readyCategories,
+  };
 }
 
 export function loadUnifiedReadyCategories({

--- a/src/scaffold/NavigationSidebar/connectors/useWorkstationSidebarHandlers.ts
+++ b/src/scaffold/NavigationSidebar/connectors/useWorkstationSidebarHandlers.ts
@@ -1,6 +1,6 @@
 import { save as saveDialog } from "@tauri-apps/plugin-dialog";
 import { writeTextFile } from "@tauri-apps/plugin-fs";
-import { useSetAtom } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import { type Dispatch, type SetStateAction, useCallback } from "react";
 
 import { deleteSession } from "@src/api/tauri/agent";
@@ -21,6 +21,7 @@ import {
   type SessionListCategory,
   loadMoreCategory,
   removeSession,
+  sessionPaginationAtom,
   upsertSession,
 } from "@src/store/session";
 import {
@@ -35,6 +36,10 @@ import {
   NEW_SESSION_MENU_ITEM_ID,
   getDraftIdFromMenuItemId,
 } from "./sidebarConnectorUtils";
+import {
+  isUnifiedLoadMoreId,
+  loadUnifiedReadyCategories,
+} from "./useSessionMenuItems/paginationHelpers";
 
 const log = createLogger("WorkstationSidebar");
 
@@ -86,6 +91,7 @@ export function useWorkstationSidebarHandlers({
   const setBenchmarkActiveBatchTaskId = useSetAtom(
     benchmarkActiveBatchTaskIdAtom
   );
+  const pagination = useAtomValue(sessionPaginationAtom);
   const handleDeleteSession = useCallback(
     async (sessionId: string) => {
       try {
@@ -156,6 +162,15 @@ export function useWorkstationSidebarHandlers({
         return;
       }
 
+      if (isUnifiedLoadMoreId(item.id)) {
+        void loadUnifiedReadyCategories({
+          disabled: item.disabled,
+          pagination,
+          loadCategory: loadMoreCategoryAction,
+        });
+        return;
+      }
+
       const loadMoreGroupId = getLoadMoreGroupId(item.id);
       if (loadMoreGroupId) {
         setGroupVisibleCounts((previousCounts) => {
@@ -209,6 +224,7 @@ export function useWorkstationSidebarHandlers({
     [
       getLoadMoreGroupId,
       isLoadMoreId,
+      pagination,
       sessionMap,
       openSession,
       goToNewSession,


### PR DESCRIPTION
## Summary

- Fix duplicate `Load more` rows in grouped sidebar views by replacing them with one unified button that loads all ready backend categories.
- fix #208

## Test plan

- [x] `pnpm vitest run src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/paginationHelpers.test.ts src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/menuSectionBuilders.test.ts`
- [x] ESLint passed for the changed source and test files.
- [x] `git diff --check`
- [x] Locally verified the sidebar behavior: grouped views show one unified `Load more` row, by-agent keeps per-category rows, and the unified row loads all ready backend categories.
- [ ] `pnpm exec tsc --noEmit` currently fails on pre-existing unrelated type errors:
  - `src/modules/MainApp/Settings/SettingsSlot.tsx`
  - `src/modules/WorkStation/TabContent/renderers/githubIssueDetail.tsx`
  - `src/services/context/appUiSnapshot.ts`

## Submit checklist

- [x] The PR is focused and has a scoped Conventional Commits title, such as `fix(sidebar): unify grouped load more row`.
- [x] I ran the relevant checks, or explained why they were not run.
- [x] No secrets, private config, generated output, or unrelated formatting changes are included.
- [x] Docs, screenshots, and locale updates are included when the change needs them.
