### PR TITLE
fix(chat): refresh question status after answer

### DIFF
--- a/src/engines/ChatPanel/InputArea/AskQuestionCard/__tests__/questionSubmitUtils.test.ts
+++ b/src/engines/ChatPanel/InputArea/AskQuestionCard/__tests__/questionSubmitUtils.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+
+import { markQuestionAnswered } from "../questionSubmitUtils";
+
+const { getEventsSpy, upsertSpy } = vi.hoisted(() => ({
+  getEventsSpy: vi.fn(),
+  upsertSpy: vi.fn(),
+}));
+
+vi.mock("@src/engines/SessionCore/core/store/EventStoreProxy", () => ({
+  eventStoreProxy: {
+    getEvents: getEventsSpy,
+    upsert: upsertSpy,
+  },
+}));
+
+function pendingQuestionEvent(): SessionEvent {
+  return {
+    id: "tool-call-question-1",
+    chunk_id: "tool-call-question-1",
+    sessionId: "session-1",
+    createdAt: "2026-07-21T00:00:00.000Z",
+    functionName: "ask_user_questions",
+    uiCanonical: "ask_user_questions",
+    actionType: "tool_call",
+    args: { questions: [{ question: "Proceed?" }] },
+    result: {},
+    source: "assistant",
+    displayText: "ask_user_questions",
+    displayStatus: "awaiting_user",
+    displayVariant: "tool_call",
+    activityStatus: "pending",
+    callId: "question-1",
+  };
+}
+
+describe("markQuestionAnswered", () => {
+  beforeEach(() => {
+    getEventsSpy.mockReset();
+    upsertSpy.mockReset();
+    upsertSpy.mockResolvedValue(undefined);
+  });
+
+  it("immediately completes the visible question in its owning session", async () => {
+    getEventsSpy.mockResolvedValue([pendingQuestionEvent()]);
+
+    const updated = await markQuestionAnswered(
+      "session-1",
+      "tool-call-question-1",
+      [["Yes"]]
+    );
+
+    expect(updated).toBe(true);
+    expect(getEventsSpy).toHaveBeenCalledWith("session-1");
+    expect(upsertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "tool-call-question-1",
+        sessionId: "session-1",
+        displayStatus: "completed",
+        activityStatus: "processed",
+        result: { answers: [["Yes"]], status: "answered" },
+      }),
+      "session-1"
+    );
+  });
+
+  it("does not mutate another session when the event is absent", async () => {
+    getEventsSpy.mockResolvedValue([]);
+
+    await expect(
+      markQuestionAnswered("session-2", "tool-call-question-1", [["Yes"]])
+    ).resolves.toBe(false);
+    expect(upsertSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/engines/ChatPanel/InputArea/AskQuestionCard/questionSubmitUtils.ts
+++ b/src/engines/ChatPanel/InputArea/AskQuestionCard/questionSubmitUtils.ts
@@ -99,24 +99,28 @@ export function validateAnswers(
 }
 
 /**
- * Force-finalize a stale question event on the FE when the backend has no
- * pending request (e.g. the session was restarted after the question was
- * asked). This is the ONLY optimistic path — the normal flow relies on the
- * Rust `agent:interaction_finalized` broadcast.
+ * Finalize a question event in the frontend store as soon as the response API
+ * succeeds. Rust's `agent:interaction_finalized` remains the authoritative,
+ * idempotent confirmation, but the visible card must not stay in
+ * `awaiting_user` while that broadcast travels through the event pipeline.
  *
  * `status` distinguishes "user answered" (default) from "user dismissed via
  * Skip" ("rejected"). The history card renders the two differently.
  */
-export function markEventStaleAnswered(
+export async function markQuestionAnswered(
+  sessionId: string,
   chunkId: string,
   answerLabels: string[][],
   status: "answered" | "rejected" = "answered"
-): void {
-  if (!chunkId) return;
-  eventStoreProxy.getEvents().then((events) => {
-    const evt = events.find((e) => e.id === chunkId);
-    if (!evt) return;
-    eventStoreProxy.upsert({
+): Promise<boolean> {
+  if (!chunkId) return false;
+
+  const events = await eventStoreProxy.getEvents(sessionId);
+  const evt = events.find((event) => event.id === chunkId);
+  if (!evt) return false;
+
+  await eventStoreProxy.upsert(
+    {
       ...evt,
       result: {
         ...(evt.result as Record<string, unknown>),
@@ -125,6 +129,8 @@ export function markEventStaleAnswered(
       },
       displayStatus: "completed" as EventDisplayStatus,
       activityStatus: "processed",
-    });
-  });
+    },
+    sessionId
+  );
+  return true;
 }

--- a/src/engines/ChatPanel/InputArea/AskQuestionCard/useQuestionSubmission.ts
+++ b/src/engines/ChatPanel/InputArea/AskQuestionCard/useQuestionSubmission.ts
@@ -18,7 +18,7 @@ import type { SingleQuestion } from "@src/engines/ChatPanel/InputArea/AskQuestio
 import {
   buildAnswerIds,
   buildAnswerLabels,
-  markEventStaleAnswered,
+  markQuestionAnswered,
   validateAnswers,
 } from "./questionSubmitUtils";
 
@@ -77,7 +77,8 @@ export function useQuestionSubmission(): UseQuestionSubmissionReturn {
         // the finalize event is dropped (e.g. tool_call_id mismatch, channel
         // buffer eviction) — the broadcast then becomes an idempotent confirm.
         await respondQuestion(sessionId, questionId, answers);
-        markEventStaleAnswered(
+        await markQuestionAnswered(
+          sessionId,
           chunkId,
           buildAnswerLabels(questions, selections, customTexts)
         );
@@ -96,7 +97,8 @@ export function useQuestionSubmission(): UseQuestionSubmissionReturn {
           // The user DID answer — expired only means the pending request was
           // already gone (session restart, etc.). Use their real selections,
           // not a "skipped" placeholder.
-          markEventStaleAnswered(
+          await markQuestionAnswered(
+            sessionId,
             chunkId,
             buildAnswerLabels(questions, selections, customTexts)
           );
@@ -117,8 +119,16 @@ export function useQuestionSubmission(): UseQuestionSubmissionReturn {
       const skippedLabel = t("chat.skippedByUser");
 
       try {
-        // Rust emits `agent:interaction_finalized` with status=rejected.
+        // Rust emits `agent:interaction_finalized` with status=rejected. Keep
+        // the same immediate frontend completion as the answer path so Skip
+        // cannot remain visually stuck if that broadcast is delayed.
         await rejectQuestion(sessionId, questionId);
+        await markQuestionAnswered(
+          sessionId,
+          chunkId,
+          [[skippedLabel]],
+          "rejected"
+        );
         return true;
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -130,7 +140,12 @@ export function useQuestionSubmission(): UseQuestionSubmissionReturn {
         if (isExpired) {
           Message.warning(t("chat.questionExpired"));
         }
-        markEventStaleAnswered(chunkId, [[skippedLabel]], "rejected");
+        await markQuestionAnswered(
+          sessionId,
+          chunkId,
+          [[skippedLabel]],
+          "rejected"
+        );
         return true;
       }
     },


### PR DESCRIPTION
## Summary

- immediately complete the owning `ask_user_questions` event after answer submission succeeds
- apply the same immediate terminal state after Skip
- keep `agent:interaction_finalized` as the authoritative idempotent confirmation
- scope event lookup and upsert to the owning session
- add regression coverage for immediate completion and cross-session isolation

## Testing

- `pnpm exec vitest run src/engines/ChatPanel/InputArea/AskQuestionCard/__tests__/questionSubmitUtils.test.ts`
- `pnpm exec eslint src/engines/ChatPanel/InputArea/AskQuestionCard/questionSubmitUtils.ts src/engines/ChatPanel/InputArea/AskQuestionCard/useQuestionSubmission.ts src/engines/ChatPanel/InputArea/AskQuestionCard/__tests__/questionSubmitUtils.test.ts`
- scoped TypeScript check from the pre-commit hook

Closes #459
