### PR TITLE
fix(perf): eliminate idle CPU storms in session creator

### DIFF
--- a/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.tsx
+++ b/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.tsx
@@ -11,7 +11,14 @@
  */
 import { useAtom, useAtomValue } from "jotai";
 import { Layout, MoreHorizontal } from "lucide-react";
-import React, { memo, useCallback, useMemo, useRef, useState } from "react";
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
@@ -185,13 +192,34 @@ const PinnedActionsBar: React.FC<PinnedActionsBarProps> = memo(
       return map;
     }, [availableItems]);
 
+    // Resolve pinned skill paths lazily: only scan when a pinned skill is
+    // missing its `skillPath` (needed for the hover preview). Pinned actions
+    // that already carry a path — the common case — never trigger a scan, so
+    // mounting the input stays free. The scan itself is bounded/coalesced by
+    // the shared scanner, and the full "…" panel list still loads on open.
+    const unresolvedPinnedSkillsKey = useMemo(
+      () =>
+        pinnedActions
+          .filter((action) => action.category === "skill" && !action.skillPath)
+          .map((action) => action.skillName ?? action.name)
+          .sort()
+          .join("\0"),
+      [pinnedActions]
+    );
+
+    useEffect(() => {
+      if (!unresolvedPinnedSkillsKey) return;
+      void fetchFresh();
+    }, [unresolvedPinnedSkillsKey, fetchFresh]);
+
     // ── "..." panel state ─────────────────────────────────────────────────────
 
     const [panelOpen, setPanelOpen] = useState(false);
     const moreButtonRef = useRef<HTMLButtonElement>(null);
 
     const handleOpenPanel = useCallback(() => {
-      void fetchFresh();
+      // Explicit user action → get a fresh list (still coalesced).
+      void fetchFresh({ force: true });
       setPanelOpen((prev) => !prev);
     }, [fetchFresh]);
 

--- a/src/engines/ChatPanel/hooks/useInputArea/useSlashItemsCache.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/useSlashItemsCache.ts
@@ -12,10 +12,12 @@
  *  - The hook maintains a warm in-memory cache via `itemsCacheRef`.
  *  - `prefetch(query)` shows cached items immediately, then fires a fresh
  *    fetch in the background and updates `filteredItems`.
- *  - `fetchFresh()` always hits the backend; the caller can await it.
+ *  - `fetchFresh()` refreshes the list (bounded by the shared skills scanner's
+ *    TTL + coalescing; pass `{ force: true }` to bypass the TTL). Awaitable.
+ *  - Skill scans are lazy: mounting the hook does NOT scan — the backend
+ *    `skills_list` fires only on `prefetch`/`fetchFresh`.
  *  - A `cancelledRef` prevents setState after unmount.
  */
-import { invoke } from "@tauri-apps/api/core";
 import { useSetAtom } from "jotai";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -26,6 +28,7 @@ import {
 } from "@src/engines/ChatPanel/InputArea/components/SlashCommandPortal/slashItemUtils";
 import { createLogger } from "@src/hooks/logger";
 import { mergeInstalledSkills } from "@src/hooks/skills/installedSkillsMerge";
+import { scanInstalledSkills } from "@src/hooks/skills/installedSkillsScan";
 import { installedSkillsAtom } from "@src/store/skills/installedSkillsAtom";
 import { type InstalledSkill, type SlashItem } from "@src/types/extensions";
 
