### PR TITLE
feat(quota): add bounded Qoder credits

### DIFF
--- a/src-tauri/crates/key-vault/src/commands/validate.rs
+++ b/src-tauri/crates/key-vault/src/commands/validate.rs
@@ -20,6 +20,7 @@ use crate::providers::minimax::MiniMaxQuotaFetcher;
 use crate::providers::openai::OpenAIValidator;
 use crate::providers::opencode_go::{workspace_id_override_from_key, OpenCodeGoQuotaFetcher};
 use crate::providers::openrouter::OpenRouterQuotaFetcher;
+use crate::providers::qoder::QoderQuotaFetcher;
 use crate::providers::zai_team::{
     has_partial_team_scope, team_scope_from_key, ZaiTeamQuotaFetcher,
     ORGANIZATION_METADATA_KEY as ZAI_TEAM_ORGANIZATION_METADATA_KEY,
@@ -922,12 +923,9 @@ async fn fetch_quota_for_key(
                 .await
         }
         ModelType::OpenCode => {
-            let cookie = key
-                .session_token
-                .as_deref()
-                .or(key.api_key.as_deref())
-                .filter(|token| !token.trim().is_empty())
-                .ok_or_else(|| "OpenCode account has no session cookie".to_string())?;
+            let cookie =
+                first_non_empty_secret(key.session_token.as_deref(), key.api_key.as_deref())
+                    .ok_or_else(|| "OpenCode account has no session cookie".to_string())?;
             OpenCodeGoQuotaFetcher::new()
                 .fetch_quota(cookie, workspace_id_override_from_key(key))
                 .await
@@ -977,6 +975,14 @@ async fn fetch_quota_for_key(
                 .fetch_quota(token, key.base_url.as_deref())
                 .await
         }
+        ModelType::QoderCli => {
+            let cookie =
+                first_non_empty_secret(key.session_token.as_deref(), key.api_key.as_deref())
+                    .ok_or_else(|| "Qoder account has no saved cookie or token".to_string())?;
+            QoderQuotaFetcher::new()
+                .fetch_quota(cookie, key.base_url.as_deref())
+                .await
+        }
         ref other => Err(format!(
             "{} does not have a quota refresh API",
             other.as_str()
@@ -984,8 +990,19 @@ async fn fetch_quota_for_key(
     }
 }
 
+fn first_non_empty_secret<'a>(
+    preferred: Option<&'a str>,
+    fallback: Option<&'a str>,
+) -> Option<&'a str> {
+    preferred
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .or_else(|| fallback.map(str::trim).filter(|value| !value.is_empty()))
+}
+
 fn quota_refresh_uses_strict_request_count(key: &crate::key_store::ModelKey) -> bool {
-    key.model_type == ModelType::ZhipuApi && team_scope_from_key(key).is_some()
+    matches!(key.model_type, ModelType::QoderCli)
+        || (key.model_type == ModelType::ZhipuApi && team_scope_from_key(key).is_some())
 }
 
 pub(super) fn key_can_refresh_quota(key: &crate::key_store::ModelKey) -> bool {
@@ -1004,6 +1021,10 @@ pub(super) fn key_can_refresh_quota(key: &crate::key_store::ModelKey) -> bool {
         | ModelType::OpenrouterApi
         | ModelType::MinimaxApi => has_api_key,
         ModelType::ZhipuApi => has_api_key && !has_partial_team_scope(key),
+        ModelType::QoderCli => {
+            (has_session_token || has_api_key)
+                && crate::providers::qoder::has_supported_region(key.base_url.as_deref())
+        }
         ModelType::OpenCode => has_session_token || has_api_key,
         ModelType::ClaudeCode | ModelType::Codex => {
             key.auth_method == AuthMethod::Oauth && has_session_token
@@ -1018,15 +1039,16 @@ mod direct_quota_dispatch_tests {
 
     #[tokio::test]
     async fn direct_provider_variants_reach_their_stored_key_dispatch_arms() {
-        for (model_type, expected_provider) in [
-            (ModelType::DeepseekApi, "DeepSeek"),
-            (ModelType::OpenrouterApi, "OpenRouter"),
-            (ModelType::MinimaxApi, "MiniMax"),
+        for (model_type, expected_provider, expected_secret) in [
+            (ModelType::DeepseekApi, "DeepSeek", "no API key"),
+            (ModelType::OpenrouterApi, "OpenRouter", "no API key"),
+            (ModelType::MinimaxApi, "MiniMax", "no API key"),
+            (ModelType::QoderCli, "Qoder", "no saved cookie or token"),
         ] {
             let key = crate::key_store::ModelKey::new(model_type);
             let error = fetch_quota_for_key(&key).await.unwrap_err();
             assert!(
-                error.contains(expected_provider) && error.contains("no API key"),
+                error.contains(expected_provider) && error.contains(expected_secret),
                 "unexpected dispatch error: {error}"
             );
         }
@@ -1059,6 +1081,7 @@ mod direct_quota_dispatch_tests {
             ModelType::DeepseekApi,
             ModelType::OpenrouterApi,
             ModelType::MinimaxApi,
+            ModelType::QoderCli,
         ] {
             let mut key = crate::key_store::ModelKey::new(model_type);
             key.api_key = Some("api-key".to_string());
@@ -1097,6 +1120,30 @@ mod direct_quota_dispatch_tests {
         assert!(key_can_refresh_quota(&key));
         assert!(quota_refresh_uses_strict_request_count(&key));
         assert_ne!(partial_revision, quota_credential_revision(&key));
+    }
+
+    #[test]
+    fn qoder_capability_requires_an_explicit_saved_secret() {
+        let mut key = crate::key_store::ModelKey::new(ModelType::QoderCli);
+        assert!(!key_can_refresh_quota(&key));
+        key.session_token = Some("session=qoder".into());
+        assert!(key_can_refresh_quota(&key));
+        assert!(quota_refresh_uses_strict_request_count(&key));
+        key.base_url = Some("https://example.com".into());
+        assert!(!key_can_refresh_quota(&key));
+    }
+
+    #[test]
+    fn stored_cookie_resolution_skips_blank_preferred_values() {
+        assert_eq!(
+            first_non_empty_secret(Some("  "), Some(" fallback-cookie ")),
+            Some("fallback-cookie")
+        );
+        assert_eq!(
+            first_non_empty_secret(Some(" preferred-cookie "), Some("fallback-cookie")),
+            Some("preferred-cookie")
+        );
+        assert_eq!(first_non_empty_secret(Some(" "), None), None);
     }
 }
 

--- a/src-tauri/crates/key-vault/src/providers/mod.rs
+++ b/src-tauri/crates/key-vault/src/providers/mod.rs
@@ -13,6 +13,7 @@ pub mod minimax;
 pub mod openai;
 pub mod opencode_go;
 pub mod openrouter;
+pub mod qoder;
 pub(crate) mod quota_http;
 pub(crate) mod quota_windows;
 pub mod zai_team;

--- a/src-tauri/crates/key-vault/src/providers/qoder.rs
+++ b/src-tauri/crates/key-vault/src/providers/qoder.rs
@@ -1,0 +1,439 @@
+//! Qoder web-session credit quota lookup.
+//!
+//! The stored cookie is used only on an explicitly pinned Qoder region. Usage
+//! costs one GET. A second same-region request is allowed solely to fill a
+//! missing plan label after usable quota has already been parsed.
+
+use reqwest::header::{
+    HeaderMap, HeaderValue, ACCEPT, ACCEPT_LANGUAGE, COOKIE, ORIGIN, REFERER, USER_AGENT,
+};
+use serde_json::Value;
+
+use crate::providers::quota_http::get_json_with_headers;
+use crate::providers::quota_windows::json_time_to_rfc3339;
+use crate::types::{QuotaInfo, UsageItem};
+
+const GLOBAL_ORIGIN: &str = "https://qoder.com";
+const CN_ORIGIN: &str = "https://qoder.com.cn";
+const QUOTA_SOURCE: &str = "qoder_big_model_credits";
+const PLAN_TYPE_DEFAULT: &str = "Qoder";
+const MAX_COOKIE_BYTES: usize = 64 * 1024;
+const BROWSER_USER_AGENT: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
+AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QoderRegion {
+    Global,
+    Cn,
+}
+
+impl QoderRegion {
+    fn origin(self) -> &'static str {
+        match self {
+            Self::Global => GLOBAL_ORIGIN,
+            Self::Cn => CN_ORIGIN,
+        }
+    }
+
+    fn usage_url(self) -> String {
+        format!("{}/api/v2/me/usages/big_model_credits", self.origin())
+    }
+
+    fn plan_url(self) -> String {
+        format!("{}/api/v1/me/userplan", self.origin())
+    }
+}
+
+pub struct QoderQuotaFetcher;
+
+impl QoderQuotaFetcher {
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Fetch usage in one request, with at most one plan-label-only fallback.
+    pub async fn fetch_quota(
+        &self,
+        cookie: &str,
+        base_url: Option<&str>,
+    ) -> Result<QuotaInfo, String> {
+        let cookie = cookie.trim();
+        if cookie.is_empty() {
+            return Err("Qoder account has no saved cookie or token".to_string());
+        }
+        let region = resolve_region(base_url)?;
+        let headers = qoder_headers(cookie, region)?;
+        let body = get_json_with_headers("Qoder", &region.usage_url(), headers.clone())
+            .await
+            .map_err(|error| error.to_string())?;
+        let mut quota = parse_qoder_quota(&body)?;
+
+        if quota.plan_type.as_deref() == Some(PLAN_TYPE_DEFAULT) {
+            if let Ok(plan_body) =
+                get_json_with_headers("Qoder plan", &region.plan_url(), headers).await
+            {
+                if let Some(plan) = parse_qoder_plan_label(&plan_body) {
+                    quota.plan_type = Some(plan);
+                }
+            }
+        }
+        Ok(quota)
+    }
+}
+
+impl Default for QoderQuotaFetcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn resolve_region(base_url: Option<&str>) -> Result<QoderRegion, String> {
+    let Some(base_url) = base_url
+        .map(str::trim)
+        .filter(|base_url| !base_url.is_empty())
+    else {
+        return Ok(QoderRegion::Global);
+    };
+    let parsed =
+        url::Url::parse(base_url).map_err(|error| format!("Invalid Qoder base URL: {error}"))?;
+    match parsed.host_str().map(|host| host.to_ascii_lowercase()) {
+        Some(host) if matches!(host.as_str(), "qoder.com" | "www.qoder.com") => {
+            Ok(QoderRegion::Global)
+        }
+        Some(host) if matches!(host.as_str(), "qoder.com.cn" | "www.qoder.com.cn") => {
+            Ok(QoderRegion::Cn)
+        }
+        _ => Err("Qoder base URL must select qoder.com or qoder.com.cn".to_string()),
+    }
+}
+
+pub(crate) fn has_supported_region(base_url: Option<&str>) -> bool {
+    resolve_region(base_url).is_ok()
+}
+
+fn qoder_headers(cookie: &str, region: QoderRegion) -> Result<HeaderMap, String> {
+    let origin = region.origin();
+    let mut headers = HeaderMap::with_capacity(8);
+    headers.insert(COOKIE, header_value(cookie, "Qoder cookie")?);
+    headers.insert(
+        ACCEPT,
+        HeaderValue::from_static("application/json, text/plain, */*"),
+    );
+    headers.insert(ACCEPT_LANGUAGE, HeaderValue::from_static("en-US,en;q=0.9"));
+    headers.insert(USER_AGENT, HeaderValue::from_static(BROWSER_USER_AGENT));
+    headers.insert(ORIGIN, HeaderValue::from_static(origin));
+    headers.insert(
+        REFERER,
+        header_value(&format!("{origin}/account/usage"), "Qoder referrer")?,
+    );
+    headers.insert(
+        reqwest::header::HeaderName::from_static("x-requested-with"),
+        HeaderValue::from_static("XMLHttpRequest"),
+    );
+    headers.insert(
+        reqwest::header::HeaderName::from_static("bx-v"),
+        HeaderValue::from_static("2.5.35"),
+    );
+    Ok(headers)
+}
+
+fn header_value(value: &str, field: &str) -> Result<HeaderValue, String> {
+    if value.len() > MAX_COOKIE_BYTES {
+        return Err(format!(
+            "{field} exceeds the {MAX_COOKIE_BYTES}-byte request-header limit"
+        ));
+    }
+    HeaderValue::from_str(value).map_err(|_| format!("{field} is not a valid HTTP header value"))
+}
+
+#[derive(Debug)]
+struct CreditSummary {
+    used: f64,
+    limit: f64,
+    remaining: f64,
+    usage_percentage: Option<f64>,
+}
+
+fn parse_qoder_quota(body: &Value) -> Result<QuotaInfo, String> {
+    let payload = body
+        .get("data")
+        .filter(|value| value.is_object())
+        .unwrap_or(body);
+    let total = payload
+        .get("totalQuota")
+        .or_else(|| payload.get("total_quota"))
+        .and_then(quota_summary)
+        .and_then(parse_credit_summary)
+        .ok_or_else(|| {
+            "Qoder quota HTTP 200 response has no usable totalQuota.quotaSummary".to_string()
+        })?;
+    let shared = payload
+        .get("sharedQuota")
+        .or_else(|| payload.get("shared_quota"))
+        .and_then(quota_summary)
+        .and_then(parse_credit_summary);
+
+    let used = total.used + shared.as_ref().map_or(0.0, |summary| summary.used);
+    let limit = total.limit + shared.as_ref().map_or(0.0, |summary| summary.limit);
+    let remaining = total.remaining + shared.as_ref().map_or(0.0, |summary| summary.remaining);
+    let used_percent = if limit > 0.0 {
+        (used / limit * 100.0).clamp(0.0, 100.0)
+    } else {
+        total.usage_percentage.unwrap_or(100.0)
+    };
+    let remaining_percent = 100.0 - used_percent;
+    let reset_time = payload
+        .get("nextResetAt")
+        .or_else(|| payload.get("next_reset_at"))
+        .and_then(json_time_to_rfc3339);
+    let plan_type = parse_qoder_plan_label(body).unwrap_or_else(|| PLAN_TYPE_DEFAULT.to_string());
+
+    Ok(QuotaInfo {
+        remaining_percentage: remaining_percent,
+        used: Some(used.round() as i64),
+        limit: Some(limit.round() as i64),
+        remaining: Some(remaining.round() as i64),
+        reset_time: reset_time.clone(),
+        plan_type: Some(plan_type),
+        quota_source: Some(QUOTA_SOURCE.to_string()),
+        usage_items: vec![UsageItem {
+            usage_type: "credits".to_string(),
+            enabled: true,
+            used: Some(used.round() as i64),
+            limit: Some(limit.round() as i64),
+            remaining: Some(remaining.round() as i64),
+            remaining_percentage: remaining_percent,
+            reset_time,
+        }],
+        ..Default::default()
+    })
+}
+
+fn quota_summary(value: &Value) -> Option<&Value> {
+    value
+        .get("quotaSummary")
+        .or_else(|| value.get("quota_summary"))
+}
+
+fn parse_credit_summary(summary: &Value) -> Option<CreditSummary> {
+    let used = finite_number(
+        summary
+            .get("usedValue")
+            .or_else(|| summary.get("used_value")),
+    )?;
+    let limit = finite_number(
+        summary
+            .get("limitValue")
+            .or_else(|| summary.get("limit_value")),
+    )?;
+    if used < 0.0 || limit < 0.0 {
+        return None;
+    }
+    let remaining = finite_number(
+        summary
+            .get("remainingValue")
+            .or_else(|| summary.get("remaining_value")),
+    )
+    .unwrap_or_else(|| (limit - used).max(0.0))
+    .max(0.0);
+    let usage_percentage = finite_number(
+        summary
+            .get("usagePercentage")
+            .or_else(|| summary.get("usage_percentage")),
+    )
+    .map(|percentage| percentage.clamp(0.0, 100.0));
+    Some(CreditSummary {
+        used,
+        limit,
+        remaining,
+        usage_percentage,
+    })
+}
+
+fn finite_number(value: Option<&Value>) -> Option<f64> {
+    let value = value?;
+    let number = value
+        .as_f64()
+        .or_else(|| value.as_str()?.trim().parse::<f64>().ok())?;
+    number.is_finite().then_some(number)
+}
+
+fn parse_qoder_plan_label(body: &Value) -> Option<String> {
+    let data = body.get("data").filter(|value| value.is_object());
+    let subscription = data
+        .and_then(|value| value.get("subscription"))
+        .or_else(|| body.get("subscription"));
+    let current = data
+        .and_then(|value| {
+            value
+                .get("current")
+                .or_else(|| value.get("currentPlan"))
+                .or_else(|| value.get("current_plan"))
+        })
+        .or_else(|| {
+            body.get("current")
+                .or_else(|| body.get("currentPlan"))
+                .or_else(|| body.get("current_plan"))
+        });
+
+    [Some(body), data, subscription, current]
+        .into_iter()
+        .flatten()
+        .find_map(first_plan_label)
+}
+
+fn first_plan_label(value: &Value) -> Option<String> {
+    [
+        "plan_tier",
+        "planTier",
+        "plan",
+        "tier",
+        "name",
+        "product_name",
+        "productName",
+        "subscription_type",
+        "subscriptionType",
+    ]
+    .into_iter()
+    .find_map(|field| value.get(field).and_then(Value::as_str))
+    .and_then(normalize_plan_label)
+}
+
+fn normalize_plan_label(raw: &str) -> Option<String> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    let uppercase = raw.to_ascii_uppercase();
+    let without_prefix = if uppercase.starts_with("ORGANIZATION_PLAN_TIER_") {
+        &raw["ORGANIZATION_PLAN_TIER_".len()..]
+    } else if uppercase.starts_with("PLAN_TIER_") {
+        &raw["PLAN_TIER_".len()..]
+    } else {
+        raw
+    };
+    let normalized = without_prefix
+        .replace(['_', '-'], " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase();
+    let known = match normalized.as_str() {
+        "free" | "community" | "communityedition" | "community edition" => {
+            Some("Community Edition")
+        }
+        "protrial" | "pro trial" => Some("Pro Trial"),
+        "pro" => Some("Pro"),
+        "proplus" | "pro plus" | "pro+" => Some("Pro+"),
+        "ultra" => Some("Ultra"),
+        "team" | "teams" => Some("Teams"),
+        "enterprise" => Some("Enterprise"),
+        _ => None,
+    };
+    Some(
+        known
+            .map(str::to_string)
+            .unwrap_or_else(|| title_case(&normalized)),
+    )
+}
+
+fn title_case(value: &str) -> String {
+    value
+        .split_whitespace()
+        .map(|word| {
+            let mut characters = word.chars();
+            match characters.next() {
+                Some(first) => first.to_uppercase().chain(characters).collect(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn base_url_pins_exactly_one_region() {
+        assert_eq!(resolve_region(None).unwrap(), QoderRegion::Global);
+        assert_eq!(
+            resolve_region(Some("https://qoder.com/account")).unwrap(),
+            QoderRegion::Global
+        );
+        assert_eq!(
+            resolve_region(Some("https://www.qoder.com.cn/account")).unwrap(),
+            QoderRegion::Cn
+        );
+        assert!(resolve_region(Some("https://example.com")).is_err());
+        assert!(!has_supported_region(Some("https://example.com")));
+    }
+
+    #[test]
+    fn parser_combines_total_and_shared_credits() {
+        let quota = parse_qoder_quota(&json!({
+            "data": {
+                "planTier": "PLAN_TIER_PRO_PLUS",
+                "totalQuota": {
+                    "quotaSummary": {
+                        "usedValue": "20",
+                        "limitValue": 100,
+                        "remainingValue": 80
+                    }
+                },
+                "shared_quota": {
+                    "quota_summary": {
+                        "used_value": 10,
+                        "limit_value": "100",
+                        "remaining_value": 90
+                    }
+                },
+                "nextResetAt": 1785564000000_i64
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(quota.plan_type.as_deref(), Some("Pro+"));
+        assert_eq!(quota.used, Some(30));
+        assert_eq!(quota.limit, Some(200));
+        assert_eq!(quota.remaining, Some(170));
+        assert_eq!(quota.remaining_percentage, 85.0);
+        assert_eq!(quota.usage_items.len(), 1);
+        assert_eq!(quota.usage_items[0].usage_type, "credits");
+        assert_eq!(quota.reset_time.as_deref(), Some("2026-08-01T06:00:00Z"));
+    }
+
+    #[test]
+    fn plan_parser_handles_nested_subscription_and_known_tiers() {
+        assert_eq!(
+            parse_qoder_plan_label(&json!({
+                "data": {
+                    "subscription": {"subscription_type": "ORGANIZATION_PLAN_TIER_TEAM"}
+                }
+            }))
+            .as_deref(),
+            Some("Teams")
+        );
+        assert_eq!(
+            parse_qoder_plan_label(&json!({"data": {"current_plan": {"name": "alpha-plan"}}}))
+                .as_deref(),
+            Some("Alpha Plan")
+        );
+    }
+
+    #[test]
+    fn parser_rejects_missing_total_summary() {
+        let error = parse_qoder_quota(&json!({"data": {}})).unwrap_err();
+        assert!(error.contains("HTTP 200"));
+        assert!(error.contains("totalQuota.quotaSummary"));
+    }
+
+    #[test]
+    fn cookie_header_has_an_explicit_memory_bound() {
+        let oversized = "x".repeat(MAX_COOKIE_BYTES + 1);
+        let error = header_value(&oversized, "Qoder cookie").unwrap_err();
+        assert!(error.contains("request-header limit"));
+    }
+}


### PR DESCRIPTION
## Problem

ORGII knew Qoder as a CLI agent but could not surface its account credit usage. A naive integration could probe both Qoder regions, retry transient responses, or fetch plan metadata on every refresh, multiplying network work and cache churn.

## Solution

Add one bounded Qoder credit adapter on top of the ZAI Team and quota-runtime stack:

- select exactly one region from the saved base URL, accepting only qoder.com or qoder.com.cn;
- prefer the saved session token, fall back to the saved API-key field, and send the value only as a capped Cookie header;
- fetch big-model credit usage with one GET;
- issue at most one same-region plan request, and only when usable quota lacks a plan label;
- disable transient retry for Qoder so the end-to-end ceiling is one request on the normal path and two on the label-fallback path;
- combine total and shared credits, validate finite non-negative values, and expose refresh capability only when both a secret and supported region exist.

The adapter reuses single-flight, global concurrency 3, success TTL, failure cooldown, generation guard, 256-account LRU, HTTPS-only client, redirect denial, 12-second deadline, and 1 MiB response cap. It adds no timer, watcher, scan, process invocation, cross-region probing, or retained provider-specific cache.

## Potential risks

- Qoder uses a web-session cookie and private JSON response shapes; an upstream field or authentication change may make refresh fail until the adapter is updated. Failed attempts preserve last-good quota through the shared runtime.
- When the usage response omits a plan label, refresh performs one additional request. That fallback is same-region, best-effort, and never blocks otherwise valid credit data.
- No live Qoder account was used for end-to-end verification. Fixture tests cover total plus shared credits, plan nesting, region pinning, header limits, and malformed payloads.
- The OpenCode credential selection now skips a blank preferred session token before falling back to the API-key field; tests cover the shared helper and preserve existing nonblank precedence.
- No persistence schema or public wire shape changes are introduced. Rollback is a revert of this commit; the parent quota runtime remains compatible.

## Audit

Performance guard verdict: pass. Idle cost is zero, normal refresh is one request, worst-case refresh is two, response memory is capped at 1 MiB, Cookie memory is capped at 64 KiB, concurrency and retained account state remain bounded, and there is no region probing.

Architecture review covered provider ownership, secret precedence, region identity, request-count state transitions, capability parity, failure and last-good semantics, shared runtime boundaries, and test seams. Frontend rendering and unrelated lifecycle code are unchanged.

No screenshot was captured because this is a backend provider adapter with no layout, copy, loading, empty, or error-state UI change.

## Verification

- CARGO_BUILD_JOBS=1 cargo test -p key_vault --lib — 331 passed on the full Qoder plus parent stack.
- CARGO_BUILD_JOBS=1 cargo clippy -p key_vault --all-targets --no-deps — completed with only three pre-existing warnings in unrelated key-vault files.
- rustfmt on the three changed Rust files — passed.
- git diff --check — passed.
- Diff scan for secrets, private keys, bearer tokens, and personal paths — passed.
- The isolated worktree lacked the generated Husky shim, so the equivalent Rust formatting, tests, scoped clippy, and staged-diff checks were run manually before committing.

Not run: a live Qoder request, because no Qoder credential was used.
