### PR TITLE
fix(git): clarify local service failures

### DIFF
--- a/src/api/http/git/branchOps.ts
+++ b/src/api/http/git/branchOps.ts
@@ -9,6 +9,11 @@ import { fetchRustApi, gitRepoUrl } from "./client";
 
 const log = createLogger("GitAPI");
 
+export interface GitBranchMutationResult {
+  success: boolean;
+  error?: string;
+}
+
 /**
  * Create a new branch
  * Uses Rust HTTP server
@@ -19,7 +24,7 @@ export const gitCreateBranch = async (params: {
   name: string;
   start_point?: string | null;
   checkout?: boolean;
-}): Promise<boolean> => {
+}): Promise<GitBranchMutationResult> => {
   const queryParams = new URLSearchParams();
   if (params.repo_path) queryParams.append("path", params.repo_path);
 
@@ -35,10 +40,11 @@ export const gitCreateBranch = async (params: {
         }),
       }
     );
-    return true;
+    return { success: true };
   } catch (error) {
-    log.error("[GitAPI] Failed to create branch:", error);
-    return false;
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    log.error("[GitAPI] Failed to create branch:", errorMessage);
+    return { success: false, error: errorMessage };
   }
 };
 
@@ -51,7 +57,7 @@ export const gitDeleteBranch = async (params: {
   repo_path?: string;
   branch_name: string;
   force?: boolean;
-}): Promise<boolean> => {
+}): Promise<GitBranchMutationResult> => {
   const queryParams = new URLSearchParams();
   if (params.repo_path) queryParams.append("path", params.repo_path);
 
@@ -60,10 +66,11 @@ export const gitDeleteBranch = async (params: {
       `${gitRepoUrl(params.repo_id)}/branch/${encodeURIComponent(params.branch_name)}${queryParams.toString() ? `?${queryParams.toString()}` : ""}`,
       { method: "DELETE" }
     );
-    return true;
+    return { success: true };
   } catch (error) {
-    log.error("[GitAPI] Failed to delete branch:", error);
-    return false;
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    log.error("[GitAPI] Failed to delete branch:", errorMessage);
+    return { success: false, error: errorMessage };
   }
 };
 

--- a/src/api/http/git/scopedGitApi.ts
+++ b/src/api/http/git/scopedGitApi.ts
@@ -22,12 +22,13 @@ import {
 
 import { gitCommit } from "./commits";
 import { gitDiscardChanges, gitStageFiles, gitUnstageFiles } from "./staging";
+import type { GitCommitResponse } from "./types";
 
 export interface ScopedGitApi {
   stage: (files: string[]) => Promise<boolean>;
   unstage: (files: string[]) => Promise<boolean>;
   discard: (files: string[]) => Promise<boolean>;
-  commit: (message: string) => Promise<unknown>;
+  commit: (message: string) => Promise<GitCommitResponse["data"]>;
 }
 
 export function createScopedGitApi(

--- a/src/features/SessionCreator/components/SessionInfoLine.tsx
+++ b/src/features/SessionCreator/components/SessionInfoLine.tsx
@@ -289,14 +289,20 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
   const handleCreateBranch = useCallback(
     async (branch: string, startPoint?: string) => {
       if (!repoId || !repoPath) return;
-      const success = await gitApi.gitCreateBranch({
+      const result = await gitApi.gitCreateBranch({
         repo_id: repoId,
         repo_path: repoPath,
         name: branch,
         start_point: startPoint ?? null,
         checkout: false,
       });
-      if (!success) return;
+      if (!result.success) {
+        showGitActionDialogSafely(
+          result.error || `Failed to create branch "${branch}"`,
+          "error"
+        );
+        return;
+      }
       await handleBranchSelect(branch);
     },
     [handleBranchSelect, repoId, repoPath]
@@ -315,14 +321,14 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
         return { success: false, message };
       }
 
-      const success = await gitApi.gitDeleteBranch({
+      const result = await gitApi.gitDeleteBranch({
         repo_id: repoId,
         repo_path: repoPath,
         branch_name: branch,
       });
 
-      if (!success) {
-        const message = `Failed to delete branch "${branch}"`;
+      if (!result.success) {
+        const message = result.error || `Failed to delete branch "${branch}"`;
         if (!options?.silent) {
           showGitActionDialogSafely(message, "error");
         }

--- a/src/features/SessionCreator/components/SessionInfoLine.tsx
+++ b/src/features/SessionCreator/components/SessionInfoLine.tsx
@@ -249,7 +249,7 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
       if (!repoId || !repoPath || repoKind === REPO_KIND.FOLDER) {
         onBranchChange?.(branch);
         setIsBranchSelectorOpen(false);
-        return;
+        return true;
       }
 
       const result = await runGuardedCheckout({
@@ -265,7 +265,7 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
           showGitActionDialogSafely(result.message, "info");
         }
         setIsBranchSelectorOpen(false);
-        return;
+        return true;
       }
 
       if (result.outcome !== "cancelled") {
@@ -274,8 +274,16 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
           "error"
         );
       }
+      return false;
     },
     [onBranchChange, repoId, repoKind, repoPath]
+  );
+
+  const handleBranchPaletteSelect = useCallback(
+    async (branch: string) => {
+      await handleBranchSelect(branch);
+    },
+    [handleBranchSelect]
   );
 
   const handleCreateBranch = useCallback(
@@ -568,7 +576,7 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
           <BranchPalette
             isOpen={isBranchSelectorOpen}
             onClose={handleBranchClose}
-            onSelect={handleBranchSelect}
+            onSelect={handleBranchPaletteSelect}
             repoId={repoId}
             repoPath={repoPath}
             currentBranchName={branchName}

--- a/src/modules/WorkStation/ActionSystem/registration/actions/git/gitBranchActions.zod.ts
+++ b/src/modules/WorkStation/ActionSystem/registration/actions/git/gitBranchActions.zod.ts
@@ -87,10 +87,10 @@ export const gitCreateBranchFromCommit = defineZodAction(
       checkout,
     });
 
-    if (!created) {
+    if (!created.success) {
       return {
         success: false,
-        message: "Failed to create branch from commit",
+        message: created.error || "Failed to create branch from commit",
       };
     }
 

--- a/src/scaffold/GlobalSpotlight/index.tsx
+++ b/src/scaffold/GlobalSpotlight/index.tsx
@@ -190,7 +190,7 @@ const GlobalSpotlightInner: React.FC<
       // Create WITHOUT checking out, then route the checkout through
       // selectBranch so a dirty working tree surfaces the CheckoutConflictDialog
       // instead of the raw create+checkout bypassing the guard.
-      const success = await gitApi.gitCreateBranch({
+      const result = await gitApi.gitCreateBranch({
         repo_id: selectedRepoId,
         repo_path: currentRepo.path,
         name: branchName,
@@ -198,9 +198,9 @@ const GlobalSpotlightInner: React.FC<
         checkout: false,
       });
 
-      if (!success) {
+      if (!result.success) {
         showGitActionDialogSafely(
-          `Failed to create branch "${branchName}"`,
+          result.error || `Failed to create branch "${branchName}"`,
           "error"
         );
         return;
@@ -227,14 +227,15 @@ const GlobalSpotlightInner: React.FC<
         return { success: false, message };
       }
 
-      const success = await gitApi.gitDeleteBranch({
+      const result = await gitApi.gitDeleteBranch({
         repo_id: selectedRepoId,
         repo_path: currentRepo.path,
         branch_name: branchName,
       });
 
-      if (!success) {
-        const message = `Failed to delete branch "${branchName}"`;
+      if (!result.success) {
+        const message =
+          result.error || `Failed to delete branch "${branchName}"`;
         if (!options?.silent) {
           showGitActionDialogSafely(message, "error");
         }

--- a/src/scaffold/GlobalSpotlight/palettes/BranchPalette/BranchDropdown.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/BranchPalette/BranchDropdown.tsx
@@ -79,7 +79,10 @@ const BranchRow: React.FC<BranchRowProps> = ({
 export interface BranchDropdownProps {
   isOpen: boolean;
   onClose: () => void;
-  onSelect: (branchName: string, branch: BranchItem) => void | Promise<void>;
+  onSelect: (
+    branchName: string,
+    branch: BranchItem
+  ) => boolean | void | Promise<boolean | void>;
   repoId: string;
   repoPath?: string;
   currentBranchName?: string;
@@ -182,8 +185,10 @@ export const BranchDropdown: React.FC<BranchDropdownProps> = ({
 
   const handleSelect = useCallback(
     async (branch: BranchItem) => {
-      await onSelect(branch.name, branch);
-      onClose();
+      const shouldClose = await onSelect(branch.name, branch);
+      if (shouldClose !== false) {
+        onClose();
+      }
     },
     [onSelect, onClose]
   );

--- a/src/util/dialogs/__tests__/gitErrorDialogHelpers.test.ts
+++ b/src/util/dialogs/__tests__/gitErrorDialogHelpers.test.ts
@@ -6,6 +6,7 @@
  */
 import { describe, expect, it } from "vitest";
 
