### PR TITLE
fix(windows): suppress console flash on child process spawns

### DIFF
--- a/src-tauri/crates/agent-core/src/core/tools/impls/desktop/peekaboo_cli_tool.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/desktop/peekaboo_cli_tool.rs
@@ -587,6 +587,11 @@ async fn run_peekaboo_cli_command(
     #[cfg(unix)]
     command.process_group(0);
 
+    // Suppress the console window the bundled Peekaboo CLI would otherwise
+    // flash on Windows (it is spawned without a parent console).
+    #[cfg(windows)]
+    command.creation_flags(app_platform::CREATE_NO_WINDOW);
+
     let child = command
         .spawn()
         .map_err(|err| format!("Failed to run bundled Peekaboo CLI: {}", err))?;

--- a/src-tauri/crates/app-paths/src/lib.rs
+++ b/src-tauri/crates/app-paths/src/lib.rs
@@ -876,9 +876,11 @@ pub fn set_sensitive_file_permissions(path: &Path) -> std::io::Result<()> {
 
 #[cfg(windows)]
 fn current_windows_account_for_acl() -> Option<String> {
-    let whoami = std::process::Command::new("whoami")
-        .stdin(Stdio::null())
-        .stderr(Stdio::null())
+    let mut cmd = std::process::Command::new("whoami");
+    cmd.stdin(Stdio::null()).stderr(Stdio::null());
+    // Suppress console window on Windows.
+    app_platform::hide_console(&mut cmd);
+    let whoami = cmd
         .output()
         .ok()
         .and_then(|output| {

--- a/src-tauri/src/benchmark/process.rs
+++ b/src-tauri/src/benchmark/process.rs
@@ -199,13 +199,16 @@ pub(super) async fn terminate_process(process_id: u32) -> Result<(), String> {
         .await;
 
     #[cfg(windows)]
-    let output = Command::new("taskkill")
-        .arg("/PID")
-        .arg(process_id.to_string())
-        .arg("/T")
-        .arg("/F")
-        .output()
-        .await;
+    let output = {
+        let mut cmd = Command::new("taskkill");
+        cmd.arg("/PID")
+            .arg(process_id.to_string())
+            .arg("/T")
+            .arg("/F");
+        // Suppress the console window on Windows.
+        cmd.creation_flags(app_platform::CREATE_NO_WINDOW);
+        cmd.output().await
+    };
 
     let output =
         output.map_err(|error| format!("Failed to terminate process {process_id}: {error}"))?;


### PR DESCRIPTION
## Summary

Closes #537.

The Windows GUI host is built with `#![windows_subsystem = "windows"]` and has no console of its own, so console-subsystem child processes allocate and flash a console window when spawned. Three sites were missing the `CREATE_NO_WINDOW` flag that sibling spawn paths already use; each now mirrors the existing guarded pattern in its own file:

| Site | Command | Fix |
|---|---|---|
| `app-paths::current_windows_account_for_acl` | `whoami` (`std::process::Command`) | `app_platform::hide_console(&mut cmd)` |
| `agent-core` bundled Peekaboo CLI | bundled CLI (`tokio::process::Command`) | `#[cfg(windows)] cmd.creation_flags(CREATE_NO_WINDOW)` |
| `benchmark::process::terminate_process` | `taskkill` (`tokio::process::Command`) | `#[cfg(windows)] cmd.creation_flags(CREATE_NO_WINDOW)` |

## Why these patterns

The codebase already centralizes the flag in `app-platform` (`CREATE_NO_WINDOW` const + `hide_console` helper) and uses both forms at sibling sites (`sidecar_setup.rs`, `kiro.rs`, `lifecycle.rs`, `session.rs`, `env_setup.rs`). This PR only closes the remaining gaps — no new abstraction.

## Verification

- All touched symbols (`app_platform::CREATE_NO_WINDOW`, `hide_console`, `app_platform` / `app_paths` crate deps) confirmed present.
- The three edits match the existing guarded call sites verbatim in style.
- ✅ Verified on Windows: built and run on Windows; the `whoami`, bundled Peekaboo CLI, and `taskkill` console flashes no longer appear.
