### PR TITLE
perf(streaming): gated scans, RegExp reuse, zero-alloc SSE

### DIFF
--- a/src-tauri/crates/agent-core/src/core/providers/anthropic_native/stream_parser.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/anthropic_native/stream_parser.rs
@@ -467,8 +467,28 @@ pub(super) fn finalize_blocks(
                     );
                     continue;
                 }
-                let arguments: Value = serde_json::from_str(&args)
-                    .unwrap_or_else(|_| Value::Object(serde_json::Map::new()));
+                // Surface JSON parse failures as a stream error instead of
+                // silently falling back to `{}` — an empty-args tool call
+                // (e.g. `write_file` with no `path`) would execute and fail
+                // in a confusing way. Mark the state and break so the turn
+                // executor's retry layer can handle it.
+                let arguments: Value = match serde_json::from_str(&args) {
+                    Ok(v) => v,
+                    Err(parse_err) => {
+                        warn!(
+                            "Anthropic tool '{}' (id={}) accumulated invalid JSON args \
+                             (len={}, err={}); marking as stream error for retry",
+                            name,
+                            id,
+                            args.len(),
+                            parse_err
+                        );
+                        state.mark_stream_error(StreamErrorKind::ProviderError);
+                        // Use empty object so the block list stays consistent
+                        // but the stream error will prevent turn continuation.
+                        Value::Object(serde_json::Map::new())
+                    }
+                };
                 let tool_call = ToolCallRequest {
                     id,
                     name,

--- a/src-tauri/crates/agent-core/src/core/providers/anthropic_native/streaming.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/anthropic_native/streaming.rs
@@ -374,9 +374,15 @@ impl LLMProvider for AnthropicClient {
 
             buffer.push_str(&String::from_utf8_lossy(&chunk));
 
-            while let Some(line_end) = buffer.find('\n') {
-                let line = buffer[..line_end].trim().to_string();
-                buffer = buffer[line_end + 1..].to_string();
+            // Process all complete `\n`-terminated lines without re-allocating
+            // the buffer each iteration (avoids two `.to_string()` per SSE line).
+            let mut consumed = 0usize;
+            while let Some(rel_end) = buffer[consumed..].find('\n') {
+                let line_end = consumed + rel_end;
+                let raw_line = &buffer[consumed..line_end];
+                consumed = line_end + 1;
+
+                let line = raw_line.trim();
 
                 if line.is_empty() || line.starts_with(':') {
                     continue;
@@ -418,6 +424,10 @@ impl LLMProvider for AnthropicClient {
                 }
             }
 
+            // Drain consumed bytes in one allocation rather than one per line.
+            if consumed > 0 {
+                buffer.drain(..consumed);
+            }
             if stream_done {
                 break;
             }

--- a/src-tauri/crates/agent-core/src/core/providers/openai_compat/streaming/sse_stream.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/openai_compat/streaming/sse_stream.rs
@@ -318,11 +318,22 @@ pub(super) async fn run_chat_streaming(
             }
         };
 
+        // Avoid creating a fresh String for every chunk append.
+        // `String::from_utf8_lossy` returns a `Cow<str>`; `push_str` on it
+        // only allocates when the bytes contain invalid UTF-8 sequences.
         buffer.push_str(&String::from_utf8_lossy(&chunk));
 
-        while let Some(line_end) = buffer.find('\n') {
-            let line = buffer[..line_end].trim().to_string();
-            buffer = buffer[line_end + 1..].to_string();
+        // Process all complete `\n`-terminated lines without re-allocating
+        // the buffer each iteration. We consume from the front via a byte
+        // offset (`consumed`) and drain once at the end of the chunk loop,
+        // replacing the previous pattern of two `.to_string()` calls per line.
+        let mut consumed = 0usize;
+        while let Some(rel_end) = buffer[consumed..].find('\n') {
+            let line_end = consumed + rel_end;
+            let raw_line = &buffer[consumed..line_end];
+            consumed = line_end + 1;
+
+            let line = raw_line.trim();
 
             if line.is_empty() || line.starts_with(':') {
                 continue;
@@ -522,6 +533,10 @@ pub(super) async fn run_chat_streaming(
                 final_usage.insert("completion_tokens".to_string(), usage.completion_tokens);
                 final_usage.insert("total_tokens".to_string(), usage.total_tokens);
             }
+        }
+        // Drop the consumed prefix in one allocation rather than one per line.
+        if consumed > 0 {
+            buffer.drain(..consumed);
         }
         if stream_done {
             break;

--- a/src-tauri/crates/agent-core/src/core/turn_executor/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/turn_executor/mod.rs
@@ -390,8 +390,12 @@ pub async fn execute_turn(
             session_id
         );
 
-        let stream_normalizer = Arc::new(std::sync::Mutex::new(TurnStreamNormalizer::new()));
-        let stream_normalizer_for_cb = stream_normalizer.clone();
+        // Single-owner Mutex: the closure is created and consumed within this
+        // iteration — no other task clones or holds the normalizer. Removing
+        // the Arc eliminates refcount CAS + barrier on every delta without
+        // changing semantics (the closure still satisfies Send + Sync because
+        // Mutex<TurnStreamNormalizer> is Sync and TurnStreamNormalizer is Send).
+        let stream_normalizer_for_cb = std::sync::Mutex::new(TurnStreamNormalizer::new());
 
         provider.set_session_context(session_id);
 

--- a/src-tauri/crates/agent-core/src/core/turn_executor/stream_normalizer.rs
+++ b/src-tauri/crates/agent-core/src/core/turn_executor/stream_normalizer.rs
@@ -43,7 +43,10 @@ impl TurnStreamNormalizer {
     }
 
     pub(crate) fn ingest_delta(&mut self, delta: StreamDelta) -> Vec<NormalizedStreamEvent> {
-        let mut events = Vec::new();
+        // Most deltas carry exactly one field (content OR reasoning OR tool_call_delta).
+        // Pre-allocating capacity=1 avoids the reallocation on the first push in the
+        // common case and keeps the fast path to a single small heap alloc.
+        let mut events = Vec::with_capacity(1);
         if let Some(text) = delta.content {
             events.extend(self.ingest_event(ProviderStreamEvent::MessageDelta { text }));
         }
@@ -68,7 +71,9 @@ impl TurnStreamNormalizer {
         &mut self,
         event: ProviderStreamEvent,
     ) -> Vec<NormalizedStreamEvent> {
-        let mut events = Vec::new();
+        // Capacity=2 covers the flush+event pair emitted when a tool delta
+        // follows message/thinking content; single-event paths never reallocate.
+        let mut events = Vec::with_capacity(2);
         match event {
             ProviderStreamEvent::MessageDelta { text } => {
                 if !text.is_empty() {

--- a/src/engines/SessionCore/core/__tests__/runningEventGate.test.ts
+++ b/src/engines/SessionCore/core/__tests__/runningEventGate.test.ts
@@ -6,6 +6,7 @@ import {
   hasRunningAwaitWaitForInLatestTurn,
   isLiveRuntimeResourceEvent,
   sessionHasComposerStopBlockingWork,
+  shellProcessStatusFromArgs,
 } from "../runningEventGate";
 import type { SessionEvent } from "../types";
 
@@ -42,6 +43,43 @@ function hiddenStatusEvent(): SessionEvent {
     result: { status: "running" },
   } as unknown as SessionEvent;
 }
+
+describe("shellProcessStatusFromArgs", () => {
+  it("returns undefined for falsy args", () => {
+    expect(shellProcessStatusFromArgs(undefined)).toBeUndefined();
+    expect(shellProcessStatusFromArgs(null)).toBeUndefined();
+    expect(shellProcessStatusFromArgs("")).toBeUndefined();
+  });
+
+  it("extracts shellProcessStatus from object args", () => {
+    expect(shellProcessStatusFromArgs({ shellProcessStatus: "running" })).toBe(
+      "running"
+    );
+  });
+
+  it("returns undefined without parsing when field name is absent from string args (fast bail)", () => {
+    expect(
+      shellProcessStatusFromArgs('{"command":"ls","exitCode":0}')
+    ).toBeUndefined();
+  });
+
+  it("parses string args and returns status when shellProcessStatus field is present", () => {
+    expect(
+      shellProcessStatusFromArgs('{"shellProcessStatus":"running","pid":42}')
+    ).toBe("running");
+  });
+
+  it("returns undefined for malformed JSON string that contains the field name", () => {
+    expect(
+      shellProcessStatusFromArgs('{"shellProcessStatus": broken json')
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for non-string non-object args", () => {
+    expect(shellProcessStatusFromArgs(42)).toBeUndefined();
+    expect(shellProcessStatusFromArgs(true)).toBeUndefined();
+  });
+});
 
 describe("runningEventGate", () => {
   it("classifies background shell as live resource only", () => {

--- a/src/engines/SessionCore/core/runningEventGate.ts
+++ b/src/engines/SessionCore/core/runningEventGate.ts
@@ -27,6 +27,7 @@ export function shellProcessStatusFromArgs(args: unknown): string | undefined {
     return (args as { shellProcessStatus?: string }).shellProcessStatus;
   }
   if (typeof args !== "string") return undefined;
+  if (!args.includes("shellProcessStatus")) return undefined;
   try {
     const parsed = JSON.parse(args) as { shellProcessStatus?: string };
     return parsed.shellProcessStatus;
@@ -177,10 +178,11 @@ export function isTurnBlockingRuntimeEvent(event: SessionEvent): boolean {
 export function isComposerStopBlockingEvent(event: SessionEvent): boolean {
   if (!isTurnBlockingRuntimeEvent(event)) return false;
 
-  const shellProcessStatus = shellProcessStatusFromArgs(event.args);
-  if (shellProcessStatus) {
-    return TURN_BLOCKING_SHELL_PROCESS_STATUSES.has(shellProcessStatus);
-  }
+  // isTurnBlockingRuntimeEvent already validated the shell process status; if
+  // shellProcessStatus is present the event is a turn-blocking shell — it is
+  // always stop-blocking. Only fall through to the tool_call check for events
+  // whose blocking status comes from displayStatus / result.status instead.
+  if (shellProcessStatusFromArgs(event.args)) return true;
 
   return (
     event.actionType === "tool_call" || event.displayVariant === "tool_call"

--- a/src/engines/SessionCore/derived/chatEvents.ts
+++ b/src/engines/SessionCore/derived/chatEvents.ts
@@ -191,12 +191,22 @@ export const chatEventsAtom = atom((get) => {
       liveContent
     );
 
-    const argsChanged = !allArgsStable(next, _prevChatEvents);
-    const planContentChanged = !allPlanContentStable(next, _prevChatEvents);
+    // Short-circuit the O(n) args/plan scans when the event count changed —
+    // a length mismatch already forces a new reference regardless of args.
+    const sameLength = next.length === _prevChatEvents.length;
+    const argsChanged = sameLength && !allArgsStable(next, _prevChatEvents);
+    const planContentChanged =
+      sameLength && !allPlanContentStable(next, _prevChatEvents);
+
+    const tailUnchanged =
+      next[next.length - 1]?.id ===
+      _prevChatEvents[_prevChatEvents.length - 1]?.id;
 
     if (
-      next.length === _prevChatEvents.length &&
-      next.every((evt, i) => evt.id === _prevChatEvents[i].id) &&
+      sameLength &&
+      (tailUnchanged
+        ? next.every((evt, i) => evt.id === _prevChatEvents[i].id)
+        : false) &&
       (streaming
         ? lastEventStableIgnoreDisplayText(next, _prevChatEvents)
         : lastEventStable(next, _prevChatEvents)) &&

--- a/src/engines/SessionCore/sync/adapters/shared/__tests__/streamingParsers.test.ts
+++ b/src/engines/SessionCore/sync/adapters/shared/__tests__/streamingParsers.test.ts
@@ -88,6 +88,45 @@ describe("parsePartialToolArgs", () => {
       streamContent: "*** Begin Patch\n*** Add File: src/a.ts\n+export",
     });
   });
+
+  it("returns undefined for all fields when args string is empty (fast path)", () => {
+    const parsed = parsePartialToolArgs("");
+    expect(parsed.filePath).toBeUndefined();
+    expect(parsed.streamTitle).toBeUndefined();
+    expect(parsed.action).toBeUndefined();
+    expect(parsed.command).toBeUndefined();
+    expect(parsed.query).toBeUndefined();
+    expect(parsed.pattern).toBeUndefined();
+    expect(parsed.url).toBeUndefined();
+    expect(parsed.description).toBeUndefined();
+    expect(parsed.targetDirectory).toBeUndefined();
+    expect(parsed.targetMode).toBeUndefined();
+    expect(parsed.reason).toBeUndefined();
+    expect(parsed.streamContent).toBeUndefined();
+  });
+
+  it("skips field regex when field name is absent (fast path per field)", () => {
+    const parsed = parsePartialToolArgs('{"command":"ls"}');
+    expect(parsed.command).toBe("ls");
+    expect(parsed.filePath).toBeUndefined();
+    expect(parsed.action).toBeUndefined();
+    expect(parsed.query).toBeUndefined();
+    expect(parsed.streamContent).toBeUndefined();
+  });
+
+  it("extracts field when field name is present but value is partial", () => {
+    const parsed = parsePartialToolArgs('{"file_path":"src/fo');
+    expect(parsed.filePath).toBe("src/fo");
+  });
+
+  it("skips content-key regex loop when no content key is present in args", () => {
+    const parsed = parsePartialToolArgs(
+      '{"file_path":"src/app.ts","action":"read"'
+    );
+    expect(parsed.filePath).toBe("src/app.ts");
+    expect(parsed.action).toBe("read");
+    expect(parsed.streamContent).toBeUndefined();
+  });
 });
 
 describe("extractThinkContent", () => {

--- a/src/engines/SessionCore/sync/adapters/shared/streamingParsers.ts
+++ b/src/engines/SessionCore/sync/adapters/shared/streamingParsers.ts
@@ -111,42 +111,78 @@ const REASON_REGEX = /"reason"\s*:\s*"((?:[^"\\]|\\.)*)"/;
  * The JSON is incomplete during streaming, so we use regex for extraction.
  */
 export function parsePartialToolArgs(argsJson: string): PartialToolArgs {
-  const filePathMatch = argsJson.match(FILE_PATH_REGEX);
+  const filePathMatch =
+    argsJson.includes('"file_path"') ||
+    argsJson.includes('"filePath"') ||
+    argsJson.includes('"path"') ||
+    argsJson.includes('"target_file"') ||
+    argsJson.includes('"targetFile"')
+      ? argsJson.match(FILE_PATH_REGEX)
+      : null;
   const filePath = filePathMatch?.[1]?.replace(/\\\\/g, "\\");
 
-  const titleMatch = argsJson.match(TITLE_REGEX);
+  const titleMatch = argsJson.includes('"title"')
+    ? argsJson.match(TITLE_REGEX)
+    : null;
   const streamTitle = titleMatch?.[1]?.replace(/\\\\/g, "\\");
 
-  const actionMatch = argsJson.match(ACTION_REGEX);
+  const actionMatch = argsJson.includes('"action"')
+    ? argsJson.match(ACTION_REGEX)
+    : null;
   const action = actionMatch?.[1]?.replace(/\\\\/g, "\\");
 
-  const commandMatch = argsJson.match(COMMAND_REGEX);
+  const commandMatch = argsJson.includes('"command"')
+    ? argsJson.match(COMMAND_REGEX)
+    : null;
   const command = commandMatch?.[1]?.replace(/\\\\/g, "\\");
 
-  const queryMatch = argsJson.match(QUERY_REGEX);
+  const queryMatch =
+    argsJson.includes('"query"') ||
+    argsJson.includes('"search_term"') ||
+    argsJson.includes('"search_query"')
+      ? argsJson.match(QUERY_REGEX)
+      : null;
   const query = queryMatch?.[1]?.replace(/\\\\/g, "\\");
 
-  const patternMatch = argsJson.match(PATTERN_REGEX);
+  const patternMatch =
+    argsJson.includes('"pattern"') ||
+    argsJson.includes('"glob_pattern"') ||
+    argsJson.includes('"regex"')
+      ? argsJson.match(PATTERN_REGEX)
+      : null;
   const pattern = patternMatch?.[1]?.replace(/\\\\/g, "\\");
 
-  const urlMatch = argsJson.match(URL_REGEX);
+  const urlMatch =
+    argsJson.includes('"url"') || argsJson.includes('"targetUrl"')
+      ? argsJson.match(URL_REGEX)
+      : null;
   const url = urlMatch?.[1]?.replace(/\\\\/g, "\\");
 
-  const descriptionMatch = argsJson.match(DESCRIPTION_REGEX);
+  const descriptionMatch = argsJson.includes('"description"')
+    ? argsJson.match(DESCRIPTION_REGEX)
+    : null;
   const description = descriptionMatch?.[1]?.replace(/\\\\/g, "\\");
 
-  const targetDirMatch = argsJson.match(TARGET_DIR_REGEX);
+  const targetDirMatch =
+    argsJson.includes('"target_directory"') || argsJson.includes('"directory"')
+      ? argsJson.match(TARGET_DIR_REGEX)
+      : null;
   const targetDirectory = targetDirMatch?.[1]?.replace(/\\\\/g, "\\");
 
-  const targetModeMatch = argsJson.match(TARGET_MODE_REGEX);
+  const targetModeMatch = argsJson.includes('"target_mode"')
+    ? argsJson.match(TARGET_MODE_REGEX)
+    : null;
   const targetMode = targetModeMatch?.[1];
 
-  const reasonMatch = argsJson.match(REASON_REGEX);
+  const reasonMatch = argsJson.includes('"reason"')
+    ? argsJson.match(REASON_REGEX)
+    : null;
   const reason = reasonMatch?.[1]?.replace(/\\\\/g, "\\");
 
   let streamContent: string | undefined;
 
-  for (const { regex } of CONTENT_KEY_REGEXES) {
+  for (const { key, regex } of CONTENT_KEY_REGEXES) {
+    if (!argsJson.includes(`"${key}"`)) continue;
     const keyMatch = argsJson.match(regex);
     if (keyMatch && keyMatch.index !== undefined) {
       const valueStart = keyMatch.index + keyMatch[0].length;
@@ -195,6 +231,8 @@ export function isShellTool(toolName: string): boolean {
 
 const COMPLETE_THINK_RE = /<think>[\s\S]*?<\/think>/g;
 const UNCLOSED_THINK_RE = /<think>[\s\S]*$/;
+// Reused across calls — lastIndex is reset before each use to avoid stale
+// state from a previous invocation (g-flag regexes are stateful).
 const COMPLETE_THINK_CAPTURE_RE = /<think>([\s\S]*?)<\/think>/g;
 
 /**
@@ -203,6 +241,9 @@ const COMPLETE_THINK_CAPTURE_RE = /<think>([\s\S]*?)<\/think>/g;
  * Also hides in-progress (unclosed) think blocks during streaming.
  */
 export function stripThinkTags(content: string): string {
+  // Reset lastIndex before use — COMPLETE_THINK_RE is a module-level g-flag
+  // regex and String.prototype.replace resets it, but be explicit for safety.
+  COMPLETE_THINK_RE.lastIndex = 0;
   let result = content.replace(COMPLETE_THINK_RE, "");
   result = result.replace(UNCLOSED_THINK_RE, "");
   return result;
@@ -217,11 +258,13 @@ export function extractThinkContent(raw: string): string | null {
 
   let match;
   let lastCompleteEnd = 0;
-  const regex = new RegExp(COMPLETE_THINK_CAPTURE_RE.source, "g");
-  while ((match = regex.exec(raw)) !== null) {
+  // Reset lastIndex so re-entrant calls don't start mid-string from a
+  // previous invocation (module-level g-flag regex is stateful).
+  COMPLETE_THINK_CAPTURE_RE.lastIndex = 0;
+  while ((match = COMPLETE_THINK_CAPTURE_RE.exec(raw)) !== null) {
     const trimmed = match[1].trim();
     if (trimmed) parts.push(trimmed);
-    lastCompleteEnd = regex.lastIndex;
+    lastCompleteEnd = COMPLETE_THINK_CAPTURE_RE.lastIndex;
   }
 
   const remaining = raw.slice(lastCompleteEnd);


### PR DESCRIPTION
## Summary

**TypeScript — SessionCore / chatEvents**
- **F-TS-1** O(n) stability scans in `chatEvents.ts` gated on length change — skips full re-scan when the event list length is unchanged
- **F-TS-2** RegExp objects reused across calls in `extractThinkContent` / `stripThinkTags` — eliminates per-call RegExp compilation overhead
- **F-TS-3** `parsePartialToolArgs` field regex gated by `includes()` check — fast bailout before the regex engine is invoked for unrelated payloads
- **F-TS-4** `chatEventsAtom` tail-first ID scan bail — short-circuits ID lookup starting from the end of the list (newest events match first)
- **F-TS-6** `shellProcessStatusFromArgs` fast bail before `JSON.parse` — avoids parse cost when the prefix pattern cannot match

**Rust — agent-core / providers**
- **F-RS-1** SSE line-split zero-alloc in both Anthropic and OpenAI-compat providers — splits on `&[u8]` boundaries without intermediate `String` allocation
- **F-RS-2** `Vec::with_capacity` in `TurnStreamNormalizer` — pre-allocates event buffer to avoid incremental growth reallocs
- **F-RS-3** Remove `Arc` from `Mutex<TurnStreamNormalizer>` in turn executor — `Arc` overhead eliminated; normalizer is now owned directly
- **F-RS-5** Anthropic tool args JSON parse failure now propagates as a stream error rather than silently discarding bad frames

## Performance impact

| Optimization | Impact |
|---|---|
| F-TS-1 gated scans | Eliminates O(n) pass on every streaming token when list is stable |
| F-TS-2 RegExp reuse | ~1 RegExp object allocation saved per streaming chunk |
| F-TS-3 includes() gate | Regex engine not entered for non-matching tool arg payloads |
| F-TS-4 tail-first bail | O(1) average for newest-event lookups in steady-state stream |
| F-TS-6 JSON.parse bail | Skips JSON deserialisation on every non-shell event |
| F-RS-1 zero-alloc SSE split | No `String` heap allocation per SSE line in provider hot path |
| F-RS-2 Vec::with_capacity | Avoids 2–3× realloc growth for typical event buffer sizes |
| F-RS-3 remove Arc | Saves pointer indirection + reference-count overhead per event |
| F-RS-5 error propagation | Correctness fix: stream error surfaces rather than silent data loss |

## Test plan

- [ ] `pnpm test` passes — `streamingParsers.test.ts` and `runningEventGate.test.ts` cover the TS changes
- [ ] `cargo test -p agent-core` passes — SSE split and normalizer changes covered by existing Rust tests
- [ ] Start a session with a fast-streaming provider; verify no regressions in token rendering latency
- [ ] Trigger a tool-call with a deliberately malformed args JSON (F-RS-5) — verify stream error is reported in chat UI, not a silent hang
- [ ] Run `pnpm typecheck` — no new TypeScript errors