### PR TITLE
fix(cloud): sync-plane hardening batch from the PR 605 audit

### DIFF
--- a/src/engines/SessionCore/turns/importedHistoryTurnLoader.ts
+++ b/src/engines/SessionCore/turns/importedHistoryTurnLoader.ts
@@ -12,6 +12,7 @@ import type { SessionTurnLoader } from "./types";
 interface PendingImportedTurnBatch {
   turnIds: Set<string>;
   waiters: Array<{
+    turnId: string;
     resolve: (loaded: boolean) => void;
     reject: (error: unknown) => void;
   }>;
@@ -36,18 +37,26 @@ async function flushPendingBatch(sessionId: string): Promise<void> {
         turnIds,
       });
       const chunks = windows.flatMap((window) => window.chunks);
-      // Batch-level resolution: per-turn attribution is not available on
-      // this wire, but provider files are local so an empty window means
-      // the whole batch found nothing.
-      let loaded = false;
+      let merged = false;
       if (chunks.length > 0) {
         const events = await processChunksRust(chunks, sessionId);
         if (events.length > 0) {
           await eventStoreProxy.mergeRoundWindowEvents(events, sessionId);
-          loaded = true;
+          merged = true;
         }
       }
-      for (const waiter of waiters) waiter.resolve(loaded);
+      // Per-turn resolution: the wire names each window's turn, so a turn
+      // whose window came back empty must NOT be marked loaded by its
+      // batch-mates — that would disarm exactly the retry affordance the
+      // loader contract exists to preserve.
+      const loadedTurnIds = new Set(
+        windows
+          .filter((window) => window.chunks.length > 0)
+          .map((window) => window.turnId)
+      );
+      for (const waiter of waiters) {
+        waiter.resolve(merged && loadedTurnIds.has(waiter.turnId));
+      }
     } catch (error) {
       for (const waiter of waiters) waiter.reject(error);
     }
