### PR TITLE
fix(chat): unify chat tab session activation

### DIFF
--- a/src/engines/ChatPanel/hooks/useChatPanelTabsController.ts
+++ b/src/engines/ChatPanel/hooks/useChatPanelTabsController.ts
@@ -40,7 +40,7 @@ export function useChatPanelTabsController({
 
   useEffect(() => {
     if (!activeTabId || activeTabType !== "session") return;
-    if (activeTabSessionId !== currentSessionId) {
+    if (!activeTabSessionId && currentSessionId) {
       setTabSessionId({
         tabId: activeTabId,
         sessionId: currentSessionId,

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
@@ -619,14 +619,27 @@ export const WorkstationSidebarConnector: React.FC = () => {
   });
   const handleOpenInNewTab = useCallback(
     (sessionId: string) => {
+      activateMyStationRouteForProjectTabContent();
+      navigateChatPanel({ kind: CHAT_PANEL_SURFACE_KIND.SESSION });
       if (isChatPanelTuiSessionId(sessionId)) {
         const tabId = getChatPanelTabIdFromTuiSessionId(sessionId);
         if (tabId) activateChatPanelTab(tabId);
         return;
       }
-      openSessionInNewChatTab(sessionId);
+      const session = sessionMap.get(sessionId);
+      openSessionInNewChatTab({
+        sessionId,
+        sessionName: session?.name,
+        repoPath: session?.repoPath,
+      });
     },
-    [activateChatPanelTab, openSessionInNewChatTab]
+    [
+      activateChatPanelTab,
+      activateMyStationRouteForProjectTabContent,
+      navigateChatPanel,
+      openSessionInNewChatTab,
+      sessionMap,
+    ]
   );
 
   const handleToggleSubagentExpansion = useCallback((sessionId: string) => {

--- a/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
+++ b/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Session } from "@src/store/session/sessionAtom/types";
+
+function makeSession(
+  sessionId: string,
+  overrides: Partial<Session> = {}
+): Session {
+  const now = "2026-01-01T00:00:00.000Z";
+  return {
+    session_id: sessionId,
+    status: "completed",
+    created_at: now,
+    updated_at: now,
+    ...overrides,
+  };
+}
+
+async function loadChatPanelTabAtoms() {
+  const { createInstrumentedStore } =
+    await import("@src/util/core/state/instrumentedStore");
+  const store = createInstrumentedStore();
+  const { activeSessionIdAtom, sessionViewAtom } =
+    await import("@src/store/session/viewAtom");
+  const { sessionsAtom } = await import("@src/store/session/sessionAtom");
+  const {
+    activateChatPanelTabAtom,
+    chatPanelTabsAtom,
+    closeChatPanelTabAtom,
+    openSessionInNewChatTabAtom,
+    prevChatPanelTabAtom,
+  } = await import("../chatPanelTabsAtom");
+
+  return {
+    activateChatPanelTabAtom,
+    activeSessionIdAtom,
+    chatPanelTabsAtom,
+    closeChatPanelTabAtom,
+    openSessionInNewChatTabAtom,
+    prevChatPanelTabAtom,
+    sessionViewAtom,
+    sessionsAtom,
+    store,
+  };
+}
+
+describe("openSessionInNewChatTabAtom", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    localStorage.removeItem("orgii:chatPanelTabs");
+    localStorage.removeItem("orgii-v2-session-view");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("opens a linked tab and switches the WorkStation session", async () => {
+    const {
+      activeSessionIdAtom,
+      chatPanelTabsAtom,
+      openSessionInNewChatTabAtom,
+      sessionViewAtom,
+      store,
+    } = await loadChatPanelTabAtoms();
+
+    const tabId = store.set(openSessionInNewChatTabAtom, {
+      sessionId: "session-target",
+      sessionName: "Target session",
+      repoPath: "/repos/orgii",
+    });
+
+    const tabsState = store.get(chatPanelTabsAtom);
+    const sessionView = store.get(sessionViewAtom);
+
+    expect(tabsState.activeTabId).toBe(tabId);
+    expect(tabsState.tabs.at(-1)).toMatchObject({
+      id: tabId,
+      type: "session",
+      sessionId: "session-target",
+    });
+    expect(sessionView).toMatchObject({
+      activeSessionId: "session-target",
+      sessionName: "Target session",
+      repoPath: "/repos/orgii",
+    });
+    expect(store.get(activeSessionIdAtom)).toBe("session-target");
+  });
+
+  it("activates a linked session tab through the shared activation action", async () => {
+    const {
+      activateChatPanelTabAtom,
+      activeSessionIdAtom,
+      openSessionInNewChatTabAtom,
+      sessionViewAtom,
+      sessionsAtom,
+      store,
+    } = await loadChatPanelTabAtoms();
+
+    store.set(sessionsAtom, [
+      makeSession("session-a", {
+        name: "Session A",
+        repoPath: "/repos/a",
+      }),
+      makeSession("session-b", {
+        name: "Session B",
+        repoPath: "/repos/b",
+      }),
+    ]);
+    const firstTabId = store.set(openSessionInNewChatTabAtom, "session-a");
+    store.set(openSessionInNewChatTabAtom, "session-b");
+
+    store.set(activateChatPanelTabAtom, firstTabId);
+
+    expect(store.get(activeSessionIdAtom)).toBe("session-a");
+    expect(store.get(sessionViewAtom)).toMatchObject({
+      activeSessionId: "session-a",
+      sessionName: "Session A",
+      repoPath: "/repos/a",
+    });
+  });
+
+  it("uses the shared activation path for previous-tab navigation", async () => {
+    const {
+      activeSessionIdAtom,
+      openSessionInNewChatTabAtom,
+      prevChatPanelTabAtom,
+      sessionsAtom,
+      store,
+    } = await loadChatPanelTabAtoms();
+
+    store.set(sessionsAtom, [
+      makeSession("session-a", { name: "Session A", repoPath: "/repos/a" }),
+      makeSession("session-b", { name: "Session B", repoPath: "/repos/b" }),
+    ]);
+    store.set(openSessionInNewChatTabAtom, "session-a");
+    store.set(openSessionInNewChatTabAtom, "session-b");
+
+    store.set(prevChatPanelTabAtom);
+
+    expect(store.get(activeSessionIdAtom)).toBe("session-a");
+  });
+
+  it("uses the shared activation path after closing the active tab", async () => {
+    const {
+      activeSessionIdAtom,
+      closeChatPanelTabAtom,
+      openSessionInNewChatTabAtom,
+      sessionsAtom,
+      store,
+    } = await loadChatPanelTabAtoms();
+
+    store.set(sessionsAtom, [
+      makeSession("session-a", { name: "Session A", repoPath: "/repos/a" }),
+      makeSession("session-b", { name: "Session B", repoPath: "/repos/b" }),
+    ]);
+    store.set(openSessionInNewChatTabAtom, "session-a");
+    const secondTabId = store.set(openSessionInNewChatTabAtom, "session-b");
+
+    store.set(closeChatPanelTabAtom, secondTabId);
+
+    expect(store.get(activeSessionIdAtom)).toBe("session-a");
+  });
+});

--- a/src/store/chatPanel/chatPanelTabsAtom.ts
+++ b/src/store/chatPanel/chatPanelTabsAtom.ts
@@ -22,6 +22,12 @@ import { atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 
 import { destroyChatPanelTerminalAtom } from "@src/store/chatPanel/chatPanelTerminalAtom";
+import { sessionByIdAtom } from "@src/store/session/sessionAtom";
+import {
+  activeSessionIdAtom,
+  jumpToSessionAtom,
+  workstationActiveSessionIdAtom,
+} from "@src/store/session/viewAtom";
 
 // ────────────────────────────────────────────────────────────────────────────
 // Types
@@ -183,14 +189,47 @@ export const chatPanelTabCountAtom = atom(
 // Write-only action atoms
 // ────────────────────────────────────────────────────────────────────────────
 
-/** Switch to a tab by ID */
+interface ActivateChatPanelTabOptions {
+  tabId: string;
+  sessionName?: string;
+  repoPath?: string;
+}
+
+function getActivateTabOptions(
+  optionsOrTabId: ActivateChatPanelTabOptions | string
+): ActivateChatPanelTabOptions {
+  return typeof optionsOrTabId === "string"
+    ? { tabId: optionsOrTabId }
+    : optionsOrTabId;
+}
+
+/** Switch to a tab by ID and sync session state for linked session tabs. */
 export const activateChatPanelTabAtom = atom(
   null,
-  (_get, set, tabId: string) => {
-    set(chatPanelTabsAtom, (prev) => {
-      if (!prev.tabs.some((tab) => tab.id === tabId)) return prev;
-      return { ...prev, activeTabId: tabId };
-    });
+  (get, set, optionsOrTabId: ActivateChatPanelTabOptions | string) => {
+    const { tabId, sessionName, repoPath } =
+      getActivateTabOptions(optionsOrTabId);
+    const state = get(chatPanelTabsAtom);
+    const tab = state.tabs.find((candidate) => candidate.id === tabId);
+    if (!tab) return;
+
+    if (state.activeTabId !== tabId) {
+      set(chatPanelTabsAtom, { ...state, activeTabId: tabId });
+    }
+
+    const sessionId = tab.type === "session" ? tab.sessionId : null;
+    if (
+      sessionId &&
+      (get(workstationActiveSessionIdAtom) !== sessionId ||
+        get(activeSessionIdAtom) !== sessionId)
+    ) {
+      const session = get(sessionByIdAtom(sessionId));
+      set(jumpToSessionAtom, {
+        sessionId,
+        sessionName: sessionName ?? session?.name,
+        repoPath: repoPath ?? session?.repoPath,
+      });
+    }
   }
 );
 activateChatPanelTabAtom.debugLabel = "activateChatPanelTab";
@@ -218,14 +257,24 @@ export const addChatPanelSessionTabAtom = atom(null, (_get, set) => {
 });
 addChatPanelSessionTabAtom.debugLabel = "addChatPanelSessionTab";
 
+interface OpenSessionInNewChatTabOptions {
+  sessionId: string;
+  sessionName?: string;
+  repoPath?: string;
+}
+
 /**
- * Open an existing session in a new chat panel tab.
- * Creates the tab pre-linked to the given sessionId so the tab pill shows the
- * session icon/name immediately and the chat history loads without a redirect.
+ * Open an existing session in a new chat panel tab and make it the active
+ * WorkStation session.
  */
 export const openSessionInNewChatTabAtom = atom(
   null,
-  (_get, set, sessionId: string) => {
+  (_get, set, optionsOrSessionId: OpenSessionInNewChatTabOptions | string) => {
+    const options =
+      typeof optionsOrSessionId === "string"
+        ? { sessionId: optionsOrSessionId }
+        : optionsOrSessionId;
+    const { sessionId, sessionName, repoPath } = options;
     const id = `chat-${crypto.randomUUID()}`;
     const now = new Date().toISOString();
     set(chatPanelTabsAtom, (prev) => ({
@@ -243,6 +292,7 @@ export const openSessionInNewChatTabAtom = atom(
       ],
       activeTabId: id,
     }));
+    set(activateChatPanelTabAtom, { tabId: id, sessionName, repoPath });
     return id;
   }
 );
@@ -304,56 +354,62 @@ export const clearChatPanelTabCliCommandAtom = atom(
 clearChatPanelTabCliCommandAtom.debugLabel = "clearChatPanelTabCliCommand";
 
 /** Close a tab by ID. If it was active, move to the nearest neighbour. */
-export const closeChatPanelTabAtom = atom(null, (_get, set, tabId: string) => {
-  set(chatPanelTabsAtom, (prev) => {
-    const idx = prev.tabs.findIndex((t) => t.id === tabId);
-    if (idx === -1) return prev;
-    const tab = prev.tabs[idx];
-    if (!tab.closable) return prev;
-    const nextTabs = prev.tabs.filter((t) => t.id !== tabId);
-    if (nextTabs.length === 0) {
-      // Re-create primary tab if we just closed the last one
-      const now = new Date().toISOString();
-      const primary: ChatPanelTab = {
-        id: PRIMARY_TAB_ID,
-        type: "session",
-        title: "Chat",
-        createdAt: now,
-        updatedAt: now,
-        isPrimary: true,
-        closable: false,
-        sessionId: null,
-      };
-      return { tabs: [primary], activeTabId: PRIMARY_TAB_ID };
-    }
-    let nextActiveId = prev.activeTabId;
-    if (prev.activeTabId === tabId) {
-      // Prefer the tab to the left, fall back to the one to the right
-      const nextIdx = Math.max(0, idx - 1);
-      nextActiveId = nextTabs[Math.min(nextIdx, nextTabs.length - 1)].id;
-    }
-    return { tabs: nextTabs, activeTabId: nextActiveId };
-  });
+export const closeChatPanelTabAtom = atom(null, (get, set, tabId: string) => {
+  const state = get(chatPanelTabsAtom);
+  const idx = state.tabs.findIndex((tab) => tab.id === tabId);
+  if (idx === -1) return;
+  const tab = state.tabs[idx];
+  if (!tab.closable) return;
+
+  const nextTabs = state.tabs.filter((candidate) => candidate.id !== tabId);
+  let nextActiveId = state.activeTabId;
+
+  if (nextTabs.length === 0) {
+    const now = new Date().toISOString();
+    const primary: ChatPanelTab = {
+      id: PRIMARY_TAB_ID,
+      type: "session",
+      title: "Chat",
+      createdAt: now,
+      updatedAt: now,
+      isPrimary: true,
+      closable: false,
+      sessionId: null,
+    };
+    set(chatPanelTabsAtom, { tabs: [primary], activeTabId: PRIMARY_TAB_ID });
+    return;
+  }
+
+  if (state.activeTabId === tabId) {
+    const nextIdx = Math.max(0, idx - 1);
+    nextActiveId = nextTabs[Math.min(nextIdx, nextTabs.length - 1)].id;
+  }
+
+  set(chatPanelTabsAtom, { tabs: nextTabs, activeTabId: nextActiveId });
+  if (state.activeTabId === tabId) {
+    set(activateChatPanelTabAtom, nextActiveId);
+  }
 });
 closeChatPanelTabAtom.debugLabel = "closeChatPanelTab";
 
 /** Navigate to the next tab (wraps around) */
-export const nextChatPanelTabAtom = atom(null, (_get, set) => {
-  set(chatPanelTabsAtom, (prev) => {
-    const idx = prev.tabs.findIndex((tab) => tab.id === prev.activeTabId);
-    const nextIdx = (idx + 1) % prev.tabs.length;
-    return { ...prev, activeTabId: prev.tabs[nextIdx].id };
-  });
+export const nextChatPanelTabAtom = atom(null, (get, set) => {
+  const state = get(chatPanelTabsAtom);
+  if (state.tabs.length === 0) return;
+  const idx = state.tabs.findIndex((tab) => tab.id === state.activeTabId);
+  const nextIdx = ((idx === -1 ? 0 : idx) + 1) % state.tabs.length;
+  set(activateChatPanelTabAtom, state.tabs[nextIdx].id);
 });
 nextChatPanelTabAtom.debugLabel = "nextChatPanelTab";
 
 /** Navigate to the previous tab (wraps around) */
-export const prevChatPanelTabAtom = atom(null, (_get, set) => {
-  set(chatPanelTabsAtom, (prev) => {
-    const idx = prev.tabs.findIndex((tab) => tab.id === prev.activeTabId);
-    const prevIdx = (idx - 1 + prev.tabs.length) % prev.tabs.length;
-    return { ...prev, activeTabId: prev.tabs[prevIdx].id };
-  });
+export const prevChatPanelTabAtom = atom(null, (get, set) => {
+  const state = get(chatPanelTabsAtom);
+  if (state.tabs.length === 0) return;
+  const idx = state.tabs.findIndex((tab) => tab.id === state.activeTabId);
+  const currentIdx = idx === -1 ? 0 : idx;
+  const prevIdx = (currentIdx - 1 + state.tabs.length) % state.tabs.length;
+  set(activateChatPanelTabAtom, state.tabs[prevIdx].id);
 });
 prevChatPanelTabAtom.debugLabel = "prevChatPanelTab";
 


### PR DESCRIPTION
## Summary

Unifies chat-panel tab activation so session switching has one owner instead of being split across sidebar handlers and ChatPanel effects.

- Makes `activateChatPanelTabAtom` the shared activation path for linked session tabs, syncing both WorkStation session memory and the live pipeline session.
- Routes open-in-new-tab, previous/next tab navigation, and close-active-tab fallback through that activation path.
- Leaves `useChatPanelTabsController` responsible only for binding a newly launched session to an empty tab.
- Adds atom-level coverage for open-in-new-tab, direct activation, previous-tab navigation, and closing the active tab.

## Root Cause

The previous `Open in New Tab` flow created or activated a tab without consistently switching the underlying WorkStation/pipeline session. Some reconciliation lived in `useChatPanelTabsController`, which made tab/session state depend on a later React effect and allowed entry points to drift.

## Architecture Audit

Covered the relevant architecture-audit layers for this TypeScript state-flow refactor:

- Layer 1: compilation and validation checks run.
- Layer 2: removed the duplicate session-jump responsibility from the ChatPanel controller and centralized tab activation behavior.
- Layer 3: updated comments/names around open-session tab activation to match behavior.
- Layer 4: separated tab activation semantics from session binding semantics; `tab.sessionId` now drives activation through one action.
- Layer 5: reviewed no-op/default paths for missing tabs, terminal tabs, empty tabs, and fallback primary tabs.
- Layer 6: no Rust/backend or cross-domain leakage introduced.
- Layer 7: reduced new-developer confusion by keeping sidebar as an entry adapter and the tab atom as the state owner.
- Layer 8: no wire protocol/serialization changes.
- Layer 9: aligned tab activation entry points: tab click, previous/next, close fallback, TUI tab activation, and open-in-new-tab all route through `activateChatPanelTabAtom` where applicable.
- Layer 10: no multi-field backend resolver changes.

## Validation

- `npm test -- src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts`
- `npx eslint src/engines/ChatPanel/hooks/useChatPanelTabsController.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx src/store/chatPanel/chatPanelTabsAtom.ts src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts`
- `git diff --check`
- `npm run typecheck -- --pretty false`

Note: local working tree still has unrelated unstaged changes in `src/modules/WorkStation/AppShell/AgentStationChromeFrame.tsx` and `src/styles/_utilities.scss`; they are intentionally not included in this PR.