### PR TITLE
feat(chat): add per-session timeline, changes, and raw views

### DIFF
--- a/src/engines/ChatPanel/ChatPanelContent.test.ts
+++ b/src/engines/ChatPanel/ChatPanelContent.test.ts
@@ -1,0 +1,69 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import type { SessionViewMode } from "./hooks/useSessionViewMode";
+
+vi.mock("./SessionContentView", () => ({
+  default: ({ sessionId }: { sessionId: string }) =>
+    createElement("div", { "data-gui-session": sessionId }),
+}));
+
+vi.mock("@src/features/BenchmarkPanel", () => ({
+  BenchmarkPanel: () => createElement("div", { "data-benchmark": "true" }),
+}));
+
+const { ChatPanelContent } = await import("./ChatPanelContent");
+
+function render(sessionViewMode: SessionViewMode): string {
+  return renderToStaticMarkup(
+    createElement(ChatPanelContent, {
+      currentSessionId: "s-1",
+      displayMode: "full" as const,
+      emptyChatContent: createElement("div", { "data-empty": "true" }),
+      handleRegisterSearchOpen: () => undefined,
+      onSessionContinuation: () => undefined,
+      paginationEnabled: false,
+      position: "right" as const,
+      showBenchmarkSessionGroupContent: false,
+      showPanelContent: true,
+      showSessionContent: true,
+      sessionViewMode,
+      alternateSessionView: createElement("div", {
+        "data-alternate-session": sessionViewMode,
+      }),
+    })
+  );
+}
+
+const ALTERNATE_MODES: SessionViewMode[] = ["timeline", "changes", "raw"];
+
+describe("ChatPanelContent session views", () => {
+  it("shows the transcript and mounts no alternate view in gui mode", () => {
+    const markup = render("gui");
+
+    expect(markup).toContain(
+      '<div class="min-h-0 flex-1 flex-col flex"><div data-gui-session="s-1">'
+    );
+    expect(markup).not.toContain("data-alternate-session");
+  });
+
+  it.each(ALTERNATE_MODES)(
+    "keeps the transcript mounted but hidden in %s mode",
+    (mode) => {
+      // Regression guard for the virtualized chat list: unmounting the GUI
+      // subtree on every view switch would drop TanStack Virtual's measurement
+      // cache and force a full re-measure of every turn on the way back. The
+      // wrapper must flip to `hidden`, with the transcript still in the tree.
+      const markup = render(mode);
+
+      expect(markup).toContain(
+        '<div class="min-h-0 flex-1 flex-col hidden"><div data-gui-session="s-1">'
+      );
+    }
+  );
+
+  it.each(ALTERNATE_MODES)("mounts the alternate view in %s mode", (mode) => {
+    expect(render(mode)).toContain(`data-alternate-session="${mode}"`);
+  });
+});

--- a/src/engines/ChatPanel/ChatPanelContent.tsx
+++ b/src/engines/ChatPanel/ChatPanelContent.tsx
@@ -4,6 +4,7 @@ import type { SessionContinuation } from "@src/store/session/sessionTabPlacement
 import type { ChatHistoryDisplayMode } from "@src/store/ui/chatPanelAtom";
 
 import SessionContentView from "./SessionContentView";
+import type { SessionViewMode } from "./hooks/useSessionViewMode";
 
 const BenchmarkPanel = React.lazy(() =>
   import("@src/features/BenchmarkPanel").then((module) => ({
@@ -22,6 +23,10 @@ interface ChatPanelContentProps {
   showBenchmarkSessionGroupContent: boolean;
   showPanelContent: boolean;
   showSessionContent: boolean;
+  /** Non-GUI surface for the active session; mounted only while one is on. */
+  alternateSessionView?: React.ReactNode;
+  /** Which per-session view the header select currently resolves to. */
+  sessionViewMode?: SessionViewMode;
 }
 
 /**
@@ -42,7 +47,10 @@ export function ChatPanelContent({
   showBenchmarkSessionGroupContent,
   showPanelContent,
   showSessionContent,
+  alternateSessionView,
+  sessionViewMode = "gui",
 }: ChatPanelContentProps): React.ReactNode {
+  const alternateActive = sessionViewMode !== "gui";
   return (
     <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
       {!showPanelContent ? null : showBenchmarkSessionGroupContent ? (
@@ -50,16 +58,30 @@ export function ChatPanelContent({
           <BenchmarkPanel surface="runList" />
         </Suspense>
       ) : showSessionContent && currentSessionId ? (
-        <div className="flex min-h-0 flex-1 flex-col">
-          <SessionContentView
-            sessionId={currentSessionId}
-            onRegisterSearchOpen={handleRegisterSearchOpen}
-            displayMode={displayMode}
-            turnPaginationEnabled={paginationEnabled}
-            position={position}
-            onSessionContinuation={onSessionContinuation}
-          />
-        </div>
+        <>
+          {/* Kept mounted while another view is showing: unmounting would drop
+              the virtualized chat list's measurement cache and force a full
+              re-measure of every turn on the way back. Hidden, not unmounted. */}
+          <div
+            className={`min-h-0 flex-1 flex-col ${
+              alternateActive ? "hidden" : "flex"
+            }`}
+          >
+            <SessionContentView
+              sessionId={currentSessionId}
+              onRegisterSearchOpen={handleRegisterSearchOpen}
+              displayMode={displayMode}
+              turnPaginationEnabled={paginationEnabled}
+              position={position}
+              onSessionContinuation={onSessionContinuation}
+            />
+          </div>
+          {/* Mounted only while active. Each alternate view windows its own
+              rows (CodeMirror for Raw, Virtuoso for Timeline / Changes), so
+              none needs extra virtualization here — but none should be held
+              in memory while the reader is back in the transcript. */}
+          {alternateActive ? alternateSessionView : null}
+        </>
       ) : (
         emptyChatContent
       )}

--- a/src/engines/ChatPanel/components/SessionRawTranscriptDialog/useSessionRawTranscript.ts
+++ b/src/engines/ChatPanel/components/SessionRawTranscriptDialog/useSessionRawTranscript.ts
@@ -63,11 +63,26 @@ export function useSessionRawTranscript(
     };
   }, [enabled, loadTranscript, sessionId]);
 
+  // Release the transcript when the Raw view closes. For a large imported
+  // session the snapshot holds the complete raw entry array (tens of MB);
+  // keeping it pinned in React state for the panel's lifetime was one of the
+  // #443 retention leaks. Re-entering Raw reloads it from source.
+  useEffect(() => {
+    if (enabled) return;
+    requestIdRef.current += 1;
+    setLoadingSessionId(null);
+    setState(null);
+  }, [enabled]);
+
   const snapshot = state?.sessionId === sessionId ? state.snapshot : null;
   const error = state?.sessionId === sessionId ? state.error : null;
   const loading = loadingSessionId === sessionId;
