### PR TITLE
perf(history): bound sync and push down usage queries

### DIFF
--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/paths.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/paths.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
@@ -122,6 +122,18 @@ pub fn sqlite_session_activity_signature(
             db_path.display()
         )
     })?;
+    sqlite_session_activity_signature_from_conn(&conn, source_session_id, source_name)
+}
+
+/// Read the same session-local activity signature from an already-open store.
+///
+/// Metadata scans use this form so all sessions share one read-only connection
+/// instead of reopening the SQLite database once per session.
+pub fn sqlite_session_activity_signature_from_conn(
+    conn: &Connection,
+    source_session_id: &str,
+    source_name: &str,
+) -> Result<Option<(i64, u64)>, String> {
     conn.query_row(
         "SELECT MAX(
                     COALESCE(s.time_updated, 0),
@@ -149,6 +161,57 @@ pub fn sqlite_session_activity_signature(
     .map_err(|err| {
         format!("Failed to read {source_name} session signature {source_session_id}: {err}")
     })
+}
+
+/// Read activity signatures for every session in one bounded SQLite pass.
+///
+/// A metadata scan already needs one row per session. Aggregating `part` once
+/// avoids an N+1 query pattern and, more importantly, avoids quadratic work on
+/// provider databases that do not index `part.session_id`.
+pub fn sqlite_all_session_activity_signatures_from_conn(
+    conn: &Connection,
+    source_name: &str,
+) -> Result<HashMap<String, (i64, u64)>, String> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT s.id,
+                    MAX(COALESCE(s.time_updated, 0), COALESCE(parts.last_created_at, 0)),
+                    COALESCE(parts.last_rowid, 0),
+                    COALESCE(parts.total_data_bytes, 0)
+             FROM session s
+             LEFT JOIN (
+                 SELECT session_id,
+                        MAX(time_created) AS last_created_at,
+                        MAX(rowid) AS last_rowid,
+                        COALESCE(SUM(length(CAST(data AS BLOB))), 0) AS total_data_bytes
+                 FROM part
+                 GROUP BY session_id
+             ) parts ON parts.session_id = s.id",
+        )
+        .map_err(|err| format!("Failed to prepare {source_name} activity signatures: {err}"))?;
+    let rows = stmt
+        .query_map([], |row| {
+            let source_session_id = row.get::<_, String>(0)?;
+            let updated_at = row.get::<_, Option<i64>>(1)?.unwrap_or_default();
+            let last_part_rowid = row.get::<_, Option<i64>>(2)?.unwrap_or_default();
+            let total_part_bytes = row.get::<_, Option<i64>>(3)?.unwrap_or_default();
+            Ok((
+                source_session_id,
+                (
+                    updated_at,
+                    fold_activity_signature_components(&[last_part_rowid, total_part_bytes]),
+                ),
+            ))
+        })
+        .map_err(|err| format!("Failed to query {source_name} activity signatures: {err}"))?;
+
+    let mut signatures = HashMap::new();
+    for row in rows {
+        let (source_session_id, signature) =
+            row.map_err(|err| format!("Failed to read {source_name} activity signature: {err}"))?;
+        signatures.insert(source_session_id, signature);
+    }
+    Ok(signatures)
 }
 
 fn sqlite_sidecar_path(db_path: &Path, suffix: &str) -> PathBuf {
@@ -226,8 +289,7 @@ mod tests {
             [],
         )
         .expect("in-place update of open session part");
-        let grown =
-            sqlite_session_activity_signature(&path, "a", "Test").expect("signature grown");
+        let grown = sqlite_session_activity_signature(&path, "a", "Test").expect("signature grown");
         assert_ne!(grown, before);
 
         drop(conn);

--- a/src-tauri/crates/orgtrack-core/src/sources/mimo_code/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/mimo_code/history.rs
@@ -101,8 +101,7 @@ fn sync_mimo_code_history_cache(cache_conn: &mut Connection) -> Result<(), Strin
             continue;
         }
         let conn = open_mimo_code_db_at(&db_path)?;
-        let (mtime, size) = imported_paths::file_metadata_signature(&db_path, "Mimo Code")?;
-        metas.extend(list_session_meta_from_conn(&conn, &db_path, mtime, size)?);
+        metas.extend(list_session_meta_from_conn(&conn, &db_path)?);
     }
 
     let container_parent_ids = container_parent_ids(&metas);
