### PR TITLE
fix: exclude redo snapshots from rewind history

### DIFF
--- a/src-tauri/crates/agent-core/src/core/tools/file_history/inspect.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/file_history/inspect.rs
@@ -35,6 +35,13 @@ pub(super) fn rewind_snapshot_ids(
     let db_snapshot_ids =
         crate::persistence::session_snapshots::get_snapshots_after(session_id, target_created_at)
             .map_err(|err| io::Error::other(format!("DB error fetching snapshots: {}", err)))?;
+    let redo_snapshot_ids = crate::persistence::session_snapshots::get_snapshot_ids_by_tool_call_id(
+        session_id,
+        super::rewind::REDO_SNAPSHOT_TOOL_CALL_ID,
+    )
+    .map_err(|err| io::Error::other(format!("DB error fetching redo snapshots: {}", err)))?
+    .into_iter()
+    .collect::<BTreeSet<_>>();
     let pre_message_snapshot_id =
         crate::persistence::session_snapshots::get_latest_snapshot_before_by_tool_call_id(
             session_id,
@@ -55,6 +62,9 @@ pub(super) fn rewind_snapshot_ids(
         .chain(manifest_anchor_snapshot_id)
         .chain(manifest_snapshot_ids)
     {
+        if redo_snapshot_ids.contains(&snapshot_id) {
+            continue;
+        }
         if !seen.insert(snapshot_id.clone()) {
             continue;
         }

--- a/src-tauri/crates/agent-core/src/core/tools/file_history/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/file_history/mod.rs
@@ -196,6 +196,36 @@ mod tests {
     }
 
     #[test]
+    fn rewind_to_message_excludes_redo_snapshot_from_later_rewinds() {
+        with_sandbox(|sandbox| {
+            crate::persistence::session_snapshots::ensure_tables().unwrap();
+
+            let project = sandbox.join("proj");
+            fs::create_dir_all(&project).unwrap();
+            let file = project.join("a.txt");
+            fs::write(&file, b"v1").unwrap();
+
+            let sid = "sess-redo-filter";
+            let snap = make_snapshot(sid).unwrap();
+            track_edit(sid, &snap, &file).unwrap();
+            crate::core::session::persistence::save_snapshot(sid, "tool-call-1", &snap).unwrap();
+            let created_at = crate::persistence::session_snapshots::get_snapshot_created_at_by_hash(
+                sid, &snap,
+            )
+            .unwrap()
+            .unwrap();
+
+            fs::write(&file, b"v2").unwrap();
+            let rewind_stats = rewind_to_message(sid, &created_at).unwrap();
+            assert!(rewind_stats.redo_snapshot_id.is_some());
+            assert_eq!(fs::read(&file).unwrap(), b"v1");
+
+            let candidates = inspect::rewind_snapshot_ids(sid, &created_at).unwrap();
+            assert_eq!(candidates, vec![snap]);
+        });
+    }
+
+    #[test]
     fn track_edit_is_idempotent_first_capture_wins() {
         with_sandbox(|sandbox| {
             let project = sandbox.join("proj");

--- a/src-tauri/crates/agent-core/src/foundation/persistence/session_snapshots.rs
+++ b/src-tauri/crates/agent-core/src/foundation/persistence/session_snapshots.rs
@@ -302,13 +302,18 @@ pub fn get_snapshots_after(session_id: &str, created_at: &str) -> SqliteResult<V
     let conn = get_connection()?;
     let mut stmt = conn.prepare(
         "SELECT hash FROM agent_snapshots
-         WHERE session_id = ?1 AND created_at >= ?2
+         WHERE session_id = ?1 AND created_at >= ?2 AND tool_call_id != ?3
          ORDER BY created_at ASC",
     )?;
     let rows = stmt
-        .query_map(params![session_id, created_at], |row| {
-            row.get::<_, String>(0)
-        })?
+        .query_map(
+            params![
+                session_id,
+                created_at,
+                crate::tools::file_history::REDO_SNAPSHOT_TOOL_CALL_ID
+            ],
+            |row| row.get::<_, String>(0),
+        )?
         .collect::<SqliteResult<Vec<_>>>()?;
     Ok(rows)
 }


### PR DESCRIPTION
## Summary
- Exclude redo sentinel snapshots from rewind candidate collection
- Keep redo anchors from being replayed as normal history snapshots
- Add regression coverage for the redo exclusion path

## Verification
- cargo test -p agent_core file_history::tests::rewind_to_message_excludes_redo_snapshot_from_later_rewinds
- cargo test -p agent_core core::tools::file_history::tests::
- pre-commit hook: cargo clippy scoped to agent_core passed