### PR TITLE
fix(providers): route official Claude OAuth to the official endpoint

### DIFF
--- a/src-tauri/crates/agent-core/src/core/providers/factory.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/factory.rs
@@ -506,6 +506,46 @@ fn resolve_protocol(spec: &ProviderSpec, cred: &ModelKey) -> ProviderProtocol {
     })
 }
 
+/// Routing (custom base URL + protocol) for a resolved credential.
+///
+/// Official Claude OAuth access tokens (`sk-ant-oat…`) authenticate only at
+/// the official Anthropic endpoint, so stale relay routing on the row — a
+/// `base_url` or `protocol: openai` left behind by an earlier third-party
+/// configuration of the same account — must not steer the request. Honoring
+/// it would ship the OAuth bearer token plus the Claude Code beta headers to
+/// a relay that rejects them with 401 (issue #276), or route the token
+/// through the Chat Completions client. Relay ClaudeCode credentials
+/// (non-`sk-ant-oat` session tokens) keep their stored routing untouched.
+/// Endpoint officialness is decided by key-vault's
+/// `is_official_anthropic_endpoint` so both crates stay in lockstep.
+fn resolve_credential_routing(
+    spec: &'static ProviderSpec,
+    cred: &ModelKey,
+) -> (Option<String>, ProviderProtocol) {
+    let official_claude_oauth = is_claude_oauth_key(cred)
+        && cred
+            .session_token
+            .as_deref()
+            .is_some_and(key_vault::commands::is_claude_official_oauth_token);
+    if !official_claude_oauth {
+        return (cred.base_url.clone(), resolve_protocol(spec, cred));
+    }
+
+    let custom_base_url = cred
+        .base_url
+        .clone()
+        .filter(|url| key_vault::commands::is_official_anthropic_endpoint(Some(url)));
+    if custom_base_url.is_none() && cred.base_url.is_some() {
+        tracing::warn!(
+            "[provider] Claude OAuth account '{}' carries non-official base_url {:?}; \
+             official OAuth tokens only authenticate at api.anthropic.com — ignoring it",
+            cred.id,
+            cred.base_url
+        );
+    }
+    (custom_base_url, ProviderProtocol::Anthropic)
+}
+
 fn resolve_provider_endpoint(
     spec: &ProviderSpec,
     custom_base_url: Option<&String>,
@@ -679,8 +719,8 @@ fn resolve_credentials(
     } else {
         AnthropicAuthMode::ApiKey
     };
-    let protocol = resolve_protocol(spec, &cred);
-    let api_base = resolve_provider_endpoint(spec, cred.base_url.as_ref(), protocol)?;
+    let (custom_base_url, protocol) = resolve_credential_routing(spec, &cred);
+    let api_base = resolve_provider_endpoint(spec, custom_base_url.as_ref(), protocol)?;
 
     tracing::info!(
         "[provider] Using credential '{}' (type={}, auth={:?}, provider={}, protocol={}, codex_oauth={}, claude_oauth={}, azure_proxy={}, api_base={:?})",
@@ -700,7 +740,7 @@ fn resolve_credentials(
         token,
         protocol,
         api_base,
-        custom_base_url: cred.base_url.clone(),
+        custom_base_url,
         is_codex_oauth,
         is_gemini_oauth,
         gemini_project_id: gemini_project_id(&cred),
@@ -1155,5 +1195,109 @@ mod tests {
             .expect_err("Zhipu Anthropic endpoint requires custom base URL");
 
         assert!(err.to_string().contains("no default Anthropic endpoint"));
+    }
+
+    fn claude_oauth_key_with_token(token: &str) -> ModelKey {
+        let mut key = ModelKey::new(ModelType::ClaudeCode);
+        key.auth_method = AuthMethod::Oauth;
+        key.session_token = Some(token.to_string());
+        key
+    }
+
+    #[test]
+    fn official_claude_oauth_ignores_stale_relay_routing() {
+        let spec =
+            registry::find_by_name(provider_id::ANTHROPIC).expect("Anthropic provider registered");
+        let mut key = claude_oauth_key_with_token("sk-ant-oat01-abc");
+        key.base_url = Some("https://relay.example.com/v1".to_string());
+        key.protocol = Some(ProviderProtocol::OpenAi);
+
+        let (custom_base_url, protocol) = resolve_credential_routing(spec, &key);
+        let api_base = resolve_provider_endpoint(spec, custom_base_url.as_ref(), protocol)
+            .expect("official endpoint should resolve");
+
+        assert_eq!(custom_base_url, None);
+        assert_eq!(protocol, ProviderProtocol::Anthropic);
+        assert_eq!(api_base.as_deref(), Some("https://api.anthropic.com/v1"));
+    }
+
+    #[test]
+    fn official_claude_oauth_keeps_explicit_official_base_url() {
+        let spec =
+            registry::find_by_name(provider_id::ANTHROPIC).expect("Anthropic provider registered");
+        let mut key = claude_oauth_key_with_token("sk-ant-oat01-abc");
+        key.base_url = Some("https://api.anthropic.com/v1".to_string());
+
+        let (custom_base_url, protocol) = resolve_credential_routing(spec, &key);
+
+        assert_eq!(
+            custom_base_url.as_deref(),
+            Some("https://api.anthropic.com/v1")
+        );
+        assert_eq!(protocol, ProviderProtocol::Anthropic);
+    }
+
+    #[test]
+    fn relay_claude_oauth_keeps_stored_routing_untouched() {
+        let spec =
+            registry::find_by_name(provider_id::ANTHROPIC).expect("Anthropic provider registered");
+        let mut key = claude_oauth_key_with_token("sk-relay-issued-token");
+        key.base_url = Some("https://relay.example.com/v1".to_string());
+        key.protocol = Some(ProviderProtocol::OpenAi);
+
+        let (custom_base_url, protocol) = resolve_credential_routing(spec, &key);
+
+        assert_eq!(
+            custom_base_url.as_deref(),
+            Some("https://relay.example.com/v1")
+        );
+        assert_eq!(protocol, ProviderProtocol::OpenAi);
+    }
+
+    #[test]
+    fn api_key_credential_routing_is_passthrough() {
+        let spec = registry::find_by_name(provider_id::ZHIPU).expect("Zhipu provider registered");
+        let mut key = ModelKey::new(ModelType::ZhipuApi);
+        key.api_key = Some("sk-zhipu".to_string());
+        key.protocol = Some(ProviderProtocol::Anthropic);
+        key.base_url = Some("https://proxy.example.com/anthropic".to_string());
+
+        let (custom_base_url, protocol) = resolve_credential_routing(spec, &key);
+
+        assert_eq!(
+            custom_base_url.as_deref(),
+            Some("https://proxy.example.com/anthropic")
+        );
+        assert_eq!(protocol, ProviderProtocol::Anthropic);
+    }
+
+    /// Lockstep guard: agent-core's official-endpoint decision must be exactly
+    /// key-vault's `is_official_anthropic_endpoint` (same discipline as
+    /// `effort_capability_stays_in_lockstep_with_key_vault`).
+    #[test]
+    fn official_endpoint_gate_stays_in_lockstep_with_key_vault() {
+        for (base_url, expected_official) in [
+            (None, true),
+            (Some("https://api.anthropic.com/v1"), true),
+            (Some("https://relay.example.com/v1"), false),
+        ] {
+            assert_eq!(
+                key_vault::commands::is_official_anthropic_endpoint(base_url),
+                expected_official,
+                "key-vault official-endpoint verdict changed for {base_url:?}; \
+                 resolve_credential_routing relies on it"
+            );
+
+            let spec = registry::find_by_name(provider_id::ANTHROPIC)
+                .expect("Anthropic provider registered");
+            let mut key = claude_oauth_key_with_token("sk-ant-oat01-abc");
+            key.base_url = base_url.map(str::to_string);
+            let (custom_base_url, _) = resolve_credential_routing(spec, &key);
+            assert_eq!(
+                custom_base_url.is_some(),
+                expected_official && base_url.is_some(),
+                "routing must drop exactly the non-official base_urls for {base_url:?}"
+            );
+        }
     }
 }

--- a/src-tauri/crates/key-vault/src/commands/crud.rs
+++ b/src-tauri/crates/key-vault/src/commands/crud.rs
@@ -7,6 +7,9 @@ use crate::key_store::{
     AuthMethod, DefaultVariant, HealthStatus, ModelKey, ModelType, ModelVariant, ProviderProtocol,
     KEY_SERVICE,
 };
+// Re-exported here so consumers keep the established
+// `key_vault::commands::` path (matching `model_supports_output_config_effort`).
+pub use crate::key_store::{is_claude_official_oauth_token, is_official_anthropic_endpoint};
 
 const CURSOR_NATIVE_FALLBACK_MODELS: &[&str] = &["composer-2"];
 
@@ -247,15 +250,32 @@ fn is_cursor_web_session_token(token: &str) -> bool {
     value.get("type").and_then(|value| value.as_str()) == Some("web")
 }
 
-/// Whether the account talks to an official Anthropic endpoint. A configured
-/// `base_url` means the traffic goes through a third-party relay/mirror whose
-/// gateway may reject `output_config`/effort — those accounts must behave
-/// exactly as before this feature.
-fn is_official_anthropic_endpoint(base_url: Option<&str>) -> bool {
-    match base_url.map(str::trim) {
-        None | Some("") => true,
-        Some(url) => url.starts_with("https://api.anthropic.com"),
+/// Drop stale relay routing from a ClaudeCode row that carries official
+/// Anthropic OAuth material.
+///
+/// Re-detecting Claude Code OAuth on top of an account row that was earlier
+/// configured for a third-party relay leaves the relay's `base_url` (and a
+/// possible `protocol: openai`) on the row, because `save_key` only
+/// overwrites fields present in the request. The Rust agent then sends the
+/// `sk-ant-oat…` bearer token to the relay, which 401s (issue #276). Official
+/// OAuth tokens have exactly one valid endpoint, so the relay routing state
+/// is unambiguously stale. Relay ClaudeCode accounts (non-`sk-ant-oat`
+/// tokens) are left untouched.
+fn normalize_claude_official_oauth_routing(entry: &mut ModelKey) {
+    if entry.model_type != ModelType::ClaudeCode
+        || entry.auth_method != AuthMethod::Oauth
+        || !entry
+            .session_token
+            .as_deref()
+            .is_some_and(is_claude_official_oauth_token)
+    {
+        return;
     }
+
+    if !is_official_anthropic_endpoint(entry.base_url.as_deref()) {
+        entry.base_url = None;
+    }
+    entry.protocol = None;
 }
 
 fn account_uses_anthropic_native_messages(entry: &ModelKey) -> bool {
@@ -927,6 +947,8 @@ pub async fn save_key(request: SaveKeyRequest) -> Result<KeyInfo, String> {
             entry.api_key = None;
         }
 
+        normalize_claude_official_oauth_routing(&mut entry);
+
         if entry.auth_method == AuthMethod::Oauth && received_oauth_material {
             entry.oauth_refresh_failure_count = 0;
             entry.last_oauth_refresh_failed_at = None;
@@ -1067,4 +1089,122 @@ pub async fn clipboard_write_text(text: String) -> Result<(), String> {
     })
     .await
     .map_err(|err| format!("Task join error: {}", err))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn official_anthropic_endpoint_accepts_empty_and_official_urls() {
+        assert!(is_official_anthropic_endpoint(None));
+        assert!(is_official_anthropic_endpoint(Some("")));
+        assert!(is_official_anthropic_endpoint(Some("  ")));
+        assert!(is_official_anthropic_endpoint(Some(
+            "https://api.anthropic.com"
+        )));
+        assert!(is_official_anthropic_endpoint(Some(
+            "https://api.anthropic.com/v1"
+        )));
+        assert!(is_official_anthropic_endpoint(Some(
+            "https://api.anthropic.com:443/v1"
+        )));
+        assert!(!is_official_anthropic_endpoint(Some(
+            "https://relay.example.com/v1"
+        )));
+        assert!(!is_official_anthropic_endpoint(Some(
+            "http://api.anthropic.com"
+        )));
+        // Lookalike hosts must not pass the boundary check.
+        assert!(!is_official_anthropic_endpoint(Some(
+            "https://api.anthropic.com.evil.example/v1"
+        )));
+        assert!(!is_official_anthropic_endpoint(Some(
+            "https://api.anthropic.community"
+        )));
+        assert!(!is_official_anthropic_endpoint(Some(
+            "https://api.anthropic.com@evil.example/"
+        )));
+        assert!(!is_official_anthropic_endpoint(Some(
+            "https://api.anthropic.com:pass@evil.example/"
+        )));
+    }
+
+    #[test]
+    fn official_claude_oauth_token_requires_oat_prefix() {
+        assert!(is_claude_official_oauth_token("sk-ant-oat01-abc"));
+        assert!(is_claude_official_oauth_token("  sk-ant-oat01-abc  "));
+        assert!(!is_claude_official_oauth_token("sk-ant-api03-abc"));
+        assert!(!is_claude_official_oauth_token("sk-relay-key"));
+        assert!(!is_claude_official_oauth_token(""));
+    }
+
+    fn claude_oauth_entry(token: &str) -> ModelKey {
+        let mut entry = ModelKey::new(ModelType::ClaudeCode);
+        entry.auth_method = AuthMethod::Oauth;
+        entry.session_token = Some(token.to_string());
+        entry
+    }
+
+    #[test]
+    fn official_oauth_save_drops_stale_relay_routing() {
+        let mut entry = claude_oauth_entry("sk-ant-oat01-abc");
+        entry.base_url = Some("https://relay.example.com/v1".to_string());
+        entry.protocol = Some(ProviderProtocol::OpenAi);
+
+        normalize_claude_official_oauth_routing(&mut entry);
+
+        assert_eq!(entry.base_url, None);
+        assert_eq!(entry.protocol, None);
+    }
+
+    #[test]
+    fn official_oauth_save_keeps_explicit_official_base_url() {
+        let mut entry = claude_oauth_entry("sk-ant-oat01-abc");
+        entry.base_url = Some("https://api.anthropic.com/v1".to_string());
+
+        normalize_claude_official_oauth_routing(&mut entry);
+
+        assert_eq!(
+            entry.base_url.as_deref(),
+            Some("https://api.anthropic.com/v1")
+        );
+    }
+
+    #[test]
+    fn relay_claude_oauth_save_keeps_relay_routing_untouched() {
+        let mut entry = claude_oauth_entry("sk-relay-issued-token");
+        entry.base_url = Some("https://relay.example.com/v1".to_string());
+        entry.protocol = Some(ProviderProtocol::OpenAi);
+
+        normalize_claude_official_oauth_routing(&mut entry);
+
+        assert_eq!(
+            entry.base_url.as_deref(),
+            Some("https://relay.example.com/v1")
+        );
+        assert_eq!(entry.protocol, Some(ProviderProtocol::OpenAi));
+    }
+
+    #[test]
+    fn non_claude_and_api_key_rows_are_never_normalized() {
+        let mut api_key_entry = ModelKey::new(ModelType::ClaudeCode);
+        api_key_entry.api_key = Some("sk-ant-oat01-misfiled".to_string());
+        api_key_entry.base_url = Some("https://relay.example.com/v1".to_string());
+        normalize_claude_official_oauth_routing(&mut api_key_entry);
+        assert_eq!(
+            api_key_entry.base_url.as_deref(),
+            Some("https://relay.example.com/v1")
+        );
+
+        let mut anthropic_entry = ModelKey::new(ModelType::AnthropicApi);
+        anthropic_entry.auth_method = AuthMethod::Oauth;
+        anthropic_entry.session_token = Some("sk-ant-oat01-abc".to_string());
+        anthropic_entry.base_url = Some("https://relay.example.com/v1".to_string());
+        normalize_claude_official_oauth_routing(&mut anthropic_entry);
+        assert_eq!(
+            anthropic_entry.base_url.as_deref(),
+            Some("https://relay.example.com/v1")
+        );
+    }
 }

--- a/src-tauri/crates/key-vault/src/key_store/agent_env_builder.rs
+++ b/src-tauri/crates/key-vault/src/key_store/agent_env_builder.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 
 use super::service::KeyService;
-use super::types::{AuthMethod, ModelType};
+use super::types::{
+    is_claude_official_oauth_token, is_official_anthropic_endpoint, AuthMethod, ModelType,
+};
 use core_types::providers::KIMI_CODE_URL_FRAGMENT;
 
 const ZENMUX_OPENAI_BASE_URL: &str = "https://zenmux.ai/api/v1";
@@ -81,7 +83,40 @@ impl KeyService {
                 } else if let Some(ref key) = entry.api_key {
                     env.insert("ANTHROPIC_API_KEY".to_string(), key.clone());
                 }
-                if let Some(ref url) = entry.base_url {
+                // Official Claude OAuth tokens (sk-ant-oat…) only authenticate
+                // at api.anthropic.com. A non-official base_url on such a row
+                // is stale relay state (issue #276) — exporting it would send
+                // the OAuth bearer to the relay, which 401s. Rows persisted
+                // before save_key started normalizing this still carry the
+                // stale URL, so the export path must guard too. Relay
+                // accounts (non-oat tokens) keep their base_url untouched.
+                let official_oauth = entry.auth_method == AuthMethod::Oauth
+                    && entry
+                        .session_token
+                        .as_deref()
+                        .is_some_and(is_claude_official_oauth_token);
+                if official_oauth
+                    && !is_official_anthropic_endpoint(
+                        env.get("ANTHROPIC_BASE_URL").map(String::as_str),
+                    )
+                {
+                    tracing::warn!(
+                        "[agent_env_builder] Claude OAuth key {} has a non-official ANTHROPIC_BASE_URL env var; \
+                         official OAuth tokens only authenticate at api.anthropic.com — dropping it",
+                        entry.id
+                    );
+                    env.remove("ANTHROPIC_BASE_URL");
+                }
+                let official_oauth_with_stale_base_url =
+                    official_oauth && !is_official_anthropic_endpoint(entry.base_url.as_deref());
+                if official_oauth_with_stale_base_url {
+                    tracing::warn!(
+                        "[agent_env_builder] Claude OAuth key {} carries non-official base_url {:?}; \
+                         official OAuth tokens only authenticate at api.anthropic.com — not exporting ANTHROPIC_BASE_URL",
+                        entry.id,
+                        entry.base_url
+                    );
+                } else if let Some(ref url) = entry.base_url {
                     env.insert("ANTHROPIC_BASE_URL".to_string(), url.clone());
                 } else if entry.model_type == ModelType::ZenmuxApi {
                     env.insert(

--- a/src-tauri/crates/key-vault/src/key_store/tests/tests.rs
+++ b/src-tauri/crates/key-vault/src/key_store/tests/tests.rs
@@ -630,6 +630,58 @@ fn test_claude_code_oauth_env_uses_auth_token_without_exporting_refresh_token() 
 }
 
 #[test]
+fn test_claude_code_official_oauth_env_drops_stale_relay_base_url() {
+    let temp_dir = tempdir().unwrap();
+    let service = KeyService::new(Some(temp_dir.path().to_path_buf()));
+
+    // A row persisted before save_key normalized routing: official OAuth
+    // token + relay base_url left behind by an earlier relay configuration
+    // (issue #276). The env export must not send the OAuth token there.
+    let mut claude_key = ModelKey::new(ModelType::ClaudeCode);
+    claude_key.auth_method = AuthMethod::Oauth;
+    claude_key.session_token = Some("sk-ant-oat01-abc".to_string());
+    claude_key.base_url = Some("https://relay.example.com/v1".to_string());
+    claude_key.env_vars.insert(
+        "ANTHROPIC_BASE_URL".to_string(),
+        "https://relay.example.com/v1".to_string(),
+    );
+    let key_id = claude_key.id.clone();
+    service.save_key(claude_key).unwrap();
+
+    let env = service.get_env_for_agent(&ModelType::ClaudeCode, Some(&key_id));
+    assert_eq!(
+        env.get("ANTHROPIC_AUTH_TOKEN").map(|v| v.as_str()),
+        Some("sk-ant-oat01-abc"),
+    );
+    assert!(!env.contains_key("ANTHROPIC_BASE_URL"));
+}
+
+#[test]
+fn test_claude_code_relay_oauth_env_keeps_relay_base_url() {
+    let temp_dir = tempdir().unwrap();
+    let service = KeyService::new(Some(temp_dir.path().to_path_buf()));
+
+    // Relay-issued token (not sk-ant-oat): the relay base_url is the
+    // account's real endpoint and must keep flowing to the CLI unchanged.
+    let mut claude_key = ModelKey::new(ModelType::ClaudeCode);
+    claude_key.auth_method = AuthMethod::Oauth;
+    claude_key.session_token = Some("sk-relay-issued-token".to_string());
+    claude_key.base_url = Some("https://relay.example.com/v1".to_string());
+    let key_id = claude_key.id.clone();
+    service.save_key(claude_key).unwrap();
+
+    let env = service.get_env_for_agent(&ModelType::ClaudeCode, Some(&key_id));
+    assert_eq!(
+        env.get("ANTHROPIC_AUTH_TOKEN").map(|v| v.as_str()),
+        Some("sk-relay-issued-token"),
+    );
+    assert_eq!(
+        env.get("ANTHROPIC_BASE_URL").map(|v| v.as_str()),
+        Some("https://relay.example.com/v1"),
+    );
+}
+
+#[test]
 fn test_gemini_oauth_env_exports_access_refresh_expiry_and_project() {
     let temp_dir = tempdir().unwrap();
     let service = KeyService::new(Some(temp_dir.path().to_path_buf()));

--- a/src-tauri/crates/key-vault/src/key_store/types.rs
+++ b/src-tauri/crates/key-vault/src/key_store/types.rs
@@ -550,3 +550,46 @@ impl ModelKey {
         })
     }
 }
+
+/// Whether the account talks to an official Anthropic endpoint. A configured
+/// `base_url` means the traffic goes through a third-party relay/mirror whose
+/// gateway may reject Anthropic-native request features (`output_config`/
+/// effort, OAuth bearer auth, beta headers) — those accounts must never
+/// receive them.
+///
+/// The prefix must end at a host boundary so lookalike hosts
+/// (e.g. `api.anthropic.com.evil.example`) don't classify as official.
+///
+/// Shared with agent-core's provider factory so both crates agree on what
+/// "official endpoint" means (same lockstep discipline as
+/// `model_supports_output_config_effort`).
+pub fn is_official_anthropic_endpoint(base_url: Option<&str>) -> bool {
+    const OFFICIAL_ORIGIN: &str = "https://api.anthropic.com";
+    match base_url.map(str::trim) {
+        None | Some("") => true,
+        Some(url) => match url.strip_prefix(OFFICIAL_ORIGIN) {
+            Some(rest) => match rest.as_bytes().first() {
+                None => true,
+                Some(b'/') | Some(b'?') => true,
+                // Allow an explicit port, but only digits up to the path —
+                // `:pass@evil.example/` must not read as official.
+                Some(b':') => {
+                    let port = &rest[1..];
+                    let port = &port[..port.find(['/', '?']).unwrap_or(port.len())];
+                    !port.is_empty() && port.bytes().all(|byte| byte.is_ascii_digit())
+                }
+                Some(_) => false,
+            },
+            None => false,
+        },
+    }
+}
+
+/// Whether `token` is an official Anthropic OAuth access token (Claude Code
+/// sign-in). These carry the `sk-ant-oat` prefix and only authenticate
+/// against the official Anthropic API — presenting one to a third-party
+/// relay gets it rejected as an unknown API key. Relay-issued ClaudeCode
+/// session tokens do not have this prefix.
+pub fn is_claude_official_oauth_token(token: &str) -> bool {
+    token.trim().starts_with("sk-ant-oat")
+}

--- a/src/scaffold/WizardSystem/variants/KeyVault/hooks/keyHelpers.test.ts
+++ b/src/scaffold/WizardSystem/variants/KeyVault/hooks/keyHelpers.test.ts
@@ -53,9 +53,50 @@ describe("keyHelpers", () => {
         raw_key_input: "",
         quota_info: undefined,
         available_models: ["composer-2", "claude-sonnet-4-6"],
+        model_context_lengths: {},
         enabled_models: ["claude-sonnet-4-6", "composer-2"],
         validated: true,
       },
     ]);
+  });
+
+  it("clears stale extracted api key and base URL when applying an OAuth detection", () => {
+    const updates: Partial<WizardData>[] = [];
+
+    const detectedKey: DetectedKey = {
+      id: "claude_code_oauth_local",
+      name: "Anthropic",
+      auth_method: "oauth",
+      session_token: "sk-ant-oat01-abc",
+      available_models: ["claude-fable-5"],
+      validated: true,
+    };
+
+    applyKey(detectedKey, {
+      onChange: (update) => updates.push(update),
+      setTokenDetected: () => {},
+      setCursorSessionToken: () => {},
+      setTokenError: () => {},
+      setShowKeySelection: () => {},
+      isCursor: false,
+      isOAuthAgent: true,
+      noValidTokenMsg: "No valid token",
+      validationFailedMsg: "Validation failed",
+    });
+
+    expect(updates).toHaveLength(1);
+    // Wizard state merges via spread ({ ...prev, ...update }), so the OAuth
+    // update must explicitly overwrite leftovers from an earlier api_key
+    // detection — otherwise submit() persists the relay base_url onto the
+    // OAuth account and the OAuth token gets sent to the relay (issue #276).
+    const previousDetection: Partial<WizardData> = {
+      extracted_api_key: "sk-old-relay-key",
+      extracted_base_url: "https://relay.example.com/v1",
+    };
+    const merged = { ...previousDetection, ...updates[0] };
+    expect(merged.extracted_api_key).toBeUndefined();
+    expect(merged.extracted_base_url).toBeUndefined();
+    expect(merged.oauth_session_token).toBe("sk-ant-oat01-abc");
+    expect(merged.auth_method).toBe("oauth");
   });
 });

