### PR TITLE
refactor(session): scope pending plan approval reads

### DIFF
--- a/src/engines/ChatPanel/ChatView.tsx
+++ b/src/engines/ChatPanel/ChatView.tsx
@@ -54,6 +54,7 @@ import { AppType } from "@src/engines/Simulator/types/appTypes";
 import { ForkCancelledError } from "@src/features/TeamCollaboration/forkSession";
 import { useFileReviewSync } from "@src/hooks/fileReview";
 import { createLogger } from "@src/hooks/logger";
+import { usePendingPlanApproval } from "@src/hooks/session/usePendingPlanApproval";
 import { useSessionWorkspaceSync } from "@src/hooks/session/useSessionWorkspaceSync";
 import { useSessionView } from "@src/hooks/ui/tabs/useSessionView";
 import {
@@ -68,7 +69,6 @@ import {
   sessionRuntimeStatusAtom,
   streamRetryStatusAtom,
 } from "@src/store/session/cliSessionStatusAtom";
-import { pendingPlanApprovalsAtom } from "@src/store/session/planApprovalAtom";
 import type { SessionContinuation } from "@src/store/session/sessionTabPlacementAtom";
 import type { ChatHistoryDisplayMode } from "@src/store/ui/chatPanelAtom";
 import { chatPanelMaximizedAtom } from "@src/store/ui/chatPanelAtom";
@@ -461,9 +461,7 @@ const ChatView: React.FC<ChatViewProps> = memo(
         openLatestCanvas,
       ]
     );
-    const currentPlanApproval = useAtomValue(pendingPlanApprovalsAtom).get(
-      sessionId
-    )?.current;
+    const currentPlanApproval = usePendingPlanApproval(sessionId);
     const chatEvents = snapshot?.chatEvents ?? EMPTY_CHAT_EVENTS;
     const isAgentWorking = useAtomValue(isSessionActiveAtom);
 

--- a/src/engines/ChatPanel/blocks/CreatePlanCard/index.tsx
+++ b/src/engines/ChatPanel/blocks/CreatePlanCard/index.tsx
@@ -35,6 +35,7 @@ import {
   shouldDefaultCollapsePlanCard,
 } from "@src/engines/SessionCore/derived/planDisplayEvents";
 import { useMountedCleanup } from "@src/hooks/lifecycle/useMounted";
+import { usePendingPlanApproval } from "@src/hooks/session/usePendingPlanApproval";
 import { FileService } from "@src/services/file";
 import { sessionRuntimeStatusAtom } from "@src/store/session/cliSessionStatusAtom";
 import { creatorDefaultModelSelectionAtom } from "@src/store/session/creatorDefaultModelAtom";
@@ -138,7 +139,7 @@ const CreatePlanCard: React.FC<CreatePlanCardProps> = memo(
     const { t } = useTranslation("sessions");
     const activeSessionId = useAtomValue(activeSessionIdAtom);
     const sessionId = sessionIdProp ?? activeSessionId;
-    const approvalMap = useAtomValue(pendingPlanApprovalsAtom);
+    const currentPendingPlan = usePendingPlanApproval(sessionId);
     const setPendingPlanApprovals = useSetAtom(pendingPlanApprovalsAtom);
     const runtimeStatus = useAtomValue(sessionRuntimeStatusAtom);
     // Read the plan's *own* session row for model+key — approving a
@@ -183,18 +184,17 @@ const CreatePlanCard: React.FC<CreatePlanCardProps> = memo(
       if (!isEditing) setEditedContent(content);
     }, [content, isEditing]);
 
-    const state = sessionId ? approvalMap.get(sessionId) : undefined;
     const cardRevisionId = planRevisionId || toolCallId;
     const idMatch =
-      !!state?.current &&
+      !!currentPendingPlan &&
       !!cardRevisionId &&
-      (state.current.planRevisionId === cardRevisionId ||
-        state.current.toolCallId === cardRevisionId);
+      (currentPendingPlan.planRevisionId === cardRevisionId ||
+        currentPendingPlan.toolCallId === cardRevisionId);
     const ready =
       surfaceState?.readyForReview ??
       (idMatch && !isStreaming && effectiveApprovalStatus === "pending");
     const autoApproveAt = idMatch
-      ? (state.current?.autoApproveAt ?? null)
+      ? (currentPendingPlan.autoApproveAt ?? null)
       : null;
     const [nowMs, setNowMs] = useState<number>(() => Date.now());
 
