### PR TITLE
fix(codex): classify responses stream failures

### DIFF
--- a/src-tauri/crates/agent-core/src/core/providers/codex_native/streaming.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/codex_native/streaming.rs
@@ -27,6 +27,71 @@ fn is_codex_auth_error_message(message: &str) -> bool {
         || lower.contains("expired") && lower.contains("token")
 }
 
+fn classify_codex_stream_error(message: String) -> ProviderError {
+    let lower = message.to_ascii_lowercase();
+
+    if is_codex_auth_error_message(&message) {
+        ProviderError::AuthError(message)
+    } else if lower.contains("context_length_exceeded")
+        || lower.contains("context window")
+        || lower.contains("maximum context length")
+        || lower.contains("prompt is too long")
+        || lower.contains("input is too long")
+    {
+        ProviderError::ContextTooLong(message)
+    } else if lower.contains("rate_limit") || lower.contains("rate limit") {
+        ProviderError::RateLimited {
+            message,
+            retry_after_secs: None,
+        }
+    } else if lower.contains("overloaded") || lower.contains("capacity") {
+        ProviderError::Overloaded {
+            message,
+            retry_after_secs: None,
+        }
+    } else if lower.contains("model_not_found") || lower.contains("model not found") {
+        ProviderError::ModelNotFound(message)
+    } else {
+        ProviderError::RequestFailed(message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::classify_codex_stream_error;
+    use crate::providers::traits::ProviderError;
+
+    #[test]
+    fn classifies_context_failure_as_non_retryable() {
+        let error = classify_codex_stream_error(
+            "Input rejected (code=context_length_exceeded, type=invalid_request_error)".to_string(),
+        );
+
+        assert!(matches!(error, ProviderError::ContextTooLong(_)));
+    }
+
+    #[test]
+    fn classifies_rate_limit_and_overload_failures() {
+        let rate_limit = classify_codex_stream_error(
+            "Rate limit reached (code=rate_limit_exceeded)".to_string(),
+        );
+        let overload =
+            classify_codex_stream_error("Service unavailable (type=overloaded_error)".to_string());
+
+        assert!(matches!(rate_limit, ProviderError::RateLimited { .. }));
+        assert!(matches!(overload, ProviderError::Overloaded { .. }));
+    }
+
+    #[test]
+    fn keeps_unclassified_server_failure_retryable() {
+        let error = classify_codex_stream_error(
+            "Internal failure (code=internal_error, type=server_error)".to_string(),
+        );
+
+        assert!(matches!(error, ProviderError::RequestFailed(_)));
+    }
+}
+
 #[async_trait]
 impl LLMProvider for CodexNativeClient {
     async fn chat(
@@ -320,7 +385,7 @@ impl LLMProvider for CodexNativeClient {
                                     }
                                     return Err(ProviderError::AuthError(error_msg));
                                 }
-                                return Err(ProviderError::RequestFailed(error_msg));
+                                return Err(classify_codex_stream_error(error_msg));
                             }
                             ResponsesStreamOutput::UnknownFrame { event_type, sample } => {
                                 warn!(event_type, sample, "[codex-native] unknown stream frame");

--- a/src-tauri/crates/agent-core/src/core/providers/responses_common/parser.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/responses_common/parser.rs
@@ -209,6 +209,9 @@ mod tests {
             usage: None,
             error: Some(ResponsesError {
                 message: Some("Rate limit exceeded".to_string()),
+                code: None,
+                error_type: None,
+                param: None,
             }),
         };
 

--- a/src-tauri/crates/agent-core/src/core/providers/responses_common/streaming_events.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/responses_common/streaming_events.rs
@@ -122,11 +122,18 @@ impl ResponsesStreamNormalizer {
                 }
             }
             ResponseStreamEventKind::Error => {
-                let message = event
-                    .response
-                    .and_then(|response| response.error)
-                    .and_then(|error| error.message)
-                    .unwrap_or_else(|| "Unknown streaming error".to_string());
+                let error = event
+                    .error
+                    .or_else(|| event.response.and_then(|response| response.error));
+                let message = error
+                    .as_ref()
+                    .map(|error| error.display_message())
+                    .unwrap_or_else(|| {
+                        format!(
+                            "Responses API returned {} without an error payload",
+                            event.event_type
+                        )
+                    });
                 outputs.push(ResponsesStreamOutput::Error(message));
             }
             ResponseStreamEventKind::Unknown(event_type) => {
@@ -275,7 +282,7 @@ impl ResponseStreamEventKind {
             "response.output_item.added" => Self::OutputItemAdded,
             "response.function_call_arguments.done" => Self::FunctionCallArgumentsDone,
             "response.completed" => Self::Completed,
-            "error" => Self::Error,
+            "error" | "response.failed" => Self::Error,
             "response.created"
             | "response.in_progress"
             | "response.output_item.done"
@@ -438,6 +445,100 @@ mod tests {
         assert!(matches!(
             completion.as_slice(),
             [ResponsesStreamOutput::ResponseCompleted(_)]
+        ));
+    }
+
+    #[test]
+    fn normalizes_top_level_error_event() {
+        let mut normalizer = ResponsesStreamNormalizer::new();
+
+        let outputs = normalizer.ingest(event(json!({
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "code": "context_length_exceeded",
+                "message": "Your input exceeds the context window."
+            }
+        })));
+
+        assert!(matches!(
+            outputs.as_slice(),
+            [ResponsesStreamOutput::Error(message)]
+                if message.starts_with("Your input exceeds the context window.")
+                    && message.contains("code=context_length_exceeded")
+                    && message.contains("type=invalid_request_error")
+        ));
+    }
+
+    #[test]
+    fn normalizes_response_failed_error_envelope() {
+        let mut normalizer = ResponsesStreamNormalizer::new();
+
+        let outputs = normalizer.ingest(event(json!({
+            "type": "response.failed",
+            "response": {
+                "output": [],
+                "usage": null,
+                "error": {
+                    "type": "server_error",
+                    "code": "internal_error",
+                    "message": "The service encountered an internal error."
+                }
+            }
+        })));
+
+        assert!(matches!(
+            outputs.as_slice(),
+            [ResponsesStreamOutput::Error(message)]
+                if message.starts_with("The service encountered an internal error.")
+                    && message.contains("code=internal_error")
+                    && message.contains("type=server_error")
+        ));
+    }
+
+    #[test]
+    fn preserves_error_code_when_message_is_missing() {
+        let mut normalizer = ResponsesStreamNormalizer::new();
+
+        let outputs = normalizer.ingest(event(json!({
+            "type": "response.failed",
+            "response": {
+                "output": [],
+                "usage": null,
+                "error": {
+                    "type": "invalid_request_error",
+                    "code": "context_length_exceeded",
+                    "param": "input"
+                }
+            }
+        })));
+
+        assert!(matches!(
+            outputs.as_slice(),
+            [ResponsesStreamOutput::Error(message)]
+                if message.contains("code=context_length_exceeded")
+                    && message.contains("type=invalid_request_error")
+                    && message.contains("param=input")
+        ));
+    }
+
+    #[test]
+    fn reports_missing_error_payload_without_claiming_unknown_streaming_failure() {
+        let mut normalizer = ResponsesStreamNormalizer::new();
+
+        let outputs = normalizer.ingest(event(json!({
+            "type": "response.failed",
+            "response": {
+                "output": [],
+                "usage": null,
+                "error": null
+            }
+        })));
+
+        assert!(matches!(
+            outputs.as_slice(),
+            [ResponsesStreamOutput::Error(message)]
+                if message == "Responses API returned response.failed without an error payload"
         ));
     }
 

--- a/src-tauri/crates/agent-core/src/core/providers/responses_common/types.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/responses_common/types.rs
@@ -115,9 +115,50 @@ pub struct ResponsesUsage {
 }
 
 /// Error from the Responses API.
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct ResponsesError {
     pub message: Option<String>,
+    #[serde(default)]
+    pub code: Option<String>,
+    #[serde(rename = "type", default)]
+    pub error_type: Option<String>,
+    #[serde(default)]
+    pub param: Option<String>,
+}
+
+impl ResponsesError {
+    pub fn display_message(&self) -> String {
+        let mut details = Vec::new();
+        if let Some(code) = self.code.as_deref().filter(|code| !code.is_empty()) {
+            details.push(format!("code={code}"));
+        }
+        if let Some(error_type) = self
+            .error_type
+            .as_deref()
+            .filter(|error_type| !error_type.is_empty())
+        {
+            details.push(format!("type={error_type}"));
+        }
+        if let Some(param) = self.param.as_deref().filter(|param| !param.is_empty()) {
+            details.push(format!("param={param}"));
+        }
+
+        if let Some(message) = self
+            .message
+            .as_deref()
+            .filter(|message| !message.is_empty())
+        {
+            if details.is_empty() {
+                message.to_string()
+            } else {
+                format!("{message} ({})", details.join(", "))
+            }
+        } else if details.is_empty() {
+            "Responses API returned an error without details".to_string()
+        } else {
+            format!("Responses API error ({})", details.join(", "))
+        }
+    }
 }
 
 // ============================================
@@ -136,9 +177,13 @@ pub struct ResponsesError {
 pub struct StreamEvent {
     #[serde(rename = "type")]
     pub event_type: String,
-    /// Present on response.completed
+    /// Present on response.completed and response.failed.
     #[serde(default)]
     pub response: Option<ResponsesResponse>,
+    /// Present on top-level `error` events. Some Responses-compatible
+    /// backends put the error here instead of under `response.error`.
+    #[serde(default)]
+    pub error: Option<ResponsesError>,
     /// Present on text delta events
     pub delta: Option<String>,
     pub call_id: Option<String>,


### PR DESCRIPTION
Pre-commit hook ran. Total eslint: 0, total circular: 0

## Summary

-

## Test plan

-

## Submit checklist

- [ ] The PR is focused and has a scoped Conventional Commits title, such as `feat(scope): summary` or `fix(scope): summary`.
- [ ] I ran the relevant checks, or explained why they were not run.
- [ ] No secrets, private config, generated output, or unrelated formatting changes are included.
- [ ] Docs, screenshots, and locale updates are included when the change needs them.
