### PR TITLE
fix(i18n): point GitHub reconnect prompts at Settings → Connections

### DIFF
--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -1134,9 +1134,9 @@
       "tokenLabel": "Personal access token",
       "tokenRequired": "Token ist erforderlich",
       "createTokenButton": "Token erstellen",
-      "openGitSettingsButton": "Git-Einstellungen öffnen",
+      "openGitSettingsButton": "Einstellungen öffnen",
       "configureInSettings": "Git in den Einstellungen konfigurieren",
-      "configureInSettingsDesc": "Füge GitHub App-Zugriff hinzu, speichere ein Token oder scanne lokale Zugangsdaten unter Einstellungen → Integrationen → Git und versuche diese Git-Operation erneut."
+      "configureInSettingsDesc": "Füge GitHub App-Zugriff hinzu, speichere ein Token oder scanne lokale Zugangsdaten unter Einstellungen → Verbindungen und versuche diese Git-Operation erneut."
     },
     "actions": {
       "publish": "Publish",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1165,9 +1165,9 @@
       "tokenLabel": "Personal access token",
       "tokenRequired": "Token is required",
       "createTokenButton": "Create Token",
-      "openGitSettingsButton": "Open Git Settings",
+      "openGitSettingsButton": "Open Settings",
       "configureInSettings": "Configure Git in Settings",
-      "configureInSettingsDesc": "Add GitHub App access, save a token, or scan local credentials in Settings → Integrations → Git, then retry this Git operation."
+      "configureInSettingsDesc": "Add GitHub App access, save a token, or scan local credentials in Settings → Connections, then retry this Git operation."
     },
     "actions": {
       "publish": "Publish",
@@ -1234,7 +1234,7 @@
       },
       "authRequired": {
         "title": "Connect GitHub",
-        "description": "Go to Settings → Integrations → Git to connect your GitHub account."
+        "description": "Go to Settings → Connections to connect your GitHub account."
       }
     },
     "issues": {
@@ -1267,10 +1267,10 @@
       },
       "authRequired": {
         "title": "Connect GitHub",
-        "description": "Go to Settings → Integrations → Git to connect your GitHub account."
+        "description": "Go to Settings → Connections to connect your GitHub account."
       },
       "reAuthRequired": "GitHub Authorization Required",
