### PR TITLE
feat(chat): add toggle to hide the per-turn edits/reads footer

### DIFF
--- a/src/engines/ChatPanel/ChatHistory/components/TurnMetadataFooterSlot.tsx
+++ b/src/engines/ChatPanel/ChatHistory/components/TurnMetadataFooterSlot.tsx
@@ -1,6 +1,7 @@
 import { useAtomValue } from "jotai";
 import React, { memo } from "react";
 
+import { chatTurnMetadataVisibleAtom } from "@src/store/ui/chatPanelAtom";
 import { hasLoadedMoreActivitiesAtom } from "@src/store/ui/sessionPaginationAtom";
 
 import { turnMetadataAtomFamily, turnMetadataKey } from "../turnMetadataAtom";
@@ -19,7 +20,13 @@ const TurnMetadataFooterSlot: React.FC<TurnMetadataFooterSlotProps> = memo(
       turnMetadataAtomFamily(turnMetadataKey(sessionId ?? "", turnId))
     );
     const hasLoadedMoreActivities = useAtomValue(hasLoadedMoreActivitiesAtom);
-    if (!sessionId || !summary || !isTerminalTurnStatus(summary.status))
+    const turnMetadataVisible = useAtomValue(chatTurnMetadataVisibleAtom);
+    if (
+      !turnMetadataVisible ||
+      !sessionId ||
+      !summary ||
+      !isTerminalTurnStatus(summary.status)
+    )
       return null;
     return (
       <TurnMetadataFooter

--- a/src/engines/ChatPanel/ChatHistory/components/__tests__/TurnMetadataFooterSlot.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/components/__tests__/TurnMetadataFooterSlot.test.ts
@@ -1,0 +1,79 @@
+import { Provider, createStore } from "jotai";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { TurnSummary } from "@src/engines/SessionCore/storage/sqliteCache";
+import { chatTurnMetadataVisibleAtom } from "@src/store/ui/chatPanelAtom";
+
+import {
+  turnMetadataAtomFamily,
+  turnMetadataKey,
+} from "../../turnMetadataAtom";
+import TurnMetadataFooterSlot from "../TurnMetadataFooterSlot";
+
+vi.mock("@src/components/FileTypeIcon", () => ({
+  default: () => React.createElement("span"),
+}));
+
+const SUMMARY: TurnSummary = {
+  sessionId: "session-1",
+  turnId: "turn-1",
+  startSequence: 1,
+  endSequence: 2,
+  nextTurnId: null,
+  startedAt: "2026-07-30T00:00:00.000Z",
+  endedAt: "2026-07-30T00:00:01.000Z",
+  durationMs: 1000,
+  userEventIds: [],
+  userPreview: "",
+  eventCount: 1,
+  bodyEventCount: 1,
+  status: "completed",
+  interrupted: false,
+  modifiedFiles: [
+    {
+      path: "src/app.ts",
+      fileName: "app.ts",
+      status: "modified",
+      additions: 2,
+      deletions: 1,
+    },
+  ],
+  resourceInteractions: [],
+  gitArtifacts: [],
+};
+
+function renderSlot(visible: boolean): string {
+  const store = createStore();
+  store.set(
+    turnMetadataAtomFamily(turnMetadataKey(SUMMARY.sessionId, SUMMARY.turnId)),
+    SUMMARY
+  );
+  store.set(chatTurnMetadataVisibleAtom, visible);
+  return renderToStaticMarkup(
+    React.createElement(
+      Provider,
+      { store },
+      React.createElement(TurnMetadataFooterSlot, {
+        sessionId: SUMMARY.sessionId,
+        turnId: SUMMARY.turnId,
+        isLastGroup: true,
+      })
+    )
+  );
+}
+
+describe("TurnMetadataFooterSlot visibility toggle", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("renders the edits/reads card when the toggle is on", () => {
+    expect(renderSlot(true)).toContain('data-testid="turn-metadata-footer"');
+  });
+
+  it("renders nothing when the toggle is off", () => {
+    expect(renderSlot(false)).toBe("");
+  });
+});

