### PR TITLE
feat(canvas): render inline HTML canvas via sanitized Shadow DOM

### DIFF
--- a/src-tauri/crates/agent-core/src/core/tools/impls/coding/render_inline_canvas.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/coding/render_inline_canvas.rs
@@ -5,20 +5,20 @@
 //! element (A2UI) inline in the chat without requiring a separate canvas app.
 //!
 //! ## Modes
-//! - `"html"` — self-contained HTML/SVG/CSS string rendered in a sandboxed
-//!   iframe. The agent should inline all styles and scripts.
-//! - `"url"` — a URL that will be loaded inside an embedded iframe. Only
-//!   HTTPS URLs or relative paths are accepted by the frontend sandbox.
+//! - `"html"` — self-contained HTML/SVG/CSS string sanitized and rendered in
+//!   Shadow DOM. Styles are preserved; scripts and event handlers are removed.
+//! - `"url"` — an HTTPS URL or relative path presented as an external-open
+//!   action rather than embedded in chat.
 //! - `"a2ui"` — a streaming JSONL sequence of A2UI element descriptors.
 //!   Supported types: heading, text, code, image, button, divider, list,
 //!   table, chart, form. Each JSONL line is streamed incrementally to the
 //!   card as it arrives.
 //!
 //! ## Return value
-//! The tool echoes back the accepted payload as a JSON confirmation so the LLM
-//! can verify the arguments were accepted. The frontend picks up the canvas
-//! event through the `canvas-inline-event` window event pipeline — not via the
-//! tool result text.
+//! The tool returns a concise acceptance acknowledgment. It deliberately does
+//! not claim visual success because the tool execution path cannot inspect the
+//! rendered card. The frontend picks up the canvas event through the
+//! `canvas-inline-event` window event pipeline — not via the tool result text.
 
 use async_trait::async_trait;
 use serde_json::Value;
@@ -27,6 +27,18 @@ use crate::tools::names as tool_names;
 use crate::tools::traits::{Tool, ToolError};
 
 pub struct RenderInlineCanvasTool;
