### PR TITLE
fix(session): scope rewind boundary signals

### DIFF
--- a/src/engines/SessionCore/control/__tests__/sessionTimelineBoundaryHelpers.test.ts
+++ b/src/engines/SessionCore/control/__tests__/sessionTimelineBoundaryHelpers.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldInterruptTimelineBoundary } from "../sessionTimelineBoundaryHelpers";
+
+describe("shouldInterruptTimelineBoundary", () => {
+  it("always interrupts stop and force-send", () => {
+    const idle = { turnActive: false, hasLiveSubagents: false };
+    expect(shouldInterruptTimelineBoundary("stop", idle)).toBe(true);
+    expect(shouldInterruptTimelineBoundary("force-send", idle)).toBe(true);
+  });
+
+  it("skips an idle rewind", () => {
+    expect(
+      shouldInterruptTimelineBoundary("rewind", {
+        turnActive: false,
+        hasLiveSubagents: false,
+      })
+    ).toBe(false);
+  });
+
+  it("interrupts rewind for an active target turn or its live subagents", () => {
+    expect(
+      shouldInterruptTimelineBoundary("rewind", {
+        turnActive: true,
+        hasLiveSubagents: false,
+      })
+    ).toBe(true);
+    expect(
+      shouldInterruptTimelineBoundary("rewind", {
+        turnActive: false,
+        hasLiveSubagents: true,
+      })
+    ).toBe(true);
+  });
+});

--- a/src/engines/SessionCore/control/sessionTimelineBoundary.test.ts
+++ b/src/engines/SessionCore/control/sessionTimelineBoundary.test.ts
@@ -17,6 +17,14 @@ const markStoppedSpy = vi.hoisted(() => vi.fn());
 const getEventsSpy = vi.hoisted(() => vi.fn());
 const patchByIdsSpy = vi.hoisted(() => vi.fn());
 const killAgentShellProcessSpy = vi.hoisted(() => vi.fn());
