### PR TITLE
fix(updater): handle stalled update downloads

### DIFF
--- a/docs/frontend-ui-audit-2026-07-16/AppUpdater.md
+++ b/docs/frontend-ui-audit-2026-07-16/AppUpdater.md
@@ -1,0 +1,41 @@
+# Frontend UI Audit — AppUpdater
+
+**File:** `src/scaffold/AppUpdater/index.tsx` (507 LOC)
+
+**Date:** 2026-07-16
+
+**Auditor:** Codex
+
+## D1 — Raw HTML vs Design System
+
+| Line | Element         | Verdict          | Reason                                                                                                                                     | Suggested change |
+| ---- | --------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| —    | Visible actions | keep with reason | Existing modal actions use `Button`, update preferences use `Checkbox`, and the download visualization is delegated to `DownloadProgress`. | —                |
+
+## D2 — Arbitrary Tailwind Value vs Token
+
+| Line | Value              | Verdict          | Reason                                                                         | Suggested change |
+| ---- | ------------------ | ---------------- | ------------------------------------------------------------------------------ | ---------------- |
+| —    | Changed updater UI | keep with reason | No new arbitrary Tailwind color or spacing values are introduced in this file. | —                |
+
+## D3 — Hardcoded Sizes / Colors
+
+| Line | Value              | Verdict          | Reason                                                                                                        | Suggested change |
+| ---- | ------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------- | ---------------- |
+| —    | Changed updater UI | keep with reason | Progress timing constants are behavioral values; visible sizing remains in existing design-system components. | —                |
+
+## D4 — Accessibility
+
+| Line   | Element                     | Verdict          | Reason                                                                                                                                                                  | Suggested change |
+| ------ | --------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| 82–119 | persistent notice lifecycle | keep with reason | Manual close collapses rather than cancels the operation; reopening restores the same live state, while the notice inherits the Message close button's accessible name. | —                |
+
+## D5 — Visual Patterns Observed
+
+- Persistent-notice-to-collapsed-orb behavior is unique to long-running app downloads; no three-site abstraction candidate.
+
+## Summary
+
+- 0 fixes recommended
+- 4 kept with documented reason
+- 0 abstract candidates

--- a/docs/frontend-ui-audit-2026-07-16/DownloadProgress.md
+++ b/docs/frontend-ui-audit-2026-07-16/DownloadProgress.md
@@ -1,0 +1,46 @@
+# Frontend UI Audit — DownloadProgress
+
+**File:** `src/scaffold/AppUpdater/DownloadProgress.tsx` (128 LOC)
+
+**Companion styles:** `src/scaffold/AppUpdater/DownloadProgress.scss` (118 LOC)
+
+**Date:** 2026-07-16
+
+**Auditor:** Codex
+
+## D1 — Raw HTML vs Design System
+
+| Line | Element                        | Verdict          | Reason                                                                                                                                                                                                | Suggested change |
+| ---- | ------------------------------ | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| 108  | `<button>` liquid download orb | keep with reason | The orb requires a clipped, percentage-driven liquid layer and fixed circular overlay geometry that the design-system `Button` content wrapper does not expose. Native button semantics are retained. | —                |
+
+## D2 — Arbitrary Tailwind Value vs Token
+
+| Line       | Value                                        | Verdict          | Reason                                                                                                                          | Suggested change |
+| ---------- | -------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| 104        | `--download-progress` inline custom property | keep with reason | This is runtime progress state, not a project-owned static design value; CSS consumes it as the liquid height.                  | —                |
+| SCSS 48–63 | primary-token gradient and wave mix          | keep with reason | Both colors come from project tokens; the mix supplies the translucent moving liquid edge and has no equivalent static utility. | —                |
+
+## D3 — Hardcoded Sizes / Colors
+
+| Line       | Value                  | Verdict          | Reason                                                                                                                                             | Suggested change |
+| ---------- | ---------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| SCSS 11–12 | `2.75rem` orb diameter | keep with reason | The 44px floating target is deliberately larger than the 40px large-button token and meets touch-target guidance while remaining visually compact. | —                |
+
+## D4 — Accessibility
+
+| Line    | Element               | Verdict          | Reason                                                                                                                                      | Suggested change |
+| ------- | --------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| 59–65   | progressbar semantics | keep with reason | Provides label, min/max, current value when determinate, and human-readable downloaded-size text.                                           | —                |
+| 108–126 | liquid orb button     | keep with reason | Uses native keyboard semantics, a progress-aware accessible name, visible focus treatment, decorative child layers, and reduced-motion CSS. | —                |
+
+## D5 — Visual Patterns Observed
+
+- Liquid-fill collapsed progress orb: one implementation; no abstraction candidate.
+- Linear progress uses the existing `ProgressBar` design-system component.
+
+## Summary
+
+- 0 fixes recommended
+- 5 kept with documented reason
+- 0 abstract candidates