+  // Both memos are gated on `enabled`: once a session has loaded its snapshot,
+  // an ungated merge + JSON.stringify of the whole transcript would re-run on
+  // every streaming event for as long as the hook stays mounted — including
+  // while the host is showing the GUI view and nothing reads these values.
   const entries = useMemo(() => {
-    if (!snapshot) return [];
+    if (!enabled || !snapshot) return [];
     if (snapshot.source.kind !== "orgii-event-store") {
       return snapshot.entries;
     }
@@ -76,7 +91,7 @@ export function useSessionRawTranscript(
       liveEvents,
       snapshot.sessionId
     );
-  }, [liveEvents, snapshot]);
+  }, [enabled, liveEvents, snapshot]);
   const transcriptJson = useMemo(
     () => JSON.stringify(entries, null, 2),
     [entries]

--- a/src/engines/ChatPanel/components/SessionViewSwitcher/SessionChangesView.tsx
+++ b/src/engines/ChatPanel/components/SessionViewSwitcher/SessionChangesView.tsx
@@ -1,0 +1,109 @@
+/**
+ * What one session did to the working tree: every file it wrote, aggregated
+ * across turns, busiest first.
+ *
+ * Same single turn-index read as the Timeline view, and virtualized for the
+ * same reason — a long refactor session can touch hundreds of paths.
+ */
+import React, { memo, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import { VirtualizedListBase } from "@src/components/TreeRow";
+
+import { SessionDerivedViewShell } from "./SessionDerivedViewShell";
+import type { ChangedFileRow } from "./sessionViewProjections";
+import { projectSessionChanges } from "./sessionViewProjections";
+import type { SessionDerivedViewProps } from "./types";
+
+const ROW_HEIGHT = 34;
+
+const STATUS_TONE: Record<ChangedFileRow["status"], string> = {
+  created: "bg-success-6",
+  modified: "bg-warning-6",
+  deleted: "bg-danger-6",
+};
+
+const ChangedFileRowView: React.FC<{ row: ChangedFileRow }> = memo(
+  ({ row }) => {
+    const { t } = useTranslation("sessions");
+    return (
+      <div
+        className="flex h-[34px] items-center gap-2 px-3 text-xs"
+        data-testid="session-changes-row"
+        data-path={row.path}
+      >
+        <span
+          className={`size-1.5 shrink-0 rounded-full ${STATUS_TONE[row.status]}`}
+          aria-hidden
+        />
+        <span className="shrink-0 truncate text-text-1">{row.fileName}</span>
+        <span className="min-w-0 flex-1 truncate text-text-3" title={row.path}>
+          {row.path}
+        </span>
+        {row.turnCount > 1 && (
+          <span className="shrink-0 tabular-nums text-text-3">
+            {t("chat.sessionViews.turnCount", {
+              count: row.turnCount,
+              defaultValue: "{{count}} turns",
+            })}
+          </span>
+        )}
+        <span className="w-12 shrink-0 text-right tabular-nums text-success-6">
+          {row.additions > 0 ? `+${row.additions}` : ""}
+        </span>
+        <span className="w-12 shrink-0 text-right tabular-nums text-danger-6">
+          {row.deletions > 0 ? `−${row.deletions}` : ""}
+        </span>
+      </div>
+    );
+  }
+);
+
+ChangedFileRowView.displayName = "ChangedFileRowView";
+
+const SessionChangesView: React.FC<SessionDerivedViewProps> = memo(
+  ({ turns, loading, error }) => {
+    const { t } = useTranslation("sessions");
+    const changes = useMemo(() => projectSessionChanges(turns), [turns]);
+
+    return (
+      <SessionDerivedViewShell
+        testId="session-changes-view"
+        loading={loading}
+        error={error}
+        isEmpty={changes.files.length === 0}
+        emptyLabel={t("chat.sessionViews.changesEmpty", {
+          defaultValue: "This session did not write any files.",
+        })}
+        summary={
+          <span className="flex items-center gap-2">
+            <span>
+              {t("chat.sessionViews.fileCount", {
+                count: changes.files.length,
+                defaultValue: "{{count}} files",
+              })}
+            </span>
+            <span className="tabular-nums text-success-6">
+              +{changes.totalAdditions}
+            </span>
+            <span className="tabular-nums text-danger-6">
+              −{changes.totalDeletions}
+            </span>
+          </span>
+        }
+      >
+        <VirtualizedListBase<ChangedFileRow>
+          items={changes.files}
+          itemHeight={ROW_HEIGHT}
+          computeItemKey={(row) => row.path}
+          getItemPath={(row) => row.path}
+          renderItem={(row) => <ChangedFileRowView row={row} />}
+        />
+      </SessionDerivedViewShell>
+    );
+  }
+);
+
+SessionChangesView.displayName = "SessionChangesView";
+
+export default SessionChangesView;

--- a/src/engines/ChatPanel/components/SessionViewSwitcher/SessionDerivedViewShell.tsx
+++ b/src/engines/ChatPanel/components/SessionViewSwitcher/SessionDerivedViewShell.tsx
@@ -1,0 +1,72 @@
+/**
+ * Common chrome for the derived per-session views: a summary strip plus the
+ * loading / error / empty states, so Timeline and Changes only own their rows.
+ */
+import React, { memo } from "react";
+import { useTranslation } from "react-i18next";
+
+export interface SessionDerivedViewShellProps {
+  testId: string;
+  loading: boolean;
+  error: string | null;
+  isEmpty: boolean;
+  emptyLabel: string;
+  /** Right-aligned one-line stat strip; hidden while empty. */
+  summary: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export const SessionDerivedViewShell: React.FC<SessionDerivedViewShellProps> =
+  memo(({ testId, loading, error, isEmpty, emptyLabel, summary, children }) => {
+    const { t } = useTranslation("common");
+
+    if (error) {
+      return (
+        <div
+          role="alert"
+          data-testid={`${testId}-error`}
+          className="m-3 rounded-md border border-danger-6/40 bg-danger-1 px-3 py-2 text-sm text-danger-6"
+        >
+          {error}
+        </div>
+      );
+    }
+
+    // Loading only takes the surface before the first rows arrive; a reload
+    // over existing rows keeps them on screen instead of flashing empty.
+    if (loading && isEmpty) {
+      return (
+        <div
+          data-testid={`${testId}-loading`}
+          className="flex flex-1 items-center justify-center text-sm text-text-3"
+        >
+          {t("status.loading", { defaultValue: "Loading…" })}
+        </div>
+      );
+    }
+
+    if (isEmpty) {
+      return (
+        <div
+          data-testid={`${testId}-empty`}
+          className="flex flex-1 items-center justify-center text-sm text-text-3"
+        >
+          {emptyLabel}
+        </div>
+      );
+    }
+
+    return (
+      <div
+        data-testid={testId}
+        className="flex min-h-0 flex-1 flex-col overflow-hidden"
+      >
+        <div className="flex h-8 shrink-0 items-center justify-end border-b border-border-2 px-3 text-xs text-text-3">
+          {summary}
+        </div>
+        <div className="min-h-0 flex-1">{children}</div>
+      </div>
+    );
+  });
+
+SessionDerivedViewShell.displayName = "SessionDerivedViewShell";

--- a/src/engines/ChatPanel/components/SessionViewSwitcher/SessionTimelineView.tsx
+++ b/src/engines/ChatPanel/components/SessionViewSwitcher/SessionTimelineView.tsx
@@ -1,0 +1,104 @@
+/**
+ * Per-turn gantt over one session: where the wall-clock time actually went.
+ *
+ * Rows come from the session turn index (metadata only, no event bodies), so
+ * a long session costs one read regardless of transcript size. Rendering is
+ * virtualized — a session with thousands of turns paints a viewport's worth.
+ */
+import React, { memo, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import { VirtualizedListBase } from "@src/components/TreeRow";
+import { formatDuration } from "@src/util/time/formatDuration";
+
+import { SessionDerivedViewShell } from "./SessionDerivedViewShell";
+import type { TimelineRow } from "./sessionViewProjections";
+import { projectSessionTimeline } from "./sessionViewProjections";
+import type { SessionDerivedViewProps } from "./types";
+
+const ROW_HEIGHT = 34;
+
+/** Failed and interrupted turns are the ones a reader is scanning for. */
+function barToneFor(row: TimelineRow): string {
+  if (row.status === "failed") return "bg-danger-6";
+  if (row.interrupted || row.status === "interrupted") return "bg-warning-6";
+  if (row.status === "working" || row.status === "pending")
+    return "bg-primary-4";
+  return "bg-primary-6";
+}
+
+const TimelineRowView: React.FC<{ row: TimelineRow }> = memo(({ row }) => {
+  const { t } = useTranslation("sessions");
+  return (
+    <div
+      className="flex h-[34px] items-center gap-2 px-3 text-xs"
+      data-testid="session-timeline-row"
+      data-turn-id={row.turnId}
+    >
+      <span className="w-8 shrink-0 tabular-nums text-text-3">
+        #{row.ordinal}
+      </span>
+      <span className="w-40 shrink-0 truncate text-text-2" title={row.preview}>
+        {row.preview}
+      </span>
+      <span className="relative h-2 min-w-0 flex-1 overflow-hidden rounded-full bg-fill-2">
+        <span
+          className={`absolute inset-y-0 rounded-full ${barToneFor(row)}`}
+          style={{
+            left: `${row.offsetRatio * 100}%`,
+            width: `${row.widthRatio * 100}%`,
+          }}
+        />
+      </span>
+      <span className="w-14 shrink-0 text-right tabular-nums text-text-3">
+        {row.durationMs === null ? "—" : formatDuration(row.durationMs)}
+      </span>
+      <span className="w-16 shrink-0 text-right tabular-nums text-text-3">
+        {row.fileCount > 0
+          ? t("chat.sessionViews.fileCount", {
+              count: row.fileCount,
+              defaultValue: "{{count}} files",
+            })
+          : ""}
+      </span>
+    </div>
+  );
+});
+
+TimelineRowView.displayName = "TimelineRowView";
+
+const SessionTimelineView: React.FC<SessionDerivedViewProps> = memo(
+  ({ turns, loading, error }) => {
+    const { t } = useTranslation("sessions");
+    const timeline = useMemo(() => projectSessionTimeline(turns), [turns]);
+
+    return (
+      <SessionDerivedViewShell
+        testId="session-timeline-view"
+        loading={loading}
+        error={error}
+        isEmpty={timeline.rows.length === 0}
+        emptyLabel={t("chat.sessionViews.timelineEmpty", {
+          defaultValue: "No turns to show yet.",
+        })}
+        summary={t("chat.sessionViews.timelineSummary", {
+          count: timeline.rows.length,
+          duration: formatDuration(timeline.totalMs),
+          defaultValue: "{{count}} turns over {{duration}}",
+        })}
+      >
+        <VirtualizedListBase<TimelineRow>
+          items={timeline.rows}
+          itemHeight={ROW_HEIGHT}
+          computeItemKey={(row) => row.turnId}
+          getItemPath={(row) => row.turnId}
+          renderItem={(row) => <TimelineRowView row={row} />}
+        />
+      </SessionDerivedViewShell>
+    );
+  }
+);
+
+SessionTimelineView.displayName = "SessionTimelineView";
+
+export default SessionTimelineView;

--- a/src/engines/ChatPanel/components/SessionViewSwitcher/index.tsx
+++ b/src/engines/ChatPanel/components/SessionViewSwitcher/index.tsx
@@ -1,0 +1,178 @@
+/**
+ * Header pieces and body dispatcher for the per-session view switch, shared by
+ * the chat pane and the Workstation `chat-session` tab so both hosts render an
+ * identical control.
+ *
+ * - `SessionHeaderViewControls` owns the published-header leading slot:
+ *   breadcrumb, separator, and the ghost mode select.
+ * - `SessionRawToolbarActions` owns the trailing Refresh/Copy pair, which only
+ *   applies to Raw and renders nothing in the other views.
+ * - `SessionAlternateSurface` owns every non-GUI body. It mounts only the view
+ *   in play, so neither the raw document nor the turn index is held while the
+ *   reader is back in the transcript.
+ */
+import { Clipboard, RefreshCw } from "lucide-react";
+import React, { memo } from "react";
+import { useTranslation } from "react-i18next";
+
+import Button from "@src/components/Button";
+import Select from "@src/components/Select";
+import type { Session } from "@src/store/session";
+
+import { useSessionTurnIndex } from "../../hooks/useSessionTurnIndex";
+import type { UseSessionViewModeResult } from "../../hooks/useSessionViewMode";
+import SessionHeaderBreadcrumb, {
+  type SessionHeaderParentTarget,
+} from "../SessionHeaderBreadcrumb";
+import SessionRawTranscriptView from "../SessionRawTranscriptView";
+import SessionChangesView from "./SessionChangesView";
+import SessionTimelineView from "./SessionTimelineView";
+
+const RAW_ACTION_ICON_SIZE = 14;
+
+export interface SessionHeaderViewControlsProps {
+  session: Session | null | undefined;
+  sessionId: string;
+  fallbackName: string;
+  onParentSessionClick?: (target: SessionHeaderParentTarget) => void;
+  view: UseSessionViewModeResult;
+  /** Test id prefix so each host keeps distinguishable selectors. */
+  testIdPrefix: string;
+}
+
+export const SessionHeaderViewControls: React.FC<SessionHeaderViewControlsProps> =
+  memo(
+    ({
+      session,
+      sessionId,
+      fallbackName,
+      onParentSessionClick,
+      view,
+      testIdPrefix,
+    }) => (
+      <div className="flex min-w-0 flex-1 items-center gap-1.5">
+        <SessionHeaderBreadcrumb
+          session={session}
+          sessionId={sessionId}
+          fallbackName={fallbackName}
+          onParentSessionClick={onParentSessionClick}
+        />
+        {view.switchable && (
+          <>
+            <Select
+              value={view.mode}
+              options={view.options}
+              onChange={view.onChange}
+              size="small"
+              variant="ghost"
+              radius="lg"
+              dropdownAlign="right"
+              dropdownMinWidth={160}
+              dropdownWidthMode="auto"
+              className="w-auto shrink-0"
+              selectorClassName="!gap-2 !px-1 [&_.select-suffix]:!ml-1"
+              dataTestId={`${testIdPrefix}-view-select`}
+            />
+            <span
+              className="pointer-events-none mx-1.5 h-4 w-px shrink-0 bg-border-2"
+              aria-hidden
+            />
+          </>
+        )}
+      </div>
+    )
+  );
+
+SessionHeaderViewControls.displayName = "SessionHeaderViewControls";
+
+export interface SessionRawToolbarActionsProps {
+  view: UseSessionViewModeResult;
+  /** Test id prefix so each host keeps distinguishable selectors. */
+  testIdPrefix: string;
+}
+
+export const SessionRawToolbarActions: React.FC<SessionRawToolbarActionsProps> =
+  memo(({ view, testIdPrefix }) => {
+    const { t } = useTranslation(["sessions", "common"]);
+    const { isRaw, transcript } = view;
+    if (!isRaw) return null;
+
+    const refreshLabel = t("common:actions.refresh", "Refresh");
+    const copyLabel = t("common:actions.copy", "Copy");
+
+    return (
+      <>
+        <Button
+          size="small"
+          variant="tertiary"
+          icon={<RefreshCw size={RAW_ACTION_ICON_SIZE} strokeWidth={2} />}
+          iconOnly
+          loading={transcript.loading}
+          aria-label={refreshLabel}
+          title={refreshLabel}
+          data-testid={`${testIdPrefix}-raw-refresh-button`}
+          onClick={() => void transcript.loadTranscript()}
+        />
+        <Button
+          size="small"
+          variant="tertiary"
+          icon={<Clipboard size={RAW_ACTION_ICON_SIZE} strokeWidth={2} />}
+          iconOnly
+          disabled={!transcript.snapshot || transcript.loading}
+          aria-label={copyLabel}
+          title={copyLabel}
+          data-testid={`${testIdPrefix}-raw-copy-button`}
+          onClick={() => void transcript.copyTranscript()}
+        />
+      </>
+    );
+  });
+
+SessionRawToolbarActions.displayName = "SessionRawToolbarActions";
+
+export interface SessionAlternateSurfaceProps {
+  sessionId: string | null;
+  view: UseSessionViewModeResult;
+}
+
+/**
+ * Body for every non-GUI view. Renders nothing in "gui" so the host can keep
+ * the transcript mounted underneath without a second surface fighting it.
+ */
+export const SessionAlternateSurface: React.FC<SessionAlternateSurfaceProps> =
+  memo(({ sessionId, view }) => {
+    const { mode } = view;
+    const needsTurnIndex = mode === "timeline" || mode === "changes";
+    const turnIndex = useSessionTurnIndex(sessionId, needsTurnIndex);
+
+    if (!sessionId) return null;
+    if (mode === "raw") {
+      return (
+        <SessionRawTranscriptView
+          sessionId={sessionId}
+          transcript={view.transcript}
+        />
+      );
+    }
+    if (mode === "timeline") {
+      return (
+        <SessionTimelineView
+          turns={turnIndex.turns}
+          loading={turnIndex.loading}
+          error={turnIndex.error}
+        />
+      );
+    }
+    if (mode === "changes") {
+      return (
+        <SessionChangesView
+          turns={turnIndex.turns}
+          loading={turnIndex.loading}
+          error={turnIndex.error}
+        />
+      );
+    }
+    return null;
+  });
+
+SessionAlternateSurface.displayName = "SessionAlternateSurface";

--- a/src/engines/ChatPanel/components/SessionViewSwitcher/sessionViewProjections.test.ts
+++ b/src/engines/ChatPanel/components/SessionViewSwitcher/sessionViewProjections.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  TurnModifiedFile,
+  TurnSummary,
+} from "@src/engines/SessionCore/storage/sqliteCache";
+
+import {
+  MIN_TIMELINE_BAR_RATIO,
+  projectSessionChanges,
+  projectSessionTimeline,
+} from "./sessionViewProjections";
+
+function file(
+  path: string,
+  overrides: Partial<TurnModifiedFile> = {}
+): TurnModifiedFile {
+  return {
+    path,
+    fileName: path.split("/").pop() ?? path,
+    status: "modified",
+    additions: 0,
+    deletions: 0,
+    ...overrides,
+  };
+}
+
+function turn(overrides: Partial<TurnSummary> = {}): TurnSummary {
+  return {
+    sessionId: "s-1",
+    turnId: "t-1",
+    startSequence: 0,
+    endSequence: 1,
+    nextTurnId: null,
+    startedAt: "2026-07-28T10:00:00.000Z",
+    endedAt: "2026-07-28T10:00:10.000Z",
+    durationMs: 10_000,
+    userEventIds: [],
+    userPreview: "do a thing",
+    eventCount: 3,
+    bodyEventCount: 2,
+    status: "completed",
+    interrupted: false,
+    modifiedFiles: [],
+    resourceInteractions: [],
+    gitArtifacts: [],
+    ...overrides,
+  };
+}
+
+describe("projectSessionTimeline", () => {
+  it("lays bars out against the session's own wall-clock span", () => {
+    const { rows, totalMs } = projectSessionTimeline([
+      turn({
+        turnId: "a",
+        startedAt: "2026-07-28T10:00:00.000Z",
+        endedAt: "2026-07-28T10:00:30.000Z",
+      }),
+      turn({
+        turnId: "b",
+        startedAt: "2026-07-28T10:00:30.000Z",
+        endedAt: "2026-07-28T10:01:00.000Z",
+      }),
+    ]);
+
+    expect(totalMs).toBe(60_000);
+    expect(rows[0].offsetRatio).toBe(0);
+    expect(rows[0].widthRatio).toBeCloseTo(0.5);
+    expect(rows[1].offsetRatio).toBeCloseTo(0.5);
+    expect(rows[1].widthRatio).toBeCloseTo(0.5);
+  });
+
+  it("floors a zero-length turn to a still-visible bar", () => {
+    const { rows } = projectSessionTimeline([
+      turn({
+        turnId: "a",
+        startedAt: "2026-07-28T10:00:00.000Z",
+        endedAt: "2026-07-28T10:00:00.000Z",
+        durationMs: 0,
+      }),
+      turn({
+        turnId: "b",
+        startedAt: "2026-07-28T10:00:00.000Z",
+        endedAt: "2026-07-28T10:10:00.000Z",
+      }),
+    ]);
+
+    expect(rows[0].widthRatio).toBe(MIN_TIMELINE_BAR_RATIO);
+  });
+
+  it("never lets a floored bar overflow the track", () => {
+    // A zero-length turn at the very end would otherwise start at ratio 1.0
+    // and still claim the minimum width, painting past the right edge.
+    const { rows } = projectSessionTimeline([
+      turn({
+        turnId: "a",
+        startedAt: "2026-07-28T10:00:00.000Z",
+        endedAt: "2026-07-28T10:10:00.000Z",
+      }),
+      turn({
+        turnId: "b",
+        startedAt: "2026-07-28T10:10:00.000Z",
+        endedAt: "2026-07-28T10:10:00.000Z",
+        durationMs: 0,
+      }),
+    ]);
+
+    const last = rows[rows.length - 1];
+    expect(last.offsetRatio + last.widthRatio).toBeLessThanOrEqual(1);
+  });
+
+  it("derives an open turn's end from its duration", () => {
+    const { rows } = projectSessionTimeline([
+      turn({
+        turnId: "a",
+        startedAt: "2026-07-28T10:00:00.000Z",
+        endedAt: null,
+        durationMs: 5_000,
+        status: "working",
+      }),
+    ]);
+
+    expect(rows[0].durationMs).toBe(5_000);
+  });
+
+  it("skips turns with an unparseable start rather than collapsing the span", () => {
+    const { rows, totalMs } = projectSessionTimeline([
+      turn({ turnId: "bad", startedAt: "not-a-date" }),
+      turn({
+        turnId: "good",
+        startedAt: "2026-07-28T10:00:00.000Z",
+        endedAt: "2026-07-28T10:00:20.000Z",
+      }),
+    ]);
+
+    expect(rows.map((row) => row.turnId)).toEqual(["good"]);
+    expect(totalMs).toBe(20_000);
+  });
+
+  it("returns an empty timeline for a session with no timed turns", () => {
+    expect(projectSessionTimeline([])).toEqual({ rows: [], totalMs: 0 });
+  });
+});
+
+describe("projectSessionChanges", () => {
+  it("sums a path's line stats across every turn that touched it", () => {
+    const { files, totalAdditions, totalDeletions } = projectSessionChanges([
+      turn({
+        turnId: "a",
+        modifiedFiles: [file("src/a.ts", { additions: 10, deletions: 2 })],
+      }),
+      turn({
+        turnId: "b",
+        modifiedFiles: [file("src/a.ts", { additions: 5, deletions: 1 })],
+      }),
+    ]);
+
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatchObject({
+      path: "src/a.ts",
+      additions: 15,
+      deletions: 3,
+      turnCount: 2,
+      firstTurnId: "a",
+    });
+    expect(totalAdditions).toBe(15);
+    expect(totalDeletions).toBe(3);
+  });
+
+  it("orders by total churn so the busiest files lead", () => {
+    const { files } = projectSessionChanges([
+      turn({
+        modifiedFiles: [
+          file("small.ts", { additions: 1 }),
+          file("big.ts", { additions: 40, deletions: 10 }),
+          file("mid.ts", { additions: 12 }),
+        ],
+      }),
+    ]);
+
+    expect(files.map((entry) => entry.path)).toEqual([
+      "big.ts",
+      "mid.ts",
+      "small.ts",
+    ]);
+  });
+
+  it("keeps the session-level status when a path is created then modified", () => {
+    const { files } = projectSessionChanges([
+      turn({ modifiedFiles: [file("new.ts", { status: "created" })] }),
+      turn({ modifiedFiles: [file("new.ts", { status: "modified" })] }),
+    ]);
+
+    expect(files[0].status).toBe("created");
+  });
+
+  it("lets a delete anywhere in the session win", () => {
+    const { files } = projectSessionChanges([
+      turn({ modifiedFiles: [file("gone.ts", { status: "created" })] }),
+      turn({ modifiedFiles: [file("gone.ts", { status: "deleted" })] }),
+      turn({ modifiedFiles: [file("gone.ts", { status: "modified" })] }),
+    ]);
+
+    expect(files[0].status).toBe("deleted");
+  });
+
+  it("returns nothing for a session that wrote no files", () => {
+    expect(projectSessionChanges([turn()])).toEqual({
+      files: [],
+      totalAdditions: 0,
+      totalDeletions: 0,
+    });
+  });
+});

--- a/src/engines/ChatPanel/components/SessionViewSwitcher/sessionViewProjections.ts
+++ b/src/engines/ChatPanel/components/SessionViewSwitcher/sessionViewProjections.ts
@@ -1,0 +1,179 @@
+/**
+ * Pure projections backing the derived per-session views. Kept free of React
+ * so the layout maths and the aggregation rules are testable directly.
+ *
+ * Both read the same `TurnSummary[]` the session turn index already returns —
+ * neither view needs event bodies, which is what keeps a whole-session view
+ * affordable on long sessions.
+ */
+import type {
+  TurnModifiedFile,
+  TurnStatus,
+  TurnSummary,
+} from "@src/engines/SessionCore/storage/sqliteCache";
+
+/** A zero-length turn still needs a visible bar. Ratio of the total span. */
+export const MIN_TIMELINE_BAR_RATIO = 0.01;
+
+export interface TimelineRow {
+  turnId: string;
+  /** 1-based position, shown as the row label prefix. */
+  ordinal: number;
+  preview: string;
+  startedAtMs: number;
+  durationMs: number | null;
+  /** Bar offset from the session start, 0..1 of the total span. */
+  offsetRatio: number;
+  /** Bar width, 0..1 of the total span, floored so every turn is visible. */
+  widthRatio: number;
+  status: TurnStatus;
+  interrupted: boolean;
+  fileCount: number;
+  eventCount: number;
+  commitCount: number;
+}
+
+export interface SessionTimeline {
+  rows: TimelineRow[];
+  /** Wall-clock span from the first turn's start to the last turn's end. */
+  totalMs: number;
+}
+
+function parseTime(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/** End of a turn: its own end stamp, or start + duration when still open. */
+function turnEndMs(turn: TurnSummary, startMs: number): number {
+  const ended = parseTime(turn.endedAt);
+  if (ended !== null) return ended;
+  const duration =
+    typeof turn.durationMs === "number" && Number.isFinite(turn.durationMs)
+      ? Math.max(0, turn.durationMs)
+      : 0;
+  return startMs + duration;
+}
+
+export function projectSessionTimeline(turns: TurnSummary[]): SessionTimeline {
+  const timed = turns
+    .map((turn) => ({ turn, startMs: parseTime(turn.startedAt) }))
+    .filter(
+      (entry): entry is { turn: TurnSummary; startMs: number } =>
+        entry.startMs !== null
+    );
+
+  if (timed.length === 0) return { rows: [], totalMs: 0 };
+
+  const sessionStart = Math.min(...timed.map((entry) => entry.startMs));
+  const sessionEnd = Math.max(
+    ...timed.map((entry) => turnEndMs(entry.turn, entry.startMs))
+  );
+  // A session whose turns all share one instant has no span to divide by;
+  // fall back to 1 so every ratio resolves to the minimum bar instead of NaN.
+  const totalMs = Math.max(1, sessionEnd - sessionStart);
+
+  const rows = timed.map(({ turn, startMs }, index) => {
+    const endMs = turnEndMs(turn, startMs);
+    const offsetRatio = (startMs - sessionStart) / totalMs;
+    const rawWidth = (endMs - startMs) / totalMs;
+    const widthRatio = Math.min(
+      1 - offsetRatio,
+      Math.max(MIN_TIMELINE_BAR_RATIO, rawWidth)
+    );
+    return {
+      turnId: turn.turnId,
+      ordinal: index + 1,
+      preview: turn.userPreview,
+      startedAtMs: startMs,
+      durationMs:
+        typeof turn.durationMs === "number" && Number.isFinite(turn.durationMs)
+          ? Math.max(0, turn.durationMs)
+          : endMs > startMs
+            ? endMs - startMs
+            : null,
+      offsetRatio,
+      widthRatio,
+      status: turn.status,
+      interrupted: turn.interrupted,
+      fileCount: turn.modifiedFiles.length,
+      eventCount: turn.eventCount,
+      commitCount: turn.gitArtifacts.length,
+    };
+  });
+
+  return { rows, totalMs };
+}
+
+export interface ChangedFileRow {
+  path: string;
+  fileName: string;
+  /**
+   * Net status across the session: a file created then modified still reads
+   * as "created", and a delete anywhere in the session wins — that is what the
+   * session did to the file overall, not what its last turn did.
+   */
+  status: TurnModifiedFile["status"];
+  additions: number;
+  deletions: number;
+  /** How many turns touched this path. */
+  turnCount: number;
+  /** First turn that touched it — the jump target from the row. */
+  firstTurnId: string;
+}
+
+export interface SessionChanges {
+  files: ChangedFileRow[];
+  totalAdditions: number;
+  totalDeletions: number;
+}
+
+function mergeStatus(
+  current: TurnModifiedFile["status"],
+  next: TurnModifiedFile["status"]
+): TurnModifiedFile["status"] {
+  if (current === "deleted" || next === "deleted") return "deleted";
+  if (current === "created" || next === "created") return "created";
+  return "modified";
+}
+
+export function projectSessionChanges(turns: TurnSummary[]): SessionChanges {
+  const byPath = new Map<string, ChangedFileRow>();
+
+  for (const turn of turns) {
+    for (const file of turn.modifiedFiles) {
+      const existing = byPath.get(file.path);
+      if (!existing) {
+        byPath.set(file.path, {
+          path: file.path,
+          fileName: file.fileName,
+          status: file.status,
+          additions: file.additions,
+          deletions: file.deletions,
+          turnCount: 1,
+          firstTurnId: turn.turnId,
+        });
+        continue;
+      }
+      existing.status = mergeStatus(existing.status, file.status);
+      existing.additions += file.additions;
+      existing.deletions += file.deletions;
+      existing.turnCount += 1;
+    }
+  }
+
+  // Busiest files first: the ones a reviewer wants at the top are the ones the
+  // session churned most, not the ones it happened to touch first.
+  const files = Array.from(byPath.values()).sort(
+    (a, b) =>
+      b.additions + b.deletions - (a.additions + a.deletions) ||
+      a.path.localeCompare(b.path)
+  );
+
+  return {
+    files,
+    totalAdditions: files.reduce((sum, file) => sum + file.additions, 0),
+    totalDeletions: files.reduce((sum, file) => sum + file.deletions, 0),
+  };
+}

--- a/src/engines/ChatPanel/components/SessionViewSwitcher/types.ts
+++ b/src/engines/ChatPanel/components/SessionViewSwitcher/types.ts
@@ -1,0 +1,8 @@
+import type { TurnSummary } from "@src/engines/SessionCore/storage/sqliteCache";
+
+/** Shared prop contract for the derived per-session views (Timeline, Changes). */
+export interface SessionDerivedViewProps {
+  turns: TurnSummary[];
+  loading: boolean;
+  error: string | null;
+}

--- a/src/engines/ChatPanel/hooks/useSessionTurnIndex.ts
+++ b/src/engines/ChatPanel/hooks/useSessionTurnIndex.ts
@@ -1,0 +1,72 @@
+/**
+ * Loads a session's full turn index for the derived per-session views
+ * (Timeline, Changes).
+ *
+ * `loadTurnIndex` returns the whole index in one round-trip, so both views
+ * share a single load rather than paging: the index is metadata only (no event
+ * bodies), which is what makes a whole-session view affordable at all.
+ *
+ * Gated on `enabled` so a session that never leaves the GUI view never pays
+ * the read, and re-entering a view it already loaded does not re-read.
+ */
+import { useEffect, useRef, useState } from "react";
+
+import { loadTurnIndex } from "@src/engines/SessionCore/storage/cacheAdapter";
+import type { TurnSummary } from "@src/engines/SessionCore/storage/sqliteCache";
+
+export interface SessionTurnIndexState {
+  turns: TurnSummary[];
+  loading: boolean;
+  error: string | null;
+}
+
+interface LoadedIndex {
+  sessionId: string;
+  turns: TurnSummary[];
+  error: string | null;
+}
+
+const EMPTY_TURNS: TurnSummary[] = [];
+
+export function useSessionTurnIndex(
+  sessionId: string | null,
+  enabled: boolean
+): SessionTurnIndexState {
+  const [result, setResult] = useState<LoadedIndex | null>(null);
+  // Guards against a slow load for session A resolving after the host has
+  // switched to session B and overwriting B's rows.
+  const requestIdRef = useRef(0);
+
+  const settled = result?.sessionId === sessionId;
+
+  useEffect(() => {
+    if (!enabled || !sessionId || settled) return;
+    const requestId = ++requestIdRef.current;
+    loadTurnIndex(sessionId)
+      .then((turns) => {
+        if (requestId !== requestIdRef.current) return;
+        setResult({ sessionId, turns, error: null });
+      })
+      .catch((loadError: unknown) => {
+        if (requestId !== requestIdRef.current) return;
+        setResult({
+          sessionId,
+          turns: EMPTY_TURNS,
+          error:
+            loadError instanceof Error ? loadError.message : String(loadError),
+        });
+      });
+    return () => {
+      requestIdRef.current += 1;
+    };
+  }, [enabled, settled, sessionId]);
+
+  // Loading is derived, not stored: "asked for it and it hasn't settled yet".
+  // Keeping it out of state avoids a synchronous setState in the effect body
+  // and the extra render that comes with it.
+  return {
+    turns: settled ? (result?.turns ?? EMPTY_TURNS) : EMPTY_TURNS,
+    loading: Boolean(enabled && sessionId) && !settled,
+    error: settled ? (result?.error ?? null) : null,
+  };
+}

--- a/src/engines/ChatPanel/hooks/useSessionViewMode.test.ts
+++ b/src/engines/ChatPanel/hooks/useSessionViewMode.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SESSION_VIEW_MODES,
+  type SessionViewMode,
+  type SessionViewModeState,
+  isSessionViewMode,
+  resolveSessionViewMode,
+} from "./useSessionViewMode";
+
+function state(
+  mode: SessionViewMode,
+  sessionId: string | null
+): SessionViewModeState {
+  return { mode, sessionId };
+}
+
+describe("resolveSessionViewMode", () => {
+  it("keeps the stored mode for the session it was stored against", () => {
+    expect(resolveSessionViewMode(state("raw", "s-1"), "s-1", true)).toBe(
+      "raw"
+    );
+  });
+
+  it("falls back to gui when the stored entry belongs to another session", () => {
+    // Regression: opening Raw on one session and then switching tabs must not
+    // strand the newly-opened session in Raw.
+    expect(resolveSessionViewMode(state("raw", "s-1"), "s-2", true)).toBe(
+      "gui"
+    );
+  });
+
+  it("pins non-switchable sessions to gui even with a matching raw entry", () => {
+    // Human sessions have no agent transcript to serialize.
+    expect(resolveSessionViewMode(state("raw", "s-1"), "s-1", false)).toBe(
+      "gui"
+    );
+  });
+
+  it("resolves to gui when there is no active session", () => {
+    expect(resolveSessionViewMode(state("raw", null), null, false)).toBe("gui");
+  });
+});
+
+describe("isSessionViewMode", () => {
+  it("accepts every supported mode", () => {
+    expect(SESSION_VIEW_MODES.every(isSessionViewMode)).toBe(true);
+  });
+
+  it("rejects anything else so a stray select value cannot write bad state", () => {
+    expect(isSessionViewMode("tree")).toBe(false);
+    expect(isSessionViewMode("")).toBe(false);
+  });
+});

--- a/src/engines/ChatPanel/hooks/useSessionViewMode.ts
+++ b/src/engines/ChatPanel/hooks/useSessionViewMode.ts
@@ -1,0 +1,146 @@
+/**
+ * Per-session view-mode state, shared by the two hosts that render a session
+ * surface: the chat pane (`ChatPanel/index.tsx`) and the Workstation
+ * `chat-session` tab renderer. Both show the same ghost select and the same
+ * bodies, so the mode state, the option list and the raw-transcript wiring
+ * live here instead of being duplicated per host.
+ *
+ * The mode is keyed by session id: switching to another session inside the
+ * same host lands back on "gui" rather than stranding the new session in the
+ * previous one's view.
+ *
+ * `useSessionRawTranscript` is called with `enabled = isRaw`, so a session that
+ * never opens Raw pays neither the transcript load nor the JSON serialization.
+ */
+import { Braces, FileDiff, GanttChart, MessagesSquare } from "lucide-react";
+import React, { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { SelectOption } from "@src/components/Select";
+
+import { useSessionRawTranscript } from "../components/SessionRawTranscriptDialog/useSessionRawTranscript";
+
+export const SESSION_VIEW_MODES = [
+  "gui",
+  "timeline",
+  "changes",
+  "raw",
+] as const;
+export type SessionViewMode = (typeof SESSION_VIEW_MODES)[number];
+
+export function isSessionViewMode(value: string): value is SessionViewMode {
+  return (SESSION_VIEW_MODES as readonly string[]).includes(value);
+}
+
+export interface SessionViewModeState {
+  mode: SessionViewMode;
+  sessionId: string | null;
+}
+
+/**
+ * Effective mode for the session currently being rendered.
+ *
+ * A state entry belonging to another session (or a session that cannot switch
+ * at all) resolves to "gui" without a state write, so changing sessions never
+ * needs an effect to reset the mode — and a session can never inherit the
+ * previous session's view.
+ */
+export function resolveSessionViewMode(
+  state: SessionViewModeState,
+  sessionId: string | null,
+  switchable: boolean
+): SessionViewMode {
+  if (!switchable) return "gui";
+  return state.sessionId === sessionId ? state.mode : "gui";
+}
+
+const MODE_ICONS: Record<SessionViewMode, typeof MessagesSquare> = {
+  gui: MessagesSquare,
+  timeline: GanttChart,
+  changes: FileDiff,
+  raw: Braces,
+};
+
+const MODE_ICON_SIZE = 14;
+
+const SESSION_VIEW_FALLBACK_LABELS: Record<SessionViewMode, string> = {
+  gui: "Chat",
+  timeline: "Timeline",
+  changes: "Changes",
+  raw: "Raw",
+};
+
+export interface UseSessionViewModeOptions {
+  sessionId: string | null;
+  /**
+   * Human sessions carry no agent event transcript, so there is nothing to
+   * show in the derived views — the mode is pinned to "gui" and the select is
+   * suppressed.
+   */
+  humanSession: boolean;
+}
+
+export interface UseSessionViewModeResult {
+  mode: SessionViewMode;
+  isRaw: boolean;
+  /** False for human sessions / no session — hosts skip the select entirely. */
+  switchable: boolean;
+  options: SelectOption[];
+  onChange: (value: string | number | (string | number)[]) => void;
+  /** Jump straight to Raw; wired to the header menu's "Raw transcript" item. */
+  showRaw: () => void;
+  transcript: ReturnType<typeof useSessionRawTranscript>;
+}
+
+export function useSessionViewMode({
+  sessionId,
+  humanSession,
+}: UseSessionViewModeOptions): UseSessionViewModeResult {
+  const { t } = useTranslation("sessions");
+  const [state, setState] = useState<SessionViewModeState>({
+    mode: "gui",
+    sessionId,
+  });
+
+  const switchable = Boolean(sessionId) && !humanSession;
+  const mode = resolveSessionViewMode(state, sessionId, switchable);
+  const isRaw = mode === "raw";
+
+  const transcript = useSessionRawTranscript(sessionId, isRaw);
+
+  const options = useMemo<SelectOption[]>(
+    () =>
+      SESSION_VIEW_MODES.map((value) => {
+        const Icon = MODE_ICONS[value];
+        return {
+          value,
+          label: t(`chat.sessionViews.${value}`, {
+            defaultValue: SESSION_VIEW_FALLBACK_LABELS[value],
+          }),
+          icon: React.createElement(Icon, {
+            size: MODE_ICON_SIZE,
+            strokeWidth: 1.75,
+          }),
+          dataTestId: `session-view-option-${value}`,
+        };
+      }),
+    [t]
+  );
+
+  const onChange = useCallback(
+    (value: string | number | (string | number)[]) => {
+      if (Array.isArray(value)) return;
+      const next = String(value);
+      if (!isSessionViewMode(next)) return;
+      setState({ mode: next, sessionId });
+    },
+    [sessionId]
+  );
+
+  const showRaw = useCallback(() => {
+    if (!sessionId) return;
+    setState({ mode: "raw", sessionId });
+  }, [sessionId]);
+
+  return { mode, isRaw, switchable, options, onChange, showRaw, transcript };
+}

--- a/src/engines/ChatPanel/index.tsx
+++ b/src/engines/ChatPanel/index.tsx
@@ -71,7 +71,11 @@ import {
   ChatPanelTabBar,
   useChatPanelTabShortcuts,
 } from "./ChatPanelTabBar";
-import SessionHeaderBreadcrumb from "./components/SessionHeaderBreadcrumb";
+import {
+  SessionAlternateSurface,
+  SessionHeaderViewControls,
+  SessionRawToolbarActions,
+} from "./components/SessionViewSwitcher";
 import { useAiWorkItemCreator } from "./hooks/useAiWorkItemCreator";
 import { useChatPanelContentState } from "./hooks/useChatPanelContentState";
 import { useChatPanelCreateTarget } from "./hooks/useChatPanelCreateTarget";
@@ -82,6 +86,7 @@ import { useChatPanelSessionModals } from "./hooks/useChatPanelSessionModals";
 import { useChatPanelTabsController } from "./hooks/useChatPanelTabsController";
 import { usePanelTitle } from "./hooks/usePanelTitle";
 import { useProjectWorkItemHandlers } from "./hooks/useProjectWorkItemHandlers";
+import { useSessionViewMode } from "./hooks/useSessionViewMode";
 import { useViewportWidth } from "./hooks/useViewportWidth";
 import type { ChatPanelProps, ChatPanelRegionNotice } from "./types";
 
@@ -109,6 +114,10 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
       currentSession?.category === "human_session" ||
       isHumanSession(currentSessionId);
     const handleReloadSession = useReloadSession(currentSessionId ?? null);
+    const sessionView = useSessionViewMode({
+      sessionId: currentSessionId ?? null,
+      humanSession: humanSessionActive,
+    });
 
     const [contentMode, setContentMode] = useAtom(chatPanelContentModeAtom);
     const [createTarget, setCreateTarget] = useAtom(chatPanelCreateTargetAtom);
@@ -411,7 +420,6 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
       handleOpenExportSessionJson,
       handleOpenLinkWorkItem,
       handleOpenCloudShareSettings,
-      handleOpenRawTranscript,
       showCloudShareSettings,
       sessionModals,
     } = useChatPanelSessionModals({
@@ -492,7 +500,7 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
         handleOpenExportSessionJson={handleOpenExportSessionJson}
         handleOpenLinkWorkItem={handleOpenLinkWorkItem}
         handleOpenCloudShareSettings={handleOpenCloudShareSettings}
-        handleOpenRawTranscript={handleOpenRawTranscript}
+        handleOpenRawTranscript={sessionView.showRaw}
         handleMoveToWorkstation={handleMoveToWorkstation}
         handleOpenSearch={handleOpenSearch}
         handlePaginationToggle={handlePaginationToggle}
@@ -528,17 +536,23 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
                   non-cloud sessions, exactly like the fork extras. */}
             <SessionCommentsHeaderExtras session={currentSession ?? null} />
             <SessionForkHeaderExtras session={currentSession ?? null} />
+            <SessionRawToolbarActions
+              view={sessionView}
+              testIdPrefix="chat-panel-session"
+            />
           </>
         }
         sessionHeaderContent={
           contentState.showSessionContent &&
           !isStandaloneToolTabActive &&
           currentSessionId ? (
-            <SessionHeaderBreadcrumb
+            <SessionHeaderViewControls
               session={currentSession}
               sessionId={currentSessionId}
               fallbackName={panelTitle}
               onParentSessionClick={handleSessionContinuation}
+              view={sessionView}
+              testIdPrefix="chat-panel-session"
             />
           ) : null
         }
@@ -562,6 +576,13 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
         }
         showPanelContent={contentState.showPanelContent}
         showSessionContent={contentState.showSessionContent}
+        sessionViewMode={sessionView.mode}
+        alternateSessionView={
+          <SessionAlternateSurface
+            sessionId={currentSessionId ?? null}
+            view={sessionView}
+          />
+        }
       />
     );
 

--- a/src/i18n/locales/de/sessions.json
+++ b/src/i18n/locales/de/sessions.json
@@ -1197,6 +1197,20 @@
         "filters": "Filters",
         "openInGitHub": "Open in GitHub"
       }
