### PR TITLE
refactor(runtime): drop the self-service footer from the team panel

### DIFF
--- a/src/modules/shared/dataSource/TeamRuntimePanel.test.ts
+++ b/src/modules/shared/dataSource/TeamRuntimePanel.test.ts
@@ -18,25 +18,17 @@ import { utcDayStartMs } from "./teamRuntimeData";
 const mocks = vi.hoisted(() => ({
   listMemberRuntime: vi.fn(),
   getMemberUsage: vi.fn(),
-  clearMemberRuntime: vi.fn(),
   getCloudCapabilities: vi.fn(),
   ensureFreshSession: vi.fn(),
   externalCliSourcesDetect: vi.fn(),
-  updateSettingsBatch: vi.fn(),
   signIn: vi.fn(),
-  resetMemberRuntimePushState: vi.fn(),
 }));
 
 vi.mock("@src/features/Org2Cloud/memberRuntime/memberRuntimeClient", () => ({
   listMemberRuntime: mocks.listMemberRuntime,
   getMemberUsage: mocks.getMemberUsage,
-  clearMemberRuntime: mocks.clearMemberRuntime,
   upsertMemberRuntime: vi.fn(),
   setOrgRuntimeTelemetry: vi.fn(),
-}));
-
-vi.mock("@src/features/Org2Cloud/memberRuntime/memberRuntimePushState", () => ({
-  resetMemberRuntimePushState: mocks.resetMemberRuntimePushState,
 }));
 
 // The auth and orgs atoms are replaced with plain writable atoms so each test
