### PR TITLE
fix(source-control): prevent Review tab refresh flash

### DIFF
--- a/src/hooks/git/useRepoGitInitialization.test.ts
+++ b/src/hooks/git/useRepoGitInitialization.test.ts
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import {
+  type RepoGitInitializationState,
+  useRepoGitInitialization,
+} from "./useRepoGitInitialization";
+
+const mocks = vi.hoisted(() => ({
+  checkIsGitRepo: vi.fn(),
+}));
+
+vi.mock("@src/api/tauri/repo", () => ({
+  repoApi: {
+    checkIsGitRepo: mocks.checkIsGitRepo,
+  },
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function initializationLabel(
+  value: RepoGitInitializationState
+): "loading" | "ready" | "uninitialized" {
+  return value === null ? "loading" : value ? "ready" : "uninitialized";
+}
+
+function Harness({
+  knownGitStatusExists,
+  repoPath,
+}: {
+  knownGitStatusExists?: boolean;
+  repoPath: string | null;
+}) {
+  const { isGitInitialized } = useRepoGitInitialization(repoPath, {
+    knownGitStatusExists,
+  });
+
+  return createElement("div", {
+    "data-initialization-state": initializationLabel(isGitInitialized),
+  });
+}
+
+describe("useRepoGitInitialization", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("keeps a known initialized repo visible while the remount check is pending", async () => {
+    const check = deferred<boolean>();
+    mocks.checkIsGitRepo.mockReturnValue(check.promise);
+
+    act(() => {
+      root.render(
+        createElement(Harness, {
+          repoPath: "/workspace/repo",
+          knownGitStatusExists: true,
+        })
+      );
+    });
+
+    expect(
+      container.firstElementChild?.getAttribute("data-initialization-state")
+    ).toBe("ready");
+
+    await act(async () => {
+      check.resolve(true);
+      await check.promise;
+    });
+
+    expect(
+      container.firstElementChild?.getAttribute("data-initialization-state")
+    ).toBe("ready");
+  });
+
+  it("shows loading when neither the status owner nor the check has a result", () => {
+    mocks.checkIsGitRepo.mockReturnValue(new Promise<boolean>(() => {}));
+
+    act(() => {
+      root.render(
+        createElement(Harness, {
+          repoPath: "/workspace/first-load",
+        })
+      );
+    });
+
+    expect(
+      container.firstElementChild?.getAttribute("data-initialization-state")
+    ).toBe("loading");
+  });
+
+  it("prefers a newer scoped Git status over the fallback check result", async () => {
+    mocks.checkIsGitRepo.mockResolvedValue(true);
+
+    await act(async () => {
+      root.render(
+        createElement(Harness, {
+          repoPath: "/workspace/repo",
+        })
+      );
+    });
+
+    expect(
+      container.firstElementChild?.getAttribute("data-initialization-state")
+    ).toBe("ready");
+
+    act(() => {
+      root.render(
+        createElement(Harness, {
+          repoPath: "/workspace/repo",
+          knownGitStatusExists: false,
+        })
+      );
+    });
+
+    expect(
+      container.firstElementChild?.getAttribute("data-initialization-state")
+    ).toBe("uninitialized");
+  });
+
+  it("does not expose the previous repo result after a scope switch", async () => {
+    const firstCheck = deferred<boolean>();
+    const secondCheck = deferred<boolean>();
+    mocks.checkIsGitRepo
+      .mockReturnValueOnce(firstCheck.promise)
+      .mockReturnValueOnce(secondCheck.promise);
+
+    act(() => {
+      root.render(
+        createElement(Harness, {
+          repoPath: "/workspace/first",
+          knownGitStatusExists: true,
+        })
+      );
+    });
+
+    act(() => {
+      root.render(
+        createElement(Harness, {
+          repoPath: "/workspace/second",
+        })
+      );
+    });
+
+    expect(
+      container.firstElementChild?.getAttribute("data-initialization-state")
+    ).toBe("loading");
+
+    await act(async () => {
+      firstCheck.resolve(false);
+      await firstCheck.promise;
+    });
+
+    expect(
+      container.firstElementChild?.getAttribute("data-initialization-state")
+    ).toBe("loading");
+
+    await act(async () => {
+      secondCheck.resolve(false);
+      await secondCheck.promise;
+    });
+
+    expect(
+      container.firstElementChild?.getAttribute("data-initialization-state")
+    ).toBe("uninitialized");
+  });
+});

--- a/src/hooks/git/useRepoGitInitialization.ts
+++ b/src/hooks/git/useRepoGitInitialization.ts
@@ -7,29 +7,50 @@ const logger = createLogger("RepoGitInitialization");
 
 export type RepoGitInitializationState = boolean | null;
 
+export interface UseRepoGitInitializationOptions {
+  /**
+   * GitStatusContext already owns a repo-scoped status snapshot. Reuse its
+   * `exists` result while the lightweight initialization check refreshes so a
+   * remounted Source Control sidebar does not fall back to a loading screen.
+   */
+  knownGitStatusExists?: boolean;
+}
+
 export interface UseRepoGitInitializationReturn {
   isGitInitialized: RepoGitInitializationState;
   refreshGitInitialization: () => Promise<void>;
 }
 
+interface CheckedInitializationState {
+  repoPath: string;
+  value: boolean;
+}
+
 export function useRepoGitInitialization(
-  repoPath: string | null | undefined
+  repoPath: string | null | undefined,
+  options: UseRepoGitInitializationOptions = {}
 ): UseRepoGitInitializationReturn {
-  const [isGitInitialized, setIsGitInitialized] =
-    useState<RepoGitInitializationState>(null);
+  const { knownGitStatusExists } = options;
+  const [checkedState, setCheckedState] =
+    useState<CheckedInitializationState | null>(null);
+
+  const checkedValue =
+    repoPath && checkedState?.repoPath === repoPath ? checkedState.value : null;
+  // The already-scoped Git status is the authoritative live value. The
+  // dedicated check is only a fallback for first load / no-status cases.
+  const isGitInitialized = knownGitStatusExists ?? checkedValue ?? null;
 
   const refreshGitInitialization = useCallback(async () => {
     if (!repoPath) {
-      setIsGitInitialized(null);
       return;
     }
 
     try {
       const result = await repoApi.checkIsGitRepo(repoPath);
-      setIsGitInitialized(result);
+      setCheckedState({ repoPath, value: result });
     } catch (error) {
       logger.warn("Failed to check Git initialization:", error, { repoPath });
-      setIsGitInitialized(false);
+      setCheckedState({ repoPath, value: false });
     }
   }, [repoPath]);
 
@@ -38,17 +59,15 @@ export function useRepoGitInitialization(
 
     async function checkGitInitialization() {
       if (!repoPath) {
-        setIsGitInitialized(null);
         return;
       }
 
-      setIsGitInitialized(null);
       try {
         const result = await repoApi.checkIsGitRepo(repoPath);
-        if (!cancelled) setIsGitInitialized(result);
+        if (!cancelled) setCheckedState({ repoPath, value: result });
       } catch (error) {
         logger.warn("Failed to check Git initialization:", error, { repoPath });
-        if (!cancelled) setIsGitInitialized(false);
+        if (!cancelled) setCheckedState({ repoPath, value: false });
       }
     }
 

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlTab.initialization.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlTab.initialization.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { Fragment, act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { useSourceControlTabConfig } from "./SourceControlTab";
+
+const mocks = vi.hoisted(() => ({
+  useRepoGitInitialization: vi.fn(),
+}));
+
+vi.mock("jotai", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("jotai")>()),
+  useAtomValue: () => [],
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@src/contexts/git", () => ({
+  useGitStatus: () => ({
+    currentGitStatus: { exists: true },
+    forceRefresh: vi.fn(),
+  }),
+}));
+
+vi.mock("@src/hooks/git", () => ({
+  useRepoGitInitialization: mocks.useRepoGitInitialization,
+}));
+
+vi.mock("@src/modules/shared/layouts/blocks", () => ({
+  Placeholder: () => "loading-placeholder",
+}));
+
+vi.mock("../hooks/useGitWorktrees", () => ({
+  useGitWorktrees: () => ({
+    worktrees: [],
+    hasWorktrees: false,
+    loading: false,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("../hooks/useSourceControlScope", () => ({
+  useSourceControlScope: () => ({ scope: { kind: "local" } }),
+}));
+
+vi.mock("../content/MultiRootSourceControlContent", () => ({
+  default: () => "multi-root-source-control",
+}));
+
+vi.mock("./SourceControlTabPanels", () => ({
+  NotGitInitializedContent: () => "not-git-initialized",
+  SourceControlTabContent: () => "source-control-content",
+  SourceControlWithWorktrees: () => "worktree-source-control",
+}));
+
+function Harness() {
+  const tab = useSourceControlTabConfig({
+    repoPath: "/workspace/repo",
+    repoId: "repo-1",
+    showFilter: false,
+    viewMode: "list-tree",
+    sourceControlRef: { current: null },
+    actions: [],
+    worktrees: [],
+    hasWorktrees: false,
+    worktreesLoading: false,
+  });
+
+  return createElement(Fragment, null, tab.sections?.[0]?.content);
+}
+
+describe("SourceControlTab initialization gate", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    mocks.useRepoGitInitialization.mockImplementation(
+      (_repoPath: string, options: { knownGitStatusExists?: boolean }) => ({
+        isGitInitialized: options.knownGitStatusExists ?? null,
+        refreshGitInitialization: vi.fn(),
+      })
+    );
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("renders Source Control immediately from the scoped status hint", () => {
+    act(() => {
+      root.render(createElement(Harness));
+    });
+
+    expect(mocks.useRepoGitInitialization).toHaveBeenCalledWith(
+      "/workspace/repo",
+      { knownGitStatusExists: true }
+    );
+    expect(container.textContent).toBe("source-control-content");
+    expect(container.textContent).not.toContain("loading-placeholder");
+  });
+});

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlTab.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlTab.tsx
@@ -111,9 +111,11 @@ export function useSourceControlTabConfig({
   const SourceControlIcon = ICON_CONFIG.sourceControl;
   const workspaceFolders = useAtomValue(workspaceFoldersAtom);
 
+  const { currentGitStatus, forceRefresh } = useGitStatus();
   const { isGitInitialized, refreshGitInitialization } =
-    useRepoGitInitialization(repoPath);
-  const { forceRefresh } = useGitStatus();
+    useRepoGitInitialization(repoPath, {
+      knownGitStatusExists: currentGitStatus?.exists,
+    });
 
   const handleGitInitialized = useCallback(async () => {
     await refreshGitInitialization();

--- a/src/modules/WorkStation/CodeEditor/TEST_CASES.md
+++ b/src/modules/WorkStation/CodeEditor/TEST_CASES.md
@@ -24,20 +24,21 @@
 
 ## Edge Cases
 
-| #   | Scenario                         | Steps                                              | Expected Result                                                              |
-| --- | -------------------------------- | -------------------------------------------------- | ---------------------------------------------------------------------------- |
-| 1   | Open a binary/unsupported file   | Click a `.png` in file tree.                       | Editor shows "binary file" or preview fallback; no garbled text.             |
-| 2   | Open an empty file               | Click an empty `.ts` file.                         | Editor renders empty; no crash; save works.                                  |
-| 3   | File deleted externally mid-edit | Delete file outside app while it's open in editor. | Tab marked as "file not found"; editor shows warning.                        |
-| 4   | Very large file (> 1 MB)         | Open a 2 MB log file.                              | CodeMirror loads without UI freeze; syntax highlight may be disabled.        |
-| 5   | Git diff with binary changes     | Open file with only binary changes in diff.        | Diff gutter shows changed state; no garbled diff output.                     |
-| 6   | Multiple tabs open               | Open 15 files simultaneously.                      | All tabs shown (or overflow scrolled); each renders correctly.               |
-| 7   | Search with no results           | Open search; type string not present in file.      | "No results" indicator shown; no crash.                                      |
-| 8   | Search with regex                | Open search; enable regex mode; type `\d+`.        | Numeric matches highlighted.                                                 |
-| 9   | Close unsaved tab                | Edit a file; close tab without saving.             | Confirmation dialog appears; cancel preserves tab; confirm discards changes. |
-| 10  | Window resize                    | Resize workstation panel while file is open.       | Editor reflows; no layout artifacts.                                         |
-| 11  | Stash count badge                | `useStashCount` returns > 0.                       | Git status area shows stash count badge.                                     |
-| 12  | Rapid open/close tabs            | Open and close 5 tabs rapidly.                     | No memory leak; no stale state in CodeMirror instances.                      |
+| #   | Scenario                         | Steps                                              | Expected Result                                                                                       |
+| --- | -------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| 1   | Open a binary/unsupported file   | Click a `.png` in file tree.                       | Editor shows "binary file" or preview fallback; no garbled text.                                      |
+| 2   | Open an empty file               | Click an empty `.ts` file.                         | Editor renders empty; no crash; save works.                                                           |
+| 3   | File deleted externally mid-edit | Delete file outside app while it's open in editor. | Tab marked as "file not found"; editor shows warning.                                                 |
+| 4   | Very large file (> 1 MB)         | Open a 2 MB log file.                              | CodeMirror loads without UI freeze; syntax highlight may be disabled.                                 |
+| 5   | Git diff with binary changes     | Open file with only binary changes in diff.        | Diff gutter shows changed state; no garbled diff output.                                              |
+| 6   | Multiple tabs open               | Open 15 files simultaneously.                      | All tabs shown (or overflow scrolled); each renders correctly.                                        |
+| 7   | Search with no results           | Open search; type string not present in file.      | "No results" indicator shown; no crash.                                                               |
+| 8   | Search with regex                | Open search; enable regex mode; type `\d+`.        | Numeric matches highlighted.                                                                          |
+| 9   | Close unsaved tab                | Edit a file; close tab without saving.             | Confirmation dialog appears; cancel preserves tab; confirm discards changes.                          |
+| 10  | Window resize                    | Resize workstation panel while file is open.       | Editor reflows; no layout artifacts.                                                                  |
+| 11  | Stash count badge                | `useStashCount` returns > 0.                       | Git status area shows stash count badge.                                                              |
+| 12  | Rapid open/close tabs            | Open and close 5 tabs rapidly.                     | No memory leak; no stale state in CodeMirror instances.                                               |
+| 13  | Return to Review tab             | Open Review, switch to Files, then return.         | Existing Source Control tree stays visible while Git initialization is revalidated; no loading flash. |
 
 ## Error / Degraded States
 


### PR DESCRIPTION
## Summary

- keep the existing Source Control tree visible while Git initialization is revalidated after returning to Review
- use the repo-scoped Git status as the live authority and scope fallback checks by repository path
- preserve first-load, non-Git repository, and repository-switch behavior without keeping the heavy sidebar mounted

## Verification

- `pnpm vitest run src/hooks/git/useRepoGitInitialization.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlTab.initialization.test.ts`
- `pnpm typecheck`
- targeted ESLint and Prettier checks
- `git diff --check`

## Performance

No polling, cache, listener, or keep-alive behavior was added. The Source Control sidebar still releases its heavy diff state when inactive.
