### PR TITLE
feat(kanban): expandable Data Sources table with inline detail card

### DIFF
--- a/src/components/SessionHoverCard/HoverCardBase.tsx
+++ b/src/components/SessionHoverCard/HoverCardBase.tsx
@@ -180,8 +180,7 @@ const HoverCardTrigger: React.FC<HoverCardTriggerProps> = ({
 
   const originalProps =
     (children.props as ElementProps | undefined) ?? ({} as ElementProps);
-  const originalRef = (children as unknown as { ref?: React.Ref<HTMLElement> })
-    .ref;
+  const originalRef = originalProps.ref;
 
   const composedRef = useCallback(
     (node: HTMLElement | null) => {

--- a/src/features/TaskKanban/components/DataSourcePanel/DataSourceDetailsCard.tsx
+++ b/src/features/TaskKanban/components/DataSourcePanel/DataSourceDetailsCard.tsx
@@ -1,0 +1,112 @@
+/**
+ * DataSourceDetailsCard
+ *
+ * Reusable inline detail card shown when a Data Sources row is expanded.
+ * Surfaces the on-disk store path(s) — with Copy / Open-folder actions — and
+ * the imported session count. Composed from the same primitives the KeyVault
+ * "keys" inline cards use (`InlineInfoCard` + `INFO_CARD_TOKENS`), so the two
+ * expanded-row surfaces read identically.
+ */
+import { Copy, FolderOpen } from "lucide-react";
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import type {
+  ExternalCliSourceProbe,
+  ExternalSourceStats,
+} from "@src/api/tauri/externalHistory";
+import Button from "@src/components/Button";
+import { INFO_CARD_TOKENS } from "@src/config/detailPanelTokens";
+import InlineInfoCard from "@src/modules/shared/layouts/blocks/InlineInfoCard";
+import { copyText } from "@src/util/data/clipboard";
+
+import { storeKindLabel, tildePath } from "./sourcePath";
+
+export interface DataSourceDetailsCardProps {
+  probe: ExternalCliSourceProbe;
+  stats: ExternalSourceStats | null;
+  /** Reveal the given path in the OS file manager. */
+  onOpenFolder: (path: string) => void;
+  /** Copy the given path to the clipboard. Defaults to the shared `copyText`. */
+  onCopyPath?: (path: string) => void;
+}
+
+const DataSourceDetailsCard: React.FC<DataSourceDetailsCardProps> = ({
+  probe,
+  stats,
+  onOpenFolder,
+  onCopyPath,
+}) => {
+  const { t } = useTranslation("sessions", { keyPrefix: "kanban.dataSource" });
+  const paths = probe.historyPaths;
+  const kindLabel = storeKindLabel(probe);
+  const handleCopy = onCopyPath ?? ((path: string) => void copyText(path));
+
+  return (
+    <InlineInfoCard>
+      <div className={`grid ${INFO_CARD_TOKENS.rowGap}`}>
+        {/* Store path(s) — with Copy + Open-folder actions per path. */}
+        <div className="flex items-start justify-between gap-3">
+          <span className={`${INFO_CARD_TOKENS.label} pt-1`}>
+            {t("details.path")}
+          </span>
+          {paths.length > 0 ? (
+            <div className="flex min-w-0 flex-col items-end gap-1">
+              {paths.map((path) => (
+                <div
+                  key={path}
+                  className="flex min-w-0 max-w-full items-center gap-1.5"
+                >
+                  <span
+                    className="min-w-0 truncate text-[12px] text-text-1"
+                    title={path}
+                  >
+                    {tildePath(path)}
+                  </span>
+                  <Button
+                    variant="secondary"
+                    size="small"
+                    iconOnly
+                    icon={<Copy size={13} />}
+                    title={t("details.copyPath")}
+                    onClick={() => handleCopy(path)}
+                  />
+                  <Button
+                    variant="secondary"
+                    size="small"
+                    iconOnly
+                    icon={<FolderOpen size={13} />}
+                    title={t("openFolder")}
+                    onClick={() => onOpenFolder(path)}
+                  />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <span className={INFO_CARD_TOKENS.value}>{t("noPath")}</span>
+          )}
+        </div>
+
+        {/* Store format (JSONL / SQLite / …). */}
+        {kindLabel ? (
+          <div className={INFO_CARD_TOKENS.row}>
+            <span className={INFO_CARD_TOKENS.label}>
+              {t("details.storeType")}
+            </span>
+            <span className={INFO_CARD_TOKENS.value}>{kindLabel}</span>
+          </div>
+        ) : null}
+
+        {/* Imported session count. */}
+        <div className={INFO_CARD_TOKENS.row}>
+          <span className={INFO_CARD_TOKENS.label}>{t("col.sessions")}</span>
+          <span className={`${INFO_CARD_TOKENS.value} tabular-nums`}>
+            {stats?.sessionCount ?? 0}
+          </span>
+        </div>
+      </div>
+    </InlineInfoCard>
+  );
+};
+
+export default DataSourceDetailsCard;

--- a/src/features/TaskKanban/components/DataSourcePanel/index.tsx
+++ b/src/features/TaskKanban/components/DataSourcePanel/index.tsx
@@ -38,6 +38,10 @@ import {
 import Button from "@src/components/Button";
 import ModelIcon, { type IconProvider } from "@src/components/ModelIcon";
 import Select from "@src/components/Select";
+import SettingsTable, {
+  SETTINGS_TABLE_CELL,
+  type SettingsTableColumn,
+} from "@src/components/SettingsTable";
 import StatusBadge, { type StatusType } from "@src/components/StatusBadge";
 import Switch from "@src/components/Switch";
 import TabPill, { type TabPillItem } from "@src/components/TabPill";
@@ -45,8 +49,6 @@ import {
   SECTION_CONTROL_STYLE,
   SectionContainer,
   SectionRow,
-  SectionTable,
-  type SectionTableColumn,
 } from "@src/modules/shared/layouts/SectionLayout";
 import { loadSidebarSessions } from "@src/store/session";
 import {
@@ -59,7 +61,11 @@ import {
   dataSourceGlobalFrequencyAtom,
   getSourceConfig,
 } from "@src/store/session/dataSourceConfigAtom";
+import { copyText } from "@src/util/data/clipboard";
 import { formatRelativeElapsedShort } from "@src/util/data/formatters/date";
+
+import DataSourceDetailsCard from "./DataSourceDetailsCard";
+import { storeKindLabel, tildePath } from "./sourcePath";
 
 type DataSourceTab = "all" | "apps" | "clis";
 
@@ -72,13 +78,6 @@ function isImportableId(id: string): id is ImportedHistorySourceId {
   return IMPORTABLE_SOURCE_IDS.has(id as ImportedHistorySourceId);
 }
 
-const STORE_KIND_LABELS: Record<string, string> = {
-  jsonl: "JSONL",
-  sqlite: "SQLite",
-  json: "JSON",
-  markdown: "Markdown",
-};
-
 interface SourceRow {
   probe: ExternalCliSourceProbe;
   importable: boolean;
@@ -86,11 +85,6 @@ interface SourceRow {
   statsLoading: boolean;
   rescanning: boolean;
   error: boolean;
-}
-
-/** Collapse an absolute home path to a leading `~/` for display. */
-function tildePath(path: string): string {
-  return path.replace(/^(\/Users\/[^/]+|\/home\/[^/]+)\//, "~/");
 }
 
 const SourceIcon: React.FC<{ probe: ExternalCliSourceProbe }> = ({ probe }) => (
@@ -105,9 +99,12 @@ const DataSourcePanel: React.FC = () => {
   const { t } = useTranslation("sessions", {
     keyPrefix: "kanban.dataSource",
   });
+  const { t: tCommon } = useTranslation("common");
   const [rows, setRows] = useState<SourceRow[] | null>(null);
   const [rescanningAll, setRescanningAll] = useState(false);
   const [tab, setTab] = useState<DataSourceTab>("all");
+  const [expandedRowKeys, setExpandedRowKeys] = useState<string[]>([]);
+  const [searchQuery, setSearchQuery] = useState("");
   const [configMap, setConfigMap] = useAtom(dataSourceConfigAtom);
   const [globalFrequency, setGlobalFrequency] = useAtom(
     dataSourceGlobalFrequencyAtom
@@ -319,8 +316,7 @@ const DataSourcePanel: React.FC = () => {
       const path = row.probe.historyPaths[0]
         ? tildePath(row.probe.historyPaths[0])
         : t("noPath");
-      const typeLabel =
-        STORE_KIND_LABELS[row.probe.storeKind] ?? row.probe.storeKind;
+      const typeLabel = storeKindLabel(row.probe);
       return typeLabel ? `${path} · ${typeLabel}` : path;
     },
     [t]
@@ -365,20 +361,16 @@ const DataSourcePanel: React.FC = () => {
     tab === "apps" ? row.importable : tab === "clis" ? !row.importable : true
   );
   const importableCount = (rows ?? []).filter((r) => r.importable).length;
-  const rowById = new Map(visibleRows.map((row) => [row.probe.sourceId, row]));
 
-  const columns: SectionTableColumn[] = [
-    { key: "sessions", label: t("col.sessions"), width: 84 },
-    { key: "lastScan", label: t("col.lastScan"), width: 118 },
-    { key: "frequency", label: t("col.frequency") },
-    { key: "status", label: t("col.status"), width: 104 },
-    { key: "actions", label: "", width: 128 },
-  ];
-  const tableRows = visibleRows.map((row) => ({
-    key: row.probe.sourceId,
-    icon: <SourceIcon probe={row.probe} />,
-    label: row.probe.displayName,
-  }));
+  const searchTerm = searchQuery.trim().toLowerCase();
+  const searchedRows = searchTerm
+    ? visibleRows.filter((row) =>
+        [row.probe.displayName, row.probe.sourceId, ...row.probe.historyPaths]
+          .join(" ")
+          .toLowerCase()
+          .includes(searchTerm)
+      )
+    : visibleRows;
 
   const badgeFor = (
     row: SourceRow,
@@ -391,33 +383,62 @@ const DataSourcePanel: React.FC = () => {
       : { status: "empty", labelKey: "notInstalled" };
   };
 
-  const renderCell = (rowKey: string, columnKey: string): React.ReactNode => {
-    const row = rowById.get(rowKey);
-    if (!row) return null;
-    const cfg = getSourceConfig(configMap, rowKey);
-    const disabled = row.importable && !cfg.enabled;
-    const path = row.probe.historyPaths[0];
-
-    switch (columnKey) {
-      case "sessions":
+  const columns: SettingsTableColumn<SourceRow>[] = [
+    {
+      key: "source",
+      label: t("col.source"),
+      renderCell: (row) => (
+        <span className={`${SETTINGS_TABLE_CELL.primaryIcon} min-w-0`}>
+          <span className="shrink-0 text-text-2">
+            <SourceIcon probe={row.probe} />
+          </span>
+          <span className="truncate">{row.probe.displayName}</span>
+        </span>
+      ),
+    },
+    {
+      key: "sessions",
+      label: t("col.sessions"),
+      width: "84px",
+      renderCell: (row) => {
+        const cfg = getSourceConfig(configMap, row.probe.sourceId);
+        const disabled = row.importable && !cfg.enabled;
         return row.importable && !disabled && row.stats ? (
-          <span className="text-xs tabular-nums text-text-2">
+          <span className="tabular-nums text-text-2">
             {row.stats.sessionCount}
           </span>
         ) : null;
-      case "lastScan":
+      },
+    },
+    {
+      key: "lastScan",
+      label: t("col.lastScan"),
+      width: "118px",
+      renderCell: (row) => {
+        const cfg = getSourceConfig(configMap, row.probe.sourceId);
+        const disabled = row.importable && !cfg.enabled;
         return row.importable && !disabled && cfg.lastScannedAt ? (
-          <span className="whitespace-nowrap text-xs text-text-3">
+          <span className="whitespace-nowrap text-text-3">
             {formatRelativeElapsedShort(new Date(cfg.lastScannedAt))}
           </span>
         ) : null;
-      case "frequency":
+      },
+    },
+    {
+      key: "frequency",
+      label: t("col.frequency"),
+      width: "160px",
+      renderCell: (row) => {
+        const cfg = getSourceConfig(configMap, row.probe.sourceId);
+        const disabled = row.importable && !cfg.enabled;
         return row.importable && !disabled ? (
           <Select
             value={cfg.frequency}
             onChange={(v) => {
               if (typeof v === "string") {
-                updateConfig(rowKey, { frequency: v as SourceFrequency });
+                updateConfig(row.probe.sourceId, {
+                  frequency: v as SourceFrequency,
+                });
               }
             }}
             options={sourceFrequencyOptions}
@@ -426,7 +447,15 @@ const DataSourcePanel: React.FC = () => {
             aria-label={t("frequencyTitle")}
           />
         ) : null;
-      case "status": {
+      },
+    },
+    {
+      key: "status",
+      label: t("col.status"),
+      width: "104px",
+      renderCell: (row) => {
+        const cfg = getSourceConfig(configMap, row.probe.sourceId);
+        const disabled = row.importable && !cfg.enabled;
         const badge = badgeFor(row, disabled);
         return (
           <StatusBadge
@@ -436,8 +465,20 @@ const DataSourcePanel: React.FC = () => {
             size="sm"
           />
         );
-      }
-      case "actions":
+      },
+    },
+    {
+      // Key must stay "actions" — SettingsTable pins the last column when its
+      // key ∈ {actions, status, enabled}, keeping these controls visible while
+      // the table scrolls horizontally.
+      key: "actions",
+      label: "",
+      width: "128px",
+      align: "right",
+      renderCell: (row) => {
+        const cfg = getSourceConfig(configMap, row.probe.sourceId);
+        const disabled = row.importable && !cfg.enabled;
+        const path = row.probe.historyPaths[0];
         return (
           <div className="flex items-center justify-end gap-1.5">
             {path && (
@@ -471,41 +512,17 @@ const DataSourcePanel: React.FC = () => {
             )}
           </div>
         );
-      default:
-        return null;
-    }
-  };
+      },
+    },
+  ];
 
   return (
     <div className="absolute inset-0 overflow-y-auto scrollbar-hide">
-      <div className="mx-auto flex max-w-3xl flex-col gap-3 p-4">
-        <div className="flex items-start justify-between gap-4">
-          <div className="min-w-0">
-            <div className="text-sm font-medium text-text-1">{t("title")}</div>
-            <div className="mt-0.5 text-xs text-text-3">{t("description")}</div>
-          </div>
-          {(rows ?? []).length > 0 && (
-            <Button
-              variant="secondary"
-              size="small"
-              loading={rescanningAll}
-              icon={<RefreshCw size={14} />}
-              onClick={() => void handleRescanAll()}
-            >
-              {t("rescanAll")}
-            </Button>
-          )}
+      <div className="mx-auto flex w-full max-w-[932px] flex-col gap-3 p-4">
+        <div className="min-w-0">
+          <div className="text-sm font-medium text-text-1">{t("title")}</div>
+          <div className="mt-0.5 text-xs text-text-3">{t("description")}</div>
         </div>
-
-        <TabPill
-          activeTab={tab}
-          tabs={tabs}
-          onChange={(key) => setTab(key as DataSourceTab)}
-          variant="pill"
-          color="fill"
-          fillWidth={false}
-          size="small"
-        />
 
         {importableCount > 0 && (
           <SectionContainer>
@@ -529,14 +546,62 @@ const DataSourcePanel: React.FC = () => {
           </SectionContainer>
         )}
 
-        <SectionContainer>
-          <SectionTable
-            columns={columns}
-            rows={tableRows}
-            renderCell={renderCell}
-            labelColumnHeader={t("col.source")}
-          />
-        </SectionContainer>
+        <SettingsTable<SourceRow>
+          columns={columns}
+          rows={searchedRows}
+          getRowKey={(row) => row.probe.sourceId}
+          headerHeight="tall"
+          headerBorder
+          hover
+          loading={rows === null}
+          emptyTitle={searchTerm ? tCommon("status.noResults") : undefined}
+          searchBar={{
+            searchValue: searchQuery,
+            searchPlaceholder: tCommon("common.searchPlaceholder"),
+            onSearchChange: setSearchQuery,
+            onSearchClear: () => setSearchQuery(""),
+            rightContent:
+              (rows ?? []).length > 0 ? (
+                <Button
+                  variant="secondary"
+                  size="small"
+                  loading={rescanningAll}
+                  icon={<RefreshCw size={14} />}
+                  onClick={() => void handleRescanAll()}
+                >
+                  {t("rescanAll")}
+                </Button>
+              ) : undefined,
+            tabPills: (
+              <TabPill
+                activeTab={tab}
+                tabs={tabs}
+                onChange={(key) => setTab(key as DataSourceTab)}
+                variant="pill"
+                color="fill"
+                fillWidth={false}
+                size="small"
+              />
+            ),
+            searchCountText:
+              searchTerm && searchedRows.length !== visibleRows.length
+                ? `${searchedRows.length} / ${visibleRows.length}`
+                : undefined,
+          }}
+          expandable={{
+            expandedRowRender: (row) => (
+              <DataSourceDetailsCard
+                probe={row.probe}
+                stats={row.stats}
+                onOpenFolder={openFolder}
+                onCopyPath={(path) => void copyText(path)}
+              />
+            ),
+            rowExpandable: (row) => row.probe.historyPaths.length > 0,
+            expandedRowKeys,
+            onExpandedRowsChange: setExpandedRowKeys,
+          }}
+        />
       </div>
     </div>
   );

--- a/src/features/TaskKanban/components/DataSourcePanel/sourcePath.ts
+++ b/src/features/TaskKanban/components/DataSourcePanel/sourcePath.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared display helpers for external data-source on-disk paths.
+ *
+ * Lifted out of DataSourcePanel so the row cells and the expanded
+ * DataSourceDetailsCard format store paths + kinds identically.
+ */
+import type { ExternalCliSourceProbe } from "@src/api/tauri/externalHistory";
+
+/** Human labels for the on-disk store format ORGII parses. */
+export const STORE_KIND_LABELS: Record<string, string> = {
+  jsonl: "JSONL",
+  sqlite: "SQLite",
+  json: "JSON",
+  markdown: "Markdown",
+};
+
+/** Collapse an absolute home path to a leading `~/` for display. */
+export function tildePath(path: string): string {
+  return path.replace(/^(\/Users\/[^/]+|\/home\/[^/]+)\//, "~/");
+}
+
+/** Display label for a source's store format, e.g. "JSONL" (empty when unknown). */
+export function storeKindLabel(probe: ExternalCliSourceProbe): string {
+  return STORE_KIND_LABELS[probe.storeKind] ?? probe.storeKind;
+}

--- a/src/i18n/locales/de/sessions.json
+++ b/src/i18n/locales/de/sessions.json
@@ -124,6 +124,11 @@
       },
       "sessions_one": "{{count}} Sitzung",
       "sessions_other": "{{count}} Sitzungen",
+      "details": {
+        "path": "Pfad",
+        "storeType": "Speichertyp",
+        "copyPath": "Pfad kopieren"
+      },
       "noPath": "Kein Pfad erkannt",
       "notImported": "Nicht importiert",
       "status": {

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -124,6 +124,11 @@
       },
       "sessions_one": "{{count}} session",
       "sessions_other": "{{count}} sessions",
+      "details": {
+        "path": "Path",
+        "storeType": "Store type",
+        "copyPath": "Copy path"
+      },
       "noPath": "No path detected",
       "notImported": "Not imported",
       "status": {

--- a/src/i18n/locales/es/sessions.json
+++ b/src/i18n/locales/es/sessions.json
@@ -124,6 +124,11 @@
       },
       "sessions_one": "{{count}} sesión",
       "sessions_other": "{{count}} sesiones",
+      "details": {
+        "path": "Ruta",
+        "storeType": "Tipo de almacenamiento",
+        "copyPath": "Copiar ruta"
+      },
       "noPath": "Ninguna ruta detectada",
       "notImported": "No importado",
       "status": {

--- a/src/i18n/locales/fr/sessions.json
+++ b/src/i18n/locales/fr/sessions.json
@@ -124,6 +124,11 @@
       },
       "sessions_one": "{{count}} session",
       "sessions_other": "{{count}} sessions",
+      "details": {
+        "path": "Chemin",
+        "storeType": "Type de stockage",
+        "copyPath": "Copier le chemin"
+      },
       "noPath": "Aucun chemin détecté",
       "notImported": "Non importé",
       "status": {

--- a/src/i18n/locales/ja/sessions.json
+++ b/src/i18n/locales/ja/sessions.json
@@ -123,6 +123,11 @@
         "clis": "CLI"
       },
       "sessions_other": "{{count}} 件のセッション",
+      "details": {
+        "path": "パス",
+        "storeType": "保存形式",
+        "copyPath": "パスをコピー"
+      },
       "noPath": "パスが検出されません",
       "notImported": "未インポート",
       "status": {

--- a/src/i18n/locales/ko/sessions.json
+++ b/src/i18n/locales/ko/sessions.json
@@ -123,6 +123,11 @@
         "clis": "CLI"
       },
       "sessions_other": "{{count}}개 세션",
+      "details": {
+        "path": "경로",
+        "storeType": "저장 형식",
+        "copyPath": "경로 복사"
+      },
       "noPath": "경로가 감지되지 않음",
       "notImported": "가져오지 않음",
       "status": {

--- a/src/i18n/locales/pl/sessions.json
+++ b/src/i18n/locales/pl/sessions.json
@@ -126,6 +126,11 @@
       "sessions_few": "{{count}} sesje",
       "sessions_many": "{{count}} sesji",
       "sessions_other": "{{count}} sesji",
+      "details": {
+        "path": "Ścieżka",
+        "storeType": "Typ magazynu",
+        "copyPath": "Kopiuj ścieżkę"
+      },
       "noPath": "Nie wykryto ścieżki",
       "notImported": "Nie zaimportowano",
       "status": {

--- a/src/i18n/locales/pt/sessions.json
+++ b/src/i18n/locales/pt/sessions.json
@@ -124,6 +124,11 @@
       },
       "sessions_one": "{{count}} sessão",
       "sessions_other": "{{count}} sessões",
+      "details": {
+        "path": "Caminho",
+        "storeType": "Tipo de armazenamento",
+        "copyPath": "Copiar caminho"
+      },
       "noPath": "Nenhum caminho detectado",
       "notImported": "Não importado",
       "status": {

--- a/src/i18n/locales/ru/sessions.json
+++ b/src/i18n/locales/ru/sessions.json
@@ -126,6 +126,11 @@
       "sessions_few": "{{count}} сессии",
       "sessions_many": "{{count}} сессий",
       "sessions_other": "{{count}} сессии",
+      "details": {
+        "path": "Путь",
+        "storeType": "Тип хранилища",
+        "copyPath": "Копировать путь"
+      },
       "noPath": "Путь не обнаружен",
       "notImported": "Не импортировано",
       "status": {

--- a/src/i18n/locales/tr/sessions.json
+++ b/src/i18n/locales/tr/sessions.json
@@ -124,6 +124,11 @@
       },
       "sessions_one": "{{count}} oturum",
       "sessions_other": "{{count}} oturum",
+      "details": {
+        "path": "Yol",
+        "storeType": "Depolama türü",
+        "copyPath": "Yolu kopyala"
+      },
       "noPath": "Yol algılanmadı",
       "notImported": "İçe aktarılmadı",
       "status": {

--- a/src/i18n/locales/vi/sessions.json
+++ b/src/i18n/locales/vi/sessions.json
@@ -123,6 +123,11 @@
         "clis": "CLI"
       },
       "sessions_other": "{{count}} phiên",
+      "details": {
+        "path": "Đường dẫn",
+        "storeType": "Loại lưu trữ",
+        "copyPath": "Sao chép đường dẫn"
+      },
       "noPath": "Không phát hiện đường dẫn",
       "notImported": "Chưa nhập",
       "status": {

--- a/src/i18n/locales/zh-Hant/sessions.json
+++ b/src/i18n/locales/zh-Hant/sessions.json
@@ -123,6 +123,11 @@
         "clis": "命令列"
       },
       "sessions_other": "{{count}} 個工作階段",
+      "details": {
+        "path": "路徑",
+        "storeType": "儲存類型",
+        "copyPath": "複製路徑"
+      },
       "noPath": "未偵測到路徑",
       "notImported": "未匯入",
       "status": {

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -123,6 +123,11 @@
         "clis": "命令行"
       },
       "sessions_other": "{{count}} 个会话",
+      "details": {
+        "path": "路径",
+        "storeType": "存储类型",
+        "copyPath": "复制路径"
+      },
       "noPath": "未检测到路径",
       "notImported": "未导入",
       "status": {


### PR DESCRIPTION
## Summary

Renders the Kanban **Data Sources** tab through the shared `SettingsTable` instead of the grid-based `SectionTable`, so it gains the settings-table capabilities that grid can't provide: a pinned actions column, expandable rows, and the built-in sticky search bar.

Previously the on-disk store path was only reachable via a FolderOpen button's tooltip, the table couldn't scroll-pin a column, and rows couldn't expand.

## What changed

- **Pinned last column** — the `actions` column (Open / Rescan / enable toggle) stays visible while the table scrolls horizontally, via `SettingsTable`'s built-in last-column pin (auto-engages on the `actions` key).
- **Expandable rows** — each source row expands to a reusable **`DataSourceDetailsCard`** showing the store path(s) with Copy / Open-folder actions, the store type (JSONL/SQLite/…), and the imported session count. The card is composed from the shared inline-card primitives (`InlineInfoCard` + `INFO_CARD_TOKENS`), matching the KeyVault "keys" inline cards.
- **Built-in sticky search bar** — mirrors the CLI Clients table: the `All / Apps / CLIs` tabs move into the search bar's `tabPills` slot and `Rescan All` into its `rightContent`, so the whole toolbar (search + tabs + action) stays pinned. Search filters by source name, id, and path.
- **Layout** — panel constrained to the shared `max-w-[932px]` content width used elsewhere in the chat pane.
- **Refactor** — lifted `tildePath` + store-kind label helpers into a co-located `sourcePath` module shared by the panel and the card.

## Reviewer notes

- No changes to `SettingsTable` / `Table` / CSS — this reuses existing props (`expandable`, `searchBar`, the `actions`-keyed pin).
- i18n: adds `kanban.dataSource.details.{path,storeType,copyPath}` across all 13 locales; reuses `common:common.searchPlaceholder` and `common:status.noResults`.
- Row expansion is currently multi-row (any number open at once) rather than the CLI table's single-row accordion — easy to switch if preferred.

## Testing

- `tsc --noEmit`: 0 errors project-wide; ESLint clean; no new circular deps.
- Not yet exercised in the live Tauri app — suggest a manual pass: open Kanban → Data Sources, narrow the pane to trigger horizontal scroll (actions stays pinned), expand a row (card shows path + type + count; Copy/Open work), and verify the search + tab filters.