### PR TITLE
fix(agent-org): delete workers when deleting an Agent Org session

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,16 @@ This file orients Codex / orgii agents working in this repo. It tells you **whic
 
 > Cursor IDE users: live UI-feature delivery rules live in `.cursor/rules/ui-feature-workflow.mdc`. This file does **not** replace those — it's about skill routing for AI agents, not unit-test gates.
 
-This is **advisory**, not a hard contract. Use judgment based on PR size and risk.
+Except for requirements explicitly marked as hard requirements, this file is **advisory**, not a hard contract. Use judgment based on PR size and risk.
+
+---
+
+## GitHub Identity (Hard Requirement)
+
+- Perform every GitHub operation for this repository as the GitHub account `ShiboSheng`. This includes pushes, issue and PR creation or updates, reviews, comments, labels, merges, releases, and other GitHub writes.
+- Before the first GitHub write in a task, verify the authenticated identity with `gh api user --jq .login`. Continue only when the result is exactly `ShiboSheng`.
+- Do not use another GitHub connector, browser session, CLI account, or credential as a fallback. If `ShiboSheng` is unavailable or authentication has expired, stop and ask the user to reconnect it.
+- Keep local Git commits authored as `Shibo Sheng <shiboshengs2@gmail.com>` unless the user explicitly requests a different identity.
 
 ---
 

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_runs/store.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_runs/store.rs
@@ -27,6 +27,17 @@ use super::{
 
 pub struct AgentOrgRunStore;
 
+pub(crate) struct AgentOrgRunDeleteOutcome {
+    plan_artifacts: Vec<(String, String)>,
+    deleted: bool,
+}
+
+impl AgentOrgRunDeleteOutcome {
+    pub(crate) fn deleted(&self) -> bool {
+        self.deleted
+    }
+}
+
 impl AgentOrgRunStore {
     pub fn create(params: CreateAgentOrgRunParams) -> Result<AgentOrgRunRecord, String> {
         let entry_mode = validate_entry_mode(params.entry_mode.as_str())?;
@@ -182,6 +193,38 @@ impl AgentOrgRunStore {
         if changed {
             crate::coordination::agent_org_run_events::notify_agent_org_run_changed(run_id);
         }
+        Ok(changed)
+    }
+
+    /// Establish the durable fence for a user-requested hierarchy deletion.
+    ///
+    /// `paused` remains resumable, so deletion must not use it as the final
+    /// stop signal. Moving a live run to `cancelled` prevents resume and wake
+    /// paths from starting new work while the caller drains Rust runtimes.
+    pub(crate) fn cancel_for_delete_with_connection(
+        conn: &Connection,
+        run_id: &str,
+    ) -> Result<bool, String> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let changed = conn
+            .execute(
+                "UPDATE agent_org_runs
+                 SET status='cancelled',
+                     updated_at=?2,
+                     completed_at=COALESCE(completed_at, ?2)
+                 WHERE id=?1
+                   AND status IN ('running', 'paused')",
+                params![run_id, &now],
+            )
+            .map_err(|err| err.to_string())?
+            > 0;
+        conn.execute(
+            "UPDATE agent_org_plan_approvals
+             SET status='cancelled', decision_by='system', resolved_at=?2
+             WHERE org_run_id=?1 AND status='pending'",
+            params![run_id, &now],
+        )
+        .map_err(|err| err.to_string())?;
         Ok(changed)
     }
 
@@ -631,84 +674,96 @@ impl AgentOrgRunStore {
     }
 
     pub fn delete_by_id(run_id: &str) -> Result<(), String> {
-        let (plan_artifacts, deleted) =
-            with_sessions_writer(|| -> Result<(Vec<(String, String)>, bool), String> {
-                let mut conn = get_connection().map_err(|err| err.to_string())?;
-                let tx = conn
-                    .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
-                    .map_err(|err| err.to_string())?;
-                let plan_artifacts = {
-                    let mut stmt = tx
-                        .prepare(
-                            "SELECT DISTINCT approval.source_session_id, approval.plan_path
-                         FROM agent_org_plan_approvals approval
-                         WHERE approval.org_run_id=?1
-                           AND NOT EXISTS (
-                             SELECT 1 FROM agent_org_plan_approvals other
-                             WHERE other.plan_path=approval.plan_path
-                               AND other.org_run_id<>?1
-                           )",
-                        )
-                        .map_err(|err| err.to_string())?;
-                    let rows = stmt
-                        .query_map(params![run_id], |row| {
-                            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-                        })
-                        .map_err(|err| err.to_string())?;
-                    rows.collect::<Result<Vec<_>, _>>()
-                        .map_err(|err| err.to_string())?
-                };
+        let outcome = with_sessions_writer(|| -> Result<AgentOrgRunDeleteOutcome, String> {
+            let mut conn = get_connection().map_err(|err| err.to_string())?;
+            let tx = conn
+                .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+                .map_err(|err| err.to_string())?;
+            let outcome = Self::delete_by_id_with_connection(&tx, run_id)?;
+            tx.commit().map_err(|err| err.to_string())?;
+            Ok(outcome)
+        })?;
 
-                // A session tree can contain another Agent Org run. Intent rows
-                // therefore carry explicit run ownership: deleting this run must
-                // remove all of its direct and wake/resume turns without touching
-                // a nested run merely because its root is a session descendant.
-                tx.execute(
-                    "DELETE FROM session_turn_intents WHERE org_run_id=?1",
-                    params![run_id],
+        Self::finish_delete(run_id, outcome);
+        Ok(())
+    }
+
+    pub(crate) fn delete_by_id_with_connection(
+        conn: &Connection,
+        run_id: &str,
+    ) -> Result<AgentOrgRunDeleteOutcome, String> {
+        let plan_artifacts = {
+            let mut stmt = conn
+                .prepare(
+                    "SELECT DISTINCT approval.source_session_id, approval.plan_path
+                     FROM agent_org_plan_approvals approval
+                     WHERE approval.org_run_id=?1
+                       AND NOT EXISTS (
+                         SELECT 1 FROM agent_org_plan_approvals other
+                         WHERE other.plan_path=approval.plan_path
+                           AND other.org_run_id<>?1
+                       )",
                 )
                 .map_err(|err| err.to_string())?;
-                tx.execute(
-                    "DELETE FROM agent_inbox_materializations
-                 WHERE inbox_id IN (
-                     SELECT id FROM agent_inbox WHERE org_run_id=?1
-                 )",
-                    params![run_id],
-                )
-                .map_err(|err| {
-                    format!(
-                        "failed to delete agent_inbox_materializations rows for {run_id}: {err}"
-                    )
-                })?;
-                for table in [
-                    "agent_org_plan_approvals",
-                    "agent_org_recovery_attempts",
-                    "agent_org_task_events",
-                    "agent_org_tasks",
-                    "agent_inbox_delivery_resolutions",
-                    "agent_inbox",
-                    "agent_member_interventions",
-                    "agent_org_run_progress",
-                    "agent_org_task_run_schema_migrations",
-                ] {
-                    tx.execute(
-                        &format!("DELETE FROM {table} WHERE org_run_id=?1"),
-                        params![run_id],
-                    )
-                    .map_err(|err| format!("failed to delete {table} rows for {run_id}: {err}"))?;
-                }
-                let deleted = tx
-                    .execute("DELETE FROM agent_org_runs WHERE id=?1", params![run_id])
-                    .map_err(|err| err.to_string())?
-                    > 0;
-                tx.commit().map_err(|err| err.to_string())?;
-                Ok((plan_artifacts, deleted))
-            })?;
+            let rows = stmt
+                .query_map(params![run_id], |row| {
+                    Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+                })
+                .map_err(|err| err.to_string())?;
+            rows.collect::<Result<Vec<_>, _>>()
+                .map_err(|err| err.to_string())?
+        };
 
+        // Intent ownership is explicit. The hierarchy delete caller rejects
+        // nested run roots before reaching this helper; standalone run cleanup
+        // still deletes only rows owned by the requested run.
+        conn.execute(
+            "DELETE FROM session_turn_intents WHERE org_run_id=?1",
+            params![run_id],
+        )
+        .map_err(|err| err.to_string())?;
+        conn.execute(
+            "DELETE FROM agent_inbox_materializations
+             WHERE inbox_id IN (
+                 SELECT id FROM agent_inbox WHERE org_run_id=?1
+             )",
+            params![run_id],
+        )
+        .map_err(|err| {
+            format!("failed to delete agent_inbox_materializations rows for {run_id}: {err}")
+        })?;
+        for table in [
+            "agent_org_plan_approvals",
+            "agent_org_recovery_attempts",
+            "agent_org_task_events",
+            "agent_org_tasks",
+            "agent_inbox_delivery_resolutions",
+            "agent_inbox",
+            "agent_member_interventions",
+            "agent_org_run_progress",
+            "agent_org_task_run_schema_migrations",
+        ] {
+            conn.execute(
+                &format!("DELETE FROM {table} WHERE org_run_id=?1"),
+                params![run_id],
+            )
+            .map_err(|err| format!("failed to delete {table} rows for {run_id}: {err}"))?;
+        }
+        let deleted = conn
+            .execute("DELETE FROM agent_org_runs WHERE id=?1", params![run_id])
+            .map_err(|err| err.to_string())?
+            > 0;
+        Ok(AgentOrgRunDeleteOutcome {
+            plan_artifacts,
+            deleted,
+        })
+    }
+
+    pub(crate) fn finish_delete(run_id: &str, outcome: AgentOrgRunDeleteOutcome) {
         // SQLite is the source of truth. Files are derived artifacts, so they
         // are cleaned only after the transaction commits and failures are
         // logged without resurrecting already-deleted durable state.
-        for (source_session_id, plan_path) in plan_artifacts {
+        for (source_session_id, plan_path) in outcome.plan_artifacts {
             if let Err(err) = AgentOrgPlanApprovalStore::remove_managed_plan_artifact(
                 &source_session_id,
                 &plan_path,
@@ -722,10 +777,9 @@ impl AgentOrgRunStore {
                 );
             }
         }
-        if deleted {
+        if outcome.deleted {
             crate::coordination::agent_org_run_events::notify_agent_org_run_changed(run_id);
         }
-        Ok(())
     }
 
     /// Find the freshest materialized worker session for a canonical roster

--- a/src-tauri/crates/agent-core/src/core/session/persistence/crud/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/session/persistence/crud/mod.rs
@@ -31,6 +31,9 @@ pub use ops::{
     update_org_member_id, update_pinned, update_reply_target_event_id, update_status,
     update_work_item_link, upsert_session,
 };
+pub(crate) use ops::{
+    delete_session_with_connection, finish_session_delete, prepare_session_delete,
+};
 pub use record::{session_type, UnifiedSessionRecord};
 pub use workspace::{
     clear_worktree_metadata, load_workspace, save_workspace, save_worktree_metadata,

--- a/src-tauri/crates/agent-core/src/core/session/persistence/crud/ops.rs
+++ b/src-tauri/crates/agent-core/src/core/session/persistence/crud/ops.rs
@@ -13,6 +13,19 @@ use database::db::{get_connection, with_sessions_writer};
 use super::super::super::types::{SessionListFilter, SessionStatus};
 use super::record::{row_to_record, session_type, UnifiedSessionRecord, UNIFIED_SESSION_SELECT};
 
+const SESSION_DELETE_TABLES: &[&str] = &[
+    "agent_messages",
+    "agent_todos",
+    "agent_snapshots",
+    "agent_file_resolutions",
+    "session_token_usage",
+    "session_llm_usage_spans",
+    "session_tool_usage",
+    "events",
+    "pending_plan_approvals",
+    "agent_sessions",
+];
+
 /// Process-global mirror hook, registered once at app startup (see
 /// `lib.rs` setup). Fired after a successful write to any column the
 /// orgtrack canonical session store carries (name, status, model,
@@ -727,6 +740,47 @@ pub fn backfill_agent_definition_id(session_id: &str, definition_id: &str) -> Re
 /// run_deferred_cleanup` instead, which can delete DB rows without
 /// racing the runtime because the cache rehydrates from DB at startup.
 pub fn delete_session(session_id: &str) -> SqliteResult<()> {
+    prepare_session_delete(session_id)?;
+    shared::delete_session_cascade(session_id, SESSION_DELETE_TABLES)?;
+    notify_session_delete_mirror(session_id);
+
+    // Lineage tables can't ride the generic cascade: `commit_lineage` is keyed
+    // by `provenance_id` (FK into `node_provenance`), not `session_id`, so the
+    // generic `DELETE FROM commit_lineage WHERE session_id = ?1` fails at
+    // prepare time. Walk the join explicitly and drop both tables here.
+    if let Err(err) = project_management::lineage::delete_session_lineage(session_id) {
+        warn!(
+            "Failed to delete lineage rows for session {}: {}",
+            session_id, err
+        );
+    }
+
+    // Soft-unlink learnings produced by this session: keep the learning
+    // itself (it is a knowledge artefact, not session transient state) but
+    // null the back-pointer so it no longer dangles to a deleted session.
+    let unlink_result = with_sessions_writer(|| -> SqliteResult<()> {
+        let conn = get_connection()?;
+        conn.execute(
+            "UPDATE learnings SET source_session_id = NULL WHERE source_session_id = ?1",
+            [session_id],
+        )?;
+        Ok(())
+    });
+    if let Err(err) = unlink_result {
+        warn!(
+            "Failed to null learnings.source_session_id for deleted session {}: {}",
+            session_id, err
+        );
+    }
+
+    cleanup_session_derived_resources(session_id);
+    Ok(())
+}
+
+/// Validate and perform the existing pre-database resource cleanup for a
+/// session. Agent Org hierarchy deletion calls this for every Rust session
+/// before opening its shared SQLite transaction.
+pub(crate) fn prepare_session_delete(session_id: &str) -> SqliteResult<()> {
     if let Err(error) =
         crate::tools::impls::coding::exec::shell_replay::ensure_session_replays_deletable(
             session_id,
@@ -776,53 +830,42 @@ pub fn delete_session(session_id: &str) -> SqliteResult<()> {
             ));
         }
     }
+    Ok(())
+}
 
-    shared::delete_session_cascade(
-        session_id,
-        &[
-            "agent_messages",
-            "agent_todos",
-            "agent_snapshots",
-            "agent_file_resolutions",
-            "session_token_usage",
-            "session_llm_usage_spans",
-            "session_tool_usage",
-            "events",
-            "pending_plan_approvals",
-            "agent_sessions",
-        ],
+/// Delete the SQLite-owned data for one session through a caller-owned
+/// transaction. Unlike ordinary SDE deletion, hierarchy deletion treats
+/// lineage and learning unlink failures as transaction failures so no subset
+/// of the Agent Org tree can commit.
+pub(crate) fn delete_session_with_connection(
+    conn: &rusqlite::Connection,
+    session_id: &str,
+) -> SqliteResult<()> {
+    let exists = conn.query_row(
+        "SELECT EXISTS(SELECT 1 FROM agent_sessions WHERE session_id=?1)",
+        [session_id],
+        |row| row.get::<_, bool>(0),
     )?;
+    if !exists {
+        return Err(rusqlite::Error::QueryReturnedNoRows);
+    }
+    shared::delete_session_cascade_with_connection(conn, session_id, SESSION_DELETE_TABLES)?;
+    project_management::lineage::delete_session_lineage_with_connection(conn, session_id)?;
+    conn.execute(
+        "UPDATE learnings SET source_session_id = NULL WHERE source_session_id = ?1",
+        [session_id],
+    )?;
+    Ok(())
+}
+
+/// Run post-commit mirrors and derived filesystem cleanup for one deleted
+/// session.
+pub(crate) fn finish_session_delete(session_id: &str) {
     notify_session_delete_mirror(session_id);
+    cleanup_session_derived_resources(session_id);
+}
 
-    // Lineage tables can't ride the generic cascade: `commit_lineage` is keyed
-    // by `provenance_id` (FK into `node_provenance`), not `session_id`, so the
-    // generic `DELETE FROM commit_lineage WHERE session_id = ?1` fails at
-    // prepare time. Walk the join explicitly and drop both tables here.
-    if let Err(err) = project_management::lineage::delete_session_lineage(session_id) {
-        warn!(
-            "Failed to delete lineage rows for session {}: {}",
-            session_id, err
-        );
-    }
-
-    // Soft-unlink learnings produced by this session: keep the learning
-    // itself (it is a knowledge artefact, not session transient state) but
-    // null the back-pointer so it no longer dangles to a deleted session.
-    let unlink_result = with_sessions_writer(|| -> SqliteResult<()> {
-        let conn = get_connection()?;
-        conn.execute(
-            "UPDATE learnings SET source_session_id = NULL WHERE source_session_id = ?1",
-            [session_id],
-        )?;
-        Ok(())
-    });
-    if let Err(err) = unlink_result {
-        warn!(
-            "Failed to null learnings.source_session_id for deleted session {}: {}",
-            session_id, err
-        );
-    }
-
+fn cleanup_session_derived_resources(session_id: &str) {
     // Per-session file-history is addressed by session_id alone, so drop the
     // whole directory regardless of workspace_path. Other sessions on the same
     // project are untouched.
@@ -843,7 +886,6 @@ pub fn delete_session(session_id: &str) -> SqliteResult<()> {
             session_id, err
         );
     }
-    Ok(())
 }
 
 /// Get all child sessions for a given parent session.

--- a/src-tauri/crates/agent-core/src/core/session/persistence/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/session/persistence/mod.rs
@@ -32,6 +32,9 @@ pub use crud::{
     update_reply_target_event_id, update_status, update_work_item_link,
     update_worktree_merge_status, upsert_session, UnifiedSessionRecord,
 };
+pub(crate) use crud::{
+    delete_session_with_connection, finish_session_delete, prepare_session_delete,
+};
 
 pub use messages::{
     anchor_at_or_after_created_at, append_compact_boundary, clear_messages,

--- a/src-tauri/crates/agent-core/src/foundation/bus/event_pipeline_bridge.rs
+++ b/src-tauri/crates/agent-core/src/foundation/bus/event_pipeline_bridge.rs
@@ -102,6 +102,9 @@ pub type PinSessionFn = fn(handle: &AppHandle, session_id: &str);
 /// the in-memory map.
 pub type UnpinSessionFn = fn(handle: &AppHandle, session_id: &str);
 
+/// Immediately remove a deleted session from the EventStore LRU and store map.
+pub type EvictSessionFn = fn(handle: &AppHandle, session_id: &str);
+
 /// Snapshot the in-memory event list for `session_id`. Returns an empty
 /// vector when the session has no live store.
 pub type ReadSessionEventsFn = fn(handle: &AppHandle, session_id: &str) -> Vec<SessionEvent>;
@@ -171,6 +174,7 @@ static REPLACE_STREAMING_EVENT: OnceLock<ReplaceStreamingEventFn> = OnceLock::ne
 static REMOVE_EVENTS_BY_IDS: OnceLock<RemoveEventsByIdsFn> = OnceLock::new();
 static PIN_SESSION: OnceLock<PinSessionFn> = OnceLock::new();
 static UNPIN_SESSION: OnceLock<UnpinSessionFn> = OnceLock::new();
+static EVICT_SESSION: OnceLock<EvictSessionFn> = OnceLock::new();
 static READ_SESSION_EVENTS: OnceLock<ReadSessionEventsFn> = OnceLock::new();
 static FINALIZE_PLAN_REVISION_EVENTS: OnceLock<FinalizePlanRevisionEventsFn> = OnceLock::new();
 static PERSIST_EVENTS: OnceLock<PersistEventsFn> = OnceLock::new();
@@ -198,6 +202,7 @@ pub fn register(
     remove_events_by_ids: RemoveEventsByIdsFn,
     pin_session: PinSessionFn,
     unpin_session: UnpinSessionFn,
+    evict_session: EvictSessionFn,
     read_session_events: ReadSessionEventsFn,
     finalize_plan_revision_events: FinalizePlanRevisionEventsFn,
     persist_events: PersistEventsFn,
@@ -216,6 +221,7 @@ pub fn register(
     let _ = REMOVE_EVENTS_BY_IDS.set(remove_events_by_ids);
     let _ = PIN_SESSION.set(pin_session);
     let _ = UNPIN_SESSION.set(unpin_session);
+    let _ = EVICT_SESSION.set(evict_session);
     let _ = READ_SESSION_EVENTS.set(read_session_events);
     let _ = FINALIZE_PLAN_REVISION_EVENTS.set(finalize_plan_revision_events);
     let _ = PERSIST_EVENTS.set(persist_events);
@@ -250,6 +256,17 @@ pub fn schedule_notify(handle: &AppHandle, session_id: &str) {
     } else {
         tracing::warn!(
             "[event-pipeline-bridge] schedule_notify called before register for {}",
+            session_id
+        );
+    }
+}
+
+pub fn evict_session(handle: &AppHandle, session_id: &str) {
+    if let Some(f) = EVICT_SESSION.get() {
+        f(handle, session_id);
+    } else {
+        tracing::warn!(
+            "[event-pipeline-bridge] evict_session called before register for {}",
             session_id
         );
     }

--- a/src-tauri/crates/agent-core/src/foundation/persistence/db_helpers/mod.rs
+++ b/src-tauri/crates/agent-core/src/foundation/persistence/db_helpers/mod.rs
@@ -96,6 +96,14 @@ mod tests {
 /// Collect all image file paths referenced by messages in a session.
 fn collect_session_image_paths(prefix: &str, session_id: &str) -> SqliteResult<Vec<String>> {
     let conn = get_connection()?;
+    collect_session_image_paths_with_connection(&conn, prefix, session_id)
+}
+
+fn collect_session_image_paths_with_connection(
+    conn: &rusqlite::Connection,
+    prefix: &str,
+    session_id: &str,
+) -> SqliteResult<Vec<String>> {
     let sql = format!(
         "SELECT images FROM {prefix}_messages WHERE session_id = ?1 AND images IS NOT NULL"
     );
@@ -138,33 +146,71 @@ pub fn delete_session_cascade(session_id: &str, tables: &[&str]) -> SqliteResult
     with_sessions_writer(|| {
         let mut conn = get_connection()?;
         let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
-        if tables.contains(&"agent_messages") {
-            let receipts_exist: bool = tx.query_row(
-                "SELECT EXISTS(
-                     SELECT 1 FROM sqlite_master
-                     WHERE type='table' AND name='agent_inbox_materializations'
-                 )",
-                [],
-                |row| row.get(0),
-            )?;
-            if receipts_exist {
-                // Keep the source Inbox rows unread while atomically removing
-                // receipts for transcript rows deleted by this cascade.
-                tx.execute(
-                    "DELETE FROM agent_inbox_materializations WHERE session_id=?1",
-                    [session_id],
-                )?;
-            }
-        }
-        for table in tables {
-            tx.execute(
-                &format!("DELETE FROM {table} WHERE session_id = ?1"),
-                [session_id],
-            )?;
-        }
+        delete_session_rows_with_connection(&tx, session_id, tables)?;
         tx.commit()?;
         Ok(())
     })
+}
+
+/// Transaction-aware form of [`delete_session_cascade`].
+///
+/// The caller owns the transaction boundary. This is used when several Rust
+/// Agent Org sessions and their run-owned rows must commit or roll back as one
+/// hierarchy. Ordinary single-session deletion continues to use
+/// [`delete_session_cascade`] and therefore keeps its existing transaction
+/// behavior.
+pub(crate) fn delete_session_cascade_with_connection(
+    conn: &rusqlite::Connection,
+    session_id: &str,
+    tables: &[&str],
+) -> SqliteResult<()> {
+    // Collect image file paths before deleting the rows. Infer the
+    // prefix from the first table that ends with "_messages".
+    let prefix = tables
+        .iter()
+        .find(|t| t.ends_with("_messages"))
+        .and_then(|t| t.strip_suffix("_messages"));
+
+    if let Some(prefix) = prefix {
+        let image_paths = collect_session_image_paths_with_connection(conn, prefix, session_id)?;
+        if !image_paths.is_empty() {
+            super::images::delete_image_files(&image_paths);
+        }
+    }
+
+    delete_session_rows_with_connection(conn, session_id, tables)
+}
+
+fn delete_session_rows_with_connection(
+    conn: &rusqlite::Connection,
+    session_id: &str,
+    tables: &[&str],
+) -> SqliteResult<()> {
+    if tables.contains(&"agent_messages") {
+        let receipts_exist: bool = conn.query_row(
+            "SELECT EXISTS(
+                 SELECT 1 FROM sqlite_master
+                 WHERE type='table' AND name='agent_inbox_materializations'
+             )",
+            [],
+            |row| row.get(0),
+        )?;
+        if receipts_exist {
+            // Keep the source Inbox rows unread while atomically removing
+            // receipts for transcript rows deleted by this cascade.
+            conn.execute(
+                "DELETE FROM agent_inbox_materializations WHERE session_id=?1",
+                [session_id],
+            )?;
+        }
+    }
+    for table in tables {
+        conn.execute(
+            &format!("DELETE FROM {table} WHERE session_id = ?1"),
+            [session_id],
+        )?;
+    }
+    Ok(())
 }
 
 // ============================================

--- a/src-tauri/crates/agent-core/src/state/commands/session/message/org_wake.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/session/message/org_wake.rs
@@ -93,6 +93,43 @@ pub(super) fn promote_agent_org_wake_session_to_running(
     .map_err(|error| error.to_string())
 }
 
+/// Promote a direct Rust Agent Org turn unless deletion has established the
+/// run's terminal `cancelled` fence. Direct user turns intentionally retain
+/// their existing behavior for completed/failed historical runs; this guard
+/// only closes the race where a message was queued while hierarchy deletion
+/// was stopping the run.
+pub(super) fn promote_agent_org_direct_session_to_running(
+    conn: &rusqlite::Connection,
+    run_id: &str,
+    session_id: &str,
+) -> Result<usize, String> {
+    use rusqlite::OptionalExtension;
+
+    let run_status = conn
+        .query_row(
+            "SELECT status FROM agent_org_runs WHERE id=?1",
+            [run_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(|error| error.to_string())?;
+    if run_status.as_deref() == Some("cancelled") || run_status.is_none() {
+        return Ok(0);
+    }
+
+    conn.execute(
+        "UPDATE agent_sessions
+         SET status=?1, updated_at=?2
+         WHERE session_id=?3",
+        rusqlite::params![
+            crate::session::SessionStatus::Running.as_str(),
+            chrono::Utc::now().to_rfc3339(),
+            session_id,
+        ],
+    )
+    .map_err(|error| error.to_string())
+}
+
 /// Resolve the execution mode for one background Agent Org wake from unread
 /// control envelopes in durable inbox order.
 ///

--- a/src-tauri/crates/agent-core/src/state/commands/session/message/send.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/session/message/send.rs
@@ -22,7 +22,10 @@ use crate::state::commands::session::org_tasks;
 use crate::state::AgentAppState;
 
 use super::exec_mode::{resolve_agent_mode, restore_mode_before_plan_entry};
-use super::org_wake::{promote_agent_org_wake_session_to_running, resolve_agent_org_wake_mode};
+use super::org_wake::{
+    promote_agent_org_direct_session_to_running, promote_agent_org_wake_session_to_running,
+    resolve_agent_org_wake_mode,
+};
 
 pub(super) fn should_divert_to_mid_turn_steering(
     source: TurnIntentBridgeSource,
@@ -330,6 +333,7 @@ pub(crate) async fn send_message_impl(
     let display_text_for_closure = display_text;
     let workspace_root_for_closure = effective_workspace_root.clone();
     let turn_intent_id_for_closure = effective_turn_intent_id.clone();
+    let intent_org_run_id_for_closure = effective_intent_org_run_id.clone();
     // Resolve durable mode-control rows from exactly the bounded inbox batch
     // this background wake will drain. A control row in a later batch must
     // not change the mode of earlier work; rows become one-shot only when the
@@ -382,22 +386,38 @@ pub(crate) async fn send_message_impl(
         let session = session_for_closure;
         let turn_intent_id = turn_intent_id_for_closure;
         let org_wake_run_id = org_wake_run_id;
+        let intent_org_run_id = intent_org_run_id_for_closure;
 
         Box::pin(async move {
+            // Clear a stale pre-turn cancel signal before the durable
+            // Agent Org gate. This must happen before that gate: deletion may
+            // establish its cancelled fence immediately after the DB claim
+            // and then set the cancel flag while `active_turn` is not yet
+            // registered. Clearing later would erase that deletion signal.
+            //
+            // Messages that reach this closure have already passed the
+            // scheduler generation check, so queued work invalidated by Stop
+            // or hierarchy deletion is discarded before this callback runs.
+            cancel_flag.store(false, std::sync::atomic::Ordering::SeqCst);
+
             // Queued and coalesced messages are not running sessions. Promote
             // the DB state only when the scheduler actually begins execution.
-            // For Agent Org wakes, re-check the run and update the session in
-            // the same writer transaction used by run finality.
+            // Agent Org wakes require a running run. Direct Agent Org turns
+            // retain their historical-run behavior but refuse the terminal
+            // `cancelled` fence established by hierarchy deletion.
             let status_sid = sid.clone();
-            let status_run_id = org_wake_run_id.clone();
+            let status_wake_run_id = org_wake_run_id.clone();
+            let status_intent_run_id = intent_org_run_id.clone();
             match tokio::task::spawn_blocking(move || {
                 database::db::with_sessions_writer(|| -> Result<bool, String> {
                     let mut conn = database::db::get_connection().map_err(|err| err.to_string())?;
                     let tx = conn
                         .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
                         .map_err(|err| err.to_string())?;
-                    let updated = if let Some(run_id) = status_run_id.as_deref() {
+                    let updated = if let Some(run_id) = status_wake_run_id.as_deref() {
                         promote_agent_org_wake_session_to_running(&tx, run_id, &status_sid)?
+                    } else if let Some(run_id) = status_intent_run_id.as_deref() {
+                        promote_agent_org_direct_session_to_running(&tx, run_id, &status_sid)?
                     } else {
                         tx.execute(
                             "UPDATE agent_sessions SET status=?1, updated_at=?2 WHERE session_id=?3",
@@ -410,7 +430,7 @@ pub(crate) async fn send_message_impl(
                         .map_err(|err| err.to_string())?
                     };
                     if updated != 1 {
-                        if status_run_id.is_some() {
+                        if status_wake_run_id.is_some() || status_intent_run_id.is_some() {
                             tx.commit().map_err(|err| err.to_string())?;
                             return Ok(false);
                         }
@@ -427,18 +447,6 @@ pub(crate) async fn send_message_impl(
                 Ok(Err(err)) => return Err(format!("failed to persist running status: {err}")),
                 Err(err) => return Err(format!("running-status task failed: {err}")),
             }
-
-            // Clear any stale pre-turn cancel signal before starting a fresh
-            // turn. A UserStop that lands while the session is idle (e.g. only
-            // a background subagent is still running, the parent turn already
-            // finished) takes the `keep_pre_turn_cancel_when_idle` branch in
-            // `cancel_active_turn` and leaves `cancel_flag = true`. Without
-            // this reset the *next* user message inherits that flag and the
-            // turn loop self-cancels on iteration 1 (0 tokens, no response).
-            // Messages that reach this closure have already passed the
-            // scheduler's generation check, so a still-queued Send-Now that
-            // Stop meant to discard was dropped as stale before getting here.
-            cancel_flag.store(false, std::sync::atomic::Ordering::SeqCst);
 
             let turn_id = session.begin_turn(content.clone()).await;
 

--- a/src-tauri/crates/agent-core/src/state/commands/session/message/tests.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/session/message/tests.rs
@@ -6,7 +6,10 @@
 //! exercised together here rather than split across their two modules.
 
 use super::exec_mode::{resolve_agent_mode, restore_mode_before_plan_entry};
-use super::org_wake::{promote_agent_org_wake_session_to_running, resolve_agent_org_wake_mode};
+use super::org_wake::{
+    promote_agent_org_direct_session_to_running, promote_agent_org_wake_session_to_running,
+    resolve_agent_org_wake_mode,
+};
 use super::send::should_divert_to_mid_turn_steering;
 use crate::coordination::agent_inbox::{
     AgentInboxStore, AgentMessage, InsertInboxParams, RequestId,
@@ -268,6 +271,31 @@ fn queued_agent_org_wake_rechecks_run_member_and_intervention_at_turn_start() {
             .expect("intervened wake is a no-op"),
         0
     );
+}
+
+#[test]
+fn direct_agent_org_turn_refuses_cancelled_delete_fence() {
+    let fixture = setup_wake_mode_fixture("build", TaskStatus::Pending);
+    let conn = database::db::get_connection().expect("test db");
+    conn.execute(
+        "UPDATE agent_org_runs SET status='cancelled' WHERE id=?1",
+        [&fixture.run_id],
+    )
+    .expect("establish delete fence");
+
+    assert_eq!(
+        promote_agent_org_direct_session_to_running(&conn, &fixture.run_id, &fixture.session_id)
+            .expect("cancelled run claim is a no-op"),
+        0
+    );
+    let status = conn
+        .query_row(
+            "SELECT status FROM agent_sessions WHERE session_id=?1",
+            [&fixture.session_id],
+            |row| row.get::<_, String>(0),
+        )
+        .expect("load member status");
+    assert_eq!(status, "idle");
 }
 
 #[test]

--- a/src-tauri/crates/agent-core/src/state/commands/session/persistence.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/session/persistence.rs
@@ -1,4 +1,8 @@
-//! Persistence commands for session data (no Tauri state needed).
+//! Persistence commands for session data.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
 
 use crate::coordination::agent_org_runs::AgentOrgRunStore;
 use crate::interaction::plan_approval::persistence::PlanApprovalStore;
@@ -7,11 +11,12 @@ use crate::persistence::session_snapshots;
 use crate::session::persistence as session_persistence;
 use crate::session::{SessionListFilter, SessionStatus};
 use crate::state::control_flow::CancelReason;
-use crate::state::AgentAppState;
+use crate::state::{AgentAppState, AgentSession};
 use crate::tools::file_history;
 use core_types::workflow::{AgentRole, LinkedSession, LinkedSessionStatus, LinkedSessionType};
-use database::db::get_connection;
-use rusqlite::OptionalExtension;
+use database::db::{get_connection, with_sessions_writer};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::Serialize;
 
 use super::common::review_session_ids;
 
@@ -47,35 +52,628 @@ pub async fn agent_list_all_sessions() -> Result<Vec<serde_json::Value>, String>
     .await
 }
 
+const MAX_AGENT_ORG_DELETE_SESSIONS: usize = 1_024;
+const AGENT_ORG_DELETE_STOP_TIMEOUT: Duration = Duration::from_secs(10);
+const AGENT_ORG_DELETE_STOP_POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeleteSessionReceipt {
+    pub deleted_session_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AgentOrgSessionDeleteNode {
+    session_id: String,
+    parent_session_id: Option<String>,
+    status: SessionStatus,
+    depth: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AgentOrgSessionDeletePlan {
+    run_id: String,
+    root_session_id: String,
+    run_status: crate::coordination::agent_org_runs::AgentOrgRunStatus,
+    sessions: Vec<AgentOrgSessionDeleteNode>,
+}
+
 /// Delete a session and all related data.
 #[tauri::command]
-pub async fn agent_delete_session(session_id: String) -> Result<(), String> {
-    tokio::task::spawn_blocking(move || delete_session_with_agent_org_history(&session_id))
+pub async fn agent_delete_session(
+    state: tauri::State<'_, AgentAppState>,
+    session_id: String,
+) -> Result<DeleteSessionReceipt, String> {
+    let planned_session_id = session_id.clone();
+    let plan = tokio::task::spawn_blocking(move || {
+        let conn = get_connection().map_err(|err| err.to_string())?;
+        load_agent_org_session_delete_plan(&conn, &planned_session_id)
+    })
+    .await
+    .map_err(|err| format!("session deletion planning worker failed: {err}"))??;
+
+    let Some(plan) = plan else {
+        let deleted_session_id = session_id.clone();
+        tokio::task::spawn_blocking(move || {
+            session_persistence::delete_session(&deleted_session_id).map_err(|err| err.to_string())
+        })
         .await
-        .map_err(|err| format!("session deletion worker failed: {err}"))?
-}
+        .map_err(|err| format!("session deletion worker failed: {err}"))??;
+        return Ok(DeleteSessionReceipt {
+            deleted_session_ids: vec![session_id],
+        });
+    };
 
-fn delete_session_with_agent_org_history(session_id: &str) -> Result<(), String> {
-    // Only the coordinator/root session owns a Run. Deleting a worker session
-    // must not erase the rest of the team execution. Capture and remove the
-    // owned Run first so a subsequent session-row failure remains retryable
-    // and can never silently leave permanent Inbox/Plan history behind.
-    if let Some(run_id) = owned_agent_org_run_id(session_id)? {
-        AgentOrgRunStore::delete_by_id(&run_id)?;
+    let (plan, quiesced_runtime_session_ids) = if matches!(
+        plan.run_status,
+        crate::coordination::agent_org_runs::AgentOrgRunStatus::Running
+            | crate::coordination::agent_org_runs::AgentOrgRunStatus::Paused
+            | crate::coordination::agent_org_runs::AgentOrgRunStatus::Cancelled
+    ) {
+        let fenced_plan =
+            tokio::task::spawn_blocking(move || establish_agent_org_delete_fence(&plan))
+                .await
+                .map_err(|err| format!("Agent Org deletion fence worker failed: {err}"))??;
+        let quiesced_runtime_session_ids = if fenced_plan.run_status
+            == crate::coordination::agent_org_runs::AgentOrgRunStatus::Cancelled
+        {
+            stop_agent_org_runtime_sessions(&state, &fenced_plan).await?
+        } else {
+            ensure_agent_org_runtime_sessions_idle(&state, &fenced_plan).await?;
+            HashSet::new()
+        };
+        let root_session_id = fenced_plan.root_session_id.clone();
+        let current_plan = tokio::task::spawn_blocking(move || {
+            let conn = get_connection().map_err(|err| err.to_string())?;
+            load_agent_org_session_delete_plan(&conn, &root_session_id)?.ok_or_else(|| {
+                format!(
+                    "Refusing to delete Agent Org root {root_session_id}: ownership disappeared while stopping"
+                )
+            })
+        })
+        .await
+        .map_err(|err| format!("Agent Org post-stop planning worker failed: {err}"))??;
+        if !agent_org_delete_topology_matches(&fenced_plan, &current_plan) {
+            return Err(format!(
+                "Refusing to delete Agent Org run {}: session hierarchy changed while stopping",
+                fenced_plan.run_id
+            ));
+        }
+        (current_plan, quiesced_runtime_session_ids)
+    } else {
+        ensure_agent_org_runtime_sessions_idle(&state, &plan).await?;
+        (plan, HashSet::new())
+    };
+
+    validate_agent_org_delete_ready(&plan, &quiesced_runtime_session_ids)?;
+    ensure_agent_org_runtime_sessions_idle(&state, &plan).await?;
+
+    let receipt = tokio::task::spawn_blocking(move || {
+        delete_agent_org_session_hierarchy(&plan, &quiesced_runtime_session_ids)
+    })
+    .await
+    .map_err(|err| format!("Agent Org session deletion worker failed: {err}"))??;
+
+    state.remove_sessions(&receipt.deleted_session_ids).await;
+    if let Some(app_handle) = state.app_handle.as_ref() {
+        for deleted_session_id in &receipt.deleted_session_ids {
+            crate::bus::event_pipeline_bridge::evict_session(app_handle, deleted_session_id);
+        }
     }
-    session_persistence::delete_session(session_id).map_err(|err| err.to_string())
+    Ok(receipt)
 }
 
-fn owned_agent_org_run_id(session_id: &str) -> Result<Option<String>, String> {
-    get_connection()
-        .map_err(|err| err.to_string())?
-        .query_row(
-            "SELECT id FROM agent_org_runs WHERE root_session_id=?1 LIMIT 1",
-            [session_id],
-            |row| row.get(0),
+fn load_agent_org_session_delete_plan(
+    conn: &Connection,
+    root_session_id: &str,
+) -> Result<Option<AgentOrgSessionDeletePlan>, String> {
+    let run_rows = {
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, status
+                 FROM agent_org_runs
+                 WHERE root_session_id=?1
+                 ORDER BY id",
+            )
+            .map_err(|err| err.to_string())?;
+        let rows = stmt
+            .query_map([root_session_id], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .map_err(|err| err.to_string())?;
+        rows.collect::<Result<Vec<_>, _>>()
+            .map_err(|err| err.to_string())?
+    };
+
+    let Some((run_id, run_status_raw)) = run_rows.first() else {
+        return Ok(None);
+    };
+    if run_rows.len() != 1 {
+        return Err(format!(
+            "Refusing to delete Agent Org root {root_session_id}: {} runs claim the same root",
+            run_rows.len()
+        ));
+    }
+    let run_status = crate::coordination::agent_org_runs::AgentOrgRunStatus::parse(run_status_raw)
+        .ok_or_else(|| {
+            format!(
+                "Refusing to delete Agent Org run {run_id}: unknown run status {run_status_raw:?}"
+            )
+        })?;
+
+    let mut stmt = conn
+        .prepare(
+            "WITH RECURSIVE descendants(
+                 session_id, parent_session_id, status, depth, path, cycle
+             ) AS (
+                 SELECT session_id,
+                        parent_session_id,
+                        status,
+                        0,
+                        '/' || hex(session_id) || '/',
+                        0
+                 FROM agent_sessions
+                 WHERE session_id=?1
+                 UNION ALL
+                 SELECT child.session_id,
+                        child.parent_session_id,
+                        child.status,
+                        parent.depth + 1,
+                        parent.path || hex(child.session_id) || '/',
+                        instr(parent.path, '/' || hex(child.session_id) || '/') > 0
+                 FROM agent_sessions child
+                 JOIN descendants parent
+                   ON child.parent_session_id=parent.session_id
+                 WHERE parent.cycle=0
+                   AND parent.depth < ?3
+             )
+             SELECT descendant.session_id,
+                    descendant.parent_session_id,
+                    descendant.status,
+                    descendant.depth,
+                    descendant.cycle,
+                    (
+                        SELECT nested.id
+                        FROM agent_org_runs nested
+                        WHERE nested.id<>?2
+                          AND nested.root_session_id=descendant.session_id
+                        ORDER BY nested.id
+                        LIMIT 1
+                    ) AS nested_run_id,
+                    EXISTS(
+                        SELECT 1
+                        FROM agent_sessions child
+                        WHERE child.parent_session_id=descendant.session_id
+                    ) AS has_children
+             FROM descendants descendant",
         )
-        .optional()
-        .map_err(|err| err.to_string())
+        .map_err(|err| err.to_string())?;
+    let rows = stmt
+        .query_map(
+            params![
+                root_session_id,
+                run_id,
+                MAX_AGENT_ORG_DELETE_SESSIONS as i64
+            ],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, i64>(3)?,
+                    row.get::<_, bool>(4)?,
+                    row.get::<_, Option<String>>(5)?,
+                    row.get::<_, bool>(6)?,
+                ))
+            },
+        )
+        .map_err(|err| err.to_string())?;
+
+    let mut sessions = Vec::new();
+    let mut visited = std::collections::HashSet::new();
+    for row in rows {
+        let (session_id, parent_session_id, status_raw, depth, cycle, nested_run_id, has_children) =
+            row.map_err(|err| err.to_string())?;
+        if cycle {
+            return Err(format!(
+                "Refusing to delete Agent Org run {run_id}: session ancestry contains a cycle at {session_id}"
+            ));
+        }
+        if !visited.insert(session_id.clone()) {
+            return Err(format!(
+                "Refusing to delete Agent Org run {run_id}: session hierarchy visits {session_id} more than once"
+            ));
+        }
+        if depth < 0 {
+            return Err(format!(
+                "Refusing to delete Agent Org run {run_id}: invalid depth for {session_id}"
+            ));
+        }
+        let depth = usize::try_from(depth).map_err(|err| err.to_string())?;
+        if depth >= MAX_AGENT_ORG_DELETE_SESSIONS && has_children {
+            return Err(format!(
+                "Refusing to delete Agent Org run {run_id}: session hierarchy exceeds {MAX_AGENT_ORG_DELETE_SESSIONS} nodes"
+            ));
+        }
+        if depth > 0 {
+            if let Some(nested_run_id) = nested_run_id {
+                return Err(format!(
+                    "Refusing to delete Agent Org run {run_id}: descendant session {session_id} is root of unsupported nested run {nested_run_id}"
+                ));
+            }
+        }
+        let status = SessionStatus::parse(&status_raw).ok_or_else(|| {
+            format!(
+                "Refusing to delete Agent Org run {run_id}: session {session_id} has unknown status {status_raw:?}"
+            )
+        })?;
+        sessions.push(AgentOrgSessionDeleteNode {
+            session_id,
+            parent_session_id,
+            status,
+            depth,
+        });
+        if sessions.len() > MAX_AGENT_ORG_DELETE_SESSIONS {
+            return Err(format!(
+                "Refusing to delete Agent Org run {run_id}: session hierarchy exceeds {MAX_AGENT_ORG_DELETE_SESSIONS} nodes"
+            ));
+        }
+    }
+    if sessions.is_empty()
+        || sessions
+            .iter()
+            .all(|node| node.session_id != root_session_id)
+    {
+        return Err(format!(
+            "Refusing to delete Agent Org run {run_id}: root session {root_session_id} is missing"
+        ));
+    }
+    let depths = sessions
+        .iter()
+        .map(|node| (node.session_id.as_str(), node.depth))
+        .collect::<std::collections::HashMap<_, _>>();
+    for node in &sessions {
+        if node.depth == 0 {
+            if node.session_id != root_session_id {
+                return Err(format!(
+                    "Refusing to delete Agent Org run {run_id}: unexpected depth-zero session {}",
+                    node.session_id
+                ));
+            }
+            continue;
+        }
+        let parent_session_id = node.parent_session_id.as_deref().ok_or_else(|| {
+            format!(
+                "Refusing to delete Agent Org run {run_id}: descendant session {} has no parent",
+                node.session_id
+            )
+        })?;
+        let parent_depth = depths.get(parent_session_id).ok_or_else(|| {
+            format!(
+                "Refusing to delete Agent Org run {run_id}: descendant session {} references missing parent {parent_session_id}",
+                node.session_id
+            )
+        })?;
+        if parent_depth.saturating_add(1) != node.depth {
+            return Err(format!(
+                "Refusing to delete Agent Org run {run_id}: descendant session {} has inconsistent depth",
+                node.session_id
+            ));
+        }
+    }
+
+    sessions.sort_by(|left, right| {
+        right
+            .depth
+            .cmp(&left.depth)
+            .then_with(|| left.session_id.cmp(&right.session_id))
+    });
+    Ok(Some(AgentOrgSessionDeletePlan {
+        run_id: run_id.clone(),
+        root_session_id: root_session_id.to_string(),
+        run_status,
+        sessions,
+    }))
+}
+
+fn agent_org_delete_topology_matches(
+    expected: &AgentOrgSessionDeletePlan,
+    current: &AgentOrgSessionDeletePlan,
+) -> bool {
+    expected.run_id == current.run_id
+        && expected.root_session_id == current.root_session_id
+        && expected.sessions.len() == current.sessions.len()
+        && expected
+            .sessions
+            .iter()
+            .zip(&current.sessions)
+            .all(|(left, right)| {
+                left.session_id == right.session_id
+                    && left.parent_session_id == right.parent_session_id
+                    && left.depth == right.depth
+            })
+}
+
+fn establish_agent_org_delete_fence(
+    expected_plan: &AgentOrgSessionDeletePlan,
+) -> Result<AgentOrgSessionDeletePlan, String> {
+    let (current_plan, changed) = with_sessions_writer(|| {
+        let mut conn = get_connection().map_err(|err| err.to_string())?;
+        let tx = conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .map_err(|err| err.to_string())?;
+        let mut current_plan =
+            load_agent_org_session_delete_plan(&tx, &expected_plan.root_session_id)?.ok_or_else(
+                || {
+                    format!(
+                "Refusing to delete Agent Org run {}: root ownership changed before stopping",
+                expected_plan.run_id
+            )
+                },
+            )?;
+        if !agent_org_delete_topology_matches(expected_plan, &current_plan) {
+            return Err(format!(
+                "Refusing to delete Agent Org run {}: session hierarchy changed before stopping",
+                expected_plan.run_id
+            ));
+        }
+
+        let changed = match current_plan.run_status {
+            crate::coordination::agent_org_runs::AgentOrgRunStatus::Running
+            | crate::coordination::agent_org_runs::AgentOrgRunStatus::Paused => {
+                let changed =
+                    AgentOrgRunStore::cancel_for_delete_with_connection(&tx, &current_plan.run_id)?;
+                if !changed {
+                    return Err(format!(
+                        "Refusing to delete Agent Org run {}: run status changed before cancellation",
+                        current_plan.run_id
+                    ));
+                }
+                current_plan.run_status =
+                    crate::coordination::agent_org_runs::AgentOrgRunStatus::Cancelled;
+                true
+            }
+            crate::coordination::agent_org_runs::AgentOrgRunStatus::Cancelled => false,
+            status if status.is_terminal() => false,
+            status => {
+                return Err(format!(
+                    "Refusing to delete Agent Org run {}: unsupported run status {}",
+                    current_plan.run_id,
+                    status.as_str()
+                ));
+            }
+        };
+        tx.commit().map_err(|err| err.to_string())?;
+        Ok::<_, String>((current_plan, changed))
+    })?;
+    if changed {
+        crate::coordination::agent_org_run_events::notify_agent_org_run_changed(
+            &current_plan.run_id,
+        );
+    }
+    Ok(current_plan)
+}
+
+fn validate_agent_org_delete_ready(
+    plan: &AgentOrgSessionDeletePlan,
+    quiesced_runtime_session_ids: &HashSet<String>,
+) -> Result<(), String> {
+    if !plan.run_status.is_terminal() {
+        return Err(format!(
+            "Refusing to delete Agent Org run {}: run status is {}",
+            plan.run_id,
+            plan.run_status.as_str()
+        ));
+    }
+
+    for node in &plan.sessions {
+        let allowed = node.status == SessionStatus::Idle
+            || node.status.is_terminal()
+            || (plan.run_status
+                == crate::coordination::agent_org_runs::AgentOrgRunStatus::Cancelled
+                && (matches!(node.status, SessionStatus::Pending | SessionStatus::Paused)
+                    || (node.status.is_in_flight()
+                        && quiesced_runtime_session_ids.contains(&node.session_id))));
+        if !allowed {
+            return Err(format!(
+                "Refusing to delete Agent Org run {}: session {} status is {}",
+                plan.run_id,
+                node.session_id,
+                node.status.as_str()
+            ));
+        }
+    }
+    Ok(())
+}
+
+async fn agent_org_runtime_sessions(
+    state: &AgentAppState,
+    plan: &AgentOrgSessionDeletePlan,
+) -> Vec<(String, Arc<AgentSession>)> {
+    let sessions = state.sessions.lock().await;
+    plan.sessions
+        .iter()
+        .filter_map(|node| {
+            sessions
+                .get(&node.session_id)
+                .cloned()
+                .map(|session| (node.session_id.clone(), session))
+        })
+        .collect()
+}
+
+async fn agent_org_runtime_blockers(
+    runtime_sessions: &[(String, Arc<AgentSession>)],
+) -> Vec<String> {
+    let mut blockers = Vec::new();
+    for (session_id, session) in runtime_sessions {
+        let scheduler_processing = session.scheduler.is_processing();
+        let pending_count = session.scheduler.pending_count();
+        let active_turn = session.active_turn.lock().await.is_some();
+        if active_turn || scheduler_processing || pending_count > 0 {
+            blockers.push(format!(
+                "{session_id}(active_turn={active_turn},scheduler_processing={scheduler_processing},pending={pending_count})"
+            ));
+        }
+    }
+    blockers
+}
+
+async fn stop_agent_org_runtime_sessions(
+    state: &AgentAppState,
+    plan: &AgentOrgSessionDeletePlan,
+) -> Result<HashSet<String>, String> {
+    stop_agent_org_runtime_sessions_with_timeout(state, plan, AGENT_ORG_DELETE_STOP_TIMEOUT).await
+}
+
+async fn stop_agent_org_runtime_sessions_with_timeout(
+    state: &AgentAppState,
+    plan: &AgentOrgSessionDeletePlan,
+    timeout: Duration,
+) -> Result<HashSet<String>, String> {
+    let runtime_sessions = agent_org_runtime_sessions(state, plan).await;
+    let runtime_session_ids = runtime_sessions
+        .iter()
+        .map(|(session_id, _)| session_id.clone())
+        .collect::<HashSet<_>>();
+
+    for (_, session) in &runtime_sessions {
+        session
+            .cancel_active_turn(CancelReason::AgentOrgDelete)
+            .await;
+    }
+
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let blockers = agent_org_runtime_blockers(&runtime_sessions).await;
+        if blockers.is_empty() {
+            return Ok(runtime_session_ids);
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Err(format!(
+                "Timed out stopping Agent Org run {} before deletion: {}",
+                plan.run_id,
+                blockers.join(", ")
+            ));
+        }
+        tokio::time::sleep(AGENT_ORG_DELETE_STOP_POLL_INTERVAL).await;
+    }
+}
+
+async fn ensure_agent_org_runtime_sessions_idle(
+    state: &AgentAppState,
+    plan: &AgentOrgSessionDeletePlan,
+) -> Result<(), String> {
+    let runtime_sessions = agent_org_runtime_sessions(state, plan).await;
+    let blockers = agent_org_runtime_blockers(&runtime_sessions).await;
+    if blockers.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "Refusing to delete Agent Org run {}: active Rust runtime sessions: {}",
+            plan.run_id,
+            blockers.join(", ")
+        ))
+    }
+}
+
+fn delete_agent_org_session_hierarchy(
+    expected_plan: &AgentOrgSessionDeletePlan,
+    quiesced_runtime_session_ids: &HashSet<String>,
+) -> Result<DeleteSessionReceipt, String> {
+    for node in &expected_plan.sessions {
+        session_persistence::prepare_session_delete(&node.session_id)
+            .map_err(|err| format!("prepare session {} for deletion: {err}", node.session_id))?;
+    }
+
+    let outcome = with_sessions_writer(|| {
+        let mut conn = get_connection().map_err(|err| err.to_string())?;
+        let tx = conn
+            .transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)
+            .map_err(|err| err.to_string())?;
+        let current_plan = load_agent_org_session_delete_plan(&tx, &expected_plan.root_session_id)?
+            .ok_or_else(|| {
+                format!(
+                    "Refusing to delete Agent Org run {}: root ownership changed before deletion",
+                    expected_plan.run_id
+                )
+            })?;
+        if current_plan != *expected_plan {
+            return Err(format!(
+                "Refusing to delete Agent Org run {}: session hierarchy or status changed before deletion",
+                expected_plan.run_id
+            ));
+        }
+        validate_agent_org_delete_ready(&current_plan, quiesced_runtime_session_ids)?;
+
+        for node in &expected_plan.sessions {
+            session_persistence::delete_session_with_connection(&tx, &node.session_id)
+                .map_err(|err| format!("delete session {}: {err}", node.session_id))?;
+        }
+        let outcome = AgentOrgRunStore::delete_by_id_with_connection(&tx, &expected_plan.run_id)?;
+        if !outcome.deleted() {
+            return Err(format!(
+                "Refusing to commit Agent Org run {} deletion: run row disappeared during deletion",
+                expected_plan.run_id
+            ));
+        }
+        ensure_agent_org_hierarchy_absent(&tx, expected_plan)?;
+        tx.commit().map_err(|err| err.to_string())?;
+        Ok::<_, String>(outcome)
+    })?;
+
+    for node in &expected_plan.sessions {
+        session_persistence::finish_session_delete(&node.session_id);
+    }
+    AgentOrgRunStore::finish_delete(&expected_plan.run_id, outcome);
+
+    Ok(DeleteSessionReceipt {
+        deleted_session_ids: expected_plan
+            .sessions
+            .iter()
+            .map(|node| node.session_id.clone())
+            .collect(),
+    })
+}
+
+fn ensure_agent_org_hierarchy_absent(
+    conn: &Connection,
+    plan: &AgentOrgSessionDeletePlan,
+) -> Result<(), String> {
+    for node in &plan.sessions {
+        let residual: Option<String> = conn
+            .query_row(
+                "SELECT session_id
+                 FROM agent_sessions
+                 WHERE session_id=?1 OR parent_session_id=?1
+                 ORDER BY session_id
+                 LIMIT 1",
+                [&node.session_id],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(|err| err.to_string())?;
+        if let Some(session_id) = residual {
+            return Err(format!(
+                "Refusing to commit Agent Org run {} deletion: residual session hierarchy row {session_id} references deleted session {}",
+                plan.run_id, node.session_id
+            ));
+        }
+    }
+    let run_exists = conn
+        .query_row(
+            "SELECT EXISTS(SELECT 1 FROM agent_org_runs WHERE id=?1)",
+            [&plan.run_id],
+            |row| row.get::<_, bool>(0),
+        )
+        .map_err(|err| err.to_string())?;
+    if run_exists {
+        return Err(format!(
+            "Refusing to commit Agent Org run {} deletion: run row still exists",
+            plan.run_id
+        ));
+    }
+    Ok(())
 }
 
 /// Clear all messages for a session.
@@ -458,6 +1056,8 @@ mod tests {
         crate::interaction::plan_approval::persistence::init_schema(&conn)
             .expect("plan approval schema");
         crate::coordination::init_agent_org_schemas(&conn).expect("Agent Org schemas");
+        project_management::lineage::schema::init_lineage_tables(&conn).expect("lineage schema");
+        crate::memory::learnings::init_learnings_table(&conn).expect("learnings schema");
         database::init_shell_replay_tables(&conn).expect("shell replay schema");
         conn.execute_batch(
             "CREATE TABLE IF NOT EXISTS events (
@@ -487,17 +1087,18 @@ mod tests {
         .expect("session runtime schemas");
     }
 
-    fn seed_session(session_id: &str, parent_session_id: Option<&str>) {
+    fn seed_session_with_status(session_id: &str, parent_session_id: Option<&str>, status: &str) {
         let conn = get_connection().expect("sandbox DB");
         conn.execute(
             "INSERT INTO agent_sessions (
                  session_id, name, status, user_input, created_at, updated_at,
                  session_type, parent_session_id, workspace_additional_json,
                  key_source
-             ) VALUES (?1, ?2, 'idle', NULL, ?3, ?3, 'agent', ?4, '{}', 'own_key')",
+             ) VALUES (?1, ?2, ?3, NULL, ?4, ?4, 'agent', ?5, '{}', 'own_key')",
             rusqlite::params![
                 session_id,
                 format!("session-{session_id}"),
+                status,
                 "2026-07-16T00:00:00Z",
                 parent_session_id,
             ],
@@ -505,17 +1106,77 @@ mod tests {
         .expect("seed session");
     }
 
-    fn seed_run(run_id: &str, root_session_id: &str) {
+    fn seed_session(session_id: &str, parent_session_id: Option<&str>) {
+        seed_session_with_status(session_id, parent_session_id, "idle");
+    }
+
+    fn seed_run_with_status(run_id: &str, root_session_id: &str, status: &str) {
         let conn = get_connection().expect("sandbox DB");
         conn.execute(
             "INSERT INTO agent_org_runs (
                  id, org_id, coordinator_agent_id, root_session_id,
                  entry_mode, status, created_at, updated_at
              ) VALUES (?1, 'org-delete-test', 'coordinator-agent', ?2,
-                       'standalone_session', 'running', ?3, ?3)",
-            rusqlite::params![run_id, root_session_id, "2026-07-16T00:00:00Z"],
+                       'standalone_session', ?3, ?4, ?4)",
+            rusqlite::params![run_id, root_session_id, status, "2026-07-16T00:00:00Z"],
         )
         .expect("seed run");
+    }
+
+    fn seed_run(run_id: &str, root_session_id: &str) {
+        seed_run_with_status(run_id, root_session_id, "completed");
+    }
+
+    fn seed_session_owned_rows(session_id: &str) {
+        let conn = get_connection().expect("sandbox DB");
+        conn.execute(
+            "INSERT INTO agent_messages (
+                 id, session_id, role, content, sequence, created_at
+             ) VALUES (?1, ?2, 'user', 'delete me', 0, ?3)",
+            rusqlite::params![
+                format!("message-{session_id}"),
+                session_id,
+                "2026-07-16T00:00:00Z"
+            ],
+        )
+        .expect("seed message");
+        conn.execute(
+            "INSERT INTO agent_todos (session_id, content) VALUES (?1, 'delete me')",
+            [session_id],
+        )
+        .expect("seed todo");
+        conn.execute(
+            "INSERT INTO events (id, session_id) VALUES (?1, ?2)",
+            rusqlite::params![format!("event-{session_id}"), session_id],
+        )
+        .expect("seed event");
+        conn.execute(
+            "INSERT INTO session_token_usage (
+                 session_id, session_type, total_tokens, created_at
+             ) VALUES (?1, 'agent', 1, ?2)",
+            rusqlite::params![session_id, "2026-07-16T00:00:00Z"],
+        )
+        .expect("seed usage");
+    }
+
+    fn seed_run_owned_rows(run_id: &str) {
+        let conn = get_connection().expect("sandbox DB");
+        conn.execute(
+            "INSERT INTO agent_inbox (
+                 recipient_agent_id, recipient_member_id, sender_agent_id,
+                 org_run_id, payload_kind, payload_json, created_at
+             ) VALUES ('worker-agent', 'worker', 'system', ?1,
+                       'plain', '{\"summary\":\"run history\",\"text\":\"body\"}', ?2)",
+            rusqlite::params![run_id, "2026-07-16T00:00:00Z"],
+        )
+        .expect("seed run inbox history");
+        conn.execute(
+            "INSERT INTO agent_org_tasks (
+                 id, org_run_id, subject, status, created_at, updated_at
+             ) VALUES (?1, ?2, 'delete me', 'completed', ?3, ?3)",
+            rusqlite::params![format!("task-{run_id}"), run_id, "2026-07-16T00:00:00Z"],
+        )
+        .expect("seed run task history");
     }
 
     fn row_exists(table: &str, column: &str, value: &str) -> bool {
@@ -530,36 +1191,616 @@ mod tests {
     }
 
     #[test]
-    fn deleting_worker_keeps_run_but_deleting_root_cascades_run_history() {
+    fn session_hierarchy_delete_removes_all_rust_descendants_and_run_history() {
         let _sandbox = test_helpers::test_env::sandbox();
         ensure_test_schemas();
-        seed_session("root-delete-test", None);
-        seed_session("worker-delete-test", Some("root-delete-test"));
-        seed_run("run-delete-test", "root-delete-test");
+        let root = "hierarchy-delete-root";
+        let worker = "hierarchy-delete-worker";
+        let grandchild = "hierarchy-delete-grandchild";
+        let unrelated = "hierarchy-delete-unrelated";
+        let unrelated_root = "hierarchy-delete-other-root";
+        seed_session(root, None);
+        seed_session_with_status(worker, Some(root), "completed");
+        seed_session_with_status(grandchild, Some(worker), "failed");
+        seed_session(unrelated, None);
+        seed_session(unrelated_root, None);
+        seed_run("hierarchy-delete-run", root);
+        seed_run("hierarchy-delete-other-run", unrelated_root);
+        for session_id in [root, worker, grandchild, unrelated] {
+            seed_session_owned_rows(session_id);
+        }
+        seed_run_owned_rows("hierarchy-delete-run");
+        seed_run_owned_rows("hierarchy-delete-other-run");
+
+        let conn = get_connection().expect("sandbox DB");
+        let plan = load_agent_org_session_delete_plan(&conn, root)
+            .expect("plan hierarchy")
+            .expect("root owns Agent Org run");
+        drop(conn);
+        let receipt = delete_agent_org_session_hierarchy(&plan, &HashSet::new())
+            .expect("delete completed hierarchy");
+
+        assert_eq!(
+            receipt.deleted_session_ids,
+            vec![grandchild.to_string(), worker.to_string(), root.to_string()]
+        );
+        for session_id in [root, worker, grandchild] {
+            for table in [
+                "agent_sessions",
+                "agent_messages",
+                "agent_todos",
+                "events",
+                "session_token_usage",
+            ] {
+                assert!(
+                    !row_exists(table, "session_id", session_id),
+                    "{table} still contains {session_id}"
+                );
+            }
+        }
+        assert!(!row_exists("agent_org_runs", "id", "hierarchy-delete-run"));
+        assert!(!row_exists(
+            "agent_inbox",
+            "org_run_id",
+            "hierarchy-delete-run"
+        ));
+        assert!(!row_exists(
+            "agent_org_tasks",
+            "org_run_id",
+            "hierarchy-delete-run"
+        ));
+        assert!(row_exists("agent_sessions", "session_id", unrelated));
+        assert!(row_exists("agent_messages", "session_id", unrelated));
+        assert!(row_exists(
+            "agent_org_runs",
+            "id",
+            "hierarchy-delete-other-run"
+        ));
+        assert!(row_exists(
+            "agent_inbox",
+            "org_run_id",
+            "hierarchy-delete-other-run"
+        ));
+    }
+
+    #[test]
+    fn session_hierarchy_delete_worker_keeps_root_and_run() {
+        let _sandbox = test_helpers::test_env::sandbox();
+        ensure_test_schemas();
+        let root = "hierarchy-worker-root";
+        let worker = "hierarchy-worker-direct-delete";
+        seed_session(root, None);
+        seed_session(worker, Some(root));
+        seed_run("hierarchy-worker-run", root);
+        seed_run_owned_rows("hierarchy-worker-run");
+
+        let conn = get_connection().expect("sandbox DB");
+        assert!(
+            load_agent_org_session_delete_plan(&conn, worker)
+                .expect("plan worker")
+                .is_none(),
+            "a worker must not be promoted to hierarchy root deletion"
+        );
+        drop(conn);
+        session_persistence::delete_session(worker).expect("canonical single-session deletion");
+
+        assert!(!row_exists("agent_sessions", "session_id", worker));
+        assert!(row_exists("agent_sessions", "session_id", root));
+        assert!(row_exists("agent_org_runs", "id", "hierarchy-worker-run"));
+        assert!(row_exists(
+            "agent_inbox",
+            "org_run_id",
+            "hierarchy-worker-run"
+        ));
+    }
+
+    #[test]
+    fn session_hierarchy_delete_fences_active_run_and_requires_quiesced_sessions() {
+        let _sandbox = test_helpers::test_env::sandbox();
+        ensure_test_schemas();
+        let root = "hierarchy-active-root";
+        let worker = "hierarchy-active-worker";
+        seed_session(root, None);
+        seed_session_with_status(worker, Some(root), "running");
+        seed_run_with_status("hierarchy-active-run", root, "running");
+
+        let conn = get_connection().expect("sandbox DB");
+        let plan = load_agent_org_session_delete_plan(&conn, root)
+            .expect("load running hierarchy")
+            .expect("root owns run");
+        drop(conn);
+        let fenced = establish_agent_org_delete_fence(&plan).expect("cancel run for deletion");
+        assert_eq!(
+            fenced.run_status,
+            crate::coordination::agent_org_runs::AgentOrgRunStatus::Cancelled
+        );
+        assert_eq!(
+            get_connection()
+                .expect("sandbox DB")
+                .query_row(
+                    "SELECT status FROM agent_org_runs WHERE id='hierarchy-active-run'",
+                    [],
+                    |row| row.get::<_, String>(0)
+                )
+                .expect("load fenced status"),
+            "cancelled"
+        );
+
+        let error = validate_agent_org_delete_ready(&fenced, &HashSet::new())
+            .expect_err("unobserved running worker must fail closed");
+        assert!(error.contains(worker));
+        assert!(error.contains("running"));
+
+        let quiesced = HashSet::from([worker.to_string()]);
+        validate_agent_org_delete_ready(&fenced, &quiesced)
+            .expect("a stopped live runtime may retain a stale running row");
+        assert!(row_exists("agent_sessions", "session_id", root));
+        assert!(row_exists("agent_sessions", "session_id", worker));
+        assert!(row_exists("agent_org_runs", "id", "hierarchy-active-run"));
+    }
+
+    #[test]
+    fn session_hierarchy_delete_blocks_resource_preflight_failures_before_database_changes() {
+        let _sandbox = test_helpers::test_env::sandbox();
+        ensure_test_schemas();
+        let root = "hierarchy-replay-root";
+        let worker = "hierarchy-replay-worker";
+        seed_session(root, None);
+        seed_session(worker, Some(root));
+        seed_run("hierarchy-replay-run", root);
+        let conn = get_connection().expect("sandbox DB");
+        let plan = load_agent_org_session_delete_plan(&conn, root)
+            .expect("plan hierarchy")
+            .expect("root owns run");
+        drop(conn);
+
+        let replay_root = std::env::temp_dir().join(format!(
+            "orgii-hierarchy-delete-replay-{}",
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&replay_root).expect("create replay root");
+        let writer = crate::tools::impls::coding::exec::shell_replay::ShellReplayWriter::create(
+            &replay_root,
+            crate::tools::impls::coding::exec::shell_replay::ShellReplayTarget::new(
+                worker,
+                "active-call",
+            ),
+            "still running",
+            &replay_root,
+            None,
+        )
+        .expect("create active replay");
+
+        let error = delete_agent_org_session_hierarchy(&plan, &HashSet::new())
+            .expect_err("active replay must block hierarchy deletion");
+        assert!(error.contains(worker));
+        assert!(error.contains("shell replay calls are active"));
+        assert!(row_exists("agent_sessions", "session_id", root));
+        assert!(row_exists("agent_sessions", "session_id", worker));
+        assert!(row_exists("agent_org_runs", "id", "hierarchy-replay-run"));
+
+        writer
+            .finalize(core_types::session_event::ShellReplayStatus::Complete, None)
+            .expect("finalize replay");
+
+        let worktree_path = replay_root.join("owned-worktree");
+        let missing_repo_path = replay_root.join("missing-repository");
+        std::fs::create_dir_all(&worktree_path).expect("create worktree fixture");
         get_connection()
             .expect("sandbox DB")
             .execute(
-                "INSERT INTO agent_inbox (
-                     recipient_agent_id, recipient_member_id, sender_agent_id,
-                     org_run_id, payload_kind, payload_json, created_at
-                 ) VALUES ('worker-agent', 'worker', 'system', ?1,
-                           'plain', '{\"summary\":\"kept until root delete\",\"text\":\"body\"}', ?2)",
-                rusqlite::params!["run-delete-test", "2026-07-16T00:00:00Z"],
+                "UPDATE agent_sessions
+                 SET workspace_path=?1, worktree_path=?2, base_branch='develop'
+                 WHERE session_id=?3",
+                rusqlite::params![
+                    missing_repo_path.to_string_lossy(),
+                    worktree_path.to_string_lossy(),
+                    worker,
+                ],
             )
-            .expect("seed run inbox history");
+            .expect("seed invalid worktree metadata");
+        let error = delete_agent_org_session_hierarchy(&plan, &HashSet::new())
+            .expect_err("worktree validation failure must block hierarchy deletion");
+        assert!(error.contains(worker));
+        assert!(error.contains("repository path no longer exists"));
+        assert!(row_exists("agent_sessions", "session_id", root));
+        assert!(row_exists("agent_sessions", "session_id", worker));
+        assert!(row_exists("agent_org_runs", "id", "hierarchy-replay-run"));
 
-        delete_session_with_agent_org_history("worker-delete-test").expect("delete worker session");
-        assert!(row_exists("agent_org_runs", "id", "run-delete-test"));
-        assert!(row_exists("agent_inbox", "org_run_id", "run-delete-test"));
+        std::fs::remove_dir_all(replay_root).expect("remove replay fixture");
+    }
 
-        delete_session_with_agent_org_history("root-delete-test")
-            .expect("delete root session and owned run");
-        assert!(!row_exists("agent_org_runs", "id", "run-delete-test"));
-        assert!(!row_exists("agent_inbox", "org_run_id", "run-delete-test"));
-        assert!(!row_exists(
-            "agent_sessions",
-            "session_id",
-            "root-delete-test"
+    #[test]
+    fn session_hierarchy_delete_rejects_nested_agent_org_without_mutation() {
+        let _sandbox = test_helpers::test_env::sandbox();
+        ensure_test_schemas();
+        let outer_root = "hierarchy-nested-outer-root";
+        let inner_root = "hierarchy-nested-inner-root";
+        let inner_worker = "hierarchy-nested-inner-worker";
+        seed_session(outer_root, None);
+        seed_session(inner_root, Some(outer_root));
+        seed_session(inner_worker, Some(inner_root));
+        seed_run("hierarchy-nested-outer-run", outer_root);
+        seed_run("hierarchy-nested-inner-run", inner_root);
+
+        let conn = get_connection().expect("sandbox DB");
+        let error = load_agent_org_session_delete_plan(&conn, outer_root)
+            .expect_err("nested Agent Org must fail closed");
+        assert!(error.contains(inner_root));
+        assert!(error.contains("hierarchy-nested-inner-run"));
+        for session_id in [outer_root, inner_root, inner_worker] {
+            assert!(row_exists("agent_sessions", "session_id", session_id));
+        }
+        assert!(row_exists(
+            "agent_org_runs",
+            "id",
+            "hierarchy-nested-outer-run"
         ));
+        assert!(row_exists(
+            "agent_org_runs",
+            "id",
+            "hierarchy-nested-inner-run"
+        ));
+    }
+
+    #[test]
+    fn session_hierarchy_delete_rejects_cycle_and_size_limit() {
+        let _sandbox = test_helpers::test_env::sandbox();
+        ensure_test_schemas();
+        let cycle_root = "hierarchy-cycle-root";
+        let cycle_worker = "hierarchy-cycle-worker";
+        seed_session(cycle_root, Some(cycle_worker));
+        seed_session(cycle_worker, Some(cycle_root));
+        seed_run("hierarchy-cycle-run", cycle_root);
+
+        let conn = get_connection().expect("sandbox DB");
+        let error = load_agent_org_session_delete_plan(&conn, cycle_root)
+            .expect_err("cycle must fail closed");
+        assert!(error.contains("cycle"));
+        assert!(row_exists("agent_sessions", "session_id", cycle_root));
+        assert!(row_exists("agent_sessions", "session_id", cycle_worker));
+        drop(conn);
+
+        let limit_root = "hierarchy-limit-root";
+        seed_session(limit_root, None);
+        seed_run("hierarchy-limit-run", limit_root);
+        let mut conn = get_connection().expect("sandbox DB");
+        let tx = conn.transaction().expect("seed oversized hierarchy");
+        for index in 0..MAX_AGENT_ORG_DELETE_SESSIONS {
+            let session_id = format!("hierarchy-limit-worker-{index:04}");
+            tx.execute(
+                "INSERT INTO agent_sessions (
+                     session_id, name, status, created_at, updated_at,
+                     session_type, parent_session_id, workspace_additional_json,
+                     key_source
+                 ) VALUES (?1, ?1, 'idle', ?2, ?2, 'agent', ?3, '{}', 'own_key')",
+                rusqlite::params![session_id, "2026-07-16T00:00:00Z", limit_root],
+            )
+            .expect("seed worker");
+        }
+        tx.commit().expect("commit oversized hierarchy");
+        let error = load_agent_org_session_delete_plan(&conn, limit_root)
+            .expect_err("oversized hierarchy must fail closed");
+        assert!(error.contains("exceeds"));
+        assert!(row_exists("agent_sessions", "session_id", limit_root));
+        assert!(row_exists("agent_org_runs", "id", "hierarchy-limit-run"));
+    }
+
+    #[test]
+    fn session_hierarchy_delete_rechecks_concurrent_structure_changes() {
+        let _sandbox = test_helpers::test_env::sandbox();
+        ensure_test_schemas();
+        let root = "hierarchy-recheck-root";
+        let worker = "hierarchy-recheck-worker";
+        seed_session(root, None);
+        seed_session(worker, Some(root));
+        seed_run("hierarchy-recheck-run", root);
+
+        let conn = get_connection().expect("sandbox DB");
+        let plan = load_agent_org_session_delete_plan(&conn, root)
+            .expect("initial plan")
+            .expect("root owns run");
+        drop(conn);
+        seed_session("hierarchy-recheck-late-worker", Some(root));
+
+        let error = delete_agent_org_session_hierarchy(&plan, &HashSet::new())
+            .expect_err("changed hierarchy must fail closed");
+        assert!(error.contains("changed before deletion"));
+        for session_id in [root, worker, "hierarchy-recheck-late-worker"] {
+            assert!(row_exists("agent_sessions", "session_id", session_id));
+        }
+        assert!(row_exists("agent_org_runs", "id", "hierarchy-recheck-run"));
+    }
+
+    #[test]
+    fn session_hierarchy_delete_rolls_back_on_midway_database_failure() {
+        let _sandbox = test_helpers::test_env::sandbox();
+        ensure_test_schemas();
+        let root = "hierarchy-rollback-root";
+        let worker = "hierarchy-rollback-worker";
+        seed_session(root, None);
+        seed_session(worker, Some(root));
+        seed_session_owned_rows(root);
+        seed_session_owned_rows(worker);
+        seed_run("hierarchy-rollback-run", root);
+        seed_run_owned_rows("hierarchy-rollback-run");
+
+        let conn = get_connection().expect("sandbox DB");
+        let plan = load_agent_org_session_delete_plan(&conn, root)
+            .expect("plan hierarchy")
+            .expect("root owns run");
+        conn.execute_batch(
+            "CREATE TRIGGER hierarchy_delete_abort_root
+             BEFORE DELETE ON agent_sessions
+             WHEN OLD.session_id='hierarchy-rollback-root'
+             BEGIN
+                 SELECT RAISE(ABORT, 'injected hierarchy delete failure');
+             END;",
+        )
+        .expect("install failure trigger");
+        drop(conn);
+
+        let error = delete_agent_org_session_hierarchy(&plan, &HashSet::new())
+            .expect_err("trigger must abort transaction");
+        assert!(error.contains("injected hierarchy delete failure"));
+        for session_id in [root, worker] {
+            for table in [
+                "agent_sessions",
+                "agent_messages",
+                "agent_todos",
+                "events",
+                "session_token_usage",
+            ] {
+                assert!(
+                    row_exists(table, "session_id", session_id),
+                    "{table} lost {session_id} despite rollback"
+                );
+            }
+        }
+        assert!(row_exists("agent_org_runs", "id", "hierarchy-rollback-run"));
+        assert!(row_exists(
+            "agent_inbox",
+            "org_run_id",
+            "hierarchy-rollback-run"
+        ));
+        assert!(row_exists(
+            "agent_org_tasks",
+            "org_run_id",
+            "hierarchy-rollback-run"
+        ));
+    }
+
+    #[test]
+    fn session_hierarchy_delete_rolls_back_transaction_time_structure_changes() {
+        let _sandbox = test_helpers::test_env::sandbox();
+        ensure_test_schemas();
+        let root = "hierarchy-trigger-change-root";
+        let worker = "hierarchy-trigger-change-worker";
+        let injected = "hierarchy-trigger-change-injected";
+        seed_session(root, None);
+        seed_session(worker, Some(root));
+        seed_run("hierarchy-trigger-change-run", root);
+
+        let conn = get_connection().expect("sandbox DB");
+        let plan = load_agent_org_session_delete_plan(&conn, root)
+            .expect("plan hierarchy")
+            .expect("root owns run");
+        conn.execute_batch(
+            "CREATE TRIGGER hierarchy_delete_insert_child
+             AFTER DELETE ON agent_sessions
+             WHEN OLD.session_id='hierarchy-trigger-change-root'
+             BEGIN
+                 INSERT INTO agent_sessions (
+                     session_id, name, status, created_at, updated_at,
+                     session_type, parent_session_id, workspace_additional_json,
+                     key_source
+                 ) VALUES (
+                     'hierarchy-trigger-change-injected',
+                     'injected',
+                     'idle',
+                     '2026-07-16T00:00:00Z',
+                     '2026-07-16T00:00:00Z',
+                     'agent',
+                     'hierarchy-trigger-change-root',
+                     '{}',
+                     'own_key'
+                 );
+             END;",
+        )
+        .expect("install mutation trigger");
+        drop(conn);
+
+        let error = delete_agent_org_session_hierarchy(&plan, &HashSet::new())
+            .expect_err("transaction-time hierarchy mutation must abort");
+        assert!(error.contains("residual session hierarchy row"));
+        assert!(row_exists("agent_sessions", "session_id", root));
+        assert!(row_exists("agent_sessions", "session_id", worker));
+        assert!(!row_exists("agent_sessions", "session_id", injected));
+        assert!(row_exists(
+            "agent_org_runs",
+            "id",
+            "hierarchy-trigger-change-run"
+        ));
+    }
+
+    #[tokio::test]
+    async fn session_hierarchy_delete_stops_active_runtime_and_discards_pending_work() {
+        let _sandbox = test_helpers::test_env::sandbox();
+        ensure_test_schemas();
+        let root = "hierarchy-runtime-root";
+        let state = AgentAppState::new();
+        let root_runtime = std::sync::Arc::new(crate::state::AgentSession::new(
+            root.to_string(),
+            crate::definitions::AgentDefinition::default(),
+        ));
+        let turn_started = std::sync::Arc::new(tokio::sync::Notify::new());
+        let turn_started_for_job = std::sync::Arc::clone(&turn_started);
+        let runtime_for_job = std::sync::Arc::clone(&root_runtime);
+        root_runtime
+            .scheduler
+            .enqueue(crate::session::ScheduledMessage {
+                kind: crate::session::ScheduledKind::Turn,
+                message_id: "hierarchy-runtime-processing".to_string(),
+                generation: 0,
+                client_message_id: None,
+                turn_intent_id: "hierarchy-runtime-processing-intent".to_string(),
+                org_run_id: Some("hierarchy-runtime-run".to_string()),
+                content: String::new(),
+                execute: Box::new(move || {
+                    let runtime = std::sync::Arc::clone(&runtime_for_job);
+                    let started = std::sync::Arc::clone(&turn_started_for_job);
+                    Box::pin(async move {
+                        runtime.begin_turn("still running".to_string()).await;
+                        started.notify_one();
+                        while !runtime
+                            .cancel_flag
+                            .load(std::sync::atomic::Ordering::SeqCst)
+                        {
+                            tokio::task::yield_now().await;
+                        }
+                        runtime
+                            .end_turn(
+                                crate::session::DialogTurnState::Cancelled,
+                                crate::session::TurnStats::default(),
+                            )
+                            .await;
+                        Err("cancelled for hierarchy deletion".to_string())
+                    })
+                }),
+            })
+            .await
+            .expect("enqueue processing work");
+        tokio::time::timeout(std::time::Duration::from_secs(1), turn_started.notified())
+            .await
+            .expect("turn starts processing");
+        let pending_executed = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let pending_executed_for_job = std::sync::Arc::clone(&pending_executed);
+        root_runtime
+            .scheduler
+            .enqueue(crate::session::ScheduledMessage {
+                kind: crate::session::ScheduledKind::Turn,
+                message_id: "hierarchy-runtime-pending".to_string(),
+                generation: 0,
+                client_message_id: None,
+                turn_intent_id: "hierarchy-runtime-pending-intent".to_string(),
+                org_run_id: Some("hierarchy-runtime-run".to_string()),
+                content: String::new(),
+                execute: Box::new(move || {
+                    let executed = std::sync::Arc::clone(&pending_executed_for_job);
+                    Box::pin(async move {
+                        executed.store(true, std::sync::atomic::Ordering::SeqCst);
+                        Ok(String::new())
+                    })
+                }),
+            })
+            .await
+            .expect("enqueue pending work");
+        state
+            .sessions
+            .lock()
+            .await
+            .insert(root.to_string(), std::sync::Arc::clone(&root_runtime));
+        let plan = AgentOrgSessionDeletePlan {
+            run_id: "hierarchy-runtime-run".to_string(),
+            root_session_id: root.to_string(),
+            run_status: crate::coordination::agent_org_runs::AgentOrgRunStatus::Cancelled,
+            sessions: vec![AgentOrgSessionDeleteNode {
+                session_id: root.to_string(),
+                parent_session_id: None,
+                status: SessionStatus::Running,
+                depth: 0,
+            }],
+        };
+
+        let quiesced = stop_agent_org_runtime_sessions_with_timeout(
+            &state,
+            &plan,
+            std::time::Duration::from_secs(1),
+        )
+        .await
+        .expect("active Rust runtime stops");
+        assert_eq!(quiesced, HashSet::from([root.to_string()]));
+        assert_eq!(root_runtime.scheduler.pending_count(), 0);
+        assert!(!root_runtime.scheduler.is_processing());
+        assert!(root_runtime.active_turn.lock().await.is_none());
+        assert!(!pending_executed.load(std::sync::atomic::Ordering::SeqCst));
+        validate_agent_org_delete_ready(&plan, &quiesced)
+            .expect("quiesced active status is safe behind cancelled fence");
+    }
+
+    #[tokio::test]
+    async fn session_hierarchy_delete_times_out_without_removing_runtime() {
+        let _sandbox = test_helpers::test_env::sandbox();
+        ensure_test_schemas();
+        let root = "hierarchy-runtime-timeout-root";
+        let state = AgentAppState::new();
+        let runtime = std::sync::Arc::new(crate::state::AgentSession::new(
+            root.to_string(),
+            crate::definitions::AgentDefinition::default(),
+        ));
+        let release = std::sync::Arc::new(tokio::sync::Notify::new());
+        let release_for_job = std::sync::Arc::clone(&release);
+        runtime
+            .scheduler
+            .enqueue(crate::session::ScheduledMessage {
+                kind: crate::session::ScheduledKind::Maintenance,
+                message_id: "hierarchy-runtime-timeout".to_string(),
+                generation: 0,
+                client_message_id: None,
+                turn_intent_id: "hierarchy-runtime-timeout-intent".to_string(),
+                org_run_id: Some("hierarchy-runtime-timeout-run".to_string()),
+                content: String::new(),
+                execute: Box::new(move || {
+                    let release = std::sync::Arc::clone(&release_for_job);
+                    Box::pin(async move {
+                        release.notified().await;
+                        Ok(String::new())
+                    })
+                }),
+            })
+            .await
+            .expect("enqueue non-cooperative maintenance");
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while !runtime.scheduler.is_processing() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("maintenance starts");
+        state
+            .sessions
+            .lock()
+            .await
+            .insert(root.to_string(), std::sync::Arc::clone(&runtime));
+        let plan = AgentOrgSessionDeletePlan {
+            run_id: "hierarchy-runtime-timeout-run".to_string(),
+            root_session_id: root.to_string(),
+            run_status: crate::coordination::agent_org_runs::AgentOrgRunStatus::Cancelled,
+            sessions: vec![AgentOrgSessionDeleteNode {
+                session_id: root.to_string(),
+                parent_session_id: None,
+                status: SessionStatus::Running,
+                depth: 0,
+            }],
+        };
+
+        let error = stop_agent_org_runtime_sessions_with_timeout(
+            &state,
+            &plan,
+            std::time::Duration::from_millis(50),
+        )
+        .await
+        .expect_err("non-cooperative work must time out");
+        assert!(error.contains("Timed out stopping"));
+        assert!(error.contains(root));
+        assert!(state.get_session(root).await.is_some());
+        release.notify_one();
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while runtime.scheduler.is_processing() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("maintenance finishes after the timeout assertion");
     }
 }

--- a/src-tauri/crates/agent-core/src/state/control_flow.rs
+++ b/src-tauri/crates/agent-core/src/state/control_flow.rs
@@ -7,6 +7,7 @@ pub enum CancelReason {
     UserStop,
     ForceSend,
     OrgPause,
+    AgentOrgDelete,
     ProgrammaticShutdown,
     SessionEviction,
     ModeSwitchAbort,
@@ -38,7 +39,7 @@ impl CancelReason {
     /// enumerates durable member rows, including lazy members that have never
     /// started, so absence is normal for `OrgPause` and must not corrupt them.
     pub const fn repairs_missing_session_as_failed(self) -> bool {
-        !matches!(self, Self::OrgPause)
+        !matches!(self, Self::OrgPause | Self::AgentOrgDelete)
     }
 
     pub fn boundary_effect(self) -> TurnBoundaryEffect {
@@ -67,6 +68,18 @@ impl CancelReason {
                 discard_queued_messages: false,
                 cancel_background_workers: true,
             },
+            Self::AgentOrgDelete => TurnBoundaryEffect {
+                // The delete fence can land after the scheduler has claimed a
+                // job but before that job registers `active_turn`. Keep the
+                // signal across that narrow boundary so the claimed turn
+                // cannot outlive deletion.
+                keep_pre_turn_cancel_when_idle: true,
+                clear_pending_approvals: true,
+                persist_cancel_marker: false,
+                allow_crash_repair_on_next_turn: false,
+                discard_queued_messages: true,
+                cancel_background_workers: true,
+            },
             Self::ProgrammaticShutdown | Self::SessionEviction | Self::ModeSwitchAbort => {
                 TurnBoundaryEffect {
                     keep_pre_turn_cancel_when_idle: false,
@@ -85,6 +98,7 @@ impl CancelReason {
             Self::UserStop => "user_stop",
             Self::ForceSend => "force_send",
             Self::OrgPause => "org_pause",
+            Self::AgentOrgDelete => "agent_org_delete",
             Self::ProgrammaticShutdown => "programmatic_shutdown",
             Self::SessionEviction => "session_eviction",
             Self::ModeSwitchAbort => "mode_switch_abort",
@@ -99,6 +113,12 @@ mod tests {
     #[test]
     fn org_pause_does_not_fail_lazy_persisted_sessions() {
         assert!(!CancelReason::OrgPause.repairs_missing_session_as_failed());
+        assert!(!CancelReason::AgentOrgDelete.repairs_missing_session_as_failed());
+        assert!(
+            CancelReason::AgentOrgDelete
+                .boundary_effect()
+                .keep_pre_turn_cancel_when_idle
+        );
         assert!(CancelReason::UserStop.repairs_missing_session_as_failed());
         assert!(CancelReason::ProgrammaticShutdown.repairs_missing_session_as_failed());
     }

--- a/src-tauri/crates/agent-core/src/state/unified.rs
+++ b/src-tauri/crates/agent-core/src/state/unified.rs
@@ -344,6 +344,18 @@ impl AgentAppState {
         info!("[agent-state] Removed session: {}", session_id);
     }
 
+    /// Remove several sessions while holding the registry lock once.
+    ///
+    /// Used after an Agent Org hierarchy transaction commits so descendant
+    /// runtimes cannot remain retained after their durable rows are gone.
+    pub async fn remove_sessions(&self, session_ids: &[String]) {
+        let mut sessions = self.sessions.lock().await;
+        for session_id in session_ids {
+            sessions.remove(session_id);
+            info!("[agent-state] Removed session: {}", session_id);
+        }
+    }
+
     /// Invalidate the runtime attached to a session, forcing re-initialization
     /// on the next request.
     pub async fn invalidate_session(&self, session_id: &str) {

--- a/src-tauri/crates/project-management/src/lineage/mod.rs
+++ b/src-tauri/crates/project-management/src/lineage/mod.rs
@@ -23,7 +23,7 @@ pub mod provenance;
 pub mod schema;
 
 use database::db::get_connection;
-use rusqlite::Result as SqliteResult;
+use rusqlite::{Connection, Result as SqliteResult};
 
 /// Drop every lineage row tied to `session_id`.
 ///
@@ -35,6 +35,17 @@ use rusqlite::Result as SqliteResult;
 /// rows after the owning session is gone.
 pub fn delete_session_lineage(session_id: &str) -> SqliteResult<()> {
     let conn = get_connection()?;
+    delete_session_lineage_with_connection(&conn, session_id)
+}
+
+/// Transaction-aware form of [`delete_session_lineage`].
+///
+/// Agent Org hierarchy deletion uses this to keep lineage removal inside the
+/// same SQLite transaction as the owning Rust sessions and run state.
+pub fn delete_session_lineage_with_connection(
+    conn: &Connection,
+    session_id: &str,
+) -> SqliteResult<()> {
     conn.execute(
         "DELETE FROM commit_lineage
          WHERE provenance_id IN (

--- a/src-tauri/src/agent_sessions/event_pipeline/agent_core_bridge.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/agent_core_bridge.rs
@@ -280,6 +280,22 @@ fn unpin_session_adapter(handle: &AppHandle, session_id: &str) {
     }
 }
 
+fn evict_session_adapter(handle: &AppHandle, session_id: &str) {
+    let state = handle.state::<EventStoreState>();
+    {
+        let mut manager = state
+            .session_manager
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        manager.evict(session_id);
+    }
+    state
+        .stores
+        .lock()
+        .unwrap_or_else(|error| error.into_inner())
+        .remove(session_id);
+}
+
 fn read_session_events_adapter(handle: &AppHandle, session_id: &str) -> Vec<SessionEvent> {
     let state = handle.state::<EventStoreState>();
     state
@@ -620,6 +636,7 @@ pub fn register() {
         remove_events_by_ids_adapter,
         pin_session_adapter,
         unpin_session_adapter,
+        evict_session_adapter,
         read_session_events_adapter,
         finalize_plan_revision_events_adapter,
         persist_events_adapter,

--- a/src-tauri/src/api/agent/mod.rs
+++ b/src-tauri/src/api/agent/mod.rs
@@ -723,6 +723,10 @@ pub fn create_routes() -> Router {
             post(test::agent_org::test_agent_org_seed_stale_worker_run),
         )
         .route(
+            "/test/agent-org/session-delete/snapshot",
+            post(test::agent_org::test_agent_org_session_delete_snapshot),
+        )
+        .route(
             "/test/agent-org/stale-workers/seed-cli-member",
             post(test::agent_org::test_agent_org_seed_cli_member_run),
         )

--- a/src-tauri/src/api/agent/test/agent_org.rs
+++ b/src-tauri/src/api/agent/test/agent_org.rs
@@ -1662,6 +1662,30 @@ pub async fn test_agent_org_seed_stale_worker_run(
         .filter(|value| !value.trim().is_empty())
         .map(str::to_string)
         .unwrap_or_else(|| format!("agent-org-stale-root-{}", uuid::Uuid::new_v4()));
+    let root_status = match obj.get("root_status").and_then(|value| value.as_str()) {
+        Some(value) => match SessionStatus::parse(value) {
+            Some(parsed) => parsed,
+            None => {
+                return Json(serde_json::json!({
+                    "ok": false,
+                    "error": format!("unknown root_status value: {value}")
+                }))
+            }
+        },
+        None => SessionStatus::Running,
+    };
+    let run_status = match obj.get("run_status").and_then(|value| value.as_str()) {
+        Some(value) => match AgentOrgRunStatus::parse(value) {
+            Some(parsed) => parsed,
+            None => {
+                return Json(serde_json::json!({
+                    "ok": false,
+                    "error": format!("unknown run_status value: {value}")
+                }))
+            }
+        },
+        None => AgentOrgRunStatus::Running,
+    };
     let workers = match obj.get("workers").and_then(|value| value.as_array()) {
         Some(value) if !value.is_empty() => value.clone(),
         _ => {
@@ -1688,7 +1712,7 @@ pub async fn test_agent_org_seed_stale_worker_run(
         upsert_session(&UnifiedSessionRecord {
             session_id: root_session_id.clone(),
             name: "stale-worker-root".to_string(),
-            status: SessionStatus::Running.as_str().to_string(),
+            status: root_status.as_str().to_string(),
             session_type: session_type::GENERIC.to_string(),
             agent_definition_id: Some(coordinator_agent_id.clone()),
             org_member_id: Some(COORDINATOR_MEMBER_ID.to_string()),
@@ -1744,7 +1768,7 @@ pub async fn test_agent_org_seed_stale_worker_run(
             root_session_id: Some(root_session_id.clone()),
             org_snapshot,
             entry_mode: AgentOrgRunEntryMode::StandaloneSession,
-            status: AgentOrgRunStatus::Running,
+            status: run_status,
             work_item_id: None,
             project_slug: None,
             routine_fire_id: None,
@@ -1785,13 +1809,19 @@ pub async fn test_agent_org_seed_stale_worker_run(
                 },
                 None => SessionStatus::Running,
             };
+            let parent_session_id = worker_obj
+                .get("parent_session_id")
+                .and_then(|value| value.as_str())
+                .filter(|value| !value.trim().is_empty())
+                .map(str::to_string)
+                .unwrap_or_else(|| root_session_id.clone());
 
             upsert_session(&UnifiedSessionRecord {
                 session_id: session_id.clone(),
                 name: format!("stale-worker-{agent_definition_id}"),
                 status: status.as_str().to_string(),
                 session_type: session_type::ORG_MEMBER.to_string(),
-                parent_session_id: Some(root_session_id.clone()),
+                parent_session_id: Some(parent_session_id),
                 agent_definition_id: Some(agent_definition_id.clone()),
                 org_member_id: member_id,
                 created_at: updated_at.clone(),
@@ -1812,6 +1842,90 @@ pub async fn test_agent_org_seed_stale_worker_run(
             "org_run_id": run.id,
             "root_session_id": root_session_id,
             "worker_sessions": worker_sessions,
+        }))
+    })
+    .await;
+
+    match result {
+        Err(join_err) => Json(serde_json::json!({
+            "ok": false,
+            "error": format!("spawn_blocking join error: {join_err}"),
+        })),
+        Ok(Err(err)) => Json(serde_json::json!({ "ok": false, "error": err })),
+        Ok(Ok(value)) => Json(value),
+    }
+}
+
+/// Read-only persistence snapshot for rendered Agent Org hierarchy-deletion
+/// tests. The deletion itself must still be triggered through the real
+/// sidebar action.
+pub async fn test_agent_org_session_delete_snapshot(
+    Json(body): Json<serde_json::Value>,
+) -> Json<serde_json::Value> {
+    let Some(obj) = body.as_object() else {
+        return Json(serde_json::json!({ "ok": false, "error": "body must be an object" }));
+    };
+    let session_ids = obj
+        .get("session_ids")
+        .and_then(|value| value.as_array())
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|value| value.as_str())
+                .filter(|value| !value.trim().is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let run_ids = obj
+        .get("run_ids")
+        .and_then(|value| value.as_array())
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(|value| value.as_str())
+                .filter(|value| !value.trim().is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    if session_ids.is_empty() && run_ids.is_empty() {
+        return Json(serde_json::json!({
+            "ok": false,
+            "error": "session_ids or run_ids must contain at least one ID"
+        }));
+    }
+
+    let result = tokio::task::spawn_blocking(move || -> Result<serde_json::Value, String> {
+        let conn = database::db::get_connection().map_err(|err| err.to_string())?;
+        let mut sessions = serde_json::Map::new();
+        for session_id in session_ids {
+            let exists = conn
+                .query_row(
+                    "SELECT EXISTS(
+                         SELECT 1 FROM agent_sessions WHERE session_id=?1
+                     )",
+                    [&session_id],
+                    |row| row.get::<_, bool>(0),
+                )
+                .map_err(|err| err.to_string())?;
+            sessions.insert(session_id, serde_json::Value::Bool(exists));
+        }
+        let mut runs = serde_json::Map::new();
+        for run_id in run_ids {
+            let exists = conn
+                .query_row(
+                    "SELECT EXISTS(SELECT 1 FROM agent_org_runs WHERE id=?1)",
+                    [&run_id],
+                    |row| row.get::<_, bool>(0),
+                )
+                .map_err(|err| err.to_string())?;
+            runs.insert(run_id, serde_json::Value::Bool(exists));
+        }
+        Ok(serde_json::json!({
+            "ok": true,
+            "sessions": sessions,
+            "runs": runs,
         }))
     })
     .await;

--- a/src/api/tauri/agent/session.ts
+++ b/src/api/tauri/agent/session.ts
@@ -14,6 +14,7 @@ import type { SessionStatus } from "@src/types/session/session";
 import type {
   AgentExecModeConfig,
   AgentStatusInfo,
+  DeleteSessionReceipt,
   FileResolution,
   FileResolutionValue,
   HousekeeperContextCompactionState,
@@ -119,7 +120,9 @@ export async function listAllSessions(): Promise<SessionMeta[]> {
   return rpc.agentSession.listAllSessions();
 }
 
-export async function deleteSession(sessionId: string): Promise<void> {
+export async function deleteSession(
+  sessionId: string
+): Promise<DeleteSessionReceipt> {
   return rpc.agentSession.deleteSession({ sessionId });
 }
 

--- a/src/api/tauri/agent/types.ts
+++ b/src/api/tauri/agent/types.ts
@@ -201,6 +201,10 @@ export interface SessionMeta {
   errorMessage?: string | null;
 }
 
+export interface DeleteSessionReceipt {
+  deletedSessionIds: string[];
+}
+
 export interface SnapshotRecord {
   sessionId: string;
   toolCallId: string;

--- a/src/api/tauri/rpc/procedures/agentSession.ts
+++ b/src/api/tauri/rpc/procedures/agentSession.ts
@@ -56,6 +56,7 @@ export const agentSession = {
     .build(),
   deleteSession: defineProcedure("agent_delete_session")
     .input(schemas.agentSession.SessionIdInput)
+    .output(schemas.agentSession.DeleteSessionReceiptSchema)
     .build(),
   clearMessages: defineProcedure("agent_clear_messages")
     .input(schemas.agentSession.SessionIdInput)

--- a/src/api/tauri/rpc/schemas/__tests__/agentSessionDelete.test.ts
+++ b/src/api/tauri/rpc/schemas/__tests__/agentSessionDelete.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import { DeleteSessionReceiptSchema } from "../agentSession";
+
+describe("DeleteSessionReceiptSchema", () => {
+  it("parses every deleted Rust session ID", () => {
+    expect(
+      DeleteSessionReceiptSchema.parse({
+        deletedSessionIds: ["worker", "root"],
+      })
+    ).toEqual({
+      deletedSessionIds: ["worker", "root"],
+    });
+  });
+
+  it("rejects the legacy void response", () => {
+    expect(DeleteSessionReceiptSchema.safeParse(undefined).success).toBe(false);
+  });
+});

--- a/src/api/tauri/rpc/schemas/agentSession.ts
+++ b/src/api/tauri/rpc/schemas/agentSession.ts
@@ -3,6 +3,7 @@ import { z } from "zod/v4";
 import type {
   AgentExecModeConfig,
   AgentStatusInfo,
+  DeleteSessionReceipt,
   FileResolution,
   HousekeeperContextCompactionState,
   ManualCompactResult,
@@ -21,6 +22,10 @@ const JsonRecordSchema = z.record(z.string(), z.unknown());
 export const SessionIdInput = z.object({
   sessionId: z.string(),
 });
+
+export const DeleteSessionReceiptSchema = z.object({
+  deletedSessionIds: z.array(z.string()),
+}) as z.ZodType<DeleteSessionReceipt, DeleteSessionReceipt>;
 
 /**
  * Input for `agent_session_manual_compact` — optional free-form user

--- a/src/features/TeamCollaboration/forkSession.test.ts
+++ b/src/features/TeamCollaboration/forkSession.test.ts
@@ -175,7 +175,9 @@ beforeEach(() => {
   resolveScopeKeysMock.mockResolvedValue([]);
   existsMock.mockResolvedValue(true);
   saveSessionMock.mockResolvedValue(undefined);
-  deleteSessionMock.mockResolvedValue(undefined);
+  deleteSessionMock.mockResolvedValue({
+    deletedSessionIds: ["agentsession-fork-1"],
+  });
   eventStoreMock.clear.mockResolvedValue(undefined);
   eventStoreMock.getPersistedEvents.mockResolvedValue([]);
   store.set(sessionsAtom, []);

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sessionRowActions.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sessionRowActions.tsx
@@ -108,6 +108,7 @@ export function useDecorateSessionRowActions({
             icon: MoreHorizontal,
             label: tCommon("actions.more"),
             active: activeSessionMoreMenuId === item.id,
+            dataTestId: `sidebar-session-more-${item.id}`,
             onClick: (event) => {
               setActiveSessionMoreMenuId(item.id);
               void handleMenuItemContextMenu(event, item.key, item).finally(

--- a/src/scaffold/NavigationSidebar/connectors/rustSessionDeleteReceipt.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/rustSessionDeleteReceipt.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { applyRustSessionDeleteReceipt } from "./rustSessionDeleteReceipt";
+
+function cleanupSpies() {
+  return {
+    removeSession: vi.fn(),
+    removeForkRelayEntry: vi.fn(),
+    disposeWorkstationWorkspace: vi.fn(),
+    clearPendingFileOpens: vi.fn(),
+    clearPendingCodeEditorTab: vi.fn(),
+    evictEventStore: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("applyRustSessionDeleteReceipt", () => {
+  it("cleans every Agent Org descendant and evicts all receipt IDs", async () => {
+    const cleanup = cleanupSpies();
+
+    const deletedActiveSession = await applyRustSessionDeleteReceipt({
+      requestedSessionId: "root",
+      activeSessionId: "worker-b",
+      isAgentOrgRoot: true,
+      receipt: {
+        deletedSessionIds: ["worker-a", "worker-b", "root"],
+      },
+      cleanup,
+    });
+
+    expect(deletedActiveSession).toBe(true);
+    for (const cleanupFn of [
+      cleanup.removeSession,
+      cleanup.removeForkRelayEntry,
+      cleanup.disposeWorkstationWorkspace,
+      cleanup.clearPendingFileOpens,
+      cleanup.clearPendingCodeEditorTab,
+    ]) {
+      expect(cleanupFn.mock.calls).toEqual([["worker-a"], ["worker-b"]]);
+    }
+    expect(cleanup.evictEventStore.mock.calls).toEqual([
+      ["worker-a"],
+      ["worker-b"],
+      ["root"],
+    ]);
+  });
+
+  it("leaves ordinary SDE cleanup on the existing single-session path", async () => {
+    const cleanup = cleanupSpies();
+
+    const deletedActiveSession = await applyRustSessionDeleteReceipt({
+      requestedSessionId: "ordinary-session",
+      activeSessionId: "ordinary-session",
+      isAgentOrgRoot: false,
+      receipt: {
+        deletedSessionIds: ["ordinary-session"],
+      },
+      cleanup,
+    });
+
+    expect(deletedActiveSession).toBe(true);
+    expect(cleanup.removeSession).not.toHaveBeenCalled();
+    expect(cleanup.removeForkRelayEntry).not.toHaveBeenCalled();
+    expect(cleanup.disposeWorkstationWorkspace).not.toHaveBeenCalled();
+    expect(cleanup.clearPendingFileOpens).not.toHaveBeenCalled();
+    expect(cleanup.clearPendingCodeEditorTab).not.toHaveBeenCalled();
+    expect(cleanup.evictEventStore).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates malformed duplicate IDs before local cleanup", async () => {
+    const cleanup = cleanupSpies();
+
+    await applyRustSessionDeleteReceipt({
+      requestedSessionId: "root",
+      activeSessionId: "unrelated",
+      isAgentOrgRoot: true,
+      receipt: {
+        deletedSessionIds: ["worker", "worker", "root"],
+      },
+      cleanup,
+    });
+
+    expect(cleanup.removeSession).toHaveBeenCalledTimes(1);
+    expect(cleanup.removeSession).toHaveBeenCalledWith("worker");
+    expect(cleanup.evictEventStore.mock.calls).toEqual([["worker"], ["root"]]);
+  });
+});

--- a/src/scaffold/NavigationSidebar/connectors/rustSessionDeleteReceipt.ts
+++ b/src/scaffold/NavigationSidebar/connectors/rustSessionDeleteReceipt.ts
@@ -1,0 +1,51 @@
+import type { DeleteSessionReceipt } from "@src/api/tauri/agent";
+
+interface RustSessionDeleteCleanup {
+  removeSession: (sessionId: string) => void;
+  removeForkRelayEntry: (sessionId: string) => void;
+  disposeWorkstationWorkspace: (sessionId: string) => void;
+  clearPendingFileOpens: (sessionId: string) => void;
+  clearPendingCodeEditorTab: (sessionId: string) => void;
+  evictEventStore: (sessionId: string) => Promise<void>;
+}
+
+interface ApplyRustSessionDeleteReceiptOptions {
+  requestedSessionId: string;
+  activeSessionId: string;
+  isAgentOrgRoot: boolean;
+  receipt: DeleteSessionReceipt;
+  cleanup: RustSessionDeleteCleanup;
+}
+
+/**
+ * Apply the additional local cleanup described by a Rust deletion receipt.
+ *
+ * The requested row keeps the sidebar's existing single-session cleanup path.
+ * Only descendant IDs are handled here, so an ordinary SDE receipt containing
+ * one ID has no new cleanup side effects.
+ */
+export async function applyRustSessionDeleteReceipt({
+  requestedSessionId,
+  activeSessionId,
+  isAgentOrgRoot,
+  receipt,
+  cleanup,
+}: ApplyRustSessionDeleteReceiptOptions): Promise<boolean> {
+  const deletedSessionIds = [...new Set(receipt.deletedSessionIds)];
+  for (const deletedSessionId of deletedSessionIds) {
+    if (deletedSessionId === requestedSessionId) continue;
+    cleanup.removeSession(deletedSessionId);
+    cleanup.removeForkRelayEntry(deletedSessionId);
+    cleanup.disposeWorkstationWorkspace(deletedSessionId);
+    cleanup.clearPendingFileOpens(deletedSessionId);
+    cleanup.clearPendingCodeEditorTab(deletedSessionId);
+  }
+
+  if (isAgentOrgRoot || deletedSessionIds.length > 1) {
+    await Promise.all(
+      deletedSessionIds.map((sessionId) => cleanup.evictEventStore(sessionId))
+    );
+  }
+
+  return deletedSessionIds.includes(activeSessionId);
+}

--- a/src/scaffold/NavigationSidebar/connectors/useWorkstationSidebarHandlers.ts
+++ b/src/scaffold/NavigationSidebar/connectors/useWorkstationSidebarHandlers.ts
@@ -8,6 +8,7 @@ import { benchmarkApi } from "@src/api/tauri/benchmark";
 import { deleteHumanSession } from "@src/api/tauri/humanSession";
 import { rpc } from "@src/api/tauri/rpc";
 import Message from "@src/components/Message";
+import { eventStoreProxy } from "@src/engines/SessionCore/core/store/EventStoreProxy";
 import {
   commitRefreshedAuth,
   org2CloudAuthAtom,
@@ -67,6 +68,7 @@ import {
   isChatPanelTuiSessionId,
 } from "@src/util/ui/terminal/chatPanelTuiSessionId";
 
+import { applyRustSessionDeleteReceipt } from "./rustSessionDeleteReceipt";
 import {
   NEW_SESSION_MENU_ITEM_ID,
   getDraftIdFromMenuItemId,
@@ -157,6 +159,7 @@ export function useWorkstationSidebarHandlers({
           return;
         }
         const session = sessionMap.get(sessionId);
+        let deletedActiveRustSession = false;
         const forkedFrom = session ? getSessionForkedFrom(session) : undefined;
         // Cloud retraction targets, mirroring the engine's publish targets:
         // a fork publishes only to its source org; an ordinary session
@@ -201,7 +204,29 @@ export function useWorkstationSidebarHandlers({
         } else if (isHumanSession(sessionId)) {
           await deleteHumanSession(sessionId);
         } else {
-          await deleteSession(sessionId);
+          const receipt = await deleteSession(sessionId);
+          deletedActiveRustSession = await applyRustSessionDeleteReceipt({
+            requestedSessionId: sessionId,
+            activeSessionId,
+            isAgentOrgRoot: Boolean(session?.agentOrgId),
+            receipt,
+            cleanup: {
+              removeSession,
+              removeForkRelayEntry,
+              disposeWorkstationWorkspace,
+              clearPendingFileOpens: clearPendingFileOpensForSession,
+              clearPendingCodeEditorTab: clearPendingCodeEditorTabForSession,
+              evictEventStore: (deletedSessionId) =>
+                eventStoreProxy
+                  .evictSession(deletedSessionId)
+                  .catch((error) =>
+                    log.warn(
+                      "[WorkstationSidebar] Failed to evict deleted Agent Org session:",
+                      { deletedSessionId, error }
+                    )
+                  ),
+            },
+          });
         }
         removeSession(sessionId);
         removeForkRelayEntry(sessionId);
@@ -209,7 +234,7 @@ export function useWorkstationSidebarHandlers({
         clearPendingFileOpensForSession(sessionId);
         clearPendingCodeEditorTabForSession(sessionId);
 
-        if (sessionId === activeSessionId) {
+        if (sessionId === activeSessionId || deletedActiveRustSession) {
           goToNewSession();
         }
       } catch (error) {

--- a/tests/e2e/specs/core/agent-org-session-delete-ui.spec.mjs
+++ b/tests/e2e/specs/core/agent-org-session-delete-ui.spec.mjs
@@ -1,0 +1,241 @@
+/* global describe, before, it, browser, process */
+import { execFileSync } from "node:child_process";
+
+import {
+  RENDER_TIMEOUT_MS,
+  execJS,
+  invokeE2E,
+  openRenderedSidebarSession,
+  unwrap,
+  waitForApp,
+} from "../../support/core/agentOrgUiDriver.mjs";
+
+const E2E_BASE_URL = `http://127.0.0.1:${process.env.E2E_IDE_SERVER_PORT ?? "13847"}`;
+const RUN_ID = Date.now();
+
+async function postJson(pathname, body = {}, timeoutMs = 15_000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(`${E2E_BASE_URL}${pathname}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    const json = await response.json();
+    if (!response.ok || json?.ok !== true) {
+      throw new Error(`${pathname} failed: ${JSON.stringify(json)}`);
+    }
+    return json;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function seedHierarchy({
+  label,
+  rootStatus = "completed",
+  runStatus = "completed",
+  workerStatus = "completed",
+  nested = false,
+}) {
+  const rootSessionId = `sdeagent-e2e-delete-${label}-root-${RUN_ID}`;
+  const firstWorkerId = `sdeagent-e2e-delete-${label}-worker-a-${RUN_ID}`;
+  const secondWorkerId = `sdeagent-e2e-delete-${label}-worker-b-${RUN_ID}`;
+  const workers = [
+    {
+      session_id: firstWorkerId,
+      member_id: `${label}-worker-a`,
+      agent_definition_id: "builtin:sde",
+      status: workerStatus,
+    },
+  ];
+  if (nested) {
+    workers.push({
+      session_id: secondWorkerId,
+      parent_session_id: firstWorkerId,
+      member_id: `${label}-worker-b`,
+      agent_definition_id: "builtin:sde",
+      status: workerStatus,
+    });
+  }
+  const seeded = await postJson(
+    "/agent/test/agent-org/stale-workers/seed-run",
+    {
+      org_id: `e2e-delete-${label}-${RUN_ID}`,
+      coordinator_agent_id: "builtin:sde",
+      root_session_id: rootSessionId,
+      root_status: rootStatus,
+      run_status: runStatus,
+      workers,
+    }
+  );
+  return {
+    runId: seeded.org_run_id,
+    rootSessionId,
+    workerSessionIds: workers.map((worker) => worker.session_id),
+  };
+}
+
+async function refreshAndWaitForSidebarRow(sessionId) {
+  unwrap(
+    await invokeE2E("seedSidebarSession", {
+      sessionId,
+      name: `Agent Org delete ${sessionId}`,
+      status: "completed",
+    }),
+    `seedSidebarSession(${sessionId})`
+  );
+  const selector = `[data-testid="sidebar-session-item-${sessionId}"]`;
+  await browser.waitUntil(
+    async () =>
+      execJS(`return !!document.querySelector(${JSON.stringify(selector)});`),
+    {
+      timeout: RENDER_TIMEOUT_MS,
+      interval: 200,
+      timeoutMsg: `sidebar row ${sessionId} did not render`,
+    }
+  );
+}
+
+async function chooseDeleteFromRenderedSidebarMenu(sessionId) {
+  const rowSelector = `[data-testid="sidebar-session-item-${sessionId}"]`;
+  const moreSelector = `[data-testid="sidebar-session-more-${sessionId}"]`;
+  const row = await browser.$(rowSelector);
+  await row.moveTo();
+
+  let opened = false;
+  for (let attempt = 0; attempt < 2 && !opened; attempt += 1) {
+    await (await browser.$(moreSelector)).click();
+    opened = await browser
+      .waitUntil(
+        async () =>
+          execJS(
+            `return document.querySelector(${JSON.stringify(moreSelector)})?.getAttribute('aria-pressed') === 'true';`
+          ),
+        { timeout: 2_000, interval: 100 }
+      )
+      .catch(() => false);
+  }
+  if (!opened) {
+    throw new Error(`native sidebar menu did not open for ${sessionId}`);
+  }
+
+  // WebDriver key actions target the WebView rather than the macOS menu
+  // process. Native menus support type-to-select, so select the uniquely
+  // named Delete item and confirm it with real OS key events.
+  execFileSync("osascript", [
+    "-e",
+    'tell application "System Events" to keystroke "d"',
+    "-e",
+    'tell application "System Events" to key code 36',
+  ]);
+}
+
+async function persistenceSnapshot(sessionIds, runIds) {
+  return postJson("/agent/test/agent-org/session-delete/snapshot", {
+    session_ids: sessionIds,
+    run_ids: runIds,
+  });
+}
+
+async function deleteHierarchyAndAssertGone(hierarchy) {
+  await refreshAndWaitForSidebarRow(hierarchy.rootSessionId);
+  await openRenderedSidebarSession(hierarchy.rootSessionId);
+
+  await chooseDeleteFromRenderedSidebarMenu(hierarchy.rootSessionId);
+
+  const rootSelector = `[data-testid="sidebar-session-item-${hierarchy.rootSessionId}"]`;
+  await browser.waitUntil(
+    async () =>
+      execJS(
+        `return !document.querySelector(${JSON.stringify(rootSelector)});`
+      ),
+    {
+      timeout: RENDER_TIMEOUT_MS,
+      interval: 200,
+      timeoutMsg: "deleted Agent Org root remained in the sidebar",
+    }
+  );
+  const snapshot = await persistenceSnapshot(
+    [hierarchy.rootSessionId, ...hierarchy.workerSessionIds],
+    [hierarchy.runId]
+  );
+  for (const sessionId of [
+    hierarchy.rootSessionId,
+    ...hierarchy.workerSessionIds,
+  ]) {
+    if (snapshot.sessions[sessionId] !== false) {
+      throw new Error(
+        `deleted Rust session remained durable: ${sessionId} ${JSON.stringify(snapshot)}`
+      );
+    }
+  }
+  if (snapshot.runs[hierarchy.runId] !== false) {
+    throw new Error(
+      `deleted run remained durable: ${JSON.stringify(snapshot)}`
+    );
+  }
+}
+
+describe("Agent Org Rust session hierarchy deletion rendered UI", () => {
+  before(async () => {
+    await waitForApp();
+  });
+
+  it("deletes the completed root and all Rust workers through the real sidebar menu", async () => {
+    const hierarchy = await seedHierarchy({
+      label: "completed",
+      nested: true,
+    });
+    const unrelated = await seedHierarchy({
+      label: "unrelated",
+    });
+    await deleteHierarchyAndAssertGone(hierarchy);
+    const activeSessionId = unwrap(
+      await invokeE2E("getActiveSessionId"),
+      "getActiveSessionId after hierarchy delete"
+    ).sessionId;
+    if (activeSessionId === hierarchy.rootSessionId) {
+      throw new Error(
+        "deleting the active Agent Org root did not navigate once"
+      );
+    }
+
+    const snapshot = await persistenceSnapshot(
+      [unrelated.rootSessionId],
+      [unrelated.runId]
+    );
+    if (
+      snapshot.sessions[unrelated.rootSessionId] !== true ||
+      snapshot.runs[unrelated.runId] !== true
+    ) {
+      throw new Error(
+        `unrelated Agent Org was modified: ${JSON.stringify(snapshot)}`
+      );
+    }
+  });
+
+  it("stops a running run and deletes its Rust hierarchy through the real sidebar menu", async () => {
+    const hierarchy = await seedHierarchy({
+      label: "running",
+      rootStatus: "idle",
+      runStatus: "running",
+      workerStatus: "pending",
+      nested: true,
+    });
+    await deleteHierarchyAndAssertGone(hierarchy);
+  });
+
+  it("deletes a paused run and its Rust hierarchy through the real sidebar menu", async () => {
+    const hierarchy = await seedHierarchy({
+      label: "paused",
+      rootStatus: "paused",
+      runStatus: "paused",
+      workerStatus: "paused",
+      nested: true,
+    });
+    await deleteHierarchyAndAssertGone(hierarchy);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #556

Before this change, deleting an Agent Org session removed only the root/coordinator session. Its Rust worker sessions could remain in the database with a parent that no longer existed.

After this change, deleting the Agent Org root from the sidebar stops the active Rust run when needed, then removes the root, all Rust workers, and the run-owned coordination data together. The sidebar also removes every deleted session immediately.

## What changed

- Build the complete Rust worker hierarchy from `agent_sessions.parent_session_id` and delete it leaf-first.
- Allow running and paused Agent Org runs to be stopped and deleted through the same user action.
- Recheck the hierarchy and session states inside one SQLite transaction so the database cannot keep only half of the hierarchy.
- Fail without deleting anything when the structure is unsafe, including nested Agent Org roots, cycles, excessive depth/size, concurrent topology changes, or a runtime that does not stop in time.
- Evict the deleted sessions from the Rust runtime registry and EventStore retained state after the database commit.
- Return all deleted session IDs to the frontend so the sidebar clears the root and workers together and navigates only once.

## Scope

- Rust Agent Org sessions only.
- No `code_sessions` queries or CLI lifecycle/cleanup changes.
- No database migration and no automatic cleanup of historical orphan rows.
- Ordinary SDE/non-Agent Org deletion still uses the existing single-session path; only its successful result is wrapped in the new receipt shape.

## Known limitation

This PR stops the active Rust runtime and clears queued work before deletion, but it does not add a new global drain/tombstone protocol for every detached background writer. Hardening extremely late asynchronous writes can be handled separately without expanding #556.

## Verification

- `cargo test -p agent_core` — 3151 passed, 2 ignored
- `cargo test -p project_management` — 521 passed
- `cargo test -p agent_core session_hierarchy_delete` — 11 passed
- `cargo test -p agent_core direct_agent_org_turn_refuses_cancelled_delete_fence` — 1 passed
- `pnpm test` — 770 files, 6823 tests passed
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run check:circular` — no circular dependencies
- Isolated rendered Tauri E2E — 3 scenarios passed through the real sidebar menu: completed, running, and paused runs
- Changed Rust files passed `rustfmt --check`; changed frontend/E2E files passed Prettier
- `git diff --check`
- Husky pre-commit and commitlint hooks passed without bypass

## Repository baseline notes

- `cargo clippy --all-targets -- -D warnings` is currently blocked by six existing warnings in unchanged `orgtrack_core` and `project_management` files. Scoped Husky Clippy passed for `agent_core`, `org2`, and `project_management`, and no warning points to a #556 changed file.
- `cargo fmt --all -- --check` is currently blocked by existing formatting differences outside this PR. Every Rust file changed by #556 passes the format check.