+    },
+    "sessionViews": {
+      "gui": "Chat",
+      "timeline": "Zeitachse",
+      "changes": "Änderungen",
+      "raw": "Rohdaten",
+      "timelineSummary_one": "{{count}} Runde über {{duration}}",
+      "timelineSummary_other": "{{count}} Runden über {{duration}}",
+      "timelineEmpty": "Noch keine Runden vorhanden.",
+      "changesEmpty": "Diese Sitzung hat keine Dateien geschrieben.",
+      "fileCount_one": "{{count}} Datei",
+      "fileCount_other": "{{count}} Dateien",
+      "turnCount_one": "{{count}} Runde",
+      "turnCount_other": "{{count}} Runden"
     }
   },
   "chatStatus": {

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -1248,6 +1248,20 @@
         "filters": "Filters",
         "openInGitHub": "Open in GitHub"
       }
+    },
+    "sessionViews": {
+      "gui": "Chat",
+      "timeline": "Timeline",
+      "changes": "Changes",
+      "raw": "Raw",
+      "timelineSummary_one": "{{count}} turn over {{duration}}",
+      "timelineSummary_other": "{{count}} turns over {{duration}}",
+      "timelineEmpty": "No turns to show yet.",
+      "changesEmpty": "This session did not write any files.",
+      "fileCount_one": "{{count}} file",
+      "fileCount_other": "{{count}} files",
+      "turnCount_one": "{{count}} turn",
+      "turnCount_other": "{{count}} turns"
     }
   },
   "chatStatus": {

--- a/src/i18n/locales/es/sessions.json
+++ b/src/i18n/locales/es/sessions.json
@@ -1199,6 +1199,20 @@
         "filters": "Filters",
         "openInGitHub": "Open in GitHub"
       }
