### PR TITLE
feat(quota): add bounded Kimi Code usage

### DIFF
--- a/src-tauri/crates/key-vault/src/commands/validate.rs
+++ b/src-tauri/crates/key-vault/src/commands/validate.rs
@@ -15,6 +15,7 @@ use crate::providers::copilot::CopilotValidator;
 use crate::providers::cursor::CursorValidator;
 use crate::providers::deepseek::DeepSeekQuotaFetcher;
 use crate::providers::google::GoogleValidator;
+use crate::providers::kimi::KimiCodeQuotaFetcher;
 use crate::providers::kiro::KiroValidator;
 use crate::providers::minimax::MiniMaxQuotaFetcher;
 use crate::providers::openai::OpenAIValidator;
@@ -975,6 +976,16 @@ async fn fetch_quota_for_key(
                 .fetch_quota(token, key.base_url.as_deref())
                 .await
         }
+        ModelType::MoonshotApi => {
+            let token = key
+                .api_key
+                .as_deref()
+                .filter(|token| !token.trim().is_empty())
+                .ok_or_else(|| "Kimi Code account has no API key".to_string())?;
+            KimiCodeQuotaFetcher::new()
+                .fetch_quota(token, key.base_url.as_deref())
+                .await
+        }
         ModelType::QoderCli => {
             let cookie =
                 first_non_empty_secret(key.session_token.as_deref(), key.api_key.as_deref())
@@ -1003,6 +1014,8 @@ fn first_non_empty_secret<'a>(
 fn quota_refresh_uses_strict_request_count(key: &crate::key_store::ModelKey) -> bool {
     matches!(key.model_type, ModelType::QoderCli)
         || (key.model_type == ModelType::ZhipuApi && team_scope_from_key(key).is_some())
+        || (key.model_type == ModelType::MoonshotApi
+            && crate::providers::kimi::has_supported_base_url(key.base_url.as_deref()))
 }
 
 pub(super) fn key_can_refresh_quota(key: &crate::key_store::ModelKey) -> bool {
@@ -1020,6 +1033,9 @@ pub(super) fn key_can_refresh_quota(key: &crate::key_store::ModelKey) -> bool {
         | ModelType::DeepseekApi
         | ModelType::OpenrouterApi
         | ModelType::MinimaxApi => has_api_key,
+        ModelType::MoonshotApi => {
+            has_api_key && crate::providers::kimi::has_supported_base_url(key.base_url.as_deref())
+        }
         ModelType::ZhipuApi => has_api_key && !has_partial_team_scope(key),
         ModelType::QoderCli => {
             (has_session_token || has_api_key)
@@ -1043,6 +1059,7 @@ mod direct_quota_dispatch_tests {
             (ModelType::DeepseekApi, "DeepSeek", "no API key"),
             (ModelType::OpenrouterApi, "OpenRouter", "no API key"),
             (ModelType::MinimaxApi, "MiniMax", "no API key"),
+            (ModelType::MoonshotApi, "Kimi Code", "no API key"),
             (ModelType::QoderCli, "Qoder", "no saved cookie or token"),
         ] {
             let key = crate::key_store::ModelKey::new(model_type);
@@ -1081,11 +1098,16 @@ mod direct_quota_dispatch_tests {
             ModelType::DeepseekApi,
             ModelType::OpenrouterApi,
             ModelType::MinimaxApi,
+            ModelType::MoonshotApi,
             ModelType::QoderCli,
         ] {
+            let is_kimi_code = model_type == ModelType::MoonshotApi;
             let mut key = crate::key_store::ModelKey::new(model_type);
             key.api_key = Some("api-key".to_string());
             key.session_token = Some("session-token".to_string());
+            if is_kimi_code {
+                key.base_url = Some("https://api.kimi.com/coding".to_string());
+            }
             assert!(key_can_refresh_quota(&key));
         }
 
@@ -1131,6 +1153,24 @@ mod direct_quota_dispatch_tests {
         assert!(quota_refresh_uses_strict_request_count(&key));
         key.base_url = Some("https://example.com".into());
         assert!(!key_can_refresh_quota(&key));
+    }
+
+    #[test]
+    fn kimi_code_capability_is_fixed_route_and_strict_one_attempt() {
+        let mut key = crate::key_store::ModelKey::new(ModelType::MoonshotApi);
+        key.api_key = Some("kimi-code-key".into());
+        assert!(!key_can_refresh_quota(&key));
+        assert!(!quota_refresh_uses_strict_request_count(&key));
+
+        key.base_url = Some("https://api.moonshot.ai/v1".into());
+        assert!(!key_can_refresh_quota(&key));
+        assert!(!quota_refresh_uses_strict_request_count(&key));
+
+        let ordinary_revision = quota_credential_revision(&key);
+        key.base_url = Some("https://api.kimi.com/coding/".into());
+        assert!(key_can_refresh_quota(&key));
+        assert!(quota_refresh_uses_strict_request_count(&key));
+        assert_ne!(ordinary_revision, quota_credential_revision(&key));
     }
 
     #[test]

--- a/src-tauri/crates/key-vault/src/providers/kimi.rs
+++ b/src-tauri/crates/key-vault/src/providers/kimi.rs
@@ -1,0 +1,332 @@
+//! Kimi Code quota lookup for explicitly pinned Kimi Code API accounts.
+//!
+//! This intentionally supports only the fixed Kimi Code API route. It does not
+//! inspect CLI credentials, refresh OAuth tokens, read browser cookies, or
+//! probe Kimi's multi-request web membership endpoints.
+
+use serde_json::Value;
+
+use crate::providers::quota_http::get_bearer_json;
+use crate::providers::quota_windows::{json_time_to_rfc3339, quota_from_windows, QuotaWindow};
+use crate::types::QuotaInfo;
+
+const KIMI_CODE_USAGE_URL: &str = "https://api.kimi.com/coding/v1/usages";
+const KIMI_CODE_HOST: &str = "api.kimi.com";
+const PLAN_TYPE_DEFAULT: &str = "Kimi Code";
+const QUOTA_SOURCE: &str = "kimi_code_usage";
+const MAX_API_KEY_BYTES: usize = 64 * 1024;
+const MAX_PLAN_LABEL_BYTES: usize = 64;
+const MAX_LIMIT_ROWS: usize = 32;
+const SESSION_MAX_MINUTES: f64 = 6.0 * 60.0;
+
+pub struct KimiCodeQuotaFetcher;
+
+impl KimiCodeQuotaFetcher {
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Fetch the fixed Kimi Code usage endpoint with exactly one GET.
+    pub async fn fetch_quota(
+        &self,
+        api_key: &str,
+        base_url: Option<&str>,
+    ) -> Result<QuotaInfo, String> {
+        let api_key = api_key.trim();
+        if api_key.is_empty() {
+            return Err("Kimi Code account has no API key".to_string());
+        }
+        if api_key.len() > MAX_API_KEY_BYTES {
+            return Err(format!(
+                "Kimi Code API key exceeds the {MAX_API_KEY_BYTES}-byte request-header limit"
+            ));
+        }
+        validate_kimi_code_base_url(base_url)?;
+
+        let body = get_bearer_json("Kimi Code", KIMI_CODE_USAGE_URL, api_key)
+            .await
+            .map_err(|error| error.to_string())?;
+        parse_kimi_code_quota(&body)
+    }
+}
+
+impl Default for KimiCodeQuotaFetcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub(crate) fn has_supported_base_url(base_url: Option<&str>) -> bool {
+    validate_kimi_code_base_url(base_url).is_ok()
+}
+
+fn validate_kimi_code_base_url(base_url: Option<&str>) -> Result<(), String> {
+    let base_url = base_url
+        .map(str::trim)
+        .filter(|base_url| !base_url.is_empty())
+        .ok_or_else(|| {
+            "Kimi Code quota requires an explicitly saved api.kimi.com/coding base URL".to_string()
+        })?;
+    let parsed = url::Url::parse(base_url)
+        .map_err(|error| format!("Invalid Kimi Code base URL: {error}"))?;
+    let path = parsed.path().trim_end_matches('/');
+    let is_supported = parsed.scheme() == "https"
+        && parsed.host_str() == Some(KIMI_CODE_HOST)
+        && parsed.port_or_known_default() == Some(443)
+        && parsed.username().is_empty()
+        && parsed.password().is_none()
+        && parsed.query().is_none()
+        && parsed.fragment().is_none()
+        && matches!(path, "/coding" | "/coding/v1");
+    if is_supported {
+        Ok(())
+    } else {
+        Err(
+            "Kimi Code quota base URL must be https://api.kimi.com/coding or \
+             https://api.kimi.com/coding/v1"
+                .to_string(),
+        )
+    }
+}
+
+fn parse_kimi_code_quota(body: &Value) -> Result<QuotaInfo, String> {
+    let mut session = None;
+    if let Some(limits) = body.get("limits").and_then(Value::as_array) {
+        for entry in limits.iter().take(MAX_LIMIT_ROWS) {
+            let Some(window_minutes) = entry.get("window").and_then(kimi_window_minutes) else {
+                continue;
+            };
+            if window_minutes > SESSION_MAX_MINUTES {
+                continue;
+            }
+            let Some(detail) = entry.get("detail") else {
+                continue;
+            };
+            if let Some((used_percent, reset_time)) = parse_quota_detail(detail) {
+                session = Some(QuotaWindow::session(used_percent, reset_time));
+                break;
+            }
+        }
+    }
+
+    let weekly = body
+        .get("usage")
+        .and_then(parse_quota_detail)
+        .map(|(used_percent, reset_time)| QuotaWindow::weekly(used_percent, reset_time));
+
+    let mut windows = Vec::with_capacity(2);
+    if let Some(session) = session {
+        windows.push(session);
+    }
+    if let Some(weekly) = weekly {
+        windows.push(weekly);
+    }
+    if windows.is_empty() {
+        return Err(
+            "Kimi Code quota HTTP 200 response has no usable session or weekly window".to_string(),
+        );
+    }
+
+    let plan_type = body
+        .pointer("/user/membership/level")
+        .and_then(Value::as_str)
+        .and_then(normalize_plan_label)
+        .unwrap_or_else(|| PLAN_TYPE_DEFAULT.to_string());
+    Ok(quota_from_windows(&plan_type, QUOTA_SOURCE, windows))
+}
+
+fn parse_quota_detail(detail: &Value) -> Option<(f64, Option<String>)> {
+    let limit = detail.get("limit").and_then(finite_number)?;
+    if limit <= 0.0 {
+        return None;
+    }
+    let remaining = detail
+        .get("remaining")
+        .and_then(finite_number)
+        .map(|remaining| remaining.max(0.0));
+    let used = detail
+        .get("used")
+        .and_then(finite_number)
+        .map(|used| used.max(0.0))
+        .or_else(|| remaining.map(|remaining| (limit - remaining).max(0.0)))?;
+    let used_percent = (used / limit * 100.0).clamp(0.0, 100.0);
+    let reset_time = detail.get("resetTime").and_then(json_time_to_rfc3339);
+    Some((used_percent, reset_time))
+}
+
+fn kimi_window_minutes(window: &Value) -> Option<f64> {
+    let duration = window.get("duration").and_then(finite_number)?;
+    if duration <= 0.0 {
+        return None;
+    }
+    match window
+        .get("timeUnit")
+        .or_else(|| window.get("time_unit"))
+        .and_then(Value::as_str)?
+    {
+        "TIME_UNIT_MINUTE" => Some(duration),
+        "TIME_UNIT_HOUR" => Some(duration * 60.0),
+        "TIME_UNIT_DAY" => Some(duration * 24.0 * 60.0),
+        "TIME_UNIT_WEEK" => Some(duration * 7.0 * 24.0 * 60.0),
+        _ => None,
+    }
+}
+
+fn finite_number(value: &Value) -> Option<f64> {
+    let number = value
+        .as_f64()
+        .or_else(|| value.as_str()?.trim().parse::<f64>().ok())?;
+    number.is_finite().then_some(number)
+}
+
+fn normalize_plan_label(raw: &str) -> Option<String> {
+    let raw = raw.trim();
+    if raw.is_empty() || raw.len() > MAX_PLAN_LABEL_BYTES {
+        return None;
+    }
+    let label = raw
+        .strip_prefix("LEVEL_")
+        .unwrap_or(raw)
+        .replace('_', " ")
+        .split_whitespace()
+        .map(title_case_ascii)
+        .collect::<Vec<_>>()
+        .join(" ");
+    (!label.is_empty() && label.len() <= MAX_PLAN_LABEL_BYTES).then_some(label)
+}
+
+fn title_case_ascii(word: &str) -> String {
+    let mut chars = word.chars();
+    match chars.next() {
+        Some(first) if first.is_ascii() => first
+            .to_ascii_uppercase()
+            .to_string()
+            .chars()
+            .chain(chars.flat_map(char::to_lowercase))
+            .collect(),
+        Some(first) => first.to_uppercase().chain(chars).collect(),
+        None => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn base_url_accepts_only_the_fixed_kimi_code_route() {
+        for supported in [
+            "https://api.kimi.com/coding",
+            "https://api.kimi.com/coding/",
+            "https://api.kimi.com/coding/v1",
+            "https://api.kimi.com/coding/v1/",
+        ] {
+            assert!(has_supported_base_url(Some(supported)), "{supported}");
+        }
+        for rejected in [
+            "https://api.moonshot.ai/v1",
+            "https://api.kimi.com",
+            "https://api.kimi.com/coding/v2",
+            "http://api.kimi.com/coding",
+            "https://api.kimi.com.evil.test/coding",
+            "https://api.kimi.com/coding?region=other",
+        ] {
+            assert!(!has_supported_base_url(Some(rejected)), "{rejected}");
+        }
+        assert!(!has_supported_base_url(None));
+        assert_eq!(KIMI_CODE_USAGE_URL, "https://api.kimi.com/coding/v1/usages");
+    }
+
+    #[test]
+    fn canonical_response_maps_five_hour_and_weekly_windows() {
+        let quota = parse_kimi_code_quota(&json!({
+            "usage": {
+                "limit": "2048",
+                "used": "214",
+                "remaining": "1834",
+                "resetTime": "2026-07-14T00:00:00Z"
+            },
+            "limits": [{
+                "window": {
+                    "duration": 300,
+                    "timeUnit": "TIME_UNIT_MINUTE"
+                },
+                "detail": {
+                    "limit": "200",
+                    "used": "139",
+                    "remaining": "61",
+                    "resetTime": "2026-07-08T05:00:00Z"
+                }
+            }],
+            "user": {
+                "membership": {
+                    "level": "LEVEL_PRO_PLUS"
+                }
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(quota.plan_type.as_deref(), Some("Pro Plus"));
+        assert_eq!(quota.quota_source.as_deref(), Some(QUOTA_SOURCE));
+        assert_eq!(quota.usage_items.len(), 2);
+        assert_eq!(quota.usage_items[0].usage_type, "session");
+        assert_eq!(quota.usage_items[0].remaining_percentage, 30.5);
+        assert_eq!(
+            quota.usage_items[0].reset_time.as_deref(),
+            Some("2026-07-08T05:00:00Z")
+        );
+        assert_eq!(quota.usage_items[1].usage_type, "weekly");
+        assert!((quota.usage_items[1].remaining_percentage - 89.55078125).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parser_uses_limit_minus_remaining_when_used_is_absent() {
+        let quota = parse_kimi_code_quota(&json!({
+            "usage": {
+                "limit": "100",
+                "remaining": "75"
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(quota.usage_items.len(), 1);
+        assert_eq!(quota.usage_items[0].usage_type, "weekly");
+        assert_eq!(quota.usage_items[0].remaining_percentage, 75.0);
+    }
+
+    #[test]
+    fn parser_rejects_empty_success_and_bounds_limit_rows() {
+        let error = parse_kimi_code_quota(&json!({"limits": []})).unwrap_err();
+        assert!(error.contains("HTTP 200"));
+        assert!(error.contains("no usable"));
+
+        let limits = (0..MAX_LIMIT_ROWS + 10)
+            .map(|index| {
+                json!({
+                    "window": {
+                        "duration": if index == MAX_LIMIT_ROWS + 1 { 300 } else { 7 },
+                        "timeUnit": if index == MAX_LIMIT_ROWS + 1 {
+                            "TIME_UNIT_MINUTE"
+                        } else {
+                            "TIME_UNIT_DAY"
+                        }
+                    },
+                    "detail": {"limit": 100, "remaining": 50}
+                })
+            })
+            .collect::<Vec<_>>();
+        let error = parse_kimi_code_quota(&json!({"limits": limits})).unwrap_err();
+        assert!(error.contains("no usable"));
+    }
+
+    #[tokio::test]
+    async fn oversized_api_key_is_rejected_before_request_construction() {
+        let api_key = "x".repeat(MAX_API_KEY_BYTES + 1);
+        let error = KimiCodeQuotaFetcher::new()
+            .fetch_quota(&api_key, Some("https://api.kimi.com/coding"))
+            .await
+            .unwrap_err();
+        assert!(error.contains("request-header limit"));
+    }
+}

--- a/src-tauri/crates/key-vault/src/providers/mod.rs
+++ b/src-tauri/crates/key-vault/src/providers/mod.rs
@@ -8,6 +8,7 @@ pub mod copilot;
 pub mod cursor;
 pub mod deepseek;
 pub mod google;
+pub mod kimi;
 pub mod kiro;
 pub mod minimax;
 pub mod openai;


### PR DESCRIPTION
## Problem

ORGII can store Moonshot/Kimi Code credentials but cannot show Kimi Code session and weekly quota. Copying token-monitor's combined web-membership path would add cookies, parallel endpoints, credential probing, and avoidable refresh work. Ordinary Moonshot API accounts must also not be sent to the Kimi Code-only usage endpoint.

## Solution

Add quota refresh only for explicitly saved `moonshot_api` accounts whose base URL is exactly the HTTPS `api.kimi.com/coding[/v1]` route. Refresh performs one fixed GET to `/coding/v1/usages`, reuses the bounded quota HTTP/runtime infrastructure, disables transient retry, and parses at most one session plus one weekly window. API key, plan label, response body, account lanes, request concurrency, TTL/cooldown, last-good, and credential-generation behavior retain explicit bounds. No CLI credential scan, OAuth refresh, browser cookie, web membership request, fallback, timer, watcher, or background worker is introduced.

## Potential risks

Kimi may change the `/coding/v1/usages` response fields or window enum labels; such a change will return a scoped refresh error while retaining last-good data. Accounts using `api.moonshot.ai`, `api.moonshot.cn`, a proxy, or no explicit Kimi Code base URL intentionally remain ineligible. No live credential was available, so endpoint authentication was not exercised. Rollback is removal of the Kimi provider module and its dispatch/capability arm; there is no persistence, schema, dependency, or public wire change.

## Audit

- Architecture: dispatch and capability share one fixed-route predicate; ordinary Moonshot accounts cannot fall through to Kimi Code. Wire parsing is fixture-tested and returns the existing quota type. No alternate initialization or resolver path was added.
- Performance: fixed one-request policy, 1 MiB shared response cap, 64 KiB API-key header cap, 32 parsed limit rows, at most two output windows, process-wide single-flight/TTL/cooldown/concurrency/generation guard. No idle or hidden work.

## Verification

- `CARGO_BUILD_JOBS=1 cargo test -p key_vault providers::kimi::tests -- --test-threads=1` — 5 passed.
- `CARGO_BUILD_JOBS=1 cargo test -p key_vault commands::validate::direct_quota_dispatch_tests -- --test-threads=1` — 7 passed.
- `CARGO_BUILD_JOBS=1 cargo test -p key_vault -- --test-threads=1` — 337 passed.
- `CARGO_BUILD_JOBS=1 cargo clippy -p key_vault --all-targets --no-deps` — completed; only three pre-existing key-vault warnings remain.
- `cargo fmt --check`/focused rustfmt and `git diff --check` — passed.
- Scope and secret/private-key/personal-path scan — clean.
- No live Kimi credential test was run.
- No screenshot was captured because this stacked backend provider uses the existing quota UI and adds no new UI layout.