### PR TITLE
fix(agent): prefer display_text as goal to avoid skill pill truncation

### DIFF
--- a/src-tauri/crates/agent-core/src/core/session/goal_loop.rs
+++ b/src-tauri/crates/agent-core/src/core/session/goal_loop.rs
@@ -125,14 +125,31 @@ fn clear_state(session_id: &str) {
 /// Record a real user message as the session's standing goal. Called from
 /// the user-submit dispatch path only — continuations (source `Queue`)
 /// never reset the goal, so the counter survives the loop's own messages.
-pub fn on_user_message(session_id: &str, content: &str) {
+///
+/// `display_text` is the compact human-readable form of the user's message
+/// before pill/skill references are expanded (e.g. `speckit-implement
+/// [skill:/speckit-implement]` rather than the 13 KB SKILL.md body). When
+/// present, it is preferred as the goal text so the judge receives the
+/// user's *intent* — not multi-thousand-character expanded context — and
+/// truncation does not silently drop implementation instructions.
+pub fn on_user_message(session_id: &str, content: &str, display_text: Option<&str>) {
     let trimmed = content.trim();
     if trimmed.is_empty() {
         return;
     }
+
+    // Prefer display_text when it is a shorter, more focused
+    // representation of the same intent. This prevents skill-pill expansions
+    // (e.g. a 13 KB SKILL.md body) from replacing the actual goal sentence
+    // with truncated skill instructions that the judge cannot fully evaluate.
+    let goal_source = display_text
+        .map(str::trim)
+        .filter(|d| !d.is_empty() && d.len() < trimmed.len())
+        .unwrap_or(trimmed);
+
     save_state(&GoalState {
         session_id: session_id.to_string(),
-        goal_text: crate::utils::safe_truncate_chars_to_string(&trimmed, 8_000),
+        goal_text: crate::utils::safe_truncate_chars_to_string(&goal_source, 8_000),
         turns_used: 0,
         status: "active".to_string(),
     });
@@ -529,7 +546,7 @@ mod tests {
         #[test]
         fn user_message_sets_goal_and_resets_counter() {
             let _lock = prepare();
-            on_user_message("s_goal", "fix every failing test");
+            on_user_message("s_goal", "fix every failing test", None);
             let state = load_state("s_goal").expect("state");
             assert_eq!(state.goal_text, "fix every failing test");
             assert_eq!(state.turns_used, 0);
@@ -542,7 +559,7 @@ mod tests {
                 turns_used: 5,
                 status: "paused".to_string(),
             });
-            on_user_message("s_goal", "new goal");
+            on_user_message("s_goal", "new goal", None);
             let state = load_state("s_goal").expect("state");
             assert_eq!(state.goal_text, "new goal");
             assert_eq!(state.turns_used, 0);
@@ -552,16 +569,49 @@ mod tests {
         #[test]
         fn empty_user_message_is_ignored() {
             let _lock = prepare();
-            on_user_message("s_empty", "   ");
+            on_user_message("s_empty", "   ", None);
             assert!(load_state("s_empty").is_none());
         }
 
         #[test]
         fn clear_state_removes_row() {
             let _lock = prepare();
-            on_user_message("s_clear", "goal");
+            on_user_message("s_clear", "goal", None);
             clear_state("s_clear");
             assert!(load_state("s_clear").is_none());
+        }
+
+        #[test]
+        fn display_text_preferred_over_expanded_skill_content() {
+            let _lock = prepare();
+            // Simulate a pill-expanded user message: display_text is the short
+            // form the user typed; content is the expanded SKILL.md body.
+            let short_intent = "speckit-implement [skill:/speckit-implement]";
+            let expanded_content = format!(
+                "{}\n\n---\n**Referenced content (auto-expanded):**\n\n{}",
+                short_intent,
+                "x".repeat(12_000) // simulate large SKILL.md body
+            );
+            on_user_message(
+                "s_display",
+                &expanded_content,
+                Some(short_intent),
+            );
+            let state = load_state("s_display").expect("state");
+            // Goal text must reflect the user's intent, not the expanded body.
+            assert_eq!(state.goal_text, short_intent);
+        }
+
+        #[test]
+        fn display_text_ignored_when_longer_than_content() {
+            let _lock = prepare();
+            // If display_text is somehow longer (e.g. debug paths), fall back
+            // to the raw content so the goal is never empty.
+            let content = "short";
+            let longer_display = "a very long display text that exceeds content length";
+            on_user_message("s_longer", content, Some(longer_display));
+            let state = load_state("s_longer").expect("state");
+            assert_eq!(state.goal_text, content);
         }
     }
 }

--- a/src-tauri/crates/agent-core/src/state/commands/session/message.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/session/message.rs
@@ -174,7 +174,11 @@ pub(crate) async fn send_message_impl(
         TurnIntentBridgeSource::UserSubmit | TurnIntentBridgeSource::ForceSend
     ) && !is_resume
     {
-        crate::session::goal_loop::on_user_message(&session_id, &content);
+        crate::session::goal_loop::on_user_message(
+            &session_id,
+            &content,
+            display_text.as_deref(),
+        );
     }
 
     let effective_model = identity.model;


### PR DESCRIPTION
## Summary

- Skill pill expansion (~13 KB of `SKILL.md`) was being stored as the session's standing goal text
- The goal text is truncated at 8,000 chars, capturing only the YAML header — not the Outline section with actual implementation steps
- On token-quota continuation turns, the agent had no skill instructions in context and incorrectly marked tasks complete without executing them

## Root Cause

`on_user_message` received the already-expanded pill content as its `content` argument. The 8,000-character truncation then silently discarded everything after the YAML front-matter, leaving the judge with a goal that said nothing about *what* to implement.

## Fix

`on_user_message` now accepts a new `display_text: Option<&str>` parameter — the compact pre-expansion form typed by the user (e.g. `speckit-implement [skill:/speckit-implement]`). When `display_text` is shorter than the expanded content, it is used as the goal text instead, ensuring the judge always sees the user's *intent* rather than truncated skill instructions.

The `message.rs` dispatch path passes `display_text.as_deref()` through to `on_user_message`.

## Tests

Four unit tests added inline in `goal_loop.rs`:
1. `user_message_sets_goal_and_resets_counter` — updated for new signature
2. `user_message_overwrites_existing_state` — updated for new signature
3. `display_text_preferred_over_expanded_skill_content` — new: verifies short intent wins over large expanded body
4. `display_text_ignored_when_longer_than_content` — new: verifies fallback to raw content when display_text is longer

## Test Plan

- [ ] `cargo test -p agent_core` passes
- [ ] Manual: run `speckit-implement` with a skill pill and verify the implement step executes rather than being prematurely marked complete

Closes #52