--- a/src/scaffold/WizardSystem/variants/KeyVault/hooks/keyHelpers.ts
+++ b/src/scaffold/WizardSystem/variants/KeyVault/hooks/keyHelpers.ts
@@ -113,6 +113,12 @@ export function applyKey(
       oauth_session_token: sessionToken,
       cursor_session_token: "",
       raw_key_input: "",
+      // Clear leftovers from an earlier api_key detection/extraction in the
+      // same wizard session: submit() sends extracted_base_url verbatim, and
+      // a stale relay URL saved onto an OAuth account sends the OAuth token
+      // to the relay, which rejects it with 401 (issue #276).
+      extracted_api_key: undefined,
+      extracted_base_url: undefined,
       quota_info: quotaInfo,
       available_models: modelsAvailable,
       model_context_lengths: {},


### PR DESCRIPTION
Auto-detecting Claude Code OAuth on top of an account row that was earlier configured for a third-party relay left the relay's base_url (and a possible protocol=openai) on the row. Both the Rust agent and the CLI env builder then sent the sk-ant-oat bearer token to the relay, which rejected it with HTTP 401 and left the session stuck reconnecting.

Official OAuth access tokens (sk-ant-oat prefix) authenticate only at api.anthropic.com, so stale relay routing on such rows is unambiguously dead state:

- agent-core: resolve_credential_routing drops a non-official base_url and forces the Anthropic protocol for credentials carrying official OAuth tokens; relay-issued ClaudeCode credentials keep their stored routing untouched
- key-vault: save_key normalizes ClaudeCode rows with official OAuth material (clears stale relay base_url/protocol); get_env_for_agent applies the same guard for rows persisted before this fix so CLI sessions stop exporting ANTHROPIC_BASE_URL=<relay> next to the token
- key-vault: is_official_anthropic_endpoint now checks the host boundary (lookalike hosts such as api.anthropic.com.evil.example no longer classify as official) and is shared with agent-core in lockstep
- wizard: applyKey's OAuth branch clears extracted_api_key and extracted_base_url left over from an earlier api_key detection so they cannot ride into the saved OAuth account

Also aligns the pre-existing Cursor applyKey test with the model_context_lengths field the implementation already emits.

Fixes #276

Pre-commit hook ran. Total eslint: 0, total circular: 0

## Summary

-

## Test plan

-

## Submit checklist

- [ ] The PR is focused and has a scoped Conventional Commits title, such as `feat(scope): summary` or `fix(scope): summary`.
- [ ] I ran the relevant checks, or explained why they were not run.
- [ ] No secrets, private config, generated output, or unrelated formatting changes are included.
- [ ] Docs, screenshots, and locale updates are included when the change needs them.
