### PR TITLE
perf(warp): decode only changed imported conversations

### DIFF
--- a/docs/architecture-audit-2026-07-21/WarpHistoryCache.md
+++ b/docs/architecture-audit-2026-07-21/WarpHistoryCache.md
@@ -1,0 +1,65 @@
+# Architecture Audit — Warp History Cache
+
+**Scope:** per-conversation Warp cache signatures and changed-record decoding
+**Date:** 2026-07-21
+**Auditor:** Codex
+
+## 10-layer audit
+
+### Layer 1 — Compilation correctness
+
+- `cargo check -p orgtrack_core` passes.
+- `cargo clippy -p orgtrack_core --lib` reports only the unchanged `qoder/log_enrichment.rs` type-complexity warning; changed Warp code is clean.
+- All six targeted Warp history tests pass.
+
+### Layer 2 — Dead code and structural deduplication
+
+- `WarpConversationRecord::signature` is the single constructor used by cache comparison and cache-input creation.
+- Task protobufs are loaded and decoded only for records returned by `changed_records_from_conn`.
+
+### Layer 3 — Naming consistency
+
+- `task_last_modified_at` identifies per-conversation task freshness rather than database-global WAL state.
+- `signature` matches the imported-history cache terminology used by sibling importers.
+
+### Layer 4 — Semantic overloading
+
+| Term      | Meaning                                                                     | Verdict                                                         |
+| --------- | --------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| signature | Per-conversation metadata sufficient to decide whether decoding is required | Keep; database-global sidecar state is no longer mixed into it. |
+
+### Layer 5 — Default branch analysis
+
+- Missing or malformed timestamps fall back to zero without hiding a changed fingerprint.
+- Missing task aggregates retain explicit empty defaults.
+- An unavailable Warp database continues through the existing empty-source synchronization path.
+
+### Layer 6 — Cross-domain leakage
+
+- Warp SQL and protobuf analysis remain inside the Warp source module.
+- Generic changed-record and live-ID operations remain owned by imported-history cache helpers.
+
+### Layer 7 — New-developer confusion test
+
+- Signature construction is colocated with the queried record fields.
+- The sync flow reads as discover records, compare signatures, decode changed records, then synchronize live IDs.
+
+### Layer 8 — Wire protocol and serialization
+
+- No external network payload changes.
+- Persisted imported-history signature columns retain their existing contract and parser version.
+
+### Layer 9 — Init parity
+
+- Initial import and subsequent refresh use the same record query and signature constructor.
+- Pre-summary Warp schemas remain covered by the compatibility test.
+
+### Layer 10 — Resolver symmetry
+
+- Cache comparison and cache-input creation call the same `record.signature(db_path)` method.
+- Conversation and task modification timestamps participate in one symmetric maximum-freshness calculation.
+
+## Systematic sweep
+
+- Compared the Warp importer with sibling `changed_records_from_conn` consumers.
+- Verified live-ID derivation remains independent of the changed-record subset so deletions still synchronize.

--- a/src-tauri/crates/orgtrack-core/src/sources/warp/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/warp/history.rs
@@ -20,9 +20,12 @@ use serde_json::{json, Value};
 
 use crate::sources::imported_history::{
     self, cache as imported_cache,
-    metadata::{ImportedHistoryCacheInput, ImportedHistoryImpactStats, SOURCE_WARP},
-    paths as imported_paths, ImportedHistoryRecentPath, ImportedHistorySessionPage,
-    ImportedHistorySessionRow, ImportedToolCall,
+    metadata::{
+        ImportedHistoryCacheInput, ImportedHistoryImpactStats, ImportedHistoryRecordSignature,
+        SOURCE_WARP,
+    },
+    ImportedHistoryRecentPath, ImportedHistorySessionPage, ImportedHistorySessionRow,
+    ImportedToolCall,
 };
 
 pub const WARP_SESSION_PREFIX: &str = "warpapp-";
