### PR TITLE
refactor(replay): centralize diff start-line evidence

### DIFF
--- a/docs/architecture-audit-2026-07-21/DiffStartLines.md
+++ b/docs/architecture-audit-2026-07-21/DiffStartLines.md
@@ -1,0 +1,66 @@
+# Architecture Audit — Diff Start-Line Evidence
+
+**Scope:** shared replay diff start-line evidence and its two construction pipelines
+**Date:** 2026-07-21
+**Auditor:** Codex
+
+## 10-layer audit
+
+### Layer 1 — Compilation correctness
+
+- The split branch passes the scoped TypeScript pre-commit check.
+- Twenty-one targeted Vitest tests pass across the shared helper, file converter, and replay section builder.
+
+### Layer 2 — Dead code and structural deduplication
+
+- `src/util/diff/startLines.ts` owns the only implementation of the evidence predicate.
+- `fileConverter.ts` re-exports the helper because existing replay consumers import through that public boundary; both construction pipelines execute the shared implementation.
+
+### Layer 3 — Naming consistency
+
+- `shouldTrustDiffStartLines` is retained at all call sites and still describes the boolean contract.
+- The removed private helpers have no remaining definitions.
+
+### Layer 4 — Semantic overloading
+
+| Term                | Meaning                                                                        | Verdict                                          |
+| ------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------ |
+| trusted start lines | Line offsets backed by an ordinary edit, unified hunk, or concrete result diff | Keep; one shared predicate now defines the term. |
+
+### Layer 5 — Default branch analysis
+
+- Missing events return `false`.
+- Events without patch text retain the existing ordinary-edit behavior and return `true`.
+- Compact patch placeholders require either a unified hunk or a concrete result diff.
+
+### Layer 6 — Cross-domain leakage
+
+- The shared utility accepts a minimal evidence shape and does not import workstation or session-event modules.
+- Replay-specific event types remain in their existing callers.
+
+### Layer 7 — New-developer confusion test
+
+- The helper comment states why the predicate exists.
+- The public name and tests make the accepted evidence forms explicit.
+
+### Layer 8 — Wire protocol and serialization
+
+- No request, response, persisted record, or serialized event shape changes.
+- The change only interprets existing in-memory event evidence.
+
+### Layer 9 — Init parity
+
+| Entry point                             | Shared predicate              |
+| --------------------------------------- | ----------------------------- |
+| Session replay file conversion          | `src/util/diff/startLines.ts` |
+| Workstation replay section construction | `src/util/diff/startLines.ts` |
+
+### Layer 10 — Resolver symmetry
+
+- Both replay pipelines evaluate the same argument and result fallback chain through the shared helper.
+- No multi-field resolver or database fallback chain is introduced.
+
+## Systematic sweep
+
+- Searched every `shouldTrustDiffStartLines` definition and consumer; one implementation remains.
+- Targeted tests cover missing events, ordinary edits, unified hunks, compact placeholders, and result-backed diffs.

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/converters/fileConverter.ts
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/converters/fileConverter.ts
@@ -14,6 +14,7 @@ import { getAppSubtool } from "@src/engines/SessionCore/rendering/registry/initT
 import { isDeleteTool } from "@src/engines/SessionCore/rendering/registry/toolRegistryDomain";
 import type { EventStatus } from "@src/engines/SessionCore/rendering/types/universalProps";
 import { getEventStatus } from "@src/util/data/converters/eventStatus";