+    },
+    "sessionViews": {
+      "gui": "Chat",
+      "timeline": "Cronología",
+      "changes": "Cambios",
+      "raw": "Sin procesar",
+      "timelineSummary_one": "{{count}} turno en {{duration}}",
+      "timelineSummary_other": "{{count}} turnos en {{duration}}",
+      "timelineEmpty": "Todavía no hay turnos que mostrar.",
+      "changesEmpty": "Esta sesión no escribió ningún archivo.",
+      "fileCount_one": "{{count}} archivo",
+      "fileCount_other": "{{count}} archivos",
+      "turnCount_one": "{{count}} turno",
+      "turnCount_other": "{{count}} turnos"
     }
   },
   "chatStatus": {

--- a/src/i18n/locales/fr/sessions.json
+++ b/src/i18n/locales/fr/sessions.json
@@ -1199,6 +1199,20 @@
         "filters": "Filters",
         "openInGitHub": "Open in GitHub"
       }
+    },
+    "sessionViews": {
+      "gui": "Chat",
+      "timeline": "Chronologie",
+      "changes": "Modifications",
+      "raw": "Brut",
+      "timelineSummary_one": "{{count}} tour sur {{duration}}",
+      "timelineSummary_other": "{{count}} tours sur {{duration}}",
+      "timelineEmpty": "Aucun tour à afficher pour le moment.",
+      "changesEmpty": "Cette session n'a écrit aucun fichier.",
+      "fileCount_one": "{{count}} fichier",
+      "fileCount_other": "{{count}} fichiers",
+      "turnCount_one": "{{count}} tour",
+      "turnCount_other": "{{count}} tours"
     }
   },
   "chatStatus": {

--- a/src/i18n/locales/ja/sessions.json
+++ b/src/i18n/locales/ja/sessions.json
@@ -1198,6 +1198,20 @@
         "filters": "Filters",
         "openInGitHub": "Open in GitHub"
       }
