### PR TITLE
Fix session sidebar external subagents

### DIFF
--- a/src-tauri/crates/orgtrack-core/src/sources/claude_code/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/claude_code/history.rs
@@ -26,7 +26,7 @@ use crate::sources::imported_history::{
 
 const CLAUDE_CODE_SESSION_PREFIX: &str = "claudecodeapp-";
 const CLAUDE_CODE_PROVIDER_SLUG: &str = "claudecode";
-const CLAUDE_CODE_METADATA_PARSER_VERSION: i64 = 2;
+const CLAUDE_CODE_METADATA_PARSER_VERSION: i64 = 3;
 
 pub type ClaudeCodeHistorySessionRow = ImportedHistorySessionRow;
 pub type ClaudeCodeHistorySessionPage = ImportedHistorySessionPage;
@@ -58,6 +58,8 @@ struct ClaudeJsonlLine {
     #[serde(default)]
     r#type: String,
     #[serde(default)]
+    summary: String,
+    #[serde(default)]
     timestamp: Option<String>,
     #[serde(default)]
     cwd: String,
@@ -87,6 +89,23 @@ struct ClaudeUsage {
     cache_read_input_tokens: i64,
     #[serde(default)]
     cache_creation_input_tokens: i64,
+}
+
+#[derive(Debug, Clone)]
+struct ClaudeSessionTitle {
+    name: String,
+    name_source: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ClaudeSessionMetadataFile {
+    #[serde(default)]
+    session_id: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    name_source: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -148,28 +167,28 @@ fn sync_claude_code_history_cache(conn: &mut Connection) -> Result<(), String> {
 }
 
 fn discover_claude_code_history_records() -> Result<Vec<ImportedHistoryDiscoveredRecord>, String> {
-    let mut files = Vec::new();
+    let mut records = Vec::new();
     for projects_dir in claude_projects_dirs()? {
         if projects_dir.is_dir() {
+            let title_index = load_claude_session_titles_for_projects_dir(&projects_dir)?;
+            let mut files = Vec::new();
             collect_claude_session_files(&projects_dir, &mut files)?;
+            for file in files {
+                let (source_mtime_ms, source_size_bytes) =
+                    imported_paths::file_metadata_signature(&file.path, "Claude")?;
+                records.push(ImportedHistoryDiscoveredRecord {
+                    source_session_id: file.file_stem.clone(),
+                    source_path: file.path,
+                    source_record_key: file.file_stem.clone(),
+                    source_mtime_ms,
+                    source_size_bytes,
+                    source_fingerprint: claude_source_fingerprint(&file.file_stem, &title_index),
+                    parser_version: CLAUDE_CODE_METADATA_PARSER_VERSION,
+                });
+            }
         }
     }
-    files
-        .into_iter()
-        .map(|file| {
-            let (source_mtime_ms, source_size_bytes) =
-                imported_paths::file_metadata_signature(&file.path, "Claude")?;
-            Ok(ImportedHistoryDiscoveredRecord {
-                source_session_id: file.file_stem.clone(),
-                source_path: file.path,
-                source_record_key: file.file_stem,
-                source_mtime_ms,
-                source_size_bytes,
-                source_fingerprint: String::new(),
-                parser_version: CLAUDE_CODE_METADATA_PARSER_VERSION,
-            })
-        })
-        .collect()
+    Ok(records)
 }
 
 fn collect_claude_session_files(
@@ -197,6 +216,99 @@ fn collect_claude_session_files(
     Ok(())
 }
 
+fn load_claude_session_titles_for_projects_dir(
+    projects_dir: &Path,
+) -> Result<HashMap<String, ClaudeSessionTitle>, String> {
+    let Some(root) = projects_dir.parent() else {
+        return Ok(HashMap::new());
+    };
+    load_claude_session_titles(&root.join("sessions"))
+}
+
+fn load_claude_session_titles(
+    sessions_dir: &Path,
+) -> Result<HashMap<String, ClaudeSessionTitle>, String> {
+    let mut entries = HashMap::new();
+    if !sessions_dir.is_dir() {
+        return Ok(entries);
+    }
+
+    for entry in fs::read_dir(sessions_dir)
+        .map_err(|err| format!("Failed to read Claude sessions dir: {err}"))?
+    {
+        let entry = entry.map_err(|err| format!("Failed to read Claude session entry: {err}"))?;
+        let path = entry.path();
+        if !path
+            .extension()
+            .is_some_and(|extension| extension == "json")
+        {
+            continue;
+        }
+        let contents = fs::read_to_string(&path).map_err(|err| {
+            format!(
+                "Failed to read Claude session metadata {}: {err}",
+                path.display()
+            )
+        })?;
+        let parsed: ClaudeSessionMetadataFile = match serde_json::from_str(&contents) {
+            Ok(parsed) => parsed,
+            Err(_) => continue,
+        };
+        let session_id = parsed.session_id.trim();
+        let name = parsed.name.trim();
+        if session_id.is_empty() || name.is_empty() {
+            continue;
+        }
+        entries.insert(
+            session_id.to_string(),
+            ClaudeSessionTitle {
+                name: name.to_string(),
+                name_source: parsed.name_source,
+            },
+        );
+    }
+
+    Ok(entries)
+}
+
+fn claude_source_fingerprint(
+    file_stem: &str,
+    title_index: &HashMap<String, ClaudeSessionTitle>,
+) -> String {
+    title_index
+        .get(file_stem)
+        .map(|title| {
+            format!(
+                "session-meta:{}:{}",
+                title.name_source.as_deref().unwrap_or_default(),
+                title.name
+            )
+        })
+        .unwrap_or_default()
+}
+
+fn claude_session_title_for_record(
+    record: &ImportedHistoryDiscoveredRecord,
+) -> Result<String, String> {
+    let Some(sessions_dir) = claude_sessions_dir_for_session_path(&record.source_path) else {
+        return Ok(String::new());
+    };
+    let title_index = load_claude_session_titles(&sessions_dir)?;
+    Ok(title_index
+        .get(&record.source_record_key)
+        .map(|title| imported_history::truncate_name(&title.name, 200))
+        .unwrap_or_default())
+}
+
+fn claude_sessions_dir_for_session_path(session_path: &Path) -> Option<PathBuf> {
+    session_path.ancestors().find_map(|ancestor| {
+        if ancestor.file_name().and_then(|name| name.to_str()) == Some("projects") {
+            return ancestor.parent().map(|root| root.join("sessions"));
+        }
+        None
+    })
+}
+
 fn parse_claude_session_meta(
     record: &ImportedHistoryDiscoveredRecord,
 ) -> Result<Option<ClaudeCodeHistoryMeta>, String> {
@@ -210,6 +322,7 @@ fn parse_claude_session_meta(
 
     let mut created_at_ms = 0;
     let mut updated_at_ms = 0;
+    let mut external_title = claude_session_title_for_record(record)?;
     let mut first_prompt = String::new();
     let mut model: Option<String> = None;
     let mut repo_path: Option<String> = None;
@@ -246,6 +359,12 @@ fn parse_claude_session_meta(
         }
         if branch.is_none() && !parsed.git_branch.trim().is_empty() {
             branch = Some(parsed.git_branch.clone());
+        }
+        if external_title.is_empty() && parsed.r#type == "summary" {
+            let summary = parsed.summary.trim();
+            if !summary.is_empty() {
+                external_title = imported_history::truncate_name(summary, 200);
+            }
         }
         if let Some(message) = parsed.message {
             if first_prompt.is_empty() && parsed.r#type == "user" {
@@ -288,7 +407,9 @@ fn parse_claude_session_meta(
         source_mtime_ms: record.source_mtime_ms,
         source_size_bytes: record.source_size_bytes,
         source_fingerprint: record.source_fingerprint.clone(),
-        name: if first_prompt.is_empty() {
+        name: if !external_title.is_empty() {
+            external_title
+        } else if first_prompt.is_empty() {
             record.source_record_key.clone()
         } else {
             first_prompt

--- a/src-tauri/crates/orgtrack-core/src/sources/claude_code/history_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/claude_code/history_tests.rs
@@ -117,3 +117,79 @@ fn parses_claude_session_metadata() {
     std::fs::remove_file(&path).expect("remove fixture");
     std::fs::remove_dir(&temp_dir).expect("remove temp dir");
 }
+
+#[test]
+fn prefers_claude_session_json_name_as_name() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-claude-history-session-name-test-{}",
+        std::process::id()
+    ));
+    let project_dir = temp_dir.join("projects").join("-Users-me-project");
+    let sessions_dir = temp_dir.join("sessions");
+    std::fs::create_dir_all(&project_dir).expect("create project dir");
+    std::fs::create_dir_all(&sessions_dir).expect("create sessions dir");
+
+    let path = project_dir.join("64c10ac1-0c64-4437-86df-8a5beac77f4b.jsonl");
+    let content = r#"{"type":"user","sessionId":"64c10ac1-0c64-4437-86df-8a5beac77f4b","cwd":"/Users/me/project","gitBranch":"main","timestamp":"2026-07-08T07:06:46.543Z","message":{"role":"user","content":"first prompt fallback"}}
+{"type":"assistant","sessionId":"64c10ac1-0c64-4437-86df-8a5beac77f4b","cwd":"/Users/me/project","gitBranch":"main","timestamp":"2026-07-08T07:06:49.000Z","message":{"role":"assistant","model":"claude-sonnet-4","content":[{"type":"text","text":"done"}],"usage":{"input_tokens":12,"output_tokens":34}}}
+"#;
+    std::fs::write(&path, content).expect("write fixture");
+    std::fs::write(
+        sessions_dir.join("48664.json"),
+        r#"{"pid":48664,"sessionId":"64c10ac1-0c64-4437-86df-8a5beac77f4b","cwd":"/Users/me/project","startedAt":1783522457884,"name":"orgii-05","nameSource":"derived"}"#,
+    )
+    .expect("write session metadata");
+
+    let (source_mtime_ms, source_size_bytes) =
+        imported_paths::file_metadata_signature(&path, "Claude").expect("metadata");
+    let record = ImportedHistoryDiscoveredRecord {
+        source_session_id: "64c10ac1-0c64-4437-86df-8a5beac77f4b".to_string(),
+        source_path: path.clone(),
+        source_record_key: "64c10ac1-0c64-4437-86df-8a5beac77f4b".to_string(),
+        source_mtime_ms,
+        source_size_bytes,
+        source_fingerprint: String::new(),
+        parser_version: CLAUDE_CODE_METADATA_PARSER_VERSION,
+    };
+    let meta = parse_claude_session_meta(&record)
+        .expect("parse")
+        .expect("session meta");
+
+    assert_eq!(meta.name, "orgii-05");
+
+    std::fs::remove_dir_all(&temp_dir).expect("remove temp dir");
+}
+
+#[test]
+fn prefers_claude_summary_as_session_name() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-claude-history-summary-test-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+    let path = temp_dir.join("claude-summary.jsonl");
+    let content = r#"{"type":"summary","summary":"Ship auth dashboard","leafUuid":"abc"}
+{"type":"user","sessionId":"abc","cwd":"/tmp/project","gitBranch":"main","timestamp":"2026-04-01T07:06:46.543Z","message":{"role":"user","content":"build this"}}
+"#;
+    std::fs::write(&path, content).expect("write fixture");
+
+    let (source_mtime_ms, source_size_bytes) =
+        imported_paths::file_metadata_signature(&path, "Claude").expect("metadata");
+    let record = ImportedHistoryDiscoveredRecord {
+        source_session_id: "claude-summary".to_string(),
+        source_path: path.clone(),
+        source_record_key: "claude-summary".to_string(),
+        source_mtime_ms,
+        source_size_bytes,
+        source_fingerprint: String::new(),
+        parser_version: CLAUDE_CODE_METADATA_PARSER_VERSION,
+    };
+    let meta = parse_claude_session_meta(&record)
+        .expect("parse")
+        .expect("session meta");
+
+    assert_eq!(meta.name, "Ship auth dashboard");
+
+    std::fs::remove_file(&path).expect("remove fixture");
+    std::fs::remove_dir(&temp_dir).expect("remove temp dir");
+}

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app.rs
@@ -27,7 +27,7 @@ use crate::sources::imported_history::{
 
 const CODEX_APP_SESSION_PREFIX: &str = "codexapp-";
 const CODEX_PROVIDER_SLUG: &str = "codex";
-const CODEX_APP_METADATA_PARSER_VERSION: i64 = 3;
+const CODEX_APP_METADATA_PARSER_VERSION: i64 = 7;
 
 pub type CodexAppSessionRow = ImportedHistorySessionRow;
 pub type CodexAppSessionPage = ImportedHistorySessionPage;
@@ -43,6 +43,7 @@ struct CodexAppSessionMeta {
     source_size_bytes: i64,
     source_fingerprint: String,
     name: String,
+    parent_session_id: Option<String>,
     created_at_ms: i64,
     updated_at_ms: i64,
     model: Option<String>,
@@ -56,6 +57,8 @@ struct CodexAppSessionMeta {
 struct CodexJsonlLine {
     #[serde(default)]
     timestamp: Option<String>,
+    #[serde(default, rename = "type")]
+    line_type: String,
     #[serde(default)]
     payload: Value,
 }
@@ -66,6 +69,22 @@ struct CodexTurnContextPayload {
     cwd: String,
     #[serde(default)]
     model: String,
+}
+
+#[derive(Debug, Clone)]
+struct CodexSessionIndexEntry {
+    thread_name: String,
+    updated_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexSessionIndexLine {
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    thread_name: String,
+    #[serde(default)]
+    updated_at: Option<String>,
 }
 
 pub fn list_codex_app_sessions_paginated(
@@ -122,29 +141,33 @@ fn discover_codex_app_records() -> Result<Vec<ImportedHistoryDiscoveredRecord>, 
     let mut sessions = Vec::new();
     for sessions_dir in codex_sessions_dirs()? {
         if sessions_dir.is_dir() {
-            collect_codex_session_files(&sessions_dir, &mut sessions)?;
+            let title_index = load_codex_session_index_for_sessions_dir(&sessions_dir)?;
+            let mut files = Vec::new();
+            collect_codex_session_files(&sessions_dir, &mut files)?;
+            for path in files {
+                let Some(file_stem) = path
+                    .file_stem()
+                    .and_then(|value| value.to_str())
+                    .map(ToString::to_string)
+                else {
+                    continue;
+                };
+                let (source_mtime_ms, source_size_bytes) =
+                    imported_paths::file_metadata_signature(&path, "Codex")?;
+                let source_fingerprint = codex_source_fingerprint(&file_stem, &title_index);
+                sessions.push(ImportedHistoryDiscoveredRecord {
+                    source_session_id: file_stem.clone(),
+                    source_path: path,
+                    source_record_key: file_stem,
+                    source_mtime_ms,
+                    source_size_bytes,
+                    source_fingerprint,
+                    parser_version: CODEX_APP_METADATA_PARSER_VERSION,
+                });
+            }
         }
     }
-    sessions
-        .into_iter()
-        .filter_map(|path| {
-            let file_stem = path.file_stem()?.to_str()?.to_string();
-            Some((path, file_stem))
-        })
-        .map(|(path, file_stem)| {
-            let (source_mtime_ms, source_size_bytes) =
-                imported_paths::file_metadata_signature(&path, "Codex")?;
-            Ok(ImportedHistoryDiscoveredRecord {
-                source_session_id: file_stem.clone(),
-                source_path: path,
-                source_record_key: file_stem,
-                source_mtime_ms,
-                source_size_bytes,
-                source_fingerprint: String::new(),
-                parser_version: CODEX_APP_METADATA_PARSER_VERSION,
-            })
-        })
-        .collect()
+    Ok(sessions)
 }
 
 fn collect_codex_session_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), String> {
@@ -163,6 +186,139 @@ fn collect_codex_session_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(),
     Ok(())
 }
 
+fn load_codex_session_index_for_sessions_dir(
+    sessions_dir: &Path,
+) -> Result<HashMap<String, CodexSessionIndexEntry>, String> {
+    let Some(root) = sessions_dir.parent() else {
+        return Ok(HashMap::new());
+    };
+    load_codex_session_index(&root.join("session_index.jsonl"))
+}
+
+fn load_codex_session_index(
+    index_path: &Path,
+) -> Result<HashMap<String, CodexSessionIndexEntry>, String> {
+    let mut entries = HashMap::new();
+    if !index_path.is_file() {
+        return Ok(entries);
+    }
+
+    let file = fs::File::open(index_path).map_err(|err| {
+        format!(
+            "Failed to open Codex session index {}: {err}",
+            index_path.display()
+        )
+    })?;
+    let reader = BufReader::new(file);
+
+    for line in reader.lines() {
+        let line = line.map_err(|err| {
+            format!(
+                "Failed to read Codex session index {}: {err}",
+                index_path.display()
+            )
+        })?;
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let parsed: CodexSessionIndexLine = match serde_json::from_str(trimmed) {
+            Ok(parsed) => parsed,
+            Err(_) => continue,
+        };
+        let id = parsed.id.trim();
+        let thread_name = parsed.thread_name.trim();
+        if id.is_empty() || thread_name.is_empty() {
+            continue;
+        }
+        entries.insert(
+            id.to_string(),
+            CodexSessionIndexEntry {
+                thread_name: thread_name.to_string(),
+                updated_at: parsed.updated_at,
+            },
+        );
+    }
+
+    Ok(entries)
+}
+
+fn codex_source_fingerprint(
+    file_stem: &str,
+    title_index: &HashMap<String, CodexSessionIndexEntry>,
+) -> String {
+    codex_title_entry_for_file_stem(file_stem, title_index)
+        .map(|entry| {
+            format!(
+                "session-index:{}:{}",
+                entry.updated_at.as_deref().unwrap_or_default(),
+                entry.thread_name
+            )
+        })
+        .unwrap_or_default()
+}
+
+fn codex_session_index_title_for_record(
+    record: &ImportedHistoryDiscoveredRecord,
+) -> Result<String, String> {
+    let Some(index_path) = codex_index_path_for_session_path(&record.source_path) else {
+        return Ok(String::new());
+    };
+    let title_index = load_codex_session_index(&index_path)?;
+    Ok(
+        codex_title_entry_for_file_stem(&record.source_record_key, &title_index)
+            .map(|entry| imported_history::truncate_name(&entry.thread_name, 200))
+            .unwrap_or_default(),
+    )
+}
+
+fn codex_index_path_for_session_path(session_path: &Path) -> Option<PathBuf> {
+    codex_sessions_dir_for_session_path(session_path).and_then(|sessions_dir| {
+        sessions_dir
+            .parent()
+            .map(|root| root.join("session_index.jsonl"))
+    })
+}
+
+fn codex_sessions_dir_for_session_path(session_path: &Path) -> Option<PathBuf> {
+    session_path
+        .ancestors()
+        .find(|ancestor| ancestor.file_name().and_then(|name| name.to_str()) == Some("sessions"))
+        .map(Path::to_path_buf)
+}
+
+fn codex_title_entry_for_file_stem<'a>(
+    file_stem: &str,
+    title_index: &'a HashMap<String, CodexSessionIndexEntry>,
+) -> Option<&'a CodexSessionIndexEntry> {
+    codex_thread_id_from_file_stem(file_stem).and_then(|thread_id| title_index.get(thread_id))
+}
+
+fn codex_thread_id_from_file_stem(file_stem: &str) -> Option<&str> {
+    if is_uuid_like(file_stem) {
+        return Some(file_stem);
+    }
+    if file_stem.len() < 36 {
+        return None;
+    }
+    let candidate = &file_stem[file_stem.len() - 36..];
+    is_uuid_like(candidate).then_some(candidate)
+}
+
+fn is_uuid_like(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.len() != 36 {
+        return false;
+    }
+    bytes.iter().enumerate().all(|(index, byte)| {
+        if matches!(index, 8 | 13 | 18 | 23) {
+            *byte == b'-'
+        } else {
+            byte.is_ascii_hexdigit()
+        }
+    })
+}
+
 fn parse_codex_session_meta(
     record: &ImportedHistoryDiscoveredRecord,
 ) -> Result<Option<CodexAppSessionMeta>, String> {
@@ -176,6 +332,7 @@ fn parse_codex_session_meta(
 
     let mut created_at_ms = 0;
     let mut updated_at_ms = 0;
+    let mut external_title = codex_session_index_title_for_record(record)?;
     let mut first_prompt = String::new();
     let mut model: Option<String> = None;
     let mut repo_path: Option<String> = None;
@@ -183,6 +340,7 @@ fn parse_codex_session_meta(
     let mut output_tokens = 0;
     let mut impact = ImportedHistoryImpactStats::default();
     let mut touched_files = BTreeSet::new();
+    let mut parent_thread_id: Option<String> = None;
 
     for line in reader.lines() {
         let line = line.map_err(|err| format!("Failed to read Codex history line: {err}"))?;
@@ -210,6 +368,17 @@ fn parse_codex_session_meta(
             if let Some(message) = user_message_from_payload(&parsed.payload) {
                 first_prompt = imported_history::truncate_name(&message, 200);
             }
+        }
+        if external_title.is_empty() && parsed.line_type == "session_meta" {
+            if let Some(title) = session_title_from_payload(&parsed.payload) {
+                external_title = imported_history::truncate_name(&title, 200);
+            }
+        }
+        if parent_thread_id.is_none() && parsed.line_type == "session_meta" {
+            parent_thread_id = parent_thread_id_from_session_meta_payload(
+                &parsed.payload,
+                codex_thread_id_from_file_stem(&record.source_record_key),
+            );
         }
         if model.is_none() || repo_path.is_none() {
             if let Ok(turn_context) =
@@ -245,7 +414,9 @@ fn parse_codex_session_meta(
         return Ok(None);
     }
 
-    let name = if first_prompt.is_empty() {
+    let name = if !external_title.is_empty() {
+        external_title
+    } else if first_prompt.is_empty() {
         record.source_record_key.clone()
     } else {
         first_prompt
@@ -259,6 +430,9 @@ fn parse_codex_session_meta(
         source_size_bytes: record.source_size_bytes,
         source_fingerprint: record.source_fingerprint.clone(),
         name,
+        parent_session_id: parent_thread_id
+            .as_deref()
+            .and_then(|thread_id| codex_parent_session_id_for_record(record, thread_id)),
         created_at_ms: if created_at_ms > 0 {
             created_at_ms
         } else {
@@ -299,8 +473,70 @@ fn session_meta_to_cache_input(meta: CodexAppSessionMeta) -> ImportedHistoryCach
         impact: meta.impact,
         listable: true,
         source_metadata_json: None,
-        parent_session_id: None,
+        parent_session_id: meta.parent_session_id,
     }
+}
+
+fn parent_thread_id_from_session_meta_payload(
+    payload: &Value,
+    current_thread_id: Option<&str>,
+) -> Option<String> {
+    let is_subagent = payload.get("thread_source").and_then(Value::as_str) == Some("subagent")
+        || payload.pointer("/source/subagent").is_some();
+    if !is_subagent {
+        return None;
+    }
+
+    let direct_candidates = [
+        payload.get("parent_thread_id"),
+        payload.pointer("/source/subagent/thread_spawn/parent_thread_id"),
+        payload.get("forked_from_id"),
+        payload.get("session_id"),
+    ];
+
+    for candidate in direct_candidates {
+        if let Some(parent_thread_id) = candidate
+            .and_then(Value::as_str)
+            .and_then(|value| normalize_parent_thread_id_candidate(value, current_thread_id))
+        {
+            return Some(parent_thread_id);
+        }
+    }
+    None
+}
+
+fn normalize_parent_thread_id_candidate(
+    value: &str,
+    current_thread_id: Option<&str>,
+) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || Some(trimmed) == current_thread_id {
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+fn codex_parent_session_id_for_record(
+    record: &ImportedHistoryDiscoveredRecord,
+    parent_thread_id: &str,
+) -> Option<String> {
+    let parent_file_stem =
+        codex_file_stem_for_thread_id_near_session(&record.source_path, parent_thread_id)?;
+    Some(format!("{CODEX_APP_SESSION_PREFIX}{parent_file_stem}"))
+}
+
+fn codex_file_stem_for_thread_id_near_session(
+    session_path: &Path,
+    thread_id: &str,
+) -> Option<String> {
+    let sessions_dir = codex_sessions_dir_for_session_path(session_path)?;
+    let mut files = Vec::new();
+    collect_codex_session_files(&sessions_dir, &mut files).ok()?;
+    files.into_iter().find_map(|path| {
+        let file_stem = path.file_stem().and_then(|value| value.to_str())?;
+        (codex_thread_id_from_file_stem(file_stem) == Some(thread_id))
+            .then(|| file_stem.to_string())
+    })
 }
 
 fn collect_codex_impact_from_payload(
@@ -359,6 +595,19 @@ fn accumulate_patch_impact(
 }
 
 fn patch_file_path_from_line(line: &str) -> Option<String> {
+    for prefix in [
+        "*** Add File:",
+        "*** Update File:",
+        "*** Modify File:",
+        "*** Delete File:",
+    ] {
+        if let Some(path) = line.strip_prefix(prefix) {
+            let path = path.trim();
+            if !path.is_empty() {
+                return Some(path.to_string());
+            }
+        }
+    }
     if let Some(rest) = line.strip_prefix("diff --git ") {
         let mut parts = rest.split_whitespace();
         let _old_path = parts.next();
@@ -388,7 +637,7 @@ fn load_codex_app_from_path(session_id: &str, path: &Path) -> Result<Vec<Activit
     let reader = BufReader::new(file);
 
     let mut chunks = Vec::new();
-    let mut pending_tool_calls: HashMap<String, ImportedToolCall> = HashMap::new();
+    let mut pending_tool_calls: HashMap<String, Vec<ImportedToolCall>> = HashMap::new();
     let mut sequence = 0usize;
 
     for line in reader.lines() {
@@ -462,28 +711,33 @@ fn load_codex_app_from_path(session_id: &str, path: &Path) -> Result<Vec<Activit
                 }
             }
             "function_call" => {
-                if let Some(call) = pending_tool_call_from_payload(&parsed.payload, &created_at) {
-                    pending_tool_calls.insert(call.call_id.clone(), call);
+                if let Some((call_id, calls)) =
+                    pending_tool_calls_from_payload(&parsed.payload, &created_at)
+                {
+                    pending_tool_calls.insert(call_id, calls);
                 }
             }
             "custom_tool_call" => {
-                if let Some(call) =
-                    pending_custom_tool_call_from_payload(&parsed.payload, &created_at)
+                if let Some((call_id, calls)) =
+                    pending_custom_tool_calls_from_payload(&parsed.payload, &created_at)
                 {
-                    pending_tool_calls.insert(call.call_id.clone(), call);
+                    pending_tool_calls.insert(call_id, calls);
                 }
             }
             "function_call_output" | "custom_tool_call_output" => {
                 let call_id = parsed.payload.get("call_id").and_then(Value::as_str);
                 if let Some(call_id) = call_id {
-                    if let Some(call) = pending_tool_calls.remove(call_id) {
+                    if let Some(calls) = pending_tool_calls.remove(call_id) {
                         let output = parsed
                             .payload
                             .get("output")
                             .and_then(Value::as_str)
                             .unwrap_or_default();
-                        chunks.push(codex_tool_call_chunk(session_id, sequence, &call, output));
-                        sequence += 1;
+                        let outputs = output_parts_for_tool_calls(&calls, output);
+                        for (call, output) in calls.iter().zip(outputs.iter()) {
+                            chunks.push(codex_tool_call_chunk(session_id, sequence, call, output));
+                            sequence += 1;
+                        }
                     }
                 }
             }
@@ -491,9 +745,11 @@ fn load_codex_app_from_path(session_id: &str, path: &Path) -> Result<Vec<Activit
         }
     }
 
-    for call in pending_tool_calls.into_values() {
-        chunks.push(codex_tool_call_chunk(session_id, sequence, &call, ""));
-        sequence += 1;
+    for calls in pending_tool_calls.into_values() {
+        for call in calls {
+            chunks.push(codex_tool_call_chunk(session_id, sequence, &call, ""));
+            sequence += 1;
+        }
     }
 
     Ok(chunks)
@@ -526,7 +782,52 @@ fn codex_tool_call_chunk(
     chunk
 }
 
-fn pending_tool_call_from_payload(payload: &Value, created_at: &str) -> Option<ImportedToolCall> {
+fn output_parts_for_tool_calls(calls: &[ImportedToolCall], output: &str) -> Vec<String> {
+    if calls.len() <= 1 {
+        return vec![output.to_string()];
+    }
+
+    let limits = calls
+        .iter()
+        .map(read_line_limit_from_call)
+        .collect::<Option<Vec<_>>>();
+    let Some(limits) = limits else {
+        return vec![output.to_string(); calls.len()];
+    };
+
+    let lines = output.split_inclusive('\n').collect::<Vec<_>>();
+    let mut cursor = 0usize;
+    calls
+        .iter()
+        .enumerate()
+        .map(|(index, _)| {
+            let remaining = lines.len().saturating_sub(cursor);
+            let take = if index + 1 == calls.len() {
+                remaining
+            } else {
+                limits[index].min(remaining)
+            };
+            let part = lines[cursor..cursor.saturating_add(take)].concat();
+            cursor = cursor.saturating_add(take);
+            part
+        })
+        .collect()
+}
+
+fn read_line_limit_from_call(call: &ImportedToolCall) -> Option<usize> {
+    if call.canonical_name != imported_history::FUNCTION_READ_FILE {
+        return None;
+    }
+    call.args
+        .get("limit")
+        .and_then(Value::as_i64)
+        .and_then(|value| usize::try_from(value).ok())
+}
+
+fn pending_tool_calls_from_payload(
+    payload: &Value,
+    created_at: &str,
+) -> Option<(String, Vec<ImportedToolCall>)> {
     let call_id = payload.get("call_id")?.as_str()?.to_string();
     let raw_name = payload.get("name")?.as_str()?.to_string();
     let arguments = payload
@@ -534,20 +835,29 @@ fn pending_tool_call_from_payload(payload: &Value, created_at: &str) -> Option<I
         .and_then(Value::as_str)
         .map(imported_history::parse_inner_json)
         .unwrap_or_else(|| json!({}));
-    let (canonical_name, args) = normalize_codex_tool_call(&raw_name, arguments);
-    Some(ImportedToolCall {
-        call_id,
-        raw_name,
-        canonical_name,
-        args,
-        created_at: created_at.to_string(),
-    })
+    let normalized_calls = normalize_codex_tool_calls(&raw_name, arguments);
+    let call_count = normalized_calls.len();
+    if call_count == 0 {
+        return None;
+    }
+    let calls = normalized_calls
+        .into_iter()
+        .enumerate()
+        .map(|(index, (canonical_name, args))| ImportedToolCall {
+            call_id: split_call_id(&call_id, index, call_count),
+            raw_name: raw_name.clone(),
+            canonical_name,
+            args,
+            created_at: created_at.to_string(),
+        })
+        .collect();
+    Some((call_id, calls))
 }
 
-fn pending_custom_tool_call_from_payload(
+fn pending_custom_tool_calls_from_payload(
     payload: &Value,
     created_at: &str,
-) -> Option<ImportedToolCall> {
+) -> Option<(String, Vec<ImportedToolCall>)> {
     let call_id = payload.get("call_id")?.as_str()?.to_string();
     let raw_name = payload.get("name")?.as_str()?.to_string();
     let input = payload
@@ -559,61 +869,81 @@ fn pending_custom_tool_call_from_payload(
     } else {
         json!({ "input": input })
     };
-    let (canonical_name, args) = normalize_codex_tool_call(&raw_name, args);
-    Some(ImportedToolCall {
-        call_id,
-        raw_name,
-        canonical_name,
-        args,
-        created_at: created_at.to_string(),
-    })
+    let normalized_calls = normalize_codex_tool_calls(&raw_name, args);
+    let call_count = normalized_calls.len();
+    if call_count == 0 {
+        return None;
+    }
+    let calls = normalized_calls
+        .into_iter()
+        .enumerate()
+        .map(|(index, (canonical_name, args))| ImportedToolCall {
+            call_id: split_call_id(&call_id, index, call_count),
+            raw_name: raw_name.clone(),
+            canonical_name,
+            args,
+            created_at: created_at.to_string(),
+        })
+        .collect();
+    Some((call_id, calls))
 }
 
-fn normalize_codex_tool_call(raw_name: &str, args: Value) -> (String, Value) {
+fn split_call_id(call_id: &str, index: usize, total: usize) -> String {
+    if total <= 1 {
+        call_id.to_string()
+    } else {
+        format!("{call_id}:part-{index}")
+    }
+}
+
+fn normalize_codex_tool_calls(raw_name: &str, args: Value) -> Vec<(String, Value)> {
     let key = normalize_tool_name_key(raw_name);
     match key.as_str() {
         "shell" | "shell_command" | "bash" | "terminal" | "terminal_command" | "run_shell"
         | "run_command" | "execute" | "exec" => {
             let shell_args = normalize_shell_args(args);
-            if let Some(read_args) = read_file_args_from_shell_args(&shell_args) {
-                (imported_history::FUNCTION_READ_FILE.to_string(), read_args)
+            if let Some(read_args) = read_file_arg_values_from_shell_args(&shell_args) {
+                read_args
+                    .into_iter()
+                    .map(|args| (imported_history::FUNCTION_READ_FILE.to_string(), args))
+                    .collect()
             } else if let Some(search_args) = rg_search_args_from_shell_args(&shell_args) {
-                (
+                vec![(
                     imported_history::FUNCTION_CODE_SEARCH.to_string(),
                     search_args,
-                )
+                )]
             } else {
-                (
+                vec![(
                     imported_history::FUNCTION_RUN_COMMAND_LINE.to_string(),
                     shell_args,
-                )
+                )]
             }
         }
         "rg" | "ripgrep" | "grep" | "search" | "code_search" | "search_code"
-        | "search_codebase" => (
+        | "search_codebase" => vec![(
             imported_history::FUNCTION_CODE_SEARCH.to_string(),
             normalize_search_args(args),
-        ),
+        )],
         "cat" | "sed" | "head" | "tail" => {
             let shell_args = normalize_shell_args(args);
             if let Some(read_args) = read_file_args_from_shell_args(&shell_args) {
-                (imported_history::FUNCTION_READ_FILE.to_string(), read_args)
+                vec![(imported_history::FUNCTION_READ_FILE.to_string(), read_args)]
             } else {
-                (
+                vec![(
                     imported_history::FUNCTION_RUN_COMMAND_LINE.to_string(),
                     shell_args,
-                )
+                )]
             }
         }
-        "apply_patch" => (
+        "apply_patch" => vec![(
             imported_history::FUNCTION_EDIT_FILE.to_string(),
             normalize_apply_patch_args(args),
-        ),
-        "edit" | "edit_file" | "write" | "write_file" | "create_file" => (
+        )],
+        "edit" | "edit_file" | "write" | "write_file" | "create_file" => vec![(
             imported_history::FUNCTION_EDIT_FILE.to_string(),
             normalize_edit_args(raw_name, args),
-        ),
-        _ => (raw_name.to_string(), args),
+        )],
+        _ => vec![(raw_name.to_string(), args)],
     }
 }
 
@@ -722,29 +1052,80 @@ fn normalize_search_args(args: Value) -> Value {
 }
 
 fn read_file_args_from_shell_args(shell_args: &Value) -> Option<Value> {
+    read_file_arg_values_from_shell_args(shell_args)?
+        .into_iter()
+        .next()
+}
+
+fn read_file_arg_values_from_shell_args(shell_args: &Value) -> Option<Vec<Value>> {
     let command = shell_args.get("command").and_then(Value::as_str)?.trim();
     if command.is_empty() {
         return None;
     }
 
-    let tokens = shell_tokens(command);
-    let read_args = read_file_args_from_tokens(&tokens)?;
     let cwd = shell_args
         .get("cwd")
         .and_then(Value::as_str)
         .unwrap_or_default()
         .to_string();
+    let commands = split_shell_read_command_chain(command)?;
+    let command_count = commands.len();
+    let mut read_args_values = Vec::with_capacity(command_count);
 
-    Some(json!({
+    for (index, command_part) in commands.iter().enumerate() {
+        let tokens = shell_tokens(command_part);
+        let read_args = read_file_args_from_tokens(&tokens)?;
+        if command_count > 1 && read_args.limit.is_none() {
+            return None;
+        }
+        let mut value = shell_read_args_to_value(
+            read_args,
+            command_part,
+            &cwd,
+            shell_args,
+            command,
+            index,
+            command_count,
+        );
+        if command_count == 1 {
+            if let Some(obj) = value.as_object_mut() {
+                obj.remove("source_command");
+                obj.remove("command_index");
+                obj.remove("command_count");
+            }
+        }
+        read_args_values.push(value);
+    }
+
+    if read_args_values.is_empty() {
+        None
+    } else {
+        Some(read_args_values)
+    }
+}
+
+fn shell_read_args_to_value(
+    read_args: ShellReadArgs,
+    command: &str,
+    cwd: &str,
+    shell_args: &Value,
+    source_command: &str,
+    command_index: usize,
+    command_count: usize,
+) -> Value {
+    json!({
         "path": read_args.path.clone(),
         "file_path": read_args.path.clone(),
         "target_file": read_args.path,
         "offset": read_args.offset,
         "limit": read_args.limit,
         "command": command,
+        "source_command": source_command,
+        "command_index": command_index,
+        "command_count": command_count,
         "cwd": cwd,
         "payload": shell_args.clone(),
-    }))
+    })
 }
 
 struct ShellReadArgs {
@@ -753,8 +1134,71 @@ struct ShellReadArgs {
     limit: Option<i64>,
 }
 
+fn split_shell_read_command_chain(command: &str) -> Option<Vec<String>> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut quote: Option<char> = None;
+    let mut chars = command.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if let Some(active_quote) = quote {
+            current.push(ch);
+            if ch == active_quote {
+                quote = None;
+            } else if ch == '\\' && active_quote == '"' {
+                if let Some(next) = chars.next() {
+                    current.push(next);
+                }
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' | '"' => {
+                quote = Some(ch);
+                current.push(ch);
+            }
+            '&' if chars.peek() == Some(&'&') => {
+                chars.next();
+                push_shell_command_part(&mut parts, &mut current)?;
+            }
+            '|' if chars.peek() == Some(&'|') => return None,
+            ';' => {
+                push_shell_command_part(&mut parts, &mut current)?;
+            }
+            _ => current.push(ch),
+        }
+    }
+
+    if quote.is_some() {
+        return None;
+    }
+    push_shell_command_part(&mut parts, &mut current)?;
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts)
+    }
+}
+
+fn push_shell_command_part(parts: &mut Vec<String>, current: &mut String) -> Option<()> {
+    let part = current.trim();
+    if part.is_empty() {
+        return None;
+    }
+    parts.push(part.to_string());
+    current.clear();
+    Some(())
+}
+
 fn read_file_args_from_tokens(tokens: &[String]) -> Option<ShellReadArgs> {
-    if tokens.is_empty() || tokens.iter().any(|token| is_shell_separator(token)) {
+    if tokens.is_empty() {
+        return None;
+    }
+    if let Some(read_args) = read_file_args_from_nl_sed_pipeline(tokens) {
+        return Some(read_args);
+    }
+    if tokens.iter().any(|token| is_shell_separator(token)) {
         return None;
     }
 
@@ -766,6 +1210,117 @@ fn read_file_args_from_tokens(tokens: &[String]) -> Option<ShellReadArgs> {
         "tail" => read_file_args_from_head_tail(&tokens[1..], false),
         _ => None,
     }
+}
+
+fn read_file_args_from_nl_sed_pipeline(tokens: &[String]) -> Option<ShellReadArgs> {
+    if tokens
+        .iter()
+        .any(|token| matches!(token.as_str(), "&&" | "||" | ";"))
+    {
+        return None;
+    }
+
+    let mut pipe_indices = tokens
+        .iter()
+        .enumerate()
+        .filter_map(|(index, token)| (token == "|").then_some(index));
+    let pipe_index = pipe_indices.next()?;
+    if pipe_indices.next().is_some() || pipe_index == 0 || pipe_index + 1 >= tokens.len() {
+        return None;
+    }
+
+    let path = read_file_path_from_nl(&tokens[..pipe_index])?;
+    let (offset, limit) = read_range_from_pipeline_sed(&tokens[(pipe_index + 1)..])?;
+    Some(ShellReadArgs {
+        path,
+        offset,
+        limit,
+    })
+}
+
+fn read_file_path_from_nl(tokens: &[String]) -> Option<String> {
+    if tokens.is_empty() {
+        return None;
+    }
+    let executable = tokens[0].rsplit('/').next().unwrap_or(tokens[0].as_str());
+    if executable != "nl" {
+        return None;
+    }
+
+    let mut paths = Vec::new();
+    let mut index = 1usize;
+    while index < tokens.len() {
+        let token = tokens[index].as_str();
+        if token == "--" {
+            paths.extend(tokens[(index + 1)..].iter().cloned());
+            break;
+        }
+        if token.starts_with('-') {
+            index += if nl_option_consumes_next(token) { 2 } else { 1 };
+            continue;
+        }
+        paths.push(token.to_string());
+        index += 1;
+    }
+
+    single_shell_path_arg(&paths)
+}
+
+fn nl_option_consumes_next(token: &str) -> bool {
+    matches!(
+        token,
+        "-b" | "-d" | "-f" | "-h" | "-i" | "-l" | "-n" | "-s" | "-v" | "-w"
+    ) || matches!(
+        token,
+        "--body-numbering"
+            | "--section-delimiter"
+            | "--footer-numbering"
+            | "--header-numbering"
+            | "--line-increment"
+            | "--join-blank-lines"
+            | "--number-format"
+            | "--number-separator"
+            | "--starting-line-number"
+            | "--number-width"
+    )
+}
+
+fn read_range_from_pipeline_sed(tokens: &[String]) -> Option<(Option<i64>, Option<i64>)> {
+    if tokens.is_empty() {
+        return None;
+    }
+    let executable = tokens[0].rsplit('/').next().unwrap_or(tokens[0].as_str());
+    if executable != "sed" {
+        return None;
+    }
+
+    let mut index = 1usize;
+    let mut has_quiet = false;
+    let mut range_expr: Option<&str> = None;
+    while index < tokens.len() {
+        let token = tokens[index].as_str();
+        match token {
+            "-n" | "--quiet" | "--silent" => {
+                has_quiet = true;
+                index += 1;
+            }
+            "-e" | "--expression" => {
+                range_expr = tokens.get(index + 1).map(String::as_str);
+                index += 2;
+            }
+            _ if token.starts_with('-') => return None,
+            _ if range_expr.is_none() => {
+                range_expr = Some(token);
+                index += 1;
+            }
+            _ => return None,
+        }
+    }
+
+    if !has_quiet {
+        return None;
+    }
+    sed_range_to_offset_limit(range_expr?)
 }
 
 fn read_file_args_from_cat(tokens: &[String]) -> Option<ShellReadArgs> {
@@ -907,7 +1462,26 @@ fn single_shell_path_arg(paths: &[String]) -> Option<String> {
 
 fn sed_range_to_offset_limit(expr: &str) -> Option<(Option<i64>, Option<i64>)> {
     let expr = expr.trim().trim_end_matches(';');
-    if !expr.ends_with('p') || expr.contains('/') || expr.contains('s') {
+    if expr.contains('/') || expr.contains('s') {
+        return None;
+    }
+    let mut parts = expr
+        .split(';')
+        .map(str::trim)
+        .filter(|part| !part.is_empty());
+    let first_part = parts.next()?;
+    let (offset, limit) = sed_single_range_to_offset_limit(first_part)?;
+    for part in parts {
+        sed_single_range_to_offset_limit(part)?;
+    }
+    if expr.contains(';') {
+        return Some((offset, None));
+    }
+    Some((offset, limit))
+}
+
+fn sed_single_range_to_offset_limit(expr: &str) -> Option<(Option<i64>, Option<i64>)> {
+    if !expr.ends_with('p') {
         return None;
     }
     let range = expr.trim_end_matches('p').trim();
@@ -1099,19 +1673,6 @@ fn rg_flag_consumes_next(token: &str) -> bool {
 
 fn first_apply_patch_file_path(patch: &str) -> Option<String> {
     for line in patch.lines() {
-        for prefix in [
-            "*** Add File:",
-            "*** Update File:",
-            "*** Modify File:",
-            "*** Delete File:",
-        ] {
-            if let Some(path) = line.strip_prefix(prefix) {
-                let path = path.trim();
-                if !path.is_empty() {
-                    return Some(path.to_string());
-                }
-            }
-        }
         if let Some(path) = patch_file_path_from_line(line) {
             if path != "/dev/null" {
                 return Some(path);
@@ -1142,6 +1703,22 @@ fn user_message_from_payload(payload: &Value) -> Option<String> {
         .get("message")
         .and_then(Value::as_str)
         .map(ToString::to_string)
+}
+
+fn session_title_from_payload(payload: &Value) -> Option<String> {
+    [
+        "title",
+        "name",
+        "threadName",
+        "thread_name",
+        "conversationTitle",
+        "conversation_title",
+    ]
+    .iter()
+    .filter_map(|key| payload.get(*key).and_then(Value::as_str))
+    .map(str::trim)
+    .find(|value| !value.is_empty())
+    .map(ToString::to_string)
 }
 
 fn content_text_from_payload(payload: &Value) -> Option<String> {

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app.rs
@@ -27,7 +27,7 @@ use crate::sources::imported_history::{
 
 const CODEX_APP_SESSION_PREFIX: &str = "codexapp-";
 const CODEX_PROVIDER_SLUG: &str = "codex";
-const CODEX_APP_METADATA_PARSER_VERSION: i64 = 7;
+const CODEX_APP_METADATA_PARSER_VERSION: i64 = 8;
 
 pub type CodexAppSessionRow = ImportedHistorySessionRow;
 pub type CodexAppSessionPage = ImportedHistorySessionPage;

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
@@ -186,6 +186,146 @@ fn codex_sed_shell_command_renders_as_read_file() {
 }
 
 #[test]
+fn codex_chained_sed_reads_split_into_read_file_chunks() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-codex-history-chained-sed-read-test-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+    let path = temp_dir.join("rollout-chained-sed-read.jsonl");
+    let command = "sed -n '250,285p' src-tauri/crates/orgtrack-core/src/sources/imported_history/mod.rs && sed -n '860,900p' src-tauri/crates/orgtrack-core/src/sources/codex/app.rs";
+    let arguments =
+        serde_json::json!({ "command": command, "workdir": "/tmp/project" }).to_string();
+    let output = (1..=77)
+        .map(|line| format!("line-{line}\n"))
+        .collect::<String>();
+    let content = format!(
+        r#"{{"timestamp":"2026-02-11T06:16:07.000Z","type":"response_item","payload":{{"type":"function_call","name":"shell_command","arguments":{},"call_id":"call_chained_sed"}}}}
+{{"timestamp":"2026-02-11T06:16:08.000Z","type":"response_item","payload":{{"type":"function_call_output","call_id":"call_chained_sed","output":{}}}}}
+"#,
+        serde_json::to_string(&arguments).expect("encode args string"),
+        serde_json::to_string(&output).expect("encode output string")
+    );
+    std::fs::write(&path, content).expect("write fixture");
+
+    let chunks = load_codex_app_from_path("codexapp-chained-sed-read", &path).expect("parse");
+
+    assert_eq!(chunks.len(), 2);
+    assert_eq!(chunks[0].function, imported_history::FUNCTION_READ_FILE);
+    assert_eq!(chunks[1].function, imported_history::FUNCTION_READ_FILE);
+    assert_eq!(
+        chunks[0].args.get("path").and_then(Value::as_str),
+        Some("src-tauri/crates/orgtrack-core/src/sources/imported_history/mod.rs")
+    );
+    assert_eq!(
+        chunks[0].args.get("offset").and_then(Value::as_i64),
+        Some(249)
+    );
+    assert_eq!(
+        chunks[0].args.get("limit").and_then(Value::as_i64),
+        Some(36)
+    );
+    assert_eq!(
+        chunks[1].args.get("path").and_then(Value::as_str),
+        Some("src-tauri/crates/orgtrack-core/src/sources/codex/app.rs")
+    );
+    assert_eq!(
+        chunks[1].args.get("offset").and_then(Value::as_i64),
+        Some(859)
+    );
+    assert_eq!(
+        chunks[1].args.get("limit").and_then(Value::as_i64),
+        Some(41)
+    );
+    assert_eq!(
+        chunks[0].args.get("source_command").and_then(Value::as_str),
+        Some(command)
+    );
+    let first_output = (1..=36)
+        .map(|line| format!("line-{line}\n"))
+        .collect::<String>();
+    let second_output = (37..=77)
+        .map(|line| format!("line-{line}\n"))
+        .collect::<String>();
+    assert_eq!(
+        chunks[0].result.get("output").and_then(Value::as_str),
+        Some(first_output.as_str())
+    );
+    assert_eq!(
+        chunks[1].result.get("output").and_then(Value::as_str),
+        Some(second_output.as_str())
+    );
+
+    std::fs::remove_file(&path).expect("remove fixture");
+    std::fs::remove_dir(&temp_dir).expect("remove temp dir");
+}
+
+#[test]
+fn codex_mixed_chained_shell_command_stays_terminal() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-codex-history-mixed-chain-test-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+    let path = temp_dir.join("rollout-mixed-chain.jsonl");
+    let content = r#"{"timestamp":"2026-02-11T06:16:07.000Z","type":"response_item","payload":{"type":"function_call","name":"shell_command","arguments":"{\"command\":\"sed -n '1,2p' src/app.ts && git status --short\",\"workdir\":\"/tmp/project\"}","call_id":"call_mixed_chain"}}
+{"timestamp":"2026-02-11T06:16:08.000Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_mixed_chain","output":"const x = 1;\n M src/app.ts"}}
+"#;
+    std::fs::write(&path, content).expect("write fixture");
+
+    let chunks = load_codex_app_from_path("codexapp-mixed-chain", &path).expect("parse");
+
+    assert_eq!(chunks.len(), 1);
+    assert_eq!(
+        chunks[0].function,
+        imported_history::FUNCTION_RUN_COMMAND_LINE
+    );
+
+    std::fs::remove_file(&path).expect("remove fixture");
+    std::fs::remove_dir(&temp_dir).expect("remove temp dir");
+}
+
+#[test]
+fn codex_nl_sed_pipeline_shell_command_renders_as_read_file() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-codex-history-nl-sed-read-test-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+    let path = temp_dir.join("rollout-nl-sed-read.jsonl");
+    let content = r#"{"timestamp":"2026-02-11T06:16:07.000Z","type":"response_item","payload":{"type":"function_call","name":"shell_command","arguments":"{\"command\":\"nl -ba src-tauri/crates/orgtrack-core/src/sources/codex/app.rs | sed -n '52,65p;176,265p;1148,1165p'\",\"workdir\":\"/tmp/project\"}","call_id":"call_nl_sed"}}
+{"timestamp":"2026-02-11T06:16:08.000Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_nl_sed","output":"    52\t    impact: ImportedHistoryImpactStats,\n   176\t    let mut created_at_ms = 0;"}}
+"#;
+    std::fs::write(&path, content).expect("write fixture");
+
+    let chunks = load_codex_app_from_path("codexapp-nl-sed-read", &path).expect("parse");
+
+    assert_eq!(chunks.len(), 1);
+    assert_eq!(chunks[0].function, imported_history::FUNCTION_READ_FILE);
+    assert_eq!(
+        chunks[0].args.get("path").and_then(Value::as_str),
+        Some("src-tauri/crates/orgtrack-core/src/sources/codex/app.rs")
+    );
+    assert_eq!(
+        chunks[0].args.get("offset").and_then(Value::as_i64),
+        Some(51)
+    );
+    assert!(chunks[0]
+        .args
+        .get("limit")
+        .is_some_and(serde_json::Value::is_null));
+    assert_eq!(
+        chunks[0].args.get("command").and_then(Value::as_str),
+        Some(
+            "nl -ba src-tauri/crates/orgtrack-core/src/sources/codex/app.rs | sed -n '52,65p;176,265p;1148,1165p'"
+        )
+    );
+
+    std::fs::remove_file(&path).expect("remove fixture");
+    std::fs::remove_dir(&temp_dir).expect("remove temp dir");
+}
+
+#[test]
 fn codex_sed_transform_shell_command_stays_terminal() {
     let temp_dir = std::env::temp_dir().join(format!(
         "orgii-codex-history-sed-terminal-test-{}",
@@ -208,6 +348,35 @@ fn codex_sed_transform_shell_command_stays_terminal() {
     assert_eq!(
         chunks[0].args.get("command").and_then(Value::as_str),
         Some("sed 's/old/new/' src/app.ts")
+    );
+
+    std::fs::remove_file(&path).expect("remove fixture");
+    std::fs::remove_dir(&temp_dir).expect("remove temp dir");
+}
+
+#[test]
+fn codex_nl_sed_transform_pipeline_stays_terminal() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-codex-history-nl-sed-terminal-test-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+    let path = temp_dir.join("rollout-nl-sed-terminal.jsonl");
+    let content = r#"{"timestamp":"2026-02-11T06:16:07.000Z","type":"response_item","payload":{"type":"function_call","name":"shell_command","arguments":"{\"command\":\"nl -ba src/app.ts | sed 's/old/new/'\",\"workdir\":\"/tmp/project\"}","call_id":"call_nl_sed_transform"}}
+{"timestamp":"2026-02-11T06:16:08.000Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_nl_sed_transform","output":"new text"}}
+"#;
+    std::fs::write(&path, content).expect("write fixture");
+
+    let chunks = load_codex_app_from_path("codexapp-nl-sed-terminal", &path).expect("parse");
+
+    assert_eq!(chunks.len(), 1);
+    assert_eq!(
+        chunks[0].function,
+        imported_history::FUNCTION_RUN_COMMAND_LINE
+    );
+    assert_eq!(
+        chunks[0].args.get("command").and_then(Value::as_str),
+        Some("nl -ba src/app.ts | sed 's/old/new/'")
     );
 
     std::fs::remove_file(&path).expect("remove fixture");
@@ -254,6 +423,51 @@ fn codex_apply_patch_exposes_patch_text_and_file_path() {
 }
 
 #[test]
+fn codex_apply_patch_headers_contribute_file_stats() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-codex-history-apply-patch-stats-test-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+    let path = temp_dir.join("rollout-apply-patch-stats.jsonl");
+    let patch = "*** Begin Patch\n*** Update File: src/app.rs\n@@\n-old\n+new\n+extra\n*** Add File: src/new.rs\n+fresh\n*** End Patch";
+    let arguments = serde_json::json!({ "patch": patch }).to_string();
+    let content = format!(
+        r#"{{"timestamp":"2026-02-11T06:16:06.458Z","type":"session_meta","payload":{{"cwd":"/Users/me/project","id":"abc"}}}}
+{{"timestamp":"2026-02-11T06:16:07.000Z","type":"response_item","payload":{{"type":"function_call","name":"apply_patch","arguments":{},"call_id":"call_patch"}}}}
+"#,
+        serde_json::to_string(&arguments).expect("encode args string")
+    );
+    std::fs::write(&path, content).expect("write fixture");
+
+    let (source_mtime_ms, source_size_bytes) =
+        imported_paths::file_metadata_signature(&path, "Codex").expect("metadata");
+    let record = ImportedHistoryDiscoveredRecord {
+        source_session_id: "rollout-apply-patch-stats".to_string(),
+        source_path: path.clone(),
+        source_record_key: "rollout-apply-patch-stats".to_string(),
+        source_mtime_ms,
+        source_size_bytes,
+        source_fingerprint: String::new(),
+        parser_version: CODEX_APP_METADATA_PARSER_VERSION,
+    };
+    let meta = parse_codex_session_meta(&record)
+        .expect("parse")
+        .expect("session meta");
+
+    assert_eq!(meta.impact.files_changed, 2);
+    assert_eq!(meta.impact.lines_added, 3);
+    assert_eq!(meta.impact.lines_removed, 1);
+    assert_eq!(
+        meta.impact.touched_files,
+        vec!["src/app.rs".to_string(), "src/new.rs".to_string()]
+    );
+
+    std::fs::remove_file(&path).expect("remove fixture");
+    std::fs::remove_dir(&temp_dir).expect("remove temp dir");
+}
+
+#[test]
 fn parses_codex_session_metadata() {
     let temp_dir = std::env::temp_dir().join(format!(
         "orgii-codex-history-meta-test-{}",
@@ -289,6 +503,203 @@ fn parses_codex_session_metadata() {
     assert_eq!(meta.repo_path.as_deref(), Some("/Users/me/project"));
     assert_eq!(meta.input_tokens, 12);
     assert_eq!(meta.output_tokens, 34);
+
+    std::fs::remove_file(&path).expect("remove fixture");
+    std::fs::remove_dir(&temp_dir).expect("remove temp dir");
+}
+
+#[test]
+fn prefers_codex_session_index_thread_name_as_name() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-codex-history-index-title-test-{}",
+        std::process::id()
+    ));
+    let sessions_dir = temp_dir.join("sessions").join("2026").join("07").join("08");
+    std::fs::create_dir_all(&sessions_dir).expect("create sessions dir");
+    let thread_id = "019f423a-51c2-7013-8310-2df985d06f7a";
+    let path = sessions_dir.join(format!("rollout-2026-07-08T22-55-46-{thread_id}.jsonl"));
+    let content = r#"{"timestamp":"2026-07-08T14:55:46.000Z","type":"session_meta","payload":{"cwd":"/Users/me/project","id":"019f423a-51c2-7013-8310-2df985d06f7a"}}
+{"timestamp":"2026-07-08T14:55:47.000Z","type":"event_msg","payload":{"type":"user_message","message":"first prompt fallback","images":[],"local_images":[],"text_elements":[]}}
+"#;
+    std::fs::write(&path, content).expect("write fixture");
+    std::fs::write(
+        temp_dir.join("session_index.jsonl"),
+        format!(
+            r#"{{"id":"{thread_id}","thread_name":"Update session sidebar","updated_at":"2026-07-08T14:55:57.939376Z"}}
+"#
+        ),
+    )
+    .expect("write session index");
+
+    let (source_mtime_ms, source_size_bytes) =
+        imported_paths::file_metadata_signature(&path, "Codex").expect("metadata");
+    let record = ImportedHistoryDiscoveredRecord {
+        source_session_id: path
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .expect("file stem")
+            .to_string(),
+        source_path: path.clone(),
+        source_record_key: path
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .expect("file stem")
+            .to_string(),
+        source_mtime_ms,
+        source_size_bytes,
+        source_fingerprint: String::new(),
+        parser_version: CODEX_APP_METADATA_PARSER_VERSION,
+    };
+    let meta = parse_codex_session_meta(&record)
+        .expect("parse")
+        .expect("session meta");
+
+    assert_eq!(meta.name, "Update session sidebar");
+
+    std::fs::remove_dir_all(&temp_dir).expect("remove temp dir");
+}
+
+#[test]
+fn maps_codex_subagent_parent_thread_to_parent_session_id() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-codex-history-subagent-parent-test-{}",
+        std::process::id()
+    ));
+    let sessions_dir = temp_dir.join("sessions").join("2026").join("07").join("08");
+    std::fs::create_dir_all(&sessions_dir).expect("create sessions dir");
+
+    let parent_thread_id = "019f423a-51c2-7013-8310-2df985d06f7a";
+    let child_thread_id = "019f4249-5f02-7ec3-998c-981f6676ccb3";
+    let parent_file_stem = format!("rollout-2026-07-08T22-55-46-{parent_thread_id}");
+    let child_file_stem = format!("rollout-2026-07-08T23-12-12-{child_thread_id}");
+    let parent_path = sessions_dir.join(format!("{parent_file_stem}.jsonl"));
+    let child_path = sessions_dir.join(format!("{child_file_stem}.jsonl"));
+
+    std::fs::write(
+        &parent_path,
+        format!(
+            r#"{{"timestamp":"2026-07-08T14:55:46.000Z","type":"session_meta","payload":{{"cwd":"/Users/me/project","id":"{parent_thread_id}"}}}}
+"#
+        ),
+    )
+    .expect("write parent fixture");
+    std::fs::write(
+        &child_path,
+        format!(
+            r#"{{"timestamp":"2026-07-08T15:12:12.000Z","type":"session_meta","payload":{{"cwd":"/Users/me/project","id":"{child_thread_id}","session_id":"{parent_thread_id}","forked_from_id":"{parent_thread_id}","parent_thread_id":"{parent_thread_id}","thread_source":"subagent","source":{{"subagent":{{"thread_spawn":{{"parent_thread_id":"{parent_thread_id}","depth":1,"agent_nickname":"Copernicus"}}}}}}}}}}
+{{"timestamp":"2026-07-08T15:12:13.000Z","type":"event_msg","payload":{{"type":"user_message","message":"inspect session naming","images":[],"local_images":[],"text_elements":[]}}}}
+"#
+        ),
+    )
+    .expect("write child fixture");
+
+    let (source_mtime_ms, source_size_bytes) =
+        imported_paths::file_metadata_signature(&child_path, "Codex").expect("metadata");
+    let record = ImportedHistoryDiscoveredRecord {
+        source_session_id: child_file_stem.clone(),
+        source_path: child_path,
+        source_record_key: child_file_stem,
+        source_mtime_ms,
+        source_size_bytes,
+        source_fingerprint: String::new(),
+        parser_version: CODEX_APP_METADATA_PARSER_VERSION,
+    };
+    let meta = parse_codex_session_meta(&record)
+        .expect("parse")
+        .expect("session meta");
+
+    let expected_parent_session_id = format!("codexapp-{parent_file_stem}");
+    assert_eq!(
+        meta.parent_session_id.as_deref(),
+        Some(expected_parent_session_id.as_str())
+    );
+
+    std::fs::remove_dir_all(&temp_dir).expect("remove temp dir");
+}
+
+#[test]
+fn does_not_map_regular_codex_fork_as_subagent_parent() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-codex-history-regular-fork-test-{}",
+        std::process::id()
+    ));
+    let sessions_dir = temp_dir.join("sessions").join("2026").join("07").join("08");
+    std::fs::create_dir_all(&sessions_dir).expect("create sessions dir");
+
+    let parent_thread_id = "019f423a-51c2-7013-8310-2df985d06f7a";
+    let child_thread_id = "019f4249-5f02-7ec3-998c-981f6676ccb3";
+    let parent_file_stem = format!("rollout-2026-07-08T22-55-46-{parent_thread_id}");
+    let child_file_stem = format!("rollout-2026-07-08T23-12-12-{child_thread_id}");
+    let parent_path = sessions_dir.join(format!("{parent_file_stem}.jsonl"));
+    let child_path = sessions_dir.join(format!("{child_file_stem}.jsonl"));
+
+    std::fs::write(
+        &parent_path,
+        format!(
+            r#"{{"timestamp":"2026-07-08T14:55:46.000Z","type":"session_meta","payload":{{"cwd":"/Users/me/project","id":"{parent_thread_id}"}}}}
+"#
+        ),
+    )
+    .expect("write parent fixture");
+    std::fs::write(
+        &child_path,
+        format!(
+            r#"{{"timestamp":"2026-07-08T15:12:12.000Z","type":"session_meta","payload":{{"cwd":"/Users/me/project","id":"{child_thread_id}","forked_from_id":"{parent_thread_id}"}}}}
+{{"timestamp":"2026-07-08T15:12:13.000Z","type":"event_msg","payload":{{"type":"user_message","message":"regular fork","images":[],"local_images":[],"text_elements":[]}}}}
+"#
+        ),
+    )
+    .expect("write child fixture");
+
+    let (source_mtime_ms, source_size_bytes) =
+        imported_paths::file_metadata_signature(&child_path, "Codex").expect("metadata");
+    let record = ImportedHistoryDiscoveredRecord {
+        source_session_id: child_file_stem.clone(),
+        source_path: child_path,
+        source_record_key: child_file_stem,
+        source_mtime_ms,
+        source_size_bytes,
+        source_fingerprint: String::new(),
+        parser_version: CODEX_APP_METADATA_PARSER_VERSION,
+    };
+    let meta = parse_codex_session_meta(&record)
+        .expect("parse")
+        .expect("session meta");
+
+    assert!(meta.parent_session_id.is_none());
+
+    std::fs::remove_dir_all(&temp_dir).expect("remove temp dir");
+}
+
+#[test]
+fn prefers_codex_session_meta_title_as_name() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-codex-history-title-test-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+    let path = temp_dir.join("rollout-title.jsonl");
+    let content = r#"{"timestamp":"2026-02-11T06:16:06.458Z","type":"session_meta","payload":{"cwd":"/Users/me/project","id":"abc","title":"Review payment flow"}}
+{"timestamp":"2026-02-11T06:16:08.000Z","type":"event_msg","payload":{"type":"user_message","message":"build this","images":[],"local_images":[],"text_elements":[]}}
+"#;
+    std::fs::write(&path, content).expect("write fixture");
+
+    let (source_mtime_ms, source_size_bytes) =
+        imported_paths::file_metadata_signature(&path, "Codex").expect("metadata");
+    let record = ImportedHistoryDiscoveredRecord {
+        source_session_id: "rollout-title".to_string(),
+        source_path: path.clone(),
+        source_record_key: "rollout-title".to_string(),
+        source_mtime_ms,
+        source_size_bytes,
+        source_fingerprint: String::new(),
+        parser_version: CODEX_APP_METADATA_PARSER_VERSION,
+    };
+    let meta = parse_codex_session_meta(&record)
+        .expect("parse")
+        .expect("session meta");
+
+    assert_eq!(meta.name, "Review payment flow");
 
     std::fs::remove_file(&path).expect("remove fixture");
     std::fs::remove_dir(&temp_dir).expect("remove temp dir");

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
@@ -565,15 +565,25 @@ fn maps_codex_subagent_parent_thread_to_parent_session_id() {
         "orgii-codex-history-subagent-parent-test-{}",
         std::process::id()
     ));
-    let sessions_dir = temp_dir.join("sessions").join("2026").join("07").join("08");
-    std::fs::create_dir_all(&sessions_dir).expect("create sessions dir");
+    let parent_sessions_dir = temp_dir
+        .join("sessions")
+        .join("2026")
+        .join("07")
+        .join("08");
+    let child_sessions_dir = temp_dir
+        .join("sessions")
+        .join("2026")
+        .join("07")
+        .join("09");
+    std::fs::create_dir_all(&parent_sessions_dir).expect("create parent sessions dir");
+    std::fs::create_dir_all(&child_sessions_dir).expect("create child sessions dir");
 
     let parent_thread_id = "019f423a-51c2-7013-8310-2df985d06f7a";
-    let child_thread_id = "019f4249-5f02-7ec3-998c-981f6676ccb3";
+    let child_thread_id = "019f427d-8e5a-7533-baf4-2bce6a8bcdda";
     let parent_file_stem = format!("rollout-2026-07-08T22-55-46-{parent_thread_id}");
-    let child_file_stem = format!("rollout-2026-07-08T23-12-12-{child_thread_id}");
-    let parent_path = sessions_dir.join(format!("{parent_file_stem}.jsonl"));
-    let child_path = sessions_dir.join(format!("{child_file_stem}.jsonl"));
+    let child_file_stem = format!("rollout-2026-07-09T00-09-12-{child_thread_id}");
+    let parent_path = parent_sessions_dir.join(format!("{parent_file_stem}.jsonl"));
+    let child_path = child_sessions_dir.join(format!("{child_file_stem}.jsonl"));
 
     std::fs::write(
         &parent_path,

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache.rs
@@ -314,7 +314,7 @@ fn query_cached_sessions_from_conn(
     query_cached_sessions_by_filter_from_conn(
         conn,
         source,
-        "listable = ?2",
+        "listable = ?2 AND parent_session_id = ''",
         &[SqlValue::from(1_i64)],
         limit,
         offset,

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache_tests.rs
@@ -158,6 +158,28 @@ fn cache_source_list_filters_unlistable_sessions() {
 }
 
 #[test]
+fn cache_session_page_filters_child_sessions() {
+    let mut conn = fixture_conn();
+    let parent = input(SOURCE_CODEX_APP, "parent", 200);
+    let mut child = input(SOURCE_CODEX_APP, "child", 300);
+    child.parent_session_id = Some("codex_app-parent".to_string());
+    upsert_imported_session_cache_from_conn(&mut conn, &[parent, child]).expect("upsert");
+
+    let page =
+        query_imported_session_page_from_conn(&conn, SOURCE_CODEX_APP, 10, 0).expect("query page");
+    let cached_child = query_cached_session_from_conn(&conn, SOURCE_CODEX_APP, "child")
+        .expect("query child")
+        .expect("cached child");
+
+    assert_eq!(page.sessions.len(), 1);
+    assert_eq!(page.sessions[0].session_id, "codex_app-parent");
+    assert_eq!(
+        cached_child.parent_session_id.as_deref(),
+        Some("codex_app-parent")
+    );
+}
+
+#[test]
 fn cache_range_query_is_source_scoped_and_filters_unlistable_sessions() {
     let mut conn = fixture_conn();
     let inside = input(SOURCE_CODEX_APP, "inside", 200);

--- a/src-tauri/crates/perf-utils/src/diff_patch/conversion.rs
+++ b/src-tauri/crates/perf-utils/src/diff_patch/conversion.rs
@@ -6,9 +6,26 @@
 
 use super::types::{PatchConversionResult, PatchSegment};
 
+fn is_hunk_marker(line: &str) -> bool {
+    line.trim_start().starts_with("@@")
+}
+
+fn is_explicit_hunk_header(line: &str) -> bool {
+    let mut parts = line.split_whitespace();
+    matches!(parts.next(), Some("@@"))
+        && parts.next().is_some_and(|part| part.starts_with('-'))
+        && parts.next().is_some_and(|part| part.starts_with('+'))
+}
+
 /// Build unified diff lines for one section and return a `PatchSegment`.
 fn flush_section(file_path: &str, is_add: bool, section: &mut Vec<String>) -> Option<PatchSegment> {
-    if file_path.is_empty() || section.is_empty() {
+    let body_lines: Vec<&String> = section
+        .iter()
+        .filter(|line| !is_hunk_marker(line))
+        .collect();
+    let has_explicit_hunk_header = section.iter().any(|line| is_explicit_hunk_header(line));
+
+    if file_path.is_empty() || (body_lines.is_empty() && !has_explicit_hunk_header) {
         section.clear();
         return None;
     }
@@ -20,31 +37,36 @@ fn flush_section(file_path: &str, is_add: bool, section: &mut Vec<String>) -> Op
     if is_add {
         diff_lines.push("--- /dev/null".to_string());
         diff_lines.push(format!("+++ {}", file_path));
-        diff_lines.push(format!("@@ -0,0 +1,{} @@", section.len()));
+        diff_lines.push(format!("@@ -0,0 +1,{} @@", body_lines.len()));
     } else {
         diff_lines.push(format!("--- {}", file_path));
         diff_lines.push(format!("+++ {}", file_path));
-        let add_count = section.iter().filter(|l| l.starts_with('+')).count();
-        let rem_count = section.iter().filter(|l| l.starts_with('-')).count();
-        let ctx_count = section
-            .iter()
-            .filter(|l| !l.starts_with('+') && !l.starts_with('-'))
-            .count();
-        diff_lines.push(format!(
-            "@@ -1,{} +1,{} @@",
-            rem_count + ctx_count,
-            add_count + ctx_count
-        ));
+        if !has_explicit_hunk_header {
+            let add_count = body_lines.iter().filter(|l| l.starts_with('+')).count();
+            let rem_count = body_lines.iter().filter(|l| l.starts_with('-')).count();
+            let ctx_count = body_lines
+                .iter()
+                .filter(|l| !l.starts_with('+') && !l.starts_with('-'))
+                .count();
+            diff_lines.push(format!(
+                "@@ -1,{} +1,{} @@",
+                rem_count + ctx_count,
+                add_count + ctx_count
+            ));
+        }
     }
 
     for line in section.iter() {
+        if is_hunk_marker(line) && !is_explicit_hunk_header(line) {
+            continue;
+        }
         if line.starts_with('+') {
             seg_added += 1;
         } else if line.starts_with('-') {
             seg_removed += 1;
         }
+        diff_lines.push(line.clone());
     }
-    diff_lines.append(&mut section.clone());
     section.clear();
 
     Some(PatchSegment {
@@ -53,6 +75,7 @@ fn flush_section(file_path: &str, is_add: bool, section: &mut Vec<String>) -> Op
         lines_added: seg_added,
         lines_removed: seg_removed,
         is_deleted: false,
+        has_explicit_hunk_header: is_add || has_explicit_hunk_header,
     })
 }
 
@@ -76,10 +99,14 @@ pub(super) fn convert_patch_to_unified_impl(patch_text: &str) -> PatchConversion
             is_add_file = true;
             continue;
         }
-        if let Some(rest) = line.strip_prefix("*** Modify File: ").or_else(|| {
-            line.strip_prefix("***  Modify File: ")
-                .or_else(|| line.strip_prefix("*** \tModify File: "))
-        }) {
+        if let Some(rest) = line
+            .strip_prefix("*** Modify File: ")
+            .or_else(|| line.strip_prefix("***  Modify File: "))
+            .or_else(|| line.strip_prefix("*** \tModify File: "))
+            .or_else(|| line.strip_prefix("*** Update File: "))
+            .or_else(|| line.strip_prefix("***  Update File: "))
+            .or_else(|| line.strip_prefix("*** \tUpdate File: "))
+        {
             if let Some(seg) = flush_section(&current_file, is_add_file, &mut section_lines) {
                 segments.push(seg);
             }
@@ -105,6 +132,7 @@ pub(super) fn convert_patch_to_unified_impl(patch_text: &str) -> PatchConversion
                 lines_added: 0,
                 lines_removed: 0,
                 is_deleted: true,
+                has_explicit_hunk_header: false,
             });
             current_file = String::new();
             continue;
@@ -189,6 +217,7 @@ mod tests {
         let patch = "\
 *** Begin Patch
 *** Modify File: src/utils.rs
+@@
  fn helper() {
 -    old_impl();
 +    new_impl();
@@ -201,8 +230,31 @@ mod tests {
         assert_eq!(result.segments[0].file_path, "src/utils.rs");
         assert_eq!(result.segments[0].lines_added, 1);
         assert_eq!(result.segments[0].lines_removed, 1);
+        assert!(!result.segments[0].has_explicit_hunk_header);
+        assert!(!result.segments[0].diff.contains("\n@@\n"));
         assert_eq!(result.lines_added, 1);
         assert_eq!(result.lines_removed, 1);
+    }
+
+    #[test]
+    fn explicit_hunk_header_is_preserved() {
+        let patch = "\
+*** Begin Patch
+*** Update File: src/utils.rs
+@@ -42,3 +43,3 @@
+ context
+-old
++new
+*** End Patch";
+
+        let result = convert_patch_to_unified_impl(patch);
+
+        assert_eq!(result.segments.len(), 1);
+        assert!(result.segments[0].has_explicit_hunk_header);
+        assert!(result.segments[0].diff.contains("@@ -42,3 +43,3 @@"));
+        assert!(result.diff.contains("@@ -42,3 +43,3 @@"));
+        assert_eq!(result.segments[0].lines_added, 1);
+        assert_eq!(result.segments[0].lines_removed, 1);
     }
 
     #[test]

--- a/src-tauri/crates/perf-utils/src/diff_patch/types.rs
+++ b/src-tauri/crates/perf-utils/src/diff_patch/types.rs
@@ -191,6 +191,10 @@ pub struct PatchSegment {
     pub lines_added: usize,
     pub lines_removed: usize,
     pub is_deleted: bool,
+    /// True when the source patch supplied a numeric `@@ -N +M @@` hunk range.
+    /// Synthetic ranges keep the unified diff renderable but should not be
+    /// treated as authoritative line metadata.
+    pub has_explicit_hunk_header: bool,
 }
 
 /// Result of converting a "*** Begin Patch" format to unified diff.

--- a/src-tauri/src/agent_sessions/event_pipeline/extractors/file_extractor.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/extractors/file_extractor.rs
@@ -62,8 +62,14 @@ pub(super) fn extract_file(
         }
         None => (None, None),
     };
+    let (metadata_start_line, metadata_line_count) = read_line_metadata(args);
     let language = detect_language(&file_name);
-    let line_count = content.as_ref().map(|c| c.split('\n').count());
+    let line_count = if start_line.is_some() {
+        content.as_ref().map(|c| c.split('\n').count())
+    } else {
+        metadata_line_count.or_else(|| content.as_ref().map(|c| c.split('\n').count()))
+    };
+    let start_line = start_line.or(metadata_start_line);
 
     ExtractedFileData {
         file_path,
@@ -73,6 +79,26 @@ pub(super) fn extract_file(
         line_count,
         start_line,
     }
+}
+
+fn read_line_metadata(
+    args: Option<&serde_json::Map<String, serde_json::Value>>,
+) -> (Option<usize>, Option<usize>) {
+    let Some(args) = args else {
+        return (None, None);
+    };
+    let limit = args
+        .get("limit")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok());
+    let Some(limit) = limit else {
+        return (None, None);
+    };
+    let start_line = args
+        .get("offset")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|value| usize::try_from(value.saturating_add(1)).ok());
+    (start_line, Some(limit))
 }
 
 fn normalize_edit(mut edit: ExtractedEditData) -> ExtractedEditData {
@@ -108,11 +134,12 @@ pub(super) fn extract_edit(
 ) -> ExtractedEditData {
     // apply_patch: multi-file patch with custom format. Delegate to the
     // Rust patch converter so per-file segments are pre-computed.
-    if let Some(patch_text) = args
-        .and_then(|a| a.get("patch_text"))
-        .and_then(|v| v.as_str())
-    {
-        return extract_apply_patch(patch_text, result);
+    if let Some(patch_text) = args.and_then(|a| {
+        obj_str(a, "patch_text")
+            .or_else(|| obj_str(a, "patch"))
+            .or_else(|| obj_str(a, "input"))
+    }) {
+        return extract_apply_patch(&patch_text, result);
     }
 
     let file_data = extract_file(args, result);
@@ -229,8 +256,16 @@ pub(super) fn extract_apply_patch(
 
     let has_diff = !converted.diff.is_empty();
     let diff = if has_diff { Some(converted.diff) } else { None };
-    let (old_start_line, new_start_line) = parse_diff_start_lines(diff.as_deref());
-    normalize_edit(ExtractedEditData {
+    let has_explicit_hunk_header = converted
+        .segments
+        .iter()
+        .any(|seg| seg.has_explicit_hunk_header);
+    let (old_start_line, new_start_line) = if has_explicit_hunk_header {
+        parse_diff_start_lines(diff.as_deref())
+    } else {
+        (None, None)
+    };
+    let mut edit = normalize_edit(ExtractedEditData {
         file_path: first_path,
         file_name,
         language: "diff".to_string(),
@@ -245,7 +280,12 @@ pub(super) fn extract_apply_patch(
         lines_removed: Some(converted.lines_removed),
         is_deleted: false,
         apply_patch_segments: segments,
-    })
+    });
+    if !has_explicit_hunk_header {
+        edit.old_start_line = None;
+        edit.new_start_line = None;
+    }
+    edit
 }
 
 pub(super) fn extract_real_apply_patch_result(
@@ -417,9 +457,14 @@ pub(super) fn segment_to_edit(
     } else {
         None
     };
-    let (old_start_line, new_start_line) = parse_diff_start_lines(diff.as_deref());
+    let (old_start_line, new_start_line) = if segment.has_explicit_hunk_header {
+        parse_diff_start_lines(diff.as_deref())
+    } else {
+        (None, None)
+    };
 
-    normalize_edit(ExtractedEditData {
+    let has_explicit_hunk_header = segment.has_explicit_hunk_header;
+    let mut edit = normalize_edit(ExtractedEditData {
         file_path: segment.file_path.clone(),
         file_name,
         language,
@@ -434,5 +479,10 @@ pub(super) fn segment_to_edit(
         lines_removed: Some(segment.lines_removed),
         is_deleted: false,
         apply_patch_segments: Vec::new(),
-    })
+    });
+    if !has_explicit_hunk_header {
+        edit.old_start_line = None;
+        edit.new_start_line = None;
+    }
+    edit
 }

--- a/src-tauri/src/agent_sessions/event_pipeline/extractors/tests/extractors_tests.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/extractors/tests/extractors_tests.rs
@@ -88,6 +88,30 @@ fn test_extract_file_read() {
 }
 
 #[test]
+fn test_extract_file_read_uses_offset_limit_for_plain_imported_output() {
+    let event = make_event(
+        "read_file",
+        EventDisplayVariant::ToolCall,
+        serde_json::json!({
+            "file_path": "src/app.rs",
+            "offset": 249,
+            "limit": 36,
+        }),
+        serde_json::json!({"output": "plain imported sed output"}),
+    );
+
+    let data = extract_event_data(&event).unwrap();
+    match data {
+        ExtractedData::File(f) => {
+            assert_eq!(f.file_path, "src/app.rs");
+            assert_eq!(f.start_line, Some(250));
+            assert_eq!(f.line_count, Some(36));
+        }
+        _ => panic!("Expected File variant"),
+    }
+}
+
+#[test]
 fn test_extract_file_read_accepts_camel_case_file_path() {
     let event = make_event(
         "read_file",
@@ -740,6 +764,57 @@ fn test_extract_apply_patch_single_file() {
             assert!(e.apply_patch_segments.is_empty());
             assert_eq!(e.file_path, "src/new.rs");
             assert_eq!(e.file_name, "new.rs");
+        }
+        _ => panic!("Expected Edit variant"),
+    }
+}
+
+#[test]
+fn test_extract_apply_patch_accepts_patch_arg() {
+    let patch = "*** Begin Patch\n*** Update File: src/app.rs\n@@\n-old\n+new\n*** End Patch";
+    let event = make_event(
+        "apply_patch",
+        EventDisplayVariant::ToolCall,
+        serde_json::json!({"patch": patch}),
+        serde_json::json!({}),
+    );
+
+    let data = extract_event_data(&event).unwrap();
+    match data {
+        ExtractedData::Edit(e) => {
+            assert_eq!(e.file_path, "src/app.rs");
+            assert_eq!(e.file_name, "app.rs");
+            assert_eq!(e.lines_added, Some(1));
+            assert_eq!(e.lines_removed, Some(1));
+            assert_eq!(e.old_start_line, None);
+            assert_eq!(e.new_start_line, None);
+            assert!(e.diff.as_deref().unwrap_or_default().contains("+new"));
+        }
+        _ => panic!("Expected Edit variant"),
+    }
+}
+
+#[test]
+fn test_extract_apply_patch_preserves_explicit_hunk_line_range() {
+    let patch = "*** Begin Patch\n*** Update File: src/app.rs\n@@ -42,2 +43,2 @@\n-old\n+new\n*** End Patch";
+    let event = make_event(
+        "apply_patch",
+        EventDisplayVariant::ToolCall,
+        serde_json::json!({"patch": patch}),
+        serde_json::json!({}),
+    );
+
+    let data = extract_event_data(&event).unwrap();
+    match data {
+        ExtractedData::Edit(e) => {
+            assert_eq!(e.file_path, "src/app.rs");
+            assert_eq!(e.old_start_line, Some(42));
+            assert_eq!(e.new_start_line, Some(43));
+            assert!(e
+                .diff
+                .as_deref()
+                .unwrap_or_default()
+                .contains("@@ -42,2 +43,2 @@"));
         }
         _ => panic!("Expected Edit variant"),
     }

--- a/src/api/tauri/session/__tests__/session.test.ts
+++ b/src/api/tauri/session/__tests__/session.test.ts
@@ -43,6 +43,7 @@ describe("toFrontendSession", () => {
     const record = makeAggregateRecord({
       sessionId: "session-abc",
       name: "My Session",
+      displayLabel: "My Display Session",
       status: "completed",
       createdAt: "2024-02-15T08:00:00Z",
       updatedAt: "2024-02-15T09:30:00Z",
@@ -53,6 +54,7 @@ describe("toFrontendSession", () => {
 
     expect(result.session_id).toBe("session-abc");
     expect(result.name).toBe("My Session");
+    expect(result.displayLabel).toBe("My Display Session");
     expect(result.status).toBe("completed");
     expect(result.created_at).toBe("2024-02-15T08:00:00Z");
     expect(result.updated_at).toBe("2024-02-15T09:30:00Z");

--- a/src/api/tauri/session/index.ts
+++ b/src/api/tauri/session/index.ts
@@ -132,6 +132,7 @@ export function toFrontendSession(record: SessionAggregateRecord): Session {
     user_input: record.userInput,
     repo_name: record.repoName || "",
     name: record.name,
+    displayLabel: record.displayLabel,
     branch: record.branch || "",
     is_active: record.isActive,
     category,

--- a/src/components/SessionHoverCard/SessionHoverCardContent.tsx
+++ b/src/components/SessionHoverCard/SessionHoverCardContent.tsx
@@ -7,6 +7,7 @@ import {
   GitBranch,
   GitCommitVertical,
   Grip,
+  Pin,
   Save,
   Timer,
 } from "lucide-react";
@@ -17,6 +18,7 @@ import {
   type CursorIdeSessionDetail,
   cursorIdeSessionDetail,
 } from "@src/api/tauri/externalHistory";
+import { IMPORTED_HISTORY_SOURCE_DESCRIPTORS } from "@src/api/tauri/externalHistory/imported/descriptors";
 import {
   type CoreSessionSummary,
   getOrgtrackSessionSummary,
@@ -42,6 +44,7 @@ import { formatBranchLabel } from "@src/util/git/branchLabel";
 import { basename } from "@src/util/path";
 import {
   getDispatchCategory,
+  getExternalHistorySourceId,
   resolveSessionIconId,
 } from "@src/util/session/sessionDispatch";
 import { formatDuration } from "@src/util/time/formatDuration";
@@ -57,6 +60,13 @@ const logger = createLogger("SessionHoverCard");
 interface AgentSessionInfo {
   icon: React.ReactNode;
   label: string;
+  textClassName?: string;
+}
+
+interface SessionOriginInfo {
+  icon: React.ReactNode;
+  label: string;
+  sourceLabel: string;
   textClassName?: string;
 }
 
@@ -127,6 +137,36 @@ function getAgentSessionInfo(session: {
     icon: <AgentIcon size={13} strokeWidth={1.75} />,
     label: session.agentDisplayName || "Agent",
     textClassName: "text-text-1",
+  };
+}
+
+function getSessionOriginInfo(
+  sessionId: string,
+  t: (key: string, options?: { defaultValue?: string }) => string
+): SessionOriginInfo {
+  const sourceId = getExternalHistorySourceId(sessionId);
+  const source = IMPORTED_HISTORY_SOURCE_DESCRIPTORS.find(
+    (descriptor) => descriptor.sourceId === sourceId
+  );
+
+  if (source) {
+    return {
+      icon: <Pin size={13} strokeWidth={1.75} />,
+      label: t("history.detail.externalSession", {
+        defaultValue: "External session",
+      }),
+      sourceLabel: source.displayName,
+      textClassName: "text-accent-9",
+    };
+  }
+
+  return {
+    icon: <Pin size={13} strokeWidth={1.75} />,
+    label: t("history.detail.internalSession", {
+      defaultValue: "Internal session",
+    }),
+    sourceLabel: "ORGII",
+    textClassName: "text-text-3",
   };
 }
 
@@ -302,6 +342,7 @@ export const SessionHoverCardContent: React.FC<SessionHoverCardContentProps> =
       lastModel?.listingModel || lastModel?.model || undefined;
     const modelIconAgent = lastModel?.listingModelType || undefined;
     const agentSessionInfo = getAgentSessionInfo(session);
+    const sessionOriginInfo = getSessionOriginInfo(session.session_id, t);
 
     const dateTimeLabelOptions = {
       todayLabel: t("common:relativeDate.today"),
@@ -324,6 +365,19 @@ export const SessionHoverCardContent: React.FC<SessionHoverCardContentProps> =
 
     return (
       <HoverCardPanel>
+        <HoverCardRow
+          icon={sessionOriginInfo.icon}
+          iconClassName={sessionOriginInfo.textClassName}
+        >
+          <div
+            className="truncate text-text-2"
+            title={`${sessionOriginInfo.label} · ${sessionOriginInfo.sourceLabel}`}
+          >
+            <span className="text-text-3">{sessionOriginInfo.label}</span>
+            <span className="mx-1 text-text-4">·</span>
+            <span>{sessionOriginInfo.sourceLabel}</span>
+          </div>
+        </HoverCardRow>
         <HoverCardRow
           icon={agentSessionInfo.icon}
           iconClassName={agentSessionInfo.textClassName}

--- a/src/engines/ChatPanel/rendering/adapters/DiffAdapter.tsx
+++ b/src/engines/ChatPanel/rendering/adapters/DiffAdapter.tsx
@@ -12,16 +12,29 @@ import {
   statusToLifecycle,
   useLifecycleLabels,
 } from "@src/engines/SessionCore/rendering/registry";
-import type { UniversalEventProps } from "@src/engines/SessionCore/rendering/types/universalProps";
+import type {
+  ExtractedEditData,
+  UniversalEventProps,
+} from "@src/engines/SessionCore/rendering/types/universalProps";
 import { getFileName } from "@src/util/file/pathUtils";
 
 import DiffBlock from "../../blocks/DiffBlock";
+
+function firstSegmentFileName(editData: ExtractedEditData): string | undefined {
+  return editData.applyPatchSegments
+    ?.map(
+      (segment) =>
+        getFileName(segment.filePath) || getFileName(segment.fileName)
+    )
+    .find(Boolean);
+}
 
 export const DiffAdapter: React.FC<UniversalEventProps> = (props) => {
   const { t } = useTranslation("sessions");
   const action = (props.args?.action as string) || undefined;
   const editData = extractEditData(props);
   const fileName =
+    firstSegmentFileName(editData) ||
     getFileName(editData.filePath) ||
     getFileName(editData.fileName) ||
     (typeof props.args?.file_path === "string"

--- a/src/engines/SessionCore/core/atoms/actions.ts
+++ b/src/engines/SessionCore/core/atoms/actions.ts
@@ -19,7 +19,11 @@ import {
 } from "../../sync/utils/activityIds";
 import { isLiveRuntimeResourceEvent } from "../runningEventGate";
 import { eventStoreProxy } from "../store/EventStoreProxy";
-import type { SessionEvent, SessionSpec } from "../types";
+import type {
+  SessionEvent,
+  SessionSpec,
+  SimulatorEventPreview,
+} from "../types";
 import {
   applyRunningArgs,
   extendRunningArgsCache,
@@ -111,6 +115,96 @@ function isSimulatorVisibleApprox(event: SessionEvent): boolean {
     event.displayVariant === "thinking" ||
     event.displayVariant === "message"
   );
+}
+
+function getSimulatorFilterCategory(
+  event: SessionEvent
+): SimulatorEventPreview["filterCategory"] {
+  if (event.source === "user") return "key_interactions";
+  if (
+    event.uiCanonical === "edit_file" ||
+    event.uiCanonical === "delete_file"
+  ) {
+    return "file_changes";
+  }
+  if (event.command || event.uiCanonical === "run_shell") {
+    return "terminal_events";
+  }
+  if (
+    event.uiCanonical === "read_file" ||
+    event.uiCanonical === "list_dir" ||
+    event.uiCanonical === "code_search" ||
+    event.uiCanonical === "glob" ||
+    event.uiCanonical === "find_files" ||
+    event.uiCanonical === "search"
+  ) {
+    return "explore";
+  }
+  if (event.filePath) return "file_changes";
+  return "other";
+}
+
+function buildSimulatorPreview(event: SessionEvent): SimulatorEventPreview {
+  return {
+    id: event.id,
+    sessionId: event.sessionId,
+    createdAt: event.createdAt,
+    functionName: event.functionName,
+    uiCanonical: event.uiCanonical,
+    actionType: event.actionType,
+    source: event.source,
+    displayText: event.displayText,
+    displayStatus: event.displayStatus,
+    displayVariant: event.displayVariant,
+    activityStatus: event.activityStatus,
+    filterCategory: getSimulatorFilterCategory(event),
+    threadId: event.threadId,
+    processId: event.processId,
+    callId: event.callId,
+    filePath: event.filePath,
+    command: event.command,
+    isDelta: event.isDelta,
+    repoId: event.repoId,
+    repoPath: event.repoPath,
+  };
+}
+
+function buildSimulatorPreviewFields(events: SessionEvent[]): {
+  sortedSimulatorEventIds: string[];
+  eventPreviewById: Record<string, SimulatorEventPreview>;
+  createdAtById: Record<string, string>;
+  threadIdById: Record<string, string>;
+  functionNameById: Record<string, string>;
+  displayStatusById: Record<string, string>;
+  displayVariantById: Record<string, string>;
+} {
+  const sortedSimulatorEventIds: string[] = [];
+  const eventPreviewById: Record<string, SimulatorEventPreview> = {};
+  const createdAtById: Record<string, string> = {};
+  const threadIdById: Record<string, string> = {};
+  const functionNameById: Record<string, string> = {};
+  const displayStatusById: Record<string, string> = {};
+  const displayVariantById: Record<string, string> = {};
+
+  for (const event of events) {
+    sortedSimulatorEventIds.push(event.id);
+    eventPreviewById[event.id] = buildSimulatorPreview(event);
+    createdAtById[event.id] = event.createdAt;
+    if (event.threadId) threadIdById[event.id] = event.threadId;
+    functionNameById[event.id] = event.functionName;
+    displayStatusById[event.id] = event.displayStatus;
+    displayVariantById[event.id] = event.displayVariant;
+  }
+
+  return {
+    sortedSimulatorEventIds,
+    eventPreviewById,
+    createdAtById,
+    threadIdById,
+    functionNameById,
+    displayStatusById,
+    displayVariantById,
+  };
 }
 
 function syntheticMatchesQueuedMessage(
@@ -366,17 +460,20 @@ export const loadSessionAtom = atom(
     const eventIndex = Object.fromEntries(
       mergedEvents.map((event, index) => [event.id, index])
     );
+    const simulatorEvents = mergedEvents.filter(isSimulatorVisibleApprox);
+    const simulatorPreviewFields = buildSimulatorPreviewFields(simulatorEvents);
     set(derivedSnapshotAtom, {
       version: Date.now(),
       eventCount: mergedEvents.length,
       events: mergedEvents,
       chatEvents: mergedEvents.filter(isVisibleInChat),
-      messagesEvents: mergedEvents.filter(isSimulatorVisibleApprox),
-      sortedSimulatorEvents: mergedEvents.filter(isSimulatorVisibleApprox),
+      messagesEvents: simulatorEvents,
+      sortedSimulatorEvents: simulatorEvents,
       lastEvent: mergedEvents[mergedEvents.length - 1] ?? null,
       eventIndex,
       chatEventCount: mergedEvents.filter(isVisibleInChat).length,
       hasRunningEvent: mergedEvents.some(isLiveRuntimeResourceEvent),
+      ...simulatorPreviewFields,
     });
 
     // Merge events into Rust EventStore with explicit sessionId.

--- a/src/engines/SessionCore/rendering/props/__tests__/propsDataExtractors.test.ts
+++ b/src/engines/SessionCore/rendering/props/__tests__/propsDataExtractors.test.ts
@@ -498,6 +498,42 @@ describe("extractFileData", () => {
       expect(data.startLine).toBeUndefined();
     });
 
+    it("uses imported offset/limit metadata for plain read output ranges", () => {
+      const props = makeUniversalProps({
+        args: {
+          file_path: "src/app.rs",
+          offset: 249,
+          limit: 36,
+        },
+        result: { output: "plain imported sed output" },
+      });
+      const data = extractFileData(props);
+      expect(data.content).toBe("plain imported sed output");
+      expect(data.startLine).toBe(250);
+      expect(data.lineCount).toBe(36);
+    });
+
+    it("lets offset/limit repair stale rust extracted read ranges", () => {
+      const props = makeUniversalProps({
+        args: {
+          file_path: "src/app.rs",
+          offset: 859,
+          limit: 41,
+        },
+        rustExtracted: {
+          kind: "file",
+          filePath: "src/app.rs",
+          fileName: "app.rs",
+          content: "plain imported sed output",
+          language: "rust",
+          lineCount: 1,
+        },
+      });
+      const data = extractFileData(props);
+      expect(data.startLine).toBe(860);
+      expect(data.lineCount).toBe(41);
+    });
+
     it("reports startLine for ranged reads (offset/limit)", () => {
       const rangedContent = "[action: read_text]\n   120│fn main() {\n   121│}";
       const props = makeUniversalProps({
@@ -828,6 +864,82 @@ describe("extractEditData", () => {
       expect(data.applyPatchSegments?.[1]?.filePath).toBe("src/b.ts");
       expect(data.applyPatchSegments?.[1]?.linesRemoved).toBe(1);
       expect(data.applyPatchSegments?.[2]?.filePath).toBe("src/c.ts");
+    });
+
+    it("parses apply_patch text from args.patch", () => {
+      const patchText = [
+        "*** Begin Patch",
+        "*** Update File: src/from-patch.ts",
+        "@@",
+        "-old",
+        "+new",
+        "*** End Patch",
+      ].join("\n");
+      const props = makeUniversalProps({
+        args: { patch: patchText },
+      });
+      const data = extractEditData(props);
+      expect(data.filePath).toBe("src/from-patch.ts");
+      expect(data.fileName).toBe("from-patch.ts");
+      expect(data.applyPatchSegments).toHaveLength(1);
+      expect(data.linesAdded).toBe(1);
+      expect(data.linesRemoved).toBe(1);
+      expect(data.oldStartLine).toBeUndefined();
+      expect(data.newStartLine).toBeUndefined();
+      expect(data.applyPatchSegments?.[0]?.oldStartLine).toBeUndefined();
+      expect(data.applyPatchSegments?.[0]?.newStartLine).toBeUndefined();
+    });
+
+    it("preserves explicit apply_patch hunk line ranges", () => {
+      const patchText = [
+        "*** Begin Patch",
+        "*** Update File: src/ranged.ts",
+        "@@ -42,2 +43,2 @@",
+        "-old",
+        "+new",
+        "*** End Patch",
+      ].join("\n");
+      const props = makeUniversalProps({
+        args: { patch: patchText },
+      });
+      const data = extractEditData(props);
+      expect(data.filePath).toBe("src/ranged.ts");
+      expect(data.oldStartLine).toBe(42);
+      expect(data.newStartLine).toBe(43);
+      expect(data.applyPatchSegments?.[0]?.oldStartLine).toBe(42);
+      expect(data.applyPatchSegments?.[0]?.newStartLine).toBe(43);
+    });
+
+    it("repairs stale Rust patch placeholders from args.patch", () => {
+      const patchText = [
+        "*** Begin Patch",
+        "*** Update File: src/repaired.ts",
+        "@@",
+        "-const oldValue = true;",
+        "+const newValue = true;",
+        "*** End Patch",
+      ].join("\n");
+      const props = makeUniversalProps({
+        args: { patch: patchText },
+        rustExtracted: {
+          kind: "edit",
+          filePath: "",
+          fileName: "patch",
+          language: "diff",
+          diff: "",
+          linesAdded: 0,
+          linesRemoved: 0,
+          isDeleted: false,
+          applyPatchSegments: [],
+        },
+      });
+      const data = extractEditData(props);
+      expect(data.filePath).toBe("src/repaired.ts");
+      expect(data.fileName).toBe("repaired.ts");
+      expect(data.applyPatchSegments).toHaveLength(1);
+      expect(data.applyPatchSegments?.[0]?.filePath).toBe("src/repaired.ts");
+      expect(data.linesAdded).toBe(1);
+      expect(data.linesRemoved).toBe(1);
     });
 
     it("computes line counts from patch diff lines", () => {

--- a/src/engines/SessionCore/rendering/props/editExtractors.ts
+++ b/src/engines/SessionCore/rendering/props/editExtractors.ts
@@ -21,6 +21,7 @@ import { extractFileData } from "./fileExtractors";
 
 const HUNK_HEADER_REGEX = /^@@\s+-(\d+)(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/m;
 const DIFF_CODE_FENCE_REGEX = /```diff\s*\n([\s\S]*?)\n```/;
+const HUNK_MARKER_REGEX = /^@@/;
 
 interface DiffLineMeta {
   oldStartLine?: number;
@@ -47,6 +48,25 @@ function parseDiffLineMeta(diff: string | undefined): DiffLineMeta {
 // Main extractor
 // ============================================
 
+function patchTextFromArgs(
+  args: UniversalEventProps["args"]
+): string | undefined {
+  if (typeof args?.patch_text === "string") return args.patch_text;
+  if (typeof args?.patch === "string") return args.patch;
+  if (typeof args?.input === "string") return args.input;
+  return undefined;
+}
+
+function isPatchPlaceholder(edit: ExtractedEditData): boolean {
+  const filePath = edit.filePath.trim();
+  const fileName = edit.fileName.trim();
+  return (
+    !edit.applyPatchSegments?.length &&
+    (!filePath || filePath === "patch") &&
+    (!fileName || fileName === "patch")
+  );
+}
+
 export function extractEditData(props: UniversalEventProps): ExtractedEditData {
   if (props.rustExtracted?.kind === "edit") {
     const rust = props.rustExtracted;
@@ -69,7 +89,7 @@ export function extractEditData(props: UniversalEventProps): ExtractedEditData {
             isDeleted: seg.isDeleted || undefined,
           }))
         : undefined;
-    return {
+    const editData = {
       filePath: rust.filePath,
       fileName: rust.fileName,
       content: rust.content,
@@ -85,12 +105,18 @@ export function extractEditData(props: UniversalEventProps): ExtractedEditData {
       isDeleted: rust.isDeleted || undefined,
       applyPatchSegments,
     };
+    const patchText = patchTextFromArgs(props.args);
+    if (patchText && isPatchPlaceholder(editData)) {
+      return extractApplyPatchData(patchText, props.result);
+    }
+    return editData;
   }
 
   const { args, result } = props;
 
-  if (args?.patch_text && typeof args.patch_text === "string") {
-    return extractApplyPatchData(args.patch_text as string, result);
+  const patchText = patchTextFromArgs(args);
+  if (patchText) {
+    return extractApplyPatchData(patchText, result);
   }
 
   const fileData = extractFileData(props);
@@ -176,9 +202,20 @@ function extractApplyPatchData(
   const firstPath = parsed.filePaths.length > 0 ? parsed.filePaths[0] : "";
   const rawFileName = getFileName(firstPath) || "patch";
 
-  const applyPatchSegments = splitCombinedDiffIntoSegments(parsed.diff);
+  const applyPatchSegments = splitCombinedDiffIntoSegments(parsed.diff).map(
+    (segment) =>
+      parsed.hasExplicitHunkHeaders
+        ? segment
+        : {
+            ...segment,
+            oldStartLine: undefined,
+            newStartLine: undefined,
+          }
+  );
 
-  const diffMeta = parseDiffLineMeta(parsed.diff);
+  const diffMeta = parsed.hasExplicitHunkHeaders
+    ? parseDiffLineMeta(parsed.diff)
+    : {};
 
   return {
     filePath: firstPath,
@@ -330,6 +367,7 @@ function patchSegmentToExtractedEdit(
     linesAdded: number;
     linesRemoved: number;
     isDeleted: boolean;
+    hasExplicitHunkHeader?: boolean;
   },
   resultSummary: string | undefined,
   segmentIndex: number,
@@ -353,7 +391,10 @@ function patchSegmentToExtractedEdit(
   const detectedLang = detectLanguage(rawFileName);
   const language = detectedLang === "plaintext" ? "diff" : detectedLang;
 
-  const diffMeta = parseDiffLineMeta(segment.diff);
+  const diffMeta =
+    segment.hasExplicitHunkHeader === false
+      ? {}
+      : parseDiffLineMeta(segment.diff);
 
   return {
     filePath: segment.filePath,
@@ -383,6 +424,7 @@ interface SyncPatchResult {
   filePaths: string[];
   linesAdded: number;
   linesRemoved: number;
+  hasExplicitHunkHeaders: boolean;
 }
 
 const MAX_PATCH_CACHE = 50;
@@ -407,9 +449,17 @@ function convertPatchToUnifiedDiffSync(patchText: string): SyncPatchResult {
   let sectionLines: string[] = [];
   let totalAdded = 0;
   let totalRemoved = 0;
+  let hasExplicitHunkHeaders = false;
 
   const flushSection = () => {
     if (!currentFile || (sectionLines.length === 0 && !isDeleteFile)) return;
+    const bodyLines = sectionLines.filter(
+      (line) => !HUNK_MARKER_REGEX.test(line)
+    );
+    const hasExplicitHunkHeader = sectionLines.some((line) =>
+      HUNK_HEADER_REGEX.test(line)
+    );
+    hasExplicitHunkHeaders ||= isAddFile || hasExplicitHunkHeader;
     if (isDeleteFile) {
       diffLines.push(`--- ${currentFile}`);
       diffLines.push("+++ /dev/null");
@@ -417,21 +467,26 @@ function convertPatchToUnifiedDiffSync(patchText: string): SyncPatchResult {
     } else if (isAddFile) {
       diffLines.push("--- /dev/null");
       diffLines.push(`+++ ${currentFile}`);
-      diffLines.push(`@@ -0,0 +1,${sectionLines.length} @@`);
+      diffLines.push(`@@ -0,0 +1,${bodyLines.length} @@`);
     } else {
       diffLines.push(`--- ${currentFile}`);
       diffLines.push(`+++ ${currentFile}`);
-      let added = 0;
-      let removed = 0;
-      let context = 0;
-      for (const sl of sectionLines) {
-        if (sl.startsWith("+")) added++;
-        else if (sl.startsWith("-")) removed++;
-        else context++;
+      if (!hasExplicitHunkHeader) {
+        let added = 0;
+        let removed = 0;
+        let context = 0;
+        for (const sl of bodyLines) {
+          if (sl.startsWith("+")) added++;
+          else if (sl.startsWith("-")) removed++;
+          else context++;
+        }
+        diffLines.push(`@@ -1,${removed + context} +1,${added + context} @@`);
       }
-      diffLines.push(`@@ -1,${removed + context} +1,${added + context} @@`);
     }
     for (const sl of sectionLines) {
+      if (HUNK_MARKER_REGEX.test(sl) && !HUNK_HEADER_REGEX.test(sl)) {
+        continue;
+      }
       if (sl.startsWith("+")) totalAdded++;
       else if (sl.startsWith("-")) totalRemoved++;
       diffLines.push(sl);
@@ -485,9 +540,6 @@ function convertPatchToUnifiedDiffSync(patchText: string): SyncPatchResult {
     ) {
       continue;
     }
-    if (line.startsWith("@@")) {
-      continue;
-    }
     if (currentFile) {
       sectionLines.push(line);
     }
@@ -499,6 +551,7 @@ function convertPatchToUnifiedDiffSync(patchText: string): SyncPatchResult {
     filePaths,
     linesAdded: totalAdded,
     linesRemoved: totalRemoved,
+    hasExplicitHunkHeaders,
   };
   evictAndSet(patchCache, key, syncResult, MAX_PATCH_CACHE);
   return syncResult;

--- a/src/engines/SessionCore/rendering/props/fileExtractors.ts
+++ b/src/engines/SessionCore/rendering/props/fileExtractors.ts
@@ -19,17 +19,55 @@ import {
   stripLineNumberPrefixes,
 } from "./extractorShared";
 
+function payloadNumber(
+  payload: Record<string, unknown> | undefined,
+  key: string
+): number | undefined {
+  const value = payload?.[key];
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return value;
+  }
+  return undefined;
+}
+
+function readLineMetadata(args: UniversalEventProps["args"]): {
+  startLine?: number;
+  lineCount?: number;
+} {
+  const offset = payloadNumber(args, "offset");
+  const limit = payloadNumber(args, "limit");
+  if (limit === undefined) return {};
+  return {
+    startLine: offset !== undefined ? offset + 1 : undefined,
+    lineCount: limit,
+  };
+}
+
 export function extractFileData(props: UniversalEventProps): ExtractedFileData {
+  const metadata = readLineMetadata(props.args);
+
   if (props.rustExtracted?.kind === "file" && props.rustExtracted.filePath) {
     const { filePath, fileName, content, language } = props.rustExtracted;
     const stripped = content ? stripLineNumberPrefixes(content) : undefined;
+    const startLine =
+      stripped?.startLine ??
+      props.rustExtracted.startLine ??
+      metadata.startLine;
+    const hasNumberedStart =
+      stripped?.startLine !== undefined ||
+      props.rustExtracted.startLine !== undefined;
+    const lineCount = hasNumberedStart
+      ? (stripped?.lineCount ?? props.rustExtracted.lineCount)
+      : (metadata.lineCount ??
+        props.rustExtracted.lineCount ??
+        stripped?.lineCount);
     return {
       filePath,
       fileName,
       content: stripped?.content,
       language,
-      lineCount: stripped?.lineCount ?? props.rustExtracted.lineCount,
-      startLine: stripped?.startLine ?? props.rustExtracted.startLine,
+      lineCount,
+      startLine,
     };
   }
 
@@ -57,8 +95,11 @@ export function extractFileData(props: UniversalEventProps): ExtractedFileData {
 
   const stripped = rawContent ? stripLineNumberPrefixes(rawContent) : undefined;
   const content = stripped?.content;
-  const lineCount = stripped?.lineCount;
-  const startLine = stripped?.startLine;
+  const startLine = stripped?.startLine ?? metadata.startLine;
+  const lineCount =
+    stripped?.startLine !== undefined
+      ? stripped.lineCount
+      : (metadata.lineCount ?? stripped?.lineCount);
 
   const language = detectLanguage(fileName);
 

--- a/src/engines/SessionCore/rendering/types/universalProps.ts
+++ b/src/engines/SessionCore/rendering/types/universalProps.ts
@@ -216,6 +216,7 @@ export interface RustPatchSegment {
   linesAdded: number;
   linesRemoved: number;
   isDeleted: boolean;
+  hasExplicitHunkHeader?: boolean;
 }
 
 /** Mirrors Rust `PatchConversionResult` (serde camelCase). */

--- a/src/engines/SessionCore/sync/adapters/__tests__/externalHistoryAdapter.test.ts
+++ b/src/engines/SessionCore/sync/adapters/__tests__/externalHistoryAdapter.test.ts
@@ -22,6 +22,18 @@ describe("external history initial window", () => {
     expect(selectExternalHistoryInitialWindow(chunks)).toBe(chunks);
   });
 
+  it("returns full histories for non-windowed sources", () => {
+    const chunks = Array.from({ length: 250 }, (_, index) =>
+      chunk(index, index === 0 ? "raw" : "tool_call", "user_message")
+    );
+
+    expect(
+      selectExternalHistoryInitialWindow(chunks, {
+        supportsWindowedReplay: false,
+      })
+    ).toBe(chunks);
+  });
+
   it("expands the tail window back to the current user round", () => {
     const chunks = [
       chunk(0, "raw", "user_message"),

--- a/src/engines/SessionCore/sync/adapters/externalHistoryAdapter.ts
+++ b/src/engines/SessionCore/sync/adapters/externalHistoryAdapter.ts
@@ -22,8 +22,13 @@ function isUserMessageChunk(chunk: ActivityChunk): boolean {
 }
 
 export function selectExternalHistoryInitialWindow(
-  chunks: ActivityChunk[]
+  chunks: ActivityChunk[],
+  options: { supportsWindowedReplay?: boolean } = {}
 ): ActivityChunk[] {
+  if (options.supportsWindowedReplay === false) {
+    return chunks;
+  }
+
   if (chunks.length <= EXTERNAL_HISTORY_INITIAL_CHUNK_LIMIT) {
     return chunks;
   }
@@ -67,7 +72,9 @@ async function loadExternalHistory(
   if (signal.aborted || !Array.isArray(chunks) || chunks.length === 0) {
     return [];
   }
-  const initialWindow = selectExternalHistoryInitialWindow(chunks);
+  const initialWindow = selectExternalHistoryInitialWindow(chunks, {
+    supportsWindowedReplay: source.supportsWindowedReplay,
+  });
   const events = await processChunksRust(initialWindow, sessionId);
   if (signal.aborted) return [];
   return events;

--- a/src/features/CodeMirror/Diff/index.tsx
+++ b/src/features/CodeMirror/Diff/index.tsx
@@ -87,6 +87,8 @@ export interface CodeMirrorDiffProps {
   oldStartLine?: number;
   /** Starting line number for new/modified content when rendering a diff hunk. */
   newStartLine?: number;
+  /** Show editor gutter line numbers. */
+  showLineNumbers?: boolean;
   /** Custom class name */
   className?: string;
   /**
@@ -185,6 +187,7 @@ export const CodeMirrorDiff: React.FC<CodeMirrorDiffProps> = ({
   changeType,
   oldStartLine = 1,
   newStartLine = 1,
+  showLineNumbers = true,
   className = "",
   noBottomPadding = false,
 }) => {
@@ -234,12 +237,14 @@ export const CodeMirrorDiff: React.FC<CodeMirrorDiffProps> = ({
     new: string;
     changeType?: GitFileStatus;
     startLine: number;
+    showLineNumbers: boolean;
   } | null>(null);
   const splitContentRef = useRef<{
     old: string;
     new: string;
     oldStartLine: number;
     newStartLine: number;
+    showLineNumbers: boolean;
   } | null>(null);
 
   // ── Stable base extensions (rebuilt only when theme/settings change) ─────
@@ -253,32 +258,34 @@ export const CodeMirrorDiff: React.FC<CodeMirrorDiffProps> = ({
     exts.push(getCodeMirrorTheme());
     exts.push(CODEMIRROR_BASE_LAYOUT_THEME);
 
-    if (appearanceSettings.lineNumbers === "on") {
-      exts.push(lineNumbers({ formatNumber: formatAbsoluteLineNumber }));
-    } else if (appearanceSettings.lineNumbers === "relative") {
-      exts.push(
-        lineNumbers({
-          formatNumber: (lineNo: number, state: EditorState) => {
-            const cursorLine = state.doc.lineAt(
-              state.selection.main.head
-            ).number;
-            return lineNo === cursorLine
-              ? formatAbsoluteLineNumber(lineNo)
-              : String(Math.abs(lineNo - cursorLine));
-          },
-        })
-      );
-    } else if (appearanceSettings.lineNumbers === "interval") {
-      exts.push(
-        lineNumbers({
-          formatNumber: (lineNo: number) => {
-            const absoluteLineNo = lineNo + lineNumberOffset;
-            return absoluteLineNo === 1 || absoluteLineNo % 10 === 0
-              ? String(absoluteLineNo)
-              : "";
-          },
-        })
-      );
+    if (showLineNumbers) {
+      if (appearanceSettings.lineNumbers === "on") {
+        exts.push(lineNumbers({ formatNumber: formatAbsoluteLineNumber }));
+      } else if (appearanceSettings.lineNumbers === "relative") {
+        exts.push(
+          lineNumbers({
+            formatNumber: (lineNo: number, state: EditorState) => {
+              const cursorLine = state.doc.lineAt(
+                state.selection.main.head
+              ).number;
+              return lineNo === cursorLine
+                ? formatAbsoluteLineNumber(lineNo)
+                : String(Math.abs(lineNo - cursorLine));
+            },
+          })
+        );
+      } else if (appearanceSettings.lineNumbers === "interval") {
+        exts.push(
+          lineNumbers({
+            formatNumber: (lineNo: number) => {
+              const absoluteLineNo = lineNo + lineNumberOffset;
+              return absoluteLineNo === 1 || absoluteLineNo % 10 === 0
+                ? String(absoluteLineNo)
+                : "";
+            },
+          })
+        );
+      }
     }
 
     if (appearanceSettings.highlightActiveLine) {
@@ -325,7 +332,8 @@ export const CodeMirrorDiff: React.FC<CodeMirrorDiffProps> = ({
       if (
         prev.old !== oldValue ||
         prev.changeType !== changeType ||
-        prev.startLine !== newStartLine
+        prev.startLine !== newStartLine ||
+        prev.showLineNumbers !== showLineNumbers
       ) {
         unifiedViewRef.current.destroy();
         unifiedViewRef.current = null;
@@ -349,6 +357,7 @@ export const CodeMirrorDiff: React.FC<CodeMirrorDiffProps> = ({
         new: newValue,
         changeType,
         startLine: newStartLine,
+        showLineNumbers,
       };
       setUnifiedLines(view.state.doc.lines);
       return;
@@ -405,6 +414,7 @@ export const CodeMirrorDiff: React.FC<CodeMirrorDiffProps> = ({
         new: newValue,
         changeType,
         startLine: newStartLine,
+        showLineNumbers,
       };
       setUnifiedScrollEl(view.scrollDOM);
       setUnifiedLines(view.state.doc.lines);
@@ -425,6 +435,7 @@ export const CodeMirrorDiff: React.FC<CodeMirrorDiffProps> = ({
     newValue,
     changeType,
     newStartLine,
+    showLineNumbers,
     readOnly,
     mergeControls,
     collapseUnchanged,
@@ -465,7 +476,8 @@ export const CodeMirrorDiff: React.FC<CodeMirrorDiffProps> = ({
       const prev = splitContentRef.current;
       if (
         prev.oldStartLine !== oldStartLine ||
-        prev.newStartLine !== newStartLine
+        prev.newStartLine !== newStartLine ||
+        prev.showLineNumbers !== showLineNumbers
       ) {
         splitMergeViewRef.current.destroy();
         splitMergeViewRef.current = null;
@@ -495,6 +507,7 @@ export const CodeMirrorDiff: React.FC<CodeMirrorDiffProps> = ({
         new: newValue,
         oldStartLine,
         newStartLine,
+        showLineNumbers,
       };
       setSplitLines(mv.b.state.doc.lines);
       return;
@@ -533,6 +546,7 @@ export const CodeMirrorDiff: React.FC<CodeMirrorDiffProps> = ({
         new: newValue,
         oldStartLine,
         newStartLine,
+        showLineNumbers,
       };
       setSplitScrollEl(splitContainerRef.current);
       setSplitLines(mergeView.b.state.doc.lines);
@@ -563,6 +577,7 @@ export const CodeMirrorDiff: React.FC<CodeMirrorDiffProps> = ({
     newValue,
     oldStartLine,
     newStartLine,
+    showLineNumbers,
     readOnly,
     collapseUnchanged,
     autoHeight,

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/CodePanel/CombinedDiffView.tsx
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/CodePanel/CombinedDiffView.tsx
@@ -16,6 +16,7 @@ import Button from "@src/components/Button";
 import DiffStatsBadge from "@src/components/DiffStatsBadge";
 import { VirtualizedModernDiff } from "@src/features/CodeViewer/VirtualizedModernDiff";
 
+import { shouldTrustDiffStartLines } from "../converters/fileConverter";
 import { resolveFileOperationPayload } from "../resolveFilePayload";
 import type { FileOperationEntry } from "../types";
 import { getEditStartLine } from "./editUtils";
@@ -54,6 +55,7 @@ const EditSection: React.FC<{
     if (isCollapsed) return null;
     return resolveFileOperationPayload(op);
   }, [isCollapsed, op]);
+  const showLineNumbers = shouldTrustDiffStartLines(op.event);
   const hasContent =
     payload !== null &&
     (payload.oldContent !== undefined || payload.newContent !== undefined);
@@ -101,6 +103,7 @@ const EditSection: React.FC<{
               height="auto"
               oldStartLine={payload.oldStartLine}
               newStartLine={payload.newStartLine}
+              showLineNumbers={showLineNumbers}
               contextLines={3}
               collapseUnchanged={true}
               showFilePath={false}

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/CodePanel/editUtils.ts
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/CodePanel/editUtils.ts
@@ -1,3 +1,4 @@
+import { shouldTrustDiffStartLines } from "../converters/fileConverter";
 import type { FileOperationEntry } from "../types";
 
 /**
@@ -6,6 +7,7 @@ import type { FileOperationEntry } from "../types";
  */
 export function getEditStartLine(op: FileOperationEntry): number {
   if (op.newStartLine) return op.newStartLine;
+  if (!shouldTrustDiffStartLines(op.event)) return 0;
 
   const event = op.event as unknown as {
     context_start_line?: number;

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/CodePanel/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/CodePanel/index.tsx
@@ -30,6 +30,7 @@ import {
 } from "@src/util/file/previewTypes";
 import { deriveToolAction } from "@src/util/ui/rendering/toolAction";
 
+import { shouldTrustDiffStartLines } from "../converters/fileConverter";
 import { resolveFileOperationPayload } from "../resolveFilePayload";
 import {
   CODE_PANEL_MODE,
@@ -305,6 +306,7 @@ export const CodePanel: React.FC<CodePanelProps> = memo(
 
     const { filePath, type, language, relatedOperations } = operation;
     const operationIsLoading = operation.isLoading || isLoading;
+    const showDiffLineNumbers = shouldTrustDiffStartLines(operation.event);
 
     if (operation.isFailed) {
       return (
@@ -410,6 +412,7 @@ export const CodePanel: React.FC<CodePanelProps> = memo(
               height="100%"
               oldStartLine={resolvedPayload?.oldStartLine}
               newStartLine={resolvedPayload?.newStartLine}
+              showLineNumbers={showDiffLineNumbers}
               contextLines={3}
               collapseUnchanged={true}
               showFilePath={false}

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/converters/__tests__/fileConverter.test.ts
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/converters/__tests__/fileConverter.test.ts
@@ -195,8 +195,40 @@ describe("convertToFileOperation", () => {
     expect(op?.newContent).toBe(
       "const newValue = true;\nexport const kept = 1;"
     );
+    expect(op?.oldStartLine).toBeUndefined();
+    expect(op?.newStartLine).toBeUndefined();
     expect(op?.linesAdded).toBe(1);
     expect(op?.linesRemoved).toBe(1);
+  });
+
+  it("preserves explicit line ranges from imported Codex apply_patch hunks", () => {
+    const patchText = [
+      "*** Begin Patch",
+      "*** Update File: src/app.ts",
+      "@@ -42,2 +43,2 @@",
+      "-const oldValue = true;",
+      "+const newValue = true;",
+      "*** End Patch",
+    ].join("\n");
+    const event = minimalSessionEvent({
+      id: "patch-ranged",
+      functionName: "edit_file_by_replace",
+      args: {
+        patch_text: patchText,
+        file_path: "src/app.ts",
+        target_file: "src/app.ts",
+      },
+      result: { content: "Success. Updated src/app.ts" },
+      filePath: "src/app.ts",
+    });
+
+    const op = convertToFileOperation(event, true);
+
+    expect(op).not.toBeNull();
+    expect(op?.oldStartLine).toBe(42);
+    expect(op?.newStartLine).toBe(43);
+    expect(op?.oldContent).toBe("const oldValue = true;");
+    expect(op?.newContent).toBe("const newValue = true;");
   });
 
   it("returns null when file path cannot be resolved", () => {

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/converters/fileConverter.ts
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/converters/fileConverter.ts
@@ -22,6 +22,8 @@ import {
 } from "../types";
 
 const HUNK_HEADER_REGEX = /^@@\s+-(\d+)(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/;
+const PATCH_HUNK_HEADER_REGEX =
+  /^@@\s+-(\d+)(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/m;
 
 interface ParsedUnifiedDiffPayload {
   oldContent: string;
@@ -103,6 +105,38 @@ function parseUnifiedDiffPayload(
     oldStartLine,
     newStartLine,
   };
+}
+
+function patchTextFromArgs(args: SessionEvent["args"]): string | undefined {
+  if (typeof args?.patch_text === "string") return args.patch_text;
+  if (typeof args?.patch === "string") return args.patch;
+  if (typeof args?.input === "string") return args.input;
+  return undefined;
+}
+
+function resultHasRealDiff(result: SessionEvent["result"]): boolean {
+  if (!result) return false;
+  if (
+    typeof result.diffString === "string" ||
+    typeof result.diff === "string"
+  ) {
+    return true;
+  }
+  if (Array.isArray(result.segments) && result.segments.length > 0) {
+    return true;
+  }
+  const output = result.output as Record<string, unknown> | undefined;
+  const success = output?.success as Record<string, unknown> | undefined;
+  return Boolean(
+    typeof success?.diffString === "string" || typeof success?.diff === "string"
+  );
+}
+
+export function shouldTrustDiffStartLines(event: SessionEvent): boolean {
+  const patchText = patchTextFromArgs(event.args);
+  if (!patchText) return true;
+  if (PATCH_HUNK_HEADER_REGEX.test(patchText)) return true;
+  return resultHasRealDiff(event.result);
 }
 
 export function parseFilePath(path: string): {
@@ -242,12 +276,17 @@ export function convertToFileOperation(
     if (!data.filePath) return null;
 
     const { fileName, directory } = parseFilePath(data.filePath);
+    const trustDiffStartLines = shouldTrustDiffStartLines(event);
 
     const parsedDiff = parseUnifiedDiffPayload(data.diff);
     let oldContent = parsedDiff?.oldContent ?? data.oldContent;
     let newContent = parsedDiff?.newContent ?? data.newContent;
-    const oldStartLine = parsedDiff?.oldStartLine ?? data.oldStartLine;
-    const newStartLine = parsedDiff?.newStartLine ?? data.newStartLine;
+    const oldStartLine = trustDiffStartLines
+      ? (parsedDiff?.oldStartLine ?? data.oldStartLine)
+      : undefined;
+    const newStartLine = trustDiffStartLines
+      ? (parsedDiff?.newStartLine ?? data.newStartLine)
+      : undefined;
     if (!oldContent && !newContent) {
       const result = event.result || {};
       const args = event.args || {};

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/resolveFilePayload.ts
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/resolveFilePayload.ts
@@ -7,7 +7,10 @@
  */
 import { parseUnifiedDiffToOldNew } from "@src/engines/SessionCore/rendering/props";
 
-import { convertToFileOperation } from "./converters/fileConverter";
+import {
+  convertToFileOperation,
+  shouldTrustDiffStartLines,
+} from "./converters/fileConverter";
 import type { FileOperationEntry } from "./types";
 
 export interface ResolvedFilePayload {
@@ -25,7 +28,10 @@ function isEmptyEventPlaceholder(event: FileOperationEntry["event"]): boolean {
   return !event || Object.keys(event as object).length === 0;
 }
 
-function normalizePayload(payload: ResolvedFilePayload): ResolvedFilePayload {
+function normalizePayload(
+  payload: ResolvedFilePayload,
+  trustDiffStartLines = true
+): ResolvedFilePayload {
   if (
     payload.diff !== undefined &&
     payload.oldContent === undefined &&
@@ -36,8 +42,12 @@ function normalizePayload(payload: ResolvedFilePayload): ResolvedFilePayload {
       ...payload,
       oldContent: parsed.oldValue,
       newContent: parsed.newValue,
-      oldStartLine: payload.oldStartLine ?? parsed.oldStartLine,
-      newStartLine: payload.newStartLine ?? parsed.newStartLine,
+      oldStartLine: trustDiffStartLines
+        ? (payload.oldStartLine ?? parsed.oldStartLine)
+        : payload.oldStartLine,
+      newStartLine: trustDiffStartLines
+        ? (payload.newStartLine ?? parsed.newStartLine)
+        : payload.newStartLine,
     };
   }
   return payload;
@@ -55,16 +65,19 @@ export function resolveFileOperationPayload(
     op.newContent !== undefined ||
     op.diff !== undefined
   ) {
-    return normalizePayload({
-      content: op.content,
-      contentStartLine: op.contentStartLine,
-      oldContent: op.oldContent,
-      newContent: op.newContent,
-      diff: op.diff,
-      oldStartLine: op.oldStartLine,
-      newStartLine: op.newStartLine,
-      language: op.language,
-    });
+    return normalizePayload(
+      {
+        content: op.content,
+        contentStartLine: op.contentStartLine,
+        oldContent: op.oldContent,
+        newContent: op.newContent,
+        diff: op.diff,
+        oldStartLine: op.oldStartLine,
+        newStartLine: op.newStartLine,
+        language: op.language,
+      },
+      shouldTrustDiffStartLines(op.event)
+    );
   }
 
   if (isEmptyEventPlaceholder(op.event)) {
@@ -76,14 +89,17 @@ export function resolveFileOperationPayload(
     return { language: op.language };
   }
 
-  return normalizePayload({
-    content: reconverted.content,
-    contentStartLine: reconverted.contentStartLine,
-    oldContent: reconverted.oldContent,
-    newContent: reconverted.newContent,
-    diff: reconverted.diff,
-    oldStartLine: reconverted.oldStartLine,
-    newStartLine: reconverted.newStartLine,
-    language: reconverted.language ?? op.language,
-  });
+  return normalizePayload(
+    {
+      content: reconverted.content,
+      contentStartLine: reconverted.contentStartLine,
+      oldContent: reconverted.oldContent,
+      newContent: reconverted.newContent,
+      diff: reconverted.diff,
+      oldStartLine: reconverted.oldStartLine,
+      newStartLine: reconverted.newStartLine,
+      language: reconverted.language ?? op.language,
+    },
+    shouldTrustDiffStartLines(op.event)
+  );
 }

--- a/src/modules/WorkStation/shared/DiffFileSection/index.tsx
+++ b/src/modules/WorkStation/shared/DiffFileSection/index.tsx
@@ -71,6 +71,7 @@ export interface DiffFileSectionData {
   newContent?: string;
   oldStartLine?: number;
   newStartLine?: number;
+  showLineNumbers?: boolean;
   unifiedDiff?: string;
   isBinary?: boolean;
   /** True when the file was edited but content could not be retrieved (e.g. Cursor IDE blob pruned). */
@@ -315,6 +316,7 @@ const DiffFileSection: React.FC<DiffFileSectionProps> = ({
           changeType={file.status}
           oldStartLine={resolvedDiff.oldStartLine}
           newStartLine={resolvedDiff.newStartLine}
+          showLineNumbers={file.showLineNumbers !== false}
           viewMode="unified"
           readOnly={true}
           mergeControls={false}

--- a/src/modules/WorkStation/shared/DiffSectionList/sessionReplaySections.test.ts
+++ b/src/modules/WorkStation/shared/DiffSectionList/sessionReplaySections.test.ts
@@ -139,6 +139,44 @@ describe("session replay diff sections", () => {
     expect(sections[0].file.newContent).toBe(
       "const newValue = true;\nexport const kept = 1;"
     );
+    expect(sections[0].file.oldStartLine).toBeUndefined();
+    expect(sections[0].file.newStartLine).toBeUndefined();
+    expect(sections[0].file.showLineNumbers).toBe(false);
+  });
+
+  it("preserves explicit Codex apply_patch hunk line ranges", () => {
+    const patchText = [
+      "*** Begin Patch",
+      "*** Update File: src/app.ts",
+      "@@ -42,2 +43,2 @@",
+      "-const oldValue = true;",
+      "+const newValue = true;",
+      "*** End Patch",
+    ].join("\n");
+
+    const sections = buildSessionReplayDiffSectionItems({
+      entryId: "patch-ranged",
+      filePath: "src/app.ts",
+      fileName: "app.ts",
+      event: minimalSessionEvent({
+        id: "patch-ranged",
+        functionName: "edit_file_by_replace",
+        args: {
+          patch_text: patchText,
+          file_path: "src/app.ts",
+          target_file: "src/app.ts",
+        },
+        result: { content: "Success. Updated src/app.ts" },
+        filePath: "src/app.ts",
+      }),
+    });
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0].file.oldStartLine).toBe(42);
+    expect(sections[0].file.newStartLine).toBe(43);
+    expect(sections[0].file.showLineNumbers).toBeUndefined();
+    expect(sections[0].file.oldContent).toBe("const oldValue = true;");
+    expect(sections[0].file.newContent).toBe("const newValue = true;");
   });
 
   it("keeps distant hunks in one unified content pair", () => {

--- a/src/modules/WorkStation/shared/DiffSectionList/sessionReplaySections.ts
+++ b/src/modules/WorkStation/shared/DiffSectionList/sessionReplaySections.ts
@@ -10,6 +10,9 @@ import { normalizeDiffFilePath } from "@src/util/file/pathUtils";
 import type { DiffFileSectionData } from "../DiffFileSection";
 import type { DiffSectionListItem } from "./index";
 
+const PATCH_HUNK_HEADER_REGEX =
+  /^@@\s+-(\d+)(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/m;
+
 export interface SessionReplayDiffEntryLike {
   entryId: string;
   event: SessionEvent;
@@ -21,6 +24,38 @@ export interface SessionReplayDiffSectionItem extends DiffSectionListItem<DiffFi
   entryIds: string[];
   /** Raw compact diff strings from each edit, used for multi-hunk merge during consolidation. */
   rawDiffs: string[];
+}
+
+function patchTextFromArgs(args: SessionEvent["args"]): string | undefined {
+  if (typeof args?.patch_text === "string") return args.patch_text;
+  if (typeof args?.patch === "string") return args.patch;
+  if (typeof args?.input === "string") return args.input;
+  return undefined;
+}
+
+function resultHasRealDiff(result: SessionEvent["result"]): boolean {
+  if (!result) return false;
+  if (
+    typeof result.diffString === "string" ||
+    typeof result.diff === "string"
+  ) {
+    return true;
+  }
+  if (Array.isArray(result.segments) && result.segments.length > 0) {
+    return true;
+  }
+  const output = result.output as Record<string, unknown> | undefined;
+  const success = output?.success as Record<string, unknown> | undefined;
+  return Boolean(
+    typeof success?.diffString === "string" || typeof success?.diff === "string"
+  );
+}
+
+function shouldTrustDiffStartLines(event: SessionEvent): boolean {
+  const patchText = patchTextFromArgs(event.args);
+  if (!patchText) return true;
+  if (PATCH_HUNK_HEADER_REGEX.test(patchText)) return true;
+  return resultHasRealDiff(event.result);
 }
 
 function getDiffStatus(
@@ -58,6 +93,7 @@ export function buildSessionReplayDiffSectionItems(
       : [editData];
 
   return segments.flatMap((segment, index) => {
+    const trustDiffStartLines = shouldTrustDiffStartLines(entry.event);
     // When a compact diff string is available, always parse it into
     // old/new values. This avoids passing full file bodies to CodeMirrorDiff
     // (which would show the entire file as context) and gives correct
@@ -88,8 +124,13 @@ export function buildSessionReplayDiffSectionItems(
         deletions: segment.linesRemoved,
         oldContent: contentUnavailable ? undefined : oldContent,
         newContent: contentUnavailable ? undefined : newContent,
-        oldStartLine: segment.oldStartLine ?? parsed?.oldStartLine,
-        newStartLine: segment.newStartLine ?? parsed?.newStartLine,
+        oldStartLine: trustDiffStartLines
+          ? (segment.oldStartLine ?? parsed?.oldStartLine)
+          : undefined,
+        newStartLine: trustDiffStartLines
+          ? (segment.newStartLine ?? parsed?.newStartLine)
+          : undefined,
+        showLineNumbers: trustDiffStartLines ? undefined : false,
         isUnavailable: contentUnavailable || undefined,
       },
       entryIds: [entry.entryId],
@@ -142,6 +183,11 @@ export function buildConsolidatedSessionReplayDiffSectionItems<
           existing.file.deletions !== undefined ||
           section.file.deletions !== undefined
             ? (existing.file.deletions ?? 0) + (section.file.deletions ?? 0)
+            : undefined,
+        showLineNumbers:
+          existing.file.showLineNumbers === false ||
+          section.file.showLineNumbers === false
+            ? false
             : undefined,
       };
 

--- a/src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/NavigationMenuRow.tsx
+++ b/src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/NavigationMenuRow.tsx
@@ -261,7 +261,7 @@ export const NavigationMenuLeafRow = React.forwardRef<
     >
       {dragState && <ReferenceDragGhost dragState={dragState} />}
       {showIndentGuide && (
-        <span className="pointer-events-none absolute bottom-1 left-2 top-1 w-px rounded-full bg-border-2" />
+        <span className="pointer-events-none absolute -bottom-0.5 -top-0.5 left-2 w-px bg-text-3" />
       )}
       <div
         data-testid={item.dataTestId}

--- a/src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/NavigationMenuRow.tsx
+++ b/src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/NavigationMenuRow.tsx
@@ -236,6 +236,7 @@ export const NavigationMenuLeafRow = React.forwardRef<
     markClicked,
     resetCursor: resetImmediateCursor,
   } = useImmediateCursorReset(isSelected, !item.disabled);
+  const showIndentGuide = Boolean(item.showIndentGuide);
 
   const handleRootMouseLeave = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
@@ -251,7 +252,7 @@ export const NavigationMenuLeafRow = React.forwardRef<
       {...rootProps}
       {...dragHandlers}
       ref={ref}
-      className={`${rootProps.className ?? ""} ${item.dragPayload ? "cursor-grab active:cursor-grabbing" : ""}`}
+      className={`${rootProps.className ?? ""} ${showIndentGuide ? "relative pl-4" : ""} ${item.dragPayload ? "cursor-grab active:cursor-grabbing" : ""}`}
       onMouseEnter={onMouseEnter}
       onMouseLeave={handleRootMouseLeave}
       onContextMenu={(event: React.MouseEvent) =>
@@ -259,6 +260,9 @@ export const NavigationMenuLeafRow = React.forwardRef<
       }
     >
       {dragState && <ReferenceDragGhost dragState={dragState} />}
+      {showIndentGuide && (
+        <span className="pointer-events-none absolute bottom-1 left-2 top-1 w-px rounded-full bg-border-2" />
+      )}
       <div
         data-testid={item.dataTestId}
         className={`group flex ${rowHeightClass} items-center justify-between overflow-hidden rounded-lg transition-colors duration-150 ${

--- a/src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/NavigationMenuRow.tsx
+++ b/src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/NavigationMenuRow.tsx
@@ -110,7 +110,11 @@ export const NavigationMenuParentRow = React.forwardRef<
         }
       >
         <div className="flex min-w-0 flex-1 items-center gap-3">
-          {renderIcon(item.icon, item.iconName, iconColor, item.iconElement)}
+          {renderLeadingIcon({
+            item,
+            iconColor,
+            renderIcon,
+          })}
           {!collapsed && (
             <div className="flex min-w-0 flex-1 flex-col gap-0">
               <span
@@ -284,7 +288,11 @@ export const NavigationMenuLeafRow = React.forwardRef<
         }
       >
         <div className="flex min-w-0 flex-1 items-center gap-3">
-          {renderIcon(item.icon, item.iconName, iconColor, item.iconElement)}
+          {renderLeadingIcon({
+            item,
+            iconColor,
+            renderIcon,
+          })}
           {!collapsed && (
             <div className="flex min-w-0 flex-1 flex-col gap-0">
               <span
@@ -322,6 +330,52 @@ export const NavigationMenuLeafRow = React.forwardRef<
     </div>
   );
 });
+
+interface RenderLeadingIconArgs {
+  item: NavigationMenuItem;
+  iconColor: string;
+  renderIcon: NavigationMenuIconRenderer;
+}
+
+function renderLeadingIcon({
+  item,
+  iconColor,
+  renderIcon,
+}: RenderLeadingIconArgs): React.ReactNode {
+  const icon = renderIcon(
+    item.icon,
+    item.iconName,
+    iconColor,
+    item.iconElement
+  );
+  const action = item.iconAction;
+  if (!action) return icon;
+
+  const ActionIcon = action.icon ?? ChevronDown;
+
+  return (
+    <span className="relative inline-flex h-[14px] w-[14px] flex-shrink-0 items-center justify-center leading-none">
+      <span className="inline-flex items-center justify-center leading-none transition-opacity duration-150 group-focus-within:pointer-events-none group-focus-within:opacity-0 group-hover:pointer-events-none group-hover:opacity-0">
+        {icon}
+      </span>
+      <button
+        type="button"
+        aria-label={action.label}
+        title={action.label}
+        className={`pointer-events-none absolute left-1/2 top-1/2 flex h-5 w-5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded opacity-0 transition-[background-color,color,opacity] duration-150 hover:bg-fill-2 hover:text-text-1 focus:pointer-events-auto focus:opacity-100 focus:outline-none group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100 ${
+          action.active ? "text-primary-6" : "text-text-3"
+        }`}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          action.onClick(event);
+        }}
+      >
+        <ActionIcon size={14} strokeWidth={2} />
+      </button>
+    </span>
+  );
+}
 
 interface RenderLeafRowAccessoryArgs {
   item: NavigationMenuItem;

--- a/src/scaffold/NavigationSidebar/components/NavigationMenu/config.ts
+++ b/src/scaffold/NavigationSidebar/components/NavigationMenu/config.ts
@@ -48,6 +48,8 @@ export interface NavigationMenuItem {
   workingIndicator?: ReactNode;
   /** Shows a chevron to indicate the row opens a deeper sidebar level. */
   showDrillDownIndicator?: boolean;
+  /** Indents the row and draws a vertical guide line for inline child rows. */
+  showIndentGuide?: boolean;
   visualTone?: "default" | "secondary";
   /** Show hover-only row action buttons. */
   showMoreActions?: boolean;

--- a/src/scaffold/NavigationSidebar/components/NavigationMenu/config.ts
+++ b/src/scaffold/NavigationSidebar/components/NavigationMenu/config.ts
@@ -13,6 +13,8 @@ export interface NavigationMenuRowAction {
   onClick: (event: MouseEvent<HTMLButtonElement>) => void;
 }
 
+export type NavigationMenuIconAction = NavigationMenuRowAction;
+
 /**
  * Navigation menu item configuration
  * Defines structure for menu items used in sidebar navigation
@@ -33,6 +35,8 @@ export interface NavigationMenuItem {
   iconName?: string;
   /** Arbitrary rendered icon — takes precedence over `icon` when set. */
   iconElement?: ReactNode;
+  /** Optional hover/focus action that replaces the leading icon in-place. */
+  iconAction?: NavigationMenuIconAction;
   /** Optional element rendered at the far right edge of the row. */
   trailingElement?: ReactNode;
   /**

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
@@ -277,6 +277,9 @@ export const WorkstationSidebarConnector: React.FC = () => {
   const [groupVisibleCounts, setGroupVisibleCounts] = useState<
     Map<string, number>
   >(new Map());
+  const [expandedSubagentParentIds, setExpandedSubagentParentIds] = useState<
+    Set<string>
+  >(() => new Set());
   const [projectsGroupVisibleCounts, setProjectsGroupVisibleCounts] = useState<
     Map<string, number>
   >(new Map());
@@ -340,18 +343,24 @@ export const WorkstationSidebarConnector: React.FC = () => {
     [orgSelectorOptions, selectedOrgId]
   );
 
-  const { menuItems, sessionMap, isLoadMoreId, getLoadMoreGroupId } =
-    useSessionMenuItems({
-      sortedSessions,
-      visitedSessions,
-      repoPathToName,
-      groupByMode,
-      untitledSession,
-      searchQuery: sidebarSearchQueries.workstation,
-      selectedOrgId: activeOrgId,
-      includeExternal,
-      groupVisibleCounts,
-    });
+  const {
+    menuItems,
+    sessionMap,
+    subagentParentIds,
+    isLoadMoreId,
+    getLoadMoreGroupId,
+  } = useSessionMenuItems({
+    sortedSessions,
+    visitedSessions,
+    repoPathToName,
+    groupByMode,
+    untitledSession,
+    searchQuery: sidebarSearchQueries.workstation,
+    selectedOrgId: activeOrgId,
+    includeExternal,
+    groupVisibleCounts,
+    expandedSubagentParentIds,
+  });
   const {
     menuItems: projectsWorkItemMenuItems,
     projectMap: projectsProjectMap,
@@ -620,6 +629,18 @@ export const WorkstationSidebarConnector: React.FC = () => {
     [activateChatPanelTab, openSessionInNewChatTab]
   );
 
+  const handleToggleSubagentExpansion = useCallback((sessionId: string) => {
+    setExpandedSubagentParentIds((previousIds) => {
+      const nextIds = new Set(previousIds);
+      if (nextIds.has(sessionId)) {
+        nextIds.delete(sessionId);
+      } else {
+        nextIds.add(sessionId);
+      }
+      return nextIds;
+    });
+  }, []);
+
   const handleMenuItemContextMenu = useWorkstationSidebarContextMenu({
     sessionMap,
     rename,
@@ -636,9 +657,12 @@ export const WorkstationSidebarConnector: React.FC = () => {
     deleteSessionCreatorDraft,
     handleMenuItemContextMenu,
     handleTogglePin,
+    handleToggleSubagentExpansion,
+    expandedSubagentParentIds,
     pinLabel: pinFolderLabel,
     sessionMap,
     setActiveSessionMoreMenuId,
+    subagentParentIds,
     tCommon,
     unpinLabel: unpinFolderLabel,
   });

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sessionRowActions.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sessionRowActions.tsx
@@ -1,6 +1,6 @@
 import {
-  ChevronDown,
-  ChevronUp,
+  ChevronsDownUp,
+  ChevronsUpDown,
   MoreHorizontal,
   Pin,
   PinOff,
@@ -85,7 +85,7 @@ export function useDecorateSessionRowActions({
         if (hasSubagentChildren) {
           const expanded = expandedSubagentParentIds.has(item.id);
           rowActions.push({
-            icon: expanded ? ChevronUp : ChevronDown,
+            icon: expanded ? ChevronsDownUp : ChevronsUpDown,
             label: expanded
               ? tCommon("sessions:sidebar.hideSubagents", "Hide subagents")
               : tCommon("sessions:sidebar.showSubagents", "Show subagents"),

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sessionRowActions.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sessionRowActions.tsx
@@ -1,4 +1,11 @@
-import { MoreHorizontal, Pin, PinOff, X } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronUp,
+  MoreHorizontal,
+  Pin,
+  PinOff,
+  X,
+} from "lucide-react";
 import React, { useCallback } from "react";
 
 import type {
@@ -13,6 +20,8 @@ import { getDraftIdFromMenuItemId } from "../sidebarConnectorUtils";
 
 type TCommon = (key: string, defaultValue?: string) => string;
 
+const SUBAGENT_SESSION_ID_SEGMENT = ":subagent:";
+
 interface UseSessionRowActionsParams {
   activeSessionMoreMenuId: string;
   deleteSessionCreatorDraft: (draftId: string) => void;
@@ -22,9 +31,12 @@ interface UseSessionRowActionsParams {
     item: NavigationMenuItem
   ) => Promise<void>;
   handleTogglePin: (sessionId: string) => Promise<void> | void;
+  handleToggleSubagentExpansion: (sessionId: string) => void;
+  expandedSubagentParentIds: ReadonlySet<string>;
   pinLabel: string;
   sessionMap: ReadonlyMap<string, Session>;
   setActiveSessionMoreMenuId: React.Dispatch<React.SetStateAction<string>>;
+  subagentParentIds: ReadonlySet<string>;
   tCommon: TCommon;
   unpinLabel: string;
 }
@@ -34,9 +46,12 @@ export function useDecorateSessionRowActions({
   deleteSessionCreatorDraft,
   handleMenuItemContextMenu,
   handleTogglePin,
+  handleToggleSubagentExpansion,
+  expandedSubagentParentIds,
   pinLabel,
   sessionMap,
   setActiveSessionMoreMenuId,
+  subagentParentIds,
   tCommon,
   unpinLabel,
 }: UseSessionRowActionsParams): (
@@ -63,7 +78,23 @@ export function useDecorateSessionRowActions({
         const session = sessionMap.get(item.id);
         if (!session) return item;
         const rowActions: NavigationMenuRowAction[] = [];
-        if (!isChatPanelTuiSessionId(item.id)) {
+        const isChildSession =
+          Boolean(session.parentSessionId) ||
+          item.id.includes(SUBAGENT_SESSION_ID_SEGMENT);
+        const hasSubagentChildren = subagentParentIds.has(item.id);
+        let iconAction: NavigationMenuItem["iconAction"];
+        if (hasSubagentChildren) {
+          const expanded = expandedSubagentParentIds.has(item.id);
+          iconAction = {
+            icon: expanded ? ChevronUp : ChevronDown,
+            label: expanded
+              ? tCommon("sessions:sidebar.hideSubagents", "Hide subagents")
+              : tCommon("sessions:sidebar.showSubagents", "Show subagents"),
+            active: expanded,
+            onClick: () => handleToggleSubagentExpansion(item.id),
+          };
+        }
+        if (!isChildSession && !isChatPanelTuiSessionId(item.id)) {
           rowActions.push({
             icon: session.pinned ? PinOff : Pin,
             label: session.pinned ? unpinLabel : pinLabel,
@@ -91,6 +122,7 @@ export function useDecorateSessionRowActions({
         }
         return {
           ...item,
+          iconAction,
           showMoreActions: true,
           rowActions,
         };
@@ -100,9 +132,12 @@ export function useDecorateSessionRowActions({
       deleteSessionCreatorDraft,
       handleMenuItemContextMenu,
       handleTogglePin,
+      handleToggleSubagentExpansion,
+      expandedSubagentParentIds,
       pinLabel,
       sessionMap,
       setActiveSessionMoreMenuId,
+      subagentParentIds,
       tCommon,
       unpinLabel,
     ]

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sessionRowActions.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sessionRowActions.tsx
@@ -82,17 +82,16 @@ export function useDecorateSessionRowActions({
           Boolean(session.parentSessionId) ||
           item.id.includes(SUBAGENT_SESSION_ID_SEGMENT);
         const hasSubagentChildren = subagentParentIds.has(item.id);
-        let iconAction: NavigationMenuItem["iconAction"];
         if (hasSubagentChildren) {
           const expanded = expandedSubagentParentIds.has(item.id);
-          iconAction = {
+          rowActions.push({
             icon: expanded ? ChevronUp : ChevronDown,
             label: expanded
               ? tCommon("sessions:sidebar.hideSubagents", "Hide subagents")
               : tCommon("sessions:sidebar.showSubagents", "Show subagents"),
             active: expanded,
             onClick: () => handleToggleSubagentExpansion(item.id),
-          };
+          });
         }
         if (!isChildSession && !isChatPanelTuiSessionId(item.id)) {
           rowActions.push({
@@ -122,7 +121,6 @@ export function useDecorateSessionRowActions({
         }
         return {
           ...item,
-          iconAction,
           showMoreActions: true,
           rowActions,
         };

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/menuSectionBuilders.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/menuSectionBuilders.test.ts
@@ -174,7 +174,7 @@ describe("session menu section builders", () => {
     });
 
     expect(getLoadMoreItemIds(items)).toEqual([
-      "load-more-group-agent:cursor_ide",
+      "load-more-group-agent:external_history:cursor_ide",
     ]);
   });
 
@@ -190,6 +190,8 @@ describe("session menu section builders", () => {
       loadMoreRowFor,
     });
 
-    expect(getLoadMoreItemIds(items)).toEqual(["load-more-cursor_ide"]);
+    expect(getLoadMoreItemIds(items)).toEqual([
+      "load-more-external_history:cursor_ide",
+    ]);
   });
 });

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/index.tsx
@@ -12,6 +12,7 @@ import {
   DEFAULT_SESSION_ORG_ID,
   type Session,
   type SessionListCategory,
+  sessionLastLoadedAtom,
   sessionPaginationAtom,
   upsertSession,
 } from "@src/store/session";
@@ -152,6 +153,7 @@ export function useSessionMenuItems({
 }: UseSessionMenuItemsParams): UseSessionMenuItemsResult {
   const { t: tCommon } = useTranslation();
   const pagination = useAtomValue(sessionPaginationAtom);
+  const sessionLastLoaded = useAtomValue(sessionLastLoadedAtom);
   const benchmarkAgentBatchStatus = useAtomValue(benchmarkAgentBatchStatusAtom);
   const [benchmarkHistoryChildSessionIds, setBenchmarkHistoryChildSessionIds] =
     useState<ReadonlySet<string>>(() => new Set());
@@ -233,6 +235,10 @@ export function useSessionMenuItems({
     () => visibleSessions.map((session) => session.session_id),
     [visibleSessions]
   );
+
+  useEffect(() => {
+    setQueriedSubagentParentIds(new Set());
+  }, [sessionLastLoaded]);
 
   useEffect(() => {
     const parentIdsToQuery = visibleSessionIds.filter(

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/index.tsx
@@ -105,7 +105,7 @@ function buildChildSessionMenuItem(
   const item = buildSessionRow(session);
   return {
     ...item,
-    subtitle: "Subagent",
+    showIndentGuide: true,
     visualTone: "secondary",
     dataTestId: `sidebar-subagent-session-item-${session.session_id}`,
   };

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/index.tsx
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import { useAtomValue } from "jotai";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -12,6 +13,7 @@ import {
   type Session,
   type SessionListCategory,
   sessionPaginationAtom,
+  upsertSession,
 } from "@src/store/session";
 import { isImportedHistorySession } from "@src/util/session/sessionDispatch";
 import { getSessionSearchText } from "@src/util/session/sessionSearch";
@@ -48,6 +50,94 @@ export { getLoadMoreGroupId, isLoadMoreId } from "./paginationHelpers";
 
 const logger = createLogger("SessionSidebar");
 
+interface ChildSessionRecord {
+  sessionId: string;
+  name: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  sessionType: string;
+  parentSessionId: string | null;
+}
+
+const SUBAGENT_SESSION_ID_SEGMENT = ":subagent:";
+
+function parentSessionIdFor(session: Session): string | null {
+  if (session.parentSessionId) return session.parentSessionId;
+  const segmentIndex = session.session_id.indexOf(SUBAGENT_SESSION_ID_SEGMENT);
+  if (segmentIndex <= 0) return null;
+  return session.session_id.slice(0, segmentIndex);
+}
+
+function agentNameFromChildName(name: string): string | undefined {
+  const markerIndex = name.indexOf(" (");
+  const label = markerIndex >= 0 ? name.slice(0, markerIndex) : name;
+  const trimmed = label.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function childRecordToSession(
+  record: ChildSessionRecord,
+  parentSessionId: string
+): Session {
+  const name = record.name?.trim() || record.sessionId;
+  return {
+    session_id: record.sessionId,
+    status: record.status,
+    created_at: record.createdAt,
+    updated_at: record.updatedAt,
+    created_time: record.createdAt,
+    updated_time: record.updatedAt,
+    name,
+    category: "rust_agent",
+    keySource: "own_key",
+    parentSessionId: record.parentSessionId ?? parentSessionId,
+    background: true,
+    agentDisplayName: agentNameFromChildName(name),
+  };
+}
+
+function buildChildSessionMenuItem(
+  session: Session,
+  buildSessionRow: (session: Session) => NavigationMenuItem
+): NavigationMenuItem {
+  const item = buildSessionRow(session);
+  return {
+    ...item,
+    subtitle: "Subagent",
+    visualTone: "secondary",
+    dataTestId: `sidebar-subagent-session-item-${session.session_id}`,
+  };
+}
+
+function insertExpandedSubagentRows({
+  items,
+  childSessionsByParent,
+  expandedSubagentParentIds,
+  buildSessionRow,
+}: {
+  items: readonly NavigationMenuItem[];
+  childSessionsByParent: ReadonlyMap<string, readonly Session[]>;
+  expandedSubagentParentIds: ReadonlySet<string>;
+  buildSessionRow: (session: Session) => NavigationMenuItem;
+}): NavigationMenuItem[] {
+  if (expandedSubagentParentIds.size === 0) return items.slice();
+
+  const nextItems: NavigationMenuItem[] = [];
+  for (const item of items) {
+    nextItems.push(item);
+    if (!expandedSubagentParentIds.has(item.id)) continue;
+    const childSessions = childSessionsByParent.get(item.id);
+    if (!childSessions || childSessions.length === 0) continue;
+    nextItems.push(
+      ...childSessions.map((session) =>
+        buildChildSessionMenuItem(session, buildSessionRow)
+      )
+    );
+  }
+  return nextItems;
+}
+
 export function useSessionMenuItems({
   sortedSessions,
   visitedSessions,
@@ -58,12 +148,18 @@ export function useSessionMenuItems({
   selectedOrgId,
   includeExternal,
   groupVisibleCounts,
+  expandedSubagentParentIds = new Set(),
 }: UseSessionMenuItemsParams): UseSessionMenuItemsResult {
   const { t: tCommon } = useTranslation();
   const pagination = useAtomValue(sessionPaginationAtom);
   const benchmarkAgentBatchStatus = useAtomValue(benchmarkAgentBatchStatusAtom);
   const [benchmarkHistoryChildSessionIds, setBenchmarkHistoryChildSessionIds] =
     useState<ReadonlySet<string>>(() => new Set());
+  const [queriedSubagentParentIds, setQueriedSubagentParentIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set());
+  const [fetchedChildSessionsByParent, setFetchedChildSessionsByParent] =
+    useState<ReadonlyMap<string, Session[]>>(() => new Map());
 
   useEffect(() => {
     let cancelled = false;
@@ -133,6 +229,118 @@ export function useSessionMenuItems({
     ]
   );
 
+  const visibleSessionIds = useMemo(
+    () => visibleSessions.map((session) => session.session_id),
+    [visibleSessions]
+  );
+
+  useEffect(() => {
+    const parentIdsToQuery = visibleSessionIds.filter(
+      (sessionId) => !queriedSubagentParentIds.has(sessionId)
+    );
+    if (parentIdsToQuery.length === 0) return;
+
+    setQueriedSubagentParentIds((previousIds) => {
+      const nextIds = new Set(previousIds);
+      for (const sessionId of parentIdsToQuery) {
+        nextIds.add(sessionId);
+      }
+      return nextIds;
+    });
+
+    let cancelled = false;
+    void Promise.allSettled(
+      parentIdsToQuery.map(async (parentSessionId) => {
+        const records = await invoke<ChildSessionRecord[]>(
+          "es_get_child_sessions",
+          { parentSessionId }
+        );
+        const childSessions = records.map((record) =>
+          childRecordToSession(record, parentSessionId)
+        );
+        for (const childSession of childSessions) {
+          upsertSession(childSession);
+        }
+        return { parentSessionId, childSessions };
+      })
+    ).then((results) => {
+      if (cancelled) return;
+      setFetchedChildSessionsByParent((previousMap) => {
+        const nextMap = new Map(previousMap);
+        for (const result of results) {
+          if (result.status !== "fulfilled") continue;
+          nextMap.set(result.value.parentSessionId, result.value.childSessions);
+        }
+        return nextMap;
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [queriedSubagentParentIds, visibleSessionIds]);
+
+  const childSessionsByParent = useMemo(() => {
+    const map = new Map<string, Session[]>();
+
+    for (const session of sortedSessions) {
+      const parentSessionId = parentSessionIdFor(session);
+      if (!parentSessionId) continue;
+      const bucket = map.get(parentSessionId);
+      if (bucket) {
+        bucket.push(session);
+      } else {
+        map.set(parentSessionId, [session]);
+      }
+    }
+
+    for (const [
+      parentSessionId,
+      childSessions,
+    ] of fetchedChildSessionsByParent) {
+      const byId = new Map(
+        (map.get(parentSessionId) ?? []).map(
+          (session) => [session.session_id, session] as const
+        )
+      );
+      for (const childSession of childSessions) {
+        const existing = byId.get(childSession.session_id);
+        byId.set(childSession.session_id, {
+          ...existing,
+          ...childSession,
+          parentSessionId:
+            childSession.parentSessionId ?? existing?.parentSessionId,
+          agentOrgId: childSession.agentOrgId ?? existing?.agentOrgId,
+          agentOrgName: childSession.agentOrgName ?? existing?.agentOrgName,
+          agentDefinitionId:
+            childSession.agentDefinitionId ?? existing?.agentDefinitionId,
+          agentIconId: childSession.agentIconId ?? existing?.agentIconId,
+          agentDisplayName:
+            childSession.agentDisplayName ?? existing?.agentDisplayName,
+        });
+      }
+      map.set(parentSessionId, Array.from(byId.values()));
+    }
+
+    for (const childSessions of map.values()) {
+      childSessions.sort((left, right) =>
+        (right.updated_at || "").localeCompare(left.updated_at || "")
+      );
+    }
+
+    return map;
+  }, [fetchedChildSessionsByParent, sortedSessions]);
+
+  const subagentParentIds = useMemo(
+    () =>
+      new Set(
+        Array.from(childSessionsByParent.entries())
+          .filter(([, childSessions]) => childSessions.length > 0)
+          .map(([parentSessionId]) => parentSessionId)
+      ),
+    [childSessionsByParent]
+  );
+
   const { filteredItems: searchedSessions, isFiltering } = useFilteredItems({
     items: visibleSessions,
     searchQuery,
@@ -154,8 +362,13 @@ export function useSessionMenuItems({
     for (const session of visibleSessions) {
       map.set(session.session_id, session);
     }
+    for (const childSessions of childSessionsByParent.values()) {
+      for (const session of childSessions) {
+        map.set(session.session_id, session);
+      }
+    }
     return map;
-  }, [visibleSessions]);
+  }, [childSessionsByParent, visibleSessions]);
 
   const buildSessionRow = useCallback(
     (session: Session): NavigationMenuItem =>
@@ -295,7 +508,7 @@ export function useSessionMenuItems({
       appendTrailingLoadMoreItems,
     ]
   );
-  const menuItems = useMemo<NavigationMenuItem[]>(() => {
+  const baseMenuItems = useMemo<NavigationMenuItem[]>(() => {
     switch (groupByMode) {
       case "byAgent":
         return byAgentMenuItems;
@@ -307,5 +520,27 @@ export function useSessionMenuItems({
     }
   }, [groupByMode, byTimeMenuItems, byAgentMenuItems, byWorkspaceMenuItems]);
 
-  return { menuItems, sessionMap, isLoadMoreId, getLoadMoreGroupId };
+  const menuItems = useMemo<NavigationMenuItem[]>(
+    () =>
+      insertExpandedSubagentRows({
+        items: baseMenuItems,
+        childSessionsByParent,
+        expandedSubagentParentIds,
+        buildSessionRow,
+      }),
+    [
+      baseMenuItems,
+      buildSessionRow,
+      childSessionsByParent,
+      expandedSubagentParentIds,
+    ]
+  );
+
+  return {
+    menuItems,
+    sessionMap,
+    subagentParentIds,
+    isLoadMoreId,
+    getLoadMoreGroupId,
+  };
 }

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/types.ts
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/types.ts
@@ -13,11 +13,13 @@ export interface UseSessionMenuItemsParams {
   selectedOrgId?: string;
   includeExternal: boolean;
   groupVisibleCounts: ReadonlyMap<string, number>;
+  expandedSubagentParentIds?: ReadonlySet<string>;
 }
 
 export interface UseSessionMenuItemsResult {
   menuItems: NavigationMenuItem[];
   sessionMap: Map<string, Session>;
+  subagentParentIds: ReadonlySet<string>;
   isLoadMoreId: (id: string) => SessionListCategory | null;
   getLoadMoreGroupId: (id: string) => string | null;
 }

--- a/src/store/session/sessionAtom/__tests__/loaders.test.ts
+++ b/src/store/session/sessionAtom/__tests__/loaders.test.ts
@@ -14,7 +14,11 @@ import { describe, expect, it } from "vitest";
 import { __TESTS_ONLY } from "../loaders";
 import type { Session } from "../types";
 
-const { mergeSessions, replaceExternalHistorySourceFirstPage } = __TESTS_ONLY;
+const {
+  mergeSessions,
+  replaceAllImportedHistoryFirstPage,
+  replaceExternalHistorySourceFirstPage,
+} = __TESTS_ONLY;
 
 function makeSession(
   id: string,
@@ -107,6 +111,24 @@ describe("replaceExternalHistorySourceFirstPage", () => {
       "codexapp-new",
       "claudecodeapp-keep",
       "cursoride-keep",
+    ]);
+  });
+});
+
+describe("replaceAllImportedHistoryFirstPage", () => {
+  it("drops stale imported rows while preserving non-imported sessions", () => {
+    const prev = [
+      makeSession("codexapp-stale-child", "2026-01-03"),
+      makeSession("claudecodeapp-stale", "2026-01-02"),
+      makeSession("cliagent-keep", "2026-01-01"),
+    ];
+    const incoming = [makeSession("codexapp-parent", "2026-01-04")];
+
+    const merged = replaceAllImportedHistoryFirstPage(prev, incoming);
+
+    expect(merged.map((session) => session.session_id)).toEqual([
+      "codexapp-parent",
+      "cliagent-keep",
     ]);
   });
 });

--- a/src/store/session/sessionAtom/loaders.ts
+++ b/src/store/session/sessionAtom/loaders.ts
@@ -121,6 +121,15 @@ function replaceExternalHistorySourceFirstPage(
   );
 }
 
+function replaceAllImportedHistoryFirstPage(
+  prev: readonly Session[],
+  incoming: readonly Session[]
+): Session[] {
+  return replaceImportedFirstPage(prev, incoming, (sessionId) =>
+    Boolean(getImportedHistorySourceBySessionId(sessionId))
+  );
+}
+
 function setPaginationFor(
   category: SessionListCategory,
   patch: Partial<SessionPaginationMap[SessionListCategory]>
@@ -370,7 +379,9 @@ export const loadSidebarSessions = async (options?: {
   try {
     const { sessions: externalSessions, hasMore: externalHasMore } =
       await fetchExternalHistoryPage(0, pageSize);
-    store.set(sessionsAtom, (prev) => mergeSessions(prev, externalSessions));
+    store.set(sessionsAtom, (prev) =>
+      replaceAllImportedHistoryFirstPage(prev, externalSessions)
+    );
 
     const sessionsBySource = new Map<ImportedHistorySource, Session[]>();
     for (const session of externalSessions) {
@@ -434,5 +445,6 @@ export const loadMoreCategory = async (
 
 export const __TESTS_ONLY = {
   mergeSessions,
+  replaceAllImportedHistoryFirstPage,
   replaceExternalHistorySourceFirstPage,
 };

--- a/src/store/session/sessionAtom/types.ts
+++ b/src/store/session/sessionAtom/types.ts
@@ -36,6 +36,8 @@ export interface Session {
   user_input?: string;
   repo_name?: string;
   name?: string;
+  /** Backend-computed display label for list/search surfaces. */
+  displayLabel?: string;
   branch?: string;
   is_active?: boolean;
   /** Session category: CLI-based agent or Rust-native agent */

--- a/src/util/session/__tests__/sessionLabel.test.ts
+++ b/src/util/session/__tests__/sessionLabel.test.ts
@@ -17,6 +17,16 @@ describe("sessionLabel", () => {
     ).toBe("Fix the bug in auth");
   });
 
+  it("prefers backend displayLabel before user_input for default names", () => {
+    expect(
+      sessionLabel({
+        name: "New Session",
+        displayLabel: "External app title",
+        user_input: "Fix the bug in auth",
+      })
+    ).toBe("External app title");
+  });
+
   it("falls back to user_input when name is undefined", () => {
     expect(sessionLabel({ user_input: "Refactor store" })).toBe(
       "Refactor store"

--- a/src/util/session/sessionLabel.ts
+++ b/src/util/session/sessionLabel.ts
@@ -10,14 +10,18 @@ import { stripPillReferences } from "./stripPillReferences";
  * @param maxLength - truncation limit (default 30)
  */
 export function sessionLabel(
-  session: { name?: string; user_input?: string },
+  session: { name?: string; user_input?: string; displayLabel?: string },
   maxLength = 30
 ): string {
   const displayName =
     session.name && session.name !== SESSION_CONFIG.DEFAULT_SESSION_NAME
       ? session.name
       : undefined;
+  const generatedDisplayLabel = session.displayLabel?.trim() || undefined;
   const rawInput =
-    displayName || session.user_input?.slice(0, 80) || "Untitled";
+    displayName ||
+    generatedDisplayLabel ||
+    session.user_input?.slice(0, 80) ||
+    "Untitled";
   return stripPillReferences(rawInput).slice(0, maxLength) || "Untitled";
 }

--- a/src/util/session/sessionSidebarRow.ts
+++ b/src/util/session/sessionSidebarRow.ts
@@ -11,7 +11,7 @@ import { sessionLabel } from "@src/util/session/sessionLabel";
 
 /** Full-length session display name (no truncation). */
 export function getSessionListDisplayName(
-  session: { name?: string; user_input?: string },
+  session: { name?: string; user_input?: string; displayLabel?: string },
   fallback: string
 ): string {
   return sessionLabel(session, Infinity) || fallback;


### PR DESCRIPTION
## Summary
- Improve session replay diff payload extraction/rendering so synthetic hunk metadata does not leak into displayed diff sections.
- Sync imported Codex and Claude Code titles/parent metadata from external histories instead of falling back to the first prompt.
- Nest external subagent sessions under their parent sidebar row with hover chevron controls and hide child rows by default.
- Load full Codex/Claude-style non-windowed external histories so early rounds are not trimmed from long sessions.

## Why
Codex and Claude Code imported sessions were being labeled from prompt text, some child sessions were still rendered as standalone sidebar entries, and long imported sessions could lose earlier rounds because the shared external-history adapter applied a 200-chunk tail window to sources that cannot lazy-load older turns.

## Validation
- `node_modules/.bin/vitest run src/engines/SessionCore/rendering/props/__tests__/propsDataExtractors.test.ts src/modules/WorkStation/CodeEditor/SessionReplay/converters/__tests__/fileConverter.test.ts src/modules/WorkStation/shared/DiffSectionList/sessionReplaySections.test.ts src/store/session/sessionAtom/__tests__/loaders.test.ts src/util/session/__tests__/sessionLabel.test.ts src/api/tauri/session/__tests__/session.test.ts src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/menuSectionBuilders.test.ts src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/sessionGroupHelpers.test.ts src/util/session/__tests__/sessionVisibility.test.ts`
- `./node_modules/.bin/vitest run src/engines/SessionCore/sync/adapters/__tests__/externalHistoryAdapter.test.ts`
- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/eslint` on touched TS/TSX files
- `git diff --check`
- `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- `CARGO_TARGET_DIR=/tmp/orgii-orgtrack-core-target cargo check --manifest-path src-tauri/Cargo.toml -p orgtrack_core`
- `CARGO_TARGET_DIR=/tmp/orgii-perf-utils-target cargo check --manifest-path src-tauri/Cargo.toml -p perf_utils`
- `CARGO_TARGET_DIR=/tmp/orgii-app-target cargo check --manifest-path src-tauri/Cargo.toml -p org2` after a cold-build timeout, rerun passed

## Notes
- Full Rust tests remain blocked by existing missing Cursor fixture files under `src-tauri/crates/orgtrack-core/src/sources/fixtures/`.
- Replaces #311, which GitHub closed when the branch was renamed from `harry/session-sidebar-subagents` to `fix/session-sidebar-subagents`.