### PR TITLE
feat(UI): simplify macOS window surfaces and sidebar navigation

### DIFF
--- a/docs/frontend-ui-audit-2026-07-11/BackgroundLayer.md
+++ b/docs/frontend-ui-audit-2026-07-11/BackgroundLayer.md
@@ -1,0 +1,46 @@
+# Frontend UI Audit — BackgroundLayer / native macOS sidebar
+
+**Files:** `src/modules/shared/components/BackgroundLayer/index.tsx`, `src/modules/index.tsx`, `src/scaffold/NavigationSidebar/SidebarBase.tsx`
+**Date:** 2026-07-11
+**Auditor:** Codex
+
+## D1 — Raw HTML vs Design System
+
+| Line                            | Element                  | Verdict          | Reason                                                                                                                                                            | Suggested change |
+| ------------------------------- | ------------------------ | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `BackgroundLayer/index.tsx:112` | Background frame `<div>` | keep with reason | This is a non-interactive clipping/layout layer, not a control or content surface; a design-system component would add semantics and chrome that do not apply.    | —                |
+| `BackgroundLayer/index.tsx:122` | Background paint `<div>` | keep with reason | This element is the actual CSS image/color paint target read by the native-background bridge through `data-background-layer`; it must remain a plain DOM surface. | —                |
+
+## D2 — Arbitrary Tailwind Value vs Token
+
+| Line | Value | Verdict          | Reason                                                                                                                                                                        | Suggested change |
+| ---- | ----- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| —    | —     | keep with reason | No arbitrary Tailwind values, raw color literals, or duplicated utility formulas were introduced. Geometry that depends on live sidebar width remains in typed inline styles. | —                |
+
+## D3 — Hardcoded Sizes / Colors
+
+| Line                            | Value                              | Verdict          | Reason                                                                                                                                                                                                                        | Suggested change |
+| ------------------------------- | ---------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `BackgroundLayer/index.tsx:94`  | `height: "100vh"`                  | keep with reason | The background frame intentionally covers the native window viewport independently of route content height.                                                                                                                   | —                |
+| `BackgroundLayer/index.tsx:112` | Shared `layout-panel-motion` class | keep with reason | Reuses the layout motion duration/easing and reduced-motion rule added for the sidebar, while overriding only `transition-property` to `left`; it also honors the layout-animation setting and disables motion during resize. | —                |
+| `BackgroundLayer/index.tsx:126` | Glass opacity `0.5`                | keep with reason | Preserves the existing content-area tint used in glass mode; the tint is now clipped away from the native sidebar rather than visually changed.                                                                               | —                |
+| `BackgroundLayer/index.tsx:137` | Blur scale `1.05`                  | keep with reason | Preserves the existing overscan required to prevent transparent edges when the user applies background blur; the new overflow frame clips that overscan before it reaches the sidebar.                                        | —                |
+
+## D4 — Accessibility
+
+| Line                            | Element          | Verdict          | Reason                                                                                                                                                                            | Suggested change |
+| ------------------------------- | ---------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `BackgroundLayer/index.tsx:112` | Background frame | keep with reason | The decorative layer is non-interactive and has `pointer-events-none`; it adds no focus target or misleading accessible control. Shared motion respects `prefers-reduced-motion`. | —                |
+
+## D5 — Visual Patterns Observed
+
+- Pattern: docked macOS chrome reveals one native window material, while app wallpaper/color begins at the live sidebar boundary.
+- Pattern: background inset motion consumes the same panel-motion class and user preference as the sidebar instead of defining a second animation token.
+- Pattern: floating/forced-visible sidebars remain solid for legibility; only the docked macOS sidebar uses the native material.
+- No multi-file sweep candidate was found beyond the shared motion token already consumed here.
+
+## Summary
+
+- 0 fixes recommended
+- 8 kept with documented reason
+- 0 abstract candidates (>= 3 occurrences)

--- a/docs/frontend-ui-audit-2026-07-11/PaneTransitions.md
+++ b/docs/frontend-ui-audit-2026-07-11/PaneTransitions.md
@@ -1,0 +1,24 @@
+# Pane transitions UI audit
+
+Scope: opening, closing, focusing, and resizing behavior for the primary navigation sidebar, workstation surface, and chat pane.
+
+| Line                        | Element                        | Verdict          | Reason                                                                                                                                                                                                      | Suggested change |
+| --------------------------- | ------------------------------ | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `viewContainerTokens.ts:25` | Shared pane transition token   | abstract         | One reduced-motion-aware token coordinates the timing and limits animation to real layout dimensions; no transform or opacity layer is introduced.                                                          | None.            |
+| `viewContainerTokens.ts:35` | Chat/workstation flex geometry | abstract         | Pure helpers express visible, hidden, and focused widths as normal-flow flex values, keeping intermediate widths observable and unit-testable.                                                              | None.            |
+| `SidebarBase.tsx:237`       | Sidebar width model            | keep with reason | The outer sidebar animates to zero while its existing surface retains the exact persisted expanded width behind an existing overflow clip, preventing content reflow and avoiding a duplicate render layer. | None.            |
+| `SidebarBase.tsx:553`       | Sidebar interaction state      | keep with reason | Collapsed content remains mounted for the exit animation but is `aria-hidden`, non-interactive, and releases keyboard focus; the resize handle is removed only while collapsed.                             | None.            |
+| `AppLayout.tsx:193`         | Chat mount policy              | keep with reason | Chat remains mounted at zero width only while a workstation route owns the slot, preserving close/open motion without retaining the heavy panel on unrelated routes.                                        | None.            |
+| `AppLayout.tsx:264`         | Chat pane container            | keep with reason | The existing chat container stays in normal flex flow and transitions its exact configured width; it does not create an absolute overlay when focused.                                                      | None.            |
+| `AppLayout.tsx:298`         | Workstation surface            | keep with reason | Workstation and chat exchange flex growth in the existing row, and transition completion re-notifies native webview layout consumers.                                                                       | None.            |
+| `useChatPanelResize.ts:144` | Manual chat resize             | keep with reason | A shared transient dragging atom disables pane transitions during direct manipulation, so the rendered edge tracks the pointer without easing lag.                                                          | None.            |
+| `useNarrowChatFocus.ts:110` | Narrow-layout width evaluation | fix              | Programmatic reopen now evaluates the projected target width instead of transient animation frames, preventing chat from immediately re-maximizing and hiding the center resize handle.                     | None.            |
+| `AppLayout.tsx:202`         | Shared pane-row underlay       | keep with reason | The existing flex row paints the theme-aware chat surface beneath both panes, preventing background flashes from subpixel rounding without adding another DOM or absolute layer.                            | None.            |
+| `ChatPanelShell.tsx:51`     | Full-height resize divider     | fix              | The existing 1px handle overlaps inside the exact pane width and sits above pinned headers and the composer, keeping its line and hit area continuous without changing width calculations.                  | None.            |
+
+## Summary
+
+- Fix: 2
+- Keep with reason: 7
+- Abstract: 2
+- Sweep candidates: 0

--- a/docs/frontend-ui-audit-2026-07-11/SidebarEdgeLayering.md
+++ b/docs/frontend-ui-audit-2026-07-11/SidebarEdgeLayering.md
@@ -1,0 +1,19 @@
+# Sidebar edge layering UI audit
+
+Scope: theme-aware macOS sidebar depth at the vertical content boundary and its user-facing Appearance control.
+
+| Line                          | Element                      | Verdict          | Reason                                                                                                                                                    | Suggested change |
+| ----------------------------- | ---------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `AppearanceSection.tsx:180`   | Sidebar appearance controls  | keep with reason | The macOS-only edge-depth option reuses the shared `SectionRow` and `Switch` components and sits with the related sidebar opacity and selection controls. | None.            |
+| `general.ts:144`              | Persisted edge-depth setting | keep with reason | A schema-backed boolean provides validation, migration-safe defaulting, and the same persistence path as adjacent appearance settings.                    | None.            |
+| `SidebarBase.tsx:460`         | Sidebar edge rendering       | abstract         | The shared sidebar shell consumes one setting and one semantic theme token, so all sidebar variants react immediately without duplicating styling logic.  | None.            |
+| `orgii_main.css:128`          | Light edge token             | keep with reason | The light theme uses a deliberately restrained inset shadow alongside the existing separator.                                                             | None.            |
+| `orgii_dark.css:128`          | Dark edge token              | keep with reason | The dark theme increases both separator contrast and depth falloff so the boundary remains perceptible on dark surfaces.                                  | None.            |
+| `orgii_high_contrast.css:125` | High-contrast edge token     | keep with reason | High contrast disables the decorative shadow and relies on its stronger existing border.                                                                  | None.            |
+
+## Summary
+
+- Fix: 0
+- Keep with reason: 5
+- Abstract: 1
+- Sweep candidates: 0

--- a/public/error.html
+++ b/public/error.html
@@ -28,7 +28,7 @@
         position: fixed;
         inset: 0;
         background-color: #f5f5f5;
-        border-radius: 26px;
+        border-radius: 10px;
         overflow: hidden;
         display: flex;
         flex-direction: column;