@@ -115,8 +118,12 @@ export interface UseSlashItemsCacheReturn {
    * backend fetch and update `filteredItems` when it resolves.
    */
   prefetch: (query: string) => void;
-  /** Fire a fresh backend fetch unconditionally, update the full item list when it changed, and return it. */
-  fetchFresh: () => Promise<SlashItem[]>;
+  /**
+   * Fetch the full item list and update it when it changed. Bounded by the
+   * shared scanner's TTL + in-flight coalescing; pass `{ force: true }` to
+   * bypass the TTL (e.g. an explicit "…" panel open).
+   */
+  fetchFresh: (options?: { force?: boolean }) => Promise<SlashItem[]>;
 }
 
 export function useSlashItemsCache(
@@ -138,108 +145,103 @@ export function useSlashItemsCache(
   const builtinItemsRef = useRef(builtinItems);
   builtinItemsRef.current = builtinItems;
 
-  const doFetch = useCallback(async (): Promise<SlashItem[]> => {
-    setLoading(true);
-    try {
-      const scopePaths = workspacePathsKey ? workspacePathsKey.split("\0") : [];
-      const skillListTasks = [
-        invoke<InstalledSkill[]>("skills_list", { workspacePath: null }),
-        ...scopePaths.map((path) =>
-          invoke<InstalledSkill[]>("skills_list", { workspacePath: path })
-        ),
-      ];
-      const [skillResults, mcpServers] = await Promise.all([
-        Promise.allSettled(skillListTasks),
-        rpc.mcp.listServers({}).catch((err) => {
-          logger.warn("Failed to list MCP servers for slash menu:", err);
-          return [];
-        }),
-      ]);
+  const doFetch = useCallback(
+    async (force = false): Promise<SlashItem[]> => {
+      setLoading(true);
+      try {
+        const scopePaths = workspacePathsKey
+          ? workspacePathsKey.split("\0")
+          : [];
+        // Skills are scanned through the bounded shared scanner (coalesces
+        // concurrent callers, reuses a recent result within the TTL) so opening
+        // the menu/panel repeatedly can never hammer the backend `skills_list`.
+        const [rawSkills, mcpServers] = await Promise.all([
+          scanInstalledSkills(scopePaths, { force }),
+          rpc.mcp.listServers({}).catch((err) => {
+            logger.warn("Failed to list MCP servers for slash menu:", err);
+            return [];
+          }),
+        ]);
 
-      const rawSkills = mergeInstalledSkills(
-        skillResults.flatMap((result) => {
-          if (result.status === "fulfilled") return [result.value];
-          logger.warn("Failed to list skills for slash menu:", result.reason);
-          return [];
-        })
-      );
-      const workspaceSkillRoots = scopePaths.map(normalizeWorkspacePath);
-      logger.rateLimited("slash-skills-scan", 5_000, "slash skills fetched", {
-        workspacePaths: workspaceSkillRoots,
-        skillCount: rawSkills.length,
-        workspaceSkillCount: rawSkills.filter((skill) =>
-          isWorkspaceSkill(skill, workspaceSkillRoots)
-        ).length,
-        skillPaths: rawSkills.map((skill) => skill.path),
-      });
+        const workspaceSkillRoots = scopePaths.map(normalizeWorkspacePath);
+        logger.rateLimited("slash-skills-scan", 5_000, "slash skills fetched", {
+          workspacePaths: workspaceSkillRoots,
+          skillCount: rawSkills.length,
+          workspaceSkillCount: rawSkills.filter((skill) =>
+            isWorkspaceSkill(skill, workspaceSkillRoots)
+          ).length,
+          skillPaths: rawSkills.map((skill) => skill.path),
+        });
 
-      if (rawSkills.length > 0) {
-        setInstalledSkills((current) =>
-          mergeInstalledSkills([current, rawSkills])
+        if (rawSkills.length > 0) {
+          setInstalledSkills((current) =>
+            mergeInstalledSkills([current, rawSkills])
+          );
+        }
+
+        const skillItems: SlashItem[] = rawSkills
+          .filter((s) => s.enabled)
+          .map((s) => ({
+            name: s.name,
+            skillName: s.name,
+            skillPath: s.path,
+            description: normalizeSkillDescription(s),
+            category: "skill" as const,
+            source: resolveSkillGroup(s),
+            acceptsArgs: false,
+            skillScope: isWorkspaceSkill(s, workspaceSkillRoots)
+              ? "workspace"
+              : "user",
+          }));
+
+        const connectedServers = mcpServers.filter(
+          (srv) => srv.status === "connected" && !srv.disabled
         );
-      }
 
-      const skillItems: SlashItem[] = rawSkills
-        .filter((s) => s.enabled)
-        .map((s) => ({
-          name: s.name,
-          skillName: s.name,
-          skillPath: s.path,
-          description: normalizeSkillDescription(s),
-          category: "skill" as const,
-          source: resolveSkillGroup(s),
-          acceptsArgs: false,
-          skillScope: isWorkspaceSkill(s, workspaceSkillRoots)
-            ? "workspace"
-            : "user",
-        }));
-
-      const connectedServers = mcpServers.filter(
-        (srv) => srv.status === "connected" && !srv.disabled
-      );
-
-      const toolItems: SlashItem[] = (
-        await Promise.all(
-          connectedServers.map((srv) =>
-            rpc.mcp.listServerTools({ serverName: srv.name }).then(
-              (tools) =>
-                tools.map((tool) => ({
-                  name: tool.name,
-                  description: tool.description,
-                  category: "tool" as const,
-                  source: srv.name,
-                  acceptsArgs: true,
-                  serverName: srv.name,
-                })),
-              (err) => {
-                logger.warn(
-                  `Failed to list tools for MCP server "${srv.name}":`,
-                  err
-                );
-                return [] as SlashItem[];
-              }
+        const toolItems: SlashItem[] = (
+          await Promise.all(
+            connectedServers.map((srv) =>
+              rpc.mcp.listServerTools({ serverName: srv.name }).then(
+                (tools) =>
+                  tools.map((tool) => ({
+                    name: tool.name,
+                    description: tool.description,
+                    category: "tool" as const,
+                    source: srv.name,
+                    acceptsArgs: true,
+                    serverName: srv.name,
+                  })),
+                (err) => {
+                  logger.warn(
+                    `Failed to list tools for MCP server "${srv.name}":`,
+                    err
+                  );
+                  return [] as SlashItem[];
+                }
+              )
             )
           )
-        )
-      ).flat();
+        ).flat();
 
-      const assembled: SlashItem[] = [
-        ...builtinItemsRef.current,
-        ...skillItems,
-        ...toolItems,
-      ];
+        const assembled: SlashItem[] = [
+          ...builtinItemsRef.current,
+          ...skillItems,
+          ...toolItems,
+        ];
 
-      setScopedSlashItemsCache(workspacePathsKey, assembled);
-      if (!cancelledRef.current) {
-        itemsCacheRef.current = assembled;
+        setScopedSlashItemsCache(workspacePathsKey, assembled);
+        if (!cancelledRef.current) {
+          itemsCacheRef.current = assembled;
+        }
+        return assembled;
+      } finally {
+        if (!cancelledRef.current) {
+          setLoading(false);
+        }
       }
-      return assembled;
-    } finally {
-      if (!cancelledRef.current) {
-        setLoading(false);
-      }
-    }
-  }, [setInstalledSkills, workspacePathsKey]);
+    },
+    [setInstalledSkills, workspacePathsKey]
+  );
 
   const prefetch = useCallback(
     (_query: string) => {
@@ -262,37 +264,34 @@ export function useSlashItemsCache(
     [doFetch, workspacePathsKey]
   );
 
-  const fetchFresh = useCallback(async (): Promise<SlashItem[]> => {
-    const currentItems = itemsCacheRef.current;
-    const items = await doFetch();
-    if (!cancelledRef.current && !slashItemsEqual(currentItems, items)) {
-      setFilteredItems(items);
-    }
-    return items;
-  }, [doFetch]);
+  const fetchFresh = useCallback(
+    async (options?: { force?: boolean }): Promise<SlashItem[]> => {
+      const currentItems = itemsCacheRef.current;
+      const items = await doFetch(options?.force ?? false);
+      if (!cancelledRef.current && !slashItemsEqual(currentItems, items)) {
+        setFilteredItems(items);
+      }
+      return items;
+    },
+    [doFetch]
+  );
 
-  // Warm the cache and refresh when the active repo/workspace scope changes.
+  // Lazy warm-up: when the active repo/workspace scope changes, only paint the
+  // cached items for that scope (instant, no IPC). The actual backend scan is
+  // deferred until the user opens the "/" menu (`prefetch`) or the "…" panel
+  // (`fetchFresh`), or a pinned skill needs resolving — so simply mounting the
+  // chat input no longer triggers a `skills_list` scan.
   useEffect(() => {
     cancelledRef.current = false;
-    const currentFetchSeq = fetchSeqRef.current + 1;
-    fetchSeqRef.current = currentFetchSeq;
     const cachedItems = slashItemsCacheByScope.get(workspacePathsKey) ?? [];
     if (cachedItems.length > 0) {
       itemsCacheRef.current = cachedItems;
       setFilteredItems(cachedItems);
     }
-    doFetch().then((items) => {
-      if (cancelledRef.current || fetchSeqRef.current !== currentFetchSeq) {
-        return;
-      }
-      if (cachedItems.length === 0 || !slashItemsEqual(cachedItems, items)) {
-        setFilteredItems(items);
-      }
-    });
     return () => {
       cancelledRef.current = true;
     };
-  }, [doFetch, workspacePathsKey]);
+  }, [workspacePathsKey]);
 
   return { filteredItems, loading, prefetch, fetchFresh };
 }

--- a/src/hooks/perf/useSidebarMemoryEntry.ts
+++ b/src/hooks/perf/useSidebarMemoryEntry.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import {
   type SidebarMemoryKind,
@@ -27,6 +27,18 @@ interface SidebarMemoryInput {
 export function useSidebarMemoryEntry(input: SidebarMemoryInput): void {
   const key = useMemo(() => Symbol(input.label), [input.label]);
 
+  // `source` is typically an inline object literal (fresh identity every
+  // render). Listing it as an effect dep re-ran the estimation — a graph
+  // walk of up to SIDEBAR_ESTIMATION_NODE_LIMIT nodes — on EVERY render,
+  // which turned render storms into heavy CPU burn. The estimate is an
+  // approximation keyed to the sidebar's shape, so re-running it when the
+  // primitive shape inputs (items/sections/tabs/label/kind) change is
+  // enough; the latest source is read through a ref.
+  const sourceRef = useRef(input.source);
+  useEffect(() => {
+    sourceRef.current = input.source;
+  });
+
   useEffect(() => {
     if (input.enabled === false) {
       removeSidebarMemoryEntry(key);
@@ -35,8 +47,9 @@ export function useSidebarMemoryEntry(input: SidebarMemoryInput): void {
 
     const sections = input.sections ?? 0;
     const tabs = input.tabs ?? 0;
-    const sourceBytes = input.source
-      ? estimateRuntimeValueBytes(input.source, SIDEBAR_ESTIMATION_NODE_LIMIT)
+    const source = sourceRef.current;
+    const sourceBytes = source
+      ? estimateRuntimeValueBytes(source, SIDEBAR_ESTIMATION_NODE_LIMIT)
       : 0;
     const renderBytes =
       SIDEBAR_BASE_RENDER_BYTES +
@@ -58,7 +71,6 @@ export function useSidebarMemoryEntry(input: SidebarMemoryInput): void {
     input.kind,
     input.label,
     input.sections,
-    input.source,
     input.tabs,
     key,
   ]);

--- a/src/hooks/skills/installedSkillsScan.ts
+++ b/src/hooks/skills/installedSkillsScan.ts
@@ -1,0 +1,123 @@
+/**
+ * Bounded, coalesced installed-skills scanner.
+ *
+ * `skills_list` is a filesystem scan on the Rust side. Several UI surfaces
+ * (the "/" slash menu, the pinned-actions "…" panel, the Skills manager) used
+ * to each fire it *eagerly on mount* and re-fire on scope churn — mounting a
+ * chat input therefore hammered the backend with repeated scans. This module
+ * funnels every scan through a single cache so that:
+ *   - concurrent scans of the same scope share one in-flight request, and
+ *   - repeat scans of a scope within {@link SKILLS_SCAN_TTL_MS} reuse the
+ *     cached result — unless `force` is set (e.g. right after an install /
+ *     toggle / delete, where the caller needs fresh data).
+ *
+ * Result: no surface can trigger unlimited scans, and callers stay lazy —
+ * they scan only when the user actually opens the menu/panel or when a pinned
+ * skill needs its path resolved.
+ */
+import { invoke } from "@tauri-apps/api/core";
+
+import { createLogger } from "@src/hooks/logger";
+import { mergeInstalledSkills } from "@src/hooks/skills/installedSkillsMerge";
+import type { InstalledSkill } from "@src/types/extensions";
+
+const logger = createLogger("installedSkillsScan");
+
+/** Reuse a scope's cached scan for this long before hitting the backend again. */
+export const SKILLS_SCAN_TTL_MS = 15_000;
+/** Cap the number of distinct workspace scopes we keep cached (LRU). */
+const MAX_SCOPE_CACHE_SIZE = 16;
+
+interface ScopeEntry {
+  items: InstalledSkill[];
+  fetchedAt: number;
+}
+
+const cacheByScope = new Map<string, ScopeEntry>();
+const inflightByScope = new Map<string, Promise<InstalledSkill[]>>();
+
+function normalizeWorkspacePath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function toScope(scopePaths: readonly string[]): {
+  key: string;
+  paths: string[];
+} {
+  const seen = new Set<string>();
+  for (const path of scopePaths) {
+    const normalized = normalizeWorkspacePath(path);
+    if (normalized) seen.add(normalized);
+  }
+  const paths = [...seen].sort();
+  return { key: paths.join("\0"), paths };
+}
+
+function rememberScope(key: string, items: InstalledSkill[]): void {
+  if (!cacheByScope.has(key)) {
+    while (cacheByScope.size >= MAX_SCOPE_CACHE_SIZE) {
+      const oldestKey = cacheByScope.keys().next().value;
+      if (oldestKey === undefined) break;
+      cacheByScope.delete(oldestKey);
+    }
+  }
+  cacheByScope.set(key, { items, fetchedAt: Date.now() });
+}
+
+/** Synchronously read the last cached scan for a scope, or `null` if none. */
+export function peekInstalledSkills(
+  scopePaths: readonly string[]
+): InstalledSkill[] | null {
+  const { key } = toScope(scopePaths);
+  return cacheByScope.get(key)?.items ?? null;
+}
+
+/**
+ * Scan installed skills for the given workspace scope. Always queries the
+ * global scope (`workspacePath: null`) plus each supplied path, then merges
+ * and de-dupes. Bounded: coalesces concurrent callers and reuses a recent
+ * result unless `force` is passed.
+ */
+export async function scanInstalledSkills(
+  scopePaths: readonly string[] = [],
+  options: { force?: boolean } = {}
+): Promise<InstalledSkill[]> {
+  const { force = false } = options;
+  const { key, paths } = toScope(scopePaths);
+
+  const inflight = inflightByScope.get(key);
+  if (inflight) return inflight;
+
+  if (!force) {
+    const cached = cacheByScope.get(key);
+    if (cached && Date.now() - cached.fetchedAt < SKILLS_SCAN_TTL_MS) {
+      return cached.items;
+    }
+  }
+
+  const run = (async () => {
+    const tasks: Promise<InstalledSkill[]>[] = [
+      invoke<InstalledSkill[]>("skills_list", { workspacePath: null }),
+      ...paths.map((path) =>
+        invoke<InstalledSkill[]>("skills_list", { workspacePath: path })
+      ),
+    ];
+    const results = await Promise.allSettled(tasks);
+    const lists: InstalledSkill[][] = [];
+    for (const result of results) {
+      if (result.status === "fulfilled") {
+        lists.push(result.value);
+      } else {
+        logger.warn("skills_list failed for a scope:", result.reason);
+      }
+    }
+    const merged = mergeInstalledSkills(lists);
+    rememberScope(key, merged);
+    return merged;
+  })().finally(() => {
+    inflightByScope.delete(key);
+  });
+
+  inflightByScope.set(key, run);
+  return run;
+}

--- a/src/hooks/skills/useSkillsHub.ts
+++ b/src/hooks/skills/useSkillsHub.ts
@@ -12,7 +12,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useMounted } from "@src/hooks/lifecycle/useMounted";
 import { createLogger } from "@src/hooks/logger";
-import { mergeInstalledSkills } from "@src/hooks/skills/installedSkillsMerge";
+import { scanInstalledSkills } from "@src/hooks/skills/installedSkillsScan";
 import {
   installedSkillsAtom,
   installedSkillsLoadingAtom,
@@ -82,31 +82,20 @@ export function useSkillsHub({
     "\0"
   );
 
-  const listInstalledSkills = useCallback(async (workspacePaths?: string[]) => {
-    // Always query the global scope; additionally query any workspace/repo
-    // paths so repo-scoped skills (`.<tool>/skills` and root `skills`)
-    // appear in the list — `skills_list(null)` only returns global + builtin skills.
-    const uniqueWorkspacePaths = getUniqueWorkspacePaths(workspacePaths ?? []);
-    const tasks: Promise<InstalledSkill[]>[] = [
-      invoke<InstalledSkill[]>("skills_list", { workspacePath: null }),
-    ];
-    for (const path of uniqueWorkspacePaths) {
-      tasks.push(
-        invoke<InstalledSkill[]>("skills_list", { workspacePath: path })
+  const listInstalledSkills = useCallback(
+    async (workspacePaths?: string[], options?: { force?: boolean }) => {
+      // Bounded/coalesced shared scan. Always queries the global scope plus any
+      // workspace/repo paths so repo-scoped skills (`.<tool>/skills` and root
+      // `skills`) appear. `force` bypasses the TTL after a mutation.
+      return scanInstalledSkills(
+        getUniqueWorkspacePaths(workspacePaths ?? []),
+        {
+          force: options?.force,
+        }
       );
-    }
-
-    const results = await Promise.allSettled(tasks);
-    const lists: InstalledSkill[][] = [];
-    for (const result of results) {
-      if (result.status === "fulfilled") {
-        lists.push(result.value);
-      } else {
-        log.error("[SkillsHub] skills_list failed:", result.reason);
-      }
-    }
-    return mergeInstalledSkills(lists);
-  }, []);
+    },
+    []
+  );
 
   const refreshInstalled = useCallback(
     async (extraWorkspacePaths?: string[], options?: { scoped?: boolean }) => {
@@ -125,7 +114,7 @@ export function useSkillsHub({
       const refreshSeq = ++refreshSeqRef.current;
       setInstalledLoading(true);
       try {
-        const result = await listInstalledSkills(scopePaths);
+        const result = await listInstalledSkills(scopePaths, { force: true });
         if (refreshSeq === refreshSeqRef.current) {
           setInstalledSkills(result);
         }
@@ -153,7 +142,7 @@ export function useSkillsHub({
       const retryDelaysMs = [100, 300, 700];
       for (const delayMs of retryDelaysMs) {
         await new Promise((resolve) => setTimeout(resolve, delayMs));
-        const result = await listInstalledSkills(scopePaths);
+        const result = await listInstalledSkills(scopePaths, { force: true });
         if (!result.some((skill) => skill.name === deletedName)) {
           setInstalledSkills(result);
           return;

--- a/src/scaffold/GlobalSpotlight/hooks/forms/useAddWorkspaceFlow.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/forms/useAddWorkspaceFlow.ts
@@ -291,21 +291,51 @@ export function useAddWorkspaceFlow(
     [getModalSourceLabel]
   );
 
+  // The form hooks return fresh object identities each render, so effects
+  // must read them through this ref instead of listing them as deps — a
+  // fresh-object dep re-runs the effect on EVERY render. That exact mistake
+  // in the reset effect below once produced a self-sustaining ~1000
+  // commits/s loop: resetForm()'s setState batch scheduled another render
+  // (React can't eagerly bail a multi-setState batch even when all values
+  // are unchanged), which re-created the form objects and re-fired the
+  // effect — pegging the webview at ~90% CPU whenever a closed
+  // WorkspacePalette was mounted (e.g. the session-creator repo pill).
+  const formsRef = useRef({
+    localWorkspaceForm,
+    cloneForm,
+    multiRepoWorkspaceForm,
+  });
+  useEffect(() => {
+    formsRef.current = {
+      localWorkspaceForm,
+      cloneForm,
+      multiRepoWorkspaceForm,
+    };
+  });
+
   useEffect(() => {
     if (!isDirectOpenStage(modalStage)) return;
 
     const initialPath = consumeDragDropInitialPath();
     setModalStage(null);
-    void localWorkspaceForm.handleOpenLocalWorkspace(initialPath);
-  }, [modalStage, localWorkspaceForm, setModalStage]);
+    void formsRef.current.localWorkspaceForm.handleOpenLocalWorkspace(
+      initialPath
+    );
+  }, [modalStage, setModalStage]);
+
+  // Reset the forms when the modal CLOSES (stage transitions to null) — not
+  // on every render while it is closed (see formsRef comment above).
+  const prevModalStageRef = useRef<AddWorkspaceModalStage>(modalStage);
 
   useEffect(() => {
-    if (!modalStage) {
-      localWorkspaceForm.resetForm();
-      cloneForm.resetForm();
-      multiRepoWorkspaceForm.resetForm();
+    const previousStage = prevModalStageRef.current;
+    prevModalStageRef.current = modalStage;
+    if (modalStage === null && previousStage !== null) {
+      formsRef.current.localWorkspaceForm.resetForm();
+      formsRef.current.cloneForm.resetForm();
+      formsRef.current.multiRepoWorkspaceForm.resetForm();
     }
-  }, [modalStage, localWorkspaceForm, cloneForm, multiRepoWorkspaceForm]);
+  }, [modalStage]);
 
   const hasAttemptedGitHubFetchRef = useRef(false);
   const cloneFormReposLength = cloneForm.repositories.length;

--- a/src/scaffold/GlobalSpotlight/hooks/selectors/useSelector.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/selectors/useSelector.ts
@@ -254,10 +254,17 @@ export function useSelector(options: UseSelectorOptions): UseSelectorReturn {
     }
   }, [itemsIdentityKey, findFirstSelectable]);
 
-  // Refocus input after DOM commits when the view changes
+  // Refocus input after DOM commits when the view changes. Two guards keep
+  // this from becoming a focus-steal loop (it once pegged the webview at
+  // ~90% CPU on the session-starter page):
+  //  - never run while closed — a closed palette must not steal focus from
+  //    the composer (the steal triggers re-renders that re-fire this effect);
+  //  - key on the items' CONTENT identity, not the array reference, which
+  //    changes on every parent render.
   useEffect(() => {
+    if (!isOpen) return;
     focusInput();
-  }, [focusTick, items, focusInput]);
+  }, [focusTick, itemsIdentityKey, isOpen, focusInput]);
 
   // Unified keyboard navigation with global listener support
   const { handleKeyDown: internalHandleKeyDown } = useListNavigation({

--- a/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/index.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/index.tsx
@@ -268,9 +268,13 @@ export const UnifiedModelPalette: React.FC<UnifiedModelPaletteProps> = ({
   }, [hoveredItem, previewModel]);
 
   useEffect(() => {
+    // Never steal focus while closed — a closed palette focusing its input
+    // yanks the caret from the composer (same class of bug as the
+    // WorkspacePalette focus loop).
+    if (!isOpen) return;
     kernel.focusInput();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeColumn]);
+  }, [activeColumn, isOpen]);
 
   const handleRemovePathSegment = useCallback(() => {
     onClose();


### PR DESCRIPTION
## Summary

The session-creator (start page Work tab, and any chat input) pegged the WebKit renderer at ~90% CPU and the Rust backend at ~30-60% while completely idle. Switching away dropped both to <1% instantly. Native sampling + a React commit probe traced it to three independent problems that compounded:

### 1. Closed-palette render loop (~1000 React commits/s) — root cause
`useAddWorkspaceFlow` reset its three forms on **every render** while the add-workspace modal was closed: the form hooks return fresh object identities each render and were listed as effect deps, and the `resetForm()` setState batch scheduled another render — a self-sustaining loop. The session-creator repo pill mounts a (closed) `WorkspacePalette`, so the Work tab spun while other tabs stayed idle; the loop also re-rendered the entire navigation sidebar every commit. Reset now fires only on the open → closed stage transition, with forms read through a ref.

### 2. Closed-palette focus steal (~700 `setTimeout(0)`/s)
`useSelector`'s refocus effect had no `isOpen` gate and used the raw `items` array as a dep, so closed palettes continuously stole focus from the composer. Now gated on `isOpen` and keyed on the items' content identity; `UnifiedModelPalette` gets the same guard.

### 3. Unbounded `skills_list` filesystem scans (backend CPU)
Every chat-input mount eagerly fired multi-path skill scans from three surfaces with no coalescing. Scans are now lazy (only on opening the `/` menu / "…" panel, or when a pinned skill needs its path resolved) and funneled through a shared bounded scanner (in-flight coalescing + 15s TTL + LRU-capped scopes; mutations bypass the TTL).

Also fixed the amplifier that made the render loop so expensive: `useSidebarMemoryEntry` re-ran its up-to-800-node object-graph size estimation on every render because callers pass `source` as an inline literal; it now re-runs only when the primitive shape inputs change.

## Verification

- Reproduced the storm with a native `sample` of the WebContent process + a temporary devtools-hook commit probe (~750-1200 commits/s, `UPDATERS: WorkspacePalette`); after the fixes the start page idles quietly and the backend `skills_list` log shows scans only on menu/panel open.
- `eslint` clean on all six files; `tsc --noEmit` introduces no new errors; `installedSkillsMerge` tests pass (7/7).

## Attribution note

Bug archaeology (upstream `yorg_frontend`): the reset loop landed in `a76028af98` ("Simplify workspace add flow", 2026-06-01), the focus effect in `2c32406d0e` (2026-02-22), the eager skill scan in `aafb433d8d` (2026-06-01), and the estimation amplifier in `da3a15332d` (2026-05-31) — three of the four landed in the 48h before the ORGII squash import, so none appear in this repo's history.
