### PR TITLE
refactor(workstation): scope source-control PR/issue state by repo and polish scope picker

### DIFF
--- a/docs/frontend-ui-audit-2026-07-09/InlineAlert.md
+++ b/docs/frontend-ui-audit-2026-07-09/InlineAlert.md
@@ -1,0 +1,45 @@
+# Frontend UI Audit — InlineAlert
+
+**File:** `src/components/InlineAlert/index.tsx` (220 LOC)
+**Date:** 2026-07-09
+**Auditor:** Codex
+
+## D1 — Raw HTML vs Design System
+
+| Line | Element                     | Verdict          | Reason                                                                                                                                                                                                                                                          | Suggested change                                                                                         |
+| ---- | --------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| 185  | `<button>` pill expander    | keep with reason | This is the semantic wrapper for the whole alert title row, needs `aria-expanded`, text-left full-width layout, and wraps arbitrary title/icon content; DS `Button` would add button chrome that does not match the pill alert surface.                         | —                                                                                                        |
+| 199  | `<button>` close affordance | keep with reason | It is icon-only and has an accessible label; the local styling intentionally inherits the alert color with a tiny transparent hit area. Existing `IconButton` is toolbar-oriented and would introduce workstation button sizing/variant styling into the alert. | Consider an `InlineAlert`-specific close subcomponent only if this pattern grows outside this component. |
+
+## D2 — Arbitrary Tailwind Value vs Token
+
+| Line | Value | Verdict          | Reason                                                                                         | Suggested change |
+| ---- | ----- | ---------------- | ---------------------------------------------------------------------------------------------- | ---------------- |
+| —    | —     | keep with reason | No CSS-var arbitrary values, raw hex colors, or raw RGB/HSL color literals found in this file. | —                |
+
+## D3 — Hardcoded Sizes / Colors
+
+| Line | Value                           | Verdict          | Reason                                                                                                                                                                             | Suggested change |
+| ---- | ------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| 51   | `text-[13px]`, `leading-[14px]` | keep with reason | Alert title typography is below the standard text scale and is now centralized in `INLINE_ALERT_TOKENS`; changing to a spacing/text scale token would alter compact alert density. | —                |
+| 52   | `text-[12px]`                   | keep with reason | Alert body typography is compact by design and reused through `INLINE_ALERT_TOKENS.bodyText`.                                                                                      | —                |
+| 53   | `text-[11px]`                   | keep with reason | Subtitle typography is a compact secondary treatment and reused through `INLINE_ALERT_TOKENS.subtitleText`.                                                                        | —                |
+| 160  | `h-[14px]`                      | keep with reason | This is a sub-scale optical alignment wrapper matching the 14px lucide icons used by the component.                                                                                | —                |
+
+## D4 — Accessibility
+
+| Line | Element              | Verdict          | Reason                                                                                                                   | Suggested change |
+| ---- | -------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| 185  | Pill expander button | keep with reason | It exposes `aria-expanded` and contains visible title/body text through `titleNode`, so it has a usable accessible name. | —                |
+| 199  | Close button         | keep with reason | It has `aria-label={closeAriaLabel}` with a default label, so the icon-only control is named.                            | —                |
+
+## D5 — Visual Patterns Observed
+
+- Pattern: compact inline alert surface with icon, optional title/body, action, close, and pill expansion — implemented as the shared `InlineAlert` component itself, not duplicated across audited files.
+- Pattern: compact alert typography — centralized in `INLINE_ALERT_TOKENS`, so no sweep candidate from this change.
+
+## Summary
+
+- 0 fixes recommended
+- 8 kept with documented reason
+- 0 abstract candidates (>= 3 occurrences)

--- a/src/components/InlineAlert/index.tsx
+++ b/src/components/InlineAlert/index.tsx
@@ -47,6 +47,12 @@ const DEFAULT_ICONS: Record<string, React.ReactNode> = {
   info: <Info size={14} className="flex-shrink-0" />,
 };
 
