### PR TITLE
fix(kanban): replay team sessions in the board preview window

### DIFF
--- a/src/features/Org2Cloud/cloudSessionReplayLifecycle.ts
+++ b/src/features/Org2Cloud/cloudSessionReplayLifecycle.ts
@@ -1,18 +1,32 @@
-import { IMPORTED_HISTORY_SOURCE_DESCRIPTORS } from "@src/api/tauri/externalHistory";
 import type { RemoteTeammateSessionMetadata } from "@src/store/collaboration/types";
+import { resolveSessionDisplayMetadata } from "@src/util/session/sessionDisplayMetadata";
 
-/** Icon identity already visible on the source row before local hydration. */
+type CloudSessionReplayIconInput = Partial<
+  Pick<
+    RemoteTeammateSessionMetadata,
+    | "sourceSessionId"
+    | "cliAgentType"
+    | "agentDisplayName"
+    | "agentDefinitionId"
+    | "model"
+    | "origin"
+  >
+>;
+
+/**
+ * Icon identity already visible on the source row before local hydration.
+ * Delegates to the canonical row projection so the placeholder shown while a
+ * replay imports is the exact mark the Team Sessions row carries — including
+ * the legacy `*_cli` wire aliases, which resolve to no registered icon on
+ * their own.
+ */
 export function resolveCloudSessionReplayIconId(
-  session: Pick<RemoteTeammateSessionMetadata, "origin" | "cliAgentType">
+  session: CloudSessionReplayIconInput
 ): string {
-  if (session.origin?.kind === "external_history") {
-    const sourceId = session.origin.source;
-    const descriptor = IMPORTED_HISTORY_SOURCE_DESCRIPTORS.find(
-      (source) => source.sourceId === sourceId
-    );
-    if (descriptor) return descriptor.iconId;
-  }
-  return session.cliAgentType || "orgii";
+  return resolveSessionDisplayMetadata({
+    kind: "remote",
+    session: { ...session, sourceSessionId: session.sourceSessionId ?? "" },
+  }).agentIconId;
 }
 
 /**

--- a/src/features/Org2Cloud/useCloudSessionActions.ts
+++ b/src/features/Org2Cloud/useCloudSessionActions.ts
@@ -51,6 +51,23 @@ import { useOpenCloudBilling } from "./useOpenCloudBilling";
 
 const log = createLogger("useCloudSessionActions");
 
+export interface CloudSessionReplayOptions {
+  /**
+   * Surface that should show the replay, called synchronously with the local
+   * session id the import will write into — before the remote transcript is
+   * fetched. Defaults to opening/replacing a Chat Pane session tab.
+   *
+   * Boards that are themselves unmounted by a tab switch (Work Management
+   * only mounts while its tab is active) MUST pass their own in-place
+   * surface: opening a tab would tear down the caller and abort the import
+   * it just started, leaving the new tab permanently empty.
+   */
+  openSurface?: (params: {
+    localSessionId: string;
+    remoteSession: RemoteTeammateSessionMetadata;
+  }) => void;
+}
+
 export type CloudSessionActionOutcome =
   | "opened"
   /** The click raced past the server-side retention filter — show upgrade. */
