### PR TITLE
refactor(session): read pending plan approval via scoped usePendingPlanApproval hook

### DIFF
--- a/src/engines/ChatPanel/ChatView.tsx
+++ b/src/engines/ChatPanel/ChatView.tsx
@@ -51,6 +51,7 @@ import { useTodoSync } from "@src/engines/SessionCore/hooks/session/useTodoSync"
 import { AppType } from "@src/engines/Simulator/types/appTypes";
 import { useFileReviewSync } from "@src/hooks/fileReview";
 import { createLogger } from "@src/hooks/logger";
+import { usePendingPlanApproval } from "@src/hooks/session/usePendingPlanApproval";
 import { useSessionWorkspaceSync } from "@src/hooks/session/useSessionWorkspaceSync";
 import {
   activeSessionIdAtom,
@@ -64,7 +65,6 @@ import {
   sessionRuntimeStatusAtom,
   streamRetryStatusAtom,
 } from "@src/store/session/cliSessionStatusAtom";
-import { pendingPlanApprovalsAtom } from "@src/store/session/planApprovalAtom";
 import type { ChatHistoryDisplayMode } from "@src/store/ui/chatPanelAtom";
 import { chatPanelMaximizedAtom } from "@src/store/ui/chatPanelAtom";
 import {
@@ -455,9 +455,7 @@ const ChatView: React.FC<ChatViewProps> = memo(
           : null,
       [canvasPreview?.openedInSimulator, latestCanvasPayload, openLatestCanvas]
     );
-    const currentPlanApproval = useAtomValue(pendingPlanApprovalsAtom).get(
-      sessionId
-    )?.current;
+    const currentPlanApproval = usePendingPlanApproval(sessionId);
     const chatEvents = snapshot?.chatEvents ?? EMPTY_CHAT_EVENTS;
     const isAgentWorking = useAtomValue(isSessionActiveAtom);
 

--- a/src/engines/ChatPanel/blocks/CreatePlanCard/index.tsx
+++ b/src/engines/ChatPanel/blocks/CreatePlanCard/index.tsx
@@ -35,6 +35,7 @@ import {
   shouldDefaultCollapsePlanCard,
 } from "@src/engines/SessionCore/derived/planDisplayEvents";
 import { useMountedCleanup } from "@src/hooks/lifecycle/useMounted";
+import { usePendingPlanApproval } from "@src/hooks/session/usePendingPlanApproval";
 import { FileService } from "@src/services/file";
 import { sessionRuntimeStatusAtom } from "@src/store/session/cliSessionStatusAtom";
 import { creatorDefaultModelSelectionAtom } from "@src/store/session/creatorDefaultModelAtom";
@@ -138,7 +139,7 @@ const CreatePlanCard: React.FC<CreatePlanCardProps> = memo(
     const { t } = useTranslation("sessions");
     const activeSessionId = useAtomValue(activeSessionIdAtom);
     const sessionId = sessionIdProp ?? activeSessionId;
-    const approvalMap = useAtomValue(pendingPlanApprovalsAtom);
+    const currentPendingPlan = usePendingPlanApproval(sessionId);
     const setPendingPlanApprovals = useSetAtom(pendingPlanApprovalsAtom);
     const runtimeStatus = useAtomValue(sessionRuntimeStatusAtom);
     // Read the plan's *own* session row for model+key — approving a
@@ -183,18 +184,17 @@ const CreatePlanCard: React.FC<CreatePlanCardProps> = memo(
       if (!isEditing) setEditedContent(content);
     }, [content, isEditing]);
 
-    const state = sessionId ? approvalMap.get(sessionId) : undefined;
     const cardRevisionId = planRevisionId || toolCallId;
     const idMatch =
-      !!state?.current &&
+      !!currentPendingPlan &&
       !!cardRevisionId &&
-      (state.current.planRevisionId === cardRevisionId ||
-        state.current.toolCallId === cardRevisionId);
+      (currentPendingPlan.planRevisionId === cardRevisionId ||
+        currentPendingPlan.toolCallId === cardRevisionId);
     const ready =
       surfaceState?.readyForReview ??
       (idMatch && !isStreaming && effectiveApprovalStatus === "pending");
     const autoApproveAt = idMatch
-      ? (state.current?.autoApproveAt ?? null)
+      ? (currentPendingPlan.autoApproveAt ?? null)
       : null;
     const [nowMs, setNowMs] = useState<number>(() => Date.now());
 
@@ -327,7 +327,7 @@ const CreatePlanCard: React.FC<CreatePlanCardProps> = memo(
     // Save persists the edited plan to its backing store (plan file + the plan
     // event the preview re-reads + the pending snapshot) and exits edit mode,
     // WITHOUT approving or building. A later Build approves the persisted plan.
-    const pendingSnapshot = state?.current ?? null;
+    const pendingSnapshot = currentPendingPlan;
     const handleSave = useCallback(async () => {
       if (!sessionId || !interactive || submittingRef.current) return;
       submittingRef.current = true;

--- a/src/engines/ChatPanel/hooks/useInputArea/index.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/index.ts
@@ -32,6 +32,7 @@ import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 import { isPlanDisplayEvent } from "@src/engines/SessionCore/derived/planDisplayEvents";
 import { useSessionId } from "@src/engines/SessionCore/hooks/session";
 import { createLogger } from "@src/hooks/logger";
+import { usePendingPlanApproval } from "@src/hooks/session/usePendingPlanApproval";
 import {
   useSessionDraftField,
   useSessionReplyField,
@@ -42,7 +43,6 @@ import {
   isSessionActiveAtom,
   sessionRuntimeStatusAtom,
 } from "@src/store/session/cliSessionStatusAtom";
-import { pendingPlanApprovalsAtom } from "@src/store/session/planApprovalAtom";
 import { sessionByIdAtom } from "@src/store/session/sessionAtom/atoms";
 import { wpReadOnlyAtom } from "@src/store/ui/chatPanelAtom";
 import { workspaceFoldersAtom } from "@src/store/ui/workspaceFoldersAtom";
@@ -205,7 +205,6 @@ export function useInputArea(
   const rawIsSessionActive = useAtomValue(isSessionActiveAtom);
   const rawIsPendingCancel = useAtomValue(isPendingCancelAtom);
   const runtimeStatus = useAtomValue(sessionRuntimeStatusAtom);
-  const pendingPlanApprovals = useAtomValue(pendingPlanApprovalsAtom);
   const isSessionless = sessionScope === "none";
   const isSessionActive = isSessionless ? false : rawIsSessionActive;
   const isPendingCancel = isSessionless ? false : rawIsPendingCancel;
@@ -294,9 +293,7 @@ export function useInputArea(
   const currentRepoPath = activeSessionId
     ? (activeSession?.repoPath ?? workspaceRepoPath)
     : workspaceRepoPath;
-  const pendingPlan = activeSessionId
-    ? pendingPlanApprovals.get(activeSessionId)?.current
-    : null;
+  const pendingPlan = usePendingPlanApproval(activeSessionId);
   const sessionFileMentionOptions = useMemo<ReadonlyArray<CustomMentionOption>>(
     () =>
       sessionFiles.slice(0, 12).map((file) => {

--- a/src/engines/ChatPanel/rendering/adapters/PlanDocAdapter.tsx
+++ b/src/engines/ChatPanel/rendering/adapters/PlanDocAdapter.tsx
@@ -19,7 +19,7 @@ import {
   getPlanSubmittedPayloadFromResult,
 } from "@src/engines/SessionCore/derived/planDisplayEvents";
 import type { UniversalEventProps } from "@src/engines/SessionCore/rendering/types/universalProps";
-import { pendingPlanApprovalsAtom } from "@src/store/session/planApprovalAtom";
+import { usePendingPlanApproval } from "@src/hooks/session/usePendingPlanApproval";
 
 import CreatePlanCard from "../../blocks/CreatePlanCard";
 
@@ -28,10 +28,7 @@ function asString(value: unknown): string {
 }
 
 export const PlanDocAdapter: React.FC<UniversalEventProps> = (props) => {
-  const approvalMap = useAtomValue(pendingPlanApprovalsAtom);
-  const pendingPlan = props.sessionId
-    ? approvalMap.get(props.sessionId)?.current
-    : null;
+  const pendingPlan = usePendingPlanApproval(props.sessionId);
   const chatEvents = useAtomValue(chatEventsAtom);
   const eventForIdentity = chatEvents.find(
     (event) => event.id === props.eventId

--- a/src/hooks/session/index.ts
+++ b/src/hooks/session/index.ts
@@ -1,4 +1,5 @@
 export * from "./useAgentFileChangeListener";
 export * from "./useNativeSessionStatusMonitor";
+export * from "./usePendingPlanApproval";
 export * from "./useSessionPatch";
 export * from "./useSessionWorkspaceSync";

--- a/src/hooks/session/usePendingPlanApproval.ts
+++ b/src/hooks/session/usePendingPlanApproval.ts
@@ -1,0 +1,12 @@
+import { useAtomValue } from "jotai";
+
+import {
+  type PendingPlanApproval,
+  pendingPlanApprovalForSessionAtomFamily,
+} from "@src/store/session/planApprovalAtom";
+
+export function usePendingPlanApproval(
+  sessionId: string | null | undefined
+): PendingPlanApproval | null {
+  return useAtomValue(pendingPlanApprovalForSessionAtomFamily(sessionId ?? ""));
+}

--- a/src/modules/WorkStation/Chat/Communication/MessageViewer.tsx
+++ b/src/modules/WorkStation/Chat/Communication/MessageViewer.tsx
@@ -17,8 +17,8 @@ import {
   derivePlanApprovalViewState,
   isPlanDisplayEvent,
 } from "@src/engines/SessionCore/derived/planDisplayEvents";
+import { usePendingPlanApproval } from "@src/hooks/session/usePendingPlanApproval";
 import type { SessionReplayPlaceholderMode } from "@src/modules/WorkStation/shared";
-import { pendingPlanApprovalsAtom } from "@src/store/session/planApprovalAtom";
 
 import { isEmailBubbleEvent } from "./EmailMessageBubble";
 import { EmptyState } from "./EmptyState";
@@ -134,7 +134,6 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
     setViewMode?.("todo");
   }, [setViewMode]);
   const { t } = useTranslation(["common", "sessions"]);
-  const approvalMap = useAtomValue(pendingPlanApprovalsAtom);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const loadMoreScrollAnchorRef = useRef<{
     scrollTop: number;
@@ -234,6 +233,18 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
     }
     return null;
   }, [messages, viewMode]);
+  const selectedPlanMessage =
+    viewMode === "preview" && previewSelectedPlan && selectedMessage?.event
+      ? isPlanDisplayEvent(selectedMessage.event)
+        ? selectedMessage
+        : null
+      : null;
+
+  const activePlanMessage =
+    controlledActivePlanMessage ?? selectedPlanMessage ?? latestPlanMessage;
+  const pendingPlan = usePendingPlanApproval(
+    activePlanMessage?.event.sessionId
+  );
 
   if (messages.length === 0) {
     return (
@@ -251,20 +262,7 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
     );
   }
 
-  const selectedPlanMessage =
-    viewMode === "preview" && previewSelectedPlan && selectedMessage?.event
-      ? isPlanDisplayEvent(selectedMessage.event)
-        ? selectedMessage
-        : null
-      : null;
-
-  const activePlanMessage =
-    controlledActivePlanMessage ?? selectedPlanMessage ?? latestPlanMessage;
-
   if (viewMode === "preview" && activePlanMessage) {
-    const pendingPlan = approvalMap.get(
-      activePlanMessage.event.sessionId
-    )?.current;
     const plan = getPlanDocViewModel(activePlanMessage.event, pendingPlan);
     const statusView = getPlanDocStatusViewModel(
       activePlanMessage.event,

--- a/src/modules/WorkStation/Chat/Communication/usePlanApproval.ts
+++ b/src/modules/WorkStation/Chat/Communication/usePlanApproval.ts
@@ -17,6 +17,7 @@ import {
   isPlanDisplayEvent,
   planAliasesContain,
 } from "@src/engines/SessionCore/derived/planDisplayEvents";
+import { usePendingPlanApproval } from "@src/hooks/session/usePendingPlanApproval";
 import { FileService } from "@src/services/file";
 import { sessionRuntimeStatusAtom } from "@src/store/session/cliSessionStatusAtom";
 import { creatorDefaultModelSelectionAtom } from "@src/store/session/creatorDefaultModelAtom";
@@ -128,7 +129,7 @@ export function usePlanApproval({
 }: UsePlanApprovalOptions): PlanApprovalState {
   const { t } = useTranslation("sessions");
   const activeSessionId = useAtomValue(activeSessionIdAtom);
-  const approvalMap = useAtomValue(pendingPlanApprovalsAtom);
+  const activeSessionPendingPlan = usePendingPlanApproval(activeSessionId);
   const setPendingPlanApprovals = useSetAtom(pendingPlanApprovalsAtom);
   const sessionMap = useAtomValue(sessionMapAtom);
   const runtimeStatus = useAtomValue(sessionRuntimeStatusAtom);
@@ -146,10 +147,7 @@ export function usePlanApproval({
     null
   ) as React.RefObject<HTMLButtonElement>;
 
-  const activeSessionApprovalState = activeSessionId
-    ? approvalMap.get(activeSessionId)
-    : undefined;
-  const currentPendingPlan = activeSessionApprovalState?.current;
+  const currentPendingPlan = activeSessionPendingPlan;
   const planViewState = useMemo(
     () =>
       derivePlanApprovalViewState({
@@ -205,14 +203,12 @@ export function usePlanApproval({
     ? getPlanEventAliases(activePlanMessage!.event)
     : [];
 
-  const approvalState = planSessionId
-    ? approvalMap.get(planSessionId)
-    : undefined;
+  const planSessionPendingPlan = usePendingPlanApproval(planSessionId);
 
   const planRawContent = isPlanDoc
     ? resolvePlanMarkdownContent(
         activePlanMessage!.event,
-        approvalState?.current
+        planSessionPendingPlan
       )
     : "";
   const planPath =
@@ -220,7 +216,7 @@ export function usePlanApproval({
     asStringArg(planResult?.["planPath"]) ||
     null;
 
-  const planApprovalAliases = getPendingPlanAliases(approvalState?.current);
+  const planApprovalAliases = getPendingPlanAliases(planSessionPendingPlan);
   const matchesCurrentPendingPlan = planIdentity.some((identity) =>
     planAliasesContain(planApprovalAliases, identity)
   );

--- a/src/store/session/planApprovalAtom.ts
+++ b/src/store/session/planApprovalAtom.ts
@@ -25,6 +25,7 @@
  * disabled (nothing to mark in FE state).
  */
 import { atom } from "jotai";
+import { atomFamily } from "jotai-family";
 
 export interface PendingPlanApproval {
   sessionId: string;
@@ -46,6 +47,17 @@ export interface SessionPlanApprovalState {
 export type PlanApprovalStateMap = Map<string, SessionPlanApprovalState>;
 
 export const pendingPlanApprovalsAtom = atom<PlanApprovalStateMap>(new Map());
+
+export const pendingPlanApprovalForSessionAtomFamily = atomFamily(
+  (sessionId: string) => {
+    const scopedAtom = atom<PendingPlanApproval | null>((get) => {
+      if (!sessionId) return null;
+      return get(pendingPlanApprovalsAtom).get(sessionId)?.current ?? null;
+    });
+    scopedAtom.debugLabel = `pendingPlanApproval(${sessionId})`;
+    return scopedAtom;
+  }
+);
 
 function emptyState(): SessionPlanApprovalState {
   return { current: null };


### PR DESCRIPTION
## Summary
- Add a scoped usePendingPlanApproval hook backed by the plan approval atom.
- Consume the hook across ChatPanel blocks/adapters/views and Chat communication components.
- Centralizes pending plan approval reads instead of reading the atom directly.

Part of a split from a larger change.