### PR TITLE
perf: replace polling hot spots with push invalidation

### DIFF
--- a/src-tauri/crates/agent-core/src/core/coordination/agent_inbox.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_inbox.rs
@@ -23,7 +23,7 @@
 //!   serde `tag = "kind"` on `AgentMessage` — see the `kind_tag_matches_serde_tag`
 //!   regression test below.
 
-use rusqlite::{params, Connection, Result as SqliteResult};
+use rusqlite::{params, Connection, OptionalExtension, Result as SqliteResult};
 use serde::{Deserialize, Serialize};
 
 use crate::session::AgentExecMode;
@@ -594,6 +594,8 @@ impl AgentInboxStore {
     pub fn insert(params: InsertInboxParams) -> Result<AgentInboxRecord, String> {
         params.message.validate()?;
 
+        let changed_org_run_id = params.org_run_id.clone();
+
         let kind = params.message.kind_tag().to_string();
         let request_id = params.message.request_id().map(|r| r.0.clone());
         let payload_json = serde_json::to_string(&params.message)
@@ -630,7 +632,7 @@ impl AgentInboxStore {
             .map_err(|err| err.to_string())?;
             Ok(conn.last_insert_rowid())
         })?;
-        Ok(AgentInboxRecord {
+        let record = AgentInboxRecord {
             id,
             recipient_agent_id: params.recipient_agent_id,
             recipient_member_id: params.recipient_member_id,
@@ -642,7 +644,11 @@ impl AgentInboxStore {
             request_id,
             created_at: now,
             read_at: None,
-        })
+        };
+        if let Some(org_run_id) = changed_org_run_id {
+            crate::coordination::agent_org_run_events::notify_agent_org_run_changed(&org_run_id);
+        }
+        Ok(record)
     }
 }
 
@@ -746,29 +752,50 @@ impl AgentInboxStore {
         if ids.is_empty() {
             return Ok(0);
         }
-        with_sessions_writer(|| -> Result<usize, String> {
-            let mut conn = get_connection().map_err(|err| err.to_string())?;
-            let tx = conn
-                .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
-                .map_err(|err| err.to_string())?;
-            let now = chrono::Utc::now().to_rfc3339();
-            let mut updated = 0usize;
-            {
-                let mut stmt = tx
-                    .prepare(
-                        "UPDATE agent_inbox SET read_at = ?1 WHERE id = ?2 AND read_at IS NULL",
-                    )
+        let (updated, changed_run_ids) = with_sessions_writer(
+            || -> Result<(usize, std::collections::HashSet<String>), String> {
+                let mut conn = get_connection().map_err(|err| err.to_string())?;
+                let tx = conn
+                    .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
                     .map_err(|err| err.to_string())?;
-                for id in ids {
-                    let n = stmt
-                        .execute(params![&now, id])
+                let now = chrono::Utc::now().to_rfc3339();
+                let mut updated = 0usize;
+                let mut changed_run_ids = std::collections::HashSet::new();
+                {
+                    let mut stmt = tx
+                        .prepare(
+                            "UPDATE agent_inbox SET read_at = ?1 WHERE id = ?2 AND read_at IS NULL",
+                        )
                         .map_err(|err| err.to_string())?;
-                    updated += n;
+                    for id in ids {
+                        let org_run_id = tx
+                        .query_row(
+                            "SELECT org_run_id FROM agent_inbox WHERE id = ?1 AND read_at IS NULL",
+                            params![id],
+                            |row| row.get::<_, Option<String>>(0),
+                        )
+                        .optional()
+                        .map_err(|err| err.to_string())?
+                        .flatten();
+                        let n = stmt
+                            .execute(params![&now, id])
+                            .map_err(|err| err.to_string())?;
+                        updated += n;
+                        if n > 0 {
+                            if let Some(org_run_id) = org_run_id {
+                                changed_run_ids.insert(org_run_id);
+                            }
+                        }
+                    }
                 }
-            }
-            tx.commit().map_err(|err| err.to_string())?;
-            Ok(updated)
-        })
+                tx.commit().map_err(|err| err.to_string())?;
+                Ok((updated, changed_run_ids))
+            },
+        )?;
+        for org_run_id in changed_run_ids {
+            crate::coordination::agent_org_run_events::notify_agent_org_run_changed(&org_run_id);
+        }
+        Ok(updated)
     }
 }
 

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_member_interventions.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_member_interventions.rs
@@ -134,17 +134,19 @@ impl AgentMemberInterventionStore {
             Ok(())
         })?;
 
-        Self::get(&params.org_run_id, &params.member_id)?.ok_or_else(|| {
+        let record = Self::get(&params.org_run_id, &params.member_id)?.ok_or_else(|| {
             format!(
                 "agent_member_interventions upsert did not return row for run={} member={}",
                 params.org_run_id, params.member_id
             )
-        })
+        })?;
+        crate::coordination::agent_org_run_events::notify_agent_org_run_changed(&record.org_run_id);
+        Ok(record)
     }
 
     pub fn clear(org_run_id: &str, member_id: &str) -> Result<bool, String> {
         let now = chrono::Utc::now().to_rfc3339();
-        with_sessions_writer(|| -> Result<bool, String> {
+        let changed = with_sessions_writer(|| -> Result<bool, String> {
             let conn = get_connection().map_err(|err| err.to_string())?;
             let updated = conn
                 .execute(
@@ -155,7 +157,11 @@ impl AgentMemberInterventionStore {
                 )
                 .map_err(|err| err.to_string())?;
             Ok(updated > 0)
-        })
+        })?;
+        if changed {
+            crate::coordination::agent_org_run_events::notify_agent_org_run_changed(org_run_id);
+        }
+        Ok(changed)
     }
 
     pub fn get(

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_run_events.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_run_events.rs
@@ -1,0 +1,48 @@
+//! Run-scoped frontend invalidation for Agent Org read models.
+//!
+//! The run view is assembled from several durable stores (run, tasks, inbox,
+//! interventions, and session runtime rows). Each owner emits the same small
+//! invalidation after a successful mutation. The frontend then coalesces these
+//! pushes and refreshes one shared projection per mounted run.
+
+use serde::Serialize;
+
+use super::agent_org_runs::AgentOrgRunStore;
+
+pub const AGENT_ORG_RUN_CHANGED_EVENT: &str = "agent_org:run_changed";
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentOrgRunChangedPayload<'a> {
+    org_run_id: &'a str,
+}
+
+/// Notify connected frontends that a run's composite read model is stale.
+pub fn notify_agent_org_run_changed(org_run_id: &str) {
+    if crate::bus::frontend_subscriber_count() == 0 {
+        return;
+    }
+    crate::bus::broadcast_event(
+        AGENT_ORG_RUN_CHANGED_EVENT,
+        AgentOrgRunChangedPayload { org_run_id },
+    );
+}
+
+/// Resolve a changed session back to its Agent Org run, if any, and notify it.
+///
+/// Session persistence calls this outside its writer guard, so the parent walk
+/// can safely open a read connection without extending a write-lock lifetime.
+pub fn notify_agent_org_session_changed(session_id: &str) {
+    if crate::bus::frontend_subscriber_count() == 0 {
+        return;
+    }
+    match AgentOrgRunStore::run_id_for_session_with_parent_walk(session_id) {
+        Ok(Some(org_run_id)) => notify_agent_org_run_changed(&org_run_id),
+        Ok(None) => {}
+        Err(error) => tracing::warn!(
+            session_id,
+            error = %error,
+            "[agent_org] failed to resolve changed session to a run"
+        ),
+    }
+}

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_runs/store.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_runs/store.rs
@@ -50,6 +50,7 @@ impl AgentOrgRunStore {
             insert_run(&conn, &run).map_err(|err| err.to_string())?;
             Ok(())
         })?;
+        crate::coordination::agent_org_run_events::notify_agent_org_run_changed(&run.id);
         Ok(run)
     }
 
@@ -59,7 +60,7 @@ impl AgentOrgRunStore {
         let paused = validate_status(AgentOrgRunStatus::Paused.as_str())?;
         let running = validate_status(AgentOrgRunStatus::Running.as_str())?;
         let now = chrono::Utc::now().to_rfc3339();
-        with_sessions_writer(|| -> Result<bool, String> {
+        let changed = with_sessions_writer(|| -> Result<bool, String> {
             let conn = get_connection().map_err(|err| err.to_string())?;
             let rows_changed = conn
                 .execute(
@@ -72,7 +73,11 @@ impl AgentOrgRunStore {
                 )
                 .map_err(|err| err.to_string())?;
             Ok(rows_changed > 0)
-        })
+        })?;
+        if changed {
+            crate::coordination::agent_org_run_events::notify_agent_org_run_changed(run_id);
+        }
+        Ok(changed)
     }
 
     /// Called once at app startup to pause every org run that was `running`
@@ -110,7 +115,7 @@ impl AgentOrgRunStore {
         let running = validate_status(AgentOrgRunStatus::Running.as_str())?;
         let paused = validate_status(AgentOrgRunStatus::Paused.as_str())?;
         let now = chrono::Utc::now().to_rfc3339();
-        with_sessions_writer(|| -> Result<bool, String> {
+        let changed = with_sessions_writer(|| -> Result<bool, String> {
             let conn = get_connection().map_err(|err| err.to_string())?;
             let rows_changed = conn
                 .execute(
@@ -123,7 +128,11 @@ impl AgentOrgRunStore {
                 )
                 .map_err(|err| err.to_string())?;
             Ok(rows_changed > 0)
-        })
+        })?;
+        if changed {
+            crate::coordination::agent_org_run_events::notify_agent_org_run_changed(run_id);
+        }
+        Ok(changed)
     }
 
     pub fn mark_failed(run_id: &str, error_message: &str) -> Result<(), String> {
@@ -142,7 +151,9 @@ impl AgentOrgRunStore {
             )
             .map_err(|err| err.to_string())?;
             Ok(())
-        })
+        })?;
+        crate::coordination::agent_org_run_events::notify_agent_org_run_changed(run_id);
+        Ok(())
     }
 
     pub fn reconcile_if_terminal(run_id: &str) -> Result<Option<AgentOrgRunStatus>, String> {
@@ -209,6 +220,7 @@ impl AgentOrgRunStore {
             .map_err(|err| err.to_string())?;
             Ok(())
         })?;
+        crate::coordination::agent_org_run_events::notify_agent_org_run_changed(run_id);
         Ok(Some(next_status))
     }
 