@@ -61,7 +78,8 @@ export type CloudSessionActionOutcome =
 
 export interface UseCloudSessionActionsResult {
   replaySession: (
-    remoteSession: RemoteTeammateSessionMetadata
+    remoteSession: RemoteTeammateSessionMetadata,
+    options?: CloudSessionReplayOptions
   ) => Promise<CloudSessionActionOutcome>;
   forkSession: (
     remoteSession: RemoteTeammateSessionMetadata
@@ -129,7 +147,8 @@ export function useCloudSessionActions(
   // then surfaces as an upgrade prompt, not a generic failure.
   const replaySession = useCallback(
     async (
-      remoteSession: RemoteTeammateSessionMetadata
+      remoteSession: RemoteTeammateSessionMetadata,
+      options?: CloudSessionReplayOptions
     ): Promise<CloudSessionActionOutcome> => {
       if (!orgId || remoteSession.eventsEpoch === undefined) return "noop";
       if (busySessionRowId) return "noop";
@@ -166,6 +185,13 @@ export function useCloudSessionActions(
               iconId: resolveCloudSessionReplayIconId(remoteSession),
             }),
           openTab: (sessionId) => {
+            if (options?.openSurface) {
+              options.openSurface({
+                localSessionId: sessionId,
+                remoteSession,
+              });
+              return;
+            }
             openOrReplaceSessionTab({
               sessionId,
               sessionName: remoteSession.title,

--- a/src/features/TaskKanban/TEST_CASES.md
+++ b/src/features/TaskKanban/TEST_CASES.md
@@ -76,3 +76,15 @@ Manual acceptance: switch between Personal and an organization from both the sid
 | Open Kanban without a saved range          | The initial activity window is 3 days                                            | `config.test.ts`           |
 
 Manual acceptance: use a column with at least 60 tasks, confirm the initial scrollbar represents 25 cards, scroll to the bottom twice, and confirm tasks 26–50 and then 51–60 appear without mounting the full history at once. Clear `orgii:kanbanTimeFilter` and reload to confirm the range starts at **3d**.
+
+## Team session preview
+
+| Case                                            | Expected result                                                                   | Coverage                                                        |
+| ----------------------------------------------- | --------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| Click a replayable teammate card or List row    | The board's draggable preview window opens in place; no Chat Pane tab is created  | `TaskKanban` `openSurface` replay target                        |
+| The replay import is still running              | The preview renders the teammate card with the pending imported session id        | `cloudReplayPreview.test.ts`                                    |
+| The imported copy lands on the board            | The preview switches to the local imported task, whose cloud duplicate is dropped | `cloudReplayPreview.test.ts`                                    |
+| Navigate to another card while a replay is open | The other card previews normally; the stale replay target is ignored              | `cloudReplayPreview.test.ts`                                    |
+| Click a metadata-only teammate card             | Nothing opens (no published events to replay)                                     | `TaskKanban` `canOpen` guard; `cloudRemoteToKanbanTask.test.ts` |
+
+Manual acceptance: open **Work Management → Kanban** with an organization selected, click a teammate's session card, and confirm the floating preview window opens over the board (Work Management stays mounted, so the import is not aborted) and fills with the replayed transcript. Close it and confirm the board selection resets.

--- a/src/features/TaskKanban/index.tsx
+++ b/src/features/TaskKanban/index.tsx
@@ -36,6 +36,7 @@ import { kanbanReplayModeAtom } from "@src/store/ui/kanbanReplayAtom";
 import {
   kanbanAgentTypeFilterAtom,
   kanbanAutoArchiveTtlAtom,
+  kanbanCloudReplayTargetAtom,
   kanbanDetailPanelVisibleAtom,
   kanbanFileSearchQueryAtom,
   kanbanManualArchivedSessionIdsAtom,
@@ -58,6 +59,7 @@ import {
 import { useKanbanTasks } from "./hooks/useKanbanTasks";
 import { useTaskKanbanFilters } from "./hooks/useTaskKanbanFilters";
 import { useTaskKanbanHeader } from "./hooks/useTaskKanbanHeader";
+import { resolveKanbanPreviewTask } from "./utils/cloudReplayPreview";
 import {
   beginKanbanHorizontalScrollGuard,
   resetKanbanHorizontalScroll,
@@ -124,6 +126,9 @@ const Kanban: React.FC<TaskKanbanProps> = ({
   );
   const [creatorVisible, setCreatorVisible] = useAtom(
     workManagementCreatorVisibleAtom
+  );
+  const [cloudReplayTarget, setCloudReplayTarget] = useAtom(
+    kanbanCloudReplayTargetAtom
   );
   const kanbanReplayMode = useAtomValue(kanbanReplayModeAtom);
   const selectedOrgId = useAtomValue(sidebarSelectedOrgIdAtom);
@@ -217,32 +222,58 @@ const Kanban: React.FC<TaskKanbanProps> = ({
     }
   }, []);
 
-  const handleTaskClick = useCallback(
-    (task: KanbanTask) => {
-      const remoteSession = remoteSessionsByTaskId.get(task.id);
-      if (remoteSession) {
-        if (task.canOpen !== false) void replaySession(remoteSession);
-        return;
-      }
-      setSelectedTaskId(task.id);
+  const openTaskPreview = useCallback(
+    (taskId: string) => {
+      setSelectedTaskId(taskId);
       setDetailPanelVisible(true);
       setCreatorVisible(false);
       beginKanbanHorizontalScrollGuard();
     },
+    [setCreatorVisible, setDetailPanelVisible, setSelectedTaskId]
+  );
+
+  const handleTaskClick = useCallback(
+    (task: KanbanTask) => {
+      const remoteSession = remoteSessionsByTaskId.get(task.id);
+      if (remoteSession) {
+        if (task.canOpen === false) return;
+        // Team sessions replay into the board's own preview window. Handing
+        // them to a Chat Pane tab instead unmounts Work Management — and the
+        // replay's abort controller with it — so the import this click just
+        // started would be cancelled and the new tab would stay empty.
+        void replaySession(remoteSession, {
+          openSurface: ({ localSessionId }) => {
+            setCloudReplayTarget({
+              taskId: task.id,
+              sessionId: localSessionId,
+            });
+            openTaskPreview(task.id);
+          },
+        });
+        return;
+      }
+      setCloudReplayTarget(null);
+      openTaskPreview(task.id);
+    },
     [
+      openTaskPreview,
       remoteSessionsByTaskId,
       replaySession,
-      setCreatorVisible,
-      setDetailPanelVisible,
-      setSelectedTaskId,
+      setCloudReplayTarget,
     ]
   );
 
   const handleCloseDetailPanel = useCallback(() => {
     setDetailPanelVisible(false);
     setSelectedTaskId(null);
+    setCloudReplayTarget(null);
     resetKanbanHorizontalScroll();
-  }, [setDetailPanelVisible, setSelectedTaskId]);
+  }, [setCloudReplayTarget, setDetailPanelVisible, setSelectedTaskId]);
+
+  const detailTask = useMemo(
+    () => resolveKanbanPreviewTask(selectedTask, cloudReplayTarget, allTasks),
+    [allTasks, cloudReplayTarget, selectedTask]
+  );
 
   useEffect(() => {
     const previousOrgId = previousSelectedOrgIdRef.current;
@@ -393,7 +424,7 @@ const Kanban: React.FC<TaskKanbanProps> = ({
           >
             <TaskDetailPanel
               visible={detailPanelVisible}
-              task={selectedTask}
+              task={detailTask}
               onClose={handleCloseDetailPanel}
               onNavigate={handleNavigateTask}
               hasPrev={taskNavigation.hasPrev}

--- a/src/features/TaskKanban/utils/cloudReplayPreview.test.ts
+++ b/src/features/TaskKanban/utils/cloudReplayPreview.test.ts
@@ -1,0 +1,66 @@
+import type { KanbanTask } from "@src/features/KanbanBoard";
+
+import { resolveKanbanPreviewTask } from "./cloudReplayPreview";
+
+function task(overrides: Partial<KanbanTask> & { id: string }): KanbanTask {
+  return {
+    title: overrides.id,
+    status: "turn_finished",
+    ...overrides,
+  } as KanbanTask;
+}
+
+describe("resolveKanbanPreviewTask", () => {
+  const cloudTask = task({ id: "cloud-remote:row-1", title: "Supabase" });
+  const target = {
+    taskId: cloudTask.id,
+    sessionId: "imported-session-1",
+  };
+
+  it("returns the selected task untouched without a replay in flight", () => {
+    expect(resolveKanbanPreviewTask(cloudTask, null, [cloudTask])).toBe(
+      cloudTask
+    );
+  });
+
+  it("grafts the pending session id onto the cloud card while importing", () => {
+    const preview = resolveKanbanPreviewTask(cloudTask, target, [cloudTask]);
+
+    expect(preview).toMatchObject({
+      id: cloudTask.id,
+      title: "Supabase",
+      session_id: "imported-session-1",
+    });
+  });
+
+  it("hands over to the imported copy once it lands on the board", () => {
+    const importedTask = task({
+      id: "imported-session-1",
+      session_id: "imported-session-1",
+      title: "Supabase",
+    });
+
+    expect(resolveKanbanPreviewTask(cloudTask, target, [importedTask])).toBe(
+      importedTask
+    );
+  });
+
+  it("still previews the imported copy after the cloud card is dropped", () => {
+    const importedTask = task({
+      id: "imported-session-1",
+      session_id: "imported-session-1",
+    });
+
+    expect(resolveKanbanPreviewTask(null, target, [importedTask])).toBe(
+      importedTask
+    );
+  });
+
+  it("leaves another selected card alone when the target is stale", () => {
+    const localTask = task({ id: "local-1", session_id: "local-1" });
+
+    expect(resolveKanbanPreviewTask(localTask, target, [localTask])).toBe(
+      localTask
+    );
+  });
+});

--- a/src/features/TaskKanban/utils/cloudReplayPreview.ts
+++ b/src/features/TaskKanban/utils/cloudReplayPreview.ts
@@ -1,0 +1,31 @@
+/**
+ * Which task the board's preview window should render while (and after) a
+ * Team Session replays.
+ *
+ * A cloud card carries no `session_id` of its own, and the local copy the
+ * replay imports only joins the board once its transcript lands. Until then
+ * the cloud card is previewed with that pending session id grafted on; after
+ * it lands, the imported task takes over (the cloud row is dropped from the
+ * projection as a duplicate of the local copy).
+ */
+import type { KanbanTask } from "@src/features/KanbanBoard";
+import type { KanbanCloudReplayTarget } from "@src/store/ui/kanbanViewStateAtom";
+
+export function resolveKanbanPreviewTask(
+  selectedTask: KanbanTask | null,
+  cloudReplayTarget: KanbanCloudReplayTarget | null,
+  allTasks: readonly KanbanTask[]
+): KanbanTask | null {
+  if (!cloudReplayTarget) return selectedTask;
+  // The user moved on to another card; the replay target is stale context.
+  if (selectedTask && selectedTask.id !== cloudReplayTarget.taskId) {
+    return selectedTask;
+  }
+  const importedTask = allTasks.find(
+    (task) => task.session_id === cloudReplayTarget.sessionId
+  );
+  if (importedTask) return importedTask;
+  return selectedTask
+    ? { ...selectedTask, session_id: cloudReplayTarget.sessionId }
+    : null;
+}

--- a/src/store/ui/kanbanViewStateAtom.ts
+++ b/src/store/ui/kanbanViewStateAtom.ts
@@ -264,6 +264,24 @@ kanbanSelectedTaskIdAtom.debugLabel = "kanban/selectedTaskId";
 export const kanbanDetailPanelVisibleAtom = atom<boolean>(false);
 kanbanDetailPanelVisibleAtom.debugLabel = "kanban/detailPanelVisible";
 
+/**
+ * Team-session card currently previewed on the board, paired with the local
+ * session id its replay import materializes. The cloud card carries no
+ * `session_id` of its own, and the imported copy only joins the board once
+ * the transcript lands — this is what lets the preview render the session in
+ * between. Transient, like the selection atoms above.
+ */
+export interface KanbanCloudReplayTarget {
+  /** Cloud task id (`cloud-remote:<row id>`) that was clicked. */
+  taskId: string;
+  /** Local session id the replay import writes into. */
+  sessionId: string;
+}
+export const kanbanCloudReplayTargetAtom = atom<KanbanCloudReplayTarget | null>(
+  null
+);
+kanbanCloudReplayTargetAtom.debugLabel = "kanban/cloudReplayTarget";
+
 /** Transient filename/path query; intentionally resets on app reload. */
 export const kanbanFileSearchQueryAtom = atom<string>("");
 kanbanFileSearchQueryAtom.debugLabel = "kanban/fileSearchQuery";

--- a/src/util/session/sessionDisplayMetadata.test.ts
+++ b/src/util/session/sessionDisplayMetadata.test.ts
@@ -202,6 +202,69 @@ describe("resolveSessionDisplayMetadata", () => {
     });
   });
 
+  it("marks a native session with the brand its model names", () => {
+    const remote = resolveSessionDisplayMetadata({
+      kind: "remote",
+      session: {
+        sourceSessionId: "remote-native-claude",
+        model: "claude-sonnet-5",
+        origin: { kind: "orgii" },
+      },
+    });
+
+    // The mark names the provider actually behind the run; the label keeps
+    // naming the runtime, which is what the Agent filter groups on.
+    expect(remote).toMatchObject({
+      agentIconId: "claude",
+      agentLabel: "ORG2",
+    });
+
+    expect(
+      resolveSessionDisplayMetadata({
+        kind: "local",
+        session: {
+          session_id: "imported-session-native-claude",
+          agentIconId: "archive",
+          importedFrom: {
+            orgId: "org-1",
+            sourceSessionId: "remote-native-claude",
+            ownerMemberId: "member-1",
+            epoch: 1,
+            seq: 0,
+            count: 1,
+            sourceDisplay: { model: "claude-sonnet-5" },
+          },
+        },
+      }).agentIconId
+    ).toBe(remote.agentIconId);
+  });
+
+  it("keeps the ORG2 mark when no model names a brand", () => {
+    expect(
+      resolveSessionDisplayMetadata({
+        kind: "remote",
+        session: {
+          sourceSessionId: "remote-native-unknown-model",
+          model: "house-blend-7",
+          origin: { kind: "orgii" },
+        },
+      }).agentIconId
+    ).toBe("orgii");
+  });
+
+  it("keeps a chosen agent icon ahead of the model brand", () => {
+    expect(
+      resolveSessionDisplayMetadata({
+        kind: "local",
+        session: {
+          session_id: "local-agent-session",
+          agentIconId: "brain",
+          model: "claude-sonnet-5",
+        },
+      }).agentIconId
+    ).toBe("brain");
+  });
+
   it("keeps a native imported replay labeled ORG2 instead of its definition name", () => {
     const display = resolveSessionDisplayMetadata({
       kind: "local",

--- a/src/util/session/sessionDisplayMetadata.ts
+++ b/src/util/session/sessionDisplayMetadata.ts
@@ -6,6 +6,7 @@ import { CLI_AGENT, type CliAgentType } from "@src/api/types/keys";
 import { formatAgentType } from "@src/assets/providers";
 import {
   THEMEABLE_ICONS,
+  getIconProviderFromModelName,
   getIconProviderFromType,
 } from "@src/components/ModelIcon/config";
 import type { RemoteTeammateSessionMetadata } from "@src/store/collaboration/types";
@@ -143,6 +144,15 @@ function resolveExternalSource(
   );
 }
 
+/** Brand mark named by a model id (`claude-sonnet-5` → the Claude mark). */
+function resolveModelBrandIconId(
+  modelName: string | undefined
+): string | undefined {
+  if (!modelName) return undefined;
+  const provider = getIconProviderFromModelName(modelName);
+  return provider === "unknown" ? undefined : provider;
+}
+
 function resolveAgentIconId(
   input: NormalizedSessionDisplayInput,
   agentType: string | undefined,
@@ -167,12 +177,23 @@ function resolveAgentIconId(
     return "orgii";
   }
 
+  // ORG2-native sessions publish no `cliAgentType` — the Rust session
+  // categories store it as NULL — so a shared Claude or GPT session arrives
+  // with no agent identity at all and used to land on the generic ORG2 glyph.
+  // Its model names the provider actually behind the run, which is the mark
+  // the viewer recognizes. Only the ICON follows the model: `agentLabel` (and
+  // with it the Agent filter) keeps naming the runtime.
+  const modelBrandIconId = resolveModelBrandIconId(input.modelName);
+
   // Imported native ORGII replays used to carry `agentIconId: "archive"`,
   // which is not a registered agent icon and therefore fell through to Bot.
-  if (input.imported) return "orgii";
-  if (input.remoteNative) return "orgii";
+  if (input.imported || input.remoteNative) return modelBrandIconId ?? "orgii";
 
-  return input.agentIconId || resolveSessionIconId(input.sessionId);
+  return (
+    input.agentIconId ||
+    modelBrandIconId ||
+    resolveSessionIconId(input.sessionId)
+  );
 }
 
 function resolveCliAgentLabel(


### PR DESCRIPTION
## The bug

Clicking a Team Sessions card on the Kanban board opened a new Chat Pane tab that never loaded — it sat on `Session data unable to load` forever. Clicking the same session in the sidebar worked.

`replaySession` opens a Chat Pane **session tab**. That tab switch unmounts Work Management — `UnifiedChatPanelTabContent` mounts it *only while its tab is active* — which unmounts `TaskKanban`, which fires the cleanup in `useCloudSessionActions` that aborts the in-flight import. The click cancelled its own replay. The abort path returns `"noop"` with no toast, so the failure was silent. The sidebar never unmounts itself, hence the asymmetry.

## The fix

Team sessions now replay into the board's own draggable preview window — the surface the board already uses for local cards — instead of spawning a tab.

- `replaySession` takes an optional `openSurface`. Callers that a tab switch would unmount supply their own in-place surface; the sidebar and fork-header callers keep the default tab behavior unchanged.
- While the import runs, the preview renders the cloud card with the pending imported session id grafted on. Once the local copy lands on the board, its own task takes over (the cloud row is dropped from the projection as a duplicate). That handover is `resolveKanbanPreviewTask`, unit-tested in isolation.
- The preview target lives in a transient module-level atom, same tier as the existing board-selection atoms.

## Provider mark

ORG2-native sessions publish no `cliAgentType` — the Rust session categories store it as NULL — so a teammate's Claude or GPT session arrived with no agent identity and rendered under the generic ORG2 glyph. The mark now falls back to the brand its **model** names before the ORG2 glyph.

Scope is deliberate: only the icon follows the model. `agentLabel` — and with it the Agent filter's grouping — keeps naming the runtime. An explicitly chosen `agentIconId` still wins, and a model no brand rule recognizes still lands on the ORG2 mark.

Separately, the replay hydration placeholder now shares the row's own projection instead of duplicating a simpler rule, so legacy `*_cli` wire aliases stop falling through to the Bot mark mid-load.

## Verification

- `tsc --noEmit` clean; eslint clean on every touched file.
- New: 5 cases for the preview handover, 3 for the model-brand mark.
- Regression sweep: `src/util/session`, `src/features/TaskKanban`, `src/features/Org2Cloud`, `src/features/TeamCollaboration`, `src/components`, `src/scaffold`, `src/engines/ChatPanel` — 1576 tests pass.
- Manual acceptance is in `src/features/TaskKanban/TEST_CASES.md` under **Team session preview**.