### PR TITLE
refactor(ui): normalize empty-state semantics

### DIFF
--- a/docs/frontend-ui-audit-2026-07-27/EmptyStateSemantics.md
+++ b/docs/frontend-ui-audit-2026-07-27/EmptyStateSemantics.md
@@ -1,0 +1,43 @@
+# Frontend UI Audit — Empty-State Semantics
+
+**Files:** user-visible empty-value renderers under `src/components`, `src/features`, and `src/modules`
+**Date:** 2026-07-27
+**Auditor:** ORGII coding session
+
+## D1 — Raw HTML vs Design System
+
+| Line | Element | Verdict | Reason | Suggested change |
+|---|---|---|---|---|
+| — | Existing inline text wrappers | keep with reason | This sweep changes empty-value semantics only; the wrappers are non-interactive text/layout elements and do not have a covering design-system requirement. | — |
+
+## D2 — Arbitrary Tailwind Value vs Token
+
+| Line | Value | Verdict | Reason | Suggested change |
+|---|---|---|---|---|
+| — | Existing classes in audited renderers | keep with reason | No new arbitrary color or CSS-variable value was introduced by the empty-state changes. | — |
+
+## D3 — Hardcoded Sizes / Colors
+
+| Line | Value | Verdict | Reason | Suggested change |
+|---|---|---|---|---|
+| — | Existing sizing and color classes | keep with reason | This issue class concerns semantic empty-state presentation; no new hardcoded size or color was introduced. | — |
+
+## D4 — Accessibility
+
+| Line | Element | Verdict | Reason | Suggested change |
+|---|---|---|---|---|
+| `src/components/ContextListDropdown/index.tsx:194` | Empty context list | fix | The same `AlertCircle` used for load failures was also used for a normal empty result. | Completed: the error icon remains only on the error branch. |
+| Other changed dash fallbacks | Plain text empty values | keep with reason | A muted em dash is conventional table/metadata empty-value output and does not claim an error. | — |
+
+## D5 — Visual Patterns Observed
+
+- Pattern: ordinary missing optional metadata should use a quiet `—`, not `N/A` or a blocked/error icon.
+- Migrated sites: testing framework label, image diff metadata, CLI installation source, CLI API/protocol lists, and the internal flow-awareness summary.
+- Pattern: true operational states remain explicit. Permission unavailable, unsupported capability, failed probes, failed loading, cancelled jobs, and CI neutral/skipped states were intentionally not rewritten.
+
+## Summary
+
+- 7 empty-value render sites migrated to the neutral dash convention.
+- 1 normal empty-state alert icon removed.
+- 0 design-system abstractions required; the shared convention already exists in `SessionTable` and `SectionLayout/Table`.
+- Residual `N/A` locale keys are either unused generic resources or technical diagnostics (for example FPS sampling unavailable), not confirmed instances of ordinary optional data being presented as an error.

--- a/src/components/ContextListDropdown/index.tsx
+++ b/src/components/ContextListDropdown/index.tsx
@@ -193,7 +193,6 @@ const ContextListDropdown: React.FC<ContextListDropdownProps> = ({
         </div>
       ) : (
         <div className={DROPDOWN_CLASSES.listMessage}>
-          <AlertCircle size={DROPDOWN_ITEM.iconSize} />
           {t("contextList.noContextItemsFound")}
         </div>
       )}

