### PR TITLE
feat(updater): add configurable automatic updates

### DIFF
--- a/docs/architecture-audit-2026-07-13/AppUpdater.md
+++ b/docs/architecture-audit-2026-07-13/AppUpdater.md
@@ -1,0 +1,92 @@
+# Architecture Audit — AppUpdater
+
+**Scope:** `src/scaffold/AppUpdater/`, `general.autoUpdateEnabled`, and the General settings entry
+**Date:** 2026-07-13
+**Auditor:** Codex
+
+## Acceptance criteria
+
+- [x] One lifecycle owner for check, download, and install state
+- [x] One scheduler for startup, interval, foreground, and online triggers
+- [x] Automatic updates default on and can be disabled through persisted settings
+- [x] Startup can install and relaunch; active-use checks silently pre-download
+- [x] Manual checks and installs remain available when automation is disabled
+- [x] Check throttling, force bypass, coalescing, cache failure semantics, progress throttling, install deduplication, and scheduler cleanup are tested
+- [x] Targeted ESLint and updater Vitest suite pass
+
+## 10-layer audit
+
+### Layer 1 — Compilation correctness
+
+- Targeted ESLint passes for every changed TypeScript/TSX file.
+- Updater lifecycle tests pass (12/12); the settings-default test also passes.
+- Full `tsc --noEmit` reaches one pre-existing error at `src/engines/ChatPanel/InputArea/components/ContextInfoButton.tsx:468` (`string | undefined` passed where `string` is required); no updater diagnostic is emitted.
+- Settings UI parity remains red on the `develop` baseline because eight existing `housekeeper.*` keys are not covered by the manifest. The new `general.autoUpdateEnabled` key is covered by the General-section prefix.
+
+### Layer 2 — Dead code and structural deduplication
+
+- Traced automatic entry point: `AppDeferredServices` → `AppUpdater` → `AppUpdaterScheduler` → `runAutomaticUpdate` → `AppUpdaterCoordinator`.
+- Traced manual entry points from Settings, Spotlight/ActionSystem, Sidebar, and ChatPanel.
+- Removed parallel module-level throttle/check/install state. Jotai atoms are projections of coordinator state.
+- Production updater calls now have one owner: `check`, `download`, `install`, and `downloadAndInstall` are invoked only by the coordinator.
+
+### Layer 3 — Naming consistency
+
+- `autoUpdateEnabled` consistently means the persisted user preference.
+- `AutomaticUpdateReason` distinguishes startup, interval, foreground, and online scheduling.
+- Documentation now matches the options-object API and current two-hour interval.
+
+### Layer 4 — Semantic overloading
+
+| Term             | Meaning                      | Verdict                                                              |
+| ---------------- | ---------------------------- | -------------------------------------------------------------------- |
+| update           | Tauri `Update` resource      | Keep; concrete external type                                         |
+| automatic update | Configured scheduling policy | Keep; represented by `autoUpdateEnabled` and `AutomaticUpdateReason` |
+| install          | Apply a downloaded package   | Keep; distinct from download and relaunch phases                     |
+
+No conflicting domain meanings remain inside the updater module.
+
+### Layer 5 — Default branch analysis
+
+- `general.autoUpdateEnabled` defaults to `true` in the canonical settings registry and the derived atom also uses `true` as a defensive fallback.
+- Public check defaults remain silent and throttled (`notify: false`, `force: false`).
+- Download-event handling is exhaustive over Tauri's `Started | Progress | Finished` union; there is no unsafe catch-all branch.
+
+### Layer 6 — Cross-domain leakage
+
+- Scheduling and updater resources remain under `scaffold/AppUpdater`.
+- The platform settings atom only adapts the central settings domain; it does not own updater lifecycle state.
+- General Settings only binds the preference to existing design-system controls.
+
+### Layer 7 — New-developer confusion test
+
+- Coordinator, scheduler, and settings preference have separate purpose-based names.
+- Comments explain why active-use automation downloads without installing: Windows installation can terminate the app.
+- The state model and entry points are documented in the component guide.
+
+### Layer 8 — Wire protocol and serialization
+
+- The only persisted wire value is `general.autoUpdateEnabled: boolean`; it is validated by the canonical Zod registry and written through `updateSettingAtom`.
+- The updater release request and signed package protocol remain owned by pinned `@tauri-apps/plugin-updater` 2.9.0; this change adds no custom payload or schema generation.
+- Tauri's `Update` resource is closed when replaced or explicitly cleared to avoid stale native resources.
+
+### Layer 9 — Init parity
+
+| Entry point         | Checks setting |        Fresh check | Throttle/dedupe |  Download | Install | Relaunch |
+| ------------------- | -------------: | -----------------: | --------------: | --------: | ------: | -------: |
+| Startup automatic   |            Yes |                Yes |             Yes |       Yes |     Yes |      Yes |
+| Two-hour interval   |            Yes |                Yes |             Yes |       Yes |      No |       No |
+| Foreground / online |            Yes | If throttle allows |             Yes |       Yes |      No |       No |
+| Manual check        |             No |                Yes |             Yes |        No |      No |       No |
+| Manual install      |             No |     If cache empty |             Yes | If needed |     Yes |      Yes |
+
+Manual paths intentionally ignore the automation preference so users can update on demand after disabling background behavior.
+
+### Layer 10 — Resolver symmetry
+
+No multi-field fallback resolver was introduced. Both schema default and atom fallback resolve the single automatic-update preference to `true`; there is no asymmetric source chain.
+
+## Systematic sweep
+
+- Swept all updater imports and call sites with `checkForAppUpdates`, `installAvailableAppUpdate`, `useAvailableAppUpdate`, `check`, `download`, `install`, and `downloadAndInstall`.
+- No second production scheduler, updater transport caller, or install-state writer remains.

--- a/docs/frontend-ui-audit-2026-07-13/GeneralSection.md
+++ b/docs/frontend-ui-audit-2026-07-13/GeneralSection.md
@@ -1,0 +1,35 @@
+# Frontend UI Audit — GeneralSection
+
+**File:** `src/modules/MainApp/Settings/sections/GeneralSection.tsx` (411 LOC)
+**Date:** 2026-07-13
+**Auditor:** Codex
+
+## D1 — Raw HTML vs Design System
+
+| Line    | Element                       | Verdict          | Reason                                                                                                  | Suggested change |
+| ------- | ----------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------- | ---------------- |
+| 371–376 | Automatic-update settings row | keep with reason | Uses the established `SectionRow` and design-system `Switch`; no raw interactive element was introduced | —                |
+
+## D2 — Arbitrary Tailwind Value vs Token
+
+No hits in the changed UI.
+
+## D3 — Hardcoded Sizes / Colors
+
+No hits in the changed UI.
+
+## D4 — Accessibility
+
+| Line    | Element                 | Verdict          | Reason                                                                                                                                  | Suggested change |
+| ------- | ----------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| 371–376 | Automatic-update switch | keep with reason | `SectionRow` supplies the visible setting label and the existing `Switch` component supplies keyboard interaction and control semantics | —                |
+
+## D5 — Visual Patterns Observed
+
+- The new row follows the existing settings-row pattern; no new independent visual pattern was introduced.
+
+## Summary
+
+- 0 fixes recommended
+- 2 kept with documented reason
+- 0 abstract candidates

--- a/src/config/settingsSchema/__tests__/autoUpdateDefault.test.ts
+++ b/src/config/settingsSchema/__tests__/autoUpdateDefault.test.ts
@@ -1,0 +1,16 @@
+import {
+  getSettingsDefaults,
+  validateSettings,
+} from "@src/config/settingsSchema";
+
+describe("automatic update setting", () => {
+  it("defaults to enabled and preserves an explicit opt-out", () => {
+    expect(getSettingsDefaults()["general.autoUpdateEnabled"]).toBe(true);
+    expect(validateSettings({})["general.autoUpdateEnabled"]).toBe(true);
+    expect(
+      validateSettings({ "general.autoUpdateEnabled": false })[
+        "general.autoUpdateEnabled"
+      ]
+    ).toBe(false);
+  });
+});

--- a/src/config/settingsSchema/index.ts
+++ b/src/config/settingsSchema/index.ts
@@ -90,7 +90,7 @@ export function generateJsoncContent(settings: SettingsObject): string {
     "{",
     "  // NOTE: This file only includes schema-backed settings.",
     "  // Some Settings UI sections are managed by other systems and are not represented here.",
-    "  // Not covered in this JSON: update, network, dependencies, monitor, storage,",
+    "  // Not covered in this JSON: network, dependencies, monitor, storage,",
     "  // and Agent sections: cli-config, agent-tools, agent-skills, agent-connectivity.",
   ];
 

--- a/src/config/settingsSchema/registry/general.ts
+++ b/src/config/settingsSchema/registry/general.ts
@@ -250,6 +250,13 @@ export const GENERAL_SETTINGS_REGISTRY = {
       "Prevent the system from sleeping while any agent session is actively working. Releases automatically when all sessions finish or the toggle is turned off",
     category: "general",
   },
