### PR TITLE
perf(history): resume JSONL from bounded seams

### DIFF
--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/watermark.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/watermark.rs
@@ -4,11 +4,12 @@
 //! its `(mtime, size)` signature on every boot, which used to force a full
 //! re-parse of the whole file each time. The watermark persists, per
 //! `(source, source_session_id)`, the byte offset of the last COMPLETE line
-//! already folded into the parser's accumulator, a hash of exactly those
-//! bytes, and the accumulator state itself (`state_json`). A later parse
-//! resumes from the offset when the prefix is verifiably intact — file at
-//! least as large, mtime not regressed, same parser version, prefix hash
-//! match — and falls back to a full re-parse otherwise.
+//! already folded into the parser's accumulator, a fixed-size fingerprint at
+//! that byte boundary, the source file identity, and the accumulator state
+//! itself (`state_json`). A later parse resumes from the offset only when the
+//! same file grew (or is byte-for-byte unchanged at the metadata level) and
+//! the old boundary fingerprint still matches. This makes append validation
+//! O(1) instead of re-reading and re-hashing the whole historical prefix.
 //!
 //! Only newline-terminated lines advance the watermark: a live writer may
 //! still be appending to the final unterminated line, so its effects must
@@ -18,8 +19,22 @@
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::Path;
+#[cfg(all(not(unix), not(windows)))]
+use std::time::UNIX_EPOCH;
 
 use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+