@@ -86,6 +89,22 @@ struct WarpConversationRecord {
     summary_json: Option<String>,
     task_count: i64,
     task_bytes: i64,
+    task_last_modified_at: String,
+}
+
+impl WarpConversationRecord {
+    fn signature(&self, db_path: &Path) -> ImportedHistoryRecordSignature {
+        let conversation_modified = parse_warp_timestamp_ms(&self.last_modified_at).unwrap_or(0);
+        let task_modified = parse_warp_timestamp_ms(&self.task_last_modified_at).unwrap_or(0);
+        ImportedHistoryRecordSignature {
+            source_session_id: self.conversation_id.clone(),
+            source_path: db_path.to_string_lossy().to_string(),
+            source_mtime_ms: conversation_modified.max(task_modified),
+            source_size_bytes: self.task_bytes,
+            source_fingerprint: warp_source_fingerprint(self),
+            parser_version: WARP_METADATA_PARSER_VERSION,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default)]
@@ -146,17 +165,18 @@ fn sync_warp_history_cache(cache_conn: &mut Connection) -> Result<(), String> {
         return Ok(());
     };
 
-    let (source_mtime_ms, source_size_bytes) =
-        imported_paths::file_metadata_signature(&db_path, "Warp")?;
-    let sidecar_signature = imported_paths::sqlite_sidecar_signature(&db_path);
     let records = list_conversation_records(&source_conn)?;
-    let live_ids = records
+    let signatures = records
         .iter()
-        .map(|record| record.conversation_id.clone())
+        .map(|record| record.signature(&db_path))
         .collect::<Vec<_>>();
-    let mut inputs = Vec::with_capacity(records.len());
+    let changed =
+        imported_cache::changed_records_from_conn(cache_conn, SOURCE_WARP, &records, |record| {
+            record.signature(&db_path)
+        })?;
+    let mut inputs = Vec::with_capacity(changed.len());
 
-    for record in records {
+    for record in changed {
         let fallback_ms = parse_warp_timestamp_ms(&record.last_modified_at).unwrap_or(0);
         let task_blobs = load_task_blobs(&source_conn, &record.conversation_id)?;
         let analysis = analyze_task_blobs(
@@ -165,16 +185,18 @@ fn sync_warp_history_cache(cache_conn: &mut Connection) -> Result<(), String> {
             fallback_ms,
         );
         inputs.push(conversation_to_cache_input(
-            record,
+            record.clone(),
             analysis,
             &db_path,
-            source_mtime_ms,
-            source_size_bytes,
-            &sidecar_signature,
         ));
     }
 
-    imported_cache::sync_source_cache_from_conn(cache_conn, SOURCE_WARP, live_ids, inputs)
+    imported_cache::sync_source_cache_from_conn(
+        cache_conn,
+        SOURCE_WARP,
+        imported_cache::live_ids_from_signatures(&signatures),
+        inputs,
+    )
 }
 
 fn list_conversation_records(conn: &Connection) -> Result<Vec<WarpConversationRecord>, String> {
@@ -190,7 +212,8 @@ fn list_conversation_records(conn: &Connection) -> Result<Vec<WarpConversationRe
         "SELECT c.conversation_id, c.conversation_data, \
                 CAST(c.last_modified_at AS TEXT), {summary_expr}, \
                 (SELECT COUNT(*) FROM agent_tasks t WHERE t.conversation_id = c.conversation_id), \
-                (SELECT COALESCE(SUM(LENGTH(t.task)), 0) FROM agent_tasks t WHERE t.conversation_id = c.conversation_id) \
+                (SELECT COALESCE(SUM(LENGTH(t.task)), 0) FROM agent_tasks t WHERE t.conversation_id = c.conversation_id), \
+                (SELECT COALESCE(MAX(CAST(t.last_modified_at AS TEXT)), '') FROM agent_tasks t WHERE t.conversation_id = c.conversation_id) \
          FROM agent_conversations c ORDER BY c.last_modified_at ASC, c.id ASC"
     );
     let mut stmt = conn
@@ -205,6 +228,7 @@ fn list_conversation_records(conn: &Connection) -> Result<Vec<WarpConversationRe
                 summary_json: row.get(3)?,
                 task_count: row.get::<_, Option<i64>>(4)?.unwrap_or_default(),
                 task_bytes: row.get::<_, Option<i64>>(5)?.unwrap_or_default(),
+                task_last_modified_at: row.get::<_, Option<String>>(6)?.unwrap_or_default(),
             })
         })
         .map_err(|err| format!("Failed to query Warp conversations: {err}"))?;
