### PR TITLE
fix(session): fix phantom-idle UI, duplicate retry bubbles, and chat file resolution

### DIFF
--- a/src-tauri/crates/agent-core/src/core/session/turn/event_handler/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/event_handler/mod.rs
@@ -136,6 +136,14 @@ pub struct UnifiedEventHandler {
     /// Streaming buffer for message/thinking accumulation (Rust single source of truth).
     streaming_buffer: StreamingBuffer,
     flushed_message_sessions: Mutex<HashSet<String>>,
+    /// EventStore ids of message/thinking segments flushed during the LLM
+    /// response currently being received, keyed by session. When the stream
+    /// errors mid-response the retry regenerates the WHOLE response, so
+    /// these already-pushed segments must be retracted or they remain as
+    /// duplicated orphan bubbles (`on_stream_retry`). Cleared when a
+    /// response completes normally (`on_assistant_iteration_complete`) —
+    /// from that point the segments are authoritative.
+    retractable_stream_segments: Mutex<std::collections::HashMap<String, Vec<String>>>,
     /// Per-index accumulation of streamed `create_plan` tool args, keyed by
     /// the provider's tool-call block index. Powers the live drafting plan
     /// card: a skeleton tool_call event is pushed on block start, then
@@ -178,6 +186,33 @@ impl UnifiedEventHandler {
             .is_some_and(|active_turn_id| active_turn_id == bound_turn_id)
     }
 
+    /// Remember a flushed stream segment as retractable until the current
+    /// LLM response completes successfully.
+    fn track_retractable_segment(&self, session_id: &str, event_id: &str) {
+        if let Ok(mut segments) = self.retractable_stream_segments.lock() {
+            segments
+                .entry(session_id.to_string())
+                .or_default()
+                .push(event_id.to_string());
+        }
+    }
+
+    /// The in-flight LLM response completed successfully — its flushed
+    /// segments are now authoritative and must survive any later retry.
+    fn commit_retractable_segments(&self, session_id: &str) {
+        if let Ok(mut segments) = self.retractable_stream_segments.lock() {
+            segments.remove(session_id);
+        }
+    }
+
+    /// Drain the retractable segment ids for a session (retry path).
+    fn take_retractable_segments(&self, session_id: &str) -> Vec<String> {
+        self.retractable_stream_segments
+            .lock()
+            .map(|mut segments| segments.remove(session_id).unwrap_or_default())
+            .unwrap_or_default()
+    }
+
     /// Creates a new unified event handler.
     pub fn new(config: EventHandlerConfig) -> Self {
         Self {
@@ -187,6 +222,7 @@ impl UnifiedEventHandler {
             agent_called: AtomicBool::new(false),
             streaming_buffer: StreamingBuffer::with_default_timeout(),
             flushed_message_sessions: Mutex::new(HashSet::new()),
+            retractable_stream_segments: Mutex::new(std::collections::HashMap::new()),
             plan_draft_streams: Mutex::new(std::collections::HashMap::new()),
             last_context_tokens: std::sync::atomic::AtomicI64::new(0),
         }
@@ -208,6 +244,7 @@ impl UnifiedEventHandler {
         // this order would render Thought *after* the answer on reload.
         if let Some(mut event) = self.streaming_buffer.complete_thinking(session_id) {
             attach_turn_id(&mut event, self.config.turn_id.as_deref());
+            self.track_retractable_segment(session_id, &event.id);
             self.push_to_store(session_id, event.clone());
             broadcast_event(
                 "agent:streaming_complete",
@@ -224,6 +261,7 @@ impl UnifiedEventHandler {
             if let Ok(mut sessions) = self.flushed_message_sessions.lock() {
                 sessions.insert(session_id.to_string());
             }
+            self.track_retractable_segment(session_id, &event.id);
             self.push_to_store(session_id, event.clone());
             broadcast_event(
                 "agent:streaming_complete",
@@ -662,6 +700,11 @@ impl TurnEventHandler for UnifiedEventHandler {
             return;
         }
 
+        // This response finished streaming successfully — any segments
+        // flushed while it was arriving are final. Must happen before the
+        // empty-content early return: tool-call-only iterations also commit.
+        self.commit_retractable_segments(session_id);
+
         // Persist one `assistant` row per LLM iteration that produced text.
         //
         // Iterations with only tool_calls (no text) are skipped here: the
@@ -834,6 +877,30 @@ impl TurnEventHandler for UnifiedEventHandler {
         max_attempts: u32,
         backoff_ms: u64,
     ) {
+        // The interrupted response will be regenerated from scratch, so
+        // everything already surfaced from it must be withdrawn:
+        //
+        // 1. Retract flushed segments (EventStore + SQLite write-through).
+        //    A response like `[Text, ToolBlock…interrupted]` has already
+        //    pushed `Text` as an authoritative segment at the tool-block
+        //    flush; without retraction the retry produces a near-identical
+        //    second bubble (the "duplicated 'Writing 300 lines…'" bug).
+        // 2. Drop any partial in-buffer accumulation so it can't prefix the
+        //    regenerated text.
+        // 3. Un-mark the session's flushed-message flag: the flushed segment
+        //    is gone, so the retry's final text must not be suppressed by
+        //    `consumed_streamed_message` in `on_assistant_iteration_complete`.
+        let retracted = self.take_retractable_segments(session_id);
+        if !retracted.is_empty() {
+            if let Some(ref handle) = self.config.app_handle {
+                event_pipeline_bridge::remove_events_by_ids(handle, session_id, retracted);
+            }
+        }
+        self.streaming_buffer.discard_streams(session_id);
+        if let Ok(mut sessions) = self.flushed_message_sessions.lock() {
+            sessions.remove(session_id);
+        }
+
         // Low-key observability. The frontend uses this to render a footer
         // indicator ("Reconnecting… attempt N/M"). NEVER broadcast this as
         // `agent:message_delta` — that would poison the chat bubble with
@@ -924,5 +991,33 @@ mod tests {
     #[test]
     fn assistant_event_pushes_terminal_text_after_prior_streamed_segment() {
         assert!(should_push_assistant_event(false, false, true));
+    }
+
+    #[test]
+    fn retractable_segments_drained_once_on_retry() {
+        let handler = UnifiedEventHandler::new(EventHandlerConfig::default());
+        handler.track_retractable_segment("s1", "stream-msg-s1-1");
+        handler.track_retractable_segment("s1", "stream-think-s1-1");
+        handler.track_retractable_segment("s2", "stream-msg-s2-1");
+
+        let drained = handler.take_retractable_segments("s1");
+        assert_eq!(drained, vec!["stream-msg-s1-1", "stream-think-s1-1"]);
+        // Second drain is empty — a retry must not retract the same ids twice.
+        assert!(handler.take_retractable_segments("s1").is_empty());
+        // Other sessions are untouched.
+        assert_eq!(
+            handler.take_retractable_segments("s2"),
+            vec!["stream-msg-s2-1"]
+        );
+    }
+
+    #[test]
+    fn committed_segments_survive_later_retry() {
+        let handler = UnifiedEventHandler::new(EventHandlerConfig::default());
+        handler.track_retractable_segment("s1", "stream-msg-s1-1");
+        // Response completed successfully — segment becomes authoritative.
+        handler.commit_retractable_segments("s1");
+        // A retry in a LATER response must not retract the committed segment.
+        assert!(handler.take_retractable_segments("s1").is_empty());
     }
 }

--- a/src-tauri/crates/agent-core/src/foundation/bus/event_pipeline_bridge.rs
+++ b/src-tauri/crates/agent-core/src/foundation/bus/event_pipeline_bridge.rs
@@ -76,6 +76,13 @@ pub type SetSessionStreamingFn = fn(handle: &AppHandle, session_id: &str, stream
 pub type ReplaceStreamingEventFn =
     fn(handle: &AppHandle, session_id: &str, placeholder_id: &str, event: SessionEvent);
 
+/// Remove events by exact ids from the in-memory store AND the SQLite
+/// write-through, then schedule a notification. Used by stream-error
+/// recovery to retract segments that belong to an aborted LLM response:
+/// the retry regenerates the whole response, so the already-flushed
+/// segments would otherwise remain as duplicated orphan bubbles.
+pub type RemoveEventsByIdsFn = fn(handle: &AppHandle, session_id: &str, ids: Vec<String>);
+
 /// Mark `session_id` as pinned in the LRU (subagent child sessions).
 pub type PinSessionFn = fn(handle: &AppHandle, session_id: &str);
 
@@ -148,6 +155,7 @@ static COMPLETE_TOOL_CALL_BY_CALL_ID: OnceLock<CompleteToolCallByCallIdFn> = Onc
 static FINALIZE_STREAMING: OnceLock<FinalizeStreamingFn> = OnceLock::new();
 static SET_SESSION_STREAMING: OnceLock<SetSessionStreamingFn> = OnceLock::new();
 static REPLACE_STREAMING_EVENT: OnceLock<ReplaceStreamingEventFn> = OnceLock::new();
+static REMOVE_EVENTS_BY_IDS: OnceLock<RemoveEventsByIdsFn> = OnceLock::new();
 static PIN_SESSION: OnceLock<PinSessionFn> = OnceLock::new();
 static UNPIN_SESSION: OnceLock<UnpinSessionFn> = OnceLock::new();
 static READ_SESSION_EVENTS: OnceLock<ReadSessionEventsFn> = OnceLock::new();
@@ -173,6 +181,7 @@ pub fn register(
     finalize_streaming: FinalizeStreamingFn,
     set_session_streaming: SetSessionStreamingFn,
     replace_streaming_event: ReplaceStreamingEventFn,
+    remove_events_by_ids: RemoveEventsByIdsFn,
     pin_session: PinSessionFn,
     unpin_session: UnpinSessionFn,
     read_session_events: ReadSessionEventsFn,
@@ -189,6 +198,7 @@ pub fn register(
     let _ = FINALIZE_STREAMING.set(finalize_streaming);
     let _ = SET_SESSION_STREAMING.set(set_session_streaming);
     let _ = REPLACE_STREAMING_EVENT.set(replace_streaming_event);
+    let _ = REMOVE_EVENTS_BY_IDS.set(remove_events_by_ids);
     let _ = PIN_SESSION.set(pin_session);
     let _ = UNPIN_SESSION.set(unpin_session);
     let _ = READ_SESSION_EVENTS.set(read_session_events);
@@ -315,6 +325,18 @@ pub fn replace_streaming_event(
     } else {
         tracing::warn!(
             "[event-pipeline-bridge] replace_streaming_event called before register for {}",
+            session_id
+        );
+    }
+}
+
+pub fn remove_events_by_ids(handle: &AppHandle, session_id: &str, ids: Vec<String>) {
+    if let Some(f) = REMOVE_EVENTS_BY_IDS.get() {
+        f(handle, session_id, ids);
+    } else {
+        tracing::warn!(
+            "[event-pipeline-bridge] remove_events_by_ids called before register; dropping {} removals for {}",
+            ids.len(),
             session_id
         );
     }

--- a/src-tauri/crates/agent-core/src/foundation/streaming.rs
+++ b/src-tauri/crates/agent-core/src/foundation/streaming.rs
@@ -302,6 +302,16 @@ impl StreamingBuffer {
         counters.retain(|(sid, _), _| sid != session_id);
     }
 
+    /// Discard any in-flight streams for a session WITHOUT resetting segment
+    /// counters. Used by stream-error retry: the partial accumulation belongs
+    /// to an aborted LLM response and must not prefix the retry's regenerated
+    /// text, while counters keep advancing so retracted segment ids are never
+    /// reused by later flushes.
+    pub fn discard_streams(&self, session_id: &str) {
+        let mut streams = self.streams.lock().unwrap();
+        streams.retain(|(sid, _), _| sid != session_id);
+    }
+
     /// Flush expired streams. Returns events for streams that timed out.
     /// Call this periodically (e.g., every second) to auto-complete stale streams.
     pub fn flush_expired(&self) -> Vec<SessionEvent> {

--- a/src-tauri/src/agent_sessions/event_pipeline/agent_core_bridge.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/agent_core_bridge.rs
@@ -454,6 +454,32 @@ pub fn repair_stranded_plan_events() {
     }
 }
 
+fn remove_events_by_ids_adapter(handle: &AppHandle, session_id: &str, ids: Vec<String>) {
+    if ids.is_empty() {
+        return;
+    }
+    let state = handle.state::<EventStoreState>();
+    let removed = state.with_store_mut(session_id, |store| store.remove_by_ids(&ids));
+    if removed > 0 {
+        schedule_notify(handle, &state, session_id);
+    }
+
+    // SQLite write-through: the segments were persisted by push_events, so
+    // they must be retracted from disk too or a reload resurrects them.
+    let sid = session_id.to_string();
+    tokio::task::spawn_blocking(move || {
+        for event_id in &ids {
+            if let Err(err) = session_persistence::delete_event(&sid, event_id) {
+                tracing::warn!(
+                    "[event-pipeline] remove_events_by_ids: failed to delete {} from SQLite: {}",
+                    event_id,
+                    err
+                );
+            }
+        }
+    });
+}
+
 /// Register every IoC slot exposed by `agent_core::bus::event_pipeline_bridge`.
 /// Called once from `app::run` at startup.
 pub fn register() {
@@ -466,6 +492,7 @@ pub fn register() {
         finalize_streaming_adapter,
         set_session_streaming_adapter,
         replace_streaming_event_adapter,
+        remove_events_by_ids_adapter,
         pin_session_adapter,
         unpin_session_adapter,
         read_session_events_adapter,

--- a/src-tauri/src/agent_sessions/event_pipeline/store/event_ops.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/store/event_ops.rs
@@ -195,6 +195,18 @@ impl EventStore {
         removed
     }
 
+    /// Remove events by exact ids. Ids not present are ignored.
+    /// Returns the number of events actually removed.
+    pub fn remove_by_ids(&mut self, ids: &[String]) -> usize {
+        let existing_ids: Vec<String> = self
+            .events
+            .iter()
+            .filter(|event| ids.contains(&event.id))
+            .map(|event| event.id.clone())
+            .collect();
+        self.remove_events_by_ids(existing_ids)
+    }
+
     pub fn remove_synthetic_user_inputs(&mut self) -> usize {
         let removed_ids: Vec<String> = self
             .events

--- a/src-tauri/src/agent_sessions/event_pipeline/tests/store_tests.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/tests/store_tests.rs
@@ -461,6 +461,40 @@ fn test_remove_by_id_prefix_no_match() {
 }
 
 #[test]
+fn test_remove_by_ids() {
+    let mut store = EventStore::new();
+    store.set(vec![
+        make_event("stream-msg-1", "message"),
+        make_event("normal-1", "tool_call"),
+        make_event("stream-think-1", "message"),
+    ]);
+    let removed = store.remove_by_ids(&[
+        "stream-msg-1".to_string(),
+        "stream-think-1".to_string(),
+        "nonexistent".to_string(),
+    ]);
+    assert_eq!(removed, 2);
+    assert!(store.get_by_id("stream-msg-1").is_none());
+    assert!(store.get_by_id("stream-think-1").is_none());
+    assert!(store.get_by_id("normal-1").is_some());
+
+    // Removed ids surface in delta tracking so `es:changed` subscribers drop them.
+    let (_, _, removed_ids) = store.take_delta_tracking();
+    assert!(removed_ids.contains(&"stream-msg-1".to_string()));
+    assert!(removed_ids.contains(&"stream-think-1".to_string()));
+}
+
+#[test]
+fn test_remove_by_ids_no_match_keeps_version() {
+    let mut store = EventStore::new();
+    store.set(vec![make_event("a", "message")]);
+    let v_before = store.version();
+    let removed = store.remove_by_ids(&["nonexistent".to_string()]);
+    assert_eq!(removed, 0);
+    assert_eq!(store.version(), v_before);
+}
+
+#[test]
 fn test_remove_synthetic_user_inputs_keeps_backend_user_input_ids() {
     let mut store = EventStore::new();
     let mut synthetic = make_event("user-input-synthetic", "raw");

--- a/src/engines/SessionCore/hooks/replay/usePlanningIndicator.test.ts
+++ b/src/engines/SessionCore/hooks/replay/usePlanningIndicator.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { shouldShowPlanningIndicator } from "./usePlanningIndicator";
+import {
+  planningWatchdogDelayMs,
+  shouldShowPlanningIndicator,
+} from "./usePlanningIndicator";
 
 const baseInput = {
   runtimeStatus: "running",
@@ -101,5 +104,33 @@ describe("shouldShowPlanningIndicator", () => {
         hasRunningAwaitWaitFor: true,
       })
     ).toBe(false);
+  });
+});
+
+describe("planningWatchdogDelayMs", () => {
+  const WATCHDOG = 60_000;
+
+  it("trips when no channel event was ever observed", () => {
+    expect(planningWatchdogDelayMs(null, WATCHDOG)).toBeNull();
+  });
+
+  it("trips when the channel has been silent for the full window", () => {
+    expect(planningWatchdogDelayMs(WATCHDOG, WATCHDOG)).toBeNull();
+    expect(planningWatchdogDelayMs(WATCHDOG + 5_000, WATCHDOG)).toBeNull();
+  });
+
+  it("re-arms for the remainder while ephemeral deltas keep the channel busy", () => {
+    // tool_call_delta arrived 1s ago (never bumps the store version) —
+    // probe again in 59s rather than force-completing a live turn.
+    expect(planningWatchdogDelayMs(1_000, WATCHDOG)).toBe(59_000);
+  });
+
+  it("re-arms with a shrinking window as silence grows", () => {
+    expect(planningWatchdogDelayMs(59_999, WATCHDOG)).toBe(1);
+  });
+
+  it("clamps negative recency (clock skew) to a full window", () => {
+    // msSinceSessionChannelActivity floors at 0, but guard the policy too.
+    expect(planningWatchdogDelayMs(0, WATCHDOG)).toBe(WATCHDOG);
   });
 });

--- a/src/engines/SessionCore/hooks/replay/usePlanningIndicator.ts
+++ b/src/engines/SessionCore/hooks/replay/usePlanningIndicator.ts
@@ -49,12 +49,14 @@ import {
   noopSessionScopedPlanningMetaAtom,
   sessionScopedPlanningMetaAtomFamily,
 } from "@src/engines/SessionCore/derived/sessionScopedChatEvents";
+import { msSinceSessionChannelActivity } from "@src/engines/SessionCore/sync/sessionChannelActivity";
 import { createLogger } from "@src/hooks/logger";
 import {
   isPendingCancelAtom,
   isSessionActiveAtom,
   sessionRuntimeStatusAtom,
   setSessionRuntimeStatusAtom,
+  streamRetryStatusAtom,
 } from "@src/store/session/cliSessionStatusAtom";
 import {
   hasLiveSubagentJobs,
@@ -73,6 +75,31 @@ const IDLE_THRESHOLD_MS = 1000;
  * past a full minute almost certainly indicates a missed `agent:complete`.
  */
 const PLANNING_WATCHDOG_MS = 60_000;
+
+/**
+ * Decide what the watchdog should do when its timer fires, given how long
+ * ago the session's IPC channel last delivered ANY event.
+ *
+ * Returns `null` to trip (fire the force-complete), or a positive delay in
+ * ms to re-arm for. Pure so the recency policy is unit-testable without
+ * faking React timers.
+ *
+ * - `null` recency (no event observed since app start) trips: with the
+ *   channel silent for the whole watchdog window there is nothing to prove
+ *   the backend is alive, which is exactly the event-loss case the watchdog
+ *   exists for.
+ * - Recent activity re-arms for the REMAINDER of the window so a turn that
+ *   streams ephemeral deltas (never bumping the store version) is probed at
+ *   the right moment instead of on a fixed cadence.
+ */
+export function planningWatchdogDelayMs(
+  msSinceChannelActivity: number | null,
+  watchdogMs: number = PLANNING_WATCHDOG_MS
+): number | null {
+  if (msSinceChannelActivity === null) return null;
+  if (msSinceChannelActivity >= watchdogMs) return null;
+  return watchdogMs - msSinceChannelActivity;
+}
 
 export interface PlanningIndicatorVisibilityInput {
   runtimeStatus: string;
@@ -168,6 +195,7 @@ export function usePlanningIndicator(
   const globalVersion = useAtomValue(eventStoreVersionAtom);
   const sessionId = useAtomValue(sessionIdAtom);
   const subagentJobMap = useAtomValue(subagentJobMapAtom);
+  const streamRetryStatus = useAtomValue(streamRetryStatusAtom);
   const setSessionRuntimeStatus = useSetAtom(setSessionRuntimeStatusAtom);
   const scopedMeta = useAtomValue(
     scope
@@ -293,6 +321,10 @@ export function usePlanningIndicator(
   const hasLiveSubagent = scoped
     ? false
     : hasLiveSubagentJobs(subagentJobMap, sessionId);
+  // Backoff wait between LLM stream retries — silent by design, must not
+  // count as a stall (rate-limit backoffs can exceed the watchdog window).
+  const hasPendingStreamRetry =
+    !scoped && streamRetryStatus?.sessionId === sessionId;
   const visible = shouldShowPlanningIndicator({
     runtimeStatus,
     isSessionActive,
@@ -312,6 +344,15 @@ export function usePlanningIndicator(
   // which cancels this timer; on the next idle the watchdog re-arms.
   // We only trip on genuine "no activity at all" stalls.
   //
+  // "Activity" is CHANNEL activity, not store mutations: several event
+  // classes are deliberately ephemeral and never bump the store version —
+  // `agent:tool_call_delta` buffers in memory only (a model can spend
+  // minutes streaming one large edit_file call), `agent:stream_retry`
+  // writes a side atom. When the timer fires we therefore consult
+  // `msSinceSessionChannelActivity` and re-arm for the remaining window
+  // instead of tripping while the backend is demonstrably alive
+  // (see planningWatchdogDelayMs).
+  //
   // UI-only: this clears the runtime-status mirror so the footer stops
   // saying "Planning…", but deliberately does NOT touch the turn-lifecycle
   // FSM. A long quiet stretch (subagent wait, slow tool) is not proof the
@@ -330,23 +371,47 @@ export function usePlanningIndicator(
   // the parent status to "completed" mid-wait — the child's
   // `agent:subagent_job_changed` terminal event is the real completion
   // signal, not a 60s wall clock.
+  //
+  // hasPendingStreamRetry guard: `agent:stream_retry` means the backend is
+  // deliberately waiting out a backoff (rate-limit backoffs can exceed the
+  // watchdog window) with zero events by design. The retry pill is the
+  // user-visible activity indicator; the recovery/exhausted event re-arms
+  // normal watchdog coverage.
   useEffect(() => {
-    if (scoped || !visible || !sessionId || hasLiveSubagent || anyRunning)
+    if (
+      scoped ||
+      !visible ||
+      !sessionId ||
+      hasLiveSubagent ||
+      anyRunning ||
+      hasPendingStreamRetry
+    )
       return;
-    const timerId = window.setTimeout(() => {
-      log.warn(
-        `[usePlanningIndicator] watchdog: planning indicator stuck for ${PLANNING_WATCHDOG_MS}ms — ` +
-          "forcing session status to 'completed'. This usually means Rust dropped agent:complete " +
-          "or the idle agent:queue_status frame."
-      );
-      setSessionRuntimeStatus({
-        sessionId,
-        status: "completed",
-        source: "planning",
-      });
-    }, PLANNING_WATCHDOG_MS);
+    let timerId: number | null = null;
+    const arm = (delayMs: number) => {
+      timerId = window.setTimeout(() => {
+        const rearmDelay = planningWatchdogDelayMs(
+          msSinceSessionChannelActivity(sessionId)
+        );
+        if (rearmDelay !== null) {
+          arm(rearmDelay);
+          return;
+        }
+        log.warn(
+          `[usePlanningIndicator] watchdog: planning indicator stuck for ${PLANNING_WATCHDOG_MS}ms ` +
+            "with no channel activity — forcing session status to 'completed'. This usually means " +
+            "Rust dropped agent:complete or the idle agent:queue_status frame."
+        );
+        setSessionRuntimeStatus({
+          sessionId,
+          status: "completed",
+          source: "planning",
+        });
+      }, delayMs);
+    };
+    arm(PLANNING_WATCHDOG_MS);
     return () => {
-      window.clearTimeout(timerId);
+      if (timerId !== null) window.clearTimeout(timerId);
     };
   }, [
     scoped,
@@ -354,6 +419,7 @@ export function usePlanningIndicator(
     sessionId,
     hasLiveSubagent,
     anyRunning,
+    hasPendingStreamRetry,
     setSessionRuntimeStatus,
   ]);
 

--- a/src/engines/SessionCore/sync/adapters/createRustAgentAdapter.ts
+++ b/src/engines/SessionCore/sync/adapters/createRustAgentAdapter.ts
@@ -32,6 +32,7 @@ import type { ContextUsageSnapshot } from "@src/store/session/cliSessionStatusAt
 import { invokeTauri } from "@src/util/platform/tauri/init";
 import { retryInvokeTauri } from "@src/util/platform/tauri/retryInvoke";
 
+import { noteSessionChannelActivity } from "../sessionChannelActivity";
 import type {
   AdapterSendInput,
   AgentTokenUsageInfo,
@@ -435,6 +436,13 @@ export function createRustAgentAdapter(
       return {
         handleEvent(raw: RawSessionEvent): void {
           if (_disposed) return;
+
+          // Liveness stamp for EVERY channel event, before any filtering.
+          // Ephemeral events (tool_call_delta, stream_retry) never reach the
+          // EventStore, so this is the only place their arrival is recorded;
+          // the planning watchdog reads it to distinguish "backend still
+          // streaming" from "backend went silent".
+          noteSessionChannelActivity(sessionId);
 
           const payload =
             raw.payload && typeof raw.payload === "object" ? raw.payload : {};

--- a/src/engines/SessionCore/sync/sessionChannelActivity.test.ts
+++ b/src/engines/SessionCore/sync/sessionChannelActivity.test.ts
@@ -1,0 +1,56 @@
+/**
+ * sessionChannelActivity — liveness stamp regression tests.
+ *
+ * Regression target: the planning watchdog force-completed sessions whose
+ * turns streamed only ephemeral events (tool_call_delta never bumps the
+ * EventStore version), because "activity" was defined as store mutations.
+ * These tests pin the channel-activity source the watchdog now consults.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  clearSessionChannelActivity,
+  msSinceSessionChannelActivity,
+  noteSessionChannelActivity,
+} from "./sessionChannelActivity";
+
+afterEach(() => {
+  clearSessionChannelActivity();
+});
+
+describe("sessionChannelActivity", () => {
+  it("returns null for a session with no observed events", () => {
+    expect(msSinceSessionChannelActivity("s-unknown")).toBeNull();
+  });
+
+  it("measures recency from the latest stamp", () => {
+    noteSessionChannelActivity("s1", 1_000);
+    expect(msSinceSessionChannelActivity("s1", 4_500)).toBe(3_500);
+  });
+
+  it("newer stamps overwrite older ones", () => {
+    noteSessionChannelActivity("s1", 1_000);
+    noteSessionChannelActivity("s1", 10_000);
+    expect(msSinceSessionChannelActivity("s1", 11_000)).toBe(1_000);
+  });
+
+  it("tracks sessions independently", () => {
+    noteSessionChannelActivity("s1", 1_000);
+    noteSessionChannelActivity("s2", 5_000);
+    expect(msSinceSessionChannelActivity("s1", 6_000)).toBe(5_000);
+    expect(msSinceSessionChannelActivity("s2", 6_000)).toBe(1_000);
+  });
+
+  it("floors clock skew at zero", () => {
+    noteSessionChannelActivity("s1", 10_000);
+    expect(msSinceSessionChannelActivity("s1", 9_000)).toBe(0);
+  });
+
+  it("clears one session without touching others", () => {
+    noteSessionChannelActivity("s1", 1_000);
+    noteSessionChannelActivity("s2", 1_000);
+    clearSessionChannelActivity("s1");
+    expect(msSinceSessionChannelActivity("s1")).toBeNull();
+    expect(msSinceSessionChannelActivity("s2", 2_000)).toBe(1_000);
+  });
+});

--- a/src/engines/SessionCore/sync/sessionChannelActivity.ts
+++ b/src/engines/SessionCore/sync/sessionChannelActivity.ts
@@ -1,0 +1,49 @@
+/**
+ * Session Channel Activity
+ *
+ * Last-seen timestamp of ANY event arriving on a session's per-session IPC
+ * channel. This is the single liveness source for "is the backend still
+ * feeding us events", independent of whether an event mutates the EventStore.
+ *
+ * Why not the EventStore `version`: several event classes are deliberately
+ * ephemeral and never bump it — `agent:tool_call_delta` buffers in memory
+ * only (see streamHandlers.ts), `agent:stream_retry` writes a side atom, etc.
+ * A turn that spends minutes streaming one large tool call therefore looks
+ * "dead" to any version-based watchdog while the channel is in fact busy.
+ *
+ * Deliberately NOT reactive (plain Map, no jotai atom): deltas arrive at
+ * token frequency and must not trigger React re-renders. Consumers with a
+ * deadline (planning watchdog) check recency when their timer fires and
+ * re-arm for the remainder instead of subscribing.
+ */
+
+const lastChannelActivityBySession = new Map<string, number>();
+
+/** Stamp channel activity for a session. Called once per received event. */
+export function noteSessionChannelActivity(
+  sessionId: string,
+  now: number = Date.now()
+): void {
+  lastChannelActivityBySession.set(sessionId, now);
+}
+
+/**
+ * Milliseconds since the last channel event for the session, or `null` when
+ * no event has been observed since app start (cold session, never subscribed).
+ */
+export function msSinceSessionChannelActivity(
+  sessionId: string,
+  now: number = Date.now()
+): number | null {
+  const last = lastChannelActivityBySession.get(sessionId);
+  return last === undefined ? null : Math.max(0, now - last);
+}
+
+/** Test-only reset so specs don't leak activity across cases. */
+export function clearSessionChannelActivity(sessionId?: string): void {
+  if (sessionId === undefined) {
+    lastChannelActivityBySession.clear();
+    return;
+  }
+  lastChannelActivityBySession.delete(sessionId);
+}

--- a/src/hooks/terminal/useProcessReconciliation.ts
+++ b/src/hooks/terminal/useProcessReconciliation.ts
@@ -27,6 +27,7 @@ import {
   pruneSubagentJobsAtom,
   updateSubagentJobAtom,
 } from "@src/store/session/subagentJobAtom";
+import { activeSessionIdAtom } from "@src/store/session/viewAtom";
 import {
   removeStaleTerminalSessionAtom,
   terminalSessionsAtom,
@@ -88,6 +89,7 @@ export function findStaleShellProcesses(
 export function useProcessReconciliation(): void {
   const shellProcessMap = useAtomValue(shellProcessMapAtom);
   const terminalSessions = useAtomValue(terminalSessionsAtom);
+  const activeSessionId = useAtomValue(activeSessionIdAtom);
   const dispatchUpdateShellProcess = useSetAtom(updateShellProcessAtom);
   const dispatchUpdateSubagentJob = useSetAtom(updateSubagentJobAtom);
   const dispatchPruneSubagentJobs = useSetAtom(pruneSubagentJobsAtom);
@@ -103,6 +105,9 @@ export function useProcessReconciliation(): void {
   const dispatchPruneSubagentJobsRef = useRef(dispatchPruneSubagentJobs);
   const dispatchUpdateTerminalInfoRef = useRef(dispatchUpdateTerminalInfo);
   const dispatchRemoveStaleSessionRef = useRef(dispatchRemoveStaleSession);
+  // Latest reconcile closure, exposed to the session-switch effect below
+  // without re-running the one-shot listener setup.
+  const reconcileRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
     shellProcessMapRef.current = shellProcessMap;
@@ -236,6 +241,8 @@ export function useProcessReconciliation(): void {
       }
     }
 
+    reconcileRef.current = reconcile;
+
     // Run immediately on mount, then only reconcile when the user returns to
     // the app. Live process events remain the fast path while the app is open;
     // this path repairs stale state after reloads, missed events, or time away.
@@ -254,9 +261,21 @@ export function useProcessReconciliation(): void {
 
     return () => {
       cancelled = true;
+      reconcileRef.current = null;
       window.removeEventListener("focus", onFocus);
       document.removeEventListener("visibilitychange", onVisibility);
     };
   }, []); // Reconciliation listeners set up once; live values accessed via refs
   // updated on every render above. Startup, focus, and visibility drive re-runs.
+
+  // Session switches also reconcile. The per-session IPC channel only
+  // subscribes to the VISIBLE session, so a subagent's terminal
+  // `agent:subagent_job_changed` broadcast is lost while the user is on
+  // another session — the ghost "running" row then keeps `hasLiveSubagent`
+  // true forever (stuck planning footer / Stop button). Focus/visibility
+  // can't catch this case because the window never lost focus.
+  useEffect(() => {
+    if (!activeSessionId) return;
+    reconcileRef.current?.();
+  }, [activeSessionId]);
 }

--- a/src/hooks/workStation/editor/resolveFileAgainstRoots.test.ts
+++ b/src/hooks/workStation/editor/resolveFileAgainstRoots.test.ts
@@ -1,0 +1,123 @@
+/**
+ * resolveFileAgainstRoots — regression tests.
+ *
+ * Regression target: chat file references (pills / markdown links) with
+ * relative paths were always joined onto the active WorkStation root, so
+ * a session working in another repo (or a /add-dir root) produced
+ * "Unable to locate the file". The resolver must prefer the session's
+ * own roots and fall back through the multi-root workspace folders.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCandidateRoots,
+  isUnderAnyRoot,
+  resolveFileAgainstRoots,
+} from "./resolveFileAgainstRoots";
+
+function existsIn(...present: string[]) {
+  return (path: string) => Promise.resolve(present.includes(path));
+}
+
+describe("buildCandidateRoots", () => {
+  it("orders session root, additional dirs, active root, then folders", () => {
+    expect(
+      buildCandidateRoots({
+        sessionRepoPath: "/p/cloud-infra",
+        sessionAdditionalDirs: ["/p/orgii"],
+        activeRootPath: "/p/brick-vault",
+        workspaceFolderPaths: ["/p/brick-vault", "/p/other"],
+      })
+    ).toEqual(["/p/cloud-infra", "/p/orgii", "/p/brick-vault", "/p/other"]);
+  });
+
+  it("dedupes overlapping roots and trims trailing slashes", () => {
+    expect(
+      buildCandidateRoots({
+        sessionRepoPath: "/p/repo/",
+        activeRootPath: "/p/repo",
+        workspaceFolderPaths: ["/p/repo/"],
+      })
+    ).toEqual(["/p/repo"]);
+  });
+
+  it("drops empty/null entries and works without session context", () => {
+    expect(
+      buildCandidateRoots({
+        sessionRepoPath: null,
+        activeRootPath: "/p/repo",
+        workspaceFolderPaths: ["", "/p/second"],
+      })
+    ).toEqual(["/p/repo", "/p/second"]);
+  });
+});
+
+describe("resolveFileAgainstRoots", () => {
+  it("resolves against the session root even when the active root differs", async () => {
+    const resolved = await resolveFileAgainstRoots(
+      "scripts/cloud/wipe-all-and-verify.sql",
+      ["/p/cloud-infra", "/p/brick-vault"],
+      existsIn("/p/cloud-infra/scripts/cloud/wipe-all-and-verify.sql")
+    );
+    expect(resolved).toBe(
+      "/p/cloud-infra/scripts/cloud/wipe-all-and-verify.sql"
+    );
+  });
+
+  it("falls through to a later root when earlier roots miss", async () => {
+    const resolved = await resolveFileAgainstRoots(
+      "src/main.rs",
+      ["/p/cloud-infra", "/p/orgii", "/p/brick-vault"],
+      existsIn("/p/brick-vault/src/main.rs")
+    );
+    expect(resolved).toBe("/p/brick-vault/src/main.rs");
+  });
+
+  it("prefers the earlier root when the path exists under several", async () => {
+    const resolved = await resolveFileAgainstRoots(
+      "README.md",
+      ["/p/cloud-infra", "/p/brick-vault"],
+      existsIn("/p/cloud-infra/README.md", "/p/brick-vault/README.md")
+    );
+    expect(resolved).toBe("/p/cloud-infra/README.md");
+  });
+
+  it("returns null when no root contains the file", async () => {
+    const resolved = await resolveFileAgainstRoots(
+      "missing.txt",
+      ["/p/a", "/p/b"],
+      existsIn()
+    );
+    expect(resolved).toBeNull();
+  });
+
+  it("strips a leading ./ before joining", async () => {
+    const resolved = await resolveFileAgainstRoots(
+      "./src/app.ts",
+      ["/p/a"],
+      existsIn("/p/a/src/app.ts")
+    );
+    expect(resolved).toBe("/p/a/src/app.ts");
+  });
+
+  it("treats probe errors as miss and keeps scanning", async () => {
+    const resolved = await resolveFileAgainstRoots(
+      "file.txt",
+      ["/p/broken", "/p/ok"],
+      (path) =>
+        path.startsWith("/p/broken")
+          ? Promise.reject(new Error("EACCES"))
+          : Promise.resolve(path === "/p/ok/file.txt")
+    );
+    expect(resolved).toBe("/p/ok/file.txt");
+  });
+});
+
+describe("isUnderAnyRoot", () => {
+  it("matches exact root and descendants, not sibling prefixes", () => {
+    const roots = ["/p/repo"];
+    expect(isUnderAnyRoot("/p/repo", roots)).toBe(true);
+    expect(isUnderAnyRoot("/p/repo/src/a.ts", roots)).toBe(true);
+    expect(isUnderAnyRoot("/p/repo-other/a.ts", roots)).toBe(false);
+  });
+});

--- a/src/hooks/workStation/editor/resolveFileAgainstRoots.ts
+++ b/src/hooks/workStation/editor/resolveFileAgainstRoots.ts
@@ -1,0 +1,100 @@
+/**
+ * resolveFileAgainstRoots — multi-root resolution for relative file
+ * references coming from chat (file pills, markdown code-block links).
+ *
+ * A relative path in an agent message is relative to whatever root the
+ * AGENT was working in — which in a multi-root workspace is not
+ * necessarily the folder the WorkStation file tree currently shows.
+ * Historically the click handlers joined the path onto the active
+ * WorkStation root only, producing "Unable to locate the file" whenever
+ * the session ran in a different repo (or in one of its /add-dir roots).
+ *
+ * The resolver probes an ordered list of candidate roots and returns the
+ * first that actually contains the file. Ordering encodes intent:
+ *
+ *   1. the session's own workspace root — the message came from this
+ *      session's agent, so its root is the most likely base;
+ *   2. the session's additional directories (agent /add-dir grants,
+ *      IDE-synced folders) in workspace order;
+ *   3. the active WorkStation root — preserves pre-multi-root behavior
+ *      and covers clicks without session context;
+ *   4. the remaining IDE workspace folders.
+ *
+ * Ambiguity (same relative path existing under several roots) is decided
+ * by that same order — session root wins on purpose.
+ */
+
+export interface CandidateRootsInput {
+  /** The active session's persisted workspace root, if any. */
+  sessionRepoPath?: string | null;
+  /** The active session's additional directories (absolute paths). */
+  sessionAdditionalDirs?: readonly string[];
+  /** WorkStation's current root (`activeWorkspaceRootPathAtom`). */
+  activeRootPath?: string | null;
+  /** All IDE workspace folder paths (multi-root). */
+  workspaceFolderPaths?: readonly string[];
+}
+
+function normalizeRoot(path: string | null | undefined): string | null {
+  if (!path) return null;
+  const trimmed = path.replace(/\/+$/, "");
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/** Ordered, deduplicated candidate roots. */
+export function buildCandidateRoots(input: CandidateRootsInput): string[] {
+  const ordered = [
+    input.sessionRepoPath,
+    ...(input.sessionAdditionalDirs ?? []),
+    input.activeRootPath,
+    ...(input.workspaceFolderPaths ?? []),
+  ];
+  const roots: string[] = [];
+  const seen = new Set<string>();
+  for (const candidate of ordered) {
+    const normalized = normalizeRoot(candidate);
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    roots.push(normalized);
+  }
+  return roots;
+}
+
+/** Whether `absolutePath` falls under any of `roots` (path-segment aware). */
+export function isUnderAnyRoot(
+  absolutePath: string,
+  roots: readonly string[]
+): boolean {
+  return roots.some(
+    (root) => absolutePath === root || absolutePath.startsWith(`${root}/`)
+  );
+}
+
+/**
+ * Probe `relativePath` against each root in order; resolve to the first
+ * absolute path that exists, or `null` when no root contains it.
+ *
+ * `pathExists` is injected so the policy stays a pure, unit-testable
+ * function (production passes `exists` from `@tauri-apps/plugin-fs`).
+ * Probe failures on one root (permission errors etc.) are treated as
+ * "not here" and the scan continues.
+ */
+export async function resolveFileAgainstRoots(
+  relativePath: string,
+  roots: readonly string[],
+  pathExists: (absolutePath: string) => Promise<boolean>
+): Promise<string | null> {
+  const cleanRelative = relativePath.replace(/^\.\//, "");
+  if (!cleanRelative) return null;
+  for (const root of roots) {
+    const candidate = `${root}/${cleanRelative}`;
+    let found = false;
+    try {
+      found = await pathExists(candidate);
+    } catch {
+      found = false;
+    }
+    if (found) return candidate;
+  }
+  return null;
+}

--- a/src/hooks/workStation/editor/useCodeEditorEvents.ts
+++ b/src/hooks/workStation/editor/useCodeEditorEvents.ts
@@ -16,9 +16,11 @@
  * - orgii:open-file-in-editor (Tauri) - Cross-window file open (e.g. from SessionDiffWindow)
  */
 import { listen } from "@tauri-apps/api/event";
+import { exists } from "@tauri-apps/plugin-fs";
 import { useSetAtom } from "jotai";
 import { useEffect, useRef } from "react";
 
+import { listSessionWorkspace } from "@src/api/tauri/agent/sessionWorkspace";
 import Message from "@src/components/Message";
 import { ROUTES } from "@src/config/routes";
 import { createEditorSpotlightRequest } from "@src/scaffold/GlobalSpotlight/openSpotlight";
@@ -26,11 +28,14 @@ import { FileOperationsService } from "@src/services/file/FileOperationsService"
 import { PanelService } from "@src/services/panel";
 import { TerminalService } from "@src/services/terminal";
 import { WorkStationViewService } from "@src/services/workStation";
+import { sessionsAtom } from "@src/store/session/sessionAtom/atoms";
+import { workstationActiveSessionIdAtom } from "@src/store/session/viewAtom";
 import { stationModeAtom } from "@src/store/ui/simulatorAtom";
 import {
   spotlightInitialQueryAtom,
   spotlightOpenAtom,
 } from "@src/store/ui/uiAtom";
+import { workspaceFoldersAtom } from "@src/store/ui/workspaceFoldersAtom";
 import {
   type PanelState,
   consumePendingCodeEditorTab,
@@ -45,6 +50,12 @@ import {
 import type { GitFile } from "@src/types/git/types";
 import { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";
 import { isTauriDesktop } from "@src/util/platform/tauri";
+
+import {
+  buildCandidateRoots,
+  isUnderAnyRoot,
+  resolveFileAgainstRoots,
+} from "./resolveFileAgainstRoots";
 
 // ============================================
 // Types
@@ -132,6 +143,65 @@ export function useCodeEditorEvents(options: CodeEditorEventsOptions): void {
     };
 
     // ============================================
+    // Multi-root file resolution for chat references
+    // ============================================
+    // Relative paths in agent messages are relative to the SESSION's
+    // workspace, not necessarily the folder the file tree shows. Build
+    // the ordered candidate roots at click time (session root →
+    // session additional dirs → active WorkStation root → other IDE
+    // folders) and probe for existence. See resolveFileAgainstRoots.ts.
+    const gatherCandidateRoots = async (): Promise<string[]> => {
+      const store = getInstrumentedStore();
+      const activeSessionId = store.get(workstationActiveSessionIdAtom);
+      const session = activeSessionId
+        ? store.get(sessionsAtom).find((s) => s.session_id === activeSessionId)
+        : undefined;
+
+      // Additional directories live in the session runtime; the lookup
+      // fails for historical/idle sessions — that's fine, the session
+      // root + IDE folders still cover the common cases.
+      let additionalDirs: string[] = [];
+      if (activeSessionId) {
+        try {
+          const workspace = await listSessionWorkspace(activeSessionId);
+          additionalDirs = workspace.additionalDirectories.map(
+            (dir) => dir.path
+          );
+        } catch {
+          additionalDirs = [];
+        }
+      }
+
+      return buildCandidateRoots({
+        sessionRepoPath: session?.repoPath,
+        sessionAdditionalDirs: additionalDirs,
+        activeRootPath: optionsRef.current.repoPath,
+        workspaceFolderPaths: store
+          .get(workspaceFoldersAtom)
+          .map((folder) => folder.path),
+      });
+    };
+
+    const resolveChatFilePath = async (
+      rawPath: string
+    ): Promise<{ absolutePath: string; roots: string[] }> => {
+      const roots = await gatherCandidateRoots();
+      if (rawPath.startsWith("/")) {
+        return { absolutePath: rawPath, roots };
+      }
+      const resolved = await resolveFileAgainstRoots(rawPath, roots, exists);
+      // No root contains the file: fall back to the legacy join so the
+      // editor surfaces its normal "Unable to locate the file" view
+      // instead of silently doing nothing.
+      return {
+        absolutePath:
+          resolved ??
+          `${optionsRef.current.repoPath}/${rawPath.replace(/^\.\//, "")}`,
+        roots,
+      };
+    };
+
+    // ============================================
     // Keyboard Shortcuts
     // ============================================
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -187,27 +257,26 @@ export function useCodeEditorEvents(options: CodeEditorEventsOptions): void {
 
       if (isFolder) return;
 
-      let absolutePath: string;
-      if (filePath.startsWith("/")) {
-        absolutePath = filePath;
-      } else {
-        absolutePath = `${opts.repoPath}/${filePath}`;
-      }
+      void (async () => {
+        const { absolutePath, roots } = await resolveChatFilePath(filePath);
 
-      if (!absolutePath.startsWith(opts.repoPath)) {
-        const lineParam = lineStart ? `:${lineStart}` : "";
-        window.location.href = `vscode://file${absolutePath}${lineParam}`;
-        return;
-      }
+        // Absolute paths outside every known root belong to another
+        // checkout entirely — hand off to VS Code like before.
+        if (!isUnderAnyRoot(absolutePath, roots)) {
+          const lineParam = lineStart ? `:${lineStart}` : "";
+          window.location.href = `vscode://file${absolutePath}${lineParam}`;
+          return;
+        }
 
-      focusCodeEditor();
+        focusCodeEditor();
 
-      if (opts.selectedFile === absolutePath) return;
+        if (optionsRef.current.selectedFile === absolutePath) return;
 
-      opts.selectFile(absolutePath);
+        optionsRef.current.selectFile(absolutePath);
 
-      const tab = createFileTab(absolutePath);
-      opts.setPrimaryPanel((prev) => openTab(prev, tab));
+        const tab = createFileTab(absolutePath);
+        optionsRef.current.setPrimaryPanel((prev) => openTab(prev, tab));
+      })();
     };
 
     // ============================================
@@ -284,26 +353,27 @@ export function useCodeEditorEvents(options: CodeEditorEventsOptions): void {
     ) => {
       if (!path) return;
 
-      let absolutePath = path;
-      if (!path.startsWith("/")) {
-        absolutePath = `${opts.repoPath}/${path.replace(/^\.\//, "")}`;
-      }
+      void (async () => {
+        const absolutePath = path.startsWith("/")
+          ? path
+          : (await resolveChatFilePath(path)).absolutePath;
 
-      focusCodeEditor();
+        focusCodeEditor();
 
-      if (isDirectory || path.endsWith("/")) {
-        PanelService.showPrimarySidebar("files");
-        void FileOperationsService.reveal(absolutePath, {
-          expandTargetDirectory: true,
-        });
-        const tab = createDirectoryTab(absolutePath.replace(/\/+$/, ""));
-        opts.setPrimaryPanel((prev) => openTab(prev, tab));
-        return;
-      }
+        if (isDirectory || path.endsWith("/")) {
+          PanelService.showPrimarySidebar("files");
+          void FileOperationsService.reveal(absolutePath, {
+            expandTargetDirectory: true,
+          });
+          const tab = createDirectoryTab(absolutePath.replace(/\/+$/, ""));
+          optionsRef.current.setPrimaryPanel((prev) => openTab(prev, tab));
+          return;
+        }
 
-      const tab = createFileTab(absolutePath, line);
-      opts.setPrimaryPanel((prev) => openTab(prev, tab));
-      opts.selectFile(absolutePath);
+        const tab = createFileTab(absolutePath, line);
+        optionsRef.current.setPrimaryPanel((prev) => openTab(prev, tab));
+        optionsRef.current.selectFile(absolutePath);
+      })();
     };
 
     const handleOpenFileInEditor = (event: Event) => {


### PR DESCRIPTION
## Summary

Four related fixes for "session looks stopped but is actually running" and its fallout, all root-caused from live session `sdeagent-2ef2ea9d` / `sdeagent-a1c86152` reproductions:

- **Planning watchdog false-completes during long tool-call streams** — the 60s watchdog defined "activity" as EventStore mutations, but `agent:tool_call_delta` is deliberately ephemeral (never bumps store version). A model spending minutes streaming one large `edit_file` call tripped the watchdog and force-wrote `completed` while the backend kept running. New `sessionChannelActivity` module stamps every per-session IPC channel event; the watchdog now probes channel recency and re-arms for the remaining window instead of tripping. Also added a `stream_retry` exemption (rate-limit backoffs can exceed 60s with zero events by design).
- **Duplicate assistant bubbles after stream-error retry** — a response like `[text, huge tool call…interrupted]` had already flushed the text as an authoritative segment; the retry regenerates the whole response, producing a near-identical second bubble. The event handler now tracks flushed segments as retractable until the response completes; `on_stream_retry` retracts them from the in-memory EventStore and the SQLite write-through via a new `remove_events_by_ids` bridge slot.
- **Ghost "running" subagent rows pin the planning footer forever** — a background worker's terminal `agent:subagent_job_changed` broadcast is lost while the user is viewing another session (per-session channel subscription), leaving `hasLiveSubagent` stuck true. `useProcessReconciliation` now also reconciles on session switch, not just mount/focus.
- **Chat file references resolve against the wrong root** — relative paths in agent messages were always joined onto the active WorkStation root, so sessions working in another repo (or a `/add-dir` root) hit "Unable to locate the file" in multi-root workspaces. New `resolveFileAgainstRoots` probes ordered candidate roots: session workspace root → session additional directories → active WorkStation root → remaining IDE workspace folders. Deliberately does NOT auto-switch the My Station tree (preserves a53071f7's "no retarget on session jump" design).

## Test plan

- `vitest`: 21/21 planning watchdog + channel activity tests, 10/10 file-resolver tests (ordering, dedup, ambiguity-prefers-session-root, probe-error tolerance)
- `cargo test`: 17/17 — retractable-segment bookkeeping (drain-once, committed-segments-survive-retry) + EventStore `remove_by_ids` (delta tracking, version stability)
- `cargo check -p agent_core -p org2` clean; `eslint` clean; `tsc` no new errors on touched files
- Live repro validated the bugs pre-fix: a 5-minute pure tool-call stream (session `a1c86152`, 19:09–19:14) showed UI idle while backend logged iterations; the same stream's connection drop reproduced the duplicate "Writing 300 lines…" bubble
- Not yet live-verified post-fix (Rust changes need a dev restart); repro prompt: ask an agent to write 300+ unique lines via a single `edit_file` and watch the spinner stay alive past 60s

## Submit checklist

- [x] The PR is focused and has a scoped Conventional Commits title, such as `feat(scope): summary` or `fix(scope): summary`.
- [x] I ran the relevant checks, or explained why they were not run.
- [x] No secrets, private config, generated output, or unrelated formatting changes are included.
- [x] Docs, screenshots, and locale updates are included when the change needs them (none needed — no user-facing copy or API changes).