### PR TITLE
fix(plan): show cancelled plan status

### DIFF
--- a/src/engines/ChatPanel/blocks/CreatePlanCard/index.tsx
+++ b/src/engines/ChatPanel/blocks/CreatePlanCard/index.tsx
@@ -76,10 +76,10 @@ function getPlanStateLabel(
   isStreaming: boolean,
   ready: boolean
 ): string {
-  if (isStreaming) return t("planDoc.drafting");
   if (status === "approved") return t("planDoc.built");
   if (status === "archived") return t("planDoc.archived");
   if (status === "cancelled") return t("planDoc.cancelled");
+  if (isStreaming) return t("planDoc.drafting");
   if (ready) return t("planDoc.readyForReview");
   return t("planDoc.idle");
 }

--- a/src/engines/SessionCore/derived/__tests__/planDisplayEvents.test.ts
+++ b/src/engines/SessionCore/derived/__tests__/planDisplayEvents.test.ts
@@ -309,6 +309,41 @@ describe("plan display event derivation", () => {
     expect(derived[0].result.status).toBe("cancelled");
   });
 
+  it("does not label a cancelled plan as drafting when the raw draft is still running", () => {
+    const raw = rawCreatePlan({
+      id: "tool-call-call_1",
+      callId: "call_1",
+      displayStatus: "running",
+      createdAt: "2026-05-15T00:00:00.000Z",
+    });
+    const cancelled = planApproval({
+      id: "call_1-cancelled",
+      callId: "call_1",
+      result: {
+        status: "cancelled",
+        planId: "plan-1",
+        planRevisionId: "call_1",
+        planPath: "/tmp/plan.md",
+      },
+      displayStatus: "completed",
+      createdAt: "2026-05-15T00:00:01.000Z",
+    });
+
+    const [displayEvent] = derivePlanDisplayEvents([raw, cancelled]);
+    const viewState = derivePlanApprovalViewState({
+      pendingPlan: null,
+      chatEvents: [displayEvent],
+    });
+
+    expect(displayEvent.result.status).toBe("cancelled");
+    expect(viewState.getEventState(displayEvent, "transcript")).toMatchObject({
+      status: "cancelled",
+      readyForReview: false,
+      actionable: false,
+      label: "skipped",
+    });
+  });
+
   it("does not render rehydrated pending-plan snapshots in transcript history", () => {
     const rehydratedApproval = planApproval({
       id: "call_1",

--- a/src/engines/SessionCore/derived/planDisplayEvents.ts
+++ b/src/engines/SessionCore/derived/planDisplayEvents.ts
@@ -439,10 +439,10 @@ function planSurfaceLabel(options: {
   readyForReview: boolean;
   isStreaming: boolean;
 }): PlanStateLabel {
-  if (options.isStreaming) return "drafting";
   if (options.status === "approved") return "built";
   if (options.status === "archived") return "archived";
   if (options.status === "cancelled") return "skipped";
+  if (options.isStreaming) return "drafting";
   if (options.readyForReview) return "ready";
   return "idle";
 }


### PR DESCRIPTION
## Summary
- Prioritize terminal plan statuses over streaming draft state in plan cards
- Keep derived plan surface labels from showing cancelled plans as drafting
- Add regression coverage for cancelled lifecycle updates while a raw draft is still running

Fixes #201

## Verification
- /Users/junyu/github/ORGII/node_modules/.bin/vitest run src/engines/SessionCore/derived/__tests__/planDisplayEvents.test.ts
- /Users/junyu/github/ORGII/node_modules/.bin/eslint src/engines/ChatPanel/blocks/CreatePlanCard/index.tsx src/engines/SessionCore/derived/planDisplayEvents.ts src/engines/SessionCore/derived/__tests__/planDisplayEvents.test.ts
- /Users/junyu/github/ORGII/node_modules/.bin/prettier --check src/engines/ChatPanel/blocks/CreatePlanCard/index.tsx src/engines/SessionCore/derived/planDisplayEvents.ts src/engines/SessionCore/derived/__tests__/planDisplayEvents.test.ts
- npx tsc --noEmit --incremental --tsBuildInfoFile .git/.tsbuildinfo --pretty false (filtered to changed files: no matches)