### PR TITLE
feat(windows): add adaptive translucent chrome

### DIFF
--- a/public/orgii_dark.css
+++ b/public/orgii_dark.css
@@ -97,6 +97,7 @@
 body {
   --color-bg-1: #0f0f0f;
   --color-bg-2: #141414;
+  --windows-native-chrome-opacity: 82%;
   --color-bg-3: #2a2a2b;
   --color-bg-4: #313132;
   --color-neutral-1: #f7f8fa;

--- a/public/orgii_high_contrast.css
+++ b/public/orgii_high_contrast.css
@@ -94,6 +94,7 @@
 body {
   --color-bg-1: #050505;
   --color-bg-2: #0a0a0a;
+  --windows-native-chrome-opacity: 92%;
   --color-bg-3: #171717;
   --color-bg-4: #222222;
   --color-neutral-1: #ffffff;

--- a/public/orgii_main.css
+++ b/public/orgii_main.css
@@ -97,6 +97,7 @@
 body {
   --color-bg-1: #f4f4f4;
   --color-bg-2: #ffffff;
+  --windows-native-chrome-opacity: 30%;
   --color-bg-3: #ffffff;
   --color-bg-4: #ffffff;
   --color-neutral-1: #f7f8fa;

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -47,6 +47,7 @@
     "core:window:default",
     "core:window:allow-start-dragging",
     "core:window:allow-set-decorations",
+    "core:window:allow-set-theme",
     "core:window:allow-set-size",
     "core:window:allow-center",
     "core:window:allow-set-background-color",

--- a/src-tauri/crates/app-window/src/lib.rs
+++ b/src-tauri/crates/app-window/src/lib.rs
@@ -7,10 +7,7 @@
 //! glue. All operations are synchronous against a `tauri::AppHandle` /
 //! `WebviewWindow` — no async runtime, no IoC hooks.
 
-use tauri::{AppHandle, Manager, WebviewUrl, WebviewWindowBuilder};
-
-#[cfg(target_os = "macos")]
-use tauri::{LogicalPosition, Position, TitleBarStyle};
+use tauri::{AppHandle, Manager, WebviewWindowBuilder};
 
 #[cfg(target_os = "macos")]
 use objc2::msg_send;
@@ -224,15 +221,9 @@ fn is_main_thread() -> bool {
     }
 }
 
-/// Default window sizes
-const DEFAULT_WIDTH: f64 = 1200.0;
-const DEFAULT_HEIGHT: f64 = 800.0;
-const DEFAULT_MIN_WIDTH: f64 = 450.0;
-const DEFAULT_MIN_HEIGHT: f64 = 300.0;
-
 /// Host-native window chrome so the OS frame matches frontend corner radii.
 ///
-/// - **Windows 11+:** `DWMWCP_ROUNDSMALL` via DWM (pairs with `--radius-page` in the web layer).
+/// - **Windows 11+:** `DWMWCP_ROUND` via DWM (pairs with `--border-radius-window` in the web layer).
 /// - **macOS:** Applied separately through [`apply_macos_window_material`].
 /// - **Linux / others:** No-op.
 pub fn apply_host_desktop_window_chrome(
@@ -275,12 +266,12 @@ pub fn clear_macos_window_material(window: &tauri::WebviewWindow) {
 // Main Window Recovery
 // ============================================
 
-/// Recreate the main window with label "main" and default app URL.
+/// Recreate the main window from the platform-merged Tauri configuration.
 ///
 /// Used when the main window was somehow destroyed and needs to be restored.
-/// This always uses the "main" label so all code that references
-/// `get_webview_window("main")` continues to work (tray events, menu events,
-/// handle_opened_urls, etc.).
+/// Reusing the startup configuration keeps platform-specific chrome in parity:
+/// macOS overlay/transparency and the Windows frameless backdrop must not disappear
+/// after a tray or menu recovery.
 pub fn recreate_main_window(app: &AppHandle) -> Result<(), String> {
     // Safety: if "main" already exists, just focus it
     if let Some(existing) = app.get_webview_window("main") {
@@ -291,24 +282,15 @@ pub fn recreate_main_window(app: &AppHandle) -> Result<(), String> {
 
     println!("📦 [Window] Recreating main window");
 
-    let builder = WebviewWindowBuilder::new(app, "main", WebviewUrl::default())
-        .title("ORGII")
-        .inner_size(DEFAULT_WIDTH, DEFAULT_HEIGHT)
-        .min_inner_size(DEFAULT_MIN_WIDTH, DEFAULT_MIN_HEIGHT)
-        .resizable(true)
-        .visible(true)
-        .decorations(true)
-        .center();
-
-    #[cfg(target_os = "macos")]
-    let builder = builder
-        .transparent(true)
-        .hidden_title(true)
-        .title_bar_style(TitleBarStyle::Overlay)
-        .traffic_light_position(Position::Logical(LogicalPosition::new(
-            TRAFFIC_LIGHT_X,
-            TRAFFIC_LIGHT_Y,
-        )));
+    let main_config = app
+        .config()
+        .app
+        .windows
+        .iter()
+        .find(|config| config.label == "main")
+        .ok_or("Main window configuration not found")?;
+    let builder = WebviewWindowBuilder::from_config(app, main_config)
+        .map_err(|error| format!("Failed to load main window configuration: {error}"))?;
 
     let ownership_observation = perf_utils::begin_webview_ownership_observation("main");
     let window = builder

--- a/src-tauri/crates/system-services/src/app_menu.rs
+++ b/src-tauri/crates/system-services/src/app_menu.rs
@@ -599,9 +599,7 @@ pub fn setup_menu_events(app: &AppHandle) {
             }
             "recent_clear" => {
                 clear_recent_menu(&app_handle);
-                if let Ok(menu) = create_app_menu(&app_handle) {
-                    let _ = app.set_menu(menu);
-                }
+                let _ = rebuild_menu(&app_handle);
             }
             id if id.starts_with("recent_") && id != "recent_none" && id != "recent_clear" => {
                 // Handle recent item click
@@ -620,6 +618,16 @@ pub fn setup_menu_events(app: &AppHandle) {
 }
 
 /// Rebuild the menu (call after adding/removing recent items)
+#[cfg(windows)]
+pub fn rebuild_menu(_app: &AppHandle) -> Result<(), tauri::Error> {
+    // Windows owns its single-row frameless chrome in `WindowsTopBar`.
+    // Attaching a native application menu adds a second File/Edit/View row
+    // beneath the web header and forces conflicting non-client chrome.
+    Ok(())
+}
+
+/// Rebuild the menu (call after adding/removing recent items)
+#[cfg(not(windows))]
 pub fn rebuild_menu(app: &AppHandle) -> Result<(), tauri::Error> {
     let menu = create_app_menu(app)?;
     app.set_menu(menu)?;

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -9,12 +9,15 @@
         "minWidth": 450,
         "minHeight": 300,
         "resizable": true,
-        "maximized": true,
+        "maximized": false,
         "fullscreen": false,
         "decorations": false,
         "hiddenTitle": true,
-        "backgroundColor": "#0d0d0d",
-        "transparent": false
+        "backgroundColor": "#00000000",
+        "transparent": true,
+        "windowEffects": {
+          "effects": ["acrylic"]
+        }
       }
     ]
   },

--- a/src/components/WindowChrome/WindowsTopBar.tsx
+++ b/src/components/WindowChrome/WindowsTopBar.tsx
@@ -280,7 +280,7 @@ const WindowsTopBarComponent: React.FC = () => {
 
   return (
     <div
-      className="relative z-50 flex shrink-0 items-center border-b border-border-2 bg-bg-2 text-text-1"
+      className="relative z-50 flex shrink-0 items-center text-text-1"
       data-windows-top-bar="true"
       data-tauri-drag-region
       style={

--- a/src/config/windowChromeRadius.ts
+++ b/src/config/windowChromeRadius.ts
@@ -21,7 +21,7 @@ const CHROME_RADIUS_PX: Record<
   { windowPx: number; pagePx: number }
 > = {
   [HOST_DESKTOP.MACOS]: { windowPx: 10, pagePx: 20 },
-  [HOST_DESKTOP.WINDOWS]: { windowPx: 8, pagePx: 8 },
+  [HOST_DESKTOP.WINDOWS]: { windowPx: 8, pagePx: 12 },
   [HOST_DESKTOP.LINUX]: { windowPx: 12, pagePx: 12 },
 };
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -536,14 +536,34 @@ html[data-host-desktop="macos"] .sidebar-base {
   background: transparent;
 }
 
-html[data-host-desktop="windows"],
 html[data-host-desktop="windows"] body,
 html[data-host-desktop="windows"] #root {
-  background: var(--color-bg-2);
+  background: transparent;
 }
 
 html[data-host-desktop="windows"] .sidebar-base {
-  background: var(--sidebar-bg);
+  background: transparent;
+}
+
+// The work surface overlaps the sidebar edge like Codex: only the inner
+// top-left corner is rounded, while the sidebar keeps its native edge depth.
+html[data-host-desktop="windows"] .windows-main-page-surface {
+  overflow: hidden;
+  border-top-left-radius: var(--radius-page);
+}
+
+// Windows uses a frameless Tauri window with DWM owning the outer shape.
+// Clip the HTML header to the same radius so its translucent fill cannot
+// square off the native top corners.
+html[data-host-desktop="windows"] [data-windows-top-bar="true"] {
+  overflow: hidden;
+  border-top-left-radius: var(--border-radius-window);
+  border-top-right-radius: var(--border-radius-window);
+  background: color-mix(
+    in srgb,
+    var(--color-bg-2) var(--windows-native-chrome-opacity, 30%),
+    transparent
+  );
 }
 
 // Ensure popup layers are not clipped by body's overflow: hidden

--- a/src/modules/index.tsx
+++ b/src/modules/index.tsx
@@ -131,16 +131,13 @@ const WorkStationLoadingFallback: React.FC = () => (
   <div className="h-full w-full bg-workstation-bg" />
 );
 
-const IS_MACOS_HOST = resolveHostDesktop() === HOST_DESKTOP.MACOS;
+const HOST_DESKTOP_VALUE = resolveHostDesktop();
+const HOST_USES_NATIVE_BACKDROP =
+  HOST_DESKTOP_VALUE === HOST_DESKTOP.MACOS ||
+  HOST_DESKTOP_VALUE === HOST_DESKTOP.WINDOWS;
 
-interface ConfiguredBackgroundLayerProps {
-  sidebarInset: number;
-}
-
-/** Legacy wallpaper/color background, retained for non-macOS hosts. */
-const ConfiguredBackgroundLayer: React.FC<ConfiguredBackgroundLayerProps> = ({
-  sidebarInset,
-}) => {
+/** Legacy wallpaper/color background, retained for browser and Linux hosts. */
+const ConfiguredBackgroundLayer: React.FC = () => {
   const backgroundConfig = useAtomValue(resolvedBackgroundConfigAtom);
   const currentBackgroundImage = useBackgroundImage();
 
@@ -155,7 +152,6 @@ const ConfiguredBackgroundLayer: React.FC<ConfiguredBackgroundLayerProps> = ({
       blurAmount={backgroundConfig.blurAmount ?? 0}
       backgroundColor={backgroundConfig.backgroundColor}
       glass={backgroundConfig.glass}
-      sidebarInset={sidebarInset}
     />
   );
 };
@@ -404,11 +400,7 @@ const AppShell = () => {
           className="relative flex h-full"
           data-guide-target={GUIDE_TARGETS.APP_ROOT}
         >
-          {!IS_MACOS_HOST && (
-            <ConfiguredBackgroundLayer
-              sidebarInset={sidebarCollapsed ? 0 : sidebarWidth}
-            />
-          )}
+          {!HOST_USES_NATIVE_BACKDROP && <ConfiguredBackgroundLayer />}
 
           {/* Main layout with sidebar, toolbar, content, and chat panel */}
           <AppLayout

--- a/src/modules/shared/components/BackgroundLayer/index.tsx
+++ b/src/modules/shared/components/BackgroundLayer/index.tsx
@@ -17,7 +17,6 @@ import {
   addToBackgroundCache,
   backgroundImageCache,
 } from "@src/util/core/init/backgroundInit";
-import { isMacOS, isWindows } from "@src/util/platform/tauri";
 
 const log = createLogger("BackgroundLayer");
 
@@ -26,8 +25,6 @@ interface BackgroundLayerProps {
   blurAmount: number;
   backgroundColor?: string;
   glass?: "regular" | "medium" | "thick";
-  /** Width reserved for native macOS sidebar material. */
-  sidebarInset?: number;
 }
 
 export const BackgroundLayer: React.FC<BackgroundLayerProps> = ({
@@ -35,7 +32,6 @@ export const BackgroundLayer: React.FC<BackgroundLayerProps> = ({
   blurAmount,
   backgroundColor,
   glass,
-  sidebarInset = 0,
 }) => {
   const [displayedImage, setDisplayedImage] = useState<string | null>(() => {
     if (!image) return null;
@@ -78,25 +74,14 @@ export const BackgroundLayer: React.FC<BackgroundLayerProps> = ({
 
   // If backgroundColor is set and no image, use solid color
   const useColorBackground = backgroundColor && !displayedImage;
-  const nativeSidebarInset = isMacOS() ? Math.max(0, sidebarInset) : 0;
   const frameStyle = useMemo<React.CSSProperties>(
     () => ({
-      left: nativeSidebarInset,
+      left: 0,
       right: 0,
       height: "100vh",
     }),
-    [nativeSidebarInset]
+    []
   );
-
-  if (isWindows()) {
-    return (
-      <div
-        data-background-layer="true"
-        className="absolute left-0 top-0 z-0 bg-bg-2"
-        style={{ width: "100vw", height: "100vh" }}
-      />
-    );
-  }
 
   return (
     <div

--- a/src/modules/shared/layouts/AppLayout.tsx
+++ b/src/modules/shared/layouts/AppLayout.tsx
@@ -341,7 +341,11 @@ const AppLayoutComponent: React.FC<AppLayoutProps> = ({
         )}
 
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-          <MainContentArea className="relative min-h-0 flex-1">
+          <MainContentArea
+            className={`relative min-h-0 flex-1 ${
+              windowsHost ? "windows-main-page-surface" : ""
+            }`}
+          >
             {contentArea}
           </MainContentArea>
 

--- a/src/scaffold/NavigationSidebar/SidebarBase.tsx
+++ b/src/scaffold/NavigationSidebar/SidebarBase.tsx
@@ -480,7 +480,7 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
     // current layout mode so it visually detaches from the workspace.
     const sidebarBoxShadow = shouldForceVisible
       ? "var(--sidebar-shadow)"
-      : IS_MACOS_HOST && sidebarEdgeDepthEnabled
+      : IS_WINDOWS_HOST || (IS_MACOS_HOST && sidebarEdgeDepthEnabled)
         ? "var(--sidebar-edge-shadow)"
         : "none";
     const sidebarBackdropFilter = "none";
@@ -496,7 +496,9 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
           ...floatingSurfaceOverride,
         }
       : {
-          backgroundColor: "var(--sidebar-bg)",
+          backgroundColor: IS_WINDOWS_HOST
+            ? "color-mix(in srgb, var(--color-bg-2) var(--windows-native-chrome-opacity, 30%), transparent)"
+            : "var(--sidebar-bg)",
           borderColor: "var(--sidebar-border)",
           boxShadow: sidebarBoxShadow,
           backdropFilter: sidebarBackdropFilter,
@@ -516,7 +518,10 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
     // Modern chrome keeps the sidebar flush against the rounded window edge,
     // with only a separator where it meets the content panel.
     const modernSurfaceStyle = {
-      borderTopLeftRadius: "var(--border-radius-window)",
+      // The Windows header spans the full native top edge and owns both top
+      // radii. Rounding the sidebar again below it creates a detached inner
+      // curve; macOS has no HTML topbar, so its sidebar still owns this corner.
+      borderTopLeftRadius: IS_WINDOWS_HOST ? 0 : "var(--border-radius-window)",
       borderBottomLeftRadius: "var(--border-radius-window)",
       borderTopRightRadius: 0,
       borderBottomRightRadius: 0,

--- a/src/util/core/init/themeInit.ts
+++ b/src/util/core/init/themeInit.ts
@@ -4,7 +4,10 @@ import {
   resolveGlobalThemePreference,
 } from "@src/config/appearance/globalThemes";
 import { createLogger } from "@src/hooks/logger";
-import { preloadThemeCss } from "@src/util/ui/theme/swapThemeCss";
+import {
+  preloadThemeCss,
+  syncThemeAppearance,
+} from "@src/util/ui/theme/swapThemeCss";
 
 const log = createLogger("Theme");
 
@@ -71,7 +74,14 @@ const initTheme = (): Promise<void> => {
     };
 
     // Wait for CSS to load before resolving
-    link.onload = safeResolve;
+    link.onload = () => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          syncThemeAppearance(theme);
+          safeResolve();
+        });
+      });
+    };
 
     link.onerror = (error) => {
       if (resolved) return;

--- a/src/util/ui/theme/swapThemeCss.ts
+++ b/src/util/ui/theme/swapThemeCss.ts
@@ -7,12 +7,59 @@
  * loading, creating a mixed light/dark state. This utility avoids that
  * by keeping the old CSS active until the new one is fully loaded.
  */
+import { isWindows } from "@src/util/platform/tauri";
 
 const THEME_LINK_ATTR = "data-orgii-theme";
 const PRELOAD_LINK_ATTR = "data-orgii-theme-preload";
 const SWAP_TIMEOUT_MS = 4000;
 
 let latestRequestedCssPath = "";
+
+function isActiveThemeDark(cssPath: string): boolean {
+  const background = getComputedStyle(document.body)
+    .getPropertyValue("--color-bg-2")
+    .trim();
+  const hexMatch = /^#([\da-f]{6})$/i.exec(background);
+
+  if (hexMatch) {
+    const value = hexMatch[1];
+    const red = Number.parseInt(value.slice(0, 2), 16);
+    const green = Number.parseInt(value.slice(2, 4), 16);
+    const blue = Number.parseInt(value.slice(4, 6), 16);
+    const luminance = (0.2126 * red + 0.7152 * green + 0.0722 * blue) / 255;
+    return luminance < 0.5;
+  }
+
+  return (
+    cssPath.endsWith("/orgii_high_contrast.css") ||
+    cssPath.endsWith("/orgii_dark.css")
+  );
+}
+
+/** Keep CSS chrome and the Windows system backdrop on the same color scheme. */
+export function syncThemeAppearance(cssPath: string): void {
+  const isHighContrast = cssPath.endsWith("/orgii_high_contrast.css");
+  const isDark = isActiveThemeDark(cssPath);
+  const colorScheme = isDark ? "dark" : "light";
+  const root = document.documentElement;
+
+  root.dataset.theme = colorScheme;
+  root.dataset.themeId = isHighContrast
+    ? "orgii-high-contrast"
+    : isDark
+      ? "github-dark"
+      : "github-light";
+  root.style.colorScheme = colorScheme;
+
+  if (!isWindows()) return;
+
+  void import("@tauri-apps/api/window")
+    .then(({ getCurrentWindow }) => getCurrentWindow().setTheme(colorScheme))
+    .catch(() => {
+      // Browser previews and windows closing during a theme swap have no
+      // native backdrop to synchronize.
+    });
+}
 
 /**
  * Warm the browser's stylesheet cache for the given theme CSS files so a
@@ -86,6 +133,7 @@ export function swapThemeCss(newCssPath: string): Promise<void> {
 
   if (existingLink.href.endsWith(newCssPath)) {
     removeOtherThemeLinks(existingLink);
+    syncThemeAppearance(newCssPath);
     return Promise.resolve();
   }
 
@@ -145,6 +193,7 @@ function swapFromExisting(
       await nextPaint();
       oldLink.remove();
       removeOtherThemeLinks(newLink);
+      syncThemeAppearance(newCssPath);
       resolve();
     };
 
@@ -187,6 +236,7 @@ function insertFreshLink(
       } else {
         await nextPaint();
         removeOtherThemeLinks(link);
+        syncThemeAppearance(cssPath);
       }
 
       resolve();


### PR DESCRIPTION
## Problem

On Windows, ORG2 used an opaque webview surface and conflicting native/custom chrome. This produced duplicate File/Edit/View menu rows, disconnected top corners, no native translucency, and window-recovery behavior that could diverge from startup configuration. Windows also rendered the legacy background layer over the native backdrop, preventing the sidebar and top bar from matching the macOS/Codex material treatment.

## Solution

Configure the Windows Tauri window as transparent with an Acrylic backdrop and keep it frameless with the existing custom Windows top bar. Disable the native application menu on Windows so there is one menu/header row, recreate destroyed main windows from the platform-merged Tauri configuration, and synchronize the native light/dark window theme after the active public theme CSS paints.

The Windows sidebar and top bar now derive color and opacity atomically from the active public theme tokens. The main page stack clips to a 12px top-left radius, the header owns the native top radii, and Windows reuses the existing theme-aware sidebar edge depth. Native-backdrop hosts no longer mount the legacy image/background layer.

## Potential risks

- Acrylic and rounded DWM behavior depend on the Windows version/compositor; unsupported systems may use the platform fallback.
- Windows intentionally stops mounting configurable wallpaper/background images while the native backdrop is active.
- The native Windows menu is disabled, so command availability depends on the custom `WindowsTopBar`; the single-row chrome and controls were visually verified, but every menu command was not exhaustively exercised.
- Light and dark themes were inspected live; high-contrast token behavior was statically verified but not manually inspected.
- macOS and Linux were not runtime-tested in this Windows environment. Their platform configuration and menu paths remain separate.
- Rollback is a normal revert of this single commit; there are no data, persistence, IPC, or schema migrations.

## Architecture

Reviewed window configuration, startup/recreation parity, native menu ownership, platform-specific backdrop ownership, theme synchronization, and the frontend page/sidebar boundary. Persistence, wire protocol, domain FSM, and background-work lifecycle layers were intentionally out of scope because this change adds no data flow, protocol, timer, worker, subscription, or cache behavior.

## Verification

- `pnpm exec prettier --check <changed frontend/config files>` - passed.
- `pnpm exec eslint <changed TypeScript/TSX files>` - passed.
- `pnpm exec tsc --noEmit --pretty false` - passed before and after rebasing onto the latest `origin/develop`.
- `cargo fmt --check -p app_window -p system_services` from `src-tauri` - passed.
- `cargo clippy --manifest-path src-tauri/Cargo.toml -p app_window -p system_services --all-targets -- -D warnings -A clippy::needless_return` - passed after rebase.
- The same clippy command without the single allow flag is currently blocked by an upstream `clippy::needless_return` warning in unchanged `crates/system-services/src/workspace_ports/scanner.rs:363`.
- Parsed `src-tauri/capabilities/default.json` and `src-tauri/tauri.windows.conf.json` with PowerShell `ConvertFrom-Json` - passed.
- `git diff --check origin/develop...HEAD` - passed.
- `pnpm run tauri:dev` - compiled and launched the debug app repeatedly after native configuration changes.
- Computer Use manual QA - verified one menu/header row, native rounded outer window corners, light/dark Acrylic chrome, connected top bar/sidebar, 12px page top-left radius, sidebar edge depth, and working minimize/maximize/close controls.

Visual QA was performed against the live Windows app throughout implementation. A screenshot was not added to the repository because the desktop capture is review evidence rather than a source artifact.