--- a/public/index.html
+++ b/public/index.html
@@ -51,6 +51,8 @@
           pageVal = "12px";
           html.dataset.hostDesktop = "linux";
         } else {
+          winVal = "10px";
+          pageVal = "20px";
           html.dataset.hostDesktop = "macos";
         }
         if (winVal) {
@@ -261,7 +263,7 @@
     </script>
     <style nonce="orgii-codemirror-style">
       :root {
-        --border-radius-window: 26px;
+        --border-radius-window: 10px;
       }
       * {
         margin: 0;

--- a/public/orgii_dark.css
+++ b/public/orgii_dark.css
@@ -116,7 +116,7 @@ body {
   --sidebar-tab-pill-selected-shadow: 0 1px 3px rgba(0, 0, 0, 0.18);
 
   /* Sidebar */
-  --sidebar-bg: rgba(27, 28, 31, 0.84);
+  --sidebar-bg: rgba(23, 24, 27, 0.88);
   --sidebar-border: rgba(255, 255, 255, 0.1);
   --sidebar-backdrop: blur(12px) saturate(150%);
   --sidebar-shadow: 0 1px 2px rgba(0, 0, 0, 0.2), 0 8px 24px rgba(0, 0, 0, 0.3);

--- a/public/orgii_dark.css
+++ b/public/orgii_dark.css
@@ -118,6 +118,12 @@ body {
   /* Sidebar */
   --sidebar-bg: rgba(23, 24, 27, 0.88);
   --sidebar-border: rgba(255, 255, 255, 0.1);
+  --sidebar-selected-row-opacity: 5%;
+  --sidebar-selected-row-bg: color-mix(
+    in oklab,
+    var(--color-text-1) var(--sidebar-selected-row-opacity),
+    transparent
+  );
   --sidebar-backdrop: blur(12px) saturate(150%);
   --sidebar-shadow: 0 1px 2px rgba(0, 0, 0, 0.2), 0 8px 24px rgba(0, 0, 0, 0.3);
 

--- a/public/orgii_dark.css
+++ b/public/orgii_dark.css
@@ -125,6 +125,9 @@ body {
     transparent
   );
   --sidebar-backdrop: blur(12px) saturate(150%);
+  --sidebar-edge-shadow:
+    inset -1px 0 0 rgba(255, 255, 255, 0.07),
+    inset -8px 0 12px -12px rgba(0, 0, 0, 0.9);
   --sidebar-shadow: 0 1px 2px rgba(0, 0, 0, 0.2), 0 8px 24px rgba(0, 0, 0, 0.3);
 
   /* Start Page */

--- a/public/orgii_high_contrast.css
+++ b/public/orgii_high_contrast.css
@@ -115,6 +115,12 @@ body {
   /* Sidebar */
   --sidebar-bg: rgba(4, 4, 4, 0.9);
   --sidebar-border: rgba(255, 255, 255, 0.22);
+  --sidebar-selected-row-opacity: 5%;
+  --sidebar-selected-row-bg: color-mix(
+    in oklab,
+    var(--color-text-1) var(--sidebar-selected-row-opacity),
+    transparent
+  );
   --sidebar-backdrop: blur(8px) saturate(120%);
   --sidebar-shadow: none;
 

--- a/public/orgii_high_contrast.css
+++ b/public/orgii_high_contrast.css
@@ -122,6 +122,7 @@ body {
     transparent
   );
   --sidebar-backdrop: blur(8px) saturate(120%);
+  --sidebar-edge-shadow: none;
   --sidebar-shadow: none;
 
   /* Start Page */

--- a/public/orgii_main.css
+++ b/public/orgii_main.css
@@ -125,6 +125,9 @@ body {
     transparent
   );
   --sidebar-backdrop: blur(10px) saturate(140%);
+  --sidebar-edge-shadow:
+    inset -1px 0 0 rgba(0, 0, 0, 0.015),
+    inset -8px 0 12px -12px rgba(0, 0, 0, 0.12);
   --sidebar-shadow:
     0 1px 2px rgba(0, 0, 0, 0.04), 0 8px 24px rgba(0, 0, 0, 0.08);
 

--- a/public/orgii_main.css
+++ b/public/orgii_main.css
@@ -118,6 +118,12 @@ body {
   /* Sidebar */
   --sidebar-bg: rgba(242, 242, 242, 0.78);
   --sidebar-border: rgba(0, 0, 0, 0.08);
+  --sidebar-selected-row-opacity: 5%;
+  --sidebar-selected-row-bg: color-mix(
+    in oklab,
+    var(--color-text-1) var(--sidebar-selected-row-opacity),
+    transparent
+  );
   --sidebar-backdrop: blur(10px) saturate(140%);
   --sidebar-shadow:
     0 1px 2px rgba(0, 0, 0, 0.04), 0 8px 24px rgba(0, 0, 0, 0.08);

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -239,7 +239,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -250,7 +250,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -309,9 +309,9 @@ dependencies = [
  "objc2-foundation",
  "serde",
  "tauri",
+ "tauri-plugin-liquid-glass",
  "tracing",
  "url",
- "window-vibrancy",
  "windows 0.61.3",
 ]
 
@@ -813,6 +813,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1254,6 +1260,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "cocoa"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad36507aeb7e16159dfe68db81ccc27571c3ccd4b76fb2fb72fc59e7a4b1b64c"
+dependencies = [
+ "bitflags 2.13.0",
+ "block",
+ "cocoa-foundation",
+ "core-foundation",
+ "core-graphics 0.24.0",
+ "foreign-types",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
+dependencies = [
+ "bitflags 2.13.0",
+ "block",
+ "core-foundation",
+ "core-graphics-types",
+ "objc",
 ]
 
 [[package]]
@@ -1975,8 +2010,14 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "dispatch2"
@@ -2260,7 +2301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3474,7 +3515,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4358,6 +4399,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4692,7 +4742,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4825,6 +4875,15 @@ dependencies = [
  "sha2",
  "thiserror 1.0.69",
  "url",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -5230,6 +5289,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-drag",
  "tauri-plugin-fs",
+ "tauri-plugin-liquid-glass",
  "tauri-plugin-notification",
  "tauri-plugin-oauth",
  "tauri-plugin-opener",
@@ -5303,7 +5363,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6054,7 +6114,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -6696,7 +6756,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6763,7 +6823,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7476,7 +7536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8243,6 +8303,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-liquid-glass"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a86fd9cd6fc62cad37daa0d7f8be8f4986543d13dd30e4ff5cd2bc81ff91d0"
+dependencies = [
+ "cocoa",
+ "dispatch",
+ "log",
+ "objc",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "tauri-plugin-notification"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8493,7 +8571,7 @@ dependencies = [
  "serde_with",
  "swift-rs",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "url",
  "urlpattern",
  "uuid",
@@ -8533,7 +8611,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9231,7 +9309,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9874,7 +9952,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -208,6 +208,7 @@ tauri-plugin-store = "2"
 tauri-plugin-drag = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-webdriver-automation = { version = "0.1", optional = true }
+tauri-plugin-liquid-glass = "0.1.6"
 portable-pty = "0.9"
 tokio = { workspace = true }
 uuid = { version = "1", features = ["v4"] }
@@ -234,7 +235,8 @@ app_paths = { path = "crates/app-paths" }
 # `set_sensitive_file_permissions` chmod.
 app_utils = { path = "crates/app-utils" }
 
-# Native window helpers (macOS traffic-light positioning,
+# Native window helpers (macOS traffic-light positioning + liquid-glass
+# background,
 # Windows DWM rounded corners, "Open new window" /
 # "Recreate main window" flows). Used by `app::lib`, the macOS app menu,
 # and `browser::windows`. Synchronous Tauri operations only — no IoC

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -19,6 +19,7 @@
   ],
   "permissions": [
     "core:default",
+    "liquid-glass:default",
     "shell:allow-open",
     "shell:default",
     "shell:allow-spawn",

--- a/src-tauri/crates/app-window/Cargo.toml
+++ b/src-tauri/crates/app-window/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 rust-version = "1.85.0"
 
-# Centralised native-window helpers: macOS traffic-light positioning,
+# Centralised native-window helpers: macOS traffic-light positioning and
+# liquid-glass material,
 # Windows rounded-corner DWM tweaks, and the
 # "Open New Window" / "Recreate main window" flows used by the Tauri menu
 # and the in-app "Open in new window" affordance.
@@ -36,7 +37,7 @@ url = "2"
 
 # macOS-specific native-window plumbing
 [target.'cfg(target_os = "macos")'.dependencies]
-window-vibrancy = "0.6"
+tauri-plugin-liquid-glass = "0.1.6"
 
 # Modern Objective-C bindings. `dispatch2::DispatchQueue::main()` is the
 # typed replacement for `dispatch::Queue::main()` used by `set_window_vibrancy`

--- a/src-tauri/crates/app-window/src/commands.rs
+++ b/src-tauri/crates/app-window/src/commands.rs
@@ -13,9 +13,6 @@
 use tauri::{AppHandle, Manager};
 
 #[cfg(target_os = "macos")]
-use window_vibrancy::clear_vibrancy;
-
-#[cfg(target_os = "macos")]
 use objc2::msg_send;
 #[cfg(target_os = "macos")]
 use objc2::runtime::{AnyClass, AnyObject};
@@ -130,8 +127,10 @@ pub async fn set_window_vibrancy(
     {
         use base64::Engine as _;
 
-        if !enabled {
-            let _ = clear_vibrancy(&window);
+        if enabled {
+            super::apply_macos_window_material(&window);
+        } else {
+            super::clear_macos_window_material(&window);
         }
 
         let image_bytes: Option<Vec<u8>> = bg_image_base64

--- a/src-tauri/crates/app-window/src/lib.rs
+++ b/src-tauri/crates/app-window/src/lib.rs
@@ -1,7 +1,7 @@
 //! Native window helpers for Tauri windows.
 //!
 //! Centralised so `app`, `browser`, and other leaf crates can apply
-//! consistent native chrome (macOS traffic-light positioning,
+//! consistent native chrome (macOS traffic-light positioning + liquid glass,
 //! Windows DWM rounded corners) and recreate the main window
 //! from the Tauri menu without each consumer reimplementing the platform
 //! glue. All operations are synchronous against a `tauri::AppHandle` /
@@ -19,6 +19,8 @@ use objc2::msg_send;
 use objc2::runtime::{AnyClass, AnyObject};
 #[cfg(target_os = "macos")]
 use objc2_app_kit::NSWindowButton;
+#[cfg(target_os = "macos")]
+use tauri_plugin_liquid_glass::{GlassMaterialVariant, LiquidGlassConfig, LiquidGlassExt};
 
 #[cfg(windows)]
 mod windows_corner;
@@ -232,13 +234,42 @@ const DEFAULT_MIN_HEIGHT: f64 = 300.0;
 /// Host-native window chrome so the OS frame matches frontend corner radii.
 ///
 /// - **Windows 11+:** `DWMWCP_ROUNDSMALL` via DWM (pairs with `--radius-page` in the web layer).
-/// - **macOS:** Vibrancy corner radius is applied separately in [`create_window`] / [`set_window_vibrancy`].
+/// - **macOS:** Applied separately through [`apply_macos_window_material`].
 /// - **Linux / others:** No-op.
 pub fn apply_host_desktop_window_chrome(
     #[cfg_attr(not(windows), allow(unused_variables))] window: &tauri::WebviewWindow,
 ) {
     #[cfg(windows)]
     windows_corner::apply_dwm_rounded_corner_preference(window);
+}
+
+/// Apply the native macOS AbuttedSidebar material underneath the transparent webview.
+/// macOS 26+ uses NSGlassEffectView; older releases fall back to
+/// NSVisualEffectView. AppKit owns the outer window clipping; a subtle native
+/// tint keeps the sidebar legible without covering the desktop color.
+#[cfg(target_os = "macos")]
+pub fn apply_macos_window_material(window: &tauri::WebviewWindow) {
+    let config = LiquidGlassConfig {
+        corner_radius: 0.0,
+        tint_color: Some("#ffffff18".into()),
+        variant: GlassMaterialVariant::AbuttedSidebar,
+        ..Default::default()
+    };
+    if let Err(error) = window.liquid_glass().set_effect(window, config) {
+        tracing::warn!(%error, "Failed to apply macOS liquid-glass material");
+    }
+}
+
+/// Remove the native macOS material on AppKit's main thread.
+#[cfg(target_os = "macos")]
+pub fn clear_macos_window_material(window: &tauri::WebviewWindow) {
+    let config = LiquidGlassConfig {
+        enabled: false,
+        ..Default::default()
+    };
+    if let Err(error) = window.liquid_glass().set_effect(window, config) {
+        tracing::warn!(%error, "Failed to clear macOS liquid-glass material");
+    }
 }
 
 // ============================================
@@ -291,7 +322,7 @@ pub struct CreateWindowOptions {
 
 /// Create a new app window with consistent native styling.
 ///
-/// - **macOS:** Hidden title, overlay title bar, traffic lights, vibrancy (26px material radius).
+/// - **macOS:** Hidden title, overlay title bar, traffic lights, and native vibrancy.
 /// - **Windows 11+:** DWM small rounded corners (see [`apply_host_desktop_window_chrome`]).
 /// - **All platforms:** Decorated, transparent client area where supported.
 pub fn create_window(app: &AppHandle, options: CreateWindowOptions) -> Result<(), String> {
@@ -330,6 +361,7 @@ pub fn create_window(app: &AppHandle, options: CreateWindowOptions) -> Result<()
     #[cfg(target_os = "macos")]
     {
         builder = builder
+            .transparent(true)
             .hidden_title(true)
             .title_bar_style(TitleBarStyle::Overlay)
             .traffic_light_position(Position::Logical(LogicalPosition::new(
@@ -352,7 +384,10 @@ pub fn create_window(app: &AppHandle, options: CreateWindowOptions) -> Result<()
 
     // Manually set traffic light position (Tauri's builder method doesn't always work)
     #[cfg(target_os = "macos")]
-    set_traffic_light_position(&window, TRAFFIC_LIGHT_X, TRAFFIC_LIGHT_Y);
+    {
+        set_traffic_light_position(&window, TRAFFIC_LIGHT_X, TRAFFIC_LIGHT_Y);
+        apply_macos_window_material(&window);
+    }
 
     apply_host_desktop_window_chrome(&window);
 
@@ -398,6 +433,7 @@ pub fn recreate_main_window(app: &AppHandle) -> Result<(), String> {
 
     #[cfg(target_os = "macos")]
     let builder = builder
+        .transparent(true)
         .hidden_title(true)
         .title_bar_style(TitleBarStyle::Overlay)
         .traffic_light_position(Position::Logical(LogicalPosition::new(
@@ -413,6 +449,7 @@ pub fn recreate_main_window(app: &AppHandle) -> Result<(), String> {
     {
         set_traffic_light_position(&window, TRAFFIC_LIGHT_X, TRAFFIC_LIGHT_Y);
         apply_window_background_color(&window);
+        apply_macos_window_material(&window);
     }
 
     apply_host_desktop_window_chrome(&window);
@@ -447,6 +484,7 @@ pub fn create_new_app_window(app: &AppHandle) -> Result<(), String> {
 
     #[cfg(target_os = "macos")]
     let builder = builder
+        .transparent(true)
         .hidden_title(true)
         .title_bar_style(TitleBarStyle::Overlay)
         .traffic_light_position(Position::Logical(LogicalPosition::new(
@@ -459,7 +497,10 @@ pub fn create_new_app_window(app: &AppHandle) -> Result<(), String> {
         .map_err(|e| format!("Failed to create app window: {}", e))?;
 
     #[cfg(target_os = "macos")]
-    set_traffic_light_position(&window, TRAFFIC_LIGHT_X, TRAFFIC_LIGHT_Y);
+    {
+        set_traffic_light_position(&window, TRAFFIC_LIGHT_X, TRAFFIC_LIGHT_Y);
+        apply_macos_window_material(&window);
+    }
 
     apply_host_desktop_window_chrome(&window);
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -325,6 +325,7 @@ pub fn run() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_drag::init())
+        .plugin(tauri_plugin_liquid_glass::init())
         .on_window_event(|_window, _event| {
             #[cfg(target_os = "macos")]
             match _event {
@@ -379,6 +380,7 @@ pub fn run() {
                             app_window::TRAFFIC_LIGHT_X,
                             app_window::TRAFFIC_LIGHT_Y,
                         );
+                        app_window::apply_macos_window_material(&main_window);
                     }
 
                     app_window::apply_host_desktop_window_chrome(&main_window);

--- a/src/config/__tests__/sidebarSelectionSettings.test.ts
+++ b/src/config/__tests__/sidebarSelectionSettings.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getSettingsDefaults,
+  validateSettings,
+} from "@src/config/settingsSchema";
+
+describe("sidebar item appearance", () => {
+  it("uses the Codex-equivalent selection default", () => {
+    expect(getSettingsDefaults()["layout.sidebarSelectedRowOpacity"]).toBe(5);
+  });
+
+  it("accepts a user-selected highlight intensity", () => {
+    expect(
+      validateSettings({ "layout.sidebarSelectedRowOpacity": 12 })[
+        "layout.sidebarSelectedRowOpacity"
+      ]
+    ).toBe(12);
+  });
+});

--- a/src/config/__tests__/sidebarSelectionSettings.test.ts
+++ b/src/config/__tests__/sidebarSelectionSettings.test.ts
@@ -17,4 +17,16 @@ describe("sidebar item appearance", () => {
       ]
     ).toBe(12);
   });
+
+  it("enables the sidebar edge depth by default", () => {
+    expect(getSettingsDefaults()["layout.sidebarEdgeDepthEnabled"]).toBe(true);
+  });
+
+  it("accepts disabling the sidebar edge depth", () => {
+    expect(
+      validateSettings({ "layout.sidebarEdgeDepthEnabled": false })[
+        "layout.sidebarEdgeDepthEnabled"
+      ]
+    ).toBe(false);
+  });
 });

--- a/src/config/settingsSchema/registry/general.ts
+++ b/src/config/settingsSchema/registry/general.ts
@@ -141,6 +141,13 @@ export const GENERAL_SETTINGS_REGISTRY = {
     description: "Selected sidebar row highlight intensity percentage",
     category: "general",
   },
+  "layout.sidebarEdgeDepthEnabled": {
+    schema: z.boolean(),
+    default: true,
+    description:
+      "Show a theme-aware depth edge between the macOS sidebar and content panel",
+    category: "general",
+  },
   "general.workStationChatPosition": {
     schema: z.enum(["left", "right"]),
     default: "left" as const,

--- a/src/config/settingsSchema/registry/general.ts
+++ b/src/config/settingsSchema/registry/general.ts
@@ -135,6 +135,12 @@ export const GENERAL_SETTINGS_REGISTRY = {
       center: "Page center",
     },
   },
+  "layout.sidebarSelectedRowOpacity": {
+    schema: z.number().min(0).max(20),
+    default: 5,
+    description: "Selected sidebar row highlight intensity percentage",
+    category: "general",
+  },
   "general.workStationChatPosition": {
     schema: z.enum(["left", "right"]),
     default: "left" as const,

--- a/src/config/windowChromeRadius.ts
+++ b/src/config/windowChromeRadius.ts
@@ -1,7 +1,7 @@
 /**
  * Host-desktop window and page corner radii.
  *
- * macOS values match NSWindow glass rounding (see src-tauri glass config corner_radius 26.0).
+ * macOS uses the standard desktop window curve; native vibrancy is clipped by AppKit.
  * Windows uses smaller radii to align with DWM / Win11 window chrome.
  *
  * Keep magic numbers in sync with the preflight script in public/index.html.
@@ -20,7 +20,7 @@ const CHROME_RADIUS_PX: Record<
   HostDesktop,
   { windowPx: number; pagePx: number }
 > = {
-  [HOST_DESKTOP.MACOS]: { windowPx: 26, pagePx: 20 },
+  [HOST_DESKTOP.MACOS]: { windowPx: 10, pagePx: 20 },
   [HOST_DESKTOP.WINDOWS]: { windowPx: 8, pagePx: 8 },
   [HOST_DESKTOP.LINUX]: { windowPx: 12, pagePx: 12 },
 };

--- a/src/engines/ChatPanel/ChatPanelShell.tsx
+++ b/src/engines/ChatPanel/ChatPanelShell.tsx
@@ -51,6 +51,7 @@ export function ChatPanelShell({
   const dragHandle = showResizeHandle && (
     <VerticalResizeHandle
       key="chat-panel-resize-handle"
+      className={`!z-[80] ${isLeftPosition ? "-ml-px" : "-mr-px"}`}
       onMouseDown={onResizeMouseDown}
       variant={embedded ? "border" : "transparent"}
       noAccent={!embedded}

--- a/src/engines/ChatPanel/hooks/useChatPanelResize.ts
+++ b/src/engines/ChatPanel/hooks/useChatPanelResize.ts
@@ -26,7 +26,11 @@ import {
   useState,
 } from "react";
 
-import { DEFAULT_CHAT_WIDTH, chatWidthAtom } from "@src/store/ui/chatPanelAtom";
+import {
+  DEFAULT_CHAT_WIDTH,
+  chatPanelDraggingAtom,
+  chatWidthAtom,
+} from "@src/store/ui/chatPanelAtom";
 
 import {
   CHAT_WIDTH_CSS_VAR,
@@ -78,6 +82,7 @@ export function useChatPanelResize(
   // OPTIMIZED: Only use setter, don't subscribe to value changes
   // Width is read from CSS variable when needed
   const setChatWidth = useSetAtom(chatWidthAtom);
+  const setChatPanelDragging = useSetAtom(chatPanelDraggingAtom);
   const [isDragging, setIsDragging] = useState(false);
 
   // Refs for pure DOM resize (no React renders during drag)
@@ -141,6 +146,7 @@ export function useChatPanelResize(
         if (!hasDraggedRef.current) {
           hasDraggedRef.current = true;
           setIsDragging(true);
+          setChatPanelDragging(true);
 
           // Set cursor globally - only when actually dragging
           document.body.style.cursor = "ew-resize";
@@ -186,6 +192,7 @@ export function useChatPanelResize(
 
           commitPendingWidth();
           setIsDragging(false);
+          setChatPanelDragging(false);
           hasDraggedRef.current = false;
         }
       };
@@ -202,12 +209,13 @@ export function useChatPanelResize(
         }
         hasDraggedRef.current = false;
         setIsDragging(false);
+        setChatPanelDragging(false);
       };
 
       document.addEventListener("mousemove", handleMouseMove);
       document.addEventListener("mouseup", handleMouseUp);
     },
-    [isLeftPosition, setChatWidth, useExternalWidth]
+    [isLeftPosition, setChatPanelDragging, setChatWidth, useExternalWidth]
   );
 
   // Cleanup drag listeners on unmount

--- a/src/hooks/theme/useGlassMaterial.ts
+++ b/src/hooks/theme/useGlassMaterial.ts
@@ -29,6 +29,10 @@
 import { useAtomValue } from "jotai";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import {
+  HOST_DESKTOP,
+  resolveHostDesktop,
+} from "@src/config/windowChromeRadius";
 import { useMountedCleanup } from "@src/hooks/lifecycle/useMounted";
 import { createLogger } from "@src/hooks/logger";
 // Direct leaf import to avoid pulling @src/store's barrel — which transitively
@@ -48,6 +52,7 @@ import { useCurrentTheme } from "@src/util/ui/theme/themeUtils";
 import { useBackgroundImage } from "./useBackgroundImage";
 
 const log = createLogger("useGlassMaterial");
+const IS_MACOS_HOST = resolveHostDesktop() === HOST_DESKTOP.MACOS;
 
 // Neutral color field used when no background image or color is available
 // (e.g. Glass mode — native OS provides the background, not a URL).
@@ -119,8 +124,11 @@ export function useGlassMaterial(
 
   // Get current context
   const backgroundConfig = useAtomValue(resolvedBackgroundConfigAtom);
-  const backgroundImageUrl = useBackgroundImage();
-  const backgroundColor = backgroundConfig.backgroundColor;
+  const storedBackgroundImageUrl = useBackgroundImage();
+  const backgroundImageUrl = IS_MACOS_HOST ? "" : storedBackgroundImageUrl;
+  const backgroundColor = IS_MACOS_HOST
+    ? undefined
+    : backgroundConfig.backgroundColor;
   const { isDark } = useCurrentTheme();
   const appearance = isDark ? "dark" : "light";
 
@@ -281,8 +289,11 @@ export function useGlassMaterial(
  */
 export function usePreloadGlassMaterials(): { isPreloaded: boolean } {
   const backgroundConfig = useAtomValue(resolvedBackgroundConfigAtom);
-  const backgroundImageUrl = useBackgroundImage();
-  const backgroundColor = backgroundConfig.backgroundColor;
+  const storedBackgroundImageUrl = useBackgroundImage();
+  const backgroundImageUrl = IS_MACOS_HOST ? "" : storedBackgroundImageUrl;
+  const backgroundColor = IS_MACOS_HOST
+    ? undefined
+    : backgroundConfig.backgroundColor;
   const { isDark } = useCurrentTheme();
   const appearance = isDark ? "dark" : "light";
   const [isPreloaded, setIsPreloaded] = useState(false);

--- a/src/hooks/theme/useRegionLuminance.ts
+++ b/src/hooks/theme/useRegionLuminance.ts
@@ -22,6 +22,10 @@
 import { useAtomValue } from "jotai";
 import { useEffect, useMemo, useState } from "react";
 
+import {
+  HOST_DESKTOP,
+  resolveHostDesktop,
+} from "@src/config/windowChromeRadius";
 import { createLogger } from "@src/hooks/logger";
 import { resolvedBackgroundConfigAtom } from "@src/store";
 import { useCurrentTheme } from "@src/util/ui/theme/themeUtils";
@@ -41,6 +45,7 @@ import type {
 import { useBackgroundImage } from "./useBackgroundImage";
 
 const log = createLogger("RegionLuminance");
+const IS_MACOS_HOST = resolveHostDesktop() === HOST_DESKTOP.MACOS;
 
 // ============================================
 // Hook
@@ -62,7 +67,9 @@ export function useRegionLuminance(): UseRegionLuminanceReturn {
   const backgroundConfig = useAtomValue(resolvedBackgroundConfigAtom);
   const currentImageUrl = useBackgroundImage();
   const shouldUseAdaptiveColors = Boolean(
-    backgroundConfig.adaptiveColors && backgroundConfig.selectedImageId
+    !IS_MACOS_HOST &&
+    backgroundConfig.adaptiveColors &&
+    backgroundConfig.selectedImageId
   );
   const adaptiveImageUrl = shouldUseAdaptiveColors ? currentImageUrl : "";
   const { isDark } = useCurrentTheme();

--- a/src/hooks/ui/sidebar/useSidebarState.ts
+++ b/src/hooks/ui/sidebar/useSidebarState.ts
@@ -31,6 +31,8 @@ import {
 export interface UseSidebarStateReturn {
   /** Current sidebar width in pixels (0 if collapsed) */
   width: number;
+  /** Persisted expanded width, even while the sidebar is collapsed. */
+  expandedWidth: number;
   /** Whether sidebar is collapsed */
   isCollapsed: boolean;
   /** Whether currently dragging */
@@ -200,6 +202,7 @@ export function useSidebarState(): UseSidebarStateReturn {
 
   return {
     width,
+    expandedWidth: globalWidth,
     isCollapsed,
     isDragging,
     handleMouseDown,

--- a/src/hooks/workStation/useNarrowChatFocus.test.ts
+++ b/src/hooks/workStation/useNarrowChatFocus.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveWorkbenchEvaluationWidth } from "./useNarrowChatFocus";
+
+describe("resolveWorkbenchEvaluationWidth", () => {
+  it("uses the projected target width during programmatic reopening", () => {
+    expect(
+      resolveWorkbenchEvaluationWidth({
+        chatPanelDragging: false,
+        chatPanelMaximized: false,
+        chatVisible: true,
+        chatWidth: 520,
+        mainContentWidth: 1280,
+        measuredWorkbenchWidth: 24,
+      })
+    ).toBe(760);
+  });
+
+  it("uses the projected target width while chat is maximized", () => {
+    expect(
+      resolveWorkbenchEvaluationWidth({
+        chatPanelDragging: false,
+        chatPanelMaximized: true,
+        chatVisible: true,
+        chatWidth: 520,
+        mainContentWidth: 1280,
+        measuredWorkbenchWidth: 0,
+      })
+    ).toBe(760);
+  });
+
+  it("uses the measured width during direct chat resizing", () => {
+    expect(
+      resolveWorkbenchEvaluationWidth({
+        chatPanelDragging: true,
+        chatPanelMaximized: false,
+        chatVisible: true,
+        chatWidth: 520,
+        mainContentWidth: 1280,
+        measuredWorkbenchWidth: 472,
+      })
+    ).toBe(472);
+  });
+});

--- a/src/hooks/workStation/useNarrowChatFocus.ts
+++ b/src/hooks/workStation/useNarrowChatFocus.ts
@@ -25,28 +25,23 @@
  * un-maximize actions taken while narrow are preserved across the
  * next resize.
  *
- * Width sources (two of them, switched on the maximized flag):
+ * Width sources (two of them, switched on direct manipulation):
  *
- * - Normal layout: `[data-workbench-surface]` is the children-wrapping
- *   div, sized exactly to the visible workbench. Its
- *   `contentRect.width` IS the workbench width.
+ * - While the user drags the chat divider, `[data-workbench-surface]`
+ *   provides the live width because the CSS variable intentionally leads
+ *   the persisted chat-width atom.
  *
- * - Maximized layout: the workbench surface is forcibly collapsed to
- *   `w-0` by `AppLayout` so any inline native webview hosted inside
- *   it shrinks to a zero-area frame (WKWebViews are window-level
- *   sibling NSViews, not DOM children, so this is the only way to
- *   keep them mounted without painting through the React chat
- *   panel). The element's measured width is therefore ~0 and would
- *   immediately trip the restore branch, creating a feedback loop.
- *   So while maximized we compute the *projected* workbench width
- *   from `[data-main-content].contentRect.width - chatWidth`, which
- *   models "what the workbench width would be if chat were docked
- *   normally". Stable across maximize toggles.
+ * - At rest or during programmatic pane motion, derive the projected target
+ *   width from `[data-main-content].contentRect.width - chatWidth`. This
+ *   keeps animated intermediate widths from looking like a genuine narrow
+ *   viewport while still shrinking inline native webviews with the real
+ *   flex track.
  */
 import { useAtomValue, useSetAtom } from "jotai";
 import { useEffect, useRef } from "react";
 
 import {
+  chatPanelDraggingAtom,
   chatPanelMaximizedAtom,
   chatVisibleAtom,
   chatWidthAtom,
@@ -91,11 +86,43 @@ interface UseNarrowChatFocusOptions {
   enabled: boolean;
 }
 
+interface ResolveWorkbenchEvaluationWidthOptions {
+  chatPanelDragging: boolean;
+  chatPanelMaximized: boolean;
+  chatVisible: boolean;
+  chatWidth: number;
+  mainContentWidth: number;
+  measuredWorkbenchWidth: number;
+}
+
+/**
+ * Use the target normal-flow width for programmatic pane motion so the
+ * intermediate animation frames do not look like a genuine narrow layout.
+ * During direct manipulation, keep reading the measured workbench because
+ * the live CSS width intentionally leads the persisted chat-width atom.
+ */
+export function resolveWorkbenchEvaluationWidth({
+  chatPanelDragging,
+  chatPanelMaximized,
+  chatVisible,
+  chatWidth,
+  mainContentWidth,
+  measuredWorkbenchWidth,
+}: ResolveWorkbenchEvaluationWidthOptions): number {
+  if (chatPanelDragging && !chatPanelMaximized) {
+    return measuredWorkbenchWidth;
+  }
+
+  const chatSlice = chatVisible ? chatWidth : 0;
+  return Math.max(0, mainContentWidth - chatSlice);
+}
+
 export function useNarrowChatFocus({
   enabled,
 }: UseNarrowChatFocusOptions): void {
   const stationMode = useAtomValue(stationModeAtom);
   const chatPanelMaximized = useAtomValue(chatPanelMaximizedAtom);
+  const chatPanelDragging = useAtomValue(chatPanelDraggingAtom);
   const chatWidth = useAtomValue(chatWidthAtom);
   const chatVisible = useAtomValue(chatVisibleAtom);
   const setChatPanelMaximized = useSetAtom(chatPanelMaximizedAtom);
@@ -118,14 +145,22 @@ export function useNarrowChatFocus({
   // ref write happens after render (react-hooks/refs lint rule).
   const stationModeRef = useRef(stationMode);
   const chatPanelMaximizedRef = useRef(chatPanelMaximized);
+  const chatPanelDraggingRef = useRef(chatPanelDragging);
   const chatWidthRef = useRef(chatWidth);
   const chatVisibleRef = useRef(chatVisible);
   useEffect(() => {
     stationModeRef.current = stationMode;
     chatPanelMaximizedRef.current = chatPanelMaximized;
+    chatPanelDraggingRef.current = chatPanelDragging;
     chatWidthRef.current = chatWidth;
     chatVisibleRef.current = chatVisible;
-  }, [stationMode, chatPanelMaximized, chatWidth, chatVisible]);
+  }, [
+    stationMode,
+    chatPanelDragging,
+    chatPanelMaximized,
+    chatWidth,
+    chatVisible,
+  ]);
 
   // Last observed measurements. Cached so atom-driven re-evaluations
   // (chat width slider, chat visibility toggle, maximize toggle) can
@@ -147,17 +182,14 @@ export function useNarrowChatFocus({
     let lookupTimer: ReturnType<typeof setInterval> | null = null;
 
     const computeWorkbenchWidth = (): number => {
-      // When maximized, AppLayout collapses the workbench surface to
-      // `w-0` (so inline NSView webviews shrink with it), so its
-      // measured width is ~0. Project from main-content minus the
-      // docked chat slice instead — this models "what the workbench
-      // width would be if chat were docked normally" and keeps the
-      // narrow→wide edge stable across maximize toggles.
-      if (chatPanelMaximizedRef.current) {
-        const slice = chatVisibleRef.current ? chatWidthRef.current : 0;
-        return Math.max(0, mainContentWidthRef.current - slice);
-      }
-      return workbenchWidthRef.current;
+      return resolveWorkbenchEvaluationWidth({
+        chatPanelDragging: chatPanelDraggingRef.current,
+        chatPanelMaximized: chatPanelMaximizedRef.current,
+        chatVisible: chatVisibleRef.current,
+        chatWidth: chatWidthRef.current,
+        mainContentWidth: mainContentWidthRef.current,
+        measuredWorkbenchWidth: workbenchWidthRef.current,
+      });
     };
 
     const evaluate = () => {
@@ -254,9 +286,14 @@ export function useNarrowChatFocus({
       return;
     }
 
-    const width = chatPanelMaximized
-      ? Math.max(0, mainContentWidthRef.current - (chatVisible ? chatWidth : 0))
-      : workbenchWidthRef.current;
+    const width = resolveWorkbenchEvaluationWidth({
+      chatPanelDragging,
+      chatPanelMaximized,
+      chatVisible,
+      chatWidth,
+      mainContentWidth: mainContentWidthRef.current,
+      measuredWorkbenchWidth: workbenchWidthRef.current,
+    });
 
     if (width <= 0) return;
 
@@ -280,6 +317,7 @@ export function useNarrowChatFocus({
     }
   }, [
     enabled,
+    chatPanelDragging,
     chatWidth,
     chatVisible,
     stationMode,

--- a/src/i18n/locales/de/settings.json
+++ b/src/i18n/locales/de/settings.json
@@ -151,6 +151,7 @@
     "layout": "Layout",
     "sidebar": "Seitenleiste",
     "spotlight": "Spotlight",
+    "sidebarEdgeDepth": "Tiefe der Seitenleistenkante",
     "selectedItemTransparency": "Transparenz ausgewählter Elemente",
     "spotlightPlacement": "Spotlight-Position",
     "spotlightPlacementDesc": "Wählen Sie, wo die Spotlight-Befehlspalette geöffnet wird",

--- a/src/i18n/locales/de/settings.json
+++ b/src/i18n/locales/de/settings.json
@@ -149,6 +149,9 @@
       "zh-Hant": "Traditionelles Chinesisch"
     },
     "layout": "Layout",
+    "sidebar": "Seitenleiste",
+    "spotlight": "Spotlight",
+    "selectedItemTransparency": "Transparenz ausgewählter Elemente",
     "spotlightPlacement": "Spotlight-Position",
     "spotlightPlacementDesc": "Wählen Sie, wo die Spotlight-Befehlspalette geöffnet wird",
     "spotlightPlacementOptions": {

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -151,6 +151,7 @@
     "layout": "Layout",
     "sidebar": "Sidebar",
     "spotlight": "Spotlight",
+    "sidebarEdgeDepth": "Sidebar edge depth",
     "selectedItemTransparency": "Selected item transparency",
     "spotlightPlacement": "Spotlight position",
     "spotlightPlacementDesc": "Choose where the Spotlight command palette opens",

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -149,6 +149,9 @@
       "zh-Hant": "Traditional Chinese"
     },
     "layout": "Layout",
+    "sidebar": "Sidebar",
+    "spotlight": "Spotlight",
+    "selectedItemTransparency": "Selected item transparency",
     "spotlightPlacement": "Spotlight position",
     "spotlightPlacementDesc": "Choose where the Spotlight command palette opens",
     "spotlightPlacementOptions": {

--- a/src/i18n/locales/es/settings.json
+++ b/src/i18n/locales/es/settings.json
@@ -149,6 +149,9 @@
       "zh-Hant": "Chino tradicional"
     },
     "layout": "Diseño",
+    "sidebar": "Barra lateral",
+    "spotlight": "Spotlight",
+    "selectedItemTransparency": "Transparencia del elemento seleccionado",
     "spotlightPlacement": "Posición de Spotlight",
     "spotlightPlacementDesc": "Elige dónde se abre la paleta de comandos Spotlight",
     "spotlightPlacementOptions": {

--- a/src/i18n/locales/es/settings.json
+++ b/src/i18n/locales/es/settings.json
@@ -151,6 +151,7 @@
     "layout": "Diseño",
     "sidebar": "Barra lateral",
     "spotlight": "Spotlight",
+    "sidebarEdgeDepth": "Profundidad del borde de la barra lateral",
     "selectedItemTransparency": "Transparencia del elemento seleccionado",
     "spotlightPlacement": "Posición de Spotlight",
     "spotlightPlacementDesc": "Elige dónde se abre la paleta de comandos Spotlight",

--- a/src/i18n/locales/fr/settings.json
+++ b/src/i18n/locales/fr/settings.json
@@ -149,6 +149,9 @@
       "zh-Hant": "Chinois traditionnel"
     },
     "layout": "Disposition",
+    "sidebar": "Barre latérale",
+    "spotlight": "Spotlight",
+    "selectedItemTransparency": "Transparence de l’élément sélectionné",
     "spotlightPlacement": "Position de Spotlight",
     "spotlightPlacementDesc": "Choisissez où s’ouvre la palette de commandes Spotlight",
     "spotlightPlacementOptions": {

--- a/src/i18n/locales/fr/settings.json
+++ b/src/i18n/locales/fr/settings.json
@@ -151,6 +151,7 @@
     "layout": "Disposition",
     "sidebar": "Barre latérale",
     "spotlight": "Spotlight",
+    "sidebarEdgeDepth": "Profondeur du bord de la barre latérale",
     "selectedItemTransparency": "Transparence de l’élément sélectionné",
     "spotlightPlacement": "Position de Spotlight",
     "spotlightPlacementDesc": "Choisissez où s’ouvre la palette de commandes Spotlight",

--- a/src/i18n/locales/ja/settings.json
+++ b/src/i18n/locales/ja/settings.json
@@ -149,6 +149,9 @@
       "zh-Hant": "繁体中国語"
     },
     "layout": "レイアウト",
+    "sidebar": "サイドバー",
+    "spotlight": "Spotlight",
+    "selectedItemTransparency": "選択項目の透明度",
     "spotlightPlacement": "Spotlight の位置",
     "spotlightPlacementDesc": "Spotlight コマンドパレットを開く位置を選択",
     "spotlightPlacementOptions": {

--- a/src/i18n/locales/ja/settings.json
+++ b/src/i18n/locales/ja/settings.json
@@ -151,6 +151,7 @@
     "layout": "レイアウト",
     "sidebar": "サイドバー",
     "spotlight": "Spotlight",
+    "sidebarEdgeDepth": "サイドバー境界の奥行き",
     "selectedItemTransparency": "選択項目の透明度",
     "spotlightPlacement": "Spotlight の位置",
     "spotlightPlacementDesc": "Spotlight コマンドパレットを開く位置を選択",

--- a/src/i18n/locales/ko/settings.json
+++ b/src/i18n/locales/ko/settings.json
@@ -149,6 +149,9 @@
       "zh-Hant": "중국어 번체"
     },
     "layout": "레이아웃",
+    "sidebar": "사이드바",
+    "spotlight": "Spotlight",
+    "selectedItemTransparency": "선택한 항목 투명도",
     "spotlightPlacement": "Spotlight 위치",
     "spotlightPlacementDesc": "Spotlight 명령 팔레트가 열릴 위치를 선택합니다",
     "spotlightPlacementOptions": {

--- a/src/i18n/locales/ko/settings.json
+++ b/src/i18n/locales/ko/settings.json
@@ -151,6 +151,7 @@
     "layout": "레이아웃",
     "sidebar": "사이드바",
     "spotlight": "Spotlight",
+    "sidebarEdgeDepth": "사이드바 경계 깊이",
     "selectedItemTransparency": "선택한 항목 투명도",
     "spotlightPlacement": "Spotlight 위치",
     "spotlightPlacementDesc": "Spotlight 명령 팔레트가 열릴 위치를 선택합니다",

--- a/src/i18n/locales/pl/settings.json
+++ b/src/i18n/locales/pl/settings.json
@@ -151,6 +151,7 @@
     "layout": "Układ",
     "sidebar": "Pasek boczny",
     "spotlight": "Spotlight",
+    "sidebarEdgeDepth": "Głębia krawędzi paska bocznego",
     "selectedItemTransparency": "Przezroczystość wybranego elementu",
     "spotlightPlacement": "Pozycja Spotlight",
     "spotlightPlacementDesc": "Wybierz, gdzie otwiera się paleta poleceń Spotlight",

--- a/src/i18n/locales/pl/settings.json
+++ b/src/i18n/locales/pl/settings.json
@@ -149,6 +149,9 @@
       "zh-Hant": "Chiński tradycyjny"
     },
     "layout": "Układ",
+    "sidebar": "Pasek boczny",
+    "spotlight": "Spotlight",
+    "selectedItemTransparency": "Przezroczystość wybranego elementu",
     "spotlightPlacement": "Pozycja Spotlight",
     "spotlightPlacementDesc": "Wybierz, gdzie otwiera się paleta poleceń Spotlight",
     "spotlightPlacementOptions": {

--- a/src/i18n/locales/pt/settings.json
+++ b/src/i18n/locales/pt/settings.json
@@ -151,6 +151,7 @@
     "layout": "Layout",
     "sidebar": "Barra lateral",
     "spotlight": "Spotlight",
+    "sidebarEdgeDepth": "Profundidade da borda da barra lateral",
     "selectedItemTransparency": "Transparência do item selecionado",
     "spotlightPlacement": "Posição do Spotlight",
     "spotlightPlacementDesc": "Escolha onde a paleta de comandos Spotlight abre",

--- a/src/i18n/locales/pt/settings.json
+++ b/src/i18n/locales/pt/settings.json
@@ -149,6 +149,9 @@
       "zh-Hant": "Chinês tradicional"
     },
     "layout": "Layout",
+    "sidebar": "Barra lateral",
+    "spotlight": "Spotlight",
+    "selectedItemTransparency": "Transparência do item selecionado",
     "spotlightPlacement": "Posição do Spotlight",
     "spotlightPlacementDesc": "Escolha onde a paleta de comandos Spotlight abre",
     "spotlightPlacementOptions": {

--- a/src/i18n/locales/ru/settings.json
+++ b/src/i18n/locales/ru/settings.json
@@ -149,6 +149,9 @@
       "zh-Hant": "Китайский традиционный"
     },
     "layout": "Макет",
+    "sidebar": "Боковая панель",
+    "spotlight": "Spotlight",
+    "selectedItemTransparency": "Прозрачность выбранного элемента",
     "spotlightPlacement": "Положение Spotlight",
     "spotlightPlacementDesc": "Выберите, где открывается командная палитра Spotlight",
     "spotlightPlacementOptions": {

--- a/src/i18n/locales/ru/settings.json
+++ b/src/i18n/locales/ru/settings.json
@@ -151,6 +151,7 @@
     "layout": "Макет",
     "sidebar": "Боковая панель",
     "spotlight": "Spotlight",
+    "sidebarEdgeDepth": "Глубина границы боковой панели",
     "selectedItemTransparency": "Прозрачность выбранного элемента",
     "spotlightPlacement": "Положение Spotlight",
     "spotlightPlacementDesc": "Выберите, где открывается командная палитра Spotlight",

--- a/src/i18n/locales/tr/settings.json
+++ b/src/i18n/locales/tr/settings.json
@@ -149,6 +149,9 @@
       "zh-Hant": "Geleneksel Çince"
     },
     "layout": "Düzen",
+    "sidebar": "Kenar çubuğu",
+    "spotlight": "Spotlight",
+    "selectedItemTransparency": "Seçili öğe şeffaflığı",
     "spotlightPlacement": "Spotlight konumu",
     "spotlightPlacementDesc": "Spotlight komut paletinin nerede açılacağını seçin",
     "spotlightPlacementOptions": {

--- a/src/i18n/locales/tr/settings.json
+++ b/src/i18n/locales/tr/settings.json
@@ -151,6 +151,7 @@
     "layout": "Düzen",
     "sidebar": "Kenar çubuğu",
     "spotlight": "Spotlight",
+    "sidebarEdgeDepth": "Kenar çubuğu kenar derinliği",
     "selectedItemTransparency": "Seçili öğe şeffaflığı",
     "spotlightPlacement": "Spotlight konumu",
     "spotlightPlacementDesc": "Spotlight komut paletinin nerede açılacağını seçin",

--- a/src/i18n/locales/vi/settings.json
+++ b/src/i18n/locales/vi/settings.json
@@ -151,6 +151,7 @@
     "layout": "Bố cục",
     "sidebar": "Thanh bên",
     "spotlight": "Spotlight",
+    "sidebarEdgeDepth": "Độ sâu cạnh thanh bên",
     "selectedItemTransparency": "Độ trong suốt của mục đã chọn",
     "spotlightPlacement": "Vị trí Spotlight",
     "spotlightPlacementDesc": "Chọn nơi bảng lệnh Spotlight mở ra",

--- a/src/i18n/locales/vi/settings.json
+++ b/src/i18n/locales/vi/settings.json
@@ -149,6 +149,9 @@
       "zh-Hant": "Tiếng Trung phồn thể"
     },
     "layout": "Bố cục",
+    "sidebar": "Thanh bên",
+    "spotlight": "Spotlight",
+    "selectedItemTransparency": "Độ trong suốt của mục đã chọn",
     "spotlightPlacement": "Vị trí Spotlight",
     "spotlightPlacementDesc": "Chọn nơi bảng lệnh Spotlight mở ra",
     "spotlightPlacementOptions": {

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -149,6 +149,9 @@
       "zh-Hant": "繁體中文"
     },
     "layout": "佈局",
+    "sidebar": "側邊欄",
+    "spotlight": "Spotlight",
+    "selectedItemTransparency": "選取項目透明度",
     "spotlightPlacement": "Spotlight 位置",
     "spotlightPlacementDesc": "選擇 Spotlight 命令面板開啟的位置",
     "spotlightPlacementOptions": {

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -151,6 +151,7 @@
     "layout": "佈局",
     "sidebar": "側邊欄",
     "spotlight": "Spotlight",
+    "sidebarEdgeDepth": "側邊欄邊緣層次",
     "selectedItemTransparency": "選取項目透明度",
     "spotlightPlacement": "Spotlight 位置",
     "spotlightPlacementDesc": "選擇 Spotlight 命令面板開啟的位置",

--- a/src/i18n/locales/zh/settings.json
+++ b/src/i18n/locales/zh/settings.json
@@ -151,6 +151,7 @@
     "layout": "布局",
     "sidebar": "侧边栏",
     "spotlight": "Spotlight",
+    "sidebarEdgeDepth": "侧边栏边缘层次",
     "selectedItemTransparency": "选中项目透明度",
     "spotlightPlacement": "Spotlight 位置",
     "spotlightPlacementDesc": "选择 Spotlight 命令面板打开的位置",

--- a/src/i18n/locales/zh/settings.json
+++ b/src/i18n/locales/zh/settings.json
@@ -149,6 +149,9 @@
       "zh-Hant": "繁体中文"
     },
     "layout": "布局",
+    "sidebar": "侧边栏",
+    "spotlight": "Spotlight",
+    "selectedItemTransparency": "选中项目透明度",
     "spotlightPlacement": "Spotlight 位置",
     "spotlightPlacementDesc": "选择 Spotlight 命令面板打开的位置",
     "spotlightPlacementOptions": {

--- a/src/index.scss
+++ b/src/index.scss
@@ -432,6 +432,20 @@ body {
   background: var(--color-bg-2);
 }
 
+// macOS paints a native AbuttedSidebar material underneath the transparent webview.
+// Keep a faint app tint at the root so empty/transitional areas remain legible,
+// while translucent chrome (notably the navigation sidebar) can reveal the
+// desktop material. Other desktop hosts retain the opaque fallback above.
+html[data-host-desktop="macos"],
+html[data-host-desktop="macos"] body,
+html[data-host-desktop="macos"] #root {
+  background: color-mix(in srgb, var(--color-bg-2) 15%, transparent);
+}
+
+html[data-host-desktop="macos"] .sidebar-base {
+  background: transparent;
+}
+
 html[data-host-desktop="windows"],
 html[data-host-desktop="windows"] body,
 html[data-host-desktop="windows"] #root {

--- a/src/modules/MainApp/Settings/sections/AppearanceSection.tsx
+++ b/src/modules/MainApp/Settings/sections/AppearanceSection.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 
 import Select from "@src/components/Select";
 import Slider from "@src/components/Slider";
+import Switch from "@src/components/Switch";
 import type { ApplicationUiFontId } from "@src/config/appearance/applicationUiFonts";
 import type { PrimaryColorPreset } from "@src/config/appearance/primaryColors";
 import {
@@ -87,6 +88,9 @@ const AppearanceSection: React.FC<AppearanceSectionProps> = ({
   const { t } = useTranslation("settings");
   const [sidebarSelectedRowOpacity, setSidebarSelectedRowOpacity] = useSetting(
     "layout.sidebarSelectedRowOpacity"
+  );
+  const [sidebarEdgeDepthEnabled, setSidebarEdgeDepthEnabled] = useSetting(
+    "layout.sidebarEdgeDepthEnabled"
   );
   const {
     globalThemeId,
@@ -190,6 +194,14 @@ const AppearanceSection: React.FC<AppearanceSectionProps> = ({
                 />
               </div>
             </SectionRow>
+            {IS_MACOS_HOST && (
+              <SectionRow label={t("general.sidebarEdgeDepth")}>
+                <Switch
+                  checked={sidebarEdgeDepthEnabled}
+                  onChange={setSidebarEdgeDepthEnabled}
+                />
+              </SectionRow>
+            )}
           </SectionContainer>
 
           <SectionContainer title={t("general.spotlight")}>

--- a/src/modules/MainApp/Settings/sections/AppearanceSection.tsx
+++ b/src/modules/MainApp/Settings/sections/AppearanceSection.tsx
@@ -4,18 +4,32 @@ import {
   SectionContainer,
   SectionRow,
 } from "@/src/modules/shared/layouts/SectionLayout";
+import { useAtom } from "jotai";
 import React from "react";
 import { useTranslation } from "react-i18next";
 
 import Select from "@src/components/Select";
+import Slider from "@src/components/Slider";
 import type { ApplicationUiFontId } from "@src/config/appearance/applicationUiFonts";
 import type { PrimaryColorPreset } from "@src/config/appearance/primaryColors";
+import {
+  HOST_DESKTOP,
+  resolveHostDesktop,
+} from "@src/config/windowChromeRadius";
+import { useSetting } from "@src/hooks/settings/useSettings";
 import { BackgroundSettings } from "@src/modules/MainApp/Settings/subpages/BackgroundPage/BackgroundSettings";
 import {
   FeaturesSection as EditorFeaturesSection,
   TerminalSection as EditorTerminalSection,
   TypographySection as EditorTypographySection,
 } from "@src/modules/MainApp/Settings/subpages/EditorAppearancePage";
+import {
+  DEFAULT_SIDEBAR_OPACITY,
+  MAX_SIDEBAR_OPACITY,
+  MIN_SIDEBAR_OPACITY,
+  backgroundConfigPersistAtom,
+  sanitizeSidebarOpacity,
+} from "@src/store/ui/backgroundConfigAtom";
 import type { SpotlightPlacement } from "@src/store/ui/uiAtom";
 
 import { ChatPanelAppearanceTab } from "./ChatPanelAppearanceTab";
@@ -37,6 +51,31 @@ export type AppearanceTabKey =
   (typeof APPEARANCE_TAB_KEYS)[keyof typeof APPEARANCE_TAB_KEYS];
 
 const SPOTLIGHT_PLACEMENT_OPTIONS: SpotlightPlacement[] = ["top", "center"];
+const IS_MACOS_HOST = resolveHostDesktop() === HOST_DESKTOP.MACOS;
+
+const MacOSSidebarOpacityRow: React.FC = () => {
+  const { t } = useTranslation("settings");
+  const [config, setConfig] = useAtom(backgroundConfigPersistAtom);
+
+  return (
+    <SectionRow label={t("background.sidebarOpacity")}>
+      <div className="min-w-0" style={SECTION_CONTROL_STYLE}>
+        <Slider
+          min={MIN_SIDEBAR_OPACITY}
+          max={MAX_SIDEBAR_OPACITY}
+          value={config.sidebarOpacity ?? DEFAULT_SIDEBAR_OPACITY}
+          onChange={(value) =>
+            setConfig({
+              ...config,
+              sidebarOpacity: sanitizeSidebarOpacity(value),
+            })
+          }
+          noPadding
+        />
+      </div>
+    </SectionRow>
+  );
+};
 
 interface AppearanceSectionProps {
   activeTab?: string;
@@ -46,6 +85,9 @@ const AppearanceSection: React.FC<AppearanceSectionProps> = ({
   activeTab = APPEARANCE_TAB_KEYS.APP,
 }) => {
   const { t } = useTranslation("settings");
+  const [sidebarSelectedRowOpacity, setSidebarSelectedRowOpacity] = useSetting(
+    "layout.sidebarSelectedRowOpacity"
+  );
   const {
     globalThemeId,
     primaryColorPreset,
@@ -131,7 +173,26 @@ const AppearanceSection: React.FC<AppearanceSectionProps> = ({
             </SectionRow>
           </SectionContainer>
 
-          <SectionContainer title={t("general.layout")}>
+          <SectionContainer title={t("general.sidebar")}>
+            {IS_MACOS_HOST && <MacOSSidebarOpacityRow />}
+            <SectionRow label={t("general.selectedItemTransparency")}>
+              <div className="min-w-0" style={SECTION_CONTROL_STYLE}>
+                <Slider
+                  min={0}
+                  max={20}
+                  value={sidebarSelectedRowOpacity}
+                  onChange={(value) =>
+                    setSidebarSelectedRowOpacity(
+                      Array.isArray(value) ? value[0] : value
+                    )
+                  }
+                  noPadding
+                />
+              </div>
+            </SectionRow>
+          </SectionContainer>
+
+          <SectionContainer title={t("general.spotlight")}>
             <SectionRow
               label={t("general.spotlightPlacement")}
               description={t("general.spotlightPlacementDesc")}
@@ -151,7 +212,7 @@ const AppearanceSection: React.FC<AppearanceSectionProps> = ({
             </SectionRow>
           </SectionContainer>
 
-          <BackgroundSettings embedded showHeader={false} />
+          {!IS_MACOS_HOST && <BackgroundSettings embedded showHeader={false} />}
         </>
       )}
 

--- a/src/modules/MainApp/StartPage/components/AppGrid/index.tsx
+++ b/src/modules/MainApp/StartPage/components/AppGrid/index.tsx
@@ -22,6 +22,10 @@ import React, { useCallback, useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { ACTION_ID, useActionSystemOptional } from "@src/ActionSystem";
+import {
+  HOST_DESKTOP,
+  resolveHostDesktop,
+} from "@src/config/windowChromeRadius";
 import { CODEMIRROR_STYLE_NONCE } from "@src/features/CodeMirror/config/nonce";
 import { useRegionLuminance } from "@src/hooks/theme/useRegionLuminance";
 import { appGridConfigAtom } from "@src/store/ui/appGridAtom";
@@ -32,6 +36,8 @@ import AppGridEditPanel from "../AppGridEditPanel";
 import { AppGridIcon } from "./AppGridIcon";
 import { APP_GRID_ITEMS, type AppItem } from "./config";
 import { useAppGridDrag } from "./useAppGridDrag";
+
+const IS_MACOS_HOST = resolveHostDesktop() === HOST_DESKTOP.MACOS;
 
 // ============================================
 // Styles
@@ -190,7 +196,9 @@ const AppGrid: React.FC<AppGridProps> = ({ className }) => {
   const [gridConfig, setGridConfig] = useAtom(appGridConfigAtom);
   const backgroundConfig = useAtomValue(resolvedBackgroundConfigAtom);
   const shouldUseAdaptiveColors = Boolean(
-    backgroundConfig.adaptiveColors && backgroundConfig.selectedImageId
+    !IS_MACOS_HOST &&
+    backgroundConfig.adaptiveColors &&
+    backgroundConfig.selectedImageId
   );
 
   const sortedApps = useMemo(() => {

--- a/src/modules/MainApp/StartPage/index.tsx
+++ b/src/modules/MainApp/StartPage/index.tsx
@@ -3,14 +3,29 @@
  *
  * Main landing page with Launchpad grid
  */
+import { useAtomValue } from "jotai";
 import React from "react";
+
+import {
+  HOST_DESKTOP,
+  resolveHostDesktop,
+} from "@src/config/windowChromeRadius";
+import { getPagePanelBackgroundStyle } from "@src/modules/shared/layouts/viewContainerTokens";
+import { resolvedBackgroundConfigAtom } from "@src/store/ui/backgroundConfigAtom";
 
 import { AppGrid } from "./components";
 import "./index.scss";
 
+const IS_MACOS_HOST = resolveHostDesktop() === HOST_DESKTOP.MACOS;
+
 const SuggestionsPage: React.FC = () => {
+  const backgroundConfig = useAtomValue(resolvedBackgroundConfigAtom);
+  const homeSurfaceStyle = IS_MACOS_HOST
+    ? getPagePanelBackgroundStyle(backgroundConfig.pageOpacity)
+    : undefined;
+
   return (
-    <div className="relative flex h-full flex-col">
+    <div className="relative flex h-full flex-col" style={homeSurfaceStyle}>
       <div
         className="absolute inset-x-0 top-0 z-10 h-[72px]"
         data-tauri-drag-region

--- a/src/modules/SetupWalkthrough/steps/ThemeSelectionStep.tsx
+++ b/src/modules/SetupWalkthrough/steps/ThemeSelectionStep.tsx
@@ -6,9 +6,57 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 
+import Select from "@src/components/Select";
+import {
+  HOST_DESKTOP,
+  resolveHostDesktop,
+} from "@src/config/windowChromeRadius";
+import { useAppearanceState } from "@src/modules/MainApp/Settings/sections/useAppearanceState";
 import { BackgroundSettings } from "@src/modules/MainApp/Settings/subpages/BackgroundPage";
+import {
+  SECTION_CONTROL_STYLE,
+  SectionRow,
+} from "@src/modules/shared/layouts/SectionLayout";
 
 import { AnimatedTitle } from "../components";
+
+const IS_MACOS_HOST = resolveHostDesktop() === HOST_DESKTOP.MACOS;
+
+const MacOSThemeControls: React.FC = () => {
+  const { t } = useTranslation("settings");
+  const {
+    appearanceMode,
+    appearanceModeOptions,
+    globalThemeId,
+    themeOptions,
+    handleAppearanceModeChange,
+    handleThemeChange,
+  } = useAppearanceState();
+
+  return (
+    <div className="flex flex-col gap-2 px-6">
+      <SectionRow compact label={t("general.appearanceMode")}>
+        <Select
+          value={appearanceMode}
+          onChange={handleAppearanceModeChange}
+          options={appearanceModeOptions}
+          size="default"
+          style={SECTION_CONTROL_STYLE}
+        />
+      </SectionRow>
+      <SectionRow compact label={t("general.themePreset")}>
+        <Select
+          value={globalThemeId}
+          onChange={(value) => handleThemeChange(String(value))}
+          options={themeOptions}
+          showSearch
+          size="default"
+          style={SECTION_CONTROL_STYLE}
+        />
+      </SectionRow>
+    </div>
+  );
+};
 
 export const ThemeSelectionStep: React.FC = () => {
   const { t } = useTranslation("onboarding");
@@ -20,10 +68,14 @@ export const ThemeSelectionStep: React.FC = () => {
         subtitle={t("theme.description")}
       />
       <div className="absolute inset-0 top-14 flex animate-[fadeInUp_0.6s_ease-out_2s_backwards] flex-col scrollbar-hide">
-        <BackgroundSettings
-          showHeader={false}
-          translationNamespace="settings"
-        />
+        {IS_MACOS_HOST ? (
+          <MacOSThemeControls />
+        ) : (
+          <BackgroundSettings
+            showHeader={false}
+            translationNamespace="settings"
+          />
+        )}
       </div>
     </div>
   );

--- a/src/modules/index.tsx
+++ b/src/modules/index.tsx
@@ -457,6 +457,7 @@ const AppShell = () => {
             blurAmount={backgroundConfig.blurAmount ?? 0}
             backgroundColor={backgroundConfig.backgroundColor}
             glass={backgroundConfig.glass}
+            sidebarInset={sidebarCollapsed ? 0 : sidebarWidth}
           />
 
           {/* Main layout with sidebar, toolbar, content, and chat panel */}

--- a/src/modules/index.tsx
+++ b/src/modules/index.tsx
@@ -28,6 +28,10 @@ import { Outlet, useLocation, useNavigate } from "react-router-dom";
 
 import { useRouteViewMode } from "@src/config/routeViewModeConfig";
 import { ROUTES } from "@src/config/routes";
+import {
+  HOST_DESKTOP,
+  resolveHostDesktop,
+} from "@src/config/windowChromeRadius";
 import { BrowserProvider, TerminalProvider } from "@src/contexts/workstation";
 import { useAgentADEActions } from "@src/engines/SessionCore/hooks/useAgentADEActions";
 import { useProjectDataChangedListener } from "@src/hooks/project";
@@ -147,9 +151,16 @@ const WorkStationLoadingFallback: React.FC = () => (
   <div className="h-full w-full bg-workstation-bg" />
 );
 
-const AppShell = () => {
-  const location = useLocation();
+const IS_MACOS_HOST = resolveHostDesktop() === HOST_DESKTOP.MACOS;
 
+interface ConfiguredBackgroundLayerProps {
+  sidebarInset: number;
+}
+
+/** Legacy wallpaper/color background, retained for non-macOS hosts. */
+const ConfiguredBackgroundLayer: React.FC<ConfiguredBackgroundLayerProps> = ({
+  sidebarInset,
+}) => {
   const backgroundConfig = useAtomValue(resolvedBackgroundConfigAtom);
   const currentBackgroundImage = useBackgroundImage();
 
@@ -157,6 +168,20 @@ const AppShell = () => {
     if (!backgroundConfig.backgroundColor) return;
     prewarmColor(backgroundConfig.backgroundColor);
   }, [backgroundConfig.backgroundColor]);
+
+  return (
+    <BackgroundLayer
+      image={backgroundConfig.backgroundColor ? null : currentBackgroundImage}
+      blurAmount={backgroundConfig.blurAmount ?? 0}
+      backgroundColor={backgroundConfig.backgroundColor}
+      glass={backgroundConfig.glass}
+      sidebarInset={sidebarInset}
+    />
+  );
+};
+
+const AppShell = () => {
+  const location = useLocation();
 
   const viewMode = useRouteViewMode();
 
@@ -450,15 +475,11 @@ const AppShell = () => {
           className="relative flex h-full"
           data-guide-target={GUIDE_TARGETS.APP_ROOT}
         >
-          <BackgroundLayer
-            image={
-              backgroundConfig.backgroundColor ? null : currentBackgroundImage
-            }
-            blurAmount={backgroundConfig.blurAmount ?? 0}
-            backgroundColor={backgroundConfig.backgroundColor}
-            glass={backgroundConfig.glass}
-            sidebarInset={sidebarCollapsed ? 0 : sidebarWidth}
-          />
+          {!IS_MACOS_HOST && (
+            <ConfiguredBackgroundLayer
+              sidebarInset={sidebarCollapsed ? 0 : sidebarWidth}
+            />
+          )}
 
           {/* Main layout with sidebar, toolbar, content, and chat panel */}
           <AppLayout

--- a/src/modules/shared/components/BackgroundLayer/index.tsx
+++ b/src/modules/shared/components/BackgroundLayer/index.tsx
@@ -10,14 +10,14 @@
  * - Trusts cached images immediately (no redundant Image() preload)
  * - Only preloads truly new/uncached images (e.g., user just selected a new background)
  */
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 
 import { createLogger } from "@src/hooks/logger";
 import {
   addToBackgroundCache,
   backgroundImageCache,
 } from "@src/util/core/init/backgroundInit";
-import { isWindows } from "@src/util/platform/tauri";
+import { isMacOS, isWindows } from "@src/util/platform/tauri";
 
 const log = createLogger("BackgroundLayer");
 
@@ -26,6 +26,8 @@ interface BackgroundLayerProps {
   blurAmount: number;
   backgroundColor?: string;
   glass?: "regular" | "medium" | "thick";
+  /** Width reserved for native macOS sidebar material. */
+  sidebarInset?: number;
 }
 
 export const BackgroundLayer: React.FC<BackgroundLayerProps> = ({
@@ -33,6 +35,7 @@ export const BackgroundLayer: React.FC<BackgroundLayerProps> = ({
   blurAmount,
   backgroundColor,
   glass,
+  sidebarInset = 0,
 }) => {
   const [displayedImage, setDisplayedImage] = useState<string | null>(() => {
     if (!image) return null;
@@ -75,6 +78,15 @@ export const BackgroundLayer: React.FC<BackgroundLayerProps> = ({
 
   // If backgroundColor is set and no image, use solid color
   const useColorBackground = backgroundColor && !displayedImage;
+  const nativeSidebarInset = isMacOS() ? Math.max(0, sidebarInset) : 0;
+  const frameStyle = useMemo<React.CSSProperties>(
+    () => ({
+      left: nativeSidebarInset,
+      right: 0,
+      height: "100vh",
+    }),
+    [nativeSidebarInset]
+  );
 
   if (isWindows()) {
     return (
@@ -86,29 +98,23 @@ export const BackgroundLayer: React.FC<BackgroundLayerProps> = ({
     );
   }
 
-  // Glass mode: render a 30% bg-2 tint behind the native glass effect
-  if (glass != null) {
-    return (
-      <div
-        data-background-layer="true"
-        className="absolute left-0 top-0 z-0 bg-bg-2"
-        style={{ width: "100vw", height: "100vh", opacity: 0.5 }}
-      />
-    );
-  }
-
   return (
-    <>
-      {/* Base background layer - absolute with explicit viewport height */}
+    <div
+      className="pointer-events-none absolute top-0 z-0 overflow-hidden"
+      style={frameStyle}
+      data-background-layer-frame="true"
+    >
       <div
         data-background-layer="true"
-        className="absolute left-0 top-0 z-0"
+        className={`absolute inset-0 ${glass != null ? "bg-bg-2" : ""}`}
         style={{
-          width: "100vw",
-          height: "100vh",
-          backgroundColor: useColorBackground ? backgroundColor : undefined,
+          width: "100%",
+          height: "100%",
+          opacity: glass != null ? 0.5 : undefined,
+          backgroundColor:
+            glass == null && useColorBackground ? backgroundColor : undefined,
           backgroundImage:
-            displayedImage && !backgroundColor
+            glass == null && displayedImage && !backgroundColor
               ? `url(${displayedImage})`
               : "none",
           backgroundSize: "cover",
@@ -121,6 +127,6 @@ export const BackgroundLayer: React.FC<BackgroundLayerProps> = ({
           willChange: "transform",
         }}
       />
-    </>
+    </div>
   );
 };

--- a/src/modules/shared/layouts/AppLayout.tsx
+++ b/src/modules/shared/layouts/AppLayout.tsx
@@ -14,7 +14,7 @@
  */
 import { HoverSidebar } from "@/src/scaffold/NavigationSidebar";
 import { useAtomValue } from "jotai";
-import React, { memo, useCallback, useEffect } from "react";
+import React, { memo, useCallback, useEffect, useRef } from "react";
 
 import { ActionSystemProvider } from "@src/ActionSystem";
 import { sendAdeActionResult } from "@src/api/tauri/agent";
@@ -35,12 +35,19 @@ import type { SessionCreatorChatPanelProps } from "@src/features/SessionCreator/
 import { dispatchWebviewLayoutChanged } from "@src/hooks/platform/useInlineWebview/webviewLayoutEvents";
 import GlobalSessionSync from "@src/modules/shared/components/GlobalSessionSync";
 import { GlobalSpotlightPortal } from "@src/modules/shared/components/GlobalSpotlightPortal";
-import { getPagePanelBackgroundStyle } from "@src/modules/shared/layouts/viewContainerTokens";
+import {
+  PANE_WIDTH_TRANSITION_CLASSES,
+  getChatPanelBackgroundStyle,
+  getChatSlotLayoutStyle,
+  getPagePanelBackgroundStyle,
+  getWorkbenchLayoutStyle,
+} from "@src/modules/shared/layouts/viewContainerTokens";
 import { GENERAL_LAYOUT_TOUR_TARGETS } from "@src/scaffold/Tutorials/generalLayoutTourConfig";
 import { resolvedBackgroundConfigAtom } from "@src/store/ui/backgroundConfigAtom";
 import {
   type ChatPanelMode,
   DEFAULT_CHAT_WIDTH,
+  chatPanelDraggingAtom,
   chatWidthAtom,
 } from "@src/store/ui/chatPanelAtom";
 import type { ChatPanelPosition } from "@src/store/ui/workStationLayout/chatPositionAtoms";
@@ -166,8 +173,10 @@ const AppLayoutComponent: React.FC<AppLayoutProps> = ({
   children,
 }) => {
   const rawChatWidth = useAtomValue(chatWidthAtom);
+  const isChatPanelDragging = useAtomValue(chatPanelDraggingAtom);
   const backgroundConfig = useAtomValue(resolvedBackgroundConfigAtom);
   const viewportWidth = useViewportWidth();
+  const chatSlotRef = useRef<HTMLDivElement>(null);
   // Settings-in-slot must always have a usable width even if the user
   // previously dragged the chat to zero. Fall back to the configured
   // default so opening Settings never produces a collapsed slot.
@@ -183,13 +192,51 @@ const AppLayoutComponent: React.FC<AppLayoutProps> = ({
   // (otherwise an existing zero-width chat would hide the settings panel
   // too).
   const isSlotVisible = chatPanelMode === "settings" ? true : isChatVisible;
+  // Keep the chat mounted at zero width while the workstation route owns the
+  // slot. This lets close/open animate without keeping the heavy panel alive
+  // on unrelated routes.
+  const shouldMountSlot = isSettingsSlot || showChatPanel || chatPanelMaximized;
   const settingsSurfaceStyle = getPagePanelBackgroundStyle(
     backgroundConfig.pageOpacity
+  );
+  const chatPanelSurfaceStyle = getChatPanelBackgroundStyle(
+    backgroundConfig.pageOpacity
+  );
+  const paneUnderlayStyle: React.CSSProperties = {
+    backgroundColor: chatPanelSurfaceStyle.backgroundColor,
+  };
+  const paneTransitionClassName = isChatPanelDragging
+    ? ""
+    : PANE_WIDTH_TRANSITION_CLASSES;
+  const chatSlotStyle = getChatSlotLayoutStyle({
+    maximized: chatPanelMaximized,
+    visible: isSlotVisible,
+    visibleWidth: chatWidthStyleValue,
+  });
+  const workbenchStyle = getWorkbenchLayoutStyle(chatPanelMaximized);
+
+  const handlePaneTransitionEnd = useCallback(
+    (event: React.TransitionEvent<HTMLDivElement>) => {
+      if (event.currentTarget !== event.target) return;
+      dispatchWebviewLayoutChanged();
+    },
+    []
   );
 
   useEffect(() => {
     dispatchWebviewLayoutChanged();
   }, [chatPosition, chatPanelMaximized, chatWidth, isSlotVisible]);
+
+  useEffect(() => {
+    if (isSlotVisible) return;
+    const activeElement = document.activeElement;
+    if (
+      activeElement instanceof HTMLElement &&
+      chatSlotRef.current?.contains(activeElement)
+    ) {
+      activeElement.blur();
+    }
+  }, [isSlotVisible]);
 
   // Slot content: either the live chat panel or the in-slot Settings surface.
   // Both share the slot's outer maximize/inset behaviour — only the inner
@@ -221,6 +268,27 @@ const AppLayoutComponent: React.FC<AppLayoutProps> = ({
       />
     );
 
+  const chatSlot = shouldMountSlot ? (
+    <div
+      key="chat-slot"
+      ref={chatSlotRef}
+      className={`relative z-10 flex min-h-0 min-w-0 overflow-hidden ${paneTransitionClassName}`}
+      style={chatSlotStyle}
+      aria-hidden={!isSlotVisible}
+      data-fullmode-chat-wrapper
+      data-tour-target={
+        chatPanelMode === "session"
+          ? GENERAL_LAYOUT_TOUR_TARGETS.chatPanel
+          : undefined
+      }
+      data-chat-focus={chatPanelMaximized || undefined}
+      data-chat-slot-mode={chatPanelMode}
+      onTransitionEnd={handlePaneTransitionEnd}
+    >
+      {slotInner}
+    </div>
+  ) : null;
+
   // Shared content wrapped in providers
   const contentArea = (
     <DataProvider>
@@ -232,68 +300,28 @@ const AppLayoutComponent: React.FC<AppLayoutProps> = ({
             className="min-h-0 min-w-0 flex-1 overflow-hidden"
             data-main-content
           >
-            <div className="relative isolate flex h-full min-h-0 min-w-0 flex-row overflow-hidden">
-              {isChatOnLeft && isSlotVisible && (
-                <div
-                  key="chat-slot"
-                  className={
-                    chatPanelMaximized
-                      ? "absolute inset-0 z-10 flex min-h-0 min-w-0"
-                      : "relative z-10 flex flex-shrink-0"
-                  }
-                  style={
-                    chatPanelMaximized
-                      ? undefined
-                      : { width: chatWidthStyleValue }
-                  }
-                  data-fullmode-chat-wrapper
-                  data-tour-target={
-                    chatPanelMode === "session"
-                      ? GENERAL_LAYOUT_TOUR_TARGETS.chatPanel
-                      : undefined
-                  }
-                  data-chat-focus={chatPanelMaximized || undefined}
-                  data-chat-slot-mode={chatPanelMode}
-                >
-                  {slotInner}
-                </div>
-              )}
+            <div
+              className="relative isolate flex h-full min-h-0 min-w-0 flex-row overflow-hidden"
+              style={paneUnderlayStyle}
+              data-pane-surface-underlay
+            >
+              {isChatOnLeft && chatSlot}
               <div
                 key="workbench-surface"
-                // Maximizing the slot collapses the workbench surface to
-                // zero width so inline native webviews shrink to zero-area.
-                className={`relative z-0 h-full min-h-0 min-w-0 overflow-hidden ${chatPanelMaximized ? "w-0 flex-none" : "flex-1"}`}
+                // Animate the real flex track to zero so inline native
+                // webviews and ResizeObserver consumers see the exact width
+                // throughout focus/unfocus instead of an overlay swap.
+                className={`relative z-0 h-full min-h-0 min-w-0 overflow-hidden ${paneTransitionClassName}`}
+                style={workbenchStyle}
+                aria-hidden={chatPanelMaximized}
                 data-workbench-surface
+                onTransitionEnd={handlePaneTransitionEnd}
               >
                 <WorkbenchActionSystemScope>
                   {children}
                 </WorkbenchActionSystemScope>
               </div>
-              {!isChatOnLeft && isSlotVisible && (
-                <div
-                  key="chat-slot"
-                  className={
-                    chatPanelMaximized
-                      ? "absolute inset-0 z-10 flex min-h-0 min-w-0"
-                      : "relative z-10 flex flex-shrink-0"
-                  }
-                  style={
-                    chatPanelMaximized
-                      ? undefined
-                      : { width: chatWidthStyleValue }
-                  }
-                  data-fullmode-chat-wrapper
-                  data-tour-target={
-                    chatPanelMode === "session"
-                      ? GENERAL_LAYOUT_TOUR_TARGETS.chatPanel
-                      : undefined
-                  }
-                  data-chat-focus={chatPanelMaximized || undefined}
-                  data-chat-slot-mode={chatPanelMode}
-                >
-                  {slotInner}
-                </div>
-              )}
+              {!isChatOnLeft && chatSlot}
               {chatPanelMaximized && chatPanelMode === "session" && (
                 <FocusedChatWorkstationRail />
               )}

--- a/src/modules/shared/layouts/AppLayout.tsx
+++ b/src/modules/shared/layouts/AppLayout.tsx
@@ -35,7 +35,9 @@ import type { SessionCreatorChatPanelProps } from "@src/features/SessionCreator/
 import { dispatchWebviewLayoutChanged } from "@src/hooks/platform/useInlineWebview/webviewLayoutEvents";
 import GlobalSessionSync from "@src/modules/shared/components/GlobalSessionSync";
 import { GlobalSpotlightPortal } from "@src/modules/shared/components/GlobalSpotlightPortal";
+import { getPagePanelBackgroundStyle } from "@src/modules/shared/layouts/viewContainerTokens";
 import { GENERAL_LAYOUT_TOUR_TARGETS } from "@src/scaffold/Tutorials/generalLayoutTourConfig";
+import { resolvedBackgroundConfigAtom } from "@src/store/ui/backgroundConfigAtom";
 import {
   type ChatPanelMode,
   DEFAULT_CHAT_WIDTH,
@@ -164,6 +166,7 @@ const AppLayoutComponent: React.FC<AppLayoutProps> = ({
   children,
 }) => {
   const rawChatWidth = useAtomValue(chatWidthAtom);
+  const backgroundConfig = useAtomValue(resolvedBackgroundConfigAtom);
   const viewportWidth = useViewportWidth();
   // Settings-in-slot must always have a usable width even if the user
   // previously dragged the chat to zero. Fall back to the configured
@@ -180,6 +183,9 @@ const AppLayoutComponent: React.FC<AppLayoutProps> = ({
   // (otherwise an existing zero-width chat would hide the settings panel
   // too).
   const isSlotVisible = chatPanelMode === "settings" ? true : isChatVisible;
+  const settingsSurfaceStyle = getPagePanelBackgroundStyle(
+    backgroundConfig.pageOpacity
+  );
 
   useEffect(() => {
     dispatchWebviewLayoutChanged();
@@ -190,7 +196,15 @@ const AppLayoutComponent: React.FC<AppLayoutProps> = ({
   // component differs.
   const slotInner =
     chatPanelMode === "settings" ? (
-      <React.Suspense fallback={<div className="h-full w-full" />}>
+      <React.Suspense
+        fallback={
+          <div
+            data-settings-loading-surface
+            className="h-full w-full"
+            style={settingsSurfaceStyle}
+          />
+        }
+      >
         <SettingsSlot
           maximized={chatPanelMaximized}
           position={chatPosition}

--- a/src/modules/shared/layouts/viewContainerTokens.test.ts
+++ b/src/modules/shared/layouts/viewContainerTokens.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PANE_WIDTH_TRANSITION_CLASSES,
+  getChatSlotLayoutStyle,
+  getWorkbenchLayoutStyle,
+} from "./viewContainerTokens";
+
+describe("pane width transitions", () => {
+  it("transitions layout dimensions without transform geometry", () => {
+    expect(PANE_WIDTH_TRANSITION_CLASSES).toContain("width");
+    expect(PANE_WIDTH_TRANSITION_CLASSES).toContain("flex-grow");
+    expect(PANE_WIDTH_TRANSITION_CLASSES).toContain("flex-basis");
+    expect(PANE_WIDTH_TRANSITION_CLASSES).not.toContain("transform");
+  });
+
+  it("collapses a hidden chat pane to an inert zero-width flex item", () => {
+    expect(
+      getChatSlotLayoutStyle({
+        maximized: false,
+        visible: false,
+        visibleWidth: "var(--orgii-chat-width)",
+      })
+    ).toEqual({
+      flexBasis: 0,
+      flexGrow: 0,
+      flexShrink: 0,
+      pointerEvents: "none",
+      width: 0,
+    });
+  });
+
+  it("uses the exact configured width for a visible chat pane", () => {
+    const width = "var(--orgii-chat-width)";
+    expect(
+      getChatSlotLayoutStyle({
+        maximized: false,
+        visible: true,
+        visibleWidth: width,
+      })
+    ).toMatchObject({ flexBasis: width, pointerEvents: "auto", width });
+  });
+
+  it("exchanges normal-flow flex growth between chat and workstation", () => {
+    expect(
+      getChatSlotLayoutStyle({
+        maximized: true,
+        visible: true,
+        visibleWidth: 520,
+      }).flexGrow
+    ).toBe(1);
+    expect(getWorkbenchLayoutStyle(true).flexGrow).toBe(0);
+    expect(getWorkbenchLayoutStyle(false).flexGrow).toBe(1);
+  });
+});

--- a/src/modules/shared/layouts/viewContainerTokens.ts
+++ b/src/modules/shared/layouts/viewContainerTokens.ts
@@ -7,9 +7,15 @@
 import type { CSSProperties } from "react";
 
 import {
+  HOST_DESKTOP,
+  resolveHostDesktop,
+} from "@src/config/windowChromeRadius";
+import {
   sanitizePageOpacity,
   sanitizeSidebarOpacity,
 } from "@src/store/ui/backgroundConfigAtom";
+
+const IS_MACOS_HOST = resolveHostDesktop() === HOST_DESKTOP.MACOS;
 
 /**
  * View container class strings for modules/index.tsx
@@ -52,7 +58,7 @@ export const LAYOUT_CONTAIN_STYLE: CSSProperties = {
 export function getPagePanelBackgroundStyle(
   pageOpacity: number | undefined
 ): CSSProperties {
-  const opacity = sanitizePageOpacity(pageOpacity);
+  const opacity = IS_MACOS_HOST ? 100 : sanitizePageOpacity(pageOpacity);
   return {
     backgroundColor: `color-mix(in srgb, var(--color-bg-2) ${opacity}%, transparent)`,
   };
@@ -88,7 +94,7 @@ export function getSidebarSurfaceBackgroundStyle(
 export function getChatPanelBackgroundStyle(
   pageOpacity: number | undefined
 ): CSSProperties {
-  const opacity = sanitizePageOpacity(pageOpacity);
+  const opacity = IS_MACOS_HOST ? 100 : sanitizePageOpacity(pageOpacity);
   const chatPaneMix = `color-mix(in srgb, var(--color-chat-pane-base) ${opacity}%, transparent)`;
   return {
     backgroundColor: chatPaneMix,

--- a/src/modules/shared/layouts/viewContainerTokens.ts
+++ b/src/modules/shared/layouts/viewContainerTokens.ts
@@ -18,6 +18,56 @@ import {
 const IS_MACOS_HOST = resolveHostDesktop() === HOST_DESKTOP.MACOS;
 
 /**
+ * Shared pane transition. It animates layout dimensions themselves rather
+ * than transforms, so ResizeObserver and native-webview measurements see the
+ * real intermediate width throughout the motion.
+ */
+export const PANE_WIDTH_TRANSITION_CLASSES =
+  "transition-[width,flex-grow,flex-basis] duration-200 ease-out motion-reduce:transition-none";
+
+interface ChatSlotLayoutStyleOptions {
+  maximized: boolean;
+  visible: boolean;
+  visibleWidth: string | number;
+}
+
+/** Normal-flow flex geometry for the chat pane at each visibility state. */
+export function getChatSlotLayoutStyle({
+  maximized,
+  visible,
+  visibleWidth,
+}: ChatSlotLayoutStyleOptions): CSSProperties {
+  if (maximized) {
+    return {
+      flexBasis: 0,
+      flexGrow: 1,
+      flexShrink: 1,
+      width: 0,
+    };
+  }
+
+  const width = visible ? visibleWidth : 0;
+  return {
+    flexBasis: width,
+    flexGrow: 0,
+    flexShrink: 0,
+    pointerEvents: visible ? "auto" : "none",
+    width,
+  };
+}
+
+/** Normal-flow flex geometry for the workstation beside the chat pane. */
+export function getWorkbenchLayoutStyle(maximized: boolean): CSSProperties {
+  return {
+    flexBasis: 0,
+    flexGrow: maximized ? 0 : 1,
+    flexShrink: 1,
+    pointerEvents: maximized ? "none" : "auto",
+    width: 0,
+  };
+}
+
+/**
  * View container class strings for modules/index.tsx
  *
  * `WithBg` suffix preserved for backward-compat in caller code. The

--- a/src/scaffold/ModalSystem/index.scss
+++ b/src/scaffold/ModalSystem/index.scss
@@ -18,7 +18,7 @@
   isolation: isolate; // Create new stacking context
   border-radius: var(
     --border-radius-window
-  ); // Match window corner radius (26px)
+  ); // Match the host window corner radius
   overflow: hidden; // Clip children to rounded corners
 }
 
@@ -34,7 +34,7 @@
   animation: mask-fade-in 0.25s cubic-bezier(0.4, 0, 0.2, 1);
   border-radius: var(
     --border-radius-window
-  ); // Match window corner radius (26px)
+  ); // Match the host window corner radius
 
   [data-theme="dark"] & {
     background: rgba(0, 0, 0, 0.7);

--- a/src/scaffold/NavigationSidebar/SidebarBase.tsx
+++ b/src/scaffold/NavigationSidebar/SidebarBase.tsx
@@ -52,6 +52,7 @@ import type { SidebarBaseProps } from "./types";
 const log = createLogger("SidebarBase");
 
 const HOST_DESKTOP_KIND = resolveHostDesktop();
+const IS_MACOS_HOST = HOST_DESKTOP_KIND === HOST_DESKTOP.MACOS;
 const IS_WINDOWS_HOST = HOST_DESKTOP_KIND === HOST_DESKTOP.WINDOWS;
 const SHOW_HOST_TITLE =
   HOST_DESKTOP_KIND === HOST_DESKTOP.WINDOWS ||
@@ -97,6 +98,9 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
     } = useSidebarState();
     const sidebarSelectedRowOpacity = useSettingValue(
       "layout.sidebarSelectedRowOpacity"
+    );
+    const sidebarEdgeDepthEnabled = useSettingValue(
+      "layout.sidebarEdgeDepthEnabled"
     );
     useEffect(() => {
       document.body.style.setProperty(
@@ -441,12 +445,11 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
     );
 
     // Modern layout: the sidebar is flush with the rounded window edge
-    // (top-left + bottom-left curves match `--border-radius-window`). Both
-    // the floating drop shadow and the backdrop-filter blur produce a
-    // faint dark halo along that curve — the shadow smudges the boundary
-    // with the content panel, and `backdrop-filter` samples beyond the
-    // rounded clip on WebKit, leaving a visible "shade" tracing the
-    // corner. Drop both in compact so the corner is a clean fill.
+    // (top-left + bottom-left curves match `--border-radius-window`). Avoid
+    // a broad docked drop shadow because it traces the window corner. On
+    // macOS, use a narrow inset edge shadow instead: it creates the vertical
+    // Codex-style depth where the sidebar meets the content panel without
+    // bleeding outside the rounded clip.
     //
     // Floating / hover sidebar: it pops out over the workspace content as
     // a transient overlay. It should feel solid (so it's legible against
@@ -456,7 +459,9 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
     // current layout mode so it visually detaches from the workspace.
     const sidebarBoxShadow = shouldForceVisible
       ? "var(--sidebar-shadow)"
-      : "none";
+      : IS_MACOS_HOST && sidebarEdgeDepthEnabled
+        ? "var(--sidebar-edge-shadow)"
+        : "none";
     const sidebarBackdropFilter = "none";
     const floatingSurfaceOverride: React.CSSProperties = shouldForceVisible
       ? { backgroundColor: "var(--color-bg-1)" }

--- a/src/scaffold/NavigationSidebar/SidebarBase.tsx
+++ b/src/scaffold/NavigationSidebar/SidebarBase.tsx
@@ -22,7 +22,7 @@ import {
 import i18next from "i18next";
 import { useAtomValue, useSetAtom } from "jotai";
 import { PanelLeft, Plus, X } from "lucide-react";
-import React, { useCallback, useEffect, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
 
 import { KeyboardShortcutTooltipContent } from "@src/components/KeyboardShortcut";
 import Tooltip from "@src/components/Tooltip";
@@ -34,7 +34,10 @@ import {
 import { createLogger } from "@src/hooks/logger";
 import { useSettingValue } from "@src/hooks/settings/useSettings";
 import { useSidebarState } from "@src/hooks/ui/sidebar/useSidebarState";
-import { getSidebarSurfaceBackgroundStyle } from "@src/modules/shared/layouts/viewContainerTokens";
+import {
+  PANE_WIDTH_TRANSITION_CLASSES,
+  getSidebarSurfaceBackgroundStyle,
+} from "@src/modules/shared/layouts/viewContainerTokens";
 import { VerticalResizeHandle } from "@src/scaffold/Resize";
 import { resolvedBackgroundConfigAtom } from "@src/store/ui/backgroundConfigAtom";
 import { hoverSidebarOpenAtom } from "@src/store/ui/hoverSidebarAtom";
@@ -87,8 +90,10 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
     beforeAddNewActions,
     headerActions,
   }) => {
+    const sidebarContainerRef = useRef<HTMLDivElement>(null);
     const {
       width: sidebarWidth,
+      expandedWidth: expandedSidebarWidth,
       isDragging,
       handleMouseDown,
       isCollapsed,
@@ -108,7 +113,6 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
         `${sidebarSelectedRowOpacity}%`
       );
     }, [sidebarSelectedRowOpacity]);
-
     const isMacOS = isTauriDesktop();
     const hideSidebarShortcut = getShortcutKeys("toggle_sidebar");
     const isFullscreen = useAtomValue(windowFullscreenAtom);
@@ -121,6 +125,16 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
     // Check for force visible from context (for hover sidebar)
     const forceVisibleFromContext = useForceVisibleSidebar();
     const shouldForceVisible = forceVisibleProp || forceVisibleFromContext;
+    useEffect(() => {
+      if (!isCollapsed || shouldForceVisible) return;
+      const activeElement = document.activeElement;
+      if (
+        activeElement instanceof HTMLElement &&
+        sidebarContainerRef.current?.contains(activeElement)
+      ) {
+        activeElement.blur();
+      }
+    }, [isCollapsed, shouldForceVisible]);
 
     // Check if hover sidebar is open — split read/write to avoid re-renders from setter reference
     const isHoverSidebarOpen = useAtomValue(hoverSidebarOpenAtom);
@@ -223,6 +237,10 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
     // When forceVisible and collapsed, use default width instead of 0
     const effectiveWidth =
       shouldForceVisible && isCollapsed ? DEFAULT_SIDEBAR_WIDTH : sidebarWidth;
+    const surfaceWidth =
+      shouldForceVisible && isCollapsed
+        ? DEFAULT_SIDEBAR_WIDTH
+        : expandedSidebarWidth;
 
     // Memoize outer container style to avoid re-creating on every render
     const containerStyle = useMemo(
@@ -230,15 +248,18 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
         ({
           width: `${effectiveWidth}px`,
           willChange: isDragging ? ("width" as const) : ("auto" as const),
+          pointerEvents:
+            isCollapsed && !shouldForceVisible ? ("none" as const) : undefined,
           "--sidebar-selected-row-opacity": `${sidebarSelectedRowOpacity}%`,
         }) as React.CSSProperties,
-      [effectiveWidth, isDragging, sidebarSelectedRowOpacity]
+      [
+        effectiveWidth,
+        isCollapsed,
+        isDragging,
+        shouldForceVisible,
+        sidebarSelectedRowOpacity,
+      ]
     );
-
-    // Don't render if collapsed (unless forceVisible is true)
-    if (isCollapsed && !shouldForceVisible) {
-      return null;
-    }
 
     const sidebarTopChromeClassName = SIDEBAR_TOP_CHROME_CLASS_NAME;
 
@@ -506,13 +527,14 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
     } as const;
     const wrappedContent = wrapInSurface ? (
       <div
-        className={`sidebar-base flex h-full w-full flex-col ${innerClassName}`}
+        className={`sidebar-base flex h-full w-full flex-col overflow-hidden ${innerClassName}`}
       >
         <div
-          className="flex flex-1 flex-col overflow-hidden"
+          className="flex h-full flex-none flex-col overflow-hidden"
           style={{
             ...surfaceStyle,
             ...modernSurfaceStyle,
+            width: `${surfaceWidth}px`,
           }}
         >
           {content}
@@ -529,14 +551,17 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
 
     return (
       <div
+        ref={sidebarContainerRef}
         className={`group/sidebar relative flex h-full flex-shrink-0 ${
-          isDragging ? "" : "transition-[width] duration-150"
+          isDragging ? "" : PANE_WIDTH_TRANSITION_CLASSES
         } ${className}`}
         style={containerStyle}
+        aria-hidden={isCollapsed && !shouldForceVisible}
+        data-sidebar-collapsed={isCollapsed || undefined}
         onContextMenu={handleResizeContextMenu}
       >
         {wrappedContent}
-        {renderResizeHandle()}
+        {(!isCollapsed || shouldForceVisible) && renderResizeHandle()}
       </div>
     );
   }

--- a/src/scaffold/NavigationSidebar/SidebarBase.tsx
+++ b/src/scaffold/NavigationSidebar/SidebarBase.tsx
@@ -22,7 +22,7 @@ import {
 import i18next from "i18next";
 import { useAtomValue, useSetAtom } from "jotai";
 import { PanelLeft, Plus, X } from "lucide-react";
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 
 import { KeyboardShortcutTooltipContent } from "@src/components/KeyboardShortcut";
 import Tooltip from "@src/components/Tooltip";
@@ -32,6 +32,7 @@ import {
   resolveHostDesktop,
 } from "@src/config/windowChromeRadius";
 import { createLogger } from "@src/hooks/logger";
+import { useSettingValue } from "@src/hooks/settings/useSettings";
 import { useSidebarState } from "@src/hooks/ui/sidebar/useSidebarState";
 import { getSidebarSurfaceBackgroundStyle } from "@src/modules/shared/layouts/viewContainerTokens";
 import { VerticalResizeHandle } from "@src/scaffold/Resize";
@@ -94,6 +95,15 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
       expand,
       setWidth,
     } = useSidebarState();
+    const sidebarSelectedRowOpacity = useSettingValue(
+      "layout.sidebarSelectedRowOpacity"
+    );
+    useEffect(() => {
+      document.body.style.setProperty(
+        "--sidebar-selected-row-opacity",
+        `${sidebarSelectedRowOpacity}%`
+      );
+    }, [sidebarSelectedRowOpacity]);
 
     const isMacOS = isTauriDesktop();
     const hideSidebarShortcut = getShortcutKeys("toggle_sidebar");
@@ -212,11 +222,13 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
 
     // Memoize outer container style to avoid re-creating on every render
     const containerStyle = useMemo(
-      () => ({
-        width: `${effectiveWidth}px`,
-        willChange: isDragging ? ("width" as const) : ("auto" as const),
-      }),
-      [effectiveWidth, isDragging]
+      () =>
+        ({
+          width: `${effectiveWidth}px`,
+          willChange: isDragging ? ("width" as const) : ("auto" as const),
+          "--sidebar-selected-row-opacity": `${sidebarSelectedRowOpacity}%`,
+        }) as React.CSSProperties,
+      [effectiveWidth, isDragging, sidebarSelectedRowOpacity]
     );
 
     // Don't render if collapsed (unless forceVisible is true)
@@ -297,7 +309,7 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
                     role="button"
                     tabIndex={0}
                   >
-                    <div className="flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-[100px] transition-colors duration-150 hover:bg-fill-2">
+                    <div className="flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-[100px] transition-colors duration-150 hover:bg-sidebar-selected">
                       <AddIcon
                         size={16}
                         strokeWidth={2}
@@ -329,7 +341,7 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
                     {/* Expand sidebar permanently button */}
                     <button
                       type="button"
-                      className="flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-[100px] border-none bg-transparent p-0 transition-colors duration-150 hover:bg-fill-2"
+                      className="flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-[100px] border-none bg-transparent p-0 transition-colors duration-150 hover:bg-sidebar-selected"
                       onClick={handleExpand}
                     >
                       <PanelLeft
@@ -342,7 +354,7 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
                     {/* Close floating sidebar button */}
                     <button
                       type="button"
-                      className="flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-[100px] border-none bg-transparent p-0 transition-colors duration-150 hover:bg-fill-2"
+                      className="flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-[100px] border-none bg-transparent p-0 transition-colors duration-150 hover:bg-sidebar-selected"
                       onClick={handleCollapse}
                     >
                       <X
@@ -368,7 +380,7 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
                     <div className="inline-flex">
                       <button
                         type="button"
-                        className="flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-[100px] border-none bg-transparent p-0 transition-colors duration-150 hover:bg-fill-2"
+                        className="flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-[100px] border-none bg-transparent p-0 transition-colors duration-150 hover:bg-sidebar-selected"
                         onClick={handleCollapse}
                       >
                         <PanelLeft

--- a/src/scaffold/NavigationSidebar/blocks/SidebarGroup.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarGroup.tsx
@@ -82,8 +82,8 @@ function SidebarGroupInner<T extends SidebarItemData = SidebarItemData>({
         <div
           className={`group mx-2 flex h-[36px] cursor-pointer items-center justify-between rounded-lg px-2 transition-colors duration-150 ${
             hasSelectedChild
-              ? "bg-fill-2 text-primary-6"
-              : "text-text-1 hover:bg-fill-2"
+              ? "bg-sidebar-selected text-text-1"
+              : "text-text-1 hover:bg-sidebar-selected"
           }`}
           onClick={handleToggle}
         >
@@ -91,15 +91,10 @@ function SidebarGroupInner<T extends SidebarItemData = SidebarItemData>({
             {/* Icon */}
             {group.icon &&
               renderSidebarIcon(group.icon, {
-                className: hasSelectedChild ? "text-primary-6" : "text-text-1",
+                className: "text-text-1",
               })}
             {/* Title */}
-            <span
-              className={`text-[13px] ${
-                hasSelectedChild ? "font-medium text-primary-6" : "text-text-1"
-              }`}
-              style={headerStyle}
-            >
+            <span className="text-[13px] text-text-1" style={headerStyle}>
               {group.title}
             </span>
           </div>
@@ -112,7 +107,7 @@ function SidebarGroupInner<T extends SidebarItemData = SidebarItemData>({
                   e.stopPropagation();
                   group.onAddNew?.();
                 }}
-                className="flex h-5 w-5 items-center justify-center rounded text-text-3 opacity-0 transition-all hover:bg-fill-2 hover:text-primary-6 group-hover:opacity-100"
+                className="flex h-5 w-5 items-center justify-center rounded text-text-3 opacity-0 transition-all hover:bg-sidebar-selected hover:text-primary-6 group-hover:opacity-100"
                 title={group.addButtonLabel || t("sidebar.actions.addNew")}
               >
                 <Plus size={12} strokeWidth={2} />
@@ -123,13 +118,13 @@ function SidebarGroupInner<T extends SidebarItemData = SidebarItemData>({
               <ChevronsUpDown
                 size={12}
                 strokeWidth={2}
-                className={hasSelectedChild ? "text-primary-6" : "text-text-2"}
+                className="text-text-2"
               />
             ) : (
               <ChevronsDownUp
                 size={12}
                 strokeWidth={2}
-                className={hasSelectedChild ? "text-primary-6" : "text-text-2"}
+                className="text-text-2"
               />
             )}
           </div>

--- a/src/scaffold/NavigationSidebar/blocks/SidebarHeaderNavButton.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarHeaderNavButton.tsx
@@ -20,7 +20,7 @@ const SidebarHeaderNavButton: React.FC<SidebarHeaderNavButtonProps> = ({
 }) => {
   return (
     <div
-      className={`group flex min-h-[36px] w-full cursor-pointer items-center justify-between overflow-hidden rounded-lg px-2 text-text-1 transition-colors duration-150 hover:bg-fill-2 ${className}`}
+      className={`group flex min-h-[36px] w-full cursor-pointer items-center justify-between overflow-hidden rounded-lg px-2 text-text-1 transition-colors duration-150 hover:bg-sidebar-selected ${className}`}
       onClick={onClick}
       role="button"
       tabIndex={0}

--- a/src/scaffold/NavigationSidebar/blocks/SidebarItem.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarItem.tsx
@@ -41,16 +41,16 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
     : isActive
       ? isPrivateTab
         ? "font-medium text-warning-6"
-        : "font-medium text-text-1"
+        : "text-text-1"
       : "text-text-1";
 
   const rowStateClasses = isActive
     ? isPrivateTab
       ? "bg-bg-1 text-warning-6"
-      : "bg-bg-1 text-text-1"
+      : "bg-sidebar-selected text-text-1"
     : theme
       ? "text-text-1"
-      : "text-text-1 hover:bg-fill-2";
+      : "text-text-1 hover:bg-sidebar-selected";
 
   const handleContextMenu = (event: React.MouseEvent<HTMLDivElement>) => {
     if (!canSecondaryClickClose || !onClose) return;

--- a/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.tsx
@@ -251,7 +251,7 @@ const SidebarSettingsMenuButton: React.FC = React.memo(() => {
             type="button"
             aria-label={t("sidebar.bottomBar.settings")}
             className={`flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-[100px] border-none p-0 transition-colors duration-150 ${
-              isOpen ? "bg-bg-1" : "bg-transparent hover:bg-fill-2"
+              isOpen ? "bg-bg-1" : "bg-transparent hover:bg-sidebar-selected"
             }`}
             onClick={handleToggle}
             onMouseEnter={(event) => triggerIconAnimation(event.currentTarget)}

--- a/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.tsx
@@ -4,6 +4,7 @@ import {
   Contrast,
   Gauge,
   HelpCircle,
+  House,
   Laptop,
   MessageCircle,
   MousePointer2,
@@ -76,7 +77,7 @@ function getSubmenuPosition(
 const SidebarSettingsMenuButton: React.FC = React.memo(() => {
   const { t } = useTranslation("navigation");
   const { t: tSettings } = useTranslation("settings");
-  const { goToSettings } = useAppNavigation();
+  const { goToSettings, goToStartPage } = useAppNavigation();
   const ramPanelRef = useRef<HTMLDivElement | null>(null);
   const submenuPanelRef = useRef<HTMLDivElement | null>(null);
   const preserveRamPanelOnMenuCloseRef = useRef(false);
@@ -179,6 +180,11 @@ const SidebarSettingsMenuButton: React.FC = React.memo(() => {
     goToSettings();
   }, [closeAll, goToSettings]);
 
+  const handleOpenHome = useCallback(() => {
+    closeAll();
+    goToStartPage();
+  }, [closeAll, goToStartPage]);
+
   const handleViewRam = useCallback(() => {
     setActiveSubmenu(null);
     setSubmenuPosition(null);
@@ -274,6 +280,20 @@ const SidebarSettingsMenuButton: React.FC = React.memo(() => {
             }}
           >
             <div className={DROPDOWN_CLASSES.itemsColumn}>
+              <button
+                type="button"
+                className={`${DROPDOWN_CLASSES.menuActionItem} gap-2`}
+                onMouseEnter={() => setActiveSubmenu(null)}
+                onFocus={() => setActiveSubmenu(null)}
+                onClick={handleOpenHome}
+              >
+                <House
+                  size={DROPDOWN_ITEM.iconSize}
+                  className={MENU_ICON_CLASS_NAME}
+                />
+                <span>{t("sidebar.tabs.build")}</span>
+              </button>
+              <div className={DROPDOWN_CLASSES.menuSeparator} />
               <button
                 type="button"
                 className={`${DROPDOWN_CLASSES.menuActionItem} justify-between`}

--- a/src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/NavigationMenuRow.tsx
+++ b/src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/NavigationMenuRow.tsx
@@ -62,7 +62,7 @@ export const NavigationMenuParentRow = React.forwardRef<
   },
   ref
 ): React.ReactElement {
-  const iconColor = submenuSelected ? "text-primary-6" : "text-text-1";
+  const iconColor = "text-text-1";
   const { dragHandlers, dragState } = useNavItemDrag(item);
   const {
     cursorReset,
@@ -99,7 +99,7 @@ export const NavigationMenuParentRow = React.forwardRef<
         data-testid={item.dataTestId}
         className={`group flex ${rowHeightClass} items-center justify-between rounded-lg transition-colors duration-150 ${
           isChild ? "pl-5 pr-2" : "px-2"
-        } ${submenuSelected ? "cursor-default bg-fill-2 text-primary-6" : cursorReset ? "cursor-default text-text-1 hover:bg-fill-2" : "cursor-pointer text-text-1 hover:bg-fill-2"}`}
+        } ${submenuSelected ? "cursor-default bg-sidebar-selected text-text-1" : cursorReset ? "cursor-default text-text-1 hover:bg-sidebar-selected" : "cursor-pointer text-text-1 hover:bg-sidebar-selected"}`}
         onClick={() => {
           if (item.disabled) return;
           markClicked();
@@ -117,11 +117,7 @@ export const NavigationMenuParentRow = React.forwardRef<
           })}
           {!collapsed && (
             <div className="flex min-w-0 flex-1 flex-col gap-0">
-              <span
-                className={`truncate text-[13px] ${
-                  submenuSelected ? "font-medium text-primary-6" : "text-text-1"
-                }`}
-              >
+              <span className="truncate text-[13px] text-text-1">
                 {item.label}
               </span>
               {item.subtitle && (
@@ -143,7 +139,7 @@ export const NavigationMenuParentRow = React.forwardRef<
               type="button"
               aria-label={isOpen ? t("actions.collapse") : t("actions.expand")}
               title={isOpen ? t("actions.collapse") : t("actions.expand")}
-              className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded text-text-3 transition-colors duration-150 hover:bg-fill-2 hover:text-text-1 focus:outline-none"
+              className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded text-text-3 transition-colors duration-150 hover:bg-sidebar-selected hover:text-text-1 focus:outline-none"
               data-testid={`${item.key}-session-tree-toggle`}
               onClick={(event) => {
                 event.preventDefault();
@@ -156,7 +152,7 @@ export const NavigationMenuParentRow = React.forwardRef<
                 strokeWidth={2}
                 className={`transition-transform duration-200 ${
                   isOpen ? "rotate-180" : ""
-                } ${submenuSelected ? "text-primary-6" : "text-text-2"}`}
+                } text-text-2`}
               />
             </button>
           </span>
@@ -225,7 +221,7 @@ export const NavigationMenuLeafRow = React.forwardRef<
       ? "text-text-2"
       : "text-text-3"
     : isSelected
-      ? "text-primary-6"
+      ? "text-text-1"
       : isSecondaryTone
         ? "text-text-2"
         : "text-text-1";
@@ -273,10 +269,10 @@ export const NavigationMenuLeafRow = React.forwardRef<
               ? "cursor-default text-text-2 opacity-60"
               : "cursor-default text-text-3 opacity-60"
             : isSelected
-              ? "cursor-default bg-fill-2 text-primary-6"
+              ? "cursor-default bg-sidebar-selected text-text-1"
               : isSecondaryTone
-                ? `${cursorReset ? "cursor-default" : "cursor-pointer"} text-text-2 hover:bg-fill-2 hover:text-text-1`
-                : `${cursorReset ? "cursor-default" : "cursor-pointer"} text-text-1 hover:bg-fill-2`
+                ? `${cursorReset ? "cursor-default" : "cursor-pointer"} text-text-2 hover:bg-sidebar-selected hover:text-text-1`
+                : `${cursorReset ? "cursor-default" : "cursor-pointer"} text-text-1 hover:bg-sidebar-selected`
         }`}
         onClick={(event: React.MouseEvent) => {
           if (item.disabled) return;
@@ -306,7 +302,7 @@ export const NavigationMenuLeafRow = React.forwardRef<
                       ? "text-text-2"
                       : "text-text-3"
                     : isSelected
-                      ? "font-medium text-primary-6"
+                      ? "text-text-1"
                       : isSecondaryTone
                         ? "text-text-2"
                         : "text-text-1"
@@ -366,7 +362,7 @@ function renderLeadingIcon({
         type="button"
         aria-label={action.label}
         title={action.label}
-        className={`pointer-events-none absolute left-1/2 top-1/2 flex h-5 w-5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded opacity-0 transition-[background-color,color,opacity] duration-150 hover:bg-fill-2 hover:text-text-1 focus:pointer-events-auto focus:opacity-100 focus:outline-none group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100 ${
+        className={`pointer-events-none absolute left-1/2 top-1/2 flex h-5 w-5 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded opacity-0 transition-[background-color,color,opacity] duration-150 hover:bg-sidebar-selected hover:text-text-1 focus:pointer-events-auto focus:opacity-100 focus:outline-none group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100 ${
           action.active ? "text-primary-6" : "text-text-3"
         }`}
         onClick={(event) => {
@@ -445,7 +441,7 @@ function renderLeafRowAccessory({
             <ChevronRight
               size={13}
               strokeWidth={2}
-              className={isSelected ? "text-primary-6" : "text-text-3"}
+              className={isSelected ? "text-text-1" : "text-text-3"}
             />
           )}
         </>

--- a/src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/RowAccessorySlot.tsx
+++ b/src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/RowAccessorySlot.tsx
@@ -33,10 +33,17 @@ export function NavigationMenuRowAccessorySlot({
     actionContent ||
     workingIndicatorContent
   );
+  const hasHoverReplacement = Boolean(hoverContent || actionContent);
   const stackedContent = hasStacked ? (
     <span className="grid items-center justify-end leading-none">
       {(persistentContent || workingIndicatorContent) && (
-        <span className="col-start-1 row-start-1 inline-flex items-center justify-end leading-none transition-opacity duration-150 group-hover:pointer-events-none group-hover:opacity-0">
+        <span
+          className={`col-start-1 row-start-1 inline-flex items-center justify-end leading-none transition-opacity duration-150 ${
+            hasHoverReplacement
+              ? "group-hover:pointer-events-none group-hover:opacity-0"
+              : ""
+          }`}
+        >
           {persistentContent}
           {workingIndicatorContent}
         </span>

--- a/src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/RowActionButton.tsx
+++ b/src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/RowActionButton.tsx
@@ -23,7 +23,7 @@ export function NavigationMenuRowActionButton({
       type="button"
       aria-label={label}
       title={label}
-      className={`flex h-5 w-5 flex-shrink-0 items-center justify-center rounded transition-colors duration-150 hover:bg-fill-2 hover:text-text-1 focus:outline-none ${
+      className={`flex h-5 w-5 flex-shrink-0 items-center justify-center rounded transition-colors duration-150 hover:bg-sidebar-selected hover:text-text-1 focus:outline-none ${
         active ? "text-primary-6" : "text-text-3"
       }`}
       onClick={(event) => {

--- a/src/scaffold/NavigationSidebar/connectors/SidebarRamMonitorButton/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/SidebarRamMonitorButton/index.tsx
@@ -257,7 +257,7 @@ export const SidebarRamMonitorButton: React.FC = React.memo(() => {
         <button
           type="button"
           className={`flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-[100px] border-none p-0 transition-colors duration-150 ${
-            isOpen ? "bg-bg-1" : "bg-transparent hover:bg-fill-2"
+            isOpen ? "bg-bg-1" : "bg-transparent hover:bg-sidebar-selected"
           }`}
           onClick={toggle}
           onMouseEnter={(event) => triggerIconAnimation(event.currentTarget)}

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/bottomActions.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/bottomActions.tsx
@@ -52,7 +52,7 @@ export function useSidebarBottomRightActions({
         type="button"
         title={collapseAllLabel}
         aria-label={collapseAllLabel}
-        className="flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-[100px] border-none bg-transparent p-0 transition-colors duration-150 hover:bg-fill-2"
+        className="flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-[100px] border-none bg-transparent p-0 transition-colors duration-150 hover:bg-sidebar-selected"
         onClick={handleCollapseAllActiveSections}
       >
         <ListChevronsDownUp size={16} strokeWidth={2} className="text-text-2" />

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
@@ -1,6 +1,6 @@
 import { RenameModal } from "@/src/scaffold/ModalSystem/variants";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import { Search } from "lucide-react";
+import { ChevronLeft, Search } from "lucide-react";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
@@ -72,11 +72,15 @@ import {
   toChatPanelTuiSessionId,
 } from "@src/util/ui/terminal/chatPanelTuiSessionId";
 
-import { SidebarBottomBar } from "../../blocks";
+import { SidebarBottomBar, SidebarHeaderNavButton } from "../../blocks";
 import SidebarSettingsMenuButton from "../../blocks/SidebarSettingsMenuButton";
 import NavigationSidebar from "../../variants/NavigationSidebar";
 import SidebarOrgSelector from "../SidebarOrgSelector";
-import { COLLAB_ADD_ORG_MENU_ITEM_ID } from "../sidebarConnectorUtils";
+import {
+  COLLAB_ADD_ORG_MENU_ITEM_ID,
+  WORKSPACES_SIDEBAR_MENU_ITEM_ID,
+  WORK_ITEMS_SIDEBAR_MENU_ITEM_ID,
+} from "../sidebarConnectorUtils";
 import {
   sidebarGroupByAtom,
   sidebarIncludeExternalAtom,
@@ -117,11 +121,7 @@ import {
   useSessionSidebarMenuItems,
 } from "./sidebarMenuCollections";
 import { useSidebarSessionRefreshEffects } from "./sidebarSessionRefresh";
-import {
-  SidebarSearchShortcutTooltip,
-  isWorkstationSidebarKey,
-  useWorkstationSidebarTabs,
-} from "./sidebarTabs";
+import { SidebarSearchShortcutTooltip } from "./sidebarTabs";
 import type { WorkstationSidebarKey } from "./types";
 import {
   openRepoTarget,
@@ -193,10 +193,7 @@ export const WorkstationSidebarConnector: React.FC = () => {
   >({ folders: "", workstation: "", projects: "" });
   const [, setFoldersDashboardSelected] = useState(false);
   const [, setFoldersExploreSelected] = useState(false);
-  const tabs = useWorkstationSidebarTabs(t);
-
-  const handleTabChange = useCallback((key: string) => {
-    if (!isWorkstationSidebarKey(key)) return;
+  const handleSidebarLayerChange = useCallback((key: WorkstationSidebarKey) => {
     if (key !== "folders") {
       setFoldersDashboardSelected(false);
       setFoldersExploreSelected(false);
@@ -304,6 +301,8 @@ export const WorkstationSidebarConnector: React.FC = () => {
   const unpinFolderLabel = tCommon("sessions:chat.unpinSession", "Unpin");
   const createProjectLabel = tProjects("projects.createProject");
   const createWorkItemLabel = tProjects("workItems.createWorkItem");
+  const workspacesLabel = t("launchpad.dashboardTitle");
+  const workItemsLabel = t("labels.workItems");
   const importGithubIssuesLabel = tProjects("githubIssuesImport.menuLabel");
   const addOrgLabel = t("collaboration.addOrg");
   const searchPlaceholder =
@@ -406,6 +405,8 @@ export const WorkstationSidebarConnector: React.FC = () => {
     createWorkItemLabel,
     importGithubIssuesLabel,
     newSessionLabel,
+    workspacesLabel,
+    workItemsLabel,
     t,
   });
   const sessionSidebarMenuItems = useSessionSidebarMenuItems({
@@ -736,14 +737,39 @@ export const WorkstationSidebarConnector: React.FC = () => {
 
   const handleSessionMenuItemClick = useCallback(
     (key: string, item: NavigationMenuItem) => {
+      if (item.id === WORKSPACES_SIDEBAR_MENU_ITEM_ID) {
+        handleSidebarLayerChange("folders");
+        return;
+      }
+      if (item.id === WORK_ITEMS_SIDEBAR_MENU_ITEM_ID) {
+        handleSidebarLayerChange("projects");
+        return;
+      }
       if (isChatTerminalSidebarItem(item.id)) {
         activateChatPanelTab(getChatTerminalTabId(item.id));
         return;
       }
       handleMenuItemClick(key, item);
     },
-    [activateChatPanelTab, handleMenuItemClick]
+    [activateChatPanelTab, handleMenuItemClick, handleSidebarLayerChange]
   );
+
+  const handleBackToSessionSidebar = useCallback(() => {
+    handleSidebarLayerChange("workstation");
+  }, [handleSidebarLayerChange]);
+
+  const sidebarLayerHeader =
+    activeSidebarKey === "workstation" ? null : (
+      <div className="shrink-0 px-3">
+        <SidebarHeaderNavButton
+          icon={ChevronLeft}
+          label={
+            activeSidebarKey === "folders" ? workspacesLabel : workItemsLabel
+          }
+          onClick={handleBackToSessionSidebar}
+        />
+      </div>
+    );
 
   const resolvedMenuItemClick =
     activeSidebarKey === "projects"
@@ -833,21 +859,22 @@ export const WorkstationSidebarConnector: React.FC = () => {
     pinnedMenuItems,
     selectedMenuItemId,
     sidebarMenuItems,
-    tabCount: tabs.length,
+    tabCount: 0,
   });
 
   return (
     <>
       <NavigationSidebar
-        items={tabs}
+        items={[]}
         activeKey={activeSidebarKey}
-        onChange={handleTabChange}
+        onChange={() => undefined}
         menuItems={sidebarMenuItems}
         pinnedMenuItems={pinnedMenuItems}
         selectedKey={selectedMenuItemId}
         onMenuItemClick={resolvedMenuItemClick}
         onMenuItemContextMenu={resolvedMenuItemContextMenu}
         renderMenuItemWrapper={resolvedRenderMenuItemWrapper}
+        preListContent={sidebarLayerHeader}
         compactRows
         onAddNew={handleOpenSpotlight}
         addIcon={Search}

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
@@ -118,7 +118,6 @@ import {
 } from "./sidebarMenuCollections";
 import { useSidebarSessionRefreshEffects } from "./sidebarSessionRefresh";
 import {
-  HomeHeaderAction,
   SidebarSearchShortcutTooltip,
   isWorkstationSidebarKey,
   useWorkstationSidebarTabs,
@@ -180,7 +179,7 @@ export const WorkstationSidebarConnector: React.FC = () => {
     closeAndDestroyChatPanelTabAtom
   );
   const { openSession } = useSessionView();
-  const { goToStartPage, goToNewSession, navigateTo } = useAppNavigation();
+  const { goToNewSession, navigateTo } = useAppNavigation();
   const [activeSidebarKey, setActiveSidebarKey] =
     useState<WorkstationSidebarKey>("workstation");
   const [activeSessionMoreMenuId, setActiveSessionMoreMenuId] = useState("");
@@ -307,7 +306,6 @@ export const WorkstationSidebarConnector: React.FC = () => {
   const createWorkItemLabel = tProjects("workItems.createWorkItem");
   const importGithubIssuesLabel = tProjects("githubIssuesImport.menuLabel");
   const addOrgLabel = t("collaboration.addOrg");
-  const homeLabel = t("sidebar.tabs.build");
   const searchPlaceholder =
     activeSidebarKey === "projects"
       ? t("sidebar.search.projects")
@@ -857,13 +855,6 @@ export const WorkstationSidebarConnector: React.FC = () => {
         addTooltipContent={
           <SidebarSearchShortcutTooltip
             searchLabel={tCommon("actions.search")}
-          />
-        }
-        beforeAddNewActions={
-          <HomeHeaderAction
-            label={homeLabel}
-            tooltipLabel={t("sidebar.actions.openHome")}
-            onClick={goToStartPage}
           />
         }
         search={{

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarMenuCollections.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarMenuCollections.ts
@@ -42,6 +42,8 @@ interface UsePinnedMenuItemsParams {
   createWorkItemLabel: string;
   importGithubIssuesLabel: string;
   newSessionLabel: string;
+  workspacesLabel: string;
+  workItemsLabel: string;
   t: TFunction<"navigation">;
 }
 
@@ -56,6 +58,8 @@ export function usePinnedMenuItems({
   createWorkItemLabel,
   importGithubIssuesLabel,
   newSessionLabel,
+  workspacesLabel,
+  workItemsLabel,
   t,
 }: UsePinnedMenuItemsParams): UsePinnedMenuItemsResult {
   const sessionPinnedMenuItems = useMemo<NavigationMenuItem[]>(
@@ -66,8 +70,10 @@ export function usePinnedMenuItems({
         opsControlLabel: t("routes.opsControl"),
         opsControlRoutePath: ROUTES.workStation.opsControl.path,
         opsControlShortcut: getShortcutKeys("open_ops_control"),
+        workspacesLabel,
+        workItemsLabel,
       }),
-    [newSessionLabel, t]
+    [newSessionLabel, t, workItemsLabel, workspacesLabel]
   );
   const projectsPinnedMenuItems = useMemo<NavigationMenuItem[]>(
     () =>

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarTabs.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarTabs.tsx
@@ -1,43 +1,7 @@
-import type { TFunction } from "i18next";
-import { Folders, ListTodo, MessageCircle } from "lucide-react";
-import React, { useMemo } from "react";
+import React from "react";
 
 import { KeyboardShortcutTooltipContent } from "@src/components/KeyboardShortcut";
 import { getShortcutKeys } from "@src/config/keyboard/shortcutDisplay";
-
-import type { WorkstationSidebarKey } from "./types";
-
-export function isWorkstationSidebarKey(
-  key: string
-): key is WorkstationSidebarKey {
-  return key === "folders" || key === "workstation" || key === "projects";
-}
-
-export function useWorkstationSidebarTabs(t: TFunction<"navigation">) {
-  return useMemo(
-    () => [
-      {
-        key: "folders",
-        label: t("labels.folders"),
-        icon: Folders,
-        iconName: "folders",
-      },
-      {
-        key: "workstation",
-        label: t("labels.session"),
-        icon: MessageCircle,
-        iconName: "message-circle",
-      },
-      {
-        key: "projects",
-        label: t("labels.workItems"),
-        icon: ListTodo,
-        iconName: "list-todo",
-      },
-    ],
-    [t]
-  );
-}
 
 export function SidebarSearchShortcutTooltip({
   searchLabel,

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarTabs.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarTabs.tsx
@@ -1,9 +1,8 @@
 import type { TFunction } from "i18next";
-import { Folders, House, ListTodo, MessageCircle } from "lucide-react";
+import { Folders, ListTodo, MessageCircle } from "lucide-react";
 import React, { useMemo } from "react";
 
 import { KeyboardShortcutTooltipContent } from "@src/components/KeyboardShortcut";
-import Tooltip from "@src/components/Tooltip";
 import { getShortcutKeys } from "@src/config/keyboard/shortcutDisplay";
 
 import type { WorkstationSidebarKey } from "./types";
@@ -55,35 +54,5 @@ export function SidebarSearchShortcutTooltip({
         },
       ]}
     />
-  );
-}
-
-export function HomeHeaderAction({
-  label,
-  tooltipLabel,
-  onClick,
-}: {
-  label: string;
-  tooltipLabel: string;
-  onClick: () => void;
-}): React.ReactElement {
-  return (
-    <Tooltip
-      content={<KeyboardShortcutTooltipContent label={tooltipLabel} />}
-      position="bottom"
-      mouseEnterDelay={200}
-      framedPanel
-    >
-      <div className="inline-flex">
-        <button
-          type="button"
-          className="flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-[100px] border-none bg-transparent p-0 transition-colors duration-150 hover:bg-fill-2"
-          onClick={onClick}
-          aria-label={label}
-        >
-          <House size={16} strokeWidth={2} className="text-text-2" />
-        </button>
-      </div>
-    </Tooltip>
   );
 }

--- a/src/scaffold/NavigationSidebar/connectors/sidebarConnectorUtils.ts
+++ b/src/scaffold/NavigationSidebar/connectors/sidebarConnectorUtils.ts
@@ -18,6 +18,8 @@ export const PROJECTS_IMPORT_GITHUB_ISSUES_MENU_ITEM_ID =
   "projects-import-github-issues";
 export const PROJECTS_NEW_WORK_ITEM_MENU_ITEM_ID = "projects-new-work-item";
 export const OPS_CONTROL_MENU_ITEM_ID = "ops-control";
+export const WORKSPACES_SIDEBAR_MENU_ITEM_ID = "open-workspaces-sidebar";
+export const WORK_ITEMS_SIDEBAR_MENU_ITEM_ID = "open-work-items-sidebar";
 export const COLLAB_ADD_ORG_MENU_ITEM_ID = "colleagues-add-org";
 export const SESSION_CREATOR_DRAFT_MENU_PREFIX = "session-creator-draft:";
 

--- a/src/scaffold/NavigationSidebar/connectors/workstationSidebarMenuItems.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/workstationSidebarMenuItems.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  OPS_CONTROL_MENU_ITEM_ID,
+  WORKSPACES_SIDEBAR_MENU_ITEM_ID,
+  WORK_ITEMS_SIDEBAR_MENU_ITEM_ID,
+} from "./sidebarConnectorUtils";
+import { buildPinnedMenuItems } from "./workstationSidebarMenuItems";
+
+describe("buildPinnedMenuItems", () => {
+  it("places workspace drill-downs directly below Ops Control", () => {
+    const items = buildPinnedMenuItems({
+      newSessionLabel: "New Session",
+      newSessionShortcut: "⌘N",
+      opsControlLabel: "Ops Control",
+      opsControlRoutePath: "/ops-control",
+      opsControlShortcut: "⌘O",
+      workspacesLabel: "Workspaces",
+      workItemsLabel: "Work Items",
+    });
+
+    expect(items.map((item) => item.id)).toEqual([
+      "new-session",
+      OPS_CONTROL_MENU_ITEM_ID,
+      WORKSPACES_SIDEBAR_MENU_ITEM_ID,
+      WORK_ITEMS_SIDEBAR_MENU_ITEM_ID,
+    ]);
+    expect(items[2]?.showDrillDownIndicator).toBe(true);
+    expect(items[3]?.showDrillDownIndicator).toBe(true);
+  });
+});

--- a/src/scaffold/NavigationSidebar/connectors/workstationSidebarMenuItems.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/workstationSidebarMenuItems.tsx
@@ -1,8 +1,10 @@
 import {
   Box,
   Compass,
+  Folders,
   Github,
   LayoutDashboard,
+  ListTodo,
   Plus,
   Radar,
   SquarePen,
@@ -20,6 +22,8 @@ import {
   PROJECTS_IMPORT_GITHUB_ISSUES_MENU_ITEM_ID,
   PROJECTS_NEW_PROJECT_MENU_ITEM_ID,
   PROJECTS_NEW_WORK_ITEM_MENU_ITEM_ID,
+  WORKSPACES_SIDEBAR_MENU_ITEM_ID,
+  WORK_ITEMS_SIDEBAR_MENU_ITEM_ID,
   getDraftMenuItemId,
   getDraftPreviewText,
 } from "./sidebarConnectorUtils";
@@ -30,6 +34,8 @@ interface BuildPinnedMenuItemsParams {
   opsControlLabel: string;
   opsControlRoutePath: string;
   opsControlShortcut: string;
+  workspacesLabel: string;
+  workItemsLabel: string;
 }
 
 interface BuildProjectsPinnedMenuItemsParams {
@@ -51,6 +57,8 @@ export function buildPinnedMenuItems({
   opsControlLabel,
   opsControlRoutePath,
   opsControlShortcut,
+  workspacesLabel,
+  workItemsLabel,
 }: BuildPinnedMenuItemsParams): NavigationMenuItem[] {
   return [
     {
@@ -69,6 +77,24 @@ export function buildPinnedMenuItems({
       iconName: "radar",
       routePath: opsControlRoutePath,
       shortcut: opsControlShortcut,
+    },
+    {
+      id: WORKSPACES_SIDEBAR_MENU_ITEM_ID,
+      key: WORKSPACES_SIDEBAR_MENU_ITEM_ID,
+      label: workspacesLabel,
+      icon: Folders,
+      iconName: "folders",
+      showDrillDownIndicator: true,
+      dataTestId: "sidebar-open-workspaces",
+    },
+    {
+      id: WORK_ITEMS_SIDEBAR_MENU_ITEM_ID,
+      key: WORK_ITEMS_SIDEBAR_MENU_ITEM_ID,
+      label: workItemsLabel,
+      icon: ListTodo,
+      iconName: "list-todo",
+      showDrillDownIndicator: true,
+      dataTestId: "sidebar-open-work-items",
     },
   ];
 }

--- a/src/scaffold/NavigationSidebar/variants/HomeSidebar.tsx
+++ b/src/scaffold/NavigationSidebar/variants/HomeSidebar.tsx
@@ -151,7 +151,7 @@ const HomeSidebar: React.FC = () => {
         <div className="inline-flex">
           <button
             type="button"
-            className="flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-[100px] border-none bg-transparent p-0 transition-colors duration-150 hover:bg-fill-2"
+            className="flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-[100px] border-none bg-transparent p-0 transition-colors duration-150 hover:bg-sidebar-selected"
             onClick={handleOpenWorkstation}
           >
             <SquareMousePointer

--- a/src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx
+++ b/src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx
@@ -446,7 +446,7 @@ const NavigationSidebar: React.FC<NavigationSidebarProps> = React.memo(
                                   type="button"
                                   title={action.label}
                                   aria-label={action.label}
-                                  className="flex h-5 w-5 items-center justify-center rounded text-text-2 transition-colors duration-150 hover:bg-fill-2 hover:text-text-1 focus:outline-none"
+                                  className="flex h-5 w-5 items-center justify-center rounded text-text-2 transition-colors duration-150 hover:bg-sidebar-selected hover:text-text-1 focus:outline-none"
                                   onClick={(event) => {
                                     event.preventDefault();
                                     event.stopPropagation();

--- a/src/scaffold/NavigationSidebar/variants/SettingsSidebar.tsx
+++ b/src/scaffold/NavigationSidebar/variants/SettingsSidebar.tsx
@@ -72,7 +72,7 @@ const SettingsFooterBackButton: React.FC<SettingsFooterBackButtonProps> = ({
   <button
     type="button"
     aria-label={label}
-    className="flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-[100px] border-none bg-bg-1 p-0 text-primary-6 transition-colors duration-150 hover:bg-fill-2"
+    className="flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-[100px] border-none bg-bg-1 p-0 text-primary-6 transition-colors duration-150 hover:bg-sidebar-selected"
     onClick={onClick}
     onMouseEnter={(event) => triggerIconAnimation(event.currentTarget)}
   >

--- a/src/store/ui/chatPanelAtom.ts
+++ b/src/store/ui/chatPanelAtom.ts
@@ -86,6 +86,10 @@ if (typeof document !== "undefined") {
 const chatWidthBaseAtom = atom<number>(initialChatWidth);
 chatWidthBaseAtom.debugLabel = "chatWidthBaseAtom";
 
+/** True only while the user is actively resizing the chat pane. */
+export const chatPanelDraggingAtom = atom<boolean>(false);
+chatPanelDraggingAtom.debugLabel = "chatPanelDraggingAtom";
+
 /**
  * Chat width atom with optimized persistence
  * - Reads from base atom (fast)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -40,6 +40,9 @@ module.exports = {
           "selected-hover": colorVariable("surface-selected-hover"),
           container: colorVariable("surface-container"),
         },
+        sidebar: {
+          selected: "var(--sidebar-selected-row-bg)",
+        },
         event: {
           block: colorVariable("event-block"),
           "block-fade": colorVariable("event-block-fade"),


### PR DESCRIPTION
## Summary

Simplifies the macOS layout with native translucent surfaces, clearer sidebar navigation, configurable visual depth, and smooth pane transitions.

## What changed

### macOS appearance

- Restored native macOS liquid-glass window surfaces.
- Replaced the oversized 26px radius with standard macOS window radii.
- Disabled legacy background image and color customization on macOS while preserving it on other platforms.
- Added adjustable, theme-aware sidebar transparency.
- Applied the Settings surface background to the macOS Home page and Settings loading fallback.
- Updated setup and appearance controls for the macOS-specific behavior.

### Sidebar navigation

- Replaced the Workspaces/Work Items tab switch with root-level navigation rows.
- Added second-level Workspaces and Work Items menus with back navigation.
- Moved Home into the Settings menu.
- Unified hover and selected backgrounds behind one adjustable token.
- Changed selected rows to regular text styling instead of primary-colored bold text.
- Kept drill-down chevrons visible on hover.

### Sidebar edge depth

- Added a theme-aware vertical depth treatment between the macOS sidebar and main content.
- Tuned light and dark themes independently.
- Kept high-contrast mode shadow-free.
- Added a macOS-only “Sidebar edge depth” switch under Appearance → Sidebar.
- Enabled the effect by default and localized the setting across supported languages.

### Pane transitions

- Added coordinated animations for opening and closing the sidebar, workstation, and chat pane.
- Animated real width and flex geometry instead of transforms.
- Kept panes in normal layout flow without introducing overlay render layers.
- Preserved exact measurable widths throughout transitions.
- Disabled easing during manual resizing so the divider tracks the pointer directly.
- Added reduced-motion support.
- Released keyboard focus when a pane closes.

### Chat and workstation fixes

- Prevented the narrow-layout guard from immediately re-maximizing chat while the workstation is reopening.
- Restored the center chat resize divider after leaving focused-chat mode.
- Kept the divider and resize hit area above pinned messages, input/composer chrome, and other persistent chat content.
- Added a theme-aware chat-surface underlay beneath both panes to prevent background flashes during resizing and animation.

## Platform behavior

- macOS uses native translucent surfaces and the new macOS appearance controls.
- Other platforms retain the existing configurable background system.
- High-contrast mode preserves its stronger borders without decorative edge shadows.

## Validation

- Focused Vitest coverage passed.
- TypeScript checks passed.
- ESLint and formatting checks passed.
- Production Webpack build passed.
- Repository pre-commit validation passed.