--- a/src/components/FlowAwarenessTest/index.tsx
+++ b/src/components/FlowAwarenessTest/index.tsx
@@ -310,7 +310,7 @@ export function FlowAwarenessTest({
                   </ul>
                 </div>
                 <div>
-                  <strong>Idle Seconds:</strong> {summary.idleSeconds ?? "N/A"}
+                  <strong>Idle Seconds:</strong> {summary.idleSeconds ?? "—"}
                 </div>
               </div>
             ) : (

--- a/src/modules/MainApp/Integrations/KeyVault/CliClients/Table/CliClientStatusContent.tsx
+++ b/src/modules/MainApp/Integrations/KeyVault/CliClients/Table/CliClientStatusContent.tsx
@@ -75,7 +75,7 @@ export function CliClientStatusContent({
                   {agent.installedVia
                     ? (METHOD_DISPLAY_LABELS[agent.installedVia] ??
                       agent.installedVia)
-                    : t("common:status.na")}
+                    : "—"}
                 </span>
               </InfoRow>
             )}

--- a/src/modules/MainApp/Integrations/KeyVault/CliClients/Table/CliClientSubscriptionsContent.tsx
+++ b/src/modules/MainApp/Integrations/KeyVault/CliClients/Table/CliClientSubscriptionsContent.tsx
@@ -26,11 +26,11 @@ export function CliClientSubscriptionsContent({
   const compatibleApiLabels = agent.compatibleApiProviders.map((provider) =>
     formatAgentType(provider)
   );
-  const valueOrNA = (values: string[]): React.ReactNode =>
+  const valueOrEmpty = (values: string[]): React.ReactNode =>
     values.length > 0 ? (
       <span className="text-[12px] text-text-1">{values.join(", ")}</span>
     ) : (
-      <span className="text-[12px] text-text-3">{t("common:status.na")}</span>
+      <span className="text-[12px] text-text-3">—</span>
     );
 
   return (
@@ -47,10 +47,10 @@ export function CliClientSubscriptionsContent({
         </InfoRow>
       )}
       <InfoRow label={t("cliPreview.compatibleApis")} layout="vertical">
-        {valueOrNA(compatibleApiLabels)}
+        {valueOrEmpty(compatibleApiLabels)}
       </InfoRow>
       <InfoRow label={t("cliPreview.supportedProtocols")} layout="vertical">
-        {valueOrNA(agent.supportedProtocols)}
+        {valueOrEmpty(agent.supportedProtocols)}
       </InfoRow>
       <InfoRow label={t("cliPreview.addedSubscriptions")} layout="vertical">
         {subscriptionAccounts.length > 0 ? (

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/FilePreviewContent/ImagePreview/ImageBottomBar.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/FilePreviewContent/ImagePreview/ImageBottomBar.tsx
@@ -108,7 +108,7 @@ const DiffLeft: React.FC<DiffModeProps> = ({ oldImage, newImage, status }) => {
           {oldImage.width} × {oldImage.height} · {formatFileSize(oldImage.size)}
         </span>
       ) : (
-        <span>{isAdded ? "New file" : "N/A"}</span>
+        <span>{isAdded ? "New file" : "—"}</span>
       )}
       <ArrowRight size={12} className="text-text-3" />
       {newImage ? (
@@ -116,7 +116,7 @@ const DiffLeft: React.FC<DiffModeProps> = ({ oldImage, newImage, status }) => {
           {newImage.width} × {newImage.height} · {formatFileSize(newImage.size)}
         </span>
       ) : (
-        <span>{isDeleted ? "Deleted" : "N/A"}</span>
+        <span>{isDeleted ? "Deleted" : "—"}</span>
       )}
     </div>
   );

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/TestingTab.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/TestingTab.tsx
@@ -52,9 +52,10 @@ export function useTestingTabConfig({
     discoverTests,
   } = useTestRunner({ repoPath, autoDiscover: true, isActive });
 
-  // Get framework label (or "N/A" if no framework)
+  // Keep an undetected framework visually neutral; detection can legitimately
+  // produce no result for repositories without a supported test setup.
   const frameworkLabel =
-    framework !== "unknown" ? getFrameworkLabel(framework) : "N/A";
+    framework !== "unknown" ? getFrameworkLabel(framework) : "—";
 
   const { spinClass: refreshSpinClass, handleClick: handleRefreshClick } =
     useRefreshSpin(discoverTests, isDiscovering);


### PR DESCRIPTION
## Problem

Several UI surfaces render ordinary missing values as errors or use inconsistent empty-state visuals, making absence look like failure.

## Solution

- Render ordinary missing values with a neutral dash.
- Reserve alert/error visuals for actual failures.
- Apply the same semantic rule across the audited component sweep.
- Validation: TypeScript typecheck, frontend UI audit, and GitHub CI.

## Potential risks

- A genuinely actionable failure must not be downgraded to a neutral empty state.
- This is a cross-component consistency sweep; each changed surface should be reviewed against its domain meaning, not only its visual appearance.