@@ -327,7 +327,7 @@ const CreatePlanCard: React.FC<CreatePlanCardProps> = memo(
     // Save persists the edited plan to its backing store (plan file + the plan
     // event the preview re-reads + the pending snapshot) and exits edit mode,
     // WITHOUT approving or building. A later Build approves the persisted plan.
-    const pendingSnapshot = state?.current ?? null;
+    const pendingSnapshot = currentPendingPlan;
     const handleSave = useCallback(async () => {
       if (!sessionId || !interactive || submittingRef.current) return;
       submittingRef.current = true;

--- a/src/engines/ChatPanel/hooks/useInputArea/index.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/index.ts
@@ -40,6 +40,7 @@ import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 import { isPlanDisplayEvent } from "@src/engines/SessionCore/derived/planDisplayEvents";
 import { useSessionId } from "@src/engines/SessionCore/hooks/session";
 import { createLogger } from "@src/hooks/logger";
+import { usePendingPlanApproval } from "@src/hooks/session/usePendingPlanApproval";
 import {
   useSessionDraftField,
   useSessionReplyField,
@@ -50,7 +51,6 @@ import {
   isSessionActiveAtom,
   sessionRuntimeStatusAtom,
 } from "@src/store/session/cliSessionStatusAtom";
-import { pendingPlanApprovalsAtom } from "@src/store/session/planApprovalAtom";
 import { sessionByIdAtom } from "@src/store/session/sessionAtom/atoms";
 import { wpReadOnlyAtom } from "@src/store/ui/chatPanelAtom";
 import { workspaceFoldersAtom } from "@src/store/ui/workspaceFoldersAtom";
@@ -213,7 +213,6 @@ export function useInputArea(
   const rawIsSessionActive = useAtomValue(isSessionActiveAtom);
   const rawIsPendingCancel = useAtomValue(isPendingCancelAtom);
   const runtimeStatus = useAtomValue(sessionRuntimeStatusAtom);
-  const pendingPlanApprovals = useAtomValue(pendingPlanApprovalsAtom);
   const isSessionless = sessionScope === "none";
   const isSessionActive = isSessionless ? false : rawIsSessionActive;
   const isPendingCancel = isSessionless ? false : rawIsPendingCancel;
@@ -302,9 +301,7 @@ export function useInputArea(
   const currentRepoPath = activeSessionId
     ? (activeSession?.repoPath ?? workspaceRepoPath)
     : workspaceRepoPath;
-  const pendingPlan = activeSessionId
-    ? pendingPlanApprovals.get(activeSessionId)?.current
-    : null;
+  const pendingPlan = usePendingPlanApproval(activeSessionId);
   const sessionFileMentionOptions = useMemo<ReadonlyArray<CustomMentionOption>>(
     () =>
       sessionFiles.slice(0, 12).map((file) => {

--- a/src/engines/ChatPanel/rendering/adapters/PlanDocAdapter.tsx
+++ b/src/engines/ChatPanel/rendering/adapters/PlanDocAdapter.tsx
@@ -19,7 +19,7 @@ import {
   getPlanSubmittedPayloadFromResult,
 } from "@src/engines/SessionCore/derived/planDisplayEvents";
 import type { UniversalEventProps } from "@src/engines/SessionCore/rendering/types/universalProps";
-import { pendingPlanApprovalsAtom } from "@src/store/session/planApprovalAtom";
+import { usePendingPlanApproval } from "@src/hooks/session/usePendingPlanApproval";
 
 import CreatePlanCard from "../../blocks/CreatePlanCard";
 
@@ -28,10 +28,7 @@ function asString(value: unknown): string {
 }
 
 export const PlanDocAdapter: React.FC<UniversalEventProps> = (props) => {
-  const approvalMap = useAtomValue(pendingPlanApprovalsAtom);
-  const pendingPlan = props.sessionId
-    ? approvalMap.get(props.sessionId)?.current
-    : null;
+  const pendingPlan = usePendingPlanApproval(props.sessionId);
   const chatEvents = useAtomValue(chatEventsAtom);
   const eventForIdentity = chatEvents.find(
     (event) => event.id === props.eventId

--- a/src/hooks/session/index.ts
+++ b/src/hooks/session/index.ts
@@ -1,4 +1,5 @@
 export * from "./useAgentFileChangeListener";
 export * from "./useNativeSessionStatusMonitor";
+export * from "./usePendingPlanApproval";
 export * from "./useSessionPatch";
 export * from "./useSessionWorkspaceSync";

--- a/src/hooks/session/usePendingPlanApproval.ts
+++ b/src/hooks/session/usePendingPlanApproval.ts
@@ -1,0 +1,12 @@
+import { useAtomValue } from "jotai";
+
+import {
+  type PendingPlanApproval,
+  pendingPlanApprovalForSessionAtomFamily,
+} from "@src/store/session/planApprovalAtom";
+
+export function usePendingPlanApproval(
+  sessionId: string | null | undefined
+): PendingPlanApproval | null {
+  return useAtomValue(pendingPlanApprovalForSessionAtomFamily(sessionId ?? ""));
+}

--- a/src/modules/WorkStation/Chat/Communication/MessageViewer.tsx
+++ b/src/modules/WorkStation/Chat/Communication/MessageViewer.tsx
@@ -1,4 +1,3 @@
-import { useAtomValue } from "jotai";
 import { ChevronsUpDown } from "lucide-react";
 import React, {
   useCallback,
@@ -17,8 +16,8 @@ import {
   derivePlanApprovalViewState,
   isPlanDisplayEvent,
 } from "@src/engines/SessionCore/derived/planDisplayEvents";
+import { usePendingPlanApproval } from "@src/hooks/session/usePendingPlanApproval";
 import type { SessionReplayPlaceholderMode } from "@src/modules/WorkStation/shared";
-import { pendingPlanApprovalsAtom } from "@src/store/session/planApprovalAtom";
 
 import { isEmailBubbleEvent } from "./EmailMessageBubble";
 import { EmptyState } from "./EmptyState";
@@ -137,7 +136,6 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
     setViewMode?.("todo");
   }, [setViewMode]);
   const { t } = useTranslation(["common", "sessions"]);
-  const approvalMap = useAtomValue(pendingPlanApprovalsAtom);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const loadMoreScrollAnchorRef = useRef<{
     scrollTop: number;
@@ -238,6 +236,17 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
     return null;
   }, [messages, viewMode]);
 
+  const selectedPlanMessage =
+    viewMode === "preview" && previewSelectedPlan && selectedMessage?.event
+      ? isPlanDisplayEvent(selectedMessage.event)
+        ? selectedMessage
+        : null
+      : null;
+  const activePlanMessage =
+    controlledActivePlanMessage ?? selectedPlanMessage ?? latestPlanMessage;
+  const pendingPlan = usePendingPlanApproval(
+    activePlanMessage?.event.sessionId
+  );
   const canRenderDurableAgentOrgBoard =
     viewMode === "todo" && agentOrgTasks !== undefined;
 
@@ -257,20 +266,7 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
     );
   }
 
-  const selectedPlanMessage =
-    viewMode === "preview" && previewSelectedPlan && selectedMessage?.event
-      ? isPlanDisplayEvent(selectedMessage.event)
-        ? selectedMessage
-        : null
-      : null;
-
-  const activePlanMessage =
-    controlledActivePlanMessage ?? selectedPlanMessage ?? latestPlanMessage;
-
   if (viewMode === "preview" && activePlanMessage) {
-    const pendingPlan = approvalMap.get(
-      activePlanMessage.event.sessionId
-    )?.current;
     const plan = getPlanDocViewModel(activePlanMessage.event, pendingPlan);
     const statusView = getPlanDocStatusViewModel(
       activePlanMessage.event,

--- a/src/modules/WorkStation/Chat/Communication/usePlanApproval.ts
+++ b/src/modules/WorkStation/Chat/Communication/usePlanApproval.ts
@@ -17,6 +17,7 @@ import {
   isPlanDisplayEvent,
   planAliasesContain,
 } from "@src/engines/SessionCore/derived/planDisplayEvents";
+import { usePendingPlanApproval } from "@src/hooks/session/usePendingPlanApproval";
 import { FileService } from "@src/services/file";
 import { sessionRuntimeStatusAtom } from "@src/store/session/cliSessionStatusAtom";
 import { creatorDefaultModelSelectionAtom } from "@src/store/session/creatorDefaultModelAtom";
@@ -128,7 +129,7 @@ export function usePlanApproval({
 }: UsePlanApprovalOptions): PlanApprovalState {
   const { t } = useTranslation("sessions");
   const activeSessionId = useAtomValue(activeSessionIdAtom);
-  const approvalMap = useAtomValue(pendingPlanApprovalsAtom);
+  const activeSessionPendingPlan = usePendingPlanApproval(activeSessionId);
   const setPendingPlanApprovals = useSetAtom(pendingPlanApprovalsAtom);
   const sessionMap = useAtomValue(sessionMapAtom);
   const runtimeStatus = useAtomValue(sessionRuntimeStatusAtom);
@@ -146,10 +147,7 @@ export function usePlanApproval({
     null
   ) as React.RefObject<HTMLButtonElement>;
 
-  const activeSessionApprovalState = activeSessionId
-    ? approvalMap.get(activeSessionId)
-    : undefined;
-  const currentPendingPlan = activeSessionApprovalState?.current;
+  const currentPendingPlan = activeSessionPendingPlan;
   const planViewState = useMemo(
     () =>
       derivePlanApprovalViewState({
@@ -205,14 +203,12 @@ export function usePlanApproval({
     ? getPlanEventAliases(activePlanMessage!.event)
     : [];
 
-  const approvalState = planSessionId
-    ? approvalMap.get(planSessionId)
-    : undefined;
+  const planSessionPendingPlan = usePendingPlanApproval(planSessionId);
 
   const planRawContent = isPlanDoc
     ? resolvePlanMarkdownContent(
         activePlanMessage!.event,
-        approvalState?.current
+        planSessionPendingPlan
       )
     : "";
   const planPath =
@@ -220,7 +216,7 @@ export function usePlanApproval({
     asStringArg(planResult?.["planPath"]) ||
     null;
 
-  const planApprovalAliases = getPendingPlanAliases(approvalState?.current);
+  const planApprovalAliases = getPendingPlanAliases(planSessionPendingPlan);
   const matchesCurrentPendingPlan = planIdentity.some((identity) =>
     planAliasesContain(planApprovalAliases, identity)
   );

--- a/src/store/session/__tests__/planApprovalAtom.test.ts
+++ b/src/store/session/__tests__/planApprovalAtom.test.ts
@@ -1,3 +1,4 @@
+import { createStore } from "jotai";
 import { describe, expect, it } from "vitest";
 
 import type {
@@ -7,6 +8,8 @@ import type {
 import {
   clearPendingPlanApproval,
   normalizePlanCallId,
+  pendingPlanApprovalForSessionAtomFamily,
+  pendingPlanApprovalsAtom,
   rehydratePendingPlanApprovalIfNewer,
   upsertPendingPlanApproval,
 } from "../planApprovalAtom";
@@ -35,6 +38,37 @@ function emptyMap(): PlanApprovalStateMap {
 function mapWithPlan(plan: PendingPlanApproval): PlanApprovalStateMap {
   return upsertPendingPlanApproval(emptyMap(), plan);
 }
+
+describe("pendingPlanApprovalForSessionAtomFamily", () => {
+  it("returns only the requested session and updates independently", () => {
+    const store = createStore();
+    const sessionOne = pendingPlanApprovalForSessionAtomFamily("session-1");
+    const sessionTwo = pendingPlanApprovalForSessionAtomFamily("session-2");
+    const planOne = makePlan({ sessionId: "session-1" });
+    const planTwo = makePlan({
+      sessionId: "session-2",
+      planRevisionId: "call_2",
+      toolCallId: "call_2",
+    });
+
+    store.set(pendingPlanApprovalsAtom, mapWithPlan(planOne));
+    expect(store.get(sessionOne)).toBe(planOne);
+    expect(store.get(sessionTwo)).toBeNull();
+
+    store.set(pendingPlanApprovalsAtom, (prev) =>
+      upsertPendingPlanApproval(prev, planTwo)
+    );
+    expect(store.get(sessionOne)).toBe(planOne);
+    expect(store.get(sessionTwo)).toBe(planTwo);
+  });
+
+  it("returns null when no session is selected", () => {
+    const store = createStore();
+    store.set(pendingPlanApprovalsAtom, mapWithPlan(makePlan()));
+
+    expect(store.get(pendingPlanApprovalForSessionAtomFamily(""))).toBeNull();
+  });
+});
 
 // ─── normalizePlanCallId ─────────────────────────────────────────────────────
 

--- a/src/store/session/planApprovalAtom.ts
+++ b/src/store/session/planApprovalAtom.ts
@@ -31,6 +31,7 @@
  * arrived while the async RPC was in flight.
  */
 import { atom } from "jotai";
+import { atomFamily } from "jotai-family";
 
 export interface PendingPlanApproval {
   sessionId: string;
@@ -52,6 +53,17 @@ export interface SessionPlanApprovalState {
 export type PlanApprovalStateMap = Map<string, SessionPlanApprovalState>;
 
 export const pendingPlanApprovalsAtom = atom<PlanApprovalStateMap>(new Map());
+
+export const pendingPlanApprovalForSessionAtomFamily = atomFamily(
+  (sessionId: string) => {
+    const scopedAtom = atom<PendingPlanApproval | null>((get) => {
+      if (!sessionId) return null;
+      return get(pendingPlanApprovalsAtom).get(sessionId)?.current ?? null;
+    });
+    scopedAtom.debugLabel = `pendingPlanApproval(${sessionId})`;
+    return scopedAtom;
+  }
+);
 
 function emptyState(): SessionPlanApprovalState {
   return { current: null };


### PR DESCRIPTION
## Summary

- add a session-scoped `usePendingPlanApproval` hook backed by a derived atom family
- migrate pending-plan read consumers while retaining `pendingPlanApprovalsAtom` as the single write/source-of-truth path
- add focused coverage for session isolation and empty-session behavior

Supersedes closed PR #318. This rebuild starts from current `develop`.

## Validation

- 24 focused Vitest tests passed
- `tsc --noEmit --pretty false`
- ESLint on all 10 changed files
- `git diff --check`
- GitHub Frontend and Rust CI passed

## Scope notes

- preserves the existing rehydrate race protection on `develop`
- does not duplicate or replace `usePlanApproval`
- does not add a second writable approval atom