### PR TITLE
fix(terminal): stop duplicated PTY output and dev status-bar residue

### DIFF
--- a/scripts/dev/tauri.js
+++ b/scripts/dev/tauri.js
@@ -117,7 +117,13 @@ function printBanner(features) {
 function writeStatusBar() {
   if (!isTTY) return;
 
-  const cols = process.stdout.columns || 80;
+  // Keep every status-bar line strictly narrower than the terminal width.
+  // A line that exactly fills `cols` triggers the terminal's autowrap/
+  // "pending wrap" behavior, so the following "\n" can consume a second
+  // physical row. The redraw only moves the cursor up 3 rows, so any extra
+  // wrapped row is never erased and accumulates on each repaint (duplicated
+  // separators + status block).
+  const cols = Math.max(1, (process.stdout.columns || 80) - 1);
   const separator = "─".repeat(cols);
   const rustLine = `\x1b[2m[Rust]   \x1b[0m ${STATUS.rust}`.slice(0, cols);
   const webpackLine = `\x1b[2m[Webpack]\x1b[0m ${STATUS.webpack}`.slice(

--- a/src/components/TerminalInteractive/__tests__/terminalPty.test.ts
+++ b/src/components/TerminalInteractive/__tests__/terminalPty.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { initPtyConnection } from "../terminalPty";
+
+const listenTauri = vi.fn();
+const invokeTauri = vi.fn();
+const isTauriReady = vi.fn(() => true);
+
+vi.mock("@src/util/platform/tauri/init", () => ({
+  listenTauri: (event: string, handler: unknown) => listenTauri(event, handler),
+  invokeTauri: (cmd: string, payload?: unknown) => invokeTauri(cmd, payload),
+  isTauriReady: () => isTauriReady(),
+}));
+
+vi.mock("@src/hooks/logger", () => ({
+  createLogger: () => ({ error: vi.fn(), warn: vi.fn(), info: vi.fn() }),
+}));
+
+vi.mock("../bufferCache", () => ({
+  getTerminalBuffer: vi.fn(() => null),
+  deleteTerminalBuffer: vi.fn(),
+}));
+
+vi.mock("../utils", () => ({
+  writeBrowserModeMessage: vi.fn(),
+}));
+
+type Ref<T> = { current: T };
+
+function ref<T>(value: T): Ref<T> {
+  return { current: value };
+}
+
+function createFakeTerminal() {
+  return {
+    write: vi.fn(),
+    writeln: vi.fn(),
+    focus: vi.fn(),
+    cols: 80,
+    rows: 20,
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function createParams(overrides: Partial<Record<string, any>> = {}) {
+  const terminal = overrides.terminal ?? createFakeTerminal();
+  return {
+    params: {
+      cols: 80,
+      rows: 20,
+      sessionKey: "session-1",
+      terminalRef: overrides.terminalRef ?? ref(terminal),
+      sessionIdRef: ref<string | null>(null),
+      unlistenOutputRef:
+        overrides.unlistenOutputRef ?? ref<(() => void) | null>(null),
+      unlistenExitRef:
+        overrides.unlistenExitRef ?? ref<(() => void) | null>(null),
+      repoPathRef: ref<string | undefined>(undefined),
+      shellType: "default" as const,
+      setIsBrowserMode: vi.fn(),
+      setIsConnecting: vi.fn(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any,
+    terminal,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isTauriReady.mockReturnValue(true);
+  // Default: pty does not exist yet, so a fresh session is created.
+  invokeTauri.mockImplementation((cmd: string) => {
+    if (cmd === "resize_pty") return Promise.reject(new Error("no pty"));
+    if (cmd === "get_pty_info") {
+      return Promise.resolve({
+        session_id: "terminal-pty-session-1",
+        pid: 1,
+        shell: "/bin/zsh",
+        cwd: null,
+      });
+    }
+    return Promise.resolve();
+  });
+  // Each listen registration returns its own unique unlisten fn.
+  listenTauri.mockImplementation(() => Promise.resolve(vi.fn()));
+});
+
+describe("initPtyConnection", () => {
+  it("registers exactly one output + one exit listener for a fresh session", async () => {
+    const { params, terminal } = createParams();
+
+    await initPtyConnection(params);
+
+    const listenedEvents = listenTauri.mock.calls.map((call) => call[0]);
+    expect(listenedEvents).toEqual([
+      "pty-output-terminal-pty-session-1",
+      "pty-exit-terminal-pty-session-1",
+    ]);
+    expect(typeof params.unlistenOutputRef.current).toBe("function");
+    expect(typeof params.unlistenExitRef.current).toBe("function");
+    expect(terminal.focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("tears down a previous listener before registering a new one (no stacking)", async () => {
+    const prevOutput = vi.fn();
+    const prevExit = vi.fn();
+    const { params } = createParams({
+      unlistenOutputRef: ref<(() => void) | null>(prevOutput),
+      unlistenExitRef: ref<(() => void) | null>(prevExit),
+    });
+
+    await initPtyConnection(params);
+
+    // The stale listeners from a prior init must be removed exactly once so a
+    // second listener never ends up writing the same PTY output to xterm.
+    expect(prevOutput).toHaveBeenCalledTimes(1);
+    expect(prevExit).toHaveBeenCalledTimes(1);
+    expect(params.unlistenOutputRef.current).not.toBe(prevOutput);
+    expect(params.unlistenExitRef.current).not.toBe(prevExit);
+  });
+
+  it("drops the listener and bails if the terminal is replaced during async init", async () => {
+    const terminal = createFakeTerminal();
+    const terminalRef = ref<ReturnType<typeof createFakeTerminal> | null>(
+      terminal
+    );
+    const droppedOutputUnlisten = vi.fn();
+
+    // Simulate the xterm instance being disposed/recreated (ref reassigned)
+    // while `listenTauri` is awaited.
+    listenTauri.mockImplementationOnce(() => {
+      terminalRef.current = createFakeTerminal();
+      return Promise.resolve(droppedOutputUnlisten);
+    });
+
+    const { params } = createParams({ terminal, terminalRef });
+
+    await initPtyConnection(params);
+
+    expect(droppedOutputUnlisten).toHaveBeenCalledTimes(1);
+    expect(params.unlistenOutputRef.current).toBeNull();
+    expect(params.unlistenExitRef.current).toBeNull();
+    // Bailed before touching the backend / registering the exit listener.
+    expect(listenTauri).toHaveBeenCalledTimes(1);
+    expect(
+      invokeTauri.mock.calls.some((call) => call[0] === "resize_pty")
+    ).toBe(false);
+  });
+});

--- a/src/components/TerminalInteractive/index.tsx
+++ b/src/components/TerminalInteractive/index.tsx
@@ -266,6 +266,14 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
       return () => {
         cleanupContainerVisibilityInit();
         cleanupTerminalHandlers();
+        // Tear down PTY listeners together with the terminal they write to.
+        // If this effect re-runs (e.g. an initPTY dependency changed), the old
+        // xterm is disposed here; leaving its listeners alive would stack a
+        // second listener on the recreated terminal and duplicate all output.
+        cleanupPtyListeners({
+          unlistenOutputRef,
+          unlistenExitRef,
+        });
 
         if (webglAddonRef.current) {
           webglAddonRef.current.dispose();
@@ -281,15 +289,6 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
       // existing terminal lifetime semantics documented at the top of this file.
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [fitTerminal, initPTY]);
-
-    useEffect(() => {
-      return () => {
-        cleanupPtyListeners({
-          unlistenOutputRef,
-          unlistenExitRef,
-        });
-      };
-    }, []);
 
     useTerminalResizeListeners({
       containerRef,

--- a/src/components/TerminalInteractive/terminalPty.ts
+++ b/src/components/TerminalInteractive/terminalPty.ts
@@ -245,6 +245,16 @@ export async function initPtyConnection({
     const terminal = terminalRef.current;
     if (!terminal) return;
 
+    // Tear down any listener left over from a previous init before registering
+    // new ones. Without this, a re-init (e.g. the xterm instance is recreated
+    // because an initPTY dependency such as shellOverride changed) stacks a
+    // second `pty-output` listener on top of the first, so every PTY chunk is
+    // written to xterm twice — the whole session renders duplicated line-by-line.
+    unlistenOutputRef.current?.();
+    unlistenOutputRef.current = null;
+    unlistenExitRef.current?.();
+    unlistenExitRef.current = null;
+
     const utf8Decoder = new TextDecoder("utf-8", { fatal: false });
     let ackPendingBytes = 0;
     let ackScheduled = false;
@@ -285,6 +295,14 @@ export async function initPtyConnection({
         }
       }
     );
+    // The `await` above yields to the event loop; the terminal may have been
+    // disposed/recreated in the meantime (React effect cleanup nulls the ref).
+    // Binding a listener to a stale terminal would leak it and double output on
+    // the live instance, so drop it immediately if we lost the race.
+    if (terminalRef.current !== terminal) {
+      unlistenOutput();
+      return;
+    }
     unlistenOutputRef.current = unlistenOutput;
 
     const unlistenExit = await listenTauri(`pty-exit-${sessionId}`, () => {
@@ -294,6 +312,12 @@ export async function initPtyConnection({
       }
       terminal.writeln("\r\n\x1b[33m[Session ended]\x1b[0m");
     });
+    if (terminalRef.current !== terminal) {
+      unlistenOutput();
+      unlistenExit();
+      unlistenOutputRef.current = null;
+      return;
+    }
     unlistenExitRef.current = unlistenExit;
 
     await reconnectOrCreatePty({


### PR DESCRIPTION
## Summary

Fixes two distinct terminal-output duplication bugs (both present since the initial repo import):

- **Duplicated PTY output (whole session rendered twice, line-by-line).** `TerminalView` re-registered its `pty-output` listener whenever an `initPTY` dependency changed — notably `shellOverride`, which flips from `undefined` → the detected shell the moment `onSessionInfoReady` writes it back into `session.shell`. The previous listener was never removed (its cleanup lived in a separate `[]`-deps effect that only ran on full unmount), so two live listeners each wrote every PTY chunk to xterm.
  - Tear down PTY listeners in the **same** effect that disposes the terminal, so a listener can never outlive the xterm instance it writes to.
  - Make `initPtyConnection` idempotent (unlisten before re-register) and add **staleness guards** after each async `listenTauri` so a listener is never bound to a disposed/replaced terminal.
- **Dev status-bar residue.** `scripts/dev/tauri.js` drew a separator of exactly `cols` width; a full-width line triggers the terminal's autowrap/pending-wrap, so the following `\n` consumed a second physical row. The redraw only moves the cursor up 3 rows, leaving accumulating separator/status residue on each repaint. Narrowed all status-bar lines to `cols - 1`.

## Test plan

- [x] `pnpm vitest run src/components/TerminalInteractive/__tests__/terminalPty.test.ts` — 3/3 pass (idempotent registration, unlisten-before-register, stale-terminal drop).
- [x] Pre-commit hooks (lint-staged + tsc) pass.
- [ ] Manual: run `npm run tauri:dev`, open a **fresh** terminal tab — first `Last login:` line and all output appear exactly once.
- [ ] Manual: dev status bar repaints cleanly with no stacked separators.