### PR TITLE
docs(zh): add Linux download links to Chinese README

### DIFF
--- a/docs/readmes/README.zh.md
+++ b/docs/readmes/README.zh.md
@@ -18,6 +18,10 @@
   ·
   <a href="https://github.com/yorgai/ORG2/releases/latest/download/ORG2-latest-windows-x64.msi"><strong>Windows MSI</strong></a>
   ·
+  <a href="https://github.com/yorgai/ORG2/releases/latest/download/ORG2-latest-linux-x64.AppImage"><strong>Linux AppImage</strong></a>
+  ·
+  <a href="https://github.com/yorgai/ORG2/releases/latest/download/ORG2-latest-linux-x64.deb"><strong>Linux DEB</strong></a>
+  ·
   <a href="https://github.com/yorgai/ORG2/releases/latest"><strong>All latest release assets</strong></a>
 </p>
 


### PR DESCRIPTION
## Summary

Add Linux AppImage and DEB download links to the Chinese README.

### Changes
- Added `Linux AppImage` download link
- Added `Linux DEB` download link
- Matches the English README download section

### Note
All other language READMEs (zh-Hant, es, ru, pt, de, ja, ko, tr, vi, pl) are also missing Linux links. This PR only fixes the Chinese README to keep it focused.