### PR TITLE
fix(key-vault): prevent CLI discovery from hanging packaged app

### DIFF
--- a/docs/architecture-audit-2026-07-27/CliAgentDiscoveryHang.md
+++ b/docs/architecture-audit-2026-07-27/CliAgentDiscoveryHang.md
@@ -1,0 +1,62 @@
+# Architecture Audit — CLI Agent Discovery Hang
+
+**Scope:** `get_available_agents` discovery, resolver fallback behavior, frontend consumers, cache invalidation, and packaged-app execution
+
+**Date:** 2026-07-27
+
+**Verdict:** pass
+
+## Root cause and lifecycle
+
+The release hang report showed the main thread waiting on a mutex while several Tokio workers were
+blocked delivering Wry custom-protocol responses to WebKit. At the same time, independently mounted
+frontend consumers invoked `get_available_agents` concurrently. Each request synchronously searched
+roughly thirty CLI definitions and, for every missing CLI, could launch a login shell with a
+three-second timeout. This exhausted async worker capacity and created the packaged-app circular
+wait; the HTTP development surface did not exercise the same Wry response path.
+
+The repaired lifecycle is:
+
+`frontend consumers → shared in-flight Promise → Tauri command → shared backend refresh → spawn_blocking → bounded PATH/known-location inventory → fingerprinted cache`
+
+Concurrent callers receive the same result. A failed blocking worker clears the in-flight state so
+the next caller can retry. No successful frontend result is retained beyond the in-flight request;
+the backend remains authoritative for PATH, key, binary-fingerprint, and TTL invalidation.
+
+## 10-layer audit
+
+| Layer                      | Scope checked                                                               | Verdict | Evidence                                                                                                                                                                                                                                         |
+| -------------------------- | --------------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1. Compilation             | Rust resolver/key-vault crates, Tauri binary, RPC/Zod, React consumers      | pass    | `pnpm typecheck`, production Webpack, targeted Rust tests, changed-file ESLint, and strict changed-crate Clippy pass. The full dev-build binary compiled; bundle signing alone failed because the configured Developer ID certificate is absent. |
+| 2. Dead code / duplication | all production `get_available_agents` entry points                          | pass    | Five consumers use `loadAvailableAgents`; the unused `agentOrgs.availableCliAgents` alias and duplicate schema were removed. The direct E2E helper remains to test the command boundary.                                                         |
+| 3. Naming                  | inventory resolution, installation snapshot, in-flight refresh              | pass    | `resolve_cli_binary_for_inventory` explicitly distinguishes bounded inventory from launch-time resolution; `CliInstallationSnapshot` owns one coherent observation.                                                                              |
+| 4. Semantic overloading    | installed, resolved command, fingerprint, frontend cache                    | pass    | “Installed” means an executable exists on PATH or a known location. Frontend state means only “request in flight”; it does not imply freshness.                                                                                                  |
+| 5. Default branches        | PATH hit/miss, known location, missing binary, poisoned mutex, worker panic | pass    | Missing binaries return the bare command without shell execution. Poisoned result locks recover. Worker failure is returned and subsequent retry is proven by test.                                                                              |
+| 6. Cross-domain leakage    | CLI resolver, Key Vault registry, UI consumers                              | pass    | Resolver owns executable lookup policy; registry owns key/config enrichment and cache keys; UI owns presentation sorting without mutating the shared result.                                                                                     |
+| 7. New-developer clarity   | cache ownership and concurrency contract                                    | pass    | Comments at the Rust command and frontend service state who owns freshness and why only in-flight work is shared.                                                                                                                                |
+| 8. Wire protocol           | Tauri command name and `AvailableAgent` schema                              | pass    | `get_available_agents` and its output schema are unchanged; no serialized field or enum changed.                                                                                                                                                 |
+| 9. Init parity             | cold start, concurrent mounts, cache hit, failure/retry, repeated launch    | pass    | Four concurrent backend callers execute one scan; concurrent frontend callers execute one RPC; two isolated packaged-surface launches completed and terminated normally.                                                                         |
+| 10. Resolver symmetry      | PATH lookup, known-location fallback, returned command, cache signature     | pass    | One `CliInstallationSnapshot` supplies installed state, command, install method, and fingerprint, avoiding separate asymmetric probes. Launch-time callers retain login-shell fallback; bounded inventory intentionally does not.                |
+
+## Entry-point sweep
+
+| Entry point                 | Before                          | After                                    | Verdict                                               |
+| --------------------------- | ------------------------------- | ---------------------------------------- | ----------------------------------------------------- |
+| Session discovery           | direct validation RPC           | shared service                           | fixed                                                 |
+| Key Vault provider registry | local promise around direct RPC | local registry cache over shared service | fixed                                                 |
+| CLI clients hook            | raw Tauri `invoke`              | shared service                           | fixed                                                 |
+| Account compatibility       | direct validation RPC           | shared service                           | fixed                                                 |
+| WorkStation CLI tab         | duplicate agent-org RPC alias   | shared service; copies before sorting    | fixed                                                 |
+| E2E account helper          | direct validation RPC           | unchanged                                | keep with reason: exercises the real command boundary |
+
+## Findings
+
+| Line / element                                          | Verdict | Reason                                                                                                                                                             | Suggested change |
+| ------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| `cli_binary_resolver.rs:374` bounded inventory resolver | keep    | Startup already augments PATH once; inventory remains bounded to PATH plus known locations and never starts per-agent login shells.                                | None.            |
+| `commands.rs:149` in-flight coordinator                 | keep    | Per-process ownership is explicit, result storage is bounded to one active refresh, and waiters retain the exact refresh object even if a later generation begins. | None.            |
+| `commands.rs:353` blocking inventory                    | keep    | Filesystem metadata and Key Vault reads run on Tokio's blocking pool, outside Wry response workers.                                                                | None.            |
+| `availableAgents.ts:4` module-scoped Promise            | keep    | Exactly one Promise is retained only while pending; success and failure both clear it.                                                                             | None.            |
+| Existing 60-second backend value cache                  | keep    | Cache keys include PATH, key signature, and resolved binary fingerprints; callers still detect binary appearance/replacement before reuse.                         | None.            |
+
+No unresolved architecture finding remains in this scope.

