### PR TITLE
feat: add presence option for plan mode auto switch

### DIFF
--- a/src-tauri/crates/agent-core/src/core/interaction/mode_switch.rs
+++ b/src-tauri/crates/agent-core/src/core/interaction/mode_switch.rs
@@ -182,14 +182,25 @@ impl ModeSwitchManager {
         self.pending.lock().await.is_some()
     }
 
-    /// Auto-skip a pending request after the user-visible timeout elapses.
+    /// Auto-resolve a pending request after the user-visible timeout elapses.
     ///
-    /// Mode switching follows timeout-as-continue semantics: if the user does
-    /// not respond, continue in the current mode instead of surfacing a tool error
-    /// or leaving the UI card awaiting forever.
-    pub async fn auto_skip_after_timeout(&self) {
+    /// By default mode switching follows timeout-as-continue semantics: if the
+    /// user does not respond, continue in the current mode. Presence policy can
+    /// opt into treating the same timeout as accepting the suggested Plan mode.
+    pub async fn auto_resolve_after_timeout(&self, choice: &ModeSwitchChoice) {
         let Some(entry) = self.pending.lock().await.take() else {
             return;
+        };
+
+        let (content, choice_label) = match choice {
+            ModeSwitchChoice::Switch(mode) => (
+                format!("Mode-switch suggestion timed out; auto-switching to {mode} mode."),
+                "switch",
+            ),
+            ModeSwitchChoice::Skip => (
+                "Mode-switch suggestion timed out; continuing in the current mode.".to_string(),
+                "skip",
+            ),
         };
 
         finalize_interaction_event(
@@ -197,15 +208,21 @@ impl ModeSwitchManager {
             entry.tool_call_id.as_deref(),
             crate::tools::names::SUGGEST_MODE_SWITCH,
             FinalizedStatus::Answered,
-            "Mode-switch suggestion timed out; continuing in the current mode.",
+            &content,
             serde_json::json!({
-                "choice": "skip",
+                "choice": choice_label,
                 "targetMode": entry.target_mode,
                 "auto": "timeout",
             }),
         );
 
         drop(entry.sender);
+    }
+
+    /// Backward-compatible helper for callers/tests that expect timeout-as-skip.
+    pub async fn auto_skip_after_timeout(&self) {
+        self.auto_resolve_after_timeout(&ModeSwitchChoice::Skip)
+            .await;
     }
 
     /// Cancel any pending request (Stop button / timeout). Finalizes the event

--- a/src-tauri/crates/agent-core/src/core/interaction/presence_policy.rs
+++ b/src-tauri/crates/agent-core/src/core/interaction/presence_policy.rs
@@ -73,6 +73,7 @@ impl GoalLoopPolicy {
 pub struct PresencePolicy {
     pub question_auto_resolve: AutoResolve,
     pub plan_auto_approve: AutoResolve,
+    pub mode_switch_auto_plan: bool,
     pub goal_loop: GoalLoopPolicy,
     pub prompt_stance: PresenceStance,
 }
@@ -83,6 +84,7 @@ impl Default for PresencePolicy {
         Self {
             question_auto_resolve: AutoResolve::Off,
             plan_auto_approve: AutoResolve::Off,
+            mode_switch_auto_plan: false,
             goal_loop: GoalLoopPolicy::Off,
             prompt_stance: PresenceStance::Interactive,
         }
@@ -92,13 +94,13 @@ impl Default for PresencePolicy {
 /// Built-in defaults per well-known mode id, used when the wire payload
 /// predates the spec redesign (mode only, no policy fields). Mirrors
 /// `BUILT_IN_PRESENCE_POLICY` in `src/types/userPresence.ts`.
-fn built_in_defaults(mode: &str) -> (PresenceStance, u32, u32, u32) {
+fn built_in_defaults(mode: &str) -> (PresenceStance, u32, u32, bool, u32) {
     match mode {
-        presence_mode_ids::AWAY => (PresenceStance::DeferAndBatch, 180, 0, 0),
-        presence_mode_ids::INVISIBLE => (PresenceStance::Autonomous, 30, 120, 20),
+        presence_mode_ids::AWAY => (PresenceStance::DeferAndBatch, 180, 0, false, 0),
+        presence_mode_ids::INVISIBLE => (PresenceStance::Autonomous, 30, 120, false, 20),
         // Online and any unknown/custom mode without explicit fields:
         // conservative interactive, nothing auto-resolves.
-        _ => (PresenceStance::Interactive, 0, 0, 0),
+        _ => (PresenceStance::Interactive, 0, 0, false, 0),
     }
 }
 
@@ -106,8 +108,13 @@ impl PresencePolicy {
     /// Resolve the policy from a wire snapshot. Explicit wire fields win;
     /// missing fields fall back to built-in defaults for the mode id.
     pub fn resolve(presence: &UserPresence) -> Self {
-        let (default_stance, default_question, default_plan, default_goal) =
-            built_in_defaults(&presence.mode);
+        let (
+            default_stance,
+            default_question,
+            default_plan,
+            default_mode_switch_auto_plan,
+            default_goal,
+        ) = built_in_defaults(&presence.mode);
 
         Self {
             question_auto_resolve: AutoResolve::from_secs(
@@ -118,6 +125,9 @@ impl PresencePolicy {
             plan_auto_approve: AutoResolve::from_secs(
                 presence.plan_auto_approve_secs.unwrap_or(default_plan),
             ),
+            mode_switch_auto_plan: presence
+                .mode_switch_auto_plan
+                .unwrap_or(default_mode_switch_auto_plan),
             goal_loop: GoalLoopPolicy::from_max_turns(
                 presence.goal_max_turns.unwrap_or(default_goal),
             ),
@@ -151,6 +161,7 @@ mod tests {
             stance: Some(PresenceStance::Autonomous),
             question_auto_resolve_secs: Some(15),
             plan_auto_approve_secs: Some(0),
+            mode_switch_auto_plan: Some(true),
             goal_max_turns: Some(2),
             ..Default::default()
         };
@@ -161,6 +172,7 @@ mod tests {
             AutoResolve::After(Duration::from_secs(15))
         );
         assert_eq!(policy.plan_auto_approve, AutoResolve::Off);
+        assert!(policy.mode_switch_auto_plan);
         assert_eq!(policy.goal_loop, GoalLoopPolicy::On { max_turns: 2 });
     }
 
@@ -168,6 +180,12 @@ mod tests {
     fn legacy_payload_online_maps_to_interactive_off() {
         let policy = PresencePolicy::resolve(&wire("online"));
         assert_eq!(policy, PresencePolicy::default());
+    }
+
+    #[test]
+    fn legacy_payload_defaults_to_mode_switch_auto_skip() {
+        let policy = PresencePolicy::resolve(&wire("invisible"));
+        assert!(!policy.mode_switch_auto_plan);
     }
 
     #[test]

--- a/src-tauri/crates/agent-core/src/core/session/types/context.rs
+++ b/src-tauri/crates/agent-core/src/core/session/types/context.rs
@@ -120,6 +120,9 @@ pub struct UserPresence {
     /// Seconds until pending plan approvals auto-approve. 0 = off.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub plan_auto_approve_secs: Option<u32>,
+    /// Whether pending mode-switch suggestions auto-switch to Plan on timeout.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode_switch_auto_plan: Option<bool>,
     /// Goal continuation loop budget (Ralph loop). 0 = disabled.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub goal_max_turns: Option<u32>,

--- a/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/suggest_mode_switch.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/orchestration/suggest_mode_switch.rs
@@ -17,6 +17,8 @@ use crate::interaction::finalize::{
     await_with_cancel, AutoTimeoutAction, AutoTimeoutPolicy, FinalizedStatus, InteractionOutcome,
 };
 use crate::interaction::mode_switch::{ModeSwitchChoice, ModeSwitchManager};
+use crate::interaction::presence_policy::PresencePolicy;
+use crate::interaction::presence_state;
 use crate::tools::names as tool_names;
 use crate::tools::traits::{Tool, ToolError};
 
@@ -26,6 +28,34 @@ pub struct ModeSwitchToolContext {
     /// Current agent exec mode — set at session init, read by `llm_description()`.
     /// Uses `std::sync::Mutex` because `llm_description()` is sync.
     pub current_mode: std::sync::Mutex<Option<String>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timeout_choice_defaults_to_skip() {
+        let choice = mode_switch_timeout_choice(PresencePolicy::default(), "plan");
+
+        assert!(matches!(choice, ModeSwitchChoice::Skip));
+    }
+
+    #[test]
+    fn timeout_choice_switches_to_plan_when_presence_allows_it() {
+        let choice = mode_switch_timeout_choice(
+            PresencePolicy {
+                mode_switch_auto_plan: true,
+                ..PresencePolicy::default()
+            },
+            "plan",
+        );
+
+        match choice {
+            ModeSwitchChoice::Switch(mode) => assert_eq!(mode, "plan"),
+            ModeSwitchChoice::Skip => panic!("expected auto switch"),
+        }
+    }
 }
 
 impl ModeSwitchToolContext {
@@ -57,6 +87,14 @@ impl SuggestModeSwitchTool {
 /// to decide whether to break the loop.
 pub const SWITCH_ACCEPTED_PREFIX: &str = "MODE_SWITCH_ACCEPTED:";
 const MODE_SWITCH_AUTO_SKIP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
+fn mode_switch_timeout_choice(policy: PresencePolicy, target_mode: &str) -> ModeSwitchChoice {
+    if policy.mode_switch_auto_plan && target_mode == "plan" {
+        ModeSwitchChoice::Switch(target_mode.to_string())
+    } else {
+        ModeSwitchChoice::Skip
+    }
+}
 
 #[async_trait]
 impl Tool for SuggestModeSwitchTool {
@@ -171,7 +209,15 @@ impl Tool for SuggestModeSwitchTool {
             cancel_flag,
             Some(AutoTimeoutPolicy {
                 timeout: MODE_SWITCH_AUTO_SKIP_TIMEOUT,
-                on_expire: Box::new(|| AutoTimeoutAction::Respond(ModeSwitchChoice::Skip)),
+                on_expire: Box::new({
+                    let target_mode = target_mode.to_string();
+                    move || {
+                        AutoTimeoutAction::Respond(mode_switch_timeout_choice(
+                            presence_state::global_policy(),
+                            &target_mode,
+                        ))
+                    }
+                }),
             }),
         )
         .await;
@@ -179,7 +225,7 @@ impl Tool for SuggestModeSwitchTool {
         let choice = match outcome {
             InteractionOutcome::Responded(c) => c,
             InteractionOutcome::AutoResponded(c) => {
-                self.context.manager.auto_skip_after_timeout().await;
+                self.context.manager.auto_resolve_after_timeout(&c).await;
                 c
             }
             InteractionOutcome::Cancelled => {

--- a/src/config/settingsSchema/registry/agent.ts
+++ b/src/config/settingsSchema/registry/agent.ts
@@ -43,6 +43,12 @@ const goalMaxTurnsByPresenceSchema = z.object({
   away: z.number().int().min(0).max(100),
 });
 
+const modeSwitchAutoPlanByPresenceSchema = z.object({
+  online: z.boolean(),
+  invisible: z.boolean(),
+  away: z.boolean(),
+});
+
 export const AGENT_SETTINGS_REGISTRY = {
   "agent.sde.questionAutoSkipTimeoutByPresence": {
     schema: questionAutoSkipTimeoutByPresenceSchema,
@@ -75,6 +81,17 @@ export const AGENT_SETTINGS_REGISTRY = {
     },
     description:
       "Goal continuation loop budget per user status (0 = disabled). When > 0, the agent judges its own turn-end output against the original request and keeps working until done or the budget runs out.",
+    category: "agent",
+  },
+  "agent.sde.modeSwitchAutoPlanByPresence": {
+    schema: modeSwitchAutoPlanByPresenceSchema,
+    default: {
+      online: false,
+      invisible: false,
+      away: false,
+    },
+    description:
+      "Auto-switch pending mode-switch suggestions to Plan mode on timeout per user status. Disabled by default to preserve timeout-as-skip behavior.",
     category: "agent",
   },
 } as const satisfies Record<string, SettingDefinition>;

--- a/src/config/settingsUiManifest/sections/integrations.ts
+++ b/src/config/settingsUiManifest/sections/integrations.ts
@@ -8,6 +8,7 @@ const MY_ROLE_SETTING_KEYS = [
   "agent.sde.questionAutoSkipTimeoutByPresence",
   "agent.sde.planAutoApproveTimeoutByPresence",
   "agent.sde.goalMaxTurnsByPresence",
+  "agent.sde.modeSwitchAutoPlanByPresence",
   "general.presenceGuidanceOnline",
   "general.presenceGuidanceInvisible",
   "general.presenceGuidanceAway",

--- a/src/engines/ChatPanel/InputArea/ModeSwitchCard/useModeSwitchActions.ts
+++ b/src/engines/ChatPanel/InputArea/ModeSwitchCard/useModeSwitchActions.ts
@@ -238,12 +238,12 @@ function isE2EModeSwitchMockEnabled(): boolean {
   );
 }
 
-export async function switchMode(
+export async function switchModeForSession(
+  sessionId: string,
   eventId: string,
   targetMode: string
 ): Promise<void> {
   const store = getInstrumentedStore();
-  const sessionId = store.get(activeSessionIdAtom);
   if (!sessionId) return;
 
   markResolved(eventId, "switched");
@@ -273,6 +273,16 @@ export async function switchMode(
   if (isAgentSession(sessionId)) {
     await switchAgentMode(eventId, sessionId, targetMode);
   }
+}
+
+export async function switchMode(
+  eventId: string,
+  targetMode: string
+): Promise<void> {
+  const store = getInstrumentedStore();
+  const sessionId = store.get(activeSessionIdAtom);
+  if (!sessionId) return;
+  await switchModeForSession(sessionId, eventId, targetMode);
 }
 
 export async function skipMode(eventId: string): Promise<void> {

--- a/src/engines/ChatPanel/InputArea/index.tsx
+++ b/src/engines/ChatPanel/InputArea/index.tsx
@@ -295,7 +295,7 @@ const InputArea: React.FC<InputAreaProps> = memo(
       isCursorIde && sessionId ? (
         <CursorModePill sessionId={sessionId} />
       ) : (
-        <ModePill hideWhenDefault resetToDefaultOnClick />
+        <ModePill resetToDefaultOnClick />
       );
     const clearReplyInfo = useCallback(
       () => setReplyInfo({ isReply: false }),

--- a/src/engines/ChatPanel/events/interactive_events/mode-switch/index.tsx
+++ b/src/engines/ChatPanel/events/interactive_events/mode-switch/index.tsx
@@ -6,6 +6,7 @@
  * - Switched: "Switched to {{mode}} Mode" title, no subtitle
  * - Skipped: "Mode change skipped" title, no subtitle
  */
+import { useAtomValue } from "jotai";
 import React from "react";
 
 import { getEventIcon } from "@src/config/toolIcons";
@@ -30,6 +31,7 @@ import {
   useToolLabelText,
 } from "@src/engines/SessionCore/rendering/registry";
 import type { EventVariant } from "@src/engines/SessionCore/rendering/types/universalProps";
+import { sessionByIdAtom } from "@src/store/session/sessionAtom";
 
 import { AskQuestionHistoryBody } from "../ask-question/AskQuestionHistoryChrome";
 
@@ -148,6 +150,8 @@ export const ModeSwitchEvent: React.FC<ModeSwitchEventProps> = (props) => {
   const reason = (args.reason as string) ?? "";
 
   const displayStatus = props.event?.displayStatus as string | undefined;
+  const eventSessionId = props.event?.sessionId;
+  const session = useAtomValue(sessionByIdAtom(eventSessionId ?? ""));
   const result = props.event?.result as Record<string, unknown> | undefined;
   // Authoritative field written by Rust `ModeSwitchManager::respond` via
   // `agent:interaction_finalized` ("switch" or "skip"). The local cache
@@ -185,15 +189,10 @@ export const ModeSwitchEvent: React.FC<ModeSwitchEventProps> = (props) => {
   } else if (contentChoice === "skip") {
     resolvedStatus = "skipped";
   } else if (displayStatus === "completed" && !resultChoice) {
-    // Rust's `finalize_interaction_event` always writes `choice` ("switch" /
-    // "skip") on every terminal path — including timeout, stop, and superseded.
-    // Reaching this fallback means the structured result lost its `choice`
-    // field AND the content prefix didn't match either of the known phrases
-    // (Rust copy drift). The user actually saw a Plan card and acted on it;
-    // defaulting to "skipped" here was a wrong-by-default guess. Default to
-    // "switched" so the common Build→Plan accept flow is reflected correctly
-    // after reload.
-    resolvedStatus = "switched";
+    // If legacy/clobbered events lost the structured `choice`, fall back to
+    // the session's authoritative mode instead of guessing from completion.
+    resolvedStatus =
+      session?.agentExecMode === targetMode ? "switched" : "skipped";
   }
 
   if (resolvedStatus === "pending") {

--- a/src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/__tests__/createPlanFinalization.test.ts
+++ b/src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/__tests__/createPlanFinalization.test.ts
@@ -11,7 +11,11 @@ import {
   handlePlanReadyForApproval,
 } from "../agentSpecific";
 import { handleToolCallDelta } from "../streamHandlers";
-import { handleToolCall, handleToolResult } from "../toolHandlers";
+import {
+  handleInteractionFinalized,
+  handleToolCall,
+  handleToolResult,
+} from "../toolHandlers";
 import type { EventHandlerContext } from "../types";
 
 vi.hoisted(() => {
@@ -40,6 +44,7 @@ const {
   mergeSpy,
   patchByIdsSpy,
   completeLastRunningSpy,
+  switchModeForSessionSpy,
 } = vi.hoisted(() => {
   const events = new Map<string, SessionEvent>();
   const upsert = vi.fn((event: SessionEvent) => {
@@ -88,6 +93,7 @@ const {
     mergeSpy: merge,
     patchByIdsSpy: patchByIds,
     completeLastRunningSpy: vi.fn(),
+    switchModeForSessionSpy: vi.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -105,6 +111,13 @@ vi.mock(
   "@src/engines/ChatPanel/blocks/CanvasInlineCard/openInSimulatorCanvas",
   () => ({
     openInSimulatorCanvas: vi.fn(),
+  })
+);
+
+vi.mock(
+  "@src/engines/ChatPanel/InputArea/ModeSwitchCard/useModeSwitchActions",
+  () => ({
+    switchModeForSession: switchModeForSessionSpy,
   })
 );
 
@@ -144,6 +157,7 @@ beforeEach(() => {
   mergeSpy.mockClear();
   patchByIdsSpy.mockClear();
   completeLastRunningSpy.mockClear();
+  switchModeForSessionSpy.mockClear();
   vi.stubGlobal("window", {
     dispatchEvent: vi.fn(),
   });
@@ -228,6 +242,32 @@ describe("create_plan streaming finalization", () => {
     expect(upsertSpy).not.toHaveBeenCalledWith(
       expect.objectContaining({ id: "call_plan_1-archived" }),
       "session-1"
+    );
+  });
+
+  it("resumes the session when mode switch is auto-accepted by timeout", async () => {
+    await handleInteractionFinalized(
+      {
+        type: "agent:interaction_finalized",
+        sessionId: "session-1",
+        tool: "suggest_mode_switch",
+        toolCallId: "call_mode_1",
+        resultObject: {
+          choice: "switch",
+          targetMode: "plan",
+          auto: "timeout",
+        },
+        resultPreview:
+          "Mode-switch suggestion timed out; auto-switching to plan mode.",
+      },
+      "session-1"
+    );
+
+    expect(mergeSpy).toHaveBeenCalledTimes(1);
+    expect(switchModeForSessionSpy).toHaveBeenCalledWith(
+      "session-1",
+      "tool-call-call_mode_1",
+      "plan"
     );
   });
 

--- a/src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/toolHandlers.ts
+++ b/src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/toolHandlers.ts
@@ -4,6 +4,7 @@
  * Handlers for tool_call, tool_result, and interaction finalization events.
  * Shell process / exec-output handlers live in shellHandlers.ts.
  */
+import { switchModeForSession } from "@src/engines/ChatPanel/InputArea/ModeSwitchCard/useModeSwitchActions";
 import { openInSimulatorCanvas } from "@src/engines/ChatPanel/blocks/CanvasInlineCard/openInSimulatorCanvas";
 import type { CanvasInlineMode } from "@src/engines/ChatPanel/blocks/CanvasInlineCard/types";
 import { eventStoreProxy } from "@src/engines/SessionCore/core/store/EventStoreProxy";
@@ -22,6 +23,17 @@ import { clearStreamingInfo, getToolCallId } from "./streamHelpers";
 import type { EventHandlerContext } from "./types";
 
 const log = createLogger("ToolHandlers");
+
+function isAutoModeSwitchAccept(
+  tool: string | undefined,
+  resultObject: Record<string, unknown>
+): boolean {
+  return (
+    tool === "suggest_mode_switch" &&
+    resultObject.choice === "switch" &&
+    resultObject.auto === "timeout"
+  );
+}
 
 export function handleToolCall(
   event: AgentWSEvent,
@@ -260,6 +272,18 @@ export async function handleInteractionFinalized(
     ...resultObject,
   };
   await eventStoreProxy.mergeEvents([resultEvent], sessionId);
+
+  if (isAutoModeSwitchAccept(event.tool, resultObject)) {
+    const targetMode =
+      typeof resultObject.targetMode === "string"
+        ? resultObject.targetMode
+        : "plan";
+    await switchModeForSession(
+      sessionId,
+      `tool-call-${toolCallId}`,
+      targetMode
+    );
+  }
 }
 
 export {

--- a/src/features/SessionCreator/components/ControlButtons/index.tsx
+++ b/src/features/SessionCreator/components/ControlButtons/index.tsx
@@ -75,7 +75,6 @@ const ControlButtons: React.FC<ControlButtonsProps> = memo(
         {!hideModePill && usesOrgiiExecMode && (
           <ModePill
             forceVisible
-            hideWhenDefault
             resetToDefaultOnClick
             onModeChange={handleSdeModeChange}
             placement={dropdownDirection === "up" ? "top" : "bottom"}

--- a/src/modules/MainApp/Integrations/KeyVault/MyRoles/MyRolesSection.tsx
+++ b/src/modules/MainApp/Integrations/KeyVault/MyRoles/MyRolesSection.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from "react-i18next";
 
 import NumberInput from "@src/components/NumberInput";
 import Select, { type SelectOption } from "@src/components/Select";
+import Switch from "@src/components/Switch";
 import TagsInput from "@src/components/TagsInput";
 import Textarea from "@src/components/Textarea";
 import {
@@ -88,6 +89,9 @@ const MyRolesSection: React.FC<MyRolesSectionProps> = ({
   const goalMaxTurnsByPresence = settings[
     "agent.sde.goalMaxTurnsByPresence"
   ] as Record<BuiltInPresenceMode, number>;
+  const modeSwitchAutoPlanByPresence = settings[
+    "agent.sde.modeSwitchAutoPlanByPresence"
+  ] as Record<BuiltInPresenceMode, boolean>;
   const presenceGuidanceOnline =
     (settings["general.presenceGuidanceOnline"] as string | undefined) ?? "";
   const presenceGuidanceInvisible =
@@ -199,6 +203,19 @@ const MyRolesSection: React.FC<MyRolesSectionProps> = ({
     [goalMaxTurnsByPresence, updateSetting]
   );
 
+  const handleModeSwitchAutoPlanChange = useCallback(
+    (mode: BuiltInPresenceMode) => (checked: boolean) => {
+      updateSetting({
+        key: "agent.sde.modeSwitchAutoPlanByPresence",
+        value: {
+          ...modeSwitchAutoPlanByPresence,
+          [mode]: checked,
+        },
+      });
+    },
+    [modeSwitchAutoPlanByPresence, updateSetting]
+  );
+
   const renderPolicyRows = useCallback(
     (mode: BuiltInPresenceMode, statusLabel: string) => (
       <>
@@ -260,6 +277,25 @@ const MyRolesSection: React.FC<MyRolesSectionProps> = ({
             style={SECTION_CONTROL_STYLE}
           />
         </SectionRow>
+        <SectionRow
+          label={t("sdeAgent.modeSwitchAutoPlanByStatus", {
+            status: statusLabel,
+            defaultValue: `${statusLabel} mode switch auto-plan`,
+          })}
+          description={t("sdeAgent.modeSwitchAutoPlanByStatusDesc", {
+            defaultValue:
+              "Auto-switch pending Plan mode suggestions when their confirmation timer expires.",
+          })}
+        >
+          <Switch
+            checked={modeSwitchAutoPlanByPresence[mode]}
+            onChange={handleModeSwitchAutoPlanChange(mode)}
+            ariaLabel={t("sdeAgent.modeSwitchAutoPlanByStatus", {
+              status: statusLabel,
+              defaultValue: `${statusLabel} mode switch auto-plan`,
+            })}
+          />
+        </SectionRow>
       </>
     ),
     [
@@ -267,9 +303,11 @@ const MyRolesSection: React.FC<MyRolesSectionProps> = ({
       questionAutoSkipTimeoutByPresence,
       planAutoApproveTimeoutByPresence,
       goalMaxTurnsByPresence,
+      modeSwitchAutoPlanByPresence,
       handleQuestionAutoSkipTimeoutChange,
       handlePlanAutoApproveTimeoutChange,
       handleGoalMaxTurnsChange,
+      handleModeSwitchAutoPlanChange,
     ]
   );
 

--- a/src/modules/MainApp/MyRole/index.tsx
+++ b/src/modules/MainApp/MyRole/index.tsx
@@ -22,6 +22,7 @@ import Button from "@src/components/Button";
 import Input from "@src/components/Input";
 import NumberInput from "@src/components/NumberInput";
 import Select from "@src/components/Select";
+import Switch from "@src/components/Switch";
 import Textarea from "@src/components/Textarea";
 import {
   SECTION_CONTROL_STYLE,
@@ -210,12 +211,14 @@ const MyRolePage: React.FC = () => {
         stance: PresenceStance;
         questionAutoResolveSecs: number;
         planAutoApproveSecs: number;
+        modeSwitchAutoPlan: boolean;
         goalMaxTurns: number;
       },
       onChange: (patch: {
         stance?: PresenceStance;
         questionAutoResolveSecs?: number;
         planAutoApproveSecs?: number;
+        modeSwitchAutoPlan?: boolean;
         goalMaxTurns?: number;
       }) => void,
       options?: { lockStance?: boolean }
@@ -282,6 +285,23 @@ const MyRolePage: React.FC = () => {
           />
         </SectionRow>
         <SectionRow
+          label={t("myRole.modeSwitchAutoPlanLabel", {
+            defaultValue: "Mode switch auto-plan",
+          })}
+          description={t("myRole.modeSwitchAutoPlanDesc", {
+            defaultValue:
+              "Auto-switch pending Plan mode suggestions when their confirmation timer expires.",
+          })}
+        >
+          <Switch
+            checked={values.modeSwitchAutoPlan}
+            onChange={(checked) => onChange({ modeSwitchAutoPlan: checked })}
+            ariaLabel={t("myRole.modeSwitchAutoPlanLabel", {
+              defaultValue: "Mode switch auto-plan",
+            })}
+          />
+        </SectionRow>
+        <SectionRow
           label={t("myRole.goalMaxTurnsLabel", {
             defaultValue: "Goal continuation budget",
           })}
@@ -313,6 +333,9 @@ const MyRolePage: React.FC = () => {
   const planByPresence = settings[
     "agent.sde.planAutoApproveTimeoutByPresence"
   ] as Record<BuiltInPresenceMode, number>;
+  const modeSwitchByPresence = settings[
+    "agent.sde.modeSwitchAutoPlanByPresence"
+  ] as Record<BuiltInPresenceMode, boolean>;
   const goalByPresence = settings["agent.sde.goalMaxTurnsByPresence"] as Record<
     BuiltInPresenceMode,
     number
@@ -324,6 +347,7 @@ const MyRolePage: React.FC = () => {
         stance?: PresenceStance;
         questionAutoResolveSecs?: number;
         planAutoApproveSecs?: number;
+        modeSwitchAutoPlan?: boolean;
         goalMaxTurns?: number;
       }) => {
         // Built-in stances are fixed (they define the mode); only the
@@ -343,6 +367,15 @@ const MyRolePage: React.FC = () => {
             value: { ...planByPresence, [mode]: patch.planAutoApproveSecs },
           });
         }
+        if (patch.modeSwitchAutoPlan !== undefined) {
+          updateSetting({
+            key: "agent.sde.modeSwitchAutoPlanByPresence",
+            value: {
+              ...modeSwitchByPresence,
+              [mode]: patch.modeSwitchAutoPlan,
+            },
+          });
+        }
         if (patch.goalMaxTurns !== undefined) {
           updateSetting({
             key: "agent.sde.goalMaxTurnsByPresence",
@@ -350,7 +383,13 @@ const MyRolePage: React.FC = () => {
           });
         }
       },
-    [updateSetting, questionByPresence, planByPresence, goalByPresence]
+    [
+      updateSetting,
+      questionByPresence,
+      planByPresence,
+      modeSwitchByPresence,
+      goalByPresence,
+    ]
   );
 
   return (
@@ -409,6 +448,9 @@ const MyRolePage: React.FC = () => {
                       planAutoApproveSecs:
                         planByPresence[role.mode] ??
                         BUILT_IN_PRESENCE_POLICY[role.mode].planAutoApproveSecs,
+                      modeSwitchAutoPlan:
+                        modeSwitchByPresence[role.mode] ??
+                        BUILT_IN_PRESENCE_POLICY[role.mode].modeSwitchAutoPlan,
                       goalMaxTurns:
                         goalByPresence[role.mode] ??
                         BUILT_IN_PRESENCE_POLICY[role.mode].goalMaxTurns,
@@ -517,6 +559,7 @@ const MyRolePage: React.FC = () => {
                         questionAutoResolveSecs:
                           role.questionAutoResolveSecs ?? 0,
                         planAutoApproveSecs: role.planAutoApproveSecs ?? 0,
+                        modeSwitchAutoPlan: role.modeSwitchAutoPlan ?? false,
                         goalMaxTurns: role.goalMaxTurns ?? 0,
                       },
                       (patch) => handleRoleChange(role.id, patch)

--- a/src/store/user/__tests__/userPresenceAtom.test.ts
+++ b/src/store/user/__tests__/userPresenceAtom.test.ts
@@ -37,6 +37,7 @@ describe("presenceModeSpecResolver / userPresenceWireAtom", () => {
     expect(spec!.questionAutoResolveSecs).toBe(30);
     expect(spec!.planAutoApproveSecs).toBe(120);
     expect(spec!.goalMaxTurns).toBe(20);
+    expect(spec!.modeSwitchAutoPlan).toBe(false);
     expect(spec!.builtIn).toBe(true);
   });
 
@@ -60,6 +61,7 @@ describe("presenceModeSpecResolver / userPresenceWireAtom", () => {
         stance: PRESENCE_STANCE.AUTONOMOUS,
         questionAutoResolveSecs: 15,
         planAutoApproveSecs: 0,
+        modeSwitchAutoPlan: true,
         goalMaxTurns: 2,
       },
     ]);
@@ -69,6 +71,7 @@ describe("presenceModeSpecResolver / userPresenceWireAtom", () => {
     expect(spec!.label).toBe("Angry");
     expect(spec!.stance).toBe(PRESENCE_STANCE.AUTONOMOUS);
     expect(spec!.questionAutoResolveSecs).toBe(15);
+    expect(spec!.modeSwitchAutoPlan).toBe(true);
     expect(spec!.goalMaxTurns).toBe(2);
     expect(spec!.builtIn).toBe(false);
   });
@@ -88,6 +91,7 @@ describe("presenceModeSpecResolver / userPresenceWireAtom", () => {
     expect(spec!.stance).toBe(PRESENCE_STANCE.INTERACTIVE);
     expect(spec!.questionAutoResolveSecs).toBe(0);
     expect(spec!.planAutoApproveSecs).toBe(0);
+    expect(spec!.modeSwitchAutoPlan).toBe(false);
     expect(spec!.goalMaxTurns).toBe(0);
   });
 
@@ -105,6 +109,7 @@ describe("presenceModeSpecResolver / userPresenceWireAtom", () => {
     expect(wire!.stance).toBe(PRESENCE_STANCE.AUTONOMOUS);
     expect(wire!.questionAutoResolveSecs).toBe(30);
     expect(wire!.planAutoApproveSecs).toBe(120);
+    expect(wire!.modeSwitchAutoPlan).toBe(false);
     expect(wire!.goalMaxTurns).toBe(20);
   });
 
@@ -119,6 +124,7 @@ describe("presenceModeSpecResolver / userPresenceWireAtom", () => {
         stance: PRESENCE_STANCE.DEFER_AND_BATCH,
         questionAutoResolveSecs: 60,
         planAutoApproveSecs: 0,
+        modeSwitchAutoPlan: true,
         goalMaxTurns: 0,
       },
     ]);
@@ -128,6 +134,7 @@ describe("presenceModeSpecResolver / userPresenceWireAtom", () => {
     expect(wire!.guidance).toBe("Heads down.");
     expect(wire!.stance).toBe(PRESENCE_STANCE.DEFER_AND_BATCH);
     expect(wire!.questionAutoResolveSecs).toBe(60);
+    expect(wire!.modeSwitchAutoPlan).toBe(true);
   });
 
   it("wire snapshot is undefined for a stale role mode", () => {

--- a/src/store/user/userPresenceAtom.ts
+++ b/src/store/user/userPresenceAtom.ts
@@ -79,6 +79,7 @@ const BUILT_IN_LABELS: Record<BuiltInPresenceMode, string> = {
 };
 
 type PresencePolicyByMode = Partial<Record<string, number>>;
+type PresenceBooleanPolicyByMode = Partial<Record<string, boolean>>;
 
 function policyNumber(
   byPresence: unknown,
@@ -88,6 +89,20 @@ function policyNumber(
   if (byPresence && typeof byPresence === "object") {
     const value = (byPresence as PresencePolicyByMode)[mode];
     if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+      return value;
+    }
+  }
+  return fallback;
+}
+
+function policyBoolean(
+  byPresence: unknown,
+  mode: BuiltInPresenceMode,
+  fallback: boolean
+): boolean {
+  if (byPresence && typeof byPresence === "object") {
+    const value = (byPresence as PresenceBooleanPolicyByMode)[mode];
+    if (typeof value === "boolean") {
       return value;
     }
   }
@@ -116,6 +131,8 @@ export const presenceModeSpecResolverAtom = atom(
           settings["agent.sde.questionAutoSkipTimeoutByPresence"];
         const planByPresence =
           settings["agent.sde.planAutoApproveTimeoutByPresence"];
+        const modeSwitchByPresence =
+          settings["agent.sde.modeSwitchAutoPlanByPresence"];
         const goalByPresence = settings["agent.sde.goalMaxTurnsByPresence"];
         return {
           id: mode,
@@ -131,6 +148,11 @@ export const presenceModeSpecResolverAtom = atom(
             planByPresence,
             mode,
             policy.planAutoApproveSecs
+          ),
+          modeSwitchAutoPlan: policyBoolean(
+            modeSwitchByPresence,
+            mode,
+            policy.modeSwitchAutoPlan
           ),
           goalMaxTurns: policyNumber(goalByPresence, mode, policy.goalMaxTurns),
           builtIn: true,
@@ -149,6 +171,7 @@ export const presenceModeSpecResolverAtom = atom(
         stance: role.stance ?? PRESENCE_STANCE.INTERACTIVE,
         questionAutoResolveSecs: role.questionAutoResolveSecs ?? 0,
         planAutoApproveSecs: role.planAutoApproveSecs ?? 0,
+        modeSwitchAutoPlan: role.modeSwitchAutoPlan ?? false,
         goalMaxTurns: role.goalMaxTurns ?? 0,
         builtIn: false,
       };
@@ -185,6 +208,7 @@ export const userPresenceWireAtom = atom<UserPresenceWire | undefined>(
       stance: spec.stance,
       questionAutoResolveSecs: spec.questionAutoResolveSecs,
       planAutoApproveSecs: spec.planAutoApproveSecs,
+      modeSwitchAutoPlan: spec.modeSwitchAutoPlan,
       goalMaxTurns: spec.goalMaxTurns,
     };
 

--- a/src/types/userPresence.ts
+++ b/src/types/userPresence.ts
@@ -113,6 +113,8 @@ export interface PresenceModeSpec {
   questionAutoResolveSecs: number;
   /** Seconds until a pending plan approval auto-approves. 0 = off. */
   planAutoApproveSecs: number;
+  /** Whether pending mode-switch suggestions auto-switch to Plan on timeout. */
+  modeSwitchAutoPlan: boolean;
   /** Goal-loop continuation budget (Ralph loop). 0 = loop disabled. */
   goalMaxTurns: number;
   /** Built-in modes cannot be deleted and keep fixed ids/icons. */
@@ -131,6 +133,7 @@ export const BUILT_IN_PRESENCE_POLICY: Record<
     | "stance"
     | "questionAutoResolveSecs"
     | "planAutoApproveSecs"
+    | "modeSwitchAutoPlan"
     | "goalMaxTurns"
   >
 > = {
@@ -138,18 +141,21 @@ export const BUILT_IN_PRESENCE_POLICY: Record<
     stance: PRESENCE_STANCE.INTERACTIVE,
     questionAutoResolveSecs: 0,
     planAutoApproveSecs: 0,
+    modeSwitchAutoPlan: false,
     goalMaxTurns: 0,
   },
   [USER_PRESENCE_MODE.AWAY]: {
     stance: PRESENCE_STANCE.DEFER_AND_BATCH,
     questionAutoResolveSecs: 180,
     planAutoApproveSecs: 0,
+    modeSwitchAutoPlan: false,
     goalMaxTurns: 0,
   },
   [USER_PRESENCE_MODE.INVISIBLE]: {
     stance: PRESENCE_STANCE.AUTONOMOUS,
     questionAutoResolveSecs: 30,
     planAutoApproveSecs: 120,
+    modeSwitchAutoPlan: false,
     goalMaxTurns: 20,
   },
 };
@@ -176,6 +182,8 @@ export interface UserPresenceWire {
   questionAutoResolveSecs?: number;
   /** Seconds until pending plan approvals auto-approve. 0 = off. */
   planAutoApproveSecs?: number;
+  /** Whether pending mode-switch suggestions auto-switch to Plan on timeout. */
+  modeSwitchAutoPlan?: boolean;
   /** Goal-loop continuation budget. 0 = off. */
   goalMaxTurns?: number;
 }
@@ -285,5 +293,6 @@ export interface CustomRoleDefinition {
   stance?: PresenceStance;
   questionAutoResolveSecs?: number;
   planAutoApproveSecs?: number;
+  modeSwitchAutoPlan?: boolean;
   goalMaxTurns?: number;
 }


### PR DESCRIPTION
## Summary

Adds a user-presence–aware option controlling the plan-mode auto-switch behavior. When the auto-switch-to-plan policy fires, it now respects the current user presence state so the mode switch is only auto-suggested/applied in the appropriate presence context.

## Changes

- **Backend (agent-core)**
  - `mode_switch.rs` / `presence_policy.rs`: thread presence state into the auto-switch decision.
  - `session/types/context.rs`: carry presence in session context.
  - `orchestration/suggest_mode_switch.rs`: honor the presence policy when suggesting a mode switch.
- **Frontend**
  - `settingsSchema/registry/agent.ts` + `integrations.ts`: new configurable presence option.
  - `ModeSwitchCard/useModeSwitchActions.ts`, `mode-switch/index.tsx`, `toolHandlers.ts`: wire the option through the mode-switch UI/event path.
  - `userPresenceAtom.ts` + `types/userPresence.ts` + `MyRole` / `MyRolesSection`: presence state store and role UI.

## Tests

- `createPlanFinalization.test.ts` and `userPresenceAtom.test.ts` updated/extended.
- Pre-commit hook: eslint 0, circular 0.
