### PR TITLE
fix(codex): reconnect expired OAuth accounts from chat

### DIFF
--- a/docs/architecture-audit-2026-07-21/CodexReauthentication.md
+++ b/docs/architecture-audit-2026-07-21/CodexReauthentication.md
@@ -1,0 +1,73 @@
+# Architecture Audit — Codex Reauthentication
+
+**Scope:** expired-login detection, repair routing, Key Vault readiness, account replacement, OAuth auto-start, and return navigation
+**Date:** 2026-07-21
+**Auditor:** Codex
+
+## 10-layer audit
+
+### Layer 1 — Compilation correctness
+
+- The split branch passes the scoped TypeScript pre-commit check and targeted ESLint.
+- Twenty targeted route and error-classification Vitest tests pass.
+- Common-error translations are complete across all 13 locales with zero missing keys.
+
+### Layer 2 — Dead code and structural deduplication
+
+- The chat error action calls the public route builder; the Key Vault page consumes the matching parser.
+- `hasLoaded` comes from the key-store request lifecycle rather than a duplicate page-level inference.
+- Auto-start is passed through the existing Key Vault wizard stack without adding a second OAuth implementation.
+
+### Layer 3 — Naming consistency
+
+- `buildCodexReauthPath` and `parseCodexReauthIntent` form an explicit route codec.
+- `CODEX_REAUTH_RETURN_TO_STATE_KEY`, `hasLoaded`, and `autoStartCodexLogin` describe their ownership and purpose.
+
+### Layer 4 — Semantic overloading
+
+| Term             | Meaning                                                          | Verdict                                          |
+| ---------------- | ---------------------------------------------------------------- | ------------------------------------------------ |
+| reauthentication | Replace rotating OAuth credentials for an existing Codex account | Keep; distinct from adding an unrelated account. |
+| return-to state  | Trusted in-app route restored after saving repaired credentials  | Keep; constrained to `/orgii/app`.               |
+
+### Layer 5 — Default branch analysis
+
+- Non-Codex and generic 401 errors retain the existing error presentation.
+- Ordinary Key Vault add flows remain unchanged when `reauth=codex` is absent.
+- Missing explicit account IDs fall back only when exactly one Codex account exists.
+
+### Layer 6 — Cross-domain leakage
+
+- URL construction remains in `config/mainAppPaths`; the chat item invokes the public builder.
+- Key-store readiness and account resolution remain in Key Vault hooks and page orchestration.
+- The shared wizard receives typed intent props without importing chat/session state.
+
+### Layer 7 — New-developer confusion test
+
+- The route, state key, account resolution, and auto-start intent are named at their ownership boundaries.
+- Comments explain why an expired Codex login needs reconnection instead of retry.
+
+### Layer 8 — Wire protocol and serialization
+
+- Route construction and parsing are tested with URL-encoded query parameters.
+- Return navigation accepts only `/orgii/app` paths.
+- No backend OAuth credential or RPC wire type changes.
+
+### Layer 9 — Init parity
+
+| Entry point          | Readiness                  | OAuth callback            | Completion              |
+| -------------------- | -------------------------- | ------------------------- | ----------------------- |
+| Normal Key Vault add | Existing behavior          | Existing behavior         | Models page             |
+| Codex error repair   | Waits for initial key load | Desktop callback in Tauri | Original in-app session |
+| Web OAuth            | Existing behavior          | HTTP callback             | Existing behavior       |
+
+### Layer 10 — Resolver symmetry
+
+- Reauthentication resolves an explicit account first, then the sole-Codex-account fallback.
+- The resolved ID is used consistently for duplicate-name exclusion and saving the replacement credentials.
+
+## Systematic sweep
+
+- Checked all 13 `common` locale files; `errors.*` completeness reports zero missing keys.
+- Checked Codex expired-login signals so generic 401s and other providers do not enter this flow.
+- Traced the full path from chat action through route state, Key Vault load, wizard auto-start, save, and return navigation.

--- a/src/config/__tests__/mainAppPaths.test.ts
+++ b/src/config/__tests__/mainAppPaths.test.ts
@@ -1,7 +1,9 @@
 import {
   SETTINGS_ROUTE_ROOT,
+  buildCodexReauthPath,
   classifySettingsRouteRoot,
   deriveRouteCacheKey,
+  parseCodexReauthIntent,
 } from "../mainAppPaths";
 
 describe("classifySettingsRouteRoot", () => {
@@ -24,6 +26,27 @@ describe("classifySettingsRouteRoot", () => {
     expect(
       classifySettingsRouteRoot("/orgii/app/settings/agent-orgs/orgs")
     ).toBe(SETTINGS_ROUTE_ROOT.AGENT_ORGS);
+  });
+});
+
+describe("Codex reauthentication route", () => {
+  it("opens the Key Vault wizard for the failed account and auto-starts OAuth", () => {
+    const path = buildCodexReauthPath("account-123");
+
+    expect(path).toBe(
+      "/orgii/app/settings/integrations/models?wizard=key-add&id=account-123&reauth=codex&autoStart=true"
+    );
+    expect(parseCodexReauthIntent(path.split("?")[1])).toEqual({
+      active: true,
+      autoStart: true,
+    });
+  });
+
+  it("does not activate for an ordinary Key Vault wizard", () => {
+    expect(parseCodexReauthIntent("?wizard=key-add")).toEqual({
+      active: false,
+      autoStart: false,
+    });
   });
 });
 

