### PR TITLE
fix(cli): unify agent binary resolution

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3774,6 +3774,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri",
+ "tempfile",
  "time",
  "tokio",
  "tokio-rustls",

--- a/src-tauri/crates/integrations/Cargo.toml
+++ b/src-tauri/crates/integrations/Cargo.toml
@@ -87,3 +87,6 @@ webpki-roots = { workspace = true }
 # is best-effort and the liveness check is gated out.
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[dev-dependencies]
+tempfile = "3"

--- a/src-tauri/crates/integrations/src/cli_binary_resolver.rs
+++ b/src-tauri/crates/integrations/src/cli_binary_resolver.rs
@@ -1,0 +1,514 @@
+use std::env;
+use std::ffi::OsString;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CliBinaryId {
+    CursorCli,
+    ClaudeCode,
+    Codex,
+    Aider,
+    GeminiCli,
+    Kiro,
+    Copilot,
+    Cline,
+    Goose,
+    OpenCode,
+    KimiCli,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CliBinaryResolutionSource {
+    ProcessPath,
+    LoginShell,
+    KnownLocation,
+    BareCommandFallback,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CliBinaryMetadata {
+    pub id: CliBinaryId,
+    pub row_id: &'static str,
+    pub display_name: &'static str,
+    pub command: &'static str,
+    pub launchable: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CliBinaryResolution {
+    pub metadata: &'static CliBinaryMetadata,
+    pub command: String,
+    pub source: CliBinaryResolutionSource,
+    pub diagnostics: Vec<String>,
+}
+
+impl CliBinaryResolution {
+    pub fn installed(&self) -> bool {
+        !matches!(self.source, CliBinaryResolutionSource::BareCommandFallback)
+    }
+
+    pub fn path_for_detection(&self) -> String {
+        if self.installed() {
+            self.command.clone()
+        } else {
+            String::new()
+        }
+    }
+}
+
+const LOGIN_SHELL_TIMEOUT: Duration = Duration::from_secs(3);
+
+const CLI_BINARY_METADATA: &[CliBinaryMetadata] = &[
+    CliBinaryMetadata {
+        id: CliBinaryId::CursorCli,
+        row_id: "cursor-agent",
+        display_name: "Cursor Agent",
+        command: "cursor-agent",
+        launchable: true,
+    },
+    CliBinaryMetadata {
+        id: CliBinaryId::ClaudeCode,
+        row_id: "claude",
+        display_name: "Claude Code",
+        command: "claude",
+        launchable: true,
+    },
+    CliBinaryMetadata {
+        id: CliBinaryId::Codex,
+        row_id: "codex",
+        display_name: "Codex",
+        command: "codex",
+        launchable: true,
+    },
+    CliBinaryMetadata {
+        id: CliBinaryId::Aider,
+        row_id: "aider",
+        display_name: "Aider",
+        command: "aider",
+        launchable: false,
+    },
+    CliBinaryMetadata {
+        id: CliBinaryId::GeminiCli,
+        row_id: "gemini-cli",
+        display_name: "Gemini CLI",
+        command: "gemini",
+        launchable: true,
+    },
+    CliBinaryMetadata {
+        id: CliBinaryId::Kiro,
+        row_id: "kiro",
+        display_name: "Kiro",
+        command: "kiro-cli",
+        launchable: true,
+    },
+    CliBinaryMetadata {
+        id: CliBinaryId::Copilot,
+        row_id: "copilot",
+        display_name: "Copilot",
+        command: "copilot",
+        launchable: true,
+    },
+    CliBinaryMetadata {
+        id: CliBinaryId::Cline,
+        row_id: "cline",
+        display_name: "Cline",
+        command: "cline",
+        launchable: false,
+    },
+    CliBinaryMetadata {
+        id: CliBinaryId::Goose,
+        row_id: "goose",
+        display_name: "Goose",
+        command: "goose",
+        launchable: false,
+    },
+    CliBinaryMetadata {
+        id: CliBinaryId::OpenCode,
+        row_id: "opencode",
+        display_name: "OpenCode",
+        command: "opencode",
+        launchable: true,
+    },
+    CliBinaryMetadata {
+        id: CliBinaryId::KimiCli,
+        row_id: "kimi",
+        display_name: "Kimi",
+        command: "kimi",
+        launchable: true,
+    },
+];
+
+pub fn all_cli_binary_metadata() -> &'static [CliBinaryMetadata] {
+    CLI_BINARY_METADATA
+}
+
+pub fn launchable_cli_binary_metadata() -> impl Iterator<Item = &'static CliBinaryMetadata> {
+    CLI_BINARY_METADATA
+        .iter()
+        .filter(|metadata| metadata.launchable)
+}
+
+pub fn metadata_for_id(id: CliBinaryId) -> &'static CliBinaryMetadata {
+    CLI_BINARY_METADATA
+        .iter()
+        .find(|metadata| metadata.id == id)
+        .expect("missing CLI binary metadata")
+}
+
+pub fn resolve_cli_binary(id: CliBinaryId) -> CliBinaryResolution {
+    resolve_cli_binary_with_options(id, &ResolveOptions::default())
+}
+
+pub fn resolve_cli_binary_command(id: CliBinaryId) -> String {
+    resolve_cli_binary(id).command
+}
+
+#[derive(Debug, Clone)]
+struct ResolveOptions {
+    path_env: Option<OsString>,
+    shell: Option<OsString>,
+    home_dir: Option<PathBuf>,
+    login_shell_timeout: Duration,
+}
+
+impl Default for ResolveOptions {
+    fn default() -> Self {
+        Self {
+            path_env: env::var_os("PATH"),
+            shell: env::var_os("SHELL"),
+            home_dir: dirs::home_dir(),
+            login_shell_timeout: LOGIN_SHELL_TIMEOUT,
+        }
+    }
+}
+
+fn resolve_cli_binary_with_options(
+    id: CliBinaryId,
+    options: &ResolveOptions,
+) -> CliBinaryResolution {
+    let metadata = metadata_for_id(id);
+    let mut diagnostics = Vec::new();
+
+    if let Some(path) = find_on_process_path(metadata.command, options.path_env.as_ref()) {
+        return CliBinaryResolution {
+            metadata,
+            command: path.to_string_lossy().to_string(),
+            source: CliBinaryResolutionSource::ProcessPath,
+            diagnostics,
+        };
+    }
+    diagnostics.push(format!("{} not found on process PATH", metadata.command));
+
+    if let Some(path) = resolve_via_login_shell(metadata.command, options) {
+        return CliBinaryResolution {
+            metadata,
+            command: path.to_string_lossy().to_string(),
+            source: CliBinaryResolutionSource::LoginShell,
+            diagnostics,
+        };
+    }
+    diagnostics.push(format!(
+        "{} not found via login-shell lookup",
+        metadata.command
+    ));
+
+    if let Some(path) = known_locations_for(id, options)
+        .into_iter()
+        .find(|path| is_executable_file(path))
+    {
+        return CliBinaryResolution {
+            metadata,
+            command: path.to_string_lossy().to_string(),
+            source: CliBinaryResolutionSource::KnownLocation,
+            diagnostics,
+        };
+    }
+    diagnostics.push(format!(
+        "{} not found in known install locations",
+        metadata.command
+    ));
+
+    CliBinaryResolution {
+        metadata,
+        command: metadata.command.to_string(),
+        source: CliBinaryResolutionSource::BareCommandFallback,
+        diagnostics,
+    }
+}
+
+fn find_on_process_path(command: &str, path_env: Option<&OsString>) -> Option<PathBuf> {
+    if contains_path_separator(command) {
+        let path = PathBuf::from(command);
+        return is_executable_file(&path).then_some(path);
+    }
+
+    let path_env = path_env?;
+    env::split_paths(path_env)
+        .flat_map(|dir| command_path_candidates(&dir, command))
+        .find(|path| is_executable_file(path))
+}
+
+fn known_locations_for(id: CliBinaryId, options: &ResolveOptions) -> Vec<PathBuf> {
+    match id {
+        CliBinaryId::CursorCli => options
+            .home_dir
+            .as_ref()
+            .map(|home| vec![home.join(".local/bin/cursor-agent")])
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
+
+#[cfg(unix)]
+fn resolve_via_login_shell(command: &str, options: &ResolveOptions) -> Option<PathBuf> {
+    let shell = options
+        .shell
+        .clone()
+        .filter(|shell| !shell.is_empty())
+        .unwrap_or_else(|| OsString::from("/bin/zsh"));
+    let script = format!("command -v -- {}", shell_quote(command));
+    let stdout = run_shell_command_with_timeout(&shell, &script, options.login_shell_timeout)?;
+    stdout.lines().find_map(parse_command_v_path)
+}
+
+#[cfg(unix)]
+fn run_shell_command_with_timeout(
+    shell: &OsString,
+    script: &str,
+    timeout: Duration,
+) -> Option<String> {
+    let mut child = Command::new(shell)
+        .args(["-i", "-l", "-c", script])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+
+    let started_at = std::time::Instant::now();
+    loop {
+        if let Ok(Some(status)) = child.try_wait() {
+            if !status.success() {
+                return None;
+            }
+            let mut stdout = String::new();
+            child.stdout.take()?.read_to_string(&mut stdout).ok()?;
+            return Some(stdout);
+        }
+
+        if started_at.elapsed() >= timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            return None;
+        }
+
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+#[cfg(not(unix))]
+fn resolve_via_login_shell(_command: &str, _options: &ResolveOptions) -> Option<PathBuf> {
+    None
+}
+
+fn parse_command_v_path(line: &str) -> Option<PathBuf> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() || trimmed.contains('\n') || trimmed.contains('\r') {
+        return None;
+    }
+
+    let path = Path::new(trimmed);
+    if path.is_absolute() && is_executable_file(path) {
+        Some(path.to_path_buf())
+    } else {
+        None
+    }
+}
+
+fn contains_path_separator(command: &str) -> bool {
+    command.contains('/') || command.contains('\\')
+}
+
+fn command_path_candidates(dir: &Path, command: &str) -> Vec<PathBuf> {
+    #[cfg(windows)]
+    {
+        if Path::new(command).extension().is_some() {
+            return vec![dir.join(command)];
+        }
+
+        let path_ext = env::var_os("PATHEXT")
+            .and_then(|value| value.into_string().ok())
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| ".COM;.EXE;.BAT;.CMD".to_string());
+
+        path_ext
+            .split(';')
+            .filter_map(|extension| {
+                let extension = extension.trim();
+                if extension.is_empty() {
+                    None
+                } else if extension.starts_with('.') {
+                    Some(dir.join(format!("{command}{extension}")))
+                } else {
+                    Some(dir.join(format!("{command}.{extension}")))
+                }
+            })
+            .collect()
+    }
+    #[cfg(not(windows))]
+    {
+        vec![dir.join(command)]
+    }
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    if !path.is_file() {
+        return false;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        path.metadata()
+            .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+    }
+
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+#[cfg(unix)]
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn make_executable(path: &Path) {
+        fs::write(path, "#!/bin/sh\nexit 0\n").unwrap();
+        set_executable(path);
+    }
+
+    fn set_executable(path: &Path) {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = fs::metadata(path).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(path, permissions).unwrap();
+        }
+    }
+
+    #[test]
+    fn command_path_candidates_include_platform_command() {
+        let dir = Path::new("/tmp/bin");
+        let candidates = command_path_candidates(dir, "codex");
+
+        #[cfg(windows)]
+        assert!(candidates
+            .iter()
+            .any(|path| path.file_name().and_then(|name| name.to_str()) == Some("codex.CMD")));
+
+        #[cfg(not(windows))]
+        assert_eq!(candidates, vec![dir.join("codex")]);
+    }
+
+    #[test]
+    fn process_path_hit_returns_absolute_path() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let binary = temp_dir.path().join("codex");
+        make_executable(&binary);
+
+        let options = ResolveOptions {
+            path_env: Some(OsString::from(temp_dir.path().as_os_str())),
+            shell: Some(OsString::from("/bin/false")),
+            home_dir: None,
+            login_shell_timeout: Duration::from_millis(10),
+        };
+
+        let resolution = resolve_cli_binary_with_options(CliBinaryId::Codex, &options);
+        assert_eq!(resolution.command, binary.to_string_lossy());
+        assert_eq!(resolution.source, CliBinaryResolutionSource::ProcessPath);
+        assert!(resolution.installed());
+    }
+
+    #[test]
+    fn cursor_known_location_fallback_is_preserved() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let bin_dir = temp_dir.path().join(".local/bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+        let binary = bin_dir.join("cursor-agent");
+        make_executable(&binary);
+
+        let options = ResolveOptions {
+            path_env: Some(OsString::new()),
+            shell: Some(OsString::from("/bin/false")),
+            home_dir: Some(temp_dir.path().to_path_buf()),
+            login_shell_timeout: Duration::from_millis(10),
+        };
+
+        let resolution = resolve_cli_binary_with_options(CliBinaryId::CursorCli, &options);
+        assert_eq!(resolution.command, binary.to_string_lossy());
+        assert_eq!(resolution.source, CliBinaryResolutionSource::KnownLocation);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn login_shell_fallback_rejects_non_path_output() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let shell = temp_dir.path().join("fake-shell");
+        fs::write(&shell, "#!/bin/sh\nprintf 'codex is a function\\n'\n").unwrap();
+        set_executable(&shell);
+
+        let options = ResolveOptions {
+            path_env: Some(OsString::new()),
+            shell: Some(shell.into_os_string()),
+            home_dir: None,
+            login_shell_timeout: Duration::from_millis(500),
+        };
+
+        let resolution = resolve_cli_binary_with_options(CliBinaryId::Codex, &options);
+        assert_eq!(resolution.command, "codex");
+        assert_eq!(
+            resolution.source,
+            CliBinaryResolutionSource::BareCommandFallback
+        );
+        assert!(!resolution.installed());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn login_shell_output_accepts_executable_absolute_path() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let bin_dir = temp_dir.path().join("bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+        let binary = bin_dir.join("claude");
+        make_executable(&binary);
+
+        let shell = OsString::from("/bin/sh");
+        let stdout = run_shell_command_with_timeout(
+            &shell,
+            &format!("printf '{}\\n'", binary.to_string_lossy()),
+            Duration::from_millis(500),
+        )
+        .unwrap();
+
+        assert_eq!(stdout.lines().find_map(parse_command_v_path), Some(binary));
+    }
+
+    #[test]
+    fn kiro_canonical_command_is_kiro_cli() {
+        let metadata = metadata_for_id(CliBinaryId::Kiro);
+        assert_eq!(metadata.command, "kiro-cli");
+        assert_eq!(metadata.row_id, "kiro");
+    }
+}