+    },
+    "sessionViews": {
+      "gui": "チャット",
+      "timeline": "タイムライン",
+      "changes": "変更",
+      "raw": "生データ",
+      "timelineSummary_one": "{{count}} ラウンド / {{duration}}",
+      "timelineSummary_other": "{{count}} ラウンド / {{duration}}",
+      "timelineEmpty": "表示できるラウンドがありません。",
+      "changesEmpty": "このセッションはファイルを書き込んでいません。",
+      "fileCount_one": "{{count}} ファイル",
+      "fileCount_other": "{{count}} ファイル",
+      "turnCount_one": "{{count}} ラウンド",
+      "turnCount_other": "{{count}} ラウンド"
     }
   },
   "chatStatus": {

--- a/src/i18n/locales/ko/sessions.json
+++ b/src/i18n/locales/ko/sessions.json
@@ -1198,6 +1198,20 @@
         "filters": "Filters",
         "openInGitHub": "Open in GitHub"
       }
+    },
+    "sessionViews": {
+      "gui": "대화",
+      "timeline": "타임라인",
+      "changes": "변경 사항",
+      "raw": "원본",
+      "timelineSummary_one": "턴 {{count}}개, {{duration}}",
+      "timelineSummary_other": "턴 {{count}}개, {{duration}}",
+      "timelineEmpty": "표시할 턴이 없습니다.",
+      "changesEmpty": "이 세션은 파일을 쓰지 않았습니다.",
+      "fileCount_one": "파일 {{count}}개",
+      "fileCount_other": "파일 {{count}}개",
+      "turnCount_one": "턴 {{count}}개",
+      "turnCount_other": "턴 {{count}}개"
     }
   },
   "chatStatus": {

--- a/src/i18n/locales/pl/sessions.json
+++ b/src/i18n/locales/pl/sessions.json
@@ -1212,6 +1212,20 @@
         "filters": "Filters",
         "openInGitHub": "Open in GitHub"
       }
