### PR TITLE
fix(cloud): billing opens signed-in via one-time bridge link

### DIFF
--- a/src/features/Org2Cloud/config.test.ts
+++ b/src/features/Org2Cloud/config.test.ts
@@ -6,6 +6,7 @@ import {
   ORG2_CLOUD_OFFICIAL_SUPABASE_URL,
   ORG2_CLOUD_OFFICIAL_WEB_ORIGIN,
   Org2CloudEndpointOverrideSchema,
+  buildCloudAuthBridgeUrl,
   buildCloudAuthCallbackUrl,
   buildCloudBillingLoginUrl,
   buildOrg2CloudLoginUrl,
@@ -157,6 +158,27 @@ describe("buildCloudBillingLoginUrl", () => {
     const url = new URL(buildCloudBillingLoginUrl());
     expect(url.origin).toBe(OVERRIDE.webOrigin);
     expect(url.pathname).toBe("/login");
+  });
+});
+
+describe("buildCloudAuthBridgeUrl", () => {
+  it("targets the official web origin by default", () => {
+    expect(buildCloudAuthBridgeUrl()).toBe(
+      `${ORG2_CLOUD_OFFICIAL_WEB_ORIGIN}/api/auth/bridge`
+    );
+  });
+
+  it("follows a custom endpoint's web origin", () => {
+    storeOverride(OVERRIDE);
+    expect(buildCloudAuthBridgeUrl()).toBe(
+      `${OVERRIDE.webOrigin}/api/auth/bridge`
+    );
+  });
+
+  it("uses an explicitly passed origin", () => {
+    expect(buildCloudAuthBridgeUrl("https://cloud.other.dev")).toBe(
+      "https://cloud.other.dev/api/auth/bridge"
+    );
   });
 });
 

--- a/src/features/Org2Cloud/config.ts
+++ b/src/features/Org2Cloud/config.ts
@@ -166,3 +166,11 @@ export function buildCloudBillingLoginUrl(): string {
   url.searchParams.set("return_to", CLOUD_BILLING_PATH);
   return url.toString();
 }
+
+export const CLOUD_AUTH_BRIDGE_PATH = "/api/auth/bridge";
+
+export function buildCloudAuthBridgeUrl(
+  webOrigin: string = getCloudEndpoint().webOrigin
+): string {
+  return new URL(CLOUD_AUTH_BRIDGE_PATH, webOrigin).toString();
+}

