### PR TITLE
feat(spotlight): support session reference search

### DIFF
--- a/src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightSearchBuilder.test.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightSearchBuilder.test.ts
@@ -9,6 +9,7 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
+import type { SpotlightItem } from "../../../types";
 import { APP_ACTIONS } from "../spotlightActionDefinitions";
 import { buildSearchModeItems } from "../spotlightSearchBuilder";
 
@@ -19,7 +20,11 @@ const BUILT_IN_TOOLS_DESTINATION_ID = "nav-integrations-nav-int-tools";
 // independent of the loaded i18n bundle.
 const echoTranslate = (key: string) => key;
 
-function runSearch(searchQuery: string, devModeEnabled = false) {
+function runSearch(
+  searchQuery: string,
+  devModeEnabled = false,
+  sessionItems: SpotlightItem[] = []
+) {
   const onSelectStaticAction = vi.fn();
   const items = buildSearchModeItems({
     searchQuery,
@@ -30,6 +35,7 @@ function runSearch(searchQuery: string, devModeEnabled = false) {
     onSelectEditorAction: vi.fn(),
     onSelectPath: vi.fn(),
     translate: echoTranslate,
+    sessionItems,
     devModeEnabled,
   });
   return { items, onSelectStaticAction };
@@ -77,5 +83,21 @@ describe("buildSearchModeItems — app commands", () => {
         (item) => item.id === BUILT_IN_TOOLS_DESTINATION_ID
       )
     ).toBe(true);
+  });
+
+  it("groups general Spotlight session matches ahead of commands", () => {
+    const sessionItem = {
+      id: "general-session:session-1",
+      label: "Rollout notes",
+      type: "option" as const,
+    };
+    const { items } = runSearch("update", false, [sessionItem]);
+
+    expect(items.slice(0, 4).map((item) => item.id)).toEqual([
+      "section-search-sessions",
+      sessionItem.id,
+      "section-search-actions",
+      DETECT_UPDATE_ID,
+    ]);
   });
 });

