### PR TITLE
fix(build): restore linux bundle target in fast parallel build

### DIFF
--- a/scripts/tauri/build-fast-parallel.cjs
+++ b/scripts/tauri/build-fast-parallel.cjs
@@ -291,7 +291,12 @@ async function main() {
     },
   });
 
-  const bundleTarget = process.platform === "darwin" ? "app" : "nsis";
+  const bundleTarget =
+    process.platform === "darwin"
+      ? "app"
+      : process.platform === "win32"
+        ? "nsis"
+        : "deb";
   const tauriArgs = ["build"];
   if (featureString.length > 0) {
     tauriArgs.push("--features", featureString);


### PR DESCRIPTION
Fixes #278.

`scripts/tauri/build-fast-parallel.cjs` selects the bundle target with a darwin/else branch, sending `nsis` to tauri on Linux where only `deb`/`rpm`/`appimage` are valid — so `pnpm run tauri:build:fast` exits with code 2 on every Linux machine.

This PR keeps the darwin (`app`) and win32 (`nsis`) behavior and falls back to `deb` for Linux/other platforms.

Verified on Ubuntu 22.04: full fast build completes, `ORG2_1.1.12_amd64.deb` bundle produced.

```
[build-fast-parallel] Phase 2: tauri bundle (assemble only)
    Finished 1 bundle at: .../target/dev-build/bundle/deb/ORG2_1.1.12_amd64.deb
[build-fast-parallel] Total: 207.3s
```