--- a/docs/frontend-ui-audit-2026-07-16/Message.md
+++ b/docs/frontend-ui-audit-2026-07-16/Message.md
@@ -1,0 +1,44 @@
+# Frontend UI Audit — Message
+
+**File:** `src/components/Message/index.tsx` (428 LOC)
+
+**Date:** 2026-07-16
+
+**Auditor:** Codex
+
+## D1 — Raw HTML vs Design System
+
+| Line | Element                                | Verdict          | Reason                                                                                                                                                                                    | Suggested change |
+| ---- | -------------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| 219  | `<button>` compact cancel/retry action | keep with reason | Toast actions intentionally render as zero-padding inline links; the design-system `Button` adds a 24px minimum height and horizontal padding that changes this established toast layout. | —                |
+| 228  | `<button>` compact download action     | keep with reason | Same compact inline-action contract as cancel/retry, with visible text and native semantics.                                                                                              | —                |
+| 242  | `<button>` close control               | keep with reason | The control uses a 24px toast-specific alignment box with negative optical margins; the design-system circle button would change spacing inside the constrained notice row.               | —                |
+
+## D2 — Arbitrary Tailwind Value vs Token
+
+| Line   | Value                                             | Verdict | Reason                                                                                          | Suggested change   |
+| ------ | ------------------------------------------------- | ------- | ----------------------------------------------------------------------------------------------- | ------------------ |
+| 87–103 | status border/icon arbitrary CSS-variable classes | fix     | Applied in this PR: replaced with `border-*-6/30`, `bg-*-6/15`, and `text-*-6` token utilities. | No further change. |
+
+## D3 — Hardcoded Sizes / Colors
+
+| Line    | Value                                      | Verdict          | Reason                                                                                                                                                                                 | Suggested change                                                                |
+| ------- | ------------------------------------------ | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| 193–210 | 13px toast typography and custom elevation | keep with reason | These pre-existing values define the compact toast density and two-layer floating elevation; changing them is outside the progress behavior and lacks a pixel-equivalent shared token. | Consider a dedicated toast typography/elevation token in a future system sweep. |
+
+## D4 — Accessibility
+
+| Line    | Element                 | Verdict          | Reason                                                                                                                            | Suggested change |
+| ------- | ----------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| 219–248 | toast actions and close | keep with reason | Actions have visible labels; the icon-only close button has an i18n-backed `aria-label`; all use native keyboard-capable buttons. | —                |
+
+## D5 — Visual Patterns Observed
+
+- Fixed-ID persistent notice slots are message infrastructure behavior, not a duplicated visual pattern.
+- No new cross-file visual abstraction candidate reached the three-site threshold.
+
+## Summary
+
+- 1 fix applied
+- 5 kept with documented reason
+- 0 abstract candidates

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -69,7 +69,7 @@
     "updater": {
       "active": true,
       "endpoints": [
-        "https://github.com/YORG-AI/ORGII/releases/latest/download/latest.json"
+        "https://github.com/yorgai/ORG2/releases/latest/download/latest.json"
       ],
       "dialog": false,
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDExNEQ5NjIzMjA1ODI5OUMKUldTY0tWZ2dJNVpORWFiWXB3NW5UaWwyOHVxRXhzVmRVbXl2WktZNnhiN2tqcXlVY3gxTTlPV3EK"

--- a/src/components/Message/index.tsx
+++ b/src/components/Message/index.tsx
@@ -48,6 +48,8 @@ export interface MessageConfig {
   icon?: ReactNode;
   className?: string;
   id?: string;
+  /** Keep this message from being evicted by the three-message soft limit. */
+  persistent?: boolean;
   /** Optional title for the message */
   title?: string;
   /** Optional download action shown in the toast */
@@ -84,23 +86,20 @@ const ICONS: Record<MessageType, typeof CheckCircle2> = {
 
 const TYPE_STYLES: Record<MessageType, { border: string; icon: string }> = {
   success: {
-    border:
-      "border-[color-mix(in_srgb,var(--color-success-6)_30%,transparent)]",
-    icon: "text-[var(--color-success-6)] bg-[color-mix(in_srgb,var(--color-success-6)_15%,transparent)]",
+    border: "border-success-6/30",
+    icon: "bg-success-6/15 text-success-6",
   },
   error: {
-    border: "border-[color-mix(in_srgb,var(--color-danger-6)_30%,transparent)]",
-    icon: "text-[var(--color-danger-6)] bg-[color-mix(in_srgb,var(--color-danger-6)_15%,transparent)]",
+    border: "border-danger-6/30",
+    icon: "bg-danger-6/15 text-danger-6",
   },
   warning: {
-    border:
-      "border-[color-mix(in_srgb,var(--color-warning-6)_30%,transparent)]",
-    icon: "text-[var(--color-warning-6)] bg-[color-mix(in_srgb,var(--color-warning-6)_15%,transparent)]",
+    border: "border-warning-6/30",
+    icon: "bg-warning-6/15 text-warning-6",
   },
   info: {
-    border:
-      "border-[color-mix(in_srgb,var(--color-primary-6)_30%,transparent)]",
-    icon: "text-[var(--color-primary-6)] bg-[color-mix(in_srgb,var(--color-primary-6)_15%,transparent)]",
+    border: "border-primary-6/30",
+    icon: "bg-primary-6/15 text-primary-6",
   },
 };
 
@@ -241,7 +240,7 @@ const MessageItem = ({
       {/* Close button */}
       {closable && (
         <button
-          className="my-[-2px] ml-1 mr-[-4px] flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-md border-none bg-transparent p-0 text-text-3 opacity-60 transition-all duration-150 ease-out hover:bg-[rgba(255,255,255,0.1)] hover:text-text-1 hover:opacity-100 active:scale-95"
+          className="my-[-2px] ml-1 mr-[-4px] flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-md border-none bg-transparent p-0 text-text-3 opacity-60 transition-all duration-150 ease-out hover:bg-white/10 hover:text-text-1 hover:opacity-100 active:scale-95"
           onClick={handleClose}
           aria-label={t("actions.close")}
         >
@@ -334,29 +333,34 @@ class MessageManager {
   private add(config: MessageConfig): string {
     this.ensureContainer();
 
-    // Deduplication: Skip if same message was shown recently
-    const hash = this.generateHash(config);
-    if (this.recentHashes.has(hash)) {
-      return ""; // Skip duplicate
-    }
-
-    // Mark as shown and auto-clear after duration
-    this.recentHashes.add(hash);
-    setTimeout(
-      () => {
-        this.recentHashes.delete(hash);
-      },
-      (config.duration || DEFAULT_DURATION) + 500
-    );
-
     const id = config.id || this.generateId();
 
-    // Limit to max 3 messages
-    if (this.messages.size >= 3) {
-      const firstKey = this.messages.keys().next().value;
-      if (firstKey) {
-        this.messages.delete(firstKey);
+    // Fixed IDs are update slots: callers use them to replace live progress
+    // and must also be able to reopen the same content immediately after a
+    // manual close. Only generated one-shot messages participate in dedupe.
+    if (!config.id) {
+      const hash = this.generateHash(config);
+      if (this.recentHashes.has(hash)) {
+        return ""; // Skip duplicate
       }
+
+      this.recentHashes.add(hash);
+      setTimeout(
+        () => {
+          this.recentHashes.delete(hash);
+        },
+        (config.duration || DEFAULT_DURATION) + 500
+      );
+    }
+
+    // Limit one-shot messages to a soft maximum of three. Replacing an
+    // existing slot does not evict anything, and persistent progress notices
+    // are never chosen as eviction candidates.
+    if (!this.messages.has(id) && this.messages.size >= 3) {
+      const firstDismissible = Array.from(this.messages.entries()).find(
+        ([, message]) => !message.persistent
+      );
+      if (firstDismissible) this.messages.delete(firstDismissible[0]);
     }
 
     this.messages.set(id, config);

--- a/src/scaffold/AppUpdater/DownloadProgress.scss
+++ b/src/scaffold/AppUpdater/DownloadProgress.scss
@@ -1,0 +1,118 @@
+.app-update-download-progress--indeterminate > div {
+  width: 36% !important;
+  animation: app-update-progress-slide 1.2s ease-in-out infinite;
+}
+
+.app-update-download-orb {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 9999;
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid var(--color-border-2);
+  border-radius: 9999px;
+  color: var(--color-text-1);
+  background: var(--color-bg-2);
+  box-shadow:
+    0 2px 6px rgb(0 0 0 / 12%),
+    0 12px 28px rgb(0 0 0 / 18%);
+  cursor: pointer;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.app-update-download-orb:hover {
+  border-color: var(--color-primary-6);
+  box-shadow:
+    0 3px 8px rgb(0 0 0 / 14%),
+    0 16px 32px rgb(0 0 0 / 22%);
+  transform: translateY(-2px);
+}
+
+.app-update-download-orb:focus-visible {
+  outline: 2px solid var(--color-primary-6);
+  outline-offset: 2px;
+}
+
+.app-update-download-orb__liquid {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: var(--download-progress);
+  background: linear-gradient(
+    180deg,
+    var(--color-primary-5),
+    var(--color-primary-6)
+  );
+  transition: height 300ms ease;
+}
+
+.app-update-download-orb__wave {
+  position: absolute;
+  top: -0.35rem;
+  left: -25%;
+  width: 150%;
+  height: 0.75rem;
+  border-radius: 45%;
+  background: color-mix(in srgb, var(--color-primary-4) 78%, transparent);
+  animation: app-update-liquid-wave 2.2s linear infinite;
+}
+
+.app-update-download-orb__icon {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-1);
+  filter: drop-shadow(0 1px 2px rgb(0 0 0 / 35%));
+}
+
+.app-update-download-orb--indeterminate .app-update-download-orb__liquid {
+  animation: app-update-liquid-breathe 1.5s ease-in-out infinite alternate;
+}
+
+@keyframes app-update-progress-slide {
+  0% {
+    transform: translateX(-110%);
+  }
+  100% {
+    transform: translateX(280%);
+  }
+}
+
+@keyframes app-update-liquid-wave {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes app-update-liquid-breathe {
+  from {
+    height: 22%;
+  }
+  to {
+    height: 42%;
+  }
+}
+
+@media (max-width: 480px) {
+  .app-update-download-orb {
+    right: 0.5rem;
+    bottom: 0.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-update-download-progress--indeterminate > div,
+  .app-update-download-orb__wave,
+  .app-update-download-orb--indeterminate .app-update-download-orb__liquid {
+    animation: none;
+  }
+}

--- a/src/scaffold/AppUpdater/DownloadProgress.tsx
+++ b/src/scaffold/AppUpdater/DownloadProgress.tsx
@@ -1,0 +1,128 @@
+import { Download } from "lucide-react";
+import type { CSSProperties, FC } from "react";
+
+import ProgressBar from "@src/components/ProgressBar";
+
+import "./DownloadProgress.scss";
+
+export interface AppUpdateDownloadProgress {
+  active: boolean;
+  collapsed: boolean;
+  downloadedBytes: number;
+  totalBytes: number | null;
+  percent: number | null;
+}
+
+export const EMPTY_APP_UPDATE_DOWNLOAD_PROGRESS: AppUpdateDownloadProgress = {
+  active: false,
+  collapsed: false,
+  downloadedBytes: 0,
+  totalBytes: null,
+  percent: null,
+};
+
+function formatBytes(bytes: number): string {
+  const mb = bytes / (1024 * 1024);
+  if (mb >= 1) return `${mb.toFixed(1)} MB`;
+  return `${Math.max(1, Math.round(bytes / 1024))} KB`;
+}
+
+export function getDownloadProgressTitle(
+  progress: AppUpdateDownloadProgress
+): string {
+  return progress.percent === null
+    ? "Downloading update…"
+    : `Downloading update… ${progress.percent}%`;
+}
+
+function getDownloadProgressDetail(
+  progress: AppUpdateDownloadProgress
+): string {
+  if (progress.totalBytes) {
+    return `${formatBytes(progress.downloadedBytes)} of ${formatBytes(
+      progress.totalBytes
+    )}`;
+  }
+  if (progress.downloadedBytes > 0) {
+    return `${formatBytes(progress.downloadedBytes)} downloaded`;
+  }
+  return "Preparing download…";
+}
+
+export const AppUpdateDownloadNoticeContent: FC<{
+  progress: AppUpdateDownloadProgress;
+}> = ({ progress }) => {
+  const detail = getDownloadProgressDetail(progress);
+
+  return (
+    <div className="w-64 max-w-full pt-1">
+      <div
+        role="progressbar"
+        aria-label="Update download progress"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={progress.percent ?? undefined}
+        aria-valuetext={detail}
+      >
+        <ProgressBar
+          percent={progress.percent ?? 0}
+          height="h-1.5"
+          className={
+            progress.percent === null
+              ? "app-update-download-progress--indeterminate"
+              : undefined
+          }
+        />
+      </div>
+      <div className="mt-2 flex items-center justify-between gap-3 text-xs text-text-3">
+        <span>{detail}</span>
+        {progress.percent !== null && (
+          <span className="shrink-0 tabular-nums">{progress.percent}%</span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+interface DownloadProgressOrbProps {
+  progress: AppUpdateDownloadProgress;
+  onExpand: () => void;
+}
+
+type OrbStyle = CSSProperties & { "--download-progress": string };
+
+export const DownloadProgressOrb: FC<DownloadProgressOrbProps> = ({
+  progress,
+  onExpand,
+}) => {
+  if (!progress.active || !progress.collapsed) return null;
+
+  const liquidPercent = progress.percent ?? 28;
+  const progressLabel =
+    progress.percent === null ? "in progress" : `${progress.percent}%`;
+  const style: OrbStyle = {
+    "--download-progress": `${liquidPercent}%`,
+  };
+
+  return (
+    <button
+      type="button"
+      className={`app-update-download-orb ${
+        progress.percent === null
+          ? "app-update-download-orb--indeterminate"
+          : ""
+      }`}
+      style={style}
+      aria-label={`Update download ${progressLabel}. Open progress notice.`}
+      title="Open update download progress"
+      onClick={onExpand}
+    >
+      <span className="app-update-download-orb__liquid" aria-hidden>
+        <span className="app-update-download-orb__wave" />
+      </span>
+      <span className="app-update-download-orb__icon" aria-hidden>
+        <Download size={18} strokeWidth={2.2} />
+      </span>
+    </button>
+  );
+};

--- a/src/scaffold/AppUpdater/appUpdaterCoordinator.test.ts
+++ b/src/scaffold/AppUpdater/appUpdaterCoordinator.test.ts
@@ -25,6 +25,7 @@ describe("AppUpdaterCoordinator", () => {
     check = vi.fn();
     coordinator = new AppUpdaterCoordinator({
       check,
+      downloadTimeoutMs: 5 * 60_000,
       getVersion: vi.fn().mockResolvedValue("1.1.21"),
       minCheckIntervalMs: 5_000,
       now: () => now,
@@ -93,7 +94,9 @@ describe("AppUpdaterCoordinator", () => {
     await coordinator.downloadAvailableUpdate();
     await coordinator.installAvailableUpdate();
 
-    expect(update.download).toHaveBeenCalledOnce();
+    expect(update.download).toHaveBeenCalledWith(undefined, {
+      timeout: 5 * 60_000,
+    });
     expect(update.install).toHaveBeenCalledOnce();
     expect(update.downloadAndInstall).not.toHaveBeenCalled();
   });
@@ -115,6 +118,8 @@ describe("AppUpdaterCoordinator", () => {
 
     await expect(first).resolves.toBe(true);
     await expect(second).resolves.toBe(false);
-    expect(update.downloadAndInstall).toHaveBeenCalledOnce();
+    expect(update.downloadAndInstall).toHaveBeenCalledWith(undefined, {
+      timeout: 5 * 60_000,
+    });
   });
 });

--- a/src/scaffold/AppUpdater/appUpdaterCoordinator.ts
+++ b/src/scaffold/AppUpdater/appUpdaterCoordinator.ts
@@ -28,6 +28,7 @@ export interface AppUpdateCheckResult {
 
 interface AppUpdaterCoordinatorDependencies {
   check: () => Promise<Update | null>;
+  downloadTimeoutMs: number;
   getVersion: () => Promise<string>;
   onStateChange: (state: AppUpdaterState) => void;
   minCheckIntervalMs: number;
@@ -136,7 +137,7 @@ export class AppUpdaterCoordinator {
 
     this.setState({ phase: "downloading", error: null });
     const operation = update
-      .download(onEvent)
+      .download(onEvent, { timeout: this.deps.downloadTimeoutMs })
       .then(() => {
         this.setState({ phase: "downloaded", downloaded: true });
         return update;
@@ -243,7 +244,9 @@ export class AppUpdaterCoordinator {
       if (this.state.downloaded) {
         await update.install();
       } else {
-        await update.downloadAndInstall(onEvent);
+        await update.downloadAndInstall(onEvent, {
+          timeout: this.deps.downloadTimeoutMs,
+        });
       }
       this.setState({ phase: "relaunching" });
       return true;

--- a/src/scaffold/AppUpdater/index.test.ts
+++ b/src/scaffold/AppUpdater/index.test.ts
@@ -190,7 +190,7 @@ describe("AppUpdater", () => {
 
     await expect(checkForUpdatesManually()).resolves.toBe(update);
 
-    expect(mocks.check).toHaveBeenCalledOnce();
+    expect(mocks.check).toHaveBeenCalledWith({ timeout: 30_000 });
     expect(mocks.messageInfo).toHaveBeenCalledWith(
       expect.objectContaining({
         content: "Version 1.1.22 is ready to install.",
@@ -226,6 +226,29 @@ describe("AppUpdater", () => {
     expect(update.downloadAndInstall).not.toHaveBeenCalled();
     expect(mocks.relaunch).not.toHaveBeenCalled();
     expect(mocks.storeSet).toHaveBeenLastCalledWith(expect.anything(), true);
+  });
+
+  it("surfaces a retry action when the update download times out", async () => {
+    const update = createUpdate({
+      download: vi.fn().mockRejectedValue(new Error("request timed out")),
+    });
+    mocks.check.mockResolvedValue(update);
+
+    await installAvailableAppUpdate();
+
+    expect(mocks.relaunch).not.toHaveBeenCalled();
+    expect(mocks.messageError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content:
+          "The download timed out. Check your network or proxy, then retry.",
+        duration: 0,
+        title: "Update download failed",
+        cancel: expect.objectContaining({
+          closeOnClick: false,
+          label: "Retry",
+        }),
+      })
+    );
   });
 
   it("installs and relaunches only after confirmation", async () => {

--- a/src/scaffold/AppUpdater/index.test.ts
+++ b/src/scaffold/AppUpdater/index.test.ts
@@ -1,8 +1,13 @@
 import type { DownloadEvent, Update } from "@tauri-apps/plugin-updater";
-import { type ReactNode, createElement } from "react";
+import { type ReactElement, type ReactNode, createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import {
+  AppUpdateDownloadNoticeContent,
+  type AppUpdateDownloadProgress,
+  DownloadProgressOrb,
+} from "./DownloadProgress";
 import {
   AppUpdater,
   checkForUpdatesManually,
@@ -32,9 +37,12 @@ const mocks = vi.hoisted(() => ({
   getVersion: vi.fn(),
   messageError: vi.fn(),
   messageInfo: vi.fn(),
+  messageRemove: vi.fn(),
   messageSuccess: vi.fn(),
   relaunch: vi.fn(),
+  storeGet: vi.fn(),
   storeSet: vi.fn(),
+  storeValues: new Map<unknown, unknown>(),
   useAtom: vi.fn(),
   useAtomValue: vi.fn(),
   setAutoUpdateEnabled: vi.fn(),
@@ -127,6 +135,7 @@ vi.mock("@src/components/Message", () => ({
   default: {
     error: mocks.messageError,
     info: mocks.messageInfo,
+    remove: mocks.messageRemove,
     success: mocks.messageSuccess,
   },
 }));
@@ -141,6 +150,7 @@ vi.mock("@src/hooks/logger", () => ({
 
 vi.mock("@src/util/core/state/instrumentedStore", () => ({
   getInstrumentedStore: () => ({
+    get: mocks.storeGet,
     set: mocks.storeSet,
   }),
 }));
@@ -164,6 +174,13 @@ describe("AppUpdater", () => {
     mocks.buttons.length = 0;
     mocks.checkbox = null;
     mocks.modal = null;
+    mocks.storeValues.clear();
+    mocks.storeGet.mockImplementation((target) =>
+      mocks.storeValues.get(target)
+    );
+    mocks.storeSet.mockImplementation((target, value) => {
+      mocks.storeValues.set(target, value);
+    });
     mocks.getVersion.mockResolvedValue("1.1.21");
     resetAppUpdaterForTests();
   });
@@ -172,7 +189,10 @@ describe("AppUpdater", () => {
     mocks.useAtom
       .mockReturnValueOnce([true, mocks.setAutoUpdateEnabled])
       .mockReturnValueOnce([true, mocks.setInstallPromptVisible]);
-    mocks.useAtomValue.mockReturnValueOnce(update).mockReturnValueOnce(true);
+    mocks.useAtomValue
+      .mockReturnValueOnce(update)
+      .mockReturnValueOnce({ active: false })
+      .mockReturnValueOnce(true);
     return renderToStaticMarkup(createElement(AppUpdater));
   }
 
@@ -251,6 +271,70 @@ describe("AppUpdater", () => {
     );
   });
 
+  it("renders determinate progress and a collapsible liquid download orb", () => {
+    const progress: AppUpdateDownloadProgress = {
+      active: true,
+      collapsed: true,
+      downloadedBytes: 32,
+      totalBytes: 100,
+      percent: 32,
+    };
+    const onExpand = vi.fn();
+
+    const noticeMarkup = renderToStaticMarkup(
+      createElement(AppUpdateDownloadNoticeContent, { progress })
+    );
+    const orb = DownloadProgressOrb({ progress, onExpand }) as ReactElement<{
+      onClick: () => void;
+    }>;
+    const orbMarkup = renderToStaticMarkup(orb);
+
+    expect(noticeMarkup).toContain('role="progressbar"');
+    expect(noticeMarkup).toContain('aria-valuenow="32"');
+    expect(noticeMarkup).toContain("32%");
+    expect(orbMarkup).toContain("--download-progress:32%");
+    expect(orbMarkup).toContain("Open progress notice");
+
+    orb.props.onClick();
+    expect(onExpand).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a manually collapsed progress notice closed as download advances", async () => {
+    let reportProgress: ((event: DownloadEvent) => void) | undefined;
+    let finishDownload: (() => void) | undefined;
+    const update = createUpdate({
+      download: vi.fn(
+        (onEvent) =>
+          new Promise<void>((resolve) => {
+            reportProgress = onEvent as (event: DownloadEvent) => void;
+            finishDownload = resolve;
+          })
+      ),
+    });
+    mocks.check.mockResolvedValue(update);
+    await checkForUpdatesManually();
+
+    const pendingDownload = installAvailableAppUpdate();
+    const progressNotice = mocks.messageInfo.mock.calls.find(
+      ([message]) => message.id === "app-update-progress"
+    )?.[0];
+    expect(progressNotice).toBeDefined();
+
+    progressNotice?.onClose?.();
+    const messageCountAfterClose = mocks.messageInfo.mock.calls.length;
+    reportProgress?.({ event: "Started", data: { contentLength: 100 } });
+    reportProgress?.({ event: "Progress", data: { chunkLength: 50 } });
+
+    expect(mocks.messageInfo).toHaveBeenCalledTimes(messageCountAfterClose);
+    expect(mocks.storeSet).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ active: true, collapsed: true })
+    );
+
+    finishDownload?.();
+    await pendingDownload;
+  });
+
   it("installs and relaunches only after confirmation", async () => {
     const update = createUpdate();
     mocks.check.mockResolvedValue(update);
@@ -325,7 +409,7 @@ describe("AppUpdater", () => {
     expect(mocks.setInstallPromptVisible).toHaveBeenCalledWith(false);
   });
 
-  it("throttles download progress messages", async () => {
+  it("keeps one progress notice alive and updates it in place", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(10_000);
     const update = createUpdate({
@@ -345,9 +429,15 @@ describe("AppUpdater", () => {
     const progressMessages = mocks.messageInfo.mock.calls.filter(
       ([message]) => message.id === "app-update-progress"
     );
-    expect(progressMessages).toHaveLength(3);
-    expect(progressMessages[1]?.[0].content).toBe("Downloading update… 50%");
-    expect(progressMessages[2]?.[0].content).toBe("Update ready to install.");
+    expect(progressMessages).toHaveLength(4);
+    expect(progressMessages[0]?.[0]).toMatchObject({
+      duration: 0,
+      persistent: true,
+      title: "Downloading update…",
+    });
+    expect(progressMessages[2]?.[0].title).toBe("Downloading update… 50%");
+    expect(progressMessages[3]?.[0].title).toBe("Downloading update… 100%");
+    expect(mocks.messageRemove).toHaveBeenCalledWith("app-update-progress");
     expect(mocks.relaunch).not.toHaveBeenCalled();
     vi.useRealTimers();
   });

--- a/src/scaffold/AppUpdater/index.tsx
+++ b/src/scaffold/AppUpdater/index.tsx
@@ -16,6 +16,13 @@ import { settingsLoadedAtom } from "@src/store/settings/settingsAtom";
 import { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";
 
 import {
+  AppUpdateDownloadNoticeContent,
+  type AppUpdateDownloadProgress,
+  DownloadProgressOrb,
+  EMPTY_APP_UPDATE_DOWNLOAD_PROGRESS,
+  getDownloadProgressTitle,
+} from "./DownloadProgress";
+import {
   AppUpdaterCoordinator,
   type AppUpdaterState,
   createInitialAppUpdaterState,
@@ -31,7 +38,7 @@ const STARTUP_CHECK_DELAY_MS = 10_000;
 const UPDATE_CHECK_INTERVAL_MS = 2 * 60 * 60_000;
 const FOREGROUND_CHECK_MIN_INTERVAL_MS = 5 * 60_000;
 const FOREGROUND_EVENT_DEBOUNCE_MS = 750;
-const INSTALL_PROGRESS_MESSAGE_MIN_INTERVAL_MS = 2_000;
+const DOWNLOAD_PROGRESS_UPDATE_MIN_INTERVAL_MS = 250;
 const UPDATE_TOAST_DURATION_MS = 5_000;
 const UPDATE_CHECK_TIMEOUT_MS = 30_000;
 const UPDATE_DOWNLOAD_TIMEOUT_MS = 5 * 60_000;
@@ -51,6 +58,9 @@ const appUpdaterStateAtom = atom<AppUpdaterState>(
 );
 const availableAppUpdateAtom = atom((get) => get(appUpdaterStateAtom).update);
 const appUpdateInstallPromptAtom = atom(false);
+const appUpdateDownloadProgressAtom = atom<AppUpdateDownloadProgress>(
+  EMPTY_APP_UPDATE_DOWNLOAD_PROGRESS
+);
 const isAppUpdateInstallingAtom = atom((get) => {
   const phase = get(appUpdaterStateAtom).phase;
   return (
@@ -60,6 +70,50 @@ const isAppUpdateInstallingAtom = atom((get) => {
 
 function store() {
   return getInstrumentedStore();
+}
+
+function setDownloadProgress(progress: AppUpdateDownloadProgress): void {
+  store().set(appUpdateDownloadProgressAtom, progress);
+}
+
+function collapseDownloadProgressNotice(): void {
+  const progress = store().get(appUpdateDownloadProgressAtom);
+  if (!progress.active || progress.collapsed) return;
+  setDownloadProgress({ ...progress, collapsed: true });
+}
+
+function showDownloadProgressNotice(progress: AppUpdateDownloadProgress): void {
+  Message.info({
+    id: INSTALL_TOAST_ID,
+    title: getDownloadProgressTitle(progress),
+    content: <AppUpdateDownloadNoticeContent progress={progress} />,
+    duration: 0,
+    closable: true,
+    persistent: true,
+    onClose: collapseDownloadProgressNotice,
+  });
+}
+
+function beginDownloadProgress(): void {
+  const progress = {
+    ...EMPTY_APP_UPDATE_DOWNLOAD_PROGRESS,
+    active: true,
+  };
+  setDownloadProgress(progress);
+  showDownloadProgressNotice(progress);
+}
+
+function expandDownloadProgressNotice(): void {
+  const progress = store().get(appUpdateDownloadProgressAtom);
+  if (!progress.active) return;
+  const expanded = { ...progress, collapsed: false };
+  setDownloadProgress(expanded);
+  showDownloadProgressNotice(expanded);
+}
+
+function endDownloadProgress(): void {
+  Message.remove(INSTALL_TOAST_ID);
+  setDownloadProgress(EMPTY_APP_UPDATE_DOWNLOAD_PROGRESS);
 }
 
 function getSkippedUpdateVersion(): string | null {
@@ -173,32 +227,10 @@ export async function checkForUpdatesManually(): Promise<Update | null> {
   return checkForAppUpdates({ notify: true, force: true });
 }
 
-function formatBytes(bytes: number): string {
-  const mb = bytes / (1024 * 1024);
-  if (mb >= 1) return `${mb.toFixed(1)} MB`;
-  return `${Math.max(1, Math.round(bytes / 1024))} KB`;
-}
-
 function createProgressReporter(): (event: DownloadEvent) => void {
   let lastReportedAt = 0;
   let downloaded = 0;
   let total: number | null = null;
-
-  const describe = (event: DownloadEvent): string => {
-    switch (event.event) {
-      case "Started":
-        return total
-          ? `Downloading update (${formatBytes(total)})…`
-          : "Downloading update…";
-      case "Progress": {
-        if (!total) return `Downloading update… ${formatBytes(downloaded)}`;
-        const percent = Math.min(100, Math.round((downloaded / total) * 100));
-        return `Downloading update… ${percent}%`;
-      }
-      case "Finished":
-        return "Update ready to install.";
-    }
-  };
 
   return (event) => {
     if (event.event === "Started") {
@@ -211,15 +243,26 @@ function createProgressReporter(): (event: DownloadEvent) => void {
     const now = Date.now();
     const shouldReport =
       event.event !== "Progress" ||
-      now - lastReportedAt >= INSTALL_PROGRESS_MESSAGE_MIN_INTERVAL_MS;
+      now - lastReportedAt >= DOWNLOAD_PROGRESS_UPDATE_MIN_INTERVAL_MS;
     if (!shouldReport) return;
 
     lastReportedAt = now;
-    Message.info({
-      id: INSTALL_TOAST_ID,
-      content: describe(event),
-      duration: event.event === "Finished" ? 1500 : 2200,
-    });
+    const previous = store().get(appUpdateDownloadProgressAtom);
+    const percent =
+      event.event === "Finished"
+        ? 100
+        : total
+          ? Math.min(100, Math.round((downloaded / total) * 100))
+          : null;
+    const progress: AppUpdateDownloadProgress = {
+      active: true,
+      collapsed: previous.collapsed,
+      downloadedBytes: downloaded,
+      totalBytes: total,
+      percent,
+    };
+    setDownloadProgress(progress);
+    if (!progress.collapsed) showDownloadProgressNotice(progress);
   };
 }
 
@@ -242,13 +285,17 @@ export async function installAvailableAppUpdate(
   if (!update) return;
 
   if (!confirmed) {
+    const progressReporter = silentDownload
+      ? undefined
+      : createProgressReporter();
     try {
       clearSkippedUpdateVersion(update.version);
-      await coordinator.downloadAvailableUpdate(
-        silentDownload ? undefined : createProgressReporter()
-      );
+      if (progressReporter) beginDownloadProgress();
+      await coordinator.downloadAvailableUpdate(progressReporter);
+      if (progressReporter) endDownloadProgress();
       store().set(appUpdateInstallPromptAtom, true);
     } catch (error) {
+      if (progressReporter) endDownloadProgress();
       Message.error({
         id: INSTALL_TOAST_ID,
         title: "Update download failed",
@@ -329,6 +376,7 @@ export const AppUpdater: React.FC = () => {
     autoUpdateEnabledAtom
   );
   const availableUpdate = useAtomValue(availableAppUpdateAtom);
+  const downloadProgress = useAtomValue(appUpdateDownloadProgressAtom);
   const [installPromptVisible, setInstallPromptVisible] = useAtom(
     appUpdateInstallPromptAtom
   );
@@ -376,69 +424,78 @@ export const AppUpdater: React.FC = () => {
   }, [autoUpdateEnabled, settingsLoaded]);
 
   return (
-    <Modal
-      visible={installPromptVisible && Boolean(availableUpdate)}
-      title={t("update.installConfirmTitle")}
-      width={620}
-      closable={false}
-      maskClosable={false}
-      escToExit={false}
-      onCancel={handleInstallLater}
-      onClose={handleInstallLater}
-      bodyClassName="px-6 py-5"
-      footerTopBorder={false}
-      footer={
-        <div className="flex items-center justify-between gap-3 px-5 py-4">
-          <Button
-            variant="tertiary"
-            appearance="ghost"
-            size="large"
-            shape="round"
-            onClick={handleSkipVersion}
-          >
-            {t("update.skipVersion")}
-          </Button>
-          <div className="flex items-center gap-2">
+    <>
+      <Modal
+        visible={installPromptVisible && Boolean(availableUpdate)}
+        title={t("update.installConfirmTitle")}
+        width={620}
+        closable={false}
+        maskClosable={false}
+        escToExit={false}
+        onCancel={handleInstallLater}
+        onClose={handleInstallLater}
+        bodyClassName="px-6 py-5"
+        footerTopBorder={false}
+        footer={
+          <div className="flex items-center justify-between gap-3 px-5 py-4">
             <Button
-              variant="secondary"
-              appearance="solid"
+              variant="tertiary"
+              appearance="ghost"
               size="large"
               shape="round"
-              onClick={handleInstallLater}
+              onClick={handleSkipVersion}
             >
-              {t("common:actions.later")}
+              {t("update.skipVersion")}
             </Button>
-            <Button
-              variant="primary"
-              size="large"
-              shape="round"
-              onClick={handleInstallConfirm}
-              data-modal-primary-action
-            >
-              {t("update.installAndRestart")}
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="secondary"
+                appearance="solid"
+                size="large"
+                shape="round"
+                onClick={handleInstallLater}
+              >
+                {t("common:actions.later")}
+              </Button>
+              <Button
+                variant="primary"
+                size="large"
+                shape="round"
+                onClick={handleInstallConfirm}
+                data-modal-primary-action
+              >
+                {t("update.installAndRestart")}
+              </Button>
+            </div>
           </div>
+        }
+      >
+        <div className="flex items-center gap-5">
+          <AppMark
+            size={72}
+            className="border border-border-2 bg-bg-2 shadow-sm"
+            glyphClassName="text-text-1"
+          />
+          <p className="min-w-0 flex-1 text-sm leading-6 text-text-2">
+            {t("update.installConfirmDesc", {
+              version: availableUpdate?.version,
+            })}
+          </p>
         </div>
-      }
-    >
-      <div className="flex items-center gap-5">
-        <AppMark
-          size={72}
-          className="border border-border-2 bg-bg-2 shadow-sm"
-          glyphClassName="text-text-1"
-        />
-        <p className="min-w-0 flex-1 text-sm leading-6 text-text-2">
-          {t("update.installConfirmDesc", {
-            version: availableUpdate?.version,
-          })}
-        </p>
-      </div>
-      <div className="mt-5 border-t border-border-1 pt-4">
-        <Checkbox checked={autoUpdateEnabled} onChange={handleAutoUpdateChange}>
-          {t("update.autoDownloadUpdates")}
-        </Checkbox>
-      </div>
-    </Modal>
+        <div className="mt-5 border-t border-border-1 pt-4">
+          <Checkbox
+            checked={autoUpdateEnabled}
+            onChange={handleAutoUpdateChange}
+          >
+            {t("update.autoDownloadUpdates")}
+          </Checkbox>
+        </div>
+      </Modal>
+      <DownloadProgressOrb
+        progress={downloadProgress}
+        onExpand={expandDownloadProgressNotice}
+      />
+    </>
   );
 };
 
@@ -446,4 +503,5 @@ export const AppUpdater: React.FC = () => {
 export function resetAppUpdaterForTests(): void {
   coordinator.reset();
   store().set(appUpdateInstallPromptAtom, false);
+  setDownloadProgress(EMPTY_APP_UPDATE_DOWNLOAD_PROGRESS);
 }

--- a/src/scaffold/AppUpdater/index.tsx
+++ b/src/scaffold/AppUpdater/index.tsx
@@ -33,6 +33,8 @@ const FOREGROUND_CHECK_MIN_INTERVAL_MS = 5 * 60_000;
 const FOREGROUND_EVENT_DEBOUNCE_MS = 750;
 const INSTALL_PROGRESS_MESSAGE_MIN_INTERVAL_MS = 2_000;
 const UPDATE_TOAST_DURATION_MS = 5_000;
+const UPDATE_CHECK_TIMEOUT_MS = 30_000;
+const UPDATE_DOWNLOAD_TIMEOUT_MS = 5 * 60_000;
 
 const CHECK_TOAST_ID = "app-update-check";
 const INSTALL_TOAST_ID = "app-update-progress";
@@ -78,7 +80,8 @@ function clearSkippedUpdateVersion(version: string): void {
 
 function createCoordinator(): AppUpdaterCoordinator {
   return new AppUpdaterCoordinator({
-    check,
+    check: () => check({ timeout: UPDATE_CHECK_TIMEOUT_MS }),
+    downloadTimeoutMs: UPDATE_DOWNLOAD_TIMEOUT_MS,
     getVersion,
     minCheckIntervalMs: FOREGROUND_CHECK_MIN_INTERVAL_MS,
     onStateChange: (state) => store().set(appUpdaterStateAtom, state),
@@ -90,6 +93,14 @@ const coordinator = createCoordinator();
 function getErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
   return typeof error === "string" ? error : "Unknown error";
+}
+
+function getDownloadErrorMessage(error: unknown): string {
+  const message = getErrorMessage(error);
+  if (/timed?\s*out|timeout/i.test(message)) {
+    return "The download timed out. Check your network or proxy, then retry.";
+  }
+  return message;
 }
 
 function notifyCheckSuccess(
@@ -241,8 +252,13 @@ export async function installAvailableAppUpdate(
       Message.error({
         id: INSTALL_TOAST_ID,
         title: "Update download failed",
-        content: getErrorMessage(error),
-        duration: 6000,
+        content: getDownloadErrorMessage(error),
+        duration: 0,
+        cancel: {
+          label: "Retry",
+          onClick: () => void installAvailableAppUpdate({ silentDownload }),
+          closeOnClick: false,
+        },
       });
       log.error("Update download failed", error);
     }


### PR DESCRIPTION
Adds explicit timeouts for update checks and package downloads, surfaces a persistent retry action after download failures, and switches the updater manifest endpoint to the canonical yorgai/ORG2 release URL. Tests: pnpm exec eslint src/scaffold/AppUpdater/index.tsx src/scaffold/AppUpdater/index.test.ts src/scaffold/AppUpdater/appUpdaterCoordinator.ts src/scaffold/AppUpdater/appUpdaterCoordinator.test.ts; pnpm vitest run src/scaffold/AppUpdater/index.test.ts src/scaffold/AppUpdater/appUpdaterCoordinator.test.ts; pnpm exec tsc --noEmit --pretty false.