### PR TITLE
fix(cloud): hollow guard, deterministic ingest, sync hardening, Take Over parity

### DIFF
--- a/.orgii/skills/dual-instance-verification/SKILL.md
+++ b/.orgii/skills/dual-instance-verification/SKILL.md
@@ -19,18 +19,32 @@ instance, and the cloud rows — and every state mutation in between is explaina
 
 ## Non-negotiables
 
-1. **Cloud ground-truth ledger.** Snapshot the org's `cloud_sessions` (session_id,
-   deleted_at, access_mode, events_count, events_frozen_seq, stored_bytes) BEFORE
-   and AFTER every scenario, via service key. Diff must be explainable
-   line-by-line. Any unexplained `deleted_at`, access_mode downgrade, or
-   events_count drop is a FAILURE even if the UI looks fine.
-   (Would have caught: vanished-sweep mass retract, boot out-of-scope retract.)
+1. **Cloud ground-truth ledger — fleet-wide, invariant-based.** Snapshot
+   `cloud_sessions` (session_id, deleted_at, access_mode, events_count,
+   events_frozen_seq, events_epoch, stored_bytes) BEFORE and AFTER every
+   scenario, via service key — for EVERY org the instances can see, not just the
+   org under test. Diff must be explainable line-by-line, and "explainable"
+   means a verified mechanism, not a plausible story ("that session is active"
+   is a story; "its rollout grew by N lines, here they are" is a mechanism).
+   On top of the diff, assert invariants: for every session the scenario did
+   NOT deliberately touch, `events_epoch` is CONSTANT and `events_count` is
+   monotone; flag any row with `events_epoch` above a small threshold (>3)
+   anywhere in the fleet. Any unexplained `deleted_at`, access_mode downgrade,
+   events_count drop, or epoch bump is a FAILURE even if the UI looks fine.
+   (Would have caught: vanished-sweep mass retract, boot out-of-scope retract,
+   and the #608 rewrite storm — a 28-epoch counter sat in this column for weeks
+   while diffs on the test org alone stayed clean.)
 
-2. **Destructive-verb audit at INFO level.** After each scenario AND after each
-   app boot, grep both instances' frontend+backend logs for
-   `retract|untag|drop|delete|demote|evict|vanish|superseded` at ALL levels, not
-   just WARN/ERROR. Every hit needs a justification. Destructive actions wearing
-   legitimate INFO wording are exactly how retract bugs hid.
+2. **Destructive-effect audit at INFO level — classify by effect, not verb.**
+   After each scenario AND after each app boot, grep both instances'
+   frontend+backend logs for
+   `retract|untag|drop|delete|demote|evict|vanish|superseded|epoch rewrite|rewrite`
+   at ALL levels, not just WARN/ERROR. Every hit needs a justification. The
+   audit's unit is "anything that replaces or deletes cloud bytes" — a full
+   epoch rewrite re-uploads and REPLACES the entire stored copy and is more
+   destructive than a retract, yet it wears routine INFO wording and matches no
+   scary verb. When new log lines gain the power to mutate cloud rows, add them
+   to this list in the same PR.
 
 3. **Lifecycle-boundary cells are mandatory.** The matrix is feature ×
    lifecycle-event, not feature × instance. For every sharing feature, run at
@@ -73,9 +87,46 @@ instance, and the cloud rows — and every state mutation in between is explaina
    `routeSessionChannelEvent`, `handleEvent(_disposed)`, and the runtime-status
    gate all dropped silently. Those five now log; keep that bar for new code.
 
-8. **Resource three-piece stays.** cmd+5/Activity Monitor curves (idle ≈0%,
-   RSS returns to baseline), feature signals, and WARN/ERROR delta with each new
-   line triaged. This skill ADDS to it; it does not replace it.
+8. **Resource three-piece stays — and anomalies are defects until mechanized.**
+   cmd+5/Activity Monitor curves (idle ≈0%, RSS returns to baseline), feature
+   signals, and WARN/ERROR delta with each new line triaged. This skill ADDS to
+   it; it does not replace it. A recurring resource anomaly (a CPU wave on
+   every boot, RSS that climbs per pass) must open an investigation cell — it
+   may NOT be closed with a narrative. The #608 storm's boot-time CPU wave was
+   observed, named "ingest re-hash convergence", and normalized; the re-hash
+   WAS the bug. Naming an anomaly is not explaining it.
+
+## Invariant & determinism cells (mandatory additions per run)
+
+Born from the 2026-07-30 reflection on why #608 (rewrite storm), the hollow
+wipe, and the scope flap all survived multiple live rounds: the protocol
+asserted presence (the tested flow works) while these bugs were silent surplus
+actions in the background, invisible to every existing cell.
+
+- **Two-boot determinism cell.** With local state unchanged, cold-boot the
+  instance twice and let sync passes run. Boot 2 must produce ZERO epoch
+  rewrites and zero destructive-effect hits (boot 1 may re-anchor once after a
+  legitimate format/order change — each such rewrite must be explained as
+  exactly-once). Nondeterminism bugs are per-process (HashMap iteration order,
+  random seeds); a single boot cannot sample them by construction. Measured
+  cost: ~18 minutes wall clock, mostly unattended.
+- **Absence needs liveness beside it.** Any "zero X since the fix" claim must
+  pair the constant (epoch, deleted_at) with a mover (events_count,
+  updated_at, pass counters in the log) proving the engine actually ran over
+  the rows in question. Deferred/skipped sessions (e.g. scope-guard deferrals)
+  are UNCOVERED, not passing.
+- **At least one fault-injection cell per run.** Healthy instances sample only
+  the happy path; the hollow wipe (empty local read while cursor covers >0)
+  and the scope flap (transient GitHub identity failure) lived exclusively in
+  degraded states no healthy-path cell can reach. Rotate through: rename/move
+  a local source DB mid-run (hollow read), block the identity endpoint
+  (lookup failure), kill the app mid-transfer (partial persist). The guard
+  under test must defer/refuse — any destructive act under injected fault is
+  a failure.
+- **Unexplained delta becomes a cell.** The first ledger delta, log line, or
+  resource pattern without a mechanism-level explanation is promoted to a
+  scenario in the CURRENT run — not noted for later. "Background sync noise"
+  is the phrase that hid a data-destroying storm.
 
 ## Ledger commands
 
@@ -148,6 +199,16 @@ rollover or the window silently truncates.
   that must still be MOVING (events_count / updated_at). Same shape as
   watchdog-masked completion — silence and health look identical until you
   measure both.