--- a/src/config/mainAppPaths.ts
+++ b/src/config/mainAppPaths.ts
@@ -21,8 +21,11 @@ export {
 export type { ExternalSkillsetsTab } from "./mainAppPaths/externalSkillsets";
 
 export {
+  buildCodexReauthPath,
   buildIntegrationsPath,
+  CODEX_REAUTH_RETURN_TO_STATE_KEY,
   INTEGRATIONS_CATEGORIES,
+  parseCodexReauthIntent,
   parseIntegrationsPath,
 } from "./mainAppPaths/integrations";
 export type {

--- a/src/config/mainAppPaths/integrations.ts
+++ b/src/config/mainAppPaths/integrations.ts
@@ -1,4 +1,5 @@
 import { SETTINGS_BASE, settingsPathParts } from "./shared";
+import { WIZARD_IDS, buildWizardPath } from "./wizards";
 
 export const EXTERNAL_SKILLSETS_URL_SEGMENT = "skills-mcps-plugins";
 
@@ -73,11 +74,43 @@ export interface IntegrationsPathOptions {
   category?: IntegrationsCategorySegment;
 }
 
+const CODEX_REAUTH_PARAM = "reauth";
+const CODEX_REAUTH_VALUE = "codex";
+const CODEX_REAUTH_AUTO_START_PARAM = "autoStart";
+
+export const CODEX_REAUTH_RETURN_TO_STATE_KEY = "codexReauthReturnTo";
+
 export function buildIntegrationsPath(
   options: IntegrationsPathOptions = {}
 ): string {
   const category = options.category ?? "models";
   return `${SETTINGS_BASE}/integrations/${toCategoryUrlSegment(category)}`;
+}
+
+/** Build the direct Key Vault route used to repair a Codex OAuth account. */
+export function buildCodexReauthPath(accountId?: string): string {
+  const wizardPath = buildWizardPath(
+    buildIntegrationsPath({ category: "models" }),
+    WIZARD_IDS.KEY_ADD,
+    accountId
+  );
+  const [pathname, search = ""] = wizardPath.split("?");
+  const params = new URLSearchParams(search);
+  params.set(CODEX_REAUTH_PARAM, CODEX_REAUTH_VALUE);
+  params.set(CODEX_REAUTH_AUTO_START_PARAM, "true");
+  return `${pathname}?${params.toString()}`;
+}
+
+export function parseCodexReauthIntent(search: string): {
+  active: boolean;
+  autoStart: boolean;
+} {
+  const params = new URLSearchParams(search);
+  const active = params.get(CODEX_REAUTH_PARAM) === CODEX_REAUTH_VALUE;
+  return {
+    active,
+    autoStart: active && params.get(CODEX_REAUTH_AUTO_START_PARAM) === "true",
+  };
 }
 
 export function parseIntegrationsPath(pathname: string): {

--- a/src/engines/ChatPanel/ChatItems/AgentErrorChatItem.tsx
+++ b/src/engines/ChatPanel/ChatItems/AgentErrorChatItem.tsx
@@ -10,12 +10,23 @@
  * Subscribing here creates a nested Jotai listener chain that overflows the
  * call stack when the session snapshot changes (e.g. on tab switch).
  */
+import { useAtomValue } from "jotai";
 import React, { memo } from "react";
 import { useTranslation } from "react-i18next";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import InlineAlert from "@src/components/InlineAlert";
+import {
+  CODEX_REAUTH_RETURN_TO_STATE_KEY,
+  buildCodexReauthPath,
+} from "@src/config/mainAppPaths";
+import { sessionIdAtom } from "@src/engines/SessionCore/core/atoms";
+import { sessionByIdAtom } from "@src/store/session";
 
-import { sanitizeAgentErrorMessage } from "./sanitizeAgentErrorMessage";
+import {
+  requiresCodexReauthentication,
+  sanitizeAgentErrorMessage,
+} from "./sanitizeAgentErrorMessage";
 
 export interface AgentErrorChatItemProps {
   errorMessage: string;
@@ -24,13 +35,49 @@ export interface AgentErrorChatItemProps {
 const AgentErrorChatItem: React.FC<AgentErrorChatItemProps> = memo(
   ({ errorMessage }) => {
     const { t } = useTranslation();
+    const navigate = useNavigate();
+    const location = useLocation();
+    const sessionId = useAtomValue(sessionIdAtom);
+    const session = useAtomValue(sessionByIdAtom(sessionId ?? ""));
 
     const cleanMessage = sanitizeAgentErrorMessage(errorMessage);
+    const needsCodexReauthentication =
+      requiresCodexReauthentication(errorMessage);
+    const title = needsCodexReauthentication
+      ? t("errors.codexLoginExpired")
+      : t("errors.agentRequestFailed");
+    const action = needsCodexReauthentication
+      ? {
+          label: t("errors.reconnectCodex"),
+          onClick: () => {
+            const returnTo = `${location.pathname}${location.search}${location.hash}`;
+            navigate(buildCodexReauthPath(session?.accountId), {
+              state: { [CODEX_REAUTH_RETURN_TO_STATE_KEY]: returnTo },
+            });
+          },
+        }
+      : undefined;
 
     return (
       <div className="animate-fade-in">
-        <InlineAlert type="danger" title={t("errors.agentRequestFailed")}>
-          <div className="whitespace-pre-wrap break-words">{cleanMessage}</div>
+        <InlineAlert type="danger" title={title} action={action}>
+          {needsCodexReauthentication ? (
+            <>
+              <div>{t("errors.codexLoginExpiredDescription")}</div>
+              <details className="mt-2 opacity-70">
+                <summary className="cursor-pointer select-none">
+                  {t("errors.technicalDetails")}
+                </summary>
+                <div className="mt-1 whitespace-pre-wrap break-words">
+                  {cleanMessage}
+                </div>
+              </details>
+            </>
+          ) : (
+            <div className="whitespace-pre-wrap break-words">
+              {cleanMessage}
+            </div>
+          )}
         </InlineAlert>
       </div>
     );

--- a/src/engines/ChatPanel/ChatItems/__tests__/sanitizeAgentErrorMessage.test.ts
+++ b/src/engines/ChatPanel/ChatItems/__tests__/sanitizeAgentErrorMessage.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { sanitizeAgentErrorMessage } from "../sanitizeAgentErrorMessage";
+import {
+  requiresCodexReauthentication,
+  sanitizeAgentErrorMessage,
+} from "../sanitizeAgentErrorMessage";
 
 const HTML_500 = `<!doctype html>
 <html lang=en>
@@ -68,5 +71,35 @@ describe("sanitizeAgentErrorMessage", () => {
     expect(sanitizeAgentErrorMessage("   padded message   ")).toBe(
       "padded message"
     );
+  });
+});
+
+describe("requiresCodexReauthentication", () => {
+  it("recognizes a reused Codex OAuth refresh token", () => {
+    const raw =
+      '[session_launch] Auth error: Codex OAuth refresh failed with HTTP 401: {"code":"refresh_token_reused","message":"Please try signing in again."}';
+    expect(requiresCodexReauthentication(raw)).toBe(true);
+  });
+
+  it("recognizes a Codex invalid_grant response", () => {
+    expect(
+      requiresCodexReauthentication(
+        "Codex OAuth refresh failed: invalid_grant; try signing in again"
+      )
+    ).toBe(true);
+  });
+
+  it("does not turn a generic 401 into a Codex login prompt", () => {
+    expect(
+      requiresCodexReauthentication("HTTP 401 Unauthorized: invalid API key")
+    ).toBe(false);
+  });
+
+  it("does not route another provider's refresh failure to Codex", () => {
+    expect(
+      requiresCodexReauthentication(
+        "OAuth refresh_token_reused; try signing in again"
+      )
+    ).toBe(false);
   });
 });

--- a/src/engines/ChatPanel/ChatItems/sanitizeAgentErrorMessage.ts
+++ b/src/engines/ChatPanel/ChatItems/sanitizeAgentErrorMessage.ts
@@ -36,6 +36,21 @@ const HTML_HINT =
   /<!doctype html|<html[\s>]|<head[\s>]|<body[\s>]|<title[\s>]/i;
 const HTTP_STATUS = /\bHTTP\s+(\d{3})\b/i;
 
+/** Whether retrying cannot recover and the Codex OAuth account must reconnect. */
+export function requiresCodexReauthentication(raw: string): boolean {
+  const message = raw.toLowerCase();
+  if (!message) return false;
+
+  const hasCodexContext = message.includes("codex");
+  const hasReauthenticationSignal =
+    message.includes("refresh_token_reused") ||
+    message.includes("refresh token has already been used") ||
+    message.includes("try signing in again") ||
+    message.includes("invalid_grant");
+
+  return hasCodexContext && hasReauthenticationSignal;
+}
+
 /**
  * Convert a raw error message into a clean, bounded, single-block string safe
  * for `whitespace-pre-wrap` rendering.

--- a/src/features/SessionSetup/components/CodexSessionSetup/index.tsx
+++ b/src/features/SessionSetup/components/CodexSessionSetup/index.tsx
@@ -37,6 +37,7 @@ export interface CodexSessionSetupProps {
   tokenError?: string | null;
   onClearTokenError?: () => void;
   closeSignal?: number;
+  autoStart?: boolean;
 }
 
 const CodexSessionSetup: React.FC<CodexSessionSetupProps> = ({
@@ -47,9 +48,10 @@ const CodexSessionSetup: React.FC<CodexSessionSetupProps> = ({
   tokenError = null,
   onClearTokenError,
   closeSignal = 0,
+  autoStart = false,
 }) => {
   const { t } = useTranslation("integrations");
-  const [showBrowser, setShowBrowser] = useState(false);
+  const [showBrowser, setShowBrowser] = useState(autoStart);
   const containerRef = useRef<HTMLDivElement>(null);
 
   const {

--- a/src/hooks/keyVault/types.ts
+++ b/src/hooks/keyVault/types.ts
@@ -111,6 +111,8 @@ export interface UseKeyVaultReturn {
   accounts: KeyVaultAccount[];
   localAccounts: KeyVaultAccount[];
   loading: boolean;
+  /** Whether the initial key-store load has settled at least once. */
+  hasLoaded: boolean;
   error: string | null;
   /** Refresh everything: accounts list + quotas + validation (all in parallel) */
   refresh: (force?: boolean) => Promise<void>;

--- a/src/hooks/keyVault/useKeyVault.ts
+++ b/src/hooks/keyVault/useKeyVault.ts
@@ -154,6 +154,7 @@ export function useKeyVault(
     accounts,
     localAccounts,
     loading: local.loading,
+    hasLoaded: local.hasLoaded,
     error: local.error,
     refresh,
     refreshAccount,

--- a/src/hooks/keyVault/useLocalKeys.ts
+++ b/src/hooks/keyVault/useLocalKeys.ts
@@ -54,6 +54,8 @@ export interface UseLocalKeysReturn {
   keysByAgentType: Map<ModelType, KeyInfo>;
   /** Loading state */
   loading: boolean;
+  /** Whether the initial key-store load has settled at least once. */
+  hasLoaded: boolean;
   /** Error message */
   error: string | null;
   /** Reload keys from the store */
@@ -84,6 +86,7 @@ export function useLocalKeys(
   // State
   const [allKeys, setAllKeys] = useState<KeyInfo[]>(getSharedLocalKeys);
   const [loading, setLoading] = useState(false);
+  const [hasLoaded, setHasLoaded] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // Track in-flight validations to prevent duplicates
@@ -121,6 +124,7 @@ export function useLocalKeys(
       setError(message);
       log.error("Failed to load keys:", err);
     } finally {
+      setHasLoaded(true);
       setLoading(false);
     }
   }, []);
@@ -395,6 +399,7 @@ export function useLocalKeys(
     allKeys,
     keysByAgentType,
     loading,
+    hasLoaded,
     error,
     refreshAgents,
     saveKey: saveKeyFn,

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -531,6 +531,10 @@
     "failedToRenderEvent": "Ereignis konnte nicht gerendert werden",
     "unknown": "Unbekannter Fehler",
     "agentRequestFailed": "Agent-Anfrage fehlgeschlagen",
+    "codexLoginExpired": "Codex-Anmeldung abgelaufen",
+    "codexLoginExpiredDescription": "Verbinde Codex erneut, um dieses Konto zu reparieren. Nach dem Speichern der neuen Anmeldung kehrst du zu dieser Sitzung zurück.",
+    "reconnectCodex": "Codex erneut verbinden",
+    "technicalDetails": "Technische Details",
     "failedToCopy": "Kopieren fehlgeschlagen",
     "api": {
       "titles": {

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -558,6 +558,10 @@
     "failedToRenderEvent": "Failed to render event",
     "unknown": "Unknown error",
     "agentRequestFailed": "Agent request failed",
+    "codexLoginExpired": "Codex sign-in expired",
+    "codexLoginExpiredDescription": "Reconnect Codex to repair this account. You will return to this session after the new sign-in is saved.",
+    "reconnectCodex": "Reconnect Codex",
+    "technicalDetails": "Technical details",
     "failedToCopy": "Failed to copy",
     "api": {
       "titles": {

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -531,6 +531,10 @@
     "failedToRenderEvent": "Error al renderizar el evento",
     "unknown": "Error desconocido",
     "agentRequestFailed": "Error en la solicitud del Agent",
+    "codexLoginExpired": "La sesión de Codex ha caducado",
+    "codexLoginExpiredDescription": "Vuelve a conectar Codex para reparar esta cuenta. Regresarás a esta sesión cuando se guarde el nuevo inicio de sesión.",
+    "reconnectCodex": "Volver a conectar Codex",
+    "technicalDetails": "Detalles técnicos",
     "failedToCopy": "No se pudo copiar",
     "api": {
       "titles": {

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -531,6 +531,10 @@
     "failedToRenderEvent": "Échec du rendu de l'événement",
     "unknown": "Erreur inconnue",
     "agentRequestFailed": "Échec de la requête Agent",
+    "codexLoginExpired": "La connexion à Codex a expiré",
+    "codexLoginExpiredDescription": "Reconnectez Codex pour réparer ce compte. Vous reviendrez à cette session une fois la nouvelle connexion enregistrée.",
+    "reconnectCodex": "Reconnecter Codex",
+    "technicalDetails": "Détails techniques",
     "failedToCopy": "Échec de la copie",
     "api": {
       "titles": {

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -531,6 +531,10 @@
     "failedToRenderEvent": "イベントのレンダリングに失敗しました",
     "unknown": "不明なエラー",
     "agentRequestFailed": "Agent リクエスト失敗",
+    "codexLoginExpired": "Codex のサインイン期限が切れました",
+    "codexLoginExpiredDescription": "このアカウントを修復するには Codex に再接続してください。新しいサインインを保存すると、このセッションに戻ります。",
+    "reconnectCodex": "Codex に再接続",
+    "technicalDetails": "技術的な詳細",
     "failedToCopy": "コピーに失敗しました",
     "api": {
       "titles": {

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -531,6 +531,10 @@
     "failedToRenderEvent": "이벤트 렌더링 실패",
     "unknown": "알 수 없는 오류",
     "agentRequestFailed": "Agent 요청 실패",
+    "codexLoginExpired": "Codex 로그인 만료",
+    "codexLoginExpiredDescription": "이 계정을 복구하려면 Codex에 다시 연결하세요. 새 로그인이 저장되면 이 세션으로 돌아옵니다.",
+    "reconnectCodex": "Codex 다시 연결",
+    "technicalDetails": "기술 세부 정보",
     "failedToCopy": "복사에 실패했습니다",
     "api": {
       "titles": {

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -532,6 +532,10 @@
     "failedToRenderEvent": "Nie udało się wyrenderować zdarzenia",
     "unknown": "Nieznany błąd",
     "agentRequestFailed": "Żądanie Agenta nie powiodło się",
+    "codexLoginExpired": "Logowanie do Codex wygasło",
+    "codexLoginExpiredDescription": "Połącz ponownie Codex, aby naprawić to konto. Po zapisaniu nowego logowania wrócisz do tej sesji.",
+    "reconnectCodex": "Połącz ponownie Codex",
+    "technicalDetails": "Szczegóły techniczne",
     "failedToCopy": "Nie udało się skopiować",
     "api": {
       "titles": {

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -532,6 +532,10 @@
     "failedToRenderEvent": "Falha ao renderizar evento",
     "unknown": "Erro desconhecido",
     "agentRequestFailed": "A requisição ao Agent falhou",
+    "codexLoginExpired": "A sessão do Codex expirou",
+    "codexLoginExpiredDescription": "Reconecte o Codex para reparar esta conta. Você retornará a esta sessão quando o novo login for salvo.",
+    "reconnectCodex": "Reconectar o Codex",
+    "technicalDetails": "Detalhes técnicos",
     "failedToCopy": "Falha ao copiar",
     "api": {
       "titles": {

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -531,6 +531,10 @@
     "failedToRenderEvent": "Не удалось отобразить событие",
     "unknown": "Неизвестная ошибка",
     "agentRequestFailed": "Ошибка запроса Agent",
+    "codexLoginExpired": "Срок входа в Codex истёк",
+    "codexLoginExpiredDescription": "Повторно подключите Codex, чтобы восстановить эту учётную запись. После сохранения нового входа вы вернётесь к этому сеансу.",
+    "reconnectCodex": "Повторно подключить Codex",
+    "technicalDetails": "Технические сведения",
     "failedToCopy": "Не удалось скопировать",
     "api": {
       "titles": {

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -531,6 +531,10 @@
     "failedToRenderEvent": "Olay oluşturulamadı",
     "unknown": "Bilinmeyen hata",
     "agentRequestFailed": "Agent isteği başarısız oldu",
+    "codexLoginExpired": "Codex oturumunun süresi doldu",
+    "codexLoginExpiredDescription": "Bu hesabı onarmak için Codex'e yeniden bağlanın. Yeni oturum kaydedildiğinde bu oturuma geri döneceksiniz.",
+    "reconnectCodex": "Codex'e yeniden bağlan",
+    "technicalDetails": "Teknik ayrıntılar",
     "failedToCopy": "Kopyalanamadı",
     "api": {
       "titles": {

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -531,6 +531,10 @@
     "failedToRenderEvent": "Không thể hiển thị sự kiện",
     "unknown": "Lỗi không xác định",
     "agentRequestFailed": "Yêu cầu Agent thất bại",
+    "codexLoginExpired": "Phiên đăng nhập Codex đã hết hạn",
+    "codexLoginExpiredDescription": "Kết nối lại Codex để khôi phục tài khoản này. Bạn sẽ quay lại phiên này sau khi thông tin đăng nhập mới được lưu.",
+    "reconnectCodex": "Kết nối lại Codex",
+    "technicalDetails": "Chi tiết kỹ thuật",
     "failedToCopy": "Sao chép thất bại",
     "api": {
       "titles": {

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -544,6 +544,10 @@
     "failedToRenderEvent": "渲染事件失敗",
     "unknown": "未知錯誤",
     "agentRequestFailed": "Agent 請求失敗",
+    "codexLoginExpired": "Codex 登入已過期",
+    "codexLoginExpiredDescription": "重新連接 Codex 以修復此帳戶。儲存新的登入資訊後，你將返回此工作階段。",
+    "reconnectCodex": "重新連接 Codex",
+    "technicalDetails": "技術詳細資訊",
     "failedToCopy": "複製失敗",
     "api": {
       "titles": {

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -545,6 +545,10 @@
     "failedToRenderEvent": "渲染事件失败",
     "unknown": "未知错误",
     "agentRequestFailed": "Agent 请求失败",
+    "codexLoginExpired": "Codex 登录已失效",
+    "codexLoginExpiredDescription": "重新连接 Codex 即可修复此账号；登录并保存后会返回当前会话。",
+    "reconnectCodex": "重新连接 Codex",
+    "technicalDetails": "技术详情",
     "failedToCopy": "复制失败",
     "api": {
       "titles": {

--- a/src/modules/MainApp/Integrations/KeyVault/AccountCategoryView.tsx
+++ b/src/modules/MainApp/Integrations/KeyVault/AccountCategoryView.tsx
@@ -20,7 +20,10 @@ export const AccountCategoryView: React.FC<{
         onSubmit={accounts.handleFormSubmit}
         onCancel={accounts.handleFormCancel}
         loading={accounts.formLoading}
-        existingAccountNames={accounts.accounts.map((account) => account.name)}
+        initialAgentType={accounts.formInitialAgentType}
+        initialData={accounts.formInitialData}
+        autoStartCodexLogin={accounts.autoStartCodexLogin}
+        existingAccountNames={accounts.formExistingAccountNames}
       />
     );
   }

--- a/src/modules/MainApp/Integrations/KeyVault/hooks/useKeyVaultPage.ts
+++ b/src/modules/MainApp/Integrations/KeyVault/hooks/useKeyVaultPage.ts
@@ -14,13 +14,18 @@
 import { useSetAtom } from "jotai";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import { getFullKey, validateKey } from "@src/api/services/keyValidation";
 import type { SaveKeyRequest as RpcSaveKeyRequest } from "@src/api/tauri/rpc/schemas/validation";
 import type { ModelType, SaveKeyRequest } from "@src/api/types/keys";
 import Message from "@src/components/Message";
-import { WIZARD_IDS, buildIntegrationsPath } from "@src/config/mainAppPaths";
+import {
+  CODEX_REAUTH_RETURN_TO_STATE_KEY,
+  WIZARD_IDS,
+  buildIntegrationsPath,
+  parseCodexReauthIntent,
+} from "@src/config/mainAppPaths";
 import { useKeyVault } from "@src/hooks/keyVault";
 import { createLogger } from "@src/hooks/logger";
 import { useWizardParam } from "@src/hooks/navigation";
@@ -36,12 +41,25 @@ import {
 
 const log = createLogger("KeyVaultPage");
 
+function readCodexReauthReturnTo(state: unknown): string | null {
+  if (!state || typeof state !== "object") return null;
+  const returnTo = (state as Record<string, unknown>)[
+    CODEX_REAUTH_RETURN_TO_STATE_KEY
+  ];
+  return typeof returnTo === "string" &&
+    (returnTo === "/orgii/app" || returnTo.startsWith("/orgii/app/"))
+    ? returnTo
+    : null;
+}
+
 export function useKeyVaultPage() {
   const { t } = useTranslation("integrations");
   const navigate = useNavigate();
+  const location = useLocation();
   const {
     accounts,
     loading,
+    hasLoaded,
     error,
     refresh,
     refreshAccount,
@@ -67,12 +85,35 @@ export function useKeyVaultPage() {
   const [refreshingAllModels, setRefreshingAllModels] = useState(false);
 
   // Wizard open-state derived from URL
-  const { wizard, openWizard } = useWizardParam();
+  const { wizard, entityId, openWizard } = useWizardParam();
   const showAddForm = wizard === WIZARD_IDS.KEY_ADD;
+  const codexReauthIntent = parseCodexReauthIntent(location.search);
+  const isCodexReauth = showAddForm && codexReauthIntent.active;
+  const explicitReauthAccount = entityId ? getAccount(entityId) : undefined;
+  const soleCodexAccount = useMemo(() => {
+    const codexAccounts = accounts.filter(
+      (account) => account.modelType === "codex"
+    );
+    return codexAccounts.length === 1 ? codexAccounts[0] : undefined;
+  }, [accounts]);
+  const reauthAccount = isCodexReauth
+    ? (explicitReauthAccount ?? soleCodexAccount)
+    : undefined;
+  const reauthAccountId =
+    reauthAccount?.id ?? (isCodexReauth ? entityId : null);
+  const isResolvingReauthAccount =
+    isCodexReauth && !hasLoaded && !reauthAccount;
+  const reauthReturnTo = isCodexReauth
+    ? readCodexReauthReturnTo(location.state)
+    : null;
 
   const closeKeyVaultWizard = useCallback(() => {
+    if (reauthReturnTo) {
+      navigate(reauthReturnTo, { replace: true });
+      return;
+    }
     navigate(buildIntegrationsPath({ category: "models" }), { replace: true });
-  }, [navigate]);
+  }, [navigate, reauthReturnTo]);
 
   // Initial load
   useEffect(() => {
@@ -225,6 +266,7 @@ export function useKeyVaultPage() {
       try {
         const saveRequest: SaveKeyRequest = {
           ...(data as SaveKeyRequest),
+          ...(reauthAccountId ? { id: reauthAccountId } : {}),
           has_local_key: true,
           is_listed: false,
         };
@@ -242,7 +284,7 @@ export function useKeyVaultPage() {
         setFormLoading(false);
       }
     },
-    [saveKey, refresh, t, closeKeyVaultWizard]
+    [saveKey, refresh, t, closeKeyVaultWizard, reauthAccountId]
   );
 
   const handleEditAccountSave = useCallback(
@@ -319,9 +361,20 @@ export function useKeyVaultPage() {
     agentTypeFilter,
 
     // Form state
-    showAddForm,
+    showAddForm: showAddForm && !isResolvingReauthAccount,
     formLoading,
     selectedAccountId,
+    formInitialAgentType: isCodexReauth ? ("codex" as const) : undefined,
+    formInitialData: isCodexReauth
+      ? {
+          name: reauthAccount?.name ?? "",
+          setup_method: "signin",
+        }
+      : undefined,
+    formExistingAccountNames: accounts
+      .filter((account) => account.id !== reauthAccountId)
+      .map((account) => account.name),
+    autoStartCodexLogin: isCodexReauth && codexReauthIntent.autoStart,
 
     // Handlers
     handleAccountSelect,

--- a/src/scaffold/WizardSystem/variants/KeyVault/components/AgentSetupRouter.tsx
+++ b/src/scaffold/WizardSystem/variants/KeyVault/components/AgentSetupRouter.tsx
@@ -53,6 +53,7 @@ interface AgentSetupRouterProps extends AgentSetupProps {
   handleSessionTokenCaptured: (sessionToken: string) => void;
   handleUrlChange: (url: string) => void;
   hasSessionToken: boolean;
+  autoStartCodexLogin?: boolean;
 }
 
 /**
@@ -78,6 +79,7 @@ export const AgentSetupRouter: React.FC<AgentSetupRouterProps> = ({
   handleSessionTokenCaptured,
   handleUrlChange,
   hasSessionToken,
+  autoStartCodexLogin,
   ...sharedProps
 }) => {
   const { onChange } = sharedProps;
@@ -122,6 +124,7 @@ export const AgentSetupRouter: React.FC<AgentSetupRouterProps> = ({
           onDetectToken={sharedProps.onAutoDetect ?? (() => {})}
           onClearTokenError={clearTokenError}
           preselectedMethod={isComplex ? setupMethod : undefined}
+          autoStartLogin={autoStartCodexLogin}
           onSessionCaptured={async (values: CodexSessionValues) => {
             let catalog: OAuthModelCatalog = {
               models: [],

--- a/src/scaffold/WizardSystem/variants/KeyVault/components/ApiSetup.tsx
+++ b/src/scaffold/WizardSystem/variants/KeyVault/components/ApiSetup.tsx
@@ -48,6 +48,7 @@ const ApiSetup: React.FC<ApiSetupProps> = ({
   existingAccountNames,
   browserCloseSignal = 0,
   onBrowserStateChange,
+  autoStartCodexLogin = false,
 }) => {
   const { t } = useTranslation("integrations");
   const hook = useApiSetup({ data, onChange });
@@ -413,6 +414,7 @@ const ApiSetup: React.FC<ApiSetupProps> = ({
               handleSessionTokenCaptured={hook.handleSessionTokenCaptured}
               handleUrlChange={hook.handleUrlChange}
               hasSessionToken={hook.hasSessionToken}
+              autoStartCodexLogin={autoStartCodexLogin}
             />
           )}
 

--- a/src/scaffold/WizardSystem/variants/KeyVault/components/KeyVaultWizard.tsx
+++ b/src/scaffold/WizardSystem/variants/KeyVault/components/KeyVaultWizard.tsx
@@ -26,6 +26,7 @@ const KeyVaultWizard: React.FC<KeyVaultWizardProps> = ({
   initialAgentType,
   title,
   initialData,
+  autoStartCodexLogin = false,
   primaryProvidersOnly = true,
   existingAccountNames,
 }) => {
@@ -99,6 +100,7 @@ const KeyVaultWizard: React.FC<KeyVaultWizardProps> = ({
         loading={loading}
         browserCloseSignal={browserCloseSignal}
         onBrowserStateChange={setBrowserOpen}
+        autoStartCodexLogin={autoStartCodexLogin}
       />
     </WizardShell>
   );

--- a/src/scaffold/WizardSystem/variants/KeyVault/components/setup/CodexSetup.tsx
+++ b/src/scaffold/WizardSystem/variants/KeyVault/components/setup/CodexSetup.tsx
@@ -38,6 +38,7 @@ const CodexSetup: React.FC<CodexSetupProps> = ({
   browserOpen,
   setBrowserOpen,
   browserCloseSignal,
+  autoStartLogin = false,
 }) => {
   const { t } = useTranslation("integrations");
 
@@ -118,6 +119,7 @@ const CodexSetup: React.FC<CodexSetupProps> = ({
           onSessionCaptured={onSessionCaptured}
           onBrowserStateChange={setBrowserOpen}
           closeSignal={browserCloseSignal}
+          autoStart={autoStartLogin}
         />
       )}
 

--- a/src/scaffold/WizardSystem/variants/KeyVault/components/setup/types.ts
+++ b/src/scaffold/WizardSystem/variants/KeyVault/components/setup/types.ts
@@ -121,6 +121,7 @@ export interface CodexSetupProps extends AgentSetupProps {
   onClearTokenError?: () => void;
   onSessionCaptured?: (values: CodexSessionValues) => void;
   preselectedMethod?: string;
+  autoStartLogin?: boolean;
 }
 
 export interface KiroSetupProps extends AgentSetupProps {

--- a/src/scaffold/WizardSystem/variants/KeyVault/types/index.ts
+++ b/src/scaffold/WizardSystem/variants/KeyVault/types/index.ts
@@ -139,6 +139,8 @@ export interface KeyVaultWizardProps {
   title?: string;
   /** Initial data to pre-fill the wizard */
   initialData?: Partial<WizardData>;
+  /** Open the embedded Codex OAuth browser immediately for a repair flow. */
+  autoStartCodexLogin?: boolean;
   /** Limit displayed providers to primary ones with region restrictions (Cursor, OpenAI, Anthropic, Google, OpenRouter) */
   primaryProvidersOnly?: boolean;
   /** Existing account names — used to generate default names and reject duplicate custom names. */
@@ -161,4 +163,5 @@ export interface ApiSetupProps {
   existingAccountNames?: string[];
   browserCloseSignal?: number;
   onBrowserStateChange?: (isOpen: boolean) => void;
+  autoStartCodexLogin?: boolean;
 }


### PR DESCRIPTION
## Summary

- recognize expired Codex OAuth credentials in chat errors and offer a direct reconnect action
- wait for Key Vault initialization, resolve the existing Codex account, and replace its credentials
- auto-start the Codex sign-in wizard and return to the failed session after saving
- add complete error copy across all 13 common locales
- include a scoped 10-layer architecture audit

Split from #442. This PR is stacked on #468, which supplies Tauri runtime-aware OAuth callback routing.

## Validation

- 20 targeted Vitest tests for route encoding and error classification
- targeted ESLint for all 18 changed TypeScript and TSX files
- scoped TypeScript pre-commit check
- common `errors.*` i18n completeness across 13 locales — 0 missing

## Stack

1. #468 — Tauri OAuth runtime routing
2. This PR — Codex expired-login repair flow

Retarget this PR to `develop` after #468 merges.
