### PR TITLE
fix(cloud): stop cross-org polling fanout

### DIFF
--- a/src-tauri/crates/orgtrack-cli/src/commands.rs
+++ b/src-tauri/crates/orgtrack-cli/src/commands.rs
@@ -484,6 +484,8 @@ pub(crate) fn cmd_usage(
         0,
         limit,
         TrendBucket::Day,
+        true,
+        false,
     )?;
 
     if let Some(formatter) = formatter_for(opts, formatters) {

--- a/src/engines/ChatPanel/panels/CloudOrgPanelView/useCloudOrgManagement.ts
+++ b/src/engines/ChatPanel/panels/CloudOrgPanelView/useCloudOrgManagement.ts
@@ -24,6 +24,7 @@ import {
   type CloudOrgMember,
   ensureFreshSession,
 } from "@src/features/Org2Cloud/org2CloudClient";
+import { broadcastOrgControlChangedToPeers } from "@src/features/Org2Cloud/org2CloudControlBus";
 import {
   type CreatedCloudInvite,
   createCloudInvite,
@@ -417,6 +418,7 @@ export function useCloudOrgManagement({
       try {
         const token = await getFreshToken();
         await renameCloudOrg(token, orgId, name);
+        broadcastOrgControlChangedToPeers(orgId, "roster");
         // Selector + panel header read from org2CloudOrgsAtom.
         await refetchOrgs({
           until: (orgs) =>

--- a/src/engines/ChatPanel/panels/CloudOrgPanelView/useCloudOrgPanelState.ts
+++ b/src/engines/ChatPanel/panels/CloudOrgPanelView/useCloudOrgPanelState.ts
@@ -17,9 +17,13 @@ import {
   ensureFreshSession,
   getEntitlementState,
 } from "@src/features/Org2Cloud/org2CloudClient";
+import { broadcastOrgControlChangedToPeers } from "@src/features/Org2Cloud/org2CloudControlBus";
 import { isFetchTransportError } from "@src/features/Org2Cloud/org2CloudFetchRetry";
 import { loadCloudOrgMembers } from "@src/features/Org2Cloud/org2CloudMembersCoordinator";
-import { org2CloudRosterVersionAtom } from "@src/features/Org2Cloud/org2CloudOrgsAtom";
+import {
+  org2CloudRosterRealtimeConnectedAtom,
+  org2CloudRosterVersionAtom,
+} from "@src/features/Org2Cloud/org2CloudOrgsAtom";
 import {
   deriveScopeQuotaView,
   parseScopeCooldownFreesAt,
@@ -44,7 +48,8 @@ import { isTauriReady } from "@src/util/platform/tauri/init";
 import type { SelectValue } from "./cloudOrgPanelTypes";
 
 const log = createLogger("CloudOrgPanelView");
-const MEMBER_ROSTER_FALLBACK_MS = 30_000;
+/** Safety pull only while the roster Realtime channel is unavailable. */
+const MEMBER_ROSTER_FALLBACK_MS = 5 * 60_000;
 /** Stable reference for the identity-mismatch window (no re-render churn). */
 const NO_VISIBLE_MEMBERS: CloudOrgMember[] = [];
 
@@ -59,6 +64,9 @@ export function useCloudOrgPanelState(orgId: string) {
   const store = useStore();
   const [auth, setAuth] = useAtom(org2CloudAuthAtom);
   const rosterVersionByOrg = useAtomValue(org2CloudRosterVersionAtom);
+  const rosterRealtimeConnectedByOrg = useAtomValue(
+    org2CloudRosterRealtimeConnectedAtom
+  );
   const [entitlement, setEntitlement] = useState<CloudEntitlementState | null>(
     null
   );
@@ -80,6 +88,7 @@ export function useCloudOrgPanelState(orgId: string) {
   const [scopesError, setScopesError] = useState<string | null>(null);
   const [refreshNonce, setRefreshNonce] = useState(0);
   const [membersFallbackVersion, setMembersFallbackVersion] = useState(0);
+  const [membersVisibilityVersion, setMembersVisibilityVersion] = useState(0);
 
   useTauriListen(
     "org2-cloud-billing-complete",
@@ -91,6 +100,7 @@ export function useCloudOrgPanelState(orgId: string) {
   );
 
   const rosterVersion = rosterVersionByOrg[orgId] ?? 0;
+  const rosterRealtimeConnected = rosterRealtimeConnectedByOrg[orgId] === true;
   const rosterVersionRef = useRef(rosterVersion);
   rosterVersionRef.current = rosterVersion;
   const signedIn = Boolean(auth);
@@ -142,16 +152,22 @@ export function useCloudOrgPanelState(orgId: string) {
     if (!signedIn) return undefined;
     const refreshWhenVisible = () => {
       if (document.visibilityState !== "hidden") {
-        setMembersFallbackVersion((version) => version + 1);
+        setMembersVisibilityVersion((version) => version + 1);
       }
     };
-    const timer = setInterval(refreshWhenVisible, MEMBER_ROSTER_FALLBACK_MS);
+    const timer = rosterRealtimeConnected
+      ? null
+      : setInterval(() => {
+          if (document.visibilityState !== "hidden") {
+            setMembersFallbackVersion((version) => version + 1);
+          }
+        }, MEMBER_ROSTER_FALLBACK_MS);
     document.addEventListener("visibilitychange", refreshWhenVisible);
     return () => {
-      clearInterval(timer);
+      if (timer) clearInterval(timer);
       document.removeEventListener("visibilitychange", refreshWhenVisible);
     };
-  }, [signedIn, authIdentityKey, orgId]);
+  }, [signedIn, authIdentityKey, orgId, rosterRealtimeConnected]);
 
   useEffect(() => {
     if (!signedIn) return;
@@ -242,6 +258,7 @@ export function useCloudOrgPanelState(orgId: string) {
   }, [orgId]);
   useEffect(() => {
     if (!signedIn) return;
+    if (document.visibilityState === "hidden") return;
     const rosterChanged = observedRosterVersionRef.current !== rosterVersion;
     const fallbackChanged =
       observedMembersFallbackVersionRef.current !== membersFallbackVersion;
@@ -285,6 +302,7 @@ export function useCloudOrgPanelState(orgId: string) {
     authIdentityKey,
     rosterVersion,
     membersFallbackVersion,
+    membersVisibilityVersion,
     setAuth,
     store,
   ]);
@@ -320,6 +338,7 @@ export function useCloudOrgPanelState(orgId: string) {
         [orgId]: draftScopes,
       }));
       setScopesSaved(true);
+      broadcastOrgControlChangedToPeers(orgId, "scopes");
       await refreshScopeState(fresh.accessToken);
     } catch (error) {
       if (isOrg2SyncErrorCode(error, "ORG2_SCOPE_COOLDOWN")) {
@@ -366,6 +385,7 @@ export function useCloudOrgPanelState(orgId: string) {
       if (!fresh) throw new Error(t("cloud.orgPanel.loadError"));
       commitRefreshedAuth(setAuth, current, fresh);
       await setOrgSharingFloor(fresh.accessToken, orgId, next);
+      broadcastOrgControlChangedToPeers(orgId, "entitlement");
       await org2CloudSyncEngine.runSyncPassAndWaitForDrain();
     } catch (error) {
       setFloorByOrg((currentFloors) => ({

--- a/src/features/Org2Cloud/org2CloudControlBus.test.ts
+++ b/src/features/Org2Cloud/org2CloudControlBus.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ORG_CONTROL_CHANGED_EVENT,
+  broadcastOrgControlChangedToPeers,
+  parseOrgControlChangeKind,
+  registerOrgControlBroadcaster,
+} from "./org2CloudControlBus";
+
+describe("org2 cloud control bus", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("coalesces metadata and replay writes into one sessions nudge", () => {
+    vi.useFakeTimers();
+    const sender = vi.fn();
+    const unregister = registerOrgControlBroadcaster("org-1", sender);
+
+    broadcastOrgControlChangedToPeers("org-1", "sessions");
+    broadcastOrgControlChangedToPeers("org-1", "sessions");
+    vi.advanceTimersByTime(250);
+
+    expect(sender).toHaveBeenCalledTimes(1);
+    expect(sender).toHaveBeenCalledWith(ORG_CONTROL_CHANGED_EVENT, {
+      kind: "sessions",
+    });
+    unregister();
+  });
+
+  it("cancels a pending nudge when the org channel closes", () => {
+    vi.useFakeTimers();
+    const sender = vi.fn();
+    const unregister = registerOrgControlBroadcaster("org-1", sender);
+
+    broadcastOrgControlChangedToPeers("org-1", "sessions");
+    unregister();
+    vi.runAllTimers();
+
+    expect(sender).not.toHaveBeenCalled();
+  });
+
+  it("rejects unknown wire kinds", () => {
+    expect(parseOrgControlChangeKind({ kind: "projects" })).toBeNull();
+    expect(parseOrgControlChangeKind({ kind: "scopes" })).toBe("scopes");
+  });
+});

--- a/src/features/Org2Cloud/org2CloudControlBus.ts
+++ b/src/features/Org2Cloud/org2CloudControlBus.ts
@@ -1,0 +1,71 @@
+/** Low-volume, plane-specific nudges carried by the active org Presence channel. */
+
+export const ORG_CONTROL_CHANGED_EVENT = "org-control-changed";
+
+export type Org2CloudControlChangeKind =
+  | "entitlement"
+  | "roster"
+  | "scopes"
+  | "sessions";
+
+type BroadcastSender = (
+  event: string,
+  payload: Record<string, unknown>
+) => void;
+
+const senders = new Map<string, BroadcastSender>();
+const pendingSessionTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+/** Wired by useOrg2CloudRealtime while this instance owns the org channel. */
+export function registerOrgControlBroadcaster(
+  orgId: string,
+  sender: BroadcastSender
+): () => void {
+  senders.set(orgId, sender);
+  return () => {
+    if (senders.get(orgId) !== sender) return;
+    senders.delete(orgId);
+    const timer = pendingSessionTimers.get(orgId);
+    if (timer) clearTimeout(timer);
+    pendingSessionTimers.delete(orgId);
+  };
+}
+
+/**
+ * Notify peers that a specific control plane changed. The server's durable
+ * org_change_signals row remains the low-frequency recovery path when no
+ * channel is open or a broadcast is missed.
+ */
+export function broadcastOrgControlChangedToPeers(
+  orgId: string,
+  kind: Org2CloudControlChangeKind
+): void {
+  const sender = senders.get(orgId);
+  if (!sender) return;
+  if (kind === "sessions") {
+    // Metadata + event payload writes touch the same logical row in quick
+    // succession. Collapse them into one peer listing refresh.
+    if (pendingSessionTimers.has(orgId)) return;
+    const timer = setTimeout(() => {
+      pendingSessionTimers.delete(orgId);
+      if (senders.get(orgId) === sender) {
+        sender(ORG_CONTROL_CHANGED_EVENT, { kind });
+      }
+    }, 250);
+    pendingSessionTimers.set(orgId, timer);
+    return;
+  }
+  sender(ORG_CONTROL_CHANGED_EVENT, { kind });
+}
+
+export function parseOrgControlChangeKind(
+  payload: Record<string, unknown>
+): Org2CloudControlChangeKind | null {
+  const kind = payload.kind;
+  return kind === "entitlement" ||
+    kind === "roster" ||
+    kind === "scopes" ||
+    kind === "sessions"
+    ? kind
+    : null;
+}

--- a/src/features/Org2Cloud/org2CloudEntitlementCoordinator.ts
+++ b/src/features/Org2Cloud/org2CloudEntitlementCoordinator.ts
@@ -24,10 +24,9 @@ const log = createLogger("Org2CloudEntitlement");
 type JotaiStore = ReturnType<typeof createStore>;
 
 /**
- * Short on purpose: `org_change_signals` cannot say WHICH plane changed, and
- * an admin floor flip must reach members promptly (it gates uploads). The
- * single-flight entry still bounds a signal burst to one entitlement RPC per
- * org per window.
+ * Short on purpose: a burst of explicit floor-change broadcasts and
+ * reconnect recovery must still collapse to one request. Generic session /
+ * project / comment signals no longer enter this coordinator.
  */
 export const ENTITLEMENT_REFRESH_TTL_MS = 10_000;
 

--- a/src/features/Org2Cloud/org2CloudOrgsAtom.ts
+++ b/src/features/Org2Cloud/org2CloudOrgsAtom.ts
@@ -147,6 +147,13 @@ export function commitOrg2CloudOrgsRequest(
 export const org2CloudRosterVersionAtom = atom<Record<string, number>>({});
 org2CloudRosterVersionAtom.debugLabel = "org2CloudRosterVersionAtom";
 
+/** Active orgs whose member-roster Postgres Changes channel is subscribed. */
+export const org2CloudRosterRealtimeConnectedAtom = atom<
+  Record<string, boolean>
+>({});
+org2CloudRosterRealtimeConnectedAtom.debugLabel =
+  "org2CloudRosterRealtimeConnectedAtom";
+
 /** Cloud org id currently selected in the sidebar workspace scope selector (null = a local scope). */
 export const sidebarActiveCloudOrgIdAtom = atom<string | null>(null);
 sidebarActiveCloudOrgIdAtom.debugLabel = "sidebarActiveCloudOrgIdAtom";

--- a/src/features/Org2Cloud/org2CloudRemoteSessionsAtom.test.ts
+++ b/src/features/Org2Cloud/org2CloudRemoteSessionsAtom.test.ts
@@ -1,14 +1,38 @@
 import { describe, expect, it } from "vitest";
 
+import type { RemoteTeammateSessionMetadata } from "@src/store/collaboration/types";
+
 import {
   type CloudOrgRemoteSessionsEntry,
   MAX_REMOTE_SESSIONS_VERSION_KEYS,
   MAX_REMOTE_SESSION_CACHE_ENTRIES,
   beginRemoteSessionsFetch,
+  mergeRemoteSessionDelta,
   rememberRemoteSessionsFetchedVersion,
   remoteSessionsEntryForIdentity,
   writeRemoteSessionsEntry,
 } from "./org2CloudRemoteSessionsAtom";
+
+function row(
+  id: string,
+  overrides: Partial<RemoteTeammateSessionMetadata> = {}
+): RemoteTeammateSessionMetadata {
+  return {
+    id,
+    orgId: "org-1",
+    ownerMemberId: "member-1",
+    ownerUserId: "user-1",
+    ownerDisplayName: "Owner",
+    ownerIdentityKind: "human",
+    sourceSessionId: id,
+    title: id,
+    eventsEpoch: undefined,
+    eventsFrozenSeq: undefined,
+    eventsCount: undefined,
+    eventsTailHash: undefined,
+    ...overrides,
+  };
+}
 
 function readyEntry(identityKey: string): CloudOrgRemoteSessionsEntry {
   return {
@@ -67,5 +91,24 @@ describe("cloud remote session identity isolation", () => {
     }
     expect(Object.keys(entries)).toHaveLength(MAX_REMOTE_SESSION_CACHE_ENTRIES);
     expect(entries["org-0"]).toBeUndefined();
+  });
+
+  it("merges cursor deltas and removes soft tombstones", () => {
+    expect(
+      mergeRemoteSessionDelta(
+        [
+          row("keep", { title: "old", lastActivityAt: "2026-07-01" }),
+          row("remove"),
+        ],
+        [
+          row("keep", { title: "new", lastActivityAt: "2026-07-03" }),
+          row("remove", { deletedAt: "2026-07-04" }),
+          row("add", { lastActivityAt: "2026-07-02" }),
+        ]
+      ).map(({ id, title }) => ({ id, title }))
+    ).toEqual([
+      { id: "keep", title: "new" },
+      { id: "add", title: "add" },
+    ]);
   });
 });

--- a/src/features/Org2Cloud/org2CloudRemoteSessionsAtom.ts
+++ b/src/features/Org2Cloud/org2CloudRemoteSessionsAtom.ts
@@ -15,7 +15,7 @@ import {
   useSetAtom,
   useStore,
 } from "jotai";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { createLogger } from "@src/hooks/logger";
 import type { RemoteTeammateSessionMetadata } from "@src/store/collaboration/types";
@@ -31,6 +31,7 @@ import { listOrgSessions } from "./org2CloudSyncClient";
 const log = createLogger("Org2CloudRemoteSessions");
 
 const REMOTE_SESSIONS_TTL_MS = 60_000;
+const REMOTE_SESSIONS_CURSOR_OVERLAP_MS = 2_000;
 export const MAX_REMOTE_SESSION_CACHE_ENTRIES = 64;
 export const MAX_REMOTE_SESSIONS_VERSION_KEYS = 64;
 
@@ -101,6 +102,8 @@ export interface CloudOrgRemoteSessionsEntry {
   state: CloudRemoteSessionsFetchState;
   /** Epoch ms of the last completed fetch attempt (0 ⇒ never fetched). */
   fetchedAt: number;
+  /** Server-clock delta cursor; absent forces a complete listing. */
+  serverCursor?: string;
 }
 
 const EMPTY_ENTRY: CloudOrgRemoteSessionsEntry = {
@@ -108,6 +111,31 @@ const EMPTY_ENTRY: CloudOrgRemoteSessionsEntry = {
   state: "idle",
   fetchedAt: 0,
 };
+
+/** Merge a server delta and apply soft-tombstones without duplicating rows. */
+export function mergeRemoteSessionDelta(
+  previous: readonly RemoteTeammateSessionMetadata[],
+  delta: readonly RemoteTeammateSessionMetadata[]
+): RemoteTeammateSessionMetadata[] {
+  const byId = new Map(previous.map((row) => [row.id, row]));
+  for (const row of delta) {
+    if (row.deletedAt) byId.delete(row.id);
+    else byId.set(row.id, row);
+  }
+  return [...byId.values()].sort((left, right) =>
+    (right.lastActivityAt ?? "").localeCompare(left.lastActivityAt ?? "")
+  );
+}
+
+function cursorFromServerTime(
+  serverTime: string | undefined,
+  fallback: string | undefined
+): string | undefined {
+  if (!serverTime) return fallback;
+  const serverMs = new Date(serverTime).getTime();
+  if (!Number.isFinite(serverMs)) return fallback;
+  return new Date(serverMs - REMOTE_SESSIONS_CURSOR_OVERLAP_MS).toISOString();
+}
 
 export function beginRemoteSessionsFetch(
   entry: CloudOrgRemoteSessionsEntry | undefined,
@@ -156,11 +184,10 @@ export const org2CloudRemoteSessionsAtom = atom<
 org2CloudRemoteSessionsAtom.debugLabel = "org2CloudRemoteSessionsAtom";
 
 /**
- * Per-org invalidation counter for the remote-sessions list, bumped by the
- * Realtime `org_change_signals` subscription (useOrg2CloudRealtime) whenever
- * a teammate's session push / access change / delete lands. The fetch effect
- * keys on it, so the TEAM SESSIONS section refreshes live instead of only on
- * scope switches past the 60s TTL.
+ * Per-org invalidation counter for the remote-sessions list. Plane-specific
+ * Presence nudges provide the live path; the bounded durable signal fallback
+ * and reconnect recovery cover missed broadcasts. Fetches after the first
+ * snapshot use the server cursor and merge deltas/tombstones.
  */
 export const org2CloudRemoteSessionsVersionAtom = atom<Record<string, number>>(
   {}
@@ -190,6 +217,18 @@ export function useCloudOrgRemoteSessions(
   const versionByOrg = useAtomValue(org2CloudRemoteSessionsVersionAtom);
   const setVersionByOrg = useSetAtom(org2CloudRemoteSessionsVersionAtom);
   const invalidationVersion = orgId ? (versionByOrg[orgId] ?? 0) : 0;
+  const [visibilityVersion, setVisibilityVersion] = useState(0);
+  useEffect(() => {
+    if (typeof document === "undefined") return undefined;
+    const onVisibilityChange = () => {
+      if (document.visibilityState !== "hidden") {
+        setVisibilityVersion((version) => version + 1);
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () =>
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+  }, []);
   const entriesRef = useRef(entries);
   useEffect(() => {
     entriesRef.current = entries;
@@ -215,13 +254,21 @@ export function useCloudOrgRemoteSessions(
     ? remoteSessionsEntryForIdentity(entries[orgId], authIdentityKey)
     : undefined;
   const fetchOrgSessions = useCallback(
-    async (targetOrgId: string): Promise<void> => {
+    async (
+      targetOrgId: string,
+      options: { full?: boolean } = {}
+    ): Promise<void> => {
       const current = authRef.current;
       if (!current) return;
       const identityKey = org2CloudAuthIdentityKey(current);
       const requestKey = `${identityKey}|${targetOrgId}`;
       if (requestState.inFlightKeys.has(requestKey)) return;
       requestState.inFlightKeys.add(requestKey);
+      const entryAtStart = remoteSessionsEntryForIdentity(
+        entriesRef.current[targetOrgId],
+        identityKey
+      );
+      const since = options.full ? undefined : entryAtStart?.serverCursor;
       setEntries((previous) =>
         writeRemoteSessionsEntry(
           previous,
@@ -233,19 +280,47 @@ export function useCloudOrgRemoteSessions(
         const fresh = await ensureFreshSession(current);
         if (!fresh) throw new Error("token refresh failed");
         commitRefreshedAuth(setAuth, current, fresh);
-        const result = await listOrgSessions(fresh.accessToken, targetOrgId);
+        const result = await listOrgSessions(
+          fresh.accessToken,
+          targetOrgId,
+          since
+        );
         const latest = authRef.current;
         if (!latest || org2CloudAuthIdentityKey(latest) !== identityKey) {
           return;
         }
-        setEntries((previous) =>
-          writeRemoteSessionsEntry(previous, targetOrgId, {
+        setEntries((previous) => {
+          const current = remoteSessionsEntryForIdentity(
+            previous[targetOrgId],
+            identityKey
+          );
+          // A reconnect/full-refresh invalidation removes the cached entry. If
+          // an older delta request was already in flight, never let its partial
+          // response recreate that entry and turn the required full reload back
+          // into another delta. Writing an idle sentinel wakes the effect after
+          // the request leaves the single-flight set, so the next call is full.
+          if (since && !current) {
+            return writeRemoteSessionsEntry(previous, targetOrgId, {
+              identityKey,
+              rows: [],
+              state: "idle",
+              fetchedAt: 0,
+            });
+          }
+          const rows = since
+            ? mergeRemoteSessionDelta(current?.rows ?? [], result.sessions)
+            : result.sessions.filter((row) => !row.deletedAt);
+          return writeRemoteSessionsEntry(previous, targetOrgId, {
             identityKey,
-            rows: result.sessions,
+            rows,
             state: "ready",
             fetchedAt: Date.now(),
-          })
-        );
+            serverCursor: cursorFromServerTime(
+              result.serverTime,
+              current?.serverCursor
+            ),
+          });
+        });
       } catch (error) {
         log.warn("cloud_list_org_sessions failed:", error);
         setEntries((previous) =>
@@ -273,6 +348,11 @@ export function useCloudOrgRemoteSessions(
   // lets the queued version fetch instead of stranding it until the 60s TTL.
   useEffect(() => {
     if (!orgId || !signedIn || !authIdentityKey) return;
+    if (
+      typeof document !== "undefined" &&
+      document.visibilityState === "hidden"
+    )
+      return;
     const entry = remoteSessionsEntryForIdentity(
       entriesRef.current[orgId],
       authIdentityKey
@@ -302,12 +382,18 @@ export function useCloudOrgRemoteSessions(
     authIdentityKey,
     fetchOrgSessions,
     requestState,
+    visibilityVersion,
   ]);
 
   const refresh = useCallback(() => {
     if (!orgId || !signedIn || !authIdentityKey) return;
+    if (
+      typeof document !== "undefined" &&
+      document.visibilityState === "hidden"
+    )
+      return;
     if (requestState.inFlightKeys.has(`${authIdentityKey}|${orgId}`)) return;
-    void fetchOrgSessions(orgId);
+    void fetchOrgSessions(orgId, { full: true });
   }, [orgId, signedIn, authIdentityKey, fetchOrgSessions, requestState]);
 
   const entry = entrySnapshot ?? EMPTY_ENTRY;

--- a/src/features/Org2Cloud/org2CloudSessionSync.ts
+++ b/src/features/Org2Cloud/org2CloudSessionSync.ts
@@ -31,6 +31,7 @@ import { getSessionForkedFrom } from "../TeamCollaboration/forkSession";
 import { computeSegmentHash } from "../TeamCollaboration/sync/collabGzip";
 import type { CloudPushAccess } from "./org2CloudAccessSettings";
 import type { Org2CloudAuthState } from "./org2CloudAuthAtom";
+import { broadcastOrgControlChangedToPeers } from "./org2CloudControlBus";
 import type { CollabSessionPushCursor } from "./org2CloudSyncAtoms";
 import {
   org2CloudPushCursorsAtom,
@@ -38,7 +39,10 @@ import {
 } from "./org2CloudSyncAtoms";
 import * as org2CloudSyncClient from "./org2CloudSyncClient";
 import { isOrg2SyncErrorCode } from "./org2CloudSyncClient";
-import type { CloudStore } from "./org2CloudSyncLifecycle";
+import {
+  type CloudStore,
+  EXTERNAL_HISTORY_ACTIVITY_DEBOUNCE_MS,
+} from "./org2CloudSyncLifecycle";
 
 const log = createLogger("Org2CloudSyncEngine");
 
@@ -56,6 +60,7 @@ export type Org2CloudSyncClientDeps = Pick<
   | "rewriteSessionEvents"
   | "getSessionEvents"
   | "getOrgRepoScopes"
+  | "listOrgSessions"
   | "deleteSession"
 >;
 
@@ -71,6 +76,40 @@ interface PreparedPushEvents {
   stampAtRead: number;
   events: SessionEvent[];
   plan(): Promise<PreparedPushPlan>;
+}
+
+interface CleanEventPlaneStamp {
+  verifiedAt: number;
+  /** Imported transcript version used for this proof. */
+  sourceUpdatedAt?: string;
+}
+
+interface ExternalHistoryVersionObservation {
+  sourceUpdatedAt: string;
+  observedAt: number;
+}
+
+function metadataPayloadForHash(
+  metadata: RemoteTeammateSessionMetadata
+): Partial<RemoteTeammateSessionMetadata> {
+  const payload: Partial<RemoteTeammateSessionMetadata> = { ...metadata };
+  // These fields are derived by the listing RPC, not authored by
+  // cloud_upsert_session_metadata. Excluding them makes a server summary
+  // comparable to the exact payload this client would upload.
+  // ownerMemberId is also server-authoritative: the synthetic local member
+  // uses auth.userId, while the listing returns the org-membership row id.
+  // The row id embeds that membership id, so it is server-derived too.
+  delete payload.id;
+  delete payload.ownerMemberId;
+  delete payload.directlySharedWithMe;
+  delete payload.eventsEpoch;
+  delete payload.eventsFrozenSeq;
+  delete payload.eventsCount;
+  delete payload.eventsTailHash;
+  delete payload.deletedAt;
+  delete payload.commentCount;
+  delete payload.unresolvedCommentCount;
+  return payload;
 }
 
 /**
@@ -125,9 +164,21 @@ export class Org2CloudSessionSync {
   /** `${orgId}:${sessionId}` to hash of the last upserted metadata. */
   private readonly lastPushedMetadataHashes = new Map<string, string>();
   /** sessionId to orgId to time when the event plane was verified clean. */
-  private readonly cleanEventPlanes = new Map<string, Map<string, number>>();
+  private readonly cleanEventPlanes = new Map<
+    string,
+    Map<string, CleanEventPlaneStamp>
+  >();
+  /** A cold-start remote summary may seed each (org, session) only once. */
+  private readonly remoteSeedAttemptedKeys = new Set<string>();
   /** Session activity stamp prevents a mid-push write from being marked clean. */
   private readonly eventActivityStamps = new Map<string, number>();
+  /** Last write time for quiet-window gating of mutable external histories. */
+  private readonly eventActivityAtMs = new Map<string, number>();
+  /** Last imported-source version observed from sessionsAtom. */
+  private readonly externalHistoryVersions = new Map<
+    string,
+    ExternalHistoryVersionObservation
+  >();
   /** Org-independent event reads and hashing shared across orgs in one pass. */
   private readonly passPushPrepareCache = new Map<
     string,
@@ -143,7 +194,10 @@ export class Org2CloudSessionSync {
     this.lastPushedMetadataHashes.clear();
     this.cleanEventPlanes.clear();
     this.eventActivityStamps.clear();
+    this.eventActivityAtMs.clear();
+    this.externalHistoryVersions.clear();
     this.passPushPrepareCache.clear();
+    this.remoteSeedAttemptedKeys.clear();
   }
 
   /** Start a new engine pass; prepared events must never leak across passes. */
@@ -170,6 +224,15 @@ export class Org2CloudSessionSync {
         this.lastPushedMetadataHashes.delete(key);
       }
     }
+    for (const key of this.remoteSeedAttemptedKeys) {
+      const separatorIndex = key.indexOf(":");
+      const orgId = separatorIndex === -1 ? key : key.slice(0, separatorIndex);
+      const sessionId =
+        separatorIndex === -1 ? "" : key.slice(separatorIndex + 1);
+      if (!liveOrgIds.has(orgId) || !liveSessionIds.has(sessionId)) {
+        this.remoteSeedAttemptedKeys.delete(key);
+      }
+    }
     for (const [sessionId, byOrg] of this.cleanEventPlanes) {
       if (!liveSessionIds.has(sessionId)) {
         this.cleanEventPlanes.delete(sessionId);
@@ -185,6 +248,16 @@ export class Org2CloudSessionSync {
         this.eventActivityStamps.delete(sessionId);
       }
     }
+    for (const sessionId of this.eventActivityAtMs.keys()) {
+      if (!liveSessionIds.has(sessionId)) {
+        this.eventActivityAtMs.delete(sessionId);
+      }
+    }
+    for (const sessionId of this.externalHistoryVersions.keys()) {
+      if (!liveSessionIds.has(sessionId)) {
+        this.externalHistoryVersions.delete(sessionId);
+      }
+    }
   }
 
   /** Drop clean markers and stamp a local event-store write. */
@@ -193,26 +266,126 @@ export class Org2CloudSessionSync {
       sessionId,
       (this.eventActivityStamps.get(sessionId) ?? 0) + 1
     );
+    this.eventActivityAtMs.set(sessionId, Date.now());
     this.cleanEventPlanes.delete(sessionId);
   }
 
-  private isEventPlaneClean(orgId: string, sessionId: string): boolean {
-    const cleanAt = this.cleanEventPlanes.get(sessionId)?.get(orgId);
-    return cleanAt !== undefined && Date.now() - cleanAt < EVENTS_CLEAN_TTL_MS;
+  /**
+   * Imported CLI files are mutable snapshots, not append-only EventStore
+   * streams. During a live turn older normalized records can still change;
+   * wait for the same quiet window as the lifecycle timer before doing the
+   * expensive full read/normalize/rewrite. Metadata remains live.
+   */
+  private isExternalHistorySettled(session: Session): boolean {
+    const sessionId = session.session_id;
+    if (!isImportedHistorySession(sessionId)) return true;
+    const now = Date.now();
+    const observed = this.externalHistoryVersions.get(sessionId);
+    if (!observed || observed.sourceUpdatedAt !== session.updated_at) {
+      this.externalHistoryVersions.set(sessionId, {
+        sourceUpdatedAt: session.updated_at,
+        observedAt: now,
+      });
+      return false;
+    }
+    const changedAt = Math.max(
+      observed.observedAt,
+      this.eventActivityAtMs.get(sessionId) ?? 0
+    );
+    return now - changedAt >= EXTERNAL_HISTORY_ACTIVITY_DEBOUNCE_MS;
+  }
+
+  private isEventPlaneClean(orgId: string, session: Session): boolean {
+    const clean = this.cleanEventPlanes.get(session.session_id)?.get(orgId);
+    if (!clean || Date.now() - clean.verifiedAt >= EVENTS_CLEAN_TTL_MS) {
+      return false;
+    }
+    return (
+      !isImportedHistorySession(session.session_id) ||
+      clean.sourceUpdatedAt === session.updated_at
+    );
   }
 
   private markEventPlaneClean(
     orgId: string,
-    sessionId: string,
-    stampAtRead: number
+    session: Session,
+    stampAtRead: number,
+    verifiedAt = Date.now()
   ): void {
+    const sessionId = session.session_id;
     if ((this.eventActivityStamps.get(sessionId) ?? 0) !== stampAtRead) return;
     let byOrg = this.cleanEventPlanes.get(sessionId);
     if (!byOrg) {
       byOrg = new Map();
       this.cleanEventPlanes.set(sessionId, byOrg);
     }
-    byOrg.set(orgId, Date.now());
+    byOrg.set(orgId, {
+      verifiedAt,
+      sourceUpdatedAt: isImportedHistorySession(sessionId)
+        ? session.updated_at
+        : undefined,
+    });
+  }
+
+  /**
+   * Seed the volatile cold-start caches from a server-authoritative listing.
+   * For imported CLI sessions the local `updated_at` comes from the source
+   * transcript and is part of the uploaded metadata. When that payload and
+   * the persisted cursor both match the server summary, a restart does not
+   * need to read/normalize/hash the entire transcript again.
+   */
+  async seedFromRemoteSummary(
+    auth: Org2CloudAuthState,
+    orgId: string,
+    session: Session,
+    scopeKey: string | null,
+    access: CloudPushAccess,
+    remote: RemoteTeammateSessionMetadata
+  ): Promise<void> {
+    const key = `${orgId}:${session.session_id}`;
+    if (this.remoteSeedAttemptedKeys.has(key)) return;
+    this.remoteSeedAttemptedKeys.add(key);
+    if (
+      remote.deletedAt ||
+      remote.ownerUserId !== auth.userId ||
+      remote.sourceSessionId !== session.session_id
+    ) {
+      return;
+    }
+    const displayName =
+      auth.profile?.displayName ?? auth.profile?.primaryEmail ?? auth.userId;
+    const localMetadata = buildCloudSessionMetadata(
+      session,
+      orgId,
+      auth.userId,
+      displayName,
+      scopeKey,
+      access
+    );
+    const [localHash, remoteHash] = await Promise.all([
+      sha256Hex(stableStringify(metadataPayloadForHash(localMetadata))),
+      sha256Hex(stableStringify(metadataPayloadForHash(remote))),
+    ]);
+    if (localHash !== remoteHash) return;
+
+    this.lastPushedMetadataHashes.set(key, localHash);
+    this.setPushedMetadataMarker(orgId, session.session_id);
+    if (!isImportedHistorySession(session.session_id)) return;
+    const cursor = this.getCursor(orgId, session.session_id);
+    if (
+      !cursor ||
+      remote.eventsEpoch !== cursor.epoch ||
+      remote.eventsFrozenSeq !== cursor.frozenSeq ||
+      remote.eventsCount !== cursor.pushedCount ||
+      (remote.eventsTailHash ?? null) !== cursor.tailHash
+    ) {
+      return;
+    }
+    this.markEventPlaneClean(
+      orgId,
+      session,
+      this.eventActivityStamps.get(session.session_id) ?? 0
+    );
   }
 
   private getCursor(
@@ -262,10 +435,10 @@ export class Org2CloudSessionSync {
   }
 
   private setPushedMetadataMarker(orgId: string, sessionId: string): void {
-    this.getStore()?.set(org2CloudPushedMetadataAtom, (current) => ({
-      ...current,
-      [`${orgId}:${sessionId}`]: true,
-    }));
+    const key = `${orgId}:${sessionId}`;
+    this.getStore()?.set(org2CloudPushedMetadataAtom, (current) =>
+      current[key] ? current : { ...current, [key]: true }
+    );
   }
 
   private clearPushedMetadataMarker(orgId: string, sessionId: string): void {
@@ -302,6 +475,7 @@ export class Org2CloudSessionSync {
     this.invalidatePushedMetadataHash(orgId, sessionId);
     this.clearPushedMetadataMarker(orgId, sessionId);
     this.clearCursor(orgId, sessionId);
+    broadcastOrgControlChangedToPeers(orgId, "sessions");
   }
 
   private async upsertMetadataIfChanged(
@@ -333,6 +507,7 @@ export class Org2CloudSessionSync {
     );
     this.lastPushedMetadataHashes.set(key, hash);
     this.setPushedMetadataMarker(orgId, session.session_id);
+    broadcastOrgControlChangedToPeers(orgId, "sessions");
   }
 
   /** Load the complete native or external-history transcript for upload. */
@@ -411,7 +586,12 @@ export class Org2CloudSessionSync {
       this.clearCursor(orgId, sessionId);
       return;
     }
-    if (this.isEventPlaneClean(orgId, sessionId)) {
+    // The external-history scanner updates sessionsAtom directly, without an
+    // EventStore notification. Gate on the source's updated_at as well as the
+    // event-store stamp, and defer metadata together with replay so a live CLI
+    // turn does not produce one cloud upsert per scanner refresh.
+    if (!this.isExternalHistorySettled(session)) return;
+    if (this.isEventPlaneClean(orgId, session)) {
       await this.upsertMetadataIfChanged(
         auth,
         orgId,
@@ -432,7 +612,7 @@ export class Org2CloudSessionSync {
         scopeKey,
         access
       );
-      this.markEventPlaneClean(orgId, sessionId, stampAtRead);
+      this.markEventPlaneClean(orgId, session, stampAtRead);
       return;
     }
     if (cursor && events.length < cursor.pushedCount) {
@@ -481,7 +661,7 @@ export class Org2CloudSessionSync {
             scopeKey,
             access
           );
-          this.markEventPlaneClean(orgId, sessionId, stampAtRead);
+          this.markEventPlaneClean(orgId, session, stampAtRead);
           return;
         }
         await this.upsertMetadataIfChanged(
@@ -516,7 +696,8 @@ export class Org2CloudSessionSync {
             frozenChainHash,
             tailHash,
           });
-          this.markEventPlaneClean(orgId, sessionId, stampAtRead);
+          broadcastOrgControlChangedToPeers(orgId, "sessions");
+          this.markEventPlaneClean(orgId, session, stampAtRead);
           return;
         } catch (error) {
           if (!isOrg2SyncErrorCode(error, "ORG2_CONFLICT")) throw error;
@@ -528,7 +709,7 @@ export class Org2CloudSessionSync {
             tailHash,
             newEpoch: null,
           });
-          this.markEventPlaneClean(orgId, sessionId, stampAtRead);
+          this.markEventPlaneClean(orgId, session, stampAtRead);
           return;
         }
       }
@@ -541,7 +722,7 @@ export class Org2CloudSessionSync {
         tailHash,
         newEpoch: cursor.epoch + 1,
       });
-      this.markEventPlaneClean(orgId, sessionId, stampAtRead);
+      this.markEventPlaneClean(orgId, session, stampAtRead);
       return;
     }
 
@@ -553,7 +734,7 @@ export class Org2CloudSessionSync {
       tailHash,
       newEpoch: 1,
     });
-    this.markEventPlaneClean(orgId, sessionId, stampAtRead);
+    this.markEventPlaneClean(orgId, session, stampAtRead);
   }
 
   /** Full epoch rewrite; conflicts re-anchor on the current server epoch once. */
@@ -603,6 +784,7 @@ export class Org2CloudSessionSync {
           frozenChainHash: plan.frozenChainHash,
           tailHash: plan.tailHash,
         });
+        broadcastOrgControlChangedToPeers(orgId, "sessions");
         return;
       } catch (error) {
         if (!isOrg2SyncErrorCode(error, "ORG2_CONFLICT") || reanchored) {

--- a/src/features/Org2Cloud/org2CloudSyncEngine.projects.test.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.projects.test.ts
@@ -42,6 +42,7 @@ describe("Org2CloudSyncEngine project and endpoint synchronization", () => {
   beforeEach(() => {
     fixture = createEngineFixture();
     ({ store, client, projectsClient, bridge, engine } = fixture);
+    documentStub.visibilityState = "visible";
   });
 
   afterEach(() => {
@@ -65,6 +66,7 @@ describe("Org2CloudSyncEngine project and endpoint synchronization", () => {
   }
 
   it("drives the ProjectSyncChannel per org: full listing first, cursor delta after", async () => {
+    store.set(sidebarActiveCloudOrgIdAtom, "corg-1");
     projectsClient.listOrgCollabState.mockResolvedValue({
       serverTime: "2026-07-01T12:00:00.000Z",
       projects: [
@@ -116,6 +118,24 @@ describe("Org2CloudSyncEngine project and endpoint synchronization", () => {
     );
   });
 
+  it("keeps inactive project inbound on 30 minutes and scope hydration demand-driven", async () => {
+    store.set(sidebarActiveCloudOrgIdAtom, null);
+    const startedAt = Date.now();
+    await engine.runSyncPass();
+    projectsClient.listOrgCollabState.mockClear();
+    client.getOrgRepoScopes.mockClear();
+
+    vi.setSystemTime(startedAt + 10 * 60_000 + 1);
+    await engine.runSyncPass();
+    expect(projectsClient.listOrgCollabState).not.toHaveBeenCalled();
+    expect(client.getOrgRepoScopes).not.toHaveBeenCalled();
+
+    vi.setSystemTime(startedAt + 30 * 60_000 + 1);
+    await engine.runSyncPass();
+    expect(projectsClient.listOrgCollabState).toHaveBeenCalledTimes(1);
+    expect(client.getOrgRepoScopes).not.toHaveBeenCalled();
+  });
+
   it("scopes Realtime pulls to one org, preserves delta cursors, and skips the outbox probe", async () => {
     store.set(org2CloudOrgsAtom, [
       { orgId: "corg-1", name: "Cloud Team", role: "member" },
@@ -135,6 +155,36 @@ describe("Org2CloudSyncEngine project and endpoint synchronization", () => {
       "2026-07-01T11:59:58.000Z"
     );
     expect(bridge.drainOutbox).not.toHaveBeenCalled();
+  });
+
+  it("defers Realtime inbound pulls while hidden", async () => {
+    await engine.runSyncPass();
+    projectsClient.listOrgCollabState.mockClear();
+    // Ignore the engine.start() zero-delay bootstrap; this assertion targets
+    // only the explicit hidden Realtime invalidation below.
+    vi.clearAllTimers();
+    documentStub.visibilityState = "hidden";
+
+    engine.invalidateOrgInbound("corg-1");
+    await vi.advanceTimersByTimeAsync(1_000);
+
+    documentStub.visibilityState = "visible";
+    expect(projectsClient.listOrgCollabState).not.toHaveBeenCalled();
+  });
+
+  it("does not feed a Realtime inbound nudge back into session uploads", async () => {
+    await engine.runSyncPass();
+    client.upsertSessionMetadata.mockClear();
+    client.appendSessionEvents.mockClear();
+    client.rewriteSessionEvents.mockClear();
+    engine.invalidatePushedMetadataHash("corg-1", "session-1");
+
+    await engine.invalidateOrgInboundAndWait("corg-1");
+
+    expect(projectsClient.listOrgCollabState).toHaveBeenCalled();
+    expect(client.upsertSessionMetadata).not.toHaveBeenCalled();
+    expect(client.appendSessionEvents).not.toHaveBeenCalled();
+    expect(client.rewriteSessionEvents).not.toHaveBeenCalled();
   });
 
   it("applies snake_case tombstones from Realtime-scoped project pulls", async () => {

--- a/src/features/Org2Cloud/org2CloudSyncEngine.sessions.test.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.sessions.test.ts
@@ -22,7 +22,7 @@ import {
 import type { EngineFixture } from "./org2CloudSyncEngine.testUtils";
 
 const {
-  INACTIVE_ORG_BACKOFF_COOLDOWN_MS,
+  EXTERNAL_HISTORY_ACTIVITY_DEBOUNCE_MS,
   ORG_BACKOFF_COOLDOWN_MS,
   PERSONAL_EXCLUDED_TOKEN,
   Org2CloudSyncEngine,
@@ -207,6 +207,7 @@ describe("Org2CloudSyncEngine session publishing", () => {
       "corg-personal": "full_replay",
       "corg-team": "full_replay",
     });
+    store.set(sidebarActiveCloudOrgIdAtom, "corg-team");
 
     await engine.runSyncPass();
 
@@ -404,25 +405,20 @@ describe("Org2CloudSyncEngine session publishing", () => {
     expect(messageMock.warning).toHaveBeenCalledTimes(1);
   });
 
-  it("silently slows quota retries for an inactive org", async () => {
+  it("does not publish sessions for an inactive org", async () => {
     store.set(sidebarActiveCloudOrgIdAtom, null);
     client.upsertSessionMetadata.mockRejectedValue(
       new Org2CloudSyncError("ORG2_QUOTA_EXCEEDED", 403)
     );
-    const failedAt = Date.now();
 
     await engine.runSyncPass();
     expect(messageMock.warning).not.toHaveBeenCalled();
-
-    client.upsertSessionMetadata.mockClear();
-    vi.setSystemTime(failedAt + ORG_BACKOFF_COOLDOWN_MS + 1);
-    await engine.runSyncPass();
     expect(client.upsertSessionMetadata).not.toHaveBeenCalled();
 
-    vi.setSystemTime(failedAt + INACTIVE_ORG_BACKOFF_COOLDOWN_MS + 1);
+    store.set(sidebarActiveCloudOrgIdAtom, "corg-1");
     await engine.runSyncPass();
     expect(client.upsertSessionMetadata).toHaveBeenCalledTimes(1);
-    expect(messageMock.warning).not.toHaveBeenCalled();
+    expect(messageMock.warning).toHaveBeenCalledTimes(1);
   });
 
   it("treats the visible management org as active for retry and toast policy", async () => {
@@ -440,7 +436,7 @@ describe("Org2CloudSyncEngine session publishing", () => {
     );
   });
 
-  it("resumes and warns once when a backed-off inactive org becomes active", async () => {
+  it("starts publishing and warns when an inactive org becomes active", async () => {
     store.set(sidebarActiveCloudOrgIdAtom, null);
     client.upsertSessionMetadata.mockRejectedValue(
       new Org2CloudSyncError("ORG2_QUOTA_EXCEEDED", 403)
@@ -448,6 +444,7 @@ describe("Org2CloudSyncEngine session publishing", () => {
 
     await engine.runSyncPass();
     expect(messageMock.warning).not.toHaveBeenCalled();
+    expect(client.upsertSessionMetadata).not.toHaveBeenCalled();
 
     client.upsertSessionMetadata.mockClear();
     store.set(sidebarActiveCloudOrgIdAtom, "corg-1");
@@ -623,6 +620,24 @@ describe("Org2CloudSyncEngine session publishing", () => {
     expect(client.getOrgRepoScopes).toHaveBeenCalledTimes(1);
   });
 
+  it("hydrates and publishes the session plane only for the active org", async () => {
+    store.set(org2CloudOrgsAtom, [
+      { orgId: "corg-1", name: "Active Team", role: "member" },
+      { orgId: "corg-2", name: "Inactive Team", role: "member" },
+    ]);
+    store.set(org2CloudRepoScopesAtom, {
+      "corg-1": [SCOPE_KEY],
+      "corg-2": [SCOPE_KEY],
+    });
+
+    await engine.runSyncPass();
+
+    expect(client.listOrgSessions).toHaveBeenCalledTimes(1);
+    expect(client.listOrgSessions).toHaveBeenCalledWith("jwt-1", "corg-1");
+    expect(client.upsertSessionMetadata).toHaveBeenCalledTimes(1);
+    expect(client.upsertSessionMetadata.mock.calls[0][1]).toBe("corg-1");
+  });
+
   // --- Access ladder (§13.4) ------------------------------------------------
 
   it("a scope-matched session is NOT uploaded with no org minimum or session override", async () => {
@@ -649,11 +664,109 @@ describe("Org2CloudSyncEngine session publishing", () => {
 
     await engine.runSyncPass();
 
+    expect(client.upsertSessionMetadata).not.toHaveBeenCalled();
+    expect(loadFullTranscriptChunks).not.toHaveBeenCalled();
+
+    vi.setSystemTime(Date.now() + EXTERNAL_HISTORY_ACTIVITY_DEBOUNCE_MS + 1);
+    await engine.runSyncPass();
+
     expect(client.upsertSessionMetadata).toHaveBeenCalledTimes(1);
     expect(client.upsertSessionMetadata.mock.calls[0][3].accessMode).toBe(
       "full_replay"
     );
     expect(loadFullTranscriptChunks).toHaveBeenCalledWith("cursoride-thread-1");
+  });
+
+  it("waits for a quiet window before normalizing a changing external replay", async () => {
+    const source = getImportedHistorySourceBySessionId("cursoride-thread-1");
+    const loadFullTranscriptChunks = vi
+      .spyOn(source!, "loadFullTranscriptChunks")
+      .mockResolvedValue([] as never);
+    store.set(sessionsAtom, [
+      { ...SESSION, session_id: "cursoride-thread-1", orgId: "personal-org" },
+    ]);
+    notifySessionEvents("cursoride-thread-1");
+
+    await engine.runSyncPass();
+
+    expect(client.upsertSessionMetadata).not.toHaveBeenCalled();
+    expect(loadFullTranscriptChunks).not.toHaveBeenCalled();
+    expect(processChunksRustMock).not.toHaveBeenCalled();
+
+    vi.setSystemTime(Date.now() + EXTERNAL_HISTORY_ACTIVITY_DEBOUNCE_MS + 1);
+    await engine.runSyncPass();
+
+    expect(client.upsertSessionMetadata).toHaveBeenCalledTimes(1);
+    expect(loadFullTranscriptChunks).toHaveBeenCalledTimes(1);
+  });
+
+  it("seeds unchanged external replay state from the server after restart", async () => {
+    const sessionId = "cursoride-thread-1";
+    const source = getImportedHistorySourceBySessionId(sessionId);
+    const loadFullTranscriptChunks = vi
+      .spyOn(source!, "loadFullTranscriptChunks")
+      .mockResolvedValue([{ id: "cursor-chunk" }] as never);
+    processChunksRustMock.mockResolvedValue([makeEvent("cursor-event")]);
+    store.set(sessionsAtom, [
+      { ...SESSION, session_id: sessionId, orgId: "personal-org" },
+    ]);
+
+    await engine.runSyncPass();
+    vi.setSystemTime(Date.now() + EXTERNAL_HISTORY_ACTIVITY_DEBOUNCE_MS + 1);
+    await engine.runSyncPass();
+
+    const metadata = client.upsertSessionMetadata.mock.calls[0][3];
+    const cursor = store.get(org2CloudPushCursorsAtom)[`corg-1:${sessionId}`];
+    expect(cursor).toBeDefined();
+
+    engine.stop();
+    client.listOrgSessions.mockResolvedValue({
+      serverTime: "2026-07-01T12:01:00.000Z",
+      sessions: [
+        {
+          ...metadata,
+          eventsEpoch: cursor.epoch,
+          eventsFrozenSeq: cursor.frozenSeq,
+          eventsCount: cursor.pushedCount,
+          eventsTailHash: cursor.tailHash ?? undefined,
+        },
+      ],
+    });
+    client.upsertSessionMetadata.mockClear();
+    client.rewriteSessionEvents.mockClear();
+    client.appendSessionEvents.mockClear();
+    loadFullTranscriptChunks.mockClear();
+    processChunksRustMock.mockClear();
+
+    engine = new Org2CloudSyncEngine(client, projectsClient, bridge);
+    engine.start(store);
+    await engine.runSyncPass();
+
+    expect(client.listOrgSessions).toHaveBeenCalledWith("jwt-1", "corg-1");
+    expect(client.upsertSessionMetadata).not.toHaveBeenCalled();
+    expect(loadFullTranscriptChunks).not.toHaveBeenCalled();
+    expect(processChunksRustMock).not.toHaveBeenCalled();
+    expect(client.rewriteSessionEvents).not.toHaveBeenCalled();
+    expect(client.appendSessionEvents).not.toHaveBeenCalled();
+
+    store.set(sessionsAtom, [
+      {
+        ...SESSION,
+        session_id: sessionId,
+        orgId: "personal-org",
+        updated_at: "2026-07-01T12:02:00.000Z",
+      },
+    ]);
+    await engine.runSyncPass();
+    expect(client.upsertSessionMetadata).not.toHaveBeenCalled();
+    expect(loadFullTranscriptChunks).not.toHaveBeenCalled();
+    expect(processChunksRustMock).not.toHaveBeenCalled();
+
+    vi.setSystemTime(Date.now() + EXTERNAL_HISTORY_ACTIVITY_DEBOUNCE_MS + 1);
+    await engine.runSyncPass();
+    expect(client.upsertSessionMetadata).toHaveBeenCalledTimes(1);
+    expect(loadFullTranscriptChunks).toHaveBeenCalledTimes(1);
+    expect(processChunksRustMock).toHaveBeenCalledTimes(1);
   });
 
   it("the floor still lifts imported history the user explicitly shared", async () => {
@@ -672,6 +785,11 @@ describe("Org2CloudSyncEngine session publishing", () => {
       { ...SESSION, session_id: "cursoride-thread-1", orgId: "personal-org" },
     ]);
 
+    await engine.runSyncPass();
+
+    expect(client.upsertSessionMetadata).not.toHaveBeenCalled();
+
+    vi.setSystemTime(Date.now() + EXTERNAL_HISTORY_ACTIVITY_DEBOUNCE_MS + 1);
     await engine.runSyncPass();
 
     expect(client.upsertSessionMetadata).toHaveBeenCalledTimes(1);
@@ -753,7 +871,7 @@ describe("Org2CloudSyncEngine session publishing", () => {
     });
   });
 
-  it("prepares a multi-org session once per pass (single read + hash)", async () => {
+  it("publishes a multi-tagged session only to the active org", async () => {
     store.set(org2CloudOrgsAtom, [
       { orgId: "corg-1", name: "Cloud Team", role: "member" },
       { orgId: "corg-2", name: "Other Team", role: "member" },
@@ -782,7 +900,8 @@ describe("Org2CloudSyncEngine session publishing", () => {
 
     await engine.runSyncPass();
 
-    expect(client.rewriteSessionEvents).toHaveBeenCalledTimes(2);
+    expect(client.rewriteSessionEvents).toHaveBeenCalledTimes(1);
+    expect(client.rewriteSessionEvents.mock.calls[0][1].orgId).toBe("corg-1");
     expect(eventStoreMock.getPersistedEvents).toHaveBeenCalledTimes(1);
   });
 

--- a/src/features/Org2Cloud/org2CloudSyncEngine.testUtils.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.testUtils.ts
@@ -53,12 +53,14 @@ import {
 import type {
   CloudAppendSessionEventsInput,
   CloudOrgScopeState,
+  CloudOrgSessions,
   CloudRewriteSessionEventsInput,
   CloudSessionEventsSnapshot,
 } from "./org2CloudSyncClient";
 import { Org2CloudSyncError } from "./org2CloudSyncClient";
 import {
   DATA_CHANGED_DEBOUNCE_MS,
+  EXTERNAL_HISTORY_ACTIVITY_DEBOUNCE_MS,
   HIDDEN_PASS_INTERVAL_MS,
   INACTIVE_ORG_BACKOFF_COOLDOWN_MS,
   ORG_BACKOFF_COOLDOWN_MS,
@@ -229,6 +231,12 @@ export function makeClient() {
         coolingDown: [],
       })
     ),
+    listOrgSessions: vi.fn(
+      async (_token: string, _orgId: string): Promise<CloudOrgSessions> => ({
+        serverTime: "2026-07-01T12:00:00.000Z",
+        sessions: [],
+      })
+    ),
     deleteSession: vi.fn(
       async (_token: string, _orgId: string, _sessionId: string) => undefined
     ),
@@ -293,7 +301,7 @@ export function createEngineFixture() {
     { orgId: "corg-1", name: "Cloud Team", role: "member" },
   ]);
   store.set(chatPanelSelectedCloudOrgAtom, null);
-  store.set(sidebarActiveCloudOrgIdAtom, null);
+  store.set(sidebarActiveCloudOrgIdAtom, "corg-1");
   store.set(org2CloudRepoScopesAtom, { "corg-1": [SCOPE_KEY] });
   store.set(org2CloudSyncEnabledAtom, {});
   store.set(org2CloudPushCursorsAtom, {});
@@ -347,6 +355,7 @@ export function cleanupEngineFixture(engine: Org2CloudSyncEngine): void {
  */
 export const engineTestDeps = {
   DATA_CHANGED_DEBOUNCE_MS,
+  EXTERNAL_HISTORY_ACTIVITY_DEBOUNCE_MS,
   chatPanelSelectedCloudOrgAtom,
   ensureProjectOrgForCloudOrg,
   getImportedHistorySourceBySessionId,

--- a/src/features/Org2Cloud/org2CloudSyncEngine.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.ts
@@ -48,6 +48,7 @@ import Message from "@src/components/Message";
 import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 import { createLogger } from "@src/hooks/logger";
 import i18n from "@src/i18n";
+import type { RemoteTeammateSessionMetadata } from "@src/store/collaboration/types";
 import { sessionsAtom } from "@src/store/session/sessionAtom/atoms";
 import type { Session } from "@src/store/session/sessionAtom/types";
 import { chatPanelSelectedCloudOrgAtom } from "@src/store/ui/chatPanelAtom";
@@ -108,6 +109,7 @@ import { Org2CloudSyncLifecycle } from "./org2CloudSyncLifecycle";
 
 export {
   DATA_CHANGED_DEBOUNCE_MS,
+  EXTERNAL_HISTORY_ACTIVITY_DEBOUNCE_MS,
   HIDDEN_PASS_INTERVAL_MS,
   PASS_INTERVAL_MS,
   PROJECT_PUSH_RETRY_DELAY_MS,
@@ -122,6 +124,9 @@ const log = createLogger("Org2CloudSyncEngine");
 
 /** Repo-scope mirror refresh cadence (server truth changes rarely). */
 const SCOPE_HYDRATE_TTL_MS = 10 * 60_000;
+/** Inactive orgs heal on a quiet disaster-recovery cadence; selecting the
+ * org subscribes Realtime and immediately forces a fresh pull. */
+const INACTIVE_ORG_FALLBACK_INTERVAL_MS = 30 * 60_000;
 /** Re-probe a schema-mismatched custom endpoint after this long (an
  * in-place backend upgrade must heal without an app relaunch). */
 const SCHEMA_MISMATCH_REPROBE_MS = 5 * 60_000;
@@ -185,6 +190,8 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
   private readonly projectOrgAliasIds = new Map<string, string>();
   /** Orgs whose CURRENT start already pulled one COMPLETE collab-state listing. */
   private readonly fullCollabStateOrgIds = new Set<string>();
+  /** Orgs whose owner-session summaries seeded the cold-start push caches. */
+  private readonly sessionSummariesHydratedOrgIds = new Set<string>();
   /**
    * Custom-endpoint schema gate (Phase C), KEYED BY the probed supabaseUrl:
    * the engine singleton is never stopped in production, so an endpoint
@@ -229,6 +236,7 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
     this.scopeHydratedAtMs.clear();
     this.projectOrgAliasIds.clear();
     this.fullCollabStateOrgIds.clear();
+    this.sessionSummariesHydratedOrgIds.clear();
     this.schemaGate = null;
     this.schemaMismatchToastedUrls.clear();
   }
@@ -249,8 +257,11 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
     this.sessionSync.noteSessionEventActivity(sessionId);
   }
 
-  protected override async syncAllOrgs(generation: number): Promise<void> {
-    this.sessionSync.beginPass();
+  protected override async syncAllOrgs(
+    generation: number,
+    options: { pushSessions: boolean }
+  ): Promise<void> {
+    if (options.pushSessions) this.sessionSync.beginPass();
     const store = this.store;
     if (!store) return;
     const auth = store.get(org2CloudAuthAtom);
@@ -308,26 +319,35 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
       fresh
     );
 
-    // Refresh the local scope mirror from server truth BEFORE picking
-    // targets — a second device has no locally-set scopes at all until
-    // hydration lands.
-    await this.hydrateRepoScopes(fresh, orgs, generation);
+    // The session plane follows visible-org demand. Hydrating every org here
+    // made one open workspace scan/replay sessions across every matching team
+    // and kept inactive-org scope RPCs alive. Switching/opening an org causes
+    // its Realtime subscription to request an immediate full session pass.
+    const activeSessionOrgs = orgs.filter((org) => this.isActiveOrg(org.orgId));
+    await this.hydrateRepoScopes(fresh, activeSessionOrgs, generation);
     if (this.generation !== generation) return;
 
     const scopesByOrg = store.get(org2CloudRepoScopesAtom);
-    const targets = orgs.filter(
-      (org) =>
-        ((scopesByOrg[org.orgId]?.length ?? 0) > 0 ||
-          orgsWithTaggedSessions.has(org.orgId)) &&
-        enabledByOrg[org.orgId] !== false &&
-        !this.isOrgBackedOff(org.orgId)
-    );
+    const targets = options.pushSessions
+      ? activeSessionOrgs.filter(
+          (org) =>
+            ((scopesByOrg[org.orgId]?.length ?? 0) > 0 ||
+              orgsWithTaggedSessions.has(org.orgId)) &&
+            enabledByOrg[org.orgId] !== false &&
+            !this.isOrgBackedOff(org.orgId)
+        )
+      : [];
 
     for (const org of targets) {
       // Bail the whole pass if the endpoint changed under us (see
       // passSupabaseUrl) — never push this backend's sessions elsewhere.
       if (getCloudEndpoint().supabaseUrl !== passSupabaseUrl) return;
       const scopes = scopesByOrg[org.orgId] ?? [];
+      const remoteSummaries = await this.loadSessionSummariesForColdStart(
+        fresh,
+        org.orgId,
+        generation
+      );
       for (const session of store.get(sessionsAtom)) {
         if (this.generation !== generation) return;
         if (!isCloudPushCandidate(session)) continue;
@@ -543,6 +563,18 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
           }
           continue;
         }
+        const remoteSummary = remoteSummaries?.get(session.session_id);
+        if (remoteSummary) {
+          await this.sessionSync.seedFromRemoteSummary(
+            fresh,
+            org.orgId,
+            session,
+            matchedScope,
+            access,
+            remoteSummary
+          );
+          if (this.generation !== generation) return;
+        }
         try {
           await this.sessionSync.pushSession(
             fresh,
@@ -597,7 +629,10 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
     const fallbackInboundOrgIds = new Set<string>();
     for (const org of orgs) {
       const lastInbound = this.lastInboundPassAtMs.get(org.orgId) ?? 0;
-      if (nowMs - lastInbound >= INBOUND_FALLBACK_INTERVAL_MS) {
+      const fallbackInterval = this.isActiveOrg(org.orgId)
+        ? INBOUND_FALLBACK_INTERVAL_MS
+        : INACTIVE_ORG_FALLBACK_INTERVAL_MS;
+      if (nowMs - lastInbound >= fallbackInterval) {
         inboundOrgIds.add(org.orgId);
         fallbackInboundOrgIds.add(org.orgId);
       }
@@ -738,6 +773,37 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
   }
 
   /**
+   * Read one server summary page per org/start so a restart can prove that
+   * already-published imported transcripts are unchanged without reopening
+   * and normalizing every CLI history file. The map is pass-local: keeping a
+   * second copy of every remote session for the app lifetime would trade I/O
+   * pressure for RAM pressure.
+   */
+  private async loadSessionSummariesForColdStart(
+    auth: Org2CloudAuthState,
+    orgId: string,
+    generation: number
+  ): Promise<Map<string, RemoteTeammateSessionMetadata> | undefined> {
+    if (this.sessionSummariesHydratedOrgIds.has(orgId)) return undefined;
+    try {
+      const result = await this.client.listOrgSessions(auth.accessToken, orgId);
+      if (this.generation !== generation) return undefined;
+      this.sessionSummariesHydratedOrgIds.add(orgId);
+      return new Map(
+        result.sessions
+          .filter((row) => row.ownerUserId === auth.userId && !row.deletedAt)
+          .map((row) => [row.sourceSessionId, row])
+      );
+    } catch (error) {
+      log.warn(
+        `cloud session summary hydration failed for org ${orgId}:`,
+        error
+      );
+      return undefined;
+    }
+  }
+
+  /**
    * One org's projects/work-items cycle: pull the collab-state delta, hand
    * it to the shared ProjectSyncChannel (apply + outbox drain/push/ack),
    * then advance the persisted cursor. Once per engine start the cursor is
@@ -830,7 +896,10 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
   ): Promise<void> {
     for (const org of orgs) {
       const lastAttempt = this.scopeHydratedAtMs.get(org.orgId) ?? 0;
-      if (Date.now() - lastAttempt < SCOPE_HYDRATE_TTL_MS) continue;
+      const hydrateInterval = this.isActiveOrg(org.orgId)
+        ? SCOPE_HYDRATE_TTL_MS
+        : INACTIVE_ORG_FALLBACK_INTERVAL_MS;
+      if (Date.now() - lastAttempt < hydrateInterval) continue;
       this.scopeHydratedAtMs.set(org.orgId, Date.now());
       try {
         const state = await this.client.getOrgRepoScopes(
@@ -944,6 +1013,11 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
     }
     for (const orgId of this.fullCollabStateOrgIds) {
       if (!currentOrgIds.has(orgId)) this.fullCollabStateOrgIds.delete(orgId);
+    }
+    for (const orgId of this.sessionSummariesHydratedOrgIds) {
+      if (!currentOrgIds.has(orgId)) {
+        this.sessionSummariesHydratedOrgIds.delete(orgId);
+      }
     }
     for (const orgId of this.lastInboundPassAtMs.keys()) {
       if (!currentOrgIds.has(orgId)) this.lastInboundPassAtMs.delete(orgId);

--- a/src/features/Org2Cloud/org2CloudSyncLifecycle.ts
+++ b/src/features/Org2Cloud/org2CloudSyncLifecycle.ts
@@ -4,6 +4,7 @@ import type { UnlistenFn } from "@tauri-apps/api/event";
 import { eventStoreProxy } from "@src/engines/SessionCore/core/store/EventStoreProxy";
 import { createLogger } from "@src/hooks/logger";
 import type { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";
+import { isImportedHistorySession } from "@src/util/session/sessionDispatch";
 
 const log = createLogger("Org2CloudSyncEngine");
 
@@ -14,6 +15,14 @@ export const PASS_INTERVAL_MS = 60_000;
 /** Hidden documents stretch the same timer chain instead of adding another. */
 export const HIDDEN_PASS_INTERVAL_MS = 300_000;
 const ACTIVITY_DEBOUNCE_MS = 3_000;
+/**
+ * External CLI transcripts rewrite earlier mutable records while a turn is
+ * streaming. Publishing each file change can therefore turn a single live
+ * turn into a chain of full cloud rewrites. Wait for a quiet window and send
+ * one converged replay instead. Native EventStore sessions keep the short
+ * debounce because their append/tail protocol is already incremental.
+ */
+export const EXTERNAL_HISTORY_ACTIVITY_DEBOUNCE_MS = 30_000;
 /** `orgii-data-changed` projects-plane debounce. */
 export const DATA_CHANGED_DEBOUNCE_MS = 1_500;
 /** One-shot retry just after the Rust outbox's first retry slot. */
@@ -38,12 +47,16 @@ export abstract class Org2CloudSyncLifecycle {
   protected generation = 0;
   private timer: ReturnType<typeof setTimeout> | null = null;
   private activityTimer: ReturnType<typeof setTimeout> | null = null;
+  private externalHistoryActivityTimer: ReturnType<typeof setTimeout> | null =
+    null;
   private dataChangedTimer: ReturnType<typeof setTimeout> | null = null;
   private projectPushRetryTimer: ReturnType<typeof setTimeout> | null = null;
   private dataChangedUnlisten: Promise<UnlistenFn> | null = null;
   private eventStoreUnsubscribe: (() => void) | null = null;
   private passRunning = false;
   private passDirty = false;
+  /** A full/outbound trigger that arrived while the current pass was busy. */
+  private nextPassPushSessions = false;
   /** Serialized passes actually started (test seam for pass-count budgets). */
   startedPassCount = 0;
   /** Explicit user-action waiters resolve after the active and dirty passes drain. */
@@ -59,7 +72,10 @@ export abstract class Org2CloudSyncLifecycle {
   /** Set by `orgii-data-changed` so the next pass drains the projects plane. */
   protected forceProjectsNextPass = false;
 
-  protected abstract syncAllOrgs(generation: number): Promise<void>;
+  protected abstract syncAllOrgs(
+    generation: number,
+    options: { pushSessions: boolean }
+  ): Promise<void>;
   protected abstract noteSessionEventActivity(sessionId: string): void;
   protected abstract resetSyncState(): void;
   protected abstract clearOrgBackoff(orgId: string): void;
@@ -100,7 +116,7 @@ export abstract class Org2CloudSyncLifecycle {
     this.eventStoreUnsubscribe = eventStoreProxy.subscribe(
       (_snapshot, sessionId) => {
         this.noteSessionEventActivity(sessionId);
-        this.scheduleActivityPass();
+        this.scheduleActivityPass(sessionId);
       }
     );
     if (typeof document !== "undefined") {
@@ -123,6 +139,10 @@ export abstract class Org2CloudSyncLifecycle {
     this.timer = null;
     if (this.activityTimer !== null) clearTimeout(this.activityTimer);
     this.activityTimer = null;
+    if (this.externalHistoryActivityTimer !== null) {
+      clearTimeout(this.externalHistoryActivityTimer);
+    }
+    this.externalHistoryActivityTimer = null;
     if (this.dataChangedTimer !== null) clearTimeout(this.dataChangedTimer);
     this.dataChangedTimer = null;
     if (this.projectPushRetryTimer !== null) {
@@ -142,6 +162,7 @@ export abstract class Org2CloudSyncLifecycle {
     this.resetSyncState();
     this.passRunning = false;
     this.passDirty = false;
+    this.nextPassPushSessions = false;
     for (const resolve of this.passDrainWaiters.splice(0)) resolve();
     this.lastInboundPassAtMs.clear();
     this.pendingInboundOrgIds.clear();
@@ -152,24 +173,28 @@ export abstract class Org2CloudSyncLifecycle {
   }
 
   /** Run a pass now (test seam / manual trigger). Serialized. */
-  async runSyncPass(): Promise<void> {
+  async runSyncPass(options: { pushSessions?: boolean } = {}): Promise<void> {
     if (!this.started || !this.store) return;
+    const pushSessions = options.pushSessions !== false;
     if (this.passRunning) {
       this.passDirty = true;
+      this.nextPassPushSessions ||= pushSessions;
       return;
     }
     this.passRunning = true;
     this.startedPassCount += 1;
     const generation = this.generation;
     try {
-      await this.syncAllOrgs(generation);
+      await this.syncAllOrgs(generation, { pushSessions });
     } catch (error) {
       log.warn("cloud sync pass failed:", error);
     } finally {
       this.passRunning = false;
       if (this.started && this.generation === generation && this.passDirty) {
         this.passDirty = false;
-        void this.runSyncPass();
+        const nextPushSessions = this.nextPassPushSessions;
+        this.nextPassPushSessions = false;
+        void this.runSyncPass({ pushSessions: nextPushSessions });
       } else {
         for (const resolve of this.passDrainWaiters.splice(0)) resolve();
       }
@@ -187,7 +212,10 @@ export abstract class Org2CloudSyncLifecycle {
   }
 
   /** Realtime invalidation; ordinary changes target one org and keep cursors. */
-  invalidateOrgInbound(orgId?: string, options: { full?: boolean } = {}): void {
+  invalidateOrgInbound(
+    orgId?: string,
+    options: { full?: boolean; pushSessions?: boolean } = {}
+  ): void {
     if (!this.started) return;
     if (orgId) {
       this.clearOrgBackoff(orgId);
@@ -201,13 +229,17 @@ export abstract class Org2CloudSyncLifecycle {
       this.forceAllInboundNextPass = true;
       this.invalidateFullInboundState();
     }
-    void this.runSyncPass();
+    if (isDocumentHidden()) return;
+    // Realtime invalidation is normally an inbound nudge. Running the outbound
+    // session scan here fed our own server signal back into another replay
+    // upload. Explicit policy/user actions opt back into outbound work.
+    void this.runSyncPass({ pushSessions: options.pushSessions === true });
   }
 
   /** Invalidate and resolve after all work coalesced into that pass drains. */
   async invalidateOrgInboundAndWait(
     orgId?: string,
-    options: { full?: boolean } = {}
+    options: { full?: boolean; pushSessions?: boolean } = {}
   ): Promise<void> {
     if (!this.started || !this.store) return;
     const drained = new Promise<void>((resolve) => {
@@ -219,12 +251,15 @@ export abstract class Org2CloudSyncLifecycle {
 
   /** Resume immediately after a user-controlled access or policy change. */
   resumeOrg(orgId: string): void {
-    this.invalidateOrgInbound(orgId, { full: true });
+    this.invalidateOrgInbound(orgId, { full: true, pushSessions: true });
   }
 
   /** Resume an org and wait for the resulting serialized pass to drain. */
   async resumeOrgAndWait(orgId: string): Promise<void> {
-    await this.invalidateOrgInboundAndWait(orgId, { full: true });
+    await this.invalidateOrgInboundAndWait(orgId, {
+      full: true,
+      pushSessions: true,
+    });
   }
 
   private schedulePass(delayMs: number): void {
@@ -240,14 +275,26 @@ export abstract class Org2CloudSyncLifecycle {
     }, delayMs);
   }
 
-  private scheduleActivityPass(): void {
+  private scheduleActivityPass(sessionId: string): void {
     if (!this.started || isDocumentHidden()) return;
-    if (this.activityTimer !== null) clearTimeout(this.activityTimer);
-    this.activityTimer = setTimeout(() => {
-      this.activityTimer = null;
-      if (isDocumentHidden()) return;
-      void this.runSyncPass();
-    }, ACTIVITY_DEBOUNCE_MS);
+    const externalHistory = isImportedHistorySession(sessionId);
+    const timer = externalHistory
+      ? this.externalHistoryActivityTimer
+      : this.activityTimer;
+    if (timer !== null) clearTimeout(timer);
+    const nextTimer = setTimeout(
+      () => {
+        if (externalHistory) this.externalHistoryActivityTimer = null;
+        else this.activityTimer = null;
+        if (isDocumentHidden()) return;
+        void this.runSyncPass();
+      },
+      externalHistory
+        ? EXTERNAL_HISTORY_ACTIVITY_DEBOUNCE_MS
+        : ACTIVITY_DEBOUNCE_MS
+    );
+    if (externalHistory) this.externalHistoryActivityTimer = nextTimer;
+    else this.activityTimer = nextTimer;
   }
 
   private scheduleProjectsPass(): void {
@@ -258,7 +305,7 @@ export abstract class Org2CloudSyncLifecycle {
     this.dataChangedTimer = setTimeout(() => {
       this.dataChangedTimer = null;
       if (isDocumentHidden()) return;
-      void this.runSyncPass();
+      void this.runSyncPass({ pushSessions: false });
     }, DATA_CHANGED_DEBOUNCE_MS);
   }
 
@@ -269,7 +316,7 @@ export abstract class Org2CloudSyncLifecycle {
       this.projectPushRetryTimer = null;
       if (!this.started) return;
       this.forceProjectsNextPass = true;
-      void this.runSyncPass();
+      void this.runSyncPass({ pushSessions: false });
     }, PROJECT_PUSH_RETRY_DELAY_MS);
   }
 }

--- a/src/features/Org2Cloud/useOrg2CloudRealtime.ts
+++ b/src/features/Org2Cloud/useOrg2CloudRealtime.ts
@@ -11,14 +11,12 @@
  *                        change → `refetchOrgs()` (`list_my_orgs`), the single
  *                        source of truth. The subscribe true-edge compensates
  *                        for membership changes missed while no org was open.
- *  - Slice B (signals):  subscribe the actively-used org's
- *                        `org_change_signals` — a tiny
- *                        member-readable table that server-side triggers
- *                        touch on EVERY cloud_projects / cloud_work_items /
- *                        cloud_session_comments change (the data tables stay
- *                        RPC-only). Any signal →
- *                        `engine.invalidateOrgInbound(orgId)` (reuses the
- *                        existing collab-state pull + cursor/LWW/apply).
+ *  - Slice B (signals):  subscribe the actively-used org's durable, coarse
+ *                        `org_change_signals` row. Plane-specific Presence
+ *                        broadcasts drive the normal live path; the coarse
+ *                        row is rate-limited to one recovery pull per minute
+ *                        so unrelated planes cannot invalidate one another
+ *                        on every write.
  *
  * Realtime is an INVALIDATION signal only: the data still arrives through the
  * existing RPC pull paths, so no cursor/tombstone logic is duplicated here. The
@@ -26,8 +24,8 @@
  * a dropped socket still reaches eventual consistency.
  *
  * On (re)subscribe the true-edge of `onStatus` forces a compensating full pull
- * (roster refetch for A; `invalidateOrgInbound` for B) to recover any events
- * missed while disconnected.
+ * (roster refetch for A; inbound/session/policy recovery for B) to recover any
+ * events missed while disconnected.
  */
 import { useAtomValue, useSetAtom, useStore } from "jotai";
 import {
@@ -48,6 +46,7 @@ import type { Session } from "@src/store/session/sessionAtom/types";
 import { activeSessionIdAtom } from "@src/store/session/viewAtom";
 import { chatPanelSelectedCloudOrgAtom } from "@src/store/ui/chatPanelAtom";
 
+import { org2CloudSharingFloorAtom } from "./org2CloudAccessSettings";
 import {
   commitRefreshedAuth,
   org2CloudAuthAtom,
@@ -62,11 +61,17 @@ import {
   registerCommentsBroadcaster,
   sessionCommentsKey,
 } from "./org2CloudCommentsBus";
+import {
+  ORG_CONTROL_CHANGED_EVENT,
+  parseOrgControlChangeKind,
+  registerOrgControlBroadcaster,
+} from "./org2CloudControlBus";
 import { refreshOrgEntitlement } from "./org2CloudEntitlementCoordinator";
 import { org2CloudMemberNamesAtom } from "./org2CloudMemberNamesAtom";
 import { clearCloudOrgMembersCache } from "./org2CloudMembersCoordinator";
 import {
   org2CloudOrgsAtom,
+  org2CloudRosterRealtimeConnectedAtom,
   org2CloudRosterVersionAtom,
   sidebarActiveCloudOrgIdAtom,
   useRefetchOrg2CloudOrgs,
@@ -109,8 +114,20 @@ const log = createLogger("Org2CloudRealtime");
  */
 const CHANGE_SIGNALS_TABLE = "org_change_signals";
 
-/** Bounds signal-burst roster refetches to one list_my_orgs per window. */
-const ROSTER_SIGNAL_REFRESH_TTL_MS = 10_000;
+/**
+ * The backend's durable signal is intentionally coarse. Plane-specific
+ * Presence broadcasts provide the live path; this bounded trailing fallback
+ * recovers missed broadcasts without turning every session write into five
+ * unrelated RPCs.
+ */
+const COARSE_SIGNAL_FALLBACK_MS = 60_000;
+const CONTROL_PLANE_FALLBACK_MS = 5 * 60_000;
+
+function isDocumentHidden(): boolean {
+  return (
+    typeof document !== "undefined" && document.visibilityState === "hidden"
+  );
+}
 
 /**
  * Establish + maintain the inbound Realtime subscriptions for the signed-in
@@ -133,6 +150,9 @@ export function useOrg2CloudRealtime(): void {
   );
   const refetchOrgs = useRefetchOrg2CloudOrgs();
   const setRosterVersion = useSetAtom(org2CloudRosterVersionAtom);
+  const setRosterRealtimeConnected = useSetAtom(
+    org2CloudRosterRealtimeConnectedAtom
+  );
   const bumpRosterVersion = useCallback(
     (orgId: string) => {
       setRosterVersion((current) => ({
@@ -178,6 +198,7 @@ export function useOrg2CloudRealtime(): void {
     clearCloudOrgMembersCache(store);
     setMemberNames({});
     setRosterVersion({});
+    setRosterRealtimeConnected({});
     setRemoteSessions({});
     setRemoteSessionsVersion({});
     setSessionComments({});
@@ -193,15 +214,33 @@ export function useOrg2CloudRealtime(): void {
     setRemoteSessions,
     setRemoteSessionsVersion,
     setRosterVersion,
+    setRosterRealtimeConnected,
     setSessionComments,
     store,
   ]);
   // Stable refs so the per-org effect and status callbacks read current values
   // without forcing the connection to rebuild.
   const refetchRef = useRef(refetchOrgs);
-  const rosterSignalRefreshAtRef = useRef(0);
-  const rosterTrailingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null
+  const coarseSignalRefreshAtRef = useRef(0);
+  const controlPlaneRefreshAtRef = useRef(0);
+  const coarseSignalTrailingTimerRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
+  const hiddenRecoveryRef = useRef<{
+    orgId: string;
+    pushSessions: boolean;
+  } | null>(null);
+  const deferHiddenRecovery = useCallback(
+    (orgId: string, pushSessions: boolean) => {
+      const previous = hiddenRecoveryRef.current;
+      hiddenRecoveryRef.current = {
+        orgId,
+        pushSessions:
+          pushSessions ||
+          (previous?.orgId === orgId && previous.pushSessions === true),
+      };
+    },
+    []
   );
   useEffect(() => {
     refetchRef.current = refetchOrgs;
@@ -222,7 +261,8 @@ export function useOrg2CloudRealtime(): void {
   // (store-keyed single-flight + TTL) instead of using list_my_orgs as a
   // policy cache invalidation mechanism.
   const refreshEntitlementForOrg = useCallback(
-    async (orgId: string): Promise<void> => {
+    async (orgId: string): Promise<boolean> => {
+      const before = store.get(org2CloudSharingFloorAtom)[orgId];
       await refreshOrgEntitlement(store, orgId, async () => {
         const current = authRef.current;
         if (!current) return null;
@@ -231,11 +271,52 @@ export function useOrg2CloudRealtime(): void {
         commitRefreshedAuth(setAuth, current, fresh);
         return fresh.accessToken;
       });
+      return store.get(org2CloudSharingFloorAtom)[orgId] !== before;
     },
     [setAuth, store]
   );
 
   const connectionRef = useRef<Org2CloudRealtimeConnection | null>(null);
+
+  // Realtime channels stay joined while hidden, but network pulls do not.
+  // Collapse every hidden nudge into one full recovery when the window is
+  // visible again; a hidden scopes change also re-evaluates local uploads.
+  useEffect(() => {
+    if (typeof document === "undefined") return undefined;
+    const recoverWhenVisible = () => {
+      if (isDocumentHidden()) return;
+      const pending = hiddenRecoveryRef.current;
+      if (!pending || pending.orgId !== activeRealtimeOrgId) return;
+      hiddenRecoveryRef.current = null;
+      void (async () => {
+        const [, floorChanged] = await Promise.all([
+          refetchRef.current(),
+          refreshEntitlementForOrg(pending.orgId),
+        ]);
+        org2CloudSyncEngine.invalidateOrgInbound(pending.orgId, {
+          full: true,
+          pushSessions: pending.pushSessions || floorChanged,
+        });
+      })();
+      setRemoteSessions((current) => {
+        if (!(pending.orgId in current)) return current;
+        const next = { ...current };
+        delete next[pending.orgId];
+        return next;
+      });
+      bumpRemoteSessionsVersion(pending.orgId);
+      bumpOrgCommentsSignal(pending.orgId);
+    };
+    document.addEventListener("visibilitychange", recoverWhenVisible);
+    return () =>
+      document.removeEventListener("visibilitychange", recoverWhenVisible);
+  }, [
+    activeRealtimeOrgId,
+    bumpOrgCommentsSignal,
+    bumpRemoteSessionsVersion,
+    refreshEntitlementForOrg,
+    setRemoteSessions,
+  ]);
 
   // --- Connection + Slice A (roster). Rebuilds on user / endpoint / active
   // org. A fresh connection on scope switch avoids supabase-js reusing a
@@ -294,58 +375,73 @@ export function useOrg2CloudRealtime(): void {
 
     const unsubscribes: Array<() => void> = [];
     const orgId = activeRealtimeOrgId;
+    const runCoarseSignalFallback = () => {
+      const now = Date.now();
+      coarseSignalRefreshAtRef.current = now;
+      if (isDocumentHidden()) {
+        deferHiddenRecovery(orgId, false);
+        return;
+      }
+      org2CloudSyncEngine.invalidateOrgInbound(orgId);
+      bumpRemoteSessionsVersion(orgId);
+      bumpOrgCommentsSignal(orgId);
+      if (now - controlPlaneRefreshAtRef.current >= CONTROL_PLANE_FALLBACK_MS) {
+        controlPlaneRefreshAtRef.current = now;
+        void refetchRef.current();
+        void refreshEntitlementForOrg(orgId).then((floorChanged) => {
+          if (floorChanged) org2CloudSyncEngine.resumeOrg(orgId);
+        });
+      }
+    };
+    const scheduleCoarseSignalFallback = () => {
+      const now = Date.now();
+      const elapsed = now - coarseSignalRefreshAtRef.current;
+      if (elapsed >= COARSE_SIGNAL_FALLBACK_MS) {
+        runCoarseSignalFallback();
+        return;
+      }
+      if (coarseSignalTrailingTimerRef.current) return;
+      coarseSignalTrailingTimerRef.current = setTimeout(() => {
+        coarseSignalTrailingTimerRef.current = null;
+        runCoarseSignalFallback();
+      }, COARSE_SIGNAL_FALLBACK_MS - elapsed);
+    };
     unsubscribes.push(
       connection.subscribe({
         table: CHANGE_SIGNALS_TABLE,
         filter: `org_id=eq.${orgId}`,
         onChange: () => {
-          // One scoped, cursor-based pull. The former unconditional roster
-          // refetch here re-read list_my_orgs + every org's entitlement for
-          // unrelated project/comment/session writes, and the follow-up
-          // explicit pass dirtied the just-started pass, doubling all
-          // inbound RPCs.
-          void org2CloudSyncEngine.invalidateOrgInboundAndWait(orgId);
-          void refreshEntitlementForOrg(orgId);
-          // Server contract (cloud_rename_org): this signal row is the
-          // durable nudge that keeps member-side org names coherent — the
-          // roster must refetch on it. TTL-gated so signal bursts cost at
-          // most one list_my_orgs per window (entitlements ride their own
-          // coordinator; the refetch itself is single-flighted per store).
-          const now = Date.now();
-          if (
-            now - rosterSignalRefreshAtRef.current >=
-            ROSTER_SIGNAL_REFRESH_TTL_MS
-          ) {
-            rosterSignalRefreshAtRef.current = now;
-            void refetchRef.current();
-          } else if (!rosterTrailingTimerRef.current) {
-            // A gated signal is deferred to window expiry, never dropped —
-            // it may be the rename/policy change's only nudge.
-            const delay =
-              ROSTER_SIGNAL_REFRESH_TTL_MS -
-              (now - rosterSignalRefreshAtRef.current);
-            rosterTrailingTimerRef.current = setTimeout(() => {
-              rosterTrailingTimerRef.current = null;
-              rosterSignalRefreshAtRef.current = Date.now();
-              void refetchRef.current();
-            }, delay);
-          }
-          // The signal covers cloud_sessions too — refresh the sidebar's
-          // TEAM SESSIONS rows (teammate shared/forked/retracted a session).
-          bumpRemoteSessionsVersion(orgId);
-          // Durable fallback for comment CRUD. cloud_session_comments
-          // touches this same org_change_signals row, so an open thread
-          // refetches even when its low-latency Presence broadcast was
-          // missed or the private channel failed to join.
-          bumpOrgCommentsSignal(orgId);
+          // This row carries no plane/entity discriminator. Treat it only as
+          // a bounded durable fallback; plane-specific Presence broadcasts
+          // below keep normal session/comment/control changes immediate.
+          scheduleCoarseSignalFallback();
         },
         onStatus: (subscribed) => {
           // On (re)subscribe force a complete listing for this org so
           // tombstones (revoked projects / deleted work items / removed
           // tasks) that landed while disconnected are observed.
           if (subscribed) {
-            org2CloudSyncEngine.invalidateOrgInbound(orgId, { full: true });
-            void refreshEntitlementForOrg(orgId);
+            coarseSignalRefreshAtRef.current = Date.now();
+            controlPlaneRefreshAtRef.current = Date.now();
+            if (isDocumentHidden()) {
+              deferHiddenRecovery(orgId, false);
+              return;
+            }
+            org2CloudSyncEngine.invalidateOrgInbound(orgId, {
+              full: true,
+              pushSessions: true,
+            });
+            void refreshEntitlementForOrg(orgId).then((floorChanged) => {
+              if (floorChanged) org2CloudSyncEngine.resumeOrg(orgId);
+            });
+            // Force a complete session listing after a disconnected window;
+            // subsequent invalidations use its server cursor.
+            setRemoteSessions((current) => {
+              if (!(orgId in current)) return current;
+              const next = { ...current };
+              delete next[orgId];
+              return next;
+            });
             bumpRemoteSessionsVersion(orgId);
             bumpOrgCommentsSignal(orgId);
           }
@@ -364,6 +460,11 @@ export function useOrg2CloudRealtime(): void {
           bumpRosterVersion(orgId);
         },
         onStatus: (subscribed) => {
+          setRosterRealtimeConnected((current) =>
+            current[orgId] === subscribed
+              ? current
+              : { ...current, [orgId]: subscribed }
+          );
           // Compensate for roster events missed while disconnected.
           if (subscribed) bumpRosterVersion(orgId);
         },
@@ -373,9 +474,15 @@ export function useOrg2CloudRealtime(): void {
 
     return () => {
       for (const unsub of unsubscribes) unsub();
-      if (rosterTrailingTimerRef.current) {
-        clearTimeout(rosterTrailingTimerRef.current);
-        rosterTrailingTimerRef.current = null;
+      setRosterRealtimeConnected((current) => {
+        if (!(orgId in current)) return current;
+        const next = { ...current };
+        delete next[orgId];
+        return next;
+      });
+      if (coarseSignalTrailingTimerRef.current) {
+        clearTimeout(coarseSignalTrailingTimerRef.current);
+        coarseSignalTrailingTimerRef.current = null;
       }
     };
     // Connection identity follows the same activeRealtimeOrgId key in Slice A.
@@ -460,6 +567,28 @@ export function useOrg2CloudRealtime(): void {
       key: userId,
       payload: initialPayload,
       onBroadcast: (event, payload) => {
+        if (event === ORG_CONTROL_CHANGED_EVENT) {
+          const kind = parseOrgControlChangeKind(payload);
+          if (kind && isDocumentHidden()) {
+            deferHiddenRecovery(
+              orgId,
+              kind === "scopes" || kind === "entitlement"
+            );
+            return;
+          }
+          if (kind === "entitlement") {
+            void refreshEntitlementForOrg(orgId).then((floorChanged) => {
+              if (floorChanged) org2CloudSyncEngine.resumeOrg(orgId);
+            });
+          } else if (kind === "roster") {
+            void refetchRef.current();
+          } else if (kind === "scopes") {
+            org2CloudSyncEngine.resumeOrg(orgId);
+          } else if (kind === "sessions") {
+            bumpRemoteSessionsVersion(orgId);
+          }
+          return;
+        }
         if (event === PRESENCE_VIEW_CHANGED_EVENT) {
           setPresence((current) =>
             applyOrg2CloudPresenceViewChanged(current, orgId, payload)
@@ -469,6 +598,10 @@ export function useOrg2CloudRealtime(): void {
         if (event !== COMMENTS_CHANGED_EVENT) return;
         const sessionId = payload.sessionId;
         if (typeof sessionId !== "string" || !sessionId) return;
+        if (isDocumentHidden()) {
+          deferHiddenRecovery(orgId, false);
+          return;
+        }
         setCommentsSignal((current) =>
           bumpCommentsSignalKey(current, sessionCommentsKey(orgId, sessionId))
         );
@@ -515,6 +648,11 @@ export function useOrg2CloudRealtime(): void {
       handle.send(event, payload)
     );
     unregisters.push(unregister);
+    unregisters.push(
+      registerOrgControlBroadcaster(orgId, (event, payload) =>
+        handle.send(event, payload)
+      )
+    );
     return () => {
       for (const unregister of unregisters.splice(0)) unregister();
       for (const [orgId, handle] of handles) {

--- a/src/modules/shared/layouts/blocks/sessionTableItem.test.ts
+++ b/src/modules/shared/layouts/blocks/sessionTableItem.test.ts
@@ -117,7 +117,10 @@ describe("mapKanbanTaskToSessionTableItem", () => {
 
     expect(isValidElement(item.agentIcon)).toBe(true);
     expect(isValidElement(item.modelIcon)).toBe(true);
-    if (!isValidElement(item.agentIcon) || !isValidElement(item.modelIcon)) {
+    if (
+      !isValidElement<{ className?: string }>(item.agentIcon) ||
+      !isValidElement<{ className?: string }>(item.modelIcon)
+    ) {
       throw new Error("missing agent or model icon");
     }
     expect(item.agentIcon.props.className).toBe("text-text-1");

--- a/src/util/platform/tauri/index.ts
+++ b/src/util/platform/tauri/index.ts
@@ -90,10 +90,15 @@ const patchTauriInternals = () => {
  */
 const patchTauriEventPluginInternals = () => {
   if (typeof window === "undefined") return;
+  const targetWindow = window;
 
   // The event plugin internals may not be available immediately, so we set up a polling mechanism
   const tryPatch = () => {
-    const eventInternals = window.__TAURI_EVENT_PLUGIN_INTERNALS__;
+    // Stop an old environment's bounded retry after teardown/replacement. This
+    // prevents a late startup timer from touching a new window or a missing one.
+    if (typeof window === "undefined" || window !== targetWindow) return true;
+
+    const eventInternals = targetWindow.__TAURI_EVENT_PLUGIN_INTERNALS__;
     if (!eventInternals) return false;
 
     try {

--- a/src/util/platform/tauri/patchLifecycle.test.ts
+++ b/src/util/platform/tauri/patchLifecycle.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("Tauri event internals patch lifecycle", () => {
+  const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    "window"
+  );
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.resetModules();
+    if (originalWindowDescriptor) {
+      Object.defineProperty(globalThis, "window", originalWindowDescriptor);
+    }
+  });
+
+  it("stops a pending startup retry when its window is torn down", async () => {
+    vi.useFakeTimers();
+    vi.resetModules();
+
+    await import("./index");
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+    expect(Reflect.deleteProperty(globalThis, "window")).toBe(true);
+    expect(typeof window).toBe("undefined");
+
+    expect(() => vi.runAllTimers()).not.toThrow();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- scope session upload, remote summaries, and repo-scope hydration to the currently visible cloud org
- split realtime control signals by plane and prevent inbound events from feeding back into full outbound scans
- add incremental remote-session listing with tombstone merging, hidden-window deferral, and reconnect recovery
- seed cold-start state from server summaries and wait for external CLI histories to become quiet before replay upload
- bound roster, entitlement, and coarse-signal fallback work

## Verification
- Org2Cloud: 56 test files, 610 tests passed
- TypeScript, ESLint, Prettier, and git diff --check passed
- dual-instance optimized Tauri build passed
- Computer Use validation with vinceorz and isolated vinceorz418 instances

## Performance evidence
After clearing Ctrl+5 and observing the active cloud org for two minutes, cloudTargets remained empty. The prior entitlement, org/member/session listing, metadata upsert, replay rewrite, and Codex/Claude chunk hotspots did not recur. Remaining calls were local session aggregation, workspace scanning, and the configured external-history source scan.