### PR TITLE
fix(chat): guard send and stop gestures

### DIFF
--- a/src/engines/ChatPanel/InputArea/components/InputActions.tsx
+++ b/src/engines/ChatPanel/InputArea/components/InputActions.tsx
@@ -27,6 +27,11 @@ import { INPUT_AREA_BUTTONS } from "@src/config/inputAreaTokens";
 import { getShortcutKeys } from "@src/config/keyboard/shortcutDisplay";
 import { chatAppearanceAtom } from "@src/store/config/configAtom";
 
+import {
+  type InputActionGuardState,
+  shouldSuppressOppositeInputAction,
+} from "./inputActionClickGuard";
+
 interface InputActionsProps {
   isInputEmpty: boolean;
   isWpGeneWorking: boolean;
@@ -69,7 +74,7 @@ const InputActions: React.FC<InputActionsProps> = memo(
   }) => {
     const { t } = useTranslation();
     const { sendOnEnter } = useAtomValue(chatAppearanceAtom);
-    const suppressSubmitClickUntilRef = useRef(0);
+    const lastInputActionRef = useRef<InputActionGuardState | null>(null);
 
     // Non-empty input ALWAYS wins over the working indicator: the user can
     // type a new message while the agent is running, and it will be silently
@@ -89,15 +94,33 @@ const InputActions: React.FC<InputActionsProps> = memo(
         if (submitDisabled) {
           return;
         }
-        if (Date.now() < suppressSubmitClickUntilRef.current) {
+        const now = Date.now();
+        if (
+          shouldSuppressOppositeInputAction(
+            lastInputActionRef.current,
+            "submit",
+            now
+          )
+        ) {
           return;
         }
+        lastInputActionRef.current = { action: "submit", at: now };
         onSubmit();
         return;
       }
       if (showStop) {
         if (canStopAgent) {
-          suppressSubmitClickUntilRef.current = Date.now() + 700;
+          const now = Date.now();
+          if (
+            shouldSuppressOppositeInputAction(
+              lastInputActionRef.current,
+              "stop",
+              now
+            )
+          ) {
+            return;
+          }
+          lastInputActionRef.current = { action: "stop", at: now };
           void onInterrupt();
         } else {
           Message.info(t("sessions:chat.workspaceIsWorking"));

--- a/src/engines/ChatPanel/InputArea/components/__tests__/inputActionClickGuard.test.ts
+++ b/src/engines/ChatPanel/InputArea/components/__tests__/inputActionClickGuard.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldSuppressOppositeInputAction } from "../inputActionClickGuard";
+
+describe("shouldSuppressOppositeInputAction", () => {
+  it("blocks a Stop click that lands immediately after Send changes state", () => {
+    expect(
+      shouldSuppressOppositeInputAction(
+        { action: "submit", at: 1_000 },
+        "stop",
+        1_143
+      )
+    ).toBe(true);
+  });
+
+  it("allows Stop after the gesture guard expires", () => {
+    expect(
+      shouldSuppressOppositeInputAction(
+        { action: "submit", at: 1_000 },
+        "stop",
+        1_700
+      )
+    ).toBe(false);
+  });
+
+  it("does not block repeated actions with the same meaning", () => {
+    expect(
+      shouldSuppressOppositeInputAction(
+        { action: "stop", at: 1_000 },
+        "stop",
+        1_100
+      )
+    ).toBe(false);
+  });
+});

--- a/src/engines/ChatPanel/InputArea/components/inputActionClickGuard.ts
+++ b/src/engines/ChatPanel/InputArea/components/inputActionClickGuard.ts
@@ -1,0 +1,27 @@
+const OPPOSITE_ACTION_GUARD_MS = 700;
+
+export type InputActionKind = "submit" | "stop";
+
+export interface InputActionGuardState {
+  action: InputActionKind;
+  at: number;
+}
+
+/**
+ * The composer reuses one DOM button for Send and Stop. A fast second click can
+ * land after React has switched the button's meaning, so suppress only the
+ * opposite action from the same short gesture window. Repeating the same
+ * action remains available.
+ */
+export function shouldSuppressOppositeInputAction(
+  previous: InputActionGuardState | null,
+  nextAction: InputActionKind,
+  now = Date.now()
+): boolean {
+  return (
+    previous !== null &&
+    previous.action !== nextAction &&
+    now - previous.at >= 0 &&
+    now - previous.at < OPPOSITE_ACTION_GUARD_MS
+  );
+}


### PR DESCRIPTION
## Problem

A single pointer gesture can trigger both stop and send actions in the chat composer, causing duplicate or contradictory control intent.

## Solution

- Guard input actions so one click/pointer gesture can invoke only one logical action.
- Isolate the guard in a focused helper with regression coverage.
- Validation: 3 focused Vitest tests, TypeScript typecheck, and GitHub CI.

## Potential risks

- Keyboard submission and accessibility activation must remain unaffected.
- The guard must reset between distinct gestures without suppressing a legitimate later action.
