### PR TITLE
feat(ui): show worktree + branch in rail, hover card, and composer bar

### DIFF
--- a/src/components/SessionHoverCard/SessionHoverCardContent.tsx
+++ b/src/components/SessionHoverCard/SessionHoverCardContent.tsx
@@ -28,12 +28,14 @@ import ModelIcon from "@src/components/ModelIcon";
 import { resolveAgentIcon } from "@src/config/agentIcons";
 import TaskImpactLine from "@src/features/KanbanBoard/components/TaskImpactLine";
 import type { KanbanTask } from "@src/features/KanbanBoard/types";
+import { useRepoSelection } from "@src/hooks/git/useRepoSelection";
 import { createLogger } from "@src/hooks/logger";
 import { useResolvedModelLabel } from "@src/hooks/models";
 import { useValidatedLastPair } from "@src/hooks/models/useValidatedLastPair";
 import { workspaceGitStatusMapAtom } from "@src/store/git/gitStatusAtom";
 import type { LastModelSelection } from "@src/store/session/creatorDefaultModelAtom";
 import { sessionByIdAtom } from "@src/store/session/sessionAtom/atoms";
+import { activeWorkspaceRootPathAtom } from "@src/store/workspace/derived";
 import { copyText } from "@src/util/data/clipboard";
 import {
   formatReplayDateLabel,
@@ -185,6 +187,10 @@ export const SessionHoverCardContent: React.FC<SessionHoverCardContentProps> =
     const { t, i18n } = useTranslation(["sessions", "common"]);
     const session = useAtomValue(sessionByIdAtom(sessionId));
     const workspaceGitStatusMap = useAtomValue(workspaceGitStatusMapAtom);
+    const activeWorkspaceRootPath = useAtomValue(activeWorkspaceRootPathAtom);
+    const { currentBranch: activeWorkspaceBranch } = useRepoSelection({
+      autoLoad: false,
+    });
     const creatorDefaultLastModel = useValidatedLastPair();
     const turnOverview: SessionTurnOverview | null =
       useSessionTurnOverview(sessionId);
@@ -415,12 +421,19 @@ export const SessionHoverCardContent: React.FC<SessionHoverCardContentProps> =
       : undefined;
     const worktreePathLabel = worktreePath ? basename(worktreePath) : "";
     const effectiveBranch = session.branch;
+    const sessionRepoMatchesActive =
+      !!normalizedRepoPath &&
+      !!activeWorkspaceRootPath &&
+      normalizedRepoPath === normalizePath(activeWorkspaceRootPath);
     const branchLabel =
       formatBranchLabel(session.worktreeBranch) ||
       (worktreePath ? worktreePathLabel : "") ||
       formatBranchLabel(effectiveBranch) ||
       formatBranchLabel(session.baseBranch) ||
-      formatBranchLabel(workspaceGitStatus?.current_branch);
+      formatBranchLabel(workspaceGitStatus?.current_branch) ||
+      (sessionRepoMatchesActive
+        ? formatBranchLabel(activeWorkspaceBranch)
+        : "");
     const modelIconName =
       lastModel?.listingModel || lastModel?.model || undefined;
     const modelIconAgent = lastModel?.listingModelType || undefined;
@@ -453,6 +466,17 @@ export const SessionHoverCardContent: React.FC<SessionHoverCardContentProps> =
 
     return (
       <HoverCardPanel title={session.name || session.session_id}>
+        {(repoName || branchLabel) && (
+          <HoverCardRow icon={<GitBranch size={13} strokeWidth={1.75} />}>
+            <div className="truncate text-text-2">
+              {repoName && <span>{repoName}</span>}
+              {repoName && branchLabel && (
+                <span className="mx-1 text-text-4">·</span>
+              )}
+              {branchLabel && <span>{branchLabel}</span>}
+            </div>
+          </HoverCardRow>
+        )}
         <HoverCardRow
           icon={agentSessionInfo.icon}
           iconClassName={agentSessionInfo.textClassName}
@@ -485,17 +509,6 @@ export const SessionHoverCardContent: React.FC<SessionHoverCardContentProps> =
             )}
           </div>
         </HoverCardRow>
