### PR TITLE
feat(kanban): card right-click menu — floating pane / new tab pane

### DIFF
--- a/src/features/KanbanBoard/components/KanbanColumn/index.tsx
+++ b/src/features/KanbanBoard/components/KanbanColumn/index.tsx
@@ -67,6 +67,7 @@ export interface KanbanColumnProps {
   column: KanbanColumnConfig;
   tasks: KanbanTask[];
   onTaskClick?: (task: KanbanTask) => void;
+  onTaskContextMenu?: (task: KanbanTask, event: React.MouseEvent) => void;
   onAddTask?: (status: string) => void;
   isDragging?: boolean;
   showAddButton?: boolean;
@@ -86,6 +87,7 @@ const KanbanColumn: React.FC<KanbanColumnProps> = ({
   column,
   tasks,
   onTaskClick,
+  onTaskContextMenu,
   onAddTask,
   isDragging,
   showAddButton = true,
@@ -290,6 +292,7 @@ const KanbanColumn: React.FC<KanbanColumnProps> = ({
               tasks={renderedTasks}
               scrollElementRef={bodyRef}
               onTaskClick={onTaskClick}
+              onTaskContextMenu={onTaskContextMenu}
               dropIndicator={dropIndicator}
               columnColor={column.color}
               allowTaskDrag={allowTaskDrag}
@@ -341,6 +344,7 @@ interface ColumnTaskListProps {
   /** The scrollable column body — used as the virtualizer's scroll element. */
   scrollElementRef: React.MutableRefObject<HTMLDivElement | null>;
   onTaskClick?: (task: KanbanTask) => void;
+  onTaskContextMenu?: (task: KanbanTask, event: React.MouseEvent) => void;
   dropIndicator?: DropIndicatorState | null;
   columnColor: string;
   allowTaskDrag: boolean;
@@ -362,6 +366,7 @@ const ColumnTaskList: React.FC<ColumnTaskListProps> = ({
   tasks,
   scrollElementRef,
   onTaskClick,
+  onTaskContextMenu,
   dropIndicator,
   columnColor,
   allowTaskDrag,
@@ -376,6 +381,9 @@ const ColumnTaskList: React.FC<ColumnTaskListProps> = ({
         key={task.id}
         task={task}
         onTaskClick={task.canOpen === false ? undefined : onTaskClick}
+        onTaskContextMenu={
+          task.canOpen === false ? undefined : onTaskContextMenu
+        }
         showIndicatorBefore={dropIndicator?.beforeTaskId === task.id}
         indicatorColor={columnColor}
         allowDrag={allowTaskDrag && task.canMove !== false}
@@ -390,6 +398,7 @@ const ColumnTaskList: React.FC<ColumnTaskListProps> = ({
       columnColor,
       dropIndicator?.beforeTaskId,
       onTaskClick,
+      onTaskContextMenu,
       scaleDragTransform,
       selectedTaskId,
       useDragOverlay,
@@ -508,6 +517,7 @@ const VirtualTaskList: React.FC<VirtualTaskListProps> = ({
 interface SortableTaskCardProps {
   task: KanbanTask;
   onTaskClick?: (task: KanbanTask) => void;
+  onTaskContextMenu?: (task: KanbanTask, event: React.MouseEvent) => void;
   showIndicatorBefore?: boolean;
   indicatorColor?: string;
   allowDrag?: boolean;
@@ -525,6 +535,7 @@ interface SortableTaskCardProps {
 const SortableTaskCard: React.FC<SortableTaskCardProps> = ({
   task,
   onTaskClick,
+  onTaskContextMenu,
   showIndicatorBefore,
   indicatorColor = "var(--color-primary-6)",
   allowDrag = true,
@@ -579,6 +590,7 @@ const SortableTaskCard: React.FC<SortableTaskCardProps> = ({
         <TaskCard
           task={task}
           onClick={onTaskClick}
+          onContextMenu={onTaskContextMenu}
           isDragging={isDragging}
           isSelected={isSelected}
         />

--- a/src/features/KanbanBoard/components/TaskCard/index.tsx
+++ b/src/features/KanbanBoard/components/TaskCard/index.tsx
@@ -21,6 +21,12 @@ import { formatTaskCardLastUpdated } from "./taskCardTime";
 export interface TaskCardProps {
   task: KanbanTask;
   onClick?: (task: KanbanTask) => void;
+  /**
+   * Right-click (secondary click) on the card. Consumers that pass this own
+   * the menu — including suppressing the WebView default — so the card only
+   * forwards the event.
+   */
+  onContextMenu?: (task: KanbanTask, event: React.MouseEvent) => void;
   isDragging?: boolean;
   /**
    * True when this card backs the currently-open session preview. Adds
@@ -47,12 +53,17 @@ function renderAgentIcon(task: KanbanTask) {
 const TaskCard: React.FC<TaskCardProps> = ({
   task,
   onClick,
+  onContextMenu,
   isDragging,
   isSelected = false,
 }) => {
   const handleClick = () => {
     onClick?.(task);
   };
+
+  const handleContextMenu = onContextMenu
+    ? (event: React.MouseEvent) => onContextMenu(task, event)
+    : undefined;
 
   const isInteractive = Boolean(onClick);
   const updatedAt = task.updated_at ?? task.completed_at ?? task.created_at;
@@ -73,6 +84,7 @@ const TaskCard: React.FC<TaskCardProps> = ({
       className={cardClasses}
       data-testid={`kanban-task-card-${task.id}`}
       onClick={handleClick}
+      onContextMenu={handleContextMenu}
     >
       {/* Owning Agent Team (only set on the global Kanban board) */}
       {task.orgName && (

--- a/src/features/KanbanBoard/index.tsx
+++ b/src/features/KanbanBoard/index.tsx
@@ -110,6 +110,12 @@ export interface KanbanBoardProps {
   ) => void;
   /** Callback when a task is clicked */
   onTaskClick?: (task: KanbanTask) => void;
+  /**
+   * Callback when a task is secondary-clicked (right-click / two-finger tap).
+   * The consumer owns the menu and is responsible for suppressing the WebView
+   * default menu. Cards with `canOpen === false` never receive it.
+   */
+  onTaskContextMenu?: (task: KanbanTask, event: React.MouseEvent) => void;
   /** Callback when add task button is clicked */
   onAddTask?: (status: TaskStatus) => void;
   /** Callback when column order changes */
@@ -142,6 +148,7 @@ const KanbanBoard: React.FC<KanbanBoardProps> = ({
   showAddButton = true,
   onTaskMove,
   onTaskClick,
+  onTaskContextMenu,
   onAddTask,
   onColumnOrderChange,
   selectedTaskId,
@@ -452,6 +459,7 @@ const KanbanBoard: React.FC<KanbanBoardProps> = ({
                   column={column}
                   tasks={groupedTasks.get(column.id) || []}
                   onTaskClick={onTaskClick}
+                  onTaskContextMenu={onTaskContextMenu}
                   onAddTask={handleAddTask}
                   isDragging={activeType === "column" && activeId === column.id}
                   showAddButton={column.showAddButton ?? showAddButton}

--- a/src/features/TaskKanban/TEST_CASES.md
+++ b/src/features/TaskKanban/TEST_CASES.md
@@ -88,3 +88,16 @@ Manual acceptance: use a column with at least 60 tasks, confirm the initial scro
 | Click a metadata-only teammate card             | Nothing opens (no published events to replay)                                     | `TaskKanban` `canOpen` guard; `cloudRemoteToKanbanTask.test.ts` |
 
 Manual acceptance: open **Work Management → Kanban** with an organization selected, click a teammate's session card, and confirm the floating preview window opens over the board (Work Management stays mounted, so the import is not aborted) and fills with the replayed transcript. Close it and confirm the board selection resets.
+
+## Card secondary-click menu
+
+| Case                                         | Expected result                                                                           | Coverage                                                            |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Right-click a local session card             | A native menu offers **Open as Floating Pane** and **Open in New Tab**                    | `cardContextMenu.test.ts`                                           |
+| Choose **Open as Floating Pane**             | Same result as a primary click — the board's floating preview opens over the board        | `TaskKanban` reuses `handleTaskClick` for the action                |
+| Choose **Open in New Tab**                   | The session opens (or focuses) its own Chat Pane tab; the Kanban tab stays open           | `openOrFocusSessionInChatPanelTabAtom`; `chatPanelTabsAtom.test.ts` |
+| Right-click a replayable teammate cloud card | Only the floating action is offered — a Chat Pane tab would abort the board-hosted import | `cardContextMenu.test.ts`                                           |
+| Right-click a card with no local session     | Only the floating action is offered                                                       | `cardContextMenu.test.ts`                                           |
+| Right-click a card that cannot be opened     | No ORGII menu is shown                                                                    | `cardContextMenu.test.ts`; `KanbanColumn` `canOpen` guard           |
+
+Manual acceptance: open **Work Management → Kanban**, right-click a session card and confirm the ORGII menu replaces the WebView's Reload / Inspect Element menu. Pick **Open in New Tab** and confirm a new Chat Pane pill appears with that session while the Kanban pill stays open; right-click another card, pick **Open as Floating Pane**, and confirm the draggable preview opens over the board.

--- a/src/features/TaskKanban/components/TaskKanbanContent/index.tsx
+++ b/src/features/TaskKanban/components/TaskKanbanContent/index.tsx
@@ -28,6 +28,8 @@ export interface TaskKanbanContentProps {
   calendarDate: Date;
   onTaskMove: (taskId: string, newStatus: TaskStatus) => void;
   onTaskClick: (task: KanbanTask) => void;
+  /** Card secondary-click. Board view only — List/Diary rows keep the default. */
+  onTaskContextMenu?: (task: KanbanTask, event: React.MouseEvent) => void;
   onAddTask: () => void;
   renderListRowAction?: (task: KanbanTask) => React.ReactNode;
   hasFileSearchQuery: boolean;
@@ -44,6 +46,7 @@ const TaskKanbanContent: React.FC<TaskKanbanContentProps> = ({
   calendarDate,
   onTaskMove,
   onTaskClick,
+  onTaskContextMenu,
   onAddTask,
   renderListRowAction,
   hasFileSearchQuery,
@@ -99,6 +102,7 @@ const TaskKanbanContent: React.FC<TaskKanbanContentProps> = ({
           columns={visibleColumns as unknown as KanbanColumnConfig[]}
           onTaskMove={onTaskMove}
           onTaskClick={onTaskClick}
+          onTaskContextMenu={onTaskContextMenu}
           onAddTask={onAddTask}
           allowColumnReorder={false}
           allowTaskDrag

--- a/src/features/TaskKanban/hooks/useKanbanCardContextMenu.ts
+++ b/src/features/TaskKanban/hooks/useKanbanCardContextMenu.ts
@@ -1,0 +1,105 @@
+/**
+ * Native secondary-click menu for Kanban cards.
+ *
+ * Mirrors the sidebar's session row menu (`useWorkstationSidebarContextMenu`):
+ * a Tauri menu popped at the cursor, so a right-click on a card offers the two
+ * open surfaces instead of the WebView's default Reload / Inspect menu.
+ */
+import { MenuItem, Menu as TauriMenu } from "@tauri-apps/api/menu";
+import { useSetAtom } from "jotai";
+import { type MouseEvent, useCallback } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { KanbanTask } from "@src/features/KanbanBoard";
+import { createLogger } from "@src/hooks/logger";
+import { openOrFocusSessionInChatPanelTabAtom } from "@src/store/chatPanel/chatPanelTabsAtom";
+import { activeStationChatVisibleAtom } from "@src/store/ui/chatPanelAtom";
+
+import {
+  KANBAN_CARD_CONTEXT_ACTION,
+  planKanbanCardContextMenu,
+} from "../utils/cardContextMenu";
+
+const log = createLogger("TaskKanban");
+
+export interface UseKanbanCardContextMenuParams {
+  /**
+   * Open the board's floating preview — the same action the primary click
+   * performs, including the team-session replay import it may have to start.
+   */
+  onOpenFloatingPane: (task: KanbanTask) => void;
+  /** Teammate cloud cards keyed by task id, as projected by `useKanbanTasks`. */
+  remoteSessionsByTaskId: ReadonlyMap<string, unknown>;
+}
+
+export function useKanbanCardContextMenu({
+  onOpenFloatingPane,
+  remoteSessionsByTaskId,
+}: UseKanbanCardContextMenuParams): (
+  task: KanbanTask,
+  event: MouseEvent
+) => void {
+  const { t } = useTranslation("sessions");
+  const { t: tCommon } = useTranslation("common");
+  const openSessionTab = useSetAtom(openOrFocusSessionInChatPanelTabAtom);
+  const setStationChatVisible = useSetAtom(activeStationChatVisibleAtom);
+
+  const openInNewTabPane = useCallback(
+    (sessionId: string, sessionName: string) => {
+      // The board also runs inside a WorkStation tab, where the chat pane can
+      // be collapsed — reveal it so the new pill is actually visible.
+      setStationChatVisible("my-station", true);
+      openSessionTab({ sessionId, sessionName });
+    },
+    [openSessionTab, setStationChatVisible]
+  );
+
+  const showMenu = useCallback(
+    async (task: KanbanTask): Promise<void> => {
+      const { actions, sessionId } = planKanbanCardContextMenu({
+        task,
+        isRemoteTeamCard: remoteSessionsByTaskId.has(task.id),
+      });
+      if (actions.length === 0) return;
+
+      const items: MenuItem[] = [];
+      for (const action of actions) {
+        if (action === KANBAN_CARD_CONTEXT_ACTION.OpenFloatingPane) {
+          items.push(
+            await MenuItem.new({
+              text: t("kanban.card.openAsFloatingPane"),
+              action: () => onOpenFloatingPane(task),
+            })
+          );
+          continue;
+        }
+        if (!sessionId) continue;
+        items.push(
+          await MenuItem.new({
+            text: tCommon("actions.openInNewTab"),
+            action: () => openInNewTabPane(sessionId, task.title),
+          })
+        );
+      }
+
+      const menu = await TauriMenu.new({ items });
+      await menu.popup();
+    },
+    [onOpenFloatingPane, openInNewTabPane, remoteSessionsByTaskId, t, tCommon]
+  );
+
+  return useCallback(
+    (task: KanbanTask, event: MouseEvent) => {
+      // Suppress the WebView menu even when the popup fails — a card that
+      // sometimes answers with Reload / Inspect Element reads as a bug.
+      event.preventDefault();
+      event.stopPropagation();
+      void showMenu(task).catch((error) => {
+        log.error("Failed to show Kanban card context menu:", error);
+      });
+    },
+    [showMenu]
+  );
+}
+
+export default useKanbanCardContextMenu;

--- a/src/features/TaskKanban/index.tsx
+++ b/src/features/TaskKanban/index.tsx
@@ -56,6 +56,7 @@ import {
   DEFAULT_KANBAN_TIME_FILTER,
   type KanbanTimeFilter,
 } from "./config";
+import { useKanbanCardContextMenu } from "./hooks/useKanbanCardContextMenu";
 import { useKanbanTasks } from "./hooks/useKanbanTasks";
 import { useTaskKanbanFilters } from "./hooks/useTaskKanbanFilters";
 import { useTaskKanbanHeader } from "./hooks/useTaskKanbanHeader";
@@ -263,6 +264,13 @@ const Kanban: React.FC<TaskKanbanProps> = ({
     ]
   );
 
+  // Secondary click offers the same target in either surface: the board's
+  // floating preview (what the primary click does) or its own Chat Pane tab.
+  const handleTaskContextMenu = useKanbanCardContextMenu({
+    onOpenFloatingPane: handleTaskClick,
+    remoteSessionsByTaskId,
+  });
+
   const handleCloseDetailPanel = useCallback(() => {
     setDetailPanelVisible(false);
     setSelectedTaskId(null);
@@ -375,6 +383,7 @@ const Kanban: React.FC<TaskKanbanProps> = ({
           calendarDate={calendarDate}
           onTaskMove={handleTaskMove}
           onTaskClick={handleTaskClick}
+          onTaskContextMenu={handleTaskContextMenu}
           onAddTask={handleAddTask}
           renderListRowAction={renderListRowAction}
           hasFileSearchQuery={effectiveFileSearchQuery.trim().length > 0}

--- a/src/features/TaskKanban/utils/cardContextMenu.test.ts
+++ b/src/features/TaskKanban/utils/cardContextMenu.test.ts
@@ -1,0 +1,55 @@
+import type { KanbanTask } from "@src/features/KanbanBoard";
+
+import {
+  KANBAN_CARD_CONTEXT_ACTION,
+  planKanbanCardContextMenu,
+} from "./cardContextMenu";
+
+function task(overrides: Partial<KanbanTask> & { id: string }): KanbanTask {
+  return {
+    title: overrides.id,
+    status: "turn_finished",
+    ...overrides,
+  } as KanbanTask;
+}
+
+describe("planKanbanCardContextMenu", () => {
+  it("offers both surfaces for a local session card", () => {
+    const plan = planKanbanCardContextMenu({
+      task: task({ id: "claude-1", session_id: "claude-1" }),
+      isRemoteTeamCard: false,
+    });
+    expect(plan.actions).toEqual([
+      KANBAN_CARD_CONTEXT_ACTION.OpenFloatingPane,
+      KANBAN_CARD_CONTEXT_ACTION.OpenInNewTabPane,
+    ]);
+    expect(plan.sessionId).toBe("claude-1");
+  });
+
+  it("keeps a teammate cloud card on the floating preview only", () => {
+    // Its replay import is hosted by the board; a Chat Pane tab would unmount
+    // Work Management mid-import and leave the new tab empty.
+    const plan = planKanbanCardContextMenu({
+      task: task({ id: "cloud-remote:row-1" }),
+      isRemoteTeamCard: true,
+    });
+    expect(plan.actions).toEqual([KANBAN_CARD_CONTEXT_ACTION.OpenFloatingPane]);
+  });
+
+  it("omits the new-tab action for a card with no local session", () => {
+    const plan = planKanbanCardContextMenu({
+      task: task({ id: "todo-1" }),
+      isRemoteTeamCard: false,
+    });
+    expect(plan.actions).toEqual([KANBAN_CARD_CONTEXT_ACTION.OpenFloatingPane]);
+    expect(plan.sessionId).toBeNull();
+  });
+
+  it("shows no menu for a card that cannot be opened", () => {
+    const plan = planKanbanCardContextMenu({
+      task: task({ id: "cloud-remote:row-2", canOpen: false }),
+      isRemoteTeamCard: true,
+    });
+    expect(plan.actions).toEqual([]);
+  });
+});

--- a/src/features/TaskKanban/utils/cardContextMenu.ts
+++ b/src/features/TaskKanban/utils/cardContextMenu.ts
@@ -1,0 +1,56 @@
+/**
+ * Secondary-click (right-click) plan for a Kanban card.
+ *
+ * The board's primary click opens the floating session preview. The context
+ * menu exposes the same target in either surface — the floating preview or a
+ * new Chat Pane tab — so the decision of *which* actions a given card can
+ * offer is kept here, away from the native-menu plumbing.
+ */
+import type { KanbanTask } from "@src/features/KanbanBoard";
+
+export const KANBAN_CARD_CONTEXT_ACTION = {
+  /** Open the board's own floating session-preview window (primary click). */
+  OpenFloatingPane: "open-floating-pane",
+  /** Open the session as its own Chat Pane tab, leaving the board open. */
+  OpenInNewTabPane: "open-in-new-tab-pane",
+} as const;
+
+export type KanbanCardContextAction =
+  (typeof KANBAN_CARD_CONTEXT_ACTION)[keyof typeof KANBAN_CARD_CONTEXT_ACTION];
+
+export interface KanbanCardContextMenuPlan {
+  /** Menu items to show, in display order. Empty means "show no menu". */
+  actions: KanbanCardContextAction[];
+  /** Local session id the new-tab action targets; `null` when unavailable. */
+  sessionId: string | null;
+}
+
+export interface PlanKanbanCardContextMenuOptions {
+  task: KanbanTask;
+  /**
+   * True for teammate cloud cards. Their transcript only exists after a replay
+   * import that the board itself hosts — handing them to a Chat Pane tab
+   * unmounts Work Management (and the import's abort controller with it), so
+   * these cards only get the floating preview.
+   */
+  isRemoteTeamCard: boolean;
+}
+
+export function planKanbanCardContextMenu({
+  task,
+  isRemoteTeamCard,
+}: PlanKanbanCardContextMenuOptions): KanbanCardContextMenuPlan {
+  if (task.canOpen === false) {
+    return { actions: [], sessionId: null };
+  }
+
+  const sessionId = task.session_id ?? null;
+  const actions: KanbanCardContextAction[] = [
+    KANBAN_CARD_CONTEXT_ACTION.OpenFloatingPane,
+  ];
+  if (!isRemoteTeamCard && sessionId) {
+    actions.push(KANBAN_CARD_CONTEXT_ACTION.OpenInNewTabPane);
+  }
+
+  return { actions, sessionId };
+}

--- a/src/i18n/locales/de/sessions.json
+++ b/src/i18n/locales/de/sessions.json
@@ -84,6 +84,9 @@
     }
   },
   "kanban": {
+    "card": {
+      "openAsFloatingPane": "Als schwebendes Fenster öffnen"
+    },
     "sessions": "Session",
     "fileSearch": {
       "placeholder": "Sitzungen nach Dateipfad suchen",
@@ -949,6 +952,7 @@
     "defaultTitle": "Chat",
     "hideChatPanel": "Chat-Panel ausblenden",
     "showTokenUsage": "Token anzeigen",
+    "showTurnMetadata": "Änderungen & Lesevorgänge anzeigen",
     "compactDisplayMode": "Kompakter Modus",
     "replay": {
       "follow": "Folgen"

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -97,6 +97,9 @@
     }
   },
   "kanban": {
+    "card": {
+      "openAsFloatingPane": "Open as Floating Pane"
+    },
     "sessions": "Sessions",
     "fileSearch": {
       "placeholder": "Search sessions by file path",
@@ -1005,6 +1008,7 @@
     "defaultTitle": "Chat",
     "hideChatPanel": "Hide chat panel",
     "showTokenUsage": "Show token",
+    "showTurnMetadata": "Show edits & reads",
     "compactDisplayMode": "Compact mode",
     "replay": {
       "follow": "Follow"

--- a/src/i18n/locales/es/sessions.json
+++ b/src/i18n/locales/es/sessions.json
@@ -84,6 +84,9 @@
     }
   },
   "kanban": {
+    "card": {
+      "openAsFloatingPane": "Abrir como panel flotante"
+    },
     "sessions": "Session",
     "fileSearch": {
       "placeholder": "Buscar sesiones por ruta de archivo",
@@ -951,6 +954,7 @@
     "defaultTitle": "Chat",
     "hideChatPanel": "Ocultar panel de chat",
     "showTokenUsage": "Mostrar Token",
+    "showTurnMetadata": "Mostrar ediciones y lecturas",
     "compactDisplayMode": "Modo compacto",
     "replay": {
       "follow": "Seguir"

--- a/src/i18n/locales/fr/sessions.json
+++ b/src/i18n/locales/fr/sessions.json
@@ -84,6 +84,9 @@
     }
   },
   "kanban": {
+    "card": {
+      "openAsFloatingPane": "Ouvrir en volet flottant"
+    },
     "sessions": "Sessions",
     "fileSearch": {
       "placeholder": "Rechercher par chemin de fichier",
@@ -951,6 +954,7 @@
     "defaultTitle": "Chat",
     "hideChatPanel": "Masquer le panneau de chat",
     "showTokenUsage": "Afficher les Token",
+    "showTurnMetadata": "Afficher les modifications et lectures",
     "compactDisplayMode": "Mode compact",
     "replay": {
       "follow": "Suivre"

--- a/src/i18n/locales/ja/sessions.json
+++ b/src/i18n/locales/ja/sessions.json
@@ -84,6 +84,9 @@
     }
   },
   "kanban": {
+    "card": {
+      "openAsFloatingPane": "フローティングパネルで開く"
+    },
     "sessions": "Session",
     "fileSearch": {
       "placeholder": "ファイルパスでセッションを検索",
@@ -950,6 +953,7 @@
     "defaultTitle": "チャット",
     "hideChatPanel": "チャットパネルを非表示",
     "showTokenUsage": "Token を表示",
+    "showTurnMetadata": "編集と読み取りを表示",
     "compactDisplayMode": "コンパクトモード",
     "replay": {
       "follow": "フォロー"

--- a/src/i18n/locales/ko/sessions.json
+++ b/src/i18n/locales/ko/sessions.json
@@ -84,6 +84,9 @@
     }
   },
   "kanban": {
+    "card": {
+      "openAsFloatingPane": "플로팅 패널로 열기"
+    },
     "sessions": "Session",
     "fileSearch": {
       "placeholder": "파일 경로로 세션 검색",
@@ -950,6 +953,7 @@
     "defaultTitle": "채팅",
     "hideChatPanel": "채팅 패널 숨기기",
     "showTokenUsage": "Token 표시",
+    "showTurnMetadata": "편집·읽기 표시",
     "compactDisplayMode": "컴팩트 모드",
     "replay": {
       "follow": "팔로우"

--- a/src/i18n/locales/pl/sessions.json
+++ b/src/i18n/locales/pl/sessions.json
@@ -84,6 +84,9 @@
     }
   },
   "kanban": {
+    "card": {
+      "openAsFloatingPane": "Otwórz jako pływający panel"
+    },
     "sessions": "Sesje",
     "fileSearch": {
       "placeholder": "Szukaj sesji według ścieżki pliku",
@@ -952,6 +955,7 @@
     "defaultTitle": "Czat",
     "hideChatPanel": "Ukryj panel czatu",
     "showTokenUsage": "Pokaż Token",
+    "showTurnMetadata": "Pokaż zmiany i odczyty",
     "compactDisplayMode": "Tryb kompaktowy",
     "replay": {
       "follow": "Śledź"

--- a/src/i18n/locales/pt/sessions.json
+++ b/src/i18n/locales/pt/sessions.json
@@ -84,6 +84,9 @@
     }
   },
   "kanban": {
+    "card": {
+      "openAsFloatingPane": "Abrir como painel flutuante"
+    },
     "sessions": "Sessões",
     "fileSearch": {
       "placeholder": "Buscar sessões pelo caminho do arquivo",
@@ -950,6 +953,7 @@
     "defaultTitle": "Chat",
     "hideChatPanel": "Ocultar painel de chat",
     "showTokenUsage": "Mostrar Token",
+    "showTurnMetadata": "Mostrar edições e leituras",
     "compactDisplayMode": "Modo compacto",
     "replay": {
       "follow": "Acompanhar"

--- a/src/i18n/locales/ru/sessions.json
+++ b/src/i18n/locales/ru/sessions.json
@@ -84,6 +84,9 @@
     }
   },
   "kanban": {
+    "card": {
+      "openAsFloatingPane": "Открыть во всплывающей панели"
+    },
     "sessions": "Session",
     "fileSearch": {
       "placeholder": "Поиск сессий по пути файла",
@@ -955,6 +958,7 @@
     "defaultTitle": "Чат",
     "hideChatPanel": "Скрыть панель чата",
     "showTokenUsage": "Показывать Token",
+    "showTurnMetadata": "Показывать правки и чтения",
     "compactDisplayMode": "Компактный режим",
     "replay": {
       "follow": "Следовать"

--- a/src/i18n/locales/tr/sessions.json
+++ b/src/i18n/locales/tr/sessions.json
@@ -84,6 +84,9 @@
     }
   },
   "kanban": {
+    "card": {
+      "openAsFloatingPane": "Yüzen Panelde Aç"
+    },
     "sessions": "Session",
     "fileSearch": {
       "placeholder": "Dosya yoluna göre oturum ara",
@@ -951,6 +954,7 @@
     "defaultTitle": "Sohbet",
     "hideChatPanel": "Sohbet panelini gizle",
     "showTokenUsage": "Token göster",
+    "showTurnMetadata": "Düzenlemeleri ve okumaları göster",
     "compactDisplayMode": "Kompakt mod",
     "replay": {
       "follow": "Takip et"

--- a/src/i18n/locales/vi/sessions.json
+++ b/src/i18n/locales/vi/sessions.json
@@ -84,6 +84,9 @@
     }
   },
   "kanban": {
+    "card": {
+      "openAsFloatingPane": "Mở dạng bảng nổi"
+    },
     "sessions": "Session",
     "fileSearch": {
       "placeholder": "Tìm phiên theo đường dẫn tệp",
@@ -948,6 +951,7 @@
     "defaultTitle": "Chat",
     "hideChatPanel": "Ẩn bảng trò chuyện",
     "showTokenUsage": "Hiển thị Token",
+    "showTurnMetadata": "Hiện chỉnh sửa và đọc",
     "compactDisplayMode": "Chế độ gọn",
     "replay": {
       "follow": "Theo dõi"

--- a/src/i18n/locales/zh-Hant/sessions.json
+++ b/src/i18n/locales/zh-Hant/sessions.json
@@ -95,6 +95,9 @@
     }
   },
   "kanban": {
+    "card": {
+      "openAsFloatingPane": "以浮動面板打開"
+    },
     "sessions": "Session",
     "fileSearch": {
       "placeholder": "依檔案路徑搜尋 Session",
@@ -965,6 +968,7 @@
     "defaultTitle": "Session",
     "hideChatPanel": "隱藏聊天面板",
     "showTokenUsage": "顯示 Token",
+    "showTurnMetadata": "顯示讀寫摘要",
     "compactDisplayMode": "精簡模式",
     "replay": {
       "follow": "跟隨"

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -97,6 +97,9 @@
     }
   },
   "kanban": {
+    "card": {
+      "openAsFloatingPane": "以悬浮面板打开"
+    },
     "sessions": "Session",
     "fileSearch": {
       "placeholder": "按文件路径搜索 Session",
@@ -996,6 +999,7 @@
     "defaultTitle": "Session",
     "hideChatPanel": "隐藏聊天面板",
     "showTokenUsage": "显示 Token",
+    "showTurnMetadata": "显示读写摘要",
     "compactDisplayMode": "紧凑模式",
     "replay": {
       "follow": "跟随"


### PR DESCRIPTION
## Why

Right-clicking a Kanban card fell through to the WebView's own menu (Reload / Inspect Element / AutoFill) — the card had no `onContextMenu` handler at all. A session card should offer the surfaces it can open in, like the sidebar session rows already do.

## What

Cards now pop a native Tauri menu, the same pattern used by `useWorkstationSidebarContextMenu` and `ChatPanelTabContextMenu`:

- **Open as Floating Pane** — identical to the primary click: the board's draggable preview window over the board (including the replay import for teammate cloud cards).
- **Open in New Tab** — opens or focuses the session as its own Chat Pane pill, leaving the Kanban pill in place. Reuses `common:actions.openInNewTab`, the label the sidebar uses for the same action.

Per-card availability lives in a pure planner (`utils/cardContextMenu.ts`) so it is unit-testable:

| Card | Menu |
| --- | --- |
| Local session card | Floating + New Tab |
| Teammate cloud card (replayable) | Floating only — its replay import is hosted by the board, and a Chat Pane tab would unmount Work Management and abort it |
| No local `session_id` | Floating only |
| `canOpen === false` (read-only Todo Kanban) | No ORGII menu; default behaviour unchanged |

The new-tab action reveals the chat pane first, because the board also runs inside a WorkStation tab (`WorkManagementPage embedded`) where that pane can be collapsed.

Scope note: board cards only. List and Diary rows keep the default menu.

## Files

- `src/features/TaskKanban/utils/cardContextMenu.ts` — action planner
- `src/features/TaskKanban/hooks/useKanbanCardContextMenu.ts` — native menu + dispatch
- `onTaskContextMenu` plumbed `KanbanBoard` → `KanbanColumn` → `TaskCard`, wired in `TaskKanban`
- `kanban.card.openAsFloatingPane` added to all 13 locales
- Test-case table appended to `src/features/TaskKanban/TEST_CASES.md`

## Verification

- `src/features/TaskKanban/utils/cardContextMenu.test.ts` — 4 cases covering the table above
- `npx tsc --noEmit` clean; eslint clean on both features
- `vitest run src/features src/store/chatPanel` — 1339 tests pass

Not yet exercised in the running app: the popup needs the Tauri runtime, so the menu itself and the two open paths remain on the manual-acceptance line in `TEST_CASES.md` (right-click a card → confirm the ORGII menu replaces the WebView menu; **Open in New Tab** adds a Chat Pane pill while the Kanban pill stays; **Open as Floating Pane** opens the preview).