### PR TITLE
feat(workstation): support Git worktree switching

### DIFF
--- a/docs/frontend-ui-audit-2026-07-13/WorktreeDropdown.md
+++ b/docs/frontend-ui-audit-2026-07-13/WorktreeDropdown.md
@@ -1,0 +1,42 @@
+# Frontend UI Audit — WorktreeDropdown
+
+**File:** `src/features/SessionCreator/components/SessionInfoLine/WorktreeDropdown.tsx` (231 LOC)
+**Date:** 2026-07-13
+**Auditor:** ORGII implementation session
+
+## D1 — Raw HTML vs Design System
+
+| Line | Element                 | Verdict          | Reason                                                                                                                                                                                                                                                  | Suggested change |
+| ---- | ----------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| 44   | Worktree row `<button>` | keep with reason | The dropdown navigation engine supplies row-level hover, click, selected index, and keyboard props directly. This matches the neighboring WorkspaceDropdown and BranchDropdown raw-row pattern; the DS Button does not expose this listbox integration. | —                |
+| 196  | Search `<input>`        | keep with reason | It is embedded in the shared `DROPDOWN_CLASSES.searchContainer` pattern and uses `searchInput` tokens plus Tauri-specific Select All behavior, matching sibling dropdowns.                                                                              | —                |
+
+## D2 — Arbitrary Tailwind Value vs Token
+
+| Line | Value                         | Verdict          | Reason                                                                                                                                                                          | Suggested change |
+| ---- | ----------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| 63   | `text-[11px]` branch metadata | keep with reason | This exact compact metadata size is established across WorkspaceDropdown, CursorModelDropdown, and selector section labels. It is not a raw color or isolated visual invention. | —                |
+
+## D3 — Hardcoded Sizes / Colors
+
+| Line  | Value                                                     | Verdict          | Reason                                                                                                                       | Suggested change |
+| ----- | --------------------------------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| 27–29 | 360px list cap, 12px viewport margin, 320px minimum width | keep with reason | These constants intentionally mirror WorkspaceDropdown's positioning contract, keeping sibling selector geometry consistent. | —                |
+
+## D4 — Accessibility
+
+| Line | Element               | Verdict          | Reason                                                                                                              | Suggested change                                     |
+| ---- | --------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| 44   | Worktree row button   | keep with reason | Visible worktree and branch text provide an accessible name; keyboard selection is supplied by `useDropdownEngine`. | —                                                    |
+| 196  | Worktree search input | fix (applied)    | Placeholder text alone is not a durable accessible name.                                                            | Added `aria-label` using the localized search label. |
+
+## D5 — Visual Patterns Observed
+
+- The component intentionally reuses the existing anchored selector pattern (`DROPDOWN_CLASSES`, `DROPDOWN_ITEM`, `DROPDOWN_PANEL`, `useDropdownEngine`) rather than introducing a new dropdown implementation.
+- No new repeated visual pattern reaches the >=3 independent implementation threshold; the relevant pattern is already abstracted by shared dropdown tokens and hooks.
+
+## Summary
+
+- 1 fix recommended and applied
+- 5 findings kept with documented reason
+- 0 abstract candidates

--- a/src-tauri/crates/git-api/src/routes/worktrees.rs
+++ b/src-tauri/crates/git-api/src/routes/worktrees.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 
 use axum::{
     extract::{Path, Query},
-    routing::{delete, get},
+    routing::{delete, get, post},
     Json, Router,
 };
 use serde::Deserialize;
@@ -17,8 +17,8 @@ use serde::Deserialize;
 use crate::error::{GitApiError, GitApiResult};
 use crate::extractors::{lookup_repo_path, validate_path};
 use crate::types::{
-    RemoveWorktreeRequest, WorktreeDiffSummary, WorktreeEntry, WorktreeListResponse,
-    WorktreeRemoveResponse,
+    CreateWorktreeRequest, RemoveWorktreeRequest, WorktreeDiffSummary, WorktreeEntry,
+    WorktreeListResponse, WorktreeRemoveResponse,
 };
 
 /// Cache TTL for worktree diff summaries. Recomputation is skipped if the
@@ -41,6 +41,7 @@ fn diff_cache() -> &'static Mutex<HashMap<(String, String), DiffCacheEntry>> {
 pub fn routes() -> Router {
     Router::new()
         .route("/api/git/repo/{repo_id}/worktrees", get(get_worktrees))
+        .route("/api/git/repo/{repo_id}/worktrees", post(create_worktree))
         .route("/api/git/repo/{repo_id}/worktrees", delete(remove_worktree))
 }
 