--- a/docs/org2-performance-guard-2026-07-27/CliAgentDiscoveryHang.md
+++ b/docs/org2-performance-guard-2026-07-27/CliAgentDiscoveryHang.md
@@ -1,0 +1,70 @@
+# ORG2 Performance Guard — CLI Agent Discovery Hang
+
+**Date:** 2026-07-27
+
+**Scope:** CLI registry scanning, concurrent IPC, caches, process lookup, packaged Wry lifecycle
+
+**Performance verdict: pass**
+
+The former path had multiplicative work: each mounted consumer started a full registry scan, and
+each missing CLI could start a login shell and wait up to three seconds. The repaired path has no
+timer or polling loop, shares concurrent work on both sides of IPC, performs blocking filesystem
+work on Tokio's blocking pool, and never launches a shell during registry inventory.
+
+## Lifecycle matrix
+
+| State                   | Trigger / cadence                | Work performed                                             | Retained state                                | Cleanup / bound                                              |
+| ----------------------- | -------------------------------- | ---------------------------------------------------------- | --------------------------------------------- | ------------------------------------------------------------ |
+| Cold visible mount      | consumer demand only             | one bounded registry scan                                  | one in-flight result plus backend cache entry | result notifies all waiters; in-flight slot clears           |
+| Concurrent mounts       | same event burst                 | one frontend RPC and one backend blocking scan             | same Promise / refresh object                 | all consumers share completion                               |
+| Warm request            | consumer demand only             | PATH/known-location fingerprints, then backend cache reuse | one 60-second value entry                     | replaced on key/PATH/binary change or TTL expiry             |
+| Hidden / idle           | none                             | no scan, timer, retry, or polling                          | backend cache only                            | bounded to one registry result                               |
+| Worker failure          | blocking task panic/cancellation | error returned; no automatic loop                          | completed error only for existing waiters     | in-flight slot clears; later demand may retry                |
+| Component unmount       | React cleanup                    | no new work                                                | Rust refresh may finish for other consumers   | component ignores completion; shared request remains bounded |
+| Repeated app close/open | process lifecycle                | at most one cold scan per process                          | process-local only                            | OS teardown releases Promise, refresh, and cache             |
+| Multiple app instances  | demand per isolated process      | one bounded scan per process                               | one entry per process                         | no cross-process retained state or shared lock               |
+
+## Resource ownership
+
+| Resource                     | Owner                       | Maximum count / size     | Hot-path cost                          | Terminal behavior                     |
+| ---------------------------- | --------------------------- | ------------------------ | -------------------------------------- | ------------------------------------- |
+| Frontend in-flight Promise   | `availableAgents.ts` module | 1                        | one IPC for concurrent consumers       | cleared on resolve or reject          |
+| Backend in-flight refresh    | key-vault process singleton | 1                        | one `spawn_blocking` task              | result delivered; active slot cleared |
+| Backend value cache          | key-vault process singleton | 1 registry vector        | bounded PATH/metadata fingerprint pass | replaced/expired; process teardown    |
+| Login-shell process          | launch-time resolver only   | 0 for registry inventory | none in this feature                   | not applicable                        |
+| Timers/subscriptions/workers | none added                  | 0                        | none while idle/hidden                 | not applicable                        |
+
+## Runtime evidence
+
+- Targeted resolver suite: 9 tests pass in 0.44 seconds, including a fake-shell marker proving
+  bounded inventory never launches the shell.
+- Key-vault lifecycle suite: 3 tests pass in 0.04 seconds, including four simultaneous callers
+  sharing one scan and recovery after a simulated blocking-worker panic.
+- Frontend service suite: 3 tests pass, covering shared success, post-settlement refresh, and
+  rejection followed by retry.
+- A real optimized `dev-build` Tauri binary compiled successfully. Final `.app` signing failed only
+  because `Developer ID Application: HOUYi HE (S4UG24G7HJ)` is not installed on this machine.
+- The produced custom-protocol binary was launched twice with isolated `ORGII_HOME`, ports, and
+  history roots. On the 20-second run, diagnostics recorded two successful
+  `get_available_agents` calls and zero failures. On the 15-second debug run, the cold registry
+  result was emitted by one blocking thread from `12:50:43.346594` through
+  `12:50:43.347612`; the process then settled at 0.0% CPU and about 0.9% memory.
+- A one-second macOS system sample after settling showed the main thread normally waiting in the
+  AppKit event loop and Tokio workers waiting on condition variables. It did not reproduce the
+  reported main-thread mutex / `WKURLSchemeTask` circular wait.
+
+## Verification and limits
+
+| Check                                   | Result                                                                          |
+| --------------------------------------- | ------------------------------------------------------------------------------- |
+| `pnpm typecheck`                        | pass                                                                            |
+| changed-file ESLint and Prettier        | pass                                                                            |
+| production Webpack build                | pass                                                                            |
+| targeted Rust and Vitest suites         | pass                                                                            |
+| changed-crate Clippy with `-D warnings` | pass after command-line suppression of three unchanged key-vault baseline lints |
+| full optimized Tauri binary compile     | pass                                                                            |
+| macOS bundle signing                    | environment-blocked: configured Developer ID identity absent                    |
+| packaged-surface launch / idle sample   | pass using the produced unsigned custom-protocol binary                         |
+
+No unbounded CPU, RAM, I/O, retry, timer, cache-growth, or repeated-open/close path remains in the
+changed lifecycle.

