### PR TITLE
fix(runtime): show team RAM as approximate whole gigabytes

### DIFF
--- a/src/features/Org2Cloud/memberRuntime/memberRuntimePayload.ts
+++ b/src/features/Org2Cloud/memberRuntime/memberRuntimePayload.ts
@@ -11,6 +11,7 @@ import type { ExternalCliSourceProbe } from "@src/api/tauri/externalHistory/dete
 import {
   detectLocalModelHardware,
   getSystemInfo,
+  getSystemMemory,
   systemRuntimeSnapshot,
 } from "@src/api/tauri/perf/metrics";
 import type {
@@ -47,6 +48,7 @@ async function composeMemberRuntimeMachine(): Promise<MemberRuntimeMachine> {
       systemInfo = null;
     }
   }
+  const totalRamGb = await resolveTotalRamGb(hardware);
   return {
     deviceId: identity.deviceId,
     machineLabel: identity.machineLabel,
@@ -57,9 +59,7 @@ async function composeMemberRuntimeMachine(): Promise<MemberRuntimeMachine> {
     ...(hardware && hardware.cpu_cores > 0
       ? { cpuCores: hardware.cpu_cores }
       : {}),
-    ...(hardware && hardware.total_ram_gb > 0
-      ? { totalRamGb: hardware.total_ram_gb }
-      : {}),
+    ...(totalRamGb > 0 ? { totalRamGb } : {}),
     ...(hardware?.gpu_name ? { gpuName: hardware.gpu_name } : {}),
     ...(hardware?.gpu_vram_gb != null
       ? { gpuVramGb: hardware.gpu_vram_gb }
@@ -67,6 +67,23 @@ async function composeMemberRuntimeMachine(): Promise<MemberRuntimeMachine> {
     ...(hardware ? { unifiedMemory: hardware.unified_memory } : {}),
     appVersion,
   };
+}
+
+/** Approximate whole-GB RAM size ("32", never "31.6"): rounded hardware
+ * figure, falling back to the cheap cached sysinfo total when hardware
+ * detection degraded. 0 = unknown (field omitted). */
+async function resolveTotalRamGb(
+  hardware: LocalModelHardwareSummary | null
+): Promise<number> {
+  if (hardware && hardware.total_ram_gb > 0) {
+    return Math.round(hardware.total_ram_gb);
+  }
+  try {
+    const memory = await getSystemMemory();
+    return memory.total_mb > 0 ? Math.round(memory.total_mb / 1024) : 0;
+  } catch {
+    return 0;
+  }
 }
 
 let cachedMachine: Promise<MemberRuntimeMachine> | null = null;

--- a/src/features/Org2Cloud/memberRuntime/types.ts
+++ b/src/features/Org2Cloud/memberRuntime/types.ts
@@ -78,6 +78,7 @@ export interface MemberRuntimeMachine {
   chipType: string;
   cpuName?: string;
   cpuCores?: number;
+  /** Approximate whole GB (rounded at collection — "32", never "31.6"). */
   totalRamGb?: number;
   gpuName?: string;
   gpuVramGb?: number;

--- a/src/modules/shared/dataSource/TeamMemberDetail.tsx
+++ b/src/modules/shared/dataSource/TeamMemberDetail.tsx
@@ -381,7 +381,7 @@ export default function TeamMemberDetail({
                 {machine.totalRamGb ? (
                   <SectionRow label={t("detail.memory")}>
                     <span className="text-xs text-text-2">
-                      {machine.totalRamGb} GB
+                      {Math.round(machine.totalRamGb)} GB
                       {machine.unifiedMemory ? ` · ${t("detail.unified")}` : ""}
                     </span>
                   </SectionRow>

--- a/src/modules/shared/dataSource/TeamRuntimePanel.test.ts
+++ b/src/modules/shared/dataSource/TeamRuntimePanel.test.ts
@@ -566,7 +566,7 @@ describe("TeamRuntimePanel roster", () => {
     expect(card?.textContent).toContain("Swarm Founder");
     // CPU% and RAM used-of-total (GPU absent: no name, null percent).
     expect(card?.textContent).toContain("card.cpu 42%");
-    expect(card?.textContent).toContain("card.ram 12.5/32 GB");
+    expect(card?.textContent).toContain("card.ram 13/32 GB");
     // Known id → icon; unknown id → raw id; not_detected → hidden.
     expect(
       card?.querySelector('[data-testid="model-icon-claude"]')

--- a/src/modules/shared/dataSource/teamRuntimeData.ts
+++ b/src/modules/shared/dataSource/teamRuntimeData.ts
@@ -339,8 +339,11 @@ export function isInstalledAgentPresent(agent: MemberInstalledAgent): boolean {
 // Machine chips
 // ---------------------------------------------------------------------------
 
-/** Megabytes → gigabytes with at most one decimal (`24576` → `"24"`). */
+/** Megabytes → approximate whole gigabytes (`12800` → `"13"`, `32768` →
+ * `"32"`) — the roster deliberately shows "13/32 GB", never "12.5/31.6".
+ * Non-zero inputs floor at "1" so a lightly-loaded machine doesn't read as
+ * using nothing. */
 export function formatMemGb(mb: number): string {
   if (!Number.isFinite(mb) || mb <= 0) return "0";
-  return String(Number((mb / 1024).toFixed(1)));
+  return String(Math.max(1, Math.round(mb / 1024)));
 }


### PR DESCRIPTION
## Summary

- **Live CPU/RAM sampling stays** — it's how teammates see whether a device is busy. This PR only changes presentation and collection rounding (follow-up to the reverted removal attempt in #579).
- Roster RAM chips render approximate whole numbers: `RAM 13/32 GB`, never `12.5/31.6` (non-zero usage floors at 1 GB so a lightly-loaded machine doesn't read as using nothing).
- `machine.totalRamGb` is rounded at collection (31.6 → 32), with a cheap cached-sysinfo fallback when `detectLocalModelHardware` degrades (previously the field was simply omitted); the drilldown memory row rounds as well for data pushed by older builds.

## Test plan

- `tsc --noEmit` clean; 85/85 tests across the touched suites (panel assertion updated to `13/32 GB`); pre-commit hook passed.

## Submit checklist

- [x] The PR is focused and has a scoped Conventional Commits title, such as `feat(scope): summary` or `fix(scope): summary`.
- [x] I ran the relevant checks, or explained why they were not run.
- [x] No secrets, private config, generated output, or unrelated formatting changes are included.
- [x] Docs, screenshots, and locale updates are included when the change needs them.