+    },
+    "sessionViews": {
+      "gui": "Czat",
+      "timeline": "Oś czasu",
+      "changes": "Zmiany",
+      "raw": "Surowe",
+      "timelineSummary_one": "{{count}} runda w ciągu {{duration}}",
+      "timelineSummary_other": "{{count}} rund w ciągu {{duration}}",
+      "timelineEmpty": "Brak rund do wyświetlenia.",
+      "changesEmpty": "Ta sesja nie zapisała żadnych plików.",
+      "fileCount_one": "{{count}} plik",
+      "fileCount_other": "{{count}} plików",
+      "turnCount_one": "{{count}} runda",
+      "turnCount_other": "{{count}} rund"
     }
   },
   "chatStatus": {

--- a/src/i18n/locales/pt/sessions.json
+++ b/src/i18n/locales/pt/sessions.json
@@ -1198,6 +1198,20 @@
         "filters": "Filters",
         "openInGitHub": "Open in GitHub"
       }
+    },
+    "sessionViews": {
+      "gui": "Chat",
+      "timeline": "Linha do tempo",
+      "changes": "Alterações",
+      "raw": "Bruto",
+      "timelineSummary_one": "{{count}} rodada em {{duration}}",
+      "timelineSummary_other": "{{count}} rodadas em {{duration}}",
+      "timelineEmpty": "Ainda não há rodadas para mostrar.",
+      "changesEmpty": "Esta sessão não gravou nenhum arquivo.",
+      "fileCount_one": "{{count}} arquivo",
+      "fileCount_other": "{{count}} arquivos",
+      "turnCount_one": "{{count}} rodada",
+      "turnCount_other": "{{count}} rodadas"
     }
   },
   "chatStatus": {

--- a/src/i18n/locales/ru/sessions.json
+++ b/src/i18n/locales/ru/sessions.json
@@ -1215,6 +1215,20 @@
         "filters": "Filters",
         "openInGitHub": "Open in GitHub"
       }
