### PR TITLE
fix: add plan auto-execute countdown

### DIFF
--- a/src-tauri/crates/agent-core/src/core/interaction/plan_approval/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/interaction/plan_approval/mod.rs
@@ -382,12 +382,7 @@ impl PlanApprovalManager {
 
         // Presence policy: initial auto-approve deadline (if any) rides on
         // the broadcast so the FE can render a countdown on the Build card.
-        let auto_approve_at_ms = match super::presence_state::global_policy().plan_auto_approve {
-            super::presence_policy::AutoResolve::Off => None,
-            super::presence_policy::AutoResolve::After(window) => {
-                Some(created_at_ms + window.as_millis() as i64)
-            }
-        };
+        let auto_approve_at_ms = auto_approve_deadline_ms(snapshot.created_at_ms);
 
         let payload = serde_json::json!({
             "sessionId": &snapshot.session_id,
@@ -518,6 +513,8 @@ impl PlanApprovalManager {
 
         self.push_plan_approval_event(&snapshot, "rehydrate", PlanApprovalCardStatus::Pending);
 
+        let auto_approve_at_ms = auto_approve_deadline_ms(snapshot.created_at_ms);
+
         let payload = serde_json::json!({
             "sessionId": &snapshot.session_id,
             "planPath": &snapshot.plan_path,
@@ -528,6 +525,7 @@ impl PlanApprovalManager {
             "planRevisionId": &snapshot.plan_revision_id,
             "originToolCallId": &snapshot.origin_tool_call_id,
             "planEventSource": "rehydrate",
+            "autoApproveAt": auto_approve_at_ms,
         });
         crate::bus::broadcast_event("agent:plan_ready_for_approval", payload);
 
@@ -576,6 +574,19 @@ fn plan_id_for(session_id: &str, plan_path: &str) -> String {
 
 fn revision_id_for(tool_call_id: Option<&str>, fallback: &str) -> String {
     tool_call_id.unwrap_or(fallback).to_string()
+}
+
+fn auto_approve_deadline_ms(created_at_ms: i64) -> Option<i64> {
+    match super::presence_state::global_policy().plan_auto_approve {
+        super::presence_policy::AutoResolve::Off => None,
+        super::presence_policy::AutoResolve::After(window) => {
+            Some(created_at_ms + window.as_millis() as i64)
+        }
+    }
+}
+
+pub fn auto_approve_deadline_for_snapshot(snapshot: &PendingPlanApproval) -> Option<i64> {
+    auto_approve_deadline_ms(snapshot.created_at_ms)
 }
 
 fn plan_created_at_iso(snapshot: &PendingPlanApproval) -> String {

--- a/src-tauri/crates/agent-core/src/state/commands/session/interaction.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/session/interaction.rs
@@ -271,6 +271,9 @@ pub async fn agent_get_pending_plan_approval(
         return Ok(None);
     };
 
+    let auto_approve_at_ms =
+        crate::interaction::plan_approval::auto_approve_deadline_for_snapshot(&snapshot);
+
     Ok(Some(serde_json::json!({
         "sessionId": &snapshot.session_id,
         "planPath": &snapshot.plan_path,
@@ -280,6 +283,7 @@ pub async fn agent_get_pending_plan_approval(
         "planId": &snapshot.plan_id,
         "planRevisionId": &snapshot.plan_revision_id,
         "originToolCallId": &snapshot.origin_tool_call_id,
+        "autoApproveAt": auto_approve_at_ms,
     })))
 }
 

--- a/src/api/tauri/agent/session.ts
+++ b/src/api/tauri/agent/session.ts
@@ -217,6 +217,7 @@ export async function getPendingPlanApproval(sessionId: string): Promise<{
   planId?: string;
   planRevisionId?: string;
   originToolCallId?: string;
+  autoApproveAt?: number | null;
 } | null> {
   return rpc.agentSession.getPendingPlanApproval({ sessionId });
 }

--- a/src/api/tauri/rpc/schemas/agentSession.ts
+++ b/src/api/tauri/rpc/schemas/agentSession.ts
@@ -172,6 +172,7 @@ export const PendingPlanApprovalSchema = z
     planId: z.string().optional(),
     planRevisionId: z.string().optional(),
     originToolCallId: z.string().optional(),
+    autoApproveAt: z.number().nullable().optional(),
   })
   .nullable();
 

--- a/src/engines/ChatPanel/blocks/CreatePlanCard/index.tsx
+++ b/src/engines/ChatPanel/blocks/CreatePlanCard/index.tsx
@@ -404,11 +404,11 @@ const CreatePlanCard: React.FC<CreatePlanCardProps> = memo(
       ) : undefined;
     const planActions = ownsActions ? (
       <div
-        className={`flex items-center justify-end gap-1 px-3 py-2 ${isCollapsed ? "" : "border-t border-border-2"}`}
+        className={`flex flex-wrap items-center justify-end gap-2 px-3 py-2 ${isCollapsed ? "" : "border-t border-border-2"}`}
         onClick={(event) => event.stopPropagation()}
       >
         {autoApproveRemaining !== null && ready && !isEditing && (
-          <span className="chat-block-xs tabular-nums text-text-3">
+          <span className="chat-block-xs mr-auto min-w-0 truncate tabular-nums text-text-3">
             {t("chat.autoExecuteCountdown", {
               seconds: autoApproveRemaining,
             })}

--- a/src/engines/SessionCore/sync/adapters/cliAdapter.ts
+++ b/src/engines/SessionCore/sync/adapters/cliAdapter.ts
@@ -482,6 +482,15 @@ export const cliAdapter: SessionAdapter = {
       return typeof value === "string" && value.length > 0 ? value : undefined;
     }
 
+    function rawNumber(raw: RawSessionEvent, key: string): number | null {
+      const value = raw[key];
+      return typeof value === "number" && Number.isFinite(value) ? value : null;
+    }
+
+    function asNumber(value: unknown): number | null {
+      return typeof value === "number" && Number.isFinite(value) ? value : null;
+    }
+
     function handlePlanReadyForApproval(raw: RawSessionEvent): void {
       const store = getStore();
       if (!store) return;
@@ -497,6 +506,7 @@ export const cliAdapter: SessionAdapter = {
           planId: rawString(raw, "planId"),
           planRevisionId: rawString(raw, "planRevisionId"),
           originToolCallId: rawString(raw, "originToolCallId"),
+          autoApproveAt: rawNumber(raw, "autoApproveAt"),
         })
       );
     }
@@ -541,6 +551,7 @@ export const cliAdapter: SessionAdapter = {
           planId: asString(args.planId),
           planRevisionId: asString(args.planRevisionId),
           originToolCallId: asString(args.originToolCallId),
+          autoApproveAt: asNumber(args.autoApproveAt),
         })
       );
       normalizeChunkRust(chunk, sessionId)


### PR DESCRIPTION
## Summary
- show the plan auto-execute countdown without crowding the Build/Skip actions
- carry autoApproveAt through live CLI events, rehydrate broadcasts, and the pending-plan RPC
- reuse the presence policy deadline for restored pending plans

Fixes #137

## Verification
- pnpm exec eslint src/engines/ChatPanel/blocks/CreatePlanCard/index.tsx src/engines/SessionCore/sync/adapters/cliAdapter.ts src/api/tauri/agent/session.ts src/api/tauri/rpc/schemas/agentSession.ts
- pnpm exec tsc --noEmit --pretty false | rg changed-file paths (no matches)
- cargo check -p agent_core
- git commit hooks: lint-staged, scoped TypeScript, cargo clippy (agent_core)

Note: cargo fmt --check -p agent_core still reports pre-existing formatting drift in unrelated agent_core files; touched Rust files have no fmt diff.