+- **Presence oracles miss surplus actions**: every cell asserted "the thing I
+  did worked"; the escaped bugs were things NOBODY did — silent rewrites,
+  silent retracts, a silent wipe — that break no foreground flow. The fleet
+  ledger's invariant columns (epoch constant, count monotone) are the only
+  surface where surplus actions are visible at all.
+- **Per-process nondeterminism is invisible to single-boot runs**: HashMap
+  iteration order reshuffled an unchanged transcript's flushed tail on every
+  boot, and positional chunk ids turned the shuffle into a fresh hash chain
+  each time. Within one app lifetime everything looked stable; only
+  boot-vs-boot comparison of push decisions could see it. (#608 root cause.)
 - **Waiting for a pass the engine will never run**: the session plane follows
   visible-org demand — an org's push/retract pass runs only while that org is
   the active workspace. A fix whose cleanup rides "the next pass" looks

--- a/src-tauri/crates/orgtrack-core/src/sources/claude_code/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/claude_code/history.rs
@@ -1305,7 +1305,8 @@ fn load_claude_code_history_from_reader<R: BufRead>(
     forced_first_user_id: Option<&str>,
 ) -> Result<Vec<ActivityChunk>, String> {
     let mut chunks = Vec::new();
-    let mut pending_tool_calls: HashMap<String, ImportedToolCall> = HashMap::new();
+    let mut pending_tool_calls: imported_history::PendingCallMap<ImportedToolCall> =
+        imported_history::PendingCallMap::new();
     let mut sequence = start_sequence;
     let mut forced_first_user_id = forced_first_user_id;
 
@@ -1409,7 +1410,7 @@ fn load_claude_code_history_from_reader<R: BufRead>(
         }
     }
 
-    for call in pending_tool_calls.into_values() {
+    for call in pending_tool_calls.drain_in_file_order() {
         chunks.push(imported_history::tool_call_chunk(
             session_id,
             CLAUDE_CODE_PROVIDER_SLUG,

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app/transcript.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app/transcript.rs
@@ -987,8 +987,10 @@ fn load_codex_app_from_path_with_mode<'a>(
     let mut reader = BufReader::new(file);
 
     let mut collector = CodexTranscriptCollector::new(session_id, mode);
-    let mut pending_tool_calls: HashMap<String, Vec<ImportedToolCall>> = HashMap::new();
-    let mut background_tool_calls: HashMap<String, PendingBackgroundToolCall> = HashMap::new();
+    let mut pending_tool_calls: imported_history::PendingCallMap<Vec<ImportedToolCall>> =
+        imported_history::PendingCallMap::new();
+    let mut background_tool_calls: imported_history::PendingCallMap<PendingBackgroundToolCall> =
+        imported_history::PendingCallMap::new();
     let mut pending_task_turn_id: Option<String> = None;
     let mut pending_task_turn_offset: Option<u64> = None;
     let mut active_task_turn_id: Option<String> = None;
@@ -1139,16 +1141,21 @@ fn load_codex_app_from_path_with_mode<'a>(
             "function_call_output" | "custom_tool_call_output" => {
                 let call_id = parsed.payload.get("call_id").and_then(Value::as_str);
                 if let Some(call_id) = call_id {
-                    if let Some(calls) = pending_tool_calls.remove(call_id) {
+                    if let Some((file_order, calls)) = pending_tool_calls.take(call_id) {
                         let output_value = parsed.payload.get("output");
                         let output = codex_tool_output_text(output_value);
                         if let Some(cell_id) = wait_cell_id(&calls) {
                             let cell_key = background_cell_key(cell_id);
-                            if let Some(mut background) = background_tool_calls.remove(&cell_key) {
+                            if let Some((background_order, mut background)) =
+                                background_tool_calls.take(&cell_key)
+                            {
                                 if let Some(next_cell_id) = background_cell_id(&output) {
                                     background.latest_output = output;
-                                    background_tool_calls
-                                        .insert(background_cell_key(&next_cell_id), background);
+                                    background_tool_calls.reinsert(
+                                        background_cell_key(&next_cell_id),
+                                        background_order,
+                                        background,
+                                    );
                                 } else {
                                     let final_output = if output.trim().is_empty() {
                                         background.latest_output
@@ -1158,6 +1165,7 @@ fn load_codex_app_from_path_with_mode<'a>(
                                     resolve_codex_tool_outputs(
                                         session_id,
                                         background.calls,
+                                        background_order,
                                         output_value,
                                         &final_output,
                                         &mut collector.current,
@@ -1169,8 +1177,9 @@ fn load_codex_app_from_path_with_mode<'a>(
                             }
                         }
                         if let Some(cell_id) = background_cell_id(&output) {
-                            background_tool_calls.insert(
+                            background_tool_calls.reinsert(
                                 background_cell_key(&cell_id),
+                                file_order,
                                 PendingBackgroundToolCall {
                                     calls,
                                     latest_output: output,
@@ -1181,6 +1190,7 @@ fn load_codex_app_from_path_with_mode<'a>(
                         resolve_codex_tool_outputs(
                             session_id,
                             calls,
+                            file_order,
                             output_value,
                             &output,
                             &mut collector.current,
@@ -1230,7 +1240,7 @@ fn load_codex_app_from_path_with_mode<'a>(
         }
     }
 
-    for calls in pending_tool_calls.into_values() {
+    for calls in pending_tool_calls.drain_in_file_order() {
         for call in calls {
             collector
                 .current
@@ -1238,7 +1248,7 @@ fn load_codex_app_from_path_with_mode<'a>(
             sequence += 1;
         }
     }
-    for background in background_tool_calls.into_values() {
+    for background in background_tool_calls.drain_in_file_order() {
         if background
             .calls
             .iter()
@@ -1260,7 +1270,7 @@ fn load_codex_app_from_path_with_mode<'a>(
 
 fn attach_subagent_activity_to_pending_call(
     payload: &Value,
-    pending_tool_calls: &mut HashMap<String, Vec<ImportedToolCall>>,
+    pending_tool_calls: &mut imported_history::PendingCallMap<Vec<ImportedToolCall>>,
 ) {
     if payload.get("kind").and_then(Value::as_str) != Some("started") {
         return;
@@ -1311,14 +1321,16 @@ fn lifecycle_turn_id<'a>(payload: &'a Value, active_turn_id: Option<&'a str>) ->
         .or(active_turn_id)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn resolve_codex_tool_outputs(
     transcript_session_id: &str,
     calls: Vec<ImportedToolCall>,
+    file_order: u64,
     output_value: Option<&Value>,
     fallback_output: &str,
     chunks: &mut Vec<ActivityChunk>,
     sequence: &mut usize,
-    background_tool_calls: &mut HashMap<String, PendingBackgroundToolCall>,
+    background_tool_calls: &mut imported_history::PendingCallMap<PendingBackgroundToolCall>,
 ) {
     let mut results = codex_exec_results(output_value);
     if results.len() == calls.len() {
@@ -1326,6 +1338,7 @@ fn resolve_codex_tool_outputs(
             resolve_codex_call_group(
                 transcript_session_id,
                 vec![call],
+                file_order,
                 result,
                 chunks,
                 sequence,
@@ -1338,6 +1351,7 @@ fn resolve_codex_tool_outputs(
         resolve_codex_call_group(
             transcript_session_id,
             calls,
+            file_order,
             results.remove(0),
             chunks,
             sequence,
@@ -1359,10 +1373,11 @@ fn resolve_codex_tool_outputs(
 fn resolve_codex_call_group(
     transcript_session_id: &str,
     calls: Vec<ImportedToolCall>,
+    file_order: u64,
     result: CodexExecResult,
     chunks: &mut Vec<ActivityChunk>,
     sequence: &mut usize,
-    background_tool_calls: &mut HashMap<String, PendingBackgroundToolCall>,
+    background_tool_calls: &mut imported_history::PendingCallMap<PendingBackgroundToolCall>,
 ) {
     if calls.len() == 1 && calls[0].canonical_name == imported_history::FUNCTION_AWAIT_OUTPUT {
         resolve_write_stdin_call(
@@ -1378,8 +1393,9 @@ fn resolve_codex_call_group(
 
     if result.exit_code.is_none() {
         if let Some(session_id) = result.session_id.as_deref() {
-            background_tool_calls.insert(
+            background_tool_calls.reinsert(
                 background_session_key(session_id),
+                file_order,
                 PendingBackgroundToolCall {
                     calls,
                     latest_output: result.output,
@@ -1405,15 +1421,15 @@ fn resolve_write_stdin_call(
     result: CodexExecResult,
     chunks: &mut Vec<ActivityChunk>,
     sequence: &mut usize,
-    background_tool_calls: &mut HashMap<String, PendingBackgroundToolCall>,
+    background_tool_calls: &mut imported_history::PendingCallMap<PendingBackgroundToolCall>,
 ) {
     let source_session_id = continuation
         .args
         .get("session_id")
         .and_then(Value::as_str)
         .unwrap_or_default();
-    let Some(mut background) =
-        background_tool_calls.remove(&background_session_key(source_session_id))
+    let Some((background_order, mut background)) =
+        background_tool_calls.take(&background_session_key(source_session_id))
     else {
         emit_codex_call_group(
             transcript_session_id,
@@ -1431,7 +1447,11 @@ fn resolve_write_stdin_call(
 
     if result.exit_code.is_none() {
         if let Some(next_session_id) = result.session_id.as_deref() {
-            background_tool_calls.insert(background_session_key(next_session_id), background);
+            background_tool_calls.reinsert(
+                background_session_key(next_session_id),
+                background_order,
+                background,
+            );
             return;
         }
     }

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
@@ -2280,3 +2280,64 @@ fn resumes_codex_meta_parse_from_watermark() {
 
     std::fs::remove_dir_all(&temp_dir).expect("remove temp dir");
 }
+
+#[test]
+fn unresolved_tool_calls_flush_in_file_order_across_reparses() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-codex-pending-order-test-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+    let path = temp_dir.join("rollout-pending-order.jsonl");
+
+    let file_order_call_ids = [
+        "call_zulu",
+        "call_echo",
+        "call_romeo",
+        "call_alpha",
+        "call_x1",
+        "call_mike",
+        "call_kilo",
+        "call_bravo",
+        "call_yankee",
+        "call_delta",
+    ];
+    let mut content = String::from(
+        r#"{"timestamp":"2026-07-30T10:00:00.000Z","type":"event_msg","payload":{"type":"user_message","message":"run everything"}}
+{"timestamp":"2026-07-30T10:00:01.000Z","type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{\"command\":\"echo resolved\"}","call_id":"call_resolved"}}
+{"timestamp":"2026-07-30T10:00:02.000Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_resolved","output":"resolved"}}
+"#,
+    );
+    for (index, call_id) in file_order_call_ids.iter().enumerate() {
+        content.push_str(&format!(
+            "{{\"timestamp\":\"2026-07-30T10:00:{:02}.000Z\",\"type\":\"response_item\",\"payload\":{{\"type\":\"function_call\",\"name\":\"shell\",\"arguments\":\"{{\\\"command\\\":\\\"sleep {index}\\\"}}\",\"call_id\":\"{call_id}\"}}}}\n",
+            10 + index
+        ));
+    }
+    std::fs::write(&path, content).expect("write fixture");
+
+    let flushed_call_ids = |chunks: &[core_types::activity::ActivityChunk]| -> Vec<String> {
+        chunks
+            .iter()
+            .filter(|chunk| chunk.action_type == imported_history::ACTION_TYPE_TOOL_CALL)
+            .filter_map(|chunk| chunk.result.get("call_id")?.as_str().map(str::to_string))
+            .filter(|call_id| call_id != "call_resolved")
+            .collect()
+    };
+
+    let first = load_codex_app_from_path("codexapp-pending-order", &path).expect("parse");
+    assert_eq!(flushed_call_ids(&first), file_order_call_ids);
+
+    let second = load_codex_app_from_path("codexapp-pending-order", &path).expect("reparse");
+    let first_ids = first
+        .iter()
+        .map(|chunk| &chunk.chunk_id)
+        .collect::<Vec<_>>();
+    let second_ids = second
+        .iter()
+        .map(|chunk| &chunk.chunk_id)
+        .collect::<Vec<_>>();
+    assert_eq!(first_ids, second_ids);
+
+    std::fs::remove_dir_all(&temp_dir).expect("remove temp dir");
+}

--- a/src-tauri/crates/orgtrack-core/src/sources/cursor_cli/history/mod.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/cursor_cli/history/mod.rs
@@ -38,7 +38,7 @@
 //! input/output token split (field 5 only exposes context usage, surfaced
 //! here as the session's token total).
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 

--- a/src-tauri/crates/orgtrack-core/src/sources/cursor_cli/history/transcript.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/cursor_cli/history/transcript.rs
@@ -20,7 +20,8 @@ pub(super) fn load_history_from_store_conn(
 
     let mut chunks = Vec::new();
     let mut sequence = 0usize;
-    let mut pending_tool_calls: HashMap<String, ImportedToolCall> = HashMap::new();
+    let mut pending_tool_calls: imported_history::PendingCallMap<ImportedToolCall> =
+        imported_history::PendingCallMap::new();
     let mut last_user_text: Option<String> = None;
 
     for blob_id in &manifest.message_blob_ids {
@@ -116,7 +117,7 @@ pub(super) fn load_history_from_store_conn(
     }
 
     // In-flight calls at the tail of an interrupted session: still show them.
-    for call in pending_tool_calls.into_values() {
+    for call in pending_tool_calls.drain_in_file_order() {
         chunks.push(imported_history::tool_call_chunk(
             session_id,
             CURSOR_CLI_PROVIDER_SLUG,

--- a/src-tauri/crates/orgtrack-core/src/sources/cursor_ide/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/cursor_ide/history.rs
@@ -249,16 +249,24 @@ fn cached_rows_to_session_page(
 /// (`cursoride-{uuid}`); the prefix is stripped here before reading from
 /// Cursor's DB.
 ///
-/// Returns `Ok(vec![])` if Cursor's DB is missing or the composer is unknown
-/// — read-only history is best-effort by definition; we don't synthesize
-/// errors for missing data. Returns `Err` only on IO/SQL failures we cannot
-/// recover from.
+/// An unreadable source is an `Err`, never an empty transcript: this is the
+/// full-transcript loader behind cloud push and fork, and a locked/replaced
+/// `state.vscdb` or a composer row missing mid-rebuild reported as
+/// `Ok(vec![])` reads upstream as "this session has 0 events" — the exact
+/// hollow read that erased a session's cloud copy (301 → 0) before the push
+/// plane's hollow guard existed. Preview/listing paths keep their own
+/// best-effort behavior.
 pub fn load_history_for_session(session_id: &str) -> Result<Vec<ActivityChunk>, String> {
     let composer_id = strip_session_prefix(session_id);
 
     let cursor_conn = match open_cursor_db() {
         Some(conn) => conn,
-        None => return Ok(vec![]),
+        None => {
+            return Err(format!(
+                "Cursor state.vscdb is not readable right now; \
+                 refusing to report session {session_id} as empty"
+            ))
+        }
     };
 
     let composer = load_composer_for_order(&cursor_conn, composer_id)?;
@@ -269,7 +277,11 @@ pub fn load_history_for_session(session_id: &str) -> Result<Vec<ActivityChunk>, 
         &composer.full_conversation_headers_only,
     )?;
     if order.is_empty() {
-        return Ok(vec![]);
+        return Err(format!(
+            "Cursor composer {composer_id} has no readable bubbles \
+             (missing or mid-rebuild); refusing to report session \
+             {session_id} as empty"
+        ));
     }
 
     let bubbles = load_bubbles_by_id(&cursor_conn, composer_id, &order)?;

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/mod.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/mod.rs
@@ -282,6 +282,68 @@ pub struct ImportedToolCall {
     pub created_at: String,
 }
 
+/// Parse-state map for tool calls awaiting their output row. Drains in
+/// insertion (file-appearance) order: `HashMap` iteration order is randomized
+/// per process, and a nondeterministic emit order changes positional chunk
+/// ids across re-ingests of an unchanged transcript, which the cloud sync
+/// plane sees as an endless chain mismatch and answers with epoch rewrites.
+pub struct PendingCallMap<T> {
+    entries: HashMap<String, (u64, T)>,
+    next_order: u64,
+}
+
+impl<T> Default for PendingCallMap<T> {
+    fn default() -> Self {
+        Self {
+            entries: HashMap::new(),
+            next_order: 0,
+        }
+    }
+}
+
+impl<T> PendingCallMap<T> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn insert(&mut self, key: String, value: T) {
+        let order = self.next_order;
+        self.next_order += 1;
+        self.entries.insert(key, (order, value));
+    }
+
+    /// Insert under a caller-supplied order slot, so an entry that moves
+    /// between keys (or maps) keeps its original file position.
+    pub fn reinsert(&mut self, key: String, order: u64, value: T) {
+        self.next_order = self.next_order.max(order.saturating_add(1));
+        self.entries.insert(key, (order, value));
+    }
+
+    pub fn remove(&mut self, key: &str) -> Option<T> {
+        self.entries.remove(key).map(|(_, value)| value)
+    }
+
+    pub fn take(&mut self, key: &str) -> Option<(u64, T)> {
+        self.entries.remove(key)
+    }
+
+    pub fn get_mut(&mut self, key: &str) -> Option<&mut T> {
+        self.entries.get_mut(key).map(|(_, value)| value)
+    }
+
+    pub fn drain_in_file_order(self) -> impl Iterator<Item = T> {
+        let mut entries = self.entries.into_iter().collect::<Vec<_>>();
+        entries.sort_unstable_by(
+            |(left_key, (left_order, _)), (right_key, (right_order, _))| {
+                left_order
+                    .cmp(right_order)
+                    .then_with(|| left_key.cmp(right_key))
+            },
+        );
+        entries.into_iter().map(|(_, (_, value))| value)
+    }
+}
+
 pub fn effective_limit(limit: usize) -> usize {
     if limit == 0 {
         DEFAULT_LIST_LIMIT

--- a/src-tauri/crates/orgtrack-core/src/sources/workbuddy/mod.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/workbuddy/mod.rs
@@ -5,7 +5,7 @@
 //! `ActivityChunk` shape for read-only replay through the existing
 //! external-history pipeline.
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashSet};
 use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};

--- a/src-tauri/crates/orgtrack-core/src/sources/workbuddy/transcript.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/workbuddy/transcript.rs
@@ -13,7 +13,8 @@ pub(super) fn load_workbuddy_history_from_path(
     let reader = BufReader::new(file);
 
     let mut chunks = Vec::new();
-    let mut pending_tool_calls: HashMap<String, ImportedToolCall> = HashMap::new();
+    let mut pending_tool_calls: imported_history::PendingCallMap<ImportedToolCall> =
+        imported_history::PendingCallMap::new();
     let mut sequence = 0usize;
 
     for line in reader.lines() {
@@ -152,7 +153,7 @@ pub(super) fn load_workbuddy_history_from_path(
         }
     }
 
-    for call in pending_tool_calls.into_values() {
+    for call in pending_tool_calls.drain_in_file_order() {
         chunks.push(imported_history::tool_call_chunk(
             session_id,
             WORKBUDDY_PROVIDER_SLUG,

--- a/src/components/ProgressBar/ProgressBar.scss
+++ b/src/components/ProgressBar/ProgressBar.scss
@@ -1,0 +1,20 @@
+.progress-bar--indeterminate > div {
+  width: 36% !important;
+  animation: progress-bar-indeterminate-slide 1.2s ease-in-out infinite;
+}
+
+@keyframes progress-bar-indeterminate-slide {
+  0% {
+    transform: translateX(-110%);
+  }
+
+  100% {
+    transform: translateX(280%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progress-bar--indeterminate > div {
+    animation: none;
+  }
+}

--- a/src/components/ProgressBar/index.tsx
+++ b/src/components/ProgressBar/index.tsx
@@ -6,9 +6,20 @@
  */
 import React, { memo } from "react";
 
+import "./ProgressBar.scss";
+
 export interface ProgressBarProps {
   /** Progress percentage (0-100) */
   percent: number;
+  /**
+   * Unknown total: render a sliding segment instead of a fill and expose no
+   * aria-valuenow. `percent` is ignored while set.
+   */
+  indeterminate?: boolean;
+  /** Accessible name for the progressbar role. */
+  ariaLabel?: string;
+  /** Human-readable progress detail (aria-valuetext). */
+  ariaValuetext?: string;
   /** Background color class for the filled portion (default: "bg-primary-6") */
   color?: string;
   /** Height class or pixel value (default: "h-1.5") */
@@ -26,6 +37,9 @@ export interface ProgressBarProps {
 export const ProgressBar: React.FC<ProgressBarProps> = memo(
   ({
     percent,
+    indeterminate = false,
+    ariaLabel,
+    ariaValuetext,
     color = "bg-primary-6",
     height = "h-1.5",
     width = "flex",
@@ -43,14 +57,22 @@ export const ProgressBar: React.FC<ProgressBarProps> = memo(
 
     return (
       <div
-        className={`overflow-hidden rounded-full ${trackColor} ${widthClass} ${heightClass} ${className}`}
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={indeterminate ? undefined : clampedPercent}
+        aria-label={ariaLabel}
+        aria-valuetext={ariaValuetext}
+        className={`overflow-hidden rounded-full ${trackColor} ${widthClass} ${heightClass} ${
+          indeterminate ? "progress-bar--indeterminate" : ""
+        } ${className}`}
         style={heightStyle}
       >
         <div
           className={`h-full rounded-full ${color} transition-all duration-300 ${
             animated ? "animate-pulse" : ""
           }`}
-          style={{ width: `${clampedPercent}%` }}
+          style={indeterminate ? undefined : { width: `${clampedPercent}%` }}
         />
       </div>
     );

--- a/src/engines/SessionCore/turns/importedHistoryTurnLoader.ts
+++ b/src/engines/SessionCore/turns/importedHistoryTurnLoader.ts
@@ -12,6 +12,7 @@ import type { SessionTurnLoader } from "./types";
 interface PendingImportedTurnBatch {
   turnIds: Set<string>;
   waiters: Array<{
+    turnId: string;
     resolve: (loaded: boolean) => void;
     reject: (error: unknown) => void;
   }>;
@@ -36,18 +37,26 @@ async function flushPendingBatch(sessionId: string): Promise<void> {
         turnIds,
       });
       const chunks = windows.flatMap((window) => window.chunks);
-      // Batch-level resolution: per-turn attribution is not available on
-      // this wire, but provider files are local so an empty window means
-      // the whole batch found nothing.
-      let loaded = false;
+      let merged = false;
       if (chunks.length > 0) {
         const events = await processChunksRust(chunks, sessionId);
         if (events.length > 0) {
           await eventStoreProxy.mergeRoundWindowEvents(events, sessionId);
-          loaded = true;
+          merged = true;
         }
       }
-      for (const waiter of waiters) waiter.resolve(loaded);
+      // Per-turn resolution: the wire names each window's turn, so a turn
+      // whose window came back empty must NOT be marked loaded by its
+      // batch-mates — that would disarm exactly the retry affordance the
+      // loader contract exists to preserve.
+      const loadedTurnIds = new Set(
+        windows
+          .filter((window) => window.chunks.length > 0)
+          .map((window) => window.turnId)
+      );
+      for (const waiter of waiters) {
+        waiter.resolve(merged && loadedTurnIds.has(waiter.turnId));
+      }
     } catch (error) {
       for (const waiter of waiters) waiter.reject(error);
     }
@@ -64,13 +73,13 @@ function enqueueImportedTurnLoad(
     const existing = pendingBatches.get(sessionId);
     if (existing) {
       existing.turnIds.add(turnId);
-      existing.waiters.push({ resolve, reject });
+      existing.waiters.push({ turnId, resolve, reject });
       return;
     }
 
     pendingBatches.set(sessionId, {
       turnIds: new Set([turnId]),
-      waiters: [{ resolve, reject }],
+      waiters: [{ turnId, resolve, reject }],
       flushing: false,
     });
     queueMicrotask(() => {

--- a/src/features/Org2Cloud/CloudSessionDownloadProgressCard.tsx
+++ b/src/features/Org2Cloud/CloudSessionDownloadProgressCard.tsx
@@ -22,6 +22,7 @@ import type React from "react";
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
+import ProgressBar from "@src/components/ProgressBar";
 
 import { cancelCloudSessionDownload } from "./cloudSessionDownloadAbortRegistry";
 import {
@@ -46,39 +47,28 @@ interface CloudSessionDownloadProgressCardProps {
   variant?: "card" | "centered";
 }
 
-const ProgressBar: React.FC<{
+const DownloadBar: React.FC<{
   percent: number | null;
   paused?: boolean;
   className: string;
 }> = ({ percent, paused = false, className }) => (
-  <div
-    role="progressbar"
-    aria-valuemin={0}
-    aria-valuemax={100}
-    aria-valuenow={percent ?? undefined}
-    className={`h-1.5 overflow-hidden rounded-full bg-fill-3 ${className}`}
-  >
-    <div
-      className={
-        percent === null
-          ? "h-full w-1/3 animate-pulse rounded-full bg-primary-6"
-          : paused
-            ? "h-full rounded-full bg-fill-4"
-            : "h-full rounded-full bg-primary-6 transition-[width] duration-300"
-      }
-      style={percent === null ? undefined : { width: `${percent}%` }}
-    />
-  </div>
+  <ProgressBar
+    percent={percent ?? 0}
+    indeterminate={percent === null}
+    color={paused ? "bg-fill-4" : "bg-primary-6"}
+    width={className}
+  />
 );
 
 /** Start/Resume both funnel through the sidebar-consumed request slot. */
 function useRequestDownloadStart(): (params: {
   rowId: string;
   orgId: string;
+  kind?: "replay" | "fork";
 }) => void {
   const setStartRequest = useSetAtom(cloudDownloadStartRequestAtom);
-  return ({ rowId, orgId }) =>
-    setStartRequest({ requestId: Date.now(), rowId, orgId });
+  return ({ rowId, orgId, kind = "replay" }) =>
+    setStartRequest({ requestId: Date.now(), rowId, orgId, kind });
 }
 
 const PendingPlay: React.FC<{
@@ -97,10 +87,16 @@ const PendingPlay: React.FC<{
       size={variant === "centered" ? "small" : "mini"}
       data-testid="cloud-session-download-start"
       onClick={() =>
-        requestStart({ rowId: pending.rowId, orgId: pending.orgId })
+        requestStart({
+          rowId: pending.rowId,
+          orgId: pending.orgId,
+          kind: pending.kind,
+        })
       }
     >
-      {t("cloud.download.start")}
+      {pending.kind === "fork"
+        ? t("cloud.orgPanel.fork")
+        : t("cloud.download.start")}
     </Button>
   );
   if (variant === "centered") {
@@ -140,7 +136,7 @@ const CenteredProgress: React.FC<{
       className="flex h-full flex-col items-center justify-center gap-3 p-6"
       data-testid="cloud-session-download-progress"
     >
-      <ProgressBar
+      <DownloadBar
         percent={percent}
         paused={paused}
         className="w-64 max-w-full"
@@ -256,7 +252,7 @@ const CardProgress: React.FC<{
         </span>
       </div>
       <div className="mt-2">
-        <ProgressBar percent={percent} paused={paused} className="w-full" />
+        <DownloadBar percent={percent} paused={paused} className="w-full" />
       </div>
       <div className="mt-1.5 flex items-center justify-between gap-2 text-[11px] text-text-3">
         <span className="tabular-nums">

--- a/src/features/Org2Cloud/cloudSessionDownloadControlAtoms.test.ts
+++ b/src/features/Org2Cloud/cloudSessionDownloadControlAtoms.test.ts
@@ -48,6 +48,7 @@ describe("cloud download control atoms", () => {
         orgId: "org-1",
         pendingEvents: 4450,
         etaMs: 17_000,
+        kind: "replay",
       },
     });
     expect(
@@ -65,11 +66,13 @@ describe("cloud download control atoms", () => {
       requestId: 1,
       rowId: "row-1",
       orgId: "org-1",
+      kind: "replay",
     });
     store.set(cloudDownloadStartRequestAtom, {
       requestId: 2,
       rowId: "row-2",
       orgId: "org-1",
+      kind: "fork",
     });
     expect(store.get(cloudDownloadStartRequestAtom)?.rowId).toBe("row-2");
   });

--- a/src/features/Org2Cloud/cloudSessionDownloadControlAtoms.ts
+++ b/src/features/Org2Cloud/cloudSessionDownloadControlAtoms.ts
@@ -69,6 +69,12 @@ export interface CloudPendingPlay {
   /** Events the download would actually fetch (listing count minus covered). */
   pendingEvents: number;
   etaMs: number;
+  /**
+   * What Start resumes: a read-only replay or a Take Over pre-import. Both
+   * ride the same card/progress surface; the start-request consumer routes
+   * by this.
+   */
+  kind: "replay" | "fork";
 }
 
 /** Keyed by the LOCAL imported-session id (the Chat Pane tab's key). */
@@ -103,6 +109,7 @@ export interface CloudDownloadStartRequest {
   requestId: number;
   rowId: string;
   orgId: string;
+  kind: "replay" | "fork";
 }
 
 /** Single-slot: a newer request replaces an unconsumed older one. */

--- a/src/features/Org2Cloud/cloudSessionDownloadProgressAtom.ts
+++ b/src/features/Org2Cloud/cloudSessionDownloadProgressAtom.ts
@@ -12,6 +12,8 @@
  */
 import { atom, type createStore } from "jotai";
 
+import { formatDurationCompact } from "@src/util/time/formatDuration";
+
 export interface CloudSessionDownloadProgress {
   /** Remote row id (`RemoteTeammateSessionMetadata.id`) this download serves. */
   rowId: string;
@@ -208,14 +210,5 @@ export function createThrottledProgressReporter(
 
 /** Compact locale-neutral duration: "8s", "1m20s", "2h05m". */
 export function formatCloudDownloadEta(etaMs: number): string {
-  const totalSeconds = Math.max(1, Math.round(etaMs / 1000));
-  if (totalSeconds < 60) return `${totalSeconds}s`;
-  const totalMinutes = Math.floor(totalSeconds / 60);
-  const seconds = totalSeconds % 60;
-  if (totalMinutes < 60) {
-    return seconds > 0 ? `${totalMinutes}m${seconds}s` : `${totalMinutes}m`;
-  }
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-  return `${hours}h${String(minutes).padStart(2, "0")}m`;
+  return formatDurationCompact(etaMs);
 }

--- a/src/features/Org2Cloud/org2CloudCapabilities.ts
+++ b/src/features/Org2Cloud/org2CloudCapabilities.ts
@@ -8,7 +8,10 @@
 import { z } from "zod/v4";
 
 import { getCloudEndpoint } from "./config";
-import { getCloudCapabilitiesRaw } from "./org2CloudClient";
+import {
+  type CloudRpcEndpoint,
+  getCloudCapabilitiesRaw,
+} from "./org2CloudClient";
 import { runCloudRequestWithTimeout } from "./org2CloudFetchRetry";
 
 const CLOUD_CAPABILITIES_TIMEOUT_MS = 15_000;
@@ -73,11 +76,12 @@ const inFlightByEndpoint = new Map<
 
 async function probeCloudCapabilities(
   accessToken: string,
-  endpointKey: string
+  endpointKey: string,
+  endpoint?: CloudRpcEndpoint
 ): Promise<CloudCapabilitiesProbeResult> {
   try {
     const payload = await runCloudRequestWithTimeout(
-      (signal) => getCloudCapabilitiesRaw(accessToken, signal),
+      (signal) => getCloudCapabilitiesRaw(accessToken, signal, endpoint),
       CLOUD_CAPABILITIES_TIMEOUT_MS
     );
     const parsed = CloudCapabilitiesWireSchema.safeParse(payload);
@@ -115,14 +119,18 @@ async function probeCloudCapabilities(
  * this time" — see the member-runtime push scheduler's capability blackout.
  */
 export async function getCloudCapabilitiesConfirmed(
-  accessToken: string
+  accessToken: string,
+  endpoint?: CloudRpcEndpoint
 ): Promise<CloudCapabilitiesProbeResult> {
-  const endpointKey = getCloudEndpoint().supabaseUrl;
+  // Per-endpoint routing: home-endpoint orgs answer for their OWN backend.
+  // Probing the default endpoint for a per-org feature gate reads the wrong
+  // server's capability set (fails toward "off", but wrongly).
+  const endpointKey = (endpoint ?? getCloudEndpoint()).supabaseUrl;
   const cached = capabilitiesByEndpoint.get(endpointKey);
   if (cached) return { capabilities: cached, confirmed: true };
   const inFlight = inFlightByEndpoint.get(endpointKey);
   if (inFlight) return inFlight;
-  const probe = probeCloudCapabilities(accessToken, endpointKey);
+  const probe = probeCloudCapabilities(accessToken, endpointKey, endpoint);
   inFlightByEndpoint.set(endpointKey, probe);
   try {
     return await probe;
@@ -132,9 +140,11 @@ export async function getCloudCapabilitiesConfirmed(
 }
 
 export async function getCloudCapabilities(
-  accessToken: string
+  accessToken: string,
+  endpoint?: CloudRpcEndpoint
 ): Promise<CloudCapabilities> {
-  return (await getCloudCapabilitiesConfirmed(accessToken)).capabilities;
+  return (await getCloudCapabilitiesConfirmed(accessToken, endpoint))
+    .capabilities;
 }
 
 export const __CAPABILITIES_INTERNALS = {

--- a/src/features/Org2Cloud/org2CloudClient.ts
+++ b/src/features/Org2Cloud/org2CloudClient.ts
@@ -70,7 +70,7 @@ let inFlightRefresh:
   | { key: string; promise: Promise<RefreshAttemptResult> }
   | undefined;
 
-type CloudRpcEndpoint = Pick<
+export type CloudRpcEndpoint = Pick<
   ReturnType<typeof getCloudEndpoint>,
   "supabaseUrl" | "anonKey"
 >;
@@ -136,13 +136,14 @@ export async function schemaVersion(): Promise<number | null> {
  */
 export async function getCloudCapabilitiesRaw(
   accessToken: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  endpoint?: CloudRpcEndpoint
 ): Promise<unknown | null> {
   return callRpc(
     "get_cloud_capabilities",
     accessToken,
     undefined,
-    getCloudEndpoint(),
+    endpoint ?? getCloudEndpoint(),
     signal
   );
 }

--- a/src/features/Org2Cloud/org2CloudOfflineSync.ts
+++ b/src/features/Org2Cloud/org2CloudOfflineSync.ts
@@ -63,6 +63,7 @@ import { buildCloudSessionFetchClient } from "./org2CloudBackendAdapter";
 import { getCloudCapabilities } from "./org2CloudCapabilities";
 import { ensureFreshSession } from "./org2CloudClient";
 import { isFetchTransportError } from "./org2CloudFetchRetry";
+import { endpointForOrg } from "./org2CloudOrgEndpointRouter";
 import {
   org2CloudOrgsAtom,
   sidebarActiveCloudOrgIdAtom,
@@ -235,7 +236,12 @@ class Org2CloudOfflineSyncScheduler {
       remoteSessionsEntryForIdentity(entry, org2CloudAuthIdentityKey(auth))
         ?.rows ?? [];
     if (rows.length === 0) return;
-    if (!(await getCloudCapabilities(auth.accessToken)).offlineSync) return;
+    if (
+      !(await getCloudCapabilities(auth.accessToken, endpointForOrg(orgId)))
+        .offlineSync
+    ) {
+      return;
+    }
     if (generation !== this.generation) return;
 
     const candidates = pickOfflineSyncCandidates({

--- a/src/features/Org2Cloud/org2CloudOrgEndpointRouter.ts
+++ b/src/features/Org2Cloud/org2CloudOrgEndpointRouter.ts
@@ -44,6 +44,18 @@ export function endpointForOrg(orgId: string): CloudEndpoint {
   return shardKey ? { ...endpoint, anonKey: shardKey } : endpoint;
 }
 
+/**
+ * Endpoint for a connection that is already pinned to an https origin (the
+ * realtime socket follows `auth.supabaseUrl`, not an org id). Falls back to
+ * the official endpoint when the origin is not a routed shard.
+ */
+export function endpointForOrigin(supabaseUrl: string): CloudEndpoint {
+  const official = getCloudEndpoint();
+  const anonKey = anonKeyByOrigin.get(supabaseUrl);
+  if (supabaseUrl === official.supabaseUrl) return official;
+  return { ...official, supabaseUrl, anonKey: anonKey ?? official.anonKey };
+}
+
 export function resetOrgEndpointDirectory(): void {
   orgEndpoints.clear();
   anonKeyByOrigin.clear();

--- a/src/features/Org2Cloud/org2CloudSessionSync.shrink.test.ts
+++ b/src/features/Org2Cloud/org2CloudSessionSync.shrink.test.ts
@@ -1,0 +1,99 @@
+import { createStore } from "jotai";
+import { describe, expect, it, vi } from "vitest";
+
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+import { COLLAB_SESSION_ACCESS_MODE } from "@src/store/collaboration/types";
+
+import type { CloudPushAccess } from "./org2CloudAccessSettings";
+import { Org2CloudSessionSync } from "./org2CloudSessionSync";
+import type { Org2CloudSyncClientDeps } from "./org2CloudSessionSync.types";
+import { AUTH, SCOPE_KEY, SESSION } from "./org2CloudSyncEngine.testUtils";
+
+const ORG_ID = "corg-1";
+
+const ACCESS: CloudPushAccess = {
+  accessMode: COLLAB_SESSION_ACCESS_MODE.FULL_REPLAY,
+  visibility: "org",
+};
+
+function makeClient() {
+  return {
+    upsertSessionMetadata: vi.fn(async () => {}),
+    appendSessionEvents: vi.fn(async () => {}),
+    rewriteSessionEvents: vi.fn(async () => {}),
+    getSessionEvents: vi.fn(async () => ({ events: [], epoch: 0 })),
+    getOrgRepoScopes: vi.fn(async () => ({ repoScopes: [] })),
+    listOrgSessions: vi.fn(async () => ({ sessions: [] })),
+    deleteSession: vi.fn(async () => {}),
+  } as unknown as Org2CloudSyncClientDeps & {
+    rewriteSessionEvents: ReturnType<typeof vi.fn>;
+    appendSessionEvents: ReturnType<typeof vi.fn>;
+  };
+}
+
+function pushEvent(index: number): SessionEvent {
+  return {
+    id: `event-${index}`,
+    chunk_id: `event-${index}`,
+    sessionId: SESSION.session_id,
+    createdAt: new Date(1700000000000 + index * 1000).toISOString(),
+    functionName: "user_message",
+    uiCanonical: "user_message",
+    actionType: "raw",
+    args: {},
+    result: { type: "user", message: { content: `m${index}`, role: "user" } },
+    source: "user",
+    displayText: `m${index}`,
+    displayStatus: "completed",
+    displayVariant: "message",
+    activityStatus: "agent",
+  } as unknown as SessionEvent;
+}
+
+async function pushPass(
+  sync: Org2CloudSessionSync,
+  events: SessionEvent[]
+): Promise<void> {
+  sync.beginPass();
+  sync.noteSessionEventActivity(SESSION.session_id);
+  vi.spyOn(sync, "loadPushEvents").mockResolvedValueOnce(events);
+  await sync.pushSession(AUTH, ORG_ID, SESSION, SCOPE_KEY, ACCESS);
+}
+
+describe("Org2CloudSessionSync shrink guard", () => {
+  it("never rewrites the cloud copy from a hollow local read, even across passes", async () => {
+    const client = makeClient();
+    const store = createStore();
+    const sync = new Org2CloudSessionSync(() => store, client);
+
+    await pushPass(sync, [pushEvent(1), pushEvent(2), pushEvent(3)]);
+    expect(client.rewriteSessionEvents).toHaveBeenCalledTimes(1);
+
+    // The old consecutive-pass confirmation treated the second identical
+    // hollow read as intent and erased the cloud copy. An empty store reads
+    // zero forever, so no number of passes may confirm it.
+    await pushPass(sync, []);
+    await pushPass(sync, []);
+    await pushPass(sync, []);
+
+    expect(client.rewriteSessionEvents).toHaveBeenCalledTimes(1);
+    expect(client.appendSessionEvents).not.toHaveBeenCalled();
+  });
+
+  it("still re-anchors a NONZERO shrink after consecutive-pass confirmation", async () => {
+    const client = makeClient();
+    const store = createStore();
+    const sync = new Org2CloudSessionSync(() => store, client);
+
+    await pushPass(sync, [pushEvent(1), pushEvent(2), pushEvent(3)]);
+    expect(client.rewriteSessionEvents).toHaveBeenCalledTimes(1);
+
+    // First shrunk read is a candidate only.
+    await pushPass(sync, [pushEvent(1), pushEvent(2)]);
+    expect(client.rewriteSessionEvents).toHaveBeenCalledTimes(1);
+
+    // Second consecutive identical read confirms the user-truncated history.
+    await pushPass(sync, [pushEvent(1), pushEvent(2)]);
+    expect(client.rewriteSessionEvents).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/features/Org2Cloud/org2CloudSessionSync.ts
+++ b/src/features/Org2Cloud/org2CloudSessionSync.ts
@@ -79,7 +79,7 @@ const TURN_INDEX_PROMPT_MAX_CHARS = 240;
 const TURN_INDEX_MAX_ROUNDS = 2_000;
 
 /** Mirror of Rust normalize_turn_user_preview (turn_window.rs) + truncation. */
-function normalizeTurnPromptPreview(preview: string): string {
+export function normalizeTurnPromptPreview(preview: string): string {
   const trimmed = preview.trim();
   const stripped = trimmed.startsWith("user_message ")
     ? trimmed.slice("user_message ".length)
@@ -454,6 +454,24 @@ export class Org2CloudSessionSync extends Org2CloudSessionSyncState {
     const shrinkKey = `${orgId}:${sessionId}`;
     let confirmedShrink = false;
     if (cursor && events.length < cursor.pushedCount) {
+      if (events.length === 0) {
+        // A hollow local read can NEVER authorize erasing the cloud copy.
+        // An empty store (wiped cache, missing provider DB, rebuilding
+        // import) reads zero on EVERY pass, so consecutive-pass
+        // confirmation is no evidence of intent — and the cloud row may be
+        // the only surviving copy (cursoride-93121e8a lost its 301 cloud
+        // events to exactly this rewrite on 2026-07-31). Recovery for a
+        // hollow local store is seed/import, not an empty rewrite.
+        this.sessionShrinkCandidates.delete(shrinkKey);
+        log.rateLimited(
+          `hollow-push-${shrinkKey}`,
+          60_000,
+          `persisted read for ${sessionId} returned 0 events but the ` +
+            `cloud cursor covers ${cursor.pushedCount}; refusing hollow ` +
+            `epoch rewrite`
+        );
+        return;
+      }
       if (this.sessionShrinkCandidates.get(shrinkKey) === events.length) {
         this.sessionShrinkCandidates.delete(shrinkKey);
         confirmedShrink = true;
@@ -559,7 +577,12 @@ export class Org2CloudSessionSync extends Org2CloudSessionSyncState {
           );
           broadcastOrgControlChangedToPeers(orgId, "sessions");
           this.markEventPlaneClean(orgId, session, stampAtRead);
-          void this.publishTurnIndexBestEffort(auth, orgId, session);
+          void this.publishTurnIndexBestEffort(
+            auth,
+            orgId,
+            session,
+            stampAtRead
+          );
           return;
         } catch (error) {
           if (!isOrg2SyncErrorCode(error, "ORG2_CONFLICT")) throw error;
@@ -573,7 +596,12 @@ export class Org2CloudSessionSync extends Org2CloudSessionSyncState {
             newEpoch: null,
           });
           this.markEventPlaneClean(orgId, session, stampAtRead);
-          void this.publishTurnIndexBestEffort(auth, orgId, session);
+          void this.publishTurnIndexBestEffort(
+            auth,
+            orgId,
+            session,
+            stampAtRead
+          );
           return;
         }
       }
@@ -588,7 +616,7 @@ export class Org2CloudSessionSync extends Org2CloudSessionSyncState {
         newEpoch: cursor.epoch + 1,
       });
       this.markEventPlaneClean(orgId, session, stampAtRead);
-      void this.publishTurnIndexBestEffort(auth, orgId, session);
+      void this.publishTurnIndexBestEffort(auth, orgId, session, stampAtRead);
       return;
     }
 
@@ -602,7 +630,7 @@ export class Org2CloudSessionSync extends Org2CloudSessionSyncState {
       newEpoch: 1,
     });
     this.markEventPlaneClean(orgId, session, stampAtRead);
-    void this.publishTurnIndexBestEffort(auth, orgId, session);
+    void this.publishTurnIndexBestEffort(auth, orgId, session, stampAtRead);
   }
 
   /**
@@ -617,12 +645,21 @@ export class Org2CloudSessionSync extends Org2CloudSessionSyncState {
   private async publishTurnIndexBestEffort(
     auth: Org2CloudAuthState,
     orgId: string,
-    session: Session
+    session: Session,
+    stampAtRead: number
   ): Promise<void> {
     const sessionId = session.session_id;
     try {
       const upsertTurnIndex = this.client.upsertSessionTurnIndex;
       if (!upsertTurnIndex) return;
+      // The local turn index is read AFTER the events push and reflects the
+      // LIVE store. If events landed since the pushed snapshot, the index
+      // would advertise rounds whose bodies are not on the server yet
+      // (phantom placeholders for every viewer); skip — the push those
+      // events trigger republishes.
+      if ((this.eventActivityStamps.get(sessionId) ?? 0) !== stampAtRead) {
+        return;
+      }
       // The cursor the push just committed carries the epoch this index
       // describes; without one there is nothing published to annotate.
       const cursor = this.getCursor(orgId, sessionId);

--- a/src/features/Org2Cloud/org2CloudSessionSync.turnIndexPreview.test.ts
+++ b/src/features/Org2Cloud/org2CloudSessionSync.turnIndexPreview.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeTurnPromptPreview } from "./org2CloudSessionSync";
+
+// Locked mirror of Rust normalize_turn_user_preview (turn_window.rs). If the
+// Rust normalization changes, these goldens must change WITH it — a silent
+// drift ships different prompts to viewers than the owner's own skeleton.
+describe("normalizeTurnPromptPreview", () => {
+  it("strips the user_message prefix", () => {
+    expect(normalizeTurnPromptPreview("user_message fix the bug")).toBe(
+      "fix the bug"
+    );
+  });
+
+  it("strips the bare user prefix", () => {
+    expect(normalizeTurnPromptPreview("user fix the bug")).toBe("fix the bug");
+  });
+
+  it("trims without stripping unrelated prefixes", () => {
+    expect(normalizeTurnPromptPreview("  username says hi  ")).toBe(
+      "username says hi"
+    );
+  });
+
+  it("caps at 240 chars with a trailing ellipsis", () => {
+    const long = "x".repeat(300);
+    const normalized = normalizeTurnPromptPreview(long);
+    expect(normalized).toHaveLength(241);
+    expect(normalized.endsWith("…")).toBe(true);
+    expect(normalized.slice(0, 240)).toBe("x".repeat(240));
+  });
+});

--- a/src/features/Org2Cloud/org2CloudSyncClient.ts
+++ b/src/features/Org2Cloud/org2CloudSyncClient.ts
@@ -219,7 +219,11 @@ const log = createLogger("Org2CloudSyncClient");
 
 const CloudOrgSessionsSchema = z.object({
   serverTime: z.string().optional(),
-  sessions: z.array(RemoteTeammateSessionMetadataSchema).default([]),
+  // Per-row tolerance: one malformed row (a newer client's shape, a bad
+  // owner payload) must cost that row, not the whole org listing — a failed
+  // listing reads as "org has no sessions" downstream, which the sidebar,
+  // offline sync, and the retract sweep all treat as authoritative absence.
+  sessions: z.array(z.unknown()).default([]),
   // 0005 backends return a keyset cursor when a bounded page has more rows;
   // absent on legacy backends and on the final page. `.catch(undefined)`
   // degrades a malformed cursor to "no more pages" instead of failing the
@@ -229,6 +233,30 @@ const CloudOrgSessionsSchema = z.object({
     .nullish()
     .catch(undefined),
 });
+
+function parseListingRows(
+  orgId: string,
+  rows: readonly unknown[]
+): RemoteTeammateSessionMetadata[] {
+  const parsed: RemoteTeammateSessionMetadata[] = [];
+  let dropped = 0;
+  for (const row of rows) {
+    const result = RemoteTeammateSessionMetadataSchema.safeParse(row);
+    if (result.success) {
+      parsed.push(result.data);
+    } else {
+      dropped += 1;
+    }
+  }
+  if (dropped > 0) {
+    log.rateLimited(
+      `listing-malformed-${orgId}`,
+      60_000,
+      `cloud_list_org_sessions dropped ${dropped} malformed row(s) for org ${orgId}`
+    );
+  }
+  return parsed;
+}
 
 /** Read-side segment wire: inline (`payloadGz`) or offloaded (`storagePath`). */
 export interface CloudSegmentWire {
@@ -575,10 +603,14 @@ export async function listOrgSessions(
       signal,
       15_000
     );
-    return CloudOrgSessionsSchema.parse(payload);
+    const raw = CloudOrgSessionsSchema.parse(payload);
+    return {
+      ...(raw.serverTime !== undefined ? { serverTime: raw.serverTime } : {}),
+      sessions: parseListingRows(orgId, raw.sessions),
+    } satisfies CloudOrgSessions;
   };
 
-  let parsed: z.output<typeof CloudOrgSessionsSchema>;
+  let parsed: CloudOrgSessions;
   if (
     since !== undefined ||
     paginationUnsupportedEndpoints.has(endpoint.supabaseUrl)
@@ -619,19 +651,25 @@ export async function listOrgSessions(
         throw error;
       }
       const pageParsed = CloudOrgSessionsSchema.parse(payload);
-      sessions.push(...pageParsed.sessions);
+      sessions.push(...parseListingRows(orgId, pageParsed.sessions));
       serverTime = pageParsed.serverTime ?? serverTime;
       cursor = pageParsed.nextCursor ?? undefined;
       page += 1;
       if (!cursor) {
-        parsed = { serverTime, sessions };
+        parsed = {
+          ...(serverTime !== undefined ? { serverTime } : {}),
+          sessions,
+        };
         break;
       }
       if (page >= SESSION_LISTING_MAX_PAGES) {
         log.warn(
           `cloud_list_org_sessions stopped after ${page} pages for org ${orgId}`
         );
-        parsed = { serverTime, sessions };
+        parsed = {
+          ...(serverTime !== undefined ? { serverTime } : {}),
+          sessions,
+        };
         break;
       }
     }
@@ -948,7 +986,7 @@ export async function upsertSessionTurnIndex(
 ): Promise<boolean> {
   const endpoint = endpointForOrg(orgId);
   if (turnIndexUnsupportedEndpoints.has(endpoint.supabaseUrl)) return false;
-  if (!(await getCloudCapabilities(accessToken)).sessionTurnIndex) {
+  if (!(await getCloudCapabilities(accessToken, endpoint)).sessionTurnIndex) {
     return false;
   }
   try {
@@ -994,7 +1032,7 @@ export async function getSessionTurnIndex(
   if (turnIndexUnsupportedEndpoints.has(endpoint.supabaseUrl)) {
     return NO_TURN_INDEX;
   }
-  if (!(await getCloudCapabilities(accessToken)).sessionTurnIndex) {
+  if (!(await getCloudCapabilities(accessToken, endpoint)).sessionTurnIndex) {
     return NO_TURN_INDEX;
   }
   let payload: unknown;

--- a/src/features/Org2Cloud/org2CloudSyncEngine.retractReconcile.test.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.retractReconcile.test.ts
@@ -16,6 +16,15 @@ import {
   reconcileOrgRetracts,
 } from "./org2CloudSyncEngine.retractReconcile";
 
+// Network-identity lookups must ANSWER in these tests: a FAILED lookup now
+// defers the out-of-scope verdict (scope-flapping guard) instead of counting
+// as "no match". Identity = itself keeps exact-string semantics.
+vi.mock("@src/api/tauri/github", () => ({
+  resolveGitHubRepoNetworkIdentityLocal: vi.fn(async (fullName: string) => ({
+    source_full_name: fullName,
+  })),
+}));
+
 const ORG = "11111111-1111-4111-8111-111111111111";
 
 describe("push-marker enumeration", () => {

--- a/src/features/Org2Cloud/org2CloudSyncEngine.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.ts
@@ -482,6 +482,16 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
           scopeKeys,
           scopes
         );
+        if (matchedScope === undefined) {
+          // A failed network-identity lookup cannot prove out-of-scope:
+          // retracting on it flapped rename-family scopes every time the
+          // identity API blipped. Skip until a lookup answers.
+          log.info(
+            `scope check deferred for session ${session.session_id} org ` +
+              `${org.orgId}: network identity lookup failed this pass`
+          );
+          continue;
+        }
         if (matchedScope === null) {
           // The scope mirror is persisted and restored empty-or-stale on
           // boot. An unconfirmed mirror cannot prove "out of scope": acting

--- a/src/features/Org2Cloud/useCloudSessionActions.ts
+++ b/src/features/Org2Cloud/useCloudSessionActions.ts
@@ -106,6 +106,11 @@ export interface CloudSessionReplayOptions {
   skipDownloadGate?: boolean;
 }
 
+export interface CloudSessionForkOptions {
+  /** True for starts the play card's Start button already confirmed. */
+  skipDownloadGate?: boolean;
+}
+
 export type CloudSessionActionOutcome =
   | "opened"
   /** The click raced past the server-side retention filter — show upgrade. */
@@ -120,7 +125,8 @@ export interface UseCloudSessionActionsResult {
     options?: CloudSessionReplayOptions
   ) => Promise<CloudSessionActionOutcome>;
   forkSession: (
-    remoteSession: RemoteTeammateSessionMetadata
+    remoteSession: RemoteTeammateSessionMetadata,
+    options?: CloudSessionForkOptions
   ) => Promise<CloudSessionActionOutcome>;
   /**
    * Row ids (`remoteSession.id`) with a replay/fork in flight. Per-row and
@@ -256,6 +262,7 @@ export function useCloudSessionActions(
               orgId,
               pendingEvents,
               etaMs: decision.etaMs,
+              kind: "replay",
             },
           });
           dismissCloudReferenceOpeningToast();
@@ -608,26 +615,240 @@ export function useCloudSessionActions(
   // engine fork + backend row registration + first-send context handoff.
   const forkSession = useCallback(
     async (
-      remoteSession: RemoteTeammateSessionMetadata
+      remoteSession: RemoteTeammateSessionMetadata,
+      options?: CloudSessionForkOptions
     ): Promise<CloudSessionActionOutcome> => {
       if (!orgId || remoteSession.eventsEpoch === undefined) return "noop";
       if (store.get(cloudSessionBusyRowsAtom).has(remoteSession.id)) {
         return "noop";
       }
+      // Big-session gate, replay parity: a Take Over whose pre-import would
+      // stream a large transcript parks the same play card (count + ETA) in
+      // the imported copy's pane and transfers nothing until Start. A
+      // current local copy, a resumable pause, or a small delta stays
+      // gate-free — those never surprise with a long transfer.
+      if (!options?.skipDownloadGate) {
+        const gateEndpointUrl = authRef.current?.supabaseUrl;
+        const pausedGateEntry = store
+          .get(cloudSessionPausedDownloadsAtom)
+          .get(remoteSession.id);
+        if (gateEndpointUrl && !pausedGateEntry) {
+          const gateSession = findImportedSession(
+            store.get(sessionsAtom),
+            orgId,
+            remoteSession.sourceSessionId,
+            gateEndpointUrl
+          );
+          const gateCursor = gateSession?.importedFrom;
+          const coveredCount =
+            gateCursor && gateCursor.epoch === remoteSession.eventsEpoch
+              ? gateCursor.count
+              : 0;
+          const pendingEvents = Math.max(
+            0,
+            (remoteSession.eventsCount ?? 0) - coveredCount
+          );
+          const decision = decideCloudDownloadGate(pendingEvents);
+          if (decision.gate) {
+            const pendingLocalId =
+              gateSession?.session_id ??
+              (await deriveImportedSessionId(
+                orgId,
+                remoteSession.sourceSessionId,
+                gateEndpointUrl
+              ));
+            store.set(setCloudDownloadPendingPlayAtom, {
+              localSessionId: pendingLocalId,
+              entry: {
+                rowId: remoteSession.id,
+                orgId,
+                pendingEvents,
+                etaMs: decision.etaMs,
+                kind: "fork",
+              },
+            });
+            openOrReplaceSessionTab({
+              sessionId: pendingLocalId,
+              sessionName: remoteSession.title,
+            });
+            return "noop";
+          }
+        }
+      }
       beginSessionBusy({
         rowId: remoteSession.id,
         entry: { kind: "fork", orgId },
       });
+      let forkPausedCommitted = false;
       try {
         const accessToken = await freshAccessToken();
         if (!accessToken) {
           Message.error(t("collaboration.session.forkFailed"));
           return "failed";
         }
+        // Local-copy-first parity: a Take Over of a session without a
+        // CURRENT local replay copy first runs the standard streamed import
+        // — same sidebar spinner/percent, same pause/resume semantics, and
+        // the fork then assembles from the local copy without a second
+        // download. With org offline sync on this pre-step is a no-op.
+        const sourceEndpointUrl = authRef.current?.supabaseUrl;
+        if (sourceEndpointUrl) {
+          const existing = findImportedSession(
+            store.get(sessionsAtom),
+            orgId,
+            remoteSession.sourceSessionId,
+            sourceEndpointUrl
+          );
+          const cursor = existing?.importedFrom;
+          const cursorCurrent =
+            !!cursor &&
+            cursor.epoch === remoteSession.eventsEpoch &&
+            cursor.seq === (remoteSession.eventsFrozenSeq ?? 0) &&
+            cursor.count === remoteSession.eventsCount &&
+            (cursor.tailHash ?? null) ===
+              (remoteSession.eventsTailHash ?? null);
+          if (!cursorCurrent) {
+            const pausedEntry =
+              store
+                .get(cloudSessionPausedDownloadsAtom)
+                .get(remoteSession.id) ?? null;
+            store.set(clearCloudPausedDownloadAtom, remoteSession.id);
+            const abortController = new AbortController();
+            registerCloudDownloadAbort(remoteSession.id, () =>
+              abortController.abort()
+            );
+            const importSessionId =
+              existing?.session_id ??
+              (await deriveImportedSessionId(
+                orgId,
+                remoteSession.sourceSessionId,
+                sourceEndpointUrl
+              ));
+            store.set(clearCloudDownloadPendingPlayAtom, importSessionId);
+            updateSessionBusy({
+              rowId: remoteSession.id,
+              patch: { localSessionId: importSessionId },
+            });
+            const baseEvents =
+              pausedEntry?.cursor?.count ??
+              (cursor && cursor.epoch === remoteSession.eventsEpoch
+                ? cursor.count
+                : 0);
+            const progressStartedAt = Date.now();
+            let maxLoadedEvents = pausedEntry ? baseEvents : 0;
+            const reporter = createThrottledProgressReporter((payload) =>
+              upsertDownloadProgress(payload)
+            );
+            const reportDownloadProgress = (
+              loadedEvents: number,
+              totalEvents: number | null,
+              phase: "downloading" | "finalizing" = "downloading"
+            ) => {
+              maxLoadedEvents = Math.max(maxLoadedEvents, loadedEvents);
+              reporter.report({
+                localSessionId: importSessionId,
+                progress: {
+                  rowId: remoteSession.id,
+                  orgId,
+                  loadedEvents: maxLoadedEvents,
+                  totalEvents,
+                  baseEvents,
+                  startedAtMs: progressStartedAt,
+                  updatedAtMs: Date.now(),
+                  phase,
+                },
+              });
+            };
+            reportDownloadProgress(
+              baseEvents,
+              remoteSession.eventsCount ?? pausedEntry?.totalEvents ?? null
+            );
+            let pausedCaptured: CloudPausedDownloadCursor | null = null;
+            try {
+              const imported = await importRemoteSession({
+                client: buildCloudSessionFetchClient(accessToken, undefined, {
+                  onTransferProgress: (progress) =>
+                    reportDownloadProgress(
+                      baseEvents + progress.decodedEvents,
+                      progress.totalEvents
+                    ),
+                }),
+                orgId,
+                remoteSession,
+                sourceEndpointUrl,
+                signal: abortController.signal,
+                onProgress: (progress) =>
+                  reportDownloadProgress(
+                    progress.loadedEvents,
+                    progress.totalEvents,
+                    progress.phase ?? "downloading"
+                  ),
+                onPauseState: (state) => {
+                  pausedCaptured = state;
+                },
+                ...(pausedEntry?.cursor
+                  ? { resumeCursor: pausedEntry.cursor }
+                  : {}),
+              });
+              if (imported?.updated && maxLoadedEvents > baseEvents) {
+                recordCloudDownloadSample(
+                  maxLoadedEvents - baseEvents,
+                  Date.now() - progressStartedAt
+                );
+              }
+            } catch (error) {
+              if (abortController.signal.aborted) {
+                const lastProgress = store
+                  .get(cloudSessionDownloadProgressAtom)
+                  .get(importSessionId);
+                const captured =
+                  pausedCaptured as CloudPausedDownloadCursor | null;
+                const heldLoaded =
+                  lastProgress?.loadedEvents ?? captured?.count ?? 0;
+                const heldTotal =
+                  lastProgress?.totalEvents ??
+                  remoteSession.eventsCount ??
+                  null;
+                store.set(setCloudPausedDownloadAtom, {
+                  rowId: remoteSession.id,
+                  entry: {
+                    localSessionId: importSessionId,
+                    orgId,
+                    totalEvents: heldTotal,
+                    loadedEvents: heldLoaded,
+                    cursor: captured,
+                  },
+                });
+                upsertDownloadProgress({
+                  localSessionId: importSessionId,
+                  progress: {
+                    rowId: remoteSession.id,
+                    orgId,
+                    loadedEvents: heldLoaded,
+                    totalEvents: heldTotal,
+                    startedAtMs: lastProgress?.startedAtMs ?? Date.now(),
+                    updatedAtMs: Date.now(),
+                    phase: "paused",
+                  },
+                });
+                forkPausedCommitted = true;
+                return "noop";
+              }
+              throw error;
+            } finally {
+              unregisterCloudDownloadAbort(remoteSession.id);
+              reporter.cancel();
+              if (!forkPausedCommitted) {
+                clearDownloadProgress(importSessionId);
+              }
+            }
+          }
+        }
         const result = await forkTeammateSession({
           client: buildCloudSessionFetchClient(accessToken),
           orgId,
           remoteSession,
+          ...(sourceEndpointUrl ? { sourceEndpointUrl } : {}),
           promptForExecution: true,
         });
         if (!result) {
@@ -689,6 +910,7 @@ export function useCloudSessionActions(
     },
     [
       beginSessionBusy,
+      clearDownloadProgress,
       endSessionBusy,
       freshAccessToken,
       openOrReplaceSessionTab,
@@ -697,6 +919,8 @@ export function useCloudSessionActions(
       orgId,
       store,
       t,
+      updateSessionBusy,
+      upsertDownloadProgress,
     ]
   );
 

--- a/src/features/Org2Cloud/useOrg2CloudRealtime.ts
+++ b/src/features/Org2Cloud/useOrg2CloudRealtime.ts
@@ -79,6 +79,7 @@ import {
 import { refreshOrgEntitlement } from "./org2CloudEntitlementCoordinator";
 import { org2CloudMemberNamesAtom } from "./org2CloudMemberNamesAtom";
 import { clearCloudOrgMembersCache } from "./org2CloudMembersCoordinator";
+import { endpointForOrigin } from "./org2CloudOrgEndpointRouter";
 import {
   org2CloudOrgsAtom,
   org2CloudRosterRealtimeConnectedAtom,
@@ -313,7 +314,10 @@ export function useOrg2CloudRealtime(): void {
     setBroadcastSignals(false);
     const current = authRef.current;
     if (!userId || !current) return undefined;
-    void getCloudCapabilities(current.accessToken).then((capabilities) => {
+    void getCloudCapabilities(
+      current.accessToken,
+      endpointForOrigin(current.supabaseUrl)
+    ).then((capabilities) => {
       if (!cancelled && capabilities.broadcastSignals) {
         setBroadcastSignals(true);
       }

--- a/src/features/TeamCollaboration/engine/collabSessionFork.ts
+++ b/src/features/TeamCollaboration/engine/collabSessionFork.ts
@@ -28,6 +28,7 @@ import type {
 } from "@src/store/session/sessionAtom/types";
 import { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";
 
+import { stripCopyEventNamespace } from "../copyEventId";
 import {
   isModelRunnableWithAccount,
   resolveForkModel,
@@ -37,8 +38,14 @@ import {
   ForkOperationError,
   ForkSnapshotIntegrityError,
 } from "../forkSnapshotIntegrity";
-import { rewriteEventsForImportedSnapshot } from "./collabImportIdentity";
-import type { RemoteSessionFetchOptions } from "./collabRemoteFetch";
+import {
+  findImportedSession,
+  rewriteEventsForImportedSnapshot,
+} from "./collabImportIdentity";
+import type {
+  AssembledSegments,
+  RemoteSessionFetchOptions,
+} from "./collabRemoteFetch";
 import { fetchAndAssembleSegments } from "./collabRemoteFetch";
 
 /**
@@ -162,6 +169,60 @@ export interface ForkSessionOptions extends RemoteSessionFetchOptions {
  * published no segments (metadata-only sessions have nothing to inherit);
  * THROWS on a failed durable write so callers surface it as retryable.
  */
+/**
+ * Local-copy-first sourcing: when a CURRENT imported replay of the source
+ * already exists (cursor exactly matches the listing summary and the
+ * persisted store really holds it — hollow copies never qualify), the fork
+ * assembles from it instead of re-downloading the full history. With org
+ * offline sync on, this makes Take Over instant and transfer-free for
+ * every synced session. Copy-namespaced ids are stripped back to SOURCE
+ * ids so the fork's own namespacing lands byte-identical to a
+ * remote-fetched fork. Guest (share-token) forks keep the remote path.
+ */
+async function loadForkSourceFromLocalCopy(
+  options: ForkSessionOptions
+): Promise<AssembledSegments | null> {
+  if (options.shareToken !== undefined) return null;
+  if (options.sourceEndpointUrl === undefined) return null;
+  const store = getInstrumentedStore();
+  const existing = findImportedSession(
+    store.get(sessionsAtom) as Session[],
+    options.orgId,
+    options.remoteSession.sourceSessionId,
+    options.sourceEndpointUrl
+  );
+  const cursor = existing?.importedFrom;
+  if (!existing || !cursor || cursor.frozenCount === undefined) return null;
+  const summary = options.remoteSession;
+  if (
+    cursor.epoch !== summary.eventsEpoch ||
+    cursor.seq !== (summary.eventsFrozenSeq ?? 0) ||
+    cursor.count !== summary.eventsCount ||
+    (cursor.tailHash ?? null) !== (summary.eventsTailHash ?? null)
+  ) {
+    return null;
+  }
+  const persisted = await eventStoreProxy.getPersistedEvents(
+    existing.session_id
+  );
+  if (persisted.length !== cursor.count) return null;
+  return {
+    events: persisted.map((event) => ({
+      ...event,
+      id: stripCopyEventNamespace(existing.session_id, event.id),
+      chunk_id:
+        event.chunk_id == null
+          ? event.chunk_id
+          : stripCopyEventNamespace(existing.session_id, event.chunk_id),
+      sessionId: options.remoteSession.sourceSessionId,
+    })),
+    epoch: cursor.epoch,
+    frozenSeq: cursor.seq,
+    frozenCount: cursor.frozenCount,
+    tailHash: cursor.tailHash ?? null,
+  };
+}
+
 export async function forkSession(
   options: ForkSessionOptions
 ): Promise<ForkSessionResult | null> {
@@ -209,15 +270,19 @@ export async function forkSession(
     ? { model: options.execution.model, fellBack: false }
     : resolveForkModel(remoteSession.model, localKeys, defaultModel);
 
-  // Full fetch from seq 0, same assembly + validation as the importer. Forks
-  // additionally fail closed against the list-row summary: an internally
-  // valid tail-only response must not materialize when the row promised a
-  // larger frozen history. The summary is a floor, not an exact match — a
-  // LIVE source keeps pushing between the list read and the segment fetch,
-  // so a snapshot that is AHEAD of the summary (owner rewrote to a newer
-  // epoch, or the same epoch grew) is the healthy race, while anything
-  // BEHIND the summary is the truncation this guard exists for.
-  const assembled = await fetchAndAssembleSegments(options, 0, [], null);
+  // Local-copy-first, then full fetch from seq 0 with the same assembly +
+  // validation as the importer. Forks additionally fail closed against the
+  // list-row summary: an internally valid tail-only response must not
+  // materialize when the row promised a larger frozen history. The summary
+  // is a floor, not an exact match — a LIVE source keeps pushing between
+  // the list read and the segment fetch, so a snapshot that is AHEAD of the
+  // summary (owner rewrote to a newer epoch, or the same epoch grew) is the
+  // healthy race, while anything BEHIND the summary is the truncation this
+  // guard exists for. A local-copy source equals the summary by
+  // construction (cursor match + persisted count probe).
+  const assembled =
+    (await loadForkSourceFromLocalCopy(options)) ??
+    (await fetchAndAssembleSegments(options, 0, [], null));
   const summaryEpoch = remoteSession.eventsEpoch;
   const summaryFrozenSeq = remoteSession.eventsFrozenSeq ?? 0;
   const summaryCount = remoteSession.eventsCount;

--- a/src/features/TeamCollaboration/repoScopeResolver.ts
+++ b/src/features/TeamCollaboration/repoScopeResolver.ts
@@ -22,6 +22,7 @@ import { useSyncExternalStore } from "react";
 
 import { getGitRemotes } from "@src/api/http/git/remotes";
 import { resolveGitHubRepoNetworkIdentityLocal } from "@src/api/tauri/github";
+import { createLogger } from "@src/hooks/logger";
 
 import {
   isLocalRepoPath,
@@ -51,12 +52,35 @@ const shareableScopeKeyInFlight = new Map<string, Promise<string[] | null>>();
 
 interface RepoNetworkScopeCacheEntry {
   value: string | null;
+  /**
+   * True when the provider lookup FAILED (transport/API error) rather than
+   * answering "no network identity". A failed entry rate-limits retries for
+   * its TTL but must never be read as proof of no identity: scope matching
+   * that would need this key reports UNKNOWN instead of no-match, because
+   * no-match retracts live shared rows and drops org tags.
+   */
+  failed: boolean;
   expiresAt: number;
 }
 
 const repoNetworkScopeCache = new Map<string, RepoNetworkScopeCacheEntry>();
 const repoNetworkScopeInFlight = new Map<string, Promise<string | null>>();
 const NETWORK_LOOKUP_FAILURE_TTL_MS = 30_000;
+/**
+ * Repeated failures back off geometrically (30s → 2m → 8m → 30m cap). An
+ * unauthenticated client gets 60 GitHub requests/hour; a flat 30s retry on
+ * just two failing repos burns ~240/hour, so the failure becomes
+ * self-sustaining for the rest of every rate-limit window.
+ */
+const NETWORK_LOOKUP_FAILURE_TTL_MAX_MS = 30 * 60_000;
+const networkLookupFailureStreaks = new Map<string, number>();
+const log = createLogger("RepoScopeResolver");
+
+function networkLookupFailureTtlMs(streak: number): number {
+  const ttl =
+    NETWORK_LOOKUP_FAILURE_TTL_MS * 4 ** Math.max(0, Math.min(streak - 1, 5));
+  return Math.min(ttl, NETWORK_LOOKUP_FAILURE_TTL_MAX_MS);
+}
 
 function readLruEntry<K, V>(cache: Map<K, V>, key: K): V | undefined {
   const value = cache.get(key);
@@ -247,6 +271,7 @@ export function clearShareableScopeKeyCache(): void {
   shareableScopeKeyInFlight.clear();
   repoNetworkScopeCache.clear();
   repoNetworkScopeInFlight.clear();
+  networkLookupFailureStreaks.clear();
 }
 
 // ============================================================================
@@ -301,16 +326,38 @@ export async function resolveRepoNetworkScopeKey(
       const sourceKey = normalizeRepoScopeKey(
         `github.com/${identity.source_full_name}`
       );
-      return sourceKey && !isLocalRepoPath(sourceKey) ? sourceKey : null;
+      return {
+        value: sourceKey && !isLocalRepoPath(sourceKey) ? sourceKey : null,
+        failed: false,
+      };
     })
-    .catch(() => null)
-    .then((value) => {
+    .catch((error: unknown) => {
+      const streak = (networkLookupFailureStreaks.get(normalized) ?? 0) + 1;
+      networkLookupFailureStreaks.set(normalized, streak);
+      log.rateLimited(
+        `network-identity-${normalized}`,
+        60_000,
+        `GitHub network identity lookup failed for ${fullName} ` +
+          `(streak ${streak}, next retry in ` +
+          `${Math.round(networkLookupFailureTtlMs(streak) / 1000)}s): ` +
+          `${error instanceof Error ? error.message : String(error)}`
+      );
+      return { value: null, failed: true };
+    })
+    .then(({ value, failed }) => {
+      if (!failed) networkLookupFailureStreaks.delete(normalized);
       if (repoNetworkScopeInFlight.get(normalized) === task) {
         writeLruEntry(repoNetworkScopeCache, normalized, {
           value,
+          failed,
           expiresAt:
             value === null
-              ? Date.now() + NETWORK_LOOKUP_FAILURE_TTL_MS
+              ? Date.now() +
+                networkLookupFailureTtlMs(
+                  failed
+                    ? (networkLookupFailureStreaks.get(normalized) ?? 1)
+                    : 1
+                )
               : Number.POSITIVE_INFINITY,
         });
         // Reuse the existing cache-version subscription: repo pickers and
@@ -371,18 +418,44 @@ export function peekMatchingOrgRepoScope(
   return unresolved ? undefined : null;
 }
 
+/** True when a cached network lookup for `input` is a rate-limited FAILURE. */
+function peekRepoNetworkLookupFailed(input: string): boolean {
+  const normalized = normalizeRepoScopeKey(input);
+  if (!normalized || isLocalRepoPath(normalized)) return false;
+  if (!githubRepoFullName(normalized)) return false;
+  const entry = readLruEntry(repoNetworkScopeCache, normalized);
+  return Boolean(entry && entry.failed && entry.expiresAt > Date.now());
+}
+
+/**
+ * `undefined` ⇒ UNKNOWN: no direct match, and at least one network-identity
+ * lookup that a match could hinge on has FAILED (transient GitHub/API
+ * error). Callers on destructive paths (out-of-scope retract/untag) must
+ * defer on unknown — treating a failed lookup as "no match" retracted live
+ * rows and dropped org tags whenever the identity API blipped, then pushed
+ * them again once the 30s failure TTL expired (scope flapping).
+ */
 export async function resolveMatchingOrgRepoScope(
   repoScopeKeys: string[] | null | undefined,
   orgScopes: string[] | null | undefined
-): Promise<string | null> {
+): Promise<string | null | undefined> {
   const immediate = peekMatchingOrgRepoScope(repoScopeKeys, orgScopes);
-  if (immediate !== undefined) return immediate;
+  if (immediate != null) return immediate;
   await Promise.all(
     [...(repoScopeKeys ?? []), ...(orgScopes ?? [])].map((key) =>
       resolveRepoNetworkScopeKey(key)
     )
   );
-  return peekMatchingOrgRepoScope(repoScopeKeys, orgScopes) ?? null;
+  const matched = peekMatchingOrgRepoScope(repoScopeKeys, orgScopes) ?? null;
+  if (matched !== null) return matched;
+  if (
+    [...(repoScopeKeys ?? []), ...(orgScopes ?? [])].some(
+      peekRepoNetworkLookupFailed
+    )
+  ) {
+    return undefined;
+  }
+  return null;
 }
 
 // ============================================================================
@@ -429,7 +502,7 @@ export async function resolveLocalCheckoutForScopeKey(
       const candidateKeys = await resolve(normalizedPath);
       if (
         candidateKeys?.includes(normalizedKey) ||
-        (await resolveMatchingOrgRepoScope(candidateKeys, [normalizedKey])) !==
+        (await resolveMatchingOrgRepoScope(candidateKeys, [normalizedKey])) !=
           null
       ) {
         return normalizedPath;

--- a/src/scaffold/AppUpdater/DownloadProgress.scss
+++ b/src/scaffold/AppUpdater/DownloadProgress.scss
@@ -1,8 +1,3 @@
-.app-update-download-progress--indeterminate > div {
-  width: 36% !important;
-  animation: app-update-progress-slide 1.2s ease-in-out infinite;
-}
-
 .app-update-download-orb {
   position: fixed;
   right: 1rem;
@@ -78,15 +73,6 @@
   animation: app-update-liquid-breathe 1.5s ease-in-out infinite alternate;
 }
 
-@keyframes app-update-progress-slide {
-  0% {
-    transform: translateX(-110%);
-  }
-  100% {
-    transform: translateX(280%);
-  }
-}
-
 @keyframes app-update-liquid-wave {
   to {
     transform: rotate(360deg);
@@ -110,7 +96,6 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .app-update-download-progress--indeterminate > div,
   .app-update-download-orb__wave,
   .app-update-download-orb--indeterminate .app-update-download-orb__liquid {
     animation: none;

--- a/src/scaffold/AppUpdater/DownloadProgress.tsx
+++ b/src/scaffold/AppUpdater/DownloadProgress.tsx
@@ -56,24 +56,13 @@ export const AppUpdateDownloadNoticeContent: FC<{
 
   return (
     <div className="w-64 max-w-full pt-1">
-      <div
-        role="progressbar"
-        aria-label="Update download progress"
-        aria-valuemin={0}
-        aria-valuemax={100}
-        aria-valuenow={progress.percent ?? undefined}
-        aria-valuetext={detail}
-      >
-        <ProgressBar
-          percent={progress.percent ?? 0}
-          height="h-1.5"
-          className={
-            progress.percent === null
-              ? "app-update-download-progress--indeterminate"
-              : undefined
-          }
-        />
-      </div>
+      <ProgressBar
+        percent={progress.percent ?? 0}
+        indeterminate={progress.percent === null}
+        height="h-1.5"
+        ariaLabel="Update download progress"
+        ariaValuetext={detail}
+      />
       <div className="mt-2 flex items-center justify-between gap-3 text-xs text-text-3">
         <span>{detail}</span>
         {progress.percent !== null && (

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.tsx
@@ -287,12 +287,19 @@ export function useCloudSessionsSection({
     }
     const row = findRow(downloadStartRequest.rowId);
     if (!row) return;
+    const startKind = downloadStartRequest.kind;
     store.set(cloudDownloadStartRequestAtom, null);
     // queueMicrotask to satisfy react-hooks/set-state-in-effect: the
     // resubscribe inside runReplay touches React state, and the request
     // slot was already consumed synchronously above.
-    queueMicrotask(() => runReplay(row, { skipGate: true }));
-  }, [downloadStartRequest, findRow, orgId, runReplay, store]);
+    queueMicrotask(() => {
+      if (startKind === "fork") {
+        void forkSession(row, { skipDownloadGate: true });
+      } else {
+        runReplay(row, { skipGate: true });
+      }
+    });
+  }, [downloadStartRequest, findRow, forkSession, orgId, runReplay, store]);
 
   const runFork = useCallback(
     (row: RemoteTeammateSessionMetadata) => {

--- a/src/util/time/formatDuration.ts
+++ b/src/util/time/formatDuration.ts
@@ -31,3 +31,21 @@ export function formatDuration(ms: number): string {
   }
   return `${hours}h ${remainingMinutes}m`;
 }
+
+/**
+ * Compact locale-neutral duration for tight UI slots: "8s", "1m20s",
+ * "2h05m". Rounds to the nearest second and clamps at "1s" — an estimate of
+ * "0s" reads as done while work is still visibly running.
+ */
+export function formatDurationCompact(ms: number): string {
+  const totalSeconds = Math.max(1, Math.round(ms / 1000));
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (totalMinutes < 60) {
+    return seconds > 0 ? `${totalMinutes}m${seconds}s` : `${totalMinutes}m`;
+  }
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours}h${String(minutes).padStart(2, "0")}m`;
+}


### PR DESCRIPTION
A hollow local read can no longer authorize erasing a session's cloud copy.

## The data loss this closes

`cursoride-93121e8a` lost its 301 cloud events on 2026-07-31: the local store read hollow (wiped/rebuilding cache), the 14:50 pass logged `persisted read returned 0 events but the cloud cursor covers 301; skipping` (strike one), and the 00:30 pass read the same zero, "confirmed" the shrink, and epoch-rewrote the cloud row to `count=0, stored_bytes=0`.

The consecutive-pass confirmation that guards nonzero shrinks is no defense against emptiness: an empty store reads zero on **every** pass, so any number of passes will agree. Persistent emptiness is evidence of local data loss, not user intent — and the cloud row may be the only surviving copy.

## The fix

In `pushSessionOnce`, a read of 0 events while the cursor covers more now hard-refuses the rewrite with a rate-limited warn (`refusing hollow epoch rewrite`), on every pass, forever. Recovery for a hollow local store is seed/import, never an empty rewrite. Nonzero shrinks (user-truncated history) keep the existing consecutive-pass re-anchor unchanged.

Unit tests cover both sides: hollow reads never rewrite across arbitrarily many passes; a nonzero shrink still re-anchors on the second consecutive identical read.

## Verification

tsc, eslint, Org2Cloud suite 96 files / 976 tests green. Live-staging the hollow cell would require deliberately corrupting a real session's local store; the recorded production sequence above (skip → confirm → wipe) is the reproduction this guard is written against.

---

# Sync-plane hardening batch (folded from the PR 605 audit)

## What changed

- **Per-row listing tolerance.** `cloud_list_org_sessions` now parses rows individually and drops malformed ones with a rate-limited count. Previously one bad row (a newer client's shape, a corrupt owner payload) failed the whole listing parse — and an empty listing reads as authoritative absence to the sidebar, offline sync, and the retract sweep.
- **Scope-flap guard (root cause found).** `resolveRepoNetworkScopeKey` cached a FAILED GitHub network-identity lookup as "no identity" for 30s. Rename-family matching (old remote spelling vs new org scope spelling) hinges entirely on that identity, so an identity-API blip produced a definitive "out of scope" → live rows retracted, org tags dropped → re-pushed after the TTL. Failures now cache as `failed`, matching that would hinge on them returns UNKNOWN, and the retract/untag paths defer on unknown (same philosophy as the existing "unconfirmed mirror cannot prove out-of-scope" guard). Fork-relay matching treats unknown as no-match (non-destructive path).
- **Per-org capability probes.** The 0012/0013 gates (turn index, offline sync) now probe the org's endpoint instead of the default one — a home-endpoint org's flags were read from the wrong backend (failed toward "off", but wrongly).
- **Turn-index publish snapshot guard.** The index is read from the live store after the events push; if events landed since the pushed snapshot (activity-stamp check) the publish is skipped rather than advertising rounds whose bodies are not on the server yet.
- **Per-turn imported-history load resolution.** The wire names each window's turn, so a turn whose window came back empty is no longer marked loaded by its batch-mates — its placeholder keeps its retry affordances.
- **Golden tests** lock `normalizeTurnPromptPreview` against its Rust mirror (`normalize_turn_user_preview`), so drift fails a test instead of shipping viewers different prompts than the owner's own skeleton.

## Verification

tsc, eslint, i18n gate, and the full Org2Cloud + TeamCollaboration + SessionCore suites green (187 files / 2408 tests), including a new unsubscribe-exclusion case and the retract-reconcile suite re-anchored on answered identity lookups (the old passes leaned on the exact conflation this PR removes).

---

# Take Over parity + progress-UI unification (folded)

## Local-copy-first Take Over

Fork sourcing now prefers a CURRENT local imported replay (cursor exactly matches the listing summary AND the persisted store really holds it — hollow copies never qualify) and assembles from it with copy-namespace ids stripped back to source ids, byte-identical to a remote-fetched fork. With org offline sync on, Take Over is instant and transfer-free for every synced session. Without a current copy, the fork first runs the standard streamed import — same sidebar spinner/percent, same pause/resume semantics (a paused pre-import holds a resumable cursor), same rate sampling — then assembles locally without a second transfer. This closes the audit's fork-parity gap (spinner-only, uncancellable, unannounced downloads).

## Progress-UI unification

The shared ProgressBar gains an indeterminate mode (the AppUpdater's sliding animation hoisted with its reduced-motion guard) plus built-in progressbar semantics (role, aria-value*, optional label/valuetext); the cloud download card and the update notice both render through it — one progress-bar treatment repo-wide. `formatCloudDownloadEta` delegates to a new `formatDurationCompact` beside `formatDuration`.

## Verification (whole PR)

tsc, eslint, i18n gate, full frontend suite **824 files / 7217 tests** green.

---

# Root fix for #608: deterministic external-history ingest (folded)

Closes #608.

## Root cause

Four external-history parsers (codex app, claude code, workbuddy, cursor cli) held unresolved tool calls in a `HashMap` and flushed the leftovers at end of parse in `HashMap::into_values()` order — randomized per process. Any transcript with in-flight calls at its tail (every actively-appending rollout) therefore emitted its flushed tail in a different permutation on every boot, with different positional chunk ids (`codex-tool-{sequence}-{call_id}`). The push plane hashes events per position, so an UNCHANGED transcript produced a fresh chain mismatch each boot and answered with a full epoch rewrite — the 28-epoch / 25MB-per-day storm in #608. The cross-epoch forensics (same position, `codex-tool-2324-*` in both epochs binding different call ids/timestamps) match this mechanism exactly.

## Fix

`imported_history::PendingCallMap` keeps O(1) call-id resolution but drains in insertion (file-appearance) order; codex background cells keep their original file slot across cell-id rotation, and per-call splits tie-break on the deterministic cell/session key. All four parsers converted. This also stops the local replay's flushed tail from reshuffling between boots — pushed order now equals display order. (A TS-side push canonicalization was considered and rejected: chunk ids are assigned positionally during the parse, so any post-hoc sort still ships different ids per boot; determinism has to come from the parser.)

## Verification

- `orgtrack_core` suite 445 tests green, incl. a new regression test that re-parses a rollout with ten unresolved calls and pins both flush order (file order, non-lexicographic ids) and cross-parse chunk-id equality — pre-fix code fails it with probability 1 − 1/10!.
- Two-boot on-device proof: boot 1 re-anchored the storm sessions exactly once each (`chainMismatch=true`, `frozen == cursorFrozen`) then went silent across all subsequent passes; boot 2 ran ~18 minutes of sync passes with **zero** epoch rewrites and a clean destructive-verb audit. ⌘5 API-calls panel empty; idle 0.0% CPU / 535MB RSS.

---

# Residual-batch closeout (folded — nothing deferred to a next PR)

- **GitHub identity-lookup backoff (root cause of the all-night scope deferrals).** The resolver retried failed network-identity lookups on a flat 30s TTL; this machine's lookups run unauthenticated (SSH-only git credentials), whose GitHub budget is 60 req/hour — two failing repos burned ~240/hour, so the rate-limit 403 became self-sustaining for the rest of every window, all night. Failures now back off geometrically per repo (30s → 2m → 8m → 30m cap, reset on success) and log the underlying error (previously swallowed to a bare `failed` flag).
- **Cursor IDE: unavailable ≠ empty.** The full-transcript loader (behind cloud push and fork) returned `Ok(vec![])` for an unopenable `state.vscdb` or a composer row missing mid-rebuild — the exact hollow read upstream saw as "this session has 0 events" in the 301→0 wipe. Those states are now errors with explicit reasons; the push pass fails truthfully and retries instead of proposing emptiness. Preview/listing paths keep best-effort semantics.
- **Realtime capability probe per origin.** The broadcast-signals probe now follows the socket's own origin (`endpointForOrigin`) instead of the default endpoint — the last capability probe not routed per connection.
- **Take Over big-session gate (replay parity).** A fork whose pre-import would stream a large transcript now parks the same play card (count + ETA, Fork button) in the imported copy's pane and transfers nothing until confirmed. Current local copies, resumable pauses, and small deltas stay gate-free. The start-request slot carries a `kind` so the sidebar consumer routes Start to fork or replay.
- **Offline-sweep hydration window: investigated, no guard needed.** `sessionsAtom` initializes synchronously from persistence at module init, before any effect can run the sweep; the only empty-read state is a genuinely fresh install, where importing everything is correct and idempotent.
- **Dual-instance verification skill** gains the invariant & determinism cells (fleet-wide epoch/count invariants, two-boot determinism, effect-based destructive audit, fault injection, anomaly-is-a-defect) from the reflection on why this PR's bug families survived earlier live rounds.

## Verification (residual batch)

tsc, eslint, Org2Cloud suite 1025 tests green; `orgtrack_core` cursor_ide suite 67 green, clippy/fmt clean on touched files. On-device smoke on the final build: boot clean, no unexpected epoch rewrites, identity-lookup failures now surface with reason and backoff.
