### PR TITLE
fix(terminal): restore output after session switch

### DIFF
--- a/src/components/TerminalReadOnly/index.tsx
+++ b/src/components/TerminalReadOnly/index.tsx
@@ -113,7 +113,7 @@ const TerminalReadOnly: React.FC<TerminalReadOnlyProps> = ({
         }
       }
     }
-  }, [appendOutput, events]);
+  }, [agentSessionId, appendOutput, events]);
 
   return (
     <div className="h-full w-full overflow-hidden">

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/TerminalMainContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/TerminalMainContent/index.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/src/engines/TerminalCore/exports";
 import { useAtomValue, useSetAtom } from "jotai";
 import { Trash2 } from "lucide-react";
-import React, { Suspense, memo, useCallback, useMemo } from "react";
+import React, { Suspense, memo, useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
@@ -20,6 +20,8 @@ import {
   clearTerminalTargetReferencesAtom,
   codeEditorTerminalTargetAtom,
 } from "@src/store/workstation/codeEditor";
+
+import { resolveRestoredPtySessionId } from "./restorePtySelection";
 
 const TerminalCore = React.lazy(
   () => import("@/src/engines/TerminalCore/exports")
@@ -63,6 +65,17 @@ const TerminalMainContent: React.FC<TerminalMainContentProps> = ({
   const isAgentTerminal = terminalTarget?.kind === "agent";
   const terminalPid = activePtySession?.pid;
   const terminalShell = activePtySession?.shell ?? "zsh";
+
+  useEffect(() => {
+    const restoredSessionId = resolveRestoredPtySessionId(
+      terminalTarget,
+      terminalState.sessions,
+      terminalState.activeSessionId
+    );
+    if (restoredSessionId) {
+      terminalState.setActiveSession(restoredSessionId);
+    }
+  }, [terminalState, terminalTarget]);
 
   const handleNewTerminal = useCallback(
     (options?: {

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/TerminalMainContent/restorePtySelection.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/TerminalMainContent/restorePtySelection.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import type { TerminalSession } from "@src/engines/TerminalCore/types";
+
+import { resolveRestoredPtySessionId } from "./restorePtySelection";
+
+function terminal(id: string): TerminalSession {
+  return { id, name: id, isActive: false };
+}
+
+describe("resolveRestoredPtySessionId", () => {
+  const sessions = [terminal("pty-A"), terminal("pty-B")];
+
+  it("restores the PTY remembered by the selected workspace", () => {
+    expect(
+      resolveRestoredPtySessionId(
+        { kind: "pty", ptySessionId: "pty-A" },
+        sessions,
+        "pty-B"
+      )
+    ).toBe("pty-A");
+  });
+
+  it("does not reselect the already active PTY", () => {
+    expect(
+      resolveRestoredPtySessionId(
+        { kind: "pty", ptySessionId: "pty-A" },
+        sessions,
+        "pty-A"
+      )
+    ).toBeNull();
+  });
+
+  it("ignores agent targets and stale PTY references", () => {
+    expect(
+      resolveRestoredPtySessionId(
+        { kind: "agent", sessionId: "agent-A" },
+        sessions,
+        "pty-B"
+      )
+    ).toBeNull();
+    expect(
+      resolveRestoredPtySessionId(
+        { kind: "pty", ptySessionId: "closed-pty" },
+        sessions,
+        "pty-B"
+      )
+    ).toBeNull();
+  });
+});

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/TerminalMainContent/restorePtySelection.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/TerminalMainContent/restorePtySelection.ts
@@ -1,0 +1,23 @@
+import type { TerminalSession } from "@src/engines/TerminalCore/types";
+import type { TerminalTarget } from "@src/store/workstation/codeEditor/terminalTargetAtom";
+
+/**
+ * Resolve the PTY that a WorkStation workspace previously selected.
+ *
+ * PTY processes are global, while the selected terminal is workspace-scoped.
+ * Returning a value here lets the view restore that selection after a Session
+ * switch without restarting or duplicating the underlying PTY.
+ */
+export function resolveRestoredPtySessionId(
+  target: TerminalTarget | null,
+  sessions: readonly TerminalSession[],
+  activeSessionId: string
+): string | null {
+  if (target?.kind !== "pty" || target.ptySessionId === activeSessionId) {
+    return null;
+  }
+
+  return sessions.some((session) => session.id === target.ptySessionId)
+    ? target.ptySessionId
+    : null;
+}


### PR DESCRIPTION
## Related issue

Closes #453

## Summary

- restore the PTY remembered by each WorkStation session when switching back to it
- rerun read-only agent terminal history replay when `agentSessionId` changes
- ignore agent targets, stale PTY references, and already-active PTYs during restoration

## Root cause

Terminal resources are global, but the selected terminal target is scoped per WorkStation session. Switching sessions changed the scoped target without synchronizing the global active PTY. For read-only agent terminals, output was cleared on `agentSessionId` changes while the history replay effect did not depend on that identity, so unchanged event arrays left the terminal blank.

## Verification

- `pnpm vitest run src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/TerminalMainContent/restorePtySelection.test.ts src/store/workstation/codeEditor/terminal/__tests__/terminalTargetAtom.test.ts src/components/TerminalReadOnly/outputBuffer.test.ts`
- `pnpm eslint src/components/TerminalReadOnly/index.tsx src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/TerminalMainContent/index.tsx src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/TerminalMainContent/restorePtySelection.ts src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/TerminalMainContent/restorePtySelection.test.ts`
- `pnpm typecheck`
- `git diff --check`

## Scope

This branch is based on `origin/develop` and contains only the four Terminal restoration files. No unrelated changes from the source workspace are included.