@@ -223,10 +247,8 @@ fn conversation_to_cache_input(
     record: WarpConversationRecord,
     analysis: WarpTaskAnalysis,
     db_path: &Path,
-    source_mtime_ms: i64,
-    source_size_bytes: i64,
-    sidecar_signature: &str,
 ) -> ImportedHistoryCacheInput {
+    let signature = record.signature(db_path);
     let summary = record
         .summary_json
         .as_deref()
@@ -263,7 +285,6 @@ fn conversation_to_cache_input(
     let updated_at_ms = analysis.updated_at_ms.unwrap_or(fallback_updated_at);
     let parent_session_id = non_empty(data.parent_conversation_id.as_deref())
         .map(|parent| format!("{WARP_SESSION_PREFIX}{parent}"));
-    let source_fingerprint = warp_source_fingerprint(&record, sidecar_signature);
     let listable =
         !data.is_remote_child && !summary.is_unlisted_auto_code_diff && !analysis.chunks.is_empty();
     let source_metadata_json = serde_json::to_string(&json!({
@@ -276,12 +297,12 @@ fn conversation_to_cache_input(
         source: SOURCE_WARP,
         source_session_id: record.conversation_id.clone(),
         session_id: format!("{WARP_SESSION_PREFIX}{}", record.conversation_id),
-        source_path: db_path.to_string_lossy().to_string(),
+        source_path: signature.source_path,
         source_record_key: record.conversation_id,
-        source_mtime_ms,
-        source_size_bytes,
-        source_fingerprint,
-        parser_version: WARP_METADATA_PARSER_VERSION,
+        source_mtime_ms: signature.source_mtime_ms,
+        source_size_bytes: signature.source_size_bytes,
+        source_fingerprint: signature.source_fingerprint,
+        parser_version: signature.parser_version,
         name: imported_history::truncate_name(&title, 200),
         created_at_ms,
         updated_at_ms,
@@ -299,7 +320,7 @@ fn conversation_to_cache_input(
     }
 }
 
-fn warp_source_fingerprint(record: &WarpConversationRecord, sidecar_signature: &str) -> String {
+fn warp_source_fingerprint(record: &WarpConversationRecord) -> String {
     [
         record.conversation_id.as_str(),
         record.conversation_data_json.as_str(),
@@ -307,7 +328,7 @@ fn warp_source_fingerprint(record: &WarpConversationRecord, sidecar_signature: &
         record.last_modified_at.as_str(),
         &record.task_count.to_string(),
         &record.task_bytes.to_string(),
-        sidecar_signature,
+        record.task_last_modified_at.as_str(),
     ]
     .join("|")
 }
@@ -325,12 +346,14 @@ fn analyze_task_blobs(
         }
     }
 
-    let mut analysis = WarpTaskAnalysis::default();
-    analysis.root_description = task_values
-        .iter()
-        .find(|task| is_root_task(task))
-        .and_then(|task| field_str(task, &["description"]))
-        .and_then(|value| non_empty(Some(value)));
+    let mut analysis = WarpTaskAnalysis {
+        root_description: task_values
+            .iter()
+            .find(|task| is_root_task(task))
+            .and_then(|task| field_str(task, &["description"]))
+            .and_then(|value| non_empty(Some(value))),
+        ..WarpTaskAnalysis::default()
+    };
 
     let mut messages = Vec::new();
     for (task_index, task) in task_values.iter().enumerate() {

--- a/src-tauri/crates/orgtrack-core/src/sources/warp/history_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/warp/history_tests.rs
@@ -143,14 +143,8 @@ fn metadata_uses_summary_usage_parent_and_invalidates_cache_signatures() {
         .expect("record");
     let blobs = load_task_blobs(&conn, "conversation-1").expect("task blobs");
     let analysis = analyze_task_blobs("warpapp-conversation-1", &blobs, 0);
-    let input = conversation_to_cache_input(
-        record.clone(),
-        analysis,
-        Path::new("/tmp/warp.sqlite"),
-        100,
-        200,
-        "wal:10",
-    );
+    let input =
+        conversation_to_cache_input(record.clone(), analysis, Path::new("/tmp/warp.sqlite"));
 
     assert_eq!(input.session_id, "warpapp-conversation-1");
     assert_eq!(input.name, "Warp importer");
@@ -186,7 +180,7 @@ fn metadata_uses_summary_usage_parent_and_invalidates_cache_signatures() {
         ..record
     };
     let mut content_changed = cached_signature.clone();
-    content_changed.source_fingerprint = warp_source_fingerprint(&changed, "wal:10");
+    content_changed.source_fingerprint = warp_source_fingerprint(&changed);
     assert!(!imported_cache::record_matches_cached_signature(
         &cached_signature,
         &content_changed


### PR DESCRIPTION
## Summary

- derive cache signatures from per-conversation Warp metadata
- decode task protobufs only for records whose signature changed
- keep live-ID synchronization independent so deleted conversations still clear
- include a scoped 10-layer architecture audit

Split from #442.

## Validation

- `cargo test -p orgtrack_core sources::warp::history::tests` — 6 tests passed
- `cargo check -p orgtrack_core`
- `cargo clippy -p orgtrack_core --lib` — changed code clean; unchanged qoder type-complexity warning remains
