### PR TITLE
fix(opencode settings): support opencode zen and go endpoints switching

### DIFF
--- a/src-tauri/crates/agent-core/src/core/providers/registry.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/registry.rs
@@ -93,7 +93,7 @@ pub static PROVIDERS: &[ProviderSpec] = &[
         keywords: &[],
         litellm_prefix: None,
         skip_prefixes: &[],
-        default_api_base: Some("https://opencode.ai/zen/go/v1"),
+        default_api_base: Some("https://opencode.ai/zen/v1"),
         default_anthropic_api_base: None,
         is_local: false,
         env_key: Some("OPENCODE_API_KEY"),

--- a/src-tauri/crates/key-vault/src/auto_detect/opencode.rs
+++ b/src-tauri/crates/key-vault/src/auto_detect/opencode.rs
@@ -5,12 +5,10 @@ use serde::Deserialize;
 
 use super::helpers::{create_detected_key, get_home_dir};
 use super::DetectedKey;
-use crate::commands::validate_opencode_key;
+use crate::commands::{validate_opencode_key, OPENCODE_GO_BASE_URL, OPENCODE_ZEN_BASE_URL};
 
 const OPENCODE_ZEN_PROVIDER_ID: &str = "opencode";
 const OPENCODE_GO_PROVIDER_ID: &str = "opencode-go";
-const OPENCODE_ZEN_BASE_URL: &str = "https://opencode.ai/zen/v1";
-const OPENCODE_GO_BASE_URL: &str = "https://opencode.ai/zen/go/v1";
 
 #[derive(Debug, Deserialize)]
 struct OpenCodeAuthEntry {
@@ -39,11 +37,7 @@ pub(super) async fn detect_opencode_keys() -> Vec<DetectedKey> {
         ),
     ] {
         if let Ok(api_key) = env::var(env_name) {
-            if api_key.is_empty()
-                || keys
-                    .iter()
-                    .any(|key| key.api_key.as_ref() == Some(&api_key))
-            {
+            if api_key.is_empty() || is_duplicate_detected_key(&keys, &api_key, base_url) {
                 continue;
             }
 
@@ -110,6 +104,12 @@ async fn read_opencode_auth_config(path: &std::path::Path) -> Vec<DetectedKey> {
     keys
 }
 
+fn is_duplicate_detected_key(keys: &[DetectedKey], api_key: &str, base_url: &str) -> bool {
+    keys.iter().any(|key| {
+        key.api_key.as_deref() == Some(api_key) && key.base_url.as_deref() == Some(base_url)
+    })
+}
+
 fn opencode_base_url(provider_id: &str) -> Option<&'static str> {
     match provider_id {
         OPENCODE_ZEN_PROVIDER_ID => Some(OPENCODE_ZEN_BASE_URL),
@@ -149,6 +149,25 @@ mod tests {
         assert_eq!(keys[0].auth_method, "api_key");
         assert_eq!(keys[0].api_key.as_deref(), Some("opencode-test-key"));
         assert_eq!(keys[0].base_url.as_deref(), Some(OPENCODE_GO_BASE_URL));
+    }
+
+    #[test]
+    fn duplicate_detection_keeps_same_key_for_different_endpoints() {
+        let mut zen = create_detected_key("zen", "OpenCode Zen", "api_key");
+        zen.api_key = Some("shared-key".to_string());
+        zen.base_url = Some(OPENCODE_ZEN_BASE_URL.to_string());
+        let keys = vec![zen];
+
+        assert!(!is_duplicate_detected_key(
+            &keys,
+            "shared-key",
+            OPENCODE_GO_BASE_URL
+        ));
+        assert!(is_duplicate_detected_key(
+            &keys,
+            "shared-key",
+            OPENCODE_ZEN_BASE_URL
+        ));
     }
 
     #[tokio::test]

--- a/src-tauri/crates/key-vault/src/commands/validate.rs
+++ b/src-tauri/crates/key-vault/src/commands/validate.rs
@@ -77,8 +77,8 @@ use crate::provider_config::get_provider_config;
 const CLAUDE_CODE_OAUTH_MODELS_URL: &str = "https://api.anthropic.com/v1/models";
 const CLAUDE_CODE_OAUTH_BETA: &str = "oauth-2025-04-20";
 const CLAUDE_CODE_OAUTH_USER_AGENT: &str = "claude-cli/2.1.78 (orgii, cli)";
-const OPENCODE_ZEN_BASE_URL: &str = "https://opencode.ai/zen/v1";
-const OPENCODE_GO_BASE_URL: &str = "https://opencode.ai/zen/go/v1";
+pub const OPENCODE_ZEN_BASE_URL: &str = "https://opencode.ai/zen/v1";
+pub const OPENCODE_GO_BASE_URL: &str = "https://opencode.ai/zen/go/v1";
 
 const GEMINI_OAUTH_MODELS_URL: &str = "https://generativelanguage.googleapis.com/v1beta/models";
 
@@ -106,22 +106,19 @@ fn default_anthropic_base_url_for_provider(agent_type: &str) -> Option<String> {
     }
 }
 
+fn resolve_opencode_base_url(base_url: Option<&str>) -> &str {
+    base_url.unwrap_or(OPENCODE_ZEN_BASE_URL)
+}
+
 /// Validate an OpenCode Zen/Go key by listing models without issuing a completion request.
 pub async fn validate_opencode_key(api_key: &str, base_url: Option<&str>) -> ValidationResult {
     if api_key.is_empty() {
         return ValidationResult::failure("No API key provided");
     }
 
-    let result = fetch_opencode_models(api_key, base_url.unwrap_or(OPENCODE_GO_BASE_URL)).await;
-    match result {
+    match fetch_opencode_models(api_key, resolve_opencode_base_url(base_url)).await {
         Ok(models) => ValidationResult::success("API key valid").with_models(models),
-        Err(err) if err == "Invalid API key" || base_url.is_some() => {
-            ValidationResult::failure(&err)
-        }
-        Err(_) => match fetch_opencode_models(api_key, OPENCODE_ZEN_BASE_URL).await {
-            Ok(models) => ValidationResult::success("API key valid").with_models(models),
-            Err(err) => ValidationResult::failure(&err),
-        },
+        Err(err) => ValidationResult::failure(&err),
     }
 }
 
@@ -970,6 +967,19 @@ mod tests {
     fn code_assist_quota_response_rejects_invalid_json() {
         let err = parse_code_assist_quota_response("not json").unwrap_err();
         assert!(err.contains("parse failed"));
+    }
+
+    #[test]
+    fn opencode_base_url_defaults_to_zen_and_respects_selection() {
+        assert_eq!(resolve_opencode_base_url(None), OPENCODE_ZEN_BASE_URL);
+        assert_eq!(
+            resolve_opencode_base_url(Some(OPENCODE_ZEN_BASE_URL)),
+            OPENCODE_ZEN_BASE_URL
+        );
+        assert_eq!(
+            resolve_opencode_base_url(Some(OPENCODE_GO_BASE_URL)),
+            OPENCODE_GO_BASE_URL
+        );
     }
 
     // ── validate_token_format dispatch ────────────────────────────────

--- a/src-tauri/crates/key-vault/src/provider_config.rs
+++ b/src-tauri/crates/key-vault/src/provider_config.rs
@@ -86,7 +86,12 @@ pub fn get_provider_config(model_type: &str) -> ProviderConfig {
             true,
             Some("https://api.moonshot.cn/v1"),
         ),
-        "opencode" => ProviderConfig::new("OPENCODE_API_KEY", None, false, None),
+        "opencode" => ProviderConfig::new(
+            "OPENCODE_API_KEY",
+            Some("OPENCODE_BASE_URL"),
+            true,
+            Some("https://opencode.ai/zen/v1"),
+        ),
         "anthropic_api" => ProviderConfig::with_protocols(
             "ANTHROPIC_API_KEY",
             None,
@@ -346,7 +351,14 @@ mod tests {
 
         let opencode = get_provider_config("opencode");
         assert_eq!(opencode.api_key_env_var, "OPENCODE_API_KEY");
-        assert!(!opencode.supports_base_url);
-        assert!(opencode.default_base_url.is_none());
+        assert_eq!(
+            opencode.base_url_env_var,
+            Some("OPENCODE_BASE_URL".to_string())
+        );
+        assert!(opencode.supports_base_url);
+        assert_eq!(
+            opencode.default_base_url,
+            Some("https://opencode.ai/zen/v1".to_string())
+        );
     }
 }

--- a/src/modules/MainApp/Integrations/KeyVault/Accounts/Table/AccountInlineEditSection.tsx
+++ b/src/modules/MainApp/Integrations/KeyVault/Accounts/Table/AccountInlineEditSection.tsx
@@ -19,6 +19,10 @@ import InlineAlert from "@src/components/InlineAlert";
 import Input from "@src/components/Input";
 import Textarea from "@src/components/Textarea";
 import type { KeyVaultAccount } from "@src/hooks/keyVault";
+import {
+  SelectionGrid,
+  type SelectionGridOption,
+} from "@src/scaffold/WizardSystem/primitives";
 
 import {
   InlineCardColumnStack,
@@ -30,10 +34,45 @@ interface AccountInlineEditState {
   setName: (value: string) => void;
   description: string;
   setDescription: (value: string) => void;
+  endpoint: OpenCodeEndpoint;
+  setEndpoint: (value: OpenCodeEndpoint) => void;
   saving: boolean;
   savedAt: number | null;
   canSave: boolean;
   handleSave: () => Promise<void>;
+}
+
+type OpenCodeEndpoint = "zen" | "go";
+
+const OPENCODE_ZEN_BASE_URL = "https://opencode.ai/zen/v1";
+const OPENCODE_GO_BASE_URL = "https://opencode.ai/zen/go/v1";
+
+const OPENCODE_ENDPOINT_OPTIONS: SelectionGridOption<OpenCodeEndpoint>[] = [
+  {
+    key: "zen",
+    label: "OpenCode Zen",
+    badge: "Recommended",
+    description: "Use Zen subscription models such as Claude Sonnet.",
+  },
+  {
+    key: "go",
+    label: "OpenCode Go",
+    description: "Use the OpenCode Go endpoint and model list.",
+  },
+];
+
+function getOpenCodeEndpointFromBaseUrl(
+  baseUrl?: string | null
+): OpenCodeEndpoint {
+  return baseUrl === OPENCODE_GO_BASE_URL ? "go" : "zen";
+}
+
+function getOpenCodeBaseUrl(endpoint: OpenCodeEndpoint): string {
+  return endpoint === "go" ? OPENCODE_GO_BASE_URL : OPENCODE_ZEN_BASE_URL;
+}
+
+function isOpenCodeAccount(account: KeyVaultAccount): boolean {
+  return account.modelType === "opencode";
 }
 
 /**
@@ -42,34 +81,44 @@ interface AccountInlineEditState {
  */
 export function useAccountInlineEditState(
   account: KeyVaultAccount,
-  onSave: (name: string, description: string) => Promise<void>
+  onSave: (name: string, description: string, baseUrl?: string) => Promise<void>
 ): AccountInlineEditState {
   const [name, setName] = useState(account.name);
   const [description, setDescription] = useState(account.description ?? "");
+  const [endpoint, setEndpoint] = useState<OpenCodeEndpoint>(
+    getOpenCodeEndpointFromBaseUrl(account.baseUrl)
+  );
   const [saving, setSaving] = useState(false);
   const [savedAt, setSavedAt] = useState<number | null>(null);
 
   useEffect(() => {
     setName(account.name);
     setDescription(account.description ?? "");
-  }, [account.id, account.name, account.description]);
+    setEndpoint(getOpenCodeEndpointFromBaseUrl(account.baseUrl));
+  }, [account.id, account.name, account.description, account.baseUrl]);
 
   const trimmedName = name.trim();
   const isDirty =
     trimmedName !== account.name ||
-    description.trim() !== (account.description ?? "").trim();
+    description.trim() !== (account.description ?? "").trim() ||
+    (isOpenCodeAccount(account) &&
+      endpoint !== getOpenCodeEndpointFromBaseUrl(account.baseUrl));
   const canSave = isDirty && trimmedName.length > 0 && !saving;
 
   const handleSave = useCallback(async () => {
     if (!canSave) return;
     setSaving(true);
     try {
-      await onSave(trimmedName, description.trim());
+      await onSave(
+        trimmedName,
+        description.trim(),
+        isOpenCodeAccount(account) ? getOpenCodeBaseUrl(endpoint) : undefined
+      );
       setSavedAt(Date.now());
     } finally {
       setSaving(false);
     }
-  }, [canSave, description, onSave, trimmedName]);
+  }, [account, canSave, description, endpoint, onSave, trimmedName]);
 
   useEffect(() => {
     if (savedAt == null) return;
@@ -82,6 +131,8 @@ export function useAccountInlineEditState(
     setName,
     description,
     setDescription,
+    endpoint,
+    setEndpoint,
     saving,
     savedAt,
     canSave,
@@ -90,14 +141,17 @@ export function useAccountInlineEditState(
 }
 
 interface AccountInlineEditBodyProps {
+  account: KeyVaultAccount;
   state: AccountInlineEditState;
 }
 
 export const AccountInlineEditBody: React.FC<AccountInlineEditBodyProps> = ({
+  account,
   state,
 }) => {
   const { t } = useTranslation("integrations");
-  const { name, setName, description, setDescription } = state;
+  const { name, setName, description, setDescription, endpoint, setEndpoint } =
+    state;
 
   return (
     <div className="flex min-w-0 flex-col gap-3">
@@ -126,6 +180,21 @@ export const AccountInlineEditBody: React.FC<AccountInlineEditBodyProps> = ({
             rows={2}
           />
         </div>
+        {isOpenCodeAccount(account) ? (
+          <div className="flex min-w-0 flex-col gap-1">
+            <span className="text-[12px] font-semibold text-text-1">
+              OpenCode endpoint
+            </span>
+            <SelectionGrid
+              options={OPENCODE_ENDPOINT_OPTIONS}
+              selected={endpoint}
+              onSelect={setEndpoint}
+              columns={2}
+              cardVariant="subtle"
+              compactCards
+            />
+          </div>
+        ) : null}
       </InlineCardColumnStack>
 
       <InlineAlert type="info">{t("keyVault.edit.apiChangeHint")}</InlineAlert>

--- a/src/modules/MainApp/Integrations/KeyVault/Accounts/Table/AccountInlineExpandedCard.tsx
+++ b/src/modules/MainApp/Integrations/KeyVault/Accounts/Table/AccountInlineExpandedCard.tsx
@@ -71,7 +71,8 @@ interface AccountInlineExpandedCardProps {
   onEditSave?: (
     accountId: string,
     name: string,
-    description: string
+    description: string,
+    baseUrl?: string
   ) => Promise<void>;
   /** When true, the Edit tab is shown and auto-activated. Driven by the
    *  parent table — set by clicking the row's pencil button, cleared when
@@ -161,9 +162,9 @@ const AccountInlineExpandedCard: React.FC<AccountInlineExpandedCardProps> = ({
   }, [account.id, onRevalidateAccount, t]);
 
   const handleEditFormSave = useCallback(
-    async (nextName: string, nextDescription: string) => {
+    async (nextName: string, nextDescription: string, endpoint?: string) => {
       if (!onEditSave) return;
-      await onEditSave(account.id, nextName, nextDescription);
+      await onEditSave(account.id, nextName, nextDescription, endpoint);
       onEditCancel?.();
     },
     [account.id, onEditCancel, onEditSave]
@@ -305,7 +306,7 @@ const AccountInlineExpandedCard: React.FC<AccountInlineExpandedCardProps> = ({
         return <AccountInlineStatusSection account={account} />;
       case ACCOUNT_INLINE_TAB.EDIT:
         if (!showEditTab) return null;
-        return <AccountInlineEditBody state={editState} />;
+        return <AccountInlineEditBody account={account} state={editState} />;
       case ACCOUNT_INLINE_TAB.MODELS:
         if (showGatewayDeployment && onRefresh) {
           return (

--- a/src/modules/MainApp/Integrations/KeyVault/Accounts/Table/MyAccountsTableSection.tsx
+++ b/src/modules/MainApp/Integrations/KeyVault/Accounts/Table/MyAccountsTableSection.tsx
@@ -58,7 +58,8 @@ interface MyAccountsTableSectionProps {
   onEditAccountSave?: (
     accountId: string,
     name: string,
-    description: string
+    description: string,
+    baseUrl?: string
   ) => Promise<void>;
   t: (key: string, options?: Record<string, unknown>) => string;
 }

--- a/src/modules/MainApp/Integrations/KeyVault/Table/AccountsTable.tsx
+++ b/src/modules/MainApp/Integrations/KeyVault/Table/AccountsTable.tsx
@@ -65,7 +65,8 @@ interface AccountsTableProps {
   onEditAccountSave?: (
     accountId: string,
     name: string,
-    description: string
+    description: string,
+    baseUrl?: string
   ) => Promise<void>;
   onDisconnectAccount?: (
     accountId: string,

--- a/src/modules/MainApp/Integrations/KeyVault/hooks/useKeyVaultPage.ts
+++ b/src/modules/MainApp/Integrations/KeyVault/hooks/useKeyVaultPage.ts
@@ -16,6 +16,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
+import { getFullKey, validateKey } from "@src/api/services/keyValidation";
 import type { SaveKeyRequest as RpcSaveKeyRequest } from "@src/api/tauri/rpc/schemas/validation";
 import type { ModelType, SaveKeyRequest } from "@src/api/types/keys";
 import Message from "@src/components/Message";
@@ -176,16 +177,54 @@ export function useKeyVaultPage() {
   );
 
   const handleEditAccountSave = useCallback(
-    async (accountId: string, name: string, description: string) => {
+    async (
+      accountId: string,
+      name: string,
+      description: string,
+      baseUrl?: string
+    ) => {
       const account = getAccount(accountId);
       if (!account) return;
       try {
-        await saveKey({
+        const request: SaveKeyRequest = {
           id: account.id,
           agent_type: account.modelType,
           name,
           description,
-        });
+        };
+
+        if (
+          account.modelType === "opencode" &&
+          baseUrl &&
+          baseUrl !== account.baseUrl
+        ) {
+          const fullKey = await getFullKey(account.modelType, account.id);
+          if (!fullKey?.api_key) {
+            throw new Error("OpenCode account has no API key.");
+          }
+          const validation = await validateKey(
+            account.modelType,
+            fullKey.api_key,
+            baseUrl
+          );
+          if (!validation.valid) {
+            throw new Error(
+              validation.message || "OpenCode endpoint validation failed."
+            );
+          }
+          request.base_url = baseUrl;
+          request.available_models = validation.models_available;
+          request.enabled_models = validation.models_available.slice(0, 1);
+          request.default_variants = [];
+          request.model_variants = validation.models_available.map((model) => ({
+            model,
+            base_model: model,
+            fast: false,
+            context_window: validation.model_context_lengths?.[model],
+          }));
+        }
+
+        await saveKey(request);
         await refresh();
       } catch (err) {
         Message.error(

--- a/src/scaffold/WizardSystem/variants/KeyVault/components/KeySelectionModal.tsx
+++ b/src/scaffold/WizardSystem/variants/KeyVault/components/KeySelectionModal.tsx
@@ -27,6 +27,12 @@ interface KeySelectionModalProps {
   onClose: () => void;
 }
 
+function getOpenCodeEndpointLabel(baseUrl?: string | null): string | null {
+  if (baseUrl === "https://opencode.ai/zen/v1") return "OpenCode Zen";
+  if (baseUrl === "https://opencode.ai/zen/go/v1") return "OpenCode Go";
+  return null;
+}
+
 const KeySelectionModal: React.FC<KeySelectionModalProps> = ({
   keys,
   selectedIndex,
@@ -115,6 +121,11 @@ const KeySelectionModal: React.FC<KeySelectionModalProps> = ({
                           : t("keyVault.apiKeyLabel")}
                       </span>
                       {/* Validation status badge */}
+                      {getOpenCodeEndpointLabel(cred.base_url) && (
+                        <span className="rounded-full bg-fill-3 px-2 py-0.5 text-[10px] text-text-2">
+                          {getOpenCodeEndpointLabel(cred.base_url)}
+                        </span>
+                      )}
                       {cred.validated === true ? (
                         <span className="flex items-center gap-1 rounded-full bg-success-1 px-2 py-0.5 text-[10px] text-success-6">
                           <CheckCircle size={10} />

--- a/src/scaffold/WizardSystem/variants/KeyVault/components/setup/GenericSetup.tsx
+++ b/src/scaffold/WizardSystem/variants/KeyVault/components/setup/GenericSetup.tsx
@@ -40,6 +40,32 @@ import type { AgentSetupProps } from "./types";
 
 type SetupMethod = "autodetect" | "enter_key" | "extract";
 type BaseUrlMode = "official" | "custom";
+type OpenCodeEndpoint = "zen" | "go";
+
+const OPENCODE_ZEN_BASE_URL = "https://opencode.ai/zen/v1";
+const OPENCODE_GO_BASE_URL = "https://opencode.ai/zen/go/v1";
+
+const OPENCODE_ENDPOINT_OPTIONS: SelectionGridOption<OpenCodeEndpoint>[] = [
+  {
+    key: "zen",
+    label: "OpenCode Zen",
+    badge: "Recommended",
+    description: "Use Zen subscription models such as Claude Sonnet.",
+  },
+  {
+    key: "go",
+    label: "OpenCode Go",
+    description: "Use the OpenCode Go endpoint and model list.",
+  },
+];
+
+function getOpenCodeEndpointFromBaseUrl(baseUrl?: string): OpenCodeEndpoint {
+  return baseUrl === OPENCODE_GO_BASE_URL ? "go" : "zen";
+}
+
+function getOpenCodeBaseUrl(endpoint: OpenCodeEndpoint): string {
+  return endpoint === "go" ? OPENCODE_GO_BASE_URL : OPENCODE_ZEN_BASE_URL;
+}
 
 const GenericSetup: FC<AgentSetupProps> = ({
   data,
@@ -83,6 +109,10 @@ const GenericSetup: FC<AgentSetupProps> = ({
   // Check if API key was auto-detected (non-OAuth)
   const isApiKeyDetected =
     !isOAuthConfigured && data.validated && !!data.raw_key_input;
+  const isOpenCode = data.agent_type === "opencode";
+  const selectedOpenCodeEndpoint = getOpenCodeEndpointFromBaseUrl(
+    data.extracted_base_url
+  );
 
   // Single flat setup method — no nested selection
   const [setupMethod, setSetupMethod] = useState<SetupMethod>("autodetect");
@@ -105,7 +135,19 @@ const GenericSetup: FC<AgentSetupProps> = ({
 
   // Sync official URL to data when in official mode (for validation)
   useEffect(() => {
+    if (isOpenCode && !data.extracted_base_url) {
+      onChange({
+        extracted_base_url: OPENCODE_ZEN_BASE_URL,
+        validated: false,
+        available_models: [],
+        model_context_lengths: {},
+        enabled_models: [],
+      });
+      return;
+    }
+
     if (
+      !isOpenCode &&
       setupMethod === "enter_key" &&
       envConfig?.supportsBaseUrl &&
       baseUrlMode === "official" &&
@@ -116,6 +158,7 @@ const GenericSetup: FC<AgentSetupProps> = ({
     }
   }, [
     setupMethod,
+    isOpenCode,
     envConfig,
     baseUrlMode,
     officialBaseUrl,
@@ -191,6 +234,33 @@ const GenericSetup: FC<AgentSetupProps> = ({
           />
         </SectionRow>
       </SectionContainer>
+
+      {isOpenCode && (
+        <SectionContainer>
+          <SectionRow
+            label="OpenCode endpoint"
+            description="Choose whether this key should load and run OpenCode Zen or Go models."
+            layout="vertical"
+          >
+            <SelectionGrid
+              options={OPENCODE_ENDPOINT_OPTIONS}
+              selected={selectedOpenCodeEndpoint}
+              onSelect={(endpoint) => {
+                onChange({
+                  extracted_base_url: getOpenCodeBaseUrl(endpoint),
+                  validated: false,
+                  available_models: [],
+                  model_context_lengths: {},
+                  enabled_models: [],
+                });
+              }}
+              columns={2}
+              cardVariant="subtle"
+              compactCards
+            />
+          </SectionRow>
+        </SectionContainer>
+      )}
 
       {/* ======================== */}
       {/* Autodetect Section       */}
@@ -298,7 +368,7 @@ const GenericSetup: FC<AgentSetupProps> = ({
             </SectionRow>
           )}
 
-          {envConfig.supportsBaseUrl && (
+          {envConfig.supportsBaseUrl && !isOpenCode && (
             <SectionRow
               label={t("keyVault.baseUrlLabel")}
               description={t("keyVault.baseUrlDesc")}
@@ -348,7 +418,8 @@ const GenericSetup: FC<AgentSetupProps> = ({
             </SectionRow>
           )}
 
-          {envConfig.supportsBaseUrl &&
+          {!isOpenCode &&
+            envConfig.supportsBaseUrl &&
             baseUrlMode === "custom" &&
             !baseUrlWarningDismissed && (
               <InlineAlert

--- a/src/scaffold/WizardSystem/variants/KeyVault/hooks/useApiSetupTokenDetection.ts
+++ b/src/scaffold/WizardSystem/variants/KeyVault/hooks/useApiSetupTokenDetection.ts
@@ -4,6 +4,7 @@ import { type MutableRefObject, useCallback } from "react";
 import {
   autoDetectKey,
   getCodexOAuthModels as fetchCodexOAuthModels,
+  validateKey,
 } from "@src/api/services/keyValidation";
 import type { DetectedKey } from "@src/api/types/keys";
 import { createLogger } from "@src/hooks/logger";
@@ -18,6 +19,43 @@ import type { WizardData } from "../types";
 import { applyKey } from "./keyHelpers";
 
 const log = createLogger("ApiSetup");
+
+const OPENCODE_ZEN_BASE_URL = "https://opencode.ai/zen/v1";
+const OPENCODE_GO_BASE_URL = "https://opencode.ai/zen/go/v1";
+
+function selectedOpenCodeBaseUrl(baseUrl?: string): string {
+  return baseUrl === OPENCODE_GO_BASE_URL
+    ? OPENCODE_GO_BASE_URL
+    : OPENCODE_ZEN_BASE_URL;
+}
+
+function canUseDetectedOpenCodeKeyForEndpoint(
+  key: DetectedKey,
+  baseUrl: string
+): boolean {
+  if (baseUrl === OPENCODE_ZEN_BASE_URL) {
+    return key.base_url === OPENCODE_ZEN_BASE_URL;
+  }
+  return (
+    key.base_url === OPENCODE_GO_BASE_URL ||
+    key.base_url === OPENCODE_ZEN_BASE_URL
+  );
+}
+
+async function validateDetectedOpenCodeKeyForEndpoint(
+  key: DetectedKey,
+  baseUrl: string
+): Promise<DetectedKey> {
+  if (!key.api_key) return key;
+  const validation = await validateKey("opencode", key.api_key, baseUrl);
+  return {
+    ...key,
+    base_url: baseUrl,
+    validated: validation.valid,
+    validation_message: validation.message,
+    available_models: validation.models_available ?? [],
+  };
+}
 
 interface UseApiSetupTokenDetectionOptions {
   data: WizardData;
@@ -60,6 +98,23 @@ export function useApiSetupTokenDetection({
 }: UseApiSetupTokenDetectionOptions) {
   const applySelectedKey = useCallback(
     async (cred: DetectedKey) => {
+      if (data.agent_type === "opencode" && cred.api_key) {
+        const models = cred.available_models ?? [];
+        applyKey(cred, {
+          onChange,
+          setTokenDetected,
+          setCursorSessionToken,
+          setTokenError,
+          setShowKeySelection,
+          isCursor,
+          isOAuthAgent,
+          fallbackModels: models,
+          noValidTokenMsg: t("keyVault.noValidTokenFound"),
+          validationFailedMsg: t("keyVault.quickActions.keyValidationFailed"),
+        });
+        return;
+      }
+
       let fallbackModels = isClaudeCode
         ? getClaudeCodeOAuthModels()
         : isCodex
@@ -107,6 +162,7 @@ export function useApiSetupTokenDetection({
       });
     },
     [
+      data.agent_type,
       agentModelsRef,
       isClaudeCode,
       isCodex,
@@ -135,18 +191,38 @@ export function useApiSetupTokenDetection({
       }
 
       const keys = result.keys || [];
+      const candidateKeys =
+        data.agent_type === "opencode"
+          ? await Promise.all(
+              keys
+                .filter((key) =>
+                  canUseDetectedOpenCodeKeyForEndpoint(
+                    key,
+                    selectedOpenCodeBaseUrl(data.extracted_base_url)
+                  )
+                )
+                .map((key) =>
+                  validateDetectedOpenCodeKeyForEndpoint(
+                    key,
+                    selectedOpenCodeBaseUrl(data.extracted_base_url)
+                  )
+                )
+            )
+          : keys;
 
-      if (keys.length === 0) {
+      if (candidateKeys.length === 0) {
         setTokenError(t("keyVault.couldNotDetectKeys"));
         return;
       }
 
-      if (keys.length > 1) {
-        setDetectedKeys(keys);
-        const validApiKeyIndex = keys.findIndex(
+      if (candidateKeys.length > 1) {
+        setDetectedKeys(candidateKeys);
+        const validApiKeyIndex = candidateKeys.findIndex(
           (cred) => cred.auth_method === "api_key" && cred.validated
         );
-        const firstValidIndex = keys.findIndex((cred) => cred.validated);
+        const firstValidIndex = candidateKeys.findIndex(
+          (cred) => cred.validated
+        );
         setSelectedCredentialIndex(
           validApiKeyIndex >= 0
             ? validApiKeyIndex
@@ -158,7 +234,7 @@ export function useApiSetupTokenDetection({
         return;
       }
 
-      applySelectedKey(keys[0]);
+      applySelectedKey(candidateKeys[0]);
     } catch (err) {
       log.error("[ApiSetup] Failed to auto-detect credentials:", err);
       setTokenError(t("keyVault.failedToDetectKeys"));
@@ -167,6 +243,7 @@ export function useApiSetupTokenDetection({
     }
   }, [
     data.agent_type,
+    data.extracted_base_url,
     applySelectedKey,
     setDetectedKeys,
     setDetectingToken,

--- a/src/scaffold/WizardSystem/variants/KeyVault/hooks/useProviderSelection.ts
+++ b/src/scaffold/WizardSystem/variants/KeyVault/hooks/useProviderSelection.ts
@@ -29,6 +29,8 @@ import {
 } from "../config";
 import type { ApiSetupProps } from "../types";
 
+const OPENCODE_ZEN_BASE_URL = "https://opencode.ai/zen/v1";
+
 // ── Types ─────────────────────────────────────────────────────────────────────
 
 export interface UseProviderSelectionOptions {
@@ -113,6 +115,10 @@ export function useProviderSelection({
         const selectedVariant = selectedProvider?.variants.find(
           (variant) => variant.modelType === agentValue
         );
+        const defaultBaseUrl =
+          typedModelType === CLI_AGENT.OPENCODE
+            ? OPENCODE_ZEN_BASE_URL
+            : undefined;
         onChange({
           agent_type: typedModelType,
           raw_key_input: "",
@@ -125,7 +131,7 @@ export function useProviderSelection({
           enabled_models: [],
           quota_info: undefined,
           extracted_api_key: undefined,
-          extracted_base_url: undefined,
+          extracted_base_url: defaultBaseUrl,
           protocol: selectedVariant?.defaultProtocol,
           setup_method:
             localRuntime ??


### PR DESCRIPTION
## Summary
 
Fixes #260
 
Add explicit OpenCode Zen/Go endpoint support for key setup, auto-detection, and saved account editing.
 
## Root Cause
 
OpenCode was treated as a single provider with a Go-biased default endpoint. The key validation path defaulted to OpenCode Go before Zen, and Settings did not expose a clear way to choose or switch between OpenCode Zen and OpenCode Go.
 
That caused Zen subscribers to see the wrong model catalog, and made endpoint switching require re-adding credentials.
 
## Fix
 
- Default OpenCode validation/provider configuration to Zen instead of Go.
- Add explicit OpenCode Zen / OpenCode Go endpoint selection in the KeyVault setup flow.
- Preserve Go as a selectable endpoint and validate the chosen endpoint directly instead of silently falling back.
- Update OpenCode auto-detection so:
  - `opencode` keys can be checked against Zen or Go.
  - `opencode-go` keys are treated as Go-only.
  - detected candidates show their OpenCode endpoint in the selection modal.
- Allow existing OpenCode accounts to switch Zen/Go from the inline Edit tab without re-entering the API key.
- Refresh endpoint-specific model lists and persist the selected endpoint as the account `base_url`.
- Ensure Rust-native SDE provider resolution uses the saved OpenCode endpoint.
 
## Screenshots
 
### OpenCode endpoint selection in setup
 
<img width="941" height="951" alt="image" src="https://github.com/user-attachments/assets/b9a34715-723d-4430-90c1-2d23b375c477" />
 
### OpenCode endpoint switching in existing account edit
 
<img width="941" height="723" alt="Screenshot 2026-07-06 at 12 56 22 AM" src="https://github.com/user-attachments/assets/1508b360-4e18-49c5-bf71-2ac44aee5c29" />
 
## Verification
 
- `pnpm run lint` — passed
- `pnpm run check:circular` — failed due to pre-existing cycle outside this diff:
  - `api/tauri/session/index.ts > util/session/sessionDispatch.ts`
- `cargo clippy --all-targets -- -D warnings` — failed due to pre-existing warnings outside changed files
- `pnpm exec eslint src/modules/MainApp/Integrations/KeyVault/hooks/useKeyVaultPage.ts src/modules/MainApp/Integrations/KeyVault/Accounts/Table/AccountInlineEditSection.tsx src/modules/MainApp/Integrations/KeyVault/Accounts/Table/AccountInlineExpandedCard.tsx src/modules/MainApp/Integrations/KeyVault/Accounts/Table/MyAccountsTableSection.tsx src/modules/MainApp/Integrations/KeyVault/Table/AccountsTable.tsx src/scaffold/WizardSystem/variants/KeyVault/hooks/useApiSetupTokenDetection.ts src/scaffold/WizardSystem/variants/KeyVault/components/KeySelectionModal.tsx src/scaffold/WizardSystem/variants/KeyVault/components/setup/GenericSetup.tsx` — passed
- `cargo test -p key_vault opencode` — passed
- `rustfmt --edition 2021 --check crates/key-vault/src/commands/validate.rs crates/key-vault/src/auto_detect/opencode.rs crates/key-vault/src/provider_config.rs crates/agent-core/src/core/providers/registry.rs` — passed
- Husky pre-commit hook passed