### PR TITLE
fix(key-vault): finalize provider endpoint switching

### DIFF
--- a/src-tauri/crates/key-vault/src/commands/registry/mod.rs
+++ b/src-tauri/crates/key-vault/src/commands/registry/mod.rs
@@ -81,7 +81,6 @@ pub struct AvailableAgent {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_setup_method: Option<String>,
     /// Setup methods available in the Key Vault GenericSetup wizard flow.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub supported_setup_methods: Vec<String>,
     pub popular: bool,
     /// Icon provider key for ModelIcon lookup (e.g., "cursor", "claude_code")

--- a/src/hooks/keyVault/useKeyValidation.ts
+++ b/src/hooks/keyVault/useKeyValidation.ts
@@ -40,6 +40,36 @@ function cleanInput(value?: string): string | undefined {
   return cleaned ? cleaned : undefined;
 }
 
+function buildValidationSignature({
+  agentType,
+  rawKeyInput,
+  cursorSessionToken,
+  baseUrl,
+  protocol,
+  testModel,
+}: {
+  agentType: ModelType;
+  rawKeyInput: string;
+  cursorSessionToken?: string;
+  baseUrl?: string;
+  protocol?: ProviderProtocol;
+  testModel?: string;
+}): string {
+  const cleanBaseUrl = cleanInput(baseUrl);
+  const credential =
+    rawKeyInput.trim() ||
+    (agentType === LOCAL_MODEL_PROVIDER && cleanBaseUrl ? "local-model" : "");
+
+  return JSON.stringify({
+    agentType,
+    credential,
+    cursorSessionToken: cleanInput(cursorSessionToken) ?? "",
+    baseUrl: cleanBaseUrl ?? "",
+    protocol: protocol ?? "",
+    testModel: cleanInput(testModel) ?? "",
+  });
+}
+
 /**
  * Quota shape carried back to the wizard. Either the strict-null Tauri
  * `QuotaInfo` or the legacy flat `QuotaSnapshot`.
@@ -190,7 +220,7 @@ export function useKeyValidation(
   const [extractedConfig, setExtractedConfig] =
     useState<ExtractedConfig | null>(null);
 
-  const lastValidatedKeyRef = useRef<string | null>(null);
+  const lastValidationSignatureRef = useRef<string | null>(null);
 
   const resetValidation = useCallback(() => {
     setKeyValidated(false);
@@ -201,15 +231,31 @@ export function useKeyValidation(
   }, []);
 
   useEffect(() => {
-    if (lastValidatedKeyRef.current === null && !keyValidated) return;
-    const cleanBaseUrl = cleanInput(baseUrl);
-    const currentValidationKey =
-      rawKeyInput.trim() ||
-      (agentType === LOCAL_MODEL_PROVIDER && cleanBaseUrl ? "local-model" : "");
-    if (keyValidated && currentValidationKey !== lastValidatedKeyRef.current) {
+    if (lastValidationSignatureRef.current === null && !keyValidated) return;
+    const currentValidationSignature = buildValidationSignature({
+      agentType,
+      rawKeyInput,
+      cursorSessionToken,
+      baseUrl,
+      protocol,
+      testModel,
+    });
+    if (
+      keyValidated &&
+      currentValidationSignature !== lastValidationSignatureRef.current
+    ) {
       resetValidation();
     }
-  }, [agentType, baseUrl, rawKeyInput, keyValidated, resetValidation]);
+  }, [
+    agentType,
+    baseUrl,
+    cursorSessionToken,
+    protocol,
+    rawKeyInput,
+    keyValidated,
+    resetValidation,
+    testModel,
+  ]);
 
   const validateKeyCb = useCallback(
     async (overrideTestModel?: unknown) => {
@@ -265,7 +311,14 @@ export function useKeyValidation(
         }
 
         if (result.valid) {
-          lastValidatedKeyRef.current = cleanRawKeyInput;
+          lastValidationSignatureRef.current = buildValidationSignature({
+            agentType,
+            rawKeyInput,
+            cursorSessionToken,
+            baseUrl,
+            protocol,
+            testModel: effectiveTestModel ?? testModel,
+          });
 
           const envVars =
             (result as { extracted_env_vars?: EnvVar[] }).extracted_env_vars ??

--- a/src/modules/MainApp/Integrations/KeyVault/hooks/useKeyVaultPage.ts
+++ b/src/modules/MainApp/Integrations/KeyVault/hooks/useKeyVaultPage.ts
@@ -232,23 +232,22 @@ export function useKeyVaultPage() {
           description,
         };
 
-        if (
-          account.modelType === "opencode" &&
-          baseUrl &&
-          baseUrl !== account.baseUrl
-        ) {
+        if (baseUrl && baseUrl !== account.baseUrl) {
           const fullKey = await getFullKey(account.modelType, account.id);
           if (!fullKey?.api_key) {
-            throw new Error("OpenCode account has no API key.");
+            throw new Error("Account has no API key.");
           }
           const validation = await validateKey(
             account.modelType,
             fullKey.api_key,
-            baseUrl
+            baseUrl,
+            undefined,
+            undefined,
+            account.protocol ?? undefined
           );
           if (!validation.valid) {
             throw new Error(
-              validation.message || "OpenCode endpoint validation failed."
+              validation.message || "Endpoint validation failed."
             );
           }
           request.base_url = baseUrl;


### PR DESCRIPTION
Follow-up to #293 after review.

Fixes:
- Invalidate API key validation when endpoint/protocol/session/test-model inputs change.
- Apply inline endpoint edits for every multi-endpoint provider, not only OpenCode.
- Always serialize supportedSetupMethods as an array so the Rust registry matches the TS RPC schema.

Checks run locally:
- git diff --check
- eslint src/hooks/keyVault/useKeyValidation.ts src/modules/MainApp/Integrations/KeyVault/hooks/useKeyVaultPage.ts
- cargo test -p key_vault setup_methods --lib
- cargo test -p key_vault provider_config::tests --lib