### PR TITLE
chore: remove orphan Gemini adapter module

### DIFF
--- a/src-tauri/src/agent_sessions/cli/platform_adapters/gemini/mod.rs
+++ b/src-tauri/src/agent_sessions/cli/platform_adapters/gemini/mod.rs
@@ -1,1 +1,0 @@
-pub mod oauth;


### PR DESCRIPTION
## Summary

Remove the unreferenced `platform_adapters/gemini/mod.rs` file left after PR #359 deleted the Gemini OAuth adapter and removed the parent module export.

## Scope

- One file deleted
- No runtime behavior change
- Completes the Gemini CLI source cleanup from #359

## Validation

- Confirmed the file is no longer referenced or reachable from `platform_adapters/mod.rs`
- Confirmed the follow-up diff against `develop` is exactly one deletion
- `git diff --check` passes