### PR TITLE
fix(usage): label day buckets by their UTC day

### DIFF
--- a/src/config/timezone.ts
+++ b/src/config/timezone.ts
@@ -40,6 +40,19 @@ export const getCurrentTimezone = (): TimezoneOption => {
 };
 
 /**
+ * The user's timezone preference as an `Intl` `timeZone` option.
+ *
+ * `undefined` means "auto" — let `Intl` use the system zone, which is also
+ * the right value to spread into options (an explicit `timeZone: undefined`
+ * behaves identically to omitting the key).
+ */
+export function resolveTimeZoneForIntl(): string | undefined {
+  const timezone = getCurrentTimezone();
+  if (timezone === "auto") return undefined;
+  return timezone === "utc" ? "UTC" : timezone;
+}
+
+/**
  * Get timezone offset information for a given timezone
  */
 export function getTimezoneOffset(tzValue: TimezoneOption): {

--- a/src/modules/shared/dataSource/UsageTrendChart.tsx
+++ b/src/modules/shared/dataSource/UsageTrendChart.tsx
@@ -58,15 +58,25 @@ interface ChartDatum {
   cost: number | null;
 }
 
-function formatBucketLabel(
+export function formatBucketLabel(
   ms: number,
   hourly: boolean,
   locale: string
 ): string {
   const date = new Date(ms);
+  // Day buckets are UTC calendar days (`TrendBucket::Day` floors on UTC, and
+  // `MemberUsageDay.day` is a UTC date string), so the label must name the
+  // bucket's own day: formatting UTC midnight in a negative-offset zone would
+  // print the PREVIOUS date and make teammates in different zones disagree
+  // about identical data. Hour buckets are plain instants — those stay local,
+  // which is what a viewer wants for "when did this happen".
   return hourly
     ? formatCompactHour(date)
-    : date.toLocaleDateString(locale, { month: "2-digit", day: "2-digit" });
+    : date.toLocaleDateString(locale, {
+        month: "2-digit",
+        day: "2-digit",
+        timeZone: "UTC",
+      });
 }
 
 export default function UsageTrendChart({

--- a/src/modules/shared/dataSource/usageTrendLabels.test.ts
+++ b/src/modules/shared/dataSource/usageTrendLabels.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { formatBucketLabel } from "./UsageTrendChart";
+
+/**
+ * Day-bucket labels must name the bucket's own UTC day.
+ *
+ * Trend buckets are UTC calendar days (`TrendBucket::Day` floors on UTC, and
+ * a teammate's `MemberUsageDay.day` is a UTC date string). Formatting UTC
+ * midnight in a negative-offset zone prints the PREVIOUS date, so every bar
+ * reads a day early in the Americas and two teammates in different zones
+ * disagree about identical data.
+ *
+ * TZ is pinned to a negative offset before any Date work so this actually
+ * fails if the UTC pin is removed — on a UTC runner the bug is invisible.
+ */
+process.env.TZ = "America/Los_Angeles";
+
+const UTC_MIDNIGHT = Date.parse("2026-07-30T00:00:00Z");
+
+describe("formatBucketLabel", () => {
+  it("labels a day bucket by its UTC date, not the viewer's local date", () => {
+    expect(formatBucketLabel(UTC_MIDNIGHT, false, "en-US")).toBe("07/30");
+  });
+
+  it("does not drift to the previous local calendar day", () => {
+    // What the pre-fix code produced under this TZ — the exact bug.
+    const localDate = new Date(UTC_MIDNIGHT).toLocaleDateString("en-US", {
+      month: "2-digit",
+      day: "2-digit",
+    });
+    expect(localDate).toBe("07/29");
+    expect(formatBucketLabel(UTC_MIDNIGHT, false, "en-US")).not.toBe(localDate);
+  });
+
+  it("keeps hour buckets in the viewer's local zone", () => {
+    // Hour buckets are plain instants: UTC midnight IS 5PM in Los Angeles,
+    // and that is what a viewer wants to read.
+    expect(formatBucketLabel(UTC_MIDNIGHT, true, "en-US")).toBe("5PM");
+  });
+});

--- a/src/util/data/formatters/date.ts
+++ b/src/util/data/formatters/date.ts
@@ -13,7 +13,10 @@
  */
 // Direct leaf import to avoid pulling @src/store's barrel — which transitively
 // reaches workstation/codeEditor modules and creates a circular dependency.
-import { getCurrentTimezone } from "@src/config/timezone";
+import {
+  getCurrentTimezone,
+  resolveTimeZoneForIntl,
+} from "@src/config/timezone";
 
 import { parseApiDate } from "./dateCore";
 
@@ -98,12 +101,6 @@ export function toIntlLocaleTag(language: string | undefined): string {
   if (language === "ja") return "ja-JP";
   if (language === "ko") return "ko-KR";
   return language;
-}
-
-function resolveTimeZoneForIntl(): string | undefined {
-  const timezone = getCurrentTimezone();
-  if (timezone === "auto") return undefined;
-  return timezone === "utc" ? "UTC" : timezone;
 }
 
 function dateKeyInTimezone(date: Date, timeZone: string | undefined): string {

--- a/src/util/time/formatRelativeTime.test.ts
+++ b/src/util/time/formatRelativeTime.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { formatRelativeTime } from "./formatRelativeTime";
+
+/**
+ * `formatRelativeTime`'s >7-day date fallback must honor the explicit
+ * timezone preference, like every other formatter in the app (which route
+ * through `resolveTimeZoneForIntl`). Only "auto" should follow the system
+ * zone.
+ *
+ * TZ is pinned to a negative offset so a preference of UTC is observably
+ * different from the system zone.
+ */
+process.env.TZ = "America/Los_Angeles";
+
+const { getCurrentTimezoneMock } = vi.hoisted(() => ({
+  getCurrentTimezoneMock: vi.fn<() => string>(() => "auto"),
+}));
+
+vi.mock("@src/config/timezone", () => ({
+  getCurrentTimezone: getCurrentTimezoneMock,
+  resolveTimeZoneForIntl: () => {
+    const timezone = getCurrentTimezoneMock();
+    if (timezone === "auto") return undefined;
+    return timezone === "utc" ? "UTC" : timezone;
+  },
+}));
+
+/** 2026-07-30T00:00:00Z is still 07/29 in Los Angeles. */
+const OLD_INSTANT = Date.parse("2026-07-30T00:00:00Z");
+/** Far enough past OLD_INSTANT to land in the ">7 days" date fallback. */
+const NOW = Date.parse("2026-08-20T00:00:00Z");
+
+afterEach(() => {
+  vi.useRealTimers();
+  getCurrentTimezoneMock.mockReturnValue("auto");
+});
+
+describe("formatRelativeTime date fallback", () => {
+  it("renders in the system zone when the preference is auto", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    getCurrentTimezoneMock.mockReturnValue("auto");
+
+    expect(formatRelativeTime(OLD_INSTANT, "short")).toBe(
+      new Date(OLD_INSTANT).toLocaleDateString(undefined, {
+        timeZone: "America/Los_Angeles",
+      })
+    );
+  });
+
+  it("honors an explicit timezone preference instead of the system zone", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    getCurrentTimezoneMock.mockReturnValue("utc");
+
+    const rendered = formatRelativeTime(OLD_INSTANT, "short");
+    expect(rendered).toBe(
+      new Date(OLD_INSTANT).toLocaleDateString(undefined, { timeZone: "UTC" })
+    );
+    // The bug: the system zone puts this instant on the previous day.
+    expect(rendered).not.toBe(
+      new Date(OLD_INSTANT).toLocaleDateString(undefined, {
+        timeZone: "America/Los_Angeles",
+      })
+    );
+  });
+
+  it("still returns relative phrasing inside the 7-day window", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(OLD_INSTANT + 2 * 24 * 60 * 60 * 1000);
+    getCurrentTimezoneMock.mockReturnValue("utc");
+
+    expect(formatRelativeTime(OLD_INSTANT, "short")).toBe("2 days ago");
+  });
+});

--- a/src/util/time/formatRelativeTime.ts
+++ b/src/util/time/formatRelativeTime.ts
@@ -1,3 +1,5 @@
+import { resolveTimeZoneForIntl } from "@src/config/timezone";
+
 export type RelativeTimeStyle = "short" | "compact" | "long" | "nano" | "issue";
 
 const SEC = 1000;
@@ -52,7 +54,12 @@ export function formatRelativeTime(
     if (diffHr < 24) return `${diffHr} hr ago`;
     if (diffDay === 1) return "Yesterday";
     if (diffDay < 7) return `${diffDay} days ago`;
-    return new Date(ms).toLocaleDateString();
+    // Honor the explicit timezone preference like every other formatter
+    // (`resolveTimeZoneForIntl` answers undefined for "auto", which Intl
+    // treats as the system zone).
+    return new Date(ms).toLocaleDateString(undefined, {
+      timeZone: resolveTimeZoneForIntl(),
+    });
   }
 
   if (style === "compact") {


### PR DESCRIPTION
## Problem

Two timezone defects in shared time formatting, both found while auditing whether teammate timestamps render correctly across zones (the rest of that audit came back clean — cloud timestamps carry explicit UTC offsets end to end, so every relative "X ago" is already correct).

1. **Usage trend chart labels the wrong day.** Trend buckets are UTC calendar days — the Rust aggregator floors on UTC, and a teammate's `MemberUsageDay.day` is a UTC date string — but `formatBucketLabel` formatted the bucket's UTC midnight with `toLocaleDateString` and **no `timeZone`**. For any viewer at a negative UTC offset, `2026-07-30T00:00:00Z` renders as `07/29`: every bar in the Team tab's usage history reads one day early in the Americas, and two teammates in different zones see different date labels for identical data. The local Usage tab has the same UTC-floored buckets, so it was mislabeled symmetrically.
2. **`formatRelativeTime` ignored the timezone preference.** Its ">7 days" fallback called bare `toLocaleDateString()`, while every other formatter routes through `resolveTimeZoneForIntl`. A user who explicitly picked a non-system timezone saw system-zone dates on week-old session comments and similar surfaces.

## Solution

- Pin the **daily** branch of `formatBucketLabel` to `timeZone: "UTC"` so a day bucket is named by its own day. Hour buckets stay local deliberately — those are plain instants, and a viewer wants them in their own zone.
- Route the `formatRelativeTime` fallback through `resolveTimeZoneForIntl`, which answers `undefined` for "auto" (Intl then uses the system zone, preserving today's behavior for the default).
- `resolveTimeZoneForIntl` was private to `date.ts`; hoisted it into `@src/config/timezone` next to `getCurrentTimezone` so there is a single definition rather than a copy. `date.ts` now imports it.

Both fixes have regression tests that pin `process.env.TZ` to a negative-offset zone, so they fail if the fix is reverted rather than passing vacuously on a UTC runner. I verified this by temporarily reverting the UTC pin: 2 of 3 chart tests fail, and pass again once restored.

## Potential risks

- **Deliberate display change on the local Usage tab.** Users at negative offsets will see daily bars shift label by one day — that is the fix, but it will look like a change to anyone who had internalized the old labels. Users at positive offsets (e.g. UTC+8) see no difference, since UTC midnight already falls on the same calendar day there.
- **Day buckets remain UTC-aggregated.** This corrects the *label*, not the bucketing: a user at UTC-7 still has their evening work counted into the next UTC day. Making buckets local-day would require changing the Rust aggregator and the synced `MemberUsageDay` contract, and would break cross-timezone team comparability — out of scope here.
- **`resolveTimeZoneForIntl` moved modules.** It was private, so there are no external callers to break; `date.ts`'s three call sites are unchanged in behavior and covered by the existing suite.
- The `formatRelativeTime` change is a no-op for anyone on the default "auto" setting.
- Not covered: `formatCompactHour` (hourly labels) still uses local `getHours()` — correct for instants, but in half-hour-offset zones a UTC hour boundary lands mid-hour and the minutes are dropped. Pre-existing and unchanged.

## Test plan

- `tsc --noEmit` clean.
- `vitest run src/util src/modules/shared/dataSource src/config` → **974 passed (95 files)**, including 6 new.
- Revert-check performed on the chart fix (described above) to confirm the tests are load-bearing; machine TZ is UTC+8, and the pinned-TZ assertions hold, proving the pin takes effect.
- eslint clean; pre-commit hook (lint-staged + scoped tsc) passed.
