### PR TITLE
perf(cloud): batched roster entitlements + paged session listings

### DIFF
--- a/docs/cloud-scalability-audit-2026-07-23/README.md
+++ b/docs/cloud-scalability-audit-2026-07-23/README.md
@@ -7,6 +7,8 @@ Branch: `codex/reclaim-cloud-realtime-connections` (rebased onto develop `a14bb4
 
 > **进度 2026-07-23 晚**：客户端 P0 1–5 已全部落地在本分支（`d344f3b06` 租约宽限期+hash 种子、`d5850cd40` 断连门控+评论 force+抖动+hidden outbound、`ea3344388` 全量 listing 收敛到活跃 org、`bd0b444f4` 下拉滚动条样式冲突）。服务端 P0 的 0001 就地编辑 + 线上 delta 正在起草，验证基建（disposable Postgres + A/B 协议冒烟）已就绪。
 > 另：早前的「侧栏 roster 3 vs 7」已定性为纯 UI 裁剪问题（数据管线健康），见 branch 记忆。
+>
+> **进度 2026-07-24**：服务端 P0 1–4 已通过 cloud-infra `0003_scalability_p0.sql` 上线并零漂移核验；P0 5 的事件分页由用户的 `0002_bounded_session_event_pages.sql` 覆盖。后续批 `0004_roster_and_listing_scalability.sql`（cloud-infra `a45adcd`，待线上粘贴）一次性收编：B1 批量 entitlement、C2 sessions keyset 分页、H3 collab-state 统一 cursor 分页 + tombstone GC、M1 工作项稳态编辑不再锁 project 行、M4 评论 `p_since` delta、L2 bookkeeping GC。客户端配套（entitlement 种子 + sessions/collab 分页走查，全部向后兼容 PGRST202 回落）在 PR #509。仍未动的平台级方向：Broadcast-from-Database（H4）、Storage payload 外移（H5）——各需独立迁移与客户端订阅重写；`org_change_signals` 去抖后仍是 org 内写串行点（C1 残余）。
 
 ### P0 — 客户端（本分支范围内可修）
 

--- a/src/features/Org2Cloud/org2CloudClient.test.ts
+++ b/src/features/Org2Cloud/org2CloudClient.test.ts
@@ -263,3 +263,66 @@ describe("org2_cloud RPC calls", () => {
     await expect(listOrgMembers("at-1", "org-1")).resolves.toEqual([]);
   });
 });
+
+describe("listMyOrgs batched entitlements (0004)", () => {
+  it("normalizes a roster row's entitlement payload", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([
+        {
+          orgId: "org-1",
+          name: "Acme",
+          role: "member",
+          entitlement: {
+            plan: "pro",
+            status: "active",
+            replayRetentionDays: null,
+            maxOrgMembers: 3,
+            sessionSyncEnabled: true,
+            orgSharingFloor: "metadata_only",
+          },
+        },
+      ])
+    );
+    await expect(listMyOrgs("at-1")).resolves.toEqual([
+      {
+        orgId: "org-1",
+        name: "Acme",
+        role: "member",
+        entitlement: {
+          plan: "pro",
+          status: "active",
+          maxOrgMembers: 3,
+          sessionSyncEnabled: true,
+          orgSharingFloor: "metadata_only",
+        },
+      },
+    ]);
+  });
+
+  it("keeps the org and drops only the entitlement when the payload is malformed", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([
+        {
+          orgId: "org-1",
+          name: "Acme",
+          role: "owner",
+          entitlement: { plan: 42 },
+        },
+        { orgId: "org-2", name: "Beta", role: "member", entitlement: null },
+      ])
+    );
+    await expect(listMyOrgs("at-1")).resolves.toEqual([
+      { orgId: "org-1", name: "Acme", role: "owner" },
+      { orgId: "org-2", name: "Beta", role: "member" },
+    ]);
+  });
+
+  it("parses pre-0004 rows without the entitlement key", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([{ orgId: "org-1", name: "Acme", role: "owner" }])
+    );
+    await expect(listMyOrgs("at-1")).resolves.toEqual([
+      { orgId: "org-1", name: "Acme", role: "owner" },
+    ]);
+  });
+});

--- a/src/features/Org2Cloud/org2CloudClient.ts
+++ b/src/features/Org2Cloud/org2CloudClient.ts
@@ -158,16 +158,64 @@ export async function getCloudProfile(
   };
 }
 
+const EntitlementStateWireSchema = z.object({
+  plan: z.string(),
+  status: z.string(),
+  replayRetentionDays: z.number().nullish(),
+  maxOrgMembers: z.number().nullish(),
+  sessionSyncEnabled: z.boolean().nullish(),
+  // Admin-set org sharing FLOOR (0002): the minimum access mode a member may
+  // share a session at. Absent on pre-0002 backends ⇒ treat as 'off' (no
+  // floor). An unrecognized value is dropped by the enum, degrading to 'off'.
+  orgSharingFloor: z
+    .enum([
+      COLLAB_SESSION_ACCESS_MODE.OFF,
+      COLLAB_SESSION_ACCESS_MODE.METADATA_ONLY,
+      COLLAB_SESSION_ACCESS_MODE.FULL_REPLAY,
+    ])
+    .nullish()
+    .catch(undefined),
+});
+
+export interface CloudEntitlementState {
+  plan: string;
+  status: string;
+  replayRetentionDays?: number;
+  maxOrgMembers?: number;
+  sessionSyncEnabled?: boolean;
+  /** Org sharing floor; `undefined` (absent on the wire) ⇒ 'off' / no floor. */
+  orgSharingFloor?: CollabSessionAccessMode;
+}
+
+function normalizeEntitlementWire(
+  parsed: z.infer<typeof EntitlementStateWireSchema>
+): CloudEntitlementState {
+  return {
+    plan: parsed.plan,
+    status: parsed.status,
+    replayRetentionDays: parsed.replayRetentionDays ?? undefined,
+    maxOrgMembers: parsed.maxOrgMembers ?? undefined,
+    sessionSyncEnabled: parsed.sessionSyncEnabled ?? undefined,
+    orgSharingFloor: parsed.orgSharingFloor ?? undefined,
+  };
+}
+
 const CloudOrgWireSchema = z.object({
   orgId: z.string(),
   name: z.string(),
   role: z.enum(CLOUD_ORG_ROLES),
+  // 0004 backends resolve each org's entitlement inside the roster listing;
+  // null/absent (older or degraded backends, or one failing org) falls back
+  // to the per-org RPC for exactly that org. `.catch(undefined)` keeps a
+  // malformed entitlement from failing the whole roster parse.
+  entitlement: EntitlementStateWireSchema.nullish().catch(undefined),
 });
 
 export interface CloudOrg {
   orgId: string;
   name: string;
   role: CloudOrgRole;
+  entitlement?: CloudEntitlementState;
 }
 
 const CloudOrgMemberWireSchema = z.object({
@@ -199,35 +247,6 @@ export interface CloudOrgMember {
   sharingFloor?: CollabSessionAccessMode;
 }
 
-const EntitlementStateWireSchema = z.object({
-  plan: z.string(),
-  status: z.string(),
-  replayRetentionDays: z.number().nullish(),
-  maxOrgMembers: z.number().nullish(),
-  sessionSyncEnabled: z.boolean().nullish(),
-  // Admin-set org sharing FLOOR (0002): the minimum access mode a member may
-  // share a session at. Absent on pre-0002 backends ⇒ treat as 'off' (no
-  // floor). An unrecognized value is dropped by the enum, degrading to 'off'.
-  orgSharingFloor: z
-    .enum([
-      COLLAB_SESSION_ACCESS_MODE.OFF,
-      COLLAB_SESSION_ACCESS_MODE.METADATA_ONLY,
-      COLLAB_SESSION_ACCESS_MODE.FULL_REPLAY,
-    ])
-    .nullish()
-    .catch(undefined),
-});
-
-export interface CloudEntitlementState {
-  plan: string;
-  status: string;
-  replayRetentionDays?: number;
-  maxOrgMembers?: number;
-  sessionSyncEnabled?: boolean;
-  /** Org sharing floor; `undefined` (absent on the wire) ⇒ 'off' / no floor. */
-  orgSharingFloor?: CollabSessionAccessMode;
-}
-
 /**
  * Cloud orgs the signed-in user belongs to (`list_my_orgs`). Returns `null`
  * on any failure (offline / unreachable / wire drift) and `[]` only when the
@@ -247,7 +266,14 @@ export async function listMyOrgs(
     }
     return null;
   }
-  return parsed.data;
+  return parsed.data.map(({ orgId, name, role, entitlement }) => ({
+    orgId,
+    name,
+    role,
+    ...(entitlement
+      ? { entitlement: normalizeEntitlementWire(entitlement) }
+      : {}),
+  }));
 }
 
 /** Members of a cloud org (`list_org_members`). `[]` on any failure. */
@@ -295,15 +321,7 @@ export async function getEntitlementState(
     }
     return null;
   }
-  const { plan, status, replayRetentionDays, maxOrgMembers } = parsed.data;
-  return {
-    plan,
-    status,
-    replayRetentionDays: replayRetentionDays ?? undefined,
-    maxOrgMembers: maxOrgMembers ?? undefined,
-    sessionSyncEnabled: parsed.data.sessionSyncEnabled ?? undefined,
-    orgSharingFloor: parsed.data.orgSharingFloor ?? undefined,
-  };
+  return normalizeEntitlementWire(parsed.data);
 }
 
 /**

--- a/src/features/Org2Cloud/org2CloudEntitlementCoordinator.test.ts
+++ b/src/features/Org2Cloud/org2CloudEntitlementCoordinator.test.ts
@@ -1,6 +1,8 @@
 import { createStore } from "jotai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { COLLAB_SESSION_ACCESS_MODE } from "@src/store/collaboration/types";
+
 import { org2CloudSharingFloorAtom } from "./org2CloudAccessSettings";
 import { getEntitlementState } from "./org2CloudClient";
 import {
@@ -8,6 +10,7 @@ import {
   __ENTITLEMENT_COORDINATOR_INTERNALS,
   refreshOrgEntitlement,
   resetOrgEntitlementCoordinator,
+  seedOrgEntitlement,
 } from "./org2CloudEntitlementCoordinator";
 
 vi.mock("./org2CloudClient", () => ({
@@ -124,5 +127,46 @@ describe("refreshOrgEntitlement", () => {
     resetOrgEntitlementCoordinator(store);
     await vi.advanceTimersByTimeAsync(ENTITLEMENT_REFRESH_TTL_MS * 2);
     expect(getEntitlementStateMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("seedOrgEntitlement", () => {
+  let store: ReturnType<typeof createStore>;
+  const token = async () => "jwt-1";
+
+  beforeEach(() => {
+    store = createStore();
+    store.set(org2CloudSharingFloorAtom, {});
+    getEntitlementStateMock.mockReset();
+    __ENTITLEMENT_COORDINATOR_INTERNALS.resetForStore(store);
+  });
+
+  it("writes the floor mirror without any RPC", () => {
+    seedOrgEntitlement(store, "corg-1", {
+      plan: "pro",
+      status: "active",
+      orgSharingFloor: COLLAB_SESSION_ACCESS_MODE.METADATA_ONLY,
+    });
+    expect(store.get(org2CloudSharingFloorAtom)).toEqual({
+      "corg-1": COLLAB_SESSION_ACCESS_MODE.METADATA_ONLY,
+    });
+    expect(getEntitlementStateMock).not.toHaveBeenCalled();
+  });
+
+  it("defaults a missing floor to off", () => {
+    seedOrgEntitlement(store, "corg-1", { plan: "free", status: "active" });
+    expect(store.get(org2CloudSharingFloorAtom)).toEqual({
+      "corg-1": COLLAB_SESSION_ACCESS_MODE.OFF,
+    });
+  });
+
+  it("stamps the TTL window so an immediate refresh is coalesced", async () => {
+    seedOrgEntitlement(store, "corg-1", {
+      plan: "pro",
+      status: "active",
+      orgSharingFloor: COLLAB_SESSION_ACCESS_MODE.FULL_REPLAY,
+    });
+    await refreshOrgEntitlement(store, "corg-1", token);
+    expect(getEntitlementStateMock).not.toHaveBeenCalled();
   });
 });

--- a/src/features/Org2Cloud/org2CloudEntitlementCoordinator.ts
+++ b/src/features/Org2Cloud/org2CloudEntitlementCoordinator.ts
@@ -17,6 +17,7 @@ import { createLogger } from "@src/hooks/logger";
 import { COLLAB_SESSION_ACCESS_MODE } from "@src/store/collaboration/types";
 
 import { org2CloudSharingFloorAtom } from "./org2CloudAccessSettings";
+import type { CloudEntitlementState } from "./org2CloudClient";
 import { getEntitlementState } from "./org2CloudClient";
 
 const log = createLogger("Org2CloudEntitlement");
@@ -58,6 +59,26 @@ function entryFor(store: JotaiStore, orgId: string): OrgEntitlementEntry {
     entries.set(orgId, entry);
   }
   return entry;
+}
+
+/**
+ * Commit an entitlement snapshot the ROSTER LISTING already resolved (0004
+ * backends return one per org row). This is an authoritative read for TTL
+ * purposes: stamping the window keeps a same-moment signal burst from
+ * re-reading what the roster round-trip just delivered. Backends without the
+ * batched key keep using `refreshOrgEntitlement` per org.
+ */
+export function seedOrgEntitlement(
+  store: JotaiStore,
+  orgId: string,
+  entitlement: CloudEntitlementState
+): void {
+  const entry = entryFor(store, orgId);
+  entry.lastAttemptAt = Date.now();
+  const floor = entitlement.orgSharingFloor ?? COLLAB_SESSION_ACCESS_MODE.OFF;
+  store.set(org2CloudSharingFloorAtom, (previous) =>
+    previous[orgId] === floor ? previous : { ...previous, [orgId]: floor }
+  );
 }
 
 /**

--- a/src/features/Org2Cloud/org2CloudOrgsAtom.ts
+++ b/src/features/Org2Cloud/org2CloudOrgsAtom.ts
@@ -23,14 +23,42 @@ import {
   org2CloudAuthIdentityKey,
 } from "./org2CloudAuthAtom";
 import { ensureFreshSession, listMyOrgs } from "./org2CloudClient";
-import { refreshOrgEntitlement } from "./org2CloudEntitlementCoordinator";
+import type { CloudEntitlementState } from "./org2CloudClient";
+import {
+  refreshOrgEntitlement,
+  seedOrgEntitlement,
+} from "./org2CloudEntitlementCoordinator";
 
 const log = createLogger("Org2CloudOrgs");
+
+/** Seed roster-resolved entitlements; per-org RPC only for unresolved orgs. */
+function hydrateOrgEntitlements(
+  store: ReturnType<typeof createStore>,
+  orgs: readonly Org2CloudOrg[],
+  getAccessToken: () => Promise<string | null>
+): void {
+  const unresolved: Org2CloudOrg[] = [];
+  for (const org of orgs) {
+    if (org.entitlement) {
+      seedOrgEntitlement(store, org.orgId, org.entitlement);
+    } else {
+      unresolved.push(org);
+    }
+  }
+  if (unresolved.length === 0) return;
+  void Promise.all(
+    unresolved.map((org) =>
+      refreshOrgEntitlement(store, org.orgId, getAccessToken)
+    )
+  );
+}
 
 export interface Org2CloudOrg {
   orgId: string;
   name: string;
   role: string;
+  /** Batched entitlement from a 0004 roster listing; absent ⇒ per-org RPC. */
+  entitlement?: CloudEntitlementState;
 }
 
 export interface RefetchOrg2CloudOrgsOptions {
@@ -275,15 +303,12 @@ export function useOrg2CloudOrgs(): void {
       // Best-effort: hydrate the admin sharing-FLOOR mirror (0002) for each
       // org so the per-session sync dialog — opened straight from the session
       // context menu, without ever visiting the org panel — can gate its
-      // options against the floor. Non-blocking; per-org failures (null) just
+      // options against the floor. A 0004 backend already resolved each
+      // org's entitlement inside the roster round-trip — seed those straight
+      // into the coordinator; only orgs the listing could not resolve fall
+      // back to the per-org RPC. Non-blocking; per-org failures (null) just
       // leave that org's persisted mirror untouched (server still enforces).
-      // Reads go through the shared entitlement coordinator (single-flight +
-      // TTL per org) — never a second cache owner.
-      void Promise.all(
-        orgs.map((o) =>
-          refreshOrgEntitlement(store, o.orgId, async () => fresh.accessToken)
-        )
-      );
+      hydrateOrgEntitlements(store, orgs, async () => fresh.accessToken);
     };
     void runAttempt(0);
     return () => {
@@ -343,16 +368,12 @@ export function useRefetchOrg2CloudOrgs(): (
             } else if (commitOrg2CloudOrgsRequest(store, requestEpoch, orgs)) {
               latest = orgs;
               // Entitlement hydration is enrichment, not part of roster
-              // convergence. Background per-org reads through the shared
-              // coordinator: single-flight + TTL, no second cache owner.
-              void Promise.all(
-                orgs.map((org) =>
-                  refreshOrgEntitlement(
-                    store,
-                    org.orgId,
-                    async () => fresh.accessToken
-                  )
-                )
+              // convergence. Batched 0004 payloads seed the coordinator
+              // directly; only unresolved orgs read through the per-org RPC.
+              hydrateOrgEntitlements(
+                store,
+                orgs,
+                async () => fresh.accessToken
               );
             } else {
               latest = store.get(org2CloudOrgsAtom);

--- a/src/features/Org2Cloud/org2CloudProjectsClient.test.ts
+++ b/src/features/Org2Cloud/org2CloudProjectsClient.test.ts
@@ -7,7 +7,9 @@ import {
   ORG2_CLOUD_POSTGREST_SCHEMA,
 } from "./config";
 import {
+  COLLAB_LISTING_PAGE_SIZE,
   Org2CloudProjectsError,
+  __COLLAB_LISTING_INTERNALS,
   acquireWorkItemLock,
   allocateWorkItemShortId,
   createCloudProjectSyncClient,
@@ -49,6 +51,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals();
   fetchMock.mockReset();
+  __COLLAB_LISTING_INTERNALS.resetPaginationSupport();
 });
 
 describe("org2CloudProjectsClient headers", () => {
@@ -238,7 +241,14 @@ describe("cloud_list_org_collab_state", () => {
       })
     );
     const state = await listOrgCollabState("jwt-1", "org-1");
-    expect(lastBody()).toEqual({ p_org_id: "org-1", since: null });
+    expect(lastBody()).toEqual({
+      p_org_id: "org-1",
+      since: null,
+      p_limit: COLLAB_LISTING_PAGE_SIZE,
+      p_cursor_updated_at: null,
+      p_cursor_kind: null,
+      p_cursor_id: null,
+    });
     expect(state.serverTime).toBe("2026-07-06T00:00:00.000Z");
     // The channel (and Rust apply) read the self-hosted updatedByMemberId /
     // deletedAt keys; cloud values are kept alongside them verbatim.
@@ -267,6 +277,122 @@ describe("cloud_list_org_collab_state", () => {
     });
     expect(state.projects).toEqual([]);
     expect(state.workItems).toEqual([]);
+  });
+});
+
+describe("cloud_list_org_collab_state pagination (0004)", () => {
+  it("walks keyset pages on a full listing and reunites both row kinds", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          serverTime: "2026-07-23T00:00:00.000Z",
+          projects: [{ id: "p-1", version: 1 }],
+          workItems: [{ id: "w-1", version: 1 }],
+          nextCursor: {
+            updatedAt: "2026-07-22T00:00:00.000Z",
+            kind: "workItem",
+            id: "w-1",
+          },
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          serverTime: "2026-07-23T00:00:01.000Z",
+          projects: [],
+          workItems: [{ id: "w-2", version: 3 }],
+        })
+      );
+    const state = await listOrgCollabState("jwt-1", "org-1");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(lastBody()).toEqual({
+      p_org_id: "org-1",
+      since: null,
+      p_limit: COLLAB_LISTING_PAGE_SIZE,
+      p_cursor_updated_at: "2026-07-22T00:00:00.000Z",
+      p_cursor_kind: "workItem",
+      p_cursor_id: "w-1",
+    });
+    expect(state.projects.map((row) => row.id)).toEqual(["p-1"]);
+    expect(state.workItems.map((row) => row.id)).toEqual(["w-1", "w-2"]);
+    expect(state.serverTime).toBe("2026-07-23T00:00:01.000Z");
+  });
+
+  it("falls back to the legacy call on PGRST202 and remembers the endpoint", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        jsonResponse(
+          {
+            code: "PGRST202",
+            message:
+              "Could not find the function org2_cloud.cloud_list_org_collab_state(p_cursor_id, p_cursor_kind, p_cursor_updated_at, p_limit, p_org_id, since) in the schema cache",
+          },
+          404
+        )
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ projects: [{ id: "p-1" }], workItems: [] })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ projects: [{ id: "p-1" }], workItems: [] })
+      );
+    const state = await listOrgCollabState("jwt-1", "org-1");
+    expect(state.projects.map((row) => row.id)).toEqual(["p-1"]);
+    expect(lastBody()).toEqual({ p_org_id: "org-1", since: null });
+    await listOrgCollabState("jwt-1", "org-1");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(lastBody()).toEqual({ p_org_id: "org-1", since: null });
+  });
+
+  it("keeps delta pulls single-shot with the legacy body", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ projects: [], workItems: [] })
+    );
+    await listOrgCollabState("jwt-1", "org-1", "2026-07-01T00:00:00.000Z");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(lastBody()).toEqual({
+      p_org_id: "org-1",
+      since: "2026-07-01T00:00:00.000Z",
+    });
+  });
+
+  it("treats a malformed nextCursor as the final page", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        projects: [{ id: "p-1" }],
+        workItems: [],
+        nextCursor: { updatedAt: "2026-07-22T00:00:00.000Z" },
+      })
+    );
+    const state = await listOrgCollabState("jwt-1", "org-1");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(state.projects.map((row) => row.id)).toEqual(["p-1"]);
+  });
+
+  it("stops a runaway walk at the page cap", async () => {
+    fetchMock.mockImplementation(async () =>
+      jsonResponse({
+        projects: [{ id: "p-1" }],
+        workItems: [],
+        nextCursor: {
+          updatedAt: "2026-07-22T00:00:00.000Z",
+          kind: "project",
+          id: "p-1",
+        },
+      })
+    );
+    const state = await listOrgCollabState("jwt-1", "org-1");
+    expect(fetchMock).toHaveBeenCalledTimes(50);
+    expect(state.projects).toHaveLength(50);
+  });
+
+  it("propagates a non-signature error without falling back", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ message: "ORG2_MEMBER_REQUIRED" }, 403)
+    );
+    await expect(listOrgCollabState("jwt-1", "org-1")).rejects.toSatisfy(
+      (error) => isOrg2ProjectsErrorCode(error, "ORG2_MEMBER_REQUIRED")
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/features/Org2Cloud/org2CloudProjectsClient.ts
+++ b/src/features/Org2Cloud/org2CloudProjectsClient.ts
@@ -16,8 +16,9 @@
  *   int version (the SQL parameter is `lock_payload`; the design's shorthand
  *   `lock` is a reserved SQL keyword)
  * - `cloud_release_work_item_lock(p_org_id, p_work_item_id)` → int version
- * - `cloud_list_org_collab_state(p_org_id, since)` →
- *   `{serverTime, projects, workItems}`
+ * - `cloud_list_org_collab_state(p_org_id, since[, p_limit, p_cursor_*])` →
+ *   `{serverTime, projects, workItems[, nextCursor]}` (0004 adds bounded
+ *   keyset pages over the unified `(updated_at, kind, id)` order)
  *
  * Whole-row OCC everywhere: a base-version mismatch raises `ORG2_CONFLICT`,
  * which the shared `ProjectSyncChannel` dispatches through the generalized
@@ -26,6 +27,8 @@
  * self-hosted channel + Rust bridge drive the cloud backend unchanged.
  */
 import { z } from "zod/v4";
+
+import { createLogger } from "@src/hooks/logger";
 
 import type { ProjectSyncChannelDeps } from "../TeamCollaboration/engine/ProjectSyncChannel";
 import type {
@@ -153,7 +156,36 @@ const CloudOrgCollabStateSchema = z.object({
   serverTime: z.string().optional(),
   projects: z.array(CloudCollabRowSchema).default([]),
   workItems: z.array(CloudCollabRowSchema).default([]),
+  // 0004 backends return a unified keyset cursor over the (updated_at, kind,
+  // id) total order when a bounded page has more rows; absent on legacy
+  // backends and on the final page. `.catch(undefined)` degrades a malformed
+  // cursor to "no more pages" instead of failing the whole listing parse.
+  nextCursor: z
+    .object({ updatedAt: z.string(), kind: z.string(), id: z.string() })
+    .nullish()
+    .catch(undefined),
 });
+
+const log = createLogger("Org2CloudProjectsClient");
+
+/** Rows per page for full collab listings against a 0004 backend. */
+export const COLLAB_LISTING_PAGE_SIZE = 200;
+/** Runaway guard: a full listing never walks more pages than this. */
+const COLLAB_LISTING_MAX_PAGES = 50;
+/** supabaseUrl set of backends that rejected the paged signature (pre-0004). */
+const collabPaginationUnsupportedEndpoints = new Set<string>();
+
+function isCollabPagedSignatureUnsupported(error: unknown): boolean {
+  return (
+    error instanceof Org2CloudProjectsError &&
+    error.status === 404 &&
+    /could not find the function/i.test(error.message)
+  );
+}
+
+export const __COLLAB_LISTING_INTERNALS = {
+  resetPaginationSupport: () => collabPaginationUnsupportedEndpoints.clear(),
+};
 
 /** Projects/work-items delta: rows are `payload || {version, updatedBy…, deletedAt}`. */
 export interface CloudOrgCollabState {
@@ -340,15 +372,79 @@ export async function listOrgCollabState(
   orgId: string,
   since?: string
 ): Promise<CloudOrgCollabState> {
-  const payload = await callProjectsRpc(
-    "cloud_list_org_collab_state",
-    accessToken,
-    {
-      p_org_id: orgId,
-      since: since ?? null,
+  const endpoint = getCloudEndpoint();
+  const legacyCall = async () => {
+    const payload = await callProjectsRpc(
+      "cloud_list_org_collab_state",
+      accessToken,
+      {
+        p_org_id: orgId,
+        since: since ?? null,
+      }
+    );
+    return CloudOrgCollabStateSchema.parse(payload);
+  };
+
+  let parsed: z.output<typeof CloudOrgCollabStateSchema>;
+  if (
+    since !== undefined ||
+    collabPaginationUnsupportedEndpoints.has(endpoint.supabaseUrl)
+  ) {
+    // Delta pulls stay single-shot (bounded by the cursor overlap); known
+    // pre-0004 backends keep the legacy unbounded call.
+    parsed = await legacyCall();
+  } else {
+    // Full listing: walk bounded keyset pages over the unified
+    // (updated_at, kind, id) order. Ascending order makes mid-walk writes
+    // safe — an update moves its row toward the unread tail, never behind
+    // the cursor — so the last page's serverTime anchors the delta cursor.
+    const projects: Array<Record<string, unknown>> = [];
+    const workItems: Array<Record<string, unknown>> = [];
+    let serverTime: string | undefined;
+    let cursor: { updatedAt: string; kind: string; id: string } | undefined;
+    let page = 0;
+    for (;;) {
+      let payload: unknown;
+      try {
+        payload = await callProjectsRpc(
+          "cloud_list_org_collab_state",
+          accessToken,
+          {
+            p_org_id: orgId,
+            since: null,
+            p_limit: COLLAB_LISTING_PAGE_SIZE,
+            p_cursor_updated_at: cursor?.updatedAt ?? null,
+            p_cursor_kind: cursor?.kind ?? null,
+            p_cursor_id: cursor?.id ?? null,
+          }
+        );
+      } catch (error) {
+        if (page === 0 && isCollabPagedSignatureUnsupported(error)) {
+          collabPaginationUnsupportedEndpoints.add(endpoint.supabaseUrl);
+          parsed = await legacyCall();
+          break;
+        }
+        throw error;
+      }
+      const pageParsed = CloudOrgCollabStateSchema.parse(payload);
+      projects.push(...pageParsed.projects);
+      workItems.push(...pageParsed.workItems);
+      serverTime = pageParsed.serverTime ?? serverTime;
+      cursor = pageParsed.nextCursor ?? undefined;
+      page += 1;
+      if (!cursor) {
+        parsed = { serverTime, projects, workItems };
+        break;
+      }
+      if (page >= COLLAB_LISTING_MAX_PAGES) {
+        log.warn(
+          `cloud_list_org_collab_state stopped after ${page} pages for org ${orgId}`
+        );
+        parsed = { serverTime, projects, workItems };
+        break;
+      }
     }
-  );
-  const parsed = CloudOrgCollabStateSchema.parse(payload);
+  }
   return {
     serverTime: parsed.serverTime,
     projects: parsed.projects.map(toChannelRow),

--- a/src/features/Org2Cloud/org2CloudSyncClient.test.ts
+++ b/src/features/Org2Cloud/org2CloudSyncClient.test.ts
@@ -10,6 +10,7 @@ import {
 } from "./config";
 import {
   Org2CloudSyncError,
+  __SESSION_LISTING_INTERNALS,
   appendSessionEvents,
   getOrgRepoScopes,
   getSessionEvents,
@@ -259,7 +260,13 @@ describe("cloud_list_org_sessions", () => {
       })
     );
     const result = await listOrgSessions("jwt-1", "org-1");
-    expect(lastBody()).toEqual({ p_org_id: "org-1", since: null });
+    expect(lastBody()).toEqual({
+      p_org_id: "org-1",
+      since: null,
+      p_limit: 200,
+      p_cursor_updated_at: null,
+      p_cursor_session_id: null,
+    });
     expect(result.serverTime).toBe("2026-07-04T00:00:00.000Z");
     expect(result.sessions).toHaveLength(1);
     expect(result.sessions[0].ownerDisplayName).toBe("Bea");
@@ -495,6 +502,86 @@ describe("cloud_get_session_events", () => {
       p_session_id: "s-1",
       p_after_seq: 0,
       p_limit: 64,
+    });
+  });
+});
+
+describe("cloud_list_org_sessions keyset pagination (0005)", () => {
+  const row = (sessionId: string) => ({
+    id: `org-1:u-2:${sessionId}`,
+    orgId: "org-1",
+    ownerMemberId: "u-2",
+    ownerUserId: "u-2",
+    ownerDisplayName: "Bea",
+    ownerIdentityKind: "human",
+    sourceSessionId: sessionId,
+    title: sessionId,
+  });
+
+  beforeEach(() => {
+    __SESSION_LISTING_INTERNALS.resetPaginationSupport();
+  });
+
+  it("walks pages until the cursor disappears and concatenates rows", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        serverTime: "2026-07-23T00:00:00.000Z",
+        sessions: [row("s-1"), row("s-2")],
+        nextCursor: { updatedAt: "2026-07-22T00:00:00.000Z", sessionId: "s-2" },
+      })
+    );
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        serverTime: "2026-07-23T00:00:01.000Z",
+        sessions: [row("s-3")],
+      })
+    );
+
+    const result = await listOrgSessions("jwt-1", "org-1");
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const secondBody = JSON.parse(
+      String((fetchMock.mock.calls[1] as [string, RequestInit])[1].body)
+    );
+    expect(secondBody.p_cursor_updated_at).toBe("2026-07-22T00:00:00.000Z");
+    expect(secondBody.p_cursor_session_id).toBe("s-2");
+    expect(result.sessions.map((s) => s.sourceSessionId)).toEqual([
+      "s-1",
+      "s-2",
+      "s-3",
+    ]);
+  });
+
+  it("falls back to the legacy call on a pre-0005 backend and remembers it", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse(
+        {
+          message:
+            "Could not find the function org2_cloud.cloud_list_org_sessions",
+        },
+        404
+      )
+    );
+    fetchMock.mockResolvedValueOnce(jsonResponse({ sessions: [row("s-1")] }));
+
+    const result = await listOrgSessions("jwt-1", "org-1");
+    expect(result.sessions).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(lastBody()).toEqual({ p_org_id: "org-1", since: null });
+
+    fetchMock.mockResolvedValueOnce(jsonResponse({ sessions: [] }));
+    await listOrgSessions("jwt-1", "org-1");
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(lastBody()).toEqual({ p_org_id: "org-1", since: null });
+  });
+
+  it("keeps delta pulls single-shot with the legacy body", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ sessions: [] }));
+    await listOrgSessions("jwt-1", "org-1", "2026-07-22T00:00:00.000Z");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(lastBody()).toEqual({
+      p_org_id: "org-1",
+      since: "2026-07-22T00:00:00.000Z",
     });
   });
 });

--- a/src/features/Org2Cloud/org2CloudSyncClient.ts
+++ b/src/features/Org2Cloud/org2CloudSyncClient.ts
@@ -16,6 +16,7 @@
 import { z } from "zod/v4";
 
 import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+import { createLogger } from "@src/hooks/logger";
 import { RemoteTeammateSessionMetadataSchema } from "@src/store/collaboration/protocol";
 import type {
   CollabSessionAccessMode,
@@ -200,9 +201,19 @@ const CloudOrgScopeStateSchema = z.object({
   coolingDown: z.array(CloudCoolingScopeSchema).default([]),
 });
 
+const log = createLogger("Org2CloudSyncClient");
+
 const CloudOrgSessionsSchema = z.object({
   serverTime: z.string().optional(),
   sessions: z.array(RemoteTeammateSessionMetadataSchema).default([]),
+  // 0005 backends return a keyset cursor when a bounded page has more rows;
+  // absent on legacy backends and on the final page. `.catch(undefined)`
+  // degrades a malformed cursor to "no more pages" instead of failing the
+  // whole listing parse.
+  nextCursor: z
+    .object({ updatedAt: z.string(), sessionId: z.string() })
+    .nullish()
+    .catch(undefined),
 });
 
 export interface CloudSessionEventsSnapshot {
@@ -223,6 +234,25 @@ export interface CloudOrgSessions {
   serverTime?: string;
   sessions: RemoteTeammateSessionMetadata[];
 }
+
+/** Rows per page for full listings against a 0005 backend. */
+export const SESSION_LISTING_PAGE_SIZE = 200;
+/** Runaway guard: a full listing never walks more pages than this. */
+const SESSION_LISTING_MAX_PAGES = 50;
+/** supabaseUrl set of backends that rejected the paged signature (pre-0005). */
+const paginationUnsupportedEndpoints = new Set<string>();
+
+function isPagedSignatureUnsupported(error: unknown): boolean {
+  return (
+    error instanceof Org2CloudSyncError &&
+    error.status === 404 &&
+    /could not find the function/i.test(error.message)
+  );
+}
+
+export const __SESSION_LISTING_INTERNALS = {
+  resetPaginationSupport: () => paginationUnsupportedEndpoints.clear(),
+};
 
 export type CloudOrgScopeState = z.output<typeof CloudOrgScopeStateSchema>;
 
@@ -381,18 +411,80 @@ export async function listOrgSessions(
   since?: string,
   signal?: AbortSignal
 ): Promise<CloudOrgSessions> {
-  const payload = await callSyncRpc(
-    "cloud_list_org_sessions",
-    accessToken,
-    {
-      p_org_id: orgId,
-      since: since ?? null,
-    },
-    getCloudEndpoint(),
-    signal,
-    15_000
-  );
-  const parsed = CloudOrgSessionsSchema.parse(payload);
+  const endpoint = getCloudEndpoint();
+  const legacyCall = async () => {
+    const payload = await callSyncRpc(
+      "cloud_list_org_sessions",
+      accessToken,
+      {
+        p_org_id: orgId,
+        since: since ?? null,
+      },
+      endpoint,
+      signal,
+      15_000
+    );
+    return CloudOrgSessionsSchema.parse(payload);
+  };
+
+  let parsed: z.output<typeof CloudOrgSessionsSchema>;
+  if (
+    since !== undefined ||
+    paginationUnsupportedEndpoints.has(endpoint.supabaseUrl)
+  ) {
+    // Delta pulls stay single-shot (bounded by the cursor overlap); known
+    // pre-0005 backends keep the legacy unbounded call.
+    parsed = await legacyCall();
+  } else {
+    // Full listing: walk bounded keyset pages so a large org can never push
+    // one giant aggregate through the managed statement timeout.
+    const sessions: RemoteTeammateSessionMetadata[] = [];
+    let serverTime: string | undefined;
+    let cursor: { updatedAt: string; sessionId: string } | undefined;
+    let page = 0;
+    for (;;) {
+      let payload: unknown;
+      try {
+        payload = await callSyncRpc(
+          "cloud_list_org_sessions",
+          accessToken,
+          {
+            p_org_id: orgId,
+            since: null,
+            p_limit: SESSION_LISTING_PAGE_SIZE,
+            p_cursor_updated_at: cursor?.updatedAt ?? null,
+            p_cursor_session_id: cursor?.sessionId ?? null,
+          },
+          endpoint,
+          signal,
+          15_000
+        );
+      } catch (error) {
+        if (page === 0 && isPagedSignatureUnsupported(error)) {
+          paginationUnsupportedEndpoints.add(endpoint.supabaseUrl);
+          parsed = await legacyCall();
+          break;
+        }
+        throw error;
+      }
+      const pageParsed = CloudOrgSessionsSchema.parse(payload);
+      sessions.push(...pageParsed.sessions);
+      serverTime = pageParsed.serverTime ?? serverTime;
+      cursor = pageParsed.nextCursor ?? undefined;
+      page += 1;
+      if (!cursor) {
+        parsed = { serverTime, sessions };
+        break;
+      }
+      if (page >= SESSION_LISTING_MAX_PAGES) {
+        log.warn(
+          `cloud_list_org_sessions stopped after ${page} pages for org ${orgId}`
+        );
+        parsed = { serverTime, sessions };
+        break;
+      }
+    }
+  }
   // Access-ladder normalization: the cloud column is `events_epoch integer
   // DEFAULT 0 NOT NULL`, so the wire never omits the segment summary — but
   // consumers gate replay/fork/disabled-row on `eventsEpoch === undefined`


### PR DESCRIPTION
## Summary
Client side of ORGII-cloud-infra migration `0004_roster_and_listing_scalability.sql` (one paste, all offline-validatable scalability fixes). Every path is fully backward compatible with pre-0004 backends.

**Part 1 — batched org entitlements (audit B1).** Eliminates the `get_entitlement_state × N` fan-out on every roster read (measured live: 7 extra RPCs per org activation and per coarse-signal refresh). Roster rows carrying an `entitlement` payload seed the coordinator directly (`seedOrgEntitlement`: floor mirror + TTL stamp); only unresolved rows fall back to the per-org RPC. Malformed payloads degrade via `.catch` without failing the roster parse.

**Part 2 — keyset-paged full session listings (audit C2).** Full `cloud_list_org_sessions` pulls walk `p_limit=200` keyset pages until `nextCursor` disappears, so a large org can never push one unbounded aggregate through the managed statement timeout. Delta pulls stay single-shot. A pre-0004-signature backend answers the first paged call with PGRST202; the client falls back to the legacy call and remembers per endpoint. Runaway guard at 50 pages.

**Part 3 — keyset-paged full collab-state listings (audit H3).** Same treatment for `cloud_list_org_collab_state`: full listings walk the server's unified `(updated_at, kind, id)` cursor (one cursor pages projects and work items together), delta pulls stay single-shot, PGRST202 falls back with per-endpoint memory, 50-page guard. Ascending keyset order makes mid-walk writes safe — an update moves its row toward the unread tail, never behind the cursor.

Server-only parts of 0004 with no client change needed: work-item project-lock narrowing (M1 — steady-state edits stop locking the project row), comments `p_since` delta (M4 — client adoption deferred; threads are small), service-role GC for collab tombstones and bookkeeping tables (H3/L2).

## Test plan
- `tsc` clean; full suite green (6156 tests / 684 files); 15 new Org2Cloud tests across entitlement seeding, session paging, and collab paging (multi-page walk + cursor threading, PGRST202 fallback + endpoint memory, delta single-shot body, malformed-cursor degrade, page-cap guard, non-signature error propagation).
- Server counterpart validated twice on disposable Postgres 16 (author agent + independent re-run): full 0001→0004 sequence, idempotent re-run, legacy calls byte-identical vs a 0003-only DB (collab state, comments, 6-step work-item upsert battery), paged unions equal unbounded listings, comments delta exact-set, GC horizon/live-item guards, `pg_locks`-level proof that steady-state work-item edits no longer wait on the project row.
