### PR TITLE
fix(replay): restore sidebar entry switching

### DIFF
--- a/src/modules/WorkStation/CodeEditor/SessionReplay/__tests__/resolveSelectedOperations.test.ts
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/__tests__/resolveSelectedOperations.test.ts
@@ -2,8 +2,15 @@ import { describe, expect, it } from "vitest";
 
 import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 
-import { resolveSelectedFileOperation } from "../resolveSelectedOperations";
-import { FILE_OPERATION_TYPE, type FileOperationEntry } from "../types";
+import {
+  resolveSelectedFileOperation,
+  resolveSelectedShellOperation,
+} from "../resolveSelectedOperations";
+import {
+  FILE_OPERATION_TYPE,
+  type FileOperationEntry,
+  type ShellOperationEntry,
+} from "../types";
 
 function minimalSessionEvent(
   overrides: Partial<SessionEvent> = {}
@@ -43,6 +50,24 @@ function fileOperation(
   };
 }
 
+function shellOperation(
+  overrides: Partial<ShellOperationEntry> = {}
+): ShellOperationEntry {
+  const event = minimalSessionEvent({
+    id: overrides.eventId ?? "shell-1",
+    functionName: "run_shell",
+  });
+  return {
+    command: "pwd",
+    shortCommand: "pwd",
+    commandKeywords: "pwd",
+    event,
+    eventId: event.id,
+    isCurrent: false,
+    ...overrides,
+  };
+}
+
 describe("resolveSelectedFileOperation", () => {
   it("prioritizes a running read over a stale manual selection", () => {
     const manualSelection = fileOperation({
@@ -71,5 +96,43 @@ describe("resolveSelectedFileOperation", () => {
     expect(selected?.eventId).toBe("read-running");
     expect(selected?.filePath).toBe("/repo/live.ts");
     expect(selected?.isLoading).toBe(true);
+  });
+});
+
+describe("resolveSelectedShellOperation", () => {
+  it("keeps following the running command until the user selects one", () => {
+    const completed = shellOperation({ eventId: "shell-completed" });
+    const running = shellOperation({
+      eventId: "shell-running",
+      isCurrent: true,
+      isLoading: true,
+      streamOutput: "still running",
+    });
+
+    expect(
+      resolveSelectedShellOperation([completed, running], null, null)?.eventId
+    ).toBe("shell-running");
+  });
+
+  it("honors a manual command selection while another command is running", () => {
+    const completed = shellOperation({
+      eventId: "shell-completed",
+      output: "finished output",
+    });
+    const running = shellOperation({
+      eventId: "shell-running",
+      isCurrent: true,
+      isLoading: true,
+      streamOutput: "still running",
+    });
+
+    const selected = resolveSelectedShellOperation(
+      [completed, running],
+      running,
+      "shell-completed"
+    );
+
+    expect(selected?.eventId).toBe("shell-completed");
+    expect(selected?.output).toBe("finished output");
   });
 });

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/index.tsx
@@ -163,26 +163,31 @@ const SessionReplayIDEComponent: React.FC<SimulatorIDEProps> = ({
 
   const handleShellSelect = useCallback(
     (selectedEventId: string) => {
+      setFileViewMode(FILE_PANEL_VIEW_MODE.TERMINAL);
       setUserPickedTool(false);
       selectShellOperation(selectedEventId);
     },
-    [selectShellOperation]
+    [setFileViewMode, selectShellOperation]
   );
 
   const handleSearchSelect = useCallback(
     (selectedEventId: string) => {
+      setFileViewMode(FILE_PANEL_VIEW_MODE.EXPLORE);
       setUserExploreChoice("search");
       selectExploreOperation(selectedEventId);
     },
-    [selectExploreOperation]
+    [setFileViewMode, selectExploreOperation]
   );
 
   const handleToolSelect = useCallback(
     (selectedEventId: string) => {
+      // Shell commands and generic tools share the Terminal sidebar tab, so
+      // selecting either section must also switch the content-panel mode.
+      setFileViewMode(FILE_PANEL_VIEW_MODE.TOOL);
       setUserPickedTool(true);
       selectToolOperation(selectedEventId);
     },
-    [selectToolOperation]
+    [setFileViewMode, selectToolOperation]
   );
 
   // Mixed-kind tab click: the unified replay tab strip renders entries of

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/resolveSelectedOperations.ts
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/resolveSelectedOperations.ts
@@ -97,18 +97,19 @@ export function resolveSelectedShellOperation(
   currentShellOperation: ShellOperationEntry | null,
   userSelectedShellEventId: string | null
 ): ShellOperationEntry | null {
-  // A running command always takes priority over any manual selection so that
-  // live streamOutput is visible without requiring user interaction. Once the
-  // command finishes, control returns to the user's prior selection.
-  const runningOp = allShellOperations.find((op) => op.isLoading);
-  if (runningOp) return runningOp;
-
+  // An explicit click is local browsing and must win over the live command.
+  // Otherwise every render snaps back to the running operation, making older
+  // command rows appear unclickable. With no manual selection, keep following
+  // the running command so streamOutput remains visible automatically.
   if (userSelectedShellEventId) {
     const found = allShellOperations.find(
       (op) => op.eventId === userSelectedShellEventId
     );
     if (found) return found;
   }
+
+  const runningOp = allShellOperations.find((op) => op.isLoading);
+  if (runningOp) return runningOp;
 
   if (currentShellOperation) return currentShellOperation;
   return allShellOperations[0] || null;


### PR DESCRIPTION
## Summary

- synchronize sidebar entry clicks with the Code Editor replay content mode
- keep explicit command selections visible while another command is running
- add regression coverage for automatic live-command following and manual selection priority

Closes #457

## Validation

- focused `resolveSelectedOperations` Vitest
- pre-commit scoped TypeScript, ESLint, and Prettier checks
- GitHub Frontend and Rust CI passed

## Merge order

This PR overlaps #448 in `SessionReplay/index.tsx`. Land #448 first, then refresh this branch and preserve both event-scoped FILES READ selection and explicit Terminal/Explore/Tool panel-mode switching.