### PR TITLE
fix: remove non-macOS traffic-light tab inset

### DIFF
--- a/src/engines/ChatPanel/ChatPanelHeader.tsx
+++ b/src/engines/ChatPanel/ChatPanelHeader.tsx
@@ -13,7 +13,7 @@ import { KeyboardShortcutTooltipContent } from "@src/components/KeyboardShortcut
 import RegionNoticeButton from "@src/components/RegionNoticeButton";
 import Tooltip from "@src/components/Tooltip";
 import type { DropdownEnginePosition } from "@src/hooks/dropdown";
-import { COLLAPSED_SIDEBAR_CHROME_OFFSET } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
+import { getCollapsedSidebarChromeOffset } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
 import { TabBarTrailingIconButton } from "@src/modules/WorkStation/shared";
 import { HEADER_ICON_SIZE } from "@src/modules/WorkStation/shared/tokens";
 import { CollapsedSidebarButton } from "@src/scaffold/NavigationSidebar/CollapsedSidebarButton";
@@ -282,7 +282,7 @@ export function ChatPanelHeader({
         style={
           {
             paddingLeft: shouldOffsetHeaderForCollapsedSidebar
-              ? COLLAPSED_SIDEBAR_CHROME_OFFSET
+              ? getCollapsedSidebarChromeOffset()
               : undefined,
             ...(windowsHost
               ? CHAT_PANEL_HEADER_NO_DRAG_STYLE

--- a/src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset.test.ts
+++ b/src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getCollapsedSidebarButtonLeft,
+  getCollapsedSidebarChromeOffset,
+} from "./useCollapsedSidebarChromeOffset";
+
+const { isMacOSMock } = vi.hoisted(() => ({
+  isMacOSMock: vi.fn(),
+}));
+
+vi.mock("@src/util/platform/tauri", () => ({
+  isMacOS: isMacOSMock,
+}));
+
+describe("getCollapsedSidebarChromeOffset", () => {
+  beforeEach(() => {
+    isMacOSMock.mockReset();
+  });
+
+  it("reserves native traffic-light space on macOS", () => {
+    isMacOSMock.mockReturnValue(true);
+
+    expect(getCollapsedSidebarButtonLeft()).toBe(88);
+    expect(getCollapsedSidebarChromeOffset()).toBe(118);
+  });
+
+  it("reserves only the standalone sidebar toggle on Windows or Linux", () => {
+    isMacOSMock.mockReturnValue(false);
+
+    expect(getCollapsedSidebarButtonLeft()).toBe(8);
+    expect(getCollapsedSidebarChromeOffset()).toBe(38);
+  });
+});

--- a/src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset.ts
+++ b/src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset.ts
@@ -11,8 +11,26 @@ import {
   sessionChatPositionAtom,
   workStationChatPositionAtom,
 } from "@src/store/ui/workStationLayout/chatPositionAtoms";
+import { isMacOS } from "@src/util/platform/tauri";
 
-export const COLLAPSED_SIDEBAR_CHROME_OFFSET = 118;
+const COLLAPSED_SIDEBAR_BUTTON_LEFT_INSET = 8;
+const COLLAPSED_SIDEBAR_BUTTON_RESERVED_WIDTH = 30;
+const MACOS_TRAFFIC_LIGHTS_RESERVED_WIDTH = 80;
+
+export function getCollapsedSidebarChromeOffset(): number {
+  return (
+    (isMacOS() ? MACOS_TRAFFIC_LIGHTS_RESERVED_WIDTH : 0) +
+    COLLAPSED_SIDEBAR_BUTTON_LEFT_INSET +
+    COLLAPSED_SIDEBAR_BUTTON_RESERVED_WIDTH
+  );
+}
+
+export function getCollapsedSidebarButtonLeft(): number {
+  return (
+    (isMacOS() ? MACOS_TRAFFIC_LIGHTS_RESERVED_WIDTH : 0) +
+    COLLAPSED_SIDEBAR_BUTTON_LEFT_INSET
+  );
+}
 
 export function useShouldOffsetWorkStationTopBar(): boolean {
   const sidebarCollapsed = useAtomValue(sidebarCollapsedAtom);

--- a/src/modules/MainApp/shared/MainAppPageHeader.tsx
+++ b/src/modules/MainApp/shared/MainAppPageHeader.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 import {
-  COLLAPSED_SIDEBAR_CHROME_OFFSET,
+  getCollapsedSidebarChromeOffset,
   useShouldOffsetMainAppHeader,
 } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
 import { PageBreadcrumb } from "@src/modules/shared/layouts/blocks";
@@ -37,7 +37,7 @@ const MainAppPageHeader: React.FC<MainAppPageHeaderProps> = ({
         {
           ...style,
           paddingLeft: shouldOffsetHeaderForCollapsedSidebar
-            ? COLLAPSED_SIDEBAR_CHROME_OFFSET
+            ? getCollapsedSidebarChromeOffset()
             : undefined,
           ...DRAG_STYLE,
         } as React.CSSProperties

--- a/src/modules/WorkStation/AppShell/AgentStationTopHeader.tsx
+++ b/src/modules/WorkStation/AppShell/AgentStationTopHeader.tsx
@@ -23,7 +23,7 @@ import CaptionBar from "@src/engines/Simulator/components/CaptionBar";
 import { useCurrentTurnLastAgentMessage } from "@src/engines/Simulator/hooks/useCurrentTurnLastAgentMessage";
 import { AppType } from "@src/engines/Simulator/types/appTypes";
 import {
-  COLLAPSED_SIDEBAR_CHROME_OFFSET,
+  getCollapsedSidebarChromeOffset,
   useShouldOffsetWorkStationTopBar,
 } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
 import { HEADER_ICON_SIZE } from "@src/modules/WorkStation/shared/tokens";
@@ -148,7 +148,7 @@ const AgentStationTopHeader: React.FC = memo(() => {
         style={
           {
             paddingLeft: shouldOffsetLeftChrome
-              ? COLLAPSED_SIDEBAR_CHROME_OFFSET
+              ? getCollapsedSidebarChromeOffset()
               : undefined,
             WebkitAppRegion: "drag",
           } as React.CSSProperties

--- a/src/modules/WorkStation/shared/TabBar/index.tsx
+++ b/src/modules/WorkStation/shared/TabBar/index.tsx
@@ -41,7 +41,7 @@ import FileTypeIcon from "@src/components/FileTypeIcon";
 import { NoDragRegion } from "@src/components/WindowChrome";
 import SessionRawTranscriptDialog from "@src/engines/ChatPanel/components/SessionRawTranscriptDialog";
 import {
-  COLLAPSED_SIDEBAR_CHROME_OFFSET,
+  getCollapsedSidebarChromeOffset,
   useShouldOffsetWorkStationTopBar,
 } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
 import { requestTeamInboxSessionHandoffAtom } from "@src/modules/MainApp/TeamInbox/store";
@@ -377,7 +377,7 @@ export const TabBar: React.FC<TabBarProps> = memo(
           {
             height: `${TAB_BAR_HEIGHT + 8}px`,
             paddingLeft: shouldOffsetLeftChrome
-              ? COLLAPSED_SIDEBAR_CHROME_OFFSET
+              ? getCollapsedSidebarChromeOffset()
               : undefined,
             WebkitAppRegion: "drag",
           } as React.CSSProperties

--- a/src/scaffold/NavigationSidebar/CollapsedSidebarButton.tsx
+++ b/src/scaffold/NavigationSidebar/CollapsedSidebarButton.tsx
@@ -7,9 +7,8 @@ import Button from "@src/components/Button";
 import { KeyboardShortcutTooltipContent } from "@src/components/KeyboardShortcut";
 import Tooltip from "@src/components/Tooltip";
 import { getShortcutKeys } from "@src/config/keyboard/shortcutDisplay";
+import { getCollapsedSidebarButtonLeft } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
 import { sidebarCollapsedAtom } from "@src/store/ui/sidebarAtom";
-
-const COLLAPSED_SIDEBAR_BUTTON_LEFT = 88;
 
 const CollapsedSidebarButtonComponent: React.FC = () => {
   const { t } = useTranslation("sessions");
@@ -33,7 +32,7 @@ const CollapsedSidebarButtonComponent: React.FC = () => {
       data-collapsed-sidebar-button
       style={
         {
-          left: COLLAPSED_SIDEBAR_BUTTON_LEFT,
+          left: getCollapsedSidebarButtonLeft(),
           top: "calc(50% + 4px)",
           WebkitAppRegion: "no-drag",
         } as React.CSSProperties & { WebkitAppRegion: string }


### PR DESCRIPTION
## Problem
On Windows and Linux, collapsed-sidebar chat-pane tab bars inherit the 118px macOS traffic-light inset. This leaves a large empty gap before the tabs even though those platforms do not render native macOS traffic lights.

## Solution
Make the collapsed-sidebar chrome metrics platform-aware. macOS keeps the existing traffic-light plus toggle reservation; Windows and Linux reserve only the standalone sidebar toggle footprint and position that toggle at the normal 8px inset. Apply the shared metric to the Chat Panel, Workstation, Agent Station, and page headers, with focused platform regression tests.

## Potential risks
The shared collapsed-sidebar chrome helper affects several headers that use the same sidebar toggle. The non-macOS reservation is intentionally still 38px so the toggle remains reachable; no persisted state, IPC, wire protocol, or dependency changes are involved. Visual screenshot evidence was not captured in this headless session; the platform metrics are covered by focused tests.

## Verification
- `pnpm exec vitest run src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset.test.ts` - 2 tests passed.
- Targeted eslint over all changed files - passed.
- `pnpm typecheck` - passed.