### PR TITLE
fix(agent): wake idle parent on subagent completion; unblock turn end

### DIFF
--- a/src-tauri/crates/agent-core/src/core/model_context/session_memory/extract.rs
+++ b/src-tauri/crates/agent-core/src/core/model_context/session_memory/extract.rs
@@ -5,7 +5,10 @@
 //! - [`find_last_safe_boundary`] — picks the highest message index safe to mark
 //!   as the SM boundary (avoids splitting a tool_use → tool_result pair)
 
+use std::sync::Arc;
+
 use serde_json::Value;
+use tokio::sync::Mutex;
 use tracing::{info, warn};
 
 use super::config::SessionMemoryConfig;
@@ -94,19 +97,30 @@ pub fn should_extract(
 /// content, and recent messages. Returns the updated SM markdown.
 pub async fn extract_session_memory(
     messages: &[Value],
-    state: &mut SessionMemoryState,
+    sm_state: Arc<Mutex<SessionMemoryState>>,
     config: &SessionMemoryConfig,
     provider: &dyn LLMProvider,
     model: &str,
 ) -> Result<String, String> {
     use crate::core::model_context::summarization;
 
-    state.extraction_in_progress = true;
-
-    let start_idx = state
-        .last_summarized_msg_idx
-        .map(|idx| idx + 1)
-        .unwrap_or(0);
+    // ── Prepare: brief lock to snapshot the read-side state + flag the
+    // extraction as in-progress. The mutex is NOT held across the LLM call
+    // below — otherwise the next turn's brief `sm_state` reads (pre-turn
+    // compaction, the gate pre-check) would block for the whole extraction.
+    let (start_idx, existing_content, consumed_tool_calls) = {
+        let mut state = sm_state.lock().await;
+        state.extraction_in_progress = true;
+        let start_idx = state
+            .last_summarized_msg_idx
+            .map(|idx| idx + 1)
+            .unwrap_or(0);
+        (
+            start_idx,
+            state.content.clone(),
+            state.tool_calls_since_extraction,
+        )
+    };
 
     let new_messages = if start_idx < messages.len() {
         &messages[start_idx..]
@@ -116,7 +130,7 @@ pub async fn extract_session_memory(
 
     let mut user_content = String::new();
 
-    let section_reminders = if let Some(ref existing) = state.content {
+    let section_reminders = if let Some(ref existing) = existing_content {
         user_content.push_str("<current_session_memory>\n");
         user_content.push_str(existing);
         user_content.push_str("\n</current_session_memory>\n\n");
@@ -209,6 +223,11 @@ pub async fn extract_session_memory(
 
     let result = side_query::side_query(provider, &user_messages, &sq_config, model).await;
 
+    // ── Finalize: brief lock to merge the result back. Concurrent
+    // `record_tool_calls` increments that arrived while the LLM was running
+    // are preserved by subtracting only what we consumed at prepare time,
+    // rather than blindly resetting the counter to 0.
+    let mut state = sm_state.lock().await;
     state.extraction_in_progress = false;
 
     match result {
@@ -226,7 +245,9 @@ pub async fn extract_session_memory(
             };
             state.content = Some(sm_content.clone());
             state.tokens_at_last_extraction = tokenizer::count_messages_tokens(messages);
-            state.tool_calls_since_extraction = 0;
+            state.tool_calls_since_extraction = state
+                .tool_calls_since_extraction
+                .saturating_sub(consumed_tool_calls);
             state.initialized = true;
 
             if let Some(last_safe_idx) = find_last_safe_boundary(messages) {

--- a/src-tauri/crates/agent-core/src/core/session/turn/post_turn.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/post_turn.rs
@@ -79,39 +79,54 @@ pub(super) async fn spawn_session_memory_extraction(input: SessionMemoryExtracti
         fork_provider,
     } = input;
 
-    let current_tokens = if prompt_tokens > 0 {
-        prompt_tokens as usize
-    } else {
-        crate::model_context::tokenizer::count_messages_tokens(messages)
-    };
-    let has_tool_calls = session_memory::last_turn_has_tool_calls(messages);
-    let mut sm_state_guard = sm_state.lock().await;
-
-    sm_state_guard.record_tool_calls(tool_calls_count as usize);
-
-    if !session_memory::should_extract(&sm_state_guard, &sm_config, current_tokens, has_tool_calls)
-    {
-        return;
-    }
-
-    info!(
-        "[unified_processor] Spawning async SM extraction for session {} (tokens={}, tc_since={})",
-        session_id, current_tokens, sm_state_guard.tool_calls_since_extraction
-    );
-    drop(sm_state_guard);
-
+    // Everything below — including the `sm_state.lock()` gate pre-check —
+    // runs inside a detached task. This is the turn-completion hot path:
+    // `dispatch_post_turn_work` awaits this fn and the scheduler only emits
+    // the idle queue-status (which hides the "Planning…" footer) AFTER
+    // `process()` returns. The previous version `await`ed the `sm_state.lock()`
+    // pre-check directly here, so when the PRIOR turn's extractor still held
+    // that lock across its (up-to-60s) LLM round-trip, this turn's completion
+    // signal was blocked for the whole extraction. Spawning the entire body
+    // keeps the function a true fire-and-forget so completion is instant.
     let sm_messages = messages.to_vec();
     let sm_session_id = session_id.to_string();
 
     tokio::spawn(async move {
+        let current_tokens = if prompt_tokens > 0 {
+            prompt_tokens as usize
+        } else {
+            crate::model_context::tokenizer::count_messages_tokens(&sm_messages)
+        };
+        let has_tool_calls = session_memory::last_turn_has_tool_calls(&sm_messages);
+        let mut sm_state_guard = sm_state.lock().await;
+
+        sm_state_guard.record_tool_calls(tool_calls_count as usize);
+
+        if !session_memory::should_extract(
+            &sm_state_guard,
+            &sm_config,
+            current_tokens,
+            has_tool_calls,
+        ) {
+            return;
+        }
+
+        info!(
+            "[unified_processor] Spawning async SM extraction for session {} (tokens={}, tc_since={})",
+            sm_session_id, current_tokens, sm_state_guard.tool_calls_since_extraction
+        );
+        drop(sm_state_guard);
+
         const SM_TIMEOUT: Duration = Duration::from_secs(60);
 
         let extraction = async {
             let provider = fresh_fork_provider(&fork_provider).await?;
-            let mut state = sm_state.lock().await;
+            // `extract_session_memory` now manages the `sm_state` lock
+            // internally (brief prepare + finalize, never across the LLM
+            // call), so we pass the Arc instead of holding the guard here.
             let result = session_memory::extract_session_memory(
                 &sm_messages,
-                &mut state,
+                sm_state.clone(),
                 &sm_config,
                 provider.as_ref(),
                 &fork_provider.model,
@@ -121,7 +136,7 @@ pub(super) async fn spawn_session_memory_extraction(input: SessionMemoryExtracti
             if let Ok(ref sm_content) = result {
                 let sid = sm_session_id.clone();
                 let content = sm_content.clone();
-                let last_idx = state.last_summarized_msg_idx;
+                let last_idx = sm_state.lock().await.last_summarized_msg_idx;
                 tokio::task::block_in_place(|| {
                     if let Err(err) =
                         unified_persistence::save_session_memory_state(&sid, &content, last_idx)
@@ -219,6 +234,54 @@ pub(super) async fn spawn_extract_memories(input: ExtractMemoriesInput<'_>) {
     }
     let messages = em_messages;
 
+    // Everything below — including the gate pre-checks that lock `em_state` —
+    // runs inside a detached task. This is the turn-completion hot path:
+    // `dispatch_post_turn_work` awaits this fn, and the scheduler only
+    // broadcasts the idle queue-status (which hides the "Planning…" footer)
+    // AFTER `process()` returns. The previous version `await`ed the
+    // `em_state.lock()` gate pre-checks directly here, so when the PRIOR
+    // turn's extractor still held that lock across its (minutes-long) LLM
+    // round-trip, this turn's completion signal was blocked for the whole
+    // extraction — the footer kept spinning "Figuring out what to do next…"
+    // long after the agent had clearly finished. Spawning the entire body
+    // keeps the function a true fire-and-forget so completion is instant.
+    let sid = session_id.to_string();
+    tokio::spawn(async move {
+        run_extract_memories_task(RunExtractMemoriesTask {
+            session_id: sid,
+            ws_path,
+            messages,
+            em_state,
+            fork_provider,
+            tool_registry,
+        })
+        .await;
+    });
+}
+
+struct RunExtractMemoriesTask {
+    session_id: String,
+    ws_path: PathBuf,
+    messages: Vec<Value>,
+    em_state: Arc<Mutex<ExtractMemoriesState>>,
+    fork_provider: ForkProviderSpec,
+    tool_registry: Arc<ToolRegistry>,
+}
+
+/// Owned-data body of [`spawn_extract_memories`], run inside a detached task.
+///
+/// Performs the gate pre-checks (Stages 1–2) and then the extraction loop.
+/// All `em_state` lock contention lives here, off the turn-completion path.
+async fn run_extract_memories_task(task: RunExtractMemoriesTask) {
+    let RunExtractMemoriesTask {
+        session_id,
+        ws_path,
+        messages,
+        em_state,
+        fork_provider,
+        tool_registry,
+    } = task;
+
     // Stage 1: main agent wrote memory → skip + advance cursor.
     let main_wrote = {
         let mut state = em_state.lock().await;
@@ -252,59 +315,61 @@ pub(super) async fn spawn_extract_memories(input: ExtractMemoriesInput<'_>) {
         return;
     }
 
-    let sid = session_id.to_string();
+    let sid = session_id;
     info!(
         "[unified_processor] Spawning extract_memories for session {}",
         sid
     );
 
-    tokio::spawn(async move {
-        // Loop until no pending trailing transcript remains. Each
-        // iteration runs the extractor on the current transcript and, if
-        // a new transcript was stashed while we were running, picks it up
-        // on the next pass — guaranteeing every transcript is processed
-        // even when extractions arrive faster than they finish.
-        let mut current_msgs = messages;
-        loop {
-            {
-                let mut state = em_state.lock().await;
-                let provider = match fresh_fork_provider(&fork_provider).await {
-                    Ok(provider) => provider,
-                    Err(err) => {
-                        warn!("[extract_memories] Failed for session {}: {}", sid, err);
-                        break;
-                    }
-                };
-                let params = crate::memory::MemoryAgentParams {
-                    messages: &current_msgs,
-                    provider,
-                    model: &fork_provider.model,
-                    workspace: &ws_path,
-                    parent_tools: tool_registry.clone(),
-                    session_id: &sid,
-                    definitions_store: None,
-                };
-                if let Err(err) = extract_memories::run_extraction(&mut state, params).await {
-                    warn!("[extract_memories] Failed for session {}: {}", sid, err);
-                    // Still drain pending to avoid stashed work becoming stuck.
-                }
+    // Already inside a detached task (see `spawn_extract_memories`); run the
+    // extraction loop inline. Loop until no pending trailing transcript
+    // remains. Each iteration runs the extractor on the current transcript
+    // and, if a new transcript was stashed while we were running, picks it up
+    // on the next pass — guaranteeing every transcript is processed even when
+    // extractions arrive faster than they finish.
+    let mut current_msgs = messages;
+    loop {
+        // `fresh_fork_provider` and `run_extraction` both run WITHOUT holding
+        // `em_state` — provider creation can do a network preflight and the
+        // extractor runs a multi-iteration forked agent, neither of which may
+        // block the next turn's brief `em_state` reads. `run_extraction`
+        // manages the lock internally (brief prepare + finalize).
+        let provider = match fresh_fork_provider(&fork_provider).await {
+            Ok(provider) => provider,
+            Err(err) => {
+                warn!("[extract_memories] Failed for session {}: {}", sid, err);
+                em_state.lock().await.clear_in_progress();
+                break;
             }
-            let trailing = {
-                let mut state = em_state.lock().await;
-                extract_memories::take_pending(&mut state)
-            };
-            match trailing {
-                Some(next) => {
-                    info!(
-                        "[extract_memories] Running trailing extraction for session {}",
-                        sid
-                    );
-                    current_msgs = next;
-                }
-                None => break,
-            }
+        };
+        let params = crate::memory::MemoryAgentParams {
+            messages: &current_msgs,
+            provider,
+            model: &fork_provider.model,
+            workspace: &ws_path,
+            parent_tools: tool_registry.clone(),
+            session_id: &sid,
+            definitions_store: None,
+        };
+        if let Err(err) = extract_memories::run_extraction(em_state.clone(), params).await {
+            warn!("[extract_memories] Failed for session {}: {}", sid, err);
+            // Still drain pending to avoid stashed work becoming stuck.
         }
-    });
+        let trailing = {
+            let mut state = em_state.lock().await;
+            extract_memories::take_pending(&mut state)
+        };
+        match trailing {
+            Some(next) => {
+                info!(
+                    "[extract_memories] Running trailing extraction for session {}",
+                    sid
+                );
+                current_msgs = next;
+            }
+            None => break,
+        }
+    }
 }
 
 // ── Auto-dream consolidation (step 9d) ──────────────────────────────
@@ -330,39 +395,45 @@ pub(super) async fn spawn_auto_dream(input: AutoDreamInput<'_>) {
         tool_registry,
     } = input;
 
-    let should_run = {
-        let state = ad_state.lock().await;
-        auto_dream::should_attempt(&state, &ws_path)
-    };
-    if !should_run {
-        return;
-    }
-
+    // Everything below — including the `ad_state.lock()` gate pre-check —
+    // runs inside a detached task. This is the turn-completion hot path:
+    // `dispatch_post_turn_work` awaits this fn and the scheduler only emits
+    // the idle queue-status (which hides the "Planning…" footer) AFTER
+    // `process()` returns. The previous version `await`ed the `ad_state.lock()`
+    // pre-check directly here, so when the PRIOR turn's consolidation still
+    // held that lock across its (minutes-long) LLM round-trip, this turn's
+    // completion signal was blocked. Spawning the entire body keeps the
+    // function a true fire-and-forget so completion is instant.
     let sid = session_id.to_string();
-    info!(
-        "[unified_processor] Spawning auto_dream for session {}",
-        sid
-    );
-
     tokio::spawn(async move {
-        let provider = match fresh_fork_provider(&fork_provider).await {
-            Ok(provider) => provider,
-            Err(err) => {
-                warn!("[auto_dream] Failed for session {}: {}", sid, err);
+        // Brief lock ONLY for the throttle gate + advance — never held across
+        // the consolidation LLM call below.
+        {
+            let mut state = ad_state.lock().await;
+            if !auto_dream::should_attempt(&state, &ws_path) {
                 return;
             }
-        };
-        let mut state = ad_state.lock().await;
+            state.mark_scan_now();
+        }
+
+        info!("[unified_processor] Spawning auto_dream for session {}", sid);
+
         let params = crate::memory::MemoryAgentParams {
             messages: &messages,
-            provider,
+            provider: match fresh_fork_provider(&fork_provider).await {
+                Ok(provider) => provider,
+                Err(err) => {
+                    warn!("[auto_dream] Failed for session {}: {}", sid, err);
+                    return;
+                }
+            },
             model: &fork_provider.model,
             workspace: &ws_path,
             parent_tools: tool_registry,
             session_id: &sid,
             definitions_store: None,
         };
-        if let Err(err) = auto_dream::run_consolidation(&mut state, params).await {
+        if let Err(err) = auto_dream::run_consolidation(params).await {
             warn!("[auto_dream] Failed for session {}: {}", sid, err);
         }
     });

--- a/src-tauri/crates/agent-core/src/core/session/turn/processor/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/processor/mod.rs
@@ -638,6 +638,24 @@ impl UnifiedMessageProcessor {
         if let Some(guard) = inbox_guard.take() {
             guard.commit();
         }
+
+        // 4d. Subagent-wake prefill safety net.
+        //
+        // A background-subagent completion resumes the parent with empty
+        // content (no persisted user row → same round, no new bubble). But a
+        // plain SDE session has no inbox_drain to append a trailing user
+        // message, so the conversation can still end on the parent's last
+        // assistant turn ("已在后台启动。"). Providers (Anthropic, OpenAI)
+        // reject that with HTTP 400 "conversation must end with a user
+        // message". When a resume leaves an assistant-tailed message list,
+        // append a single TRANSIENT user nudge — in-memory only, never
+        // persisted, so it neither creates a round nor a visible bubble.
+        // Mirrors inbox_drain's transient injection, generalized to the SDE
+        // path.
+        if context.is_resume {
+            Self::inject_subagent_wake_nudge_if_needed(&mut messages, session_id);
+        }
+
         // 5/5b/6. Pre-turn message-list compaction (microcompact +
         // aggregate budget + LLM context compaction + compact-fork).
         if let CompactionPhaseOutcome::ForkRedirect(redirect) = self
@@ -756,6 +774,47 @@ impl UnifiedMessageProcessor {
             turn_summary: None,
             fork_redirect: None,
         })
+    }
+
+    /// Append a transient, in-memory-only trailing user message when a resumed
+    /// turn's assembled message list still ends on an assistant turn.
+    ///
+    /// Background-subagent wakes resume the parent with empty content (so no
+    /// user row is persisted and no new round is created), but a plain SDE
+    /// session has no inbox_drain to supply the trailing user message that
+    /// providers require ("conversation must end with a user message"). This
+    /// closes that gap without persisting anything: the nudge lives only in
+    /// the provider request, never in the DB or the UI, so the parent
+    /// continues in the SAME round with no synthetic bubble.
+    ///
+    /// No-op unless the last non-system message is an assistant message —
+    /// normal resumes (e.g. mode-switch) that already end on a user or tool
+    /// message are left untouched.
+    fn inject_subagent_wake_nudge_if_needed(messages: &mut Vec<Value>, session_id: &str) {
+        let last_non_system_role = messages
+            .iter()
+            .rev()
+            .find_map(|m| m.get("role").and_then(|v| v.as_str()))
+            .filter(|role| *role != "system");
+
+        if last_non_system_role != Some("assistant") {
+            return;
+        }
+
+        const WAKE_NUDGE: &str = "<system-reminder>A background subagent you launched has \
+            finished. Its result is now available in the Background Jobs list above. Read the \
+            completed worker's output and continue the task you were doing — do not re-launch \
+            it.</system-reminder>";
+
+        messages.push(serde_json::json!({
+            "role": "user",
+            "content": WAKE_NUDGE,
+        }));
+
+        info!(
+            "[unified_processor] Injected transient subagent-wake nudge to satisfy prefill (session={})",
+            session_id
+        );
     }
 }
 

--- a/src-tauri/crates/agent-core/src/core/tools/impls/coding/exec/await_tool/commands.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/coding/exec/await_tool/commands.rs
@@ -11,8 +11,8 @@ use tokio::time::Instant;
 use super::super::registry;
 use super::body::{find_match_line, read_body};
 use super::params::{
-    lookup_job, parse_handles, parse_tail_lines, parse_wait_mode, WaitMode, DEFAULT_BLOCK_MS,
-    POLL_INTERVAL_MS,
+    parse_handles, parse_tail_lines, parse_wait_mode, resolve_job_or_unknown, WaitMode,
+    DEFAULT_BLOCK_MS, POLL_INTERVAL_MS,
 };
 use super::response::{build_list_response, build_response};
 use super::snapshot::{running_snapshot, terminal_snapshot, HandleSnapshot, AWAIT_STATUS_RUNNING};
@@ -52,10 +52,13 @@ impl AwaitTool {
             None
         };
 
-        // Resolve all handles up-front so missing ones fail fast with a clean error.
+        // Resolve all handles up-front. A vanished-but-tombstoned handle
+        // resolves to its real terminal status (precise "it finished"); a
+        // genuinely unknown handle returns an error so the agent learns it
+        // mistyped, instead of being told a non-existent job "completed".
         let jobs: Vec<(String, registry::JobKind)> = handles
             .iter()
-            .map(|h| lookup_job(h).map(|(_, kind)| (h.clone(), kind)))
+            .map(|h| resolve_job_or_unknown(h).map(|(_, kind)| (h.clone(), kind)))
             .collect::<Result<_, _>>()?;
 
         // Non-blocking call (block_until_ms=0): return immediate snapshots.
@@ -191,7 +194,13 @@ impl AwaitTool {
                     }
                     None => {
                         registry::acknowledge_output(h);
-                        terminal_snapshot(h, kind, &registry::JobStatus::Completed, body)
+                        // Reaped between resolution and now: use the tombstoned
+                        // terminal status when available (precise), else fall
+                        // back to Completed (the job is gone, so it's done).
+                        let status = registry::resolve_status_with_tombstone(h)
+                            .map(|(s, _)| s)
+                            .unwrap_or(registry::JobStatus::Completed);
+                        terminal_snapshot(h, kind, &status, body)
                     }
                     Some(_) => {
                         let matched = regex.as_ref().map(|re| re.is_match(&body));
@@ -244,7 +253,10 @@ impl AwaitTool {
         let snapshots: Vec<HandleSnapshot> = handles
             .iter()
             .map(|h| {
-                let (status, kind) = lookup_job(h)?;
+                // A reaped-but-tombstoned job renders with its real terminal
+                // status; a genuinely unknown handle errors so the agent learns
+                // it mistyped rather than seeing a fake "completed".
+                let (status, kind) = resolve_job_or_unknown(h)?;
                 let body = read_body(h, &kind);
                 if !matches!(status, registry::JobStatus::Running) {
                     registry::acknowledge_output(h);

--- a/src-tauri/crates/agent-core/src/core/tools/impls/coding/exec/await_tool/params.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/coding/exec/await_tool/params.rs
@@ -101,12 +101,27 @@ pub(super) fn parse_tail_lines(params: &Value) -> usize {
         .unwrap_or(DEFAULT_TAIL_LINES)
 }
 
-pub(super) fn lookup_job(
+/// Resolve a handle's status + kind, consulting the tombstone map for jobs
+/// that already finished and were reaped from the live registry.
+///
+/// Three outcomes (see [`registry::resolve_status_with_tombstone`]):
+/// - live job → its real `(status, kind)`.
+/// - reaped-but-tombstoned job → its real terminal `(status, kind)` — a precise
+///   "it finished" answer (kind is the actual recorded kind, not a guess).
+/// - genuinely unknown handle → `Err`, so the caller reports a real error
+///   instead of pretending a typo'd handle "completed".
+///
+/// This replaces the earlier lenient resolver that synthesised a `Completed`
+/// status and *guessed* the kind from the handle shape, which could not tell a
+/// just-reaped job from a mistyped handle.
+pub(super) fn resolve_job_or_unknown(
     handle: &str,
 ) -> Result<(registry::JobStatus, registry::JobKind), ToolError> {
-    registry::get_status(handle).ok_or_else(|| {
+    registry::resolve_status_with_tombstone(handle).ok_or_else(|| {
         ToolError::ExecutionFailed(format!(
-            "No background job with handle \"{}\". It may have already completed and been cleaned up.",
+            "No background job with handle \"{}\". The handle is unknown — it was never \
+             registered, or it finished long enough ago that its record has expired. \
+             Check the handle, or call await_output(command=\"list\") to see active jobs.",
             handle
         ))
     })

--- a/src-tauri/crates/agent-core/src/core/tools/impls/coding/exec/registry.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/coding/exec/registry.rs
@@ -76,6 +76,17 @@ pub struct BackgroundJob {
     /// from the per-turn system reminder to avoid the stale-reminder
     /// problem common to background bash notifications.
     output_acknowledged: bool,
+    /// Set to `true` once a parent-session wake has been dispatched to deliver
+    /// this (completed) subagent's result. Distinct from `output_acknowledged`:
+    /// dispatch means "we resumed the idle parent so it COULD read the result",
+    /// ack means "the agent actually read it via await_output". Together they
+    /// make the subagent-wake coordinator behaviour-independent and exactly-once:
+    /// a result triggers AT MOST ONE wake dispatch, regardless of whether the
+    /// woken agent goes on to read it. This single flag subsumes both the
+    /// empty-wake loop (woken parent ignores the result → no re-wake) and the
+    /// retry storm (a failed wake turn → no re-wake for the same result).
+    /// Always `false` for shell jobs (only subagents trigger parent wakes).
+    wake_dispatched: bool,
 }
 
 impl BackgroundJob {
@@ -131,6 +142,27 @@ const BROADCAST_CAPACITY: usize = 512;
 static REGISTRY: LazyLock<Mutex<HashMap<String, BackgroundJob>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
+/// How long a finished job's tombstone is retained after it leaves the live
+/// registry. Long enough that an `await_output` arriving just after the grace
+/// eviction still gets a precise "completed" answer (with the real kind), short
+/// enough that the map cannot grow unbounded. Distinct from the live-job
+/// retention window in `background.rs`.
+const TOMBSTONE_TTL: std::time::Duration = std::time::Duration::from_secs(10 * 60);
+
+/// A lightweight record of a job that has left the live registry. Lets
+/// `await_output` distinguish "this handle finished and was reaped" (precise
+/// terminal status + real kind) from "this handle never existed" (the agent
+/// mistyped it), instead of synthesising a guess from the handle string.
+#[derive(Clone)]
+struct Tombstone {
+    status: JobStatus,
+    kind: JobKind,
+    created_at: Instant,
+}
+
+static TOMBSTONES: LazyLock<Mutex<HashMap<String, Tombstone>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
 /// Register a backgrounded shell process. Returns a `broadcast::Sender` the
 /// caller should use to feed live output lines.
 pub fn register_shell(
@@ -155,6 +187,7 @@ pub fn register_shell(
         join_handle: None,
         cancel_flag: None,
         output_acknowledged: false,
+        wake_dispatched: false,
     };
     let mut reg = REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
     reg.insert(handle, job);
@@ -215,6 +248,7 @@ pub fn register_subagent_with_flag(
         join_handle: None,
         cancel_flag: Some(Arc::clone(&cancel_flag)),
         output_acknowledged: false,
+        wake_dispatched: false,
     };
     let mut reg = REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
     reg.insert(handle.clone(), job);
@@ -293,9 +327,30 @@ pub fn set_final_result(handle: &str, result: String) {
 }
 
 /// Remove a job from the registry (called after grace period).
+///
+/// Leaves a short-lived [`Tombstone`] behind so a late `await_output` can
+/// still report a precise terminal status with the real job kind, rather than
+/// the caller having to guess from the handle shape. Opportunistically prunes
+/// expired tombstones on the same pass so the map stays bounded without a
+/// dedicated reaper.
 pub fn remove(handle: &str) {
-    let mut reg = REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
-    reg.remove(handle);
+    let removed = {
+        let mut reg = REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+        reg.remove(handle)
+    };
+    if let Some(job) = removed {
+        let mut tombs = TOMBSTONES.lock().unwrap_or_else(|e| e.into_inner());
+        let now = Instant::now();
+        tombs.retain(|_, t| now.duration_since(t.created_at) < TOMBSTONE_TTL);
+        tombs.insert(
+            handle.to_string(),
+            Tombstone {
+                status: job.status.clone(),
+                kind: job.kind.clone(),
+                created_at: now,
+            },
+        );
+    }
 }
 
 /// Retrieve a snapshot of job metadata. Returns `None` if not found.
@@ -303,6 +358,33 @@ pub fn get_status(handle: &str) -> Option<(JobStatus, JobKind)> {
     let reg = REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
     reg.get(handle)
         .map(|job| (job.status.clone(), job.kind.clone()))
+}
+
+/// Resolve a handle's terminal status + kind, consulting the tombstone map
+/// when the job has already left the live registry.
+///
+/// Three-way outcome:
+/// - **live job present** → its real `(status, kind)`.
+/// - **tombstone present (not expired)** → the reaped job's real terminal
+///   `(status, kind)` — a precise "it finished" answer.
+/// - **neither** → `None`, meaning the handle genuinely never existed (or its
+///   tombstone expired): the caller can report a real "unknown handle" error.
+///
+/// This replaces the old "synthesise a Completed status and guess the kind from
+/// the handle string" heuristic, which could not tell a just-reaped job from a
+/// typo.
+pub fn resolve_status_with_tombstone(handle: &str) -> Option<(JobStatus, JobKind)> {
+    if let Some(found) = get_status(handle) {
+        return Some(found);
+    }
+    let tombs = TOMBSTONES.lock().unwrap_or_else(|e| e.into_inner());
+    tombs.get(handle).and_then(|t| {
+        if Instant::now().duration_since(t.created_at) < TOMBSTONE_TTL {
+            Some((t.status.clone(), t.kind.clone()))
+        } else {
+            None
+        }
+    })
 }
 
 /// Get the final result text for a job.
@@ -353,6 +435,14 @@ pub fn acknowledge_output(handle: &str) {
     }
 }
 
+/// Whether a job's output has been acknowledged (read via the reminder /
+/// await path). Returns `None` if the handle is no longer in the registry —
+/// callers treat a missing job as "nothing left to retain" (acknowledged).
+pub fn is_output_acknowledged(handle: &str) -> Option<bool> {
+    let reg = REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+    reg.get(handle).map(|job| job.output_acknowledged)
+}
+
 /// List jobs that should appear in the per-turn system reminder.
 ///
 /// Includes:
@@ -369,6 +459,65 @@ pub fn list_jobs_for_reminder(session_id: &str) -> Vec<JobSnapshot> {
         })
         .map(|job| job.snapshot())
         .collect()
+}
+
+/// Atomically claim every completed-but-unconsumed **subagent** job for
+/// `session_id` that has not already had a parent wake dispatched, marking
+/// each as `wake_dispatched` and returning whether any were claimed.
+///
+/// This is the single exactly-once primitive behind the subagent-wake
+/// coordinator. "Needs a wake" means the job is:
+///   * a subagent (shells never wake the parent),
+///   * finished (not running),
+///   * not yet acknowledged (the agent hasn't read it via await_output), and
+///   * not yet wake-dispatched (no prior wake already delivered it).
+///
+/// Marking `wake_dispatched = true` in the same locked pass guarantees a
+/// given result triggers AT MOST ONE wake, no matter how many triggers fire
+/// (the completion push AND the turn-end re-check both call this; whichever
+/// runs first claims it, the other sees nothing). This makes exactly-once an
+/// invariant of the registry, not of caller ordering — and subsumes both the
+/// empty-wake loop and the failed-wake retry storm without any `response.is_ok`
+/// / status gating in the callers.
+///
+/// Returns `true` if at least one job was newly claimed (caller should
+/// dispatch a wake), `false` if there was nothing new to deliver.
+pub fn claim_subagent_wake_for_session(session_id: &str) -> bool {
+    let mut reg = REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+    let mut claimed = false;
+    for job in reg.values_mut() {
+        if job.session_id == session_id
+            && matches!(job.kind, JobKind::Subagent { .. })
+            && !job.is_running()
+            && !job.output_acknowledged
+            && !job.wake_dispatched
+        {
+            job.wake_dispatched = true;
+            claimed = true;
+        }
+    }
+    claimed
+}
+
+/// Release a wake claim previously taken by `claim_subagent_wake_for_session`
+/// for every completed-unconsumed subagent of `session_id`.
+///
+/// Used when the coordinator claimed a result but then found the parent was
+/// still running (so it could not dispatch a resume turn). Releasing restores
+/// `wake_dispatched = false` so the turn-end re-check can re-claim it once the
+/// parent goes idle. Only clears the flag on jobs that are still unconsumed —
+/// an already-acknowledged job needs no further wake regardless.
+pub fn release_subagent_wake_for_session(session_id: &str) {
+    let mut reg = REGISTRY.lock().unwrap_or_else(|e| e.into_inner());
+    for job in reg.values_mut() {
+        if job.session_id == session_id
+            && matches!(job.kind, JobKind::Subagent { .. })
+            && !job.is_running()
+            && !job.output_acknowledged
+        {
+            job.wake_dispatched = false;
+        }
+    }
 }
 
 /// Lightweight snapshot of a running shell job, suitable for frontend

--- a/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/agent/background.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/agent/background.rs
@@ -77,6 +77,7 @@ impl AgentTool {
         } = args;
 
         let bg_session_id = subagent_session_id.clone();
+        let bg_parent_session_id = parent_session_id.clone();
         let bg_agent_name = agent.name.clone();
         let bg_model = model;
         let bg_provider = provider;
@@ -259,6 +260,17 @@ impl AgentTool {
             // Disarm so the guard's Drop does not overwrite it with Failed.
             finalize_guard.disarm();
 
+            // Push completion to the (possibly idle) parent. When the parent
+            // launched this worker in background and then ended its own turn,
+            // there is no active parent turn to surface the result via the
+            // Background Jobs reminder. The wake hook resumes the parent's
+            // turn loop so it consumes the result; it is a no-op when the
+            // parent is still running (the next turn's reminder covers that)
+            // or when no app handle is installed (headless / tests). Mirrors
+            // Claude Code's task-notification → idle-queue-processor design.
+            crate::tools::impls::orchestration::subagent_wake::current_subagent_completion_wake_hook()
+                .wake_parent(&bg_parent_session_id);
+
             // Clean up worktree isolation after the task completes.
             // Runs before the grace-period sleep so `await_output` callers
             // see the result before the disk is cleaned up, and the worktree
@@ -277,8 +289,36 @@ impl AgentTool {
                 }
             }
 
-            // Remove from registry after grace period
-            tokio::time::sleep(Duration::from_secs(120)).await;
+            // Remove from registry once the parent has consumed the result,
+            // or after a hard cap if it never does.
+            //
+            // The old behaviour — an unconditional 120s sleep then remove —
+            // raced the parent: a worker that finished while the parent was
+            // idle (and slow to take its next turn) had its result deleted
+            // before the Background Jobs reminder could ever surface it, so
+            // the parent never learned the worker completed. Now we retain
+            // the job until `acknowledge_output` is called (the reminder /
+            // await path marks it read), polling at a coarse interval, with
+            // a hard upper bound so a parent that never returns cannot leak
+            // the entry forever.
+            const ACK_POLL_INTERVAL: Duration = Duration::from_secs(5);
+            const MAX_RETENTION: Duration = Duration::from_secs(30 * 60);
+            let retain_deadline = std::time::Instant::now() + MAX_RETENTION;
+            loop {
+                tokio::time::sleep(ACK_POLL_INTERVAL).await;
+                // Missing (already removed elsewhere) or acknowledged → done.
+                match job_registry::is_output_acknowledged(&bg_session_id) {
+                    None | Some(true) => break,
+                    Some(false) => {}
+                }
+                if std::time::Instant::now() >= retain_deadline {
+                    warn!(
+                        "[agent:bg] '{}' result was never acknowledged within retention window; evicting",
+                        bg_session_id
+                    );
+                    break;
+                }
+            }
             job_registry::remove(&bg_session_id);
         });
 

--- a/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/mod.rs
@@ -17,6 +17,7 @@
 //! Helpers:
 //! - [`context_builders`]     — shared context-builder helpers used by orchestration tools
 //! - [`subagent_handler`]     — shared Agent-worker event handler for Delegate/Shadow runs (used by `agent`)
+//! - [`subagent_wake`]        — process-wide hook to wake an idle parent when a background subagent completes
 
 pub mod agent;
 pub mod agent_org;
@@ -29,6 +30,7 @@ pub mod manage_session;
 pub mod member_idle;
 pub mod member_shutdown;
 pub mod subagent_handler;
+pub mod subagent_wake;
 pub mod suggest_mode_switch;
 pub mod suggest_next_steps;
 

--- a/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/subagent_wake.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/subagent_wake.rs
@@ -1,0 +1,286 @@
+//! `SubagentCompletionWakeHook` trait + process-wide `OnceLock` install slot.
+//!
+//! # Problem this solves
+//!
+//! When a parent agent launches a **background** subagent and then ends its
+//! own turn (e.g. it asked the user a question and went idle), the subagent
+//! finishes minutes later with no active parent turn to surface its result.
+//! Until the parent takes another turn, the completed subagent's output sits
+//! unread — and the 120s registry grace period can delete it first. The
+//! result: the parent never learns the subagent finished and silently does
+//! not continue.
+//!
+//! # How the wake works
+//!
+//! This mirrors Claude Code's `task-notification` → idle-queue-processor
+//! design (`tasks/LocalAgentTask.tsx` enqueues a notification; `useQueueProcessor`
+//! auto-starts a turn when the parent loop is idle). ORGII already has the
+//! equivalent restart primitive in `send_message_impl_for_subagent_wake(session_id)`
+//! (a sibling of the Agent Org `InboxWakeHook`'s `send_message_impl_for_wake`).
+//! This hook lets the background-subagent completion path reach it without
+//! `background.rs` (which lives below the Tauri layer) needing an `AppHandle`.
+//!
+//! # Single coordinator, two triggers, exactly-once
+//!
+//! Two triggers can observe a completed background subagent:
+//!   1. the completion push from `background.rs` (fires the moment the worker
+//!      terminates), and
+//!   2. the turn-end re-check in `lifecycle::finalize_session` (fires when the
+//!      parent's own turn ends, covering the case where the worker finished
+//!      while the parent was still mid-turn).
+//!
+//! Both call the SAME coordinator (`wake_parent` → `wake_parent_session`),
+//! which owns the entire decision. It does not carry per-trigger gates; instead
+//! it atomically *claims* the result via
+//! `registry::claim_subagent_wake_for_session` (which marks the job
+//! `wake_dispatched` in the same locked pass). Whichever trigger claims first
+//! delivers it; the other sees nothing. This makes "a result wakes the parent
+//! at most once" an invariant of the registry rather than of caller ordering,
+//! and removes the earlier ad-hoc retry-storm / empty-wake guards.
+//!
+//! The production implementation (installed at app boot in `lib.rs`) resolves
+//! the parent session's status after claiming: if the parent is idle/terminal
+//! it dispatches a resume turn; if it is still running it RELEASES the claim
+//! (so the turn-end re-check can re-claim once the parent goes idle), because a
+//! running parent will otherwise pick the result up via its current turn's
+//! Background Jobs reminder. The status gate is `should_wake_parent`.
+
+use std::sync::{Arc, OnceLock};
+
+/// Hook invoked when a background subagent reaches a terminal state, so the
+/// (possibly idle) parent session can be woken to consume the result.
+pub trait SubagentCompletionWakeHook: Send + Sync {
+    /// Wake `parent_session_id` if it is idle/terminal. Implementations must
+    /// be safe to call unconditionally: a parent that is still running, or a
+    /// missing/headless app handle, is a silent no-op (the result remains in
+    /// the registry for the next turn's reminder).
+    fn wake_parent(&self, parent_session_id: &str);
+}
+
+/// No-op hook for early boot / headless / unit-test contexts where there is
+/// no real session runtime to wake.
+pub struct NoopSubagentCompletionWakeHook;
+
+impl SubagentCompletionWakeHook for NoopSubagentCompletionWakeHook {
+    fn wake_parent(&self, _parent_session_id: &str) {}
+}
+
+/// Process-wide hook installed by the boot path (`lib.rs`). Looked up at
+/// subagent-completion time. Idempotent after the first install.
+static SUBAGENT_WAKE_HOOK: OnceLock<Arc<dyn SubagentCompletionWakeHook>> = OnceLock::new();
+
+/// Install the production [`SubagentCompletionWakeHook`] at app boot.
+/// Idempotent after the first install (subsequent calls are a no-op).
+pub fn install_subagent_completion_wake_hook(hook: Arc<dyn SubagentCompletionWakeHook>) {
+    let _ = SUBAGENT_WAKE_HOOK.set(hook);
+}
+
+/// Resolve the active hook, falling back to the no-op hook if nothing has
+/// been installed yet (early boot, headless / unit-test contexts).
+pub fn current_subagent_completion_wake_hook() -> Arc<dyn SubagentCompletionWakeHook> {
+    SUBAGENT_WAKE_HOOK
+        .get()
+        .cloned()
+        .unwrap_or_else(|| Arc::new(NoopSubagentCompletionWakeHook) as Arc<dyn SubagentCompletionWakeHook>)
+}
+
+/// Statuses for which waking the parent is useful. A `Running` parent will
+/// pick the completed subagent up via its next turn's Background Jobs
+/// reminder, so re-dispatching a turn would be redundant (and `send_message`
+/// would reject a second in-flight turn anyway). Mirrors
+/// `inbox_wake::should_dispatch_wake`.
+fn should_wake_parent(status: crate::core::session::SessionStatus) -> bool {
+    use crate::core::session::SessionStatus;
+    matches!(
+        status,
+        SessionStatus::Idle
+            | SessionStatus::Completed
+            | SessionStatus::Failed
+            | SessionStatus::Cancelled
+            | SessionStatus::Abandoned
+            | SessionStatus::Timeout
+    )
+}
+
+/// Production [`SubagentCompletionWakeHook`] backed by [`AgentAppState`].
+///
+/// On `wake_parent`, resolves the parent session's persisted status and, when
+/// it is idle/terminal, fires `send_message_impl_for_subagent_wake(parent_session_id)`
+/// on a detached Tokio task. The resumed turn opens with the Background Jobs
+/// reminder carrying the completed subagent's "unread output" entry, so the
+/// parent agent reads the result and continues.
+///
+/// Safe to call unconditionally: a running parent, a missing app state, or a
+/// status lookup failure is logged and swallowed — the subagent result stays
+/// in the registry for the next organic turn's reminder.
+pub struct AppHandleSubagentCompletionWakeHook {
+    app_handle: tauri::AppHandle,
+}
+
+impl AppHandleSubagentCompletionWakeHook {
+    pub fn new(app_handle: tauri::AppHandle) -> Arc<Self> {
+        Arc::new(Self { app_handle })
+    }
+}
+
+impl SubagentCompletionWakeHook for AppHandleSubagentCompletionWakeHook {
+    fn wake_parent(&self, parent_session_id: &str) {
+        let parent = parent_session_id.to_string();
+        let app_handle = self.app_handle.clone();
+        tokio::spawn(async move {
+            wake_parent_session(app_handle, parent).await;
+        });
+    }
+}
+
+async fn wake_parent_session(app_handle: tauri::AppHandle, parent_session_id: String) {
+    use tauri::Manager;
+
+    // Exactly-once claim: mark any completed-unconsumed subagent result for
+    // this parent as wake-dispatched, in one atomic registry pass. If nothing
+    // was claimed, another trigger already delivered it (or there is nothing
+    // to deliver) — return without dispatching. This is what makes the two
+    // wake triggers (completion push + turn-end re-check) collapse to a single
+    // coordinator with one shared decision, instead of each carrying its own
+    // ad-hoc gate.
+    let claimed = tokio::task::spawn_blocking({
+        let sid = parent_session_id.clone();
+        move || crate::tools::impls::coding::exec::registry::claim_subagent_wake_for_session(&sid)
+    })
+    .await
+    .unwrap_or(false);
+
+    if !claimed {
+        return;
+    }
+
+    // Resolve the parent's persisted status off the async runtime thread.
+    let lookup = {
+        let sid = parent_session_id.clone();
+        tokio::task::spawn_blocking(move || {
+            crate::core::session::persistence::get_session(&sid)
+        })
+        .await
+    };
+
+    let status = match lookup {
+        Ok(Ok(Some(record))) => crate::core::session::SessionStatus::parse(&record.status),
+        Ok(Ok(None)) => {
+            tracing::info!(
+                parent_session_id = %parent_session_id,
+                "[subagent_wake] parent session not found; skipping wake"
+            );
+            return;
+        }
+        Ok(Err(err)) => {
+            tracing::warn!(
+                parent_session_id = %parent_session_id,
+                error = %err,
+                "[subagent_wake] parent status lookup failed; skipping wake"
+            );
+            return;
+        }
+        Err(join_err) => {
+            tracing::warn!(
+                parent_session_id = %parent_session_id,
+                error = %join_err,
+                "[subagent_wake] parent status lookup task panicked; skipping wake"
+            );
+            return;
+        }
+    };
+
+    let Some(status) = status else {
+        tracing::warn!(
+            parent_session_id = %parent_session_id,
+            "[subagent_wake] parent has an unrecognized status string; skipping wake"
+        );
+        return;
+    };
+
+    if !should_wake_parent(status) {
+        // Parent is still running: it will see the result via its current
+        // turn's Background Jobs reminder, OR — if the worker finished after
+        // the reminder was already built — via the turn-end re-check, which
+        // calls back into this coordinator once the turn goes idle. The claim
+        // above is NOT a problem here: a running parent that ends without
+        // reading the result re-claims nothing (still unacknowledged) only if
+        // we DON'T mark dispatched. So we must release the claim so the
+        // turn-end re-check can pick it up.
+        tracing::info!(
+            parent_session_id = %parent_session_id,
+            status = status.as_str(),
+            "[subagent_wake] parent still running; releasing claim for turn-end re-check"
+        );
+        let _ = tokio::task::spawn_blocking({
+            let sid = parent_session_id.clone();
+            move || {
+                crate::tools::impls::coding::exec::registry::release_subagent_wake_for_session(&sid)
+            }
+        })
+        .await;
+        return;
+    }
+
+    let state = match app_handle.try_state::<crate::state::AgentAppState>() {
+        Some(s) => s,
+        None => {
+            tracing::warn!(
+                parent_session_id = %parent_session_id,
+                "[subagent_wake] AgentAppState not registered; cannot wake parent"
+            );
+            return;
+        }
+    };
+
+    match crate::state::commands::session::message::send_message_impl_for_subagent_wake(
+        &state,
+        parent_session_id.clone(),
+    )
+    .await
+    {
+        Ok(_) => tracing::info!(
+            parent_session_id = %parent_session_id,
+            "[subagent_wake] queued resume turn for idle parent after subagent completion"
+        ),
+        Err(err) => tracing::warn!(
+            parent_session_id = %parent_session_id,
+            error = %err,
+            "[subagent_wake] resume turn dispatch failed"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::session::SessionStatus;
+
+    #[test]
+    fn wakes_idle_and_terminal_parents() {
+        for status in [
+            SessionStatus::Idle,
+            SessionStatus::Completed,
+            SessionStatus::Failed,
+            SessionStatus::Cancelled,
+            SessionStatus::Abandoned,
+            SessionStatus::Timeout,
+        ] {
+            assert!(should_wake_parent(status), "status={}", status.as_str());
+        }
+    }
+
+    #[test]
+    fn does_not_wake_running_or_blocked_parents() {
+        for status in [
+            SessionStatus::Running,
+            SessionStatus::Pending,
+            SessionStatus::Paused,
+            SessionStatus::WaitingForUser,
+            SessionStatus::WaitingForFunds,
+            SessionStatus::Archived,
+        ] {
+            assert!(!should_wake_parent(status), "status={}", status.as_str());
+        }
+    }
+}

--- a/src-tauri/crates/agent-core/src/core/tools/tests/job_registry_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/tests/job_registry_tests.rs
@@ -181,3 +181,146 @@ async fn test_cancel_subagents_for_session_scopes_to_session() {
     registry::remove(&mine);
     registry::remove(&other);
 }
+
+/// Wake-claim lifecycle: `claim_subagent_wake_for_session` is the exactly-once
+/// signal the subagent-wake coordinator uses. It claims a finished,
+/// not-acknowledged, not-yet-dispatched subagent result and marks it dispatched
+/// in the same pass — so a second call returns false (no double wake).
+#[test]
+fn test_claim_subagent_wake_lifecycle() {
+    let session = "wake-claim-session";
+    let handle = "agent-builtin:explore-wakeclaim".to_string();
+    let (_tx, _cancel) = registry::register_subagent(
+        handle.clone(),
+        "delegate".into(),
+        "Explore".into(),
+        session.into(),
+    );
+
+    // Still running → nothing to claim.
+    assert!(!registry::claim_subagent_wake_for_session(session));
+
+    // Completed but unacknowledged → first claim succeeds.
+    registry::set_final_result(&handle, "explored 12 files".into());
+    registry::mark_exited(&handle, JobStatus::Completed);
+    assert!(registry::claim_subagent_wake_for_session(session));
+
+    // EXACTLY-ONCE invariant: a second claim of the same result returns false,
+    // because the first marked it wake_dispatched. This is what makes the two
+    // wake triggers (completion push + turn-end re-check) collapse to a single
+    // dispatch regardless of ordering.
+    assert!(
+        !registry::claim_subagent_wake_for_session(session),
+        "a result must be claimable at most once"
+    );
+
+    // After release, it becomes claimable again (the running-parent path frees
+    // the claim so the turn-end re-check can pick it up).
+    registry::release_subagent_wake_for_session(session);
+    assert!(registry::claim_subagent_wake_for_session(session));
+
+    // Once acknowledged (the agent read it), no further claims fire.
+    registry::acknowledge_output(&handle);
+    registry::release_subagent_wake_for_session(session);
+    assert!(
+        !registry::claim_subagent_wake_for_session(session),
+        "an acknowledged result needs no wake"
+    );
+
+    // Other sessions are never matched.
+    assert!(!registry::claim_subagent_wake_for_session("some-other-session"));
+
+    registry::remove(&handle);
+}
+
+/// A finished **shell** job must NOT trigger a subagent wake — the coordinator
+/// is subagent-specific (shells surface via the reminder only).
+#[test]
+fn test_claim_subagent_wake_ignores_shell_jobs() {
+    let session = "wake-claim-shell-session";
+    let pid = 99997;
+    let _tx = registry::register_shell(
+        pid,
+        "build".into(),
+        PathBuf::from("/tmp/wakeclaim.txt"),
+        session.into(),
+    );
+    let handle = pid.to_string();
+    registry::mark_exited(&handle, JobStatus::Exited(0));
+
+    assert!(
+        !registry::claim_subagent_wake_for_session(session),
+        "a completed shell job must not be mistaken for an unconsumed subagent result"
+    );
+
+    registry::remove(&handle);
+}
+
+/// Tombstone resolution: after a finished job is reaped via `remove`, a later
+/// `resolve_status_with_tombstone` still reports its REAL terminal status and
+/// kind (precise "it finished") — distinct from a genuinely-unknown handle,
+/// which resolves to `None` (the agent mistyped it).
+#[test]
+fn test_tombstone_distinguishes_reaped_from_unknown() {
+    let session = "tombstone-session";
+    let handle = "agent-builtin:explore-tombstone".to_string();
+    let (_tx, _cancel) = registry::register_subagent(
+        handle.clone(),
+        "delegate".into(),
+        "Explore".into(),
+        session.into(),
+    );
+    registry::set_final_result(&handle, "done".into());
+    registry::mark_exited(&handle, JobStatus::Completed);
+
+    // Live job present → resolves directly.
+    let live = registry::resolve_status_with_tombstone(&handle);
+    assert!(matches!(
+        live,
+        Some((JobStatus::Completed, JobKind::Subagent { .. }))
+    ));
+
+    // Reap it. The tombstone must preserve the REAL terminal status + kind.
+    registry::remove(&handle);
+    assert!(
+        registry::get_status(&handle).is_none(),
+        "job should be gone from the live registry"
+    );
+    let tomb = registry::resolve_status_with_tombstone(&handle);
+    assert!(
+        matches!(tomb, Some((JobStatus::Completed, JobKind::Subagent { .. }))),
+        "reaped job must resolve to its real terminal status + kind, got {:?}",
+        tomb.map(|(s, _)| s)
+    );
+
+    // A handle that was never registered resolves to None → caller errors.
+    assert!(
+        registry::resolve_status_with_tombstone("agent-never-existed-xyz").is_none(),
+        "an unknown handle must not be mistaken for a finished job"
+    );
+}
+
+/// A reaped **shell** job's tombstone preserves the real exit code, not a
+/// synthesised `Completed` — so `await_output` reports `exit N` accurately even
+/// after the live job is gone.
+#[test]
+fn test_tombstone_preserves_shell_exit_code() {
+    let session = "tombstone-shell-session";
+    let pid = 99996;
+    let _tx = registry::register_shell(
+        pid,
+        "false".into(),
+        PathBuf::from("/tmp/tombstone-shell.txt"),
+        session.into(),
+    );
+    let handle = pid.to_string();
+    registry::mark_exited(&handle, JobStatus::Exited(1));
+    registry::remove(&handle);
+
+    let tomb = registry::resolve_status_with_tombstone(&handle);
+    assert!(
+        matches!(tomb, Some((JobStatus::Exited(1), JobKind::Shell { .. }))),
+        "tombstone must preserve the real exit code + shell kind, got {:?}",
+        tomb.map(|(s, _)| s)
+    );
+}

--- a/src-tauri/crates/agent-core/src/lifecycle.rs
+++ b/src-tauri/crates/agent-core/src/lifecycle.rs
@@ -501,6 +501,23 @@ pub async fn finalize_session(
         persist_session_error_event(app_handle, session_id, message);
     }
 
+    // Turn-end wake re-check (one of the two triggers feeding the single
+    // subagent-wake coordinator). A background subagent that completed while
+    // THIS turn was still running had its completion-push wake released back
+    // (the parent wasn't idle yet). Now that the turn has ended and the
+    // session row is idle/terminal, re-invoke the coordinator so the result is
+    // delivered. The coordinator is the sole decision point: it atomically
+    // claims the result (exactly-once across both triggers), checks the parent
+    // is wakeable, and dispatches — so this call is an unconditional no-op
+    // when there is nothing new to deliver. No `response.is_ok()` /
+    // unread-precheck gating here anymore: the claim flag makes re-waking a
+    // failed/ignored result impossible, which is what previously required the
+    // ad-hoc retry-storm guard.
+    if !is_agent_org_member_session {
+        crate::tools::impls::orchestration::subagent_wake::current_subagent_completion_wake_hook()
+            .wake_parent(session_id);
+    }
+
     // NOTE: Error broadcasting is handled by the scheduler. Do NOT broadcast here
     // to avoid duplicate transient error notifications; this path only persists
     // the authoritative EventStore row for UI history/replay.

--- a/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/auto_dream.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/auto_dream.rs
@@ -50,6 +50,17 @@ pub struct AutoDreamState {
     last_scan_at: Option<Instant>,
 }
 
+impl AutoDreamState {
+    /// Record that a scan/consolidation attempt is starting now. Set by the
+    /// post-turn dispatcher under a brief lock so the throttle advances even
+    /// though `run_consolidation` itself no longer holds the state mutex
+    /// (it must not — the consolidation LLM call would otherwise block the
+    /// next turn's brief `ad_state` reads).
+    pub fn mark_scan_now(&mut self) {
+        self.last_scan_at = Some(Instant::now());
+    }
+}
+
 // ============================================
 // Core Logic
 // ============================================
@@ -84,11 +95,8 @@ pub fn should_attempt(state: &AutoDreamState, workspace: &Path) -> bool {
 /// 4. On success, the lock mtime advances (recording consolidation)
 /// 5. On failure, rolls back the lock
 pub async fn run_consolidation(
-    state: &mut AutoDreamState,
     params: super::super::MemoryAgentParams<'_>,
 ) -> Result<(), String> {
-    state.last_scan_at = Some(Instant::now());
-
     let workspace = params.workspace;
     let mem_dir = super::memory_dir(workspace);
 

--- a/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/extract/runner.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/extract/runner.rs
@@ -7,6 +7,7 @@
 //! `ExtractMemoriesState` once the fork returns.
 
 use std::sync::Arc;
+use tokio::sync::Mutex;
 use tracing::{info, warn};
 
 use crate::definitions::builtin::MEMORY_EXTRACTOR_ID;
@@ -29,31 +30,44 @@ const MAX_EXTRACTION_TURNS: u32 = 5;
 /// 3. Has a restricted tool set (read-only + edit within memory dir)
 /// 4. Runs for at most MAX_EXTRACTION_TURNS iterations
 pub async fn run_extraction(
-    state: &mut ExtractMemoriesState,
+    em_state: Arc<Mutex<ExtractMemoriesState>>,
     params: super::super::super::MemoryAgentParams<'_>,
 ) -> Result<(), String> {
-    state.in_progress = true;
-    state.turns_since_extraction = 0;
+    // ── Prepare: brief lock to flag in-progress + read the cursor. The mutex
+    // is NOT held across the fork/LLM call below — otherwise the next turn's
+    // brief `em_state` reads (the gate pre-check that decides whether to
+    // stash) would block for the whole extraction. The `in_progress` flag
+    // (kept true until finalize) is what preserves the "at most one extractor"
+    // invariant during the lock-free window.
+    let last_processed_idx = {
+        let mut state = em_state.lock().await;
+        state.in_progress = true;
+        state.turns_since_extraction = 0;
+        state.last_processed_idx
+    };
 
     let workspace = params.workspace;
     let mem_dir = super::super::memory_dir(workspace);
 
     if let Err(err) = std::fs::create_dir_all(&mem_dir) {
-        state.in_progress = false;
+        em_state.lock().await.in_progress = false;
         return Err(format!("Failed to create memory dir: {}", err));
     }
 
     let agent_def =
-        resolve_definition_by_id(MEMORY_EXTRACTOR_ID, params.definitions_store.as_deref())
-            .map_err(|err| {
-                format!(
+        match resolve_definition_by_id(MEMORY_EXTRACTOR_ID, params.definitions_store.as_deref()) {
+            Ok(def) => def,
+            Err(err) => {
+                em_state.lock().await.in_progress = false;
+                return Err(format!(
                     "Agent definition not found: {}: {}",
                     MEMORY_EXTRACTOR_ID, err
-                )
-            })?;
+                ));
+            }
+        };
 
     let messages = params.messages;
-    let new_count = count_new_messages(messages, state.last_processed_idx);
+    let new_count = count_new_messages(messages, last_processed_idx);
     let existing_memories =
         super::super::format_memory_manifest(&super::super::scan_memory_files(&mem_dir));
     let user_prompt = build_extraction_prompt(new_count, &existing_memories, &mem_dir);
@@ -131,6 +145,9 @@ pub async fn run_extraction(
     )
     .await;
 
+    // ── Finalize: brief lock to clear the in-progress flag + advance the
+    // cursor on success.
+    let mut state = em_state.lock().await;
     state.in_progress = false;
 
     match result {

--- a/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/extract/state.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/extract/state.rs
@@ -64,6 +64,13 @@ impl ExtractMemoriesState {
     pub fn is_in_progress(&self) -> bool {
         self.in_progress
     }
+
+    /// Clear the overlap-guard flag. Used by the post-turn dispatcher when a
+    /// provider build fails before `run_extraction` is reached, so the guard
+    /// doesn't stay stuck `true` and block every future extraction.
+    pub fn clear_in_progress(&mut self) {
+        self.in_progress = false;
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/crates/agent-core/src/state/commands/session/message.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/session/message.rs
@@ -12,6 +12,45 @@ use crate::coordination::agent_member_interventions::{
     AgentMemberInterventionStore, EnterMemberInterventionParams, DEFAULT_INTERVENTION_TTL_SECS,
 };
 
+/// Wake-only entry point for the **background-subagent** completion hook.
+///
+/// Resumes the parent with **empty content** (`is_resume = true`), exactly
+/// like the Agent Org inbox auto-resume — so NO new user message is persisted
+/// and NO new chat round is created. The parent continues inside the same
+/// round it was already in.
+///
+/// A plain SDE session has no inbox to drain, so unlike the Agent Org path
+/// nothing converts to a trailing user message on its own. That would leave
+/// the conversation ending on the parent's last *assistant* message
+/// ("已在后台启动。"), which providers reject with `HTTP 400: ... conversation
+/// must end with a user message`. The unified processor closes that gap: on a
+/// resume whose assembled message list still ends with an assistant turn, it
+/// appends a **transient** (in-memory only, never persisted) user nudge so the
+/// prefill invariant holds — see `inject_subagent_wake_nudge_if_needed` in
+/// `turn/processor/mod.rs`. The actual subagent result still arrives via the
+/// background-jobs system reminder.
+pub async fn send_message_impl_for_subagent_wake(
+    state: &AgentAppState,
+    session_id: String,
+) -> Result<AgentResponse, String> {
+    send_message_impl(
+        state,
+        session_id,
+        String::new(),
+        None,
+        IdentityOverrides::default(),
+        None,
+        None,
+        None,
+        true,
+        false,
+        None,
+        None,
+        TurnIntentBridgeSource::Resume,
+    )
+    .await
+}
+
 /// Wake-only entry point for the inbox auto-resume hook.
 ///
 /// Equivalent to calling [`send_message_impl`] with empty content,

--- a/src-tauri/crates/e2e-test/src/main.rs
+++ b/src-tauri/crates/e2e-test/src/main.rs
@@ -496,6 +496,16 @@ fn all_scenarios() -> Vec<ScenarioDef> {
             "background-launch-msg-no-poll",
             subagent::background_launch_msg_no_poll
         ),
+        scenario!(
+            "subagent",
+            "subagent-completion-wakes-parent",
+            subagent::subagent_completion_wakes_parent
+        ),
+        scenario!(
+            "subagent",
+            "subagent-wake-race-after-poll",
+            subagent::subagent_wake_race_after_poll
+        ),
         // Housekeeping (deferred disk cleanup)
         scenario!(
             "housekeeping",

--- a/src-tauri/crates/e2e-test/src/subagent.rs
+++ b/src-tauri/crates/e2e-test/src/subagent.rs
@@ -258,6 +258,222 @@ pub async fn dispatch_subagent_cannot_spawn_subagent(cfg: &Config) -> bool {
     )
 }
 
+/// Subagent-completion push-wake: a background subagent that finishes while
+/// its parent is idle must wake the parent's turn loop so the result is
+/// consumed — without this, the parent silently never continues. Mirrors
+/// Claude Code's task-notification → idle-queue-processor wake.
+///
+/// Flow:
+///   turn 1 (no_cleanup): parent launches an Explore subagent with
+///     `background:true` and is instructed to END ITS TURN IMMEDIATELY so it
+///     goes idle while the worker is still running.
+///   wait: poll the parent transcript. The production
+///     `SubagentCompletionWakeHook` (installed in lib.rs) fires when the
+///     worker terminates and resumes the parent via
+///     `send_message_impl_for_subagent_wake`. The resumed turn carries the
+///     Background Jobs reminder with the completed worker's unread output, so
+///     the parent's message count grows AFTER the HTTP call returned.
+///
+/// Assertions:
+///   - turn 1 actually dispatched a background subagent (tool_calls has
+///     `agent`), proving the worker path ran.
+///   - the parent transcript GROWS after going idle (the auto-woken turn),
+///     proving the push-wake fired without any second user message.
+pub async fn subagent_completion_wakes_parent(cfg: &Config) -> bool {
+    let session_id = format!("{}-wake-parent", cfg.session_prefix);
+    let project = crate::sde::tmp_workspace_path("wake-parent");
+
+    // Turn 1: launch a background subagent, then stop the turn immediately.
+    let opts = harness::SdeMessageOpts {
+        no_cleanup: true,
+        ..Default::default()
+    };
+    let turn1 = harness::send_sde_message_with_opts(
+        cfg,
+        "Use the `agent` tool with agent_id=\"builtin:explore\" and background=true \
+         to launch ONE background subagent whose prompt is: \"List the files in the \
+         repository root and report what you find.\" \
+         As soon as the agent tool returns the launch confirmation, STOP and END YOUR \
+         TURN IMMEDIATELY with a one-sentence acknowledgement. Do NOT call await_output, \
+         do NOT wait for the subagent, do NOT do any other work this turn.",
+        &session_id,
+        "build",
+        &project,
+        &opts,
+    )
+    .await;
+
+    let turn1 = match turn1 {
+        Err(err) => return harness::print_error("Subagent completion wakes idle parent", &err),
+        Ok(resp) => resp,
+    };
+
+    let launched_background = harness::assert_sde_tool_used(&turn1, "agent");
+
+    // Snapshot the parent's message count right after it went idle.
+    let baseline = harness::fetch_transcript(cfg, &session_id)
+        .await
+        .map(|t| t.messages.len())
+        .unwrap_or(0);
+
+    // Poll for the auto-woken turn: the worker finishes within a few seconds,
+    // the wake hook resumes the parent, and its transcript grows.
+    //
+    // CRITICAL (anti-false-positive): a resume that 400s on assistant-prefill
+    // does NOT append to `load_llm_history` (failed turns aren't persisted as
+    // LLM rows), so a bare "len grew" check is necessary but not sufficient.
+    // We additionally require the woken turn to END with a non-empty
+    // **assistant** message — proving the resumed turn actually produced model
+    // output instead of erroring. This is exactly the gap that let the earlier
+    // version pass while the real app 400'd.
+    let mut grew_to = baseline;
+    let mut woke = false;
+    let mut produced_assistant = false;
+    for _ in 0..40 {
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        if let Ok(snap) = harness::fetch_transcript(cfg, &session_id).await {
+            if snap.messages.len() > baseline {
+                grew_to = snap.messages.len();
+                woke = true;
+                produced_assistant = snap.messages.iter().rev().any(|m| {
+                    m.get("role").and_then(|v| v.as_str()) == Some("assistant")
+                        && m.get("content")
+                            .and_then(|v| v.as_str())
+                            .map(|s| !s.trim().is_empty())
+                            .unwrap_or(false)
+                });
+                if produced_assistant {
+                    break;
+                }
+            }
+        }
+    }
+
+    let _ = harness::cleanup_sde_session(cfg, &session_id).await;
+
+    harness::print_result(
+        "Subagent completion wakes idle parent",
+        &format!(
+            "turn1 tools={:?}, baseline_msgs={}, grew_to={}, produced_assistant={}",
+            turn1.tool_calls, baseline, grew_to, produced_assistant
+        ),
+        &[
+            (
+                "Turn 1 dispatched a background subagent (agent tool)",
+                launched_background,
+            ),
+            ("Parent had a transcript after going idle", baseline > 0),
+            (
+                "Parent was auto-woken (transcript grew with no new user message)",
+                woke,
+            ),
+            (
+                "Woken turn produced a real assistant response (no prefill 400)",
+                produced_assistant,
+            ),
+        ],
+    )
+}
+
+/// Wake-race close: the parent launches a background subagent, polls ONCE
+/// with `await_output` (which returns `running`), then ends its turn — and the
+/// worker finishes a moment later, while the parent is still mid-turn. The
+/// completion push is suppressed by `should_wake_parent`'s running gate, so if
+/// nothing re-fired the wake once the turn ended, the parent would silently
+/// never consume the result.
+///
+/// The fix is the turn-end re-check in `finalize_session`: it re-invokes the
+/// subagent-wake coordinator, which atomically claims the unconsumed result
+/// (`claim_subagent_wake_for_session`) and resumes the now-idle parent. This
+/// scenario drives the poll-then-stop path and asserts the parent still
+/// resumes.
+pub async fn subagent_wake_race_after_poll(cfg: &Config) -> bool {
+    let session_id = format!("{}-wake-race", cfg.session_prefix);
+    let project = crate::sde::tmp_workspace_path("wake-race");
+
+    let opts = harness::SdeMessageOpts {
+        no_cleanup: true,
+        ..Default::default()
+    };
+    // Mirror the real session: launch in background, poll progress ONCE,
+    // then stop — inviting the race where the worker finishes during this
+    // same turn.
+    let turn1 = harness::send_sde_message_with_opts(
+        cfg,
+        "Use the `agent` tool with agent_id=\"builtin:explore\" and background=true \
+         to launch ONE background subagent whose prompt is: \"List the files in the \
+         repository root and summarize the structure.\" \
+         After it launches, call await_output EXACTLY ONCE to peek at its progress, \
+         then END YOUR TURN with a one-sentence status — do NOT loop on await_output, \
+         do NOT wait for completion.",
+        &session_id,
+        "build",
+        &project,
+        &opts,
+    )
+    .await;
+
+    let turn1 = match turn1 {
+        Err(err) => return harness::print_error("Subagent wake race (poll-then-stop)", &err),
+        Ok(resp) => resp,
+    };
+
+    let launched_background = harness::assert_sde_tool_used(&turn1, "agent");
+
+    let baseline = harness::fetch_transcript(cfg, &session_id)
+        .await
+        .map(|t| t.messages.len())
+        .unwrap_or(0);
+
+    let mut grew_to = baseline;
+    let mut woke = false;
+    let mut produced_assistant = false;
+    for _ in 0..40 {
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        if let Ok(snap) = harness::fetch_transcript(cfg, &session_id).await {
+            if snap.messages.len() > baseline {
+                grew_to = snap.messages.len();
+                woke = true;
+                produced_assistant = snap.messages.iter().rev().any(|m| {
+                    m.get("role").and_then(|v| v.as_str()) == Some("assistant")
+                        && m.get("content")
+                            .and_then(|v| v.as_str())
+                            .map(|s| !s.trim().is_empty())
+                            .unwrap_or(false)
+                });
+                if produced_assistant {
+                    break;
+                }
+            }
+        }
+    }
+
+    let _ = harness::cleanup_sde_session(cfg, &session_id).await;
+
+    harness::print_result(
+        "Subagent wake race (poll-then-stop)",
+        &format!(
+            "turn1 tools={:?}, baseline_msgs={}, grew_to={}, produced_assistant={}",
+            turn1.tool_calls, baseline, grew_to, produced_assistant
+        ),
+        &[
+            (
+                "Turn 1 dispatched a background subagent (agent tool)",
+                launched_background,
+            ),
+            ("Parent had a transcript after the turn", baseline > 0),
+            (
+                "Parent self-woke after the race (transcript grew, no new user message)",
+                woke,
+            ),
+            (
+                "Woken turn produced a real assistant response (no prefill 400)",
+                produced_assistant,
+            ),
+        ],
+    )
+}
+
 /// Background-launch message contract: when a subagent is launched with
 /// `background:true`, the tool_result handed back to the parent agent must
 /// (a) carry the subagent's session_id (the DB key), (b) hand the parent a

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -553,6 +553,19 @@ pub fn run() {
             );
             tracing::info!("[MemberIdle] Member idle hook installed");
 
+            // Install the production `SubagentCompletionWakeHook` so a
+            // background subagent that finishes while its parent is idle
+            // resumes the parent's turn loop (which then consumes the result
+            // via the Background Jobs reminder). Without this, an idle parent
+            // never learns the worker completed. Mirrors Claude Code's
+            // task-notification → idle-queue-processor wake.
+            agent_core::tools::impls::orchestration::subagent_wake::install_subagent_completion_wake_hook(
+                agent_core::tools::impls::orchestration::subagent_wake::AppHandleSubagentCompletionWakeHook::new(
+                    app.handle().clone(),
+                ),
+            );
+            tracing::info!("[SubagentWake] Subagent completion wake hook installed");
+
             app.manage(unified_state);
             tracing::info!("[UnifiedAgent] Unified agent state initialized");
 

--- a/src/engines/SessionCore/core/__tests__/runningEventGate.test.ts
+++ b/src/engines/SessionCore/core/__tests__/runningEventGate.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  classifyLatestTurnActivity,
   hasLiveRuntimeResourceInLatestTurn,
+  hasRunningAwaitWaitForInLatestTurn,
   isLiveRuntimeResourceEvent,
   sessionHasComposerStopBlockingWork,
 } from "../runningEventGate";
@@ -123,10 +125,11 @@ function settledToolEvent(id: string): SessionEvent {
 }
 
 function awaitOutputEvent(
-  displayStatus: "running" | "completed"
+  displayStatus: "running" | "completed",
+  command: "wait_for" | "monitor" = "wait_for"
 ): SessionEvent {
   return {
-    id: `await-${displayStatus}`,
+    id: `await-${command}-${displayStatus}`,
     sessionId: "session-1",
     source: "assistant",
     createdAt: new Date().toISOString(),
@@ -135,7 +138,7 @@ function awaitOutputEvent(
     uiCanonical: "await_output",
     displayStatus,
     displayVariant: "tool_call",
-    args: { command: "wait_for", handles: ["pid-123"] },
+    args: { command, handles: ["pid-123"] },
   } as unknown as SessionEvent;
 }
 
@@ -181,9 +184,12 @@ describe("hasLiveRuntimeResourceInLatestTurn", () => {
     expect(hasLiveRuntimeResourceInLatestTurn(events)).toBe(true);
   });
 
-  it("exempts running await_output from suppressing the planning footer", () => {
+  it("treats a running await_output wait_for as live activity (watchdog must not kill it)", () => {
+    // Under the unified model a blocked wait IS genuine activity, so the
+    // watchdog input is true. The footer is hidden separately via the
+    // selfIndicating classification, not by pretending nothing is live.
     const events = [userEvent("u1"), awaitOutputEvent("running")];
-    expect(hasLiveRuntimeResourceInLatestTurn(events)).toBe(false);
+    expect(hasLiveRuntimeResourceInLatestTurn(events)).toBe(true);
   });
 
   it("still detects other running tools alongside a running await_output", () => {
@@ -193,5 +199,67 @@ describe("hasLiveRuntimeResourceInLatestTurn", () => {
       shellEvent("running"),
     ];
     expect(hasLiveRuntimeResourceInLatestTurn(events)).toBe(true);
+  });
+});
+
+describe("classifyLatestTurnActivity (single source of truth)", () => {
+  it("idle when the latest turn is fully settled", () => {
+    expect(
+      classifyLatestTurnActivity([userEvent("u1"), settledToolEvent("t1")])
+    ).toBe("idle");
+  });
+
+  it("selfIndicating for a running wait_for (its own countdown is the indicator)", () => {
+    expect(
+      classifyLatestTurnActivity([userEvent("u1"), awaitOutputEvent("running")])
+    ).toBe("selfIndicating");
+  });
+
+  it("liveSilent for a running shell (needs the footer to convey activity)", () => {
+    expect(
+      classifyLatestTurnActivity([userEvent("u1"), shellEvent("running")])
+    ).toBe("liveSilent");
+  });
+
+  it("liveSilent for a non-blocking monitor await (no countdown of its own)", () => {
+    expect(
+      classifyLatestTurnActivity([
+        userEvent("u1"),
+        awaitOutputEvent("running", "monitor"),
+      ])
+    ).toBe("liveSilent");
+  });
+
+  it("a running wait_for dominates a sibling silent resource", () => {
+    expect(
+      classifyLatestTurnActivity([
+        userEvent("u1"),
+        shellEvent("running"),
+        awaitOutputEvent("running"),
+      ])
+    ).toBe("selfIndicating");
+  });
+
+  // The invariant that the unification exists to guarantee: the two derived
+  // booleans agree by construction — `selfIndicating` ALWAYS implies the
+  // footer is suppressed AND the watchdog sees live activity, and they are
+  // never both reasoning about await_output in opposite directions.
+  it("derived booleans are consistent with the classification (no conflict)", () => {
+    const cases: SessionEvent[][] = [
+      [userEvent("u1"), settledToolEvent("t1")],
+      [userEvent("u1"), shellEvent("running")],
+      [userEvent("u1"), awaitOutputEvent("running")],
+      [userEvent("u1"), awaitOutputEvent("running", "monitor")],
+      [userEvent("u1"), shellEvent("running"), awaitOutputEvent("running")],
+    ];
+    for (const events of cases) {
+      const kind = classifyLatestTurnActivity(events);
+      const live = hasLiveRuntimeResourceInLatestTurn(events);
+      const selfIndicating = hasRunningAwaitWaitForInLatestTurn(events);
+      expect(live).toBe(kind !== "idle");
+      expect(selfIndicating).toBe(kind === "selfIndicating");
+      // selfIndicating ⇒ live (a self-indicating wait is, by definition, live).
+      if (selfIndicating) expect(live).toBe(true);
+    }
   });
 });

--- a/src/engines/SessionCore/core/runningEventGate.ts
+++ b/src/engines/SessionCore/core/runningEventGate.ts
@@ -54,37 +54,66 @@ export function isLiveRuntimeResourceEvent(event: SessionEvent): boolean {
 }
 
 /**
- * Planning-footer variant of the live-resource scan: only the LATEST turn
- * (events after the last user-source message) counts.
+ * The latest turn's live-activity classification — the SINGLE source of truth
+ * for "is the agent visibly working, and does that work already show its own
+ * indicator?". Both `hasLiveRuntimeResourceInLatestTurn` (watchdog input) and
+ * `hasRunningAwaitWaitForInLatestTurn` (footer suppression) are derived from
+ * this one scan, so they can never disagree about how `await_output` is
+ * treated — the previous two-independent-scans design reasoned about
+ * await_output in OPPOSITE directions (one excluded it "so the footer shows",
+ * the other matched it "so the footer hides"), which only happened to compose
+ * correctly. Modelling it once removes that latent conflict.
  *
- * Why not the whole session: zombie running events — tool calls whose
- * terminal status merge was dropped, or shell events whose
- * `shellProcessStatus` froze at "running" after the process exited — are
- * permanent once persisted. Scanning the full history lets one zombie from
- * an old turn suppress the "Planning next step…" footer for every later
- * turn in the session. Old-turn background shells (dev servers) are also
- * deliberately excluded: a pinned background process is not a reason to
- * hide "the agent is thinking".
+ * - `idle` — no live runtime resource in the latest turn.
+ * - `selfIndicating` — a running `await_output wait_for`: it renders its own
+ *   live "Waiting {countdown} for …" title, which IS the activity indicator,
+ *   so the planning footer would be a redundant second one.
+ * - `liveSilent` — a running resource (shell, etc.) with no self-evident
+ *   indicator of its own; the planning footer is the thing that conveys "still
+ *   alive", so it should stay.
  *
- * Within the current turn this only answers whether a live row exists; the
- * planning footer may still show after the row has been idle long enough, but
- * the watchdog must not force-complete the session while this returns true.
+ * Scoped to the latest turn (events after the last user-source message) to
+ * avoid zombie running rows from older turns — tool calls whose terminal
+ * status merge was dropped, or shells whose `shellProcessStatus` froze at
+ * "running" after exit. Old-turn background shells (dev servers) are likewise
+ * excluded: a pinned background process is not a reason to change the footer.
+ */
+export type LatestTurnActivity = "idle" | "selfIndicating" | "liveSilent";
+
+export function classifyLatestTurnActivity(
+  events: readonly SessionEvent[]
+): LatestTurnActivity {
+  let sawLiveSilent = false;
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i];
+    if (event.source === "user") break;
+    if (!isLiveRuntimeResourceEvent(event)) continue;
+    if (isAwaitOutputEvent(event) && isAwaitWaitForCommand(event.args)) {
+      // A running wait_for dominates: it self-indicates regardless of any
+      // sibling silent resource, so we can stop scanning.
+      return "selfIndicating";
+    }
+    // A running resource without its own indicator (incl. a non-wait_for
+    // await_output like `monitor`, which is a quick snapshot, or a shell).
+    sawLiveSilent = true;
+  }
+  return sawLiveSilent ? "liveSilent" : "idle";
+}
+
+/**
+ * True when the latest turn has any live runtime resource — used by the
+ * planning-indicator watchdog so it does not force-complete a session that is
+ * genuinely still working (a long `wait_for`, a running shell, …).
  *
- * `await_output` is exempt: it polls/blocks waiting for OTHER jobs (shell
- * processes, subagents) and renders as a subtle TitleOnlyBlock whose
- * shimmer is too faint to convey activity. The planning footer is a
- * better signal that the agent is still alive during a long wait_for.
+ * Unlike the pre-unification version, this now INCLUDES a running `wait_for`:
+ * a blocked wait is genuine activity, so the watchdog should not kill it. The
+ * footer is suppressed during a wait_for via `hasRunningAwaitWaitForInLatestTurn`
+ * (the `selfIndicating` case), not by pretending no resource is live.
  */
 export function hasLiveRuntimeResourceInLatestTurn(
   events: readonly SessionEvent[]
 ): boolean {
-  for (let i = events.length - 1; i >= 0; i--) {
-    const event = events[i];
-    if (event.source === "user") return false;
-    if (isLiveRuntimeResourceEvent(event) && !isAwaitOutputEvent(event))
-      return true;
-  }
-  return false;
+  return classifyLatestTurnActivity(events) !== "idle";
 }
 
 function isAwaitOutputEvent(event: SessionEvent): boolean {
@@ -92,6 +121,47 @@ function isAwaitOutputEvent(event: SessionEvent): boolean {
     event.functionName === "await_output" ||
     event.uiCanonical === "await_output"
   );
+}
+
+/**
+ * True when the latest turn's activity is self-indicating — i.e. a still-running
+ * `await_output wait_for` whose own "Waiting {countdown} for …" title already
+ * conveys "the agent is alive and blocked on a job". Callers suppress the
+ * planning footer in this window so the user does not see two stacked waiting
+ * indicators for the same wait. `monitor`/`list` are non-blocking snapshots and
+ * never self-indicate, so the footer still shows for them.
+ */
+export function hasRunningAwaitWaitForInLatestTurn(
+  events: readonly SessionEvent[]
+): boolean {
+  return classifyLatestTurnActivity(events) === "selfIndicating";
+}
+
+/**
+ * Resolve whether an `await_output` event is a blocking `wait_for` call.
+ * Mirrors the adapter's `resolveAwaitCommand` inference: explicit `command`
+ * wins; otherwise a present `pattern`/`wait_mode` implies `wait_for`.
+ */
+function isAwaitWaitForCommand(args: unknown): boolean {
+  const parsed: Record<string, unknown> | undefined =
+    typeof args === "string"
+      ? (() => {
+          try {
+            return JSON.parse(args) as Record<string, unknown>;
+          } catch {
+            return undefined;
+          }
+        })()
+      : (args as Record<string, unknown> | undefined);
+  if (!parsed) return false;
+  const command = parsed.command;
+  if (typeof command === "string" && command.length > 0) {
+    return command === "wait_for";
+  }
+  const hasPattern = parsed.pattern !== undefined && parsed.pattern !== null;
+  const hasWaitMode =
+    parsed.wait_mode !== undefined && parsed.wait_mode !== null;
+  return hasPattern || hasWaitMode;
 }
 
 export function isTurnBlockingRuntimeEvent(event: SessionEvent): boolean {

--- a/src/engines/SessionCore/derived/planningIndicatorAtoms.ts
+++ b/src/engines/SessionCore/derived/planningIndicatorAtoms.ts
@@ -15,7 +15,10 @@ import { atom } from "jotai";
 
 import { derivedSnapshotAtom } from "../core/atoms/events";
 import { isInteractiveTool } from "../core/interactiveTools";
-import { hasLiveRuntimeResourceInLatestTurn } from "../core/runningEventGate";
+import {
+  hasLiveRuntimeResourceInLatestTurn,
+  hasRunningAwaitWaitForInLatestTurn,
+} from "../core/runningEventGate";
 
 /**
  * True when the latest agent turn has at least one live runtime resource
@@ -28,6 +31,20 @@ export const globalAnyRunningAtom = atom((get) => {
   return hasLiveRuntimeResourceInLatestTurn(snapshot.chatEvents);
 });
 globalAnyRunningAtom.debugLabel = "planning/globalAnyRunning";
+
+/**
+ * True when the latest turn has a still-running `await_output` wait_for call.
+ * Its own live "Waiting {countdown} for …" title already conveys activity, so
+ * the planning footer is suppressed in this window to avoid two stacked
+ * waiting indicators. Changes only when the wait_for starts/ends.
+ */
+export const globalHasRunningAwaitWaitForAtom = atom((get) => {
+  const snapshot = get(derivedSnapshotAtom);
+  if (!snapshot || !("chatEvents" in snapshot)) return false;
+  return hasRunningAwaitWaitForInLatestTurn(snapshot.chatEvents);
+});
+globalHasRunningAwaitWaitForAtom.debugLabel =
+  "planning/globalHasRunningAwaitWaitFor";
 
 /**
  * True when there is a pending interactive tool call awaiting user input.

--- a/src/engines/SessionCore/derived/sessionScopedChatEvents.ts
+++ b/src/engines/SessionCore/derived/sessionScopedChatEvents.ts
@@ -30,7 +30,10 @@ import { atomFamily } from "jotai-family";
 import { createLogger } from "@src/hooks/logger";
 
 import { isInteractiveTool } from "../core/interactiveTools";
-import { hasLiveRuntimeResourceInLatestTurn } from "../core/runningEventGate";
+import {
+  hasLiveRuntimeResourceInLatestTurn,
+  hasRunningAwaitWaitForInLatestTurn,
+} from "../core/runningEventGate";
 import type { Snapshot } from "../core/store/EventStoreProxy";
 import {
   eventStoreProxy,
@@ -183,12 +186,18 @@ export interface SessionScopedPlanningMeta {
   anyRunning: boolean;
   /** True while an interactive tool is blocked waiting for user input. */
   hasAwaitingUserInteraction: boolean;
+  /**
+   * True while the latest turn has a still-running `await_output` wait_for —
+   * its own live countdown title makes the planning footer redundant.
+   */
+  hasRunningAwaitWaitFor: boolean;
 }
 
 const EMPTY_PLANNING_META: SessionScopedPlanningMeta = {
   version: 0,
   anyRunning: false,
   hasAwaitingUserInteraction: false,
+  hasRunningAwaitWaitFor: false,
 };
 
 export const sessionScopedPlanningMetaAtomFamily = atomFamily(
@@ -208,11 +217,13 @@ export const sessionScopedPlanningMetaAtomFamily = atomFamily(
             event.activityStatus !== "processed" &&
             isInteractiveTool(event.functionName)
         ),
+        hasRunningAwaitWaitFor: hasRunningAwaitWaitForInLatestTurn(chatEvents),
       };
       if (
         next.version === prev.version &&
         next.anyRunning === prev.anyRunning &&
-        next.hasAwaitingUserInteraction === prev.hasAwaitingUserInteraction
+        next.hasAwaitingUserInteraction === prev.hasAwaitingUserInteraction &&
+        next.hasRunningAwaitWaitFor === prev.hasRunningAwaitWaitFor
       ) {
         return prev;
       }

--- a/src/engines/SessionCore/hooks/replay/usePlanningIndicator.test.ts
+++ b/src/engines/SessionCore/hooks/replay/usePlanningIndicator.test.ts
@@ -12,6 +12,7 @@ const baseInput = {
   idleAfterVersion: 10,
   version: 10,
   hasLiveSubagent: false,
+  hasRunningAwaitWaitFor: false,
 };
 
 describe("shouldShowPlanningIndicator", () => {
@@ -78,5 +79,27 @@ describe("shouldShowPlanningIndicator", () => {
         anyRunning: true,
       })
     ).toBe(true);
+  });
+
+  it("hides while a running await_output wait_for shows its own countdown", () => {
+    // The wait_for block renders a live "Waiting {countdown} for …" title, so
+    // the planning footer would be a redundant second waiting indicator.
+    expect(
+      shouldShowPlanningIndicator({
+        ...baseInput,
+        hasRunningAwaitWaitFor: true,
+      })
+    ).toBe(false);
+  });
+
+  it("still hides the footer during a wait_for even if a subagent is live", () => {
+    expect(
+      shouldShowPlanningIndicator({
+        ...baseInput,
+        runtimeStatus: "idle",
+        hasLiveSubagent: true,
+        hasRunningAwaitWaitFor: true,
+      })
+    ).toBe(false);
   });
 });

--- a/src/engines/SessionCore/hooks/replay/usePlanningIndicator.ts
+++ b/src/engines/SessionCore/hooks/replay/usePlanningIndicator.ts
@@ -54,6 +54,7 @@ import { sessionIdAtom } from "@src/engines/SessionCore/core/atoms/metadata";
 import {
   globalAnyRunningAtom,
   globalHasAwaitingUserInteractionAtom,
+  globalHasRunningAwaitWaitForAtom,
   globalLastIsSettledAssistantMessageAtom,
 } from "@src/engines/SessionCore/derived/planningIndicatorAtoms";
 import {
@@ -104,6 +105,12 @@ export interface PlanningIndicatorVisibilityInput {
    * would vanish during that gap even though work is clearly ongoing.
    */
   hasLiveSubagent: boolean;
+  /**
+   * True while the latest turn has a still-running `await_output` wait_for.
+   * That call renders its own live "Waiting {countdown} for …" title, so the
+   * planning footer is suppressed to avoid two stacked waiting indicators.
+   */
+  hasRunningAwaitWaitFor: boolean;
 }
 
 export function shouldShowPlanningIndicator({
@@ -115,6 +122,7 @@ export function shouldShowPlanningIndicator({
   idleAfterVersion,
   version,
   hasLiveSubagent,
+  hasRunningAwaitWaitFor,
 }: PlanningIndicatorVisibilityInput): boolean {
   const runtimeCanShowPlanning =
     runtimeStatus === "running" ||
@@ -127,6 +135,7 @@ export function shouldShowPlanningIndicator({
     isSessionActive &&
     !isPendingCancel &&
     !hasAwaitingUserInteraction &&
+    !hasRunningAwaitWaitFor &&
     (coldStartVisible || idleAfterVersion === version)
   );
 }
@@ -208,6 +217,15 @@ export function usePlanningIndicator(
   const hasAwaitingUserInteraction = scoped
     ? scopedMeta.hasAwaitingUserInteraction
     : globalHasAwaitingUserInteraction;
+
+  // Running wait_for in the latest turn → its own countdown title is the
+  // activity signal; suppress the duplicate planning footer.
+  const globalHasRunningAwaitWaitFor = useAtomValue(
+    globalHasRunningAwaitWaitForAtom
+  );
+  const hasRunningAwaitWaitFor = scoped
+    ? scopedMeta.hasRunningAwaitWaitFor
+    : globalHasRunningAwaitWaitFor;
 
   // True when the most recent chat-visible event is a non-streaming
   // assistant message that has already settled. In this state the user
@@ -315,6 +333,7 @@ export function usePlanningIndicator(
     idleAfterVersion,
     version,
     hasLiveSubagent,
+    hasRunningAwaitWaitFor,
   });
 
   const [showSlowHint, setShowSlowHint] = useState(false);


### PR DESCRIPTION
A background subagent that finished while its parent was idle never woke the parent's turn loop, so the result sat unread and the parent silently stopped. Separately, the "Planning…/working" footer could stay spinning for ~57s after the agent had clearly finished talking, because the post-turn memory extractors held a state lock across their LLM call and the next turn's completion signal blocked on that lock.

Subagent wake (new `subagent_wake` process hook, installed at boot):
- On background-subagent completion, push-wake the parent via `send_message_impl_for_subagent_wake` (empty-content resume → same round, no new bubble). A transient, never-persisted user nudge is injected in the turn processor only when the resume tail is an assistant message, satisfying provider prefill (Anthropic/OpenAI both reject an assistant-tailed conversation) without creating a visible message.
- Single coordinator, two triggers, exactly-once: the completion push and the `finalize_session` turn-end re-check both call one coordinator that atomically claims the result via `registry::claim_subagent_wake_for_session` (marks `wake_dispatched` in the same locked pass). Whichever claims first delivers it; the other no-ops. This makes "a result wakes the parent at most once" a registry invariant rather than caller ordering, removing the earlier retry-storm / empty-wake guards. A claim taken while the parent is still running is released so the turn-end re-check can re-claim once idle.

Post-turn no longer blocks turn completion:
- `extract_memories`, `session_memory`, and `auto_dream` now move their whole body (incl. the gate pre-check locks) inside `tokio::spawn`, so the awaited dispatch returns instantly.
- The extractors no longer hold their state mutex across the LLM call: brief-lock prepare (snapshot + flag) → lock-free LLM → brief-lock finalize (merge). SM tool-call counter merges via saturating_sub so concurrent increments are not lost.

await_output precision (registry tombstones):
- `remove` leaves a short-lived tombstone (real terminal status + kind, 10-min TTL, opportunistic prune). `resolve_status_with_tombstone` is three-way: live job / reaped-but-tombstoned (precise "finished") / unknown (real error). Replaces the old lenient resolver that synthesised Completed and guessed the kind from the handle string, so a just-reaped job reads "done" while a mistyped handle reports an error.

Activity-indicator unification (footer):
- One `classifyLatestTurnActivity` (idle / selfIndicating / liveSilent) is the single source of truth; `hasLiveRuntimeResourceInLatestTurn` (watchdog) and `hasRunningAwaitWaitForInLatestTurn` (footer suppression) derive from it, so they can no longer reason about await_output in opposite directions. A running wait_for is now live activity (watchdog won't kill it) and self-indicates (footer hides).

Tests: job-registry wake-claim exactly-once + tombstone three-way (Rust); runningEventGate classifier + derived-boolean consistency, planning indicator suppression (FE). Verified live against opus-4-8: push-wake + poll-then-stop race both resume in the same round with no prefill 400 and exactly one wake each; turn completion fires ~6ms after talk-done while a 17s extraction runs independently in the background.

Pre-commit hook ran. Total eslint: 0, total circular: 0

## Summary

-

## Test plan

-

## Submit checklist

- [ ] The PR is focused and has a scoped Conventional Commits title, such as `feat(scope): summary` or `fix(scope): summary`.
- [ ] I ran the relevant checks, or explained why they were not run.
- [ ] No secrets, private config, generated output, or unrelated formatting changes are included.
- [ ] Docs, screenshots, and locale updates are included when the change needs them.