-        {(repoName || branchLabel) && (
-          <HoverCardRow icon={<GitBranch size={13} strokeWidth={1.75} />}>
-            <div className="truncate text-text-2">
-              {repoName && <span>{repoName}</span>}
-              {repoName && branchLabel && (
-                <span className="mx-1 text-text-4">·</span>
-              )}
-              {branchLabel && <span>{branchLabel}</span>}
-            </div>
-          </HoverCardRow>
-        )}
         {repoPath && (
           <HoverCardRow icon={<Folder size={13} strokeWidth={1.75} />}>
             <button

--- a/src/engines/ChatPanel/InputArea/components/InputComposerBars.tsx
+++ b/src/engines/ChatPanel/InputArea/components/InputComposerBars.tsx
@@ -15,6 +15,7 @@ import InputActions from "./InputActions";
 import InputEditor from "./InputEditor";
 import PromptPolishButton from "./PromptPolishButton";
 import ReplyInfoDisplay from "./ReplyInfoDisplay";
+import WorktreeBranchPill from "./WorktreeBranchPill";
 
 interface SharedComposerBarProps {
   composerInputRef: React.RefObject<ComposerInputRef | null>;
@@ -412,6 +413,7 @@ export const NormalComposerContent: React.FC<NormalComposerContentProps> = ({
             >
               {modePill}
               {modelPill}
+              <WorktreeBranchPill />
             </div>
           }
           submitButton={

--- a/src/engines/ChatPanel/InputArea/components/WorktreeBranchPill.tsx
+++ b/src/engines/ChatPanel/InputArea/components/WorktreeBranchPill.tsx
@@ -1,0 +1,47 @@
+/**
+ * WorktreeBranchPill — read-only worktree + branch indicator for the composer
+ * status bar. Rendered in the center cluster between pills (model|effort) and
+ * the context ring, mirroring Claude Code CLI's bottom cwd/branch line.
+ */
+import { useAtomValue } from "jotai";
+import { Folder, GitBranch } from "lucide-react";
+import React, { memo } from "react";
+
+import { useRepoSelection } from "@src/hooks/git/useRepoSelection";
+import { activeWorkspaceRootAtom } from "@src/store/workspace";
+
+const WorktreeBranchPill: React.FC = memo(() => {
+  const root = useAtomValue(activeWorkspaceRootAtom);
+  const { currentBranch } = useRepoSelection({ autoLoad: false });
+
+  const name = root?.name;
+  const path = root?.path;
+  const branch = currentBranch || undefined;
+
+  if (!name && !branch) return null;
+
+  return (
+    <div
+      className="flex h-[28px] min-w-0 max-w-full shrink items-center gap-1.5 rounded-full px-2 text-[12px] text-text-3"
+      title={path ? `${path}${branch ? ` · ${branch}` : ""}` : branch}
+    >
+      {name && (
+        <span className="flex min-w-0 items-center gap-1">
+          <Folder size={13} strokeWidth={1.75} className="shrink-0" />
+          <span className="truncate">{name}</span>
+        </span>
+      )}
+      {name && branch && <span className="shrink-0 text-text-4">·</span>}
+      {branch && (
+        <span className="flex min-w-0 items-center gap-1">
+          <GitBranch size={13} strokeWidth={1.75} className="shrink-0" />
+          <span className="truncate">{branch}</span>
+        </span>
+      )}
+    </div>
+  );
+});
+
+WorktreeBranchPill.displayName = "WorktreeBranchPill";
+
+export default WorktreeBranchPill;

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail.tsx
@@ -5,6 +5,7 @@ import {
   File,
   FileDiff,
   Folder,
+  GitBranch,
   Globe,
   type LucideIcon,
   SquareTerminal,
@@ -23,6 +24,7 @@ import { getShortcutKeys } from "@src/config/keyboard/shortcutDisplay";
 import { ROUTES } from "@src/config/routes";
 import { getTerminalDisplayTitle } from "@src/engines/TerminalCore/types";
 import { useActiveRepoRef } from "@src/hooks/git/useActiveRepoRef";
+import { useRepoSelection } from "@src/hooks/git/useRepoSelection";
 import { useWorkingTreeDiffTotals } from "@src/hooks/git/useWorkingTreeDiffTotals";
 import { useCloseTabWithGuard } from "@src/hooks/workStation/tabs/useCloseTabWithGuard";
 import { WorkStationViewService } from "@src/services/workStation/WorkStationViewService";
@@ -124,6 +126,9 @@ export function FocusedChatWorkstationRail() {
     chatPanelSurface.kind === CHAT_PANEL_SURFACE_KIND.WORK_ITEM;
 
   const activeWorkspaceRoot = useAtomValue(activeWorkspaceRootAtom);
+  const workspacePath = activeWorkspaceRoot?.path;
+  const { currentBranch } = useRepoSelection({ autoLoad: false });
+  const branchName = currentBranch || undefined;
 
   // Working-tree +/- shown on the Review row, matching the branch pill's badge.
   const { repoId, repoPath } = useActiveRepoRef();
@@ -378,6 +383,26 @@ export function FocusedChatWorkstationRail() {
                 <div className="text-text-tertiary mb-1.5 px-1 text-[11px] font-medium uppercase tracking-wide">
                   {section.label}
                 </div>
+                {section.key === "workspace" &&
+                  (branchName || workspacePath) && (
+                    <div className="mb-1.5 space-y-0.5">
+                      {branchName && (
+                        <div className="text-text-tertiary flex h-6 min-w-0 items-center gap-1.5 truncate rounded-lg px-2 text-[11px]">
+                          <GitBranch size={11} className="shrink-0" />
+                          <span className="truncate">{branchName}</span>
+                        </div>
+                      )}
+                      {workspacePath && (
+                        <div
+                          className="text-text-tertiary flex h-6 min-w-0 items-center gap-1.5 truncate rounded-lg px-2 text-[11px]"
+                          title={workspacePath}
+                        >
+                          <Folder size={11} className="shrink-0" />
+                          <span className="truncate">{workspacePath}</span>
+                        </div>
+                      )}
+                    </div>
+                  )}
                 <div className="space-y-1">
                   {section.items.map((item) => {
                     const Icon = item.icon;


### PR DESCRIPTION
## Summary

Surfaces the current branch and worktree path in three places so the active repo context is visible without opening the status bar.

## Changes

### 1. `FocusedChatWorkstationRail` — workspace section info rows
Below the "Workspace" section header, two read-only rows (branch + worktree path) appear when the rail is expanded. Each row is an independent `h-6` line matching the rail's row rhythm. Branch comes from `useRepoSelection().currentBranch`; path from `activeWorkspaceRoot.path`.

### 2. `SessionHoverCard` — branch row promoted to top + real-time fallback
- The existing `repo · branch` row is moved to the top of the card (above agent/model), since branch/repo context is what you scan first on a session.
- Added a real-time branch fallback at the end of the `branchLabel` chain. It is **gated**: the global `useRepoSelection().currentBranch` is only used when the session's `repoPath` matches the active workspace root, so cross-repo sessions in the list never show the wrong branch.

### 3. `WorktreeBranchPill` (new) — in the chat composer bar
New read-only pill `📁 worktree · 🌿 branch` placed inside the pills cluster, right after `model | effort`. Left-aligned with the other pills (not centered, not in its own grid area — tried a center grid area first, reverted because it broke the rhythm). Subscribes to `activeWorkspaceRootAtom` and `useRepoSelection({ autoLoad: false })`. Returns `null` when both are empty.

## Why not center / why in pills cluster
A dedicated center grid area (`left pills center right`) was implemented and then reverted — it required widening the shared `ComposerBar` template (affecting `SessionCreator` too) and left an awkward center orphan in compact rows. Putting the pill in the pills cluster is a 2-line addition, keeps it left-aligned next to model|effort (matching Claude Code CLI's bottom-bar grouping), and naturally inherits the pills cluster's hide/show behavior.

## Verification
- `tsc --noEmit` — 0 errors across all changed files
- pre-commit hooks (lint-staged / eslint / prettier / scoped type check) — all passed
