### PR TITLE
fix(canvas): prevent canvas from reappearing in subsequent conversation rounds

### DIFF
--- a/src/engines/ChatPanel/blocks/CanvasInlineCard/__tests__/canvasVisibilityLifecycle.test.ts
+++ b/src/engines/ChatPanel/blocks/CanvasInlineCard/__tests__/canvasVisibilityLifecycle.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for canvas visibility lifecycle fixes (issue #188).
+ *
+ * Covers:
+ * - Canvas preview is only returned when sessionId matches and not dismissed
+ * - Passing null sessionId always returns null (used by non-streaming ChatVariant)
+ * - dismissCanvasAtNewTurn marks the entry as cardDismissed for the right session
+ * - A new turn ("running" status) triggers canvas dismissal
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { CanvasPreviewEntry } from "@src/store/session/canvasPreviewAtom";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeEntry(
+  overrides?: Partial<CanvasPreviewEntry>
+): CanvasPreviewEntry {
+  return {
+    sessionId: "session-1",
+    payload: {
+      mode: "html",
+      content: "<div>hello</div>",
+      eventId: "tool-call-abc",
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * Pure implementation of useCanvasPreviewForSession's payload derivation.
+ * Mirrors the hook's logic without React dependencies.
+ */
+function deriveCanvasPayload(
+  entry: CanvasPreviewEntry | null,
+  sessionId: string | null | undefined
+) {
+  if (!entry) return null;
+  if (!sessionId) return null;
+  if (entry.sessionId !== sessionId) return null;
+  if (entry.cardDismissed) return null;
+  return entry.payload;
+}
+
+/**
+ * Pure implementation of the dismissCanvasAtNewTurn updater.
+ * Mirrors the useSetAtom updater in useSessionSync.
+ */
+function dismissCanvasForSession(
+  prev: CanvasPreviewEntry | null,
+  sessionId: string
+): CanvasPreviewEntry | null {
+  if (!prev || prev.sessionId !== sessionId || prev.cardDismissed) return prev;
+  return { ...prev, cardDismissed: true };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe("canvas visibility lifecycle", () => {
+  describe("deriveCanvasPayload (mirrors useCanvasPreviewForSession logic)", () => {
+    it("returns payload for matching session with no dismissal", () => {
+      const entry = makeEntry();
+      expect(deriveCanvasPayload(entry, "session-1")).toEqual(entry.payload);
+    });
+
+    it("returns null when entry is null", () => {
+      expect(deriveCanvasPayload(null, "session-1")).toBeNull();
+    });
+
+    it("returns null when sessionId is null (non-streaming ChatVariant guard)", () => {
+      const entry = makeEntry();
+      expect(deriveCanvasPayload(entry, null)).toBeNull();
+    });
+
+    it("returns null when sessionId is undefined", () => {
+      const entry = makeEntry();
+      expect(deriveCanvasPayload(entry, undefined)).toBeNull();
+    });
+
+    it("returns null when sessionId does not match entry", () => {
+      const entry = makeEntry({ sessionId: "session-1" });
+      expect(deriveCanvasPayload(entry, "session-2")).toBeNull();
+    });
+
+    it("returns null when canvas is dismissed", () => {
+      const entry = makeEntry({ cardDismissed: true });
+      expect(deriveCanvasPayload(entry, "session-1")).toBeNull();
+    });
+
+    it("returns payload even when openedInSimulator is set (that flag is for pill only)", () => {
+      const entry = makeEntry({ openedInSimulator: true });
+      expect(deriveCanvasPayload(entry, "session-1")).toEqual(entry.payload);
+    });
+  });
+
+  describe("dismissCanvasForSession (mirrors dismissCanvasAtNewTurn updater)", () => {
+    it("sets cardDismissed: true for the matching session", () => {
+      const entry = makeEntry({ sessionId: "session-1" });
+      const result = dismissCanvasForSession(entry, "session-1");
+      expect(result?.cardDismissed).toBe(true);
+    });
+
+    it("preserves all other fields when dismissing", () => {
+      const entry = makeEntry({ sessionId: "session-1" });
+      const result = dismissCanvasForSession(entry, "session-1");
+      expect(result?.sessionId).toBe("session-1");
+      expect(result?.payload).toEqual(entry.payload);
+    });
+
+    it("does not modify entry for a different session", () => {
+      const entry = makeEntry({ sessionId: "session-1" });
+      const result = dismissCanvasForSession(entry, "session-2");
+      expect(result).toBe(entry);
+    });
+
+    it("does not modify entry when already dismissed", () => {
+      const entry = makeEntry({ cardDismissed: true });
+      const result = dismissCanvasForSession(entry, "session-1");
+      expect(result).toBe(entry);
+    });
+
+    it("returns null when called with null entry", () => {
+      const result = dismissCanvasForSession(null, "session-1");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("new-turn dismissal integration (onStatusChange('running'))", () => {
+    it("dismissCanvasAtNewTurn is invoked when status is 'running'", () => {
+      const dismissCanvasAtNewTurn = vi.fn();
+      const actions = {
+        setSessionContextTokens: vi.fn(),
+        setSessionContextUsage: vi.fn(),
+        setSessionContextBreakdown: vi.fn(),
+        setSessionRuntimeStatus: vi.fn(),
+        setSessionRuntimeError: vi.fn(),
+        setPendingCancel: vi.fn(),
+        setSessionRolledBack: vi.fn(),
+        dismissCanvasAtNewTurn,
+        setStreamingDeltaContent: vi.fn(),
+      };
+
+      // Simulate the onStatusChange("running") branch in sessionSyncStateHelpers
+      function simulateRunningStatus(sid: string) {
+        actions.setSessionRuntimeError(null);
+        actions.setSessionRolledBack(false);
+        actions.dismissCanvasAtNewTurn(sid);
+      }
+
+      simulateRunningStatus("session-1");
+
+      expect(dismissCanvasAtNewTurn).toHaveBeenCalledOnce();
+      expect(dismissCanvasAtNewTurn).toHaveBeenCalledWith("session-1");
+    });
+
+    it("a canvas from a prior round is invisible to the new streaming ChatVariant after dismissal", () => {
+      const priorEntry = makeEntry({
+        sessionId: "session-1",
+        payload: {
+          mode: "html",
+          content: "<div>old canvas</div>",
+          eventId: "tool-call-old",
+        },
+      });
+
+      // New turn starts → dismiss
+      const dismissed = dismissCanvasForSession(priorEntry, "session-1");
+
+      // New streaming ChatVariant reads the atom — should get null
+      const payload = deriveCanvasPayload(dismissed, "session-1");
+      expect(payload).toBeNull();
+    });
+
+    it("new canvas in the same round becomes visible after render_inline_canvas fires", () => {
+      const priorEntry = makeEntry({
+        sessionId: "session-1",
+        payload: {
+          mode: "html",
+          content: "<div>old canvas</div>",
+          eventId: "tool-call-old",
+        },
+        cardDismissed: true,
+      });
+
+      // New round's render_inline_canvas replaces the atom entry (no cardDismissed)
+      const newEntry: CanvasPreviewEntry = {
+        sessionId: "session-1",
+        payload: {
+          mode: "html",
+          content: "<div>new canvas</div>",
+          eventId: "tool-call-new",
+        },
+      };
+
+      expect(deriveCanvasPayload(priorEntry, "session-1")).toBeNull();
+      expect(deriveCanvasPayload(newEntry, "session-1")).toEqual(
+        newEntry.payload
+      );
+    });
+  });
+
+  describe("cross-session isolation", () => {
+    it("canvas from session-A does not leak into session-B's streaming view", () => {
+      const entry = makeEntry({ sessionId: "session-A" });
+      expect(deriveCanvasPayload(entry, "session-B")).toBeNull();
+    });
+
+    it("dismissing session-A canvas does not affect session-B entry", () => {
+      const entryA = makeEntry({ sessionId: "session-A" });
+      // dismissCanvasForSession is called with session-A's id but only modifies session-A
+      const afterDismissA = dismissCanvasForSession(entryA, "session-A");
+      expect(afterDismissA?.cardDismissed).toBe(true);
+
+      const entryB = makeEntry({ sessionId: "session-B" });
+      const afterDismissOnB = dismissCanvasForSession(entryB, "session-A");
+      expect(afterDismissOnB).toBe(entryB);
+      expect(afterDismissOnB?.cardDismissed).toBeUndefined();
+    });
+  });
+});

--- a/src/engines/ChatPanel/events/stream/agent-message/index.tsx
+++ b/src/engines/ChatPanel/events/stream/agent-message/index.tsx
@@ -171,8 +171,16 @@ const ChatVariant: React.FC<ChatVariantProps> = ({
   llmUsage,
   eventId,
 }) => {
-  const { payload: canvasPayload, dismiss: _dismissCanvas } =
-    useCanvasPreviewForSession(sessionId);
+  // Canvas preview from the global atom is only relevant for the live
+  // streaming message. Historical (non-streaming) messages already have
+  // their canvas rendered inline via CanvasInlineAdapter in the event list.
+  // Reading the global atom unconditionally caused re-shows: any time a new
+  // round started and openInSimulatorCanvas cleared cardDismissed, every
+  // historical ChatVariant instance would briefly re-render the old canvas.
+  const { payload: streamingCanvasPayload } = useCanvasPreviewForSession(
+    isStreaming ? sessionId : null
+  );
+  const canvasPayload = isStreaming ? streamingCanvasPayload : null;
 
   if (!content && !thinkingContent && !isStreaming && !canvasPayload)
     return null;

--- a/src/engines/SessionCore/sync/__tests__/sessionSyncStateHelpers.test.ts
+++ b/src/engines/SessionCore/sync/__tests__/sessionSyncStateHelpers.test.ts
@@ -58,6 +58,7 @@ function createActions(): SessionEventHandlerStateActions & {
     setSessionRuntimeError: vi.fn(),
     setPendingCancel: vi.fn(),
     setSessionRolledBack: vi.fn(),
+    dismissCanvasAtNewTurn: vi.fn(),
     setStreamingDeltaContent: vi.fn((update) => {
       actions.streamingMap =
         typeof update === "function" ? update(actions.streamingMap) : update;
@@ -194,6 +195,34 @@ describe("session sync state callbacks", () => {
     callbacks.onStatusChange?.("running");
 
     expect(markTurnRunning).toHaveBeenCalledWith("session-1");
+  });
+
+  it("calls dismissCanvasAtNewTurn with the session id when status is 'running'", () => {
+    const actions = createActions();
+    const callbacks = createSessionEventHandlerCallbacks(
+      "session-42",
+      actions,
+      vi.fn()
+    );
+
+    callbacks.onStatusChange?.("running");
+
+    expect(actions.dismissCanvasAtNewTurn).toHaveBeenCalledWith("session-42");
+  });
+
+  it("does not call dismissCanvasAtNewTurn for terminal statuses", () => {
+    const actions = createActions();
+    const callbacks = createSessionEventHandlerCallbacks(
+      "session-1",
+      actions,
+      vi.fn()
+    );
+
+    for (const status of ["completed", "failed", "cancelled"]) {
+      callbacks.onStatusChange?.(status);
+    }
+
+    expect(actions.dismissCanvasAtNewTurn).not.toHaveBeenCalled();
   });
 });
 

--- a/src/engines/SessionCore/sync/sessionSyncStateHelpers.ts
+++ b/src/engines/SessionCore/sync/sessionSyncStateHelpers.ts
@@ -68,6 +68,8 @@ export interface SessionEventHandlerStateActions {
   setStreamingDeltaContent: (
     update: SetStateAction<Map<string, StreamingDeltaContent>>
   ) => void;
+  /** Dismiss any existing canvas preview when a new agent turn starts. */
+  dismissCanvasAtNewTurn: (sessionId: string) => void;
 }
 
 const TERMINAL_HANDLER_STATUSES = new Set<string>([
@@ -214,6 +216,11 @@ export function createSessionEventHandlerCallbacks(
         actions.setSessionRuntimeError(null);
         eventStoreProxy.pinSession(sessionId);
         actions.setSessionRolledBack(false);
+        // Dismiss any leftover canvas from a previous round. The new round's
+        // canvas will re-populate the atom only when render_inline_canvas is
+        // called. Without this, the streaming ChatVariant briefly shows a
+        // stale canvas from a prior turn at the start of each new turn.
+        actions.dismissCanvasAtNewTurn(sessionId);
       }
     },
     onTokenUpdate: (tokens) => {

--- a/src/engines/SessionCore/sync/useSessionSync.ts
+++ b/src/engines/SessionCore/sync/useSessionSync.ts
@@ -16,6 +16,7 @@ import {
   streamingDeltaContentAtom,
 } from "@src/engines/SessionCore";
 import { createLogger } from "@src/hooks/logger";
+import { canvasPreviewAtom } from "@src/store/session/canvasPreviewAtom";
 import {
   type CliSessionStatus,
   isPendingCancelAtom,
@@ -89,6 +90,16 @@ export function useSessionSync(
   const setStreamRetryStatus = useSetAtom(streamRetryStatusAtom);
   const setStreamingDeltaContent = useSetAtom(streamingDeltaContentAtom);
   const setPendingPlanApprovals = useSetAtom(pendingPlanApprovalsAtom);
+  const setCanvasPreview = useSetAtom(canvasPreviewAtom);
+  const dismissCanvasAtNewTurn = useCallback(
+    (sid: string) => {
+      setCanvasPreview((prev) => {
+        if (!prev || prev.sessionId !== sid || prev.cardDismissed) return prev;
+        return { ...prev, cardDismissed: true };
+      });
+    },
+    [setCanvasPreview]
+  );
 
   const adapterRef = useRef<SessionAdapter | null>(null);
   const handlerRef = useRef<SessionEventHandler | null>(null);
@@ -167,6 +178,7 @@ export function useSessionSync(
       setPendingCancel,
       setSessionRolledBack,
       setStreamingDeltaContent,
+      dismissCanvasAtNewTurn,
     }),
     [
       setSessionContextTokens,
@@ -177,6 +189,7 @@ export function useSessionSync(
       setPendingCancel,
       setSessionRolledBack,
       setStreamingDeltaContent,
+      dismissCanvasAtNewTurn,
     ]
   );
 


### PR DESCRIPTION
## Summary
- Gate `useCanvasPreviewForSession` on `isStreaming` so historical ChatVariant instances never render the global canvas atom
- Add `dismissCanvasAtNewTurn` called on turn start ("running") to clear stale canvas from prior rounds before new streaming begins

## Root causes
Two bugs in `canvasPreviewAtom` (global singleton) lifecycle:
1. Historical (non-streaming) message components were reading the atom unconditionally — when a new round opened a canvas, all historical messages briefly showed it
2. On new turn start, the atom still held the previous round's canvas, causing a flash before the new `render_inline_canvas` fired (or persisting indefinitely if the new turn had no canvas)

## Issues
Closes #188

## Test plan
- [ ] 17 new unit tests in `canvasVisibilityLifecycle.test.ts` pass
- [ ] Manual: generate a canvas, continue conversation — canvas should not reappear in subsequent rounds
- [ ] Manual: start new streaming round — old canvas should not flash at turn start
- [ ] `pnpm test` passes with no new failures