--- a/src-tauri/crates/integrations/src/cli_binary_resolver.rs
+++ b/src-tauri/crates/integrations/src/cli_binary_resolver.rs
@@ -365,6 +365,26 @@ pub fn resolve_cli_binary_for_registry_name(name: &str) -> Option<CliBinaryResol
     id_for_registry_name(name).map(resolve_cli_binary)
 }
 
+/// Resolve a registry CLI for inventory/discovery without launching a login shell.
+///
+/// App startup already augments the process `PATH` from the user's login shell.
+/// Inventory callers can therefore stay bounded to the supplied `PATH` plus
+/// known install locations instead of launching one interactive shell per
+/// missing CLI.
+pub fn resolve_cli_binary_for_inventory(
+    name: &str,
+    path_env: Option<OsString>,
+) -> Option<CliBinaryResolution> {
+    id_for_registry_name(name).map(|id| {
+        let options = ResolveOptions {
+            path_env,
+            search_login_shell: false,
+            ..ResolveOptions::default()
+        };
+        resolve_cli_binary_with_options(id, &options)
+    })
+}
+
 pub fn resolve_cli_binary(id: CliBinaryId) -> CliBinaryResolution {
     resolve_cli_binary_with_options(id, &ResolveOptions::default())
 }
@@ -465,6 +485,7 @@ struct ResolveOptions {
     path_env: Option<OsString>,
     shell: Option<OsString>,
     home_dir: Option<PathBuf>,
+    search_login_shell: bool,
     login_shell_timeout: Duration,
 }
 
@@ -474,6 +495,7 @@ impl Default for ResolveOptions {
             path_env: env::var_os("PATH"),
             shell: env::var_os("SHELL"),
             home_dir: dirs::home_dir(),
+            search_login_shell: true,
             login_shell_timeout: LOGIN_SHELL_TIMEOUT,
         }
     }
@@ -496,18 +518,25 @@ fn resolve_cli_binary_with_options(
     }
     diagnostics.push(format!("{} not found on process PATH", metadata.command));
 
-    if let Some(path) = resolve_via_login_shell(metadata.command, options) {
-        return CliBinaryResolution {
-            metadata,
-            command: path.to_string_lossy().to_string(),
-            source: CliBinaryResolutionSource::LoginShell,
-            diagnostics,
-        };
+    if options.search_login_shell {
+        if let Some(path) = resolve_via_login_shell(metadata.command, options) {
+            return CliBinaryResolution {
+                metadata,
+                command: path.to_string_lossy().to_string(),
+                source: CliBinaryResolutionSource::LoginShell,
+                diagnostics,
+            };
+        }
+        diagnostics.push(format!(
+            "{} not found via login-shell lookup",
+            metadata.command
+        ));
+    } else {
+        diagnostics.push(format!(
+            "{} login-shell lookup skipped for bounded inventory",
+            metadata.command
+        ));
     }
-    diagnostics.push(format!(
-        "{} not found via login-shell lookup",
-        metadata.command
-    ));
 
     if let Some(path) = known_locations_for(id, options)
         .into_iter()
@@ -741,6 +770,7 @@ mod tests {
             path_env: Some(OsString::from(temp_dir.path().as_os_str())),
             shell: Some(OsString::from("/bin/false")),
             home_dir: None,
+            search_login_shell: true,
             login_shell_timeout: Duration::from_millis(10),
         };
 
@@ -762,6 +792,7 @@ mod tests {
             path_env: Some(OsString::new()),
             shell: Some(OsString::from("/bin/false")),
             home_dir: Some(temp_dir.path().to_path_buf()),
+            search_login_shell: true,
             login_shell_timeout: Duration::from_millis(10),
         };
 
@@ -782,6 +813,7 @@ mod tests {
             path_env: Some(OsString::new()),
             shell: Some(shell.into_os_string()),
             home_dir: None,
+            search_login_shell: true,
             login_shell_timeout: Duration::from_millis(500),
         };
 
@@ -792,6 +824,35 @@ mod tests {
             CliBinaryResolutionSource::BareCommandFallback
         );
         assert!(!resolution.installed());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_inventory_skips_login_shell() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let marker = temp_dir.path().join("shell-invoked");
+        let shell = temp_dir.path().join("fake-shell");
+        fs::write(
+            &shell,
+            format!("#!/bin/sh\ntouch '{}'\n", marker.to_string_lossy()),
+        )
+        .unwrap();
+        set_executable(&shell);
+
+        let options = ResolveOptions {
+            path_env: Some(OsString::new()),
+            shell: Some(shell.into_os_string()),
+            home_dir: None,
+            search_login_shell: false,
+            login_shell_timeout: Duration::from_millis(500),
+        };
+
+        let resolution = resolve_cli_binary_with_options(CliBinaryId::Codex, &options);
+        assert_eq!(
+            resolution.source,
+            CliBinaryResolutionSource::BareCommandFallback
+        );
+        assert!(!marker.exists(), "inventory must not launch a login shell");
     }
 
     #[cfg(unix)]

