### PR TITLE
perf(terminal): O(1) scheduler, zero-alloc PTY, WebGL context guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@codemirror/lang-json": "^6.0.2",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/lang-python": "^6.2.1",
+    "@codemirror/legacy-modes": "^6.5.3",
     "@codemirror/lang-rust": "^6.0.2",
     "@codemirror/lang-sql": "^6.10.0",
     "@codemirror/language": "6.12.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@codemirror/language':
         specifier: 6.12.2
         version: 6.12.2
+      '@codemirror/legacy-modes':
+        specifier: ^6.5.3
+        version: 6.5.3
       '@codemirror/lint':
         specifier: ^6.9.2
         version: 6.9.5
@@ -1079,6 +1082,9 @@ packages:
 
   '@codemirror/language@6.12.2':
     resolution: {integrity: sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg==}
+
+  '@codemirror/legacy-modes@6.5.3':
+    resolution: {integrity: sha512-xCsmIzH78MyWkib9jlPaaun57XNkfbMIhagfaZVd0iLTqlpw3jXaIcbZm72MTmmn64eTZpBVNjbyYh+QXnxRsg==}
 
   '@codemirror/lint@6.9.5':
     resolution: {integrity: sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==}
@@ -8771,6 +8777,10 @@ snapshots:
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.8
       style-mod: 4.1.3
+
+  '@codemirror/legacy-modes@6.5.3':
+    dependencies:
+      '@codemirror/language': 6.12.2
 
   '@codemirror/lint@6.9.5':
     dependencies:

--- a/src-tauri/crates/agent-core/src/core/tools/impls/coding/exec/pty.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/coding/exec/pty.rs
@@ -9,6 +9,9 @@ use tauri::AppHandle;
 use tokio::sync::broadcast;
 use tracing::info;
 
+type TapSender = broadcast::Sender<Arc<[u8]>>;
+type TapReceiver = broadcast::Receiver<Arc<[u8]>>;
+
 use crate::tools::traits::ToolError;
 use ::terminal::pty_commands::pty::PtySession;
 
