### PR TITLE
fix(build): keep Homebrew paths out of Cargo config

### DIFF
--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -1,11 +1,9 @@
 # Cargo build configuration
 
-# ── FFmpeg environment (ac-ffmpeg linking, ARM Homebrew) ──────────────────────
-[env]
-PKG_CONFIG_PATH    = { value = "/opt/homebrew/lib/pkgconfig:/opt/homebrew/opt/openssl@3/lib/pkgconfig", force = true }
-OPENSSL_DIR        = { value = "/opt/homebrew/opt/openssl@3",               force = true }
-FFMPEG_LIB_DIR     = { value = "/opt/homebrew/Cellar/ffmpeg/8.0.1_2/lib",  force = false }
-FFMPEG_INCLUDE_DIR = { value = "/opt/homebrew/Cellar/ffmpeg/8.0.1_2/include", force = false }
+# ── FFmpeg / OpenSSL environment ──────────────────────────────────────────────
+# Keep machine-local Homebrew paths out of the committed Cargo config.
+# Linux/CI builds must use system pkg-config defaults; macOS developers can set
+# OPENSSL_DIR or PKG_CONFIG_PATH in their personal shell/~/.cargo config.
 
 # ── Build performance ─────────────────────────────────────────────────────────
 # Cap parallel rustc processes to limit memory usage (~4-5 GB each).
@@ -59,9 +57,7 @@ incremental = false
 # ── macOS / Apple Silicon target ─────────────────────────────────────────────
 [target.aarch64-apple-darwin]
 rustflags = [
-  # FFmpeg library search paths (arm64 Homebrew)
-  "-L", "/opt/homebrew/lib",
-  "-L", "/opt/homebrew/Cellar/ffmpeg/8.0.1_2/lib",
+  # Add local Homebrew FFmpeg/OpenSSL library paths in personal cargo config if needed.
 ]
 # lld (LLVM linker) is ~3× faster than ld64 for incremental links but is a
 # machine-local optimization: the absolute Homebrew path is not present on CI


### PR DESCRIPTION
## Summary
- Remove machine-local Homebrew paths from the committed Cargo config.
- Keep Linux/CI builds on system `pkg-config` defaults instead of forcing `/opt/homebrew/...`.
- Leave macOS Homebrew customization to each developer's personal shell or `~/.cargo/config.toml`.

## Why
The current `src-tauri/.cargo/config.toml` forces Apple Silicon Homebrew paths globally:

```toml
PKG_CONFIG_PATH = "/opt/homebrew/lib/pkgconfig:/opt/homebrew/opt/openssl@3/lib/pkgconfig"
OPENSSL_DIR = "/opt/homebrew/opt/openssl@3"
```

On Linux/Docker this redirects `pkg-config` away from system paths and breaks crates such as `glib-sys` with errors like:

```text
The system library `glib-2.0` required by crate `glib-sys` was not found.
PKG_CONFIG_PATH contains:
  /opt/homebrew/lib/pkgconfig
  /opt/homebrew/opt/openssl@3/lib/pkgconfig
```

This makes Linux startup/build validation fail even when the correct Linux packages are available.

## Validation
Validated in a clean Ubuntu 22.04 Docker-based ORG2 build environment on Linux:

- `pnpm exec tsc --noEmit` ✅
- `cargo test -p agent_core channel_handler::slash --lib` ✅
- `cargo check -p agent_core` ✅

Commit was created with the repository pre-commit hook:

```text
Pre-commit hook ran. Total eslint: 4, total circular: 0
```
