### PR TITLE
feat(chat): improve Enter/Escape keyboard behavior

### DIFF
--- a/src/components/ComposerInput/keyboard.ts
+++ b/src/components/ComposerInput/keyboard.ts
@@ -575,7 +575,10 @@ export function createKeyDownHandler(ctx: KeyDownHandlerContext) {
         ctx.insertNewline();
         return;
       }
-      if (!event.shiftKey) {
+      // `requireCmdEnter` is false → "send on Enter" is on. Bare Enter
+      // submits; Shift+Enter and Ctrl/Cmd+Enter both insert a newline so the
+      // user always has an explicit "insert line break" chord available.
+      if (!event.shiftKey && !event.metaKey && !event.ctrlKey) {
         event.preventDefault();
         const text = ctx.getText();
         if (text.trim()) ctx.getOnSubmit()?.(text);

--- a/src/engines/ChatPanel/InputArea/hooks/useStopOnDoubleEscape.ts
+++ b/src/engines/ChatPanel/InputArea/hooks/useStopOnDoubleEscape.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from "react";
+
+/** Window in which a second Escape must land to count as a double-press. */
+const DOUBLE_PRESS_MS = 400;
+
+/**
+ * Triggers `onStop` when the Escape key is pressed twice in quick succession
+ * while the chat turn is running. Only active while `enabled` is true.
+ *
+ * A single Escape is intentionally inert — stopping must be a deliberate
+ * double-press so a stray Escape never cancels a running turn. The listener
+ * is attached at the document level (and only while enabled) so the shortcut
+ * works whether or not the input itself is focused.
+ */
+export function useStopOnDoubleEscape(
+  enabled: boolean,
+  onStop: () => void
+): void {
+  const lastEscapeRef = useRef(0);
+  const onStopRef = useRef(onStop);
+  useEffect(() => {
+    onStopRef.current = onStop;
+  }, [onStop]);
+
+  useEffect(() => {
+    if (!enabled) {
+      lastEscapeRef.current = 0;
+      return;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      const now = Date.now();
+      if (now - lastEscapeRef.current <= DOUBLE_PRESS_MS) {
+        lastEscapeRef.current = 0;
+        event.preventDefault();
+        onStopRef.current();
+      } else {
+        lastEscapeRef.current = now;
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      lastEscapeRef.current = 0;
+    };
+  }, [enabled]);
+}

--- a/src/engines/ChatPanel/InputArea/index.tsx
+++ b/src/engines/ChatPanel/InputArea/index.tsx
@@ -36,6 +36,7 @@ import { useEditMode } from "./hooks/useEditMode";
 import { useEditorExpansion } from "./hooks/useEditorExpansion";
 import { useInputAreaMenus } from "./hooks/useInputAreaMenus";
 import { useInputAreaVoice } from "./hooks/useInputAreaVoice";
+import { useStopOnDoubleEscape } from "./hooks/useStopOnDoubleEscape";
 import { openedTabMentionOptionsAtom } from "./openedTabMentionOptionsAtom";
 
 interface InputAreaProps {
@@ -342,6 +343,10 @@ const InputAreaInteractive: React.FC<InputAreaProps> = memo(
     useEffect(() => {
       observeCompact(isCursorCompactRow);
     }, [isCursorCompactRow, observeCompact]);
+
+    // Double-press Escape to stop the running turn. Active only while a turn
+    // is running and stoppable; a single Escape is inert.
+    useStopOnDoubleEscape(isWpGeneWorking && canStopAgent, interruptSession);
 
     // Cursor IDE sessions are read-only; no interactive model/mode pill.
     const modelPill =

--- a/src/i18n/locales/de/settings.json
+++ b/src/i18n/locales/de/settings.json
@@ -145,7 +145,7 @@
     "timezoneAuto": "Automatisch (Browser)",
     "timezoneSearchPlaceholder": "Nächste Städte suchen",
     "sendOnEnter": "Nachrichten mit Enter senden",
-    "sendOnEnterDesc": "Wenn aktiviert, sendet Enter und Shift+Enter fügt eine neue Zeile ein. Wenn deaktiviert, sendet Ctrl/Cmd+Enter",
+    "sendOnEnterDesc": "Wenn aktiviert, sendet Enter; Shift+Enter und Ctrl/Cmd+Enter fügen eine neue Zeile ein. Wenn deaktiviert, sendet Ctrl/Cmd+Enter",
     "language": "Sprache",
     "languageSearchPlaceholder": "Sprachen suchen...",
     "languageNames": {
@@ -1011,7 +1011,7 @@
     "decryptEffect": "Decrypt-Effekt",
     "decryptEffectDesc": "Decrypt-Animation für Agent-Nachrichten aktivieren",
     "sendOnEnter": "Nachrichten mit Enter senden",
-    "sendOnEnterDesc": "Wenn aktiviert, sendet Enter und Shift+Enter fügt eine neue Zeile ein. Wenn deaktiviert, sendet Ctrl/Cmd+Enter"
+    "sendOnEnterDesc": "Wenn aktiviert, sendet Enter; Shift+Enter und Ctrl/Cmd+Enter fügen eine neue Zeile ein. Wenn deaktiviert, sendet Ctrl/Cmd+Enter"
   },
   "languageServers": {
     "languageServersDesc": "LSP-Server für Autovervollständigung, Diagnose und Code-Intelligenz verwalten",

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -145,7 +145,7 @@
     "timezoneAuto": "Auto (Browser)",
     "timezoneSearchPlaceholder": "Search closest cities",
     "sendOnEnter": "Send messages with Enter",
-    "sendOnEnterDesc": "When enabled, Enter sends and Shift+Enter inserts a new line. When disabled, Ctrl/Cmd+Enter sends",
+    "sendOnEnterDesc": "When enabled, Enter sends; Shift+Enter and Ctrl/Cmd+Enter insert a new line. When disabled, Ctrl/Cmd+Enter sends",
     "language": "Language",
     "languageSearchPlaceholder": "Search languages...",
     "languageNames": {
@@ -1027,7 +1027,7 @@
     "decryptEffect": "Typewriter Effect",
     "decryptEffectDesc": "Reveal Agent messages character by character",
     "sendOnEnter": "Send messages with Enter",
-    "sendOnEnterDesc": "When enabled, Enter sends and Shift+Enter inserts a new line. When disabled, Ctrl/Cmd+Enter sends"
+    "sendOnEnterDesc": "When enabled, Enter sends; Shift+Enter and Ctrl/Cmd+Enter insert a new line. When disabled, Ctrl/Cmd+Enter sends"
   },
   "languageServers": {
     "languageServersDesc": "Manage LSP servers for autocomplete, diagnostics, and code intelligence",

--- a/src/i18n/locales/es/settings.json
+++ b/src/i18n/locales/es/settings.json
@@ -145,7 +145,7 @@
     "timezoneAuto": "Auto (navegador)",
     "timezoneSearchPlaceholder": "Buscar ciudades cercanas",
     "sendOnEnter": "Enviar mensajes con Enter",
-    "sendOnEnterDesc": "Si está activado, Enter envía y Shift+Enter inserta una nueva línea. Si está desactivado, Ctrl/Cmd+Enter envía",
+    "sendOnEnterDesc": "Si está activado, Enter envía; Shift+Enter y Ctrl/Cmd+Enter insertan una nueva línea. Si está desactivado, Ctrl/Cmd+Enter envía",
     "language": "Idioma",
     "languageSearchPlaceholder": "Buscar idiomas...",
     "languageNames": {
@@ -1011,7 +1011,7 @@
     "decryptEffect": "Efecto Decrypt",
     "decryptEffectDesc": "Activar animación Decrypt para mensajes del Agent",
     "sendOnEnter": "Enviar mensajes con Enter",
-    "sendOnEnterDesc": "Si está activado, Enter envía y Shift+Enter inserta una nueva línea. Si está desactivado, Ctrl/Cmd+Enter envía"
+    "sendOnEnterDesc": "Si está activado, Enter envía; Shift+Enter y Ctrl/Cmd+Enter insertan una nueva línea. Si está desactivado, Ctrl/Cmd+Enter envía"
   },
   "languageServers": {
     "languageServersDesc": "Gestionar servidores LSP para autocompletado, diagnósticos e inteligencia de código",

--- a/src/i18n/locales/fr/settings.json
+++ b/src/i18n/locales/fr/settings.json
@@ -145,7 +145,7 @@
     "timezoneAuto": "Auto (navigateur)",
     "timezoneSearchPlaceholder": "Rechercher des villes proches",
     "sendOnEnter": "Envoyer les messages avec Entrée",
-    "sendOnEnterDesc": "Lorsque cette option est activée, Entrée envoie et Shift+Entrée insère une nouvelle ligne. Sinon, Ctrl/Cmd+Entrée envoie",
+    "sendOnEnterDesc": "Lorsque cette option est activée, Entrée envoie ; Shift+Entrée et Ctrl/Cmd+Entrée insèrent une nouvelle ligne. Sinon, Ctrl/Cmd+Entrée envoie",
     "language": "Langue",
     "languageSearchPlaceholder": "Rechercher des langues...",
     "languageNames": {
@@ -1011,7 +1011,7 @@
     "decryptEffect": "Effet Decrypt",
     "decryptEffectDesc": "Activer l'animation Decrypt pour les messages Agent",
     "sendOnEnter": "Envoyer les messages avec Entrée",
-    "sendOnEnterDesc": "Lorsque cette option est activée, Entrée envoie et Shift+Entrée insère une nouvelle ligne. Sinon, Ctrl/Cmd+Entrée envoie"
+    "sendOnEnterDesc": "Lorsque cette option est activée, Entrée envoie ; Shift+Entrée et Ctrl/Cmd+Entrée insèrent une nouvelle ligne. Sinon, Ctrl/Cmd+Entrée envoie"
   },
   "languageServers": {
     "languageServersDesc": "Gérer les serveurs LSP pour l'autocomplétion, les diagnostics et l'intelligence du code",

--- a/src/i18n/locales/ja/settings.json
+++ b/src/i18n/locales/ja/settings.json
@@ -145,7 +145,7 @@
     "timezoneAuto": "自動（ブラウザ）",
     "timezoneSearchPlaceholder": "近くの都市を検索",
     "sendOnEnter": "Enter でメッセージを送信",
-    "sendOnEnterDesc": "有効にすると Enter で送信し、Shift+Enter で改行します。無効の場合は Ctrl/Cmd+Enter で送信します",
+    "sendOnEnterDesc": "有効にすると Enter で送信し、Shift+Enter と Ctrl/Cmd+Enter で改行します。無効の場合は Ctrl/Cmd+Enter で送信します",
     "language": "言語",
     "languageSearchPlaceholder": "言語を検索...",
     "languageNames": {
@@ -1011,7 +1011,7 @@
     "decryptEffect": "Decrypt エフェクト",
     "decryptEffectDesc": "Agent メッセージに Decrypt アニメーションを有効にする",
     "sendOnEnter": "Enter でメッセージを送信",
-    "sendOnEnterDesc": "有効にすると Enter で送信し、Shift+Enter で改行します。無効の場合は Ctrl/Cmd+Enter で送信します"
+    "sendOnEnterDesc": "有効にすると Enter で送信し、Shift+Enter と Ctrl/Cmd+Enter で改行します。無効の場合は Ctrl/Cmd+Enter で送信します"
   },
   "languageServers": {
     "languageServersDesc": "オートコンプリート、診断、コードインテリジェンスのためのLSPサーバーを管理",

--- a/src/i18n/locales/ko/settings.json
+++ b/src/i18n/locales/ko/settings.json
@@ -145,7 +145,7 @@
     "timezoneAuto": "자동 (브라우저)",
     "timezoneSearchPlaceholder": "가까운 도시 검색",
     "sendOnEnter": "Enter로 메시지 보내기",
-    "sendOnEnterDesc": "활성화하면 Enter로 보내고 Shift+Enter로 줄바꿈합니다. 비활성화하면 Ctrl/Cmd+Enter로 보냅니다",
+    "sendOnEnterDesc": "활성화하면 Enter로 보내고, Shift+Enter와 Ctrl/Cmd+Enter로 줄바꿈합니다. 비활성화하면 Ctrl/Cmd+Enter로 보냅니다",
     "language": "언어",
     "languageSearchPlaceholder": "언어 검색...",
     "languageNames": {
@@ -1011,7 +1011,7 @@
     "decryptEffect": "Decrypt 효과",
     "decryptEffectDesc": "Agent 메시지에 Decrypt 애니메이션 활성화",
     "sendOnEnter": "Enter로 메시지 보내기",
-    "sendOnEnterDesc": "활성화하면 Enter로 보내고 Shift+Enter로 줄바꿈합니다. 비활성화하면 Ctrl/Cmd+Enter로 보냅니다"
+    "sendOnEnterDesc": "활성화하면 Enter로 보내고, Shift+Enter와 Ctrl/Cmd+Enter로 줄바꿈합니다. 비활성화하면 Ctrl/Cmd+Enter로 보냅니다"
   },
   "languageServers": {
     "languageServersDesc": "자동 완성, 진단 및 코드 인텔리전스를 위한 LSP 서버 관리",

--- a/src/i18n/locales/pl/settings.json
+++ b/src/i18n/locales/pl/settings.json
@@ -145,7 +145,7 @@
     "timezoneAuto": "Auto (przeglądarka)",
     "timezoneSearchPlaceholder": "Szukaj najbliższych miast",
     "sendOnEnter": "Wysyłaj wiadomości klawiszem Enter",
-    "sendOnEnterDesc": "Po włączeniu Enter wysyła, a Shift+Enter wstawia nową linię. Po wyłączeniu wysyła Ctrl/Cmd+Enter",
+    "sendOnEnterDesc": "Po włączeniu Enter wysyła, a Shift+Enter i Ctrl/Cmd+Enter wstawiają nową linię. Po wyłączeniu wysyła Ctrl/Cmd+Enter",
     "language": "Język",
     "languageSearchPlaceholder": "Szukaj języków...",
     "languageNames": {
@@ -1014,7 +1014,7 @@
     "decryptEffect": "Efekt deszyfrowania",
     "decryptEffectDesc": "Włącz animację deszyfrowania dla wiadomości Agent",
     "sendOnEnter": "Wysyłaj wiadomości klawiszem Enter",
-    "sendOnEnterDesc": "Po włączeniu Enter wysyła, a Shift+Enter wstawia nową linię. Po wyłączeniu wysyła Ctrl/Cmd+Enter"
+    "sendOnEnterDesc": "Po włączeniu Enter wysyła, a Shift+Enter i Ctrl/Cmd+Enter wstawiają nową linię. Po wyłączeniu wysyła Ctrl/Cmd+Enter"
   },
   "languageServers": {
     "languageServersDesc": "Zarządzaj serwerami LSP dla autouzupełniania, diagnostyki i inteligencji kodu",

--- a/src/i18n/locales/pt/settings.json
+++ b/src/i18n/locales/pt/settings.json
@@ -145,7 +145,7 @@
     "timezoneAuto": "Automático (Navegador)",
     "timezoneSearchPlaceholder": "Pesquisar cidades próximas",
     "sendOnEnter": "Enviar mensagens com Enter",
-    "sendOnEnterDesc": "Quando ativado, Enter envia e Shift+Enter insere uma nova linha. Quando desativado, Ctrl/Cmd+Enter envia",
+    "sendOnEnterDesc": "Quando ativado, Enter envia; Shift+Enter e Ctrl/Cmd+Enter inserem uma nova linha. Quando desativado, Ctrl/Cmd+Enter envia",
     "language": "Idioma",
     "languageSearchPlaceholder": "Pesquisar idiomas...",
     "languageNames": {
@@ -1011,7 +1011,7 @@
     "decryptEffect": "Efeito de Decriptação",
     "decryptEffectDesc": "Habilita a animação de decriptação para mensagens do Agent",
     "sendOnEnter": "Enviar mensagens com Enter",
-    "sendOnEnterDesc": "Quando ativado, Enter envia e Shift+Enter insere uma nova linha. Quando desativado, Ctrl/Cmd+Enter envia"
+    "sendOnEnterDesc": "Quando ativado, Enter envia; Shift+Enter e Ctrl/Cmd+Enter inserem uma nova linha. Quando desativado, Ctrl/Cmd+Enter envia"
   },
   "languageServers": {
     "languageServersDesc": "Gerencie LSP servers para autocompletar, diagnósticos e inteligência de código",

--- a/src/i18n/locales/ru/settings.json
+++ b/src/i18n/locales/ru/settings.json
@@ -145,7 +145,7 @@
     "timezoneAuto": "Авто (браузер)",
     "timezoneSearchPlaceholder": "Поиск ближайших городов",
     "sendOnEnter": "Отправлять сообщения клавишей Enter",
-    "sendOnEnterDesc": "Если включено, Enter отправляет, а Shift+Enter вставляет новую строку. Если выключено, отправка выполняется Ctrl/Cmd+Enter",
+    "sendOnEnterDesc": "Если включено, Enter отправляет, а Shift+Enter и Ctrl/Cmd+Enter вставляют новую строку. Если выключено, отправка выполняется Ctrl/Cmd+Enter",
     "language": "Язык",
     "languageSearchPlaceholder": "Поиск языков...",
     "languageNames": {
@@ -1011,7 +1011,7 @@
     "decryptEffect": "Эффект Decrypt",
     "decryptEffectDesc": "Включить Decrypt анимацию для сообщений Agent",
     "sendOnEnter": "Отправлять сообщения клавишей Enter",
-    "sendOnEnterDesc": "Если включено, Enter отправляет, а Shift+Enter вставляет новую строку. Если выключено, отправка выполняется Ctrl/Cmd+Enter"
+    "sendOnEnterDesc": "Если включено, Enter отправляет, а Shift+Enter и Ctrl/Cmd+Enter вставляют новую строку. Если выключено, отправка выполняется Ctrl/Cmd+Enter"
   },
   "languageServers": {
     "languageServersDesc": "Управление LSP серверами для автодополнения, диагностики и интеллекта кода",

--- a/src/i18n/locales/tr/settings.json
+++ b/src/i18n/locales/tr/settings.json
@@ -145,7 +145,7 @@
     "timezoneAuto": "Otomatik (Tarayıcı)",
     "timezoneSearchPlaceholder": "En yakın şehirleri ara",
     "sendOnEnter": "Mesajları Enter ile gönder",
-    "sendOnEnterDesc": "Etkinleştirildiğinde Enter gönderir ve Shift+Enter yeni satır ekler. Devre dışıysa Ctrl/Cmd+Enter gönderir",
+    "sendOnEnterDesc": "Etkinleştirildiğinde Enter gönderir; Shift+Enter ve Ctrl/Cmd+Enter yeni satır ekler. Devre dışıysa Ctrl/Cmd+Enter gönderir",
     "language": "Dil",
     "languageSearchPlaceholder": "Dillerde ara...",
     "languageNames": {
@@ -1011,7 +1011,7 @@
     "decryptEffect": "Decrypt Efekti",
     "decryptEffectDesc": "Agent mesajları için Decrypt animasyonunu etkinleştir",
     "sendOnEnter": "Mesajları Enter ile gönder",
-    "sendOnEnterDesc": "Etkinleştirildiğinde Enter gönderir ve Shift+Enter yeni satır ekler. Devre dışıysa Ctrl/Cmd+Enter gönderir"
+    "sendOnEnterDesc": "Etkinleştirildiğinde Enter gönderir; Shift+Enter ve Ctrl/Cmd+Enter yeni satır ekler. Devre dışıysa Ctrl/Cmd+Enter gönderir"
   },
   "languageServers": {
     "languageServersDesc": "Otomatik tamamlama, tanılama ve kod zekası için LSP sunucularını yönet",

--- a/src/i18n/locales/vi/settings.json
+++ b/src/i18n/locales/vi/settings.json
@@ -145,7 +145,7 @@
     "timezoneAuto": "Tự động (Trình duyệt)",
     "timezoneSearchPlaceholder": "Tìm kiếm thành phố gần nhất",
     "sendOnEnter": "Gửi tin nhắn bằng Enter",
-    "sendOnEnterDesc": "Khi bật, Enter gửi và Shift+Enter chèn dòng mới. Khi tắt, Ctrl/Cmd+Enter gửi",
+    "sendOnEnterDesc": "Khi bật, Enter gửi; Shift+Enter và Ctrl/Cmd+Enter chèn dòng mới. Khi tắt, Ctrl/Cmd+Enter gửi",
     "language": "Ngôn ngữ",
     "languageSearchPlaceholder": "Tìm kiếm ngôn ngữ...",
     "languageNames": {
@@ -1011,7 +1011,7 @@
     "decryptEffect": "Hiệu ứng Decrypt",
     "decryptEffectDesc": "Bật hiệu ứng Decrypt cho tin nhắn Agent",
     "sendOnEnter": "Gửi tin nhắn bằng Enter",
-    "sendOnEnterDesc": "Khi bật, Enter gửi và Shift+Enter chèn dòng mới. Khi tắt, Ctrl/Cmd+Enter gửi"
+    "sendOnEnterDesc": "Khi bật, Enter gửi; Shift+Enter và Ctrl/Cmd+Enter chèn dòng mới. Khi tắt, Ctrl/Cmd+Enter gửi"
   },
   "languageServers": {
     "languageServersDesc": "Quản lý máy chủ LSP cho tự động hoàn thành, chẩn đoán và trí tuệ mã",

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -145,7 +145,7 @@
     "timezoneAuto": "自動（瀏覽器）",
     "timezoneSearchPlaceholder": "搜索附近城市",
     "sendOnEnter": "Enter 發送消息",
-    "sendOnEnterDesc": "啟用後 Enter 發送，Shift+Enter 換行；關閉後 Ctrl/Cmd+Enter 發送",
+    "sendOnEnterDesc": "啟用後 Enter 發送，Shift+Enter 與 Ctrl/Cmd+Enter 換行；關閉後 Ctrl/Cmd+Enter 發送",
     "language": "語言",
     "languageSearchPlaceholder": "搜索語言...",
     "languageNames": {
@@ -1019,7 +1019,7 @@
     "decryptEffect": "解密效果",
     "decryptEffectDesc": "爲 Agent 消息啓用解密動畫效果",
     "sendOnEnter": "Enter 發送消息",
-    "sendOnEnterDesc": "啟用後 Enter 發送，Shift+Enter 換行；關閉後 Ctrl/Cmd+Enter 發送"
+    "sendOnEnterDesc": "啟用後 Enter 發送，Shift+Enter 與 Ctrl/Cmd+Enter 換行；關閉後 Ctrl/Cmd+Enter 發送"
   },
   "languageServers": {
     "languageServersDesc": "管理用於自動補全、診斷和代碼智能的 LSP 服務器",

--- a/src/i18n/locales/zh/settings.json
+++ b/src/i18n/locales/zh/settings.json
@@ -145,7 +145,7 @@
     "timezoneAuto": "自动（浏览器）",
     "timezoneSearchPlaceholder": "搜索附近城市",
     "sendOnEnter": "Enter 发送消息",
-    "sendOnEnterDesc": "启用后 Enter 发送，Shift+Enter 换行；关闭后 Ctrl/Cmd+Enter 发送",
+    "sendOnEnterDesc": "启用后 Enter 发送，Shift+Enter 与 Ctrl/Cmd+Enter 换行；关闭后 Ctrl/Cmd+Enter 发送",
     "language": "语言",
     "languageSearchPlaceholder": "搜索语言...",
     "languageNames": {
@@ -1027,7 +1027,7 @@
     "decryptEffect": "打字机效果",
     "decryptEffectDesc": "Agent 消息逐字显示",
     "sendOnEnter": "Enter 发送消息",
-    "sendOnEnterDesc": "启用后 Enter 发送，Shift+Enter 换行；关闭后 Ctrl/Cmd+Enter 发送"
+    "sendOnEnterDesc": "启用后 Enter 发送，Shift+Enter 与 Ctrl/Cmd+Enter 换行；关闭后 Ctrl/Cmd+Enter 发送"
   },
   "languageServers": {
     "languageServersDesc": "管理用于自动补全、诊断和代码智能的 LSP 服务器",


### PR DESCRIPTION
## Summary

Two keyboard-UX improvements for the chat composer.

### 1. Ctrl/Cmd+Enter inserts a newline when "send on Enter" is on

When the **Send messages with Enter** setting is enabled, bare `Enter` sends but `Ctrl/Cmd+Enter` also sent — leaving no explicit "insert line break" chord. Now:

| Setting | Enter | Shift+Enter | Ctrl/Cmd+Enter |
| --- | --- | --- | --- |
| **send on Enter = ON** | send | newline | **newline** (was: send) |
| **send on Enter = OFF** | newline | newline | send (unchanged) |

Fix is a one-condition change in `ComposerInput/keyboard.ts` (`sendOnEnter` path): the submit guard now also requires no `metaKey`/`ctrlKey`.

### 2. Double-press Escape to stop a running turn

While a turn is running and stoppable, pressing `Escape` **twice within ~400ms** triggers the same cancel action as the stop button (reuses the existing `interruptSession` handler). A single `Escape` is intentionally inert, so a stray key never cancels a turn. The listener is document-level and only mounted while `isWpGeneWorking && canStopAgent`.

New hook: `src/engines/ChatPanel/InputArea/hooks/useStopOnDoubleEscape.ts`, wired into `InputArea/index.tsx`.

### i18n

Updated the `sendOnEnterDesc` copy across all 13 locales to reflect the new Ctrl/Cmd+Enter behavior.

## Verification

- [x] `eslint` clean on changed files
- [x] `tsc --noEmit` clean
- [x] ComposerInput + InputArea tests pass (162 tests)

## Notes

- Does not change idle Escape behavior.
- Does not change `sendOnEnter = false` behavior.
