### PR TITLE
fix(housekeeping): cover local storage artifacts

### DIFF
--- a/src-tauri/crates/advanced-search/src/commands/semantic_commands.rs
+++ b/src-tauri/crates/advanced-search/src/commands/semantic_commands.rs
@@ -75,7 +75,7 @@ fn get_lang_from_extension(path: &Path) -> Option<String> {
 
 #[cfg(feature = "semantic-search")]
 fn default_model_dir() -> PathBuf {
-    app_paths::orgii_root().join("models")
+    app_paths::models_dir()
 }
 
 #[cfg(feature = "semantic-search")]

--- a/src-tauri/crates/agent-core/src/core/turn_executor/helpers/truncate.rs
+++ b/src-tauri/crates/agent-core/src/core/turn_executor/helpers/truncate.rs
@@ -70,9 +70,7 @@ pub fn truncate_output(output: &str, budget: Option<usize>) -> String {
 
 /// Directory where oversized tool results are persisted for a session.
 pub fn tool_results_dir(session_id: &str) -> std::path::PathBuf {
-    app_paths::orgii_root()
-        .join("tool-results")
-        .join(session_id)
+    app_paths::tool_results_dir(session_id)
 }
 
 /// Like [`truncate_output`], but when the output exceeds the budget the FULL

--- a/src-tauri/crates/app-paths/src/lib.rs
+++ b/src-tauri/crates/app-paths/src/lib.rs
@@ -182,6 +182,11 @@ pub fn code_map_root() -> PathBuf {
     orgii_root().join("code-map")
 }
 
+/// Local embedding/model downloads: `~/.orgii/models/`.
+pub fn models_dir() -> PathBuf {
+    orgii_root().join("models")
+}
+
 /// Semantic-search USearch index: `~/.orgii/semantic_index/`.
 pub fn semantic_index_dir() -> PathBuf {
     orgii_root().join("semantic_index")
@@ -632,6 +637,10 @@ pub fn ensure_scratchpad(session_id: &str, workspace_path: &Path) -> std::io::Re
 /// `/private/tmp/orgii-501/` on macOS)
 /// Windows: `{TEMP}\orgii\`  (TEMP is already per-user)
 pub fn orgii_temp_root() -> PathBuf {
+    if let Ok(override_path) = std::env::var("ORGII_TEMP_ROOT") {
+        return PathBuf::from(override_path);
+    }
+
     let base = std::env::temp_dir();
     let resolved = std::fs::canonicalize(&base).unwrap_or(base);
 
@@ -681,6 +690,16 @@ pub fn cleanup_scratchpad_by_session_id(session_id: &str) {
             let _ = std::fs::remove_dir_all(&session_dir);
         }
     }
+}
+
+/// Hosted Kiro proxy HOME root: `/tmp/orgii-{uid}/kiro-proxy/`.
+pub fn kiro_proxy_home_root() -> PathBuf {
+    orgii_temp_root().join("kiro-proxy")
+}
+
+/// Hosted Kiro proxy HOME dir for one CLI session.
+pub fn kiro_proxy_home(session_id: &str) -> PathBuf {
+    kiro_proxy_home_root().join(sanitize_path_segment(session_id))
 }
 
 fn sanitize_workspace_path(workspace_path: &Path) -> String {
@@ -845,6 +864,16 @@ pub fn opencode_cli_profile_root() -> PathBuf {
 /// Account-scoped OpenCode CLI HOME dir.
 pub fn opencode_cli_profile_dir(account_id: &str) -> PathBuf {
     opencode_cli_profile_root().join(sanitize_path_segment(account_id))
+}
+
+/// Oversized tool result spill root: `~/.orgii/tool-results/`.
+pub fn tool_results_root() -> PathBuf {
+    orgii_root().join("tool-results")
+}
+
+/// Oversized tool result spill dir for one session.
+pub fn tool_results_dir(session_id: &str) -> PathBuf {
+    tool_results_root().join(session_id)
 }
 
 /// Agent worktrees root: `~/.orgii/agent-worktrees/`.

--- a/src-tauri/src/agent_sessions/cli/platform_adapters/kiro/proxy_auth.rs
+++ b/src-tauri/src/agent_sessions/cli/platform_adapters/kiro/proxy_auth.rs
@@ -142,11 +142,7 @@ pub fn setup_proxy_auth_db(
     region: &str,
     session_id: &str,
 ) -> Result<PathBuf, String> {
-    let safe_id = session_id.replace(
-        |char_value: char| !char_value.is_alphanumeric() && char_value != '-',
-        "_",
-    );
-    let temp_home = std::env::temp_dir().join(format!("kiro-proxy-{}", safe_id));
+    let temp_home = app_paths::kiro_proxy_home(session_id);
     let db_path = temp_home.join(kiro_sqlite_relative_path());
 
     use base64::Engine;

--- a/src-tauri/src/infrastructure/housekeeping.rs
+++ b/src-tauri/src/infrastructure/housekeeping.rs
@@ -10,13 +10,16 @@
 //! - File-history per-session cap enforcement (100 manifests)
 //! - Log file TTL prune (30 days, mtime-based)
 //! - Browser automation screenshot TTL prune (7 days, mtime-based)
+//! - Oversized tool-result spill TTL prune (7 days, mtime-based, recursive)
 //! - Plan-mode plan file TTL prune (30 days, mtime-based, recursive)
 //! - Merkle snapshot TTL prune (30 days, mtime-based — stale snapshots
 //!   auto-rebuild on next access)
-//! - Orphan `cursor-config/<session_id>/` and `gemini-cli-home/<session_id>/`
-//!   eviction (session no longer present in `agent_sessions` DB)
+//! - Orphan `cursor-config/<session_id>/`, hosted Claude Code profile,
+//!   Gemini home, and Kiro proxy home eviction (session no longer present
+//!   in `agent_sessions` DB)
 //! - Orphan `agent-worktrees/<repo_hash>/<session_id>/` eviction (session
 //!   no longer present in `agent_sessions` DB)
+//! - Orphan temp scratchpad eviction under `/tmp/orgii-{uid}/.../<session_id>/`
 //! - Orphan `session-images/<hash>.{ext}` eviction (hash no longer
 //!   referenced by any message's `images` column)
 //! - Orphan `gateway_bindings` row prune (target session no longer
@@ -47,6 +50,11 @@ pub const LOG_TTL_DAYS: u64 = 30;
 /// screenshots are purely diagnostic — they are never consulted after
 /// the tool round they belong to has landed in the event log.
 pub const SCREENSHOTS_TTL_DAYS: u64 = 7;
+
+/// Retention window for oversized tool-result spill files in
+/// `~/.orgii/tool-results/<session_id>/`. These are retrieval aids for
+/// recent large outputs, not durable user artifacts.
+pub const TOOL_RESULTS_TTL_DAYS: u64 = 7;
 
 /// Retention window for Plan-mode plan markdown under
 /// `~/.orgii/plans/<agent_id>/*.plan.md`. Plans are per-session scratchpads
@@ -85,12 +93,20 @@ pub struct HousekeepingStats {
     /// Per-session directories removed from `~/.orgii/cursor-config/` because
     /// their owning session was no longer present in `agent_sessions`.
     pub cursor_configs_evicted: usize,
+    /// Hosted per-session Claude Code profile dirs removed from
+    /// `~/.orgii/claude-code-cli-profiles/` because their owning CLI
+    /// session was gone. Account-scoped BYOK profiles are retained.
+    pub claude_code_session_profiles_evicted: usize,
     /// Per-session directories removed from `~/.orgii/gemini-cli-home/`
     /// because their owning session was no longer present in
     /// `agent_sessions`.
     pub gemini_homes_evicted: usize,
+    /// Hosted Kiro proxy HOME dirs removed from `/tmp/orgii-{uid}/kiro-proxy/`.
+    pub kiro_proxy_homes_evicted: usize,
     /// Screenshot files removed from `~/.orgii/screenshots/` via TTL sweep.
     pub screenshots_removed: usize,
+    /// Oversized tool-result spill files removed from `~/.orgii/tool-results/`.
+    pub tool_results_removed: usize,
     /// Plan markdown files removed recursively under `~/.orgii/plans/` via
     /// TTL sweep.
     pub plans_removed: usize,
@@ -100,6 +116,8 @@ pub struct HousekeepingStats {
     /// because their owning session was no longer present in
     /// `agent_sessions`.
     pub agent_worktrees_evicted: usize,
+    /// Per-session temp scratchpad dirs removed from `/tmp/orgii-{uid}/.../`.
+    pub scratchpads_evicted: usize,
     /// Session-image files deleted from `~/.orgii/session-images/` because
     /// no surviving message row still referenced their filename.
     pub session_images_evicted: usize,
@@ -154,10 +172,24 @@ pub fn run_deferred_cleanup() -> HousekeepingStats {
                     tracing::warn!("[housekeeping] cursor-config orphan sweep failed: {}", err)
                 }
             }
+            match evict_orphan_cli_session_profiles(paths::claude_code_cli_profile_root(), &known) {
+                Ok(n) => stats.claude_code_session_profiles_evicted = n,
+                Err(err) => tracing::warn!(
+                    "[housekeeping] claude-code hosted profile orphan sweep failed: {}",
+                    err
+                ),
+            }
             match evict_orphan_session_dirs(paths::gemini_cli_home_root(), &known) {
                 Ok(n) => stats.gemini_homes_evicted = n,
                 Err(err) => tracing::warn!(
                     "[housekeeping] gemini-cli-home orphan sweep failed: {}",
+                    err
+                ),
+            }
+            match evict_orphan_kiro_proxy_homes(&known) {
+                Ok(n) => stats.kiro_proxy_homes_evicted = n,
+                Err(err) => tracing::warn!(
+                    "[housekeeping] kiro proxy home orphan sweep failed: {}",
                     err
                 ),
             }
@@ -167,6 +199,12 @@ pub fn run_deferred_cleanup() -> HousekeepingStats {
                     "[housekeeping] agent-worktrees orphan sweep failed: {}",
                     err
                 ),
+            }
+            match evict_orphan_scratchpads(&known) {
+                Ok(n) => stats.scratchpads_evicted = n,
+                Err(err) => {
+                    tracing::warn!("[housekeeping] scratchpad orphan sweep failed: {}", err)
+                }
             }
             match evict_orphan_gateway_bindings(&known) {
                 Ok(n) => stats.gateway_bindings_evicted = n,
@@ -190,26 +228,32 @@ pub fn run_deferred_cleanup() -> HousekeepingStats {
         Err(err) => tracing::warn!("[housekeeping] screenshots prune failed: {}", err),
     }
 
-    // Step 6: Plan-mode plan markdown TTL (recursive — nested per-agent dirs).
+    // Step 6: oversized tool-result spill TTL (recursive per-session dirs).
+    match prune_old_files_recursive(paths::tool_results_root(), TOOL_RESULTS_TTL_DAYS) {
+        Ok(n) => stats.tool_results_removed = n,
+        Err(err) => tracing::warn!("[housekeeping] tool-results prune failed: {}", err),
+    }
+
+    // Step 7: Plan-mode plan markdown TTL (recursive — nested per-agent dirs).
     match prune_old_files_recursive(paths::orgii_root().join("plans"), PLANS_TTL_DAYS) {
         Ok(n) => stats.plans_removed = n,
         Err(err) => tracing::warn!("[housekeeping] plans prune failed: {}", err),
     }
 
-    // Step 7: Merkle snapshot TTL — pruned snapshots auto-rebuild on next access.
+    // Step 8: Merkle snapshot TTL — pruned snapshots auto-rebuild on next access.
     match prune_old_files_in_dir(paths::merkle_root(), MERKLE_TTL_DAYS) {
         Ok(n) => stats.merkle_snapshots_removed = n,
         Err(err) => tracing::warn!("[housekeeping] merkle prune failed: {}", err),
     }
 
-    // Step 8: session-image orphan eviction — files whose filename no
+    // Step 9: session-image orphan eviction — files whose filename no
     // longer appears in any surviving message's `images` JSON array.
     match evict_orphan_session_images() {
         Ok(n) => stats.session_images_evicted = n,
         Err(err) => tracing::warn!("[housekeeping] session-images orphan sweep failed: {}", err),
     }
 
-    // Step 9: session-cache TTL — drops `sessions`/`events` rows older
+    // Step 10: session-cache TTL — drops `sessions`/`events` rows older
     // than SESSION_CACHE_TTL_DAYS. `agent_snapshots` is cascaded by
     // `clear_old_sessions` as a side-effect.
     match session_persistence::clear_old_sessions(
@@ -220,7 +264,7 @@ pub fn run_deferred_cleanup() -> HousekeepingStats {
     }
 
     tracing::info!(
-        "[housekeeping] pass finished: file_history(sessions={}, rows={}), capped(sessions={}, manifests={}, blobs={}), logs_removed={}, cursor_configs_evicted={}, gemini_homes_evicted={}, agent_worktrees_evicted={}, screenshots_removed={}, plans_removed={}, merkle_snapshots_removed={}, session_images_evicted={}, gateway_bindings_evicted={}, session_cache_rows_evicted={}",
+        "[housekeeping] pass finished: file_history(sessions={}, rows={}), capped(sessions={}, manifests={}, blobs={}), logs_removed={}, cursor_configs_evicted={}, claude_code_session_profiles_evicted={}, gemini_homes_evicted={}, kiro_proxy_homes_evicted={}, agent_worktrees_evicted={}, scratchpads_evicted={}, screenshots_removed={}, tool_results_removed={}, plans_removed={}, merkle_snapshots_removed={}, session_images_evicted={}, gateway_bindings_evicted={}, session_cache_rows_evicted={}",
         stats.file_history.sessions_removed,
         stats.file_history.db_rows_removed,
         stats.sessions_capped,
@@ -228,9 +272,13 @@ pub fn run_deferred_cleanup() -> HousekeepingStats {
         stats.blobs_capped,
         stats.log_files_removed,
         stats.cursor_configs_evicted,
+        stats.claude_code_session_profiles_evicted,
         stats.gemini_homes_evicted,
+        stats.kiro_proxy_homes_evicted,
         stats.agent_worktrees_evicted,
+        stats.scratchpads_evicted,
         stats.screenshots_removed,
+        stats.tool_results_removed,
         stats.plans_removed,
         stats.merkle_snapshots_removed,
         stats.session_images_evicted,
@@ -324,6 +372,32 @@ mod tests {
     }
 
     #[test]
+    fn prune_tool_results_drops_aged_spills_and_empty_session_dirs() {
+        with_sandbox(|_| {
+            let live_dir = paths::tool_results_dir("sid-live");
+            let dead_dir = paths::tool_results_dir("sid-dead");
+            std::fs::create_dir_all(&live_dir).unwrap();
+            std::fs::create_dir_all(&dead_dir).unwrap();
+
+            let fresh = live_dir.join("fresh.txt");
+            let aged = dead_dir.join("aged.txt");
+            std::fs::write(&fresh, b"fresh").unwrap();
+            std::fs::write(&aged, b"aged").unwrap();
+            set_mtime_days_ago(&aged, TOOL_RESULTS_TTL_DAYS + 1).unwrap();
+
+            let removed =
+                prune_old_files_recursive(paths::tool_results_root(), TOOL_RESULTS_TTL_DAYS)
+                    .unwrap();
+
+            assert_eq!(removed, 1);
+            assert!(fresh.exists(), "fresh spill kept");
+            assert!(!aged.exists(), "aged spill removed");
+            assert!(live_dir.exists(), "non-empty session dir kept");
+            assert!(!dead_dir.exists(), "empty session dir pruned");
+        });
+    }
+
+    #[test]
     fn evict_orphan_agent_worktrees_prunes_only_unknown_sids() {
         with_sandbox(|_| {
             let root = paths::agent_worktrees_root();
@@ -349,6 +423,92 @@ mod tests {
                 repo.exists(),
                 "repo-hash parent kept even when a child is evicted"
             );
+        });
+    }
+
+    #[test]
+    fn evict_orphan_scratchpads_prunes_unknown_session_dirs() {
+        with_sandbox(|root| {
+            let previous_temp_root = std::env::var("ORGII_TEMP_ROOT").ok();
+            let temp_root = root.join("tmp");
+            std::env::set_var("ORGII_TEMP_ROOT", &temp_root);
+
+            let workspace = paths::workspace_temp_dir(Path::new("/Users/me/project"));
+            let live_dir = workspace.join("sid-live").join("scratchpad");
+            let dead_dir = workspace.join("sid-dead").join("scratchpad");
+            std::fs::create_dir_all(&live_dir).unwrap();
+            std::fs::create_dir_all(&dead_dir).unwrap();
+            std::fs::write(live_dir.join("keep.txt"), b"live").unwrap();
+            std::fs::write(dead_dir.join("drop.txt"), b"dead").unwrap();
+
+            let mut known = std::collections::HashSet::new();
+            known.insert("sid-live".to_string());
+
+            let removed = evict_orphan_scratchpads(&known).unwrap();
+
+            assert_eq!(removed, 1);
+            assert!(workspace.join("sid-live").exists(), "live scratchpad kept");
+            assert!(
+                !workspace.join("sid-dead").exists(),
+                "dead scratchpad removed"
+            );
+            match previous_temp_root {
+                Some(value) => std::env::set_var("ORGII_TEMP_ROOT", value),
+                None => std::env::remove_var("ORGII_TEMP_ROOT"),
+            }
+        });
+    }
+
+    #[test]
+    fn evict_orphan_cli_session_profiles_keeps_account_profiles() {
+        with_sandbox(|_| {
+            let root = paths::claude_code_cli_profile_root();
+            let live_sid = "cliagent-live";
+            let dead_sid = "cliagent-dead";
+            let account_id = "acct-user-profile";
+            std::fs::create_dir_all(root.join(live_sid)).unwrap();
+            std::fs::create_dir_all(root.join(dead_sid)).unwrap();
+            std::fs::create_dir_all(root.join(account_id)).unwrap();
+
+            let mut known = std::collections::HashSet::new();
+            known.insert(live_sid.to_string());
+
+            let removed = evict_orphan_cli_session_profiles(root.clone(), &known).unwrap();
+
+            assert_eq!(removed, 1);
+            assert!(root.join(live_sid).exists(), "live session profile kept");
+            assert!(
+                !root.join(dead_sid).exists(),
+                "dead session profile removed"
+            );
+            assert!(root.join(account_id).exists(), "account profile retained");
+        });
+    }
+
+    #[test]
+    fn evict_orphan_kiro_proxy_homes_prunes_unknown_sessions() {
+        with_sandbox(|root| {
+            let previous_temp_root = std::env::var("ORGII_TEMP_ROOT").ok();
+            let temp_root = root.join("tmp-kiro");
+            std::env::set_var("ORGII_TEMP_ROOT", &temp_root);
+
+            let live_sid = "cliagent-live";
+            let dead_sid = "cliagent-dead";
+            std::fs::create_dir_all(paths::kiro_proxy_home(live_sid)).unwrap();
+            std::fs::create_dir_all(paths::kiro_proxy_home(dead_sid)).unwrap();
+
+            let mut known = std::collections::HashSet::new();
+            known.insert(live_sid.to_string());
+
+            let removed = evict_orphan_kiro_proxy_homes(&known).unwrap();
+
+            assert_eq!(removed, 1);
+            assert!(paths::kiro_proxy_home(live_sid).exists());
+            assert!(!paths::kiro_proxy_home(dead_sid).exists());
+            match previous_temp_root {
+                Some(value) => std::env::set_var("ORGII_TEMP_ROOT", value),
+                None => std::env::remove_var("ORGII_TEMP_ROOT"),
+            }
         });
     }
 

--- a/src-tauri/src/infrastructure/housekeeping/housekeeping_orphans.rs
+++ b/src-tauri/src/infrastructure/housekeeping/housekeeping_orphans.rs
@@ -6,6 +6,7 @@
 use std::fs;
 
 use app_paths as paths;
+use core_types::session::CLI_SESSION_PREFIX;
 
 /// Fetch every session_id currently present in both the `agent_sessions`
 /// table (Rust-native agents) and the `code_sessions` table (CLI agents).
@@ -107,6 +108,114 @@ pub(super) fn evict_orphan_session_dirs(
     if removed > 0 {
         tracing::info!(
             "[housekeeping] evicted {} orphan session dir(s) under {}",
+            removed,
+            root.display()
+        );
+    }
+
+    Ok(removed)
+}
+
+/// Evict hosted Claude Code per-session profile dirs (`cliagent-*`) whose
+/// backing CLI session no longer exists. Account-scoped BYOK profile dirs are
+/// intentionally retained.
+pub(super) fn evict_orphan_cli_session_profiles(
+    root: std::path::PathBuf,
+    known_session_ids: &std::collections::HashSet<String>,
+) -> std::io::Result<usize> {
+    if !root.exists() {
+        return Ok(0);
+    }
+
+    let mut removed = 0;
+    for entry in fs::read_dir(&root)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if !name.starts_with(CLI_SESSION_PREFIX) || known_session_ids.contains(name) {
+            continue;
+        }
+        if let Err(err) = fs::remove_dir_all(&path) {
+            tracing::warn!(
+                "[housekeeping] failed to evict orphan CLI session profile {}: {}",
+                path.display(),
+                err
+            );
+            continue;
+        }
+        removed += 1;
+    }
+
+    if removed > 0 {
+        tracing::info!(
+            "[housekeeping] evicted {} orphan CLI session profile dir(s) under {}",
+            removed,
+            root.display()
+        );
+    }
+
+    Ok(removed)
+}
+
+/// Evict hosted Kiro proxy HOME dirs keyed by CLI session id.
+pub(super) fn evict_orphan_kiro_proxy_homes(
+    known_session_ids: &std::collections::HashSet<String>,
+) -> std::io::Result<usize> {
+    evict_orphan_session_dirs(paths::kiro_proxy_home_root(), known_session_ids)
+}
+
+/// Walk `/tmp/orgii-{uid}/{workspace}/{session_id}/` and remove session temp
+/// dirs whose session id no longer exists in the durable session tables.
+pub(super) fn evict_orphan_scratchpads(
+    known_session_ids: &std::collections::HashSet<String>,
+) -> std::io::Result<usize> {
+    let root = paths::orgii_temp_root();
+    if !root.exists() {
+        return Ok(0);
+    }
+
+    let mut removed = 0;
+    for workspace_entry in fs::read_dir(&root)? {
+        let workspace_entry = workspace_entry?;
+        let workspace_path = workspace_entry.path();
+        if !workspace_path.is_dir() {
+            continue;
+        }
+        for session_entry in fs::read_dir(&workspace_path)? {
+            let session_entry = session_entry?;
+            let session_path = session_entry.path();
+            if !session_path.is_dir() {
+                continue;
+            }
+            let Some(name) = session_path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            if known_session_ids.contains(name) {
+                continue;
+            }
+            if let Err(err) = fs::remove_dir_all(&session_path) {
+                tracing::warn!(
+                    "[housekeeping] failed to evict orphan scratchpad {}: {}",
+                    session_path.display(),
+                    err
+                );
+                continue;
+            }
+            removed += 1;
+        }
+        if fs::read_dir(&workspace_path)?.next().is_none() {
+            let _ = fs::remove_dir(&workspace_path);
+        }
+    }
+
+    if removed > 0 {
+        tracing::info!(
+            "[housekeeping] evicted {} orphan scratchpad dir(s) under {}",
             removed,
             root.display()
         );

--- a/src-tauri/src/infrastructure/storage_commands.rs
+++ b/src-tauri/src/infrastructure/storage_commands.rs
@@ -11,9 +11,12 @@
 use std::path::{Path, PathBuf};
 
 use app_paths::{
-    agent_worktrees_root, claude_code_cli_profile_root, codex_cli_profile_root, cursor_config_root,
-    extensions_dir, file_history_root, gemini_cli_home_root, logs_dir, lsp_bin_dir, orgii_root,
-    personal_workspace, screenshots_dir, session_images_dir, sessions_db,
+    agent_worktrees_root, claude_code_cli_profile_root, code_map_root, codex_cli_profile_root,
+    cursor_cli_profile_root, cursor_config_root, diagnostics_dir, extensions_dir,
+    file_history_root, gemini_cli_home_root, gemini_cli_profile_root, kiro_cli_profile_root,
+    logs_dir, lsp_bin_dir, models_dir, opencode_cli_profile_root, orgii_root, personal_workspace,
+    screenshots_dir, semantic_index_dir, session_images_dir, sessions_db, sidecar_bin_dir,
+    tool_results_root,
 };
 
 /// Tauri command: path where agent memory (KG) is stored: `~/.orgii/sessions.db`.
@@ -92,6 +95,11 @@ pub fn get_disk_usage() -> DiskUsageReport {
         ),
         ("cursorConfig", "Session CLI Configs", cursor_config_root()),
         (
+            "cursorCliProfiles",
+            "Cursor CLI Profiles",
+            cursor_cli_profile_root(),
+        ),
+        (
             "claudeCodeCliProfiles",
             "Claude Code CLI Profiles",
             claude_code_cli_profile_root(),
@@ -102,15 +110,44 @@ pub fn get_disk_usage() -> DiskUsageReport {
             codex_cli_profile_root(),
         ),
         ("geminiCliHome", "Gemini CLI Homes", gemini_cli_home_root()),
+        (
+            "geminiCliProfiles",
+            "Gemini CLI Profiles",
+            gemini_cli_profile_root(),
+        ),
+        (
+            "kiroCliProfiles",
+            "Kiro CLI Profiles",
+            kiro_cli_profile_root(),
+        ),
+        (
+            "opencodeCliProfiles",
+            "OpenCode CLI Profiles",
+            opencode_cli_profile_root(),
+        ),
         ("extensions", "Extensions", extensions_dir()),
         ("sessionImages", "Chat Images", session_images_dir()),
         ("screenshots", "Browser Screenshots", screenshots_dir()),
+        ("toolResults", "Oversized Tool Results", tool_results_root()),
+        ("diagnostics", "Diagnostics Queue", diagnostics_dir()),
+        ("models", "Downloaded Models", models_dir()),
+        ("codeMap", "Code Map Indexes", code_map_root()),
+        (
+            "semanticIndex",
+            "Semantic Search Index",
+            semantic_index_dir(),
+        ),
         (
             "agentWorktrees",
             "Agent Session Worktrees",
             agent_worktrees_root(),
         ),
         ("lspBin", "LSP Server Binaries", lsp_bin_dir()),
+        (
+            "sidecarBin",
+            "Downloaded Sidecar Binaries",
+            sidecar_bin_dir(),
+        ),
     ];
 
     let categories: Vec<StorageCategory> = categories_spec
@@ -145,13 +182,24 @@ fn category_path(key: &str) -> Option<PathBuf> {
         "fileHistory" => Some(file_history_root()),
         "personalWorkspace" => Some(personal_workspace()),
         "cursorConfig" => Some(cursor_config_root()),
+        "cursorCliProfiles" => Some(cursor_cli_profile_root()),
         "claudeCodeCliProfiles" => Some(claude_code_cli_profile_root()),
         "codexCliProfiles" => Some(codex_cli_profile_root()),
         "geminiCliHome" => Some(gemini_cli_home_root()),
+        "geminiCliProfiles" => Some(gemini_cli_profile_root()),
+        "kiroCliProfiles" => Some(kiro_cli_profile_root()),
+        "opencodeCliProfiles" => Some(opencode_cli_profile_root()),
         "extensions" => Some(extensions_dir()),
+        "sessionImages" => Some(session_images_dir()),
         "agentWorktrees" => Some(agent_worktrees_root()),
         "screenshots" => Some(screenshots_dir()),
+        "toolResults" => Some(tool_results_root()),
+        "diagnostics" => Some(diagnostics_dir()),
+        "models" => Some(models_dir()),
+        "codeMap" => Some(code_map_root()),
+        "semanticIndex" => Some(semantic_index_dir()),
         "lspBin" => Some(lsp_bin_dir()),
+        "sidecarBin" => Some(sidecar_bin_dir()),
         _ => None,
     }
 }
@@ -189,4 +237,49 @@ pub fn clear_storage_category(key: String) -> Result<u64, String> {
     }
 
     Ok(freed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn disk_usage_categories_have_clear_paths_except_protected_files() {
+        let report = get_disk_usage();
+        for category in report.categories {
+            if PROTECTED_CATEGORIES.contains(&category.key.as_str()) {
+                continue;
+            }
+            assert!(
+                category_path(&category.key).is_some(),
+                "{} should be clearable or explicitly protected",
+                category.key
+            );
+        }
+    }
+
+    #[test]
+    fn new_storage_roots_are_reported() {
+        let report = get_disk_usage();
+        let keys: std::collections::HashSet<_> = report
+            .categories
+            .iter()
+            .map(|category| category.key.as_str())
+            .collect();
+
+        for expected in [
+            "toolResults",
+            "diagnostics",
+            "models",
+            "codeMap",
+            "semanticIndex",
+            "cursorCliProfiles",
+            "geminiCliProfiles",
+            "kiroCliProfiles",
+            "opencodeCliProfiles",
+            "sidecarBin",
+        ] {
+            assert!(keys.contains(expected), "missing {expected}");
+        }
+    }
 }

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -909,8 +909,18 @@
     "diskCategory_codexCliProfiles": "Codex CLI Profiles",
     "diskCategory_sessionImages": "Chat Images",
     "diskCategory_screenshots": "Browser Screenshots",
+    "diskCategory_toolResults": "Oversized Tool Results",
+    "diskCategory_diagnostics": "Diagnostics Queue",
+    "diskCategory_models": "Downloaded Models",
+    "diskCategory_codeMap": "Code Map Indexes",
+    "diskCategory_semanticIndex": "Semantic Search Index",
+    "diskCategory_cursorCliProfiles": "Cursor CLI Profiles",
+    "diskCategory_geminiCliProfiles": "Gemini CLI Profiles",
+    "diskCategory_kiroCliProfiles": "Kiro CLI Profiles",
+    "diskCategory_opencodeCliProfiles": "OpenCode CLI Profiles",
     "diskCategory_agentWorktrees": "Agent Session Worktrees",
     "diskCategory_lspBin": "LSP Server Binaries",
+    "diskCategory_sidecarBin": "Downloaded Sidecar Binaries",
     "loadZeroRows": "Click to load {{count}} more"
   },
   "dependencies": {

--- a/src/i18n/locales/zh/settings.json
+++ b/src/i18n/locales/zh/settings.json
@@ -909,8 +909,18 @@
     "diskCategory_codexCliProfiles": "Codex CLI 配置",
     "diskCategory_sessionImages": "聊天图片",
     "diskCategory_screenshots": "浏览器截图",
+    "diskCategory_toolResults": "大型工具结果",
+    "diskCategory_diagnostics": "诊断队列",
+    "diskCategory_models": "下载的模型",
+    "diskCategory_codeMap": "Code Map 索引",
+    "diskCategory_semanticIndex": "语义搜索索引",
+    "diskCategory_cursorCliProfiles": "Cursor CLI 配置",
+    "diskCategory_geminiCliProfiles": "Gemini CLI 配置",
+    "diskCategory_kiroCliProfiles": "Kiro CLI 配置",
+    "diskCategory_opencodeCliProfiles": "OpenCode CLI 配置",
     "diskCategory_agentWorktrees": "Agent Session Worktrees",
     "diskCategory_lspBin": "LSP Server 二进制",
+    "diskCategory_sidecarBin": "下载的 Sidecar 二进制",
     "loadZeroRows": "点击加载另外 {{count}} 项"
   },
   "storage": {


### PR DESCRIPTION
## Summary
- add housekeeping coverage for oversized tool-result spills, scratchpads, hosted Claude Code profiles, and Kiro proxy homes
- centralize new storage path helpers for tool results, models, and Kiro proxy homes
- expand Settings disk-usage categories and clear mappings for newer local storage roots

## Verification
- `cargo test --manifest-path src-tauri/Cargo.toml housekeeping::tests -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml storage_commands::tests -- --nocapture`
- `cargo test --manifest-path src-tauri/Cargo.toml -p app_paths orgii_temp_root_contains_orgii_segment -- --nocapture`
- `cargo check --manifest-path src-tauri/Cargo.toml -p org2`
- `git diff --check`