--- a/src-tauri/crates/integrations/src/external_ide.rs
+++ b/src-tauri/crates/integrations/src/external_ide.rs
@@ -5,6 +5,8 @@
 use std::process::Command;
 use tokio::process::Command as AsyncCommand;
 
+use crate::cli_binary_resolver::{all_cli_binary_metadata, resolve_cli_binary};
+
 // ============================================
 // IDE Detection
 // ============================================
@@ -20,7 +22,7 @@ use tokio::process::Command as AsyncCommand;
 /// - **last_used**: via macOS Spotlight (`mdls`), or file modification time
 #[tauri::command]
 pub async fn server_detect_ides() -> Result<Vec<serde_json::Value>, String> {
-    // (id, display_name, cli_binary, category) — detected via `which`/`where`
+    // (id, display_name, cli_binary, category) — GUI IDE CLIs stay on `which`/`where`.
     let cli_ides: Vec<(&str, &str, &str, &str)> = vec![
         ("vscode", "Visual Studio Code", "code", "ide"),
         (
@@ -54,21 +56,11 @@ pub async fn server_detect_ides() -> Result<Vec<serde_json::Value>, String> {
         ("eclipse", "Eclipse", "eclipse", "ide"),
         ("netbeans", "NetBeans", "netbeans", "ide"),
         ("atom", "Atom", "atom", "ide"),
-        ("claude", "Claude Code", "claude", "ai_cli"),
-        ("codex", "Codex", "codex", "ai_cli"),
-        ("aider", "Aider", "aider", "ai_cli"),
-        ("gemini-cli", "Gemini CLI", "gemini", "ai_cli"),
-        ("kiro", "Kiro", "kiro", "ai_cli"),
-        ("copilot", "Copilot", "copilot", "ai_cli"),
-        ("cline", "Cline", "cline", "ai_cli"),
-        ("goose", "Goose", "goose", "ai_cli"),
-        ("opencode", "OpenCode", "opencode", "ai_cli"),
-        ("kimi", "Kimi", "kimi", "ai_cli"),
     ];
 
     let which_cmd = if cfg!(windows) { "where" } else { "which" };
 
-    // Stage 1: detect which CLIs are present (parallel)
+    // Stage 1: detect which GUI IDE CLIs are present (parallel)
     let cli_futures: Vec<_> = cli_ides
         .iter()
         .map(|(ide_id, name, binary, category)| async move {
@@ -94,7 +86,22 @@ pub async fn server_detect_ides() -> Result<Vec<serde_json::Value>, String> {
         })
         .collect();
 
-    let cli_results = futures::future::join_all(cli_futures).await;
+    let mut cli_results = futures::future::join_all(cli_futures).await;
+    let ai_cli_results = all_cli_binary_metadata()
+        .iter()
+        .map(|metadata| {
+            let resolution = resolve_cli_binary(metadata.id);
+            (
+                metadata.row_id,
+                metadata.display_name,
+                metadata.command,
+                "ai_cli",
+                resolution.installed(),
+                resolution.path_for_detection(),
+            )
+        })
+        .collect::<Vec<_>>();
+    cli_results.extend(ai_cli_results);
 
     let mut results = Vec::new();
     let mut found_ids = std::collections::HashSet::<String>::new();

--- a/src-tauri/crates/integrations/src/lib.rs
+++ b/src-tauri/crates/integrations/src/lib.rs
@@ -15,6 +15,7 @@
 //! Note: Cursor and Kiro runner-specific modules (credential capture, usage
 //! tracking, SSO) live in `agent_sessions::cli::platform_adapters::{cursor,kiro}`.
 
+pub mod cli_binary_resolver;
 pub mod commands;
 pub mod computer_use_lock;
 pub mod external_ide;

--- a/src-tauri/src/agent_sessions/cli/session_runner/command.rs
+++ b/src-tauri/src/agent_sessions/cli/session_runner/command.rs
@@ -5,22 +5,25 @@ use crate::agent_sessions::cli::parsers::codex::CodexParser;
 use crate::agent_sessions::cli::parsers::cursor::CursorParser;
 use crate::agent_sessions::cli::parsers::gemini::GeminiParser;
 use crate::agent_sessions::cli::parsers::CliAgentParser;
+use integrations::cli_binary_resolver::{resolve_cli_binary_command, CliBinaryId};
 use key_vault::key_store::ModelType;
 
-/// Resolve the full path to the `cursor-agent` binary.
-///
-/// Prefers `~/.local/bin/cursor-agent` (installed by `cursor-agent update` or
-/// `curl -sS https://cursor.com/install | bash`). Falls back to the bare
-/// command name if the home directory cannot be resolved (which would be
-/// extraordinary on macOS/Linux).
-pub(super) fn resolve_cursor_agent_path() -> String {
-    if let Some(home) = dirs::home_dir() {
-        let path = home.join(".local/bin/cursor-agent");
-        if path.is_file() {
-            return path.to_string_lossy().to_string();
-        }
-    }
-    "cursor-agent".to_string()
+pub(super) fn resolve_cli_agent_command(agent: &ModelType) -> String {
+    let binary_id = match agent {
+        ModelType::CursorCli => CliBinaryId::CursorCli,
+        ModelType::ClaudeCode => CliBinaryId::ClaudeCode,
+        ModelType::Codex => CliBinaryId::Codex,
+        ModelType::GeminiCli => CliBinaryId::GeminiCli,
+        ModelType::Kiro => CliBinaryId::Kiro,
+        ModelType::Copilot => CliBinaryId::Copilot,
+        ModelType::OpenCode => CliBinaryId::OpenCode,
+        ModelType::KimiCli => CliBinaryId::KimiCli,
+        other => panic!(
+            "ModelType::{:?} is not a CLI agent — cannot resolve command",
+            other
+        ),
+    };
+    resolve_cli_binary_command(binary_id)
 }
 
 /// Build the CLI command for a given CLI agent type.
@@ -56,8 +59,7 @@ pub(super) fn build_command(
     }
     match agent {
         ModelType::CursorCli => {
-            let cursor_agent_bin = resolve_cursor_agent_path();
-            let mut cmd = vec![cursor_agent_bin, "agent".into()];
+            let mut cmd = vec![resolve_cli_agent_command(agent), "agent".into()];
             cmd.push("--output-format".into());
             cmd.push("stream-json".into());
             cmd.push("--stream-partial-output".into());
@@ -99,7 +101,7 @@ pub(super) fn build_command(
             cmd
         }
         ModelType::ClaudeCode => {
-            let mut cmd = vec!["claude".into()];
+            let mut cmd = vec![resolve_cli_agent_command(agent)];
             cmd.push("--output-format".into());
             cmd.push("stream-json".into());
             cmd.push("--verbose".into());
@@ -127,7 +129,7 @@ pub(super) fn build_command(
             cmd
         }
         ModelType::Codex => {
-            let mut cmd = vec!["codex".into(), "exec".into()];
+            let mut cmd = vec![resolve_cli_agent_command(agent), "exec".into()];
             cmd.push("--json".into());
             cmd.push("--skip-git-repo-check".into());
             cmd.push("--sandbox".into());
@@ -156,7 +158,7 @@ pub(super) fn build_command(
             cmd
         }
         ModelType::GeminiCli => {
-            let mut cmd = vec!["gemini".into()];
+            let mut cmd = vec![resolve_cli_agent_command(agent)];
             cmd.push("--output-format".into());
             cmd.push("stream-json".into());
             cmd.push("--yolo".into());
@@ -172,12 +174,13 @@ pub(super) fn build_command(
             cmd.push(task.into());
             cmd
         }
-        ModelType::Kiro => {
-            let cmd = vec!["kiro-cli".into(), "acp".into()];
-            cmd
-        }
+        ModelType::Kiro => vec![resolve_cli_agent_command(agent), "acp".into()],
         ModelType::Copilot => {
-            let mut cmd = vec!["copilot".into(), "--acp".into(), "--stdio".into()];
+            let mut cmd = vec![
+                resolve_cli_agent_command(agent),
+                "--acp".into(),
+                "--stdio".into(),
+            ];
             cmd.push("--allow-all-tools".to_string());
             if let Some(rid) = resume_id {
                 cmd.push("--resume".into());
@@ -189,10 +192,7 @@ pub(super) fn build_command(
             }
             cmd
         }
-        ModelType::OpenCode => {
-            let cmd = vec!["opencode".into(), "acp".into()];
-            cmd
-        }
+        ModelType::OpenCode => vec![resolve_cli_agent_command(agent), "acp".into()],
         other => {
             panic!(
                 "ModelType::{:?} is not a CLI agent — cannot build command",

--- a/src-tauri/src/agent_sessions/cli/session_runner/session.rs
+++ b/src-tauri/src/agent_sessions/cli/session_runner/session.rs
@@ -14,6 +14,7 @@ use tokio::sync::Mutex;
 use crate::agent_sessions::cli::parsers::copilot;
 use crate::agent_sessions::cli::parsers::kiro;
 use crate::api::websocket_handler;
+use integrations::cli_binary_resolver::{resolve_cli_binary_command, CliBinaryId};
 use key_vault::key_store::{KeyService, ModelKey, ModelType, KEY_SERVICE};
 
 use super::super::persistence;
@@ -799,8 +800,12 @@ pub async fn run_session(
 
         let api_key_val = session.proxy_token.as_deref().unwrap_or("");
         if !api_key_val.is_empty() {
-            tracing::info!("[CodeSession] Running codex login --with-api-key...");
-            let mut login_cmd = Command::new("codex");
+            let codex_bin = resolve_cli_binary_command(CliBinaryId::Codex);
+            tracing::info!(
+                "[CodeSession] Running codex login --with-api-key via {}...",
+                codex_bin
+            );
+            let mut login_cmd = Command::new(&codex_bin);
             login_cmd
                 .arg("login")
                 .arg("--with-api-key")

--- a/src-tauri/src/agent_sessions/cli/tests/runner_command_tests.rs
+++ b/src-tauri/src/agent_sessions/cli/tests/runner_command_tests.rs
@@ -1,5 +1,13 @@
 use super::command::{build_command, map_claude_model};
 use key_vault::key_store::ModelType;
+use std::path::Path;
+
+fn command_name(command: &str) -> &str {
+    Path::new(command)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(command)
+}
 
 // ============================================
 // build_command — CursorCli
@@ -18,7 +26,7 @@ fn build_cursor_cli_basic() {
         None,
         &[],
     );
-    assert!(cmd[0].contains("cursor-agent") || cmd[0] == "cursor-agent");
+    assert_eq!(command_name(&cmd[0]), "cursor-agent");
     assert!(cmd.contains(&"agent".to_string()));
     assert!(cmd.contains(&"--output-format".to_string()));
     assert!(cmd.contains(&"stream-json".to_string()));
@@ -87,7 +95,7 @@ fn build_claude_code_basic() {
         None,
         &[],
     );
-    assert_eq!(cmd[0], "claude");
+    assert_eq!(command_name(&cmd[0]), "claude");
     assert!(cmd.contains(&"--output-format".to_string()));
     assert!(cmd.contains(&"--verbose".to_string()));
     assert!(cmd.contains(&"--dangerously-skip-permissions".to_string()));
@@ -130,7 +138,7 @@ fn build_codex_basic() {
         None,
         &[],
     );
-    assert_eq!(cmd[0], "codex");
+    assert_eq!(command_name(&cmd[0]), "codex");
     assert_eq!(cmd[1], "exec");
     assert!(cmd.contains(&"--json".to_string()));
     assert!(cmd.contains(&"-m".to_string()));
@@ -172,7 +180,7 @@ fn build_gemini_cli_basic() {
         None,
         &[],
     );
-    assert_eq!(cmd[0], "gemini");
+    assert_eq!(command_name(&cmd[0]), "gemini");
     assert!(cmd.contains(&"--yolo".to_string()));
     assert!(cmd.contains(&"--model".to_string()));
     assert!(cmd.contains(&"-p".to_string()));
@@ -195,7 +203,7 @@ fn build_kiro_basic() {
         None,
         &[],
     );
-    assert_eq!(cmd[0], "kiro-cli");
+    assert_eq!(command_name(&cmd[0]), "kiro-cli");
     assert_eq!(cmd[1], "acp");
 }
 
@@ -216,10 +224,31 @@ fn build_copilot_basic() {
         None,
         &[],
     );
-    assert_eq!(cmd[0], "copilot");
+    assert_eq!(command_name(&cmd[0]), "copilot");
     assert!(cmd.contains(&"--acp".to_string()));
     assert!(cmd.contains(&"--stdio".to_string()));
     assert!(cmd.contains(&"--allow-all-tools".to_string()));
+}
+
+// ============================================
+// build_command — OpenCode
+// ============================================
+
+#[test]
+fn build_opencode_basic() {
+    let cmd = build_command(
+        &ModelType::OpenCode,
+        None,
+        "task",
+        None,
+        None,
+        None,
+        None,
+        None,
+        &[],
+    );
+    assert_eq!(command_name(&cmd[0]), "opencode");
+    assert_eq!(cmd[1], "acp");
 }
 
 // ============================================


### PR DESCRIPTION
## Summary
- Add a shared CLI-agent binary resolver for AI CLI detection and launch.
- Wire Codex, Claude Code, Gemini, Kiro, Copilot, OpenCode, and Cursor session launch through the resolver while preserving existing command arguments.
- Use the same resolver for `server_detect_ides` AI CLI rows and the separate `codex login --with-api-key` path.

## Test plan
- `cargo test -p integrations cli_binary_resolver`
- `cargo test -p org2 agent_sessions::cli::tests::runner_command_tests`
- `cargo check -p integrations -p org2`

Closes #218