+import { shouldTrustDiffStartLines } from "@src/util/diff/startLines";
 
 import {
   FILE_OPERATION_TYPE,
@@ -22,8 +23,6 @@ import {
 } from "../types";
 
 const HUNK_HEADER_REGEX = /^@@\s+-(\d+)(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/;
-const PATCH_HUNK_HEADER_REGEX =
-  /^@@\s+-(\d+)(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/m;
 
 interface ParsedUnifiedDiffPayload {
   oldContent: string;
@@ -107,37 +106,7 @@ function parseUnifiedDiffPayload(
   };
 }
 
-function patchTextFromArgs(args: SessionEvent["args"]): string | undefined {
-  if (typeof args?.patch_text === "string") return args.patch_text;
-  if (typeof args?.patch === "string") return args.patch;
-  if (typeof args?.input === "string") return args.input;
-  return undefined;
-}
-
-function resultHasRealDiff(result: SessionEvent["result"]): boolean {
-  if (!result) return false;
-  if (
-    typeof result.diffString === "string" ||
-    typeof result.diff === "string"
-  ) {
-    return true;
-  }
-  if (Array.isArray(result.segments) && result.segments.length > 0) {
-    return true;
-  }
-  const output = result.output as Record<string, unknown> | undefined;
-  const success = output?.success as Record<string, unknown> | undefined;
-  return Boolean(
-    typeof success?.diffString === "string" || typeof success?.diff === "string"
-  );
-}
-
-export function shouldTrustDiffStartLines(event: SessionEvent): boolean {
-  const patchText = patchTextFromArgs(event.args);
-  if (!patchText) return true;
-  if (PATCH_HUNK_HEADER_REGEX.test(patchText)) return true;
-  return resultHasRealDiff(event.result);
-}
+export { shouldTrustDiffStartLines } from "@src/util/diff/startLines";
 
 export function parseFilePath(path: string): {
   fileName: string;

--- a/src/modules/WorkStation/shared/DiffSectionList/sessionReplaySections.ts
+++ b/src/modules/WorkStation/shared/DiffSectionList/sessionReplaySections.ts
@@ -5,13 +5,11 @@ import {
   parseUnifiedDiffToOldNew,
 } from "@src/engines/SessionCore/rendering/props/propsDataExtractors";
 import { normalizeEventProps } from "@src/engines/SessionCore/rendering/props/propsNormalizer";
+import { shouldTrustDiffStartLines } from "@src/util/diff/startLines";
 import { normalizeDiffFilePath } from "@src/util/file/pathUtils";
 
 import type { DiffFileSectionData } from "../DiffFileSection";
 import type { DiffSectionListItem } from "./index";
-
-const PATCH_HUNK_HEADER_REGEX =
-  /^@@\s+-(\d+)(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/m;
 
 export interface SessionReplayDiffEntryLike {
   entryId: string;
@@ -24,38 +22,6 @@ export interface SessionReplayDiffSectionItem extends DiffSectionListItem<DiffFi
   entryIds: string[];
   /** Raw compact diff strings from each edit, used for multi-hunk merge during consolidation. */
   rawDiffs: string[];
-}
-
-function patchTextFromArgs(args: SessionEvent["args"]): string | undefined {
-  if (typeof args?.patch_text === "string") return args.patch_text;
-  if (typeof args?.patch === "string") return args.patch;
-  if (typeof args?.input === "string") return args.input;
-  return undefined;
-}
-
-function resultHasRealDiff(result: SessionEvent["result"]): boolean {
-  if (!result) return false;
-  if (
-    typeof result.diffString === "string" ||
-    typeof result.diff === "string"
-  ) {
-    return true;
-  }
-  if (Array.isArray(result.segments) && result.segments.length > 0) {
-    return true;
-  }
-  const output = result.output as Record<string, unknown> | undefined;
-  const success = output?.success as Record<string, unknown> | undefined;
-  return Boolean(
-    typeof success?.diffString === "string" || typeof success?.diff === "string"
-  );
-}
-
-function shouldTrustDiffStartLines(event: SessionEvent): boolean {
-  const patchText = patchTextFromArgs(event.args);
-  if (!patchText) return true;
-  if (PATCH_HUNK_HEADER_REGEX.test(patchText)) return true;
-  return resultHasRealDiff(event.result);
 }
 
 function getDiffStatus(

--- a/src/util/diff/__tests__/startLines.test.ts
+++ b/src/util/diff/__tests__/startLines.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldTrustDiffStartLines } from "../startLines";
+
+describe("shouldTrustDiffStartLines", () => {
+  it("rejects missing events", () => {
+    expect(shouldTrustDiffStartLines(null)).toBe(false);
+    expect(shouldTrustDiffStartLines(undefined)).toBe(false);
+  });
+
+  it("trusts ordinary edits and unified diff hunks", () => {
+    expect(shouldTrustDiffStartLines({ args: {} })).toBe(true);
+    expect(
+      shouldTrustDiffStartLines({
+        args: { patch: "@@ -4,2 +9,3 @@\n-old\n+new" },
+      })
+    ).toBe(true);
+  });
+
+  it("rejects compact patch placeholders unless the result has a real diff", () => {
+    const compactPatch = { args: { patch: "*** Begin Patch" } };
+    expect(shouldTrustDiffStartLines(compactPatch)).toBe(false);
+    expect(
+      shouldTrustDiffStartLines({
+        ...compactPatch,
+        result: { output: { success: { diffString: "@@ -1 +1 @@" } } },
+      })
+    ).toBe(true);
+  });
+});

--- a/src/util/diff/startLines.ts
+++ b/src/util/diff/startLines.ts
@@ -1,0 +1,45 @@
+interface DiffStartLineEvidence {
+  args?: Record<string, unknown>;
+  result?: Record<string, unknown>;
+}
+
+const PATCH_HUNK_HEADER_REGEX =
+  /^@@\s+-(\d+)(?:,\d+)?\s+\+(\d+)(?:,\d+)?\s+@@/m;
+
+function patchTextFromArgs(
+  args: DiffStartLineEvidence["args"]
+): string | undefined {
+  if (typeof args?.patch_text === "string") return args.patch_text;
+  if (typeof args?.patch === "string") return args.patch;
+  if (typeof args?.input === "string") return args.input;
+  return undefined;
+}
+
+function resultHasRealDiff(result: DiffStartLineEvidence["result"]): boolean {
+  if (!result) return false;
+  if (
+    typeof result.diffString === "string" ||
+    typeof result.diff === "string"
+  ) {
+    return true;
+  }
+  if (Array.isArray(result.segments) && result.segments.length > 0) {
+    return true;
+  }
+  const output = result.output as Record<string, unknown> | undefined;
+  const success = output?.success as Record<string, unknown> | undefined;
+  return Boolean(
+    typeof success?.diffString === "string" || typeof success?.diff === "string"
+  );
+}
+
+/** Whether line offsets attached to a file event are backed by a real diff. */
+export function shouldTrustDiffStartLines(
+  event: DiffStartLineEvidence | null | undefined
+): boolean {
+  if (!event) return false;
+  const patchText = patchTextFromArgs(event.args);
+  if (!patchText) return true;
+  if (PATCH_HUNK_HEADER_REGEX.test(patchText)) return true;
+  return resultHasRealDiff(event.result);
+}


### PR DESCRIPTION
## Summary

- centralize diff start-line evidence in one shared utility
- route both replay construction pipelines through the same predicate
- preserve the existing file-converter export for current consumers
- include a scoped 10-layer architecture audit

Split from #442.

## Validation

- 21 targeted Vitest tests across the shared helper, file converter, and replay section builder
- targeted ESLint and Prettier via the pre-commit hook
- scoped TypeScript pre-commit check
