### PR TITLE
fix(cloud): sign out locally when the refresh token is rejected

### DIFF
--- a/src/features/Org2Cloud/org2CloudAuthAtom.test.ts
+++ b/src/features/Org2Cloud/org2CloudAuthAtom.test.ts
@@ -8,6 +8,7 @@ import {
   ORG2_CLOUD_AUTH_STORAGE_KEY,
   type Org2CloudAuthState,
   Org2CloudAuthStateSchema,
+  clearRejectedAuth,
   commitRefreshedAuth,
   org2CloudAuthAtom,
 } from "./org2CloudAuthAtom";
@@ -183,6 +184,63 @@ describe("commitRefreshedAuth", () => {
   });
 });
 
+describe("clearRejectedAuth", () => {
+  it("clears the atom when the atom holds a DIFFERENT OBJECT with the same identity", () => {
+    // Regression for the zombie-signed-in bug: `atomWithStorage`'s onMount
+    // re-hydrates a freshly parsed object from localStorage on every mount
+    // (see the module doc comment), so the atom's live value is routinely
+    // NOT `===` a `current` snapshot captured just beforehand even though
+    // it is the exact same session. Rebuild that with a spread copy rather
+    // than reusing the VALID_STATE reference.
+    const store = createStore();
+    const rehydrated: Org2CloudAuthState = { ...VALID_STATE };
+    expect(rehydrated).not.toBe(VALID_STATE);
+    store.set(org2CloudAuthAtom, rehydrated);
+
+    expect(clearRejectedAuth(boundSetter(store), VALID_STATE)).toBe(true);
+
+    expect(store.get(org2CloudAuthAtom)).toBeNull();
+  });
+
+  it("is a no-op when already signed out", () => {
+    const store = createStore();
+    store.set(org2CloudAuthAtom, null);
+
+    expect(clearRejectedAuth(boundSetter(store), VALID_STATE)).toBe(false);
+
+    expect(store.get(org2CloudAuthAtom)).toBeNull();
+  });
+
+  it("does NOT clear a newer sign-in by a different user (CAS)", () => {
+    const store = createStore();
+    const newerLogin: Org2CloudAuthState = {
+      ...VALID_STATE,
+      userId: "user-2",
+      refreshToken: "rt-other",
+    };
+    store.set(org2CloudAuthAtom, newerLogin);
+
+    expect(clearRejectedAuth(boundSetter(store), VALID_STATE)).toBe(false);
+
+    expect(store.get(org2CloudAuthAtom)).toBe(newerLogin);
+  });
+
+  it("does NOT clear a session already rotated by a concurrent successful refresh (CAS)", () => {
+    const store = createStore();
+    const rotated: Org2CloudAuthState = {
+      ...VALID_STATE,
+      accessToken: "at-2",
+      refreshToken: "rt-2",
+    };
+    store.set(org2CloudAuthAtom, rotated);
+
+    // The rejection carries the STALE (pre-rotation) refresh token.
+    expect(clearRejectedAuth(boundSetter(store), VALID_STATE)).toBe(false);
+
+    expect(store.get(org2CloudAuthAtom)).toBe(rotated);
+  });
+});
+
 // The four @agent-adjacent callers (MoveToOrgDialog, useWorkstationSidebarHandlers,
 // useForkImportedSession, CreateCollabOrgView) all rotate the single-use refresh
 // token via ensureFreshSession, then MUST write it back through commitRefreshedAuth.