+  "general.autoUpdateEnabled": {
+    schema: z.boolean(),
+    default: true,
+    description:
+      "Automatically check for app updates, install them during startup, and download them silently while the app is running",
+    category: "general",
+  },
   "general.voiceInputEnabled": {
     schema: z.boolean(),
     default: true,

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -792,7 +792,9 @@
     "currentVersion": "Current Version",
     "installConfirmTitle": "Update ready to install",
     "installConfirmDesc": "Version {{version}} has been downloaded. Save any ongoing work before installing and restarting ORGII.",
-    "installAndRestart": "Install and restart"
+    "installAndRestart": "Install and restart",
+    "autoDownloadUpdates": "Automatically download future updates",
+    "skipVersion": "Skip this version"
   },
   "monitor": {
     "categoryTerminal": "Terminal/tool process",

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -786,6 +786,8 @@
   },
   "update": {
     "title": "App Update",
+    "autoUpdate": "Automatic updates",
+    "autoUpdateDesc": "Install updates during startup and download new versions silently while ORGII is running",
     "detectUpdate": "Detect Update",
     "currentVersion": "Current Version"
   },

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -787,9 +787,12 @@
   "update": {
     "title": "App Update",
     "autoUpdate": "Automatic updates",
-    "autoUpdateDesc": "Install updates during startup and download new versions silently while ORGII is running",
+    "autoUpdateDesc": "Download updates automatically and ask before installing and restarting ORGII",
     "detectUpdate": "Detect Update",
-    "currentVersion": "Current Version"
+    "currentVersion": "Current Version",
+    "installConfirmTitle": "Update ready to install",
+    "installConfirmDesc": "Version {{version}} has been downloaded. Save any ongoing work before installing and restarting ORGII.",
+    "installAndRestart": "Install and restart"
   },
   "monitor": {
     "categoryTerminal": "Terminal/tool process",

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -787,9 +787,12 @@
   "update": {
     "title": "App 更新",
     "autoUpdate": "自動更新",
-    "autoUpdateDesc": "啟動時自動安裝更新，並在 ORGII 運行期間靜默下載新版本",
+    "autoUpdateDesc": "自動下載更新，並在安裝和重新啓動 ORGII 前詢問",
     "detectUpdate": "檢測更新",
-    "currentVersion": "目前版本"
+    "currentVersion": "目前版本",
+    "installConfirmTitle": "更新已準備好安裝",
+    "installConfirmDesc": "版本 {{version}} 已下載。安裝並重新啓動 ORGII 前，請儲存正在進行的工作。",
+    "installAndRestart": "安裝並重新啓動"
   },
   "monitor": {
     "categoryTerminal": "終端機/工具程序",

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -792,7 +792,9 @@
     "currentVersion": "目前版本",
     "installConfirmTitle": "更新已準備好安裝",
     "installConfirmDesc": "版本 {{version}} 已下載。安裝並重新啓動 ORGII 前，請儲存正在進行的工作。",
-    "installAndRestart": "安裝並重新啓動"
+    "installAndRestart": "安裝並重新啓動",
+    "autoDownloadUpdates": "以後自動下載更新",
+    "skipVersion": "跳過此版本"
   },
   "monitor": {
     "categoryTerminal": "終端機/工具程序",

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -786,6 +786,8 @@
   },
   "update": {
     "title": "App 更新",
+    "autoUpdate": "自動更新",
+    "autoUpdateDesc": "啟動時自動安裝更新，並在 ORGII 運行期間靜默下載新版本",
     "detectUpdate": "檢測更新",
     "currentVersion": "目前版本"
   },

--- a/src/i18n/locales/zh/settings.json
+++ b/src/i18n/locales/zh/settings.json
@@ -786,6 +786,8 @@
   },
   "update": {
     "title": "App 更新",
+    "autoUpdate": "自动更新",
+    "autoUpdateDesc": "启动时自动安装更新，并在 ORGII 运行期间静默下载新版本",
     "detectUpdate": "检测更新",
     "currentVersion": "当前版本"
   },

--- a/src/i18n/locales/zh/settings.json
+++ b/src/i18n/locales/zh/settings.json
@@ -792,7 +792,9 @@
     "currentVersion": "当前版本",
     "installConfirmTitle": "更新已准备好安装",
     "installConfirmDesc": "版本 {{version}} 已下载。安装并重新启动 ORGII 前，请保存正在进行的工作。",
-    "installAndRestart": "安装并重新启动"
+    "installAndRestart": "安装并重新启动",
+    "autoDownloadUpdates": "以后自动下载更新",
+    "skipVersion": "跳过此版本"
   },
   "monitor": {
     "categoryTerminal": "终端/工具进程",

--- a/src/i18n/locales/zh/settings.json
+++ b/src/i18n/locales/zh/settings.json
@@ -787,9 +787,12 @@
   "update": {
     "title": "App 更新",
     "autoUpdate": "自动更新",
-    "autoUpdateDesc": "启动时自动安装更新，并在 ORGII 运行期间静默下载新版本",
+    "autoUpdateDesc": "自动下载更新，并在安装和重新启动 ORGII 前询问",
     "detectUpdate": "检测更新",
-    "currentVersion": "当前版本"
+    "currentVersion": "当前版本",
+    "installConfirmTitle": "更新已准备好安装",
+    "installConfirmDesc": "版本 {{version}} 已下载。安装并重新启动 ORGII 前，请保存正在进行的工作。",
+    "installAndRestart": "安装并重新启动"
   },
   "monitor": {
     "categoryTerminal": "终端/工具进程",

--- a/src/modules/MainApp/Settings/sections/GeneralSection.tsx
+++ b/src/modules/MainApp/Settings/sections/GeneralSection.tsx
@@ -57,6 +57,7 @@ import { NAV_BUTTON_PROPS } from "@src/modules/MainApp/Settings/config";
 import { checkForUpdatesManually } from "@src/scaffold/AppUpdater";
 import { type TimezoneOption, timezoneAtom } from "@src/store";
 import { chatAppearancePersistAtom } from "@src/store/config/configAtom";
+import { autoUpdateEnabledAtom } from "@src/store/platform/autoUpdateAtom";
 import { devModeEnabledAtom } from "@src/store/platform/devModeAtom";
 import { preventSleepWhileRunningAtom } from "@src/store/platform/preventSleepAtom";
 import { voiceInputEnabledAtom } from "@src/store/platform/voiceInputAtom";
@@ -134,6 +135,9 @@ const GeneralTabBody: React.FC = () => {
   }, []);
 
   const [devModeEnabled, setDevModeEnabled] = useAtom(devModeEnabledAtom);
+  const [autoUpdateEnabled, setAutoUpdateEnabled] = useAtom(
+    autoUpdateEnabledAtom
+  );
   const [preventSleepWhileRunning, setPreventSleepWhileRunning] = useAtom(
     preventSleepWhileRunningAtom
   );
@@ -364,6 +368,12 @@ const GeneralTabBody: React.FC = () => {
       </SectionContainer>
 
       <SectionContainer>
+        <SectionRow
+          label={t("update.autoUpdate")}
+          description={t("update.autoUpdateDesc")}
+        >
+          <Switch checked={autoUpdateEnabled} onChange={setAutoUpdateEnabled} />
+        </SectionRow>
         <SectionRow label={t("update.detectUpdate")}>
           <Button
             size="default"

--- a/src/scaffold/AppUpdater/appUpdaterCoordinator.test.ts
+++ b/src/scaffold/AppUpdater/appUpdaterCoordinator.test.ts
@@ -1,0 +1,120 @@
+import type { Update } from "@tauri-apps/plugin-updater";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AppUpdaterCoordinator } from "./appUpdaterCoordinator";
+
+function createUpdate(version = "1.1.22"): Update {
+  return {
+    available: true,
+    close: vi.fn().mockResolvedValue(undefined),
+    currentVersion: "1.1.21",
+    download: vi.fn().mockResolvedValue(undefined),
+    downloadAndInstall: vi.fn().mockResolvedValue(undefined),
+    install: vi.fn().mockResolvedValue(undefined),
+    version,
+  } as unknown as Update;
+}
+
+describe("AppUpdaterCoordinator", () => {
+  let now: number;
+  let check: ReturnType<typeof vi.fn>;
+  let coordinator: AppUpdaterCoordinator;
+
+  beforeEach(() => {
+    now = 10_000;
+    check = vi.fn();
+    coordinator = new AppUpdaterCoordinator({
+      check,
+      getVersion: vi.fn().mockResolvedValue("1.1.21"),
+      minCheckIntervalMs: 5_000,
+      now: () => now,
+      onStateChange: vi.fn(),
+    });
+  });
+
+  it("reuses a recent result and lets force bypass the throttle", async () => {
+    const update = createUpdate();
+    check.mockResolvedValue(update);
+
+    await expect(coordinator.checkForUpdate()).resolves.toMatchObject({
+      update,
+      fromCache: false,
+    });
+    now += 1_000;
+    await expect(coordinator.checkForUpdate()).resolves.toMatchObject({
+      update,
+      fromCache: true,
+    });
+    await coordinator.checkForUpdate(true);
+
+    expect(check).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces concurrent checks", async () => {
+    let resolveCheck: ((update: Update | null) => void) | undefined;
+    check.mockReturnValue(
+      new Promise<Update | null>((resolve) => {
+        resolveCheck = resolve;
+      })
+    );
+
+    const first = coordinator.checkForUpdate();
+    const second = coordinator.checkForUpdate(true);
+    resolveCheck?.(createUpdate());
+
+    await Promise.all([first, second]);
+    expect(check).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a successful cached update when a silent refresh fails", async () => {
+    const update = createUpdate();
+    check
+      .mockResolvedValueOnce(update)
+      .mockRejectedValueOnce(new Error("offline"));
+    await coordinator.checkForUpdate();
+    now += 10_000;
+
+    await expect(coordinator.checkForUpdate(true)).rejects.toThrow("offline");
+
+    expect(coordinator.getAvailableUpdate()).toBe(update);
+    expect(coordinator.getState()).toMatchObject({
+      phase: "failed",
+      update,
+      error: "offline",
+    });
+  });
+
+  it("downloads once and installs the prepared package without downloading twice", async () => {
+    const update = createUpdate();
+    check.mockResolvedValue(update);
+    await coordinator.checkForUpdate();
+
+    await coordinator.downloadAvailableUpdate();
+    await coordinator.downloadAvailableUpdate();
+    await coordinator.installAvailableUpdate();
+
+    expect(update.download).toHaveBeenCalledOnce();
+    expect(update.install).toHaveBeenCalledOnce();
+    expect(update.downloadAndInstall).not.toHaveBeenCalled();
+  });
+
+  it("lets only the install owner continue to relaunch", async () => {
+    const update = createUpdate();
+    let resolveInstall: (() => void) | undefined;
+    vi.mocked(update.downloadAndInstall).mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveInstall = resolve;
+      })
+    );
+    check.mockResolvedValue(update);
+    await coordinator.checkForUpdate();
+
+    const first = coordinator.installAvailableUpdate();
+    const second = coordinator.installAvailableUpdate();
+    resolveInstall?.();
+
+    await expect(first).resolves.toBe(true);
+    await expect(second).resolves.toBe(false);
+    expect(update.downloadAndInstall).toHaveBeenCalledOnce();
+  });
+});

