### PR TITLE
fix(release): keep Windows beta signing alive when msi bundle is absent

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -345,7 +345,10 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: |
           BUNDLE_DIR="src-tauri/target/x86_64-pc-windows-msvc/release/bundle"
-          MSI=$(find "$BUNDLE_DIR/msi" -name "*.msi" ! -name "*.zip" 2>/dev/null | head -1)
+          # The msi directory does not exist on prerelease builds (nsis-only).
+          # This step runs under bash -eo pipefail, so a bare find would kill
+          # the whole script the moment it exits non-zero.
+          MSI=$(find "$BUNDLE_DIR/msi" -name "*.msi" ! -name "*.zip" 2>/dev/null | head -1 || true)
           NSIS=$(find "$BUNDLE_DIR/nsis" -name "*.exe" ! -name "*.zip" | head -1)
 
           if [ ! -f "$NSIS" ]; then
@@ -371,8 +374,10 @@ jobs:
         run: |
           BUNDLE_DIR="src-tauri/target/x86_64-pc-windows-msvc/release/bundle"
 
-          MSI=$(find "$BUNDLE_DIR/msi" -name "*.msi" ! -name "*.zip" 2>/dev/null | head -1)
-          MSI_SIG=$(find "$BUNDLE_DIR/msi" -name "*.msi.sig" 2>/dev/null | head -1)
+          # msi directory is absent on prerelease builds; see note in the
+          # signature-regeneration step about bash -eo pipefail.
+          MSI=$(find "$BUNDLE_DIR/msi" -name "*.msi" ! -name "*.zip" 2>/dev/null | head -1 || true)
+          MSI_SIG=$(find "$BUNDLE_DIR/msi" -name "*.msi.sig" 2>/dev/null | head -1 || true)
           NSIS=$(find "$BUNDLE_DIR/nsis" -name "*.exe" ! -name "*.zip" | head -1)
           NSIS_SIG=$(find "$BUNDLE_DIR/nsis" -name "*.exe.sig" | head -1)
 
@@ -615,6 +620,10 @@ jobs:
           # after a newer one already published (e.g. a stable hotfix behind
           # the current beta). semver handles prerelease ordering correctly.
           HIGHEST=$(npx --yes semver@7 "$NEW_VERSION" "$EXISTING_VERSION" | tail -1)
+          if [ -z "$HIGHEST" ]; then
+            echo "semver comparison produced no output (npx failure?); refusing to guess" >&2
+            exit 1
+          fi
           if [ "$HIGHEST" != "$NEW_VERSION" ]; then
             echo "Skipping beta.json: existing $EXISTING_VERSION > new $NEW_VERSION"
             exit 0


### PR DESCRIPTION
## Problem

The first beta tag (`v1.1.25-beta.1`, run [29514971200](https://github.com/yorgai/ORG2/actions/runs/29514971200)) failed in the Windows job's **Regenerate updater signatures** step — instantly, with no output.

Root cause: prerelease tags build `nsis`-only (#398), so the `msi` bundle directory never exists. The Windows steps run under `bash -eo pipefail`, where

~~~bash
MSI=$(find "$BUNDLE_DIR/msi" ... 2>/dev/null | head -1)
~~~

kills the whole script at the assignment: `find` exits non-zero on the missing directory, `pipefail` propagates it through `head`, and `-e` aborts before the script reaches its own `IS_PRERELEASE` handling. Reproduced locally with `bash -e -o pipefail`.

## Fix

- Guard the three msi `find` pipelines (signature-regeneration + artifact-gathering steps) with `|| true` — an empty `MSI` is exactly the prerelease case the script already handles, and stable builds still hard-fail on a genuinely missing MSI via the existing `IS_PRERELEASE` check.
- Hardening in the same family: the beta.json publish step now fails loudly if the `npx semver` comparison produces no output, instead of silently skipping the manifest update.

## Verification

Both behaviors reproduced/validated locally under `bash -e -o pipefail`: the unguarded assignment exits 1 before any output; the guarded one proceeds with `MSI=""`. Workflow YAML parses.

## After merge

Re-tag as `v1.1.25-beta.2` from develop (tag-triggered workflows run the workflow file at the tag's commit, so the failed `v1.1.25-beta.1` tag can't be fixed in place).

Refs #399