### PR TITLE
fix(cloud): remove viewer organization role

### DIFF
--- a/src/engines/ChatPanel/panels/CloudOrgPanelView/ManagementSections.tsx
+++ b/src/engines/ChatPanel/panels/CloudOrgPanelView/ManagementSections.tsx
@@ -6,7 +6,7 @@
  *    expiry), one-time copyable `orgii://cloud/join` link, inventory with
  *    usage/state, revoke.
  *  - `CloudMembersSection` — member rows; admins get a role dropdown
- *    (admin/member/viewer) and Remove; everyone but the owner gets Leave
+ *    (admin/member) and Remove; everyone but the owner gets Leave
  *    with an inline confirm (the owner must transfer or delete instead).
  *  - `CloudOrgSettingsSection` (admin/owner) — rename; owner-only transfer
  *    picker and delete with typed name confirmation.
@@ -22,10 +22,13 @@ import Input from "@src/components/Input";
 import Select from "@src/components/Select";
 import type { CloudOrgMember } from "@src/features/Org2Cloud/org2CloudClient";
 import {
+  CLOUD_ASSIGNABLE_ROLES,
   CLOUD_INVITE_STATE,
+  type CloudAssignableRole,
   type CloudInviteRecord,
   deriveCloudInviteState,
   getCloudInviteRemainingUses,
+  isCloudAssignableRole,
 } from "@src/features/Org2Cloud/org2CloudOrgManagement";
 import {
   SECTION_ACTION_GAP_CLASSES,
@@ -57,17 +60,13 @@ const MEMBER_ROLE_CONTROL_STYLE = {
   ...SECTION_CONTROL_STYLE,
   width: 132,
 } as const;
-const CLOUD_ROLES = ["admin", "member", "viewer"] as const;
-
-function roleLabel(t: TFunction<"navigation">, role: string): string {
-  switch (role) {
-    case "admin":
-      return t("cloud.orgManagement.invites.roleAdmin");
-    case "viewer":
-      return t("cloud.orgManagement.invites.roleViewer");
-    default:
-      return t("cloud.orgManagement.invites.roleMember");
-  }
+function roleLabel(
+  t: TFunction<"navigation">,
+  role: CloudAssignableRole
+): string {
+  return role === "admin"
+    ? t("cloud.orgManagement.invites.roleAdmin")
+    : t("cloud.orgManagement.invites.roleMember");
 }
 
 function CloudBadge({ children }: { children: React.ReactNode }) {
@@ -107,7 +106,7 @@ export function CloudInvitesCard({ t, management }: CloudInvitesCardProps) {
   const [expiresInDays, setExpiresInDays] = useState<number>(
     DEFAULT_INVITE_EXPIRY_DAYS
   );
-  const [role, setRole] = useState<string>("member");
+  const [role, setRole] = useState<CloudAssignableRole>("member");
 
   const usageOptions = useMemo(
     () =>
@@ -136,7 +135,7 @@ export function CloudInvitesCard({ t, management }: CloudInvitesCardProps) {
   );
   const roleOptions = useMemo(
     () =>
-      CLOUD_ROLES.map((value) => ({
+      CLOUD_ASSIGNABLE_ROLES.map((value) => ({
         value,
         label: roleLabel(t, value),
         dataTestId: `cloud-org-invite-role-${value}`,
@@ -284,7 +283,9 @@ export function CloudInvitesCard({ t, management }: CloudInvitesCardProps) {
             options={roleOptions}
             style={SECTION_CONTROL_STYLE}
             dataTestId="cloud-org-invite-role-select"
-            onChange={(value) => setRole(String(value))}
+            onChange={(value) => {
+              if (isCloudAssignableRole(value)) setRole(value);
+            }}
           />
         </SectionRow>
         <SectionRow label={t("cloud.orgManagement.invites.create")}>
@@ -344,7 +345,7 @@ export function CloudMembersSection({
 
   const roleOptions = useMemo(
     () =>
-      CLOUD_ROLES.map((value) => ({
+      CLOUD_ASSIGNABLE_ROLES.map((value) => ({
         value,
         label: roleLabel(t, value),
         dataTestId: `cloud-org-member-role-option-${value}`,
@@ -375,7 +376,10 @@ export function CloudMembersSection({
     [t]
   );
 
-  const handleRoleChange = async (member: CloudOrgMember, role: string) => {
+  const handleRoleChange = async (
+    member: CloudOrgMember,
+    role: CloudAssignableRole
+  ) => {
     if (role === member.role) return;
     const confirmed = await confirmDestructiveAction({
       title: t("cloud.orgManagement.members.roleChangeTitle"),
@@ -481,9 +485,11 @@ export function CloudMembersSection({
                         disabled={Boolean(updatingRoleUserId)}
                         loading={updatingRoleUserId === member.userId}
                         dataTestId={`cloud-org-member-role-${member.userId}`}
-                        onChange={(value) =>
-                          void handleRoleChange(member, String(value))
-                        }
+                        onChange={(value) => {
+                          if (isCloudAssignableRole(value)) {
+                            void handleRoleChange(member, value);
+                          }
+                        }}
                       />
                       <Button
                         htmlType="button"

--- a/src/engines/ChatPanel/panels/CloudOrgPanelView/useCloudOrgManagement.ts
+++ b/src/engines/ChatPanel/panels/CloudOrgPanelView/useCloudOrgManagement.ts
@@ -37,6 +37,7 @@ import {
   updateCloudMemberRole,
 } from "@src/features/Org2Cloud/org2CloudManagementClient";
 import {
+  type CloudAssignableRole,
   type CloudInviteRecord,
   cloudManagementErrorMessage,
   wouldRemoveLastAdmin,
@@ -58,8 +59,7 @@ export interface CreateCloudInviteOptions {
   usageLimit: number;
   /** null = the invite never expires. */
   expiresInDays: number | null;
-  /** admin | member | viewer. */
-  role: string;
+  role: CloudAssignableRole;
 }
 
 interface UseCloudOrgManagementParams {
@@ -255,7 +255,7 @@ export function useCloudOrgManagement({
   );
 
   const handleUpdateMemberRole = useCallback(
-    async (member: CloudOrgMember, role: string) => {
+    async (member: CloudOrgMember, role: CloudAssignableRole) => {
       if (updatingRoleUserId || member.role === role) return;
       setMemberError(null);
       // Client-side last-admin pre-check (server ORG2_LAST_ADMIN mirror).

--- a/src/features/Org2Cloud/org2CloudClient.test.ts
+++ b/src/features/Org2Cloud/org2CloudClient.test.ts
@@ -8,6 +8,8 @@ import type { Org2CloudAuthState } from "./org2CloudAuthAtom";
 import {
   ensureFreshSession,
   getCloudProfile,
+  listMyOrgs,
+  listOrgMembers,
   refreshSession,
   schemaVersion,
 } from "./org2CloudClient";
@@ -222,5 +224,25 @@ describe("org2_cloud RPC calls", () => {
   it("getCloudProfile returns null on non-200", async () => {
     fetchMock.mockResolvedValueOnce(jsonResponse({ message: "nope" }, 401));
     expect(await getCloudProfile("at-1")).toBeNull();
+  });
+
+  it("rejects the removed viewer role from org and member roster payloads", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([{ orgId: "org-1", name: "Acme", role: "viewer" }])
+    );
+    await expect(listMyOrgs("at-1")).resolves.toBeNull();
+
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([
+        {
+          userId: "user-2",
+          displayName: "Viewer",
+          role: "viewer",
+          status: "active",
+          joinedAt: "2026-07-01T00:00:00Z",
+        },
+      ])
+    );
+    await expect(listOrgMembers("at-1", "org-1")).resolves.toEqual([]);
   });
 });

--- a/src/features/Org2Cloud/org2CloudClient.ts
+++ b/src/features/Org2Cloud/org2CloudClient.ts
@@ -18,6 +18,7 @@ import type { CollabSessionAccessMode } from "@src/store/collaboration/types";
 
 import { ORG2_CLOUD_POSTGREST_SCHEMA, getCloudEndpoint } from "./config";
 import type { Org2CloudAuthState, Org2CloudProfile } from "./org2CloudAuthAtom";
+import { CLOUD_ORG_ROLES, type CloudOrgRole } from "./org2CloudOrgManagement";
 
 const log = createLogger("Org2CloudClient");
 
@@ -145,19 +146,19 @@ export async function getCloudProfile(
 const CloudOrgWireSchema = z.object({
   orgId: z.string(),
   name: z.string(),
-  role: z.string(),
+  role: z.enum(CLOUD_ORG_ROLES),
 });
 
 export interface CloudOrg {
   orgId: string;
   name: string;
-  role: string;
+  role: CloudOrgRole;
 }
 
 const CloudOrgMemberWireSchema = z.object({
   userId: z.string(),
   displayName: z.string().nullish(),
-  role: z.string(),
+  role: z.enum(CLOUD_ORG_ROLES),
   status: z.string(),
   joinedAt: z.string().nullish(),
   // Per-member sharing floor (admin-set MINIMUM for this member; 'off' = no
@@ -176,7 +177,7 @@ const CloudOrgMemberWireSchema = z.object({
 export interface CloudOrgMember {
   userId: string;
   displayName?: string;
-  role: string;
+  role: CloudOrgRole;
   status: string;
   joinedAt?: string;
   /** Member-level sharing floor; absent/'off' ⇒ no member requirement. */

--- a/src/features/Org2Cloud/org2CloudManagementClient.test.ts
+++ b/src/features/Org2Cloud/org2CloudManagementClient.test.ts
@@ -151,6 +151,13 @@ describe("invites", () => {
     });
   });
 
+  it("rejects the removed viewer role from invite responses", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ orgId: "org-1", role: "viewer" })
+    );
+    await expect(acceptCloudInvite("jwt-1", "plain-code")).rejects.toThrow();
+  });
+
   it("cloud_list_invites normalizes nullish expiry/revocation", async () => {
     fetchMock.mockResolvedValueOnce(
       jsonResponse({
@@ -192,11 +199,11 @@ describe("invites", () => {
 
 describe("members", () => {
   it("cloud_update_member_role posts the target + role", async () => {
-    await updateCloudMemberRole("jwt-1", "org-1", "user-2", "viewer");
+    await updateCloudMemberRole("jwt-1", "org-1", "user-2", "admin");
     expect(lastBody()).toEqual({
       p_org_id: "org-1",
       p_user_id: "user-2",
-      p_role: "viewer",
+      p_role: "admin",
     });
   });
 

--- a/src/features/Org2Cloud/org2CloudManagementClient.ts
+++ b/src/features/Org2Cloud/org2CloudManagementClient.ts
@@ -19,6 +19,8 @@ import { z } from "zod/v4";
 
 import { ORG2_CLOUD_POSTGREST_SCHEMA, getCloudEndpoint } from "./config";
 import {
+  CLOUD_ASSIGNABLE_ROLES,
+  type CloudAssignableRole,
   type CloudInviteRecord,
   type Org2ManagementErrorCode,
   buildCloudInviteLink,
@@ -110,12 +112,12 @@ const CreateInviteResponseSchema = z.object({
 
 const AcceptInviteResponseSchema = z.object({
   orgId: z.string(),
-  role: z.string(),
+  role: z.enum(CLOUD_ASSIGNABLE_ROLES),
 });
 
 const CloudInviteWireSchema = z.object({
   inviteId: z.string(),
-  role: z.string(),
+  role: z.enum(CLOUD_ASSIGNABLE_ROLES),
   maxUses: z.number(),
   usedCount: z.number(),
   expiresAt: z.string().nullish(),
@@ -199,8 +201,7 @@ export async function leaveCloudOrg(
 
 export interface CreateCloudInviteInput {
   orgId: string;
-  /** admin | member | viewer (server rejects anything else). */
-  role: string;
+  role: CloudAssignableRole;
   maxUses: number;
   /** ISO timestamp; omitted = the invite never expires. */
   expiresAt?: string;
@@ -239,7 +240,7 @@ export async function createCloudInvite(
 export async function acceptCloudInvite(
   accessToken: string,
   inviteCode: string
-): Promise<{ orgId: string; role: string }> {
+): Promise<{ orgId: string; role: CloudAssignableRole }> {
   const payload = await callManagementRpc("accept_invite", accessToken, {
     invite_code_hash: await sha256Hex(inviteCode),
   });
@@ -284,12 +285,12 @@ export async function revokeCloudInvite(
 // Members
 // ---------------------------------------------------------------------------
 
-/** `cloud_update_member_role` — p_role ∈ admin|member|viewer (never owner). */
+/** `cloud_update_member_role` — only admin/member are assignable (never owner). */
 export async function updateCloudMemberRole(
   accessToken: string,
   orgId: string,
   userId: string,
-  role: string
+  role: CloudAssignableRole
 ): Promise<void> {
   await callManagementRpc("cloud_update_member_role", accessToken, {
     p_org_id: orgId,

--- a/src/features/Org2Cloud/org2CloudOrgManagement.test.ts
+++ b/src/features/Org2Cloud/org2CloudOrgManagement.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  CLOUD_ASSIGNABLE_ROLES,
   CLOUD_INVITE_STATE,
+  type CloudMemberLike,
   buildCloudInviteLink,
   buildCloudSessionShareLink,
   cloudManagementErrorKey,
@@ -11,6 +13,7 @@ import {
   extractOrg2ManagementErrorCode,
   generateCloudInviteCode,
   getCloudInviteRemainingUses,
+  isCloudAssignableRole,
   isCloudInviteDeepLink,
   isCloudShareDeepLink,
   parseCloudInviteDeepLink,
@@ -20,6 +23,16 @@ import {
   sha256Hex,
   wouldRemoveLastAdmin,
 } from "./org2CloudOrgManagement";
+
+describe("cloud assignable roles", () => {
+  it("only exposes admin and member", () => {
+    expect(CLOUD_ASSIGNABLE_ROLES).toEqual(["admin", "member"]);
+    expect(isCloudAssignableRole("admin")).toBe(true);
+    expect(isCloudAssignableRole("member")).toBe(true);
+    expect(isCloudAssignableRole("viewer")).toBe(false);
+    expect(isCloudAssignableRole("owner")).toBe(false);
+  });
+});
 
 describe("invite code generation + hashing", () => {
   it("mints 64-char lowercase hex codes (32 bytes of entropy)", () => {
@@ -189,7 +202,7 @@ describe("invite state derivation", () => {
 });
 
 describe("last-admin pre-check", () => {
-  const members = [
+  const members: CloudMemberLike[] = [
     { userId: "u-owner", role: "owner", status: "active" },
     { userId: "u-admin", role: "admin", status: "active" },
     { userId: "u-member", role: "member", status: "active" },
@@ -210,7 +223,7 @@ describe("last-admin pre-check", () => {
   });
 
   it("flags the last remaining admin (owner counts as admin)", () => {
-    const soloAdmin = [
+    const soloAdmin: CloudMemberLike[] = [
       { userId: "u-admin", role: "admin", status: "active" },
       { userId: "u-member", role: "member", status: "active" },
     ];
@@ -218,7 +231,7 @@ describe("last-admin pre-check", () => {
   });
 
   it("removed admins do not count toward the surviving-admin set", () => {
-    const withGhost = [
+    const withGhost: CloudMemberLike[] = [
       { userId: "u-admin", role: "admin", status: "active" },
       { userId: "u-removed-admin", role: "admin", status: "removed" },
     ];

--- a/src/features/Org2Cloud/org2CloudOrgManagement.ts
+++ b/src/features/Org2Cloud/org2CloudOrgManagement.ts
@@ -15,6 +15,26 @@
 // Invite code generation / hashing
 // ---------------------------------------------------------------------------
 
+/** Complete role vocabulary accepted from the managed-cloud roster. */
+export const CLOUD_ORG_ROLES = ["owner", "admin", "member"] as const;
+
+export type CloudOrgRole = (typeof CLOUD_ORG_ROLES)[number];
+
+/** Non-owner roles that admins may assign through invites or the roster. */
+export const CLOUD_ASSIGNABLE_ROLES = ["admin", "member"] as const;
+
+export type CloudAssignableRole = (typeof CLOUD_ASSIGNABLE_ROLES)[number];
+
+const CLOUD_ASSIGNABLE_ROLE_SET: ReadonlySet<string> = new Set(
+  CLOUD_ASSIGNABLE_ROLES
+);
+
+export function isCloudAssignableRole(
+  value: unknown
+): value is CloudAssignableRole {
+  return typeof value === "string" && CLOUD_ASSIGNABLE_ROLE_SET.has(value);
+}
+
 /** Random 32-byte hex invite code (same entropy as self-hosted org secrets). */
 export function generateCloudInviteCode(): string {
   const bytes = new Uint8Array(32);
@@ -183,7 +203,7 @@ export function parseCloudShareInput(raw: string): CloudShareDeepLink | null {
 /** One invite row as listed by `cloud_list_invites` (admin-only). */
 export interface CloudInviteRecord {
   inviteId: string;
-  role: string;
+  role: CloudAssignableRole;
   maxUses: number;
   usedCount: number;
   expiresAt?: string;
@@ -238,7 +258,7 @@ export function deriveCloudInviteState(
 
 export interface CloudMemberLike {
   userId: string;
-  role: string;
+  role: CloudOrgRole;
   status: string;
 }
 

--- a/src/features/Org2Cloud/useProjectOrgCloudPermissions.test.ts
+++ b/src/features/Org2Cloud/useProjectOrgCloudPermissions.test.ts
@@ -23,7 +23,6 @@ describe("canAdministerProjectOrg", () => {
     ["owner", true],
     ["admin", true],
     ["member", false],
-    ["viewer", false],
   ])("maps the direct cloud %s role", (role, expected) => {
     expect(
       canAdministerProjectOrg(

--- a/src/i18n/locales/de/navigation.json
+++ b/src/i18n/locales/de/navigation.json
@@ -519,7 +519,6 @@
         "expiryOptionNever": "Nie",
         "roleAdmin": "Admin",
         "roleMember": "Mitglied",
-        "roleViewer": "Betrachter",
         "createdAt": "Erstellt am {{date}}",
         "remainingUses": "Verbleibende Verwendungen: {{uses}}",
         "expires": "Läuft ab am {{date}}",

--- a/src/i18n/locales/en/navigation.json
+++ b/src/i18n/locales/en/navigation.json
@@ -546,7 +546,6 @@
         "expiryOptionNever": "Never",
         "roleAdmin": "Admin",
         "roleMember": "Member",
-        "roleViewer": "Viewer",
         "createdAt": "Created {{date}}",
         "remainingUses": "Uses left: {{uses}}",
         "expires": "Expires {{date}}",

--- a/src/i18n/locales/es/navigation.json
+++ b/src/i18n/locales/es/navigation.json
@@ -519,7 +519,6 @@
         "expiryOptionNever": "Nunca",
         "roleAdmin": "Admin",
         "roleMember": "Miembro",
-        "roleViewer": "Observador",
         "createdAt": "Creada el {{date}}",
         "remainingUses": "Usos restantes: {{uses}}",
         "expires": "Caduca el {{date}}",

--- a/src/i18n/locales/fr/navigation.json
+++ b/src/i18n/locales/fr/navigation.json
@@ -519,7 +519,6 @@
         "expiryOptionNever": "Jamais",
         "roleAdmin": "Admin",
         "roleMember": "Membre",
-        "roleViewer": "Lecteur",
         "createdAt": "Créée le {{date}}",
         "remainingUses": "Utilisations restantes : {{uses}}",
         "expires": "Expire le {{date}}",

--- a/src/i18n/locales/ja/navigation.json
+++ b/src/i18n/locales/ja/navigation.json
@@ -517,7 +517,6 @@
         "expiryOptionNever": "無期限",
         "roleAdmin": "管理者",
         "roleMember": "メンバー",
-        "roleViewer": "閲覧者",
         "createdAt": "作成: {{date}}",
         "remainingUses": "残り回数: {{uses}}",
         "expires": "{{date}} に期限切れ",

--- a/src/i18n/locales/ko/navigation.json
+++ b/src/i18n/locales/ko/navigation.json
@@ -517,7 +517,6 @@
         "expiryOptionNever": "무기한",
         "roleAdmin": "관리자",
         "roleMember": "멤버",
-        "roleViewer": "뷰어",
         "createdAt": "생성: {{date}}",
         "remainingUses": "남은 횟수: {{uses}}",
         "expires": "{{date}} 만료",

--- a/src/i18n/locales/pl/navigation.json
+++ b/src/i18n/locales/pl/navigation.json
@@ -517,7 +517,6 @@
         "expiryOptionNever": "Nigdy",
         "roleAdmin": "Administrator",
         "roleMember": "Członek",
-        "roleViewer": "Obserwator",
         "createdAt": "Utworzono {{date}}",
         "remainingUses": "Pozostałe użycia: {{uses}}",
         "expires": "Wygasa {{date}}",

--- a/src/i18n/locales/pt/navigation.json
+++ b/src/i18n/locales/pt/navigation.json
@@ -519,7 +519,6 @@
         "expiryOptionNever": "Nunca",
         "roleAdmin": "Admin",
         "roleMember": "Membro",
-        "roleViewer": "Visualizador",
         "createdAt": "Criado em {{date}}",
         "remainingUses": "Usos restantes: {{uses}}",
         "expires": "Expira em {{date}}",

--- a/src/i18n/locales/ru/navigation.json
+++ b/src/i18n/locales/ru/navigation.json
@@ -517,7 +517,6 @@
         "expiryOptionNever": "Бессрочно",
         "roleAdmin": "Администратор",
         "roleMember": "Участник",
-        "roleViewer": "Наблюдатель",
         "createdAt": "Создано {{date}}",
         "remainingUses": "Осталось использований: {{uses}}",
         "expires": "Истекает {{date}}",

--- a/src/i18n/locales/tr/navigation.json
+++ b/src/i18n/locales/tr/navigation.json
@@ -517,7 +517,6 @@
         "expiryOptionNever": "Süresiz",
         "roleAdmin": "Yönetici",
         "roleMember": "Üye",
-        "roleViewer": "İzleyici",
         "createdAt": "Oluşturulma: {{date}}",
         "remainingUses": "Kalan kullanım: {{uses}}",
         "expires": "{{date}} tarihinde sona erer",

--- a/src/i18n/locales/vi/navigation.json
+++ b/src/i18n/locales/vi/navigation.json
@@ -517,7 +517,6 @@
         "expiryOptionNever": "Không bao giờ",
         "roleAdmin": "Quản trị viên",
         "roleMember": "Thành viên",
-        "roleViewer": "Người xem",
         "createdAt": "Tạo lúc {{date}}",
         "remainingUses": "Số lần còn lại: {{uses}}",
         "expires": "Hết hạn {{date}}",

--- a/src/i18n/locales/zh-Hant/navigation.json
+++ b/src/i18n/locales/zh-Hant/navigation.json
@@ -609,7 +609,6 @@
         "expiryOptionNever": "永不過期",
         "roleAdmin": "管理員",
         "roleMember": "成員",
-        "roleViewer": "檢視者",
         "createdAt": "建立於 {{date}}",
         "remainingUses": "剩餘次數：{{uses}}",
         "expires": "{{date}} 到期",

--- a/src/i18n/locales/zh/navigation.json
+++ b/src/i18n/locales/zh/navigation.json
@@ -609,7 +609,6 @@
         "expiryOptionNever": "永不过期",
         "roleAdmin": "管理员",
         "roleMember": "成员",
-        "roleViewer": "查看者",
         "createdAt": "创建于 {{date}}",
         "remainingUses": "剩余次数：{{uses}}",
         "expires": "{{date}} 过期",

--- a/tests/e2e/specs/core/cloud-dual-instance-ui.spec.mjs
+++ b/tests/e2e/specs/core/cloud-dual-instance-ui.spec.mjs
@@ -2940,40 +2940,40 @@ describe("Cloud collaboration with two independent rendered app instances", func
       ),
     ]);
 
-    // Exercise both demotion and promotion. A viewer retains read access but
-    // must not gain any admin surface; an admin receives it live.
     await clickRendered(
-      `[data-testid="cloud-org-member-role-${teammate.userId}"]`,
-      "owner teammate role selector"
+      '[data-testid="cloud-org-invite-role-select"]',
+      "owner invite role selector"
     );
+    const viewerInviteRoleExists = await execJS(
+      `return !!document.querySelector('[data-testid="cloud-org-invite-role-viewer"]');`
+    );
+    if (viewerInviteRoleExists) {
+      throw new Error("removed viewer role remained in the invite selector");
+    }
     await clickRendered(
-      '[data-testid="cloud-org-member-role-option-viewer"]',
-      "owner demote teammate to viewer"
+      '[data-testid="cloud-org-invite-role-member"]',
+      "owner keep member invite role"
     );
-    await second.client.waitUntil(
-      async () =>
-        executeOn(
-          second.client,
-          `return document.querySelector('[data-testid="cloud-org-member-row"][data-member-id="${teammate.userId}"]')?.textContent?.toLowerCase().includes('viewer') === true;`
-        ),
-      {
-        timeout: CLOUD_FETCH_TIMEOUT_MS,
-        interval: 250,
-        timeoutMsg: "viewer role did not propagate to the teammate",
-      }
-    );
-    const viewerHasAdminSurface = await executeOn(
+
+    // A member has no admin surface; promotion to admin receives it live.
+    const memberHasAdminSurface = await executeOn(
       second.client,
       `return !!document.querySelector('[data-testid="cloud-org-invites"], [data-testid="cloud-org-settings"], [data-testid="cloud-org-danger-zone"]');`
     );
-    if (viewerHasAdminSurface) {
-      throw new Error("viewer was offered an admin/owner management surface");
+    if (memberHasAdminSurface) {
+      throw new Error("member was offered an admin/owner management surface");
     }
 
     await clickRendered(
       `[data-testid="cloud-org-member-role-${teammate.userId}"]`,
-      "owner viewer role selector"
+      "owner member role selector"
     );
+    const viewerRoleOptionExists = await execJS(
+      `return !!document.querySelector('[data-testid="cloud-org-member-role-option-viewer"]');`
+    );
+    if (viewerRoleOptionExists) {
+      throw new Error("removed viewer role remained in the member selector");
+    }
     await clickRendered(
       '[data-testid="cloud-org-member-role-option-admin"]',
       "owner promote teammate to admin"


### PR DESCRIPTION
## Summary

- remove Viewer from Cloud organization invite and member role selectors
- centralize the supported roster roles as owner/admin/member and assignable roles as admin/member
- reject removed Viewer values at the org roster, member roster, and invite response wire boundaries
- remove the obsolete Viewer copy from all 13 navigation locales while retaining unrelated live-presence viewer semantics

## Testing

- npm run typecheck
- npm run lint
- npm test -- --run (444 files, 5129 tests)
- npm run check:i18n:cloud
- targeted Org2Cloud tests (4 files, 75 tests)
- node --check tests/e2e/specs/core/cloud-dual-instance-ui.spec.mjs
- git diff --check

## E2E coverage

The real dual-instance Cloud scenario now opens both role selectors and asserts that Viewer is absent before exercising the supported member-to-admin promotion flow. It was not executed locally because this checkout has no tests/e2e/.env Cloud credentials; the spec syntax and all local gates above pass.