### PR TITLE
fix(runtime): harden reauth, replay, and Warp cache

### DIFF
--- a/docs/architecture-audit-2026-07-20/ReliabilityFixes.md
+++ b/docs/architecture-audit-2026-07-20/ReliabilityFixes.md
@@ -1,0 +1,77 @@
+# Architecture Audit — Reliability Fixes
+
+**Scope:** Warp imported-history cache, session-replay diff offsets, Codex OAuth repair routing, and editor-canvas token consumers
+**Date:** 2026-07-20
+**Auditor:** Codex
+
+## 10-layer audit
+
+### Layer 1 — Compilation correctness
+
+- Full TypeScript typecheck passes.
+- Targeted ESLint passes for every changed TypeScript/TSX file.
+- Forty-three targeted frontend tests and six Warp importer tests pass.
+- `orgtrack_core` clippy reports only the unchanged `qoder/log_enrichment.rs:128` baseline `type_complexity` diagnostic; the changed Warp module is clean.
+
+### Layer 2 — Dead code and structural deduplication
+
+- Diff start-line evidence is owned by `src/util/diff/startLines.ts`; both replay pipelines consume it.
+- Five editor-canvas class literals now consume the existing workstation token.
+- Warp cache synchronization decodes task protobufs only for records whose per-conversation signature changed.
+
+### Layer 3 — Naming consistency
+
+- `hasLoaded` means the initial local key-store request has settled.
+- `buildCodexReauthPath` and `parseCodexReauthIntent` form an explicit route codec.
+- Warp `signature` contains only per-conversation evidence rather than database-global metadata.
+
+### Layer 4 — Semantic overloading
+
+| Term               | Meaning                                                                                | Verdict                                                   |
+| ------------------ | -------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| reauth account     | Existing Codex account whose rotating OAuth credentials must be replaced               | Keep; distinct from adding an unrelated account.          |
+| source signature   | Per-conversation metadata sufficient to decide whether transcript decoding is required | Keep; no longer overloaded with whole-database WAL state. |
+| trusted start line | Offset backed by an ordinary edit, unified hunk, or concrete result diff               | Keep; shared predicate documents the contract.            |
+
+### Layer 5 — Default branch analysis
+
+- Ordinary Key Vault add flows are unchanged when `reauth=codex` is absent.
+- Missing diff events return `false`, avoiding placeholder line numbers.
+- An unavailable Warp database still clears the imported source cache through the existing empty-sync path.
+
+### Layer 6 — Cross-domain leakage
+
+- URL encoding remains in `config/mainAppPaths`; the chat error card only invokes the public builder.
+- Key-store readiness remains in key-vault hooks; the page does not infer readiness from array length.
+- Worker/database concerns do not leak into UI components.
+
+### Layer 7 — New-developer confusion test
+
+- The reauthentication route, return-state key, and auto-start intent are named at their ownership boundary.
+- Comments explain why Codex errors require reconnect rather than retry.
+- The Warp signature method makes incremental-cache evidence reviewable beside the record definition.
+
+### Layer 8 — Wire protocol and serialization
+
+- Reauth intent is URL-serializable and route-tested; return navigation accepts only `/orgii/app` paths.
+- No Rust/TypeScript wire type changed.
+- Warp cache columns retain the existing `ImportedHistoryRecordSignature` contract.
+
+### Layer 9 — Init parity
+
+| Entry point          | Account readiness                                 | OAuth callback                            | Return navigation       |
+| -------------------- | ------------------------------------------------- | ----------------------------------------- | ----------------------- |
+| Normal Key Vault add | Existing behavior                                 | Existing behavior                         | Models page             |
+| Codex error repair   | Waits for initial key load before mounting wizard | Desktop callback in Tauri dev and release | Original in-app session |
+| Web OAuth            | Existing behavior                                 | HTTP callback                             | Existing behavior       |
+
+### Layer 10 — Resolver symmetry
+
+- Reauth resolves an explicit account id first, then the sole Codex account fallback; the same resolved id is excluded from duplicate-name validation and used for saving.
+- Warp signature creation and cache-input creation call the same `record.signature` method.
+
+## Systematic sweep
+
+- Checked all `shouldTrustDiffStartLines` definitions and consumers; one implementation remains.
+- Checked exact `bg-[var(--cm-editor-background)]` TSX occurrences; all five use the shared token.
+- Checked all 13 `common` locale files; `errors.*` completeness is zero missing keys.

--- a/docs/frontend-ui-audit-2026-07-20/EditorCanvasToken.md
+++ b/docs/frontend-ui-audit-2026-07-20/EditorCanvasToken.md
@@ -1,0 +1,44 @@
+# Frontend UI Audit — Editor Canvas Token
+
+**Scope:** five changed `*.tsx` consumers of the CodeMirror editor-canvas background
+**Date:** 2026-07-20
+**Auditor:** Codex
+
+## D1 — Raw HTML vs Design System
+
+| Line | Element                         | Verdict          | Reason                                                                                                          | Suggested change |
+| ---: | ------------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------- | ---------------- |
+|    — | Existing containers and buttons | keep with reason | This sweep changes only background-token ownership; replacing established semantic elements would be unrelated. | None.            |
+
+## D2 — Arbitrary Tailwind Value vs Token
+
+|                            Line | Element                           | Verdict  | Reason                                                                                                          | Suggested change                  |
+| ------------------------------: | --------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+|     `ActivitySimulator.tsx:255` | Empty simulator canvas            | abstract | Repeated `bg-[var(--cm-editor-background)]` encoded the same workstation surface contract locally.              | Use `EDITOR_TAB_CANVAS_BG_CLASS`. |
+|  `SubagentPromptToggle.tsx:131` | Prompt dialog canvas              | abstract | Same editor-canvas background contract as the simulator and diff surfaces.                                      | Use `EDITOR_TAB_CANVAS_BG_CLASS`. |
+|       `CombinedDiffView.tsx:72` | Sticky diff header                | abstract | Same editor-canvas background contract as other workstation headers.                                            | Use `EDITOR_TAB_CANVAS_BG_CLASS`. |
+| `DiffFileSection/index.tsx:395` | Diff file header                  | abstract | Same editor-canvas background contract as other diff headers.                                                   | Use `EDITOR_TAB_CANVAS_BG_CLASS`. |
+|     `PanelHeader/index.tsx:294` | `editorCanvas` background variant | abstract | The named variant should resolve through the shared workstation token rather than restating its implementation. | Use `EDITOR_TAB_CANVAS_BG_CLASS`. |
+
+## D3 — Hardcoded Sizes / Colors
+
+| Line | Element                | Verdict          | Reason                                                                                                      | Suggested change |
+| ---: | ---------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------- | ---------------- |
+|    — | Changed surface colors | keep with reason | No literal color or new size was introduced; the sweep removes five repeated arbitrary-value class strings. | None.            |
+
+## D4 — Accessibility
+
+| Line | Element           | Verdict          | Reason                                                                                                | Suggested change |
+| ---: | ----------------- | ---------------- | ----------------------------------------------------------------------------------------------------- | ---------------- |
+|    — | Existing controls | keep with reason | Class composition only; roles, accessible names, focus behavior, and keyboard behavior are unchanged. | None.            |
+
+## D5 — Visual Patterns Observed
+
+- `EDITOR_TAB_CANVAS_BG_CLASS` is now the single shared expression for the five exact editor-canvas background uses in changed TSX surfaces.
+- No additional multi-file design-system sweep candidate was found in this scope.
+
+## Summary
+
+- 0 fixes recommended
+- 3 kept with documented reason
+- 5 abstract candidates completed

--- a/src-tauri/crates/orgtrack-core/src/sources/warp/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/warp/history.rs
@@ -20,9 +20,12 @@ use serde_json::{json, Value};
 
 use crate::sources::imported_history::{
     self, cache as imported_cache,
-    metadata::{ImportedHistoryCacheInput, ImportedHistoryImpactStats, SOURCE_WARP},
-    paths as imported_paths, ImportedHistoryRecentPath, ImportedHistorySessionPage,
-    ImportedHistorySessionRow, ImportedToolCall,
+    metadata::{
+        ImportedHistoryCacheInput, ImportedHistoryImpactStats, ImportedHistoryRecordSignature,
+        SOURCE_WARP,
+    },
+    ImportedHistoryRecentPath, ImportedHistorySessionPage, ImportedHistorySessionRow,
+    ImportedToolCall,
 };
 
 pub const WARP_SESSION_PREFIX: &str = "warpapp-";
