### PR TITLE
fix(canvas): clear preview on session switch

### DIFF
--- a/src/engines/ChatPanel/blocks/CanvasInlineCard/__tests__/canvasVisibilityLifecycle.test.ts
+++ b/src/engines/ChatPanel/blocks/CanvasInlineCard/__tests__/canvasVisibilityLifecycle.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   type CanvasPreviewEntry,
+  clearCanvasOnSessionSwitch,
   deriveCanvasForSessionSnapshot,
   dismissCanvasForSession,
 } from "@src/store/session/canvasPreviewAtom";
@@ -106,6 +107,22 @@ describe("canvas visibility lifecycle", () => {
     it("returns null when called with null entry", () => {
       const result = dismissCanvasForSession(null, "session-1");
       expect(result).toBeNull();
+    });
+  });
+
+  describe("clearCanvasOnSessionSwitch", () => {
+    it("clears the single stored entry when switching sessions", () => {
+      expect(
+        clearCanvasOnSessionSwitch(makeEntry(), "session-1", "session-2")
+      ).toBeNull();
+    });
+
+    it("preserves the entry for same-session reloads and first load", () => {
+      const entry = makeEntry();
+      expect(clearCanvasOnSessionSwitch(entry, "session-1", "session-1")).toBe(
+        entry
+      );
+      expect(clearCanvasOnSessionSwitch(entry, null, "session-1")).toBe(entry);
     });
   });
 

--- a/src/engines/SessionCore/sync/__tests__/sessionSyncStateHelpers.test.ts
+++ b/src/engines/SessionCore/sync/__tests__/sessionSyncStateHelpers.test.ts
@@ -242,6 +242,7 @@ describe("resetSessionSwitchState optimistic-running preservation", () => {
       setSessionRuntimeError: vi.fn(),
       setPendingCancel: vi.fn(),
       setStreamRetryStatus: vi.fn(),
+      clearCanvasPreviewOnSessionSwitch: vi.fn(),
     };
   }
 
