### PR TITLE
feat(sidebar): show git branch and PR status on session rows

### DIFF
--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache.rs
@@ -406,7 +406,7 @@ pub fn query_imported_sidebar_page_from_conn(
         "SELECT session_id, name, created_at_ms, updated_at_ms, cache.repo_path,
                 model, files_changed, lines_added, lines_removed, touched_files_json,
                 input_tokens, output_tokens, source_path,
-                identity.repo_root_path, identity.remote_urls_json
+                identity.repo_root_path, identity.remote_urls_json, cache.branch
          FROM imported_history_session_cache cache
          LEFT JOIN imported_history_repo_identity identity
            ON identity.working_path = cache.repo_path
@@ -440,6 +440,9 @@ pub fn query_imported_sidebar_page_from_conn(
                     .map_err(|err| {
                         rusqlite::Error::FromSqlConversionFailure(14, Type::Text, Box::new(err))
                     })?;
+            // Stored as "" for sources that report no branch (the upsert
+            // coalesces `None`), so normalize back to absent.
+            let branch: String = row.get(15)?;
             Ok(ImportedHistorySidebarRow {
                 session_id: row.get(0)?,
                 name: row.get(1)?,
@@ -450,6 +453,7 @@ pub fn query_imported_sidebar_page_from_conn(
                 repo_path: non_empty_string(repo_path),
                 repo_root_path: repo_root_path.and_then(non_empty_string),
                 repo_remote_urls,
+                branch: non_empty_string(branch),
                 storage_path: non_empty_string(source_path),
                 model: non_empty_string(model),
                 total_tokens: input_tokens + output_tokens,

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache_tests.rs
@@ -137,11 +137,30 @@ fn sidebar_query_is_date_bounded_and_carries_impact_metadata() {
     // The Kanban board and other card surfaces render these inline, so the
     // lightweight sidebar row must carry them (regression guard).
     assert_eq!(row.model.as_deref(), Some("model-a"));
+    // The sidebar's git indicator reads this branch straight from the cache —
+    // it is whatever the source app recorded, never a working-copy lookup.
+    assert_eq!(row.branch.as_deref(), Some("main"));
     assert_eq!(row.total_tokens, 7); // input_tokens (3) + output_tokens (4)
     assert_eq!(row.files_changed, 1);
     assert_eq!(row.lines_added, 7);
     assert_eq!(row.lines_removed, 2);
     assert_eq!(row.touched_files, vec!["large/path.rs".to_string()]);
+}
+
+#[test]
+fn sidebar_query_reports_no_branch_for_sources_that_record_none() {
+    let mut conn = fixture_conn();
+    let mut branchless = input(SOURCE_CODEX_APP, "branchless", 250);
+    branchless.branch = None;
+    upsert_imported_session_cache_from_conn(&mut conn, &[branchless]).expect("upsert");
+
+    let page =
+        query_imported_sidebar_page_from_conn(&conn, SOURCE_CODEX_APP, Some(200), Some(300), 10, 0)
+            .expect("sidebar page");
+
+    // The upsert stores `None` as "", which must not reach the frontend as an
+    // empty branch — that would render a git indicator with no branch at all.
+    assert_eq!(page.sessions[0].branch, None);
 }
 
 #[test]

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/mod.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/mod.rs
@@ -216,6 +216,13 @@ pub struct ImportedHistorySidebarRow {
     pub repo_root_path: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub repo_remote_urls: Vec<String>,
+    /// Git branch recorded by the source application itself (Claude Code's
+    /// `gitBranch` transcript field, Cursor/Windsurf tracked-repo metadata).
+    /// Never derived by scanning the working copy: sources that do not report
+    /// a branch leave this absent, and so do rows cached before it was
+    /// carried onto the sidebar projection.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
     /// The source app's own transcript file — the store of record for an
     /// imported session, which never has a `sessions.db` copy. Absent for
     /// rows cached before the path was recorded.

--- a/src/api/tauri/rpc/schemas/sessionAggregate.ts
+++ b/src/api/tauri/rpc/schemas/sessionAggregate.ts
@@ -246,6 +246,10 @@ export const ExternalHistorySidebarRowSchema = z.object({
   repoPath: z.string().optional(),
   repoRootPath: z.string().optional(),
   repoRemoteUrls: z.array(z.string()).optional(),
+  // Branch as recorded by the source app itself (Claude Code transcripts,
+  // Cursor/Windsurf tracked-repo metadata). Absent for sources that never
+  // report one — the sidebar simply omits the git indicator then.
+  branch: z.string().optional(),
   // The source app's transcript file. Imported sessions have no sessions.db
   // copy, so this is their only storage path.
   storagePath: z.string().optional(),

--- a/src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/NavigationMenuRow.test.ts
+++ b/src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/NavigationMenuRow.test.ts
@@ -87,4 +87,46 @@ describe("NavigationMenuRow", () => {
       `lucide-refresh-cw ${REFRESH_ICON_TOKENS.oneShot}`
     );
   });
+
+  it("swaps the accessory slot instantly, with no reveal animation", () => {
+    const markup = renderToStaticMarkup(
+      createElement(NavigationMenuLeafRow, {
+        item: {
+          ...baseItem,
+          shortcut: "21h",
+          showMoreActions: true,
+          trailingElement: createElement("span", null, "dot"),
+        },
+        isChild: false,
+        isSelected: false,
+        collapsed: false,
+        t: (key: string) => key,
+        renderIcon: () => null,
+        onMenuItemClick: vi.fn(),
+        onMenuItemContextMenu: vi.fn(),
+        onRowMouseEnter: vi.fn(),
+        onRowActionClick: vi.fn(),
+      })
+    );
+
+    // The reveal must not animate: an animated width reflowed the label on
+    // every frame, and the crossfade left the persistent glyph painted over the
+    // `more` button for the duration. The layer still collapses at rest so the
+    // label keeps its width — it just resizes in one step.
+    expect(markup).not.toContain("transition-[max-width");
+    expect(markup).not.toContain("transition-opacity");
+    expect(markup).toContain("max-w-0");
+    expect(markup).toContain("group-hover:opacity-0");
+    expect(markup).toContain("group-hover:opacity-100");
+
+    // The 2px edge nudge must sit ON the `overflow-hidden` layer. Inside it,
+    // those 2px fall outside the clip rect and shear the last button's right
+    // edge — which is exactly what the sidebar showed.
+    const clippingLayer = markup.match(
+      /class="[^"]*overflow-hidden[^"]*max-w-0[^"]*"|class="[^"]*max-w-0[^"]*overflow-hidden[^"]*"/
+    )?.[0];
+    expect(clippingLayer).toBeDefined();
+    expect(clippingLayer).toContain("-mr-0.5");
+    expect(markup).not.toContain('class="-mr-0.5');
+  });
 });

--- a/src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/RowAccessorySlot.tsx
+++ b/src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/RowAccessorySlot.tsx
@@ -30,10 +30,10 @@ export function NavigationMenuRowAccessorySlot({
     return null;
   }
 
-  // Persistent content fades on hover ONLY when hover content replaces it
+  // Persistent content hides on hover ONLY when hover content replaces it
   // (develop's guard — otherwise it blinks out with nothing in its place);
-  // parent thread rows scope the transition to the named group so a nested
-  // child's anonymous `group` cannot capture it.
+  // parent thread rows scope the swap to the named group so a nested child's
+  // anonymous `group` cannot capture it.
   const hasHoverReplacement = Boolean(hoverContent || actionContent);
   const persistentHoverClasses = !hasHoverReplacement
     ? ""
@@ -43,6 +43,12 @@ export function NavigationMenuRowAccessorySlot({
   const revealedHoverClasses = parentHoverGroup
     ? "group-hover/parent:pointer-events-auto group-hover/parent:max-w-[11rem] group-hover/parent:opacity-100"
     : "group-hover:pointer-events-auto group-hover:max-w-[11rem] group-hover:opacity-100";
+  // The action group is nudged 2px past the slot's right edge so its glyphs sit
+  // as close to the row edge as the at-rest status dot (a 20px hit target pads
+  // its 14px icon by 3px). That nudge has to live on the CLIPPING layer, not on
+  // a child of it: a negative margin inside an `overflow-hidden` box puts those
+  // 2px outside the clip rect, which sheared the right edge off the last button.
+  const actionNudgeClass = actionContent ? "-mr-0.5" : "";
   const hasStacked = Boolean(
     persistentContent ||
     hoverContent ||
@@ -51,14 +57,21 @@ export function NavigationMenuRowAccessorySlot({
   );
   const stackedContent = hasStacked ? (
     <span className="grid items-center justify-end leading-none">
-      {/* Both layers share one grid cell and must be `justify-self-end`. The
+      {/* Both layers share one grid cell and must be `justify-self-end`: the
           cell is as wide as the widest layer, and a stretched item whose
-          `max-width` clamps it falls back to *start* alignment — so while the
-          reveal animates `max-w-0 → 11rem` the buttons would slide rightwards
-          from behind the persistent layer instead of staying put. */}
+          `max-width` clamps it falls back to *start* alignment, which would
+          park the buttons left of where they belong.
+
+          The hover layer still collapses to `max-w-0` at rest — reserving its
+          width permanently would cost every row ~30px of label — but the swap
+          carries NO transition. That is deliberate: an animated reveal reflowed
+          the label on every frame (visible jitter) and, worse, left the two
+          layers painted on top of each other for 150ms, so the persistent git
+          glyph eclipsed the `more` button on the way in. Instant means the cell
+          resizes exactly once and only one layer is ever on screen. */}
       {(persistentContent || workingIndicatorContent) && (
         <span
-          className={`col-start-1 row-start-1 inline-flex items-center justify-end justify-self-end leading-none transition-opacity duration-150 ${persistentHoverClasses}`}
+          className={`col-start-1 row-start-1 inline-flex items-center justify-end justify-self-end leading-none ${persistentHoverClasses}`}
         >
           {persistentContent}
           {workingIndicatorContent}
@@ -66,7 +79,7 @@ export function NavigationMenuRowAccessorySlot({
       )}
       {(hoverContent || actionContent) && (
         <span
-          className={`pointer-events-none col-start-1 row-start-1 inline-flex max-w-0 items-center justify-end gap-1.5 justify-self-end overflow-hidden whitespace-nowrap opacity-0 transition-[max-width,opacity] duration-150 ${revealedHoverClasses}`}
+          className={`pointer-events-none col-start-1 row-start-1 inline-flex max-w-0 items-center justify-end gap-1.5 justify-self-end overflow-hidden whitespace-nowrap opacity-0 ${actionNudgeClass} ${revealedHoverClasses}`}
         >
           {hoverContent && (
             <span className="inline-flex max-w-[4rem] items-center justify-end overflow-hidden">
@@ -74,7 +87,7 @@ export function NavigationMenuRowAccessorySlot({
             </span>
           )}
           {actionContent && (
-            <span className="-mr-0.5 inline-flex items-center justify-end gap-1">
+            <span className="inline-flex items-center justify-end gap-1">
               {actionContent}
             </span>
           )}

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/menuItemBuilders.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/menuItemBuilders.test.ts
@@ -1,0 +1,139 @@
+import type { ReactElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { BranchPrSnapshot } from "@src/store/git";
+import type { Session } from "@src/store/session";
+
+import { buildSessionMenuItem } from "../menuItemBuilders";
+
+const BASE_SESSION = {
+  session_id: "s1",
+  status: "completed",
+  created_at: "2026-07-30T00:00:00Z",
+  updated_at: "2026-07-30T00:00:00Z",
+  name: "Session",
+} satisfies Session;
+
+function buildItem(
+  session: Partial<Session>,
+  visited = ["s1"],
+  pr?: BranchPrSnapshot
+) {
+  return buildSessionMenuItem({
+    session: { ...BASE_SESSION, ...session },
+    untitledSession: "Untitled",
+    visitedSessions: new Set(visited),
+    pr,
+  });
+}
+
+function markup(node: unknown): string {
+  return renderToStaticMarkup(node as ReactElement);
+}
+
+describe("buildSessionMenuItem trailing accessories", () => {
+  it("renders only the status dot when the session reports no branch", () => {
+    const html = markup(buildItem({}).trailingElement);
+    expect(html).toContain("rounded-full");
+    expect(html).not.toContain("aria-label");
+  });
+
+  it("puts the git indicator before the status dot", () => {
+    const html = markup(
+      buildItem({ branch: "main" }, ["s1"], {
+        status: "open",
+        number: 1,
+        url: "https://github.com/o/r/pull/1",
+        title: "Add thing",
+      }).trailingElement
+    );
+    const gitIndex = html.indexOf('aria-label="Open PR #1: main"');
+    const dotIndex = html.indexOf("rounded-full");
+    expect(gitIndex).toBeGreaterThanOrEqual(0);
+    expect(dotIndex).toBeGreaterThanOrEqual(0);
+    expect(gitIndex).toBeLessThan(dotIndex);
+  });
+
+  it("shows no marker for a branch with no pull request", () => {
+    // The generic branch glyph is deliberately gone: it could not distinguish
+    // "no PR", "not fetched yet", "not GitHub", and "unknown state".
+    const html = markup(buildItem({ branch: "main" }).trailingElement);
+    expect(html).toContain("rounded-full");
+    expect(html).not.toContain("aria-label");
+  });
+
+  it("shows no marker once a worktree has merged or conflicted", () => {
+    for (const mergeStatus of ["merged", "conflict"] as const) {
+      const html = markup(
+        buildItem({ worktreeBranch: "agent/feature-x", mergeStatus })
+          .trailingElement
+      );
+      expect(html).not.toContain("aria-label");
+    }
+  });
+
+  it("keeps the git indicator on a working row, whose dot moves to the working slot", () => {
+    const item = buildItem(
+      { status: "running", worktreeBranch: "agent/feature-x" },
+      []
+    );
+    expect(markup(item.trailingElement)).toContain(
+      'aria-label="Worktree branch: feature-x"'
+    );
+    expect(markup(item.workingIndicator)).toContain('aria-label="Working"');
+  });
+});
+
+describe("buildSessionMenuItem PR state", () => {
+  function prMarkup(status: string): string {
+    return markup(
+      buildItem({ branch: "feature-x" }, ["s1"], {
+        status,
+        number: 42,
+        url: "https://github.com/o/r/pull/42",
+        title: "Add thing",
+      }).trailingElement
+    );
+  }
+
+  it.each([
+    ["open", "Open PR #42: feature-x", "--color-success-6"],
+    ["draft", "Draft PR #42: feature-x", "--color-text-3"],
+    ["merged", "Merged PR #42: feature-x", "--color-primary-6"],
+    ["closed", "Closed PR #42: feature-x", "--color-danger-6"],
+  ])("renders %s with its own icon color", (status, label, color) => {
+    const html = prMarkup(status);
+    expect(html).toContain(`aria-label="${label}"`);
+    expect(html).toContain(color);
+  });
+
+  it("shows no marker for an unrecognized state on a plain branch", () => {
+    expect(prMarkup("pending_review")).not.toContain("aria-label");
+  });
+
+  it("still marks an in-flight worktree whose PR state is unrecognized", () => {
+    const html = markup(
+      buildItem({ worktreeBranch: "agent/feature-x" }, ["s1"], {
+        status: "pending_review",
+        number: 5,
+        url: "https://github.com/o/r/pull/5",
+        title: "Add thing",
+      }).trailingElement
+    );
+    expect(html).toContain('aria-label="Worktree branch: feature-x"');
+    expect(html).toContain("--color-success-6");
+  });
+
+  it("matches on the raw ref, so an agent worktree branch still labels short", () => {
+    const html = markup(
+      buildItem({ worktreeBranch: "agent/feature-x" }, ["s1"], {
+        status: "merged",
+        number: 7,
+        url: "https://github.com/o/r/pull/7",
+        title: "Add thing",
+      }).trailingElement
+    );
+    expect(html).toContain('aria-label="Merged PR #7: feature-x"');
+  });
+});

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/gitIndicator.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/gitIndicator.tsx
@@ -1,0 +1,92 @@
+import {
+  GitBranch,
+  GitMerge,
+  GitPullRequest,
+  GitPullRequestClosed,
+  GitPullRequestDraft,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+import type { BranchPrSnapshot } from "@src/store/git";
+import {
+  type SessionGitLinkSource,
+  resolveSessionGitLink,
+} from "@src/util/session/sessionGitLink";
+
+/**
+ * Icon + color per PR state. Semantics match `shared/pr/prStatus` — open is
+ * success, merged is primary, closed is danger, draft is neutral — so a row
+ * marker and a PR badge elsewhere in the app never disagree about a state.
+ */
+const PR_STATUS_PRESENTATION: Record<
+  string,
+  { Icon: LucideIcon; color: string; label: string }
+> = {
+  open: {
+    Icon: GitPullRequest,
+    color: "var(--color-success-6)",
+    label: "Open PR",
+  },
+  draft: {
+    Icon: GitPullRequestDraft,
+    color: "var(--color-text-3)",
+    label: "Draft PR",
+  },
+  merged: {
+    Icon: GitMerge,
+    color: "var(--color-primary-6)",
+    label: "Merged PR",
+  },
+  closed: {
+    Icon: GitPullRequestClosed,
+    color: "var(--color-danger-6)",
+    label: "Closed PR",
+  },
+};
+
+/**
+ * Git marker rendered immediately BEFORE the row's status dot.
+ *
+ * Every glyph it can draw answers exactly one question — "what is the state of
+ * this session's pull request?" — with one deliberate addition: a worktree
+ * whose work is still in flight, which no PR can describe yet.
+ *
+ * There is NO generic branch fallback. A muted branch glyph would have to
+ * stand for "no PR exists", "the repo's PRs have not loaded yet", "this remote
+ * is not GitHub", and "the PR is in a state we do not recognize" all at once,
+ * which makes it unreadable. Those rows render their status dot alone.
+ *
+ * Glyph only: the branch name and PR title live in the session hover card, so
+ * this never widens the row.
+ */
+export function renderSessionGitIndicator(
+  session: SessionGitLinkSource,
+  pr?: BranchPrSnapshot
+): ReactNode {
+  const link = resolveSessionGitLink(session);
+  if (!link) return null;
+
+  const prPresentation = pr ? PR_STATUS_PRESENTATION[pr.status] : undefined;
+  if (!prPresentation && !link.isActiveWorktree) return null;
+
+  const { Icon, color, label } = prPresentation ?? {
+    Icon: GitBranch,
+    color: "var(--color-success-6)",
+    label: "Worktree branch",
+  };
+
+  return (
+    <span
+      aria-label={
+        prPresentation
+          ? `${label} #${pr?.number}: ${link.branch}`
+          : `${label}: ${link.branch}`
+      }
+      className="inline-flex shrink-0 items-center leading-none"
+      style={{ color }}
+    >
+      <Icon size={11} strokeWidth={2} />
+    </span>
+  );
+}

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/index.tsx
@@ -47,6 +47,7 @@ import type {
   UseSessionMenuItemsParams,
   UseSessionMenuItemsResult,
 } from "./types";
+import { useSessionPrStatuses } from "./useSessionPrStatuses";
 
 /**
  * One-line subtitle for a session row, shown ONLY while the session is
@@ -437,6 +438,10 @@ export function useSessionMenuItems({
     return map;
   }, [childSessionsByParent, visibleSessions]);
 
+  // Keyed off the listed rows, not `visibleSessions`: a repo only earns a PR
+  // fetch once one of its sessions is actually on screen.
+  const prForSession = useSessionPrStatuses(listedSessions);
+
   const buildSessionRow = useCallback(
     (session: Session): NavigationMenuItem =>
       buildSessionMenuItem({
@@ -446,8 +451,9 @@ export function useSessionMenuItems({
         liveDetail: liveDetailForSession(
           agentLiveStatuses.get(session.session_id)
         ),
+        pr: prForSession(session),
       }),
-    [agentLiveStatuses, untitledSession, visitedSessions]
+    [agentLiveStatuses, prForSession, untitledSession, visitedSessions]
   );
 
   const loadMoreRowFor = useCallback(

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/menuItemBuilders.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/menuItemBuilders.tsx
@@ -1,4 +1,5 @@
 import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/components/NavigationMenu/config";
+import type { BranchPrSnapshot } from "@src/store/git";
 import type { Session } from "@src/store/session";
 import { isTerminalStatus } from "@src/types/session/session";
 import { isSessionInProgress } from "@src/util/session/sessionInProgress";
@@ -9,6 +10,7 @@ import {
 } from "@src/util/session/sessionSidebarRow";
 import { formatRelativeTime } from "@src/util/time/formatRelativeTime";
 
+import { renderSessionGitIndicator } from "./gitIndicator";
 import { renderBreathingStatusDot, renderStatusDot } from "./statusIndicators";
 
 export function separator(id: string, title = ""): NavigationMenuItem {
@@ -41,6 +43,12 @@ interface BuildSessionMenuItemParams {
    * question). Rendered as the row subtitle only while the session waits.
    */
   liveDetail?: string;
+  /**
+   * PR the session's branch belongs to, from the sidebar's per-repo snapshot
+   * cache. Absent until the first fetch lands, or permanently for non-GitHub
+   * remotes — the row falls back to a plain branch glyph either way.
+   */
+  pr?: BranchPrSnapshot;
 }
 
 export function buildSessionMenuItem({
@@ -48,6 +56,7 @@ export function buildSessionMenuItem({
   untitledSession,
   visitedSessions,
   liveDetail,
+  pr,
 }: BuildSessionMenuItemParams): NavigationMenuItem {
   const inProgress = isSessionInProgress(session.status, session);
   const displayName = getSessionListDisplayName(session, untitledSession);
@@ -60,6 +69,11 @@ export function buildSessionMenuItem({
     : unread
       ? "unread"
       : "default";
+  // A working row parks its dot in `workingIndicator` instead, so the trailing
+  // slot may hold the git marker alone.
+  const statusDot =
+    inProgress && !pendingAsking ? null : renderStatusDot(statusDotTone);
+  const gitIndicator = renderSessionGitIndicator(session, pr);
 
   return {
     id: session.session_id,
@@ -71,11 +85,13 @@ export function buildSessionMenuItem({
     subtitle: liveDetail && pendingAsking ? liveDetail : undefined,
     workingIndicator:
       inProgress && !pendingAsking ? renderBreathingStatusDot() : undefined,
-    trailingElement: pendingAsking
-      ? renderStatusDot(statusDotTone)
-      : inProgress
-        ? undefined
-        : renderStatusDot(statusDotTone),
+    trailingElement:
+      gitIndicator || statusDot ? (
+        <span className="inline-flex items-center gap-1 leading-none">
+          {gitIndicator}
+          {statusDot}
+        </span>
+      ) : undefined,
     shortcut: formatRelativeTime(timestampSrc, "nano"),
     openContextMenuOnSelectedClick: true,
     dragPayload: {

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/useSessionPrStatuses.ts
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/useSessionPrStatuses.ts
@@ -1,0 +1,157 @@
+/**
+ * Keeps the sidebar's per-repo PR snapshots warm and hands rows an O(1)
+ * lookup.
+ *
+ * Deliberately conservative about work:
+ *  - only the {@link MAX_SESSIONS_SCANNED} most recent rows contribute repos,
+ *    so a fully paginated sidebar does not widen the fetch;
+ *  - repos are capped, deduped, and fetched once each (two list calls), never
+ *    once per session;
+ *  - a repo is refetched only when its snapshot ages past the TTL, and the
+ *    interval tick is skipped entirely while the window is hidden;
+ *  - repos that scroll out of the considered set are pruned from the cache.
+ */
+import { useAtom } from "jotai";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+
+import { listPRsLocal } from "@src/api/tauri/github/pullRequests";
+import { createLogger } from "@src/hooks/logger";
+import {
+  type BranchPrSnapshot,
+  PR_STATUS_CACHE_CONFIG,
+  buildRepoPrSnapshot,
+  isRepoPrStatusStale,
+  pruneRepoPrStatusCache,
+  repoPrStatusCacheAtom,
+} from "@src/store/git";
+import type { Session } from "@src/store/session";
+import { resolveGithubRepoFullName } from "@src/util/git/githubRemote";
+import { resolveSessionGitLink } from "@src/util/session/sessionGitLink";
+
+const logger = createLogger("useSessionPrStatuses");
+
+/**
+ * Rows are already newest-first, so the head of the list is what a user
+ * actually looks at. Older rows still render their branch glyph — they just
+ * do not pull a repo into the fetch set on their own.
+ */
+const MAX_SESSIONS_SCANNED = 60;
+
+export type SessionPrLookup = (
+  session: Session
+) => BranchPrSnapshot | undefined;
+
+const NO_PR: SessionPrLookup = () => undefined;
+
+export function useSessionPrStatuses(
+  sessions: readonly Session[]
+): SessionPrLookup {
+  const [cache, setCache] = useAtom(repoPrStatusCacheAtom);
+  const inFlightRef = useRef(new Set<string>());
+  const cacheRef = useRef(cache);
+  cacheRef.current = cache;
+
+  const activeRepos = useMemo(() => {
+    const repos = new Set<string>();
+    for (const session of sessions.slice(0, MAX_SESSIONS_SCANNED)) {
+      // A session with no branch can never match a PR, so it must not be the
+      // reason a repo gets fetched.
+      if (!resolveSessionGitLink(session)) continue;
+      const repoFullName = resolveGithubRepoFullName(session.repoRemoteUrls);
+      if (!repoFullName) continue;
+      repos.add(repoFullName);
+      if (repos.size >= PR_STATUS_CACHE_CONFIG.MAX_REPOS) break;
+    }
+    return repos;
+  }, [sessions]);
+
+  // Stable across renders that produce the same repo set, so the refresh
+  // interval is not torn down every time the session list re-sorts.
+  const activeReposKey = useMemo(
+    () => [...activeRepos].sort().join(","),
+    [activeRepos]
+  );
+
+  const refresh = useCallback(async () => {
+    const repos = activeReposKey ? activeReposKey.split(",") : [];
+    const repoSet = new Set(repos);
+
+    setCache((current) => {
+      const pruned = pruneRepoPrStatusCache(current, repoSet);
+      return pruned.size === current.size ? current : pruned;
+    });
+
+    const now = Date.now();
+    const stale = repos.filter(
+      (repoFullName) =>
+        !inFlightRef.current.has(repoFullName) &&
+        isRepoPrStatusStale(cacheRef.current.get(repoFullName), now)
+    );
+
+    await Promise.all(
+      stale.map(async (repoFullName) => {
+        inFlightRef.current.add(repoFullName);
+        try {
+          const [open, closed] = await Promise.all([
+            listPRsLocal(
+              repoFullName,
+              "open",
+              PR_STATUS_CACHE_CONFIG.PAGE_SIZE
+            ),
+            listPRsLocal(
+              repoFullName,
+              "closed",
+              PR_STATUS_CACHE_CONFIG.PAGE_SIZE
+            ),
+          ]);
+          const snapshot = buildRepoPrSnapshot({ open, closed });
+          setCache((current) => new Map(current).set(repoFullName, snapshot));
+        } catch (error) {
+          // A repo the user cannot read (no GitHub connection, private fork,
+          // rate limit) must not be retried on every tick.
+          logger.warn("failed to load pull requests", { error, repoFullName });
+          setCache((current) =>
+            new Map(current).set(repoFullName, {
+              fetchedAt: Date.now(),
+              byBranch: new Map(),
+              error: true,
+              retryAt: Date.now() + PR_STATUS_CACHE_CONFIG.ERROR_RETRY_MS,
+            })
+          );
+        } finally {
+          inFlightRef.current.delete(repoFullName);
+        }
+      })
+    );
+  }, [activeReposKey, setCache]);
+
+  useEffect(() => {
+    if (!activeReposKey) return;
+    void refresh();
+    const timer = setInterval(() => {
+      // Nothing on screen to update — let the next visible tick do the work.
+      if (typeof document !== "undefined" && document.hidden) return;
+      void refresh();
+    }, PR_STATUS_CACHE_CONFIG.TTL_MS);
+    return () => clearInterval(timer);
+  }, [activeReposKey, refresh]);
+
+  return useMemo<SessionPrLookup>(() => {
+    if (cache.size === 0) return NO_PR;
+    return (session) => {
+      const link = resolveSessionGitLink(session);
+      if (!link) return undefined;
+      const repoFullName = resolveGithubRepoFullName(session.repoRemoteUrls);
+      if (!repoFullName) return undefined;
+      // Match on the raw branch ref: `formatBranchLabel` strips the `agent/`
+      // worktree prefix for display, but GitHub knows the branch by its real
+      // name.
+      const headBranch =
+        session.worktreeBranch || session.branch || session.baseBranch;
+      if (!headBranch) return undefined;
+      return cache
+        .get(repoFullName)
+        ?.byBranch.get(headBranch.replace(/^refs\/heads\//, ""));
+    };
+  }, [cache]);
+}

--- a/src/services/git/operations/createPullRequest.ts
+++ b/src/services/git/operations/createPullRequest.ts
@@ -3,15 +3,12 @@ import { gitPush } from "@src/api/http/git/operations";
 import { getGitRemotes } from "@src/api/http/git/remotes";
 import { createPRLocal } from "@src/api/tauri/github";
 import { createLogger } from "@src/hooks/logger";
+import { parseRepoFullNameFromRemote } from "@src/util/git/githubRemote";
 
 const logger = createLogger("createPullRequest");
 
 export function parseGithubRepoFullName(remoteUrl: string): string | null {
-  const sshMatch = remoteUrl.match(/git@[^:]+:(.+?)(?:\.git)?$/);
-  if (sshMatch) return sshMatch[1];
-  const httpsMatch = remoteUrl.match(/https?:\/\/[^/]+\/(.+?)(?:\.git)?$/);
-  if (httpsMatch) return httpsMatch[1];
-  return null;
+  return parseRepoFullNameFromRemote(remoteUrl);
 }
 
 export interface CreatePullRequestParams {

--- a/src/store/git/__tests__/prStatusAtom.test.ts
+++ b/src/store/git/__tests__/prStatusAtom.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "vitest";
+
+import type { OpenPRItem } from "@src/api/tauri/github/pullRequests";
+import {
+  PR_STATUS_CACHE_CONFIG,
+  type RepoPrSnapshot,
+  buildRepoPrSnapshot,
+  isRepoPrStatusStale,
+  pruneRepoPrStatusCache,
+} from "@src/store/git/prStatusAtom";
+
+function pr(overrides: Partial<OpenPRItem> & { head_branch: string }) {
+  return {
+    number: 1,
+    url: "https://github.com/o/r/pull/1",
+    title: "PR",
+    state: "open",
+    base_branch: "main",
+    draft: false,
+    created_at: "2026-07-01T00:00:00Z",
+    updated_at: "2026-07-01T00:00:00Z",
+    ...overrides,
+  } satisfies OpenPRItem;
+}
+
+describe("buildRepoPrSnapshot", () => {
+  it("indexes each list response by head branch", () => {
+    const snapshot = buildRepoPrSnapshot(
+      {
+        open: [pr({ head_branch: "feature-a", number: 10 })],
+        closed: [pr({ head_branch: "feature-b", number: 4, state: "merged" })],
+      },
+      1000
+    );
+
+    expect(snapshot.fetchedAt).toBe(1000);
+    expect(snapshot.byBranch.get("feature-a")?.status).toBe("open");
+    expect(snapshot.byBranch.get("feature-b")).toMatchObject({
+      status: "merged",
+      number: 4,
+    });
+  });
+
+  it("marks a draft PR as draft rather than open", () => {
+    const snapshot = buildRepoPrSnapshot({
+      open: [pr({ head_branch: "wip", draft: true })],
+      closed: [],
+    });
+    expect(snapshot.byBranch.get("wip")?.status).toBe("draft");
+  });
+
+  it("lets a live open PR win over an older closed one on the same branch", () => {
+    const snapshot = buildRepoPrSnapshot({
+      open: [pr({ head_branch: "reused", number: 9 })],
+      closed: [pr({ head_branch: "reused", number: 2, state: "closed" })],
+    });
+    expect(snapshot.byBranch.get("reused")).toMatchObject({
+      status: "open",
+      number: 9,
+    });
+  });
+
+  it("keeps the newest PR when one response repeats a branch", () => {
+    const snapshot = buildRepoPrSnapshot({
+      open: [
+        pr({ head_branch: "dup", number: 20 }),
+        pr({ head_branch: "dup", number: 3 }),
+      ],
+      closed: [],
+    });
+    expect(snapshot.byBranch.get("dup")?.number).toBe(20);
+  });
+
+  it("keeps the newest repeat even when both entries normalize alike", () => {
+    // Regression guard: deduping by comparing the stored NORMALIZED status
+    // against the raw `state` let a second draft overwrite the newest one,
+    // because a draft's raw state is "open".
+    const snapshot = buildRepoPrSnapshot({
+      open: [
+        pr({ head_branch: "dup", number: 20, draft: true }),
+        pr({ head_branch: "dup", number: 3, draft: true }),
+      ],
+      closed: [],
+    });
+    expect(snapshot.byBranch.get("dup")).toMatchObject({
+      status: "draft",
+      number: 20,
+    });
+  });
+
+  it("caps retained branches so one busy repo cannot grow unbounded", () => {
+    const many = Array.from(
+      { length: PR_STATUS_CACHE_CONFIG.MAX_BRANCHES_PER_REPO + 25 },
+      (_, index) => pr({ head_branch: `branch-${index}`, number: index })
+    );
+    const snapshot = buildRepoPrSnapshot({ open: many, closed: [] });
+    expect(snapshot.byBranch.size).toBe(
+      PR_STATUS_CACHE_CONFIG.MAX_BRANCHES_PER_REPO
+    );
+  });
+
+  it("ignores entries with no head branch", () => {
+    const snapshot = buildRepoPrSnapshot({
+      open: [pr({ head_branch: "  " })],
+      closed: [],
+    });
+    expect(snapshot.byBranch.size).toBe(0);
+  });
+});
+
+describe("isRepoPrStatusStale", () => {
+  const fresh: RepoPrSnapshot = { fetchedAt: 1000, byBranch: new Map() };
+
+  it("treats a missing snapshot as stale", () => {
+    expect(isRepoPrStatusStale(undefined, 1000)).toBe(true);
+  });
+
+  it("holds a snapshot until the TTL elapses", () => {
+    expect(isRepoPrStatusStale(fresh, 1000 + 1)).toBe(false);
+    expect(
+      isRepoPrStatusStale(fresh, 1000 + PR_STATUS_CACHE_CONFIG.TTL_MS)
+    ).toBe(true);
+  });
+
+  it("backs off a failed fetch until its retry time", () => {
+    const failed: RepoPrSnapshot = {
+      fetchedAt: 1000,
+      byBranch: new Map(),
+      error: true,
+      retryAt: 9000,
+    };
+    expect(isRepoPrStatusStale(failed, 8999)).toBe(false);
+    expect(isRepoPrStatusStale(failed, 9000)).toBe(true);
+  });
+});
+
+describe("pruneRepoPrStatusCache", () => {
+  function snapshot(fetchedAt: number): RepoPrSnapshot {
+    return { fetchedAt, byBranch: new Map() };
+  }
+
+  it("drops repos that are no longer on screen", () => {
+    const cache = new Map([
+      ["o/keep", snapshot(1)],
+      ["o/gone", snapshot(2)],
+    ]);
+    const pruned = pruneRepoPrStatusCache(cache, new Set(["o/keep"]));
+    expect([...pruned.keys()]).toEqual(["o/keep"]);
+  });
+
+  it("evicts the least recently fetched once over the repo cap", () => {
+    const repos = Array.from(
+      { length: PR_STATUS_CACHE_CONFIG.MAX_REPOS + 3 },
+      (_, index) => [`o/repo-${index}`, snapshot(index)] as const
+    );
+    const pruned = pruneRepoPrStatusCache(
+      new Map(repos),
+      new Set(repos.map(([name]) => name))
+    );
+
+    expect(pruned.size).toBe(PR_STATUS_CACHE_CONFIG.MAX_REPOS);
+    // Highest `fetchedAt` values survive.
+    expect(pruned.has(`o/repo-${repos.length - 1}`)).toBe(true);
+    expect(pruned.has("o/repo-0")).toBe(false);
+  });
+});

--- a/src/store/git/index.ts
+++ b/src/store/git/index.ts
@@ -6,3 +6,4 @@
 
 export * from "./gitStatusAtom";
 export * from "./gitOperationAtom";
+export * from "./prStatusAtom";

--- a/src/store/git/prStatusAtom.ts
+++ b/src/store/git/prStatusAtom.ts
@@ -1,0 +1,127 @@
+/**
+ * Pull-request status cache for session list rows.
+ *
+ * The sidebar wants a real open / draft / merged / closed state per session
+ * branch, but a per-session lookup would be one API round trip per row. This
+ * cache is keyed by REPO instead: two list calls (`open` + `closed`, both
+ * sorted by recency) cover every branch in that repo at once, so a sidebar
+ * showing 200 sessions across 3 repos costs 6 requests, not 200.
+ *
+ * Memory is bounded on three axes so a long-lived window cannot grow without
+ * limit: at most {@link PR_STATUS_CACHE_CONFIG.MAX_REPOS} repos are tracked
+ * (least-recently-fetched evicted first), at most
+ * {@link PR_STATUS_CACHE_CONFIG.MAX_BRANCHES_PER_REPO} branches are retained
+ * per repo, and each entry stores four scalars — never the raw PR payload.
+ */
+import { atom } from "jotai";
+
+import type { OpenPRItem } from "@src/api/tauri/github/pullRequests";
+import { normalizePrStatus } from "@src/shared/pr/prStatus";
+
+export const PR_STATUS_CACHE_CONFIG = {
+  /** Refetch a repo once its snapshot is older than this. */
+  TTL_MS: 5 * 60 * 1000,
+  /** Distinct repos held in memory at once. */
+  MAX_REPOS: 8,
+  /** Branch entries retained per repo, newest-updated first. */
+  MAX_BRANCHES_PER_REPO: 200,
+  /** Page size for each of the two list calls per repo. */
+  PAGE_SIZE: 100,
+  /** Backoff after a failed fetch, so an unauthenticated repo is not hammered. */
+  ERROR_RETRY_MS: 10 * 60 * 1000,
+} as const;
+
+/** Everything a row needs from a PR — deliberately not the whole payload. */
+export interface BranchPrSnapshot {
+  /** Normalized: `open` | `draft` | `merged` | `closed`. */
+  status: string;
+  number: number;
+  url: string;
+  title: string;
+}
+
+export interface RepoPrSnapshot {
+  fetchedAt: number;
+  /** Head branch → its newest PR. Empty on a failed fetch. */
+  byBranch: Map<string, BranchPrSnapshot>;
+  /** Set when the last fetch failed; suppresses refetch until `retryAt`. */
+  error?: boolean;
+  retryAt?: number;
+}
+
+/** repoFullName (`owner/repo`) → snapshot. */
+export const repoPrStatusCacheAtom = atom<Map<string, RepoPrSnapshot>>(
+  new Map()
+);
+repoPrStatusCacheAtom.debugLabel = "repoPrStatusCacheAtom";
+
+export function isRepoPrStatusStale(
+  cached: RepoPrSnapshot | undefined,
+  now: number = Date.now()
+): boolean {
+  if (!cached) return true;
+  if (cached.error) return now >= (cached.retryAt ?? 0);
+  return now - cached.fetchedAt >= PR_STATUS_CACHE_CONFIG.TTL_MS;
+}
+
+/**
+ * Fold the two list responses into one branch → PR map.
+ *
+ * `open` is applied last so a branch that has both a stale closed PR and a
+ * live open one resolves to the open one. Within a single response the API's
+ * `sort=updated&direction=desc` ordering means the first entry for a branch is
+ * its newest PR, so later duplicates are dropped.
+ */
+export function buildRepoPrSnapshot(
+  responses: { open: OpenPRItem[]; closed: OpenPRItem[] },
+  now: number = Date.now()
+): RepoPrSnapshot {
+  const byBranch = new Map<string, BranchPrSnapshot>();
+  for (const items of [responses.closed, responses.open]) {
+    // Scoped per pass: within one response the first entry for a branch is
+    // its newest PR and wins, but the open pass must still overwrite whatever
+    // the closed pass left behind.
+    const claimed = new Set<string>();
+    for (const item of items) {
+      const branch = item.head_branch?.trim();
+      if (!branch || claimed.has(branch)) continue;
+      if (
+        byBranch.size >= PR_STATUS_CACHE_CONFIG.MAX_BRANCHES_PER_REPO &&
+        !byBranch.has(branch)
+      ) {
+        continue;
+      }
+      claimed.add(branch);
+      byBranch.set(branch, {
+        // The Rust command already rewrites a merged PR's state, but draft
+        // only ever arrives as a separate boolean.
+        status: normalizePrStatus({ state: item.state, draft: item.draft }),
+        number: item.number,
+        url: item.url,
+        title: item.title,
+      });
+    }
+  }
+  return { fetchedAt: now, byBranch };
+}
+
+/**
+ * Drop repos that are no longer on screen, then evict the least recently
+ * fetched until the cache is back under the repo cap. `activeRepos` is the
+ * set the sidebar currently cares about — anything outside it is free to go
+ * even if it is still fresh.
+ */
+export function pruneRepoPrStatusCache(
+  cache: Map<string, RepoPrSnapshot>,
+  activeRepos: ReadonlySet<string>
+): Map<string, RepoPrSnapshot> {
+  const retained = new Map(
+    [...cache].filter(([repoFullName]) => activeRepos.has(repoFullName))
+  );
+  if (retained.size <= PR_STATUS_CACHE_CONFIG.MAX_REPOS) return retained;
+
+  const byAge = [...retained].sort(
+    ([, left], [, right]) => right.fetchedAt - left.fetchedAt
+  );
+  return new Map(byAge.slice(0, PR_STATUS_CACHE_CONFIG.MAX_REPOS));
+}

--- a/src/store/session/sessionAtom/loaders.ts
+++ b/src/store/session/sessionAtom/loaders.ts
@@ -234,6 +234,7 @@ function importedHistoryPageResult(
         repoPath: row.repoPath,
         repoRootPath: row.repoRootPath,
         repoRemoteUrls: row.repoRemoteUrls,
+        branch: row.branch,
         storagePath: row.storagePath,
         agentIconId: source.iconId,
         agentDisplayName: source.displayName,

--- a/src/util/git/__tests__/githubRemote.test.ts
+++ b/src/util/git/__tests__/githubRemote.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseRepoFullNameFromRemote,
+  resolveGithubRepoFullName,
+} from "@src/util/git/githubRemote";
+
+describe("parseRepoFullNameFromRemote", () => {
+  it("parses ssh and https remotes", () => {
+    expect(parseRepoFullNameFromRemote("git@github.com:org2ai/org2.git")).toBe(
+      "org2ai/org2"
+    );
+    expect(
+      parseRepoFullNameFromRemote("https://github.com/org2ai/org2.git")
+    ).toBe("org2ai/org2");
+    expect(parseRepoFullNameFromRemote("https://github.com/org2ai/org2")).toBe(
+      "org2ai/org2"
+    );
+  });
+
+  it("returns null for anything that is not a remote URL", () => {
+    expect(parseRepoFullNameFromRemote("/local/path")).toBeNull();
+  });
+});
+
+describe("resolveGithubRepoFullName", () => {
+  it("picks the first github.com remote", () => {
+    expect(
+      resolveGithubRepoFullName([
+        "git@gitlab.com:team/thing.git",
+        "https://github.com/org2ai/org2.git",
+      ])
+    ).toBe("org2ai/org2");
+  });
+
+  it("ignores non-github hosts, including enterprise", () => {
+    expect(
+      resolveGithubRepoFullName(["git@github.enterprise.dev:team/thing.git"])
+    ).toBeNull();
+    expect(
+      resolveGithubRepoFullName(["https://gitlab.com/a/b.git"])
+    ).toBeNull();
+  });
+
+  it("rejects anything that is not exactly owner/repo", () => {
+    // A blob URL cached as a remote must never be pasted into an API path.
+    expect(
+      resolveGithubRepoFullName(["https://github.com/org2ai/org2/tree/main"])
+    ).toBeNull();
+  });
+
+  it("handles an absent or empty remote list", () => {
+    expect(resolveGithubRepoFullName(undefined)).toBeNull();
+    expect(resolveGithubRepoFullName([])).toBeNull();
+  });
+});

--- a/src/util/git/githubRemote.ts
+++ b/src/util/git/githubRemote.ts
@@ -1,0 +1,40 @@
+/**
+ * Remote-URL parsing shared by PR creation and the sidebar's PR status cache.
+ */
+
+/**
+ * `git@host:owner/repo.git` / `https://host/owner/repo.git` → `owner/repo`.
+ * Host-agnostic and unvalidated: callers that hit the GitHub API must go
+ * through {@link resolveGithubRepoFullName} instead.
+ */
+export function parseRepoFullNameFromRemote(remoteUrl: string): string | null {
+  const sshMatch = remoteUrl.match(/git@[^:]+:(.+?)(?:\.git)?$/);
+  if (sshMatch) return sshMatch[1] ?? null;
+  const httpsMatch = remoteUrl.match(/https?:\/\/[^/]+\/(.+?)(?:\.git)?$/);
+  if (httpsMatch) return httpsMatch[1] ?? null;
+  return null;
+}
+
+/** github.com only — GitHub Enterprise hosts have their own API base. */
+function isGithubRemote(remoteUrl: string): boolean {
+  return /(^|@|\/\/)github\.com([:/]|$)/i.test(remoteUrl);
+}
+
+/**
+ * First github.com remote in `remotes`, as a strict `owner/repo`.
+ *
+ * Rejects anything that does not parse to exactly two path segments so a
+ * stray blob/tree URL cached as a "remote" can never be pasted into an API
+ * path.
+ */
+export function resolveGithubRepoFullName(
+  remotes: readonly string[] | undefined
+): string | null {
+  if (!remotes) return null;
+  for (const remote of remotes) {
+    if (!remote || !isGithubRemote(remote)) continue;
+    const fullName = parseRepoFullNameFromRemote(remote);
+    if (fullName && /^[^/\s]+\/[^/\s]+$/.test(fullName)) return fullName;
+  }
+  return null;
+}

--- a/src/util/session/__tests__/sessionGitLink.test.ts
+++ b/src/util/session/__tests__/sessionGitLink.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSessionGitLink } from "@src/util/session/sessionGitLink";
+
+describe("resolveSessionGitLink", () => {
+  it("returns null when the session reports no branch at all", () => {
+    expect(resolveSessionGitLink({})).toBeNull();
+    expect(resolveSessionGitLink({ branch: "" })).toBeNull();
+  });
+
+  it("uses the source-reported branch for imported sessions", () => {
+    expect(resolveSessionGitLink({ branch: "refs/heads/main" })).toEqual({
+      branch: "main",
+      isActiveWorktree: false,
+    });
+  });
+
+  it("prefers the worktree branch over the launch branch", () => {
+    expect(
+      resolveSessionGitLink({
+        branch: "main",
+        worktreeBranch: "agent/abc123",
+        worktreePath: "/tmp/wt",
+      })
+    ).toEqual({ branch: "abc123", isActiveWorktree: true });
+  });
+
+  it("falls back to the base branch when nothing else is recorded", () => {
+    expect(resolveSessionGitLink({ baseBranch: "develop" })).toEqual({
+      branch: "develop",
+      isActiveWorktree: false,
+    });
+  });
+
+  it("keeps a pending worktree active", () => {
+    expect(
+      resolveSessionGitLink({
+        worktreeBranch: "agent/abc123",
+        mergeStatus: "pending",
+      })?.isActiveWorktree
+    ).toBe(true);
+  });
+
+  it("settles a worktree once it is merged or conflicted", () => {
+    // A settled worktree is no longer work in flight, so the sidebar stops
+    // marking it — only a real PR can speak for it after that.
+    expect(
+      resolveSessionGitLink({
+        worktreeBranch: "agent/abc123",
+        mergeStatus: "merged",
+      })?.isActiveWorktree
+    ).toBe(false);
+    expect(
+      resolveSessionGitLink({
+        worktreeBranch: "agent/abc123",
+        mergeStatus: "conflict",
+      })?.isActiveWorktree
+    ).toBe(false);
+  });
+});

--- a/src/util/session/sessionGitLink.ts
+++ b/src/util/session/sessionGitLink.ts
@@ -1,0 +1,53 @@
+/**
+ * Resolve the Git linkage a session row advertises in the sidebar.
+ *
+ * Read-only over metadata the session already carries: local sessions from
+ * their launch params (`worktreeBranch` / `branch` / `baseBranch` /
+ * `mergeStatus`), imported sessions from whatever branch their SOURCE app
+ * recorded (Claude Code transcripts, Cursor/Windsurf tracked-repo metadata).
+ * Nothing here inspects a working copy or shells out to git — a session whose
+ * source never reported a branch simply has no link.
+ */
+import { formatBranchLabel } from "@src/util/git/branchLabel";
+
+export interface SessionGitLink {
+  /** Branch name with `refs/heads/` and the `agent/` worktree prefix stripped. */
+  branch: string;
+  /**
+   * The branch lives in an isolated worktree that has not yet been merged or
+   * conflicted out — i.e. work still in flight. This is the only branch-level
+   * state the sidebar marks on its own; everything else it shows comes from a
+   * real pull request.
+   */
+  isActiveWorktree: boolean;
+}
+
+export interface SessionGitLinkSource {
+  branch?: string;
+  worktreePath?: string;
+  worktreeBranch?: string;
+  baseBranch?: string;
+  mergeStatus?: string;
+}
+
+/**
+ * Branch precedence mirrors `SessionHoverCardContent`: the worktree branch is
+ * where the session actually ran, so it outranks the repo branch captured at
+ * launch, which in turn outranks the base branch a worktree forked from.
+ */
+export function resolveSessionGitLink(
+  session: SessionGitLinkSource
+): SessionGitLink | null {
+  const worktreeBranch = formatBranchLabel(session.worktreeBranch);
+  const branch =
+    worktreeBranch ||
+    formatBranchLabel(session.branch) ||
+    formatBranchLabel(session.baseBranch);
+  if (!branch) return null;
+
+  const isWorktree = Boolean(worktreeBranch || session.worktreePath);
+  const isSettled =
+    session.mergeStatus === "merged" || session.mergeStatus === "conflict";
+
+  return { branch, isActiveWorktree: isWorktree && !isSettled };
+}


### PR DESCRIPTION
## Problem

Sidebar session rows say nothing about a session's git outcome. Whether a branch's PR is open, merged, or closed — the single most useful "what happened to this work" signal — required opening the session or leaving the app. Imported CLI sessions (Claude Code, Cursor, Windsurf) could not even show a branch: the source apps record one, but the sidebar cache projection dropped it before it reached the frontend.

## Solution

**Backend** — carry `branch` onto the imported-history sidebar row: the cache query selects `cache.branch`, the serialized struct gains an `Option<String>` (with `skip_serializing_if`, and the upsert's `""`-for-`None` normalized back to absent), mirrored in the zod schema and the session loader.

**PR snapshot store** — new `store/git/prStatusAtom`: a per-repo cache keyed by repo full name holding a branch → `{status, number}` map built from two `listPRsLocal` calls (open + closed), with TTL staleness, error backoff (`retryAt`), and pruning of repos that left the visible set.

**Sidebar wiring** — `useSessionPrStatuses` scans at most the 60 newest rows, dedupes repos into a capped fetch set, fetches each repo once, and refreshes on a TTL tick that skips hidden windows; rows get an O(1) lookup matching on the raw branch ref (`worktreeBranch || branch || baseBranch`, `refs/heads/` stripped). `gitIndicator` renders a glyph ahead of the status dot: open/draft/merged/closed PR in the same semantic colors as `shared/pr/prStatus`, and a plain branch glyph only for an active worktree that has no PR yet. Deliberately **no generic branch fallback** — a glyph that could mean "no PR / not loaded / not GitHub / unknown state" is unreadable, so those rows render just their dot.

**Shared utils** — `util/git/githubRemote` extracts the owner/repo remote parsing out of `createPullRequest` (which now delegates); `util/session/sessionGitLink` resolves which branch a session actually maps to.

**Accessory slot fix** — the trailing-slot hover swap is now instant instead of animated: the 150ms reveal reflowed the row label every frame and painted the persistent git glyph over the `more` button during the crossfade. The 2px right-edge nudge also moves onto the clipping layer — inside it, those 2px fell outside the clip rect and sheared the last action button's edge.

## Potential risks

- Each repo in the visible set costs two local PR-list calls per TTL tick. The capped/deduped repo set, hidden-window skip, and error backoff bound the load, but sidebar-driven PR fetching is new traffic for users with many repos on screen.
- Matching is by branch name within the resolved repo: a branch name reused across same-named repos cannot be told apart, and sessions whose source recorded no branch (older cache rows, sources that never report one) simply never show a glyph.
- The accessory-slot swap is a visible interaction change on every sidebar row (hover reveal no longer animates) — deliberate, pinned by the new `NavigationMenuRow` test.
- The Rust field is additive and optional end to end: old rows deserialize as absent, old frontends ignore it.

## Test plan

- `cargo test -p orgtrack_core --lib imported_history` — new tests pin that the branch is carried onto sidebar rows and that a source recording no branch yields `None` (not `""`).
- `npx vitest run` over the five touched suites — `prStatusAtom` (snapshot build/staleness/prune), `githubRemote`, `sessionGitLink`, `menuItemBuilders` (glyph + dot composition in the trailing slot), `NavigationMenuRow` (instant swap, nudge on the clipping layer) — all passing.
- `tsc --noEmit` clean, eslint clean, pre-commit scoped hooks (incl. scoped clippy for the Rust files) pass.