+const isTurnActiveSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("@src/engines/SessionCore/control/turnLifecycle", async () => {
+  const actual = await vi.importActual<
+    typeof import("@src/engines/SessionCore/control/turnLifecycle")
+  >("@src/engines/SessionCore/control/turnLifecycle");
+  return { ...actual, isTurnActive: isTurnActiveSpy };
+});
 
 vi.mock("@src/util/core/state/instrumentedStore", () => ({
   getInstrumentedStore: () => ({ get: storeGetSpy, set: storeSetSpy }),
@@ -54,6 +62,7 @@ describe("sessionTimelineBoundary", () => {
     getEventsSpy.mockResolvedValue([]);
     patchByIdsSpy.mockResolvedValue(undefined);
     killAgentShellProcessSpy.mockResolvedValue("killed");
+    isTurnActiveSpy.mockReturnValue(false);
   });
 
   it("makes Stop boundary local and O(1)", () => {
@@ -312,12 +321,9 @@ describe("sessionTimelineBoundary", () => {
   });
 
   it("interrupts backend for active rewind boundaries", async () => {
-    storeGetSpy.mockImplementation((atom: { debugLabel?: string }) => {
-      if (atom.debugLabel === "isSessionActive") return true;
-      if (atom.debugLabel === "sessionRuntimeStatus") return "running";
-      if (atom.debugLabel === "session/sortedEvents") return [];
-      return new Map();
-    });
+    isTurnActiveSpy.mockImplementation(
+      (sessionId: string) => sessionId === "session-1"
+    );
     interruptSpy.mockResolvedValue(undefined);
 
     await cancelTurnForTimelineBoundary("session-1", "rewind");

--- a/src/engines/SessionCore/control/sessionTimelineBoundary.ts
+++ b/src/engines/SessionCore/control/sessionTimelineBoundary.ts
@@ -1,7 +1,12 @@
 import { CANCEL_REASON } from "@src/api/tauri/agent";
 import {
+  type TimelineBoundaryReason,
+  shouldInterruptTimelineBoundary,
+} from "@src/engines/SessionCore/control/sessionTimelineBoundaryHelpers";
+import {
   beginTurnStopping,
   forceTurnIdle,
+  isTurnActive,
 } from "@src/engines/SessionCore/control/turnLifecycle";
 import { isTimelineBoundaryClosableRuntimeEvent } from "@src/engines/SessionCore/core/runningEventGate";
 import { eventStoreProxy } from "@src/engines/SessionCore/core/store/EventStoreProxy";
@@ -11,20 +16,22 @@ import { createLogger } from "@src/hooks/logger";
 import { killAgentShellProcess } from "@src/services/terminal";
 import {
   isPendingCancelAtom,
-  isSessionActiveAtom,
-  sessionRuntimeStatusAtom,
   setSessionRuntimeStatusAtom,
   streamRetryStatusAtom,
   userInitiatedCancelAtom,
 } from "@src/store/session/cliSessionStatusAtom";
 import { shellProcessMapAtom } from "@src/store/session/shellProcessAtom";
+import {
+  hasLiveSubagentJobs,
+  subagentJobMapAtom,
+} from "@src/store/session/subagentJobAtom";
 import { holdSessionQueueForStopAtom } from "@src/store/ui/messageQueueAtom";
 import { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";
 
 import { streamingDeltaContentAtom } from "../core/atoms";
 import { discardStreamingDeltaBuffer } from "../core/atoms/streamingDeltaBuffer";
 
-export type TimelineBoundaryReason = "stop" | "force-send" | "rewind";
+export type { TimelineBoundaryReason } from "./sessionTimelineBoundaryHelpers";
 
 /**
  * Which OS shell processes a boundary terminates.
@@ -149,18 +156,17 @@ async function closeRunningEventsForTimelineBoundary(
 }
 
 function shouldInterruptForTimelineBoundary(
-  _sessionId: string,
+  sessionId: string,
   reason: TimelineBoundaryReason
 ): boolean {
-  if (reason !== "rewind") return true;
-
   const store = getInstrumentedStore();
-  const runtimeStatus = store.get(sessionRuntimeStatusAtom);
-  return (
-    store.get(isSessionActiveAtom) ||
-    runtimeStatus === "running" ||
-    runtimeStatus === "installing"
-  );
+  return shouldInterruptTimelineBoundary(reason, {
+    turnActive: isTurnActive(sessionId),
+    hasLiveSubagents: hasLiveSubagentJobs(
+      store.get(subagentJobMapAtom),
+      sessionId
+    ),
+  });
 }
 
 export function beginTimelineBoundary(

--- a/src/engines/SessionCore/control/sessionTimelineBoundaryHelpers.ts
+++ b/src/engines/SessionCore/control/sessionTimelineBoundaryHelpers.ts
@@ -1,0 +1,18 @@
+export type TimelineBoundaryReason = "stop" | "force-send" | "rewind";
+
+export interface RewindInterruptSignals {
+  turnActive: boolean;
+  hasLiveSubagents: boolean;
+}
+
+/**
+ * Resolve boundary interruption from signals belonging to the target session.
+ * Rewind must not consult global UI status, which may describe another session.
+ */
+export function shouldInterruptTimelineBoundary(
+  reason: TimelineBoundaryReason,
+  signals: RewindInterruptSignals
+): boolean {
+  if (reason !== "rewind") return true;
+  return signals.turnActive || signals.hasLiveSubagents;
+}


### PR DESCRIPTION
## Summary

- decide rewind interruption from the target session turn FSM and live subagent jobs
- remove dependence on global runtime/UI mirrors that can describe a different visible session
- keep Stop and force-send interruption behavior unchanged

Extracted from closed PR #281.

## Validation

- 27 focused Vitest tests passed
- scoped ESLint passed
- `pnpm run typecheck`
- `git diff --check`
- GitHub Frontend and Rust CI passed