### PR TITLE
fix(orgtrack): connect Codex hook trust flow

### DIFF
--- a/src-tauri/crates/agent-cli/src/session_provenance.rs
+++ b/src-tauri/crates/agent-cli/src/session_provenance.rs
@@ -10,9 +10,11 @@ use std::sync::{Mutex, MutexGuard, OnceLock};
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
 
 const HOOK_MARKER: &str = "--session-provenance-hook";
 const PREFERENCES_SCHEMA_VERSION: u32 = 1;
+const ACTIVATION_RECEIPT_SCHEMA_VERSION: u32 = 1;
 const ALL_SESSION_PROVENANCE_HOOK_PLATFORMS: [SessionProvenanceHookPlatform; 11] = [
     SessionProvenanceHookPlatform::ClaudeCode,
     SessionProvenanceHookPlatform::Codex,
@@ -276,14 +278,40 @@ pub struct SessionProvenanceHookStatus {
     pub platform: SessionProvenanceHookPlatform,
     pub enabled: bool,
     pub desired_enabled: bool,
+    pub activation_state: SessionProvenanceHookActivationState,
+    pub last_activated_at: Option<String>,
     pub config_path: String,
     pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionProvenanceHookActivationState {
+    Inactive,
+    AwaitingApproval,
+    Active,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HookActivationReceipt {
+    schema_version: u32,
+    platform: SessionProvenanceHookPlatform,
+    hook_fingerprint: String,
+    activated_at: String,
 }
 
 fn preferences_path() -> PathBuf {
     app_paths::orgii_root()
         .join("session-provenance")
         .join("hooks.json")
+}
+
+fn activation_receipt_path(platform: SessionProvenanceHookPlatform) -> PathBuf {
+    app_paths::orgii_root()
+        .join("session-provenance")
+        .join("activations")
+        .join(format!("{}.json", platform.source_arg()))
 }
 
 fn operation_guard() -> Result<MutexGuard<'static, ()>, String> {
@@ -1294,6 +1322,180 @@ fn config_has_managed_hooks(platform: SessionProvenanceHookPlatform) -> Result<b
     Ok(config_has_complete_managed_hooks(&config, platform))
 }
 
+/// Fingerprint only ORG2-managed definitions, so unrelated user hooks neither
+/// invalidate nor accidentally satisfy a Codex activation receipt.
+fn managed_hook_fingerprint(
+    config: &Value,
+    platform: SessionProvenanceHookPlatform,
+) -> Option<String> {
+    let hooks = config.get("hooks")?.as_object()?;
+    let mut definitions = Vec::new();
+    for (event_name, groups) in hooks {
+        let Some(groups) = groups.as_array() else {
+            continue;
+        };
+        for group in groups {
+            let matcher = group.get("matcher").cloned().unwrap_or(Value::Null);
+            let Some(commands) = group.get("hooks").and_then(Value::as_array) else {
+                continue;
+            };
+            for command in commands {
+                if !command_is_managed_for_platform(command, platform) {
+                    continue;
+                }
+                definitions.push(
+                    serde_json::to_string(&json!({
+                        "event": event_name,
+                        "matcher": matcher,
+                        "type": command.get("type").cloned().unwrap_or(Value::Null),
+                        "command": command.get("command").cloned().unwrap_or(Value::Null),
+                        "commandWindows": command
+                            .get("commandWindows")
+                            .cloned()
+                            .unwrap_or(Value::Null),
+                        "timeout": command.get("timeout").cloned().unwrap_or(Value::Null),
+                    }))
+                    .expect("managed hook fingerprint value is serializable"),
+                );
+            }
+        }
+    }
+    if definitions.is_empty() {
+        return None;
+    }
+    definitions.sort();
+    let digest = Sha256::digest(definitions.join("\n").as_bytes());
+    Some(format!("{digest:x}"))
+}
+
+fn current_managed_hook_fingerprint(
+    platform: SessionProvenanceHookPlatform,
+) -> Result<Option<String>, String> {
+    match platform {
+        SessionProvenanceHookPlatform::Codex => {
+            let config = read_config(&platform.config_path())?;
+            Ok(managed_hook_fingerprint(&config, platform))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn read_activation_receipt(
+    platform: SessionProvenanceHookPlatform,
+) -> Option<HookActivationReceipt> {
+    let bytes = std::fs::read(activation_receipt_path(platform)).ok()?;
+    let receipt = serde_json::from_slice::<HookActivationReceipt>(&bytes).ok()?;
+    (receipt.schema_version == ACTIVATION_RECEIPT_SCHEMA_VERSION && receipt.platform == platform)
+        .then_some(receipt)
+}
+
+fn codex_activation_from_receipt(
+    fingerprint: &str,
+    receipt: Option<HookActivationReceipt>,
+) -> (SessionProvenanceHookActivationState, Option<String>) {
+    if let Some(receipt) = receipt.filter(|receipt| receipt.hook_fingerprint == fingerprint) {
+        (
+            SessionProvenanceHookActivationState::Active,
+            Some(receipt.activated_at),
+        )
+    } else {
+        (SessionProvenanceHookActivationState::AwaitingApproval, None)
+    }
+}
+
+fn activation_for_installed_hook(
+    platform: SessionProvenanceHookPlatform,
+    installed: bool,
+) -> Result<(SessionProvenanceHookActivationState, Option<String>), String> {
+    if !installed {
+        return Ok((SessionProvenanceHookActivationState::Inactive, None));
+    }
+    if platform != SessionProvenanceHookPlatform::Codex {
+        return Ok((SessionProvenanceHookActivationState::Active, None));
+    }
+
+    let fingerprint = current_managed_hook_fingerprint(platform)?.ok_or_else(|| {
+        "Installed Codex hooks are missing a managed definition fingerprint".to_string()
+    })?;
+    Ok(codex_activation_from_receipt(
+        &fingerprint,
+        read_activation_receipt(platform),
+    ))
+}
+
+fn append_error(existing: Option<String>, next: String) -> Option<String> {
+    Some(match existing {
+        Some(existing) => format!("{existing}; {next}"),
+        None => next,
+    })
+}
+
+fn build_hook_status(
+    platform: SessionProvenanceHookPlatform,
+    desired_enabled: bool,
+    operation_error: Option<String>,
+) -> SessionProvenanceHookStatus {
+    let (enabled, mut error) = match config_has_managed_hooks(platform) {
+        Ok(enabled) => (enabled, operation_error),
+        Err(inspection_error) => (
+            false,
+            append_error(
+                operation_error,
+                format!("failed to inspect resulting hook config: {inspection_error}"),
+            ),
+        ),
+    };
+    let (activation_state, last_activated_at) =
+        match activation_for_installed_hook(platform, enabled) {
+            Ok(activation) => activation,
+            Err(activation_error) => {
+                error = append_error(error, activation_error);
+                (SessionProvenanceHookActivationState::Inactive, None)
+            }
+        };
+    SessionProvenanceHookStatus {
+        platform,
+        enabled,
+        desired_enabled,
+        activation_state,
+        last_activated_at,
+        config_path: platform.config_path().to_string_lossy().into_owned(),
+        error,
+    }
+}
+
+/// Record proof that Codex invoked the current ORG2-managed hook definition.
+/// A matching receipt is the only state that upgrades the UI from
+/// `awaiting_approval` to `active`.
+pub fn record_session_provenance_hook_activation(source: &str) -> Result<bool, String> {
+    if source != SessionProvenanceHookPlatform::Codex.source_arg() {
+        return Ok(false);
+    }
+    let _guard = operation_guard()?;
+    let platform = SessionProvenanceHookPlatform::Codex;
+    if !config_has_managed_hooks(platform)? {
+        return Ok(false);
+    }
+    let fingerprint = current_managed_hook_fingerprint(platform)?.ok_or_else(|| {
+        "Cannot record Codex activation without managed hook definitions".to_string()
+    })?;
+    if read_activation_receipt(platform)
+        .is_some_and(|receipt| receipt.hook_fingerprint == fingerprint)
+    {
+        return Ok(false);
+    }
+    let receipt = HookActivationReceipt {
+        schema_version: ACTIVATION_RECEIPT_SCHEMA_VERSION,
+        platform,
+        hook_fingerprint: fingerprint,
+        activated_at: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+    };
+    let bytes = serde_json::to_vec_pretty(&receipt)
+        .map_err(|err| format!("Failed to serialize hook activation receipt: {err}"))?;
+    write_atomic(&activation_receipt_path(platform), &bytes)?;
+    Ok(true)
+}
+
 /// Reconcile hook files with ORG2 preferences. On first launch preferences
 /// default to all supported platforms enabled.
 pub fn ensure_hooks_from_preferences() -> Result<(), String> {
@@ -1332,19 +1534,7 @@ pub async fn session_provenance_hooks_status() -> Result<Vec<SessionProvenanceHo
         Ok::<_, String>(
             ALL_SESSION_PROVENANCE_HOOK_PLATFORMS
                 .into_iter()
-                .map(|platform| {
-                    let (enabled, error) = match config_has_managed_hooks(platform) {
-                        Ok(enabled) => (enabled, None),
-                        Err(error) => (false, Some(error)),
-                    };
-                    SessionProvenanceHookStatus {
-                        platform,
-                        enabled,
-                        desired_enabled: preferences.enabled(platform),
-                        config_path: platform.config_path().to_string_lossy().into_owned(),
-                        error,
-                    }
-                })
+                .map(|platform| build_hook_status(platform, preferences.enabled(platform), None))
                 .collect::<Vec<_>>(),
         )
     })
@@ -1368,25 +1558,7 @@ pub async fn session_provenance_hooks_set_enabled(
         // If a malformed or read-only config cannot be repaired immediately,
         // startup reconciliation can retry without losing the opt-out.
         let update_error = update_platform(platform, enabled, &executable).err();
-        let (installed, inspection_error) = match config_has_managed_hooks(platform) {
-            Ok(installed) => (installed, None),
-            Err(err) => (false, Some(err)),
-        };
-        let error = match (update_error, inspection_error) {
-            (Some(update), Some(inspection)) => Some(format!(
-                "{update}; failed to inspect resulting hook config: {inspection}"
-            )),
-            (Some(update), None) => Some(update),
-            (None, Some(inspection)) => Some(inspection),
-            (None, None) => None,
-        };
-        Ok(SessionProvenanceHookStatus {
-            platform,
-            enabled: installed,
-            desired_enabled: enabled,
-            config_path: platform.config_path().to_string_lossy().into_owned(),
-            error,
-        })
+        Ok(build_hook_status(platform, enabled, update_error))
     })
     .await
     .map_err(|err| format!("Task join error: {err}"))?
@@ -1476,6 +1648,94 @@ mod tests {
         update_codex_platform(&mut config, false, "unused", "unused").expect("disable Codex hooks");
         assert!(config.to_string().contains("user-hook"));
         assert!(!config.to_string().contains(HOOK_MARKER));
+    }
+
+    #[test]
+    fn codex_fingerprint_tracks_only_managed_definition_changes() {
+        let mut config = json!({
+            "hooks": {
+                "PostToolUse": [{
+                    "matcher": "Read",
+                    "hooks": [{"type": "command", "command": "user-hook"}]
+                }]
+            },
+            "theme": "dark"
+        });
+        update_codex_platform(
+            &mut config,
+            true,
+            "orgii --session-provenance-hook codex",
+            "orgii.exe --session-provenance-hook codex",
+        )
+        .expect("enable Codex hooks");
+        let original = managed_hook_fingerprint(&config, SessionProvenanceHookPlatform::Codex)
+            .expect("managed fingerprint");
+
+        config["hooks"]["PostToolUse"]
+            .as_array_mut()
+            .unwrap()
+            .push(json!({
+                "matcher": "Write",
+                "hooks": [{"type": "command", "command": "another-user-hook"}]
+            }));
+        config["theme"] = json!("light");
+        assert_eq!(
+            managed_hook_fingerprint(&config, SessionProvenanceHookPlatform::Codex),
+            Some(original.clone()),
+            "unrelated user configuration must not invalidate approval"
+        );
+
+        let managed_group = config["hooks"]["PostToolUse"]
+            .as_array_mut()
+            .unwrap()
+            .iter_mut()
+            .find(|group| group.to_string().contains(HOOK_MARKER))
+            .expect("managed PostToolUse group");
+        managed_group["matcher"] = json!("apply_patch");
+        assert_ne!(
+            managed_hook_fingerprint(&config, SessionProvenanceHookPlatform::Codex),
+            Some(original),
+            "a managed matcher change requires fresh approval"
+        );
+    }
+
+    #[test]
+    fn codex_activation_requires_a_matching_receipt() {
+        let receipt = HookActivationReceipt {
+            schema_version: ACTIVATION_RECEIPT_SCHEMA_VERSION,
+            platform: SessionProvenanceHookPlatform::Codex,
+            hook_fingerprint: "current".to_string(),
+            activated_at: "2026-07-15T12:00:00.000Z".to_string(),
+        };
+        assert_eq!(
+            codex_activation_from_receipt("current", None),
+            (SessionProvenanceHookActivationState::AwaitingApproval, None)
+        );
+        assert_eq!(
+            codex_activation_from_receipt("stale", Some(receipt.clone())),
+            (SessionProvenanceHookActivationState::AwaitingApproval, None)
+        );
+        assert_eq!(
+            codex_activation_from_receipt("current", Some(receipt)),
+            (
+                SessionProvenanceHookActivationState::Active,
+                Some("2026-07-15T12:00:00.000Z".to_string())
+            )
+        );
+    }
+
+    #[test]
+    fn activation_state_is_immediate_for_providers_without_a_trust_gate() {
+        assert_eq!(
+            activation_for_installed_hook(SessionProvenanceHookPlatform::ClaudeCode, true)
+                .expect("Claude activation"),
+            (SessionProvenanceHookActivationState::Active, None)
+        );
+        assert_eq!(
+            activation_for_installed_hook(SessionProvenanceHookPlatform::Codex, false)
+                .expect("inactive Codex"),
+            (SessionProvenanceHookActivationState::Inactive, None)
+        );
     }
 
     #[test]

--- a/src-tauri/src/orgtrack/session_provenance/hook_capture.rs
+++ b/src-tauri/src/orgtrack/session_provenance/hook_capture.rs
@@ -26,6 +26,7 @@ static INBOX_DRAIN_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 /// Entry point used by `orgii --session-provenance-hook <source>`.
 /// Provenance failures are diagnostic only and never block the provider tool.
 pub fn capture_hook_stdin(source: &str) -> Result<usize, String> {
+    let source_arg = source;
     let source = HookSource::parse(source)?;
     let mut stdin = std::io::stdin().take(MAX_HOOK_PAYLOAD_BYTES + 1);
     let mut payload = Vec::new();
@@ -46,6 +47,15 @@ pub fn capture_hook_stdin(source: &str) -> Result<usize, String> {
     }
     if let Some(lifecycle) = lifecycle.as_ref() {
         spool_actor_lifecycle(lifecycle)?;
+    }
+    if let Err(error) =
+        agent_cli::session_provenance::record_session_provenance_hook_activation(source_arg)
+    {
+        tracing::warn!(
+            error = %error,
+            source = source_arg,
+            "[SessionProvenance] Failed to record hook activation"
+        );
     }
     Ok(envelopes.len() + usize::from(lifecycle.is_some()))
 }

--- a/src/api/tauri/rpc/__tests__/sessionProvenanceSchemas.test.ts
+++ b/src/api/tauri/rpc/__tests__/sessionProvenanceSchemas.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { rpc } from "../router";
 import {
   SessionProvenanceHookPlatformSchema,
+  SessionProvenanceHookStatusSchema,
   SessionProvenanceRecentSignalSchema,
 } from "../schemas/agentOrgs";
 import {
@@ -34,6 +35,20 @@ describe("session provenance RPC schemas", () => {
     expect(() =>
       SessionProvenanceHookPlatformSchema.parse("gemini_cli")
     ).toThrow();
+  });
+
+  it("keeps hook installation separate from verified activation", () => {
+    const parsed = SessionProvenanceHookStatusSchema.parse({
+      platform: "codex",
+      enabled: true,
+      desiredEnabled: true,
+      activationState: "awaiting_approval",
+      lastActivatedAt: null,
+      configPath: "/Users/test/.codex/hooks.json",
+      error: null,
+    });
+    expect(parsed.enabled).toBe(true);
+    expect(parsed.activationState).toBe("awaiting_approval");
   });
 
   it("parses a recent hook signal from the Rust camelCase payload", () => {

--- a/src/api/tauri/rpc/schemas/agentOrgs.ts
+++ b/src/api/tauri/rpc/schemas/agentOrgs.ts
@@ -32,10 +32,18 @@ export const SessionProvenanceHookPlatformSchema = z.enum([
   "zcode",
 ]);
 
+export const SessionProvenanceHookActivationStateSchema = z.enum([
+  "inactive",
+  "awaiting_approval",
+  "active",
+]);
+
 export const SessionProvenanceHookStatusSchema = z.object({
   platform: SessionProvenanceHookPlatformSchema,
   enabled: z.boolean(),
   desiredEnabled: z.boolean(),
+  activationState: SessionProvenanceHookActivationStateSchema,
+  lastActivatedAt: z.string().nullable().optional(),
   configPath: z.string(),
   error: z.string().nullable().optional(),
 });

--- a/src/engines/TerminalCore/index.tsx
+++ b/src/engines/TerminalCore/index.tsx
@@ -362,6 +362,7 @@ export const TerminalCore: React.FC<TerminalCoreProps> = ({
                 onOpenFileLink={onOpenFileLink}
                 backgroundColor={bgColor}
                 shellOverride={session.shell}
+                nameOverride={session.name}
                 onUserInput={() => {
                   requestProcessRefresh();
                   if (!session.hasUserInput) {

--- a/src/engines/TerminalCore/types.ts
+++ b/src/engines/TerminalCore/types.ts
@@ -63,6 +63,10 @@ export function getTerminalDisplayTitle(session: TerminalSession): string {
 }
 
 export interface AddSessionOptions {
+  /** Internal setup flows may require a dedicated session immediately after
+   * the Terminal tab mounts its default session. User-initiated creation must
+   * leave this false so rapid clicks remain throttled. */
+  bypassCreationCooldown?: boolean;
   /** Shell profile ID to use (if omitted, uses default profile) */
   profileId?: string;
   /** Shell executable path override */

--- a/src/i18n/locales/de/integrations.json
+++ b/src/i18n/locales/de/integrations.json
@@ -1704,8 +1704,16 @@
         "on": "Ein",
         "off": "Aus",
         "repair": "Reparieren",
+        "needsApproval": "Genehmigung erforderlich",
         "checking": "Wird geprüft…",
         "error": "Fehler"
+      },
+      "codexApproval": {
+        "title": "Approve ORG2 hooks in Codex",
+        "description": "Codex has the ORG2 hooks installed, but Codex still needs your approval before it can run them.",
+        "instructions": "Open Codex, review the 3 ORG2 hooks, then choose Trust all and continue. ORG2 marks this active after the first real hook signal.",
+        "review": "Review in Codex",
+        "verified": "Verified by a real Codex hook signal {{time}}."
       },
       "signals": {
         "title": "Aktuelle Signale",
@@ -1714,6 +1722,8 @@
         "search": "Signale durchsuchen",
         "refresh": "Aktualisieren",
         "openSession": "Sitzung {{session}} öffnen",
+        "diffLoading": "Loading patch…",
+        "diffEmpty": "No patch captured. Provenance records file changes as metadata; a diff appears only once this session's edits are imported.",
         "col": {
           "source": "Werkzeug",
           "action": "Aktion",

--- a/src/i18n/locales/en/integrations.json
+++ b/src/i18n/locales/en/integrations.json
@@ -2397,8 +2397,16 @@
         "on": "On",
         "off": "Off",
         "repair": "Repair",
+        "needsApproval": "Needs approval",
         "checking": "Checking…",
         "error": "Error"
+      },
+      "codexApproval": {
+        "title": "Approve ORG2 hooks in Codex",
+        "description": "Codex has the ORG2 hooks installed, but Codex still needs your approval before it can run them.",
+        "instructions": "Open Codex, review the 3 ORG2 hooks, then choose Trust all and continue. ORG2 marks this active after the first real hook signal.",
+        "review": "Review in Codex",
+        "verified": "Verified by a real Codex hook signal {{time}}."
       },
       "signals": {
         "title": "Recent signals",

--- a/src/i18n/locales/es/integrations.json
+++ b/src/i18n/locales/es/integrations.json
@@ -1701,8 +1701,16 @@
         "on": "Activado",
         "off": "Desactivado",
         "repair": "Reparar",
+        "needsApproval": "Requiere aprobación",
         "checking": "Comprobando…",
         "error": "Error"
+      },
+      "codexApproval": {
+        "title": "Approve ORG2 hooks in Codex",
+        "description": "Codex has the ORG2 hooks installed, but Codex still needs your approval before it can run them.",
+        "instructions": "Open Codex, review the 3 ORG2 hooks, then choose Trust all and continue. ORG2 marks this active after the first real hook signal.",
+        "review": "Review in Codex",
+        "verified": "Verified by a real Codex hook signal {{time}}."
       },
       "signals": {
         "title": "Señales recientes",
@@ -1711,6 +1719,8 @@
         "search": "Buscar señales",
         "refresh": "Actualizar",
         "openSession": "Abrir sesión {{session}}",
+        "diffLoading": "Loading patch…",
+        "diffEmpty": "No patch captured. Provenance records file changes as metadata; a diff appears only once this session's edits are imported.",
         "col": {
           "source": "Herramienta",
           "action": "Acción",

--- a/src/i18n/locales/fr/integrations.json
+++ b/src/i18n/locales/fr/integrations.json
@@ -1704,8 +1704,16 @@
         "on": "Activé",
         "off": "Désactivé",
         "repair": "Réparer",
+        "needsApproval": "Approbation requise",
         "checking": "Vérification…",
         "error": "Erreur"
+      },
+      "codexApproval": {
+        "title": "Approve ORG2 hooks in Codex",
+        "description": "Codex has the ORG2 hooks installed, but Codex still needs your approval before it can run them.",
+        "instructions": "Open Codex, review the 3 ORG2 hooks, then choose Trust all and continue. ORG2 marks this active after the first real hook signal.",
+        "review": "Review in Codex",
+        "verified": "Verified by a real Codex hook signal {{time}}."
       },
       "signals": {
         "title": "Signaux récents",
@@ -1714,6 +1722,8 @@
         "search": "Rechercher des signaux",
         "refresh": "Actualiser",
         "openSession": "Ouvrir la session {{session}}",
+        "diffLoading": "Loading patch…",
+        "diffEmpty": "No patch captured. Provenance records file changes as metadata; a diff appears only once this session's edits are imported.",
         "col": {
           "source": "Outil",
           "action": "Action",

--- a/src/i18n/locales/ja/integrations.json
+++ b/src/i18n/locales/ja/integrations.json
@@ -1704,8 +1704,16 @@
         "on": "オン",
         "off": "オフ",
         "repair": "修復",
+        "needsApproval": "承認が必要",
         "checking": "確認中…",
         "error": "エラー"
+      },
+      "codexApproval": {
+        "title": "Approve ORG2 hooks in Codex",
+        "description": "Codex has the ORG2 hooks installed, but Codex still needs your approval before it can run them.",
+        "instructions": "Open Codex, review the 3 ORG2 hooks, then choose Trust all and continue. ORG2 marks this active after the first real hook signal.",
+        "review": "Review in Codex",
+        "verified": "Verified by a real Codex hook signal {{time}}."
       },
       "signals": {
         "title": "最近のシグナル",
@@ -1714,6 +1722,8 @@
         "search": "シグナルを検索",
         "refresh": "更新",
         "openSession": "セッション {{session}} を開く",
+        "diffLoading": "Loading patch…",
+        "diffEmpty": "No patch captured. Provenance records file changes as metadata; a diff appears only once this session's edits are imported.",
         "col": {
           "source": "ツール",
           "action": "アクション",

--- a/src/i18n/locales/ko/integrations.json
+++ b/src/i18n/locales/ko/integrations.json
@@ -1701,8 +1701,16 @@
         "on": "켜짐",
         "off": "꺼짐",
         "repair": "복구",
+        "needsApproval": "승인 필요",
         "checking": "확인 중…",
         "error": "오류"
+      },
+      "codexApproval": {
+        "title": "Approve ORG2 hooks in Codex",
+        "description": "Codex has the ORG2 hooks installed, but Codex still needs your approval before it can run them.",
+        "instructions": "Open Codex, review the 3 ORG2 hooks, then choose Trust all and continue. ORG2 marks this active after the first real hook signal.",
+        "review": "Review in Codex",
+        "verified": "Verified by a real Codex hook signal {{time}}."
       },
       "signals": {
         "title": "최근 신호",
@@ -1711,6 +1719,8 @@
         "search": "신호 검색",
         "refresh": "새로 고침",
         "openSession": "세션 {{session}} 열기",
+        "diffLoading": "Loading patch…",
+        "diffEmpty": "No patch captured. Provenance records file changes as metadata; a diff appears only once this session's edits are imported.",
         "col": {
           "source": "도구",
           "action": "액션",

--- a/src/i18n/locales/pl/integrations.json
+++ b/src/i18n/locales/pl/integrations.json
@@ -1701,8 +1701,16 @@
         "on": "Wł.",
         "off": "Wył.",
         "repair": "Napraw",
+        "needsApproval": "Wymaga zatwierdzenia",
         "checking": "Sprawdzanie…",
         "error": "Błąd"
+      },
+      "codexApproval": {
+        "title": "Approve ORG2 hooks in Codex",
+        "description": "Codex has the ORG2 hooks installed, but Codex still needs your approval before it can run them.",
+        "instructions": "Open Codex, review the 3 ORG2 hooks, then choose Trust all and continue. ORG2 marks this active after the first real hook signal.",
+        "review": "Review in Codex",
+        "verified": "Verified by a real Codex hook signal {{time}}."
       },
       "signals": {
         "title": "Ostatnie sygnały",
@@ -1711,6 +1719,8 @@
         "search": "Szukaj sygnałów",
         "refresh": "Odśwież",
         "openSession": "Otwórz sesję {{session}}",
+        "diffLoading": "Loading patch…",
+        "diffEmpty": "No patch captured. Provenance records file changes as metadata; a diff appears only once this session's edits are imported.",
         "col": {
           "source": "Narzędzie",
           "action": "Akcja",

--- a/src/i18n/locales/pt/integrations.json
+++ b/src/i18n/locales/pt/integrations.json
@@ -1704,8 +1704,16 @@
         "on": "Ativado",
         "off": "Desativado",
         "repair": "Reparar",
+        "needsApproval": "Requer aprovação",
         "checking": "Verificando…",
         "error": "Erro"
+      },
+      "codexApproval": {
+        "title": "Approve ORG2 hooks in Codex",
+        "description": "Codex has the ORG2 hooks installed, but Codex still needs your approval before it can run them.",
+        "instructions": "Open Codex, review the 3 ORG2 hooks, then choose Trust all and continue. ORG2 marks this active after the first real hook signal.",
+        "review": "Review in Codex",
+        "verified": "Verified by a real Codex hook signal {{time}}."
       },
       "signals": {
         "title": "Sinais recentes",
@@ -1714,6 +1722,8 @@
         "search": "Pesquisar sinais",
         "refresh": "Atualizar",
         "openSession": "Abrir sessão {{session}}",
+        "diffLoading": "Loading patch…",
+        "diffEmpty": "No patch captured. Provenance records file changes as metadata; a diff appears only once this session's edits are imported.",
         "col": {
           "source": "Ferramenta",
           "action": "Ação",

--- a/src/i18n/locales/ru/integrations.json
+++ b/src/i18n/locales/ru/integrations.json
@@ -1704,8 +1704,16 @@
         "on": "Вкл.",
         "off": "Выкл.",
         "repair": "Восстановить",
+        "needsApproval": "Требуется одобрение",
         "checking": "Проверка…",
         "error": "Ошибка"
+      },
+      "codexApproval": {
+        "title": "Approve ORG2 hooks in Codex",
+        "description": "Codex has the ORG2 hooks installed, but Codex still needs your approval before it can run them.",
+        "instructions": "Open Codex, review the 3 ORG2 hooks, then choose Trust all and continue. ORG2 marks this active after the first real hook signal.",
+        "review": "Review in Codex",
+        "verified": "Verified by a real Codex hook signal {{time}}."
       },
       "signals": {
         "title": "Недавние сигналы",
@@ -1714,6 +1722,8 @@
         "search": "Поиск сигналов",
         "refresh": "Обновить",
         "openSession": "Открыть сессию {{session}}",
+        "diffLoading": "Loading patch…",
+        "diffEmpty": "No patch captured. Provenance records file changes as metadata; a diff appears only once this session's edits are imported.",
         "col": {
           "source": "Инструмент",
           "action": "Действие",

--- a/src/i18n/locales/tr/integrations.json
+++ b/src/i18n/locales/tr/integrations.json
@@ -1701,8 +1701,16 @@
         "on": "Açık",
         "off": "Kapalı",
         "repair": "Onar",
+        "needsApproval": "Onay gerekli",
         "checking": "Kontrol ediliyor…",
         "error": "Hata"
+      },
+      "codexApproval": {
+        "title": "Approve ORG2 hooks in Codex",
+        "description": "Codex has the ORG2 hooks installed, but Codex still needs your approval before it can run them.",
+        "instructions": "Open Codex, review the 3 ORG2 hooks, then choose Trust all and continue. ORG2 marks this active after the first real hook signal.",
+        "review": "Review in Codex",
+        "verified": "Verified by a real Codex hook signal {{time}}."
       },
       "signals": {
         "title": "Son sinyaller",
@@ -1711,6 +1719,8 @@
         "search": "Sinyal ara",
         "refresh": "Yenile",
         "openSession": "{{session}} oturumunu aç",
+        "diffLoading": "Loading patch…",
+        "diffEmpty": "No patch captured. Provenance records file changes as metadata; a diff appears only once this session's edits are imported.",
         "col": {
           "source": "Araç",
           "action": "Eylem",

--- a/src/i18n/locales/vi/integrations.json
+++ b/src/i18n/locales/vi/integrations.json
@@ -1704,8 +1704,16 @@
         "on": "Bật",
         "off": "Tắt",
         "repair": "Sửa",
+        "needsApproval": "Cần phê duyệt",
         "checking": "Đang kiểm tra…",
         "error": "Lỗi"
+      },
+      "codexApproval": {
+        "title": "Approve ORG2 hooks in Codex",
+        "description": "Codex has the ORG2 hooks installed, but Codex still needs your approval before it can run them.",
+        "instructions": "Open Codex, review the 3 ORG2 hooks, then choose Trust all and continue. ORG2 marks this active after the first real hook signal.",
+        "review": "Review in Codex",
+        "verified": "Verified by a real Codex hook signal {{time}}."
       },
       "signals": {
         "title": "Tín hiệu gần đây",
@@ -1714,6 +1722,8 @@
         "search": "Tìm tín hiệu",
         "refresh": "Làm mới",
         "openSession": "Mở phiên {{session}}",
+        "diffLoading": "Loading patch…",
+        "diffEmpty": "No patch captured. Provenance records file changes as metadata; a diff appears only once this session's edits are imported.",
         "col": {
           "source": "Công cụ",
           "action": "Hành động",

--- a/src/i18n/locales/zh-Hant/integrations.json
+++ b/src/i18n/locales/zh-Hant/integrations.json
@@ -1704,8 +1704,16 @@
         "on": "開啟",
         "off": "關閉",
         "repair": "修復",
+        "needsApproval": "需要授權",
         "checking": "檢查中…",
         "error": "錯誤"
+      },
+      "codexApproval": {
+        "title": "在 Codex 中授權 ORG2 hooks",
+        "description": "ORG2 hooks 已安裝，但 Codex 仍需要你的明確授權才能執行。",
+        "instructions": "開啟 Codex，檢查 3 條 ORG2 hooks，然後選擇 Trust all and continue。收到第一條真實 hook 訊號後，ORG2 會自動標記為已啟用。",
+        "review": "在 Codex 中檢查",
+        "verified": "已透過真實 Codex hook 訊號驗證（{{time}}）。"
       },
       "signals": {
         "title": "最近訊號",
@@ -1714,6 +1722,8 @@
         "search": "搜尋訊號",
         "refresh": "重新整理",
         "openSession": "開啟會話 {{session}}",
+        "diffLoading": "正在載入 patch…",
+        "diffEmpty": "尚未擷取到 patch。Provenance 會記錄檔案變更 metadata；只有在此會話的編輯匯入後才會顯示 diff。",
         "col": {
           "source": "工具",
           "action": "動作",

--- a/src/i18n/locales/zh/integrations.json
+++ b/src/i18n/locales/zh/integrations.json
@@ -1757,8 +1757,16 @@
         "on": "开启",
         "off": "关闭",
         "repair": "修复",
+        "needsApproval": "需要授权",
         "checking": "检查中…",
         "error": "错误"
+      },
+      "codexApproval": {
+        "title": "在 Codex 中授权 ORG2 hooks",
+        "description": "ORG2 hooks 已安装，但 Codex 需要你的明确授权才能运行它们。",
+        "instructions": "打开 Codex，检查 3 条 ORG2 hooks，然后选择 Trust all and continue。收到第一条真实 hook 信号后，ORG2 会自动标记为已启用。",
+        "review": "在 Codex 中检查",
+        "verified": "已通过真实 Codex hook 信号验证（{{time}}）。"
       },
       "signals": {
         "title": "最近信号",
@@ -1767,6 +1775,8 @@
         "search": "搜索信号",
         "refresh": "刷新",
         "openSession": "打开会话 {{session}}",
+        "diffLoading": "正在加载补丁…",
+        "diffEmpty": "尚未采集到补丁。Provenance 会记录文件变更 metadata；只有在该会话的编辑被导入后才会显示 diff。",
         "col": {
           "source": "工具",
           "action": "动作",

--- a/src/modules/shared/dataSource/SessionProvenanceHooksPanel.tsx
+++ b/src/modules/shared/dataSource/SessionProvenanceHooksPanel.tsx
@@ -15,7 +15,8 @@
  *    and links through to that session's WorkStation view. Edit signals expand
  *    to lazily load the file's diff patch when one exists.
  */
-import { RefreshCw, Terminal } from "lucide-react";
+import { useAtomValue } from "jotai";
+import { AlertTriangle, RefreshCw, Terminal } from "lucide-react";
 import React, {
   useCallback,
   useEffect,
@@ -50,6 +51,11 @@ import { parseUnifiedDiffToOldNew } from "@src/engines/SessionCore/rendering/pro
 import { CodeMirrorDiff } from "@src/features/CodeMirror/Diff";
 import { useSessionView } from "@src/hooks/ui/tabs/useSessionView";
 import InlineInfoCard from "@src/modules/shared/layouts/blocks/InlineInfoCard";
+import { TerminalService } from "@src/services/terminal";
+import {
+  activeWorkspaceRootPathAtom,
+  primaryWorkspaceRootPathAtom,
+} from "@src/store/workspace";
 import { copyText } from "@src/util/data/clipboard";
 import { formatRelativeElapsedShort } from "@src/util/data/formatters/date";
 import { openFileInWorkStation } from "@src/util/ui/openFileInWorkStation";
@@ -130,6 +136,8 @@ const SourceIcon: React.FC<{ iconId: IconProvider }> = ({ iconId }) => (
 const HookPlatformsTable: React.FC = () => {
   const { t } = useTranslation("integrations");
   const { t: tCommon } = useTranslation("common");
+  const activeWorkspaceRootPath = useAtomValue(activeWorkspaceRootPathAtom);
+  const primaryWorkspaceRootPath = useAtomValue(primaryWorkspaceRootPathAtom);
   const [statuses, setStatuses] = useState<StatusByPlatform>({});
   const [initialLoading, setInitialLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -139,14 +147,19 @@ const HookPlatformsTable: React.FC = () => {
   >(() => new Set());
   const [errors, setErrors] = useState<ErrorByPlatform>({});
   const [expandedRowKeys, setExpandedRowKeys] = useState<string[]>([]);
+  const [launchingCodexApproval, setLaunchingCodexApproval] = useState(false);
+  const approvalAutoExpanded = useRef<Set<SessionProvenanceHookPlatform>>(
+    new Set()
+  );
 
-  const loadStatuses = useCallback(async () => {
-    setRefreshing(true);
+  const loadStatuses = useCallback(async (silent = false) => {
+    if (!silent) setRefreshing(true);
     try {
       const nextStatuses = await rpc.agentOrgs.sessionProvenance.status();
       setStatuses(indexStatuses(nextStatuses));
-      setErrors({});
+      if (!silent) setErrors({});
     } catch (error) {
+      if (silent) return;
       const message = error instanceof Error ? error.message : String(error);
       setErrors(
         Object.fromEntries(
@@ -155,13 +168,53 @@ const HookPlatformsTable: React.FC = () => {
       );
     } finally {
       setInitialLoading(false);
-      setRefreshing(false);
+      if (!silent) setRefreshing(false);
     }
   }, []);
 
   useEffect(() => {
     void loadStatuses();
   }, [loadStatuses]);
+
+  useEffect(() => {
+    if (statuses.codex?.activationState !== "awaiting_approval") return;
+    const interval = window.setInterval(() => void loadStatuses(true), 2_000);
+    return () => window.clearInterval(interval);
+  }, [loadStatuses, statuses.codex?.activationState]);
+
+  useEffect(() => {
+    for (const platform of PLATFORMS) {
+      const awaitingApproval =
+        platform.id === "codex" &&
+        statuses[platform.id]?.activationState === "awaiting_approval";
+      if (awaitingApproval && !approvalAutoExpanded.current.has(platform.id)) {
+        approvalAutoExpanded.current.add(platform.id);
+        setExpandedRowKeys((current) =>
+          current.includes(platform.id) ? current : [...current, platform.id]
+        );
+      } else if (!awaitingApproval) {
+        approvalAutoExpanded.current.delete(platform.id);
+      }
+    }
+  }, [statuses]);
+
+  const handleReviewCodexHooks = useCallback(async () => {
+    setLaunchingCodexApproval(true);
+    setErrors((current) => ({ ...current, codex: undefined }));
+    try {
+      await TerminalService.executeInNewSession("codex", {
+        name: "Codex hook approval",
+        cwd: activeWorkspaceRootPath || primaryWorkspaceRootPath || undefined,
+      });
+    } catch (error) {
+      setErrors((current) => ({
+        ...current,
+        codex: error instanceof Error ? error.message : String(error),
+      }));
+    } finally {
+      setLaunchingCodexApproval(false);
+    }
+  }, [activeWorkspaceRootPath, primaryWorkspaceRootPath]);
 
   const handleChange = useCallback(
     async (platform: SessionProvenanceHookPlatform, enabled: boolean) => {
@@ -224,6 +277,9 @@ const HookPlatformsTable: React.FC = () => {
     if (status && status.desiredEnabled && !status.enabled) {
       return { color: "warning", labelKey: "repair" };
     }
+    if (status?.activationState === "awaiting_approval") {
+      return { color: "warning", labelKey: "needsApproval" };
+    }
     return status?.enabled
       ? { color: "success", labelKey: "on" }
       : { color: "default", labelKey: "off" };
@@ -243,11 +299,21 @@ const HookPlatformsTable: React.FC = () => {
               <SourceIcon iconId={row.iconId} />
             </span>
             <span className="truncate">{row.label}</span>
-            <Tag size="mini" color={statusTag.color} pill className="shrink-0">
-              {t(`agentOrgs.sessionProvenance.status.${statusTag.labelKey}`, {
-                defaultValue: statusTag.labelKey,
-              })}
-            </Tag>
+            <span
+              data-testid={`session-provenance-hook-status-${row.id}`}
+              data-activation-state={row.status?.activationState ?? "inactive"}
+            >
+              <Tag
+                size="mini"
+                color={statusTag.color}
+                pill
+                className="shrink-0"
+              >
+                {t(`agentOrgs.sessionProvenance.status.${statusTag.labelKey}`, {
+                  defaultValue: statusTag.labelKey,
+                })}
+              </Tag>
+            </span>
           </span>
         );
       },
@@ -301,6 +367,18 @@ const HookPlatformsTable: React.FC = () => {
           defaultValue:
             "The saved preference and installed hook differ. Toggle capture to repair the managed hook. Config: {{path}}",
           path: status.configPath,
+        });
+      }
+      if (status?.activationState === "awaiting_approval") {
+        return t("agentOrgs.sessionProvenance.codexApproval.description", {
+          defaultValue:
+            "Codex has the ORG2 hooks installed, but Codex still needs your approval before it can run them.",
+        });
+      }
+      if (status?.activationState === "active" && status.lastActivatedAt) {
+        return t("agentOrgs.sessionProvenance.codexApproval.verified", {
+          defaultValue: "Verified by a real Codex hook signal {{time}}.",
+          time: formatRelativeElapsedShort(new Date(status.lastActivatedAt)),
         });
       }
       return t("agentOrgs.sessionProvenance.description", {
@@ -384,6 +462,50 @@ const HookPlatformsTable: React.FC = () => {
               <p className="text-[12px] leading-relaxed text-text-2">
                 {description(row)}
               </p>
+              {row.id === "codex" &&
+                row.status?.activationState === "awaiting_approval" && (
+                  <div
+                    className="flex items-start justify-between gap-4 rounded-md border border-warning-3 bg-warning-1 px-3 py-2.5"
+                    data-testid="session-provenance-codex-approval"
+                  >
+                    <div className="flex min-w-0 items-start gap-2.5">
+                      <AlertTriangle
+                        size={16}
+                        className="mt-0.5 shrink-0 text-warning-6"
+                      />
+                      <div className="min-w-0">
+                        <p className="text-[12px] font-medium text-text-1">
+                          {t(
+                            "agentOrgs.sessionProvenance.codexApproval.title",
+                            { defaultValue: "Approve ORG2 hooks in Codex" }
+                          )}
+                        </p>
+                        <p className="mt-0.5 text-[12px] leading-relaxed text-text-2">
+                          {t(
+                            "agentOrgs.sessionProvenance.codexApproval.instructions",
+                            {
+                              defaultValue:
+                                "Open Codex, review the 3 ORG2 hooks, then choose Trust all and continue. ORG2 marks this active after the first real hook signal.",
+                            }
+                          )}
+                        </p>
+                      </div>
+                    </div>
+                    <span data-testid="session-provenance-review-codex-hooks">
+                      <Button
+                        variant="primary"
+                        size="small"
+                        icon={<Terminal size={14} />}
+                        loading={launchingCodexApproval}
+                        onClick={() => void handleReviewCodexHooks()}
+                      >
+                        {t("agentOrgs.sessionProvenance.codexApproval.review", {
+                          defaultValue: "Review in Codex",
+                        })}
+                      </Button>
+                    </span>
+                  </div>
+                )}
             </div>
           </InlineInfoCard>
         ),

--- a/src/services/terminal/TerminalService.ts
+++ b/src/services/terminal/TerminalService.ts
@@ -92,10 +92,15 @@ async function writeToPty(command: string, sessionId: string): Promise<void> {
 /**
  * Ensure terminal is ready and return session ID
  */
-async function ensureTerminalReady(): Promise<string> {
+async function ensureTerminalReady(
+  preferredSessionId?: string,
+  openTerminal = true
+): Promise<string> {
   // Bottom-panel Terminal is intentionally hidden while the standalone Terminal tab is the single source of truth.
   // PanelService.showBottomPanel("terminal");
-  await WorkStationViewService.openTerminalTab();
+  if (openTerminal) {
+    await WorkStationViewService.openTerminalTab();
+  }
 
   const store = getStore();
   const activeId = store.get(activeTerminalIdAtom);
@@ -103,23 +108,27 @@ async function ensureTerminalReady(): Promise<string> {
   const sessions = store.get(terminalSessionsAtom);
 
   // Check if we have an active initialized session
+  const requestedId = preferredSessionId ?? activeId;
   const hasValidSession =
-    sessions.length > 0 && activeId && initialized.has(activeId);
+    sessions.some((session) => session.id === requestedId) &&
+    requestedId &&
+    initialized.has(requestedId);
 
   if (hasValidSession) {
     await delay(100); // Small delay to ensure PTY is ready
-    return activeId;
+    return requestedId;
   }
 
   // No valid session - wait for one to be available
   // (UI creates session on mount, or we can create one)
-  for (let attempt = 0; attempt < 10; attempt++) {
+  for (let attempt = 0; attempt < 25; attempt++) {
     await delay(200);
     const currentActiveId = store.get(activeTerminalIdAtom);
     const currentInitialized = store.get(initializedTerminalIdsAtom);
+    const candidateId = preferredSessionId ?? currentActiveId;
 
-    if (currentActiveId && currentInitialized.has(currentActiveId)) {
-      return currentActiveId;
+    if (candidateId && currentInitialized.has(candidateId)) {
+      return candidateId;
     }
   }
 
@@ -141,6 +150,36 @@ export const TerminalService = {
   },
 
   /**
+   * Execute a command in a dedicated visible terminal session. This avoids
+   * interrupting a user's running process and is used for interactive setup
+   * flows that require the user to see and approve the CLI's native prompt.
+   */
+  async executeInNewSession(
+    command: string,
+    options?: {
+      shell?: string;
+      args?: string[];
+      name?: string;
+      profileId?: string;
+      env?: Record<string, string>;
+      cwd?: string;
+    }
+  ): Promise<string> {
+    await WorkStationViewService.openTerminalTab({
+      forceCodeEditorSurface: true,
+    });
+    const store = getStore();
+    const sessionId = store.set(editorAddTerminalSessionAtom, {
+      ...options,
+      bypassCreationCooldown: true,
+    });
+    store.set(setActiveTerminalAtom, sessionId);
+    await ensureTerminalReady(sessionId, false);
+    await writeToPty(command, sessionId);
+    return sessionId;
+  },
+
+  /**
    * Focus/show the terminal panel
    */
   focus(): void {
@@ -158,6 +197,7 @@ export const TerminalService = {
     name?: string;
     profileId?: string;
     env?: Record<string, string>;
+    cwd?: string;
   }): string {
     // Bottom-panel Terminal is intentionally hidden while the standalone Terminal tab is the single source of truth.
     // PanelService.showBottomPanel("terminal");

--- a/src/services/workStation/WorkStationViewService.ts
+++ b/src/services/workStation/WorkStationViewService.ts
@@ -77,6 +77,9 @@ interface NavigationOptions {
   toggleChatPanelMaximizedWhenActive?: boolean;
   /** Match active tab by type (e.g. any `source-control` pinned tab id). */
   activeTabType?: WorkStationTabType;
+  /** Interactive setup flows that create a managed PTY must use the Code
+   * Editor terminal even when invoked from Agent Station. */
+  forceCodeEditorSurface?: boolean;
 }
 
 async function shouldToggleMaximizedForActiveTab(
@@ -350,7 +353,8 @@ export const WorkStationViewService = {
 
     if (
       isWorkStationRoute() &&
-      store.get(stationModeAtom) === "agent-station"
+      store.get(stationModeAtom) === "agent-station" &&
+      !options?.forceCodeEditorSurface
     ) {
       store.set(chatPanelMaximizedAtom, false);
       store.set(simulatorSelectedAppAtom, AppType.CODE_EDITOR);

--- a/src/store/workstation/codeEditor/terminal/__tests__/terminalAtoms.test.ts
+++ b/src/store/workstation/codeEditor/terminal/__tests__/terminalAtoms.test.ts
@@ -8,6 +8,11 @@ import { createStore } from "jotai/vanilla";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  notifyTerminalCreationCooldown,
+  tryBeginTerminalCreation,
+} from "@src/util/ui/terminal/creationThrottle";
+
+import {
   activeTerminalIdAtom,
   closeTerminalSessionAtom,
   createAgentSessionTerminalAtom,
@@ -46,6 +51,7 @@ describe("terminal atoms", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(tryBeginTerminalCreation).mockReturnValue(true);
     store = createStore();
     // Initialize with a clean state
     store.set(terminalSessionsAtom, [
@@ -94,6 +100,22 @@ describe("terminal atoms", () => {
       expect(newSession?.shell).toBe("/bin/fish");
       expect(newSession?.profileId).toBe("fish-profile");
       expect(newSession?.cwd).toBe("/repo/project");
+    });
+
+    it("allows controlled setup flows to create a dedicated session during cooldown", () => {
+      vi.mocked(tryBeginTerminalCreation).mockReturnValue(false);
+
+      const newId = store.set(editorAddTerminalSessionAtom, {
+        name: "Codex hook approval",
+        bypassCreationCooldown: true,
+      });
+
+      const sessions = store.get(terminalSessionsAtom);
+      expect(sessions).toHaveLength(2);
+      expect(sessions.find((session) => session.id === newId)?.name).toBe(
+        "Codex hook approval"
+      );
+      expect(notifyTerminalCreationCooldown).not.toHaveBeenCalled();
     });
   });
 

--- a/src/store/workstation/codeEditor/terminal/index.ts
+++ b/src/store/workstation/codeEditor/terminal/index.ts
@@ -269,7 +269,7 @@ function removeTerminalSessionLocalOnly(
 export const editorAddTerminalSessionAtom = atom(
   null,
   (get, set, options?: AddSessionOptions) => {
-    if (!tryBeginTerminalCreation()) {
+    if (!options?.bypassCreationCooldown && !tryBeginTerminalCreation()) {
       notifyTerminalCreationCooldown();
       return get(activeTerminalIdAtom);
     }

--- a/tests/e2e/specs/core/session-launch-wiring-ui.spec.mjs
+++ b/tests/e2e/specs/core/session-launch-wiring-ui.spec.mjs
@@ -3,6 +3,7 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   BUILTIN_SDE_AGENT_ID,
@@ -28,6 +29,12 @@ import {
 } from "../../support/core/session/toolCoverage.mjs";
 
 const RUN_ID = Date.now();
+const SPEC_DIR = path.dirname(fileURLToPath(import.meta.url));
+const APP_BINARY = path.resolve(
+  SPEC_DIR,
+  "../../../..",
+  "src-tauri/target/debug/org2"
+);
 const BUILTIN_OS_AGENT_ID = "builtin:os";
 const RENDER_TIMEOUT_MS = 30_000;
 const E2E_BASE_URL = `http://127.0.0.1:${process.env.E2E_IDE_SERVER_PORT ?? "13847"}`;
@@ -105,6 +112,31 @@ async function postJson(pathname, body = {}, timeoutMs = 10_000) {
 
 async function execJS(script) {
   return browser.executeScript(script, []);
+}
+
+async function invokeTauriCommand(command, args = {}) {
+  const envelope = await browser.executeAsyncScript(
+    `
+      const cb = arguments[arguments.length - 1];
+      const command = arguments[0];
+      const args = arguments[1];
+      const invoke = window.__TAURI_INTERNALS__?.invoke;
+      if (typeof invoke !== 'function') {
+        cb({ ok: false, error: 'Tauri invoke is unavailable' });
+        return;
+      }
+      Promise.resolve(invoke(command, args))
+        .then((result) => cb({ ok: true, result }))
+        .catch((error) => cb({ ok: false, error: String(error?.message || error) }));
+    `,
+    [command, args]
+  );
+  if (envelope?.ok !== true) {
+    throw new Error(
+      `Tauri ${command} failed: ${envelope?.error ?? "unknown error"}`
+    );
+  }
+  return envelope.result;
 }
 
 async function waitForRenderedSession(sessionId, label) {
@@ -1010,6 +1042,10 @@ describe("Session launch wiring rendered UI invariants", function () {
       return;
     }
 
+    unwrap(
+      await invokeE2E("ensureRepoSelected", { repoPath: E2E_REPO_PATH }),
+      "select workspace for Codex hook approval"
+    );
     unwrap(await invokeE2E("resetToNewSession"), "reset to Launchpad");
 
     const clickVisible = async (selector, label) => {
@@ -1078,19 +1114,24 @@ describe("Session launch wiring rendered UI invariants", function () {
     };
 
     const openHooks = async () => {
-      const runtimeVisible = await execJS(`
-        const element = document.querySelector('[data-testid="chat-panel-start-page-runtime"]');
-        if (!element) return false;
-        const rect = element.getBoundingClientRect();
-        const style = window.getComputedStyle(element);
-        return rect.width > 0 && rect.height > 0 && style.display !== 'none' && style.visibility !== 'hidden';
-      `);
-      if (!runtimeVisible) {
-        await clickVisible(
-          '[data-testid="chat-panel-start-page-tab-runtime"]',
-          "Launchpad Runtime tab"
-        );
-      }
+      await clickVisible(
+        '[data-testid="chat-panel-start-page-tab-runtime"]',
+        "Launchpad Runtime tab"
+      );
+      await browser.waitUntil(
+        async () =>
+          execJS(`
+            const hooks = document.querySelector('[data-testid="data-source-view-hooks"]');
+            if (hooks) return true;
+            document.querySelector('[data-testid="chat-panel-start-page-tab-runtime"]')?.click();
+            return false;
+          `),
+        {
+          timeout: RENDER_TIMEOUT_MS,
+          interval: 300,
+          timeoutMsg: "Launchpad Runtime content did not activate",
+        }
+      );
       await clickVisible('[data-testid="data-source-view-hooks"]', "Hooks tab");
       await browser.waitUntil(
         async () =>
@@ -1108,10 +1149,6 @@ describe("Session launch wiring rendered UI invariants", function () {
       );
     };
 
-    await clickVisible(
-      '[data-testid="chat-panel-start-page-tab-runtime"]',
-      "Launchpad Runtime tab"
-    );
     await openHooks();
 
     let panelState = null;
@@ -1184,6 +1221,186 @@ describe("Session launch wiring rendered UI invariants", function () {
         );
       }
       await waitForSwitchState("codex", originalCodexState);
+    }
+
+    // Codex is the one managed provider with its own trust gate. Installation
+    // alone must never be rendered as active.
+    await openHooks();
+    const codexEnabled = await execJS(`
+      return document.querySelector('[data-testid="session-provenance-hook-switch-codex"]')?.getAttribute('aria-checked') === 'true';
+    `);
+    if (!codexEnabled) {
+      await clickVisible(
+        '[data-testid="session-provenance-hook-switch-codex"]',
+        "Codex hook switch for approval flow"
+      );
+      await waitForSwitchState("codex", true);
+    }
+
+    let approvalState = null;
+    try {
+      await browser.waitUntil(
+        async () => {
+          try {
+            approvalState = await execJS(`
+              return [
+                document.querySelector('[data-testid="session-provenance-hook-status-codex"]')?.getAttribute('data-activation-state') || '',
+                document.querySelector('[data-testid="session-provenance-codex-approval"]')?.textContent || '',
+                Boolean(document.querySelector('[data-testid="session-provenance-review-codex-hooks"] button'))
+              ];
+            `);
+          } catch (error) {
+            approvalState = ["webdriver-error", String(error), false];
+            return false;
+          }
+          const activationState = String(approvalState?.[0] ?? "").trim();
+          const cardText = String(approvalState?.[1] ?? "")
+            .trim()
+            .replace(/\s+/g, " ");
+          return (
+            activationState === "awaiting_approval" &&
+            cardText.includes("ORG2 hooks") &&
+            cardText.includes("Trust all and continue") &&
+            approvalState?.[2] === true
+          );
+        },
+        {
+          timeout: RENDER_TIMEOUT_MS,
+          interval: 250,
+          timeoutMsg: "Codex approval state did not render",
+        }
+      );
+    } catch (error) {
+      throw new Error(
+        `${error.message}: latest=${JSON.stringify(approvalState)}`
+      );
+    }
+
+    const ptysBeforeApproval = await invokeTauriCommand("list_pty_sessions");
+    const ptyIdsBeforeApproval = new Set(
+      ptysBeforeApproval.map((session) => session.session_id)
+    );
+    let approvalPty = null;
+    let approvalOutput = "";
+    let latestPtySessions = [];
+    let skippedCodexUpdatePrompt = false;
+    try {
+      await clickVisible(
+        '[data-testid="session-provenance-review-codex-hooks"] button',
+        "Review Codex hooks button"
+      );
+
+      // The production button must open a dedicated visible terminal and run
+      // Codex far enough to render its native trust prompt. We intentionally do
+      // not choose a trust option in automation.
+      try {
+        await browser.waitUntil(
+          async () => {
+            latestPtySessions = await invokeTauriCommand("list_pty_sessions");
+            approvalPty = latestPtySessions.find(
+              (session) =>
+                !ptyIdsBeforeApproval.has(session.session_id) &&
+                session.name === "Codex hook approval"
+            );
+            if (!approvalPty) return false;
+            const snapshot = await invokeTauriCommand(
+              "get_pty_output_snapshot",
+              { sessionId: approvalPty.session_id }
+            );
+            approvalOutput = String(snapshot?.output ?? "");
+            if (
+              !skippedCodexUpdatePrompt &&
+              approvalOutput.includes("Update now") &&
+              approvalOutput.includes("Skip")
+            ) {
+              // A Codex release prompt can precede hook review. Skip only this
+              // update choice; the user's hook trust decision remains untouched.
+              await invokeTauriCommand("write_pty", {
+                sessionId: approvalPty.session_id,
+                data: "2",
+              });
+              skippedCodexUpdatePrompt = true;
+              return false;
+            }
+            return (
+              approvalOutput.includes("3 hooks are new or changed") &&
+              approvalOutput.includes("Trust") &&
+              approvalOutput.includes("continue")
+            );
+          },
+          {
+            timeout: RENDER_TIMEOUT_MS,
+            interval: 300,
+            timeoutMsg: "Codex native hook trust prompt did not appear",
+          }
+        );
+      } catch (error) {
+        const terminalUiState = await execJS(`
+          return {
+            href: window.location.href,
+            hasTerminal: Boolean(document.querySelector('.terminal-core')),
+            body: (document.body.innerText || '').slice(0, 2000)
+          };
+        `);
+        throw new Error(
+          `${error.message}: ptys=${JSON.stringify(latestPtySessions)} selected=${JSON.stringify(approvalPty)} output=${JSON.stringify(approvalOutput.slice(-2000))} ui=${JSON.stringify(terminalUiState)}`
+        );
+      }
+
+      if (approvalPty.name !== "Codex hook approval") {
+        throw new Error(
+          `Dedicated approval terminal was not named correctly: ${JSON.stringify(approvalPty)}`
+        );
+      }
+
+      // Deterministically emulate the first post-approval callback by invoking
+      // the real installed hook binary and adapter path. This establishes the
+      // activation receipt without automating the user's security decision.
+      execFileSync(APP_BINARY, ["--session-provenance-hook", "codex"], {
+        input: JSON.stringify({
+          session_id: `e2e-codex-trust-${RUN_ID}`,
+          turn_id: `turn-${RUN_ID}`,
+          cwd: E2E_REPO_PATH,
+          hook_event_name: "PostToolUse",
+          tool_name: "apply_patch",
+          tool_use_id: `tool-${RUN_ID}`,
+          tool_input: {
+            command:
+              "*** Begin Patch\n*** Add File: e2e-trust-proof.txt\n+proof\n*** End Patch",
+          },
+        }),
+        env: process.env,
+        stdio: ["pipe", "ignore", "pipe"],
+      });
+    } finally {
+      if (approvalPty?.session_id) {
+        await invokeTauriCommand("close_pty", {
+          sessionId: approvalPty.session_id,
+        });
+      }
+    }
+
+    let activeState = null;
+    await browser.waitUntil(
+      async () => {
+        activeState = await execJS(`
+          return document.querySelector('[data-testid="session-provenance-hook-status-codex"]')?.getAttribute('data-activation-state') ?? '';
+        `);
+        return activeState === "active";
+      },
+      {
+        timeout: RENDER_TIMEOUT_MS,
+        interval: 250,
+        timeoutMsg: `Codex did not render active after a real hook callback: ${JSON.stringify(activeState)}`,
+      }
+    );
+
+    if (!originalCodexState) {
+      await clickVisible(
+        '[data-testid="session-provenance-hook-switch-codex"]',
+        "Codex hook switch final restore"
+      );
+      await waitForSwitchState("codex", false);
     }
   });
 


### PR DESCRIPTION
## Summary

- separate managed-hook installation from runtime activation so Codex reports `awaiting_approval` until the current ORG2 hook definition actually runs
- persist an atomic, versioned activation receipt keyed by a fingerprint of only ORG2-managed Codex hooks, preserving unrelated user hooks and invalidating stale approvals when managed definitions change
- add a localized `Needs approval` UX that opens a dedicated named Codex terminal in the current/primary workspace and silently refreshes to `Active` after the first real hook callback
- make controlled terminal setup reliable across Agent Station and Code Editor without weakening the user-facing terminal creation throttle
- extend the rendered runtime-hooks E2E to cover the native Codex review screen and the post-approval adapter/activation loop without automating the user's trust decision

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm exec vitest run src/api/tauri/rpc/__tests__/sessionProvenanceSchemas.test.ts src/store/workstation/codeEditor/terminal/__tests__/terminalAtoms.test.ts` (25 passed)
- [x] `cargo test -p agent_cli session_provenance --lib` (31 passed)
- [x] `cargo check -p org2`
- [x] commit hooks: lint-staged, scoped TypeScript check, and `cargo clippy` for `agent_cli` + `org2`
- [x] integrations i18n completeness check (0 missing)
- [x] real macOS Tauri/WebDriver runtime-hooks scenario twice consecutively (native Codex hook review prompt, installed adapter callback, automatic `active`; 1 passed / 16 filtered each run)

## Submit checklist

- [x] The PR is focused and has a scoped Conventional Commits title, such as `feat(scope): summary` or `fix(scope): summary`.
- [x] I ran the relevant checks, or explained why they were not run.
- [x] No secrets, private config, generated output, or unrelated formatting changes are included.
- [x] Docs, screenshots, and locale updates are included when the change needs them.