--- a/src/features/Org2Cloud/useOpenCloudBilling.test.ts
+++ b/src/features/Org2Cloud/useOpenCloudBilling.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ORG2_CLOUD_ENDPOINT_OVERRIDE_STORAGE_KEY,
+  ORG2_CLOUD_OFFICIAL_WEB_ORIGIN,
+  buildCloudBillingLoginUrl,
+} from "./config";
+import type { Org2CloudAuthState } from "./org2CloudAuthAtom";
+import { openCloudBilling } from "./useOpenCloudBilling";
+
+const { ensureFreshSessionMock, messageErrorMock, openUrlMock } = vi.hoisted(
+  () => ({
+    ensureFreshSessionMock: vi.fn(),
+    messageErrorMock: vi.fn(),
+    openUrlMock: vi.fn(),
+  })
+);
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: openUrlMock,
+}));
+
+vi.mock("@src/components/Message", () => ({
+  default: { error: messageErrorMock },
+}));
+
+vi.mock("@src/i18n", () => ({
+  default: { t: (key: string) => key },
+}));
+
+vi.mock("./org2CloudClient", () => ({
+  ensureFreshSession: ensureFreshSessionMock,
+}));
+
+const AUTH: Org2CloudAuthState = {
+  kind: "org2_cloud",
+  supabaseUrl: "https://project.supabase.test",
+  supabaseAnonKey: "anon-key",
+  userId: "user-1",
+  accessToken: "access-1",
+  refreshToken: "refresh-1",
+  expiresAt: 9_999_999_999,
+};
+
+const BRIDGE_URL = `${ORG2_CLOUD_OFFICIAL_WEB_ORIGIN}/api/auth/bridge`;
+const VERIFY_URL = `${ORG2_CLOUD_OFFICIAL_WEB_ORIGIN}/auth/callback?token_hash=abc&type=magiclink&return_to=%2Fbilling`;
+
+const fetchMock = vi.fn();
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function stateHarness(initial: Org2CloudAuthState | null) {
+  let current = initial;
+  return {
+    get current() {
+      return current;
+    },
+    setAuth(
+      update:
+        | Org2CloudAuthState
+        | null
+        | ((prev: Org2CloudAuthState | null) => Org2CloudAuthState | null)
+    ) {
+      current = typeof update === "function" ? update(current) : update;
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+  localStorage.removeItem(ORG2_CLOUD_ENDPOINT_OVERRIDE_STORAGE_KEY);
+});
+
+describe("openCloudBilling", () => {
+  it("opens the bridge verifyUrl when the bridge succeeds", async () => {
+    const state = stateHarness(AUTH);
+    ensureFreshSessionMock.mockResolvedValueOnce(AUTH);
+    fetchMock.mockResolvedValueOnce(jsonResponse({ verifyUrl: VERIFY_URL }));
+
+    await openCloudBilling(AUTH, state.setAuth);
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(BRIDGE_URL);
+    expect(init.method).toBe("POST");
+    const headers = init.headers as Record<string, string>;
+    expect(headers.authorization).toBe("Bearer access-1");
+    expect(headers["content-type"]).toBe("application/json");
+    expect(JSON.parse(String(init.body))).toEqual({ return_to: "/billing" });
+    expect(openUrlMock).toHaveBeenCalledWith(VERIFY_URL);
+    expect(messageErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("commits a rotated session and uses its access token", async () => {
+    const state = stateHarness(AUTH);
+    const fresh: Org2CloudAuthState = {
+      ...AUTH,
+      accessToken: "access-2",
+      refreshToken: "refresh-2",
+    };
+    ensureFreshSessionMock.mockResolvedValueOnce(fresh);
+    fetchMock.mockResolvedValueOnce(jsonResponse({ verifyUrl: VERIFY_URL }));
+
+    await openCloudBilling(AUTH, state.setAuth);
+
+    expect(state.current).toBe(fresh);
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers.authorization).toBe("Bearer access-2");
+    expect(openUrlMock).toHaveBeenCalledWith(VERIFY_URL);
+  });
+
+  it("opens the web login when signed out, without calling the bridge", async () => {
+    const state = stateHarness(null);
+
+    await openCloudBilling(null, state.setAuth);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(openUrlMock).toHaveBeenCalledWith(buildCloudBillingLoginUrl());
+    expect(messageErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the web login when the token refresh fails", async () => {
+    const state = stateHarness(AUTH);
+    ensureFreshSessionMock.mockResolvedValueOnce(null);
+
+    await openCloudBilling(AUTH, state.setAuth);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(openUrlMock).toHaveBeenCalledWith(buildCloudBillingLoginUrl());
+    expect(messageErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the web login on a non-200 bridge response", async () => {
+    const state = stateHarness(AUTH);
+    ensureFreshSessionMock.mockResolvedValueOnce(AUTH);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ error: "unauthorized" }, 401)
+    );
+
+    await openCloudBilling(AUTH, state.setAuth);
+
+    expect(openUrlMock).toHaveBeenCalledWith(buildCloudBillingLoginUrl());
+    expect(messageErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the web login on a network error", async () => {
+    const state = stateHarness(AUTH);
+    ensureFreshSessionMock.mockResolvedValueOnce(AUTH);
+    fetchMock.mockRejectedValueOnce(new Error("offline"));
+
+    await openCloudBilling(AUTH, state.setAuth);
+
+    expect(openUrlMock).toHaveBeenCalledWith(buildCloudBillingLoginUrl());
+    expect(messageErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses a foreign-origin verifyUrl and falls back to the web login", async () => {
+    const state = stateHarness(AUTH);
+    ensureFreshSessionMock.mockResolvedValueOnce(AUTH);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        verifyUrl: "https://evil.example.com/auth/callback?token_hash=abc",
+      })
+    );
+
+    await openCloudBilling(AUTH, state.setAuth);
+
+    expect(openUrlMock).toHaveBeenCalledWith(buildCloudBillingLoginUrl());
+    expect(messageErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the web login on an unexpected response shape", async () => {
+    const state = stateHarness(AUTH);
+    ensureFreshSessionMock.mockResolvedValueOnce(AUTH);
+    fetchMock.mockResolvedValueOnce(jsonResponse({ url: VERIFY_URL }));
+
+    await openCloudBilling(AUTH, state.setAuth);
+
+    expect(openUrlMock).toHaveBeenCalledWith(buildCloudBillingLoginUrl());
+  });
+
+  it("falls back to the web login when verifyUrl is not a URL", async () => {
+    const state = stateHarness(AUTH);
+    ensureFreshSessionMock.mockResolvedValueOnce(AUTH);
+    fetchMock.mockResolvedValueOnce(jsonResponse({ verifyUrl: "not a url" }));
+
+    await openCloudBilling(AUTH, state.setAuth);
+
+    expect(openUrlMock).toHaveBeenCalledWith(buildCloudBillingLoginUrl());
+  });
+
+  it("targets a custom endpoint's web origin for bridge and origin check", async () => {
+    localStorage.setItem(
+      ORG2_CLOUD_ENDPOINT_OVERRIDE_STORAGE_KEY,
+      JSON.stringify({
+        webOrigin: "https://cloud.acme.dev",
+        supabaseUrl: "https://supabase.acme.dev",
+        anonKey: "sb_publishable_custom",
+      })
+    );
+    const state = stateHarness(AUTH);
+    ensureFreshSessionMock.mockResolvedValueOnce(AUTH);
+    const customVerifyUrl =
+      "https://cloud.acme.dev/auth/callback?token_hash=abc&type=magiclink";
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ verifyUrl: customVerifyUrl })
+    );
+
+    await openCloudBilling(AUTH, state.setAuth);
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe("https://cloud.acme.dev/api/auth/bridge");
+    expect(openUrlMock).toHaveBeenCalledWith(customVerifyUrl);
+  });
+
+  it("toasts only when the browser open itself fails", async () => {
+    const state = stateHarness(AUTH);
+    ensureFreshSessionMock.mockResolvedValueOnce(AUTH);
+    fetchMock.mockResolvedValueOnce(jsonResponse({ verifyUrl: VERIFY_URL }));
+    openUrlMock.mockRejectedValueOnce(new Error("no browser"));
+
+    await openCloudBilling(AUTH, state.setAuth);
+
+    expect(messageErrorMock).toHaveBeenCalledWith(
+      "navigation:cloud.billing.openFailed"
+    );
+  });
+});

