### PR TITLE
fix(orgtrack): skip harness-injected user lines as round headers

### DIFF
--- a/src-tauri/crates/orgtrack-core/src/sources/anthropic_jsonl.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/anthropic_jsonl.rs
@@ -92,6 +92,21 @@ struct JsonlLine {
     model_id: String,
     git_branch: String,
     message: Option<JsonlMessage>,
+    is_meta: bool,
+    origin: Option<JsonlOrigin>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct JsonlOrigin {
+    kind: String,
+}
+
+fn is_harness_injected_line(parsed: &JsonlLine) -> bool {
+    imported_history::is_harness_injected_user_marker(
+        parsed.is_meta,
+        parsed.origin.as_ref().map(|origin| origin.kind.as_str()),
+    )
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -106,6 +121,7 @@ struct JsonlMessage {
 struct TranscriptTurn {
     created_at: String,
     message: JsonlMessage,
+    harness_injected: bool,
 }
 
 #[derive(Default)]
@@ -397,6 +413,7 @@ impl SessionMetaState {
             ensure_bounded_state_value("model", parsed.model_id.trim(), MAX_STATE_LABEL_BYTES)?;
             self.model = Some(parsed.model_id.trim().to_string());
         }
+        let harness_injected = is_harness_injected_line(&parsed);
         let Some(message) = parsed.message else {
             return Ok(());
         };
@@ -410,7 +427,7 @@ impl SessionMetaState {
         self.cache_read_tokens = self.cache_read_tokens.saturating_add(cache_read);
         self.cache_write_tokens = self.cache_write_tokens.saturating_add(cache_write);
         let role = effective_role(&parsed.line_type, &message.role);
-        if self.first_user_text.is_none() && role == "user" {
+        if self.first_user_text.is_none() && role == "user" && !harness_injected {
             self.first_user_text = first_content_text(&message.content)
                 .map(|text| imported_history::truncate_name(&text, 200));
         }
@@ -774,10 +791,14 @@ fn read_transcript(config: &AnthropicJsonlSource, path: &Path) -> Result<Transcr
             read.cache_read_tokens = read.cache_read_tokens.saturating_add(cache_read);
             read.cache_write_tokens = read.cache_write_tokens.saturating_add(cache_write);
             let role = effective_role(&parsed.line_type, &message.role);
-            if read.first_user_text.is_none() && role == "user" {
+            if read.first_user_text.is_none()
+                && role == "user"
+                && !is_harness_injected_line(&parsed)
+            {
                 read.first_user_text = first_content_text(&message.content);
             }
         }
+        let harness_injected = is_harness_injected_line(&parsed);
         match parsed.line_type.as_str() {
             "message" | "user" | "assistant" => {
                 if let Some(mut message) = parsed.message.take() {
@@ -787,6 +808,7 @@ fn read_transcript(config: &AnthropicJsonlSource, path: &Path) -> Result<Transcr
                     read.turns.push(TranscriptTurn {
                         created_at,
                         message,
+                        harness_injected,
                     });
                 }
             }
@@ -800,6 +822,7 @@ fn read_transcript(config: &AnthropicJsonlSource, path: &Path) -> Result<Transcr
                             content: json!([{ "type": "thinking", "thinking": text }]),
                             ..JsonlMessage::default()
                         },
+                        harness_injected: false,
                     });
                 }
             }
@@ -843,6 +866,9 @@ fn messages_to_chunks(
         for block in content_blocks(&turn.message.content) {
             match block_type(&block) {
                 "text" => {
+                    if is_user && turn.harness_injected {
+                        continue;
+                    }
                     let text = block
                         .get("text")
                         .and_then(Value::as_str)
@@ -1148,6 +1174,43 @@ mod tests {
     }
 
     #[test]
+    fn harness_injected_user_lines_emit_no_bubble_and_no_title() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "orgii-anthropic-jsonl-synthetic-test-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+        let path = temp_dir.join("synthetic.jsonl");
+        let content = r#"{"type":"user","timestamp":"2026-04-01T07:00:00Z","isMeta":true,"message":{"role":"user","content":[{"type":"text","text":"<local-command-caveat>Caveat</local-command-caveat>"}]}}
+{"type":"user","timestamp":"2026-04-01T07:00:01Z","origin":{"kind":"task-notification"},"message":{"role":"user","content":[{"type":"text","text":"<task-notification><task-id>t1</task-id></task-notification>"}]}}
+{"type":"user","timestamp":"2026-04-01T07:00:02Z","origin":{"kind":"human"},"message":{"role":"user","content":[{"type":"text","text":"real prompt"}]}}
+{"type":"assistant","timestamp":"2026-04-01T07:00:03Z","message":{"role":"assistant","content":[{"type":"text","text":"done"}]}}
+"#;
+        std::fs::write(&path, content).expect("write fixture");
+
+        let read = read_transcript(&test_config(), &path).expect("read transcript");
+        assert_eq!(read.first_user_text.as_deref(), Some("real prompt"));
+
+        let chunks = messages_to_chunks(&test_config(), "testapp-session", &read.turns);
+        let user_texts = chunks
+            .iter()
+            .filter(|chunk| chunk.function == imported_history::FUNCTION_USER_MESSAGE)
+            .map(|chunk| {
+                chunk
+                    .result
+                    .pointer("/message/content")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(user_texts, vec!["real prompt"]);
+
+        std::fs::remove_file(&path).expect("remove fixture");
+        std::fs::remove_dir(&temp_dir).expect("remove temp dir");
+    }
+
+    #[test]
     fn tool_results_are_paired_with_calls() {
         let turns = vec![
             TranscriptTurn {
@@ -1157,6 +1220,7 @@ mod tests {
                     content: json!([{"type":"tool_use","id":"call-1","name":"bash","input":{"command":"pwd"}}]),
                     ..JsonlMessage::default()
                 },
+                harness_injected: false,
             },
             TranscriptTurn {
                 created_at: String::new(),
@@ -1165,6 +1229,7 @@ mod tests {
                     content: json!([{"type":"tool_result","tool_use_id":"call-1","content":"/repo"}]),
                     ..JsonlMessage::default()
                 },
+                harness_injected: false,
             },
         ];
         let chunks = messages_to_chunks(&test_config(), "testapp-session", &turns);

--- a/src-tauri/crates/orgtrack-core/src/sources/claude_code/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/claude_code/history.rs
@@ -35,7 +35,10 @@ const CLAUDE_CODE_PROVIDER_SLUG: &str = "claudecode";
 // v7: capture cache_read/cache_write tokens separately (input stays cache-inclusive).
 // v8: emit per-round usage rows (imported_history_round_usage).
 // v9: dedup usage by message.id (one API response spans repeated JSONL lines).
-const CLAUDE_CODE_METADATA_PARSER_VERSION: i64 = 9;
+// v10: harness-injected user lines (isMeta, task-notification origin) no
+// longer open rounds or feed the first-prompt title; user image blocks
+// surface as data-URL attachments on the user bubble.
+const CLAUDE_CODE_METADATA_PARSER_VERSION: i64 = 10;
 
 pub type ClaudeCodeHistorySessionRow = ImportedHistorySessionRow;
 pub type ClaudeCodeHistorySessionPage = ImportedHistorySessionPage;
@@ -111,6 +114,27 @@ struct ClaudeJsonlLine {
     /// Per-message uuid, preserved verbatim across continuation rewrites.
     #[serde(default)]
     uuid: String,
+    /// `true` on harness-injected user lines (command caveats, hook feedback,
+    /// loop ticks) that Claude Code's own UI hides from the conversation.
+    #[serde(default)]
+    is_meta: bool,
+    /// Provenance of a user line. Observed kinds: `human` (typed prompt) and
+    /// `task-notification` (background-task completion wake).
+    #[serde(default)]
+    origin: Option<ClaudeLineOrigin>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaudeLineOrigin {
+    #[serde(default)]
+    kind: String,
+}
+
+fn is_harness_injected_user_line(parsed: &ClaudeJsonlLine) -> bool {
+    imported_history::is_harness_injected_user_marker(
+        parsed.is_meta,
+        parsed.origin.as_ref().map(|origin| origin.kind.as_str()),
+    )
 }
 
 #[derive(Debug, Deserialize)]
@@ -305,7 +329,7 @@ fn index_claude_user_turns(
             count_toward_previous_turn(&mut turns);
             continue;
         };
-        if parsed.r#type != "user" {
+        if parsed.r#type != "user" || is_harness_injected_user_line(&parsed) {
             count_toward_previous_turn(&mut turns);
             continue;
         }
@@ -929,8 +953,9 @@ impl ClaudeSessionMetaState {
         {
             self.first_user_uuid = Some(parsed.uuid.trim().to_string());
         }
+        let harness_injected = is_harness_injected_user_line(&parsed);
         if let Some(message) = parsed.message {
-            if self.first_prompt.is_empty() && parsed.r#type == "user" {
+            if self.first_prompt.is_empty() && parsed.r#type == "user" && !harness_injected {
                 if let Some(text) = claude_content_text(&message.content) {
                     // GUI-launched runs prefix the first prompt with the
                     // exec-mode briefing; bridge-only text is no title
@@ -1325,6 +1350,7 @@ fn load_claude_code_history_from_reader<R: BufRead>(
             .as_deref()
             .map(imported_history::normalize_created_at)
             .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
+        let harness_injected = is_harness_injected_user_line(&parsed);
         let Some(message) = parsed.message else {
             continue;
         };
@@ -1349,20 +1375,28 @@ fn load_claude_code_history_from_reader<R: BufRead>(
                             sequence += 1;
                         }
                     }
-                } else if let Some(text) = claude_content_text(&message.content) {
+                } else {
                     // Strip the GUI exec-mode briefing; a bridge-only message
                     // carries no user-authored text, so emit no bubble.
-                    let text = imported_history::strip_orgii_exec_mode_bridge(&text);
-                    if !text.trim().is_empty() {
+                    let text = claude_content_text(&message.content)
+                        .map(|text| {
+                            imported_history::strip_orgii_exec_mode_bridge(&text).to_string()
+                        })
+                        .unwrap_or_default();
+                    let images = claude_content_image_data_urls(&message.content);
+                    if !harness_injected && (!text.trim().is_empty() || !images.is_empty()) {
                         let mut chunk = imported_history::user_message_chunk(
                             session_id,
                             CLAUDE_CODE_PROVIDER_SLUG,
                             sequence,
                             &created_at,
-                            text,
+                            &text,
                         );
                         if let Some(turn_id) = forced_first_user_id.take() {
                             chunk.chunk_id = turn_id.to_string();
+                        }
+                        if !images.is_empty() {
+                            chunk.result["images"] = json!(images);
                         }
                         chunks.push(chunk);
                         sequence += 1;
@@ -1591,6 +1625,33 @@ fn claude_content_text(content: &Value) -> Option<String> {
         }
         _ => None,
     }
+}
+
+fn claude_content_image_data_urls(content: &Value) -> Vec<String> {
+    let Value::Array(items) = content else {
+        return Vec::new();
+    };
+    items
+        .iter()
+        .filter_map(|item| {
+            if item.get("type").and_then(Value::as_str) != Some("image") {
+                return None;
+            }
+            let source = item.get("source")?;
+            if source.get("type").and_then(Value::as_str) != Some("base64") {
+                return None;
+            }
+            let media_type = source
+                .get("media_type")
+                .and_then(Value::as_str)
+                .unwrap_or("image/png");
+            let data = source.get("data").and_then(Value::as_str)?;
+            if data.is_empty() {
+                return None;
+            }
+            Some(format!("data:{media_type};base64,{data}"))
+        })
+        .collect()
 }
 
 fn claude_tool_result_text(content: &Value) -> Option<Option<(String, String)>> {

--- a/src-tauri/crates/orgtrack-core/src/sources/claude_code/history_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/claude_code/history_tests.rs
@@ -166,6 +166,170 @@ fn byte_index_discovers_rounds_without_parsing_tool_result_bodies() {
 }
 
 #[test]
+fn harness_injected_user_lines_do_not_open_rounds() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-claude-history-synthetic-test-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+    let path = temp_dir.join("claude-synthetic.jsonl");
+    let content = r#"{"type":"user","timestamp":"2026-04-01T07:00:00Z","origin":{"kind":"human"},"message":{"role":"user","content":"real prompt"}}
+{"type":"assistant","timestamp":"2026-04-01T07:00:01Z","message":{"role":"assistant","content":[{"type":"text","text":"working"}]}}
+{"type":"user","timestamp":"2026-04-01T07:00:02Z","origin":{"kind":"task-notification"},"message":{"role":"user","content":"<task-notification>\n<task-id>abc123</task-id>\n<status>completed</status>\n</task-notification>"}}
+{"type":"assistant","timestamp":"2026-04-01T07:00:03Z","message":{"role":"assistant","content":[{"type":"text","text":"task consumed"}]}}
+{"type":"user","timestamp":"2026-04-01T07:00:04Z","isMeta":true,"message":{"role":"user","content":"<local-command-caveat>Caveat: the following was run</local-command-caveat>"}}
+{"type":"assistant","timestamp":"2026-04-01T07:00:05Z","message":{"role":"assistant","content":[{"type":"text","text":"caveat consumed"}]}}
+{"type":"user","timestamp":"2026-04-01T07:01:00Z","message":{"role":"user","content":"second prompt"}}
+{"type":"assistant","timestamp":"2026-04-01T07:01:01Z","message":{"role":"assistant","content":[{"type":"text","text":"second done"}]}}
+"#;
+    std::fs::write(&path, content).expect("write fixture");
+
+    let indexed =
+        index_claude_user_turns("claudecodeapp-synthetic", &path).expect("index user turns");
+    let previews = indexed
+        .iter()
+        .map(|turn| {
+            turn.user_chunk
+                .result
+                .get("message")
+                .and_then(|message| message.get("content"))
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(previews, vec!["real prompt", "second prompt"]);
+    assert_eq!(
+        indexed
+            .iter()
+            .map(|turn| turn.following_line_count)
+            .collect::<Vec<_>>(),
+        vec![5, 1]
+    );
+
+    let chunks =
+        load_claude_code_history_from_path("claudecodeapp-synthetic", &path).expect("parse");
+    let user_texts = chunks
+        .iter()
+        .filter(|chunk| chunk.function == imported_history::FUNCTION_USER_MESSAGE)
+        .map(|chunk| {
+            chunk
+                .result
+                .get("message")
+                .and_then(|message| message.get("content"))
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(user_texts, vec!["real prompt", "second prompt"]);
+    let rendered = chunks
+        .iter()
+        .map(|chunk| chunk.result.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(!rendered.contains("task-notification"));
+    assert!(!rendered.contains("local-command-caveat"));
+    assert!(rendered.contains("task consumed"));
+
+    std::fs::remove_file(&path).expect("remove fixture");
+    std::fs::remove_dir(&temp_dir).expect("remove temp dir");
+}
+
+#[test]
+fn user_image_blocks_surface_as_data_url_attachments() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-claude-history-image-test-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+    let path = temp_dir.join("claude-images.jsonl");
+    let content = r#"{"type":"user","timestamp":"2026-04-01T07:00:00Z","message":{"role":"user","content":[{"type":"text","text":"make a pet from this"},{"type":"image","source":{"type":"base64","media_type":"image/webp","data":"UklGRg=="}}]}}
+{"type":"assistant","timestamp":"2026-04-01T07:00:01Z","message":{"role":"assistant","content":[{"type":"text","text":"working"}]}}
+{"type":"user","timestamp":"2026-04-01T07:01:00Z","message":{"role":"user","content":[{"type":"image","source":{"type":"base64","media_type":"image/png","data":"iVBORw=="}}]}}
+"#;
+    std::fs::write(&path, content).expect("write fixture");
+
+    let chunks = load_claude_code_history_from_path("claudecodeapp-images", &path).expect("parse");
+    let user_chunks = chunks
+        .iter()
+        .filter(|chunk| chunk.function == imported_history::FUNCTION_USER_MESSAGE)
+        .collect::<Vec<_>>();
+    assert_eq!(user_chunks.len(), 2);
+
+    let first_images = user_chunks[0]
+        .result
+        .get("images")
+        .and_then(Value::as_array)
+        .expect("first user chunk images");
+    assert_eq!(
+        first_images
+            .iter()
+            .filter_map(Value::as_str)
+            .collect::<Vec<_>>(),
+        vec!["data:image/webp;base64,UklGRg=="]
+    );
+    assert_eq!(
+        user_chunks[0]
+            .result
+            .pointer("/message/content")
+            .and_then(Value::as_str),
+        Some("make a pet from this")
+    );
+
+    let second_images = user_chunks[1]
+        .result
+        .get("images")
+        .and_then(Value::as_array)
+        .expect("image-only user chunk images");
+    assert_eq!(
+        second_images
+            .iter()
+            .filter_map(Value::as_str)
+            .collect::<Vec<_>>(),
+        vec!["data:image/png;base64,iVBORw=="]
+    );
+
+    std::fs::remove_file(&path).expect("remove fixture");
+    std::fs::remove_dir(&temp_dir).expect("remove temp dir");
+}
+
+#[test]
+fn harness_injected_first_line_does_not_title_session() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-claude-history-synthetic-title-test-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+    let path = temp_dir.join("claude-synthetic-title.jsonl");
+    let content = r#"{"type":"user","timestamp":"2026-04-01T07:00:00Z","isMeta":true,"message":{"role":"user","content":"<local-command-caveat>Caveat: the following was run</local-command-caveat>"}}
+{"type":"user","timestamp":"2026-04-01T07:00:01Z","origin":{"kind":"human"},"message":{"role":"user","content":"actual request"}}
+{"type":"assistant","timestamp":"2026-04-01T07:00:02Z","message":{"role":"assistant","model":"claude-sonnet-4","content":[{"type":"text","text":"done"}],"usage":{"input_tokens":1,"output_tokens":1}}}
+"#;
+    std::fs::write(&path, content).expect("write fixture");
+
+    let (source_mtime_ms, source_size_bytes) =
+        imported_paths::file_metadata_signature(&path, "Claude").expect("metadata");
+    let record = ImportedHistoryDiscoveredRecord {
+        source_session_id: "claude-synthetic-title".to_string(),
+        source_path: path.clone(),
+        source_record_key: "claude-synthetic-title".to_string(),
+        source_mtime_ms,
+        source_size_bytes,
+        source_fingerprint: String::new(),
+        parser_version: CLAUDE_CODE_METADATA_PARSER_VERSION,
+    };
+    let meta = parse_claude_session_meta(&record)
+        .expect("parse")
+        .expect("session meta");
+
+    assert_eq!(meta.name, "actual request");
+
+    std::fs::remove_file(&path).expect("remove fixture");
+    std::fs::remove_dir(&temp_dir).expect("remove temp dir");
+}
+
+#[test]
 fn claude_initial_window_placeholders_advertise_fetchable_bodies() {
     let temp_dir = std::env::temp_dir().join(format!(
         "orgii-claude-window-counts-test-{}",
@@ -184,8 +348,7 @@ fn claude_initial_window_placeholders_advertise_fetchable_bodies() {
     }
     std::fs::write(&path, content).expect("write fixture");
 
-    let indexed =
-        index_claude_user_turns("claudecodeapp-counts", &path).expect("index user turns");
+    let indexed = index_claude_user_turns("claudecodeapp-counts", &path).expect("index user turns");
     let file_len = std::fs::metadata(&path).expect("stat fixture").len();
     let mut file = std::fs::File::open(&path).expect("open fixture");
     let mut chunks = Vec::new();

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app/transcript.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app/transcript.rs
@@ -568,9 +568,19 @@ pub fn load_codex_app_turn_from_path(
             .next()
             .map(|entry| entry.byte_offset)
         {
-            if let Some((previous_user, previous_summary)) =
+            if let Some((previous_user, mut previous_summary)) =
                 load_codex_turn_header(session_id, path, previous_offset)?
             {
+                // The context placeholder spans up to the loaded turn's
+                // start. The header-only summary carries ended_at ==
+                // started_at, and that created_at tie flips the placeholder
+                // before its own header in chat sorting.
+                if let Some(loaded_turn_start) = selected_chunks
+                    .first()
+                    .map(|chunk| chunk.created_at.clone())
+                {
+                    previous_summary.ended_at = Some(loaded_turn_start);
+                }
                 chunks.push(previous_user);
                 chunks.push(build_unloaded_turn_placeholder_chunk(
                     session_id,

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
@@ -255,6 +255,16 @@ fn codex_initial_window_catalogs_old_turns_and_loads_one_turn_on_demand() {
             .collect::<Vec<_>>(),
         vec!["first", "second"]
     );
+    // The context placeholder must span up to the loaded turn's start. If it
+    // fell back to the previous header's own started_at, the created_at tie
+    // would sort the placeholder before its header in chat and split a
+    // phantom headerless round.
+    let context_placeholder = &turn.chunks[1];
+    assert!(context_placeholder
+        .chunk_id
+        .starts_with("codex-unloaded-turn-"));
+    assert_eq!(context_placeholder.created_at, turn.chunks[2].created_at);
+    assert_ne!(context_placeholder.created_at, turn.chunks[0].created_at);
 
     std::fs::remove_file(&path).expect("remove fixture");
     std::fs::remove_dir(&temp_dir).expect("remove temp dir");

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/mod.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/mod.rs
@@ -527,6 +527,15 @@ pub fn strip_orgii_exec_mode_bridge(text: &str) -> &str {
     strip_internal_context_blocks(text)
 }
 
+/// Anthropic-family transcripts mark harness-injected user lines with
+/// `isMeta: true` (command caveats, hook feedback, loop ticks) or
+/// `origin.kind == "task-notification"` (background-task completion wakes).
+/// Such lines are transcript plumbing, not conversational rounds: they must
+/// not open a turn, become a round preview, or title the session.
+pub fn is_harness_injected_user_marker(is_meta: bool, origin_kind: Option<&str>) -> bool {
+    is_meta || origin_kind == Some("task-notification")
+}
+
 pub fn user_message_chunk(
     session_id: &str,
     provider_slug: &str,

--- a/src-tauri/crates/orgtrack-core/src/sources/omp/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/omp/history.rs
@@ -17,7 +17,7 @@ fn config() -> AnthropicJsonlSource {
         session_prefix: OMP_SESSION_PREFIX,
         provider_slug: "omp",
         display_name: "OMP",
-        parser_version: 1,
+        parser_version: 2,
         candidate_roots: omp_history_candidate_paths(),
         exclude_subagent_dirs: false,
         max_discovery_depth: None,

--- a/src-tauri/crates/orgtrack-core/src/sources/qoder_cli/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/qoder_cli/history.rs
@@ -17,7 +17,7 @@ fn config() -> AnthropicJsonlSource {
         session_prefix: QODER_CLI_SESSION_PREFIX,
         provider_slug: "qoder_cli",
         display_name: "Qoder CLI",
-        parser_version: 1,
+        parser_version: 2,
         candidate_roots: qoder_cli_history_candidate_paths(),
         // Qoder keeps delegated-agent transcripts below each primary session.
         // They are replay internals, not standalone sessions in the sidebar.

--- a/src-tauri/src/agent_sessions/event_pipeline/tests/derived_tests.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/tests/derived_tests.rs
@@ -457,3 +457,36 @@ fn test_compute_derived_anchors_late_turn_summary_before_next_user_turn() {
         vec!["user-1", "assistant-1", "summary-turn-1", "user-2"]
     );
 }
+
+// =========================================================================
+// chat ordering: created_at ties
+// =========================================================================
+
+#[test]
+fn test_unloaded_placeholder_sorts_before_same_instant_next_header() {
+    // An unloaded-turn placeholder spans up to the NEXT round's start, so its
+    // created_at ties with that round's user header. It must stay BEFORE the
+    // header (tail of the previous group) or the previous round loses its
+    // expand affordance and the next group inherits a foreign placeholder.
+    let mut placeholder = make_event(
+        "codex-unloaded-turn-codex-user-1",
+        EventDisplayVariant::Message,
+    );
+    placeholder.action_type = "assistant".to_string();
+    placeholder.function_name = "assistant".to_string();
+    placeholder.created_at = "2026-07-31T00:07:15.017+00:00".to_string();
+    let mut next_header = make_user_message("codex-user-2");
+    next_header.function_name = "user".to_string();
+    next_header.created_at = "2026-07-31T00:07:15.017+00:00".to_string();
+
+    let derived = compute_derived(&[next_header, placeholder], 1);
+    let chat_ids: Vec<&str> = derived
+        .chat_events
+        .iter()
+        .map(|event| event.id.as_str())
+        .collect();
+    assert_eq!(
+        chat_ids,
+        vec!["codex-unloaded-turn-codex-user-1", "codex-user-2"]
+    );
+}

--- a/src/components/MarkDown/MarkDownImpl.tsx
+++ b/src/components/MarkDown/MarkDownImpl.tsx
@@ -34,8 +34,10 @@ import { copyText } from "@src/util/data/clipboard";
 import { openFileInWorkStation } from "@src/util/ui/openFileInWorkStation";
 
 import LinkHoverCard from "./LinkHoverCard";
+import MarkdownLocalImage, { openLocalMarkdownRef } from "./MarkdownLocalImage";
 import MermaidBlock from "./MermaidBlock";
 import "./index.scss";
+import { classifyMarkdownImageSrc } from "./markdownImageSrc";
 import { markdownUrlTransform } from "./markdownUrlTransform";
 import {
   detectCodeType,
@@ -409,6 +411,18 @@ const MarkdownComponent: React.FC<MarkdownProps> = ({
     (event: React.MouseEvent<HTMLAnchorElement>, href: string) => {
       event.preventDefault();
       event.stopPropagation();
+      // Local filesystem hrefs (agents link generated artifacts by path)
+      // open in the WorkStation / editor — the browser app cannot load a
+      // filesystem path. Workspace-relative hrefs are deliberately not
+      // resolved here: only unambiguous local refs are rerouted.
+      const localSource = classifyMarkdownImageSrc(href);
+      if (localSource.kind === "local") {
+        void openLocalMarkdownRef(
+          localSource.path,
+          localSource.homeRelative === true
+        );
+        return;
+      }
       openUrlInBrowserApp(href);
     },
     []
@@ -600,6 +614,15 @@ const MarkdownComponent: React.FC<MarkdownProps> = ({
 
         // Regular inline code
         return <code {...props}>{children}</code>;
+      },
+      img({ src, alt }) {
+        return (
+          <MarkdownLocalImage
+            src={typeof src === "string" ? src : undefined}
+            alt={typeof alt === "string" ? alt : undefined}
+            workspaceRootPath={activeWorkspaceRootPath}
+          />
+        );
       },
       a({ children, href, ...props }) {
         const url = href ?? "";

--- a/src/components/MarkDown/MarkdownLocalImage.test.ts
+++ b/src/components/MarkDown/MarkdownLocalImage.test.ts
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import MarkdownLocalImage, { openLocalMarkdownRef } from "./MarkdownLocalImage";
+
+const mocks = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  stat: vi.fn(async () => ({ isDirectory: false })),
+  openFileInWorkStation: vi.fn(),
+  openFileInEditor: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-fs", () => ({
+  readFile: mocks.readFile,
+  stat: mocks.stat,
+}));
+
+vi.mock("@src/util/ui/openFileInEditor", () => ({
+  openFileInEditor: mocks.openFileInEditor,
+}));
+
+vi.mock("@tauri-apps/api/path", () => ({
+  homeDir: vi.fn(async () => "/Users/me"),
+  join: vi.fn(async (...parts: string[]) => parts.join("/")),
+}));
+
+vi.mock("@src/util/ui/openFileInWorkStation", () => ({
+  openFileInWorkStation: mocks.openFileInWorkStation,
+}));
+
+vi.mock("@src/components/ImagePreviewOverlay", () => ({
+  default: () =>
+    createElement("div", { "data-testid": "image-preview-overlay" }),
+}));
+
+vi.mock("@src/components/FileTypeIcon", () => ({
+  default: () => createElement("span", { "data-testid": "file-type-icon" }),
+}));
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+describe("MarkdownLocalImage", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(reactActEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  function renderInsideLink(props: Record<string, unknown>): {
+    anchorNavigations: () => number;
+  } {
+    let navigations = 0;
+    act(() => {
+      root.render(
+        createElement(
+          "a",
+          {
+            href: "/Users/me/artifact.png",
+            onClick: (event: MouseEvent) => {
+              if (!event.defaultPrevented) navigations += 1;
+            },
+          },
+          createElement(MarkdownLocalImage, props)
+        )
+      );
+    });
+    return { anchorNavigations: () => navigations };
+  }
+
+  it("opens the preview overlay on click and never lets a wrapping link navigate", async () => {
+    mocks.readFile.mockResolvedValueOnce(new Uint8Array([1, 2, 3]));
+    const { anchorNavigations } = renderInsideLink({
+      src: "/Users/me/artifact.png",
+      alt: "artifact",
+    });
+    await act(async () => {});
+
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    await act(async () => {
+      img?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      );
+    });
+
+    expect(
+      container.querySelector('[data-testid="image-preview-overlay"]')
+    ).not.toBeNull();
+    expect(anchorNavigations()).toBe(0);
+    expect(mocks.openFileInWorkStation).not.toHaveBeenCalled();
+  });
+
+  it("renders non-image local paths as a file chip that opens in the WorkStation without reading the file", async () => {
+    const { anchorNavigations } = renderInsideLink({
+      src: "/Users/me/demo-final.mp4",
+      alt: "demo",
+    });
+    await act(async () => {});
+
+    expect(mocks.readFile).not.toHaveBeenCalled();
+    const chip = container.querySelector('[data-image-state="file"]');
+    expect(chip).not.toBeNull();
+    expect(chip?.textContent).toContain("demo");
+
+    await act(async () => {
+      chip?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      );
+    });
+
+    expect(mocks.openFileInWorkStation).toHaveBeenCalledWith(
+      "/Users/me/demo-final.mp4"
+    );
+    expect(anchorNavigations()).toBe(0);
+  });
+
+  it("resolves home-relative file chips against the home directory", async () => {
+    act(() => {
+      root.render(
+        createElement(MarkdownLocalImage, { src: "~/clips/demo.mov" })
+      );
+    });
+    await act(async () => {});
+
+    const chip = container.querySelector('[data-image-state="file"]');
+    await act(async () => {
+      chip?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      );
+    });
+
+    expect(mocks.openFileInWorkStation).toHaveBeenCalledWith(
+      "/Users/me/clips/demo.mov"
+    );
+  });
+
+  it("reveals directories in the editor instead of opening a file tab", async () => {
+    mocks.stat.mockResolvedValueOnce({ isDirectory: true });
+    await openLocalMarkdownRef("/Users/me/.codex/pets/locke", false);
+
+    expect(mocks.openFileInEditor).toHaveBeenCalledWith(
+      "/Users/me/.codex/pets/locke",
+      { isDirectory: true }
+    );
+    expect(mocks.openFileInWorkStation).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the file tab when the path cannot be stat'ed", async () => {
+    mocks.stat.mockRejectedValueOnce(new Error("gone"));
+    await openLocalMarkdownRef("/Users/me/missing.png", false);
+
+    expect(mocks.openFileInWorkStation).toHaveBeenCalledWith(
+      "/Users/me/missing.png"
+    );
+    expect(mocks.openFileInEditor).not.toHaveBeenCalled();
+  });
+
+  it("contains clicks on missing-image placeholders", async () => {
+    mocks.readFile.mockRejectedValueOnce(new Error("gone"));
+    const { anchorNavigations } = renderInsideLink({
+      src: "/Users/me/trashed.png",
+      alt: "trashed",
+    });
+    await act(async () => {});
+
+    const chip = container.querySelector('[data-image-state="unavailable"]');
+    expect(chip).not.toBeNull();
+    await act(async () => {
+      chip?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, cancelable: true })
+      );
+    });
+
+    expect(anchorNavigations()).toBe(0);
+    expect(mocks.openFileInWorkStation).not.toHaveBeenCalled();
+    expect(
+      container.querySelector('[data-testid="image-preview-overlay"]')
+    ).toBeNull();
+  });
+});

--- a/src/components/MarkDown/MarkdownLocalImage.tsx
+++ b/src/components/MarkDown/MarkdownLocalImage.tsx
@@ -1,0 +1,205 @@
+/**
+ * MarkdownLocalImage
+ *
+ * `img` renderer for chat markdown. Local image paths are read through the
+ * fs plugin into a data URL (the webview origin cannot load raw filesystem
+ * paths); non-image local paths (agents use `![]()` for videos too) render
+ * as a file chip that opens in the WorkStation instead of being read into
+ * memory; missing files degrade to a labeled placeholder. Every state
+ * swallows the click so a wrapping markdown link can never navigate the
+ * webview or reach the browser app with a filesystem path.
+ */
+import { homeDir, join } from "@tauri-apps/api/path";
+import { readFile, stat } from "@tauri-apps/plugin-fs";
+import { ImageIcon, ImageOff } from "lucide-react";
+import React, { memo, useCallback, useEffect, useState } from "react";
+
+import FileTypeIcon from "@src/components/FileTypeIcon";
+import ImagePreviewOverlay from "@src/components/ImagePreviewOverlay";
+import { uint8ArrayToDataUrl } from "@src/util/file/binaryUtils";
+import { getImageMimeType } from "@src/util/file/previewTypes";
+import { openFileInEditor } from "@src/util/ui/openFileInEditor";
+import { openFileInWorkStation } from "@src/util/ui/openFileInWorkStation";
+
+import { classifyMarkdownImageSrc } from "./markdownImageSrc";
+
+export async function resolveLocalMarkdownPath(
+  path: string,
+  homeRelative: boolean
+): Promise<string> {
+  return homeRelative ? await join(await homeDir(), path) : path;
+}
+
+/**
+ * Open a local path referenced from chat markdown: directories reveal in
+ * the editor tree, files open in the WorkStation preview tab (which shows
+ * a not-found state for missing paths).
+ */
+export async function openLocalMarkdownRef(
+  path: string,
+  homeRelative: boolean
+): Promise<void> {
+  const absolutePath = await resolveLocalMarkdownPath(path, homeRelative);
+  let isDirectory = false;
+  try {
+    isDirectory = (await stat(absolutePath)).isDirectory;
+  } catch {
+    isDirectory = false;
+  }
+  if (isDirectory) {
+    openFileInEditor(absolutePath, { isDirectory: true });
+  } else {
+    openFileInWorkStation(absolutePath);
+  }
+}
+
+async function loadLocalImage(
+  path: string,
+  homeRelative: boolean
+): Promise<string> {
+  const absolutePath = await resolveLocalMarkdownPath(path, homeRelative);
+  const mimeType = getImageMimeType(absolutePath) ?? "image/png";
+  const data = await readFile(absolutePath);
+  return uint8ArrayToDataUrl(data, mimeType);
+}
+
+function imageLabel(alt: string | undefined, path: string): string {
+  if (alt?.trim()) return alt.trim();
+  const basename = path.split(/[\\/]/).pop();
+  return basename || path;
+}
+
+function containClick(event: React.MouseEvent): void {
+  event.preventDefault();
+  event.stopPropagation();
+}
+
+interface MarkdownLocalImageProps {
+  src?: string;
+  alt?: string;
+  workspaceRootPath?: string | null;
+}
+
+const MarkdownLocalImage: React.FC<MarkdownLocalImageProps> = memo(
+  ({ src, alt, workspaceRootPath }) => {
+    const [asyncSrc, setAsyncSrc] = useState<string | null>(null);
+    const [failed, setFailed] = useState(false);
+    const [showOverlay, setShowOverlay] = useState(false);
+
+    const source = classifyMarkdownImageSrc(src, workspaceRootPath);
+    const localIsImage =
+      source.kind === "local" && getImageMimeType(source.path) !== undefined;
+
+    useEffect(() => {
+      if (source.kind !== "local" || !localIsImage) return;
+      let cancelled = false;
+      setAsyncSrc(null);
+      setFailed(false);
+      loadLocalImage(source.path, source.homeRelative === true)
+        .then((dataUrl) => {
+          if (!cancelled) setAsyncSrc(dataUrl);
+        })
+        .catch(() => {
+          if (!cancelled) setFailed(true);
+        });
+      return () => {
+        cancelled = true;
+      };
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- `source` is derived from src/workspaceRootPath; keying on them avoids re-running on every render for an unmemoized object.
+    }, [src, workspaceRootPath, localIsImage]);
+
+    const handleImageClick = useCallback((event: React.MouseEvent) => {
+      containClick(event);
+      setShowOverlay(true);
+    }, []);
+
+    const handleFileChipClick = useCallback(
+      (event: React.MouseEvent) => {
+        containClick(event);
+        if (source.kind !== "local") return;
+        void openLocalMarkdownRef(source.path, source.homeRelative === true);
+      },
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on the scalars behind `source`.
+      [src, workspaceRootPath]
+    );
+
+    const handleClose = useCallback(() => {
+      setShowOverlay(false);
+    }, []);
+
+    if (source.kind === "skip") {
+      return alt?.trim() ? (
+        <span className="text-text-3">[{alt.trim()}]</span>
+      ) : null;
+    }
+
+    if (source.kind === "remote") {
+      return <img src={source.src} alt={alt ?? ""} loading="lazy" />;
+    }
+
+    if (!localIsImage || failed) {
+      const label = imageLabel(alt, source.path);
+      return (
+        <span
+          className="inline-flex max-w-full cursor-pointer items-center gap-1.5 rounded-md border border-border-2 bg-fill-1 px-2 py-1 align-middle text-xs text-text-2"
+          title={source.path}
+          role="button"
+          tabIndex={0}
+          data-image-state={failed ? "unavailable" : "file"}
+          onClick={failed ? containClick : handleFileChipClick}
+        >
+          {failed ? (
+            <ImageOff
+              size={14}
+              strokeWidth={1.5}
+              className="shrink-0 text-text-3"
+            />
+          ) : (
+            <FileTypeIcon fileName={label} size="small" />
+          )}
+          <span className="truncate">{label}</span>
+        </span>
+      );
+    }
+
+    if (!asyncSrc) {
+      return (
+        <span
+          className="inline-flex h-16 w-24 items-center justify-center rounded-md border border-border-2 bg-fill-1 align-middle text-text-3"
+          data-image-state="loading"
+          onClick={containClick}
+        >
+          <ImageIcon
+            size={16}
+            strokeWidth={1.5}
+            className="animate-pulse motion-reduce:animate-none"
+          />
+        </span>
+      );
+    }
+
+    return (
+      <>
+        <img
+          src={asyncSrc}
+          alt={alt ?? ""}
+          title={source.path}
+          className="cursor-zoom-in"
+          onClick={handleImageClick}
+          draggable={false}
+        />
+        {showOverlay && (
+          <ImagePreviewOverlay
+            dataUrl={asyncSrc}
+            fileName={imageLabel(alt, source.path)}
+            onClose={handleClose}
+            showCopyButton={false}
+          />
+        )}
+      </>
+    );
+  }
+);
+MarkdownLocalImage.displayName = "MarkdownLocalImage";
+
+export default MarkdownLocalImage;

--- a/src/components/MarkDown/markdownImageSrc.test.ts
+++ b/src/components/MarkDown/markdownImageSrc.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyMarkdownImageSrc } from "./markdownImageSrc";
+
+describe("classifyMarkdownImageSrc", () => {
+  it("skips empty sources", () => {
+    expect(classifyMarkdownImageSrc(undefined)).toEqual({ kind: "skip" });
+    expect(classifyMarkdownImageSrc("   ")).toEqual({ kind: "skip" });
+  });
+
+  it("passes data and web urls through as remote", () => {
+    expect(classifyMarkdownImageSrc("data:image/png;base64,AAA")).toEqual({
+      kind: "remote",
+      src: "data:image/png;base64,AAA",
+    });
+    expect(classifyMarkdownImageSrc("https://example.com/a.png")).toEqual({
+      kind: "remote",
+      src: "https://example.com/a.png",
+    });
+  });
+
+  it("classifies absolute paths as local", () => {
+    expect(
+      classifyMarkdownImageSrc("/Users/me/project/assets/final.png")
+    ).toEqual({ kind: "local", path: "/Users/me/project/assets/final.png" });
+    expect(classifyMarkdownImageSrc("C:\\pets\\sprite.png")).toEqual({
+      kind: "local",
+      path: "C:\\pets\\sprite.png",
+    });
+  });
+
+  it("decodes percent-encoded local paths", () => {
+    expect(classifyMarkdownImageSrc("/Users/me/Desktop/a%20b.png")).toEqual({
+      kind: "local",
+      path: "/Users/me/Desktop/a b.png",
+    });
+  });
+
+  it("converts tauri asset urls back to paths", () => {
+    expect(
+      classifyMarkdownImageSrc("asset://localhost/Users/me/a.png")
+    ).toEqual({ kind: "local", path: "/Users/me/a.png" });
+  });
+
+  it("converts file urls to paths", () => {
+    expect(classifyMarkdownImageSrc("file:///Users/me/a.png")).toEqual({
+      kind: "local",
+      path: "/Users/me/a.png",
+    });
+  });
+
+  it("marks tilde paths home-relative", () => {
+    expect(classifyMarkdownImageSrc("~/Desktop/a.png")).toEqual({
+      kind: "local",
+      path: "Desktop/a.png",
+      homeRelative: true,
+    });
+  });
+
+  it("resolves relative paths against the workspace root", () => {
+    expect(
+      classifyMarkdownImageSrc("assets/final.png", "/Users/me/project")
+    ).toEqual({ kind: "local", path: "/Users/me/project/assets/final.png" });
+    expect(
+      classifyMarkdownImageSrc("./assets/final.png", "/Users/me/project/")
+    ).toEqual({ kind: "local", path: "/Users/me/project/assets/final.png" });
+  });
+
+  it("skips relative paths without a workspace root", () => {
+    expect(classifyMarkdownImageSrc("assets/final.png")).toEqual({
+      kind: "skip",
+    });
+  });
+});

--- a/src/components/MarkDown/markdownImageSrc.ts
+++ b/src/components/MarkDown/markdownImageSrc.ts
@@ -1,0 +1,96 @@
+/**
+ * Classify a markdown image `src` for the chat renderer.
+ *
+ * The webview origin cannot load raw filesystem paths, but agents routinely
+ * reference generated artifacts by absolute or repo-relative path. Local
+ * classifications are read through the fs plugin into a data URL by
+ * `MarkdownLocalImage`; web/data sources render as a plain `<img>`.
+ */
+import { imageRefToRustPath } from "@src/util/file/imageRefs";
+
+const TAURI_ASSET_PREFIXES = [
+  "asset://localhost",
+  "https://asset.localhost",
+  "http://asset.localhost",
+] as const;
+
+const SCHEME_REGEX = /^[a-z][a-z0-9+.-]*:/i;
+
+export type MarkdownImageSource =
+  | { kind: "remote"; src: string }
+  | { kind: "local"; path: string; homeRelative?: boolean }
+  | { kind: "skip" };
+
+function decodeMaybeEncodedPath(path: string): string {
+  if (!path.includes("%")) return path;
+  try {
+    return decodeURIComponent(path);
+  } catch {
+    return path;
+  }
+}
+
+function fileUrlToPath(src: string): string | null {
+  try {
+    const parsed = new URL(src);
+    if (parsed.protocol !== "file:") return null;
+    const decoded = decodeMaybeEncodedPath(parsed.pathname);
+    if (parsed.hostname && parsed.hostname !== "localhost") {
+      return `//${parsed.hostname}${decoded}`;
+    }
+    return /^\/[a-z]:\//i.test(decoded) ? decoded.slice(1) : decoded;
+  } catch {
+    return null;
+  }
+}
+
+export function classifyMarkdownImageSrc(
+  src: string | undefined,
+  workspaceRootPath?: string | null
+): MarkdownImageSource {
+  const trimmed = src?.trim();
+  if (!trimmed) return { kind: "skip" };
+
+  if (trimmed.startsWith("data:")) return { kind: "remote", src: trimmed };
+
+  for (const prefix of TAURI_ASSET_PREFIXES) {
+    if (trimmed.startsWith(prefix)) {
+      return { kind: "local", path: imageRefToRustPath(trimmed) };
+    }
+  }
+
+  if (trimmed.startsWith("file://")) {
+    const path = fileUrlToPath(trimmed);
+    return path ? { kind: "local", path } : { kind: "skip" };
+  }
+
+  if (
+    trimmed.startsWith("/") ||
+    trimmed.startsWith("\\\\") ||
+    /^[a-z]:[\\/]/i.test(trimmed)
+  ) {
+    return { kind: "local", path: decodeMaybeEncodedPath(trimmed) };
+  }
+
+  if (SCHEME_REGEX.test(trimmed)) return { kind: "remote", src: trimmed };
+
+  if (trimmed.startsWith("~/")) {
+    return {
+      kind: "local",
+      path: decodeMaybeEncodedPath(trimmed.slice(2)),
+      homeRelative: true,
+    };
+  }
+
+  const root = workspaceRootPath?.trim();
+  if (root) {
+    const relative = decodeMaybeEncodedPath(trimmed.replace(/^\.\//, ""));
+    const separator = root.includes("\\") ? "\\" : "/";
+    const joined = root.endsWith(separator)
+      ? `${root}${relative}`
+      : `${root}${separator}${relative}`;
+    return { kind: "local", path: joined };
+  }
+
+  return { kind: "skip" };
+}


### PR DESCRIPTION
## Problem

In cloud team-session viewers (and the local round selector), Claude Code-harness sessions show rounds titled with raw XML like `<task-notification> <task-id>bb7f…</task-id> <tool-use-id>toolu_…`.

These are user-role lines the Claude Code harness injects into its own transcript — background-task completion wakes and meta lines (command caveats, Stop-hook feedback, loop ticks). The JSONL marks them machine-readably (`origin.kind: "task-notification"`, `isMeta: true`; the only other observed `origin.kind` in real transcripts is `human`), and Claude Code's own UI hides them. Our importer ignored both markers: every user line with text became a round header, its raw content became the round preview, and `publishTurnIndexBestEffort` shipped those previews to every cloud viewer.

## Fix 1 — claude_code parser (`sources/claude_code/history.rs`)

- `ClaudeJsonlLine` now deserializes `isMeta` and `origin.kind`; `is_harness_injected_user_line` matches `isMeta == true` or `origin.kind == "task-notification"` (shared helper `is_harness_injected_user_marker` in `imported_history`).
- Both parse paths skip matching lines as round headers: the lazy byte index folds them into the previous round's body count, and the full replay parse emits no user bubble — the agent's post-wake output continues inside the same round, mirroring ORG2's native engine (whose subagent wake is an empty resume that never persists a user message).
- The `first_prompt` title fallback also skips them.
- `CLAUDE_CODE_METADATA_PARSER_VERSION` 9 → 10 re-parses cached sessions; polluted cloud turn indexes republish on the owner's next events push.

Genuine prompts (`origin.kind: "human"` or no marker, including `[Request interrupted by user]`) keep opening rounds unchanged.

## Fix 2 — provider sweep for the same class

- **anthropic_jsonl** (shared reader for OMP / Qoder CLI — same Anthropic transcript format): same guard on round bubbles and the first-user-text title; `parser_version` 1 → 2 for both consumers.
- **codex**: audited clean — rounds key on codex's own `user_message` events; `<ide_context>` prefixes were already stripped at the shared chunk funnel. (Rare user-typed slash-command records `<command-name>…` render raw in both codex and claude transcripts; that's genuine user action display formatting, deliberately out of scope here.)
- Remaining providers (cursor, windsurf, cline, kimi, qwen, zcode, trae, warp, …) have no harness-injected user-role entries in their formats; gemini-CLI-style `System: Please continue.` lines exist in the wild but ORG2 has no gemini source.

## Fix 3 — replay images (「图片显示不了」)

Two independent gaps:

- **claude_code dropped base64 image blocks** from user messages entirely: image-only prompts vanished from replay, text+image prompts lost the image. They now surface as `data:` URLs on `result.images` — the same contract codex local-image refs and native sessions already use, rendered by the existing `ChatImageThumbnail`.
- **Chat markdown had no `img` renderer**, so an agent message referencing a generated artifact by absolute path (`![](/Users/…/final.png)`) resolved against the webview origin and rendered the browser's broken-image glyph — the `?` box in the Codex hatch-pet session. New `MarkdownLocalImage` reads local paths through the fs plugin into a data URL (absolute, `~/`, `file://`, and workspace-relative paths; classification unit-tested), renders with click-to-zoom, and degrades to a labeled placeholder for missing files (e.g. artifacts moved to Trash) instead of the broken glyph. Web/data URLs render as before.

## Tests

- Rust: `cargo test -p orgtrack_core --lib` 490 passed / 0 failed (4 new tests: round skipping ×2, title fallback, image attachments; plus anthropic_jsonl guard test). Clippy clean on touched files.
- Frontend: `markdownImageSrc` classifier 9/9; `tsc` clean (develop-owned CodeMirror errors excluded); eslint clean.
- Live-tested on a real build (rounds heal + image renders) — see PR comments.