--- a/src-tauri/crates/key-vault/src/commands/registry/commands.rs
+++ b/src-tauri/crates/key-vault/src/commands/registry/commands.rs
@@ -5,10 +5,10 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
-use integrations::cli_binary_resolver::resolve_cli_binary_for_registry_name;
+use integrations::cli_binary_resolver::resolve_cli_binary_for_inventory;
 
 use crate::key_store::KEY_SERVICE;
 use crate::provider_config::{
@@ -79,45 +79,47 @@ fn native_subscription_labels_for_agent(agent_name: &str) -> Vec<String> {
     labels.iter().map(|label| label.to_string()).collect()
 }
 
-async fn detect_cli_installation(
+#[derive(Debug)]
+struct CliInstallationSnapshot {
+    installed: bool,
+    installed_via: Option<String>,
+    resolved_command: String,
+    binary_fingerprint: String,
+}
+
+fn detect_cli_installation(
     agent_name: &str,
     binary: &str,
-    current_path: &str,
-) -> (bool, Option<String>, String) {
-    let which_cmd = if cfg!(windows) { "where" } else { "which" };
-    let mut which_command = tokio::process::Command::new(which_cmd);
-    which_command.arg(binary).env("PATH", current_path);
-    #[cfg(windows)]
-    which_command.creation_flags(app_platform::CREATE_NO_WINDOW);
-
-    if let Ok(output) = which_command.output().await {
-        if output.status.success() {
-            let first_path = String::from_utf8_lossy(&output.stdout)
-                .lines()
-                .next()
-                .unwrap_or("")
-                .trim()
-                .to_string();
-            let installed_via = if first_path.is_empty() {
-                None
-            } else {
-                infer_install_method(&first_path)
-            };
-            return (true, installed_via, binary.to_string());
-        }
+    path_env: &std::ffi::OsString,
+    path_dirs: &[PathBuf],
+) -> CliInstallationSnapshot {
+    if let Some(path) = find_executable_on_path(path_dirs, binary) {
+        let path_string = path.to_string_lossy().to_string();
+        return CliInstallationSnapshot {
+            installed: true,
+            installed_via: infer_install_method(&path_string),
+            resolved_command: binary.to_string(),
+            binary_fingerprint: binary_cache_fingerprint(&path),
+        };
     }
 
-    if let Some(resolution) = resolve_cli_binary_for_registry_name(agent_name) {
+    if let Some(resolution) = resolve_cli_binary_for_inventory(agent_name, Some(path_env.clone())) {
         if resolution.installed() {
-            return (
-                true,
-                infer_install_method(&resolution.command),
-                resolution.metadata.command.to_string(),
-            );
+            return CliInstallationSnapshot {
+                installed: true,
+                installed_via: infer_install_method(&resolution.command),
+                resolved_command: resolution.metadata.command.to_string(),
+                binary_fingerprint: binary_cache_fingerprint(Path::new(&resolution.command)),
+            };
         }
     }
 
-    (false, None, binary.to_string())
+    CliInstallationSnapshot {
+        installed: false,
+        installed_via: None,
+        resolved_command: binary.to_string(),
+        binary_fingerprint: "-".to_string(),
+    }
 }
 
 fn resolve_cli_config_path(kind: CliConfigPathKind, relative_path: &str) -> String {
@@ -143,6 +145,100 @@ struct AvailableAgentsCacheEntry {
 }
 
 static AVAILABLE_AGENTS_CACHE: OnceLock<Mutex<Option<AvailableAgentsCacheEntry>>> = OnceLock::new();
+
+struct AvailableAgentsInFlight<T> {
+    result: Mutex<Option<Result<T, String>>>,
+    completed: tokio::sync::Notify,
+}
+
+impl<T> AvailableAgentsInFlight<T>
+where
+    T: Clone,
+{
+    fn finish(&self, result: Result<T, String>) {
+        let mut completed = self
+            .result
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *completed = Some(result);
+    }
+
+    fn result(&self) -> Option<Result<T, String>> {
+        self.result
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+}
+
+struct AvailableAgentsRefreshCoordinator<T> {
+    in_flight: tokio::sync::Mutex<Option<Arc<AvailableAgentsInFlight<T>>>>,
+}
+
+impl<T> Default for AvailableAgentsRefreshCoordinator<T> {
+    fn default() -> Self {
+        Self {
+            in_flight: tokio::sync::Mutex::new(None),
+        }
+    }
+}
+
+impl<T> AvailableAgentsRefreshCoordinator<T>
+where
+    T: Clone + Send + 'static,
+{
+    async fn run<F>(&self, operation: F) -> Result<T, String>
+    where
+        F: FnOnce() -> T + Send + 'static,
+    {
+        let (refresh, is_leader) = {
+            let mut in_flight = self.in_flight.lock().await;
+            match in_flight.as_ref() {
+                Some(refresh) => (Arc::clone(refresh), false),
+                None => {
+                    let refresh = Arc::new(AvailableAgentsInFlight {
+                        result: Mutex::new(None),
+                        completed: tokio::sync::Notify::new(),
+                    });
+                    *in_flight = Some(Arc::clone(&refresh));
+                    (refresh, true)
+                }
+            }
+        };
+
+        if is_leader {
+            let result = tokio::task::spawn_blocking(operation)
+                .await
+                .map_err(|error| format!("CLI agent discovery worker failed: {error}"));
+            refresh.finish(result.clone());
+            let mut in_flight = self.in_flight.lock().await;
+            if in_flight
+                .as_ref()
+                .is_some_and(|active| Arc::ptr_eq(active, &refresh))
+            {
+                *in_flight = None;
+            }
+            drop(in_flight);
+            refresh.completed.notify_waiters();
+            return result;
+        }
+
+        loop {
+            let completed = refresh.completed.notified();
+            if let Some(result) = refresh.result() {
+                return result;
+            }
+            completed.await;
+        }
+    }
+}
+
+static AVAILABLE_AGENTS_REFRESH: OnceLock<AvailableAgentsRefreshCoordinator<Vec<AvailableAgent>>> =
+    OnceLock::new();
+
+fn available_agents_refresh() -> &'static AvailableAgentsRefreshCoordinator<Vec<AvailableAgent>> {
+    AVAILABLE_AGENTS_REFRESH.get_or_init(AvailableAgentsRefreshCoordinator::default)
+}
 
 fn cached_available_agents(
     path: &str,
@@ -247,27 +343,14 @@ fn binary_cache_fingerprint(path: &Path) -> String {
     format!("{}:{}:{}", path.to_string_lossy(), metadata.len(), modified)
 }
 
-fn path_binary_signature(registry_entries: &[(&str, &str)], path: &str) -> String {
-    let path_dirs: Vec<PathBuf> = std::env::split_paths(path).collect();
-    registry_entries
+fn find_executable_on_path(path_dirs: &[PathBuf], command: &str) -> Option<PathBuf> {
+    path_dirs
         .iter()
-        .map(|(name, binary)| {
-            let fingerprint = path_dirs
-                .iter()
-                .flat_map(|dir| command_path_candidates(dir, binary))
-                .find(|candidate| is_executable_file(candidate))
-                .map(|candidate| binary_cache_fingerprint(&candidate))
-                .unwrap_or_else(|| "-".to_string());
-            format!("{name}={fingerprint}")
-        })
-        .collect::<Vec<_>>()
-        .join("|")
+        .flat_map(|dir| command_path_candidates(dir, command))
+        .find(|candidate| is_executable_file(candidate))
 }
 
-/// Get available CLI agents with full metadata (install methods, env config, etc.).
-/// Single source of truth — frontend reads this instead of hardcoding.
-#[tauri::command]
-pub async fn get_available_agents() -> Result<Vec<AvailableAgent>, String> {
+fn get_available_agents_blocking() -> Vec<AvailableAgent> {
     let registry = cli_agent_registry();
     let stored_keys = KEY_SERVICE.list_keys();
 
@@ -275,36 +358,43 @@ pub async fn get_available_agents() -> Result<Vec<AvailableAgent>, String> {
     // (set by app_paths::augment_path_from_shell at startup) is visible even
     // if the async tokio runtime was initialised before the env was updated.
     let current_path = std::env::var("PATH").unwrap_or_default();
+    let path_env = std::ffi::OsString::from(&current_path);
+    let path_dirs: Vec<PathBuf> = std::env::split_paths(&path_env).collect();
     let mut key_signature_parts: Vec<String> = stored_keys
         .iter()
         .map(|key| format!("{}:{}", key.id, key.model_type.as_str()))
         .collect();
     key_signature_parts.sort();
     let current_key_signature = key_signature_parts.join("|");
-    let binary_signature_entries: Vec<(&str, &str)> = registry
+
+    let installation_snapshots: Vec<CliInstallationSnapshot> = registry
         .iter()
-        .map(|entry| (entry.name, entry.binary))
+        .map(|entry| detect_cli_installation(entry.name, entry.binary, &path_env, &path_dirs))
         .collect();
-    let current_binary_signature = path_binary_signature(&binary_signature_entries, &current_path);
+    let current_binary_signature = registry
+        .iter()
+        .zip(&installation_snapshots)
+        .map(|(entry, snapshot)| format!("{}={}", entry.name, snapshot.binary_fingerprint))
+        .collect::<Vec<_>>()
+        .join("|");
+
     if let Some(agents) = cached_available_agents(
         &current_path,
         &current_key_signature,
         &current_binary_signature,
     ) {
-        return Ok(agents);
+        return agents;
     }
     tracing::debug!("[get_available_agents] PATH={}", current_path);
 
     let mut results = Vec::new();
-    for entry in &registry {
-        let (installed, installed_via, resolved_command) =
-            detect_cli_installation(entry.name, entry.binary, &current_path).await;
+    for (entry, installation) in registry.iter().zip(installation_snapshots) {
         tracing::debug!(
             "[get_available_agents] {} ({}) → installed={} resolved_command={}",
             entry.display_name,
             entry.binary,
-            installed,
-            resolved_command
+            installation.installed,
+            installation.resolved_command
         );
 
         // A CLI agent is considered "configured" if the vault holds either:
@@ -321,9 +411,9 @@ pub async fn get_available_agents() -> Result<Vec<AvailableAgent>, String> {
         results.push(AvailableAgent {
             name: entry.name.to_string(),
             display_name: entry.display_name.to_string(),
-            installed,
+            installed: installation.installed,
             has_keys: has_key,
-            installed_via,
+            installed_via: installation.installed_via,
             description: entry.description.to_string(),
             brand_color: entry.brand_color.to_string(),
             docs_url: Some(entry.docs_url.to_string()),
@@ -366,7 +456,7 @@ pub async fn get_available_agents() -> Result<Vec<AvailableAgent>, String> {
             supports_rust_agents: entry.supports_rust_agents,
             acp_support: entry.acp_support,
             supports_orgii_pool: false,
-            command: resolved_command,
+            command: installation.resolved_command,
             supports_gui: entry.supports_gui,
         });
     }
@@ -377,7 +467,20 @@ pub async fn get_available_agents() -> Result<Vec<AvailableAgent>, String> {
         current_binary_signature,
         results.clone(),
     );
-    Ok(results)
+    results
+}
+
+/// Get available CLI agents with full metadata (install methods, env config, etc.).
+/// Single source of truth — frontend reads this instead of hardcoding.
+///
+/// Concurrent callers share one in-flight refresh. The complete
+/// filesystem/process inventory runs on Tokio's blocking pool, so WebView IPC
+/// and Wry custom-protocol responses keep their async executor capacity.
+#[tauri::command]
+pub async fn get_available_agents() -> Result<Vec<AvailableAgent>, String> {
+    available_agents_refresh()
+        .run(get_available_agents_blocking)
+        .await
 }
 
 /// Get available API providers with full metadata.
@@ -447,6 +550,8 @@ pub fn get_all_provider_configs() -> std::collections::HashMap<String, ProviderC
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
 
     #[cfg(unix)]
     fn make_executable(path: &Path) {
@@ -464,18 +569,69 @@ mod tests {
     }
 
     #[test]
-    fn path_binary_signature_changes_when_binary_appears_in_existing_path_dir() {
+    fn installation_fingerprint_changes_when_binary_appears_on_path() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let path = temp_dir.path().to_string_lossy().to_string();
-        let entries = [("codex", "codex")];
+        let path_env = std::ffi::OsString::from(temp_dir.path().as_os_str());
+        let path_dirs = vec![temp_dir.path().to_path_buf()];
 
-        let before = path_binary_signature(&entries, &path);
-        make_executable(&temp_dir.path().join("codex"));
-        let after = path_binary_signature(&entries, &path);
+        let before =
+            detect_cli_installation("unknown-test-agent", "test-cli", &path_env, &path_dirs);
+        make_executable(&temp_dir.path().join("test-cli"));
+        let after =
+            detect_cli_installation("unknown-test-agent", "test-cli", &path_env, &path_dirs);
 
-        assert_ne!(before, after);
-        assert!(before.contains("codex=-"));
-        assert!(after.contains("codex="));
-        assert!(!after.contains("codex=-"));
+        assert_eq!(before.binary_fingerprint, "-");
+        assert_ne!(before.binary_fingerprint, after.binary_fingerprint);
+        assert!(after.installed);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_refreshes_share_one_blocking_scan() {
+        let coordinator = Arc::new(AvailableAgentsRefreshCoordinator::default());
+        let cache = Arc::new(Mutex::new(None::<Vec<&'static str>>));
+        let scans = Arc::new(AtomicUsize::new(0));
+
+        let tasks = (0..4).map(|_| {
+            let coordinator = Arc::clone(&coordinator);
+            let cache = Arc::clone(&cache);
+            let scans = Arc::clone(&scans);
+            tokio::spawn(async move {
+                coordinator
+                    .run(move || {
+                        if let Some(value) = cache.lock().unwrap().clone() {
+                            return value;
+                        }
+                        scans.fetch_add(1, Ordering::SeqCst);
+                        std::thread::sleep(Duration::from_millis(25));
+                        let value = vec!["codex"];
+                        *cache.lock().unwrap() = Some(value.clone());
+                        value
+                    })
+                    .await
+                    .unwrap()
+            })
+        });
+
+        let mut results = Vec::new();
+        for task in tasks {
+            results.push(task.await.unwrap());
+        }
+        assert!(results.into_iter().all(|result| result == vec!["codex"]));
+        assert_eq!(scans.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn failed_refresh_releases_in_flight_state_for_retry() {
+        let coordinator = AvailableAgentsRefreshCoordinator::<Vec<&'static str>>::default();
+
+        let failed = coordinator
+            .run(|| panic!("simulated inventory worker failure"))
+            .await;
+        assert!(failed
+            .unwrap_err()
+            .contains("CLI agent discovery worker failed"));
+
+        let retried = coordinator.run(|| vec!["codex"]).await.unwrap();
+        assert_eq!(retried, vec!["codex"]);
     }
 }

--- a/src/api/services/availableAgents.test.ts
+++ b/src/api/services/availableAgents.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getAvailableAgents } = vi.hoisted(() => ({
+  getAvailableAgents: vi.fn(),
+}));
+
+vi.mock("@src/api/tauri/rpc", () => ({
+  rpc: {
+    validation: {
+      getAvailableAgents,
+    },
+  },
+}));
+
+describe("loadAvailableAgents", () => {
+  beforeEach(() => {
+    getAvailableAgents.mockReset();
+    vi.resetModules();
+  });
+
+  it("shares one in-flight IPC request across concurrent consumers", async () => {
+    let resolveRequest: ((value: never[]) => void) | undefined;
+    getAvailableAgents.mockReturnValue(
+      new Promise<never[]>((resolve) => {
+        resolveRequest = resolve;
+      })
+    );
+    const { loadAvailableAgents } = await import("./availableAgents");
+
+    const first = loadAvailableAgents();
+    const second = loadAvailableAgents();
+
+    expect(second).toBe(first);
+    expect(getAvailableAgents).toHaveBeenCalledTimes(1);
+
+    resolveRequest?.([]);
+    await expect(first).resolves.toEqual([]);
+  });
+
+  it("starts a new request after the previous request settles", async () => {
+    getAvailableAgents.mockResolvedValue([]);
+    const { loadAvailableAgents } = await import("./availableAgents");
+
+    await loadAvailableAgents();
+    await loadAvailableAgents();
+
+    expect(getAvailableAgents).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows retry after a rejected request", async () => {
+    getAvailableAgents
+      .mockRejectedValueOnce(new Error("IPC unavailable"))
+      .mockResolvedValueOnce([]);
+    const { loadAvailableAgents } = await import("./availableAgents");
+
+    await expect(loadAvailableAgents()).rejects.toThrow("IPC unavailable");
+    await expect(loadAvailableAgents()).resolves.toEqual([]);
+    expect(getAvailableAgents).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/api/services/availableAgents.ts
+++ b/src/api/services/availableAgents.ts
@@ -1,0 +1,27 @@
+import { rpc } from "@src/api/tauri/rpc";
+import type { AvailableAgent } from "@src/api/tauri/rpc/schemas/validation";
+
+let availableAgentsInFlight: Promise<AvailableAgent[]> | null = null;
+
+/**
+ * Share concurrent CLI-registry loads across every mounted consumer.
+ *
+ * Successful values are deliberately not cached here: Rust owns freshness and
+ * invalidation using PATH, key, binary fingerprint, and TTL inputs. This layer
+ * only removes duplicate IPC while a request is in flight.
+ */
+export function loadAvailableAgents(): Promise<AvailableAgent[]> {
+  if (availableAgentsInFlight) return availableAgentsInFlight;
+
+  const request = rpc.validation.getAvailableAgents();
+  availableAgentsInFlight = request;
+  void request.then(
+    () => {
+      if (availableAgentsInFlight === request) availableAgentsInFlight = null;
+    },
+    () => {
+      if (availableAgentsInFlight === request) availableAgentsInFlight = null;
+    }
+  );
+  return request;
+}

--- a/src/api/tauri/rpc/procedures/agentOrgs.ts
+++ b/src/api/tauri/rpc/procedures/agentOrgs.ts
@@ -190,9 +190,6 @@ const orgs = {
 } as const;
 
 export const agentOrgs = {
-  availableCliAgents: defineProcedure("get_available_agents")
-    .output(schemas.agentOrgs.AvailableCliAgentsSchema)
-    .build(),
   cursor,
   codex,
   claudeCode,

--- a/src/api/tauri/rpc/schemas/agentOrgs.ts
+++ b/src/api/tauri/rpc/schemas/agentOrgs.ts
@@ -1,10 +1,6 @@
 import { z } from "zod/v4";
 
-import {
-  AvailableAgentSchema,
-  ModelTypeSchema,
-  NativeHarnessTypeSchema,
-} from "./validation";
+import { ModelTypeSchema, NativeHarnessTypeSchema } from "./validation";
 
 const JsonRecordSchema = z.record(z.string(), z.unknown());
 
@@ -185,8 +181,6 @@ export const OrgJsonInput = z.object({
 export const OrgIdInput = z.object({
   orgId: z.string(),
 });
-
-export const AvailableCliAgentsSchema = z.array(AvailableAgentSchema);
 
 export const CliPermissionModeSchema = z.enum([
   "plan",

--- a/src/engines/SessionCore/hooks/session/useSessionDiscovery.ts
+++ b/src/engines/SessionCore/hooks/session/useSessionDiscovery.ts
@@ -13,6 +13,7 @@ import { useSetAtom } from "jotai";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { AgentInfo, ProviderInfo } from "@src/api/http/config";
+import { loadAvailableAgents } from "@src/api/services/availableAgents";
 import { rpc } from "@src/api/tauri/rpc";
 import type {
   AvailableAgent,
@@ -212,7 +213,7 @@ export function useSessionDiscovery(
     try {
       const [apiProviders, rawAgents, allKeys] = await Promise.all([
         rpc.validation.getAvailableApiProviders(),
-        rpc.validation.getAvailableAgents(),
+        loadAvailableAgents(),
         loadSharedLocalKeys(),
       ]);
 

--- a/src/modules/MainApp/Integrations/KeyVault/CliClients/hooks/useCliAgents.ts
+++ b/src/modules/MainApp/Integrations/KeyVault/CliClients/hooks/useCliAgents.ts
@@ -1,11 +1,11 @@
 /**
  * Hook for fetching CLI agents and performing install/uninstall/detect actions.
  */
-import { invoke } from "@tauri-apps/api/core";
 import { useSetAtom } from "jotai";
 import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { loadAvailableAgents } from "@src/api/services/availableAgents";
 import { autoDetectKey } from "@src/api/services/keyValidation";
 import type { ModelType } from "@src/api/types/keys";
 import Message from "@src/components/Message";
@@ -35,7 +35,7 @@ export function useCliAgents({ enabled = true }: UseCliAgentsOptions = {}) {
     setLoading(true);
     setError(null);
     try {
-      const raw = await invoke<AvailableAgent[]>("get_available_agents");
+      const raw = await loadAvailableAgents();
       const sorted = [...raw].sort((agentA, agentB) => {
         const installedDiff =
           Number(agentB.installed) - Number(agentA.installed);

--- a/src/modules/WorkStation/TabContent/renderers/agentConfig.tsx
+++ b/src/modules/WorkStation/TabContent/renderers/agentConfig.tsx
@@ -27,6 +27,7 @@ import React, {
 } from "react";
 import { useTranslation } from "react-i18next";
 
+import { loadAvailableAgents } from "@src/api/services/availableAgents";
 import { rpc } from "@src/api/tauri/rpc";
 import { Message } from "@src/components/Message";
 import { useKeyVault } from "@src/hooks/keyVault";
@@ -92,8 +93,8 @@ const AgentConfigInner: React.FC<AgentConfigInnerProps> = ({ data }) => {
   // ── CLI agents (only fetched when this tab hosts a CLI) ──
   const [cliAgents, setCliAgents] = useState<AvailableCliAgent[]>([]);
   const fetchCliAgents = useCallback(async () => {
-    const result = await rpc.agentOrgs.availableCliAgents();
-    return result.sort((agentA, agentB) =>
+    const result = await loadAvailableAgents();
+    return [...result].sort((agentA, agentB) =>
       agentA.displayName.localeCompare(agentB.displayName)
     );
   }, []);

--- a/src/modules/shared/keyVault/AccountCompatibilitySection.tsx
+++ b/src/modules/shared/keyVault/AccountCompatibilitySection.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { loadAvailableAgents } from "@src/api/services/availableAgents";
 import { rpc } from "@src/api/tauri/rpc";
 import type {
   AvailableAgent,
@@ -55,8 +56,7 @@ export const AccountCompatibilitySection: React.FC<
           logger.error("Failed to load API provider compatibility", error);
         });
     } else {
-      rpc.validation
-        .getAvailableAgents()
+      loadAvailableAgents()
         .then((agents) => {
           if (cancelled) return;
           const match = agents.find(

--- a/src/scaffold/WizardSystem/variants/KeyVault/hooks/useProviderRegistry.ts
+++ b/src/scaffold/WizardSystem/variants/KeyVault/hooks/useProviderRegistry.ts
@@ -9,6 +9,7 @@ import { useSetAtom } from "jotai";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { loadAvailableAgents } from "@src/api/services/availableAgents";
 import { rpc } from "@src/api/tauri/rpc";
 import type {
   AvailableAgent,
@@ -198,7 +199,7 @@ async function loadRegistry(): Promise<RegistryCache> {
   if (loadingPromise) return loadingPromise;
 
   loadingPromise = Promise.all([
-    rpc.validation.getAvailableAgents(),
+    loadAvailableAgents(),
     rpc.validation.getAvailableApiProviders(),
   ]).then(([agents, apiProviders]) => {
     registryCache = { agents, apiProviders };


### PR DESCRIPTION
## Summary

- coalesce concurrent CLI-agent discovery in the frontend and Rust backend
- move registry filesystem work to the blocking pool and skip per-agent login-shell fallback during inventory
- preserve PATH, key, binary-fingerprint, and TTL cache invalidation
- remove the duplicate agent-org RPC alias and add architecture/performance audits

## Root cause

Several independently mounted consumers invoked get_available_agents together. Each request synchronously scanned the full CLI registry and could launch a login shell with a three-second timeout for every missing CLI. In the packaged Wry surface this exhausted Tokio workers while WebKit custom-protocol responses waited on the main thread, producing the reported circular wait.

## Verification

- pnpm typecheck
- changed-file ESLint and Prettier
- production Webpack build
- 9 integrations resolver tests
- 3 key-vault discovery lifecycle tests
- 3 frontend single-flight/retry tests
- scoped Cargo Clippy via the repository commit hook
- optimized Tauri dev-build binary compiled and launched twice with isolated data roots; get_available_agents completed successfully and the process settled at 0.0% CPU
- macOS system sample showed the main thread idle in AppKit and Tokio workers idle on condition variables; the reported mutex/WKURLSchemeTask circular wait did not recur

## Build environment note

The app binary and unsigned bundle were produced successfully. Final bundle signing could not complete because the configured Developer ID Application certificate is not installed on this machine. The produced custom-protocol binary was used for the runtime smoke tests.

## Audits

- docs/architecture-audit-2026-07-27/CliAgentDiscoveryHang.md
- docs/org2-performance-guard-2026-07-27/CliAgentDiscoveryHang.md