### PR TITLE
feat(sidebar): align desktop sidebar header controls

### DIFF
--- a/src/scaffold/NavigationSidebar/SidebarBase.tsx
+++ b/src/scaffold/NavigationSidebar/SidebarBase.tsx
@@ -90,6 +90,7 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
     beforeAddNewActions,
     headerActions,
     hostTopBarLeadingContent,
+    macTopBarFollowingContent,
   }) => {
     const sidebarContainerRef = useRef<HTMLDivElement>(null);
     const {
@@ -470,6 +471,7 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
           />
         )}
         {renderTrafficLightsSpace()}
+        {IS_MACOS_HOST ? macTopBarFollowingContent : null}
         {header}
         <div className="flex flex-1 flex-col overflow-hidden">
           {resolvedChildren}

--- a/src/scaffold/NavigationSidebar/SidebarBase.tsx
+++ b/src/scaffold/NavigationSidebar/SidebarBase.tsx
@@ -57,7 +57,7 @@ const log = createLogger("SidebarBase");
 const HOST_DESKTOP_KIND = resolveHostDesktop();
 const IS_MACOS_HOST = HOST_DESKTOP_KIND === HOST_DESKTOP.MACOS;
 const IS_WINDOWS_HOST = HOST_DESKTOP_KIND === HOST_DESKTOP.WINDOWS;
-const SHOW_HOST_TITLE =
+const IS_WINDOWS_OR_LINUX_HOST =
   HOST_DESKTOP_KIND === HOST_DESKTOP.WINDOWS ||
   HOST_DESKTOP_KIND === HOST_DESKTOP.LINUX;
 
@@ -89,6 +89,7 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
     addTooltipContent,
     beforeAddNewActions,
     headerActions,