@@ -77,10 +69,6 @@ vi.mock("@src/api/tauri/usageDashboard", () => ({
 
 vi.mock("@src/features/Org2Cloud/useOrg2CloudSignIn", () => ({
   useOrg2CloudSignIn: () => mocks.signIn,
-}));
-
-vi.mock("@src/hooks/settings/useSettings", () => ({
-  useUpdateSettingsBatch: () => mocks.updateSettingsBatch,
 }));
 
 vi.mock("@src/hooks/ui", () => ({
@@ -398,7 +386,6 @@ beforeEach(() => {
   mocks.getCloudCapabilities.mockResolvedValue({ memberRuntime: true });
   mocks.listMemberRuntime.mockResolvedValue([]);
   mocks.getMemberUsage.mockResolvedValue([]);
-  mocks.clearMemberRuntime.mockResolvedValue(undefined);
   mocks.externalCliSourcesDetect.mockResolvedValue([
     {
       sourceId: "claude",
@@ -649,115 +636,6 @@ describe("TeamRuntimePanel drilldown", () => {
     });
     expect(
       container.querySelector('[data-testid="team-runtime-grid"]')
-    ).not.toBeNull();
-  });
-});
-
-describe("TeamRuntimePanel self-service", () => {
-  it("confirms inline, clears remote data, and flips the privacy setting off", async () => {
-    mocks.listMemberRuntime.mockResolvedValue([member()]);
-    await seedAtoms(AUTH, [org()]);
-    await mount();
-
-    await act(async () => {
-      container
-        .querySelector<HTMLButtonElement>(
-          '[data-testid="team-runtime-stop-sharing"]'
-        )
-        ?.click();
-    });
-    // Nothing destructive before the inline confirm.
-    expect(mocks.clearMemberRuntime).not.toHaveBeenCalled();
-    expect(
-      container.querySelector('[data-testid="team-runtime-stop-confirm"]')
-    ).not.toBeNull();
-
-    await act(async () => {
-      container
-        .querySelector<HTMLButtonElement>(
-          '[data-testid="team-runtime-stop-confirm"]'
-        )
-        ?.click();
-    });
-    for (let i = 0; i < 6; i += 1) {
-      await act(async () => {
-        await Promise.resolve();
-      });
-    }
-
-    expect(mocks.updateSettingsBatch).toHaveBeenCalledWith({
-      "privacy.shareRuntimeWithOrg": false,
-    });
-    expect(mocks.clearMemberRuntime).toHaveBeenCalledWith("token-1", "org-1");
-    // The remote delete succeeded: reset the local push-state fingerprints
-    // (same identityKey derivation the scheduler uses) so re-enabling
-    // sharing re-sends everything instead of skipping "unchanged" rows the
-    // server no longer has.
-    expect(mocks.resetMemberRuntimePushState).toHaveBeenCalledWith(
-      "https://cloud.example|me",
-      "org-1"
-    );
-  });
-
-  it("does not reset push state when the remote clear fails", async () => {
-    mocks.listMemberRuntime.mockResolvedValue([member()]);
-    mocks.clearMemberRuntime.mockRejectedValue(new Error("boom"));
-    await seedAtoms(AUTH, [org()]);
-    await mount();
-
-    await act(async () => {
-      container
-        .querySelector<HTMLButtonElement>(
-          '[data-testid="team-runtime-stop-sharing"]'
-        )
-        ?.click();
-    });
-    await act(async () => {
-      container
-        .querySelector<HTMLButtonElement>(
-          '[data-testid="team-runtime-stop-confirm"]'
-        )
-        ?.click();
-    });
-    for (let i = 0; i < 6; i += 1) {
-      await act(async () => {
-        await Promise.resolve();
-      });
-    }
-
-    expect(mocks.clearMemberRuntime).toHaveBeenCalledWith("token-1", "org-1");
-    expect(mocks.resetMemberRuntimePushState).not.toHaveBeenCalled();
-    expect(
-      container.querySelector('[data-testid="team-runtime-self-service"]')
-        ?.textContent
-    ).toContain("boom");
-  });
-
-  it("cancel backs out without touching anything", async () => {
-    mocks.listMemberRuntime.mockResolvedValue([member()]);
-    await seedAtoms(AUTH, [org()]);
-    await mount();
-
-    await act(async () => {
-      container
-        .querySelector<HTMLButtonElement>(
-          '[data-testid="team-runtime-stop-sharing"]'
-        )
-        ?.click();
-    });
-    await act(async () => {
-      container
-        .querySelector<HTMLButtonElement>(
-          '[data-testid="team-runtime-stop-cancel"]'
-        )
-        ?.click();
-    });
-
-    expect(mocks.clearMemberRuntime).not.toHaveBeenCalled();
-    expect(mocks.updateSettingsBatch).not.toHaveBeenCalled();
-    expect(mocks.resetMemberRuntimePushState).not.toHaveBeenCalled();
-    expect(
-      container.querySelector('[data-testid="team-runtime-stop-sharing"]')
     ).not.toBeNull();
   });
 });

--- a/src/modules/shared/dataSource/TeamRuntimePanel.tsx
+++ b/src/modules/shared/dataSource/TeamRuntimePanel.tsx
@@ -3,9 +3,8 @@
  * usage/cost headlines, builder type, installed agents — read from ORG2 Cloud
  * (`cloud_list_member_runtime`) for the selected cloud org.
  *
- * The panel is read-only toward the org except for the footer self-service:
- * the signed-in member can stop sharing (local `privacy.shareRuntimeWithOrg`
- * setting) and delete their own reported rows (`cloud_clear_member_runtime`).
+ * The panel is read-only: opting out of sharing lives in the privacy settings
+ * (`privacy.shareRuntimeWithOrg`), not here.
  */
 import { RefreshCw } from "lucide-react";
 import {
@@ -20,12 +19,7 @@ import { useTranslation } from "react-i18next";
 import { externalCliSourcesDetect } from "@src/api/tauri/externalHistory/detection";
 import Button from "@src/components/Button";
 import Select from "@src/components/Select";
-import type { SettingsObject } from "@src/config/settingsSchema";
-import { clearMemberRuntime } from "@src/features/Org2Cloud/memberRuntime/memberRuntimeClient";
-import { resetMemberRuntimePushState } from "@src/features/Org2Cloud/memberRuntime/memberRuntimePushState";
-import { SHARE_RUNTIME_SETTING_KEY } from "@src/features/Org2Cloud/memberRuntime/types";
 import { useOrg2CloudSignIn } from "@src/features/Org2Cloud/useOrg2CloudSignIn";
-import { useUpdateSettingsBatch } from "@src/hooks/settings/useSettings";
 import { useRefreshSpin } from "@src/hooks/ui";
 import {
   SECTION_GAP_CLASSES,
@@ -73,23 +67,6 @@ function useAgentCatalog(): AgentCatalog {
   return catalog;
 }
 
-/**
- * `privacy.shareRuntimeWithOrg` joins the settings registry with the plumbing
- * change; the cast keeps this file compiling against the pre-landing registry
- * while writing exactly the frozen key.
- */
-function useSetShareRuntimeSetting(): (enabled: boolean) => void {
-  const updateBatch = useUpdateSettingsBatch();
-  return useCallback(
-    (enabled: boolean) => {
-      updateBatch({
-        [SHARE_RUNTIME_SETTING_KEY]: enabled,
-      } as Partial<SettingsObject>);
-    },
-    [updateBatch]
-  );
-}
-
 /** Chat pane → Runtime → Team: the member-runtime roster. */
 export default function TeamRuntimePanel() {
   const { t, i18n } = useTranslation("teamRuntime");
@@ -97,12 +74,8 @@ export default function TeamRuntimePanel() {
   const roster = useTeamRuntimeRoster();
   const agentCatalog = useAgentCatalog();
   const signIn = useOrg2CloudSignIn();
-  const setShareRuntime = useSetShareRuntimeSetting();
 
   const [openMemberId, setOpenMemberId] = useState<string | null>(null);
-  const [confirmingStop, setConfirmingStop] = useState(false);
-  const [stopping, setStopping] = useState(false);
-  const [stopError, setStopError] = useState<string | null>(null);
 
   // One clock per render pass so staleness and the today/7d fold agree across
   // every card. Quantized to the whole minute (org intervals are >=15min, so
@@ -110,14 +83,14 @@ export default function TeamRuntimePanel() {
   // click, a settings change) recomputes the SAME nowMs value instead of a
   // strictly-increasing one — otherwise every card's `nowMs` prop would
   // differ by construction and the `TeamMemberCard` React.memo comparison
-  // could never hold.
+  // could never hold. The minute quantization is exactly what makes the read
+  // render-stable, so the purity rule's concern doesn't apply here.
+  // eslint-disable-next-line react-hooks/purity -- quantized clock, see above
   const nowMs = Math.floor(Date.now() / 60_000) * 60_000;
 
   // Leaving the org scope or losing the member closes the drilldown.
   useEffect(() => {
     setOpenMemberId(null);
-    setConfirmingStop(false);
-    setStopError(null);
   }, [roster.selectedOrgId, roster.currentUserId]);
 
   const { spinClass, handleClick: handleRefreshClick } = useRefreshSpin(
@@ -148,32 +121,6 @@ export default function TeamRuntimePanel() {
   const handleOpenMember = useCallback((userId: string) => {
     setOpenMemberId(userId);
   }, []);
-
-  const handleStopSharing = useCallback(async () => {
-    if (stopping || !roster.selectedOrgId) return;
-    setStopping(true);
-    setStopError(null);
-    // Flip the local opt-out first: it cannot fail, and the scheduler must
-    // stop pushing even if the remote delete needs a retry.
-    setShareRuntime(false);
-    try {
-      const accessToken = await roster.getFreshAccessToken();
-      await clearMemberRuntime(accessToken, roster.selectedOrgId);
-      // The server just deleted every row this member reported. Without
-      // resetting the local fingerprint cursor, re-enabling sharing would
-      // see "unchanged" usage-days/profile/agents against content the
-      // server no longer has and skip re-sending them.
-      if (roster.identityKey) {
-        resetMemberRuntimePushState(roster.identityKey, roster.selectedOrgId);
-      }
-      setConfirmingStop(false);
-      roster.refresh();
-    } catch (err) {
-      setStopError(err instanceof Error ? err.message : String(err));
-    } finally {
-      setStopping(false);
-    }
-  }, [roster, setShareRuntime, stopping]);
 
   let content: ReactNode;
   switch (roster.phase) {
@@ -264,76 +211,22 @@ export default function TeamRuntimePanel() {
         );
       } else {
         content = (
-          <>
-            <div
-              className="grid grid-cols-1 gap-3 @[640px]:grid-cols-2"
-              data-testid="team-runtime-grid"
-            >
-              {roster.members.map((member) => (
-                <TeamMemberCard
-                  key={member.userId}
-                  entry={member}
-                  telemetry={roster.telemetry}
-                  nowMs={nowMs}
-                  agentCatalog={agentCatalog}
-                  isSelf={member.userId === roster.currentUserId}
-                  onOpen={handleOpenMember}
-                />
-              ))}
-            </div>
-
-            <div
-              className="flex flex-wrap items-center justify-between gap-2 border-t border-border-1 pt-3"
-              data-testid="team-runtime-self-service"
-            >
-              <span className="text-[11px] text-text-3">
-                {t("selfService.hint")}
-              </span>
-              {confirmingStop ? (
-                <span className="flex items-center gap-2">
-                  <span className="text-xs text-text-2">
-                    {t("selfService.confirm")}
-                  </span>
-                  <Button
-                    variant="danger"
-                    size="small"
-                    loading={stopping}
-                    disabled={stopping}
-                    onClick={() => void handleStopSharing()}
-                    data-testid="team-runtime-stop-confirm"
-                  >
-                    {t("selfService.confirmYes")}
-                  </Button>
-                  <Button
-                    variant="tertiary"
-                    size="small"
-                    disabled={stopping}
-                    onClick={() => {
-                      setConfirmingStop(false);
-                      setStopError(null);
-                    }}
-                    data-testid="team-runtime-stop-cancel"
-                  >
-                    {t("selfService.confirmNo")}
-                  </Button>
-                </span>
-              ) : (
-                <Button
-                  variant="tertiary"
-                  size="small"
-                  onClick={() => setConfirmingStop(true)}
-                  data-testid="team-runtime-stop-sharing"
-                >
-                  {t("selfService.action")}
-                </Button>
-              )}
-              {stopError ? (
-                <span className="w-full text-right text-[12px] text-danger-6">
-                  {stopError}
-                </span>
-              ) : null}
-            </div>
-          </>
+          <div
+            className="grid grid-cols-1 gap-3 @[640px]:grid-cols-2"
+            data-testid="team-runtime-grid"
+          >
+            {roster.members.map((member) => (
+              <TeamMemberCard
+                key={member.userId}
+                entry={member}
+                telemetry={roster.telemetry}
+                nowMs={nowMs}
+                agentCatalog={agentCatalog}
+                isSelf={member.userId === roster.currentUserId}
+                onOpen={handleOpenMember}
+              />
+            ))}
+          </div>
         );
       }
       break;


### PR DESCRIPTION
## Problem

The Team Runtime roster panel carried a self-service footer (stop sharing + delete my reported rows) with its own confirm flow, error state, and push-state reset. That control belongs with the `privacy.shareRuntimeWithOrg` setting — where users actually look for sharing controls — and duplicating it inside the roster made a read-only panel stateful for no reader benefit. Separately, the panel's minute-quantized `Date.now()` clock read tripped the `react-hooks/purity` lint rule.

## Solution

- Remove the footer and its `confirmingStop`/`stopping`/`stopError` state, the settings-write hook, and the `clearMemberRuntime` + `resetMemberRuntimePushState` wiring. The panel is now purely read-only over the roster; opting out lives with the privacy setting.
- Annotate the quantized clock read with a scoped `eslint-disable-next-line react-hooks/purity`: the minute quantization is exactly what makes the read render-stable (the `React.memo` rationale is in the adjacent comment).

## Potential risks

- The panel no longer offers remote-row deletion (`cloud_clear_member_runtime`). Until the privacy-settings side wires up `clearMemberRuntime`, "delete my already-reported rows" is not reachable from the UI — flipping the setting only stops future pushes. `clearMemberRuntime`/`resetMemberRuntimePushState` remain exported for that wiring.
- `selfService.*` keys in the `teamRuntime` i18n namespace become unused (left in place for now).

## Test plan

- `TeamRuntimePanel.test.ts`: the self-service suite is removed alongside the UI; the remaining roster tests pass.
- `tsc --noEmit` clean, eslint clean (suppression scoped to the one line), pre-commit scoped hooks pass.
