### PR TITLE
fix(agent): align compaction failure semantics with reference harness

### DIFF
--- a/src-tauri/crates/agent-core/src/core/definitions/store.rs
+++ b/src-tauri/crates/agent-core/src/core/definitions/store.rs
@@ -389,6 +389,25 @@ fn migrate_legacy_workspace_settings(value: &mut serde_json::Value) -> bool {
     true
 }
 
+/// One-shot migration for the stale `summaryMaxTokens: 4096` compaction
+/// override. 4096 was the shipped default before it was raised to 20_000
+/// (a 4k cap truncates the 9-section compaction summary mid-section, cf.
+/// claude_code COMPACT_MAX_OUTPUT_TOKENS = 20_000); overlays written back
+/// then froze the old default as if the user had chosen it. Values other
+/// than 4096 are genuine user choices and are left alone. Returns `true`
+/// when the value was changed and should be re-persisted.
+fn migrate_stale_summary_max_tokens(value: &mut serde_json::Value) -> bool {
+    const STALE_DEFAULT: u64 = 4096;
+    let Some(summary_max) = value
+        .pointer_mut("/sessionModel/compaction/summaryMaxTokens")
+        .filter(|v| v.as_u64() == Some(STALE_DEFAULT))
+    else {
+        return false;
+    };
+    *summary_max = serde_json::json!(super::schema::CompactionConfig::default().summary_max_tokens);
+    true
+}
+
 fn load_from_disk(path: &std::path::Path) -> Vec<AgentDefinition> {
     if !path.exists() {
         return Vec::new();
@@ -396,9 +415,9 @@ fn load_from_disk(path: &std::path::Path) -> Vec<AgentDefinition> {
     match std::fs::read_to_string(path) {
         Ok(content) => match serde_json::from_str::<Vec<serde_json::Value>>(&content) {
             Ok(mut raw) => {
-                let migrated = raw
-                    .iter_mut()
-                    .fold(false, |acc, v| migrate_legacy_workspace_settings(v) || acc);
+                let migrated = raw.iter_mut().fold(false, |acc, v| {
+                    migrate_legacy_workspace_settings(v) | migrate_stale_summary_max_tokens(v) | acc
+                });
                 let agents: Vec<AgentDefinition> = raw
                     .into_iter()
                     .filter_map(|v| match serde_json::from_value(v) {
@@ -472,9 +491,11 @@ fn load_overrides_from_disk(path: &std::path::Path) -> BTreeMap<String, AgentDef
         Ok(content) => {
             match serde_json::from_str::<BTreeMap<String, serde_json::Value>>(&content) {
                 Ok(mut raw) => {
-                    let migrated = raw
-                        .values_mut()
-                        .fold(false, |acc, v| migrate_legacy_workspace_settings(v) || acc);
+                    let migrated = raw.values_mut().fold(false, |acc, v| {
+                        migrate_legacy_workspace_settings(v)
+                            | migrate_stale_summary_max_tokens(v)
+                            | acc
+                    });
                     let overrides: BTreeMap<String, AgentDefinition> = raw
                         .into_iter()
                         .filter_map(
@@ -668,5 +689,37 @@ mod overlay_tests {
     fn compose_unknown_builtin_returns_none() {
         let delta = serde_json::json!({"name": "ghost"});
         assert!(compose_builtin_with_delta("builtin:retired-agent", &delta).is_none());
+    }
+
+    #[test]
+    fn stale_summary_max_tokens_4096_is_migrated_to_current_default() {
+        let mut value = serde_json::json!({
+            "sessionModel": { "compaction": { "summaryMaxTokens": 4096 } }
+        });
+        assert!(migrate_stale_summary_max_tokens(&mut value));
+        assert_eq!(
+            value["sessionModel"]["compaction"]["summaryMaxTokens"].as_u64(),
+            Some(u64::from(
+                super::super::schema::CompactionConfig::default().summary_max_tokens
+            ))
+        );
+    }
+
+    #[test]
+    fn user_chosen_summary_max_tokens_is_left_alone() {
+        let mut value = serde_json::json!({
+            "sessionModel": { "compaction": { "summaryMaxTokens": 8000 } }
+        });
+        assert!(!migrate_stale_summary_max_tokens(&mut value));
+        assert_eq!(
+            value["sessionModel"]["compaction"]["summaryMaxTokens"].as_u64(),
+            Some(8000)
+        );
+    }
+
+    #[test]
+    fn missing_summary_max_tokens_is_no_op() {
+        let mut value = serde_json::json!({ "name": "no compaction override" });
+        assert!(!migrate_stale_summary_max_tokens(&mut value));
     }
 }

--- a/src-tauri/crates/agent-core/src/core/model_context/compaction.rs
+++ b/src-tauri/crates/agent-core/src/core/model_context/compaction.rs
@@ -182,7 +182,7 @@ pub enum CompactionOutcome {
     /// history is returned UNCHANGED — never silently truncated. Ref:
     /// claude_code autoCompact.ts: a failed compaction returns
     /// `wasCompacted: false` and the turn proceeds with the original
-    /// history ("压不动就不压").
+    /// history (if it can't compact, it doesn't compact).
     Failed { reason: String },
     /// History was already within budget — no compaction needed.
     Skipped,

--- a/src-tauri/crates/agent-core/src/core/model_context/compaction.rs
+++ b/src-tauri/crates/agent-core/src/core/model_context/compaction.rs
@@ -19,6 +19,7 @@ use serde_json::Value;
 use tracing::{info, warn};
 
 use super::summarization;
+pub use super::summarization::ForkSummaryInputs;
 use super::tokenizer;
 use crate::providers::traits::LLMProvider;
 
@@ -177,17 +178,20 @@ pub enum CompactionOutcome {
         messages_dropped: usize,
         messages_kept: usize,
     },
-    /// LLM summarization failed or was skipped by the circuit breaker;
-    /// oldest messages were silently dropped instead.
-    Truncated { messages_dropped: usize },
+    /// LLM summarization failed (or the circuit breaker is open). The
+    /// history is returned UNCHANGED — never silently truncated. Ref:
+    /// claude_code autoCompact.ts: a failed compaction returns
+    /// `wasCompacted: false` and the turn proceeds with the original
+    /// history ("压不动就不压").
+    Failed { reason: String },
     /// History was already within budget — no compaction needed.
     Skipped,
 }
 
 /// Result of a single LLM compaction attempt, before any fallback policy is
 /// applied. Internal to [`ContextCompactor::try_compact`] and its wrappers:
-/// the automatic path degrades non-`Compacted` attempts to truncation, the
-/// manual path maps them to user-facing statuses.
+/// the automatic path maps non-`Compacted` attempts to `Failed` (history
+/// unchanged), the manual path maps them to user-facing statuses.
 enum CompactAttempt {
     /// Summarization succeeded; `compacted` is `[summary] + recent tail`.
     Compacted {
@@ -201,9 +205,9 @@ enum CompactAttempt {
     /// there is no older segment to summarize.
     NoCompactableSegment,
     /// The summarizer input stayed prompt-too-long even after head-dropping
-    /// retries. Not a provider failure: the automatic path truncates without
-    /// feeding the circuit breaker (matching pre-refactor behavior), the
-    /// manual path surfaces it as an error.
+    /// retries. Not a provider failure: the automatic path reports `Failed`
+    /// without feeding the circuit breaker, the manual path surfaces it as
+    /// an error.
     SummarizeInputExhausted,
 }
 
@@ -367,7 +371,10 @@ impl ContextCompactor {
     /// Compact history by summarizing older messages.
     ///
     /// Returns the compacted history and an outcome describing what happened.
-    /// If compaction fails (LLM error), falls back to simple truncation.
+    /// If compaction fails (LLM error), the history is returned UNCHANGED
+    /// with [`CompactionOutcome::Failed`] — the caller decides whether to
+    /// proceed with the original history (auto path) or surface the error
+    /// (reactive/manual paths). Never silently truncates.
     pub async fn compact(
         history: &[Value],
         budget_tokens: usize,
@@ -376,12 +383,39 @@ impl ContextCompactor {
         provider: &dyn LLMProvider,
         model: &str,
     ) -> (Vec<Value>, CompactionOutcome) {
+        Self::compact_with_fork(history, budget_tokens, config, state, provider, model, None).await
+    }
+
+    /// Like [`Self::compact`], with optional fork-form summarization
+    /// inputs. When provided, the summary call is issued against the main
+    /// turn's exact request prefix (system prefix + full history + same
+    /// tools/model), reading the provider prompt cache written by the
+    /// previous turn instead of paying a cold full-prompt cost. A fork
+    /// failure falls back to the side-query path transparently.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn compact_with_fork(
+        history: &[Value],
+        budget_tokens: usize,
+        config: &CompactionConfig,
+        state: &mut CompactionState,
+        provider: &dyn LLMProvider,
+        model: &str,
+        fork_inputs: Option<&ForkSummaryInputs<'_>>,
+    ) -> (Vec<Value>, CompactionOutcome) {
         if state.consecutive_failures >= MAX_CONSECUTIVE_COMPACTION_FAILURES {
             warn!(
                 "[compaction] Circuit breaker: {} consecutive failures, skipping LLM compaction",
                 state.consecutive_failures
             );
-            return Self::truncate_outcome(history, budget_tokens);
+            return (
+                history.to_vec(),
+                CompactionOutcome::Failed {
+                    reason: format!(
+                        "circuit breaker open ({} consecutive failures)",
+                        state.consecutive_failures
+                    ),
+                },
+            );
         }
 
         match Self::try_compact(
@@ -392,6 +426,7 @@ impl ContextCompactor {
             provider,
             model,
             None,
+            fork_inputs,
         )
         .await
         {
@@ -407,16 +442,29 @@ impl ContextCompactor {
                 },
             ),
             Ok(CompactAttempt::Skipped) => (history.to_vec(), CompactionOutcome::Skipped),
-            Ok(
-                CompactAttempt::NoCompactableSegment | CompactAttempt::SummarizeInputExhausted,
-            ) => Self::truncate_outcome(history, budget_tokens),
+            Ok(CompactAttempt::NoCompactableSegment) => (
+                history.to_vec(),
+                CompactionOutcome::Failed {
+                    reason: "no compactable segment (keep window covers entire history)"
+                        .to_string(),
+                },
+            ),
+            Ok(CompactAttempt::SummarizeInputExhausted) => (
+                history.to_vec(),
+                CompactionOutcome::Failed {
+                    reason: format!(
+                        "summarization input remained too large after {} head-dropping retries",
+                        MAX_PTL_RETRIES
+                    ),
+                },
+            ),
             Err(err) => {
                 state.consecutive_failures += 1;
                 warn!(
-                    "[compaction] Summarization failed ({}/{}), falling back to truncation: {}",
+                    "[compaction] Summarization failed ({}/{}), keeping history unchanged: {}",
                     state.consecutive_failures, MAX_CONSECUTIVE_COMPACTION_FAILURES, err
                 );
-                Self::truncate_outcome(history, budget_tokens)
+                (history.to_vec(), CompactionOutcome::Failed { reason: err })
             }
         }
     }
@@ -450,6 +498,7 @@ impl ContextCompactor {
             provider,
             model,
             custom_instructions,
+            None,
         )
         .await?
         {
@@ -475,8 +524,9 @@ impl ContextCompactor {
     }
 
     /// One LLM compaction attempt with no fallback: the caller decides how
-    /// to handle a summarization failure (`compact` truncates, the manual
-    /// path surfaces the error to the user).
+    /// to handle a summarization failure (`compact` returns the history
+    /// unchanged as `Failed`, the manual path surfaces the error to the
+    /// user).
     #[allow(clippy::too_many_arguments)]
     async fn try_compact(
         history: &[Value],
@@ -486,6 +536,7 @@ impl ContextCompactor {
         provider: &dyn LLMProvider,
         model: &str,
         custom_instructions: Option<&str>,
+        fork_inputs: Option<&ForkSummaryInputs<'_>>,
     ) -> Result<CompactAttempt, String> {
         let history_tokens = Self::estimate_messages_tokens(history);
 
@@ -535,6 +586,39 @@ impl ContextCompactor {
 
         let summary_model = config.model.as_deref().unwrap_or(model);
 
+        // Fork-form first: reuse the main turn's prompt-cache prefix. The
+        // fork summarizes the FULL conversation (prefix includes `recent`);
+        // keeping `recent` verbatim afterwards mirrors claude_code, which
+        // also keeps recent turns alongside the whole-conversation summary.
+        // Any fork failure falls back to the cold side-query path (ref:
+        // claude_code tengu_compact_cache_sharing_fallback).
+        if let Some(fork) = fork_inputs {
+            match summarization::summarize_messages_forked(
+                provider,
+                fork,
+                state,
+                custom_instructions,
+            )
+            .await
+            {
+                Ok(summary_text) => {
+                    return Ok(Self::accept_summary(
+                        state,
+                        history,
+                        split_idx,
+                        recent,
+                        summary_text,
+                    ));
+                }
+                Err(err) => {
+                    warn!(
+                        "[compaction] fork-form summarization failed, falling back to side query: {}",
+                        err
+                    );
+                }
+            }
+        }
+
         let mut messages_to_summarize: Vec<Value> = older.to_vec();
         let mut ptl_retries = 0;
 
@@ -552,34 +636,13 @@ impl ContextCompactor {
 
             match summary {
                 Ok(summary_text) => {
-                    state.consecutive_failures = 0;
-                    state.summary = Some(summary_text.clone());
-                    state.compacted_count = split_idx;
-                    state.recompaction_info.compaction_count += 1;
-                    state.recompaction_info.last_compaction_turn = history.len();
-
-                    let mut compacted = Vec::with_capacity(recent.len() + 1);
-
-                    let summary_msg = compacted_summary_message(format!(
-                        "{} {} earlier messages compacted]\n\n{}",
-                        super::session_memory::compact::LLM_COMPACT_BOUNDARY_PREFIX,
+                    return Ok(Self::accept_summary(
+                        state,
+                        history,
                         split_idx,
-                        summary_text
+                        recent,
+                        summary_text,
                     ));
-                    compacted.push(summary_msg);
-                    compacted.extend_from_slice(recent);
-
-                    let compacted_tokens = Self::estimate_messages_tokens(&compacted);
-                    info!(
-                        "[compaction] Compacted history: {} messages, ~{} tokens (was {} messages, ~{} tokens)",
-                        compacted.len(), compacted_tokens, history.len(), history_tokens
-                    );
-
-                    return Ok(CompactAttempt::Compacted {
-                        compacted,
-                        messages_dropped: split_idx,
-                        messages_kept: recent.len(),
-                    });
                 }
                 Err(err)
                     if Self::is_prompt_too_long_error(&err) && ptl_retries < MAX_PTL_RETRIES =>
@@ -606,16 +669,46 @@ impl ContextCompactor {
         }
     }
 
-    /// Shared truncation fallback used by the automatic path.
-    fn truncate_outcome(history: &[Value], budget_tokens: usize) -> (Vec<Value>, CompactionOutcome) {
-        let truncated = Self::simple_truncate(history, budget_tokens);
-        let dropped = history.len().saturating_sub(truncated.len());
-        (
-            truncated,
-            CompactionOutcome::Truncated {
-                messages_dropped: dropped,
-            },
-        )
+    /// Record a successful summarization into `state` and assemble the
+    /// compacted view (`[boundary summary message] + recent tail`).
+    fn accept_summary(
+        state: &mut CompactionState,
+        history: &[Value],
+        split_idx: usize,
+        recent: &[Value],
+        summary_text: String,
+    ) -> CompactAttempt {
+        state.consecutive_failures = 0;
+        state.summary = Some(summary_text.clone());
+        state.compacted_count = split_idx;
+        state.recompaction_info.compaction_count += 1;
+        state.recompaction_info.last_compaction_turn = history.len();
+
+        let mut compacted = Vec::with_capacity(recent.len() + 1);
+
+        let summary_msg = compacted_summary_message(format!(
+            "{} {} earlier messages compacted]\n\n{}",
+            super::session_memory::compact::LLM_COMPACT_BOUNDARY_PREFIX,
+            split_idx,
+            summary_text
+        ));
+        compacted.push(summary_msg);
+        compacted.extend_from_slice(recent);
+
+        let compacted_tokens = Self::estimate_messages_tokens(&compacted);
+        info!(
+            "[compaction] Compacted history: {} messages, ~{} tokens (was {} messages, ~{} tokens)",
+            compacted.len(),
+            compacted_tokens,
+            history.len(),
+            Self::estimate_messages_tokens(history),
+        );
+
+        CompactAttempt::Compacted {
+            compacted,
+            messages_dropped: split_idx,
+            messages_kept: recent.len(),
+        }
     }
 
     /// Snap the split index forward to the nearest "user" message.

--- a/src-tauri/crates/agent-core/src/core/model_context/summarization.rs
+++ b/src-tauri/crates/agent-core/src/core/model_context/summarization.rs
@@ -3,7 +3,7 @@
 use serde_json::Value;
 
 use super::compaction::ContextCompactor;
-use crate::core::side_query::{self, SideQueryConfig, StructuredOutput};
+use crate::core::side_query::{self, SideQueryConfig};
 
 /// Relaxed cap for tool results fed to the summarizer. Large enough to keep
 /// exact error messages / paths intact; the per-message oversized guard in
@@ -162,6 +162,171 @@ pub(crate) fn format_tool_calls(msg: &Value) -> String {
         .unwrap_or_default()
 }
 
+/// Build the summarization instruction prompt (system prompt for the
+/// side-query path, user-message text for the fork path).
+///
+/// `include_prior_summary` is false on the fork path: the prior compact
+/// summary is already present in the forked message list as the boundary
+/// user message, so repeating it would only bloat the request.
+fn build_summary_prompt(
+    state: &super::compaction::CompactionState,
+    custom_instructions: Option<&str>,
+    include_prior_summary: bool,
+) -> String {
+    let mut prompt = String::from(SUMMARIZATION_SYSTEM_PROMPT);
+
+    if state.recompaction_info.compaction_count > 0 {
+        prompt.push_str(&format!(
+            "\n\n## Re-compaction Context\n\nThis is compaction #{} for this session (last at turn {}). \
+             Merge the prior summary with the new messages — preserve important details from both, \
+             but prioritize recent information when there are conflicts or superseded decisions.",
+            state.recompaction_info.compaction_count + 1,
+            state.recompaction_info.last_compaction_turn,
+        ));
+    }
+
+    if include_prior_summary {
+        if let Some(ref prior_summary) = state.summary {
+            prompt.push_str(&format!(
+                "\n\n## Prior Context Summary\n\n{}\n\n## New Messages to Incorporate\n\n",
+                prior_summary
+            ));
+        }
+    }
+
+    if let Some(instructions) = custom_instructions
+        .map(str::trim)
+        .filter(|instructions| !instructions.is_empty())
+    {
+        prompt.push_str(&format!(
+            "\n\n## Additional Instructions\n\nThe user provided extra focus instructions for this \
+             summary. Honor them on top of the required section structure — they refine emphasis, \
+             they do not replace any section:\n{}",
+            instructions
+        ));
+    }
+
+    prompt
+}
+
+/// Validate a summarizer response shared by both paths: reject output cut
+/// off at the cap and empty summaries.
+///
+/// NOTE: these messages must NOT contain any keyword matched by
+/// `ContextCompactor::is_prompt_too_long_error` (e.g. "max_tokens",
+/// "token limit"), or `try_compact` would misroute an OUTPUT-side failure
+/// into the input-shrinking PTL retry loop.
+fn validate_summary(
+    summary: String,
+    finish_reason: &str,
+    output_cap: u32,
+) -> Result<String, String> {
+    // A response cut off at the output cap is a mid-sentence summary;
+    // persisting it would durably hide the compacted messages behind an
+    // incomplete replacement.
+    if finish_reason == crate::providers::finish_reason::LENGTH {
+        return Err(format!(
+            "summary output hit the summarizer cap ({}) — refusing incomplete summary",
+            output_cap
+        ));
+    }
+    // An empty summary must never replace real history: the compacted view
+    // would render `[Conversation summary — N messages compacted]` followed
+    // by nothing, silently destroying context.
+    if summary.trim().is_empty() {
+        return Err("summarizer returned an empty summary".to_string());
+    }
+    Ok(summary)
+}
+
+// ============================================
+// Fork-form summarization (prompt-cache sharing)
+// ============================================
+
+/// Inputs for the fork-form summarization call.
+///
+/// The summary request is appended to the main turn's EXACT request prefix
+/// (runtime system prefix + full history, same tools / model / max_tokens /
+/// temperature) so the provider prompt cache written by the previous turn is
+/// read instead of paying a cold full-prompt cost. Ref: claude_code
+/// runForkedAgent + CacheSafeParams (compact.ts streamCompactSummary,
+/// forkedAgent.ts): system prompt, tools, model, message prefix and thinking
+/// config must be identical to share the parent's cache — disabling cache
+/// sharing measured ~98% cache miss.
+pub struct ForkSummaryInputs<'a> {
+    /// Wire-identical main-turn message list (runtime system prefix +
+    /// history, screenshots resolved, timestamp metadata stripped).
+    pub messages: &'a [Value],
+    /// Main turn's tool definitions. Affects both the cache key and the
+    /// thinking directive the request builder picks (no tools → PlainText,
+    /// which would diverge from the main turn's Auto).
+    pub tools: &'a [Value],
+    /// Main turn's model — NOT the compaction summary-model override.
+    pub model: &'a str,
+    /// Main turn's max_tokens. Legacy models derive the thinking budget
+    /// from it; a different value changes the thinking config and breaks
+    /// the cache prefix.
+    pub max_tokens: u32,
+    pub temperature: f32,
+}
+
+/// Fork-form summarization: main-turn prefix + a volatile-marked summary
+/// request, plain-text response.
+///
+/// `skip_cache_write` stays FALSE: on Anthropic, suppressing breakpoints
+/// removes the cache LOOKUP points too — no breakpoints means zero cache
+/// reads, not "read without writing". The prefix breakpoints land at the
+/// same positions as the main turn's request (the summary-request block is
+/// scope-marked `volatile`, so the trailing breakpoint skips it), making
+/// the call almost entirely cache reads.
+pub(crate) async fn summarize_messages_forked(
+    provider: &dyn crate::providers::traits::LLMProvider,
+    inputs: &ForkSummaryInputs<'_>,
+    state: &super::compaction::CompactionState,
+    custom_instructions: Option<&str>,
+) -> Result<String, String> {
+    use crate::session::prompt::cache::{RenderedSystemBlockScope, ORGII_SYSTEM_CACHE_SCOPE_KEY};
+
+    let prompt = build_summary_prompt(state, custom_instructions, false);
+    let mut messages: Vec<Value> = inputs.messages.to_vec();
+    messages.push(serde_json::json!({
+        "role": "user",
+        "content": [{
+            "type": "text",
+            "text": prompt,
+            (ORGII_SYSTEM_CACHE_SCOPE_KEY): RenderedSystemBlockScope::Volatile.as_str(),
+        }],
+    }));
+
+    tracing::info!(
+        "[compaction] fork summary request: {} prefix messages, {} tools, model={}",
+        inputs.messages.len(),
+        inputs.tools.len(),
+        inputs.model,
+    );
+
+    let response = provider
+        .chat_with_options(
+            &messages,
+            Some(inputs.tools),
+            inputs.model,
+            inputs.max_tokens,
+            inputs.temperature,
+            crate::providers::traits::ChatOptions::default(),
+        )
+        .await
+        .map_err(|err| err.to_string())?;
+
+    // Tools are present with tool_choice auto — a model that answers with
+    // a tool call instead of prose yields no primary text; treat as failure
+    // so the caller falls back to the side-query path.
+    let summary = response
+        .primary_text()
+        .map(str::to_string)
+        .unwrap_or_default();
+    validate_summary(summary, &response.finish_reason, inputs.max_tokens)
+}
+
 /// Generate a summary of messages using the LLM.
 ///
 /// Oversized messages (>50% of context window) are excluded from
@@ -210,60 +375,25 @@ pub(crate) async fn summarize_messages(
 
     let formatted = format_messages_for_summary_refs(&summarizable);
 
-    let mut prompt = String::from(SUMMARIZATION_SYSTEM_PROMPT);
-
-    if state.recompaction_info.compaction_count > 0 {
-        prompt.push_str(&format!(
-            "\n\n## Re-compaction Context\n\nThis is compaction #{} for this session (last at turn {}). \
-             Merge the prior summary with the new messages — preserve important details from both, \
-             but prioritize recent information when there are conflicts or superseded decisions.",
-            state.recompaction_info.compaction_count + 1,
-            state.recompaction_info.last_compaction_turn,
-        ));
-    }
-
-    if let Some(ref prior_summary) = state.summary {
-        prompt.push_str(&format!(
-            "\n\n## Prior Context Summary\n\n{}\n\n## New Messages to Incorporate\n\n",
-            prior_summary
-        ));
-    }
-
-    if let Some(instructions) = custom_instructions
-        .map(str::trim)
-        .filter(|instructions| !instructions.is_empty())
-    {
-        prompt.push_str(&format!(
-            "\n\n## Additional Instructions\n\nThe user provided extra focus instructions for this \
-             summary. Honor them on top of the required section structure — they refine emphasis, \
-             they do not replace any section:\n{}",
-            instructions
-        ));
-    }
+    let prompt = build_summary_prompt(state, custom_instructions, true);
 
     let user_message = vec![serde_json::json!({
         "role": "user",
         "content": formatted,
     })];
 
+    // Plain-text output, NOT a forced tool call. Ref: claude_code
+    // streamCompactSummary sends the compact prompt as a normal user
+    // message and reads back the assistant's text. Forcing the 9-section
+    // summary into a single tool-call string argument made models answer
+    // huge prompts (233K observed) with an empty `{}` — long-form markdown
+    // prose is what they are actually good at.
     let sq_config = SideQueryConfig {
         model: None,
         max_tokens: config.summary_max_tokens,
         temperature: 0.0,
         system_prompt: Some(prompt),
-        structured: Some(StructuredOutput {
-            tool_name: "emit_summary".to_string(),
-            schema: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "summary": {
-                        "type": "string",
-                        "description": "The complete, detailed multi-section summary of the conversation in markdown, following the required section structure"
-                    }
-                },
-                "required": ["summary"]
-            }),
-        }),
+        structured: None,
         // One-shot request over a prefix that is never sent again — writing
         // it to the provider prompt cache is pure cost.
         skip_cache_write: true,
@@ -272,40 +402,11 @@ pub(crate) async fn summarize_messages(
 
     let result = side_query::side_query(provider, &user_message, &sq_config, model).await?;
 
-    // A response cut off at the output cap is a mid-sentence summary;
-    // persisting it would durably hide the compacted messages behind an
-    // incomplete replacement. Treat as failure so the caller can fall back /
-    // surface it.
-    //
-    // NOTE: this message must NOT contain any keyword matched by
-    // `ContextCompactor::is_prompt_too_long_error` (e.g. "max_tokens",
-    // "token limit"), or `try_compact` would misroute this OUTPUT-side
-    // failure into the input-shrinking PTL retry loop.
-    if result.finish_reason == crate::providers::finish_reason::LENGTH {
-        return Err(format!(
-            "summary output hit the summarizer cap ({}) — refusing incomplete summary",
-            config.summary_max_tokens
-        ));
-    }
-
-    // Extract from structured output (forced tool call) if available,
-    // fall back to text content for providers that don't support tool_choice.
-    let mut summary = if let Some(structured) = result.structured {
-        structured
-            .get("summary")
-            .and_then(|s| s.as_str())
-            .unwrap_or("")
-            .to_string()
-    } else {
-        result.content
-    };
-
-    // An empty summary must never replace real history: the compacted view
-    // would render `[Conversation summary — N messages compacted]` followed
-    // by nothing, silently destroying context.
-    if summary.trim().is_empty() {
-        return Err("summarizer returned an empty summary".to_string());
-    }
+    let mut summary = validate_summary(
+        result.content,
+        &result.finish_reason,
+        config.summary_max_tokens,
+    )?;
 
     if !oversized_notes.is_empty() {
         summary.push_str("\n\n");

--- a/src-tauri/crates/agent-core/src/core/model_context/tests/compaction_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/model_context/tests/compaction_tests.rs
@@ -1158,6 +1158,98 @@ async fn compact_circuit_breaker_returns_failed_without_truncation() {
 }
 
 #[tokio::test]
+async fn manual_force_rescues_when_circuit_breaker_is_open() {
+    use crate::model_context::compaction::{
+        CompactionOutcome, CompactionState, MAX_CONSECUTIVE_COMPACTION_FAILURES,
+    };
+    use crate::providers::traits::{LLMProvider, LLMResponse, ProviderError};
+
+    struct SummaryProvider;
+
+    #[async_trait::async_trait]
+    impl LLMProvider for SummaryProvider {
+        async fn chat(
+            &self,
+            _messages: &[Value],
+            _tools: Option<&[Value]>,
+            _model: &str,
+            _max_tokens: u32,
+            _temperature: f32,
+        ) -> Result<LLMResponse, ProviderError> {
+            Ok(LLMResponse {
+                content: Some("rescued summary".to_string()),
+                tool_calls: vec![],
+                finish_reason: crate::providers::finish_reason::STOP.to_string(),
+                usage: std::collections::HashMap::new(),
+                reasoning_content: None,
+                blocks: Vec::new(),
+                stream_error_kind: None,
+                retry_after_ms: None,
+            })
+        }
+
+        fn default_model(&self) -> &str {
+            "test-model"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    let big = "x".repeat(400);
+    let mut history: Vec<Value> = vec![user_msg("task statement")];
+    for _ in 0..40 {
+        history.push(assistant_msg(&big));
+    }
+    let budget = ContextCompactor::estimate_messages_tokens(&history) / 2;
+    let mut config = default_config();
+    config.floor_tokens = 0;
+    // Breaker open: the automatic path refuses without touching the provider…
+    let mut state = CompactionState {
+        consecutive_failures: MAX_CONSECUTIVE_COMPACTION_FAILURES,
+        ..Default::default()
+    };
+    let (_, auto_outcome) = ContextCompactor::compact(
+        &history,
+        budget,
+        &config,
+        &mut state,
+        &SummaryProvider,
+        "test-model",
+    )
+    .await;
+    assert!(matches!(auto_outcome, CompactionOutcome::Failed { .. }));
+
+    // …but the manual-force rescue (used by the reactive path) ignores the
+    // breaker, compacts, and heals the failure counter.
+    let (rescued, rescue_outcome) = ContextCompactor::compact_manual_force(
+        &history,
+        budget,
+        &config,
+        &mut state,
+        &SummaryProvider,
+        "test-model",
+        None,
+    )
+    .await
+    .expect("rescue succeeds");
+
+    assert!(matches!(
+        rescue_outcome,
+        CompactionOutcome::Compacted { .. }
+    ));
+    assert!(rescued[0]["content"]
+        .as_str()
+        .unwrap()
+        .contains("rescued summary"));
+    assert_eq!(
+        state.consecutive_failures, 0,
+        "successful rescue must reset the circuit breaker"
+    );
+}
+
+#[tokio::test]
 async fn compact_manual_force_threads_custom_instructions_into_prompt() {
     use std::sync::Mutex;
 

--- a/src-tauri/crates/agent-core/src/core/model_context/tests/compaction_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/model_context/tests/compaction_tests.rs
@@ -674,11 +674,11 @@ fn compaction_outcome_variants() {
         assert_eq!(messages_kept, 5);
     }
 
-    let truncated = CompactionOutcome::Truncated {
-        messages_dropped: 8,
+    let failed = CompactionOutcome::Failed {
+        reason: "summarizer returned an empty summary".to_string(),
     };
-    if let CompactionOutcome::Truncated { messages_dropped } = truncated {
-        assert_eq!(messages_dropped, 8);
+    if let CompactionOutcome::Failed { reason } = failed {
+        assert!(reason.contains("empty summary"));
     }
 }
 
@@ -1042,6 +1042,122 @@ async fn compact_manual_force_propagates_summarization_failure() {
 }
 
 #[tokio::test]
+async fn compact_failure_keeps_history_unchanged_no_truncation() {
+    use crate::model_context::compaction::{CompactionOutcome, CompactionState};
+    use crate::providers::traits::{LLMProvider, LLMResponse, ProviderError};
+
+    struct FailingProvider;
+
+    #[async_trait::async_trait]
+    impl LLMProvider for FailingProvider {
+        async fn chat(
+            &self,
+            _messages: &[Value],
+            _tools: Option<&[Value]>,
+            _model: &str,
+            _max_tokens: u32,
+            _temperature: f32,
+        ) -> Result<LLMResponse, ProviderError> {
+            Err(ProviderError::RequestFailed("provider outage".to_string()))
+        }
+
+        fn default_model(&self) -> &str {
+            "test-model"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    let big = "x".repeat(400);
+    let mut history: Vec<Value> = vec![user_msg("task statement")];
+    for _ in 0..40 {
+        history.push(assistant_msg(&big));
+    }
+    // Budget well below the estimate so the trigger fires and the LLM
+    // attempt actually runs (and fails).
+    let budget = ContextCompactor::estimate_messages_tokens(&history) / 2;
+    let mut config = default_config();
+    // Default 16K floor would cover this small history entirely
+    // (NoCompactableSegment) — force the split so the LLM call happens.
+    config.floor_tokens = 0;
+    let mut state = CompactionState::default();
+
+    let (result_history, outcome) = ContextCompactor::compact(
+        &history,
+        budget,
+        &config,
+        &mut state,
+        &FailingProvider,
+        "test-model",
+    )
+    .await;
+
+    // CC semantics: failure never truncates — history comes back verbatim.
+    assert!(matches!(outcome, CompactionOutcome::Failed { .. }));
+    assert_eq!(result_history, history, "history must be unchanged");
+    assert_eq!(state.consecutive_failures, 1);
+}
+
+#[tokio::test]
+async fn compact_circuit_breaker_returns_failed_without_truncation() {
+    use crate::model_context::compaction::{
+        CompactionOutcome, CompactionState, MAX_CONSECUTIVE_COMPACTION_FAILURES,
+    };
+    use crate::providers::traits::{LLMProvider, LLMResponse, ProviderError};
+
+    struct PanickingProvider;
+
+    #[async_trait::async_trait]
+    impl LLMProvider for PanickingProvider {
+        async fn chat(
+            &self,
+            _messages: &[Value],
+            _tools: Option<&[Value]>,
+            _model: &str,
+            _max_tokens: u32,
+            _temperature: f32,
+        ) -> Result<LLMResponse, ProviderError> {
+            panic!("circuit breaker must prevent this call");
+        }
+
+        fn default_model(&self) -> &str {
+            "test-model"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    let big = "x".repeat(400);
+    let mut history: Vec<Value> = vec![user_msg("task statement")];
+    for _ in 0..40 {
+        history.push(assistant_msg(&big));
+    }
+    let budget = ContextCompactor::estimate_messages_tokens(&history) / 2;
+    let config = default_config();
+    let mut state = CompactionState {
+        consecutive_failures: MAX_CONSECUTIVE_COMPACTION_FAILURES,
+        ..Default::default()
+    };
+
+    let (result_history, outcome) = ContextCompactor::compact(
+        &history,
+        budget,
+        &config,
+        &mut state,
+        &PanickingProvider,
+        "test-model",
+    )
+    .await;
+
+    assert!(matches!(outcome, CompactionOutcome::Failed { .. }));
+    assert_eq!(result_history, history, "history must be unchanged");
+}
+
+#[tokio::test]
 async fn compact_manual_force_threads_custom_instructions_into_prompt() {
     use std::sync::Mutex;
 
@@ -1188,5 +1304,211 @@ async fn compact_rejects_empty_summary() {
     // the summarizer's own validation) the message differs, but both surface
     // an "empty" error instead of accepting the summary.
     let err = result.expect_err("empty summary is rejected");
-    assert!(err.to_lowercase().contains("empty"), "unexpected error: {err}");
+    assert!(
+        err.to_lowercase().contains("empty"),
+        "unexpected error: {err}"
+    );
+}
+
+// -- Fork-form summarization (prompt-cache sharing) --
+
+#[tokio::test]
+async fn compact_with_fork_uses_main_turn_prefix_and_plain_text_reply() {
+    use std::sync::Mutex;
+
+    use crate::model_context::compaction::{CompactionOutcome, CompactionState, ForkSummaryInputs};
+    use crate::providers::traits::{LLMProvider, LLMResponse, ProviderError};
+
+    /// Captures the request so the test can assert the fork rode the
+    /// main-turn prefix (messages + tools + model + max_tokens).
+    struct CapturingForkProvider {
+        captured: Mutex<Option<(usize, usize, String, u32)>>,
+    }
+
+    #[async_trait::async_trait]
+    impl LLMProvider for CapturingForkProvider {
+        async fn chat(
+            &self,
+            messages: &[Value],
+            tools: Option<&[Value]>,
+            model: &str,
+            max_tokens: u32,
+            _temperature: f32,
+        ) -> Result<LLMResponse, ProviderError> {
+            *self.captured.lock().unwrap() = Some((
+                messages.len(),
+                tools.map(<[Value]>::len).unwrap_or(0),
+                model.to_string(),
+                max_tokens,
+            ));
+            Ok(LLMResponse {
+                content: Some("## Primary Request and Intent\nforked summary".to_string()),
+                tool_calls: vec![],
+                finish_reason: crate::providers::finish_reason::STOP.to_string(),
+                usage: std::collections::HashMap::new(),
+                reasoning_content: None,
+                blocks: Vec::new(),
+                stream_error_kind: None,
+                retry_after_ms: None,
+            })
+        }
+
+        fn default_model(&self) -> &str {
+            "test-model"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    let big = "x".repeat(400);
+    let mut history: Vec<Value> = vec![user_msg("task statement")];
+    for _ in 0..40 {
+        history.push(assistant_msg(&big));
+    }
+    let budget = ContextCompactor::estimate_messages_tokens(&history) / 2;
+    let mut config = default_config();
+    config.floor_tokens = 0;
+    // A summary-model override must NOT affect the fork path — the fork
+    // must use the MAIN model or the cache prefix breaks.
+    config.model = Some("cheap-summary-model".to_string());
+    let mut state = CompactionState::default();
+
+    // Simulated main-turn wire view: system prefix + history.
+    let mut fork_messages: Vec<Value> =
+        vec![serde_json::json!({"role": "system", "content": "runtime prefix"})];
+    fork_messages.extend_from_slice(&history);
+    let fork_tools = vec![serde_json::json!({
+        "type": "function",
+        "function": {"name": "read_file", "parameters": {}}
+    })];
+    let provider = CapturingForkProvider {
+        captured: Mutex::new(None),
+    };
+    let fork_inputs = ForkSummaryInputs {
+        messages: &fork_messages,
+        tools: &fork_tools,
+        model: "main-model",
+        max_tokens: 16384,
+        temperature: 0.0,
+    };
+
+    let (compacted, outcome) = ContextCompactor::compact_with_fork(
+        &history,
+        budget,
+        &config,
+        &mut state,
+        &provider,
+        "main-model",
+        Some(&fork_inputs),
+    )
+    .await;
+
+    assert!(matches!(outcome, CompactionOutcome::Compacted { .. }));
+    assert!(compacted[0]["content"]
+        .as_str()
+        .unwrap()
+        .contains("forked summary"));
+
+    let (msg_count, tool_count, model, max_tokens) =
+        provider.captured.lock().unwrap().clone().unwrap();
+    // Prefix messages + 1 appended summary-request user message.
+    assert_eq!(msg_count, fork_messages.len() + 1);
+    assert_eq!(tool_count, 1, "main-turn tools must ride along");
+    assert_eq!(model, "main-model", "fork must use the MAIN model");
+    assert_eq!(
+        max_tokens, 16384,
+        "fork must use the main turn's max_tokens"
+    );
+    assert_eq!(state.consecutive_failures, 0);
+}
+
+#[tokio::test]
+async fn compact_with_fork_falls_back_to_side_query_on_fork_failure() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use crate::model_context::compaction::{CompactionOutcome, CompactionState, ForkSummaryInputs};
+    use crate::providers::traits::{LLMProvider, LLMResponse, ProviderError};
+
+    /// First call (the fork) fails; subsequent calls (side query) succeed.
+    struct ForkFailsProvider {
+        calls: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl LLMProvider for ForkFailsProvider {
+        async fn chat(
+            &self,
+            _messages: &[Value],
+            _tools: Option<&[Value]>,
+            _model: &str,
+            _max_tokens: u32,
+            _temperature: f32,
+        ) -> Result<LLMResponse, ProviderError> {
+            if self.calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                return Err(ProviderError::RequestFailed(
+                    "fork request rejected".to_string(),
+                ));
+            }
+            Ok(LLMResponse {
+                content: Some("side-query summary".to_string()),
+                tool_calls: vec![],
+                finish_reason: crate::providers::finish_reason::STOP.to_string(),
+                usage: std::collections::HashMap::new(),
+                reasoning_content: None,
+                blocks: Vec::new(),
+                stream_error_kind: None,
+                retry_after_ms: None,
+            })
+        }
+
+        fn default_model(&self) -> &str {
+            "test-model"
+        }
+
+        fn provider_name(&self) -> &str {
+            "mock"
+        }
+    }
+
+    let big = "x".repeat(400);
+    let mut history: Vec<Value> = vec![user_msg("task statement")];
+    for _ in 0..40 {
+        history.push(assistant_msg(&big));
+    }
+    let budget = ContextCompactor::estimate_messages_tokens(&history) / 2;
+    let mut config = default_config();
+    config.floor_tokens = 0;
+    let mut state = CompactionState::default();
+
+    let provider = ForkFailsProvider {
+        calls: AtomicUsize::new(0),
+    };
+    let fork_inputs = ForkSummaryInputs {
+        messages: &history,
+        tools: &[],
+        model: "main-model",
+        max_tokens: 16384,
+        temperature: 0.0,
+    };
+
+    let (compacted, outcome) = ContextCompactor::compact_with_fork(
+        &history,
+        budget,
+        &config,
+        &mut state,
+        &provider,
+        "main-model",
+        Some(&fork_inputs),
+    )
+    .await;
+
+    // Fork failure must degrade to the side-query path, not to Failed.
+    assert!(matches!(outcome, CompactionOutcome::Compacted { .. }));
+    assert!(compacted[0]["content"]
+        .as_str()
+        .unwrap()
+        .contains("side-query summary"));
+    assert!(provider.calls.load(Ordering::SeqCst) >= 2);
 }

--- a/src-tauri/crates/agent-core/src/core/session/compaction/manual.rs
+++ b/src-tauri/crates/agent-core/src/core/session/compaction/manual.rs
@@ -102,10 +102,6 @@ pub struct ManualCompactSummary {
     pub messages_after: usize,
     pub tokens_before: usize,
     pub tokens_after: usize,
-    /// Whether the compactor fell back to plain truncation (no LLM
-    /// summary produced). Surfaced so the user knows their history
-    /// wasn't preserved in summary form.
-    pub truncated: bool,
 }
 
 /// Run a manual compact for `session_id`.
@@ -212,7 +208,16 @@ pub async fn run_manual_compact(
         )
         .await
     };
-    let truncated = matches!(outcome, CompactionOutcome::Truncated { .. });
+
+    // Summarization failed → the history is unchanged; forking it would
+    // waste a session id without freeing any context. Surface the error.
+    if let CompactionOutcome::Failed { reason } = outcome {
+        warn!(
+            "[manual_compact] {}: compaction failed — {}",
+            session_id, reason
+        );
+        return ManualCompactResult::Failed(format!("compaction failed: {}", reason));
+    }
 
     // History still fits the model budget. Nothing meaningful to fork:
     // the transcript is unchanged, so we short-circuit with a dedicated
@@ -252,14 +257,13 @@ pub async fn run_manual_compact(
     match fork_outcome {
         ForkOutcome::Forked { new_session_id } => {
             info!(
-                "[manual_compact] {} → {}: {} msgs ({} tokens) → {} msgs ({} tokens), truncated={}",
+                "[manual_compact] {} → {}: {} msgs ({} tokens) → {} msgs ({} tokens)",
                 session_id,
                 new_session_id,
                 messages_before,
                 tokens_before,
                 messages_after,
                 tokens_after,
-                truncated
             );
             ManualCompactResult::Forked(ManualCompactSummary {
                 old_session_id: session_id.to_string(),
@@ -268,7 +272,6 @@ pub async fn run_manual_compact(
                 messages_after,
                 tokens_before,
                 tokens_after,
-                truncated,
             })
         }
         ForkOutcome::NotChannelAttached => ManualCompactResult::NotChannelAttached,

--- a/src-tauri/crates/agent-core/src/core/session/turn/processor/compaction.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/processor/compaction.rs
@@ -85,6 +85,75 @@ pub(super) enum CompactionPhaseOutcome {
 }
 
 impl UnifiedMessageProcessor {
+    /// Reactive-path LLM compaction with a last-resort rescue.
+    ///
+    /// The provider has ALREADY rejected the prompt when this runs, so a
+    /// `Failed` outcome here means the turn dies. Instead of bouncing the
+    /// user to manual `/compact`, run the manual-compact semantics
+    /// ourselves as a rescue: `compact_manual_force` ignores the failure
+    /// circuit breaker (past failures must not doom the current stuck
+    /// session), zeroes the trigger ratio, and drops the keep floor to the
+    /// aggressive manual level — exactly what the user would get by
+    /// running `/compact` by hand. Only if the rescue also fails does the
+    /// failure propagate.
+    async fn reactive_llm_compact_with_rescue(
+        &self,
+        session_id: &str,
+        tail: &[Value],
+        budget_tokens: usize,
+    ) -> (Vec<Value>, CompactionOutcome) {
+        let mut state = self.compaction_state.lock().await;
+        let (compacted, outcome) = ContextCompactor::compact(
+            tail,
+            budget_tokens,
+            &self.runtime.resolved.compaction,
+            &mut state,
+            self.runtime.provider.as_ref(),
+            &self.runtime.model,
+        )
+        .await;
+
+        let CompactionOutcome::Failed { reason } = outcome else {
+            return (compacted, outcome);
+        };
+
+        warn!(
+            "[unified_processor] Reactive compaction failed for session {} ({}) — attempting manual-force rescue",
+            session_id, reason
+        );
+        match ContextCompactor::compact_manual_force(
+            tail,
+            budget_tokens,
+            &self.runtime.resolved.compaction,
+            &mut state,
+            self.runtime.provider.as_ref(),
+            &self.runtime.model,
+            None,
+        )
+        .await
+        {
+            Ok((rescued, rescue_outcome @ CompactionOutcome::Compacted { .. })) => {
+                info!(
+                    "[unified_processor] Manual-force rescue succeeded for session {}",
+                    session_id
+                );
+                (rescued, rescue_outcome)
+            }
+            Ok((_, _)) => (
+                tail.to_vec(),
+                CompactionOutcome::Failed {
+                    reason: format!("{reason}; rescue found nothing to compact"),
+                },
+            ),
+            Err(rescue_err) => (
+                tail.to_vec(),
+                CompactionOutcome::Failed {
+                    reason: format!("{reason}; rescue also failed: {rescue_err}"),
+                },
+            ),
+        }
+    }
+
     /// Reactive (mid-turn) compaction used by the ContextTooLong retry
     /// path. Mirrors the pre-turn pipeline — runtime system prefix is
     /// protected, SM-compact is tried first (zero API calls), the LLM
@@ -179,16 +248,9 @@ impl UnifiedMessageProcessor {
             ) {
                 // SM-compact not enough — fall through to LLM compaction on
                 // the SM-compacted tail.
-                let mut state = self.compaction_state.lock().await;
-                let (compacted, llm_outcome) = ContextCompactor::compact(
-                    &cleaned_tail,
-                    budget_tokens,
-                    &self.runtime.resolved.compaction,
-                    &mut state,
-                    self.runtime.provider.as_ref(),
-                    &self.runtime.model,
-                )
-                .await;
+                let (compacted, llm_outcome) = self
+                    .reactive_llm_compact_with_rescue(session_id, &cleaned_tail, budget_tokens)
+                    .await;
                 let cleaned = crate::model_context::cleanup::post_compact_cleanup(compacted);
                 *messages = append_compacted_tail(&prefix, cleaned);
                 outcome = llm_outcome;
@@ -211,16 +273,9 @@ impl UnifiedMessageProcessor {
             // long — resending it with a summary request appended would be
             // rejected identically. The side-query path with head-dropping
             // PTL retries is the only viable shape mid-turn.
-            let mut state = self.compaction_state.lock().await;
-            let (compacted, llm_outcome) = ContextCompactor::compact(
-                &compactable_tail,
-                budget_tokens,
-                &self.runtime.resolved.compaction,
-                &mut state,
-                self.runtime.provider.as_ref(),
-                &self.runtime.model,
-            )
-            .await;
+            let (compacted, llm_outcome) = self
+                .reactive_llm_compact_with_rescue(session_id, &compactable_tail, budget_tokens)
+                .await;
             let cleaned = crate::model_context::cleanup::post_compact_cleanup(compacted);
             *messages = append_compacted_tail(&prefix, cleaned);
             outcome = llm_outcome;

--- a/src-tauri/crates/agent-core/src/core/session/turn/processor/compaction.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/processor/compaction.rs
@@ -206,6 +206,11 @@ impl UnifiedMessageProcessor {
             let mut sm_state = self.sm_state.lock().await;
             sm_state.last_summarized_msg_idx = None;
         } else {
+            // No fork-form here (unlike pre-turn): reactive compaction runs
+            // right after the provider REJECTED this exact prefix as too
+            // long — resending it with a summary request appended would be
+            // rejected identically. The side-query path with head-dropping
+            // PTL retries is the only viable shape mid-turn.
             let mut state = self.compaction_state.lock().await;
             let (compacted, llm_outcome) = ContextCompactor::compact(
                 &compactable_tail,
@@ -408,29 +413,64 @@ impl UnifiedMessageProcessor {
         }
 
         if need_llm_compact {
+            // Fork-form summarization inputs: the summary request rides on
+            // the main turn's EXACT wire prefix (same messages after
+            // screenshot resolution + timestamp strip, same tools, same
+            // model/max_tokens/temperature) so it reads the prompt cache
+            // written by the previous turn instead of a cold 200K+ resend.
+            // Ref: claude_code runForkedAgent CacheSafeParams.
+            let fork_tools = self
+                .runtime
+                .tool_registry
+                .get_definitions_budgeted(self.effective_tool_policy().as_ref());
+            let mut fork_messages = crate::core::turn_executor::resolve_screenshot_markers(
+                messages,
+                &self.screenshot_store,
+                &self.runtime.model,
+            );
+            crate::model_context::microcompact::strip_timestamp_metadata(&mut fork_messages);
+            let fork_inputs = crate::model_context::compaction::ForkSummaryInputs {
+                messages: &fork_messages,
+                tools: &fork_tools,
+                model: &self.runtime.model,
+                max_tokens: self.runtime.resolved.max_tokens as u32,
+                temperature: self.runtime.resolved.temperature as f32,
+            };
+
             let mut state = self.compaction_state.lock().await;
-            let (compacted, outcome) = ContextCompactor::compact(
+            let (compacted, outcome) = ContextCompactor::compact_with_fork(
                 &compactable_tail,
                 budget_tokens,
                 &self.runtime.resolved.compaction,
                 &mut state,
                 self.runtime.provider.as_ref(),
                 &self.runtime.model,
+                Some(&fork_inputs),
             )
             .await;
-            let cleaned_tail = crate::model_context::cleanup::post_compact_cleanup(compacted);
-            *messages = append_compacted_tail(&prefix, cleaned_tail);
 
-            if let CompactionOutcome::Truncated { messages_dropped } = outcome {
+            // CC semantics: a failed compaction leaves the history UNCHANGED
+            // and the turn proceeds with the original messages — no silent
+            // truncation, no boundary persist for a no-op. The failure was
+            // already counted toward the circuit breaker inside `compact`.
+            if let CompactionOutcome::Failed { reason } = outcome {
+                warn!(
+                    "[unified_processor] Pre-turn compaction failed for session {} — continuing uncompacted: {}",
+                    session_id, reason
+                );
                 broadcast_agent_warning(
                     session_id,
                     &format!(
-                        "Context compaction fell back to truncation ({} conversation messages dropped without summary)",
-                        messages_dropped
+                        "Context compaction failed ({}); continuing with the uncompacted history",
+                        reason
                     ),
                     "compaction",
                 );
+                return CompactionPhaseOutcome::Continue;
             }
+
+            let cleaned_tail = crate::model_context::cleanup::post_compact_cleanup(compacted);
+            *messages = append_compacted_tail(&prefix, cleaned_tail);
 
             let mut sm_state = self.sm_state.lock().await;
             sm_state.last_summarized_msg_idx = None;

--- a/src-tauri/crates/agent-core/src/core/session/turn/processor/execute.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/processor/execute.rs
@@ -247,19 +247,19 @@ impl UnifiedMessageProcessor {
                 .await;
 
             if let CompactionOutcome::Failed { ref reason } = reactive_outcome {
-                // The provider just rejected the prompt and compaction could
-                // not shrink it — the history is unchanged, so a retry would
-                // fail identically. Surface the error instead of spinning
-                // (CC: reactive compact failure yields prompt_too_long to the
-                // user; no silent truncation).
+                // Reaching Failed here means the normal compactor AND the
+                // manual-force rescue both failed (see
+                // reactive_llm_compact_with_rescue) — typically a provider
+                // outage. The history is unchanged, so a retry would fail
+                // identically; surface the error instead of spinning.
                 warn!(
-                    "[unified_processor] Reactive compaction FAILED for session {} (attempt {}) — surfacing ContextTooLong: {}",
+                    "[unified_processor] Reactive compaction (incl. rescue) FAILED for session {} (attempt {}) — surfacing ContextTooLong: {}",
                     session_id, attempt, reason
                 );
                 broadcast_agent_warning(
                     session_id,
                     &format!(
-                        "Context compaction failed ({}); the conversation is too long for the model — consider /compact or starting a new session",
+                        "Context compaction failed ({}); the conversation exceeds the model's context window",
                         reason
                     ),
                     "compaction",

--- a/src-tauri/crates/agent-core/src/core/session/turn/processor/execute.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/processor/execute.rs
@@ -246,15 +246,25 @@ impl UnifiedMessageProcessor {
                 )
                 .await;
 
-            if let CompactionOutcome::Truncated { messages_dropped } = reactive_outcome {
+            if let CompactionOutcome::Failed { ref reason } = reactive_outcome {
+                // The provider just rejected the prompt and compaction could
+                // not shrink it — the history is unchanged, so a retry would
+                // fail identically. Surface the error instead of spinning
+                // (CC: reactive compact failure yields prompt_too_long to the
+                // user; no silent truncation).
+                warn!(
+                    "[unified_processor] Reactive compaction FAILED for session {} (attempt {}) — surfacing ContextTooLong: {}",
+                    session_id, attempt, reason
+                );
                 broadcast_agent_warning(
                     session_id,
                     &format!(
-                        "Reactive compaction fell back to truncation ({} messages dropped without summary, attempt {})",
-                        messages_dropped, attempt
+                        "Context compaction failed ({}); the conversation is too long for the model — consider /compact or starting a new session",
+                        reason
                     ),
                     "compaction",
                 );
+                return Err(last_err);
             } else if reactive_outcome == CompactionOutcome::Skipped {
                 // The provider just rejected the prompt as too long, yet the
                 // compactor's estimate judged the history within budget — the

--- a/src-tauri/crates/agent-core/src/core/side_query.rs
+++ b/src-tauri/crates/agent-core/src/core/side_query.rs
@@ -350,7 +350,36 @@ fn extract_structured_from_response(
         .tool_calls
         .iter()
         .find(|tc| tc.name == structured_cfg.tool_name)?;
+    // A forced tool call guarantees a `tool_use` block, but not a useful
+    // one: on very large prompts models sometimes emit the call with `{}`
+    // or all-empty fields (observed live: compaction summarizer answered
+    // a 233K-token prompt with completion=2 — an empty emit_summary).
+    // Accepting that as success bypasses the retry chain and hands the
+    // caller an empty payload, so treat it as "no structured output" and
+    // let the normal empty-response retry/fallback path run.
+    if structured_arguments_are_empty(&tool_call.arguments) {
+        warn!(
+            "[side-query] forced tool call '{}' returned empty arguments — treating as empty response",
+            structured_cfg.tool_name
+        );
+        return None;
+    }
     Some(tool_call.arguments.clone())
+}
+
+/// True when forced-tool-call arguments carry no usable payload: `null`,
+/// `{}`, or an object whose fields are all null / blank strings. Non-object
+/// shapes are left to the caller's own schema validation.
+fn structured_arguments_are_empty(arguments: &Value) -> bool {
+    match arguments {
+        Value::Null => true,
+        Value::Object(map) => map.values().all(|field| match field {
+            Value::Null => true,
+            Value::String(text) => text.trim().is_empty(),
+            _ => false,
+        }),
+        _ => false,
+    }
 }
 
 fn build_structured_result(response: &LLMResponse, structured: Value) -> SideQueryResult {

--- a/src-tauri/crates/agent-core/src/core/tests/side_query_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/tests/side_query_tests.rs
@@ -287,6 +287,173 @@ async fn structured_output_extracts_from_tool_call() {
     assert_eq!(structured["summary"], "Files were changed, tests passed");
 }
 
+// ── Empty forced-tool-call arguments (live bug: compaction summarizer
+//     answered a 233K-token prompt with an empty emit_summary `{}`) ──
+
+#[test]
+fn structured_arguments_are_empty_detects_useless_payloads() {
+    use super::structured_arguments_are_empty;
+
+    // Empty shapes → true
+    assert!(structured_arguments_are_empty(&json!(null)));
+    assert!(structured_arguments_are_empty(&json!({})));
+    assert!(structured_arguments_are_empty(&json!({"summary": ""})));
+    assert!(structured_arguments_are_empty(&json!({"summary": "  \n"})));
+    assert!(structured_arguments_are_empty(
+        &json!({"summary": null, "notes": ""})
+    ));
+
+    // Usable payloads → false
+    assert!(!structured_arguments_are_empty(
+        &json!({"summary": "real content"})
+    ));
+    assert!(!structured_arguments_are_empty(
+        &json!({"count": 0, "summary": ""})
+    ));
+    // Non-object shapes are the caller's schema problem, not "empty"
+    assert!(!structured_arguments_are_empty(&json!("bare string")));
+    assert!(!structured_arguments_are_empty(&json!([1, 2])));
+}
+
+/// First call answers the forced tool call with `{}`; the retry (which
+/// drops the tool_choice override) answers with a real tool call. The
+/// empty first response must NOT be accepted as structured output.
+struct EmptyThenGoodProvider {
+    call_count: Mutex<u32>,
+}
+
+#[async_trait]
+impl LLMProvider for EmptyThenGoodProvider {
+    async fn chat(
+        &self,
+        _messages: &[Value],
+        _tools: Option<&[Value]>,
+        _model: &str,
+        _max_tokens: u32,
+        _temperature: f32,
+    ) -> Result<LLMResponse, ProviderError> {
+        let mut count = self.call_count.lock().unwrap();
+        *count += 1;
+        let arguments = if *count == 1 {
+            json!({})
+        } else {
+            json!({"summary": "recovered on retry"})
+        };
+        Ok(LLMResponse {
+            content: None,
+            tool_calls: vec![ToolCallRequest {
+                id: format!("call_{count}"),
+                name: "emit_summary".to_string(),
+                arguments,
+                thought_signature: None,
+            }],
+            finish_reason: crate::providers::finish_reason::STOP.to_string(),
+            usage: HashMap::new(),
+            reasoning_content: None,
+            blocks: Vec::new(),
+            stream_error_kind: None,
+            retry_after_ms: None,
+        })
+    }
+
+    fn default_model(&self) -> &str {
+        "mock-model"
+    }
+
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
+#[tokio::test]
+async fn empty_structured_arguments_trigger_retry_instead_of_success() {
+    let provider = EmptyThenGoodProvider {
+        call_count: Mutex::new(0),
+    };
+    let messages = vec![json!({"role": "user", "content": "Summarize"})];
+    let config = SideQueryConfig {
+        structured: Some(StructuredOutput {
+            tool_name: "emit_summary".to_string(),
+            schema: json!({
+                "type": "object",
+                "properties": { "summary": { "type": "string" } },
+                "required": ["summary"]
+            }),
+        }),
+        ..SideQueryConfig::default()
+    };
+
+    let result = side_query(&provider, &messages, &config, "test-model")
+        .await
+        .unwrap();
+
+    assert_eq!(*provider.call_count.lock().unwrap(), 2);
+    let structured = result.structured.expect("retry should recover");
+    assert_eq!(structured["summary"], "recovered on retry");
+}
+
+/// Both attempts return empty arguments and no text at all → hard error,
+/// never an empty structured "success" (the caller would persist a blank
+/// summary over real history).
+struct AlwaysEmptyStructuredProvider;
+
+#[async_trait]
+impl LLMProvider for AlwaysEmptyStructuredProvider {
+    async fn chat(
+        &self,
+        _messages: &[Value],
+        _tools: Option<&[Value]>,
+        _model: &str,
+        _max_tokens: u32,
+        _temperature: f32,
+    ) -> Result<LLMResponse, ProviderError> {
+        Ok(LLMResponse {
+            content: None,
+            tool_calls: vec![ToolCallRequest {
+                id: "call_1".to_string(),
+                name: "emit_summary".to_string(),
+                arguments: json!({"summary": ""}),
+                thought_signature: None,
+            }],
+            finish_reason: crate::providers::finish_reason::STOP.to_string(),
+            usage: HashMap::new(),
+            reasoning_content: None,
+            blocks: Vec::new(),
+            stream_error_kind: None,
+            retry_after_ms: None,
+        })
+    }
+
+    fn default_model(&self) -> &str {
+        "mock-model"
+    }
+
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+}
+
+#[tokio::test]
+async fn persistently_empty_structured_arguments_return_error() {
+    let provider = AlwaysEmptyStructuredProvider;
+    let messages = vec![json!({"role": "user", "content": "Summarize"})];
+    let config = SideQueryConfig {
+        structured: Some(StructuredOutput {
+            tool_name: "emit_summary".to_string(),
+            schema: json!({
+                "type": "object",
+                "properties": { "summary": { "type": "string" } },
+                "required": ["summary"]
+            }),
+        }),
+        ..SideQueryConfig::default()
+    };
+
+    let result = side_query(&provider, &messages, &config, "test-model").await;
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("empty content"));
+}
+
 #[tokio::test]
 async fn structured_output_sends_tool_with_choice_override() {
     let provider = MockProvider::with_tool_call("emit_summary", json!({"summary": "ok"}));

--- a/src-tauri/crates/agent-core/src/core/turn_executor/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/turn_executor/mod.rs
@@ -11,6 +11,7 @@ mod length_recovery;
 #[cfg(debug_assertions)]
 pub mod provider_request_capture;
 mod screenshot;
+pub(crate) use screenshot::resolve_screenshot_markers;
 mod stream_error_recovery;
 pub(crate) mod stream_normalizer;
 pub(crate) mod tool_execution;
@@ -61,7 +62,6 @@ use stream_normalizer::{NormalizedStreamEvent, TurnStreamNormalizer};
 use crate::model_context::microcompact;
 
 use length_recovery::{maybe_recover_from_length, LengthRecoveryOutcome};
-use screenshot::resolve_screenshot_markers;
 use stream_error_recovery::{handle_stream_error, RetryBudgets, StreamErrorOutcome};
 use tool_execution::{execute_tool_calls, is_cancelled, ToolBatchOutcome};
 use usage_accumulator::UsageTotals;

--- a/src-tauri/crates/agent-core/src/core/turn_executor/screenshot.rs
+++ b/src-tauri/crates/agent-core/src/core/turn_executor/screenshot.rs
@@ -60,7 +60,7 @@ fn is_vision_model(model: &str) -> bool {
 /// native format (e.g. Anthropic's `image` block).
 ///
 /// For text-only models the markers are simply stripped.
-pub(super) fn resolve_screenshot_markers(
+pub(crate) fn resolve_screenshot_markers(
     messages: &[Value],
     store: &ScreenshotStore,
     model: &str,

--- a/src-tauri/crates/agent-core/src/state/commands/channel_handler/slash.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/channel_handler/slash.rs
@@ -80,20 +80,14 @@ pub(super) async fn handle_command(
 
             match run_manual_compact(state, &target_sid, &reset_policy).await {
                 ManualCompactResult::Forked(s) => {
-                    let suffix = if s.truncated {
-                        "\n_(Note: compactor fell back to truncation — older context dropped without summary.)_"
-                    } else {
-                        ""
-                    };
                     format!(
-                        "🗜️ Context compacted.\nCompressed: {} → {} messages (~{} → ~{} tokens).\nContinuing in new session `{}` (previous: `{}`).{}",
+                        "🗜️ Context compacted.\nCompressed: {} → {} messages (~{} → ~{} tokens).\nContinuing in new session `{}` (previous: `{}`).",
                         s.messages_before,
                         s.messages_after,
                         s.tokens_before,
                         s.tokens_after,
                         s.new_session_id,
                         s.old_session_id,
-                        suffix,
                     )
                 }
                 ManualCompactResult::AlreadyCompact { message_count, tokens } => format!(


### PR DESCRIPTION
## Summary

Fixes the "compaction makes context bigger" / empty-summary failures observed live (a 233K-token session answered the summarizer with an empty `emit_summary {}`). Four aligned changes, each verified against the reference harness implementation:

- **Reject empty forced-tool-call args in side query** — a forced tool call guarantees a `tool_use` block but not a useful one; `{}` / all-blank payloads now route into the empty-response retry chain instead of being accepted as success.
- **Plain-text summary output instead of a forced `emit_summary` tool call** — the reference harness streams the compact summary as normal assistant text; forcing a 9-section summary into a single tool-call string argument is what made models bail with `{}` on huge prompts.
- **Failure never truncates** — `CompactionOutcome::Truncated` is replaced by `Failed { reason }` and the history is returned **unchanged**. Pre-turn path continues uncompacted with a visible warning (retry next turn, 3-failure circuit breaker); reactive path surfaces ContextTooLong to the user instead of spinning; gateway `/compact` reports the error instead of forking an unchanged transcript. The old silent `simple_truncate` fallback is what produced the "compacted but grew" boundary cards. (The bounded turn-executor context-rescue truncation for subagents without a compactor is intentionally kept.)
- **Fork-form summarization (prompt-cache sharing)** — the pre-turn summary request now rides the main turn's exact wire prefix (same messages/tools/model/max_tokens, summary request marked `volatile` so the trailing cache breakpoint stays put), reading the prompt cache written by the previous turn instead of a cold full-prompt resend (reference data: ~98% cache miss without prefix sharing). Fork failure falls back to the side-query path transparently.

Also migrates stale `summaryMaxTokens: 4096` overrides in agent definitions / builtin overlays to the current 20_000 default (old default frozen on disk as if user-chosen; 4k truncates the summary mid-section).

## Test plan

- `cargo test -p agent_core --lib compaction` — 102 passed, including new tests:
  - failure returns history unchanged (no truncation), circuit-breaker open returns `Failed` without calling the provider
  - fork path uses the main-turn prefix/tools/model/max_tokens and accepts plain-text replies; summary-model override does not leak into the fork
  - fork failure degrades to the side-query path
  - stale-4096 migration: migrates exactly 4096, leaves user-chosen values and missing fields alone
- `cargo test -p agent_core` — 2878 passed; the 7 failures (inbox_drain/lifecycle/search_tool) reproduce on a clean checkout of the base commit and are unrelated to this change
- `cargo check` / `cargo fmt --check` / clippy (pre-commit) clean
- Not live-verified: requires a real 200K+ session to trigger compaction; the failure paths are covered by the unit tests above

## Submit checklist

- [x] The PR is focused and has a scoped Conventional Commits title, such as `feat(scope): summary` or `fix(scope): summary`.
- [x] I ran the relevant checks, or explained why they were not run.
- [x] No secrets, private config, generated output, or unrelated formatting changes are included.
- [x] Docs, screenshots, and locale updates are included when the change needs them. (N/A — backend-only, no user-facing strings beyond warning copy already in the diff.)