### PR TITLE
fix(chat): restore file pills across message edits

### DIFF
--- a/src/engines/ChatPanel/InputArea/utils/__tests__/pillContentParser.test.ts
+++ b/src/engines/ChatPanel/InputArea/utils/__tests__/pillContentParser.test.ts
@@ -67,6 +67,14 @@ describe("hasPillSyntax", () => {
   it("returns false for plain text", () => {
     expect(hasPillSyntax("hello world")).toBe(false);
   });
+
+  it("returns true every time the same serialized pill is checked", () => {
+    const content = "ChatView.md [file:/repo/docs/ChatView.md] 看这个file";
+
+    expect(hasPillSyntax(content)).toBe(true);
+    expect(hasPillSyntax(content)).toBe(true);
+    expect(hasPillSyntax(content)).toBe(true);
+  });
 });
 
 // ============================================================
@@ -94,15 +102,32 @@ describe("parsePillTextToSnapshot", () => {
     ]);
   });
 
-  it("does not swallow CJK prose into the pill display name when no space precedes the pill", () => {
-    // Regression: previously `lastSpaceIdx === -1` made the entire CJK prefix
-    // become the pill's fileName, rendering the whole sentence as a single
-    // blue file pill.
+  it("restores a leading file reference without duplicating its label", () => {
+    const snapshot = parsePillTextToSnapshot(
+      "AgentMessage.md [file:/repo/src/AgentMessage.md] 看看这个文件"
+    );
+    expect(snapshot.parts).toEqual([
+      {
+        kind: "pill",
+        attrs: {
+          filePath: "/repo/src/AgentMessage.md",
+          fileName: "AgentMessage.md",
+          isFolder: false,
+          iconType: "file",
+          lineStart: null,
+          lineEnd: null,
+        },
+      },
+      { kind: "text", text: " 看看这个文件" },
+    ]);
+  });
+
+  it("preserves CJK prose adjacent to a file pill without duplicating its label", () => {
     const snapshot = parsePillTextToSnapshot(
       "生成一个plan给我看看这个package.json [file:/repo/package.json]"
     );
     expect(snapshot.parts).toEqual([
-      { kind: "text", text: "生成一个plan给我看看这个package.json" },
+      { kind: "text", text: "生成一个plan给我看看这个" },
       {
         kind: "pill",
         attrs: {

--- a/src/engines/ChatPanel/InputArea/utils/pillContentParser.ts
+++ b/src/engines/ChatPanel/InputArea/utils/pillContentParser.ts
@@ -37,10 +37,16 @@ export function stripExpandedPillContent(text: string): string {
   return idx === -1 ? text : text.slice(0, idx);
 }
 
+const PILL_SYNTAX_REGEX = new RegExp(
+  PILL_REGEX.source,
+  PILL_REGEX.flags.replace("g", "")
+);
+
 export function hasPillSyntax(text: string): boolean {
-  // Use PILL_REGEX (which can cross newlines) only for the fast-path check;
-  // actual parsing uses SINGLE_LINE_PILL_REGEX per line.
-  return PILL_REGEX.test(text);
+  // Use a non-global clone for boolean detection. Calling `.test()` on the
+  // shared global regex mutates `lastIndex`, making repeated edit restores
+  // alternate between parsed pills and raw serialized text.
+  return PILL_SYNTAX_REGEX.test(text);
 }
 
 /**
@@ -75,15 +81,20 @@ export function parsePillTextToSnapshot(text: string): ComposerSnapshot {
       let precedingText: string;
       let fileName: string;
       const pillType = match[2] as PillType;
+      const pathFileName =
+        match[3].split("/").pop()?.split("::")[0] || match[3];
       if (lastSpaceIdx >= 0) {
         precedingText = rawDisplayName.slice(0, lastSpaceIdx + 1);
         fileName = rawDisplayName.slice(lastSpaceIdx + 1).trim();
       } else if (pillType === "session") {
         precedingText = "";
         fileName = rawDisplayName.trim();
+      } else if (rawDisplayName.endsWith(pathFileName)) {
+        precedingText = rawDisplayName.slice(0, -pathFileName.length);
+        fileName = pathFileName;
       } else {
         precedingText = rawDisplayName;
-        fileName = match[3].split("/").pop()?.split("::")[0] || match[3];
+        fileName = pathFileName;
       }
 
       if (matchStart > lastIndex) {


### PR DESCRIPTION
## Summary

- restore serialized file references as a single composer pill instead of duplicated filename text plus pill UI
- make pill-syntax detection stateless so leaving and re-entering sent-message edit mode consistently reparses the reference
- preserve adjacent CJK prose while removing only the serialized file label

## Root cause

`PILL_REGEX` is global, so calling `.test()` mutated `lastIndex`. Repeated checks of the same message alternated between matching and not matching, which made the second edit entry render raw `displayName [file:path]` text.

For file pills without whitespace before the serialized label, the parser also preserved the basename as normal text while creating a pill for the same file.

## Verification

- `vitest run src/engines/ChatPanel/InputArea/utils/__tests__/pillContentParser.test.ts` — 16 tests passed
- ESLint on both changed files — passed
- `tsc --noEmit --pretty false` — passed
- pre-commit scoped TypeScript check — passed
- `git diff --check origin/develop...HEAD` — passed

## Audit

- swept `src` for stateful global-RegExp `.test()` usage; `PILL_REGEX.test()` was the only matching instance in this problem class
- confirmed both sent-message edit restore and persisted draft restore use `applyParsedContent`
- confirmed no upstream changes to the parser files and no wire-format changes
- PR is isolated to the parser and its regression tests
