### PR TITLE
fix(todo): preserve titles on status updates

### DIFF
--- a/src-tauri/crates/agent-core/src/core/tools/impls/coding/manage_todo.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/coding/manage_todo.rs
@@ -136,6 +136,26 @@ fn sanitize_todo_text(value: &str) -> String {
     }
 }
 
+fn sanitize_required_todo_content(value: &str, idx: usize) -> Result<String, ToolError> {
+    let content = sanitize_todo_text(value);
+    if content.is_empty() {
+        return Err(ToolError::InvalidParams(format!(
+            "Todo {} has empty 'content'",
+            idx
+        )));
+    }
+    Ok(content)
+}
+
+fn sanitize_optional_todo_content(value: &str) -> Option<String> {
+    let content = sanitize_todo_text(value);
+    if content.is_empty() {
+        None
+    } else {
+        Some(content)
+    }
+}
+
 #[async_trait]
 impl Tool for TodoTool {
     fn name(&self) -> &str {
@@ -178,6 +198,7 @@ Skip this tool when:\n\
 ## Task Management Rules\n\
 - Exactly ONE task must be in_progress at a time (not zero, not two)\n\
 - Mark tasks completed IMMEDIATELY after finishing — don't batch completions\n\
+- When updating only status or priority, omit `content`; never pass an empty title\n\
 - ONLY mark completed when you have FULLY accomplished the task. If tests fail, implementation is partial, or errors remain, keep it in_progress and create a follow-up task describing the blocker.\n\
 - Remove tasks that are no longer relevant (status=cancelled or a full rewrite)\n\
 - Use `blockedBy` when tasks have clear sequential dependencies so you always pick up the next unblocked task\n\n\
@@ -210,6 +231,7 @@ Skip this tool when:\n\
                         "properties": {
                             "content": {
                                 "type": "string",
+                                "minLength": 1,
                                 "description": "Imperative-form title (e.g. \"Run tests\")"
                             },
                             "activeForm": {
@@ -239,7 +261,8 @@ Skip this tool when:\n\
                 },
                 "content": {
                     "type": "string",
-                    "description": "Optional for update. New imperative-form title."
+                    "minLength": 1,
+                    "description": "Optional for update. New imperative-form title. Omit to keep the existing title; never pass an empty string."
                 },
                 "activeForm": {
                     "type": "string",
@@ -334,10 +357,14 @@ impl TodoTool {
 
         let mut records: Vec<TodoRecord> = Vec::with_capacity(todos_raw.len());
         for (idx, todo) in todos_raw.iter().enumerate() {
-            let content =
-                sanitize_todo_text(todo.get("content").and_then(|v| v.as_str()).ok_or_else(
-                    || ToolError::InvalidParams(format!("Todo {} missing 'content'", idx)),
-                )?);
+            let content = sanitize_required_todo_content(
+                todo.get("content")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| {
+                        ToolError::InvalidParams(format!("Todo {} missing 'content'", idx))
+                    })?,
+                idx,
+            )?;
             let active_form = todo
                 .get("activeForm")
                 .and_then(|v| v.as_str())
@@ -396,7 +423,7 @@ impl TodoTool {
             content: params
                 .get("content")
                 .and_then(|v| v.as_str())
-                .map(sanitize_todo_text),
+                .and_then(sanitize_optional_todo_content),
             // Empty string clears `activeForm` (stored as None); a missing
             // key leaves it untouched. The outer Option distinguishes the
             // two, the inner Option is the stored value.
@@ -604,7 +631,10 @@ fn broadcast_todos(session_id: &str, records: &[TodoRecord]) {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_embedded_todo_array, sanitize_todo_text};
+    use super::{
+        parse_embedded_todo_array, sanitize_optional_todo_content, sanitize_required_todo_content,
+        sanitize_todo_text,
+    };
 
     #[test]
     fn sanitize_todo_text_replaces_standalone_internal_plan_artifacts() {
@@ -627,6 +657,39 @@ mod tests {
         assert_eq!(
             sanitize_todo_text("Implement tasks from `.orgii/plans/foo.plan.md`"),
             "Implement tasks from `approved plan`"
+        );
+    }
+
+    #[test]
+    fn sanitize_required_todo_content_rejects_empty_after_trim() {
+        let err = sanitize_required_todo_content("   ", 3).unwrap_err();
+        assert!(
+            err.to_string().contains("Todo 3 has empty 'content'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn sanitize_optional_todo_content_drops_empty_update_patch() {
+        assert_eq!(sanitize_optional_todo_content("   "), None);
+        assert_eq!(
+            sanitize_optional_todo_content(" Update docs "),
+            Some("Update docs".to_string())
+        );
+    }
+
+    #[test]
+    fn parameters_require_non_empty_todo_content_when_present() {
+        let tool = super::TodoTool::new(std::sync::Arc::new(super::TodoSessionContext::new()));
+        let parameters = crate::tools::traits::Tool::parameters(&tool);
+
+        assert_eq!(
+            parameters.pointer("/properties/todos/items/properties/content/minLength"),
+            Some(&serde_json::json!(1))
+        );
+        assert_eq!(
+            parameters.pointer("/properties/content/minLength"),
+            Some(&serde_json::json!(1))
         );
     }
 

--- a/src/engines/ChatPanel/rendering/adapters/TodoAdapter.test.ts
+++ b/src/engines/ChatPanel/rendering/adapters/TodoAdapter.test.ts
@@ -1,0 +1,72 @@
+import { Provider, createStore } from "jotai";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import type { UniversalEventProps } from "@src/engines/SessionCore/rendering/types/universalProps";
+import { sessionTodoMapAtom } from "@src/store/ui/todoAtom";
+
+import { TodoAdapter } from "./TodoAdapter";
+
+vi.mock("../../blocks/TodoBlock", async () => {
+  const React = await import("react");
+  return {
+    default: ({ todos }: { todos: Array<{ content: string }> }) =>
+      React.createElement(
+        "div",
+        { "data-testid": "todo-labels" },
+        todos.map((todo) => todo.content).join("|")
+      ),
+  };
+});
+
+vi.mock("@src/engines/SessionCore/rendering/registry", () => ({
+  statusToLifecycle: () => "success",
+  useLifecycleLabels: () => ({ success: "Updated to-do" }),
+}));
+
+describe("TodoAdapter", () => {
+  it("backfills an empty event title from the reconstructed session todo state", () => {
+    const store = createStore();
+    store.set(
+      sessionTodoMapAtom,
+      new Map([
+        [
+          "session-1",
+          {
+            todos: [
+              {
+                id: "0",
+                content: "Review repository structure",
+                status: "completed" as const,
+              },
+            ],
+            isUpdating: false,
+            lastUpdatedAt: null,
+            isVisible: true,
+          },
+        ],
+      ])
+    );
+
+    const props: UniversalEventProps = {
+      eventId: "todo-update",
+      eventType: "manage_todo",
+      functionName: "manage_todo",
+      sessionId: "session-1",
+      args: { action: "update", index: 0, status: "completed" },
+      result: {
+        todos: [{ id: "0", content: "", status: "completed" }],
+      },
+      status: "success",
+      variant: "chat",
+      context: "chat",
+    };
+
+    const markup = renderToStaticMarkup(
+      createElement(Provider, { store }, createElement(TodoAdapter, props))
+    );
+
+    expect(markup).toContain("Review repository structure");
+  });
+});

--- a/src/engines/ChatPanel/rendering/adapters/TodoAdapter.tsx
+++ b/src/engines/ChatPanel/rendering/adapters/TodoAdapter.tsx
@@ -3,6 +3,7 @@
  * `null` when the extracted todo list is empty (the block would show
  * nothing useful) so the chat timeline stays tight.
  */
+import { useAtomValue } from "jotai";
 import React from "react";
 
 import { extractTodoData } from "@src/engines/SessionCore/rendering/props/propsDataExtractors";
@@ -11,12 +12,17 @@ import {
   useLifecycleLabels,
 } from "@src/engines/SessionCore/rendering/registry";
 import type { UniversalEventProps } from "@src/engines/SessionCore/rendering/types/universalProps";
+import { getTodosForSession, sessionTodoMapAtom } from "@src/store/ui/todoAtom";
+import { preserveTodoContent } from "@src/store/ui/todoMerge";
 
 import TodoBlock from "../../blocks/TodoBlock";
 
 export const TodoAdapter: React.FC<UniversalEventProps> = (props) => {
   const action = (props.args?.action as string) || undefined;
-  const { todos, wasMerge } = extractTodoData(props);
+  const { todos: eventTodos, wasMerge } = extractTodoData(props);
+  const todoMap = useAtomValue(sessionTodoMapAtom);
+  const sessionTodos = getTodosForSession(todoMap, props.sessionId);
+  const todos = preserveTodoContent(sessionTodos, eventTodos);
   const labels = useLifecycleLabels(props.eventType, action);
   const state = statusToLifecycle(props.status);
 

--- a/src/engines/SessionCore/hooks/session/__tests__/useTodoSync.helpers.test.ts
+++ b/src/engines/SessionCore/hooks/session/__tests__/useTodoSync.helpers.test.ts
@@ -24,6 +24,7 @@ import {
   sanitizeTodoDisplayText,
 } from "../todoNormalization";
 import {
+  extractTodosFromManageTodoSequence,
   findLatestManageTodoEvent,
   isManageTodoEvent,
   normalizePersistedTodo,
@@ -304,6 +305,77 @@ describe("findLatestManageTodoEvent", () => {
     expect(findLatestManageTodoEvent(events, "sdeagent-test", 0)?.id).toBe(
       "todo-old"
     );
+  });
+});
+
+describe("extractTodosFromManageTodoSequence", () => {
+  function nativeTodoContent(
+    header: string,
+    todos: Array<Record<string, unknown>>
+  ): string {
+    return [
+      header,
+      JSON.stringify(todos, null, 2),
+      "",
+      "Ensure that you continue to use the todo list to track your progress.",
+    ].join("\n");
+  }
+
+  it("backfills empty titles in later update snapshots from earlier todo events", () => {
+    const events = [
+      makeManageTodoEvent({
+        id: "todo-write",
+        result: {
+          content: nativeTodoContent("3 todos (3 remaining)", [
+            {
+              index: 0,
+              content: "Review remaining version metadata changes",
+              status: "pending",
+            },
+            {
+              index: 1,
+              content: "Verify synchronized release version",
+              status: "pending",
+            },
+            {
+              index: 2,
+              content: "Commit synchronized release metadata",
+              status: "pending",
+            },
+          ]),
+        },
+      }),
+      makeManageTodoEvent({
+        id: "todo-update",
+        result: {
+          content: nativeTodoContent(
+            "Updated todo #2 — 3 todos (1 remaining)",
+            [
+              { index: 0, content: "", status: "completed" },
+              { index: 1, content: "   ", status: "completed" },
+              {
+                index: 2,
+                content: "Verify commits and clean working tree",
+                status: "in_progress",
+              },
+            ]
+          ),
+        },
+      }),
+    ];
+
+    const todos = extractTodosFromManageTodoSequence(events, "sdeagent-test");
+
+    expect(todos.map((todo) => todo.content)).toEqual([
+      "Review remaining version metadata changes",
+      "Verify synchronized release version",
+      "Verify commits and clean working tree",
+    ]);
+    expect(todos.map((todo) => todo.status)).toEqual([
+      "completed",
+      "completed",
+      "in_progress",
+    ]);
   });
 });
 

--- a/src/engines/SessionCore/hooks/session/useTodoSync.ts
+++ b/src/engines/SessionCore/hooks/session/useTodoSync.ts
@@ -34,6 +34,7 @@ import {
   sessionTodoMapAtom,
   updateTodosForSessionAtom,
 } from "@src/store/ui/todoAtom";
+import { preserveTodoContent } from "@src/store/ui/todoMerge";
 
 import {
   type RawPersistedTodoItem,
@@ -70,6 +71,11 @@ export type { RawPersistedTodoItem };
 export const normalizePersistedTodo = normalizePersistedTodoCore;
 export const normalizePersistedTodoList = normalizePersistedTodoListCore;
 
+function eventMatchesSession(event: SessionEvent, sessionId: string): boolean {
+  const eventSid = event.sessionId;
+  return !eventSid || eventSid === sessionId;
+}
+
 export function findLatestManageTodoEvent(
   events: readonly SessionEvent[],
   sessionId: string,
@@ -79,8 +85,7 @@ export function findLatestManageTodoEvent(
   for (let index = limit; index >= 0; index--) {
     const event = events[index];
     if (!isManageTodoEvent(event)) continue;
-    const eventSid = event.sessionId;
-    if (eventSid && eventSid !== sessionId) continue;
+    if (!eventMatchesSession(event, sessionId)) continue;
     return event;
   }
   return null;
@@ -113,7 +118,7 @@ function extractTodosFromEvent(event: SessionEvent): TodoItem[] {
     context: "chat" as const,
   });
 
-  return todoData.todos.map((todo) => {
+  return todoData.todos.map((todo, idx) => {
     const raw = todo as unknown as Record<string, unknown>;
     const activeForm =
       typeof raw.activeForm === "string" && raw.activeForm.length > 0
@@ -123,13 +128,34 @@ function extractTodosFromEvent(event: SessionEvent): TodoItem[] {
       ? (raw.blockedBy as number[])
       : todo.blockedBy;
     return {
-      id: todo.id || crypto.randomUUID(),
+      id: todo.id || `event-todo-${idx}`,
       content: sanitizeTodoDisplayText(todo.content || ""),
       activeForm: activeForm ? sanitizeTodoDisplayText(activeForm) : undefined,
       status: (todo.status || "pending") as TodoItem["status"],
       ...(blockedBy && blockedBy.length > 0 ? { blockedBy } : {}),
     };
   });
+}
+
+export function extractTodosFromManageTodoSequence(
+  events: readonly SessionEvent[],
+  sessionId: string,
+  maxIndex = events.length - 1
+): TodoItem[] {
+  const limit = Math.min(maxIndex, events.length - 1);
+  let todos: TodoItem[] = [];
+
+  for (let index = 0; index <= limit; index++) {
+    const event = events[index];
+    if (!isManageTodoEvent(event)) continue;
+    if (!eventMatchesSession(event, sessionId)) continue;
+
+    const nextTodos = extractTodosFromEvent(event);
+    if (nextTodos.length === 0) continue;
+    todos = preserveTodoContent(todos, nextTodos);
+  }
+
+  return todos;
 }
 
 // ============================================
@@ -253,7 +279,11 @@ export function useTodoSync(sessionId?: string): void {
 
     if (!latestTodoEvent) return;
 
-    const todos = extractTodosFromEvent(latestTodoEvent);
+    const todos = extractTodosFromManageTodoSequence(
+      replayEvents,
+      sessionId,
+      maxIndex
+    );
     if (todos.length === 0) return;
 
     const snapshot = serializeTodoSnapshot(todos);

--- a/src/modules/WorkStation/Chat/Communication/TodoKanban.test.ts
+++ b/src/modules/WorkStation/Chat/Communication/TodoKanban.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+
+import { buildTimeline } from "./TodoKanban";
+import type { MessageEntry } from "./types";
+
+function todoMessage(
+  id: string,
+  order: number,
+  todos: Array<{ id: string; content: string; status: string }>
+): MessageEntry {
+  return {
+    eventId: id,
+    event: {
+      id,
+      extracted: { kind: "todo", todos, wasMerge: false },
+    } as SessionEvent,
+    type: "todo",
+    content: "",
+    sender: "agent",
+    timestamp: `2026-07-10T10:00:0${order}Z`,
+    order,
+    isCurrent: false,
+  };
+}
+
+describe("buildTimeline", () => {
+  it("preserves a prior title when a replacement snapshot carries empty content", () => {
+    const { todos } = buildTimeline([
+      todoMessage("todo-write", 0, [
+        { id: "0", content: "Review repository structure", status: "pending" },
+      ]),
+      todoMessage("todo-update", 1, [
+        { id: "0", content: "", status: "completed" },
+      ]),
+    ]);
+
+    expect(todos).toEqual([
+      {
+        id: "0",
+        content: "Review repository structure",
+        status: "completed",
+      },
+    ]);
+  });
+});

--- a/src/modules/WorkStation/Chat/Communication/TodoKanban.tsx
+++ b/src/modules/WorkStation/Chat/Communication/TodoKanban.tsx
@@ -33,6 +33,7 @@ import KanbanBoard, {
 } from "@src/features/KanbanBoard";
 import { createLogger } from "@src/hooks/logger";
 import { normalizeActivity } from "@src/lib/activityData";
+import { preserveTodoContent } from "@src/store/ui/todoMerge";
 import { formatSmartDateTime } from "@src/util/data/formatters/date";
 import { prettifyMemberName } from "@src/util/data/formatters/memberName";
 
@@ -259,7 +260,7 @@ function isSnapshotMessage(message: MessageEntry): boolean {
   return extracted?.kind !== "orgTask" || extracted.action === "list";
 }
 
-function buildTimeline(messages: MessageEntry[]): {
+export function buildTimeline(messages: MessageEntry[]): {
   todos: TodoLike[];
   timeline: Map<string, TodoTimelineEntry>;
 } {
@@ -272,12 +273,18 @@ function buildTimeline(messages: MessageEntry[]): {
   for (const message of messages) {
     const snapshot = todosFromMessage(message);
     const ts = message.timestamp;
+    const previousTodos = Array.from(todoMap.values());
+    const reconciledSnapshot = preserveTodoContent(previousTodos, snapshot);
     if (isSnapshotMessage(message)) {
       todoMap.clear();
     }
 
-    for (let todoIndex = 0; todoIndex < snapshot.length; todoIndex++) {
-      const todo = snapshot[todoIndex];
+    for (
+      let todoIndex = 0;
+      todoIndex < reconciledSnapshot.length;
+      todoIndex++
+    ) {
+      const todo = reconciledSnapshot[todoIndex];
       // Fall back to position when the source omitted a stable id. This is
       // best-effort: positional ids only match across events if the list
       // wasn't reordered, but it's better than collapsing every id-less

--- a/src/store/ui/__tests__/todoMerge.test.ts
+++ b/src/store/ui/__tests__/todoMerge.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { preserveTodoContent } from "../todoMerge";
+
+describe("preserveTodoContent", () => {
+  it("keeps incoming non-empty content unchanged", () => {
+    const result = preserveTodoContent(
+      [{ id: "0", content: "Old title" }],
+      [{ id: "0", content: "New title", status: "completed" }]
+    );
+
+    expect(result[0]).toEqual({
+      id: "0",
+      content: "New title",
+      status: "completed",
+    });
+  });
+
+  it("fills an empty incoming title from the previous todo with the same id", () => {
+    const result = preserveTodoContent(
+      [{ id: "0", content: "Review remaining metadata" }],
+      [{ id: "0", content: "", status: "completed" }]
+    );
+
+    expect(result[0]).toEqual({
+      id: "0",
+      content: "Review remaining metadata",
+      status: "completed",
+    });
+  });
+
+  it("falls back to position when ids changed but order stayed stable", () => {
+    const result = preserveTodoContent(
+      [{ id: "persisted-0", content: "Verify synchronized release version" }],
+      [{ id: "0", content: "   ", status: "completed" }]
+    );
+
+    expect(result[0].content).toBe("Verify synchronized release version");
+  });
+
+  it("leaves empty content alone when there is no previous title", () => {
+    const result = preserveTodoContent(
+      [],
+      [{ id: "0", content: "", status: "completed" }]
+    );
+
+    expect(result[0].content).toBe("");
+  });
+});

--- a/src/store/ui/todoAtom.ts
+++ b/src/store/ui/todoAtom.ts
@@ -20,6 +20,8 @@ import { atom } from "jotai";
 
 import { workstationActiveSessionIdAtom } from "@src/store/session/viewAtom";
 
+import { preserveTodoContent } from "./todoMerge";
+
 // ============================================
 // Types
 // ============================================
@@ -149,16 +151,17 @@ export const updateTodosForSessionAtom = atom(
 
     const current = get(sessionTodoMapAtom);
     const prev = current.get(sessionId) ?? EMPTY_TODO_STATE;
+    const reconciledNewTodos = preserveTodoContent(prev.todos, newTodos);
 
     let nextTodos: TodoItem[];
     if (merge && prev.todos.length > 0) {
       const todoMap = new Map(prev.todos.map((todo) => [todo.id, todo]));
-      newTodos.forEach((todo) => {
+      reconciledNewTodos.forEach((todo) => {
         todoMap.set(todo.id, todo);
       });
       nextTodos = Array.from(todoMap.values());
     } else {
-      nextTodos = newTodos;
+      nextTodos = reconciledNewTodos;
     }
 
     const nextState: TodoState = {

--- a/src/store/ui/todoMerge.ts
+++ b/src/store/ui/todoMerge.ts
@@ -1,0 +1,43 @@
+export interface TodoContentLike {
+  id?: string;
+  content?: string;
+}
+
+function meaningfulContent(value: string | null | undefined): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * Preserve the last known non-empty title for a todo row when a later
+ * incremental snapshot carries the same row with `content: ""`.
+ */
+export function preserveTodoContent<T extends TodoContentLike>(
+  previousTodos: readonly TodoContentLike[],
+  incomingTodos: readonly T[]
+): T[] {
+  if (previousTodos.length === 0 || incomingTodos.length === 0) {
+    return [...incomingTodos];
+  }
+
+  const previousById = new Map<string, string>();
+  previousTodos.forEach((todo) => {
+    const content = meaningfulContent(todo.content);
+    if (todo.id && content) {
+      previousById.set(todo.id, content);
+    }
+  });
+
+  return incomingTodos.map((todo, index) => {
+    if (meaningfulContent(todo.content)) return todo;
+
+    const previousContent =
+      (todo.id ? previousById.get(todo.id) : undefined) ??
+      meaningfulContent(previousTodos[index]?.content);
+    if (!previousContent) return todo;
+
+    return {
+      ...todo,
+      content: previousContent,
+    };
+  });
+}


### PR DESCRIPTION
## Summary

- prevent `manage_todo` writes from accepting empty titles and treat blank update content as an omitted patch
- declare non-empty todo content in the tool schema so models avoid emitting `content: ""`
- recover historical blank titles from earlier snapshots across session sync, inline chat cards, and the Communication kanban
- use stable positional fallback IDs so replay snapshots can be reconciled deterministically

## Root cause

A status update could include `content: ""`. The backend treated that optional field as a literal title replacement, persisted the empty string, and returned it in later snapshots. Renderers then displayed each snapshot independently, so completed rows appeared with only a checkbox.

Fixes #335.

## Impact

New status-only updates preserve the existing title, and previously recorded blank snapshots can recover their last known non-empty title while replaying session history.

## Audit

Reviewed the cross-layer flow from tool schema and persistence through event extraction, session state, inline chat rendering, and Communication kanban rendering. The audit caught and fixed two gaps before publishing: inline TodoBlock history recovery and replacement-snapshot ordering in the kanban.

## Validation

- `./node_modules/.bin/vitest run ...` — 4 files, 36 tests passed
- `./node_modules/.bin/tsc --noEmit --pretty false`
- ESLint on all changed TypeScript/TSX files
- `cargo test -p agent_core manage_todo::tests --lib` — 8 tests passed
- `cargo check -p agent_core --lib`
- commit hook: scoped TypeScript, ESLint, Prettier, circular stats, and `agent_core` Clippy passed