--- a/src/scaffold/AppUpdater/appUpdaterCoordinator.ts
+++ b/src/scaffold/AppUpdater/appUpdaterCoordinator.ts
@@ -1,0 +1,271 @@
+import type { DownloadEvent, Update } from "@tauri-apps/plugin-updater";
+
+export type AppUpdaterPhase =
+  | "idle"
+  | "checking"
+  | "up-to-date"
+  | "available"
+  | "downloading"
+  | "downloaded"
+  | "installing"
+  | "relaunching"
+  | "failed";
+
+export interface AppUpdaterState {
+  phase: AppUpdaterPhase;
+  update: Update | null;
+  downloaded: boolean;
+  currentVersion?: string;
+  lastCheckStartedAt: number | null;
+  error: string | null;
+}
+
+export interface AppUpdateCheckResult {
+  update: Update | null;
+  currentVersion?: string;
+  fromCache: boolean;
+}
+
+interface AppUpdaterCoordinatorDependencies {
+  check: () => Promise<Update | null>;
+  getVersion: () => Promise<string>;
+  onStateChange: (state: AppUpdaterState) => void;
+  minCheckIntervalMs: number;
+  now?: () => number;
+}
+
+export function createInitialAppUpdaterState(): AppUpdaterState {
+  return {
+    phase: "idle",
+    update: null,
+    downloaded: false,
+    lastCheckStartedAt: null,
+    error: null,
+  };
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return typeof error === "string" ? error : "Unknown error";
+}
+
+/**
+ * Owns updater lifecycle state and serializes check/download/install work.
+ * UI atoms are projections of this coordinator rather than a second source
+ * of truth.
+ */
+export class AppUpdaterCoordinator {
+  private state = createInitialAppUpdaterState();
+  private pendingCheck: Promise<AppUpdateCheckResult> | null = null;
+  private pendingDownload: Promise<Update | null> | null = null;
+  private pendingInstall: Promise<boolean> | null = null;
+
+  constructor(private readonly deps: AppUpdaterCoordinatorDependencies) {}
+
+  getState(): AppUpdaterState {
+    return { ...this.state };
+  }
+
+  getAvailableUpdate(): Update | null {
+    return this.state.update;
+  }
+
+  clearAvailableUpdate(): void {
+    const update = this.state.update;
+    if (update) void update.close().catch(() => undefined);
+    this.setState({
+      phase: this.state.phase === "failed" ? "failed" : "idle",
+      update: null,
+      downloaded: false,
+    });
+  }
+
+  reset(): void {
+    const update = this.state.update;
+    if (update) void update.close().catch(() => undefined);
+    this.pendingCheck = null;
+    this.pendingDownload = null;
+    this.pendingInstall = null;
+    this.state = createInitialAppUpdaterState();
+    this.deps.onStateChange(this.getState());
+  }
+
+  checkForUpdate(force = false): Promise<AppUpdateCheckResult> {
+    if (this.pendingCheck) return this.pendingCheck;
+
+    if (this.pendingDownload || this.pendingInstall) {
+      return Promise.resolve(this.cachedCheckResult());
+    }
+
+    const now = this.deps.now?.() ?? Date.now();
+    if (
+      !force &&
+      this.state.lastCheckStartedAt !== null &&
+      now - this.state.lastCheckStartedAt < this.deps.minCheckIntervalMs
+    ) {
+      return Promise.resolve(this.cachedCheckResult());
+    }
+
+    this.setState({
+      phase: "checking",
+      lastCheckStartedAt: now,
+      error: null,
+    });
+
+    const operation = this.runCheck();
+    this.pendingCheck = operation;
+    void operation.then(
+      () => {
+        if (this.pendingCheck === operation) this.pendingCheck = null;
+      },
+      () => {
+        if (this.pendingCheck === operation) this.pendingCheck = null;
+      }
+    );
+    return operation;
+  }
+
+  downloadAvailableUpdate(
+    onEvent?: (event: DownloadEvent) => void
+  ): Promise<Update | null> {
+    if (this.pendingDownload) return this.pendingDownload;
+    if (this.state.downloaded) return Promise.resolve(this.state.update);
+
+    const update = this.state.update;
+    if (!update) return Promise.resolve(null);
+
+    this.setState({ phase: "downloading", error: null });
+    const operation = update
+      .download(onEvent)
+      .then(() => {
+        this.setState({ phase: "downloaded", downloaded: true });
+        return update;
+      })
+      .catch((error: unknown) => {
+        this.setState({ phase: "available", error: errorMessage(error) });
+        throw error;
+      });
+
+    this.pendingDownload = operation;
+    void operation.then(
+      () => {
+        if (this.pendingDownload === operation) this.pendingDownload = null;
+      },
+      () => {
+        if (this.pendingDownload === operation) this.pendingDownload = null;
+      }
+    );
+    return operation;
+  }
+
+  installAvailableUpdate(
+    onEvent?: (event: DownloadEvent) => void
+  ): Promise<boolean> {
+    if (this.pendingInstall) {
+      return this.pendingInstall.then(() => false);
+    }
+
+    const operation = this.runInstall(onEvent);
+    this.pendingInstall = operation;
+    void operation.then(
+      () => {
+        if (this.pendingInstall === operation) this.pendingInstall = null;
+      },
+      () => {
+        if (this.pendingInstall === operation) this.pendingInstall = null;
+      }
+    );
+    return operation;
+  }
+
+  private async runCheck(): Promise<AppUpdateCheckResult> {
+    try {
+      const [currentVersion, checkedUpdate] = await Promise.all([
+        this.deps.getVersion().catch(() => undefined),
+        this.deps.check(),
+      ]);
+      const update = await this.replaceCheckedUpdate(checkedUpdate);
+      const downloaded = Boolean(
+        update &&
+        this.state.update === update &&
+        this.state.downloaded &&
+        update.version === checkedUpdate?.version
+      );
+
+      this.setState({
+        phase: update
+          ? downloaded
+            ? "downloaded"
+            : "available"
+          : "up-to-date",
+        update,
+        downloaded,
+        currentVersion,
+        error: null,
+      });
+
+      return { update, currentVersion, fromCache: false };
+    } catch (error) {
+      this.setState({ phase: "failed", error: errorMessage(error) });
+      throw error;
+    }
+  }
+
+  private async replaceCheckedUpdate(
+    checkedUpdate: Update | null
+  ): Promise<Update | null> {
+    const current = this.state.update;
+    if (current === checkedUpdate) return current;
+
+    if (
+      current &&
+      checkedUpdate &&
+      this.state.downloaded &&
+      current.version === checkedUpdate.version
+    ) {
+      await checkedUpdate.close().catch(() => undefined);
+      return current;
+    }
+
+    if (current) await current.close().catch(() => undefined);
+    return checkedUpdate;
+  }
+
+  private async runInstall(
+    onEvent?: (event: DownloadEvent) => void
+  ): Promise<boolean> {
+    if (this.pendingDownload) await this.pendingDownload;
+    const update = this.state.update;
+    if (!update) return false;
+
+    this.setState({ phase: "installing", error: null });
+    try {
+      if (this.state.downloaded) {
+        await update.install();
+      } else {
+        await update.downloadAndInstall(onEvent);
+      }
+      this.setState({ phase: "relaunching" });
+      return true;
+    } catch (error) {
+      this.setState({
+        phase: this.state.downloaded ? "downloaded" : "available",
+        error: errorMessage(error),
+      });
+      throw error;
+    }
+  }
+
+  private cachedCheckResult(): AppUpdateCheckResult {
+    return {
+      update: this.state.update,
+      currentVersion: this.state.currentVersion,
+      fromCache: true,
+    };
+  }
+
+  private setState(update: Partial<AppUpdaterState>): void {
+    this.state = { ...this.state, ...update };
+    this.deps.onStateChange(this.getState());
+  }
+}

--- a/src/scaffold/AppUpdater/appUpdaterScheduler.test.ts
+++ b/src/scaffold/AppUpdater/appUpdaterScheduler.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AppUpdaterScheduler } from "./appUpdaterScheduler";
+
+describe("AppUpdaterScheduler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const windowTarget = new EventTarget();
+    const documentTarget = new EventTarget();
+    vi.stubGlobal(
+      "window",
+      Object.assign(windowTarget, {
+        clearInterval: globalThis.clearInterval,
+        clearTimeout: globalThis.clearTimeout,
+        setInterval: globalThis.setInterval,
+        setTimeout: globalThis.setTimeout,
+      })
+    );
+    vi.stubGlobal(
+      "document",
+      Object.assign(documentTarget, { visibilityState: "visible" })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("debounces focus and visibility events into one foreground check", () => {
+    const onCheck = vi.fn();
+    const scheduler = new AppUpdaterScheduler({
+      startupDelayMs: 10_000,
+      intervalMs: 20_000,
+      foregroundDebounceMs: 500,
+    });
+    scheduler.start(onCheck);
+
+    window.dispatchEvent(new Event("focus"));
+    document.dispatchEvent(new Event("visibilitychange"));
+    vi.advanceTimersByTime(499);
+    expect(onCheck).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+
+    expect(onCheck).toHaveBeenCalledOnce();
+    expect(onCheck).toHaveBeenCalledWith("foreground");
+    scheduler.stop();
+  });
+
+  it("stops startup, interval, and event checks", () => {
+    const onCheck = vi.fn();
+    const scheduler = new AppUpdaterScheduler({
+      startupDelayMs: 1_000,
+      intervalMs: 2_000,
+      foregroundDebounceMs: 100,
+    });
+    scheduler.start(onCheck);
+    scheduler.stop();
+
+    window.dispatchEvent(new Event("focus"));
+    window.dispatchEvent(new Event("online"));
+    vi.advanceTimersByTime(10_000);
+
+    expect(onCheck).not.toHaveBeenCalled();
+  });
+
+  it("can start active-use scheduling without a startup install", () => {
+    const onCheck = vi.fn();
+    const scheduler = new AppUpdaterScheduler({
+      startupDelayMs: null,
+      intervalMs: 2_000,
+      foregroundDebounceMs: 100,
+    });
+    scheduler.start(onCheck);
+
+    vi.advanceTimersByTime(1_999);
+    expect(onCheck).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+
+    expect(onCheck).toHaveBeenCalledOnce();
+    expect(onCheck).toHaveBeenCalledWith("interval");
+    scheduler.stop();
+  });
+});