@@ -86,6 +89,22 @@ struct WarpConversationRecord {
     summary_json: Option<String>,
     task_count: i64,
     task_bytes: i64,
+    task_last_modified_at: String,
+}
+
+impl WarpConversationRecord {
+    fn signature(&self, db_path: &Path) -> ImportedHistoryRecordSignature {
+        let conversation_modified = parse_warp_timestamp_ms(&self.last_modified_at).unwrap_or(0);
+        let task_modified = parse_warp_timestamp_ms(&self.task_last_modified_at).unwrap_or(0);
+        ImportedHistoryRecordSignature {
+            source_session_id: self.conversation_id.clone(),
+            source_path: db_path.to_string_lossy().to_string(),
+            source_mtime_ms: conversation_modified.max(task_modified),
+            source_size_bytes: self.task_bytes,
+            source_fingerprint: warp_source_fingerprint(self),
+            parser_version: WARP_METADATA_PARSER_VERSION,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -146,17 +165,18 @@ fn sync_warp_history_cache(cache_conn: &mut Connection) -> Result<(), String> {
         return Ok(());
     };
 
-    let (source_mtime_ms, source_size_bytes) =
-        imported_paths::file_metadata_signature(&db_path, "Warp")?;
-    let sidecar_signature = imported_paths::sqlite_sidecar_signature(&db_path);
     let records = list_conversation_records(&source_conn)?;
-    let live_ids = records
+    let signatures = records
         .iter()
-        .map(|record| record.conversation_id.clone())
+        .map(|record| record.signature(&db_path))
         .collect::<Vec<_>>();
-    let mut inputs = Vec::with_capacity(records.len());
+    let changed =
+        imported_cache::changed_records_from_conn(cache_conn, SOURCE_WARP, &records, |record| {
+            record.signature(&db_path)
+        })?;
+    let mut inputs = Vec::with_capacity(changed.len());
 
-    for record in records {
+    for record in changed {
         let fallback_ms = parse_warp_timestamp_ms(&record.last_modified_at).unwrap_or(0);
         let task_blobs = load_task_blobs(&source_conn, &record.conversation_id)?;
         let analysis = analyze_task_blobs(
@@ -165,16 +185,18 @@ fn sync_warp_history_cache(cache_conn: &mut Connection) -> Result<(), String> {
             fallback_ms,
         );
         inputs.push(conversation_to_cache_input(
-            record,
+            record.clone(),
             analysis,
             &db_path,
-            source_mtime_ms,
-            source_size_bytes,
-            &sidecar_signature,
         ));
     }
 
-    imported_cache::sync_source_cache_from_conn(cache_conn, SOURCE_WARP, live_ids, inputs)
+    imported_cache::sync_source_cache_from_conn(
+        cache_conn,
+        SOURCE_WARP,
+        imported_cache::live_ids_from_signatures(&signatures),
+        inputs,
+    )
 }
 
 fn list_conversation_records(conn: &Connection) -> Result<Vec<WarpConversationRecord>, String> {
@@ -190,7 +212,8 @@ fn list_conversation_records(conn: &Connection) -> Result<Vec<WarpConversationRe
         "SELECT c.conversation_id, c.conversation_data, \
                 CAST(c.last_modified_at AS TEXT), {summary_expr}, \
                 (SELECT COUNT(*) FROM agent_tasks t WHERE t.conversation_id = c.conversation_id), \
-                (SELECT COALESCE(SUM(LENGTH(t.task)), 0) FROM agent_tasks t WHERE t.conversation_id = c.conversation_id) \
+                (SELECT COALESCE(SUM(LENGTH(t.task)), 0) FROM agent_tasks t WHERE t.conversation_id = c.conversation_id), \
+                (SELECT COALESCE(MAX(CAST(t.last_modified_at AS TEXT)), '') FROM agent_tasks t WHERE t.conversation_id = c.conversation_id) \
          FROM agent_conversations c ORDER BY c.last_modified_at ASC, c.id ASC"
     );
     let mut stmt = conn
@@ -205,6 +228,7 @@ fn list_conversation_records(conn: &Connection) -> Result<Vec<WarpConversationRe
                 summary_json: row.get(3)?,
                 task_count: row.get::<_, Option<i64>>(4)?.unwrap_or_default(),
                 task_bytes: row.get::<_, Option<i64>>(5)?.unwrap_or_default(),
+                task_last_modified_at: row.get::<_, Option<String>>(6)?.unwrap_or_default(),
             })
         })
         .map_err(|err| format!("Failed to query Warp conversations: {err}"))?;
