### PR TITLE
chore(source-control): polish scope picker menu

### DIFF
--- a/docs/frontend-ui-audit-2026-07-08/SourceControlScopeToolbar.md
+++ b/docs/frontend-ui-audit-2026-07-08/SourceControlScopeToolbar.md
@@ -1,0 +1,44 @@
+# Frontend UI Audit — SourceControlScopeToolbar
+
+**File:** `src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlScopeToolbar.tsx` (371 LOC)
+**Date:** 2026-07-08
+**Auditor:** Codex
+
+## D1 — Raw HTML vs Design System
+
+| Line | Element | Verdict | Reason | Suggested change |
+|---|---|---|---|---|
+| 143 | `DropdownItem` scope row | keep with reason | Uses existing DS dropdown row and adds DS icon/suffix props rather than raw button markup. | — |
+| 158 | `IconButton` remove action | keep with reason | Uses DS icon button with `aria-label`; custom absolute positioning is limited to overlay placement. | — |
+| 268 | `<input type="search">` existing dropdown search | keep with reason | Existing local Dropdown search pattern uses `DROPDOWN_CLASSES.searchInput`; this PR does not introduce the raw input. | — |
+
+## D2 — Arbitrary Tailwind Value vs Token
+
+| Line | Value | Verdict | Reason | Suggested change |
+|---|---|---|---|---|
+| — | — | keep with reason | No new arbitrary color/token values introduced by this PR. | — |
+
+## D3 — Hardcoded Sizes / Colors
+
+| Line | Value | Verdict | Reason | Suggested change |
+|---|---|---|---|---|
+| 258 | `max-w-[320px]` existing dropdown width cap | keep with reason | Existing constrained dropdown width; the PR only reuses the surrounding panel. | — |
+
+## D4 — Accessibility
+
+| Line | Element | Verdict | Reason | Suggested change |
+|---|---|---|---|---|
+| 147 | row icon | keep with reason | Decorative icon is inside the already named `DropdownItem` row. | — |
+| 164 | remove button `aria-label` | keep with reason | Icon-only destructive action has explicit accessible name. | — |
+| 297 | separator | keep with reason | Decorative separator is marked `aria-hidden`. | — |
+
+## D5 — Visual Patterns Observed
+
+- Pattern: selected dropdown suffix with optional stats and trailing checkmark — implemented once here using existing `DropdownSelectedCheck`.
+- Pattern: section separator and section label — uses `DROPDOWN_CLASSES.menuSeparatorInset` and `DROPDOWN_CLASSES.sectionLabel`.
+
+## Summary
+
+- 0 fixes recommended
+- 6 kept with documented reason
+- 0 abstract candidates

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlScopeToolbar.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlScopeToolbar.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, Search, Trash2 } from "lucide-react";
+import { ChevronRight, GitBranch, GitFork, Search, Trash2 } from "lucide-react";
 import React, { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -6,6 +6,7 @@ import type { GitWorktreeDiffSummary } from "@src/api/http/git/types";
 import DiffStatsBadge from "@src/components/DiffStatsBadge";
 import Dropdown from "@src/components/Dropdown";
 import DropdownItem from "@src/components/Dropdown/DropdownItem";
+import DropdownSelectedCheck from "@src/components/Dropdown/DropdownSelectedCheck";
 import {
   DROPDOWN_CLASSES,
   DROPDOWN_ITEM,
@@ -42,9 +43,6 @@ const BREADCRUMB_TONE_CLASS = {
   primary: "text-[12px] font-medium text-text-1",
   secondary: "text-[11px] text-text-2",
 } as const;
-
-const SCOPE_SECTION_LABEL =
-  "px-1.5 pb-0.5 pt-2 text-[11px] font-medium text-text-4 first:pt-1";
 
 const SCOPE_PICKER_REMOVE_BUTTON = [
   "absolute right-1 top-1/2 z-[1] -translate-y-1/2 bg-surface-hover",
@@ -83,8 +81,30 @@ function ScopePickerDiffStats({
   );
 }
 
+function ScopePickerItemSuffix({
+  selected,
+  summary,
+}: {
+  selected: boolean;
+  summary?: GitWorktreeDiffSummary | null;
+}) {
+  const stats = <ScopePickerDiffStats summary={summary} />;
+  if (!selected) return stats;
+
+  return (
+    <span className="flex shrink-0 items-center gap-2">
+      {stats}
+      <DropdownSelectedCheck />
+    </span>
+  );
+}
+
 function ScopePickerSectionLabel({ label }: { label: string }) {
-  return <div className={SCOPE_SECTION_LABEL}>{label}</div>;
+  return (
+    <div className={DROPDOWN_CLASSES.sectionLabel}>
+      {label.toLocaleUpperCase()}
+    </div>
+  );
 }
 
 function ScopePickerItem({
@@ -115,6 +135,8 @@ function ScopePickerItem({
   ]
     .filter(Boolean)
     .join("\n");
+  const ScopeIcon = kind === "worktree" ? GitFork : GitBranch;
+  const hasDiffStats = diffStatsFromSummary(summary) !== null;
 
   return (
     <div className="group/scope-row relative w-full">
@@ -122,8 +144,13 @@ function ScopePickerItem({
         selected={selected}
         showCheckmark={false}
         onClick={onSelect}
+        icon={<ScopeIcon size={DROPDOWN_ITEM.iconSize} strokeWidth={1.75} />}
         className="w-full"
-        suffix={<ScopePickerDiffStats summary={summary} />}
+        suffix={
+          selected || hasDiffStats ? (
+            <ScopePickerItemSuffix selected={selected} summary={summary} />
+          ) : undefined
+        }
       >
         <span title={title}>{label}</span>
       </DropdownItem>
@@ -266,6 +293,12 @@ export function SourceControlScopeToolbar({
         ) : null}
         {filteredWorktrees.length > 0 ? (
           <>
+            {showMainScope ? (
+              <div
+                aria-hidden="true"
+                className={DROPDOWN_CLASSES.menuSeparatorInset}
+              />
+            ) : null}
             {showMainScope ? (
               <ScopePickerSectionLabel
                 label={t("sourceControl.scope.worktrees")}


### PR DESCRIPTION
## Summary
- Add branch/worktree icons to Source Control scope picker rows.
- Use `DropdownSelectedCheck` and existing dropdown section/separator tokens.
- Only render stats suffix when selected or diff stats exist.
- Add frontend UI audit report.

## Audit
- `docs/frontend-ui-audit-2026-07-08/SourceControlScopeToolbar.md`
- Result: 0 fixes recommended, 6 kept with documented reason, 0 abstract candidates.

## Validation
- `./node_modules/.bin/tsc --noEmit --pretty false`
- targeted ESLint on `SourceControlScopeToolbar.tsx`

Draft until a quick visual pass confirms the menu spacing.