### PR TITLE
fix(ui): tighten workstation type handling

### DIFF
--- a/src/components/SettingsTable/index.tsx
+++ b/src/components/SettingsTable/index.tsx
@@ -91,7 +91,7 @@ export const SETTINGS_TABLE_COL = {
 export interface SettingsTableColumn<RowData> {
   key: string;
   label: ReactNode;
-  width?: string;
+  width?: React.CSSProperties["width"];
   align?: "left" | "center" | "right";
   /** Legacy: SettingsTable now preserves columns and relies on internal horizontal scrolling. */
   hideBelow?: "sm" | "md";

--- a/src/modules/WorkStation/Diff/SessionReplay/index.tsx
+++ b/src/modules/WorkStation/Diff/SessionReplay/index.tsx
@@ -126,12 +126,14 @@ const TAB_IDS: Record<DiffReplayTab, string> = {
   all: "diff-tab:all",
   diff: "diff-tab:diff",
   submissions: "diff-tab:submissions",
+  requirements: "diff-tab:requirements",
 };
 
 const TAB_BY_ID: Record<string, DiffReplayTab> = {
   [TAB_IDS.all]: "all",
   [TAB_IDS.diff]: "diff",
   [TAB_IDS.submissions]: "submissions",
+  [TAB_IDS.requirements]: "requirements",
 };
 
 function hasRepoContext(context: SubmissionRepoContext | null): boolean {

--- a/src/modules/WorkStation/Diff/SessionReplay/types.ts
+++ b/src/modules/WorkStation/Diff/SessionReplay/types.ts
@@ -25,7 +25,7 @@ export interface DiffEntry {
 }
 
 /** Top-level tabs surfaced in the Diff app chrome. */
-export type DiffReplayTab = "all" | "diff" | "submissions";
+export type DiffReplayTab = "all" | "diff" | "submissions" | "requirements";
 
 /**
  * State derived from filtered events; consumed by the index component.


### PR DESCRIPTION
## Summary
- Allow `SettingsTable` column width to use React CSS width values.
- Add the missing `requirements` replay tab id mapping.
- Tighten the Diff replay tab union for the requirements tab.

## Validation
- `./node_modules/.bin/tsc --noEmit --pretty false`
- targeted ESLint on changed files

Draft until the Diff replay requirements tab path is clicked once in app.
