### PR TITLE
fix(side-query): reject length-truncated structured outputs

### DIFF
--- a/src-tauri/crates/agent-core/src/core/side_query.rs
+++ b/src-tauri/crates/agent-core/src/core/side_query.rs
@@ -21,7 +21,7 @@ use serde_json::Value;
 use tracing::{info, warn};
 
 use crate::providers::model_capabilities;
-use crate::providers::traits::{LLMProvider, LLMResponse, ProviderError};
+use crate::providers::traits::{finish_reason, LLMProvider, LLMResponse, ProviderError};
 
 /// Configuration for a side query call.
 pub struct SideQueryConfig {
@@ -91,6 +91,9 @@ pub struct SideQueryResult {
 #[derive(Debug)]
 pub enum SideQueryError {
     Provider(ProviderError),
+    /// The model hit its output token limit. Never accept this for side queries:
+    /// summaries / classifiers may be syntactically parseable but semantically truncated.
+    IncompleteOutput { finish_reason: String },
     EmptyContent,
 }
 
@@ -98,6 +101,10 @@ impl std::fmt::Display for SideQueryError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Provider(err) => write!(formatter, "Side query failed: {err}"),
+            Self::IncompleteOutput { finish_reason } => write!(
+                formatter,
+                "Side query returned incomplete output: finish_reason={finish_reason}"
+            ),
             Self::EmptyContent => write!(formatter, "Side query returned empty content"),
         }
     }
