### PR TITLE
refactor(lint): apply safe static analysis fixes

### DIFF
--- a/packages/orgtrack/src/cli.ts
+++ b/packages/orgtrack/src/cli.ts
@@ -3,7 +3,7 @@
 const command = process.argv[2];
 
 if (!command || command === "help" || command === "--help") {
-  console.log("orgtrack commands: scan, sync, repair, stats");
+  process.stdout.write("orgtrack commands: scan, sync, repair, stats\n");
   process.exit(0);
 }
 
@@ -12,6 +12,6 @@ if (!["scan", "sync", "repair", "stats"].includes(command)) {
   process.exit(1);
 }
 
-console.log(
-  `orgtrack ${command} is a thin package entrypoint. Native orgtrack-core bindings will be attached during publish prep.`
+process.stdout.write(
+  `orgtrack ${command} is a thin package entrypoint. Native orgtrack-core bindings will be attached during publish prep.\n`
 );

--- a/src-tauri/crates/agent-core/src/core/definitions/tests_extended.rs
+++ b/src-tauri/crates/agent-core/src/core/definitions/tests_extended.rs
@@ -572,7 +572,7 @@ mod tests_extended {
         let json = serde_json::to_string(&sm).expect("serialize");
         let restored: SessionModel = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(restored.max_iterations, 500);
-        assert_eq!(restored.processing_lock, true);
+        assert!(restored.processing_lock);
         assert_eq!(restored.mode, SessionMode::PerSession);
     }
 
@@ -617,7 +617,7 @@ mod tests_extended {
         };
         let json = serde_json::to_string(&original).expect("serialize");
         let restored: AgentPolicy = serde_json::from_str(&json).expect("deserialize");
-        assert_eq!(restored.workspace_only, true);
+        assert!(restored.workspace_only);
         assert_eq!(
             restored.blocked_commands,
             vec!["rm".to_string(), "sudo".to_string()]

--- a/src-tauri/crates/agent-core/src/core/interaction/question.rs
+++ b/src-tauri/crates/agent-core/src/core/interaction/question.rs
@@ -179,6 +179,7 @@ impl QuestionManager {
     /// presence change so a mid-wait mode switch takes effect immediately:
     ///   * switch to a mode with auto-resolve Off → keeps waiting forever,
     ///   * switch to a shorter window that already elapsed → resolves now.
+    ///
     /// Exits silently when the pending entry disappears (user answered,
     /// cancel, reject) — `take_pending` makes resolution idempotent.
     fn spawn_auto_resolve_watcher(&self, request_id: String, created_at_ms: i64) {

--- a/src-tauri/crates/agent-core/src/core/model_context/session_memory/sections.rs
+++ b/src-tauri/crates/agent-core/src/core/model_context/session_memory/sections.rs
@@ -68,7 +68,7 @@ pub fn generate_section_reminders(
         .filter(|sec| sec.tokens > max_section_tokens)
         .map(|sec| (sec.header.as_str(), sec.tokens))
         .collect();
-    oversized.sort_by(|a, b| b.1.cmp(&a.1));
+    oversized.sort_by_key(|entry| std::cmp::Reverse(entry.1));
 
     if oversized.is_empty() && !over_budget {
         return String::new();

--- a/src-tauri/crates/agent-core/src/core/providers/codex_native/streaming.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/codex_native/streaming.rs
@@ -302,13 +302,11 @@ impl LLMProvider for CodexNativeClient {
                                 let has_partial_data = !accumulated_text.is_empty()
                                     || stream_normalizer.has_pending_tool_calls()
                                     || !tool_calls.is_empty();
-                                if error.is_auth_error() {
-                                    if !auth_retry_used && !has_partial_data {
-                                        warn!("[codex-native] Access token rejected inside stream before output; refreshing and retrying once");
-                                        self.refresh_auth_after_unauthorized().await?;
-                                        auth_retry_used = true;
-                                        continue 'request_attempt;
-                                    }
+                                if error.is_auth_error() && !auth_retry_used && !has_partial_data {
+                                    warn!("[codex-native] Access token rejected inside stream before output; refreshing and retrying once");
+                                    self.refresh_auth_after_unauthorized().await?;
+                                    auth_retry_used = true;
+                                    continue 'request_attempt;
                                 }
                                 return Err(error.into_provider_error());
                             }

--- a/src-tauri/crates/agent-core/src/core/providers/responses_common/converter.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/responses_common/converter.rs
@@ -147,12 +147,8 @@ fn normalize_input_message(msg: &Value) -> Value {
     };
 
     let mut normalized = msg.clone();
-    normalized["content"] = Value::Array(
-        content
-            .iter()
-            .map(|part| normalize_input_content_part(part))
-            .collect(),
-    );
+    normalized["content"] =
+        Value::Array(content.iter().map(normalize_input_content_part).collect());
     normalized
 }
 

--- a/src-tauri/crates/agent-core/src/core/providers/responses_common/streaming_events.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/responses_common/streaming_events.rs
@@ -43,6 +43,12 @@ struct PendingToolCall {
     arguments_json: String,
 }
 
+impl Default for ResponsesStreamNormalizer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl ResponsesStreamNormalizer {
     pub fn new() -> Self {
         Self {

--- a/src-tauri/crates/agent-core/src/core/session/launch/launch_helpers.rs
+++ b/src-tauri/crates/agent-core/src/core/session/launch/launch_helpers.rs
@@ -186,7 +186,7 @@ pub(super) fn member_runtime_key_source(
 ) -> Result<KeySource, String> {
     match config.and_then(|cfg| clean_runtime_value(cfg.key_source.as_ref())) {
         Some(raw) => KeySource::parse(&raw).ok_or_else(|| format!("Unknown key_source: {raw:?}")),
-        None => Ok(fallback.clone()),
+        None => Ok(*fallback),
     }
 }
 

--- a/src-tauri/crates/agent-core/src/core/session/launch/launch_org.rs
+++ b/src-tauri/crates/agent-core/src/core/session/launch/launch_org.rs
@@ -128,7 +128,7 @@ pub(super) async fn materialize_org_member_sessions(
         let rust_org_name = org_name.clone();
         let rust_model = model.clone();
         let rust_account_id = account_id.clone();
-        let rust_key_source = key_source.clone();
+        let rust_key_source = key_source;
         let rust_agent_exec_mode = agent_exec_mode.clone();
         let rust_native_harness_type = native_harness_type.clone();
         let rust_work_item_id = work_item_id.clone();

--- a/src-tauri/crates/agent-core/src/core/session/launch/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/session/launch/mod.rs
@@ -617,7 +617,7 @@ pub(crate) async fn launch_rust_agent_run(
                 std::path::PathBuf::from(&workspace_path_for_send),
                 account_id_for_send.clone(),
                 model_for_send.clone(),
-                native_harness_type_for_send.clone(),
+                native_harness_type_for_send,
                 content_for_send.clone(),
             );
             let send_result = send_initial_turn(
@@ -734,7 +734,7 @@ pub(crate) async fn launch_rust_agent_run(
                 std::path::PathBuf::from(&workspace_path_for_send),
                 account_id_for_send.clone(),
                 model_for_send.clone(),
-                native_harness_type_for_send.clone(),
+                native_harness_type_for_send,
                 content_for_send.clone(),
             );
 

--- a/src-tauri/crates/agent-core/src/core/session/types/context.rs
+++ b/src-tauri/crates/agent-core/src/core/session/types/context.rs
@@ -50,9 +50,11 @@ pub struct ProcessingContext {
 /// classes. New custom modes pick a stance; new stances require code.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum PresenceStance {
     /// User at the keyboard — ask freely, confirm destructive actions,
     /// blocking interactions wait indefinitely.
+    #[default]
     Interactive,
     /// User stepped away — work first, batch questions, hold
     /// irreversible actions until they're back.
@@ -60,12 +62,6 @@ pub enum PresenceStance {
     /// Goal mode — never ask, auto-resolve blockers, keep working until
     /// the goal is met.
     Autonomous,
-}
-
-impl Default for PresenceStance {
-    fn default() -> Self {
-        PresenceStance::Interactive
-    }
 }
 
 impl PresenceStance {

--- a/src-tauri/crates/agent-core/src/core/tools/impls/coding/exec/subprocess.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/coding/exec/subprocess.rs
@@ -247,7 +247,7 @@ fn finish_cancelled_process(
     session_key: Option<&str>,
     log_writer: Option<&Arc<StdMutex<TerminalLogWriter>>>,
 ) -> Result<String, ToolError> {
-    if let Some(ref log) = log_writer {
+    if let Some(log) = log_writer {
         if let Ok(mut writer) = log.lock() {
             let _ = writer.finalize(LogProcessStatus::Killed, None);
         }

--- a/src-tauri/crates/agent-core/src/core/turn_executor/tool_execution/parallel.rs
+++ b/src-tauri/crates/agent-core/src/core/turn_executor/tool_execution/parallel.rs
@@ -244,7 +244,7 @@ pub(super) async fn execute_parallel_group(
     let mut results_by_index: std::collections::BTreeMap<usize, ExecResult> =
         std::collections::BTreeMap::new();
     for ((idx, raw_result, duration_ms), (_, effective_args, display_name)) in
-        exec_outputs.into_iter().zip(futures_to_run.into_iter())
+        exec_outputs.into_iter().zip(futures_to_run)
     {
         results_by_index.insert(
             idx,

--- a/src-tauri/crates/agent-core/src/foundation/flow_awareness/store.rs
+++ b/src-tauri/crates/agent-core/src/foundation/flow_awareness/store.rs
@@ -213,7 +213,7 @@ impl FlowStore {
 
         // Filter by age, sort by timestamp (newest first), take max_count
         all_activities.retain(|a| a.timestamp >= cutoff);
-        all_activities.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        all_activities.sort_by_key(|activity| std::cmp::Reverse(activity.timestamp));
         all_activities.truncate(max_count);
 
         all_activities

--- a/src-tauri/crates/agent-core/src/foundation/tool_infra/project/work_items.rs
+++ b/src-tauri/crates/agent-core/src/foundation/tool_infra/project/work_items.rs
@@ -363,8 +363,7 @@ pub async fn create_work_item(
 
         io::write_work_item(&slug, &short_id, &frontmatter, &body)?;
 
-        let schedule_info = if frontmatter.schedule.is_some() {
-            let sched = frontmatter.schedule.as_ref().unwrap();
+        let schedule_info = if let Some(sched) = frontmatter.schedule.as_ref() {
             if let Some(ref at) = sched.at {
                 format!(" (scheduled at {})", at)
             } else if let Some(ref cron_expr) = sched.cron {

--- a/src-tauri/crates/agent-core/src/integrations/channels/discord.rs
+++ b/src-tauri/crates/agent-core/src/integrations/channels/discord.rs
@@ -161,9 +161,9 @@ impl Channel for DiscordChannel {
                                         }
                                     });
                                 }
-                                0 => {
+                                0
                                     // Dispatch event
-                                    if event_type == Some("MESSAGE_CREATE") {
+                                    if event_type == Some("MESSAGE_CREATE") => {
                                         if let Some(data) = payload.get("d") {
                                             let content = data
                                                 .get("content")
@@ -205,7 +205,6 @@ impl Channel for DiscordChannel {
                                             }
                                         }
                                     }
-                                }
                                 _ => {}
                             }
                         }

--- a/src-tauri/crates/agent-core/src/specialization/external_import/detect/cursor.rs
+++ b/src-tauri/crates/agent-core/src/specialization/external_import/detect/cursor.rs
@@ -5,7 +5,7 @@
 //!   - `.cursor/agents/<name>.md`  → `AgentDefinition`
 //!   - `.cursor/skills/<name>/SKILL.md` (workspace)
 //!   - `~/.cursor/skills-cursor/<name>/SKILL.md` (user-global)
-//!                                 → `Skill`
+//!     → `Skill`
 
 use std::path::Path;
 

--- a/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/manifest.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/manifest.rs
@@ -27,7 +27,7 @@ pub fn scan_memory_files(dir: &Path) -> Vec<MemoryHeader> {
 
     scan_recursive(dir, dir, &mut headers);
 
-    headers.sort_by(|a, b| b.mtime_ms.cmp(&a.mtime_ms));
+    headers.sort_by_key(|header| std::cmp::Reverse(header.mtime_ms));
     headers.truncate(MAX_MEMORY_FILES);
     headers
 }
@@ -493,8 +493,7 @@ mod tests {
         // 300-byte CJK lines (100 chars * 3 bytes), well under the 200-line cap
         // but together far over the 25_000-byte budget.
         let line = "你".repeat(100);
-        let content: String = std::iter::repeat(line.as_str())
-            .take(100)
+        let content: String = std::iter::repeat_n(line.as_str(), 100)
             .collect::<Vec<_>>()
             .join("\n");
         assert!(content.lines().count() <= MAX_ENTRYPOINT_LINES);

--- a/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/prefetch.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/prefetch.rs
@@ -699,8 +699,7 @@ mod tests {
     fn test_truncate_memory_to_file_budget_cuts_at_line_boundary_with_marker() {
         // ~100-byte lines, well past the 4KB cap.
         let line = "x".repeat(99);
-        let content: String = std::iter::repeat(line.as_str())
-            .take(100)
+        let content: String = std::iter::repeat_n(line.as_str(), 100)
             .collect::<Vec<_>>()
             .join("\n");
         assert!(content.len() > MAX_MEMORY_FILE_BYTES);
@@ -786,8 +785,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let mem_dir = tmp.path().join(".orgii").join("workspace-memory");
         std::fs::create_dir_all(&mem_dir).unwrap();
-        let big_body: String = std::iter::repeat("z".repeat(80))
-            .take(200) // ~16KB, 4x over the per-file cap
+        let big_body: String = std::iter::repeat_n("z".repeat(80), 200) // ~16KB, 4x over the per-file cap
             .collect::<Vec<_>>()
             .join("\n");
         std::fs::write(

--- a/src-tauri/crates/agent-core/src/specialization/skills/market/install.rs
+++ b/src-tauri/crates/agent-core/src/specialization/skills/market/install.rs
@@ -152,7 +152,7 @@ pub async fn skills_hub_install(
     let snapshot = fetch_skill_snapshot(&client, &slug).await?;
     let content = snapshot_skill_md(&snapshot).unwrap_or_default();
 
-    let skill_name = extract_skill_name(&content).unwrap_or_else(|| slug.clone());
+    let skill_name = extract_skill_name(content).unwrap_or_else(|| slug.clone());
 
     let skills_dir = global_skills_dir();
     let skill_dir = skills_dir.join(&skill_name);

--- a/src-tauri/crates/e2e-test/src/agent_org.rs
+++ b/src-tauri/crates/e2e-test/src/agent_org.rs
@@ -841,7 +841,7 @@ pub async fn run_view_shows_failed_member_and_released_task_state(cfg: &Config) 
         == Some(1);
     let released_task_visible = released_task
         .and_then(|task| task.get("owner"))
-        .map_or(true, serde_json::Value::is_null)
+        .is_none_or(serde_json::Value::is_null)
         && released_task.and_then(|task| task.get("status").and_then(|value| value.as_str()))
             == Some(TASK_STATUS_PENDING);
     let peer_task_visible = peer_task

--- a/src-tauri/crates/e2e-test/src/agent_org_tasks_and_exec_mode.rs
+++ b/src-tauri/crates/e2e-test/src/agent_org_tasks_and_exec_mode.rs
@@ -1279,7 +1279,7 @@ pub async fn stale_worker_timeout_releases_open_tasks(cfg: &Config) -> bool {
 
     let stale_open_released = stale_open
         .and_then(|item| item.get("owner"))
-        .map_or(true, serde_json::Value::is_null)
+        .is_none_or(serde_json::Value::is_null)
         && stale_open.and_then(|item| item.get("status").and_then(|value| value.as_str()))
             == Some("pending");
     let completed_preserved = stale_completed

--- a/src-tauri/crates/e2e-test/src/sde/worktree.rs
+++ b/src-tauri/crates/e2e-test/src/sde/worktree.rs
@@ -171,9 +171,8 @@ pub async fn worktree_tool_hidden_from_os_agent(cfg: &Config) -> bool {
     let session_id = format!("{}-wt-hidden-os", cfg.session_prefix);
 
     println!("  [step 1] Initialising OS Agent session...");
-    match harness::send_os_message(cfg, "Say hello briefly.", &session_id).await {
-        Err(err) => return harness::print_error("Worktree Hidden From OS Agent", &err),
-        Ok(_) => {}
+    if let Err(err) = harness::send_os_message(cfg, "Say hello briefly.", &session_id).await {
+        return harness::print_error("Worktree Hidden From OS Agent", &err);
     }
 
     println!("  [step 2] Fetching session-scoped effective tools for OS Agent session...");

--- a/src-tauri/crates/git-api/src/commands/ai.rs
+++ b/src-tauri/crates/git-api/src/commands/ai.rs
@@ -406,7 +406,7 @@ mod tests {
     fn provider_prompt_payloads_share_the_effective_instructions() {
         let system_prompt = build_system_prompt(Some("Include a detailed body."))
             .expect("custom instructions should be accepted");
-        let messages = vec![
+        let messages = [
             json!({ "role": "system", "content": &system_prompt }),
             json!({ "role": "user", "content": "diff summary" }),
         ];

--- a/src-tauri/crates/git-api/src/commands/streaming.rs
+++ b/src-tauri/crates/git-api/src/commands/streaming.rs
@@ -74,12 +74,11 @@ pub(crate) fn detect_error_type_from_output(output: &str, operation: &str) -> &'
                 return "merge_conflicts";
             }
         }
-        "fetch" => {
+        "fetch"
             // Check for deleted branches
-            if lower.contains("[deleted]") {
+            if lower.contains("[deleted]") => {
                 return "remote_branch_deleted";
             }
-        }
         _ => {}
     }
 

--- a/src-tauri/crates/integrations/src/external_ide.rs
+++ b/src-tauri/crates/integrations/src/external_ide.rs
@@ -470,7 +470,7 @@ fn build_app_path_map() -> std::collections::HashMap<String, String> {
                 map.insert(id.to_string(), path.to_string());
             }
         }
-        return map;
+        map
     }
 
     #[cfg(not(target_os = "macos"))]

--- a/src-tauri/crates/integrations/src/github/profile.rs
+++ b/src-tauri/crates/integrations/src/github/profile.rs
@@ -197,7 +197,7 @@ async fn aggregate_language_stats(
         })
         .collect();
 
-    stats.sort_by(|a, b| b.bytes.cmp(&a.bytes));
+    stats.sort_by_key(|stat| std::cmp::Reverse(stat.bytes));
     Ok(stats)
 }
 

--- a/src-tauri/crates/key-vault/src/commands/prompt_polish.rs
+++ b/src-tauri/crates/key-vault/src/commands/prompt_polish.rs
@@ -1148,13 +1148,11 @@ fn extract_first_json_object(text: &str) -> Option<&str> {
                 }
                 depth += 1;
             }
-            b'}' => {
-                if depth > 0 {
-                    depth -= 1;
-                    if depth == 0 {
-                        if let Some(start) = start {
-                            return text.get(start..=index);
-                        }
+            b'}' if depth > 0 => {
+                depth -= 1;
+                if depth == 0 {
+                    if let Some(start) = start {
+                        return text.get(start..=index);
                     }
                 }
             }

--- a/src-tauri/crates/key-vault/src/commands/registry/commands.rs
+++ b/src-tauri/crates/key-vault/src/commands/registry/commands.rs
@@ -153,9 +153,7 @@ fn cached_available_agents(
     let Ok(cache) = cache.lock() else {
         return None;
     };
-    let Some(entry) = cache.as_ref() else {
-        return None;
-    };
+    let entry = cache.as_ref()?;
     if entry.path == path
         && entry.key_signature == key_signature
         && entry.binary_signature == binary_signature
@@ -225,10 +223,9 @@ fn is_executable_file(path: &Path) -> bool {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        return path
-            .metadata()
+        path.metadata()
             .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
-            .unwrap_or(false);
+            .unwrap_or(false)
     }
 
     #[cfg(not(unix))]

--- a/src-tauri/crates/key-vault/src/key_store/service.rs
+++ b/src-tauri/crates/key-vault/src/key_store/service.rs
@@ -548,7 +548,7 @@ impl KeyService {
             let cooldown_secs = retry_after_secs
                 .and_then(|secs| i64::try_from(secs).ok())
                 .filter(|secs| *secs > 0)
-                .unwrap_or_else(|| match status {
+                .unwrap_or(match status {
                     429 => OAUTH_RATE_LIMIT_FALLBACK_SECONDS,
                     529 => OAUTH_RATE_LIMIT_FALLBACK_SECONDS * 2,
                     401 | 403 => OAUTH_TEMPORARY_UNAVAILABLE_SECONDS,

--- a/src-tauri/crates/key-vault/src/providers/opencode_go.rs
+++ b/src-tauri/crates/key-vault/src/providers/opencode_go.rs
@@ -33,6 +33,12 @@ struct ParsedSubscription {
     monthly_reset_in_sec: Option<i64>,
 }
 
+impl Default for OpenCodeGoQuotaFetcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl OpenCodeGoQuotaFetcher {
     pub fn new() -> Self {
         Self {

--- a/src-tauri/crates/orgtrack-core/src/pricing.rs
+++ b/src-tauri/crates/orgtrack-core/src/pricing.rs
@@ -114,7 +114,7 @@ fn catalog() -> &'static Catalog {
         }
         // Longest normalized id first so prefix fallback prefers the most specific
         // family (e.g. `claude-sonnet-4-5` before `claude-sonnet`).
-        by_normalized.sort_by(|a, b| b.0.len().cmp(&a.0.len()));
+        by_normalized.sort_by_key(|entry| std::cmp::Reverse(entry.0.len()));
         Catalog {
             default,
             by_exact,

--- a/src-tauri/crates/orgtrack-core/src/privacy/mod.rs
+++ b/src-tauri/crates/orgtrack-core/src/privacy/mod.rs
@@ -32,22 +32,12 @@ impl OrgtrackTier {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[derive(Default)]
 pub struct RedactionPolicy {
     pub include_raw_prompts: bool,
     pub include_tool_args: bool,
     pub include_tool_results: bool,
     pub include_file_contents: bool,
-}
-
-impl Default for RedactionPolicy {
-    fn default() -> Self {
-        Self {
-            include_raw_prompts: false,
-            include_tool_args: false,
-            include_tool_results: false,
-            include_file_contents: false,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/crates/orgtrack-core/src/sources/claude_code/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/claude_code/history.rs
@@ -320,10 +320,7 @@ fn load_claude_session_titles(
     {
         let entry = entry.map_err(|err| format!("Failed to read Claude session entry: {err}"))?;
         let path = entry.path();
-        if !path
-            .extension()
-            .is_some_and(|extension| extension == "json")
-        {
+        if path.extension().is_none_or(|extension| extension != "json") {
             continue;
         }
         let contents = fs::read_to_string(&path).map_err(|err| {

--- a/src-tauri/crates/orgtrack-core/src/sources/cursor_ide/helpers.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/cursor_ide/helpers.rs
@@ -586,11 +586,9 @@ fn normalize_args_for_canonical(canonical: &str, cursor_name: &str, args: &mut V
         // web_fetch is renamed to web_search but keeps Cursor's `url` field.
         // `WebSearchAdapter` reads `query` only — surface the URL there too
         // so the card shows something meaningful.
-        "web_search" => {
-            if cursor_name == "web_fetch" {
-                if let Some(Value::String(url)) = obj.get("url").cloned() {
-                    obj.entry("query".to_string()).or_insert(Value::String(url));
-                }
+        "web_search" if cursor_name == "web_fetch" => {
+            if let Some(Value::String(url)) = obj.get("url").cloned() {
+                obj.entry("query".to_string()).or_insert(Value::String(url));
             }
         }
         _ => {}

--- a/src-tauri/crates/orgtrack-core/src/sources/trae/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/trae/history.rs
@@ -516,7 +516,7 @@ fn parse_trae_time_ms(value: &str) -> Option<i64> {
 
 fn trae_time_to_iso(value: &str) -> String {
     parse_trae_time_ms(value)
-        .and_then(|ms| chrono::DateTime::from_timestamp_millis(ms))
+        .and_then(chrono::DateTime::from_timestamp_millis)
         .map(|dt| dt.to_rfc3339())
         .unwrap_or_else(|| chrono::Utc::now().to_rfc3339())
 }

--- a/src-tauri/crates/search/src/code/tests/commands_fast_search_tests.rs
+++ b/src-tauri/crates/search/src/code/tests/commands_fast_search_tests.rs
@@ -64,7 +64,7 @@ fn fast_search_inner_finds_literal_case_insensitive_matches() {
     temp_dir.write_file("src/lib.rs", "AlphaNeedle\nbeta needle\n");
     temp_dir.write_file("src/ignored.txt", "needle\n");
 
-    let outcome = search_code_fast_inner(&"needle", &temp_dir.path_str(), test_filters(10), None)
+    let outcome = search_code_fast_inner("needle", &temp_dir.path_str(), test_filters(10), None)
         .expect("fast search should succeed");
 
     assert_eq!(outcome.total_matches, 2);
@@ -89,7 +89,7 @@ fn fast_search_inner_respects_max_results() {
     let temp_dir = TempSearchDir::new("limit");
     temp_dir.write_file("src/lib.rs", "needle one\nneedle two\nneedle three\n");
 
-    let outcome = search_code_fast_inner(&"needle", &temp_dir.path_str(), test_filters(2), None)
+    let outcome = search_code_fast_inner("needle", &temp_dir.path_str(), test_filters(2), None)
         .expect("fast search should succeed");
 
     assert_eq!(outcome.total_matches, 2);
@@ -109,7 +109,7 @@ fn fast_search_inner_handlers_receive_file_count_and_progress() {
     let file_count_for_callback = Arc::clone(&file_count_seen);
     let progress_for_callback = Arc::clone(&progress_seen);
     let outcome = search_code_fast_inner_with_handlers(
-        &"needle",
+        "needle",
         &temp_dir.path_str(),
         test_filters(10),
         None,

--- a/src-tauri/crates/system-services/src/power.rs
+++ b/src-tauri/crates/system-services/src/power.rs
@@ -10,11 +10,11 @@
 //!
 //! Platform implementations:
 //! - macOS:   `IOPMAssertionCreateWithName` (`kIOPMAssertPreventUserIdleSystemSleep`).
-//!            Releasing the assertion ID is what lets the system sleep again.
+//!   Releasing the assertion ID is what lets the system sleep again.
 //! - Windows: `SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED)`.
-//!            Release clears with `ES_CONTINUOUS` alone.
+//!   Release clears with `ES_CONTINUOUS` alone.
 //! - Linux:   No-op for now (D-Bus `org.freedesktop.ScreenSaver.Inhibit` can
-//!            be added later if there's user demand).
+//!   be added later if there's user demand).
 
 use std::sync::Mutex;
 use tauri::State;

--- a/src-tauri/crates/system-services/src/workspace_ports/attribution.rs
+++ b/src-tauri/crates/system-services/src/workspace_ports/attribution.rs
@@ -37,10 +37,7 @@ pub(crate) fn attribute_port_to_workspaces(
         }
     }
 
-    let command_normalized = command_line.map(normalize_comparable_text);
-    let Some(command_line) = command_normalized else {
-        return None;
-    };
+    let command_line = command_line.map(normalize_comparable_text)?;
 
     let matched = pick_deepest_matching(folders, |candidate| {
         includes_path_boundary(&command_line, &candidate.normalized_path)
@@ -64,10 +61,10 @@ fn to_owner(
     }
 }
 
-fn pick_deepest_matching<'a, F>(
-    candidates: &'a [NormalizedWorkspacePortProbe],
+fn pick_deepest_matching<F>(
+    candidates: &[NormalizedWorkspacePortProbe],
     predicate: F,
-) -> Option<&'a NormalizedWorkspacePortProbe>
+) -> Option<&NormalizedWorkspacePortProbe>
 where
     F: Fn(&NormalizedWorkspacePortProbe) -> bool,
 {

--- a/src-tauri/crates/system-services/src/workspace_ports/scanner.rs
+++ b/src-tauri/crates/system-services/src/workspace_ports/scanner.rs
@@ -351,7 +351,7 @@ impl std::fmt::Display for ScanError {
 fn scan_platform_listening_ports() -> Result<Vec<RawListeningPort>, ScanError> {
     #[cfg(target_os = "macos")]
     {
-        return scan_darwin_lsof_ports();
+        scan_darwin_lsof_ports()
     }
     #[cfg(target_os = "linux")]
     {

--- a/src-tauri/src/agent_sessions/cli/parsers/kiro.rs
+++ b/src-tauri/src/agent_sessions/cli/parsers/kiro.rs
@@ -263,7 +263,7 @@ pub fn list_kiro_sessions() -> Vec<KiroSessionInfo> {
         })
         .collect();
 
-    sessions.sort_by(|a, b| b.last_modified.cmp(&a.last_modified));
+    sessions.sort_by_key(|session| std::cmp::Reverse(session.last_modified));
     sessions
 }
 

--- a/src-tauri/src/agent_sessions/cli/session_runner/launch_profiles.rs
+++ b/src-tauri/src/agent_sessions/cli/session_runner/launch_profiles.rs
@@ -6,17 +6,13 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
+#[derive(Default)]
 pub enum CliPermissionMode {
     Plan,
+    #[default]
     FullPermission,
     AutoEdit,
     Manual,
-}
-
-impl Default for CliPermissionMode {
-    fn default() -> Self {
-        Self::FullPermission
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src-tauri/src/agent_sessions/event_pipeline/analytics.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/analytics.rs
@@ -328,7 +328,7 @@ pub fn compute_session_analytics(events: &[SessionEvent]) -> SessionAnalytics {
             total_duration_ms: 0, // Duration requires paired start/end — not available in single events
         })
         .collect();
-    tool_usage.sort_by(|a, b| b.call_count.cmp(&a.call_count));
+    tool_usage.sort_by_key(|tool| std::cmp::Reverse(tool.call_count));
 
     // File changes
     let mut by_operation: Vec<FileOperationEntry> = file_op_map
@@ -339,7 +339,7 @@ pub fn compute_session_analytics(events: &[SessionEvent]) -> SessionAnalytics {
             files: files.len(),
         })
         .collect();
-    by_operation.sort_by(|a, b| b.count.cmp(&a.count));
+    by_operation.sort_by_key(|operation| std::cmp::Reverse(operation.count));
 
     let mut top_files: Vec<FileFrequencyEntry> = file_freq
         .into_iter()
@@ -349,7 +349,7 @@ pub fn compute_session_analytics(events: &[SessionEvent]) -> SessionAnalytics {
             touch_count: count,
         })
         .collect();
-    top_files.sort_by(|a, b| b.touch_count.cmp(&a.touch_count));
+    top_files.sort_by_key(|file| std::cmp::Reverse(file.touch_count));
     let total_files = top_files.len();
     top_files.truncate(20);
 
@@ -417,8 +417,9 @@ pub fn compute_session_analytics(events: &[SessionEvent]) -> SessionAnalytics {
             failure_count: fails,
         })
         .collect();
-    by_tool_errors
-        .sort_by(|a, b| (b.error_count + b.failure_count).cmp(&(a.error_count + a.failure_count)));
+    by_tool_errors.sort_by_key(|tool| {
+        std::cmp::Reverse(tool.error_count + tool.failure_count)
+    });
 
     let error_stats = ErrorStats {
         total_errors,

--- a/src-tauri/src/agent_sessions/event_pipeline/commands/cache_bridge.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/commands/cache_bridge.rs
@@ -623,7 +623,7 @@ mod tests {
         assistant.display_text = FINAL_ASSISTANT_ANSWER.to_string();
         assistant.is_delta = Some(false);
 
-        let cached = vec![user, subagent, assistant]
+        let cached = [user, subagent, assistant]
             .iter()
             .filter(|event| !is_synthetic_persistence_artifact(event))
             .map(session_event_to_cached_event)

--- a/src-tauri/src/agent_sessions/event_pipeline/history.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/history.rs
@@ -239,7 +239,7 @@ pub fn group_sessions(sessions: &[SessionRecord], group_by: &str) -> Vec<Session
         })
         .collect();
 
-    result.sort_by(|a, b| b.count.cmp(&a.count));
+    result.sort_by_key(|entry| std::cmp::Reverse(entry.count));
     result
 }
 

--- a/src-tauri/src/agent_sessions/event_pipeline/ingestion/normalizer.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/ingestion/normalizer.rs
@@ -143,10 +143,8 @@ fn infer_display_variant(
     result: &serde_json::Value,
 ) -> EventDisplayVariant {
     // User messages
-    if action_type == "raw" || action_type == "raw_event" {
-        if raw_message_text(result).is_some() {
-            return EventDisplayVariant::Message;
-        }
+    if (action_type == "raw" || action_type == "raw_event") && raw_message_text(result).is_some() {
+        return EventDisplayVariant::Message;
     }
 
     // Thinking events

--- a/src-tauri/src/agent_sessions/event_pipeline/pagination.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/pagination.rs
@@ -203,7 +203,7 @@ pub fn get_distinct_functions(events: &[SessionEvent]) -> Vec<FunctionUsageCount
             count,
         })
         .collect();
-    result.sort_by(|a, b| b.count.cmp(&a.count));
+    result.sort_by_key(|entry| std::cmp::Reverse(entry.count));
     result
 }
 

--- a/src-tauri/src/agent_sessions/event_pipeline/statistics.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/statistics.rs
@@ -120,7 +120,7 @@ pub fn compute_session_statistics(sessions: &[SessionRecord]) -> SessionStatisti
             percentage: count as f64 / total as f64 * 100.0,
         })
         .collect();
-    by_status.sort_by(|a, b| b.count.cmp(&a.count));
+    by_status.sort_by_key(|entry| std::cmp::Reverse(entry.count));
 
     // Type counts
     let mut type_map: HashMap<String, usize> = HashMap::new();
@@ -135,7 +135,7 @@ pub fn compute_session_statistics(sessions: &[SessionRecord]) -> SessionStatisti
             percentage: count as f64 / total as f64 * 100.0,
         })
         .collect();
-    by_type.sort_by(|a, b| b.count.cmp(&a.count));
+    by_type.sort_by_key(|entry| std::cmp::Reverse(entry.count));
 
     // File changes aggregate
     let mut total_file_changes = FileChangeStats::default();
@@ -180,7 +180,7 @@ pub fn compute_session_statistics(sessions: &[SessionRecord]) -> SessionStatisti
             total_deletions: acc.total_deletions,
         })
         .collect();
-    top_repos.sort_by(|a, b| b.session_count.cmp(&a.session_count));
+    top_repos.sort_by_key(|repo| std::cmp::Reverse(repo.session_count));
     top_repos.truncate(10);
 
     // Model usage
@@ -197,7 +197,7 @@ pub fn compute_session_statistics(sessions: &[SessionRecord]) -> SessionStatisti
             session_count: count,
         })
         .collect();
-    top_models.sort_by(|a, b| b.session_count.cmp(&a.session_count));
+    top_models.sort_by_key(|model| std::cmp::Reverse(model.session_count));
 
     // Daily activity
     let mut daily_map: HashMap<String, DailyAccum> = HashMap::new();
@@ -242,7 +242,7 @@ pub fn compute_session_statistics(sessions: &[SessionRecord]) -> SessionStatisti
             }
         })
         .collect();
-    impactful.sort_by(|a, b| b.total_changes.cmp(&a.total_changes));
+    impactful.sort_by_key(|file| std::cmp::Reverse(file.total_changes));
     impactful.truncate(10);
 
     SessionStatistics {

--- a/src-tauri/src/agent_sessions/session_directory/aggregation.rs
+++ b/src-tauri/src/agent_sessions/session_directory/aggregation.rs
@@ -282,7 +282,9 @@ fn decorate_imported_live_status(records: &mut [SessionAggregateRecord]) {
         }
         if record.status == IMPORTED_STATUS_COMPLETED {
             let recently_updated = DateTime::parse_from_rfc3339(&record.updated_at)
-                .map(|updated| now_ms - updated.timestamp_millis() < IMPORTED_MTIME_ACTIVE_WINDOW_MS)
+                .map(|updated| {
+                    now_ms - updated.timestamp_millis() < IMPORTED_MTIME_ACTIVE_WINDOW_MS
+                })
                 .unwrap_or(false);
             if recently_updated {
                 record.status = "running".to_string();
@@ -373,7 +375,9 @@ fn load_imported_history_sessions(
 /// The filter is destructured exhaustively on purpose: adding a field to
 /// `SessionFilter` must fail compilation here so the new field's fast-path
 /// semantics are decided explicitly.
-fn plain_native_page(filter: Option<&SessionFilter>) -> Result<Option<SessionListResponse>, String> {
+fn plain_native_page(
+    filter: Option<&SessionFilter>,
+) -> Result<Option<SessionListResponse>, String> {
     let Some(filter) = filter else {
         return Ok(None);
     };
@@ -863,9 +867,9 @@ fn apply_sorting(sessions: &mut [SessionAggregateRecord], filter: Option<&Sessio
         }
         "name" => {
             if sort_desc {
-                sessions.sort_by(|a, b| b.name.to_lowercase().cmp(&a.name.to_lowercase()));
+                sessions.sort_by_key(|session| std::cmp::Reverse(session.name.to_lowercase()));
             } else {
-                sessions.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+                sessions.sort_by_key(|a| a.name.to_lowercase());
             }
         }
         _ => {

--- a/src-tauri/src/agent_sessions/session_directory/conversion.rs
+++ b/src-tauri/src/agent_sessions/session_directory/conversion.rs
@@ -59,6 +59,12 @@ fn native_impact_fields(
     }
 }
 
+impl Default for AgentMetadataResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl AgentMetadataResolver {
     pub fn new() -> Self {
         Self {

--- a/src-tauri/src/api/agent/dto_extended_tests.rs
+++ b/src-tauri/src/api/agent/dto_extended_tests.rs
@@ -2611,9 +2611,9 @@ mod dto_extended_tests {
         let view = AgentLearningsView::from(&cfg);
         let json = serde_json::to_string(&view).expect("serialize");
         let back: AgentLearningsView = serde_json::from_str(&json).expect("deserialize");
-        assert_eq!(back.enabled, false);
-        assert_eq!(back.extract_memories_enabled, false);
-        assert_eq!(back.auto_dream_enabled, false);
+        assert!(!back.enabled);
+        assert!(!back.extract_memories_enabled);
+        assert!(!back.auto_dream_enabled);
     }
 
     #[test]

--- a/src-tauri/src/api/agent/test/agent_org.rs
+++ b/src-tauri/src/api/agent/test/agent_org.rs
@@ -432,7 +432,7 @@ pub async fn test_agent_org_launch_coordinator(
                         agent_core::lifecycle::finalize_session(
                             &result.session_id,
                             &content_result,
-                            Some(&handle),
+                            Some(handle),
                             Some(sync_workspace_path.as_path()),
                             true,
                             Some(agent_core::lifecycle::TerminalTurnSignal {
@@ -457,7 +457,7 @@ pub async fn test_agent_org_launch_coordinator(
                         agent_core::lifecycle::finalize_session(
                             &result.session_id,
                             &content_result,
-                            Some(&handle),
+                            Some(handle),
                             Some(sync_workspace_path.as_path()),
                             true,
                             None,
@@ -482,7 +482,7 @@ pub async fn test_agent_org_launch_coordinator(
                         agent_core::lifecycle::finalize_session(
                             &result.session_id,
                             &content_result,
-                            Some(&handle),
+                            Some(handle),
                             Some(sync_workspace_path.as_path()),
                             true,
                             None,

--- a/src-tauri/src/api/agent/test/core.rs
+++ b/src-tauri/src/api/agent/test/core.rs
@@ -1207,7 +1207,7 @@ pub async fn test_work_item_scheduler_run_once() -> Json<serde_json::Value> {
 pub async fn debug_work_item_scheduler_run_once() -> Result<serde_json::Value, String> {
     let handle = crate::api::get_app_handle()
         .ok_or_else(|| "AppHandle not initialized. Is the Tauri app running?".to_string())?;
-    agent_core::coordination::work_item_scheduler::debug_run_once(&handle).await?;
+    agent_core::coordination::work_item_scheduler::debug_run_once(handle).await?;
     Ok(serde_json::json!({ "ran": true }))
 }
 
@@ -1215,7 +1215,7 @@ pub async fn debug_work_item_scheduler_run_once() -> Result<serde_json::Value, S
 pub async fn debug_routine_scheduler_run_once() -> Result<serde_json::Value, String> {
     let handle = crate::api::get_app_handle()
         .ok_or_else(|| "AppHandle not initialized. Is the Tauri app running?".to_string())?;
-    agent_core::coordination::routine_scheduler::debug_run_once(&handle).await?;
+    agent_core::coordination::routine_scheduler::debug_run_once(handle).await?;
     Ok(serde_json::json!({ "ran": true }))
 }
 

--- a/src-tauri/src/orgtrack/importer.rs
+++ b/src-tauri/src/orgtrack/importer.rs
@@ -51,9 +51,7 @@ pub fn read_file_timeline(
         return Ok(None);
     }
     let mut timeline: OrgtrackFileTimeline = paths::read_json(&legacy_path)?;
-    timeline
-        .entries
-        .sort_by(|first, second| first.timestamp.cmp(&second.timestamp));
+    timeline.entries.sort_by_key(|first| first.timestamp);
     Ok(Some(timeline))
 }
 

--- a/src-tauri/src/orgtrack/mod.rs
+++ b/src-tauri/src/orgtrack/mod.rs
@@ -519,8 +519,8 @@ fn project_file_session_history(
     }
 
     let mut sessions = grouped
-        .into_iter()
-        .map(|(_, entry)| {
+        .into_values()
+        .map(|entry| {
             let root_replay_target = entry
                 .transcript_session_id
                 .as_deref()

--- a/src-tauri/src/orgtrack/session_provenance/collaboration_replay.rs
+++ b/src-tauri/src/orgtrack/session_provenance/collaboration_replay.rs
@@ -139,7 +139,6 @@ pub(crate) fn index_collaboration_replay(
             &fingerprint,
             COLLABORATION_REPLAY_PARSER_VERSION,
         )? {
-            drop(store);
             tx.commit().map_err(|err| err.to_string())?;
             return Ok(0);
         }
@@ -197,7 +196,6 @@ pub(crate) fn index_collaboration_replay(
             COLLABORATION_REPLAY_PARSER_VERSION,
             &Utc::now().to_rfc3339(),
         )?;
-        drop(store);
         tx.commit().map_err(|err| err.to_string())?;
         Ok(persisted)
     })

--- a/src-tauri/src/usage_diagnostics/types.rs
+++ b/src-tauri/src/usage_diagnostics/types.rs
@@ -8,16 +8,12 @@ pub const MAX_UPLOAD_INTERVAL_HOURS: u64 = 24;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
+#[derive(Default)]
 pub enum DiagnosticsLevel {
     Off,
     PerformanceOnly,
+    #[default]
     Default,
-}
-
-impl Default for DiagnosticsLevel {
-    fn default() -> Self {
-        Self::Default
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

- eliminate the two orgtrack TypeScript lint warnings
- apply behavior-preserving Clippy cleanups across the Rust workspace
- reduce independent Rust warnings from 158 to 77 without adding warning suppressions

## Validation

- `cargo clippy --workspace --all-targets` — 0 errors
- `pnpm exec eslint packages/orgtrack/src/cli.ts --no-ignore --max-warnings=0`
- `pnpm exec tsc -p packages/orgtrack/tsconfig.json --noEmit`
- 1,744 focused Rust tests passed; 1 ignored

The broad Rust test run hit the pre-existing deadlock in `agent_core::specialization::external_import::tests::HomeEnvGuard`; focused suites for the affected code passed.

## Architecture audit

The changed diff was checked across all 10 architecture-audit layers. It introduces no new cross-layer dependencies, domain naming, wire or serde shape changes, initialization-path differences, or resolver fallback asymmetry. Enum `Default` derives preserve the previous default variants, and the whole-workspace Clippy run served as the systematic sweep.

## Deferred lint debt

The remaining 77 independent warnings are intentionally outside this easy-fix batch: 37 `field_reassign_with_default`, 15 `too_many_arguments`, 9 `items_after_test_module`, 6 `type_complexity`, plus smaller architectural or policy categories.