### PR TITLE
fix(cli sessions structures design): wire OpenCode external-cli adapter

### DIFF
--- a/src-tauri/crates/orgtrack-core/src/sources/opencode/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/opencode/history.rs
@@ -146,20 +146,85 @@ fn sync_opencode_history_cache(cache_conn: &mut Connection) -> Result<(), String
         source_mtime_ms,
         source_size_bytes,
     )?;
-    let container_parent_ids: HashSet<String> = metas
-        .iter()
-        .filter_map(|meta| meta.parent_id.clone())
-        .filter(|parent_id| metas.iter().any(|m| &m.source_session_id == parent_id))
-        .collect();
+    let managed_source_session_ids = managed_opencode_source_session_ids_from_conn(cache_conn)?;
+    let container_parent_ids = container_parent_ids_from_metas(&metas);
     let live_ids = metas
         .iter()
         .map(|meta| meta.source_session_id.clone())
         .collect::<Vec<_>>();
     let inputs = metas
         .into_iter()
-        .map(|meta| session_meta_to_cache_input(meta, &container_parent_ids))
+        .map(|meta| {
+            session_meta_to_cache_input(meta, &container_parent_ids, &managed_source_session_ids)
+        })
         .collect::<Vec<_>>();
     imported_cache::sync_source_cache_from_conn(cache_conn, SOURCE_OPENCODE, live_ids, inputs)