--- a/src/engines/ChatPanel/ChatPanelHeader.tsx
+++ b/src/engines/ChatPanel/ChatPanelHeader.tsx
@@ -49,6 +49,7 @@ interface ChatPanelHeaderProps {
   handlePaginationToggle: (checked: boolean) => void;
   handleReloadFromMenu: () => void;
   handleTokenUsageVisibleToggle: (checked: boolean) => void;
+  handleTurnMetadataVisibleToggle: (checked: boolean) => void;
   headerActionsDropdownRef: React.RefObject<HTMLDivElement | null>;
   headerActionsPosition: DropdownEnginePosition;
   headerActionsTriggerRef: React.RefObject<HTMLButtonElement | null>;
@@ -58,6 +59,7 @@ interface ChatPanelHeaderProps {
   focusedWorkstationMenuHostRef?: React.RefCallback<HTMLSpanElement>;
   paginationEnabled: boolean;
   tokenUsageVisible: boolean;
+  turnMetadataVisible: boolean;
   shouldOffsetHeaderForCollapsedSidebar: boolean;
   showChatFocusToggle: boolean;
   showHeader: boolean;
@@ -98,6 +100,7 @@ export function ChatPanelHeader({
   handlePaginationToggle,
   handleReloadFromMenu,
   handleTokenUsageVisibleToggle,
+  handleTurnMetadataVisibleToggle,
   headerActionsDropdownRef,
   headerActionsPosition,
   headerActionsTriggerRef,
@@ -107,6 +110,7 @@ export function ChatPanelHeader({
   focusedWorkstationMenuHostRef,
   paginationEnabled,
   tokenUsageVisible,
+  turnMetadataVisible,
   shouldOffsetHeaderForCollapsedSidebar,
   showChatFocusToggle,
   showHeader,
@@ -208,6 +212,7 @@ export function ChatPanelHeader({
             handlePaginationToggle={handlePaginationToggle}
             handleReloadFromMenu={handleReloadFromMenu}
             handleTokenUsageVisibleToggle={handleTokenUsageVisibleToggle}
+            handleTurnMetadataVisibleToggle={handleTurnMetadataVisibleToggle}
             headerActionsDropdownRef={headerActionsDropdownRef}
             headerActionsPosition={headerActionsPosition}
             headerActionsTriggerRef={headerActionsTriggerRef}
@@ -218,6 +223,7 @@ export function ChatPanelHeader({
             showCloudShareSettings={showCloudShareSettings}
             showTranscriptActions={showTranscriptActions}
             tokenUsageVisible={tokenUsageVisible}
+            turnMetadataVisible={turnMetadataVisible}
             toggleHeaderActionsMenu={toggleHeaderActionsMenu}
             triggerTestId="chat-panel-header-more-button"
           />

--- a/src/engines/ChatPanel/components/SessionHeaderActionsMenu.tsx
+++ b/src/engines/ChatPanel/components/SessionHeaderActionsMenu.tsx
@@ -43,6 +43,7 @@ export interface SessionHeaderActionsMenuProps {
   handlePaginationToggle: (checked: boolean) => void;
   handleReloadFromMenu: () => void;
   handleTokenUsageVisibleToggle: (checked: boolean) => void;
+  handleTurnMetadataVisibleToggle: (checked: boolean) => void;
   headerActionsDropdownRef: React.RefObject<HTMLDivElement | null>;
   headerActionsPosition: DropdownEnginePosition;
   headerActionsTriggerRef: React.RefObject<HTMLButtonElement | null>;
@@ -53,6 +54,7 @@ export interface SessionHeaderActionsMenuProps {
   showCloudShareSettings: boolean;
   showTranscriptActions?: boolean;
   tokenUsageVisible: boolean;
+  turnMetadataVisible: boolean;
   toggleHeaderActionsMenu: () => void;
   triggerTestId: string;
 }
@@ -77,6 +79,7 @@ export const SessionHeaderActionsMenu: React.FC<
   handlePaginationToggle,
   handleReloadFromMenu,
   handleTokenUsageVisibleToggle,
+  handleTurnMetadataVisibleToggle,
   headerActionsDropdownRef,
   headerActionsPosition,
   headerActionsTriggerRef,
@@ -87,6 +90,7 @@ export const SessionHeaderActionsMenu: React.FC<
   showCloudShareSettings,
   showTranscriptActions = true,
   tokenUsageVisible,
+  turnMetadataVisible,
   toggleHeaderActionsMenu,
   triggerTestId,
 }) => {
@@ -257,6 +261,20 @@ export const SessionHeaderActionsMenu: React.FC<
                     onChange={handleTokenUsageVisibleToggle}
                     size="small"
                     ariaLabel={t("chat.showTokenUsage")}
+                  />
+                </div>
+                <div
+                  className={`${DROPDOWN_CLASSES.item} w-full justify-between text-left`}
+                >
+                  <span className="flex-1 truncate">
+                    {t("chat.showTurnMetadata")}
+                  </span>
+                  <Switch
+                    checked={turnMetadataVisible}
+                    onChange={handleTurnMetadataVisibleToggle}
+                    size="small"
+                    ariaLabel={t("chat.showTurnMetadata")}
+                    dataTestId="session-menu-turn-metadata-toggle"
                   />
                 </div>
                 <div

--- a/src/engines/ChatPanel/hooks/useSessionHeaderActions.ts
+++ b/src/engines/ChatPanel/hooks/useSessionHeaderActions.ts
@@ -9,6 +9,7 @@ import { useDropdownEngine } from "@src/hooks/dropdown";
 import {
   chatHistoryDisplayModeAtom,
   chatTokenUsageVisibleAtom,
+  chatTurnMetadataVisibleAtom,
   chatTurnPaginationEnabledAtom,
 } from "@src/store/ui/chatPanelAtom";
 
@@ -41,6 +42,9 @@ export function useSessionHeaderActions({
   const [displayMode, setDisplayMode] = useAtom(chatHistoryDisplayModeAtom);
   const [tokenUsageVisible, setTokenUsageVisible] = useAtom(
     chatTokenUsageVisibleAtom
+  );
+  const [turnMetadataVisible, setTurnMetadataVisible] = useAtom(
+    chatTurnMetadataVisibleAtom
   );
   const eventCount = useAtomValue(eventCountAtom);
   const events = useAtomValue(eventsAtom);
@@ -77,6 +81,10 @@ export function useSessionHeaderActions({
     (checked: boolean) => setTokenUsageVisible(checked),
     [setTokenUsageVisible]
   );
+  const handleTurnMetadataVisibleToggle = useCallback(
+    (checked: boolean) => setTurnMetadataVisible(checked),
+    [setTurnMetadataVisible]
+  );
 
   const handleCopyEventJson = useCallback(() => {
     const json = JSON.stringify(events, null, 2);
@@ -105,6 +113,7 @@ export function useSessionHeaderActions({
     handleRegisterSearchOpen,
     handleReloadFromMenu,
     handleTokenUsageVisibleToggle,
+    handleTurnMetadataVisibleToggle,
     headerActionsDropdownRef,
     headerActionsPosition,
     headerActionsTriggerRef,
@@ -112,6 +121,7 @@ export function useSessionHeaderActions({
     isHeaderActionsPositioned,
     paginationEnabled,
     tokenUsageVisible,
+    turnMetadataVisible,
     toggleHeaderActionsMenu,
   };
 }

--- a/src/engines/ChatPanel/index.tsx
+++ b/src/engines/ChatPanel/index.tsx
@@ -324,6 +324,7 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
       handleRegisterSearchOpen,
       handleReloadFromMenu,
       handleTokenUsageVisibleToggle,
+      handleTurnMetadataVisibleToggle,
       headerActionsDropdownRef,
       headerActionsPosition,
       headerActionsTriggerRef,
@@ -331,6 +332,7 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
       isHeaderActionsPositioned,
       paginationEnabled,
       tokenUsageVisible,
+      turnMetadataVisible,
       toggleHeaderActionsMenu,
     } = useChatPanelHeaderActions({ handleReloadSession });
 
@@ -531,6 +533,7 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
         handlePaginationToggle={handlePaginationToggle}
         handleReloadFromMenu={handleReloadFromMenu}
         handleTokenUsageVisibleToggle={handleTokenUsageVisibleToggle}
+        handleTurnMetadataVisibleToggle={handleTurnMetadataVisibleToggle}
         headerActionsDropdownRef={headerActionsDropdownRef}
         headerActionsPosition={headerActionsPosition}
         headerActionsTriggerRef={headerActionsTriggerRef}
@@ -544,6 +547,7 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
         }
         paginationEnabled={paginationEnabled}
         tokenUsageVisible={tokenUsageVisible}
+        turnMetadataVisible={turnMetadataVisible}
         shouldOffsetHeaderForCollapsedSidebar={
           shouldOffsetHeaderForCollapsedSidebar
         }

--- a/src/modules/WorkStation/TabContent/renderers/chatSession.tsx
+++ b/src/modules/WorkStation/TabContent/renderers/chatSession.tsx
@@ -142,6 +142,9 @@ const ChatSessionTabRenderer: React.FC<UnifiedTabContentProps> = memo(
           handleTokenUsageVisibleToggle={
             headerActions.handleTokenUsageVisibleToggle
           }
+          handleTurnMetadataVisibleToggle={
+            headerActions.handleTurnMetadataVisibleToggle
+          }
           headerActionsDropdownRef={headerActions.headerActionsDropdownRef}
           headerActionsPosition={headerActions.headerActionsPosition}
           headerActionsTriggerRef={headerActions.headerActionsTriggerRef}
@@ -152,6 +155,7 @@ const ChatSessionTabRenderer: React.FC<UnifiedTabContentProps> = memo(
           showCloudShareSettings={sessionActions.showCloudShareSettings}
           showTranscriptActions={!humanSession}
           tokenUsageVisible={headerActions.tokenUsageVisible}
+          turnMetadataVisible={headerActions.turnMetadataVisible}
           toggleHeaderActionsMenu={headerActions.toggleHeaderActionsMenu}
           triggerTestId="workstation-session-header-more-button"
         />

--- a/src/store/ui/chatPanelAtom.ts
+++ b/src/store/ui/chatPanelAtom.ts
@@ -219,6 +219,20 @@ export const chatTokenUsageVisibleAtom = atomWithStorage<boolean>(
 );
 chatTokenUsageVisibleAtom.debugLabel = "chatTokenUsageVisibleAtom";
 
+/**
+ * Whether the per-round edits/reads summary card (`TurnMetadataFooter`)
+ * renders at the end of each agent turn. On by default; turning it off
+ * only hides the card — turn metadata is still indexed and still backs
+ * the composer files pill and Agent Station diff scoping.
+ */
+export const chatTurnMetadataVisibleAtom = atomWithStorage<boolean>(
+  "orgii:chatTurnMetadataVisible",
+  true,
+  createZodJsonStorage(z.boolean()),
+  { getOnInit: true }
+);
+chatTurnMetadataVisibleAtom.debugLabel = "chatTurnMetadataVisibleAtom";
+
 /** Presentation style for the chat panel model picker. */
 export type ModelPickerStyle = "spotlight" | "dropdown";
 


### PR DESCRIPTION
## Problem

The per-turn "edits & reads" summary card renders after every agent turn with no way to opt out. Users who want a compact transcript had no way to hide it — unlike token usage, which already has a visibility toggle in the session header menu.

## Solution

New persisted `chatTurnMetadataVisibleAtom` (default **on**, localStorage-backed like its token-usage sibling) gates rendering of `TurnMetadataFooterSlot`. It is wired as a `Switch` row in `SessionHeaderActionsMenu` directly below the token-usage toggle, through both header paths (chat panel and workstation tab renderer), using the existing `chat.showTurnMetadata` locale key.

Hiding the card changes presentation only — turn metadata is still indexed and still backs the composer files pill and Agent Station diff scoping (stated in the atom's doc comment).

## Potential risks

- Low: default-on preserves today's behavior for everyone; the atom is presentation-only.
- One more prop drilled through `ChatPanelHeader` → `SessionHeaderActionsMenu`; this follows the exact pattern of the existing `tokenUsageVisible` toggle rather than introducing a new one.

## Test plan

- New `TurnMetadataFooterSlot` test renders the slot through a seeded jotai `Provider` and asserts the card renders with the toggle on and disappears with it off (2 tests, passing).
- `tsc --noEmit` clean, eslint clean, pre-commit scoped hooks pass.
