### PR TITLE
refactor(ui): reuse editor canvas background token

### DIFF
--- a/docs/frontend-ui-audit-2026-07-20/EditorCanvasToken.md
+++ b/docs/frontend-ui-audit-2026-07-20/EditorCanvasToken.md
@@ -1,0 +1,45 @@
+# Frontend UI Audit — Editor Canvas Token
+
+**Scope:** six changed `*.tsx` consumers of the CodeMirror editor-canvas background
+**Date:** 2026-07-20
+**Auditor:** Codex
+
+## D1 — Raw HTML vs Design System
+
+| Line | Element                         | Verdict          | Reason                                                                                                          | Suggested change |
+| ---: | ------------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------- | ---------------- |
+|    — | Existing containers and buttons | keep with reason | This sweep changes only background-token ownership; replacing established semantic elements would be unrelated. | None.            |
+
+## D2 — Arbitrary Tailwind Value vs Token
+
+|                                 Line | Element                           | Verdict  | Reason                                                                                                                   | Suggested change                  |
+| -----------------------------------: | --------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------------- |
+|          `ActivitySimulator.tsx:255` | Empty simulator canvas            | abstract | Repeated `bg-[var(--cm-editor-background)]` encoded the same workstation surface contract locally.                       | Use `EDITOR_TAB_CANVAS_BG_CLASS`. |
+|       `SubagentPromptToggle.tsx:131` | Prompt dialog canvas              | abstract | Same editor-canvas background contract as the simulator and diff surfaces.                                               | Use `EDITOR_TAB_CANVAS_BG_CLASS`. |
+|            `CombinedDiffView.tsx:72` | Sticky diff header                | abstract | Same editor-canvas background contract as other workstation headers.                                                     | Use `EDITOR_TAB_CANVAS_BG_CLASS`. |
+|      `DiffFileSection/index.tsx:416` | Diff file header                  | abstract | Same editor-canvas background contract as other diff headers.                                                            | Use `EDITOR_TAB_CANVAS_BG_CLASS`. |
+| `FocusedChatWorkstationRail.tsx:331` | Focused-chat workstation rail     | abstract | A new exact editor-canvas background literal landed on `develop` after the original audit and belongs to the same sweep. | Use `EDITOR_TAB_CANVAS_BG_CLASS`. |
+|          `PanelHeader/index.tsx:294` | `editorCanvas` background variant | abstract | The named variant should resolve through the shared workstation token rather than restating its implementation.          | Use `EDITOR_TAB_CANVAS_BG_CLASS`. |
+
+## D3 — Hardcoded Sizes / Colors
+
+| Line | Element                | Verdict          | Reason                                                                                                      | Suggested change |
+| ---: | ---------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------- | ---------------- |
+|    — | Changed surface colors | keep with reason | No literal color or new size was introduced; the sweep removes five repeated arbitrary-value class strings. | None.            |
+
+## D4 — Accessibility
+
+| Line | Element           | Verdict          | Reason                                                                                                | Suggested change |
+| ---: | ----------------- | ---------------- | ----------------------------------------------------------------------------------------------------- | ---------------- |
+|    — | Existing controls | keep with reason | Class composition only; roles, accessible names, focus behavior, and keyboard behavior are unchanged. | None.            |
+
+## D5 — Visual Patterns Observed
+
+- `EDITOR_TAB_CANVAS_BG_CLASS` is now the single shared expression for the six exact editor-canvas background uses in changed TSX surfaces.
+- No additional multi-file design-system sweep candidate was found in this scope.
+
+## Summary
+
+- 0 fixes recommended
+- 3 kept with documented reason
+- 6 abstract candidates completed