+    hostTopBarLeadingContent,
   }) => {
     const sidebarContainerRef = useRef<HTMLDivElement>(null);
     const {
@@ -269,11 +270,13 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
 
       // In fullscreen mode, traffic lights are hidden, so no padding needed
       const trafficLightPadding =
-        IS_WINDOWS_HOST || isFullscreen
+        IS_WINDOWS_OR_LINUX_HOST || isFullscreen
           ? 0
           : SIDEBAR_STYLE.trafficLightsPadding;
-      const alignmentClassName = IS_WINDOWS_HOST
-        ? "justify-between pl-5 pr-2"
+      const alignmentClassName = IS_WINDOWS_OR_LINUX_HOST
+        ? hostTopBarLeadingContent
+          ? "justify-between pl-3 pr-2"
+          : "justify-between pl-5 pr-2"
         : "justify-end pr-2";
 
       return (
@@ -290,13 +293,22 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
             } as React.CSSProperties
           }
         >
-          {SHOW_HOST_TITLE ? (
-            <span className="select-none text-[13px] font-semibold tracking-wide text-text-2">
-              ORG2
-            </span>
+          {IS_WINDOWS_OR_LINUX_HOST ? (
+            hostTopBarLeadingContent ? (
+              <div
+                className="min-w-0 flex-1"
+                style={{ WebkitAppRegion: "no-drag" } as React.CSSProperties}
+              >
+                {hostTopBarLeadingContent}
+              </div>
+            ) : (
+              <span className="select-none text-[13px] font-semibold tracking-wide text-text-2">
+                ORG2
+              </span>
+            )
           ) : null}
           <div
-            className={`flex items-center gap-1 ${sidebarTopChromeClassName}`}
+            className={`flex shrink-0 items-center gap-1 ${sidebarTopChromeClassName}`}
           >
             {beforeAddNewActions ? (
               <div

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
@@ -4,6 +4,10 @@ import React, { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 
+import {
+  HOST_DESKTOP,
+  resolveHostDesktop,
+} from "@src/config/windowChromeRadius";
 import { useAppNavigation } from "@src/hooks/navigation/useAppNavigation";
 import { useSessionView } from "@src/hooks/ui/tabs/useSessionView";
 import { teamInboxUnreadCountAtom } from "@src/modules/MainApp/TeamInbox/store";
@@ -48,6 +52,11 @@ import { useWorkstationSidebarSessionAndProjectMenuItems } from "./sidebarConnec
 import { useWorkstationSidebarSessionInteractionHandlers } from "./sidebarConnector.sessionInteractionHandlers";
 import { SidebarSearchShortcutTooltip } from "./sidebarTabs";
 import type { WorkstationSidebarKey } from "./types";
+
+const HOST_DESKTOP_KIND = resolveHostDesktop();
+const SHOW_ORG_SELECTOR_IN_TOP_CHROME =
+  HOST_DESKTOP_KIND === HOST_DESKTOP.WINDOWS ||
+  HOST_DESKTOP_KIND === HOST_DESKTOP.LINUX;
 
 /**
  * Workstation sidebar coordinator. The bulk of this connector's state,
@@ -562,9 +571,14 @@ export const WorkstationSidebarConnector: React.FC = () => {
         onSubmenuOpenChange={handleSubmenuOpenChange}
         onMenuItemContextMenu={resolvedMenuItemContextMenu}
         renderMenuItemWrapper={resolvedRenderMenuItemWrapper}
+        hostTopBarLeadingContent={
+          SHOW_ORG_SELECTOR_IN_TOP_CHROME ? sidebarOrgSelector : undefined
+        }
         preListContent={
           <>
-            <div className="shrink-0 px-3 pt-1">{sidebarOrgSelector}</div>
+            {!SHOW_ORG_SELECTOR_IN_TOP_CHROME ? (
+              <div className="shrink-0 px-3 pt-1">{sidebarOrgSelector}</div>
+            ) : null}
             {sidebarLayerHeader}
           </>
         }

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
@@ -4,10 +4,6 @@ import React, { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 
-import {
-  HOST_DESKTOP,
-  resolveHostDesktop,
-} from "@src/config/windowChromeRadius";
 import { useAppNavigation } from "@src/hooks/navigation/useAppNavigation";
 import { useSessionView } from "@src/hooks/ui/tabs/useSessionView";
 import { teamInboxUnreadCountAtom } from "@src/modules/MainApp/TeamInbox/store";
@@ -52,11 +48,6 @@ import { useWorkstationSidebarSessionAndProjectMenuItems } from "./sidebarConnec
 import { useWorkstationSidebarSessionInteractionHandlers } from "./sidebarConnector.sessionInteractionHandlers";
 import { SidebarSearchShortcutTooltip } from "./sidebarTabs";
 import type { WorkstationSidebarKey } from "./types";
-
-const HOST_DESKTOP_KIND = resolveHostDesktop();
-const SHOW_ORG_SELECTOR_IN_TOP_CHROME =
-  HOST_DESKTOP_KIND === HOST_DESKTOP.WINDOWS ||
-  HOST_DESKTOP_KIND === HOST_DESKTOP.LINUX;
 
 /**
  * Workstation sidebar coordinator. The bulk of this connector's state,
@@ -571,17 +562,11 @@ export const WorkstationSidebarConnector: React.FC = () => {
         onSubmenuOpenChange={handleSubmenuOpenChange}
         onMenuItemContextMenu={resolvedMenuItemContextMenu}
         renderMenuItemWrapper={resolvedRenderMenuItemWrapper}
-        hostTopBarLeadingContent={
-          SHOW_ORG_SELECTOR_IN_TOP_CHROME ? sidebarOrgSelector : undefined
+        hostTopBarLeadingContent={sidebarOrgSelector}
+        macTopBarFollowingContent={
+          <div className="shrink-0 px-3 pt-1">{sidebarOrgSelector}</div>
         }
-        preListContent={
-          <>
-            {!SHOW_ORG_SELECTOR_IN_TOP_CHROME ? (
-              <div className="shrink-0 px-3 pt-1">{sidebarOrgSelector}</div>
-            ) : null}
-            {sidebarLayerHeader}
-          </>
-        }
+        preListContent={sidebarLayerHeader}
         onAddNew={handleOpenSpotlight}
         addIcon={Search}
         addLabel={tCommon("actions.search")}

--- a/src/scaffold/NavigationSidebar/types.ts
+++ b/src/scaffold/NavigationSidebar/types.ts
@@ -166,6 +166,8 @@ export interface SidebarBaseProps {
   beforeAddNewActions?: ReactNode;
   /** Extra controls to the right of the add button (e.g. session group-by filter) */
   headerActions?: ReactNode;
+  /** Leading content in the Windows/Linux sidebar chrome row. */
+  hostTopBarLeadingContent?: ReactNode;
 }
 
 /** SidebarHeader props */

--- a/src/scaffold/NavigationSidebar/types.ts
+++ b/src/scaffold/NavigationSidebar/types.ts
@@ -168,6 +168,8 @@ export interface SidebarBaseProps {
   headerActions?: ReactNode;
   /** Leading content in the Windows/Linux sidebar chrome row. */
   hostTopBarLeadingContent?: ReactNode;
+  /** Equivalent content rendered below the traffic-light row on macOS. */
+  macTopBarFollowingContent?: ReactNode;
 }
 
 /** SidebarHeader props */

--- a/src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx
+++ b/src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx
@@ -77,6 +77,8 @@ export interface NavigationSidebarProps {
   headerActions?: React.ReactNode;
   /** Leading content in the Windows/Linux sidebar chrome row. */
   hostTopBarLeadingContent?: React.ReactNode;
+  /** Equivalent content rendered below the traffic-light row on macOS. */
+  macTopBarFollowingContent?: React.ReactNode;
   /** Preserve top padding for the scrollable menu list. */
   listTopPadding?: boolean;
   /** Optional ghost search row rendered above the scrollable menu list. */
@@ -187,6 +189,7 @@ const NavigationSidebar: React.FC<NavigationSidebarProps> = React.memo(
     beforeAddNewActions,
     headerActions,
     hostTopBarLeadingContent,
+    macTopBarFollowingContent,
     listTopPadding = false,
     search,
     preListContent,
@@ -376,6 +379,7 @@ const NavigationSidebar: React.FC<NavigationSidebarProps> = React.memo(
         beforeAddNewActions={beforeAddNewActions}
         headerActions={headerActions}
         hostTopBarLeadingContent={hostTopBarLeadingContent}
+        macTopBarFollowingContent={macTopBarFollowingContent}
         solidSurface={solidSurface}
       >
         {preListContent}

--- a/src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx
+++ b/src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx
@@ -75,6 +75,8 @@ export interface NavigationSidebarProps {
   beforeAddNewActions?: React.ReactNode;
   /** Extra controls next to add-new (passed to SidebarBase) */
   headerActions?: React.ReactNode;
+  /** Leading content in the Windows/Linux sidebar chrome row. */
+  hostTopBarLeadingContent?: React.ReactNode;
   /** Preserve top padding for the scrollable menu list. */
   listTopPadding?: boolean;
   /** Optional ghost search row rendered above the scrollable menu list. */
@@ -184,6 +186,7 @@ const NavigationSidebar: React.FC<NavigationSidebarProps> = React.memo(
     addTooltipContent,
     beforeAddNewActions,
     headerActions,
+    hostTopBarLeadingContent,
     listTopPadding = false,
     search,
     preListContent,
@@ -372,6 +375,7 @@ const NavigationSidebar: React.FC<NavigationSidebarProps> = React.memo(
         addTooltipContent={addTooltipContent}
         beforeAddNewActions={beforeAddNewActions}
         headerActions={headerActions}
+        hostTopBarLeadingContent={hostTopBarLeadingContent}
         solidSurface={solidSurface}
       >
         {preListContent}

--- a/src/scaffold/NavigationSidebar/variants/SettingsSidebar.tsx
+++ b/src/scaffold/NavigationSidebar/variants/SettingsSidebar.tsx
@@ -175,8 +175,11 @@ const SettingsSidebar: React.FC = () => {
           searchLabel={t("common:actions.search")}
         />
       }
+      hostTopBarLeadingContent={settingsReturnItem}
+      macTopBarFollowingContent={
+        <div className="shrink-0 px-3">{settingsReturnItem}</div>
+      }
     >
-      <div className="shrink-0 px-3">{settingsReturnItem}</div>
       <SettingsRootBody devModeEnabled={devModeEnabled} />
       <SidebarBottomBar
         rightActions={


### PR DESCRIPTION
## Problem

On Windows and Linux, the Workstation organization selector and Settings back control appeared on separate rows beneath Search and the sidebar toggle. This consumed unnecessary vertical space and left the sidebar header visually disconnected.

macOS needs to retain its existing traffic-light-aware stacked layout.

## Solution

Added shared platform-adaptive sidebar header slots.

On Windows and Linux:

- The organization selector, Search, and sidebar toggle share one row in Workstation.
- The back/Settings control, Search, and sidebar toggle share one row in Settings.
- The redundant secondary header rows are removed.

On macOS, the organization selector and Settings control remain in their existing separate rows below the traffic-light area.

Each control is mounted only once per platform, preserving its existing state, accessibility behavior, tooltips, and actions.

## Potential risks

Long organization names or localized Settings labels may truncate sooner at narrow sidebar widths. The layout uses the existing flexible selector and fixed-width action controls to keep Search and sidebar toggle accessible.

Windows was verified in the running application. Linux and macOS were verified through their platform-specific code paths but were not launched locally.

## Verification

- `pnpm run tauri:dev` — application launched successfully on Windows
- Manually verified the Workstation organization-selector header
- Manually verified the Settings back/header layout
- `pnpm exec eslint <changed files>` — passed
- `pnpm run typecheck` — passed
- Prettier and commit hooks — passed
- `git diff --check origin/develop...HEAD` — passed
- Confirmed the branch contains only the shared sidebar layout and its Workstation/Settings integrations