+    },
+    "sessionViews": {
+      "gui": "Чат",
+      "timeline": "Хронология",
+      "changes": "Изменения",
+      "raw": "Исходные данные",
+      "timelineSummary_one": "{{count}} раунд за {{duration}}",
+      "timelineSummary_other": "{{count}} раундов за {{duration}}",
+      "timelineEmpty": "Пока нет раундов для показа.",
+      "changesEmpty": "В этой сессии не было записано ни одного файла.",
+      "fileCount_one": "{{count}} файл",
+      "fileCount_other": "{{count}} файлов",
+      "turnCount_one": "{{count}} раунд",
+      "turnCount_other": "{{count}} раундов"
     }
   },
   "chatStatus": {

--- a/src/i18n/locales/tr/sessions.json
+++ b/src/i18n/locales/tr/sessions.json
@@ -1199,6 +1199,20 @@
         "filters": "Filters",
         "openInGitHub": "Open in GitHub"
       }
+    },
+    "sessionViews": {
+      "gui": "Sohbet",
+      "timeline": "Zaman çizelgesi",
+      "changes": "Değişiklikler",
+      "raw": "Ham",
+      "timelineSummary_one": "{{duration}} içinde {{count}} tur",
+      "timelineSummary_other": "{{duration}} içinde {{count}} tur",
+      "timelineEmpty": "Henüz gösterilecek tur yok.",
+      "changesEmpty": "Bu oturum hiçbir dosya yazmadı.",
+      "fileCount_one": "{{count}} dosya",
+      "fileCount_other": "{{count}} dosya",
+      "turnCount_one": "{{count}} tur",
+      "turnCount_other": "{{count}} tur"
     }
   },
   "chatStatus": {

--- a/src/i18n/locales/vi/sessions.json
+++ b/src/i18n/locales/vi/sessions.json
@@ -1196,6 +1196,20 @@
         "filters": "Filters",
         "openInGitHub": "Open in GitHub"
       }
+    },
+    "sessionViews": {
+      "gui": "Trò chuyện",
+      "timeline": "Dòng thời gian",
+      "changes": "Thay đổi",
+      "raw": "Thô",
+      "timelineSummary_one": "{{count}} lượt trong {{duration}}",
+      "timelineSummary_other": "{{count}} lượt trong {{duration}}",
+      "timelineEmpty": "Chưa có lượt nào để hiển thị.",
+      "changesEmpty": "Phiên này không ghi tệp nào.",
+      "fileCount_one": "{{count}} tệp",
+      "fileCount_other": "{{count}} tệp",
+      "turnCount_one": "{{count}} lượt",
+      "turnCount_other": "{{count}} lượt"
     }
   },
   "chatStatus": {

--- a/src/i18n/locales/zh-Hant/sessions.json
+++ b/src/i18n/locales/zh-Hant/sessions.json
@@ -1213,6 +1213,20 @@
         "filters": "Filters",
         "openInGitHub": "Open in GitHub"
       }
+    },
+    "sessionViews": {
+      "gui": "對話",
+      "timeline": "時間軸",
+      "changes": "變更",
+      "raw": "原始",
+      "timelineSummary_one": "{{count}} 輪，歷時 {{duration}}",
+      "timelineSummary_other": "{{count}} 輪，歷時 {{duration}}",
+      "timelineEmpty": "尚無可顯示的輪次。",
+      "changesEmpty": "此工作階段沒有寫入任何檔案。",
+      "fileCount_one": "{{count}} 個檔案",
+      "fileCount_other": "{{count}} 個檔案",
+      "turnCount_one": "{{count}} 輪",
+      "turnCount_other": "{{count}} 輪"
     }
   },
   "chatStatus": {

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -1244,6 +1244,20 @@
         "filters": "Filters",
         "openInGitHub": "Open in GitHub"
       }
