### PR TITLE
fix(dev): Linux tauri:dev startup failures (WebKitGTK load + i18n mount race)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -191,8 +191,14 @@ async function initializeApp() {
   // - Background: loads from IndexedDB + decodes (disk + GPU)
   //
   // Wrap in timeout to prevent hanging forever if any init hangs
+  // i18n is NOT degradable: App calls useTranslation() at render, which crashes
+  // (this.store undefined → "undefined is not an object evaluating
+  // 'this.store.hasLanguageSomeTranslations'") if i18n.init() hasn't completed.
+  // Keep it out of the bounded race below and await it unconditionally before
+  // mount. i18nReady already started at module load and runs in parallel with
+  // the other ops; this await only blocks when cold start is slow enough that
+  // locale bundles are still loading.
   const initPromise = Promise.all([
-    i18nReady,
     initTheme(),
     initializeTauriAPIs(),
     initBackgroundImage(),
@@ -210,6 +216,21 @@ async function initializeApp() {
   } catch (error) {
     // Log but continue - we want to mount React even if some init failed
     log.warn("[Init] Initialization issue:", error);
+  }
+
+  // i18n must be fully initialized before React mounts — a half-initialized
+  // i18next instance crashes the first useTranslation() call. A rejection here
+  // means language resources couldn't load at all; surface it rather than
+  // mounting a guaranteed-to-crash React tree.
+  try {
+    await i18nReady;
+  } catch (error) {
+    log.critical("[Init] i18n initialization failed:", error);
+    showEmergencyError(
+      "Initialization Failed",
+      "The application could not initialize its language resources. Please try restarting."
+    );
+    return;
   }
 
   const App = (await appModulePromise).default;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -159,7 +159,18 @@ async function initializeApp() {
     // A focus event retries synchronization after React mounts.
     log.warn("[Init] Shared auth storage unavailable:", error);
   }
-  const appModulePromise = import("@src/App");
+  // In dev, bundle App into main.js (webpackMode: "eager") instead of emitting
+  // it as a separate runtime chunk. App is the aggregate entry and pulls in
+  // most of the app; with eval-cheap-module-source-map that chunk balloons to
+  // ~77MB and WebKitGTK fails the dynamic import → "Initialization Failed".
+  // eager keeps the Promise-returning import() semantics (so the await below
+  // still defers App module-tree evaluation until after the runtime-identity
+  // config above has run) without emitting a loadable chunk. Production keeps
+  // the normal dynamic import — prod minifies and has no eval source maps, so
+  // the App chunk is small there.
+  const appModulePromise = isDev
+    ? import(/* webpackMode: "eager" */ "@src/App")
+    : import("@src/App");
 
   // Clear stale opened repos from previous app session (main window only)
   // Secondary windows should not clear, as they'd wipe main window's registration

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -636,8 +636,15 @@ module.exports = (env, argv) => {
       // Only show minimal info in dev mode
       preset: isProduction ? "normal" : "minimal",
     },
-    // eval-cheap-module-source-map maps to original lines via loaders.
-    // Light dev disables source maps to reduce renderer and compiler memory.
-    devtool: useDevSourceMaps ? "eval-cheap-module-source-map" : false,
+    // App is bundled into main.js via `webpackMode: "eager"` in dev
+    // (see src/index.tsx) so it is not emitted as a separate runtime chunk.
+    // With eval-cheap-module-source-map, that inlines every module's source
+    // into main.js, swelling it past 80MB — too large for some WebViews to
+    // load. So dev writes source maps to separate lazily-loaded .map files
+    // (`cheap-source-map`), keeping the executable bundle small while still
+    // giving line-level debuggability. Cost vs eval mode: incremental rebuilds
+    // are marginally slower (a .map file is written each time). Light dev
+    // disables source maps entirely to reduce renderer and compiler memory.
+    devtool: useDevSourceMaps ? "cheap-source-map" : false,
   };
 };


### PR DESCRIPTION
## Summary

Fixes #508 — on Linux, `pnpm tauri:dev` fails to reach the main UI due to two
related dev-only startup failures.

Two coordinated, dev-only commits; **production builds are untouched.**

### Commit 1 — `fix(dev): keep App bundled into main.js so WebKitGTK can load it`

Since `e06f4b471`, App is loaded via a runtime dynamic `import("@src/App")`,
which webpack emits as a separate chunk. Under `eval-cheap-module-source-map`
that chunk inlines every module's source and balloons to ~77MB; WebKitGTK
fails the runtime dynamic import → "Initialization Failed".

- `src/index.tsx`: in dev, mark the App import with
  `/* webpackMode: "eager" */`. App is bundled into `main.js` instead of
  being a separate runtime chunk, while `import()` keeps its Promise-returning
  semantics (so App module-tree eval still runs after the runtime-identity
  config). Production keeps the normal dynamic import.
- `webpack.config.js`: dev `devtool` switches from
  `eval-cheap-module-source-map` to `cheap-source-map` (separate lazily-loaded
  `.map` file), keeping the executable `main.js` at ~41MB with line-level
  debuggability. Cost: incremental dev rebuilds are marginally slower.

### Commit 2 — `fix(dev): await i18n before React mount to avoid store-undefined crash`

On a slow cold start the parallel init `Promise.all` loses the 10s
`Promise.race`; the rejection was swallowed and React mounted before
`i18n.init()` completed, crashing the first `useTranslation()` call on
i18next's not-yet-initialized `this.store`.

i18n is **not degradable** (App calls `useTranslation()` unconditionally at
render), so pull `i18nReady` out of the bounded race and `await` it
unconditionally after the degradable ops settle. It still starts at module
load and runs parallel to the other ops, so the await only blocks when
locale bundles are genuinely still loading. On rejection, surface the
emergency error UI instead of mounting a guaranteed-to-crash React tree.

## Production safety

- `webpackMode: "eager"` is gated behind `isDev` (compile-time). Production
  keeps the normal dynamic import.
- The `devtool` change is dev-only: `useDevSourceMaps = !isProduction && ...`,
  so production `devtool` stays `false`.
- The i18n `await` change is runtime code but correct regardless of build:
  i18n must be initialized before React renders `useTranslation()` consumers.

## Test plan

- [x] `pnpm tauri:dev` on Linux reaches the main UI (no "Initialization Failed")
- [x] First cold launch no longer crashes with `hasLanguageSomeTranslations`;
      no manual reload needed
- [x] `eslint src/index.tsx` — clean
- [x] `tsc --noEmit` — no new errors (3 pre-existing errors in
      `src/modules/ProjectManager/` are unrelated to this change)
- [ ] Reviewer: confirm `pnpm tauri:dev` on macOS is unaffected
- [ ] Reviewer: confirm production build (`pnpm tauri:build`) is unaffected

Verified on Ubuntu 22.04 / WebKitGTK. Regression range: since `e06f4b471`.
