### PR TITLE
fix(workstation): finish session workspace isolation

### DIFF
--- a/src/app/root/e2e/helpers/navigation.ts
+++ b/src/app/root/e2e/helpers/navigation.ts
@@ -31,10 +31,10 @@ import {
   createAgentConfigTab,
   createProjectWorkItemsIndexTab,
   createProjectWorkItemsTab,
-  openTab,
+  openWorkstationTabAtom,
+  presentedWorkstationWorkspaceKeyAtom,
   workstationLayoutAtom,
 } from "@src/store/workstation/tabs";
-import { LAYOUT_STORAGE_KEY } from "@src/store/workstation/tabs/storage";
 import { getRustAgentType } from "@src/util/session/sessionDispatch";
 
 import { asError } from "../result";
@@ -65,13 +65,8 @@ export function createNavigationHelpers(store: E2EStore) {
       store.set(stationModeAtom, "my-station");
       store.set(chatPanelMaximizedAtom, false);
       const tab = createProjectWorkItemsIndexTab();
-      const current = store.get(workstationLayoutAtom);
-      const nextLayout = {
-        ...current,
-        mainPane: openTab({ tabs: [], activeTabId: null }, tab),
-      };
-      localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(nextLayout));
-      store.set(workstationLayoutAtom, nextLayout);
+      const workspace = store.get(presentedWorkstationWorkspaceKeyAtom);
+      store.set(openWorkstationTabAtom, { workspace, tab });
       void router.navigate("/orgii/workstation/project").catch(() => undefined);
       const layout = store.get(workstationLayoutAtom);
       return {
@@ -107,13 +102,8 @@ export function createNavigationHelpers(store: E2EStore) {
         projectSlug,
         PROJECT_DETAIL_SURFACE_VIEW.WORK_ITEMS
       );
-      const current = store.get(workstationLayoutAtom);
-      const nextLayout = {
-        ...current,
-        mainPane: openTab({ tabs: [], activeTabId: null }, tab),
-      };
-      localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(nextLayout));
-      store.set(workstationLayoutAtom, nextLayout);
+      const workspace = store.get(presentedWorkstationWorkspaceKeyAtom);
+      store.set(openWorkstationTabAtom, { workspace, tab });
       void router.navigate("/orgii/workstation/project").catch(() => undefined);
       const layout = store.get(workstationLayoutAtom);
       return {
@@ -165,30 +155,11 @@ export function createNavigationHelpers(store: E2EStore) {
         displayName: agentSnapshot?.name ?? agentId,
         entitySnapshot: agentSnapshot,
       });
-      const current = store.get(workstationLayoutAtom);
-      const nextLayout = {
-        ...current,
-        mainPane: openTab(
-          current?.mainPane ?? { tabs: [], activeTabId: null },
-          agentConfigTab
-        ),
-      };
-      localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(nextLayout));
-      store.set(workstationLayoutAtom, nextLayout);
+      const workspace = store.get(presentedWorkstationWorkspaceKeyAtom);
+      store.set(openWorkstationTabAtom, { workspace, tab: agentConfigTab });
       store.set(agentOrgsActiveTabAtom, tab);
       await router.navigate("/orgii/workstation/code");
-      const mountedLayout = {
-        ...store.get(workstationLayoutAtom),
-        mainPane: openTab(
-          store.get(workstationLayoutAtom)?.mainPane ?? {
-            tabs: [],
-            activeTabId: null,
-          },
-          agentConfigTab
-        ),
-      };
-      localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(mountedLayout));
-      store.set(workstationLayoutAtom, mountedLayout);
+      store.set(openWorkstationTabAtom, { workspace, tab: agentConfigTab });
       for (let attempt = 0; attempt < 10; attempt += 1) {
         await new Promise((resolve) => window.setTimeout(resolve, 50));
         store.set(chatPanelMaximizedAtom, false);
@@ -229,16 +200,8 @@ export function createNavigationHelpers(store: E2EStore) {
         displayName: displayName ?? orgSnapshot?.name ?? orgId,
         entitySnapshot: orgSnapshot,
       });
