### PR TITLE
perf(ui): coalesce high-frequency updates

### DIFF
--- a/src/hooks/dropdown/useDropdownEngine.ts
+++ b/src/hooks/dropdown/useDropdownEngine.ts
@@ -169,6 +169,7 @@ export function useDropdownEngine<
     latestTriggerRef.current = triggerRef;
   }, [triggerRef]);
   const panelRef = useRef<HTMLDivElement>(null!);
+  const positionFrameRef = useRef<number | null>(null);
   const [panelPosition, setPanelPosition] = useState<DropdownEnginePosition>({
     left: 0,
     width: 0,
@@ -224,6 +225,24 @@ export function useDropdownEngine<
     setIsPositioned(true);
   }, [gap, placement, align]);
 
+  const schedulePositionUpdate = useCallback(() => {
+    if (positionFrameRef.current !== null) return;
+
+    positionFrameRef.current = window.requestAnimationFrame(() => {
+      positionFrameRef.current = null;
+      updatePosition();
+    });
+  }, [updatePosition]);
+
+  useEffect(() => {
+    return () => {
+      if (positionFrameRef.current !== null) {
+        window.cancelAnimationFrame(positionFrameRef.current);
+        positionFrameRef.current = null;
+      }
+    };
+  }, []);
+
   const setIsOpen = useCallback(
     (newOpen: boolean) => {
       if (disabled && newOpen) return;
@@ -276,18 +295,23 @@ export function useDropdownEngine<
     };
   }, [isOpen, updatePosition]);
 
