### PR TITLE
fix(windows): harden desktop startup stack

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -20,6 +20,7 @@ const OPTIONAL_SIDECAR_RESOURCES: &[&str] = &[];
 fn main() {
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"));
     ensure_optional_sidecar_resources(&manifest_dir);
+    configure_windows_main_stack();
 
     tauri_build::build();
 
@@ -38,6 +39,26 @@ fn main() {
     fs::write(&out_path, generated).unwrap_or_else(|err| {
         panic!("failed to write {}: {}", out_path.display(), err);
     });
+}
+
+/// The generated Tauri invoke handler and setup closure share the Windows
+/// process main thread. The PE default reserves only 1 MiB, which is too
+/// narrow for debug builds as the command registry grows and can terminate
+/// startup with `STATUS_STACK_OVERFLOW` before Rust can run the panic hook.
+///
+/// Reserve additional virtual address space for the desktop binary only.
+/// Windows commits stack pages on demand, so this does not add 8 MiB of
+/// resident memory to every process.
+fn configure_windows_main_stack() {
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
+        return;
+    }
+
+    let link_arg = match env::var("CARGO_CFG_TARGET_ENV").as_deref() {
+        Ok("msvc") => "/STACK:8388608",
+        _ => "-Wl,--stack,8388608",
+    };
+    println!("cargo:rustc-link-arg-bin=org2={link_arg}");
 }
 
 fn ensure_optional_sidecar_resources(manifest_dir: &Path) {

--- a/src-tauri/crates/integrations/src/cli_binary_resolver.rs
+++ b/src-tauri/crates/integrations/src/cli_binary_resolver.rs
@@ -1,8 +1,11 @@
 use std::env;
 use std::ffi::OsString;
+#[cfg(unix)]
 use std::io::Read;
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+#[cfg(unix)]
+use std::process::Command;
+use std::process::Stdio;
 use std::time::Duration;
 
 const CLI_VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(5);
@@ -88,6 +91,7 @@ impl CliBinaryResolution {
     }
 }
 