-      const current = store.get(workstationLayoutAtom);
-      const nextLayout = {
-        ...current,
-        mainPane: openTab(
-          current?.mainPane ?? { tabs: [], activeTabId: null },
-          tab
-        ),
-      };
-      localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(nextLayout));
-      store.set(workstationLayoutAtom, nextLayout);
+      const workspace = store.get(presentedWorkstationWorkspaceKeyAtom);
+      store.set(openWorkstationTabAtom, { workspace, tab });
       store.set(agentOrgsActiveTabAtom, "orgs");
       await router.navigate("/orgii/workstation/code");
       for (let attempt = 0; attempt < 10; attempt += 1) {

--- a/src/engines/SessionCore/services/PlanExecutionService.ts
+++ b/src/engines/SessionCore/services/PlanExecutionService.ts
@@ -28,6 +28,7 @@ async function sendPlanMessage(
 ): Promise<void> {
   const adeContext = collectAdeContext({
     expectedRepoPath: params.workspacePath ?? null,
+    sessionId,
   });
   // Raw invoke bypasses useMessageDispatch — without the optimistic running
   // the planning indicator stays blank until Rust's first status event (#8).

--- a/src/engines/SessionCore/services/SessionService.ts
+++ b/src/engines/SessionCore/services/SessionService.ts
@@ -305,6 +305,7 @@ export const SessionService = {
     const sessionRow = getInstrumentedStore().get(sessionByIdAtom(sessionId));
     const adeContext = collectAdeContext({
       expectedRepoPath: sessionRow?.repoPath ?? null,
+      sessionId,
     });
     const adapter = getAdapterForSession(sessionId);
     if (!adapter) {

--- a/src/hooks/git/useGitErrorDialog.ts
+++ b/src/hooks/git/useGitErrorDialog.ts
@@ -22,8 +22,8 @@ import {
 } from "@src/store/ui/workStationAtom";
 import {
   createGitLogTab,
-  openTab,
-  workstationLayoutAtom,
+  openWorkstationTabAtom,
+  presentedWorkstationWorkspaceKeyAtom,
 } from "@src/store/workstation/tabs";
 import { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";
 import { showGitActionDialogSafely } from "@src/util/dialogs/gitActionDialog";
@@ -237,8 +237,8 @@ export function useGitErrorDialog(
 
     const store = getInstrumentedStore();
     const errorInfo = buildGitErrorInfo(options);
+    const workspace = store.get(presentedWorkstationWorkspaceKeyAtom);
 
-    // Create the git log tab
     const tab = createGitLogTab(
       errorInfo.operation,
       errorInfo.errorMessage,
@@ -246,11 +246,9 @@ export function useGitErrorDialog(
       errorInfo.timestamp
     );
 
-    const layout = store.get(workstationLayoutAtom);
-    if (!layout) return;
-    store.set(workstationLayoutAtom, {
-      ...layout,
-      mainPane: openTab(layout.mainPane, tab),
+    store.set(openWorkstationTabAtom, {
+      workspace,
+      tab,
     });
   }, []);
 
@@ -351,13 +349,11 @@ export async function showGitErrorAndHandle(
         errorInfo.timestamp
       );
 
-      const layout = store.get(workstationLayoutAtom);
-      if (layout) {
-        store.set(workstationLayoutAtom, {
-          ...layout,
-          mainPane: openTab(layout.mainPane, tab),
-        });
-      }
+      const workspace = store.get(presentedWorkstationWorkspaceKeyAtom);
+      store.set(openWorkstationTabAtom, {
+        workspace,
+        tab,
+      });
       break;
     }
 

--- a/src/scaffold/NavigationSidebar/connectors/useProjectsWorkItemMenuItems/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/useProjectsWorkItemMenuItems/index.tsx
@@ -1,4 +1,4 @@
-import { useSetAtom } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -16,8 +16,8 @@ import {
   STORY_ORG_SCOPE,
   createProjectLinearWorkItemsTab,
   createProjectOrgTab,
-  openTab,
-  workstationLayoutAtom,
+  openWorkstationTabAtom,
+  presentedWorkstationWorkspaceKeyAtom,
 } from "@src/store/workstation/tabs";
 import { STORY_PERSONAL_ORG_FILTER_ID } from "@src/store/workstation/tabs/factories/project";
 
@@ -72,7 +72,8 @@ export function useProjectsWorkItemMenuItems({
   selectedOrgId,
 }: UseProjectsWorkItemMenuItemsParams): UseProjectsWorkItemMenuItemsResult {
   const { t } = useTranslation(["projects", "common", "navigation"]);
-  const setLayout = useSetAtom(workstationLayoutAtom);
+  const openWorkstationTab = useSetAtom(openWorkstationTabAtom);
+  const presentedWorkspace = useAtomValue(presentedWorkstationWorkspaceKeyAtom);
   const [localOrgs, setLocalOrgs] = useState<ProjectOrg[]>([]);
   const [localProjects, setLocalProjects] = useState<SidebarProject[]>([]);
   const [workItems, setWorkItems] = useState<SidebarWorkItem[]>([]);
@@ -428,12 +429,9 @@ export function useProjectsWorkItemMenuItems({
         PROJECT_ORG_SURFACE_VIEW.WORK_ITEMS,
         orgScope
       );
-      setLayout((layout) => ({
-        ...layout,
-        mainPane: openTab(layout.mainPane, tab),
-      }));
+      openWorkstationTab({ workspace: presentedWorkspace, tab });
     },
-    [setLayout]
+    [openWorkstationTab, presentedWorkspace]
   );
 
   const openLinearOrg = useCallback(
@@ -443,12 +441,9 @@ export function useProjectsWorkItemMenuItems({
         teamId: org.teamId,
         teamName: org.teamName,
       });
-      setLayout((layout) => ({
-        ...layout,
-        mainPane: openTab(layout.mainPane, tab),
-      }));
+      openWorkstationTab({ workspace: presentedWorkspace, tab });
     },
-    [setLayout]
+    [openWorkstationTab, presentedWorkspace]
   );
 
   const openLinearWorkItem = useCallback(
@@ -460,12 +455,9 @@ export function useProjectsWorkItemMenuItems({
         teamId: workItem.teamId,
         teamName: workItem.teamName,
       });
-      setLayout((layout) => ({
-        ...layout,
-        mainPane: openTab(layout.mainPane, tab),
-      }));
+      openWorkstationTab({ workspace: presentedWorkspace, tab });
     },
-    [setLayout]
+    [openWorkstationTab, presentedWorkspace]
   );
 
   return {

--- a/src/scaffold/NavigationSidebar/connectors/useWorkstationSidebarHandlers.ts
+++ b/src/scaffold/NavigationSidebar/connectors/useWorkstationSidebarHandlers.ts
@@ -50,6 +50,11 @@ import {
   CHAT_PANEL_SURFACE_KIND,
   chatPanelNavigateAtom,
 } from "@src/store/ui/chatPanelAtom";
+import {
+  clearPendingFileOpensForSession,
+  disposeWorkstationWorkspaceAtom,
+} from "@src/store/workstation/tabs";
+import { clearPendingCodeEditorTabForSession } from "@src/store/workstation/tabs/pendingCodeEditorTab";
 import { invokeTauri } from "@src/util/platform/tauri/init";
 import { isCliSession } from "@src/util/session/sessionDispatch";
 import { getSessionListDisplayName } from "@src/util/session/sessionSidebarRow";
@@ -132,6 +137,9 @@ export function useWorkstationSidebarHandlers({
   const setBenchmarkActiveBatchTaskId = useSetAtom(
     benchmarkActiveBatchTaskIdAtom
   );
+  const disposeWorkstationWorkspace = useSetAtom(
+    disposeWorkstationWorkspaceAtom
+  );
   const pagination = useAtomValue(sessionPaginationAtom);
   const cloudAuth = useAtomValue(org2CloudAuthAtom);
   const setCloudAuth = useSetAtom(org2CloudAuthAtom);
@@ -192,6 +200,9 @@ export function useWorkstationSidebarHandlers({
         }
         removeSession(sessionId);
         removeForkRelayEntry(sessionId);
+        disposeWorkstationWorkspace(sessionId);
+        clearPendingFileOpensForSession(sessionId);
+        clearPendingCodeEditorTabForSession(sessionId);
 
         if (sessionId === activeSessionId) {
           goToNewSession();
@@ -206,6 +217,7 @@ export function useWorkstationSidebarHandlers({
       cloudAuth,
       setCloudAuth,
       cloudOrgs,
+      disposeWorkstationWorkspace,
       goToNewSession,
       onCloseChatPanelTab,
       sessionMap,

--- a/src/services/context/collectors/AdeContextCollector.ts
+++ b/src/services/context/collectors/AdeContextCollector.ts
@@ -35,6 +35,7 @@ import type {
 } from "@src/services/context/workspaceSnapshot";
 import { currentGitStatusAtom } from "@src/store/git";
 import { currentBranchAtom } from "@src/store/repo/atoms";
+import { workstationActiveSessionIdAtom } from "@src/store/session/viewAtom";
 import { settingsAtom } from "@src/store/settings";
 import { globalStatusBarStateAtom } from "@src/store/ui/workStationAtom";
 import { workspaceFoldersAtom } from "@src/store/ui/workspaceFoldersAtom";
@@ -47,8 +48,9 @@ import {
   workstationRepoScopeKey,
 } from "@src/store/workstation/codeEditor/workstationPrAtom";
 import {
-  activeWorkStationFilePathAtom,
-  workstationLayoutAtom,
+  selectWorkstationPanel,
+  sessionWorkstationWorkspaceKey,
+  workstationTabsStateAtom,
 } from "@src/store/workstation/tabs";
 import { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";
 
@@ -81,6 +83,8 @@ export interface CollectAdeContextOptions {
    * have no session affinity.
    */
   expectedRepoPath?: string | null;
+  /** Agent session whose WorkStation task workspace supplies file context. */
+  sessionId?: string | null;
 }
 
 function normalizeRepoPath(value: string | undefined | null): string | null {
@@ -201,11 +205,26 @@ export function collectAdeContext(
 
     const payload: WorkspaceSnapshot = {};
     let hasData = false;
+    const workspaceSessionId = options.sessionId ?? null;
+    const workspacePanel = workspaceSessionId
+      ? selectWorkstationPanel(
+          store.get(workstationTabsStateAtom),
+          sessionWorkstationWorkspaceKey(workspaceSessionId)
+        )
+      : null;
+    const presentedSessionId = store.get(workstationActiveSessionIdAtom);
 
-    // Active file
+    // Active/open files are owned by the target agent session. New-session
+    // callers intentionally have no task workspace and therefore attach none.
     try {
-      const activeFile = store.get(activeWorkStationFilePathAtom);
-      if (activeFile) {
+      const activeTab = workspacePanel?.tabs.find(
+        (tab) => tab.id === workspacePanel.activeTabId
+      );
+      const activeFile =
+        activeTab?.type === "file" || activeTab?.type === "git-diff"
+          ? activeTab.data.filePath
+          : null;
+      if (typeof activeFile === "string" && activeFile) {
         payload.activeFile = activeFile;
         hasData = true;
       }
@@ -213,10 +232,8 @@ export function collectAdeContext(
       /* not available */
     }
 
-    // Open files in the single main pane
     try {
-      const layout = store.get(workstationLayoutAtom);
-      const tabs = layout?.mainPane?.tabs ?? [];
+      const tabs = workspacePanel?.tabs ?? [];
       const seen = new Set<string>();
       const openFiles: string[] = [];
       for (const tab of tabs) {
@@ -235,10 +252,14 @@ export function collectAdeContext(
       /* tabs not available */
     }
 
-    // Cursor position (file:line:column)
+    // Cursor state is a live UI value and is safe only when the target session
+    // still owns the presented WorkStation workspace.
     try {
+      const canAttachCursor =
+        workspaceSessionId !== null &&
+        workspaceSessionId === presentedSessionId;
       const statusBar = store.get(globalStatusBarStateAtom);
-      if (statusBar.cursor && payload.activeFile) {
+      if (canAttachCursor && statusBar.cursor && payload.activeFile) {
         payload.cursorPosition = `${payload.activeFile}:${statusBar.cursor.line}:${statusBar.cursor.column}`;
         hasData = true;
       }


### PR DESCRIPTION
## Summary

- route remaining WorkStation tab opens through the presented workspace
- collect ADE file context from the target session workspace
- dispose session workspace and pending file/editor opens on deletion
- align E2E navigation helpers with workspace-owned tab state

## Verification

- `pnpm exec eslint` on all 7 changed files
- `pnpm exec vitest run src/store/workstation/tabs/__tests__/workspaceState.test.ts src/store/workstation/tabs/__tests__/pendingFileOpens.test.ts src/store/workstation/tabs/__tests__/pendingCodeEditorTab.test.ts` — 20 passed
- pre-commit scoped TypeScript check passed
- `git diff --check` passed

## Note

Full `pnpm exec tsc --noEmit --pretty false` is currently blocked by missing local Tiptap packages; no changed-file TypeScript error was reported by the scoped commit check.

Follow-up to #455.