### PR TITLE
refactor(cli): replace arg-count suppressions with request structs

### DIFF
--- a/src-tauri/src/agent_sessions/cli/agent_core_bridge.rs
+++ b/src-tauri/src/agent_sessions/cli/agent_core_bridge.rs
@@ -17,7 +17,10 @@ use agent_core::interaction::plan_approval::{self, PlanResolution};
 use agent_core::session::AgentExecMode;
 use agent_core::tools::names as tool_names;
 
-use super::commands::{cli_agent_create, cli_agent_delete, cli_agent_message, cli_agent_run};
+use super::commands::{
+    cli_agent_create, cli_agent_delete, cli_agent_message, cli_agent_run, CliMessageRequest,
+    CliRunRequest,
+};
 use super::persistence::{self, CreateCodeSessionParams};
 
 fn run(
@@ -59,14 +62,14 @@ fn run(
         let created_at = session.created_at.clone();
 
         if !params.user_input.trim().is_empty() {
-            if let Err(err) = cli_agent_run(
-                session_id.clone(),
-                params.user_input,
-                None,
-                params.ide_context,
-                params.mode,
-                params.images,
-            )
+            if let Err(err) = cli_agent_run(CliRunRequest {
+                session_id: session_id.clone(),
+                user_input: params.user_input,
+                ide_context: params.ide_context,
+                mode: params.mode,
+                images: params.images,
+                ..Default::default()
+            })
             .await
             {
                 tracing::warn!(
@@ -193,17 +196,14 @@ fn respond_plan_approval(
             edited_marker = if edited { " (edited)" } else { "" },
         );
 
-        cli_agent_message(
-            params.session_id,
-            synthetic_content,
-            params.model,
-            params.account_id,
-            None,
-            Some(AgentExecMode::Build.as_str().to_string()),
-            None,
-            None,
-            None,
-        )
+        cli_agent_message(CliMessageRequest {
+            session_id: params.session_id,
+            content: synthetic_content,
+            model: params.model,
+            account_id: params.account_id,
+            mode: Some(AgentExecMode::Build.as_str().to_string()),
+            ..Default::default()
+        })
         .await
         .map(|_| ())
     })

--- a/src-tauri/src/agent_sessions/cli/commands/run.rs
+++ b/src-tauri/src/agent_sessions/cli/commands/run.rs
@@ -6,7 +6,7 @@ use super::super::persistence;
 use super::super::session_runner;
 use super::super::types::{KeySource, SessionStatus};
 use agent_core::session::IdeContext;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -14,6 +14,68 @@ pub struct CliRunReceipt {
     pub session_id: String,
     pub turn_intent_id: String,
     pub status: SessionStatus,
+}
+
+/// Start one CLI turn on an existing session row.
+///
+/// `Default` is derived so callers that only drive a plain prompt (the
+/// agent-core bridge, the debug runtime probes) can name just the fields
+/// they mean instead of padding the call with positional `None`s.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliRunRequest {
+    pub session_id: String,
+    pub user_input: String,
+    pub cli_resume_id: Option<String>,
+    pub ide_context: Option<IdeContext>,
+    pub mode: Option<String>,
+    pub images: Option<Vec<String>>,
+}
+
+/// Send a follow-up message on an existing session, optionally switching the
+/// model/account first. `turn_intent_id` / `client_message_id` are optional:
+/// the frontend pre-assigns them so its optimistic user row and the persisted
+/// intent share one identity, while callers without a UI row omit them.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliMessageRequest {
+    pub session_id: String,
+    pub content: String,
+    pub model: Option<String>,
+    pub account_id: Option<String>,
+    pub ide_context: Option<IdeContext>,
+    pub mode: Option<String>,
+    pub images: Option<Vec<String>>,
+    pub turn_intent_id: Option<String>,
+    pub client_message_id: Option<String>,
+}
+
+/// Identity of a single turn. `turn_intent_id` keys the `turn_intents` row and
+/// every `status_changed` broadcast for the turn; `client_message_id`
+/// reconciles the frontend's optimistic user message with the persisted one.
+#[derive(Debug)]
+struct TurnIdentity {
+    turn_intent_id: String,
+    client_message_id: String,
+}
+
+impl TurnIdentity {
+    /// Mint a fresh pair for a turn no client pre-assigned ids for.
+    fn generate() -> Self {
+        Self::from_client(None, None)
+    }
+
+    /// Adopt whichever halves the client supplied, minting the rest.
+    fn from_client(turn_intent_id: Option<String>, client_message_id: Option<String>) -> Self {
+        Self {
+            turn_intent_id: turn_intent_id.unwrap_or_else(new_id),
+            client_message_id: client_message_id.unwrap_or_else(new_id),
+        }
+    }
+}
+
+fn new_id() -> String {
+    uuid::Uuid::new_v4().to_string()
 }
 
 /// Prepend IDE context (open files, git status, etc.) to the user prompt
@@ -45,38 +107,27 @@ pub async fn cli_agent_tui_release(session_id: String) -> Result<bool, String> {
 
 /// Run a code session (spawn CLI agent in background).
 #[tauri::command]
-pub async fn cli_agent_run(
-    session_id: String,
-    user_input: String,
-    cli_resume_id: Option<String>,
-    ide_context: Option<IdeContext>,
-    mode: Option<String>,
-    images: Option<Vec<String>>,
-) -> Result<(), String> {
-    cli_agent_run_internal(
+pub async fn cli_agent_run(request: CliRunRequest) -> Result<(), String> {
+    run_turn(request, TurnIdentity::generate()).await
+}
+
+/// Shared turn body behind both `cli_agent_run` and `cli_agent_message`:
+/// persist acceptance under the registry lock, broadcast `running`, then spawn
+/// the background runner.
+async fn run_turn(request: CliRunRequest, turn: TurnIdentity) -> Result<(), String> {
+    let CliRunRequest {
         session_id,
         user_input,
         cli_resume_id,
         ide_context,
         mode,
         images,
-        uuid::Uuid::new_v4().to_string(),
-        uuid::Uuid::new_v4().to_string(),
-    )
-    .await
-}
+    } = request;
+    let TurnIdentity {
+        turn_intent_id,
+        client_message_id,
+    } = turn;
 
-#[allow(clippy::too_many_arguments)]
-async fn cli_agent_run_internal(
-    session_id: String,
-    user_input: String,
-    cli_resume_id: Option<String>,
-    ide_context: Option<IdeContext>,
-    mode: Option<String>,
-    images: Option<Vec<String>>,
-    turn_intent_id: String,
-    client_message_id: String,
-) -> Result<(), String> {
     tracing::info!(
         session_id = %session_id,
         has_resume_id = cli_resume_id.is_some(),
@@ -213,20 +264,19 @@ async fn cli_agent_run_internal(
 /// If `model` or `account_id` is provided, updates the session config before
 /// re-running so the CLI uses the newly selected model/key.
 #[tauri::command]
-#[allow(clippy::too_many_arguments)]
-pub async fn cli_agent_message(
-    session_id: String,
-    content: String,
-    model: Option<String>,
-    account_id: Option<String>,
-    ide_context: Option<IdeContext>,
-    mode: Option<String>,
-    images: Option<Vec<String>>,
-    turn_intent_id: Option<String>,
-    client_message_id: Option<String>,
-) -> Result<CliRunReceipt, String> {
-    let turn_intent_id = turn_intent_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-    let client_message_id = client_message_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+pub async fn cli_agent_message(request: CliMessageRequest) -> Result<CliRunReceipt, String> {
+    let CliMessageRequest {
+        session_id,
+        content,
+        model,
+        account_id,
+        ide_context,
+        mode,
+        images,
+        turn_intent_id,
+        client_message_id,
+    } = request;
+    let turn = TurnIdentity::from_client(turn_intent_id, client_message_id);
     tracing::info!(
         session_id = %session_id,
         has_model_override = model.is_some(),
@@ -377,15 +427,17 @@ pub async fn cli_agent_message(
 
     // Re-run the session with the new message
     tracing::info!(session_id = %session_id, "cli_agent_message: dispatching rerun");
-    cli_agent_run_internal(
-        session_id.clone(),
-        content,
-        cli_resume_id,
-        ide_context,
-        mode,
-        images,
-        turn_intent_id.clone(),
-        client_message_id,
+    let turn_intent_id = turn.turn_intent_id.clone();
+    run_turn(
+        CliRunRequest {
+            session_id: session_id.clone(),
+            user_input: content,
+            cli_resume_id,
+            ide_context,
+            mode,
+            images,
+        },
+        turn,
     )
     .await?;
     Ok(CliRunReceipt {

--- a/src-tauri/src/api/agent/test/cli.rs
+++ b/src-tauri/src/api/agent/test/cli.rs
@@ -10,7 +10,7 @@ use tokio::process::Command;
 
 use crate::agent_sessions::cli::commands::{
     cli_agent_chunks, cli_agent_create, cli_agent_message, cli_agent_resume, cli_agent_run,
-    cli_agent_status,
+    cli_agent_status, CliMessageRequest, CliRunRequest,
 };
 use crate::agent_sessions::cli::persistence::{self, CreateCodeSessionParams};
 use crate::agent_sessions::cli::session_runner;
@@ -196,14 +196,11 @@ pub async fn test_cursor_cli_runtime(
         }));
     }
 
-    if let Err(err) = cli_agent_run(
-        session_id.clone(),
-        request.content.clone(),
-        None,
-        None,
-        None,
-        None,
-    )
+    if let Err(err) = cli_agent_run(CliRunRequest {
+        session_id: session_id.clone(),
+        user_input: request.content.clone(),
+        ..Default::default()
+    })
     .await
     {
         return Json(json!({ "error": format!("cli_agent_run failed: {err}") }));
@@ -301,14 +298,11 @@ pub async fn test_cursor_cli_account_switch(
         Err(err) => return Json(json!({ "error": format!("cli_agent_create failed: {err}") })),
     };
     let session_id = created.session_id;
-    if let Err(err) = cli_agent_run(
-        session_id.clone(),
-        request.initial_content.clone(),
-        None,
-        None,
-        None,
-        None,
-    )
+    if let Err(err) = cli_agent_run(CliRunRequest {
+        session_id: session_id.clone(),
+        user_input: request.initial_content.clone(),
+        ..Default::default()
+    })
     .await
     {
         return Json(json!({ "error": format!("initial cli_agent_run failed: {err}") }));
@@ -320,17 +314,12 @@ pub async fn test_cursor_cli_account_switch(
         Err(err) => return Json(json!({ "error": err, "session_id": session_id })),
     };
 
-    if let Err(err) = cli_agent_message(
-        session_id.clone(),
-        request.followup_content.clone(),
-        None,
-        Some(request.followup_account_id.clone()),
-        None,
-        None,
-        None,
-        None,
-        None,
-    )
+    if let Err(err) = cli_agent_message(CliMessageRequest {
+        session_id: session_id.clone(),
+        content: request.followup_content.clone(),
+        account_id: Some(request.followup_account_id.clone()),
+        ..Default::default()
+    })
     .await
     {
         return Json(json!({ "error": format!("cli_agent_message failed: {err}") }));
@@ -419,14 +408,11 @@ pub async fn test_claude_code_cli_account_switch(
         Err(err) => return Json(json!({ "error": format!("cli_agent_create failed: {err}") })),
     };
     let session_id = created.session_id;
-    if let Err(err) = cli_agent_run(
-        session_id.clone(),
-        request.initial_content.clone(),
-        None,
-        None,
-        None,
-        None,
-    )
+    if let Err(err) = cli_agent_run(CliRunRequest {
+        session_id: session_id.clone(),
+        user_input: request.initial_content.clone(),
+        ..Default::default()
+    })
     .await
     {
         return Json(json!({ "error": format!("initial cli_agent_run failed: {err}") }));
@@ -444,17 +430,13 @@ pub async fn test_claude_code_cli_account_switch(
     let baseline_chunk_count = initial_chunks.len();
     let baseline_updated_at = initial_session.updated_at.clone();
 
-    if let Err(err) = cli_agent_message(
-        session_id.clone(),
-        request.followup_content.clone(),
-        Some(model.clone()),
-        Some(request.followup_account_id.clone()),
-        None,
-        None,
-        None,
-        None,
-        None,
-    )
+    if let Err(err) = cli_agent_message(CliMessageRequest {
+        session_id: session_id.clone(),
+        content: request.followup_content.clone(),
+        model: Some(model.clone()),
+        account_id: Some(request.followup_account_id.clone()),
+        ..Default::default()
+    })
     .await
     {
         return Json(json!({ "error": format!("cli_agent_message failed: {err}") }));
@@ -580,14 +562,11 @@ pub async fn test_codex_cli_account_switch(
     let initial_codex_home = app_paths::codex_cli_profile_dir(&request.initial_account_id);
     let followup_codex_home = app_paths::codex_cli_profile_dir(&request.followup_account_id);
 
-    if let Err(err) = cli_agent_run(
-        session_id.clone(),
-        request.initial_content.clone(),
-        None,
-        None,
-        None,
-        None,
-    )
+    if let Err(err) = cli_agent_run(CliRunRequest {
+        session_id: session_id.clone(),
+        user_input: request.initial_content.clone(),
+        ..Default::default()
+    })
     .await
     {
         return Json(json!({ "error": format!("initial cli_agent_run failed: {err}") }));
@@ -605,17 +584,13 @@ pub async fn test_codex_cli_account_switch(
     let baseline_chunk_count = initial_chunks.len();
     let baseline_updated_at = initial_session.updated_at.clone();
 
-    if let Err(err) = cli_agent_message(
-        session_id.clone(),
-        request.followup_content.clone(),
-        Some(model.clone()),
-        Some(request.followup_account_id.clone()),
-        None,
-        None,
-        None,
-        None,
-        None,
-    )
+    if let Err(err) = cli_agent_message(CliMessageRequest {
+        session_id: session_id.clone(),
+        content: request.followup_content.clone(),
+        model: Some(model.clone()),
+        account_id: Some(request.followup_account_id.clone()),
+        ..Default::default()
+    })
     .await
     {
         return Json(json!({ "error": format!("cli_agent_message failed: {err}") }));
@@ -798,14 +773,11 @@ pub async fn test_cli_resume_lock_isolation() -> Json<serde_json::Value> {
     tokio::time::sleep(std::time::Duration::from_millis(150)).await;
 
     let peer_start = std::time::Instant::now();
-    let peer_result = cli_agent_run(
-        peer_session_id.clone(),
-        "E2E peer start should not wait on unrelated resume cleanup".to_string(),
-        None,
-        None,
-        None,
-        None,
-    )
+    let peer_result = cli_agent_run(CliRunRequest {
+        session_id: peer_session_id.clone(),
+        user_input: "E2E peer start should not wait on unrelated resume cleanup".to_string(),
+        ..Default::default()
+    })
     .await;
     let peer_start_ms = peer_start.elapsed().as_millis() as u64;
 

--- a/src/api/tauri/rpc/schemas/cli.ts
+++ b/src/api/tauri/rpc/schemas/cli.ts
@@ -2,7 +2,7 @@ import { z } from "zod/v4";
 
 import { ActivityChunkSchema } from "@src/api/realtime/websocket/schemas";
 
-export const CliMessageInputSchema = z.object({
+export const CliMessageRequestSchema = z.object({
   sessionId: z.string().min(1),
   content: z.string(),
   turnIntentId: z.string().min(1),
@@ -12,6 +12,12 @@ export const CliMessageInputSchema = z.object({
   ideContext: z.unknown().optional(),
   mode: z.string().optional(),
   images: z.array(z.string()).optional(),
+});
+
+/** `cli_agent_message` takes a single `request` struct, like the other
+ * multi-field commands (`benchmark_*`, `human_session_*`, pagination). */
+export const CliMessageInputSchema = z.object({
+  request: CliMessageRequestSchema,
 });
 
 export const CliRunReceiptSchema = z.object({

--- a/src/engines/SessionCore/sync/adapters/cli/__tests__/cliTransport.test.ts
+++ b/src/engines/SessionCore/sync/adapters/cli/__tests__/cliTransport.test.ts
@@ -41,10 +41,12 @@ describe("sendCliMessage acceptance boundary", () => {
     ).resolves.toBeUndefined();
 
     expect(mocks.message).toHaveBeenCalledWith({
-      sessionId: "cliagent-worker",
-      content: "continue",
-      turnIntentId: "intent-1",
-      clientMessageId: "message-1",
+      request: {
+        sessionId: "cliagent-worker",
+        content: "continue",
+        turnIntentId: "intent-1",
+        clientMessageId: "message-1",
+      },
     });
     expect(mocks.registerReceipt).toHaveBeenCalledWith({
       sessionId: "cliagent-worker",

--- a/src/engines/SessionCore/sync/adapters/cli/cliTransport.ts
+++ b/src/engines/SessionCore/sync/adapters/cli/cliTransport.ts
@@ -26,17 +26,19 @@ export async function sendCliMessage(input: AdapterSendInput): Promise<void> {
   const turnIntentId = input.turnIntentId ?? newMessageId();
   const clientMessageId = input.clientMessageId ?? newMessageId();
   const receipt = await rpc.cli.message({
-    sessionId,
-    content,
-    turnIntentId,
-    clientMessageId,
-    ...(model ? { model } : {}),
-    ...(accountId ? { accountId } : {}),
-    ...(mode ? { mode } : {}),
-    ...(imageDataUrls && imageDataUrls.length > 0
-      ? { images: imageDataUrls }
-      : {}),
-    ...(adeContext ? { ideContext: adeContext } : {}),
+    request: {
+      sessionId,
+      content,
+      turnIntentId,
+      clientMessageId,
+      ...(model ? { model } : {}),
+      ...(accountId ? { accountId } : {}),
+      ...(mode ? { mode } : {}),
+      ...(imageDataUrls && imageDataUrls.length > 0
+        ? { images: imageDataUrls }
+        : {}),
+      ...(adeContext ? { ideContext: adeContext } : {}),
+    },
   });
   cliTurnLifecycleCoordinator.registerReceipt(receipt);
 }


### PR DESCRIPTION
## Summary

Follow-up to #565, which introduced two `#[allow(clippy::too_many_arguments)]` suppressions in `agent_sessions/cli/commands/run.rs`. This removes both by grouping the arguments into request structs instead of silencing the lint.

## Problem

#565 grew `cli_agent_run_internal` to 8 arguments and the `cli_agent_message` command to 9, and suppressed the resulting clippy warnings. Beyond the suppressions themselves, the flat signatures made every Rust caller unreadable — the agent-core bridge called `cli_agent_message` with five consecutive positional `None`s, and the debug runtime probes had six such call sites. The "adopt the client's turn ids or mint fresh ones" rule was also duplicated across both entry points.

## Solution

- `CliRunRequest` / `CliMessageRequest` replace the flat argument lists. Both derive `Default`, so callers name only the fields they mean (`..Default::default()`) instead of padding with positional `None`s. This matches the `request: T` command convention already used by `benchmark_*`, `human_session_*`, `pagination_*`, and `xlsx_*`.
- `TurnIdentity` holds the `turn_intent_id` + `client_message_id` pair, with `generate()` (mint both) and `from_client()` (adopt whichever halves the client supplied). The id-defaulting rule now lives in one place.
- `cli_agent_run_internal` becomes `run_turn(request, turn)` — 2 args, no suppression.
- Wire change: `cli_agent_message` now takes a single `request` object, so the frontend sends `{ request: {...} }`. `CliMessageRequestSchema` is the inner shape; `CliMessageInputSchema` wraps it.

Net: both suppressions gone, 159 lines deleted for 193 added (mostly doc comments on the new structs), and 8 call sites became self-documenting.

## Potential risks

- **`cli_agent_message` payload shape changed.** `rpc.cli.message` is the only caller (`cliTransport.ts`), updated in this PR along with its unit test. The zod input schema still enforces `sessionId`/`content`/`turnIntentId`/`clientMessageId`, so a stale caller fails validation before IPC rather than silently sending a malformed payload.
- **`cli_agent_run`'s argument shape also changed**, but it has no TS caller — only the agent-core bridge and the debug-only runtime probes invoke it, both updated here.
- **`Default` on the request structs means `session_id` can silently default to `""` at a Rust call site that forgets it.** Not reachable over the wire: serde still rejects missing non-`Option` fields, and all four Rust call sites set `session_id` explicitly.
- No behavior change intended — this is signature-level only. The lifecycle contracts from #565 (acceptance persistence under the registry lock, `turn_intent_id` on every `status_changed` broadcast, receipt-based resolution) are untouched.

## Test plan

- `cargo clippy --all-targets` — clean; no warnings in the three touched Rust files. The 11 pre-existing `org2` lib warnings are all in files this PR does not touch.
- `cargo fmt --check` — no diffs in touched files (27 pre-existing diffs elsewhere in the repo).
- `npx tsc --noEmit` — passes.
- `npx eslint` on the three touched TS files — clean.
- `npx vitest run src/engines/SessionCore/sync/adapters/cli/__tests__/cliTransport.test.ts` — 2/2 passing (expectation updated for the `{ request }` payload).
- Pre-commit hook (lint-staged + scoped tsc + scoped clippy) passed.

Not run: end-to-end CLI turn against a live agent. The change is signature-level with no behavioral edits, but a manual follow-up turn (send message → verify the optimistic row reconciles against the receipt) would confirm the `{ request }` payload lands correctly through real IPC.