### PR TITLE
Refresh MiniMax default model and pricing to current values

### DIFF
--- a/src-tauri/crates/git-api/src/commands/ai.rs
+++ b/src-tauri/crates/git-api/src/commands/ai.rs
@@ -103,7 +103,7 @@ fn default_model_for(agent_type: &ModelType) -> &'static str {
         ModelType::ZenmuxApi => "deepseek/deepseek-chat",
         ModelType::DashscopeApi => "qwen-turbo",
         ModelType::MoonshotApi => "moonshot-v1-8k",
-        ModelType::MinimaxApi => "abab6.5s-chat",
+        ModelType::MinimaxApi => "MiniMax-M3",
         ModelType::ZhipuApi => "glm-4-flash",
         ModelType::VllmApi => "default",
         _ => "gpt-4o-mini",
@@ -374,7 +374,7 @@ mod tests {
         (ModelType::ZenmuxApi, "zenmux", "deepseek/deepseek-chat"),
         (ModelType::DashscopeApi, "dashscope", "qwen-turbo"),
         (ModelType::MoonshotApi, "moonshot", "moonshot-v1-8k"),
-        (ModelType::MinimaxApi, "minimax", "abab6.5s-chat"),
+        (ModelType::MinimaxApi, "minimax", "MiniMax-M3"),
         (ModelType::ZhipuApi, "zhipu", "glm-4-flash"),
         (ModelType::VllmApi, "vllm", "default"),
     ];

--- a/src-tauri/crates/orgtrack-core/src/model_pricing_catalog.json
+++ b/src-tauri/crates/orgtrack-core/src/model_pricing_catalog.json
@@ -556,10 +556,10 @@
     },
     {
       "id": "minimax-m3",
-      "input": 0.3,
-      "output": 1.2,
-      "cache_write": 0.3,
-      "cache_read": 0.06
+      "input": 0.6,
+      "output": 2.4,
+      "cache_write": 0.6,
+      "cache_read": 0.12
     },
     {
       "id": "minimax-m2-7-highspeed",
@@ -619,10 +619,10 @@
     },
     {
       "id": "minimax",
-      "input": 0.3,
-      "output": 1.2,
-      "cache_write": 0.375,
-      "cache_read": 0.06
+      "input": 0.6,
+      "output": 2.4,
+      "cache_write": 0.6,
+      "cache_read": 0.12
     },
     {
       "id": "glm-5-2",


### PR DESCRIPTION
Reason: Refresh MiniMax text parameters — the Git AI default model and bundled MiniMax-M3 pricing were stale.

## What

- `src-tauri/crates/git-api/src/commands/ai.rs`: the per-provider small/cheap default model for MiniMax (`default_model_for`) pointed at the obsolete `abab6.5s-chat`. It now resolves to `MiniMax-M3`. The matching `EXPECTED_SMALL_MODELS` test fixture is updated so `preferred_api_types_have_explicit_small_model_defaults` continues to assert the explicit default.
- `src-tauri/crates/orgtrack-core/src/model_pricing_catalog.json`: the bundled price catalog recorded MiniMax-M3 at $0.30 input / $1.20 output / $0.06 cache-read per million tokens. Updated to the current $0.60 input / $2.40 output / $0.12 cache-read. The provider-level `minimax` fallback entry is aligned to the same current rates. `MiniMax-M2.7` (input $0.30 / output $1.20 / cache-write $0.375 / cache-read $0.06) is left as-is since it already matches the current values.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml -p git_api ai::` — 6 passed, 0 failed.
- `cargo test --manifest-path src-tauri/Cargo.toml -p orgtrack_core pricing` — 8 passed, 0 failed (catalog still parses and indexes; pricing lookups unchanged for non-MiniMax models).
- No other provider, model, vendor, or endpoint references were touched.