-      "reAuthDescription": "Your GitHub token has expired. Go to Settings → Integrations → Git to reconnect.",
+      "reAuthDescription": "Your GitHub token has expired. Go to Settings → Connections to reconnect.",
       "goToSettings": "Go to Settings"
     },
     "commit": {

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -1134,9 +1134,9 @@
       "tokenLabel": "Token de acceso personal",
       "tokenRequired": "El token es obligatorio",
       "createTokenButton": "Crear token",
-      "openGitSettingsButton": "Abrir ajustes de Git",
+      "openGitSettingsButton": "Abrir ajustes",
       "configureInSettings": "Configura Git en Ajustes",
-      "configureInSettingsDesc": "Añade acceso de GitHub App, guarda un token o escanea credenciales locales en Ajustes → Integraciones → Git y vuelve a intentar esta operación de Git."
+      "configureInSettingsDesc": "Añade acceso de GitHub App, guarda un token o escanea credenciales locales en Ajustes → Conexiones y vuelve a intentar esta operación de Git."
     },
     "actions": {
       "publish": "Publish",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1134,9 +1134,9 @@
       "tokenLabel": "Token d’accès personnel",
       "tokenRequired": "Le token est requis",
       "createTokenButton": "Créer un token",
-      "openGitSettingsButton": "Ouvrir les paramètres Git",
+      "openGitSettingsButton": "Ouvrir les paramètres",
       "configureInSettings": "Configurer Git dans les paramètres",
-      "configureInSettingsDesc": "Ajoutez l’accès GitHub App, enregistrez un token ou analysez les identifiants locaux dans Paramètres → Intégrations → Git, puis réessayez cette opération Git."
+      "configureInSettingsDesc": "Ajoutez l’accès GitHub App, enregistrez un token ou analysez les identifiants locaux dans Paramètres → Connexions, puis réessayez cette opération Git."
     },
     "actions": {
       "publish": "Publish",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -1135,9 +1135,9 @@
       "tokenLabel": "Personal access token",
       "tokenRequired": "Token は必須です",
       "createTokenButton": "Token を作成",
-      "openGitSettingsButton": "Git 設定を開く",
+      "openGitSettingsButton": "設定を開く",
       "configureInSettings": "設定で Git を構成",
-      "configureInSettingsDesc": "設定 → 連携 → Git で GitHub App アクセスの追加、token の保存、またはローカル認証情報のスキャンを行い、その後この Git 操作を再試行してください。"
+      "configureInSettingsDesc": "設定 → 接続 で GitHub App アクセスの追加、token の保存、またはローカル認証情報のスキャンを行い、その後この Git 操作を再試行してください。"
     },
     "actions": {
       "publish": "Publish",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -1135,9 +1135,9 @@
       "tokenLabel": "Personal access token",
       "tokenRequired": "Token is required",
       "createTokenButton": "Token 만들기",
-      "openGitSettingsButton": "Git 설정 열기",
+      "openGitSettingsButton": "설정 열기",
       "configureInSettings": "설정에서 Git 구성",
-      "configureInSettingsDesc": "설정 → 통합 → Git에서 GitHub App 액세스를 추가하거나 token을 저장하거나 로컬 자격 증명을 스캔한 다음 이 Git 작업을 다시 시도하세요."
+      "configureInSettingsDesc": "설정 → 연결에서 GitHub App 액세스를 추가하거나 token을 저장하거나 로컬 자격 증명을 스캔한 다음 이 Git 작업을 다시 시도하세요."
     },
     "actions": {
       "publish": "Publish",

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -1134,9 +1134,9 @@
       "tokenLabel": "Personal access token",
       "tokenRequired": "Token jest wymagany",
       "createTokenButton": "Utwórz token",
-      "openGitSettingsButton": "Otwórz ustawienia Git",
+      "openGitSettingsButton": "Otwórz ustawienia",
       "configureInSettings": "Skonfiguruj Git w ustawieniach",
-      "configureInSettingsDesc": "Dodaj dostęp GitHub App, zapisz token lub przeskanuj lokalne dane uwierzytelniające w Ustawienia → Integracje → Git, a następnie spróbuj ponownie wykonać tę operację Git."
+      "configureInSettingsDesc": "Dodaj dostęp GitHub App, zapisz token lub przeskanuj lokalne dane uwierzytelniające w Ustawienia → Połączenia, a następnie spróbuj ponownie wykonać tę operację Git."
     },
     "actions": {
       "publish": "Opublikuj",

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -1134,9 +1134,9 @@
       "tokenLabel": "Personal access token",
       "tokenRequired": "Token é obrigatório",
       "createTokenButton": "Criar token",
-      "openGitSettingsButton": "Abrir configurações do Git",
+      "openGitSettingsButton": "Abrir configurações",
       "configureInSettings": "Configure o Git nas configurações",
-      "configureInSettingsDesc": "Adicione acesso do GitHub App, salve um token ou escaneie credenciais locais em Configurações → Integrações → Git e tente esta operação Git novamente."
+      "configureInSettingsDesc": "Adicione acesso do GitHub App, salve um token ou escaneie credenciais locais em Configurações → Conexões e tente esta operação Git novamente."
     },
     "actions": {
       "publish": "Publicar",

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -1134,9 +1134,9 @@
       "tokenLabel": "Personal access token",
       "tokenRequired": "Token обязателен",
       "createTokenButton": "Создать token",
-      "openGitSettingsButton": "Открыть настройки Git",
+      "openGitSettingsButton": "Открыть настройки",
       "configureInSettings": "Настройте Git в настройках",
-      "configureInSettingsDesc": "Добавьте доступ GitHub App, сохраните token или просканируйте локальные учетные данные в Настройки → Интеграции → Git, затем повторите эту операцию Git."
+      "configureInSettingsDesc": "Добавьте доступ GitHub App, сохраните token или просканируйте локальные учетные данные в Настройки → Подключения, затем повторите эту операцию Git."
     },
     "actions": {
       "publish": "Publish",

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -1135,9 +1135,9 @@
       "tokenLabel": "Personal access token",
       "tokenRequired": "Token gerekli",
       "createTokenButton": "Token oluştur",
-      "openGitSettingsButton": "Git ayarlarını aç",
+      "openGitSettingsButton": "Ayarları aç",
       "configureInSettings": "Git’i ayarlarda yapılandır",
-      "configureInSettingsDesc": "Ayarlar → Entegrasyonlar → Git içinde GitHub App erişimi ekleyin, token kaydedin veya yerel kimlik bilgilerini tarayın; ardından bu Git işlemini yeniden deneyin."
+      "configureInSettingsDesc": "Ayarlar → Bağlantılar içinde GitHub App erişimi ekleyin, token kaydedin veya yerel kimlik bilgilerini tarayın; ardından bu Git işlemini yeniden deneyin."
     },
     "actions": {
       "publish": "Publish",

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -1135,9 +1135,9 @@
       "tokenLabel": "Personal access token",
       "tokenRequired": "Cần token",
       "createTokenButton": "Tạo token",
-      "openGitSettingsButton": "Mở cài đặt Git",
+      "openGitSettingsButton": "Mở cài đặt",
       "configureInSettings": "Cấu hình Git trong cài đặt",
-      "configureInSettingsDesc": "Thêm quyền truy cập GitHub App, lưu token hoặc quét thông tin xác thực cục bộ trong Cài đặt → Tích hợp → Git, rồi thử lại thao tác Git này."
+      "configureInSettingsDesc": "Thêm quyền truy cập GitHub App, lưu token hoặc quét thông tin xác thực cục bộ trong Cài đặt → Kết nối, rồi thử lại thao tác Git này."
     },
     "actions": {
       "publish": "Publish",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -1147,9 +1147,9 @@
       "tokenLabel": "Personal access token",
       "tokenRequired": "需要 token",
       "createTokenButton": "建立 Token",
-      "openGitSettingsButton": "開啟 Git 設定",
+      "openGitSettingsButton": "開啟設定",
       "configureInSettings": "在設定中配置 Git",
-      "configureInSettingsDesc": "在 設定 → 整合 → Git 中加入 GitHub App 存取權限、儲存 token 或掃描本機憑證，然後重試此 Git 操作。"
+      "configureInSettingsDesc": "在 設定 → 連接 中加入 GitHub App 存取權限、儲存 token 或掃描本機憑證，然後重試此 Git 操作。"
     },
     "actions": {
       "publish": "Publish",

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -1154,9 +1154,9 @@
       "tokenLabel": "Personal access token",
       "tokenRequired": "需要 token",
       "createTokenButton": "创建 Token",
-      "openGitSettingsButton": "打开 Git 设置",
+      "openGitSettingsButton": "打开设置",
       "configureInSettings": "在设置中配置 Git",
-      "configureInSettingsDesc": "在 设置 → 集成 → Git 中添加 GitHub App 访问权限、保存 token 或扫描本地凭据，然后重试此 Git 操作。"
+      "configureInSettingsDesc": "在 设置 → 连接 中添加 GitHub App 访问权限、保存 token 或扫描本地凭据，然后重试此 Git 操作。"
     },
     "actions": {
       "publish": "Publish",

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/IssuesContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/IssuesContent/index.tsx
@@ -305,11 +305,12 @@ const IssuesContent: React.FC<IssuesContentProps> = memo(
           )}
           subtitle={t(
             "git.issues.reAuthDescription",
-            "Your GitHub token has expired. Go to Settings → Integrations → Git to reconnect."
+            "Your GitHub token has expired. Go to Settings → Connections to reconnect."
           )}
           action={{
             label: t("git.issues.goToSettings", "Go to Settings"),
-            onClick: () => navigate(buildIntegrationsPath({ category: "git" })),
+            onClick: () =>
+              navigate(buildIntegrationsPath({ category: "connections" })),
           }}
           fillParentHeight
         />

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useWorkstationPr.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useWorkstationPr.ts
@@ -231,7 +231,7 @@ export function useWorkstationPr(options: UseWorkstationPrOptions) {
     if (result.error) {
       if (result.error === "not_authenticated") {
         setCreatingByBranch((current) => ({ ...current, [branchName]: false }));
-        navigate(buildIntegrationsPath({ category: "git" }));
+        navigate(buildIntegrationsPath({ category: "connections" }));
         Message.info({
           id: "github-auth-required",
           title: t("git.pr.authRequired.title"),

--- a/src/util/dialogs/gitAuthenticationDialog.tsx
+++ b/src/util/dialogs/gitAuthenticationDialog.tsx
@@ -26,8 +26,12 @@ interface GitAuthenticationDialogProps extends GitAuthenticationDialogOptions {
 
 const APP_TOP_DRAG_ZONE_HEIGHT = 52;
 
-function openGitSettingsPage() {
-  window.history.pushState({}, "", buildIntegrationsPath({ category: "git" }));
+function openConnectionsPage() {
+  window.history.pushState(
+    {},
+    "",
+    buildIntegrationsPath({ category: "connections" })
+  );
   window.dispatchEvent(new PopStateEvent("popstate"));
 }
 
@@ -38,8 +42,8 @@ function GitAuthenticationDialog({ onResolve }: GitAuthenticationDialogProps) {
     onResolve(null);
   }, [onResolve]);
 
-  const handleOpenGitSettings = useCallback(() => {
-    openGitSettingsPage();
+  const handleOpenConnections = useCallback(() => {
+    openConnectionsPage();
     onResolve(null);
   }, [onResolve]);
 
@@ -51,7 +55,7 @@ function GitAuthenticationDialog({ onResolve }: GitAuthenticationDialogProps) {
       topDragZoneHeight={APP_TOP_DRAG_ZONE_HEIGHT}
       okText={t("git.authDialog.openGitSettingsButton")}
       cancelText={t("actions.cancel")}
-      onOk={handleOpenGitSettings}
+      onOk={handleOpenConnections}
       onCancel={handleCancel}
       onClose={handleCancel}
       maskClosable={false}
@@ -66,7 +70,7 @@ function GitAuthenticationDialog({ onResolve }: GitAuthenticationDialogProps) {
           ]}
           primaryAction={{
             label: t("git.authDialog.openGitSettingsButton"),
-            onClick: handleOpenGitSettings,
+            onClick: handleOpenConnections,
             variant: "primary",
           }}
         />


### PR DESCRIPTION
## Summary

The "GitHub authorization required" prompts sent users to **Settings → Integrations → Git to reconnect**, but that path is a dead end — and one level in it doesn't even exist in the UI.

## The bug (two distinct problems)

1. **Wrong page.** The `Git` settings category (`GitTable.tsx`) is a **read-only list** of existing GitHub connections with only a delete button. There is **no add/reconnect affordance** there. The real flow (PAT/SSH/OAuth via `ChannelWizard`) lives under the **`Connections`** item. Multiple source comments already say "Connections wizard" (`useGitHubConnections.ts`, `api/tauri/github/index.ts`, `integrations/github/client.rs`).

2. **Ghost UI level.** "Integrations" is **not a user-visible sidebar label** — it's only a URL segment (`/settings/integrations/<cat>`) and code namespace. The actual Settings sidebar (`SettingsSidebar.tsx` → `SETTINGS_ROOT_LIST_SECTIONS`) renders three groups: **Core / Agent Tools / Connections**. So "Settings → Integrations → Connections" references a level the user can never find in the sidebar.

Reported by a user: *"go to settings-> integrations ->git to reconnect 没找到这个设置"*.

## Changes

**3 nav call sites → `category: "connections"`:**
- `IssuesContent/index.tsx` — the Issues re-auth placeholder button
- `useWorkstationPr.ts` — the PR-create `not_authenticated` toast redirect
- `gitAuthenticationDialog.tsx` — the Git push/pull/fetch/sync auth dialog OK button

**User-facing copy, all 13 locales (`common.json`):**
- `git.issues.reAuthDescription`, `git.pr.authRequired.description`, `git.issues.authRequired.description`, `git.authDialog.configureInSettingsDesc` → now "Settings → Connections" (UI-accurate), dropping the nonexistent "Integrations" level.
- `git.authDialog.openGitSettingsButton` neutralized from "Open Git Settings" → "Open Settings" so the button no longer names a page it does not open.

**Internal naming honesty (`gitAuthenticationDialog.tsx`):**
- `openGitSettingsPage` → `openConnectionsPage`, `handleOpenGitSettings` → `handleOpenConnections` (module-local, no export impact). The i18n **key** `openGitSettingsButton` is deliberately kept unchanged — it's an external translation contract across 13 locales; renaming the key has no user benefit.

## Why no regression test

Considered a unit test binding the copy strings to the Connections sidebar label per locale. Rejected it: the bug's root cause is the **jump target + copy** together pointing at a wrong page, and the project's vitest surface only runs pure `*.ts` (no component render), so it physically cannot reach the `buildIntegrationsPath({ category })` calls in `.tsx`. A copy-contains-word guard would catch only a secondary drift mode with a high false-positive rate against normal copy rewrites, while missing the actual failure mode. The right guard is an E2E asserting the user can navigate from a re-auth prompt to a page with an Add-Connection UI — out of scope for this copy/nav fix.

## Verification

- `lint-staged` passed on commit (eslint + prettier + TypeScript scoped type check + circular-dep check).
- All 13 `common.json` parse cleanly.
- Manual sweep confirmed no residual "Integrations → Git" / "Open Git Settings" user-facing copy; the only remaining "Git settings" string is `preferencesTitle` (a section header *inside* the Git category page — correct as-is).

## Entry points after the fix

| Surface | Copy | Jump target |
|---|---|---|
| Issues re-auth placeholder | "Settings → Connections" | `connections` ✅ |
| PR create auth toast | "Settings → Connections" | `connections` ✅ |
| Git push/pull auth dialog | "Settings → Connections" + "Open Settings" button | `connections` ✅ |
