### PR TITLE
fix(workstation): preserve async git views across tab switches

### DIFF
--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/DirectoryExplorerContent.remount.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/DirectoryExplorerContent.remount.test.ts
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+import { readDir } from "@tauri-apps/plugin-fs";
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { getGitCommits } from "@src/api/http/git";
+import { resetDirectoryViewResourceForTests } from "@src/services/git/directoryViewResource";
+
+import DirectoryExplorerContent from "./DirectoryExplorerContent";
+
+const mocks = vi.hoisted(() => ({
+  t: (key: string) => key,
+}));
+
+vi.mock("@tauri-apps/plugin-fs", () => ({
+  readDir: vi.fn(),
+}));
+
+vi.mock("@src/api/http/git", () => ({
+  getGitCommits: vi.fn(),
+}));
+
+vi.mock("@src/components/FileTypeIcon", () => ({
+  default: () => null,
+}));
+
+vi.mock("@src/engines/ChatPanel/blocks/primitives", () => ({
+  ComposerStackListRow: ({ primary }: { primary: string }) =>
+    createElement("span", null, primary),
+}));
+
+vi.mock("@src/modules/WorkStation/shared", () => ({
+  FileHeader: ({ filePath }: { filePath: string }) =>
+    createElement("header", null, filePath),
+}));
+
+vi.mock("@src/modules/shared/layouts/blocks", () => ({
+  Placeholder: ({ variant }: { variant: string }) =>
+    createElement("div", { "data-placeholder": variant }, variant),
+}));
+
+vi.mock("@src/store/workstation/tabs", () => ({
+  createDirectoryTab: vi.fn(),
+  openTab: vi.fn(),
+  workstationLayoutAtom: {},
+}));
+
+vi.mock("@src/util/core/state/instrumentedStore", () => ({
+  getInstrumentedStore: () => ({ set: vi.fn() }),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: mocks.t,
+  }),
+}));
+
+vi.mock("react-virtuoso", () => ({
+  Virtuoso: ({
+    data,
+    itemContent,
+  }: {
+    data: Array<{ path: string; type: string }>;
+    itemContent: (
+      index: number,
+      item: { path: string; type: string }
+    ) => unknown;
+  }) =>
+    createElement(
+      "div",
+      null,
+      ...data.map((item, index) =>
+        createElement(
+          "div",
+          { key: `${item.type}:${item.path}` },
+          itemContent(index, item) as never
+        )
+      )
+    ),
+}));
+
+const readDirMock = vi.mocked(readDir);
+const getGitCommitsMock = vi.mocked(getGitCommits);
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+describe("DirectoryExplorerContent remount continuity", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    resetDirectoryViewResourceForTests();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    readDirMock.mockResolvedValue([
+      {
+        isDirectory: false,
+        isFile: true,
+        isSymlink: false,
+        name: "a.ts",
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(reactActEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("shows entries before metadata settles and keeps them on re-entry", async () => {
+    const metadata = deferred<Awaited<ReturnType<typeof getGitCommits>>>();
+    getGitCommitsMock.mockReturnValue(metadata.promise);
+
+    await act(async () => {
+      root.render(
+        createElement(DirectoryExplorerContent, {
+          directoryPath: "/repo/src",
+          onFileSelect: vi.fn(),
+          repoPath: "/repo",
+        })
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain("a.ts");
+    expect(container.querySelector('[data-placeholder="loading"]')).toBeNull();
+
+    act(() => root.unmount());
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        createElement(DirectoryExplorerContent, {
+          directoryPath: "/repo/src",
+          onFileSelect: vi.fn(),
+          repoPath: "/repo",
+        })
+      );
+    });
+
+    expect(container.textContent).toContain("a.ts");
+    expect(container.querySelector('[data-placeholder="loading"]')).toBeNull();
+    expect(readDirMock).toHaveBeenCalledTimes(1);
+    expect(getGitCommitsMock).toHaveBeenCalledTimes(1);
+
+    metadata.resolve({ commits: [], total_count: 0 });
+    await act(async () => {
+      await metadata.promise;
+      await Promise.resolve();
+    });
+  });
+});

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/DirectoryExplorerContent.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/DirectoryExplorerContent.tsx
@@ -1,4 +1,3 @@
-import { readDir } from "@tauri-apps/plugin-fs";
 import React, {
   memo,
   useCallback,
@@ -10,38 +9,33 @@ import React, {
 import { useTranslation } from "react-i18next";
 import { Virtuoso } from "react-virtuoso";
 
-import { getGitCommits } from "@src/api/http/git";
 import FileTypeIcon from "@src/components/FileTypeIcon";
 import { ComposerStackListRow } from "@src/engines/ChatPanel/blocks/primitives";
 import { FileHeader } from "@src/modules/WorkStation/shared";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
+import {
+  type DirectoryEntryGitMeta,
+  type DirectoryEntryRow,
+  type DirectoryViewRequest,
+  getCachedDirectoryEntries,
+  getCachedDirectoryMetadata,
+  loadDirectoryEntries,
+  loadDirectoryMetadata,
+} from "@src/services/git/directoryViewResource";
 import {
   createDirectoryTab,
   openTab as openTabHelper,
   workstationLayoutAtom,
 } from "@src/store/workstation/tabs";
 import { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";
-import { toFsPluginPath } from "@src/util/file/pathUtils";
 import { formatRelativeTime } from "@src/util/time/formatRelativeTime";
 
-const MAX_GIT_META_ENTRIES = 80;
 const DIRECTORY_ROW_HEIGHT = 34;
 
 interface DirectoryExplorerContentProps {
   directoryPath: string;
   repoPath: string;
   onFileSelect: (path: string) => void;
-}
-
-interface DirectoryEntryRow {
-  name: string;
-  path: string;
-  type: "directory" | "file";
-}
-
-interface DirectoryEntryGitMeta {
-  summary: string;
-  authorDate: string;
 }
 
 interface DirectoryListItem {
@@ -63,67 +57,6 @@ function getParentPath(path: string): string | null {
   return normalized.slice(0, separatorIndex);
 }
 
-async function loadDirectoryEntries(
-  directoryPath: string
-): Promise<DirectoryEntryRow[]> {
-  // On Windows the repo path arrives canonicalized as `\\?\C:\…`, which the
-  // Tauri fs plugin can't read (readDir returns nothing → "top level but no
-  // children"). Strip the verbatim prefix before reading, and build child
-  // paths from the cleaned dir so they're usable too.
-  const dir = toFsPluginPath(directoryPath).replace(/\/+$/, "");
-  const entries = await readDir(dir);
-  return entries
-    .map((entry) => ({
-      name: entry.name,
-      path: `${dir}/${entry.name}`,
-      type: entry.isDirectory ? ("directory" as const) : ("file" as const),
-    }))
-    .sort((left, right) => {
-      if (left.type !== right.type) {
-        return left.type === "directory" ? -1 : 1;
-      }
-      return left.name.localeCompare(right.name);
-    });
-}
-
-async function loadEntryGitMeta(
-  entryPath: string,
-  repoPath: string
-): Promise<DirectoryEntryGitMeta | undefined> {
-  const filePath = toRelativePath(entryPath, repoPath);
-  const result = await getGitCommits({
-    repo_id: repoPath,
-    repo_path: repoPath,
-    file_path: filePath,
-    limit: 1,
-  });
-  const commit = result?.commits[0];
-  if (!commit) return undefined;
-  return {
-    summary: commit.summary,
-    authorDate: commit.author.date,
-  };
-}
-
-async function loadEntryGitMetaMap(
-  entries: DirectoryEntryRow[],
-  repoPath: string
-): Promise<Map<string, DirectoryEntryGitMeta>> {
-  const pairs = await Promise.all(
-    entries.slice(0, MAX_GIT_META_ENTRIES).map(async (entry) => {
-      try {
-        const meta = await loadEntryGitMeta(entry.path, repoPath);
-        return meta ? ([entry.path, meta] as const) : null;
-      } catch {
-        return null;
-      }
-    })
-  );
-  return new Map(
-    pairs.filter((pair): pair is [string, DirectoryEntryGitMeta] => !!pair)
-  );
-}
-
 function openDirectoryTab(directoryPath: string): void {
   const store = getInstrumentedStore();
   const tab = createDirectoryTab(directoryPath);
@@ -139,11 +72,31 @@ function openDirectoryTab(directoryPath: string): void {
 const DirectoryExplorerContent: React.FC<DirectoryExplorerContentProps> = memo(
   ({ directoryPath, repoPath, onFileSelect }) => {
     const { t } = useTranslation("sessions");
-    const [entries, setEntries] = useState<DirectoryEntryRow[]>([]);
+    const request = useMemo<DirectoryViewRequest>(
+      () => ({ directoryPath, repoPath }),
+      [directoryPath, repoPath]
+    );
+    const initialEntries = useMemo(
+      () => getCachedDirectoryEntries(request),
+      [request]
+    );
+    const initialMetadata = useMemo(
+      () =>
+        initialEntries
+          ? getCachedDirectoryMetadata(request, initialEntries)
+          : null,
+      [initialEntries, request]
+    );
+    const [entries, setEntries] = useState<DirectoryEntryRow[]>(
+      () => initialEntries ?? []
+    );
     const [gitMetaMap, setGitMetaMap] = useState<
       Map<string, DirectoryEntryGitMeta>
-    >(new Map());
-    const [loading, setLoading] = useState(true);
+    >(() => initialMetadata ?? new Map());
+    const [hasLoadedEntries, setHasLoadedEntries] = useState(
+      () => initialEntries !== null
+    );
+    const [loading, setLoading] = useState(() => initialEntries === null);
     const [error, setError] = useState<string | null>(null);
     const loadGenerationRef = useRef(0);
 
@@ -176,25 +129,43 @@ const DirectoryExplorerContent: React.FC<DirectoryExplorerContentProps> = memo(
 
     useEffect(() => {
       const generation = ++loadGenerationRef.current;
-      setEntries([]);
-      setGitMetaMap(new Map());
-      setLoading(true);
+      const cachedEntries = getCachedDirectoryEntries(request);
+      const cachedMetadata = cachedEntries
+        ? getCachedDirectoryMetadata(request, cachedEntries)
+        : null;
+
+      setEntries(cachedEntries ?? []);
+      setGitMetaMap(cachedMetadata ?? new Map());
+      setHasLoadedEntries(cachedEntries !== null);
+      setLoading(cachedEntries === null);
       setError(null);
 
       void (async () => {
         try {
-          const loadedEntries = await loadDirectoryEntries(directoryPath);
-          if (generation !== loadGenerationRef.current) return;
-
-          const loadedGitMetaMap = await loadEntryGitMetaMap(
-            loadedEntries,
-            repoPath
-          );
+          const loadedEntries = await loadDirectoryEntries(request);
           if (generation !== loadGenerationRef.current) return;
 
           setEntries(loadedEntries);
-          setGitMetaMap(loadedGitMetaMap);
+          setHasLoadedEntries(true);
+          setLoading(false);
           setError(null);
+
+          const cachedLoadedMetadata = getCachedDirectoryMetadata(
+            request,
+            loadedEntries
+          );
+          if (cachedLoadedMetadata) {
+            setGitMetaMap(cachedLoadedMetadata);
+          } else if (cachedEntries !== loadedEntries) {
+            setGitMetaMap(new Map());
+          }
+
+          const loadedGitMetaMap = await loadDirectoryMetadata(
+            request,
+            loadedEntries
+          );
+          if (generation !== loadGenerationRef.current) return;
+          setGitMetaMap(loadedGitMetaMap);
         } catch (loadError: unknown) {
           if (generation !== loadGenerationRef.current) return;
           const message =
@@ -212,7 +183,7 @@ const DirectoryExplorerContent: React.FC<DirectoryExplorerContentProps> = memo(
           loadGenerationRef.current += 1;
         }
       };
-    }, [directoryPath, repoPath, t]);
+    }, [request, t]);
 
     const handleOpenItem = useCallback(
       (item: DirectoryListItem) => {
@@ -275,7 +246,7 @@ const DirectoryExplorerContent: React.FC<DirectoryExplorerContentProps> = memo(
       [handleOpenItem]
     );
 
-    if (loading) {
+    if (loading && !hasLoadedEntries) {
       return (
         <>
           <FileHeader
@@ -297,7 +268,7 @@ const DirectoryExplorerContent: React.FC<DirectoryExplorerContentProps> = memo(
       );
     }
 
-    if (error) {
+    if (error && !hasLoadedEntries) {
       return (
         <>
           <FileHeader

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitCommitDetailContent/useCommitDiffLoader.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitCommitDetailContent/useCommitDiffLoader.ts
@@ -1,8 +1,15 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { getGitCommitDiff } from "@src/api/http/git/diff";
 import type { CommitDiffResult } from "@src/api/http/git/types";
 import { createLogger } from "@src/hooks/logger";
+import {
+  type CommitDetailRequest,
+  getCachedCommitDiff,
+  getCachedCommitSelection,
+  getCommitDetailScopeKey,
+  loadCommitDiff,
+  setCachedCommitSelection,
+} from "@src/services/git/gitCommitDetailResource";
 import { decodeOctalPath } from "@src/util/file/pathUtils";
 
 type CommitLoadState = "loading" | "ready" | "error" | "no-files" | "missing";
@@ -26,9 +33,69 @@ interface UseCommitDiffLoaderResult {
   reloadCommit: () => void;
 }
 
+interface CommitLoaderState {
+  commitDiff: CommitDiffResult | null;
+  commitError: string | null;
+  commitLoadState: CommitLoadState;
+  scopeKey: string;
+  selectedFilePath: string | null;
+}
+
+function selectAvailableFile(
+  request: CommitDetailRequest,
+  commitDiff: CommitDiffResult,
+  preferredPath?: string | null
+): string | null {
+  const files = commitDiff.files ?? [];
+  const decodedPaths = files.map((file) => decodeOctalPath(file.file_path));
+  const cachedPath = getCachedCommitSelection(request);
+  const selectedPath =
+    (preferredPath && decodedPaths.includes(preferredPath)
+      ? preferredPath
+      : null) ??
+    (cachedPath && decodedPaths.includes(cachedPath) ? cachedPath : null) ??
+    decodedPaths[0] ??
+    null;
+  return selectedPath;
+}
+
+function stateFromDiff(
+  request: CommitDetailRequest,
+  scopeKey: string,
+  commitDiff: CommitDiffResult,
+  preferredPath?: string | null
+): CommitLoaderState {
+  const files = commitDiff.files ?? [];
+  return {
+    commitDiff,
+    commitError: null,
+    commitLoadState: files.length === 0 ? "no-files" : "ready",
+    scopeKey,
+    selectedFilePath: selectAvailableFile(request, commitDiff, preferredPath),
+  };
+}
+
+function initialState(
+  request: CommitDetailRequest,
+  scopeKey: string
+): CommitLoaderState {
+  const cachedDiff = getCachedCommitDiff(request);
+  return cachedDiff
+    ? stateFromDiff(request, scopeKey, cachedDiff)
+    : {
+        commitDiff: null,
+        commitError: null,
+        commitLoadState: "loading",
+        scopeKey,
+        selectedFilePath: null,
+      };
+}
+
 /**
  * Fetches the commit diff (file list + stats) for a given commit SHA.
- * Automatically selects the first file when the diff loads successfully.
+ * Successful immutable SHA data and the selected file survive tab remounts in
+ * a bounded app-session cache; explicit reload preserves visible data while
+ * the replacement request is pending.
  */
 export function useCommitDiffLoader({
   commitSha,
@@ -37,139 +104,147 @@ export function useCommitDiffLoader({
   isRepoReady,
   treatEmptyResultAsMissing = false,
 }: UseCommitDiffLoaderParams): UseCommitDiffLoaderResult {
-  const [commitDiff, setCommitDiff] = useState<CommitDiffResult | null>(null);
-  const [commitLoadState, setCommitLoadState] =
-    useState<CommitLoadState>("loading");
-  const [commitError, setCommitError] = useState<string | null>(null);
-  const [selectedFilePath, setSelectedFilePath] = useState<string | null>(null);
-  const [commitReloadKey, setCommitReloadKey] = useState(0);
+  const request = useMemo<CommitDetailRequest>(
+    () => ({ commitSha, repoId, repoPath }),
+    [commitSha, repoId, repoPath]
+  );
+  const scopeKey = getCommitDetailScopeKey(request);
+  const scopedInitialState = useMemo(
+    () => initialState(request, scopeKey),
+    [request, scopeKey]
+  );
+  const [state, setState] = useState<CommitLoaderState>(
+    () => scopedInitialState
+  );
+  const loadGenerationRef = useRef(0);
 
-  const reloadCommit = useCallback(() => {
-    setCommitLoadState("loading");
-    setCommitError(null);
-    setCommitDiff(null);
-    setSelectedFilePath(null);
-    setCommitReloadKey((prev) => prev + 1);
-  }, []);
+  const runLoad = useCallback(
+    async (force: boolean) => {
+      if (!repoId || !repoPath || !isRepoReady) return;
 
-  useEffect(() => {
-    let cancelled = false;
-
-    const fetchDiff = async () => {
-      if (!repoId || !repoPath || !isRepoReady) {
-        logger.warn(
-          `commit diff load skipped sha=${commitSha} repoId=${repoId} repoPath=${repoPath} ready=${isRepoReady}`,
-          {
-            commitSha,
-            repoId,
-            repoPath,
-            isRepoReady,
-          }
-        );
-        return;
-      }
+      const requestId = ++loadGenerationRef.current;
+      // Let the scope-derived render state paint first. This also keeps the
+      // effect entry point from synchronously cascading into another render.
+      await Promise.resolve();
+      if (requestId !== loadGenerationRef.current) return;
+      const cachedDiff = getCachedCommitDiff(request);
+      setState((current) => {
+        if (current.scopeKey === scopeKey && current.commitDiff) {
+          return { ...current, commitError: null };
+        }
+        return cachedDiff
+          ? stateFromDiff(request, scopeKey, cachedDiff)
+          : {
+              commitDiff: null,
+              commitError: null,
+              commitLoadState: "loading",
+              scopeKey,
+              selectedFilePath: null,
+            };
+      });
 
       logger.info(
         `commit diff load start sha=${commitSha} repoId=${repoId} repoPath=${repoPath}`,
-        {
-          commitSha,
-          repoId,
-          repoPath,
-        }
+        { commitSha, repoId, repoPath }
       );
-      setCommitLoadState("loading");
-      setCommitError(null);
-      setCommitDiff(null);
-      setSelectedFilePath(null);
 
       try {
-        const result = await getGitCommitDiff({
-          repo_id: repoId,
-          repo_path: repoPath,
-          commit_sha: commitSha,
-        });
-
-        if (cancelled) return;
+        const result = await loadCommitDiff(request, { force });
+        if (requestId !== loadGenerationRef.current) return;
 
         if (!result) {
           logger.warn(
             `commit diff load returned empty result sha=${commitSha} repoId=${repoId} repoPath=${repoPath}`,
-            {
-              commitSha,
-              repoId,
-              repoPath,
-            }
+            { commitSha, repoId, repoPath }
           );
-          setCommitLoadState(treatEmptyResultAsMissing ? "missing" : "error");
-          setCommitError(`commit=${commitSha}`);
+          setState({
+            commitDiff: null,
+            commitError: `commit=${commitSha}`,
+            commitLoadState: treatEmptyResultAsMissing ? "missing" : "error",
+            scopeKey,
+            selectedFilePath: null,
+          });
           return;
         }
 
-        setCommitDiff(result);
-
-        const files = result.files ?? [];
-        if (files.length === 0) {
-          logger.info(
-            `commit diff loaded with no files sha=${commitSha} repoId=${repoId} repoPath=${repoPath}`,
-            {
-              commitSha,
-              repoId,
-              repoPath,
-            }
-          );
-          setCommitLoadState("no-files");
-          return;
-        }
-
-        logger.info(
-          `commit diff load ready sha=${commitSha} repoId=${repoId} repoPath=${repoPath} files=${files.length}`,
-          {
-            commitSha,
-            repoId,
-            repoPath,
-            fileCount: files.length,
-            firstFilePath: files[0]?.file_path,
-          }
+        setState((current) =>
+          stateFromDiff(
+            request,
+            scopeKey,
+            result,
+            current.scopeKey === scopeKey ? current.selectedFilePath : null
+          )
         );
-        setCommitLoadState("ready");
-        setSelectedFilePath(decodeOctalPath(files[0].file_path));
-      } catch (err) {
-        if (!cancelled) {
-          logger.error(
-            `commit diff load failed sha=${commitSha} repoId=${repoId} repoPath=${repoPath}`,
-            {
-              commitSha,
-              repoId,
-              repoPath,
-              error: err,
-            }
-          );
-          setCommitLoadState("error");
-          setCommitError(
-            err instanceof Error ? err.message : `commit=${commitSha}`
-          );
-        }
+      } catch (error) {
+        if (requestId !== loadGenerationRef.current) return;
+        const message =
+          error instanceof Error ? error.message : `commit=${commitSha}`;
+        logger.error(
+          `commit diff load failed sha=${commitSha} repoId=${repoId} repoPath=${repoPath}`,
+          { commitSha, repoId, repoPath, error }
+        );
+        setState((current) =>
+          current.scopeKey === scopeKey && current.commitDiff
+            ? { ...current, commitError: message }
+            : {
+                commitDiff: null,
+                commitError: message,
+                commitLoadState: "error",
+                scopeKey,
+                selectedFilePath: null,
+              }
+        );
       }
-    };
+    },
+    [
+      commitSha,
+      isRepoReady,
+      repoId,
+      repoPath,
+      request,
+      scopeKey,
+      treatEmptyResultAsMissing,
+    ]
+  );
 
-    fetchDiff();
+  useEffect(() => {
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (!cancelled) void runLoad(false);
+    });
     return () => {
       cancelled = true;
+      loadGenerationRef.current += 1;
     };
-  }, [
-    commitSha,
-    repoId,
-    repoPath,
-    isRepoReady,
-    commitReloadKey,
-    treatEmptyResultAsMissing,
-  ]);
+  }, [runLoad]);
+
+  const reloadCommit = useCallback(() => {
+    void runLoad(true);
+  }, [runLoad]);
+
+  const setSelectedFilePath = useCallback(
+    (path: string | null) => {
+      setCachedCommitSelection(request, path);
+      setState((current) =>
+        current.scopeKey === scopeKey
+          ? { ...current, selectedFilePath: path }
+          : current
+      );
+    },
+    [request, scopeKey]
+  );
+
+  const visibleState = state.scopeKey === scopeKey ? state : scopedInitialState;
+
+  useEffect(() => {
+    setCachedCommitSelection(request, visibleState.selectedFilePath);
+  }, [request, visibleState.selectedFilePath]);
 
   return {
-    commitDiff,
-    commitLoadState,
-    commitError,
-    selectedFilePath,
+    commitDiff: visibleState.commitDiff,
+    commitLoadState: visibleState.commitLoadState,
+    commitError: visibleState.commitError,
+    selectedFilePath: visibleState.selectedFilePath,
     setSelectedFilePath,
     reloadCommit,
   };

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitCommitDetailContent/useCommitFileDiffLoader.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitCommitDetailContent/useCommitFileDiffLoader.ts
@@ -1,8 +1,14 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import { getGitFileContent } from "@src/api/http/git/diff";
 import type { CommitDiffResult } from "@src/api/http/git/types";
 import { createLogger } from "@src/hooks/logger";
+import {
+  type CommitFileDiffRequest,
+  type CommitFileDiffSnapshot,
+  getCachedCommitFileDiff,
+  getCommitFileDiffScopeKey,
+  loadCommitFileDiff,
+} from "@src/services/git/gitCommitDetailResource";
 import { decodeOctalPath } from "@src/util/file/pathUtils";
 
 const log = createLogger("GitCommitDetailContent");
@@ -27,9 +33,37 @@ interface UseCommitFileDiffLoaderResult {
   reloadFile: () => void;
 }
 
+interface FileLoaderState extends CommitFileDiffSnapshot {
+  fileError: string | null;
+  fileLoadState: FileLoadState;
+  scopeKey: string | null;
+}
+
+const IDLE_STATE: FileLoaderState = {
+  fileError: null,
+  fileLoadState: "idle",
+  isBinary: false,
+  newContent: "",
+  oldContent: "",
+  scopeKey: null,
+};
+
+function readyState(
+  scopeKey: string,
+  snapshot: CommitFileDiffSnapshot
+): FileLoaderState {
+  return {
+    ...snapshot,
+    fileError: null,
+    fileLoadState: "ready",
+    scopeKey,
+  };
+}
+
 /**
- * Fetches the old and new file content for the selected file within a commit.
- * Re-fetches automatically when `selectedFilePath` or `commitDiff` changes.
+ * Fetches old/new file content for the selected commit file. Successful bodies
+ * are kept in a small byte-bounded cache so remounting a Commit or Stash tab
+ * does not blank the diff or repeat the same pair of git reads.
  */
 export function useCommitFileDiffLoader({
   commitSha,
@@ -39,140 +73,131 @@ export function useCommitFileDiffLoader({
   selectedFilePath,
   commitDiff,
 }: UseCommitFileDiffLoaderParams): UseCommitFileDiffLoaderResult {
-  const [fileOldContent, setFileOldContent] = useState<string>("");
-  const [fileNewContent, setFileNewContent] = useState<string>("");
-  const [selectedFileIsBinary, setSelectedFileIsBinary] = useState(false);
-  const [fileLoadState, setFileLoadState] = useState<FileLoadState>("idle");
-  const [fileError, setFileError] = useState<string | null>(null);
-  const [fileReloadKey, setFileReloadKey] = useState(0);
+  const fileInfo = useMemo(
+    () =>
+      selectedFilePath
+        ? ((commitDiff?.files ?? []).find(
+            (file) => decodeOctalPath(file.file_path) === selectedFilePath
+          ) ?? null)
+        : null,
+    [commitDiff, selectedFilePath]
+  );
+  const request = useMemo<CommitFileDiffRequest | null>(
+    () =>
+      selectedFilePath && fileInfo
+        ? {
+            commitSha,
+            filePath: selectedFilePath,
+            fileStatus: fileInfo.status,
+            parentSha: commitDiff?.parent_sha ?? null,
+            repoId,
+            repoPath,
+          }
+        : null,
+    [
+      commitDiff?.parent_sha,
+      commitSha,
+      fileInfo,
+      repoId,
+      repoPath,
+      selectedFilePath,
+    ]
+  );
+  const scopeKey = request ? getCommitFileDiffScopeKey(request) : null;
+  const scopedInitialState = useMemo<FileLoaderState>(() => {
+    if (!request || !scopeKey) return IDLE_STATE;
+    const cached = getCachedCommitFileDiff(request);
+    return cached
+      ? readyState(scopeKey, cached)
+      : { ...IDLE_STATE, fileLoadState: "loading", scopeKey };
+  }, [request, scopeKey]);
+  const [state, setState] = useState<FileLoaderState>(() => scopedInitialState);
+  const loadGenerationRef = useRef(0);
 
-  const reloadFile = useCallback(() => {
-    setFileReloadKey((prev) => prev + 1);
-  }, []);
+  const runLoad = useCallback(
+    async (force: boolean) => {
+      if (!request || !scopeKey || !repoId || !isRepoReady) return;
 
-  useEffect(() => {
-    let cancelled = false;
-
-    if (!selectedFilePath || !repoId || !commitDiff || !isRepoReady) {
-      return;
-    }
-
-    const fileInfo = (commitDiff.files ?? []).find(
-      (file) => decodeOctalPath(file.file_path) === selectedFilePath
-    );
-
-    if (!fileInfo) {
-      log.warn("[GitCommitDetailContent] file_not_in_commit_payload", {
-        commitSha,
-        selectedFilePath,
+      const requestId = ++loadGenerationRef.current;
+      // Defer state publication until after the scope-derived render commits.
+      await Promise.resolve();
+      if (requestId !== loadGenerationRef.current) return;
+      const cached = getCachedCommitFileDiff(request);
+      setState((current) => {
+        if (
+          current.scopeKey === scopeKey &&
+          current.fileLoadState === "ready"
+        ) {
+          return { ...current, fileError: null };
+        }
+        return cached
+          ? readyState(scopeKey, cached)
+          : { ...IDLE_STATE, fileLoadState: "loading", scopeKey };
       });
-      return;
-    }
 
-    const parentSha = commitDiff.parent_sha;
-    const oldRef = parentSha ?? "none";
-    const newRef = commitSha;
-
-    const fetchContent = async () => {
       log.debug("[GitCommitDetailContent] file_load_start", {
         commitSha,
         selectedFilePath,
       });
-      setFileLoadState("loading");
-      setFileError(null);
 
       try {
-        const [oldResult, newResult] = await Promise.all([
-          // No old content for added files or initial commits (no parent)
-          fileInfo?.status === "added" || !parentSha
-            ? Promise.resolve(undefined)
-            : getGitFileContent({
-                repo_id: repoId,
-                repo_path: repoPath,
-                file_path: selectedFilePath,
-                ref: parentSha,
-              }),
-          // No new content for deleted files
-          fileInfo?.status === "deleted"
-            ? Promise.resolve(undefined)
-            : getGitFileContent({
-                repo_id: repoId,
-                repo_path: repoPath,
-                file_path: selectedFilePath,
-                ref: commitSha,
-              }),
-        ]);
-
-        if (cancelled) return;
-
-        const expectedOld = fileInfo.status !== "added" && Boolean(parentSha);
-        const expectedNew = fileInfo.status !== "deleted";
-        const oldFailed = expectedOld && !oldResult;
-        const newFailed = expectedNew && !newResult;
-
-        if (oldFailed || newFailed) {
-          log.warn("[GitCommitDetailContent] file_load_partial_failure", {
-            selectedFilePath,
-            oldRef,
-            newRef,
-            oldFailed,
-            newFailed,
-          });
-          setFileLoadState("error");
-          setFileError(
-            `Failed to load content for ${selectedFilePath} (old_ref=${oldRef}, new_ref=${newRef}, old_failed=${String(oldFailed)}, new_failed=${String(newFailed)})`
-          );
-          return;
-        }
-
-        const isBinaryEncoding =
-          oldResult?.encoding === "base64" || newResult?.encoding === "base64";
-        log.debug("[GitCommitDetailContent] file_load_ready", {
+        const result = await loadCommitFileDiff(request, { force });
+        if (requestId !== loadGenerationRef.current) return;
+        setState(readyState(scopeKey, result));
+      } catch (error) {
+        if (requestId !== loadGenerationRef.current) return;
+        const message =
+          error instanceof Error
+            ? error.message
+            : `Failed to load content for ${selectedFilePath ?? ""}`;
+        log.error("[GitCommitDetailContent] file_load_error", {
+          commitSha,
           selectedFilePath,
-          isBinaryEncoding,
+          error,
         });
-        setSelectedFileIsBinary(isBinaryEncoding);
-        setFileOldContent(oldResult?.content ?? "");
-        setFileNewContent(newResult?.content ?? "");
-        setFileLoadState("ready");
-      } catch (err) {
-        if (!cancelled) {
-          log.error("[GitCommitDetailContent] file_load_error", {
-            selectedFilePath,
-            oldRef,
-            newRef,
-            error: err,
-          });
-          setFileLoadState("error");
-          setFileError(
-            err instanceof Error
-              ? err.message
-              : `Failed to load content for ${selectedFilePath} (old_ref=${oldRef}, new_ref=${newRef})`
-          );
-        }
+        setState((current) =>
+          current.scopeKey === scopeKey && current.fileLoadState === "ready"
+            ? { ...current, fileError: message }
+            : {
+                ...IDLE_STATE,
+                fileError: message,
+                fileLoadState: "error",
+                scopeKey,
+              }
+        );
       }
-    };
+    },
+    [commitSha, isRepoReady, repoId, request, scopeKey, selectedFilePath]
+  );
 
-    fetchContent();
+  useEffect(() => {
+    if (!request) {
+      loadGenerationRef.current += 1;
+      return undefined;
+    }
+
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (!cancelled) void runLoad(false);
+    });
     return () => {
       cancelled = true;
+      loadGenerationRef.current += 1;
     };
-  }, [
-    selectedFilePath,
-    repoId,
-    repoPath,
-    commitSha,
-    commitDiff,
-    isRepoReady,
-    fileReloadKey,
-  ]);
+  }, [request, runLoad]);
+
+  const reloadFile = useCallback(() => {
+    void runLoad(true);
+  }, [runLoad]);
+
+  const visibleState = state.scopeKey === scopeKey ? state : scopedInitialState;
 
   return {
-    fileOldContent,
-    fileNewContent,
-    selectedFileIsBinary,
-    fileLoadState,
-    fileError,
+    fileOldContent: visibleState.oldContent,
+    fileNewContent: visibleState.newContent,
+    selectedFileIsBinary: visibleState.isBinary,
+    fileLoadState: visibleState.fileLoadState,
+    fileError: visibleState.fileError,
     reloadFile,
   };
 }

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitCommitDetailContent/useCommitLoaders.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitCommitDetailContent/useCommitLoaders.test.ts
@@ -1,0 +1,250 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { getGitCommitDiff, getGitFileContent } from "@src/api/http/git/diff";
+import type { CommitDiffResult } from "@src/api/http/git/types";
+import { resetGitCommitDetailResourceForTests } from "@src/services/git/gitCommitDetailResource";
+
+import { useCommitDiffLoader } from "./useCommitDiffLoader";
+import { useCommitFileDiffLoader } from "./useCommitFileDiffLoader";
+
+vi.mock("@src/api/http/git/diff", () => ({
+  getGitCommitDiff: vi.fn(),
+  getGitFileContent: vi.fn(),
+}));
+
+const getGitCommitDiffMock = vi.mocked(getGitCommitDiff);
+const getGitFileContentMock = vi.mocked(getGitFileContent);
+
+function commitDiff(sha: string, summary = `Commit ${sha}`): CommitDiffResult {
+  return {
+    author: {
+      date: "2026-07-31",
+      email: "a@example.com",
+      name: "Ada",
+    },
+    body: "",
+    commit_sha: sha,
+    committer: {
+      date: "2026-07-31",
+      email: "a@example.com",
+      name: "Ada",
+    },
+    files: [
+      {
+        binary: false,
+        deletions: 1,
+        file_path: "src/a.ts",
+        hunks: [],
+        insertions: 1,
+        new_content: "after",
+        old_content: "before",
+        old_path: null,
+        status: "modified",
+      },
+    ],
+    parent_mode: "first-parent",
+    parent_sha: `${sha}-parent`,
+    parent_shas: [`${sha}-parent`],
+    selected_parent_index: 0,
+    short_sha: sha.slice(0, 7),
+    stats: { deletions: 1, files_changed: 1, insertions: 1 },
+    summary,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+interface LoaderSnapshot {
+  commit: ReturnType<typeof useCommitDiffLoader>;
+  file: ReturnType<typeof useCommitFileDiffLoader>;
+}
+
+function Probe({
+  commitSha,
+  onValue,
+}: {
+  commitSha: string;
+  onValue: (value: LoaderSnapshot) => void;
+}) {
+  const commit = useCommitDiffLoader({
+    commitSha,
+    isRepoReady: true,
+    repoId: "repo-1",
+    repoPath: "/repo",
+  });
+  const file = useCommitFileDiffLoader({
+    commitDiff: commit.commitDiff,
+    commitSha,
+    isRepoReady: true,
+    repoId: "repo-1",
+    repoPath: "/repo",
+    selectedFilePath: commit.selectedFilePath,
+  });
+  onValue({ commit, file });
+  return null;
+}
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+async function flushAsyncWork(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("commit detail loaders", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    resetGitCommitDetailResourceForTests();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    getGitCommitDiffMock.mockResolvedValue(commitDiff("commit-a"));
+    getGitFileContentMock.mockImplementation(async ({ ref }) => ({
+      content: ref?.endsWith("-parent") ? "before" : "after",
+      encoding: "utf-8",
+      exists: true,
+      file_path: "src/a.ts",
+      ref: ref ?? "HEAD",
+      size: 6,
+    }));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(reactActEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("hydrates the first remount render without commit or file loading states", async () => {
+    let latest!: LoaderSnapshot;
+    await act(async () => {
+      root.render(
+        createElement(Probe, {
+          commitSha: "commit-a",
+          onValue: (value) => {
+            latest = value;
+          },
+        })
+      );
+      await flushAsyncWork();
+    });
+    expect(latest.commit.commitLoadState).toBe("ready");
+    expect(latest.file.fileLoadState).toBe("ready");
+
+    act(() => root.unmount());
+    root = createRoot(container);
+    const remountStates: LoaderSnapshot[] = [];
+    await act(async () => {
+      root.render(
+        createElement(Probe, {
+          commitSha: "commit-a",
+          onValue: (value) => {
+            remountStates.push(value);
+          },
+        })
+      );
+      await flushAsyncWork();
+    });
+
+    expect(remountStates[0]?.commit.commitLoadState).toBe("ready");
+    expect(remountStates[0]?.file.fileLoadState).toBe("ready");
+    expect(getGitCommitDiffMock).toHaveBeenCalledTimes(1);
+    expect(getGitFileContentMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps successful commit content visible during an explicit reload", async () => {
+    let latest!: LoaderSnapshot;
+    await act(async () => {
+      root.render(
+        createElement(Probe, {
+          commitSha: "commit-a",
+          onValue: (value) => {
+            latest = value;
+          },
+        })
+      );
+      await flushAsyncWork();
+    });
+
+    const replacement = deferred<CommitDiffResult | undefined>();
+    getGitCommitDiffMock.mockReturnValueOnce(replacement.promise);
+    act(() => latest.commit.reloadCommit());
+
+    expect(latest.commit.commitLoadState).toBe("ready");
+    expect(latest.commit.commitDiff?.summary).toBe("Commit commit-a");
+
+    replacement.resolve(commitDiff("commit-a", "Updated"));
+    await act(flushAsyncWork);
+    expect(latest.commit.commitLoadState).toBe("ready");
+    expect(latest.commit.commitDiff?.summary).toBe("Updated");
+  });
+
+  it("ignores a late commit response after switching scopes", async () => {
+    const oldRequest = deferred<CommitDiffResult | undefined>();
+    getGitCommitDiffMock.mockImplementation(({ commit_sha }) =>
+      commit_sha === "commit-old"
+        ? oldRequest.promise
+        : Promise.resolve(commitDiff("commit-new"))
+    );
+    let latest!: LoaderSnapshot;
+
+    await act(async () => {
+      root.render(
+        createElement(Probe, {
+          commitSha: "commit-old",
+          onValue: (value) => {
+            latest = value;
+          },
+        })
+      );
+      await Promise.resolve();
+    });
+    await act(async () => {
+      root.render(
+        createElement(Probe, {
+          commitSha: "commit-new",
+          onValue: (value) => {
+            latest = value;
+          },
+        })
+      );
+      await flushAsyncWork();
+    });
+    expect(latest.commit.commitDiff?.commit_sha).toBe("commit-new");
+
+    oldRequest.resolve(commitDiff("commit-old"));
+    await act(flushAsyncWork);
+    expect(latest.commit.commitDiff?.commit_sha).toBe("commit-new");
+  });
+});

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/GitHistoryContent/GitHistoryContent.remount.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/GitHistoryContent/GitHistoryContent.remount.test.ts
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { getGitCommits } from "@src/api/http/git/commits";
+import { resetGitHistoryResourceForTests } from "@src/services/git/gitHistoryResource";
+
+import GitHistoryContent from ".";
+
+vi.mock("@src/api/http/git/commits", () => ({
+  getGitCommits: vi.fn(),
+}));
+
+vi.mock("@src/ActionSystem", () => ({
+  useActionSystem: () => ({ dispatch: vi.fn() }),
+}));
+
+vi.mock("@src/hooks/workStation/tabs/useWorkStationTabs", () => ({
+  useWorkStationTabs: () => ({
+    activeTab: { data: {}, type: "source-control" },
+    openTab: vi.fn(),
+    updateTabData: vi.fn(),
+  }),
+}));
+
+vi.mock("@src/modules/shared/layouts/blocks", () => ({
+  Placeholder: ({ variant }: { variant: string }) =>
+    createElement("div", { "data-placeholder": variant }, variant),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+
+vi.mock("react-virtuoso", () => ({
+  Virtuoso: ({
+    data,
+    itemContent,
+  }: {
+    data: Array<{ sha: string }>;
+    itemContent: (index: number, item: { sha: string }) => unknown;
+  }) =>
+    createElement(
+      "div",
+      null,
+      ...data.map((item, index) =>
+        createElement(
+          "div",
+          { key: item.sha },
+          itemContent(index, item) as never
+        )
+      )
+    ),
+}));
+
+vi.mock("./GitHistoryContextMenu", () => ({
+  default: () => null,
+}));
+
+const getGitCommitsMock = vi.mocked(getGitCommits);
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+describe("GitHistoryContent remount continuity", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    resetGitHistoryResourceForTests();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    getGitCommitsMock.mockResolvedValue({
+      commits: [
+        {
+          author: {
+            date: "2026-07-31",
+            email: "a@example.com",
+            name: "Ada",
+          },
+          body: "",
+          committer: {
+            date: "2026-07-31",
+            email: "a@example.com",
+            name: "Ada",
+          },
+          parent_shas: [],
+          sha: "abc1234",
+          short_sha: "abc1234",
+          summary: "Cached commit",
+        },
+      ],
+      total_count: 1,
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(reactActEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("renders cached rows instead of a loading placeholder on re-entry", async () => {
+    await act(async () => {
+      root.render(
+        createElement(GitHistoryContent, {
+          repoId: "repo-1",
+          repoPath: "/repo",
+          viewMode: "list",
+        })
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.textContent).toContain("Cached commit");
+
+    act(() => root.unmount());
+    root = createRoot(container);
+    await act(async () => {
+      root.render(
+        createElement(GitHistoryContent, {
+          repoId: "repo-1",
+          repoPath: "/repo",
+          viewMode: "list",
+        })
+      );
+    });
+
+    expect(container.textContent).toContain("Cached commit");
+    expect(container.querySelector('[data-placeholder="loading"]')).toBeNull();
+    expect(getGitCommitsMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/GitHistoryContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/GitHistoryContent/index.tsx
@@ -32,6 +32,12 @@ import {
 import { PRIMARY_SIDEBAR_HOVER } from "@src/modules/WorkStation/shared/tokens";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
 import {
+  type GitHistoryRequest,
+  getCachedGitHistory,
+  loadGitHistory,
+  writeGitHistoryCache,
+} from "@src/services/git/gitHistoryResource";
+import {
   SOURCE_CONTROL_CHANGES_TAB_ID,
   type SourceControlHistorySelection,
   createGitCommitDetailTab,
@@ -258,14 +264,29 @@ const GitHistoryContentInner: React.FC<GitHistoryContentInnerProps> = ({
         ? activeHistorySelection.commitSha
         : null;
 
-  const [commits, setCommits] = useState<GitCommitInfo[]>([]);
-  const [loading, setLoading] = useState(false);
+  const historyRequest = useMemo<GitHistoryRequest>(
+    () => ({
+      limit: COMMITS_PAGE_SIZE,
+      repoId,
+      repoPath,
+    }),
+    [repoId, repoPath]
+  );
+  const initialHistory = useMemo(
+    () => getCachedGitHistory(historyRequest),
+    [historyRequest]
+  );
+  const [commits, setCommits] = useState<GitCommitInfo[]>(
+    () => initialHistory?.commits ?? []
+  );
+  const [loading, setLoading] = useState(() => initialHistory === null);
   const [loadingMore, setLoadingMore] = useState(false);
-  const [hasMore, setHasMore] = useState(false);
+  const [hasMore, setHasMore] = useState(
+    () => initialHistory?.hasMore ?? false
+  );
   const [error, setError] = useState<string | null>(null);
   const [contextMenuCommit, setContextMenuCommit] =
     useState<GitCommitInfo | null>(null);
-  const lastLoadedKeyRef = useRef<string | null>(null);
   const loadGenerationRef = useRef(0);
   const loadingMoreRef = useRef(false);
 
@@ -273,29 +294,17 @@ const GitHistoryContentInner: React.FC<GitHistoryContentInnerProps> = ({
     async ({ force = false }: { force?: boolean } = {}) => {
       if (!repoId) return;
 
-      const loadKey = `${repoId}:${repoPath}`;
-      if (!force && lastLoadedKeyRef.current === loadKey) return;
-
       const requestId = ++loadGenerationRef.current;
       setLoading(true);
       setError(null);
 
       try {
-        const result = await getGitCommits({
-          repo_id: repoId,
-          repo_path: repoPath,
-          limit: COMMITS_PAGE_SIZE,
-        });
+        const result = await loadGitHistory(historyRequest, { force });
 
         if (requestId !== loadGenerationRef.current) return;
 
-        if (result?.commits) {
-          setCommits(result.commits);
-          setHasMore(result.commits.length >= COMMITS_PAGE_SIZE);
-          lastLoadedKeyRef.current = loadKey;
-        } else {
-          setError("Failed to load commit history");
-        }
+        setCommits(result.commits);
+        setHasMore(result.hasMore);
       } catch (err) {
         if (requestId !== loadGenerationRef.current) return;
 
@@ -306,7 +315,7 @@ const GitHistoryContentInner: React.FC<GitHistoryContentInnerProps> = ({
         }
       }
     },
-    [repoId, repoPath]
+    [historyRequest, repoId]
   );
 
   // Reset all component-owned history when the repository scope changes. The
@@ -314,10 +323,11 @@ const GitHistoryContentInner: React.FC<GitHistoryContentInnerProps> = ({
   // repurposed history view.
   useEffect(() => {
     loadGenerationRef.current += 1;
-    lastLoadedKeyRef.current = null;
     loadingMoreRef.current = false;
-    setCommits([]);
-    setHasMore(false);
+    const cachedHistory = getCachedGitHistory(historyRequest);
+    setCommits(cachedHistory?.commits ?? []);
+    setHasMore(cachedHistory?.hasMore ?? false);
+    setLoading(cachedHistory === null);
     setLoadingMore(false);
     setError(null);
     setContextMenuCommit(null);
@@ -325,18 +335,14 @@ const GitHistoryContentInner: React.FC<GitHistoryContentInnerProps> = ({
 
     return () => {
       loadGenerationRef.current += 1;
-      lastLoadedKeyRef.current = null;
       loadingMoreRef.current = false;
     };
-  }, [loadInitialCommits, repoId, repoPath]);
+  }, [historyRequest, loadInitialCommits]);
 
-  // Refresh: clear cache and re-fetch from scratch
+  // Refresh in place: keep the last successful rows visible while revalidating.
   const handleRefresh = useCallback(() => {
-    loadGenerationRef.current += 1;
-    lastLoadedKeyRef.current = null;
     loadingMoreRef.current = false;
     setLoadingMore(false);
-    setHasMore(false);
     setError(null);
     void loadInitialCommits({ force: true });
   }, [loadInitialCommits]);
@@ -365,8 +371,16 @@ const GitHistoryContentInner: React.FC<GitHistoryContentInnerProps> = ({
       if (requestGeneration !== loadGenerationRef.current) return;
 
       if (result?.commits) {
-        setCommits((prev) => [...prev, ...result.commits]);
-        setHasMore(result.commits.length >= COMMITS_PAGE_SIZE);
+        const nextHasMore = result.commits.length >= COMMITS_PAGE_SIZE;
+        setCommits((prev) => {
+          const nextCommits = [...prev, ...result.commits];
+          writeGitHistoryCache(historyRequest, {
+            commits: nextCommits,
+            hasMore: nextHasMore,
+          });
+          return nextCommits;
+        });
+        setHasMore(nextHasMore);
       } else {
         setHasMore(false);
       }
@@ -379,7 +393,7 @@ const GitHistoryContentInner: React.FC<GitHistoryContentInnerProps> = ({
         setLoadingMore(false);
       }
     }
-  }, [repoId, repoPath, commits.length, hasMore]);
+  }, [repoId, repoPath, commits.length, hasMore, historyRequest]);
 
   const filteredCommits = useMemo(() => {
     if (!filterQuery) return commits;
@@ -467,14 +481,14 @@ const GitHistoryContentInner: React.FC<GitHistoryContentInnerProps> = ({
   );
 
   // Loading state
-  if (loading) {
+  if (loading && commits.length === 0) {
     return (
       <Placeholder variant="loading" placement="sidebar" fillParentHeight />
     );
   }
 
   // Error state
-  if (error) {
+  if (error && commits.length === 0) {
     return (
       <Placeholder
         variant="error"

--- a/src/modules/WorkStation/CodeEditor/TEST_CASES.md
+++ b/src/modules/WorkStation/CodeEditor/TEST_CASES.md
@@ -48,6 +48,20 @@
 | 3   | Git diff IPC fails  | Git status fetch throws.                 | Diff gutter hidden or shows neutral state; no crash.       |
 | 4   | Terminal crash      | Terminal process exits unexpectedly.     | Terminal tab shows exit message; restart button available. |
 
+## Async Git View Continuity
+
+| #   | Scenario                       | Steps                                                                          | Expected Result                                                                                |
+| --- | ------------------------------ | ------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| 1   | History mode re-entry          | Load Source Control History, switch to Changes, then return.                   | Cached commit rows render on the first frame; no full-sidebar loading placeholder.             |
+| 2   | History refresh                | With commit rows visible, click Refresh.                                       | Existing rows remain visible until the replacement response succeeds; pagination stays usable. |
+| 3   | Commit detail re-entry         | Open a commit, select a changed file, switch tabs, then return.                | Commit summary, selected file, and diff body render without a full-page loading placeholder.   |
+| 4   | Stash detail re-entry          | Open a stash detail, switch tabs, then return.                                 | The same bounded commit/file cache restores the stash diff without retaining CodeMirror.       |
+| 5   | Directory metadata pending     | Open a directory whose Git metadata queries are slow.                          | Directory entries appear after `readDir`; supplemental author/commit metadata fills in later.  |
+| 6   | Directory re-entry             | Load a directory, switch tabs, then return within the cache window.            | Entries render immediately and duplicate directory/metadata requests are not issued.           |
+| 7   | Repository switch              | Open equivalent History/Directory/Commit views in two repositories.            | Data remains isolated by repo ID/path; one repository never paints another repository's rows.  |
+| 8   | Late response after tab switch | Start a slow commit request, switch to another commit, finish the old request. | The late response may populate its own cache key but cannot replace the active commit view.    |
+| 9   | Oversized commit file          | Open a commit file body larger than the per-entry cache limit.                 | Content displays for the active view but is not retained after unmount.                        |
+
 ## Accessibility
 
 - [ ] Keyboard-navigable (Tab moves between editor, tabs, and panels)
@@ -64,5 +78,7 @@
 - [ ] Unsaved tab close triggers confirmation dialog
 - [ ] Terminal in bottom panel executes commands
 - [ ] Problems tab lists diagnostics from the active file
+- [ ] Warm History, Commit/Stash, and Directory re-entry does not replace successful content with loading UI
+- [ ] Git view caches remain entry/byte bounded and repository-scoped
 - [ ] `pnpm test` passes with no new failures
 - [ ] No TypeScript errors (`pnpm typecheck`)

--- a/src/modules/WorkStation/TabContent/renderers/directory.tsx
+++ b/src/modules/WorkStation/TabContent/renderers/directory.tsx
@@ -35,7 +35,7 @@ const DirectoryTabRenderer: React.FC<UnifiedTabContentProps> = memo(
     return (
       <Suspense fallback={<LazyFallback />}>
         <DirectoryExplorerContent
-          key={directoryPath}
+          key={`${repoPath}:${directoryPath}`}
           directoryPath={directoryPath}
           repoPath={repoPath}
           onFileSelect={onFileSelect}

--- a/src/services/git/directoryViewResource.test.ts
+++ b/src/services/git/directoryViewResource.test.ts
@@ -1,0 +1,113 @@
+import { readDir } from "@tauri-apps/plugin-fs";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getGitCommits } from "@src/api/http/git";
+
+import {
+  getDirectoryViewResourceStats,
+  loadDirectoryEntries,
+  loadDirectoryMetadata,
+  resetDirectoryViewResourceForTests,
+} from "./directoryViewResource";
+
+vi.mock("@tauri-apps/plugin-fs", () => ({
+  readDir: vi.fn(),
+}));
+
+vi.mock("@src/api/http/git", () => ({
+  getGitCommits: vi.fn(),
+}));
+
+const readDirMock = vi.mocked(readDir);
+const getGitCommitsMock = vi.mocked(getGitCommits);
+
+afterEach(() => {
+  resetDirectoryViewResourceForTests();
+  vi.clearAllMocks();
+});
+
+describe("directoryViewResource", () => {
+  it("reuses directory and metadata snapshots across remounts", async () => {
+    readDirMock.mockResolvedValue([
+      {
+        isDirectory: false,
+        isFile: true,
+        isSymlink: false,
+        name: "a.ts",
+      },
+    ]);
+    getGitCommitsMock.mockResolvedValue({
+      commits: [
+        {
+          author: {
+            date: "2026-07-31",
+            email: "a@example.com",
+            name: "Ada",
+          },
+          body: "",
+          committer: {
+            date: "2026-07-31",
+            email: "a@example.com",
+            name: "Ada",
+          },
+          parent_shas: [],
+          sha: "abc",
+          short_sha: "abc",
+          summary: "Latest",
+        },
+      ],
+      total_count: 1,
+    });
+    const request = {
+      directoryPath: "/repo/src",
+      repoPath: "/repo",
+    };
+
+    const entries = await loadDirectoryEntries(request);
+    await loadDirectoryMetadata(request, entries);
+    await loadDirectoryEntries(request);
+    await loadDirectoryMetadata(request, entries);
+
+    expect(readDirMock).toHaveBeenCalledTimes(1);
+    expect(getGitCommitsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds supplemental git metadata concurrency", async () => {
+    let active = 0;
+    let maxActive = 0;
+    getGitCommitsMock.mockImplementation(async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await Promise.resolve();
+      active -= 1;
+      return { commits: [], total_count: 0 };
+    });
+    const entries = Array.from({ length: 20 }, (_, index) => ({
+      name: `${index}.ts`,
+      path: `/repo/src/${index}.ts`,
+      type: "file" as const,
+    }));
+
+    await loadDirectoryMetadata(
+      { directoryPath: "/repo/src", repoPath: "/repo" },
+      entries
+    );
+
+    expect(getGitCommitsMock).toHaveBeenCalledTimes(20);
+    expect(maxActive).toBeLessThanOrEqual(6);
+  });
+
+  it("bounds directory scopes and isolates identical paths by repository", async () => {
+    readDirMock.mockResolvedValue([]);
+
+    for (let index = 0; index < 11; index += 1) {
+      await loadDirectoryEntries({
+        directoryPath: `/repo-${index}/src`,
+        repoPath: `/repo-${index}`,
+      });
+    }
+
+    expect(getDirectoryViewResourceStats().entries.entries).toBe(10);
+    expect(readDirMock).toHaveBeenCalledTimes(11);
+  });
+});

--- a/src/services/git/directoryViewResource.ts
+++ b/src/services/git/directoryViewResource.ts
@@ -1,0 +1,208 @@
+import { readDir } from "@tauri-apps/plugin-fs";
+
+import { getGitCommits } from "@src/api/http/git";
+import { toFsPluginPath } from "@src/util/file/pathUtils";
+
+import {
+  ScopedResourceCache,
+  type ScopedResourceCacheStats,
+} from "./scopedResourceCache";
+
+const DIRECTORY_CACHE_MAX_ENTRIES = 10;
+const DIRECTORY_CACHE_MAX_BYTES = 2 * 1024 * 1024;
+const DIRECTORY_CACHE_MAX_ENTRY_BYTES = 512 * 1024;
+const DIRECTORY_CACHE_MAX_AGE_MS = 5_000;
+const DIRECTORY_META_CACHE_MAX_AGE_MS = 30_000;
+const DIRECTORY_META_CONCURRENCY = 6;
+export const DIRECTORY_META_MAX_ENTRIES = 80;
+
+export interface DirectoryViewRequest {
+  directoryPath: string;
+  repoPath: string;
+}
+
+export interface DirectoryEntryRow {
+  name: string;
+  path: string;
+  type: "directory" | "file";
+}
+
+export interface DirectoryEntryGitMeta {
+  authorDate: string;
+  summary: string;
+}
+
+function directoryKey(request: DirectoryViewRequest): string {
+  return JSON.stringify([request.repoPath, request.directoryPath]);
+}
+
+function entrySignature(entries: DirectoryEntryRow[]): string {
+  let hash = 5381;
+  for (const entry of entries) {
+    const value = `${entry.type}:${entry.path}\0`;
+    for (let index = 0; index < value.length; index += 1) {
+      hash = (hash * 33) ^ value.charCodeAt(index);
+    }
+  }
+  return `${entries.length}:${hash >>> 0}`;
+}
+
+function metadataKey(
+  request: DirectoryViewRequest,
+  entries: DirectoryEntryRow[]
+): string {
+  return `${directoryKey(request)}:${entrySignature(entries)}`;
+}
+
+function estimateEntriesBytes(entries: DirectoryEntryRow[]): number {
+  return entries.reduce(
+    (total, entry) => total + (entry.name.length + entry.path.length) * 2 + 64,
+    64
+  );
+}
+
+function estimateMetadataBytes(
+  metadata: Map<string, DirectoryEntryGitMeta>
+): number {
+  let bytes = 64;
+  for (const [path, value] of metadata) {
+    bytes +=
+      (path.length + value.summary.length + value.authorDate.length) * 2 + 64;
+  }
+  return bytes;
+}
+
+const entriesCache = new ScopedResourceCache<DirectoryEntryRow[]>({
+  estimateSize: estimateEntriesBytes,
+  maxAgeMs: DIRECTORY_CACHE_MAX_AGE_MS,
+  maxBytes: DIRECTORY_CACHE_MAX_BYTES,
+  maxEntries: DIRECTORY_CACHE_MAX_ENTRIES,
+  maxEntryBytes: DIRECTORY_CACHE_MAX_ENTRY_BYTES,
+});
+
+const metadataCache = new ScopedResourceCache<
+  Map<string, DirectoryEntryGitMeta>
+>({
+  estimateSize: estimateMetadataBytes,
+  maxAgeMs: DIRECTORY_META_CACHE_MAX_AGE_MS,
+  maxBytes: DIRECTORY_CACHE_MAX_BYTES,
+  maxEntries: DIRECTORY_CACHE_MAX_ENTRIES,
+  maxEntryBytes: DIRECTORY_CACHE_MAX_ENTRY_BYTES,
+});
+
+function toRelativePath(path: string, repoPath: string): string {
+  if (!repoPath || !path.startsWith(repoPath)) return path;
+  return path.slice(repoPath.length).replace(/^\//, "") || ".";
+}
+
+export function getCachedDirectoryEntries(
+  request: DirectoryViewRequest
+): DirectoryEntryRow[] | null {
+  return entriesCache.get(directoryKey(request))?.value ?? null;
+}
+
+export function loadDirectoryEntries(
+  request: DirectoryViewRequest,
+  options: { force?: boolean } = {}
+): Promise<DirectoryEntryRow[]> {
+  return entriesCache.load(
+    directoryKey(request),
+    async () => {
+      const dir = toFsPluginPath(request.directoryPath).replace(/\/+$/, "");
+      const entries = await readDir(dir);
+      return entries
+        .map((entry) => ({
+          name: entry.name,
+          path: `${dir}/${entry.name}`,
+          type: entry.isDirectory ? ("directory" as const) : ("file" as const),
+        }))
+        .sort((left, right) => {
+          if (left.type !== right.type) {
+            return left.type === "directory" ? -1 : 1;
+          }
+          return left.name.localeCompare(right.name);
+        });
+    },
+    options
+  );
+}
+
+export function getCachedDirectoryMetadata(
+  request: DirectoryViewRequest,
+  entries: DirectoryEntryRow[]
+): Map<string, DirectoryEntryGitMeta> | null {
+  return metadataCache.get(metadataKey(request, entries))?.value ?? null;
+}
+
+async function loadEntryMetadata(
+  entry: DirectoryEntryRow,
+  repoPath: string
+): Promise<DirectoryEntryGitMeta | null> {
+  const result = await getGitCommits({
+    repo_id: repoPath,
+    repo_path: repoPath,
+    file_path: toRelativePath(entry.path, repoPath),
+    limit: 1,
+  });
+  const commit = result?.commits[0];
+  return commit
+    ? {
+        summary: commit.summary,
+        authorDate: commit.author.date,
+      }
+    : null;
+}
+
+export function loadDirectoryMetadata(
+  request: DirectoryViewRequest,
+  entries: DirectoryEntryRow[],
+  options: { force?: boolean } = {}
+): Promise<Map<string, DirectoryEntryGitMeta>> {
+  const limitedEntries = entries.slice(0, DIRECTORY_META_MAX_ENTRIES);
+  return metadataCache.load(
+    metadataKey(request, entries),
+    async () => {
+      const metadata = new Map<string, DirectoryEntryGitMeta>();
+      let nextIndex = 0;
+      const workerCount = Math.min(
+        DIRECTORY_META_CONCURRENCY,
+        limitedEntries.length
+      );
+
+      await Promise.all(
+        Array.from({ length: workerCount }, async () => {
+          while (nextIndex < limitedEntries.length) {
+            const entryIndex = nextIndex;
+            nextIndex += 1;
+            const entry = limitedEntries[entryIndex];
+            try {
+              const value = await loadEntryMetadata(entry, request.repoPath);
+              if (value) metadata.set(entry.path, value);
+            } catch {
+              // Git metadata is supplemental; one failed row must not block
+              // the directory listing or the remaining metadata workers.
+            }
+          }
+        })
+      );
+
+      return metadata;
+    },
+    options
+  );
+}
+
+export function getDirectoryViewResourceStats(): {
+  entries: ScopedResourceCacheStats;
+  metadata: ScopedResourceCacheStats;
+} {
+  return {
+    entries: entriesCache.getStats(),
+    metadata: metadataCache.getStats(),
+  };
+}
+
+export function resetDirectoryViewResourceForTests(): void {
+  entriesCache.clear();
+  metadataCache.clear();
+}

--- a/src/services/git/gitCommitDetailResource.test.ts
+++ b/src/services/git/gitCommitDetailResource.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getGitCommitDiff, getGitFileContent } from "@src/api/http/git/diff";
+import type { CommitDiffResult } from "@src/api/http/git/types";
+
+import {
+  getGitCommitDetailResourceStats,
+  loadCommitDiff,
+  loadCommitFileDiff,
+  resetGitCommitDetailResourceForTests,
+  setCachedCommitSelection,
+} from "./gitCommitDetailResource";
+
+vi.mock("@src/api/http/git/diff", () => ({
+  getGitCommitDiff: vi.fn(),
+  getGitFileContent: vi.fn(),
+}));
+
+const getGitCommitDiffMock = vi.mocked(getGitCommitDiff);
+const getGitFileContentMock = vi.mocked(getGitFileContent);
+
+const commitDiff = {
+  author: {
+    date: "2026-07-31",
+    email: "a@example.com",
+    name: "Ada",
+  },
+  body: "",
+  commit_sha: "commit",
+  committer: {
+    date: "2026-07-31",
+    email: "a@example.com",
+    name: "Ada",
+  },
+  files: [
+    {
+      binary: false,
+      deletions: 1,
+      file_path: "src/a.ts",
+      hunks: [],
+      insertions: 1,
+      new_content: "after",
+      old_content: "before",
+      old_path: null,
+      status: "modified",
+    },
+  ],
+  parent_mode: "first-parent",
+  parent_sha: "parent",
+  parent_shas: ["parent"],
+  selected_parent_index: 0,
+  short_sha: "commit",
+  stats: { deletions: 1, files_changed: 1, insertions: 1 },
+  summary: "Commit",
+} satisfies CommitDiffResult;
+
+afterEach(() => {
+  resetGitCommitDetailResourceForTests();
+  vi.clearAllMocks();
+});
+
+describe("gitCommitDetailResource", () => {
+  it("reuses immutable commit and file bodies across remounts", async () => {
+    getGitCommitDiffMock.mockResolvedValue(commitDiff);
+    getGitFileContentMock.mockImplementation(async ({ ref }) => ({
+      content: ref === "parent" ? "before" : "after",
+      encoding: "utf-8",
+      exists: true,
+      file_path: "src/a.ts",
+      ref: ref ?? "HEAD",
+      size: 6,
+    }));
+    const commitRequest = {
+      commitSha: "commit",
+      repoId: "repo-1",
+      repoPath: "/repo",
+    };
+    const fileRequest = {
+      ...commitRequest,
+      filePath: "src/a.ts",
+      fileStatus: "modified",
+      parentSha: "parent",
+    };
+
+    await loadCommitDiff(commitRequest);
+    await loadCommitDiff(commitRequest);
+    await loadCommitFileDiff(fileRequest);
+    await loadCommitFileDiff(fileRequest);
+
+    expect(getGitCommitDiffMock).toHaveBeenCalledTimes(1);
+    expect(getGitFileContentMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retain an oversized file body", async () => {
+    getGitFileContentMock.mockResolvedValue({
+      content: "x".repeat(2_200_000),
+      encoding: "utf-8",
+      exists: true,
+      file_path: "src/a.ts",
+      ref: "commit",
+      size: 2_200_000,
+    });
+    const request = {
+      commitSha: "commit",
+      filePath: "src/a.ts",
+      fileStatus: "modified",
+      parentSha: "parent",
+      repoId: "repo-1",
+      repoPath: "/repo",
+    };
+
+    await loadCommitFileDiff(request);
+    await loadCommitFileDiff(request);
+
+    expect(getGitFileContentMock).toHaveBeenCalledTimes(4);
+    expect(getGitCommitDetailResourceStats().files.entries).toBe(0);
+  });
+
+  it("bounds selected-file state by commit scope", () => {
+    for (let index = 0; index < 9; index += 1) {
+      setCachedCommitSelection(
+        {
+          commitSha: `commit-${index}`,
+          repoId: "repo-1",
+          repoPath: "/repo",
+        },
+        `src/${index}.ts`
+      );
+    }
+
+    expect(getGitCommitDetailResourceStats().selections).toBe(8);
+  });
+});

--- a/src/services/git/gitCommitDetailResource.ts
+++ b/src/services/git/gitCommitDetailResource.ts
@@ -1,0 +1,205 @@
+import { getGitCommitDiff, getGitFileContent } from "@src/api/http/git/diff";
+import type { CommitDiffResult } from "@src/api/http/git/types";
+import { BoundedMap } from "@src/util/collections/BoundedMap";
+
+import {
+  ScopedResourceCache,
+  type ScopedResourceCacheStats,
+} from "./scopedResourceCache";
+
+const COMMIT_CACHE_MAX_ENTRIES = 8;
+const COMMIT_CACHE_MAX_BYTES = 4 * 1024 * 1024;
+const COMMIT_CACHE_MAX_ENTRY_BYTES = 1024 * 1024;
+const FILE_CACHE_MAX_ENTRIES = 8;
+const FILE_CACHE_MAX_BYTES = 8 * 1024 * 1024;
+const FILE_CACHE_MAX_ENTRY_BYTES = 4 * 1024 * 1024;
+
+export interface CommitDetailRequest {
+  commitSha: string;
+  repoId: string;
+  repoPath: string;
+}
+
+export interface CommitFileDiffRequest extends CommitDetailRequest {
+  filePath: string;
+  fileStatus: string;
+  parentSha: string | null;
+}
+
+export interface CommitFileDiffSnapshot {
+  isBinary: boolean;
+  newContent: string;
+  oldContent: string;
+}
+
+function commitKey(request: CommitDetailRequest): string {
+  return JSON.stringify([request.repoId, request.repoPath, request.commitSha]);
+}
+
+function fileKey(request: CommitFileDiffRequest): string {
+  return JSON.stringify([
+    request.repoId,
+    request.repoPath,
+    request.commitSha,
+    request.parentSha,
+    request.fileStatus,
+    request.filePath,
+  ]);
+}
+
+function estimateCommitBytes(value: CommitDiffResult | null): number {
+  if (!value) return 8;
+  try {
+    return JSON.stringify(value).length * 2 + 256;
+  } catch {
+    return COMMIT_CACHE_MAX_ENTRY_BYTES + 1;
+  }
+}
+
+function estimateFileBytes(value: CommitFileDiffSnapshot): number {
+  return (value.oldContent.length + value.newContent.length) * 2 + 256;
+}
+
+const commitCache = new ScopedResourceCache<CommitDiffResult | null>({
+  estimateSize: estimateCommitBytes,
+  maxBytes: COMMIT_CACHE_MAX_BYTES,
+  maxEntries: COMMIT_CACHE_MAX_ENTRIES,
+  maxEntryBytes: COMMIT_CACHE_MAX_ENTRY_BYTES,
+});
+
+const fileCache = new ScopedResourceCache<CommitFileDiffSnapshot>({
+  estimateSize: estimateFileBytes,
+  maxBytes: FILE_CACHE_MAX_BYTES,
+  maxEntries: FILE_CACHE_MAX_ENTRIES,
+  maxEntryBytes: FILE_CACHE_MAX_ENTRY_BYTES,
+});
+
+const selectedFileByCommit = new BoundedMap<string, string>({
+  maxSize: COMMIT_CACHE_MAX_ENTRIES,
+  name: "GitCommitSelectedFile",
+});
+
+export function getCommitDetailScopeKey(request: CommitDetailRequest): string {
+  return commitKey(request);
+}
+
+export function getCachedCommitDiff(
+  request: CommitDetailRequest
+): CommitDiffResult | null {
+  return commitCache.get(commitKey(request))?.value ?? null;
+}
+
+export function loadCommitDiff(
+  request: CommitDetailRequest,
+  options: { force?: boolean } = {}
+): Promise<CommitDiffResult | null> {
+  return commitCache.load(
+    commitKey(request),
+    () =>
+      getGitCommitDiff({
+        repo_id: request.repoId,
+        repo_path: request.repoPath,
+        commit_sha: request.commitSha,
+      }).then((result) => result ?? null),
+    {
+      ...options,
+      shouldCache: (value) => value !== null,
+    }
+  );
+}
+
+export function getCachedCommitSelection(
+  request: CommitDetailRequest
+): string | null {
+  return selectedFileByCommit.get(commitKey(request)) ?? null;
+}
+
+export function setCachedCommitSelection(
+  request: CommitDetailRequest,
+  filePath: string | null
+): void {
+  const key = commitKey(request);
+  if (filePath) {
+    selectedFileByCommit.set(key, filePath);
+  } else {
+    selectedFileByCommit.delete(key);
+  }
+}
+
+export function getCommitFileDiffScopeKey(
+  request: CommitFileDiffRequest
+): string {
+  return fileKey(request);
+}
+
+export function getCachedCommitFileDiff(
+  request: CommitFileDiffRequest
+): CommitFileDiffSnapshot | null {
+  return fileCache.get(fileKey(request))?.value ?? null;
+}
+
+export function loadCommitFileDiff(
+  request: CommitFileDiffRequest,
+  options: { force?: boolean } = {}
+): Promise<CommitFileDiffSnapshot> {
+  return fileCache.load(
+    fileKey(request),
+    async () => {
+      const [oldResult, newResult] = await Promise.all([
+        request.fileStatus === "added" || !request.parentSha
+          ? Promise.resolve(undefined)
+          : getGitFileContent({
+              repo_id: request.repoId,
+              repo_path: request.repoPath,
+              file_path: request.filePath,
+              ref: request.parentSha,
+            }),
+        request.fileStatus === "deleted"
+          ? Promise.resolve(undefined)
+          : getGitFileContent({
+              repo_id: request.repoId,
+              repo_path: request.repoPath,
+              file_path: request.filePath,
+              ref: request.commitSha,
+            }),
+      ]);
+
+      const expectedOld =
+        request.fileStatus !== "added" && Boolean(request.parentSha);
+      const expectedNew = request.fileStatus !== "deleted";
+      const oldFailed = expectedOld && !oldResult;
+      const newFailed = expectedNew && !newResult;
+      if (oldFailed || newFailed) {
+        throw new Error(
+          `Failed to load content for ${request.filePath} (old_ref=${request.parentSha ?? "none"}, new_ref=${request.commitSha}, old_failed=${String(oldFailed)}, new_failed=${String(newFailed)})`
+        );
+      }
+
+      return {
+        isBinary:
+          oldResult?.encoding === "base64" || newResult?.encoding === "base64",
+        oldContent: oldResult?.content ?? "",
+        newContent: newResult?.content ?? "",
+      };
+    },
+    options
+  );
+}
+
+export function getGitCommitDetailResourceStats(): {
+  commits: ScopedResourceCacheStats;
+  files: ScopedResourceCacheStats;
+  selections: number;
+} {
+  return {
+    commits: commitCache.getStats(),
+    files: fileCache.getStats(),
+    selections: selectedFileByCommit.size,
+  };
+}
+
+export function resetGitCommitDetailResourceForTests(): void {
+  commitCache.clear();
+  fileCache.clear();
+  selectedFileByCommit.clear();
+}

--- a/src/services/git/gitHistoryResource.test.ts
+++ b/src/services/git/gitHistoryResource.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getGitCommits } from "@src/api/http/git/commits";
+import type { GitCommitInfo } from "@src/api/http/git/types";
+
+import {
+  getCachedGitHistory,
+  getGitHistoryResourceStats,
+  loadGitHistory,
+  resetGitHistoryResourceForTests,
+  writeGitHistoryCache,
+} from "./gitHistoryResource";
+
+vi.mock("@src/api/http/git/commits", () => ({
+  getGitCommits: vi.fn(),
+}));
+
+const getGitCommitsMock = vi.mocked(getGitCommits);
+
+function commit(sha: string): GitCommitInfo {
+  return {
+    author: { date: "2026-07-31", email: "a@example.com", name: "Ada" },
+    body: "",
+    committer: { date: "2026-07-31", email: "a@example.com", name: "Ada" },
+    parent_shas: [],
+    sha,
+    short_sha: sha.slice(0, 7),
+    summary: `Commit ${sha}`,
+  };
+}
+
+afterEach(() => {
+  resetGitHistoryResourceForTests();
+  vi.clearAllMocks();
+});
+
+describe("gitHistoryResource", () => {
+  it("serves a remount from the repo-scoped cache without another request", async () => {
+    getGitCommitsMock.mockResolvedValue({
+      commits: [commit("abc1234")],
+      total_count: 1,
+    });
+    const request = { limit: 25, repoId: "repo-1", repoPath: "/repo/one" };
+
+    await expect(loadGitHistory(request)).resolves.toMatchObject({
+      commits: [{ sha: "abc1234" }],
+    });
+    await expect(loadGitHistory(request)).resolves.toMatchObject({
+      commits: [{ sha: "abc1234" }],
+    });
+
+    expect(getGitCommitsMock).toHaveBeenCalledTimes(1);
+    expect(getCachedGitHistory(request)?.commits[0]?.sha).toBe("abc1234");
+  });
+
+  it("keeps repository scopes isolated and bounds retained histories", () => {
+    for (let index = 0; index < 7; index += 1) {
+      writeGitHistoryCache(
+        {
+          limit: 25,
+          repoId: `repo-${index}`,
+          repoPath: `/repo/${index}`,
+        },
+        { commits: [commit(String(index))], hasMore: false }
+      );
+    }
+
+    expect(getGitHistoryResourceStats().entries).toBe(6);
+    expect(
+      getCachedGitHistory({
+        limit: 25,
+        repoId: "repo-0",
+        repoPath: "/repo/0",
+      })
+    ).toBeNull();
+    expect(
+      getCachedGitHistory({
+        limit: 25,
+        repoId: "repo-6",
+        repoPath: "/repo/6",
+      })?.commits[0]?.sha
+    ).toBe("6");
+  });
+
+  it("caps the remount snapshot while preserving pagination availability", () => {
+    const request = { limit: 25, repoId: "repo-1", repoPath: "/repo/one" };
+    writeGitHistoryCache(request, {
+      commits: Array.from({ length: 205 }, (_, index) => commit(String(index))),
+      hasMore: false,
+    });
+
+    const snapshot = getCachedGitHistory(request);
+    expect(snapshot?.commits).toHaveLength(200);
+    expect(snapshot?.hasMore).toBe(true);
+  });
+});

--- a/src/services/git/gitHistoryResource.ts
+++ b/src/services/git/gitHistoryResource.ts
@@ -1,0 +1,112 @@
+import { getGitCommits } from "@src/api/http/git/commits";
+import type { GitCommitInfo } from "@src/api/http/git/types";
+
+import {
+  ScopedResourceCache,
+  type ScopedResourceCacheStats,
+} from "./scopedResourceCache";
+
+const HISTORY_CACHE_MAX_ENTRIES = 6;
+const HISTORY_CACHE_MAX_BYTES = 2 * 1024 * 1024;
+const HISTORY_CACHE_MAX_ENTRY_BYTES = 512 * 1024;
+const HISTORY_CACHE_MAX_COMMITS = 200;
+const HISTORY_CACHE_MAX_AGE_MS = 15_000;
+
+export interface GitHistoryRequest {
+  limit: number;
+  repoId: string;
+  repoPath: string;
+}
+
+export interface GitHistorySnapshot {
+  commits: GitCommitInfo[];
+  hasMore: boolean;
+}
+
+function historyKey(request: GitHistoryRequest): string {
+  return JSON.stringify([request.repoId, request.repoPath, request.limit]);
+}
+
+function estimateHistoryBytes(snapshot: GitHistorySnapshot): number {
+  return snapshot.commits.reduce(
+    (total, commit) =>
+      total +
+      (commit.sha.length +
+        commit.short_sha.length +
+        commit.summary.length +
+        commit.body.length +
+        commit.author.name.length +
+        commit.author.email.length +
+        commit.author.date.length +
+        commit.committer.name.length +
+        commit.committer.email.length +
+        commit.committer.date.length +
+        commit.parent_shas.join("").length) *
+        2 +
+      256,
+    64
+  );
+}
+
+function boundedSnapshot(snapshot: GitHistorySnapshot): GitHistorySnapshot {
+  const commits = snapshot.commits.slice(0, HISTORY_CACHE_MAX_COMMITS);
+  return {
+    commits,
+    hasMore:
+      snapshot.hasMore || snapshot.commits.length > HISTORY_CACHE_MAX_COMMITS,
+  };
+}
+
+const historyCache = new ScopedResourceCache<GitHistorySnapshot>({
+  estimateSize: estimateHistoryBytes,
+  maxAgeMs: HISTORY_CACHE_MAX_AGE_MS,
+  maxBytes: HISTORY_CACHE_MAX_BYTES,
+  maxEntries: HISTORY_CACHE_MAX_ENTRIES,
+  maxEntryBytes: HISTORY_CACHE_MAX_ENTRY_BYTES,
+});
+
+export function getCachedGitHistory(
+  request: GitHistoryRequest
+): GitHistorySnapshot | null {
+  return historyCache.get(historyKey(request))?.value ?? null;
+}
+
+export function loadGitHistory(
+  request: GitHistoryRequest,
+  options: { force?: boolean } = {}
+): Promise<GitHistorySnapshot> {
+  const key = historyKey(request);
+  return historyCache.load(
+    key,
+    async () => {
+      const result = await getGitCommits({
+        repo_id: request.repoId,
+        repo_path: request.repoPath,
+        limit: request.limit,
+      });
+      if (!result?.commits) {
+        throw new Error("Failed to load commit history");
+      }
+      return boundedSnapshot({
+        commits: result.commits,
+        hasMore: result.commits.length >= request.limit,
+      });
+    },
+    options
+  );
+}
+
+export function writeGitHistoryCache(
+  request: GitHistoryRequest,
+  snapshot: GitHistorySnapshot
+): void {
+  historyCache.set(historyKey(request), boundedSnapshot(snapshot));
+}
+
+export function getGitHistoryResourceStats(): ScopedResourceCacheStats {
+  return historyCache.getStats();
+}
+
+export function resetGitHistoryResourceForTests(): void {
+  historyCache.clear();
+}

--- a/src/services/git/scopedResourceCache.test.ts
+++ b/src/services/git/scopedResourceCache.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ScopedResourceCache } from "./scopedResourceCache";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("ScopedResourceCache", () => {
+  it("shares an equal in-flight request and retains the settled result", async () => {
+    const cache = new ScopedResourceCache<string>({ maxEntries: 2 });
+    const pending = deferred<string>();
+    const loader = vi.fn(() => pending.promise);
+
+    const first = cache.load("repo:a", loader);
+    const second = cache.load("repo:a", loader);
+
+    expect(first).toBe(second);
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    pending.resolve("ready");
+    await expect(first).resolves.toBe("ready");
+    await expect(cache.load("repo:a", loader)).resolves.toBe("ready");
+    expect(loader).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps stale data readable while one background replacement runs", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const cache = new ScopedResourceCache<string>({
+      maxAgeMs: 100,
+      maxEntries: 2,
+    });
+    cache.set("repo:a", "old");
+    vi.setSystemTime(1_200);
+
+    const pending = deferred<string>();
+    const replacement = cache.load("repo:a", () => pending.promise);
+
+    expect(cache.get("repo:a")).toMatchObject({
+      stale: true,
+      value: "old",
+    });
+
+    pending.resolve("new");
+    await expect(replacement).resolves.toBe("new");
+    expect(cache.get("repo:a")).toMatchObject({
+      stale: false,
+      value: "new",
+    });
+  });
+
+  it("enforces both LRU entry and byte bounds", () => {
+    const cache = new ScopedResourceCache<string>({
+      estimateSize: (value) => value.length,
+      maxBytes: 5,
+      maxEntries: 2,
+      maxEntryBytes: 4,
+    });
+
+    cache.set("a", "aa");
+    cache.set("b", "bb");
+    cache.get("a");
+    cache.set("c", "cc");
+
+    expect(cache.get("b")).toBeNull();
+    expect(cache.get("a")?.value).toBe("aa");
+    expect(cache.get("c")?.value).toBe("cc");
+    expect(cache.getStats()).toMatchObject({ bytes: 4, entries: 2 });
+
+    cache.set("oversized", "12345");
+    expect(cache.get("oversized")).toBeNull();
+    expect(cache.getStats()).toMatchObject({ bytes: 4, entries: 2 });
+  });
+
+  it("does not cache rejected or explicitly excluded results", async () => {
+    const cache = new ScopedResourceCache<string | null>({ maxEntries: 2 });
+    const failure = vi.fn().mockRejectedValue(new Error("offline"));
+
+    await expect(cache.load("repo:a", failure)).rejects.toThrow("offline");
+    expect(cache.getStats()).toMatchObject({ entries: 0, inFlight: 0 });
+
+    const empty = vi.fn().mockResolvedValue(null);
+    await cache.load("repo:a", empty, {
+      shouldCache: (value) => value !== null,
+    });
+    await cache.load("repo:a", empty, {
+      shouldCache: (value) => value !== null,
+    });
+    expect(empty).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds coalescing handles when unrelated requests remain pending", () => {
+    const cache = new ScopedResourceCache<string>({
+      maxEntries: 2,
+      maxInFlight: 2,
+    });
+
+    void cache.load("repo:a", () => new Promise(() => undefined));
+    void cache.load("repo:b", () => new Promise(() => undefined));
+    void cache.load("repo:c", () => new Promise(() => undefined));
+
+    expect(cache.getStats()).toMatchObject({ inFlight: 2, maxInFlight: 2 });
+  });
+
+  it("does not let an evicted in-flight handle publish a late cache value", async () => {
+    const cache = new ScopedResourceCache<string>({
+      maxEntries: 2,
+      maxInFlight: 1,
+    });
+    const oldRequest = deferred<string>();
+    const newRequest = deferred<string>();
+
+    const oldResult = cache.load("repo:old", () => oldRequest.promise);
+    const newResult = cache.load("repo:new", () => newRequest.promise);
+    newRequest.resolve("new");
+    await expect(newResult).resolves.toBe("new");
+    oldRequest.resolve("old");
+    await expect(oldResult).resolves.toBe("old");
+
+    expect(cache.get("repo:old")).toBeNull();
+    expect(cache.get("repo:new")?.value).toBe("new");
+  });
+});

--- a/src/services/git/scopedResourceCache.ts
+++ b/src/services/git/scopedResourceCache.ts
@@ -1,0 +1,177 @@
+export interface ScopedResourceSnapshot<T> {
+  cachedAt: number;
+  stale: boolean;
+  value: T;
+}
+
+export interface ScopedResourceCacheOptions<T> {
+  estimateSize?: (value: T) => number;
+  maxAgeMs?: number;
+  maxBytes?: number;
+  maxEntries: number;
+  maxEntryBytes?: number;
+  maxInFlight?: number;
+}
+
+export interface ScopedResourceCacheStats {
+  bytes: number;
+  entries: number;
+  inFlight: number;
+  maxBytes: number;
+  maxEntries: number;
+  maxInFlight: number;
+}
+
+interface CacheEntry<T> {
+  byteSize: number;
+  cachedAt: number;
+  value: T;
+}
+
+export interface ScopedResourceLoadOptions<T> {
+  force?: boolean;
+  shouldCache?: (value: T) => boolean;
+}
+
+/**
+ * Small app-session cache for read-only resources that must survive a React
+ * remount. Reads are stale-while-revalidate, equal requests are single-flight,
+ * and both entry count and retained bytes are bounded.
+ */
+export class ScopedResourceCache<T> {
+  private readonly entries = new Map<string, CacheEntry<T>>();
+  private readonly inFlight = new Map<string, Promise<T>>();
+  private readonly estimateSize: (value: T) => number;
+  private readonly maxAgeMs: number | undefined;
+  private readonly maxBytes: number;
+  private readonly maxEntries: number;
+  private readonly maxEntryBytes: number;
+  private readonly maxInFlight: number;
+  private retainedBytes = 0;
+
+  constructor(options: ScopedResourceCacheOptions<T>) {
+    if (!Number.isInteger(options.maxEntries) || options.maxEntries <= 0) {
+      throw new RangeError("maxEntries must be a positive integer");
+    }
+
+    this.maxEntries = options.maxEntries;
+    this.maxInFlight = options.maxInFlight ?? options.maxEntries;
+    if (!Number.isInteger(this.maxInFlight) || this.maxInFlight <= 0) {
+      throw new RangeError("maxInFlight must be a positive integer");
+    }
+    this.maxAgeMs = options.maxAgeMs;
+    this.maxBytes = options.maxBytes ?? Number.POSITIVE_INFINITY;
+    this.maxEntryBytes = options.maxEntryBytes ?? this.maxBytes;
+    this.estimateSize = options.estimateSize ?? (() => 1);
+  }
+
+  get(key: string): ScopedResourceSnapshot<T> | null {
+    const entry = this.entries.get(key);
+    if (!entry) return null;
+
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+
+    return {
+      cachedAt: entry.cachedAt,
+      stale:
+        this.maxAgeMs !== undefined &&
+        Date.now() - entry.cachedAt >= this.maxAgeMs,
+      value: entry.value,
+    };
+  }
+
+  set(key: string, value: T): void {
+    const byteSize = Math.max(0, this.estimateSize(value));
+    if (
+      !Number.isFinite(byteSize) ||
+      byteSize > this.maxEntryBytes ||
+      byteSize > this.maxBytes
+    ) {
+      return;
+    }
+
+    this.delete(key);
+    while (
+      this.entries.size >= this.maxEntries ||
+      this.retainedBytes + byteSize > this.maxBytes
+    ) {
+      const oldestKey = this.entries.keys().next().value as string | undefined;
+      if (!oldestKey) break;
+      this.delete(oldestKey);
+    }
+
+    this.entries.set(key, {
+      byteSize,
+      cachedAt: Date.now(),
+      value,
+    });
+    this.retainedBytes += byteSize;
+  }
+
+  delete(key: string): boolean {
+    const entry = this.entries.get(key);
+    if (!entry) return false;
+    this.entries.delete(key);
+    this.retainedBytes -= entry.byteSize;
+    return true;
+  }
+
+  load(
+    key: string,
+    loader: () => Promise<T>,
+    options: ScopedResourceLoadOptions<T> = {}
+  ): Promise<T> {
+    const cached = this.get(key);
+    if (cached && !options.force && !cached.stale) {
+      return Promise.resolve(cached.value);
+    }
+
+    const activeRequest = this.inFlight.get(key);
+    if (activeRequest) return activeRequest;
+
+    const request = loader()
+      .then((value) => {
+        if (
+          this.inFlight.get(key) === request &&
+          options.shouldCache?.(value) !== false
+        ) {
+          this.set(key, value);
+        }
+        return value;
+      })
+      .finally(() => {
+        if (this.inFlight.get(key) === request) {
+          this.inFlight.delete(key);
+        }
+      });
+
+    while (this.inFlight.size >= this.maxInFlight) {
+      const oldestKey = this.inFlight.keys().next().value as string | undefined;
+      if (!oldestKey) break;
+      // The underlying operation cannot be cancelled generically, but removing
+      // its coalescing handle keeps this app-session registry hard-bounded. The
+      // identity check above also prevents its eventual value from publishing.
+      this.inFlight.delete(oldestKey);
+    }
+    this.inFlight.set(key, request);
+    return request;
+  }
+
+  clear(): void {
+    this.entries.clear();
+    this.inFlight.clear();
+    this.retainedBytes = 0;
+  }
+
+  getStats(): ScopedResourceCacheStats {
+    return {
+      bytes: this.retainedBytes,
+      entries: this.entries.size,
+      inFlight: this.inFlight.size,
+      maxBytes: this.maxBytes,
+      maxEntries: this.maxEntries,
+      maxInFlight: this.maxInFlight,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

- hydrate Source Control History, Commit/Stash detail, and Directory views from bounded repository-scoped session caches
- keep the last successful content visible while stale data revalidates, including the selected commit file
- render directory entries immediately after `readDir` and fill supplemental Git metadata with a six-worker concurrency cap
- coalesce identical requests and reject late responses from publishing into a newer view scope

This is a follow-up to #612, which fixes the Source Control Changes view specifically.

## State and lifecycle

- cold load: preserves the existing loading, empty, and error states
- warm remount: paints cached successful data on the first render
- refresh: uses stale-while-revalidate and preserves the last success on transient failures
- repository/path/SHA changes: isolate cache keys and guard state publication by request generation
- heavy diff/editor components still unmount; only bounded read-only payloads and the selected path are retained

## Resource bounds

- History: 6 scopes, 2 MiB total, 200 commits per scope
- Directory entries/metadata: 10 scopes and 2 MiB per cache; metadata capped at 80 entries with 6 concurrent requests
- Commit details: 8 scopes, 4 MiB total
- Commit file bodies: 8 scopes, 8 MiB total, 4 MiB per entry
- no timers, polling, listeners, workers, or background refresh loops

## Verification

- `npx vitest run ...` — 7 files, 20 tests passed
- `npx tsc --noEmit --pretty false`
- changed-file ESLint
- Prettier check
- `git diff --check`

## Remaining manual QA

- Live Tauri visual/frame-time observation was not run in this headless worktree.
