### PR TITLE
docs(contributing): require single-purpose agent PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,51 @@ Run every applicable skill. Keep architecture, React performance, and UI-consist
 
 Run `org2-performance-guard` whenever a change adds or modifies polling, timers, retries, subscriptions, workers, streaming hot paths, caches, scans, sync loops, pagination, or multi-instance state. Apply its lifecycle matrix and rejection rules even when performance is not the feature's headline. State the performance verdict and concrete verification in the delivery message.
 
+### Pull request contract
+
+Every pull request created or updated by an agent MUST follow these rules.
+
+#### Single responsibility
+
+- One PR solves one problem or delivers one feature. Do not combine multiple
+  features, unrelated bug fixes, opportunistic refactors, cleanup, formatting,
+  or documentation changes in the same PR.
+- Supporting tests and documentation belong in the same PR only when they
+  directly verify or explain that PR's single change.
+- If requested work contains independent changes, split them into separate
+  branches/worktrees and separate PRs.
+- If a new unrelated request arrives after a PR has been opened, do not append
+  it to the existing branch. Create a separate PR.
+- Before handoff, compare the branch against its base and confirm every changed
+  file maps directly to the PR's stated problem or solution.
+
+#### Description format
+
+The PR description MUST begin with these top-level sections in this exact
+order:
+
+```markdown
+## Problem
+
+<What is wrong, who or what is affected, and the root cause.>
+
+## Solution
+
+<What changed, the resulting invariant or behavior, and why this approach was chosen.>
+
+## Potential risks
+
+<Concrete regressions, compatibility concerns, unverified paths, or operational tradeoffs.>
+```
+
+- Do not replace these sections with `Summary`, `Overview`, or `Test plan`.
+- Do not leave a required section blank. If no material risk remains, state
+  that explicitly and explain why.
+- Additional sections such as `Audit`, `Verification`, screenshots, or rollout
+  notes may follow the three required sections.
+- Before handing off a PR, read back the published description (for example
+  with `gh pr view`) and verify the section names and order.
+
 ---
 
 ## What This File Does NOT Do

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,59 @@ order:
 - Before handing off a PR, read back the published description (for example
   with `gh pr view`) and verify the section names and order.
 
+#### Base and diff integrity
+
+- Start from the intended target branch. Before handoff, fetch its latest state
+  and check whether the PR needs to be updated or conflicts resolved.
+- After resolving conflicts or incorporating target-branch changes, rerun the
+  checks affected by that integration.
+- Keep the published description synchronized with the final diff. Remove
+  claims about approaches, files, or behavior that are no longer present.
+- Avoid unrelated merge commits and generated churn. Do not rewrite published
+  history after review begins unless necessary; if history must change, use the
+  safest available method and tell reviewers what changed.
+
+#### Verification evidence
+
+- List the exact commands and meaningful manual checks that actually ran,
+  together with their outcomes.
+- State which relevant checks were not run and why. Do not write unsupported
+  claims such as "all tests pass" or infer runtime/performance improvement from
+  typecheck or code shape alone.
+- Verification must be proportional to risk and cover the changed behavior at
+  its owning boundary, not only a helper or selector.
+
+#### Risk, compatibility, and rollback
+
+- `Potential risks` must name concrete compatibility, data, concurrency,
+  lifecycle, platform, rollout, and unverified-path concerns that apply. Do not
+  use a generic "no risk" statement to avoid analysis.
+- Dependency or lockfile changes, database/schema migrations, configuration or
+  persistence format changes, and public API/IPC/wire changes must state why
+  they are necessary, how compatibility is handled, and how to roll back or
+  recover.
+- Destructive or difficult-to-reverse behavior requires an explicit rollback
+  or recovery plan before the PR is ready for review.
+
+#### UI and security evidence
+
+- User-visible UI changes should include screenshots or recordings appropriate
+  to the change, including relevant themes, viewport constraints, and
+  loading/empty/error states. If visual evidence is not useful, say why.
+- Before handoff, inspect the diff for secrets, tokens, personal paths, private
+  configuration, debug logs, build artifacts, caches, and unrelated formatting
+  changes. None may be included.
+
+#### Draft, ready, and review lifecycle
+
+- Keep the PR in Draft while material design choices, known blockers, required
+  migrations, or risk-proportionate verification remain incomplete.
+- Mark the PR ready only when its acceptance criteria are met and the
+  description reflects the current implementation.
+- If scope, behavior, or the chosen solution changes materially after review
+  begins, update the description and notify reviewers instead of silently
+  changing direction.
+
 ---
 
 ## What This File Does NOT Do


### PR DESCRIPTION
## Problem

The repository does not currently give agents a mandatory pull request scope and readiness contract. As a result, an agent can combine multiple features, unrelated bug fixes, opportunistic cleanup, or later follow-up requests into one PR, making review, rollback, and risk assessment harder.

Agent-created PRs can also become stale or difficult to verify when they omit concrete test evidence, leave the description out of sync with the final diff, hide compatibility or rollback concerns, include accidental artifacts, or move from Draft to Ready before material work is complete.

## Solution

Add a repository-level agent PR contract to `AGENTS.md` covering:

- **Single responsibility:** one problem or one feature per PR; independent changes require separate branches/worktrees and PRs.
- **Description format:** `Problem`, `Solution`, and `Potential risks` must be the first three sections, in that exact order, and the published body must be read back before handoff.
- **Base and diff integrity:** start from the intended target branch, re-check after target-branch changes or conflict resolution, keep the description synchronized, and avoid unrelated history or generated churn.
- **Verification evidence:** list the exact commands and manual checks that actually ran, state omissions honestly, and test behavior at its owning boundary.
- **Risk, compatibility, and rollback:** identify concrete risks; explain dependency, schema, configuration, persistence, API/IPC, and wire changes; provide recovery for destructive behavior.
- **UI and security evidence:** provide relevant visual evidence for visible UI changes and inspect the diff for secrets, personal paths, debug output, artifacts, caches, and unrelated formatting.
- **Draft and review lifecycle:** remain Draft while material blockers or verification gaps exist, become Ready only after acceptance criteria are met, and notify reviewers when the solution or scope changes materially.

This PR modifies only the agent instruction file; it does not change the general GitHub template for human contributors.

## Potential risks

- This is an instruction-level guard, not a CI-enforced merge check. An agent that does not load or follow `AGENTS.md` can still violate the contract.
- Existing open PRs are not retroactively split or reformatted.
- Strict separation can create more PRs for tightly related work. The rule allows directly supporting tests and documentation to remain with the implementation to avoid artificial fragmentation.
- Visual-evidence and proportional-verification decisions still require judgment; the contract requires an explanation when evidence is not useful rather than enforcing one mechanical checklist for every change.
- Human-authored PRs continue to use the existing general GitHub template; these mandatory rules apply specifically to agents.

## Verification

- Confirmed `git diff origin/develop...HEAD --name-only` contains only `AGENTS.md`.
- Ran Prettier on `AGENTS.md`.
- Ran `git diff --check`.
- Pre-commit `lint-staged` checks passed for both commits.
- Read back the published PR description and verified the required section order.