--- a/src/scaffold/AppUpdater/appUpdaterScheduler.ts
+++ b/src/scaffold/AppUpdater/appUpdaterScheduler.ts
@@ -1,0 +1,80 @@
+export type AutomaticUpdateReason =
+  | "startup"
+  | "interval"
+  | "foreground"
+  | "online";
+
+interface AppUpdaterSchedulerOptions {
+  startupDelayMs: number | null;
+  intervalMs: number;
+  foregroundDebounceMs: number;
+}
+
+/** Browser-event scheduler with a single debounced foreground path. */
+export class AppUpdaterScheduler {
+  private startupTimer: number | null = null;
+  private intervalTimer: number | null = null;
+  private foregroundTimer: number | null = null;
+  private onCheck: ((reason: AutomaticUpdateReason) => void) | null = null;
+
+  constructor(private readonly options: AppUpdaterSchedulerOptions) {}
+
+  start(onCheck: (reason: AutomaticUpdateReason) => void): void {
+    this.stop();
+    this.onCheck = onCheck;
+    if (this.options.startupDelayMs !== null) {
+      this.startupTimer = window.setTimeout(
+        () => onCheck("startup"),
+        this.options.startupDelayMs
+      );
+    }
+    this.intervalTimer = window.setInterval(
+      () => onCheck("interval"),
+      this.options.intervalMs
+    );
+    window.addEventListener("focus", this.handleFocus);
+    window.addEventListener("online", this.handleOnline);
+    document.addEventListener("visibilitychange", this.handleVisibilityChange);
+  }
+
+  stop(): void {
+    if (this.startupTimer !== null) window.clearTimeout(this.startupTimer);
+    if (this.intervalTimer !== null) window.clearInterval(this.intervalTimer);
+    if (this.foregroundTimer !== null) {
+      window.clearTimeout(this.foregroundTimer);
+    }
+    this.startupTimer = null;
+    this.intervalTimer = null;
+    this.foregroundTimer = null;
+    window.removeEventListener("focus", this.handleFocus);
+    window.removeEventListener("online", this.handleOnline);
+    document.removeEventListener(
+      "visibilitychange",
+      this.handleVisibilityChange
+    );
+    this.onCheck = null;
+  }
+
+  private scheduleForegroundCheck(reason: "foreground" | "online"): void {
+    if (!this.onCheck || document.visibilityState !== "visible") return;
+    if (this.foregroundTimer !== null) {
+      window.clearTimeout(this.foregroundTimer);
+    }
+    this.foregroundTimer = window.setTimeout(() => {
+      this.foregroundTimer = null;
+      this.onCheck?.(reason);
+    }, this.options.foregroundDebounceMs);
+  }
+
+  private handleFocus = (): void => {
+    this.scheduleForegroundCheck("foreground");
+  };
+
+  private handleOnline = (): void => {
+    this.scheduleForegroundCheck("online");
+  };
+
+  private handleVisibilityChange = (): void => {
+    this.scheduleForegroundCheck("foreground");
+  };
+}

--- a/src/scaffold/AppUpdater/component-app-updater-1226.md
+++ b/src/scaffold/AppUpdater/component-app-updater-1226.md
@@ -16,22 +16,22 @@ Settings → General.
 ## Automatic behavior
 
 - **Startup:** after a 10-second delay, check for a fresh release. If one is
-  available, download, install, and relaunch ORGII.
+  available, download it and ask before installing or relaunching ORGII.
 - **While running:** check every two hours, when the app returns to the
   foreground, and when network connectivity returns.
 - **Foreground event deduplication:** focus and visibility events share one
   750 ms debounce path; checks also have a five-minute throttle.
-- **Silent preparation:** while the user is active, download an available
-  package in the background without showing progress toasts or forcing a
-  restart. The existing update button installs the prepared package, or the
-  next startup flow completes installation.
+- **Silent preparation:** download an available package in the background
+  without showing progress toasts or forcing a restart, then show one
+  confirmation dialog. Installation only starts after the user confirms.
 - **Disabled:** no startup, interval, foreground, or online checks are
   registered. Manual checks and installs remain available.
-- **Enabled during an active session:** starts with a silent foreground check;
-  it does not run the disruptive startup install/relaunch path.
+- **Enabled during an active session:** starts with a silent foreground check
+  and uses the same confirmation-gated install path as every other trigger.
 
-Installing while the user is active is intentionally not automatic because
-the Tauri updater installer can terminate the running process on Windows.
+Installing is never automatic because the Tauri updater installer can
+terminate the running process on Windows. Users can postpone installation and
+save ongoing work before confirming the restart.
 
 ## Public API
 
@@ -48,8 +48,9 @@ useIsAppUpdateInstalling(): boolean
   concurrent check.
 - Manual check failures clear a stale available-update result. Silent failures
   preserve the last successful result while marking the coordinator failed.
-- Concurrent install requests share one install; only the owning request may
-  continue to relaunch.
+- Download requests prepare the package and open the install confirmation.
+- Concurrent confirmed install requests share one install; only the owning
+  request may continue to relaunch.
 
 ## State model
 

--- a/src/scaffold/AppUpdater/component-app-updater-1226.md
+++ b/src/scaffold/AppUpdater/component-app-updater-1226.md
@@ -24,6 +24,9 @@ Settings → General.
 - **Silent preparation:** download an available package in the background
   without showing progress toasts or forcing a restart, then show one
   confirmation dialog. Installation only starts after the user confirms.
+- **Dialog actions:** users can skip the detected version, postpone the
+  decision while keeping the package ready, or install and restart. Skipped
+  versions remain suppressed across app launches.
 - **Disabled:** no startup, interval, foreground, or online checks are
   registered. Manual checks and installs remain available.
 - **Enabled during an active session:** starts with a silent foreground check

--- a/src/scaffold/AppUpdater/component-app-updater-1226.md
+++ b/src/scaffold/AppUpdater/component-app-updater-1226.md
@@ -1,177 +1,76 @@
-# AppUpdater Component
+# AppUpdater
 
-**Status**: ✅ Complete  
-**Location**: `src/scaffold/AppUpdater/`  
-**Last Updated**: December 26, 2025
-
----
+**Location:** `src/scaffold/AppUpdater/`
+**Last updated:** July 13, 2026
 
 ## Overview
 
-The AppUpdater component provides automatic update checking for Tauri applications. It checks for updates on app startup and periodically, with support for automatic installation and user-initiated updates. Uses Tauri updater plugin for version checking and update installation. Component renders nothing (returns null) - it only handles background update checking.
+`AppUpdater` is the headless Tauri update service mounted by
+`AppDeferredServices`. It uses one coordinator for check, download, and install
+state, and one scheduler for automatic triggers.
 
-### Key Features
+Automatic updates are controlled by `general.autoUpdateEnabled` in
+`~/.orgii/settings.jsonc`. The setting defaults to `true` and can be disabled in
+Settings → General.
 
-- ✅ **Automatic Checking**: Check for updates on app startup
-- ✅ **Periodic Checking**: Check every hour (60 _ 60 _ 1000ms interval)
-- ✅ **Auto Install**: Automatically download and install updates on startup/periodic checks
-- ✅ **User Initiated**: User-initiated update checks via exported function
-- ✅ **Version Display**: Display current and new versions in dialogs
-- ✅ **Update Notifications**: Notify users of available updates via Tauri dialogs
-- ✅ **Tauri Integration**: Tauri updater plugin integration
-- ✅ **No UI Rendering**: Component returns null, only handles background logic
-- ✅ **Browser Detection**: Shows message in browser environment (Tauri-only feature)
+## Automatic behavior
 
----
+- **Startup:** after a 10-second delay, check for a fresh release. If one is
+  available, download, install, and relaunch ORGII.
+- **While running:** check every two hours, when the app returns to the
+  foreground, and when network connectivity returns.
+- **Foreground event deduplication:** focus and visibility events share one
+  750 ms debounce path; checks also have a five-minute throttle.
+- **Silent preparation:** while the user is active, download an available
+  package in the background without showing progress toasts or forcing a
+  restart. The existing update button installs the prepared package, or the
+  next startup flow completes installation.
+- **Disabled:** no startup, interval, foreground, or online checks are
+  registered. Manual checks and installs remain available.
+- **Enabled during an active session:** starts with a silent foreground check;
+  it does not run the disruptive startup install/relaunch path.
 
-## Functions
+Installing while the user is active is intentionally not automatic because
+the Tauri updater installer can terminate the running process on Windows.
 
-The AppUpdater component serves as:
+## Public API
 
-1. **Update Management**: Manage application updates
-2. **Version Checking**: Check for new versions
-3. **Update Installation**: Install updates automatically
-4. **User Notifications**: Notify users of updates
-
----
-
-## Where It's Used
-
-### Primary Usage
-
-- Used in main App component
-- Automatically checks for updates
-
-```tsx
-// Used in App.tsx
-import { AppUpdater } from "@src/scaffold/AppUpdater";
-
-function App() {
-  return (
-    <>
-      <AppUpdater />
-      {/* App content */}
-    </>
-  );
-}
+```ts
+checkForAppUpdates({ notify?: boolean, force?: boolean }): Promise<Update | null>
+checkForUpdatesManually(): Promise<Update | null>
+installAvailableAppUpdate(): Promise<void>
+useAvailableAppUpdate(): Update | null
+useIsAppUpdateInstalling(): boolean
 ```
 
----
+- `notify` shows toast feedback for the caller.
+- `force` bypasses the five-minute result throttle, but never starts a second
+  concurrent check.
+- Manual check failures clear a stale available-update result. Silent failures
+  preserve the last successful result while marking the coordinator failed.
+- Concurrent install requests share one install; only the owning request may
+  continue to relaunch.
 
-## How to Use
+## State model
 
-### Basic Usage
-
-```tsx
-import { AppUpdater, checkForAppUpdates } from "@src/scaffold/AppUpdater";
-
-function App() {
-  return (
-    <>
-      <AppUpdater />
-      {/* App content */}
-    </>
-  );
-}
-
-// Manual check
-async function handleCheckUpdate() {
-  await checkForAppUpdates(true, false);
-}
+```text
+idle → checking → up-to-date | available | failed
+available → downloading → downloaded
+available | downloaded → installing → relaunching
 ```
 
-### Manual Update Check
+`appUpdaterCoordinator.ts` owns this lifecycle. Jotai atoms in `index.tsx` are
+read-only UI projections and are not independent sources of truth.
 
-```tsx
-import { checkForAppUpdates } from "@src/scaffold/AppUpdater";
+## Entry points
 
-async function handleManualCheck() {
-  // onUserClick=true, autoInstall=false
-  await checkForAppUpdates(true, false);
-}
-```
+- Automatic scheduling: `AppDeferredServices` → `AppUpdater`
+- Manual check: Settings, Global Spotlight, ActionSystem
+- Manual install: sidebar update button and ChatPanel update action
 
----
+## Dependencies
 
