### PR TITLE
perf(renderer): split startup bundles

### DIFF
--- a/src/app/root/AppDeferredServices.tsx
+++ b/src/app/root/AppDeferredServices.tsx
@@ -17,81 +17,141 @@
  * - APICallPanelProvider      — DevTools API call inspector
  * - SecretCaptureModal        — out-of-band secret capture overlay
  */
-import React, { useEffect } from "react";
+import React from "react";
 
-import GlobalDragDrop from "@src/components/GlobalDragDrop";
-import { AutoIndexingProvider } from "@src/components/System";
-import { hydrateFromPersistence } from "@src/components/TerminalInteractive/bufferCache";
-import { useGitAutoFetch } from "@src/hooks/git";
 import { createLogger } from "@src/hooks/logger";
-import {
-  useUserPresenceSync,
-  useUserProfileSync,
-  useWindowFocusTracking,
-} from "@src/hooks/platform";
-import { useProcessReconciliation } from "@src/hooks/terminal";
-import { APICallPanelProvider } from "@src/modules/shared/DevTools/APICallPanel";
-import { AppUpdater } from "@src/scaffold/AppUpdater";
-import SecretCaptureModal from "@src/scaffold/SecretCaptureModal";
-import {
-  flushPendingWrites,
-  loadPersistedBuffers,
-  startAutoSave,
-  stopAutoSave,
-} from "@src/services/terminal";
 
 const log = createLogger("TerminalPersistence");
 
-const DeferredWindowFocusTracking: React.FC = () => {
-  useWindowFocusTracking();
-  return null;
-};
+const GlobalDragDrop = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "deferred-services" */ "@src/components/GlobalDragDrop"
+    )
+);
 
-const DeferredUserPresenceSync: React.FC = () => {
-  useUserPresenceSync();
-  return null;
-};
+const AutoIndexingProvider = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "deferred-services" */ "@src/components/System/AutoIndexingProvider"
+    )
+);
 
-const DeferredUserProfileSync: React.FC = () => {
-  useUserProfileSync();
-  return null;
-};
+const AppUpdater = React.lazy(() =>
+  import(
+    /* webpackChunkName: "deferred-services" */ "@src/scaffold/AppUpdater"
+  ).then((module) => ({ default: module.AppUpdater }))
+);
 
-const DeferredGitAutoFetch: React.FC = () => {
-  useGitAutoFetch();
-  return null;
-};
+const APICallPanelProvider = React.lazy(() =>
+  import(
+    /* webpackChunkName: "deferred-services" */ "@src/modules/shared/DevTools/APICallPanel"
+  ).then((module) => ({ default: module.APICallPanelProvider }))
+);
 
-const DeferredProcessReconciliation: React.FC = () => {
-  useProcessReconciliation();
-  return null;
-};
+const SecretCaptureModal = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "deferred-services" */ "@src/scaffold/SecretCaptureModal"
+    )
+);
 