+    },
+    "sessionViews": {
+      "gui": "对话",
+      "timeline": "时间线",
+      "changes": "变更",
+      "raw": "原始",
+      "timelineSummary_one": "{{count}} 轮，历时 {{duration}}",
+      "timelineSummary_other": "{{count}} 轮，历时 {{duration}}",
+      "timelineEmpty": "暂无可展示的轮次。",
+      "changesEmpty": "此会话没有写入任何文件。",
+      "fileCount_one": "{{count}} 个文件",
+      "fileCount_other": "{{count}} 个文件",
+      "turnCount_one": "{{count}} 轮",
+      "turnCount_other": "{{count}} 轮"
     }
   },
   "chatStatus": {

--- a/src/modules/WorkStation/TabContent/renderers/chatSession.tsx
+++ b/src/modules/WorkStation/TabContent/renderers/chatSession.tsx
@@ -7,20 +7,20 @@
  * without rewriting the session workspace to the Workstation's current repo.
  */
 import { useAtomValue, useSetAtom } from "jotai";
-import { Clipboard, RefreshCw } from "lucide-react";
-import React, { memo, useCallback, useMemo, useState } from "react";
+import React, { memo, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-import Button from "@src/components/Button";
-import TabPill from "@src/components/TabPill";
 import { useReloadSession } from "@src/engines/ChatPanel/ChatHistory/hooks/useReloadSession";
 import SessionContentView from "@src/engines/ChatPanel/SessionContentView";
 import { SessionHeaderActionsMenu } from "@src/engines/ChatPanel/components/SessionHeaderActionsMenu";
-import SessionHeaderBreadcrumb from "@src/engines/ChatPanel/components/SessionHeaderBreadcrumb";
-import { useSessionRawTranscript } from "@src/engines/ChatPanel/components/SessionRawTranscriptDialog/useSessionRawTranscript";
-import SessionRawTranscriptView from "@src/engines/ChatPanel/components/SessionRawTranscriptView";
+import {
+  SessionAlternateSurface,
+  SessionHeaderViewControls,
+  SessionRawToolbarActions,
+} from "@src/engines/ChatPanel/components/SessionViewSwitcher";
 import { useSessionActionModals } from "@src/engines/ChatPanel/hooks/useSessionActionModals";
 import { useSessionHeaderActions } from "@src/engines/ChatPanel/hooks/useSessionHeaderActions";
+import { useSessionViewMode } from "@src/engines/ChatPanel/hooks/useSessionViewMode";
 import SessionViewersIndicator from "@src/features/Org2Cloud/SessionViewersIndicator";
 import { usePublishWorkstationTabHeader } from "@src/hooks/workStation";
 import { sessionByIdAtom } from "@src/store/session";
@@ -33,13 +33,6 @@ import { isHumanSession } from "@src/util/session/sessionDispatch";
 
 import type { UnifiedTabContentProps } from "../types";
 
-type SessionViewMode = "gui" | "raw";
-
-interface SessionViewState {
-  mode: SessionViewMode;
-  sessionId: string;
-}
-
 const ChatSessionTabRenderer: React.FC<UnifiedTabContentProps> = memo(
   ({ tab }) => {
     const { t } = useTranslation([
@@ -49,22 +42,14 @@ const ChatSessionTabRenderer: React.FC<UnifiedTabContentProps> = memo(
       "navigation",
     ]);
     const sessionId = String(tab.data.sessionId ?? "");
-    const [sessionViewState, setSessionViewState] = useState<SessionViewState>({
-      mode: "gui",
-      sessionId,
-    });
     const session = useAtomValue(sessionByIdAtom(sessionId));
     const humanSession =
       session?.category === "human_session" || isHumanSession(sessionId);
-    const sessionViewMode = humanSession
-      ? "gui"
-      : sessionViewState.sessionId === sessionId
-        ? sessionViewState.mode
-        : "gui";
-    const transcript = useSessionRawTranscript(
-      sessionId || null,
-      sessionViewMode === "raw"
-    );
+    const sessionView = useSessionViewMode({
+      sessionId: sessionId || null,
+      humanSession,
+    });
+    const sessionViewMode = sessionView.mode;
     const handleReloadSession = useReloadSession(sessionId || null);
     const retargetSessionTab = useSetAtom(retargetWorkstationSessionTabAtom);
     const moveSessionTab = useSetAtom(moveSessionTabAtom);
@@ -89,26 +74,6 @@ const ChatSessionTabRenderer: React.FC<UnifiedTabContentProps> = memo(
     );
 
     const sessionName = session?.name?.trim() || tab.title || "Chat";
-    const sessionViewTabs = useMemo(
-      () => [
-        {
-          key: "gui",
-          label: t("chat.rawTranscript.guiTab", { defaultValue: "GUI" }),
-        },
-        {
-          key: "raw",
-          label: t("chat.rawTranscript.rawTab", { defaultValue: "Raw" }),
-        },
-      ],
-      [t]
-    );
-    const handleSessionViewChange = useCallback(
-      (key: string) => {
-        if (key !== "gui" && key !== "raw") return;
-        setSessionViewState({ mode: key, sessionId });
-      },
-      [sessionId]
-    );
     const handleMoveToChatPanel = useCallback(() => {
       if (!sessionId) return;
       moveSessionTab({
@@ -127,74 +92,24 @@ const ChatSessionTabRenderer: React.FC<UnifiedTabContentProps> = memo(
     ]);
     const headerContent = useMemo(
       () => (
-        <div className="flex min-w-0 flex-1 items-center gap-1.5">
-          <SessionHeaderBreadcrumb
-            session={session}
-            sessionId={sessionId}
-            fallbackName={sessionName}
-            onParentSessionClick={handleSessionContinuation}
-          />
-          {!humanSession && (
-            <>
-              <span
-                className="pointer-events-none mx-1.5 h-4 w-px shrink-0 bg-border-2"
-                aria-hidden
-              />
-              <TabPill
-                activeTab={sessionViewMode}
-                tabs={sessionViewTabs}
-                onChange={handleSessionViewChange}
-                variant="pill"
-                color="fill"
-                fillWidth={false}
-                size="small"
-              />
-            </>
-          )}
-        </div>
+        <SessionHeaderViewControls
+          session={session}
+          sessionId={sessionId}
+          fallbackName={sessionName}
+          onParentSessionClick={handleSessionContinuation}
+          view={sessionView}
+          testIdPrefix="workstation-session"
+        />
       ),
-      [
-        handleSessionViewChange,
-        handleSessionContinuation,
-        session,
-        sessionId,
-        sessionName,
-        sessionViewMode,
-        sessionViewTabs,
-        humanSession,
-      ]
+      [handleSessionContinuation, session, sessionId, sessionName, sessionView]
     );
-    const refreshLabel = t("common:actions.refresh", "Refresh");
-    const copyLabel = t("common:actions.copy", "Copy");
     const headerTrailing = (
       <div className="flex shrink-0 items-center gap-px">
         <SessionViewersIndicator sessionId={sessionId || null} />
-        {sessionViewMode === "raw" ? (
-          <>
-            <Button
-              size="small"
-              variant="tertiary"
-              icon={<RefreshCw size={14} strokeWidth={2} />}
-              iconOnly
-              loading={transcript.loading}
-              aria-label={refreshLabel}
-              title={refreshLabel}
-              data-testid="workstation-session-raw-refresh-button"
-              onClick={() => void transcript.loadTranscript()}
-            />
-            <Button
-              size="small"
-              variant="tertiary"
-              icon={<Clipboard size={14} strokeWidth={2} />}
-              iconOnly
-              disabled={!transcript.snapshot || transcript.loading}
-              aria-label={copyLabel}
-              title={copyLabel}
-              data-testid="workstation-session-raw-copy-button"
-              onClick={() => void transcript.copyTranscript()}
-            />
-          </>
-        ) : null}
+        <SessionRawToolbarActions
+          view={sessionView}
+          testIdPrefix="workstation-session"
+        />
         <SessionHeaderActionsMenu
           activeSessionExists={Boolean(session)}
           copyEventJsonLabel={headerActions.copyEventJsonLabel}
@@ -213,7 +128,7 @@ const ChatSessionTabRenderer: React.FC<UnifiedTabContentProps> = memo(
             sessionActions.handleOpenExportSessionJson
           }
           handleOpenLinkWorkItem={sessionActions.handleOpenLinkWorkItem}
-          handleOpenRawTranscript={sessionActions.handleOpenRawTranscript}
+          handleOpenRawTranscript={sessionView.showRaw}
           handleOpenSearch={headerActions.handleOpenSearch}
           handlePaginationToggle={headerActions.handlePaginationToggle}
           handleReloadFromMenu={headerActions.handleReloadFromMenu}
@@ -255,6 +170,8 @@ const ChatSessionTabRenderer: React.FC<UnifiedTabContentProps> = memo(
             "linear-gradient(180deg, var(--color-bg-1) 0%, var(--color-fill-1) 100%)",
         }}
       >
+        {/* Hidden, never unmounted — see ChatPanelContent for why the
+            virtualized transcript must survive a view switch. */}
         <div
           className={`min-h-0 flex-1 flex-col overflow-hidden ${
             sessionViewMode === "gui" ? "flex" : "hidden"
@@ -269,12 +186,7 @@ const ChatSessionTabRenderer: React.FC<UnifiedTabContentProps> = memo(
             turnPaginationEnabled={headerActions.paginationEnabled}
           />
         </div>
-        {!humanSession && sessionViewMode === "raw" ? (
-          <SessionRawTranscriptView
-            sessionId={sessionId}
-            transcript={transcript}
-          />
-        ) : null}
+        <SessionAlternateSurface sessionId={sessionId} view={sessionView} />
         {sessionActions.sessionModals}
       </div>
     );


### PR DESCRIPTION
## What

The chat pane could only render a session as its GUI transcript. The raw JSON was reachable only through a modal, and neither host could answer *"where did the time go"* or *"what did this session touch"*.

This adds a ghost select — **Chat / Timeline / Changes / Raw** — to the session published header, shared by the chat pane and the Workstation `chat-session` tab so both hosts render one identical control rather than duplicating the switcher.

| View | What it answers |
| --- | --- |
| **Timeline** | Per-turn gantt over the session's own wall-clock span. Failed / interrupted turns are toned apart; rows carry duration and file count. |
| **Changes** | `modifiedFiles` aggregated across turns, busiest first — status dot, path, `+/−`, and how many turns touched it. |
| **Raw** | The existing transcript view, now **embedded instead of modal**. |

## Data

Both derived views read one `loadTurnIndex(sessionId)` call. That index is metadata only (no event bodies), so a whole-session view costs a single read regardless of transcript size. No Rust-side changes.

Two aggregation rules worth review, both pinned by tests:

- A path **created then modified** stays `created`; a **delete anywhere** in the session wins. That is what the session did to the file overall, not what its last turn did.
- A zero-length turn's bar is floored to 1% so it stays visible, but clamped to `1 - offsetRatio` so a zero-length turn at the very end cannot paint past the track's right edge.

## Virtualization

The chat list is virtualized (TanStack Virtual), so switching views must not remount it:

- The GUI subtree is **hidden, never unmounted** — unmounting would drop the measurement cache and force a re-measure of every turn on the way back. `ChatPanelContent.test.ts` guards this for all three alternate modes.
- Alternate views mount **only while active**, and each windows its own rows (CodeMirror for Raw, Virtuoso for Timeline / Changes).
- The turn index is gated on `enabled`, so a session that never leaves Chat never pays the read.
- `useSessionRawTranscript`'s merge + `JSON.stringify` are now gated on `enabled` too. Previously, a session that opened Raw once kept re-serializing the whole transcript on **every streaming event** for as long as the hook stayed mounted.
- `useSessionTurnIndex` derives `loading` instead of storing it — no synchronous `setState` in the effect body, one fewer render.

## Notes

- WorkStation's `chatSession.tsx` drops ~90 lines: its inline pill, mode state, and toolbar are now the shared components.
- `SessionRawTranscriptDialog` is **not** removed — `WorkStation/shared/TabBar` still opens it. Only the two session-surface hosts moved to the embedded view.
- i18n: `chat.sessionViews.*`, 12 keys incl. `_one`/`_other`, all 13 locales.
- `ChatPanel/index.tsx` is 615 lines, still over the 600-line convention noted in sibling files (was 594). Getting under it means splitting pre-existing parts of that file — deliberately left out of scope.

## Verification

- `tsc --noEmit` clean
- `eslint` clean
- `vitest run src/engines/ChatPanel src/modules/WorkStation` → **162 files / 1316 tests pass**, 24 new (11 projection logic, 6 mode resolution, 7 mount strategy)
