### PR TITLE
fix(markdown): stop linking PascalCase identifiers in chat messages

### DIFF
--- a/src/components/MarkDown/MarkDownImpl.tsx
+++ b/src/components/MarkDown/MarkDownImpl.tsx
@@ -586,24 +586,6 @@ const MarkdownComponent: React.FC<MarkdownProps> = ({
               </code>
             );
           }
-
-          if (codeType === "identifier") {
-            return (
-              <code
-                {...props}
-                className="clickable-code identifier"
-                title={`Search for ${text}`}
-                onClick={(event) => {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  // For identifiers, we can search for them
-                  openFileInEditor(text, false);
-                }}
-              >
-                {children}
-              </code>
-            );
-          }
         }
 
         // Regular inline code

--- a/src/components/MarkDown/markdownUtils.tsx
+++ b/src/components/MarkDown/markdownUtils.tsx
@@ -14,7 +14,7 @@ import React from "react";
 
 import { openFileInEditor as openFileInEditorShared } from "@src/util/ui/openFileInEditor";
 
-type InlineCodeType = "file" | "directory" | "identifier" | null;
+type InlineCodeType = "file" | "directory" | null;
 
 const FILE_CONTENT_PATTERN =
   /((Here's the content of|Content of|Read\.?\s*Highlights? from|Read)\s+`([^`]+)`\s*:)\s*\n*([^]*?)(?=\n\n[A-Z]|$)/gi;
@@ -380,8 +380,6 @@ export function detectCodeType(text: string): InlineCodeType {
     !/[=<>!&|]/.test(trimmed)
   ) {
     const hasPathSignal = trimmed.includes("/") || trimmed.endsWith("/");
-    const hasIdentifierSignal =
-      trimmed.length > 2 && /^[A-Z][a-zA-Z0-9]*$/.test(trimmed);
 
     if (hasPathSignal && /^[\w./-]+\/$/.test(trimmed)) {
       result = "directory";
@@ -397,8 +395,6 @@ export function detectCodeType(text: string): InlineCodeType {
       !/\.\w+$/.test(trimmed)
     ) {
       result = "directory";
-    } else if (hasIdentifierSignal) {
-      result = "identifier";
     }
   }
 


### PR DESCRIPTION
## Summary

Chat messages rendered PascalCase tokens (e.g. `ORG2`, `Review`, `Terminal`, `React`, `Button`) inside backticks as **clickable inline code**, but clicking always failed with "Unable to locate the file".

## Root cause

`detectCodeType()` in `src/components/MarkDown/markdownUtils.tsx` classified any token matching `/^[A-Z][a-zA-Z0-9]*$/` (length > 2) as an `"identifier"` type. The `code` renderer in `MarkDownImpl.tsx` then rendered it as `.clickable-code` with:

- `title={`Search for ${text}`}` — promising a symbol search
- `onClick` → `openFileInEditor(text, false)` — **actually treating the identifier as a relative file path**

The "search" path was never implemented; the click handler always tried to open the identifier as a file. Since no such file exists, `useFileContent` failed, `classifyFileError` returned `not_found`, and the editor's `ErrorView` surfaced "Unable to locate the file" / "无法找到文件".

There was also **no existence pre-check** — the clickable visual was shown based purely on the token's shape, before any workspace lookup.

## Fix

Removed the dead `identifier` branch entirely (Option A from investigation):

- `src/components/MarkDown/markdownUtils.tsx`
  - `InlineCodeType` no longer includes `"identifier"`
  - `detectCodeType()` no longer computes `hasIdentifierSignal` or returns `"identifier"`
- `src/components/MarkDown/MarkDownImpl.tsx`
  - Removed the `if (codeType === "identifier")` render block (including the mismatched `title`/`onClick`)

PascalCase tokens now fall through to the regular `<code>` branch — no false link, no error on click. `file` and `directory` detection are unchanged.

## Verification

- `tsc --noEmit` — clean for both files
- pre-commit hooks (lint-staged / eslint / prettier / scoped type check) — all passed