+}
+
+fn managed_opencode_source_session_ids_from_conn(
+    conn: &Connection,
+) -> Result<HashSet<String>, String> {
+    let has_code_sessions = conn
+        .query_row(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'code_sessions'",
+            [],
+            |_| Ok(()),
+        )
+        .is_ok();
+    if !has_code_sessions {
+        return Ok(HashSet::new());
+    }
+
+    let mut stmt = conn
+        .prepare(
+            "SELECT cli_session_id FROM code_sessions \
+             WHERE cli_agent_type = 'opencode' AND cli_session_id IS NOT NULL AND cli_session_id != ''",
+        )
+        .map_err(|err| format!("Failed to prepare managed OpenCode session query: {err}"))?;
+    let rows = stmt
+        .query_map([], |row| row.get::<_, String>(0))
+        .map_err(|err| format!("Failed to query managed OpenCode sessions: {err}"))?;
+
+    let mut ids = HashSet::new();
+    for row in rows {
+        let id = row
+            .map_err(|err| format!("Failed to read managed OpenCode session row: {err}"))?
+            .trim()
+            .to_string();
+        if !id.is_empty() {
+            ids.insert(id);
+        }
+    }
+    Ok(ids)
+}
+
+fn container_parent_ids_from_metas(metas: &[OpenCodeSessionMeta]) -> HashSet<String> {
+    let source_ids = metas
+        .iter()
+        .map(|meta| meta.source_session_id.as_str())
+        .collect::<HashSet<_>>();
+    let parent_by_child = metas
+        .iter()
+        .filter_map(|meta| {
+            meta.parent_id
+                .as_deref()
+                .map(|parent_id| (meta.source_session_id.as_str(), parent_id))
+        })
+        .collect::<std::collections::HashMap<_, _>>();
+
+    metas
+        .iter()
+        .filter_map(|meta| {
+            let parent_id = meta.parent_id.as_deref()?;
+            if parent_id == meta.source_session_id || !source_ids.contains(parent_id) {
+                return None;
+            }
+            if parent_by_child.get(parent_id).copied() == Some(meta.source_session_id.as_str()) {
+                return None;
+            }
+            Some(parent_id.to_string())
+        })
+        .collect()
 }
 
 fn list_all_opencode_session_meta_from_conn(
@@ -225,6 +290,7 @@ fn list_all_opencode_session_meta_from_conn(
 fn session_meta_to_cache_input(
     meta: OpenCodeSessionMeta,
     container_parent_ids: &HashSet<String>,
+    managed_source_session_ids: &HashSet<String>,
 ) -> ImportedHistoryCacheInput {
     let model = meta.model.as_deref().and_then(parse_model_name);
     let updated_at_ms = if meta.time_updated > 0 {
@@ -233,7 +299,8 @@ fn session_meta_to_cache_input(
         meta.time_created
     };
     let is_container_parent = container_parent_ids.contains(&meta.source_session_id);
-    let listable = !is_container_parent;
+    let is_managed_history_mirror = managed_source_session_ids.contains(&meta.source_session_id);
+    let listable = !is_container_parent && !is_managed_history_mirror;
     let parent_session_id = meta
         .parent_id
         .as_deref()

--- a/src-tauri/crates/orgtrack-core/src/sources/opencode/history_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/opencode/history_tests.rs
@@ -181,7 +181,7 @@ fn maps_opencode_session_metadata_to_cache_input() {
     .expect("list session metadata");
     let inputs = metas
         .into_iter()
-        .map(|meta| session_meta_to_cache_input(meta, &HashSet::new()))
+        .map(|meta| session_meta_to_cache_input(meta, &HashSet::new(), &HashSet::new()))
         .collect::<Vec<_>>();
 
     assert_eq!(inputs.len(), 1);
@@ -241,7 +241,7 @@ fn opencode_recent_paths_use_all_sessions_before_limiting() {
     let rows = list_all_opencode_session_meta_from_conn(&conn, std::path::Path::new(""), 0, 0)
         .expect("list all sessions")
         .into_iter()
-        .map(|meta| session_meta_to_cache_input(meta, &HashSet::new()))
+        .map(|meta| session_meta_to_cache_input(meta, &HashSet::new(), &HashSet::new()))
         .map(|input| {
             imported_cache::ImportedHistoryCachedSession {
                 source_session_id: input.source_session_id,
@@ -353,15 +353,11 @@ fn maps_opencode_parent_id_to_parent_session_id() {
     )
     .expect("list sessions");
 
-    let container_parent_ids: HashSet<String> = metas
-        .iter()
-        .filter_map(|meta| meta.parent_id.clone())
-        .filter(|parent_id| metas.iter().any(|m| &m.source_session_id == parent_id))
-        .collect();
+    let container_parent_ids = container_parent_ids_from_metas(&metas);
 
     let inputs: Vec<ImportedHistoryCacheInput> = metas
         .into_iter()
-        .map(|meta| session_meta_to_cache_input(meta, &container_parent_ids))
+        .map(|meta| session_meta_to_cache_input(meta, &container_parent_ids, &HashSet::new()))
         .collect();
 
     let container = inputs
@@ -383,4 +379,205 @@ fn maps_opencode_parent_id_to_parent_session_id() {
         "task row remains listable and carries parent relation"
     );
     assert_eq!(task.parent_session_id.as_deref(), Some("opencodeapp-ses_1"));
+}
+
+#[test]
+fn reads_managed_opencode_source_session_ids_from_code_sessions() {
+    let conn = fixture_conn();
+    conn.execute(
+        "CREATE TABLE code_sessions (
+            session_id TEXT PRIMARY KEY,
+            cli_agent_type TEXT,
+            cli_session_id TEXT
+        )",
+        [],
+    )
+    .expect("create code_sessions");
+    conn.execute(
+        "INSERT INTO code_sessions (session_id, cli_agent_type, cli_session_id)
+         VALUES (?1, ?2, ?3), (?4, ?5, ?6), (?7, ?8, ?9)",
+        (
+            "cliagent-opencode",
+            "opencode",
+            "ses_managed",
+            "cliagent-empty",
+            "opencode",
+            "",
+            "cliagent-codex",
+            "codex",
+            "ses_codex",
+        ),
+    )
+    .expect("insert code sessions");
+
+    let ids = managed_opencode_source_session_ids_from_conn(&conn).expect("managed ids");
+
+    assert_eq!(ids.len(), 1);
+    assert!(ids.contains("ses_managed"));
+}
+
+#[test]
+fn managed_opencode_source_session_is_hidden_but_preserved() {
+    let conn = fixture_conn();
+    let metas = list_all_opencode_session_meta_from_conn(
+        &conn,
+        std::path::Path::new("/tmp/opencode.db"),
+        0,
+        0,
+    )
+    .expect("list sessions");
+    let managed_source_session_ids = ["ses_1".to_string()].into_iter().collect::<HashSet<_>>();
+    let inputs = metas
+        .into_iter()
+        .map(|meta| session_meta_to_cache_input(meta, &HashSet::new(), &managed_source_session_ids))
+        .collect::<Vec<_>>();
+
+    assert_eq!(inputs.len(), 1);
+    assert_eq!(inputs[0].source_session_id, "ses_1");
+    assert_eq!(inputs[0].session_id, "opencodeapp-ses_1");
+    assert!(!inputs[0].listable);
+    assert!(inputs[0].parent_session_id.is_none());
+}
+
+#[test]
+fn external_unmanaged_opencode_source_session_stays_listable() {
+    let conn = fixture_conn();
+    let metas = list_all_opencode_session_meta_from_conn(
+        &conn,
+        std::path::Path::new("/tmp/opencode.db"),
+        0,
+        0,
+    )
+    .expect("list sessions");
+    let inputs = metas
+        .into_iter()
+        .map(|meta| session_meta_to_cache_input(meta, &HashSet::new(), &HashSet::new()))
+        .collect::<Vec<_>>();
+
+    assert_eq!(inputs.len(), 1);
+    assert!(inputs[0].listable);
+    assert!(inputs[0].parent_session_id.is_none());
+}
+
+#[test]
+fn ignores_missing_parent_id_so_orphan_history_stays_visible() {
+    let conn = fixture_conn();
+    conn.execute(
+        "INSERT INTO session (
+            id, title, directory, model, tokens_input, tokens_output,
+            tokens_reasoning, tokens_cache_read, tokens_cache_write,
+            time_created, time_updated, time_archived, parent_id
+        ) VALUES (?1, ?2, ?3, ?4, 0, 0, 0, 0, 0, ?5, ?6, NULL, ?7)",
+        (
+            "ses_orphan",
+            "Orphan parent history",
+            "/tmp/opencode-repo",
+            "gpt-5",
+            1770000030000_i64,
+            1770000035000_i64,
+            "ses_missing",
+        ),
+    )
+    .expect("insert orphan session");
+
+    let metas = list_all_opencode_session_meta_from_conn(
+        &conn,
+        std::path::Path::new("/tmp/opencode.db"),
+        0,
+        0,
+    )
+    .expect("list sessions");
+    let container_parent_ids = container_parent_ids_from_metas(&metas);
+    let orphan = metas
+        .into_iter()
+        .find(|meta| meta.source_session_id == "ses_orphan")
+        .expect("orphan meta");
+    let input = session_meta_to_cache_input(orphan, &container_parent_ids, &HashSet::new());
+
+    assert!(input.listable);
+    assert!(input.parent_session_id.is_none());
+}
+
+#[test]
+fn ignores_self_parent_id() {
+    let conn = fixture_conn();
+    conn.execute(
+        "INSERT INTO session (
+            id, title, directory, model, tokens_input, tokens_output,
+            tokens_reasoning, tokens_cache_read, tokens_cache_write,
+            time_created, time_updated, time_archived, parent_id
+        ) VALUES (?1, ?2, ?3, ?4, 0, 0, 0, 0, 0, ?5, ?6, NULL, ?7)",
+        (
+            "ses_self",
+            "Self parent history",
+            "/tmp/opencode-repo",
+            "gpt-5",
+            1770000040000_i64,
+            1770000045000_i64,
+            "ses_self",
+        ),
+    )
+    .expect("insert self-parent session");
+
+    let metas = list_all_opencode_session_meta_from_conn(
+        &conn,
+        std::path::Path::new("/tmp/opencode.db"),
+        0,
+        0,
+    )
+    .expect("list sessions");
+    let container_parent_ids = container_parent_ids_from_metas(&metas);
+    let self_parent = metas
+        .into_iter()
+        .find(|meta| meta.source_session_id == "ses_self")
+        .expect("self parent meta");
+    let input = session_meta_to_cache_input(self_parent, &container_parent_ids, &HashSet::new());
+
+    assert!(input.listable);
+    assert!(input.parent_session_id.is_none());
+}
+
+#[test]
+fn ignores_mutual_parent_cycle() {
+    let conn = fixture_conn();
+    for (id, parent_id, created_at) in [
+        ("ses_cycle_a", "ses_cycle_b", 1770000050000_i64),
+        ("ses_cycle_b", "ses_cycle_a", 1770000051000_i64),
+    ] {
+        conn.execute(
+            "INSERT INTO session (
+                id, title, directory, model, tokens_input, tokens_output,
+                tokens_reasoning, tokens_cache_read, tokens_cache_write,
+                time_created, time_updated, time_archived, parent_id
+            ) VALUES (?1, ?2, ?3, ?4, 0, 0, 0, 0, 0, ?5, ?6, NULL, ?7)",
+            (
+                id,
+                format!("Cycle {id}"),
+                "/tmp/opencode-repo",
+                "gpt-5",
+                created_at,
+                created_at + 5000,
+                parent_id,
+            ),
+        )
+        .expect("insert cycle session");
+    }
+
+    let metas = list_all_opencode_session_meta_from_conn(
+        &conn,
+        std::path::Path::new("/tmp/opencode.db"),
+        0,
+        0,
+    )
+    .expect("list sessions");
+    let container_parent_ids = container_parent_ids_from_metas(&metas);
+    let inputs = metas
+        .into_iter()
+        .filter(|meta| meta.source_session_id.starts_with("ses_cycle_"))
+        .map(|meta| session_meta_to_cache_input(meta, &container_parent_ids, &HashSet::new()))
+        .collect::<Vec<_>>();
+
+    assert_eq!(inputs.len(), 2);
+    assert!(inputs.iter().all(|input| input.listable));
+    assert!(inputs.iter().all(|input| input.parent_session_id.is_none()));
 }

--- a/src-tauri/src/agent_sessions/event_pipeline/session_providers.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/session_providers.rs
@@ -1,12 +1,7 @@
-use core_types::activity::ActivityChunk;
-use database::db::get_connection;
 use orgtrack_core::sources::cursor_ide::history::CURSORIDE_SESSION_PREFIX;
-use orgtrack_core::sources::opencode::history as opencode_history;
 
-use crate::agent_sessions::event_pipeline::ingestion::prompt_backfill;
-use crate::agent_sessions::event_pipeline::types::{
-    ActivityStatus, EventDisplayStatus, EventDisplayVariant, EventSource, SessionEvent,
-};
+use crate::agent_sessions::event_pipeline::types::SessionEvent;
+use crate::agent_sessions::external_cli_adapter;
 
 trait SessionProvider: Send + Sync {
     fn matches_session(&self, session_id: &str) -> bool;
@@ -43,83 +38,20 @@ impl SessionProvider for CursorIdeProvider {
     }
 }
 
-struct OpenCodeProvider;
-
-impl SessionProvider for OpenCodeProvider {
-    fn matches_session(&self, session_id: &str) -> bool {
-        session_id.starts_with("opencodeapp-")
-    }
-
-    fn load_history_events(&self, session_id: &str) -> Result<Vec<SessionEvent>, String> {
-        let chunks = opencode_history::load_opencode_history_for_session(session_id)?;
-        Ok(chunks.iter().map(activity_chunk_to_session_event).collect())
-    }
-
-    fn subagent_prompt(&self, child_session_id: &str) -> Option<String> {
-        if !self.matches_session(child_session_id) {
-            return None;
-        }
-        if let Ok(chunks) = opencode_history::load_opencode_history_for_session(child_session_id) {
-            if let Some(prompt) = prompt_backfill::prompt_from_history_chunks(&chunks) {
-                return Some(prompt);
-            }
-        }
-        let conn = get_connection().ok()?;
-        if let Ok(prompt) = conn.query_row(
-            "SELECT user_input FROM code_sessions WHERE session_id = ?1 AND cli_agent_type = 'opencode'",
-            [child_session_id],
-            |row| row.get::<_, String>(0),
-        ) {
-            if let Some(prompt) = prompt_backfill::non_generic_subagent_prompt(prompt) {
-                return Some(prompt);
-            }
-        }
-        if let Ok(name) = conn.query_row(
-            "SELECT name FROM imported_history_session_cache WHERE session_id = ?1 AND source = 'opencode'",
-            [child_session_id],
-            |row| row.get::<_, String>(0),
-        ) {
-            if let Some(name) = prompt_backfill::non_generic_subagent_prompt(name) {
-                return Some(name);
-            }
-        }
-        None
-    }
-
-    fn imported_parent_session_id(
-        &self,
-        parent_session_id: &str,
-    ) -> Result<Option<String>, String> {
-        if self.matches_session(parent_session_id) {
-            return Ok(None);
-        }
-        let conn =
-            get_connection().map_err(|err| format!("Failed to open CLI session DB: {err}"))?;
-        match conn.query_row(
-            "SELECT cli_session_id FROM code_sessions WHERE session_id = ?1 AND cli_agent_type = 'opencode'",
-            [parent_session_id],
-            |row| row.get::<_, Option<String>>(0),
-        ) {
-            Ok(Some(cli_session_id)) if !cli_session_id.trim().is_empty() => {
-                Ok(Some(format!("opencodeapp-{}", cli_session_id.trim())))
-            }
-            Ok(_) | Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-            Err(err) => Err(format!(
-                "Failed to query OpenCode CLI session id for {parent_session_id}: {err}"
-            )),
-        }
-    }
-}
-
-static PROVIDERS: &[&(dyn SessionProvider + Sync)] = &[&OpenCodeProvider, &CursorIdeProvider];
+static PROVIDERS: &[&(dyn SessionProvider + Sync)] = &[&CursorIdeProvider];
 
 pub(crate) fn skips_event_cache_save(session_id: &str) -> bool {
-    PROVIDERS.iter().any(|provider| {
-        provider.matches_session(session_id) && provider.skips_event_cache_save(session_id)
-    })
+    external_cli_adapter::adapter_for_imported_session(session_id).is_some()
+        || PROVIDERS.iter().any(|provider| {
+            provider.matches_session(session_id) && provider.skips_event_cache_save(session_id)
+        })
 }
 
 pub(crate) fn load_history_events(session_id: &str) -> Result<Vec<SessionEvent>, String> {
+    if let Some(adapter) = external_cli_adapter::adapter_for_imported_session(session_id) {
+        return adapter.load_history_events(session_id);
+    }
+
     let Some(provider) = PROVIDERS
         .iter()
         .find(|provider| provider.matches_session(session_id))
@@ -130,6 +62,10 @@ pub(crate) fn load_history_events(session_id: &str) -> Result<Vec<SessionEvent>,
 }
 
 pub(crate) fn subagent_prompt(child_session_id: &str) -> Option<String> {
+    if let Some(adapter) = external_cli_adapter::adapter_for_imported_session(child_session_id) {
+        return adapter.resolve_subagent_prompt(child_session_id);
+    }
+
     PROVIDERS
         .iter()
         .find(|provider| provider.matches_session(child_session_id))
@@ -138,53 +74,15 @@ pub(crate) fn subagent_prompt(child_session_id: &str) -> Option<String> {
 
 pub(crate) fn imported_parent_session_ids(parent_session_id: &str) -> Result<Vec<String>, String> {
     let mut session_ids = Vec::new();
+    for adapter in external_cli_adapter::adapters() {
+        if let Some(session_id) = adapter.imported_parent_session_id(parent_session_id)? {
+            session_ids.push(session_id);
+        }
+    }
     for provider in PROVIDERS {
         if let Some(session_id) = provider.imported_parent_session_id(parent_session_id)? {
             session_ids.push(session_id);
         }
     }
     Ok(session_ids)
-}
-
-fn activity_chunk_to_session_event(chunk: &ActivityChunk) -> SessionEvent {
-    let function_name = if chunk.function.is_empty() {
-        chunk.action_type.clone()
-    } else {
-        chunk.function.clone()
-    };
-    SessionEvent {
-        id: if chunk.chunk_id.is_empty() {
-            uuid::Uuid::new_v4().to_string()
-        } else {
-            chunk.chunk_id.clone()
-        },
-        chunk_id: if chunk.chunk_id.is_empty() {
-            None
-        } else {
-            Some(chunk.chunk_id.clone())
-        },
-        session_id: chunk.session_id.clone(),
-        created_at: chunk.created_at.clone(),
-        function_name: function_name.clone(),
-        ui_canonical: function_name,
-        action_type: chunk.action_type.clone(),
-        args: chunk.args.clone(),
-        result: chunk.result.clone(),
-        source: EventSource::Assistant,
-        display_text: format!("{}: {}", chunk.action_type, chunk.function),
-        display_status: EventDisplayStatus::Completed,
-        display_variant: EventDisplayVariant::ToolCall,
-        activity_status: ActivityStatus::Processed,
-        thread_id: chunk.thread_id.clone(),
-        process_id: chunk.process_id.clone(),
-        call_id: None,
-        file_path: None,
-        command: None,
-        is_delta: None,
-        repo_id: None,
-        repo_path: None,
-        extracted: None,
-        payload_refs: Vec::new(),
-        last_extract_at: None,
-    }
 }

--- a/src-tauri/src/agent_sessions/external_cli_adapter/mod.rs
+++ b/src-tauri/src/agent_sessions/external_cli_adapter/mod.rs
@@ -1,0 +1,33 @@
+use crate::agent_sessions::event_pipeline::types::SessionEvent;
+
+pub mod opencode;
+
+pub trait ExternalCliAdapter: Send + Sync {
+    fn source(&self) -> &'static str;
+    fn cli_agent_type(&self) -> &'static str;
+    fn imported_session_prefix(&self) -> &'static str;
+    fn matches_imported_session(&self, session_id: &str) -> bool;
+    fn imported_session_id_from_native(&self, native_session_id: &str) -> String;
+    fn native_session_id_from_imported<'a>(&self, imported_session_id: &'a str) -> Option<&'a str>;
+    fn load_history_events(&self, imported_session_id: &str) -> Result<Vec<SessionEvent>, String>;
+    fn resolve_subagent_prompt(&self, child_session_id: &str) -> Option<String>;
+    fn imported_parent_session_id(
+        &self,
+        managed_parent_session_id: &str,
+    ) -> Result<Option<String>, String>;
+}
+
+static ADAPTERS: &[&(dyn ExternalCliAdapter + Sync)] = &[&opencode::OPENCODE_ADAPTER];
+
+pub fn adapter_for_imported_session(
+    session_id: &str,
+) -> Option<&'static (dyn ExternalCliAdapter + Sync)> {
+    ADAPTERS
+        .iter()
+        .copied()
+        .find(|adapter| adapter.matches_imported_session(session_id))
+}
+
+pub fn adapters() -> &'static [&'static (dyn ExternalCliAdapter + Sync)] {
+    ADAPTERS
+}

--- a/src-tauri/src/agent_sessions/external_cli_adapter/opencode.rs
+++ b/src-tauri/src/agent_sessions/external_cli_adapter/opencode.rs
@@ -1,0 +1,317 @@
+use core_types::activity::ActivityChunk;
+use database::db::get_connection;
+use orgtrack_core::sources::opencode::history as opencode_history;
+use rusqlite::{Connection, OptionalExtension};
+
+use crate::agent_sessions::event_pipeline::ingestion::prompt_backfill;
+use crate::agent_sessions::event_pipeline::types::{
+    ActivityStatus, EventDisplayStatus, EventDisplayVariant, EventSource, SessionEvent,
+};
+use crate::agent_sessions::external_cli_adapter::ExternalCliAdapter;
+
+pub const OPENCODE_SOURCE: &str = "opencode";
+pub const OPENCODE_CLI_AGENT_TYPE: &str = "opencode";
+pub const OPENCODE_IMPORTED_SESSION_PREFIX: &str = "opencodeapp-";
+
+pub static OPENCODE_ADAPTER: OpenCodeAdapter = OpenCodeAdapter;
+
+pub struct OpenCodeAdapter;
+
+impl OpenCodeAdapter {
+    fn resolve_subagent_prompt_from_conn(
+        &self,
+        conn: &Connection,
+        child_session_id: &str,
+    ) -> Option<String> {
+        if let Ok(Some(prompt)) = conn
+            .query_row(
+                "SELECT user_input FROM code_sessions WHERE session_id = ?1 AND cli_agent_type = 'opencode'",
+                [child_session_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+        {
+            if let Some(prompt) = prompt_backfill::non_generic_subagent_prompt(prompt) {
+                return Some(prompt);
+            }
+        }
+
+        if let Ok(Some(name)) = conn
+            .query_row(
+                "SELECT name FROM imported_history_session_cache WHERE session_id = ?1 AND source = 'opencode'",
+                [child_session_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+        {
+            if let Some(name) = prompt_backfill::non_generic_subagent_prompt(name) {
+                return Some(name);
+            }
+        }
+
+        None
+    }
+
+    fn imported_parent_session_id_from_conn(
+        &self,
+        conn: &Connection,
+        managed_parent_session_id: &str,
+    ) -> Result<Option<String>, String> {
+        match conn.query_row(
+            "SELECT cli_session_id FROM code_sessions WHERE session_id = ?1 AND cli_agent_type = 'opencode'",
+            [managed_parent_session_id],
+            |row| row.get::<_, Option<String>>(0),
+        ) {
+            Ok(Some(cli_session_id)) if !cli_session_id.trim().is_empty() => Ok(Some(
+                self.imported_session_id_from_native(cli_session_id.trim()),
+            )),
+            Ok(_) | Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(err) => Err(format!(
+                "Failed to query OpenCode CLI session id for {managed_parent_session_id}: {err}"
+            )),
+        }
+    }
+}
+
+impl ExternalCliAdapter for OpenCodeAdapter {
+    fn source(&self) -> &'static str {
+        OPENCODE_SOURCE
+    }
+
+    fn cli_agent_type(&self) -> &'static str {
+        OPENCODE_CLI_AGENT_TYPE
+    }
+
+    fn imported_session_prefix(&self) -> &'static str {
+        OPENCODE_IMPORTED_SESSION_PREFIX
+    }
+
+    fn matches_imported_session(&self, session_id: &str) -> bool {
+        session_id.starts_with(self.imported_session_prefix())
+    }
+
+    fn imported_session_id_from_native(&self, native_session_id: &str) -> String {
+        format!("{}{}", self.imported_session_prefix(), native_session_id)
+    }
+
+    fn native_session_id_from_imported<'a>(&self, imported_session_id: &'a str) -> Option<&'a str> {
+        imported_session_id.strip_prefix(self.imported_session_prefix())
+    }
+
+    fn load_history_events(&self, imported_session_id: &str) -> Result<Vec<SessionEvent>, String> {
+        let chunks = opencode_history::load_opencode_history_for_session(imported_session_id)?;
+        Ok(chunks.iter().map(activity_chunk_to_session_event).collect())
+    }
+
+    fn resolve_subagent_prompt(&self, child_session_id: &str) -> Option<String> {
+        if !self.matches_imported_session(child_session_id) {
+            return None;
+        }
+        if let Ok(chunks) = opencode_history::load_opencode_history_for_session(child_session_id) {
+            if let Some(prompt) = prompt_backfill::prompt_from_history_chunks(&chunks) {
+                return Some(prompt);
+            }
+        }
+        let conn = get_connection().ok()?;
+        self.resolve_subagent_prompt_from_conn(&conn, child_session_id)
+    }
+
+    fn imported_parent_session_id(
+        &self,
+        managed_parent_session_id: &str,
+    ) -> Result<Option<String>, String> {
+        if self.matches_imported_session(managed_parent_session_id) {
+            return Ok(None);
+        }
+        let conn =
+            get_connection().map_err(|err| format!("Failed to open CLI session DB: {err}"))?;
+        self.imported_parent_session_id_from_conn(&conn, managed_parent_session_id)
+    }
+}
+
+fn activity_chunk_to_session_event(chunk: &ActivityChunk) -> SessionEvent {
+    let function_name = if chunk.function.is_empty() {
+        chunk.action_type.clone()
+    } else {
+        chunk.function.clone()
+    };
+    SessionEvent {
+        id: if chunk.chunk_id.is_empty() {
+            uuid::Uuid::new_v4().to_string()
+        } else {
+            chunk.chunk_id.clone()
+        },
+        chunk_id: if chunk.chunk_id.is_empty() {
+            None
+        } else {
+            Some(chunk.chunk_id.clone())
+        },
+        session_id: chunk.session_id.clone(),
+        created_at: chunk.created_at.clone(),
+        function_name: function_name.clone(),
+        ui_canonical: function_name,
+        action_type: chunk.action_type.clone(),
+        args: chunk.args.clone(),
+        result: chunk.result.clone(),
+        source: EventSource::Assistant,
+        display_text: format!("{}: {}", chunk.action_type, chunk.function),
+        display_status: EventDisplayStatus::Completed,
+        display_variant: EventDisplayVariant::ToolCall,
+        activity_status: ActivityStatus::Processed,
+        thread_id: chunk.thread_id.clone(),
+        process_id: chunk.process_id.clone(),
+        call_id: None,
+        file_path: None,
+        command: None,
+        is_delta: None,
+        repo_id: None,
+        repo_path: None,
+        extracted: None,
+        payload_refs: Vec::new(),
+        last_extract_at: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_conn() -> Connection {
+        let conn = Connection::open_in_memory().expect("open fixture db");
+        conn.execute_batch(
+            "CREATE TABLE code_sessions (
+                session_id TEXT PRIMARY KEY,
+                cli_agent_type TEXT,
+                cli_session_id TEXT,
+                user_input TEXT
+            );
+            CREATE TABLE imported_history_session_cache (
+                session_id TEXT PRIMARY KEY,
+                source TEXT,
+                name TEXT
+            );",
+        )
+        .expect("create fixture schema");
+        conn
+    }
+
+    #[test]
+    fn matches_and_converts_opencode_imported_session_ids() {
+        let adapter = OpenCodeAdapter;
+
+        assert!(adapter.matches_imported_session("opencodeapp-ses_123"));
+        assert!(!adapter.matches_imported_session("cliagent-123"));
+        assert_eq!(
+            adapter.native_session_id_from_imported("opencodeapp-ses_123"),
+            Some("ses_123")
+        );
+        assert_eq!(
+            adapter.imported_session_id_from_native("ses_123"),
+            "opencodeapp-ses_123"
+        );
+    }
+
+    #[test]
+    fn imported_parent_session_id_uses_managed_cli_session_id() {
+        let conn = fixture_conn();
+        conn.execute(
+            "INSERT INTO code_sessions (session_id, cli_agent_type, cli_session_id, user_input)
+             VALUES (?1, ?2, ?3, ?4)",
+            ("cliagent-parent", "opencode", "ses_parent", "Parent prompt"),
+        )
+        .expect("insert managed session");
+
+        let adapter = OpenCodeAdapter;
+        let imported_parent = adapter
+            .imported_parent_session_id_from_conn(&conn, "cliagent-parent")
+            .expect("resolve imported parent");
+
+        assert_eq!(imported_parent.as_deref(), Some("opencodeapp-ses_parent"));
+    }
+
+    #[test]
+    fn imported_parent_session_id_ignores_empty_or_non_opencode_cli_session_id() {
+        let conn = fixture_conn();
+        conn.execute(
+            "INSERT INTO code_sessions (session_id, cli_agent_type, cli_session_id, user_input)
+             VALUES (?1, ?2, ?3, ?4), (?5, ?6, ?7, ?8)",
+            (
+                "cliagent-empty",
+                "opencode",
+                "",
+                "Prompt",
+                "cliagent-codex",
+                "codex",
+                "ses_codex",
+                "Prompt",
+            ),
+        )
+        .expect("insert sessions");
+
+        let adapter = OpenCodeAdapter;
+
+        assert_eq!(
+            adapter
+                .imported_parent_session_id_from_conn(&conn, "cliagent-empty")
+                .expect("resolve empty"),
+            None
+        );
+        assert_eq!(
+            adapter
+                .imported_parent_session_id_from_conn(&conn, "cliagent-codex")
+                .expect("resolve codex"),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_subagent_prompt_from_conn_prefers_user_input_over_imported_name() {
+        let conn = fixture_conn();
+        conn.execute(
+            "INSERT INTO code_sessions (session_id, cli_agent_type, cli_session_id, user_input)
+             VALUES (?1, ?2, ?3, ?4)",
+            (
+                "opencodeapp-ses_child",
+                "opencode",
+                "ses_child",
+                "Review the auth module for edge cases",
+            ),
+        )
+        .expect("insert child session");
+        conn.execute(
+            "INSERT INTO imported_history_session_cache (session_id, source, name)
+             VALUES (?1, ?2, ?3)",
+            ("opencodeapp-ses_child", "opencode", "Generic Subagent"),
+        )
+        .expect("insert imported name");
+
+        let adapter = OpenCodeAdapter;
+        let prompt = adapter
+            .resolve_subagent_prompt_from_conn(&conn, "opencodeapp-ses_child")
+            .expect("prompt");
+
+        assert_eq!(prompt, "Review the auth module for edge cases");
+    }
+
+    #[test]
+    fn resolve_subagent_prompt_from_conn_uses_non_generic_imported_name_fallback() {
+        let conn = fixture_conn();
+        conn.execute(
+            "INSERT INTO imported_history_session_cache (session_id, source, name)
+             VALUES (?1, ?2, ?3)",
+            (
+                "opencodeapp-ses_child",
+                "opencode",
+                "Summarize database migration risks",
+            ),
+        )
+        .expect("insert imported name");
+
+        let adapter = OpenCodeAdapter;
+        let prompt = adapter
+            .resolve_subagent_prompt_from_conn(&conn, "opencodeapp-ses_child")
+            .expect("prompt");
+
+        assert_eq!(prompt, "Summarize database migration risks");
+    }
+}

--- a/src-tauri/src/agent_sessions/mod.rs
+++ b/src-tauri/src/agent_sessions/mod.rs
@@ -16,5 +16,6 @@
 
 pub mod cli;
 pub mod event_pipeline;
+pub mod external_cli_adapter;
 pub mod health;
 pub mod unified_stats;


### PR DESCRIPTION
## Summary

Fixes #194

OpenCode imported history and subagent UI were leaking provider-specific logic across multiple layers. This change introduces the first `ExternalCliAdapter` and consolidates OpenCode behavior behind it, while preserving the product rule that ORGII-managed `cliagent-*` sessions own the sidebar and matching `opencodeapp-*` rows remain available only as backing history sources.

## Root Cause

### 1. Provider logic was scattered across unrelated modules

OpenCode-specific rules were split and duplicated between:

- `src-tauri/src/agent_sessions/event_pipeline/session_providers.rs` — imported-session matching, OpenCode DB history loading, subagent prompt fallback, and managed-parent aliasing.
- `src-tauri/crates/orgtrack-core/src/sources/opencode/history.rs` — imported history sync, listability, and parent-child mapping.
- `src-tauri/src/agent_sessions/event_pipeline/ingestion/prompt_backfill.rs` — generic fallback helpers that had to implicitly know about OpenCode-like ids.

### 2. The data structure was not a clean, centralized provider model

There was no single place where the OpenCode provider contract was defined. Instead, provider identity leaked into generic code through raw string prefixes (`opencodeapp-*`), direct SQL against `code_sessions`, and ad-hoc conversions from `cliagent-*` to `opencodeapp-*`. The same provider entity was represented differently in every layer:

```text
OpenCode SQLite DB     → ses_123
imported_history_cache → opencodeapp-ses_123
ORGII managed wrapper  → cliagent-abc
child subagent link    → opencodeapp-ses_child
```

Each layer had its own logic for mapping between these representations, so the shape of the provider was encoded implicitly in the code rather than in a single, explicit, well-organized data structure.

### 3. The design made the system fragmented, hard to test, and hard to extend

Because the provider contract was implicit:

- ID conversion, fallback priority, and listability rules were implemented in multiple places.
- Adding or fixing one behavior (e.g., hiding a managed mirror from the sidebar) required touching unrelated modules.
- Subagent prompt fallback had to be reasoned about in both the generic backfill path and the OpenCode-specific SQL path.
- Unit tests for the same provider identity were spread across crates.

When the left sidebar duplicated `cliagent-*` and `opencodeapp-*` rows, or when SubagentBlock showed generic text like “Assigned task to subagent”, the fix had to be made in several disconnected spots. The current design was not a clean, centralized data structure; it was a collection of provider-specific snippets stitched into generic code.

### 4. The new adapter design makes future CLI providers much easier to plug in

With `ExternalCliAdapter`, each provider now lives in one concrete module. The interface is small and provider-neutral:

```text
ExternalCliAdapter
  ├─ source()
  ├─ cli_agent_type()
  ├─ imported_session_prefix()
  ├─ load_history_events()
  ├─ resolve_subagent_prompt()
  └─ imported_parent_session_id()
```

To onboard a new CLI (Cursor, Codex, Claude Code, Windsurf, etc.), we only need to implement this trait and register it in the adapter registry. The facade in `session_providers.rs` and the history pipeline will automatically route the right sessions to the right adapter. No new frontend logic, no new prefix hacks, no duplication of the same provider contract across files.

## Fix

We extracted the live OpenCode behavior into a small, intentionally minimal adapter:

```text
┌─────────────────────────────────────────────────────────────────────┐
│  cache_bridge / event_pipeline / history.rs  callers                 │
└─────────────────────────────────────────────────────────────────────┘
                                    │
                                    ▼
┌─────────────────────────────────────────────────────────────────────┐
│  session_providers.rs  (compatibility facade, provider-neutral)      │
│  - skips_event_cache_save(session_id)                                │
│  - load_history_events(session_id)                                   │
│  - subagent_prompt(child_session_id)                                  │
│  - imported_parent_session_ids(parent_session_id)                     │
└─────────────────────────────────────────────────────────────────────┘
                                    │
                                    ▼
┌─────────────────────────────────────────────────────────────────────┐
│  external_cli_adapter::adapter_for_imported_session(session_id)      │
│  - registry lookup by prefix (e.g., `opencodeapp-*`)                   │
└─────────────────────────────────────────────────────────────────────┘
                                    │
                                    ▼
┌─────────────────────────────────────────────────────────────────────┐
│  OpenCodeAdapter (the first provider-specific impl)                  │
│  - source / cli_agent_type constants                                 │
│  - native ⇄ imported ID conversion                                   │
│  - load_history_events: OpenCode DB → ActivityChunk → SessionEvent   │
│  - resolve_subagent_prompt: explicit child-history → user_input → name fallback
│  - imported_parent_session_id: managed cliagent-* → opencodeapp-*    │
└─────────────────────────────────────────────────────────────────────┘
```

### Files changed

- `src-tauri/src/agent_sessions/mod.rs` — exports `external_cli_adapter`.
- `src-tauri/src/agent_sessions/external_cli_adapter/mod.rs` — new adapter trait and registry.
- `src-tauri/src/agent_sessions/external_cli_adapter/opencode.rs` — `OpenCodeAdapter` implementation and focused tests.
- `src-tauri/src/agent_sessions/event_pipeline/session_providers.rs` — reduced to a facade that delegates OpenCode calls to the adapter.
- `src-tauri/crates/orgtrack-core/src/sources/opencode/history.rs` — keeps OpenCode DB reading and imported-cache semantics; adds managed-mirror detection from `code_sessions`.
- `src-tauri/crates/orgtrack-core/src/sources/opencode/history_tests.rs` — tests for managed-mirror hiding, external-history visibility, and conservative parent validation.

## The New Architecture: External CLI Adapter

The frontend already consumes a normalized schema (`Session`, `SessionEvent`, `ActivityChunk`, imported-history rows). The remaining gap was in Rust: how does each external CLI provider translate its own native identity, history, and subagent metadata into that normalized schema?

Our adapter design solves this by giving each external CLI a single backend-side adapter:

```text
Frontend (React)
        │ consumes Session / SessionEvent / imported rows
        │
        ▼
EventStore / cache_bridge
        │
        ▼
session_providers.rs (provider-neutral facade)
        │
        ├──────┬──────┬──────┬──────┐
        │      │      │      │      │
        ▼      ▼      ▼      ▼      ▼
   ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐
   │OpenCode│ │Cursor│ │Codex │ │Claude│ │Future│
   │Adapter │ │Future│ │Future│ │Future│ │ CLI  │
   │(live) │ │      │ │      │ │      │ │      │
   └──────┘ └──────┘ └──────┘ └──────┘ └──────┘
        │
        ▼
   OpenCode DB / native CLI history
```

Each adapter owns:

1. **Identity conversion** — e.g., `opencodeapp-ses_123` ⇄ `ses_123` ⇄ `cliagent-abc` (via `code_sessions`).
2. **History loading** — read the provider’s native history and convert to `ActivityChunk` / `SessionEvent`.
3. **Subagent prompt resolution** — know where to look for a real child task prompt when the parent event is missing it.
4. **Managed-parent aliasing** — map ORGII-managed wrapper IDs to their imported native IDs for replay/monitor.

## Why This Architecture Is Better

- **Single source of truth for provider rules.** OpenCode ID conversion, prompt fallback, and listability are no longer scattered across modules.
- **Frontend stays provider-neutral.** React does not need to know about `opencodeapp-*`, `cliagent-*`, or OpenCode DB paths.
- **Testable boundaries.** Adapter tests can exercise ID mapping, prompt fallback, and parent aliasing without running the full UI.
- **Incremental adoption.** Other CLIs (Cursor, Codex, Claude Code, Windsurf, etc.) can be added by implementing the same small trait; no big-bang rewrite needed.
- **Preserves existing behavior.** `session_providers.rs` keeps the same public functions, so existing callers do not change.

## OpenCode Prompt Fallback Order (Explicit)

For `opencodeapp-ses_*` child sessions:

```text
1. First meaningful user message in the child OpenCode history
2. code_sessions.user_input for the matching OpenCode CLI child session
3. imported_history_session_cache.name (only if non-generic)
4. None — do not invent a generic prompt
```

This fixes the SubagentBlock showing “Assigned task to subagent” by giving it a real task description.

## Listability / Sidebar Identity Rule

```text
listable = !is_container_parent && !is_managed_history_mirror
```

- ORGII-managed OpenCode session: `cliagent-*` owns the sidebar entry.
- Matching imported `opencodeapp-*` row: preserved as replay/monitor backing source, but not listed as a primary sidebar row.
- External/unmanaged OpenCode history: remains listable.
- Dirty parent data (missing, self, mutual-cycle): does not hide valid rows.

## Flow: Loading an Imported OpenCode Session

```text
User opens opencodeapp-ses_123
        │
        ▼
cache_bridge::es_load_from_cache
        │
        ├─ EventStore memory?     → direct render
        ├─ ORGII event cache?     → CachedEvent → SessionEvent
        └─ provider fallback?     → session_providers::load_history_events
                │
                ▼
        external_cli_adapter::adapter_for_imported_session
                │
                ▼
        OpenCodeAdapter::load_history_events
                │
                ▼
        OpenCode SQLite DB
                │
                ▼
        ActivityChunk[]
                │
                ▼
        SessionEvent[]
                │
                ▼
        prepare_loaded_events
        (dedup, tool-input backfill, subagent link, prompt backfill)
                │
                ▼
        EventStore
                │
                ▼
        ChatPanel / SubagentBlock / Simulator
```

## Flow: Sidebar Deduplication

```text
OpenCode DB session  ses_123
        │
        ▼
sync_opencode_history_cache
        │
        ▼
read code_sessions.cli_session_id = ses_123
        │
        ▼
mark opencodeapp-ses_123 as managed_history_mirror
        │
        ▼
listable = false
        │
        ▼
sidebar shows cliagent-abc only
        │
        └─ opencodeapp-ses_123 still available for replay/monitor/prompt
```



## How to Add the Next CLI Provider

Implement the same small trait:

```rust
pub trait ExternalCliAdapter {
    fn source(&self) -> &'static str;
    fn cli_agent_type(&self) -> &'static str;
    fn imported_session_prefix(&self) -> &'static str;
    fn matches_imported_session(&self, session_id: &str) -> bool;
    fn imported_session_id_from_native(&self, native_session_id: &str) -> String;
    fn native_session_id_from_imported(&self, imported_session_id: &str) -> Option<&str>;
    fn load_history_events(&self, imported_session_id: &str) -> Result<Vec<SessionEvent>, String>;
    fn resolve_subagent_prompt(&self, child_session_id: &str) -> Option<String>;
    fn imported_parent_session_id(&self, managed_parent_session_id: &str) -> Result<Option<String>, String>;
}
```

Register the new adapter in `external_cli_adapter/mod.rs`, and `session_providers.rs` will automatically route matching imported sessions to it.

## Verification

- `cargo check` passed
- `cargo test external_cli_adapter` — 5 passed
- `cargo test -p orgtrack_core opencode` — blocked by pre-existing missing cursor_ide fixture files (`include_str!` references), unrelated to this change
- Husky pre-commit hook passed (cargo clippy scoped to org2 + orgtrack_core, eslint: 0, circular: 0)
- Manual dev UI verification passed:
  - ORGII-managed OpenCode session shows only the `cliagent-*` row in the left sidebar.
  - Matching `opencodeapp-*` imported mirror is not a duplicate sidebar row.
  - External OpenCode history without an ORGII wrapper remains listable.
  - OpenCode subagent blocks display the real child task prompt instead of “Assigned task to subagent”.