-## API Reference
-
-### AppUpdater Component
-
-The component accepts no props and automatically checks for updates.
-
-### checkForAppUpdates Function
-
-```typescript
-async function checkForAppUpdates(
-  onUserClick?: boolean,
-  autoInstall?: boolean
-): Promise<void>;
-```
-
-**Parameters:**
-
-- `onUserClick` - Whether this is a user-initiated check (default: false)
-- `autoInstall` - Whether to automatically install updates (default: false)
-
----
-
-## Implementation Details
-
-### Automatic Checking
-
-- Checks on app startup (useEffect on mount)
-- Checks every hour (60 _ 60 _ 1000ms interval)
-- Auto-installs updates by default (autoInstall=true)
-- Only runs in Tauri desktop environment
-
-### Update Flow
-
-1. Get current version using `getVersion()` from Tauri app API
-2. Check for updates using `check()` from Tauri updater plugin
-3. If update available:
-   - **Auto-install mode**: Download and install automatically, show info dialog, relaunch app
-   - **Manual mode**: Ask user for confirmation via Tauri dialog, download/install if confirmed, relaunch app
-4. If no update: Show info message (only if user-initiated)
-
-### Version Display
-
-- Shows current version from `getVersion()`
-- Shows new version from update object
-- Displays update body/notes in dialog
-- Uses Tauri dialog API (`ask`, `message`) for user interaction
-
-### Error Handling
-
-- Catches and logs update errors
-- Shows error messages to user via Tauri dialog (only if user-initiated)
-- Handles update check failures gracefully
-- Browser environment shows Toast message instead
-
-### Tauri Dependencies
-
-- `@tauri-apps/api/app` - getVersion()
-- `@tauri-apps/plugin-dialog` - ask(), message() for user dialogs
-- `@tauri-apps/plugin-process` - relaunch() for app restart
-- `@tauri-apps/plugin-updater` - check() for update checking
-
-### Dependencies
-
-- `@src/components/Toast` - Message component for browser notifications
-- `@src/util/tauri` - isTauriDesktop() utility
-
-### Exported Functions
-
-- `checkForAppUpdates(onUserClick?, autoInstall?)` - Main update check function
-- `checkForUpdatesManually()` - Convenience function for manual checks
-
----
-
-## Related Files
-
-- `src/scaffold/AppUpdater/index.tsx` - Main component
-- `src/App.tsx` - App component using AppUpdater
-
----
-
-**Last Updated**: December 26, 2025  
-**Status**: ✅ Production Ready (Tauri only)
+- `@tauri-apps/api/app` for the current version
+- `@tauri-apps/plugin-updater` for check/download/install
+- `@tauri-apps/plugin-process` for relaunch
+- central settings registry and `settings.jsonc` persistence