--- a/src/features/Org2Cloud/useOpenCloudBilling.ts
+++ b/src/features/Org2Cloud/useOpenCloudBilling.ts
@@ -2,33 +2,119 @@
  * Shared "open the billing page" affordance for every desktop paywall
  * touchpoint (plan section, scope-cap hint, retention-expired toasts).
  *
- * Opens the web login (returning to billing) in the SYSTEM browser. The
- * browser session's cookie/refresh lifecycle is intentionally independent
- * from the desktop session so opening Billing can never rotate the
- * desktop's refresh token. After Stripe confirms the plan, the success
- * page navigates to `orgii://billing/complete`, which the OS routes back
- * to the app as a deep link (handled in useDeepLinkHandler).
+ * Opens billing in the SYSTEM browser. When the desktop is signed in, a
+ * one-time bridge link (`POST /api/auth/bridge` with the desktop access
+ * token) yields a magiclink verify URL so the browser lands on /billing
+ * already signed in. The browser still mints its OWN cookie/refresh
+ * lifecycle from that one-time link — the desktop refresh token never
+ * leaves the app, so opening Billing can never rotate it. Any bridge
+ * failure (signed out, non-200, network, foreign-origin verify URL)
+ * falls back to the plain web login returning to billing. After Stripe
+ * confirms the plan, the success page navigates to
+ * `orgii://billing/complete`, which the OS routes back to the app as a
+ * deep link (handled in useDeepLinkHandler).
  */
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useCallback } from "react";
+import { useAtom } from "jotai";
+import { useCallback, useEffect, useRef } from "react";
+import { z } from "zod/v4";
 
 import Message from "@src/components/Message";
 import { createLogger } from "@src/hooks/logger";
 import i18n from "@src/i18n";
 
-import { buildCloudBillingLoginUrl } from "./config";
+import type { SetOrg2CloudAuth } from "./completeSignIn";
+import {
+  CLOUD_BILLING_PATH,
+  buildCloudAuthBridgeUrl,
+  buildCloudBillingLoginUrl,
+  getCloudEndpoint,
+} from "./config";
+import {
+  type Org2CloudAuthState,
+  commitRefreshedAuth,
+  org2CloudAuthAtom,
+} from "./org2CloudAuthAtom";
+import { ensureFreshSession } from "./org2CloudClient";
 
 const log = createLogger("Org2CloudBilling");
 