+import { normalizeGitActionDialogMessage } from "../gitActionDialog";
 import {
   type GitErrorDialogOptions,
   buildGitErrorInfo,
@@ -221,5 +222,22 @@ describe("buildGitErrorInfo — basic fields", () => {
   it("preserves errorMessage", () => {
     const info = buildGitErrorInfo(makeOptions({ errorMessage: "my error" }));
     expect(info.errorMessage).toBe("my error");
+  });
+});
+
+describe("normalizeGitActionDialogMessage", () => {
+  it("replaces WebKit fetch transport errors with actionable Git service text", () => {
+    expect(normalizeGitActionDialogMessage("Load failed")).toContain(
+      "local Git service"
+    );
+    expect(normalizeGitActionDialogMessage("failed to fetch")).toContain(
+      "local Git service"
+    );
+  });
+
+  it("preserves normal git errors", () => {
+    expect(normalizeGitActionDialogMessage("Branch not found")).toBe(
+      "Branch not found"
+    );
   });
 });

--- a/src/util/dialogs/gitActionDialog.ts
+++ b/src/util/dialogs/gitActionDialog.ts
@@ -4,12 +4,26 @@ const log = createLogger("GitActionDialog");
 
 export type GitActionDialogKind = "info" | "warning" | "error";
 
+const TRANSPORT_ERROR_MESSAGES = new Set([
+  "load failed",
+  "failed to fetch",
+  "networkerror when attempting to fetch resource.",
+]);
+
+export function normalizeGitActionDialogMessage(dialogMessage: string): string {
+  const normalizedMessage = dialogMessage.trim().toLowerCase();
+  if (TRANSPORT_ERROR_MESSAGES.has(normalizedMessage)) {
+    return "Unable to reach the local Git service. Please try again after the app finishes starting, or restart ORGII if this keeps happening.";
+  }
+  return dialogMessage;
+}
+
 export async function showGitActionDialog(
   dialogMessage: string,
   kind: GitActionDialogKind = "info"
 ): Promise<void> {
   const { message } = await import("@tauri-apps/plugin-dialog");
-  await message(dialogMessage, {
+  await message(normalizeGitActionDialogMessage(dialogMessage), {
     title: "Git",
     kind,
     buttons: { ok: "OK" },


### PR DESCRIPTION
## Summary
- replace opaque WebKit Git transport errors with actionable local Git service copy
- keep the branch dropdown open when checkout fails instead of closing as if it succeeded
- tighten scoped Git commit return typing

## Validation
- pnpm vitest run src/util/dialogs/__tests__/gitErrorDialogHelpers.test.ts
- pnpm tsc --noEmit --pretty false (fails only on existing unrelated baseline: SettingsSlot embedded option, githubIssueDetail tab data cast, model info replaceAll lib target)