--- a/src/scaffold/AppUpdater/index.test.ts
+++ b/src/scaffold/AppUpdater/index.test.ts
@@ -1,6 +1,11 @@
+import type { DownloadEvent, Update } from "@tauri-apps/plugin-updater";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { checkForUpdatesManually, installAvailableAppUpdate } from "./index";
+import {
+  checkForUpdatesManually,
+  installAvailableAppUpdate,
+  resetAppUpdaterForTests,
+} from "./index";
 
 const mocks = vi.hoisted(() => ({
   check: vi.fn(),
@@ -9,7 +14,6 @@ const mocks = vi.hoisted(() => ({
   messageInfo: vi.fn(),
   messageSuccess: vi.fn(),
   relaunch: vi.fn(),
-  storeGet: vi.fn(),
   storeSet: vi.fn(),
 }));
 
@@ -43,25 +47,32 @@ vi.mock("@src/hooks/logger", () => ({
 
 vi.mock("@src/util/core/state/instrumentedStore", () => ({
   getInstrumentedStore: () => ({
-    get: mocks.storeGet,
     set: mocks.storeSet,
   }),
 }));
 
+function createUpdate(overrides: Partial<Update> = {}): Update {
+  return {
+    available: true,
+    close: vi.fn().mockResolvedValue(undefined),
+    currentVersion: "1.1.21",
+    download: vi.fn().mockResolvedValue(undefined),
+    downloadAndInstall: vi.fn().mockResolvedValue(undefined),
+    install: vi.fn().mockResolvedValue(undefined),
+    version: "1.1.22",
+    ...overrides,
+  } as unknown as Update;
+}
+
 describe("AppUpdater", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.storeGet.mockReturnValue(null);
+    mocks.getVersion.mockResolvedValue("1.1.21");
+    resetAppUpdaterForTests();
   });
 
   it("checks for updates without requiring a browser-exposed Tauri global", async () => {
-    const update = {
-      available: true,
-      currentVersion: "1.1.19",
-      downloadAndInstall: vi.fn(),
-      version: "1.1.20",
-    };
-    mocks.getVersion.mockResolvedValue("1.1.19");
+    const update = createUpdate();
     mocks.check.mockResolvedValue(update);
 
     await expect(checkForUpdatesManually()).resolves.toBe(update);
@@ -69,26 +80,60 @@ describe("AppUpdater", () => {
     expect(mocks.check).toHaveBeenCalledOnce();
     expect(mocks.messageInfo).toHaveBeenCalledWith(
       expect.objectContaining({
-        content: "Version 1.1.20 is ready to download.",
+        content: "Version 1.1.22 is ready to install.",
         title: "Update available",
       })
     );
   });
 
+  it("clears a stale available update after a failed manual check", async () => {
+    const update = createUpdate();
+    mocks.check
+      .mockResolvedValueOnce(update)
+      .mockRejectedValueOnce(new Error("offline"));
+    await checkForUpdatesManually();
+
+    await expect(checkForUpdatesManually()).resolves.toBeNull();
+
+    expect(update.close).toHaveBeenCalledOnce();
+    expect(mocks.messageError).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Update check failed" })
+    );
+  });
+
   it("checks, installs, and relaunches when no update is cached", async () => {
-    const downloadAndInstall = vi.fn().mockResolvedValue(undefined);
-    mocks.getVersion.mockResolvedValue("1.1.19");
-    mocks.check.mockResolvedValue({
-      available: true,
-      currentVersion: "1.1.19",
-      downloadAndInstall,
-      version: "1.1.20",
-    });
+    const update = createUpdate();
+    mocks.check.mockResolvedValue(update);
 
     await installAvailableAppUpdate();
 
     expect(mocks.check).toHaveBeenCalledOnce();
-    expect(downloadAndInstall).toHaveBeenCalledOnce();
+    expect(update.downloadAndInstall).toHaveBeenCalledOnce();
     expect(mocks.relaunch).toHaveBeenCalledOnce();
+  });
+
+  it("throttles download progress messages", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+    const update = createUpdate({
+      downloadAndInstall: vi.fn(async (onEvent) => {
+        const report = onEvent as (event: DownloadEvent) => void;
+        report({ event: "Started", data: { contentLength: 100 } });
+        report({ event: "Progress", data: { chunkLength: 10 } });
+        vi.setSystemTime(12_000);
+        report({ event: "Progress", data: { chunkLength: 40 } });
+        report({ event: "Finished" });
+      }),
+    });
+    mocks.check.mockResolvedValue(update);
+
+    await installAvailableAppUpdate();
+
+    const progressMessages = mocks.messageInfo.mock.calls.filter(
+      ([message]) => message.id === "app-update-progress"
+    );
+    expect(progressMessages).toHaveLength(4);
+    expect(progressMessages[2]?.[0].content).toBe("Downloading update… 50%");
+    vi.useRealTimers();
   });
 });

--- a/src/scaffold/AppUpdater/index.test.ts
+++ b/src/scaffold/AppUpdater/index.test.ts
@@ -101,14 +101,29 @@ describe("AppUpdater", () => {
     );
   });
 
-  it("checks, installs, and relaunches when no update is cached", async () => {
+  it("downloads and asks before installing or relaunching", async () => {
     const update = createUpdate();
     mocks.check.mockResolvedValue(update);
 
     await installAvailableAppUpdate();
 
     expect(mocks.check).toHaveBeenCalledOnce();
-    expect(update.downloadAndInstall).toHaveBeenCalledOnce();
+    expect(update.download).toHaveBeenCalledOnce();
+    expect(update.install).not.toHaveBeenCalled();
+    expect(update.downloadAndInstall).not.toHaveBeenCalled();
+    expect(mocks.relaunch).not.toHaveBeenCalled();
+    expect(mocks.storeSet).toHaveBeenLastCalledWith(expect.anything(), true);
+  });
+
+  it("installs and relaunches only after confirmation", async () => {
+    const update = createUpdate();
+    mocks.check.mockResolvedValue(update);
+
+    await installAvailableAppUpdate();
+    await installAvailableAppUpdate({ confirmed: true });
+
+    expect(update.download).toHaveBeenCalledOnce();
+    expect(update.install).toHaveBeenCalledOnce();
     expect(mocks.relaunch).toHaveBeenCalledOnce();
   });
 
@@ -116,7 +131,7 @@ describe("AppUpdater", () => {
     vi.useFakeTimers();
     vi.setSystemTime(10_000);
     const update = createUpdate({
-      downloadAndInstall: vi.fn(async (onEvent) => {
+      download: vi.fn(async (onEvent) => {
         const report = onEvent as (event: DownloadEvent) => void;
         report({ event: "Started", data: { contentLength: 100 } });
         report({ event: "Progress", data: { chunkLength: 10 } });
@@ -132,8 +147,10 @@ describe("AppUpdater", () => {
     const progressMessages = mocks.messageInfo.mock.calls.filter(
       ([message]) => message.id === "app-update-progress"
     );
-    expect(progressMessages).toHaveLength(4);
-    expect(progressMessages[2]?.[0].content).toBe("Downloading update… 50%");
+    expect(progressMessages).toHaveLength(3);
+    expect(progressMessages[1]?.[0].content).toBe("Downloading update… 50%");
+    expect(progressMessages[2]?.[0].content).toBe("Update ready to install.");
+    expect(mocks.relaunch).not.toHaveBeenCalled();
     vi.useRealTimers();
   });
 });

--- a/src/scaffold/AppUpdater/index.test.ts
+++ b/src/scaffold/AppUpdater/index.test.ts
@@ -1,11 +1,31 @@
 import type { DownloadEvent, Update } from "@tauri-apps/plugin-updater";
+import { type ReactNode, createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  AppUpdater,
   checkForUpdatesManually,
   installAvailableAppUpdate,
   resetAppUpdaterForTests,
 } from "./index";
+
+interface CapturedButtonProps {
+  children?: ReactNode;
+  onClick?: () => void | Promise<void>;
+}
+
+interface CapturedCheckboxProps {
+  children?: ReactNode;
+  checked?: boolean;
+  onChange?: (checked: boolean) => void;
+}
+
+interface CapturedModalProps {
+  children?: ReactNode;
+  footer?: ReactNode;
+  visible?: boolean;
+}
 
 const mocks = vi.hoisted(() => ({
   check: vi.fn(),
@@ -15,7 +35,81 @@ const mocks = vi.hoisted(() => ({
   messageSuccess: vi.fn(),
   relaunch: vi.fn(),
   storeSet: vi.fn(),
+  useAtom: vi.fn(),
+  useAtomValue: vi.fn(),
+  setAutoUpdateEnabled: vi.fn(),
+  setInstallPromptVisible: vi.fn(),
+  buttons: [] as CapturedButtonProps[],
+  checkbox: null as CapturedCheckboxProps | null,
+  modal: null as CapturedModalProps | null,
 }));
+
+vi.mock("jotai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("jotai")>();
+  return {
+    ...actual,
+    useAtom: mocks.useAtom,
+    useAtomValue: mocks.useAtomValue,
+  };
+});
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: { version?: string }) => {
+      const labels: Record<string, string> = {
+        "common:actions.later": "Later",
+        "update.autoDownloadUpdates": "Automatically download future updates",
+        "update.installAndRestart": "Install and restart",
+        "update.installConfirmDesc": `Version ${values?.version ?? ""} is ready.`,
+        "update.installConfirmTitle": "Update ready to install",
+        "update.skipVersion": "Skip this version",
+      };
+      return labels[key] ?? key;
+    },
+  }),
+}));
+
+vi.mock("@src/components/AppMark", async () => {
+  const React = await import("react");
+  return {
+    default: () => React.createElement("span", { "data-testid": "app-mark" }),
+  };
+});
+
+vi.mock("@src/components/Button", async () => {
+  const React = await import("react");
+  return {
+    default: (props: CapturedButtonProps) => {
+      mocks.buttons.push(props);
+      return React.createElement("button", null, props.children);
+    },
+  };
+});
+
+vi.mock("@src/components/Checkbox", async () => {
+  const React = await import("react");
+  return {
+    default: (props: CapturedCheckboxProps) => {
+      mocks.checkbox = props;
+      return React.createElement("label", null, props.children);
+    },
+  };
+});
+
+vi.mock("@src/scaffold/ModalSystem", async () => {
+  const React = await import("react");
+  return {
+    default: (props: CapturedModalProps) => {
+      mocks.modal = props;
+      return React.createElement(
+        "section",
+        { "data-visible": String(props.visible) },
+        props.children,
+        props.footer
+      );
+    },
+  };
+});
 
 vi.mock("@tauri-apps/api/app", () => ({
   getVersion: mocks.getVersion,
@@ -67,9 +161,28 @@ function createUpdate(overrides: Partial<Update> = {}): Update {
 describe("AppUpdater", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.buttons.length = 0;
+    mocks.checkbox = null;
+    mocks.modal = null;
     mocks.getVersion.mockResolvedValue("1.1.21");
     resetAppUpdaterForTests();
   });
+
+  function renderPreparedUpdate(update: Update): string {
+    mocks.useAtom
+      .mockReturnValueOnce([true, mocks.setAutoUpdateEnabled])
+      .mockReturnValueOnce([true, mocks.setInstallPromptVisible]);
+    mocks.useAtomValue.mockReturnValueOnce(update).mockReturnValueOnce(true);
+    return renderToStaticMarkup(createElement(AppUpdater));
+  }
+
+  function capturedButton(label: string): CapturedButtonProps {
+    const button = mocks.buttons.find(
+      (candidate) => candidate.children === label
+    );
+    expect(button, `Missing ${label} button`).toBeDefined();
+    return button as CapturedButtonProps;
+  }
 
   it("checks for updates without requiring a browser-exposed Tauri global", async () => {
     const update = createUpdate();
@@ -125,6 +238,68 @@ describe("AppUpdater", () => {
     expect(update.download).toHaveBeenCalledOnce();
     expect(update.install).toHaveBeenCalledOnce();
     expect(mocks.relaunch).toHaveBeenCalledOnce();
+  });
+
+  it("renders the update choices and wires later and automatic downloads", async () => {
+    const update = createUpdate();
+    mocks.check.mockResolvedValue(update);
+    await installAvailableAppUpdate();
+
+    const markup = renderPreparedUpdate(update);
+
+    expect(markup).toContain("Version 1.1.22 is ready.");
+    expect(markup).toContain("Skip this version");
+    expect(markup).toContain("Later");
+    expect(markup).toContain("Install and restart");
+    expect(mocks.modal?.visible).toBe(true);
+    expect(mocks.checkbox?.checked).toBe(true);
+
+    mocks.checkbox?.onChange?.(false);
+    capturedButton("Later").onClick?.();
+
+    expect(mocks.setAutoUpdateEnabled).toHaveBeenCalledWith(false);
+    expect(mocks.setInstallPromptVisible).toHaveBeenCalledWith(false);
+    expect(update.install).not.toHaveBeenCalled();
+    expect(mocks.relaunch).not.toHaveBeenCalled();
+  });
+
+  it("persists a skipped version and closes its update handle", async () => {
+    const values = new Map<string, string>();
+    const localStorage = {
+      getItem: vi.fn((key: string) => values.get(key) ?? null),
+      removeItem: vi.fn((key: string) => values.delete(key)),
+      setItem: vi.fn((key: string, value: string) => values.set(key, value)),
+    };
+    vi.stubGlobal("window", { localStorage });
+    const update = createUpdate();
+    mocks.check.mockResolvedValue(update);
+    await installAvailableAppUpdate();
+    renderPreparedUpdate(update);
+
+    capturedButton("Skip this version").onClick?.();
+
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      "orgii:updater:skipped-update-version",
+      "1.1.22"
+    );
+    expect(update.close).toHaveBeenCalledOnce();
+    expect(mocks.setInstallPromptVisible).toHaveBeenCalledWith(false);
+    expect(update.install).not.toHaveBeenCalled();
+    expect(mocks.relaunch).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it("installs from the dialog only after its primary action is clicked", async () => {
+    const update = createUpdate();
+    mocks.check.mockResolvedValue(update);
+    await installAvailableAppUpdate();
+    renderPreparedUpdate(update);
+
+    await capturedButton("Install and restart").onClick?.();
+
+    expect(update.install).toHaveBeenCalledOnce();
+    expect(mocks.relaunch).toHaveBeenCalledOnce();
+    expect(mocks.setInstallPromptVisible).toHaveBeenCalledWith(false);
   });
 
   it("throttles download progress messages", async () => {

--- a/src/scaffold/AppUpdater/index.tsx
+++ b/src/scaffold/AppUpdater/index.tsx
@@ -2,59 +2,70 @@ import { getVersion } from "@tauri-apps/api/app";
 import type { DownloadEvent, Update } from "@tauri-apps/plugin-updater";
 import { check } from "@tauri-apps/plugin-updater";
 import { atom, useAtomValue } from "jotai";
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 
 import Message from "@src/components/Message";
 import { createLogger } from "@src/hooks/logger";
+import { autoUpdateEnabledAtom } from "@src/store/platform/autoUpdateAtom";
+import { settingsLoadedAtom } from "@src/store/settings/settingsAtom";
 import { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";
+
+import {
+  AppUpdaterCoordinator,
+  type AppUpdaterState,
+  createInitialAppUpdaterState,
+} from "./appUpdaterCoordinator";
+import {
+  AppUpdaterScheduler,
+  type AutomaticUpdateReason,
+} from "./appUpdaterScheduler";
 
 const log = createLogger("AppUpdater");
 
 const STARTUP_CHECK_DELAY_MS = 10_000;
-// Background poll is intentionally long: focus/visibilitychange checks (throttled
-// by FOREGROUND_CHECK_MIN_INTERVAL_MS) cover active users, so the timer only
-// matters for a window left focused for hours without any focus events.
 const UPDATE_CHECK_INTERVAL_MS = 2 * 60 * 60_000;
 const FOREGROUND_CHECK_MIN_INTERVAL_MS = 5 * 60_000;
+const FOREGROUND_EVENT_DEBOUNCE_MS = 750;
 const INSTALL_PROGRESS_MESSAGE_MIN_INTERVAL_MS = 2_000;
 const UPDATE_TOAST_DURATION_MS = 5_000;
 
-// Reused toast slots so status updates replace in place instead of stacking.
 const CHECK_TOAST_ID = "app-update-check";
 const INSTALL_TOAST_ID = "app-update-progress";
 
-interface CheckForAppUpdatesOptions {
+export interface CheckForAppUpdatesOptions {
   notify?: boolean;
   force?: boolean;
 }
 
-const availableAppUpdateAtom = atom<Update | null>(null);
-const isAppUpdateInstallingAtom = atom(false);
-
-let lastCheckStartedAt = 0;
-let pendingCheck: Promise<Update | null> | null = null;
+const appUpdaterStateAtom = atom<AppUpdaterState>(
+  createInitialAppUpdaterState()
+);
+const availableAppUpdateAtom = atom((get) => get(appUpdaterStateAtom).update);
+const isAppUpdateInstallingAtom = atom((get) => {
+  const phase = get(appUpdaterStateAtom).phase;
+  return (
+    phase === "downloading" || phase === "installing" || phase === "relaunching"
+  );
+});
 
 function store() {
   return getInstrumentedStore();
 }
 
+function createCoordinator(): AppUpdaterCoordinator {
+  return new AppUpdaterCoordinator({
+    check,
+    getVersion,
+    minCheckIntervalMs: FOREGROUND_CHECK_MIN_INTERVAL_MS,
+    onStateChange: (state) => store().set(appUpdaterStateAtom, state),
+  });
+}
+
+const coordinator = createCoordinator();
+
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
   return typeof error === "string" ? error : "Unknown error";
-}
-
-function getCachedUpdate(): Update | null {
-  return store().get(availableAppUpdateAtom);
-}
-
-function setCachedUpdate(update: Update | null): void {
-  store().set(availableAppUpdateAtom, update);
-}
-
-function shouldReuseRecentResult(force: boolean): boolean {
-  return (
-    !force && Date.now() - lastCheckStartedAt < FOREGROUND_CHECK_MIN_INTERVAL_MS
-  );
 }
 
 function notifyCheckSuccess(
@@ -68,7 +79,7 @@ function notifyCheckSuccess(
     Message.info({
       id: CHECK_TOAST_ID,
       title: "Update available",
-      content: `Version ${update.version} is ready to download.`,
+      content: `Version ${update.version} is ready to install.`,
       duration: UPDATE_TOAST_DURATION_MS,
     });
     return;
@@ -96,8 +107,10 @@ function notifyCheckFailure(error: unknown, notify: boolean): void {
   });
 }
 
-async function runUpdateCheck(notify: boolean): Promise<Update | null> {
-  lastCheckStartedAt = Date.now();
+export async function checkForAppUpdates(
+  options: CheckForAppUpdatesOptions = {}
+): Promise<Update | null> {
+  const { notify = false, force = false } = options;
 
   if (notify) {
     Message.info({
@@ -108,40 +121,17 @@ async function runUpdateCheck(notify: boolean): Promise<Update | null> {
   }
 
   try {
-    const [currentVersion, update] = await Promise.all([
-      getVersion().catch(() => undefined),
-      check(),
-    ]);
-
-    setCachedUpdate(update);
-
-    if (update) {
-      log.info("Update available", {
-        currentVersion: update.currentVersion || currentVersion,
-        version: update.version,
-      });
-    }
-
-    notifyCheckSuccess(update, currentVersion, notify);
-    return update;
+    const result = await coordinator.checkForUpdate(force);
+    notifyCheckSuccess(result.update, result.currentVersion, notify);
+    return result.update;
   } catch (error) {
+    // A manual check is an explicit freshness request. Do not keep showing an
+    // update that this check could not confirm. Silent failures keep the last
+    // successful result so transient network loss does not erase UI state.
+    if (notify) coordinator.clearAvailableUpdate();
     notifyCheckFailure(error, notify);
-    return getCachedUpdate();
-  } finally {
-    pendingCheck = null;
+    return notify ? null : coordinator.getAvailableUpdate();
   }
-}
-
-export async function checkForAppUpdates(
-  options: CheckForAppUpdatesOptions = {}
-): Promise<Update | null> {
-  const { notify = false, force = false } = options;
-
-  if (pendingCheck) return pendingCheck;
-  if (shouldReuseRecentResult(force)) return getCachedUpdate();
-
-  pendingCheck = runUpdateCheck(notify);
-  return pendingCheck;
 }
 
 export async function checkForUpdatesManually(): Promise<Update | null> {
@@ -154,9 +144,6 @@ function formatBytes(bytes: number): string {
   return `${Math.max(1, Math.round(bytes / 1024))} KB`;
 }
 
-// Tracks cumulative download progress so the toast reflects real percentage
-// (or downloaded size when the server omits Content-Length) instead of a
-// static string. `Started`/`Finished` always report; `Progress` is throttled.
 function createProgressReporter(): (event: DownloadEvent) => void {
   let lastReportedAt = 0;
   let downloaded = 0;
@@ -201,21 +188,28 @@ function createProgressReporter(): (event: DownloadEvent) => void {
   };
 }
 
-export async function installAvailableAppUpdate(): Promise<void> {
-  const update = getCachedUpdate() ?? (await checkForUpdatesManually());
-  if (!update || store().get(isAppUpdateInstallingAtom)) return;
+async function relaunchApp(): Promise<void> {
+  const { relaunch } = await import("@tauri-apps/plugin-process");
+  await relaunch();
+}
 
-  store().set(isAppUpdateInstallingAtom, true);
+export async function installAvailableAppUpdate(): Promise<void> {
+  const update =
+    coordinator.getAvailableUpdate() ?? (await checkForUpdatesManually());
+  if (!update) return;
 
   try {
     Message.info({
       id: INSTALL_TOAST_ID,
       title: "Installing update",
-      content: `Preparing to download v${update.version}…`,
+      content: `Preparing v${update.version}…`,
       duration: 0,
     });
 
-    await update.downloadAndInstall(createProgressReporter());
+    const installed = await coordinator.installAvailableUpdate(
+      createProgressReporter()
+    );
+    if (!installed) return;
 
     Message.success({
       id: INSTALL_TOAST_ID,
@@ -223,9 +217,7 @@ export async function installAvailableAppUpdate(): Promise<void> {
       content: "Restarting ORGII to finish the update.",
       duration: 2500,
     });
-
-    const { relaunch } = await import("@tauri-apps/plugin-process");
-    await relaunch();
+    await relaunchApp();
   } catch (error) {
     Message.error({
       id: INSTALL_TOAST_ID,
@@ -234,8 +226,30 @@ export async function installAvailableAppUpdate(): Promise<void> {
       duration: 6000,
     });
     log.error("Update install failed", error);
-  } finally {
-    store().set(isAppUpdateInstallingAtom, false);
+  }
+}
+
+async function runAutomaticUpdate(
+  reason: AutomaticUpdateReason
+): Promise<void> {
+  try {
+    const result = await coordinator.checkForUpdate(
+      reason === "startup" || reason === "interval"
+    );
+    if (!result.update) return;
+
+    if (reason === "startup") {
+      const installed = await coordinator.installAvailableUpdate();
+      if (installed) await relaunchApp();
+      return;
+    }
+
+    // Installing can terminate the app on Windows. While the user is active,
+    // only download in the background; the existing update button can install
+    // immediately from the prepared package, or startup auto-update will.
+    await coordinator.downloadAvailableUpdate();
+  } catch (error) {
+    log.warn(`Automatic update (${reason}) failed`, getErrorMessage(error));
   }
 }
 
@@ -248,29 +262,32 @@ export function useIsAppUpdateInstalling(): boolean {
 }
 
 export const AppUpdater: React.FC = () => {
+  const autoUpdateEnabled = useAtomValue(autoUpdateEnabledAtom);
+  const settingsLoaded = useAtomValue(settingsLoadedAtom);
+  const startupSchedulingPendingRef = useRef(true);
+
   useEffect(() => {
-    const startupTimer = window.setTimeout(() => {
-      void checkForAppUpdates();
-    }, STARTUP_CHECK_DELAY_MS);
+    if (!settingsLoaded) return;
+    const scheduleStartupInstall = startupSchedulingPendingRef.current;
+    startupSchedulingPendingRef.current = false;
+    if (!autoUpdateEnabled) return;
 
-    const interval = window.setInterval(() => {
-      void checkForAppUpdates({ force: true });
-    }, UPDATE_CHECK_INTERVAL_MS);
-
-    const checkWhenVisible = () => {
-      if (document.visibilityState === "visible") void checkForAppUpdates();
-    };
-
-    window.addEventListener("focus", checkWhenVisible);
-    document.addEventListener("visibilitychange", checkWhenVisible);
-
-    return () => {
-      window.clearTimeout(startupTimer);
-      window.clearInterval(interval);
-      window.removeEventListener("focus", checkWhenVisible);
-      document.removeEventListener("visibilitychange", checkWhenVisible);
-    };
-  }, []);
+    const scheduler = new AppUpdaterScheduler({
+      startupDelayMs: scheduleStartupInstall ? STARTUP_CHECK_DELAY_MS : null,
+      intervalMs: UPDATE_CHECK_INTERVAL_MS,
+      foregroundDebounceMs: FOREGROUND_EVENT_DEBOUNCE_MS,
+    });
+    scheduler.start((reason) => {
+      void runAutomaticUpdate(reason);
+    });
+    if (!scheduleStartupInstall) void runAutomaticUpdate("foreground");
+    return () => scheduler.stop();
+  }, [autoUpdateEnabled, settingsLoaded]);
 
   return null;
 };
+
+/** Test-only reset for the module singleton. */
+export function resetAppUpdaterForTests(): void {
+  coordinator.reset();
+}

--- a/src/scaffold/AppUpdater/index.tsx
+++ b/src/scaffold/AppUpdater/index.tsx
@@ -1,11 +1,13 @@
 import { getVersion } from "@tauri-apps/api/app";
 import type { DownloadEvent, Update } from "@tauri-apps/plugin-updater";
 import { check } from "@tauri-apps/plugin-updater";
-import { atom, useAtomValue } from "jotai";
-import React, { useEffect, useRef } from "react";
+import { atom, useAtom, useAtomValue } from "jotai";
+import React, { useCallback, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
 
 import Message from "@src/components/Message";
 import { createLogger } from "@src/hooks/logger";
+import Modal from "@src/scaffold/ModalSystem";
 import { autoUpdateEnabledAtom } from "@src/store/platform/autoUpdateAtom";
 import { settingsLoadedAtom } from "@src/store/settings/settingsAtom";
 import { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";
@@ -41,6 +43,7 @@ const appUpdaterStateAtom = atom<AppUpdaterState>(
   createInitialAppUpdaterState()
 );
 const availableAppUpdateAtom = atom((get) => get(appUpdaterStateAtom).update);
+const appUpdateInstallPromptAtom = atom(false);
 const isAppUpdateInstallingAtom = atom((get) => {
   const phase = get(appUpdaterStateAtom).phase;
   return (
@@ -161,7 +164,7 @@ function createProgressReporter(): (event: DownloadEvent) => void {
         return `Downloading update… ${percent}%`;
       }
       case "Finished":
-        return "Installing update…";
+        return "Update ready to install.";
     }
   };
 
@@ -193,10 +196,36 @@ async function relaunchApp(): Promise<void> {
   await relaunch();
 }
 
-export async function installAvailableAppUpdate(): Promise<void> {
+export interface InstallAvailableAppUpdateOptions {
+  confirmed?: boolean;
+  silentDownload?: boolean;
+}
+
+export async function installAvailableAppUpdate(
+  options: InstallAvailableAppUpdateOptions = {}
+): Promise<void> {
+  const { confirmed = false, silentDownload = false } = options;
   const update =
     coordinator.getAvailableUpdate() ?? (await checkForUpdatesManually());
   if (!update) return;
+
+  if (!confirmed) {
+    try {
+      await coordinator.downloadAvailableUpdate(
+        silentDownload ? undefined : createProgressReporter()
+      );
+      store().set(appUpdateInstallPromptAtom, true);
+    } catch (error) {
+      Message.error({
+        id: INSTALL_TOAST_ID,
+        title: "Update download failed",
+        content: getErrorMessage(error),
+        duration: 6000,
+      });
+      log.error("Update download failed", error);
+    }
+    return;
+  }
 
   try {
     Message.info({
@@ -206,9 +235,7 @@ export async function installAvailableAppUpdate(): Promise<void> {
       duration: 0,
     });
 
-    const installed = await coordinator.installAvailableUpdate(
-      createProgressReporter()
-    );
+    const installed = await coordinator.installAvailableUpdate();
     if (!installed) return;
 
     Message.success({
@@ -238,16 +265,9 @@ async function runAutomaticUpdate(
     );
     if (!result.update) return;
 
-    if (reason === "startup") {
-      const installed = await coordinator.installAvailableUpdate();
-      if (installed) await relaunchApp();
-      return;
-    }
-
-    // Installing can terminate the app on Windows. While the user is active,
-    // only download in the background; the existing update button can install
-    // immediately from the prepared package, or startup auto-update will.
-    await coordinator.downloadAvailableUpdate();
+    // Installing can terminate the app on Windows. Every automatic path only
+    // prepares the package and asks the user before installing or relaunching.
+    await installAvailableAppUpdate({ silentDownload: true });
   } catch (error) {
     log.warn(`Automatic update (${reason}) failed`, getErrorMessage(error));
   }
@@ -262,9 +282,23 @@ export function useIsAppUpdateInstalling(): boolean {
 }
 
 export const AppUpdater: React.FC = () => {
+  const { t } = useTranslation(["settings", "common"]);
   const autoUpdateEnabled = useAtomValue(autoUpdateEnabledAtom);
+  const availableUpdate = useAtomValue(availableAppUpdateAtom);
+  const [installPromptVisible, setInstallPromptVisible] = useAtom(
+    appUpdateInstallPromptAtom
+  );
   const settingsLoaded = useAtomValue(settingsLoadedAtom);
   const startupSchedulingPendingRef = useRef(true);
+
+  const handleInstallLater = useCallback(() => {
+    setInstallPromptVisible(false);
+  }, [setInstallPromptVisible]);
+
+  const handleInstallConfirm = useCallback(async () => {
+    await installAvailableAppUpdate({ confirmed: true });
+    setInstallPromptVisible(false);
+  }, [setInstallPromptVisible]);
 
   useEffect(() => {
     if (!settingsLoaded) return;
@@ -284,10 +318,28 @@ export const AppUpdater: React.FC = () => {
     return () => scheduler.stop();
   }, [autoUpdateEnabled, settingsLoaded]);
 
-  return null;
+  return (
+    <Modal
+      visible={installPromptVisible && Boolean(availableUpdate)}
+      title={t("update.installConfirmTitle")}
+      size="small"
+      okText={t("update.installAndRestart")}
+      cancelText={t("common:actions.later")}
+      onOk={handleInstallConfirm}
+      onCancel={handleInstallLater}
+      onClose={handleInstallLater}
+    >
+      <p className="text-sm text-text-2">
+        {t("update.installConfirmDesc", {
+          version: availableUpdate?.version,
+        })}
+      </p>
+    </Modal>
+  );
 };
 
 /** Test-only reset for the module singleton. */
 export function resetAppUpdaterForTests(): void {
   coordinator.reset();
+  store().set(appUpdateInstallPromptAtom, false);
 }

--- a/src/scaffold/AppUpdater/index.tsx
+++ b/src/scaffold/AppUpdater/index.tsx
@@ -5,6 +5,9 @@ import { atom, useAtom, useAtomValue } from "jotai";
 import React, { useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
+import AppMark from "@src/components/AppMark";
+import Button from "@src/components/Button";
+import Checkbox from "@src/components/Checkbox";
 import Message from "@src/components/Message";
 import { createLogger } from "@src/hooks/logger";
 import Modal from "@src/scaffold/ModalSystem";
@@ -33,6 +36,8 @@ const UPDATE_TOAST_DURATION_MS = 5_000;
 
 const CHECK_TOAST_ID = "app-update-check";
 const INSTALL_TOAST_ID = "app-update-progress";
+const SKIPPED_UPDATE_VERSION_STORAGE_KEY =
+  "orgii:updater:skipped-update-version";
 
 export interface CheckForAppUpdatesOptions {
   notify?: boolean;
@@ -53,6 +58,22 @@ const isAppUpdateInstallingAtom = atom((get) => {
 
 function store() {
   return getInstrumentedStore();
+}
+
+function getSkippedUpdateVersion(): string | null {
+  if (typeof window === "undefined") return null;
+  return window.localStorage.getItem(SKIPPED_UPDATE_VERSION_STORAGE_KEY);
+}
+
+function setSkippedUpdateVersion(version: string): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(SKIPPED_UPDATE_VERSION_STORAGE_KEY, version);
+}
+
+function clearSkippedUpdateVersion(version: string): void {
+  if (typeof window !== "undefined" && getSkippedUpdateVersion() === version) {
+    window.localStorage.removeItem(SKIPPED_UPDATE_VERSION_STORAGE_KEY);
+  }
 }
 
 function createCoordinator(): AppUpdaterCoordinator {
@@ -211,6 +232,7 @@ export async function installAvailableAppUpdate(
 
   if (!confirmed) {
     try {
+      clearSkippedUpdateVersion(update.version);
       await coordinator.downloadAvailableUpdate(
         silentDownload ? undefined : createProgressReporter()
       );
@@ -264,6 +286,10 @@ async function runAutomaticUpdate(
       reason === "startup" || reason === "interval"
     );
     if (!result.update) return;
+    if (getSkippedUpdateVersion() === result.update.version) {
+      coordinator.clearAvailableUpdate();
+      return;
+    }
 
     // Installing can terminate the app on Windows. Every automatic path only
     // prepares the package and asks the user before installing or relaunching.
@@ -283,7 +309,9 @@ export function useIsAppUpdateInstalling(): boolean {
 
 export const AppUpdater: React.FC = () => {
   const { t } = useTranslation(["settings", "common"]);
-  const autoUpdateEnabled = useAtomValue(autoUpdateEnabledAtom);
+  const [autoUpdateEnabled, setAutoUpdateEnabled] = useAtom(
+    autoUpdateEnabledAtom
+  );
   const availableUpdate = useAtomValue(availableAppUpdateAtom);
   const [installPromptVisible, setInstallPromptVisible] = useAtom(
     appUpdateInstallPromptAtom
@@ -295,10 +323,23 @@ export const AppUpdater: React.FC = () => {
     setInstallPromptVisible(false);
   }, [setInstallPromptVisible]);
 
+  const handleSkipVersion = useCallback(() => {
+    if (availableUpdate) setSkippedUpdateVersion(availableUpdate.version);
+    coordinator.clearAvailableUpdate();
+    setInstallPromptVisible(false);
+  }, [availableUpdate, setInstallPromptVisible]);
+
   const handleInstallConfirm = useCallback(async () => {
     await installAvailableAppUpdate({ confirmed: true });
     setInstallPromptVisible(false);
   }, [setInstallPromptVisible]);
+
+  const handleAutoUpdateChange = useCallback(
+    (checked: boolean) => {
+      setAutoUpdateEnabled(checked);
+    },
+    [setAutoUpdateEnabled]
+  );
 
   useEffect(() => {
     if (!settingsLoaded) return;
@@ -322,18 +363,65 @@ export const AppUpdater: React.FC = () => {
     <Modal
       visible={installPromptVisible && Boolean(availableUpdate)}
       title={t("update.installConfirmTitle")}
-      size="small"
-      okText={t("update.installAndRestart")}
-      cancelText={t("common:actions.later")}
-      onOk={handleInstallConfirm}
+      width={620}
+      closable={false}
+      maskClosable={false}
+      escToExit={false}
       onCancel={handleInstallLater}
       onClose={handleInstallLater}
+      bodyClassName="px-6 py-5"
+      footerTopBorder={false}
+      footer={
+        <div className="flex items-center justify-between gap-3 px-5 py-4">
+          <Button
+            variant="tertiary"
+            appearance="ghost"
+            size="large"
+            shape="round"
+            onClick={handleSkipVersion}
+          >
+            {t("update.skipVersion")}
+          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="secondary"
+              appearance="solid"
+              size="large"
+              shape="round"
+              onClick={handleInstallLater}
+            >
+              {t("common:actions.later")}
+            </Button>
+            <Button
+              variant="primary"
+              size="large"
+              shape="round"
+              onClick={() => void handleInstallConfirm()}
+              data-modal-primary-action
+            >
+              {t("update.installAndRestart")}
+            </Button>
+          </div>
+        </div>
+      }
     >
-      <p className="text-sm text-text-2">
-        {t("update.installConfirmDesc", {
-          version: availableUpdate?.version,
-        })}
-      </p>
+      <div className="flex items-center gap-5">
+        <AppMark
+          size={72}
+          className="border border-border-2 bg-bg-2 shadow-sm"
+          glyphClassName="text-text-1"
+        />
+        <p className="min-w-0 flex-1 text-sm leading-6 text-text-2">
+          {t("update.installConfirmDesc", {
+            version: availableUpdate?.version,
+          })}
+        </p>
+      </div>
+      <div className="mt-5 border-t border-border-1 pt-4">
+        <Checkbox checked={autoUpdateEnabled} onChange={handleAutoUpdateChange}>
+          {t("update.autoDownloadUpdates")}
+        </Checkbox>
+      </div>
     </Modal>
   );
 };

--- a/src/scaffold/AppUpdater/index.tsx
+++ b/src/scaffold/AppUpdater/index.tsx
@@ -396,7 +396,7 @@ export const AppUpdater: React.FC = () => {
               variant="primary"
               size="large"
               shape="round"
-              onClick={() => void handleInstallConfirm()}
+              onClick={handleInstallConfirm}
               data-modal-primary-action
             >
               {t("update.installAndRestart")}

--- a/src/store/platform/autoUpdateAtom.ts
+++ b/src/store/platform/autoUpdateAtom.ts
@@ -1,0 +1,18 @@
+import { atom } from "jotai";
+
+import {
+  settingsAtom,
+  updateSettingAtom,
+} from "@src/store/settings/settingsAtom";
+
+/** Default-on automatic app updates, persisted in settings.jsonc. */
+export const autoUpdateEnabledAtom = atom(
+  (get) => get(settingsAtom)["general.autoUpdateEnabled"] ?? true,
+  (_get, set, value: boolean) => {
+    set(updateSettingAtom, {
+      key: "general.autoUpdateEnabled",
+      value,
+    });
+  }
+);
+autoUpdateEnabledAtom.debugLabel = "autoUpdateEnabledAtom";


### PR DESCRIPTION
## Summary

- add a persisted `general.autoUpdateEnabled` setting that defaults to on, with a General Settings switch
- replace fragmented updater globals with one testable coordinator and one scheduler
- make every automatic trigger download the update without installing or relaunching
- present a card-style update dialog with the ORGII mark, version details, and automatic-download control
- provide real “Skip this version”, “Later”, and “Install and restart” actions
- route the existing manual update actions through the same confirmation-gated install flow
- keep manual check entry points compatible, improve stale-cache failure semantics, and deduplicate concurrent checks/downloads/installs
- update updater documentation and include independent architecture and frontend UI audit reports

## Why

The existing updater mixed module-level mutable state with Jotai projections, had overlapping focus/visibility triggers, and could retain stale update UI after failed manual checks. More importantly, an automatic startup update could install and relaunch after the user had already started working.

Closes #355.

## User impact

Automatic updates remain enabled by default and can still be disabled either in Settings or directly from the update dialog. Startup, interval, foreground, and online checks now only prepare the package. Once the download finishes, ORGII shows a dedicated update card and waits for the user.

- **Skip this version** persists the skipped version across app launches and suppresses future automatic prompts for it.
- **Later** closes the dialog while keeping the downloaded package ready.
- **Install and restart** is the only action that installs and relaunches ORGII.

Manual update buttons use the same dialog. No automatic path installs or relaunches without confirmation.

## Validation

Verified from the exact remote PR HEAD:

- 16 updater/settings tests pass
- component interaction coverage invokes all three dialog actions and the automatic-download checkbox
- assertions verify that Later and Skip never install or relaunch
- assertions verify that the primary action installs and then relaunches
- targeted ESLint passes for the changed updater TypeScript/TSX files
- Prettier check passes for updater, documentation, and locale files
- `git diff --check` passes
- architecture audit covers all 10 layers
- frontend UI audit: 0 fixes, 2 keep-with-reason, 0 abstract candidates

Baseline check unrelated to this PR remains red on the isolated branch:

- `pnpm typecheck`: existing `ContextInfoButton.tsx:468` `string | undefined` error

The full local workspace typecheck passes with the existing working-tree fix for that baseline error.