### PR TITLE
fix(code editor): clarify repeated file operation order

### DIFF
--- a/src/modules/WorkStation/CodeEditor/SessionReplay/FileSidebar.tsx
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/FileSidebar.tsx
@@ -26,6 +26,7 @@ import {
 import { PANEL_CONSTANTS } from "../Panels/EditorPrimarySidebar/config";
 import { getShellStatusBadge } from "./ShellSidebar";
 import SimulatorTreePanel from "./components/SimulatorTreePanel";
+import { buildFileOperationSequenceInfo } from "./fileOperationSequence";
 import type { FileTreeInput } from "./fileTreeUtils";
 import { resolveFileOperationPayload } from "./resolveFilePayload";
 import type {
@@ -131,68 +132,91 @@ const FileSidebarComponent: React.FC<FileSidebarProps> = ({
   // buildFileTree / flattenFileTree only re-run when the actual file set
   // changes, NOT on every currentEventId navigation.
 
+  const readOperations = useMemo(
+    () => fileOperations.filter((op) => op.type === FILE_OPERATION_TYPE.READ),
+    [fileOperations]
+  );
+  const readSequenceInfo = useMemo(
+    () => buildFileOperationSequenceInfo(readOperations),
+    [readOperations]
+  );
+
   const readFileKey = useMemo(
     () =>
-      fileOperations
-        .filter((op) => op.type === FILE_OPERATION_TYPE.READ)
-        .map((op) => op.eventId)
+      readOperations
+        .map((op) => `${op.eventId}:${op.event?.createdAt ?? ""}`)
         .join(","),
-    [fileOperations]
+    [readOperations]
   );
 
   const readItems: FileTreeInput[] = useMemo(
     () =>
-      fileOperations
-        .filter((op) => op.type === FILE_OPERATION_TYPE.READ)
-        .map((op) => ({
+      readOperations.map((op) => {
+        const sequence = readSequenceInfo.get(op.eventId);
+        return {
           id: op.eventId,
           filePath: op.filePath,
           fileName: op.fileName,
-        })),
+          secondaryInfo: sequence
+            ? `${sequence.sequenceLabel} · ${sequence.pathHint}`
+            : undefined,
+        };
+      }),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed by readFileKey
-    [readFileKey]
+    [readFileKey, readSequenceInfo]
+  );
+
+  const writeOperations = useMemo(
+    () =>
+      fileOperations.filter(
+        (op) =>
+          op.type === FILE_OPERATION_TYPE.WRITE ||
+          op.type === FILE_OPERATION_TYPE.DELETE
+      ),
+    [fileOperations]
+  );
+  const writeSequenceInfo = useMemo(
+    () => buildFileOperationSequenceInfo(writeOperations),
+    [writeOperations]
   );
 
   const writeFileKey = useMemo(
     () =>
-      fileOperations
-        .filter(
-          (op) =>
-            op.type === FILE_OPERATION_TYPE.WRITE ||
-            op.type === FILE_OPERATION_TYPE.DELETE
-        )
+      writeOperations
         .map((op) => {
-          if (op.type === FILE_OPERATION_TYPE.DELETE) return `${op.eventId}:D`;
+          if (op.type === FILE_OPERATION_TYPE.DELETE) {
+            return `${op.eventId}:D:${op.event?.createdAt ?? ""}`;
+          }
           const hasBaseline =
             op.writeHasBaselineContent !== undefined
               ? op.writeHasBaselineContent
               : Boolean(resolveFileOperationPayload(op).oldContent);
-          return `${op.eventId}:${hasBaseline ? "M" : "A"}`;
+          return `${op.eventId}:${hasBaseline ? "M" : "A"}:${op.event?.createdAt ?? ""}:${op.editCount ?? 1}`;
         })
         .join(","),
-    [fileOperations]
+    [writeOperations]
   );
 
   const writeItems: FileTreeInput[] = useMemo(
     () =>
-      fileOperations
-        .filter(
-          (op) =>
-            op.type === FILE_OPERATION_TYPE.WRITE ||
-            op.type === FILE_OPERATION_TYPE.DELETE
-        )
-        .map((op) => {
-          const badge = getWriteStatusBadge(op);
-          return {
-            id: op.eventId,
-            filePath: op.filePath,
-            fileName: op.fileName,
-            statusLabel: badge?.label,
-            statusColorClass: badge?.colorClass,
-          };
-        }),
+      writeOperations.map((op) => {
+        const badge = getWriteStatusBadge(op);
+        const sequence = writeSequenceInfo.get(op.eventId);
+        const editCount =
+          op.editCount && op.editCount > 1 ? ` · ${op.editCount} edits` : "";
+        return {
+          id: op.eventId,
+          filePath: op.filePath,
+          fileName: op.fileName,
+          statusLabel: badge?.label,
+          statusColorClass: badge?.colorClass,
+          secondaryInfo: sequence
+            ? `${sequence.sequenceLabel} · ${sequence.pathHint}${editCount}`
+            : undefined,
+        };
+      }),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed by writeFileKey
-    [writeFileKey]
+    [writeFileKey, writeSequenceInfo]
   );
 
   const exploreItems: FileTreeInput[] = useMemo(

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/__tests__/fileOperationSequence.test.ts
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/__tests__/fileOperationSequence.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+
+import { buildFileOperationSequenceInfo } from "../fileOperationSequence";
+import { FILE_OPERATION_TYPE, type FileOperationEntry } from "../types";
+
+function operation(
+  eventId: string,
+  filePath: string,
+  createdAt: string
+): FileOperationEntry {
+  const parts = filePath.split("/");
+  const fileName = parts.pop() ?? filePath;
+  return {
+    eventId,
+    filePath,
+    fileName,
+    directory: parts.join("/") || "/",
+    type: FILE_OPERATION_TYPE.READ,
+    isCurrent: false,
+    event: {
+      id: eventId,
+      sessionId: "session-1",
+      createdAt,
+      functionName: "read_file",
+      actionType: "tool_call",
+      args: {},
+      result: {},
+      source: "assistant",
+      displayText: "",
+      displayStatus: "completed",
+      displayVariant: "tool_call",
+      activityStatus: "agent",
+      chunk_id: null,
+      uiCanonical: "",
+    } satisfies SessionEvent,
+  };
+}
+
+describe("buildFileOperationSequenceInfo", () => {
+  it("numbers same-name files by event chronology and exposes their parent path", () => {
+    const rootIgnore = operation(
+      "root-ignore",
+      "/repo/.gitignore",
+      "2026-07-20T10:00:00.000Z"
+    );
+    const huskyIgnore = operation(
+      "husky-ignore",
+      "/repo/.husky/.gitignore",
+      "2026-07-20T10:01:00.000Z"
+    );
+
+    const info = buildFileOperationSequenceInfo([huskyIgnore, rootIgnore]);
+
+    expect(info.get("root-ignore")).toEqual({
+      sequenceLabel: "#1",
+      pathHint: "repo",
+    });
+    expect(info.get("husky-ignore")).toEqual({
+      sequenceLabel: "#2",
+      pathHint: ".husky",
+    });
+  });
+
+  it("shows the chronological range for consolidated operations", () => {
+    const first = operation(
+      "edit-1",
+      "/repo/index.tsx",
+      "2026-07-20T10:00:00.000Z"
+    );
+    const second = operation(
+      "edit-2",
+      "/repo/index.tsx",
+      "2026-07-20T10:02:00.000Z"
+    );
+    const other = operation(
+      "other",
+      "/repo/other.ts",
+      "2026-07-20T10:01:00.000Z"
+    );
+    const consolidated = {
+      ...second,
+      relatedOperations: [first, second],
+      editCount: 2,
+    };
+
+    const info = buildFileOperationSequenceInfo([consolidated, other]);
+
+    expect(info.get("edit-2")?.sequenceLabel).toBe("#1–#3");
+    expect(info.get("other")?.sequenceLabel).toBe("#2");
+  });
+});

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/fileOperationSequence.ts
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/fileOperationSequence.ts
@@ -1,0 +1,78 @@
+import type { FileOperationEntry } from "./types";
+
+export interface FileOperationSequenceInfo {
+  sequenceLabel: string;
+  pathHint: string;
+}
+
+interface RankedOperation {
+  eventId: string;
+  createdAt: string;
+  fallbackOrder: number;
+}
+
+function getOperationEvents(
+  operation: FileOperationEntry
+): FileOperationEntry[] {
+  return operation.relatedOperations?.length
+    ? operation.relatedOperations
+    : [operation];
+}
+
+function getParentPathHint(operation: FileOperationEntry): string {
+  const normalized = operation.directory.replace(/\\/g, "/").replace(/\/$/, "");
+  if (!normalized) return "/";
+  return normalized.split("/").filter(Boolean).pop() ?? "/";
+}
+
+/**
+ * Assign chronological sequence numbers to the visible file rows. Consolidated
+ * operations retain the full range of their underlying reads/edits.
+ */
+export function buildFileOperationSequenceInfo(
+  operations: FileOperationEntry[]
+): Map<string, FileOperationSequenceInfo> {
+  const rankedOperations: RankedOperation[] = [];
+  let fallbackOrder = 0;
+
+  for (const operation of operations) {
+    for (const related of getOperationEvents(operation)) {
+      rankedOperations.push({
+        eventId: related.eventId,
+        createdAt: related.event?.createdAt ?? "",
+        fallbackOrder,
+      });
+      fallbackOrder += 1;
+    }
+  }
+
+  rankedOperations.sort((a, b) => {
+    if (a.createdAt && b.createdAt && a.createdAt !== b.createdAt) {
+      return a.createdAt.localeCompare(b.createdAt);
+    }
+    if (a.createdAt !== b.createdAt) return a.createdAt ? -1 : 1;
+    return a.fallbackOrder - b.fallbackOrder;
+  });
+
+  const rankByEventId = new Map(
+    rankedOperations.map((operation, index) => [operation.eventId, index + 1])
+  );
+  const result = new Map<string, FileOperationSequenceInfo>();
+
+  for (const operation of operations) {
+    const ranks = getOperationEvents(operation)
+      .map((related) => rankByEventId.get(related.eventId))
+      .filter((rank): rank is number => rank !== undefined)
+      .sort((a, b) => a - b);
+    const firstRank = ranks[0] ?? 1;
+    const lastRank = ranks[ranks.length - 1] ?? firstRank;
+
+    result.set(operation.eventId, {
+      sequenceLabel:
+        firstRank === lastRank ? `#${firstRank}` : `#${firstRank}–#${lastRank}`,
+      pathHint: getParentPathHint(operation),
+    });
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

- show chronological sequence labels for file operations in Session Replay
- add parent-path hints so same-name files remain distinguishable
- show sequence ranges and edit counts for consolidated file edits

## Testing

- `vitest` — 13 targeted tests passed
- pre-commit scoped TypeScript check passed
- ESLint and Prettier passed

Closes #445