@@ -91,6 +92,60 @@ pub async fn get_worktrees(
         .collect();
 
     Ok(Json(WorktreeListResponse { status: 0, data }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/git/repo/{repo_id}/worktrees",
+    params(
+        ("repo_id" = String, Path, description = "Repository UUID or path"),
+        ("path" = Option<String>, Query, description = "Repository file system path"),
+    ),
+    request_body = CreateWorktreeRequest,
+    responses(
+        (status = 200, description = "Created git worktree", body = WorktreeRemoveResponse)
+    ),
+    tag = "worktrees"
+)]
+pub async fn create_worktree(
+    Path(repo_id): Path<String>,
+    Query(query): Query<WorktreesQuery>,
+    Json(request): Json<CreateWorktreeRequest>,
+) -> GitApiResult<Json<WorktreeRemoveResponse>> {
+    let repo_path = resolve_repo_path(&repo_id, query.path.as_deref())?;
+    let worktree_path = validate_new_worktree_path(&request.worktree_path)?;
+    let branch = request.branch.trim().to_string();
+    let base_ref = request
+        .base_ref
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+
+    let created = tokio::task::spawn_blocking(move || {
+        git::worktree::create_linked_worktree(
+            &repo_path,
+            &worktree_path,
+            &branch,
+            base_ref.as_deref(),
+        )
+    })
+    .await
+    .map_err(|err| GitApiError::Internal {
+        message: format!("Worktree creation task failed: {err}"),
+    })?
+    .map_err(GitApiError::from_git_error)?;
+
+    Ok(Json(WorktreeRemoveResponse {
+        status: 0,
+        data: WorktreeEntry {
+            path: created.path,
+            branch: created.branch,
+            head_sha: created.head_sha,
+            is_main: false,
+            diff_summary: None,
+        },
+    }))
 }
 
 #[utoipa::path(
@@ -220,6 +275,30 @@ mod tests {
         assert!(!is_pathological_worktree_checkout(2, 10, 3));
         assert!(!is_pathological_worktree_checkout(50, 500, 120));
     }
+}
+
+fn validate_new_worktree_path(path: &str) -> GitApiResult<PathBuf> {
+    if path.contains("..") {
+        return Err(GitApiError::InvalidPath {
+            path: path.to_string(),
+            reason: "Path traversal is not allowed".to_string(),
+        });
+    }
+    let target = PathBuf::from(path);
+    let Some(parent) = target.parent() else {
+        return Err(GitApiError::InvalidPath {
+            path: path.to_string(),
+            reason: "Worktree path must have a parent directory".to_string(),
+        });
+    };
+    let Some(name) = target.file_name() else {
+        return Err(GitApiError::InvalidPath {
+            path: path.to_string(),
+            reason: "Worktree path must have a directory name".to_string(),
+        });
+    };
+    let parent = validate_path(&parent.to_string_lossy())?;
+    Ok(parent.join(name))
 }
 
 fn resolve_repo_path(repo_id: &str, query_path: Option<&str>) -> GitApiResult<std::path::PathBuf> {

--- a/src-tauri/crates/git-api/src/types.rs
+++ b/src-tauri/crates/git-api/src/types.rs
@@ -390,6 +390,13 @@ pub struct WorktreeEntry {
 }
 
 #[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct CreateWorktreeRequest {
+    pub worktree_path: String,
+    pub branch: String,
+    pub base_ref: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct RemoveWorktreeRequest {
     pub worktree_path: String,
     #[serde(default = "default_force_remove_worktree")]

--- a/src-tauri/crates/git/src/worktree.rs
+++ b/src-tauri/crates/git/src/worktree.rs
@@ -41,9 +41,17 @@ pub struct WorktreeInfo {
     pub branch: String,
     /// `None` when the info was reconstructed from `git worktree list` (porcelain
     /// output does not include the base ref). Always `Some` when returned by
-    /// `create_session_worktree`.
+    /// `create_session_worktree` or `create_linked_worktree`.
     pub base_branch: Option<String>,
     pub session_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LinkedWorktreeInfo {
+    pub path: String,
+    pub branch: String,
+    pub head_sha: String,
 }
 
 // `MergeStrategy` and `WorktreeMergeResult` are pure data and live in
@@ -247,6 +255,71 @@ fn current_head_ref(repo_path: &Path) -> Result<String, String> {
 // ============================================
 // Public API
 // ============================================
+
+/// Create a linked worktree for an explicit branch name.
+///
+/// Unlike [`create_session_worktree`], this is not tied to an agent session:
+/// the caller supplies the branch and target path. Existing local branches are
+/// reused; otherwise a new branch is created from `base_ref` (or `HEAD`).
+pub fn create_linked_worktree(
+    repo_path: &Path,
+    worktree_path: &Path,
+    branch: &str,
+    base_ref: Option<&str>,
+) -> Result<LinkedWorktreeInfo, String> {
+    let branch = branch.trim();
+    if branch.is_empty() {
+        return Err("branch cannot be empty".to_string());
+    }
+    let path_string = worktree_path.to_string_lossy().to_string();
+    if worktree_path.exists() {
+        return Err(format!("Worktree path already exists: {}", path_string));
+    }
+    if let Some(parent) = worktree_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|err| format!("Failed to create worktree parent dir: {}", err))?;
+    }
+
+    let branch_exists = run_git(repo_path, &["rev-parse", "--verify", branch])
+        .map(|output| output.status.success())
+        .unwrap_or(false);
+    let output = if branch_exists {
+        run_git(repo_path, &["worktree", "add", &path_string, branch])?
+    } else {
+        run_git(
+            repo_path,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                &path_string,
+                base_ref.unwrap_or("HEAD"),
+            ],
+        )?
+    };
+
+    if !output.status.success() {
+        return Err(format!("git worktree add failed: {}", git_stderr(&output)));
+    }
+
+    if let Err(err) = run_worktree_setup_hooks(repo_path, worktree_path) {
+        let _ = run_git(repo_path, &["worktree", "remove", "--force", &path_string]);
+        if !branch_exists {
+            let _ = run_git(repo_path, &["branch", "-D", branch]);
+        }
+        return Err(err);
+    }
+
+    let head_sha = run_git(worktree_path, &["rev-parse", "HEAD"])
+        .map(|output| git_stdout(&output))
+        .unwrap_or_default();
+    Ok(LinkedWorktreeInfo {
+        path: path_string,
+        branch: branch.to_string(),
+        head_sha,
+    })
+}
 
 /// Create an isolated worktree for a coding agent session.
 ///

--- a/src/api/http/git/index.ts
+++ b/src/api/http/git/index.ts
@@ -74,7 +74,7 @@ import {
   gitStashPush,
 } from "./stash";
 import { getGitStatus, getGitSuggestedAction } from "./status";
-import { getGitWorktrees } from "./worktrees";
+import { createGitWorktree, getGitWorktrees } from "./worktrees";
 
 // Re-export all types
 export * from "./types";
@@ -86,7 +86,11 @@ export { clearStatusCache } from "./client";
 export { getGitStatus, getGitSuggestedAction } from "./status";
 
 // Re-export worktree functions
-export { getGitWorktrees, removeGitWorktree } from "./worktrees";
+export {
+  createGitWorktree,
+  getGitWorktrees,
+  removeGitWorktree,
+} from "./worktrees";
 
 // Re-export branch functions
 export {
@@ -266,6 +270,7 @@ export const gitApi = {
   getGitBlame,
 
   // Worktrees
+  createGitWorktree,
   getGitWorktrees,
 
   // Cache management

--- a/src/api/http/git/worktrees.ts
+++ b/src/api/http/git/worktrees.ts
@@ -22,6 +22,31 @@ export async function getGitWorktrees(params: {
   return response.data;
 }
 
+export async function createGitWorktree(params: {
+  repo_id: string;
+  repo_path?: string;
+  worktree_path: string;
+  branch: string;
+  base_ref?: string;
+}): Promise<GitWorktreeEntry> {
+  const queryParams = new URLSearchParams();
+  if (params.repo_path) {
+    queryParams.append("path", params.repo_path);
+  }
+
+  const queryString = queryParams.toString();
+  const endpoint = `${gitRepoUrl(params.repo_id)}/worktrees${queryString ? "?" + queryString : ""}`;
+  const response = await fetchRustApi<GitWorktreeEntry>(endpoint, {
+    method: "POST",
+    body: JSON.stringify({
+      worktree_path: params.worktree_path,
+      branch: params.branch,
+      base_ref: params.base_ref ?? null,
+    }),
+  });
+  return response.data;
+}
+
 export async function removeGitWorktree(params: {
   repo_id: string;
   repo_path?: string;

--- a/src/features/SessionCreator/components/SessionInfoLine.tsx
+++ b/src/features/SessionCreator/components/SessionInfoLine.tsx
@@ -24,7 +24,11 @@ import React, {
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
-import { gitApi, removeGitWorktree } from "@src/api/http/git";
+import {
+  type GitWorktreeEntry,
+  gitApi,
+  removeGitWorktree,
+} from "@src/api/http/git";
 import { CheckoutBlockedDialog } from "@src/components/GitDialogs/CheckoutBlockedDialog";
 import { CheckoutConflictDialog } from "@src/components/GitDialogs/CheckoutConflictDialog";
 import PillGroup, { type PillGroupVariant } from "@src/components/PillGroup";
@@ -56,11 +60,19 @@ import { workspaceNameAtom } from "@src/store/workspace/derived";
 import { showGitActionDialogSafely } from "@src/util/dialogs/gitActionDialog";
 
 import {
+  WorktreeDropdown,
+  useRepoWorktrees,
+} from "./SessionInfoLine/WorktreeDropdown";
+import {
   buildSessionInfoSegments,
   getSessionInfoDisplayState,
 } from "./SessionInfoLine/buildSessionInfoSegments";
 import { type LocationRow } from "./SessionInfoLine/locationConfig";
 import { useSystemPathRepoItems } from "./SessionInfoLine/useSystemPathRepoItems";
+import {
+  getWorktreeName,
+  normalizeWorktreePath,
+} from "./SessionInfoLine/worktreeSwitcher";
 import WorktreeSourceModal from "./WorktreeSourceModal";
 
 // ============================================
@@ -124,8 +136,10 @@ export interface SessionInfoLineProps {
    * (This Mac / New Worktree / Cloud) — modelled after Cursor's context bar.
    */
   worktreeLocation?: RunningLocation;
+  selectedWorktreePath?: string | null;
   worktreeSourceLabel?: string;
   onWorktreeLocationChange?: (location: RunningLocation) => void;
+  onExistingWorktreeSelect?: (worktree: GitWorktreeEntry) => void;
   onWorktreeSourceSelect?: (source: WorktreeLaunchSource) => void;
 }
 
@@ -264,8 +278,10 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
   pillVariant = "default",
   fullWidth: _fullWidth = false,
   worktreeLocation,
+  selectedWorktreePath,
   worktreeSourceLabel,
   onWorktreeLocationChange,
+  onExistingWorktreeSelect,
   onWorktreeSourceSelect,
   disabled = false,
   hideBranch = false,
@@ -277,6 +293,7 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
   // ============================================
 
   const [isRepoSelectorOpen, setIsRepoSelectorOpen] = useState(false);
+  const [isWorktreeSelectorOpen, setIsWorktreeSelectorOpen] = useState(false);
   const [isBranchSelectorOpen, setIsBranchSelectorOpen] = useState(false);
   const [isWorktreeSourceModalOpen, setIsWorktreeSourceModalOpen] =
     useState(false);
@@ -330,6 +347,7 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
   // ============================================
 
   const repoTriggerRef = useRef<HTMLButtonElement>(null);
+  const worktreeTriggerRef = useRef<HTMLButtonElement>(null);
   const branchTriggerRef = useRef<HTMLButtonElement>(null);
   const modelPickerStyle = useAtomValue(modelPickerStyleAtom);
   const useDropdownPicker = modelPickerStyle === "dropdown";
@@ -341,6 +359,11 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
   const handleRepoTriggerClick = useCallback(() => {
     if (disabled) return;
     setIsRepoSelectorOpen((isOpen) => !isOpen);
+  }, [disabled]);
+
+  const handleWorktreeTriggerClick = useCallback(() => {
+    if (disabled) return;
+    setIsWorktreeSelectorOpen((isOpen) => !isOpen);
   }, [disabled]);
 
   const handleBranchTriggerClick = useCallback(() => {
@@ -365,10 +388,11 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
   );
 
   const systemPathSourceItems = useSystemPathRepoItems(includeSystemPaths, t);
+  const branchRepoPath = selectedWorktreePath ?? repoPath ?? "";
 
   const handleBranchSelect = useCallback(
     async (branch: string) => {
-      if (!repoId || !repoPath || repoKind === REPO_KIND.FOLDER) {
+      if (!repoId || !branchRepoPath || repoKind === REPO_KIND.FOLDER) {
         onBranchChange?.(branch);
         setIsBranchSelectorOpen(false);
         return true;
@@ -376,7 +400,7 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
 
       const result = await runGuardedCheckout({
         repoId,
-        repoPath,
+        repoPath: branchRepoPath,
         ref: branch,
         onConflict: (name) => CheckoutConflictDialog.open({ branchName: name }),
         onBlocked: ({ branch: name, errorType, message }) =>
@@ -404,7 +428,7 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
       }
       return false;
     },
-    [onBranchChange, repoId, repoKind, repoPath]
+    [branchRepoPath, onBranchChange, repoId, repoKind]
   );
 
   const handleBranchPaletteSelect = useCallback(
@@ -416,10 +440,10 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
 
   const handleCreateBranch = useCallback(
     async (branch: string, startPoint?: string) => {
-      if (!repoId || !repoPath) return;
+      if (!repoId || !branchRepoPath) return;
       const result = await gitApi.gitCreateBranch({
         repo_id: repoId,
-        repo_path: repoPath,
+        repo_path: branchRepoPath,
         name: branch,
         start_point: startPoint ?? null,
         checkout: false,
@@ -433,7 +457,7 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
       }
       await handleBranchSelect(branch);
     },
-    [handleBranchSelect, repoId, repoPath]
+    [branchRepoPath, handleBranchSelect, repoId]
   );
 
   const handleDeleteBranch = useCallback(
@@ -441,7 +465,7 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
       branch: string,
       options?: { silent?: boolean; skipRefresh?: boolean }
     ) => {
-      if (!repoId || !repoPath) {
+      if (!repoId || !branchRepoPath) {
         const message = "No repo selected";
         if (!options?.silent) {
           showGitActionDialogSafely(message, "error");
@@ -451,7 +475,7 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
 
       const result = await gitApi.gitDeleteBranch({
         repo_id: repoId,
-        repo_path: repoPath,
+        repo_path: branchRepoPath,
         branch_name: branch,
       });
 
@@ -468,7 +492,7 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
       }
       return { success: true };
     },
-    [repoId, repoPath]
+    [branchRepoPath, repoId]
   );
 
   const handleRemoveWorktree = useCallback(
@@ -578,6 +602,32 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
     ]
   );
 
+  const worktrees = useRepoWorktrees({
+    repoId,
+    repoPath,
+    enabled: showBranchRow,
+  });
+  const activeWorktreePath = selectedWorktreePath ?? repoPath ?? "";
+  const activeWorktree = worktrees.find(
+    (worktree) =>
+      normalizeWorktreePath(worktree.path) ===
+      normalizeWorktreePath(activeWorktreePath)
+  );
+  const showWorktreeRow = showBranchRow;
+  const worktreeName = activeWorktree?.is_main
+    ? t("sourceControl.scope.main")
+    : activeWorktree
+      ? getWorktreeName(activeWorktree)
+      : undefined;
+
+  const handleExistingWorktreeSelect = useCallback(
+    (worktree: GitWorktreeEntry) => {
+      onExistingWorktreeSelect?.(worktree);
+      setIsWorktreeSelectorOpen(false);
+    },
+    [onExistingWorktreeSelect]
+  );
+
   const handleLocationTriggerClick = useCallback(() => {
     if (disabled) return;
     toggleLocation();
@@ -608,6 +658,10 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
     sourceDisplayName,
     isRepoSelectorOpen,
     handleRepoTriggerClick,
+    showWorktreeRow,
+    worktreeName,
+    isWorktreeSelectorOpen,
+    handleWorktreeTriggerClick,
     showBranchRow,
     branchLoading,
     branchName,
@@ -626,6 +680,8 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
   // flag passing locally-created refs through a plain function.
   const segments = baseSegments.map((segment) => {
     if (segment.id === "repo") return { ...segment, buttonRef: repoTriggerRef };
+    if (segment.id === "worktree")
+      return { ...segment, buttonRef: worktreeTriggerRef };
     if (segment.id === "branch")
       return { ...segment, buttonRef: branchTriggerRef };
     return segment;
@@ -661,6 +717,17 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
         />
       )}
 
+      {showWorktreeRow && (
+        <WorktreeDropdown
+          isOpen={isWorktreeSelectorOpen}
+          onClose={() => setIsWorktreeSelectorOpen(false)}
+          onSelect={handleExistingWorktreeSelect}
+          worktrees={worktrees}
+          selectedPath={activeWorktreePath}
+          anchorRef={worktreeTriggerRef}
+        />
+      )}
+
       {/* Branch Selector */}
       {showBranchRow &&
         repoId &&
@@ -670,8 +737,9 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
             onClose={handleBranchClose}
             onSelect={handleBranchSelect}
             repoId={repoId}
-            repoPath={repoPath}
+            repoPath={branchRepoPath}
             currentBranchName={branchName}
+            groupWorktreeBranches={false}
             anchorRef={branchTriggerRef}
           />
         ) : (
@@ -680,8 +748,9 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
             onClose={handleBranchClose}
             onSelect={handleBranchPaletteSelect}
             repoId={repoId}
-            repoPath={repoPath}
+            repoPath={branchRepoPath}
             currentBranchName={branchName}
+            groupWorktreeBranches={false}
             onCreateBranch={handleCreateBranch}
             onDeleteBranch={handleDeleteBranch}
             onRemoveWorktree={handleRemoveWorktree}

--- a/src/features/SessionCreator/components/SessionInfoLine/WorktreeDropdown.tsx
+++ b/src/features/SessionCreator/components/SessionInfoLine/WorktreeDropdown.tsx
@@ -1,0 +1,232 @@
+import { Check, GitBranch, GitFork, Search } from "lucide-react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+
+import { type GitWorktreeEntry, getGitWorktrees } from "@src/api/http/git";
+import {
+  DROPDOWN_CLASSES,
+  DROPDOWN_ITEM,
+  DROPDOWN_PANEL,
+} from "@src/components/Dropdown/tokens";
+import {
+  type UseDropdownListNavigationReturn,
+  useDropdownEngine,
+} from "@src/hooks/dropdown";
+import { useTauriSelectAllShortcut } from "@src/hooks/keyboard";
+import { getViewportSize } from "@src/util/ui/window/viewport";
+
+import { getWorktreeName, normalizeWorktreePath } from "./worktreeSwitcher";
+
+const LIST_MAX_HEIGHT = 360;
+const VIEWPORT_MARGIN = 12;
+const MIN_DROPDOWN_WIDTH = 320;
+
+interface WorktreeRowProps {
+  worktree: GitWorktreeEntry;
+  isSelected: boolean;
+  mainLabel: string;
+  keyboardProps: ReturnType<UseDropdownListNavigationReturn["getItemProps"]>;
+}
+
+const WorktreeRow: React.FC<WorktreeRowProps> = ({
+  worktree,
+  isSelected,
+  mainLabel,
+  keyboardProps,
+}) => (
+  <button
+    type="button"
+    data-testid={`worktree-dropdown-row-${worktree.path}`}
+    {...keyboardProps}
+    className={`${DROPDOWN_CLASSES.item} ${
+      isSelected ? DROPDOWN_CLASSES.itemSelected : DROPDOWN_CLASSES.itemHover
+    } w-full justify-start`}
+  >
+    <span className="flex h-5 w-5 shrink-0 items-center justify-center">
+      {isSelected ? (
+        <Check size={DROPDOWN_ITEM.iconSize} className="text-primary-6" />
+      ) : (
+        <GitFork size={DROPDOWN_ITEM.iconSize} className="text-text-2" />
+      )}
+    </span>
+    <div className="flex min-w-0 flex-1 flex-col items-start">
+      <span className="truncate">
+        {worktree.is_main ? mainLabel : getWorktreeName(worktree)}
+      </span>
+      <span className="flex max-w-full items-center gap-1 text-[11px] text-text-3">
+        <GitBranch size={11} className="shrink-0" />
+        <span className="truncate">
+          {worktree.branch || worktree.head_sha.slice(0, 7)}
+        </span>
+      </span>
+    </div>
+  </button>
+);
+
+export interface WorktreeDropdownProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (worktree: GitWorktreeEntry) => void;
+  worktrees: readonly GitWorktreeEntry[];
+  selectedPath: string;
+  anchorRef: React.RefObject<HTMLElement | null>;
+}
+
+export function useRepoWorktrees(options: {
+  repoId?: string;
+  repoPath?: string;
+  enabled: boolean;
+}): GitWorktreeEntry[] {
+  const { repoId, repoPath, enabled } = options;
+  const requestKey =
+    enabled && repoId && repoPath ? `${repoId}:${repoPath}` : "";
+  const [result, setResult] = useState<{
+    key: string;
+    worktrees: GitWorktreeEntry[];
+  }>({ key: "", worktrees: [] });
+
+  useEffect(() => {
+    if (!requestKey || !repoId || !repoPath) return;
+
+    let cancelled = false;
+    void getGitWorktrees({ repo_id: repoId, repo_path: repoPath })
+      .then((entries) => {
+        if (!cancelled) setResult({ key: requestKey, worktrees: entries });
+      })
+      .catch(() => {
+        if (!cancelled) setResult({ key: requestKey, worktrees: [] });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [repoId, repoPath, requestKey]);
+
+  return result.key === requestKey ? result.worktrees : [];
+}
+
+export const WorktreeDropdown: React.FC<WorktreeDropdownProps> = ({
+  isOpen,
+  onClose,
+  onSelect,
+  worktrees,
+  selectedPath,
+  anchorRef,
+}) => {
+  const { t } = useTranslation();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const tauriSelectAll = useTauriSelectAllShortcut();
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const filteredWorktrees = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    if (!query) return [...worktrees];
+    return worktrees.filter((worktree) =>
+      `${getWorktreeName(worktree)} ${worktree.path} ${worktree.branch}`
+        .toLowerCase()
+        .includes(query)
+    );
+  }, [searchQuery, worktrees]);
+
+  const handleSelect = useCallback(
+    (worktree: GitWorktreeEntry) => {
+      setSearchQuery("");
+      onSelect(worktree);
+      onClose();
+    },
+    [onClose, onSelect]
+  );
+
+  const { isPositioned, panelRef, panelPosition, keyboard } = useDropdownEngine<
+    HTMLElement,
+    GitWorktreeEntry
+  >({
+    open: isOpen,
+    onOpenChange: (open) => {
+      if (!open) onClose();
+    },
+    anchorRef,
+    placement: "bottom",
+    gap: DROPDOWN_PANEL.triggerGap,
+    listNavigation: {
+      items: filteredWorktrees,
+      onSelect: handleSelect,
+      initialSelectedIndex: -1,
+    },
+  });
+
+  useEffect(() => {
+    if (!isOpen || !isPositioned) return;
+    const frame = requestAnimationFrame(() => inputRef.current?.focus());
+    return () => cancelAnimationFrame(frame);
+  }, [isOpen, isPositioned]);
+
+  if (!isOpen || !isPositioned) return null;
+
+  const width = Math.max(MIN_DROPDOWN_WIDTH, panelPosition.width);
+  const { width: viewportWidth } = getViewportSize();
+  const left = Math.max(
+    VIEWPORT_MARGIN,
+    Math.min(panelPosition.left, viewportWidth - VIEWPORT_MARGIN - width)
+  );
+
+  return createPortal(
+    <div
+      ref={panelRef}
+      className={`${DROPDOWN_CLASSES.panel} fixed flex flex-col`}
+      style={{
+        top: panelPosition.top,
+        bottom: panelPosition.bottom,
+        left,
+        width,
+      }}
+    >
+      <div className={DROPDOWN_CLASSES.searchContainer}>
+        <Search
+          size={DROPDOWN_ITEM.iconSize}
+          className="shrink-0 text-text-3"
+        />
+        <input
+          ref={inputRef}
+          value={searchQuery}
+          onChange={(event) => setSearchQuery(event.target.value)}
+          onKeyDown={tauriSelectAll}
+          aria-label={t("sourceControl.scope.searchPlaceholder")}
+          placeholder={t("sourceControl.scope.searchPlaceholder")}
+          className={DROPDOWN_CLASSES.searchInput}
+        />
+      </div>
+      <div
+        className={DROPDOWN_CLASSES.optionsContainerOverlay}
+        style={{ maxHeight: LIST_MAX_HEIGHT }}
+      >
+        {filteredWorktrees.length === 0 ? (
+          <div className={DROPDOWN_CLASSES.listMessage}>
+            {t("selectors.modelSelector.noResults")}
+          </div>
+        ) : (
+          filteredWorktrees.map((worktree, index) => (
+            <WorktreeRow
+              key={worktree.path}
+              worktree={worktree}
+              isSelected={
+                normalizeWorktreePath(worktree.path) ===
+                normalizeWorktreePath(selectedPath)
+              }
+              mainLabel={t("sourceControl.scope.main")}
+              keyboardProps={keyboard.getItemProps(index)}
+            />
+          ))
+        )}
+      </div>
+    </div>,
+    document.body
+  );
+};

--- a/src/features/SessionCreator/components/SessionInfoLine/buildSessionInfoSegments.tsx
+++ b/src/features/SessionCreator/components/SessionInfoLine/buildSessionInfoSegments.tsx
@@ -1,5 +1,12 @@
 import type { TFunction } from "i18next";
-import { Code, Folder, FolderTree, GitBranch, Home } from "lucide-react";
+import {
+  Code,
+  Folder,
+  FolderTree,
+  GitBranch,
+  GitFork,
+  Home,
+} from "lucide-react";
 import React from "react";
 
 import { KeyboardShortcutTooltipContent } from "@src/components/KeyboardShortcut";
@@ -67,6 +74,9 @@ export function getSessionInfoDisplayState({
 
 interface BuildSessionInfoSegmentsParams extends SessionInfoDisplayState {
   isRepoSelectorOpen: boolean;
+  showWorktreeRow: boolean;
+  worktreeName?: string;
+  isWorktreeSelectorOpen: boolean;
   isBranchSelectorOpen: boolean;
   branchLoading?: boolean;
   branchName?: string;
@@ -77,6 +87,7 @@ interface BuildSessionInfoSegmentsParams extends SessionInfoDisplayState {
   disabled: boolean;
   t: TFunction;
   handleRepoTriggerClick: () => void;
+  handleWorktreeTriggerClick: () => void;
   handleBranchTriggerClick: () => void;
   handleLocationTriggerClick: () => void;
 }
@@ -87,6 +98,10 @@ export function buildSessionInfoSegments({
   sourceDisplayName,
   isRepoSelectorOpen,
   handleRepoTriggerClick,
+  showWorktreeRow,
+  worktreeName,
+  isWorktreeSelectorOpen,
+  handleWorktreeTriggerClick,
   showBranchRow,
   branchLoading,
   branchName,
@@ -127,6 +142,24 @@ export function buildSessionInfoSegments({
       onClick: handleRepoTriggerClick,
     },
   ];
+
+  if (showWorktreeRow) {
+    segments.push({
+      id: "worktree",
+      icon: <GitFork size={14} strokeWidth={1.75} className="text-text-1" />,
+      label: worktreeName || t("sourceControl.scope.main"),
+      maxLabelWidth: SESSION_INFO_LABEL_MAX_WIDTH,
+      active: isWorktreeSelectorOpen,
+      tooltip: disabled
+        ? undefined
+        : t("selectors.sessionInfo.switchWorktree", "Switch worktree"),
+      tooltipFramed: true,
+      tooltipPosition: "bottom",
+      ariaLabel: t("selectors.sessionInfo.worktreeAria", "Select worktree"),
+      disabled,
+      onClick: handleWorktreeTriggerClick,
+    });
+  }
 
   if (showBranchRow) {
     segments.push({

--- a/src/features/SessionCreator/components/SessionInfoLine/worktreeSwitcher.ts
+++ b/src/features/SessionCreator/components/SessionInfoLine/worktreeSwitcher.ts
@@ -1,0 +1,10 @@
+import type { GitWorktreeEntry } from "@src/api/http/git";
+
+export function normalizeWorktreePath(path: string): string {
+  return path.replace(/^file:\/\//, "").replace(/\/+$/, "");
+}
+
+export function getWorktreeName(worktree: GitWorktreeEntry): string {
+  const normalizedPath = normalizeWorktreePath(worktree.path);
+  return normalizedPath.split("/").pop() || normalizedPath;
+}

--- a/src/features/SessionCreator/components/WorktreeSourceModal.tsx
+++ b/src/features/SessionCreator/components/WorktreeSourceModal.tsx
@@ -59,7 +59,7 @@ import {
   prNumberFromSourceRef,
 } from "./worktreeSourceResolve";
 
-interface WorktreeSourceModalProps {
+export interface WorktreeSourceModalProps {
   open: boolean;
   repoId?: string;
   repoName?: string;

--- a/src/features/SessionCreator/components/__tests__/TEST_CASES.md
+++ b/src/features/SessionCreator/components/__tests__/TEST_CASES.md
@@ -1,5 +1,18 @@
 # Test Cases: WorktreeSourceModal + worktree launch wiring
 
+## Existing worktree switching (issue #332)
+
+| #   | Steps                                                          | Expected Result                                                                                                                                         |
+| --- | -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| W1  | Open a repo with no linked worktrees                           | Session info renders Workspace → Worktree → Branch; Worktree displays `Main`, and its picker contains the main checkout                                 |
+| W2  | Open a repo with linked worktrees                              | Session info renders Workspace → Worktree → Branch; the worktree picker lists the main checkout and every linked worktree                               |
+| W3  | Inspect a linked worktree row                                  | Row shows its directory name/path identity and checked-out branch                                                                                       |
+| W4  | Select a linked worktree                                       | `selectedWorktreePath` stores its absolute path, running location becomes `worktree`, and the branch pill updates to that worktree's checked-out branch |
+| W5  | Open the branch picker after W4                                | Branch fetch/create/delete/checkout calls use the selected worktree path; sibling worktrees are no longer mixed into the branch list                    |
+| W6  | Select the main checkout                                       | `selectedWorktreePath` clears, running location returns to `local`, and branch operations use the workspace repo path                                   |
+| W7  | Choose New Worktree from the running-location picker           | The PR #349 WorktreeSourceModal flow remains unchanged and clears any existing worktree path                                                            |
+| W8  | Select a different Workspace while a linked worktree is active | Existing/new worktree state clears and running location returns to `local`; no path from the previous repository leaks into branch or launch operations |
+
 Covers the worktree-source picker (`WorktreeSourceModal.tsx`) and the
 launch-payload wiring that turns the picked source into backend worktree
 fields (`getWorktreeFields` in `useSessionLaunch/launchPayload.ts`).

--- a/src/features/SessionCreator/components/__tests__/worktreeSwitcher.test.ts
+++ b/src/features/SessionCreator/components/__tests__/worktreeSwitcher.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import type { GitWorktreeEntry } from "@src/api/http/git";
+
+import {
+  getWorktreeName,
+  normalizeWorktreePath,
+} from "../SessionInfoLine/worktreeSwitcher";
+
+function worktree(path: string, isMain = false): GitWorktreeEntry {
+  return {
+    path,
+    branch: isMain ? "develop" : "feat/worktree-switcher",
+    head_sha: "1234567890abcdef",
+    is_main: isMain,
+  };
+}
+
+describe("worktree switcher helpers", () => {
+  it("normalizes file URLs and trailing slashes for path matching", () => {
+    expect(normalizeWorktreePath("file:///repo/main///")).toBe("/repo/main");
+    expect(normalizeWorktreePath("/repo/main/")).toBe("/repo/main");
+  });
+
+  it("uses the worktree directory name as its compact label", () => {
+    expect(getWorktreeName(worktree("/repo/worktrees/issue-332"))).toBe(
+      "issue-332"
+    );
+  });
+
+  it("keeps the main checkout path distinguishable from linked worktrees", () => {
+    expect(getWorktreeName(worktree("/repo/ORG2", true))).toBe("ORG2");
+    expect(getWorktreeName(worktree("/repo/worktrees/ORG2-fix"))).toBe(
+      "ORG2-fix"
+    );
+  });
+});

--- a/src/features/SessionCreator/variants/ChatPanel/index.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/index.tsx
@@ -9,6 +9,7 @@ import React, {
 } from "react";
 import { useTranslation } from "react-i18next";
 
+import type { GitWorktreeEntry } from "@src/api/http/git";
 import type { ModelType } from "@src/api/tauri/rpc/schemas/validation";
 import type { CliAgentType } from "@src/api/types/keys";
 import Button from "@src/components/Button";
@@ -306,6 +307,7 @@ const SessionCreatorChatPanelSingle: React.FC<
 
   const runningLocation = useAtomValue(runningLocationAtom);
   const setRunningLocation = useSetAtom(runningLocationAtom);
+  const selectedWorktreePath = useAtomValue(selectedWorktreePathAtom);
   const setSelectedWorktreePath = useSetAtom(selectedWorktreePathAtom);
   const worktreeLaunchSource = useAtomValue(worktreeLaunchSourceAtom);
   const setWorktreeLaunchSource = useSetAtom(worktreeLaunchSourceAtom);
@@ -319,6 +321,23 @@ const SessionCreatorChatPanelSingle: React.FC<
       setRunningLocation(location);
     },
     [setRunningLocation, setSelectedWorktreePath, setWorktreeLaunchSource]
+  );
+
+  const handleExistingWorktreeSelect = useCallback(
+    (worktree: GitWorktreeEntry) => {
+      setWorktreeLaunchSource(null);
+      setSelectedWorktreePath(worktree.is_main ? null : worktree.path);
+      setRunningLocation(worktree.is_main ? "local" : "worktree");
+      if (worktree.branch) {
+        handleBranchChange(worktree.branch);
+      }
+    },
+    [
+      handleBranchChange,
+      setRunningLocation,
+      setSelectedWorktreePath,
+      setWorktreeLaunchSource,
+    ]
   );
 
   const handleWorktreeSourceSelect = useCallback(
@@ -377,8 +396,8 @@ const SessionCreatorChatPanelSingle: React.FC<
     setScreenPickerMonitors,
     handleShareScreenClick,
     handleScreenPicked,
-    handleRepoChange,
-    handleRepoSelectForSession,
+    handleRepoChange: handleRepoChangeBase,
+    handleRepoSelectForSession: handleRepoSelectForSessionBase,
     requestModelOpen,
     setRequestModelOpen,
     handleCategorySelect,
@@ -390,6 +409,37 @@ const SessionCreatorChatPanelSingle: React.FC<
     selectRepo,
     forceRefreshRepos,
   });
+
+  const resetWorktreeSelectionForRepoChange = useCallback(
+    (repoId: string) => {
+      if (repoId === effectiveSource?.repoId) return;
+      setSelectedWorktreePath(null);
+      setWorktreeLaunchSource(null);
+      setRunningLocation("local");
+    },
+    [
+      effectiveSource?.repoId,
+      setRunningLocation,
+      setSelectedWorktreePath,
+      setWorktreeLaunchSource,
+    ]
+  );
+
+  const handleRepoChange = useCallback(
+    (...args: Parameters<typeof handleRepoChangeBase>) => {
+      resetWorktreeSelectionForRepoChange(args[0]);
+      handleRepoChangeBase(...args);
+    },
+    [handleRepoChangeBase, resetWorktreeSelectionForRepoChange]
+  );
+
+  const handleRepoSelectForSession = useCallback(
+    (...args: Parameters<typeof handleRepoSelectForSessionBase>) => {
+      resetWorktreeSelectionForRepoChange(args[0]);
+      handleRepoSelectForSessionBase(...args);
+    },
+    [handleRepoSelectForSessionBase, resetWorktreeSelectionForRepoChange]
+  );
 
   const handleAgentPickerSelect = useCallback(
     (selection: AgentSelection) => {
@@ -749,10 +799,16 @@ const SessionCreatorChatPanelSingle: React.FC<
       branchLoading={branchLoading && !effectiveBranchName}
       onBranchChange={handleBranchChange}
       worktreeLocation={isDisplayedSystemPath ? undefined : runningLocation}
+      selectedWorktreePath={selectedWorktreePath}
       worktreeSourceLabel={
-        runningLocation === "worktree" ? worktreeLaunchSource?.label : undefined
+        runningLocation === "worktree"
+          ? selectedWorktreePath
+            ? t("common:sourceControl.scope.worktrees")
+            : worktreeLaunchSource?.label
+          : undefined
       }
       onWorktreeLocationChange={handleWorktreeLocationChange}
+      onExistingWorktreeSelect={handleExistingWorktreeSelect}
       onWorktreeSourceSelect={handleWorktreeSourceSelect}
       fullWidth
       pillVariant={headerLayout === "compact" ? "ghost" : undefined}

--- a/src/hooks/git/useRepoSelection/useBranchCheckout.ts
+++ b/src/hooks/git/useRepoSelection/useBranchCheckout.ts
@@ -15,6 +15,10 @@ import {
   selectedRepoAtom,
   selectedRepoIdAtom,
 } from "@src/store/repo";
+import {
+  activeWorkspaceRootPathAtom,
+  activeWorktreeAtom,
+} from "@src/store/workspace";
 import { showGitActionDialogSafely } from "@src/util/dialogs/gitActionDialog";
 
 import {
@@ -31,6 +35,8 @@ export function useBranchCheckout(): UseBranchCheckoutReturn {
   const selectedRepoId = useAtomValue(selectedRepoIdAtom);
   const [currentBranch, setCurrentBranch] = useAtom(currentBranchAtom);
   const selectedRepo = useAtomValue(selectedRepoAtom);
+  const activeWorktree = useAtomValue(activeWorktreeAtom);
+  const activeWorkspaceRootPath = useAtomValue(activeWorkspaceRootPathAtom);
 
   const [checkoutLoading, setCheckoutLoading] = useState(isCheckingOut);
 
@@ -47,7 +53,10 @@ export function useBranchCheckout(): UseBranchCheckoutReturn {
       }
 
       const repo = selectedRepo;
-      const repoPath = repo?.path || repo?.fs_uri;
+      const repoPath =
+        activeWorktree?.repoId === selectedRepoId
+          ? activeWorkspaceRootPath
+          : repo?.path || repo?.fs_uri;
 
       if (!repoPath) {
         log.warn("[useBranchCheckout] Cannot checkout: no repo path");
@@ -130,7 +139,14 @@ export function useBranchCheckout(): UseBranchCheckoutReturn {
         notifyCheckoutState(false);
       }
     },
-    [selectedRepoId, selectedRepo, currentBranch, setCurrentBranch]
+    [
+      selectedRepoId,
+      selectedRepo,
+      activeWorktree,
+      activeWorkspaceRootPath,
+      currentBranch,
+      setCurrentBranch,
+    ]
   );
 
   return {

--- a/src/hooks/git/useRepoSelection/useBranchLoader.ts
+++ b/src/hooks/git/useRepoSelection/useBranchLoader.ts
@@ -14,6 +14,10 @@ import {
   selectedRepoAtom,
   selectedRepoIdAtom,
 } from "@src/store/repo";
+import {
+  activeWorkspaceRootPathAtom,
+  activeWorktreeAtom,
+} from "@src/store/workspace";
 import { debounce } from "@src/util/core/debounce";
 
 import { isCheckingOut } from "./singleton";
@@ -26,6 +30,11 @@ export function useBranchLoader(): UseBranchLoaderReturn {
   const [branches, setBranches] = useAtom(branchesAtom);
   const [_currentBranch, setCurrentBranch] = useAtom(currentBranchAtom);
   const selectedRepo = useAtomValue(selectedRepoAtom);
+  const activeWorktree = useAtomValue(activeWorktreeAtom);
+  const activeWorkspaceRootPath = useAtomValue(activeWorkspaceRootPathAtom);
+  const branchContextKey = activeWorktree
+    ? `${selectedRepoId}:${activeWorktree.path}`
+    : selectedRepoId;
 
   const [branchLoading, setBranchLoading] = useState(false);
 
@@ -52,7 +61,7 @@ export function useBranchLoader(): UseBranchLoaderReturn {
     if (isCheckingOut) return;
     if (!selectedRepoId) return;
     if (loadingFastBranchRef.current) return;
-    if (lastFastBranchRepoRef.current === selectedRepoId) return;
+    if (lastFastBranchRepoRef.current === branchContextKey) return;
 
     const repo = selectedRepo;
     if (repo?.kind === REPO_KIND.FOLDER) return;
@@ -60,7 +69,9 @@ export function useBranchLoader(): UseBranchLoaderReturn {
     // Pass repo_path as a hint when available; the Rust backend falls back to
     // the DB lookup by repo_id alone, so this works even for freshly-created
     // agent repos that haven't been loaded into reposAtom yet.
-    const repoPath = repo?.path || repo?.fs_uri;
+    const repoPath = activeWorktree
+      ? activeWorkspaceRootPath
+      : repo?.path || repo?.fs_uri;
 
     loadingFastBranchRef.current = true;
 
@@ -72,14 +83,21 @@ export function useBranchLoader(): UseBranchLoaderReturn {
 
       if (branchName) {
         setCurrentBranch(branchName);
-        lastFastBranchRepoRef.current = selectedRepoId;
+        lastFastBranchRepoRef.current = branchContextKey;
       }
     } catch (error) {
       log.error("[useBranchLoader] Failed to fast load current branch:", error);
     } finally {
       loadingFastBranchRef.current = false;
     }
-  }, [selectedRepoId, selectedRepo, setCurrentBranch]);
+  }, [
+    selectedRepoId,
+    selectedRepo,
+    activeWorktree,
+    activeWorkspaceRootPath,
+    branchContextKey,
+    setCurrentBranch,
+  ]);
 
   // ============================================
   // Load Full Branch List (SLOW - for branch dropdown)
@@ -89,11 +107,13 @@ export function useBranchLoader(): UseBranchLoaderReturn {
     if (isCheckingOut) return;
     if (!selectedRepoId) return;
     if (loadingBranchesRef.current) return;
-    if (lastBranchRepoRef.current === selectedRepoId) return;
+    if (lastBranchRepoRef.current === branchContextKey) return;
 
     const repo = selectedRepo;
     if (repo?.kind === REPO_KIND.FOLDER) return;
-    const repoPath = repo?.path || repo?.fs_uri;
+    const repoPath = activeWorktree
+      ? activeWorkspaceRootPath
+      : repo?.path || repo?.fs_uri;
 
     loadingBranchesRef.current = true;
     setBranchLoading(true);
@@ -122,7 +142,7 @@ export function useBranchLoader(): UseBranchLoaderReturn {
         // Only mark as loaded when we received a non-empty branch list,
         // so repos that start with no commits can retry once data is ready.
         if (apiBranches.length > 0) {
-          lastBranchRepoRef.current = selectedRepoId;
+          lastBranchRepoRef.current = branchContextKey;
         }
       }
     } catch (error) {
@@ -131,7 +151,15 @@ export function useBranchLoader(): UseBranchLoaderReturn {
       setBranchLoading(false);
       loadingBranchesRef.current = false;
     }
-  }, [selectedRepoId, selectedRepo, setBranches, setCurrentBranch]);
+  }, [
+    selectedRepoId,
+    selectedRepo,
+    activeWorktree,
+    activeWorkspaceRootPath,
+    branchContextKey,
+    setBranches,
+    setCurrentBranch,
+  ]);
 
   // Keep ref updated with latest loadBranchesImmediate
   loadBranchesImmediateRef.current = loadBranchesImmediate;

--- a/src/modules/WorkStation/CodeEditor/useCodeEditorLocalState.ts
+++ b/src/modules/WorkStation/CodeEditor/useCodeEditorLocalState.ts
@@ -14,6 +14,7 @@ import { useDiagnostics } from "@src/hooks/workStation/diagnostics/useDiagnostic
 import {
   createBranchSpotlightRequest,
   createWorkspaceSpotlightRequest,
+  createWorktreeSpotlightRequest,
 } from "@src/scaffold/GlobalSpotlight/openSpotlight";
 import {
   spotlightInitialQueryAtom,
@@ -147,6 +148,11 @@ export function useCodeEditorLocalState({
 
   const handleBranchClick = useCallback(() => {
     setSpotlightInitialQuery(createBranchSpotlightRequest());
+    setSpotlightOpen(true);
+  }, [setSpotlightInitialQuery, setSpotlightOpen]);
+
+  const handleWorktreeClick = useCallback(() => {
+    setSpotlightInitialQuery(createWorktreeSpotlightRequest());
     setSpotlightOpen(true);
   }, [setSpotlightInitialQuery, setSpotlightOpen]);
 
@@ -286,15 +292,23 @@ export function useCodeEditorLocalState({
       ...prev,
       onRepoClick: handleRepoClick,
       onBranchClick: handleBranchClick,
+      onWorktreeClick: handleWorktreeClick,
     }));
     return () => {
       setStatusBarCallbacks((prev) => ({
         ...prev,
         onRepoClick: undefined,
         onBranchClick: undefined,
+        onWorktreeClick: undefined,
       }));
     };
-  }, [handleRepoClick, handleBranchClick, isActive, setStatusBarCallbacks]);
+  }, [
+    handleRepoClick,
+    handleBranchClick,
+    handleWorktreeClick,
+    isActive,
+    setStatusBarCallbacks,
+  ]);
 
   return {
     // State
@@ -312,6 +326,7 @@ export function useCodeEditorLocalState({
     // Handlers
     handleRepoClick,
     handleBranchClick,
+    handleWorktreeClick,
     handleCursorPositionChange,
     handleToggleEditorPanelPosition,
     handleDiagnosticsChange,

--- a/src/modules/WorkStation/shared/StatusBar/EditorStatusBar.tsx
+++ b/src/modules/WorkStation/shared/StatusBar/EditorStatusBar.tsx
@@ -7,6 +7,7 @@ import {
   FolderTree,
   GitBranch,
   GitCommit,
+  GitFork,
   Loader2,
   Unplug,
   X,
@@ -31,7 +32,10 @@ import { useRepoGitInitialization } from "@src/hooks/git";
 import { useRepoSelection } from "@src/hooks/git/useRepoSelection";
 import { sessionRepoHintAtom } from "@src/store/repo";
 import { activeFolderIdAtom } from "@src/store/workspace";
-import { activeWorkspaceRootPathAtom } from "@src/store/workspace";
+import {
+  activeWorkspaceRootPathAtom,
+  activeWorktreeAtom,
+} from "@src/store/workspace";
 import { diagnosticHealthAtom } from "@src/store/workstation/codeEditor/diagnostics";
 import {
   indexingProgressAtom,
@@ -76,6 +80,7 @@ export const EditorStatusBar: React.FC<EditorStatusBarProps> = memo(
     lspStatus,
     onRepoClick,
     onBranchClick,
+    onWorktreeClick,
     className = "",
   }) => {
     const { t } = useTranslation();
@@ -83,6 +88,7 @@ export const EditorStatusBar: React.FC<EditorStatusBarProps> = memo(
     const hasSelection = cursor?.selectedChars && cursor.selectedChars > 0;
 
     const repoPath = useAtomValue(activeWorkspaceRootPathAtom);
+    const activeWorktree = useAtomValue(activeWorktreeAtom);
 
     const {
       workspaceLabel,
@@ -180,14 +186,17 @@ export const EditorStatusBar: React.FC<EditorStatusBarProps> = memo(
             <StatusBarButton
               onClick={onRepoClick}
               title={workspaceTooltip}
+              className="min-w-0 max-w-48"
               dataTestId="status-bar-repo-name"
             >
               {isMultiRoot ? (
-                <FolderTree size={13} className="text-text-1" />
+                <FolderTree size={13} className="shrink-0 text-text-1" />
               ) : (
-                <Code size={13} className="text-text-1" />
+                <Code size={13} className="shrink-0 text-text-1" />
               )}
-              <span className="font-medium text-text-1">{workspaceLabel}</span>
+              <span className="min-w-0 truncate font-medium text-text-1">
+                {workspaceLabel}
+              </span>
             </StatusBarButton>
           ) : (
             <StatusBarButton
@@ -217,6 +226,8 @@ export const EditorStatusBar: React.FC<EditorStatusBarProps> = memo(
           {showGitControls && branchName && (
             <StatusBarButton
               onClick={onBranchClick}
+              className="min-w-0 max-w-56"
+              dataTestId="status-bar-branch"
               title={
                 checkoutLoading
                   ? t("workstation.branchTooltipSwitching", {
@@ -228,12 +239,36 @@ export const EditorStatusBar: React.FC<EditorStatusBarProps> = memo(
               {checkoutLoading ? (
                 <Loader2
                   size={SPINNER_TOKENS.small}
-                  className="animate-spin text-text-1"
+                  className="shrink-0 animate-spin text-text-1"
                 />
               ) : (
-                <GitBranch size={13} className="text-text-1" />
+                <GitBranch size={13} className="shrink-0 text-text-1" />
               )}
-              <span className="font-medium text-text-1">{branchName}</span>
+              <span className="min-w-0 truncate font-medium text-text-1">
+                {branchName}
+              </span>
+            </StatusBarButton>
+          )}
+
+          {showGitControls && branchName && (
+            <StatusBarButton
+              onClick={onWorktreeClick}
+              title={
+                activeWorktree
+                  ? `${activeWorktree.path} · ${activeWorktree.branch}`
+                  : t("selectors.branch.labels.mainWorktree", "Main worktree")
+              }
+              className="min-w-0 max-w-56"
+              dataTestId="status-bar-worktree"
+            >
+              <GitFork size={13} className="shrink-0 text-text-1" />
+              <span className="min-w-0 truncate font-medium text-text-1">
+                {activeWorktree && !activeWorktree.isMain
+                  ? activeWorktree.path.split("/").pop() ||
+                    activeWorktree.branch ||
+                    activeWorktree.path
+                  : t("selectors.branch.labels.mainWorktree", "Main")}
+              </span>
             </StatusBarButton>
           )}
 
@@ -344,6 +379,8 @@ export const EditorStatusBar: React.FC<EditorStatusBarProps> = memo(
         aheadCount,
         onRepoClick,
         onBranchClick,
+        onWorktreeClick,
+        activeWorktree,
         handleSyncClick,
         handleFetchClick,
         handlePullClick,

--- a/src/modules/WorkStation/shared/StatusBar/StatusBarRenderer.tsx
+++ b/src/modules/WorkStation/shared/StatusBar/StatusBarRenderer.tsx
@@ -93,6 +93,7 @@ export const StatusBarRenderer: React.FC<StatusBarRendererProps> = memo(
         lspStatus={state.lspStatus}
         onRepoClick={callbacks.onRepoClick}
         onBranchClick={callbacks.onBranchClick}
+        onWorktreeClick={callbacks.onWorktreeClick}
         className={className}
       />
     );

--- a/src/modules/WorkStation/shared/StatusBar/types.ts
+++ b/src/modules/WorkStation/shared/StatusBar/types.ts
@@ -27,6 +27,7 @@ export interface EditorStatusBarProps {
   lspStatus?: LspStatus;
   onRepoClick?: () => void;
   onBranchClick?: () => void;
+  onWorktreeClick?: () => void;
   className?: string;
 }
 

--- a/src/scaffold/GlobalSpotlight/hooks/features/useSpotlightEffects.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/useSpotlightEffects.ts
@@ -31,6 +31,7 @@ export interface UseSpotlightEffectsOptions {
   closeModal: () => void;
   onOpenWorkspaceLayer?: (mode: "switch" | "open" | "add" | "create") => void;
   onOpenBranchLayer?: () => void;
+  onOpenWorktreeLayer?: () => void;
   onOpenEditorLayer?: (
     query: string,
     mode?: SpotlightInitialEditorMode
@@ -49,6 +50,7 @@ export function useSpotlightEffects(options: UseSpotlightEffectsOptions): void {
     isOpen,
     dispatch,
     onOpenBranchLayer,
+    onOpenWorktreeLayer,
     onOpenEditorLayer,
     onOpenWorkspaceLayer,
     onOpenAgentSessionSearchLayer,
@@ -102,6 +104,8 @@ export function useSpotlightEffects(options: UseSpotlightEffectsOptions): void {
       onOpenWorkspaceLayer?.(initialQuery.layer.mode);
     } else if (initialQuery.layer?.kind === "branch") {
       onOpenBranchLayer?.();
+    } else if (initialQuery.layer?.kind === "worktree") {
+      onOpenWorktreeLayer?.();
     } else if (initialQuery.layer?.kind === "editor") {
       onOpenEditorLayer?.(initialQuery.query, initialQuery.layer.mode);
     } else if (initialQuery.layer?.kind === "agentSessionSearch") {
@@ -124,6 +128,7 @@ export function useSpotlightEffects(options: UseSpotlightEffectsOptions): void {
     onOpenAgentControlLayer,
     onOpenAgentSessionSearchLayer,
     onOpenBranchLayer,
+    onOpenWorktreeLayer,
     onOpenEditorLayer,
     onOpenWorkspaceLayer,
     onOpenSessionCreatorLayer,

--- a/src/scaffold/GlobalSpotlight/index.tsx
+++ b/src/scaffold/GlobalSpotlight/index.tsx
@@ -4,13 +4,22 @@
  * Command palette with reducer-based state management.
  * Modularized for better maintainability.
  */
+import { useAtomValue, useSetAtom } from "jotai";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation } from "react-router-dom";
 
 import { gitApi, removeGitWorktree } from "@src/api/http/git";
+import type { GitWorktreeEntry } from "@src/api/http/git";
 import { ROUTES } from "@src/config/routes";
+import { slugFragment } from "@src/features/SessionCreator/components/worktreeSmartInput";
 import { useRepoSelection } from "@src/hooks/git/useRepoSelection";
+import { currentBranchAtom } from "@src/store/repo";
+import type { WorktreeLaunchSource } from "@src/store/session/worktreeLaunchSourceAtom";
+import {
+  activeWorktreeAtom,
+  setActiveWorktreeAtom,
+} from "@src/store/workspace";
 import { showGitActionDialogSafely } from "@src/util/dialogs/gitActionDialog";
 
 import { SPOTLIGHT_FOOTER_ACTIVE_CHIP } from "./components";
@@ -27,6 +36,7 @@ import {
   EditorPalette,
   SessionCreatorPalette,
   WorkspacePalette,
+  WorktreePalette,
 } from "./palettes";
 import type { BranchPaletteMode } from "./palettes/BranchPalette";
 import type {
@@ -35,6 +45,7 @@ import type {
   RemoveWorktreeOptions,
   RemoveWorktreeResult,
 } from "./palettes/BranchPalette/types";
+import { refreshWorktreeMap } from "./palettes/BranchPalette/useWorktreeMap";
 import type { EditorPaletteMode } from "./palettes/EditorPalette/types";
 import { useSelectorKernel } from "./palettes/core";
 import { PaletteBody, SpotlightShell } from "./shell";
@@ -52,6 +63,24 @@ function getEditorPaletteMode(query: string): EditorPaletteMode {
   if (query.startsWith(">")) return "command";
   if (query.startsWith("@")) return "symbol";
   return "file";
+}
+
+function getWorktreeCreateName(source: WorktreeLaunchSource): string {
+  if (source.kind === "name") {
+    return slugFragment(source.title ?? source.label.replace(/^Name:\s*/i, ""));
+  }
+  if (source.sourceRef?.startsWith("issue:")) {
+    return `issue-${source.sourceRef.slice("issue:".length)}`;
+  }
+  if (source.sourceRef?.startsWith("pr:")) {
+    return `pr-${source.sourceRef.slice("pr:".length)}`;
+  }
+  const ref = source.baseBranch ?? source.title ?? source.label;
+  return `${slugFragment(ref.replace(/^Branch:\s*/i, ""))}-worktree`;
+}
+
+function getWorktreeBaseRef(source: WorktreeLaunchSource): string | undefined {
+  return source.resolvedBaseRef ?? source.baseBranch;
 }
 
 // ============================================
@@ -78,6 +107,10 @@ const GlobalSpotlightInner: React.FC<
   const [embeddedBranchMode, setEmbeddedBranchMode] =
     useState<BranchPaletteMode>("checkout");
   const [branchPickerOpen, setBranchPickerOpen] = useState(false);
+  const [worktreePickerOpen, setWorktreePickerOpen] = useState(false);
+  const activeWorktree = useAtomValue(activeWorktreeAtom);
+  const setActiveWorktree = useSetAtom(setActiveWorktreeAtom);
+  const setCurrentBranch = useSetAtom(currentBranchAtom);
   const [agentSessionSearchOpen, setAgentSessionSearchOpen] = useState(false);
   const [agentControlOpen, setAgentControlOpen] = useState(false);
   const [sessionCreatorOpen, setSessionCreatorOpen] = useState(false);
@@ -102,6 +135,10 @@ const GlobalSpotlightInner: React.FC<
 
   const handleOpenBranchPicker = useCallback(() => {
     setBranchPickerOpen(true);
+  }, []);
+
+  const handleOpenWorktreePicker = useCallback(() => {
+    setWorktreePickerOpen(true);
   }, []);
 
   const handleOpenAgentSessionSearch = useCallback(() => {
@@ -140,6 +177,11 @@ const GlobalSpotlightInner: React.FC<
     restoreLastActivatedItem();
   }, [restoreLastActivatedItem]);
 
+  const handleCloseWorktreePicker = useCallback(() => {
+    setWorktreePickerOpen(false);
+    restoreLastActivatedItem();
+  }, [restoreLastActivatedItem]);
+
   const handleCloseAgentSessionSearch = useCallback(() => {
     setAgentSessionSearchOpen(false);
     restoreLastActivatedItem();
@@ -167,6 +209,53 @@ const GlobalSpotlightInner: React.FC<
       closeModal();
     },
     [closeModal, selectRepo]
+  );
+
+  const handleWorktreePickerSelect = useCallback(
+    (worktree: GitWorktreeEntry) => {
+      if (!selectedRepoId) return;
+      setActiveWorktree({
+        repoId: selectedRepoId,
+        path: worktree.path,
+        branch: worktree.branch,
+        isMain: worktree.is_main,
+      });
+      setCurrentBranch(worktree.branch);
+      setWorktreePickerOpen(false);
+      closeModal();
+    },
+    [closeModal, selectedRepoId, setActiveWorktree, setCurrentBranch]
+  );
+
+  const handleWorktreePickerCreate = useCallback(
+    async (source: WorktreeLaunchSource) => {
+      if (!selectedRepoId || !currentRepoPath) {
+        showGitActionDialogSafely("No repo selected", "error");
+        return;
+      }
+
+      const name = getWorktreeCreateName(source);
+      const basePath = currentRepoPath.replace(/[/\\]+$/, "");
+      const worktreePath = `${basePath}/.orgii/worktrees/${name}`;
+      try {
+        const created = await gitApi.createGitWorktree({
+          repo_id: selectedRepoId,
+          repo_path: currentRepoPath,
+          worktree_path: worktreePath,
+          branch: name,
+          base_ref: getWorktreeBaseRef(source),
+        });
+        await refreshWorktreeMap(selectedRepoId, currentRepoPath);
+        handleWorktreePickerSelect(created);
+        showGitActionDialogSafely(`Worktree "${name}" created`, "info");
+      } catch (error) {
+        showGitActionDialogSafely(
+          error instanceof Error ? error.message : String(error),
+          "error"
+        );
+      }
+    },
+    [currentRepoPath, handleWorktreePickerSelect, selectedRepoId]
   );
 
   const handleBranchPickerSelect = useCallback(
@@ -328,6 +417,7 @@ const GlobalSpotlightInner: React.FC<
       if (cancelled) return;
       setWorkspacePickerMode(null);
       setBranchPickerOpen(false);
+      setWorktreePickerOpen(false);
       setAgentSessionSearchOpen(false);
       setAgentControlOpen(false);
       setSessionCreatorOpen(false);
@@ -363,6 +453,7 @@ const GlobalSpotlightInner: React.FC<
       isOpen &&
       !workspacePickerMode &&
       !branchPickerOpen &&
+      !worktreePickerOpen &&
       !agentSessionSearchOpen &&
       !agentControlOpen &&
       !sessionCreatorOpen,
@@ -370,6 +461,7 @@ const GlobalSpotlightInner: React.FC<
     closeModal,
     onOpenWorkspaceLayer: handleOpenWorkspacePicker,
     onOpenBranchLayer: handleOpenBranchPicker,
+    onOpenWorktreeLayer: handleOpenWorktreePicker,
     onOpenEditorLayer: handleOpenEditorPalette,
     onOpenAgentSessionSearchLayer: handleOpenAgentSessionSearch,
     onOpenAgentControlLayer: handleOpenAgentControl,
@@ -420,6 +512,7 @@ const GlobalSpotlightInner: React.FC<
     isOpen:
       isOpen &&
       !branchPickerOpen &&
+      !worktreePickerOpen &&
       !agentSessionSearchOpen &&
       !agentControlOpen &&
       !sessionCreatorOpen &&
@@ -444,6 +537,7 @@ const GlobalSpotlightInner: React.FC<
     if (
       workspacePickerMode ||
       branchPickerOpen ||
+      worktreePickerOpen ||
       agentSessionSearchOpen ||
       agentControlOpen ||
       sessionCreatorOpen ||
@@ -473,6 +567,7 @@ const GlobalSpotlightInner: React.FC<
     spotlight.items,
     workspacePickerMode,
     branchPickerOpen,
+    worktreePickerOpen,
     agentSessionSearchOpen,
     agentControlOpen,
     sessionCreatorOpen,
@@ -514,6 +609,7 @@ const GlobalSpotlightInner: React.FC<
   const hasActiveAction =
     !!workspacePickerMode ||
     branchPickerOpen ||
+    worktreePickerOpen ||
     agentSessionSearchOpen ||
     agentControlOpen ||
     sessionCreatorOpen ||
@@ -528,6 +624,7 @@ const GlobalSpotlightInner: React.FC<
         : null;
   const activeActionChip =
     workspacePickerMode === "switch" ||
+    worktreePickerOpen ||
     (branchPickerOpen && embeddedBranchMode === "checkout")
       ? SPOTLIGHT_FOOTER_ACTIVE_CHIP.switchSection
       : undefined;
@@ -555,9 +652,22 @@ const GlobalSpotlightInner: React.FC<
       onRemoveWorktree={handleRemoveWorktree}
       onCheckoutDetached={handleCheckoutDetached}
       repoId={effectiveCurrentRepoId ?? ""}
+      repoPath={activeWorktree?.path ?? currentRepoPath}
       currentBranchName={selectedBranchName}
       asBody
       onModeChange={setEmbeddedBranchMode}
+    />
+  ) : worktreePickerOpen ? (
+    <WorktreePalette
+      isOpen={isOpen}
+      onClose={closeModal}
+      onGoBackToParent={handleCloseWorktreePicker}
+      onSelect={handleWorktreePickerSelect}
+      onCreate={handleWorktreePickerCreate}
+      repoId={effectiveCurrentRepoId ?? ""}
+      repoPath={currentRepoPath}
+      activePath={activeWorktree?.path ?? currentRepoPath}
+      asBody
     />
   ) : agentSessionSearchOpen ? (
     <AgentSessionSearchPalette

--- a/src/scaffold/GlobalSpotlight/openSpotlight.ts
+++ b/src/scaffold/GlobalSpotlight/openSpotlight.ts
@@ -41,6 +41,10 @@ export function createBranchSpotlightRequest(): SpotlightInitialQuery {
   return { query: "", layer: { kind: "branch" } };
 }
 
+export function createWorktreeSpotlightRequest(): SpotlightInitialQuery {
+  return { query: "", layer: { kind: "worktree" } };
+}
+
 export function createAgentSessionSearchSpotlightRequest(): SpotlightInitialQuery {
   return { query: "", layer: { kind: "agentSessionSearch" } };
 }

--- a/src/scaffold/GlobalSpotlight/palettes/BranchPalette/BranchDropdown.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/BranchPalette/BranchDropdown.tsx
@@ -88,6 +88,7 @@ export interface BranchDropdownProps {
   currentBranchName?: string;
   githubConnectionId?: string;
   githubRepoFullName?: string;
+  groupWorktreeBranches?: boolean;
   /** Element the dropdown is anchored to. */
   anchorRef: React.RefObject<HTMLElement | null>;
 }
@@ -101,6 +102,7 @@ export const BranchDropdown: React.FC<BranchDropdownProps> = ({
   currentBranchName,
   githubConnectionId,
   githubRepoFullName,
+  groupWorktreeBranches = true,
   anchorRef,
 }) => {
   const { t } = useTranslation();
@@ -126,7 +128,7 @@ export const BranchDropdown: React.FC<BranchDropdownProps> = ({
   });
 
   const worktreeMap = useWorktreeMap({
-    enabled: isOpen,
+    enabled: isOpen && groupWorktreeBranches,
     repoId,
     repoPath,
     isLocalRepo: !isGitHubRepo,

--- a/src/scaffold/GlobalSpotlight/palettes/BranchPalette/index.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/BranchPalette/index.tsx
@@ -9,15 +9,188 @@
  * (`gitApi.getGitBranches`) and share the centralized branch cache to
  * prevent redundant calls.
  */
+import { GitFork, Plus } from "lucide-react";
 import React from "react";
+
+import WorktreeSourceModal from "@src/features/SessionCreator/components/WorktreeSourceModal";
+import { useFilteredItems } from "@src/hooks/search";
+import type { WorktreeLaunchSource } from "@src/store/session/worktreeLaunchSourceAtom";
 
 import {
   SPOTLIGHT_FOOTER_ACTIVE_CHIP,
   SpotlightPinnedActionSection,
 } from "../../components";
 import { PaletteBody, SpotlightShell } from "../../shell";
-import type { BranchPaletteProps } from "./types";
+import type { SpotlightItem } from "../../types";
+import { useSelectorKernel } from "../core";
+import type { BranchPaletteProps, WorktreePaletteProps } from "./types";
 import { useBranchPalette } from "./useBranchPalette";
+import { useWorktreeEntries } from "./useWorktreeMap";
+
+function normalizeWorktreePath(path: string | undefined): string {
+  return (path ?? "").replace(/^file:\/\//, "").replace(/\/+$/, "");
+}
+
+export const WorktreePalette: React.FC<WorktreePaletteProps> = ({
+  isOpen,
+  onClose,
+  onGoBackToParent,
+  repoId,
+  repoPath,
+  activePath,
+  onSelect,
+  onCreate,
+  asBody = false,
+}) => {
+  const [createModalOpen, setCreateModalOpen] = React.useState(false);
+  const [searchQuery, setSearchQuery] = React.useState("");
+  const worktrees = useWorktreeEntries({
+    enabled: isOpen,
+    repoId,
+    repoPath,
+    isLocalRepo: true,
+  });
+  const items = React.useMemo<SpotlightItem[]>(
+    () =>
+      worktrees.map((worktree) => {
+        const path = normalizeWorktreePath(worktree.path);
+        const label = worktree.is_main
+          ? "Main Worktree"
+          : path.split("/").pop() || path;
+        const isSelected =
+          path === normalizeWorktreePath(activePath || repoPath);
+        return {
+          id: `worktree:${path}`,
+          label,
+          desc: path,
+          icon: GitFork,
+          type: "option" as const,
+          data: {
+            isSelector: true,
+            isCurrentSelection: isSelected,
+            rightLabel: worktree.branch,
+            tagLabel: isSelected ? "Current" : undefined,
+          },
+          action: () => {
+            void Promise.resolve(onSelect(worktree)).then(onClose);
+          },
+        };
+      }),
+    [activePath, onClose, onSelect, repoPath, worktrees]
+  );
+  const createAction = React.useMemo<SpotlightItem>(
+    () => ({
+      id: "worktree:new",
+      label: "New Worktree...",
+      desc: "Create from a branch, PR, issue, or name",
+      icon: Plus,
+      type: "action",
+      data: { showDisclosureChevron: true },
+      action: () => setCreateModalOpen(true),
+    }),
+    []
+  );
+  const selectableItems = React.useMemo<SpotlightItem[]>(
+    () => (onCreate ? [...items, createAction] : items),
+    [createAction, items, onCreate]
+  );
+  const kernel = useSelectorKernel({
+    isOpen,
+    onClose,
+    items: selectableItems,
+    hasModalState: true,
+    onGoBack: onGoBackToParent ?? onClose,
+    isItemSelectable: () => true,
+    externalSearchQuery: searchQuery,
+    externalSetSearchQuery: setSearchQuery,
+  });
+  const { filteredItems } = useFilteredItems({
+    items,
+    searchQuery,
+    getSearchText: (item) =>
+      `${item.label} ${item.desc ?? ""} ${String(item.data?.rightLabel ?? "")}`,
+  });
+
+  const pinnedActionSection = onCreate ? (
+    <SpotlightPinnedActionSection
+      items={[createAction]}
+      startIndex={items.length}
+      selectedIndex={kernel.selectedIndex}
+      onItemSelect={kernel.handleItemClick}
+      onItemHover={kernel.setSelectedIndex}
+      searchQuery={searchQuery}
+    />
+  ) : undefined;
+
+  const handleCreateSourceSelect = React.useCallback(
+    (source: WorktreeLaunchSource) => {
+      setCreateModalOpen(false);
+      void Promise.resolve(onCreate?.(source));
+    },
+    [onCreate]
+  );
+
+  const body = (
+    <PaletteBody
+      kernel={kernel}
+      items={filteredItems}
+      placeholder="worktree"
+      path={[
+        {
+          type: "action",
+          id: "switch-worktree",
+          label: "Switch worktree",
+          icon: GitFork,
+          color: "",
+          data: {
+            template: "Switch to {worktree}",
+            requiredParams: ["worktree"],
+          },
+        },
+      ]}
+      onRemoveSegment={() => (onGoBackToParent ?? onClose)()}
+      isLoading={isOpen && worktrees.length === 0}
+      containerHeight={350}
+      fixedHeight
+      afterListSlot={pinnedActionSection}
+    />
+  );
+
+  const palette = (
+    <>
+      {body}
+      {createModalOpen && (
+        <WorktreeSourceModal
+          open
+          repoId={repoId}
+          repoPath={repoPath}
+          branchName={
+            worktrees.find(
+              (worktree) =>
+                normalizeWorktreePath(worktree.path) ===
+                normalizeWorktreePath(activePath || repoPath)
+            )?.branch
+          }
+          onClose={() => setCreateModalOpen(false)}
+          onSelect={handleCreateSourceSelect}
+        />
+      )}
+    </>
+  );
+
+  if (asBody) return palette;
+
+  return (
+    <SpotlightShell
+      isOpen={isOpen}
+      onClose={onClose}
+      hasActiveAction
+      activeActionChip={SPOTLIGHT_FOOTER_ACTIVE_CHIP.switchSection}
+    >
+      {palette}
+    </SpotlightShell>
+  );
+};
 
 // ============ COMPONENT ============
 
@@ -28,6 +201,7 @@ export const BranchPalette: React.FC<BranchPaletteProps> = ({
   repoId,
   repoPath: repoPathProp,
   currentBranchName,
+  groupWorktreeBranches = true,
   onCreateBranch,
   onDeleteBranch,
   onRemoveWorktree,
@@ -59,6 +233,7 @@ export const BranchPalette: React.FC<BranchPaletteProps> = ({
     repoId,
     repoPathProp,
     currentBranchName,
+    groupWorktreeBranches,
     onSelect,
     onCreateBranch,
     onDeleteBranch,
@@ -145,4 +320,8 @@ export const BranchPalette: React.FC<BranchPaletteProps> = ({
   );
 };
 
-export type { BranchPaletteProps, BranchPaletteMode } from "./types";
+export type {
+  BranchPaletteProps,
+  BranchPaletteMode,
+  WorktreePaletteProps,
+} from "./types";

--- a/src/scaffold/GlobalSpotlight/palettes/BranchPalette/types.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/BranchPalette/types.ts
@@ -3,6 +3,8 @@
  */
 import type React from "react";
 
+import type { WorktreeLaunchSource } from "@src/store/session/worktreeLaunchSourceAtom";
+
 import type { BasePaletteProps } from "../../shared";
 import type { BranchItem, SpotlightItem } from "../../types";
 
@@ -38,6 +40,17 @@ export type RemoveWorktreeHandler = (
   options?: RemoveWorktreeOptions
 ) => RemoveWorktreeResult | void | Promise<RemoveWorktreeResult | void>;
 
+export interface WorktreePaletteProps extends BasePaletteProps {
+  repoId: string;
+  repoPath?: string;
+  activePath?: string;
+  onSelect: (
+    worktree: import("@src/api/http/git").GitWorktreeEntry
+  ) => void | Promise<void>;
+  onCreate?: (source: WorktreeLaunchSource) => void | Promise<void>;
+  asBody?: boolean;
+}
+
 export interface BranchPaletteProps extends BasePaletteProps {
   /**
    * Callback when a branch is selected (checkout).
@@ -55,6 +68,8 @@ export interface BranchPaletteProps extends BasePaletteProps {
   repoName?: string;
   /** Currently selected branch name */
   currentBranchName?: string;
+  /** Group branches checked out by worktrees into a dedicated section. */
+  groupWorktreeBranches?: boolean;
   /** Callback to create a new branch */
   onCreateBranch?: (
     branchName: string,
@@ -93,6 +108,7 @@ export interface UseBranchPaletteOptions {
   repoId: string;
   repoPathProp?: string;
   currentBranchName?: string;
+  groupWorktreeBranches?: boolean;
   onSelect: (
     branchName: string,
     branch: BranchItem

--- a/src/scaffold/GlobalSpotlight/palettes/BranchPalette/useBranchPalette.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/BranchPalette/useBranchPalette.ts
@@ -52,6 +52,7 @@ export function useBranchPalette(options: UseBranchPaletteOptions) {
     repoId,
     repoPathProp,
     currentBranchName,
+    groupWorktreeBranches = true,
     onSelect,
     onCreateBranch,
     onDeleteBranch,
@@ -115,7 +116,7 @@ export function useBranchPalette(options: UseBranchPaletteOptions) {
 
   // ============ FETCH WORKTREES (local repos only) ============
   const worktreeMap = useWorktreeMap({
-    enabled: isOpen,
+    enabled: isOpen && groupWorktreeBranches,
     repoId,
     repoPath: repoPathProp,
     isLocalRepo: !isGitHubRepo,

--- a/src/scaffold/GlobalSpotlight/palettes/BranchPalette/useWorktreeMap.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/BranchPalette/useWorktreeMap.ts
@@ -22,13 +22,16 @@
 import { useEffect, useSyncExternalStore } from "react";
 
 import { gitApi } from "@src/api/http/git";
+import type { GitWorktreeEntry } from "@src/api/http/git";
 
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const MAX_CACHE_ENTRIES = 16;
 const EMPTY_MAP: ReadonlyMap<string, string> = new Map();
+const EMPTY_LIST: readonly GitWorktreeEntry[] = [];
 
 interface CacheEntry {
   map: Map<string, string>;
+  entries: GitWorktreeEntry[];
   fetchedAt: number;
 }
 
@@ -40,22 +43,26 @@ function notifySubscribers(): void {
   for (const cb of subscribers) cb();
 }
 
-function readCache(repoId: string): Map<string, string> | null {
+function readCache(repoId: string): CacheEntry | null {
   const entry = worktreeCache.get(repoId);
   if (!entry) return null;
   if (Date.now() - entry.fetchedAt > CACHE_TTL_MS) {
     worktreeCache.delete(repoId);
     return null;
   }
-  return entry.map;
+  return entry;
 }
 
-function writeCache(repoId: string, map: Map<string, string>): void {
+function writeCache(
+  repoId: string,
+  map: Map<string, string>,
+  entries: GitWorktreeEntry[]
+): void {
   if (worktreeCache.size >= MAX_CACHE_ENTRIES) {
     const oldestKey = worktreeCache.keys().next().value;
     if (oldestKey !== undefined) worktreeCache.delete(oldestKey);
   }
-  worktreeCache.set(repoId, { map, fetchedAt: Date.now() });
+  worktreeCache.set(repoId, { map, entries, fetchedAt: Date.now() });
   notifySubscribers();
 }
 
@@ -92,7 +99,7 @@ async function fetchWorktreeMap(
       if (!entry.branch) continue;
       map.set(entry.branch, entry.path);
     }
-    writeCache(repoId, map);
+    writeCache(repoId, map, entries);
     return map;
   })();
 
@@ -119,6 +126,27 @@ export interface UseWorktreeMapOptions {
   isLocalRepo: boolean;
 }
 
+export function useWorktreeEntries(
+  options: UseWorktreeMapOptions
+): readonly GitWorktreeEntry[] {
+  const { enabled, repoId, repoPath, isLocalRepo } = options;
+  const active = enabled && isLocalRepo && Boolean(repoId);
+
+  const getSnapshot = (): readonly GitWorktreeEntry[] => {
+    if (!active) return EMPTY_LIST;
+    return readCache(repoId)?.entries ?? EMPTY_LIST;
+  };
+
+  const entries = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  useEffect(() => {
+    if (!active || readCache(repoId)) return;
+    void fetchWorktreeMap(repoId, repoPath).catch(() => {});
+  }, [active, repoId, repoPath]);
+
+  return entries;
+}
+
 /**
  * Returns a `branchName -> worktreePath` map for the given repo.
  * Returns an empty map until the first fetch resolves; subsequent
@@ -136,7 +164,7 @@ export function useWorktreeMap(
   // shows up in the cache.
   const getSnapshot = (): ReadonlyMap<string, string> => {
     if (!active) return EMPTY_MAP;
-    return readCache(repoId) ?? EMPTY_MAP;
+    return readCache(repoId)?.map ?? EMPTY_MAP;
   };
 
   const map = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);

--- a/src/scaffold/GlobalSpotlight/palettes/index.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/index.ts
@@ -14,8 +14,8 @@ export type { WorkspacePaletteProps } from "./WorkspacePalette/types";
 export { WorkspaceDropdown } from "./WorkspacePalette/WorkspaceDropdown";
 export type { WorkspaceDropdownProps } from "./WorkspacePalette/WorkspaceDropdown";
 
-export { BranchPalette } from "./BranchPalette";
-export type { BranchPaletteProps } from "./BranchPalette";
+export { BranchPalette, WorktreePalette } from "./BranchPalette";
+export type { BranchPaletteProps, WorktreePaletteProps } from "./BranchPalette";
 
 export { BranchDropdown } from "./BranchPalette/BranchDropdown";
 export type { BranchDropdownProps } from "./BranchPalette/BranchDropdown";

--- a/src/scaffold/GlobalSpotlight/types.ts
+++ b/src/scaffold/GlobalSpotlight/types.ts
@@ -84,6 +84,8 @@ export interface BranchItem {
    * (GitHub remote repos).
    */
   worktreePath?: string;
+  /** Whether this entry represents the repository's main working tree. */
+  worktreeIsMain?: boolean;
 }
 
 // ============ SPOTLIGHT ITEM ============

--- a/src/store/ui/uiAtom.ts
+++ b/src/store/ui/uiAtom.ts
@@ -257,6 +257,7 @@ export type SpotlightInitialLayer =
   | { kind: "default" }
   | { kind: "workspace"; mode: "switch" | "open" | "add" | "create" }
   | { kind: "branch" }
+  | { kind: "worktree" }
   | { kind: "editor"; mode?: SpotlightInitialEditorMode }
   | { kind: "agentSessionSearch" }
   | { kind: "agentControl" }

--- a/src/store/ui/workStationLayout/statusBarAtoms.ts
+++ b/src/store/ui/workStationLayout/statusBarAtoms.ts
@@ -181,6 +181,7 @@ globalStatusBarStateAtom.debugLabel = "globalStatusBarState";
 export interface StatusBarCallbacks {
   onRepoClick?: () => void;
   onBranchClick?: () => void;
+  onWorktreeClick?: () => void;
   /** Opens editor settings tab (Code / Project Manager — registered from AppShell). */
   onOpenSettings?: () => void;
   /** Toggles the primary sidebar panel (left or right depending on layoutMode). */

--- a/src/store/workspace/derived.ts
+++ b/src/store/workspace/derived.ts
@@ -15,7 +15,7 @@
  */
 import { atom } from "jotai";
 
-import { reposAtom } from "@src/store/repo/atoms";
+import { reposAtom, selectedRepoIdAtom } from "@src/store/repo/atoms";
 import { matchRepoByPath } from "@src/store/repo/matchRepoByPath";
 import type { Repo } from "@src/store/repo/types";
 import { fileSelectedPathAtom } from "@src/store/workstation/codeEditor/file";
@@ -89,6 +89,48 @@ export const activeFolderAtom = atom<WorkspaceFolder | null>((get) => {
 });
 activeFolderAtom.debugLabel = "activeFolderAtom";
 
+export interface ActiveWorktreeSelection {
+  repoId: string;
+  path: string;
+  branch: string;
+  isMain: boolean;
+}
+
+/** Window-local worktree context keyed by repository ID. */
+export const activeWorktreeByRepoAtom = atom<
+  Record<string, ActiveWorktreeSelection>
+>({});
+activeWorktreeByRepoAtom.debugLabel = "activeWorktreeByRepoAtom";
+
+export const activeWorktreeAtom = atom<ActiveWorktreeSelection | null>(
+  (get) => {
+    const repoId = get(selectedRepoIdAtom);
+    if (!repoId) return null;
+    return get(activeWorktreeByRepoAtom)[repoId] ?? null;
+  }
+);
+activeWorktreeAtom.debugLabel = "activeWorktreeAtom";
+
+export const setActiveWorktreeAtom = atom(
+  null,
+  (get, set, selection: ActiveWorktreeSelection | null) => {
+    const repoId = selection?.repoId ?? get(selectedRepoIdAtom);
+    if (!repoId) return;
+
+    const previous = get(activeWorktreeByRepoAtom);
+    if (selection) {
+      set(activeWorktreeByRepoAtom, { ...previous, [repoId]: selection });
+      return;
+    }
+
+    if (!(repoId in previous)) return;
+    const next = { ...previous };
+    delete next[repoId];
+    set(activeWorktreeByRepoAtom, next);
+  }
+);
+setActiveWorktreeAtom.debugLabel = "setActiveWorktreeAtom";
+
 export interface WorkspaceRootContext {
   id: string;
   name: string;
@@ -134,7 +176,29 @@ export const activeWorkspaceFolderRepoAtom = atom<Repo | undefined>((get) => {
 activeWorkspaceFolderRepoAtom.debugLabel = "activeWorkspaceFolderRepoAtom";
 
 export const activeWorkspaceRootAtom = atom<WorkspaceRootContext | null>(
-  (get) => rootContextFromFolder(get(activeFolderAtom), get(reposAtom))
+  (get) => {
+    const folderRoot = rootContextFromFolder(
+      get(activeFolderAtom),
+      get(reposAtom)
+    );
+    const worktree = get(activeWorktreeAtom);
+    if (
+      !folderRoot ||
+      !worktree ||
+      worktree.repoId !== get(selectedRepoIdAtom)
+    ) {
+      return folderRoot;
+    }
+    return {
+      ...folderRoot,
+      id: `worktree:${worktree.path}`,
+      name: worktree.path.split("/").pop() || folderRoot.name,
+      path: worktree.path,
+      uri: `file://${worktree.path}`,
+      kind: "git",
+      repoId: worktree.repoId,
+    };
+  }
 );
 activeWorkspaceRootAtom.debugLabel = "activeWorkspaceRootAtom";
 

--- a/src/store/workspace/index.ts
+++ b/src/store/workspace/index.ts
@@ -41,5 +41,9 @@ export {
   workspaceFolderRepoMapAtom,
   workspaceNameAtom,
   workspaceFolderCountAtom,
+  activeWorktreeByRepoAtom,
+  activeWorktreeAtom,
+  setActiveWorktreeAtom,
+  type ActiveWorktreeSelection,
   type WorkspaceRootContext,
 } from "./derived";

--- a/tests/e2e/specs/core/session-repo-follow-ui.spec.mjs
+++ b/tests/e2e/specs/core/session-repo-follow-ui.spec.mjs
@@ -17,7 +17,6 @@
  *    the repo indicator, and no "Switch to" hint appears (the hint only
  *    exists for registered repos, which now auto-follow instead).
  */
-
 import { execFileSync } from "node:child_process";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -35,6 +34,8 @@ const RUN_ID = Date.now();
 const FIXTURE_ROOT = join(homedir(), `.orgii-e2e-repofollow-${RUN_ID}`);
 const REPO_X_PATH = join(FIXTURE_ROOT, "repo-x");
 const REPO_Y_PATH = join(FIXTURE_ROOT, "repo-y");
+const LINKED_WORKTREE_PATH = join(FIXTURE_ROOT, "repo-x-linked-worktree");
+const LINKED_WORKTREE_BRANCH = `e2e-linked-${RUN_ID}`;
 const UNREGISTERED_PATH = join(FIXTURE_ROOT, "unregistered");
 
 const REPO_X_NAME = `E2E Follow Repo X ${RUN_ID}`;
@@ -67,6 +68,24 @@ function createGitFixture(repoPath, readmeTitle) {
       "commit",
       "-m",
       "Initial repo-follow fixture",
+    ],
+    { stdio: "ignore" }
+  );
+}
+
+function createLinkedWorktree() {
+  rmSync(LINKED_WORKTREE_PATH, { force: true, recursive: true });
+  execFileSync(
+    "git",
+    [
+      "-C",
+      REPO_X_PATH,
+      "worktree",
+      "add",
+      "-b",
+      LINKED_WORKTREE_BRANCH,
+      LINKED_WORKTREE_PATH,
+      "main",
     ],
     { stdio: "ignore" }
   );
@@ -164,6 +183,49 @@ async function statusBarRepoLabel() {
   `);
 }
 
+async function clickRendered(selector, label) {
+  const element = await $(selector);
+  await element.waitForDisplayed({
+    timeout: RENDER_TIMEOUT_MS,
+    timeoutMsg: `${label} never rendered`,
+  });
+  await element.click();
+}
+
+async function spotlightSnapshot() {
+  return execJS(`
+    const rows = Array.from(document.querySelectorAll('[data-spotlight-item-id]'));
+    return {
+      input: document.querySelector('[data-spotlight-input="true"]')?.getAttribute('placeholder') ?? null,
+      rows: rows.map((row) => ({
+        id: row.getAttribute('data-spotlight-item-id'),
+        text: (row.textContent || '').trim(),
+        current: row.classList.contains('is-current-selection'),
+      })),
+      bodySample: (document.body.innerText || '').slice(0, 1400),
+    };
+  `);
+}
+
+async function waitForSpotlightItem(itemId, label) {
+  try {
+    await browser.waitUntil(
+      async () =>
+        execJS(
+          `return !!document.querySelector('[data-spotlight-item-id="${itemId}"]');`
+        ),
+      {
+        timeout: RENDER_TIMEOUT_MS,
+        timeoutMsg: `${label} did not render in Spotlight`,
+      }
+    );
+  } catch (error) {
+    throw new Error(
+      `${error.message}: ${JSON.stringify(await spotlightSnapshot())}`
+    );
+  }
+}
+
 async function statusBarSnapshot() {
   return execJS(`
     const repoEl = document.querySelector('[data-testid="status-bar-repo-name"]');
@@ -248,6 +310,7 @@ async function clickSidebarSessionRow(sessionId) {
 describe("My Station follows the active session's repo", () => {
   before(async () => {
     createGitFixture(REPO_X_PATH, "E2E repo-follow repo X");
+    createLinkedWorktree();
     createGitFixture(REPO_Y_PATH, "E2E repo-follow repo Y");
     await waitForApp();
 
@@ -369,7 +432,138 @@ describe("My Station follows the active session's repo", () => {
   });
 
   after(() => {
+    try {
+      execFileSync(
+        "git",
+        [
+          "-C",
+          REPO_X_PATH,
+          "worktree",
+          "remove",
+          "--force",
+          LINKED_WORKTREE_PATH,
+        ],
+        { stdio: "ignore" }
+      );
+    } catch {
+      // The fixture root cleanup below is authoritative.
+    }
     rmSync(FIXTURE_ROOT, { force: true, recursive: true });
+  });
+
+  it("opens the Worktree picker from the rendered status bar and switches the active worktree", async () => {
+    // Return to repo X so its linked worktree is the active selector context.
+    await clickSidebarSessionRow(SESSION_A);
+    await waitForStatusBarRepo(REPO_X_NAME, "before opening Worktree picker");
+
+    // Exercise the production status-bar click -> openWorktreeSpotlight ->
+    // GlobalSpotlight WorktreePalette path. The fixture helper only seeded the
+    // durable repo/worktree precondition; it does not open or select the UI.
+    await clickRendered(
+      '[data-testid="status-bar-worktree"]',
+      "status bar Worktree button"
+    );
+
+    const linkedItemId = `worktree:${LINKED_WORKTREE_PATH}`;
+    const mainItemId = `worktree:${REPO_X_PATH}`;
+    await waitForSpotlightItem(mainItemId, "main worktree row");
+    await waitForSpotlightItem(linkedItemId, "linked worktree row");
+    await waitForSpotlightItem("worktree:new", "New Worktree action");
+
+    const initial = await spotlightSnapshot();
+    const linkedRow = initial.rows.find((row) => row.id === linkedItemId);
+    if (
+      !linkedRow ||
+      !linkedRow.text.includes("repo-x-linked-worktree") ||
+      !linkedRow.text.includes(LINKED_WORKTREE_BRANCH)
+    ) {
+      throw new Error(
+        `linked Worktree row did not show path and branch: ${JSON.stringify(initial)}`
+      );
+    }
+
+    await clickRendered(
+      `[data-spotlight-item-id="${linkedItemId}"]`,
+      "linked Worktree row"
+    );
+    await browser.waitUntil(
+      async () => {
+        const snapshot = await execJS(`
+          const worktree = document.querySelector('[data-testid="status-bar-worktree"]');
+          const branch = document.querySelector('[data-testid="status-bar-branch"]');
+          return {
+            worktree: worktree ? (worktree.textContent || '').trim() : null,
+            branch: branch ? (branch.textContent || '').trim() : null,
+            spotlightOpen: !!document.querySelector('[data-spotlight-input="true"]'),
+          };
+        `);
+        return (
+          snapshot.worktree?.includes("repo-x-linked-worktree") &&
+          snapshot.branch?.includes(LINKED_WORKTREE_BRANCH) &&
+          snapshot.spotlightOpen === false
+        );
+      },
+      {
+        timeout: RENDER_TIMEOUT_MS,
+        timeoutMsg:
+          "rendered status bar did not update after selecting the linked Worktree",
+      }
+    );
+
+    // Reopen through the real rendered button to prove the new current row and
+    // the New Worktree action remain available after a production selection.
+    await clickRendered(
+      '[data-testid="status-bar-worktree"]',
+      "updated status bar Worktree button"
+    );
+    await waitForSpotlightItem(linkedItemId, "selected linked worktree row");
+    const selected = await spotlightSnapshot();
+    const selectedRow = selected.rows.find((row) => row.id === linkedItemId);
+    if (!selectedRow?.current) {
+      throw new Error(
+        `selected Worktree row was not marked current: ${JSON.stringify(selected)}`
+      );
+    }
+
+    await clickRendered(
+      '[data-spotlight-item-id="worktree:new"]',
+      "New Worktree action"
+    );
+    await browser.waitUntil(
+      async () =>
+        execJS(
+          `return !!document.getElementById('worktree-source-smart-input');`
+        ),
+      {
+        timeout: RENDER_TIMEOUT_MS,
+        timeoutMsg:
+          "New Worktree action did not open the rendered worktree source modal",
+      }
+    );
+
+    await browser.keys(["Escape"]);
+    await browser.waitUntil(
+      async () =>
+        execJS(
+          `return !document.getElementById('worktree-source-smart-input');`
+        ),
+      {
+        timeout: RENDER_TIMEOUT_MS,
+        timeoutMsg: "Escape did not close the rendered worktree source modal",
+      }
+    );
+
+    await browser.keys(["Escape"]);
+    await browser.waitUntil(
+      async () =>
+        execJS(
+          `return !document.querySelector('[data-spotlight-input="true"]');`
+        ),
+      {
+        timeout: RENDER_TIMEOUT_MS,
+        timeoutMsg: "Escape did not close the Worktree Spotlight",
+      }
+    );
   });
 
   it("switching to session B (repo Y) makes My Station show repo Y", async () => {


### PR DESCRIPTION
Closes #332

## What changed
- add backend APIs for creating and listing linked Git worktrees
- add worktree selection to Session Creator, Spotlight, and the workstation status bar
- scope branch operations and editor state to the active worktree
- add unit, Rust, and rendered regression coverage
- include the frontend UI audit report

## Validation
- `pnpm typecheck`
- 92 Vitest tests
- ESLint on all changed TypeScript/TSX files
- `cargo test -p git worktree` (33 tests)
- `cargo check -p git_api`

## Test note
The rendered WebDriver spec is included, but the full WebDriver build was not rerun locally after an earlier disk-space failure.