-  // Scroll/resize listeners
+  // Scroll/resize listeners are frame-coalesced to avoid repeated layout reads
+  // and React state writes when nested scroll containers emit in one frame.
   useEffect(() => {
     if (!isOpen) return;
 
-    window.addEventListener("scroll", updatePosition, true);
-    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", schedulePositionUpdate, true);
+    window.addEventListener("resize", schedulePositionUpdate);
 
     return () => {
-      window.removeEventListener("scroll", updatePosition, true);
-      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", schedulePositionUpdate, true);
+      window.removeEventListener("resize", schedulePositionUpdate);
+      if (positionFrameRef.current !== null) {
+        window.cancelAnimationFrame(positionFrameRef.current);
+        positionFrameRef.current = null;
+      }
     };
-  }, [isOpen, updatePosition]);
+  }, [isOpen, schedulePositionUpdate]);
 
   // Re-position when trigger/panel dimensions change (search/filter/content updates).
   useEffect(() => {

--- a/src/hooks/workStation/search/__tests__/latestRequestGuard.test.ts
+++ b/src/hooks/workStation/search/__tests__/latestRequestGuard.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { LatestRequestGuard } from "../latestRequestGuard";
+
+describe("LatestRequestGuard", () => {
+  it("allows only the newest issued request to commit", () => {
+    const guard = new LatestRequestGuard();
+    const first = guard.issue();
+    const second = guard.issue();
+
+    expect(guard.isCurrent(first)).toBe(false);
+    expect(guard.isCurrent(second)).toBe(true);
+  });
+
+  it("invalidates an in-flight request when search is cleared", () => {
+    const guard = new LatestRequestGuard();
+    const request = guard.issue();
+
+    guard.invalidate();
+
+    expect(guard.isCurrent(request)).toBe(false);
+  });
+});

--- a/src/hooks/workStation/search/latestRequestGuard.ts
+++ b/src/hooks/workStation/search/latestRequestGuard.ts
@@ -1,0 +1,16 @@
+export class LatestRequestGuard {
+  private generation = 0;
+
+  issue(): number {
+    this.generation += 1;
+    return this.generation;
+  }
+
+  invalidate(): void {
+    this.generation += 1;
+  }
+
+  isCurrent(generation: number): boolean {
+    return generation === this.generation;
+  }
+}

--- a/src/hooks/workStation/search/useCodeSearch.ts
+++ b/src/hooks/workStation/search/useCodeSearch.ts
@@ -16,6 +16,8 @@ import {
   recordCacheMissAtom,
 } from "@src/store/workstation/codeEditor/search/cacheAtom";
 
+import { LatestRequestGuard } from "./latestRequestGuard";
+
 export type { CodeSearchResult } from "@src/api/tauri/search";
 
 export type CodeSearchMode = "regex" | "semantic" | "hybrid";
@@ -90,6 +92,12 @@ export function useCodeSearch(
   const recordCacheHit = useSetAtom(recordCacheHitAtom);
   const recordCacheMiss = useSetAtom(recordCacheMissAtom);
   const abortControllerRef = useRef<AbortController | null>(null);
+  // The Tauri search API does not currently accept an AbortSignal, so only the
+  // latest request generation is allowed to commit results or loading state.
+  const latestRequestGuardRef = useRef<LatestRequestGuard | null>(null);
+  if (latestRequestGuardRef.current === null) {
+    latestRequestGuardRef.current = new LatestRequestGuard();
+  }
 
   const toggleSearchMode = useCallback(() => {
     setSearchMode((currentMode) => {
@@ -101,6 +109,9 @@ export function useCodeSearch(
   }, []);
 
   const search = useCallback(async () => {
+    const latestRequestGuard = latestRequestGuardRef.current!;
+    const searchGeneration = latestRequestGuard.issue();
+    const isLatestSearch = () => latestRequestGuard.isCurrent(searchGeneration);
     const trimmedQuery = query.trim();
 
     if (!trimmedQuery) {
@@ -137,6 +148,8 @@ export function useCodeSearch(
         repoFilter ? [repoFilter] : [],
         { max_results: opts.maxResults + 1 }
       );
+      if (!isLatestSearch()) return;
+
       const hasMoreResults = regexResults.length > opts.maxResults;
       let searchResults = hasMoreResults
         ? regexResults.slice(0, opts.maxResults)
@@ -168,6 +181,7 @@ export function useCodeSearch(
         setSearchHistory((prev) => [trimmedQuery, ...prev.slice(0, 9)]);
       }
     } catch (err: unknown) {
+      if (!isLatestSearch()) return;
       if (err instanceof Error && err.name === "AbortError") return;
       const errorMsg =
         typeof err === "string"
@@ -178,8 +192,10 @@ export function useCodeSearch(
       setError(errorMsg);
       setResults([]);
     } finally {
-      setLoading(false);
-      abortControllerRef.current = null;
+      if (isLatestSearch()) {
+        setLoading(false);
+        abortControllerRef.current = null;
+      }
     }
   }, [
     query,
@@ -196,7 +212,11 @@ export function useCodeSearch(
   ]);
 
   const clearResults = useCallback(() => {
+    latestRequestGuardRef.current?.invalidate();
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
     setResults([]);
+    setLoading(false);
     setError(null);
     setCurrentPage(1);
     setHasMore(false);
@@ -222,12 +242,17 @@ export function useCodeSearch(
       debouncedSearch();
     } else {
       debouncedSearch.cancel();
+      latestRequestGuardRef.current?.invalidate();
+      abortControllerRef.current?.abort();
+      abortControllerRef.current = null;
       setResults([]);
+      setLoading(false);
     }
   }, [query, opts.autoSearch, debouncedSearch, search]);
 
   useEffect(() => {
     return () => {
+      latestRequestGuardRef.current?.invalidate();
       abortControllerRef.current?.abort();
     };
   }, []);

--- a/src/modules/MainApp/WorkManagement/GitHubWorkItemsSurface.tsx
+++ b/src/modules/MainApp/WorkManagement/GitHubWorkItemsSurface.tsx
@@ -1,6 +1,7 @@
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import React, {
   useCallback,
+  useDeferredValue,
   useEffect,
   useMemo,
   useRef,
@@ -105,6 +106,7 @@ const GitHubWorkItemsSurface: React.FC<GitHubWorkItemsSurfaceProps> = ({
     query.scope = scope;
     return query;
   }, [scope, searchQuery]);
+  const deferredParsedSearchQuery = useDeferredValue(parsedSearchQuery);
   const selectedIssueListStates = useMemo(
     () => getIssuePageStatesForQuery(parsedSearchQuery),
     [parsedSearchQuery]
@@ -415,9 +417,9 @@ const GitHubWorkItemsSurface: React.FC<GitHubWorkItemsSurfaceProps> = ({
     () =>
       allItems.filter((item) => {
         if (!itemMatchesRepo(item, effectiveSelectedRepo)) return false;
-        return itemMatchesParsedQuery(item, parsedSearchQuery);
+        return itemMatchesParsedQuery(item, deferredParsedSearchQuery);
       }),
-    [allItems, effectiveSelectedRepo, parsedSearchQuery]
+    [allItems, deferredParsedSearchQuery, effectiveSelectedRepo]
   );
 
   const pageStates = useMemo(

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/TestingContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/TestingContent/index.tsx
@@ -9,7 +9,13 @@
  */
 import { useAtomValue } from "jotai";
 import { ChevronDown, ChevronRight, Filter as FilterIcon } from "lucide-react";
-import React, { memo, useCallback, useMemo, useState } from "react";
+import React, {
+  memo,
+  useCallback,
+  useDeferredValue,
+  useMemo,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 
 import { useActionSystem } from "@src/ActionSystem";
@@ -100,6 +106,7 @@ export const TestingContent: React.FC<TestingContentProps> = memo(
     // Dispatch for actions (unified with AI)
     const { dispatch } = useActionSystem();
     const [filterQuery, setFilterQuery] = useState("");
+    const deferredFilterQuery = useDeferredValue(filterQuery);
 
     // Hook for state only (no action calls)
     const { isDiscovering, counts } = useTestRunner({
@@ -110,8 +117,8 @@ export const TestingContent: React.FC<TestingContentProps> = memo(
 
     const testItems = useAtomValue(testItemsWithStatusAtom);
     const filteredItems = useMemo(
-      () => filterTestItems(testItems, filterQuery),
-      [testItems, filterQuery]
+      () => filterTestItems(testItems, deferredFilterQuery),
+      [testItems, deferredFilterQuery]
     );
 
     // Track user-toggled paths (collapsed by user)

--- a/src/modules/shared/DevTools/APICallPanel/hooks/useAPICallPanel.ts
+++ b/src/modules/shared/DevTools/APICallPanel/hooks/useAPICallPanel.ts
@@ -55,6 +55,8 @@ export function useAPICallPanel(): UseAPICallPanelReturn {
   // Refs
   const resizeStartY = useRef<number>(0);
   const resizeStartHeight = useRef<number>(0);
+  const resizeFrameRef = useRef<number | null>(null);
+  const pendingHeightRef = useRef<number | null>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
   // ============================================
@@ -99,10 +101,27 @@ export function useAPICallPanel(): UseAPICallPanelReturn {
         MIN_HEIGHT,
         Math.min(MAX_HEIGHT, resizeStartHeight.current + deltaY)
       );
-      setHeight(newHeight);
+      pendingHeightRef.current = newHeight;
+      if (resizeFrameRef.current !== null) return;
+
+      resizeFrameRef.current = window.requestAnimationFrame(() => {
+        resizeFrameRef.current = null;
+        if (pendingHeightRef.current !== null) {
+          setHeight(pendingHeightRef.current);
+          pendingHeightRef.current = null;
+        }
+      });
     };
 
     const handleMouseUp = () => {
+      if (resizeFrameRef.current !== null) {
+        window.cancelAnimationFrame(resizeFrameRef.current);
+        resizeFrameRef.current = null;
+      }
+      if (pendingHeightRef.current !== null) {
+        setHeight(pendingHeightRef.current);
+        pendingHeightRef.current = null;
+      }
       setIsResizing(false);
     };
 
@@ -112,6 +131,11 @@ export function useAPICallPanel(): UseAPICallPanelReturn {
     return () => {
       document.removeEventListener("mousemove", handleMouseMove);
       document.removeEventListener("mouseup", handleMouseUp);
+      if (resizeFrameRef.current !== null) {
+        window.cancelAnimationFrame(resizeFrameRef.current);
+        resizeFrameRef.current = null;
+      }
+      pendingHeightRef.current = null;
     };
   }, [isResizing]);
 


### PR DESCRIPTION
## Summary

- defer expensive test-tree and GitHub work-item filtering while keeping inputs responsive
- coalesce dropdown positioning and API panel resize updates to animation frames
- prevent stale code-search requests from overwriting newer results

## Verification

- `pnpm eslint` on all changed files
- `pnpm vitest run src/hooks/workStation/search/__tests__/latestRequestGuard.test.ts`
- `pnpm typecheck`
- pre-commit scoped TypeScript and lint-staged checks

## Runtime note

This change has correctness and static verification coverage. Tauri/WebView frame-time profiling was not performed, so no measured FPS claim is included.
