### PR TITLE
fix(windows): refresh menu headers after language changes

### DIFF
--- a/src/components/WindowChrome/WindowsTopBar.tsx
+++ b/src/components/WindowChrome/WindowsTopBar.tsx
@@ -5,8 +5,10 @@ import {
   Menu as TauriMenu,
 } from "@tauri-apps/api/menu";
 import { open } from "@tauri-apps/plugin-shell";
+import type { TFunction } from "i18next";
 import { Minus, Square, X } from "lucide-react";
 import React, { memo, useCallback } from "react";
+import { useTranslation } from "react-i18next";
 
 import {
   closeWindow,
@@ -30,7 +32,7 @@ const WINDOW_CONTROL_BUTTON_CLASS =
 const CLOSE_BUTTON_CLASS =
   "flex h-full w-11 items-center justify-center border-0 bg-transparent p-0 text-text-2 transition-colors hover:bg-danger-6 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger-6/30";
 
-type NativeMenuKey = "orgii" | "file" | "edit" | "view" | "window" | "help";
+type NativeMenuKey = "file" | "edit" | "view" | "window" | "help";
 
 type NativeMenuItem =
   | {
@@ -42,14 +44,7 @@ type NativeMenuItem =
     }
   | { type: "separator" };
 
-const MENU_LABELS: Array<{ key: NativeMenuKey; label: string }> = [
-  { key: "orgii", label: "ORGII" },
-  { key: "file", label: "File" },
-  { key: "edit", label: "Edit" },
-  { key: "view", label: "View" },
-  { key: "window", label: "Window" },
-  { key: "help", label: "Help" },
-];
+const MENU_KEYS: NativeMenuKey[] = ["file", "edit", "view", "window", "help"];
 
 function emitMenuEvent(eventName: string) {
   window.dispatchEvent(new CustomEvent(eventName));
@@ -59,82 +54,80 @@ function handleWindowAction(action: () => Promise<void>) {
   void action();
 }
 
-function getMenuItems(menu: NativeMenuKey): NativeMenuItem[] {
+function getMenuItems(menu: NativeMenuKey, t: TFunction): NativeMenuItem[] {
   switch (menu) {
-    case "orgii":
-      return [
-        {
-          type: "item",
-          text: "Quit ORGII",
-          accelerator: "Ctrl+Q",
-          action: () => emitMenuEvent("native-quit-confirmation-open"),
-        },
-      ];
     case "file":
       return [
         {
           type: "item",
-          text: "New Session",
+          text: t("windowChrome.items.newSession"),
           accelerator: "Ctrl+N",
           action: () => emitMenuEvent("menu-new-session"),
         },
         { type: "separator" },
         {
           type: "item",
-          text: "Open Folder...",
+          text: t("windowChrome.items.openFolder"),
           accelerator: "Ctrl+O",
           action: () => emitMenuEvent("menu-file-open-folder"),
         },
         {
           type: "item",
-          text: "Add Folder to Workspace...",
+          text: t("windowChrome.items.addFolderToWorkspace"),
           action: () => emitMenuEvent("menu-add-folder-to-workspace"),
         },
         { type: "separator" },
         {
           type: "item",
-          text: "Save Workspace As...",
+          text: t("windowChrome.items.saveWorkspaceAs"),
           action: () => emitMenuEvent("menu-save-workspace-as"),
         },
         { type: "separator" },
         {
           type: "item",
-          text: "Close Window",
+          text: t("windowChrome.items.closeWindow"),
           accelerator: "Ctrl+Shift+W",
           action: closeWindow,
+        },
+        { type: "separator" },
+        {
+          type: "item",
+          text: t("windowChrome.items.quitOrg2"),
+          accelerator: "Ctrl+Q",
+          action: () => emitMenuEvent("native-quit-confirmation-open"),
         },
       ];
     case "edit":
       return [
         {
           type: "item",
-          text: "Undo",
+          text: t("windowChrome.items.undo"),
           action: () => document.execCommand("undo"),
         },
         {
           type: "item",
-          text: "Redo",
+          text: t("windowChrome.items.redo"),
           action: () => document.execCommand("redo"),
         },
         { type: "separator" },
         {
           type: "item",
-          text: "Cut",
+          text: t("windowChrome.items.cut"),
           action: () => document.execCommand("cut"),
         },
         {
           type: "item",
-          text: "Copy",
+          text: t("windowChrome.items.copy"),
           action: () => document.execCommand("copy"),
         },
         {
           type: "item",
-          text: "Paste",
+          text: t("windowChrome.items.paste"),
           action: () => document.execCommand("paste"),
         },
         {
           type: "item",
-          text: "Select All",
+          text: t("windowChrome.items.selectAll"),
           action: () => emitMenuEvent("menu-select-all"),
         },
       ];
@@ -142,85 +135,97 @@ function getMenuItems(menu: NativeMenuKey): NativeMenuItem[] {
       return [
         {
           type: "item",
-          text: "Command Palette",
+          text: t("windowChrome.items.commandPalette"),
           action: () => emitMenuEvent("menu-toggle-spotlight"),
         },
         {
           type: "item",
-          text: "Go to File...",
+          text: t("windowChrome.items.goToFile"),
           action: () => emitMenuEvent("menu-open-file-palette"),
         },
         {
           type: "item",
-          text: "Select Model...",
+          text: t("windowChrome.items.selectModel"),
           accelerator: "Ctrl+/",
           action: () => emitMenuEvent("menu-open-model-selector"),
         },
         {
           type: "item",
-          text: "Switch Workspace...",
+          text: t("windowChrome.items.switchWorkspace"),
           accelerator: "Ctrl+.",
           action: () => emitMenuEvent("menu-open-workspace-selector"),
         },
         {
           type: "item",
-          text: "Switch Branch...",
+          text: t("windowChrome.items.switchBranch"),
           accelerator: "Ctrl+Alt+.",
           action: () => emitMenuEvent("menu-open-branch-selector"),
         },
         {
           type: "item",
-          text: "Switch Running Location...",
+          text: t("windowChrome.items.switchRunningLocation"),
           accelerator: "Ctrl+Shift+.",
           action: () => emitMenuEvent("menu-open-location-selector"),
         },
         { type: "separator" },
         {
           type: "item",
-          text: "Settings...",
+          text: t("windowChrome.items.settings"),
           accelerator: "Ctrl+,",
           action: () => emitMenuEvent("menu-open-settings"),
         },
         { type: "separator" },
         {
           type: "item",
-          text: "Zoom In",
+          text: t("windowChrome.items.zoomIn"),
           action: () => emitMenuEvent("menu-zoom-in"),
         },
         {
           type: "item",
-          text: "Zoom Out",
+          text: t("windowChrome.items.zoomOut"),
           action: () => emitMenuEvent("menu-zoom-out"),
         },
         {
           type: "item",
-          text: "Actual Size",
+          text: t("windowChrome.items.actualSize"),
           action: () => emitMenuEvent("menu-zoom-reset"),
         },
       ];
     case "window":
       return [
-        { type: "item", text: "Minimize", action: minWindow },
-        { type: "item", text: "Maximize / Restore", action: maxWindow },
         {
           type: "item",
-          text: "Maximize Workstation",
+          text: t("windowChrome.items.minimize"),
+          action: minWindow,
+        },
+        {
+          type: "item",
+          text: t("windowChrome.items.maximizeRestore"),
+          action: maxWindow,
+        },
+        {
+          type: "item",
+          text: t("windowChrome.items.maximizeWorkstation"),
           accelerator: "Ctrl+Shift+M",
           action: () => emitMenuEvent("menu-maximize-work-station"),
         },
         { type: "separator" },
-        { type: "item", text: "Close Window", action: closeWindow },
+        {
+          type: "item",
+          text: t("windowChrome.items.closeWindow"),
+          action: closeWindow,
+        },
       ];
     case "help":
       return [
         {
           type: "item",
-          text: "Documentation",
+          text: t("windowChrome.items.documentation"),
           action: () => open("https://github.com/YORG-AI/ORGII/wiki"),
         },
         {
           type: "item",
-          text: "Report Issue",
+          text: t("windowChrome.items.reportIssue"),
           action: () => open("https://github.com/YORG-AI/ORGII/issues"),
         },
       ];
@@ -229,10 +234,11 @@ function getMenuItems(menu: NativeMenuKey): NativeMenuItem[] {
 
 async function showNativeStyleMenu(
   menuKey: NativeMenuKey,
-  anchor: HTMLElement
+  anchor: HTMLElement,
+  t: TFunction
 ) {
   const menuItems = await Promise.all(
-    getMenuItems(menuKey).map(async (item) => {
+    getMenuItems(menuKey, t).map(async (item) => {
       if (item.type === "separator") {
         return PredefinedMenuItem.new({ item: "Separator" });
       }
@@ -259,6 +265,8 @@ async function showNativeStyleMenu(
 }
 
 const WindowsTopBarComponent: React.FC = () => {
+  const { t } = useTranslation("common");
+
   const handleMinimize = useCallback(() => {
     handleWindowAction(minWindow);
   }, []);
@@ -273,9 +281,9 @@ const WindowsTopBarComponent: React.FC = () => {
 
   const handleOpenMenu = useCallback(
     (menuKey: NativeMenuKey, event: React.MouseEvent<HTMLButtonElement>) => {
-      void showNativeStyleMenu(menuKey, event.currentTarget);
+      void showNativeStyleMenu(menuKey, event.currentTarget, t);
     },
-    []
+    [t]
   );
 
   return (
@@ -292,17 +300,20 @@ const WindowsTopBarComponent: React.FC = () => {
       }
     >
       <NoDragRegion className={MENU_BAR_CLASS}>
-        {MENU_LABELS.map((menu) => (
-          <button
-            key={menu.key}
-            type="button"
-            className={MENU_BUTTON_CLASS}
-            onClick={(event) => handleOpenMenu(menu.key, event)}
-            aria-label={`${menu.label} menu`}
-          >
-            {menu.label}
-          </button>
-        ))}
+        {MENU_KEYS.map((menuKey) => {
+          const label = t(`windowChrome.menus.${menuKey}`);
+          return (
+            <button
+              key={menuKey}
+              type="button"
+              className={MENU_BUTTON_CLASS}
+              onClick={(event) => handleOpenMenu(menuKey, event)}
+              aria-label={t("windowChrome.menus.aria", { label })}
+            >
+              {label}
+            </button>
+          );
+        })}
       </NoDragRegion>
 
       <div className="h-full min-w-0 flex-1" data-tauri-drag-region />
@@ -315,8 +326,8 @@ const WindowsTopBarComponent: React.FC = () => {
           type="button"
           className={WINDOW_CONTROL_BUTTON_CLASS}
           onClick={handleMinimize}
-          aria-label="Minimize window"
-          title="Minimize"
+          aria-label={t("windowChrome.controls.minimizeWindow")}
+          title={t("windowChrome.items.minimize")}
         >
           <Minus size={ICON_SIZE} strokeWidth={2} />
         </button>
@@ -324,8 +335,8 @@ const WindowsTopBarComponent: React.FC = () => {
           type="button"
           className={WINDOW_CONTROL_BUTTON_CLASS}
           onClick={handleMaximize}
-          aria-label="Maximize or restore window"
-          title="Maximize / Restore"
+          aria-label={t("windowChrome.controls.maximizeRestoreWindow")}
+          title={t("windowChrome.items.maximizeRestore")}
         >
           <Square size={12} strokeWidth={2} />
         </button>
@@ -333,8 +344,8 @@ const WindowsTopBarComponent: React.FC = () => {
           type="button"
           className={CLOSE_BUTTON_CLASS}
           onClick={handleClose}
-          aria-label="Close window"
-          title="Close"
+          aria-label={t("windowChrome.controls.closeWindow")}
+          title={t("windowChrome.items.closeWindow")}
         >
           <X size={ICON_SIZE} strokeWidth={2} />
         </button>

--- a/src/components/WindowChrome/WindowsTopBar.tsx
+++ b/src/components/WindowChrome/WindowsTopBar.tsx
@@ -7,9 +7,9 @@ import {
 import { open } from "@tauri-apps/plugin-shell";
 import type { TFunction } from "i18next";
 import { Minus, Square, X } from "lucide-react";
-import React, { memo, useCallback } from "react";
-import { useTranslation } from "react-i18next";
+import React, { memo, useCallback, useMemo, useSyncExternalStore } from "react";
 
+import i18n from "@src/i18n";
 import {
   closeWindow,
   maxWindow,
@@ -33,6 +33,13 @@ const CLOSE_BUTTON_CLASS =
   "flex h-full w-11 items-center justify-center border-0 bg-transparent p-0 text-text-2 transition-colors hover:bg-danger-6 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-danger-6/30";
 
 type NativeMenuKey = "file" | "edit" | "view" | "window" | "help";
+
+const subscribeToLanguageChange = (onStoreChange: () => void) => {
+  i18n.on("languageChanged", onStoreChange);
+  return () => i18n.off("languageChanged", onStoreChange);
+};
+
+const getActiveLanguage = () => i18n.resolvedLanguage ?? i18n.language ?? "en";
 
 type NativeMenuItem =
   | {
@@ -265,7 +272,15 @@ async function showNativeStyleMenu(
 }
 
 const WindowsTopBarComponent: React.FC = () => {
-  const { t } = useTranslation("common");
+  const activeLanguage = useSyncExternalStore(
+    subscribeToLanguageChange,
+    getActiveLanguage,
+    getActiveLanguage
+  );
+  const t = useMemo(
+    () => i18n.getFixedT(activeLanguage, "common"),
+    [activeLanguage]
+  );
 
   const handleMinimize = useCallback(() => {
     handleWindowAction(minWindow);

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -164,6 +164,50 @@
       "urgent": "Dringend"
     }
   },
+  "windowChrome": {
+    "menus": {
+      "file": "Datei",
+      "edit": "Bearbeiten",
+      "view": "Ansicht",
+      "window": "Fenster",
+      "help": "Hilfe",
+      "aria": "Menü {{label}}"
+    },
+    "items": {
+      "quitOrg2": "ORG-2 beenden",
+      "newSession": "Neue Sitzung",
+      "openFolder": "Ordner öffnen...",
+      "addFolderToWorkspace": "Ordner zum Arbeitsbereich hinzufügen...",
+      "saveWorkspaceAs": "Arbeitsbereich speichern unter...",
+      "closeWindow": "Fenster schließen",
+      "undo": "Rückgängig",
+      "redo": "Wiederholen",
+      "cut": "Ausschneiden",
+      "copy": "Kopieren",
+      "paste": "Einfügen",
+      "selectAll": "Alles auswählen",
+      "commandPalette": "Befehlspalette",
+      "goToFile": "Zu Datei wechseln...",
+      "selectModel": "Modell auswählen...",
+      "switchWorkspace": "Arbeitsbereich wechseln...",
+      "switchBranch": "Branch wechseln...",
+      "switchRunningLocation": "Ausführungsort wechseln...",
+      "settings": "Einstellungen...",
+      "zoomIn": "Vergrößern",
+      "zoomOut": "Verkleinern",
+      "actualSize": "Originalgröße",
+      "minimize": "Minimieren",
+      "maximizeRestore": "Maximieren / Wiederherstellen",
+      "maximizeWorkstation": "Arbeitsstation maximieren",
+      "documentation": "Dokumentation",
+      "reportIssue": "Problem melden"
+    },
+    "controls": {
+      "minimizeWindow": "Fenster minimieren",
+      "maximizeRestoreWindow": "Fenster maximieren oder wiederherstellen",
+      "closeWindow": "Fenster schließen"
+    }
+  },
   "toasts": {
     "replyEmpty": "Antwort darf nicht leer sein",
     "sessionNotFound": "Sitzung nicht gefunden",
@@ -2475,8 +2519,8 @@
     "selectRepoToStart": "Repo auswählen, um zu starten"
   },
   "quitConfirmation": {
-    "title": "ORGII beenden?",
-    "subtitle": "Laufende Sitzungen behalten ihren aktuellen Zustand. Sie können ORGII später erneut öffnen.",
+    "title": "ORG-2 beenden?",
+    "subtitle": "Laufende Sitzungen behalten ihren aktuellen Zustand. Sie können ORG-2 später erneut öffnen.",
     "cancel": "Abbrechen",
     "confirm": "Beenden"
   },

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1,4 +1,48 @@
 ﻿{
+  "windowChrome": {
+    "menus": {
+      "file": "File",
+      "edit": "Edit",
+      "view": "View",
+      "window": "Window",
+      "help": "Help",
+      "aria": "{{label}} menu"
+    },
+    "items": {
+      "quitOrg2": "Quit ORG-2",
+      "newSession": "New Session",
+      "openFolder": "Open Folder...",
+      "addFolderToWorkspace": "Add Folder to Workspace...",
+      "saveWorkspaceAs": "Save Workspace As...",
+      "closeWindow": "Close Window",
+      "undo": "Undo",
+      "redo": "Redo",
+      "cut": "Cut",
+      "copy": "Copy",
+      "paste": "Paste",
+      "selectAll": "Select All",
+      "commandPalette": "Command Palette",
+      "goToFile": "Go to File...",
+      "selectModel": "Select Model...",
+      "switchWorkspace": "Switch Workspace...",
+      "switchBranch": "Switch Branch...",
+      "switchRunningLocation": "Switch Running Location...",
+      "settings": "Settings...",
+      "zoomIn": "Zoom In",
+      "zoomOut": "Zoom Out",
+      "actualSize": "Actual Size",
+      "minimize": "Minimize",
+      "maximizeRestore": "Maximize / Restore",
+      "maximizeWorkstation": "Maximize Workstation",
+      "documentation": "Documentation",
+      "reportIssue": "Report Issue"
+    },
+    "controls": {
+      "minimizeWindow": "Minimize window",
+      "maximizeRestoreWindow": "Maximize or restore window",
+      "closeWindow": "Close window"
+    }
+  },
   "toasts": {
     "replyEmpty": "Reply cannot be empty",
     "sessionNotFound": "Session not found",
@@ -2684,8 +2728,8 @@
     "previewAlt": "Preview"
   },
   "quitConfirmation": {
-    "title": "Quit ORGII?",
-    "subtitle": "Any running sessions will keep their current state. You can reopen ORGII later.",
+    "title": "Quit ORG-2?",
+    "subtitle": "Any running sessions will keep their current state. You can reopen ORG-2 later.",
     "cancel": "Cancel",
     "confirm": "Quit"
   },

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -164,6 +164,50 @@
       "urgent": "Urgente"
     }
   },
+  "windowChrome": {
+    "menus": {
+      "file": "Archivo",
+      "edit": "Editar",
+      "view": "Ver",
+      "window": "Ventana",
+      "help": "Ayuda",
+      "aria": "Menú {{label}}"
+    },
+    "items": {
+      "quitOrg2": "Salir de ORG-2",
+      "newSession": "Nueva sesión",
+      "openFolder": "Abrir carpeta...",
+      "addFolderToWorkspace": "Añadir carpeta al espacio de trabajo...",
+      "saveWorkspaceAs": "Guardar espacio de trabajo como...",
+      "closeWindow": "Cerrar ventana",
+      "undo": "Deshacer",
+      "redo": "Rehacer",
+      "cut": "Cortar",
+      "copy": "Copiar",
+      "paste": "Pegar",
+      "selectAll": "Seleccionar todo",
+      "commandPalette": "Paleta de comandos",
+      "goToFile": "Ir al archivo...",
+      "selectModel": "Seleccionar modelo...",
+      "switchWorkspace": "Cambiar espacio de trabajo...",
+      "switchBranch": "Cambiar rama...",
+      "switchRunningLocation": "Cambiar ubicación de ejecución...",
+      "settings": "Configuración...",
+      "zoomIn": "Acercar",
+      "zoomOut": "Alejar",
+      "actualSize": "Tamaño real",
+      "minimize": "Minimizar",
+      "maximizeRestore": "Maximizar / Restaurar",
+      "maximizeWorkstation": "Maximizar estación de trabajo",
+      "documentation": "Documentación",
+      "reportIssue": "Informar de un problema"
+    },
+    "controls": {
+      "minimizeWindow": "Minimizar ventana",
+      "maximizeRestoreWindow": "Maximizar o restaurar ventana",
+      "closeWindow": "Cerrar ventana"
+    }
+  },
   "toasts": {
     "replyEmpty": "La respuesta no puede estar vacía",
     "sessionNotFound": "Sesión no encontrada",
@@ -2467,8 +2511,8 @@
     "selectRepoToStart": "Selecciona un Repo para empezar"
   },
   "quitConfirmation": {
-    "title": "¿Salir de ORGII?",
-    "subtitle": "Las sesiones en ejecución conservarán su estado actual. Puedes volver a abrir ORGII más tarde.",
+    "title": "¿Salir de ORG-2?",
+    "subtitle": "Las sesiones en ejecución conservarán su estado actual. Puedes volver a abrir ORG-2 más tarde.",
     "cancel": "Cancelar",
     "confirm": "Salir"
   },

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -164,6 +164,50 @@
       "urgent": "Urgente"
     }
   },
+  "windowChrome": {
+    "menus": {
+      "file": "Fichier",
+      "edit": "Édition",
+      "view": "Affichage",
+      "window": "Fenêtre",
+      "help": "Aide",
+      "aria": "Menu {{label}}"
+    },
+    "items": {
+      "quitOrg2": "Quitter ORG-2",
+      "newSession": "Nouvelle session",
+      "openFolder": "Ouvrir un dossier...",
+      "addFolderToWorkspace": "Ajouter un dossier à l’espace de travail...",
+      "saveWorkspaceAs": "Enregistrer l’espace de travail sous...",
+      "closeWindow": "Fermer la fenêtre",
+      "undo": "Annuler",
+      "redo": "Rétablir",
+      "cut": "Couper",
+      "copy": "Copier",
+      "paste": "Coller",
+      "selectAll": "Tout sélectionner",
+      "commandPalette": "Palette de commandes",
+      "goToFile": "Accéder au fichier...",
+      "selectModel": "Sélectionner un modèle...",
+      "switchWorkspace": "Changer d’espace de travail...",
+      "switchBranch": "Changer de branche...",
+      "switchRunningLocation": "Changer d’emplacement d’exécution...",
+      "settings": "Paramètres...",
+      "zoomIn": "Zoom avant",
+      "zoomOut": "Zoom arrière",
+      "actualSize": "Taille réelle",
+      "minimize": "Réduire",
+      "maximizeRestore": "Agrandir / Restaurer",
+      "maximizeWorkstation": "Agrandir la station de travail",
+      "documentation": "Documentation",
+      "reportIssue": "Signaler un problème"
+    },
+    "controls": {
+      "minimizeWindow": "Réduire la fenêtre",
+      "maximizeRestoreWindow": "Agrandir ou restaurer la fenêtre",
+      "closeWindow": "Fermer la fenêtre"
+    }
+  },
   "toasts": {
     "replyEmpty": "La réponse ne peut pas être vide",
     "sessionNotFound": "Session introuvable",
@@ -2470,8 +2514,8 @@
     "selectRepoToStart": "Sélectionnez un Repo pour commencer"
   },
   "quitConfirmation": {
-    "title": "Quitter ORGII ?",
-    "subtitle": "Les sessions en cours conserveront leur état actuel. Vous pourrez rouvrir ORGII plus tard.",
+    "title": "Quitter ORG-2 ?",
+    "subtitle": "Les sessions en cours conserveront leur état actuel. Vous pourrez rouvrir ORG-2 plus tard.",
     "cancel": "Annuler",
     "confirm": "Quitter"
   },

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -162,6 +162,50 @@
       "urgent": "緊急"
     }
   },
+  "windowChrome": {
+    "menus": {
+      "file": "ファイル",
+      "edit": "編集",
+      "view": "表示",
+      "window": "ウィンドウ",
+      "help": "ヘルプ",
+      "aria": "{{label}}メニュー"
+    },
+    "items": {
+      "quitOrg2": "ORG-2を終了",
+      "newSession": "新しいセッション",
+      "openFolder": "フォルダーを開く...",
+      "addFolderToWorkspace": "ワークスペースにフォルダーを追加...",
+      "saveWorkspaceAs": "ワークスペースに名前を付けて保存...",
+      "closeWindow": "ウィンドウを閉じる",
+      "undo": "元に戻す",
+      "redo": "やり直す",
+      "cut": "切り取り",
+      "copy": "コピー",
+      "paste": "貼り付け",
+      "selectAll": "すべて選択",
+      "commandPalette": "コマンドパレット",
+      "goToFile": "ファイルに移動...",
+      "selectModel": "モデルを選択...",
+      "switchWorkspace": "ワークスペースを切り替え...",
+      "switchBranch": "ブランチを切り替え...",
+      "switchRunningLocation": "実行場所を切り替え...",
+      "settings": "設定...",
+      "zoomIn": "拡大",
+      "zoomOut": "縮小",
+      "actualSize": "実際のサイズ",
+      "minimize": "最小化",
+      "maximizeRestore": "最大化 / 元に戻す",
+      "maximizeWorkstation": "ワークステーションを最大化",
+      "documentation": "ドキュメント",
+      "reportIssue": "問題を報告"
+    },
+    "controls": {
+      "minimizeWindow": "ウィンドウを最小化",
+      "maximizeRestoreWindow": "ウィンドウを最大化または元に戻す",
+      "closeWindow": "ウィンドウを閉じる"
+    }
+  },
   "toasts": {
     "replyEmpty": "返信を入力してください",
     "sessionNotFound": "セッションが見つかりません",
@@ -2470,8 +2514,8 @@
     "selectRepoToStart": "Repo を選択して開始"
   },
   "quitConfirmation": {
-    "title": "ORGII を終了しますか？",
-    "subtitle": "実行中のセッションは現在の状態を保持します。後で ORGII を再度開くことができます。",
+    "title": "ORG-2 を終了しますか？",
+    "subtitle": "実行中のセッションは現在の状態を保持します。後で ORG-2 を再度開くことができます。",
     "cancel": "キャンセル",
     "confirm": "終了"
   },

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -162,6 +162,50 @@
       "urgent": "긴급"
     }
   },
+  "windowChrome": {
+    "menus": {
+      "file": "파일",
+      "edit": "편집",
+      "view": "보기",
+      "window": "창",
+      "help": "도움말",
+      "aria": "{{label}} 메뉴"
+    },
+    "items": {
+      "quitOrg2": "ORG-2 종료",
+      "newSession": "새 세션",
+      "openFolder": "폴더 열기...",
+      "addFolderToWorkspace": "작업 영역에 폴더 추가...",
+      "saveWorkspaceAs": "작업 영역을 다른 이름으로 저장...",
+      "closeWindow": "창 닫기",
+      "undo": "실행 취소",
+      "redo": "다시 실행",
+      "cut": "잘라내기",
+      "copy": "복사",
+      "paste": "붙여넣기",
+      "selectAll": "모두 선택",
+      "commandPalette": "명령 팔레트",
+      "goToFile": "파일로 이동...",
+      "selectModel": "모델 선택...",
+      "switchWorkspace": "작업 영역 전환...",
+      "switchBranch": "브랜치 전환...",
+      "switchRunningLocation": "실행 위치 전환...",
+      "settings": "설정...",
+      "zoomIn": "확대",
+      "zoomOut": "축소",
+      "actualSize": "실제 크기",
+      "minimize": "최소화",
+      "maximizeRestore": "최대화 / 복원",
+      "maximizeWorkstation": "워크스테이션 최대화",
+      "documentation": "문서",
+      "reportIssue": "문제 신고"
+    },
+    "controls": {
+      "minimizeWindow": "창 최소화",
+      "maximizeRestoreWindow": "창 최대화 또는 복원",
+      "closeWindow": "창 닫기"
+    }
+  },
   "toasts": {
     "replyEmpty": "답장을 입력하세요",
     "sessionNotFound": "세션을 찾을 수 없습니다",
@@ -2468,8 +2512,8 @@
     "selectRepoToStart": "Repo를 선택하여 시작"
   },
   "quitConfirmation": {
-    "title": "ORGII를 종료하시겠습니까?",
-    "subtitle": "실행 중인 세션은 현재 상태를 유지합니다. 나중에 ORGII를 다시 열 수 있습니다.",
+    "title": "ORG-2를 종료하시겠습니까?",
+    "subtitle": "실행 중인 세션은 현재 상태를 유지합니다. 나중에 ORG-2를 다시 열 수 있습니다.",
     "cancel": "취소",
     "confirm": "종료"
   },

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -168,6 +168,50 @@
       "urgent": "Pilny"
     }
   },
+  "windowChrome": {
+    "menus": {
+      "file": "Plik",
+      "edit": "Edycja",
+      "view": "Widok",
+      "window": "Okno",
+      "help": "Pomoc",
+      "aria": "Menu {{label}}"
+    },
+    "items": {
+      "quitOrg2": "Zakończ ORG-2",
+      "newSession": "Nowa sesja",
+      "openFolder": "Otwórz folder...",
+      "addFolderToWorkspace": "Dodaj folder do obszaru roboczego...",
+      "saveWorkspaceAs": "Zapisz obszar roboczy jako...",
+      "closeWindow": "Zamknij okno",
+      "undo": "Cofnij",
+      "redo": "Ponów",
+      "cut": "Wytnij",
+      "copy": "Kopiuj",
+      "paste": "Wklej",
+      "selectAll": "Zaznacz wszystko",
+      "commandPalette": "Paleta poleceń",
+      "goToFile": "Przejdź do pliku...",
+      "selectModel": "Wybierz model...",
+      "switchWorkspace": "Przełącz obszar roboczy...",
+      "switchBranch": "Przełącz gałąź...",
+      "switchRunningLocation": "Przełącz lokalizację uruchomienia...",
+      "settings": "Ustawienia...",
+      "zoomIn": "Powiększ",
+      "zoomOut": "Pomniejsz",
+      "actualSize": "Rozmiar rzeczywisty",
+      "minimize": "Minimalizuj",
+      "maximizeRestore": "Maksymalizuj / Przywróć",
+      "maximizeWorkstation": "Maksymalizuj stację roboczą",
+      "documentation": "Dokumentacja",
+      "reportIssue": "Zgłoś problem"
+    },
+    "controls": {
+      "minimizeWindow": "Minimalizuj okno",
+      "maximizeRestoreWindow": "Maksymalizuj lub przywróć okno",
+      "closeWindow": "Zamknij okno"
+    }
+  },
   "toasts": {
     "replyEmpty": "Odpowiedź nie może być pusta",
     "sessionNotFound": "Nie znaleziono sesji",
@@ -2475,8 +2519,8 @@
     "selectRepoToStart": "Wybierz Repo, aby rozpocząć"
   },
   "quitConfirmation": {
-    "title": "Zamknąć ORGII?",
-    "subtitle": "Uruchomione sesje zachowają swój bieżący stan. Możesz ponownie otworzyć ORGII później.",
+    "title": "Zamknąć ORG-2?",
+    "subtitle": "Uruchomione sesje zachowają swój bieżący stan. Możesz ponownie otworzyć ORG-2 później.",
     "cancel": "Anuluj",
     "confirm": "Zamknij"
   },

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -164,6 +164,50 @@
       "urgent": "Urgente"
     }
   },
+  "windowChrome": {
+    "menus": {
+      "file": "Arquivo",
+      "edit": "Editar",
+      "view": "Exibir",
+      "window": "Janela",
+      "help": "Ajuda",
+      "aria": "Menu {{label}}"
+    },
+    "items": {
+      "quitOrg2": "Sair do ORG-2",
+      "newSession": "Nova sessão",
+      "openFolder": "Abrir pasta...",
+      "addFolderToWorkspace": "Adicionar pasta ao espaço de trabalho...",
+      "saveWorkspaceAs": "Salvar espaço de trabalho como...",
+      "closeWindow": "Fechar janela",
+      "undo": "Desfazer",
+      "redo": "Refazer",
+      "cut": "Recortar",
+      "copy": "Copiar",
+      "paste": "Colar",
+      "selectAll": "Selecionar tudo",
+      "commandPalette": "Paleta de comandos",
+      "goToFile": "Ir para arquivo...",
+      "selectModel": "Selecionar modelo...",
+      "switchWorkspace": "Alternar espaço de trabalho...",
+      "switchBranch": "Alternar branch...",
+      "switchRunningLocation": "Alternar local de execução...",
+      "settings": "Configurações...",
+      "zoomIn": "Ampliar",
+      "zoomOut": "Reduzir",
+      "actualSize": "Tamanho real",
+      "minimize": "Minimizar",
+      "maximizeRestore": "Maximizar / Restaurar",
+      "maximizeWorkstation": "Maximizar estação de trabalho",
+      "documentation": "Documentação",
+      "reportIssue": "Relatar problema"
+    },
+    "controls": {
+      "minimizeWindow": "Minimizar janela",
+      "maximizeRestoreWindow": "Maximizar ou restaurar janela",
+      "closeWindow": "Fechar janela"
+    }
+  },
   "toasts": {
     "replyEmpty": "A resposta não pode estar vazia",
     "sessionNotFound": "Sessão não encontrada",
@@ -2467,8 +2511,8 @@
     "selectRepoToStart": "Selecione um Repo para começar"
   },
   "quitConfirmation": {
-    "title": "Sair do ORGII?",
-    "subtitle": "As sessões em execução manterão o estado atual. Você poderá reabrir o ORGII mais tarde.",
+    "title": "Sair do ORG-2?",
+    "subtitle": "As sessões em execução manterão o estado atual. Você poderá reabrir o ORG-2 mais tarde.",
     "cancel": "Cancelar",
     "confirm": "Sair"
   },

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -168,6 +168,50 @@
       "urgent": "Срочный"
     }
   },
+  "windowChrome": {
+    "menus": {
+      "file": "Файл",
+      "edit": "Правка",
+      "view": "Вид",
+      "window": "Окно",
+      "help": "Справка",
+      "aria": "Меню «{{label}}»"
+    },
+    "items": {
+      "quitOrg2": "Выйти из ORG-2",
+      "newSession": "Новый сеанс",
+      "openFolder": "Открыть папку...",
+      "addFolderToWorkspace": "Добавить папку в рабочую область...",
+      "saveWorkspaceAs": "Сохранить рабочую область как...",
+      "closeWindow": "Закрыть окно",
+      "undo": "Отменить",
+      "redo": "Повторить",
+      "cut": "Вырезать",
+      "copy": "Копировать",
+      "paste": "Вставить",
+      "selectAll": "Выделить всё",
+      "commandPalette": "Палитра команд",
+      "goToFile": "Перейти к файлу...",
+      "selectModel": "Выбрать модель...",
+      "switchWorkspace": "Сменить рабочую область...",
+      "switchBranch": "Сменить ветку...",
+      "switchRunningLocation": "Сменить место выполнения...",
+      "settings": "Настройки...",
+      "zoomIn": "Увеличить",
+      "zoomOut": "Уменьшить",
+      "actualSize": "Фактический размер",
+      "minimize": "Свернуть",
+      "maximizeRestore": "Развернуть / Восстановить",
+      "maximizeWorkstation": "Развернуть рабочую станцию",
+      "documentation": "Документация",
+      "reportIssue": "Сообщить о проблеме"
+    },
+    "controls": {
+      "minimizeWindow": "Свернуть окно",
+      "maximizeRestoreWindow": "Развернуть или восстановить окно",
+      "closeWindow": "Закрыть окно"
+    }
+  },
   "toasts": {
     "replyEmpty": "Ответ не может быть пустым",
     "sessionNotFound": "Сессия не найдена",
@@ -2475,8 +2519,8 @@
     "selectRepoToStart": "Выберите Repo, чтобы начать"
   },
   "quitConfirmation": {
-    "title": "Выйти из ORGII?",
-    "subtitle": "Запущенные сеансы сохранят текущее состояние. Вы сможете открыть ORGII позже.",
+    "title": "Выйти из ORG-2?",
+    "subtitle": "Запущенные сеансы сохранят текущее состояние. Вы сможете открыть ORG-2 позже.",
     "cancel": "Отмена",
     "confirm": "Выйти"
   },

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -164,6 +164,50 @@
       "urgent": "Acil"
     }
   },
+  "windowChrome": {
+    "menus": {
+      "file": "Dosya",
+      "edit": "Düzenle",
+      "view": "Görünüm",
+      "window": "Pencere",
+      "help": "Yardım",
+      "aria": "{{label}} menüsü"
+    },
+    "items": {
+      "quitOrg2": "ORG-2'den Çık",
+      "newSession": "Yeni Oturum",
+      "openFolder": "Klasör Aç...",
+      "addFolderToWorkspace": "Çalışma Alanına Klasör Ekle...",
+      "saveWorkspaceAs": "Çalışma Alanını Farklı Kaydet...",
+      "closeWindow": "Pencereyi Kapat",
+      "undo": "Geri Al",
+      "redo": "Yinele",
+      "cut": "Kes",
+      "copy": "Kopyala",
+      "paste": "Yapıştır",
+      "selectAll": "Tümünü Seç",
+      "commandPalette": "Komut Paleti",
+      "goToFile": "Dosyaya Git...",
+      "selectModel": "Model Seç...",
+      "switchWorkspace": "Çalışma Alanını Değiştir...",
+      "switchBranch": "Dal Değiştir...",
+      "switchRunningLocation": "Çalışma Konumunu Değiştir...",
+      "settings": "Ayarlar...",
+      "zoomIn": "Yakınlaştır",
+      "zoomOut": "Uzaklaştır",
+      "actualSize": "Gerçek Boyut",
+      "minimize": "Küçült",
+      "maximizeRestore": "Büyüt / Geri Yükle",
+      "maximizeWorkstation": "Çalışma İstasyonunu Büyüt",
+      "documentation": "Belgeler",
+      "reportIssue": "Sorun Bildir"
+    },
+    "controls": {
+      "minimizeWindow": "Pencereyi küçült",
+      "maximizeRestoreWindow": "Pencereyi büyüt veya geri yükle",
+      "closeWindow": "Pencereyi kapat"
+    }
+  },
   "toasts": {
     "replyEmpty": "Yanıt boş olamaz",
     "sessionNotFound": "Oturum bulunamadı",
@@ -2472,8 +2516,8 @@
     "selectRepoToStart": "Başlamak için bir Repo seçin"
   },
   "quitConfirmation": {
-    "title": "ORGII'den çıkılsın mı?",
-    "subtitle": "Çalışan oturumlar mevcut durumunu korur. ORGII'yi daha sonra yeniden açabilirsiniz.",
+    "title": "ORG-2'den çıkılsın mı?",
+    "subtitle": "Çalışan oturumlar mevcut durumunu korur. ORG-2'yi daha sonra yeniden açabilirsiniz.",
     "cancel": "İptal",
     "confirm": "Çık"
   },

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -162,6 +162,50 @@
       "urgent": "Khẩn cấp"
     }
   },
+  "windowChrome": {
+    "menus": {
+      "file": "Tệp",
+      "edit": "Chỉnh sửa",
+      "view": "Xem",
+      "window": "Cửa sổ",
+      "help": "Trợ giúp",
+      "aria": "Trình đơn {{label}}"
+    },
+    "items": {
+      "quitOrg2": "Thoát ORG-2",
+      "newSession": "Phiên mới",
+      "openFolder": "Mở thư mục...",
+      "addFolderToWorkspace": "Thêm thư mục vào không gian làm việc...",
+      "saveWorkspaceAs": "Lưu không gian làm việc thành...",
+      "closeWindow": "Đóng cửa sổ",
+      "undo": "Hoàn tác",
+      "redo": "Làm lại",
+      "cut": "Cắt",
+      "copy": "Sao chép",
+      "paste": "Dán",
+      "selectAll": "Chọn tất cả",
+      "commandPalette": "Bảng lệnh",
+      "goToFile": "Đi tới tệp...",
+      "selectModel": "Chọn mô hình...",
+      "switchWorkspace": "Chuyển không gian làm việc...",
+      "switchBranch": "Chuyển nhánh...",
+      "switchRunningLocation": "Chuyển vị trí chạy...",
+      "settings": "Cài đặt...",
+      "zoomIn": "Phóng to",
+      "zoomOut": "Thu nhỏ",
+      "actualSize": "Kích thước thực",
+      "minimize": "Thu nhỏ",
+      "maximizeRestore": "Phóng to / Khôi phục",
+      "maximizeWorkstation": "Phóng to trạm làm việc",
+      "documentation": "Tài liệu",
+      "reportIssue": "Báo cáo sự cố"
+    },
+    "controls": {
+      "minimizeWindow": "Thu nhỏ cửa sổ",
+      "maximizeRestoreWindow": "Phóng to hoặc khôi phục cửa sổ",
+      "closeWindow": "Đóng cửa sổ"
+    }
+  },
   "toasts": {
     "replyEmpty": "Câu trả lời không được để trống",
     "sessionNotFound": "Không tìm thấy phiên",
@@ -2465,8 +2509,8 @@
     "selectRepoToStart": "Chọn một Repo để bắt đầu"
   },
   "quitConfirmation": {
-    "title": "Thoát ORGII?",
-    "subtitle": "Các phiên đang chạy sẽ giữ nguyên trạng thái hiện tại. Bạn có thể mở lại ORGII sau.",
+    "title": "Thoát ORG-2?",
+    "subtitle": "Các phiên đang chạy sẽ giữ nguyên trạng thái hiện tại. Bạn có thể mở lại ORG-2 sau.",
     "cancel": "Hủy",
     "confirm": "Thoát"
   },

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -162,6 +162,50 @@
       "urgent": "緊急"
     }
   },
+  "windowChrome": {
+    "menus": {
+      "file": "檔案",
+      "edit": "編輯",
+      "view": "檢視",
+      "window": "視窗",
+      "help": "說明",
+      "aria": "{{label}}選單"
+    },
+    "items": {
+      "quitOrg2": "結束 ORG-2",
+      "newSession": "新增工作階段",
+      "openFolder": "開啟資料夾...",
+      "addFolderToWorkspace": "將資料夾新增至工作區...",
+      "saveWorkspaceAs": "工作區另存新檔...",
+      "closeWindow": "關閉視窗",
+      "undo": "復原",
+      "redo": "重做",
+      "cut": "剪下",
+      "copy": "複製",
+      "paste": "貼上",
+      "selectAll": "全選",
+      "commandPalette": "命令選擇區",
+      "goToFile": "前往檔案...",
+      "selectModel": "選擇模型...",
+      "switchWorkspace": "切換工作區...",
+      "switchBranch": "切換分支...",
+      "switchRunningLocation": "切換執行位置...",
+      "settings": "設定...",
+      "zoomIn": "放大",
+      "zoomOut": "縮小",
+      "actualSize": "實際大小",
+      "minimize": "最小化",
+      "maximizeRestore": "最大化 / 還原",
+      "maximizeWorkstation": "最大化工作站",
+      "documentation": "文件",
+      "reportIssue": "回報問題"
+    },
+    "controls": {
+      "minimizeWindow": "最小化視窗",
+      "maximizeRestoreWindow": "最大化或還原視窗",
+      "closeWindow": "關閉視窗"
+    }
+  },
   "toasts": {
     "replyEmpty": "回覆不能為空",
     "sessionNotFound": "找不到 Session",
@@ -2495,8 +2539,8 @@
     "selectRepoToStart": "選擇一個 Repo 開始"
   },
   "quitConfirmation": {
-    "title": "結束 ORGII？",
-    "subtitle": "正在執行的工作階段會保留目前狀態。你可以稍後重新開啟 ORGII。",
+    "title": "結束 ORG-2？",
+    "subtitle": "正在執行的工作階段會保留目前狀態。你可以稍後重新開啟 ORG-2。",
     "cancel": "取消",
     "confirm": "結束"
   },

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -1,4 +1,48 @@
 ﻿{
+  "windowChrome": {
+    "menus": {
+      "file": "文件",
+      "edit": "编辑",
+      "view": "查看",
+      "window": "窗口",
+      "help": "帮助",
+      "aria": "{{label}}菜单"
+    },
+    "items": {
+      "quitOrg2": "退出 ORG-2",
+      "newSession": "新建会话",
+      "openFolder": "打开文件夹...",
+      "addFolderToWorkspace": "将文件夹添加到工作区...",
+      "saveWorkspaceAs": "工作区另存为...",
+      "closeWindow": "关闭窗口",
+      "undo": "撤销",
+      "redo": "重做",
+      "cut": "剪切",
+      "copy": "复制",
+      "paste": "粘贴",
+      "selectAll": "全选",
+      "commandPalette": "命令面板",
+      "goToFile": "转到文件...",
+      "selectModel": "选择模型...",
+      "switchWorkspace": "切换工作区...",
+      "switchBranch": "切换分支...",
+      "switchRunningLocation": "切换运行位置...",
+      "settings": "设置...",
+      "zoomIn": "放大",
+      "zoomOut": "缩小",
+      "actualSize": "实际大小",
+      "minimize": "最小化",
+      "maximizeRestore": "最大化 / 还原",
+      "maximizeWorkstation": "最大化工作台",
+      "documentation": "文档",
+      "reportIssue": "报告问题"
+    },
+    "controls": {
+      "minimizeWindow": "最小化窗口",
+      "maximizeRestoreWindow": "最大化或还原窗口",
+      "closeWindow": "关闭窗口"
+    }
+  },
   "toasts": {
     "replyEmpty": "回复不能为空",
     "sessionNotFound": "未找到会话",
@@ -2564,8 +2608,8 @@
     "previewAlt": "预览"
   },
   "quitConfirmation": {
-    "title": "退出 ORGII？",
-    "subtitle": "正在运行的会话会保留当前状态。你可以稍后重新打开 ORGII。",
+    "title": "退出 ORG-2？",
+    "subtitle": "正在运行的会话会保留当前状态。你可以稍后重新打开 ORG-2。",
     "cancel": "取消",
     "confirm": "退出"
   },


### PR DESCRIPTION
## Problem

Windows menu headers could remain in the previous language after changing the app language, requiring another render or restart before the custom title bar caught up.

## Solution

Subscribe the Windows top bar directly to i18next language changes using `useSyncExternalStore`.

The title bar now creates a language-fixed translator whenever the active language changes, keeping menu headers, accessibility labels, window controls, and newly opened native menus synchronized immediately.

macOS behavior is unchanged.

## Potential risks

The Windows title bar now depends directly on the shared i18n instance. This matches the app's current single-instance localization architecture, but would need revisiting if multiple i18n instances are introduced later.

## Verification

- Ran the Tauri development app successfully; Webpack rebuilt to 100%.
- Switched the running Windows app from English to Spanish to Korean to English.
- Pre-commit formatting, ESLint, and staged-file checks passed.
- `git diff --check` passed.