### PR TITLE
fix(terminal): stop managed TUI flicker

### DIFF
--- a/src/api/tauri/agent/cliTerminalSession.test.ts
+++ b/src/api/tauri/agent/cliTerminalSession.test.ts
@@ -36,6 +36,21 @@ describe("formatCliTuiCommand", () => {
     );
   });
 
+  it("omits Codex's prompt-required exec subcommand for interactive TUI launches", () => {
+    expect(
+      formatCliTuiCommand(
+        profile({
+          agentName: "codex",
+          defaultCommand: "codex",
+          command: "codex",
+          requiredArgs: ["exec"],
+          args: ["--dangerously-bypass-approvals-and-sandbox"],
+        }),
+        "codex"
+      )
+    ).toBe("codex --dangerously-bypass-approvals-and-sandbox");
+  });
+
   it("honors command and argument overrides with shell-safe quoting", () => {
     expect(
       formatCliTuiCommand(

--- a/src/api/tauri/agent/cliTerminalSession.ts
+++ b/src/api/tauri/agent/cliTerminalSession.ts
@@ -11,7 +11,7 @@ import { invoke } from "@tauri-apps/api/core";
 
 import { rpc } from "@src/api/tauri/rpc";
 import type { CliLaunchProfileView } from "@src/api/tauri/rpc/schemas/agentOrgs";
-import type { CliAgentType } from "@src/api/types/keys";
+import { CLI_AGENT, type CliAgentType } from "@src/api/types/keys";
 
 export interface CliTuiSessionCreateParams {
   platform: CliAgentType;
@@ -42,13 +42,18 @@ export function formatCliTuiCommand(
   const executable = profile.commandOverridden
     ? profile.command
     : detectedCommand;
-  return [executable, ...profile.requiredArgs, ...profile.args]
+  // `codex exec` is the headless runner and requires a prompt. TUI launches
+  // must start Codex's interactive CLI instead, while retaining its selected
+  // permission-mode flags (which Codex also accepts at the top level).
+  const requiredArgs =
+    profile.agentName === CLI_AGENT.CODEX ? [] : profile.requiredArgs;
+  return [executable, ...requiredArgs, ...profile.args]
     .filter((part) => part.trim().length > 0)
     .map(quotePosixShellArg)
     .join(" ");
 }
 
-/** Resolve the same required/mode arguments used by managed CLI launches. */
+/** Resolve a terminal-safe command from the managed CLI launch profile. */
 export async function resolveCliTuiCommand(
   platform: CliAgentType,
   detectedCommand: string

--- a/src/components/TerminalInteractive/terminalSizing.test.ts
+++ b/src/components/TerminalInteractive/terminalSizing.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { createRedrawTerminalAfterLayoutChange } from "./terminalSizing";
+import {
+  createFitTerminal,
+  createRedrawTerminalAfterLayoutChange,
+} from "./terminalSizing";
 
 function visibleContainer() {
   return {
@@ -47,6 +50,26 @@ describe("terminal sizing lifecycle", () => {
     expect(oldFitAddon.fit).not.toHaveBeenCalled();
     expect(newFitAddon.fit).not.toHaveBeenCalled();
     vi.unstubAllGlobals();
+  });
+
+  it("fits layout changes without clearing the renderer or forcing a full refresh", () => {
+    const terminal = {
+      clearTextureAtlas: vi.fn(),
+      refresh: vi.fn(),
+      rows: 24,
+    };
+    const fitAddon = { fit: vi.fn() };
+    const refs = {
+      containerRef: { current: visibleContainer() },
+      fitAddonRef: { current: fitAddon },
+      terminalRef: { current: terminal },
+    };
+
+    createFitTerminal(refs as never)();
+
+    expect(fitAddon.fit).toHaveBeenCalledOnce();
+    expect(terminal.clearTextureAtlas).not.toHaveBeenCalled();
+    expect(terminal.refresh).not.toHaveBeenCalled();
   });
 
   it("redraws only when terminal, addon, and container identities remain live", () => {

--- a/src/components/TerminalInteractive/terminalSizing.ts
+++ b/src/components/TerminalInteractive/terminalSizing.ts
@@ -67,9 +67,10 @@ export function createFitTerminal({
           return;
         }
 
-        terminalRef.current.clearTextureAtlas();
+        // FitAddon resizes xterm and triggers the normal renderer update. Clearing
+        // the WebGL glyph atlas and forcing a full refresh on every ResizeObserver
+        // notification causes visible flashes while embedded terminal layouts settle.
         fitAddonRef.current.fit();
-        terminalRef.current.refresh(0, terminalRef.current.rows - 1);
       } catch (error) {
         log.warn("[Terminal] Fit error:", error);
       }

--- a/src/engines/TerminalCore/index.tsx
+++ b/src/engines/TerminalCore/index.tsx
@@ -361,16 +361,15 @@ export const TerminalCore: React.FC<TerminalCoreProps> = ({
                 workingDirectory={session.liveCwd || session.cwd}
                 onOpenFileLink={onOpenFileLink}
                 backgroundColor={bgColor}
-                shellOverride={session.shell}
+                // Managed CLI terminals use the configured default shell.
+                // `session.shell` becomes runtime metadata after the PTY connects,
+                // so reusing it as a launch override would recreate xterm.
+                shellOverride={session.agentCommand ? undefined : session.shell}
                 // CLI-agent terminals: pin the PTY to the session's cwd
                 // (worktree) and let lifecycle hooks attribute status and
                 // transcripts to the backing managed session row.
                 forceRepoCwd={Boolean(session.agentCommand)}
-                envOverride={
-                  session.agentCommand && session.agentSessionId
-                    ? { ORGII_SESSION_ID: session.agentSessionId }
-                    : undefined
-                }
+                envOverride={session.envOverride}
                 nameOverride={session.name}
                 onUserInput={() => {
                   requestProcessRefresh();

--- a/src/engines/TerminalCore/types.ts
+++ b/src/engines/TerminalCore/types.ts
@@ -46,6 +46,8 @@ export interface TerminalSession {
   cliAgentType?: CliAgentType;
   /** Command injected to start the CLI agent. */
   agentCommand?: string;
+  /** Environment variables supplied when the PTY is created. */
+  envOverride?: Record<string, string>;
   /** Foreground process name expected while the CLI agent is active. */
   expectedProcess?: string;
   /** Derived lifecycle state for chat-panel TUI agent tracking. */

--- a/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
+++ b/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
@@ -51,8 +51,14 @@ async function loadChatPanelTabAtoms() {
     openOrReplaceSessionInChatPanelTabAtom,
     openSessionInNewChatTabAtom,
     prevChatPanelTabAtom,
+    setChatPanelTabTitleAtom,
     syncActiveChatPanelTabStateAtom,
   } = await import("../chatPanelTabsAtom");
+  const {
+    createChatPanelTerminalAtom,
+    terminalSessionsAtom,
+    updateTerminalSessionInfoAtom,
+  } = await import("../chatPanelTerminalAtom");
   const {
     activeChatPanelSurfaceAtom,
     chatPanelMaximizedAtom,
@@ -82,6 +88,7 @@ async function loadChatPanelTabAtoms() {
     chatPanelStartPageOpenAtom,
     chatPanelStartPageTabAtom,
     closeChatPanelTabAtom,
+    createChatPanelTerminalAtom,
     kanbanDetailPanelVisibleAtom,
     kanbanReplayBoundsAtom,
     kanbanReplayCursorAtom,
@@ -103,7 +110,10 @@ async function loadChatPanelTabAtoms() {
     workManagementProjectsViewAtom,
     openSessionInNewChatTabAtom,
     prevChatPanelTabAtom,
+    setChatPanelTabTitleAtom,
     syncActiveChatPanelTabStateAtom,
+    terminalSessionsAtom,
+    updateTerminalSessionInfoAtom,
     sessionViewAtom,
     sessionsAtom,
     store,
@@ -948,5 +958,76 @@ describe("openOrReplaceSessionInChatPanelTabAtom", () => {
         }),
       ])
     );
+  });
+});
+
+describe("managed TUI terminal state", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps the PTY environment reference across terminal metadata updates", async () => {
+    const {
+      createChatPanelTerminalAtom,
+      store,
+      terminalSessionsAtom,
+      updateTerminalSessionInfoAtom,
+    } = await loadChatPanelTabAtoms();
+    const terminalId = store.set(createChatPanelTerminalAtom, {
+      name: "Codex",
+      agentCommand: "codex",
+      agentSessionId: "managed-session",
+    });
+    const initialSession = store
+      .get(terminalSessionsAtom)
+      .find((session) => session.id === terminalId);
+
+    store.set(updateTerminalSessionInfoAtom, {
+      sessionId: terminalId,
+      info: { processName: "codex" },
+    });
+
+    const updatedSession = store
+      .get(terminalSessionsAtom)
+      .find((session) => session.id === terminalId);
+    expect(updatedSession?.envOverride).toBe(initialSession?.envOverride);
+    expect(updatedSession?.envOverride).toEqual({
+      ORGII_SESSION_ID: "managed-session",
+    });
+  });
+});
+
+describe("setChatPanelTabTitleAtom", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.resetModules();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not write tab state when the title is unchanged", async () => {
+    const { chatPanelTabsAtom, setChatPanelTabTitleAtom, store } =
+      await loadChatPanelTabAtoms();
+    const stateBefore = store.get(chatPanelTabsAtom);
+    const activeTab = stateBefore.tabs.find(
+      (tab) => tab.id === stateBefore.activeTabId
+    );
+    expect(activeTab).toBeDefined();
+
+    store.set(setChatPanelTabTitleAtom, {
+      tabId: stateBefore.activeTabId,
+      title: activeTab?.title ?? "",
+    });
+
+    expect(store.get(chatPanelTabsAtom)).toBe(stateBefore);
   });
 });

--- a/src/store/chatPanel/chatPanelTabLifecycleAtoms.ts
+++ b/src/store/chatPanel/chatPanelTabLifecycleAtoms.ts
@@ -152,13 +152,19 @@ export const setChatPanelTabSessionIdAtom = atom(
 export const setChatPanelTabTitleAtom = atom(
   null,
   (_get, set, { tabId, title }: { tabId: string; title: string }) => {
-    const now = new Date().toISOString();
-    set(chatPanelTabsAtom, (prev) => ({
-      ...prev,
-      tabs: prev.tabs.map((tab) =>
-        tab.id === tabId ? { ...tab, title, updatedAt: now } : tab
-      ),
-    }));
+    set(chatPanelTabsAtom, (prev) => {
+      if (prev.tabs.some((tab) => tab.id === tabId && tab.title === title)) {
+        return prev;
+      }
+
+      const now = new Date().toISOString();
+      return {
+        ...prev,
+        tabs: prev.tabs.map((tab) =>
+          tab.id === tabId ? { ...tab, title, updatedAt: now } : tab
+        ),
+      };
+    });
   }
 );
 

--- a/src/store/chatPanel/chatPanelTerminalAtom.ts
+++ b/src/store/chatPanel/chatPanelTerminalAtom.ts
@@ -75,6 +75,10 @@ export const createChatPanelTerminalAtom = atom(
       agentSessionId,
     } = typeof options === "string" ? { name: options } : options;
     const newId = `${CHAT_PANEL_TERMINAL_PREFIX}${crypto.randomUUID()}`;
+    const envOverride =
+      agentCommand && agentSessionId
+        ? { ORGII_SESSION_ID: agentSessionId }
+        : undefined;
     const newSession: TerminalSession = {
       id: newId,
       name,
@@ -84,6 +88,7 @@ export const createChatPanelTerminalAtom = atom(
       agentCommand,
       expectedProcess,
       agentSessionId,
+      envOverride,
       agentStatus: agentCommand ? TERMINAL_AGENT_STATUS.STARTING : undefined,
     };
     set(terminalSessionsAtom, (prev) => [...prev, newSession]);

--- a/src/store/workstation/codeEditor/terminal/__tests__/terminalAtoms.test.ts
+++ b/src/store/workstation/codeEditor/terminal/__tests__/terminalAtoms.test.ts
@@ -225,6 +225,21 @@ describe("terminal atoms", () => {
   });
 
   describe("updateTerminalSessionInfoAtom", () => {
+    it("does not replace terminal state when metadata is unchanged", () => {
+      store.set(updateTerminalSessionInfoAtom, {
+        sessionId: "initial-1",
+        info: { sequenceTitle: "Codex" },
+      });
+      const stateBefore = store.get(terminalSessionsAtom);
+
+      store.set(updateTerminalSessionInfoAtom, {
+        sessionId: "initial-1",
+        info: { sequenceTitle: "Codex" },
+      });
+
+      expect(store.get(terminalSessionsAtom)).toBe(stateBefore);
+    });
+
     it("updates session metadata", () => {
       store.set(updateTerminalSessionInfoAtom, {
         sessionId: "initial-1",

--- a/src/store/workstation/codeEditor/terminal/index.ts
+++ b/src/store/workstation/codeEditor/terminal/index.ts
@@ -515,12 +515,20 @@ export const updateTerminalSessionInfoAtom = atom(
     }
   ) => {
     const sessions = get(terminalSessionsAtom);
+    const session = sessions.find((item) => item.id === params.sessionId);
+    if (
+      !session ||
+      Object.entries(params.info).every(([key, value]) =>
+        Object.is(session[key as keyof TerminalSession], value)
+      )
+    ) {
+      return;
+    }
+
     set(
       terminalSessionsAtom,
-      sessions.map((session) =>
-        session.id === params.sessionId
-          ? { ...session, ...params.info }
-          : session
+      sessions.map((item) =>
+        item.id === params.sessionId ? { ...item, ...params.info } : item
       )
     );
 


### PR DESCRIPTION
## Summary

- avoid clearing xterm's WebGL glyph atlas and forcing a full refresh during ordinary layout resize notifications
- keep managed TUI terminal launch inputs stable so runtime PTY metadata updates do not recreate xterm
- avoid redundant terminal metadata and tab-title state writes
- start Codex TUI in interactive mode rather than injecting prompt-required `codex exec` without a prompt

## Validation

- `pnpm exec vitest run src/components/TerminalInteractive/terminalSizing.test.ts src/store/workstation/codeEditor/terminal/__tests__/terminalAtoms.test.ts src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts src/api/tauri/agent/cliTerminalSession.test.ts --reporter=dot`
  - 4 test files, 51 tests passed
- `pnpm exec eslint` on the 11 changed TypeScript files
- `pnpm exec tsc --noEmit --pretty false`
- pre-commit hook (lint-staged and scoped TypeScript check)