--- a/src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightSessionSearch.test.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/__tests__/spotlightSessionSearch.test.ts
@@ -1,0 +1,219 @@
+import { Users } from "lucide-react";
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveAgentIcon } from "@src/config/agentIcons";
+import type { RemoteTeammateSessionMetadata } from "@src/store/collaboration/types";
+import type { Session } from "@src/store/session";
+import { resolveSessionDisplayMetadata } from "@src/util/session/sessionDisplayMetadata";
+import { resolveSessionRowIcon } from "@src/util/session/sessionSidebarRow";
+
+import {
+  buildCloudSessionReferenceItem,
+  buildSpotlightSessionItems,
+  resolveAgentSessionSearchInput,
+  resolveSpotlightCloudSessionPresentation,
+} from "../spotlightSessionSearch";
+
+const SESSION_ID =
+  "codexapp-rollout-2026-07-29T17-21-00-019fad2d-620b-7971-a0f6-c76b92c38483";
+const REFERENCE = `orgii://cloud/session/ref?v=1&org=bfa7b134-2486-45fa-81ad-a369441fafb4&owner=776dbd69-ac1d-4f72-a0d4-69cb4f2667dd&session=${SESSION_ID}`;
+
+describe("resolveAgentSessionSearchInput", () => {
+  it("preserves a raw session id as free-text search", () => {
+    expect(resolveAgentSessionSearchInput(SESSION_ID)).toEqual({
+      query: SESSION_ID,
+      reference: null,
+    });
+  });
+
+  it("recognizes a copied cloud reference and extracts its source id", () => {
+    expect(resolveAgentSessionSearchInput(REFERENCE)).toEqual({
+      query: SESSION_ID,
+      reference: {
+        version: 1,
+        orgId: "bfa7b134-2486-45fa-81ad-a369441fafb4",
+        ownerUserId: "776dbd69-ac1d-4f72-a0d4-69cb4f2667dd",
+        sourceSessionId: SESSION_ID,
+      },
+    });
+  });
+
+  it("fails malformed references closed and leaves them searchable as text", () => {
+    const malformed =
+      "orgii://cloud/session/ref?v=1&org=org-1&session=session-1";
+    expect(resolveAgentSessionSearchInput(malformed)).toEqual({
+      query: malformed,
+      reference: null,
+    });
+  });
+});
+
+function session(overrides: Partial<Session> = {}): Session {
+  return {
+    session_id: SESSION_ID,
+    status: "completed",
+    created_at: "2026-07-29T00:00:00.000Z",
+    updated_at: "2026-07-29T00:00:00.000Z",
+    name: "Rollout notes",
+    ...overrides,
+  };
+}
+
+describe("buildSpotlightSessionItems", () => {
+  it("caps general Spotlight results and exposes the matched raw identity", () => {
+    const items = buildSpotlightSessionItems({
+      sessions: [
+        session(),
+        session({ session_id: `${SESSION_ID}-older` }),
+        session({ session_id: `${SESSION_ID}-oldest` }),
+      ],
+      fallbackSessionLabel: "Session",
+      visitedSessions: new Set(),
+      query: SESSION_ID,
+      onSelect: vi.fn(),
+      limit: 2,
+      idPrefix: "general-session",
+    });
+
+    expect(items).toHaveLength(2);
+    expect(items[0]).toMatchObject({
+      id: `general-session:${SESSION_ID}`,
+      label: "Rollout notes",
+      description: SESSION_ID,
+    });
+  });
+
+  it("opens the selected session with its resolved display name", () => {
+    const onSelect = vi.fn();
+    const source = session();
+    const [item] = buildSpotlightSessionItems({
+      sessions: [source],
+      fallbackSessionLabel: "Session",
+      visitedSessions: new Set([SESSION_ID]),
+      query: "rollout",
+      onSelect,
+    });
+
+    item.action?.();
+    expect(onSelect).toHaveBeenCalledWith(source, "Rollout notes");
+  });
+
+  it("builds an identity-preserving cloud reference action", () => {
+    const resolved = resolveAgentSessionSearchInput(REFERENCE);
+    const onSelect = vi.fn();
+    expect(resolved.reference).not.toBeNull();
+
+    const TestIcon = () => null;
+    const item = buildCloudSessionReferenceItem({
+      reference: resolved.reference!,
+      label: "Team session",
+      icon: TestIcon,
+      onSelect,
+      idPrefix: "general-cloud-session",
+    });
+
+    expect(item).toMatchObject({
+      id: `general-cloud-session:bfa7b134-2486-45fa-81ad-a369441fafb4:776dbd69-ac1d-4f72-a0d4-69cb4f2667dd:${SESSION_ID}`,
+      label: "Team session",
+      description: SESSION_ID,
+    });
+    expect(item.icon).toBe(TestIcon);
+    item.action?.();
+    expect(onSelect).toHaveBeenCalledWith(resolved.reference);
+  });
+});
+
+describe("resolveSpotlightCloudSessionPresentation", () => {
+  const reference = resolveAgentSessionSearchInput(REFERENCE).reference!;
+  const auth = {
+    supabaseUrl: "https://cloud.example.com",
+    userId: "viewer-user",
+  };
+  const identityKey = `${auth.supabaseUrl}|${auth.userId}`;
+  const remoteRow = {
+    id: "cloud-row",
+    orgId: reference.orgId,
+    ownerUserId: reference.ownerUserId,
+    sourceSessionId: reference.sourceSessionId,
+    title: "Codex rollout follow-up",
+    cliAgentType: "codex",
+  } as RemoteTeammateSessionMetadata;
+
+  it("uses the exact cached cloud row title and agent icon", () => {
+    const presentation = resolveSpotlightCloudSessionPresentation({
+      reference,
+      fallbackLabel: "Team session",
+      auth,
+      remoteEntries: {
+        [reference.orgId]: {
+          identityKey,
+          rows: [remoteRow],
+          state: "ready",
+          fetchedAt: 1,
+        },
+      },
+      localSessions: [],
+    });
+
+    const remoteDisplay = resolveSessionDisplayMetadata({
+      kind: "remote",
+      session: remoteRow,
+    });
+    expect(presentation).toEqual({
+      label: "Codex rollout follow-up",
+      icon: resolveAgentIcon(remoteDisplay.agentIconId),
+    });
+  });
+
+  it("does not read rows cached for a different signed-in identity", () => {
+    const presentation = resolveSpotlightCloudSessionPresentation({
+      reference,
+      fallbackLabel: "Team session",
+      auth,
+      remoteEntries: {
+        [reference.orgId]: {
+          identityKey: "https://cloud.example.com|previous-user",
+          rows: [remoteRow],
+          state: "ready",
+          fetchedAt: 1,
+        },
+      },
+      localSessions: [],
+    });
+
+    expect(presentation).toEqual({
+      label: "Team session",
+      icon: Users,
+    });
+  });
+
+  it("uses matching local presentation only for the reference owner", () => {
+    const ownerAuth = { ...auth, userId: reference.ownerUserId };
+    const local = session({ name: "My local rollout session" });
+
+    expect(
+      resolveSpotlightCloudSessionPresentation({
+        reference,
+        fallbackLabel: "Team session",
+        auth: ownerAuth,
+        remoteEntries: {},
+        localSessions: [local],
+      })
+    ).toEqual({
+      label: "My local rollout session",
+      icon: resolveSessionRowIcon(local),
+    });
+    expect(
+      resolveSpotlightCloudSessionPresentation({
+        reference,
+        fallbackLabel: "Team session",
+        auth,
+        remoteEntries: {},
+        localSessions: [local],
+      })
+    ).toEqual({
+      label: "Team session",
+      icon: Users,
+    });
+  });
+});

