### PR TITLE
feat(quota): add bounded ZAI Team limits

### DIFF
--- a/src-tauri/crates/key-vault/src/commands/validate.rs
+++ b/src-tauri/crates/key-vault/src/commands/validate.rs
@@ -20,6 +20,11 @@ use crate::providers::minimax::MiniMaxQuotaFetcher;
 use crate::providers::openai::OpenAIValidator;
 use crate::providers::opencode_go::{workspace_id_override_from_key, OpenCodeGoQuotaFetcher};
 use crate::providers::openrouter::OpenRouterQuotaFetcher;
+use crate::providers::zai_team::{
+    has_partial_team_scope, team_scope_from_key, ZaiTeamQuotaFetcher,
+    ORGANIZATION_METADATA_KEY as ZAI_TEAM_ORGANIZATION_METADATA_KEY,
+    PROJECT_METADATA_KEY as ZAI_TEAM_PROJECT_METADATA_KEY,
+};
 use crate::providers::zhipu::ZhipuQuotaFetcher;
 use crate::quota_runtime::{
     QuotaAttemptState, QuotaFreshness, QuotaRefreshCompletion, QuotaRefreshRuntime,
@@ -511,21 +516,34 @@ pub async fn refresh_key_quota(
     .await
     .map_err(|err| format!("Quota key lookup worker failed: {err}"))??;
     let credential_revision = quota_credential_revision(&key);
+    let strict_request_count = quota_refresh_uses_strict_request_count(&key);
     let operation_key = key.clone();
     let operation_revision = credential_revision.clone();
+    let operation = move || {
+        let key = operation_key.clone();
+        let revision = operation_revision.clone();
+        async move { refresh_and_store_key_quota(key, revision).await }
+    };
 
-    QUOTA_REFRESH_RUNTIME
-        .refresh(
-            key_id.clone(),
-            credential_revision,
-            force.unwrap_or(false),
-            move || {
-                let key = operation_key.clone();
-                let revision = operation_revision.clone();
-                async move { refresh_and_store_key_quota(key, revision).await }
-            },
-        )
-        .await?;
+    if strict_request_count {
+        QUOTA_REFRESH_RUNTIME
+            .refresh_without_transient_retry(
+                key_id.clone(),
+                credential_revision,
+                force.unwrap_or(false),
+                operation,
+            )
+            .await?;
+    } else {
+        QUOTA_REFRESH_RUNTIME
+            .refresh(
+                key_id.clone(),
+                credential_revision,
+                force.unwrap_or(false),
+                operation,
+            )
+            .await?;
+    }
 
     tokio::task::spawn_blocking(move || {
         KEY_SERVICE
@@ -761,6 +779,20 @@ pub(super) fn quota_credential_revision(key: &crate::key_store::ModelKey) -> Str
         "opencode_workspace",
         workspace_id_override_from_key(key),
     );
+    hash_field(
+        &mut hasher,
+        ZAI_TEAM_ORGANIZATION_METADATA_KEY,
+        key.account_metadata
+            .get(ZAI_TEAM_ORGANIZATION_METADATA_KEY)
+            .map(String::as_str),
+    );
+    hash_field(
+        &mut hasher,
+        ZAI_TEAM_PROJECT_METADATA_KEY,
+        key.account_metadata
+            .get(ZAI_TEAM_PROJECT_METADATA_KEY)
+            .map(String::as_str),
+    );
 
     format!("{:x}", hasher.finalize())
 }
@@ -906,9 +938,18 @@ async fn fetch_quota_for_key(
                 .as_deref()
                 .filter(|token| !token.trim().is_empty())
                 .ok_or_else(|| "Zhipu account has no API key".to_string())?;
-            ZhipuQuotaFetcher::new()
-                .fetch_quota(token, key.base_url.as_deref())
-                .await
+            if let Some(scope) = team_scope_from_key(key) {
+                ZaiTeamQuotaFetcher::new().fetch_quota(token, scope).await
+            } else if has_partial_team_scope(key) {
+                Err(format!(
+                    "ZAI Team quota requires both {ZAI_TEAM_ORGANIZATION_METADATA_KEY} \
+                     and {ZAI_TEAM_PROJECT_METADATA_KEY}"
+                ))
+            } else {
+                ZhipuQuotaFetcher::new()
+                    .fetch_quota(token, key.base_url.as_deref())
+                    .await
+            }
         }
         ModelType::DeepseekApi => {
             let token = key
@@ -943,6 +984,10 @@ async fn fetch_quota_for_key(
     }
 }
 
+fn quota_refresh_uses_strict_request_count(key: &crate::key_store::ModelKey) -> bool {
+    key.model_type == ModelType::ZhipuApi && team_scope_from_key(key).is_some()
+}
+
 pub(super) fn key_can_refresh_quota(key: &crate::key_store::ModelKey) -> bool {
     let has_api_key = key
         .api_key
@@ -955,10 +1000,10 @@ pub(super) fn key_can_refresh_quota(key: &crate::key_store::ModelKey) -> bool {
     match key.model_type {
         ModelType::CursorCli => has_session_token,
         ModelType::Copilot
-        | ModelType::ZhipuApi
         | ModelType::DeepseekApi
         | ModelType::OpenrouterApi
         | ModelType::MinimaxApi => has_api_key,
+        ModelType::ZhipuApi => has_api_key && !has_partial_team_scope(key),
         ModelType::OpenCode => has_session_token || has_api_key,
         ModelType::ClaudeCode | ModelType::Codex => {
             key.auth_method == AuthMethod::Oauth && has_session_token
@@ -972,7 +1017,7 @@ mod direct_quota_dispatch_tests {
     use super::*;
 
     #[tokio::test]
-    async fn wave_two_provider_variants_reach_their_stored_key_dispatch_arms() {
+    async fn direct_provider_variants_reach_their_stored_key_dispatch_arms() {
         for (model_type, expected_provider) in [
             (ModelType::DeepseekApi, "DeepSeek"),
             (ModelType::OpenrouterApi, "OpenRouter"),
@@ -1031,6 +1076,27 @@ mod direct_quota_dispatch_tests {
         assert!(!key_can_refresh_quota(&crate::key_store::ModelKey::new(
             ModelType::AnthropicApi
         )));
+    }
+
+    #[test]
+    fn zai_team_capability_requires_complete_scope_and_revision_tracks_it() {
+        let mut key = crate::key_store::ModelKey::new(ModelType::ZhipuApi);
+        key.api_key = Some("api-key".to_string());
+        assert!(key_can_refresh_quota(&key));
+        assert!(!quota_refresh_uses_strict_request_count(&key));
+        let personal_revision = quota_credential_revision(&key);
+
+        key.account_metadata
+            .insert(ZAI_TEAM_ORGANIZATION_METADATA_KEY.into(), "org-1".into());
+        assert!(!key_can_refresh_quota(&key));
+        let partial_revision = quota_credential_revision(&key);
+        assert_ne!(personal_revision, partial_revision);
+
+        key.account_metadata
+            .insert(ZAI_TEAM_PROJECT_METADATA_KEY.into(), "project-1".into());
+        assert!(key_can_refresh_quota(&key));
+        assert!(quota_refresh_uses_strict_request_count(&key));
+        assert_ne!(partial_revision, quota_credential_revision(&key));
     }
 }
 

--- a/src-tauri/crates/key-vault/src/providers/minimax.rs
+++ b/src-tauri/crates/key-vault/src/providers/minimax.rs
@@ -1,11 +1,10 @@
 //! MiniMax Token Plan quota lookup with region-locked compatibility fallback.
 
-use chrono::{DateTime, SecondsFormat, Utc};
 use reqwest::StatusCode;
 use serde_json::Value;
 
 use crate::providers::quota_http::{get_bearer_json, QuotaHttpError};
-use crate::providers::quota_windows::{quota_from_windows, QuotaWindow};
+use crate::providers::quota_windows::{json_time_to_rfc3339, quota_from_windows, QuotaWindow};
 use crate::types::QuotaInfo;
 
 const TOKEN_PLAN_URL_EN: &str = "https://api.minimax.io/v1/token_plan/remains";
@@ -155,7 +154,7 @@ fn parse_minimax_quota(body: &Value) -> Result<QuotaInfo, MiniMaxParseError> {
         {
             windows.push(QuotaWindow::session(
                 100.0 - remaining.clamp(0.0, 100.0),
-                general.get("end_time").and_then(timestamp_to_rfc3339),
+                general.get("end_time").and_then(json_time_to_rfc3339),
             ));
         }
     }
@@ -172,7 +171,7 @@ fn parse_minimax_quota(body: &Value) -> Result<QuotaInfo, MiniMaxParseError> {
                 100.0 - remaining.clamp(0.0, 100.0),
                 general
                     .get("weekly_end_time")
-                    .and_then(timestamp_to_rfc3339),
+                    .and_then(json_time_to_rfc3339),
             ));
         }
     }
@@ -233,21 +232,6 @@ fn finite_number(value: &Value) -> Option<f64> {
         .as_f64()
         .or_else(|| value.as_str()?.trim().parse::<f64>().ok())?;
     number.is_finite().then_some(number)
-}
-
-fn timestamp_to_rfc3339(value: &Value) -> Option<String> {
-    let raw = finite_number(value)?;
-    if !raw.is_finite() || raw < 0.0 {
-        return None;
-    }
-    let milliseconds = if raw < 1_000_000_000_000.0 {
-        raw * 1000.0
-    } else {
-        raw
-    };
-    let milliseconds = milliseconds.round() as i64;
-    DateTime::<Utc>::from_timestamp_millis(milliseconds)
-        .map(|time| time.to_rfc3339_opts(SecondsFormat::Secs, true))
 }
 
 #[cfg(test)]

--- a/src-tauri/crates/key-vault/src/providers/mod.rs
+++ b/src-tauri/crates/key-vault/src/providers/mod.rs
@@ -15,4 +15,5 @@ pub mod opencode_go;
 pub mod openrouter;
 pub(crate) mod quota_http;
 pub(crate) mod quota_windows;
+pub mod zai_team;
 pub mod zhipu;

--- a/src-tauri/crates/key-vault/src/providers/quota_http.rs
+++ b/src-tauri/crates/key-vault/src/providers/quota_http.rs
@@ -8,8 +8,8 @@ use std::fmt;
 use std::sync::LazyLock;
 use std::time::Duration;
 
-use reqwest::header::{ACCEPT, CONTENT_LENGTH, RETRY_AFTER};
-use reqwest::{Client, StatusCode};
+use reqwest::header::{HeaderMap, ACCEPT, CONTENT_LENGTH, RETRY_AFTER};
+use reqwest::{Client, RequestBuilder, StatusCode};
 use serde_json::Value;
 
 const REQUEST_DEADLINE: Duration = Duration::from_secs(12);
@@ -53,23 +53,52 @@ pub(crate) async fn get_bearer_json(
     url: &str,
     api_key: &str,
 ) -> Result<Value, QuotaHttpError> {
-    let client = QUOTA_HTTP_CLIENT
+    let client = quota_http_client()?;
+    send_json(
+        provider,
+        client
+            .get(url)
+            .bearer_auth(api_key)
+            .header(ACCEPT, "application/json"),
+    )
+    .await
+}
+
+/// Perform one bounded GET with provider-specific headers.
+///
+/// Callers construct a `HeaderMap` so secrets remain typed header values and
+/// never pass through URL query strings. Redirect, deadline, connection-pool,
+/// and response-size policy remains centralized in this module.
+pub(crate) async fn get_json_with_headers(
+    provider: &str,
+    url: &str,
+    headers: HeaderMap,
+) -> Result<Value, QuotaHttpError> {
+    let client = quota_http_client()?;
+    send_json(
+        provider,
+        client
+            .get(url)
+            .header(ACCEPT, "application/json")
+            .headers(headers),
+    )
+    .await
+}
+
+fn quota_http_client() -> Result<&'static Client, QuotaHttpError> {
+    QUOTA_HTTP_CLIENT
         .as_ref()
         .map_err(|message| QuotaHttpError {
             status: None,
             message: message.clone(),
-        })?;
+        })
+}
 
-    let mut response = client
-        .get(url)
-        .bearer_auth(api_key)
-        .header(ACCEPT, "application/json")
-        .send()
-        .await
-        .map_err(|error| QuotaHttpError {
-            status: None,
-            message: format!("{provider} quota request failed: {error}"),
-        })?;
+async fn send_json(provider: &str, request: RequestBuilder) -> Result<Value, QuotaHttpError> {
+    let mut response = request.send().await.map_err(|error| QuotaHttpError {
+        status: None,
+        message: format!("{provider} quota request failed: {error}"),
+    })?;
 
     let status = response.status();
     if !status.is_success() {

--- a/src-tauri/crates/key-vault/src/providers/quota_windows.rs
+++ b/src-tauri/crates/key-vault/src/providers/quota_windows.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, SecondsFormat, Utc};
+use serde_json::Value;
 
 use crate::types::{QuotaInfo, UsageItem};
 
@@ -42,6 +43,26 @@ pub(crate) fn normalize_reset_time(value: &str) -> Option<String> {
                 .to_rfc3339_opts(SecondsFormat::Secs, true)
         })
         .ok()
+}
+
+pub(crate) fn json_time_to_rfc3339(value: &Value) -> Option<String> {
+    if let Some(raw) = value.as_f64().or_else(|| {
+        value
+            .as_str()
+            .and_then(|value| value.trim().parse::<f64>().ok())
+    }) {
+        if !raw.is_finite() || raw < 0.0 {
+            return None;
+        }
+        let milliseconds = if raw < 1_000_000_000_000.0 {
+            raw * 1000.0
+        } else {
+            raw
+        };
+        return DateTime::<Utc>::from_timestamp_millis(milliseconds.round() as i64)
+            .map(|date| date.to_rfc3339_opts(SecondsFormat::Secs, true));
+    }
+    value.as_str().and_then(normalize_reset_time)
 }
 
 pub(crate) fn quota_from_windows(

--- a/src-tauri/crates/key-vault/src/providers/quota_windows_tests.rs
+++ b/src-tauri/crates/key-vault/src/providers/quota_windows_tests.rs
@@ -70,3 +70,19 @@ fn normalize_reset_time_rejects_non_datetime_text() {
     );
     assert_eq!(normalize_reset_time("tomorrow"), None);
 }
+
+#[test]
+fn json_time_normalizes_seconds_milliseconds_and_rfc3339() {
+    assert_eq!(
+        json_time_to_rfc3339(&serde_json::json!(1_783_418_400)).as_deref(),
+        Some("2026-07-07T10:00:00Z")
+    );
+    assert_eq!(
+        json_time_to_rfc3339(&serde_json::json!(1_783_418_400_000_i64)).as_deref(),
+        Some("2026-07-07T10:00:00Z")
+    );
+    assert_eq!(
+        json_time_to_rfc3339(&serde_json::json!("2026-07-07T18:00:00+08:00")).as_deref(),
+        Some("2026-07-07T10:00:00Z")
+    );
+}

--- a/src-tauri/crates/key-vault/src/providers/zai_team.rs
+++ b/src-tauri/crates/key-vault/src/providers/zai_team.rs
@@ -1,0 +1,399 @@
+//! Z.ai Team quota lookup for explicitly scoped BigModel team credentials.
+//!
+//! Team plans exist only on the China BigModel host. The endpoint, region,
+//! organization, and project are therefore fixed before the request starts:
+//! one GET, no region probing, and no subscription/plan-label follow-up.
+
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION};
+use serde_json::Value;
+
+use crate::key_store::ModelKey;
+use crate::providers::quota_http::get_json_with_headers;
+use crate::providers::quota_windows::{json_time_to_rfc3339, quota_from_windows, QuotaWindow};
+use crate::types::QuotaInfo;
+
+pub(crate) const ORGANIZATION_METADATA_KEY: &str = "zai_team_organization_id";
+pub(crate) const PROJECT_METADATA_KEY: &str = "zai_team_project_id";
+
+const ZAI_TEAM_QUOTA_URL: &str = "https://open.bigmodel.cn/api/monitor/usage/quota/limit?type=2";
+const PLAN_TYPE_DEFAULT: &str = "Z.ai Team";
+const QUOTA_SOURCE: &str = "zai_team_monitor";
+const TOKENS_LIMIT_TYPE: &str = "TOKENS_LIMIT";
+const TIME_LIMIT_TYPE: &str = "TIME_LIMIT";
+const MAX_API_KEY_HEADER_BYTES: usize = 16 * 1024;
+const MAX_SCOPE_HEADER_BYTES: usize = 8 * 1024;
+
+const ORGANIZATION_HEADER: HeaderName = HeaderName::from_static("bigmodel-organization");
+const PROJECT_HEADER: HeaderName = HeaderName::from_static("bigmodel-project");
+
+pub(crate) struct ZaiTeamScope<'a> {
+    pub(crate) organization_id: &'a str,
+    pub(crate) project_id: &'a str,
+}
+
+/// Resolve Team scope only from the provider-specific metadata pair.
+///
+/// A partial pair is deliberately not accepted: silently falling back to a
+/// personal Zhipu lookup would cache data for a different billing scope.
+pub(crate) fn team_scope_from_key(key: &ModelKey) -> Option<ZaiTeamScope<'_>> {
+    let organization_id = key
+        .account_metadata
+        .get(ORGANIZATION_METADATA_KEY)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    let project_id = key
+        .account_metadata
+        .get(PROJECT_METADATA_KEY)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    Some(ZaiTeamScope {
+        organization_id,
+        project_id,
+    })
+}
+
+pub(crate) fn has_partial_team_scope(key: &ModelKey) -> bool {
+    let has_organization = metadata_value(key, ORGANIZATION_METADATA_KEY).is_some();
+    let has_project = metadata_value(key, PROJECT_METADATA_KEY).is_some();
+    has_organization != has_project
+}
+
+fn metadata_value<'a>(key: &'a ModelKey, name: &str) -> Option<&'a str> {
+    key.account_metadata
+        .get(name)
+        .map(String::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+}
+
+pub struct ZaiTeamQuotaFetcher;
+
+impl ZaiTeamQuotaFetcher {
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Fetch Team quota from the single China endpoint.
+    pub(crate) async fn fetch_quota(
+        &self,
+        api_key: &str,
+        scope: ZaiTeamScope<'_>,
+    ) -> Result<QuotaInfo, String> {
+        let api_key = api_key.trim();
+        if api_key.is_empty() {
+            return Err("ZAI Team account has no API key".to_string());
+        }
+
+        let mut headers = HeaderMap::with_capacity(3);
+        headers.insert(AUTHORIZATION, bearer_header_value(api_key)?);
+        headers.insert(
+            ORGANIZATION_HEADER,
+            secret_header_value(
+                scope.organization_id,
+                "ZAI Team organization ID",
+                MAX_SCOPE_HEADER_BYTES,
+            )?,
+        );
+        headers.insert(
+            PROJECT_HEADER,
+            secret_header_value(
+                scope.project_id,
+                "ZAI Team project ID",
+                MAX_SCOPE_HEADER_BYTES,
+            )?,
+        );
+
+        let body = get_json_with_headers("ZAI Team", ZAI_TEAM_QUOTA_URL, headers)
+            .await
+            .map_err(|error| error.to_string())?;
+        parse_zai_team_quota(&body)
+    }
+}
+
+impl Default for ZaiTeamQuotaFetcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn secret_header_value(value: &str, field: &str, max_bytes: usize) -> Result<HeaderValue, String> {
+    if value.len() > max_bytes {
+        return Err(format!(
+            "{field} exceeds the {max_bytes}-byte request-header limit"
+        ));
+    }
+    HeaderValue::from_str(value).map_err(|_| format!("{field} is not a valid HTTP header value"))
+}
+
+fn bearer_header_value(api_key: &str) -> Result<HeaderValue, String> {
+    if api_key.len() > MAX_API_KEY_HEADER_BYTES.saturating_sub("Bearer ".len()) {
+        return Err(format!(
+            "ZAI Team API key exceeds the {MAX_API_KEY_HEADER_BYTES}-byte \
+             request-header limit"
+        ));
+    }
+    secret_header_value(
+        &format!("Bearer {api_key}"),
+        "ZAI Team API key",
+        MAX_API_KEY_HEADER_BYTES,
+    )
+}
+
+fn parse_zai_team_quota(body: &Value) -> Result<QuotaInfo, String> {
+    let data = body
+        .get("data")
+        .and_then(Value::as_object)
+        .ok_or_else(|| "ZAI Team quota HTTP 200 response has no data object".to_string())?;
+    let limits = data
+        .get("limits")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "ZAI Team quota HTTP 200 response has no limits array".to_string())?;
+
+    let mut token_count = 0_usize;
+    let mut shortest: Option<(&Value, f64, f64)> = None;
+    let mut longest: Option<(&Value, f64, f64)> = None;
+    for limit in limits
+        .iter()
+        .filter(|limit| limit_type(limit).eq_ignore_ascii_case(TOKENS_LIMIT_TYPE))
+    {
+        let Some(percent) = used_percent(limit) else {
+            continue;
+        };
+        token_count += 1;
+        let minutes = window_minutes(limit).unwrap_or(f64::MAX);
+        if shortest.is_none_or(|(_, _, shortest_minutes)| minutes < shortest_minutes) {
+            shortest = Some((limit, percent, minutes));
+        }
+        if longest.is_none_or(|(_, _, longest_minutes)| minutes >= longest_minutes) {
+            longest = Some((limit, percent, minutes));
+        }
+    }
+
+    let mut windows = Vec::with_capacity(3);
+    if token_count == 1 {
+        if let Some((limit, percent, _)) = shortest {
+            if is_session_window(limit) {
+                windows.push(QuotaWindow::session(percent, reset_time(limit)));
+            } else {
+                windows.push(QuotaWindow::weekly(percent, reset_time(limit)));
+            }
+        }
+    } else if token_count > 1 {
+        if let (Some((session, session_percent, _)), Some((weekly, weekly_percent, _))) =
+            (shortest, longest)
+        {
+            windows.push(QuotaWindow::session(session_percent, reset_time(session)));
+            windows.push(QuotaWindow::weekly(weekly_percent, reset_time(weekly)));
+        }
+    }
+
+    if let Some((limit, percent)) = limits
+        .iter()
+        .find(|limit| limit_type(limit).eq_ignore_ascii_case(TIME_LIMIT_TYPE))
+        .and_then(|limit| used_percent(limit).map(|percent| (limit, percent)))
+    {
+        windows.push(QuotaWindow {
+            usage_type: "mcp_monthly",
+            used_percent: percent,
+            reset_time: reset_time(limit),
+        });
+    }
+
+    if windows.is_empty() {
+        return Err("ZAI Team quota HTTP 200 response has no usable quota windows".to_string());
+    }
+
+    let plan = plan_label(data).unwrap_or(PLAN_TYPE_DEFAULT);
+    let mut quota = quota_from_windows(plan, QUOTA_SOURCE, windows);
+    quota.limit_type = Some("team".to_string());
+    Ok(quota)
+}
+
+fn limit_type(limit: &Value) -> &str {
+    limit
+        .get("type")
+        .or_else(|| limit.get("limit_type"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .unwrap_or_default()
+}
+
+fn finite_number(value: Option<&Value>) -> Option<f64> {
+    let value = value?;
+    let number = value
+        .as_f64()
+        .or_else(|| value.as_str()?.trim().parse::<f64>().ok())?;
+    number.is_finite().then_some(number)
+}
+
+fn used_percent(limit: &Value) -> Option<f64> {
+    let total = finite_number(limit.get("usage"));
+    let remaining = finite_number(limit.get("remaining"));
+    let current = finite_number(
+        limit
+            .get("currentValue")
+            .or_else(|| limit.get("current_value")),
+    );
+    if let Some(total) = total.filter(|total| *total > 0.0) {
+        let used = match (remaining, current) {
+            (Some(remaining), Some(current)) => (total - remaining).max(current),
+            (Some(remaining), None) => total - remaining,
+            (None, Some(current)) => current,
+            (None, None) => return fallback_percent(limit),
+        };
+        return Some((used.clamp(0.0, total) / total * 100.0).clamp(0.0, 100.0));
+    }
+    fallback_percent(limit)
+}
+
+fn fallback_percent(limit: &Value) -> Option<f64> {
+    finite_number(
+        limit
+            .get("percentage")
+            .or_else(|| limit.get("usedPercent"))
+            .or_else(|| limit.get("used_percent")),
+    )
+    .map(|percent| percent.clamp(0.0, 100.0))
+}
+
+fn window_minutes(limit: &Value) -> Option<f64> {
+    let unit = finite_number(limit.get("unit"))?;
+    let number = finite_number(limit.get("number"))?;
+    if number <= 0.0 {
+        return None;
+    }
+    match unit {
+        5.0 => Some(number),
+        3.0 => Some(number * 60.0),
+        1.0 => Some(number * 24.0 * 60.0),
+        6.0 => Some(number * 7.0 * 24.0 * 60.0),
+        _ => None,
+    }
+}
+
+fn is_session_window(limit: &Value) -> bool {
+    window_minutes(limit).is_some_and(|minutes| minutes <= 6.0 * 60.0)
+}
+
+fn reset_time(limit: &Value) -> Option<String> {
+    limit
+        .get("nextResetTime")
+        .or_else(|| limit.get("next_reset_time"))
+        .and_then(json_time_to_rfc3339)
+}
+
+fn plan_label(data: &serde_json::Map<String, Value>) -> Option<&str> {
+    [
+        "planName",
+        "plan_name",
+        "packageName",
+        "package_name",
+        "plan",
+        "plan_type",
+        "planType",
+        "level",
+    ]
+    .into_iter()
+    .find_map(|field| data.get(field).and_then(Value::as_str))
+    .map(str::trim)
+    .filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::key_store::ModelType;
+    use serde_json::json;
+
+    #[test]
+    fn scope_requires_both_provider_specific_metadata_values() {
+        let mut key = ModelKey::new(ModelType::ZhipuApi);
+        assert!(team_scope_from_key(&key).is_none());
+        assert!(!has_partial_team_scope(&key));
+
+        key.account_metadata
+            .insert(ORGANIZATION_METADATA_KEY.into(), " org-1 ".into());
+        assert!(team_scope_from_key(&key).is_none());
+        assert!(has_partial_team_scope(&key));
+
+        key.account_metadata
+            .insert(PROJECT_METADATA_KEY.into(), "project-1".into());
+        let scope = team_scope_from_key(&key).unwrap();
+        assert_eq!(scope.organization_id, "org-1");
+        assert_eq!(scope.project_id, "project-1");
+        assert!(!has_partial_team_scope(&key));
+    }
+
+    #[test]
+    fn parser_uses_exact_windows_and_includes_monthly_mcp() {
+        let quota = parse_zai_team_quota(&json!({
+            "data": {
+                "planName": "GLM TEAM",
+                "limits": [
+                    {
+                        "type": "TOKENS_LIMIT",
+                        "unit": 6,
+                        "number": 1,
+                        "usage": 1000,
+                        "remaining": 250,
+                        "currentValue": 700
+                    },
+                    {
+                        "type": "TOKENS_LIMIT",
+                        "unit": 3,
+                        "number": 5,
+                        "percentage": 20,
+                        "nextResetTime": 1783418400
+                    },
+                    {
+                        "type": "TIME_LIMIT",
+                        "percentage": "40",
+                        "next_reset_time": "2026-08-01T02:00:00+08:00"
+                    }
+                ]
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(quota.plan_type.as_deref(), Some("GLM TEAM"));
+        assert_eq!(quota.quota_source.as_deref(), Some(QUOTA_SOURCE));
+        assert_eq!(quota.limit_type.as_deref(), Some("team"));
+        assert_eq!(quota.usage_items.len(), 3);
+        assert_eq!(quota.usage_items[0].usage_type, "session");
+        assert_eq!(quota.usage_items[0].remaining_percentage, 80.0);
+        assert_eq!(
+            quota.usage_items[0].reset_time.as_deref(),
+            Some("2026-07-07T10:00:00Z")
+        );
+        assert_eq!(quota.usage_items[1].usage_type, "weekly");
+        assert_eq!(quota.usage_items[1].remaining_percentage, 25.0);
+        assert_eq!(quota.usage_items[2].usage_type, "mcp_monthly");
+        assert_eq!(quota.usage_items[2].remaining_percentage, 60.0);
+        assert_eq!(
+            quota.usage_items[2].reset_time.as_deref(),
+            Some("2026-07-31T18:00:00Z")
+        );
+        assert_eq!(quota.remaining_percentage, 25.0);
+    }
+
+    #[test]
+    fn parser_rejects_empty_success_payloads() {
+        let error = parse_zai_team_quota(&json!({"data": {"limits": []}})).unwrap_err();
+        assert!(error.contains("HTTP 200"));
+        assert!(error.contains("no usable quota windows"));
+    }
+
+    #[test]
+    fn team_headers_have_explicit_memory_bounds() {
+        let oversized = "x".repeat(MAX_SCOPE_HEADER_BYTES + 1);
+        let error = secret_header_value(&oversized, "ZAI Team project ID", MAX_SCOPE_HEADER_BYTES)
+            .unwrap_err();
+        assert!(error.contains("request-header limit"));
+
+        let oversized_key = "x".repeat(MAX_API_KEY_HEADER_BYTES);
+        let key_error = bearer_header_value(&oversized_key).unwrap_err();
+        assert!(key_error.contains("request-header limit"));
+    }
+}

--- a/src-tauri/crates/key-vault/src/quota_runtime.rs
+++ b/src-tauri/crates/key-vault/src/quota_runtime.rs
@@ -276,6 +276,42 @@ where
         F: Fn() -> Fut + Send + Sync + 'static,
         Fut: Future<Output = Result<QuotaRefreshCompletion<T>, String>> + Send + 'static,
     {
+        self.refresh_with_retry_policy(account_id, credential_revision, force, true, operation)
+            .await
+    }
+
+    /// Refresh with the same cache, single-flight, and concurrency policy but
+    /// without repeating a transient provider request.
+    ///
+    /// Use this for endpoints whose request-count contract is stricter than
+    /// the default one-retry resilience policy.
+    pub async fn refresh_without_transient_retry<F, Fut>(
+        &self,
+        account_id: String,
+        credential_revision: String,
+        force: bool,
+        operation: F,
+    ) -> Result<T, String>
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<QuotaRefreshCompletion<T>, String>> + Send + 'static,
+    {
+        self.refresh_with_retry_policy(account_id, credential_revision, force, false, operation)
+            .await
+    }
+
+    async fn refresh_with_retry_policy<F, Fut>(
+        &self,
+        account_id: String,
+        credential_revision: String,
+        force: bool,
+        retry_transient: bool,
+        operation: F,
+    ) -> Result<T, String>
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<QuotaRefreshCompletion<T>, String>> + Send + 'static,
+    {
         let now = Instant::now();
         let started_at = SystemTime::now();
         let mut superseded = None;
@@ -373,7 +409,10 @@ where
             let provider_worker = tokio::spawn(async move {
                 let permit = permits.acquire_owned().await;
                 match permit {
-                    Ok(_permit) => run_with_one_transient_retry(&operation).await,
+                    Ok(_permit) if retry_transient => {
+                        run_with_one_transient_retry(&operation).await
+                    }
+                    Ok(_permit) => operation().await,
                     Err(_) => Err("Quota refresh coordinator is shutting down".to_string()),
                 }
             });

--- a/src-tauri/crates/key-vault/src/quota_runtime_tests.rs
+++ b/src-tauri/crates/key-vault/src/quota_runtime_tests.rs
@@ -357,6 +357,25 @@ async fn transient_error_retries_once_and_non_transient_error_does_not() {
 }
 
 #[tokio::test]
+async fn strict_request_policy_does_not_retry_transient_errors() {
+    let runtime = runtime(4, 1);
+    let calls = Arc::new(AtomicUsize::new(0));
+    let error = runtime
+        .refresh_without_transient_retry("strict".into(), "revision".into(), false, {
+            let calls = Arc::clone(&calls);
+            move || {
+                calls.fetch_add(1, Ordering::SeqCst);
+                async { Err("HTTP 503 retry-after: 0".to_string()) }
+            }
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(error, "HTTP 503 retry-after: 0");
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
 async fn provider_worker_panic_releases_single_flight_waiters() {
     let runtime = runtime(4, 1);
     let error = runtime


### PR DESCRIPTION
## Problem

ZAI Team credentials were stored as ordinary Zhipu API keys, so ORGII could only refresh personal Zhipu limits. Team-scoped 5-hour, weekly, and MCP monthly limits were unavailable, and using the personal endpoint for a partially scoped team account could cache the wrong billing scope.

## Solution

Add one explicitly scoped ZAI Team quota path on top of the bounded quota runtime from the parent PR:

- require both zai_team_organization_id and zai_team_project_id before exposing refresh capability;
- pin the request to the single BigModel China monitor endpoint with Bearer, organization, and project headers;
- disable transient retry for this path so a refresh performs exactly one provider request;
- parse session, weekly, and MCP monthly windows and keep raw metadata out of URLs and logs;
- centralize bounded custom-header GETs and JSON timestamp normalization while preserving MiniMax behavior;
- include Team scope in the credential revision so cache entries cannot cross organizations or projects.

The path reuses the parent runtime single-flight, global concurrency 3, success TTL, failure cooldown, generation guard, 256-account LRU, HTTPS-only client, redirect denial, 12-second deadline, and 1 MiB response limit. It adds no timer, watcher, scan, process invocation, or region probing.

## Potential risks

- The Team endpoint and metadata keys must match the saved credential shape. Partial scope is intentionally disabled rather than falling back to personal Zhipu quota.
- The provider response is validated defensively, but no live Team credential was available for an end-to-end request. Fixture tests cover the observed 5-hour, weekly, and MCP monthly payload shapes.
- Strict one-request behavior trades automatic transient retry for predictable provider load. Existing last-good data and the failure cooldown remain available.
- Shared timestamp parsing now serves MiniMax and ZAI Team; the full key-vault suite verifies the MiniMax behavior remains unchanged.
- No persistence or public wire format changes are introduced. Rollback is a revert of this commit; cached quota data will age out under the existing runtime policy.

## Audit

Performance guard verdict: pass. Idle cost is zero, each refresh has exactly one upstream request, response memory is capped at 1 MiB, request headers are capped, concurrent provider work remains capped at 3, and retained account state remains capped at 256.

Architecture review covered provider ownership, credential-scope identity, request and retry state transitions, cache generation, failure semantics, capability parity, shared parsing boundaries, and test seams. Frontend rendering and unrelated session lifecycle are unchanged.

No screenshot was captured because this is a backend provider adapter with no layout, copy, loading, empty, or error-state UI change.

## Verification

- CARGO_BUILD_JOBS=1 cargo test -p key_vault --lib — 324 passed.
- CARGO_BUILD_JOBS=1 cargo clippy -p key_vault --all-targets --no-deps — completed with only three pre-existing warnings in unrelated key-vault files.
- cargo clippy with -D warnings was also attempted; it is blocked by pre-existing workspace and key-vault lint debt outside this diff.
- rustfmt on the nine changed Rust files — passed.
- git diff --check — passed.
- Diff scan for secrets, private keys, bearer tokens, and personal paths — passed.
- The isolated worktree lacked the generated Husky shim, so the equivalent Rust formatting, tests, scoped clippy, and staged-diff checks were run manually before committing.

Not run: a live provider request, because no ZAI Team credential was used.