--- a/src/engines/Simulator/ActivitySimulator.tsx
+++ b/src/engines/Simulator/ActivitySimulator.tsx
@@ -17,6 +17,7 @@ import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import React, { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { EDITOR_TAB_CANVAS_BG_CLASS } from "@src/config/workstation/tokens";
 import { RecentFilesProvider } from "@src/contexts/session";
 import { replayModeAtom } from "@src/engines/SessionCore";
 import type { ReplayMode } from "@src/engines/SessionCore/core/types";
@@ -250,7 +251,9 @@ const ActivitySimulator: React.FC = memo(() => {
 
   if (!hasSession) {
     return (
-      <div className="flex h-full w-full items-center justify-center bg-[var(--cm-editor-background)] p-4">
+      <div
+        className={`flex h-full w-full items-center justify-center p-4 ${EDITOR_TAB_CANVAS_BG_CLASS}`}
+      >
         <span className="text-sm text-text-3">
           {t("simulator.noActiveSession")}
         </span>

--- a/src/engines/Simulator/components/GridCell/SubagentPromptToggle.tsx
+++ b/src/engines/Simulator/components/GridCell/SubagentPromptToggle.tsx
@@ -21,6 +21,7 @@ import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
+import { EDITOR_TAB_CANVAS_BG_CLASS } from "@src/config/workstation/tokens";
 import {
   type ParsedTaskAssignedPrompt,
   parseTaskAssignedPrompt,
@@ -127,7 +128,7 @@ const SubagentPromptToggleComponent: React.FC<SubagentPromptToggleProps> = ({
             ref={panelRef}
             role="dialog"
             aria-label={label}
-            className="z-50 flex min-w-[280px] flex-col overflow-hidden rounded-lg border border-border-2 bg-[var(--cm-editor-background)] shadow-lg"
+            className={`z-50 flex min-w-[280px] flex-col overflow-hidden rounded-lg border border-border-2 shadow-lg ${EDITOR_TAB_CANVAS_BG_CLASS}`}
             style={panelStyle}
           >
             {prompt.parsed ? (

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/CodePanel/CombinedDiffView.tsx
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/CodePanel/CombinedDiffView.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
 import DiffStatsBadge from "@src/components/DiffStatsBadge";
+import { EDITOR_TAB_CANVAS_BG_CLASS } from "@src/config/workstation/tokens";
 import { VirtualizedModernDiff } from "@src/features/CodeViewer/VirtualizedModernDiff";
 
 import { shouldTrustDiffStartLines } from "../converters/fileConverter";
@@ -68,7 +69,7 @@ const EditSection: React.FC<{
     <div className="flex flex-col">
       <button
         onClick={toggleCollapse}
-        className="sticky top-0 z-10 flex h-10 w-full cursor-pointer items-center gap-2 border-t border-border-2 bg-[var(--cm-editor-background)] px-3 text-[11px] hover:bg-fill-2"
+        className={`sticky top-0 z-10 flex h-10 w-full cursor-pointer items-center gap-2 border-t border-border-2 px-3 text-[11px] hover:bg-fill-2 ${EDITOR_TAB_CANVAS_BG_CLASS}`}
       >
         {isCollapsed ? (
           <ChevronsUpDown size={14} className="shrink-0 text-text-3" />

--- a/src/modules/WorkStation/shared/DiffFileSection/index.tsx
+++ b/src/modules/WorkStation/shared/DiffFileSection/index.tsx
@@ -18,6 +18,7 @@ import {
   getStatusColor,
   getStatusLetterForFile,
 } from "@src/config/gitStatus";
+import { EDITOR_TAB_CANVAS_BG_CLASS } from "@src/config/workstation/tokens";
 import { FileHeader } from "@src/modules/shared/components/FileHeader";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
 import {
@@ -412,7 +413,7 @@ const DiffFileSection: React.FC<DiffFileSectionProps> = ({
         data-diff-section-path={dataPath}
       >
         <button
-          className="sticky top-0 z-10 flex w-full min-w-0 items-center gap-2 bg-[var(--cm-editor-background)] px-3 py-2 text-left hover:bg-fill-2 disabled:cursor-default disabled:hover:bg-transparent"
+          className={`sticky top-0 z-10 flex w-full min-w-0 items-center gap-2 px-3 py-2 text-left hover:bg-fill-2 disabled:cursor-default disabled:hover:bg-transparent ${EDITOR_TAB_CANVAS_BG_CLASS}`}
           onClick={toggleExpanded}
           disabled={isDeleted}
         >

--- a/src/modules/shared/layouts/FocusedChatWorkstationRail.tsx
+++ b/src/modules/shared/layouts/FocusedChatWorkstationRail.tsx
@@ -22,6 +22,7 @@ import { KeyboardShortcutTooltipContent } from "@src/components/KeyboardShortcut
 import Tooltip from "@src/components/Tooltip";
 import { getShortcutKeys } from "@src/config/keyboard/shortcutDisplay";
 import { ROUTES } from "@src/config/routes";
+import { EDITOR_TAB_CANVAS_BG_CLASS } from "@src/config/workstation/tokens";
 import { getTerminalDisplayTitle } from "@src/engines/TerminalCore/types";
 import { useActiveRepoRef } from "@src/hooks/git/useActiveRepoRef";
 import { useRepoSelection } from "@src/hooks/git/useRepoSelection";
@@ -327,7 +328,7 @@ export function FocusedChatWorkstationRail() {
   return (
     <div className="pointer-events-none absolute right-1 top-[88px] z-20 hidden xl:flex">
       <div
-        className={`pointer-events-auto flex bg-[var(--cm-editor-background)] transition-all ${
+        className={`pointer-events-auto flex transition-all ${EDITOR_TAB_CANVAS_BG_CLASS} ${
           collapsed
             ? "flex-col items-center rounded-xl border-[1px] border-border-1 p-1"
             : "w-64 flex-col rounded-xl border-[1px] border-border-1 p-1"

--- a/src/modules/shared/layouts/blocks/PanelHeader/index.tsx
+++ b/src/modules/shared/layouts/blocks/PanelHeader/index.tsx
@@ -41,6 +41,7 @@ import {
 import React, { createContext, memo, useContext } from "react";
 
 import Button from "@src/components/Button";
+import { EDITOR_TAB_CANVAS_BG_CLASS } from "@src/config/workstation/tokens";
 import { useRefreshSpin } from "@src/hooks/ui";
 
 /**
@@ -290,7 +291,7 @@ const PanelHeader: React.FC<PanelHeaderProps> = memo(
       resolvedBackground === "transparent"
         ? ""
         : resolvedBackground === "editorCanvas"
-          ? "bg-[var(--cm-editor-background)]"
+          ? EDITOR_TAB_CANVAS_BG_CLASS
           : "bg-bg-2";
 
     // Render custom content or default title/breadcrumb


### PR DESCRIPTION
## Summary

- replace six repeated CodeMirror canvas-background literals with the shared workstation token
- preserve the latest `develop` structure in `DiffFileSection`
- extend the sweep to the newly landed focused-chat workstation rail
- include the scoped frontend UI audit report

Split from #442.

## Validation

- targeted ESLint for all six changed TSX files
- scoped TypeScript pre-commit check
- repository sweep finds zero remaining exact TSX literals for the canvas background

## UI audit verdicts

- 0 fixes recommended
- 3 kept with documented reason
- 6 abstract candidates completed