--- a/src/scaffold/GlobalSpotlight/hooks/features/spotlightSearchBuilder.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/spotlightSearchBuilder.ts
@@ -41,6 +41,7 @@ interface BuildSearchModeItemsArgs {
     icon: SpotlightItem["icon"]
   ) => void;
   translate: Translator;
+  sessionItems?: SpotlightItem[];
   devModeEnabled?: boolean;
 }
 
@@ -53,6 +54,7 @@ export function buildSearchModeItems({
   onSelectEditorAction,
   onSelectPath,
   translate,
+  sessionItems = [],
   devModeEnabled = false,
 }: BuildSearchModeItemsArgs): SpotlightItem[] {
   const commandFilterActive = searchQuery.startsWith(">");
@@ -68,8 +70,8 @@ export function buildSearchModeItems({
     return buildEditorMatches(queryLower, onSelectEditorAction, translate);
   }
 
-  const results: SpotlightItem[] = [];
-  results.push(
+  const actionResults: SpotlightItem[] = [];
+  actionResults.push(
     ...buildStaticMatches(
       staticCommandActions,
       queryLower,
@@ -77,15 +79,38 @@ export function buildSearchModeItems({
       translate
     )
   );
-  results.push(
+  actionResults.push(
     ...buildDynamicActionMatches(queryLower, onSelectAction, translate)
   );
 
   if (isEditorRoute) {
-    results.push(
+    actionResults.push(
       ...buildEditorMatches(queryLower, onSelectEditorAction, translate)
     );
   }
+
+  const results: SpotlightItem[] = [];
+  if (sessionItems.length > 0) {
+    results.push(
+      {
+        id: "section-search-sessions",
+        label: translate("common:sessions.title"),
+        type: "option",
+        data: { isHeader: true },
+      },
+      ...sessionItems
+    );
+
+    if (actionResults.length > 0) {
+      results.push({
+        id: "section-search-actions",
+        label: translate("selectors.spotlight.groups.actions"),
+        type: "option",
+        data: { isHeader: true },
+      });
+    }
+  }
+  results.push(...actionResults);
 
   // Surface navigation destinations directly in global search so users can
   // type e.g. "mcp" and jump straight to "Manage MCP" without having to pick

--- a/src/scaffold/GlobalSpotlight/hooks/features/spotlightSessionSearch.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/spotlightSessionSearch.ts
@@ -1,0 +1,218 @@
+import { Users } from "lucide-react";
+
+import { resolveAgentIcon } from "@src/config/agentIcons";
+import {
+  type CloudSessionReference,
+  parseCloudSessionReference,
+} from "@src/features/Org2Cloud/cloudSessionReference";
+import {
+  type Org2CloudAuthState,
+  org2CloudAuthIdentityKey,
+} from "@src/features/Org2Cloud/org2CloudAuthAtom";
+import {
+  type CloudOrgRemoteSessionsEntry,
+  remoteSessionsEntryForIdentity,
+} from "@src/features/Org2Cloud/org2CloudRemoteSessionsAtom";
+import { resolveSessionReferenceTitle } from "@src/features/Org2Cloud/resolveSessionReferenceTitle";
+import {
+  isSessionCompletedUnread,
+  isSessionPendingAsking,
+} from "@src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/menuItemBuilders";
+import {
+  renderBreathingStatusDot,
+  renderStatusDot,
+} from "@src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/statusIndicators";
+import type { Session } from "@src/store/session";
+import { resolveSessionDisplayMetadata } from "@src/util/session/sessionDisplayMetadata";
+import { isSessionInProgress } from "@src/util/session/sessionInProgress";
+import {
+  getSessionListDisplayName,
+  resolveSessionRowIcon,
+} from "@src/util/session/sessionSidebarRow";
+
+import type { SpotlightItem } from "../../types";
+
+export interface ResolvedAgentSessionSearchInput {
+  query: string;
+  reference: CloudSessionReference | null;
+}
+
+/**
+ * A copied cloud reference is an exact session identity, not free text.
+ * Preserve the parsed tuple for navigation while using its source id for
+ * any local/imported-row lookup.
+ */
+export function resolveAgentSessionSearchInput(
+  value: string
+): ResolvedAgentSessionSearchInput {
+  const reference = parseCloudSessionReference(value);
+  return {
+    query: reference?.sourceSessionId ?? value,
+    reference,
+  };
+}
+
+interface ResolveSpotlightCloudSessionPresentationInput {
+  reference: CloudSessionReference;
+  fallbackLabel: string;
+  auth: Pick<Org2CloudAuthState, "supabaseUrl" | "userId"> | null;
+  remoteEntries: Record<string, CloudOrgRemoteSessionsEntry>;
+  localSessions: readonly Session[];
+}
+
+export interface SpotlightCloudSessionPresentation {
+  label: string;
+  icon: SpotlightItem["icon"];
+}
+
+/**
+ * Resolve a reference title and agent icon only from data already authorized
+ * for the active cloud identity. Local presentation is eligible only when the
+ * reference owner is the signed-in user; source ids are not globally unique
+ * across publishers.
+ */
+export function resolveSpotlightCloudSessionPresentation({
+  reference,
+  fallbackLabel,
+  auth,
+  remoteEntries,
+  localSessions,
+}: ResolveSpotlightCloudSessionPresentationInput): SpotlightCloudSessionPresentation {
+  const identityKey = auth ? org2CloudAuthIdentityKey(auth) : null;
+  const remoteEntry = remoteSessionsEntryForIdentity(
+    remoteEntries[reference.orgId],
+    identityKey
+  );
+  const localSession =
+    auth?.userId === reference.ownerUserId
+      ? localSessions.find(
+          (session) => session.session_id === reference.sourceSessionId
+        )
+      : undefined;
+  const localTitle = localSession
+    ? getSessionListDisplayName(localSession, "")
+    : undefined;
+  const remoteRow = remoteEntry?.rows.find(
+    (candidate) =>
+      candidate.sourceSessionId === reference.sourceSessionId &&
+      candidate.ownerUserId === reference.ownerUserId
+  );
+  const remoteIcon = remoteRow
+    ? resolveAgentIcon(
+        resolveSessionDisplayMetadata({
+          kind: "remote",
+          session: remoteRow,
+        }).agentIconId
+      )
+    : undefined;
+
+  return {
+    label:
+      resolveSessionReferenceTitle({
+        reference,
+        orgRows: remoteEntry?.rows,
+        localTitle,
+      }) ?? fallbackLabel,
+    icon: localSession
+      ? resolveSessionRowIcon(localSession)
+      : (remoteIcon ?? Users),
+  };
+}
+
+interface BuildSpotlightSessionItemsInput {
+  sessions: readonly Session[];
+  fallbackSessionLabel: string;
+  visitedSessions: ReadonlySet<string>;
+  query: string;
+  onSelect: (session: Session, sessionName: string) => void;
+  limit?: number;
+  idPrefix?: string;
+}
+
+function matchedSessionIdentity(
+  session: Session,
+  query: string
+): string | undefined {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return undefined;
+
+  return [session.session_id, session.importedFrom?.sourceSessionId].find(
+    (identity): identity is string =>
+      Boolean(identity?.toLowerCase().includes(normalizedQuery))
+  );
+}
+
+/**
+ * Shared row builder for both the nested and general Spotlight searches.
+ * The general palette passes a limit; the dedicated palette renders all
+ * filtered rows.
+ */
+export function buildSpotlightSessionItems({
+  sessions,
+  fallbackSessionLabel,
+  visitedSessions,
+  query,
+  onSelect,
+  limit,
+  idPrefix,
+}: BuildSpotlightSessionItemsInput): SpotlightItem[] {
+  const visibleSessions =
+    limit === undefined ? sessions : sessions.slice(0, limit);
+
+  return visibleSessions.map((session) => {
+    const sessionName = getSessionListDisplayName(
+      session,
+      fallbackSessionLabel
+    );
+    const inProgress = isSessionInProgress(session.status, session);
+    const pendingAsking = isSessionPendingAsking(session);
+    const unread = isSessionCompletedUnread(session, visitedSessions);
+    const statusDotTone = pendingAsking
+      ? "asking"
+      : unread
+        ? "unread"
+        : "default";
+
+    return {
+      id: idPrefix ? `${idPrefix}:${session.session_id}` : session.session_id,
+      label: sessionName,
+      description: matchedSessionIdentity(session, query),
+      icon: resolveSessionRowIcon(session),
+      type: "option" as const,
+      data: {
+        statusContent:
+          inProgress && !pendingAsking
+            ? renderBreathingStatusDot()
+            : renderStatusDot(statusDotTone),
+        iconTone: "text1",
+      },
+      action: () => onSelect(session, sessionName),
+    };
+  });
+}
+
+interface BuildCloudSessionReferenceItemInput {
+  reference: CloudSessionReference;
+  label: string;
+  icon?: SpotlightItem["icon"];
+  onSelect: (reference: CloudSessionReference) => void;
+  idPrefix?: string;
+}
+
+export function buildCloudSessionReferenceItem({
+  reference,
+  label,
+  icon = Users,
+  onSelect,
+  idPrefix = "cloud-session-reference",
+}: BuildCloudSessionReferenceItemInput): SpotlightItem {
+  return {
+    id: `${idPrefix}:${reference.orgId}:${reference.ownerUserId}:${reference.sourceSessionId}`,
+    label,
+    description: reference.sourceSessionId,
+    icon,
+    type: "option",
+    data: { iconTone: "text1" },
+    action: () => onSelect(reference),
+  };
+}

--- a/src/scaffold/GlobalSpotlight/hooks/features/useSpotlightItems.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/features/useSpotlightItems.ts
@@ -13,11 +13,20 @@
  * Uses shared domain adapters for repo/branch item building.
  */
 import { useAtomValue } from "jotai";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
+import type { CloudSessionReference } from "@src/features/Org2Cloud/cloudSessionReference";
+import { org2CloudAuthAtom } from "@src/features/Org2Cloud/org2CloudAuthAtom";
+import { org2CloudRemoteSessionsAtom } from "@src/features/Org2Cloud/org2CloudRemoteSessionsAtom";
+import { useFilteredItems } from "@src/hooks/search";
 import type { LanguagePreference } from "@src/i18n";
 import { devModeEnabledAtom } from "@src/store/platform/devModeAtom";
+import {
+  type Session,
+  sessionsAtom,
+  visitedSessionsAtom,
+} from "@src/store/session";
 import {
   chatPanelMaximizedAtom,
   chatTurnPaginationEnabledAtom,
@@ -36,6 +45,7 @@ import {
   workStationPrimarySidebarCollapsedAtom,
 } from "@src/store/ui/workStationAtom";
 import { activeStatusBarCallbacksAtom } from "@src/store/ui/workStationLayout/statusBarAtoms";
+import { getSessionSearchText } from "@src/util/session/sessionSearch";
 
 import { NAV_DESTINATIONS } from "../../config";
 import {
@@ -75,6 +85,14 @@ import {
   buildStaticActionItems,
 } from "./spotlightItemBuilders";
 import { buildSearchModeItems } from "./spotlightSearchBuilder";
+import {
+  buildCloudSessionReferenceItem,
+  buildSpotlightSessionItems,
+  resolveAgentSessionSearchInput,
+  resolveSpotlightCloudSessionPresentation,
+} from "./spotlightSessionSearch";
+
+const GENERAL_SPOTLIGHT_SESSION_RESULT_LIMIT = 8;
 
 // ============================================
 // Public type re-exports
@@ -102,6 +120,8 @@ interface SpotlightItemsHandlers {
   onSelectRepo: (repo: RepoItem) => void;
   onSelectBranch: (branch: BranchItem) => void;
   onSelectLanguage: (language: LanguagePreference, label: string) => void;
+  onSelectSession: (session: Session, sessionName: string) => void;
+  onSelectCloudSessionReference: (reference: CloudSessionReference) => void;
   onSelectPath: (
     path: string,
     label: string,
@@ -140,6 +160,10 @@ export function useSpotlightItems(
   const workstationSidebarPosition = useAtomValue(workStationLayoutModeAtom);
   const currentLanguage = useAtomValue(languageAtom);
   const recentActionIds = useAtomValue(spotlightRecentActionsAtom);
+  const sessions = useAtomValue(sessionsAtom);
+  const visitedSessions = useAtomValue(visitedSessionsAtom);
+  const cloudAuth = useAtomValue(org2CloudAuthAtom);
+  const cloudRemoteSessions = useAtomValue(org2CloudRemoteSessionsAtom);
   const { t } = useTranslation();
   const translate: Translator = t;
 
@@ -150,6 +174,8 @@ export function useSpotlightItems(
     onSelectRepo,
     onSelectBranch,
     onSelectLanguage,
+    onSelectSession,
+    onSelectCloudSessionReference,
     onSelectPath,
     currentRepoId,
     isEditorRoute,
@@ -161,6 +187,40 @@ export function useSpotlightItems(
   // change (e.g. selectedIndex).
   const { stage, path, currentAction, missingParam, searchQuery, isComplete } =
     state;
+  const hasAction = path.some((segment) => segment.type === "action");
+  const hasRepo = path.some((segment) => segment.type === "repo");
+  const isGeneralSearch = Boolean(searchQuery) && !hasAction && !hasRepo;
+  const resolvedSessionSearchInput = useMemo(
+    () => resolveAgentSessionSearchInput(searchQuery),
+    [searchQuery]
+  );
+  const generalSessionSearchQuery = isGeneralSearch
+    ? resolvedSessionSearchInput.query
+    : "";
+  const sortedSessions = useMemo(() => {
+    if (!isGeneralSearch || resolvedSessionSearchInput.reference) return [];
+    return sessions
+      .slice()
+      .sort((sessionA, sessionB) =>
+        (sessionB.updated_at || sessionB.updated_time || "").localeCompare(
+          sessionA.updated_at || sessionA.updated_time || ""
+        )
+      );
+  }, [isGeneralSearch, resolvedSessionSearchInput.reference, sessions]);
+  const fallbackSessionLabel = t("navigation:routes.session", "Session");
+  const cloudSessionLabel = t(
+    "navigation:cloud.sessionRef.chipLabel",
+    "Team session"
+  );
+  const getSessionText = useCallback(
+    (session: Session) => getSessionSearchText(session, fallbackSessionLabel),
+    [fallbackSessionLabel]
+  );
+  const { filteredItems: matchingSessions } = useFilteredItems({
+    items: sortedSessions,
+    searchQuery: generalSessionSearchQuery,
+    getSearchText: getSessionText,
+  });
 
   const items = useMemo((): SpotlightItem[] => {
     const viewActions = buildViewActions(
@@ -189,11 +249,33 @@ export function useSpotlightItems(
       return [];
     }
 
-    const hasAction = path.some((segment) => segment.type === "action");
-    const hasRepo = path.some((segment) => segment.type === "repo");
-
     // ========== SEARCH MODE (Global Search) ==========
     if (searchQuery && !hasAction && !hasRepo) {
+      const sessionItems = resolvedSessionSearchInput.reference
+        ? [
+            buildCloudSessionReferenceItem({
+              reference: resolvedSessionSearchInput.reference,
+              ...resolveSpotlightCloudSessionPresentation({
+                reference: resolvedSessionSearchInput.reference,
+                fallbackLabel: cloudSessionLabel,
+                auth: cloudAuth,
+                remoteEntries: cloudRemoteSessions,
+                localSessions: sessions,
+              }),
+              onSelect: onSelectCloudSessionReference,
+              idPrefix: "general-cloud-session",
+            }),
+          ]
+        : buildSpotlightSessionItems({
+            sessions: matchingSessions,
+            fallbackSessionLabel,
+            visitedSessions,
+            query: resolvedSessionSearchInput.query,
+            onSelect: onSelectSession,
+            limit: GENERAL_SPOTLIGHT_SESSION_RESULT_LIMIT,
+            idPrefix: "general-session",
+          });
+
       return buildSearchModeItems({
         searchQuery,
         isEditorRoute,
@@ -211,6 +293,7 @@ export function useSpotlightItems(
         onSelectEditorAction,
         onSelectPath,
         translate,
+        sessionItems,
         devModeEnabled,
       });
     }
@@ -323,11 +406,12 @@ export function useSpotlightItems(
     );
   }, [
     stage,
-    path,
     currentAction,
     missingParam,
     searchQuery,
     isComplete,
+    hasAction,
+    hasRepo,
     isSidebarCollapsed,
     isWorkstationSidebarCollapsed,
     isBottomPanelCollapsed,
@@ -341,6 +425,14 @@ export function useSpotlightItems(
     workstationSidebarPosition,
     currentLanguage,
     recentActionIds,
+    matchingSessions,
+    fallbackSessionLabel,
+    cloudSessionLabel,
+    cloudAuth,
+    cloudRemoteSessions,
+    sessions,
+    visitedSessions,
+    resolvedSessionSearchInput,
     devModeEnabled,
     isEditorRoute,
     isWorkStationRoute,
@@ -353,6 +445,8 @@ export function useSpotlightItems(
     onSelectRepo,
     onSelectBranch,
     onSelectLanguage,
+    onSelectSession,
+    onSelectCloudSessionReference,
     onSelectPath,
     translate,
   ]);

--- a/src/scaffold/GlobalSpotlight/hooks/useSpotlight.ts
+++ b/src/scaffold/GlobalSpotlight/hooks/useSpotlight.ts
@@ -18,9 +18,12 @@ import {
   type ActionId,
   useActionSystemOptional,
 } from "@src/ActionSystem";
+import type { CloudSessionReference } from "@src/features/Org2Cloud/cloudSessionReference";
+import { useOpenCloudSessionReference } from "@src/features/Org2Cloud/useOpenCloudSessionReference";
 import { useAppNavigation } from "@src/hooks/navigation/useAppNavigation";
 import { showScaleMessage } from "@src/hooks/navigation/useGlobalShortcuts/types";
 import { useFilteredItems } from "@src/hooks/search";
+import { useSessionView } from "@src/hooks/ui/tabs/useSessionView";
 import type { LanguagePreference } from "@src/i18n";
 import { checkForUpdatesManually } from "@src/scaffold/AppUpdater";
 import {
@@ -32,6 +35,7 @@ import { PanelService } from "@src/services/panel";
 import { WorkStationViewService } from "@src/services/workStation/WorkStationViewService";
 import { selectedRepoAtom } from "@src/store/repo";
 import { REPO_KIND } from "@src/store/repo/types";
+import type { Session } from "@src/store/session";
 import { spotlightRecentActionsAtom } from "@src/store/ui/spotlightRecentActionsAtom";
 import { UI_SCALE_CONFIG, uiScaleAtom } from "@src/store/ui/uiAtom";
 import { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";
@@ -97,6 +101,8 @@ export function useSpotlight(
   const state = useSpotlightState();
   const currentRepo = useAtomValue(selectedRepoAtom);
   const { navigateTo } = useAppNavigation();
+  const { openSession } = useSessionView();
+  const openCloudSessionReference = useOpenCloudSessionReference();
   const actionSystem = useActionSystemOptional();
   const dispatch = useSpotlightDispatch();
   const setRecentActionIds = useSetAtom(spotlightRecentActionsAtom);
@@ -381,6 +387,24 @@ export function useSpotlight(
     [closeModal, dispatch, dispatchActionOrFallback]
   );
 
+  const handleSelectSession = useCallback(
+    (session: Session, sessionName: string) => {
+      openSession(session.session_id, sessionName, session.repoPath);
+      closeModal?.();
+      dispatch({ type: "RESET_TO_IDLE" });
+    },
+    [closeModal, dispatch, openSession]
+  );
+
+  const handleSelectCloudSessionReference = useCallback(
+    (reference: CloudSessionReference) => {
+      if (!openCloudSessionReference(reference, { autoReplay: true })) return;
+      closeModal?.();
+      dispatch({ type: "RESET_TO_IDLE" });
+    },
+    [closeModal, dispatch, openCloudSessionReference]
+  );
+
   const handleSelectPath = useCallback(
     (
       path: string,
@@ -406,6 +430,8 @@ export function useSpotlight(
     onSelectRepo: handleSelectRepo,
     onSelectBranch: handleSelectBranch,
     onSelectLanguage: handleSelectLanguage,
+    onSelectSession: handleSelectSession,
+    onSelectCloudSessionReference: handleSelectCloudSessionReference,
     onSelectPath: handleSelectPath,
     isEditorRoute,
     isWorkStationRoute,

--- a/src/scaffold/GlobalSpotlight/palettes/AgentSessionSearchPalette/index.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/AgentSessionSearchPalette/index.tsx
@@ -9,16 +9,12 @@ import { Search } from "lucide-react";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import type { CloudSessionReference } from "@src/features/Org2Cloud/cloudSessionReference";
+import { org2CloudAuthAtom } from "@src/features/Org2Cloud/org2CloudAuthAtom";
+import { org2CloudRemoteSessionsAtom } from "@src/features/Org2Cloud/org2CloudRemoteSessionsAtom";
+import { useOpenCloudSessionReference } from "@src/features/Org2Cloud/useOpenCloudSessionReference";
 import { useFilteredItems } from "@src/hooks/search";
 import { useSessionView } from "@src/hooks/ui/tabs/useSessionView";
-import {
-  isSessionCompletedUnread,
-  isSessionPendingAsking,
-} from "@src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/menuItemBuilders";
-import {
-  renderBreathingStatusDot,
-  renderStatusDot,
-} from "@src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/statusIndicators";
 import {
   loadSidebarSessions,
   sessionLoadingAtom,
@@ -26,13 +22,15 @@ import {
   visitedSessionsAtom,
 } from "@src/store/session";
 import type { Session } from "@src/store/session";
-import { isSessionInProgress } from "@src/util/session/sessionInProgress";
 import { getSessionSearchText } from "@src/util/session/sessionSearch";
-import {
-  getSessionListDisplayName,
-  resolveSessionRowIcon,
-} from "@src/util/session/sessionSidebarRow";
+import { getSessionListDisplayName } from "@src/util/session/sessionSidebarRow";
 
+import {
+  buildCloudSessionReferenceItem,
+  buildSpotlightSessionItems,
+  resolveAgentSessionSearchInput,
+  resolveSpotlightCloudSessionPresentation,
+} from "../../hooks/features/spotlightSessionSearch";
 import type { BasePaletteProps } from "../../shared";
 import { PaletteBody, SpotlightShell } from "../../shell";
 import type { PathSegment, SpotlightItem } from "../../types";
@@ -51,10 +49,17 @@ export const AgentSessionSearchPalette: React.FC<
 > = ({ isOpen, onClose, onGoBackToParent, asBody = false }) => {
   const { t } = useTranslation();
   const { openSession } = useSessionView();
+  const openCloudSessionReference = useOpenCloudSessionReference();
   const sessions = useAtomValue(sessionsAtom);
   const sessionsLoading = useAtomValue(sessionLoadingAtom);
   const visitedSessions = useAtomValue(visitedSessionsAtom);
+  const cloudAuth = useAtomValue(org2CloudAuthAtom);
+  const cloudRemoteSessions = useAtomValue(org2CloudRemoteSessionsAtom);
   const [query, setQuery] = useState("");
+  const resolvedSearchInput = useMemo(
+    () => resolveAgentSessionSearchInput(query),
+    [query]
+  );
 
   useEffect(() => {
     if (!isOpen) return;
@@ -76,7 +81,7 @@ export const AgentSessionSearchPalette: React.FC<
   const fallbackSessionLabel = t("navigation:routes.session", "Session");
   const { filteredItems } = useFilteredItems({
     items: sortedSessions,
-    searchQuery: query,
+    searchQuery: resolvedSearchInput.query,
     getSearchText: (session) =>
       getSessionSearchText(session, fallbackSessionLabel),
   });
@@ -101,39 +106,56 @@ export const AgentSessionSearchPalette: React.FC<
     [fallbackSessionLabel, onClose, openSession]
   );
 
-  const items = useMemo<SpotlightItem[]>(
-    () =>
-      filteredItems.map((session) => {
-        const sessionName = getSessionListDisplayName(
-          session,
-          fallbackSessionLabel
-        );
-        const inProgress = isSessionInProgress(session.status, session);
-        const pendingAsking = isSessionPendingAsking(session);
-        const unread = isSessionCompletedUnread(session, visitedSessions);
-        const statusDotTone = pendingAsking
-          ? "asking"
-          : unread
-            ? "unread"
-            : "default";
-
-        return {
-          id: session.session_id,
-          label: sessionName,
-          icon: resolveSessionRowIcon(session),
-          type: "option" as const,
-          data: {
-            statusContent:
-              inProgress && !pendingAsking
-                ? renderBreathingStatusDot()
-                : renderStatusDot(statusDotTone),
-            iconTone: "text1",
-          },
-          action: () => handleOpenSession(session),
-        };
-      }),
-    [fallbackSessionLabel, filteredItems, handleOpenSession, visitedSessions]
+  const handleOpenCloudReference = useCallback(
+    (reference: CloudSessionReference) => {
+      if (openCloudSessionReference(reference, { autoReplay: true })) {
+        onClose();
+      }
+    },
+    [onClose, openCloudSessionReference]
   );
+
+  const items = useMemo<SpotlightItem[]>(() => {
+    if (resolvedSearchInput.reference) {
+      const reference = resolvedSearchInput.reference;
+      return [
+        buildCloudSessionReferenceItem({
+          reference,
+          ...resolveSpotlightCloudSessionPresentation({
+            reference,
+            fallbackLabel: t(
+              "navigation:cloud.sessionRef.chipLabel",
+              "Team session"
+            ),
+            auth: cloudAuth,
+            remoteEntries: cloudRemoteSessions,
+            localSessions: sessions,
+          }),
+          onSelect: handleOpenCloudReference,
+        }),
+      ];
+    }
+
+    return buildSpotlightSessionItems({
+      sessions: filteredItems,
+      fallbackSessionLabel,
+      visitedSessions,
+      query: resolvedSearchInput.query,
+      onSelect: handleOpenSession,
+    });
+  }, [
+    fallbackSessionLabel,
+    filteredItems,
+    cloudAuth,
+    cloudRemoteSessions,
+    handleOpenCloudReference,
+    handleOpenSession,
+    resolvedSearchInput.query,
+    resolvedSearchInput.reference,
+    sessions,
+    t,
+    visitedSessions,
+  ]);
 
   const isItemSelectable = useCallback((item: SpotlightItem) => {
     return !item.data?.isHeader && !item.data?.disabled;

--- a/src/util/session/sessionSearch.test.ts
+++ b/src/util/session/sessionSearch.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import type { Session } from "@src/store/session";
+
+import { getSessionSearchText } from "./sessionSearch";
+
+function session(overrides: Partial<Session> = {}): Session {
+  return {
+    session_id: "codexapp-rollout-2026-07-29",
+    status: "completed",
+    created_at: "2026-07-29T00:00:00.000Z",
+    updated_at: "2026-07-29T00:00:00.000Z",
+    name: "Rollout notes",
+    ...overrides,
+  };
+}
+
+describe("getSessionSearchText", () => {
+  it("includes the canonical session id", () => {
+    expect(getSessionSearchText(session(), "Session")).toContain(
+      "codexapp-rollout-2026-07-29"
+    );
+  });
+
+  it("includes the source id of an imported cloud replay", () => {
+    expect(
+      getSessionSearchText(
+        session({
+          session_id: "imported-session-local-copy",
+          importedFrom: {
+            orgId: "org-1",
+            sourceSessionId: "codexapp-rollout-2026-07-29",
+            ownerMemberId: "member-1",
+            epoch: 1,
+            seq: 1,
+            count: 1,
+          },
+        }),
+        "Session"
+      )
+    ).toContain("codexapp-rollout-2026-07-29");
+  });
+});

--- a/src/util/session/sessionSearch.ts
+++ b/src/util/session/sessionSearch.ts
@@ -8,6 +8,8 @@ export function getSessionSearchText(
 ): string {
   return [
     getSessionListDisplayName(session, fallback),
+    session.session_id,
+    session.importedFrom?.sourceSessionId,
     session.user_input,
     session.repo_name,
     session.repoPath,


### PR DESCRIPTION
## Summary
- search sessions in general and dedicated Spotlight by title, raw session ID, imported source ID, or copied cloud reference
- show the resolved session name and agent-specific icon for exact cloud references
- preserve cloud org, owner, and source session identity when opening a result

## Testing
- 43 focused Vitest tests passed
- ESLint passed for all changed files
- Prettier check passed
- TypeScript check passed
- git diff check passed