@@ -253,6 +265,10 @@ impl AgentOrgRunStore {
         session_id: &str,
     ) -> Result<Option<String>, String> {
         Ok(Self::run_for_session_with_parent_walk(session_id)?.and_then(|run| run.root_session_id))
+    }
+
+    pub fn run_id_for_session_with_parent_walk(session_id: &str) -> Result<Option<String>, String> {
+        Ok(Self::run_for_session_with_parent_walk(session_id)?.map(|run| run.id))
     }
 
     pub fn is_root_session(org_run_id: &str, session_id: &str) -> Result<bool, String> {
@@ -363,12 +379,17 @@ impl AgentOrgRunStore {
     }
 
     pub fn delete_by_id(run_id: &str) -> Result<(), String> {
-        with_sessions_writer(|| -> Result<(), String> {
+        let deleted = with_sessions_writer(|| -> Result<bool, String> {
             let conn = get_connection().map_err(|err| err.to_string())?;
-            conn.execute("DELETE FROM agent_org_runs WHERE id = ?1", params![run_id])
+            let rows = conn
+                .execute("DELETE FROM agent_org_runs WHERE id = ?1", params![run_id])
                 .map_err(|err| err.to_string())?;
-            Ok(())
-        })
+            Ok(rows > 0)
+        })?;
+        if deleted {
+            crate::coordination::agent_org_run_events::notify_agent_org_run_changed(run_id);
+        }
+        Ok(())
     }
 
     /// Find the freshest materialized worker session for a canonical roster

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_tasks/store.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_tasks/store.rs
@@ -36,7 +36,7 @@ impl AgentOrgTaskStore {
         let metadata_json = encode_metadata(params.metadata.as_ref())?;
         let now = now_rfc3339();
 
-        with_sessions_writer(|| -> Result<Task, String> {
+        let task = with_sessions_writer(|| -> Result<Task, String> {
             let mut conn = get_connection().map_err(|err| err.to_string())?;
             let tx = conn
                 .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
@@ -100,7 +100,9 @@ impl AgentOrgTaskStore {
             tx.commit().map_err(|err| err.to_string())?;
 
             Ok(task)
-        })
+        })?;
+        crate::coordination::agent_org_run_events::notify_agent_org_run_changed(&task.org_run_id);
+        Ok(task)
     }
 
     pub fn get(org_run_id: &str, task_id: &str) -> Result<Option<Task>, String> {
@@ -146,7 +148,9 @@ impl AgentOrgTaskStore {
     /// missing row so callers can surface a clear "task_not_found" without
     /// a separate get round-trip.
     pub fn update(org_run_id: &str, task_id: &str, patch: UpdateTaskPatch) -> Result<Task, String> {
-        with_sessions_writer(|| Self::update_inner(org_run_id, task_id, patch))
+        let task = with_sessions_writer(|| Self::update_inner(org_run_id, task_id, patch))?;
+        crate::coordination::agent_org_run_events::notify_agent_org_run_changed(org_run_id);
+        Ok(task)
     }
 
     fn update_inner(
@@ -260,7 +264,7 @@ impl AgentOrgTaskStore {
     }
 
     pub fn delete(org_run_id: &str, task_id: &str) -> Result<bool, String> {
-        with_sessions_writer(|| -> Result<bool, String> {
+        let deleted = with_sessions_writer(|| -> Result<bool, String> {
             let conn = get_connection().map_err(|err| err.to_string())?;
             let n = conn
                 .execute(
@@ -269,7 +273,11 @@ impl AgentOrgTaskStore {
                 )
                 .map_err(|err| err.to_string())?;
             Ok(n > 0)
-        })
+        })?;
+        if deleted {
+            crate::coordination::agent_org_run_events::notify_agent_org_run_changed(org_run_id);
+        }
+        Ok(deleted)
     }
 
     /// Return the first task in the run that is `pending`, `owner IS
@@ -344,9 +352,11 @@ impl AgentOrgTaskStore {
             ));
         }
 
-        with_sessions_writer(|| {
+        let task = with_sessions_writer(|| {
             Self::try_claim_inner(org_run_id, task_id, claimant_member_id, options)
-        })
+        })?;
+        crate::coordination::agent_org_run_events::notify_agent_org_run_changed(org_run_id);
+        Ok(task)
     }
 
     fn try_claim_inner(
@@ -505,7 +515,12 @@ impl AgentOrgTaskStore {
         org_run_id: &str,
         owner_member_id: &str,
     ) -> Result<Vec<Task>, String> {
-        with_sessions_writer(|| Self::unassign_for_owner_inner(org_run_id, owner_member_id))
+        let tasks =
+            with_sessions_writer(|| Self::unassign_for_owner_inner(org_run_id, owner_member_id))?;
+        if !tasks.is_empty() {
+            crate::coordination::agent_org_run_events::notify_agent_org_run_changed(org_run_id);
+        }
+        Ok(tasks)
     }
 
     fn unassign_for_owner_inner(
@@ -582,9 +597,13 @@ impl AgentOrgTaskStore {
         org_run_id: &str,
         owner_member_id: &str,
     ) -> Result<Vec<Task>, String> {
-        with_sessions_writer(|| {
+        let tasks = with_sessions_writer(|| {
             Self::requeue_in_progress_for_owner_inner(org_run_id, owner_member_id)
-        })
+        })?;
+        if !tasks.is_empty() {
+            crate::coordination::agent_org_run_events::notify_agent_org_run_changed(org_run_id);
+        }
+        Ok(tasks)
     }
 
     fn requeue_in_progress_for_owner_inner(

--- a/src-tauri/crates/agent-core/src/core/coordination/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/mod.rs
@@ -21,6 +21,7 @@
 
 pub mod agent_inbox;
 pub mod agent_member_interventions;
+pub mod agent_org_run_events;
 pub mod agent_org_runs;
 pub mod agent_org_tasks;
 pub mod agent_org_watchdog;

--- a/src-tauri/crates/agent-core/src/core/session/persistence/crud/ops.rs
+++ b/src-tauri/crates/agent-core/src/core/session/persistence/crud/ops.rs
@@ -36,6 +36,7 @@ fn notify_session_mirror(session_id: &str) {
     if let Some(hook) = SESSION_MIRROR_HOOK.get() {
         hook(session_id);
     }
+    crate::coordination::agent_org_run_events::notify_agent_org_session_changed(session_id);
 }
 
 /// Companion delete hook: the upsert-style mirror hook cannot serve deletes

--- a/src-tauri/crates/agent-core/src/core/session/persistence/messages.rs
+++ b/src-tauri/crates/agent-core/src/core/session/persistence/messages.rs
@@ -473,6 +473,12 @@ pub fn save_snapshot(session_id: &str, tool_call_id: &str, hash: &str) -> Sqlite
         Ok(())
     })?;
     crate::tools::file_history::enforce_session_cap_after_save(session_id);
+    if crate::bus::frontend_subscriber_count() > 0 {
+        crate::bus::broadcast_event(
+            "agent:snapshot_created",
+            serde_json::json!({ "sessionId": session_id }),
+        );
+    }
     Ok(())
 }
 

--- a/src-tauri/crates/git/src/watch/debounce.rs
+++ b/src-tauri/crates/git/src/watch/debounce.rs
@@ -45,6 +45,14 @@ pub(crate) fn truncate_preview(s: &str, max_bytes: usize) -> String {
     format!("{}...", &s[..end])
 }
 
+/// A status push represents a new snapshot, not merely a completed poll.
+/// Periodic polling must therefore stay silent when the durable status has not
+/// changed; otherwise every polling tick fans out into redundant frontend
+/// requests for status and diff totals.
+pub(crate) fn status_snapshot_changed(previous: Option<&GitStatus>, current: &GitStatus) -> bool {
+    previous != Some(current)
+}
+
 struct PendingEvent {
     change_type: RepoChangeType,
     first_event_at: Instant,
@@ -594,6 +602,8 @@ impl DebounceManager {
                             &event_emitter,
                         );
 
+                        let status_changed = status_snapshot_changed(old_status.as_ref(), &status);
+
                         // Update cache (this resets consecutive_failures to 0)
                         state_store.update_status(repo_id, status.clone());
 
@@ -610,13 +620,18 @@ impl DebounceManager {
                             );
                         }
 
-                        // Emit status updated event
-                        event_emitter.emit_status_updated(repo_id.to_string(), status);
+                        if status_changed {
+                            // Only publish a new snapshot. The periodic poller
+                            // intentionally runs even while a repo is idle, so
+                            // emitting an unchanged value here would wake every
+                            // frontend Git listener on each tick.
+                            event_emitter.emit_status_updated(repo_id.to_string(), status);
 
-                        // Mark git change for adaptive polling
-                        if let Some(manager_lock) = super::REPO_WATCH_MANAGER.try_read() {
-                            if let Some(manager) = manager_lock.as_ref() {
-                                manager.watcher.mark_git_change(repo_id);
+                            // Mark git change for adaptive polling
+                            if let Some(manager_lock) = super::REPO_WATCH_MANAGER.try_read() {
+                                if let Some(manager) = manager_lock.as_ref() {
+                                    manager.watcher.mark_git_change(repo_id);
+                                }
                             }
                         }
                     }

--- a/src-tauri/crates/git/src/watch/tests/mod.rs
+++ b/src-tauri/crates/git/src/watch/tests/mod.rs
@@ -1,3 +1,4 @@
 mod debounce_tests;
 mod state_store_tests;
+mod status_snapshot_tests;
 mod watcher_tests;

--- a/src-tauri/crates/git/src/watch/tests/status_snapshot_tests.rs
+++ b/src-tauri/crates/git/src/watch/tests/status_snapshot_tests.rs
@@ -1,0 +1,23 @@
+use crate::watch::debounce::status_snapshot_changed;
+use crate::watch::types::GitStatus;
+
+#[test]
+fn unchanged_status_snapshot_does_not_publish() {
+    let status = GitStatus::default();
+
+    assert!(!status_snapshot_changed(Some(&status), &status));
+}
+
+#[test]
+fn changed_status_snapshot_publishes() {
+    let previous = GitStatus::default();
+    let mut current = previous.clone();
+    current.ahead = 1;
+
+    assert!(status_snapshot_changed(Some(&previous), &current));
+}
+
+#[test]
+fn first_status_snapshot_publishes() {
+    assert!(status_snapshot_changed(None, &GitStatus::default()));
+}

--- a/src-tauri/crates/git/src/watch/types.rs
+++ b/src-tauri/crates/git/src/watch/types.rs
@@ -89,7 +89,7 @@ impl RepoState {
 // Git Status
 // ============================================
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GitStatus {
     pub branch: String,
     pub current_upstream_branch: Option<String>,
@@ -126,7 +126,7 @@ pub struct GitStatus {
 }
 
 /// Lightweight file status for event payloads
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GitStatusFile {
     pub path: String,
     pub status: String, // M, A, D, R, C, U, ?, !

--- a/src/api/realtime/websocket/schemas.test.ts
+++ b/src/api/realtime/websocket/schemas.test.ts
@@ -3,6 +3,25 @@ import { describe, expect, it } from "vitest";
 import { maybeParseCodeEditorWebSocketMessage } from "./schemas";
 
 describe("maybeParseCodeEditorWebSocketMessage", () => {
+  it("accepts Agent Org and snapshot invalidation events", () => {
+    expect(
+      maybeParseCodeEditorWebSocketMessage(
+        JSON.stringify({
+          type: "agent_org:run_changed",
+          payload: { orgRunId: "run-1" },
+        })
+      )?.type
+    ).toBe("agent_org:run_changed");
+    expect(
+      maybeParseCodeEditorWebSocketMessage(
+        JSON.stringify({
+          type: "agent:snapshot_created",
+          payload: { sessionId: "session-1" },
+        })
+      )?.type
+    ).toBe("agent:snapshot_created");
+  });
+
   it("passes session status broadcasts through with their payload fields", () => {
     // Shape mirrors the Rust runner's broadcast (session_runner/lifecycle.rs):
     // top-level payload fields, no timestamp.

--- a/src/api/realtime/websocket/schemas.ts
+++ b/src/api/realtime/websocket/schemas.ts
@@ -326,6 +326,9 @@ export const CODE_EDITOR_WEB_SOCKET_EVENT_TYPES = [
   // useBackgroundSessionMonitor (background-session completion toasts); the
   // active session gets the same events over its own session channel.
   "code_session.status_changed",
+  // Backend-owned invalidations that replace frontend polling loops.
+  "agent_org:run_changed",
+  "agent:snapshot_created",
 ] as const;
 
 // `.passthrough()` because session broadcasts carry their payload as

--- a/src/api/tauri/agent/orgTasks.ts
+++ b/src/api/tauri/agent/orgTasks.ts
@@ -98,10 +98,6 @@ export interface AgentOrgRunView {
   inbox: AgentOrgInboxRow[];
 }
 
-export interface AgentOrgSessionInterventionState {
-  intervention?: AgentOrgMemberIntervention | null;
-}
-
 export interface AgentOrgDirectMemberMessageResponse {
   memberSessionId: string;
   response: {
@@ -115,6 +111,28 @@ export interface AgentOrgGroupChatMessageResponse {
   targetMemberId: string;
   targetMemberName: string;
   inboxRow: AgentOrgInboxRow;
+}
+
+type AgentOrgStateChangeSubscriber = (sessionId: string) => void;
+
+const agentOrgStateChangeSubscribers = new Set<AgentOrgStateChangeSubscriber>();
+
+function publishAgentOrgStateChange(sessionId: string): void {
+  for (const subscriber of agentOrgStateChangeSubscribers) {
+    subscriber(sessionId);
+  }
+}
+
+/**
+ * Invalidates cached Agent Org projections after a local mutation. Backend
+ * pushes cover background activity; the store keeps a slow recovery read for
+ * missed events.
+ */
+export function subscribeAgentOrgStateChanges(
+  subscriber: AgentOrgStateChangeSubscriber
+): () => void {
+  agentOrgStateChangeSubscribers.add(subscriber);
+  return () => agentOrgStateChangeSubscribers.delete(subscriber);
 }
 
 export interface AgentOrgTask {
@@ -162,26 +180,27 @@ export async function getAgentOrgSessionRunView(
 export async function enterAgentOrgSessionIntervention(
   sessionId: string
 ): Promise<boolean> {
-  return invokeTauri<boolean>("agent_org_session_enter_intervention", {
-    sessionId,
-  });
-}
-
-export async function getAgentOrgSessionInterventionState(
-  sessionId: string
-): Promise<AgentOrgSessionInterventionState> {
-  return invokeTauri<AgentOrgSessionInterventionState>(
-    "agent_org_session_intervention_state",
-    { sessionId }
+  const changed = await invokeTauri<boolean>(
+    "agent_org_session_enter_intervention",
+    {
+      sessionId,
+    }
   );
+  if (changed) publishAgentOrgStateChange(sessionId);
+  return changed;
 }
 
 export async function returnAgentOrgSessionToWork(
   sessionId: string
 ): Promise<boolean> {
-  return invokeTauri<boolean>("agent_org_session_return_to_work", {
-    sessionId,
-  });
+  const changed = await invokeTauri<boolean>(
+    "agent_org_session_return_to_work",
+    {
+      sessionId,
+    }
+  );
+  if (changed) publishAgentOrgStateChange(sessionId);
+  return changed;
 }
 
 export async function sendAgentOrgGroupChatMessage(
@@ -189,7 +208,7 @@ export async function sendAgentOrgGroupChatMessage(
   targetMemberId: string | null,
   content: string
 ): Promise<AgentOrgGroupChatMessageResponse> {
-  return invokeTauri<AgentOrgGroupChatMessageResponse>(
+  const response = await invokeTauri<AgentOrgGroupChatMessageResponse>(
     "agent_org_send_group_chat_message",
     {
       sessionId,
@@ -197,6 +216,8 @@ export async function sendAgentOrgGroupChatMessage(
       content,
     }
   );
+  publishAgentOrgStateChange(sessionId);
+  return response;
 }
 
 export async function sendAgentOrgUserMessageToMember(
@@ -204,7 +225,7 @@ export async function sendAgentOrgUserMessageToMember(
   memberId: string,
   content: string
 ): Promise<AgentOrgDirectMemberMessageResponse> {
-  return invokeTauri<AgentOrgDirectMemberMessageResponse>(
+  const response = await invokeTauri<AgentOrgDirectMemberMessageResponse>(
     "agent_org_send_user_message_to_member",
     {
       sessionId,
@@ -212,12 +233,22 @@ export async function sendAgentOrgUserMessageToMember(
       content,
     }
   );
+  publishAgentOrgStateChange(sessionId);
+  return response;
 }
 
 export async function pauseAgentOrgRun(sessionId: string): Promise<boolean> {
-  return invokeTauri<boolean>("agent_org_pause_run", { sessionId });
+  const changed = await invokeTauri<boolean>("agent_org_pause_run", {
+    sessionId,
+  });
+  if (changed) publishAgentOrgStateChange(sessionId);
+  return changed;
 }
 
 export async function resumeAgentOrgRun(sessionId: string): Promise<boolean> {
-  return invokeTauri<boolean>("agent_org_resume_run", { sessionId });
+  const changed = await invokeTauri<boolean>("agent_org_resume_run", {
+    sessionId,
+  });
+  if (changed) publishAgentOrgStateChange(sessionId);
+  return changed;
 }

--- a/src/engines/ChatPanel/ChatView.tsx
+++ b/src/engines/ChatPanel/ChatView.tsx
@@ -799,7 +799,11 @@ const ChatView: React.FC<ChatViewProps> = memo(
       error: agentOrgInterventionError,
       returning: agentOrgInterventionReturning,
       returnToWork: returnAgentOrgMemberToWork,
-    } = useAgentOrgIntervention(agentOrgInteractionSessionId);
+    } = useAgentOrgIntervention(
+      agentOrgInteractionSessionId,
+      agentOrgRunView,
+      refreshAgentOrgRunView
+    );
     const isViewingAgentOrgMemberPlan =
       currentAgentOrgMember !== null && !currentAgentOrgMember.isCoordinator;
     const shouldShowCurrentPlanSurface =

--- a/src/engines/ChatPanel/InputArea/components/agentOrgRunViewStore.test.ts
+++ b/src/engines/ChatPanel/InputArea/components/agentOrgRunViewStore.test.ts
@@ -1,0 +1,303 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  AGENT_ORG_RUN_VIEW_FALLBACK_MS,
+  AGENT_ORG_RUN_VIEW_PUSH_DEBOUNCE_MS,
+  getAgentOrgRunViewSnapshot,
+  subscribeAgentOrgRunView,
+} from "./agentOrgRunViewStore";
+
+const mocks = vi.hoisted(() => ({
+  getAgentOrgSessionRunView: vi.fn(),
+  subscribeAgentOrgStateChanges: vi.fn(),
+  unsubscribeStateChanges: vi.fn(),
+  websocketOn: vi.fn(),
+  unsubscribeBackendChanges: vi.fn(),
+}));
+
+vi.mock("@src/api/tauri/agent/orgTasks", () => ({
+  getAgentOrgSessionRunView: mocks.getAgentOrgSessionRunView,
+  subscribeAgentOrgStateChanges: mocks.subscribeAgentOrgStateChanges,
+}));
+
+vi.mock("@src/api/realtime/codeEditorWebSocket", () => ({
+  getCodeEditorWebSocket: () => ({ on: mocks.websocketOn }),
+}));
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function runView(
+  runStatus: "running" | "completed",
+  interventionResumeAfter?: string
+) {
+  return {
+    context: {
+      runId: "run-1",
+      orgId: "org-1",
+      orgName: "Test org",
+      orgRole: "Test",
+      coordinatorAgentId: "agent-coordinator",
+      coordinatorName: "Coordinator",
+      coordinatorRole: "Lead",
+      members: [],
+      hierarchyMode: "flat",
+      rootSessionId: "session-root",
+    },
+    runStatus,
+    currentMemberId: "coordinator",
+    members: [
+      {
+        memberId: "coordinator",
+        name: "Coordinator",
+        role: "Lead",
+        agentId: "agent-coordinator",
+        isCoordinator: true,
+        sessionRuntime: {
+          sessionId: "session-root",
+          status: "running",
+          updatedAt: "2026-07-17T00:00:00Z",
+        },
+        unreadInboxCount: 0,
+        inboxActivityCount: 0,
+        activeTaskCount: 0,
+        pendingTaskCount: 0,
+        inProgressTaskCount: 0,
+        completedTaskCount: 0,
+      },
+      {
+        memberId: "worker",
+        name: "Worker",
+        role: "Implement",
+        agentId: "agent-worker",
+        isCoordinator: false,
+        sessionRuntime: {
+          sessionId: "session-worker",
+          status: "running",
+          updatedAt: "2026-07-17T00:00:00Z",
+        },
+        intervention: interventionResumeAfter
+          ? {
+              orgRunId: "run-1",
+              memberId: "worker",
+              agentId: "agent-worker",
+              sessionId: "session-worker",
+              status: "user_intervention",
+              enteredAt: "2026-07-17T00:00:00Z",
+              lastUserActivityAt: "2026-07-17T00:00:00Z",
+              resumeAfter: interventionResumeAfter,
+            }
+          : null,
+        unreadInboxCount: 0,
+        inboxActivityCount: 0,
+        activeTaskCount: 0,
+        pendingTaskCount: 0,
+        inProgressTaskCount: 0,
+        completedTaskCount: 0,
+      },
+    ],
+    tasks: [],
+    inbox: [],
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("Agent Org run-view store", () => {
+  it("shares one fallback per run, coalesces pushes, and stops terminal runs", async () => {
+    vi.useFakeTimers();
+    let stateChangeHandler: ((sessionId: string) => void) | undefined;
+    let backendChangeHandler:
+      | ((event: { payload?: unknown }) => void)
+      | undefined;
+    let cliChangeHandler:
+      | ((event: { session_id?: unknown }) => void)
+      | undefined;
+    mocks.subscribeAgentOrgStateChanges.mockImplementation(
+      (handler: (sessionId: string) => void) => {
+        stateChangeHandler = handler;
+        return mocks.unsubscribeStateChanges;
+      }
+    );
+    mocks.websocketOn.mockImplementation(
+      (
+        event: string,
+        handler: (event: { payload?: unknown; session_id?: unknown }) => void
+      ) => {
+        if (event === "agent_org:run_changed") {
+          backendChangeHandler = handler;
+        } else if (event === "code_session.status_changed") {
+          cliChangeHandler = handler;
+        }
+        return mocks.unsubscribeBackendChanges;
+      }
+    );
+    mocks.getAgentOrgSessionRunView
+      .mockResolvedValueOnce(runView("running"))
+      .mockResolvedValueOnce(runView("completed"));
+
+    const rootSubscriber = vi.fn();
+    const secondRootSubscriber = vi.fn();
+    const workerSubscriber = vi.fn();
+    const unsubscribeRoot = subscribeAgentOrgRunView(
+      "session-root",
+      rootSubscriber
+    );
+    const unsubscribeSecondRoot = subscribeAgentOrgRunView(
+      "session-root",
+      secondRootSubscriber
+    );
+
+    expect(mocks.getAgentOrgSessionRunView).toHaveBeenCalledTimes(1);
+    await flushPromises();
+
+    const unsubscribeWorker = subscribeAgentOrgRunView(
+      "session-worker",
+      workerSubscriber
+    );
+    expect(mocks.getAgentOrgSessionRunView).toHaveBeenCalledTimes(1);
+    expect(
+      getAgentOrgRunViewSnapshot("session-worker").view?.currentMemberId
+    ).toBe("worker");
+
+    backendChangeHandler?.({ payload: { orgRunId: "run-1" } });
+    cliChangeHandler?.({ session_id: "session-worker" });
+    stateChangeHandler?.("session-worker");
+    await vi.advanceTimersByTimeAsync(AGENT_ORG_RUN_VIEW_PUSH_DEBOUNCE_MS - 1);
+    expect(mocks.getAgentOrgSessionRunView).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
+    expect(mocks.getAgentOrgSessionRunView).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(AGENT_ORG_RUN_VIEW_FALLBACK_MS * 2);
+    expect(mocks.getAgentOrgSessionRunView).toHaveBeenCalledTimes(2);
+
+    unsubscribeRoot();
+    unsubscribeSecondRoot();
+    unsubscribeWorker();
+    expect(mocks.unsubscribeStateChanges).toHaveBeenCalledTimes(1);
+    expect(mocks.unsubscribeBackendChanges).toHaveBeenCalledTimes(3);
+  });
+
+  it("stops probing a non-org session after its initial discovery", async () => {
+    vi.useFakeTimers();
+    mocks.subscribeAgentOrgStateChanges.mockReturnValue(
+      mocks.unsubscribeStateChanges
+    );
+    mocks.getAgentOrgSessionRunView.mockResolvedValue(null);
+
+    const unsubscribe = subscribeAgentOrgRunView("ordinary-session", vi.fn());
+    expect(mocks.getAgentOrgSessionRunView).toHaveBeenCalledTimes(1);
+    await flushPromises();
+
+    await vi.advanceTimersByTimeAsync(AGENT_ORG_RUN_VIEW_FALLBACK_MS * 5);
+    expect(mocks.getAgentOrgSessionRunView).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+  });
+
+  it("rejects an older discovery response that resolves after a newer one", async () => {
+    const rootRequest = deferred<ReturnType<typeof runView>>();
+    const workerRequest = deferred<ReturnType<typeof runView>>();
+    mocks.subscribeAgentOrgStateChanges.mockReturnValue(
+      mocks.unsubscribeStateChanges
+    );
+    mocks.getAgentOrgSessionRunView
+      .mockReturnValueOnce(rootRequest.promise)
+      .mockReturnValueOnce(workerRequest.promise);
+
+    const unsubscribeRoot = subscribeAgentOrgRunView("session-root", vi.fn());
+    const unsubscribeWorker = subscribeAgentOrgRunView(
+      "session-worker",
+      vi.fn()
+    );
+
+    workerRequest.resolve(runView("completed"));
+    await flushPromises();
+    rootRequest.resolve(runView("running"));
+    await flushPromises();
+
+    expect(getAgentOrgRunViewSnapshot("session-root").view?.runStatus).toBe(
+      "completed"
+    );
+    unsubscribeRoot();
+    unsubscribeWorker();
+  });
+
+  it("runs one follow-up refresh when a push arrives during an in-flight read", async () => {
+    vi.useFakeTimers();
+    let backendChangeHandler:
+      | ((event: { payload?: unknown }) => void)
+      | undefined;
+    const inFlight = deferred<ReturnType<typeof runView>>();
+    mocks.subscribeAgentOrgStateChanges.mockReturnValue(
+      mocks.unsubscribeStateChanges
+    );
+    mocks.websocketOn.mockImplementation(
+      (
+        event: string,
+        handler: (event: { payload?: unknown; session_id?: unknown }) => void
+      ) => {
+        if (event === "agent_org:run_changed") {
+          backendChangeHandler = handler;
+        }
+        return mocks.unsubscribeBackendChanges;
+      }
+    );
+    mocks.getAgentOrgSessionRunView
+      .mockResolvedValueOnce(runView("running"))
+      .mockReturnValueOnce(inFlight.promise)
+      .mockResolvedValueOnce(runView("running"));
+
+    const unsubscribe = subscribeAgentOrgRunView("session-root", vi.fn());
+    await flushPromises();
+
+    backendChangeHandler?.({ payload: { orgRunId: "run-1" } });
+    await vi.advanceTimersByTimeAsync(AGENT_ORG_RUN_VIEW_PUSH_DEBOUNCE_MS);
+    expect(mocks.getAgentOrgSessionRunView).toHaveBeenCalledTimes(2);
+
+    backendChangeHandler?.({ payload: { orgRunId: "run-1" } });
+    await vi.advanceTimersByTimeAsync(AGENT_ORG_RUN_VIEW_PUSH_DEBOUNCE_MS);
+    inFlight.resolve(runView("running"));
+    await flushPromises();
+
+    expect(mocks.getAgentOrgSessionRunView).toHaveBeenCalledTimes(3);
+    unsubscribe();
+  });
+
+  it("refreshes once when an intervention TTL expires", async () => {
+    vi.useFakeTimers();
+    const expiresAt = new Date(Date.now() + 5_000).toISOString();
+    mocks.subscribeAgentOrgStateChanges.mockReturnValue(
+      mocks.unsubscribeStateChanges
+    );
+    mocks.getAgentOrgSessionRunView
+      .mockResolvedValueOnce(runView("running", expiresAt))
+      .mockResolvedValueOnce(runView("running"));
+
+    const unsubscribe = subscribeAgentOrgRunView("session-root", vi.fn());
+    await flushPromises();
+    expect(mocks.getAgentOrgSessionRunView).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await vi.advanceTimersByTimeAsync(AGENT_ORG_RUN_VIEW_PUSH_DEBOUNCE_MS);
+    await flushPromises();
+
+    expect(mocks.getAgentOrgSessionRunView).toHaveBeenCalledTimes(2);
+    unsubscribe();
+  });
+});

--- a/src/engines/ChatPanel/InputArea/components/agentOrgRunViewStore.ts
+++ b/src/engines/ChatPanel/InputArea/components/agentOrgRunViewStore.ts
@@ -1,0 +1,400 @@
+import { getCodeEditorWebSocket } from "@src/api/realtime/codeEditorWebSocket";
+import {
+  type AgentOrgRunStatus,
+  type AgentOrgRunView,
+  getAgentOrgSessionRunView,
+  subscribeAgentOrgStateChanges,
+} from "@src/api/tauri/agent/orgTasks";
+
+export const AGENT_ORG_RUN_VIEW_FALLBACK_MS = 60_000;
+export const AGENT_ORG_RUN_VIEW_PUSH_DEBOUNCE_MS = 50;
+const MAX_NON_ORG_DISCOVERY_ATTEMPTS = 1;
+
+const TERMINAL_RUN_STATUSES: ReadonlySet<AgentOrgRunStatus> = new Set([
+  "completed",
+  "failed",
+  "cancelled",
+  "abandoned",
+]);
+
+export interface AgentOrgRunViewSnapshot {
+  view: AgentOrgRunView | null;
+  error: string | null;
+}
+
+type Subscriber = () => void;
+
+interface RunViewEntry {
+  sessionId: string;
+  snapshot: AgentOrgRunViewSnapshot;
+  serializedView: string | null;
+  subscribers: Set<Subscriber>;
+  discoveryAttempts: number;
+}
+
+const EMPTY_SNAPSHOT: AgentOrgRunViewSnapshot = {
+  view: null,
+  error: null,
+};
+
+const entriesBySessionId = new Map<string, RunViewEntry>();
+const inFlightByRunOrSession = new Map<string, Promise<void>>();
+const latestRequestIdByRun = new Map<string, number>();
+const refreshAfterInFlight = new Set<string>();
+const pushDebounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const interventionExpiryTimers = new Map<
+  string,
+  ReturnType<typeof setTimeout>
+>();
+let nextRequestId = 0;
+let activeSubscriberCount = 0;
+let pollingTimer: ReturnType<typeof setInterval> | undefined;
+let unsubscribeStateChanges: (() => void) | undefined;
+let unsubscribeBackendChanges: (() => void) | undefined;
+let unsubscribeCliSessionChanges: (() => void) | undefined;
+let unsubscribeWebsocketConnected: (() => void) | undefined;
+let visibilityListenerInstalled = false;
+
+function isDocumentVisible(): boolean {
+  return typeof document === "undefined" || !document.hidden;
+}
+
+function runViewContainsSession(
+  view: AgentOrgRunView,
+  sessionId: string
+): boolean {
+  if (view.context.rootSessionId === sessionId) return true;
+  return view.members.some(
+    (member) => member.sessionRuntime?.sessionId === sessionId
+  );
+}
+
+function viewForSession(
+  view: AgentOrgRunView,
+  sessionId: string
+): AgentOrgRunView {
+  const member = view.members.find(
+    (candidate) => candidate.sessionRuntime?.sessionId === sessionId
+  );
+  const rootCoordinator =
+    view.context.rootSessionId === sessionId
+      ? view.members.find((candidate) => candidate.isCoordinator)
+      : undefined;
+  const currentMemberId = member?.memberId ?? rootCoordinator?.memberId;
+  if (!currentMemberId || currentMemberId === view.currentMemberId) return view;
+  return { ...view, currentMemberId };
+}
+
+function isTerminal(view: AgentOrgRunView | null): boolean {
+  return view !== null && TERMINAL_RUN_STATUSES.has(view.runStatus);
+}
+
+function findEntryCoveringSession(sessionId: string): RunViewEntry | undefined {
+  for (const entry of entriesBySessionId.values()) {
+    if (
+      entry.snapshot.view &&
+      runViewContainsSession(entry.snapshot.view, sessionId)
+    ) {
+      return entry;
+    }
+  }
+  return undefined;
+}
+
+function getOrCreateEntry(sessionId: string): RunViewEntry {
+  const existing = entriesBySessionId.get(sessionId);
+  if (existing) return existing;
+
+  const coveringEntry = findEntryCoveringSession(sessionId);
+  const seededView = coveringEntry?.snapshot.view
+    ? viewForSession(coveringEntry.snapshot.view, sessionId)
+    : null;
+  const entry: RunViewEntry = {
+    sessionId,
+    snapshot: seededView
+      ? { view: seededView, error: coveringEntry?.snapshot.error ?? null }
+      : EMPTY_SNAPSHOT,
+    serializedView: seededView ? JSON.stringify(seededView) : null,
+    subscribers: new Set(),
+    discoveryAttempts: seededView ? MAX_NON_ORG_DISCOVERY_ATTEMPTS : 0,
+  };
+  entriesBySessionId.set(sessionId, entry);
+  return entry;
+}
+
+function publishEntry(
+  entry: RunViewEntry,
+  view: AgentOrgRunView | null,
+  error: string | null
+): void {
+  const serializedView = view ? JSON.stringify(view) : null;
+  if (
+    entry.serializedView === serializedView &&
+    entry.snapshot.error === error
+  ) {
+    return;
+  }
+  entry.snapshot = { view, error };
+  entry.serializedView = serializedView;
+  for (const subscriber of entry.subscribers) subscriber();
+}
+
+function publishRunView(view: AgentOrgRunView): void {
+  scheduleInterventionExpiryRefresh(view);
+  for (const entry of entriesBySessionId.values()) {
+    if (!runViewContainsSession(view, entry.sessionId)) continue;
+    entry.discoveryAttempts = MAX_NON_ORG_DISCOVERY_ATTEMPTS;
+    publishEntry(entry, viewForSession(view, entry.sessionId), null);
+  }
+}
+
+function scheduleInterventionExpiryRefresh(view: AgentOrgRunView): void {
+  const runId = view.context.runId;
+  const existing = interventionExpiryTimers.get(runId);
+  if (existing) clearTimeout(existing);
+  interventionExpiryTimers.delete(runId);
+
+  const now = Date.now();
+  const nextExpiry = view.members.reduce<number | null>((soonest, member) => {
+    const intervention =
+      member.intervention ?? member.sessionRuntime?.intervention ?? null;
+    if (!intervention) return soonest;
+    const expiresAt = Date.parse(intervention.resumeAfter);
+    if (!Number.isFinite(expiresAt) || expiresAt <= now) return soonest;
+    return soonest === null ? expiresAt : Math.min(soonest, expiresAt);
+  }, null);
+  if (nextExpiry === null) return;
+
+  const timer = setTimeout(() => {
+    interventionExpiryTimers.delete(runId);
+    scheduleRunRefresh(runId);
+  }, nextExpiry - now);
+  interventionExpiryTimers.set(runId, timer);
+}
+
+function requestKey(entry: RunViewEntry): string {
+  const runId = entry.snapshot.view?.context.runId;
+  return runId ? `run:${runId}` : `session:${entry.sessionId}`;
+}
+
+function refreshAgentOrgRunViewInternal(
+  sessionId: string,
+  queueIfBusy: boolean
+): Promise<void> {
+  const matchingEntry =
+    entriesBySessionId.get(sessionId) ?? findEntryCoveringSession(sessionId);
+  const entry = matchingEntry ?? getOrCreateEntry(sessionId);
+  const key = requestKey(entry);
+  const existing = inFlightByRunOrSession.get(key);
+  if (existing) {
+    if (queueIfBusy) refreshAfterInFlight.add(key);
+    return existing;
+  }
+
+  const requestId = ++nextRequestId;
+  const knownRunId = entry.snapshot.view?.context.runId;
+  if (knownRunId) latestRequestIdByRun.set(knownRunId, requestId);
+
+  const request = getAgentOrgSessionRunView(entry.sessionId)
+    .then((view) => {
+      if (view) {
+        const runId = view.context.runId;
+        const latestRequestId = latestRequestIdByRun.get(runId) ?? 0;
+        if (requestId < latestRequestId) return;
+        latestRequestIdByRun.set(runId, requestId);
+        publishRunView(view);
+        return;
+      }
+      entry.discoveryAttempts += 1;
+      publishEntry(entry, null, null);
+    })
+    .catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      publishEntry(entry, entry.snapshot.view, message);
+    })
+    .finally(() => {
+      if (inFlightByRunOrSession.get(key) === request) {
+        inFlightByRunOrSession.delete(key);
+      }
+      const runId = entry.snapshot.view?.context.runId;
+      const runKey = runId ? `run:${runId}` : undefined;
+      if (runKey && inFlightByRunOrSession.get(runKey) === request) {
+        inFlightByRunOrSession.delete(runKey);
+      }
+      const shouldRefreshAgain =
+        refreshAfterInFlight.delete(key) ||
+        (runKey ? refreshAfterInFlight.delete(runKey) : false);
+      if (shouldRefreshAgain && entry.subscribers.size > 0) {
+        void refreshAgentOrgRunViewInternal(entry.sessionId, false);
+      }
+    });
+  inFlightByRunOrSession.set(key, request);
+  return request;
+}
+
+export function refreshAgentOrgRunView(sessionId: string): Promise<void> {
+  return refreshAgentOrgRunViewInternal(sessionId, true);
+}
+
+function scheduleRunRefresh(runId: string): void {
+  if (pushDebounceTimers.has(runId)) return;
+  const timer = setTimeout(() => {
+    pushDebounceTimers.delete(runId);
+    const entry = Array.from(entriesBySessionId.values()).find(
+      (candidate) =>
+        candidate.subscribers.size > 0 &&
+        candidate.snapshot.view?.context.runId === runId
+    );
+    if (entry) void refreshAgentOrgRunViewInternal(entry.sessionId, true);
+  }, AGENT_ORG_RUN_VIEW_PUSH_DEBOUNCE_MS);
+  pushDebounceTimers.set(runId, timer);
+}
+
+function pollActiveRuns(): void {
+  if (!isDocumentVisible()) return;
+
+  const representatives = new Map<string, string>();
+  for (const entry of entriesBySessionId.values()) {
+    if (entry.subscribers.size === 0 || isTerminal(entry.snapshot.view))
+      continue;
+    if (
+      entry.snapshot.view === null &&
+      entry.discoveryAttempts >= MAX_NON_ORG_DISCOVERY_ATTEMPTS
+    ) {
+      continue;
+    }
+    representatives.set(requestKey(entry), entry.sessionId);
+  }
+  for (const sessionId of representatives.values()) {
+    void refreshAgentOrgRunViewInternal(sessionId, false);
+  }
+}
+
+function handleVisibilityChange(): void {
+  if (isDocumentVisible()) pollActiveRuns();
+}
+
+function startScheduler(): void {
+  if (!pollingTimer) {
+    pollingTimer = setInterval(pollActiveRuns, AGENT_ORG_RUN_VIEW_FALLBACK_MS);
+  }
+  if (!unsubscribeStateChanges) {
+    unsubscribeStateChanges = subscribeAgentOrgStateChanges((sessionId) => {
+      const entry =
+        entriesBySessionId.get(sessionId) ??
+        findEntryCoveringSession(sessionId);
+      const runId = entry?.snapshot.view?.context.runId;
+      if (runId) scheduleRunRefresh(runId);
+      else if (entry)
+        void refreshAgentOrgRunViewInternal(entry.sessionId, true);
+    });
+  }
+  if (!unsubscribeBackendChanges) {
+    unsubscribeBackendChanges = getCodeEditorWebSocket()?.on(
+      "agent_org:run_changed",
+      (event) => {
+        const payload = event.payload as { orgRunId?: unknown } | undefined;
+        if (typeof payload?.orgRunId === "string") {
+          scheduleRunRefresh(payload.orgRunId);
+        }
+      }
+    );
+  }
+  if (!unsubscribeCliSessionChanges) {
+    unsubscribeCliSessionChanges = getCodeEditorWebSocket()?.on(
+      "code_session.status_changed",
+      (event) => {
+        const sessionId = (event as { session_id?: unknown }).session_id;
+        if (typeof sessionId !== "string") return;
+        const entry =
+          entriesBySessionId.get(sessionId) ??
+          findEntryCoveringSession(sessionId);
+        const runId = entry?.snapshot.view?.context.runId;
+        if (runId) scheduleRunRefresh(runId);
+      }
+    );
+  }
+  if (!unsubscribeWebsocketConnected) {
+    unsubscribeWebsocketConnected = getCodeEditorWebSocket()?.on(
+      "connected",
+      pollActiveRuns
+    );
+  }
+  if (typeof document !== "undefined" && !visibilityListenerInstalled) {
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    visibilityListenerInstalled = true;
+  }
+  const scheduledRuns = new Set<string>();
+  for (const entry of entriesBySessionId.values()) {
+    const view = entry.snapshot.view;
+    if (!view || scheduledRuns.has(view.context.runId)) continue;
+    scheduledRuns.add(view.context.runId);
+    scheduleInterventionExpiryRefresh(view);
+  }
+}
+
+function stopScheduler(): void {
+  if (pollingTimer) {
+    clearInterval(pollingTimer);
+    pollingTimer = undefined;
+  }
+  unsubscribeStateChanges?.();
+  unsubscribeStateChanges = undefined;
+  unsubscribeBackendChanges?.();
+  unsubscribeBackendChanges = undefined;
+  unsubscribeCliSessionChanges?.();
+  unsubscribeCliSessionChanges = undefined;
+  unsubscribeWebsocketConnected?.();
+  unsubscribeWebsocketConnected = undefined;
+  for (const timer of pushDebounceTimers.values()) clearTimeout(timer);
+  pushDebounceTimers.clear();
+  for (const timer of interventionExpiryTimers.values()) clearTimeout(timer);
+  interventionExpiryTimers.clear();
+  if (typeof document !== "undefined" && visibilityListenerInstalled) {
+    document.removeEventListener("visibilitychange", handleVisibilityChange);
+    visibilityListenerInstalled = false;
+  }
+}
+
+export function subscribeAgentOrgRunView(
+  sessionId: string,
+  subscriber: Subscriber
+): () => void {
+  const entry = getOrCreateEntry(sessionId);
+  const subscription = () => subscriber();
+  entry.subscribers.add(subscription);
+  activeSubscriberCount += 1;
+  if (activeSubscriberCount === 1) startScheduler();
+  if (entry.snapshot.view === null && entry.discoveryAttempts === 0) {
+    void refreshAgentOrgRunViewInternal(sessionId, false);
+  }
+
+  return () => {
+    if (!entry.subscribers.delete(subscription)) return;
+    activeSubscriberCount -= 1;
+    if (activeSubscriberCount === 0) stopScheduler();
+    queueMicrotask(() => {
+      if (
+        entry.subscribers.size === 0 &&
+        entriesBySessionId.get(entry.sessionId) === entry
+      ) {
+        entriesBySessionId.delete(entry.sessionId);
+        const runId = entry.snapshot.view?.context.runId;
+        if (
+          runId &&
+          !Array.from(entriesBySessionId.values()).some(
+            (candidate) => candidate.snapshot.view?.context.runId === runId
+          )
+        ) {
+          latestRequestIdByRun.delete(runId);
+        }
+      }
+    });
+  };
+}
+
+export function getAgentOrgRunViewSnapshot(
+  sessionId: string
+): AgentOrgRunViewSnapshot {
+  return getOrCreateEntry(sessionId).snapshot;
+}

--- a/src/engines/ChatPanel/InputArea/components/useAgentOrgIntervention.test.ts
+++ b/src/engines/ChatPanel/InputArea/components/useAgentOrgIntervention.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import type { AgentOrgRunView } from "@src/api/tauri/agent";
+
+import { interventionForSession } from "./useAgentOrgIntervention";
+
+function runView(): AgentOrgRunView {
+  return {
+    context: {
+      runId: "run-1",
+      orgId: "org-1",
+      orgName: "Test org",
+      orgRole: "Test",
+      coordinatorAgentId: "agent-coordinator",
+      coordinatorName: "Coordinator",
+      coordinatorRole: "Lead",
+      members: [],
+      hierarchyMode: "flat",
+      rootSessionId: "session-root",
+    },
+    runStatus: "running",
+    currentMemberId: "coordinator",
+    members: [
+      {
+        memberId: "coordinator",
+        name: "Coordinator",
+        role: "Lead",
+        agentId: "agent-coordinator",
+        isCoordinator: true,
+        sessionRuntime: {
+          sessionId: "session-root",
+          status: "running",
+          updatedAt: "2026-07-18T00:00:00Z",
+        },
+        intervention: null,
+        unreadInboxCount: 0,
+        inboxActivityCount: 0,
+        activeTaskCount: 0,
+        pendingTaskCount: 0,
+        inProgressTaskCount: 0,
+        completedTaskCount: 0,
+      },
+      {
+        memberId: "worker",
+        name: "Worker",
+        role: "Build",
+        agentId: "agent-worker",
+        isCoordinator: false,
+        sessionRuntime: {
+          sessionId: "session-worker",
+          status: "idle",
+          updatedAt: "2026-07-18T00:00:00Z",
+        },
+        intervention: {
+          orgRunId: "run-1",
+          memberId: "worker",
+          agentId: "agent-worker",
+          sessionId: "session-worker",
+          status: "user_intervention",
+          reason: "direct message",
+          enteredAt: "2026-07-18T00:00:00Z",
+          lastUserActivityAt: "2026-07-18T00:00:00Z",
+          resumeAfter: "2026-07-18T00:03:00Z",
+        },
+        unreadInboxCount: 0,
+        inboxActivityCount: 0,
+        activeTaskCount: 0,
+        pendingTaskCount: 0,
+        inProgressTaskCount: 0,
+        completedTaskCount: 0,
+      },
+    ],
+    tasks: [],
+    inbox: [],
+  };
+}
+
+describe("Agent Org intervention projection", () => {
+  it("uses the matching run-view member instead of a second endpoint read", () => {
+    const view = runView();
+    expect(interventionForSession(view, "session-worker")).toEqual(
+      view.members[1].intervention
+    );
+    expect(interventionForSession(view, "session-root")).toBeNull();
+    expect(interventionForSession(view, "unrelated-session")).toBeNull();
+  });
+});

--- a/src/engines/ChatPanel/InputArea/components/useAgentOrgIntervention.ts
+++ b/src/engines/ChatPanel/InputArea/components/useAgentOrgIntervention.ts
@@ -1,16 +1,14 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import {
   type AgentOrgMemberIntervention,
-  getAgentOrgSessionInterventionState,
+  type AgentOrgRunView,
   returnAgentOrgSessionToWork,
 } from "@src/api/tauri/agent";
 import {
   isCliSession,
   isImportedHistorySession,
 } from "@src/util/session/sessionDispatch";
-
-const AGENT_ORG_INTERVENTION_REFRESH_MS = 2500;
 
 const EMPTY_RESULT = {
   intervention: null as AgentOrgMemberIntervention | null,
@@ -20,114 +18,92 @@ const EMPTY_RESULT = {
   returnToWork: async () => false,
 } as const;
 
-interface AgentOrgInterventionState {
+interface AgentOrgInterventionActionState {
   sessionId: string | null;
-  intervention: AgentOrgMemberIntervention | null;
   error: string | null;
   returning: boolean;
 }
 
-export function useAgentOrgIntervention(sessionId: string | null) {
-  const [state, setState] = useState<AgentOrgInterventionState>({
-    sessionId: null,
-    intervention: null,
-    error: null,
-    returning: false,
-  });
+export function interventionForSession(
+  view: AgentOrgRunView | null,
+  sessionId: string | null
+): AgentOrgMemberIntervention | null {
+  if (!view || !sessionId) return null;
+  const member = view.members.find(
+    (candidate) =>
+      candidate.sessionRuntime?.sessionId === sessionId ||
+      (view.context.rootSessionId === sessionId && candidate.isCoordinator)
+  );
+  return member?.intervention ?? member?.sessionRuntime?.intervention ?? null;
+}
 
-  const isPollingEnabled =
+/**
+ * Derives intervention state from the canonical run view. The old hook polled
+ * a second endpoint every 2.5 seconds even though this data is already part of
+ * each run-view member projection.
+ */
+export function useAgentOrgIntervention(
+  sessionId: string | null,
+  runView: AgentOrgRunView | null,
+  refreshRunView: () => Promise<void>
+) {
+  const [actionState, setActionState] =
+    useState<AgentOrgInterventionActionState>({
+      sessionId: null,
+      error: null,
+      returning: false,
+    });
+  const eligible =
     !!sessionId &&
     !isCliSession(sessionId) &&
     !isImportedHistorySession(sessionId);
-
-  const refresh = useCallback(async () => {
-    if (!isPollingEnabled || !sessionId) return;
-    const currentSessionId = sessionId;
-    try {
-      const result =
-        await getAgentOrgSessionInterventionState(currentSessionId);
-      setState((previous) => ({
-        sessionId: currentSessionId,
-        intervention: result.intervention ?? null,
-        error: null,
-        returning:
-          previous.sessionId === currentSessionId ? previous.returning : false,
-      }));
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      setState((previous) => ({
-        sessionId: currentSessionId,
-        intervention:
-          previous.sessionId === currentSessionId
-            ? previous.intervention
-            : null,
-        error: message,
-        returning:
-          previous.sessionId === currentSessionId ? previous.returning : false,
-      }));
-    }
-  }, [isPollingEnabled, sessionId]);
-
-  useEffect(() => {
-    if (!isPollingEnabled || !sessionId) return;
-
-    let cancelled = false;
-    const refreshIfActive = async () => {
-      if (!cancelled) {
-        await refresh();
-      }
-    };
-
-    void refreshIfActive();
-    const intervalId = window.setInterval(
-      () => void refreshIfActive(),
-      AGENT_ORG_INTERVENTION_REFRESH_MS
-    );
-
-    return () => {
-      cancelled = true;
-      window.clearInterval(intervalId);
-    };
-  }, [sessionId, isPollingEnabled, refresh]);
+  const intervention = interventionForSession(runView, sessionId);
 
   const returnToWork = useCallback(async () => {
-    if (!isPollingEnabled || !sessionId) return false;
+    if (!eligible || !sessionId) return false;
     const currentSessionId = sessionId;
-    setState((previous) => ({
-      ...previous,
+    setActionState({
       sessionId: currentSessionId,
+      error: null,
       returning: true,
-    }));
+    });
     try {
       const changed = await returnAgentOrgSessionToWork(currentSessionId);
-      await refresh();
       return changed;
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
-      setState((previous) => ({
-        ...previous,
-        sessionId: currentSessionId,
-        error: message,
-      }));
+      setActionState((previous) =>
+        previous.sessionId === currentSessionId
+          ? { ...previous, error: message }
+          : previous
+      );
       return false;
     } finally {
-      setState((previous) => ({
-        ...previous,
-        returning: false,
-      }));
+      setActionState((previous) =>
+        previous.sessionId === currentSessionId
+          ? { ...previous, returning: false }
+          : previous
+      );
     }
-  }, [isPollingEnabled, refresh, sessionId]);
+  }, [eligible, sessionId]);
 
   return useMemo(() => {
-    if (!isPollingEnabled || !sessionId || state.sessionId !== sessionId) {
-      return EMPTY_RESULT;
-    }
+    if (!eligible || !sessionId || !runView) return EMPTY_RESULT;
+    const stateMatches = actionState.sessionId === sessionId;
     return {
-      intervention: state.intervention,
-      error: state.error,
-      returning: state.returning,
-      refresh,
+      intervention,
+      error: stateMatches ? actionState.error : null,
+      returning: stateMatches ? actionState.returning : false,
+      refresh: refreshRunView,
       returnToWork,
     };
-  }, [isPollingEnabled, refresh, returnToWork, sessionId, state]);
+  }, [
+    actionState,
+    eligible,
+    intervention,
+    refreshRunView,
+    returnToWork,
+    runView,
+    sessionId,
+  ]);
 }

--- a/src/engines/ChatPanel/InputArea/components/useAgentOrgRunView.ts
+++ b/src/engines/ChatPanel/InputArea/components/useAgentOrgRunView.ts
@@ -1,190 +1,54 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useSyncExternalStore } from "react";
 
 import {
-  type AgentOrgRunStatus,
-  type AgentOrgRunView,
-  getAgentOrgSessionRunView,
-} from "@src/api/tauri/agent";
+  getAgentOrgRunViewSnapshot,
+  refreshAgentOrgRunView,
+  subscribeAgentOrgRunView,
+} from "@src/engines/ChatPanel/InputArea/components/agentOrgRunViewStore";
 import {
   isCliSession,
   isImportedHistorySession,
 } from "@src/util/session/sessionDispatch";
 
-const AGENT_ORG_RUN_VIEW_REFRESH_MS = 2500;
-const AGENT_ORG_TERMINAL_RUN_VIEW_REFRESH_MS = 10_000;
-
-/** `paused` is intentionally excluded — it is non-terminal and polling must continue. */
-const TERMINAL_RUN_STATUSES: ReadonlySet<AgentOrgRunStatus> = new Set([
-  "completed",
-  "failed",
-  "cancelled",
-  "abandoned",
-]);
-
-function isTerminalRunStatus(status: AgentOrgRunStatus | undefined): boolean {
-  return status !== undefined && TERMINAL_RUN_STATUSES.has(status);
-}
-
 const EMPTY_RESULT = { view: null, error: null } as const;
 
-interface AgentOrgRunViewState {
-  sessionId: string | null;
-  view: AgentOrgRunView | null;
-  error: string | null;
-}
-
-interface AgentOrgRunViewSnapshot {
-  view: AgentOrgRunView;
-  error: string | null;
-}
-
-type AgentOrgRunViewSubscriber = (snapshot: AgentOrgRunViewSnapshot) => void;
-
-const runViewSubscribers = new Set<AgentOrgRunViewSubscriber>();
-
-function runViewContainsSession(
-  view: AgentOrgRunView,
-  sessionId: string | null
-): sessionId is string {
-  if (!sessionId) return false;
-  if (view.context.rootSessionId === sessionId) return true;
-  return view.members.some(
-    (member) => member.sessionRuntime?.sessionId === sessionId
-  );
-}
-
-function publishRunViewSnapshot(snapshot: AgentOrgRunViewSnapshot) {
-  for (const subscriber of runViewSubscribers) {
-    subscriber(snapshot);
-  }
-}
-
+/**
+ * Reads the shared Agent Org projection for a session.
+ *
+ * All mounted consumers participate in one visibility-aware reconciliation
+ * loop per org run. Local Agent Org mutations invalidate the projection
+ * immediately; the slow fallback poll only covers background member activity.
+ */
 export function useAgentOrgRunView(sessionId: string | null) {
-  const [state, setState] = useState<AgentOrgRunViewState>({
-    sessionId: null,
-    view: null,
-    error: null,
-  });
-
-  const isRunTerminal = isTerminalRunStatus(
-    state.sessionId === sessionId ? state.view?.runStatus : undefined
-  );
-
   const canFetchRunView =
     !!sessionId &&
     !isCliSession(sessionId) &&
     !isImportedHistorySession(sessionId);
 
-  const pollingIntervalMs = isRunTerminal
-    ? AGENT_ORG_TERMINAL_RUN_VIEW_REFRESH_MS
-    : AGENT_ORG_RUN_VIEW_REFRESH_MS;
-  const isPollingEnabled = canFetchRunView;
+  const subscribe = useCallback(
+    (subscriber: () => void) => {
+      if (!canFetchRunView || !sessionId) return () => {};
+      return subscribeAgentOrgRunView(sessionId, subscriber);
+    },
+    [canFetchRunView, sessionId]
+  );
+  const getSnapshot = useCallback(() => {
+    if (!canFetchRunView || !sessionId) return EMPTY_RESULT;
+    return getAgentOrgRunViewSnapshot(sessionId);
+  }, [canFetchRunView, sessionId]);
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
   const refresh = useCallback(async () => {
-    if (
-      !sessionId ||
-      isCliSession(sessionId) ||
-      isImportedHistorySession(sessionId)
-    )
-      return;
-
-    try {
-      const view = await getAgentOrgSessionRunView(sessionId);
-      setState({ sessionId, view, error: null });
-      if (view) {
-        publishRunViewSnapshot({ view, error: null });
-      }
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      setState((previous) => ({
-        sessionId,
-        view: previous.sessionId === sessionId ? previous.view : null,
-        error: message,
-      }));
-    }
-  }, [sessionId]);
-
-  useEffect(() => {
     if (!canFetchRunView || !sessionId) return;
-
-    const subscriber: AgentOrgRunViewSubscriber = (snapshot) => {
-      if (!runViewContainsSession(snapshot.view, sessionId)) return;
-      setState({ sessionId, ...snapshot });
-    };
-
-    runViewSubscribers.add(subscriber);
-    return () => {
-      runViewSubscribers.delete(subscriber);
-    };
+    await refreshAgentOrgRunView(sessionId);
   }, [canFetchRunView, sessionId]);
 
-  useEffect(() => {
-    if (!canFetchRunView || !sessionId) return;
-
-    let cancelled = false;
-
-    async function refreshRunView() {
-      if (cancelled) return;
-      await refresh();
-    }
-
-    void refreshRunView();
-    if (!isPollingEnabled) {
-      return () => {
-        cancelled = true;
-      };
-    }
-
-    const intervalId = window.setInterval(
-      () => void refreshRunView(),
-      pollingIntervalMs
-    );
-
-    return () => {
-      cancelled = true;
-      window.clearInterval(intervalId);
-    };
-  }, [
-    canFetchRunView,
-    sessionId,
-    isPollingEnabled,
-    pollingIntervalMs,
-    refresh,
-  ]);
-
-  return useMemo(() => {
-    if (!sessionId) {
-      return { ...EMPTY_RESULT, refresh };
-    }
-    // When the run is terminal, polling slows down. We still surface the last
-    // known view so the Overview Panel remains visible and the user can see the
-    // final status. Critically, `refresh()` remains callable — if something
-    // external (e.g. a pause API call) changes the DB status, calling refresh()
-    // updates `state.view`, which causes `isRunTerminal` to re-evaluate and may
-    // return polling to the normal cadence.
-    if (isRunTerminal && state.sessionId === sessionId && state.view) {
-      return { view: state.view, error: state.error, refresh };
-    }
-    if (!isPollingEnabled) {
-      return { ...EMPTY_RESULT, refresh };
-    }
-    // While the in-flight refresh for the freshly-switched session id is
-    // landing, surface the previous session's `view` if it covers the same
-    // org. Without this, jumping between members of the same org briefly
-    // empties the org chip's `switchableMembers` list, which collapses the
-    // chip into its non-org fallback label ("SDE's Workstation"). The org
-    // membership doesn't change between members of the same org, so the
-    // stale view is structurally correct for the chip until the new fetch
-    // returns and refines tasks / unread counts / currentMemberId.
-    if (state.sessionId !== sessionId) {
-      const previousMembersIncludeTarget = state.view?.members.some(
-        (member) => member.sessionRuntime?.sessionId === sessionId
-      );
-      if (previousMembersIncludeTarget) {
-        return { view: state.view, error: state.error, refresh };
-      }
-      return { ...EMPTY_RESULT, refresh };
-    }
-    return { view: state.view, error: state.error, refresh };
-  }, [isRunTerminal, isPollingEnabled, refresh, sessionId, state]);
+  return useMemo(
+    () => ({
+      view: snapshot.view,
+      error: snapshot.error,
+      refresh,
+    }),
+    [refresh, snapshot]
+  );
 }

--- a/src/engines/ChatPanel/hooks/useWorkspaceChat/useUserIntentSubmit.ts
+++ b/src/engines/ChatPanel/hooks/useWorkspaceChat/useUserIntentSubmit.ts
@@ -9,7 +9,6 @@
 import { useAtomValue, useSetAtom, useStore } from "jotai";
 import { useCallback, useEffect } from "react";
 
-import { enterAgentOrgSessionIntervention } from "@src/api/tauri/agent";
 import type { AgentExecMode } from "@src/config/sessionCreatorConfig";
 import {
   beginOptimisticTurn,
@@ -21,7 +20,6 @@ import {
   markTurnTerminal,
 } from "@src/engines/SessionCore/control/turnLifecycle";
 import { mintTurnIntentId } from "@src/engines/SessionCore/sync/adapters/shared/eventFactories";
-import { createLogger } from "@src/hooks/logger";
 import {
   type SessionRuntimeStatusSource,
   isSessionActiveAtom,
@@ -43,8 +41,6 @@ import {
   consumeRestoredStopSubmitSuppression,
 } from "./stopSubmitGuard";
 import { useMessageDispatch } from "./useMessageDispatch";
-
-const log = createLogger("useUserIntentSubmit");
 
 const sharedSubmitGuard = { current: false };
 const sharedSubmitPayload = { current: null as string | null };
@@ -238,9 +234,6 @@ export function useUserIntentSubmit({
         onBeforeDirectDispatch?.();
         await addUserMessage(displayContent, imageDataUrls, turnIntentId);
         userEventAppended = true;
-        void enterAgentOrgSessionIntervention(sessionId).catch((error) => {
-          log.warn("[useUserIntentSubmit] intervention failed:", error);
-        });
         const displayTextForDispatch =
           contentForAgent !== displayContent ? displayContent : undefined;
         dispatchStarted = true;

--- a/src/engines/SessionCore/hooks/session/useQueueDispatch.ts
+++ b/src/engines/SessionCore/hooks/session/useQueueDispatch.ts
@@ -25,10 +25,7 @@ import type { Atom } from "jotai";
 import { useStore } from "jotai";
 import { useCallback, useEffect, useRef } from "react";
 
-import {
-  enterAgentOrgSessionIntervention,
-  getSession,
-} from "@src/api/tauri/agent";
+import { getSession } from "@src/api/tauri/agent";
 import { Message } from "@src/components/Message";
 import type { AgentExecMode } from "@src/config/sessionCreatorConfig";
 import {
@@ -256,9 +253,6 @@ export function useQueueDispatch(): void {
             }
           );
           await eventStoreProxy.append([userEvent], sessionId);
-          void enterAgentOrgSessionIntervention(sessionId).catch((error) => {
-            log.warn("[useQueueDispatch] intervention failed:", error);
-          });
           // Pass displayContent as displayText when it differs from content
           // (i.e. skill pills were expanded) so the persisted event stores
           // the pill format and re-editing shows the pill, not the YAML.

--- a/src/engines/SessionCore/hooks/session/useSessionDiscovery.ts
+++ b/src/engines/SessionCore/hooks/session/useSessionDiscovery.ts
@@ -19,6 +19,7 @@ import type {
   AvailableApiProvider,
   KeyInfo,
 } from "@src/api/tauri/rpc/schemas/validation";
+import { loadSharedLocalKeys } from "@src/hooks/keyVault/sharedLocalKeyStore";
 import { createLogger } from "@src/hooks/logger";
 import { agentRegistryAtom } from "@src/store/session/agentRegistryAtom";
 
@@ -212,7 +213,7 @@ export function useSessionDiscovery(
       const [apiProviders, rawAgents, allKeys] = await Promise.all([
         rpc.validation.getAvailableApiProviders(),
         rpc.validation.getAvailableAgents(),
-        rpc.validation.listKeys(),
+        loadSharedLocalKeys(),
       ]);
 
       if (!mountedRef.current) return;

--- a/src/features/TeamCollaboration/engine/collabSyncEngineHelpers.ts
+++ b/src/features/TeamCollaboration/engine/collabSyncEngineHelpers.ts
@@ -13,12 +13,12 @@
  * helpers were deleted with the in-app self-hosted track (cloud-parity
  * Phase E).
  */
-import { listKeys } from "@src/api/services/keyValidation";
 import { indexOrgtrackCollaborationSession } from "@src/api/tauri/lineage";
 import { DISPATCH_CATEGORY } from "@src/api/tauri/session/dispatchTypes";
 import type { KeyInfo } from "@src/api/types/keys";
 import { eventStoreProxy } from "@src/engines/SessionCore/core/store/EventStoreProxy";
 import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+import { loadSharedLocalKeys } from "@src/hooks/keyVault/sharedLocalKeyStore";
 import { createLogger } from "@src/hooks/logger";
 import type { RemoteTeammateSessionMetadata } from "@src/store/collaboration/types";
 import { lastModelPairMapAtom } from "@src/store/session/creatorDefaultModelAtom";
@@ -628,7 +628,7 @@ export async function forkSession(
 
   let localKeys: KeyInfo[] | null = null;
   try {
-    localKeys = await listKeys();
+    localKeys = await loadSharedLocalKeys();
   } catch {
     localKeys = null;
   }

--- a/src/hooks/fileReview/useFileReview.ts
+++ b/src/hooks/fileReview/useFileReview.ts
@@ -18,6 +18,7 @@ import { invoke as invokeTauri } from "@tauri-apps/api/core";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useEffect, useRef } from "react";
 
+import { getCodeEditorWebSocket } from "@src/api/realtime/codeEditorWebSocket";
 import {
   getFileResolutions,
   getSession,
@@ -29,7 +30,6 @@ import {
 } from "@src/api/tauri/agent";
 import type { SnapshotRecord } from "@src/api/tauri/agent";
 import { beginTimelineBoundary } from "@src/engines/SessionCore/control/sessionTimelineBoundary";
-import { sortedEventsAtom } from "@src/engines/SessionCore/core/atoms/events";
 import { sessionIdAtom } from "@src/engines/SessionCore/core/atoms/metadata";
 import { createLogger } from "@src/hooks/logger";
 import { sessionRuntimeStatusAtom } from "@src/store/session/cliSessionStatusAtom";
@@ -53,8 +53,7 @@ import {
 
 const log = createLogger("useFileReview");
 
-const SNAPSHOT_REFRESH_INTERVAL_MS = 1_000;
-const SNAPSHOT_REFRESH_WINDOW_MS = 120_000;
+export const SNAPSHOT_PUSH_DEBOUNCE_MS = 100;
 
 // ============================================
 // Types
@@ -132,7 +131,6 @@ export function useFileReviewSync(
   const globalSessionId = useAtomValue(sessionIdAtom);
   const sessionId =
     sessionIdOverride === undefined ? globalSessionId : sessionIdOverride;
-  const events = useAtomValue(sortedEventsAtom);
   const runtimeStatus = useAtomValue(sessionRuntimeStatusAtom);
   const resetSignal = useAtomValue(fileReviewResetSignalAtom);
   const registerBatch = useSetAtom(registerFileChangesBatchAtom);
@@ -335,19 +333,25 @@ export function useFileReviewSync(
     };
   }, [sessionId, runtimeStatus, clearReview, registerBatch, enabled]);
 
-  // ── Phase 2: Event-triggered refresh — lightweight, no cleanup ──
-  // CLI tool chunks and file-history snapshots can arrive after React has
-  // already processed the corresponding chat event. Keep polling briefly so
-  // Undo All / Keep All appear without requiring session re-entry.
+  // ── Phase 2: Snapshot-created push — lightweight, no cleanup ──
+  // The backend emits only after the snapshot row commits. The active primary
+  // ChatView refreshes on any snapshot because a root review also aggregates
+  // snapshots created by its child sessions.
   useEffect(() => {
     if (!enabled || !hasSnapshotSupport(sessionId)) return;
 
     let cancelled = false;
+    let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+    let refreshInFlight: Promise<void> | undefined;
+    let refreshAfterInFlight = false;
     const sid = sessionId;
-    const startedAt = Date.now();
 
-    const refreshSnapshots = () => {
-      fetchSnapshots(sid)
+    function refreshSnapshots() {
+      if (refreshInFlight) {
+        refreshAfterInFlight = true;
+        return;
+      }
+      refreshInFlight = fetchSnapshots(sid)
         .then(async (records) => {
           if (cancelled || records.length === 0) return;
           const hasPreMessageSnapshot = records.some(
@@ -374,23 +378,37 @@ export function useFileReviewSync(
           if (!cancelled) {
             log.warn("[useFileReviewSync] Snapshot refresh failed:", error);
           }
+        })
+        .finally(() => {
+          refreshInFlight = undefined;
+          if (refreshAfterInFlight && !cancelled) {
+            refreshAfterInFlight = false;
+            scheduleRefresh();
+          }
         });
-    };
+    }
 
-    refreshSnapshots();
-    const intervalId = window.setInterval(() => {
-      if (Date.now() - startedAt > SNAPSHOT_REFRESH_WINDOW_MS) {
-        window.clearInterval(intervalId);
-        return;
-      }
-      refreshSnapshots();
-    }, SNAPSHOT_REFRESH_INTERVAL_MS);
+    function scheduleRefresh() {
+      if (cancelled || debounceTimer) return;
+      debounceTimer = setTimeout(() => {
+        debounceTimer = undefined;
+        refreshSnapshots();
+      }, SNAPSHOT_PUSH_DEBOUNCE_MS);
+    }
+    const websocket = getCodeEditorWebSocket();
+    const unsubscribeSnapshot = websocket?.on(
+      "agent:snapshot_created",
+      scheduleRefresh
+    );
+    const unsubscribeConnected = websocket?.on("connected", scheduleRefresh);
 
     return () => {
       cancelled = true;
-      window.clearInterval(intervalId);
+      unsubscribeSnapshot?.();
+      unsubscribeConnected?.();
+      if (debounceTimer) clearTimeout(debounceTimer);
     };
-  }, [events.length, sessionId, registerBatch, enabled]);
+  }, [sessionId, registerBatch, enabled]);
 }
 
 // ============================================

--- a/src/hooks/git/useWorkingTreeDiffTotals.test.ts
+++ b/src/hooks/git/useWorkingTreeDiffTotals.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getWorkingTreeNumstatSnapshot,
+  subscribeWorkingTreeNumstat,
+} from "./useWorkingTreeDiffTotals";
+
+const mocks = vi.hoisted(() => ({
+  getGitDiffNumstatCombined: vi.fn(),
+  on: vi.fn(),
+  unsubscribe: vi.fn(),
+}));
+
+vi.mock("@src/api/http/git/diff", () => ({
+  getGitDiffNumstatCombined: mocks.getGitDiffNumstatCombined,
+}));
+
+vi.mock("@src/api/realtime/codeEditorWebSocket", () => ({
+  getCodeEditorWebSocket: () => ({ on: mocks.on }),
+}));
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe("working-tree numstat store", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("shares one listener and request across consumers of the same repo", async () => {
+    vi.useFakeTimers();
+    let statusHandler: ((data: { repo_id?: string }) => void) | undefined;
+    mocks.on.mockImplementation(
+      (_event: string, handler: (data: { repo_id?: string }) => void) => {
+        statusHandler = handler;
+        return mocks.unsubscribe;
+      }
+    );
+    mocks.getGitDiffNumstatCombined
+      .mockResolvedValueOnce({
+        files: [
+          {
+            path: "src/example.ts",
+            status: "M",
+            insertions: 4,
+            deletions: 2,
+            binary: false,
+          },
+        ],
+        totalInsertions: 4,
+        totalDeletions: 2,
+        filesChanged: 1,
+      })
+      .mockResolvedValueOnce({
+        files: [],
+        totalInsertions: 0,
+        totalDeletions: 0,
+        filesChanged: 0,
+      });
+
+    const firstConsumer = vi.fn();
+    const secondConsumer = vi.fn();
+    const unsubscribeFirst = subscribeWorkingTreeNumstat(
+      "repo-1",
+      "/workspace/repo",
+      firstConsumer
+    );
+    const unsubscribeSecond = subscribeWorkingTreeNumstat(
+      "repo-1",
+      "/workspace/repo",
+      secondConsumer
+    );
+
+    expect(mocks.on).toHaveBeenCalledTimes(1);
+    expect(mocks.on).toHaveBeenCalledWith(
+      "repo:status_updated",
+      expect.any(Function)
+    );
+    expect(mocks.getGitDiffNumstatCombined).toHaveBeenCalledTimes(1);
+
+    await flushPromises();
+    expect(firstConsumer).toHaveBeenCalledTimes(1);
+    expect(secondConsumer).toHaveBeenCalledTimes(1);
+    expect(
+      getWorkingTreeNumstatSnapshot("repo-1", "/workspace/repo")
+    ).toMatchObject({ additions: 4, deletions: 2 });
+
+    statusHandler?.({ repo_id: "another-repo" });
+    await vi.advanceTimersByTimeAsync(300);
+    expect(mocks.getGitDiffNumstatCombined).toHaveBeenCalledTimes(1);
+
+    statusHandler?.({ repo_id: "repo-1" });
+    await vi.advanceTimersByTimeAsync(300);
+    expect(mocks.getGitDiffNumstatCombined).toHaveBeenCalledTimes(2);
+
+    unsubscribeFirst();
+    expect(mocks.unsubscribe).not.toHaveBeenCalled();
+    unsubscribeSecond();
+    expect(mocks.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs one follow-up when a refresh arrives during an in-flight request", async () => {
+    vi.useFakeTimers();
+    let statusHandler: ((data: { repo_id?: string }) => void) | undefined;
+    mocks.on.mockImplementation(
+      (_event: string, handler: (data: { repo_id?: string }) => void) => {
+        statusHandler = handler;
+        return mocks.unsubscribe;
+      }
+    );
+    const first = deferred<{
+      files: never[];
+      totalInsertions: number;
+      totalDeletions: number;
+      filesChanged: number;
+    }>();
+    mocks.getGitDiffNumstatCombined
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValueOnce({
+        files: [],
+        totalInsertions: 2,
+        totalDeletions: 1,
+        filesChanged: 1,
+      });
+
+    const unsubscribe = subscribeWorkingTreeNumstat(
+      "repo-race",
+      "/workspace/race",
+      vi.fn()
+    );
+    statusHandler?.({ repo_id: "repo-race" });
+    await vi.advanceTimersByTimeAsync(300);
+    expect(mocks.getGitDiffNumstatCombined).toHaveBeenCalledTimes(1);
+
+    first.resolve({
+      files: [],
+      totalInsertions: 0,
+      totalDeletions: 0,
+      filesChanged: 0,
+    });
+    await flushPromises();
+
+    expect(mocks.getGitDiffNumstatCombined).toHaveBeenCalledTimes(2);
+    unsubscribe();
+  });
+});

--- a/src/hooks/git/useWorkingTreeDiffTotals.ts
+++ b/src/hooks/git/useWorkingTreeDiffTotals.ts
@@ -1,100 +1,260 @@
 /**
- * useWorkingTreeDiffTotals
+ * Shared working-tree numstat store.
  *
- * Fetches the working-tree diff totals (lines added / removed across all
- * changed files — staged, unstaged, and untracked new files via
- * `include_untracked`) for a repo and keeps them fresh via the
- * `repo:status_updated` WebSocket. Used to render `+N -N` badges in the editor
- * status bar's branch pill and the tab-bar `+` menu's Review row.
- *
- * Independent of the Source Control sidebar — the sidebar's numstat lives in
- * component state that only exists while that panel is mounted, so consumers
- * fetch their own aggregate here.
- *
- * The totals are cosmetic: a failed/aborted fetch resolves to zero and never
- * surfaces an error, and fetching is skipped entirely when repoId/repoPath are
- * missing (e.g. the displayed repo isn't the selected one).
+ * Several always-mounted workstation surfaces display the same `+N -N`
+ * badge. Keeping the request and WebSocket subscription in each component
+ * turned one `repo:status_updated` event into N identical HTTP requests.
+ * This module owns one subscription and one in-flight request per repo path;
+ * React consumers read the shared snapshot through `useSyncExternalStore`.
  */
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 
 import { getGitDiffNumstatCombined } from "@src/api/http/git/diff";
-import { useRepoStatusListener } from "@src/hooks/git/useRepoStatusListener";
-import { useMounted } from "@src/hooks/lifecycle/useMounted";
-import {
-  DEBOUNCE_DELAYS,
-  useDebouncedCallback,
-} from "@src/hooks/perf/useDebouncedCallback";
+import { getCodeEditorWebSocket } from "@src/api/realtime/codeEditorWebSocket";
 
 export interface WorkingTreeDiffTotals {
   additions: number;
   deletions: number;
 }
 
-const EMPTY_TOTALS: WorkingTreeDiffTotals = { additions: 0, deletions: 0 };
-
-/** Stable key identifying which repo a stored totals value belongs to. */
-function repoKeyOf(
-  repoId: string | undefined,
-  repoPath: string | undefined
-): string {
-  return repoId && repoPath ? `${repoId} ${repoPath}` : "";
+export interface WorkingTreeNumstatSnapshot extends WorkingTreeDiffTotals {
+  /** Raw repository paths, matching the Git API response. */
+  files: ReadonlyMap<string, { additions: number; deletions: number }>;
 }
 
+const EMPTY_FILES: ReadonlyMap<
+  string,
+  { additions: number; deletions: number }
+> = new Map();
+const EMPTY_SNAPSHOT: WorkingTreeNumstatSnapshot = {
+  additions: 0,
+  deletions: 0,
+  files: EMPTY_FILES,
+};
+const REFRESH_DEBOUNCE_MS = 300;
+
+interface NumstatEntry {
+  key: string;
+  repoId: string;
+  repoPath: string;
+  snapshot: WorkingTreeNumstatSnapshot;
+  subscribers: Set<() => void>;
+  unsubscribeStatus?: () => void;
+  debounceTimer?: ReturnType<typeof setTimeout>;
+  inFlight?: Promise<void>;
+  refreshAfterInFlight: boolean;
+  refreshOnVisible: boolean;
+  visibilityHandler?: () => void;
+}
+
+const entriesByKey = new Map<string, NumstatEntry>();
+
+function repoKeyOf(repoId: string, repoPath: string): string {
+  return `${repoId}\u0000${repoPath}`;
+}
+
+function notify(entry: NumstatEntry): void {
+  for (const subscriber of entry.subscribers) subscriber();
+}
+
+function snapshotsEqual(
+  left: WorkingTreeNumstatSnapshot,
+  right: WorkingTreeNumstatSnapshot
+): boolean {
+  if (
+    left.additions !== right.additions ||
+    left.deletions !== right.deletions ||
+    left.files.size !== right.files.size
+  ) {
+    return false;
+  }
+  for (const [path, stats] of left.files) {
+    const candidate = right.files.get(path);
+    if (
+      !candidate ||
+      candidate.additions !== stats.additions ||
+      candidate.deletions !== stats.deletions
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function getOrCreateEntry(repoId: string, repoPath: string): NumstatEntry {
+  const key = repoKeyOf(repoId, repoPath);
+  const existing = entriesByKey.get(key);
+  if (existing) return existing;
+
+  const entry: NumstatEntry = {
+    key,
+    repoId,
+    repoPath,
+    snapshot: EMPTY_SNAPSHOT,
+    subscribers: new Set(),
+    refreshAfterInFlight: false,
+    refreshOnVisible: false,
+  };
+  entriesByKey.set(key, entry);
+  return entry;
+}
+
+function refreshEntry(entry: NumstatEntry): void {
+  if (entry.inFlight) {
+    entry.refreshAfterInFlight = true;
+    return;
+  }
+
+  entry.inFlight = getGitDiffNumstatCombined({
+    repo_id: entry.repoId,
+    repo_path: entry.repoPath,
+    include_untracked: true,
+  })
+    .then((result) => {
+      if (!result) return;
+      const next: WorkingTreeNumstatSnapshot = {
+        additions: result.totalInsertions ?? 0,
+        deletions: result.totalDeletions ?? 0,
+        files: new Map(
+          result.files.map((file) => [
+            file.path,
+            {
+              additions: file.insertions ?? 0,
+              deletions: file.deletions ?? 0,
+            },
+          ])
+        ),
+      };
+      if (snapshotsEqual(entry.snapshot, next)) return;
+      entry.snapshot = next;
+      notify(entry);
+    })
+    .catch(() => {
+      // Diff totals are cosmetic. Preserve the last good snapshot on failure.
+    })
+    .finally(() => {
+      entry.inFlight = undefined;
+      if (entry.refreshAfterInFlight && entry.subscribers.size > 0) {
+        entry.refreshAfterInFlight = false;
+        refreshEntry(entry);
+      }
+    });
+}
+
+function scheduleRefresh(entry: NumstatEntry): void {
+  if (entry.debounceTimer) return;
+  entry.debounceTimer = setTimeout(() => {
+    entry.debounceTimer = undefined;
+    refreshEntry(entry);
+  }, REFRESH_DEBOUNCE_MS);
+}
+
+function startEntry(entry: NumstatEntry): void {
+  if (!entry.unsubscribeStatus) {
+    const websocket = getCodeEditorWebSocket();
+    if (websocket) {
+      entry.unsubscribeStatus = websocket.on("repo:status_updated", (data) => {
+        const payload = data as { repo_id?: string };
+        if (payload.repo_id !== entry.repoId) return;
+        if (typeof document !== "undefined" && document.hidden) {
+          entry.refreshOnVisible = true;
+          return;
+        }
+        scheduleRefresh(entry);
+      });
+    }
+  }
+  if (typeof document !== "undefined" && !entry.visibilityHandler) {
+    entry.visibilityHandler = () => {
+      if (document.hidden || !entry.refreshOnVisible) return;
+      entry.refreshOnVisible = false;
+      scheduleRefresh(entry);
+    };
+    document.addEventListener("visibilitychange", entry.visibilityHandler);
+  }
+  refreshEntry(entry);
+}
+
+function stopEntry(entry: NumstatEntry): void {
+  entry.unsubscribeStatus?.();
+  entry.unsubscribeStatus = undefined;
+  if (entry.debounceTimer) {
+    clearTimeout(entry.debounceTimer);
+    entry.debounceTimer = undefined;
+  }
+  if (typeof document !== "undefined" && entry.visibilityHandler) {
+    document.removeEventListener("visibilitychange", entry.visibilityHandler);
+    entry.visibilityHandler = undefined;
+  }
+  entry.refreshOnVisible = false;
+}
+
+export function subscribeWorkingTreeNumstat(
+  repoId: string,
+  repoPath: string,
+  callback: () => void
+): () => void {
+  const entry = getOrCreateEntry(repoId, repoPath);
+  entry.subscribers.add(callback);
+  if (entry.subscribers.size === 1) startEntry(entry);
+
+  return () => {
+    entry.subscribers.delete(callback);
+    if (entry.subscribers.size !== 0) return;
+    stopEntry(entry);
+    // React Strict Mode briefly unsubscribes and re-subscribes during one
+    // commit. Defer deletion so that cycle retains the same shared entry.
+    queueMicrotask(() => {
+      if (
+        entry.subscribers.size === 0 &&
+        entriesByKey.get(entry.key) === entry
+      ) {
+        entriesByKey.delete(entry.key);
+      }
+    });
+  };
+}
+
+export function getWorkingTreeNumstatSnapshot(
+  repoId: string,
+  repoPath: string
+): WorkingTreeNumstatSnapshot {
+  return (
+    entriesByKey.get(repoKeyOf(repoId, repoPath))?.snapshot ?? EMPTY_SNAPSHOT
+  );
+}
+
+/**
+ * Returns one shared per-file numstat snapshot for a repository. Consumers
+ * with the same repo id/path use one WebSocket subscription and one request.
+ */
+export function useWorkingTreeNumstat(
+  repoId: string | undefined,
+  repoPath: string | undefined
+): WorkingTreeNumstatSnapshot {
+  const active = Boolean(repoId && repoPath);
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      if (!active || !repoId || !repoPath) return () => {};
+      return subscribeWorkingTreeNumstat(repoId, repoPath, callback);
+    },
+    [active, repoId, repoPath]
+  );
+  const getSnapshot = useCallback(() => {
+    if (!active || !repoId || !repoPath) return EMPTY_SNAPSHOT;
+    return getWorkingTreeNumstatSnapshot(repoId, repoPath);
+  }, [active, repoId, repoPath]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}
+
+/**
+ * Fetches working-tree additions/deletions once per repo and shares the
+ * result across the status bar, tab menu, start page, and focused-chat rail.
+ */
 export function useWorkingTreeDiffTotals(
   repoId: string | undefined,
   repoPath: string | undefined
 ): WorkingTreeDiffTotals {
-  // Store the fetched totals alongside the repo key they were fetched for.
-  // `totals` below is then derived during render, so switching repos shows
-  // zero immediately (no stale flash) until the new fetch stamps a match —
-  // no reset effect, ref-in-render, or setState-in-render needed.
-  const [entry, setEntry] = useState<{
-    key: string;
-    totals: WorkingTreeDiffTotals;
-  }>({ key: "", totals: EMPTY_TOTALS });
-
-  const mountedRef = useMounted();
-
-  // Synchronous function whose setState lives in the promise callback — the
-  // shape the `set-state-in-effect` rule sanctions ("setState in a callback
-  // when external state changes"), so the effect can call it directly.
-  const fetchTotals = useCallback(() => {
-    if (!repoId || !repoPath) return;
-    const key = repoKeyOf(repoId, repoPath);
-    getGitDiffNumstatCombined({
-      repo_id: repoId,
-      repo_path: repoPath,
-      include_untracked: true,
-    })
-      .then((result) => {
-        if (!mountedRef.current) return;
-        setEntry({
-          key,
-          totals: result
-            ? {
-                additions: result.totalInsertions ?? 0,
-                deletions: result.totalDeletions ?? 0,
-              }
-            : EMPTY_TOTALS,
-        });
-      })
-      .catch(() => {
-        // Cosmetic — a failed numstat should never surface an error.
-      });
-  }, [repoId, repoPath, mountedRef]);
-
-  useEffect(() => {
-    fetchTotals();
-  }, [fetchTotals]);
-
-  // Coalesce rapid working-tree change events into a single re-fetch.
-  const debouncedFetch = useDebouncedCallback(
-    () => fetchTotals(),
-    DEBOUNCE_DELAYS.API
-  );
-
-  useRepoStatusListener(repoId, debouncedFetch);
-
-  const currentKey = repoKeyOf(repoId, repoPath);
-  return entry.key === currentKey ? entry.totals : EMPTY_TOTALS;
+  return useWorkingTreeNumstat(repoId, repoPath);
 }

--- a/src/hooks/keyVault/sharedLocalKeyStore.test.ts
+++ b/src/hooks/keyVault/sharedLocalKeyStore.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listKeys: vi.fn(),
+  replaceAliases: vi.fn(),
+}));
+
+vi.mock("@src/api/services/keyValidation", () => ({
+  listKeys: mocks.listKeys,
+}));
+
+vi.mock("@src/hooks/models/modelAliasRegistry", () => ({
+  replaceModelAliasesFromKeys: mocks.replaceAliases,
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+describe("shared local key store", () => {
+  it("joins concurrent loads, caches auto-loads, and allows a forced refresh", async () => {
+    let resolveFirst: ((keys: Array<{ id: string }>) => void) | undefined;
+    const firstKeys = [{ id: "key-1" }];
+    const secondKeys = [{ id: "key-2" }];
+    mocks.listKeys
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        })
+      )
+      .mockResolvedValueOnce(secondKeys);
+
+    const store = await import("./sharedLocalKeyStore");
+    const first = store.loadSharedLocalKeys();
+    const joined = store.loadSharedLocalKeys();
+
+    expect(mocks.listKeys).toHaveBeenCalledTimes(1);
+    resolveFirst?.(firstKeys);
+    await expect(first).resolves.toEqual(firstKeys);
+    await expect(joined).resolves.toEqual(firstKeys);
+
+    await expect(store.loadSharedLocalKeys()).resolves.toEqual(firstKeys);
+    expect(mocks.listKeys).toHaveBeenCalledTimes(1);
+
+    await expect(store.loadSharedLocalKeys(true)).resolves.toEqual(secondKeys);
+    expect(mocks.listKeys).toHaveBeenCalledTimes(2);
+    expect(store.getSharedLocalKeys()).toEqual(secondKeys);
+    expect(mocks.replaceAliases).toHaveBeenLastCalledWith(secondKeys);
+  });
+});

--- a/src/hooks/keyVault/sharedLocalKeyStore.ts
+++ b/src/hooks/keyVault/sharedLocalKeyStore.ts
@@ -1,0 +1,59 @@
+import { listKeys } from "@src/api/services/keyValidation";
+import type { KeyInfo } from "@src/api/services/keyValidation";
+import { replaceModelAliasesFromKeys } from "@src/hooks/models/modelAliasRegistry";
+
+type SharedLocalKeysListener = (keys: KeyInfo[]) => void;
+
+let sharedAllKeys: KeyInfo[] = [];
+let sharedKeysLoaded = false;
+let sharedKeysLoadPromise: Promise<KeyInfo[]> | undefined;
+const listeners = new Set<SharedLocalKeysListener>();
+
+export function getSharedLocalKeys(): KeyInfo[] {
+  return sharedAllKeys;
+}
+
+export function subscribeSharedLocalKeys(
+  listener: SharedLocalKeysListener
+): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function publishSharedLocalKeys(keys: KeyInfo[]): void {
+  sharedAllKeys = keys;
+  replaceModelAliasesFromKeys(keys);
+  for (const listener of listeners) listener(keys);
+}
+
+export function updateSharedLocalKeys(
+  updater: (previous: KeyInfo[]) => KeyInfo[]
+): KeyInfo[] {
+  const next = updater(sharedAllKeys);
+  publishSharedLocalKeys(next);
+  return next;
+}
+
+/**
+ * Load the local key list once for all mounted consumers.
+ *
+ * Concurrent callers join the same request. Normal auto-loads reuse the
+ * populated cache; explicit page refreshes pass `force=true` and still share
+ * any request already in flight.
+ */
+export function loadSharedLocalKeys(force = false): Promise<KeyInfo[]> {
+  if (!force && sharedKeysLoaded) return Promise.resolve(sharedAllKeys);
+  if (sharedKeysLoadPromise) return sharedKeysLoadPromise;
+
+  const request = listKeys()
+    .then((keys) => {
+      sharedKeysLoaded = true;
+      publishSharedLocalKeys(keys);
+      return keys;
+    })
+    .finally(() => {
+      if (sharedKeysLoadPromise === request) sharedKeysLoadPromise = undefined;
+    });
+  sharedKeysLoadPromise = request;
+  return request;
+}

--- a/src/hooks/keyVault/useLocalKeys.ts
+++ b/src/hooks/keyVault/useLocalKeys.ts
@@ -13,7 +13,6 @@ import {
   deleteKey as deleteKeyRpc,
   getFullKey,
   getKey,
-  listKeys,
   refreshKeyQuota,
   saveKey as saveKeyRpc,
   updateKeyHealth,
@@ -25,7 +24,14 @@ import type {
   SaveKeyRequest,
 } from "@src/api/services/keyValidation";
 import { createLogger } from "@src/hooks/logger";
-import { replaceModelAliasesFromKeys } from "@src/hooks/models/modelAliasRegistry";
+
+import {
+  getSharedLocalKeys,
+  loadSharedLocalKeys,
+  publishSharedLocalKeys,
+  subscribeSharedLocalKeys,
+  updateSharedLocalKeys,
+} from "./sharedLocalKeyStore";
 
 const log = createLogger("useLocalKeys");
 
@@ -66,22 +72,6 @@ export interface UseLocalKeysReturn {
   validateKey: (agentType: ModelType) => Promise<boolean>;
 }
 
-let sharedAllKeys: KeyInfo[] = [];
-const sharedAllKeysListeners = new Set<(keys: KeyInfo[]) => void>();
-
-function publishAllKeys(keys: KeyInfo[]) {
-  sharedAllKeys = keys;
-  for (const listener of sharedAllKeysListeners) {
-    listener(keys);
-  }
-}
-
-function updateSharedAllKeys(updater: (prev: KeyInfo[]) => KeyInfo[]) {
-  const next = updater(sharedAllKeys);
-  publishAllKeys(next);
-  return next;
-}
-
 // ============================================
 // Hook Implementation
 // ============================================
@@ -92,7 +82,7 @@ export function useLocalKeys(
   const { autoDetect: autoDetectOnMount = true } = options;
 
   // State
-  const [allKeys, setAllKeys] = useState<KeyInfo[]>(sharedAllKeys);
+  const [allKeys, setAllKeys] = useState<KeyInfo[]>(getSharedLocalKeys);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -100,10 +90,9 @@ export function useLocalKeys(
   const pendingValidations = useRef<Set<string>>(new Set());
 
   useEffect(() => {
-    sharedAllKeysListeners.add(setAllKeys);
-    return () => {
-      sharedAllKeysListeners.delete(setAllKeys);
-    };
+    const unsubscribe = subscribeSharedLocalKeys(setAllKeys);
+    setAllKeys(getSharedLocalKeys());
+    return unsubscribe;
   }, []);
 
   // Derive keys Map from allKeys (first match per agent type - legacy support)
@@ -121,14 +110,12 @@ export function useLocalKeys(
   // Core Methods
   // ============================================
 
-  const refreshAgents = useCallback(async (_force = false) => {
+  const refreshAgents = useCallback(async (force = false) => {
     setLoading(true);
     setError(null);
 
     try {
-      const keys = await listKeys();
-      publishAllKeys(keys);
-      replaceModelAliasesFromKeys(keys);
+      await loadSharedLocalKeys(force);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       setError(message);
@@ -176,7 +163,7 @@ export function useLocalKeys(
 
         const updated = await getKey(agentType, keyId);
         if (updated) {
-          updateSharedAllKeys((prev) => {
+          updateSharedLocalKeys((prev) => {
             const idx = prev.findIndex((k) => k.id === updated.id);
             if (idx >= 0) {
               const next = [...prev];
@@ -200,11 +187,11 @@ export function useLocalKeys(
    */
   const saveKeyFn = useCallback(
     async (request: SaveKeyRequest): Promise<KeyInfo | null> => {
-      const previousKeys = sharedAllKeys;
+      const previousKeys = getSharedLocalKeys();
       let appliedOptimisticUpdate = false;
 
       if (request.id) {
-        updateSharedAllKeys((prev) => {
+        updateSharedLocalKeys((prev) => {
           const idx = prev.findIndex((key) => key.id === request.id);
           if (idx < 0) return prev;
 
@@ -230,14 +217,13 @@ export function useLocalKeys(
             enabled: request.enabled ?? next[idx].enabled,
           };
           appliedOptimisticUpdate = true;
-          replaceModelAliasesFromKeys(next);
           return next;
         });
       }
 
       try {
         const saved = await saveKeyRpc(request);
-        updateSharedAllKeys((prev) => {
+        updateSharedLocalKeys((prev) => {
           const idx = prev.findIndex((k) => k.id === saved.id);
           const next = [...prev];
           if (idx >= 0) {
@@ -245,14 +231,12 @@ export function useLocalKeys(
           } else {
             next.push(saved);
           }
-          replaceModelAliasesFromKeys(next);
           return next;
         });
         return saved;
       } catch {
         if (appliedOptimisticUpdate) {
-          publishAllKeys(previousKeys);
-          replaceModelAliasesFromKeys(previousKeys);
+          publishSharedLocalKeys(previousKeys);
         }
         return null;
       }
@@ -271,11 +255,10 @@ export function useLocalKeys(
       try {
         const deleted = await deleteKeyRpc(agentType, keyId);
         if (deleted) {
-          updateSharedAllKeys((prev) => {
+          updateSharedLocalKeys((prev) => {
             const next = keyId
               ? prev.filter((k) => k.id !== keyId)
               : prev.filter((k) => k.agent_type !== agentType);
-            replaceModelAliasesFromKeys(next);
             return next;
           });
           return true;
@@ -322,7 +305,7 @@ export function useLocalKeys(
           }
 
           const updated = (await getKey(agentType, keyId)) ?? refreshed;
-          updateSharedAllKeys((prev) => {
+          updateSharedLocalKeys((prev) => {
             const idx = prev.findIndex((key) => key.id === updated.id);
             if (idx >= 0) {
               const next = [...prev];
@@ -372,7 +355,7 @@ export function useLocalKeys(
 
         const updated = await getKey(agentType, keyId);
         if (updated) {
-          updateSharedAllKeys((prev) => {
+          updateSharedLocalKeys((prev) => {
             const idx = prev.findIndex((k) => k.id === updated.id);
             if (idx >= 0) {
               const next = [...prev];

--- a/src/hooks/models/useModelAliasRegistry.ts
+++ b/src/hooks/models/useModelAliasRegistry.ts
@@ -6,19 +6,15 @@
  */
 import { useEffect } from "react";
 
-import { listKeys } from "@src/api/services/keyValidation";
-
-import { replaceModelAliasesFromKeys } from "./modelAliasRegistry";
+import { loadSharedLocalKeys } from "@src/hooks/keyVault/sharedLocalKeyStore";
 
 export function useModelAliasRegistry(): void {
   useEffect(() => {
     let cancelled = false;
 
     async function populate() {
-      const keys = await listKeys();
+      await loadSharedLocalKeys();
       if (cancelled) return;
-
-      replaceModelAliasesFromKeys(keys);
     }
 
     void populate();

--- a/src/modules/MainApp/Integrations/Connections/Channels/GatewayAgentCard.tsx
+++ b/src/modules/MainApp/Integrations/Connections/Channels/GatewayAgentCard.tsx
@@ -20,6 +20,7 @@ import Button from "@src/components/Button";
 import Select from "@src/components/Select";
 import type { SelectOption } from "@src/components/Select/types";
 import Switch from "@src/components/Switch";
+import { loadSharedLocalKeys } from "@src/hooks/keyVault/sharedLocalKeyStore";
 import { createLogger } from "@src/hooks/logger";
 import {
   SECTION_ACTION_GAP_CLASSES,
@@ -72,7 +73,7 @@ const GatewayAgentCard: React.FC = () => {
     void (async () => {
       try {
         const [listed, binding] = await Promise.all([
-          rpc.validation.listKeys(),
+          loadSharedLocalKeys(),
           loadBinding(),
         ]);
         if (cancelled) return;

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/usePerRepoSourceControl.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/usePerRepoSourceControl.ts
@@ -21,7 +21,6 @@ import { useAtomValue } from "jotai";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { GitWorkingDirectoryFile } from "@src/api/http/git";
-import { fetchNumstatMap } from "@src/api/http/git/diff";
 import {
   type ScopedGitApi,
   createScopedGitApi,
@@ -32,6 +31,7 @@ import { normalizeGitStatus } from "@src/config/gitStatus";
 import { useFileSelection } from "@src/hooks/git/sourceControl";
 import { generateCommitMessage } from "@src/hooks/git/sourceControl/commitMessageGeneration";
 import { useRepoStatusListener } from "@src/hooks/git/useRepoStatusListener";
+import { useWorkingTreeNumstat } from "@src/hooks/git/useWorkingTreeDiffTotals";
 import { useMounted } from "@src/hooks/lifecycle/useMounted";
 import { createLogger } from "@src/hooks/logger";
 import {
@@ -107,13 +107,17 @@ export function usePerRepoSourceControl(
   const [commitMessage, setCommitMessage] = useState("");
   const [commitLoading, setCommitLoading] = useState(false);
   const [generateLoading, setGenerateLoading] = useState(false);
-  const [numstatMap, setNumstatMap] = useState<
-    Map<string, { additions: number; deletions: number }>
-  >(new Map());
-
   const mountedRef = useMounted();
   const filesRef = useRef<GitFile[]>([]);
   const onGitFileSelectRef = useRef(onGitFileSelect);
+  const rawNumstat = useWorkingTreeNumstat(repoId, repoPath);
+  const numstatMap = useMemo(() => {
+    const decoded = new Map<string, { additions: number; deletions: number }>();
+    for (const [path, stats] of rawNumstat.files) {
+      decoded.set(decodeOctalPath(path), stats);
+    }
+    return decoded;
+  }, [rawNumstat.files]);
 
   // Scoped git API — binds repo_id/repo_path once
   const gitRef = useRef<ScopedGitApi>(createScopedGitApi(repoId, repoPath));
@@ -133,31 +137,17 @@ export function usePerRepoSourceControl(
     setInitialLoading(true);
     setError(null);
     setSelectedFileId("");
-    setNumstatMap(new Map());
   }, [repoPath]);
 
-  // Load per-file numstat (non-blocking, runs after status)
-  const fetchNumstat = useCallback(async () => {
-    const raw = await fetchNumstatMap(repoId, repoPath);
-    if (!mountedRef.current) return;
-    // fetchNumstatMap paths are raw (not octal-decoded); decode here so they
-    // match the already-decoded paths in `gitStatus`.
-    const decoded = new Map<string, { additions: number; deletions: number }>();
-    for (const [path, stats] of raw) {
-      decoded.set(decodeOctalPath(path), stats);
-    }
-    setNumstatMap(decoded);
-  }, [repoId, repoPath, mountedRef]);
-
-  // Core fetch — only sets initialLoading on first call.
-  // fetchNumstat only needs repoId/repoPath (not the status response), so
-  // both requests are fired in parallel via Promise.all.
+  // Core fetch — only sets initialLoading on first call. Per-file numstat is
+  // supplied by the shared working-tree store so every visible Git surface
+  // reuses one request rather than each issuing its own companion fetch.
   const fetchStatus = useCallback(async () => {
     try {
-      const [status] = await Promise.all([
-        getGitStatus({ repo_id: repoId, repo_path: repoPath }),
-        fetchNumstat(),
-      ]);
+      const status = await getGitStatus({
+        repo_id: repoId,
+        repo_path: repoPath,
+      });
       if (!mountedRef.current) return;
       if (status) {
         const decoded: GitStatusData = {
@@ -185,7 +175,7 @@ export function usePerRepoSourceControl(
         setInitialLoading(false);
       }
     }
-  }, [repoId, repoPath, fetchNumstat, mountedRef]);
+  }, [repoId, repoPath, mountedRef]);
 
   // Debounced fetch for WebSocket events — replaces hand-rolled timer
   const debouncedFetch = useDebouncedCallback(

--- a/src/store/session/creatorDefaultModelAtom.ts
+++ b/src/store/session/creatorDefaultModelAtom.ts
@@ -49,6 +49,7 @@ import type {
   AdvancedConfig,
   KeySource,
 } from "@src/features/SessionCreator/types";
+import { loadSharedLocalKeys } from "@src/hooks/keyVault/sharedLocalKeyStore";
 import { createLogger } from "@src/hooks/logger";
 import {
   rawSettingsAtom,
@@ -196,7 +197,7 @@ async function pruneStaleEntries(map: LastModelPairMap): Promise<{
   changed: boolean;
 }> {
   try {
-    const keys = await rpc.validation.listKeys();
+    const keys = await loadSharedLocalKeys();
     const validIds = new Set(keys.map((key) => key.id));
 
     let changed = false;

--- a/src/util/monitoring/__tests__/hotspotRates.test.ts
+++ b/src/util/monitoring/__tests__/hotspotRates.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { ratePerMinuteInWindow, spansRepeatedActivity } from "../hotspotRates";
+import {
+  effectiveObservationWindowMs,
+  ratePerMinuteInWindow,
+  spansRepeatedActivity,
+} from "../hotspotRates";
 
 describe("hotspot rate helpers", () => {
   it("normalizes a batch against the displayed two-minute window", () => {
@@ -11,5 +15,14 @@ describe("hotspot rate helpers", () => {
   it("does not classify a near-simultaneous provider fan-out as polling", () => {
     expect(spansRepeatedActivity(10_000, 10_002)).toBe(false);
     expect(spansRepeatedActivity(10_000, 11_000)).toBe(true);
+  });
+
+  it("normalizes warm-up rates by elapsed observation time with a floor", () => {
+    expect(effectiveObservationWindowMs(120_000, 10_000, 10_100)).toBe(1_000);
+    expect(effectiveObservationWindowMs(120_000, 10_000, 40_000)).toBe(30_000);
+    expect(effectiveObservationWindowMs(120_000, 10_000, 200_000)).toBe(
+      120_000
+    );
+    expect(effectiveObservationWindowMs(120_000, null, 20_000)).toBe(120_000);
   });
 });

--- a/src/util/monitoring/apiTracker.ts
+++ b/src/util/monitoring/apiTracker.ts
@@ -8,7 +8,11 @@ import {
   getTauriStack,
   getTimerStack,
 } from "./apiTrackerUtils";
-import { ratePerMinuteInWindow, spansRepeatedActivity } from "./hotspotRates";
+import {
+  effectiveObservationWindowMs,
+  ratePerMinuteInWindow,
+  spansRepeatedActivity,
+} from "./hotspotRates";
 
 // Extended axios config with tracking properties
 interface TrackedAxiosConfig extends InternalAxiosRequestConfig {
@@ -63,6 +67,7 @@ export interface ApiCall {
 
 let apiCalls: ApiCall[] = [];
 let trackingEnabled = false;
+let trackingObservationStartedAtMs: number | null = null;
 let tracingModeEnabled = false;
 const requestStartTimes = new Map<string, number>();
 const MAX_API_CALLS = 300;
@@ -662,6 +667,11 @@ export function recordPushEvent(kind: PushKind, name: string): void {
 
 export function getPushHotspots(windowMs = 120_000): PushHotspot[] {
   const now = Date.now();
+  const observationWindowMs = effectiveObservationWindowMs(
+    windowMs,
+    trackingObservationStartedAtMs,
+    now
+  );
   const recent = pushEvents.filter(
     (event) => now - event.timestampMs <= windowMs
   );
@@ -679,7 +689,10 @@ export function getPushHotspots(windowMs = 120_000): PushHotspot[] {
       const timestamps = events.map((event) => event.timestampMs);
       const firstMs = Math.min(...timestamps);
       const lastMs = Math.max(...timestamps);
-      const eventsPerMinute = ratePerMinuteInWindow(events.length, windowMs);
+      const eventsPerMinute = ratePerMinuteInWindow(
+        events.length,
+        observationWindowMs
+      );
       return {
         key,
         kind: events[0].kind,
@@ -779,6 +792,7 @@ let cleanupTimerTracking: (() => void) | undefined;
 let cleanupFetchTracking: (() => void) | undefined;
 
 export const enableApiTracking = () => {
+  if (!trackingEnabled) trackingObservationStartedAtMs = Date.now();
   trackingEnabled = true;
   cleanupInterceptors = initializeApiTracking();
   cleanupDirectTauriInvokeTracking = installDirectTauriInvokeTracking();
@@ -848,6 +862,11 @@ export const getApiCalls = (): ApiCall[] => {
 
 export function getApiCallHotspots(windowMs = 120_000): ApiCallHotspot[] {
   const now = Date.now();
+  const observationWindowMs = effectiveObservationWindowMs(
+    windowMs,
+    trackingObservationStartedAtMs,
+    now
+  );
   const recentCalls = apiCalls.filter((call) => {
     const timestamp = new Date(call.timestamp).getTime();
     return Number.isFinite(timestamp) && now - timestamp <= windowMs;
@@ -881,7 +900,10 @@ export function getApiCallHotspots(windowMs = 120_000): ApiCallHotspot[] {
         ? completedDurations.reduce((sum, duration) => sum + duration, 0) /
           completedDurations.length
         : undefined;
-      const callsPerMinute = ratePerMinuteInWindow(calls.length, windowMs);
+      const callsPerMinute = ratePerMinuteInWindow(
+        calls.length,
+        observationWindowMs
+      );
 
       return {
         key,
@@ -924,6 +946,11 @@ export const getTimerEvents = (): TimerFireEvent[] => [...timerEvents];
 
 export function getTimerHotspots(windowMs = 120_000): TimerHotspot[] {
   const now = Date.now();
+  const observationWindowMs = effectiveObservationWindowMs(
+    windowMs,
+    trackingObservationStartedAtMs,
+    now
+  );
   const recentEvents = timerEvents.filter((event) => {
     const timestamp = new Date(event.timestamp).getTime();
     return Number.isFinite(timestamp) && now - timestamp <= windowMs;
@@ -949,7 +976,10 @@ export function getTimerHotspots(windowMs = 120_000): TimerHotspot[] {
         new Date(event.timestamp).getTime()
       );
       const firstMs = Math.min(...timestamps);
-      const firesPerMinute = ratePerMinuteInWindow(events.length, windowMs);
+      const firesPerMinute = ratePerMinuteInWindow(
+        events.length,
+        observationWindowMs
+      );
 
       return {
         key,
@@ -986,6 +1016,7 @@ export const getApiCallsForComponent = (
 };
 
 export const clearApiCalls = () => {
+  trackingObservationStartedAtMs = Date.now();
   apiCalls = [];
   timerEvents.splice(0, timerEvents.length);
   pushEvents.splice(0, pushEvents.length);

--- a/src/util/monitoring/hotspotRates.ts
+++ b/src/util/monitoring/hotspotRates.ts
@@ -9,6 +9,23 @@ export function ratePerMinuteInWindow(
   return eventCount * (ONE_MINUTE_MS / windowMs);
 }
 
+/**
+ * Use only time that was actually observed during the panel's warm-up.
+ * A one-second floor prevents a just-opened panel from reporting meaningless
+ * hundreds-per-minute rates for a single mount-time request.
+ */
+export function effectiveObservationWindowMs(
+  configuredWindowMs: number,
+  observationStartedAtMs: number | null,
+  nowMs: number,
+  minimumWindowMs = 1_000
+): number {
+  if (configuredWindowMs <= 0) return 0;
+  if (observationStartedAtMs === null) return configuredWindowMs;
+  const observedMs = Math.max(0, nowMs - observationStartedAtMs);
+  return Math.min(configuredWindowMs, Math.max(minimumWindowMs, observedMs));
+}
+
 /** A simultaneous fan-out batch is not, by itself, a polling loop. */
 export function spansRepeatedActivity(
   firstTimestampMs: number,


### PR DESCRIPTION
## Summary

- Replaces the Agent Org run-view, intervention, snapshot, Git status, Git numstat, and local-key polling hot spots with push invalidation or shared request stores.
- Keeps bounded recovery reads for missed events, reconnects, visibility changes, and active non-terminal Agent Org runs.
- Adds stale-response and in-flight follow-up handling so coalescing requests does not trade call volume for stale UI.
- Corrects DevTools hotspot rates during the observation-window warm-up period.

## Root causes

- The Git watcher broadcast repo:status_updated after every adaptive poll, even when the status snapshot was unchanged. Every broadcast fanned out into frontend status and numstat requests.
- Multiple mounted Git and key-vault consumers independently loaded identical data.
- Agent Org run views and intervention state used separate short polling loops even though intervention data already exists in the canonical run projection.
- File-review snapshots used a one-second loop for up to two minutes after chat activity.
- Intervention entry was triggered in the submit layer, queue layer, and transport adapter for the same logical dispatch.
- Hotspot rates always used the configured two-minute window, including immediately after tracking started or was cleared.

## Implementation

### Agent Org

- Adds one backend-owned agent_org:run_changed invalidation emitted after committed run, task, inbox, intervention, and session-runtime mutations.
- Adds one shared run-view store per run/session with push debouncing, in-flight joining, stale-result rejection, hidden-tab recovery, reconnect recovery, and one queued follow-up when a mutation lands during a read.
- Retains a 60-second fallback only for active non-terminal runs; terminal runs stop and ordinary non-org sessions are probed once.
- Derives intervention state from the run view and schedules a one-shot refresh at resumeAfter instead of restoring intervention polling.
- Keeps intervention entry in the Rust/CLI transport adapters and removes duplicate submit/queue calls.

### Snapshots

- Emits agent:snapshot_created only after save_snapshot commits.
- Replaces the one-second file-review loop with a debounced push refresh.
- Coalesces snapshot events while a read is in flight and performs one follow-up when necessary.
- Retains initial load, terminal-state verification, and reconnect reconciliation.

### Git

- Compares durable GitStatus snapshots and suppresses unchanged repo:status_updated broadcasts.
- Shares one numstat request, cache, and WebSocket listener per repository across all mounted consumers.
- Queues one follow-up when a status event arrives during an in-flight numstat read and refreshes after returning to a visible tab.
- Reuses the shared per-file numstat projection in the Source Control sidebar.

### Local keys and monitoring

- Shares list_keys cache and in-flight work across discovery, model aliases, collaboration, gateway, and key-vault consumers while preserving explicit forced refresh.
- Normalizes API, timer, and push rates against actual elapsed observation time with a one-second warm-up floor.

## Expected call behavior

| Hot spot | Behavior after this change |
| --- | --- |
| agent_get_snapshots | Initial/terminal reads plus snapshot pushes; no steady one-second loop |
| agent_org_session_run_view | Push-driven shared read plus at most one 60-second recovery read per active run |
| agent_org_session_intervention_state | No production polling; intervention comes from the run projection |
| list_keys | One shared cold load, joined concurrent loads, and explicit forced refresh |
| Git status/numstat | Unchanged backend polls stay silent; mounted consumers share one numstat refresh per real change |

## Verification

- pnpm typecheck
- Focused ESLint over all changed TypeScript and TSX files
- 6 focused Vitest files: 16 tests passed
- cargo check -p agent_core --all-targets
- cargo check -p git --all-targets
- cargo test -p agent_core coordination:: — 121 tests passed
- cargo test -p git status_snapshot_tests — 3 tests passed
- Repository pre-commit hook: TypeScript passed, scoped Clippy passed for agent_core and git, ESLint 0, circular dependencies 0

## Architecture audit

- Compilation, structural deduplication, naming, semantic ownership, default/fallback behavior, cross-domain boundaries, and new-developer clarity were reviewed.
- Wire payload names and camelCase fields are covered by schema tests.
- Mutation-entry parity was checked across run, task, inbox, intervention, session, CLI-status, reconnect, and visibility paths.
- No session initialization sequence or multi-field resolver was changed; those layers were reviewed and found not applicable to the implementation.