### PR TITLE
feat(sessions): master switches for external sources and hooks

### DIFF
--- a/src-tauri/crates/agent-cli/src/session_provenance.rs
+++ b/src-tauri/crates/agent-cli/src/session_provenance.rs
@@ -203,6 +203,11 @@ fn opencode_plugin_path() -> PathBuf {
 #[serde(rename_all = "camelCase", default)]
 struct HookPreferences {
     schema_version: u32,
+    /// Master switch over every managed hook. When off, all platform hooks
+    /// are uninstalled regardless of the per-platform flags below; those
+    /// flags are preserved so switching back on restores the previous
+    /// per-platform selection.
+    master_enabled: bool,
     claude_code: bool,
     codex: bool,
     cursor: bool,
@@ -223,6 +228,7 @@ impl Default for HookPreferences {
     fn default() -> Self {
         Self {
             schema_version: PREFERENCES_SCHEMA_VERSION,
+            master_enabled: true,
             claude_code: true,
             codex: true,
             cursor: true,
@@ -239,6 +245,12 @@ impl Default for HookPreferences {
 }
 
 impl HookPreferences {
+    /// Whether the hook should actually be installed for `platform`: the
+    /// per-platform flag gated by the master switch.
+    fn effective_enabled(&self, platform: SessionProvenanceHookPlatform) -> bool {
+        self.master_enabled && self.enabled(platform)
+    }
+
     fn enabled(&self, platform: SessionProvenanceHookPlatform) -> bool {
         match platform {
             SessionProvenanceHookPlatform::ClaudeCode => self.claude_code,
@@ -1514,7 +1526,9 @@ pub fn ensure_hooks_from_preferences() -> Result<(), String> {
         .map_err(|err| format!("Failed to locate ORG2 executable: {err}"))?;
     let mut errors = Vec::new();
     for platform in ALL_SESSION_PROVENANCE_HOOK_PLATFORMS {
-        if let Err(err) = update_platform(platform, preferences.enabled(platform), &executable) {
+        if let Err(err) =
+            update_platform(platform, preferences.effective_enabled(platform), &executable)
+        {
             errors.push(format!("{platform:?}: {err}"));
         }
     }
@@ -1557,8 +1571,68 @@ pub async fn session_provenance_hooks_set_enabled(
         // Persist the user's desired state before touching a provider file.
         // If a malformed or read-only config cannot be repaired immediately,
         // startup reconciliation can retry without losing the opt-out.
-        let update_error = update_platform(platform, enabled, &executable).err();
+        // The master switch gates the actual installation.
+        let update_error = update_platform(
+            platform,
+            preferences.effective_enabled(platform),
+            &executable,
+        )
+        .err();
         Ok(build_hook_status(platform, enabled, update_error))
+    })
+    .await
+    .map_err(|err| format!("Task join error: {err}"))?
+}
+
+/// Lock-free master-switch probe for the short-lived hook capture process.
+/// Errs on the side of capturing (true): a missing or corrupt preferences
+/// file must never silently discard signals while hooks are still installed.
+pub fn provenance_hooks_master_enabled_quick() -> bool {
+    read_preferences()
+        .map(|preferences| preferences.master_enabled)
+        .unwrap_or(true)
+}
+
+/// Whether the master switch over all managed provenance hooks is on.
+#[tauri::command]
+pub async fn session_provenance_hooks_master_enabled() -> Result<bool, String> {
+    tokio::task::spawn_blocking(|| {
+        let _guard = operation_guard()?;
+        Ok::<_, String>(read_preferences()?.master_enabled)
+    })
+    .await
+    .map_err(|err| format!("Task join error: {err}"))?
+}
+
+/// Flip the master switch over all managed provenance hooks. Per-platform
+/// preferences are preserved: switching off uninstalls every managed hook,
+/// switching back on reinstalls the platforms that were individually enabled.
+/// Returns the refreshed per-platform statuses.
+#[tauri::command]
+pub async fn session_provenance_hooks_set_master_enabled(
+    enabled: bool,
+) -> Result<Vec<SessionProvenanceHookStatus>, String> {
+    tokio::task::spawn_blocking(move || {
+        let _guard = operation_guard()?;
+        let executable = std::env::current_exe()
+            .map_err(|err| format!("Failed to locate ORG2 executable: {err}"))?;
+        let mut preferences = read_preferences()?;
+        preferences.master_enabled = enabled;
+        write_preferences(&preferences)?;
+        Ok::<_, String>(
+            ALL_SESSION_PROVENANCE_HOOK_PLATFORMS
+                .into_iter()
+                .map(|platform| {
+                    let update_error = update_platform(
+                        platform,
+                        preferences.effective_enabled(platform),
+                        &executable,
+                    )
+                    .err();
+                    build_hook_status(platform, preferences.enabled(platform), update_error)
+                })
+                .collect::<Vec<_>>(),
+        )
     })
     .await
     .map_err(|err| format!("Task join error: {err}"))?

--- a/src-tauri/src/commands/handler_list.inc
+++ b/src-tauri/src/commands/handler_list.inc
@@ -821,6 +821,8 @@ agent_cli::managed_config::cli_config_restore_default,
 cli_managed_proxy::cli_managed_proxy_status,
 agent_cli::session_provenance::session_provenance_hooks_status,
 agent_cli::session_provenance::session_provenance_hooks_set_enabled,
+agent_cli::session_provenance::session_provenance_hooks_master_enabled,
+agent_cli::session_provenance::session_provenance_hooks_set_master_enabled,
 orgtrack::session_provenance::session_provenance_recent_signals,
 // Claude Code config (~/.claude/settings.json)
 agent_cli::claude_code::commands::claude_code_config_read,

--- a/src-tauri/src/orgtrack/session_provenance/hook_capture.rs
+++ b/src-tauri/src/orgtrack/session_provenance/hook_capture.rs
@@ -26,6 +26,13 @@ static INBOX_DRAIN_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 /// Entry point used by `orgii --session-provenance-hook <source>`.
 /// Provenance failures are diagnostic only and never block the provider tool.
 pub fn capture_hook_stdin(source: &str) -> Result<usize, String> {
+    // Backstop for the hooks master switch: when it is off the managed hooks
+    // are uninstalled, so this process normally isn't spawned at all — but a
+    // stale hook line (failed uninstall, read-only config) may still invoke
+    // us. Discard instead of spooling signals the user opted out of.
+    if !agent_cli::session_provenance::provenance_hooks_master_enabled_quick() {
+        return Ok(0);
+    }
     let source_arg = source;
     let source = HookSource::parse(source)?;
     let mut stdin = std::io::stdin().take(MAX_HOOK_PAYLOAD_BYTES + 1);

--- a/src/api/tauri/rpc/procedures/agentOrgs.ts
+++ b/src/api/tauri/rpc/procedures/agentOrgs.ts
@@ -127,6 +127,15 @@ const sessionProvenance = {
     .input(schemas.agentOrgs.SessionProvenanceHookSetEnabledInput)
     .output(schemas.agentOrgs.SessionProvenanceHookStatusSchema)
     .build(),
+  masterEnabled: defineProcedure("session_provenance_hooks_master_enabled")
+    .output(z.boolean())
+    .build(),
+  setMasterEnabled: defineProcedure(
+    "session_provenance_hooks_set_master_enabled"
+  )
+    .input(z.object({ enabled: z.boolean() }))
+    .output(z.array(schemas.agentOrgs.SessionProvenanceHookStatusSchema))
+    .build(),
   recentSignals: defineProcedure("session_provenance_recent_signals")
     .input(schemas.agentOrgs.SessionProvenanceRecentSignalsInput)
     .output(z.array(schemas.agentOrgs.SessionProvenanceRecentSignalSchema))

--- a/src/engines/SessionCore/sync/externalHistoryAutoRefresh.ts
+++ b/src/engines/SessionCore/sync/externalHistoryAutoRefresh.ts
@@ -1,7 +1,9 @@
+import { useAtomValue } from "jotai";
 import { useEffect } from "react";
 
 import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 import { createLogger } from "@src/hooks/logger";
+import { externalSessionsEnabledAtom } from "@src/store/session/dataSourceConfigAtom";
 import { isImportedHistorySession } from "@src/util/session/sessionDispatch";
 
 import { getAdapterForSession } from "./types";
@@ -35,8 +37,10 @@ export function useExternalHistoryAutoRefresh(options: {
   dispatchLoadSession: DispatchSessionLoad;
 }): void {
   const { sessionId, intervalMs, dispatchLoadSession } = options;
+  const externalSessionsEnabled = useAtomValue(externalSessionsEnabledAtom);
 
   useEffect(() => {
+    if (!externalSessionsEnabled) return;
     if (!sessionId || !isImportedHistorySession(sessionId)) return;
 
     let refreshRunning = false;
@@ -66,5 +70,5 @@ export function useExternalHistoryAutoRefresh(options: {
       window.clearInterval(intervalId);
       activeController?.abort();
     };
-  }, [dispatchLoadSession, intervalMs, sessionId]);
+  }, [dispatchLoadSession, externalSessionsEnabled, intervalMs, sessionId]);
 }

--- a/src/i18n/locales/en/integrations.json
+++ b/src/i18n/locales/en/integrations.json
@@ -2382,6 +2382,8 @@
     "deleteOrgMessage": "\"{{name}}\" will be permanently removed. This cannot be undone.",
     "sessionProvenance": {
       "title": "Session Provenance",
+      "masterToggle": "Provenance hooks",
+      "masterToggleDesc": "When off, all managed hooks are uninstalled and no signals are captured; per-platform choices are kept and restored on re-enable",
       "capture": "Capture file interactions",
       "description": "Records file reads and writes as metadata. Prompts, tool output, and file contents are not stored.",
       "configPath": "Records file reads and writes as metadata. Prompts, tool output, and file contents are not stored. Config: {{path}}",

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -106,6 +106,8 @@
       "lastScan": "Last scan {{time}}",
       "neverScanned": "Never scanned",
       "frequencyTitle": "Auto-scan frequency",
+      "externalSessionsToggle": "External sessions",
+      "externalSessionsToggleDesc": "When off, no external source is scanned or its sessions loaded",
       "globalFrequency": "External source auto-scan",
       "globalFrequencyDesc": "Default scan frequency for external sources set to Default",
       "activeSessionRefresh": "Open external session refresh",

--- a/src/i18n/locales/zh/integrations.json
+++ b/src/i18n/locales/zh/integrations.json
@@ -1742,6 +1742,8 @@
     },
     "sessionProvenance": {
       "title": "Session Provenance",
+      "masterToggle": "溯源 Hooks",
+      "masterToggleDesc": "关闭后将卸载所有托管 hook,不再采集任何信号;各平台的选择会保留,重新开启时恢复",
       "capture": "采集文件交互记录",
       "description": "以 metadata 形式记录文件读写；不会存储提示词、工具输出或文件内容。",
       "configPath": "以 metadata 形式记录文件读写；不会存储提示词、工具输出或文件内容。配置：{{path}}",

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -103,6 +103,8 @@
       "lastScan": "上次扫描 {{time}}",
       "neverScanned": "从未扫描",
       "frequencyTitle": "自动扫描频率",
+      "externalSessionsToggle": "外部会话",
+      "externalSessionsToggleDesc": "关闭后将停止扫描和加载所有外部数据源的会话",
       "globalFrequency": "外部数据源自动扫描",
       "globalFrequencyDesc": "设为“默认”的外部数据源所使用的扫描频率",
       "activeSessionRefresh": "已打开外部会话刷新",

--- a/src/modules/shared/dataSource/SessionProvenanceHooksPanel.tsx
+++ b/src/modules/shared/dataSource/SessionProvenanceHooksPanel.tsx
@@ -50,6 +50,10 @@ import { INFO_CARD_TOKENS } from "@src/config/detailPanelTokens";
 import { parseUnifiedDiffToOldNew } from "@src/engines/SessionCore/rendering/props/extractorShared";
 import { CodeMirrorDiff } from "@src/features/CodeMirror/Diff";
 import { useSessionView } from "@src/hooks/ui/tabs/useSessionView";
+import {
+  SectionContainer,
+  SectionRow,
+} from "@src/modules/shared/layouts/SectionLayout";
 import InlineInfoCard from "@src/modules/shared/layouts/blocks/InlineInfoCard";
 import { TerminalService } from "@src/services/terminal";
 import {
@@ -152,11 +156,40 @@ const HookPlatformsTable: React.FC = () => {
     new Set()
   );
 
+  const [masterEnabled, setMasterEnabled] = useState(true);
+  const [masterPending, setMasterPending] = useState(false);
+
+  const handleMasterChange = useCallback(async (enabled: boolean) => {
+    setMasterPending(true);
+    const previous = !enabled;
+    setMasterEnabled(enabled);
+    try {
+      const nextStatuses =
+        await rpc.agentOrgs.sessionProvenance.setMasterEnabled({ enabled });
+      setStatuses(indexStatuses(nextStatuses));
+      setErrors({});
+    } catch (error) {
+      setMasterEnabled(previous);
+      const message = error instanceof Error ? error.message : String(error);
+      setErrors(
+        Object.fromEntries(
+          PLATFORMS.map(({ id }) => [id, message])
+        ) as ErrorByPlatform
+      );
+    } finally {
+      setMasterPending(false);
+    }
+  }, []);
+
   const loadStatuses = useCallback(async (silent = false) => {
     if (!silent) setRefreshing(true);
     try {
-      const nextStatuses = await rpc.agentOrgs.sessionProvenance.status();
+      const [nextStatuses, nextMasterEnabled] = await Promise.all([
+        rpc.agentOrgs.sessionProvenance.status(),
+        rpc.agentOrgs.sessionProvenance.masterEnabled(),
+      ]);
       setStatuses(indexStatuses(nextStatuses));
+      setMasterEnabled(nextMasterEnabled);
       if (!silent) setErrors({});
     } catch (error) {
       if (silent) return;
@@ -344,7 +377,7 @@ const HookPlatformsTable: React.FC = () => {
         <div className="flex items-center justify-end">
           <Switch
             checked={row.status?.enabled ?? false}
-            disabled={row.loading}
+            disabled={row.loading || !masterEnabled}
             loading={row.pending}
             ariaLabel={`${row.label} — ${t(
               "agentOrgs.sessionProvenance.capture",
@@ -390,130 +423,157 @@ const HookPlatformsTable: React.FC = () => {
   );
 
   return (
-    <SettingsTable<PlatformRow>
-      columns={columns}
-      rows={visibleRows}
-      getRowKey={(row) => row.id}
-      headerHeight="tall"
-      inlineHeaderToolbar
-      className="table-expanded-no-hover table-settings-expanded-compact"
-      hover
-      loading={initialLoading && rows.every((row) => !row.status)}
-      emptyTitle={term ? tCommon("status.noResults") : undefined}
-      searchBar={{
-        searchValue: searchQuery,
-        searchPlaceholder: tCommon("common.searchPlaceholder"),
-        onSearchChange: setSearchQuery,
-        onSearchClear: () => setSearchQuery(""),
-        searchInputSize: "default",
-        rightContent: (
-          <Button
-            variant="secondary"
-            size="default"
-            loading={refreshing}
-            icon={<RefreshCw size={14} />}
-            onClick={() => void loadStatuses()}
-          >
-            {tCommon("actions.refresh")}
-          </Button>
-        ),
-      }}
-      expandable={{
-        expandedRowRender: (row) => (
-          <InlineInfoCard dataTestId={`session-provenance-hook-card-${row.id}`}>
-            <div className={`grid ${INFO_CARD_TOKENS.rowGap}`}>
-              <div className="flex items-start justify-between gap-3">
-                <span className={`${INFO_CARD_TOKENS.label} pt-1`}>
-                  {t("agentOrgs.sessionProvenance.col.config", {
-                    defaultValue: "Config",
-                  })}
-                </span>
-                {row.status?.configPath ? (
-                  <div className="flex min-w-0 items-center gap-1.5">
-                    <span
-                      className="min-w-0 truncate text-[12px] text-text-1"
-                      title={row.status.configPath}
-                    >
-                      {tildePath(row.status.configPath)}
-                    </span>
-                    <Button
-                      variant="secondary"
-                      size="small"
-                      onClick={() => void copyText(row.status!.configPath)}
-                    >
-                      {t("agentOrgs.sessionProvenance.copyPath", {
-                        defaultValue: "Copy",
-                      })}
-                    </Button>
-                    <Button
-                      variant="secondary"
-                      size="small"
-                      onClick={() =>
-                        openFileInWorkStation(row.status!.configPath)
-                      }
-                    >
-                      {tCommon("actions.open")}
-                    </Button>
-                  </div>
-                ) : (
-                  <span className={INFO_CARD_TOKENS.value}>—</span>
-                )}
-              </div>
-              <p className="text-[12px] leading-relaxed text-text-2">
-                {description(row)}
-              </p>
-              {row.id === "codex" &&
-                row.status?.activationState === "awaiting_approval" && (
-                  <div
-                    className="flex items-start justify-between gap-4 rounded-md border border-warning-3 bg-warning-1 px-3 py-2.5"
-                    data-testid="session-provenance-codex-approval"
-                  >
-                    <div className="flex min-w-0 items-start gap-2.5">
-                      <AlertTriangle
-                        size={16}
-                        className="mt-0.5 shrink-0 text-warning-6"
-                      />
-                      <div className="min-w-0">
-                        <p className="text-[12px] font-medium text-text-1">
-                          {t(
-                            "agentOrgs.sessionProvenance.codexApproval.title",
-                            { defaultValue: "Approve ORG2 hooks in Codex" }
-                          )}
-                        </p>
-                        <p className="mt-0.5 text-[12px] leading-relaxed text-text-2">
-                          {t(
-                            "agentOrgs.sessionProvenance.codexApproval.instructions",
-                            {
-                              defaultValue:
-                                "Open Codex, review the 3 ORG2 hooks, then choose Trust all and continue. ORG2 marks this active after the first real hook signal.",
-                            }
-                          )}
-                        </p>
-                      </div>
-                    </div>
-                    <span data-testid="session-provenance-review-codex-hooks">
-                      <Button
-                        variant="primary"
-                        size="small"
-                        icon={<Terminal size={14} />}
-                        loading={launchingCodexApproval}
-                        onClick={() => void handleReviewCodexHooks()}
+    <div className="flex flex-col gap-3">
+      <SectionContainer>
+        <SectionRow
+          label={t("agentOrgs.sessionProvenance.masterToggle", {
+            defaultValue: "Provenance hooks",
+          })}
+          description={t("agentOrgs.sessionProvenance.masterToggleDesc", {
+            defaultValue:
+              "When off, all managed hooks are uninstalled and no signals are captured",
+          })}
+        >
+          <Switch
+            checked={masterEnabled}
+            loading={masterPending}
+            onChange={(enabled) => void handleMasterChange(enabled)}
+            ariaLabel={t("agentOrgs.sessionProvenance.masterToggle", {
+              defaultValue: "Provenance hooks",
+            })}
+          />
+        </SectionRow>
+      </SectionContainer>
+      <SettingsTable<PlatformRow>
+        columns={columns}
+        rows={visibleRows}
+        getRowKey={(row) => row.id}
+        headerHeight="tall"
+        inlineHeaderToolbar
+        className="table-expanded-no-hover table-settings-expanded-compact"
+        hover
+        loading={initialLoading && rows.every((row) => !row.status)}
+        emptyTitle={term ? tCommon("status.noResults") : undefined}
+        searchBar={{
+          searchValue: searchQuery,
+          searchPlaceholder: tCommon("common.searchPlaceholder"),
+          onSearchChange: setSearchQuery,
+          onSearchClear: () => setSearchQuery(""),
+          searchInputSize: "default",
+          rightContent: (
+            <Button
+              variant="secondary"
+              size="default"
+              loading={refreshing}
+              icon={<RefreshCw size={14} />}
+              onClick={() => void loadStatuses()}
+            >
+              {tCommon("actions.refresh")}
+            </Button>
+          ),
+        }}
+        expandable={{
+          expandedRowRender: (row) => (
+            <InlineInfoCard
+              dataTestId={`session-provenance-hook-card-${row.id}`}
+            >
+              <div className={`grid ${INFO_CARD_TOKENS.rowGap}`}>
+                <div className="flex items-start justify-between gap-3">
+                  <span className={`${INFO_CARD_TOKENS.label} pt-1`}>
+                    {t("agentOrgs.sessionProvenance.col.config", {
+                      defaultValue: "Config",
+                    })}
+                  </span>
+                  {row.status?.configPath ? (
+                    <div className="flex min-w-0 items-center gap-1.5">
+                      <span
+                        className="min-w-0 truncate text-[12px] text-text-1"
+                        title={row.status.configPath}
                       >
-                        {t("agentOrgs.sessionProvenance.codexApproval.review", {
-                          defaultValue: "Review in Codex",
+                        {tildePath(row.status.configPath)}
+                      </span>
+                      <Button
+                        variant="secondary"
+                        size="small"
+                        onClick={() => void copyText(row.status!.configPath)}
+                      >
+                        {t("agentOrgs.sessionProvenance.copyPath", {
+                          defaultValue: "Copy",
                         })}
                       </Button>
-                    </span>
-                  </div>
-                )}
-            </div>
-          </InlineInfoCard>
-        ),
-        rowExpandable: () => true,
-        expandedRowKeys,
-        onExpandedRowsChange: setExpandedRowKeys,
-      }}
-    />
+                      <Button
+                        variant="secondary"
+                        size="small"
+                        onClick={() =>
+                          openFileInWorkStation(row.status!.configPath)
+                        }
+                      >
+                        {tCommon("actions.open")}
+                      </Button>
+                    </div>
+                  ) : (
+                    <span className={INFO_CARD_TOKENS.value}>—</span>
+                  )}
+                </div>
+                <p className="text-[12px] leading-relaxed text-text-2">
+                  {description(row)}
+                </p>
+                {row.id === "codex" &&
+                  row.status?.activationState === "awaiting_approval" && (
+                    <div
+                      className="flex items-start justify-between gap-4 rounded-md border border-warning-3 bg-warning-1 px-3 py-2.5"
+                      data-testid="session-provenance-codex-approval"
+                    >
+                      <div className="flex min-w-0 items-start gap-2.5">
+                        <AlertTriangle
+                          size={16}
+                          className="mt-0.5 shrink-0 text-warning-6"
+                        />
+                        <div className="min-w-0">
+                          <p className="text-[12px] font-medium text-text-1">
+                            {t(
+                              "agentOrgs.sessionProvenance.codexApproval.title",
+                              { defaultValue: "Approve ORG2 hooks in Codex" }
+                            )}
+                          </p>
+                          <p className="mt-0.5 text-[12px] leading-relaxed text-text-2">
+                            {t(
+                              "agentOrgs.sessionProvenance.codexApproval.instructions",
+                              {
+                                defaultValue:
+                                  "Open Codex, review the 3 ORG2 hooks, then choose Trust all and continue. ORG2 marks this active after the first real hook signal.",
+                              }
+                            )}
+                          </p>
+                        </div>
+                      </div>
+                      <span data-testid="session-provenance-review-codex-hooks">
+                        <Button
+                          variant="primary"
+                          size="small"
+                          icon={<Terminal size={14} />}
+                          loading={launchingCodexApproval}
+                          onClick={() => void handleReviewCodexHooks()}
+                        >
+                          {t(
+                            "agentOrgs.sessionProvenance.codexApproval.review",
+                            {
+                              defaultValue: "Review in Codex",
+                            }
+                          )}
+                        </Button>
+                      </span>
+                    </div>
+                  )}
+              </div>
+            </InlineInfoCard>
+          ),
+          rowExpandable: () => true,
+          expandedRowKeys,
+          onExpandedRowsChange: setExpandedRowKeys,
+        }}
+      />
+    </div>
   );
 };
 

--- a/src/modules/shared/dataSource/index.tsx
+++ b/src/modules/shared/dataSource/index.tsx
@@ -68,6 +68,7 @@ import {
   activeExternalSessionRefreshFrequencyAtom,
   dataSourceConfigAtom,
   dataSourceGlobalFrequencyAtom,
+  externalSessionsEnabledAtom,
   getSourceConfig,
 } from "@src/store/session/dataSourceConfigAtom";
 import { copyText } from "@src/util/data/clipboard";
@@ -131,6 +132,9 @@ const DataSourcePanel: React.FC<DataSourcePanelProps> = ({ headerContent }) => {
   );
   const [activeSessionRefreshFrequency, setActiveSessionRefreshFrequency] =
     useAtom(activeExternalSessionRefreshFrequencyAtom);
+  const [externalSessionsEnabled, setExternalSessionsEnabled] = useAtom(
+    externalSessionsEnabledAtom
+  );
 
   const patchRow = useCallback(
     (sourceId: string, patch: Partial<SourceRow>) => {
@@ -633,6 +637,18 @@ const DataSourcePanel: React.FC<DataSourcePanelProps> = ({ headerContent }) => {
               {importableCount > 0 && (
                 <SectionContainer>
                   <SectionRow
+                    label={t("externalSessionsToggle")}
+                    description={t("externalSessionsToggleDesc")}
+                  >
+                    <Switch
+                      checked={externalSessionsEnabled}
+                      onChange={(checked) =>
+                        setExternalSessionsEnabled(checked)
+                      }
+                      ariaLabel={t("externalSessionsToggle")}
+                    />
+                  </SectionRow>
+                  <SectionRow
                     label={t("globalFrequency")}
                     description={t("globalFrequencyDesc")}
                   >
@@ -647,6 +663,7 @@ const DataSourcePanel: React.FC<DataSourcePanelProps> = ({ headerContent }) => {
                       size="default"
                       style={SECTION_CONTROL_STYLE}
                       aria-label={t("globalFrequency")}
+                      disabled={!externalSessionsEnabled}
                     />
                   </SectionRow>
                   <SectionRow
@@ -666,6 +683,7 @@ const DataSourcePanel: React.FC<DataSourcePanelProps> = ({ headerContent }) => {
                       size="default"
                       style={SECTION_CONTROL_STYLE}
                       aria-label={t("activeSessionRefresh")}
+                      disabled={!externalSessionsEnabled}
                     />
                   </SectionRow>
                 </SectionContainer>
@@ -696,6 +714,7 @@ const DataSourcePanel: React.FC<DataSourcePanelProps> = ({ headerContent }) => {
                         variant="secondary"
                         size="default"
                         loading={rescanningAll}
+                        disabled={!externalSessionsEnabled}
                         icon={<RefreshCw size={14} />}
                         onClick={() => void handleRescanAll()}
                       >

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarSessionRefresh.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarSessionRefresh.ts
@@ -7,6 +7,7 @@ import {
 import { loadSidebarSessions } from "@src/store/session";
 import {
   dataSourceConfigAtom,
+  externalSessionsEnabledAtom,
   getSourceConfig,
 } from "@src/store/session/dataSourceConfigAtom";
 import { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";
@@ -14,6 +15,12 @@ import { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";
 /** Rescan every enabled external source, then reload the sidebar from cache. */
 export async function rescanSidebarSessions(): Promise<void> {
   const store = getInstrumentedStore();
+  if (!store.get(externalSessionsEnabledAtom)) {
+    // External sessions are switched off entirely — nothing to rescan, and
+    // the sidebar reload below would be a no-op for external categories.
+    await loadSidebarSessions({ forceRefresh: true });
+    return;
+  }
   const config = store.get(dataSourceConfigAtom);
   const sourceIds = IMPORTED_HISTORY_SOURCE_DESCRIPTORS.filter(
     ({ sourceId }) => getSourceConfig(config, sourceId).enabled

--- a/src/store/session/dataSourceConfigAtom.ts
+++ b/src/store/session/dataSourceConfigAtom.ts
@@ -53,6 +53,20 @@ export const dataSourceConfigAtom = atomWithStorage<DataSourceConfigMap>(
   {}
 );
 
+const EXTERNAL_SESSIONS_ENABLED_STORAGE_KEY = "orgii:externalSessionsEnabled";
+
+/**
+ * Master switch for external-session integration (default on). When off, no
+ * external source is scanned or loaded anywhere: the auto-scan scheduler,
+ * manual rescans, sidebar/list loading and the open-replay auto-refresh all
+ * skip external history. Per-source `enabled` flags are preserved and take
+ * effect again when this is switched back on.
+ */
+export const externalSessionsEnabledAtom = atomWithStorage<boolean>(
+  EXTERNAL_SESSIONS_ENABLED_STORAGE_KEY,
+  true
+);
+
 export const dataSourceGlobalFrequencyAtom = atomWithStorage<ScanFrequency>(
   GLOBAL_FREQ_STORAGE_KEY,
   DEFAULT_GLOBAL_FREQUENCY

--- a/src/store/session/sessionAtom/loaders.ts
+++ b/src/store/session/sessionAtom/loaders.ts
@@ -37,6 +37,7 @@ import { isPrimarySessionListSession } from "@src/util/session/sessionVisibility
 
 import {
   dataSourceConfigAtom,
+  externalSessionsEnabledAtom,
   isSourceDisabled,
 } from "../dataSourceConfigAtom";
 import {
@@ -341,7 +342,7 @@ export const loadSessions = async (options?: LoadSessionsOptions) => {
     const response = await sessionAggregateList({
       ...filter,
       limit: filter?.limit ?? DEFAULT_FLAT_LIST_PAGE_SIZE,
-      includeExternalHistory: true,
+      includeExternalHistory: store.get(externalSessionsEnabledAtom),
       includeStats: false,
       sortBy: filter?.sortBy ?? "updated_at",
       sortOrder: filter?.sortOrder ?? "desc",
@@ -466,10 +467,13 @@ export const loadSidebarSessions = async (options?: {
   store.set(sessionErrorAtom, null);
   store.set(sessionPaginationAtom, resetPaginationState());
 
-  // Sources the user has disabled in the Data Sources panel must not load.
+  // Sources the user has disabled in the Data Sources panel must not load;
+  // the master external-sessions switch disables all of them at once.
   const dataSourceConfig = store.get(dataSourceConfigAtom);
+  const externalSessionsEnabled = store.get(externalSessionsEnabledAtom);
   const isCategoryDisabled = (category: string): boolean => {
     if (!isImportedHistoryListCategory(category)) return false;
+    if (!externalSessionsEnabled) return true;
     const source = getImportedHistorySourceByListCategory(category);
     return source ? isSourceDisabled(dataSourceConfig, source.sourceId) : false;
   };
@@ -576,7 +580,7 @@ export const loadSidebarSessionById = async (
   // the sidebar can place them beneath the root session deterministically.
   const response = await sessionAggregateList({
     sessionIds: [normalizedSessionId],
-    includeExternalHistory: true,
+    includeExternalHistory: store.get(externalSessionsEnabledAtom),
     includeStats: false,
     limit: 1,
   });

--- a/src/store/session/useDataSourceAutoScan.ts
+++ b/src/store/session/useDataSourceAutoScan.ts
@@ -28,6 +28,7 @@ import {
   dataSourceConfigAtom,
   dataSourceGlobalFrequencyAtom,
   effectiveFrequency,
+  externalSessionsEnabledAtom,
   getSourceConfig,
 } from "./dataSourceConfigAtom";
 import { loadSidebarSessions } from "./sessionAtom/loaders";
@@ -40,6 +41,8 @@ let autoScanInFlight: Promise<void> | null = null;
 
 async function performDataSourceAutoScan(force: boolean): Promise<void> {
   const store = getInstrumentedStore();
+  // Master switch: external sessions fully off — no scans, including startup.
+  if (!store.get(externalSessionsEnabledAtom)) return;
   const cfgMap = store.get(dataSourceConfigAtom);
   const global = store.get(dataSourceGlobalFrequencyAtom);
   const now = Date.now();


### PR DESCRIPTION
## Summary

Adds two one-click master switches (both **default on**, existing users unaffected) so the external-session integration can be turned fully quiet without losing per-source configuration.

### External sessions (Data Sources panel, scanning view)

A persisted flag gates every scan and load path:

- auto-scan scheduler, **including the startup pass**
- manual "rescan all" (button disables while off)
- sidebar/list loading — external categories clear, `session_aggregate_list` drops `includeExternalHistory`
- the open-replay auto-refresh interval

Per-source enabled flags and cadences are preserved and take effect again on re-enable; the frequency selectors grey out while off.

### Provenance hooks (Data Sources panel, hooks view)

A `masterEnabled` flag in the hook preferences file gates the **effective** install state of all 11 managed platform hooks:

- switching off **uninstalls** every managed hook — signals stop at the source instead of being spawned and discarded on every external tool file operation
- per-platform choices are preserved and reinstalled on re-enable
- startup reconciliation honors the same effective state
- the capture entrypoint (`--session-provenance-hook`) discards input as a backstop when a stale hook line survives a failed uninstall (read-only/corrupt provider config)
- new `session_provenance_hooks_master_enabled` / `set_master_enabled` commands; the hooks panel gains a top-level toggle that disables the per-platform switches while off

Preferences use serde struct-level defaults, so existing preference files upgrade in place without a schema bump.

## Verification

`cargo check` clean; `agent_cli` tests 43/43; session store vitest 127/127; `eslint` and `tsc --noEmit` clean on all touched files. zh/en strings included (other locales fall back to English).
