### PR TITLE
perf(tutorials): coalesce highlight layout updates

### DIFF
--- a/src/scaffold/Tutorials/CodeEditorTour.tsx
+++ b/src/scaffold/Tutorials/CodeEditorTour.tsx
@@ -17,6 +17,7 @@ import { sourceControlFilterModeAtom } from "@src/store/workstation/codeEditor/s
 import { useCurrentTheme } from "@src/util/ui/theme/themeUtils";
 import { getViewportSize } from "@src/util/ui/window/viewport";
 
+import { createAnimationFrameScheduler } from "./animationFrameScheduler";
 import { CODE_EDITOR_TOUR_TARGETS } from "./codeEditorTourConfig";
 
 type CodeEditorTourTarget =
@@ -261,18 +262,22 @@ const CodeEditorTour: React.FC<CodeEditorTourProps> = ({ open, onClose }) => {
   useEffect(() => {
     if (!open) return;
 
-    const frameId = window.requestAnimationFrame(updateTargetRect);
-    const retryId = window.setTimeout(updateTargetRect, 220);
-    const lateRetryId = window.setTimeout(updateTargetRect, 520);
-    window.addEventListener("resize", updateTargetRect);
-    window.addEventListener("scroll", updateTargetRect, true);
+    const scheduler = createAnimationFrameScheduler(updateTargetRect, {
+      requestFrame: window.requestAnimationFrame.bind(window),
+      cancelFrame: window.cancelAnimationFrame.bind(window),
+    });
+    const retryId = window.setTimeout(scheduler.schedule, 220);
+    const lateRetryId = window.setTimeout(scheduler.schedule, 520);
+    scheduler.schedule();
+    window.addEventListener("resize", scheduler.schedule);
+    window.addEventListener("scroll", scheduler.schedule, true);
 
     return () => {
-      window.cancelAnimationFrame(frameId);
+      scheduler.cancel();
       window.clearTimeout(retryId);
       window.clearTimeout(lateRetryId);
-      window.removeEventListener("resize", updateTargetRect);
-      window.removeEventListener("scroll", updateTargetRect, true);
+      window.removeEventListener("resize", scheduler.schedule);
+      window.removeEventListener("scroll", scheduler.schedule, true);
     };
   }, [open, updateTargetRect]);
 

--- a/src/scaffold/Tutorials/GeneralLayoutTour.tsx
+++ b/src/scaffold/Tutorials/GeneralLayoutTour.tsx
@@ -21,6 +21,7 @@ import { type StationMode, stationModeAtom } from "@src/store/ui/simulatorAtom";
 import { useCurrentTheme } from "@src/util/ui/theme/themeUtils";
 import { getViewportSize } from "@src/util/ui/window/viewport";
 
+import { createAnimationFrameScheduler } from "./animationFrameScheduler";
 import { GENERAL_LAYOUT_TOUR_TARGETS } from "./generalLayoutTourConfig";
 
 type GeneralLayoutTourTarget =
@@ -270,16 +271,20 @@ const GeneralLayoutTour: React.FC<GeneralLayoutTourProps> = ({
   useEffect(() => {
     if (!open) return;
 
-    const frameId = window.requestAnimationFrame(updateTargetRect);
-    const retryId = window.setTimeout(updateTargetRect, 180);
-    window.addEventListener("resize", updateTargetRect);
-    window.addEventListener("scroll", updateTargetRect, true);
+    const scheduler = createAnimationFrameScheduler(updateTargetRect, {
+      requestFrame: window.requestAnimationFrame.bind(window),
+      cancelFrame: window.cancelAnimationFrame.bind(window),
+    });
+    const retryId = window.setTimeout(scheduler.schedule, 180);
+    scheduler.schedule();
+    window.addEventListener("resize", scheduler.schedule);
+    window.addEventListener("scroll", scheduler.schedule, true);
 
     return () => {
-      window.cancelAnimationFrame(frameId);
+      scheduler.cancel();
       window.clearTimeout(retryId);
-      window.removeEventListener("resize", updateTargetRect);
-      window.removeEventListener("scroll", updateTargetRect, true);
+      window.removeEventListener("resize", scheduler.schedule);
+      window.removeEventListener("scroll", scheduler.schedule, true);
     };
   }, [open, updateTargetRect]);
 

--- a/src/scaffold/Tutorials/GuideHighlightOverlay.tsx
+++ b/src/scaffold/Tutorials/GuideHighlightOverlay.tsx
@@ -17,6 +17,8 @@ import {
 import { useCurrentTheme } from "@src/util/ui/theme/themeUtils";
 import { getViewportSize } from "@src/util/ui/window/viewport";
 
+import { createAnimationFrameScheduler } from "./animationFrameScheduler";
+
 interface TargetRect {
   top: number;
   left: number;
@@ -131,7 +133,6 @@ const GuideHighlightOverlay: React.FC = () => {
   useEffect(() => {
     if (!highlight) return;
 
-    let frame = 0;
     const updateRect = () => {
       const nextRect = getTargetRect(highlight.targetId);
       setTargetRect({ targetId: highlight.targetId, rect: nextRect });
@@ -146,16 +147,20 @@ const GuideHighlightOverlay: React.FC = () => {
         });
       }
     };
+    const scheduler = createAnimationFrameScheduler(updateRect, {
+      requestFrame: window.requestAnimationFrame.bind(window),
+      cancelFrame: window.cancelAnimationFrame.bind(window),
+    });
 
-    frame = window.requestAnimationFrame(updateRect);
-    window.addEventListener("resize", updateRect);
-    window.addEventListener("scroll", updateRect, true);
+    scheduler.schedule();
+    window.addEventListener("resize", scheduler.schedule);
+    window.addEventListener("scroll", scheduler.schedule, true);
     const timeout = window.setTimeout(clearHighlight, AUTO_DISMISS_MS);
 
     return () => {
-      window.cancelAnimationFrame(frame);
-      window.removeEventListener("resize", updateRect);
-      window.removeEventListener("scroll", updateRect, true);
+      scheduler.cancel();
+      window.removeEventListener("resize", scheduler.schedule);
+      window.removeEventListener("scroll", scheduler.schedule, true);
       window.clearTimeout(timeout);
     };
   }, [clearHighlight, highlight]);

--- a/src/scaffold/Tutorials/__tests__/TEST_CASES.md
+++ b/src/scaffold/Tutorials/__tests__/TEST_CASES.md
@@ -1,0 +1,45 @@
+# Test Cases: Tutorial Overlay Frame Scheduling
+
+## Preconditions
+
+- A tutorial or guide highlight is open.
+- Its target element is rendered and has a measurable bounding rectangle.
+
+## Happy Path
+
+| #   | Steps                        | Expected Result                                                                                     |
+| --- | ---------------------------- | --------------------------------------------------------------------------------------------------- |
+| 1   | Open the general layout tour | The current target is highlighted after the next animation frame.                                   |
+| 2   | Open the code editor tour    | The current target is highlighted; delayed retries still locate targets rendered shortly afterward. |
+| 3   | Show a guide highlight       | The target and popover are positioned and the auto-dismiss timer remains active.                    |
+
+## Edge Cases
+
+| #   | Scenario                     | Steps                                                                  | Expected Result                                            |
+| --- | ---------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------- |
+| 1   | Repeated events in one frame | Dispatch several resize/scroll invalidations before flushing the frame | The measurement callback runs once.                        |
+| 2   | Later frame                  | Flush the pending frame, then schedule another invalidation            | A second measurement is allowed.                           |
+| 3   | Close before frame           | Schedule an update and close/unmount before the frame runs             | Pending work is cancelled and does not update state.       |
+| 4   | Target not yet rendered      | Open the code editor tour before its target appears                    | Existing delayed retries continue scheduling measurements. |
+
+## Error / Degraded States
+
+| #   | Scenario         | Steps                              | Expected Result                                                          |
+| --- | ---------------- | ---------------------------------- | ------------------------------------------------------------------------ |
+| 1   | Missing target   | Open a step with no visible target | No exception is thrown; fallback positioning behavior remains unchanged. |
+| 2   | Rapid open/close | Repeatedly open and close a tour   | Listeners, timers, and pending animation frames are removed on cleanup.  |
+
+## Accessibility
+
+- [ ] Keyboard navigation remains available while the tour is open.
+- [ ] Escape still closes the active tour.
+- [ ] Focus and click behavior are unchanged by frame scheduling.
+
+## Acceptance Criteria
+
+- [ ] Scroll and resize events trigger at most one target measurement per animation frame per active overlay.
+- [ ] Initial target measurement still occurs after opening.
+- [ ] General layout retry at 180 ms remains present.
+- [ ] Code editor retries at 220 ms and 520 ms remain present.
+- [ ] Cleanup cancels pending frame work and removes the same listener callbacks that were registered.
+- [ ] Scheduler unit tests, changed-file lint, and TypeScript diagnostics pass.

--- a/src/scaffold/Tutorials/__tests__/animationFrameScheduler.test.ts
+++ b/src/scaffold/Tutorials/__tests__/animationFrameScheduler.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createAnimationFrameScheduler } from "../animationFrameScheduler";
+
+function createFrameHarness() {
+  let nextFrameId = 1;
+  const callbacks = new Map<number, FrameRequestCallback>();
+  const requestFrame = vi.fn((callback: FrameRequestCallback) => {
+    const frameId = nextFrameId++;
+    callbacks.set(frameId, callback);
+    return frameId;
+  });
+  const cancelFrame = vi.fn((frameId: number) => {
+    callbacks.delete(frameId);
+  });
+
+  return {
+    requestFrame,
+    cancelFrame,
+    flush(frameId: number) {
+      const callback = callbacks.get(frameId);
+      callbacks.delete(frameId);
+      callback?.(0);
+    },
+  };
+}
+
+describe("createAnimationFrameScheduler", () => {
+  it("coalesces repeated schedules into one frame", () => {
+    const harness = createFrameHarness();
+    const callback = vi.fn();
+    const scheduler = createAnimationFrameScheduler(callback, harness);
+
+    scheduler.schedule();
+    scheduler.schedule();
+    scheduler.schedule();
+
+    expect(harness.requestFrame).toHaveBeenCalledTimes(1);
+    harness.flush(1);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows a new frame after the pending frame runs", () => {
+    const harness = createFrameHarness();
+    const callback = vi.fn();
+    const scheduler = createAnimationFrameScheduler(callback, harness);
+
+    scheduler.schedule();
+    harness.flush(1);
+    scheduler.schedule();
+    harness.flush(2);
+
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(harness.requestFrame).toHaveBeenCalledTimes(2);
+  });
+
+  it("cancels pending work and can schedule again", () => {
+    const harness = createFrameHarness();
+    const callback = vi.fn();
+    const scheduler = createAnimationFrameScheduler(callback, harness);
+
+    scheduler.schedule();
+    scheduler.cancel();
+    harness.flush(1);
+    expect(callback).not.toHaveBeenCalled();
+    expect(harness.cancelFrame).toHaveBeenCalledWith(1);
+
+    scheduler.schedule();
+    harness.flush(2);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/scaffold/Tutorials/animationFrameScheduler.ts
+++ b/src/scaffold/Tutorials/animationFrameScheduler.ts
@@ -1,0 +1,38 @@
+export interface AnimationFrameScheduler {
+  schedule: () => void;
+  cancel: () => void;
+}
+
+interface AnimationFrameSchedulerOptions {
+  requestFrame: (callback: FrameRequestCallback) => number;
+  cancelFrame: (frameId: number) => void;
+}
+
+/**
+ * Coalesces repeated layout invalidations so expensive DOM reads run at most
+ * once per animation frame.
+ */
+export function createAnimationFrameScheduler(
+  callback: () => void,
+  options: AnimationFrameSchedulerOptions
+): AnimationFrameScheduler {
+  let pendingFrameId: number | null = null;
+
+  const schedule = () => {
+    if (pendingFrameId !== null) return;
+
+    pendingFrameId = options.requestFrame(() => {
+      pendingFrameId = null;
+      callback();
+    });
+  };
+
+  const cancel = () => {
+    if (pendingFrameId === null) return;
+
+    options.cancelFrame(pendingFrameId);
+    pendingFrameId = null;
+  };
+
+  return { schedule, cancel };
+}


### PR DESCRIPTION
## Summary

- coalesce tutorial resize and scroll invalidations into one animation-frame callback
- share symmetric scheduling and cancellation across all three highlight surfaces
- add focused scheduler lifecycle tests and acceptance cases

## Verification

- `pnpm exec vitest run src/scaffold/Tutorials/__tests__/animationFrameScheduler.test.ts` — 3 passed
- changed-file ESLint passed
- pre-commit scoped TypeScript check passed
- `git diff --check` passed

## Runtime note

This PR verifies coalescing and cleanup semantics. Live Tauri/WebView frame-time profiling was not performed, so it does not claim a measured FPS improvement.