@@ -143,8 +142,6 @@ fn sync_mimo_code_history_cache(cache_conn: &mut Connection) -> Result<(), Strin
 fn list_session_meta_from_conn(
     conn: &Connection,
     db_path: &Path,
-    source_mtime_ms: i64,
-    source_size_bytes: i64,
 ) -> Result<Vec<MimoCodeSessionMeta>, String> {
     let pure_imported_session_ids = pure_imported_session_ids(conn)?;
     let mut stmt = conn
@@ -168,8 +165,8 @@ fn list_session_meta_from_conn(
             Ok(MimoCodeSessionMeta {
                 source_session_id: row.get::<_, Option<String>>(0)?.unwrap_or_default(),
                 source_path: db_path.to_string_lossy().to_string(),
-                source_mtime_ms,
-                source_size_bytes,
+                source_mtime_ms: 0,
+                source_size_bytes: 0,
                 source_fingerprint: String::new(),
                 title: row.get::<_, Option<String>>(1)?.unwrap_or_default(),
                 directory: row.get::<_, Option<String>>(2)?.unwrap_or_default(),
@@ -190,7 +187,8 @@ fn list_session_meta_from_conn(
         })
         .map_err(|err| format!("Failed to query Mimo Code sessions: {err}"))?;
 
-    let sidecars = imported_paths::sqlite_sidecar_signature(db_path);
+    let activity_signatures =
+        imported_paths::sqlite_all_session_activity_signatures_from_conn(conn, "Mimo Code")?;
     let mut metas = Vec::new();
     for row in rows {
         let mut meta = row.map_err(|err| format!("Failed to read Mimo Code session row: {err}"))?;
@@ -200,6 +198,12 @@ fn list_session_meta_from_conn(
         if pure_imported_session_ids.contains(&meta.source_session_id) {
             continue;
         }
+        let (activity_time, activity_fold) = activity_signatures
+            .get(&meta.source_session_id)
+            .copied()
+            .unwrap_or((meta.time_updated.max(meta.time_created), 0));
+        meta.source_mtime_ms = activity_time;
+        meta.source_size_bytes = activity_fold as i64;
         meta.source_fingerprint = [
             meta.source_session_id.as_str(),
             meta.title.as_str(),
@@ -210,7 +214,6 @@ fn list_session_meta_from_conn(
             &meta.input_tokens.to_string(),
             &meta.output_tokens.to_string(),
             meta.parent_id.as_deref().unwrap_or_default(),
-            sidecars.as_str(),
         ]
         .join("|");
         metas.push(meta);
@@ -425,7 +428,7 @@ mod tests {
     }
 
     #[test]
-    fn reads_mimo_session_metadata_and_shared_parts() {
+    fn mimo_metadata_signature_ignores_unrelated_session_writes() {
         let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(
             "CREATE TABLE session (
@@ -461,12 +464,12 @@ mod tests {
         )
         .unwrap();
 
-        let metas =
-            list_session_meta_from_conn(&conn, Path::new("mimocode.db"), 10, 20).expect("metadata");
+        let metas = list_session_meta_from_conn(&conn, Path::new("mimocode.db")).expect("metadata");
         assert_eq!(metas.len(), 1);
         assert_eq!(metas[0].model.as_deref(), Some("mimo-model"));
         assert_eq!(metas[0].input_tokens, 14);
         assert_eq!(metas[0].output_tokens, 4);
+        let before = meta_signature(&metas[0]);
 
         let chunks = load_opencode_compatible_history_from_conn(
             &conn,
@@ -476,6 +479,49 @@ mod tests {
         )
         .expect("chunks");
         assert_eq!(chunks.len(), 2);
+
+        conn.execute_batch(
+            "INSERT INTO session VALUES (
+                'ses_other', 'Other', '/other', 1, 2, NULL, NULL
+             );
+             INSERT INTO message VALUES (
+                'msg_other', 'ses_other', 1, '{\"role\":\"assistant\"}'
+             );
+             INSERT INTO part VALUES (
+                'part_other', 'msg_other', 'ses_other', 1,
+                '{\"type\":\"text\",\"text\":\"unrelated tail\"}'
+             );
+             UPDATE part
+                SET data = '{\"type\":\"text\",\"text\":\"longer unrelated tail\"}'
+              WHERE id = 'part_other';",
+        )
+        .expect("write unrelated session");
+        let after_unrelated = list_session_meta_from_conn(&conn, Path::new("mimocode.db"))
+            .expect("metadata after unrelated write")
+            .into_iter()
+            .find(|meta| meta.source_session_id == "ses_1")
+            .map(|meta| meta_signature(&meta))
+            .expect("target signature after unrelated write");
+        assert!(imported_cache::record_matches_cached_signature(
+            &before,
+            &after_unrelated
+        ));
+
+        conn.execute(
+            "UPDATE part SET data = data || ' target growth' WHERE id = 'part_2'",
+            [],
+        )
+        .expect("grow target part");
+        let after_target = list_session_meta_from_conn(&conn, Path::new("mimocode.db"))
+            .expect("metadata after target write")
+            .into_iter()
+            .find(|meta| meta.source_session_id == "ses_1")
+            .map(|meta| meta_signature(&meta))
+            .expect("target signature after target write");
+        assert!(!imported_cache::record_matches_cached_signature(
+            &before,
+            &after_target
+        ));
     }
 
     #[test]
@@ -488,6 +534,10 @@ mod tests {
              );
              CREATE TABLE message (
                 id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT
+             );
+             CREATE TABLE part (
+                id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT,
+                time_created INTEGER, data TEXT
              );
              CREATE TABLE external_import (
                 source TEXT NOT NULL, source_key TEXT NOT NULL, session_id TEXT NOT NULL,
@@ -521,8 +571,7 @@ mod tests {
         )
         .unwrap();
 
-        let metas =
-            list_session_meta_from_conn(&conn, Path::new("mimocode.db"), 10, 20).expect("metadata");
+        let metas = list_session_meta_from_conn(&conn, Path::new("mimocode.db")).expect("metadata");
         let source_ids = metas
             .into_iter()
             .map(|meta| meta.source_session_id)
@@ -549,6 +598,10 @@ mod tests {
              CREATE TABLE message (
                 id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT
              );
+             CREATE TABLE part (
+                id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT,
+                time_created INTEGER, data TEXT
+             );
              CREATE TABLE claude_import (
                 source_uuid TEXT PRIMARY KEY, session_id TEXT NOT NULL,
                 source_path TEXT NOT NULL, source_mtime INTEGER NOT NULL,
@@ -567,8 +620,7 @@ mod tests {
         )
         .unwrap();
 
-        let metas =
-            list_session_meta_from_conn(&conn, Path::new("mimocode.db"), 10, 20).expect("metadata");
+        let metas = list_session_meta_from_conn(&conn, Path::new("mimocode.db")).expect("metadata");
         assert!(metas.is_empty());
     }
 }

--- a/src-tauri/crates/orgtrack-core/src/sources/opencode/history/sync.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/opencode/history/sync.rs
@@ -12,14 +12,7 @@ pub(super) fn sync_opencode_history_cache(cache_conn: &mut Connection) -> Result
         )?;
         return Ok(());
     };
-    let (source_mtime_ms, source_size_bytes) =
-        imported_paths::file_metadata_signature(&db_path, "OpenCode")?;
-    let mut metas = list_all_opencode_session_meta_from_conn(
-        &conn,
-        &db_path,
-        source_mtime_ms,
-        source_size_bytes,
-    )?;
+    let mut metas = list_all_opencode_session_meta_from_conn(&conn, &db_path)?;
     let managed_source_session_ids = managed_opencode_source_session_ids_from_conn(cache_conn)?;
     for meta in &mut metas {
         meta.source_fingerprint.push_str(
@@ -66,7 +59,9 @@ pub(super) fn sync_opencode_history_cache(cache_conn: &mut Connection) -> Result
     imported_cache::sync_source_cache_from_conn(cache_conn, SOURCE_OPENCODE, live_ids, inputs)
 }
 
-fn opencode_meta_signature(meta: &OpenCodeSessionMeta) -> ImportedHistoryRecordSignature {
+pub(super) fn opencode_meta_signature(
+    meta: &OpenCodeSessionMeta,
+) -> ImportedHistoryRecordSignature {
     ImportedHistoryRecordSignature {
         source_session_id: meta.source_session_id.clone(),
         source_path: meta.source_path.clone(),
@@ -121,8 +116,6 @@ pub(super) fn container_parent_ids_from_metas(metas: &[OpenCodeSessionMeta]) -> 
 pub(super) fn list_all_opencode_session_meta_from_conn(
     conn: &Connection,
     db_path: &Path,
-    source_mtime_ms: i64,
-    source_size_bytes: i64,
 ) -> Result<Vec<OpenCodeSessionMeta>, String> {
     let mut stmt = conn
         .prepare(
@@ -168,20 +161,23 @@ pub(super) fn list_all_opencode_session_meta_from_conn(
         })
         .map_err(|err| format!("Failed to query OpenCode sessions: {err}"))?;
 
-    // A single `opencode.db` backs every session, so fold its WAL/`-shm`
-    // sidecars into each session's fingerprint once.
-    let sidecar_signature = imported_paths::sqlite_sidecar_signature(db_path);
+    let activity_signatures =
+        imported_paths::sqlite_all_session_activity_signatures_from_conn(conn, "OpenCode")?;
     let mut sessions = Vec::new();
     for row in rows {
         let mut meta = row.map_err(|err| format!("Failed to read OpenCode session row: {err}"))?;
         if meta.source_session_id.trim().is_empty() {
             continue;
         }
+        let (activity_time, activity_fold) = activity_signatures
+            .get(&meta.source_session_id)
+            .copied()
+            .unwrap_or((meta.time_updated.max(meta.time_created), 0));
         meta.source_path = db_path.to_string_lossy().to_string();
         meta.source_record_key = meta.source_session_id.clone();
-        meta.source_mtime_ms = source_mtime_ms;
-        meta.source_size_bytes = source_size_bytes;
-        meta.source_fingerprint = opencode_source_fingerprint(&meta, &sidecar_signature);
+        meta.source_mtime_ms = activity_time;
+        meta.source_size_bytes = activity_fold as i64;
+        meta.source_fingerprint = opencode_source_fingerprint(&meta);
         sessions.push(meta);
     }
     Ok(sessions)
@@ -189,10 +185,10 @@ pub(super) fn list_all_opencode_session_meta_from_conn(
 
 /// Content-aware change fingerprint for an OpenCode session.
 ///
-/// The `opencode.db` mtime alone can stay flat across a same-mtime rewrite, so
-/// this folds the session's own identity/title/timestamp/token/parent fields
-/// together with the shared WAL/`-shm` sidecar signature.
-fn opencode_source_fingerprint(meta: &OpenCodeSessionMeta, sidecar_signature: &str) -> String {
+/// The shared `opencode.db`/WAL changes for unrelated sessions, so this
+/// fingerprint contains only fields owned by the selected session. Transcript
+/// activity rides in the session-local mtime/size signature fields.
+fn opencode_source_fingerprint(meta: &OpenCodeSessionMeta) -> String {
     [
         meta.source_session_id.as_str(),
         meta.title.as_str(),
@@ -202,7 +198,6 @@ fn opencode_source_fingerprint(meta: &OpenCodeSessionMeta, sidecar_signature: &s
         &meta.input_tokens.to_string(),
         &meta.output_tokens.to_string(),
         meta.parent_id.as_deref().unwrap_or_default(),
-        sidecar_signature,
     ]
     .join("|")
 }

--- a/src-tauri/crates/orgtrack-core/src/sources/opencode/history_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/opencode/history_tests.rs
@@ -172,13 +172,9 @@ fn includes_opencode_candidate_db_paths() {
 fn maps_opencode_session_metadata_to_cache_input() {
     let conn = fixture_conn();
 
-    let metas = list_all_opencode_session_meta_from_conn(
-        &conn,
-        std::path::Path::new("/tmp/opencode.db"),
-        1770000006000,
-        4096,
-    )
-    .expect("list session metadata");
+    let metas =
+        list_all_opencode_session_meta_from_conn(&conn, std::path::Path::new("/tmp/opencode.db"))
+            .expect("list session metadata");
     let inputs = metas
         .into_iter()
         .map(|meta| session_meta_to_cache_input(meta, &HashSet::new(), &HashSet::new()))
@@ -221,6 +217,75 @@ fn maps_opencode_session_metadata_to_cache_input() {
 }
 
 #[test]
+fn opencode_metadata_signature_ignores_unrelated_session_writes() {
+    let conn = fixture_conn();
+    let before =
+        list_all_opencode_session_meta_from_conn(&conn, std::path::Path::new("/tmp/opencode.db"))
+            .expect("initial metadata")
+            .into_iter()
+            .find(|meta| meta.source_session_id == "ses_1")
+            .map(|meta| opencode_meta_signature(&meta))
+            .expect("target signature");
+
+    conn.execute(
+        "INSERT INTO session (
+            id, title, directory, model, tokens_input, tokens_output,
+            tokens_reasoning, tokens_cache_read, tokens_cache_write,
+            time_created, time_updated, time_archived
+         ) VALUES ('ses_other', 'Other', '/tmp/other', 'gpt-5', 0, 0, 0, 0, 0, 1, 2, NULL)",
+        [],
+    )
+    .expect("insert unrelated session");
+    conn.execute(
+        "INSERT INTO message (id, session_id, data)
+         VALUES ('msg_other', 'ses_other', '{\"role\":\"assistant\"}')",
+        [],
+    )
+    .expect("insert unrelated message");
+    conn.execute(
+        "INSERT INTO part (id, message_id, session_id, data, time_created)
+         VALUES ('prt_other', 'msg_other', 'ses_other', '{\"type\":\"text\",\"text\":\"tail\"}', 3)",
+        [],
+    )
+    .expect("insert unrelated part");
+    conn.execute(
+        "UPDATE part SET data = '{\"type\":\"text\",\"text\":\"longer unrelated tail\"}'
+         WHERE id = 'prt_other'",
+        [],
+    )
+    .expect("grow unrelated part");
+
+    let after_unrelated =
+        list_all_opencode_session_meta_from_conn(&conn, std::path::Path::new("/tmp/opencode.db"))
+            .expect("metadata after unrelated write")
+            .into_iter()
+            .find(|meta| meta.source_session_id == "ses_1")
+            .map(|meta| opencode_meta_signature(&meta))
+            .expect("target signature after unrelated write");
+    assert!(imported_cache::record_matches_cached_signature(
+        &before,
+        &after_unrelated
+    ));
+
+    conn.execute(
+        "UPDATE part SET data = data || ' target growth' WHERE id = 'prt_text'",
+        [],
+    )
+    .expect("grow target part");
+    let after_target =
+        list_all_opencode_session_meta_from_conn(&conn, std::path::Path::new("/tmp/opencode.db"))
+            .expect("metadata after target write")
+            .into_iter()
+            .find(|meta| meta.source_session_id == "ses_1")
+            .map(|meta| opencode_meta_signature(&meta))
+            .expect("target signature after target write");
+    assert!(!imported_cache::record_matches_cached_signature(
+        &before,
+        &after_target
+    ));
+}
+
+#[test]
 fn opencode_recent_paths_use_all_sessions_before_limiting() {
     let conn = fixture_conn();
     conn.execute(
@@ -240,7 +305,7 @@ fn opencode_recent_paths_use_all_sessions_before_limiting() {
     )
     .expect("insert newer session");
 
-    let rows = list_all_opencode_session_meta_from_conn(&conn, std::path::Path::new(""), 0, 0)
+    let rows = list_all_opencode_session_meta_from_conn(&conn, std::path::Path::new(""))
         .expect("list all sessions")
         .into_iter()
         .map(|meta| session_meta_to_cache_input(meta, &HashSet::new(), &HashSet::new()))
@@ -436,13 +501,9 @@ fn maps_opencode_parent_id_to_parent_session_id() {
     )
     .expect("insert child session");
 
-    let metas = list_all_opencode_session_meta_from_conn(
-        &conn,
-        std::path::Path::new("/tmp/opencode.db"),
-        0,
-        0,
-    )
-    .expect("list sessions");
+    let metas =
+        list_all_opencode_session_meta_from_conn(&conn, std::path::Path::new("/tmp/opencode.db"))
+            .expect("list sessions");
 
     let container_parent_ids = container_parent_ids_from_metas(&metas);
 
@@ -510,13 +571,9 @@ fn reads_managed_opencode_source_session_ids_from_code_sessions() {
 #[test]
 fn managed_opencode_source_session_is_hidden_but_preserved() {
     let conn = fixture_conn();
-    let metas = list_all_opencode_session_meta_from_conn(
-        &conn,
-        std::path::Path::new("/tmp/opencode.db"),
-        0,
-        0,
-    )
-    .expect("list sessions");
+    let metas =
+        list_all_opencode_session_meta_from_conn(&conn, std::path::Path::new("/tmp/opencode.db"))
+            .expect("list sessions");
     let managed_source_session_ids = ["ses_1".to_string()].into_iter().collect::<HashSet<_>>();
     let inputs = metas
         .into_iter()
@@ -533,13 +590,9 @@ fn managed_opencode_source_session_is_hidden_but_preserved() {
 #[test]
 fn external_unmanaged_opencode_source_session_stays_listable() {
     let conn = fixture_conn();
-    let metas = list_all_opencode_session_meta_from_conn(
-        &conn,
-        std::path::Path::new("/tmp/opencode.db"),
-        0,
-        0,
-    )
-    .expect("list sessions");
+    let metas =
+        list_all_opencode_session_meta_from_conn(&conn, std::path::Path::new("/tmp/opencode.db"))
+            .expect("list sessions");
     let inputs = metas
         .into_iter()
         .map(|meta| session_meta_to_cache_input(meta, &HashSet::new(), &HashSet::new()))
@@ -571,13 +624,9 @@ fn ignores_missing_parent_id_so_orphan_history_stays_visible() {
     )
     .expect("insert orphan session");
 
-    let metas = list_all_opencode_session_meta_from_conn(
-        &conn,
-        std::path::Path::new("/tmp/opencode.db"),
-        0,
-        0,
-    )
-    .expect("list sessions");
+    let metas =
+        list_all_opencode_session_meta_from_conn(&conn, std::path::Path::new("/tmp/opencode.db"))
+            .expect("list sessions");
     let container_parent_ids = container_parent_ids_from_metas(&metas);
     let orphan = metas
         .into_iter()
@@ -610,13 +659,9 @@ fn ignores_self_parent_id() {
     )
     .expect("insert self-parent session");
 
-    let metas = list_all_opencode_session_meta_from_conn(
-        &conn,
-        std::path::Path::new("/tmp/opencode.db"),
-        0,
-        0,
-    )
-    .expect("list sessions");
+    let metas =
+        list_all_opencode_session_meta_from_conn(&conn, std::path::Path::new("/tmp/opencode.db"))
+            .expect("list sessions");
     let container_parent_ids = container_parent_ids_from_metas(&metas);
     let self_parent = metas
         .into_iter()
@@ -654,13 +699,9 @@ fn ignores_mutual_parent_cycle() {
         .expect("insert cycle session");
     }
 
-    let metas = list_all_opencode_session_meta_from_conn(
-        &conn,
-        std::path::Path::new("/tmp/opencode.db"),
-        0,
-        0,
-    )
-    .expect("list sessions");
+    let metas =
+        list_all_opencode_session_meta_from_conn(&conn, std::path::Path::new("/tmp/opencode.db"))
+            .expect("list sessions");
     let container_parent_ids = container_parent_ids_from_metas(&metas);
     let inputs = metas
         .into_iter()

--- a/src-tauri/crates/orgtrack-core/src/sources/zcode/history/sync.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/zcode/history/sync.rs
@@ -12,10 +12,7 @@ pub(super) fn sync_zcode_history_cache(cache_conn: &mut Connection) -> Result<()
         )?;
         return Ok(());
     };
-    let (source_mtime_ms, source_size_bytes) =
-        imported_paths::file_metadata_signature(&db_path, "ZCode")?;
-    let metas =
-        list_all_zcode_session_meta_from_conn(&conn, &db_path, source_mtime_ms, source_size_bytes)?;
+    let metas = list_all_zcode_session_meta_from_conn(&conn, &db_path)?;
     let live_ids = metas
         .iter()
         .map(|meta| meta.source_session_id.clone())
@@ -42,7 +39,7 @@ pub(super) fn sync_zcode_history_cache(cache_conn: &mut Connection) -> Result<()
     imported_cache::sync_source_cache_from_conn(cache_conn, SOURCE_ZCODE, live_ids, inputs)
 }
 
-fn zcode_meta_signature(meta: &ZCodeSessionMeta) -> ImportedHistoryRecordSignature {
+pub(super) fn zcode_meta_signature(meta: &ZCodeSessionMeta) -> ImportedHistoryRecordSignature {
     ImportedHistoryRecordSignature {
         source_session_id: meta.source_session_id.clone(),
         source_path: meta.source_path.clone(),
@@ -56,8 +53,6 @@ fn zcode_meta_signature(meta: &ZCodeSessionMeta) -> ImportedHistoryRecordSignatu
 pub(super) fn list_all_zcode_session_meta_from_conn(
     conn: &Connection,
     db_path: &Path,
-    source_mtime_ms: i64,
-    source_size_bytes: i64,
 ) -> Result<Vec<ZCodeSessionMeta>, String> {
     // Tokens live in `turn_usage` (not on the session row): input folds in the
     // cache read/creation tokens, output folds in reasoning — mirroring how the
@@ -115,30 +110,31 @@ pub(super) fn list_all_zcode_session_meta_from_conn(
         })
         .map_err(|err| format!("Failed to query ZCode sessions: {err}"))?;
 
-    // A single `db.sqlite` backs every session, so fold its WAL/`-shm` sidecars
-    // into each session's fingerprint once.
-    let sidecar_signature = imported_paths::sqlite_sidecar_signature(db_path);
+    let activity_signatures =
+        imported_paths::sqlite_all_session_activity_signatures_from_conn(conn, "ZCode")?;
     let mut sessions = Vec::new();
     for row in rows {
         let mut meta = row.map_err(|err| format!("Failed to read ZCode session row: {err}"))?;
         if meta.source_session_id.trim().is_empty() {
             continue;
         }
+        let (activity_time, activity_fold) = activity_signatures
+            .get(&meta.source_session_id)
+            .copied()
+            .unwrap_or((meta.time_updated.max(meta.time_created), 0));
         meta.source_path = db_path.to_string_lossy().to_string();
         meta.source_record_key = meta.source_session_id.clone();
-        meta.source_mtime_ms = source_mtime_ms;
-        meta.source_size_bytes = source_size_bytes;
-        meta.source_fingerprint = zcode_source_fingerprint(&meta, &sidecar_signature);
+        meta.source_mtime_ms = activity_time;
+        meta.source_size_bytes = activity_fold as i64;
+        meta.source_fingerprint = zcode_source_fingerprint(&meta);
         sessions.push(meta);
     }
     Ok(sessions)
 }
 
-/// Content-aware change fingerprint for a ZCode session. The `db.sqlite` mtime
-/// alone can stay flat across a same-mtime rewrite, so this folds the session's
-/// own identity/title/timestamp/token/parent fields together with the shared
-/// WAL/`-shm` sidecar signature.
-fn zcode_source_fingerprint(meta: &ZCodeSessionMeta, sidecar_signature: &str) -> String {
+/// Content-aware fingerprint containing only fields owned by this ZCode
+/// session. Transcript activity rides in the session-local mtime/size fields.
+fn zcode_source_fingerprint(meta: &ZCodeSessionMeta) -> String {
     [
         meta.source_session_id.as_str(),
         meta.title.as_str(),
@@ -148,7 +144,6 @@ fn zcode_source_fingerprint(meta: &ZCodeSessionMeta, sidecar_signature: &str) ->
         &meta.input_tokens.to_string(),
         &meta.output_tokens.to_string(),
         meta.parent_id.as_deref().unwrap_or_default(),
-        sidecar_signature,
     ]
     .join("|")
 }

--- a/src-tauri/crates/orgtrack-core/src/sources/zcode/history_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/zcode/history_tests.rs
@@ -164,13 +164,9 @@ fn includes_zcode_cli_db_path() {
 #[test]
 fn maps_zcode_session_metadata_to_cache_input() {
     let conn = fixture_conn();
-    let metas = list_all_zcode_session_meta_from_conn(
-        &conn,
-        std::path::Path::new("/tmp/db.sqlite"),
-        1770000006000,
-        4096,
-    )
-    .expect("list session metadata");
+    let metas =
+        list_all_zcode_session_meta_from_conn(&conn, std::path::Path::new("/tmp/db.sqlite"))
+            .expect("list session metadata");
     assert_eq!(metas.len(), 1);
     let row = to_row(&session_meta_to_cache_input(
         metas.into_iter().next().unwrap(),
@@ -184,6 +180,74 @@ fn maps_zcode_session_metadata_to_cache_input() {
     assert_eq!(row.total_tokens, 235);
     assert_eq!(row.repo_path.as_deref(), Some("/tmp/zcode-repo"));
     assert_eq!(row.repo_name.as_deref(), Some("zcode-repo"));
+}
+
+#[test]
+fn zcode_metadata_signature_ignores_unrelated_session_writes() {
+    let conn = fixture_conn();
+    let before =
+        list_all_zcode_session_meta_from_conn(&conn, std::path::Path::new("/tmp/db.sqlite"))
+            .expect("initial metadata")
+            .into_iter()
+            .find(|meta| meta.source_session_id == "sess_1")
+            .map(|meta| zcode_meta_signature(&meta))
+            .expect("target signature");
+
+    conn.execute(
+        "INSERT INTO session (
+            id, title, directory, parent_id, task_type,
+            time_created, time_updated, time_archived
+         ) VALUES ('sess_other', 'Other', '/tmp/other', NULL, 'interactive', 1, 2, NULL)",
+        [],
+    )
+    .expect("insert unrelated session");
+    conn.execute(
+        "INSERT INTO message (id, session_id, data)
+         VALUES ('msg_other', 'sess_other', '{\"role\":\"assistant\"}')",
+        [],
+    )
+    .expect("insert unrelated message");
+    conn.execute(
+        "INSERT INTO part (id, message_id, session_id, data, time_created)
+         VALUES ('prt_other', 'msg_other', 'sess_other', '{\"type\":\"text\",\"text\":\"tail\"}', 3)",
+        [],
+    )
+    .expect("insert unrelated part");
+    conn.execute(
+        "UPDATE part SET data = '{\"type\":\"text\",\"text\":\"longer unrelated tail\"}'
+         WHERE id = 'prt_other'",
+        [],
+    )
+    .expect("grow unrelated part");
+
+    let after_unrelated =
+        list_all_zcode_session_meta_from_conn(&conn, std::path::Path::new("/tmp/db.sqlite"))
+            .expect("metadata after unrelated write")
+            .into_iter()
+            .find(|meta| meta.source_session_id == "sess_1")
+            .map(|meta| zcode_meta_signature(&meta))
+            .expect("target signature after unrelated write");
+    assert!(imported_cache::record_matches_cached_signature(
+        &before,
+        &after_unrelated
+    ));
+
+    conn.execute(
+        "UPDATE part SET data = data || ' target growth' WHERE id = 'prt_text'",
+        [],
+    )
+    .expect("grow target part");
+    let after_target =
+        list_all_zcode_session_meta_from_conn(&conn, std::path::Path::new("/tmp/db.sqlite"))
+            .expect("metadata after target write")
+            .into_iter()
+            .find(|meta| meta.source_session_id == "sess_1")
+            .map(|meta| zcode_meta_signature(&meta))
+            .expect("target signature after target write");
+    assert!(!imported_cache::record_matches_cached_signature(
+        &before,
+        &after_target
+    ));
 }
 
 #[test]
@@ -224,7 +288,7 @@ fn subagent_child_is_hidden_and_linked_to_parent() {
     .expect("insert subagent session");
 
     let inputs: Vec<ImportedHistoryCacheInput> =
-        list_all_zcode_session_meta_from_conn(&conn, std::path::Path::new("/tmp/db.sqlite"), 0, 0)
+        list_all_zcode_session_meta_from_conn(&conn, std::path::Path::new("/tmp/db.sqlite"))
             .expect("list sessions")
             .into_iter()
             .map(session_meta_to_cache_input)

--- a/src-tauri/crates/orgtrack-core/src/usage_dashboard/daily_rollup.rs
+++ b/src-tauri/crates/orgtrack-core/src/usage_dashboard/daily_rollup.rs
@@ -13,15 +13,11 @@
 //! where every member reports UTC days so team aggregation is
 //! timezone-consistent.
 //!
-//! Unlike the interactive dashboard reads, this runs unattended on a
-//! scheduler (up to every ~15 minutes) behind the shared single-permit query
-//! semaphore, so it uses [`visit_rounds_windowed`] instead of plain
-//! `visit_rounds`: the native per-turn fetch pushes this call's `[start_ms,
-//! end_ms]` window down to SQL rather than pulling every native turn ever
-//! recorded through the app layer on every tick. This is safe here (but not
-//! for the request-log/session-table reads) because this rollup never reads
-//! `UsageRoundRow::round_id`, whose numbering the windowed fetch does not
-//! preserve — see [`visit_rounds_windowed`]'s doc comment.
+//! This runs unattended on a scheduler (up to every ~15 minutes) behind the
+//! shared single-permit query semaphore. Its compatibility entry point,
+//! [`visit_rounds_windowed`], shares the same source/session/time SQL pushdown
+//! as interactive reads; stable database row/sequence ids keep window changes
+//! from renumbering request-log rows.
 
 use std::collections::{BTreeMap, HashSet};
 

--- a/src-tauri/crates/orgtrack-core/src/usage_dashboard/rounds.rs
+++ b/src-tauri/crates/orgtrack-core/src/usage_dashboard/rounds.rs
@@ -14,8 +14,11 @@ use crate::pricing;
 
 use super::{fetch_scoped_sessions, iso_to_ms, ScopedSession, UsageFilter};
 
-/// A native per-turn token row, pulled once and filtered in Rust.
+const SCOPED_SESSION_TABLE: &str = "usage_dashboard_scoped_session";
+
+/// A native per-turn token row selected inside the dashboard's scope/window.
 struct NativeTurn {
+    row_id: i64,
     session_id: String,
     created_at: String,
     model: Option<String>,
@@ -25,24 +28,110 @@ struct NativeTurn {
     cache_write_tokens: i64,
 }
 
-fn fetch_native_turns(conn: &Connection) -> Result<Vec<NativeTurn>, String> {
-    let mut statement = conn
-        .prepare(
-            "SELECT session_id, created_at, model,
-                    input_tokens, output_tokens, cache_read_tokens, cache_write_tokens
-             FROM session_token_usage",
-        )
+struct ScopedSessionTableGuard<'a> {
+    conn: &'a Connection,
+}
+
+impl Drop for ScopedSessionTableGuard<'_> {
+    fn drop(&mut self) {
+        let _ = self
+            .conn
+            .execute(&format!("DELETE FROM {SCOPED_SESSION_TABLE}"), []);
+    }
+}
+
+/// Materialize only the already bucket/session-scoped ids. Both imported and
+/// native round queries join this tiny temp table, so source filters are applied
+/// before token rows cross the SQLite/Rust boundary.
+fn prepare_scoped_session_table<'a>(
+    conn: &'a Connection,
+    sessions: &[ScopedSession],
+) -> Result<ScopedSessionTableGuard<'a>, String> {
+    conn.execute_batch(&format!(
+        "CREATE TEMP TABLE IF NOT EXISTS {SCOPED_SESSION_TABLE} (
+            session_id TEXT PRIMARY KEY,
+            is_native INTEGER NOT NULL
+         ) WITHOUT ROWID;
+         DELETE FROM {SCOPED_SESSION_TABLE};
+         SAVEPOINT usage_dashboard_scoped_session_load;"
+    ))
+    .map_err(|err| err.to_string())?;
+
+    let load_result = (|| {
+        let mut insert = conn
+            .prepare(&format!(
+                "INSERT INTO {SCOPED_SESSION_TABLE} (session_id, is_native)
+                 VALUES (?1, ?2)"
+            ))
+            .map_err(|err| err.to_string())?;
+        for session in sessions {
+            insert
+                .execute(rusqlite::params![
+                    session.session_id,
+                    i64::from(session.tokens_source == crate::session_usage::TOKENS_SOURCE_NATIVE)
+                ])
+                .map_err(|err| err.to_string())?;
+        }
+        Ok::<(), String>(())
+    })();
+
+    if let Err(err) = load_result {
+        let _ = conn.execute_batch(
+            "ROLLBACK TO usage_dashboard_scoped_session_load;
+             RELEASE usage_dashboard_scoped_session_load;",
+        );
+        let _ = conn.execute(&format!("DELETE FROM {SCOPED_SESSION_TABLE}"), []);
+        return Err(err);
+    }
+    conn.execute_batch("RELEASE usage_dashboard_scoped_session_load;")
         .map_err(|err| err.to_string())?;
+    Ok(ScopedSessionTableGuard { conn })
+}
+
+fn native_turn_query(filter: &UsageFilter) -> (String, Vec<String>) {
+    let mut clauses = vec!["scoped.is_native = 1".to_string()];
+    let mut params = Vec::new();
+    if let Some(start) = filter.start_ms.and_then(rfc3339_ms_bound) {
+        params.push(start);
+        clauses.push(format!("stu.created_at >= ?{}", params.len()));
+    }
+    if let Some(end) = filter
+        .end_ms
+        .and_then(|end| rfc3339_ms_bound(end.saturating_add(1)))
+    {
+        params.push(end);
+        clauses.push(format!("stu.created_at < ?{}", params.len()));
+    }
+    (
+        format!(
+            "SELECT stu.id, stu.session_id, stu.created_at, stu.model,
+                    stu.input_tokens, stu.output_tokens,
+                    stu.cache_read_tokens, stu.cache_write_tokens
+             FROM session_token_usage stu
+             INNER JOIN {SCOPED_SESSION_TABLE} scoped
+                     ON scoped.session_id = stu.session_id
+             WHERE {}
+             ORDER BY stu.session_id, stu.created_at, stu.id",
+            clauses.join(" AND ")
+        ),
+        params,
+    )
+}
+
+fn fetch_native_turns(conn: &Connection, filter: &UsageFilter) -> Result<Vec<NativeTurn>, String> {
+    let (sql, params) = native_turn_query(filter);
+    let mut statement = conn.prepare(&sql).map_err(|err| err.to_string())?;
     let rows = statement
-        .query_map([], |row| {
+        .query_map(rusqlite::params_from_iter(params), |row| {
             Ok(NativeTurn {
-                session_id: row.get(0)?,
-                created_at: row.get(1)?,
-                model: row.get(2)?,
-                input_tokens: row.get(3)?,
-                output_tokens: row.get(4)?,
-                cache_read_tokens: row.get(5)?,
-                cache_write_tokens: row.get(6)?,
+                row_id: row.get(0)?,
+                session_id: row.get(1)?,
+                created_at: row.get(2)?,
+                model: row.get(3)?,
+                input_tokens: row.get(4)?,
+                output_tokens: row.get(5)?,
+                cache_read_tokens: row.get(6)?,
+                cache_write_tokens: row.get(7)?,
             })
         })
         .map_err(|err| err.to_string())?;
@@ -56,68 +145,10 @@ fn fetch_native_turns(conn: &Connection) -> Result<Vec<NativeTurn>, String> {
 /// fixed `+00:00` offset and chrono's `AutoSi` fractional-second precision
 /// (the fewest digits that represent the value exactly). Comparing strings in
 /// that same format sorts identically to comparing the underlying instants,
-/// which is what lets [`fetch_native_turns_in_window`] push a time bound into
-/// SQL instead of pulling every row through the app layer to filter in Rust.
+/// which lets [`fetch_native_turns`] push a time bound into SQL instead of
+/// pulling every row through the app layer to filter in Rust.
 fn rfc3339_ms_bound(ms: i64) -> Option<String> {
     DateTime::<Utc>::from_timestamp_millis(ms).map(|dt| dt.to_rfc3339())
-}
-
-/// Windowed variant of [`fetch_native_turns`]: pushes an inclusive
-/// `[start_ms, end_ms]` bound down to SQL instead of fetching every native
-/// turn ever recorded. Used only by the unattended `daily_rollup` cadence
-/// (see `daily_rollup.rs` / [`super::visit_rounds_windowed`]) — full history
-/// can span months, and re-pulling all of it through row mapping + timestamp
-/// parsing on every ~15-minute tick is the "full-table rescan" this exists to
-/// avoid.
-///
-/// `iso_to_ms` floors sub-millisecond precision (`timestamp_millis()`
-/// truncates toward zero), so the Rust-side inclusive filter's bounds are
-/// asymmetric once translated to the underlying (unfloored) instant:
-/// `floor(x) >= start_ms` holds exactly when `x >= start_ms` (flooring an
-/// integer lower bound doesn't move it), but `floor(x) <= end_ms` holds
-/// exactly when `x < end_ms + 1ms` (a row landing in the SAME millisecond as
-/// `end_ms` with extra sub-ms precision must still be included). Getting the
-/// upper bound wrong here would silently drop rows at the trailing edge of
-/// every rollup window; `daily_rollup_native_window_pushdown_matches_
-/// unwindowed_rust_filter` in `tests.rs` pins exactly this case.
-///
-/// Falls back to the unwindowed [`fetch_native_turns`] if either bound
-/// can't be represented as a valid instant (out-of-range milliseconds), so a
-/// pathological input degrades to the always-correct full scan instead of
-/// silently skipping rows.
-fn fetch_native_turns_in_window(
-    conn: &Connection,
-    start_ms: i64,
-    end_ms: i64,
-) -> Result<Vec<NativeTurn>, String> {
-    let bounds = rfc3339_ms_bound(start_ms).zip(rfc3339_ms_bound(end_ms.saturating_add(1)));
-    let Some((lower, upper)) = bounds else {
-        return fetch_native_turns(conn);
-    };
-
-    let mut statement = conn
-        .prepare(
-            "SELECT session_id, created_at, model,
-                    input_tokens, output_tokens, cache_read_tokens, cache_write_tokens
-             FROM session_token_usage
-             WHERE created_at >= ?1 AND created_at < ?2",
-        )
-        .map_err(|err| err.to_string())?;
-    let rows = statement
-        .query_map(rusqlite::params![lower, upper], |row| {
-            Ok(NativeTurn {
-                session_id: row.get(0)?,
-                created_at: row.get(1)?,
-                model: row.get(2)?,
-                input_tokens: row.get(3)?,
-                output_tokens: row.get(4)?,
-                cache_read_tokens: row.get(5)?,
-                cache_write_tokens: row.get(6)?,
-            })
-        })
-        .map_err(|err| err.to_string())?;
-    rows.collect::<rusqlite::Result<Vec<_>>>()
-        .map_err(|err| err.to_string())
 }
 
 /// List-price cost for a token split at a model's rates.
@@ -141,7 +172,7 @@ fn turn_cost(
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UsageRoundRow {
-    /// `session_id#index` — stable within a fetch.
+    /// `session_id#stable_database_row_or_sequence_id`.
     pub round_id: String,
     pub session_id: String,
     pub session_name: String,
@@ -172,7 +203,7 @@ fn table_exists(conn: &Connection, name: &str) -> bool {
 #[allow(clippy::too_many_arguments)]
 fn build_round_row(
     session: &ScopedSession,
-    index: usize,
+    stable_key: i64,
     model: Option<String>,
     input: i64,
     output: i64,
@@ -183,7 +214,7 @@ fn build_round_row(
     let model = model.or_else(|| session.model.clone());
     let cost = turn_cost(model.as_deref(), input, output, cache_write, cache_read);
     UsageRoundRow {
-        round_id: format!("{}#{index}", session.session_id),
+        round_id: format!("{}#{stable_key}", session.session_id),
         session_id: session.session_id.clone(),
         session_name: session.name.clone(),
         bucket: session.bucket.clone(),
@@ -212,39 +243,31 @@ pub(super) fn visit_rounds(
     filter: &UsageFilter,
     visit: impl FnMut(UsageRoundRow) -> Result<(), String>,
 ) -> Result<(), String> {
-    visit_rounds_inner(conn, filter, false, visit)
+    visit_rounds_inner(conn, filter, visit)
 }
 
-/// Same streamed pass as [`visit_rounds`], but pushes the native per-turn
-/// fetch's time window down to SQL (see [`fetch_native_turns_in_window`])
-/// instead of pulling every native turn ever recorded on every call.
-///
-/// This is NOT a drop-in replacement for [`visit_rounds`]: windowing changes
-/// how many turns precede a given row within a session, which would change
-/// `UsageRoundRow::round_id` (`session_id#index`) numbering versus the
-/// unwindowed pass. That's harmless for `daily_rollup` — its aggregation
-/// folds by `(day, bucket)` and never reads `round_id` — but would break
-/// request-log pagination stability for the interactive dashboard, so only
-/// `daily_rollup` (`daily_rollup.rs`) calls this; every other caller keeps
-/// using plain [`visit_rounds`] unchanged.
+/// Compatibility entry point for the unattended rollup. Every dashboard read
+/// now applies its available time/source/session scope in SQL; stable native
+/// row ids and imported sequence ids keep request-log ids independent of the
+/// chosen window.
 pub(super) fn visit_rounds_windowed(
     conn: &Connection,
     filter: &UsageFilter,
     visit: impl FnMut(UsageRoundRow) -> Result<(), String>,
 ) -> Result<(), String> {
-    visit_rounds_inner(conn, filter, true, visit)
+    visit_rounds_inner(conn, filter, visit)
 }
 
 fn visit_rounds_inner(
     conn: &Connection,
     filter: &UsageFilter,
-    push_down_native_window: bool,
     mut visit: impl FnMut(UsageRoundRow) -> Result<(), String>,
 ) -> Result<(), String> {
     let mut sessions = fetch_scoped_sessions(conn, filter.bucket.as_deref(), filter.all_sources)?;
     if let Some(session_id) = filter.session_id.as_deref() {
         sessions.retain(|session| session.session_id == session_id);
     }
+    let _scoped_session_table = prepare_scoped_session_table(conn, &sessions)?;
 
     let session_indexes: HashMap<String, usize> = sessions
         .iter()
@@ -256,11 +279,11 @@ fn visit_rounds_inner(
         let mut clauses: Vec<String> = Vec::new();
         let mut params: Vec<i64> = Vec::new();
         if let Some(start) = filter.start_ms {
-            clauses.push(format!("created_at_ms >= ?{}", params.len() + 1));
+            clauses.push(format!("rounds.created_at_ms >= ?{}", params.len() + 1));
             params.push(start);
         }
         if let Some(end) = filter.end_ms {
-            clauses.push(format!("created_at_ms <= ?{}", params.len() + 1));
+            clauses.push(format!("rounds.created_at_ms <= ?{}", params.len() + 1));
             params.push(end);
         }
         let where_sql = if clauses.is_empty() {
@@ -269,26 +292,24 @@ fn visit_rounds_inner(
             format!(" WHERE {}", clauses.join(" AND "))
         };
         let sql = format!(
-            "SELECT session_id, model, input_tokens, output_tokens,
-                    cache_read_tokens, cache_write_tokens, created_at_ms
-             FROM imported_history_round_usage{where_sql}
-             ORDER BY session_id, created_at_ms, seq"
+            "SELECT rounds.session_id, rounds.model,
+                    rounds.input_tokens, rounds.output_tokens,
+                    rounds.cache_read_tokens, rounds.cache_write_tokens,
+                    rounds.created_at_ms, rounds.seq
+             FROM imported_history_round_usage rounds
+             INNER JOIN {SCOPED_SESSION_TABLE} scoped
+                     ON scoped.session_id = rounds.session_id{where_sql}
+             ORDER BY rounds.session_id, rounds.created_at_ms, rounds.seq"
         );
         let mut statement = conn.prepare(&sql).map_err(|err| err.to_string())?;
         let mut rows = statement
             .query(rusqlite::params_from_iter(params))
             .map_err(|err| err.to_string())?;
-        let mut current_session_id = String::new();
-        let mut current_index = 0usize;
         while let Some(row) = rows.next().map_err(|err| err.to_string())? {
             let session_id: String = row.get(0).map_err(|err| err.to_string())?;
             let Some(&session_index) = session_indexes.get(&session_id) else {
                 continue;
             };
-            if current_session_id != session_id {
-                current_session_id.clone_from(&session_id);
-                current_index = 0;
-            }
             if !imported_session_ids.contains(&session_id) {
                 imported_session_ids.insert(session_id.clone());
             }
@@ -298,7 +319,7 @@ fn visit_rounds_inner(
                 .filter(|value| !value.is_empty());
             let round = build_round_row(
                 &sessions[session_index],
-                current_index,
+                row.get(7).map_err(|err| err.to_string())?,
                 model,
                 row.get(2).map_err(|err| err.to_string())?,
                 row.get(3).map_err(|err| err.to_string())?,
@@ -306,17 +327,11 @@ fn visit_rounds_inner(
                 row.get(5).map_err(|err| err.to_string())?,
                 row.get(6).map_err(|err| err.to_string())?,
             );
-            current_index += 1;
             visit(round)?;
         }
     }
 
-    let native_turns = match (push_down_native_window, filter.start_ms, filter.end_ms) {
-        (true, Some(start_ms), Some(end_ms)) => {
-            fetch_native_turns_in_window(conn, start_ms, end_ms)?
-        }
-        _ => fetch_native_turns(conn)?,
-    };
+    let native_turns = fetch_native_turns(conn, filter)?;
     let mut native_by: HashMap<String, Vec<NativeTurn>> = HashMap::new();
     for turn in native_turns {
         if !session_indexes.contains_key(&turn.session_id)
@@ -341,14 +356,14 @@ fn visit_rounds_inner(
                 .into_iter()
                 .map(|turn| (iso_to_ms(&turn.created_at).unwrap_or(0), turn))
                 .collect();
-            turns.sort_by_key(|(ms, _)| *ms);
-            for (index, (ms, turn)) in turns.into_iter().enumerate() {
+            turns.sort_by_key(|(ms, turn)| (*ms, turn.row_id));
+            for (ms, turn) in turns {
                 if !filter.contains(ms) {
                     continue;
                 }
                 visit(build_round_row(
                     session,
-                    index,
+                    turn.row_id,
                     turn.model,
                     turn.input_tokens,
                     turn.output_tokens,
@@ -376,4 +391,38 @@ fn visit_rounds_inner(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+pub(super) fn native_turn_candidates_for_filter(
+    conn: &Connection,
+    filter: &UsageFilter,
+) -> Result<usize, String> {
+    let mut sessions = fetch_scoped_sessions(conn, filter.bucket.as_deref(), filter.all_sources)?;
+    if let Some(session_id) = filter.session_id.as_deref() {
+        sessions.retain(|session| session.session_id == session_id);
+    }
+    let _scoped_session_table = prepare_scoped_session_table(conn, &sessions)?;
+    Ok(fetch_native_turns(conn, filter)?.len())
+}
+
+#[cfg(test)]
+pub(super) fn native_turn_query_plan(
+    conn: &Connection,
+    filter: &UsageFilter,
+) -> Result<Vec<String>, String> {
+    let mut sessions = fetch_scoped_sessions(conn, filter.bucket.as_deref(), filter.all_sources)?;
+    if let Some(session_id) = filter.session_id.as_deref() {
+        sessions.retain(|session| session.session_id == session_id);
+    }
+    let _scoped_session_table = prepare_scoped_session_table(conn, &sessions)?;
+    let (sql, params) = native_turn_query(filter);
+    let mut statement = conn
+        .prepare(&format!("EXPLAIN QUERY PLAN {sql}"))
+        .map_err(|err| err.to_string())?;
+    let rows = statement
+        .query_map(rusqlite::params_from_iter(params), |row| row.get(3))
+        .map_err(|err| err.to_string())?;
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(|err| err.to_string())
 }

--- a/src-tauri/crates/orgtrack-core/src/usage_dashboard/tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/usage_dashboard/tests.rs
@@ -3,10 +3,12 @@
 //! [`super::usage_overview`] streaming pass — including the mirror-exclusion
 //! and bucket/time-window invariants the module doc comment calls out.
 
+use super::rounds::{native_turn_candidates_for_filter, native_turn_query_plan};
 use super::*;
 use crate::session_usage::recompute_session_usage;
 use crate::store::sqlite::SqliteRecordStore;
 use rusqlite::params;
+use std::collections::HashSet;
 
 fn fixture_conn() -> Connection {
     let conn = Connection::open_in_memory().expect("in-memory sqlite");
@@ -43,7 +45,9 @@ fn fixture_conn() -> Connection {
             account_id TEXT,
             key_source TEXT,
             updated_at TEXT
-         );",
+         );
+         CREATE INDEX idx_stu_session_created_at_id
+             ON session_token_usage(session_id, created_at, id);",
     )
     .expect("create app-owned tables");
     conn
@@ -793,7 +797,7 @@ fn daily_rollup_skips_zero_usage_cells() {
 }
 
 #[test]
-fn daily_rollup_native_window_pushdown_matches_unwindowed_rust_filter() {
+fn native_window_pushdown_preserves_inclusive_millisecond_bounds() {
     // A fresh, minimal fixture (not `seeded_conn`) so the boundary math below
     // is easy to check by hand without other fixture rows in range.
     let conn = fixture_conn();
@@ -862,22 +866,143 @@ fn daily_rollup_native_window_pushdown_matches_unwindowed_rust_filter() {
         all_sources: true,
     };
 
-    // Reference: the pre-existing unwindowed native fetch + Rust-side
-    // `filter.contains` (what every non-rollup caller still uses).
-    let unwindowed =
-        usage_rounds(&conn, &filter, SessionSort::Recent, 0, 100).expect("unwindowed rounds");
-    assert_eq!(unwindowed.len(), 2);
+    // Interactive and unattended callers now share the SQL-pushed-down path.
+    let interactive =
+        usage_rounds(&conn, &filter, SessionSort::Recent, 0, 100).expect("interactive rounds");
+    assert_eq!(interactive.len(), 2);
     assert_eq!(
-        unwindowed.iter().map(|r| r.input_tokens).sum::<i64>(),
+        interactive.iter().map(|r| r.input_tokens).sum::<i64>(),
         222 + 333
     );
 
-    // The SQL-pushed-down path `daily_rollup` exercises must agree exactly.
+    // The daily rollup must retain the same inclusive millisecond semantics.
     let rollup = usage_daily_rollup(&conn, boundary_ms, boundary_ms).expect("daily rollup");
     assert_eq!(rollup.days.len(), 1);
     assert_eq!(rollup.days[0].bucket, "claude");
     assert_eq!(rollup.days[0].requests, 2);
     assert_eq!(rollup.days[0].input_tokens, 222 + 333);
+}
+
+#[test]
+fn interactive_native_query_loads_only_windowed_scoped_rows_and_uses_stable_ids() {
+    let conn = fixture_conn();
+    insert_code_session(
+        &conn,
+        "windowed-claude",
+        "claude",
+        "Windowed Claude",
+        "2026-07-18T02:00:00+00:00",
+    );
+    conn.execute(
+        "INSERT INTO agent_sessions
+            (session_id, name, model, account_id, key_source, updated_at)
+         VALUES
+            ('windowed-org2', 'Windowed Org2', 'gpt-5', 'acct-1', 'own_key',
+             '2026-07-18T02:00:00+00:00')",
+        [],
+    )
+    .expect("insert out-of-source session");
+
+    // Large lifetime tail for the in-scope session. The old interactive path
+    // mapped every one of these rows before dropping them in Rust.
+    for index in 0..1_000 {
+        insert_turn(
+            &conn,
+            "windowed-claude",
+            "claude-sonnet-4-5",
+            (index + 1, 0, 0, 0),
+            "2025-01-01T00:00:00+00:00",
+        );
+    }
+    insert_turn(
+        &conn,
+        "windowed-claude",
+        "claude-sonnet-4-5",
+        (2_001, 0, 0, 0),
+        "2026-07-18T02:00:00+00:00",
+    );
+    let first_target_id = conn.last_insert_rowid();
+    insert_turn(
+        &conn,
+        "windowed-claude",
+        "claude-sonnet-4-5",
+        (2_002, 0, 0, 0),
+        "2026-07-18T02:00:00.000700+00:00",
+    );
+    let second_target_id = conn.last_insert_rowid();
+    insert_turn(
+        &conn,
+        "windowed-org2",
+        "gpt-5",
+        (9_999, 0, 0, 0),
+        "2026-07-18T02:00:00+00:00",
+    );
+    recompute_session_usage(&conn, "windowed-claude")
+        .unwrap()
+        .expect("claude projected");
+    recompute_session_usage(&conn, "windowed-org2")
+        .unwrap()
+        .expect("org2 projected");
+
+    let boundary_ms = ms("2026-07-18T02:00:00Z");
+    let filter = UsageFilter {
+        bucket: Some(BUCKET_CLAUDE.to_string()),
+        start_ms: Some(boundary_ms),
+        end_ms: Some(boundary_ms),
+        session_id: None,
+        all_sources: false,
+    };
+    let lifetime_rows: i64 = conn
+        .query_row("SELECT COUNT(*) FROM session_token_usage", [], |row| {
+            row.get(0)
+        })
+        .expect("lifetime row count");
+    assert_eq!(lifetime_rows, 1_003);
+    assert_eq!(
+        native_turn_candidates_for_filter(&conn, &filter).expect("windowed candidates"),
+        2,
+        "only the two in-window Claude rows should cross into Rust"
+    );
+
+    let rows = usage_rounds(&conn, &filter, SessionSort::Recent, 0, 100).expect("windowed rounds");
+    assert_eq!(rows.len(), 2);
+    let round_ids = rows
+        .iter()
+        .map(|row| row.round_id.clone())
+        .collect::<HashSet<_>>();
+    assert_eq!(
+        round_ids,
+        HashSet::from([
+            format!("windowed-claude#{first_target_id}"),
+            format!("windowed-claude#{second_target_id}"),
+        ])
+    );
+
+    // Changing the time window must not renumber the same database rows.
+    let broad = usage_rounds(
+        &conn,
+        &UsageFilter {
+            bucket: Some(BUCKET_CLAUDE.to_string()),
+            ..UsageFilter::default()
+        },
+        SessionSort::Recent,
+        0,
+        2_000,
+    )
+    .expect("broad rounds");
+    assert!(broad
+        .iter()
+        .any(|row| row.round_id == format!("windowed-claude#{first_target_id}")));
+    assert!(broad
+        .iter()
+        .any(|row| row.round_id == format!("windowed-claude#{second_target_id}")));
+
+    let plan = native_turn_query_plan(&conn, &filter).expect("native query plan");
+    assert!(
+        plan.iter()
+            .any(|detail| detail.contains("idx_stu_session_created_at_id")),
+        "windowed native query must use the canonical scoped-window index: {plan:?}"
+    );
 }
 
 #[test]

--- a/src-tauri/crates/session-persistence/src/schema.rs
+++ b/src-tauri/crates/session-persistence/src/schema.rs
@@ -256,6 +256,15 @@ pub fn init_session_tables(conn: &Connection) -> SqliteResult<()> {
         "CREATE INDEX IF NOT EXISTS idx_stu_session_id ON session_token_usage(session_id)",
         [],
     )?;
+    // Usage dashboard windows first scope by session/source, then by time.
+    // `IF NOT EXISTS` makes this a non-destructive migration for existing DBs;
+    // one composite index keeps the new read path cheap without duplicating
+    // another full-table index on this write-heavy event table.
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_stu_session_created_at_id
+         ON session_token_usage(session_id, created_at, id)",
+        [],
+    )?;
 
     // Migration: add context_tokens column (last LLM call's prompt tokens = context fill level)
     conn.execute(
@@ -540,6 +549,7 @@ mod tests {
         assert!(index_exists(&conn, "idx_stool_session_turn"));
         assert!(index_exists(&conn, "idx_stool_session_call"));
         assert!(index_exists(&conn, "idx_stool_session_iteration"));
+        assert!(index_exists(&conn, "idx_stu_session_created_at_id"));
         assert!(column_exists(&conn, "session_turn_intents", "org_run_id"));
         assert!(index_exists(
             &conn,

--- a/src-tauri/src/orgtrack/history_commands.rs
+++ b/src-tauri/src/orgtrack/history_commands.rs
@@ -27,20 +27,18 @@ use orgtrack_core::sources::zcode::history as zcode_history;
 use session_persistence::CachedTurnSummary;
 
 use super::external_cli_detection::{self, ExternalCliSourceProbe};
+use super::history_scan_coordinator::{
+    ExternalHistoryScanCoordinator, ExternalHistoryScanJob, ExternalHistoryScanMode,
+    ExternalHistorySourceScanOutcome, ExternalHistorySourceScanResult,
+};
 
 fn open_cache_conn() -> Result<rusqlite::Connection, String> {
     get_connection().map_err(|err| format!("Failed to open orgtrack source cache DB: {err}"))
 }
 
-static EXTERNAL_HISTORY_SCAN_QUEUE: OnceLock<tokio::sync::Semaphore> = OnceLock::new();
-
-async fn acquire_external_history_scan_permit(
-) -> Result<tokio::sync::SemaphorePermit<'static>, String> {
-    EXTERNAL_HISTORY_SCAN_QUEUE
-        .get_or_init(|| tokio::sync::Semaphore::new(1))
-        .acquire()
-        .await
-        .map_err(|_| "External history scan queue closed".to_string())
+fn external_history_scan_coordinator() -> &'static ExternalHistoryScanCoordinator {
+    static COORDINATOR: OnceLock<ExternalHistoryScanCoordinator> = OnceLock::new();
+    COORDINATOR.get_or_init(ExternalHistoryScanCoordinator::default)
 }
 
 const IMPORTED_TURN_PROJECTION_CACHE_CAPACITY: usize = 8;
@@ -442,13 +440,123 @@ fn imported_recent_paths() -> Result<Vec<imported_history::ImportedHistoryRecent
 pub struct ExternalHistoryScanResultWire {
     pub changed_sources: Vec<String>,
     /// Whole-source cache signatures for every rescanned source, changed or
-    /// not. `changed_sources` only reports writes made by THIS call; other
-    /// surfaces (kanban, usage, transcript pagers) sync the same cache
-    /// between scheduler ticks, and continuation demotions applied during
-    /// those foreign syncs would otherwise never look like a change here.
-    /// The frontend compares these against the signatures captured at its
-    /// last roster reload to decide whether the sidebar is stale.
+    /// not. Concurrent callers for the same source share one scan flight and
+    /// therefore receive the same change result. Other surfaces (kanban,
+    /// usage, transcript pagers) sync the same cache between scheduler ticks,
+    /// and continuation demotions applied during those foreign syncs would
+    /// otherwise never look like a change here. The frontend compares these
+    /// against the signatures captured at its last roster reload to decide
+    /// whether the sidebar is stale.
     pub source_signatures: std::collections::HashMap<String, String>,
+}
+
+fn external_history_scan_mode(clear: bool) -> ExternalHistoryScanMode {
+    if clear {
+        ExternalHistoryScanMode::Rebuild
+    } else {
+        ExternalHistoryScanMode::Incremental
+    }
+}
+
+fn run_external_history_scan_jobs(
+    coordinator: &ExternalHistoryScanCoordinator,
+    jobs: Vec<ExternalHistoryScanJob>,
+) -> Vec<(ExternalHistoryScanJob, ExternalHistorySourceScanOutcome)> {
+    let mut conn = match open_cache_conn() {
+        Ok(conn) => conn,
+        Err(error) => {
+            return jobs
+                .into_iter()
+                .map(|job| (job, Err(error.clone())))
+                .collect();
+        }
+    };
+
+    jobs.into_iter()
+        // A rebuild can supersede one source while an already-claimed
+        // scan-all batch is still parsing an earlier source.
+        .filter(|job| coordinator.is_current_running_job(job))
+        .map(|job| {
+            let outcome = (|| {
+                let changes_before = conn.total_changes();
+                // Rebuild is explicit: wipe this source's cached rows so all
+                // sessions are parsed again. Incremental remains the default.
+                if job.mode == ExternalHistoryScanMode::Rebuild {
+                    imported_history::cache::prune_missing_records_from_conn(
+                        &conn,
+                        &job.source,
+                        &[],
+                    )?;
+                }
+                let changed = crate::agent_sessions::session_directory::aggregation::resync_external_history_source(
+                    &mut conn,
+                    &job.source,
+                )? || conn.total_changes() > changes_before;
+                let signature =
+                    imported_history::cache::query_source_cache_signature_from_conn(
+                        &conn,
+                        &job.source,
+                    )?;
+                Ok(ExternalHistorySourceScanResult { changed, signature })
+            })();
+            (job, outcome)
+        })
+        .collect()
+}
+
+fn launch_external_history_scan_jobs(jobs: Vec<ExternalHistoryScanJob>) {
+    if jobs.is_empty() {
+        return;
+    }
+    tokio::spawn(async move {
+        let coordinator = external_history_scan_coordinator();
+        let _permit = match coordinator.acquire_permit().await {
+            Ok(permit) => permit,
+            Err(error) => {
+                coordinator.fail_current_jobs(jobs, error);
+                return;
+            }
+        };
+        let jobs = coordinator.begin_current_jobs(jobs);
+        if jobs.is_empty() {
+            return;
+        }
+        let fallback_jobs = jobs.clone();
+        let outcomes = match tokio::task::spawn_blocking(move || {
+            run_external_history_scan_jobs(coordinator, jobs)
+        })
+        .await
+        {
+            Ok(outcomes) => outcomes,
+            Err(error) => fallback_jobs
+                .into_iter()
+                .map(|job| (job, Err(format!("Task join error: {error}"))))
+                .collect(),
+        };
+        coordinator.complete_jobs(outcomes);
+    });
+}
+
+async fn external_history_rescan_validated_sources(
+    sources: Vec<String>,
+    mode: ExternalHistoryScanMode,
+) -> Result<ExternalHistoryScanResultWire, String> {
+    let schedule = external_history_scan_coordinator().schedule(sources.clone(), mode);
+    launch_external_history_scan_jobs(schedule.jobs);
+    let results = schedule.waiter.wait().await?;
+    let changed_sources = sources
+        .iter()
+        .filter(|source| results.get(*source).is_some_and(|result| result.changed))
+        .cloned()
+        .collect();
+    let source_signatures = results
+        .into_iter()
+        .map(|(source, result)| (source, result.signature))
+        .collect();
+    Ok(ExternalHistoryScanResultWire {
+        changed_sources,
+        source_signatures,
+    })
 }
 
 #[tauri::command]
@@ -459,32 +567,11 @@ pub async fn external_history_rescan_source(
     if !imported_history::metadata::is_imported_history_source(&source) {
         return Err(format!("Unknown external history source: {source}"));
     }
-    let _permit = acquire_external_history_scan_permit().await?;
-    tokio::task::spawn_blocking(move || {
-        let mut conn = open_cache_conn()?;
-        let changes_before = conn.total_changes();
-        // `clear`: wipe the source's cached rows so every session is re-parsed
-        // from scratch (drops stale rows / forces a full re-parse even when
-        // file signatures are unchanged). Otherwise this is an incremental
-        // "update" — only sessions whose signature changed are re-parsed.
-        if clear {
-            imported_history::cache::prune_missing_records_from_conn(&conn, &source, &[])?;
-        }
-        // Always re-read the on-disk store and repopulate the cache. The old
-        // behavior only pruned, leaving the count at 0 until a later lazy load.
-        let changed =
-            crate::agent_sessions::session_directory::aggregation::resync_external_history_source(
-                &mut conn, &source,
-            )? || conn.total_changes() > changes_before;
-        let signature =
-            imported_history::cache::query_source_cache_signature_from_conn(&conn, &source)?;
-        Ok(ExternalHistoryScanResultWire {
-            changed_sources: changed.then_some(source.clone()).into_iter().collect(),
-            source_signatures: std::iter::once((source, signature)).collect(),
-        })
-    })
-    .await
-    .map_err(|err| format!("Task join error: {err}"))?
+    // The normal path is signature-based incremental sync. Provider parser
+    // version changes remain part of those signatures and force the affected
+    // records to re-parse without clearing unrelated cached rows.
+    let mode = external_history_scan_mode(clear);
+    external_history_rescan_validated_sources(vec![source], mode).await
 }
 
 /// Incrementally update multiple external history sources in one IPC request.
@@ -507,34 +594,8 @@ pub async fn external_history_rescan_sources(
         }
     }
 
-    let _permit = acquire_external_history_scan_permit().await?;
-    tokio::task::spawn_blocking(move || {
-        let mut conn = open_cache_conn()?;
-        let mut changed_sources = Vec::new();
-        let mut source_signatures = std::collections::HashMap::new();
-        for source in sources {
-            let changes_before = conn.total_changes();
-            if clear {
-                imported_history::cache::prune_missing_records_from_conn(&conn, &source, &[])?;
-            }
-            let changed = crate::agent_sessions::session_directory::aggregation::resync_external_history_source(
-                &mut conn, &source,
-            )? || conn.total_changes() > changes_before;
-            source_signatures.insert(
-                source.clone(),
-                imported_history::cache::query_source_cache_signature_from_conn(&conn, &source)?,
-            );
-            if changed {
-                changed_sources.push(source);
-            }
-        }
-        Ok(ExternalHistoryScanResultWire {
-            changed_sources,
-            source_signatures,
-        })
-    })
-    .await
-    .map_err(|err| format!("Task join error: {err}"))?
+    let mode = external_history_scan_mode(clear);
+    external_history_rescan_validated_sources(sources, mode).await
 }
 
 #[tauri::command]
@@ -1367,6 +1428,18 @@ mod tests {
 
         assert_eq!(turns[0].status, "pending");
         assert!(!turns[0].interrupted);
+    }
+
+    #[test]
+    fn external_history_rebuild_requires_explicit_clear() {
+        assert_eq!(
+            external_history_scan_mode(false),
+            ExternalHistoryScanMode::Incremental
+        );
+        assert_eq!(
+            external_history_scan_mode(true),
+            ExternalHistoryScanMode::Rebuild
+        );
     }
 
     #[test]

--- a/src-tauri/src/orgtrack/history_scan_coordinator.rs
+++ b/src-tauri/src/orgtrack/history_scan_coordinator.rs
@@ -1,0 +1,423 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use tokio::sync::{watch, OwnedSemaphorePermit, Semaphore};
+
+const EXTERNAL_HISTORY_SCAN_CONCURRENCY: usize = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ExternalHistoryScanMode {
+    Incremental,
+    Rebuild,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ExternalHistorySourceScanResult {
+    pub changed: bool,
+    pub signature: String,
+}
+
+pub(super) type ExternalHistorySourceScanOutcome = Result<ExternalHistorySourceScanResult, String>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct ExternalHistoryScanJob {
+    pub source: String,
+    generation: u64,
+    pub mode: ExternalHistoryScanMode,
+}
+
+#[derive(Debug, Clone)]
+struct SourceSnapshot {
+    generation: u64,
+    mode: Option<ExternalHistoryScanMode>,
+    phase: ScanPhase,
+    outcome: Option<ExternalHistorySourceScanOutcome>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ScanPhase {
+    Queued,
+    Running,
+    Completed,
+}
+
+#[derive(Debug)]
+struct SourceState {
+    snapshot: SourceSnapshot,
+    sender: watch::Sender<SourceSnapshot>,
+}
+
+#[derive(Debug)]
+pub(super) struct ExternalHistoryScanWaiter {
+    sources: Vec<(String, watch::Receiver<SourceSnapshot>)>,
+}
+
+#[derive(Debug)]
+pub(super) struct ExternalHistoryScanSchedule {
+    pub jobs: Vec<ExternalHistoryScanJob>,
+    pub waiter: ExternalHistoryScanWaiter,
+}
+
+#[derive(Debug)]
+pub(super) struct ExternalHistoryScanCoordinator {
+    // Callers validate against the compile-time imported-source registry
+    // before scheduling, so this app-lifetime map is bounded by that registry.
+    sources: Mutex<HashMap<String, SourceState>>,
+    permits: Arc<Semaphore>,
+}
+
+impl Default for ExternalHistoryScanCoordinator {
+    fn default() -> Self {
+        Self::new(EXTERNAL_HISTORY_SCAN_CONCURRENCY)
+    }
+}
+
+impl ExternalHistoryScanCoordinator {
+    fn new(concurrency: usize) -> Self {
+        assert!(concurrency > 0, "scan concurrency must be positive");
+        Self {
+            sources: Mutex::new(HashMap::new()),
+            permits: Arc::new(Semaphore::new(concurrency)),
+        }
+    }
+
+    /// Registers one IPC request. Concurrent requests for a source share its
+    /// current flight. A rebuild supersedes an incremental generation, while
+    /// incrementals arriving during a rebuild join that rebuild.
+    pub fn schedule(
+        &self,
+        sources: Vec<String>,
+        mode: ExternalHistoryScanMode,
+    ) -> ExternalHistoryScanSchedule {
+        let mut states = self
+            .sources
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut jobs = Vec::new();
+        let mut wait_sources = Vec::with_capacity(sources.len());
+
+        for source in sources {
+            let state = states.entry(source.clone()).or_insert_with(|| {
+                let snapshot = SourceSnapshot {
+                    generation: 0,
+                    mode: None,
+                    phase: ScanPhase::Completed,
+                    outcome: None,
+                };
+                let (sender, _) = watch::channel(snapshot.clone());
+                SourceState { snapshot, sender }
+            });
+
+            let should_start = match state.snapshot.phase {
+                ScanPhase::Completed => true,
+                ScanPhase::Queued | ScanPhase::Running => {
+                    mode == ExternalHistoryScanMode::Rebuild
+                        && state.snapshot.mode == Some(ExternalHistoryScanMode::Incremental)
+                }
+            };
+
+            if should_start {
+                let generation = state
+                    .snapshot
+                    .generation
+                    .checked_add(1)
+                    .expect("external history scan generation exhausted");
+                state.snapshot = SourceSnapshot {
+                    generation,
+                    mode: Some(mode),
+                    phase: ScanPhase::Queued,
+                    outcome: None,
+                };
+                state.sender.send_replace(state.snapshot.clone());
+                jobs.push(ExternalHistoryScanJob {
+                    source: source.clone(),
+                    generation: state.snapshot.generation,
+                    mode,
+                });
+            }
+
+            wait_sources.push((source, state.sender.subscribe()));
+        }
+
+        ExternalHistoryScanSchedule {
+            jobs,
+            waiter: ExternalHistoryScanWaiter {
+                sources: wait_sources,
+            },
+        }
+    }
+
+    pub async fn acquire_permit(&self) -> Result<OwnedSemaphorePermit, String> {
+        self.permits
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| "External history scan queue closed".to_string())
+    }
+
+    /// Claims only jobs that are still current after waiting for the bounded
+    /// scan permit. Superseded queued incrementals therefore perform no I/O.
+    pub fn begin_current_jobs(
+        &self,
+        jobs: Vec<ExternalHistoryScanJob>,
+    ) -> Vec<ExternalHistoryScanJob> {
+        let mut states = self
+            .sources
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        jobs.into_iter()
+            .filter_map(|job| {
+                let state = states.get_mut(&job.source)?;
+                if state.snapshot.generation != job.generation
+                    || state.snapshot.phase != ScanPhase::Queued
+                {
+                    return None;
+                }
+                state.snapshot.phase = ScanPhase::Running;
+                state.sender.send_replace(state.snapshot.clone());
+                Some(job)
+            })
+            .collect()
+    }
+
+    pub fn is_current_running_job(&self, job: &ExternalHistoryScanJob) -> bool {
+        let states = self
+            .sources
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        states.get(&job.source).is_some_and(|state| {
+            state.snapshot.generation == job.generation
+                && state.snapshot.phase == ScanPhase::Running
+        })
+    }
+
+    /// Publishes only the matching generation. A late incremental completion
+    /// cannot satisfy waiters after a clear/rebuild has advanced the source.
+    pub fn complete_jobs(
+        &self,
+        outcomes: Vec<(ExternalHistoryScanJob, ExternalHistorySourceScanOutcome)>,
+    ) {
+        let mut states = self
+            .sources
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        for (job, outcome) in outcomes {
+            let Some(state) = states.get_mut(&job.source) else {
+                continue;
+            };
+            if state.snapshot.generation != job.generation
+                || state.snapshot.phase != ScanPhase::Running
+            {
+                continue;
+            }
+            state.snapshot.phase = ScanPhase::Completed;
+            state.snapshot.outcome = Some(outcome);
+            state.sender.send_replace(state.snapshot.clone());
+        }
+    }
+
+    pub fn fail_current_jobs(&self, jobs: Vec<ExternalHistoryScanJob>, error: String) {
+        let mut states = self
+            .sources
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        for job in jobs {
+            let Some(state) = states.get_mut(&job.source) else {
+                continue;
+            };
+            if state.snapshot.generation != job.generation {
+                continue;
+            }
+            state.snapshot.phase = ScanPhase::Completed;
+            state.snapshot.outcome = Some(Err(error.clone()));
+            state.sender.send_replace(state.snapshot.clone());
+        }
+    }
+}
+
+impl ExternalHistoryScanWaiter {
+    pub async fn wait(
+        mut self,
+    ) -> Result<HashMap<String, ExternalHistorySourceScanResult>, String> {
+        let mut results = HashMap::with_capacity(self.sources.len());
+        for (source, receiver) in &mut self.sources {
+            loop {
+                let snapshot = receiver.borrow_and_update().clone();
+                if snapshot.phase == ScanPhase::Completed {
+                    if let Some(outcome) = snapshot.outcome {
+                        results.insert(source.clone(), outcome?);
+                        break;
+                    }
+                }
+                receiver.changed().await.map_err(|_| {
+                    format!("External history scan coordinator closed for {source}")
+                })?;
+            }
+        }
+        Ok(results)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn finish(
+        coordinator: &ExternalHistoryScanCoordinator,
+        job: ExternalHistoryScanJob,
+        signature: &str,
+    ) {
+        coordinator.complete_jobs(vec![(
+            job,
+            Ok(ExternalHistorySourceScanResult {
+                changed: true,
+                signature: signature.to_string(),
+            }),
+        )]);
+    }
+
+    #[tokio::test]
+    async fn concurrent_incremental_requests_share_one_source_flight() {
+        let coordinator = ExternalHistoryScanCoordinator::new(1);
+        let first = coordinator.schedule(
+            vec!["cursor_ide".to_string()],
+            ExternalHistoryScanMode::Incremental,
+        );
+        let second = coordinator.schedule(
+            vec!["cursor_ide".to_string()],
+            ExternalHistoryScanMode::Incremental,
+        );
+
+        assert_eq!(first.jobs.len(), 1);
+        assert!(second.jobs.is_empty());
+        let mut jobs = coordinator.begin_current_jobs(first.jobs);
+        let job = jobs.pop().expect("one shared job");
+        finish(&coordinator, job, "shared");
+
+        assert_eq!(
+            first.waiter.wait().await.expect("first result")["cursor_ide"].signature,
+            "shared"
+        );
+        assert_eq!(
+            second.waiter.wait().await.expect("second result")["cursor_ide"].signature,
+            "shared"
+        );
+    }
+
+    #[test]
+    fn overlapping_scan_all_requests_only_schedule_new_sources() {
+        let coordinator = ExternalHistoryScanCoordinator::new(1);
+        let first = coordinator.schedule(
+            vec!["cursor_ide".to_string(), "codex".to_string()],
+            ExternalHistoryScanMode::Incremental,
+        );
+        let second = coordinator.schedule(
+            vec!["codex".to_string(), "claude".to_string()],
+            ExternalHistoryScanMode::Incremental,
+        );
+
+        assert_eq!(
+            first
+                .jobs
+                .iter()
+                .map(|job| job.source.as_str())
+                .collect::<Vec<_>>(),
+            vec!["cursor_ide", "codex"]
+        );
+        assert_eq!(
+            second
+                .jobs
+                .iter()
+                .map(|job| job.source.as_str())
+                .collect::<Vec<_>>(),
+            vec!["claude"]
+        );
+    }
+
+    #[tokio::test]
+    async fn incrementals_and_repeated_rebuilds_join_one_explicit_rebuild() {
+        let coordinator = ExternalHistoryScanCoordinator::new(1);
+        let rebuild = coordinator.schedule(
+            vec!["cursor_ide".to_string()],
+            ExternalHistoryScanMode::Rebuild,
+        );
+        let incremental = coordinator.schedule(
+            vec!["cursor_ide".to_string()],
+            ExternalHistoryScanMode::Incremental,
+        );
+        let repeated_rebuild = coordinator.schedule(
+            vec!["cursor_ide".to_string()],
+            ExternalHistoryScanMode::Rebuild,
+        );
+
+        assert_eq!(rebuild.jobs.len(), 1);
+        assert!(incremental.jobs.is_empty());
+        assert!(repeated_rebuild.jobs.is_empty());
+        let rebuild_job = coordinator
+            .begin_current_jobs(rebuild.jobs)
+            .pop()
+            .expect("one rebuild job");
+        finish(&coordinator, rebuild_job, "rebuilt");
+
+        assert_eq!(
+            incremental.waiter.wait().await.expect("incremental join")["cursor_ide"].signature,
+            "rebuilt"
+        );
+        assert_eq!(
+            repeated_rebuild.waiter.wait().await.expect("rebuild join")["cursor_ide"].signature,
+            "rebuilt"
+        );
+    }
+
+    #[tokio::test]
+    async fn rebuild_supersedes_incremental_and_rejects_its_late_completion() {
+        let coordinator = ExternalHistoryScanCoordinator::new(1);
+        let incremental = coordinator.schedule(
+            vec!["cursor_ide".to_string()],
+            ExternalHistoryScanMode::Incremental,
+        );
+        let incremental_job = coordinator
+            .begin_current_jobs(incremental.jobs)
+            .pop()
+            .expect("incremental job");
+
+        let rebuild = coordinator.schedule(
+            vec!["cursor_ide".to_string()],
+            ExternalHistoryScanMode::Rebuild,
+        );
+        assert_eq!(rebuild.jobs.len(), 1);
+
+        assert!(!coordinator.is_current_running_job(&incremental_job));
+        finish(&coordinator, incremental_job, "stale");
+        let rebuild_job = coordinator
+            .begin_current_jobs(rebuild.jobs)
+            .pop()
+            .expect("rebuild job");
+        finish(&coordinator, rebuild_job, "rebuilt");
+
+        assert_eq!(
+            incremental
+                .waiter
+                .wait()
+                .await
+                .expect("incremental follows rebuild")["cursor_ide"]
+                .signature,
+            "rebuilt"
+        );
+        assert_eq!(
+            rebuild.waiter.wait().await.expect("rebuild result")["cursor_ide"].signature,
+            "rebuilt"
+        );
+    }
+
+    #[tokio::test]
+    async fn scan_permits_are_bounded() {
+        let coordinator = ExternalHistoryScanCoordinator::new(1);
+        let permit = coordinator.acquire_permit().await.expect("first permit");
+        assert_eq!(coordinator.permits.available_permits(), 0);
+        drop(permit);
+        assert_eq!(coordinator.permits.available_permits(), 1);
+    }
+}

--- a/src-tauri/src/orgtrack/mod.rs
+++ b/src-tauri/src/orgtrack/mod.rs
@@ -4,6 +4,7 @@ pub mod exporter;
 pub mod external_cli_detection;
 pub mod extraction_scheduler;
 pub mod history_commands;
+mod history_scan_coordinator;
 pub mod impact_indexer;
 pub mod importer;
 pub mod paths;

--- a/src/modules/shared/dataSource/SessionUsagePanel.test.ts
+++ b/src/modules/shared/dataSource/SessionUsagePanel.test.ts
@@ -157,7 +157,7 @@ describe("SessionUsagePanel", () => {
       '[data-testid="usage-rounds-toggle"]'
     );
     await act(async () => open?.click());
-    expect(mocks.usageDashboardOverview).toHaveBeenCalledTimes(3);
+    expect(mocks.usageDashboardOverview).toHaveBeenCalledTimes(2);
 
     const refresh = container.querySelector<HTMLButtonElement>(
       '[data-testid="usage-refresh"]'
@@ -165,17 +165,12 @@ describe("SessionUsagePanel", () => {
     expect(refresh).not.toBeNull();
 
     await act(async () => refresh?.click());
-    expect(mocks.usageDashboardOverview).toHaveBeenCalledTimes(6);
-    expect(mocks.usageDashboardOverview.mock.calls[3]?.[1]).toMatchObject({
-      includeTrends: false,
-      includeRounds: false,
-    });
-    expect(mocks.usageDashboardOverview.mock.calls[4]?.[1]).toMatchObject({
-      includeHeadline: false,
+    expect(mocks.usageDashboardOverview).toHaveBeenCalledTimes(4);
+    expect(mocks.usageDashboardOverview.mock.calls[2]?.[1]).toMatchObject({
       includeTrends: true,
       includeRounds: false,
     });
-    expect(mocks.usageDashboardOverview.mock.calls[5]?.[1]).toMatchObject({
+    expect(mocks.usageDashboardOverview.mock.calls[3]?.[1]).toMatchObject({
       includeHeadline: false,
       includeTrends: false,
       includeRounds: true,
@@ -194,15 +189,15 @@ describe("SessionUsagePanel", () => {
       root.render(createElement(SessionUsagePanel));
     });
 
-    expect(mocks.usageDashboardOverview).toHaveBeenCalledTimes(2);
+    expect(mocks.usageDashboardOverview).toHaveBeenCalledTimes(1);
     expect(mocks.usageDashboardOverview.mock.calls[0]?.[1]).toMatchObject({
-      includeTrends: false,
+      includeTrends: true,
       includeRounds: false,
     });
 
     vi.useFakeTimers();
     act(() => vi.advanceTimersByTime(5 * 60 * 1_000));
-    expect(mocks.usageDashboardOverview).toHaveBeenCalledTimes(2);
+    expect(mocks.usageDashboardOverview).toHaveBeenCalledTimes(1);
     vi.useRealTimers();
 
     const toggle = container.querySelector<HTMLButtonElement>(
@@ -211,8 +206,8 @@ describe("SessionUsagePanel", () => {
     expect(toggle).not.toBeNull();
 
     await act(async () => toggle?.click());
-    expect(mocks.usageDashboardOverview).toHaveBeenCalledTimes(3);
-    expect(mocks.usageDashboardOverview.mock.calls[2]?.[1]).toMatchObject({
+    expect(mocks.usageDashboardOverview).toHaveBeenCalledTimes(2);
+    expect(mocks.usageDashboardOverview.mock.calls[1]?.[1]).toMatchObject({
       includeHeadline: false,
       includeTrends: false,
       includeRounds: true,
@@ -231,7 +226,7 @@ describe("SessionUsagePanel", () => {
     expect(refresh).not.toBeNull();
 
     await act(async () => refresh?.click());
-    expect(mocks.usageDashboardOverview).toHaveBeenCalledTimes(4);
+    expect(mocks.usageDashboardOverview).toHaveBeenCalledTimes(3);
 
     const close = container.querySelector<HTMLButtonElement>(
       '[data-testid="usage-rounds-close"]'
@@ -268,11 +263,11 @@ describe("SessionUsagePanel", () => {
     );
 
     await act(async () => open?.click());
-    expect(mocks.usageDashboardOverview).toHaveBeenCalledTimes(3);
+    expect(mocks.usageDashboardOverview).toHaveBeenCalledTimes(2);
 
     act(() => close?.click());
     await act(async () => open?.click());
-    expect(mocks.usageDashboardOverview).toHaveBeenCalledTimes(3);
+    expect(mocks.usageDashboardOverview).toHaveBeenCalledTimes(2);
 
     await act(async () => resolveRounds(createOverview()));
   });
@@ -289,9 +284,8 @@ describe("SessionUsagePanel", () => {
     await act(async () => {
       root.render(createElement(SessionUsagePanel));
     });
-    expect(mocks.usageDashboardOverview).toHaveBeenCalledTimes(2);
-    expect(mocks.usageDashboardOverview.mock.calls[1]?.[1]).toMatchObject({
-      includeHeadline: false,
+    expect(mocks.usageDashboardOverview).toHaveBeenCalledTimes(1);
+    expect(mocks.usageDashboardOverview.mock.calls[0]?.[1]).toMatchObject({
       includeTrends: true,
       includeRounds: false,
     });

--- a/src/modules/shared/dataSource/SessionUsagePanel.tsx
+++ b/src/modules/shared/dataSource/SessionUsagePanel.tsx
@@ -120,6 +120,7 @@ export default function SessionUsagePanel() {
   const headlineRequestRef = useRef(0);
   const trendRequestRef = useRef(0);
   const roundRequestRef = useRef(0);
+  const trendRequestedQueryKeyRef = useRef<string | null>(null);
   const roundInFlightRef = useRef<{
     queryKey: string;
     request: ReturnType<typeof usageDashboardOverview>;
@@ -175,29 +176,50 @@ export default function SessionUsagePanel() {
 
   const loadHeadline = useCallback(async () => {
     const requestId = ++headlineRequestRef.current;
+    const includeTrends = trendsOpen;
+    const trendRequestId = includeTrends
+      ? ++trendRequestRef.current
+      : undefined;
+    if (includeTrends) {
+      trendRequestedQueryKeyRef.current = trendQueryKey;
+      setTrendLoading(true);
+      setTrendError(null);
+    }
     setHeadlineLoading(true);
     setHeadlineError(null);
     try {
-      // Headline-only mode skips request-table facets, sorting, pagination,
-      // and row transfer until the collapsed Requests section is opened.
+      // The initially-open trend shares the headline's round-store scan.
+      // Request-table facets, sorting, pagination, and row transfer remain
+      // deferred until the collapsed Requests section is opened.
       const overview = await usageDashboardOverview(scope, {
-        includeTrends: false,
+        includeTrends,
         includeRounds: false,
       });
       if (requestId !== headlineRequestRef.current) return;
       setSummary(overview.summary);
+      if (includeTrends && trendRequestId === trendRequestRef.current) {
+        setTrends(overview.trends);
+        setLoadedTrendQueryKey(trendQueryKey);
+      }
     } catch (err) {
       if (requestId === headlineRequestRef.current) {
         setHeadlineError(String(err));
       }
+      if (includeTrends && trendRequestId === trendRequestRef.current) {
+        setTrendError(String(err));
+      }
     } finally {
       if (requestId === headlineRequestRef.current) setHeadlineLoading(false);
+      if (includeTrends && trendRequestId === trendRequestRef.current) {
+        setTrendLoading(false);
+      }
     }
-  }, [scope]);
+  }, [scope, trendQueryKey, trendsOpen]);
 
   const loadTrends = useCallback(async () => {
     const requestId = ++trendRequestRef.current;
     const requestedQueryKey = trendQueryKey;
+    trendRequestedQueryKeyRef.current = requestedQueryKey;
     setTrendLoading(true);
     setTrendError(null);
     try {
@@ -281,8 +303,14 @@ export default function SessionUsagePanel() {
   }, [loadHeadline]);
 
   useEffect(() => {
-    if (trendsOpen && !trendDataLoaded) void loadTrends();
-  }, [loadTrends, trendDataLoaded, trendsOpen]);
+    if (
+      trendsOpen &&
+      !trendDataLoaded &&
+      trendRequestedQueryKeyRef.current !== trendQueryKey
+    ) {
+      void loadTrends();
+    }
+  }, [loadTrends, trendDataLoaded, trendQueryKey, trendsOpen]);
 
   useEffect(() => {
     if (roundsOpen && !roundDataLoaded) void loadRounds();
@@ -293,6 +321,7 @@ export default function SessionUsagePanel() {
     if (open) return;
 
     trendRequestRef.current += 1;
+    trendRequestedQueryKeyRef.current = null;
     setTrends([]);
     setLoadedTrendQueryKey(null);
     setTrendLoading(false);
@@ -322,9 +351,8 @@ export default function SessionUsagePanel() {
 
   const handleUsageRefresh = useCallback(() => {
     void loadHeadline();
-    if (trendsOpen) void loadTrends();
     if (roundsOpen) void loadRounds();
-  }, [loadHeadline, loadRounds, loadTrends, roundsOpen, trendsOpen]);
+  }, [loadHeadline, loadRounds, roundsOpen]);
   const usageRefreshing =
     headlineLoading ||
     (trendsOpen && trendLoading) ||


### PR DESCRIPTION
## Problem

External-history consumers could independently scan the same source, so overlapping dashboard, roster, and manual refreshes duplicated file and SQLite work. Usage round queries also loaded lifetime native rows into Rust before source, session, and time filtering. OpenCode, ZCode, and MiMo folded shared database and WAL metadata into every session signature, causing one session write to invalidate all cached sessions.

The Usage dashboard additionally issued separate initial overview requests for headline and default-open trend data.

## Solution

Make history refresh and dashboard reads bounded at their owning boundaries:

- add a process-wide per-source scan coordinator with single-flight waiters, one blocking scan permit, generation checks, overlap coalescing, and explicit rebuild supersession;
- keep normal refresh signature-incremental and reserve destructive source rebuilds for explicit clear requests;
- scope native and imported usage rows through a connection-local temporary session table and push source, session, and inclusive time bounds into SQLite;
- use stable database row IDs and imported sequence IDs so window changes do not renumber rounds;
- add one non-destructive composite index on session_token_usage(session_id, created_at, id);
- compute OpenCode, ZCode, and MiMo activity signatures in one grouped pass and invalidate only sessions whose own rows changed;
- combine the initial Usage headline and default-open trends into one overview request while leaving request rows collapsed and lazy.

No interval timer, watcher, polling loop, new worker pool, or unbounded cache is added.

## Potential risks

- Existing large databases pay a one-time synchronous cost when SQLite first creates the composite index. CREATE INDEX IF NOT EXISTS prevents repeated rebuilds. A rollback may leave the unused compatible index in place; reverting the commit is otherwise sufficient.
- The connection-local temporary scope table must be cleared on success and failure. Its guard and error-path tests cover cleanup, and its size is bounded by the requested source or session scope.
- Session-local signatures cannot detect an in-place JSON rewrite when length, row ID, provider timestamp, and token metadata all remain unchanged. Normal append, insert, timestamp, and token changes are covered.
- Coordinator semantics intentionally cause concurrent callers for one source to share the same change result. Explicit rebuilds supersede older incremental generations so stale completion cannot publish.
- The latest develop dependency set still fails to initialize jsdom on local Node 20 because html-encoding-sniffer requires an ESM-only dependency through CommonJS. This occurs before the Usage panel test loads, but GitHub Frontend CI passed the repository test suite, so the issue is limited to that unsupported local dependency/runtime combination.

## Audit

Performance guard verdict: pass. Idle behavior is unchanged, overlapping scans coalesce per source, blocking scan concurrency is one, query transfer is proportional to scoped window matches rather than lifetime rows, and no retained cache or queue grows without a bound.

Architecture review covered scan ownership, generation and rebuild state transitions, SQLite and Rust boundary placement, stable identifiers, cache invalidation ownership, command parity, initialization compatibility, and failure cleanup. Provider wire formats and unrelated session lifecycle code are not changed.

No screenshot was captured because the frontend change only consolidates identical data requests; layout, copy, loading, empty, and error rendering are unchanged.

## Verification

- CARGO_BUILD_JOBS=1 cargo test -p orgtrack_core usage_dashboard --lib — 23 passed, including a 1003 lifetime row fixture that transfers only 2 scoped candidates and verifies the composite-index query plan.
- CARGO_BUILD_JOBS=1 cargo test -p orgtrack_core metadata_signature_ignores_unrelated_session_writes --lib — 3 passed.
- CARGO_BUILD_JOBS=1 cargo test -p session_persistence schema::tests::init_session_tables_creates_usage_telemetry_tables_and_indexes --lib — passed.
- CARGO_BUILD_JOBS=1 cargo test -p org2 history_scan_coordinator --lib — 5 passed.
- Pre-commit scoped cargo clippy for org2, orgtrack_core, and session_persistence — passed.
- pnpm eslint on SessionUsagePanel and its test — passed.
- pnpm typecheck — passed on current origin/develop.
- SessionUsagePanel — 5 passed in the original workspace; current origin/develop local run is blocked before collection by the Node 20 and jsdom dependency error described above.
- GitHub CI — Frontend, Rust clippy, and scope check all passed.
- git diff --check and secret or personal-path scan — passed.

Not run: rendered WebView profiling or a production-size database benchmark. Runtime evidence is from query plans, transferred-row counts, call-count tests, lifecycle tests, and bounded-state review.

