### PR TITLE
fix(source-control): scope issue and PR state by repo

### DIFF
--- a/docs/architecture-audit-2026-07-08/source-control-repo-scope.md
+++ b/docs/architecture-audit-2026-07-08/source-control-repo-scope.md
@@ -1,0 +1,36 @@
+# Architecture Audit — Source Control Repo Scope
+
+**Date:** 2026-07-08
+**Scope:** Source Control issue/PR workstation atoms, sidebar/main-pane readers, issue detail tabs, ADE context collection.
+
+## Layers Covered
+
+| Layer | Verdict | Notes |
+|---|---|---|
+| 1 Compilation correctness | pending verification | `npm run typecheck` and targeted lint are run after this report is staged. |
+| 2 Dead code / structural dedupe | pass with fix | Swept legacy global atom reads. Production readers now use `atomFamily`; legacy exports remain only as default-scope compatibility aliases. |
+| 3 Naming consistency | pass | New `workstationRepoScopeKey` names the repo/path fallback explicitly. |
+| 4 Semantic overloading | pass | "scope" is limited to workstation repo state, not UI filter scope. |
+| 5 Default branch analysis | pass with note | Fallback is `repo:<repoId>` -> `path:<repoPath>` -> `default`; API calls keep their existing `"default"` repo id fallback separately. |
+| 6 Cross-domain leakage | pass | Repo-scoped state remains in workstation code-editor atoms; ADE collector only reads the active workspace scope. |
+| 7 New developer confusion | pass with fix | Default-scope legacy exports now alias the corresponding family atom instead of being independent atoms. |
+| 8 Wire protocol | not applicable | No serialized payload shape changed; repo id/path request arguments are preserved. |
+| 9 Init parity | pass | Sidebar, main pane, issue detail tab, Manage Issues handoff, and ADE collector all derive a scope key before reading/writing issue/PR state. |
+| 10 Resolver symmetry | pass with fix | Issue and PR state families use the same repo id/path fallback chain, and each family instance receives its own initial object. |
+
+## Sweeps
+
+| Sweep | Result |
+|---|---|
+| Legacy global atom reads | No production reads remain outside compatibility exports and docs/test notes. |
+| Scope key propagation | `useWorkstationPr`, `useWorkstationIssues`, Source Control sidebar/main pane, issue detail tab, Manage Issues handoff, and ADE context collector all derive scoped atoms. |
+| API repo id fallback | Preserved existing `repoId ?? "default"` for backend calls while state scoping can still fall back to repo path. |
+
+## Fixes Landed From Audit
+
+- Converted legacy PR/issue callback/list exports to default-scope family aliases for consistent compatibility behavior.
+- Cloned family initial objects/arrays per scope to avoid shared initial references.
+
+## Residual Notes
+
+- `workstationSelectedPrAtom` still has a TODO referencing future atom-family migration, but it is a separate selected-PR detail surface and not part of this issue/PR list-state split.

--- a/src/engines/ChatPanel/panels/ManageIssuesPanelView.tsx
+++ b/src/engines/ChatPanel/panels/ManageIssuesPanelView.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useAtom, useAtomValue, useSetAtom, useStore } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import {
   CheckCircle2,
@@ -77,7 +77,8 @@ import {
 import { REPO_KIND, reposAtom, selectedRepoPathAtom } from "@src/store/repo";
 import type { Repo } from "@src/store/repo/types";
 import { addToAgentAtom } from "@src/store/ui/addToAgentAtom";
-import { workstationSelectedIssueAtom } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationSelectedIssueAtomFamily } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationRepoScopeKey } from "@src/store/workstation/codeEditor/workstationPrAtom";
 import { createGitHubIssueDetailTab } from "@src/store/workstation/tabs";
 import { openExternalLink } from "@src/util/platform/ipcRenderer";
 
