### PR TITLE
fix(chat): ignore stale mention search results

### DIFF
--- a/src/hooks/workStation/__tests__/latestRequestGuard.test.ts
+++ b/src/hooks/workStation/__tests__/latestRequestGuard.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { LatestRequestGuard } from "../latestRequestGuard";
+
+describe("LatestRequestGuard", () => {
+  it("allows only the latest request to commit", () => {
+    const guard = new LatestRequestGuard();
+    const backendSearch = guard.issue();
+    const frontendSearch = guard.issue();
+
+    expect(backendSearch.isCurrent()).toBe(false);
+    expect(frontendSearch.isCurrent()).toBe(true);
+  });
+
+  it("prevents an older search from overwriting a newer result", async () => {
+    const guard = new LatestRequestGuard();
+    const committedResults: string[] = [];
+    let resolveBackend!: (value: string) => void;
+    let resolveFrontend!: (value: string) => void;
+    const backendResult = new Promise<string>((resolve) => {
+      resolveBackend = resolve;
+    });
+    const frontendResult = new Promise<string>((resolve) => {
+      resolveFrontend = resolve;
+    });
+
+    const runSearch = async (result: Promise<string>) => {
+      const ticket = guard.issue();
+      const value = await result;
+      if (ticket.isCurrent()) committedResults.push(value);
+    };
+
+    const olderSearch = runSearch(backendResult);
+    const newerSearch = runSearch(frontendResult);
+    resolveFrontend("docs/FRONTEND.md");
+    await newerSearch;
+    resolveBackend("docs/BACKEND_DESIGN.md");
+    await olderSearch;
+
+    expect(committedResults).toEqual(["docs/FRONTEND.md"]);
+  });
+
+  it("invalidates an in-flight request when the consumer resets", () => {
+    const guard = new LatestRequestGuard();
+    const request = guard.issue();
+
+    guard.invalidate();
+
+    expect(request.isCurrent()).toBe(false);
+  });
+
+  it("keeps a request current until it is superseded", () => {
+    const guard = new LatestRequestGuard();
+    const request = guard.issue();
+
+    expect(request.isCurrent()).toBe(true);
+    expect(request.isCurrent()).toBe(true);
+  });
+});

--- a/src/hooks/workStation/latestRequestGuard.ts
+++ b/src/hooks/workStation/latestRequestGuard.ts
@@ -1,0 +1,27 @@
+export interface LatestRequestTicket {
+  /** True only while no newer request or explicit invalidation has occurred. */
+  isCurrent(): boolean;
+}
+
+/**
+ * Coordinates async work where only the latest request may update UI state.
+ *
+ * The underlying operation does not need cancellation support: callers issue a
+ * ticket before awaiting, then guard every success, error, and loading-state
+ * write with `ticket.isCurrent()`. `invalidate()` also makes in-flight tickets
+ * stale when the owning consumer resets or unmounts.
+ */
+export class LatestRequestGuard {
+  private generation = 0;
+
+  issue(): LatestRequestTicket {
+    const generation = ++this.generation;
+    return {
+      isCurrent: () => this.generation === generation,
+    };
+  }
+
+  invalidate(): void {
+    this.generation += 1;
+  }
+}

--- a/src/hooks/workStation/panels/useContextMenu.ts
+++ b/src/hooks/workStation/panels/useContextMenu.ts
@@ -39,6 +39,7 @@ import { sessionsAtom } from "@src/store/session/sessionAtom";
 import { workspaceFoldersAtom } from "@src/store/ui/workspaceFoldersAtom";
 import { activeWorkspaceRootAtom } from "@src/store/workspace";
 
+import { LatestRequestGuard } from "../latestRequestGuard";
 import {
   type DrilledProject,
   searchFiles,
@@ -116,6 +117,16 @@ export function useContextMenu(
   const [secondLayerActiveIndex, setSecondLayerActiveIndex] = useState(0);
   const hasMovedMainHighlightRef = useRef(false);
   const hasMovedSecondLayerHighlightRef = useRef(false);
+  const searchRequestGuardRef = useRef<LatestRequestGuard | null>(null);
+  if (searchRequestGuardRef.current === null) {
+    searchRequestGuardRef.current = new LatestRequestGuard();
+  }
+
+  useEffect(() => {
+    return () => {
+      searchRequestGuardRef.current!.invalidate();
+    };
+  }, []);
 
   // Derive effective values — when externalSearchQuery is provided, override
   // without any setState.  This eliminates the 2-setState cascade that was
@@ -166,8 +177,10 @@ export function useContextMenu(
 
   const performSearch = useCallback(
     async (query: string, type: SecondLayerId, allowEmpty: boolean = false) => {
+      const request = searchRequestGuardRef.current!.issue();
       if (!query.trim() && !allowEmpty) {
         updateSearchResults([]);
+        setSearchLoading(false);
         return;
       }
       setSearchLoading(true);
@@ -196,12 +209,18 @@ export function useContextMenu(
         } else {
           results = [];
         }
-        updateSearchResults(results);
+        if (request.isCurrent()) {
+          updateSearchResults(results);
+        }
       } catch (error) {
-        log.error("[ContextMenu] Search failed:", error);
-        updateSearchResults([]);
+        if (request.isCurrent()) {
+          log.error("[ContextMenu] Search failed:", error);
+          updateSearchResults([]);
+        }
       } finally {
-        setSearchLoading(false);
+        if (request.isCurrent()) {
+          setSearchLoading(false);
+        }
       }
     },
     [effectiveRepoPath, searchRoots, allSessions, updateSearchResults]
@@ -224,11 +243,17 @@ export function useContextMenu(
   // useDebouncedCallback keeps the function fresh.
   useEffect(() => {
     if (secondLayer) {
+      // Invalidate immediately when the user's search intent changes. The next
+      // debounced search issues its own ticket; until then, an older request
+      // must not commit results for the previous query or menu invocation.
+      searchRequestGuardRef.current!.invalidate();
       // When entering files layer without query, still search to show all files
       debouncedContextSearch(searchQuery, secondLayer, !searchQuery);
     } else if (!searchQuery) {
       debouncedContextSearch.cancel();
+      searchRequestGuardRef.current!.invalidate();
       updateSearchResults([]);
+      setSearchLoading(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchQuery, secondLayer, debouncedContextSearch]);
@@ -276,6 +301,7 @@ export function useContextMenu(
 
   // Reset state
   const reset = useCallback(() => {
+    searchRequestGuardRef.current!.invalidate();
     setActiveIndex(0);
     setKeyboardNavigated(false);
     setSecondLayer(null);


### PR DESCRIPTION
## Summary

- prevent stale `@` mention searches from overwriting newer file results
- invalidate in-flight searches when the query changes, the menu resets, or the hook unmounts
- guard result, error, and loading-state commits with one reusable request generation
- add a regression test covering `BACKEND_DESIGN.md` resolving after `FRONTEND.md`

## Verification

- `pnpm exec vitest run src/hooks/workStation/__tests__/latestRequestGuard.test.ts src/hooks/workStation/panels/__tests__/contextMenuSearchRoots.test.ts`
- `pnpm exec eslint src/hooks/workStation/panels/useContextMenu.ts src/hooks/workStation/latestRequestGuard.ts src/hooks/workStation/__tests__/latestRequestGuard.test.ts`
- `pnpm exec prettier --check src/hooks/workStation/panels/useContextMenu.ts src/hooks/workStation/latestRequestGuard.ts src/hooks/workStation/__tests__/latestRequestGuard.test.ts`
- scoped TypeScript check via pre-commit hook
- LSP diagnostics: no findings in changed files

Closes #438