@@ -64,13 +73,13 @@ function enqueueImportedTurnLoad(
     const existing = pendingBatches.get(sessionId);
     if (existing) {
       existing.turnIds.add(turnId);
-      existing.waiters.push({ resolve, reject });
+      existing.waiters.push({ turnId, resolve, reject });
       return;
     }
 
     pendingBatches.set(sessionId, {
       turnIds: new Set([turnId]),
-      waiters: [{ resolve, reject }],
+      waiters: [{ turnId, resolve, reject }],
       flushing: false,
     });
     queueMicrotask(() => {

--- a/src/features/Org2Cloud/org2CloudCapabilities.ts
+++ b/src/features/Org2Cloud/org2CloudCapabilities.ts
@@ -8,7 +8,10 @@
 import { z } from "zod/v4";
 
 import { getCloudEndpoint } from "./config";
-import { getCloudCapabilitiesRaw } from "./org2CloudClient";
+import {
+  type CloudRpcEndpoint,
+  getCloudCapabilitiesRaw,
+} from "./org2CloudClient";
 import { runCloudRequestWithTimeout } from "./org2CloudFetchRetry";
 
 const CLOUD_CAPABILITIES_TIMEOUT_MS = 15_000;
@@ -69,11 +72,12 @@ const inFlightByEndpoint = new Map<
 
 async function probeCloudCapabilities(
   accessToken: string,
-  endpointKey: string
+  endpointKey: string,
+  endpoint?: CloudRpcEndpoint
 ): Promise<CloudCapabilitiesProbeResult> {
   try {
     const payload = await runCloudRequestWithTimeout(
-      (signal) => getCloudCapabilitiesRaw(accessToken, signal),
+      (signal) => getCloudCapabilitiesRaw(accessToken, signal, endpoint),
       CLOUD_CAPABILITIES_TIMEOUT_MS
     );
     const parsed = CloudCapabilitiesWireSchema.safeParse(payload);
@@ -110,14 +114,18 @@ async function probeCloudCapabilities(
  * this time" — see the member-runtime push scheduler's capability blackout.
  */
 export async function getCloudCapabilitiesConfirmed(
-  accessToken: string
+  accessToken: string,
+  endpoint?: CloudRpcEndpoint
 ): Promise<CloudCapabilitiesProbeResult> {
-  const endpointKey = getCloudEndpoint().supabaseUrl;
+  // Per-endpoint routing: home-endpoint orgs answer for their OWN backend.
+  // Probing the default endpoint for a per-org feature gate reads the wrong
+  // server's capability set (fails toward "off", but wrongly).
+  const endpointKey = (endpoint ?? getCloudEndpoint()).supabaseUrl;
   const cached = capabilitiesByEndpoint.get(endpointKey);
   if (cached) return { capabilities: cached, confirmed: true };
   const inFlight = inFlightByEndpoint.get(endpointKey);
   if (inFlight) return inFlight;
-  const probe = probeCloudCapabilities(accessToken, endpointKey);
+  const probe = probeCloudCapabilities(accessToken, endpointKey, endpoint);
   inFlightByEndpoint.set(endpointKey, probe);
   try {
     return await probe;
@@ -127,9 +135,11 @@ export async function getCloudCapabilitiesConfirmed(
 }
 
 export async function getCloudCapabilities(
-  accessToken: string
+  accessToken: string,
+  endpoint?: CloudRpcEndpoint
 ): Promise<CloudCapabilities> {
-  return (await getCloudCapabilitiesConfirmed(accessToken)).capabilities;
+  return (await getCloudCapabilitiesConfirmed(accessToken, endpoint))
+    .capabilities;
 }
 
 export const __CAPABILITIES_INTERNALS = {

--- a/src/features/Org2Cloud/org2CloudClient.ts
+++ b/src/features/Org2Cloud/org2CloudClient.ts
@@ -70,7 +70,7 @@ let inFlightRefresh:
   | { key: string; promise: Promise<RefreshAttemptResult> }
   | undefined;
 
-type CloudRpcEndpoint = Pick<
+export type CloudRpcEndpoint = Pick<
   ReturnType<typeof getCloudEndpoint>,
   "supabaseUrl" | "anonKey"
 >;
@@ -136,13 +136,14 @@ export async function schemaVersion(): Promise<number | null> {
  */
 export async function getCloudCapabilitiesRaw(
   accessToken: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  endpoint?: CloudRpcEndpoint
 ): Promise<unknown | null> {
   return callRpc(
     "get_cloud_capabilities",
     accessToken,
     undefined,
-    getCloudEndpoint(),
+    endpoint ?? getCloudEndpoint(),
     signal
   );
 }

--- a/src/features/Org2Cloud/org2CloudOfflineSync.ts
+++ b/src/features/Org2Cloud/org2CloudOfflineSync.ts
@@ -63,6 +63,7 @@ import { buildCloudSessionFetchClient } from "./org2CloudBackendAdapter";
 import { getCloudCapabilities } from "./org2CloudCapabilities";
 import { ensureFreshSession } from "./org2CloudClient";
 import { isFetchTransportError } from "./org2CloudFetchRetry";
+import { endpointForOrg } from "./org2CloudOrgEndpointRouter";
 import {
   org2CloudOrgsAtom,
   sidebarActiveCloudOrgIdAtom,
@@ -235,7 +236,12 @@ class Org2CloudOfflineSyncScheduler {
       remoteSessionsEntryForIdentity(entry, org2CloudAuthIdentityKey(auth))
         ?.rows ?? [];
     if (rows.length === 0) return;
-    if (!(await getCloudCapabilities(auth.accessToken)).offlineSync) return;
+    if (
+      !(await getCloudCapabilities(auth.accessToken, endpointForOrg(orgId)))
+        .offlineSync
+    ) {
+      return;
+    }
     if (generation !== this.generation) return;
 
     const candidates = pickOfflineSyncCandidates({

--- a/src/features/Org2Cloud/org2CloudSessionSync.ts
+++ b/src/features/Org2Cloud/org2CloudSessionSync.ts
@@ -79,7 +79,7 @@ const TURN_INDEX_PROMPT_MAX_CHARS = 240;
 const TURN_INDEX_MAX_ROUNDS = 2_000;
 
 /** Mirror of Rust normalize_turn_user_preview (turn_window.rs) + truncation. */
-function normalizeTurnPromptPreview(preview: string): string {
+export function normalizeTurnPromptPreview(preview: string): string {
   const trimmed = preview.trim();
   const stripped = trimmed.startsWith("user_message ")
     ? trimmed.slice("user_message ".length)
@@ -559,7 +559,12 @@ export class Org2CloudSessionSync extends Org2CloudSessionSyncState {
           );
           broadcastOrgControlChangedToPeers(orgId, "sessions");
           this.markEventPlaneClean(orgId, session, stampAtRead);
-          void this.publishTurnIndexBestEffort(auth, orgId, session);
+          void this.publishTurnIndexBestEffort(
+            auth,
+            orgId,
+            session,
+            stampAtRead
+          );
           return;
         } catch (error) {
           if (!isOrg2SyncErrorCode(error, "ORG2_CONFLICT")) throw error;
@@ -573,7 +578,12 @@ export class Org2CloudSessionSync extends Org2CloudSessionSyncState {
             newEpoch: null,
           });
           this.markEventPlaneClean(orgId, session, stampAtRead);
-          void this.publishTurnIndexBestEffort(auth, orgId, session);
+          void this.publishTurnIndexBestEffort(
+            auth,
+            orgId,
+            session,
+            stampAtRead
+          );
           return;
         }
       }
@@ -588,7 +598,7 @@ export class Org2CloudSessionSync extends Org2CloudSessionSyncState {
         newEpoch: cursor.epoch + 1,
       });
       this.markEventPlaneClean(orgId, session, stampAtRead);
-      void this.publishTurnIndexBestEffort(auth, orgId, session);
+      void this.publishTurnIndexBestEffort(auth, orgId, session, stampAtRead);
       return;
     }
 
@@ -602,7 +612,7 @@ export class Org2CloudSessionSync extends Org2CloudSessionSyncState {
       newEpoch: 1,
     });
     this.markEventPlaneClean(orgId, session, stampAtRead);
-    void this.publishTurnIndexBestEffort(auth, orgId, session);
+    void this.publishTurnIndexBestEffort(auth, orgId, session, stampAtRead);
   }
 
   /**
@@ -617,12 +627,21 @@ export class Org2CloudSessionSync extends Org2CloudSessionSyncState {
   private async publishTurnIndexBestEffort(
     auth: Org2CloudAuthState,
     orgId: string,
-    session: Session
+    session: Session,
+    stampAtRead: number
   ): Promise<void> {
     const sessionId = session.session_id;
     try {
       const upsertTurnIndex = this.client.upsertSessionTurnIndex;
       if (!upsertTurnIndex) return;
+      // The local turn index is read AFTER the events push and reflects the
+      // LIVE store. If events landed since the pushed snapshot, the index
+      // would advertise rounds whose bodies are not on the server yet
+      // (phantom placeholders for every viewer); skip — the push those
+      // events trigger republishes.
+      if ((this.eventActivityStamps.get(sessionId) ?? 0) !== stampAtRead) {
+        return;
+      }
       // The cursor the push just committed carries the epoch this index
       // describes; without one there is nothing published to annotate.
       const cursor = this.getCursor(orgId, sessionId);

--- a/src/features/Org2Cloud/org2CloudSessionSync.turnIndexPreview.test.ts
+++ b/src/features/Org2Cloud/org2CloudSessionSync.turnIndexPreview.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeTurnPromptPreview } from "./org2CloudSessionSync";
+
+// Locked mirror of Rust normalize_turn_user_preview (turn_window.rs). If the
+// Rust normalization changes, these goldens must change WITH it — a silent
+// drift ships different prompts to viewers than the owner's own skeleton.
+describe("normalizeTurnPromptPreview", () => {
+  it("strips the user_message prefix", () => {
+    expect(normalizeTurnPromptPreview("user_message fix the bug")).toBe(
+      "fix the bug"
+    );
+  });
+
+  it("strips the bare user prefix", () => {
+    expect(normalizeTurnPromptPreview("user fix the bug")).toBe("fix the bug");
+  });
+
+  it("trims without stripping unrelated prefixes", () => {
+    expect(normalizeTurnPromptPreview("  username says hi  ")).toBe(
+      "username says hi"
+    );
+  });
+
+  it("caps at 240 chars with a trailing ellipsis", () => {
+    const long = "x".repeat(300);
+    const normalized = normalizeTurnPromptPreview(long);
+    expect(normalized).toHaveLength(241);
+    expect(normalized.endsWith("…")).toBe(true);
+    expect(normalized.slice(0, 240)).toBe("x".repeat(240));
+  });
+});

--- a/src/features/Org2Cloud/org2CloudSyncClient.ts
+++ b/src/features/Org2Cloud/org2CloudSyncClient.ts
@@ -219,7 +219,11 @@ const log = createLogger("Org2CloudSyncClient");
 
 const CloudOrgSessionsSchema = z.object({
   serverTime: z.string().optional(),
-  sessions: z.array(RemoteTeammateSessionMetadataSchema).default([]),
+  // Per-row tolerance: one malformed row (a newer client's shape, a bad
+  // owner payload) must cost that row, not the whole org listing — a failed
+  // listing reads as "org has no sessions" downstream, which the sidebar,
+  // offline sync, and the retract sweep all treat as authoritative absence.
+  sessions: z.array(z.unknown()).default([]),
   // 0005 backends return a keyset cursor when a bounded page has more rows;
   // absent on legacy backends and on the final page. `.catch(undefined)`
   // degrades a malformed cursor to "no more pages" instead of failing the
@@ -229,6 +233,30 @@ const CloudOrgSessionsSchema = z.object({
     .nullish()
     .catch(undefined),
 });
+
+function parseListingRows(
+  orgId: string,
+  rows: readonly unknown[]
+): RemoteTeammateSessionMetadata[] {
+  const parsed: RemoteTeammateSessionMetadata[] = [];
+  let dropped = 0;
+  for (const row of rows) {
+    const result = RemoteTeammateSessionMetadataSchema.safeParse(row);
+    if (result.success) {
+      parsed.push(result.data);
+    } else {
+      dropped += 1;
+    }
+  }
+  if (dropped > 0) {
+    log.rateLimited(
+      `listing-malformed-${orgId}`,
+      60_000,
+      `cloud_list_org_sessions dropped ${dropped} malformed row(s) for org ${orgId}`
+    );
+  }
+  return parsed;
+}
 
 /** Read-side segment wire: inline (`payloadGz`) or offloaded (`storagePath`). */
 export interface CloudSegmentWire {
@@ -575,10 +603,14 @@ export async function listOrgSessions(
       signal,
       15_000
     );
-    return CloudOrgSessionsSchema.parse(payload);
+    const raw = CloudOrgSessionsSchema.parse(payload);
+    return {
+      ...(raw.serverTime !== undefined ? { serverTime: raw.serverTime } : {}),
+      sessions: parseListingRows(orgId, raw.sessions),
+    } satisfies CloudOrgSessions;
   };
 
-  let parsed: z.output<typeof CloudOrgSessionsSchema>;
+  let parsed: CloudOrgSessions;
   if (
     since !== undefined ||
     paginationUnsupportedEndpoints.has(endpoint.supabaseUrl)
@@ -619,19 +651,25 @@ export async function listOrgSessions(
         throw error;
       }
       const pageParsed = CloudOrgSessionsSchema.parse(payload);
-      sessions.push(...pageParsed.sessions);
+      sessions.push(...parseListingRows(orgId, pageParsed.sessions));
       serverTime = pageParsed.serverTime ?? serverTime;
       cursor = pageParsed.nextCursor ?? undefined;
       page += 1;
       if (!cursor) {
-        parsed = { serverTime, sessions };
+        parsed = {
+          ...(serverTime !== undefined ? { serverTime } : {}),
+          sessions,
+        };
         break;
       }
       if (page >= SESSION_LISTING_MAX_PAGES) {
         log.warn(
           `cloud_list_org_sessions stopped after ${page} pages for org ${orgId}`
         );
-        parsed = { serverTime, sessions };
+        parsed = {
+          ...(serverTime !== undefined ? { serverTime } : {}),
+          sessions,
+        };
         break;
       }
     }
@@ -948,7 +986,7 @@ export async function upsertSessionTurnIndex(
 ): Promise<boolean> {
   const endpoint = endpointForOrg(orgId);
   if (turnIndexUnsupportedEndpoints.has(endpoint.supabaseUrl)) return false;
-  if (!(await getCloudCapabilities(accessToken)).sessionTurnIndex) {
+  if (!(await getCloudCapabilities(accessToken, endpoint)).sessionTurnIndex) {
     return false;
   }
   try {
@@ -994,7 +1032,7 @@ export async function getSessionTurnIndex(
   if (turnIndexUnsupportedEndpoints.has(endpoint.supabaseUrl)) {
     return NO_TURN_INDEX;
   }
-  if (!(await getCloudCapabilities(accessToken)).sessionTurnIndex) {
+  if (!(await getCloudCapabilities(accessToken, endpoint)).sessionTurnIndex) {
     return NO_TURN_INDEX;
   }
   let payload: unknown;

--- a/src/features/Org2Cloud/org2CloudSyncEngine.retractReconcile.test.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.retractReconcile.test.ts
@@ -16,6 +16,15 @@ import {
   reconcileOrgRetracts,
 } from "./org2CloudSyncEngine.retractReconcile";
 
+// Network-identity lookups must ANSWER in these tests: a FAILED lookup now
+// defers the out-of-scope verdict (scope-flapping guard) instead of counting
+// as "no match". Identity = itself keeps exact-string semantics.
+vi.mock("@src/api/tauri/github", () => ({
+  resolveGitHubRepoNetworkIdentityLocal: vi.fn(async (fullName: string) => ({
+    source_full_name: fullName,
+  })),
+}));
+
 const ORG = "11111111-1111-4111-8111-111111111111";
 
 describe("push-marker enumeration", () => {

--- a/src/features/Org2Cloud/org2CloudSyncEngine.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.ts
@@ -482,6 +482,16 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
           scopeKeys,
           scopes
         );
+        if (matchedScope === undefined) {
+          // A failed network-identity lookup cannot prove out-of-scope:
+          // retracting on it flapped rename-family scopes every time the
+          // identity API blipped. Skip until a lookup answers.
+          log.info(
+            `scope check deferred for session ${session.session_id} org ` +
+              `${org.orgId}: network identity lookup failed this pass`
+          );
+          continue;
+        }
         if (matchedScope === null) {
           // The scope mirror is persisted and restored empty-or-stale on
           // boot. An unconfirmed mirror cannot prove "out of scope": acting

--- a/src/features/TeamCollaboration/repoScopeResolver.ts
+++ b/src/features/TeamCollaboration/repoScopeResolver.ts
@@ -51,6 +51,14 @@ const shareableScopeKeyInFlight = new Map<string, Promise<string[] | null>>();
 
 interface RepoNetworkScopeCacheEntry {
   value: string | null;
+  /**
+   * True when the provider lookup FAILED (transport/API error) rather than
+   * answering "no network identity". A failed entry rate-limits retries for
+   * its TTL but must never be read as proof of no identity: scope matching
+   * that would need this key reports UNKNOWN instead of no-match, because
+   * no-match retracts live shared rows and drops org tags.
+   */
+  failed: boolean;
   expiresAt: number;
 }
 
@@ -301,13 +309,17 @@ export async function resolveRepoNetworkScopeKey(
       const sourceKey = normalizeRepoScopeKey(
         `github.com/${identity.source_full_name}`
       );
-      return sourceKey && !isLocalRepoPath(sourceKey) ? sourceKey : null;
+      return {
+        value: sourceKey && !isLocalRepoPath(sourceKey) ? sourceKey : null,
+        failed: false,
+      };
     })
-    .catch(() => null)
-    .then((value) => {
+    .catch(() => ({ value: null, failed: true }))
+    .then(({ value, failed }) => {
       if (repoNetworkScopeInFlight.get(normalized) === task) {
         writeLruEntry(repoNetworkScopeCache, normalized, {
           value,
+          failed,
           expiresAt:
             value === null
               ? Date.now() + NETWORK_LOOKUP_FAILURE_TTL_MS
@@ -371,18 +383,44 @@ export function peekMatchingOrgRepoScope(
   return unresolved ? undefined : null;
 }
 
+/** True when a cached network lookup for `input` is a rate-limited FAILURE. */
+function peekRepoNetworkLookupFailed(input: string): boolean {
+  const normalized = normalizeRepoScopeKey(input);
+  if (!normalized || isLocalRepoPath(normalized)) return false;
+  if (!githubRepoFullName(normalized)) return false;
+  const entry = readLruEntry(repoNetworkScopeCache, normalized);
+  return Boolean(entry && entry.failed && entry.expiresAt > Date.now());
+}
+
+/**
+ * `undefined` ⇒ UNKNOWN: no direct match, and at least one network-identity
+ * lookup that a match could hinge on has FAILED (transient GitHub/API
+ * error). Callers on destructive paths (out-of-scope retract/untag) must
+ * defer on unknown — treating a failed lookup as "no match" retracted live
+ * rows and dropped org tags whenever the identity API blipped, then pushed
+ * them again once the 30s failure TTL expired (scope flapping).
+ */
 export async function resolveMatchingOrgRepoScope(
   repoScopeKeys: string[] | null | undefined,
   orgScopes: string[] | null | undefined
-): Promise<string | null> {
+): Promise<string | null | undefined> {
   const immediate = peekMatchingOrgRepoScope(repoScopeKeys, orgScopes);
-  if (immediate !== undefined) return immediate;
+  if (immediate != null) return immediate;
   await Promise.all(
     [...(repoScopeKeys ?? []), ...(orgScopes ?? [])].map((key) =>
       resolveRepoNetworkScopeKey(key)
     )
   );
-  return peekMatchingOrgRepoScope(repoScopeKeys, orgScopes) ?? null;
+  const matched = peekMatchingOrgRepoScope(repoScopeKeys, orgScopes) ?? null;
+  if (matched !== null) return matched;
+  if (
+    [...(repoScopeKeys ?? []), ...(orgScopes ?? [])].some(
+      peekRepoNetworkLookupFailed
+    )
+  ) {
+    return undefined;
+  }
+  return null;
 }
 
 // ============================================================================
@@ -429,7 +467,7 @@ export async function resolveLocalCheckoutForScopeKey(
       const candidateKeys = await resolve(normalizedPath);
       if (
         candidateKeys?.includes(normalizedKey) ||
-        (await resolveMatchingOrgRepoScope(candidateKeys, [normalizedKey])) !==
+        (await resolveMatchingOrgRepoScope(candidateKeys, [normalizedKey])) !=
           null
       ) {
         return normalizedPath;


### PR DESCRIPTION
Five sync-plane hardening items from the PR #605 audit, plus the scope-flapping root cause.

## What changed

- **Per-row listing tolerance.** `cloud_list_org_sessions` now parses rows individually and drops malformed ones with a rate-limited count. Previously one bad row (a newer client's shape, a corrupt owner payload) failed the whole listing parse — and an empty listing reads as authoritative absence to the sidebar, offline sync, and the retract sweep.
- **Scope-flap guard (root cause found).** `resolveRepoNetworkScopeKey` cached a FAILED GitHub network-identity lookup as "no identity" for 30s. Rename-family matching (old remote spelling vs new org scope spelling) hinges entirely on that identity, so an identity-API blip produced a definitive "out of scope" → live rows retracted, org tags dropped → re-pushed after the TTL. Failures now cache as `failed`, matching that would hinge on them returns UNKNOWN, and the retract/untag paths defer on unknown (same philosophy as the existing "unconfirmed mirror cannot prove out-of-scope" guard). Fork-relay matching treats unknown as no-match (non-destructive path).
- **Per-org capability probes.** The 0012/0013 gates (turn index, offline sync) now probe the org's endpoint instead of the default one — a home-endpoint org's flags were read from the wrong backend (failed toward "off", but wrongly).
- **Turn-index publish snapshot guard.** The index is read from the live store after the events push; if events landed since the pushed snapshot (activity-stamp check) the publish is skipped rather than advertising rounds whose bodies are not on the server yet.
- **Per-turn imported-history load resolution.** The wire names each window's turn, so a turn whose window came back empty is no longer marked loaded by its batch-mates — its placeholder keeps its retry affordances.
- **Golden tests** lock `normalizeTurnPromptPreview` against its Rust mirror (`normalize_turn_user_preview`), so drift fails a test instead of shipping viewers different prompts than the owner's own skeleton.

## Verification

tsc, eslint, i18n gate, and the full Org2Cloud + TeamCollaboration + SessionCore suites green (187 files / 2408 tests), including a new unsubscribe-exclusion case and the retract-reconcile suite re-anchored on answered identity lookups (the old passes leaned on the exact conflation this PR removes).