@@ -269,5 +327,99 @@ describe("caller commit discipline (ensureFreshSession + commitRefreshedAuth)", 
     expect(fresh?.refreshToken).toBe("rt-2");
 
     expect(store.get(org2CloudAuthAtom)?.refreshToken).toBe("rt");
+  });
+});
+
+// `useOrg2CloudOrgs` (org2CloudOrgsAtom.ts) wires `ensureFreshSession`'s
+// `onRefreshRejected` straight to `clearRejectedAuth`. This exercises that
+// exact composition against a live (mocked) GoTrue response, matching the
+// bug report: a 400 `invalid_grant` from the refresh endpoint.
+describe("signing out locally on a rejected refresh (ensureFreshSession + clearRejectedAuth)", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    fetchMock.mockReset();
+  });
+
+  function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  /** The `useOrg2CloudOrgs` onRefreshRejected composition under test. */
+  async function attemptRefresh(
+    store: ReturnType<typeof createStore>,
+    current: Org2CloudAuthState
+  ): Promise<{ fresh: Org2CloudAuthState | null; cleared: boolean }> {
+    let cleared = false;
+    const fresh = await ensureFreshSession(current, {
+      onRefreshRejected: () => {
+        cleared = clearRejectedAuth(boundSetter(store), current);
+      },
+    });
+    return { fresh, cleared };
+  }
+
+  it("(a) a 400 invalid_grant rejection clears the atom, flipping the UI signed-out", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ error: "invalid_grant" }, 400)
+    );
+    const store = createStore();
+    // A freshly re-hydrated object (see clearRejectedAuth's doc comment) —
+    // NOT the same reference the earlier reference-equality guard needed.
+    const rehydrated: Org2CloudAuthState = { ...VALID_STATE };
+    store.set(org2CloudAuthAtom, rehydrated);
+
+    const { fresh, cleared } = await attemptRefresh(store, VALID_STATE);
+
+    expect(fresh).toBeNull();
+    expect(cleared).toBe(true);
+    // TeamRuntimePanel/sidebar phase derivation keys off `!auth` — this is
+    // the same condition that flips the UI to its signed-out affordances.
+    expect(store.get(org2CloudAuthAtom)).toBeNull();
+  });
+
+  it("(b) a network error retains auth (transient failures stay on the retry path)", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("offline"));
+    const store = createStore();
+    const rehydrated: Org2CloudAuthState = { ...VALID_STATE };
+    store.set(org2CloudAuthAtom, rehydrated);
+
+    const { fresh, cleared } = await attemptRefresh(store, VALID_STATE);
+
+    expect(fresh).toBeNull();
+    expect(cleared).toBe(false);
+    expect(store.get(org2CloudAuthAtom)).toBe(rehydrated);
+  });
+
+  it("(c) a rejection arriving after a newer login leaves the newer session untouched", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ error: "invalid_grant" }, 400)
+    );
+    const store = createStore();
+    store.set(org2CloudAuthAtom, VALID_STATE);
+
+    const refreshPromise = attemptRefresh(store, VALID_STATE);
+    // A newer sign-in (different user + tokens) lands while the stale
+    // refresh for VALID_STATE is still in flight.
+    const newerLogin: Org2CloudAuthState = {
+      ...VALID_STATE,
+      userId: "user-2",
+      accessToken: "at-newer",
+      refreshToken: "rt-newer",
+    };
+    store.set(org2CloudAuthAtom, newerLogin);
+
+    const { cleared } = await refreshPromise;
+
+    expect(cleared).toBe(false);
+    expect(store.get(org2CloudAuthAtom)).toBe(newerLogin);
   });
 });

--- a/src/features/Org2Cloud/org2CloudAuthAtom.ts
+++ b/src/features/Org2Cloud/org2CloudAuthAtom.ts
@@ -133,3 +133,46 @@ export function commitRefreshedAuth(
   });
   return committed;
 }
