### PR TITLE
fix(imported-history): support Windows MSRV

### DIFF
--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/watermark.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/watermark.rs
@@ -19,7 +19,7 @@
 use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom};
 use std::path::Path;
-#[cfg(all(not(unix), not(windows)))]
+#[cfg(not(unix))]
 use std::time::UNIX_EPOCH;
 
 use rusqlite::{params, Connection, OptionalExtension};
@@ -183,22 +183,13 @@ impl BoundaryFingerprint {
     }
 }
 
-fn source_file_identity(_path: &Path, metadata: &std::fs::Metadata) -> Option<String> {
+fn source_file_identity(path: &Path, metadata: &std::fs::Metadata) -> Option<String> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::MetadataExt;
         Some(format!("unix:{}:{}", metadata.dev(), metadata.ino()))
     }
-    #[cfg(windows)]
-    {
-        use std::os::windows::fs::MetadataExt;
-        Some(format!(
-            "windows:{}:{}",
-            metadata.volume_serial_number()?,
-            metadata.file_index()?
-        ))
-    }
-    #[cfg(all(not(unix), not(windows)))]
+    #[cfg(not(unix))]
     {
         // `created` is stable across appends and changes on normal rotation.
         // If the platform/filesystem cannot expose it, disable resume rather
@@ -210,7 +201,7 @@ fn source_file_identity(_path: &Path, metadata: &std::fs::Metadata) -> Option<St
             .ok()?
             .as_nanos();
         let mut path_hasher = PrefixHasher::default();
-        path_hasher.update(_path.to_string_lossy().as_bytes());
+        path_hasher.update(path.to_string_lossy().as_bytes());
         Some(format!(
             "created:{created_ns}:path:{}",
             path_hasher.digest()


### PR DESCRIPTION
## Problem

Windows builds fail because the imported-history watermark uses `MetadataExt::volume_serial_number()` and `file_index()`, which require the unstable `windows_by_handle` feature and are incompatible with the project’s Rust toolchain.

This prevents the Tauri application from compiling on Windows.

## Solution

Use the existing non-Unix file-identity strategy on Windows: combine the file creation timestamp with a hash of its path.

Unix continues using device and inode identity. If creation metadata is unavailable, watermark resume is safely disabled and the transcript is reparsed instead.

## Potential risks

Filesystems that do not expose a stable creation timestamp will fall back to a full reparse. This may reduce incremental-import performance in that case, but it preserves correctness. Unix behavior is unchanged.

## Verification

- `cargo test --manifest-path src-tauri/Cargo.toml -p orgtrack_core watermark`
  - 15 passed
  - 0 failed
- Scoped `cargo clippy` for `orgtrack_core` passed through the commit hook.
- `git diff --check` passed.
- The full Tauri startup was not completed because the preview was interrupted during the final application build.