+#[cfg(unix)]
 const LOGIN_SHELL_TIMEOUT: Duration = Duration::from_secs(3);
 
 const CLI_BINARY_METADATA: &[CliBinaryMetadata] = &[
@@ -483,9 +487,11 @@ fn parse_version_string(raw: &str) -> Option<String> {
 #[derive(Debug, Clone)]
 struct ResolveOptions {
     path_env: Option<OsString>,
+    #[cfg(unix)]
     shell: Option<OsString>,
     home_dir: Option<PathBuf>,
     search_login_shell: bool,
+    #[cfg(unix)]
     login_shell_timeout: Duration,
 }
 
@@ -493,9 +499,11 @@ impl Default for ResolveOptions {
     fn default() -> Self {
         Self {
             path_env: env::var_os("PATH"),
+            #[cfg(unix)]
             shell: env::var_os("SHELL"),
             home_dir: dirs::home_dir(),
             search_login_shell: true,
+            #[cfg(unix)]
             login_shell_timeout: LOGIN_SHELL_TIMEOUT,
         }
     }
@@ -652,6 +660,7 @@ fn resolve_via_login_shell(_command: &str, _options: &ResolveOptions) -> Option<
     None
 }
 
+#[cfg(unix)]
 fn parse_command_v_path(line: &str) -> Option<PathBuf> {
     let trimmed = line.trim();
     if trimmed.is_empty() || trimmed.contains('\n') || trimmed.contains('\r') {
@@ -736,13 +745,13 @@ mod tests {
         set_executable(path);
     }
 
-    fn set_executable(path: &Path) {
+    fn set_executable(_path: &Path) {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let mut permissions = fs::metadata(path).unwrap().permissions();
+            let mut permissions = fs::metadata(_path).unwrap().permissions();
             permissions.set_mode(0o755);
-            fs::set_permissions(path, permissions).unwrap();
+            fs::set_permissions(_path, permissions).unwrap();
         }
     }
 
@@ -763,14 +772,20 @@ mod tests {
     #[test]
     fn process_path_hit_returns_absolute_path() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let binary = temp_dir.path().join("codex");
+        let binary = if cfg!(windows) {
+            temp_dir.path().join("codex.CMD")
+        } else {
+            temp_dir.path().join("codex")
+        };
         make_executable(&binary);
 
         let options = ResolveOptions {
             path_env: Some(OsString::from(temp_dir.path().as_os_str())),
+            #[cfg(unix)]
             shell: Some(OsString::from("/bin/false")),
             home_dir: None,
             search_login_shell: true,
+            #[cfg(unix)]
             login_shell_timeout: Duration::from_millis(10),
         };
 
@@ -790,9 +805,11 @@ mod tests {
 
         let options = ResolveOptions {
             path_env: Some(OsString::new()),
+            #[cfg(unix)]
             shell: Some(OsString::from("/bin/false")),
             home_dir: Some(temp_dir.path().to_path_buf()),
             search_login_shell: true,
+            #[cfg(unix)]
             login_shell_timeout: Duration::from_millis(10),
         };
 

--- a/src-tauri/crates/key-vault/src/auto_detect/claude.rs
+++ b/src-tauri/crates/key-vault/src/auto_detect/claude.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 use std::env;
 use std::fs;
-use std::path::{Path, PathBuf};
+#[cfg(target_os = "macos")]
+use std::path::Path;
+use std::path::PathBuf;
 
 use chrono::{Duration as ChronoDuration, Utc};
 use serde::Deserialize;

--- a/src-tauri/crates/perf-utils/src/app_memory.rs
+++ b/src-tauri/crates/perf-utils/src/app_memory.rs
@@ -462,10 +462,13 @@ pub struct WebviewOwnershipObservation {
 impl WebviewOwnershipObservation {
     /// Mark the WebView creation as successful and begin a short, bounded
     /// observation period for late-spawned WebKit helpers.
-    pub fn commit(mut self) {
+    pub fn commit(self) {
         #[cfg(target_os = "macos")]
-        if let Some(id) = self.id.take() {
-            commit_macos_observation(id);
+        {
+            let mut observation = self;
+            if let Some(id) = observation.id.take() {
+                commit_macos_observation(id);
+            }
         }
     }
 }

--- a/src-tauri/crates/system-services/src/workspace_ports/scanner.rs
+++ b/src-tauri/crates/system-services/src/workspace_ports/scanner.rs
@@ -38,6 +38,7 @@ pub(crate) struct RawListeningPort {
 struct ProcessMetadata {
     process_name: Option<String>,
     command_line: Option<String>,
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
     cwd: Option<String>,
 }
 
@@ -777,7 +778,6 @@ fn load_windows_process_metadata(pids: &HashSet<u32>) -> HashMap<u32, ProcessMet
                     .get("CommandLine")
                     .and_then(|value| value.as_str())
                     .map(str::to_string),
-                cwd: None,
             },
         );
     }

--- a/src-tauri/crates/terminal/src/agent_tool/mod.rs
+++ b/src-tauri/crates/terminal/src/agent_tool/mod.rs
@@ -130,6 +130,9 @@ pub(crate) fn resolve_default_shell_path(
     platform: DefaultShellPlatform,
     shell_env: Option<&str>,
 ) -> String {
+    #[cfg(target_os = "windows")]
+    let _ = shell_env;
+
     match platform {
         #[cfg(any(test, target_os = "windows"))]
         DefaultShellPlatform::Windows => "powershell.exe".to_string(),

--- a/src-tauri/crates/terminal/src/tests/agent_tool_tests.rs
+++ b/src-tauri/crates/terminal/src/tests/agent_tool_tests.rs
@@ -8,7 +8,7 @@ use std::{
     },
 };
 
-#[cfg(any(target_os = "windows", unix))]
+#[cfg(unix)]
 static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
## Problem

On Windows, the debug `org2.exe` used the PE default 1 MiB main-thread stack while the generated Tauri invoke handler and setup closure continued to grow. A launch could therefore terminate before the panic hook with `0xc00000fd (STATUS_STACK_OVERFLOW)`. The same build also emitted platform-skew warnings because Unix/macOS-only imports, fields, and mutation were compiled on Windows, and a Windows resolver test used an extensionless fake executable that did not follow `PATHEXT`.

## Solution

Reserve an 8 MiB main-thread stack for the `org2` Windows executable from `build.rs`, using the appropriate MSVC or GNU linker argument. Windows commits stack pages on demand, so this raises address-space headroom without adding 8 MiB of resident memory.

Gate Unix/macOS-only resolver, keychain, WebKit-ownership, and process-metadata code at their owning platform boundaries. Keep the Windows shell parameter explicitly consumed, scope the terminal test environment lock to Unix, and make the Windows CLI resolver fixture use a `PATHEXT`-compatible `.CMD` executable.

The resulting invariant is that the Windows desktop binary carries an explicit 8 MiB stack reserve, the supplied Windows warning sites compile cleanly, and Unix/macOS behavior remains compiled only on the platforms that use it.

## Potential risks

- The stack linker argument is target-environment-specific. The MSVC path was built and inspected on Windows; the GNU fallback is code-reviewed but was not cross-compiled in this environment.
- Reserving 8 MiB increases virtual address-space reservation for `org2.exe`; pages remain demand-committed, so resident memory does not increase by the full reserve.
- Platform gates could expose a missed cross-platform use in a target not built here. The changed Windows target and focused cross-platform helper tests pass; macOS/Linux compilation was not run locally.
- Rollback is a normal revert of this commit. That restores the prior platform declarations and the 1 MiB Windows stack default, including the original overflow exposure.

## Verification

- `cargo check -p perf_utils -p integrations -p key_vault -p terminal -p system_services` — passed with zero warnings after rebasing onto the latest `origin/develop`.
- `cargo test -p integrations --lib cli_binary_resolver` — passed, 6 tests.
- `cargo test -p terminal --lib resolve_default_shell_path` — passed, 5 tests.
- `cargo test -p system_services --lib workspace_ports::scanner` — passed, 4 tests.
- `cargo build --bin org2` — passed with zero warnings.
- PE header inspection — `StackReserveBytes=8388608` (8 MiB), `StackCommitBytes=4096`.
- Rebuilt `target/debug/org2.exe` Windows smoke launch — remained alive for 15 seconds and completed startup instead of exiting with `STATUS_STACK_OVERFLOW`.
- `cargo clippy -p perf_utils -p integrations -p terminal --lib --no-deps -- -D warnings` — passed.
- `git diff --check origin/develop...HEAD` — passed.

Full dependency/all-target clippy was also attempted but is not green because of pre-existing, unchanged lints in `orgtrack-core`, `key-vault`, `system-services`, and the duplicate perf-utils test module. No UI screenshots are included because this changes linker metadata and platform compilation only; there is no visual behavior change.

## Audit

Architecture audit covered compilation, dead-code/platform ownership, naming, default branches, domain boundaries, new-developer clarity, and startup parity (layers 1–7 and 9). Wire payloads and multi-field resolver symmetry (layers 8 and 10) are not touched.

Performance verdict: pass. The change adds no timers, polling, subscriptions, caches, workers, or retained registries. The larger Windows stack is virtual address-space reservation with demand commit, and the rebuilt process was smoke-tested through startup.