@@ -1097,7 +1098,7 @@ const ManageIssuesPanelView: React.FC = () => {
   const repos = useAtomValue(reposAtom);
   const selectedRepoPath = useAtomValue(selectedRepoPathAtom);
   const [selectedRepo, setSelectedRepo] = useAtom(manageIssuesSelectedRepoAtom);
-  const setSelectedIssue = useSetAtom(workstationSelectedIssueAtom);
+  const store = useStore();
   const setAddToAgent = useSetAtom(addToAgentAtom);
   const { openTab } = useWorkStationTabs();
   const [repoSources, setRepoSources] = useState<GitHubRepoSource[]>([]);
@@ -1587,7 +1588,10 @@ const ManageIssuesPanelView: React.FC = () => {
 
   const handleOpenIssueInMyStation = useCallback(
     (issue: ManagedIssueItem) => {
-      setSelectedIssue({
+      const selectedIssueAtom = workstationSelectedIssueAtomFamily(
+        workstationRepoScopeKey(undefined, issue.repoPath)
+      );
+      store.set(selectedIssueAtom, {
         issue: issue.rawIssue,
         comments: [],
         loading: false,
@@ -1609,7 +1613,7 @@ const ManageIssuesPanelView: React.FC = () => {
           remoteUrl: issue.remoteUrl,
           issueNumber: issue.id,
         });
-        setSelectedIssue((current) => {
+        store.set(selectedIssueAtom, (current) => {
           if (current.issue?.html_url !== issue.rawIssue.html_url) {
             return current;
           }
@@ -1622,7 +1626,7 @@ const ManageIssuesPanelView: React.FC = () => {
         });
       })();
     },
-    [openTab, setSelectedIssue]
+    [openTab, store]
   );
 
   const handleCloseChatIssue = useCallback(async () => {

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/index.tsx
@@ -19,9 +19,10 @@ import {
 } from "@src/modules/WorkStation/shared";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
 import {
-  workstationIssueCallbackAtom,
-  workstationSelectedIssueAtom,
+  workstationIssueCallbackAtomFamily,
+  workstationSelectedIssueAtomFamily,
 } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationRepoScopeKey } from "@src/store/workstation/codeEditor/workstationPrAtom";
 import type { PrIdentity } from "@src/store/workstation/codeEditor/workstationSelectedPrAtom";
 import type { SourceControlHistorySelection } from "@src/store/workstation/tabs";
 import type { GitFile } from "@src/types/git/types";
@@ -79,8 +80,13 @@ const SourceControlMainContent: React.FC<SourceControlMainContentProps> = ({
   collapseAllSignal,
   emptyFocusActions,
 }) => {
-  const selectedIssueState = useAtomValue(workstationSelectedIssueAtom);
-  const issueCallbacks = useAtomValue(workstationIssueCallbackAtom);
+  const scopeKey = workstationRepoScopeKey(repoId, repoPath);
+  const selectedIssueState = useAtomValue(
+    workstationSelectedIssueAtomFamily(scopeKey)
+  );
+  const issueCallbacks = useAtomValue(
+    workstationIssueCallbackAtomFamily(scopeKey)
+  );
 
   const handleCloseIssue = useCallback(() => {
     if (selectedIssueState.issue && issueCallbacks.closeIssue) {

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainPane.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainPane.tsx
@@ -17,9 +17,10 @@ import type { QuickAction } from "@src/modules/WorkStation/shared";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
 import { sourceControlSessionFilterAtom } from "@src/store/workstation/codeEditor/sourceControlSessionFilterAtom";
 import {
-  workstationIssueCallbackAtom,
-  workstationSelectedIssueAtom,
+  workstationIssueCallbackAtomFamily,
+  workstationSelectedIssueAtomFamily,
 } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationRepoScopeKey } from "@src/store/workstation/codeEditor/workstationPrAtom";
 import type { GitFile } from "@src/types/git/types";
 
 import {
@@ -68,8 +69,13 @@ const SourceControlMainPane: React.FC<SourceControlMainPaneProps> = ({
   const sourceControlSessionFilter = useAtomValue(
     sourceControlSessionFilterAtom
   );
-  const selectedIssueState = useAtomValue(workstationSelectedIssueAtom);
-  const issueCallbacks = useAtomValue(workstationIssueCallbackAtom);
+  const scopeKey = workstationRepoScopeKey(repoId, repoPath);
+  const selectedIssueState = useAtomValue(
+    workstationSelectedIssueAtomFamily(scopeKey)
+  );
+  const issueCallbacks = useAtomValue(
+    workstationIssueCallbackAtomFamily(scopeKey)
+  );
 
   const handleCloseIssue = useCallback(() => {
     if (selectedIssueState.issue && issueCallbacks.closeIssue) {

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/index.tsx
@@ -62,7 +62,8 @@ import {
   SOURCE_CONTROL_ALL_SESSIONS_FILTER,
   sourceControlSessionFilterAtom,
 } from "@src/store/workstation/codeEditor/sourceControlSessionFilterAtom";
-import { workstationSelectedIssueAtom } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationSelectedIssueAtomFamily } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationRepoScopeKey } from "@src/store/workstation/codeEditor/workstationPrAtom";
 import {
   type SourceControlHistorySelection,
   createGitCommitDetailTab,
@@ -120,7 +121,10 @@ const EditorContent: React.FC<EditorContentProps> = memo(
     const sourceControlSessionFilter = useAtomValue(
       sourceControlSessionFilterAtom
     );
-    const selectedIssueState = useAtomValue(workstationSelectedIssueAtom);
+    const scopeKey = workstationRepoScopeKey(repoId, repoPath);
+    const selectedIssueState = useAtomValue(
+      workstationSelectedIssueAtomFamily(scopeKey)
+    );
     const setSourceControlSessionFilter = useSetAtom(
       sourceControlSessionFilterAtom
     );

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/IssuesContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/IssuesContent/index.tsx
@@ -29,7 +29,8 @@ import {
 } from "@src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/components/SectionStatusRow";
 import { TreeSectionHeader } from "@src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/components/TreeSectionHeader";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
-import { workstationIssueCallbackAtom } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationIssueCallbackAtomFamily } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationRepoScopeKey } from "@src/store/workstation/codeEditor/workstationPrAtom";
 
 import { useWorkstationIssues } from "../../hooks/useWorkstationIssues";
 import { IssueRow } from "./IssueRow";
@@ -70,7 +71,10 @@ const IssuesContent: React.FC<IssuesContentProps> = memo(
   }) => {
     const { t } = useTranslation("common");
     const navigate = useNavigate();
-    const setCallbackAtom = useSetAtom(workstationIssueCallbackAtom);
+    const scopeKey = workstationRepoScopeKey(repoId, repoPath);
+    const setCallbackAtom = useSetAtom(
+      workstationIssueCallbackAtomFamily(scopeKey)
+    );
 
     const {
       openIssues,

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/index.tsx
@@ -24,11 +24,12 @@ import { ReferenceDragGhost } from "@src/shared/dnd/ReferenceDragGhost";
 import { setPrDragStash } from "@src/shared/dnd/dragSideChannel";
 import { useReferencePillDrag } from "@src/shared/dnd/useReferencePillDrag";
 import {
-  workstationAllOpenPrsAtom,
-  workstationOpenPrsErrorAtom,
-  workstationOpenPrsLoadStateAtom,
-  workstationPrAtom,
-  workstationPrCallbackAtom,
+  workstationAllOpenPrsAtomFamily,
+  workstationOpenPrsErrorAtomFamily,
+  workstationOpenPrsLoadStateAtomFamily,
+  workstationPrAtomFamily,
+  workstationPrCallbackAtomFamily,
+  workstationRepoScopeKey,
 } from "@src/store/workstation/codeEditor/workstationPrAtom";
 import type { SourceControlHistorySelection } from "@src/store/workstation/tabs";
 
@@ -39,6 +40,8 @@ export interface PullRequestContentProps {
   branchName?: string;
   filterQuery?: string;
   onHistorySelectionChange?: (selection: SourceControlHistorySelection) => void;
+  repoId?: string | null;
+  repoPath?: string;
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -161,19 +164,26 @@ const PullRequestContent: React.FC<PullRequestContentProps> = ({
   branchName,
   filterQuery = "",
   onHistorySelectionChange,
+  repoId,
+  repoPath,
 }) => {
   const { t } = useTranslation("common");
+  const scopeKey = workstationRepoScopeKey(repoId, repoPath);
   const {
     prUrl,
     readyToCreate,
     isCreating: prCreating,
-  } = useAtomValue(workstationPrAtom);
+  } = useAtomValue(workstationPrAtomFamily(scopeKey));
   const { createPr: onCreatePr, loadOpenPrs } = useAtomValue(
-    workstationPrCallbackAtom
+    workstationPrCallbackAtomFamily(scopeKey)
   );
-  const allOpenPrs = useAtomValue(workstationAllOpenPrsAtom);
-  const openPrsLoadState = useAtomValue(workstationOpenPrsLoadStateAtom);
-  const openPrsError = useAtomValue(workstationOpenPrsErrorAtom);
+  const allOpenPrs = useAtomValue(workstationAllOpenPrsAtomFamily(scopeKey));
+  const openPrsLoadState = useAtomValue(
+    workstationOpenPrsLoadStateAtomFamily(scopeKey)
+  );
+  const openPrsError = useAtomValue(
+    workstationOpenPrsErrorAtomFamily(scopeKey)
+  );
 
   useEffect(() => {
     loadOpenPrs?.();

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useSourceControlState/index.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useSourceControlState/index.ts
@@ -24,9 +24,10 @@ import { gitAutoCreatePrAtom } from "@src/store/ui/editorSettingsAtom";
 import { gitReviewNavigationAtom } from "@src/store/workstation/codeEditor/gitReviewNavigationAtom";
 import { gitOutputIntegrationAtom } from "@src/store/workstation/codeEditor/outputIntegration";
 import {
-  workstationPrAtom,
-  workstationPrCallbackAtom,
-  workstationPrCommitMessageAtom,
+  workstationPrAtomFamily,
+  workstationPrCallbackAtomFamily,
+  workstationPrCommitMessageAtomFamily,
+  workstationRepoScopeKey,
 } from "@src/store/workstation/codeEditor/workstationPrAtom";
 
 import { useStashState } from "../useStashState";
@@ -69,6 +70,7 @@ export function useSourceControlState(
   // Get git output integration for streaming
   const gitOutputIntegration = useAtomValue(gitOutputIntegrationAtom);
   const setGitReviewNavigation = useSetAtom(gitReviewNavigationAtom);
+  const scopeKey = workstationRepoScopeKey(selectedRepoId, repoPath);
 
   const { currentGitStatus: gitStatus } = useGitStatus();
 
@@ -271,11 +273,11 @@ export function useSourceControlState(
     prUrl,
     isCreating: prCreating,
     readyToCreate: prReadyToCreate,
-  } = useAtomValue(workstationPrAtom);
-  const { createPr } = useAtomValue(workstationPrCallbackAtom);
+  } = useAtomValue(workstationPrAtomFamily(scopeKey));
+  const { createPr } = useAtomValue(workstationPrCallbackAtomFamily(scopeKey));
   const autoCreatePr = useAtomValue(gitAutoCreatePrAtom);
   const setWorkstationPrCommitMessage = useSetAtom(
-    workstationPrCommitMessageAtom
+    workstationPrCommitMessageAtomFamily(scopeKey)
   );
 
   // Publish the commit summary so the single PR mount can build PR titles from

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useWorkstationIssues.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useWorkstationIssues.ts
@@ -29,11 +29,12 @@ import type {
   GitHubIssueUser,
 } from "@src/services/git/operations/githubIssues";
 import {
-  workstationIssueCallbackAtom,
-  workstationIssueListAtom,
-  workstationSelectedIssueAtom,
+  workstationIssueCallbackAtomFamily,
+  workstationIssueListAtomFamily,
+  workstationSelectedIssueAtomFamily,
 } from "@src/store/workstation/codeEditor/workstationIssueAtom";
 import type { IssueFilterState } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationRepoScopeKey } from "@src/store/workstation/codeEditor/workstationPrAtom";
 
 import {
   getCachedIssues,
@@ -74,14 +75,22 @@ function mergeUniqueIssues(
 
 export function useWorkstationIssues({
   repoPath,
-  repoId = "default",
+  repoId,
   remoteUrl: remoteUrlProp,
 }: UseWorkstationIssuesOptions) {
-  const setListState = useSetAtom(workstationIssueListAtom);
-  const setSelectedState = useSetAtom(workstationSelectedIssueAtom);
-  const setCallbackAtom = useSetAtom(workstationIssueCallbackAtom);
+  const apiRepoId = repoId ?? "default";
+  const scopeKey = workstationRepoScopeKey(repoId, repoPath);
+  const setListState = useSetAtom(workstationIssueListAtomFamily(scopeKey));
+  const setSelectedState = useSetAtom(
+    workstationSelectedIssueAtomFamily(scopeKey)
+  );
+  const setCallbackAtom = useSetAtom(
+    workstationIssueCallbackAtomFamily(scopeKey)
+  );
 
-  const selectedState = useAtomValue(workstationSelectedIssueAtom);
+  const selectedState = useAtomValue(
+    workstationSelectedIssueAtomFamily(scopeKey)
+  );
 
   const mountedRef = useRef(true);
   useEffect(() => {
@@ -127,10 +136,10 @@ export function useWorkstationIssues({
         return;
       }
 
-      logger.debug("fetching remotes", { repoPath, repoId });
+      logger.debug("fetching remotes", { repoPath, repoId: apiRepoId });
       try {
         const remotesData = await getGitRemotes({
-          repo_id: repoId,
+          repo_id: apiRepoId,
           repo_path: repoPath,
         });
         logger.debug("getGitRemotes result", remotesData);
@@ -151,7 +160,7 @@ export function useWorkstationIssues({
     return () => {
       cancelled = true;
     };
-  }, [repoPath, repoId, remoteUrlProp]);
+  }, [repoPath, apiRepoId, remoteUrlProp]);
 
   // Optimistically true when the remote resolves to a GitHub URL.
   // A valid GitHub URL means credentials should be available via

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useWorkstationPr.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useWorkstationPr.ts
@@ -14,11 +14,12 @@ import {
 } from "@src/services/git/operations/createPullRequest";
 import { gitAutoCreatePrAtom } from "@src/store/ui/editorSettingsAtom";
 import {
-  workstationAllOpenPrsAtom,
-  workstationOpenPrsErrorAtom,
-  workstationOpenPrsLoadStateAtom,
-  workstationPrAtom,
-  workstationPrCallbackAtom,
+  workstationAllOpenPrsAtomFamily,
+  workstationOpenPrsErrorAtomFamily,
+  workstationOpenPrsLoadStateAtomFamily,
+  workstationPrAtomFamily,
+  workstationPrCallbackAtomFamily,
+  workstationRepoScopeKey,
 } from "@src/store/workstation/codeEditor/workstationPrAtom";
 
 import { getCachedPrs, isPrCacheStale, setCachedPrs } from "./githubListCache";
@@ -48,21 +49,29 @@ type BranchPrState = {
 export function useWorkstationPr(options: UseWorkstationPrOptions) {
   const {
     repoPath,
-    repoId = "default",
+    repoId,
     branchName,
     hasUpstream,
     uncommittedCount,
     commitMessage,
   } = options;
+  const apiRepoId = repoId ?? "default";
 
   const { t } = useTranslation();
   const navigate = useNavigate();
   const autoCreatePr = useAtomValue(gitAutoCreatePrAtom);
-  const setWorkstationPrAtom = useSetAtom(workstationPrAtom);
-  const setWorkstationPrCallbackAtom = useSetAtom(workstationPrCallbackAtom);
-  const setAllOpenPrs = useSetAtom(workstationAllOpenPrsAtom);
-  const setOpenPrsLoadState = useSetAtom(workstationOpenPrsLoadStateAtom);
-  const setOpenPrsError = useSetAtom(workstationOpenPrsErrorAtom);
+  const scopeKey = workstationRepoScopeKey(repoId, repoPath);
+  const setWorkstationPrAtom = useSetAtom(workstationPrAtomFamily(scopeKey));
+  const setWorkstationPrCallbackAtom = useSetAtom(
+    workstationPrCallbackAtomFamily(scopeKey)
+  );
+  const setAllOpenPrs = useSetAtom(workstationAllOpenPrsAtomFamily(scopeKey));
+  const setOpenPrsLoadState = useSetAtom(
+    workstationOpenPrsLoadStateAtomFamily(scopeKey)
+  );
+  const setOpenPrsError = useSetAtom(
+    workstationOpenPrsErrorAtomFamily(scopeKey)
+  );
   const branchKey = branchName ?? "";
 
   const [remotePrByBranch, setRemotePrByBranch] = useState<
@@ -97,7 +106,7 @@ export function useWorkstationPr(options: UseWorkstationPrOptions) {
     if (!repoPath) return;
 
     fetchRustApi<{ name: string }>(
-      `${gitRepoUrl(repoId)}/default-branch?${new URLSearchParams({ path: repoPath }).toString()}`
+      `${gitRepoUrl(apiRepoId)}/default-branch?${new URLSearchParams({ path: repoPath }).toString()}`
     )
       .then((resp) => {
         if (!cancelled && resp.data?.name) {
@@ -113,7 +122,7 @@ export function useWorkstationPr(options: UseWorkstationPrOptions) {
     return () => {
       cancelled = true;
     };
-  }, [repoPath, repoId]);
+  }, [repoPath, apiRepoId]);
 
   useEffect(() => {
     autoTriggeredRef.current = false;
@@ -139,7 +148,7 @@ export function useWorkstationPr(options: UseWorkstationPrOptions) {
     void (async () => {
       try {
         const remotesData = await getGitRemotes({
-          repo_id: repoId,
+          repo_id: apiRepoId,
           repo_path: repoPath,
         });
         const originRemote = remotesData?.remotes?.find(
@@ -186,7 +195,7 @@ export function useWorkstationPr(options: UseWorkstationPrOptions) {
     })();
   }, [
     repoPath,
-    repoId,
+    apiRepoId,
     branchName,
     setAllOpenPrs,
     setOpenPrsLoadState,
@@ -224,7 +233,7 @@ export function useWorkstationPr(options: UseWorkstationPrOptions) {
       repoPath,
       branch: branchName,
       title,
-      repoId,
+      repoId: apiRepoId,
       pushBeforeCreate: true,
     });
 
@@ -266,7 +275,7 @@ export function useWorkstationPr(options: UseWorkstationPrOptions) {
 
     setCreatingByBranch((current) => ({ ...current, [branchName]: false }));
     return { url: result.url };
-  }, [isCreating, branchName, repoPath, commitMessage, repoId, t, navigate]);
+  }, [isCreating, branchName, repoPath, commitMessage, apiRepoId, t, navigate]);
 
   const prIsActive = !!prUrl && prStatus !== "closed" && prStatus !== "merged";
   const readyToCreate = eligible && !prIsActive;

--- a/src/modules/WorkStation/CodeEditor/useSourceControlSetup.ts
+++ b/src/modules/WorkStation/CodeEditor/useSourceControlSetup.ts
@@ -14,7 +14,10 @@ import {
   sourceControlFilterModeHandlerAtom,
   sourceControlFocusTargetAtom,
 } from "@src/store/workstation/codeEditor";
-import { workstationPrCommitMessageAtom } from "@src/store/workstation/codeEditor/workstationPrAtom";
+import {
+  workstationPrCommitMessageAtomFamily,
+  workstationRepoScopeKey,
+} from "@src/store/workstation/codeEditor/workstationPrAtom";
 import type {
   PanelState,
   SourceControlHistorySelection,
@@ -125,8 +128,9 @@ export function useSourceControlSetup({
     repoPath,
     autoLoad: true,
   });
+  const scopeKey = workstationRepoScopeKey(repoId, repoPath);
   const workstationPrCommitMessage = useAtomValue(
-    workstationPrCommitMessageAtom
+    workstationPrCommitMessageAtomFamily(scopeKey)
   );
   useWorkstationPr({
     repoPath,

--- a/src/modules/WorkStation/TabContent/renderers/githubIssueDetail.tsx
+++ b/src/modules/WorkStation/TabContent/renderers/githubIssueDetail.tsx
@@ -23,9 +23,10 @@ import {
   reopenIssue,
 } from "@src/services/git/operations/githubIssues";
 import {
-  workstationIssueCallbackAtom,
-  workstationSelectedIssueAtom,
+  workstationIssueCallbackAtomFamily,
+  workstationSelectedIssueAtomFamily,
 } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationRepoScopeKey } from "@src/store/workstation/codeEditor/workstationPrAtom";
 import type { GitHubIssueDetailTabData } from "@src/store/workstation/tabs";
 
 import type { UnifiedTabContentProps } from "../types";
@@ -33,11 +34,18 @@ import type { UnifiedTabContentProps } from "../types";
 const GitHubIssueDetailTabRenderer: React.FC<UnifiedTabContentProps> = memo(
   ({ tab }) => {
     const { t } = useTranslation();
-    const selectedState = useAtomValue(workstationSelectedIssueAtom);
-    const callbacks = useAtomValue(workstationIssueCallbackAtom);
-    const setSelectedState = useSetAtom(workstationSelectedIssueAtom);
     const { closeTab } = useWorkStationTabs();
     const tabData = tab.data as unknown as GitHubIssueDetailTabData;
+    const scopeKey = workstationRepoScopeKey(undefined, tabData.repoPath);
+    const selectedState = useAtomValue(
+      workstationSelectedIssueAtomFamily(scopeKey)
+    );
+    const callbacks = useAtomValue(
+      workstationIssueCallbackAtomFamily(scopeKey)
+    );
+    const setSelectedState = useSetAtom(
+      workstationSelectedIssueAtomFamily(scopeKey)
+    );
 
     const handleClose = useCallback(() => {
       closeTab(tab.id);

--- a/src/modules/WorkStation/shared/SidebarModules/SourceControl/useSourceControlSidebarModule.tsx
+++ b/src/modules/WorkStation/shared/SidebarModules/SourceControl/useSourceControlSidebarModule.tsx
@@ -45,7 +45,8 @@ import {
   useSourceControlTabConfig,
 } from "@src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlTab";
 import type { PrimarySidebarTab } from "@src/modules/WorkStation/shared/PrimarySidebarLayout";
-import { workstationIssueCallbackAtom } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationIssueCallbackAtomFamily } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationRepoScopeKey } from "@src/store/workstation/codeEditor/workstationPrAtom";
 import type { SourceControlHistorySelection } from "@src/store/workstation/tabs";
 import type { GitFile } from "@src/types/git/types";
 import { confirmDestructiveAction } from "@src/util/dialogs/confirmDestructiveAction";
@@ -263,7 +264,10 @@ export function useSourceControlSidebarModule({
     clear: clearIssuesFilter,
   } = useSectionFilter();
 
-  const issueCallbacks = useAtomValue(workstationIssueCallbackAtom);
+  const scopeKey = workstationRepoScopeKey(repoId, repoPath);
+  const issueCallbacks = useAtomValue(
+    workstationIssueCallbackAtomFamily(scopeKey)
+  );
   const handleIssuesRefresh = useCallback(() => {
     issueCallbacks.refreshIssues?.();
   }, [issueCallbacks]);
@@ -396,6 +400,8 @@ export function useSourceControlSidebarModule({
           branchName={branchName}
           filterQuery={prFilterQuery}
           onHistorySelectionChange={onGitHistorySelectionChange}
+          repoId={repoId}
+          repoPath={repoPath}
         />
       </div>
     ),
@@ -406,6 +412,8 @@ export function useSourceControlSidebarModule({
       clearPrFilter,
       branchName,
       onGitHistorySelectionChange,
+      repoId,
+      repoPath,
       t,
     ]
   );

--- a/src/services/context/collectors/AdeContextCollector.ts
+++ b/src/services/context/collectors/AdeContextCollector.ts
@@ -42,8 +42,9 @@ import { userPresenceWireAtom } from "@src/store/user/userPresenceAtom";
 import { activeWorkspaceRootAtom } from "@src/store/workspace";
 import { globalLspDiagnosticsAtom } from "@src/store/workstation/codeEditor/diagnostics/globalLspDiagnosticsAtom";
 import {
-  workstationAllOpenPrsAtom,
-  workstationPrAtom,
+  workstationAllOpenPrsAtomFamily,
+  workstationPrAtomFamily,
+  workstationRepoScopeKey,
 } from "@src/store/workstation/codeEditor/workstationPrAtom";
 import {
   activeWorkStationFilePathAtom,
@@ -372,8 +373,13 @@ export async function collectAdeContextAsync(
   let currentPr: CurrentPullRequestSnapshot | undefined;
   try {
     const store = getInstrumentedStore();
-    const prSnapshot = store.get(workstationPrAtom);
-    const allOpenPrs = store.get(workstationAllOpenPrsAtom);
+    const activeWorkspaceRoot = store.get(activeWorkspaceRootAtom);
+    const scopeKey = workstationRepoScopeKey(
+      undefined,
+      options.expectedRepoPath ?? activeWorkspaceRoot?.path
+    );
+    const prSnapshot = store.get(workstationPrAtomFamily(scopeKey));
+    const allOpenPrs = store.get(workstationAllOpenPrsAtomFamily(scopeKey));
     const branch = store.get(currentBranchAtom);
 
     // Prefer the PR URL from the atom, fall back to matching by branch

--- a/src/store/workstation/codeEditor/workstationIssueAtom.ts
+++ b/src/store/workstation/codeEditor/workstationIssueAtom.ts
@@ -1,6 +1,9 @@
 import { atom } from "jotai";
+import { atomFamily } from "jotai-family";
 
 import type { GitHubIssue, GitHubIssueComment } from "@src/api/tauri/github";
+
+import { DEFAULT_WORKSTATION_REPO_SCOPE } from "./workstationPrAtom";
 
 export type IssueFilterState = "open" | "closed" | "all";
 
@@ -44,28 +47,62 @@ const initialSelectedState: WorkstationSelectedIssueState = {
   submittingComment: false,
 };
 
-// TODO(multi-panel): use atomFamily keyed by repoId when multiple workstation panels are supported.
-export const workstationIssueListAtom =
-  atom<WorkstationIssueListState>(initialListState);
-workstationIssueListAtom.debugLabel = "workstationIssueListAtom";
+export const workstationIssueListAtomFamily = atomFamily((scopeKey: string) => {
+  const scopedAtom = atom<WorkstationIssueListState>({
+    ...initialListState,
+    issues: [],
+  });
+  scopedAtom.debugLabel = `workstationIssueListAtom(${scopeKey})`;
+  return scopedAtom;
+});
 
-export const workstationSelectedIssueAtom =
-  atom<WorkstationSelectedIssueState>(initialSelectedState);
-workstationSelectedIssueAtom.debugLabel = "workstationSelectedIssueAtom";
+export const workstationIssueListAtom = workstationIssueListAtomFamily(
+  DEFAULT_WORKSTATION_REPO_SCOPE
+);
 
-// Callback atom for actions triggerable from PinnedActionsBar, agents, or the
-// github-issue-detail tab rendered in the main pane.
-export const workstationIssueCallbackAtom = atom<{
+export const workstationSelectedIssueAtomFamily = atomFamily(
+  (scopeKey: string) => {
+    const scopedAtom = atom<WorkstationSelectedIssueState>({
+      ...initialSelectedState,
+      comments: [],
+    });
+    scopedAtom.debugLabel = `workstationSelectedIssueAtom(${scopeKey})`;
+    return scopedAtom;
+  }
+);
+
+export const workstationSelectedIssueAtom = workstationSelectedIssueAtomFamily(
+  DEFAULT_WORKSTATION_REPO_SCOPE
+);
+
+export type WorkstationIssueCallbacks = {
   openNewIssueForm: (() => void) | null;
   closeIssue: ((number: number) => Promise<void>) | null;
   reopenIssue: ((number: number) => Promise<void>) | null;
   addComment: ((number: number, body: string) => Promise<void>) | null;
   refreshIssues: (() => void) | null;
-}>({
+};
+
+const initialIssueCallbacks: WorkstationIssueCallbacks = {
   openNewIssueForm: null,
   closeIssue: null,
   reopenIssue: null,
   addComment: null,
   refreshIssues: null,
-});
-workstationIssueCallbackAtom.debugLabel = "workstationIssueCallbackAtom";
+};
+
+// Callback atom for actions triggerable from PinnedActionsBar, agents, or the
+// github-issue-detail tab rendered in the main pane.
+export const workstationIssueCallbackAtomFamily = atomFamily(
+  (scopeKey: string) => {
+    const scopedAtom = atom<WorkstationIssueCallbacks>({
+      ...initialIssueCallbacks,
+    });
+    scopedAtom.debugLabel = `workstationIssueCallbackAtom(${scopeKey})`;
+    return scopedAtom;
+  }
+);
+
+export const workstationIssueCallbackAtom = workstationIssueCallbackAtomFamily(
+  DEFAULT_WORKSTATION_REPO_SCOPE
+);

--- a/src/store/workstation/codeEditor/workstationPrAtom.ts
+++ b/src/store/workstation/codeEditor/workstationPrAtom.ts
@@ -1,19 +1,24 @@
 import { atom } from "jotai";
+import { atomFamily } from "jotai-family";
 
 import type { OpenPRItem } from "@src/api/tauri/github";
+
+export const DEFAULT_WORKSTATION_REPO_SCOPE = "default";
+
+export function workstationRepoScopeKey(
+  repoId: string | null | undefined,
+  repoPath: string | null | undefined
+): string {
+  const id = repoId?.trim();
+  if (id) return `repo:${id}`;
+  const path = repoPath?.trim();
+  return path ? `path:${path}` : DEFAULT_WORKSTATION_REPO_SCOPE;
+}
 
 /**
  * Shared PR state for the active workstation repo.
  * Written by `useWorkstationPr` when eligibility or PR URL changes.
  * Read by Source Control surfaces and context collection.
- *
- * TODO(multi-panel): This is a single global atom. When multiple workstation
- * panels are open simultaneously they will share state incorrectly. Fix by
- * migrating to `atomFamily` keyed by `repoId` (from `jotai-family`), matching
- * the pattern used in `cursorModeOverrideAtom.ts`. Callers to update:
- *   - `useWorkstationPr` (useSetAtom → useAtom(workstationPrAtomFamily(repoId)))
- *   - `workstationPrCallbackAtom` consumers
- *   - Any other direct reader of `workstationPrAtom`
  */
 export interface WorkstationPrSnapshot {
   /** The branch is eligible for PR creation (not default, pushed, clean) */
@@ -30,14 +35,26 @@ export interface WorkstationPrSnapshot {
   isDefaultBranch: boolean;
 }
 
-export const workstationPrAtom = atom<WorkstationPrSnapshot>({
+const initialWorkstationPrSnapshot: WorkstationPrSnapshot = {
   readyToCreate: false,
   prUrl: undefined,
   isCreating: false,
   hasUpstream: false,
   uncommittedCount: 0,
   isDefaultBranch: false,
+};
+
+export const workstationPrAtomFamily = atomFamily((scopeKey: string) => {
+  const scopedAtom = atom<WorkstationPrSnapshot>({
+    ...initialWorkstationPrSnapshot,
+  });
+  scopedAtom.debugLabel = `workstationPrAtom(${scopeKey})`;
+  return scopedAtom;
 });
+
+export const workstationPrAtom = workstationPrAtomFamily(
+  DEFAULT_WORKSTATION_REPO_SCOPE
+);
 
 /**
  * Latest Source Control commit message for the active workstation repo.
@@ -49,14 +66,31 @@ export const workstationPrAtom = atom<WorkstationPrSnapshot>({
  * it. Empty when no Source Control panel is mounted, in which case the PR
  * title falls back to the branch name.
  */
-export const workstationPrCommitMessageAtom = atom<string>("");
+export const workstationPrCommitMessageAtomFamily = atomFamily(
+  (scopeKey: string) => {
+    const scopedAtom = atom<string>("");
+    scopedAtom.debugLabel = `workstationPrCommitMessageAtom(${scopeKey})`;
+    return scopedAtom;
+  }
+);
+export const workstationPrCommitMessageAtom =
+  workstationPrCommitMessageAtomFamily(DEFAULT_WORKSTATION_REPO_SCOPE);
 
 /**
  * All open pull requests for the active workstation repo.
  * Written by `useWorkstationPr` when the PR page requests the list.
  * Read by `PullRequestContent` to render the full PR list.
  */
-export const workstationAllOpenPrsAtom = atom<OpenPRItem[]>([]);
+export const workstationAllOpenPrsAtomFamily = atomFamily(
+  (scopeKey: string) => {
+    const scopedAtom = atom<OpenPRItem[]>([]);
+    scopedAtom.debugLabel = `workstationAllOpenPrsAtom(${scopeKey})`;
+    return scopedAtom;
+  }
+);
+export const workstationAllOpenPrsAtom = workstationAllOpenPrsAtomFamily(
+  DEFAULT_WORKSTATION_REPO_SCOPE
+);
 
 /**
  * Load lifecycle for `workstationAllOpenPrsAtom`. Lets the PR sidebar
@@ -72,16 +106,46 @@ export type WorkstationOpenPrsLoadState =
   | "ready"
   | "error";
 
+export const workstationOpenPrsLoadStateAtomFamily = atomFamily(
+  (scopeKey: string) => {
+    const scopedAtom = atom<WorkstationOpenPrsLoadState>("idle");
+    scopedAtom.debugLabel = `workstationOpenPrsLoadStateAtom(${scopeKey})`;
+    return scopedAtom;
+  }
+);
 export const workstationOpenPrsLoadStateAtom =
-  atom<WorkstationOpenPrsLoadState>("idle");
+  workstationOpenPrsLoadStateAtomFamily(DEFAULT_WORKSTATION_REPO_SCOPE);
 
-export const workstationOpenPrsErrorAtom = atom<string | null>(null);
+export const workstationOpenPrsErrorAtomFamily = atomFamily(
+  (scopeKey: string) => {
+    const scopedAtom = atom<string | null>(null);
+    scopedAtom.debugLabel = `workstationOpenPrsErrorAtom(${scopeKey})`;
+    return scopedAtom;
+  }
+);
+export const workstationOpenPrsErrorAtom = workstationOpenPrsErrorAtomFamily(
+  DEFAULT_WORKSTATION_REPO_SCOPE
+);
 
 /**
  * Stable ref-backed callback for triggering PR creation from Source Control UI.
  * Stored as a ref container to avoid stale closure issues with atom-stored functions.
  */
-export const workstationPrCallbackAtom = atom<{
+type WorkstationPrCallbacks = {
   createPr: (() => Promise<{ url?: string; error?: string }>) | null;
   loadOpenPrs: (() => void) | null;
-}>({ createPr: null, loadOpenPrs: null });
+};
+
+export const workstationPrCallbackAtomFamily = atomFamily(
+  (scopeKey: string) => {
+    const scopedAtom = atom<WorkstationPrCallbacks>({
+      createPr: null,
+      loadOpenPrs: null,
+    });
+    scopedAtom.debugLabel = `workstationPrCallbackAtom(${scopeKey})`;
+    return scopedAtom;
+  }
+);
+export const workstationPrCallbackAtom = workstationPrCallbackAtomFamily(
+  DEFAULT_WORKSTATION_REPO_SCOPE
+);


### PR DESCRIPTION
## Summary
- Migrate Source Control issue/PR state to repo/path-scoped atom families.
- Thread scope keys through sidebar, main pane, issue detail tabs, Manage Issues handoff, and ADE context collection.
- Preserve backend repo id fallback separately from frontend state scoping.
- Add architecture audit report and fix audit-found compatibility alias/initial-state consistency issues.

## Audit
- `docs/architecture-audit-2026-07-08/source-control-repo-scope.md`
- Covered all 10 layers relevant to this TypeScript state split; wire protocol marked not applicable.

## Validation
- `./node_modules/.bin/tsc --noEmit --pretty false`
- targeted ESLint on changed Source Control/context/store files

Draft until multi-repo/worktree Source Control flows are smoke-tested in app.