+const INLINE_ALERT_TOKENS = {
+  titleText: "block text-[13px] font-medium leading-[14px]",
+  bodyText: "text-[12px] font-normal leading-snug",
+  subtitleText: "mt-1 block text-[11px] opacity-70",
+} as const;
+
 export interface InlineAlertActionConfig {
   label: string;
   href?: string;
@@ -126,6 +132,7 @@ const InlineAlert: React.FC<InlineAlertProps> = ({
   const resolvedCloseIcon = closeIcon ?? (
     <X size={14} className="flex-shrink-0" />
   );
+  const hasTitle = Boolean(title);
 
   const actionNode =
     action &&
@@ -155,10 +162,15 @@ const InlineAlert: React.FC<InlineAlertProps> = ({
         </span>
       )}
       <div className="min-w-0 flex-1">
-        {title && (
-          <span className="block text-[13px] font-medium leading-[14px]">
-            {title}
-          </span>
+        {hasTitle ? (
+          <span className={INLINE_ALERT_TOKENS.titleText}>{title}</span>
+        ) : (
+          showContent &&
+          children && (
+            <span className={`block ${INLINE_ALERT_TOKENS.bodyText}`}>
+              {children}
+            </span>
+          )
         )}
       </div>
     </div>
@@ -195,13 +207,11 @@ const InlineAlert: React.FC<InlineAlertProps> = ({
           </div>
         )}
       </div>
-      {showContent && children && (
-        <div className="mt-2 text-[12px] font-normal leading-snug">
-          {children}
-        </div>
+      {showContent && hasTitle && children && (
+        <div className={`mt-2 ${INLINE_ALERT_TOKENS.bodyText}`}>{children}</div>
       )}
       {showContent && subtitle && (
-        <span className="mt-1 block text-[11px] opacity-70">{subtitle}</span>
+        <span className={INLINE_ALERT_TOKENS.subtitleText}>{subtitle}</span>
       )}
     </div>
   );

--- a/src/engines/ChatPanel/panels/ManageIssuesPanelView.tsx
+++ b/src/engines/ChatPanel/panels/ManageIssuesPanelView.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useAtom, useAtomValue, useStore } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import { CheckCircle2, ChevronDown, CircleDot } from "lucide-react";
 import React, {
@@ -43,7 +43,8 @@ import {
 } from "@src/services/git/operations/githubIssues";
 import { REPO_KIND, reposAtom, selectedRepoPathAtom } from "@src/store/repo";
 import type { Repo } from "@src/store/repo/types";
-import { workstationSelectedIssueAtom } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationSelectedIssueAtomFamily } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationRepoScopeKey } from "@src/store/workstation/codeEditor/workstationPrAtom";
 import { createGitHubIssueDetailTab } from "@src/store/workstation/tabs";
 
 const ISSUE_TAB = {
@@ -479,7 +480,7 @@ const ManageIssuesPanelView: React.FC = () => {
     ? activeTab
     : ISSUE_TAB.RECENT;
   const [selectedRepo, setSelectedRepo] = useAtom(manageIssuesSelectedRepoAtom);
-  const setSelectedIssue = useSetAtom(workstationSelectedIssueAtom);
+  const store = useStore();
   const { openTab } = useWorkStationTabs();
   const [repoSources, setRepoSources] = useState<GitHubRepoSource[]>([]);
   const [repoIssueMap, setRepoIssueMap] = useState<
@@ -764,7 +765,10 @@ const ManageIssuesPanelView: React.FC = () => {
 
   const handleOpenIssue = useCallback(
     (issue: ManagedIssueItem) => {
-      setSelectedIssue({
+      const selectedIssueAtom = workstationSelectedIssueAtomFamily(
+        workstationRepoScopeKey(undefined, issue.repoPath)
+      );
+      store.set(selectedIssueAtom, {
         issue: issue.rawIssue,
         comments: [],
         loading: false,
@@ -786,7 +790,7 @@ const ManageIssuesPanelView: React.FC = () => {
           remoteUrl: issue.remoteUrl,
           issueNumber: issue.id,
         });
-        setSelectedIssue((current) => {
+        store.set(selectedIssueAtom, (current) => {
           if (current.issue?.html_url !== issue.rawIssue.html_url)
             return current;
           return {
@@ -798,7 +802,7 @@ const ManageIssuesPanelView: React.FC = () => {
         });
       })();
     },
-    [openTab, setSelectedIssue]
+    [openTab, store]
   );
 
   const listContent = (() => {

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/index.tsx
@@ -19,9 +19,10 @@ import {
 } from "@src/modules/WorkStation/shared";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
 import {
-  workstationIssueCallbackAtom,
-  workstationSelectedIssueAtom,
+  workstationIssueCallbackAtomFamily,
+  workstationSelectedIssueAtomFamily,
 } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationRepoScopeKey } from "@src/store/workstation/codeEditor/workstationPrAtom";
 import type { SourceControlHistorySelection } from "@src/store/workstation/tabs";
 import type { GitFile } from "@src/types/git/types";
 
@@ -79,8 +80,13 @@ const SourceControlMainContent: React.FC<SourceControlMainContentProps> = ({
   emptyFocusActions,
 }) => {
   const { t } = useTranslation();
-  const selectedIssueState = useAtomValue(workstationSelectedIssueAtom);
-  const issueCallbacks = useAtomValue(workstationIssueCallbackAtom);
+  const scopeKey = workstationRepoScopeKey(repoId, repoPath);
+  const selectedIssueState = useAtomValue(
+    workstationSelectedIssueAtomFamily(scopeKey)
+  );
+  const issueCallbacks = useAtomValue(
+    workstationIssueCallbackAtomFamily(scopeKey)
+  );
 
   const handleCloseIssue = useCallback(() => {
     if (selectedIssueState.issue && issueCallbacks.closeIssue) {

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainPane.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainPane.tsx
@@ -17,9 +17,10 @@ import type { QuickAction } from "@src/modules/WorkStation/shared";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
 import { sourceControlSessionFilterAtom } from "@src/store/workstation/codeEditor/sourceControlSessionFilterAtom";
 import {
-  workstationIssueCallbackAtom,
-  workstationSelectedIssueAtom,
+  workstationIssueCallbackAtomFamily,
+  workstationSelectedIssueAtomFamily,
 } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationRepoScopeKey } from "@src/store/workstation/codeEditor/workstationPrAtom";
 import type { GitFile } from "@src/types/git/types";
 
 import {
@@ -68,8 +69,13 @@ const SourceControlMainPane: React.FC<SourceControlMainPaneProps> = ({
   const sourceControlSessionFilter = useAtomValue(
     sourceControlSessionFilterAtom
   );
-  const selectedIssueState = useAtomValue(workstationSelectedIssueAtom);
-  const issueCallbacks = useAtomValue(workstationIssueCallbackAtom);
+  const scopeKey = workstationRepoScopeKey(repoId, repoPath);
+  const selectedIssueState = useAtomValue(
+    workstationSelectedIssueAtomFamily(scopeKey)
+  );
+  const issueCallbacks = useAtomValue(
+    workstationIssueCallbackAtomFamily(scopeKey)
+  );
 
   const handleCloseIssue = useCallback(() => {
     if (selectedIssueState.issue && issueCallbacks.closeIssue) {

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/index.tsx
@@ -63,7 +63,8 @@ import {
   SOURCE_CONTROL_ALL_SESSIONS_FILTER,
   sourceControlSessionFilterAtom,
 } from "@src/store/workstation/codeEditor/sourceControlSessionFilterAtom";
-import { workstationSelectedIssueAtom } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationSelectedIssueAtomFamily } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationRepoScopeKey } from "@src/store/workstation/codeEditor/workstationPrAtom";
 import {
   type SourceControlHistorySelection,
   createGitCommitDetailTab,
@@ -250,7 +251,10 @@ const EditorContent: React.FC<EditorContentProps> = memo(
     const sourceControlSessionFilter = useAtomValue(
       sourceControlSessionFilterAtom
     );
-    const selectedIssueState = useAtomValue(workstationSelectedIssueAtom);
+    const scopeKey = workstationRepoScopeKey(repoId, repoPath);
+    const selectedIssueState = useAtomValue(
+      workstationSelectedIssueAtomFamily(scopeKey)
+    );
     const setSourceControlSessionFilter = useSetAtom(
       sourceControlSessionFilterAtom
     );

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/IssuesContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/IssuesContent/index.tsx
@@ -29,7 +29,8 @@ import {
 } from "@src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/components/SectionStatusRow";
 import { TreeSectionHeader } from "@src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/components/TreeSectionHeader";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
-import { workstationIssueCallbackAtom } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationIssueCallbackAtomFamily } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationRepoScopeKey } from "@src/store/workstation/codeEditor/workstationPrAtom";
 
 import { useWorkstationIssues } from "../../hooks/useWorkstationIssues";
 import { IssueRow } from "./IssueRow";
@@ -70,7 +71,10 @@ const IssuesContent: React.FC<IssuesContentProps> = memo(
   }) => {
     const { t } = useTranslation("common");
     const navigate = useNavigate();
-    const setCallbackAtom = useSetAtom(workstationIssueCallbackAtom);
+    const scopeKey = workstationRepoScopeKey(repoId, repoPath);
+    const setCallbackAtom = useSetAtom(
+      workstationIssueCallbackAtomFamily(scopeKey)
+    );
 
     const {
       openIssues,

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/index.tsx
@@ -25,11 +25,12 @@ import { setPrDragStash } from "@src/shared/dnd/dragSideChannel";
 import { useReferencePillDrag } from "@src/shared/dnd/useReferencePillDrag";
 import { getPrStatusLabelKey } from "@src/shared/pr/prStatus";
 import {
-  workstationAllOpenPrsAtom,
-  workstationOpenPrsErrorAtom,
-  workstationOpenPrsLoadStateAtom,
-  workstationPrAtom,
-  workstationPrCallbackAtom,
+  workstationAllOpenPrsAtomFamily,
+  workstationOpenPrsErrorAtomFamily,
+  workstationOpenPrsLoadStateAtomFamily,
+  workstationPrAtomFamily,
+  workstationPrCallbackAtomFamily,
+  workstationRepoScopeKey,
 } from "@src/store/workstation/codeEditor/workstationPrAtom";
 import { formatRelativeTime } from "@src/util/time/formatRelativeTime";
 
@@ -38,6 +39,8 @@ import { getPrStatusVariant, truncateBranchLabel } from "./prCardHelpers";
 export interface PullRequestContentProps {
   branchName?: string;
   filterQuery?: string;
+  repoId?: string | null;
+  repoPath?: string;
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -186,19 +189,26 @@ PrRow.displayName = "PrRow";
 const PullRequestContent: React.FC<PullRequestContentProps> = ({
   branchName,
   filterQuery = "",
+  repoId,
+  repoPath,
 }) => {
   const { t } = useTranslation("common");
+  const scopeKey = workstationRepoScopeKey(repoId, repoPath);
   const {
     prUrl,
     readyToCreate,
     isCreating: prCreating,
-  } = useAtomValue(workstationPrAtom);
+  } = useAtomValue(workstationPrAtomFamily(scopeKey));
   const { createPr: onCreatePr, loadOpenPrs } = useAtomValue(
-    workstationPrCallbackAtom
+    workstationPrCallbackAtomFamily(scopeKey)
   );
-  const allOpenPrs = useAtomValue(workstationAllOpenPrsAtom);
-  const openPrsLoadState = useAtomValue(workstationOpenPrsLoadStateAtom);
-  const openPrsError = useAtomValue(workstationOpenPrsErrorAtom);
+  const allOpenPrs = useAtomValue(workstationAllOpenPrsAtomFamily(scopeKey));
+  const openPrsLoadState = useAtomValue(
+    workstationOpenPrsLoadStateAtomFamily(scopeKey)
+  );
+  const openPrsError = useAtomValue(
+    workstationOpenPrsErrorAtomFamily(scopeKey)
+  );
 
   useEffect(() => {
     loadOpenPrs?.();

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useSourceControlState/index.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useSourceControlState/index.ts
@@ -24,9 +24,10 @@ import { gitAutoCreatePrAtom } from "@src/store/ui/editorSettingsAtom";
 import { gitReviewNavigationAtom } from "@src/store/workstation/codeEditor/gitReviewNavigationAtom";
 import { gitOutputIntegrationAtom } from "@src/store/workstation/codeEditor/outputIntegration";
 import {
-  workstationPrAtom,
-  workstationPrCallbackAtom,
-  workstationPrCommitMessageAtom,
+  workstationPrAtomFamily,
+  workstationPrCallbackAtomFamily,
+  workstationPrCommitMessageAtomFamily,
+  workstationRepoScopeKey,
 } from "@src/store/workstation/codeEditor/workstationPrAtom";
 
 import { useStashState } from "../useStashState";
@@ -69,6 +70,7 @@ export function useSourceControlState(
   // Get git output integration for streaming
   const gitOutputIntegration = useAtomValue(gitOutputIntegrationAtom);
   const setGitReviewNavigation = useSetAtom(gitReviewNavigationAtom);
+  const scopeKey = workstationRepoScopeKey(selectedRepoId, repoPath);
 
   const { currentGitStatus: gitStatus } = useGitStatus();
 
@@ -271,11 +273,11 @@ export function useSourceControlState(
     prUrl,
     isCreating: prCreating,
     readyToCreate: prReadyToCreate,
-  } = useAtomValue(workstationPrAtom);
-  const { createPr } = useAtomValue(workstationPrCallbackAtom);
+  } = useAtomValue(workstationPrAtomFamily(scopeKey));
+  const { createPr } = useAtomValue(workstationPrCallbackAtomFamily(scopeKey));
   const autoCreatePr = useAtomValue(gitAutoCreatePrAtom);
   const setWorkstationPrCommitMessage = useSetAtom(
-    workstationPrCommitMessageAtom
+    workstationPrCommitMessageAtomFamily(scopeKey)
   );
 
   // Publish the commit summary so the single PR mount can build PR titles from

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useWorkstationIssues.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useWorkstationIssues.ts
@@ -29,11 +29,12 @@ import type {
   GitHubIssueUser,
 } from "@src/services/git/operations/githubIssues";
 import {
-  workstationIssueCallbackAtom,
-  workstationIssueListAtom,
-  workstationSelectedIssueAtom,
+  workstationIssueCallbackAtomFamily,
+  workstationIssueListAtomFamily,
+  workstationSelectedIssueAtomFamily,
 } from "@src/store/workstation/codeEditor/workstationIssueAtom";
 import type { IssueFilterState } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationRepoScopeKey } from "@src/store/workstation/codeEditor/workstationPrAtom";
 
 import {
   getCachedIssues,
@@ -74,14 +75,22 @@ function mergeUniqueIssues(
 
 export function useWorkstationIssues({
   repoPath,
-  repoId = "default",
+  repoId,
   remoteUrl: remoteUrlProp,
 }: UseWorkstationIssuesOptions) {
-  const setListState = useSetAtom(workstationIssueListAtom);
-  const setSelectedState = useSetAtom(workstationSelectedIssueAtom);
-  const setCallbackAtom = useSetAtom(workstationIssueCallbackAtom);
+  const apiRepoId = repoId ?? "default";
+  const scopeKey = workstationRepoScopeKey(repoId, repoPath);
+  const setListState = useSetAtom(workstationIssueListAtomFamily(scopeKey));
+  const setSelectedState = useSetAtom(
+    workstationSelectedIssueAtomFamily(scopeKey)
+  );
+  const setCallbackAtom = useSetAtom(
+    workstationIssueCallbackAtomFamily(scopeKey)
+  );
 
-  const selectedState = useAtomValue(workstationSelectedIssueAtom);
+  const selectedState = useAtomValue(
+    workstationSelectedIssueAtomFamily(scopeKey)
+  );
 
   const mountedRef = useRef(true);
   useEffect(() => {
@@ -127,10 +136,10 @@ export function useWorkstationIssues({
         return;
       }
 
-      logger.debug("fetching remotes", { repoPath, repoId });
+      logger.debug("fetching remotes", { repoPath, repoId: apiRepoId });
       try {
         const remotesData = await getGitRemotes({
-          repo_id: repoId,
+          repo_id: apiRepoId,
           repo_path: repoPath,
         });
         logger.debug("getGitRemotes result", remotesData);
@@ -151,7 +160,7 @@ export function useWorkstationIssues({
     return () => {
       cancelled = true;
     };
-  }, [repoPath, repoId, remoteUrlProp]);
+  }, [repoPath, apiRepoId, remoteUrlProp]);
 
   // Optimistically true when the remote resolves to a GitHub URL.
   // A valid GitHub URL means credentials should be available via

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useWorkstationPr.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useWorkstationPr.ts
@@ -14,11 +14,12 @@ import {
 } from "@src/services/git/operations/createPullRequest";
 import { gitAutoCreatePrAtom } from "@src/store/ui/editorSettingsAtom";
 import {
-  workstationAllOpenPrsAtom,
-  workstationOpenPrsErrorAtom,
-  workstationOpenPrsLoadStateAtom,
-  workstationPrAtom,
-  workstationPrCallbackAtom,
+  workstationAllOpenPrsAtomFamily,
+  workstationOpenPrsErrorAtomFamily,
+  workstationOpenPrsLoadStateAtomFamily,
+  workstationPrAtomFamily,
+  workstationPrCallbackAtomFamily,
+  workstationRepoScopeKey,
 } from "@src/store/workstation/codeEditor/workstationPrAtom";
 
 import { getCachedPrs, isPrCacheStale, setCachedPrs } from "./githubListCache";
@@ -48,21 +49,29 @@ type BranchPrState = {
 export function useWorkstationPr(options: UseWorkstationPrOptions) {
   const {
     repoPath,
-    repoId = "default",
+    repoId,
     branchName,
     hasUpstream,
     uncommittedCount,
     commitMessage,
   } = options;
+  const apiRepoId = repoId ?? "default";
 
   const { t } = useTranslation();
   const navigate = useNavigate();
   const autoCreatePr = useAtomValue(gitAutoCreatePrAtom);
-  const setWorkstationPrAtom = useSetAtom(workstationPrAtom);
-  const setWorkstationPrCallbackAtom = useSetAtom(workstationPrCallbackAtom);
-  const setAllOpenPrs = useSetAtom(workstationAllOpenPrsAtom);
-  const setOpenPrsLoadState = useSetAtom(workstationOpenPrsLoadStateAtom);
-  const setOpenPrsError = useSetAtom(workstationOpenPrsErrorAtom);
+  const scopeKey = workstationRepoScopeKey(repoId, repoPath);
+  const setWorkstationPrAtom = useSetAtom(workstationPrAtomFamily(scopeKey));
+  const setWorkstationPrCallbackAtom = useSetAtom(
+    workstationPrCallbackAtomFamily(scopeKey)
+  );
+  const setAllOpenPrs = useSetAtom(workstationAllOpenPrsAtomFamily(scopeKey));
+  const setOpenPrsLoadState = useSetAtom(
+    workstationOpenPrsLoadStateAtomFamily(scopeKey)
+  );
+  const setOpenPrsError = useSetAtom(
+    workstationOpenPrsErrorAtomFamily(scopeKey)
+  );
   const branchKey = branchName ?? "";
 
   const [remotePrByBranch, setRemotePrByBranch] = useState<
@@ -97,7 +106,7 @@ export function useWorkstationPr(options: UseWorkstationPrOptions) {
     if (!repoPath) return;
 
     fetchRustApi<{ name: string }>(
-      `${gitRepoUrl(repoId)}/default-branch?${new URLSearchParams({ path: repoPath }).toString()}`
+      `${gitRepoUrl(apiRepoId)}/default-branch?${new URLSearchParams({ path: repoPath }).toString()}`
     )
       .then((resp) => {
         if (!cancelled && resp.data?.name) {
@@ -113,7 +122,7 @@ export function useWorkstationPr(options: UseWorkstationPrOptions) {
     return () => {
       cancelled = true;
     };
-  }, [repoPath, repoId]);
+  }, [repoPath, apiRepoId]);
 
   useEffect(() => {
     autoTriggeredRef.current = false;
@@ -139,7 +148,7 @@ export function useWorkstationPr(options: UseWorkstationPrOptions) {
     void (async () => {
       try {
         const remotesData = await getGitRemotes({
-          repo_id: repoId,
+          repo_id: apiRepoId,
           repo_path: repoPath,
         });
         const originRemote = remotesData?.remotes?.find(
@@ -186,7 +195,7 @@ export function useWorkstationPr(options: UseWorkstationPrOptions) {
     })();
   }, [
     repoPath,
-    repoId,
+    apiRepoId,
     branchName,
     setAllOpenPrs,
     setOpenPrsLoadState,
@@ -224,7 +233,7 @@ export function useWorkstationPr(options: UseWorkstationPrOptions) {
       repoPath,
       branch: branchName,
       title,
-      repoId,
+      repoId: apiRepoId,
       pushBeforeCreate: true,
     });
 
@@ -266,7 +275,7 @@ export function useWorkstationPr(options: UseWorkstationPrOptions) {
 
     setCreatingByBranch((current) => ({ ...current, [branchName]: false }));
     return { url: result.url };
-  }, [isCreating, branchName, repoPath, commitMessage, repoId, t, navigate]);
+  }, [isCreating, branchName, repoPath, commitMessage, apiRepoId, t, navigate]);
 
   const prIsActive = !!prUrl && prStatus !== "closed" && prStatus !== "merged";
   const readyToCreate = eligible && !prIsActive;

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlScopeToolbar.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlScopeToolbar.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, Search, Trash2 } from "lucide-react";
+import { ChevronRight, GitBranch, GitFork, Search, Trash2 } from "lucide-react";
 import React, { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -6,6 +6,7 @@ import type { GitWorktreeDiffSummary } from "@src/api/http/git/types";
 import DiffStatsBadge from "@src/components/DiffStatsBadge";
 import Dropdown from "@src/components/Dropdown";
 import DropdownItem from "@src/components/Dropdown/DropdownItem";
+import DropdownSelectedCheck from "@src/components/Dropdown/DropdownSelectedCheck";
 import {
   DROPDOWN_CLASSES,
   DROPDOWN_ITEM,
@@ -42,9 +43,6 @@ const BREADCRUMB_TONE_CLASS = {
   primary: "text-[12px] font-medium text-text-1",
   secondary: "text-[11px] text-text-2",
 } as const;
-
-const SCOPE_SECTION_LABEL =
-  "px-1.5 pb-0.5 pt-2 text-[11px] font-medium text-text-4 first:pt-1";
 
 const SCOPE_PICKER_REMOVE_BUTTON = [
   "absolute right-1 top-1/2 z-[1] -translate-y-1/2 bg-surface-hover",
@@ -83,8 +81,30 @@ function ScopePickerDiffStats({
   );
 }
 
+function ScopePickerItemSuffix({
+  selected,
+  summary,
+}: {
+  selected: boolean;
+  summary?: GitWorktreeDiffSummary | null;
+}) {
+  const stats = <ScopePickerDiffStats summary={summary} />;
+  if (!selected) return stats;
+
+  return (
+    <span className="flex shrink-0 items-center gap-2">
+      {stats}
+      <DropdownSelectedCheck />
+    </span>
+  );
+}
+
 function ScopePickerSectionLabel({ label }: { label: string }) {
-  return <div className={SCOPE_SECTION_LABEL}>{label}</div>;
+  return (
+    <div className={DROPDOWN_CLASSES.sectionLabel}>
+      {label.toLocaleUpperCase()}
+    </div>
+  );
 }
 
 function ScopePickerItem({
@@ -115,6 +135,8 @@ function ScopePickerItem({
   ]
     .filter(Boolean)
     .join("\n");
+  const ScopeIcon = kind === "worktree" ? GitFork : GitBranch;
+  const hasDiffStats = diffStatsFromSummary(summary) !== null;
 
   return (
     <div className="group/scope-row relative w-full">
@@ -122,8 +144,13 @@ function ScopePickerItem({
         selected={selected}
         showCheckmark={false}
         onClick={onSelect}
+        icon={<ScopeIcon size={DROPDOWN_ITEM.iconSize} strokeWidth={1.75} />}
         className="w-full"
-        suffix={<ScopePickerDiffStats summary={summary} />}
+        suffix={
+          selected || hasDiffStats ? (
+            <ScopePickerItemSuffix selected={selected} summary={summary} />
+          ) : undefined
+        }
       >
         <span title={title}>{label}</span>
       </DropdownItem>
@@ -266,6 +293,12 @@ export function SourceControlScopeToolbar({
         ) : null}
         {filteredWorktrees.length > 0 ? (
           <>
+            {showMainScope ? (
+              <div
+                aria-hidden="true"
+                className={DROPDOWN_CLASSES.menuSeparatorInset}
+              />
+            ) : null}
             {showMainScope ? (
               <ScopePickerSectionLabel
                 label={t("sourceControl.scope.worktrees")}

--- a/src/modules/WorkStation/CodeEditor/useSourceControlSetup.ts
+++ b/src/modules/WorkStation/CodeEditor/useSourceControlSetup.ts
@@ -14,7 +14,10 @@ import {
   sourceControlFilterModeHandlerAtom,
   sourceControlFocusTargetAtom,
 } from "@src/store/workstation/codeEditor";
-import { workstationPrCommitMessageAtom } from "@src/store/workstation/codeEditor/workstationPrAtom";
+import {
+  workstationPrCommitMessageAtomFamily,
+  workstationRepoScopeKey,
+} from "@src/store/workstation/codeEditor/workstationPrAtom";
 import type {
   PanelState,
   SourceControlHistorySelection,
@@ -125,8 +128,9 @@ export function useSourceControlSetup({
     repoPath,
     autoLoad: true,
   });
+  const scopeKey = workstationRepoScopeKey(repoId, repoPath);
   const workstationPrCommitMessage = useAtomValue(
-    workstationPrCommitMessageAtom
+    workstationPrCommitMessageAtomFamily(scopeKey)
   );
   useWorkstationPr({
     repoPath,

--- a/src/modules/WorkStation/TabContent/renderers/githubIssueDetail.tsx
+++ b/src/modules/WorkStation/TabContent/renderers/githubIssueDetail.tsx
@@ -22,9 +22,10 @@ import {
   reopenIssue,
 } from "@src/services/git/operations/githubIssues";
 import {
-  workstationIssueCallbackAtom,
-  workstationSelectedIssueAtom,
+  workstationIssueCallbackAtomFamily,
+  workstationSelectedIssueAtomFamily,
 } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationRepoScopeKey } from "@src/store/workstation/codeEditor/workstationPrAtom";
 import type { GitHubIssueDetailTabData } from "@src/store/workstation/tabs";
 
 import type { UnifiedTabContentProps } from "../types";
@@ -41,11 +42,18 @@ function HeaderIssueStateIcon({
 const GitHubIssueDetailTabRenderer: React.FC<UnifiedTabContentProps> = memo(
   ({ tab }) => {
     const { t } = useTranslation();
-    const selectedState = useAtomValue(workstationSelectedIssueAtom);
-    const callbacks = useAtomValue(workstationIssueCallbackAtom);
-    const setSelectedState = useSetAtom(workstationSelectedIssueAtom);
     const { closeTab } = useWorkStationTabs();
     const tabData = tab.data as unknown as GitHubIssueDetailTabData;
+    const scopeKey = workstationRepoScopeKey(undefined, tabData.repoPath);
+    const selectedState = useAtomValue(
+      workstationSelectedIssueAtomFamily(scopeKey)
+    );
+    const callbacks = useAtomValue(
+      workstationIssueCallbackAtomFamily(scopeKey)
+    );
+    const setSelectedState = useSetAtom(
+      workstationSelectedIssueAtomFamily(scopeKey)
+    );
 
     const handleClose = useCallback(() => {
       closeTab(tab.id);

--- a/src/modules/WorkStation/shared/SidebarModules/SourceControl/useSourceControlSidebarModule.tsx
+++ b/src/modules/WorkStation/shared/SidebarModules/SourceControl/useSourceControlSidebarModule.tsx
@@ -45,7 +45,8 @@ import {
   useSourceControlTabConfig,
 } from "@src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlTab";
 import type { PrimarySidebarTab } from "@src/modules/WorkStation/shared/PrimarySidebarLayout";
-import { workstationIssueCallbackAtom } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationIssueCallbackAtomFamily } from "@src/store/workstation/codeEditor/workstationIssueAtom";
+import { workstationRepoScopeKey } from "@src/store/workstation/codeEditor/workstationPrAtom";
 import type { SourceControlHistorySelection } from "@src/store/workstation/tabs";
 import type { GitFile } from "@src/types/git/types";
 import { confirmDestructiveAction } from "@src/util/dialogs/confirmDestructiveAction";
@@ -263,7 +264,10 @@ export function useSourceControlSidebarModule({
     clear: clearIssuesFilter,
   } = useSectionFilter();
 
-  const issueCallbacks = useAtomValue(workstationIssueCallbackAtom);
+  const scopeKey = workstationRepoScopeKey(repoId, repoPath);
+  const issueCallbacks = useAtomValue(
+    workstationIssueCallbackAtomFamily(scopeKey)
+  );
   const handleIssuesRefresh = useCallback(() => {
     issueCallbacks.refreshIssues?.();
   }, [issueCallbacks]);
@@ -395,6 +399,8 @@ export function useSourceControlSidebarModule({
         <PullRequestContent
           branchName={branchName}
           filterQuery={prFilterQuery}
+          repoId={repoId}
+          repoPath={repoPath}
         />
       </div>
     ),
@@ -404,6 +410,8 @@ export function useSourceControlSidebarModule({
       setPrFilterQuery,
       clearPrFilter,
       branchName,
+      repoId,
+      repoPath,
       t,
     ]
   );

--- a/src/services/context/collectors/AdeContextCollector.ts
+++ b/src/services/context/collectors/AdeContextCollector.ts
@@ -42,8 +42,9 @@ import { userPresenceWireAtom } from "@src/store/user/userPresenceAtom";
 import { activeWorkspaceRootAtom } from "@src/store/workspace";
 import { globalLspDiagnosticsAtom } from "@src/store/workstation/codeEditor/diagnostics/globalLspDiagnosticsAtom";
 import {
-  workstationAllOpenPrsAtom,
-  workstationPrAtom,
+  workstationAllOpenPrsAtomFamily,
+  workstationPrAtomFamily,
+  workstationRepoScopeKey,
 } from "@src/store/workstation/codeEditor/workstationPrAtom";
 import {
   activeWorkStationFilePathAtom,
@@ -372,8 +373,13 @@ export async function collectAdeContextAsync(
   let currentPr: CurrentPullRequestSnapshot | undefined;
   try {
     const store = getInstrumentedStore();
-    const prSnapshot = store.get(workstationPrAtom);
-    const allOpenPrs = store.get(workstationAllOpenPrsAtom);
+    const activeWorkspaceRoot = store.get(activeWorkspaceRootAtom);
+    const scopeKey = workstationRepoScopeKey(
+      undefined,
+      options.expectedRepoPath ?? activeWorkspaceRoot?.path
+    );
+    const prSnapshot = store.get(workstationPrAtomFamily(scopeKey));
+    const allOpenPrs = store.get(workstationAllOpenPrsAtomFamily(scopeKey));
     const branch = store.get(currentBranchAtom);
 
     // Prefer the PR URL from the atom, fall back to matching by branch

--- a/src/store/workstation/codeEditor/workstationIssueAtom.ts
+++ b/src/store/workstation/codeEditor/workstationIssueAtom.ts
@@ -1,6 +1,9 @@
 import { atom } from "jotai";
+import { atomFamily } from "jotai-family";
 
 import type { GitHubIssue, GitHubIssueComment } from "@src/api/tauri/github";
+
+import { DEFAULT_WORKSTATION_REPO_SCOPE } from "./workstationPrAtom";
 
 export type IssueFilterState = "open" | "closed" | "all";
 
@@ -44,14 +47,28 @@ const initialSelectedState: WorkstationSelectedIssueState = {
   submittingComment: false,
 };
 
-// TODO(multi-panel): use atomFamily keyed by repoId when multiple workstation panels are supported.
-export const workstationIssueListAtom =
-  atom<WorkstationIssueListState>(initialListState);
-workstationIssueListAtom.debugLabel = "workstationIssueListAtom";
+export const workstationIssueListAtomFamily = atomFamily((scopeKey: string) => {
+  const scopedAtom = atom<WorkstationIssueListState>(initialListState);
+  scopedAtom.debugLabel = `workstationIssueListAtom(${scopeKey})`;
+  return scopedAtom;
+});
 
-export const workstationSelectedIssueAtom =
-  atom<WorkstationSelectedIssueState>(initialSelectedState);
-workstationSelectedIssueAtom.debugLabel = "workstationSelectedIssueAtom";
+export const workstationIssueListAtom = workstationIssueListAtomFamily(
+  DEFAULT_WORKSTATION_REPO_SCOPE
+);
+
+export const workstationSelectedIssueAtomFamily = atomFamily(
+  (scopeKey: string) => {
+    const scopedAtom =
+      atom<WorkstationSelectedIssueState>(initialSelectedState);
+    scopedAtom.debugLabel = `workstationSelectedIssueAtom(${scopeKey})`;
+    return scopedAtom;
+  }
+);
+
+export const workstationSelectedIssueAtom = workstationSelectedIssueAtomFamily(
+  DEFAULT_WORKSTATION_REPO_SCOPE
+);
 
 // Callback atom for actions triggerable from PinnedActionsBar, agents, or the
 // github-issue-detail tab rendered in the main pane.
@@ -69,3 +86,23 @@ export const workstationIssueCallbackAtom = atom<{
   refreshIssues: null,
 });
 workstationIssueCallbackAtom.debugLabel = "workstationIssueCallbackAtom";
+
+export const workstationIssueCallbackAtomFamily = atomFamily(
+  (scopeKey: string) => {
+    const scopedAtom = atom<{
+      openNewIssueForm: (() => void) | null;
+      closeIssue: ((number: number) => Promise<void>) | null;
+      reopenIssue: ((number: number) => Promise<void>) | null;
+      addComment: ((number: number, body: string) => Promise<void>) | null;
+      refreshIssues: (() => void) | null;
+    }>({
+      openNewIssueForm: null,
+      closeIssue: null,
+      reopenIssue: null,
+      addComment: null,
+      refreshIssues: null,
+    });
+    scopedAtom.debugLabel = `workstationIssueCallbackAtom(${scopeKey})`;
+    return scopedAtom;
+  }
+);

--- a/src/store/workstation/codeEditor/workstationPrAtom.ts
+++ b/src/store/workstation/codeEditor/workstationPrAtom.ts
@@ -1,19 +1,24 @@
 import { atom } from "jotai";
+import { atomFamily } from "jotai-family";
 
 import type { OpenPRItem } from "@src/api/tauri/github";
+
+export const DEFAULT_WORKSTATION_REPO_SCOPE = "default";
+
+export function workstationRepoScopeKey(
+  repoId: string | null | undefined,
+  repoPath: string | null | undefined
+): string {
+  const id = repoId?.trim();
+  if (id) return `repo:${id}`;
+  const path = repoPath?.trim();
+  return path ? `path:${path}` : DEFAULT_WORKSTATION_REPO_SCOPE;
+}
 
 /**
  * Shared PR state for the active workstation repo.
  * Written by `useWorkstationPr` when eligibility or PR URL changes.
  * Read by Source Control surfaces and context collection.
- *
- * TODO(multi-panel): This is a single global atom. When multiple workstation
- * panels are open simultaneously they will share state incorrectly. Fix by
- * migrating to `atomFamily` keyed by `repoId` (from `jotai-family`), matching
- * the pattern used in `cursorModeOverrideAtom.ts`. Callers to update:
- *   - `useWorkstationPr` (useSetAtom → useAtom(workstationPrAtomFamily(repoId)))
- *   - `workstationPrCallbackAtom` consumers
- *   - Any other direct reader of `workstationPrAtom`
  */
 export interface WorkstationPrSnapshot {
   /** The branch is eligible for PR creation (not default, pushed, clean) */
@@ -30,14 +35,24 @@ export interface WorkstationPrSnapshot {
   isDefaultBranch: boolean;
 }
 
-export const workstationPrAtom = atom<WorkstationPrSnapshot>({
+const initialWorkstationPrSnapshot: WorkstationPrSnapshot = {
   readyToCreate: false,
   prUrl: undefined,
   isCreating: false,
   hasUpstream: false,
   uncommittedCount: 0,
   isDefaultBranch: false,
+};
+
+export const workstationPrAtomFamily = atomFamily((scopeKey: string) => {
+  const scopedAtom = atom<WorkstationPrSnapshot>(initialWorkstationPrSnapshot);
+  scopedAtom.debugLabel = `workstationPrAtom(${scopeKey})`;
+  return scopedAtom;
 });
+
+export const workstationPrAtom = workstationPrAtomFamily(
+  DEFAULT_WORKSTATION_REPO_SCOPE
+);
 
 /**
  * Latest Source Control commit message for the active workstation repo.
@@ -50,6 +65,13 @@ export const workstationPrAtom = atom<WorkstationPrSnapshot>({
  * title falls back to the branch name.
  */
 export const workstationPrCommitMessageAtom = atom<string>("");
+export const workstationPrCommitMessageAtomFamily = atomFamily(
+  (scopeKey: string) => {
+    const scopedAtom = atom<string>("");
+    scopedAtom.debugLabel = `workstationPrCommitMessageAtom(${scopeKey})`;
+    return scopedAtom;
+  }
+);
 
 /**
  * All open pull requests for the active workstation repo.
@@ -57,6 +79,13 @@ export const workstationPrCommitMessageAtom = atom<string>("");
  * Read by `PullRequestContent` to render the full PR list.
  */
 export const workstationAllOpenPrsAtom = atom<OpenPRItem[]>([]);
+export const workstationAllOpenPrsAtomFamily = atomFamily(
+  (scopeKey: string) => {
+    const scopedAtom = atom<OpenPRItem[]>([]);
+    scopedAtom.debugLabel = `workstationAllOpenPrsAtom(${scopeKey})`;
+    return scopedAtom;
+  }
+);
 
 /**
  * Load lifecycle for `workstationAllOpenPrsAtom`. Lets the PR sidebar
@@ -74,8 +103,22 @@ export type WorkstationOpenPrsLoadState =
 
 export const workstationOpenPrsLoadStateAtom =
   atom<WorkstationOpenPrsLoadState>("idle");
+export const workstationOpenPrsLoadStateAtomFamily = atomFamily(
+  (scopeKey: string) => {
+    const scopedAtom = atom<WorkstationOpenPrsLoadState>("idle");
+    scopedAtom.debugLabel = `workstationOpenPrsLoadStateAtom(${scopeKey})`;
+    return scopedAtom;
+  }
+);
 
 export const workstationOpenPrsErrorAtom = atom<string | null>(null);
+export const workstationOpenPrsErrorAtomFamily = atomFamily(
+  (scopeKey: string) => {
+    const scopedAtom = atom<string | null>(null);
+    scopedAtom.debugLabel = `workstationOpenPrsErrorAtom(${scopeKey})`;
+    return scopedAtom;
+  }
+);
 
 /**
  * Stable ref-backed callback for triggering PR creation from Source Control UI.
@@ -85,3 +128,13 @@ export const workstationPrCallbackAtom = atom<{
   createPr: (() => Promise<{ url?: string; error?: string }>) | null;
   loadOpenPrs: (() => void) | null;
 }>({ createPr: null, loadOpenPrs: null });
+export const workstationPrCallbackAtomFamily = atomFamily(
+  (scopeKey: string) => {
+    const scopedAtom = atom<{
+      createPr: (() => Promise<{ url?: string; error?: string }>) | null;
+      loadOpenPrs: (() => void) | null;
+    }>({ createPr: null, loadOpenPrs: null });
+    scopedAtom.debugLabel = `workstationPrCallbackAtom(${scopeKey})`;
+    return scopedAtom;
+  }
+);


### PR DESCRIPTION
## Summary
- Scope workstation source-control PR and issue state by repository via updated Jotai atoms.
- Rework the source-control hooks and setup to read/write the repo-scoped state.
- Polish the scope picker toolbar and related source-control panels/renderers.

Part of a split from a larger change.