+
+fn format_canvas_acceptance(mode: &str, content_len: usize, title: &str, url: &str) -> String {
+    match mode {
+        "html" | "a2ui" | "react" => format!(
+            "render_inline_canvas: accepted {mode} content ({content_len} bytes), title=\"{title}\"; visual output not verified"
+        ),
+        "url" => format!(
+            "render_inline_canvas: accepted url=\"{url}\", title=\"{title}\"; visual output not verified"
+        ),
+        _ => format!("render_inline_canvas: accepted mode={mode}, title=\"{title}\""),
+    }
+}
 
 impl RenderInlineCanvasTool {
     pub fn new() -> Self {
@@ -51,8 +63,8 @@ impl Tool for RenderInlineCanvasTool {
          Use this to present data visualisations, live previews, or structured output\n\
          without leaving the conversation.\n\n\
          Modes:\n\
-         - \"html\": Render a self-contained HTML/SVG/CSS snippet. Inline all styles and\n\
-           scripts — no external CDN links (they are blocked by the sandbox).\n\
+         - \"html\": Render a self-contained HTML/SVG/CSS snippet. Inline all styles;\n\
+           scripts and event-handler attributes are removed by the sandbox.\n\
          - \"url\": Embed an HTTPS URL in an iframe. Suitable for live dashboards or\n\
            documentation pages that are safe to embed.\n\
          - \"a2ui\": Stream a sequence of typed UI elements as JSONL lines. Each line is\n\
@@ -86,7 +98,10 @@ impl Tool for RenderInlineCanvasTool {
          - Prefer \"a2ui\" for structured reports, tables, and charts — it streams incrementally.\n\
          - Prefer \"html\" only for bespoke layouts that none of the a2ui types can express.\n\
          - Keep HTML payloads under 64 KB for smooth rendering.\n\
-         - Always set a descriptive \"title\" — it appears in the card header."
+         - Always set a descriptive \"title\" — it appears in the card header.\n\
+         - A successful tool result only confirms that the payload was accepted by the UI.\n\
+           It does not prove visual correctness. Do not claim the preview was visually\n\
+           verified unless you inspected it through a screenshot or browser snapshot."
     }
 
     fn category(&self) -> &str {
@@ -180,15 +195,30 @@ impl Tool for RenderInlineCanvasTool {
             .map(|s| s.len())
             .unwrap_or(0);
 
-        Ok(match mode {
-            "html" | "a2ui" | "react" => format!(
-                "render_inline_canvas: rendered {mode} content ({content_len} bytes), title=\"{title}\""
-            ),
-            "url" => {
-                let url = params.get("url").and_then(Value::as_str).unwrap_or("");
-                format!("render_inline_canvas: embedded url=\"{url}\", title=\"{title}\"")
-            }
-            _ => format!("render_inline_canvas: accepted mode={mode}, title=\"{title}\""),
-        })
+        let url = params.get("url").and_then(Value::as_str).unwrap_or("");
+        Ok(format_canvas_acceptance(mode, content_len, title, url))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_canvas_acceptance;
+
+    #[test]
+    fn acceptance_does_not_claim_visual_success() {
+        let result = format_canvas_acceptance("html", 42, "Prototype", "");
+
+        assert!(result.contains("accepted html content"));
+        assert!(result.contains("visual output not verified"));
+        assert!(!result.contains("rendered html content"));
+    }
+
+    #[test]
+    fn url_acceptance_does_not_claim_embedding_succeeded() {
+        let result = format_canvas_acceptance("url", 0, "Docs", "https://example.com");
+
+        assert!(result.contains("accepted url=\"https://example.com\""));
+        assert!(result.contains("visual output not verified"));
+        assert!(!result.contains("embedded url"));
     }
 }

--- a/src/engines/ChatPanel/blocks/CanvasInlineCard/CanvasPreviewSurface.tsx
+++ b/src/engines/ChatPanel/blocks/CanvasInlineCard/CanvasPreviewSurface.tsx
@@ -24,40 +24,14 @@ import {
   getCanvasPreviewRenderKind,
   splitA2UIContent,
 } from "./canvasPreviewPolicy";
+import {
+  buildStaticHtmlShadowMarkup,
+  extractStaticHtmlBody,
+  extractStaticHtmlStyles,
+} from "./staticHtmlCanvas";
 
 export interface CanvasPreviewSurfaceHandle {
   evalScript: (javascript: string) => void;
-}
-
-const STATIC_HTML_STYLES = `
-  :host{display:block;height:100%;min-width:0;overflow:hidden;background:var(--color-bg-1);color:var(--color-text-1);font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:14px;line-height:1.6;}
-  *,*::before,*::after{box-sizing:border-box;}
-  a{color:var(--color-primary-6);text-decoration:none;}
-  a:hover{text-decoration:underline;}
-  pre,code{font-family:monospace;background:var(--color-fill-2);padding:2px 5px;border-radius:4px;font-size:.875em;}
-  pre{padding:12px 16px;overflow-x:auto;border-radius:6px;border:1px solid var(--color-border-1);}
-  pre code{background:none;padding:0;}
-  img{max-width:100%;height:auto;border-radius:4px;}
-  ::-webkit-scrollbar{width:6px;height:6px;}
-  ::-webkit-scrollbar-track{background:transparent;}
-  ::-webkit-scrollbar-thumb{background:var(--color-fill-4);border-radius:3px;}
-`;
-
-const STATIC_HTML_CONTAINMENT_STYLES = `
-  :host{contain:layout paint style;isolation:isolate;}
-  .canvas-static-html{position:relative;height:100%;min-width:0;max-width:100%;overflow:auto;contain:layout paint style;isolation:isolate;}
-  .canvas-static-html *{max-width:100%;}
-`;
-
-function extractStaticHtmlBody(content: string): string {
-  const bodyMatch = content.match(/<body\b[^>]*>([\s\S]*?)<\/body>/i);
-  return bodyMatch?.[1] ?? content;
-}
-
-function extractStaticHtmlStyles(content: string): string {
-  return Array.from(content.matchAll(/<style\b[^>]*>([\s\S]*?)<\/style>/gi))
-    .map((match) => match[1].replace(/<\/style/gi, ""))
-    .join("\n");
 }
 
 const StaticHtmlCanvas: React.FC<{ content: string }> = ({ content }) => {
@@ -83,7 +57,7 @@ const StaticHtmlCanvas: React.FC<{ content: string }> = ({ content }) => {
     const host = hostRef.current;
     if (!host) return;
     const root = host.shadowRoot ?? host.attachShadow({ mode: "open" });
-    root.innerHTML = `<style>${STATIC_HTML_STYLES}</style><style>${styles}</style><style>${STATIC_HTML_CONTAINMENT_STYLES}</style><div class="canvas-static-html">${safeContent}</div>`;
+    root.innerHTML = buildStaticHtmlShadowMarkup(safeContent, styles);
   }, [safeContent, styles]);
 
   return (

--- a/src/engines/ChatPanel/blocks/CanvasInlineCard/staticHtmlCanvas.test.ts
+++ b/src/engines/ChatPanel/blocks/CanvasInlineCard/staticHtmlCanvas.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { IFRAME_STYLE_NONCE } from "@src/util/iframeCspNonce";
+
+import {
+  buildStaticHtmlShadowMarkup,
+  extractStaticHtmlBody,
+  extractStaticHtmlStyles,
+} from "./staticHtmlCanvas";
+
+describe("static HTML canvas", () => {
+  it("extracts styles separately from a full HTML document", () => {
+    const content = `<!doctype html><html><head><style>.app{display:grid;background:red}</style></head><body><div class="app">Styled</div></body></html>`;
+
+    expect(extractStaticHtmlStyles(content)).toBe(
+      ".app{display:grid;background:red}"
+    );
+    expect(extractStaticHtmlBody(content)).toBe(
+      '<div class="app">Styled</div>'
+    );
+  });
+
+  it("nonces every Shadow DOM style block for the Tauri WebKit CSP", () => {
+    const markup = buildStaticHtmlShadowMarkup(
+      '<div class="app">Styled</div>',
+      ".app{display:grid;background:red}"
+    );
+    const styleTags = markup.match(/<style\b[^>]*>/g) ?? [];
+
+    expect(styleTags).toHaveLength(3);
+    for (const styleTag of styleTags) {
+      expect(styleTag).toContain(`nonce="${IFRAME_STYLE_NONCE}"`);
+    }
+    expect(markup).toContain(".app{display:grid;background:red}");
+    expect(markup).toContain('<div class="app">Styled</div>');
+  });
+
+  it("neutralizes style terminators before building Shadow DOM markup", () => {
+    const styles = extractStaticHtmlStyles(
+      "<style>.safe{}<\\/style>.also-safe{}</style>"
+    );
+    const markup = buildStaticHtmlShadowMarkup("<div>Safe</div>", styles);
+
+    expect(markup.match(/<style\b[^>]*>/g)).toHaveLength(3);
+    expect(markup).not.toMatch(/<\/style[^>]*>\.also-safe/);
+  });
+});

--- a/src/engines/ChatPanel/blocks/CanvasInlineCard/staticHtmlCanvas.ts
+++ b/src/engines/ChatPanel/blocks/CanvasInlineCard/staticHtmlCanvas.ts
@@ -1,0 +1,49 @@
+import { IFRAME_STYLE_NONCE } from "@src/util/iframeCspNonce";
+
+export const STATIC_HTML_STYLES = `
+  :host{display:block;height:100%;min-width:0;overflow:hidden;background:var(--color-bg-1);color:var(--color-text-1);font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:14px;line-height:1.6;}
+  *,*::before,*::after{box-sizing:border-box;}
+  a{color:var(--color-primary-6);text-decoration:none;}
+  a:hover{text-decoration:underline;}
+  pre,code{font-family:monospace;background:var(--color-fill-2);padding:2px 5px;border-radius:4px;font-size:.875em;}
+  pre{padding:12px 16px;overflow-x:auto;border-radius:6px;border:1px solid var(--color-border-1);}
+  pre code{background:none;padding:0;}
+  img{max-width:100%;height:auto;border-radius:4px;}
+  ::-webkit-scrollbar{width:6px;height:6px;}
+  ::-webkit-scrollbar-track{background:transparent;}
+  ::-webkit-scrollbar-thumb{background:var(--color-fill-4);border-radius:3px;}
+`;
+
+export const STATIC_HTML_CONTAINMENT_STYLES = `
+  :host{contain:layout paint style;isolation:isolate;}
+  .canvas-static-html{position:relative;height:100%;min-width:0;max-width:100%;overflow:auto;contain:layout paint style;isolation:isolate;}
+  .canvas-static-html *{max-width:100%;}
+`;
+
+export function extractStaticHtmlBody(content: string): string {
+  const bodyMatch = content.match(/<body\b[^>]*>([\s\S]*?)<\/body>/i);
+  return bodyMatch?.[1] ?? content;
+}
+
+export function extractStaticHtmlStyles(content: string): string {
+  return Array.from(content.matchAll(/<style\b[^>]*>([\s\S]*?)<\/style>/gi))
+    .map((match) => match[1].replace(/<\/style/gi, ""))
+    .join("\n");
+}
+
+/**
+ * Build the Shadow DOM tree used by static HTML canvases.
+ *
+ * WKWebView applies the parent Tauri CSP to styles created through
+ * `shadowRoot.innerHTML`. Because the policy contains a nonce source, every
+ * style block must carry the canonical nonce or WebKit silently discards it.
+ */
+export function buildStaticHtmlShadowMarkup(
+  safeContent: string,
+  styles: string
+): string {
+  const styleTag = (css: string) =>
+    `<style nonce="${IFRAME_STYLE_NONCE}">${css}</style>`;
+
+  return `${styleTag(STATIC_HTML_STYLES)}${styleTag(styles)}${styleTag(STATIC_HTML_CONTAINMENT_STYLES)}<div class="canvas-static-html">${safeContent}</div>`;
+}


### PR DESCRIPTION
## Summary
- Replace the inline HTML canvas's sandboxed-iframe path with a sanitized **Shadow DOM** renderer (`staticHtmlCanvas`): styles preserved, `<script>` and event-handler attributes stripped. `url` mode becomes an external-open action instead of being embedded in chat.
- `render_inline_canvas` tool now returns an honest acceptance acknowledgment ("accepted ...; visual output not verified") rather than claiming it rendered — the tool path cannot inspect the card.

## Test plan
- [x] `tsc --noEmit` and `cargo clippy -p agent_core` pass (pre-commit hook).
- [ ] `pnpm vitest run` for `staticHtmlCanvas.test.ts`; `cargo test -p agent_core` for the acceptance-message tests.
- [ ] Manual: render an HTML canvas card — confirm styles apply, scripts do not execute, and `url` mode shows an external-open action.

Based on latest `develop`.