@@ -263,6 +264,21 @@ describe("resetSessionSwitchState optimistic-running preservation", () => {
     expect(actions.setSessionContextTokens).toHaveBeenCalledWith(0);
     expect(actions.setSessionContextUsage).toHaveBeenCalledWith(null);
     expect(actions.setSessionContextBreakdown).toHaveBeenCalledWith(null);
+  });
+
+  it("clears canvas preview when switching between sessions", () => {
+    const actions = createSwitchActions();
+    resetSessionSwitchState(actions, "session-b", "session-a");
+    expect(actions.clearCanvasPreviewOnSessionSwitch).toHaveBeenCalledWith(
+      "session-a",
+      "session-b"
+    );
+  });
+
+  it("does not request a canvas clear without an entering session", () => {
+    const actions = createSwitchActions();
+    resetSessionSwitchState(actions);
+    expect(actions.clearCanvasPreviewOnSessionSwitch).not.toHaveBeenCalled();
   });
 
   it("preserves running for a session just optimistically started", () => {

--- a/src/engines/SessionCore/sync/sessionSwitchEffectRunner.ts
+++ b/src/engines/SessionCore/sync/sessionSwitchEffectRunner.ts
@@ -43,10 +43,11 @@ export function runSessionSwitchEffect(
     logger,
   } = options;
 
+  const leavingSessionId = refs.prevSessionIdRef.current;
   refs.prevSessionIdRef.current = sessionId;
   refs.prevReloadEpochRef.current = reloadEpoch;
 
-  resetSessionSwitchState(switchActions, sessionId);
+  resetSessionSwitchState(switchActions, sessionId, leavingSessionId);
   disposeCurrentHandler(refs);
 
   const adapter = getAdapterForSession(sessionId);

--- a/src/engines/SessionCore/sync/sessionSyncStateHelpers.ts
+++ b/src/engines/SessionCore/sync/sessionSyncStateHelpers.ts
@@ -54,6 +54,10 @@ export interface SessionSwitchStateActions {
   setSessionRuntimeError: (value: string | null) => void;
   setPendingCancel: (value: boolean) => void;
   setStreamRetryStatus: (value: StreamRetryStatus | null) => void;
+  clearCanvasPreviewOnSessionSwitch: (
+    leavingSessionId: string | null,
+    enteringSessionId: string
+  ) => void;
 }
 
 export interface SessionLoadStateActions {
@@ -103,7 +107,8 @@ const RUNNING_HANDLER_STATUSES = new Set<string>([
 ]);
 export function resetSessionSwitchState(
   actions: SessionSwitchStateActions,
-  sessionId?: string
+  sessionId?: string,
+  leavingSessionId?: string | null
 ): void {
   actions.setWpReadOnly(false);
   actions.clearSessionLoadError();
@@ -124,6 +129,12 @@ export function resetSessionSwitchState(
   actions.setSessionContextTokens(0);
   actions.setSessionContextUsage(null);
   actions.setSessionContextBreakdown(null);
+  if (sessionId) {
+    actions.clearCanvasPreviewOnSessionSwitch(
+      leavingSessionId ?? null,
+      sessionId
+    );
+  }
 }
 
 export function applyPostLoadResult(

--- a/src/engines/SessionCore/sync/useSessionSync.ts
+++ b/src/engines/SessionCore/sync/useSessionSync.ts
@@ -18,6 +18,7 @@ import {
 import { createLogger } from "@src/hooks/logger";
 import {
   canvasPreviewAtom,
+  clearCanvasOnSessionSwitch,
   dismissCanvasForSession,
 } from "@src/store/session/canvasPreviewAtom";
 import {
@@ -100,6 +101,14 @@ export function useSessionSync(
   const setStreamingDeltaContent = useSetAtom(streamingDeltaContentAtom);
   const setPendingPlanApprovals = useSetAtom(pendingPlanApprovalsAtom);
   const setCanvasPreview = useSetAtom(canvasPreviewAtom);
+  const clearCanvasPreviewOnSessionSwitch = useCallback(
+    (leavingSessionId: string | null, enteringSessionId: string) => {
+      setCanvasPreview((prev) =>
+        clearCanvasOnSessionSwitch(prev, leavingSessionId, enteringSessionId)
+      );
+    },
+    [setCanvasPreview]
+  );
   const activeExternalSessionRefreshFrequency = useAtomValue(
     activeExternalSessionRefreshFrequencyAtom
   );
@@ -140,6 +149,7 @@ export function useSessionSync(
       setSessionRuntimeError,
       setPendingCancel,
       setStreamRetryStatus,
+      clearCanvasPreviewOnSessionSwitch,
     }),
     [
       clearSessionLoadError,
@@ -151,6 +161,7 @@ export function useSessionSync(
       setSessionRuntimeError,
       setPendingCancel,
       setStreamRetryStatus,
+      clearCanvasPreviewOnSessionSwitch,
     ]
   );
 

--- a/src/store/session/canvasPreviewAtom.ts
+++ b/src/store/session/canvasPreviewAtom.ts
@@ -67,5 +67,16 @@ export function clearCanvasForSession(
   return sessionId && entry?.sessionId === sessionId ? null : entry;
 }
 
+export function clearCanvasOnSessionSwitch(
+  entry: CanvasPreviewEntry | null,
+  leavingSessionId: string | null,
+  enteringSessionId: string
+): CanvasPreviewEntry | null {
+  if (!entry || !leavingSessionId || leavingSessionId === enteringSessionId) {
+    return entry;
+  }
+  return null;
+}
+
 export const canvasPreviewAtom = atom<CanvasPreviewEntry | null>(null);
 canvasPreviewAtom.debugLabel = "session/canvasPreview";


### PR DESCRIPTION
## Summary

- clear the stored canvas preview only when navigating between distinct sessions
- preserve previews across same-session reloads and initial loads
- thread the leaving session through the existing SessionCore switch lifecycle

Extracted from closed PR #281.

## Validation

- 36 focused Vitest tests passed
- scoped ESLint passed
- `pnpm run typecheck`
- `git diff --check`
- GitHub Frontend and Rust CI passed