+
+/**
+ * Sign the user out locally after GoTrue DEFINITIVELY rejects a refresh
+ * credential (400/401 `invalid_grant` — never a transient network/timeout
+ * failure, see `ensureFreshSession`'s `onRefreshRejected`). Guarded by a
+ * compare-and-set, but deliberately on STABLE IDENTITY (`userId` +
+ * `refreshToken`) rather than object reference.
+ *
+ * Reference equality is NOT safe here: `org2CloudAuthAtom` is an
+ * `atomWithStorage` with `{ getOnInit: true }`, whose `onMount` re-reads
+ * `storage.getItem(...)` and calls `setAtom(...)` on every mount (jotai's
+ * `atomWithStorage` idiom — see `node_modules/jotai/.../utils.mjs`). Because
+ * `createZodJsonStorage`'s `getItem` runs `JSON.parse` + `schema.parse` on
+ * every call, it returns a BRAND-NEW object each time even when the
+ * persisted bytes are byte-for-byte unchanged. A `current` snapshot
+ * captured just before that re-hydration settles is therefore never
+ * `===` the atom's live value again, even though it is the exact same
+ * session — so a reference-equality CAS silently never fires and the
+ * rejected session is never cleared (the reported zombie-signed-in bug).
+ * Comparing `userId`/`refreshToken` survives that re-hydration while still
+ * refusing to clobber a newer sign-in or a concurrently rotated token
+ * (different `userId` and/or `refreshToken`).
+ */
+export function clearRejectedAuth(
+  setAuth: (
+    updater: (prev: Org2CloudAuthState | null) => Org2CloudAuthState | null
+  ) => void,
+  rejected: Org2CloudAuthState
+): boolean {
+  let cleared = false;
+  setAuth((current) => {
+    if (
+      !current ||
+      current.userId !== rejected.userId ||
+      current.refreshToken !== rejected.refreshToken
+    ) {
+      return current;
+    }
+    cleared = true;
+    return null;
+  });
+  return cleared;
+}