@@ -248,6 +255,13 @@ pub async fn side_query_typed(
         .await;
 
     let result = match response {
+        Ok(resp) if is_output_truncated(&resp) => {
+            warn!(
+                "[side-query] incomplete output finish_reason={} — retrying with padded max_tokens",
+                resp.finish_reason
+            );
+            None
+        }
         Ok(resp) => try_extract_result(&resp, expecting_structured, model, config),
         Err(ProviderError::RequestFailed(ref msg))
             if msg.to_lowercase().contains("http 400")
@@ -293,6 +307,12 @@ pub async fn side_query_typed(
         .await
         .map_err(SideQueryError::Provider)?;
 
+    if is_output_truncated(&retry_response) {
+        return Err(SideQueryError::IncompleteOutput {
+            finish_reason: retry_response.finish_reason.clone(),
+        });
+    }
+
     // On retry, try structured first, then fall back to primary_text
     if expecting_structured {
         if let Some(structured_val) = extract_structured_from_response(&retry_response, config) {
@@ -311,6 +331,10 @@ pub async fn side_query_typed(
             Err(SideQueryError::EmptyContent)
         }
     }
+}
+
+fn is_output_truncated(response: &LLMResponse) -> bool {
+    response.finish_reason == finish_reason::LENGTH
 }
 
 /// Attempt to extract a result from a response. Returns `None` to signal

--- a/src-tauri/crates/agent-core/src/core/tests/side_query_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/tests/side_query_tests.rs
@@ -8,7 +8,7 @@ use crate::core::side_query::{
     extract_tool_choice_override, side_query, SideQueryConfig, StructuredOutput,
     TOOL_CHOICE_OVERRIDE_KEY,
 };
-use crate::providers::traits::{LLMProvider, LLMResponse, ProviderError, ToolCallRequest};
+use crate::providers::traits::{finish_reason, LLMProvider, LLMResponse, ProviderError, ToolCallRequest};
 
 // ── Mock infrastructure ──
 
@@ -16,6 +16,7 @@ struct MockProvider {
     response_content: String,
     reasoning_content: Option<String>,
     tool_calls: Vec<ToolCallRequest>,
+    finish_reason: String,
     usage: HashMap<String, i64>,
     observed_messages: Mutex<Vec<Value>>,
     observed_tools_were_none: Mutex<bool>,
@@ -32,6 +33,7 @@ impl MockProvider {
             response_content: content.to_string(),
             reasoning_content: None,
             tool_calls: vec![],
+            finish_reason: finish_reason::STOP.to_string(),
             usage,
             observed_messages: Mutex::new(Vec::new()),
             observed_tools_were_none: Mutex::new(false),
@@ -45,6 +47,7 @@ impl MockProvider {
             response_content: String::new(),
             reasoning_content: None,
             tool_calls: vec![],
+            finish_reason: finish_reason::STOP.to_string(),
             usage: HashMap::new(),
             observed_messages: Mutex::new(Vec::new()),
             observed_tools_were_none: Mutex::new(false),
@@ -58,6 +61,7 @@ impl MockProvider {
             response_content: String::new(),
             reasoning_content: Some(reasoning.to_string()),
             tool_calls: vec![],
+            finish_reason: finish_reason::STOP.to_string(),
             usage: {
                 let mut u = HashMap::new();
                 u.insert("prompt_tokens".to_string(), 200);
@@ -81,6 +85,7 @@ impl MockProvider {
                 arguments,
                 thought_signature: None,
             }],
+            finish_reason: finish_reason::STOP.to_string(),
             usage: {
                 let mut u = HashMap::new();
                 u.insert("prompt_tokens".to_string(), 200);
@@ -92,6 +97,13 @@ impl MockProvider {
             observed_tools: Mutex::new(None),
             call_count: Mutex::new(0),
         }
+    }
+
+
+    fn with_tool_call_finish(tool_name: &str, arguments: Value, finish: &str) -> Self {
+        let mut provider = Self::with_tool_call(tool_name, arguments);
+        provider.finish_reason = finish.to_string();
+        provider
     }
 }
 
@@ -117,7 +129,7 @@ impl LLMProvider for MockProvider {
                 Some(self.response_content.clone())
             },
             tool_calls: self.tool_calls.clone(),
-            finish_reason: crate::providers::finish_reason::STOP.to_string(),
+            finish_reason: self.finish_reason.clone(),
             usage: self.usage.clone(),
             reasoning_content: self.reasoning_content.clone(),
             blocks: Vec::new(),
@@ -285,6 +297,34 @@ async fn structured_output_extracts_from_tool_call() {
     assert!(result.structured.is_some());
     let structured = result.structured.unwrap();
     assert_eq!(structured["summary"], "Files were changed, tests passed");
+}
+
+#[tokio::test]
+async fn structured_output_length_finish_is_rejected_even_when_parseable() {
+    let provider = MockProvider::with_tool_call_finish(
+        "emit_summary",
+        json!({"summary": "partial but parseable"}),
+        finish_reason::LENGTH,
+    );
+    let messages = vec![json!({"role": "user", "content": "Summarize"})];
+    let config = SideQueryConfig {
+        structured: Some(StructuredOutput {
+            tool_name: "emit_summary".to_string(),
+            schema: json!({
+                "type": "object",
+                "properties": { "summary": { "type": "string" } },
+                "required": ["summary"]
+            }),
+        }),
+        ..SideQueryConfig::default()
+    };
+
+    let err = side_query(&provider, &messages, &config, "test-model")
+        .await
+        .expect_err("length-truncated structured output must not be accepted");
+
+    assert!(err.contains("incomplete output"), "unexpected error: {err}");
+    assert_eq!(*provider.call_count.lock().unwrap(), 2, "should retry once before hard fail");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- reject side-query responses with `finish_reason=length` before extracting structured output
- retry once with padded `max_tokens`; if retry is still length-truncated, return an `IncompleteOutput` error
- add a regression test covering parseable structured output that is still length-truncated

## Why
Structured tool-call output can remain syntactically parseable even when the model hit its output token limit. Accepting such a response can persist semantically incomplete summaries/classification results, including compaction summaries.

## Validation
- Pre-commit hook ran successfully during commit
- `cargo test --manifest-path src-tauri/Cargo.toml -p agent_core side_query -- --nocapture` → 17 passed on the 150 Docker validation environment
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml` passed on the 150 Docker validation environment before rebasing onto latest `origin/develop`; local host lacks `cargo-fmt`, so no local rustfmt run was performed
