### PR TITLE
fix: align canvas inline card with app theme

### DIFF
--- a/src/engines/ChatPanel/blocks/CanvasInlineCard/canvasBuilder.ts
+++ b/src/engines/ChatPanel/blocks/CanvasInlineCard/canvasBuilder.ts
@@ -12,23 +12,66 @@
  */
 import { IFRAME_STYLE_NONCE, stampStyleNonces } from "@src/util/iframeCspNonce";
 
+const CANVAS_THEME_VARIABLES = [
+  "--app-font-family",
+  "--code-font-family",
+  "--color-bg-1",
+  "--color-bg-2",
+  "--color-fill-2",
+  "--color-fill-3",
+  "--color-border-1",
+  "--color-text-1",
+  "--color-text-2",
+  "--color-primary-6",
+] as const;
+
+function buildThemeVariables(): string {
+  if (typeof window === "undefined") return "";
+
+  const styles = window.getComputedStyle(document.documentElement);
+  return CANVAS_THEME_VARIABLES.map((name) => {
+    const value = styles.getPropertyValue(name).trim();
+    return value ? `${name}:${value};` : "";
+  }).join("");
+}
+
+function buildThemeStyleTag(): string {
+  const themeVariables = buildThemeVariables();
+  if (!themeVariables) return "";
+  return `<style nonce="${IFRAME_STYLE_NONCE}">:root{${themeVariables}}</style>`;
+}
+
+function injectThemeVariables(html: string): string {
+  const themeStyleTag = buildThemeStyleTag();
+  if (!themeStyleTag) return html;
+
+  if (/<head\b[^>]*>/i.test(html)) {
+    return html.replace(/<head\b([^>]*)>/i, `<head$1>${themeStyleTag}`);
+  }
+
+  return html.replace(
+    /<html\b([^>]*)>/i,
+    `<html$1><head>${themeStyleTag}</head>`
+  );
+}
+
 const BASE_STYLES = `
   *,*::before,*::after{box-sizing:border-box;}
-  html,body{margin:0;padding:0;background:#141420;color:#e2e2e8;
-    font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+  html,body{margin:0;padding:0;background:var(--color-bg-2,#141420);color:var(--color-text-1,#e2e2e8);
+    font-family:var(--app-font-family,system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif);
     font-size:14px;line-height:1.6;min-height:100%;overflow-x:auto;}
-  a{color:#7c9ef7;text-decoration:none;}
+  a{color:var(--color-primary-6,#7c9ef7);text-decoration:none;}
   a:hover{text-decoration:underline;}
-  pre,code{font-family:monospace;
-    background:rgba(255,255,255,.06);padding:2px 5px;border-radius:4px;font-size:0.875em;}
+  pre,code{font-family:var(--code-font-family,monospace);
+    background:var(--color-fill-2,rgba(255,255,255,.06));padding:2px 5px;border-radius:4px;font-size:0.875em;}
   pre{padding:12px 16px;overflow-x:auto;border-radius:6px;
-    border:1px solid rgba(255,255,255,.08);}
+    border:1px solid var(--color-border-1,rgba(255,255,255,.08));}
   pre code{background:none;padding:0;}
   img{max-width:100%;height:auto;border-radius:4px;}
   button{cursor:pointer;}
   ::-webkit-scrollbar{width:6px;height:6px;}
   ::-webkit-scrollbar-track{background:transparent;}
-  ::-webkit-scrollbar-thumb{background:rgba(255,255,255,.15);border-radius:3px;}
+  ::-webkit-scrollbar-thumb{background:var(--color-fill-3,rgba(255,255,255,.15));border-radius:3px;}
 `;
 
 const EVAL_BRIDGE_SCRIPT = `
@@ -62,25 +105,27 @@ export function buildHtmlDocument(html: string): string {
     // Agent supplied a full document. Stamp nonces onto its inline <style>
     // blocks and ship it directly — wrapping it in another <html>/<body>
     // would invalidate the markup and strip the agent's styles.
-    return stampStyleNonces(html);
+    return injectThemeVariables(stampStyleNonces(html));
   }
+  const themeStyleTag = buildThemeStyleTag();
   return `<!DOCTYPE html><html lang="en"><head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<style nonce="${IFRAME_STYLE_NONCE}">${BASE_STYLES}</style>
+${themeStyleTag}<style nonce="${IFRAME_STYLE_NONCE}">${BASE_STYLES}</style>
 <script nonce="${IFRAME_STYLE_NONCE}">${EVAL_BRIDGE_SCRIPT}</script>
 </head><body style="padding:16px">${html}</body></html>`;
 }
 
 export function buildReactDocument(source: string): string {
   const escapedSource = escapeScriptContent(source);
+  const themeStyleTag = buildThemeStyleTag();
   return `<!DOCTYPE html><html lang="en"><head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<style nonce="${IFRAME_STYLE_NONCE}">${BASE_STYLES}
-body{padding:16px;background:#0f1018;color:#f3f4f8;}
+${themeStyleTag}<style nonce="${IFRAME_STYLE_NONCE}">${BASE_STYLES}
+body{padding:16px;background:var(--color-bg-2,#0f1018);color:var(--color-text-1,#f3f4f8);}
 #root{min-height:100vh;}
-#error{display:none;margin:12px 0;padding:12px;border:1px solid #ef4444;border-radius:8px;background:rgba(239,68,68,.1);color:#fecaca;white-space:pre-wrap;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;}
+#error{display:none;margin:12px 0;padding:12px;border:1px solid #ef4444;border-radius:8px;background:rgba(239,68,68,.1);color:#fecaca;white-space:pre-wrap;font-family:var(--code-font-family,ui-monospace,SFMono-Regular,Menlo,monospace);font-size:12px;}
 </style>
 </head><body><div id="root"></div><pre id="error"></pre>
 <script nonce="${IFRAME_STYLE_NONCE}">

--- a/src/engines/ChatPanel/blocks/CanvasInlineCard/index.tsx
+++ b/src/engines/ChatPanel/blocks/CanvasInlineCard/index.tsx
@@ -258,7 +258,6 @@ const CanvasInlineCard: React.FC<CanvasInlineCardProps> = ({
           {handleJumpToSimulator && (
             <IconButton
               onClick={handleJumpToSimulator}
-              className="text-text-4 hover:bg-fill-3 hover:text-primary-6"
               title={t("canvasCard.viewInSimulator", "View in Simulator")}
             >
               <Monitor size={12} />


### PR DESCRIPTION
## Summary
- Use shared IconButton styling for the Canvas inline card header action
- Inject app CSS theme variables into sandboxed canvas documents
- Remove hard-coded dark canvas colors from wrapped HTML/React previews

## Verification
- eslint --no-ignore on changed CanvasInlineCard files
- git diff --check
- pre-commit hook: lint-staged and scoped TypeScript check passed