@@ -223,10 +247,8 @@ fn conversation_to_cache_input(
     record: WarpConversationRecord,
     analysis: WarpTaskAnalysis,
     db_path: &Path,
-    source_mtime_ms: i64,
-    source_size_bytes: i64,
-    sidecar_signature: &str,
 ) -> ImportedHistoryCacheInput {
+    let signature = record.signature(db_path);
     let summary = record
         .summary_json
         .as_deref()
@@ -263,7 +285,6 @@ fn conversation_to_cache_input(
     let updated_at_ms = analysis.updated_at_ms.unwrap_or(fallback_updated_at);
     let parent_session_id = non_empty(data.parent_conversation_id.as_deref())
         .map(|parent| format!("{WARP_SESSION_PREFIX}{parent}"));
-    let source_fingerprint = warp_source_fingerprint(&record, sidecar_signature);
     let listable =
         !data.is_remote_child && !summary.is_unlisted_auto_code_diff && !analysis.chunks.is_empty();
     let source_metadata_json = serde_json::to_string(&json!({
@@ -276,12 +297,12 @@ fn conversation_to_cache_input(
         source: SOURCE_WARP,
         source_session_id: record.conversation_id.clone(),
         session_id: format!("{WARP_SESSION_PREFIX}{}", record.conversation_id),
-        source_path: db_path.to_string_lossy().to_string(),
+        source_path: signature.source_path,
         source_record_key: record.conversation_id,
-        source_mtime_ms,
-        source_size_bytes,
-        source_fingerprint,
-        parser_version: WARP_METADATA_PARSER_VERSION,
+        source_mtime_ms: signature.source_mtime_ms,
+        source_size_bytes: signature.source_size_bytes,
+        source_fingerprint: signature.source_fingerprint,
+        parser_version: signature.parser_version,
         name: imported_history::truncate_name(&title, 200),
         created_at_ms,
         updated_at_ms,
@@ -299,7 +320,7 @@ fn conversation_to_cache_input(
     }
 }
 
-fn warp_source_fingerprint(record: &WarpConversationRecord, sidecar_signature: &str) -> String {
+fn warp_source_fingerprint(record: &WarpConversationRecord) -> String {
     [
         record.conversation_id.as_str(),
         record.conversation_data_json.as_str(),
@@ -307,7 +328,7 @@ fn warp_source_fingerprint(record: &WarpConversationRecord, sidecar_signature: &
         record.last_modified_at.as_str(),
         &record.task_count.to_string(),
         &record.task_bytes.to_string(),
-        sidecar_signature,
+        record.task_last_modified_at.as_str(),
     ]
     .join("|")
 }
@@ -325,12 +346,14 @@ fn analyze_task_blobs(
         }
     }
 
-    let mut analysis = WarpTaskAnalysis::default();
-    analysis.root_description = task_values
-        .iter()
-        .find(|task| is_root_task(task))
-        .and_then(|task| field_str(task, &["description"]))
-        .and_then(|value| non_empty(Some(value)));
+    let mut analysis = WarpTaskAnalysis {
+        root_description: task_values
+            .iter()
+            .find(|task| is_root_task(task))
+            .and_then(|task| field_str(task, &["description"]))
+            .and_then(|value| non_empty(Some(value))),
+        ..WarpTaskAnalysis::default()
+    };
 
     let mut messages = Vec::new();
     for (task_index, task) in task_values.iter().enumerate() {

--- a/src-tauri/crates/orgtrack-core/src/sources/warp/history_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/warp/history_tests.rs
@@ -143,14 +143,8 @@ fn metadata_uses_summary_usage_parent_and_invalidates_cache_signatures() {
         .expect("record");
     let blobs = load_task_blobs(&conn, "conversation-1").expect("task blobs");
     let analysis = analyze_task_blobs("warpapp-conversation-1", &blobs, 0);
-    let input = conversation_to_cache_input(
-        record.clone(),
-        analysis,
-        Path::new("/tmp/warp.sqlite"),
-        100,
-        200,
-        "wal:10",
-    );
+    let input =
+        conversation_to_cache_input(record.clone(), analysis, Path::new("/tmp/warp.sqlite"));
 
     assert_eq!(input.session_id, "warpapp-conversation-1");
     assert_eq!(input.name, "Warp importer");
@@ -186,7 +180,7 @@ fn metadata_uses_summary_usage_parent_and_invalidates_cache_signatures() {
         ..record
     };
     let mut content_changed = cached_signature.clone();
-    content_changed.source_fingerprint = warp_source_fingerprint(&changed, "wal:10");
+    content_changed.source_fingerprint = warp_source_fingerprint(&changed);
     assert!(!imported_cache::record_matches_cached_signature(
         &cached_signature,
         &content_changed

--- a/src/api/http/auth/supabase.ts
+++ b/src/api/http/auth/supabase.ts
@@ -8,7 +8,7 @@ import {
   SERVICE_AUTH_CONFIG,
   clearHostedToken,
   getCallbackUrl,
-  isTauriProduction,
+  isTauriRuntime,
   storeHostedToken,
   storeHostedUserId,
 } from "@src/config/serviceAuth";
@@ -73,12 +73,13 @@ export function syncHostedTokenFromSession(session: Session): TokenResponse {
 
 export async function signInWithSupabase(): Promise<void> {
   const supabase = getSupabaseAuthClient();
+  const tauriRuntime = isTauriRuntime();
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider: SERVICE_AUTH_CONFIG.oauthProvider,
     options: {
       redirectTo: getCallbackUrl(),
       scopes: SERVICE_AUTH_CONFIG.oauthScopes,
-      skipBrowserRedirect: isTauriProduction(),
+      skipBrowserRedirect: tauriRuntime,
     },
   });
 
@@ -86,7 +87,7 @@ export async function signInWithSupabase(): Promise<void> {
     throw error;
   }
 
-  if (isTauriProduction() && data.url) {
+  if (tauriRuntime && data.url) {
     const { open } = await import("@tauri-apps/plugin-shell");
     await open(data.url);
   }

--- a/src/config/__tests__/mainAppPaths.test.ts
+++ b/src/config/__tests__/mainAppPaths.test.ts
@@ -1,7 +1,9 @@
 import {
   SETTINGS_ROUTE_ROOT,
+  buildCodexReauthPath,
   classifySettingsRouteRoot,
   deriveRouteCacheKey,
+  parseCodexReauthIntent,
 } from "../mainAppPaths";
 
 describe("classifySettingsRouteRoot", () => {
@@ -24,6 +26,27 @@ describe("classifySettingsRouteRoot", () => {
     expect(
       classifySettingsRouteRoot("/orgii/app/settings/agent-orgs/orgs")
     ).toBe(SETTINGS_ROUTE_ROOT.AGENT_ORGS);
+  });
+});
+
+describe("Codex reauthentication route", () => {
+  it("opens the Key Vault wizard for the failed account and auto-starts OAuth", () => {
+    const path = buildCodexReauthPath("account-123");
+
+    expect(path).toBe(
+      "/orgii/app/settings/integrations/models?wizard=key-add&id=account-123&reauth=codex&autoStart=true"
+    );
+    expect(parseCodexReauthIntent(path.split("?")[1])).toEqual({
+      active: true,
+      autoStart: true,
+    });
+  });
+
+  it("does not activate for an ordinary Key Vault wizard", () => {
+    expect(parseCodexReauthIntent("?wizard=key-add")).toEqual({
+      active: false,
+      autoStart: false,
+    });
   });
 });
 

--- a/src/config/mainAppPaths.ts
+++ b/src/config/mainAppPaths.ts
@@ -21,8 +21,11 @@ export {
 export type { ExternalSkillsetsTab } from "./mainAppPaths/externalSkillsets";
 
 export {
+  buildCodexReauthPath,
   buildIntegrationsPath,
+  CODEX_REAUTH_RETURN_TO_STATE_KEY,
   INTEGRATIONS_CATEGORIES,
+  parseCodexReauthIntent,
   parseIntegrationsPath,
 } from "./mainAppPaths/integrations";
 export type {

--- a/src/config/mainAppPaths/integrations.ts
+++ b/src/config/mainAppPaths/integrations.ts
@@ -1,4 +1,5 @@
 import { SETTINGS_BASE, settingsPathParts } from "./shared";
+import { WIZARD_IDS, buildWizardPath } from "./wizards";
 
 export const EXTERNAL_SKILLSETS_URL_SEGMENT = "skills-mcps-plugins";
 
@@ -73,11 +74,43 @@ export interface IntegrationsPathOptions {
   category?: IntegrationsCategorySegment;
 }
 
+const CODEX_REAUTH_PARAM = "reauth";
+const CODEX_REAUTH_VALUE = "codex";
+const CODEX_REAUTH_AUTO_START_PARAM = "autoStart";
+
+export const CODEX_REAUTH_RETURN_TO_STATE_KEY = "codexReauthReturnTo";
+
 export function buildIntegrationsPath(
   options: IntegrationsPathOptions = {}
 ): string {
   const category = options.category ?? "models";
   return `${SETTINGS_BASE}/integrations/${toCategoryUrlSegment(category)}`;
+}
+
+/** Build the direct Key Vault route used to repair a Codex OAuth account. */
+export function buildCodexReauthPath(accountId?: string): string {
+  const wizardPath = buildWizardPath(
+    buildIntegrationsPath({ category: "models" }),
+    WIZARD_IDS.KEY_ADD,
+    accountId
+  );
+  const [pathname, search = ""] = wizardPath.split("?");
+  const params = new URLSearchParams(search);
+  params.set(CODEX_REAUTH_PARAM, CODEX_REAUTH_VALUE);
+  params.set(CODEX_REAUTH_AUTO_START_PARAM, "true");
+  return `${pathname}?${params.toString()}`;
+}
+
+export function parseCodexReauthIntent(search: string): {
+  active: boolean;
+  autoStart: boolean;
+} {
+  const params = new URLSearchParams(search);
+  const active = params.get(CODEX_REAUTH_PARAM) === CODEX_REAUTH_VALUE;
+  return {
+    active,
+    autoStart: active && params.get(CODEX_REAUTH_AUTO_START_PARAM) === "true",
+  };
 }
 
 export function parseIntegrationsPath(pathname: string): {

--- a/src/config/serviceAuth.test.ts
+++ b/src/config/serviceAuth.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getCallbackUrl,
+  isTauriProduction,
+  isTauriRuntime,
+} from "./serviceAuth";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("service auth runtime routing", () => {
+  it("uses the desktop callback during Tauri development", () => {
+    vi.stubGlobal("isTauri", true);
+    vi.stubGlobal("window", {
+      location: { origin: "http://localhost:1998" },
+    });
+
+    expect(isTauriRuntime()).toBe(true);
+    expect(isTauriProduction()).toBe(false);
+    expect(getCallbackUrl()).toBe("yorgai://marketplace/callback");
+  });
+
+  it("keeps the HTTP callback outside Tauri", () => {
+    vi.stubGlobal("isTauri", false);
+    vi.stubGlobal("window", {
+      location: { origin: "http://localhost:1998" },
+    });
+
+    expect(isTauriRuntime()).toBe(false);
+    expect(getCallbackUrl()).toBe(
+      "http://localhost:1998/orgii/marketplace/callback"
+    );
+  });
+});

--- a/src/config/serviceAuth.ts
+++ b/src/config/serviceAuth.ts
@@ -5,7 +5,10 @@
  * This file keeps the app-level hosted-service token cache that existing
  * API clients and guards consume.
  */
-import { invoke } from "@tauri-apps/api/core";
+import { invoke, isTauri } from "@tauri-apps/api/core";
+
+/** True for both development and production builds hosted by Tauri. */
+export const isTauriRuntime = (): boolean => isTauri();
 
 export const isTauriProduction = (): boolean => {
   if (typeof window === "undefined") return false;
@@ -13,7 +16,7 @@ export const isTauriProduction = (): boolean => {
 };
 
 export const getCallbackUrl = (): string => {
-  if (isTauriProduction()) {
+  if (isTauriRuntime()) {
     return "yorgai://marketplace/callback";
   }
   return `${window.location.origin}/orgii/marketplace/callback`;

--- a/src/engines/ChatPanel/ChatItems/AgentErrorChatItem.tsx
+++ b/src/engines/ChatPanel/ChatItems/AgentErrorChatItem.tsx
@@ -10,12 +10,23 @@
  * Subscribing here creates a nested Jotai listener chain that overflows the
  * call stack when the session snapshot changes (e.g. on tab switch).
  */
+import { useAtomValue } from "jotai";
 import React, { memo } from "react";
 import { useTranslation } from "react-i18next";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import InlineAlert from "@src/components/InlineAlert";
+import {
+  CODEX_REAUTH_RETURN_TO_STATE_KEY,
+  buildCodexReauthPath,
+} from "@src/config/mainAppPaths";
+import { sessionIdAtom } from "@src/engines/SessionCore/core/atoms";
+import { sessionByIdAtom } from "@src/store/session";
 
-import { sanitizeAgentErrorMessage } from "./sanitizeAgentErrorMessage";
+import {
+  requiresCodexReauthentication,
+  sanitizeAgentErrorMessage,
+} from "./sanitizeAgentErrorMessage";
 
 export interface AgentErrorChatItemProps {
   errorMessage: string;
@@ -24,13 +35,49 @@ export interface AgentErrorChatItemProps {
 const AgentErrorChatItem: React.FC<AgentErrorChatItemProps> = memo(
   ({ errorMessage }) => {
     const { t } = useTranslation();
+    const navigate = useNavigate();
+    const location = useLocation();
+    const sessionId = useAtomValue(sessionIdAtom);
+    const session = useAtomValue(sessionByIdAtom(sessionId ?? ""));
 
     const cleanMessage = sanitizeAgentErrorMessage(errorMessage);
+    const needsCodexReauthentication =
+      requiresCodexReauthentication(errorMessage);
+    const title = needsCodexReauthentication
+      ? t("errors.codexLoginExpired")
+      : t("errors.agentRequestFailed");
+    const action = needsCodexReauthentication
+      ? {
+          label: t("errors.reconnectCodex"),
+          onClick: () => {
+            const returnTo = `${location.pathname}${location.search}${location.hash}`;
+            navigate(buildCodexReauthPath(session?.accountId), {
+              state: { [CODEX_REAUTH_RETURN_TO_STATE_KEY]: returnTo },
+            });
+          },
+        }
+      : undefined;
 
     return (
       <div className="animate-fade-in">
-        <InlineAlert type="danger" title={t("errors.agentRequestFailed")}>
-          <div className="whitespace-pre-wrap break-words">{cleanMessage}</div>
+        <InlineAlert type="danger" title={title} action={action}>
+          {needsCodexReauthentication ? (
+            <>
+              <div>{t("errors.codexLoginExpiredDescription")}</div>
+              <details className="mt-2 opacity-70">
+                <summary className="cursor-pointer select-none">
+                  {t("errors.technicalDetails")}
+                </summary>
+                <div className="mt-1 whitespace-pre-wrap break-words">
+                  {cleanMessage}
+                </div>
+              </details>
+            </>
+          ) : (
+            <div className="whitespace-pre-wrap break-words">
+              {cleanMessage}
+            </div>
+          )}
         </InlineAlert>
       </div>
     );

--- a/src/engines/ChatPanel/ChatItems/__tests__/sanitizeAgentErrorMessage.test.ts
+++ b/src/engines/ChatPanel/ChatItems/__tests__/sanitizeAgentErrorMessage.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { sanitizeAgentErrorMessage } from "../sanitizeAgentErrorMessage";
+import {
+  requiresCodexReauthentication,
+  sanitizeAgentErrorMessage,
+} from "../sanitizeAgentErrorMessage";
 
 const HTML_500 = `<!doctype html>
 <html lang=en>
@@ -68,5 +71,35 @@ describe("sanitizeAgentErrorMessage", () => {
     expect(sanitizeAgentErrorMessage("   padded message   ")).toBe(
       "padded message"
     );
+  });
+});
+
+describe("requiresCodexReauthentication", () => {
+  it("recognizes a reused Codex OAuth refresh token", () => {
+    const raw =
+      '[session_launch] Auth error: Codex OAuth refresh failed with HTTP 401: {"code":"refresh_token_reused","message":"Please try signing in again."}';
+    expect(requiresCodexReauthentication(raw)).toBe(true);
+  });
+
+  it("recognizes a Codex invalid_grant response", () => {
+    expect(
+      requiresCodexReauthentication(
+        "Codex OAuth refresh failed: invalid_grant; try signing in again"
+      )
+    ).toBe(true);
+  });
+
+  it("does not turn a generic 401 into a Codex login prompt", () => {
+    expect(
+      requiresCodexReauthentication("HTTP 401 Unauthorized: invalid API key")
+    ).toBe(false);
+  });
+
+  it("does not route another provider's refresh failure to Codex", () => {
+    expect(
+      requiresCodexReauthentication(
+        "OAuth refresh_token_reused; try signing in again"
+      )
+    ).toBe(false);
   });
 });

--- a/src/engines/ChatPanel/ChatItems/sanitizeAgentErrorMessage.ts
+++ b/src/engines/ChatPanel/ChatItems/sanitizeAgentErrorMessage.ts
@@ -36,6 +36,21 @@ const HTML_HINT =
   /<!doctype html|<html[\s>]|<head[\s>]|<body[\s>]|<title[\s>]/i;
 const HTTP_STATUS = /\bHTTP\s+(\d{3})\b/i;
 
+/** Whether retrying cannot recover and the Codex OAuth account must reconnect. */
+export function requiresCodexReauthentication(raw: string): boolean {
+  const message = raw.toLowerCase();
+  if (!message) return false;
+
+  const hasCodexContext = message.includes("codex");
+  const hasReauthenticationSignal =
+    message.includes("refresh_token_reused") ||
+    message.includes("refresh token has already been used") ||
+    message.includes("try signing in again") ||
+    message.includes("invalid_grant");
+
+  return hasCodexContext && hasReauthenticationSignal;
+}
+
 /**
  * Convert a raw error message into a clean, bounded, single-block string safe
  * for `whitespace-pre-wrap` rendering.

--- a/src/engines/Simulator/ActivitySimulator.tsx
+++ b/src/engines/Simulator/ActivitySimulator.tsx
@@ -17,6 +17,7 @@ import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import React, { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { EDITOR_TAB_CANVAS_BG_CLASS } from "@src/config/workstation/tokens";
 import { RecentFilesProvider } from "@src/contexts/session";
 import { replayModeAtom } from "@src/engines/SessionCore";
 import type { ReplayMode } from "@src/engines/SessionCore/core/types";
@@ -250,7 +251,9 @@ const ActivitySimulator: React.FC = memo(() => {
 
   if (!hasSession) {
     return (
-      <div className="flex h-full w-full items-center justify-center bg-[var(--cm-editor-background)] p-4">
+      <div
+        className={`flex h-full w-full items-center justify-center p-4 ${EDITOR_TAB_CANVAS_BG_CLASS}`}
+      >
         <span className="text-sm text-text-3">
           {t("simulator.noActiveSession")}
         </span>

--- a/src/engines/Simulator/components/GridCell/SubagentPromptToggle.tsx
+++ b/src/engines/Simulator/components/GridCell/SubagentPromptToggle.tsx
@@ -21,6 +21,7 @@ import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
+import { EDITOR_TAB_CANVAS_BG_CLASS } from "@src/config/workstation/tokens";
 import {
   type ParsedTaskAssignedPrompt,
   parseTaskAssignedPrompt,
@@ -127,7 +128,7 @@ const SubagentPromptToggleComponent: React.FC<SubagentPromptToggleProps> = ({
             ref={panelRef}
             role="dialog"
             aria-label={label}
-            className="z-50 flex min-w-[280px] flex-col overflow-hidden rounded-lg border border-border-2 bg-[var(--cm-editor-background)] shadow-lg"
+            className={`z-50 flex min-w-[280px] flex-col overflow-hidden rounded-lg border border-border-2 shadow-lg ${EDITOR_TAB_CANVAS_BG_CLASS}`}
             style={panelStyle}
           >
             {prompt.parsed ? (

--- a/src/features/SessionSetup/components/CodexSessionSetup/index.tsx
+++ b/src/features/SessionSetup/components/CodexSessionSetup/index.tsx
@@ -37,6 +37,7 @@ export interface CodexSessionSetupProps {
   tokenError?: string | null;
   onClearTokenError?: () => void;
   closeSignal?: number;
+  autoStart?: boolean;
 }
 
 const CodexSessionSetup: React.FC<CodexSessionSetupProps> = ({
@@ -47,9 +48,10 @@ const CodexSessionSetup: React.FC<CodexSessionSetupProps> = ({
   tokenError = null,
   onClearTokenError,
   closeSignal = 0,
+  autoStart = false,
 }) => {
   const { t } = useTranslation("integrations");
-  const [showBrowser, setShowBrowser] = useState(false);
+  const [showBrowser, setShowBrowser] = useState(autoStart);
   const containerRef = useRef<HTMLDivElement>(null);
 
   const {

--- a/src/hooks/keyVault/types.ts
+++ b/src/hooks/keyVault/types.ts
@@ -111,6 +111,8 @@ export interface UseKeyVaultReturn {
   accounts: KeyVaultAccount[];
   localAccounts: KeyVaultAccount[];
   loading: boolean;
+  /** Whether the initial key-store load has settled at least once. */
+  hasLoaded: boolean;
   error: string | null;
   /** Refresh everything: accounts list + quotas + validation (all in parallel) */
   refresh: (force?: boolean) => Promise<void>;

--- a/src/hooks/keyVault/useKeyVault.ts
+++ b/src/hooks/keyVault/useKeyVault.ts
@@ -154,6 +154,7 @@ export function useKeyVault(
     accounts,
     localAccounts,
     loading: local.loading,
+    hasLoaded: local.hasLoaded,
     error: local.error,
     refresh,
     refreshAccount,

--- a/src/hooks/keyVault/useLocalKeys.ts
+++ b/src/hooks/keyVault/useLocalKeys.ts
@@ -54,6 +54,8 @@ export interface UseLocalKeysReturn {
   keysByAgentType: Map<ModelType, KeyInfo>;
   /** Loading state */
   loading: boolean;
+  /** Whether the initial key-store load has settled at least once. */
+  hasLoaded: boolean;
   /** Error message */
   error: string | null;
   /** Reload keys from the store */
@@ -84,6 +86,7 @@ export function useLocalKeys(
   // State
   const [allKeys, setAllKeys] = useState<KeyInfo[]>(getSharedLocalKeys);
   const [loading, setLoading] = useState(false);
+  const [hasLoaded, setHasLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // Track in-flight validations to prevent duplicates
@@ -121,6 +124,7 @@ export function useLocalKeys(
       setError(message);
       log.error("Failed to load keys:", err);
     } finally {
+      setHasLoaded(true);
       setLoading(false);
     }
   }, []);
@@ -395,6 +399,7 @@ export function useLocalKeys(
     allKeys,
     keysByAgentType,
     loading,
+    hasLoaded,
     error,
     refreshAgents,
     saveKey: saveKeyFn,

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -531,6 +531,10 @@
     "failedToRenderEvent": "Ereignis konnte nicht gerendert werden",
     "unknown": "Unbekannter Fehler",
     "agentRequestFailed": "Agent-Anfrage fehlgeschlagen",
+    "codexLoginExpired": "Codex-Anmeldung abgelaufen",
+    "codexLoginExpiredDescription": "Verbinde Codex erneut, um dieses Konto zu reparieren. Nach dem Speichern der neuen Anmeldung kehrst du zu dieser Sitzung zurück.",
+    "reconnectCodex": "Codex erneut verbinden",
+    "technicalDetails": "Technische Details",
     "failedToCopy": "Kopieren fehlgeschlagen",
     "api": {
       "titles": {

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -558,6 +558,10 @@
     "failedToRenderEvent": "Failed to render event",
     "unknown": "Unknown error",
     "agentRequestFailed": "Agent request failed",
+    "codexLoginExpired": "Codex sign-in expired",
+    "codexLoginExpiredDescription": "Reconnect Codex to repair this account. You will return to this session after the new sign-in is saved.",
+    "reconnectCodex": "Reconnect Codex",
+    "technicalDetails": "Technical details",
     "failedToCopy": "Failed to copy",
     "api": {
       "titles": {

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -531,6 +531,10 @@
     "failedToRenderEvent": "Error al renderizar el evento",
     "unknown": "Error desconocido",
     "agentRequestFailed": "Error en la solicitud del Agent",
+    "codexLoginExpired": "La sesión de Codex ha caducado",
+    "codexLoginExpiredDescription": "Vuelve a conectar Codex para reparar esta cuenta. Regresarás a esta sesión cuando se guarde el nuevo inicio de sesión.",
+    "reconnectCodex": "Volver a conectar Codex",
+    "technicalDetails": "Detalles técnicos",
     "failedToCopy": "No se pudo copiar",
     "api": {
       "titles": {

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -531,6 +531,10 @@
     "failedToRenderEvent": "Échec du rendu de l'événement",
     "unknown": "Erreur inconnue",
     "agentRequestFailed": "Échec de la requête Agent",
+    "codexLoginExpired": "La connexion à Codex a expiré",
+    "codexLoginExpiredDescription": "Reconnectez Codex pour réparer ce compte. Vous reviendrez à cette session une fois la nouvelle connexion enregistrée.",
+    "reconnectCodex": "Reconnecter Codex",
+    "technicalDetails": "Détails techniques",
     "failedToCopy": "Échec de la copie",
     "api": {
       "titles": {

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -531,6 +531,10 @@
     "failedToRenderEvent": "イベントのレンダリングに失敗しました",
     "unknown": "不明なエラー",
     "agentRequestFailed": "Agent リクエスト失敗",
+    "codexLoginExpired": "Codex のサインイン期限が切れました",
+    "codexLoginExpiredDescription": "このアカウントを修復するには Codex に再接続してください。新しいサインインを保存すると、このセッションに戻ります。",
+    "reconnectCodex": "Codex に再接続",
+    "technicalDetails": "技術的な詳細",
     "failedToCopy": "コピーに失敗しました",
     "api": {
       "titles": {

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -531,6 +531,10 @@
     "failedToRenderEvent": "이벤트 렌더링 실패",
     "unknown": "알 수 없는 오류",
     "agentRequestFailed": "Agent 요청 실패",
+    "codexLoginExpired": "Codex 로그인 만료",
+    "codexLoginExpiredDescription": "이 계정을 복구하려면 Codex에 다시 연결하세요. 새 로그인이 저장되면 이 세션으로 돌아옵니다.",
+    "reconnectCodex": "Codex 다시 연결",
+    "technicalDetails": "기술 세부 정보",
     "failedToCopy": "복사에 실패했습니다",
     "api": {
       "titles": {

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -532,6 +532,10 @@
     "failedToRenderEvent": "Nie udało się wyrenderować zdarzenia",
     "unknown": "Nieznany błąd",
     "agentRequestFailed": "Żądanie Agenta nie powiodło się",
+    "codexLoginExpired": "Logowanie do Codex wygasło",
+    "codexLoginExpiredDescription": "Połącz ponownie Codex, aby naprawić to konto. Po zapisaniu nowego logowania wrócisz do tej sesji.",
+    "reconnectCodex": "Połącz ponownie Codex",
+    "technicalDetails": "Szczegóły techniczne",
     "failedToCopy": "Nie udało się skopiować",
     "api": {
       "titles": {

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -532,6 +532,10 @@
     "failedToRenderEvent": "Falha ao renderizar evento",
     "unknown": "Erro desconhecido",
     "agentRequestFailed": "A requisição ao Agent falhou",
+    "codexLoginExpired": "A sessão do Codex expirou",
+    "codexLoginExpiredDescription": "Reconecte o Codex para reparar esta conta. Você retornará a esta sessão quando o novo login for salvo.",
+    "reconnectCodex": "Reconectar o Codex",
+    "technicalDetails": "Detalhes técnicos",
     "failedToCopy": "Falha ao copiar",
     "api": {
       "titles": {

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -531,6 +531,10 @@
     "failedToRenderEvent": "Не удалось отобразить событие",
     "unknown": "Неизвестная ошибка",
     "agentRequestFailed": "Ошибка запроса Agent",
+    "codexLoginExpired": "Срок входа в Codex истёк",
+    "codexLoginExpiredDescription": "Повторно подключите Codex, чтобы восстановить эту учётную запись. После сохранения нового входа вы вернётесь к этому сеансу.",
+    "reconnectCodex": "Повторно подключить Codex",
+    "technicalDetails": "Технические сведения",
     "failedToCopy": "Не удалось скопировать",
     "api": {
       "titles": {

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -531,6 +531,10 @@
     "failedToRenderEvent": "Olay oluşturulamadı",
     "unknown": "Bilinmeyen hata",
     "agentRequestFailed": "Agent isteği başarısız oldu",
+    "codexLoginExpired": "Codex oturumunun süresi doldu",
+    "codexLoginExpiredDescription": "Bu hesabı onarmak için Codex'e yeniden bağlanın. Yeni oturum kaydedildiğinde bu oturuma geri döneceksiniz.",
+    "reconnectCodex": "Codex'e yeniden bağlan",
+    "technicalDetails": "Teknik ayrıntılar",
     "failedToCopy": "Kopyalanamadı",
     "api": {
       "titles": {

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -531,6 +531,10 @@
     "failedToRenderEvent": "Không thể hiển thị sự kiện",
     "unknown": "Lỗi không xác định",
     "agentRequestFailed": "Yêu cầu Agent thất bại",
+    "codexLoginExpired": "Phiên đăng nhập Codex đã hết hạn",
+    "codexLoginExpiredDescription": "Kết nối lại Codex để khôi phục tài khoản này. Bạn sẽ quay lại phiên này sau khi thông tin đăng nhập mới được lưu.",
+    "reconnectCodex": "Kết nối lại Codex",
+    "technicalDetails": "Chi tiết kỹ thuật",
     "failedToCopy": "Sao chép thất bại",
     "api": {
       "titles": {

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -544,6 +544,10 @@
     "failedToRenderEvent": "渲染事件失敗",
     "unknown": "未知錯誤",
     "agentRequestFailed": "Agent 請求失敗",
+    "codexLoginExpired": "Codex 登入已過期",
+    "codexLoginExpiredDescription": "重新連接 Codex 以修復此帳戶。儲存新的登入資訊後，你將返回此工作階段。",
+    "reconnectCodex": "重新連接 Codex",
+    "technicalDetails": "技術詳細資訊",
     "failedToCopy": "複製失敗",
     "api": {
       "titles": {

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -545,6 +545,10 @@
     "failedToRenderEvent": "渲染事件失败",
     "unknown": "未知错误",
     "agentRequestFailed": "Agent 请求失败",
+    "codexLoginExpired": "Codex 登录已失效",
+    "codexLoginExpiredDescription": "重新连接 Codex 即可修复此账号；登录并保存后会返回当前会话。",
+    "reconnectCodex": "重新连接 Codex",
+    "technicalDetails": "技术详情",
     "failedToCopy": "复制失败",
     "api": {
       "titles": {

--- a/src/modules/MainApp/Integrations/KeyVault/AccountCategoryView.tsx
+++ b/src/modules/MainApp/Integrations/KeyVault/AccountCategoryView.tsx
@@ -20,7 +20,10 @@ export const AccountCategoryView: React.FC<{
         onSubmit={accounts.handleFormSubmit}
         onCancel={accounts.handleFormCancel}
         loading={accounts.formLoading}
-        existingAccountNames={accounts.accounts.map((account) => account.name)}
+        initialAgentType={accounts.formInitialAgentType}
+        initialData={accounts.formInitialData}
+        autoStartCodexLogin={accounts.autoStartCodexLogin}
+        existingAccountNames={accounts.formExistingAccountNames}
       />
     );
   }

--- a/src/modules/MainApp/Integrations/KeyVault/hooks/useKeyVaultPage.ts
+++ b/src/modules/MainApp/Integrations/KeyVault/hooks/useKeyVaultPage.ts
@@ -14,13 +14,18 @@
 import { useSetAtom } from "jotai";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import { getFullKey, validateKey } from "@src/api/services/keyValidation";
 import type { SaveKeyRequest as RpcSaveKeyRequest } from "@src/api/tauri/rpc/schemas/validation";
 import type { ModelType, SaveKeyRequest } from "@src/api/types/keys";
 import Message from "@src/components/Message";
-import { WIZARD_IDS, buildIntegrationsPath } from "@src/config/mainAppPaths";
+import {
+  CODEX_REAUTH_RETURN_TO_STATE_KEY,
+  WIZARD_IDS,
+  buildIntegrationsPath,
+  parseCodexReauthIntent,
+} from "@src/config/mainAppPaths";
 import { useKeyVault } from "@src/hooks/keyVault";
 import { createLogger } from "@src/hooks/logger";
 import { useWizardParam } from "@src/hooks/navigation";
@@ -36,12 +41,25 @@ import {
 
 const log = createLogger("KeyVaultPage");
 
+function readCodexReauthReturnTo(state: unknown): string | null {
+  if (!state || typeof state !== "object") return null;
+  const returnTo = (state as Record<string, unknown>)[
+    CODEX_REAUTH_RETURN_TO_STATE_KEY
+  ];
+  return typeof returnTo === "string" &&
+    (returnTo === "/orgii/app" || returnTo.startsWith("/orgii/app/"))
+    ? returnTo
+    : null;
+}
+
 export function useKeyVaultPage() {
   const { t } = useTranslation("integrations");
   const navigate = useNavigate();
+  const location = useLocation();
   const {
     accounts,
     loading,
+    hasLoaded,
     error,
     refresh,
     refreshAccount,
@@ -67,12 +85,35 @@ export function useKeyVaultPage() {
   const [refreshingAllModels, setRefreshingAllModels] = useState(false);
 
   // Wizard open-state derived from URL
-  const { wizard, openWizard } = useWizardParam();
+  const { wizard, entityId, openWizard } = useWizardParam();
   const showAddForm = wizard === WIZARD_IDS.KEY_ADD;
+  const codexReauthIntent = parseCodexReauthIntent(location.search);
+  const isCodexReauth = showAddForm && codexReauthIntent.active;
+  const explicitReauthAccount = entityId ? getAccount(entityId) : undefined;
+  const soleCodexAccount = useMemo(() => {
+    const codexAccounts = accounts.filter(
+      (account) => account.modelType === "codex"
+    );
+    return codexAccounts.length === 1 ? codexAccounts[0] : undefined;
+  }, [accounts]);
+  const reauthAccount = isCodexReauth
+    ? (explicitReauthAccount ?? soleCodexAccount)
+    : undefined;
+  const reauthAccountId =
+    reauthAccount?.id ?? (isCodexReauth ? entityId : null);
+  const isResolvingReauthAccount =
+    isCodexReauth && !hasLoaded && !reauthAccount;
+  const reauthReturnTo = isCodexReauth
+    ? readCodexReauthReturnTo(location.state)
+    : null;
 
   const closeKeyVaultWizard = useCallback(() => {
+    if (reauthReturnTo) {
+      navigate(reauthReturnTo, { replace: true });
+      return;
+    }
     navigate(buildIntegrationsPath({ category: "models" }), { replace: true });
-  }, [navigate]);
+  }, [navigate, reauthReturnTo]);
 
   // Initial load
   useEffect(() => {
@@ -225,6 +266,7 @@ export function useKeyVaultPage() {
       try {
         const saveRequest: SaveKeyRequest = {
           ...(data as SaveKeyRequest),
+          ...(reauthAccountId ? { id: reauthAccountId } : {}),
           has_local_key: true,
           is_listed: false,
         };
@@ -242,7 +284,7 @@ export function useKeyVaultPage() {
         setFormLoading(false);
       }
     },
-    [saveKey, refresh, t, closeKeyVaultWizard]
+    [saveKey, refresh, t, closeKeyVaultWizard, reauthAccountId]
   );
 
   const handleEditAccountSave = useCallback(
@@ -319,9 +361,20 @@ export function useKeyVaultPage() {
     agentTypeFilter,
 
     // Form state
-    showAddForm,
+    showAddForm: showAddForm && !isResolvingReauthAccount,
     formLoading,
     selectedAccountId,
+    formInitialAgentType: isCodexReauth ? ("codex" as const) : undefined,
+    formInitialData: isCodexReauth
+      ? {
+          name: reauthAccount?.name ?? "",
+          setup_method: "signin",
+        }
+      : undefined,
+    formExistingAccountNames: accounts
+      .filter((account) => account.id !== reauthAccountId)
+      .map((account) => account.name),
+    autoStartCodexLogin: isCodexReauth && codexReauthIntent.autoStart,
 
     // Handlers
     handleAccountSelect,

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/CodePanel/CombinedDiffView.tsx
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/CodePanel/CombinedDiffView.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
 import DiffStatsBadge from "@src/components/DiffStatsBadge";
+import { EDITOR_TAB_CANVAS_BG_CLASS } from "@src/config/workstation/tokens";
 import { VirtualizedModernDiff } from "@src/features/CodeViewer/VirtualizedModernDiff";
 
 import { shouldTrustDiffStartLines } from "../converters/fileConverter";
@@ -68,7 +69,7 @@ const EditSection: React.FC<{
     <div className="flex flex-col">
       <button
         onClick={toggleCollapse}
-        className="sticky top-0 z-10 flex h-10 w-full cursor-pointer items-center gap-2 border-t border-border-2 bg-[var(--cm-editor-background)] px-3 text-[11px] hover:bg-fill-2"
+        className={`sticky top-0 z-10 flex h-10 w-full cursor-pointer items-center gap-2 border-t border-border-2 px-3 text-[11px] hover:bg-fill-2 ${EDITOR_TAB_CANVAS_BG_CLASS}`}
       >
         {isCollapsed ? (
           <ChevronsUpDown size={14} className="shrink-0 text-text-3" />

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/converters/fileConverter.ts
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/converters/fileConverter.ts
@@ -14,6 +14,7 @@ import { getAppSubtool } from "@src/engines/SessionCore/rendering/registry/initT
 import { isDeleteTool } from "@src/engines/SessionCore/rendering/registry/toolRegistryDomain";
 import type { EventStatus } from "@src/engines/SessionCore/rendering/types/universalProps";
 import { getEventStatus } from "@src/util/data/converters/eventStatus";
+import { shouldTrustDiffStartLines } from "@src/util/diff/startLines";
 
 import {
   FILE_OPERATION_TYPE,
@@ -22,8 +23,6 @@ import {
 } from "../types";
 
 const HUNK_HEADER_REGEX = /^@@\s+-(\d+)(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/;
-const PATCH_HUNK_HEADER_REGEX =
-  /^@@\s+-(\d+)(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/m;
 
 interface ParsedUnifiedDiffPayload {
   oldContent: string;
@@ -107,37 +106,7 @@ function parseUnifiedDiffPayload(
   };
 }
 
-function patchTextFromArgs(args: SessionEvent["args"]): string | undefined {
-  if (typeof args?.patch_text === "string") return args.patch_text;
-  if (typeof args?.patch === "string") return args.patch;
-  if (typeof args?.input === "string") return args.input;
-  return undefined;
-}
-
-function resultHasRealDiff(result: SessionEvent["result"]): boolean {
-  if (!result) return false;
-  if (
-    typeof result.diffString === "string" ||
-    typeof result.diff === "string"
-  ) {
-    return true;
-  }
-  if (Array.isArray(result.segments) && result.segments.length > 0) {
-    return true;
-  }
-  const output = result.output as Record<string, unknown> | undefined;
-  const success = output?.success as Record<string, unknown> | undefined;
-  return Boolean(
-    typeof success?.diffString === "string" || typeof success?.diff === "string"
-  );
-}
-
-export function shouldTrustDiffStartLines(event: SessionEvent): boolean {
-  const patchText = patchTextFromArgs(event.args);
-  if (!patchText) return true;
-  if (PATCH_HUNK_HEADER_REGEX.test(patchText)) return true;
-  return resultHasRealDiff(event.result);
-}
+export { shouldTrustDiffStartLines } from "@src/util/diff/startLines";
 
 export function parseFilePath(path: string): {
   fileName: string;

--- a/src/modules/WorkStation/shared/DiffFileSection/index.tsx
+++ b/src/modules/WorkStation/shared/DiffFileSection/index.tsx
@@ -18,6 +18,7 @@ import {
   getStatusColor,
   getStatusLetterForFile,
 } from "@src/config/gitStatus";
+import { EDITOR_TAB_CANVAS_BG_CLASS } from "@src/config/workstation/tokens";
 import { CodeMirrorDiff } from "@src/features/CodeMirror";
 import { FileHeader } from "@src/modules/shared/components/FileHeader";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
@@ -391,7 +392,7 @@ const DiffFileSection: React.FC<DiffFileSectionProps> = ({
         data-diff-section-path={dataPath}
       >
         <button
-          className="sticky top-0 z-10 flex w-full min-w-0 items-center gap-2 bg-[var(--cm-editor-background)] px-3 py-2 text-left hover:bg-fill-2 disabled:cursor-default disabled:hover:bg-transparent"
+          className={`sticky top-0 z-10 flex w-full min-w-0 items-center gap-2 px-3 py-2 text-left hover:bg-fill-2 disabled:cursor-default disabled:hover:bg-transparent ${EDITOR_TAB_CANVAS_BG_CLASS}`}
           onClick={toggleExpanded}
           disabled={isDeleted}
         >

--- a/src/modules/WorkStation/shared/DiffSectionList/sessionReplaySections.ts
+++ b/src/modules/WorkStation/shared/DiffSectionList/sessionReplaySections.ts
@@ -5,13 +5,11 @@ import {
   parseUnifiedDiffToOldNew,
 } from "@src/engines/SessionCore/rendering/props/propsDataExtractors";
 import { normalizeEventProps } from "@src/engines/SessionCore/rendering/props/propsNormalizer";
+import { shouldTrustDiffStartLines } from "@src/util/diff/startLines";
 import { normalizeDiffFilePath } from "@src/util/file/pathUtils";
 
 import type { DiffFileSectionData } from "../DiffFileSection";
 import type { DiffSectionListItem } from "./index";
-
-const PATCH_HUNK_HEADER_REGEX =
-  /^@@\s+-(\d+)(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/m;
 
 export interface SessionReplayDiffEntryLike {
   entryId: string;
@@ -24,38 +22,6 @@ export interface SessionReplayDiffSectionItem extends DiffSectionListItem<DiffFi
   entryIds: string[];
   /** Raw compact diff strings from each edit, used for multi-hunk merge during consolidation. */
   rawDiffs: string[];
-}
-
-function patchTextFromArgs(args: SessionEvent["args"]): string | undefined {
-  if (typeof args?.patch_text === "string") return args.patch_text;
-  if (typeof args?.patch === "string") return args.patch;
-  if (typeof args?.input === "string") return args.input;
-  return undefined;
-}
-
-function resultHasRealDiff(result: SessionEvent["result"]): boolean {
-  if (!result) return false;
-  if (
-    typeof result.diffString === "string" ||
-    typeof result.diff === "string"
-  ) {
-    return true;
-  }
-  if (Array.isArray(result.segments) && result.segments.length > 0) {
-    return true;
-  }
-  const output = result.output as Record<string, unknown> | undefined;
-  const success = output?.success as Record<string, unknown> | undefined;
-  return Boolean(
-    typeof success?.diffString === "string" || typeof success?.diff === "string"
-  );
-}
-
-function shouldTrustDiffStartLines(event: SessionEvent): boolean {
-  const patchText = patchTextFromArgs(event.args);
-  if (!patchText) return true;
-  if (PATCH_HUNK_HEADER_REGEX.test(patchText)) return true;
-  return resultHasRealDiff(event.result);
 }
 
 function getDiffStatus(

--- a/src/modules/shared/layouts/blocks/PanelHeader/index.tsx
+++ b/src/modules/shared/layouts/blocks/PanelHeader/index.tsx
@@ -41,6 +41,7 @@ import {
 import React, { createContext, memo, useContext } from "react";
 
 import Button from "@src/components/Button";
+import { EDITOR_TAB_CANVAS_BG_CLASS } from "@src/config/workstation/tokens";
 import { useRefreshSpin } from "@src/hooks/ui";
 
 /**
@@ -290,7 +291,7 @@ const PanelHeader: React.FC<PanelHeaderProps> = memo(
       resolvedBackground === "transparent"
         ? ""
         : resolvedBackground === "editorCanvas"
-          ? "bg-[var(--cm-editor-background)]"
+          ? EDITOR_TAB_CANVAS_BG_CLASS
           : "bg-bg-2";
 
     // Render custom content or default title/breadcrumb

--- a/src/scaffold/WizardSystem/variants/KeyVault/components/AgentSetupRouter.tsx
+++ b/src/scaffold/WizardSystem/variants/KeyVault/components/AgentSetupRouter.tsx
@@ -53,6 +53,7 @@ interface AgentSetupRouterProps extends AgentSetupProps {
   handleSessionTokenCaptured: (sessionToken: string) => void;
   handleUrlChange: (url: string) => void;
   hasSessionToken: boolean;
+  autoStartCodexLogin?: boolean;
 }
 
 /**
@@ -78,6 +79,7 @@ export const AgentSetupRouter: React.FC<AgentSetupRouterProps> = ({
   handleSessionTokenCaptured,
   handleUrlChange,
   hasSessionToken,
+  autoStartCodexLogin,
   ...sharedProps
 }) => {
   const { onChange } = sharedProps;
@@ -122,6 +124,7 @@ export const AgentSetupRouter: React.FC<AgentSetupRouterProps> = ({
           onDetectToken={sharedProps.onAutoDetect ?? (() => {})}
           onClearTokenError={clearTokenError}
           preselectedMethod={isComplex ? setupMethod : undefined}
+          autoStartLogin={autoStartCodexLogin}
           onSessionCaptured={async (values: CodexSessionValues) => {
             let catalog: OAuthModelCatalog = {
               models: [],

--- a/src/scaffold/WizardSystem/variants/KeyVault/components/ApiSetup.tsx
+++ b/src/scaffold/WizardSystem/variants/KeyVault/components/ApiSetup.tsx
@@ -48,6 +48,7 @@ const ApiSetup: React.FC<ApiSetupProps> = ({
   existingAccountNames,
   browserCloseSignal = 0,
   onBrowserStateChange,
+  autoStartCodexLogin = false,
 }) => {
   const { t } = useTranslation("integrations");
   const hook = useApiSetup({ data, onChange });
@@ -413,6 +414,7 @@ const ApiSetup: React.FC<ApiSetupProps> = ({
               handleSessionTokenCaptured={hook.handleSessionTokenCaptured}
               handleUrlChange={hook.handleUrlChange}
               hasSessionToken={hook.hasSessionToken}
+              autoStartCodexLogin={autoStartCodexLogin}
             />
           )}
 

--- a/src/scaffold/WizardSystem/variants/KeyVault/components/KeyVaultWizard.tsx
+++ b/src/scaffold/WizardSystem/variants/KeyVault/components/KeyVaultWizard.tsx
@@ -26,6 +26,7 @@ const KeyVaultWizard: React.FC<KeyVaultWizardProps> = ({
   initialAgentType,
   title,
   initialData,
+  autoStartCodexLogin = false,
   primaryProvidersOnly = true,
   existingAccountNames,
 }) => {
@@ -99,6 +100,7 @@ const KeyVaultWizard: React.FC<KeyVaultWizardProps> = ({
         loading={loading}
         browserCloseSignal={browserCloseSignal}
         onBrowserStateChange={setBrowserOpen}
+        autoStartCodexLogin={autoStartCodexLogin}
       />
     </WizardShell>
   );

--- a/src/scaffold/WizardSystem/variants/KeyVault/components/setup/CodexSetup.tsx
+++ b/src/scaffold/WizardSystem/variants/KeyVault/components/setup/CodexSetup.tsx
@@ -38,6 +38,7 @@ const CodexSetup: React.FC<CodexSetupProps> = ({
   browserOpen,
   setBrowserOpen,
   browserCloseSignal,
+  autoStartLogin = false,
 }) => {
   const { t } = useTranslation("integrations");
 
@@ -118,6 +119,7 @@ const CodexSetup: React.FC<CodexSetupProps> = ({
           onSessionCaptured={onSessionCaptured}
           onBrowserStateChange={setBrowserOpen}
           closeSignal={browserCloseSignal}
+          autoStart={autoStartLogin}
         />
       )}
 

--- a/src/scaffold/WizardSystem/variants/KeyVault/components/setup/types.ts
+++ b/src/scaffold/WizardSystem/variants/KeyVault/components/setup/types.ts
@@ -121,6 +121,7 @@ export interface CodexSetupProps extends AgentSetupProps {
   onClearTokenError?: () => void;
   onSessionCaptured?: (values: CodexSessionValues) => void;
   preselectedMethod?: string;
+  autoStartLogin?: boolean;
 }
 
 export interface KiroSetupProps extends AgentSetupProps {

--- a/src/scaffold/WizardSystem/variants/KeyVault/types/index.ts
+++ b/src/scaffold/WizardSystem/variants/KeyVault/types/index.ts
@@ -139,6 +139,8 @@ export interface KeyVaultWizardProps {
   title?: string;
   /** Initial data to pre-fill the wizard */
   initialData?: Partial<WizardData>;
+  /** Open the embedded Codex OAuth browser immediately for a repair flow. */
+  autoStartCodexLogin?: boolean;
   /** Limit displayed providers to primary ones with region restrictions (Cursor, OpenAI, Anthropic, Google, OpenRouter) */
   primaryProvidersOnly?: boolean;
   /** Existing account names — used to generate default names and reject duplicate custom names. */
@@ -161,4 +163,5 @@ export interface ApiSetupProps {
   existingAccountNames?: string[];
   browserCloseSignal?: number;
   onBrowserStateChange?: (isOpen: boolean) => void;
+  autoStartCodexLogin?: boolean;
 }

--- a/src/util/diff/__tests__/startLines.test.ts
+++ b/src/util/diff/__tests__/startLines.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldTrustDiffStartLines } from "../startLines";
+
+describe("shouldTrustDiffStartLines", () => {
+  it("rejects missing events", () => {
+    expect(shouldTrustDiffStartLines(null)).toBe(false);
+    expect(shouldTrustDiffStartLines(undefined)).toBe(false);
+  });
+
+  it("trusts ordinary edits and unified diff hunks", () => {
+    expect(shouldTrustDiffStartLines({ args: {} })).toBe(true);
+    expect(
+      shouldTrustDiffStartLines({
+        args: { patch: "@@ -4,2 +9,3 @@\n-old\n+new" },
+      })
+    ).toBe(true);
+  });
+
+  it("rejects compact patch placeholders unless the result has a real diff", () => {
+    const compactPatch = { args: { patch: "*** Begin Patch" } };
+    expect(shouldTrustDiffStartLines(compactPatch)).toBe(false);
+    expect(
+      shouldTrustDiffStartLines({
+        ...compactPatch,
+        result: { output: { success: { diffString: "@@ -1 +1 @@" } } },
+      })
+    ).toBe(true);
+  });
+});

--- a/src/util/diff/startLines.ts
+++ b/src/util/diff/startLines.ts
@@ -1,0 +1,45 @@
+interface DiffStartLineEvidence {
+  args?: Record<string, unknown>;
+  result?: Record<string, unknown>;
+}
+
+const PATCH_HUNK_HEADER_REGEX =
+  /^@@\s+-(\d+)(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/m;
+
+function patchTextFromArgs(
+  args: DiffStartLineEvidence["args"]
+): string | undefined {
+  if (typeof args?.patch_text === "string") return args.patch_text;
+  if (typeof args?.patch === "string") return args.patch;
+  if (typeof args?.input === "string") return args.input;
+  return undefined;
+}
+
+function resultHasRealDiff(result: DiffStartLineEvidence["result"]): boolean {
+  if (!result) return false;
+  if (
+    typeof result.diffString === "string" ||
+    typeof result.diff === "string"
+  ) {
+    return true;
+  }
+  if (Array.isArray(result.segments) && result.segments.length > 0) {
+    return true;
+  }
+  const output = result.output as Record<string, unknown> | undefined;
+  const success = output?.success as Record<string, unknown> | undefined;
+  return Boolean(
+    typeof success?.diffString === "string" || typeof success?.diff === "string"
+  );
+}
+
+/** Whether line offsets attached to a file event are backed by a real diff. */
+export function shouldTrustDiffStartLines(
+  event: DiffStartLineEvidence | null | undefined
+): boolean {
+  if (!event) return false;
+  const patchText = patchTextFromArgs(event.args);
+  if (!patchText) return true;
+  if (PATCH_HUNK_HEADER_REGEX.test(patchText)) return true;
+  return resultHasRealDiff(event.result);
+}


### PR DESCRIPTION
## Summary
- add a direct Codex OAuth repair flow that waits for Key Vault initialization and returns to the failed session
- use Tauri runtime detection for desktop OAuth in both development and release builds
- centralize null-safe diff start-line evidence and editor-canvas styling tokens
- make Warp history synchronization decode only conversations whose per-record signature changed
- include independent architecture and frontend UI audit reports

## Validation
- full pnpm typecheck
- targeted ESLint for all changed TypeScript and TSX files
- 43 targeted Vitest tests
- 6 Warp importer tests
- common errors i18n completeness across 13 locales: 0 missing
- pre-commit lint-staged, scoped TypeScript, and scoped orgtrack_core clippy