### PR TITLE
fix(key-vault): preserve Zhipu subscription endpoint

### DIFF
--- a/src/scaffold/WizardSystem/variants/KeyVault/components/setup/ApiKeyProviderSetup.tsx
+++ b/src/scaffold/WizardSystem/variants/KeyVault/components/setup/ApiKeyProviderSetup.tsx
@@ -56,7 +56,8 @@ const ApiKeyProviderSetup: React.FC<AgentSetupProps> = ({
   const offersEndpointChoice = hasEndpointChoice(endpoints);
   const selectedEndpoint = resolveSelectedEndpoint(
     endpoints,
-    data.extracted_base_url
+    data.extracted_base_url,
+    data.selected_endpoint_id
   );
   const officialBaseUrl = getOfficialBaseUrl(
     selectedEndpoint,

--- a/src/scaffold/WizardSystem/variants/KeyVault/components/setup/GenericSetup.tsx
+++ b/src/scaffold/WizardSystem/variants/KeyVault/components/setup/GenericSetup.tsx
@@ -149,7 +149,8 @@ const GenericSetup: FC<AgentSetupProps> = ({
   const offersEndpointChoice = hasEndpointChoice(endpoints);
   const selectedEndpoint = resolveSelectedEndpoint(
     endpoints,
-    data.extracted_base_url
+    data.extracted_base_url,
+    data.selected_endpoint_id
   );
   const officialBaseUrl = getOfficialBaseUrl(
     selectedEndpoint,

--- a/src/scaffold/WizardSystem/variants/KeyVault/components/setup/ProviderEndpointSectionRow.tsx
+++ b/src/scaffold/WizardSystem/variants/KeyVault/components/setup/ProviderEndpointSectionRow.tsx
@@ -61,6 +61,7 @@ export function ProviderEndpointSectionRow({
     // Switching endpoint repoints the key at a different host, so anything
     // learned from the old one (validation, model list) no longer holds.
     onChange({
+      selected_endpoint_id: endpoint.id,
       extracted_base_url: getOfficialBaseUrl(endpoint, protocol),
       validated: false,
       available_models: [],

--- a/src/scaffold/WizardSystem/variants/KeyVault/config/providerEndpoints.test.ts
+++ b/src/scaffold/WizardSystem/variants/KeyVault/config/providerEndpoints.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import type { ProviderEndpoint } from "@src/api/tauri/rpc/schemas/validation";
+
+import { resolveSelectedEndpoint } from "./providerEndpoints";
+
+const zhipuEndpoints: ProviderEndpoint[] = [
+  {
+    id: "global",
+    label: "Global API",
+    base_url: "https://api.z.ai/api/paas/v4",
+    anthropic_base_url: "https://api.z.ai/api/anthropic",
+  },
+  {
+    id: "global-subscription",
+    label: "Global Subscription",
+    base_url: "https://api.z.ai/api/coding/paas/v4",
+    anthropic_base_url: "https://api.z.ai/api/anthropic",
+  },
+];
+
+describe("resolveSelectedEndpoint", () => {
+  it("preserves an explicit endpoint when sibling endpoints share a protocol URL", () => {
+    const selected = resolveSelectedEndpoint(
+      zhipuEndpoints,
+      "https://api.z.ai/api/anthropic",
+      "global-subscription"
+    );
+
+    expect(selected?.id).toBe("global-subscription");
+  });
+
+  it("does not let a stale endpoint id override a custom URL", () => {
+    const selected = resolveSelectedEndpoint(
+      zhipuEndpoints,
+      "https://proxy.example.com",
+      "global-subscription"
+    );
+
+    expect(selected?.id).toBe("global");
+  });
+});

--- a/src/scaffold/WizardSystem/variants/KeyVault/config/providerEndpoints.ts
+++ b/src/scaffold/WizardSystem/variants/KeyVault/config/providerEndpoints.ts
@@ -41,9 +41,26 @@ export function findEndpointByBaseUrl(
  */
 export function resolveSelectedEndpoint(
   endpoints: readonly ProviderEndpoint[],
-  baseUrl?: string | null
+  baseUrl?: string | null,
+  preferredEndpointId?: string | null
 ): ProviderEndpoint | undefined {
   if (endpoints.length === 0) return undefined;
+
+  // Prefer the explicit wizard selection when the current URL still belongs
+  // to it. This matters when sibling endpoints share a protocol URL (Zhipu's
+  // API and Subscription routes use the same Anthropic host).
+  const preferredEndpoint = preferredEndpointId
+    ? endpoints.find((endpoint) => endpoint.id === preferredEndpointId)
+    : undefined;
+  if (
+    preferredEndpoint &&
+    (!baseUrl ||
+      preferredEndpoint.base_url === baseUrl ||
+      preferredEndpoint.anthropic_base_url === baseUrl)
+  ) {
+    return preferredEndpoint;
+  }
+
   return findEndpointByBaseUrl(endpoints, baseUrl) ?? endpoints[0];
 }
 

--- a/src/scaffold/WizardSystem/variants/KeyVault/hooks/useProviderSelection.ts
+++ b/src/scaffold/WizardSystem/variants/KeyVault/hooks/useProviderSelection.ts
@@ -101,6 +101,7 @@ export function useProviderSelection({
       quota_info: undefined,
       extracted_api_key: undefined,
       extracted_base_url: undefined,
+      selected_endpoint_id: undefined,
       protocol: undefined,
       setup_method: undefined,
     });
@@ -128,6 +129,7 @@ export function useProviderSelection({
           // The setup step seeds the base URL from the provider's default
           // endpoint, so nothing is hardcoded per provider here.
           extracted_base_url: undefined,
+          selected_endpoint_id: undefined,
           protocol: selectedVariant?.defaultProtocol,
           setup_method:
             localRuntime ??

--- a/src/scaffold/WizardSystem/variants/KeyVault/types/index.ts
+++ b/src/scaffold/WizardSystem/variants/KeyVault/types/index.ts
@@ -77,6 +77,12 @@ export interface WizardData {
   /** Authentication method: "api_key" (default) or "oauth" */
   auth_method?: "api_key" | "oauth";
   protocol?: ProviderProtocol;
+  /**
+   * Transient wizard-only endpoint identity. Some providers expose distinct
+   * credential types behind the same protocol URL, so the URL alone cannot
+   * always reconstruct which endpoint card the user selected.
+   */
+  selected_endpoint_id?: string;
   // Extracted values from LLM extraction (Auto-Extract mode)
   extracted_api_key?: string;
   extracted_base_url?: string;


### PR DESCRIPTION
## Summary

- preserve the explicitly selected provider endpoint in transient wizard state
- prefer that endpoint when sibling endpoints share the current protocol URL
- clear the transient endpoint identity when changing providers
- add regression coverage for shared Zhipu Anthropic URLs and stale custom URLs

Zhipu API and Subscription credentials intentionally share the same Anthropic
base URL within each region. Keeping endpoint identity separately prevents a
Subscription selection from being reconstructed as API after a protocol
change.

Fixes #501

## Verification

- `pnpm exec vitest run src/scaffold/WizardSystem/variants/KeyVault/config/providerEndpoints.test.ts`
- ESLint on all changed files
- `pnpm typecheck`
- repository pre-commit checks