--- a/src/features/Org2Cloud/org2CloudOrgsAtom.ts
+++ b/src/features/Org2Cloud/org2CloudOrgsAtom.ts
@@ -19,6 +19,7 @@ import { createLogger } from "@src/hooks/logger";
 import { enrichOrg2CloudProfile } from "./completeSignIn";
 import type { OrgRuntimeTelemetry } from "./memberRuntime/types";
 import {
+  clearRejectedAuth,
   commitRefreshedAuth,
   org2CloudAuthAtom,
   org2CloudAuthIdentityKey,
@@ -270,10 +271,21 @@ export function useOrg2CloudOrgs(): void {
       const fresh = await ensureFreshSession(current, {
         onRefreshRejected: () => {
           refreshRejected = true;
-          // Compare-and-set: never sign out a newer OAuth callback or a
-          // concurrently refreshed token chain because an older request
-          // finished late.
-          setAuth((latest) => (latest === current ? null : latest));
+          // Stable-identity compare-and-set: never sign out a newer OAuth
+          // callback or a concurrently refreshed token chain because an
+          // older request finished late. This must NOT compare by object
+          // reference — `org2CloudAuthAtom`'s `atomWithStorage` re-hydrates
+          // a freshly parsed (but content-identical) object from
+          // localStorage on every mount, so a reference captured here can
+          // legitimately diverge from the atom's live value for the exact
+          // same session. See `clearRejectedAuth` for the full explanation.
+          if (clearRejectedAuth(setAuth, current)) {
+            log.rateLimited(
+              "cloud-session-expired",
+              60_000,
+              "cloud session expired; signed out locally"
+            );
+          }
         },
       });
       if (cancelled || !isCurrentOrg2CloudOrgsRequest(store, requestEpoch)) {


### PR DESCRIPTION
## Root cause

Live evidence: `[Org2CloudClient] token refresh failed with status 400` followed by `[Org2CloudOrgs] cloud org fetch skipped: token refresh failed`, repeating on every launch, with `orgii:org2-cloud-v1:auth` never cleared from localStorage.

Checked all three candidate paths named in the investigation:

- **(a) Status classification** — `src/features/Org2Cloud/org2CloudClient.ts:422-428`, `refreshSessionAttempt` already classifies the refresh outcome correctly: `permanentlyRejected: response.status === 400 || response.status === 401`. `ensureFreshSession` (`org2CloudClient.ts:487-489`) calls `options?.onRefreshRejected?.()` exactly when `permanentlyRejected` is true. Verified this is not the bug — confirmed by the existing `ensureFreshSession` test "reports only a credential rejection as a permanent auth failure" (`org2CloudClient.test.ts:180-194`), which already passes.
- **(c) Callback wiring** — `src/features/Org2Cloud/org2CloudOrgsAtom.ts:270-278` (pre-fix), `useOrg2CloudOrgs`'s `runAttempt` does pass `onRefreshRejected` to `ensureFreshSession`, and the callback does run. Not the bug either.
- **(b) Object-identity guard — this is it.** The callback cleared auth with `setAuth((latest) => (latest === current ? null : latest))`. `org2CloudAuthAtom` (`org2CloudAuthAtom.ts:102-107`) is `atomWithStorage(..., { getOnInit: true })`. Per jotai's `atomWithStorage` (`node_modules/jotai/esm/vanilla/utils.mjs`), `baseAtom.onMount` calls `setAtom(storage.getItem(key, initialValue))` on every mount — and `createZodJsonStorage.getItem` (`src/util/core/storage/zodStorage.ts:27-40`) runs `JSON.parse` + `schema.parse` fresh every call, which allocates a **new object** even when the persisted bytes are byte-for-byte unchanged. So shortly after the app mounts, the atom's live value is replaced by a content-identical-but-reference-different object. `useOrg2CloudOrgs`'s `runAttempt` captures `current = authRef.current` before that replacement settles; by the time the async refresh rejection resolves, `current !== latest` even though it's the same session — the CAS silently no-ops and auth is never cleared.

## Fix

`src/features/Org2Cloud/org2CloudAuthAtom.ts`: added `clearRejectedAuth(setAuth, rejected)`, a compare-and-set guarded by **stable identity** (`userId` + `refreshToken` equality) instead of object reference — survives the re-hydration replacement while still refusing to clear a session that has since been rotated by a concurrent successful refresh or replaced by a newer sign-in (different `userId`/`refreshToken`).

`src/features/Org2Cloud/org2CloudOrgsAtom.ts`: `useOrg2CloudOrgs`'s `onRefreshRejected` now calls `clearRejectedAuth` instead of the reference-equality CAS, and logs a rate-limited (`60s`) INFO line `"cloud session expired; signed out locally"` when it actually clears. Transient failures (network/timeout) are untouched — `ensureFreshSession` still only invokes `onRefreshRejected` for a definitive 400/401, so the existing bounded-retry path (`RETRY_DELAYS_MS`) is unaffected.

Once `org2CloudAuthAtom` is `null`, the UI's existing signed-out affordances take over on their own — no new phase logic needed. `useTeamRuntimeRoster` (`src/modules/shared/dataSource/useTeamRuntimeRoster.ts:252-254`) already derives `phase = "signedOut"` purely from `!auth`, and its own doc comment (`useTeamRuntimeRoster.ts:79-87`) describes this exact bug as the reason a stall-detector had to be bolted on — that workaround is no longer the only backstop once the atom actually clears.

## Tests

`src/features/Org2Cloud/org2CloudAuthAtom.test.ts`:
- `clearRejectedAuth`: clears when the atom holds a *different object* with the same identity (simulates the re-hydration race); no-ops when already signed out; does NOT clear a newer sign-in by a different user; does NOT clear a session already rotated by a concurrent successful refresh.
- `signing out locally on a rejected refresh (ensureFreshSession + clearRejectedAuth)` — exercises the exact `useOrg2CloudOrgs` composition against a mocked GoTrue response:
  - (a) 400 `invalid_grant` clears the atom.
  - (b) network error leaves auth retained (`onRefreshRejected` never fires, matching the existing retry path).
  - (c) a 400 rejection resolving after a newer login has replaced the atom leaves the newer session untouched.

## Gates

- `npx vitest run` on touched files + full `src/features/Org2Cloud`: 87 files / 925 tests passed.
- `npx tsc --noEmit`: clean.
- `npx eslint --fix` on changed files: clean, no changes needed beyond what was already written.
