### PR TITLE
fix(key-vault): unblock Done after OAuth by not forcing account name

### DIFF
--- a/src/scaffold/WizardSystem/variants/KeyVault/components/AgentSetupRouter.tsx
+++ b/src/scaffold/WizardSystem/variants/KeyVault/components/AgentSetupRouter.tsx
@@ -7,6 +7,7 @@
 import React from "react";
 
 import {
+  type OAuthModelCatalog,
   getClaudeCodeOAuthModels as fetchClaudeCodeOAuthModels,
   getCodexOAuthModels as fetchCodexOAuthModels,
   getOAuthModelCatalog,
@@ -122,7 +123,15 @@ export const AgentSetupRouter: React.FC<AgentSetupRouterProps> = ({
           onClearTokenError={clearTokenError}
           preselectedMethod={isComplex ? setupMethod : undefined}
           onSessionCaptured={async (values: CodexSessionValues) => {
-            const catalog = await getOAuthModelCatalog(CLI_AGENT.CODEX);
+            let catalog: OAuthModelCatalog = {
+              models: [],
+              defaultEnabledModels: [],
+            };
+            try {
+              catalog = await getOAuthModelCatalog(CLI_AGENT.CODEX);
+            } catch (err) {
+              log.warn("[ApiSetup] Codex OAuth catalog fetch failed:", err);
+            }
             let discoveredModels: string[] = [];
             try {
               discoveredModels = await fetchCodexOAuthModels(
@@ -131,7 +140,7 @@ export const AgentSetupRouter: React.FC<AgentSetupRouterProps> = ({
               );
             } catch (err) {
               log.warn(
-                "[ApiSetup] Codex OAuth model discovery failed; using Rust catalog:",
+                "[ApiSetup] Codex OAuth model discovery failed; falling back to catalog:",
                 err
               );
             }
@@ -145,7 +154,10 @@ export const AgentSetupRouter: React.FC<AgentSetupRouterProps> = ({
                 ? defaultEnabledModels
                 : codexModels.slice(0, 1);
             onChange({
-              name: "OpenAI",
+              // Intentionally do NOT set `name` here. Forcing "OpenAI" either
+              // trips `isDuplicateName` (disabling Done) or shadows the
+              // `nextDefaultName` dedupe in `submit()`. Let the wizard's own
+              // name-resolution handle it (empty → "OpenAI" / "OpenAI-1" ...).
               auth_method: "oauth",
               oauth_session_token: values.accessToken,
               raw_key_input: "",
@@ -235,7 +247,18 @@ export const AgentSetupRouter: React.FC<AgentSetupRouterProps> = ({
           onClearTokenError={clearTokenError}
           preselectedMethod={isComplex ? setupMethod : undefined}
           onSessionCaptured={async (values: ClaudeCodeSessionValues) => {
-            const catalog = await getOAuthModelCatalog(CLI_AGENT.CLAUDE_CODE);
+            let catalog: OAuthModelCatalog = {
+              models: [],
+              defaultEnabledModels: [],
+            };
+            try {
+              catalog = await getOAuthModelCatalog(CLI_AGENT.CLAUDE_CODE);
+            } catch (err) {
+              log.warn(
+                "[ApiSetup] Claude Code OAuth catalog fetch failed:",
+                err
+              );
+            }
             let discoveredModels: string[] = [];
             try {
               discoveredModels = await fetchClaudeCodeOAuthModels(
@@ -243,7 +266,7 @@ export const AgentSetupRouter: React.FC<AgentSetupRouterProps> = ({
               );
             } catch (err) {
               log.warn(
-                "[ApiSetup] Claude Code OAuth model discovery failed; using Rust catalog:",
+                "[ApiSetup] Claude Code OAuth model discovery failed; falling back to catalog:",
                 err
               );
             }
@@ -259,7 +282,6 @@ export const AgentSetupRouter: React.FC<AgentSetupRouterProps> = ({
             const expiresAt = values.expiresIn
               ? Date.now() + values.expiresIn * 1000
               : undefined;
-            const accountName = "Anthropic";
             const envVars = [
               ...(values.refreshToken
                 ? [
@@ -292,7 +314,10 @@ export const AgentSetupRouter: React.FC<AgentSetupRouterProps> = ({
               raw_key_input: "",
               env_vars: envVars,
               account_metadata: values.accountMetadata ?? {},
-              ...(accountName ? { name: accountName } : {}),
+              // Intentionally do NOT set `name` here. Forcing "Anthropic"
+              // trips `isDuplicateName` (disabling Done) or shadows the
+              // `nextDefaultName` dedupe in `submit()`. The wizard resolves
+              // the account name itself (empty → brand label / "-1" / ...).
               available_models: claudeCodeModels,
               model_context_lengths: {},
               enabled_models: enabledModels,


### PR DESCRIPTION
## Problem

When adding a Codex (OpenAI) or Claude Code account via the **signin** OAuth flow, the wizard's **Done** button stays grayed out even after a successful sign-in — the green 'Signed in ✓' badge shows, but you can't complete the wizard.

## Root cause

The Codex and Claude Code `onSessionCaptured` handlers in `AgentSetupRouter.tsx` unconditionally force the account name:

```tsx
onChange({ name: "OpenAI", /* ... */ validated: true })
```

When a same-named account already exists (e.g. adding a second OpenAI account), `isDuplicateName` flips to `true`, and Done is gated by:

```tsx
// ApiSetup.tsx:493
canProceed={hasAgent && hook.canProceed && !isDuplicateName}
```

So `canProceed` stays `false` and Done never enables — even though the OAuth sign-in itself succeeded and `data.validated`/`auth_method` were correctly set.

## Fix

**Stop setting `name` in the OAuth callbacks.** The account name is resolved by the wizard's existing, generic machinery at submit time:

```
empty name → isDuplicateName = false → Done unblocked
           → submit() → nextDefaultName(getDefaultNameBase(agentType), existingAccountNames)
           → "OpenAI" / "OpenAI-1" / "OpenAI-2" / ...
```

This is **generic** rather than a per-agent name map:
- Covers Codex, Claude Code, Kiro, Copilot, and any future OAuth agent with zero per-agent code
- Default name comes from the provider registry's brand label (`getDefaultNameBase`), a single source of truth
- `nextDefaultName` already handles `-1`/`-2` suffix dedupe
- A user-typed name is never overwritten

## Also hardened

Wrapped the `getOAuthModelCatalog(...)` call (previously unguarded) in `try/catch` in both handlers, matching the sibling `fetchCodexOAuthModels` / `fetchClaudeCodeOAuthModels` calls. Without this, a catalog fetch failure would abort the async handler before `onChange({...validated: true})` runs, silently leaving the wizard stuck. On failure it now degrades to an empty catalog.

## Verification

- `tsc --noEmit` passes
- pre-commit hooks pass (eslint + prettier + lint-staged)
- Manual repro confirmed: adding a 2nd OpenAI account previously had Done stuck; with the fix, name auto-resolves to `OpenAI-1` and Done is clickable.

## Checklist

- [x] Single-file bug fix — no UI audit report required per AGENTS.md
- [x] Scoped to the OAuth name + catalog-fetch paths; no provider/agent-type changes