### PR TITLE
Fix terminal default shell selection on Linux

### DIFF
--- a/src-tauri/crates/terminal/src/agent_tool/mod.rs
+++ b/src-tauri/crates/terminal/src/agent_tool/mod.rs
@@ -91,6 +91,59 @@ const CLOSE_FLUSH_MS: u64 = 250;
 // Session Management
 // ============================================
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DefaultShellPlatform {
+    #[cfg(any(test, target_os = "windows"))]
+    Windows,
+    #[cfg(any(test, target_os = "macos"))]
+    Macos,
+    #[cfg(any(test, all(unix, not(target_os = "macos"))))]
+    Unix,
+}
+
+pub(crate) fn resolve_default_shell_path(
+    platform: DefaultShellPlatform,
+    shell_env: Option<&str>,
+) -> String {
+    match platform {
+        #[cfg(any(test, target_os = "windows"))]
+        DefaultShellPlatform::Windows => "powershell.exe".to_string(),
+        #[cfg(any(test, target_os = "macos"))]
+        DefaultShellPlatform::Macos => shell_env
+            .filter(|shell| !shell.trim().is_empty())
+            .unwrap_or("zsh")
+            .to_string(),
+        #[cfg(any(test, all(unix, not(target_os = "macos"))))]
+        DefaultShellPlatform::Unix => shell_env
+            .filter(|shell| !shell.trim().is_empty())
+            .unwrap_or("bash")
+            .to_string(),
+    }
+}
+
+fn default_shell_path() -> String {
+    #[cfg(target_os = "windows")]
+    {
+        resolve_default_shell_path(DefaultShellPlatform::Windows, None)
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        resolve_default_shell_path(
+            DefaultShellPlatform::Macos,
+            std::env::var("SHELL").ok().as_deref(),
+        )
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        resolve_default_shell_path(
+            DefaultShellPlatform::Unix,
+            std::env::var("SHELL").ok().as_deref(),
+        )
+    }
+}
+
 /// Parameters for creating a new PTY session.
 pub struct CreateSessionParams {
     pub session_id: String,
@@ -143,18 +196,7 @@ pub async fn create_session(params: CreateSessionParams) -> Result<(), String> {
         .map_err(|err| format!("Failed to create PTY: {}", err))?;
 
     // Determine shell to use
-    let shell_path = if let Some(ref shell_override) = shell {
-        shell_override.clone()
-    } else {
-        #[cfg(target_os = "windows")]
-        {
-            "powershell.exe".to_string()
-        }
-        #[cfg(not(target_os = "windows"))]
-        {
-            "zsh".to_string()
-        }
-    };
+    let shell_path = shell.unwrap_or_else(default_shell_path);
 
     let shell_kind = ShellKind::from_shell_path(&shell_path);
 

--- a/src-tauri/crates/terminal/src/tests/agent_tool_tests.rs
+++ b/src-tauri/crates/terminal/src/tests/agent_tool_tests.rs
@@ -1,5 +1,126 @@
 use crate::agent_tool::*;
 
+#[cfg(any(target_os = "windows", unix))]
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+// ============================================
+// default_shell_path
+// ============================================
+
+#[test]
+fn resolve_default_shell_path_uses_powershell_on_windows() {
+    assert_eq!(
+        resolve_default_shell_path(DefaultShellPlatform::Windows, Some("/bin/bash")),
+        "powershell.exe"
+    );
+}
+
+#[test]
+fn resolve_default_shell_path_uses_shell_env_on_macos() {
+    assert_eq!(
+        resolve_default_shell_path(DefaultShellPlatform::Macos, Some("/bin/bash")),
+        "/bin/bash"
+    );
+}
+
+#[test]
+fn resolve_default_shell_path_falls_back_to_zsh_on_macos() {
+    assert_eq!(
+        resolve_default_shell_path(DefaultShellPlatform::Macos, None),
+        "zsh"
+    );
+    assert_eq!(
+        resolve_default_shell_path(DefaultShellPlatform::Macos, Some("  ")),
+        "zsh"
+    );
+}
+
+#[test]
+fn resolve_default_shell_path_uses_shell_env_on_unix() {
+    assert_eq!(
+        resolve_default_shell_path(DefaultShellPlatform::Unix, Some("/usr/bin/bash")),
+        "/usr/bin/bash"
+    );
+}
+
+#[test]
+fn resolve_default_shell_path_falls_back_to_bash_on_unix() {
+    assert_eq!(
+        resolve_default_shell_path(DefaultShellPlatform::Unix, None),
+        "bash"
+    );
+    assert_eq!(
+        resolve_default_shell_path(DefaultShellPlatform::Unix, Some("  ")),
+        "bash"
+    );
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn default_shell_path_matches_windows_platform() {
+    assert_eq!(default_shell_path(), "powershell.exe");
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn default_shell_path_uses_shell_env_on_macos_platform() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let previous = std::env::var_os("SHELL");
+
+    std::env::set_var("SHELL", "/bin/bash");
+    assert_eq!(default_shell_path(), "/bin/bash");
+
+    if let Some(value) = previous {
+        std::env::set_var("SHELL", value);
+    } else {
+        std::env::remove_var("SHELL");
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn default_shell_path_falls_back_to_zsh_on_macos_platform() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let previous = std::env::var_os("SHELL");
+
+    std::env::remove_var("SHELL");
+    assert_eq!(default_shell_path(), "zsh");
+
+    if let Some(value) = previous {
+        std::env::set_var("SHELL", value);
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
+fn default_shell_path_uses_shell_env_on_unix_platform() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let previous = std::env::var_os("SHELL");
+
+    std::env::set_var("SHELL", "/usr/bin/bash");
+    assert_eq!(default_shell_path(), "/usr/bin/bash");
+
+    if let Some(value) = previous {
+        std::env::set_var("SHELL", value);
+    } else {
+        std::env::remove_var("SHELL");
+    }
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+#[test]
+fn default_shell_path_falls_back_to_bash_on_unix_platform() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    let previous = std::env::var_os("SHELL");
+
+    std::env::remove_var("SHELL");
+    assert_eq!(default_shell_path(), "bash");
+
+    if let Some(value) = previous {
+        std::env::set_var("SHELL", value);
+    }
+}
+
 // ============================================
 // clean_pty_output
 // ============================================


### PR DESCRIPTION
## Summary

- Fix terminal shell selection so Linux/Unix no longer defaults to `zsh` when no explicit shell is configured.
- Respect `$SHELL` on Unix-like platforms, with platform-specific fallbacks.
- Add cross-platform unit coverage for Windows, macOS, and Unix default-shell resolution.

## Behavior

Default shell selection is now:

1. explicit shell override, when provided
2. Windows: `powershell.exe`
3. macOS: `$SHELL`, falling back to `zsh`
4. Linux/other Unix: `$SHELL`, falling back to `bash`

This intentionally changes macOS behavior for users who changed their login shell away from zsh: ORG2 now respects their `$SHELL`. macOS users without a custom/default shell env continue to fall back to `zsh`.

Fixes #236.

## Verification

- `cargo fmt -p terminal`
- `cargo check -p terminal`
- Local Linux app verification: new terminal starts with bash instead of attempting zsh

Note: targeted/full terminal tests are currently blocked by an unrelated existing Linux test import error in `src-tauri/crates/terminal/src/pty_commands/tests/shells_tests.rs` (`parse_tpgid_from_stat` import path).