+const BRIDGE_TIMEOUT_MS = 10_000;
+
+const BridgeResponseSchema = z.object({ verifyUrl: z.string() });
+
+async function requestBridgeVerifyUrl(
+  accessToken: string
+): Promise<string | null> {
+  const { webOrigin } = getCloudEndpoint();
+  const response = await fetch(buildCloudAuthBridgeUrl(webOrigin), {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${accessToken}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ return_to: CLOUD_BILLING_PATH }),
+    signal: AbortSignal.timeout(BRIDGE_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    log.warn(`billing bridge request failed with status ${response.status}`);
+    return null;
+  }
+  const parsed = BridgeResponseSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    log.warn("billing bridge returned unexpected shape");
+    return null;
+  }
+  const verifyUrl = new URL(parsed.data.verifyUrl);
+  if (verifyUrl.origin !== new URL(webOrigin).origin) {
+    log.warn("billing bridge verifyUrl is not on the endpoint origin");
+    return null;
+  }
+  return verifyUrl.toString();
+}
+
+async function resolveCloudBillingUrl(
+  auth: Org2CloudAuthState | null,
+  setAuth: SetOrg2CloudAuth
+): Promise<string> {
+  if (!auth) return buildCloudBillingLoginUrl();
+  try {
+    const fresh = await ensureFreshSession(auth);
+    if (!fresh) return buildCloudBillingLoginUrl();
+    commitRefreshedAuth(setAuth, auth, fresh);
+    const verifyUrl = await requestBridgeVerifyUrl(fresh.accessToken);
+    return verifyUrl ?? buildCloudBillingLoginUrl();
+  } catch (error) {
+    log.warn("billing bridge failed; falling back to web login", error);
+    return buildCloudBillingLoginUrl();
+  }
+}
+
+export async function openCloudBilling(
+  auth: Org2CloudAuthState | null,
+  setAuth: SetOrg2CloudAuth
+): Promise<void> {
+  const url = await resolveCloudBillingUrl(auth, setAuth);
+  try {
+    await openUrl(url);
+  } catch (error) {
+    log.error("failed to open ORG2 Cloud billing in system browser", error);
+    Message.error(i18n.t("navigation:cloud.billing.openFailed"));
+  }
+}
+
 /**
- * Stable callback that opens the ORG2 Cloud billing login in the system
+ * Stable callback that opens the ORG2 Cloud billing page in the system
  * browser.
  */
 export function useOpenCloudBilling(): () => void {
+  const [auth, setAuth] = useAtom(org2CloudAuthAtom);
+  const authRef = useRef(auth);
+  useEffect(() => {
+    authRef.current = auth;
+  }, [auth]);
+
   return useCallback(() => {
-    void openUrl(buildCloudBillingLoginUrl()).catch((error: unknown) => {
-      log.error("failed to open ORG2 Cloud billing in system browser", error);
-      Message.error(i18n.t("navigation:cloud.billing.openFailed"));
-    });
-  }, []);
+    void openCloudBilling(authRef.current, setAuth);
+  }, [setAuth]);
 }


### PR DESCRIPTION
## Problem

Opening Billing from the desktop always launched `<site>/login?return_to=/billing` with no credentials, so the system browser asked the user to log in again even seconds after a desktop sign-in.

## Flow

1. Desktop refreshes its session the standard way (`ensureFreshSession`, rotated tokens committed back via `commitRefreshedAuth`).
2. `POST <webOrigin>/api/auth/bridge` with `Authorization: Bearer <desktop access token>` and body `{"return_to":"/billing"}` (10s timeout).
3. The endpoint mints a one-time magiclink `verifyUrl`; the desktop validates it parses as a URL on the SAME origin as the resolved cloud endpoint (foreign origins refused), then opens it in the system browser.
4. The browser verifies the magiclink and mints its OWN cookie/refresh session — the desktop refresh token never leaves the app — and lands on `/billing` signed in.

## Fallback

Any failure (signed out, refresh failure, non-200, network error/timeout, unexpected response shape, invalid or foreign-origin verifyUrl) falls back to the previous behavior: open `buildCloudBillingLoginUrl()` so billing still opens behind the login form. No error toast on the fallback path; the toast only fires if the browser open itself fails (unchanged).

Custom-endpoint overrides keep working — the bridge URL and the origin check both derive from one `getCloudEndpoint()` resolution per attempt.

## Tests

- `useOpenCloudBilling.test.ts` (new, 11 cases): bridge success opens verifyUrl; rotated-session commit + fresh token use; signed-out / refresh-failure / non-200 / network / bad-shape / non-URL / foreign-origin fallbacks; custom-endpoint origin; toast only on open failure.
- `config.test.ts`: coverage for the new `buildCloudAuthBridgeUrl()` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)