### PR TITLE
fix(providers): refresh fast model hints to current generations

### DIFF
--- a/src-tauri/crates/agent-core/src/core/providers/model_hints.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/model_hints.rs
@@ -53,11 +53,11 @@ pub fn fast_model_hint(parent_model: &str) -> String {
         || lower.contains("haiku")
         || lower.contains("opus")
     {
-        "anthropic/claude-3-5-haiku-20241022".to_string()
-    } else if lower.contains("gpt-4") || lower.contains("openai") {
-        "openai/gpt-4o-mini".to_string()
+        "anthropic/claude-haiku-4.5".to_string()
+    } else if lower.contains("gpt") || lower.contains("openai") {
+        "openai/gpt-5.4-mini".to_string()
     } else if lower.contains("gemini") {
-        "gemini/gemini-2.0-flash".to_string()
+        "gemini/gemini-3.1-flash".to_string()
     } else if lower.contains("deepseek") {
         "deepseek/deepseek-chat".to_string()
     } else {

--- a/src-tauri/crates/agent-core/src/core/providers/tests/registry_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/tests/registry_tests.rs
@@ -170,7 +170,7 @@ fn fast_model_hint_for_claude() {
 
 #[test]
 fn fast_model_hint_for_gpt() {
-    assert!(fast_model_hint("gpt-4o").contains("gpt-4o-mini"));
+    assert!(fast_model_hint("gpt-4o").contains("mini"));
 }
 
 #[test]


### PR DESCRIPTION
`fast_model_hint` is used for lightweight/side tasks, but the current hard-coded hints point at older model generations:

- Claude -> `claude-3-5-haiku-20241022`
- GPT/OpenAI -> `gpt-4o-mini`
- Gemini -> `gemini-2.0-flash`

This PR refreshes those hints to current fast generations and broadens the OpenAI predicate from only `gpt-4` to all `gpt*` model names:

- Claude -> `claude-haiku-4.5`
- OpenAI -> `gpt-5.4-mini`
- Gemini -> `gemini-3.1-flash`

Verified with `cargo test -p agent_core --lib -- fast_model_hint` (5 passed).