### PR TITLE
perf(ingest): snapshot discovery, zombie-proof freezing, cursor re-anchor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,8 @@ data.json
 !.orgii/skills/org2-performance-guard/**
 !.orgii/skills/react-best-practices/
 !.orgii/skills/react-best-practices/**
+!.orgii/skills/dual-instance-verification/
+!.orgii/skills/dual-instance-verification/**
 .soyd/
 
 # macOS copy-conflict duplicates (e.g. "file 2.rs", "file 3.rs")

--- a/.orgii/skills/dual-instance-verification/SKILL.md
+++ b/.orgii/skills/dual-instance-verification/SKILL.md
@@ -141,6 +141,15 @@ rollover or the window silently truncates.
   row (GitHub rename made two spellings one repo network), and the fork guard
   demanded snapshot == summary while a LIVE source kept growing — equality
   checks against a moving target are boot-window absence in another costume.
+- **Waiting for a pass the engine will never run**: the session plane follows
+  visible-org demand — an org's push/retract pass runs only while that org is
+  the active workspace. A fix whose cleanup rides "the next pass" looks
+  broken for any org you are not looking at. Per-org verification must OPEN
+  the org (switch the workspace to it) as the trigger, and cleanup claims
+  must name which orgs were actually visited. Corollary: rows pushed in an
+  earlier install/test cycle may have no surviving local push-state, and the
+  client rightly refuses to retract what it cannot prove it pushed — those
+  need a server-side fixture sweep, not more waiting.
 
 ## When NOT to use
 

--- a/.orgii/skills/dual-instance-verification/SKILL.md
+++ b/.orgii/skills/dual-instance-verification/SKILL.md
@@ -105,6 +105,20 @@ rollover or the window silently truncates.
   floors to metadata_only and nobody errors. Assert access_mode on the wire.
 - **Self-healing hiding lost signals**: watchdog-forced completion masked every
   lost agent:complete. Assert latency, treat watchdog as failure.
+- **A guard upstream of every probe**: the subagent bridge swallowed fork
+  terminals before any instrumented drop point ran, so nine instrumented
+  builds all stayed silent. When probes disagree with the symptom, suspect the
+  model of WHERE the loss happens, not a missed branch — walk the call path
+  from its first line, not from the suspected failure.
+- **Format drift on a shared field**: `Session.orgId` is a scope selector
+  (`cloud:<uuid>`); fork/import wrote a bare uuid, silently removing every
+  ownership-derived affordance. When one writer of a shared field disagrees
+  with the rest, diff the live values across rows — the odd one out is the
+  bug.
+- **Tests that encode the bug**: the two specs guarding the ownership stamp
+  asserted the bare form, comment included. Green tests are not evidence the
+  convention is right; check a spec's expectation against the consumers before
+  trusting it.
 
 ## When NOT to use
 

--- a/.orgii/skills/dual-instance-verification/SKILL.md
+++ b/.orgii/skills/dual-instance-verification/SKILL.md
@@ -119,6 +119,14 @@ rollover or the window silently truncates.
   asserted the bare form, comment included. Green tests are not evidence the
   convention is right; check a spec's expectation against the consumers before
   trusting it.
+- **Fixture writes that silently failed**: a direct PATCH on a
+  write-hardened table (403 — governance requires the admin RPC) surfaced as
+  an empty response body, was read as success, and a whole debugging night ran
+  on the false premise that the scope existed server-side. Every mutation of
+  test-environment cloud state MUST be followed by a read-back of the same
+  row (compare `updated_at`, not just the field). A stale local mirror is not
+  server truth either — when a UI decision depends on mirrored state, diff
+  mirror vs server before blaming the consumer code.
 
 ## When NOT to use
 

--- a/.orgii/skills/dual-instance-verification/SKILL.md
+++ b/.orgii/skills/dual-instance-verification/SKILL.md
@@ -127,6 +127,20 @@ rollover or the window silently truncates.
   row (compare `updated_at`, not just the field). A stale local mirror is not
   server truth either — when a UI decision depends on mirrored state, diff
   mirror vs server before blaming the consumer code.
+- **The running binary lags the fix**: the "verified" build predated the
+  final commit of the file under test; every on-device probe for 40 minutes
+  exercised stale code. Before declaring an on-device verdict, compare the
+  bundle mtime against the fix file's mtime — an edit made after the last
+  build is not on the device, no matter how green the tests are.
+- **A feature unreachable from the surface it was designed for**: Address
+  Comments' run path is fork-first BY DESIGN for imported histories, but that
+  composer mounts session-scope "none", and every consumer in the chain
+  (slash registry, submit interceptor) re-resolved the blank id and silently
+  no-opped. Reachability must be verified from the surface the design names.
+  Same family: candidate ordering picked a scope-matching org with no server
+  row (GitHub rename made two spellings one repo network), and the fork guard
+  demanded snapshot == summary while a LIVE source kept growing — equality
+  checks against a moving target are boot-window absence in another costume.
 
 ## When NOT to use
 

--- a/.orgii/skills/dual-instance-verification/SKILL.md
+++ b/.orgii/skills/dual-instance-verification/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: dual-instance-verification
+description: Dual-instance (双机) real-machine verification protocol for ORG2 cloud sync and session sharing. Use before declaring any sharing/sync/collab feature or fix "verified": share/unshare, push/retract, fork/import, comments, member-floor, replay, continuation, or anything touching Org2CloudSyncEngine, collab engines, or the session channel pipeline. Also use when a sharing bug escaped earlier testing, to check which discipline below was skipped.
+---
+
+# Dual-Instance Verification (双机实测)
+
+Real-machine verification of session sharing across ORG2 (primary, Neonforge) and
+ORG2 Instance 2 (VantaNode). Born from a four-bug escape on 2026-07-24 where every
+bug passed the old three-piece check (resource curves + feature signals +
+WARN/ERROR delta). The disciplines below exist because each one, applied that day,
+would have caught at least one escaped bug.
+
+## Core principle
+
+**Assert invariants, not absence of errors.** A scenario passes only when the
+positive end-state is proven on THREE surfaces — sender instance, receiver
+instance, and the cloud rows — and every state mutation in between is explainable.
+
+## Non-negotiables
+
+1. **Cloud ground-truth ledger.** Snapshot the org's `cloud_sessions` (session_id,
+   deleted_at, access_mode, events_count, events_frozen_seq, stored_bytes) BEFORE
+   and AFTER every scenario, via service key. Diff must be explainable
+   line-by-line. Any unexplained `deleted_at`, access_mode downgrade, or
+   events_count drop is a FAILURE even if the UI looks fine.
+   (Would have caught: vanished-sweep mass retract, boot out-of-scope retract.)
+
+2. **Destructive-verb audit at INFO level.** After each scenario AND after each
+   app boot, grep both instances' frontend+backend logs for
+   `retract|untag|drop|delete|demote|evict|vanish|superseded` at ALL levels, not
+   just WARN/ERROR. Every hit needs a justification. Destructive actions wearing
+   legitimate INFO wording are exactly how retract bugs hid.
+
+3. **Lifecycle-boundary cells are mandatory.** The matrix is feature ×
+   lifecycle-event, not feature × instance. For every sharing feature, run at
+   minimum these transition cells:
+   - **Cold boot**: relaunch each instance, then audit the FIRST 3 sync passes'
+     cloud mutations (ledger diff + verb audit). Boot-window races (empty scope
+     mirror, unrefreshed token, rebuilding cache) must never be treated as
+     authoritative absence.
+   - **/compact mid-share**: continue a shared session into a continuation
+     sibling; the cloud row must survive (not retract) and sharing must carry on.
+   - **Cache wipe/rebuild**: wipe imported-history cache, boot, confirm zero
+     retracts during rebuild (two-strike must defer).
+   - **Fork-on-write**: owner-side AND guest-side, with a real (small) agent run.
+     Assert the fork's cloud row access_mode equals the inherited level, events
+     and frozen segments actually land, and the receiver can OPEN the replay
+     (bright row + content renders). "Row appears in the list" is NOT success —
+     a metadata-only ghost also appears.
+
+4. **Watchdog/fallback fires are test failures.** Any
+   `usePlanningIndicator watchdog`, dead-man, forced-idle, or retry-exhausted
+   line during a scenario fails that scenario, even though the UI self-heals.
+   Self-healing masks the bug it recovers from. Turn-completion latency must be
+   asserted: terminal reaches the UI within 5s of Rust `state=Completed`.
+
+5. **Receiver-depth assertions.** On the receiving instance: open the shared/fork
+   row, confirm content renders, and for replay confirm the latest round matches
+   the sender's last round verbatim. Grayed-out rows must be explained by an
+   asserted access mode, never shrugged off.
+
+6. **Both directions.** Each cell runs A→B and B→A where roles permit. Guest-side
+   limitations (e.g. no API key on inst2) mean the cell moves to the other
+   instance, not that it gets skipped. If a cell is skipped for cost, record it as
+   UNCOVERED in the delivery message — the 2026-07-24 fork bugs lived in exactly
+   such a silently skipped cell.
+
+7. **Silent early-returns need a diagnostic.** When touching sync/channel/handler
+   code: any `return` that swallows a lifecycle-relevant frame or skips a push
+   must have a rate-limited log. The four-bug escape survived five instrumentation
+   builds only because `bus dispatch`, `waitForSessionChannelReady`,
+   `routeSessionChannelEvent`, `handleEvent(_disposed)`, and the runtime-status
+   gate all dropped silently. Those five now log; keep that bar for new code.
+
+8. **Resource three-piece stays.** cmd+5/Activity Monitor curves (idle ≈0%,
+   RSS returns to baseline), feature signals, and WARN/ERROR delta with each new
+   line triaged. This skill ADDS to it; it does not replace it.
+
+## Ledger commands
+
+Service key lives in `tests/e2e/.env` (machine-local). Snapshot:
+
+```bash
+set -a; source tests/e2e/.env; set +a
+curl -s "$E2E_CLOUD_SUPABASE_URL/rest/v1/cloud_sessions?org_id=eq.<ORG>&select=session_id,deleted_at,access_mode,events_count,events_frozen_seq,stored_bytes,updated_at&order=session_id" \
+  -H "apikey: $E2E_CLOUD_SERVICE_KEY" -H "Authorization: Bearer $E2E_CLOUD_SERVICE_KEY" \
+  -H "Accept-Profile: org2_cloud"
+```
+
+Diff the before/after JSON; explain every changed row. Logs live at
+`~/.orgii/logs/` and `~/.orgii-instance2/logs/` — backend files are UTC-dated and
+UTC-stamped, frontend files local-stamped; sweep BOTH around the UTC midnight
+rollover or the window silently truncates.
+
+## Failure taxonomy (what escaped and why — keep this list growing)
+
+- **Boot-window absence treated as authority**: empty scope mirror / rebuilding
+  cache / unrefreshed token read as "gone" → retract. Guard: grace period or
+  two-strike before any destructive act on boot-adjacent passes.
+- **Continuation demotion read as deletion**: /compact demotes the old sibling;
+  exact-id lookups report it absent by design; sweeps must use the
+  superseded-inclusive lookup.
+- **Defaults silently degrading shares**: a fork with no sharing-ladder entry
+  floors to metadata_only and nobody errors. Assert access_mode on the wire.
+- **Self-healing hiding lost signals**: watchdog-forced completion masked every
+  lost agent:complete. Assert latency, treat watchdog as failure.
+
+## When NOT to use
+
+Pure UI styling/copy changes, single-file bug fixes with no sync surface, and
+Rust-only refactors covered by unit tests that touch no cloud or channel path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ This is **advisory**, not a hard contract. Use judgment based on PR size and ris
 | React performance, re-renders, async waterfalls, bundle size, heavy dependencies, virtualization, high-frequency events    | `react-best-practices`              | For performance-focused React implementation/review; not for routine styling, copy, or single-file bug fixes without a performance concern    |
 | Both architecture and React performance change together                                                                    | Run both, keep findings categorized | Apply `architecture-audit` to ownership/boundaries and `react-best-practices` to measured React runtime concerns                              |
 | E2E test surface (Playwright / WebDriver), test stability                                                                  | `e2e-testing`                       | When adding or repairing rendered E2E specs                                                                                                   |
+| Cloud sync / session sharing / collab correctness (share, push/retract, fork, replay, comments, continuation)              | `dual-instance-verification`        | Before declaring any sharing/sync change "verified"; when a sharing bug escaped earlier testing                                               |
 
 Skills live at:
 
