### PR TITLE
fix: keep model picker usable with invalid credentials

### DIFF
--- a/src-tauri/crates/key-vault/src/commands/crud.rs
+++ b/src-tauri/crates/key-vault/src/commands/crud.rs
@@ -829,7 +829,7 @@ impl From<ModelKey> for FullKeyResponse {
 pub async fn list_keys() -> Result<Vec<KeyInfo>, String> {
     tokio::task::spawn_blocking(|| {
         KEY_SERVICE
-            .list_keys()
+            .list_keys_checked()?
             .into_iter()
             .map(key_info_from_entry)
             .collect::<Result<Vec<_>, _>>()
@@ -848,7 +848,7 @@ pub async fn get_key(
         let agent = ModelType::from_str(&agent_type)
             .ok_or_else(|| format!("Unknown agent_type: {agent_type:?}"))?;
         KEY_SERVICE
-            .get_key(&agent, key_id.as_deref())
+            .get_key_checked(&agent, key_id.as_deref())?
             .map(key_info_from_entry)
             .transpose()
     })
@@ -861,7 +861,7 @@ pub async fn get_key(
 pub async fn get_key_by_id(key_id: String) -> Result<Option<KeyInfo>, String> {
     tokio::task::spawn_blocking(move || {
         KEY_SERVICE
-            .get_key_by_id(&key_id)
+            .get_key_by_id_checked(&key_id)?
             .map(key_info_from_entry)
             .transpose()
     })
@@ -879,7 +879,7 @@ pub async fn get_full_key(
         let agent = ModelType::from_str(&agent_type)
             .ok_or_else(|| format!("Unknown agent_type: {agent_type:?}"))?;
         Ok(KEY_SERVICE
-            .get_key(&agent, key_id.as_deref())
+            .get_key_checked(&agent, key_id.as_deref())?
             .map(FullKeyResponse::from))
     })
     .await
@@ -894,10 +894,10 @@ pub async fn save_key(request: SaveKeyRequest) -> Result<KeyInfo, String> {
             ModelType::from_str(&request.agent_type).ok_or("Unknown agent type".to_string())?;
 
         // Load existing key if updating
-        let existing = request
-            .id
-            .as_ref()
-            .and_then(|id| KEY_SERVICE.get_key_by_id(id));
+        let existing = match request.id.as_deref() {
+            Some(id) => KEY_SERVICE.get_key_by_id_checked(id)?,
+            None => None,
+        };
 
         let mut entry = if let Some(existing) = existing {
             existing

--- a/src-tauri/crates/key-vault/src/key_store/service.rs
+++ b/src-tauri/crates/key-vault/src/key_store/service.rs
@@ -1,5 +1,6 @@
 use chrono::{Duration as ChronoDuration, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::PathBuf;
@@ -26,7 +27,66 @@ const OAUTH_REFRESH_FAILURE_DISABLE_THRESHOLD: u32 = 3;
 const OAUTH_TEMPORARY_UNAVAILABLE_SECONDS: i64 = 30 * 60;
 const OAUTH_RATE_LIMIT_FALLBACK_SECONDS: i64 = 5 * 60;
 const OAUTH_REFRESH_FAILURE_COOLDOWN_SECONDS: i64 = 5 * 60;
+const RETIRED_MODEL_TYPES: &[&str] = &["gemini_cli"];
 type OAuthRefreshLockMap = Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>;
+
+#[derive(Debug)]
+struct InvalidStoredCredential {
+    id: String,
+    raw: JsonValue,
+    error: String,
+}
+
+#[derive(Debug)]
+struct LoadedKeyStore {
+    store: KeyStore,
+    invalid_credentials: Vec<InvalidStoredCredential>,
+    retired_credential_count: usize,
+}
+
+impl LoadedKeyStore {
+    fn log_diagnostics(&self, storage_file: &std::path::Path) {
+        if self.retired_credential_count > 0 {
+            tracing::info!(
+                path = %storage_file.display(),
+                count = self.retired_credential_count,
+                "Ignored retired Key Vault credentials"
+            );
+        }
+        for credential in &self.invalid_credentials {
+            tracing::warn!(
+                path = %storage_file.display(),
+                credential_id = %credential.id,
+                error = %credential.error,
+                "Ignored invalid Key Vault credential; raw entry will be preserved"
+            );
+        }
+    }
+
+    fn invalid_credential_error(&self, key_id: &str) -> Option<String> {
+        self.invalid_credentials.iter().find_map(|credential| {
+            let raw_id = credential.raw.get("id").and_then(JsonValue::as_str);
+            (credential.id == key_id || raw_id == Some(key_id)).then(|| {
+                format!(
+                    "Credential {key_id:?} is invalid and was preserved: {}",
+                    credential.error
+                )
+            })
+        })
+    }
+
+    fn ensure_any_valid_credentials(&self, storage_file: &std::path::Path) -> Result<(), String> {
+        if self.store.keys.is_empty() && !self.invalid_credentials.is_empty() {
+            return Err(format!(
+                "No valid credentials could be loaded; {} invalid credential(s) were preserved in {}",
+                self.invalid_credentials.len(),
+                storage_file.display()
+            ));
+        }
+
+        Ok(())
+    }
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct CliOAuthTokenSync {
@@ -140,12 +200,16 @@ impl KeyService {
 
     /// Load keys from file.
     ///
-    /// On read or parse failure, logs an error and returns `None` so callers
-    /// can decide whether to proceed (read-only callers return empty data,
-    /// write callers abort to avoid overwriting a corrupted file).
-    fn load_store_checked(&self) -> Result<KeyStore, String> {
+    /// Root-level read/parse failures are returned to the caller. Individual
+    /// malformed credentials are isolated in `LoadedKeyStore` so valid
+    /// siblings remain usable and future writes can preserve the raw entries.
+    fn load_store_checked(&self) -> Result<LoadedKeyStore, String> {
         if !self.storage_file.exists() {
-            return Ok(KeyStore::default());
+            return Ok(LoadedKeyStore {
+                store: KeyStore::default(),
+                invalid_credentials: Vec::new(),
+                retired_credential_count: 0,
+            });
         }
 
         let contents = fs::read_to_string(&self.storage_file)
@@ -158,7 +222,7 @@ impl KeyService {
     /// Load keys, returning default on missing file but logging errors.
     fn load_store(&self) -> KeyStore {
         match self.load_store_checked() {
-            Ok(store) => store,
+            Ok(loaded) => loaded.store,
             Err(err) => {
                 eprintln!("[KeyService] {}", err);
                 KeyStore::default()
@@ -169,8 +233,12 @@ impl KeyService {
     /// Save keys to file (atomic write + restrictive permissions).
     /// Secrets (api_key, session_token) are written directly to the JSON file,
     /// protected by 0o600 permissions.
-    fn save_store(&self, store: &KeyStore) -> Result<(), String> {
-        let contents = serde_json::to_string_pretty(store)
+    fn save_store(
+        &self,
+        store: &KeyStore,
+        invalid_credentials: &[InvalidStoredCredential],
+    ) -> Result<(), String> {
+        let contents = serialize_key_store(store, invalid_credentials)
             .map_err(|e| format!("Failed to serialize credentials: {}", e))?;
 
         // Write to a temp file first, then rename — atomic on same filesystem
@@ -193,9 +261,12 @@ impl KeyService {
     {
         let _guard = self.lock.lock().map_err(|e| format!("Lock error: {}", e))?;
 
-        let mut store = self.load_store_checked()?;
-        let result = updater(&mut store);
-        self.save_store(&store)?;
+        let mut loaded = self.load_store_checked()?;
+        let result = updater(&mut loaded.store);
+        if !loaded.invalid_credentials.is_empty() {
+            loaded.log_diagnostics(&self.storage_file);
+        }
+        self.save_store(&loaded.store, &loaded.invalid_credentials)?;
 
         Ok(result)
     }
@@ -204,6 +275,58 @@ impl KeyService {
     pub fn list_keys(&self) -> Vec<ModelKey> {
         let store = self.load_store();
         store.keys.into_values().collect()
+    }
+
+    /// List stored keys while surfacing root-level corruption to user-facing
+    /// callers. Invalid individual entries are isolated and logged; valid
+    /// siblings remain available.
+    pub fn list_keys_checked(&self) -> Result<Vec<ModelKey>, String> {
+        let loaded = self.load_store_checked()?;
+        loaded.log_diagnostics(&self.storage_file);
+
+        loaded.ensure_any_valid_credentials(&self.storage_file)?;
+
+        Ok(loaded.store.keys.into_values().collect())
+    }
+
+    /// Read one credential without turning corruption into a misleading
+    /// "not found" response. Invalid siblings remain isolated.
+    pub fn get_key_checked(
+        &self,
+        agent_type: &ModelType,
+        key_id: Option<&str>,
+    ) -> Result<Option<ModelKey>, String> {
+        let loaded = self.load_store_checked()?;
+        loaded.log_diagnostics(&self.storage_file);
+
+        if let Some(key) = loaded.store.get(agent_type, key_id).cloned() {
+            return Ok(Some(key));
+        }
+        if let Some(key_id) = key_id {
+            if let Some(error) = loaded.invalid_credential_error(key_id) {
+                return Err(error);
+            }
+        }
+        loaded.ensure_any_valid_credentials(&self.storage_file)?;
+
+        Ok(None)
+    }
+
+    /// Read one credential by ID without turning corruption into a
+    /// misleading "not found" response. Invalid siblings remain isolated.
+    pub fn get_key_by_id_checked(&self, key_id: &str) -> Result<Option<ModelKey>, String> {
+        let loaded = self.load_store_checked()?;
+        loaded.log_diagnostics(&self.storage_file);
+
+        if let Some(key) = loaded.store.get_by_id(key_id).cloned() {
+            return Ok(Some(key));
+        }
+        if let Some(error) = loaded.invalid_credential_error(key_id) {
+            return Err(error);
+        }
+        loaded.ensure_any_valid_credentials(&self.storage_file)?;
+
+        Ok(None)
     }
 
     /// Get key by agent type and optional ID
@@ -1131,20 +1254,64 @@ impl KeyService {
     }
 }
 
-fn deserialize_key_store(contents: &str) -> Result<KeyStore, serde_json::Error> {
+fn deserialize_key_store(contents: &str) -> Result<LoadedKeyStore, serde_json::Error> {
     let mut value = serde_json::from_str::<serde_json::Value>(contents)?;
-    if let Some(credentials) = value
+    let credentials = value
         .get_mut("credentials")
         .and_then(serde_json::Value::as_object_mut)
-    {
-        credentials.retain(|_, credential| {
-            credential
-                .get("model_type")
-                .and_then(serde_json::Value::as_str)
-                != Some("gemini_cli")
-        });
+        .map(std::mem::take)
+        .unwrap_or_default();
+
+    // Parse the envelope separately from its entries. One unsupported or
+    // malformed credential must not poison every valid sibling in the vault.
+    let mut store = serde_json::from_value::<KeyStore>(value)?;
+    let mut invalid_credentials = Vec::new();
+    let mut retired_credential_count = 0;
+
+    for (storage_id, raw) in credentials {
+        let agent_type = raw.get("agent_type").and_then(JsonValue::as_str);
+        if agent_type.is_some_and(|value| RETIRED_MODEL_TYPES.contains(&value)) {
+            retired_credential_count += 1;
+            continue;
+        }
+
+        match serde_json::from_value::<ModelKey>(raw.clone()) {
+            Ok(key) => {
+                store.keys.insert(storage_id, key);
+            }
+            Err(error) => invalid_credentials.push(InvalidStoredCredential {
+                id: storage_id,
+                raw,
+                error: error.to_string(),
+            }),
+        }
     }
-    serde_json::from_value(value)
+
+    Ok(LoadedKeyStore {
+        store,
+        invalid_credentials,
+        retired_credential_count,
+    })
+}
+
+fn serialize_key_store(
+    store: &KeyStore,
+    invalid_credentials: &[InvalidStoredCredential],
+) -> Result<String, String> {
+    let mut value = serde_json::to_value(store).map_err(|error| error.to_string())?;
+    let credentials = value
+        .get_mut("credentials")
+        .and_then(JsonValue::as_object_mut)
+        .ok_or_else(|| "serialized KeyStore has no credentials object".to_string())?;
+
+    // Valid entries win if a previously invalid id is repaired explicitly.
+    for credential in invalid_credentials {
+        credentials
+            .entry(credential.id.clone())
+            .or_insert_with(|| credential.raw.clone());
+    }
+
+    serde_json::to_string_pretty(&value).map_err(|error| error.to_string())
 }
 
 fn parse_codex_refresh_error(body: &str) -> String {

--- a/src-tauri/crates/key-vault/src/key_store/tests/tests.rs
+++ b/src-tauri/crates/key-vault/src/key_store/tests/tests.rs
@@ -76,7 +76,7 @@ fn retired_gemini_cli_credentials_do_not_corrupt_the_vault() {
         .unwrap();
     let mut retired = credentials.get(&codex_id).unwrap().clone();
     retired["id"] = serde_json::Value::String("retired-gemini-cli".to_string());
-    retired["model_type"] = serde_json::Value::String("gemini_cli".to_string());
+    retired["agent_type"] = serde_json::Value::String("gemini_cli".to_string());
     credentials.insert("retired-gemini-cli".to_string(), retired);
     std::fs::write(&storage_file, serde_json::to_vec_pretty(&stored).unwrap()).unwrap();
 
@@ -89,6 +89,82 @@ fn retired_gemini_cli_credentials_do_not_corrupt_the_vault() {
         .unwrap();
     let persisted = std::fs::read_to_string(storage_file).unwrap();
     assert!(!persisted.contains("gemini_cli"));
+}
+
+#[test]
+fn invalid_credential_does_not_hide_valid_siblings_and_survives_writes() {
+    let temp_dir = tempdir().unwrap();
+    let service = KeyService::new(Some(temp_dir.path().to_path_buf()));
+
+    let codex_key = ModelKey::new(ModelType::Codex);
+    let codex_id = codex_key.id.clone();
+    service.save_key(codex_key).unwrap();
+
+    let storage_file = temp_dir.path().join("credentials.json");
+    let mut stored: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&storage_file).unwrap()).unwrap();
+    let credentials = stored
+        .get_mut("credentials")
+        .and_then(serde_json::Value::as_object_mut)
+        .unwrap();
+    let mut future_credential = credentials.get(&codex_id).unwrap().clone();
+    future_credential["id"] = serde_json::Value::String("future-account".to_string());
+    future_credential["agent_type"] = serde_json::Value::String("future_provider".to_string());
+    credentials.insert("future-account".to_string(), future_credential.clone());
+    std::fs::write(&storage_file, serde_json::to_vec_pretty(&stored).unwrap()).unwrap();
+
+    let keys = service.list_keys_checked().unwrap();
+    assert_eq!(keys.len(), 1);
+    assert_eq!(keys[0].model_type, ModelType::Codex);
+    assert!(service
+        .get_key_checked(&ModelType::Codex, Some(&codex_id))
+        .unwrap()
+        .is_some());
+    let invalid_error = service.get_key_by_id_checked("future-account").unwrap_err();
+    assert!(invalid_error.contains("is invalid and was preserved"));
+
+    service
+        .save_key(ModelKey::new(ModelType::AnthropicApi))
+        .unwrap();
+    let persisted: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(storage_file).unwrap()).unwrap();
+    assert_eq!(
+        persisted["credentials"]["future-account"],
+        future_credential
+    );
+    assert_eq!(
+        persisted["credentials"].as_object().unwrap().len(),
+        3,
+        "two valid credentials plus the preserved future credential"
+    );
+}
+
+#[test]
+fn checked_list_reports_when_every_credential_is_invalid() {
+    let temp_dir = tempdir().unwrap();
+    let service = KeyService::new(Some(temp_dir.path().to_path_buf()));
+
+    let key = service.save_key(ModelKey::new(ModelType::Codex)).unwrap();
+    let storage_file = temp_dir.path().join("credentials.json");
+    let mut stored: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&storage_file).unwrap()).unwrap();
+    stored["credentials"][&key.id]["agent_type"] =
+        serde_json::Value::String("future_provider".to_string());
+    std::fs::write(&storage_file, serde_json::to_vec_pretty(&stored).unwrap()).unwrap();
+
+    let error = service.list_keys_checked().unwrap_err();
+    assert!(error.contains("No valid credentials could be loaded"));
+    assert!(error.contains("1 invalid credential(s) were preserved"));
+}
+
+#[test]
+fn checked_list_reports_malformed_root_json() {
+    let temp_dir = tempdir().unwrap();
+    let service = KeyService::new(Some(temp_dir.path().to_path_buf()));
+    std::fs::write(temp_dir.path().join("credentials.json"), "{").unwrap();
+
+    let error = service.list_keys_checked().unwrap_err();
+    assert!(error.contains("Corrupted credentials file"));
 }
 
 #[test]
@@ -357,11 +433,10 @@ fn test_update_key_health_preserves_context_window_without_model_refresh() {
     );
 }
 
-/// Debug test to check parsing of real credentials file
+/// E2E coverage for the same tolerant loader used by the Tauri `list_keys`
+/// command. Never print raw file contents: they contain live secrets.
 #[test]
 fn test_parse_real_credentials_file() {
-    use std::fs;
-
     let creds_path = app_paths::keys();
 
     if !creds_path.exists() {
@@ -372,31 +447,10 @@ fn test_parse_real_credentials_file() {
     println!("\n=== Parsing Real Credentials File ===\n");
     println!("Path: {:?}", creds_path);
 
-    let contents = fs::read_to_string(&creds_path).expect("Failed to read file");
-    println!("File size: {} bytes", contents.len());
-
-    // Try to parse
-    match serde_json::from_str::<KeyStore>(&contents) {
-        Ok(store) => {
-            println!("SUCCESS: Parsed {} keys", store.keys.len());
-            for (id, cred) in &store.keys {
-                println!(
-                    "  - [{}] {} ({:?})",
-                    id,
-                    cred.name.as_deref().unwrap_or("unnamed"),
-                    cred.model_type
-                );
-            }
-        }
-        Err(e) => {
-            println!("PARSE ERROR: {}", e);
-            // Try to identify the issue
-            println!(
-                "\nFirst 1000 chars of file:\n{}",
-                &contents[..contents.len().min(1000)]
-            );
-        }
-    }
+    let keys = KEY_SERVICE
+        .list_keys_checked()
+        .expect("production Key Vault loader should read real credentials");
+    println!("SUCCESS: Parsed {} valid keys", keys.len());
 
     println!("\n=== Parse Test Complete ===\n");
 }

--- a/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/TwoColumnModelBody.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/TwoColumnModelBody.tsx
@@ -39,6 +39,12 @@ export interface TwoColumnModelBodyProps {
   selectedSourceIndex: number;
   /** Whether a model row currently owns the left-column cursor. */
   hasFocusedModel: boolean;
+  /** Whether the Key Vault account list is currently loading. */
+  accountsLoading: boolean;
+  /** Key Vault account-list load error. */
+  accountsError: string | null;
+  /** Retry loading Key Vault accounts after an error. */
+  onRetryAccounts: () => void;
   onSourceSelect: (index: number) => void;
   onSourceHover: (index: number) => void;
 }
@@ -117,6 +123,9 @@ export const TwoColumnModelBody: React.FC<TwoColumnModelBodyProps> = ({
   sourceItems,
   selectedSourceIndex,
   hasFocusedModel,
+  accountsLoading,
+  accountsError,
+  onRetryAccounts,
   onSourceSelect,
   onSourceHover,
 }) => {
@@ -210,12 +219,26 @@ export const TwoColumnModelBody: React.FC<TwoColumnModelBodyProps> = ({
               style={{ height: COLUMN_HEIGHT }}
             >
               <Placeholder
-                variant={searchQuery.trim() ? "no-results" : "empty"}
+                variant={
+                  searchQuery.trim()
+                    ? "no-results"
+                    : accountsLoading
+                      ? "loading"
+                      : accountsError
+                        ? "error"
+                        : "empty"
+                }
                 title={
                   searchQuery.trim()
                     ? t("common:common.noResults")
-                    : t("placeholders.noItemsAvailable")
+                    : accountsLoading
+                      ? t("placeholders.loading")
+                      : accountsError
+                        ? t("placeholders.failedToLoad")
+                        : t("placeholders.noItemsAvailable")
                 }
+                subtitle={accountsError ?? undefined}
+                onRetry={accountsError ? onRetryAccounts : undefined}
                 placement="sidebar"
               />
             </div>

--- a/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/UnifiedModelDropdown.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/UnifiedModelDropdown.tsx
@@ -32,6 +32,7 @@ import {
 } from "@src/hooks/dropdown";
 import { useTauriSelectAllShortcut } from "@src/hooks/keyboard";
 import { useFilteredItems } from "@src/hooks/search";
+import { Placeholder } from "@src/modules/shared/layouts/blocks";
 import { getViewportSize } from "@src/util/ui/window/viewport";
 
 import type { SpotlightItem } from "../../shared";
@@ -184,6 +185,10 @@ export const UnifiedModelDropdown: React.FC<UnifiedModelDropdownProps> = ({
     allHeader,
     sourceItems,
     selectedModelId,
+    accountsLoading,
+    accountsError,
+    refreshAllModels,
+    refreshingAllModels,
     tCommon,
   } = useUnifiedModelPalette({
     isOpen,
@@ -490,7 +495,30 @@ export const UnifiedModelDropdown: React.FC<UnifiedModelDropdownProps> = ({
           className={DROPDOWN_CLASSES.optionsContainerOverlay}
           style={{ maxHeight: LIST_MAX_HEIGHT }}
         >
-          {filteredItems.length === 0 ? (
+          {filteredItems.length === 0 &&
+          (accountsLoading || refreshingAllModels || accountsError) ? (
+            <div className="min-h-24">
+              <Placeholder
+                variant={
+                  accountsLoading || refreshingAllModels ? "loading" : "error"
+                }
+                title={
+                  accountsLoading || refreshingAllModels
+                    ? tCommon("placeholders.loading")
+                    : tCommon("placeholders.failedToLoad")
+                }
+                subtitle={accountsError ?? undefined}
+                onRetry={
+                  accountsError
+                    ? () => {
+                        void refreshAllModels();
+                      }
+                    : undefined
+                }
+                placement="sidebar"
+              />
+            </div>
+          ) : filteredItems.length === 0 ? (
             <div className={DROPDOWN_CLASSES.listMessage}>
               {tCommon("selectors.modelSelector.noResults")}
             </div>

--- a/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/index.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/index.tsx
@@ -72,6 +72,8 @@ export const UnifiedModelPalette: React.FC<UnifiedModelPaletteProps> = ({
     sourceItems,
     previewModel,
     handleBack,
+    accountsLoading,
+    accountsError,
     refreshAllModels,
     refreshingAllModels,
     tCommon: tCommonHook,
@@ -356,6 +358,11 @@ export const UnifiedModelPalette: React.FC<UnifiedModelPaletteProps> = ({
       sourceItems={sourceItems}
       selectedSourceIndex={selectedSourceIndex}
       hasFocusedModel={selectedModelId !== null}
+      accountsLoading={accountsLoading || refreshingAllModels}
+      accountsError={accountsError}
+      onRetryAccounts={() => {
+        void refreshAllModels();
+      }}
       onSourceSelect={(index) => {
         const source = sourceItems[index];
         source?.action?.();

--- a/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/modelAccountRefresh.test.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/modelAccountRefresh.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { KeyVaultAccount } from "@src/hooks/keyVault";
+
+import { refreshModelAccounts } from "./modelAccountRefresh";
+
+describe("refreshModelAccounts", () => {
+  it("reloads the Key Vault instead of no-oping when the account list is empty", async () => {
+    const reloadAccounts = vi.fn(async () => undefined);
+    const refreshLoadedAccounts = vi.fn(async () => ({
+      total: 0,
+      failed: 0,
+      added: 0,
+      removed: 0,
+    }));
+
+    const summary = await refreshModelAccounts(
+      [],
+      reloadAccounts,
+      refreshLoadedAccounts
+    );
+
+    expect(summary).toBeNull();
+    expect(reloadAccounts).toHaveBeenCalledOnce();
+    expect(refreshLoadedAccounts).not.toHaveBeenCalled();
+  });
+
+  it("refreshes loaded model catalogs before reloading persisted accounts", async () => {
+    const account = { id: "account-1" } as KeyVaultAccount;
+    const calls: string[] = [];
+    const refreshLoadedAccounts = vi.fn(async () => {
+      calls.push("models");
+      return { total: 1, failed: 0, added: 2, removed: 1 };
+    });
+    const reloadAccounts = vi.fn(async () => {
+      calls.push("accounts");
+    });
+
+    const summary = await refreshModelAccounts(
+      [account],
+      reloadAccounts,
+      refreshLoadedAccounts
+    );
+
+    expect(summary).toEqual({ total: 1, failed: 0, added: 2, removed: 1 });
+    expect(calls).toEqual(["models", "accounts"]);
+  });
+});

--- a/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/modelAccountRefresh.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/modelAccountRefresh.ts
@@ -1,0 +1,29 @@
+import type { KeyVaultAccount } from "@src/hooks/keyVault";
+import {
+  type RefreshAllAccountModelsSummary,
+  refreshAllAccountModels,
+} from "@src/modules/MainApp/Integrations/KeyVault/hooks/refreshAccountModels";
+
+type ReloadAccounts = () => Promise<void>;
+type RefreshLoadedAccounts = (
+  accounts: KeyVaultAccount[]
+) => Promise<RefreshAllAccountModelsSummary>;
+
+/**
+ * Recover the account list when it is empty; otherwise refresh every loaded
+ * account's model catalog and then reload the persisted Key Vault state.
+ */
+export async function refreshModelAccounts(
+  accounts: KeyVaultAccount[],
+  reloadAccounts: ReloadAccounts,
+  refreshLoadedAccounts: RefreshLoadedAccounts = refreshAllAccountModels
+): Promise<RefreshAllAccountModelsSummary | null> {
+  if (accounts.length === 0) {
+    await reloadAccounts();
+    return null;
+  }
+
+  const summary = await refreshLoadedAccounts(accounts);
+  await reloadAccounts();
+  return summary;
+}

--- a/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/useUnifiedModelPalette.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/useUnifiedModelPalette.tsx
@@ -39,6 +39,8 @@ export function useUnifiedModelPalette({
     recentEntries,
     recordRecent,
     saveKey,
+    accountsLoading,
+    accountsError,
     refreshAllModels,
     refreshingAllModels,
   } = useUnifiedModelPaletteData({
@@ -122,6 +124,8 @@ export function useUnifiedModelPalette({
     previewModel,
     handleModelPreview,
     handleBack,
+    accountsLoading,
+    accountsError,
     refreshAllModels,
     refreshingAllModels,
     tCommon,

--- a/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/useUnifiedModelPaletteData.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/useUnifiedModelPaletteData.ts
@@ -26,7 +26,6 @@ import { buildAccountLookup } from "@src/hooks/models/useModelAccountLookup";
 import { useOrgiiPoolCategories } from "@src/hooks/models/useOrgiiPoolCategories";
 import {
   formatRefreshSummary,
-  refreshAllAccountModels,
   refreshSummaryTone,
 } from "@src/modules/MainApp/Integrations/KeyVault/hooks/refreshAccountModels";
 import {
@@ -38,6 +37,8 @@ import {
   recentModelEntriesAtom,
   recordRecentEntry,
 } from "@src/store/session/recentModelEntriesAtom";
+
+import { refreshModelAccounts } from "./modelAccountRefresh";
 
 // ── Hook ──────────────────────────────────────────────────────────────────────
 
@@ -78,6 +79,10 @@ export interface UnifiedModelPaletteData {
    * that never refreshes until the palette is reopened.
    */
   saveKey: UseKeyVaultReturn["saveKey"];
+  /** True while the persisted Key Vault account list is loading. */
+  accountsLoading: boolean;
+  /** Account-list load failure, if the last attempt failed. */
+  accountsError: string | null;
   /** Refresh available models for every loaded account. */
   refreshAllModels: () => Promise<void>;
   /** True while {@link refreshAllModels} is running. */
@@ -108,6 +113,8 @@ export function useUnifiedModelPaletteData({
     accounts: allAccounts,
     saveKey,
     refresh,
+    loading: accountsLoading,
+    error: accountsError,
   } = useKeyVault({ autoLoad: isOpen });
 
   const [refreshingAllModels, setRefreshingAllModels] = useState(false);
@@ -136,15 +143,15 @@ export function useUnifiedModelPaletteData({
   );
 
   const refreshAllModels = useCallback(async () => {
-    if (allAccounts.length === 0) return;
     setRefreshingAllModels(true);
     try {
-      const summary = await refreshAllAccountModels(allAccounts);
-      await refresh();
-      Message[refreshSummaryTone(summary)](
-        formatRefreshSummary(summary, t),
-        5000
-      );
+      const summary = await refreshModelAccounts(allAccounts, refresh);
+      if (summary) {
+        Message[refreshSummaryTone(summary)](
+          formatRefreshSummary(summary, t),
+          5000
+        );
+      }
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
       Message.error(
@@ -168,6 +175,8 @@ export function useUnifiedModelPaletteData({
     recentEntries,
     recordRecent,
     saveKey,
+    accountsLoading,
+    accountsError,
     refreshAllModels,
     refreshingAllModels,
   };


### PR DESCRIPTION
## Summary

- parse Key Vault credentials entry-by-entry so one invalid or unsupported account cannot hide valid siblings
- preserve unknown raw credential entries across later writes while intentionally dropping retired `gemini_cli` entries
- propagate unrecoverable vault errors through the user-facing Tauri list/get/save paths
- show loading, failure, and retry states in the unified Model Picker
- reload the Key Vault when the model-account list is empty instead of treating refresh as a no-op

## Root cause

A retired `gemini_cli` credential was stored under the serialized `agent_type` field, but the compatibility filter checked `model_type`. Deserializing the credential map atomically then failed on that one unknown enum variant, and the read path silently fell back to an empty store, making the Model Picker appear blank.

## User impact

Valid model accounts remain selectable even when one persisted credential is malformed or belongs to a future provider. Unknown entries are retained for forward compatibility, and genuinely unrecoverable files now produce a retryable error instead of a misleading empty state.

## Validation

- `cargo test -p key_vault key_store::tests::tests:: -- --nocapture` — 45 passed
- `cargo check -p key_vault` — passed
- `pnpm vitest run src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/modelAccountRefresh.test.ts src/hooks/models/useModelAccountLookup.test.ts` — 7 passed
- real local credentials E2E — 8 valid accounts loaded while retired entries were isolated
- full `key_vault` suite — 260 passed; 2 pre-existing unrelated failures remain in Prompt Polish think-block cleanup and Sonnet effort ladder expectations
- strict Clippy remains blocked by pre-existing warnings outside the new code