@@ -45,7 +48,7 @@ pub async fn ensure_pty_initialized(
     pty_session_id: &str,
     agent_session_id: &str,
     working_dir: &Path,
-) -> Result<broadcast::Sender<String>, String> {
+) -> Result<TapSender, String> {
     {
         let mut sessions = pty.sessions.lock().await;
         if let Some(session) = sessions.get(pty_session_id) {
@@ -118,7 +121,7 @@ pub async fn execute_via_pty(
         .map_err(|err| ToolError::ExecutionFailed(format!("PTY init failed: {}", err)))?;
 
     if wait_secs.is_none() {
-        let mut output_rx = output_tap.subscribe();
+        let mut output_rx: TapReceiver = output_tap.subscribe();
         let timeout = Duration::from_secs(timeout_secs);
 
         match crate::tool_infra::terminal::exec_in_pty(
@@ -150,7 +153,7 @@ pub async fn execute_via_pty(
     } else {
         let effective_wait = wait_secs.unwrap_or(timeout_secs);
 
-        let mut partial_rx = output_tap.subscribe();
+        let mut partial_rx: TapReceiver = output_tap.subscribe();
 
         let output_tap_clone = output_tap.clone();
         let sessions = pty.sessions.clone();
@@ -160,7 +163,7 @@ pub async fn execute_via_pty(
         let full_timeout = Duration::from_secs(timeout_secs);
 
         let exec_handle = tokio::spawn(async move {
-            let mut rx = output_tap_clone.subscribe();
+            let mut rx: TapReceiver = output_tap_clone.subscribe();
             crate::tool_infra::terminal::exec_in_pty(
                 &cmd,
                 wd.as_ref(),
@@ -218,7 +221,9 @@ pub async fn execute_via_pty(
             match tokio::time::timeout(remaining.min(Duration::from_millis(500)), partial_rx.recv())
                 .await
             {
-                Ok(Ok(chunk)) => partial_output.push_str(&chunk),
+                Ok(Ok(chunk)) => {
+                    partial_output.push_str(&String::from_utf8_lossy(&chunk));
+                }
                 Ok(Err(broadcast::error::RecvError::Lagged(_))) => {
                     partial_output.push_str("[...some output lost...]\n");
                 }

--- a/src-tauri/crates/terminal/src/agent_tool/exec.rs
+++ b/src-tauri/crates/terminal/src/agent_tool/exec.rs
@@ -41,7 +41,7 @@ pub async fn exec_in_pty(
     working_dir: Option<&PathBuf>,
     session_id: &str,
     sessions: Arc<AsyncMutex<HashMap<String, PtySession>>>,
-    output_rx: &mut broadcast::Receiver<String>,
+    output_rx: &mut broadcast::Receiver<Arc<[u8]>>,
     timeout: Duration,
 ) -> Result<(String, i32), String> {
     let marker_id = format!(
@@ -145,7 +145,7 @@ pub async fn exec_in_pty(
             Ok(Ok(chunk)) => {
                 chunks_received += 1;
                 last_output_time = tokio::time::Instant::now();
-                collected_output.push_str(&chunk);
+                collected_output.push_str(&String::from_utf8_lossy(&chunk));
 
                 if let Some(exit_info) = extract_done_marker(&collected_output, &done_marker) {
                     phase = ExecPhase::Completed;

--- a/src-tauri/crates/terminal/src/agent_tool/mod.rs
+++ b/src-tauri/crates/terminal/src/agent_tool/mod.rs
@@ -19,13 +19,13 @@ use std::{
     collections::HashMap,
     io::{BufRead, BufReader, Write},
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicU32, AtomicUsize, Ordering},
         Arc, Mutex,
     },
     time::Duration,
 };
 use tauri::{async_runtime::Mutex as AsyncMutex, AppHandle, Emitter};
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, Notify};
 use tokio::task;
 use tracing::warn;
 
@@ -84,11 +84,16 @@ const NPM_LEAKED_ENV_VARS: &[&str] = &[
 ];
 
 /// When unacknowledged bytes exceed this, pause the reader loop.
-const HIGH_WATERMARK: usize = 100_000;
+/// Raised from 100 KB to 512 KB to prevent the reader from sleeping too
+/// aggressively during agent TUI floods (e.g. htop, cargo build progress bars).
+pub(crate) const HIGH_WATERMARK: usize = 512_000;
 /// Resume reading when unacknowledged bytes drop below this.
-const LOW_WATERMARK: usize = 5_000;
-/// How long the reader sleeps each tick while back-pressured.
-const BACKPRESSURE_SLEEP_MS: u64 = 10;
+/// Raised from 5 KB to 64 KB so recovery is less jerky after a pause.
+/// Exported so ack_pty_data can decide whether to notify the waker.
+pub(crate) const LOW_WATERMARK: usize = 64_000;
+/// Maximum time to wait for an ACK before re-checking session existence.
+/// Replaces the busy-poll BACKPRESSURE_SLEEP_MS loop.
+const BACKPRESSURE_TIMEOUT_MS: u64 = 200;
 /// Grace period before dropping a session in `close_session` to let
 /// the reader flush remaining output.
 const CLOSE_FLUSH_MS: u64 = 250;
@@ -163,7 +168,7 @@ pub struct CreateSessionParams {
     pub name: Option<String>,
     pub app_handle: AppHandle,
     pub sessions: Arc<AsyncMutex<HashMap<String, PtySession>>>,
-    pub output_tap: Option<broadcast::Sender<String>>,
+    pub output_tap: Option<broadcast::Sender<Arc<[u8]>>>,
 }
 
 /// Create a new PTY session and start the shell process.
@@ -308,6 +313,8 @@ pub async fn create_session(params: CreateSessionParams) -> Result<(), String> {
         .map_err(|err| format!("Failed to take PTY writer: {}", err))?;
 
     let unacked_bytes = Arc::new(AtomicUsize::new(0));
+    let ack_notify = Arc::new(Notify::new());
+    let frontend_render_ms = Arc::new(AtomicU32::new(0));
     let last_output_at = Arc::new(Mutex::new(None));
     let redacted_output = Arc::new(Mutex::new(String::new()));
 
@@ -322,6 +329,8 @@ pub async fn create_session(params: CreateSessionParams) -> Result<(), String> {
         name,
         output_tap: output_tap.clone(),
         unacked_bytes: unacked_bytes.clone(),
+        ack_notify: ack_notify.clone(),
+        frontend_render_ms: frontend_render_ms.clone(),
         created_at: Utc::now(),
         last_output_at: last_output_at.clone(),
         redacted_output: redacted_output.clone(),
@@ -350,11 +359,28 @@ pub async fn create_session(params: CreateSessionParams) -> Result<(), String> {
         let mut empty_reads: u32 = 0;
 
         loop {
-            // Backpressure with hysteresis: pause when unacked bytes hit
-            // HIGH_WATERMARK, resume only after they drop below LOW_WATERMARK.
+            // Backpressure state machine with proper async waker.
+            //
+            // Old approach: busy-poll with tokio::time::sleep(10ms) — wastes a
+            // Tokio thread and adds up to 10ms latency after each ACK.
+            //
+            // New approach: suspend on `ack_notify.notified()` so the task is
+            // parked with zero CPU until ack_pty_data() fires notify_one().
+            // A BACKPRESSURE_TIMEOUT_MS timeout lets us check session liveness
+            // without holding a lock continuously.
             if unacked_bytes.load(Ordering::Relaxed) >= HIGH_WATERMARK {
-                while unacked_bytes.load(Ordering::Relaxed) >= LOW_WATERMARK {
-                    tokio::time::sleep(Duration::from_millis(BACKPRESSURE_SLEEP_MS)).await;
+                loop {
+                    if unacked_bytes.load(Ordering::Relaxed) < LOW_WATERMARK {
+                        break;
+                    }
+
+                    // Wait for an ACK (notify_one) or timeout after 200ms.
+                    tokio::select! {
+                        _ = ack_notify.notified() => {}
+                        _ = tokio::time::sleep(Duration::from_millis(BACKPRESSURE_TIMEOUT_MS)) => {}
+                    }
+
+                    // Check session still exists (under lock, but we hold it briefly).
                     let exists = {
                         let map = sessions_clone.lock().await;
                         map.contains_key(&event_session_id)
@@ -392,15 +418,51 @@ pub async fn create_session(params: CreateSessionParams) -> Result<(), String> {
                         // chunk with `from_utf8_lossy` would permanently turn split box-drawing
                         // chars (e.g. `─` = E2 94 80) into U+FFFD. The xterm UI decodes this
                         // byte stream incrementally with `TextDecoder`, matching VS Code/Cursor.
-                        let data_bytes = data.to_vec();
-                        let data_len = data_bytes.len();
+                        //
+                        // Adaptive emit cap: when the frontend reports slow render times
+                        // (render_ms > 8), limit the bytes we consume per read so the
+                        // frontend scheduler's adaptive chunk sizing has room to work.
+                        // At render_ms == 0 (no telemetry yet) we use the full buffer.
+                        let render_ms = frontend_render_ms.load(Ordering::Relaxed);
+                        let emit_cap: usize = if render_ms > 8 {
+                            // Slow renderer — cap at 16 KB per PTY read
+                            16 * 1024
+                        } else if render_ms > 4 {
+                            // Medium load — cap at 64 KB
+                            64 * 1024
+                        } else {
+                            // Fast renderer or no telemetry — no cap (use full buffer)
+                            usize::MAX
+                        };
+
+                        // Avoid a heap allocation when the full buffer fits
+                        // within the emit cap — the common case for a fast renderer.
+                        let emit_slice = if data.len() <= emit_cap {
+                            data
+                        } else {
+                            &data[..emit_cap]
+                        };
+                        let data_len = emit_slice.len();
 
                         // Track unacknowledged output for backpressure
                         unacked_bytes.fetch_add(data_len, Ordering::Relaxed);
                         *last_output_at
                             .lock()
                             .expect("last_output_at mutex poisoned") = Some(Utc::now());
-                        let data_text = String::from_utf8_lossy(&data_bytes);
+                        // Emit Tauri event for frontend display
+                        if let Err(err) = app_clone.emit(
+                            &output_event,
+                            serde_json::json!({ "bytes": emit_slice, "byte_count": data_len }),
+                        ) {
+                            warn!(
+                                "[terminal] Failed to emit output event {}: {}",
+                                output_event, err
+                            );
+                        }
+
+                        // from_utf8_lossy borrows for valid UTF-8 (no alloc) — used only
+                        // for the redacted snapshot and only when needed.
+                        let data_text = String::from_utf8_lossy(emit_slice);
                         append_redacted_bounded(
                             &mut redacted_output
                                 .lock()
@@ -409,22 +471,12 @@ pub async fn create_session(params: CreateSessionParams) -> Result<(), String> {
                             MAX_REDACTED_SNAPSHOT_CHARS,
                         );
 
-                        // Emit Tauri event for frontend display
-                        if let Err(err) = app_clone.emit(
-                            &output_event,
-                            serde_json::json!({ "bytes": &data_bytes, "byte_count": data_len }),
-                        ) {
-                            warn!(
-                                "[terminal] Failed to emit output event {}: {}",
-                                output_event, err
-                            );
-                        }
-
-                        // Also send to output_tap broadcast channel if present.
-                        // A `SendError` here just means no receivers are currently subscribed,
-                        // which is a valid state for a broadcast tap, so we intentionally drop it.
+                        // Send raw bytes through the tap channel. Arc<[u8]> clone is O(1);
+                        // the receiver decodes UTF-8 lazily when it needs text. A SendError
+                        // just means no receivers are currently subscribed, which is valid.
                         if let Some(ref tap) = output_tap {
-                            if tap.send(data_text.to_string()).is_err() {
+                            let chunk: Arc<[u8]> = Arc::from(emit_slice);
+                            if tap.send(chunk).is_err() {
                                 tracing::trace!("[terminal] output_tap has no subscribers");
                             }
                         }
@@ -508,7 +560,7 @@ pub async fn create_agent_session(
     cwd: Option<String>,
     app_handle: AppHandle,
     sessions: Arc<AsyncMutex<HashMap<String, PtySession>>>,
-) -> Result<broadcast::Sender<String>, String> {
+) -> Result<broadcast::Sender<Arc<[u8]>>, String> {
     let (output_tap, _) = broadcast::channel(AGENT_OUTPUT_TAP_CAPACITY);
     create_session(CreateSessionParams {
         session_id,

--- a/src-tauri/crates/terminal/src/pty_commands/pty.rs
+++ b/src-tauri/crates/terminal/src/pty_commands/pty.rs
@@ -45,12 +45,12 @@ use std::{
     collections::HashMap,
     io::{BufReader, Read, Write},
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicUsize, AtomicU32, Ordering},
         Arc, Mutex,
     },
 };
 use tauri::{async_runtime::Mutex as AsyncMutex, AppHandle, State};
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, Notify};
 
 use super::shells::ShellKind;
 
@@ -124,12 +124,19 @@ pub struct PtySession {
     pub cwd: Option<String>,
     /// User-assigned display name (e.g., "Dev Server")
     pub name: Option<String>,
-    /// Optional broadcast channel for tapping decoded PTY output (used by OS agent).
+    /// Optional broadcast channel for tapping raw PTY output bytes (used by OS agent).
     /// When present, the reader task sends output here in addition to byte-stream Tauri events.
-    pub output_tap: Option<broadcast::Sender<String>>,
+    /// Callers decode UTF-8 lazily only when they need text.
+    pub output_tap: Option<broadcast::Sender<Arc<[u8]>>>,
     /// Bytes emitted to the frontend but not yet acknowledged.
     /// Used for backpressure: reader pauses when this exceeds HIGH_WATERMARK.
     pub unacked_bytes: Arc<AtomicUsize>,
+    /// Notifier woken by ack_pty_data so the reader task can resume immediately
+    /// without busy-sleeping. Replaces the fixed BACKPRESSURE_SLEEP_MS polling loop.
+    pub ack_notify: Arc<Notify>,
+    /// Latest render time reported by the frontend ACK (milliseconds, rounded).
+    /// The reader uses this to emit smaller PTY chunks when the renderer is slow.
+    pub frontend_render_ms: Arc<AtomicU32>,
     /// UTC timestamp when the PTY session was created.
     pub created_at: DateTime<Utc>,
     /// UTC timestamp of the latest PTY output chunk observed by the reader task.
@@ -584,13 +591,16 @@ fn get_process_cwd(pid: u32) -> Result<Option<String>, String> {
 
 /// Acknowledge that the frontend has processed `byte_count` bytes of PTY output.
 ///
-/// The reader loop tracks unacknowledged bytes and pauses when the buffer
-/// exceeds HIGH_WATERMARK (100 KB). The frontend calls this after writing
-/// data to xterm.js so the reader can resume.
+/// The `queue_depth` and `render_ms` telemetry fields are optional and come
+/// from the frontend scheduler. When present they allow the reader task to
+/// wake immediately (via `Notify`) instead of sleeping on a fixed poll interval,
+/// and let the reader adjust its emit cadence based on renderer load.
 #[tauri::command]
 pub async fn ack_pty_data(
     session_id: String,
     byte_count: usize,
+    queue_depth: Option<usize>,
+    render_ms: Option<u32>,
     state: State<'_, PtyState>,
 ) -> Result<(), String> {
     let sessions = state.inner().sessions.lock().await;
@@ -598,6 +608,18 @@ pub async fn ack_pty_data(
         let prev = session.unacked_bytes.load(Ordering::Relaxed);
         let new_val = prev.saturating_sub(byte_count);
         session.unacked_bytes.store(new_val, Ordering::Relaxed);
+
+        // Update render telemetry so the reader can adapt emit rate.
+        if let Some(rms) = render_ms {
+            session.frontend_render_ms.store(rms, Ordering::Relaxed);
+        }
+
+        // Only notify if we might have crossed the LOW_WATERMARK — avoids
+        // spurious wakeups when the reader is not currently suspended.
+        let _ = queue_depth; // captured for future use (e.g. adaptive send window)
+        if new_val < crate::agent_tool::LOW_WATERMARK {
+            session.ack_notify.notify_one();
+        }
     }
     Ok(())
 }

--- a/src/components/TerminalInteractive/__tests__/terminalOutputScheduler.test.ts
+++ b/src/components/TerminalInteractive/__tests__/terminalOutputScheduler.test.ts
@@ -1,0 +1,948 @@
+/**
+ * Unit tests for terminalOutputScheduler
+ *
+ * Covers:
+ * - Foreground vs background drain priority
+ * - Hidden backlog cap and drop behavior
+ * - Interactive bypass threshold
+ * - ACK scheduling
+ * - Pane lifecycle (register / unregister)
+ * - ANSI-aware split boundaries (never mid-sequence)
+ * - Adaptive chunk sizing (shrink on slow render, grow on fast)
+ * - MessageChannel-based work loop (drains on turn posts)
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ADAPT_GROW_CONSECUTIVE_FRAMES,
+  ADAPT_GROW_THRESHOLD_MS,
+  ADAPT_SHRINK_THRESHOLD_MS,
+  BACKGROUND_DRAIN_INTERVAL_MS,
+  BACKGROUND_TIME_BUDGET_MS,
+  HIDDEN_BACKLOG_CAP,
+  INITIAL_CHUNK_SIZE,
+  INTERACTIVE_BYPASS_BUDGET,
+  INTERACTIVE_BYPASS_SIZE_ANSI,
+  INTERACTIVE_BYPASS_SIZE_HARD,
+  INTERACTIVE_WINDOW_MS,
+  MAX_CHUNK_SIZE,
+  MIN_CHUNK_SIZE,
+  _testApplyRenderMs,
+  ansiSequenceLength,
+  findAnsiSafeSplit,
+  flushBacklog,
+  getBacklogBytes,
+  getChunkSize,
+  notifyUserInput,
+  registerPane,
+  scheduleWrite,
+  setPaneForeground,
+  unregisterPane,
+} from "../terminalOutputScheduler";
+
+// ============================================
+// MessageChannel polyfill for Node test environment
+// ============================================
+
+class FakeMessageChannel {
+  port1: FakeMessagePort;
+  port2: FakeMessagePort;
+
+  constructor() {
+    // Two ports that route messages to each other
+    this.port1 = new FakeMessagePort();
+    this.port2 = new FakeMessagePort();
+    this.port1._peer = this.port2;
+    this.port2._peer = this.port1;
+  }
+}
+
+class FakeMessagePort {
+  onmessage: ((evt: { data: unknown }) => void) | null = null;
+  _peer!: FakeMessagePort;
+  _started = false;
+
+  start() {
+    this._started = true;
+  }
+
+  close() {
+    this.onmessage = null;
+  }
+
+  postMessage(data: unknown) {
+    // Schedule delivery as a macrotask (setTimeout 0) so fake timers drive it
+    const peer = this._peer;
+    setTimeout(() => {
+      if (peer.onmessage) {
+        peer.onmessage({ data });
+      }
+    }, 0);
+  }
+}
+
+// ============================================
+// Helpers
+// ============================================
+
+function makeWrite() {
+  const calls: string[] = [];
+  const fn = vi.fn((data: string | Uint8Array) => {
+    calls.push(
+      typeof data === "string" ? data : new TextDecoder().decode(data)
+    );
+  });
+  return { fn, calls };
+}
+
+async function flushTimers() {
+  await vi.runAllTimersAsync();
+}
+
+// ============================================
+// Module mocks
+// ============================================
+
+vi.mock("@src/util/platform/tauri/init", () => ({
+  invokeTauri: vi.fn().mockResolvedValue(undefined),
+  isTauriReady: vi.fn().mockReturnValue(true),
+  listenTauri: vi.fn().mockResolvedValue(() => undefined),
+}));
+
+vi.mock("@src/hooks/logger", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+// ============================================
+// Setup / teardown
+// ============================================
+
+const SESSION_A = "test-session-a";
+const SESSION_B = "test-session-b";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+
+  // Install MessageChannel polyfill
+  global.MessageChannel =
+    FakeMessageChannel as unknown as typeof MessageChannel;
+
+  // Clean up any leftover pane registrations
+  unregisterPane(SESSION_A);
+  unregisterPane(SESSION_B);
+});
+
+afterEach(() => {
+  unregisterPane(SESSION_A);
+  unregisterPane(SESSION_B);
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  // @ts-expect-error - cleaning up polyfill
+  delete global.MessageChannel;
+});
+
+// ============================================
+// ANSI sequence length
+// ============================================
+
+describe("ansiSequenceLength", () => {
+  it("returns 0 for non-ESC character", () => {
+    expect(ansiSequenceLength("hello", 0)).toBe(0);
+  });
+
+  it("returns 0 for bare ESC at end of string (incomplete)", () => {
+    expect(ansiSequenceLength("\x1b", 0)).toBe(0);
+  });
+
+  it("measures CSI sequence ESC[33m (5 chars)", () => {
+    const s = "\x1b[33m";
+    expect(ansiSequenceLength(s, 0)).toBe(5);
+  });
+
+  it("measures CSI sequence ESC[1;32m (7 chars)", () => {
+    const s = "\x1b[1;32m";
+    expect(ansiSequenceLength(s, 0)).toBe(7);
+  });
+
+  it("measures reset ESC[0m (4 chars)", () => {
+    expect(ansiSequenceLength("\x1b[0m", 0)).toBe(4);
+  });
+
+  it("returns 0 for incomplete CSI (no final byte)", () => {
+    expect(ansiSequenceLength("\x1b[33", 0)).toBe(0);
+  });
+
+  it("measures OSC sequence terminated by BEL", () => {
+    const s = "\x1b]0;title\x07";
+    expect(ansiSequenceLength(s, 0)).toBe(s.length);
+  });
+
+  it("measures OSC sequence terminated by ST (ESC backslash)", () => {
+    const s = "\x1b]0;title\x1b\\";
+    expect(ansiSequenceLength(s, 0)).toBe(s.length);
+  });
+
+  it("returns 0 for incomplete OSC", () => {
+    expect(ansiSequenceLength("\x1b]0;title", 0)).toBe(0);
+  });
+
+  it("measures 2-char ESC sequence (ESC c = reset)", () => {
+    expect(ansiSequenceLength("\x1bc", 0)).toBe(2);
+  });
+
+  it("measures character-set designate ESC ( B (3 chars)", () => {
+    expect(ansiSequenceLength("\x1b(B", 0)).toBe(3);
+  });
+
+  it("measures from a non-zero offset", () => {
+    const s = "abc\x1b[32mdef";
+    expect(ansiSequenceLength(s, 3)).toBe(5); // ESC[32m
+  });
+});
+
+// ============================================
+// findAnsiSafeSplit
+// ============================================
+
+describe("findAnsiSafeSplit", () => {
+  it("returns targetPos for plain ASCII with no sequences", () => {
+    const s = "hello world";
+    expect(findAnsiSafeSplit(s, 5)).toBe(5);
+  });
+
+  it("never splits inside a CSI sequence", () => {
+    // "abc\x1b[33mdef" — split target = 4 (inside the ESC sequence)
+    const s = "abc\x1b[33mdef";
+    const split = findAnsiSafeSplit(s, 4);
+    // The CSI starts at index 3 and ends at 8. A safe split must be <=3
+    expect(split).toBeLessThanOrEqual(3);
+    // Verify: substring up to split does not start an incomplete sequence
+    const prefix = s.slice(0, split);
+    expect(prefix).not.toContain("\x1b[33");
+  });
+
+  it("allows splitting immediately after a complete sequence", () => {
+    const s = "\x1b[33mhello";
+    // After the 5-char CSI, index 5 is safe
+    const split = findAnsiSafeSplit(s, 5);
+    expect(split).toBe(5);
+  });
+
+  it("returns 0 if sequence at start crosses targetPos", () => {
+    // Large OSC that extends beyond targetPos=3
+    const s = "\x1b]0;long title\x07rest";
+    const split = findAnsiSafeSplit(s, 3);
+    expect(split).toBe(0);
+  });
+
+  it("handles multiple sequences correctly", () => {
+    // "\x1b[1m" = indices 0-4 (5 chars)
+    // "hello"   = indices 5-9
+    // "\x1b[0m" = indices 9-12 (ESC at 9, [ at 10, 0 at 11, m at 12)
+    // "world"   = indices 13-17
+    const s = "\x1b[1mhello\x1b[0mworld";
+    // targetPos=13 is the first char of "world" — the safe split at or before
+    // 13 is 13 (we can include the leading 'w').
+    const split = findAnsiSafeSplit(s, 13);
+    // The split should be 13: boundary falls after the reset sequence ends at 12
+    expect(split).toBe(13);
+    // Verify the prefix ends cleanly
+    const prefix = s.slice(0, split);
+    expect(prefix).toBe("\x1b[1mhello\x1b[0m");
+  });
+
+  it("handles surrogate pair boundary", () => {
+    // Unicode emoji (U+1F600) encodes as surrogate pair \uD83D\uDE00 in JS strings
+    const emoji = "\uD83D\uDE00";
+    const s = "ab" + emoji + "cd";
+    // targetPos=3 would land inside the surrogate pair — safe split is 2
+    const split = findAnsiSafeSplit(s, 3);
+    expect(split).toBe(2);
+  });
+
+  it("returns s.length when targetPos >= s.length", () => {
+    expect(findAnsiSafeSplit("hello", 100)).toBe(5);
+  });
+});
+
+// ============================================
+// Pane lifecycle
+// ============================================
+
+describe("pane lifecycle", () => {
+  it("registers and unregisters a pane", () => {
+    const { fn } = makeWrite();
+    registerPane(SESSION_A, fn);
+    expect(getBacklogBytes(SESSION_A)).toBe(0);
+
+    unregisterPane(SESSION_A);
+    expect(getBacklogBytes(SESSION_A)).toBe(0);
+  });
+
+  it("auto-registers on first scheduleWrite call", async () => {
+    const { fn, calls } = makeWrite();
+    setPaneForeground(SESSION_A, true);
+    scheduleWrite(SESSION_A, "hello", 5, fn);
+
+    await flushTimers();
+    expect(calls.some((c) => c === "hello")).toBe(true);
+  });
+});
+
+// ============================================
+// Foreground drain (MessageChannel work loop)
+// ============================================
+
+describe("foreground drain via MessageChannel", () => {
+  it("drains via MessageChannel turn (not RAF)", async () => {
+    const { fn, calls } = makeWrite();
+    registerPane(SESSION_A, fn);
+    setPaneForeground(SESSION_A, true);
+
+    scheduleWrite(SESSION_A, "data1", 5, fn);
+
+    expect(calls.length).toBe(0); // not written yet
+
+    await flushTimers();
+    expect(calls.some((c) => c === "data1")).toBe(true);
+  });
+
+  it("continues draining across multiple turns until queue is empty", async () => {
+    const { fn, calls } = makeWrite();
+    registerPane(SESSION_A, fn);
+    setPaneForeground(SESSION_A, true);
+
+    // Queue more entries than writes-per-turn
+    const count = 6;
+    for (let i = 0; i < count; i++) {
+      scheduleWrite(SESSION_A, `item${i}`, 5, fn);
+    }
+
+    await flushTimers();
+    expect(calls.length).toBe(count);
+    expect(getBacklogBytes(SESSION_A)).toBe(0);
+  });
+
+  it("switches from background to foreground drain correctly", async () => {
+    const { fn, calls } = makeWrite();
+    registerPane(SESSION_A, fn);
+    setPaneForeground(SESSION_A, false);
+
+    scheduleWrite(SESSION_A, "switch-test", 11, fn);
+
+    // Switch to foreground before background timer fires
+    setPaneForeground(SESSION_A, true);
+
+    await flushTimers();
+    expect(calls.some((c) => c === "switch-test")).toBe(true);
+  });
+});
+
+// ============================================
+// Background drain
+// ============================================
+
+describe("background drain", () => {
+  it("does not drain immediately for a background pane", async () => {
+    const { fn, calls } = makeWrite();
+    registerPane(SESSION_A, fn);
+    setPaneForeground(SESSION_A, false);
+
+    scheduleWrite(SESSION_A, "bg-data", 7, fn);
+
+    vi.advanceTimersByTime(BACKGROUND_DRAIN_INTERVAL_MS - 1);
+    expect(calls.length).toBe(0);
+  });
+
+  it(`drains after ${BACKGROUND_DRAIN_INTERVAL_MS} ms for a background pane`, async () => {
+    const { fn, calls } = makeWrite();
+    registerPane(SESSION_A, fn);
+    setPaneForeground(SESSION_A, false);
+
+    scheduleWrite(SESSION_A, "bg-data", 7, fn);
+
+    vi.advanceTimersByTime(BACKGROUND_DRAIN_INTERVAL_MS);
+    expect(calls.some((c) => c === "bg-data")).toBe(true);
+  });
+
+  it("BACKGROUND_TIME_BUDGET_MS is positive and less than one frame", () => {
+    expect(BACKGROUND_TIME_BUDGET_MS).toBeGreaterThan(0);
+    expect(BACKGROUND_TIME_BUDGET_MS).toBeLessThan(16);
+  });
+});
+
+// ============================================
+// ANSI-aware chunk splitting
+// ============================================
+
+describe("ANSI-aware chunk splitting", () => {
+  it("does not split mid-CSI-sequence when data straddles chunk boundary", async () => {
+    const { fn, calls } = makeWrite();
+    registerPane(SESSION_A, fn);
+    setPaneForeground(SESSION_A, true);
+
+    // Build data where an ANSI sequence straddles the default chunk boundary.
+    // We override chunkSize by using a very small INITIAL_CHUNK_SIZE equivalent
+    // by filling exactly INITIAL_CHUNK_SIZE bytes, then appending an ANSI sequence.
+    // Since we can't change the constant externally, we test the helper directly
+    // and also verify the integration path never corrupts.
+
+    const plain = "x".repeat(50);
+    const seq = "\x1b[1;32mHELLO\x1b[0m";
+    const data = plain + seq;
+    scheduleWrite(SESSION_A, data, data.length, fn);
+
+    await flushTimers();
+
+    // All written data stitched together must equal the original
+    const received = calls.join("");
+    expect(received).toBe(data);
+  });
+
+  it("each written chunk has no dangling incomplete ESC sequences", async () => {
+    const { fn, calls } = makeWrite();
+    registerPane(SESSION_A, fn);
+    setPaneForeground(SESSION_A, true);
+
+    // Create data larger than MAX_CHUNK_SIZE to force multiple splits,
+    // with ANSI sequences scattered throughout
+    const parts: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      parts.push("x".repeat(8192)); // 8 KB plain
+      parts.push(`\x1b[${30 + i}m`); // colour sequence
+      parts.push("text");
+      parts.push("\x1b[0m"); // reset
+    }
+    const bigData = parts.join("");
+    scheduleWrite(SESSION_A, bigData, bigData.length, fn);
+
+    await flushTimers();
+
+    // No chunk should end with a bare ESC followed by [ and then no final byte
+    for (const chunk of calls) {
+      // A chunk ending with ESC indicates a split mid-sequence
+      const endsWithEsc = chunk.endsWith("\x1b");
+      expect(endsWithEsc).toBe(false);
+      // A chunk ending with ESC[ (no final byte) is also bad
+      const endsWithCsiOpen = chunk.endsWith("\x1b[");
+      expect(endsWithCsiOpen).toBe(false);
+    }
+
+    // Total output must be lossless
+    expect(calls.join("")).toBe(bigData);
+  });
+});
+
+// ============================================
+// Adaptive chunk sizing
+// ============================================
+//
+// These tests use _testApplyRenderMs to inject render-time measurements
+// directly into the pane state, bypassing performance.now() timing issues
+// in the test environment. This tests the adaptation logic (which is pure
+// arithmetic) in isolation from the write timing measurement path.
+
+describe("adaptive chunk sizing", () => {
+  it("starts at INITIAL_CHUNK_SIZE", () => {
+    const { fn } = makeWrite();
+    registerPane(SESSION_A, fn);
+    expect(getChunkSize(SESSION_A)).toBe(INITIAL_CHUNK_SIZE);
+  });
+
+  it("halves chunk size when renderMs > ADAPT_SHRINK_THRESHOLD_MS", () => {
+    const { fn } = makeWrite();
+    registerPane(SESSION_A, fn);
+
+    _testApplyRenderMs(SESSION_A, ADAPT_SHRINK_THRESHOLD_MS + 1);
+
+    expect(getChunkSize(SESSION_A)).toBe(INITIAL_CHUNK_SIZE >> 1);
+    expect(getChunkSize(SESSION_A)).toBeGreaterThanOrEqual(MIN_CHUNK_SIZE);
+  });
+
+  it("doubles chunk size after ADAPT_GROW_CONSECUTIVE_FRAMES fast renders", () => {
+    const { fn } = makeWrite();
+    registerPane(SESSION_A, fn);
+
+    for (let i = 0; i < ADAPT_GROW_CONSECUTIVE_FRAMES; i++) {
+      _testApplyRenderMs(SESSION_A, ADAPT_GROW_THRESHOLD_MS - 1);
+    }
+
+    expect(getChunkSize(SESSION_A)).toBe(INITIAL_CHUNK_SIZE << 1);
+    expect(getChunkSize(SESSION_A)).toBeLessThanOrEqual(MAX_CHUNK_SIZE);
+  });
+
+  it("does not grow before ADAPT_GROW_CONSECUTIVE_FRAMES consecutive fast renders", () => {
+    const { fn } = makeWrite();
+    registerPane(SESSION_A, fn);
+
+    for (let i = 0; i < ADAPT_GROW_CONSECUTIVE_FRAMES - 1; i++) {
+      _testApplyRenderMs(SESSION_A, ADAPT_GROW_THRESHOLD_MS - 1);
+    }
+
+    expect(getChunkSize(SESSION_A)).toBe(INITIAL_CHUNK_SIZE);
+  });
+
+  it("resets grow streak when a medium-speed render interrupts", () => {
+    const { fn } = makeWrite();
+    registerPane(SESSION_A, fn);
+
+    // Almost enough to grow
+    for (let i = 0; i < ADAPT_GROW_CONSECUTIVE_FRAMES - 1; i++) {
+      _testApplyRenderMs(SESSION_A, ADAPT_GROW_THRESHOLD_MS - 1);
+    }
+    // Medium render resets streak
+    _testApplyRenderMs(
+      SESSION_A,
+      (ADAPT_GROW_THRESHOLD_MS + ADAPT_SHRINK_THRESHOLD_MS) / 2
+    );
+    // One more fast render — should NOT trigger growth since streak was reset
+    _testApplyRenderMs(SESSION_A, ADAPT_GROW_THRESHOLD_MS - 1);
+
+    expect(getChunkSize(SESSION_A)).toBe(INITIAL_CHUNK_SIZE);
+  });
+
+  it("chunk size never exceeds MAX_CHUNK_SIZE", () => {
+    const { fn } = makeWrite();
+    registerPane(SESSION_A, fn);
+
+    for (let i = 0; i < 100; i++) {
+      _testApplyRenderMs(SESSION_A, ADAPT_GROW_THRESHOLD_MS - 1);
+    }
+
+    expect(getChunkSize(SESSION_A)).toBeLessThanOrEqual(MAX_CHUNK_SIZE);
+  });
+
+  it("chunk size never goes below MIN_CHUNK_SIZE", () => {
+    const { fn } = makeWrite();
+    registerPane(SESSION_A, fn);
+
+    for (let i = 0; i < 30; i++) {
+      _testApplyRenderMs(SESSION_A, ADAPT_SHRINK_THRESHOLD_MS * 10);
+    }
+
+    expect(getChunkSize(SESSION_A)).toBeGreaterThanOrEqual(MIN_CHUNK_SIZE);
+  });
+
+  it("shrink resets after slow render regardless of grow streak", () => {
+    const { fn } = makeWrite();
+    registerPane(SESSION_A, fn);
+
+    // Build up a grow streak
+    for (let i = 0; i < ADAPT_GROW_CONSECUTIVE_FRAMES - 1; i++) {
+      _testApplyRenderMs(SESSION_A, ADAPT_GROW_THRESHOLD_MS - 1);
+    }
+    // Slow render — should shrink AND reset streak
+    _testApplyRenderMs(SESSION_A, ADAPT_SHRINK_THRESHOLD_MS + 1);
+
+    expect(getChunkSize(SESSION_A)).toBe(INITIAL_CHUNK_SIZE >> 1);
+  });
+});
+
+// ============================================
+// Backlog cap and drop behavior
+// ============================================
+
+describe("backlog cap", () => {
+  it(`drops oldest data when backlog exceeds ${HIDDEN_BACKLOG_CAP} bytes`, () => {
+    const { fn } = makeWrite();
+    registerPane(SESSION_A, fn);
+    setPaneForeground(SESSION_A, false);
+
+    const chunkSize = 64 * 1024;
+    const chunksNeeded = Math.ceil(HIDDEN_BACKLOG_CAP / chunkSize) + 5;
+    const earlyData = "EARLY_" + "a".repeat(chunkSize - 6);
+    scheduleWrite(SESSION_A, earlyData, chunkSize, fn);
+
+    for (let i = 0; i < chunksNeeded; i++) {
+      const data = "LATE_" + "b".repeat(chunkSize - 5);
+      scheduleWrite(SESSION_A, data, chunkSize, fn);
+    }
+
+    expect(getBacklogBytes(SESSION_A)).toBeLessThanOrEqual(HIDDEN_BACKLOG_CAP);
+  });
+
+  it("shows a warning marker in the terminal when data is dropped", () => {
+    const { fn, calls } = makeWrite();
+    registerPane(SESSION_A, fn);
+    setPaneForeground(SESSION_A, false);
+
+    const chunkSize = 64 * 1024;
+    const chunksNeeded = Math.ceil(HIDDEN_BACKLOG_CAP / chunkSize) + 5;
+
+    for (let i = 0; i < chunksNeeded; i++) {
+      scheduleWrite(SESSION_A, "x".repeat(chunkSize), chunkSize, fn);
+    }
+
+    const hasWarning = calls.some((c) => c.includes("backlog limit reached"));
+    expect(hasWarning).toBe(true);
+  });
+
+  it("does not drop data when backlog is within cap", () => {
+    const { fn } = makeWrite();
+    registerPane(SESSION_A, fn);
+    setPaneForeground(SESSION_A, false);
+
+    const smallData = "hello";
+    scheduleWrite(SESSION_A, smallData, smallData.length, fn);
+
+    expect(getBacklogBytes(SESSION_A)).toBe(smallData.length);
+  });
+});
+
+// ============================================
+// Interactive bypass
+// ============================================
+
+describe("interactive bypass", () => {
+  it("writes immediately if data is within interactive window and size limit", () => {
+    const { fn, calls } = makeWrite();
+    registerPane(SESSION_A, fn);
+    setPaneForeground(SESSION_A, false);
+
+    notifyUserInput(SESSION_A);
+
+    const smallData = "ls\r";
+    scheduleWrite(SESSION_A, smallData, smallData.length, fn);
+
+    expect(calls.some((c) => c === smallData)).toBe(true);
+  });
+
+  it(`bypasses for data <= ${INTERACTIVE_BYPASS_SIZE_HARD} bytes within interactive window`, () => {
+    const { fn, calls } = makeWrite();
+    registerPane(SESSION_A, fn);
+    setPaneForeground(SESSION_A, false);
+
+    notifyUserInput(SESSION_A);
+
+    const data = "a".repeat(INTERACTIVE_BYPASS_SIZE_HARD);
+    scheduleWrite(SESSION_A, data, data.length, fn);
+
+    expect(calls.some((c) => c === data)).toBe(true);
+  });
+
+  it(`does not bypass if data > ${INTERACTIVE_BYPASS_SIZE_HARD} bytes without ANSI`, () => {
+    const { fn, calls } = makeWrite();
+    registerPane(SESSION_A, fn);
+    setPaneForeground(SESSION_A, false);
+
+    notifyUserInput(SESSION_A);
+
+    const data = "a".repeat(INTERACTIVE_BYPASS_SIZE_HARD + 1);
+    scheduleWrite(SESSION_A, data, data.length, fn);
+
+    expect(calls.length).toBe(0);
+  });
+
+  it(`bypasses ANSI packet up to ${INTERACTIVE_BYPASS_SIZE_ANSI} bytes`, () => {
+    const { fn, calls } = makeWrite();
+    registerPane(SESSION_A, fn);
+    setPaneForeground(SESSION_A, false);
+
+    notifyUserInput(SESSION_A);
+
+    const data = "\x1b[32m" + "a".repeat(INTERACTIVE_BYPASS_SIZE_ANSI - 5);
+    scheduleWrite(SESSION_A, data, data.length, fn);
+
+    expect(calls.some((c) => c === data)).toBe(true);
+  });
+
+  it("does not bypass if outside interactive window", () => {
+    const { fn, calls } = makeWrite();
+    registerPane(SESSION_A, fn);
+    setPaneForeground(SESSION_A, false);
+
+    const inputTime = 1000;
+    vi.spyOn(performance, "now").mockReturnValueOnce(inputTime);
+    notifyUserInput(SESSION_A);
+
+    vi.spyOn(performance, "now").mockReturnValue(
+      inputTime + INTERACTIVE_WINDOW_MS + 10
+    );
+
+    const data = "ls\r";
+    scheduleWrite(SESSION_A, data, data.length, fn);
+
+    expect(calls.length).toBe(0);
+  });
+
+  it(`stops bypassing after consuming ${INTERACTIVE_BYPASS_BUDGET} bytes in window`, () => {
+    const { fn, calls } = makeWrite();
+    registerPane(SESSION_A, fn);
+    setPaneForeground(SESSION_A, false);
+
+    notifyUserInput(SESSION_A);
+
+    const packetSize = INTERACTIVE_BYPASS_SIZE_HARD;
+    const packetsToFill = Math.ceil(INTERACTIVE_BYPASS_BUDGET / packetSize) + 1;
+
+    let bypassedCount = 0;
+    for (let i = 0; i < packetsToFill; i++) {
+      const before = calls.length;
+      scheduleWrite(SESSION_A, "a".repeat(packetSize), packetSize, fn);
+      if (calls.length > before) bypassedCount++;
+    }
+
+    expect(bypassedCount).toBeLessThan(packetsToFill);
+  });
+
+  it("does not bypass if no user input was recorded", () => {
+    const { fn, calls } = makeWrite();
+    registerPane(SESSION_A, fn);
+    setPaneForeground(SESSION_A, false);
+
+    scheduleWrite(SESSION_A, "data", 4, fn);
+
+    expect(calls.length).toBe(0);
+  });
+});
+
+// ============================================
+// flushBacklog
+// ============================================
+
+describe("flushBacklog", () => {
+  it("flushes up to maxBytes immediately", async () => {
+    const { fn, calls } = makeWrite();
+    registerPane(SESSION_A, fn);
+    setPaneForeground(SESSION_A, false);
+
+    const data = "x".repeat(100);
+    scheduleWrite(SESSION_A, data, 100, fn);
+
+    const written = flushBacklog(SESSION_A, 200);
+    expect(written).toBeGreaterThan(0);
+    expect(calls.length).toBeGreaterThan(0);
+  });
+
+  it("respects maxBytes limit", () => {
+    const { fn } = makeWrite();
+    registerPane(SESSION_A, fn);
+    setPaneForeground(SESSION_A, false);
+
+    for (let i = 0; i < 3; i++) {
+      const data = "y".repeat(INITIAL_CHUNK_SIZE);
+      scheduleWrite(SESSION_A, data, INITIAL_CHUNK_SIZE, fn);
+    }
+
+    const written = flushBacklog(SESSION_A, INITIAL_CHUNK_SIZE);
+    expect(written).toBeLessThanOrEqual(INITIAL_CHUNK_SIZE + 100);
+    expect(getBacklogBytes(SESSION_A)).toBeGreaterThan(0);
+  });
+
+  it("returns 0 for unregistered session", () => {
+    expect(flushBacklog("nonexistent-session", 1024)).toBe(0);
+  });
+});
+
+// ============================================
+// O5: findAnsiSafeSplit fromPos parameter
+// ============================================
+
+describe("findAnsiSafeSplit — fromPos (O5)", () => {
+  it("fromPos=0 behaves identically to the no-arg form (backward compat)", () => {
+    const s = "abc\x1b[33mdef";
+    expect(findAnsiSafeSplit(s, 4, 0)).toBe(findAnsiSafeSplit(s, 4));
+  });
+
+  it("fast path: fromPos >= targetPos returns targetPos without scanning", () => {
+    // Plain ASCII — safe to split anywhere; fromPos already past target.
+    const s = "hello world";
+    expect(findAnsiSafeSplit(s, 5, 7)).toBe(5);
+  });
+
+  it("fast path: fromPos === targetPos returns targetPos", () => {
+    const s = "hello world";
+    expect(findAnsiSafeSplit(s, 5, 5)).toBe(5);
+  });
+
+  it("resumes scan correctly after a known-safe boundary", () => {
+    // "\x1b[1m" = ESC [ 1 m = 4 chars (indices 0-3)
+    // "x".repeat(10) = indices 4-13
+    // "\x1b[0m" = ESC [ 0 m = 4 chars (indices 14-17), total length 18
+    const s = "\x1b[1m" + "x".repeat(10) + "\x1b[0m";
+    expect(s.length).toBe(18);
+
+    // First split: target=10, fromPos=0 — scans ESC[1m (ends at 4), then plain
+    // chars 4..9. At i=10 <= targetPos=10, lastSafe=10. Returns 10.
+    const firstSplit = findAnsiSafeSplit(s, 10, 0);
+    expect(firstSplit).toBe(10);
+
+    // Second split: fromPos=10, target=14 — the char at index 14 is ESC which
+    // starts ESC[0m (crosses target). Last safe before it is 14's boundary = 14.
+    // Actually target=14: loop runs while i<14. Chars 10-13 are 'x', after i=14
+    // loop exits. lastSafe=14. Returns 14.
+    const secondSplit = findAnsiSafeSplit(s, 14, firstSplit);
+    expect(secondSplit).toBe(14);
+
+    // Third split: fromPos=14, target=18 (s.length) — ESC[0m is complete and
+    // ends exactly at 18. findAnsiSafeSplit returns s.length when targetPos >= s.length.
+    const thirdSplit = findAnsiSafeSplit(s, s.length, secondSplit);
+    expect(thirdSplit).toBe(s.length);
+  });
+
+  it("correctly handles fromPos exactly at an ANSI sequence boundary", () => {
+    // fromPos lands right at the end of a complete CSI sequence.
+    const seq = "\x1b[32m"; // 5 chars
+    const s = seq + "hello" + "\x1b[0m" + "world";
+    // fromPos=5 is exactly at the end of ESC[32m — a valid safe boundary.
+    const split = findAnsiSafeSplit(s, 10, 5);
+    // Range [5..10] is all plain ASCII; safe split is 10.
+    expect(split).toBe(10);
+  });
+
+  it("does not produce mid-sequence split when fromPos is within plain text", () => {
+    // fromPos in the middle of plain text, sequence comes after.
+    // "aaaaaa\x1b[33mbb" — fromPos=3, target=8 (inside sequence)
+    const s = "aaaaaa\x1b[33mbb";
+    const split = findAnsiSafeSplit(s, 8, 3);
+    // Safe boundary must be ≤ 6 (before the ESC)
+    expect(split).toBeLessThanOrEqual(6);
+    // Verify prefix integrity
+    // eslint-disable-next-line no-control-regex
+    expect(s.slice(0, split)).not.toMatch(/\x1b\[3$/);
+  });
+
+  it("returns fromPos (not 0) when no safe position found in the new window", () => {
+    // The only content between fromPos and targetPos is an incomplete sequence.
+    // "hello\x1b[33" — complete text "hello" (len 5) + incomplete CSI
+    const s = "hello\x1b[33";
+    // fromPos=5, target=8 — the ESC at 5 starts a sequence that doesn't finish
+    const split = findAnsiSafeSplit(s, 8, 5);
+    // No safe position found in [5..8]; lastSafe starts at fromPos=5
+    expect(split).toBe(5);
+  });
+});
+
+// ============================================
+// O5: lastSafeSplitEnd cache in SchedulerEntry
+// ============================================
+
+describe("O5 — lastSafeSplitEnd cache reduces rescanning", () => {
+  it("multi-chunk split of a large entry with OSC sequences: scanner resumes correctly", async () => {
+    // Verify the O5 optimization via findAnsiSafeSplit's direct behaviour:
+    // when fromPos equals the previously returned boundary, subsequent calls
+    // produce the same boundaries as full-scan calls (correctness guarantee).
+    const oscSeq = "\x1b]0;title\x07"; // 12 chars
+    const block = "x".repeat(INITIAL_CHUNK_SIZE - oscSeq.length) + oscSeq;
+    const data = block + block + block;
+
+    // Simulate the split sequence that consumeChunk would perform.
+    // Each step: full-scan result must equal incremental-scan result.
+    const chunkSize = INITIAL_CHUNK_SIZE;
+    let incrementalFromPos = 0;
+    let start = 0;
+
+    while (start < data.length) {
+      const target = Math.min(start + chunkSize, data.length);
+
+      const fullScan = findAnsiSafeSplit(data, target, 0);
+      const incrementalScan = findAnsiSafeSplit(
+        data,
+        target,
+        incrementalFromPos
+      );
+
+      expect(incrementalScan).toBe(fullScan);
+
+      const splitAt = incrementalScan <= start ? data.length : incrementalScan;
+      incrementalFromPos = splitAt;
+      start = splitAt;
+    }
+  });
+
+  it("first split of an entry starts from 0 (fromPos=0 matches no-arg)", () => {
+    // The O5 invariant: fromPos=0 must be identical to a fresh scan (no-arg).
+    const data = "x".repeat(INITIAL_CHUNK_SIZE) + "\x1b[32m" + "y".repeat(100);
+    const target = INITIAL_CHUNK_SIZE + 3; // lands inside the ESC sequence
+
+    expect(findAnsiSafeSplit(data, target, 0)).toBe(
+      findAnsiSafeSplit(data, target)
+    );
+  });
+
+  it("lossless output for large OSC-heavy burst across many chunks", async () => {
+    const { fn, calls } = makeWrite();
+    registerPane(SESSION_A, fn);
+    setPaneForeground(SESSION_A, true);
+
+    // 256 KB worth of OSC + plain text (simulates a real terminal title-update storm)
+    const parts: string[] = [];
+    const chunkCount = 16;
+    const chunkBytes = 16 * 1024;
+    for (let i = 0; i < chunkCount; i++) {
+      parts.push(`\x1b]0;session-${i}\x07`); // ~18 chars OSC
+      parts.push("y".repeat(chunkBytes - 20));
+    }
+    const data = parts.join("");
+    scheduleWrite(SESSION_A, data, data.length, fn);
+    await flushTimers();
+
+    expect(calls.join("")).toBe(data);
+  });
+});
+
+// ============================================
+// Multiple panes / priority isolation
+// ============================================
+
+describe("multiple panes", () => {
+  it("isolates drain state between foreground and background panes", async () => {
+    const { fn: fnA, calls: callsA } = makeWrite();
+    const { fn: fnB, calls: callsB } = makeWrite();
+
+    registerPane(SESSION_A, fnA);
+    registerPane(SESSION_B, fnB);
+
+    setPaneForeground(SESSION_A, true);
+    setPaneForeground(SESSION_B, false);
+
+    scheduleWrite(SESSION_A, "fg-data", 7, fnA);
+    scheduleWrite(SESSION_B, "bg-data", 7, fnB);
+
+    // Flush all — foreground drains via MC turn, background via timer
+    vi.runAllTimers();
+
+    expect(callsA.some((c) => c === "fg-data")).toBe(true);
+    void callsB;
+  });
+
+  it("foreground drains immediately while background waits its timer", () => {
+    const { fn: fnA, calls: callsA } = makeWrite();
+    const { fn: fnB, calls: callsB } = makeWrite();
+
+    registerPane(SESSION_A, fnA);
+    registerPane(SESSION_B, fnB);
+
+    setPaneForeground(SESSION_A, true);
+    setPaneForeground(SESSION_B, false);
+
+    scheduleWrite(SESSION_A, "fg", 2, fnA);
+    scheduleWrite(SESSION_B, "bg", 2, fnB);
+
+    // Advance just enough for MC turn (setTimeout 0) but not the bg timer
+    vi.advanceTimersByTime(0);
+
+    // Foreground should have drained, background should not
+    expect(callsA.some((c) => c === "fg")).toBe(true);
+    expect(callsB.length).toBe(0);
+  });
+
+  it("does not interfere with another session backlog after unregister", () => {
+    const { fn: fnA } = makeWrite();
+    const { fn: fnB } = makeWrite();
+
+    registerPane(SESSION_A, fnA);
+    registerPane(SESSION_B, fnB);
+    setPaneForeground(SESSION_B, false);
+
+    scheduleWrite(SESSION_B, "b-data", 6, fnB);
+
+    unregisterPane(SESSION_A);
+    expect(getBacklogBytes(SESSION_B)).toBe(6);
+  });
+});

--- a/src/components/TerminalInteractive/index.tsx
+++ b/src/components/TerminalInteractive/index.tsx
@@ -53,6 +53,7 @@ import { clearTerminalBufferCache } from "./bufferCache";
 import "./index.scss";
 import { registerTerminalEventHandlers } from "./terminalHandlers";
 import { cleanupPtyListeners } from "./terminalLifecycle";
+import { flushBacklog, setPaneForeground } from "./terminalOutputScheduler";
 import { initPtyConnection } from "./terminalPty";
 import {
   createTerminalInstance,
@@ -66,6 +67,7 @@ import {
 import type { TerminalViewHandle, TerminalViewProps } from "./types";
 import { useTerminalAppearance } from "./useTerminalAppearance";
 import { useTerminalResizeListeners } from "./useTerminalResizeListeners";
+import { releaseWebglSlot } from "./webglContextManager";
 
 // Re-export types for consumers
 export type {
@@ -81,6 +83,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
   function TerminalView(
     {
       sessionKey,
+      isForeground = true,
       onSelectionChange,
       onOutput,
       onUserInput,
@@ -270,6 +273,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
         if (webglAddonRef.current) {
           webglAddonRef.current.dispose();
           webglAddonRef.current = null;
+          releaseWebglSlot();
         }
         terminal.dispose();
         terminalRef.current = null;
@@ -287,9 +291,24 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
         cleanupPtyListeners({
           unlistenOutputRef,
           unlistenExitRef,
+          sessionIdRef,
         });
       };
     }, []);
+
+    // Scheduler foreground/background priority and tab-show backlog flush.
+    // The sessionId is set during initPtyConnection which runs after mount;
+    // we derive it the same way here rather than from the ref to keep this
+    // effect's deps clean.
+    const schedulerSessionId = `terminal-pty-${sessionKey}`;
+    useEffect(() => {
+      setPaneForeground(schedulerSessionId, isForeground);
+
+      if (isForeground) {
+        // Flush up to 256 KB of queued backlog immediately on tab show
+        flushBacklog(schedulerSessionId, 256 * 1024);
+      }
+    }, [isForeground, schedulerSessionId]);
 
     useTerminalResizeListeners({
       containerRef,

--- a/src/components/TerminalInteractive/index.tsx
+++ b/src/components/TerminalInteractive/index.tsx
@@ -193,6 +193,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
           cols,
           rows,
           sessionKey,
+          isForeground,
           terminalRef,
           sessionIdRef,
           unlistenOutputRef,
@@ -214,6 +215,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
       // eslint-disable-next-line react-hooks/exhaustive-deps
       [
         sessionKey,
+        isForeground,
         customShellPath,
         shellType,
         shellOverride,

--- a/src/components/TerminalInteractive/terminalHandlers.ts
+++ b/src/components/TerminalInteractive/terminalHandlers.ts
@@ -4,11 +4,62 @@ import type { MutableRefObject } from "react";
 
 import { createLogger } from "@src/hooks/logger";
 import { getUiScaleFromCssVar } from "@src/lib/dndKit";
+import { isMacOS } from "@src/util/platform/tauri";
 import { invokeTauri, isTauriReady } from "@src/util/platform/tauri/init";
 
 import { setTerminalBuffer } from "./bufferCache";
+import { notifyPtyUserInput } from "./terminalPty";
 import type { TerminalViewProps } from "./types";
 import { createTerminalFileLinks } from "./utils";
+
+// ============================================
+// macOS Cmd+Arrow key forwarding
+// ============================================
+
+/**
+ * ANSI escape sequences for macOS Cmd+Arrow keys.
+ *
+ * xterm.js intentionally skips Meta (Cmd) for arrow keys so the browser can
+ * handle them for text-cursor navigation in its own UI.  Inside a terminal
+ * emulator the Meta modifier should produce the xterm modifier-key sequence
+ * (modifier byte = mod_bits + 1 = Meta(8) + 1 = 9).
+ *
+ * Cmd+Up / Cmd+Down are intentionally excluded: macOS uses them for scroll
+ * actions and they are not standard readline/shell bindings.
+ */
+const MAC_CMD_ARROW_SEQUENCES: Record<string, string> = {
+  ArrowLeft: "\x1b[1;9D",
+  ArrowRight: "\x1b[1;9C",
+};
+
+/**
+ * Registers a customKeyEventHandler on the xterm Terminal so that macOS
+ * Cmd+Arrow combinations are forwarded as ANSI escape sequences to the PTY.
+ *
+ * Returns a cleanup function that removes the handler.
+ */
+function registerMacCmdArrowHandler(terminal: Terminal): () => void {
+  if (!isMacOS()) return () => undefined;
+
+  terminal.attachCustomKeyEventHandler((event: KeyboardEvent) => {
+    if (!event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
+      return true;
+    }
+    const sequence = MAC_CMD_ARROW_SEQUENCES[event.key];
+    if (!sequence) return true;
+
+    if (event.type === "keydown") {
+      terminal.input(sequence, true);
+    }
+    return false;
+  });
+
+  return () => {
+    // xterm does not expose a way to remove a custom key handler, so we
+    // replace it with a pass-through handler that always returns true.
+    terminal.attachCustomKeyEventHandler(() => true);
+  };
+}
 
 const log = createLogger("Terminal");
 
@@ -75,6 +126,8 @@ function registerInputHandler({
     if (isTauriReady() && sessionIdRef.current) {
       onOutput?.();
       onUserInput?.();
+      // Mark user input so the output scheduler can grant interactive bypass
+      notifyPtyUserInput(sessionIdRef.current);
       pendingInput += data;
       if (!inputBatchScheduled) {
         inputBatchScheduled = true;
@@ -93,8 +146,9 @@ function registerFileLinkProvider({
   RegisterTerminalEventHandlersParams,
   "terminal" | "repoPathRef" | "workingDirectoryRef" | "onOpenFileLinkRef"
 >) {
-  if (!onOpenFileLinkRef.current) return null;
-
+  // Always register the provider so it picks up `onOpenFileLink` even when the
+  // prop is set after mount. The ref is updated on every render in index.tsx;
+  // the inner check against `openFileLink` already handles the null case.
   return terminal.registerLinkProvider({
     provideLinks: (bufferLineNumber, callback) => {
       const line = terminal.buffer.active.getLine(bufferLineNumber - 1);
@@ -178,12 +232,16 @@ function registerSelectionHandlers({
     selectionDebounce = setTimeout(() => {
       const selectedText = terminal.getSelection();
       if (selectedText && selectedText.trim().length > 0) {
+        const selectionPos = terminal.getSelectionPosition();
         onSelectionChange?.({
           text: selectedText.trim(),
           position: {
             x: lastMousePosition.x / getUiScaleFromCssVar() + 10,
             y: lastMousePosition.y / getUiScaleFromCssVar() + 10,
           },
+          // xterm buffer rows are 0-based; convert to 1-based for display
+          lineStart: selectionPos ? selectionPos.start.y + 1 : undefined,
+          lineEnd: selectionPos ? selectionPos.end.y + 1 : undefined,
         });
       } else {
         onSelectionChange?.(null);
@@ -224,7 +282,7 @@ export function registerTerminalEventHandlers({
     onOutput,
     onUserInput,
   });
-  const fileLinkProvider: IDisposable | null = registerFileLinkProvider({
+  const fileLinkProvider: IDisposable = registerFileLinkProvider({
     terminal,
     repoPathRef,
     workingDirectoryRef,
@@ -244,6 +302,8 @@ export function registerTerminalEventHandlers({
     onTitleChange?.(title);
   });
 
+  const cleanupCmdArrowHandler = registerMacCmdArrowHandler(terminal);
+
   const handleSnapshotRequest = () => {
     cacheSerializedTerminalBuffer(serializeAddonRef, sessionIdRef, false);
   };
@@ -252,7 +312,8 @@ export function registerTerminalEventHandlers({
   return () => {
     cleanupSelectionHandlers();
     clearResizeTimer();
-    fileLinkProvider?.dispose();
+    cleanupCmdArrowHandler();
+    fileLinkProvider.dispose();
     inputHandler.dispose();
     resizeHandler.dispose();
     selectionHandler.dispose();

--- a/src/components/TerminalInteractive/terminalLifecycle.ts
+++ b/src/components/TerminalInteractive/terminalLifecycle.ts
@@ -1,11 +1,15 @@
 import type { MutableRefObject } from "react";
 
+import { unregisterPane } from "./terminalOutputScheduler";
+
 export function cleanupPtyListeners({
   unlistenOutputRef,
   unlistenExitRef,
+  sessionIdRef,
 }: {
   unlistenOutputRef: MutableRefObject<(() => void) | null>;
   unlistenExitRef: MutableRefObject<(() => void) | null>;
+  sessionIdRef: MutableRefObject<string | null>;
 }) {
   if (unlistenOutputRef.current) {
     unlistenOutputRef.current();
@@ -15,5 +19,10 @@ export function cleanupPtyListeners({
   if (unlistenExitRef.current) {
     unlistenExitRef.current();
     unlistenExitRef.current = null;
+  }
+
+  if (sessionIdRef.current) {
+    unregisterPane(sessionIdRef.current);
+    sessionIdRef.current = null;
   }
 }

--- a/src/components/TerminalInteractive/terminalOutputScheduler.ts
+++ b/src/components/TerminalInteractive/terminalOutputScheduler.ts
@@ -1,0 +1,827 @@
+/**
+ * Terminal Output Scheduler
+ *
+ * Deep performance architecture:
+ *
+ * 1. MessageChannel work loop (not RAF/setTimeout) — yields to the browser's
+ *    task scheduler between chunks with ~0ms latency instead of RAF's 4ms
+ *    clamping floor. User input events preempt the work loop naturally because
+ *    the channel posts a new macrotask, which sits in the task queue behind any
+ *    pending input tasks.
+ *
+ * 2. ANSI-aware chunking — the chunk splitter parses escape sequences so chunk
+ *    boundaries always fall between complete sequences. A mid-sequence split
+ *    corrupts colour/cursor state in xterm (e.g. splitting ESC[33m leaves a
+ *    partial CSI open).
+ *
+ * 3. Adaptive chunk sizing — measures wall-clock render time for each
+ *    terminal.write() call and adjusts the per-chunk byte cap:
+ *    - renderMs > 8ms  → halve chunk size (down to MIN_CHUNK_SIZE)
+ *    - renderMs < 2ms  for 5 consecutive frames → double it (up to MAX_CHUNK_SIZE)
+ *    This keeps frame time near 6–8ms regardless of terminal width/content.
+ *
+ * 4. Telemetry ACK — ack_pty_data carries { sessionId, byteCount, queueDepth,
+ *    renderMs } so Rust can adaptively throttle at the PTY-reader level instead
+ *    of just using a fixed watermark.
+ *
+ * 5. Background pane isolation — background panes use a separate MessageChannel
+ *    with a 50ms coalescing timer, so their work loop never steals time slices
+ *    from the foreground pane.
+ */
+import { createLogger } from "@src/hooks/logger";
+import { invokeTauri, isTauriReady } from "@src/util/platform/tauri/init";
+
+const log = createLogger("TerminalOutputScheduler");
+
+// ============================================
+// Constants
+// ============================================
+
+/** Initial chunk size — scheduler adapts from here. */
+const INITIAL_CHUNK_SIZE = 16 * 1024; // 16 KB
+
+/** Minimum chunk size under heavy render load. */
+const MIN_CHUNK_SIZE = 2 * 1024; // 2 KB
+
+/** Maximum chunk size when renders are very fast. */
+const MAX_CHUNK_SIZE = 64 * 1024; // 64 KB
+
+/** Max foreground writes per work-loop turn. */
+const FOREGROUND_WRITES_PER_TURN = 2;
+
+/** Background drain interval in ms (coalescing timer). */
+const BACKGROUND_DRAIN_INTERVAL_MS = 50;
+
+/** Time budget per background drain tick (ms). */
+const BACKGROUND_TIME_BUDGET_MS = 8;
+
+/** Backlog cap for hidden/background panes. Drop oldest data beyond this. */
+const HIDDEN_BACKLOG_CAP = 2 * 1024 * 1024; // 2 MB
+
+/** Interactive bypass: write immediately if data arrives within this many ms of last user input. */
+const INTERACTIVE_WINDOW_MS = 100;
+
+/** Interactive bypass: max size for immediate write (hard limit). */
+const INTERACTIVE_BYPASS_SIZE_HARD = 1024; // 1 KB
+
+/** Interactive bypass: extended size limit when packet contains ESC/ANSI sequences. */
+const INTERACTIVE_BYPASS_SIZE_ANSI = 16 * 1024; // 16 KB
+
+/** Interactive bypass budget: max bytes flushed via fast-path per window. */
+const INTERACTIVE_BYPASS_BUDGET = 32 * 1024; // 32 KB per 100 ms window
+
+/**
+ * Adaptive sizing thresholds.
+ * Halve chunk size when a single write exceeds this.
+ */
+const ADAPT_SHRINK_THRESHOLD_MS = 8;
+/** Grow chunk size after this many consecutive fast frames. */
+const ADAPT_GROW_THRESHOLD_MS = 2;
+const ADAPT_GROW_CONSECUTIVE_FRAMES = 5;
+
+// ============================================
+// Types
+// ============================================
+
+type WriteCallback = (data: string | Uint8Array) => void;
+
+interface SchedulerEntry {
+  data: string;
+  /** Cursor into `data` — bytes before this offset have already been consumed. */
+  start: number;
+  byteLength: number;
+  /**
+   * The last position returned by `findAnsiSafeSplit` for this entry.
+   *
+   * O5 optimisation: since `findAnsiSafeSplit` always returns a position where
+   * no ANSI sequence is open, the next call can resume scanning from here
+   * instead of re-scanning from byte 0, reducing cumulative split work from
+   * O(n²) to O(n) across all chunks of a large entry.
+   *
+   * Initialised to `entry.start` when the entry is enqueued (no prior split).
+   */
+  lastSafeSplitEnd: number;
+}
+
+interface PaneScheduler {
+  sessionId: string;
+  write: WriteCallback;
+  queue: SchedulerEntry[];
+  /**
+   * Index of the first unconsumed entry in `queue`.
+   *
+   * Using a head pointer instead of Array.shift() avoids O(n) copies on
+   * every consumed chunk. The array is compacted once it has grown past a
+   * threshold relative to the live window.
+   */
+  queueHead: number;
+  queueByteLength: number;
+  foreground: boolean;
+  /** MessageChannel port used for foreground work-loop posts. */
+  mcPort: MessagePort | null;
+  /** Whether a work-loop turn is already posted on the channel. */
+  mcPending: boolean;
+  /** Timer handle for background drain coalescing. */
+  timerId: ReturnType<typeof setTimeout> | null;
+  /** Bytes consumed but not yet ACKed. */
+  pendingAckBytes: number;
+  /** Whether an ACK flush is already scheduled. */
+  ackScheduled: boolean;
+  /** Timestamp of last user input to this pane (for interactive bypass). */
+  lastInputAt: number;
+  /** Bytes flushed via interactive bypass within current window. */
+  bypassBudgetUsed: number;
+  /** Start time of the current 100 ms bypass window. */
+  bypassWindowStart: number;
+  /** Current adaptive chunk size for this pane. */
+  chunkSize: number;
+  /** Consecutive frames where renderMs was below ADAPT_GROW_THRESHOLD_MS. */
+  fastFrameStreak: number;
+  /** Last measured render time in ms (for telemetry). */
+  lastRenderMs: number;
+}
+
+// ============================================
+// ANSI sequence state machine
+// ============================================
+
+/**
+ * Returns the length of a complete ANSI/VT escape sequence starting at
+ * position `pos` in `s`, or 0 if the character at `pos` is not ESC.
+ *
+ * Handles:
+ *   ESC [ ... final    (CSI — parameter bytes 0x30-0x3F, intermediate 0x20-0x2F, final 0x40-0x7E)
+ *   ESC ] ... BEL/ST   (OSC — terminated by BEL \x07 or ESC \)
+ *   ESC ( / ) / * / +  (Designate character set — 2-char)
+ *   ESC # digit        (DEC private — 3-char)
+ *   ESC P ... ST       (DCS — terminated by ST)
+ *   ESC _              (APC)
+ *   ESC ^              (PM)
+ *   ESC X              (SOS)
+ *   ESC c / ESC =, etc.(2-char sequences)
+ *
+ * Returns 0 if `s[pos] !== ESC` or if the sequence is incomplete (not yet
+ * terminated) — in which case the caller must not split at this position.
+ */
+export function ansiSequenceLength(s: string, pos: number): number {
+  if (pos >= s.length || s.charCodeAt(pos) !== 0x1b) return 0;
+
+  const next = pos + 1 < s.length ? s.charCodeAt(pos + 1) : -1;
+  if (next === -1) return 0; // incomplete — ESC at end of string
+
+  // CSI: ESC [
+  if (next === 0x5b) {
+    // [
+    let i = pos + 2;
+    while (i < s.length) {
+      const c = s.charCodeAt(i);
+      if (c >= 0x40 && c <= 0x7e) return i - pos + 1; // final byte
+      i++;
+    }
+    return 0; // incomplete
+  }
+
+  // OSC: ESC ]
+  if (next === 0x5d) {
+    // ]
+    let i = pos + 2;
+    while (i < s.length) {
+      const c = s.charCodeAt(i);
+      if (c === 0x07) return i - pos + 1; // BEL terminator
+      if (c === 0x1b && i + 1 < s.length && s.charCodeAt(i + 1) === 0x5c) {
+        // ST = ESC \
+        return i - pos + 2;
+      }
+      i++;
+    }
+    return 0; // incomplete
+  }
+
+  // DCS: ESC P / APC: ESC _ / PM: ESC ^ / SOS: ESC X  — all ST-terminated
+  if (
+    next === 0x50 || // P
+    next === 0x5f || // _
+    next === 0x5e || // ^
+    next === 0x58 // X
+  ) {
+    let i = pos + 2;
+    while (i < s.length) {
+      const c = s.charCodeAt(i);
+      if (c === 0x1b && i + 1 < s.length && s.charCodeAt(i + 1) === 0x5c) {
+        return i - pos + 2;
+      }
+      i++;
+    }
+    return 0; // incomplete
+  }
+
+  // Designate character set: ESC ( / ) / * / + — followed by one char
+  if (
+    next === 0x28 || // (
+    next === 0x29 || // )
+    next === 0x2a || // *
+    next === 0x2b // +
+  ) {
+    return pos + 2 < s.length ? 3 : 0;
+  }
+
+  // DEC private: ESC # digit
+  if (next === 0x23) {
+    // #
+    return pos + 2 < s.length ? 3 : 0;
+  }
+
+  // Everything else: 2-char sequence (ESC c, ESC =, ESC >, ESC 7/8, …)
+  return 2;
+}
+
+/**
+ * Find a safe chunk boundary in `s` at or before `targetPos` such that no
+ * ANSI escape sequence is split.
+ *
+ * The algorithm scans forward from `fromPos` (default 0), tracking sequence
+ * extents. A candidate split point is "safe" when it falls between sequences
+ * (or between plain-text characters) and does not land inside a UTF-16
+ * surrogate pair.
+ *
+ * `fromPos` optimisation (O5): if the caller already knows there are no open
+ * ANSI sequences before `fromPos` (because a previous call returned that
+ * position), scanning can resume from there. This reduces cumulative work from
+ * O(n²) to O(n) when a large entry is split into many chunks.
+ *
+ * Precondition: `fromPos` must be a position where no ANSI sequence is open
+ * (i.e., a previously returned safe split boundary). Passing an arbitrary
+ * offset is unsafe and may produce incorrect splits.
+ *
+ * Returns the byte offset of the last safe split ≤ targetPos, or `fromPos`
+ * if none found in the scanned window.
+ */
+export function findAnsiSafeSplit(
+  s: string,
+  targetPos: number,
+  fromPos: number = 0
+): number {
+  if (targetPos >= s.length) return s.length;
+  if (targetPos <= 0) return 0;
+
+  // Fast path: fromPos already covers the entire range we need to check.
+  // This happens when the cached boundary is at or beyond targetPos, meaning
+  // the range [0, targetPos] is already known to contain no open sequences.
+  if (fromPos >= targetPos) return targetPos;
+
+  // Clamp fromPos to a valid start.
+  const startPos = Math.max(0, fromPos);
+  let i = startPos;
+  let lastSafe = startPos;
+
+  while (i < targetPos) {
+    const c = s.charCodeAt(i);
+
+    if (c === 0x1b) {
+      // ESC — measure sequence
+      const seqLen = ansiSequenceLength(s, i);
+      if (seqLen === 0) {
+        // Incomplete sequence — cannot split anywhere past here safely.
+        // Return the last safe position before this ESC.
+        return lastSafe;
+      }
+      const seqEnd = i + seqLen;
+      if (seqEnd <= targetPos) {
+        i = seqEnd;
+        lastSafe = i; // safe to split immediately after a complete sequence
+      } else {
+        // Sequence crosses targetPos — back up to lastSafe
+        return lastSafe;
+      }
+    } else {
+      // Plain character — check for UTF-16 surrogate pairs
+      if ((c & 0xfc00) === 0xd800 && i + 1 < s.length) {
+        // High surrogate — must include the following low surrogate
+        i += 2;
+      } else {
+        i += 1;
+      }
+      if (i <= targetPos) {
+        lastSafe = i;
+      }
+    }
+  }
+
+  return lastSafe;
+}
+
+// ============================================
+// Scheduler registry (module-level singleton map)
+// ============================================
+
+const paneMap = new Map<string, PaneScheduler>();
+
+// ============================================
+// MessageChannel work loop
+// ============================================
+
+/**
+ * Create a MessageChannel-backed scheduler port for a pane.
+ *
+ * Why MessageChannel and not requestAnimationFrame?
+ *
+ * RAF has a 4ms clamping floor in background tabs (Chromium) and fires at most
+ * once per vsync (~16ms). Between two RAF callbacks a flood of PTY output can
+ * accumulate 30–60 KB that xterm then renders in one synchronous burst, causing
+ * a visible hitch.
+ *
+ * MessageChannel posts a macrotask that the browser schedules cooperatively at
+ * ~0ms — it will be preempted by pending user-input events (which sit in the
+ * same task queue) so interactive keystrokes are never delayed by a drain turn.
+ * We still self-throttle to FOREGROUND_WRITES_PER_TURN writes per turn to
+ * avoid starving other JS work.
+ */
+function createMessageChannelPort(pane: PaneScheduler): MessagePort {
+  const channel = new MessageChannel();
+  channel.port1.onmessage = () => {
+    pane.mcPending = false;
+    drainForegroundTurn(pane);
+  };
+  channel.port1.start();
+  return channel.port2; // caller posts to port2 to trigger port1
+}
+
+function postWorkTurn(pane: PaneScheduler) {
+  if (pane.mcPending) return;
+  if (!pane.mcPort) {
+    pane.mcPort = createMessageChannelPort(pane);
+  }
+  pane.mcPending = true;
+  pane.mcPort.postMessage(null);
+}
+
+// ============================================
+// Adaptive chunk sizing
+// ============================================
+
+function adaptChunkSize(pane: PaneScheduler, renderMs: number) {
+  pane.lastRenderMs = renderMs;
+
+  if (renderMs > ADAPT_SHRINK_THRESHOLD_MS) {
+    // Slow render — halve chunk size immediately
+    pane.chunkSize = Math.max(MIN_CHUNK_SIZE, pane.chunkSize >> 1);
+    pane.fastFrameStreak = 0;
+  } else if (renderMs < ADAPT_GROW_THRESHOLD_MS) {
+    pane.fastFrameStreak++;
+    if (pane.fastFrameStreak >= ADAPT_GROW_CONSECUTIVE_FRAMES) {
+      pane.chunkSize = Math.min(MAX_CHUNK_SIZE, pane.chunkSize << 1);
+      pane.fastFrameStreak = 0;
+    }
+  } else {
+    // Medium range — reset streak so we don't grow prematurely
+    pane.fastFrameStreak = 0;
+  }
+}
+
+// ============================================
+// Internal helpers
+// ============================================
+
+function getOrCreate(sessionId: string, write: WriteCallback): PaneScheduler {
+  let pane = paneMap.get(sessionId);
+  if (!pane) {
+    pane = {
+      sessionId,
+      write,
+      queue: [],
+      queueHead: 0,
+      queueByteLength: 0,
+      foreground: false,
+      mcPort: null,
+      mcPending: false,
+      timerId: null,
+      pendingAckBytes: 0,
+      ackScheduled: false,
+      lastInputAt: 0,
+      bypassBudgetUsed: 0,
+      bypassWindowStart: 0,
+      chunkSize: INITIAL_CHUNK_SIZE,
+      fastFrameStreak: 0,
+      lastRenderMs: 0,
+    };
+    paneMap.set(sessionId, pane);
+  } else {
+    pane.write = write;
+  }
+  return pane;
+}
+
+function scheduleAck(pane: PaneScheduler) {
+  if (pane.ackScheduled || pane.pendingAckBytes === 0) return;
+  pane.ackScheduled = true;
+  // Schedule ACK as a microtask so it goes out after the current write batch
+  // but before the next macrotask (keepin latency low).
+  queueMicrotask(() => {
+    flushAck(pane);
+  });
+}
+
+function flushAck(pane: PaneScheduler) {
+  if (pane.pendingAckBytes > 0 && isTauriReady()) {
+    invokeTauri("ack_pty_data", {
+      sessionId: pane.sessionId,
+      byteCount: pane.pendingAckBytes,
+      queueDepth: pane.queueByteLength,
+      renderMs: Math.round(pane.lastRenderMs),
+    }).catch(() => undefined);
+    pane.pendingAckBytes = 0;
+  }
+  pane.ackScheduled = false;
+}
+
+/**
+ * Compact the queue array once the dead head segment grows too large.
+ *
+ * We only splice when the wasted prefix is ≥ 16 entries AND represents at
+ * least half the allocated slots, so the amortised cost is O(1) per push.
+ */
+const QUEUE_COMPACT_MIN_DEAD = 16;
+
+function maybeCompactQueue(pane: PaneScheduler) {
+  const dead = pane.queueHead;
+  if (dead >= QUEUE_COMPACT_MIN_DEAD && dead * 2 >= pane.queue.length) {
+    pane.queue.splice(0, dead);
+    pane.queueHead = 0;
+  }
+}
+
+/**
+ * Consume up to `chunkSize` bytes from the front of the queue,
+ * respecting ANSI sequence boundaries.
+ *
+ * Returns null if queue is empty.
+ *
+ * Perf notes:
+ * - Uses `queueHead` pointer instead of `Array.shift()` to avoid O(n)
+ *   element-copy on every consumed entry.
+ * - Tracks a `start` cursor inside each entry so partial-chunk draining
+ *   never calls `String.slice()` to mutate the stored data; the slice is
+ *   only taken once when emitting to xterm.
+ */
+function consumeChunk(pane: PaneScheduler): string | null {
+  if (pane.queueHead >= pane.queue.length) return null;
+
+  const entry = pane.queue[pane.queueHead];
+  const chunkSize = pane.chunkSize;
+  const remaining = entry.data.length - entry.start;
+
+  if (remaining <= chunkSize) {
+    // Whole entry fits — emit the remaining slice and advance head.
+    const chunk =
+      entry.start === 0 ? entry.data : entry.data.slice(entry.start);
+    pane.queueHead++;
+    maybeCompactQueue(pane);
+    pane.queueByteLength -= entry.byteLength;
+    pane.pendingAckBytes += entry.byteLength;
+    return chunk;
+  }
+
+  // Find a safe split point, resuming from the last known-safe boundary so we
+  // don't re-scan bytes that were already processed in earlier splits (O5).
+  //
+  // `lastSafeSplitEnd` tracks the last position returned by findAnsiSafeSplit
+  // for this entry. We pass it as `fromPos` to skip re-scanning the prefix.
+  // The invariant holds because findAnsiSafeSplit only returns positions where
+  // no ANSI sequence is open.
+  //
+  // When entry.start has advanced (O1 head-pointer), lastSafeSplitEnd is always
+  // ≥ entry.start (we keep it updated after each split), so the fromPos is
+  // still valid for the current window.
+  const targetSplitPos = entry.start + chunkSize;
+  const fromPos = entry.lastSafeSplitEnd;
+  const splitAt = findAnsiSafeSplit(entry.data, targetSplitPos, fromPos);
+
+  if (splitAt <= entry.start) {
+    // Edge case: the sequence starting at the current cursor is longer than
+    // chunkSize — emit the entire remaining entry to avoid a mid-sequence
+    // split. Temporarily exceeds chunk budget but is the only correct option.
+    const chunk =
+      entry.start === 0 ? entry.data : entry.data.slice(entry.start);
+    pane.queueHead++;
+    maybeCompactQueue(pane);
+    pane.queueByteLength -= entry.byteLength;
+    pane.pendingAckBytes += entry.byteLength;
+    return chunk;
+  }
+
+  const chunk = entry.data.slice(entry.start, splitAt);
+  const chunkChars = splitAt - entry.start;
+
+  // Proportional byte accounting (approximate — char count ≠ byte count for
+  // non-ASCII, but the scheduler treats byte_count as a flow-control hint).
+  const totalChars = entry.data.length - entry.start;
+  const chunkBytes =
+    totalChars > 0
+      ? Math.round((chunkChars / totalChars) * entry.byteLength)
+      : entry.byteLength;
+
+  // Advance the cursor — no string mutation, no re-allocation.
+  // Also update lastSafeSplitEnd so the next split resumes from here (O5).
+  entry.start = splitAt;
+  entry.lastSafeSplitEnd = splitAt;
+  entry.byteLength -= chunkBytes;
+  pane.queueByteLength -= chunkBytes;
+  pane.pendingAckBytes += chunkBytes;
+  return chunk;
+}
+
+/**
+ * Write a chunk and measure wall-clock render time to feed adaptive sizing.
+ */
+function writeAndMeasure(pane: PaneScheduler, chunk: string) {
+  const t0 = performance.now();
+  pane.write(chunk);
+  const renderMs = performance.now() - t0;
+  adaptChunkSize(pane, renderMs);
+}
+
+function queueHasItems(pane: PaneScheduler): boolean {
+  return pane.queueHead < pane.queue.length;
+}
+
+function drainForegroundTurn(pane: PaneScheduler) {
+  if (!pane.foreground || !queueHasItems(pane)) return;
+
+  for (let i = 0; i < FOREGROUND_WRITES_PER_TURN && queueHasItems(pane); i++) {
+    const chunk = consumeChunk(pane);
+    if (chunk !== null) {
+      writeAndMeasure(pane, chunk);
+    }
+  }
+  scheduleAck(pane);
+
+  if (queueHasItems(pane)) {
+    postWorkTurn(pane); // schedule next turn
+  }
+}
+
+function drainBackground(pane: PaneScheduler) {
+  pane.timerId = null;
+  if (!queueHasItems(pane)) return;
+
+  const deadline = performance.now() + BACKGROUND_TIME_BUDGET_MS;
+  while (queueHasItems(pane) && performance.now() < deadline) {
+    const chunk = consumeChunk(pane);
+    if (chunk !== null) {
+      pane.write(chunk); // no measurement for background panes — saves CPU
+    }
+  }
+  scheduleAck(pane);
+
+  if (queueHasItems(pane)) {
+    pane.timerId = setTimeout(
+      () => drainBackground(pane),
+      BACKGROUND_DRAIN_INTERVAL_MS
+    );
+  }
+}
+
+function scheduleDrain(pane: PaneScheduler) {
+  if (pane.foreground) {
+    postWorkTurn(pane);
+  } else {
+    if (pane.timerId === null && queueHasItems(pane)) {
+      pane.timerId = setTimeout(
+        () => drainBackground(pane),
+        BACKGROUND_DRAIN_INTERVAL_MS
+      );
+    }
+  }
+}
+
+function enforceBacklogCap(pane: PaneScheduler) {
+  if (pane.queueByteLength <= HIDDEN_BACKLOG_CAP) return;
+
+  let dropped = 0;
+  while (
+    pane.queueHead < pane.queue.length &&
+    pane.queueByteLength > HIDDEN_BACKLOG_CAP
+  ) {
+    const entry = pane.queue[pane.queueHead++];
+    pane.queueByteLength -= entry.byteLength;
+    dropped += entry.byteLength;
+  }
+  maybeCompactQueue(pane);
+
+  log.warn(
+    `[OutputScheduler] Backlog cap exceeded for session ${pane.sessionId}: dropped ${dropped} bytes`
+  );
+
+  // Emit a visible warning marker into the terminal
+  pane.write(
+    "\r\n\x1b[33m[⚠ terminal output dropped: backlog limit reached]\x1b[0m\r\n"
+  );
+}
+
+function checkInteractiveBypass(
+  pane: PaneScheduler,
+  data: string,
+  byteLength: number
+): boolean {
+  const now = performance.now();
+
+  // Reset bypass window if needed
+  if (now - pane.bypassWindowStart >= INTERACTIVE_WINDOW_MS) {
+    pane.bypassWindowStart = now;
+    pane.bypassBudgetUsed = 0;
+  }
+
+  if (now - pane.lastInputAt >= INTERACTIVE_WINDOW_MS) return false;
+  if (pane.bypassBudgetUsed >= INTERACTIVE_BYPASS_BUDGET) return false;
+
+  const containsAnsi = data.includes("\x1b");
+  const sizeLimit = containsAnsi
+    ? INTERACTIVE_BYPASS_SIZE_ANSI
+    : INTERACTIVE_BYPASS_SIZE_HARD;
+
+  if (byteLength > sizeLimit) return false;
+
+  pane.bypassBudgetUsed += byteLength;
+  pane.pendingAckBytes += byteLength;
+  pane.write(data);
+  scheduleAck(pane);
+  return true;
+}
+
+// ============================================
+// Public API
+// ============================================
+
+/**
+ * Register a pane with the scheduler.
+ * Must be called once per terminal session before `scheduleWrite`.
+ */
+export function registerPane(sessionId: string, write: WriteCallback): void {
+  getOrCreate(sessionId, write);
+}
+
+/**
+ * Remove a pane from the scheduler and cancel any pending drain.
+ */
+export function unregisterPane(sessionId: string): void {
+  const pane = paneMap.get(sessionId);
+  if (!pane) return;
+
+  if (pane.mcPort) {
+    pane.mcPort.close();
+    pane.mcPort = null;
+  }
+  if (pane.timerId !== null) {
+    clearTimeout(pane.timerId);
+  }
+  paneMap.delete(sessionId);
+}
+
+/**
+ * Set whether this pane is in the foreground (active/visible) or background.
+ * Foreground panes drain on MessageChannel work loop; background on 50ms timer.
+ */
+export function setPaneForeground(
+  sessionId: string,
+  foreground: boolean
+): void {
+  const pane = paneMap.get(sessionId);
+  if (!pane || pane.foreground === foreground) return;
+
+  pane.foreground = foreground;
+
+  if (foreground) {
+    // Cancel background timer and switch to work-loop drain
+    if (pane.timerId !== null) {
+      clearTimeout(pane.timerId);
+      pane.timerId = null;
+    }
+    if (queueHasItems(pane)) {
+      postWorkTurn(pane);
+    }
+  } else {
+    // Tear down MessageChannel work loop; switch to timer drain
+    if (pane.mcPort) {
+      pane.mcPort.close();
+      pane.mcPort = null;
+    }
+    pane.mcPending = false;
+    if (queueHasItems(pane) && pane.timerId === null) {
+      pane.timerId = setTimeout(
+        () => drainBackground(pane),
+        BACKGROUND_DRAIN_INTERVAL_MS
+      );
+    }
+  }
+}
+
+/**
+ * Notify the scheduler that the user typed into the given pane.
+ * Enables the interactive bypass window for the next 100 ms.
+ */
+export function notifyUserInput(sessionId: string): void {
+  const pane = paneMap.get(sessionId);
+  if (!pane) return;
+  pane.lastInputAt = performance.now();
+}
+
+/**
+ * Schedule output to be written to the terminal, applying backpressure and
+ * priority rules.
+ */
+export function scheduleWrite(
+  sessionId: string,
+  data: string,
+  byteLength: number,
+  write: WriteCallback
+): void {
+  const pane = getOrCreate(sessionId, write);
+
+  // Interactive bypass: go straight to terminal for interactive-feeling output
+  if (checkInteractiveBypass(pane, data, byteLength)) {
+    return;
+  }
+
+  // Enqueue — lastSafeSplitEnd starts at 0 (no prior split for this entry).
+  pane.queue.push({ data, start: 0, byteLength, lastSafeSplitEnd: 0 });
+  pane.queueByteLength += byteLength;
+
+  enforceBacklogCap(pane);
+  scheduleDrain(pane);
+}
+
+/**
+ * Flush up to `maxBytes` of backlog immediately (used on tab show).
+ * Returns the number of bytes actually written.
+ */
+export function flushBacklog(sessionId: string, maxBytes: number): number {
+  const pane = paneMap.get(sessionId);
+  if (!pane) return 0;
+
+  // Use pendingAckBytes as the byte-written counter — consumeChunk already
+  // increments it by the stored byteLength of each entry, avoiding a
+  // TextEncoder allocation per chunk.
+  const bytesBeforeFlush = pane.pendingAckBytes;
+  while (queueHasItems(pane)) {
+    const written = pane.pendingAckBytes - bytesBeforeFlush;
+    if (written >= maxBytes) break;
+    const chunk = consumeChunk(pane);
+    if (chunk !== null) {
+      pane.write(chunk);
+    }
+  }
+  scheduleAck(pane);
+  return pane.pendingAckBytes - bytesBeforeFlush;
+}
+
+/**
+ * Returns the current backlog byte length for a pane (for diagnostics).
+ */
+export function getBacklogBytes(sessionId: string): number {
+  return paneMap.get(sessionId)?.queueByteLength ?? 0;
+}
+
+/**
+ * Returns the current adaptive chunk size for a pane (for diagnostics/tests).
+ */
+export function getChunkSize(sessionId: string): number {
+  return paneMap.get(sessionId)?.chunkSize ?? INITIAL_CHUNK_SIZE;
+}
+
+/**
+ * Returns the last measured render time in ms for a pane (for diagnostics/tests).
+ */
+export function getLastRenderMs(sessionId: string): number {
+  return paneMap.get(sessionId)?.lastRenderMs ?? 0;
+}
+
+/**
+ * Apply a render-time measurement to a pane's adaptive sizing state directly.
+ * Only intended for unit tests — allows testing chunk size adaptation without
+ * needing to fake `performance.now()` timing through the write path.
+ */
+export function _testApplyRenderMs(sessionId: string, renderMs: number): void {
+  const pane = paneMap.get(sessionId);
+  if (!pane) return;
+  adaptChunkSize(pane, renderMs);
+}
+
+// ============================================
+// Exported constants for tests
+// ============================================
+export {
+  INITIAL_CHUNK_SIZE,
+  MIN_CHUNK_SIZE,
+  MAX_CHUNK_SIZE,
+  FOREGROUND_WRITES_PER_TURN,
+  BACKGROUND_DRAIN_INTERVAL_MS,
+  BACKGROUND_TIME_BUDGET_MS,
+  HIDDEN_BACKLOG_CAP,
+  INTERACTIVE_WINDOW_MS,
+  INTERACTIVE_BYPASS_SIZE_HARD,
+  INTERACTIVE_BYPASS_SIZE_ANSI,
+  INTERACTIVE_BYPASS_BUDGET,
+  ADAPT_SHRINK_THRESHOLD_MS,
+  ADAPT_GROW_THRESHOLD_MS,
+  ADAPT_GROW_CONSECUTIVE_FRAMES,
+};

--- a/src/components/TerminalInteractive/terminalPty.ts
+++ b/src/components/TerminalInteractive/terminalPty.ts
@@ -10,10 +10,42 @@ import {
 } from "@src/util/platform/tauri/init";
 
 import { deleteTerminalBuffer, getTerminalBuffer } from "./bufferCache";
+import {
+  notifyUserInput,
+  registerPane,
+  scheduleWrite,
+  unregisterPane,
+} from "./terminalOutputScheduler";
 import type { TerminalViewProps } from "./types";
 import { writeBrowserModeMessage } from "./utils";
 
 const log = createLogger("TerminalView");
+
+/**
+ * Estimate UTF-8 byte length of a string without a TextEncoder allocation.
+ *
+ * Terminal output is overwhelmingly ASCII (shell prompts, command output,
+ * ANSI sequences). The rare non-ASCII cases (emoji, CJK) over-estimate by
+ * at most 3 bytes per character, which is acceptable — byte_count is used
+ * as a backpressure hint, not an exact invariant.
+ *
+ * Implementation: charCode > 0x7F catches all non-ASCII BMP code points; a
+ * surrogate pair (charCode > 0x7FF in both high+low halves) is counted as
+ * +3 each which approximates the 4-byte UTF-8 encoding of the astral plane.
+ */
+function estimateByteLength(s: string): number {
+  let len = s.length; // start with 1 byte per char (ASCII baseline)
+  for (let i = 0; i < s.length; i++) {
+    const c = s.charCodeAt(i);
+    if (c > 0x7f) {
+      // Non-ASCII: add extra bytes beyond the already-counted baseline byte.
+      // U+0080–U+07FF → 2-byte UTF-8 (+1)
+      // U+0800–U+FFFF → 3-byte UTF-8 (+2)
+      len += c > 0x7ff ? 2 : 1;
+    }
+  }
+  return len;
+}
 
 interface PtyOutputPayload {
   bytes?: number[];
@@ -40,6 +72,14 @@ interface InitPtyConnectionParams {
   onSessionInfoReady?: TerminalViewProps["onSessionInfoReady"];
   setIsBrowserMode: (value: boolean) => void;
   setIsConnecting: (value: boolean) => void;
+}
+
+/**
+ * Notify the output scheduler that the user typed into the given session.
+ * Must be called from the terminal's onData handler to enable interactive bypass.
+ */
+export function notifyPtyUserInput(sessionId: string): void {
+  notifyUserInput(sessionId);
 }
 
 function resolvePtyLaunchOptions({
@@ -246,18 +286,14 @@ export async function initPtyConnection({
     if (!terminal) return;
 
     const utf8Decoder = new TextDecoder("utf-8", { fatal: false });
-    let ackPendingBytes = 0;
-    let ackScheduled = false;
-    const flushAck = () => {
-      if (ackPendingBytes > 0 && isTauriReady()) {
-        invokeTauri("ack_pty_data", {
-          sessionId,
-          byteCount: ackPendingBytes,
-        }).catch(() => undefined);
-        ackPendingBytes = 0;
-      }
-      ackScheduled = false;
-    };
+
+    // Stable write callback — captured once per session so the hot IPC
+    // handler never allocates a new closure per event.
+    const terminalWrite = (d: string | Uint8Array) => terminal.write(d);
+
+    // Register this pane with the output scheduler. ACK is handled by the
+    // scheduler after it drains chunks — we no longer call ack directly here.
+    registerPane(sessionId, terminalWrite);
 
     const unlistenOutput = await listenTauri<PtyOutputPayload>(
       `pty-output-${sessionId}`,
@@ -269,19 +305,17 @@ export async function initPtyConnection({
             stream: true,
           });
           if (decoded) {
-            terminal.write(decoded);
+            const resolvedByteCount = byteCount ?? bytes.length;
+            scheduleWrite(sessionId, decoded, resolvedByteCount, terminalWrite);
           }
-          ackPendingBytes += byteCount ?? bytes.length;
         } else if (data) {
-          terminal.write(data);
-          ackPendingBytes += new TextEncoder().encode(data).length;
-        } else {
-          return;
-        }
-
-        if (!ackScheduled) {
-          ackScheduled = true;
-          requestAnimationFrame(flushAck);
+          // Backward-compat branch (no byte_count from backend): estimate byte
+          // length without a TextEncoder allocation. ASCII is 1 byte/char;
+          // non-ASCII (rare in terminal hot path) inflates slightly — the
+          // scheduler treats byte_count as a flow-control hint, not an exact
+          // invariant, so a cheap over-estimate is correct.
+          const encodedLen = estimateByteLength(data);
+          scheduleWrite(sessionId, data, encodedLen, terminalWrite);
         }
       }
     );
@@ -293,6 +327,7 @@ export async function initPtyConnection({
         terminal.write(trailingOutput);
       }
       terminal.writeln("\r\n\x1b[33m[Session ended]\x1b[0m");
+      unregisterPane(sessionId);
     });
     unlistenExitRef.current = unlistenExit;
 

--- a/src/components/TerminalInteractive/terminalPty.ts
+++ b/src/components/TerminalInteractive/terminalPty.ts
@@ -14,6 +14,7 @@ import {
   notifyUserInput,
   registerPane,
   scheduleWrite,
+  setPaneForeground,
   unregisterPane,
 } from "./terminalOutputScheduler";
 import type { TerminalViewProps } from "./types";
@@ -58,6 +59,7 @@ interface InitPtyConnectionParams {
   cols: number;
   rows: number;
   sessionKey: string;
+  isForeground: boolean;
   terminalRef: MutableRefObject<Terminal | null>;
   sessionIdRef: MutableRefObject<string | null>;
   unlistenOutputRef: MutableRefObject<(() => void) | null>;
@@ -252,6 +254,7 @@ export async function initPtyConnection({
   cols,
   rows,
   sessionKey,
+  isForeground,
   terminalRef,
   sessionIdRef,
   unlistenOutputRef,
@@ -294,6 +297,7 @@ export async function initPtyConnection({
     // Register this pane with the output scheduler. ACK is handled by the
     // scheduler after it drains chunks — we no longer call ack directly here.
     registerPane(sessionId, terminalWrite);
+    setPaneForeground(sessionId, isForeground);
 
     const unlistenOutput = await listenTauri<PtyOutputPayload>(
       `pty-output-${sessionId}`,

--- a/src/components/TerminalInteractive/terminalSetup.ts
+++ b/src/components/TerminalInteractive/terminalSetup.ts
@@ -16,6 +16,7 @@ import type { TerminalThemeName } from "@src/store/ui/uiAtom";
 import { shouldLoadTerminalWebgl } from "./terminalRendererPolicy";
 import type { TerminalViewProps } from "./types";
 import { getXTermTheme } from "./utils";
+import { acquireWebglSlot, releaseWebglSlot } from "./webglContextManager";
 
 const log = createLogger("Terminal");
 
@@ -107,12 +108,20 @@ export function loadTerminalWebgl(
     return;
   }
 
+  if (!acquireWebglSlot()) {
+    log.warn(
+      "[Terminal] WebGL context budget exhausted, using canvas renderer"
+    );
+    return;
+  }
+
   try {
     const webglAddon = new WebglAddon();
     webglAddon.onContextLoss(() => {
       log.warn("[Terminal] WebGL context lost, falling back to canvas");
       webglAddon.dispose();
       webglAddonRef.current = null;
+      releaseWebglSlot();
     });
     terminal.loadAddon(webglAddon);
     webglAddonRef.current = webglAddon;
@@ -121,6 +130,7 @@ export function loadTerminalWebgl(
       "[Terminal] WebGL addon failed to load, using canvas renderer:",
       error
     );
+    releaseWebglSlot();
   }
 }
 
@@ -142,12 +152,12 @@ export function initializeWhenContainerVisible({
     initialized = true;
     resizeObserver?.disconnect();
     resizeObserver = null;
-    loadWebGL();
+
     fitTerminal();
+    loadWebGL();
+
     setIsReady(true);
     initPty(terminal.cols, terminal.rows);
-    setTimeout(fitTerminal, 150);
-    setTimeout(fitTerminal, 300);
   };
 
   const tryInit = () => {

--- a/src/components/TerminalInteractive/types.ts
+++ b/src/components/TerminalInteractive/types.ts
@@ -5,6 +5,8 @@
 export interface TerminalSelectionInfo {
   text: string;
   position: { x: number; y: number };
+  lineStart?: number;
+  lineEnd?: number;
 }
 
 /** Methods exposed via ref for terminal search */
@@ -52,6 +54,8 @@ export interface TerminalFileLinkTarget {
 
 export interface TerminalViewProps {
   sessionKey: string;
+  /** Whether this terminal is the active visible pane. */
+  isForeground?: boolean;
   /** Callback when text is selected in the terminal */
   onSelectionChange?: (selection: TerminalSelectionInfo | null) => void;
   /** Callback when terminal receives output */

--- a/src/components/TerminalInteractive/webglContextManager.ts
+++ b/src/components/TerminalInteractive/webglContextManager.ts
@@ -1,0 +1,52 @@
+/**
+ * Global WebGL context slot manager for xterm terminals.
+ *
+ * macOS enforces a hard per-process limit (~16 WebGL contexts). Each xterm
+ * WebglAddon context consumes 10–30 MB of GPU memory. This manager caps
+ * simultaneous contexts at a conservative threshold so opening many terminal
+ * tabs never exhausts the budget and silently degrades to the slower canvas
+ * renderer without a recorded slot release.
+ */
+
+const MAX_WEBGL_CONTEXTS = 8;
+
+let activeContextCount = 0;
+
+/**
+ * Attempt to reserve a WebGL context slot.
+ *
+ * Returns `true` when a slot was successfully acquired and the caller should
+ * load `WebglAddon`. Returns `false` when the budget is exhausted — the
+ * caller must fall back to the canvas renderer and must NOT call
+ * `releaseWebglSlot`.
+ */
+export function acquireWebglSlot(): boolean {
+  if (activeContextCount >= MAX_WEBGL_CONTEXTS) {
+    return false;
+  }
+  activeContextCount += 1;
+  return true;
+}
+
+/**
+ * Release a previously acquired WebGL context slot.
+ *
+ * Must be called exactly once per successful `acquireWebglSlot()` call, when
+ * the associated `WebglAddon` is disposed (on context loss or terminal
+ * teardown).
+ */
+export function releaseWebglSlot(): void {
+  if (activeContextCount > 0) {
+    activeContextCount -= 1;
+  }
+}
+
+/** Exposed for tests only — do not use in production code. */
+export function _getActiveContextCount(): number {
+  return activeContextCount;
+}
+
+/** Exposed for tests only — do not use in production code. */
+export function _resetForTests(): void {
+  activeContextCount = 0;
+}

--- a/src/features/CodeMirror/shared/languageExtensions.ts
+++ b/src/features/CodeMirror/shared/languageExtensions.ts
@@ -13,6 +13,9 @@ import { json } from "@codemirror/lang-json";
 import { markdown } from "@codemirror/lang-markdown";
 import { python } from "@codemirror/lang-python";
 import { rust } from "@codemirror/lang-rust";
+import { StreamLanguage } from "@codemirror/language";
+import { dart as dartMode } from "@codemirror/legacy-modes/mode/clike";
+import { go as goMode } from "@codemirror/legacy-modes/mode/go";
 import { Extension } from "@codemirror/state";
 
 import { createLogger } from "@src/hooks/logger";
@@ -47,6 +50,7 @@ export const EXT_TO_LANG_MAP: Record<string, string> = {
   json: "json",
   md: "markdown",
   markdown: "markdown",
+  dart: "dart",
 };
 
 // ============================================
@@ -147,6 +151,12 @@ export function getLanguageExtension(
       break;
     case "markdown":
       ext = markdown();
+      break;
+    case "dart":
+      ext = StreamLanguage.define(dartMode);
+      break;
+    case "go":
+      ext = StreamLanguage.define(goMode);
       break;
     default:
       return null;
@@ -259,6 +269,17 @@ export async function loadLanguageExtension(
       case "markdown": {
         const { markdown: mdLang } = await import("@codemirror/lang-markdown");
         ext = mdLang();
+        break;
+      }
+      case "dart": {
+        const { dart: dartMode } =
+          await import("@codemirror/legacy-modes/mode/clike");
+        ext = StreamLanguage.define(dartMode);
+        break;
+      }
+      case "go": {
+        const { go: goMode } = await import("@codemirror/legacy-modes/mode/go");
+        ext = StreamLanguage.define(goMode);
         break;
       }
     }


### PR DESCRIPTION
## Summary

- **O1** Replace `Array.shift()` with a `queueHead` pointer in `terminalOutputScheduler.ts` — O(n) → O(1) dequeue, eliminates repeated array re-indexing under sustained PTY load
- **O2** Replace `new TextEncoder().encode()` with `estimateByteLength()` in `terminalPty.ts` — removes per-chunk allocator round-trip on the hot IPC path
- **O3** Hoist `terminalWrite` callback outside the IPC handler closure — prevents closure re-allocation on every incoming PTY data event
- **O4** Avoid `.to_vec()` in Rust PTY reader (`agent_tool/mod.rs`) — passes `&[u8]` slice directly instead of materialising an owned `Vec`
- **O5** `findAnsiSafeSplit` incremental scan + `lastSafeSplitEnd` cache — eliminates redundant backward scans when chunk boundary is stable across frames
- **O6** `webglContextManager.ts` — tracks the per-page WebGL context budget (browser max ≈ 16); gracefully falls back to canvas renderer; removes the `setTimeout`-based fit chain and replaces it with a single stable call
- **O7** `output_tap` channel type changed `String → Arc<[u8]>` in Rust — zero-copy broadcast to multiple subscribers, avoids per-subscriber clone

### Broader sweep fixes (bundled in same files)
- Go language highlighting fixed on sync + async path (`languageExtensions.ts`)
- `registerFileLinkProvider` early-return guard removed (`terminalSetup.ts`)
- `flushBacklog` TextEncoder loop allocation fixed (`terminalHandlers.ts`)
- `isComposerStopBlockingEvent` double-parse fixed (`terminalPty.ts`)
- Test stale constant names fixed (`terminalOutputScheduler.test.ts`)

## Performance impact

| Optimization | Impact |
|---|---|
| O1 queueHead pointer | Eliminates O(n) array re-index; ~0 overhead at 1 KB/frame, measurable gain at >100 KB/s burst |
| O2 estimateByteLength | Removes `TextEncoder` + GC allocation per IPC message (~1 object/frame saved) |
| O3 hoisted terminalWrite | 1 fewer closure allocation per PTY data event |
| O4 no .to_vec() | Avoids heap alloc + memcpy per PTY read in Rust hot path |
| O5 lastSafeSplitEnd cache | O(n) → O(1) in steady state for chunk splits at stable boundaries |
| O6 WebGL context limit | Prevents browser context limit crashes; removes setTimeout resize chain |
| O7 Arc<[u8]> tap channel | Zero-copy for all tap subscribers; was cloning String per subscriber |

## Test plan

- [ ] `pnpm test` passes (terminalOutputScheduler unit tests cover scheduler, ANSI safe-split, adaptive chunk logic)
- [ ] Open a terminal session with a long-running command producing high-throughput output (e.g. `seq 1 100000`) — verify smooth rendering, no jank
- [ ] Open 16+ terminal panels — verify graceful fallback to canvas renderer (no WebGL context limit crash)
- [ ] Rust: `cargo test -p terminal` and `cargo test -p agent-core` pass
- [ ] PTY reconnect: close and reopen a terminal tab — verify output resumes correctly