@@ -25,6 +26,7 @@ Skills live at:
 - `.orgii/skills/architecture-audit/SKILL.md` (workspace copy, if present)
 - `.orgii/skills/react-best-practices/SKILL.md` (workspace; ORGII overlay for Vercel's React guidance)
 - `.orgii/skills/e2e-testing/SKILL.md` (workspace)
+- `.orgii/skills/dual-instance-verification/SKILL.md` (workspace; 双机实测 protocol for cloud sync / sharing)
 
 If the skill block isn't already prefetched in your context, read its `SKILL.md` before acting on it.
 

--- a/src-tauri/crates/orgtrack-core/src/sources/claude_code/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/claude_code/history.rs
@@ -20,7 +20,7 @@ use crate::sources::imported_history::{
         ImportedHistoryCacheInput, ImportedHistoryDiscoveredRecord, ImportedHistoryImpactStats,
         RoundUsage, StoredRoundUsage, SOURCE_CLAUDE_CODE,
     },
-    paths as imported_paths,
+    paths as imported_paths, scan_snapshot,
     watermark::{ImportedParseWatermark, WatermarkedTranscriptReader},
     ImportedHistoryRecentPath, ImportedHistorySessionPage, ImportedHistorySessionRow,
     ImportedToolCall,
@@ -214,7 +214,21 @@ pub fn stat_claude_code_history_for_session(
 }
 
 fn sync_claude_code_history_cache(conn: &mut Connection) -> Result<(), String> {
-    let mut discovered = discover_claude_code_history_records()?;
+    let previous_snapshots =
+        scan_snapshot::read_dir_snapshots_from_conn(conn, SOURCE_CLAUDE_CODE);
+    let mut walker = scan_snapshot::SnapshotDirWalker::new(&previous_snapshots, "jsonl", "Claude");
+    let discovery = discover_claude_code_history_records(&claude_projects_dirs()?, &mut walker)?;
+    let next_snapshots = walker.into_snapshots();
+    scan_snapshot::persist_dir_snapshots_if_changed(
+        conn,
+        SOURCE_CLAUDE_CODE,
+        &previous_snapshots,
+        &next_snapshots,
+    )?;
+    let ClaudeCodeDiscovery {
+        records: mut discovered,
+        external_titles,
+    } = discovery;
     // Managed (GUI-launched) sessions surface through their code_sessions
     // row; the imported twin goes unlistable. Folding the verdict into the
     // fingerprint re-parses a session whose managed status flips.
@@ -248,7 +262,12 @@ fn sync_claude_code_history_cache(conn: &mut Connection) -> Result<(), String> {
             SOURCE_CLAUDE_CODE,
             &record.source_session_id,
         )?;
-        let parse = parse_claude_session_meta_incremental(record, stored_watermark.as_ref())?;
+        let external_title = external_titles
+            .get(&record.source_session_id)
+            .cloned()
+            .unwrap_or_default();
+        let parse =
+            parse_claude_session_meta_with_title(record, stored_watermark.as_ref(), external_title)?;
         imported_history::watermark::write_parse_watermark_from_conn(
             conn,
             SOURCE_CLAUDE_CODE,
@@ -278,29 +297,77 @@ fn sync_claude_code_history_cache(conn: &mut Connection) -> Result<(), String> {
     Ok(())
 }
 
-fn discover_claude_code_history_records() -> Result<Vec<ImportedHistoryDiscoveredRecord>, String> {
+#[derive(Debug)]
+struct ClaudeCodeDiscovery {
+    records: Vec<ImportedHistoryDiscoveredRecord>,
+    external_titles: HashMap<String, String>,
+}
+
+fn discover_claude_code_history_records(
+    projects_dirs: &[PathBuf],
+    walker: &mut scan_snapshot::SnapshotDirWalker<'_>,
+) -> Result<ClaudeCodeDiscovery, String> {
     let mut records = Vec::new();
-    for projects_dir in claude_projects_dirs()? {
-        if projects_dir.is_dir() {
-            let title_index = load_claude_session_titles_for_projects_dir(&projects_dir)?;
-            let mut files = Vec::new();
-            collect_claude_session_files(&projects_dir, &mut files)?;
-            for file in files {
-                let (source_mtime_ms, source_size_bytes) =
-                    imported_paths::file_metadata_signature(&file.path, "Claude")?;
-                records.push(ImportedHistoryDiscoveredRecord {
-                    source_session_id: file.file_stem.clone(),
-                    source_path: file.path,
-                    source_record_key: file.file_stem.clone(),
-                    source_mtime_ms,
-                    source_size_bytes,
-                    source_fingerprint: claude_source_fingerprint(&file.file_stem, &title_index),
-                    parser_version: CLAUDE_CODE_METADATA_PARSER_VERSION,
-                });
+    let mut external_titles = HashMap::new();
+    for projects_dir in projects_dirs {
+        if !projects_dir.is_dir() {
+            continue;
+        }
+        let title_index = load_claude_session_titles_for_projects_dir(projects_dir)?;
+        let mut paths = Vec::new();
+        walker.collect_files(projects_dir, &mut paths)?;
+        for path in paths {
+            if is_claude_workflow_journal_path(&path) {
+                continue;
             }
+            let Some(file_stem) = path
+                .file_stem()
+                .and_then(|value| value.to_str())
+                .map(str::to_string)
+            else {
+                continue;
+            };
+            let (source_mtime_ms, source_size_bytes) =
+                imported_paths::file_metadata_signature(&path, "Claude")?;
+            if let Some(title) = title_index.get(&file_stem) {
+                external_titles.insert(
+                    file_stem.clone(),
+                    imported_history::truncate_name(&title.name, 200),
+                );
+            }
+            records.push(ImportedHistoryDiscoveredRecord {
+                source_session_id: file_stem.clone(),
+                source_path: path,
+                source_record_key: file_stem.clone(),
+                source_mtime_ms,
+                source_size_bytes,
+                source_fingerprint: claude_source_fingerprint(&file_stem, &title_index),
+                parser_version: CLAUDE_CODE_METADATA_PARSER_VERSION,
+            });
         }
     }
-    Ok(records)
+    Ok(ClaudeCodeDiscovery {
+        records,
+        external_titles,
+    })
+}
+
+/// `<uuid>/subagents/workflows/wf_*/journal.jsonl` files are workflow event
+/// journals, not session transcripts. Their shared `journal` stem collides
+/// into one cache row that every sync pass re-upserts, so they are excluded
+/// at discovery. Workflow `agent-*.jsonl` files in the same tree ARE real
+/// sidechain transcripts and stay included.
+fn is_claude_workflow_journal_path(path: &Path) -> bool {
+    if path.file_stem().and_then(|value| value.to_str()) != Some("journal") {
+        return false;
+    }
+    let components = path
+        .components()
+        .filter_map(|component| component.as_os_str().to_str())
+        .collect::<Vec<_>>();
+    components
+        .windows(2)
+        .any(|pair| pair == ["subagents", "workflows"])
 }
 
 fn collect_claude_session_files(
@@ -316,6 +383,9 @@ fn collect_claude_session_files(
             .extension()
             .is_some_and(|extension| extension == "jsonl")
         {
+            if is_claude_workflow_journal_path(&path) {
+                continue;
+            }
             let Some(file_stem) = path.file_stem().and_then(|value| value.to_str()) else {
                 continue;
             };
@@ -396,6 +466,7 @@ fn claude_source_fingerprint(
         .unwrap_or_default()
 }
 
+#[cfg(test)]
 fn claude_session_title_for_record(
     record: &ImportedHistoryDiscoveredRecord,
 ) -> Result<String, String> {
@@ -409,6 +480,7 @@ fn claude_session_title_for_record(
         .unwrap_or_default())
 }
 
+#[cfg(test)]
 fn claude_sessions_dir_for_session_path(session_path: &Path) -> Option<PathBuf> {
     session_path.ancestors().find_map(|ancestor| {
         if ancestor.file_name().and_then(|name| name.to_str()) == Some("projects") {
@@ -684,9 +756,10 @@ struct ClaudeSessionMetaParse {
     resumed: bool,
 }
 
-fn parse_claude_session_meta_incremental(
+fn parse_claude_session_meta_with_title(
     record: &ImportedHistoryDiscoveredRecord,
     watermark: Option<&ImportedParseWatermark>,
+    external_title: String,
 ) -> Result<ClaudeSessionMetaParse, String> {
     let mut reader = WatermarkedTranscriptReader::open(
         &record.source_path,
@@ -730,7 +803,6 @@ fn parse_claude_session_meta_incremental(
             tail_state = Some(snapshot);
         }
     }
-    let external_title = claude_session_title_for_record(record)?;
     let state_json = serde_json::to_string(&state)
         .map_err(|err| format!("Failed to serialize Claude parse state: {err}"))?;
     let next_watermark = reader.into_watermark(
@@ -745,6 +817,15 @@ fn parse_claude_session_meta_incremental(
         watermark: next_watermark,
         resumed,
     })
+}
+
+#[cfg(test)]
+fn parse_claude_session_meta_incremental(
+    record: &ImportedHistoryDiscoveredRecord,
+    watermark: Option<&ImportedParseWatermark>,
+) -> Result<ClaudeSessionMetaParse, String> {
+    let external_title = claude_session_title_for_record(record)?;
+    parse_claude_session_meta_with_title(record, watermark, external_title)
 }
 
 #[cfg(test)]

--- a/src-tauri/crates/orgtrack-core/src/sources/claude_code/history_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/claude_code/history_tests.rs
@@ -747,3 +747,235 @@ fn resumes_claude_meta_parse_from_watermark() {
     std::fs::remove_file(&path).expect("remove fixture");
     std::fs::remove_dir(&temp_dir).expect("remove temp dir");
 }
+
+fn journal_filter_fixture(tag: &str) -> std::path::PathBuf {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-claude-journal-{tag}-{}",
+        std::process::id()
+    ));
+    std::fs::remove_dir_all(&temp_dir).ok();
+    let projects_dir = temp_dir.join("projects");
+    let project = projects_dir.join("-Users-example-proj");
+    let session = "11111111-1111-1111-1111-111111111111";
+    let workflow_dir = project.join(session).join("subagents/workflows/wf_abc");
+    std::fs::create_dir_all(&workflow_dir).expect("create workflow dir");
+    let line = r#"{"type":"user","sessionId":"s","timestamp":"2026-04-01T07:06:46.543Z","message":{"role":"user","content":"hello"}}
+"#;
+    std::fs::write(project.join(format!("{session}.jsonl")), line).expect("write session");
+    std::fs::write(workflow_dir.join("journal.jsonl"), "{\"type\":\"started\"}\n")
+        .expect("write journal");
+    std::fs::write(workflow_dir.join("agent-a1.jsonl"), line).expect("write workflow agent");
+    std::fs::write(
+        project.join(session).join("subagents/agent-a2.jsonl"),
+        line,
+    )
+    .expect("write subagent");
+    temp_dir
+}
+
+#[test]
+fn excludes_workflow_journal_files_from_discovery_and_collect() {
+    let temp_dir = journal_filter_fixture("filter");
+    let projects_dir = temp_dir.join("projects");
+
+    let mut files = Vec::new();
+    collect_claude_session_files(&projects_dir, &mut files).expect("collect");
+    let stems = files
+        .iter()
+        .map(|file| file.file_stem.as_str())
+        .collect::<Vec<_>>();
+    assert!(!stems.contains(&"journal"));
+    assert!(stems.contains(&"11111111-1111-1111-1111-111111111111"));
+    assert!(stems.contains(&"agent-a1"));
+    assert!(stems.contains(&"agent-a2"));
+
+    let previous = HashMap::new();
+    let mut walker = imported_history::scan_snapshot::SnapshotDirWalker::new(
+        &previous, "jsonl", "Claude",
+    );
+    let discovery = discover_claude_code_history_records(
+        std::slice::from_ref(&projects_dir),
+        &mut walker,
+    )
+    .expect("discover");
+    let ids = discovery
+        .records
+        .iter()
+        .map(|record| record.source_session_id.as_str())
+        .collect::<Vec<_>>();
+    assert!(!ids.contains(&"journal"));
+    assert_eq!(discovery.records.len(), 3);
+
+    assert!(is_claude_workflow_journal_path(Path::new(
+        "/home/u/.claude/projects/p/uuid/subagents/workflows/wf_1/journal.jsonl"
+    )));
+    assert!(!is_claude_workflow_journal_path(Path::new(
+        "/home/u/.claude/projects/p/uuid/subagents/workflows/wf_1/agent-a1.jsonl"
+    )));
+    assert!(!is_claude_workflow_journal_path(Path::new(
+        "/home/u/.claude/projects/p/uuid/subagents/agent-a2.jsonl"
+    )));
+    assert!(!is_claude_workflow_journal_path(Path::new(
+        "/home/u/.claude/projects/p/journal.jsonl"
+    )));
+
+    std::fs::remove_dir_all(&temp_dir).ok();
+}
+
+#[test]
+fn prunes_stale_journal_cache_row_after_discovery_filter() {
+    let temp_dir = journal_filter_fixture("prune");
+    let projects_dir = temp_dir.join("projects");
+    let conn = Connection::open_in_memory().expect("open in-memory db");
+    crate::store::sqlite::SqliteRecordStore::init_tables(&conn).expect("init core tables");
+    crate::store::sqlite::SqliteRecordStore::init_source_cache_tables(&conn)
+        .expect("init source cache tables");
+    conn.execute(
+        "INSERT INTO imported_history_session_cache (source, source_session_id, session_id)
+         VALUES ('claude_code', 'journal', 'claudecodeapp-journal')",
+        [],
+    )
+    .expect("seed journal cache row");
+    imported_history::watermark::write_parse_watermark_from_conn(
+        &conn,
+        SOURCE_CLAUDE_CODE,
+        "journal",
+        &ImportedParseWatermark {
+            byte_offset: 1,
+            source_size_bytes: 1,
+            source_mtime_ms: 1,
+            prefix_hash: "00".to_string(),
+            parser_version: 1,
+            state_json: "{}".to_string(),
+        },
+    )
+    .expect("seed journal watermark");
+
+    let previous = HashMap::new();
+    let mut walker = imported_history::scan_snapshot::SnapshotDirWalker::new(
+        &previous, "jsonl", "Claude",
+    );
+    let discovery = discover_claude_code_history_records(
+        std::slice::from_ref(&projects_dir),
+        &mut walker,
+    )
+    .expect("discover");
+    let signatures = discovery
+        .records
+        .iter()
+        .map(ImportedHistoryDiscoveredRecord::signature)
+        .collect::<Vec<_>>();
+    let live_ids = imported_cache::live_ids_from_signatures(&signatures);
+    assert!(!live_ids.is_empty());
+    assert!(!live_ids.iter().any(|id| id == "journal"));
+
+    imported_cache::prune_missing_records_from_conn(&conn, SOURCE_CLAUDE_CODE, &live_ids)
+        .expect("prune");
+
+    let journal_rows: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM imported_history_session_cache
+             WHERE source = 'claude_code' AND source_session_id = 'journal'",
+            [],
+            |row| row.get(0),
+        )
+        .expect("count journal rows");
+    assert_eq!(journal_rows, 0);
+    assert_eq!(
+        imported_history::watermark::read_parse_watermark_from_conn(
+            &conn,
+            SOURCE_CLAUDE_CODE,
+            "journal"
+        )
+        .expect("read journal watermark"),
+        None
+    );
+
+    std::fs::remove_dir_all(&temp_dir).ok();
+}
+
+#[test]
+fn snapshot_reuse_keeps_fresh_file_signatures() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-claude-snapshot-reuse-{}",
+        std::process::id()
+    ));
+    std::fs::remove_dir_all(&temp_dir).ok();
+    let projects_dir = temp_dir.join("projects");
+    let project = projects_dir.join("-Users-example-proj");
+    std::fs::create_dir_all(&project).expect("create project dir");
+    let session_path = project.join("22222222-2222-2222-2222-222222222222.jsonl");
+    std::fs::write(&session_path, "{\"type\":\"user\"}\n").expect("write session");
+    std::thread::sleep(std::time::Duration::from_millis(5));
+
+    let empty = HashMap::new();
+    let mut cold_walker = imported_history::scan_snapshot::SnapshotDirWalker::new(
+        &empty, "jsonl", "Claude",
+    );
+    let cold = discover_claude_code_history_records(
+        std::slice::from_ref(&projects_dir),
+        &mut cold_walker,
+    )
+    .expect("cold discover");
+    assert_eq!(cold.records.len(), 1);
+    let cold_size = cold.records[0].source_size_bytes;
+    assert!(cold_walker.dirs_enumerated >= 2);
+    let snapshots = cold_walker.into_snapshots();
+
+    std::fs::OpenOptions::new()
+        .append(true)
+        .open(&session_path)
+        .and_then(|mut file| std::io::Write::write_all(&mut file, b"{\"type\":\"assistant\"}\n"))
+        .expect("append to session");
+
+    let mut warm_walker = imported_history::scan_snapshot::SnapshotDirWalker::new(
+        &snapshots, "jsonl", "Claude",
+    );
+    let warm = discover_claude_code_history_records(
+        std::slice::from_ref(&projects_dir),
+        &mut warm_walker,
+    )
+    .expect("warm discover");
+    assert_eq!(warm_walker.dirs_enumerated, 0);
+    assert_eq!(warm_walker.dirs_reused, 2);
+    assert_eq!(warm.records.len(), 1);
+    assert!(warm.records[0].source_size_bytes > cold_size);
+    assert!(warm.records[0].source_mtime_ms >= cold.records[0].source_mtime_ms);
+
+    std::fs::remove_dir_all(&temp_dir).ok();
+}
+
+#[test]
+#[ignore]
+fn bench_real_home_claude_discovery_cold_vs_warm() {
+    let projects_dirs = claude_projects_dirs().expect("projects dirs");
+    let empty = HashMap::new();
+
+    let started = std::time::Instant::now();
+    let mut cold_walker = imported_history::scan_snapshot::SnapshotDirWalker::new(
+        &empty, "jsonl", "Claude",
+    );
+    let cold =
+        discover_claude_code_history_records(&projects_dirs, &mut cold_walker).expect("cold");
+    let cold_elapsed = started.elapsed();
+    let cold_enumerated = cold_walker.dirs_enumerated;
+    let snapshots = cold_walker.into_snapshots();
+
+    let started = std::time::Instant::now();
+    let mut warm_walker = imported_history::scan_snapshot::SnapshotDirWalker::new(
+        &snapshots, "jsonl", "Claude",
+    );
+    let warm =
+        discover_claude_code_history_records(&projects_dirs, &mut warm_walker).expect("warm");
+    let warm_elapsed = started.elapsed();
+
+    println!(
+        "claude discovery cold={cold_elapsed:?} ({} records, {cold_enumerated} dirs enumerated) \
+         warm={warm_elapsed:?} ({} records, {} dirs reused, {} dirs enumerated)",
+        cold.records.len(),
+        warm.records.len(),
+        warm_walker.dirs_reused,
+        warm_walker.dirs_enumerated,
+    );
+    assert_eq!(cold.records.len(), warm.records.len());
+}

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app/index.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app/index.rs
@@ -15,12 +15,12 @@ use crate::sources::codex::{canonical_session_id, SESSION_PREFIX as CODEX_APP_SE
 use crate::sources::imported_history::{
     self, cache as imported_cache,
     metadata::{ImportedHistoryDiscoveredRecord, SOURCE_CODEX_APP},
-    paths as imported_paths,
+    paths as imported_paths, scan_snapshot,
 };
 use crate::store::{sqlite::SqliteRecordStore, RecordStore};
 
 use super::meta::{
-    parse_codex_session_meta_incremental, resolve_codex_transcript_for_thread_id_near_path,
+    parse_codex_session_meta_with_title, resolve_codex_transcript_for_thread_id_near_path,
     session_meta_to_cache_input,
 };
 use super::transcript::{
@@ -260,7 +260,20 @@ fn best_codex_child_match(
 }
 
 fn sync_codex_app_cache(conn: &mut Connection) -> Result<(), String> {
-    let mut discovered = discover_codex_app_records()?;
+    let previous_snapshots = scan_snapshot::read_dir_snapshots_from_conn(conn, SOURCE_CODEX_APP);
+    let mut walker = scan_snapshot::SnapshotDirWalker::new(&previous_snapshots, "jsonl", "Codex");
+    let discovery = discover_codex_app_records(&codex_sessions_dirs()?, &mut walker)?;
+    let next_snapshots = walker.into_snapshots();
+    scan_snapshot::persist_dir_snapshots_if_changed(
+        conn,
+        SOURCE_CODEX_APP,
+        &previous_snapshots,
+        &next_snapshots,
+    )?;
+    let CodexAppDiscovery {
+        records: mut discovered,
+        external_titles,
+    } = discovery;
     // Managed (GUI-launched) Codex sessions surface through their
     // code_sessions row (`cli_agent_type = 'codex'`); the imported twin goes
     // unlistable. Same pattern as the OpenCode/Claude readers.
@@ -302,7 +315,12 @@ fn sync_codex_app_cache(conn: &mut Connection) -> Result<(), String> {
             SOURCE_CODEX_APP,
             &record.source_session_id,
         )?;
-        let parse = parse_codex_session_meta_incremental(record, stored_watermark.as_ref())?;
+        let external_title = external_titles
+            .get(&record.source_session_id)
+            .cloned()
+            .unwrap_or_default();
+        let parse =
+            parse_codex_session_meta_with_title(record, stored_watermark.as_ref(), external_title)?;
         imported_history::watermark::write_parse_watermark_from_conn(
             conn,
             SOURCE_CODEX_APP,
@@ -347,37 +365,57 @@ fn should_defer_active_codex_metadata(
         && now_ns.saturating_sub(record.source_mtime_ms) < ACTIVE_CODEX_METADATA_QUIET_NS
 }
 
-fn discover_codex_app_records() -> Result<Vec<ImportedHistoryDiscoveredRecord>, String> {
-    let mut sessions = Vec::new();
-    for sessions_dir in codex_sessions_dirs()? {
-        if sessions_dir.is_dir() {
-            let title_index = load_codex_session_index_for_sessions_dir(&sessions_dir)?;
-            let mut files = Vec::new();
-            collect_codex_session_files(&sessions_dir, &mut files)?;
-            for path in files {
-                let Some(file_stem) = path
-                    .file_stem()
-                    .and_then(|value| value.to_str())
-                    .map(ToString::to_string)
-                else {
-                    continue;
-                };
-                let (source_mtime_ms, source_size_bytes) =
-                    imported_paths::file_metadata_signature(&path, "Codex")?;
-                let source_fingerprint = codex_source_fingerprint(&file_stem, &title_index);
-                sessions.push(ImportedHistoryDiscoveredRecord {
-                    source_session_id: file_stem.clone(),
-                    source_path: path,
-                    source_record_key: file_stem,
-                    source_mtime_ms,
-                    source_size_bytes,
-                    source_fingerprint,
-                    parser_version: CODEX_APP_METADATA_PARSER_VERSION,
-                });
+#[derive(Debug)]
+struct CodexAppDiscovery {
+    records: Vec<ImportedHistoryDiscoveredRecord>,
+    external_titles: HashMap<String, String>,
+}
+
+fn discover_codex_app_records(
+    sessions_dirs: &[PathBuf],
+    walker: &mut scan_snapshot::SnapshotDirWalker<'_>,
+) -> Result<CodexAppDiscovery, String> {
+    let mut records = Vec::new();
+    let mut external_titles = HashMap::new();
+    for sessions_dir in sessions_dirs {
+        if !sessions_dir.is_dir() {
+            continue;
+        }
+        let title_index = load_codex_session_index_for_sessions_dir(sessions_dir)?;
+        let mut files = Vec::new();
+        walker.collect_files(sessions_dir, &mut files)?;
+        for path in files {
+            let Some(file_stem) = path
+                .file_stem()
+                .and_then(|value| value.to_str())
+                .map(ToString::to_string)
+            else {
+                continue;
+            };
+            let (source_mtime_ms, source_size_bytes) =
+                imported_paths::file_metadata_signature(&path, "Codex")?;
+            if let Some(entry) = codex_title_entry_for_file_stem(&file_stem, &title_index) {
+                external_titles.insert(
+                    file_stem.clone(),
+                    imported_history::truncate_name(&entry.thread_name, 200),
+                );
             }
+            let source_fingerprint = codex_source_fingerprint(&file_stem, &title_index);
+            records.push(ImportedHistoryDiscoveredRecord {
+                source_session_id: file_stem.clone(),
+                source_path: path,
+                source_record_key: file_stem,
+                source_mtime_ms,
+                source_size_bytes,
+                source_fingerprint,
+                parser_version: CODEX_APP_METADATA_PARSER_VERSION,
+            });
         }
     }
-    Ok(sessions)
+    Ok(CodexAppDiscovery {
+        records,
+        external_titles,
+    })
 }
 
 pub(super) fn collect_codex_session_files(
@@ -471,6 +509,7 @@ fn codex_source_fingerprint(
         .unwrap_or_default()
 }
 
+#[cfg(test)]
 pub(super) fn codex_session_index_title_for_record(
     record: &ImportedHistoryDiscoveredRecord,
 ) -> Result<String, String> {
@@ -485,6 +524,7 @@ pub(super) fn codex_session_index_title_for_record(
     )
 }
 
+#[cfg(test)]
 fn codex_index_path_for_session_path(session_path: &Path) -> Option<PathBuf> {
     codex_sessions_dir_for_session_path(session_path).and_then(|sessions_dir| {
         sessions_dir

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app/meta.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app/meta.rs
@@ -18,8 +18,8 @@ use crate::sources::imported_history::{
 
 use super::impact::{collect_codex_impact_from_patch_apply_end, collect_codex_impact_from_payload};
 use super::index::{
-    codex_session_index_title_for_record, codex_sessions_dir_for_session_path,
-    codex_thread_id_from_file_stem, collect_codex_session_files,
+    codex_sessions_dir_for_session_path, codex_thread_id_from_file_stem,
+    collect_codex_session_files,
 };
 use super::transcript::user_message_from_payload;
 use super::{
@@ -276,9 +276,10 @@ pub(crate) struct CodexSessionMetaParse {
     pub resumed: bool,
 }
 
-pub(crate) fn parse_codex_session_meta_incremental(
+pub(crate) fn parse_codex_session_meta_with_title(
     record: &ImportedHistoryDiscoveredRecord,
     watermark: Option<&ImportedParseWatermark>,
+    external_title: String,
 ) -> Result<CodexSessionMetaParse, String> {
     let mut reader = WatermarkedTranscriptReader::open(
         &record.source_path,
@@ -322,7 +323,6 @@ pub(crate) fn parse_codex_session_meta_incremental(
             tail_state = Some(snapshot);
         }
     }
-    let external_title = codex_session_index_title_for_record(record)?;
     let state_json = serde_json::to_string(&state)
         .map_err(|err| format!("Failed to serialize Codex parse state: {err}"))?;
     let next_watermark = reader.into_watermark(
@@ -339,6 +339,15 @@ pub(crate) fn parse_codex_session_meta_incremental(
         watermark: next_watermark,
         resumed,
     })
+}
+
+#[cfg(test)]
+pub(crate) fn parse_codex_session_meta_incremental(
+    record: &ImportedHistoryDiscoveredRecord,
+    watermark: Option<&ImportedParseWatermark>,
+) -> Result<CodexSessionMetaParse, String> {
+    let external_title = super::index::codex_session_index_title_for_record(record)?;
+    parse_codex_session_meta_with_title(record, watermark, external_title)
 }
 
 #[cfg(test)]

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache.rs
@@ -784,9 +784,33 @@ pub fn query_cached_session_from_conn(
 /// and one conversation shows once per continuation rewrite. Other unlistable
 /// rows (subagents, managed mirrors) still resolve — callers rely on that for
 /// parent placement and replay.
+///
+/// Existence checks that must treat a demoted sibling as still-present (the
+/// cloud vanished-session sweep) use
+/// `query_cached_session_by_session_id_including_superseded_from_conn`.
 pub fn query_cached_session_by_session_id_from_conn(
     conn: &Connection,
     session_id: &str,
+) -> Result<Option<(String, ImportedHistoryCachedSession)>, String> {
+    query_cached_session_by_session_id_impl(conn, session_id, false)
+}
+
+/// Exact-id resolution WITHOUT the continuation-supersession filter: a row
+/// demoted by the continuation election still resolves. The cloud
+/// vanished-session sweep confirms suspects through this path — a superseded
+/// sibling has not vanished locally, and reporting it absent would retract
+/// the team's shared cloud session on every context-window continuation.
+pub fn query_cached_session_by_session_id_including_superseded_from_conn(
+    conn: &Connection,
+    session_id: &str,
+) -> Result<Option<(String, ImportedHistoryCachedSession)>, String> {
+    query_cached_session_by_session_id_impl(conn, session_id, true)
+}
+
+fn query_cached_session_by_session_id_impl(
+    conn: &Connection,
+    session_id: &str,
+    include_continuation_superseded: bool,
 ) -> Result<Option<(String, ImportedHistoryCachedSession)>, String> {
     let source = conn
         .query_row(
@@ -812,7 +836,9 @@ pub fn query_cached_session_by_session_id_from_conn(
     let Some(session) = sessions.into_iter().next() else {
         return Ok(None);
     };
-    if has_newer_continuation_sibling(conn, &source, &session)? {
+    if !include_continuation_superseded
+        && has_newer_continuation_sibling(conn, &source, &session)?
+    {
         return Ok(None);
     }
     Ok(Some((source, session)))

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache_tests.rs
@@ -449,6 +449,43 @@ fn canonical_lookup_skips_continuation_superseded_siblings() {
 }
 
 #[test]
+fn including_superseded_lookup_resolves_demoted_continuation_siblings() {
+    let mut conn = fixture_conn();
+    let group = continuation_group_metadata_json(Some("family-uuid"));
+    let mut older = input(SOURCE_CODEX_APP, "gen1", 100);
+    older.source_metadata_json = group.clone();
+    let mut newest = input(SOURCE_CODEX_APP, "gen2", 200);
+    newest.source_metadata_json = group;
+    upsert_imported_session_cache_from_conn(&mut conn, &[older, newest]).expect("upsert");
+    demote_superseded_continuations_from_conn(&conn, SOURCE_CODEX_APP).expect("election");
+
+    // The vanished-session sweep's existence check must see the demoted
+    // sibling: it still exists locally and its shared cloud row must survive
+    // a context-window continuation.
+    let (_, demoted) = query_cached_session_by_session_id_including_superseded_from_conn(
+        &conn,
+        "codex_app-gen1",
+    )
+    .expect("query gen1 including superseded")
+    .expect("demoted sibling resolves");
+    assert_eq!(demoted.source_session_id, "gen1");
+    assert!(
+        query_cached_session_by_session_id_from_conn(&conn, "codex_app-gen1")
+            .expect("query gen1 default")
+            .is_none()
+    );
+    // Truly absent ids stay absent on both paths.
+    assert!(
+        query_cached_session_by_session_id_including_superseded_from_conn(
+            &conn,
+            "codex_app-missing"
+        )
+        .expect("query missing")
+        .is_none()
+    );
+}
+
+#[test]
 fn canonical_lookup_tolerates_legacy_non_json_metadata_rows() {
     let mut conn = fixture_conn();
     let group = continuation_group_metadata_json(Some("family-uuid"));

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/mod.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/mod.rs
@@ -5,6 +5,7 @@ pub mod metadata;
 pub mod paths;
 #[cfg(feature = "git")]
 pub mod repo_identity;
+pub mod scan_snapshot;
 pub mod watermark;
 
 use std::collections::{BTreeSet, HashMap};

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/scan_snapshot.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/scan_snapshot.rs
@@ -1,0 +1,221 @@
+//! Per-directory scan snapshots for incremental source discovery.
+//!
+//! A directory's mtime changes on entry create/delete/rename but NOT on
+//! in-place writes to a contained file, and never bubbles up from
+//! subdirectories. A snapshot therefore caches only the directory's NAME
+//! sets (files and subdirectories) so an unchanged directory skips
+//! re-enumeration; every listed file is still stat'ed by discovery, keeping
+//! a live-appended transcript's record signature fresh. Reuse additionally
+//! requires `dir_mtime_ns < scanned_at_ns` so a directory modified in the
+//! same instant the snapshot was taken (coarse-mtime race) re-enumerates.
+//! Any unreadable, foreign-version, or garbage row degrades to a full
+//! re-enumeration and is healed by the next write.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
+
+pub const SCAN_SNAPSHOT_VERSION: i64 = 1;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DirScanSnapshot {
+    pub dir_mtime_ns: i64,
+    pub scanned_at_ns: i64,
+    pub subdirs: Vec<String>,
+    pub files: Vec<String>,
+}
+
+pub fn read_dir_snapshots_from_conn(
+    conn: &Connection,
+    source: &str,
+) -> HashMap<String, DirScanSnapshot> {
+    let mut snapshots = HashMap::new();
+    let Ok(mut stmt) = conn.prepare(
+        "SELECT directory_path, entries_json FROM imported_history_scan_snapshots
+         WHERE source = ?1 AND snapshot_version = ?2",
+    ) else {
+        return snapshots;
+    };
+    let Ok(rows) = stmt.query_map(params![source, SCAN_SNAPSHOT_VERSION], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    }) else {
+        return snapshots;
+    };
+    for row in rows {
+        let Ok((directory_path, entries_json)) = row else {
+            continue;
+        };
+        let Ok(snapshot) = serde_json::from_str::<DirScanSnapshot>(&entries_json) else {
+            continue;
+        };
+        snapshots.insert(directory_path, snapshot);
+    }
+    snapshots
+}
+
+pub fn write_dir_snapshots_from_conn(
+    conn: &Connection,
+    source: &str,
+    snapshots: &HashMap<String, DirScanSnapshot>,
+) -> Result<(), String> {
+    let tx = conn
+        .unchecked_transaction()
+        .map_err(|err| format!("Failed to start scan snapshot transaction: {err}"))?;
+    tx.execute(
+        "DELETE FROM imported_history_scan_snapshots WHERE source = ?1",
+        [source],
+    )
+    .map_err(|err| format!("Failed to clear scan snapshots: {err}"))?;
+    {
+        let mut stmt = tx
+            .prepare(
+                "INSERT INTO imported_history_scan_snapshots (
+                    source, directory_path, dir_mtime_ns, file_count,
+                    snapshot_version, entries_json
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            )
+            .map_err(|err| format!("Failed to prepare scan snapshot insert: {err}"))?;
+        for (directory_path, snapshot) in snapshots {
+            let entries_json = serde_json::to_string(snapshot)
+                .map_err(|err| format!("Failed to encode scan snapshot: {err}"))?;
+            stmt.execute(params![
+                source,
+                directory_path,
+                snapshot.dir_mtime_ns,
+                snapshot.files.len() as i64,
+                SCAN_SNAPSHOT_VERSION,
+                entries_json,
+            ])
+            .map_err(|err| format!("Failed to write scan snapshot: {err}"))?;
+        }
+    }
+    tx.commit()
+        .map_err(|err| format!("Failed to commit scan snapshots: {err}"))
+}
+
+pub fn persist_dir_snapshots_if_changed(
+    conn: &Connection,
+    source: &str,
+    previous: &HashMap<String, DirScanSnapshot>,
+    next: &HashMap<String, DirScanSnapshot>,
+) -> Result<(), String> {
+    if previous == next {
+        return Ok(());
+    }
+    write_dir_snapshots_from_conn(conn, source, next)
+}
+
+pub struct SnapshotDirWalker<'a> {
+    previous: &'a HashMap<String, DirScanSnapshot>,
+    next: HashMap<String, DirScanSnapshot>,
+    extension: &'static str,
+    error_label: &'static str,
+    now_ns: i64,
+    pub dirs_enumerated: usize,
+    pub dirs_reused: usize,
+}
+
+impl<'a> SnapshotDirWalker<'a> {
+    pub fn new(
+        previous: &'a HashMap<String, DirScanSnapshot>,
+        extension: &'static str,
+        error_label: &'static str,
+    ) -> Self {
+        Self {
+            previous,
+            next: HashMap::new(),
+            extension,
+            error_label,
+            now_ns: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|elapsed| elapsed.as_nanos() as i64)
+                .unwrap_or(0),
+            dirs_enumerated: 0,
+            dirs_reused: 0,
+        }
+    }
+
+    pub fn collect_files(&mut self, dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), String> {
+        let key = dir.to_string_lossy().to_string();
+        let dir_mtime_ns = fs::metadata(dir)
+            .ok()
+            .and_then(|metadata| metadata.modified().ok())
+            .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+            .map(|elapsed| elapsed.as_nanos() as i64)
+            .unwrap_or(0);
+        if dir_mtime_ns > 0 {
+            if let Some(snapshot) = self.previous.get(&key) {
+                if snapshot.dir_mtime_ns == dir_mtime_ns
+                    && snapshot.dir_mtime_ns < snapshot.scanned_at_ns
+                {
+                    self.dirs_reused += 1;
+                    for name in &snapshot.files {
+                        out.push(dir.join(name));
+                    }
+                    let subdirs = snapshot.subdirs.clone();
+                    self.next.insert(key, snapshot.clone());
+                    for name in &subdirs {
+                        self.collect_files(&dir.join(name), out)?;
+                    }
+                    return Ok(());
+                }
+            }
+        }
+        self.dirs_enumerated += 1;
+        let mut snapshot = DirScanSnapshot {
+            dir_mtime_ns,
+            scanned_at_ns: self.now_ns,
+            subdirs: Vec::new(),
+            files: Vec::new(),
+        };
+        for entry in fs::read_dir(dir)
+            .map_err(|err| format!("Failed to read {} dir: {err}", self.error_label))?
+        {
+            let entry = entry
+                .map_err(|err| format!("Failed to read {} dir entry: {err}", self.error_label))?;
+            let file_name = entry.file_name();
+            let Some(name) = file_name.to_str() else {
+                continue;
+            };
+            let file_type = entry.file_type().map_err(|err| {
+                format!("Failed to read {} dir entry type: {err}", self.error_label)
+            })?;
+            let is_dir = if file_type.is_symlink() {
+                entry.path().is_dir()
+            } else {
+                file_type.is_dir()
+            };
+            if is_dir {
+                snapshot.subdirs.push(name.to_string());
+            } else if Path::new(name)
+                .extension()
+                .is_some_and(|extension| extension == self.extension)
+            {
+                snapshot.files.push(name.to_string());
+            }
+        }
+        snapshot.subdirs.sort();
+        snapshot.files.sort();
+        for name in &snapshot.files {
+            out.push(dir.join(name));
+        }
+        let subdirs = snapshot.subdirs.clone();
+        self.next.insert(key, snapshot);
+        for name in &subdirs {
+            self.collect_files(&dir.join(name), out)?;
+        }
+        Ok(())
+    }
+
+    pub fn into_snapshots(self) -> HashMap<String, DirScanSnapshot> {
+        self.next
+    }
+}
+
+#[cfg(test)]
+#[path = "scan_snapshot_tests.rs"]
+mod tests;

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/scan_snapshot_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/scan_snapshot_tests.rs
@@ -1,0 +1,211 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use rusqlite::Connection;
+
+use super::*;
+
+fn fixture_conn() -> Connection {
+    let conn = Connection::open_in_memory().expect("open in-memory db");
+    crate::store::sqlite::SqliteRecordStore::init_tables(&conn).expect("init core tables");
+    crate::store::sqlite::SqliteRecordStore::init_source_cache_tables(&conn)
+        .expect("init source cache tables");
+    conn
+}
+
+fn temp_tree(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "orgii-scan-snapshot-test-{tag}-{}",
+        std::process::id()
+    ));
+    fs::remove_dir_all(&dir).ok();
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+type WalkResult = (
+    Vec<PathBuf>,
+    HashMap<String, DirScanSnapshot>,
+    usize,
+    usize,
+);
+
+fn walk(previous: &HashMap<String, DirScanSnapshot>, root: &Path) -> WalkResult {
+    let mut walker = SnapshotDirWalker::new(previous, "jsonl", "Test");
+    let mut files = Vec::new();
+    walker.collect_files(root, &mut files).expect("walk");
+    let enumerated = walker.dirs_enumerated;
+    let reused = walker.dirs_reused;
+    (files, walker.into_snapshots(), enumerated, reused)
+}
+
+#[test]
+fn snapshot_rows_roundtrip_and_replace() {
+    let conn = fixture_conn();
+    let mut snapshots = HashMap::new();
+    snapshots.insert(
+        "/tmp/a".to_string(),
+        DirScanSnapshot {
+            dir_mtime_ns: 10,
+            scanned_at_ns: 20,
+            subdirs: vec!["sub".to_string()],
+            files: vec!["x.jsonl".to_string()],
+        },
+    );
+
+    write_dir_snapshots_from_conn(&conn, "claude_code", &snapshots).expect("write");
+    assert_eq!(read_dir_snapshots_from_conn(&conn, "claude_code"), snapshots);
+    assert!(read_dir_snapshots_from_conn(&conn, "codex_app").is_empty());
+
+    let mut replacement = HashMap::new();
+    replacement.insert("/tmp/b".to_string(), DirScanSnapshot::default());
+    write_dir_snapshots_from_conn(&conn, "claude_code", &replacement).expect("rewrite");
+    assert_eq!(
+        read_dir_snapshots_from_conn(&conn, "claude_code"),
+        replacement
+    );
+}
+
+#[test]
+fn legacy_or_garbage_snapshot_rows_read_as_absent_and_heal() {
+    let conn = fixture_conn();
+    conn.execute(
+        "INSERT INTO imported_history_scan_snapshots (
+            source, directory_path, dir_mtime_ns, file_count, snapshot_version, entries_json
+         ) VALUES ('claude_code', '/tmp/garbage', 1, 1, ?1, 'not-json')",
+        [SCAN_SNAPSHOT_VERSION],
+    )
+    .expect("insert garbage json row");
+    conn.execute(
+        "INSERT INTO imported_history_scan_snapshots (
+            source, directory_path, dir_mtime_ns, file_count, snapshot_version, entries_json
+         ) VALUES ('claude_code', '/tmp/wrong-type', 'nope', 1, ?1, 42)",
+        [SCAN_SNAPSHOT_VERSION],
+    )
+    .expect("insert wrong-type row");
+    conn.execute(
+        "INSERT INTO imported_history_scan_snapshots (
+            source, directory_path, dir_mtime_ns, file_count, snapshot_version, entries_json
+         ) VALUES ('claude_code', '/tmp/future', 1, 1, 999,
+                   '{\"dir_mtime_ns\":1,\"scanned_at_ns\":2,\"subdirs\":[],\"files\":[]}')",
+        [],
+    )
+    .expect("insert future-version row");
+
+    assert!(read_dir_snapshots_from_conn(&conn, "claude_code").is_empty());
+
+    let bare = Connection::open_in_memory().expect("open bare db");
+    assert!(read_dir_snapshots_from_conn(&bare, "claude_code").is_empty());
+
+    let mut healed = HashMap::new();
+    healed.insert(
+        "/tmp/healed".to_string(),
+        DirScanSnapshot {
+            dir_mtime_ns: 5,
+            scanned_at_ns: 6,
+            subdirs: Vec::new(),
+            files: vec!["y.jsonl".to_string()],
+        },
+    );
+    write_dir_snapshots_from_conn(&conn, "claude_code", &healed).expect("heal");
+    assert_eq!(read_dir_snapshots_from_conn(&conn, "claude_code"), healed);
+}
+
+#[test]
+fn walker_reuses_unchanged_directories_and_detects_changes() {
+    let root = temp_tree("walker");
+    fs::create_dir_all(root.join("sub/deep")).expect("create dirs");
+    fs::write(root.join("a.jsonl"), "a").expect("write a");
+    fs::write(root.join("skip.txt"), "s").expect("write skip");
+    fs::write(root.join("sub/b.jsonl"), "b").expect("write b");
+    fs::write(root.join("sub/deep/c.jsonl"), "c").expect("write c");
+    std::thread::sleep(Duration::from_millis(5));
+
+    let empty = HashMap::new();
+    let (cold_files, snapshots, cold_enumerated, cold_reused) = walk(&empty, &root);
+    assert_eq!(cold_files.len(), 3);
+    assert_eq!(cold_enumerated, 3);
+    assert_eq!(cold_reused, 0);
+
+    let (warm_files, warm_snapshots, warm_enumerated, warm_reused) = walk(&snapshots, &root);
+    assert_eq!(warm_files, cold_files);
+    assert_eq!(warm_enumerated, 0);
+    assert_eq!(warm_reused, 3);
+    assert_eq!(warm_snapshots, snapshots);
+
+    fs::write(root.join("sub/d.jsonl"), "d").expect("write d");
+    std::thread::sleep(Duration::from_millis(5));
+    let (added_files, added_snapshots, added_enumerated, added_reused) =
+        walk(&warm_snapshots, &root);
+    assert_eq!(added_files.len(), 4);
+    assert!(added_files.contains(&root.join("sub/d.jsonl")));
+    assert_eq!(added_enumerated, 1);
+    assert_eq!(added_reused, 2);
+
+    fs::remove_file(root.join("a.jsonl")).expect("remove a");
+    std::thread::sleep(Duration::from_millis(5));
+    let (removed_files, _, removed_enumerated, _) = walk(&added_snapshots, &root);
+    assert_eq!(removed_files.len(), 3);
+    assert!(!removed_files
+        .iter()
+        .any(|path| path.file_name() == Some(std::ffi::OsStr::new("a.jsonl"))));
+    assert_eq!(removed_enumerated, 1);
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn walker_ignores_racy_snapshot_whose_scan_did_not_postdate_dir_mtime() {
+    let root = temp_tree("racy");
+    fs::write(root.join("a.jsonl"), "a").expect("write a");
+    std::thread::sleep(Duration::from_millis(5));
+
+    let empty = HashMap::new();
+    let (files, snapshots, _, _) = walk(&empty, &root);
+    let mut racy = snapshots.clone();
+    for snapshot in racy.values_mut() {
+        snapshot.scanned_at_ns = snapshot.dir_mtime_ns;
+    }
+
+    let (racy_files, _, racy_enumerated, racy_reused) = walk(&racy, &root);
+    assert_eq!(racy_files, files);
+    assert_eq!(racy_reused, 0);
+    assert_eq!(racy_enumerated, 1);
+
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+#[ignore]
+fn bench_walker_cold_vs_warm() {
+    let root = temp_tree("bench");
+    for dir_index in 0..250 {
+        let dir = root.join(format!("proj-{dir_index:03}"));
+        fs::create_dir_all(&dir).expect("create bench dir");
+        for file_index in 0..10 {
+            fs::write(dir.join(format!("s-{file_index:02}.jsonl")), "x").expect("write bench file");
+        }
+    }
+    std::thread::sleep(Duration::from_millis(10));
+
+    let empty = HashMap::new();
+    let started = std::time::Instant::now();
+    let (cold_files, snapshots, cold_enumerated, _) = walk(&empty, &root);
+    let cold = started.elapsed();
+
+    let started = std::time::Instant::now();
+    let (warm_files, _, warm_enumerated, warm_reused) = walk(&snapshots, &root);
+    let warm = started.elapsed();
+
+    println!(
+        "bench_walker cold={cold:?} ({} files, {cold_enumerated} dirs enumerated) \
+         warm={warm:?} ({} files, {warm_reused} dirs reused, {warm_enumerated} dirs enumerated)",
+        cold_files.len(),
+        warm_files.len(),
+    );
+    assert_eq!(cold_files.len(), warm_files.len());
+
+    fs::remove_dir_all(&root).ok();
+}

--- a/src-tauri/crates/orgtrack-core/src/store/sqlite/schema.rs
+++ b/src-tauri/crates/orgtrack-core/src/store/sqlite/schema.rs
@@ -609,6 +609,20 @@ impl SqliteRecordStore<'_> {
                 parser_version     INTEGER NOT NULL DEFAULT 0,
                 state_json         TEXT NOT NULL DEFAULT '',
                 PRIMARY KEY (source, source_session_id)
+            );
+
+            -- Discovery-walk resume points: per-directory name-set snapshots
+            -- (see sources::imported_history::scan_snapshot for the
+            -- invalidation contract). Purely an enumeration cache — safe to
+            -- drop at any time.
+            CREATE TABLE IF NOT EXISTS imported_history_scan_snapshots (
+                source            TEXT NOT NULL,
+                directory_path    TEXT NOT NULL,
+                dir_mtime_ns      INTEGER NOT NULL DEFAULT 0,
+                file_count        INTEGER NOT NULL DEFAULT 0,
+                snapshot_version  INTEGER NOT NULL DEFAULT 0,
+                entries_json      TEXT NOT NULL DEFAULT '{}',
+                PRIMARY KEY (source, directory_path)
             );",
         )
     }

--- a/src-tauri/src/agent_sessions/session_directory/aggregation.rs
+++ b/src-tauri/src/agent_sessions/session_directory/aggregation.rs
@@ -353,12 +353,20 @@ fn load_imported_history_sessions(
         .and_then(|filter| filter.session_ids.as_ref())
         .filter(|session_ids| !session_ids.is_empty())
     {
+        let include_superseded = filter
+            .and_then(|filter| filter.include_continuation_superseded)
+            .unwrap_or(false);
         for session_id in session_ids {
-            let Some((source, session)) =
+            let resolved = if include_superseded {
+                imported_history_cache::query_cached_session_by_session_id_including_superseded_from_conn(
+                    &conn, session_id,
+                )?
+            } else {
                 imported_history_cache::query_cached_session_by_session_id_from_conn(
                     &conn, session_id,
                 )?
-            else {
+            };
+            let Some((source, session)) = resolved else {
                 continue;
             };
             if source_filter.is_some_and(|expected| expected != source.as_str())
@@ -444,6 +452,9 @@ fn plain_native_page(
         created_after_ms,
         created_before_ms,
         active_only,
+        // Only meaningful with session_ids, and plain requires session_ids
+        // to be absent, so the flag cannot affect the fast path.
+        include_continuation_superseded: _,
     } = filter;
 
     let plain = session_ids.is_none()

--- a/src-tauri/src/agent_sessions/session_directory/types.rs
+++ b/src-tauri/src/agent_sessions/session_directory/types.rs
@@ -267,6 +267,12 @@ pub struct SessionFilter {
     /// Only return active (ongoing) sessions
     #[serde(skip_serializing_if = "Option::is_none")]
     pub active_only: Option<bool>,
+    /// Exact-id lookups normally report continuation-superseded siblings as
+    /// absent so hydration surfaces never re-add rows the listing demoted.
+    /// Existence checks (the cloud vanished-session sweep) opt out: a
+    /// superseded sibling still exists locally and must not read as vanished.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub include_continuation_superseded: Option<bool>,
 }
 
 // ============================================================================

--- a/src-tauri/src/api/websocket_handler.rs
+++ b/src-tauri/src/api/websocket_handler.rs
@@ -59,6 +59,11 @@ fn get_registry() -> &'static RwLock<HashMap<String, Vec<RegisteredChannel>>> {
 pub fn register_channel(session_id: String, channel: Channel<String>) -> u64 {
     let channel_id = NEXT_CHANNEL_ID.fetch_add(1, Ordering::Relaxed);
     if let Ok(mut map) = get_registry().write() {
+        tracing::info!(
+            "[IPC] channel {} registered for session {}",
+            channel_id,
+            session_id
+        );
         map.entry(session_id).or_default().push(RegisteredChannel {
             channel_id,
             channel,
@@ -76,6 +81,12 @@ pub fn unregister_channel(session_id: &str, channel_id: u64) {
     if let Ok(mut map) = get_registry().write() {
         if let Some(channels) = map.get_mut(session_id) {
             channels.retain(|entry| entry.channel_id != channel_id);
+            tracing::info!(
+                "[IPC] channel {} unregistered for session {} ({} remain)",
+                channel_id,
+                session_id,
+                channels.len()
+            );
             if channels.is_empty() {
                 map.remove(session_id);
             }
@@ -208,6 +219,17 @@ fn dispatch_to_channels(message: &str) {
                 if channels.is_empty() {
                     map.remove(&sid);
                 }
+            } else if matches!(
+                event_type(message).as_deref(),
+                Some("agent:complete") | Some("agent:error")
+            ) {
+                tracing::warn!(
+                    "[IPC] no channel registered for session {}; dropping {} — \
+                     the frontend never subscribed this session's events and \
+                     its turn will only end via the planning-indicator watchdog",
+                    sid,
+                    event_type(message).as_deref().unwrap_or("?")
+                );
             }
             return;
         }

--- a/src/api/tauri/rpc/schemas/sessionAggregate.ts
+++ b/src/api/tauri/rpc/schemas/sessionAggregate.ts
@@ -53,6 +53,7 @@ export const SessionFilterInput = z.object({
   externalHistorySource: z.string().optional(),
   disabledExternalHistorySources: z.array(z.string()).optional(),
   activeOnly: z.boolean().optional(),
+  includeContinuationSuperseded: z.boolean().optional(),
 });
 
 export const SessionAggregateListInput = z.object({

--- a/src/engines/ChatPanel/ChatView.tsx
+++ b/src/engines/ChatPanel/ChatView.tsx
@@ -451,6 +451,7 @@ const ChatView: React.FC<ChatViewProps> = memo(
             onSubmitOverride={handleExternalHistoryForkSubmit}
             externalScrollToBottomButton={externalScrollToBottomButton}
             isImportedHistory={isImportedHistory}
+            sessionId={sessionId}
           />
           {showInteractArea && !isReadOnlySurface && (
             <ChatFloatingComposer

--- a/src/engines/ChatPanel/ChatViewPostHistoryOverlays.tsx
+++ b/src/engines/ChatPanel/ChatViewPostHistoryOverlays.tsx
@@ -24,6 +24,9 @@ interface ChatViewPostHistoryOverlaysProps {
   onSubmitOverride: (input: SubmitOverrideInput) => Promise<boolean>;
   externalScrollToBottomButton: React.ReactNode;
   isImportedHistory: boolean;
+  /** The viewed history session — Address Comments targets its threads
+   * even though this composer dispatches into a fork. */
+  sessionId?: string;
 }
 
 export function ChatViewPostHistoryOverlays({
@@ -33,6 +36,7 @@ export function ChatViewPostHistoryOverlays({
   onSubmitOverride,
   externalScrollToBottomButton,
   isImportedHistory,
+  sessionId,
 }: ChatViewPostHistoryOverlaysProps) {
   const { t: tNavigation } = useTranslation("navigation");
 
@@ -56,6 +60,7 @@ export function ChatViewPostHistoryOverlays({
                 )}
                 chatPanelPosition={position}
                 sessionScope="none"
+                addressSessionId={sessionId ?? null}
                 onSubmitOverride={onSubmitOverride}
                 topRowTrailingContent={externalScrollToBottomButton}
                 bottomAnchored

--- a/src/engines/ChatPanel/InputArea/index.tsx
+++ b/src/engines/ChatPanel/InputArea/index.tsx
@@ -56,6 +56,9 @@ interface InputAreaProps {
   omitChatHeader?: boolean;
   chatPanelPosition?: "left" | "right";
   sessionId?: string;
+  /** Session whose comment threads Address Comments targets when this
+   * composer dispatches elsewhere (external-history fork composer). */
+  addressSessionId?: string | null;
   onSubmitOverride?: (input: SubmitOverrideInput) => Promise<boolean>;
   customMentionOptions?: ReadonlyArray<CustomMentionOption>;
   topRowPills?: React.ReactNode;
@@ -120,6 +123,7 @@ const InputAreaInteractive: React.FC<InputAreaProps> = memo(
     omitChatHeader = false,
     chatPanelPosition = "right",
     sessionId: propSessionId,
+    addressSessionId,
     onSubmitOverride,
     customMentionOptions,
     topRowPills,
@@ -210,6 +214,7 @@ const InputAreaInteractive: React.FC<InputAreaProps> = memo(
     } = useInputArea({
       placeholder,
       sessionId: propSessionId,
+      addressSessionId,
       sessionScope,
       submitDisabled,
       onSubmitOverride,

--- a/src/engines/ChatPanel/hooks/useInputArea/index.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/index.ts
@@ -173,6 +173,7 @@ export function useInputArea(
     customMentionOptions,
     onSubmitOverride,
     sessionId: propSessionId,
+    addressSessionId: propAddressSessionId,
     sessionScope = "active",
     submitDisabled = false,
     enableAgentInterceptors = true,
@@ -386,6 +387,8 @@ export function useInputArea(
     setSlashQuery: state.setSlashQuery,
     workspacePaths: skillWorkspacePaths,
     sessionId: activeSessionId,
+    addressSessionId:
+      propAddressSessionId ?? propSessionId ?? resolvedActiveSessionId ?? null,
   });
 
   const imageAttachment = useImageAttachment(dropTargetId);
@@ -597,6 +600,8 @@ export function useInputArea(
   const handleDivSubmit = useSubmitMessage({
     refs,
     draftSessionId,
+    addressSessionId:
+      propAddressSessionId ?? propSessionId ?? resolvedActiveSessionId ?? null,
     replyTargetEventId,
     flushDraft,
     clearReplyTarget,

--- a/src/engines/ChatPanel/hooks/useInputArea/types.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/types.ts
@@ -42,6 +42,9 @@ export interface UseInputAreaOptions {
   placeholder?: string;
   /** Explicit session ID for the chat surface using this composer. */
   sessionId?: string;
+  /** Session whose comment threads Address Comments targets when the
+   * composer dispatches elsewhere (external-history fork composer). */
+  addressSessionId?: string | null;
   sessionScope?: "active" | "none";
   submitDisabled?: boolean;
   enableAgentInterceptors?: boolean;

--- a/src/engines/ChatPanel/hooks/useInputArea/useSlashCommand.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/useSlashCommand.ts
@@ -32,6 +32,14 @@ interface UseSlashCommandOptions {
   /** The session already resolved by the owning InputArea. */
   sessionId?: string;
   /**
+   * The session the user is VIEWING, even when the composer dispatches
+   * elsewhere. The external-history fork composer mounts with
+   * `sessionScope="none"` (sending forks into a new session), which
+   * blanks `sessionId` — but Address Comments must still target the
+   * viewed history's threads; its run path forks first by design.
+   */
+  addressSessionId?: string | null;
+  /**
    * When `true`, `/mode` always reads + writes `creatorDefaultExecModeAtom`
    * even if there is an active session in the route. Set by callers that
    * mount the input outside an in-session context (e.g. the
@@ -74,6 +82,7 @@ export function useSlashCommand(
     setSlashQuery,
     workspacePaths,
     sessionId,
+    addressSessionId,
     creatorDefaultMode: forceCreatorDefault = false,
   } = options;
 
@@ -107,7 +116,7 @@ export function useSlashCommand(
   const { t } = useTranslation("sessions");
   const { t: tNav } = useTranslation("navigation");
   const addressComments = useAddressCommentsSlashCommand(
-    isInSession ? sessionId : null
+    isInSession ? sessionId : (addressSessionId ?? null)
   );
   const addressCommentsItem = addressComments.item;
   const builtinSlashItems = useMemo<SlashItem[]>(

--- a/src/engines/ChatPanel/hooks/useInputArea/useSubmitMessage.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/useSubmitMessage.ts
@@ -77,6 +77,10 @@ export function stripContextPillBase64(text: string): string {
 export interface UseSubmitMessageOptions {
   refs: InputAreaRefs;
   draftSessionId: string;
+  /** Session whose comment threads Address Comments targets when the
+   * composer dispatches elsewhere (external-history fork composer, where
+   * `draftSessionId` is empty by design). */
+  addressSessionId?: string | null;
   replyTargetEventId: string | undefined;
   flushDraft: (text: string) => Promise<void>;
   clearReplyTarget: () => Promise<void>;
@@ -116,6 +120,7 @@ function lastSerializedPillLabel(rawLabel: string): string {
 export function useSubmitMessage({
   refs,
   draftSessionId,
+  addressSessionId,
   replyTargetEventId,
   flushDraft,
   clearReplyTarget,
@@ -133,7 +138,7 @@ export function useSubmitMessage({
   const { runManualCompact } = useManualCompact();
   const guardAgainstSecrets = useSecretScanGuard();
   const addressComments = useAddressCommentsSlashCommand(
-    draftSessionId || null
+    draftSessionId || addressSessionId || null
   );
 
   return useCallback(
@@ -195,9 +200,11 @@ export function useSubmitMessage({
         const addressDraft = parseAddressCommentsSlashCommand(displayText);
         if (addressDraft) {
           refs.composerInputRef.current.clear();
-          void flushDraft("").catch((err: unknown) => {
-            log.warn("[useSubmitMessage] flushDraft(address) failed:", err);
-          });
+          if (draftSessionId) {
+            void flushDraft("").catch((err: unknown) => {
+              log.warn("[useSubmitMessage] flushDraft(address) failed:", err);
+            });
+          }
           addressComments.run({
             selectedHeadIds: addressDraft.selectedHeadIds,
             instruction: addressDraft.instruction,

--- a/src/engines/SessionCore/sync/adapters/createRustAgentAdapter.ts
+++ b/src/engines/SessionCore/sync/adapters/createRustAgentAdapter.ts
@@ -356,6 +356,49 @@ export function createRustAgentAdapter(
       // Event queue to ensure sequential processing (prevents race conditions)
       let eventQueuePromise = Promise.resolve();
 
+      // One hung dispatch (an IPC invoke that never settles) must not starve
+      // every later event — the terminal would never apply and the turn only
+      // ends via the 60s planning watchdog. After the deadline the queue
+      // moves on; the stalled dispatch's late outcome is logged, not thrown.
+      const QUEUE_DISPATCH_DEADLINE_MS = 15_000;
+      const withQueueDeadline = (
+        dispatch: Promise<void>,
+        eventType: string
+      ): Promise<void> =>
+        new Promise((resolve, reject) => {
+          const timer = setTimeout(() => {
+            logger.error(
+              `[${category}] dispatch of "${eventType}" on ${sessionId} ` +
+                `exceeded ${QUEUE_DISPATCH_DEADLINE_MS}ms — releasing the ` +
+                `event queue so terminal events cannot starve`
+            );
+            dispatch.then(
+              () =>
+                logger.warn(
+                  `[${category}] stalled "${eventType}" dispatch on ` +
+                    `${sessionId} eventually completed`
+                ),
+              (err) =>
+                logger.warn(
+                  `[${category}] stalled "${eventType}" dispatch on ` +
+                    `${sessionId} eventually failed:`,
+                  err
+                )
+            );
+            resolve();
+          }, QUEUE_DISPATCH_DEADLINE_MS);
+          dispatch.then(
+            () => {
+              clearTimeout(timer);
+              resolve();
+            },
+            (err) => {
+              clearTimeout(timer);
+              reject(err);
+            }
+          );
+        });
+
       // Consecutive dispatch failures within a single turn. A handler that
       // throws leaves the EventStore potentially inconsistent (a tool_call
       // row written but its result never paired, a delta lost). One isolated
@@ -429,7 +472,14 @@ export function createRustAgentAdapter(
 
       return {
         handleEvent(raw: RawSessionEvent): void {
-          if (_disposed) return;
+          if (_disposed) {
+            if (TERMINAL_EVENTS.has(raw.type)) {
+              logger.warn(
+                `[${category}] disposed handler swallowed ${raw.type} for ${sessionId}`
+              );
+            }
+            return;
+          }
 
           // Liveness stamp for EVERY channel event, before any filtering.
           // Ephemeral events (tool_call_delta, stream_retry) never reach the
@@ -515,7 +565,10 @@ export function createRustAgentAdapter(
               ) {
                 return;
               }
-              return dispatchAgentEvent(event, ctx);
+              return withQueueDeadline(
+                dispatchAgentEvent(event, ctx),
+                event.type
+              );
             })
             .then(() => {
               if (_disposed) return;

--- a/src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/__tests__/forkTerminalBridge.test.ts
+++ b/src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/__tests__/forkTerminalBridge.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { dispatchAgentEvent } from "..";
+import type { EventHandlerContext } from "../types";
+
+const { getEventsSpy, saveToCacheSpy } = vi.hoisted(() => ({
+  getEventsSpy: vi.fn().mockResolvedValue([]),
+  saveToCacheSpy: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@src/engines/SessionCore/core/store/EventStoreProxy", () => ({
+  eventStoreProxy: {
+    getEvents: getEventsSpy,
+    saveToCache: saveToCacheSpy,
+    upsert: vi.fn().mockResolvedValue(undefined),
+    append: vi.fn().mockResolvedValue(undefined),
+    replaceAndRemove: vi.fn().mockResolvedValue(true),
+    removeByIdPrefix: vi.fn().mockResolvedValue(1),
+  },
+}));
+
+function ref<T>(value: T): { current: T } {
+  return { current: value };
+}
+
+/** A relay fork's own id: `agentsession-<uuid>` (createForkedSessionId). */
+const FORK_SESSION_ID = "agentsession-fddce7b4-6a90-4cad-a52e-689a77e6d406";
+
+function createForkCtx(onStatusChange: ReturnType<typeof vi.fn>) {
+  return {
+    filterSessionIdRef: ref(FORK_SESSION_ID),
+    trackedCodingSessionsRef: ref(new Map<string, string>()),
+    assistantStreamRef: ref({ idRef: ref(""), contentRef: ref("") }),
+    thinkingStreamRef: ref({ idRef: ref(""), contentRef: ref("") }),
+    streamingInfoRef: ref({
+      isStreaming: false,
+      isThinking: false,
+      content: "",
+    }),
+    onStreamingDeltaRef: ref(vi.fn()),
+    onAgentCompleteRef: ref(vi.fn()),
+    onContextUsageRef: ref(undefined),
+    onTokenUpdateRef: ref(undefined),
+    onStatusChangeRef: ref(onStatusChange),
+    onQuestionRequestRef: ref(undefined),
+    setStreaming: vi.fn(),
+    features: { hasCodingSessionBridge: true },
+    getDefaultStore: () => null,
+  } as unknown as EventHandlerContext;
+}
+
+beforeEach(() => {
+  getEventsSpy.mockClear().mockResolvedValue([]);
+  saveToCacheSpy.mockClear();
+});
+
+describe("relay fork terminals are never swallowed by the subagent bridge", () => {
+  it("completes the turn for the handler's own agentsession- id", async () => {
+    // The fork's own id matches SPAWNED_SESSION_RE, and only terminals carry
+    // a sessionId — so before the guard this event was dropped outright and
+    // the turn only ended via the 60s planning watchdog.
+    const onStatusChange = vi.fn();
+    const ctx = createForkCtx(onStatusChange);
+
+    await dispatchAgentEvent(
+      {
+        type: "agent:complete",
+        sessionId: FORK_SESSION_ID,
+        content: "ok",
+        totalTokens: 10,
+      } as never,
+      ctx
+    );
+
+    expect(onStatusChange).toHaveBeenCalledWith("completed");
+  });
+
+  it("still dispatches normally when an untracked spawned id has no active parent call", async () => {
+    const onStatusChange = vi.fn();
+    const ctx = createForkCtx(onStatusChange);
+    // A different session's terminal with no spawning tool_call to attach to:
+    // the session filter drops it, but it must not be swallowed by the bridge
+    // before the filter can even see it.
+    getEventsSpy.mockResolvedValue([]);
+
+    await dispatchAgentEvent(
+      {
+        type: "agent:complete",
+        sessionId: "agentsession-11111111-2222-3333-4444-555555555555",
+        content: "other",
+      } as never,
+      ctx
+    );
+
+    expect(onStatusChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/index.ts
+++ b/src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/index.ts
@@ -137,10 +137,17 @@ export async function dispatchAgentEvent(
   const eventSessionId = getEventSessionId(event);
   const sessionId = ctx.filterSessionIdRef.current || "";
 
-  // Coding session bridge (enabled via hasCodingSessionBridge feature flag)
+  // Coding session bridge (enabled via hasCodingSessionBridge feature flag).
+  // Never applies to the handler's OWN session: `SPAWNED_SESSION_RE` matches
+  // any `agentsession-<uuid>`, which is also the id shape a relay fork gets
+  // (createForkedSessionId), so a fork's own terminal would otherwise be
+  // mistaken for a spawned subagent's. Only `agent:complete` / `agent:error`
+  // / `agent:warning` carry a sessionId, so the symptom was precisely a
+  // fork whose text streamed normally but whose turn never ended.
   if (
     ctx.features.hasCodingSessionBridge &&
     eventSessionId &&
+    eventSessionId !== ctx.filterSessionIdRef.current &&
     ctx.trackedCodingSessionsRef
   ) {
     const parentEventId =
@@ -150,7 +157,9 @@ export async function dispatchAgentEvent(
       return;
     }
 
-    // Auto-track new spawned coding sessions
+    // Auto-track new spawned coding sessions. Without an active spawning
+    // tool_call there is no parent row to attach to — fall through to normal
+    // dispatch instead of swallowing the event.
     if (
       SPAWNED_SESSION_RE.test(eventSessionId) &&
       !ctx.trackedCodingSessionsRef.current.has(eventSessionId)
@@ -161,8 +170,8 @@ export async function dispatchAgentEvent(
         const parentId = currentEvents[activeIdx].id;
         ctx.trackedCodingSessionsRef.current.set(eventSessionId, parentId);
         handleCodingSessionEvent(event, parentId, ctx);
+        return;
       }
-      return;
     }
   }
 

--- a/src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/index.ts
+++ b/src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/index.ts
@@ -172,6 +172,12 @@ export async function dispatchAgentEvent(
     eventSessionId &&
     eventSessionId !== ctx.filterSessionIdRef.current
   ) {
+    if (event.type === "agent:complete" || event.type === "agent:error") {
+      unknownEventLogger.warn(
+        `[${event.type}] dropped by session filter: event=${eventSessionId} ` +
+          `filter=${ctx.filterSessionIdRef.current}`
+      );
+    }
     return;
   }
 

--- a/src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/sessionHandlers.ts
+++ b/src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/sessionHandlers.ts
@@ -51,6 +51,10 @@ export function handleComplete(
   sessionId: string,
   ctx: EventHandlerContext
 ): void {
+  log.info(
+    `[agent:complete] handling for ${sessionId} ` +
+      `(statusHandler=${ctx.onStatusChangeRef.current ? "wired" : "MISSING"})`
+  );
   resetAllStreamingState(ctx);
   ctx.setStreaming(false);
   clearStreamRetryStatus(ctx, sessionId);

--- a/src/engines/SessionCore/sync/sessionSyncChannel.ts
+++ b/src/engines/SessionCore/sync/sessionSyncChannel.ts
@@ -9,7 +9,15 @@ export function routeSessionChannelEvent(
   refs: Pick<SessionSyncRefs, "handlerRef">,
   logger: Logger
 ): void {
-  if (!refs.handlerRef.current) return;
+  if (!refs.handlerRef.current) {
+    logger.rateLimited(
+      "session-channel-no-handler",
+      30_000,
+      "dropped a delivered session channel frame: no handler mounted",
+      raw.slice(0, 200)
+    );
+    return;
+  }
   try {
     const parsed = parseRawSessionEvent(raw) as RawSessionEvent;
     refs.handlerRef.current.handleEvent(parsed);

--- a/src/engines/SessionCore/sync/useSessionChannel.ts
+++ b/src/engines/SessionCore/sync/useSessionChannel.ts
@@ -75,26 +75,36 @@ function markSessionChannelReady(sessionId: string): void {
  * Wait until the active SessionSyncProvider has registered the per-session IPC
  * channel. New fork sessions can complete very quickly; dispatching before this
  * edge can lose the terminal event and leave only the optimistic running state.
+ *
+ * Resolves `true` when the channel registered, `false` on timeout. A timeout
+ * means NO surface has mounted the session's channel — every lifecycle frame
+ * (agent:complete, queue_status) for a dispatch made now will be dropped at
+ * the bus registry and the turn will only end via the 60s planning-indicator
+ * watchdog. Callers must surface this loudly instead of dispatching as if
+ * ready.
  */
 export async function waitForSessionChannelReady(
   sessionId: string,
   timeoutMs = 5_000
-): Promise<void> {
-  if (readySessionChannels.has(sessionId)) return;
-  await new Promise<void>((resolve) => {
+): Promise<boolean> {
+  if (readySessionChannels.has(sessionId)) return true;
+  return new Promise<boolean>((resolve) => {
     const waiters = readySessionChannelWaiters.get(sessionId) ?? new Set();
-    waiters.add(resolve);
     readySessionChannelWaiters.set(sessionId, waiters);
     const timer = setTimeout(() => {
-      waiters.delete(resolve);
+      waiters.delete(wrappedResolve);
       if (waiters.size === 0) readySessionChannelWaiters.delete(sessionId);
-      resolve();
+      log.warn(
+        `[SessionChannel] channel for ${sessionId} not registered after ` +
+          `${timeoutMs}ms — no surface mounted it; lifecycle frames for ` +
+          `dispatches made now will be lost until a session view mounts`
+      );
+      resolve(false);
     }, timeoutMs);
     const wrappedResolve = () => {
       clearTimeout(timer);
-      resolve();
+      resolve(true);
     };
-    waiters.delete(resolve);
     waiters.add(wrappedResolve);
   });
 }

--- a/src/engines/SessionCore/sync/useSessionChannel.ts
+++ b/src/engines/SessionCore/sync/useSessionChannel.ts
@@ -279,6 +279,13 @@ export function subscribeToSessionEvents(
         warn: (message, error) => log.warn(message, error),
       },
       (raw) => {
+        if (listeners.size === 0) {
+          log.warn(
+            `[SessionChannel] delivered frame for ${sessionId} had no ` +
+              `subscribers; the backend channel outlived every consumer`
+          );
+          return;
+        }
         for (const subscriber of [...listeners]) {
           try {
             subscriber(raw);
@@ -297,6 +304,15 @@ export function subscribeToSessionEvents(
 
     channel.onmessage = (message: string) => {
       recordPushEvent("channel", "session-events");
+      if (
+        message.includes('"agent:complete"') ||
+        message.includes('"agent:error"')
+      ) {
+        log.info(
+          `[SessionChannel] lifecycle frame arrived for ${sessionId} ` +
+            `(destroyed=${lifecycle.isDestroyed()})`
+        );
+      }
       lifecycle.onMessage(message);
     };
     void lifecycle.start().then((channelId) => {
@@ -311,6 +327,14 @@ export function subscribeToSessionEvents(
   }
 
   shared.listeners.add(listener);
+  // Re-subscribing onto a channel that is still registered must re-assert
+  // readiness: `readySessionChannels` is cleared on the last unsubscribe, and
+  // without this a later consumer would wait out the full readiness timeout
+  // (and dispatch believing no channel exists) even though the backend
+  // registration never went away.
+  if (shared.lifecycle.getChannelId() !== null) {
+    markSessionChannelReady(sessionId);
+  }
   let disposed = false;
   return () => {
     if (disposed) return;

--- a/src/engines/SessionCore/sync/useSessionSync.ts
+++ b/src/engines/SessionCore/sync/useSessionSync.ts
@@ -269,6 +269,7 @@ export function useSessionSync(
       return;
     }
 
+    logger.info(`pipeline switching to session ${sessionId}`);
     return runSessionSwitchEffect({
       sessionId,
       reloadEpoch,

--- a/src/features/Org2Cloud/CloudSessionShareDialog/shareEligibility.test.ts
+++ b/src/features/Org2Cloud/CloudSessionShareDialog/shareEligibility.test.ts
@@ -170,3 +170,38 @@ describe("getActiveCloudShareOrgsForSession", () => {
     ).toEqual([]);
   });
 });
+
+describe("legacy bare-uuid orgId rows (pre-selector fork/import stamps)", () => {
+  const UUID = "0aefaa1f-de59-4fbe-a4e5-57cbe6c2bbdd";
+  const ORGS_UUID: Org2CloudOrg[] = [
+    { orgId: UUID, name: "CU Vanta", role: "member" },
+  ];
+  const scopes = { [UUID]: ["github.com/acme/alpha"] };
+
+  it("resolves ownership so a fork keeps its share affordance", () => {
+    // Forks were stamped with the bare org uuid instead of `cloud:<uuid>`,
+    // which the strict parser rejects — the session then looked org-less and
+    // the share dialog offered nothing.
+    expect(
+      getCloudShareOrgsForSession(
+        { session_id: "agentsession-1", orgId: UUID },
+        {},
+        ORGS_UUID,
+        scopes,
+        ["github.com/acme/alpha"]
+      ).map((org) => org.orgId)
+    ).toEqual([UUID]);
+  });
+
+  it("still treats non-cloud scopes as org-less", () => {
+    expect(
+      getCloudShareOrgsForSession(
+        { session_id: "s1", orgId: "personal-org" },
+        {},
+        ORGS_UUID,
+        scopes,
+        ["github.com/acme/alpha"]
+      )
+    ).toEqual([]);
+  });
+});

--- a/src/features/Org2Cloud/CloudSessionShareDialog/shareEligibility.ts
+++ b/src/features/Org2Cloud/CloudSessionShareDialog/shareEligibility.ts
@@ -23,6 +23,22 @@ import {
   parseCloudOrgSelectorValue,
 } from "../org2CloudOrgsAtom";
 
+const BARE_ORG_UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Owning cloud org from `Session.orgId`, tolerating rows written before
+ * fork/import stamped the selector form: those carry a BARE org uuid, which
+ * the strict parser rejects, so their session looked org-less and lost every
+ * ownership-derived affordance (share dialog, org selector placement).
+ * `personal-org` and other non-cloud scopes still resolve to null.
+ */
+function resolveOwningCloudOrgId(orgId: string): string | null {
+  const parsed = parseCloudOrgSelectorValue(orgId);
+  if (parsed) return parsed;
+  return BARE_ORG_UUID_RE.test(orgId) ? orgId : null;
+}
+
 export function getCloudShareOrgsForSession(
   session: Pick<Session, "session_id" | "orgId">,
   sessionOrgTags: SessionOrgTags,
@@ -35,7 +51,7 @@ export function getCloudShareOrgsForSession(
     cloudOrgIdsForSession(sessionOrgTags, session.session_id)
   );
   const owningCloudOrgId = session.orgId
-    ? parseCloudOrgSelectorValue(session.orgId)
+    ? resolveOwningCloudOrgId(session.orgId)
     : null;
   if (owningCloudOrgId) explicitOrgIds.add(owningCloudOrgId);
 

--- a/src/features/Org2Cloud/Org2CloudSection.tsx
+++ b/src/features/Org2Cloud/Org2CloudSection.tsx
@@ -18,19 +18,25 @@ import {
   SectionRow,
 } from "@/src/modules/shared/layouts/SectionLayout";
 import { useAtom, useStore } from "jotai";
-import { RefreshCw } from "lucide-react";
+import { Pencil, RefreshCw } from "lucide-react";
 import React, { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
+import Input from "@src/components/Input";
 import Message from "@src/components/Message";
 import { REFRESH_ICON_TOKENS } from "@src/components/RefreshIcon/tokens";
 import CloudEndpointCard from "@src/features/Org2Cloud/CloudEndpointCard";
 import { importBundledOrg2CloudAuthForDev } from "@src/features/Org2Cloud/devBundledAuthImport";
 import {
+  commitRefreshedAuth,
   org2CloudAuthAtom,
   org2CloudAuthIdentityKey,
 } from "@src/features/Org2Cloud/org2CloudAuthAtom";
+import {
+  ensureFreshSession,
+  updateCloudProfileDisplayName,
+} from "@src/features/Org2Cloud/org2CloudClient";
 import { resetOrgEntitlementCoordinator } from "@src/features/Org2Cloud/org2CloudEntitlementCoordinator";
 import { useOrg2CloudSignIn } from "@src/features/Org2Cloud/useOrg2CloudSignIn";
 import { createLogger } from "@src/hooks/logger";
@@ -52,6 +58,8 @@ const Org2CloudSection: React.FC<Org2CloudSectionProps> = ({
   const { t } = useTranslation(["navigation", "common"]);
   const [auth, setAuth] = useAtom(org2CloudAuthAtom);
   const [isRefreshingDevAuth, setIsRefreshingDevAuth] = useState(false);
+  const [renameDraft, setRenameDraft] = useState<string | null>(null);
+  const [isSavingRename, setIsSavingRename] = useState(false);
   const store = useStore();
   const signedInIdentity =
     auth?.profile?.displayName ??
@@ -60,6 +68,40 @@ const Org2CloudSection: React.FC<Org2CloudSectionProps> = ({
     "";
 
   const handleSignIn = useOrg2CloudSignIn();
+
+  const handleSaveRename = useCallback(async () => {
+    const trimmed = (renameDraft ?? "").trim();
+    if (!auth || !trimmed || trimmed.length > 64 || isSavingRename) return;
+    setIsSavingRename(true);
+    try {
+      const fresh = await ensureFreshSession(auth);
+      if (!fresh) {
+        Message.error(t("cloud.renameFailed"));
+        return;
+      }
+      commitRefreshedAuth(setAuth, auth, fresh);
+      const stored = await updateCloudProfileDisplayName(
+        fresh.accessToken,
+        trimmed
+      );
+      if (stored === null) {
+        Message.error(t("cloud.renameFailed"));
+        return;
+      }
+      setAuth((current) =>
+        current
+          ? {
+              ...current,
+              profile: { ...current.profile, displayName: stored },
+            }
+          : current
+      );
+      setRenameDraft(null);
+      Message.success(t("cloud.renameSaved"));
+    } finally {
+      setIsSavingRename(false);
+    }
+  }, [auth, isSavingRename, renameDraft, setAuth, t]);
 
   const handleSignOut = useCallback(() => {
     resetOrgEntitlementCoordinator(store);
@@ -112,7 +154,39 @@ const Org2CloudSection: React.FC<Org2CloudSectionProps> = ({
           align="start"
         >
           <div className={SECTION_ACTION_GAP_CLASSES}>
-            {auth ? (
+            {auth && renameDraft !== null ? (
+              <div className="flex items-center gap-2">
+                <Input
+                  value={renameDraft}
+                  onChange={(value) => setRenameDraft(value)}
+                  maxLength={64}
+                  autoFocus
+                  className="w-48"
+                  data-testid="org2-cloud-rename-input"
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") void handleSaveRename();
+                    if (event.key === "Escape") setRenameDraft(null);
+                  }}
+                />
+                <Button
+                  size="default"
+                  loading={isSavingRename}
+                  disabled={isSavingRename || !(renameDraft ?? "").trim()}
+                  onClick={() => void handleSaveRename()}
+                  data-testid="org2-cloud-rename-save"
+                >
+                  {t("common:actions.save")}
+                </Button>
+                <Button
+                  size="default"
+                  disabled={isSavingRename}
+                  onClick={() => setRenameDraft(null)}
+                  data-testid="org2-cloud-rename-cancel"
+                >
+                  {t("common:actions.cancel")}
+                </Button>
+              </div>
+            ) : auth ? (
               <div className="flex items-center gap-2">
                 <span
                   className="max-w-56 truncate text-sm text-text-2"
@@ -121,6 +195,16 @@ const Org2CloudSection: React.FC<Org2CloudSectionProps> = ({
                 >
                   {t("cloud.signedInAs", { name: signedInIdentity })}
                 </span>
+                <Button
+                  size="default"
+                  iconOnly
+                  icon={<Pencil size={14} />}
+                  aria-label={t("cloud.renameDisplayName")}
+                  onClick={() =>
+                    setRenameDraft(auth.profile?.displayName ?? "")
+                  }
+                  data-testid="org2-cloud-rename"
+                />
                 <Button
                   size="default"
                   onClick={handleSignOut}

--- a/src/features/Org2Cloud/org2CloudClient.ts
+++ b/src/features/Org2Cloud/org2CloudClient.ts
@@ -168,6 +168,22 @@ export async function getCloudProfile(
   };
 }
 
+/**
+ * Rename the signed-in user's display name (0008 `update_cloud_profile`).
+ * Returns the stored name, or `null` on any failure — including pre-0008
+ * backends, where the RPC is absent.
+ */
+export async function updateCloudProfileDisplayName(
+  accessToken: string,
+  displayName: string
+): Promise<string | null> {
+  const payload = await callRpc("update_cloud_profile", accessToken, {
+    p_display_name: displayName,
+  });
+  const parsed = z.object({ displayName: z.string() }).safeParse(payload);
+  return parsed.success ? parsed.data.displayName : null;
+}
+
 const EntitlementStateWireSchema = z.object({
   plan: z.string(),
   status: z.string(),

--- a/src/features/Org2Cloud/org2CloudSessionCommentsAtom.ts
+++ b/src/features/Org2Cloud/org2CloudSessionCommentsAtom.ts
@@ -284,7 +284,10 @@ export function useSessionComments(
             dropPendingForce(requestKey);
             return;
           }
-          log.warn("cloud_list_session_comments failed:", error);
+          log.warn(
+            `cloud_list_session_comments failed for ${targetKey}:`,
+            error
+          );
           // Visibility revocation EVICTS the cached bodies (0002 invariant
           // 5 for already-cached data); transient failures keep them.
           const evict = shouldEvictSessionCommentsOnError(error);

--- a/src/features/Org2Cloud/org2CloudSessionSync.ts
+++ b/src/features/Org2Cloud/org2CloudSessionSync.ts
@@ -95,6 +95,9 @@ export class Org2CloudSessionSync extends Org2CloudSessionSyncState {
     SessionPushRetryState
   >();
 
+  /** A short read must repeat identically across passes before it rewrites. */
+  private readonly sessionShrinkCandidates = new Map<string, number>();
+
   constructor(
     getStore: () => CloudStore | null,
     private readonly client: Org2CloudSyncClientDeps
@@ -105,6 +108,7 @@ export class Org2CloudSessionSync extends Org2CloudSessionSyncState {
   override reset(): void {
     super.reset();
     this.sessionPushRetryStates.clear();
+    this.sessionShrinkCandidates.clear();
   }
 
   override prune(
@@ -112,13 +116,19 @@ export class Org2CloudSessionSync extends Org2CloudSessionSyncState {
     liveSessionIds: ReadonlySet<string>
   ): void {
     super.prune(liveOrgIds, liveSessionIds);
-    for (const key of this.sessionPushRetryStates.keys()) {
-      const separatorIndex = key.indexOf(":");
-      const orgId = separatorIndex === -1 ? key : key.slice(0, separatorIndex);
-      const sessionId =
-        separatorIndex === -1 ? "" : key.slice(separatorIndex + 1);
-      if (!liveOrgIds.has(orgId) || !liveSessionIds.has(sessionId)) {
-        this.sessionPushRetryStates.delete(key);
+    for (const states of [
+      this.sessionPushRetryStates,
+      this.sessionShrinkCandidates,
+    ] as const) {
+      for (const key of states.keys()) {
+        const separatorIndex = key.indexOf(":");
+        const orgId =
+          separatorIndex === -1 ? key : key.slice(0, separatorIndex);
+        const sessionId =
+          separatorIndex === -1 ? "" : key.slice(separatorIndex + 1);
+        if (!liveOrgIds.has(orgId) || !liveSessionIds.has(sessionId)) {
+          states.delete(key);
+        }
       }
     }
   }
@@ -413,12 +423,27 @@ export class Org2CloudSessionSync extends Org2CloudSessionSyncState {
       this.markEventPlaneClean(orgId, session, stampAtRead);
       return;
     }
+    const shrinkKey = `${orgId}:${sessionId}`;
+    let confirmedShrink = false;
     if (cursor && events.length < cursor.pushedCount) {
-      log.warn(
-        `persisted read for ${sessionId} returned ${events.length} events ` +
-          `but the cloud cursor covers ${cursor.pushedCount}; skipping`
-      );
-      return;
+      if (this.sessionShrinkCandidates.get(shrinkKey) === events.length) {
+        this.sessionShrinkCandidates.delete(shrinkKey);
+        confirmedShrink = true;
+        log.info(
+          `persisted read for ${sessionId} returned ${events.length} events ` +
+            `on consecutive passes while the cloud cursor covers ` +
+            `${cursor.pushedCount}; re-anchoring via epoch rewrite`
+        );
+      } else {
+        this.sessionShrinkCandidates.set(shrinkKey, events.length);
+        log.warn(
+          `persisted read for ${sessionId} returned ${events.length} events ` +
+            `but the cloud cursor covers ${cursor.pushedCount}; skipping`
+        );
+        return;
+      }
+    } else {
+      this.sessionShrinkCandidates.delete(shrinkKey);
     }
 
     const {
@@ -430,7 +455,8 @@ export class Org2CloudSessionSync extends Org2CloudSessionSyncState {
     } = await plan();
 
     if (cursor) {
-      let frozenIntact = frozenEventCount >= cursor.frozenEventCount;
+      let frozenIntact =
+        !confirmedShrink && frozenEventCount >= cursor.frozenEventCount;
       if (frozenIntact && cursor.frozenEventCount > 0) {
         const chainAtCursor =
           cursor.frozenEventCount === frozenEventCount

--- a/src/features/Org2Cloud/org2CloudSessionSync.ts
+++ b/src/features/Org2Cloud/org2CloudSessionSync.ts
@@ -468,6 +468,20 @@ export class Org2CloudSessionSync extends Org2CloudSessionSyncState {
         frozenIntact = chainAtCursor === cursor.frozenChainHash;
       }
 
+      if (!frozenIntact) {
+        // An epoch rewrite re-uploads the ENTIRE frozen history. It is the
+        // expensive path, so name the condition that forced it: a silent
+        // rewrite loop is indistinguishable from steady state in the ledger.
+        log.info(
+          `epoch rewrite for ${sessionId} org ${orgId}: ` +
+            `confirmedShrink=${confirmedShrink} ` +
+            `frozen=${frozenEventCount} cursorFrozen=${cursor.frozenEventCount} ` +
+            `chainMismatch=${
+              !confirmedShrink && frozenEventCount >= cursor.frozenEventCount
+            }`
+        );
+      }
+
       if (frozenIntact) {
         const newFrozenEvents = events.slice(
           cursor.frozenEventCount,

--- a/src/features/Org2Cloud/org2CloudStorageClient.test.ts
+++ b/src/features/Org2Cloud/org2CloudStorageClient.test.ts
@@ -37,19 +37,19 @@ describe("buildReplayObjectPath", () => {
 });
 
 describe("uploadReplayObject", () => {
-  it("PUTs raw gzip bytes with JWT + apikey + upsert headers", async () => {
+  it("POSTs raw gzip bytes with JWT + apikey headers", async () => {
     const bytes = new Uint8Array([31, 139, 8, 0]);
     await uploadReplayObject("jwt-1", "org-1/s-1/3/7-abc.gz", bytes);
     const { url, init } = lastCall();
     expect(url).toBe(
       `${ORG2_CLOUD_OFFICIAL_SUPABASE_URL}/storage/v1/object/replay/org-1/s-1/3/7-abc.gz`
     );
-    expect(init.method).toBe("PUT");
+    expect(init.method).toBe("POST");
     const headers = init.headers as Record<string, string>;
     expect(headers.apikey).toBe(ORG2_CLOUD_OFFICIAL_ANON_KEY);
     expect(headers.authorization).toBe("Bearer jwt-1");
     expect(headers["content-type"]).toBe("application/gzip");
-    expect(headers["x-upsert"]).toBe("true");
+    expect(headers["x-upsert"]).toBeUndefined();
     expect(new Uint8Array(init.body as Uint8Array)).toEqual(bytes);
   });
 
@@ -81,6 +81,58 @@ describe("uploadReplayObject", () => {
     ).catch((caught: unknown) => caught);
     expect(error).toBeInstanceOf(Org2CloudStorageError);
     expect((error as Org2CloudStorageError).status).toBe(403);
+  });
+
+  it("treats an RLS-wrapped duplicate as success once the object is readable", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            statusCode: "403",
+            error: "Unauthorized",
+            message: "new row violates row-level security policy",
+          }),
+          { status: 400 }
+        )
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    await expect(
+      uploadReplayObject("jwt-1", "org-1/s-1/1/1-h.gz", new Uint8Array([1]))
+    ).resolves.toBeUndefined();
+    expect(lastCall().init.method).toBe("HEAD");
+  });
+
+  it("still throws when the RLS denial is genuine (object not readable)", async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            statusCode: "403",
+            message: "new row violates row-level security policy",
+          }),
+          { status: 400 }
+        )
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 404 }));
+
+    const error = await uploadReplayObject(
+      "jwt-1",
+      "org-1/s-1/1/1-h.gz",
+      new Uint8Array([1])
+    ).catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(Org2CloudStorageError);
+    expect((error as Org2CloudStorageError).status).toBe(400);
+  });
+
+  it("accepts a plain 409 duplicate when the object is readable", async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response(null, { status: 409 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    await expect(
+      uploadReplayObject("jwt-1", "org-1/s-1/1/1-h.gz", new Uint8Array([1]))
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/src/features/Org2Cloud/org2CloudStorageClient.ts
+++ b/src/features/Org2Cloud/org2CloudStorageClient.ts
@@ -58,22 +58,69 @@ export async function uploadReplayObject(
   signal?: AbortSignal
 ): Promise<void> {
   const response = await fetchWithTransportRetry(objectUrl(path, endpoint), {
-    method: "PUT",
+    method: "POST",
     headers: {
       ...objectHeaders(accessToken, endpoint),
       "content-type": "application/gzip",
-      "x-upsert": "true",
     },
     // Copy into a fresh ArrayBuffer-backed view: the DOM typings reject
     // Uint8Array<ArrayBufferLike> as a BodyInit.
     body: new Uint8Array(bytes),
     signal,
   });
-  if (!response.ok) {
-    throw new Org2CloudStorageError(
-      `replay object upload failed with ${response.status}`,
-      response.status
+  if (response.ok) return;
+  const body = await response.text().catch(() => "");
+  // Replay objects are content-addressed (segment hash in the key) and the
+  // storage policies grant INSERT but never UPDATE, so re-uploading an
+  // existing name is rejected rather than applied — the normal retry/resume
+  // path. Supabase reports it as 409, or as a 400 envelope wrapping a 403
+  // RLS denial when the policy blocks the implied update, which is
+  // indistinguishable by status from a genuine authorization failure.
+  // Confirm the object is actually readable before treating it as done, so
+  // a real denial still surfaces.
+  if (mayMeanReplayObjectExists(response.status, body)) {
+    const exists = await replayObjectExists(
+      accessToken,
+      path,
+      endpoint,
+      signal
     );
+    if (exists) return;
+  }
+  throw new Org2CloudStorageError(
+    `replay object upload failed with ${response.status}` +
+      (body ? `: ${body.slice(0, 300)}` : ""),
+    response.status
+  );
+}
+
+/** Statuses/bodies that can mean "this object name is already stored". */
+function mayMeanReplayObjectExists(status: number, body: string): boolean {
+  if (status === 409) return true;
+  if (status !== 400 && status !== 403) return false;
+  return (
+    body.includes("row-level security policy") ||
+    body.includes("Duplicate") ||
+    body.includes("already exists")
+  );
+}
+
+/** HEAD probe used only to confirm an upload rejection was a duplicate. */
+async function replayObjectExists(
+  accessToken: string,
+  path: string,
+  endpoint: CloudEndpoint,
+  signal?: AbortSignal
+): Promise<boolean> {
+  try {
+    const response = await fetchWithTransportRetry(objectUrl(path, endpoint), {
+      method: "HEAD",
+      headers: objectHeaders(accessToken, endpoint),
+      signal,
+    });
+    return response.ok;
+  } catch {
+    return false;
   }
 }
 

--- a/src/features/Org2Cloud/org2CloudSyncClient.test.ts
+++ b/src/features/Org2Cloud/org2CloudSyncClient.test.ts
@@ -291,11 +291,11 @@ describe("storage segment offload (0006)", () => {
     expect(uploadUrl).toBe(
       `${ORG2_CLOUD_OFFICIAL_SUPABASE_URL}/storage/v1/object/replay/${path}`
     );
-    expect(uploadInit.method).toBe("PUT");
+    expect(uploadInit.method).toBe("POST");
     const uploadHeaders = uploadInit.headers as Record<string, string>;
     expect(uploadHeaders.authorization).toBe("Bearer jwt-1");
     expect(uploadHeaders["content-type"]).toBe("application/gzip");
-    expect(uploadHeaders["x-upsert"]).toBe("true");
+    expect(uploadHeaders["x-upsert"]).toBeUndefined();
     expect(
       await decodeSegmentEventsFromBytes(uploadInit.body as Uint8Array)
     ).toEqual(frozen);

--- a/src/features/Org2Cloud/org2CloudSyncEngine.constants.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.constants.ts
@@ -37,6 +37,17 @@ export const COLLAB_LISTING_SHARE_WINDOW_MS = 2_000;
  */
 export const VANISHED_SESSION_SWEEP_INTERVAL_MS = 10 * 60_000;
 
+/**
+ * A suspect must be confirmed absent on this many CONSECUTIVE sweeps before
+ * its cloud row is retracted. A single successful-but-empty exact-id lookup
+ * is not proof of local deletion: while the imported-history cache rebuilds
+ * (schema migration, cleared cache) every not-yet-reingested session reads
+ * as absent, and one sweep in that window would mass-retract live shared
+ * rows. Rebuilds finish well inside one sweep interval, so the second
+ * confirmation only ever fires on sessions that are genuinely gone.
+ */
+export const VANISHED_SESSION_RETRACT_CONFIRMATIONS = 2;
+
 /** Entitlement failures are retried after this bounded cool-down. Realtime
  * policy signals and explicit user changes clear the deadline immediately. */
 export const ORG_BACKOFF_COOLDOWN_MS = 5 * 60_000;

--- a/src/features/Org2Cloud/org2CloudSyncEngine.repoScopeSync.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.repoScopeSync.ts
@@ -39,6 +39,12 @@ export function getSessionScopeKeys(
 export class Org2CloudRepoScopeSync {
   /** orgId → last repo-scope hydration attempt (TTL-gated per pass). */
   private readonly hydratedAtMs = new Map<string, number>();
+  /** Orgs whose scopes this RUN has confirmed against the server. The
+   * persisted mirror is restored empty-or-stale on boot, and an empty scope
+   * list makes every candidate read as out-of-scope — which retracts live
+   * shared rows and drops their org tags. Destructive scope decisions wait
+   * for a confirmed fetch; pushes still run off the mirror. */
+  private readonly serverConfirmedOrgIds = new Set<string>();
 
   constructor(
     private readonly getStore: () => CloudStore | null,
@@ -47,12 +53,23 @@ export class Org2CloudRepoScopeSync {
 
   reset(): void {
     this.hydratedAtMs.clear();
+    this.serverConfirmedOrgIds.clear();
   }
 
   prune(currentOrgIds: ReadonlySet<string>): void {
     for (const orgId of this.hydratedAtMs.keys()) {
       if (!currentOrgIds.has(orgId)) this.hydratedAtMs.delete(orgId);
     }
+    for (const orgId of this.serverConfirmedOrgIds) {
+      if (!currentOrgIds.has(orgId)) this.serverConfirmedOrgIds.delete(orgId);
+    }
+  }
+
+  /** True once THIS run has read the org's scopes from the server. Gates
+   * every scope-driven retract/untag: a mirror that was never confirmed
+   * cannot prove a session is out of scope. */
+  hasServerConfirmedScopes(orgId: string): boolean {
+    return this.serverConfirmedOrgIds.has(orgId);
   }
 
   /** Realtime full-recovery invalidation (or a plain reconnect when
@@ -93,6 +110,7 @@ export class Org2CloudRepoScopeSync {
           ...current,
           [org.orgId]: state.repoScopes,
         }));
+        this.serverConfirmedOrgIds.add(org.orgId);
       } catch (error) {
         if (!isCurrentGeneration(generation)) return;
         log.warn(`repo-scope hydration failed for org ${org.orgId}:`, error);

--- a/src/features/Org2Cloud/org2CloudSyncEngine.scopeConfirmation.test.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.scopeConfirmation.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  SCOPE_KEY,
+  SESSION,
+  cleanupEngineFixture,
+  createEngineFixture,
+  engineTestDeps,
+} from "./org2CloudSyncEngine.testUtils";
+import type { EngineFixture } from "./org2CloudSyncEngine.testUtils";
+
+const {
+  cloudOrgToken,
+  org2CloudPushedMetadataAtom,
+  org2CloudRepoScopesAtom,
+  sessionOrgTagsAtom,
+  sessionsAtom,
+} = engineTestDeps;
+
+describe("scope-driven retract requires server-confirmed scopes", () => {
+  let fixture: EngineFixture;
+  let store: EngineFixture["store"];
+  let client: EngineFixture["client"];
+  let engine: EngineFixture["engine"];
+
+  beforeEach(() => {
+    fixture = createEngineFixture();
+    ({ store, client, engine } = fixture);
+    // A previously-pushed, tagged session whose persisted scope mirror is
+    // empty — the exact boot state that mass-retracted live rows.
+    store.set(sessionsAtom, [SESSION]);
+    store.set(sessionOrgTagsAtom, {
+      [SESSION.session_id]: [cloudOrgToken("corg-1")],
+    });
+    store.set(org2CloudPushedMetadataAtom, {
+      [`corg-1:${SESSION.session_id}`]: true,
+    });
+    store.set(org2CloudRepoScopesAtom, { "corg-1": [] });
+  });
+
+  afterEach(() => {
+    cleanupEngineFixture(engine);
+  });
+
+  it("does not retract or untag while the scope fetch keeps failing", async () => {
+    client.getOrgRepoScopes.mockRejectedValue(new Error("offline"));
+
+    await engine.runSyncPass();
+
+    expect(client.deleteSession).not.toHaveBeenCalled();
+    expect(store.get(sessionOrgTagsAtom)[SESSION.session_id]).toEqual([
+      cloudOrgToken("corg-1"),
+    ]);
+  });
+
+  it("retracts once the server confirms the session is genuinely out of scope", async () => {
+    client.getOrgRepoScopes.mockResolvedValue({
+      repoScopes: ["github.com/other/repo"],
+      used: 1,
+      cap: null,
+      cooldownDays: 0,
+      coolingDown: [],
+    });
+
+    await engine.runSyncPass();
+
+    expect(client.deleteSession).toHaveBeenCalledWith(
+      "jwt-1",
+      "corg-1",
+      SESSION.session_id
+    );
+    expect(store.get(sessionOrgTagsAtom)[SESSION.session_id] ?? []).toEqual([]);
+  });
+
+  it("keeps pushing in-scope sessions on a confirmed fetch", async () => {
+    client.getOrgRepoScopes.mockResolvedValue({
+      repoScopes: [SCOPE_KEY],
+      used: 1,
+      cap: null,
+      cooldownDays: 0,
+      coolingDown: [],
+    });
+
+    await engine.runSyncPass();
+
+    expect(client.deleteSession).not.toHaveBeenCalled();
+    expect(client.upsertSessionMetadata).toHaveBeenCalled();
+  });
+});

--- a/src/features/Org2Cloud/org2CloudSyncEngine.sessionShrink.test.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.sessionShrink.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  cleanupEngineFixture,
+  createEngineFixture,
+  engineTestDeps,
+  eventStoreMock,
+  makeEvent,
+  notifySessionEvents,
+} from "./org2CloudSyncEngine.testUtils";
+import type { EngineFixture } from "./org2CloudSyncEngine.testUtils";
+
+const { org2CloudPushCursorsAtom } = engineTestDeps;
+
+describe("Org2CloudSyncEngine persistent-shrink re-anchor", () => {
+  let fixture: EngineFixture;
+  let store: EngineFixture["store"];
+  let client: EngineFixture["client"];
+  let engine: EngineFixture["engine"];
+
+  beforeEach(() => {
+    fixture = createEngineFixture();
+    ({ store, client, engine } = fixture);
+  });
+
+  afterEach(() => {
+    cleanupEngineFixture(engine);
+  });
+
+  it("skips a single short read without rewriting or moving the cursor", async () => {
+    await engine.runSyncPass();
+    const anchored = store.get(org2CloudPushCursorsAtom)["corg-1:session-1"];
+    expect(anchored).toMatchObject({ epoch: 1, pushedCount: 2 });
+
+    eventStoreMock.getPersistedEvents.mockResolvedValue([makeEvent("e1")]);
+    notifySessionEvents("session-1");
+    await engine.runSyncPass();
+
+    expect(client.rewriteSessionEvents).toHaveBeenCalledTimes(1);
+    expect(client.appendSessionEvents).not.toHaveBeenCalled();
+    expect(store.get(org2CloudPushCursorsAtom)["corg-1:session-1"]).toEqual(
+      anchored
+    );
+  });
+
+  it("re-anchors via epoch rewrite after two consecutive identical short reads", async () => {
+    await engine.runSyncPass();
+    eventStoreMock.getPersistedEvents.mockResolvedValue([makeEvent("e1")]);
+    notifySessionEvents("session-1");
+    await engine.runSyncPass();
+    expect(client.rewriteSessionEvents).toHaveBeenCalledTimes(1);
+
+    await engine.runSyncPass();
+
+    expect(client.rewriteSessionEvents).toHaveBeenCalledTimes(2);
+    expect(client.getSessionEvents).not.toHaveBeenCalled();
+    const [, rewrite] = client.rewriteSessionEvents.mock.calls[1];
+    expect(rewrite).toMatchObject({
+      orgId: "corg-1",
+      sessionId: "session-1",
+      newEpoch: 2,
+      totalCount: 1,
+    });
+    expect(
+      store.get(org2CloudPushCursorsAtom)["corg-1:session-1"]
+    ).toMatchObject({
+      epoch: 2,
+      pushedCount: 1,
+      frozenEventCount: 1,
+    });
+
+    eventStoreMock.getPersistedEvents.mockResolvedValue([
+      makeEvent("e1"),
+      makeEvent("e3", "running"),
+    ]);
+    notifySessionEvents("session-1");
+    await engine.runSyncPass();
+
+    expect(client.rewriteSessionEvents).toHaveBeenCalledTimes(2);
+    expect(client.appendSessionEvents).toHaveBeenCalledTimes(1);
+    const [, append] = client.appendSessionEvents.mock.calls[0];
+    expect(append).toMatchObject({ expectedEpoch: 2, totalCount: 2 });
+    expect(
+      store.get(org2CloudPushCursorsAtom)["corg-1:session-1"]
+    ).toMatchObject({
+      epoch: 2,
+      pushedCount: 2,
+    });
+  });
+
+  it("a full-length read between short reads resets the confirmation counter", async () => {
+    await engine.runSyncPass();
+    eventStoreMock.getPersistedEvents.mockResolvedValue([makeEvent("e1")]);
+    notifySessionEvents("session-1");
+    await engine.runSyncPass();
+    expect(client.rewriteSessionEvents).toHaveBeenCalledTimes(1);
+
+    eventStoreMock.getPersistedEvents.mockResolvedValue([
+      makeEvent("e1"),
+      makeEvent("e2"),
+      makeEvent("e3", "running"),
+    ]);
+    await engine.runSyncPass();
+
+    expect(client.rewriteSessionEvents).toHaveBeenCalledTimes(1);
+    expect(client.appendSessionEvents).toHaveBeenCalledTimes(1);
+    expect(
+      store.get(org2CloudPushCursorsAtom)["corg-1:session-1"]
+    ).toMatchObject({
+      epoch: 1,
+      pushedCount: 3,
+    });
+
+    eventStoreMock.getPersistedEvents.mockResolvedValue([makeEvent("e1")]);
+    notifySessionEvents("session-1");
+    await engine.runSyncPass();
+
+    expect(client.rewriteSessionEvents).toHaveBeenCalledTimes(1);
+    expect(client.appendSessionEvents).toHaveBeenCalledTimes(1);
+    expect(
+      store.get(org2CloudPushCursorsAtom)["corg-1:session-1"]
+    ).toMatchObject({
+      epoch: 1,
+      pushedCount: 3,
+    });
+  });
+});

--- a/src/features/Org2Cloud/org2CloudSyncEngine.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.ts
@@ -99,7 +99,10 @@ import {
   org2CloudSyncEnabledAtom,
 } from "./org2CloudSyncAtoms";
 import * as org2CloudSyncClient from "./org2CloudSyncClient";
-import { VANISHED_SESSION_SWEEP_INTERVAL_MS } from "./org2CloudSyncEngine.constants";
+import {
+  VANISHED_SESSION_RETRACT_CONFIRMATIONS,
+  VANISHED_SESSION_SWEEP_INTERVAL_MS,
+} from "./org2CloudSyncEngine.constants";
 import {
   Org2CloudOrgBackoffTracker,
   isCloudSyncBackoffError,
@@ -173,6 +176,10 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
   private readonly resolveLocalSessionIds: LocalSessionIdResolver;
   /** Per-org timestamp of the last vanished-session GC sweep. */
   private readonly lastVanishedSweepAtMs = new Map<string, number>();
+  /** `${orgId}:${sessionId}` → consecutive sweeps confirmed absent. A
+   * suspect retracts only at VANISHED_SESSION_RETRACT_CONFIRMATIONS, so one
+   * empty lookup during a cache rebuild cannot mass-retract live rows. */
+  private readonly vanishedStrikes = new Map<string, number>();
 
   constructor(
     client: Org2CloudSyncClientDeps = org2CloudSyncClient,
@@ -208,6 +215,7 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
     this.sessionColdStart.reset();
     this.schemaGate.reset();
     this.lastVanishedSweepAtMs.clear();
+    this.vanishedStrikes.clear();
   }
 
   protected override clearAllOrgBackoffs(): void {
@@ -705,13 +713,32 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
       resolveSessionIds: this.resolveLocalSessionIds,
     });
     if (this.generation !== generation) return;
+    const confirmedAbsent = new Set(vanishedIds);
+    for (const key of this.vanishedStrikes.keys()) {
+      if (!key.startsWith(`${orgId}:`)) continue;
+      if (!confirmedAbsent.has(key.slice(orgId.length + 1))) {
+        this.vanishedStrikes.delete(key);
+      }
+    }
     for (const sessionId of vanishedIds) {
       if (this.generation !== generation) return;
+      const strikeKey = `${orgId}:${sessionId}`;
+      const strikes = (this.vanishedStrikes.get(strikeKey) ?? 0) + 1;
+      if (strikes < VANISHED_SESSION_RETRACT_CONFIRMATIONS) {
+        this.vanishedStrikes.set(strikeKey, strikes);
+        log.info(
+          `vanished-session suspect ${sessionId} org ${orgId} confirmed ` +
+            `absent (${strikes}/${VANISHED_SESSION_RETRACT_CONFIRMATIONS}); ` +
+            `deferring retract to the next sweep`
+        );
+        continue;
+      }
       try {
         log.info(
           `cloud retract [vanished locally]: session ${sessionId} org ${orgId}`
         );
         await this.sessionSync.retractSession(fresh, orgId, sessionId);
+        this.vanishedStrikes.delete(strikeKey);
       } catch (error) {
         if (this.generation !== generation) return;
         if (isCloudSyncBackoffError(error)) {
@@ -741,6 +768,10 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
     this.sessionColdStart.prune(currentOrgIds);
     for (const orgId of this.lastVanishedSweepAtMs.keys()) {
       if (!currentOrgIds.has(orgId)) this.lastVanishedSweepAtMs.delete(orgId);
+    }
+    for (const key of this.vanishedStrikes.keys()) {
+      const orgId = key.slice(0, key.indexOf(":"));
+      if (!currentOrgIds.has(orgId)) this.vanishedStrikes.delete(key);
     }
     for (const orgId of this.pendingInboundOrgIds) {
       if (!currentOrgIds.has(orgId)) this.pendingInboundOrgIds.delete(orgId);

--- a/src/features/Org2Cloud/org2CloudSyncEngine.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.ts
@@ -458,6 +458,18 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
           scopes
         );
         if (matchedScope === null) {
+          // The scope mirror is persisted and restored empty-or-stale on
+          // boot. An unconfirmed mirror cannot prove "out of scope": acting
+          // on it retracts live shared rows and strips their org tags during
+          // the first passes after launch. Skip the session until this run
+          // has read the org's scopes from the server.
+          if (!this.repoScopeSync.hasServerConfirmedScopes(org.orgId)) {
+            log.info(
+              `scope check deferred for session ${session.session_id} org ` +
+                `${org.orgId}: repo scopes not yet confirmed this run`
+            );
+            continue;
+          }
           if (this.sessionSync.wasCloudPushed(org.orgId, session.session_id)) {
             try {
               log.info(

--- a/src/features/Org2Cloud/org2CloudSyncEngine.vanishedSessions.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.vanishedSessions.ts
@@ -11,14 +11,19 @@
  *
  * Absence from `sessionsAtom` alone is WEAK evidence (the roster is
  * paginated), so every suspect is confirmed gone through the backend
- * exact-id lookup before it is eligible for retraction. That lookup also
- * reports continuation-superseded siblings as absent, which is what lets the
- * sweep clean up rows pushed for siblings that were later demoted.
+ * exact-id lookup before it is eligible for retraction. The lookup runs with
+ * `includeContinuationSuperseded`: a sibling demoted by the continuation
+ * election still exists locally, and reporting it absent would retract the
+ * team's shared cloud row on every context-window continuation (/compact).
  *
  * Only ids THIS device push-marked are ever candidates: rows the same
  * account pushed from another device carry no local marker and are never
  * touched. A failed lookup means "unknown", never "gone" — the sweep returns
- * nothing rather than risk retracting a live row.
+ * nothing rather than risk retracting a live row. A successful-but-empty
+ * lookup is still weak while the imported-history cache is rebuilding
+ * (schema migration, cleared cache), so the ENGINE additionally requires a
+ * suspect to be confirmed absent on two consecutive sweeps before
+ * retracting.
  */
 import { sessionAggregateList } from "@src/api/tauri/session";
 import { createLogger } from "@src/hooks/logger";
@@ -42,6 +47,7 @@ export const resolveLocalSessionIdsViaAggregateList: LocalSessionIdResolver =
     const response = await sessionAggregateList({
       sessionIds: [...sessionIds],
       includeExternalHistory: true,
+      includeContinuationSuperseded: true,
       limit: sessionIds.length,
     });
     return new Set(response.sessions.map((record) => record.sessionId));

--- a/src/features/Org2Cloud/org2CloudSyncEngine.vanishedSweep.test.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.vanishedSweep.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  VANISHED_SESSION_RETRACT_CONFIRMATIONS,
+  VANISHED_SESSION_SWEEP_INTERVAL_MS,
+} from "./org2CloudSyncEngine.constants";
+import {
+  cleanupEngineFixture,
+  createEngineFixture,
+  engineTestDeps,
+} from "./org2CloudSyncEngine.testUtils";
+import type { EngineFixture } from "./org2CloudSyncEngine.testUtils";
+
+const { Org2CloudSyncEngine, org2CloudPushedMetadataAtom, sessionsAtom } =
+  engineTestDeps;
+
+describe("vanished-session sweep two-strike confirmation", () => {
+  let fixture: EngineFixture;
+  let store: EngineFixture["store"];
+  let client: EngineFixture["client"];
+  let engine: EngineFixture["engine"];
+  let resolveLocalSessionIds: ReturnType<typeof vi.fn>;
+
+  function startSweepEngine(): void {
+    fixture.engine.stop();
+    engine = new Org2CloudSyncEngine(
+      client,
+      fixture.projectsClient,
+      fixture.bridge,
+      undefined,
+      resolveLocalSessionIds as never
+    );
+    engine.start(store);
+  }
+
+  async function runSweepPass(): Promise<void> {
+    vi.setSystemTime(Date.now() + VANISHED_SESSION_SWEEP_INTERVAL_MS + 1);
+    await engine.runSyncPass();
+  }
+
+  beforeEach(() => {
+    fixture = createEngineFixture();
+    ({ store, client } = fixture);
+    engine = fixture.engine;
+    store.set(sessionsAtom, []);
+    store.set(org2CloudPushedMetadataAtom, { "corg-1:ghost-1": true });
+    resolveLocalSessionIds = vi.fn().mockResolvedValue(new Set());
+  });
+
+  afterEach(() => {
+    cleanupEngineFixture(engine);
+  });
+
+  it("retracts only after consecutive sweeps confirm the suspect absent", async () => {
+    startSweepEngine();
+
+    await engine.runSyncPass();
+    expect(resolveLocalSessionIds).toHaveBeenCalledTimes(1);
+    expect(client.deleteSession).not.toHaveBeenCalled();
+
+    for (let i = 1; i < VANISHED_SESSION_RETRACT_CONFIRMATIONS; i += 1) {
+      await runSweepPass();
+    }
+    expect(client.deleteSession).toHaveBeenCalledTimes(1);
+    expect(client.deleteSession).toHaveBeenCalledWith(
+      "jwt-1",
+      "corg-1",
+      "ghost-1"
+    );
+    // A successful retract clears the durable marker, so later sweeps have
+    // no suspect left to confirm.
+    await runSweepPass();
+    expect(client.deleteSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("restarts confirmation when the suspect resolves between sweeps", async () => {
+    startSweepEngine();
+
+    await engine.runSyncPass();
+    expect(client.deleteSession).not.toHaveBeenCalled();
+
+    // A cache rebuild finished: the id resolves again — the strike resets.
+    resolveLocalSessionIds.mockResolvedValue(new Set(["ghost-1"]));
+    await runSweepPass();
+    expect(client.deleteSession).not.toHaveBeenCalled();
+
+    resolveLocalSessionIds.mockResolvedValue(new Set());
+    await runSweepPass();
+    expect(client.deleteSession).not.toHaveBeenCalled();
+
+    await runSweepPass();
+    expect(client.deleteSession).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/Org2Cloud/sessionCommentTarget.test.ts
+++ b/src/features/Org2Cloud/sessionCommentTarget.test.ts
@@ -166,3 +166,50 @@ describe("resolveSessionCommentTarget", () => {
     ).toBeNull();
   });
 });
+
+describe("repo-scope auto-match admission route", () => {
+  const SCOPED = {
+    session_id: "claudecodeapp-0f593918-9d8e-43cd-8b9d-4c92d1b0e8bb",
+    repoPath: "/Users/me/Projects/ORGII",
+    repoRemoteUrls: ["git@github.com:org2AI/ORG2.git"],
+  };
+
+  it("surfaces comments for a history shared purely by repo scope", () => {
+    // The push pass admits these via isScopeMatchableImportedSession, so the
+    // cloud row and its threads exist; without the same route here the owner
+    // saw no comment affordance at all (no reply, no owner-only @agent).
+    expect(
+      resolveSessionCommentTarget({
+        session: SCOPED,
+        cloudOrgs: CLOUD_ORGS,
+        tags: {},
+        preferredOrgId: null,
+        orgRepoScopes: { "org-a": ["github.com/org2ai/org2"] },
+      })
+    ).toEqual({ orgId: "org-a", sessionId: SCOPED.session_id });
+  });
+
+  it("stays null when no org scope covers the checkout", () => {
+    expect(
+      resolveSessionCommentTarget({
+        session: SCOPED,
+        cloudOrgs: CLOUD_ORGS,
+        tags: {},
+        preferredOrgId: null,
+        orgRepoScopes: { "org-a": ["github.com/other/repo"] },
+      })
+    ).toBeNull();
+  });
+
+  it("ignores scopes of orgs the viewer is not a member of", () => {
+    expect(
+      resolveSessionCommentTarget({
+        session: SCOPED,
+        cloudOrgs: CLOUD_ORGS,
+        tags: {},
+        preferredOrgId: null,
+        orgRepoScopes: { "org-stranger": ["github.com/org2ai/org2"] },
+      })
+    ).toBeNull();
+  });
+});

--- a/src/features/Org2Cloud/sessionCommentTarget.test.ts
+++ b/src/features/Org2Cloud/sessionCommentTarget.test.ts
@@ -212,4 +212,53 @@ describe("repo-scope auto-match admission route", () => {
       })
     ).toBeNull();
   });
+
+  it("prefers the org holding the live server row over earlier scope matches", () => {
+    // After a GitHub rename both spellings resolve to one repo network, so
+    // several orgs can scope-match; only org-b ever received the push. The
+    // 34e24e9e incident: candidates[0] was a scope-matching org with no row,
+    // and every list call died with ORG2_SESSION_NOT_FOUND.
+    expect(
+      resolveSessionCommentTarget({
+        session: SCOPED,
+        cloudOrgs: CLOUD_ORGS,
+        tags: {},
+        preferredOrgId: null,
+        orgRepoScopes: {
+          "org-a": ["github.com/org2ai/org2"],
+          "org-b": ["github.com/org2ai/org2"],
+        },
+        pushedOrgIds: ["org-b"],
+      })
+    ).toEqual({ orgId: "org-b", sessionId: SCOPED.session_id });
+  });
+
+  it("keeps the full candidate set when nothing is pushed yet", () => {
+    expect(
+      resolveSessionCommentTarget({
+        session: SCOPED,
+        cloudOrgs: CLOUD_ORGS,
+        tags: {},
+        preferredOrgId: null,
+        orgRepoScopes: { "org-a": ["github.com/org2ai/org2"] },
+        pushedOrgIds: ["org-elsewhere"],
+      })
+    ).toEqual({ orgId: "org-a", sessionId: SCOPED.session_id });
+  });
+
+  it("active-scope preference still applies within the pushed set", () => {
+    expect(
+      resolveSessionCommentTarget({
+        session: SCOPED,
+        cloudOrgs: CLOUD_ORGS,
+        tags: {},
+        preferredOrgId: "org-b",
+        orgRepoScopes: {
+          "org-a": ["github.com/org2ai/org2"],
+          "org-b": ["github.com/org2ai/org2"],
+        },
+        pushedOrgIds: ["org-a", "org-b"],
+      })
+    ).toEqual({ orgId: "org-b", sessionId: SCOPED.session_id });
+  });
 });

--- a/src/features/Org2Cloud/sessionCommentTarget.ts
+++ b/src/features/Org2Cloud/sessionCommentTarget.ts
@@ -9,6 +9,7 @@ import { useAtomValue } from "jotai";
 import { useMemo } from "react";
 
 import { getSessionForkedFrom } from "@src/features/TeamCollaboration/forkSession";
+import { collectScopeMatchedImportedSessionIds } from "@src/features/TeamCollaboration/importedSessionScopeMatch";
 import {
   type SessionOrgTags,
   cloudOrgIdsForSession,
@@ -22,6 +23,7 @@ import {
   org2CloudOrgsAtom,
   parseCloudOrgSelectorValue,
 } from "./org2CloudOrgsAtom";
+import { org2CloudRepoScopesAtom } from "./org2CloudSyncAtoms";
 
 export interface SessionCommentTarget {
   orgId: string;
@@ -35,7 +37,28 @@ type CommentTargetSession = {
   orgId?: string;
   importedFrom?: Session["importedFrom"];
   forkedFrom?: Session["forkedFrom"];
+  /** Checkout identity for the repo-scope auto-match admission route. */
+  repoPath?: Session["repoPath"];
+  repoRemoteUrls?: Session["repoRemoteUrls"];
 };
+
+/** Orgs whose configured repo scopes cover this session's checkout. */
+function scopeMatchedOrgIdsForSession(
+  session: CommentTargetSession,
+  orgRepoScopes: Record<string, string[]>
+): string[] {
+  const matched: string[] = [];
+  for (const [orgId, scopes] of Object.entries(orgRepoScopes)) {
+    if (
+      collectScopeMatchedImportedSessionIds([session], scopes).has(
+        session.session_id
+      )
+    ) {
+      matched.push(orgId);
+    }
+  }
+  return matched;
+}
 
 /** Pure resolution (unit-tested; no IO). */
 export function resolveSessionCommentTarget(params: {
@@ -44,8 +67,16 @@ export function resolveSessionCommentTarget(params: {
   tags: SessionOrgTags;
   /** Cloud org id the surrounding UI scope prefers (nullable). */
   preferredOrgId: string | null;
+  /** orgId → configured repo scopes, for the auto-match admission route. */
+  orgRepoScopes?: Record<string, string[]>;
 }): SessionCommentTarget | null {
-  const { session, cloudOrgs, tags, preferredOrgId } = params;
+  const {
+    session,
+    cloudOrgs,
+    tags,
+    preferredOrgId,
+    orgRepoScopes = {},
+  } = params;
   if (!session) return null;
 
   const memberOrgIds = new Set(cloudOrgs.map((org) => org.orgId));
@@ -76,9 +107,20 @@ export function resolveSessionCommentTarget(params: {
   const ownedCloudOrgId = session.orgId
     ? parseCloudOrgSelectorValue(session.orgId)
     : null;
+  // Repo-scope auto-match is a THIRD admission route (the push pass accepts
+  // `isScopeMatchableImportedSession` alongside ownership and tags). Without
+  // it here, an imported history shared purely by repo scope has no comment
+  // surface for its owner: teammates can comment and the cloud row carries
+  // the threads, but the owner sees no affordance — so no reply, and no
+  // owner-only @agent round either.
+  const scopeMatchedOrgIds = scopeMatchedOrgIdsForSession(
+    session,
+    orgRepoScopes
+  );
   const candidateOrgIds = [
     ...(ownedCloudOrgId ? [ownedCloudOrgId] : []),
     ...cloudOrgIdsForSession(tags, session.session_id),
+    ...scopeMatchedOrgIds,
   ].filter(
     (orgId, index, all) =>
       memberOrgIds.has(orgId) && all.indexOf(orgId) === index
@@ -101,6 +143,7 @@ export function useSessionCommentTarget(
   const cloudOrgs = useAtomValue(org2CloudOrgsAtom);
   const tags = useAtomValue(sessionOrgTagsAtom);
   const selectedCloudOrg = useAtomValue(chatPanelSelectedCloudOrgAtom);
+  const orgRepoScopes = useAtomValue(org2CloudRepoScopesAtom);
 
   return useMemo(
     () =>
@@ -111,7 +154,8 @@ export function useSessionCommentTarget(
         cloudOrgs,
         tags,
         preferredOrgId: selectedCloudOrg?.orgId ?? null,
+        orgRepoScopes,
       }),
-    [session, cloudOrgs, tags, selectedCloudOrg]
+    [session, cloudOrgs, tags, selectedCloudOrg, orgRepoScopes]
   );
 }

--- a/src/features/Org2Cloud/sessionCommentTarget.ts
+++ b/src/features/Org2Cloud/sessionCommentTarget.ts
@@ -23,7 +23,11 @@ import {
   org2CloudOrgsAtom,
   parseCloudOrgSelectorValue,
 } from "./org2CloudOrgsAtom";
-import { org2CloudRepoScopesAtom } from "./org2CloudSyncAtoms";
+import {
+  org2CloudPushCursorsAtom,
+  org2CloudPushedMetadataAtom,
+  org2CloudRepoScopesAtom,
+} from "./org2CloudSyncAtoms";
 
 export interface SessionCommentTarget {
   orgId: string;
@@ -69,6 +73,15 @@ export function resolveSessionCommentTarget(params: {
   preferredOrgId: string | null;
   /** orgId → configured repo scopes, for the auto-match admission route. */
   orgRepoScopes?: Record<string, string[]>;
+  /**
+   * Orgs where THIS session has a live server row (push cursor or pushed
+   * metadata marker). Repo-scope matching alone over-generates: after a
+   * GitHub rename, the network-identity fallback makes every org that
+   * scoped either name a candidate, but the cloud row only exists where
+   * the push pass actually pushed — listing comments elsewhere is
+   * ORG2_SESSION_NOT_FOUND.
+   */
+  pushedOrgIds?: readonly string[];
 }): SessionCommentTarget | null {
   const {
     session,
@@ -76,6 +89,7 @@ export function resolveSessionCommentTarget(params: {
     tags,
     preferredOrgId,
     orgRepoScopes = {},
+    pushedOrgIds = [],
   } = params;
   if (!session) return null;
 
@@ -117,7 +131,7 @@ export function resolveSessionCommentTarget(params: {
     session,
     orgRepoScopes
   );
-  const candidateOrgIds = [
+  const allCandidateOrgIds = [
     ...(ownedCloudOrgId ? [ownedCloudOrgId] : []),
     ...cloudOrgIdsForSession(tags, session.session_id),
     ...scopeMatchedOrgIds,
@@ -125,6 +139,16 @@ export function resolveSessionCommentTarget(params: {
     (orgId, index, all) =>
       memberOrgIds.has(orgId) && all.indexOf(orgId) === index
   );
+  // A candidate with a live server row beats one that merely COULD admit
+  // the session; without any pushed candidate (fresh share, push pending)
+  // keep the full set so the composer stays available.
+  const pushedCandidateOrgIds = allCandidateOrgIds.filter((orgId) =>
+    pushedOrgIds.includes(orgId)
+  );
+  const candidateOrgIds =
+    pushedCandidateOrgIds.length > 0
+      ? pushedCandidateOrgIds
+      : allCandidateOrgIds;
   if (candidateOrgIds.length === 0) return null;
   const orgId =
     preferredOrgId && candidateOrgIds.includes(preferredOrgId)
@@ -144,6 +168,19 @@ export function useSessionCommentTarget(
   const tags = useAtomValue(sessionOrgTagsAtom);
   const selectedCloudOrg = useAtomValue(chatPanelSelectedCloudOrgAtom);
   const orgRepoScopes = useAtomValue(org2CloudRepoScopesAtom);
+  const pushCursors = useAtomValue(org2CloudPushCursorsAtom);
+  const pushedMetadata = useAtomValue(org2CloudPushedMetadataAtom);
+
+  const pushedOrgIds = useMemo(() => {
+    if (!session) return [];
+    const suffix = `:${session.session_id}`;
+    return [
+      ...Object.keys(pushCursors),
+      ...Object.keys(pushedMetadata),
+    ].flatMap((key) =>
+      key.endsWith(suffix) ? [key.slice(0, -suffix.length)] : []
+    );
+  }, [session, pushCursors, pushedMetadata]);
 
   return useMemo(
     () =>
@@ -155,7 +192,8 @@ export function useSessionCommentTarget(
         tags,
         preferredOrgId: selectedCloudOrg?.orgId ?? null,
         orgRepoScopes,
+        pushedOrgIds,
       }),
-    [session, cloudOrgs, tags, selectedCloudOrg, orgRepoScopes]
+    [session, cloudOrgs, tags, selectedCloudOrg, orgRepoScopes, pushedOrgIds]
   );
 }

--- a/src/features/TeamCollaboration/engine/collabSegmentPlanning.ts
+++ b/src/features/TeamCollaboration/engine/collabSegmentPlanning.ts
@@ -14,21 +14,157 @@ const TERMINAL_EVENT_STATUSES: ReadonlySet<string> = new Set([
   "failed",
 ]);
 
+const PLAN_EVENT_FUNCTIONS: ReadonlySet<string> = new Set([
+  "plan_approval",
+  "create_plan",
+]);
+
+/** result.status values written only by the one-shot plan resolution chokepoint. */
+const PLAN_RESOLUTION_STATUSES: ReadonlySet<string> = new Set([
+  "approved",
+  "archived",
+  "cancelled",
+]);
+
+/**
+ * Tools with no deferred completion path: their running→terminal merge can
+ * only come from the turn executor that invoked them, never from a background
+ * handle (unlike `agent` subagents via complete_parent_tool_call, or shells
+ * via shellProcessStatus merges). A "running" stamp that survived past its
+ * turn is a dropped-merge zombie that can never transition again. Additions
+ * require verifying the tool has no late-completion path in agent-core.
+ */
+const SYNCHRONOUS_TOOL_KINDS: ReadonlySet<string> = new Set([
+  "read_file",
+  "code_search",
+  "web_search",
+  "web_fetch",
+  "manage_code_map",
+]);
+
+const CREATE_PLAN_CALL_ID_PREFIX = "tool-call-";
+
+function planRevisionOf(event: SessionEvent): string | null {
+  const fromResult = event.result?.planRevisionId;
+  if (typeof fromResult === "string" && fromResult) return fromResult;
+  const fromArgs = event.args?.planRevisionId;
+  if (typeof fromArgs === "string" && fromArgs) return fromArgs;
+  if (typeof event.callId === "string" && event.callId) return event.callId;
+  if (event.id.startsWith(CREATE_PLAN_CALL_ID_PREFIX)) {
+    return event.id.slice(CREATE_PLAN_CALL_ID_PREFIX.length);
+  }
+  return null;
+}
+
+function isPlanFamilyEvent(event: SessionEvent): boolean {
+  return (
+    PLAN_EVENT_FUNCTIONS.has(event.functionName) ||
+    PLAN_EVENT_FUNCTIONS.has(event.uiCanonical)
+  );
+}
+
+interface StuckSentinelProof {
+  resolvedPlanRevisions: ReadonlySet<string>;
+  latestPendingCardIndex: number;
+  latestPendingCardRevision: string | null;
+  lastUserEventIndex: number;
+}
+
+function buildStuckSentinelProof(events: SessionEvent[]): StuckSentinelProof {
+  const resolvedPlanRevisions = new Set<string>();
+  let latestPendingCardIndex = -1;
+  let latestPendingCardRevision: string | null = null;
+  let lastUserEventIndex = -1;
+  for (let index = 0; index < events.length; index += 1) {
+    const event = events[index];
+    if (event.source === "user") lastUserEventIndex = index;
+    if (!isPlanFamilyEvent(event)) continue;
+    const resultStatus = event.result?.status;
+    if (typeof resultStatus !== "string") continue;
+    const revision = planRevisionOf(event);
+    if (!revision) continue;
+    if (PLAN_RESOLUTION_STATUSES.has(resultStatus)) {
+      resolvedPlanRevisions.add(revision);
+    } else if (resultStatus === "pending") {
+      latestPendingCardIndex = index;
+      latestPendingCardRevision = revision;
+    }
+  }
+  return {
+    resolvedPlanRevisions,
+    latestPendingCardIndex,
+    latestPendingCardRevision,
+    lastUserEventIndex,
+  };
+}
+
+/**
+ * A non-terminal event may enter the frozen region only with an in-transcript
+ * proof that its status can never transition again:
+ *
+ * - `awaiting_user` plan-family events whose revision was resolved
+ *   (approved/archived/cancelled marker anywhere in the transcript — the
+ *   resolution chokepoint is one-shot and deletes the pending row, so a
+ *   resolved revision can never re-arm) or superseded (a later pending card
+ *   for a different revision exists — the pending slot is single-occupancy
+ *   and mark_ready archives the previous revision). A dangling
+ *   `awaiting_user` here means only the status patch was dropped.
+ * - `running` events of synchronous-only tools once a later user-source
+ *   event exists: the invoking turn is over and no handle remains that could
+ *   deliver the terminal merge.
+ *
+ * Everything else non-terminal (a genuinely pending plan card, running
+ * backgroundable tools, `pending`, `ask_user_questions`) can still mutate in
+ * place — arbitrarily late — and must stay in the mutable tail.
+ */
+function isProvablyStuck(
+  event: SessionEvent,
+  index: number,
+  proof: StuckSentinelProof
+): boolean {
+  if (event.displayStatus === "awaiting_user" && isPlanFamilyEvent(event)) {
+    const revision = planRevisionOf(event);
+    if (!revision) return false;
+    if (proof.resolvedPlanRevisions.has(revision)) return true;
+    return (
+      proof.latestPendingCardIndex > index &&
+      proof.latestPendingCardRevision !== null &&
+      proof.latestPendingCardRevision !== revision
+    );
+  }
+  if (event.displayStatus === "running") {
+    return (
+      (SYNCHRONOUS_TOOL_KINDS.has(event.functionName) ||
+        SYNCHRONOUS_TOOL_KINDS.has(event.uiCanonical)) &&
+      proof.lastUserEventIndex > index
+    );
+  }
+  return false;
+}
+
 /**
  * Frozen line (design §7.2): the frozen region is the longest event PREFIX
- * whose every event carries a terminal displayStatus ("completed"/"failed").
- * The first "running" / "pending" / "awaiting_user" event and everything
- * after it belong to the mutable tail. Events with no displayStatus (should
- * not happen — Rust always stamps it) count as terminal: a later in-place
- * mutation is still caught by the per-event hash chain and only costs an
- * epoch rewrite, whereas treating them as non-terminal would pin the frozen
- * line forever.
+ * whose every event carries a terminal displayStatus ("completed"/"failed")
+ * or is a provably-stuck sentinel (see `isProvablyStuck`). The first
+ * still-mutable "running" / "pending" / "awaiting_user" event and everything
+ * after it belong to the mutable tail — without the stuck-sentinel skip-over,
+ * one dropped status patch pins the frozen line forever and every push
+ * re-uploads an ever-growing tail (quadratic cumulative upload). Events with
+ * no displayStatus (should not happen — Rust always stamps it) count as
+ * terminal: a later in-place mutation is still caught by the per-event hash
+ * chain and only costs an epoch rewrite, whereas treating them as
+ * non-terminal would pin the frozen line forever. The same hash chain backs
+ * the skip-over: if a "provably" stuck event does mutate after all, the push
+ * detects the chain mismatch and re-anchors with one epoch rewrite.
  */
 export function computeFrozenEventCount(events: SessionEvent[]): number {
+  let proof: StuckSentinelProof | null = null;
   for (let index = 0; index < events.length; index += 1) {
-    const status = events[index]?.displayStatus;
+    const event = events[index];
+    const status = event?.displayStatus;
     if (typeof status === "string" && !TERMINAL_EVENT_STATUSES.has(status)) {
-      return index;
+      proof ??= buildStuckSentinelProof(events);
+      if (!isProvablyStuck(event, index, proof)) return index;
     }
   }
   return events.length;

--- a/src/features/TeamCollaboration/engine/collabSessionFork.test.ts
+++ b/src/features/TeamCollaboration/engine/collabSessionFork.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { org2CloudAccessSettingsAtom } from "@src/features/Org2Cloud/org2CloudAccessSettings";
+import { COLLAB_SESSION_ACCESS_MODE } from "@src/store/collaboration/types";
+import { createInstrumentedStore } from "@src/util/core/state/instrumentedStore";
+
+import { inheritCloudShareLadderForFork } from "./collabSessionFork";
+
+const ORG = "corg-1";
+const SOURCE = "claudecodeapp-source-1";
+const FORK = "agentsession-fork-1";
+
+function storeWithSettings(
+  sessionModes: Record<string, "off" | "metadata_only" | "full_replay">,
+  sessionVisibility: Record<string, "org" | "restricted"> = {}
+) {
+  const store = createInstrumentedStore();
+  store.set(org2CloudAccessSettingsAtom, {
+    [ORG]: { sessionModes, sessionVisibility },
+  });
+  return store;
+}
+
+describe("inheritCloudShareLadderForFork", () => {
+  it("copies the source's explicit share mode and visibility to the fork", () => {
+    const store = storeWithSettings(
+      { [SOURCE]: COLLAB_SESSION_ACCESS_MODE.FULL_REPLAY },
+      { [SOURCE]: "restricted" }
+    );
+
+    inheritCloudShareLadderForFork(store, ORG, SOURCE, FORK);
+
+    const settings = store.get(org2CloudAccessSettingsAtom)[ORG];
+    expect(settings.sessionModes[FORK]).toBe(
+      COLLAB_SESSION_ACCESS_MODE.FULL_REPLAY
+    );
+    expect(settings.sessionVisibility[FORK]).toBe("restricted");
+    expect(settings.sessionModes[SOURCE]).toBe(
+      COLLAB_SESSION_ACCESS_MODE.FULL_REPLAY
+    );
+  });
+
+  it("leaves settings untouched when the source has no explicit entry", () => {
+    const store = storeWithSettings({});
+    const before = store.get(org2CloudAccessSettingsAtom);
+
+    inheritCloudShareLadderForFork(store, ORG, SOURCE, FORK);
+
+    expect(store.get(org2CloudAccessSettingsAtom)).toBe(before);
+  });
+
+  it("does not copy an explicit OFF override", () => {
+    const store = storeWithSettings({
+      [SOURCE]: COLLAB_SESSION_ACCESS_MODE.OFF,
+    });
+
+    inheritCloudShareLadderForFork(store, ORG, SOURCE, FORK);
+
+    const settings = store.get(org2CloudAccessSettingsAtom)[ORG];
+    expect(settings.sessionModes[FORK]).toBeUndefined();
+  });
+});

--- a/src/features/TeamCollaboration/engine/collabSessionFork.ts
+++ b/src/features/TeamCollaboration/engine/collabSessionFork.ts
@@ -9,7 +9,14 @@
 import { DISPATCH_CATEGORY } from "@src/api/tauri/session/dispatchTypes";
 import type { KeyInfo } from "@src/api/types/keys";
 import { eventStoreProxy } from "@src/engines/SessionCore/core/store/EventStoreProxy";
+import {
+  getCloudOrgAccessSettings,
+  org2CloudAccessSettingsAtom,
+  withCloudSessionMode,
+  withCloudSessionVisibility,
+} from "@src/features/Org2Cloud/org2CloudAccessSettings";
 import { loadSharedLocalKeys } from "@src/hooks/keyVault/sharedLocalKeyStore";
+import { COLLAB_SESSION_ACCESS_MODE } from "@src/store/collaboration/types";
 import { lastModelPairMapAtom } from "@src/store/session/creatorDefaultModelAtom";
 import { sessionsAtom } from "@src/store/session/sessionAtom/atoms";
 import { upsertSession } from "@src/store/session/sessionAtom/mutations";
@@ -41,6 +48,36 @@ import { fetchAndAssembleSegments } from "./collabRemoteFetch";
  */
 export function createForkedSessionId(): string {
   return `agentsession-${crypto.randomUUID()}`;
+}
+
+/**
+ * Carry the forker's OWN explicit sharing-ladder entry for the source
+ * session over to the fork id. A fork continues a conversation the forker
+ * already chose to share at a specific level; without the copy an
+ * owner-side fork of a full_replay session has no entry, lands at the tag
+ * floor (metadata_only), and teammates get a fork row that can never
+ * replay. A guest has no entry for a teammate's session, so guest forks
+ * keep the privacy default. An explicit OFF override is not share intent
+ * and never copies.
+ */
+export function inheritCloudShareLadderForFork(
+  store: ReturnType<typeof getInstrumentedStore>,
+  orgId: string,
+  sourceSessionId: string,
+  forkSessionId: string
+): void {
+  const byOrg = store.get(org2CloudAccessSettingsAtom);
+  const settings = getCloudOrgAccessSettings(byOrg, orgId);
+  const mode = settings.sessionModes[sourceSessionId];
+  const visibility = settings.sessionVisibility[sourceSessionId];
+  let next = byOrg;
+  if (mode !== undefined && mode !== COLLAB_SESSION_ACCESS_MODE.OFF) {
+    next = withCloudSessionMode(next, orgId, forkSessionId, mode);
+  }
+  if (visibility !== undefined) {
+    next = withCloudSessionVisibility(next, orgId, forkSessionId, visibility);
+  }
+  if (next !== byOrg) store.set(org2CloudAccessSettingsAtom, next);
 }
 
 /**
@@ -255,6 +292,14 @@ export async function forkSession(
     // Deliberately NO importedFrom: that field marks read-only replay copies
     // and excludes them from push (isSessionPushAllowed).
   });
+  if (!shareToken) {
+    inheritCloudShareLadderForFork(
+      store,
+      orgId,
+      remoteSession.sourceSessionId,
+      localSessionId
+    );
+  }
   persistSessions(store.get(sessionsAtom) as Session[]);
   return {
     localSessionId,

--- a/src/features/TeamCollaboration/engine/collabSessionFork.ts
+++ b/src/features/TeamCollaboration/engine/collabSessionFork.ts
@@ -212,15 +212,30 @@ export async function forkSession(
   // Full fetch from seq 0, same assembly + validation as the importer. Forks
   // additionally fail closed against the list-row summary: an internally
   // valid tail-only response must not materialize when the row promised a
-  // larger frozen history.
+  // larger frozen history. The summary is a floor, not an exact match — a
+  // LIVE source keeps pushing between the list read and the segment fetch,
+  // so a snapshot that is AHEAD of the summary (owner rewrote to a newer
+  // epoch, or the same epoch grew) is the healthy race, while anything
+  // BEHIND the summary is the truncation this guard exists for.
   const assembled = await fetchAndAssembleSegments(options, 0, [], null);
-  const summaryMatches =
+  const summaryEpoch = remoteSession.eventsEpoch;
+  const summaryFrozenSeq = remoteSession.eventsFrozenSeq ?? 0;
+  const summaryCount = remoteSession.eventsCount;
+  const summaryTailHash = remoteSession.eventsTailHash ?? null;
+  const atSummary =
     assembled !== null &&
-    assembled.epoch === remoteSession.eventsEpoch &&
-    assembled.frozenSeq === (remoteSession.eventsFrozenSeq ?? 0) &&
-    assembled.events.length === remoteSession.eventsCount &&
-    assembled.tailHash === (remoteSession.eventsTailHash ?? null);
-  if (!summaryMatches) {
+    assembled.epoch === summaryEpoch &&
+    assembled.frozenSeq === summaryFrozenSeq &&
+    assembled.events.length === summaryCount &&
+    assembled.tailHash === summaryTailHash;
+  const aheadOfSummary =
+    assembled !== null &&
+    (assembled.epoch > summaryEpoch ||
+      (assembled.epoch === summaryEpoch &&
+        (assembled.frozenSeq > summaryFrozenSeq ||
+          (assembled.frozenSeq === summaryFrozenSeq &&
+            assembled.events.length > summaryCount))));
+  if (!atSummary && !aheadOfSummary) {
     throw new ForkSnapshotIntegrityError(
       FORK_SNAPSHOT_ERROR_KIND.SNAPSHOT_INCOMPLETE,
       `Fork snapshot does not match source summary for ${remoteSession.sourceSessionId}`

--- a/src/features/TeamCollaboration/engine/collabSessionFork.ts
+++ b/src/features/TeamCollaboration/engine/collabSessionFork.ts
@@ -15,6 +15,7 @@ import {
   withCloudSessionMode,
   withCloudSessionVisibility,
 } from "@src/features/Org2Cloud/org2CloudAccessSettings";
+import { buildCloudOrgSelectorValue } from "@src/features/Org2Cloud/org2CloudOrgsAtom";
 import { loadSharedLocalKeys } from "@src/hooks/keyVault/sharedLocalKeyStore";
 import { COLLAB_SESSION_ACCESS_MODE } from "@src/store/collaboration/types";
 import { lastModelPairMapAtom } from "@src/store/session/creatorDefaultModelAtom";
@@ -287,7 +288,10 @@ export async function forkSession(
     // filed under the source org so the sidebar org selector lists it; a
     // guest (share-token) fork stays under Personal. Today forks only run in
     // member context (panel fork action), so the guard is future-proofing.
-    orgId: shareToken ? undefined : orgId,
+    // `Session.orgId` is a SELECTOR value (`cloud:<uuid>`), not a bare org
+    // uuid: a bare value fails `parseCloudOrgSelectorValue`, so the share
+    // dialog saw no owning org and never offered link sharing for a fork.
+    orgId: shareToken ? undefined : buildCloudOrgSelectorValue(orgId),
     forkedFrom,
     // Deliberately NO importedFrom: that field marks read-only replay copies
     // and excludes them from push (isSessionPushAllowed).

--- a/src/features/TeamCollaboration/engine/collabSessionImport.ts
+++ b/src/features/TeamCollaboration/engine/collabSessionImport.ts
@@ -292,7 +292,17 @@ function refreshImportedSessionPresentation(
     existing.session_id,
     refreshedImportedFrom
   );
+  // Rows imported before the ownership stamp used the selector form carry a
+  // bare org uuid, which resolves to no owning org. Heal them here: this
+  // refresh is the only path a long-lived import takes, so without it a
+  // legacy row never regains its ownership-derived affordances. Guest rows
+  // (no ownership stamp) and non-cloud scopes are left untouched.
+  const normalizedOrgId =
+    existing.orgId === importedFrom.orgId
+      ? buildCloudOrgSelectorValue(importedFrom.orgId)
+      : existing.orgId;
   const unchanged =
+    existing.orgId === normalizedOrgId &&
     existing.name === remoteSession.title &&
     existing.repoPath === repoPath &&
     existing.agentDisplayName === sourcePresentation.agentLabel &&
@@ -311,6 +321,7 @@ function refreshImportedSessionPresentation(
 
   const refreshed: Session = {
     ...existing,
+    ...(normalizedOrgId !== undefined ? { orgId: normalizedOrgId } : {}),
     name: remoteSession.title,
     repoPath,
     agentDisplayName: sourcePresentation.agentLabel,

--- a/src/features/TeamCollaboration/engine/collabSessionImport.ts
+++ b/src/features/TeamCollaboration/engine/collabSessionImport.ts
@@ -8,6 +8,7 @@
  */
 import { indexOrgtrackCollaborationSession } from "@src/api/tauri/lineage";
 import { eventStoreProxy } from "@src/engines/SessionCore/core/store/EventStoreProxy";
+import { buildCloudOrgSelectorValue } from "@src/features/Org2Cloud/org2CloudOrgsAtom";
 import { createLogger } from "@src/hooks/logger";
 import { sessionsAtom } from "@src/store/session/sessionAtom/atoms";
 import { recordGuestImportedSession } from "@src/store/session/sessionAtom/guestImportRegistry";
@@ -571,7 +572,11 @@ async function importRemoteSessionInner(
       // context (org sync profile, no token). A share-token import is the
       // GUEST path (CollabShareImportDialog, no local membership): it stays
       // under Personal, i.e. no orgId (preserving any prior member stamp).
-      orgId: shareToken ? existing?.orgId : orgId,
+      // Selector value (`cloud:<uuid>`), never a bare org uuid: a bare value
+      // fails `parseCloudOrgSelectorValue`, hiding the session from every
+      // consumer that resolves ownership through it (share dialog, org
+      // selector, the engine's own ownedByOrg gate).
+      orgId: shareToken ? existing?.orgId : buildCloudOrgSelectorValue(orgId),
       importedFrom,
       // Retire the legacy error_message idiom for collab imports; clears any
       // leftover value on upgraded pre-M3 rows.

--- a/src/features/TeamCollaboration/engine/collabSyncEngineHelpers.test.ts
+++ b/src/features/TeamCollaboration/engine/collabSyncEngineHelpers.test.ts
@@ -1360,6 +1360,121 @@ describe("forkSession (design §16.11, fork & continue)", () => {
     expect(eventStoreMock.set).not.toHaveBeenCalled();
   });
 
+  it("accepts a snapshot that grew past the list summary (live source)", async () => {
+    // A live source pushes between the list read and the segment fetch; the
+    // summary is a floor, not an exact match — only BEHIND-summary snapshots
+    // are truncation.
+    const snapshot = await sealSnapshot({
+      epoch: 3,
+      frozenSeq: 2,
+      tailHash: "fresh-tail",
+      count: 5,
+      segments: [
+        {
+          seq: 1,
+          isTail: false,
+          events: [
+            { id: "turn-1-user", sessionId: "remote-1" },
+            { id: "turn-1-agent", sessionId: "remote-1" },
+          ] as SessionEvent[],
+          eventCount: 2,
+          segmentHash: "h1",
+        },
+        {
+          seq: 2,
+          isTail: false,
+          events: [
+            { id: "turn-2-user", sessionId: "remote-1" },
+            { id: "turn-2-agent", sessionId: "remote-1" },
+          ] as SessionEvent[],
+          eventCount: 2,
+          segmentHash: "h2",
+        },
+        {
+          seq: 0,
+          isTail: true,
+          events: [
+            { id: "turn-3-user", sessionId: "remote-1" },
+          ] as SessionEvent[],
+          eventCount: 1,
+          segmentHash: "fresh-tail",
+        },
+      ],
+    });
+    const client = {
+      getSessionEventSegments: vi.fn(async () => snapshot),
+    } satisfies Pick<CollabSyncBackendClient, "getSessionEventSegments">;
+
+    const result = await forkSession({
+      client,
+      orgId: "org-1",
+      remoteSession: makeRemote({
+        eventsEpoch: 3,
+        eventsFrozenSeq: 2,
+        eventsCount: 4,
+        eventsTailHash: "stale-tail",
+      }),
+    });
+
+    expect(result?.eventCount).toBe(5);
+  });
+
+  it("accepts a snapshot whose epoch advanced past the list summary", async () => {
+    const snapshot = await sealSnapshot({
+      epoch: 3,
+      frozenSeq: 2,
+      tailHash: "tail-hash",
+      count: 5,
+      segments: [
+        {
+          seq: 1,
+          isTail: false,
+          events: [
+            { id: "turn-1-user", sessionId: "remote-1" },
+            { id: "turn-1-agent", sessionId: "remote-1" },
+          ] as SessionEvent[],
+          eventCount: 2,
+          segmentHash: "h1",
+        },
+        {
+          seq: 2,
+          isTail: false,
+          events: [
+            { id: "turn-2-user", sessionId: "remote-1" },
+            { id: "turn-2-agent", sessionId: "remote-1" },
+          ] as SessionEvent[],
+          eventCount: 2,
+          segmentHash: "h2",
+        },
+        {
+          seq: 0,
+          isTail: true,
+          events: [
+            { id: "turn-3-user", sessionId: "remote-1" },
+          ] as SessionEvent[],
+          eventCount: 1,
+          segmentHash: "tail-hash",
+        },
+      ],
+    });
+    const client = {
+      getSessionEventSegments: vi.fn(async () => snapshot),
+    } satisfies Pick<CollabSyncBackendClient, "getSessionEventSegments">;
+
+    const result = await forkSession({
+      client,
+      orgId: "org-1",
+      remoteSession: makeRemote({
+        eventsEpoch: 2,
+        eventsFrozenSeq: 6,
+        eventsCount: 9,
+        eventsTailHash: "pre-rewrite-tail",
+      }),
+    });
+
+    expect(result?.eventCount).toBe(5);
+  });
+
   it("creates a WRITABLE session with forkedFrom provenance and persisted events", async () => {
     const client = {
       getSessionEventSegments: vi.fn(async () => sealSnapshot(makeSnapshot())),

--- a/src/features/TeamCollaboration/engine/collabSyncEngineHelpers.test.ts
+++ b/src/features/TeamCollaboration/engine/collabSyncEngineHelpers.test.ts
@@ -25,6 +25,7 @@ import type {
 } from "../sync/CollabSyncBackend";
 import { computeSegmentHash } from "../sync/collabGzip";
 import {
+  computeFrozenEventCount,
   deriveImportedSessionId,
   forkSession,
   importRemoteSession,
@@ -89,6 +90,152 @@ describe("isCollabConflictError (both backends' OCC rejection)", () => {
     expect(isCollabConflictError(new Error("ORGII_UNAUTHORIZED"))).toBe(false);
     expect(isCollabConflictError("ORG2_CONFLICT")).toBe(false);
     expect(isCollabConflictError(undefined)).toBe(false);
+  });
+});
+
+describe("computeFrozenEventCount frozen line + stuck-sentinel skip-over", () => {
+  function event(overrides: Partial<SessionEvent>): SessionEvent {
+    return {
+      id: `evt-${Math.random().toString(36).slice(2)}`,
+      sessionId: "session-1",
+      functionName: "",
+      uiCanonical: "",
+      source: "assistant",
+      args: {},
+      result: {},
+      displayStatus: "completed",
+      ...overrides,
+    } as SessionEvent;
+  }
+
+  function pendingPlanCard(revision: string): SessionEvent {
+    return event({
+      id: revision,
+      functionName: "plan_approval",
+      uiCanonical: "plan_approval",
+      callId: revision,
+      args: { planRevisionId: revision },
+      result: { status: "pending", planRevisionId: revision },
+      displayStatus: "awaiting_user",
+    });
+  }
+
+  function resolutionSibling(
+    revision: string,
+    status: "approved" | "archived" | "cancelled"
+  ): SessionEvent {
+    return event({
+      id: `${revision}-${status}`,
+      functionName: "plan_approval",
+      uiCanonical: "plan_approval",
+      callId: revision,
+      args: { planRevisionId: revision },
+      result: { status, planRevisionId: revision },
+      displayStatus: "completed",
+    });
+  }
+
+  it("cuts the frozen line at the first still-mutable non-terminal event", () => {
+    const events = [
+      event({}),
+      event({ displayStatus: "running", functionName: "run_shell" }),
+      event({}),
+    ];
+    expect(computeFrozenEventCount(events)).toBe(1);
+  });
+
+  it("counts a missing displayStatus as terminal (hash chain catches mutation)", () => {
+    const events = [event({ displayStatus: undefined as never }), event({})];
+    expect(computeFrozenEventCount(events)).toBe(2);
+  });
+
+  it("freezes past an awaiting_user plan card whose revision was resolved", () => {
+    const events = [
+      event({}),
+      pendingPlanCard("rev-1"),
+      event({}),
+      resolutionSibling("rev-1", "archived"),
+      event({}),
+    ];
+    expect(computeFrozenEventCount(events)).toBe(5);
+  });
+
+  it("accepts a resolution marker that precedes the dangling card", () => {
+    const events = [
+      resolutionSibling("rev-1", "approved"),
+      pendingPlanCard("rev-1"),
+      event({}),
+    ];
+    expect(computeFrozenEventCount(events)).toBe(3);
+  });
+
+  it("freezes past a plan card superseded by a later pending revision, which itself still blocks", () => {
+    const superseded = pendingPlanCard("rev-1");
+    const latest = pendingPlanCard("rev-2");
+    const events = [superseded, event({}), latest, event({})];
+    expect(computeFrozenEventCount(events)).toBe(2);
+  });
+
+  it("keeps a genuinely pending latest plan card in the tail", () => {
+    const events = [event({}), pendingPlanCard("rev-1"), event({})];
+    expect(computeFrozenEventCount(events)).toBe(1);
+  });
+
+  it("freezes past a dangling create_plan tool call once its revision resolved", () => {
+    const createPlanCall = event({
+      id: "tool-call-rev-1",
+      functionName: "create_plan",
+      uiCanonical: "create_plan",
+      callId: "rev-1",
+      displayStatus: "awaiting_user",
+    });
+    const events = [
+      createPlanCall,
+      pendingPlanCard("rev-1"),
+      resolutionSibling("rev-1", "approved"),
+      event({}),
+    ];
+    expect(computeFrozenEventCount(events)).toBe(4);
+  });
+
+  it("freezes past a running synchronous tool zombie once a later user event exists", () => {
+    const zombie = event({
+      displayStatus: "running",
+      functionName: "read_file",
+      uiCanonical: "read_file",
+    });
+    const events = [event({}), zombie, event({}), event({ source: "user" })];
+    expect(computeFrozenEventCount(events)).toBe(4);
+  });
+
+  it("keeps a running synchronous tool in the tail while its turn may still be live", () => {
+    const running = event({
+      displayStatus: "running",
+      functionName: "read_file",
+      uiCanonical: "read_file",
+    });
+    const events = [event({ source: "user" }), event({}), running, event({})];
+    expect(computeFrozenEventCount(events)).toBe(2);
+  });
+
+  it("never freezes a running backgroundable tool, even after later user events", () => {
+    const backgroundable = event({
+      displayStatus: "running",
+      functionName: "agent",
+      uiCanonical: "subagent",
+    });
+    const events = [backgroundable, event({}), event({ source: "user" })];
+    expect(computeFrozenEventCount(events)).toBe(0);
+  });
+
+  it("keeps a non-plan awaiting_user interaction in the tail", () => {
+    const question = event({
+      displayStatus: "awaiting_user",
+      functionName: "ask_user_questions",
+      uiCanonical: "ask_user_questions",
+    });
+    const events = [event({}), question, event({}), event({ source: "user" })];
+    expect(computeFrozenEventCount(events)).toBe(1);
   });
 });
 

--- a/src/features/TeamCollaboration/engine/collabSyncEngineHelpers.test.ts
+++ b/src/features/TeamCollaboration/engine/collabSyncEngineHelpers.test.ts
@@ -748,8 +748,10 @@ describe("importRemoteSession", () => {
     const record = (store.get(sessionsAtom) as Session[]).find(
       (session) => session.session_id === result!.localSessionId
     )!;
-    // Ownership stamp (sidebar filter) AND provenance both carry the org.
-    expect(record.orgId).toBe("org-1");
+    // Ownership stamp is a SCOPE SELECTOR value (what the sidebar filter and
+    // the engine's ownedByOrg gate compare against); provenance keeps the
+    // bare org id.
+    expect(record.orgId).toBe("cloud:org-1");
     expect(record.importedFrom?.orgId).toBe("org-1");
     expect(record.importedFrom?.shareToken).toBeUndefined();
   });
@@ -1360,7 +1362,9 @@ describe("forkSession (design §16.11, fork & continue)", () => {
     expect(record!.name).toBe("⑂ Remote session");
     // Ownership stamp (member fork context): the fork files under the source
     // org so the sidebar org filter lists it alongside the org's sessions.
-    expect(record!.orgId).toBe("org-1");
+    // Selector value, not a bare org id — a bare value resolves to no owning
+    // org and strips every ownership-derived affordance (share dialog).
+    expect(record!.orgId).toBe("cloud:org-1");
   });
 
   it("uses the resolved LOCAL workspace over the owner's absolute path when provided", async () => {

--- a/src/features/TeamCollaboration/engine/collabSyncEngineHelpers.test.ts
+++ b/src/features/TeamCollaboration/engine/collabSyncEngineHelpers.test.ts
@@ -669,6 +669,53 @@ describe("importRemoteSession", () => {
     expect(client.getSessionEventSegments).not.toHaveBeenCalled();
   });
 
+  it("heals a legacy bare-uuid ownership stamp on a refresh-only import", async () => {
+    // Rows imported before the stamp used the selector form kept a bare org
+    // uuid, which resolves to no owning org; the refresh path spread
+    // `...existing` and never healed them.
+    const client = {
+      getSessionEventSegments: vi.fn(async () => sealSnapshot(makeSnapshot())),
+    } satisfies Pick<CollabSyncBackendClient, "getSessionEventSegments">;
+    const expectedId = await deriveImportedSessionId("org-1", "remote-1");
+    store.set(sessionsAtom, [
+      {
+        session_id: expectedId,
+        status: "completed",
+        created_at: "2026-07-01T00:00:00.000Z",
+        updated_at: "2026-07-01T00:00:00.000Z",
+        name: "Remote session",
+        orgId: "org-1",
+        importedFrom: {
+          orgId: "org-1",
+          sourceSessionId: "remote-1",
+          ownerMemberId: "m2",
+          ownerDisplayName: "Bob",
+          epoch: 1,
+          seq: 1,
+          count: 1,
+          frozenCount: 1,
+          tailHash: undefined,
+          importedAt: "2026-07-01T00:00:00.000Z",
+        },
+      },
+    ]);
+    eventStoreMock.getPersistedEvents.mockResolvedValue([
+      { id: "e1" } as unknown as SessionEvent,
+    ]);
+
+    await importRemoteSession({
+      client,
+      orgId: "org-1",
+      remoteSession: makeRemote(),
+    });
+
+    const record = (store.get(sessionsAtom) as Session[]).find(
+      (session) => session.session_id === expectedId
+    );
+    expect(record?.orgId).toBe("cloud:org-1");
+    expect(record?.importedFrom?.orgId).toBe("org-1");
+  });
+
   it("refreshes source display metadata without refetching unchanged events", async () => {
     const client = {
       getSessionEventSegments: vi.fn(async () => sealSnapshot(makeSnapshot())),

--- a/src/features/TeamCollaboration/importedSessionScopeMatch.test.ts
+++ b/src/features/TeamCollaboration/importedSessionScopeMatch.test.ts
@@ -23,6 +23,12 @@ const sessions = [
     repoPath: undefined,
     repoRemoteUrls: undefined,
   },
+  {
+    session_id: "claudecodeapp-agent-a5",
+    repoPath: "/Users/me/org2",
+    repoRemoteUrls: ["git@github.com:yorgai/org2.git"],
+    parentSessionId: "claudecodeapp-1",
+  },
 ];
 
 describe("collectScopeMatchedImportedSessionIds", () => {
@@ -49,6 +55,16 @@ describe("collectScopeMatchedImportedSessionIds", () => {
     ]);
     expect(ids.has("native-1")).toBe(false);
     expect(ids.has("claudecodeapp-4")).toBe(false);
+  });
+
+  it("skips spawned children — subagent transcripts fold into their parent", () => {
+    // Without this, every subagent transcript in a scoped checkout published
+    // as its own top-level team session (a wall of prompt-titled rows the
+    // team list cannot fold: the cloud row has no parent linkage).
+    const ids = collectScopeMatchedImportedSessionIds(sessions, [
+      "github.com/yorgai/org2",
+    ]);
+    expect(ids.has("claudecodeapp-agent-a5")).toBe(false);
   });
 
   it("matches sessions sharing one persisted remote identity", () => {

--- a/src/features/TeamCollaboration/importedSessionScopeMatch.ts
+++ b/src/features/TeamCollaboration/importedSessionScopeMatch.ts
@@ -9,18 +9,24 @@ import {
 
 type MatchableSession = Pick<
   Session,
-  "session_id" | "repoPath" | "repoRemoteUrls"
+  "session_id" | "repoPath" | "repoRemoteUrls" | "parentSessionId"
 >;
 
 /**
  * Persisted repo scope keys for imported history. `undefined` means the
  * session is not imported; `null` means it is imported but has no cached
- * shareable remote.
+ * shareable remote — or is a spawned CHILD (subagent transcript), which is
+ * a rendering detail of its parent, never an independently shareable unit.
+ * Without the child exclusion every subagent transcript in a scoped
+ * checkout auto-published as its own top-level team session, flooding the
+ * team list with prompt-titled rows no fold can reclaim (the cloud row
+ * carries no parent linkage).
  */
 export function persistedScopeKeysForImportedSession(
   session: MatchableSession
 ): string[] | null | undefined {
   if (!isImportedHistorySession(session.session_id)) return undefined;
+  if (session.parentSessionId) return null;
   return shareableScopeKeysFromRemoteUrls(session.repoRemoteUrls);
 }
 

--- a/src/hooks/logger/useLogger.ts
+++ b/src/hooks/logger/useLogger.ts
@@ -158,7 +158,11 @@ function formatOne(value: unknown): string {
   }
   if (typeof value === "symbol") return value.toString();
   if (value instanceof Error) {
-    return value.stack || `${value.name}: ${value.message}`;
+    // WebKit stacks omit the message line, so always lead with name+message.
+    const head = `${value.name}: ${value.message}`;
+    return value.stack && !value.stack.startsWith(head)
+      ? `${head}\n${value.stack}`
+      : value.stack || head;
   }
   if (typeof value === "object") {
     try {

--- a/src/i18n/locales/en/navigation.json
+++ b/src/i18n/locales/en/navigation.json
@@ -728,6 +728,9 @@
       "optionNone": "No minimum",
       "memberNote": "Your org admin requires sharing at least {{mode}}, so you can't set sessions below that"
     },
-    "signedInAs": "Signed in as {{name}}"
+    "signedInAs": "Signed in as {{name}}",
+    "renameDisplayName": "Edit display name",
+    "renameSaved": "Display name updated",
+    "renameFailed": "Failed to update display name"
   }
 }

--- a/src/i18n/locales/zh/navigation.json
+++ b/src/i18n/locales/zh/navigation.json
@@ -791,6 +791,9 @@
       "optionNone": "无最低要求",
       "memberNote": "组织管理员要求至少分享到{{mode}}，因此你不能把会话设得比这更低"
     },
-    "signedInAs": "已登录：{{name}}"
+    "signedInAs": "已登录：{{name}}",
+    "renameDisplayName": "修改显示名",
+    "renameSaved": "显示名已更新",
+    "renameFailed": "显示名更新失败"
   }
 }

--- a/src/store/session/cliSessionStatusAtom.ts
+++ b/src/store/session/cliSessionStatusAtom.ts
@@ -9,8 +9,11 @@
  */
 import { type Atom, atom } from "jotai";
 
+import { createLogger } from "@src/hooks/logger";
 import type { CliSessionStatus } from "@src/types/session/session";
 import { isSessionEngineActiveStatus } from "@src/util/session/sessionRuntimeExecuting";
+
+const log = createLogger("SessionRuntimeStatus");
 
 // Single source of truth: @src/types/session/session
 export type { CliSessionStatus } from "@src/types/session/session";
@@ -95,6 +98,12 @@ export const setSessionRuntimeStatusAtom = atom(
       if (!matchesVisibleSession && !noVisibleSession) {
         // Write targets a session that is not visible — dropping it keeps the
         // global mirror owned by the visible session (no cross-session bleed).
+        if (update.status === "completed" || update.status === "failed") {
+          log.warn(
+            `gate dropped terminal "${update.status}" for ` +
+              `${update.sessionId}; visible=${JSON.stringify(gateValues)}`
+          );
+        }
         return;
       }
     }


### PR DESCRIPTION
## Summary
Ingestion/push performance batch plus two fixes surfaced by real-machine verification.

**Incremental boot discovery.** Every boot re-walked all source directories and re-derived candidates. A per-directory scan snapshot (dir mtime + name sets, SQLite-persisted beside the parse watermarks) lets unchanged directories skip `read_dir` entirely — real home: 688 dirs, cold 33.7ms → warm 12.2ms with 0 dirs enumerated; per-file stats are deliberately kept (a live-appending transcript does not touch its parent dir mtime). Also removes the O(changed × index-size) external-title re-reads (index now read once per pass). Legacy/garbage snapshot rows degrade to a full rescan and self-heal (regression-tested — the lesson from the malformed-JSON incident).

**Zombie-proof tail freezing.** Measured on real data: 112.9 MB of tail bytes (18.7% of all event bytes) were pinned by 30 zombie events (dropped status patches — stranded plan cards, sync-tool `running` ghosts), so every push re-uploaded multi-MB tails (quadratic cumulative upload; worst offender 45.9 MB/push). `computeFrozenEventCount` now freezes over a non-terminal event only with an in-transcript proof it can never transition (resolved/superseded plan revisions; sync-tool zombies after turn end — backgroundable kinds deliberately excluded); the hash chain remains the backstop. Simulated on the same data: tails drop 112.9 MB → 2.6 MB (97.7%). Live push of this very session froze through seq 19 on first attempt.

**journal.jsonl false discovery.** Workflow journals under `subagents/workflows/wf_*/` matched the recursive `*.jsonl` scan, colliding ~55 files onto one cache row re-upserted every pass (the row that seeded the malformed-JSON incident). Filtered at discovery (sidechain `agent-*.jsonl` transcripts in the same tree are kept); existing rows pruned by the standard on-scan reconciliation.

**Stranded-cursor re-anchor.** A parser fix that legitimately shrinks an imported session's event count (real case: −4 after the codex envelope fix) left the session permanently skipped by the `events.length < pushedCount` transient-read guard. Two consecutive passes observing the identical shorter count now confirm the shrink and route through the existing epoch-rewrite re-anchor; single short reads keep the old skip.

**Logger.** WebKit error stacks carry no message line; `formatOne` preferred the stack, hiding every HTTP status behind `v@….js` frames. Errors now always lead with `name: message`.

## Test plan
- Gates: `tsc` clean; Org2Cloud + TeamCollaboration 762 + 210 specs green (25 new across snapshot tolerance/reuse, journal filter + prune, freeze proofs ×11, shrink re-anchor ×3, real-DB sibling harness); `cargo test -p orgtrack_core` 365 green incl. 7 watermark specs; clippy no new warnings.
- Real machine: boot cold/warm A/B; zero `malformed JSON` post-fix; push-phase CPU settles 95% → 0.6% with stable RSS; full sharing matrix re-run (replay push/receive, comment delta + un-resolve, dual-kind floor broadcasts, storage-backed fork fetch path) all clean at 0% idle CPU.
- Forensics: the branch was adversarially exonerated of both live warnings observed during testing (both root-caused to develop-era changes; harness outputs in the audit trail).


## Sharing correctness batch (second commit)
Fork-on-write real-machine testing surfaced three sharing defects; all root-caused with cloud-row + log evidence.

**Vanished-sweep misfires.** The sweep's confirming exact-id lookup reports continuation-superseded siblings as absent, so a context-window continuation (/compact) demoted the old sibling and the sweep soft-deleted the team's shared session (21 storage-backed segments + comments intact but unlisted). Separately, one sweep during an imported-history cache rebuild mass-retracted 13 live rows in a second org — a successful-but-empty lookup is not proof of deletion. The lookup now runs with `includeContinuationSuperseded` (new `SessionFilter` flag threaded to a supersession-free exact-id query), and the engine requires a suspect to be confirmed absent on two consecutive sweeps (10-min interval) before retracting. All 14 wrongly-retracted rows were restored in place.

**Relay forks pushed metadata_only.** A fork id has no sharing-ladder entry, so the org tag floored it to metadata_only: teammates saw a fork row that can never replay while the parent was full_replay. `forkSession` now copies the forker's own explicit ladder entry (mode + visibility) to the fork id; guests have no entry for a teammate's session, so guest forks keep the privacy default and the ratchet is untouched.

**Silent channel-readiness timeout.** `waitForSessionChannelReady` resolved identically on success and on its 5s timeout. When no surface mounts the relay session's IPC channel, every `agent:complete` frame is dropped at the per-session bus registry and turns only end via the 60s planning-indicator watchdog (reproduced twice on-device). The wait now returns readiness and logs the session id on timeout; the surface-wiring root fix is scoped for the follow-up sharing-flow audit.

Gates for this commit: `tsc` clean; Org2Cloud + TeamCollaboration 980 specs green (5 new: two-strike sweep ×2, ladder inheritance ×3); SessionCore sync 168 green; `cargo test` cache module 21 green incl. the new superseded-lookup spec.

## Sharing correctness, batch 2 (`2561de186`)

**Replay uploads were failing for every re-uploaded segment.** The client sent `x-upsert: true`, which requires UPDATE on `storage.objects`; the bucket policies grant INSERT/SELECT only, so Supabase answered 403 wrapped in a 400 envelope — and the client discarded the body, leaving only `upload failed with 400`. Uploads now POST, and a duplicate rejection counts as success only after a HEAD confirms the object is genuinely stored, so a real authorization failure still raises. Error text now carries the response body (that one change is what unmasked the RLS message within minutes).

**Boot-window scope retracts.** The repo-scope mirror is persisted and restored empty-or-stale at launch; an empty list makes every candidate read as out-of-scope, and the first passes after launch retracted live shared rows and stripped their org tags (reproduced twice on-device against two fork sessions, both restored). Scope-driven retract/untag now waits until the run has confirmed the org's scopes against the server; pushes still run off the mirror. Verified: a cold boot on the fixed build produced a cloud ledger identical to the pre-boot baseline, where every prior boot had deleted rows.

**Silent-drop diagnostics.** Tracing a lost `agent:complete` through nine instrumented builds surfaced a chain of drops that logged nothing: the bus dropping an unroutable terminal, delivered frames with no subscriber, frames with no mounted handler, a disposed handler swallowing terminals, and the runtime-status gate dropping terminal writes. All now log. Two real defects were fixed alongside: re-subscribing to a still-registered channel now re-asserts readiness instead of waiting out the 5s timeout, and a single hung dispatch can no longer starve the event queue (15s deadline releases it).

**Lost `agent:complete` on relay forks (`1a3cb6181`).** Root cause: a fork's own id is `agentsession-<uuid>` (`createForkedSessionId`), which is precisely what `SPAWNED_SESSION_RE` matches when the coding-session bridge looks for spawned subagent sessions. Only `agent:complete` / `agent:error` / `agent:warning` carry a `sessionId` on the wire, so a fork's streamed text dispatched normally while its terminal entered the bridge, found no tracked parent and no active spawning `tool_call`, and fell into an unconditional `return` that dropped the event silently — upstream of every other drop point, which is why nine instrumented builds all stayed quiet. The turn then ended only via the 60s watchdog, on every fork turn. The bridge now skips events belonging to the handler's own session, and an untracked spawned id with no parent call falls through to normal dispatch. Verified on-device: the terminal is handled in the same millisecond it arrives (`21:39:51.305` both lines), no watchdog; the regression test fails when the guard is reverted.

**Skill.** Adds `.orgii/skills/dual-instance-verification/SKILL.md` — the 双机 protocol these escapes justified: cloud-row ledger diffs before/after every scenario, INFO-level destructive-verb audits, mandatory lifecycle-boundary cells (cold boot, /compact, cache rebuild, owner-side fork), watchdog fires treated as failures, and receiver-depth assertions.

Gates: `tsc` clean; 2158 specs green across Org2Cloud + TeamCollaboration + SessionCore (new: scope-confirmation ×3, storage duplicate/denial ×3).

## Fork/import ownership stamp (`28de8b130`)

`Session.orgId` is a scope **selector** value (`cloud:<uuid>`, alongside tokens like `personal-org`) — the engine's `ownedByOrg` gate and the sidebar scope both compare against that form. Fork and import instead wrote the bare org uuid, which `parseCloudOrgSelectorValue` rejects, so every forked or imported session resolved to **no owning org**: the cloud share dialog offered nothing (a fork could never be link-shared at all) and the engine's ownership gate missed it — masked only because fork provenance admits the session by another route. Confirmed against the local store, where the two relay forks carry a bare uuid while every other cloud session carries the selector form.

Both write sites now stamp the selector value, and ownership resolution tolerates the bare uuid already persisted so existing rows heal without a migration; non-cloud scopes still resolve to no org. The two specs that broke asserted the bare form — they encoded the bug, including a comment claiming it was what the sidebar filter matched.

Gates: `tsc` clean; 2162 specs green across Org2Cloud + TeamCollaboration + SessionCore.

## Matrix coverage (per the new skill)

Ledger diffs before/after every scenario and INFO-level destructive-verb audits were clean throughout. Lifecycle cells run: cold boot ×4 (first 3 sync passes audited — zero retracts where every pre-fix boot deleted rows); imported-history cache wiped 5709 → 0 and rebuilt to 5709 with zero retracts through a full sweep interval (the scenario that had mass-retracted 13 live rows); a `/compact`-demoted continuation sibling whose shared cloud row survived four boots and multiple sweeps; owner-side fork end-to-end with a real agent run (inherited `full_replay`, segments uploaded, terminal handled in the same millisecond it arrived). Idle CPU 0.0%, RSS stable at 128 MB.

Not covered: the in-app guest signer flow. Creating the link share needed the affordance that `28de8b130` restores, so that cell moves to the next pass; the signer path itself keeps its 18 unit specs (grant → sign → download → single-use → re-auth).
