### PR TITLE
fix(agent): correct Copilot ACP launch flags and model passthrough

### DIFF
--- a/src-tauri/src/agent_sessions/cli/session_runner/command.rs
+++ b/src-tauri/src/agent_sessions/cli/session_runner/command.rs
@@ -177,15 +177,21 @@ pub(super) fn build_command(
             cmd
         }
         ModelType::Copilot => {
-            let mut cmd = vec!["copilot".into(), "--acp".into(), "--stdio".into()];
+            // Copilot exposes ACP over stdio only (no `--stdio`/`--port` flag).
+            // `--allow-all-tools` + `--no-ask-user` keep the agent autonomous so
+            // it never blocks on a permission or ask_user prompt.
+            let mut cmd = vec!["copilot".into(), "--acp".into()];
             cmd.push("--allow-all-tools".to_string());
+            cmd.push("--no-ask-user".to_string());
             if let Some(rid) = resume_id {
                 cmd.push("--resume".into());
                 cmd.push(rid.into());
             }
+            // Copilot routes across vendors (gpt-*, claude-*, gemini-*); pass the
+            // model id through unchanged instead of Claude-specific normalization.
             if let Some(m) = model {
                 cmd.push("--model".into());
-                cmd.push(map_claude_model(m));
+                cmd.push(m.into());
             }
             cmd
         }
@@ -206,8 +212,8 @@ pub(super) fn build_command(
 ///
 /// Fallback mapping for when the proxy's resolved `model_name` is unavailable
 /// (e.g., fallback allocation path, pool sync failure, or local billing mode).
-/// The hosted service normalizes "claude-sonnet-4.5" → "sonnet-4.5", but CLIs
-/// (Claude Code, Copilot) expect full names like "claude-sonnet-4.5".
+/// The hosted service normalizes "claude-sonnet-4.5" → "sonnet-4.5", but the
+/// Claude Code CLI expects full names like "claude-sonnet-4.5".
 /// This re-adds the "claude-" prefix for Claude-family models.
 /// Non-Claude models (gpt-*, gemini-*, grok-*, raptor-*) pass through unchanged.
 ///

--- a/src-tauri/src/agent_sessions/cli/tests/runner_command_tests.rs
+++ b/src-tauri/src/agent_sessions/cli/tests/runner_command_tests.rs
@@ -218,8 +218,30 @@ fn build_copilot_basic() {
     );
     assert_eq!(cmd[0], "copilot");
     assert!(cmd.contains(&"--acp".to_string()));
-    assert!(cmd.contains(&"--stdio".to_string()));
     assert!(cmd.contains(&"--allow-all-tools".to_string()));
+    assert!(cmd.contains(&"--no-ask-user".to_string()));
+    // Copilot serves ACP over stdio only; there is no `--stdio` flag.
+    assert!(!cmd.contains(&"--stdio".to_string()));
+}
+
+#[test]
+fn build_copilot_resume_and_model_passthrough() {
+    let cmd = build_command(
+        &ModelType::Copilot,
+        Some("gpt-5.4"),
+        "task",
+        Some("resume-123"),
+        None,
+        None,
+        None,
+        None,
+        &[],
+    );
+    assert!(cmd.contains(&"--resume".to_string()));
+    assert!(cmd.contains(&"resume-123".to_string()));
+    assert!(cmd.contains(&"--model".to_string()));
+    // Model id is passed through unchanged (Copilot is multi-vendor).
+    assert!(cmd.contains(&"gpt-5.4".to_string()));
 }
 
 // ============================================


### PR DESCRIPTION
## Summary

- The Copilot CLI session command appended a `--stdio` flag that does not exist on `copilot` (verified against v1.0.65). The agent serves ACP over stdio with `--acp` alone, the same way the `kiro-cli` and `opencode` adapters launch.
- It also pushed the selected model through `map_claude_model`, which is Claude-only normalization, even though Copilot routes across vendors (gpt-*, claude-*, gemini-*). A `gpt-5.4` selection should reach the CLI verbatim.
- Drop the bogus flag, add `--no-ask-user` so non-interactive ACP runs never block on the `ask_user` tool, and pass `--model` through unchanged. The `map_claude_model` doc comment no longer claims Copilot uses it.

## Test plan

- `cargo test --lib agent_sessions::cli::session_runner::command_tests` (20 passed), including the updated `build_copilot_basic` and a new `build_copilot_resume_and_model_passthrough`.
- `cargo clippy --lib` clean for the `org2` crate.
- Smoke-tested the resulting flags against the real CLI: `copilot --acp --allow-all-tools --no-ask-user --model auto` returns a valid ACP `initialize` result; `copilot -p ... -s --allow-all-tools --no-ask-user` runs non-interactively.

## Submit checklist

- [x] The PR is focused and has a scoped Conventional Commits title, such as `feat(scope): summary` or `fix(scope): summary`.
- [x] I ran the relevant checks, or explained why they were not run.
- [x] No secrets, private config, generated output, or unrelated formatting changes are included.
- [x] Docs, screenshots, and locale updates are included when the change needs them.