+/// A single JSONL record must fit within this many raw bytes (including its
+/// trailing newline). The reader checks the bound before extending its buffer,
+/// so malformed or hostile files cannot cause unbounded allocation.
+pub const MAX_JSONL_LINE_BYTES: usize = 1024 * 1024;
+
+/// Only a fixed window immediately before the committed offset is read when an
+/// append is validated. File identity catches rotation; this boundary catches
+/// truncate/rewrite-and-regrow at the append seam.
+const BOUNDARY_WINDOW_BYTES: usize = 4096;
+const BOUNDARY_FINGERPRINT_VERSION: u8 = 2;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ImportedParseWatermark {
@@ -27,6 +42,9 @@ pub struct ImportedParseWatermark {
     pub source_size_bytes: i64,
     /// Nanosecond mtime; see [`super::metadata::ImportedHistoryCacheInput::source_mtime_ms`].
     pub source_mtime_ms: i64,
+    /// Versioned boundary fingerprint. The column name is retained for
+    /// backwards-compatible persistence; legacy whole-prefix hashes simply
+    /// fail decoding and trigger one cold re-parse.
     pub prefix_hash: String,
     pub parser_version: i64,
     pub state_json: String,
@@ -107,10 +125,7 @@ pub fn clear_parse_watermark_from_conn(
     Ok(())
 }
 
-/// Streaming FNV-1a 64 over the processed prefix. Integrity check against
-/// accidental prefix rewrites, not an adversarial digest — chosen because it
-/// can keep hashing across the resume boundary (validate the stored prefix,
-/// then continue over newly consumed lines) without re-reading the file.
+/// FNV-1a 64 used as a compact integrity check, not an adversarial digest.
 #[derive(Debug, Clone)]
 pub struct PrefixHasher(u64);
 
@@ -133,7 +148,104 @@ impl PrefixHasher {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct BoundaryFingerprint {
+    version: u8,
+    file_identity: String,
+    tail_len: usize,
+    tail_hash: String,
+}
+
+impl BoundaryFingerprint {
+    fn new(file_identity: String, tail: &[u8]) -> Self {
+        let mut hasher = PrefixHasher::default();
+        hasher.update(tail);
+        Self {
+            version: BOUNDARY_FINGERPRINT_VERSION,
+            file_identity,
+            tail_len: tail.len(),
+            tail_hash: hasher.digest(),
+        }
+    }
+
+    fn decode(raw: &str) -> Option<Self> {
+        let decoded = serde_json::from_str::<Self>(raw).ok()?;
+        (decoded.version == BOUNDARY_FINGERPRINT_VERSION
+            && !decoded.file_identity.is_empty()
+            && decoded.tail_len <= BOUNDARY_WINDOW_BYTES)
+            .then_some(decoded)
+    }
+
+    fn encode(&self) -> String {
+        // This structure contains only integers and strings, so serialization
+        // cannot fail in practice. An empty value safely disables resume.
+        serde_json::to_string(self).unwrap_or_default()
+    }
+}
+
+fn source_file_identity(_path: &Path, metadata: &std::fs::Metadata) -> Option<String> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        Some(format!("unix:{}:{}", metadata.dev(), metadata.ino()))
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        Some(format!(
+            "windows:{}:{}",
+            metadata.volume_serial_number()?,
+            metadata.file_index()?
+        ))
+    }
+    #[cfg(all(not(unix), not(windows)))]
+    {
+        // `created` is stable across appends and changes on normal rotation.
+        // If the platform/filesystem cannot expose it, disable resume rather
+        // than accepting an identity we cannot prove.
+        let created_ns = metadata
+            .created()
+            .ok()?
+            .duration_since(UNIX_EPOCH)
+            .ok()?
+            .as_nanos();
+        let mut path_hasher = PrefixHasher::default();
+        path_hasher.update(_path.to_string_lossy().as_bytes());
+        Some(format!(
+            "created:{created_ns}:path:{}",
+            path_hasher.digest()
+        ))
+    }
+}
+
+fn read_boundary_tail(file: &mut File, offset: u64) -> Result<Vec<u8>, String> {
+    let tail_len = offset.min(BOUNDARY_WINDOW_BYTES as u64) as usize;
+    let start = offset.saturating_sub(tail_len as u64);
+    file.seek(SeekFrom::Start(start))
+        .map_err(|err| format!("Failed to seek history boundary: {err}"))?;
+    let mut tail = vec![0u8; tail_len];
+    file.read_exact(&mut tail)
+        .map_err(|err| format!("Failed to read history boundary: {err}"))?;
+    Ok(tail)
+}
+
+fn push_boundary_bytes(window: &mut Vec<u8>, bytes: &[u8]) {
+    if bytes.len() >= BOUNDARY_WINDOW_BYTES {
+        window.clear();
+        window.extend_from_slice(&bytes[bytes.len() - BOUNDARY_WINDOW_BYTES..]);
+        return;
+    }
+    let overflow = window
+        .len()
+        .saturating_add(bytes.len())
+        .saturating_sub(BOUNDARY_WINDOW_BYTES);
+    if overflow > 0 {
+        window.drain(..overflow);
+    }
+    window.extend_from_slice(bytes);
+}
+
+#[derive(Debug, PartialEq, Eq)]
 pub struct TranscriptLine {
     pub text: String,
     /// `false` only for a final line with no trailing newline — a live
@@ -143,10 +255,12 @@ pub struct TranscriptLine {
 }
 
 /// Line reader over one transcript that tracks the complete-line byte offset
-/// and prefix hash, seeking past an intact watermark prefix on open.
+/// and bounded append-boundary fingerprint, seeking past an intact watermark
+/// prefix on open.
 pub struct WatermarkedTranscriptReader {
     reader: BufReader<File>,
-    hasher: PrefixHasher,
+    file_identity: String,
+    boundary_window: Vec<u8>,
     complete_offset: u64,
     resume_state_json: Option<String>,
     buf: Vec<u8>,
@@ -168,29 +282,41 @@ impl WatermarkedTranscriptReader {
                 path.display()
             )
         })?;
-        let file_len = file
+        let metadata = file
             .metadata()
-            .map_err(|err| format!("Failed to read {error_label} history metadata: {err}"))?
-            .len();
+            .map_err(|err| format!("Failed to read {error_label} history metadata: {err}"))?;
+        let file_len = metadata.len();
+        let file_identity = source_file_identity(path, &metadata).unwrap_or_default();
 
-        let mut hasher = PrefixHasher::default();
+        let mut boundary_window = Vec::new();
         let mut complete_offset = 0u64;
         let mut resume_state_json = None;
         if let Some(watermark) = watermark {
+            let stored_fingerprint = BoundaryFingerprint::decode(&watermark.prefix_hash);
+            let same_signature = current_size_bytes == watermark.source_size_bytes
+                && current_mtime_ns == watermark.source_mtime_ms;
+            let grew = current_size_bytes > watermark.source_size_bytes
+                && current_mtime_ns >= watermark.source_mtime_ms;
             let eligible = watermark.parser_version == parser_version
                 && watermark.byte_offset >= 0
-                && current_size_bytes >= watermark.source_size_bytes
-                && current_mtime_ns >= watermark.source_mtime_ms
-                && watermark.byte_offset as u64 <= file_len;
-            if eligible
-                && Self::hash_prefix(&mut file, watermark.byte_offset as u64, &mut hasher)?
-                && hasher.digest() == watermark.prefix_hash
-            {
-                complete_offset = watermark.byte_offset as u64;
-                resume_state_json = Some(watermark.state_json.clone());
+                && (same_signature || grew)
+                && watermark.byte_offset as u64 <= file_len
+                && stored_fingerprint
+                    .as_ref()
+                    .is_some_and(|stored| stored.file_identity == file_identity);
+            if eligible {
+                let tail = read_boundary_tail(&mut file, watermark.byte_offset as u64)?;
+                let current = BoundaryFingerprint::new(file_identity.clone(), tail.as_slice());
+                if stored_fingerprint.as_ref() == Some(&current) {
+                    complete_offset = watermark.byte_offset as u64;
+                    boundary_window = tail;
+                    resume_state_json = Some(watermark.state_json.clone());
+                    file.seek(SeekFrom::Start(complete_offset))
+                        .map_err(|err| format!("Failed to seek {error_label} history: {err}"))?;
+                }
             }
             if resume_state_json.is_none() {
-                hasher = PrefixHasher::default();
+                boundary_window.clear();
                 file.seek(SeekFrom::Start(0))
                     .map_err(|err| format!("Failed to rewind {error_label} history: {err}"))?;
             }
@@ -198,33 +324,13 @@ impl WatermarkedTranscriptReader {
 
         Ok(Self {
             reader: BufReader::new(file),
-            hasher,
+            file_identity,
+            boundary_window,
             complete_offset,
             resume_state_json,
             buf: Vec::new(),
             error_label,
         })
-    }
-
-    fn hash_prefix(
-        file: &mut File,
-        prefix_len: u64,
-        hasher: &mut PrefixHasher,
-    ) -> Result<bool, String> {
-        let mut remaining = prefix_len;
-        let mut chunk = vec![0u8; 256 * 1024];
-        while remaining > 0 {
-            let take = remaining.min(chunk.len() as u64) as usize;
-            let read = file
-                .read(&mut chunk[..take])
-                .map_err(|err| format!("Failed to read history prefix: {err}"))?;
-            if read == 0 {
-                return Ok(false);
-            }
-            hasher.update(&chunk[..read]);
-            remaining -= read as u64;
-        }
-        Ok(true)
     }
 
     pub fn resume_state_json(&self) -> Option<&str> {
@@ -233,17 +339,35 @@ impl WatermarkedTranscriptReader {
 
     pub fn next_line(&mut self) -> Result<Option<TranscriptLine>, String> {
         self.buf.clear();
-        let read = self
-            .reader
-            .read_until(b'\n', &mut self.buf)
-            .map_err(|err| format!("Failed to read {} history line: {err}", self.error_label))?;
-        if read == 0 {
+        let mut terminated = false;
+        loop {
+            let available = self.reader.fill_buf().map_err(|err| {
+                format!("Failed to read {} history line: {err}", self.error_label)
+            })?;
+            if available.is_empty() {
+                break;
+            }
+            let newline = available.iter().position(|byte| *byte == b'\n');
+            let take = newline.map_or(available.len(), |index| index + 1);
+            if self.buf.len().saturating_add(take) > MAX_JSONL_LINE_BYTES {
+                return Err(format!(
+                    "Failed to read {} history line: record exceeds {} bytes",
+                    self.error_label, MAX_JSONL_LINE_BYTES
+                ));
+            }
+            self.buf.extend_from_slice(&available[..take]);
+            self.reader.consume(take);
+            if newline.is_some() {
+                terminated = true;
+                break;
+            }
+        }
+        if self.buf.is_empty() {
             return Ok(None);
         }
-        let terminated = self.buf.last() == Some(&b'\n');
         if terminated {
-            self.hasher.update(&self.buf);
-            self.complete_offset += read as u64;
+            push_boundary_bytes(&mut self.boundary_window, &self.buf);
+            self.complete_offset += self.buf.len() as u64;
         }
         let mut end = self.buf.len();
         if terminated {
@@ -269,7 +393,11 @@ impl WatermarkedTranscriptReader {
             byte_offset: self.complete_offset as i64,
             source_size_bytes: current_size_bytes,
             source_mtime_ms: current_mtime_ns,
-            prefix_hash: self.hasher.digest(),
+            prefix_hash: BoundaryFingerprint::new(
+                self.file_identity,
+                self.boundary_window.as_slice(),
+            )
+            .encode(),
             parser_version,
             state_json,
         }

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/watermark_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/watermark_tests.rs
@@ -150,6 +150,101 @@ fn prefix_mutation_forces_a_full_reparse() {
 }
 
 #[test]
+fn same_size_mtime_change_forces_a_full_reparse() {
+    let path = temp_transcript("same-size-rewrite", "aa\nbb\n");
+    let (mtime, size) = stat(&path);
+    let mut reader =
+        WatermarkedTranscriptReader::open(&path, "Test", None, 1, mtime, size).expect("open full");
+    read_all(&mut reader);
+    let watermark = reader.into_watermark(1, mtime, size, "state-1".to_string());
+
+    fs::write(&path, "cc\ndd\n").expect("same-size rewrite");
+    let mut reopened =
+        WatermarkedTranscriptReader::open(&path, "Test", Some(&watermark), 1, mtime + 1, size)
+            .expect("open rewritten");
+    assert!(reopened.resume_state_json().is_none());
+    assert_eq!(
+        read_all(&mut reopened),
+        vec![("cc".to_string(), true), ("dd".to_string(), true)]
+    );
+
+    cleanup(&path);
+}
+
+#[test]
+fn rotated_file_identity_forces_a_full_reparse() {
+    let path = temp_transcript("rotation", "old\n");
+    let old_path = path.with_extension("old");
+    let (mtime, size) = stat(&path);
+    let mut reader =
+        WatermarkedTranscriptReader::open(&path, "Test", None, 1, mtime, size).expect("open full");
+    read_all(&mut reader);
+    let watermark = reader.into_watermark(1, mtime, size, "state-1".to_string());
+
+    fs::rename(&path, &old_path).expect("rotate old file");
+    fs::write(&path, "new\nappended\n").expect("create replacement");
+    let (rotated_mtime, rotated_size) = stat(&path);
+    let mut reopened = WatermarkedTranscriptReader::open(
+        &path,
+        "Test",
+        Some(&watermark),
+        1,
+        rotated_mtime.max(mtime),
+        rotated_size,
+    )
+    .expect("open replacement");
+    assert!(reopened.resume_state_json().is_none());
+    assert_eq!(
+        read_all(&mut reopened),
+        vec![("new".to_string(), true), ("appended".to_string(), true)]
+    );
+
+    fs::remove_file(&old_path).ok();
+    cleanup(&path);
+}
+
+#[test]
+fn oversized_line_is_rejected_without_advancing_a_watermark() {
+    let path = temp_transcript("oversized", "stable\n");
+    let (mtime, size) = stat(&path);
+    let mut reader =
+        WatermarkedTranscriptReader::open(&path, "Test", None, 1, mtime, size).expect("open full");
+    assert_eq!(
+        reader.next_line().expect("read stable"),
+        Some(TranscriptLine {
+            text: "stable".to_string(),
+            terminated: true,
+        })
+    );
+    let watermark = reader.into_watermark(1, mtime, size, "stable-state".to_string());
+
+    let oversized = vec![b'x'; MAX_JSONL_LINE_BYTES + 1];
+    fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .and_then(|mut file| {
+            std::io::Write::write_all(&mut file, &oversized)?;
+            std::io::Write::write_all(&mut file, b"\n")
+        })
+        .expect("append oversized record");
+    let (mtime_after, size_after) = stat(&path);
+    let mut resumed = WatermarkedTranscriptReader::open(
+        &path,
+        "Test",
+        Some(&watermark),
+        1,
+        mtime_after,
+        size_after,
+    )
+    .expect("open appended file");
+    assert_eq!(resumed.resume_state_json(), Some("stable-state"));
+    let error = resumed.next_line().expect_err("oversized line rejected");
+    assert!(error.contains("record exceeds"));
+
+    cleanup(&path);
+}
+
+#[test]
 fn size_regression_and_parser_version_change_force_a_full_reparse() {
     let path = temp_transcript("invalidate", "aa\nbb\n");
     let (mtime, size) = stat(&path);


### PR DESCRIPTION
## Problem

Append-only JSONL importers persisted a whole-prefix hash. Every append therefore sought to the saved offset but still reread and rehashed all previously committed transcript bytes before accepting the watermark, making warm ingestion O(total history) instead of O(delta).

The shared line reader also allowed one malformed or hostile JSONL record to grow its buffer without a hard bound.

## Solution

Replace the persisted whole-prefix digest with a versioned, fixed-size resume seam while keeping the existing database column and parser state:

- store platform file identity plus the FNV-1a hash and length of at most the final 4 KiB before the last complete-line offset;
- resume only when parser version, file identity, monotonic size and mtime, saved offset, and the 4 KiB boundary fingerprint all match;
- treat legacy whole-prefix hashes, same-size rewrites, shrink, rotation, parser changes, identity changes, and seam mismatches as a cold parse of that one file;
- leave final unterminated lines outside the committed offset and state so an active writer can finish them safely;
- enforce a 1 MiB raw JSONL line cap before extending the read buffer;
- keep persistence schema-compatible by encoding the new fingerprint as JSON in the existing prefix_hash column.

Unchanged metadata remains O(metadata) at discovery; an eligible append reads O(4 KiB + appended bytes). No timer, watcher, worker, or new retained cache is added.

## Potential risks

- The first read of a legacy watermark intentionally cold-parses that file once and self-heals the stored fingerprint. No table migration is required.
- A 1 MiB physical JSONL line is now rejected. This prevents memory spikes but may reject an unusually large legitimate single-line tool payload; the existing last-good cache and watermark are not advanced on error.
- The constant-size seam detects rotation and mutations near the committed boundary, but cannot prove that bytes far earlier in a growing same-identity file were not rewritten. Same-size mtime changes, shrink, identity change, and boundary mutation do force cold parse. Full arbitrary-prefix verification would restore O(total history) work.
- Filesystems that cannot provide a stable file identity disable resume and cold-parse safely.
- The fingerprint is an integrity check, not a cryptographic adversarial guarantee.
- Rollback is a revert of this commit. The older reader will treat the JSON fingerprint as a mismatched legacy hash and perform one cold parse before restoring its older format.

## Audit

Performance guard verdict: pass. Idle cost is zero; unchanged discovery performs no transcript read; append validation reads at most 4 KiB before the delta; per-line memory is capped at 1 MiB; and reset scope is one changed file.

Architecture review covered watermark ownership, file and parser identity, resume/reset state transitions, persistence compatibility, incomplete-line lifecycle, error and last-good semantics, platform fallbacks, and focused test seams. Provider formats and frontend behavior are unchanged.

No screenshot was captured because this is a backend ingestion primitive with no UI change.

## Verification

- Clean detached-worktree validation at commit c94db5281: CARGO_BUILD_JOBS=1 cargo test -p orgtrack_core sources::imported_history::watermark::tests — 9 passed.
- Clean detached-worktree validation: CARGO_BUILD_JOBS=1 cargo clippy -p orgtrack_core --lib --no-deps — completed with only two pre-existing warnings in unrelated orgtrack-core files.
- Tests cover suffix-only resume, unterminated tails, same-size rewrite, seam mutation, shrink, parser change, file rotation, oversize rejection, database roundtrip, malformed-row fallback, and self-heal.
- rustfmt and git diff --check — passed.
- Diff scan for secrets, private keys, bearer tokens, and personal paths — passed.
- The isolated worktree lacked the generated Husky shim, so equivalent formatting, tests, scoped clippy, and staged-diff checks were run manually before committing.

Not run: production-home benchmark or filesystem-specific Windows execution.
