### PR TITLE
perf(streaming): reduce Rust allocation churn

### DIFF
--- a/src-tauri/crates/agent-core/src/core/providers/anthropic_native/streaming.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/anthropic_native/streaming.rs
@@ -416,9 +416,11 @@ impl LLMProvider for AnthropicClient {
 
             buffer.push_str(&String::from_utf8_lossy(&chunk));
 
-            while let Some(line_end) = buffer.find('\n') {
-                let line = buffer[..line_end].trim().to_string();
-                buffer = buffer[line_end + 1..].to_string();
+            let mut consumed = 0usize;
+            while let Some(relative_end) = buffer[consumed..].find('\n') {
+                let line_end = consumed + relative_end;
+                let line = buffer[consumed..line_end].trim();
+                consumed = line_end + 1;
 
                 if line.is_empty() || line.starts_with(':') {
                     continue;
@@ -460,6 +462,9 @@ impl LLMProvider for AnthropicClient {
                 }
             }
 
+            if consumed > 0 {
+                buffer.drain(..consumed);
+            }
             if stream_done {
                 break;
             }

--- a/src-tauri/crates/agent-core/src/core/providers/openai_compat/streaming/sse_stream.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/openai_compat/streaming/sse_stream.rs
@@ -320,9 +320,11 @@ pub(super) async fn run_chat_streaming(
 
         buffer.push_str(&String::from_utf8_lossy(&chunk));
 
-        while let Some(line_end) = buffer.find('\n') {
-            let line = buffer[..line_end].trim().to_string();
-            buffer = buffer[line_end + 1..].to_string();
+        let mut consumed = 0usize;
+        while let Some(relative_end) = buffer[consumed..].find('\n') {
+            let line_end = consumed + relative_end;
+            let line = buffer[consumed..line_end].trim();
+            consumed = line_end + 1;
 
             if line.is_empty() || line.starts_with(':') {
                 continue;
@@ -531,6 +533,9 @@ pub(super) async fn run_chat_streaming(
                 );
                 final_usage.extend(normalized_usage);
             }
+        }
+        if consumed > 0 {
+            buffer.drain(..consumed);
         }
         if stream_done {
             break;

--- a/src-tauri/crates/agent-core/src/core/turn_executor/execute.rs
+++ b/src-tauri/crates/agent-core/src/core/turn_executor/execute.rs
@@ -280,8 +280,7 @@ pub async fn execute_turn(
             session_id
         );
 
-        let stream_normalizer = Arc::new(std::sync::Mutex::new(TurnStreamNormalizer::new()));
-        let stream_normalizer_for_cb = stream_normalizer.clone();
+        let stream_normalizer_for_cb = std::sync::Mutex::new(TurnStreamNormalizer::new());
 
         provider.set_session_context(session_id);
 

--- a/src-tauri/crates/agent-core/src/core/turn_executor/stream_normalizer.rs
+++ b/src-tauri/crates/agent-core/src/core/turn_executor/stream_normalizer.rs
@@ -43,7 +43,7 @@ impl TurnStreamNormalizer {
     }
 
     pub(crate) fn ingest_delta(&mut self, delta: StreamDelta) -> Vec<NormalizedStreamEvent> {
-        let mut events = Vec::new();
+        let mut events = Vec::with_capacity(1);
         if let Some(text) = delta.content {
             events.extend(self.ingest_event(ProviderStreamEvent::MessageDelta { text }));
         }
@@ -68,7 +68,7 @@ impl TurnStreamNormalizer {
         &mut self,
         event: ProviderStreamEvent,
     ) -> Vec<NormalizedStreamEvent> {
-        let mut events = Vec::new();
+        let mut events = Vec::with_capacity(2);
         match event {
             ProviderStreamEvent::MessageDelta { text } => {
                 if !text.is_empty() {
@@ -178,6 +178,7 @@ mod tests {
         });
 
         assert_eq!(events.len(), 2);
+        assert!(events.capacity() >= 2);
         assert!(matches!(
             events[0],
             NormalizedStreamEvent::FlushSegment(FlushReason::BeforeTool)


### PR DESCRIPTION
## Problem

Rust streaming hot paths repeatedly parse and drain buffers and perform avoidable allocations while normalizing Anthropic and OpenAI-compatible SSE events.

## Solution

- Parse complete SSE lines by byte offset and drain each chunk once.
- Preallocate normalizer output for observed one-event and flush-plus-event paths.
- Remove a redundant `Arc` around the callback-owned normalizer mutex.
- Validation: Rust fmt/clippy, 3,074 agent-core tests plus doc tests, and a two-event capacity regression.

## Potential risks

- Parser boundary mistakes could drop or duplicate partial SSE lines.
- Malformed Anthropic JSON behavior is intentionally unchanged.
- No TypeScript or `chatEvents` behavior is changed.