-const DeferredTerminalPersistence: React.FC = () => {
-  useEffect(() => {
-    // Hydrate the in-memory buffer cache from disk on startup so terminals
-    // can restore their scrollback across app restarts.
-    loadPersistedBuffers()
-      .then((buffers) => hydrateFromPersistence(buffers))
-      .catch((error) => {
-        log.warn("[TerminalPersistence] Failed to load buffers:", error);
-      });
+const DeferredWindowFocusTracking = React.lazy(() =>
+  import(
+    /* webpackChunkName: "deferred-services" */ "@src/hooks/platform/useWindowFocusTracking"
+  ).then((module) => ({
+    default: function DeferredWindowFocusTracking() {
+      module.useWindowFocusTracking();
+      return null;
+    },
+  }))
+);
 
-    startAutoSave();
+const DeferredUserPresenceSync = React.lazy(() =>
+  import(
+    /* webpackChunkName: "deferred-services" */ "@src/hooks/platform/useUserPresenceSync"
+  ).then((module) => ({
+    default: function DeferredUserPresenceSync() {
+      module.useUserPresenceSync();
+      return null;
+    },
+  }))
+);
 
-    const handleBeforeUnload = () => {
-      void flushPendingWrites();
-    };
-    window.addEventListener("beforeunload", handleBeforeUnload);
+const DeferredUserProfileSync = React.lazy(() =>
+  import(
+    /* webpackChunkName: "deferred-services" */ "@src/hooks/platform/useUserProfileSync"
+  ).then((module) => ({
+    default: function DeferredUserProfileSync() {
+      module.useUserProfileSync();
+      return null;
+    },
+  }))
+);
 
-    return () => {
-      window.removeEventListener("beforeunload", handleBeforeUnload);
-      stopAutoSave();
-    };
-  }, []);
+const DeferredGitAutoFetch = React.lazy(() =>
+  import(
+    /* webpackChunkName: "deferred-services" */ "@src/hooks/git/useGitAutoFetch"
+  ).then((module) => ({
+    default: function DeferredGitAutoFetch() {
+      module.useGitAutoFetch();
+      return null;
+    },
+  }))
+);
 
-  return null;
-};
+const DeferredProcessReconciliation = React.lazy(() =>
+  import(
+    /* webpackChunkName: "deferred-services" */ "@src/hooks/terminal/useProcessReconciliation"
+  ).then((module) => ({
+    default: function DeferredProcessReconciliation() {
+      module.useProcessReconciliation();
+      return null;
+    },
+  }))
+);
+
+const DeferredTerminalPersistence = React.lazy(() =>
+  Promise.all([
+    import(
+      /* webpackChunkName: "deferred-services" */ "@src/components/TerminalInteractive/bufferCache"
+    ),
+    import(
+      /* webpackChunkName: "deferred-services" */ "@src/services/terminal/bufferPersistence"
+    ),
+  ]).then(([bufferCache, terminalPersistence]) => ({
+    default: function DeferredTerminalPersistence() {
+      React.useEffect(() => {
+        // Hydrate the in-memory buffer cache from disk on startup so
+        // terminals can restore their scrollback across app restarts.
+        terminalPersistence
+          .loadPersistedBuffers()
+          .then((buffers) => bufferCache.hydrateFromPersistence(buffers))
+          .catch((error) => {
+            log.warn("[TerminalPersistence] Failed to load buffers:", error);
+          });
+
+        terminalPersistence.startAutoSave();
+
+        const handleBeforeUnload = () => {
+          void terminalPersistence.flushPendingWrites();
+        };
+        window.addEventListener("beforeunload", handleBeforeUnload);
+
+        return () => {
+          window.removeEventListener("beforeunload", handleBeforeUnload);
+          terminalPersistence.stopAutoSave();
+        };
+      }, []);
+
+      return null;
+    },
+  }))
+);
+
+const DeferredServiceBoundary: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => <React.Suspense fallback={null}>{children}</React.Suspense>;
 
 export const AppDeferredServices: React.FC<{ ready: boolean }> = ({
   ready,
@@ -100,17 +160,39 @@ export const AppDeferredServices: React.FC<{ ready: boolean }> = ({
 
   return (
     <>
-      <GlobalDragDrop />
-      <DeferredWindowFocusTracking />
-      <DeferredUserPresenceSync />
-      <DeferredUserProfileSync />
-      <DeferredGitAutoFetch />
-      <DeferredProcessReconciliation />
-      <DeferredTerminalPersistence />
-      <AutoIndexingProvider />
-      <AppUpdater />
-      <APICallPanelProvider />
-      <SecretCaptureModal />
+      <DeferredServiceBoundary>
+        <GlobalDragDrop />
+      </DeferredServiceBoundary>
+      <DeferredServiceBoundary>
+        <DeferredWindowFocusTracking />
+      </DeferredServiceBoundary>
+      <DeferredServiceBoundary>
+        <DeferredUserPresenceSync />
+      </DeferredServiceBoundary>
+      <DeferredServiceBoundary>
+        <DeferredUserProfileSync />
+      </DeferredServiceBoundary>
+      <DeferredServiceBoundary>
+        <DeferredGitAutoFetch />
+      </DeferredServiceBoundary>
+      <DeferredServiceBoundary>
+        <DeferredProcessReconciliation />
+      </DeferredServiceBoundary>
+      <DeferredServiceBoundary>
+        <DeferredTerminalPersistence />
+      </DeferredServiceBoundary>
+      <DeferredServiceBoundary>
+        <AutoIndexingProvider />
+      </DeferredServiceBoundary>
+      <DeferredServiceBoundary>
+        <AppUpdater />
+      </DeferredServiceBoundary>
+      <DeferredServiceBoundary>
+        <APICallPanelProvider />
+      </DeferredServiceBoundary>
+      <DeferredServiceBoundary>
+        <SecretCaptureModal />
+      </DeferredServiceBoundary>
     </>
   );
 };

--- a/src/components/MarkDown/MarkDownImpl.tsx
+++ b/src/components/MarkDown/MarkDownImpl.tsx
@@ -24,7 +24,7 @@ import { isThemeCssPathDark } from "@src/config/appearance/globalThemes";
 import { getLanguageFromPath } from "@src/config/languageMap";
 import CanvasInlineCard from "@src/engines/ChatPanel/blocks/CanvasInlineCard";
 import ChatCodeBlock from "@src/engines/ChatPanel/blocks/CodeBlock";
-import { codeMirrorPrismTheme } from "@src/features/CodeMirror/themes";
+import { codeMirrorPrismTheme } from "@src/features/CodeMirror/themes/prism";
 import { useCopyCheck } from "@src/hooks/ui";
 import { themesAtom } from "@src/store";
 import { activeWorkspaceRootAtom } from "@src/store/workspace";

--- a/src/components/TerminalInteractive/bufferCache.ts
+++ b/src/components/TerminalInteractive/bufferCache.ts
@@ -9,7 +9,7 @@
 import {
   type PersistedBuffer,
   persistTerminalBuffer,
-} from "@src/services/terminal";
+} from "@src/services/terminal/bufferPersistence";
 
 /** Maximum number of terminal buffers to cache (prevents memory leaks) */
 const MAX_CACHE_SIZE = 10;

--- a/src/engines/ChatPanel/ChatPanelShell.tsx
+++ b/src/engines/ChatPanel/ChatPanelShell.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { MIN_WIDTH as CHAT_MIN_WIDTH } from "@src/engines/ChatPanel/config";
 import { VerticalResizeHandle } from "@src/scaffold/Resize";
-import { GUIDE_TARGETS } from "@src/scaffold/Tutorials";
+import { GUIDE_TARGETS } from "@src/scaffold/Tutorials/guideTargets";
 import type { ChatPanelTab } from "@src/store/chatPanel/chatPanelTabsAtom";
 
 import { ChatPanelTerminalContent } from "./ChatPanelTerminalContent";

--- a/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.tsx
+++ b/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.tsx
@@ -19,7 +19,7 @@ import type { ComposerInputRef } from "@src/components/ComposerInput";
 import { FileTreeHoverPreview } from "@src/components/FileTreePreview/exports";
 import UserActionButton from "@src/engines/ChatPanel/InputArea/components/UserActionButton";
 import { useSlashItemsCache } from "@src/engines/ChatPanel/hooks/useInputArea/useSlashItemsCache";
-import { EditorTabService } from "@src/services/workStation";
+import { EditorTabService } from "@src/services/workStation/EditorTabService";
 import { canvasPreviewAtom } from "@src/store/session/canvasPreviewAtom";
 import {
   type PinnedAction,

--- a/src/engines/ChatPanel/InputArea/hooks/useGitDiffActions.ts
+++ b/src/engines/ChatPanel/InputArea/hooks/useGitDiffActions.ts
@@ -15,7 +15,7 @@ import { useCallback, useMemo, useRef } from "react";
 
 import { useUserIntentSubmit } from "@src/engines/ChatPanel/hooks/useWorkspaceChat/useUserIntentSubmit";
 import { createLogger } from "@src/hooks/logger";
-import { WorkStationViewService } from "@src/services/workStation";
+import { WorkStationViewService } from "@src/services/workStation/WorkStationViewService";
 import {
   currentGitStatusAtom,
   workspaceGitStatusMapAtom,

--- a/src/engines/ChatPanel/hooks/useReplyQuestion.tsx
+++ b/src/engines/ChatPanel/hooks/useReplyQuestion.tsx
@@ -1,5 +1,5 @@
 import { useSetAtom } from "jotai";
-import { throttle } from "lodash";
+import throttle from "lodash/throttle";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useSearchParams } from "react-router-dom";

--- a/src/engines/Simulator/components/SimulatorContentArea/StateDisplays.tsx
+++ b/src/engines/Simulator/components/SimulatorContentArea/StateDisplays.tsx
@@ -10,7 +10,7 @@ import { memo } from "react";
 import { useTranslation } from "react-i18next";
 
 import { SPINNER_TOKENS } from "@src/config/spinnerTokens";
-import { CODEMIRROR_STYLE_NONCE } from "@src/features/CodeMirror/config/csp";
+import { CODEMIRROR_STYLE_NONCE } from "@src/features/CodeMirror/config/nonce";
 
 /** Idle state display - shown when no event is active (Gemini style) */
 export const IdleState = memo(() => {

--- a/src/features/CodeMirror/Diff/index.tsx
+++ b/src/features/CodeMirror/Diff/index.tsx
@@ -31,7 +31,7 @@ import { CustomScrollbar } from "@src/components/CustomScrollbar";
 import type { GitFileStatus } from "@src/config/gitStatus";
 import { createLogger } from "@src/hooks/logger";
 import { useEditorAppearanceSettings } from "@src/hooks/settings";
-import { EditorService } from "@src/services/workStation";
+import { EditorService } from "@src/services/workStation/EditorService";
 
 import { useSelectionExtension } from "../Editor/hooks/useSelectionExtension";
 import type { TextSelectionInfo } from "../Editor/types";

--- a/src/features/CodeMirror/Editor/hooks/useEditorServiceRegistration.ts
+++ b/src/features/CodeMirror/Editor/hooks/useEditorServiceRegistration.ts
@@ -7,7 +7,7 @@
 import { EditorView } from "@codemirror/view";
 import { useCallback, useEffect, useState } from "react";
 
-import { EditorService } from "@src/services/workStation";
+import { EditorService } from "@src/services/workStation/EditorService";
 
 export interface UseEditorServiceRegistrationOptions {
   /** Register with EditorService (default: true) */

--- a/src/features/CodeMirror/config/csp.ts
+++ b/src/features/CodeMirror/config/csp.ts
@@ -1,6 +1,6 @@
 import { EditorView } from "@codemirror/view";
 
-export const CODEMIRROR_STYLE_NONCE = "orgii-codemirror-style";
+import { CODEMIRROR_STYLE_NONCE } from "./nonce";
 
 export const codeMirrorCspNonceExtension = EditorView.cspNonce.of(
   CODEMIRROR_STYLE_NONCE

--- a/src/features/CodeMirror/config/index.ts
+++ b/src/features/CodeMirror/config/index.ts
@@ -5,7 +5,8 @@
  * Consumers can import from "./config" or "../config" as before.
  */
 
-export { CODEMIRROR_STYLE_NONCE, codeMirrorCspNonceExtension } from "./csp";
+export { CODEMIRROR_STYLE_NONCE } from "./nonce";
+export { codeMirrorCspNonceExtension } from "./csp";
 
 // Theme configuration
 export {

--- a/src/features/CodeMirror/config/nonce.ts
+++ b/src/features/CodeMirror/config/nonce.ts
@@ -1,0 +1,1 @@
+export const CODEMIRROR_STYLE_NONCE = "orgii-codemirror-style";

--- a/src/features/CodeViewer/DiffLineComponent.tsx
+++ b/src/features/CodeViewer/DiffLineComponent.tsx
@@ -13,7 +13,7 @@ import {
 import React from "react";
 import { Prism as PrismHighlighter } from "react-syntax-highlighter";
 
-import { codeMirrorPrismTheme } from "@src/features/CodeMirror/themes";
+import { codeMirrorPrismTheme } from "@src/features/CodeMirror/themes/prism";
 
 import type { DiffLine } from "./types";
 

--- a/src/features/CodeViewer/ModernCodeViewer.tsx
+++ b/src/features/CodeViewer/ModernCodeViewer.tsx
@@ -15,7 +15,7 @@ import { Prism as PrismHighlighter } from "react-syntax-highlighter";
 import { Components, Virtuoso } from "react-virtuoso";
 
 import { getLanguageFromPath } from "@src/config/languageMap";
-import { codeMirrorPrismTheme } from "@src/features/CodeMirror/themes";
+import { codeMirrorPrismTheme } from "@src/features/CodeMirror/themes/prism";
 import { getLanguageFromFilePath } from "@src/util/editor/extension";
 
 import "./index.scss";

--- a/src/features/CodeViewer/components/SplitRow.tsx
+++ b/src/features/CodeViewer/components/SplitRow.tsx
@@ -8,7 +8,7 @@ import { Check, Minus, Plus } from "lucide-react";
 import React from "react";
 import { Prism as PrismHighlighter } from "react-syntax-highlighter";
 
-import { codeMirrorPrismTheme } from "@src/features/CodeMirror/themes";
+import { codeMirrorPrismTheme } from "@src/features/CodeMirror/themes/prism";
 
 import type { AlignedLine } from "../types";
 import { CherryPickCheckbox } from "./CherryPickCheckbox";

--- a/src/hooks/code/useShikiHighlight.ts
+++ b/src/hooks/code/useShikiHighlight.ts
@@ -13,12 +13,123 @@
  */
 import { useAtomValue } from "jotai";
 import { useEffect, useState } from "react";
-import { createJavaScriptRegexEngine, getSingletonHighlighter } from "shiki";
+import { createBundledHighlighter, makeSingletonHighlighter } from "shiki/core";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 
 import { createLogger } from "@src/hooks/logger";
 import { isDarkThemeAtom } from "@src/store/ui/uiAtom";
 
 const logger = createLogger("ShikiHighlight");
+
+const shikiLanguages = {
+  css: () =>
+    import(/* webpackChunkName: "shiki-lang-css" */ "shiki/langs/css.mjs"),
+  diff: () =>
+    import(/* webpackChunkName: "shiki-lang-diff" */ "shiki/langs/diff.mjs"),
+  dockerfile: () =>
+    import(
+      /* webpackChunkName: "shiki-lang-dockerfile" */ "shiki/langs/dockerfile.mjs"
+    ),
+  go: () =>
+    import(/* webpackChunkName: "shiki-lang-go" */ "shiki/langs/go.mjs"),
+  html: () =>
+    import(/* webpackChunkName: "shiki-lang-html" */ "shiki/langs/html.mjs"),
+  javascript: () =>
+    import(
+      /* webpackChunkName: "shiki-lang-javascript" */ "shiki/langs/javascript.mjs"
+    ),
+  json: () =>
+    import(/* webpackChunkName: "shiki-lang-json" */ "shiki/langs/json.mjs"),
+  jsx: () =>
+    import(/* webpackChunkName: "shiki-lang-jsx" */ "shiki/langs/jsx.mjs"),
+  log: () =>
+    import(/* webpackChunkName: "shiki-lang-log" */ "shiki/langs/log.mjs"),
+  markdown: () =>
+    import(
+      /* webpackChunkName: "shiki-lang-markdown" */ "shiki/langs/markdown.mjs"
+    ),
+  python: () =>
+    import(
+      /* webpackChunkName: "shiki-lang-python" */ "shiki/langs/python.mjs"
+    ),
+  rust: () =>
+    import(/* webpackChunkName: "shiki-lang-rust" */ "shiki/langs/rust.mjs"),
+  shellscript: () =>
+    import(
+      /* webpackChunkName: "shiki-lang-shellscript" */ "shiki/langs/shellscript.mjs"
+    ),
+  sql: () =>
+    import(/* webpackChunkName: "shiki-lang-sql" */ "shiki/langs/sql.mjs"),
+  tsx: () =>
+    import(/* webpackChunkName: "shiki-lang-tsx" */ "shiki/langs/tsx.mjs"),
+  typescript: () =>
+    import(
+      /* webpackChunkName: "shiki-lang-typescript" */ "shiki/langs/typescript.mjs"
+    ),
+  yaml: () =>
+    import(/* webpackChunkName: "shiki-lang-yaml" */ "shiki/langs/yaml.mjs"),
+};
+
+const shikiThemes = {
+  "github-light": () =>
+    import(
+      /* webpackChunkName: "shiki-theme-github-light" */ "shiki/themes/github-light.mjs"
+    ),
+  "one-dark-pro": () =>
+    import(
+      /* webpackChunkName: "shiki-theme-one-dark-pro" */ "shiki/themes/one-dark-pro.mjs"
+    ),
+};
+
+type SupportedShikiLanguage = keyof typeof shikiLanguages;
+type SupportedShikiTheme = keyof typeof shikiThemes;
+
+const shikiLanguageAliases: Record<string, SupportedShikiLanguage> = {
+  bash: "shellscript",
+  cjs: "javascript",
+  js: "javascript",
+  jsonc: "json",
+  jsx: "jsx",
+  mjs: "javascript",
+  md: "markdown",
+  py: "python",
+  rs: "rust",
+  sh: "shellscript",
+  shell: "shellscript",
+  ts: "typescript",
+  tsx: "tsx",
+  txt: "log",
+  yml: "yaml",
+  zsh: "shellscript",
+};
+
+function resolveSupportedLanguage(lang: string): SupportedShikiLanguage | null {
+  const normalized = lang.trim().toLowerCase();
+  if (!normalized || normalized === "text" || normalized === "plain") {
+    return null;
+  }
+
+  if (normalized in shikiLanguages) {
+    return normalized as SupportedShikiLanguage;
+  }
+
+  return shikiLanguageAliases[normalized] ?? null;
+}
+
+function resolveSupportedTheme(
+  theme: string,
+  fallback: SupportedShikiTheme
+): SupportedShikiTheme {
+  return theme in shikiThemes ? (theme as SupportedShikiTheme) : fallback;
+}
+
+const getSingletonHighlighter = makeSingletonHighlighter(
+  createBundledHighlighter({
+    langs: shikiLanguages,
+    themes: shikiThemes,
+    engine: createJavaScriptRegexEngine,
+  })
+);
 
 // Resolve the highlighter once with the JS regex engine (no WASM) so webpack
 // production builds don't fail on `import('shiki/wasm')` dynamic imports that
@@ -26,7 +137,6 @@ const logger = createLogger("ShikiHighlight");
 const highlighterPromise = getSingletonHighlighter({
   langs: [],
   themes: [],
-  engine: createJavaScriptRegexEngine(),
 });
 
 // ============================================
@@ -138,13 +248,17 @@ export function useShikiHighlight(
   options: UseShikiHighlightOptions = {}
 ): string {
   const isDark = useAtomValue(isDarkThemeAtom);
-  const defaultTheme = isDark ? "one-dark-pro" : "github-light";
+  const defaultTheme: SupportedShikiTheme = isDark
+    ? "one-dark-pro"
+    : "github-light";
 
   const {
     lang = "shellscript",
     theme = defaultTheme,
     enabled = true,
   } = options;
+  const resolvedLang = resolveSupportedLanguage(lang);
+  const resolvedTheme = resolveSupportedTheme(theme, defaultTheme);
 
   // Store the resolved result as { key, html } so that stale HTML from a
   // previous theme/code/lang is never returned: if the stored key does not
@@ -156,16 +270,16 @@ export function useShikiHighlight(
 
   const cacheEligibility = getCacheEligibility(code);
   const cacheKey =
-    !code || !enabled || !cacheEligibility.cacheable
+    !code || !enabled || !resolvedLang || !cacheEligibility.cacheable
       ? ""
-      : getCacheKey(code, lang, theme);
+      : getCacheKey(code, resolvedLang, resolvedTheme);
   const resultKey =
-    !code || !enabled
+    !code || !enabled || !resolvedLang
       ? ""
-      : `${lang}:${theme}:${code.length}:${getStableHash(code)}`;
+      : `${resolvedLang}:${resolvedTheme}:${code.length}:${getStableHash(code)}`;
 
   useEffect(() => {
-    if (!code || !enabled) return;
+    if (!code || !enabled || !resolvedLang) return;
 
     const cached = cacheKey ? getCachedHighlight(cacheKey) : undefined;
     if (cached) {
@@ -183,9 +297,12 @@ export function useShikiHighlight(
 
     highlighterPromise
       .then(async (hl) => {
-        await hl.loadLanguage(lang as Parameters<typeof hl.loadLanguage>[0]);
-        await hl.loadTheme(theme as Parameters<typeof hl.loadTheme>[0]);
-        return hl.codeToHtml(code, { lang, theme });
+        await hl.loadLanguage(resolvedLang);
+        await hl.loadTheme(resolvedTheme);
+        return hl.codeToHtml(code, {
+          lang: resolvedLang,
+          theme: resolvedTheme,
+        });
       })
       .then((html) => {
         if (!cancelled) {
@@ -202,9 +319,17 @@ export function useShikiHighlight(
     return () => {
       cancelled = true;
     };
-  }, [cacheEligibility.bytes, cacheKey, code, enabled, lang, resultKey, theme]);
+  }, [
+    cacheEligibility.bytes,
+    cacheKey,
+    code,
+    enabled,
+    resolvedLang,
+    resolvedTheme,
+    resultKey,
+  ]);
 
-  if (!code || !enabled) return "";
+  if (!code || !enabled || !resolvedLang) return "";
   // Only return HTML when the key matches; otherwise fall back to plain text
   // so stale dark-theme colors are never painted on a light background.
   return result?.key === resultKey ? result.html : "";
@@ -237,23 +362,30 @@ export function getHighlightCacheSize(): number {
 export async function preWarmCache(
   snippets: Array<{ code: string; lang?: string; theme?: string }>
 ): Promise<void> {
-  const defaultTheme = "one-dark-pro";
+  const defaultTheme: SupportedShikiTheme = "one-dark-pro";
   const hl = await highlighterPromise;
 
   for (const snippet of snippets) {
-    const lang = snippet.lang || "shellscript";
-    const resolvedTheme = snippet.theme || defaultTheme;
+    const resolvedLang = resolveSupportedLanguage(
+      snippet.lang || "shellscript"
+    );
+    if (!resolvedLang) continue;
+
+    const resolvedTheme = resolveSupportedTheme(
+      snippet.theme || defaultTheme,
+      defaultTheme
+    );
     const cacheEligibility = getCacheEligibility(snippet.code);
     if (!cacheEligibility.cacheable) continue;
 
-    const cacheKey = getCacheKey(snippet.code, lang, resolvedTheme);
+    const cacheKey = getCacheKey(snippet.code, resolvedLang, resolvedTheme);
 
     if (!highlightCache.has(cacheKey)) {
       try {
-        await hl.loadLanguage(lang as Parameters<typeof hl.loadLanguage>[0]);
-        await hl.loadTheme(resolvedTheme as Parameters<typeof hl.loadTheme>[0]);
+        await hl.loadLanguage(resolvedLang);
+        await hl.loadTheme(resolvedTheme);
         const result = hl.codeToHtml(snippet.code, {
-          lang,
+          lang: resolvedLang,
           theme: resolvedTheme,
         });
         addToCache(cacheKey, result, cacheEligibility.bytes);

--- a/src/hooks/navigation/useGlobalShortcuts/useTabShortcuts.ts
+++ b/src/hooks/navigation/useGlobalShortcuts/useTabShortcuts.ts
@@ -12,7 +12,7 @@ import {
   createEditorSpotlightRequest,
 } from "@src/scaffold/GlobalSpotlight/openSpotlight";
 import { AppViewService } from "@src/services/app";
-import { WorkStationViewService } from "@src/services/workStation";
+import { WorkStationViewService } from "@src/services/workStation/WorkStationViewService";
 import { spotlightInitialQueryAtom, spotlightOpenAtom } from "@src/store";
 import { modelSelectorAtom } from "@src/store/ui/modelSelectorAtom";
 import {

--- a/src/hooks/workStation/editor/useCodeEditorEvents.ts
+++ b/src/hooks/workStation/editor/useCodeEditorEvents.ts
@@ -25,7 +25,7 @@ import { createEditorSpotlightRequest } from "@src/scaffold/GlobalSpotlight/open
 import { FileOperationsService } from "@src/services/file/FileOperationsService";
 import { PanelService } from "@src/services/panel";
 import { TerminalService } from "@src/services/terminal";
-import { WorkStationViewService } from "@src/services/workStation";
+import { WorkStationViewService } from "@src/services/workStation/WorkStationViewService";
 import { stationModeAtom } from "@src/store/ui/simulatorAtom";
 import {
   spotlightInitialQueryAtom,

--- a/src/hooks/workStation/tabs/useUrlPreviewEvents.ts
+++ b/src/hooks/workStation/tabs/useUrlPreviewEvents.ts
@@ -11,7 +11,7 @@ import { listen } from "@tauri-apps/api/event";
 import { useEffect, useRef } from "react";
 
 import { createLogger } from "@src/hooks/logger";
-import { EditorTabService } from "@src/services/workStation";
+import { EditorTabService } from "@src/services/workStation/EditorTabService";
 import { createUrlPreviewTab } from "@src/store/workstation/tabs/factories";
 import { isTauriDesktop } from "@src/util/platform/tauri";
 

--- a/src/modules/AppLogin/index.tsx
+++ b/src/modules/AppLogin/index.tsx
@@ -7,7 +7,7 @@ import Button from "@src/components/Button";
 import InlineAlert from "@src/components/InlineAlert";
 import { ROUTES } from "@src/config/routes";
 import { HOSTED_LOGIN_ENABLED, setAuthSkipped } from "@src/config/serviceAuth";
-import { CODEMIRROR_STYLE_NONCE } from "@src/features/CodeMirror/config/csp";
+import { CODEMIRROR_STYLE_NONCE } from "@src/features/CodeMirror/config/nonce";
 import {
   clearAuthStateCompletely,
   useServiceAuth,

--- a/src/modules/MainApp/SelectRepo/index.tsx
+++ b/src/modules/MainApp/SelectRepo/index.tsx
@@ -19,7 +19,7 @@ import { useNavigate } from "react-router-dom";
 
 import type { WorkspaceRecord } from "@src/api/tauri/workspace";
 import Input from "@src/components/Input";
-import { CODEMIRROR_STYLE_NONCE } from "@src/features/CodeMirror/config/csp";
+import { CODEMIRROR_STYLE_NONCE } from "@src/features/CodeMirror/config/nonce";
 import { useRepoSelection } from "@src/hooks/git/useRepoSelection";
 import { createLogger } from "@src/hooks/logger";
 import {

--- a/src/modules/MainApp/StartPage/components/AppGrid/index.tsx
+++ b/src/modules/MainApp/StartPage/components/AppGrid/index.tsx
@@ -22,7 +22,7 @@ import React, { useCallback, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { ACTION_ID, useActionSystemOptional } from "@src/ActionSystem";
-import { CODEMIRROR_STYLE_NONCE } from "@src/features/CodeMirror/config/csp";
+import { CODEMIRROR_STYLE_NONCE } from "@src/features/CodeMirror/config/nonce";
 import { useRegionLuminance } from "@src/hooks/theme/useRegionLuminance";
 import { appGridConfigAtom } from "@src/store/ui/appGridAtom";
 import { resolvedBackgroundConfigAtom } from "@src/store/ui/backgroundConfigAtom";

--- a/src/modules/SetupWalkthrough/index.tsx
+++ b/src/modules/SetupWalkthrough/index.tsx
@@ -14,7 +14,7 @@ import { useNavigate } from "react-router-dom";
 import Button from "@src/components/Button";
 import "@src/components/DevPassport/devpassport.css";
 import { ROUTES } from "@src/config/routes";
-import { CODEMIRROR_STYLE_NONCE } from "@src/features/CodeMirror/config/csp";
+import { CODEMIRROR_STYLE_NONCE } from "@src/features/CodeMirror/config/nonce";
 import { OnboardingLayout } from "@src/modules/shared/layouts";
 import { PanelFooter } from "@src/modules/shared/layouts/blocks";
 

--- a/src/modules/WorkStation/ActionSystem/registration/actions/editorActions.zod.ts
+++ b/src/modules/WorkStation/ActionSystem/registration/actions/editorActions.zod.ts
@@ -8,7 +8,7 @@ import { z } from "zod";
 import { ACTION_ID } from "@src/ActionSystem/actionIds";
 import { defineZodAction } from "@src/ActionSystem/schema/defineZodAction";
 import { getShortcutKeys } from "@src/config/keyboard/shortcutDisplay";
-import { EditorService } from "@src/services/workStation";
+import { EditorService } from "@src/services/workStation/EditorService";
 
 // ============================================
 // Editor Actions

--- a/src/modules/WorkStation/ActionSystem/registration/actions/editorTabActions.zod.ts
+++ b/src/modules/WorkStation/ActionSystem/registration/actions/editorTabActions.zod.ts
@@ -8,7 +8,7 @@ import { z } from "zod";
 import { ACTION_ID } from "@src/ActionSystem/actionIds";
 import { defineZodAction } from "@src/ActionSystem/schema/defineZodAction";
 import { getShortcutKeys } from "@src/config/keyboard/shortcutDisplay";
-import { EditorTabService } from "@src/services/workStation";
+import { EditorTabService } from "@src/services/workStation/EditorTabService";
 
 // ============================================
 // Editor Tab Actions

--- a/src/modules/WorkStation/ActionSystem/registration/actions/file/fileTabActions.zod.ts
+++ b/src/modules/WorkStation/ActionSystem/registration/actions/file/fileTabActions.zod.ts
@@ -8,7 +8,7 @@ import { z } from "zod";
 import { ACTION_ID } from "@src/ActionSystem/actionIds";
 import { defineZodAction } from "@src/ActionSystem/schema/defineZodAction";
 import { getShortcutKeys } from "@src/config/keyboard/shortcutDisplay";
-import { EditorTabService } from "@src/services/workStation";
+import { EditorTabService } from "@src/services/workStation/EditorTabService";
 
 const fileClose = defineZodAction(
   {

--- a/src/modules/WorkStation/ActionSystem/registration/actions/searchActions.zod.ts
+++ b/src/modules/WorkStation/ActionSystem/registration/actions/searchActions.zod.ts
@@ -12,7 +12,7 @@ import { defineZodAction } from "@src/ActionSystem/schema/defineZodAction";
 import { getShortcutKeys } from "@src/config/keyboard/shortcutDisplay";
 import { openEditorSpotlight } from "@src/scaffold/GlobalSpotlight/openSpotlight";
 import { SearchService } from "@src/services/search";
-import { WorkStationViewService } from "@src/services/workStation";
+import { WorkStationViewService } from "@src/services/workStation/WorkStationViewService";
 import type { SearchResultFile } from "@src/store/workstation/codeEditor/search";
 
 // ============================================

--- a/src/modules/WorkStation/ActionSystem/registration/actions/urlPreviewActions.zod.ts
+++ b/src/modules/WorkStation/ActionSystem/registration/actions/urlPreviewActions.zod.ts
@@ -8,7 +8,7 @@ import { z } from "zod";
 
 import { ACTION_ID } from "@src/ActionSystem/actionIds";
 import { defineZodAction } from "@src/ActionSystem/schema/defineZodAction";
-import { EditorTabService } from "@src/services/workStation";
+import { EditorTabService } from "@src/services/workStation/EditorTabService";
 import { createUrlPreviewTab } from "@src/store/workstation/tabs/factories";
 
 export const urlPreview = defineZodAction(

--- a/src/modules/WorkStation/AppShell/AppShellContent.tsx
+++ b/src/modules/WorkStation/AppShell/AppShellContent.tsx
@@ -6,11 +6,16 @@ import { Placeholder } from "@src/modules/shared/layouts/blocks";
 import { CODE_EDITOR_TOUR_TARGETS } from "@src/scaffold/Tutorials/codeEditorTourConfig";
 import { activeWorkStationTabAtom } from "@src/store/workstation/tabs";
 
-import ProjectManagerCore from "../../ProjectManager/ProjectManagerCore";
 import CodeEditor from "../CodeEditor";
 import { LspInstallPrompt } from "../CodeEditor/LspInstallPrompt";
 import { WORK_STATION_PLACEHOLDER_PAGE_BG_CLASS } from "../shared/tokens";
 
+const ProjectManagerCore = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "project-manager" */ "../../ProjectManager/ProjectManagerCore"
+    )
+);
 const Browser = React.lazy(() => import("../Browser"));
 const DatabaseManager = React.lazy(() => import("../DatabaseManager"));
 const OpsControl = React.lazy(() => import("@src/modules/MainApp/OpsControl"));
@@ -207,7 +212,9 @@ export function AppShellContent({
             className="h-full w-full"
             style={{ display: projectContentVisible ? "block" : "none" }}
           >
-            <ProjectManagerCore repoPath={repoPath} repoName={repoName} />
+            <Suspense fallback={<AppShellLoadingPlaceholder />}>
+              <ProjectManagerCore repoPath={repoPath} repoName={repoName} />
+            </Suspense>
           </div>
         )}
       </div>

--- a/src/modules/WorkStation/AppShell/index.tsx
+++ b/src/modules/WorkStation/AppShell/index.tsx
@@ -12,7 +12,7 @@ import {
   useDockFilterUrlSync,
   useWorkStationPanels,
 } from "@src/hooks/workStation";
-import { GUIDE_TARGETS } from "@src/scaffold/Tutorials";
+import { GUIDE_TARGETS } from "@src/scaffold/Tutorials/guideTargets";
 import { workstationActiveSessionIdAtom } from "@src/store/session";
 import {
   CHAT_PANEL_SURFACE_KIND,

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/CodeViewerContent/views/ContentView.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/CodeViewerContent/views/ContentView.tsx
@@ -21,7 +21,7 @@ import {
   UnsavedChangesBar,
 } from "@src/modules/WorkStation/shared";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
-import { EditorService } from "@src/services/workStation";
+import { EditorService } from "@src/services/workStation/EditorService";
 import {
   editorHighlightActiveLineAtom,
   editorLineNumbersAtom,

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitDiffContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitDiffContent/index.tsx
@@ -39,7 +39,7 @@ import {
 } from "@src/modules/WorkStation/shared";
 import { HUMANTOOLS_TEXT_KEYS } from "@src/modules/WorkStation/shared/textTokens";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
-import { EditorService } from "@src/services/workStation";
+import { EditorService } from "@src/services/workStation/EditorService";
 import {
   activeStationChatVisibleAtom,
   activeStatusBarCallbacksAtom,

--- a/src/modules/WorkStation/TabContent/renderers/canvasPreview.tsx
+++ b/src/modules/WorkStation/TabContent/renderers/canvasPreview.tsx
@@ -16,7 +16,7 @@ import {
   buildHtmlDocument,
   buildReactDocument,
 } from "@src/engines/ChatPanel/blocks/CanvasInlineCard/canvasBuilder";
-import { EditorTabService } from "@src/services/workStation";
+import { EditorTabService } from "@src/services/workStation/EditorTabService";
 import { canvasPreviewAtom } from "@src/store/session/canvasPreviewAtom";
 import { getCanvasPreviewTabId } from "@src/store/workstation/tabs/factories/canvasPreview";
 

--- a/src/modules/index.tsx
+++ b/src/modules/index.tsx
@@ -35,20 +35,14 @@ import { useBackgroundImage } from "@src/hooks/theme/useBackgroundImage";
 import { useOpenUrlInBrowser } from "@src/hooks/workStation/browser/useOpenUrlInBrowser";
 import { useUrlPreviewEvents } from "@src/hooks/workStation/tabs";
 import { useNarrowChatFocus } from "@src/hooks/workStation/useNarrowChatFocus";
-import WorkStationPage from "@src/modules/WorkStation";
 import { useGlobalBrowserWebviewLayering } from "@src/modules/WorkStation/Browser/hooks";
-import { SharedBrowserApp } from "@src/modules/WorkStation/Browser/shared";
+import { CODE_EDITOR_TOUR_EVENT } from "@src/scaffold/Tutorials/codeEditorTourConfig";
 import {
-  CODE_EDITOR_TOUR_EVENT,
-  CodeEditorTour,
   GENERAL_LAYOUT_TOUR_EVENT,
   GENERAL_LAYOUT_TOUR_TARGETS,
-  GUIDE_TARGETS,
-  GeneralLayoutTour,
-  GuideHighlightOverlay,
-  TUTORIALS_OPEN_EVENT,
-  TutorialsModal,
-} from "@src/scaffold/Tutorials";
+} from "@src/scaffold/Tutorials/generalLayoutTourConfig";
+import { GUIDE_TARGETS } from "@src/scaffold/Tutorials/guideTargets";
+import { TUTORIALS_OPEN_EVENT } from "@src/scaffold/Tutorials/tutorialRegistry";
 import { resolvedBackgroundConfigAtom } from "@src/store";
 import { useSyncStatusBridge } from "@src/store/sync";
 import {
@@ -90,6 +84,45 @@ import {
 } from "./shared/layouts/viewContainerTokens";
 import { useWorkStationPipelineBridge } from "./useWorkStationPipelineBridge";
 
+const WorkStationPage = React.lazy(
+  () => import(/* webpackChunkName: "workstation" */ "@src/modules/WorkStation")
+);
+
+const SharedBrowserApp = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "browser-shared" */ "@src/modules/WorkStation/Browser/shared/SharedBrowserApp"
+    )
+);
+
+const GuideHighlightOverlay = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "tutorials" */ "@src/scaffold/Tutorials/GuideHighlightOverlay"
+    )
+);
+
+const TutorialsModal = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "tutorials" */ "@src/scaffold/Tutorials/TutorialsModal"
+    )
+);
+
+const GeneralLayoutTour = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "tutorials" */ "@src/scaffold/Tutorials/GeneralLayoutTour"
+    )
+);
+
+const CodeEditorTour = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "tutorials" */ "@src/scaffold/Tutorials/CodeEditorTour"
+    )
+);
+
 /**
  * Main Orgii Component
  *
@@ -111,6 +144,10 @@ const BrowserEventBridge: React.FC = () => {
   useOpenUrlInBrowser();
   return null;
 };
+
+const WorkStationLoadingFallback: React.FC = () => (
+  <div className="h-full w-full bg-workstation-bg" />
+);
 
 const AppShell = () => {
   const location = useLocation();
@@ -417,7 +454,9 @@ const AppShell = () => {
     <TerminalProvider>
       <BrowserProvider>
         <BrowserEventBridge />
-        <SharedBrowserApp />
+        <React.Suspense fallback={null}>
+          <SharedBrowserApp />
+        </React.Suspense>
         <div
           className="relative flex h-full"
           data-guide-target={GUIDE_TARGETS.APP_ROOT}
@@ -466,14 +505,16 @@ const AppShell = () => {
                       : undefined
                   }
                 >
-                  <WorkStationPage
-                    isActive={isWorkStationViewActive}
-                    chatPanelFocused={effectiveChatFocus}
-                    isFullMode={
-                      globalLayoutMethod === "full" ||
-                      globalLayoutMethod === "compact"
-                    }
-                  />
+                  <React.Suspense fallback={<WorkStationLoadingFallback />}>
+                    <WorkStationPage
+                      isActive={isWorkStationViewActive}
+                      chatPanelFocused={effectiveChatFocus}
+                      isFullMode={
+                        globalLayoutMethod === "full" ||
+                        globalLayoutMethod === "compact"
+                      }
+                    />
+                  </React.Suspense>
                 </div>
               )}
 
@@ -488,21 +529,23 @@ const AppShell = () => {
               </div>
             </div>
           </AppLayout>
-          <GuideHighlightOverlay />
-          <TutorialsModal
-            open={tutorialsModalOpen}
-            onClose={() => setTutorialsModalOpen(false)}
-          />
-          <GeneralLayoutTour
-            key={`general-layout-tour-${generalLayoutTourRunId}`}
-            open={generalLayoutTourOpen}
-            onClose={() => setGeneralLayoutTourOpen(false)}
-          />
-          <CodeEditorTour
-            key={`code-editor-tour-${codeEditorTourRunId}`}
-            open={codeEditorTourOpen}
-            onClose={() => setCodeEditorTourOpen(false)}
-          />
+          <React.Suspense fallback={null}>
+            <GuideHighlightOverlay />
+            <TutorialsModal
+              open={tutorialsModalOpen}
+              onClose={() => setTutorialsModalOpen(false)}
+            />
+            <GeneralLayoutTour
+              key={`general-layout-tour-${generalLayoutTourRunId}`}
+              open={generalLayoutTourOpen}
+              onClose={() => setGeneralLayoutTourOpen(false)}
+            />
+            <CodeEditorTour
+              key={`code-editor-tour-${codeEditorTourRunId}`}
+              open={codeEditorTourOpen}
+              onClose={() => setCodeEditorTourOpen(false)}
+            />
+          </React.Suspense>
         </div>
       </BrowserProvider>
     </TerminalProvider>

--- a/src/modules/shared/components/index.ts
+++ b/src/modules/shared/components/index.ts
@@ -5,9 +5,7 @@
  */
 
 export { BackgroundLayer } from "./BackgroundLayer";
-export { default as MarkdownEditor } from "./MarkdownEditor";
 export type { MarkdownEditorProps } from "./MarkdownEditor";
-export { useMarkdownEditorTabs } from "./MarkdownEditor";
 export { default as SaveableTextarea } from "./SaveableTextarea";
 export type { SaveableTextareaProps } from "./SaveableTextarea";
 export { GlobalSpotlightPortal } from "./GlobalSpotlightPortal";

--- a/src/modules/shared/layouts/AppLayout.tsx
+++ b/src/modules/shared/layouts/AppLayout.tsx
@@ -37,7 +37,6 @@ import SessionSyncProvider from "@src/engines/SessionCore/sync/SessionSyncProvid
 import { SessionCreatorChatPanel } from "@src/features/SessionCreator/variants";
 import type { SessionCreatorChatPanelProps } from "@src/features/SessionCreator/variants/ChatPanel";
 import { dispatchWebviewLayoutChanged } from "@src/hooks/platform/useInlineWebview/webviewLayoutEvents";
-import SettingsSlot from "@src/modules/MainApp/Settings/SettingsSlot";
 import GlobalSessionSync from "@src/modules/shared/components/GlobalSessionSync";
 import { GlobalSpotlightPortal } from "@src/modules/shared/components/GlobalSpotlightPortal";
 import { GENERAL_LAYOUT_TOUR_TARGETS } from "@src/scaffold/Tutorials/GeneralLayoutTour";
@@ -56,6 +55,13 @@ import { GlobalModals } from "./GlobalModals";
 import { MainContentArea } from "./MainContentArea";
 
 export type ChatLayout = "inset" | "full" | "compact";
+
+const SettingsSlot = React.lazy(
+  () =>
+    import(
+      /* webpackChunkName: "settings-slot" */ "@src/modules/MainApp/Settings/SettingsSlot"
+    )
+);
 
 // ============================================
 // ADE-aware session creator slot
@@ -280,11 +286,13 @@ const AppLayoutComponent: React.FC<AppLayoutProps> = ({
   // component differs.
   const slotInner =
     chatPanelMode === "settings" ? (
-      <SettingsSlot
-        maximized={chatPanelMaximized}
-        position={chatPosition}
-        embedded={isFull}
-      />
+      <React.Suspense fallback={<div className="h-full w-full" />}>
+        <SettingsSlot
+          maximized={chatPanelMaximized}
+          position={chatPosition}
+          embedded={isFull}
+        />
+      </React.Suspense>
     ) : (
       <ChatPanel
         embedded={isFull}

--- a/src/scaffold/GlobalSpotlight/hooks/useSpotlight.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/useSpotlight.ts
@@ -29,7 +29,7 @@ import {
 } from "@src/scaffold/GlobalSpotlight/openSpotlight";
 import { AppViewService } from "@src/services/app";
 import { PanelService } from "@src/services/panel";
-import { WorkStationViewService } from "@src/services/workStation";
+import { WorkStationViewService } from "@src/services/workStation/WorkStationViewService";
 import { selectedRepoAtom } from "@src/store/repo";
 import { REPO_KIND } from "@src/store/repo/types";
 import { spotlightRecentActionsAtom } from "@src/store/ui/spotlightRecentActionsAtom";

--- a/src/scaffold/GlobalSpotlight/shell/SpotlightShellChrome.tsx
+++ b/src/scaffold/GlobalSpotlight/shell/SpotlightShellChrome.tsx
@@ -11,7 +11,7 @@ import { useAtomValue } from "jotai";
 import React, { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 
-import { CODEMIRROR_STYLE_NONCE } from "@src/features/CodeMirror/config/csp";
+import { CODEMIRROR_STYLE_NONCE } from "@src/features/CodeMirror/config/nonce";
 import { useOverlayLayer } from "@src/store/ui/overlayLayerAtom";
 import { spotlightPlacementAtom } from "@src/store/ui/uiAtom";
 

--- a/src/scaffold/NavigationSidebar/components/HoverAnimatedIcon.tsx
+++ b/src/scaffold/NavigationSidebar/components/HoverAnimatedIcon.tsx
@@ -1,7 +1,7 @@
 import type { LucideIcon } from "lucide-react";
 import React, { useCallback, useEffect, useRef } from "react";
 
-import { CODEMIRROR_STYLE_NONCE } from "@src/features/CodeMirror/config/csp";
+import { CODEMIRROR_STYLE_NONCE } from "@src/features/CodeMirror/config/nonce";
 
 type AnimationStrategy =
   | "stroke-draw"

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/statusIndicators.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/statusIndicators.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import { CODEMIRROR_STYLE_NONCE } from "@src/features/CodeMirror/config/csp";
+import { CODEMIRROR_STYLE_NONCE } from "@src/features/CodeMirror/config/nonce";
 
 export type StatusDotTone = "default" | "unread" | "asking";
 

--- a/src/scaffold/Tutorials/GeneralLayoutTour.tsx
+++ b/src/scaffold/Tutorials/GeneralLayoutTour.tsx
@@ -22,19 +22,12 @@ import { type DockFilter, dockFilterAtom } from "@src/store/workstation";
 import { useCurrentTheme } from "@src/util/ui/theme/themeUtils";
 import { getViewportSize } from "@src/util/ui/window/viewport";
 
-export const GENERAL_LAYOUT_TOUR_EVENT = "orgii:start-general-layout-tour";
+import { GENERAL_LAYOUT_TOUR_TARGETS } from "./generalLayoutTourConfig";
 
-export const GENERAL_LAYOUT_TOUR_TARGETS = {
-  sessionSidebar: "session-layout-session-sidebar",
-  chatPanel: "session-layout-chat-panel",
-  workstation: "session-layout-workstation",
-  stationModePill: "session-layout-station-mode-pill",
-  dock: "session-layout-dock",
-  dockAllTabs: "session-layout-dock-all-tabs",
-  dockCodeEditor: "session-layout-dock-code-editor",
-  dockBrowser: "session-layout-dock-browser",
-  dockProjects: "session-layout-dock-projects",
-} as const;
+export {
+  GENERAL_LAYOUT_TOUR_EVENT,
+  GENERAL_LAYOUT_TOUR_TARGETS,
+} from "./generalLayoutTourConfig";
 
 type GeneralLayoutTourTarget =
   (typeof GENERAL_LAYOUT_TOUR_TARGETS)[keyof typeof GENERAL_LAYOUT_TOUR_TARGETS];

--- a/src/scaffold/Tutorials/generalLayoutTourConfig.ts
+++ b/src/scaffold/Tutorials/generalLayoutTourConfig.ts
@@ -1,0 +1,13 @@
+export const GENERAL_LAYOUT_TOUR_EVENT = "orgii:start-general-layout-tour";
+
+export const GENERAL_LAYOUT_TOUR_TARGETS = {
+  sessionSidebar: "session-layout-session-sidebar",
+  chatPanel: "session-layout-chat-panel",
+  workstation: "session-layout-workstation",
+  stationModePill: "session-layout-station-mode-pill",
+  dock: "session-layout-dock",
+  dockAllTabs: "session-layout-dock-all-tabs",
+  dockCodeEditor: "session-layout-dock-code-editor",
+  dockBrowser: "session-layout-dock-browser",
+  dockProjects: "session-layout-dock-projects",
+} as const;

--- a/src/scaffold/Tutorials/tutorialRegistry.ts
+++ b/src/scaffold/Tutorials/tutorialRegistry.ts
@@ -1,5 +1,5 @@
-import { GENERAL_LAYOUT_TOUR_EVENT } from "./GeneralLayoutTour";
 import { CODE_EDITOR_TOUR_EVENT } from "./codeEditorTourConfig";
+import { GENERAL_LAYOUT_TOUR_EVENT } from "./generalLayoutTourConfig";
 
 export const TUTORIALS_OPEN_EVENT = "orgii:open-tutorials";
 

--- a/src/services/file/FileOperationsService.ts
+++ b/src/services/file/FileOperationsService.ts
@@ -18,7 +18,7 @@
 import { copyFile, mkdir, readDir } from "@tauri-apps/plugin-fs";
 
 import { createLogger } from "@src/hooks/logger";
-import { EditorTabService } from "@src/services/workStation";
+import { EditorTabService } from "@src/services/workStation/EditorTabService";
 import { fileClipboardAtom } from "@src/store/workstation/codeEditor/file/clipboardAtom";
 import { createFileTab } from "@src/store/workstation/tabs";
 import { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";

--- a/src/services/terminal/TerminalService.ts
+++ b/src/services/terminal/TerminalService.ts
@@ -16,7 +16,7 @@
 import { Command } from "@tauri-apps/plugin-shell";
 
 import { createLogger } from "@src/hooks/logger";
-import { WorkStationViewService } from "@src/services/workStation";
+import { WorkStationViewService } from "@src/services/workStation/WorkStationViewService";
 import {
   activeTerminalIdAtom,
   closeTerminalSessionAtom,

--- a/src/types/ambient/shiki-subpaths.d.ts
+++ b/src/types/ambient/shiki-subpaths.d.ts
@@ -1,0 +1,21 @@
+declare module "shiki/core" {
+  export { createBundledHighlighter, makeSingletonHighlighter } from "shiki";
+}
+
+declare module "shiki/engine/javascript" {
+  export { createJavaScriptRegexEngine } from "shiki";
+}
+
+declare module "shiki/langs/*.mjs" {
+  import type { LanguageRegistration } from "shiki";
+
+  const language: LanguageRegistration;
+  export default language;
+}
+
+declare module "shiki/themes/*.mjs" {
+  import type { ThemeRegistration } from "shiki";
+
+  const theme: ThemeRegistration;
+  export default theme;
+}

--- a/src/util/iframeCspNonce.ts
+++ b/src/util/iframeCspNonce.ts
@@ -30,7 +30,7 @@
  * (external `<link>` files), at which point the missing-nonce mistake on
  * iframe srcdoc shows up as completely unstyled previews.
  */
-import { CODEMIRROR_STYLE_NONCE } from "@src/features/CodeMirror/config/csp";
+import { CODEMIRROR_STYLE_NONCE } from "@src/features/CodeMirror/config/nonce";
 
 /**
  * The single CSP nonce token shared by every srcdoc producer in the app.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,7 +65,7 @@ module.exports = (env, argv) => {
     cache: {
       type: "filesystem",
       // Version the cache for faster invalidation
-      version: `${isProduction ? "prod" : "dev"}-6`,
+      version: `${isProduction ? "prod" : "dev"}-10`,
       buildDependencies: {
         config: [__filename],
       },
@@ -418,33 +418,90 @@ module.exports = (env, argv) => {
             splitChunks: {
               chunks: "all",
               maxInitialRequests: 25,
+              maxAsyncRequests: 30,
               minSize: 20000,
               cacheGroups: {
-                vendor: {
+                initialVendors: {
                   test: /[\\/]node_modules[\\/]/,
-                  name(module) {
-                    const packageName = module.context.match(
-                      /[\\/]node_modules[\\/](.*?)([\\/]|$)/
-                    )?.[1];
-                    const largePackages = [
-                      "react-dom",
-                      "lodash",
-                      "framer-motion",
-                    ];
-                    if (
-                      largePackages.some((pkg) => packageName?.startsWith(pkg))
-                    ) {
-                      return `vendor.${packageName.replace("@", "")}`;
-                    }
-                    return "vendors";
+                  name: "vendors",
+                  chunks: "initial",
+                  priority: 20,
+                  reuseExistingChunk: true,
+                },
+                asyncVendors: {
+                  test(module) {
+                    const moduleContext = module.context || "";
+                    const isShikiLazyGrammarModule =
+                      /[\\/]node_modules[\\/]\.pnpm[\\/]@shikijs\+(langs|themes)@/.test(
+                        moduleContext
+                      ) ||
+                      /[\\/]node_modules[\\/]@shikijs[\\/](langs|themes)[\\/]/.test(
+                        moduleContext
+                      );
+
+                    return (
+                      !isShikiLazyGrammarModule &&
+                      /[\\/]node_modules[\\/]/.test(moduleContext)
+                    );
                   },
-                  chunks: "all",
-                  priority: 10,
+                  name(module, chunks) {
+                    const moduleContext = module.context || "";
+                    const packageMatch =
+                      moduleContext.match(
+                        /[\\/]node_modules[\\/]\.pnpm[\\/][^\\/]+[\\/]node_modules[\\/](.*?)([\\/]|$)/
+                      ) ||
+                      moduleContext.match(
+                        /[\\/]node_modules[\\/](.*?)([\\/]|$)/
+                      );
+                    let packageName = packageMatch?.[1];
+                    if (packageName?.startsWith("@")) {
+                      const scopedPackageMatch =
+                        moduleContext.match(
+                          /[\\/]node_modules[\\/]\.pnpm[\\/][^\\/]+[\\/]node_modules[\\/](@[^\\/]+[\\/][^\\/]+)/
+                        ) ||
+                        moduleContext.match(
+                          /[\\/]node_modules[\\/](@[^\\/]+[\\/][^\\/]+)/
+                        );
+                      packageName = scopedPackageMatch?.[1] ?? packageName;
+                    }
+
+                    if (packageName) {
+                      return `async-vendors.${packageName
+                        .replace("@", "")
+                        .replace(/[\\/]/g, ".")
+                        .replace(/[^a-zA-Z0-9_.-]/g, "-")}`;
+                    }
+
+                    const namedChunks = chunks
+                      .map((chunk) => chunk.name)
+                      .filter(Boolean)
+                      .sort();
+
+                    if (namedChunks.length === 0) {
+                      return "async-vendors";
+                    }
+
+                    return `async-vendors.${namedChunks[0].replace(
+                      /[^a-zA-Z0-9_.-]/g,
+                      "-"
+                    )}`;
+                  },
+                  chunks: "async",
+                  priority: 15,
+                  reuseExistingChunk: true,
+                },
+                asyncCommon: {
+                  chunks: "async",
+                  minChunks: 2,
+                  priority: 8,
+                  reuseExistingChunk: true,
                 },
                 common: {
+                  chunks: "initial",
                   minChunks: 2,
                   priority: 5,
                   reuseExistingChunk: true,
+                  name: "common",
                 },
               },
             },


### PR DESCRIPTION
## Summary
- Split startup renderer bundles with lazy WorkStation, tutorial, browser shared, project manager, and deferred service boundaries.
- Move Shiki to explicit lazy language/theme imports so grammar chunks are loaded on demand.
- Tune webpack splitChunks to keep initial vendors separate from async vendor/package chunks.

## Performance notes
- Production build size: 36M.
- Largest initial JS chunks: vendors 5.7M, main 5.3M.
- Largest async chunks after split: elkjs 1.4M, mermaid 827K, cytoscape 442K, workstation 329K.

## Validation
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `npm run build`
- `node --check webpack.config.js`
- targeted ESLint on changed TS/TSX/d.ts files

Draft until runtime smoke testing on packaged Tauri is reviewed.