### PR TITLE
feat(chat): interactive ACP approvals, cursor native transcripts, session id surfacing

### DIFF
--- a/src-tauri/crates/orgtrack-core/src/sources/cursor_cli/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/cursor_cli/history.rs
@@ -157,17 +157,37 @@ pub fn stat_cursor_cli_history_for_session(
 
 /// Candidate roots holding per-session store dirs. Exposed so the
 /// external-CLI detection layer can report the store path.
+///
+/// cursor-agent resolves its config root as `$CURSOR_CONFIG_DIR ||
+/// $XDG_CONFIG_HOME/cursor || ~/.cursor` and writes one store per session at
+/// `<config-root>/chats/<md5-of-cwd>/<session-uuid>/store.db` (verified
+/// against the 2026.01 and 2026.04 CLI builds: `getChatsRootDir()` joins
+/// `chats` directly onto `getConfigDir()` — no `.cursor` component when the
+/// config dir is overridden).
 pub fn cursor_cli_history_candidate_paths() -> Vec<PathBuf> {
     let mut roots = Vec::new();
     if let Some(home_dir) = dirs::home_dir() {
         roots.push(home_dir.join(".cursor").join("chats"));
     }
-    // ORGII-managed cursor-agent runs redirect HOME into per-account profile
-    // dirs whose stores land under `<profile>/.cursor/chats`.
+    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+        if !xdg.trim().is_empty() {
+            roots.push(PathBuf::from(xdg).join("cursor").join("chats"));
+        }
+    }
+    // ORGII-managed cursor-agent runs redirect CURSOR_CONFIG_DIR (not HOME):
+    // own-key sessions into per-account profile dirs, hosted-key sessions
+    // into per-session config dirs. Chats land directly under
+    // `<config-dir>/chats` in both cases.
     roots.extend(
         crate::sources::imported_history::managed_roots::profile_root_children(
             &app_paths::cursor_cli_profile_root(),
-            &[".cursor", "chats"],
+            &["chats"],
+        ),
+    );
+    roots.extend(
+        crate::sources::imported_history::managed_roots::profile_root_children(
+            &app_paths::cursor_config_root(),
+            &["chats"],
         ),
     );
     imported_paths::dedupe_paths(roots)

--- a/src-tauri/crates/orgtrack-core/src/sources/cursor_cli/history_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/cursor_cli/history_tests.rs
@@ -355,6 +355,15 @@ fn rejects_invalid_cursor_cli_prefixed_ids() {
 fn candidate_paths_include_home_chats_root() {
     let paths = cursor_cli_history_candidate_paths();
     assert!(paths.iter().any(|path| path.ends_with(".cursor/chats")));
+    // Managed roots (`~/.orgii/cursor-cli-profiles/<account>/chats`,
+    // `~/.orgii/cursor-config/<session>/chats`) only appear when those
+    // profile dirs exist on the machine, so they can't be asserted here —
+    // but any that do appear must use the CLI's real `<config-dir>/chats`
+    // layout, never a `.cursor` component under a profile dir.
+    assert!(!paths
+        .iter()
+        .any(|path| path.to_string_lossy().contains("cursor-cli-profiles")
+            && path.to_string_lossy().contains(".cursor")));
 }
 
 #[test]

--- a/src-tauri/src/agent_sessions/cli/commands.rs
+++ b/src-tauri/src/agent_sessions/cli/commands.rs
@@ -242,9 +242,7 @@ pub async fn cli_agent_create(mut params: CreateCodeSessionParams) -> Result<Cod
                 let worktree_branch = repo
                     .as_deref()
                     .filter(|repo| !repo.is_empty())
-                    .and_then(|repo| {
-                        worktree::list_all_worktrees(std::path::Path::new(repo)).ok()
-                    })
+                    .and_then(|repo| worktree::list_all_worktrees(std::path::Path::new(repo)).ok())
                     .and_then(|entries| {
                         entries
                             .into_iter()
@@ -717,8 +715,12 @@ pub async fn cli_agent_transcript_path(
             .map_err(|err| format!("Failed to open orgtrack source cache DB: {err}"))?;
         // Exact match first; Codex caches key on the rollout file stem, which
         // only the `-`-bounded suffix variant matches.
-        let mut path = orgtrack_core::sources::imported_history::cache::
-            get_cached_source_path_from_conn(&conn, binding.source, &cli_session_id)?;
+        let mut path =
+            orgtrack_core::sources::imported_history::cache::get_cached_source_path_from_conn(
+                &conn,
+                binding.source,
+                &cli_session_id,
+            )?;
         if path.is_none() {
             path = orgtrack_core::sources::imported_history::cache::
                 get_cached_source_path_by_suffix_from_conn(&conn, binding.source, &cli_session_id)?;
@@ -756,8 +758,8 @@ pub async fn cli_agent_chunks(session_id: String) -> Result<Vec<ActivityChunk>, 
         session_id
     );
     let result = tokio::task::spawn_blocking(move || {
-        let session = persistence::get_session(&session_id)
-            .map_err(|e| format!("DB error: {}", e))?;
+        let session =
+            persistence::get_session(&session_id).map_err(|e| format!("DB error: {}", e))?;
         if let Some(session) = session.as_ref() {
             if let Some(chunks) = load_native_transcript_chunks(session) {
                 return Ok(chunks);
@@ -769,8 +771,7 @@ pub async fn cli_agent_chunks(session_id: String) -> Result<Vec<ActivityChunk>, 
             if let Some(chunk) = session
                 .as_ref()
                 .filter(|session| {
-                    session.transcript_source
-                        == super::native_transcript::TRANSCRIPT_SOURCE_NATIVE
+                    session.transcript_source == super::native_transcript::TRANSCRIPT_SOURCE_NATIVE
                 })
                 .and_then(synthesized_user_message_chunk)
             {
@@ -803,8 +804,18 @@ pub async fn cli_agent_truncate_after_chunk(
     // Kill any running agent first to prevent it from writing new chunks
     session_runner::kill_running_agent(&session_id).await;
 
-    // Clean up CLI config dir so the agent starts fresh
-    session_runner::cleanup_cursor_config_dir(&session_id);
+    // Wipe the Cursor config dir so the agent starts fresh — legacy chunk mode
+    // ONLY. Under `transcript_source = 'native'` that directory IS the
+    // transcript of record (hosted-key Cursor stores its chats under the
+    // per-session config dir), so deleting it would erase the whole
+    // conversation instead of truncating it. The fork is driven by
+    // `clear_cli_resume_state_with_tx` inside the truncate below: with no
+    // resume id the CLI opens a fresh conversation, and the superseded store
+    // stays on disk hidden behind the native-transcript ledger — the same
+    // semantics Claude/Codex native forks already have.
+    if persistence::session_persists_chunks(&session_id) {
+        session_runner::cleanup_cursor_config_dir(&session_id);
+    }
 
     let should_revert_files = revert_files.unwrap_or(true);
     if should_revert_files {

--- a/src-tauri/src/agent_sessions/cli/commands.rs
+++ b/src-tauri/src/agent_sessions/cli/commands.rs
@@ -554,8 +554,10 @@ pub async fn cli_agent_message(
 ///   (`hookperm-*`, from the `permission:request` wire event). Checked
 ///   first. `always_allow` maps to a plain allow — persistent rules stay
 ///   with Claude's own permission store.
-/// - **ACP agents** (Copilot, Kiro): the backend emits an
-///   `approval_request` chunk and blocks on a per-session oneshot.
+/// - **ACP agents** (OpenCode, Copilot, Kiro): a `session/request_permission`
+///   parked in `acp_common::PENDING_APPROVALS`, keyed by `request_id`
+///   (`acpperm-*`, from the `permission:request` wire event with
+///   `origin: "acp"`), with a session-id fallback.
 #[tauri::command]
 pub async fn cli_agent_approval_response(
     session_id: String,
@@ -575,6 +577,7 @@ pub async fn cli_agent_approval_response(
     }
     crate::agent_sessions::cli::parsers::acp_common::resolve_approval(
         &session_id,
+        request_id.as_deref(),
         approved,
         always_allow.unwrap_or(false),
     )

--- a/src-tauri/src/agent_sessions/cli/native_transcript.rs
+++ b/src-tauri/src/agent_sessions/cli/native_transcript.rs
@@ -10,7 +10,7 @@
 
 use key_vault::key_store::ModelType;
 use orgtrack_core::sources::imported_history::metadata::{
-    SOURCE_CLAUDE_CODE, SOURCE_CODEX_APP, SOURCE_OPENCODE,
+    SOURCE_CLAUDE_CODE, SOURCE_CODEX_APP, SOURCE_CURSOR_CLI, SOURCE_OPENCODE,
 };
 
 pub const TRANSCRIPT_SOURCE_CHUNKS: &str = "chunks";
@@ -31,10 +31,16 @@ impl NativeTranscriptBinding {
 }
 
 /// Which agents run in native-transcript mode. Only agents with BOTH a GUI
-/// launch profile AND an imported-history reader qualify; CursorCli is
-/// deliberately absent (the cursor-agent CLI writes `~/.cursor/chats/*`,
-/// a different store than the IDE reader parses) until a `cursor_cli`
-/// reader exists.
+/// launch profile AND an imported-history reader qualify.
+///
+/// CursorCli: the `cursor_cli` reader parses the per-session `store.db`
+/// stores the cursor-agent CLI writes under `<config-root>/chats/`, and the
+/// stream-json `session_id` field (present from the very first
+/// `type:"system"` init event) IS the store-dir uuid — verified against the
+/// CLI bundle (`sessionId = resumeId || randomUUID()` names both the store
+/// dir and every stream event) and against real stores (dir name ==
+/// `meta.agentId`). `CursorParser::cli_session_id()` surfaces it, so the
+/// runner early-binds it like Claude's.
 pub fn native_transcript_binding(agent: &ModelType) -> Option<NativeTranscriptBinding> {
     match agent {
         ModelType::ClaudeCode => Some(NativeTranscriptBinding {
@@ -49,18 +55,18 @@ pub fn native_transcript_binding(agent: &ModelType) -> Option<NativeTranscriptBi
             source: SOURCE_OPENCODE,
             imported_prefix: orgtrack_core::sources::opencode::history::OPENCODE_SESSION_PREFIX,
         }),
+        ModelType::CursorCli => Some(NativeTranscriptBinding {
+            source: SOURCE_CURSOR_CLI,
+            imported_prefix: orgtrack_core::sources::cursor_cli::SESSION_PREFIX,
+        }),
         _ => None,
     }
 }
 
-/// Rollout gate for M2: which of the bound agents actually CREATE sessions in
-/// native mode today. Codex/OpenCode keep legacy chunks until their discovery
-/// roots and replay paths are verified end-to-end (M3); their bindings above
-/// already serve dedup and live-status id mapping.
 /// Native mode for every agent whose CLI store has an imported-history
-/// reader (the binding map). Reader-less agents (Cursor CLI, Copilot, Kiro,
-/// ...) keep legacy chunk persistence — dropping their writes would leave
-/// those GUI sessions with no transcript at all.
+/// reader (the binding map). Reader-less agents (Copilot, Kiro, ...) keep
+/// legacy chunk persistence — dropping their writes would leave those GUI
+/// sessions with no transcript at all.
 pub fn native_transcript_enabled(agent: &ModelType) -> bool {
     native_transcript_binding(agent).is_some()
 }
@@ -80,10 +86,11 @@ pub fn native_store_key_for_managed_session(
         .as_deref()
         .and_then(ModelType::from_str)?;
     let binding = native_transcript_binding(&agent)?;
-    let cli_session_id = super::persistence::latest_native_transcript_id(session_id, binding.source)
-        .ok()
-        .flatten()
-        .or(session.cli_session_id)?;
+    let cli_session_id =
+        super::persistence::latest_native_transcript_id(session_id, binding.source)
+            .ok()
+            .flatten()
+            .or(session.cli_session_id)?;
     Some((binding, cli_session_id))
 }
 
@@ -112,11 +119,26 @@ mod tests {
     }
 
     #[test]
+    fn cursor_cli_binding_builds_imported_ids() {
+        let binding = native_transcript_binding(&ModelType::CursorCli).expect("binding");
+        assert_eq!(binding.source, "cursor_cli");
+        // The bound cli_session_id is the bare store-dir uuid (the stream's
+        // `session_id`), so the imported id must be exactly prefix + uuid —
+        // the same exact-match key the reader's managed-mirror dedup uses.
+        assert_eq!(
+            binding.imported_session_id("05835159-632a-419e-811b-d8e25940940a"),
+            "cursorcliapp-05835159-632a-419e-811b-d8e25940940a"
+        );
+    }
+
+    #[test]
     fn bound_agents_are_native_reader_less_stay_legacy() {
         assert!(native_transcript_enabled(&ModelType::ClaudeCode));
         assert!(native_transcript_enabled(&ModelType::Codex));
         assert!(native_transcript_enabled(&ModelType::OpenCode));
-        // No imported-history reader for the cursor-agent CLI store yet.
-        assert!(!native_transcript_enabled(&ModelType::CursorCli));
+        assert!(native_transcript_enabled(&ModelType::CursorCli));
+        // No imported-history reader for these CLI stores yet.
+        assert!(!native_transcript_enabled(&ModelType::Copilot));
+        assert!(!native_transcript_enabled(&ModelType::Kiro));
     }
 }

--- a/src-tauri/src/agent_sessions/cli/parsers/acp_common.rs
+++ b/src-tauri/src/agent_sessions/cli/parsers/acp_common.rs
@@ -19,30 +19,96 @@ pub struct ApprovalResponse {
     pub always_allow: bool,
 }
 
-type PendingApprovalsMap = HashMap<String, oneshot::Sender<ApprovalResponse>>;
+/// A parked ACP `session/request_permission`, keyed by `request_id`
+/// (`acpperm-*`) in [`PENDING_APPROVALS`]. `session_id` is kept so the
+/// Tauri command can also resolve without a request id — the protocol
+/// loop blocks on one permission at a time per session.
+struct PendingAcpApproval {
+    session_id: String,
+    sender: oneshot::Sender<ApprovalResponse>,
+}
 
-/// Global registry of pending approval requests (session_id → oneshot sender).
-/// When the frontend approves/denies, the Tauri command resolves the channel.
-pub static PENDING_APPROVALS: std::sync::LazyLock<Arc<Mutex<PendingApprovalsMap>>> =
+type PendingApprovalsMap = HashMap<String, PendingAcpApproval>;
+
+/// Global registry of pending approval requests (request_id → parked entry).
+/// When the frontend approves/denies, the Tauri command resolves the channel
+/// via [`resolve_approval`] — external callers never touch the map directly.
+static PENDING_APPROVALS: std::sync::LazyLock<Arc<Mutex<PendingApprovalsMap>>> =
     std::sync::LazyLock::new(|| Arc::new(Mutex::new(HashMap::new())));
 
-/// Resolve a pending approval request for a session.
+/// How long an ACP permission request waits for the user before the
+/// legacy auto-approve fallback fires.
+pub const ACP_APPROVAL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
+/// Resolve a pending approval request.
 /// Called by the Tauri command when the user approves or denies.
+///
+/// Looks up by `request_id` when given (the `acpperm-*` id from the
+/// `permission:request` wire event); otherwise falls back to the
+/// session's only pending entry — mirrors
+/// `hook_approvals::resolve_hook_approval`.
 pub async fn resolve_approval(
     session_id: &str,
+    request_id: Option<&str>,
     approved: bool,
     always_allow: bool,
 ) -> Result<(), String> {
-    let tx = PENDING_APPROVALS
-        .lock()
-        .await
-        .remove(session_id)
-        .ok_or_else(|| format!("No pending approval for session {}", session_id))?;
-    tx.send(ApprovalResponse {
-        approved,
-        always_allow,
-    })
-    .map_err(|_| "Approval channel closed".to_string())
+    let entry = {
+        let mut pending = PENDING_APPROVALS.lock().await;
+        let key = match request_id {
+            Some(request_id) if pending.contains_key(request_id) => Some(request_id.to_string()),
+            _ => pending
+                .iter()
+                .find(|(_, entry)| entry.session_id == session_id)
+                .map(|(key, _)| key.clone()),
+        };
+        let key = key
+            .ok_or_else(|| format!("No pending approval for session {}", session_id))?;
+        pending.remove(&key).expect("key was just found")
+    };
+    entry
+        .sender
+        .send(ApprovalResponse {
+            approved,
+            always_allow,
+        })
+        .map_err(|_| "Approval channel closed".to_string())
+}
+
+/// Park a new approval entry for a session. Returns the generated
+/// `acpperm-*` request id (broadcast to the frontend) and the receiver
+/// the protocol loop awaits on.
+async fn register_acp_approval(session_id: &str) -> (String, oneshot::Receiver<ApprovalResponse>) {
+    let request_id = format!("acpperm-{}", uuid::Uuid::new_v4());
+    let (tx, rx) = oneshot::channel::<ApprovalResponse>();
+    PENDING_APPROVALS.lock().await.insert(
+        request_id.clone(),
+        PendingAcpApproval {
+            session_id: session_id.to_string(),
+            sender: tx,
+        },
+    );
+    (request_id, rx)
+}
+
+/// Await a parked approval. On timeout or a dropped sender the legacy
+/// behavior applies: auto-approve (allow once) and clean up the entry.
+async fn await_acp_approval(
+    request_id: &str,
+    rx: oneshot::Receiver<ApprovalResponse>,
+    timeout: std::time::Duration,
+) -> ApprovalResponse {
+    match tokio::time::timeout(timeout, rx).await {
+        Ok(Ok(resp)) => resp,
+        _ => {
+            tracing::info!("[ACP] Approval timed out or channel closed — auto-approving");
+            PENDING_APPROVALS.lock().await.remove(request_id);
+            ApprovalResponse {
+                approved: true,
+                always_allow: false,
+            }
+        }
+    }
 }
 
 /// ACP major protocol version.
@@ -788,6 +854,150 @@ impl<A: AcpAgentAdapter> AcpNotificationParser<A> {
 }
 
 // ============================================
+// Permission Request Helpers
+// ============================================
+
+/// Tool info extracted from a `session/request_permission` params payload.
+struct PermissionRequestInfo {
+    /// Cursor-normalized tool name (via the adapter's kind mapping) when
+    /// the standard ACP `toolCall` shape is present; falls back to the
+    /// legacy `permissions[0].tool` field, then `"unknown_tool"`.
+    tool_name: String,
+    /// Human-readable description (`toolCall.title` or
+    /// `permissions[0].description`).
+    description: String,
+    /// Tool arguments (`toolCall.rawInput` when non-empty; otherwise a
+    /// small object carrying the title/description so the frontend card
+    /// has something to preview).
+    tool_args: Value,
+    /// The agent's tool call id when present (`toolCall.toolCallId`),
+    /// so the frontend can associate the card with the tool bubble.
+    tool_call_id: Option<String>,
+}
+
+fn extract_permission_request_info<A: AcpAgentAdapter>(
+    adapter: &A,
+    params: &Value,
+) -> PermissionRequestInfo {
+    let tool_call = params.get("toolCall");
+    let raw_input = tool_call
+        .and_then(|tc| tc.get("rawInput"))
+        .cloned()
+        .unwrap_or(Value::Object(Default::default()));
+    let title = tool_call
+        .and_then(|tc| tc.get("title"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let tool_call_id = tool_call
+        .and_then(|tc| tc.get("toolCallId"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    // Legacy shape (pre-standard agents): permissions[0].{tool,description}
+    let legacy_perm = params
+        .get("permissions")
+        .and_then(|p| p.as_array())
+        .and_then(|arr| arr.first());
+    let legacy_tool = legacy_perm
+        .and_then(|perm| perm.get("tool"))
+        .and_then(|v| v.as_str());
+    let legacy_description = legacy_perm
+        .and_then(|perm| perm.get("description"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let tool_name = match tool_call.and_then(|tc| tc.get("kind")).and_then(|v| v.as_str()) {
+        Some(kind) => adapter.map_tool_kind(kind, &raw_input),
+        None => legacy_tool.unwrap_or("unknown_tool").to_string(),
+    };
+
+    let description = if !title.is_empty() {
+        title.to_string()
+    } else {
+        legacy_description.to_string()
+    };
+
+    let tool_args = if raw_input.as_object().is_some_and(|obj| !obj.is_empty()) {
+        raw_input
+    } else {
+        let mut obj = serde_json::Map::new();
+        if !description.is_empty() {
+            obj.insert("description".to_string(), Value::String(description.clone()));
+        }
+        Value::Object(obj)
+    };
+
+    PermissionRequestInfo {
+        tool_name,
+        description,
+        tool_args,
+        tool_call_id,
+    }
+}
+
+/// Pick the `optionId` to answer a `session/request_permission` with.
+///
+/// Prefers the option whose `kind` matches the user's decision from the
+/// request's own `options` array (the protocol expects one of the offered
+/// ids). Falls back to the legacy hardcoded ids that pre-date option
+/// matching, preserving behavior for agents that omit `options`.
+fn select_acp_option_id(params: &Value, approved: bool, always_allow: bool) -> String {
+    let desired_kinds: &[&str] = if !approved {
+        &["reject_once", "reject_always"]
+    } else if always_allow {
+        &["allow_always", "allow_once"]
+    } else {
+        &["allow_once", "allow_always"]
+    };
+    if let Some(options) = params.get("options").and_then(|v| v.as_array()) {
+        for kind in desired_kinds {
+            let matched = options.iter().find(|opt| {
+                opt.get("kind").and_then(|v| v.as_str()) == Some(*kind)
+            });
+            if let Some(id) = matched
+                .and_then(|opt| opt.get("optionId"))
+                .and_then(|v| v.as_str())
+            {
+                return id.to_string();
+            }
+        }
+    }
+    if !approved {
+        "deny"
+    } else if always_allow {
+        "allow_always"
+    } else {
+        "allow_once"
+    }
+    .to_string()
+}
+
+/// Broadcast a `permission:request` wire event so the frontend
+/// `PermissionCard` renders an interactive Approve/Deny card. Mirrors
+/// `hook_approvals::broadcast_permission_request`: flat shape, top-level
+/// `session_id` for per-session IPC routing, `origin` routes the
+/// response back to this registry via `cli_agent_approval_response`.
+fn broadcast_acp_permission_request(
+    session_id: &str,
+    request_id: &str,
+    tool_name: &str,
+    tool_args: &Value,
+    tool_call_id: Option<&str>,
+) {
+    let msg = serde_json::json!({
+        "type": "permission:request",
+        "session_id": session_id,
+        "sessionId": session_id,
+        "requestId": request_id,
+        "toolName": tool_name,
+        "toolCallId": tool_call_id.unwrap_or(request_id),
+        "toolArgs": tool_args,
+        "origin": "acp",
+    });
+    crate::api::websocket_handler::broadcast(msg.to_string());
+}
+
+// ============================================
 // JSON-RPC Helpers
 // ============================================
 
@@ -1147,65 +1357,47 @@ async fn process_notification<A: AcpAgentAdapter>(
         "session/request_permission" => {
             if let Some(req_id) = msg.get("id") {
                 let params = msg.get("params").cloned().unwrap_or(Value::Null);
-                let tool_name = params
-                    .get("permissions")
-                    .and_then(|p| p.as_array())
-                    .and_then(|arr| arr.first())
-                    .and_then(|perm| perm.get("tool"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("unknown_tool")
-                    .to_string();
-                let description = params
-                    .get("permissions")
-                    .and_then(|p| p.as_array())
-                    .and_then(|arr| arr.first())
-                    .and_then(|perm| perm.get("description"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
+                let info = extract_permission_request_info(&parser.adapter, &params);
+                let tool_name = info.tool_name;
 
-                // Emit an ask_user_permissions chunk so the frontend shows an approval card
+                // Register the oneshot BEFORE broadcasting so a fast
+                // frontend response always finds the entry.
+                let (request_id, rx) = register_acp_approval(session_id).await;
+
+                // Emit an ask_user_permissions chunk (transcript record)
                 let mut chunk =
                     ActivityChunk::new(session_id, "ask_user_permissions", "ask_user_permissions");
                 chunk.args = serde_json::json!({
                     "tool_name": tool_name,
-                    "description": description,
+                    "description": info.description,
+                    "request_id": request_id,
                 });
                 chunk.result = serde_json::json!({
                     "pending": true,
                 });
                 let _ = chunk_tx.send(chunk).await;
 
-                // Register a oneshot channel and wait for the user's response
-                let (tx, rx) = oneshot::channel::<ApprovalResponse>();
-                PENDING_APPROVALS
-                    .lock()
-                    .await
-                    .insert(session_id.to_string(), tx);
+                // Broadcast the interactive permission:request wire event
+                // (rendered by PermissionCard, answered via
+                // cli_agent_approval_response with this request_id).
+                broadcast_acp_permission_request(
+                    session_id,
+                    &request_id,
+                    &tool_name,
+                    &info.tool_args,
+                    info.tool_call_id.as_deref(),
+                );
+                tracing::info!(
+                    session_id = %session_id,
+                    request_id = %request_id,
+                    tool = %tool_name,
+                    "[ACP] Waiting for user permission decision"
+                );
 
                 // 5-minute timeout for user response; auto-approve on timeout
-                let response =
-                    match tokio::time::timeout(std::time::Duration::from_secs(300), rx).await {
-                        Ok(Ok(resp)) => resp,
-                        _ => {
-                            tracing::info!(
-                                "[ACP] Approval timed out or channel closed — auto-approving"
-                            );
-                            PENDING_APPROVALS.lock().await.remove(session_id);
-                            ApprovalResponse {
-                                approved: true,
-                                always_allow: false,
-                            }
-                        }
-                    };
+                let response = await_acp_approval(&request_id, rx, ACP_APPROVAL_TIMEOUT).await;
 
-                let option_id = if response.always_allow {
-                    "allow_always"
-                } else if response.approved {
-                    "allow_once"
-                } else {
-                    "deny"
-                };
+                let option_id = select_acp_option_id(&params, response.approved, response.always_allow);
 
                 acp_respond(
                     stdin,

--- a/src-tauri/src/agent_sessions/cli/parsers/tests/parser_integration_tests.rs
+++ b/src-tauri/src/agent_sessions/cli/parsers/tests/parser_integration_tests.rs
@@ -154,6 +154,31 @@ mod tests {
         assert_eq!(chunks[0].args["cwd"], "/home/user/project");
     }
 
+    /// The cursor-agent stream-json init event carries `session_id`, which is
+    /// the `~/.cursor/chats/<ws-md5>/<uuid>/store.db` dir uuid (the CLI names
+    /// the store dir with the same id it stamps on every stream event).
+    /// Native-transcript replay and managed-mirror dedup key on the runner
+    /// early-binding this value, so it must surface after the first event.
+    #[test]
+    fn test_cursor_cli_session_id_captured_from_init_event() {
+        let mut parser = CursorParser::new("test-session");
+        assert_eq!(parser.cli_session_id(), None);
+
+        // Real shape (cursor-agent 2026.04): system/init is the first event.
+        let line = r#"{"type":"system","subtype":"init","apiKeySource":"login","cwd":"/tmp/ws","session_id":"05835159-632a-419e-811b-d8e25940940a","model":"Claude 4.5 Sonnet","permissionMode":"default"}"#;
+        let chunks = parser.parse_line(line);
+
+        assert_eq!(
+            parser.cli_session_id().as_deref(),
+            Some("05835159-632a-419e-811b-d8e25940940a")
+        );
+        // The captured id also threads through emitted chunks.
+        assert_eq!(
+            chunks[0].thread_id.as_deref(),
+            Some("05835159-632a-419e-811b-d8e25940940a")
+        );
+    }
+
     #[test]
     fn test_cursor_tool_call_shell() {
         let mut parser = CursorParser::new("test-session");

--- a/src/api/tauri/agent/session.ts
+++ b/src/api/tauri/agent/session.ts
@@ -221,12 +221,15 @@ export async function respondPermission(
 }
 
 /**
- * Resolve a permission request parked by a managed CLI session's
- * PermissionRequest hook (`origin: "cli_hook"` on the
- * `agent-permission-request` event). Routes to
- * `cli_agent_approval_response`, whose hook registry unblocks the hook
- * subprocess long-poll. `always_allow` is treated as a plain allow —
- * persistent rules stay with the CLI's own permission store.
+ * Resolve a permission request parked on the CLI side: a managed
+ * session's PermissionRequest hook (`origin: "cli_hook"`) or an ACP
+ * agent's `session/request_permission` (`origin: "acp"`) on the
+ * `agent-permission-request` event. Routes to
+ * `cli_agent_approval_response`, which checks the hook registry first
+ * and falls back to the ACP registry by `requestId`. For hooks,
+ * `always_allow` is treated as a plain allow — persistent rules stay
+ * with the CLI's own permission store; ACP agents receive their
+ * `allow_always` option when offered.
  */
 export async function respondCliHookPermission(
   sessionId: string,

--- a/src/components/SessionHoverCard/SessionHoverCardContent.tsx
+++ b/src/components/SessionHoverCard/SessionHoverCardContent.tsx
@@ -2,8 +2,10 @@ import { invoke } from "@tauri-apps/api/core";
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
 import { useAtomValue } from "jotai";
 import {
+  Check,
   Clock,
   Diff,
+  Fingerprint,
   Folder,
   GitBranch,
   GitCommitVertical,
@@ -11,9 +13,10 @@ import {
   Save,
   Timer,
 } from "lucide-react";
-import React, { memo, useEffect, useMemo, useState } from "react";
+import React, { memo, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { IMPORTED_HISTORY_SOURCE_DESCRIPTORS } from "@src/api/tauri/externalHistory/imported/descriptors";
 import {
   type CoreSessionSummary,
   getOrgtrackSessionSummary,
@@ -31,6 +34,7 @@ import { useValidatedLastPair } from "@src/hooks/models/useValidatedLastPair";
 import { workspaceGitStatusMapAtom } from "@src/store/git/gitStatusAtom";
 import type { LastModelSelection } from "@src/store/session/creatorDefaultModelAtom";
 import { sessionByIdAtom } from "@src/store/session/sessionAtom/atoms";
+import { copyText } from "@src/util/data/clipboard";
 import {
   formatReplayDateLabel,
   toIntlLocaleTag,
@@ -39,6 +43,7 @@ import { formatBranchLabel } from "@src/util/git/branchLabel";
 import { basename } from "@src/util/path";
 import {
   getDispatchCategory,
+  isCliSession,
   resolveSessionIconId,
 } from "@src/util/session/sessionDispatch";
 import { formatDuration } from "@src/util/time/formatDuration";
@@ -69,6 +74,15 @@ interface CliTranscriptLocation {
   path: string | null;
 }
 
+/**
+ * Minimal mirror of the `cli_agent_status` command payload (`CodeSession`,
+ * camelCase). Only the bound native CLI id is read here.
+ */
+interface CliAgentStatusPayload {
+  /** The CLI's own session id (e.g. Claude jsonl stem), once bound. */
+  cliSessionId?: string | null;
+}
+
 const PATH_ROW_CLASS_NAME =
   "block max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-left text-text-2 underline-offset-2 transition-colors hover:text-accent-9 hover:underline focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-accent-8";
 const COMPACT_PATH_MAX_CHARS = 44;
@@ -94,6 +108,37 @@ function formatCompactPath(path: string): string {
 
 function normalizePath(path: string): string {
   return path.replace(/\/+$/u, "");
+}
+
+/** How long the copied-check flash stays visible on the session-id row. */
+const COPIED_FLASH_MS = 1500;
+/** Characters kept on each side when middle-truncating a session id. */
+const COMPACT_ID_EDGE_CHARS = 8;
+
+/**
+ * Middle-truncate a session id so both the distinctive head and tail stay
+ * visible (UUIDs differ at both ends; opencode `ses_` ids differ at the tail).
+ */
+function formatCompactSessionId(id: string): string {
+  if (id.length <= COMPACT_ID_EDGE_CHARS * 2 + 2) return id;
+  return `${id.slice(0, COMPACT_ID_EDGE_CHARS)}…${id.slice(-COMPACT_ID_EDGE_CHARS)}`;
+}
+
+/**
+ * Strip the imported-history prefix (`claudecodeapp-`, `codexapp-`,
+ * `cursoride-`, ...) and return the RAW source-store session id — the value
+ * that matches the CLI's own tooling (Claude jsonl stem, Codex rollout id,
+ * opencode `ses_` id, Cursor composer UUID). Returns `null` for
+ * non-imported sessions.
+ */
+function getImportedRawSessionId(sessionId: string): string | null {
+  for (const descriptor of IMPORTED_HISTORY_SOURCE_DESCRIPTORS) {
+    if (sessionId.startsWith(descriptor.prefix)) {
+      const raw = sessionId.slice(descriptor.prefix.length);
+      return raw.length > 0 ? raw : null;
+    }
+  }
+  return null;
 }
 
 function handleRevealPath(path: string): void {
@@ -152,6 +197,15 @@ export const SessionHoverCardContent: React.FC<SessionHoverCardContentProps> =
       sessionId: string;
       location: CliTranscriptLocation;
     } | null>(null);
+    const [boundCliIdState, setBoundCliIdState] = useState<{
+      sessionId: string;
+      cliSessionId: string | null;
+    } | null>(null);
+    // Keyed on session id so switching cards never shows a stale check.
+    const [copiedForSessionId, setCopiedForSessionId] = useState<string | null>(
+      null
+    );
+    const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     useEffect(() => {
       let cancelled = false;
@@ -195,10 +249,61 @@ export const SessionHoverCardContent: React.FC<SessionHoverCardContentProps> =
       };
     }, [cliAgentType, sessionId]);
 
+    // Managed CLI sessions (`cliagent-*`): the bound native CLI id lives on
+    // the `code_sessions` row already returned by `cli_agent_status` — no
+    // new backend surface needed.
+    useEffect(() => {
+      let cancelled = false;
+      if (!isCliSession(sessionId)) return undefined;
+
+      invoke<CliAgentStatusPayload | null>("cli_agent_status", { sessionId })
+        .then((status) => {
+          if (!cancelled) {
+            setBoundCliIdState({
+              sessionId,
+              cliSessionId: status?.cliSessionId ?? null,
+            });
+          }
+        })
+        .catch((error: unknown) => {
+          logger.warn("failed to load bound cli session id", {
+            error,
+            sessionId,
+          });
+        });
+
+      return () => {
+        cancelled = true;
+      };
+    }, [sessionId]);
+
+    // Clear any pending copied-flash timer on unmount.
+    useEffect(() => {
+      return () => {
+        if (copiedTimerRef.current !== null) {
+          clearTimeout(copiedTimerRef.current);
+          copiedTimerRef.current = null;
+        }
+      };
+    }, []);
+
     const transcriptLocation =
       transcriptLocationState?.sessionId === sessionId
         ? transcriptLocationState.location
         : null;
+
+    // The session's underlying id in its source store, for non-org2-native
+    // sessions: imported external rows expose the prefix-stripped raw id;
+    // managed CLI rows expose the bound native CLI id (null until the first
+    // turn binds one). Pure Rust-agent sessions stay null — row hidden.
+    const underlyingSessionId = useMemo(() => {
+      const importedRawId = getImportedRawSessionId(sessionId);
+      if (importedRawId) return importedRawId;
+      if (boundCliIdState?.sessionId === sessionId) {
+        return boundCliIdState.cliSessionId;
+      }
+      return null;
+    }, [boundCliIdState, sessionId]);
 
     const lastModel: LastModelSelection | null = useMemo(() => {
       if (!session) return creatorDefaultLastModel;
@@ -284,6 +389,23 @@ export const SessionHoverCardContent: React.FC<SessionHoverCardContentProps> =
     }, [orgtrackSummary, session]);
 
     if (!session) return null;
+
+    const handleCopyUnderlyingId = (value: string): void => {
+      void copyText(value)
+        .then(() => {
+          setCopiedForSessionId(sessionId);
+          if (copiedTimerRef.current !== null) {
+            clearTimeout(copiedTimerRef.current);
+          }
+          copiedTimerRef.current = setTimeout(() => {
+            copiedTimerRef.current = null;
+            setCopiedForSessionId(null);
+          }, COPIED_FLASH_MS);
+        })
+        .catch((error: unknown) => {
+          logger.warn("failed to copy session id", { error, sessionId });
+        });
+    };
 
     const repoName = session.repo_name || (repoPath ? basename(repoPath) : "");
     const worktreePath = session.worktreePath;
@@ -402,6 +524,32 @@ export const SessionHoverCardContent: React.FC<SessionHoverCardContentProps> =
                 {t("history.detail.cliNativeStore")}
               </span>
             )}
+          </HoverCardRow>
+        )}
+        {underlyingSessionId && (
+          <HoverCardRow icon={<Fingerprint size={13} strokeWidth={1.75} />}>
+            <button
+              type="button"
+              className={PATH_ROW_CLASS_NAME}
+              title={underlyingSessionId}
+              onClick={() => handleCopyUnderlyingId(underlyingSessionId)}
+            >
+              <span className="text-text-3">
+                {t("history.detail.sessionId")}
+              </span>
+              <span className="mx-1 text-text-4">·</span>
+              <span className="font-mono">
+                {formatCompactSessionId(underlyingSessionId)}
+              </span>
+              {copiedForSessionId === sessionId && (
+                <Check
+                  size={12}
+                  strokeWidth={2}
+                  className="ml-1 inline-block align-[-1px] text-success-6"
+                  aria-hidden="true"
+                />
+              )}
+            </button>
           </HoverCardRow>
         )}
         {impactTask && (

--- a/src/engines/ChatPanel/InputArea/PermissionCard/index.tsx
+++ b/src/engines/ChatPanel/InputArea/PermissionCard/index.tsx
@@ -81,10 +81,11 @@ const PermissionCard: React.FC<PermissionCardProps> = ({
       setIsSubmitting(true);
       const respondingId = pending.requestId;
       try {
-        if (pending.origin === "cli_hook") {
-          // Managed CLI session: the approval is parked in the hook
-          // registry (PermissionRequest hook long-poll), not the
-          // Rust-agent permission manager.
+        if (pending.origin === "cli_hook" || pending.origin === "acp") {
+          // Managed CLI session: the approval is parked in a CLI-side
+          // registry (Claude PermissionRequest hook long-poll or an ACP
+          // agent's session/request_permission), not the Rust-agent
+          // permission manager.
           await respondCliHookPermission(
             pending.sessionId ?? "",
             pending.requestId,

--- a/src/engines/SessionCore/sync/adapters/cliAdapter.ts
+++ b/src/engines/SessionCore/sync/adapters/cliAdapter.ts
@@ -869,16 +869,18 @@ export const cliAdapter: SessionAdapter = {
     }
 
     /**
-     * `permission:request` with `origin: "cli_hook"` — a managed CLI
-     * session's PermissionRequest hook is parked on the backend waiting
-     * for the user. Mirror of the Rust-agent adapter's
-     * handlePermissionRequest: dispatch the window CustomEvent that
-     * PermissionCard consumes, tagged so its response routes back to the
-     * hook registry (`cli_agent_approval_response`) instead of
-     * `agent_permission_response`.
+     * `permission:request` with `origin: "cli_hook"` or `"acp"` — a
+     * managed CLI session's PermissionRequest hook (Claude) or an ACP
+     * agent's `session/request_permission` (OpenCode/Copilot/Kiro) is
+     * parked on the backend waiting for the user. Mirror of the
+     * Rust-agent adapter's handlePermissionRequest: dispatch the window
+     * CustomEvent that PermissionCard consumes, tagged so its response
+     * routes back to the CLI registries (`cli_agent_approval_response`)
+     * instead of `agent_permission_response`.
      */
-    function handleCliHookPermissionRequest(raw: RawSessionEvent): void {
-      if (raw.origin !== "cli_hook") return;
+    function handleCliPermissionRequest(raw: RawSessionEvent): void {
+      const origin = raw.origin;
+      if (origin !== "cli_hook" && origin !== "acp") return;
       const requestId = rawString(raw, "requestId");
       if (!requestId) return;
       const permEvent: PermissionRequestEvent = {
@@ -890,7 +892,7 @@ export const cliAdapter: SessionAdapter = {
           raw.toolArgs && typeof raw.toolArgs === "object"
             ? (raw.toolArgs as Record<string, unknown>)
             : {},
-        origin: "cli_hook",
+        origin,
       };
       window.dispatchEvent(
         new CustomEvent("agent-permission-request", { detail: permEvent })
@@ -906,7 +908,7 @@ export const cliAdapter: SessionAdapter = {
         if (raw.type === "agent:interaction_finalized") {
           handleInteractionFinalized(raw as unknown as AgentWSEvent, sessionId);
         } else if (raw.type === "permission:request") {
-          handleCliHookPermissionRequest(raw);
+          handleCliPermissionRequest(raw);
         } else if (raw.type === "agent:plan_ready_for_approval") {
           handlePlanReadyForApproval(raw);
         } else if (raw.type === "agent:exit_plan_mode") {

--- a/src/engines/SessionCore/sync/adapters/shared/types.ts
+++ b/src/engines/SessionCore/sync/adapters/shared/types.ts
@@ -313,10 +313,11 @@ export interface PermissionRequestEvent {
    * Where the pending approval is parked on the backend. Default
    * (undefined) is the Rust-agent `AgentPermissionManager`
    * (`agent_permission_response`). `"cli_hook"` marks a managed CLI
-   * session's PermissionRequest hook long-poll, answered via
-   * `cli_agent_approval_response` instead.
+   * session's PermissionRequest hook long-poll, `"acp"` an ACP agent's
+   * (OpenCode/Copilot/Kiro) parked `session/request_permission` — both
+   * answered via `cli_agent_approval_response` instead.
    */
-  origin?: "cli_hook";
+  origin?: "cli_hook" | "acp";
 }
 
 export interface QuestionRequestEvent {

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -24,6 +24,7 @@
       "roundCount_other": "{{count}} rounds",
       "agentWorked": "Agent worked",
       "cliNativeStore": "CLI native store",
+      "sessionId": "Session ID",
       "reasoningModel": "Reasoning Model",
       "codingModel": "Coding Model",
       "sessionMode": "Session Mode",

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -24,6 +24,7 @@
       "roundCount_other": "{{count}} 轮",
       "agentWorked": "Agent 工作",
       "cliNativeStore": "CLI 原生存储",
+      "sessionId": "会话 ID",
       "reasoningModel": "Reasoning Model",
       "codingModel": "Coding Model",
       "sessionMode": "Session 模式",


### PR DESCRIPTION
## ACP permission requests are now interactive
OpenCode/Copilot/Kiro `session/request_permission` requests previously surfaced as a passive transcript chunk and auto-approved after 300s (the frontend half was dead code). They now broadcast a `permission:request` event reusing the hook-bridge wire shape (`origin: "acp"`), render in the existing PermissionCard, and resolve through `cli_agent_approval_response` by request id. The protocol response picks the real `optionId` from the request's own `options` array by kind rather than hardcoding; the 300s auto-approve fallback is unchanged.

## Cursor CLI native transcripts
`ModelType::CursorCli` joins the native-transcript binding map. Evidence for the flip (from the cursor-agent bundle source): the store dir uuid and the stream's `session_id` are the same variable, emitted on the `system/init` event — so the runner's existing early binding captures it with no code change; verified against 8 real stores (dir name == `meta.agentId`, 8/8).

**Bug fix found while verifying**: the reader scanned `<profile>/.cursor/chats`, but cursor-agent joins `chats` directly onto `CURSOR_CONFIG_DIR` (the `.cursor` component only exists in the fallback branch) — managed stores were invisible to discovery, which under native mode means an empty transcript. Discovery now covers the config-dir roots, hosted-key per-session dirs, and `XDG_CONFIG_HOME`.

## Message edit no longer destroys native transcripts
`cli_agent_truncate_after_chunk` unconditionally wiped the hosted-key Cursor config dir "so the agent starts fresh" — but under `transcript_source = 'native'` that directory IS the transcript of record, so editing a message erased the whole conversation instead of truncating it. The fork is already driven by `clear_cli_resume_state_with_tx` inside the truncate; the wipe is now legacy-chunk-mode only, matching Claude/Codex native fork semantics (superseded store stays on disk, hidden behind the ledger).

## Session ID on the hover card
Non-org2 sessions show their underlying id (imported: prefix stripped → the CLI's own store key; managed: bound `cli_session_id`), click to copy. Reuses the existing `cli_agent_status` payload — no new backend command.

## Verification
`cargo test -p orgtrack_core cursor_cli` (9), `-p org2 --lib native_transcript` (3), `--lib cursor` (28), `--lib acp` (52), `--lib approval` (15), `cargo check -p org2 --lib`, `tsc --noEmit` — all green.

## Known gaps
- Cursor native mode has no live end-to-end run of a **managed** session yet (cursor-agent auth was unavailable during verification; an external-terminal session was verified to parse correctly — title/chunks/WAL all good). Worth one real managed session before rollout, since a discovery miss under native mode means no transcript rather than a degraded one.
- `sessionId` i18n key is en/zh only — same scope as the adjacent `cliNativeStore` key it sits next to.