### PR TITLE
fix(key-vault): add Atlas Cloud Claude Code compatibility

### DIFF
--- a/src-tauri/crates/agent-core/src/core/providers/registry.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/registry.rs
@@ -158,7 +158,7 @@ pub static PROVIDERS: &[ProviderSpec] = &[
         litellm_prefix: None,
         skip_prefixes: &["atlascloud/"],
         default_api_base: Some("https://api.atlascloud.ai/v1"),
-        default_anthropic_api_base: None,
+        default_anthropic_api_base: Some("https://api.atlascloud.ai"),
         is_local: false,
         env_key: Some("ATLASCLOUD_API_KEY"),
     },

--- a/src-tauri/crates/key-vault/src/commands/registry/data/cli_agents.rs
+++ b/src-tauri/crates/key-vault/src/commands/registry/data/cli_agents.rs
@@ -102,6 +102,7 @@ pub(crate) fn cli_agent_registry() -> Vec<CliAgentEntry> {
             has_subscription_plan: true,
             compatible_api_providers: &[
                 "anthropic_api",
+                "atlascloud_api",
                 "moonshot_api",
                 "zenmux_api",
                 "longcat_api",

--- a/src-tauri/crates/key-vault/src/commands/registry/mod.rs
+++ b/src-tauri/crates/key-vault/src/commands/registry/mod.rs
@@ -159,9 +159,10 @@ mod compatibility_tests {
 
     #[test]
     fn compatibility_comes_from_the_central_cli_registry() {
-        assert!(is_cli_provider_compatible("codex", "openai_api"));
         assert!(is_cli_provider_compatible("codex", "atlascloud_api"));
         assert!(is_cli_provider_compatible("opencode", "atlascloud_api"));
+        assert!(is_cli_provider_compatible("claude_code", "atlascloud_api"));
+        assert!(is_cli_provider_compatible("codex", "openai_api"));
         assert!(is_cli_provider_compatible("claude_code", "anthropic_api"));
         assert!(!is_cli_provider_compatible("unknown", "openai_api"));
         assert_eq!(cli_agent_display_name("opencode"), Some("OpenCode"));

--- a/src-tauri/crates/key-vault/src/key_store/agent_env_builder.rs
+++ b/src-tauri/crates/key-vault/src/key_store/agent_env_builder.rs
@@ -10,6 +10,7 @@ const ZENMUX_OPENAI_BASE_URL: &str = "https://zenmux.ai/api/v1";
 const ZENMUX_ANTHROPIC_BASE_URL: &str = "https://zenmux.ai/api/anthropic";
 const LONGCAT_OPENAI_BASE_URL: &str = "https://api.longcat.chat/openai";
 const LONGCAT_ANTHROPIC_BASE_URL: &str = "https://api.longcat.chat/anthropic";
+const ATLASCLOUD_ANTHROPIC_BASE_URL: &str = "https://api.atlascloud.ai";
 
 impl KeyService {
     /// Get environment variables for running an agent
@@ -115,6 +116,14 @@ impl KeyService {
                          official OAuth tokens only authenticate at api.anthropic.com — not exporting ANTHROPIC_BASE_URL",
                         entry.id,
                         entry.base_url
+                    );
+                } else if entry.model_type == ModelType::AtlascloudApi {
+                    // Atlas keys persist the OpenAI-protocol /v1 URL; its
+                    // Anthropic surface lives at the bare host, so the stored
+                    // URL must never reach Claude Code.
+                    env.insert(
+                        "ANTHROPIC_BASE_URL".to_string(),
+                        ATLASCLOUD_ANTHROPIC_BASE_URL.to_string(),
                     );
                 } else if let Some(ref url) = entry.base_url {
                     env.insert("ANTHROPIC_BASE_URL".to_string(), url.clone());

--- a/src-tauri/crates/key-vault/src/key_store/tests/tests.rs
+++ b/src-tauri/crates/key-vault/src/key_store/tests/tests.rs
@@ -1229,6 +1229,41 @@ fn test_cross_type_env_zenmux_as_codex_uses_openai_endpoint() {
 }
 
 #[test]
+fn test_cross_type_env_atlascloud_as_claude_code_uses_anthropic_endpoint() {
+    let temp_dir = tempdir().unwrap();
+    let service = KeyService::new(Some(temp_dir.path().to_path_buf()));
+
+    let mut atlas_key = ModelKey::new(ModelType::AtlascloudApi);
+    atlas_key.api_key = Some("atlas-test-key".to_string());
+    atlas_key.enabled_models = vec!["zai-org/glm-5.1".to_string()];
+    // The stored /v1 URL is OpenAI-protocol; the Anthropic export must
+    // ignore it and use the bare host instead.
+    atlas_key.base_url = Some("https://api.atlascloud.ai/v1".to_string());
+    let key_id = atlas_key.id.clone();
+    service.save_key(atlas_key).unwrap();
+
+    let env = service.get_env_for_agent(&ModelType::ClaudeCode, Some(&key_id));
+    assert_eq!(
+        env.get("ANTHROPIC_API_KEY").map(String::as_str),
+        Some("atlas-test-key"),
+    );
+    assert_eq!(
+        env.get("ANTHROPIC_BASE_URL").map(String::as_str),
+        Some("https://api.atlascloud.ai"),
+    );
+    assert_eq!(
+        env.get("ANTHROPIC_MODEL").map(String::as_str),
+        Some("zai-org/glm-5.1"),
+    );
+    assert_eq!(
+        env.get("CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS")
+            .map(String::as_str),
+        Some("1"),
+    );
+    assert!(!env.contains_key("ATLASCLOUD_API_KEY"));
+}
+
+#[test]
 fn test_atlascloud_provider_exports_canonical_environment() {
     let temp_dir = tempdir().unwrap();
     let service = KeyService::new(Some(temp_dir.path().to_path_buf()));

--- a/src-tauri/crates/key-vault/src/provider_config.rs
+++ b/src-tauri/crates/key-vault/src/provider_config.rs
@@ -175,6 +175,13 @@ const ZENMUX_ENDPOINTS: &[ProviderEndpointSpec] = &[ProviderEndpointSpec {
     anthropic_base_url: Some("https://zenmux.ai/api/anthropic"),
 }];
 
+const ATLASCLOUD_ENDPOINTS: &[ProviderEndpointSpec] = &[ProviderEndpointSpec {
+    id: "default",
+    label: "Atlas Cloud",
+    base_url: "https://api.atlascloud.ai/v1",
+    anthropic_base_url: Some("https://api.atlascloud.ai"),
+}];
+
 const LONGCAT_ENDPOINTS: &[ProviderEndpointSpec] = &[ProviderEndpointSpec {
     id: "default",
     label: "LongCat",
@@ -357,12 +364,15 @@ pub fn get_provider_config(model_type: &str) -> ProviderConfig {
             true,
             Some("https://api.openai.com/v1"),
         ),
-        "atlascloud_api" => ProviderConfig::new(
+        "atlascloud_api" => ProviderConfig::with_protocols(
             "ATLASCLOUD_API_KEY",
             Some("ATLASCLOUD_BASE_URL"),
             true,
-            Some("https://api.atlascloud.ai/v1"),
-        ),
+            None,
+            &["openai", "anthropic"],
+            "openai",
+        )
+        .with_endpoints(ATLASCLOUD_ENDPOINTS),
         "deepseek_api" => ProviderConfig::new(
             "DEEPSEEK_API_KEY",
             None,
@@ -594,8 +604,12 @@ mod tests {
             config.default_base_url,
             Some("https://api.atlascloud.ai/v1".to_string())
         );
-        assert_eq!(config.supported_protocols, vec!["openai"]);
+        assert_eq!(config.supported_protocols, vec!["openai", "anthropic"]);
         assert_eq!(config.default_protocol, "openai");
+        assert_eq!(
+            config.default_anthropic_base_url(),
+            Some("https://api.atlascloud.ai".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

PR #503 registered Atlas Cloud as compatible with Codex and OpenCode and generated their provider profiles, but the third CLI in Atlas Cloud's official Coding Plan docs — **Claude Code** — was never wired. Atlas's primary coding-plan audience uses Claude Code, so an Atlas key currently cannot drive it at all: the provider is absent from `claude_code.compatible_api_providers`, and no Anthropic-protocol endpoint is declared anywhere.

Official reference: https://www.atlascloud.ai/docs/en/coding-plan/api (Claude Code section: `ANTHROPIC_BASE_URL=https://api.atlascloud.ai` — bare host, no `/v1`).

## Solution

Follow the existing dual-protocol provider pattern (ZenMux/LongCat):

- `cli_agents.rs`: add `atlascloud_api` to Claude Code's `compatible_api_providers`.
- `provider_config.rs`: declare Atlas as dual-protocol (`openai` + `anthropic`) with an `ATLASCLOUD_ENDPOINTS` spec carrying `anthropic_base_url = https://api.atlascloud.ai`. `default_base_url` still resolves to `…/v1` via the endpoint, so the OpenAI validation path is unchanged, and protocol-`anthropic` key validation now resolves its endpoint too.
- `agent_env_builder.rs`: Claude Code cross-type sessions with an Atlas key export `ANTHROPIC_BASE_URL=https://api.atlascloud.ai`. The Atlas arm deliberately takes precedence over the stored `entry.base_url`: Atlas keys persist the OpenAI-protocol `/v1` URL, which must never be forwarded to Claude Code (it would produce `/v1/v1/messages`). The existing `ANTHROPIC_MODEL`/beta-disable cross-type overrides then apply as-is.
- `agent-core` provider registry: `default_anthropic_api_base = https://api.atlascloud.ai` on the Atlas `ProviderSpec`, mirroring ZenMux.

Auth header stays `ANTHROPIC_API_KEY` (x-api-key), consistent with every other cross-type provider. Verified empirically that Atlas's Anthropic surface evaluates both `x-api-key` and `Authorization: Bearer` (present-but-wrong key returns `unauthorized`, absent auth returns `invalid token`), and `POST https://api.atlascloud.ai/v1/messages` exists (401 on bad key, not 404).

## Verification

- `cargo test -p key_vault` — 345 passed (includes new `test_cross_type_env_atlascloud_as_claude_code_uses_anthropic_endpoint` pinning key/base-URL/model/beta-flag exports and the stored-`/v1`-URL precedence trap, plus updated `test_get_provider_config_atlascloud` and the registry compatibility assertions for all three CLIs).
- `cargo test -p agent_core providers` — 442 passed.
- clippy clean on all touched files; `cargo fmt` scoped (repo-wide pre-existing drift left untouched).
- Live differential probes against `api.atlascloud.ai` documented above; no paid request issued (auth-rejection responses only).

## Risks

`resolve_session_model` already suppresses `--model` for Claude Code cross-type sessions, and the env builder injects the curated model — both existing mechanisms, no change needed. The env export for same-type Atlas sessions is untouched (`ATLASCLOUD_API_KEY`/`ATLASCLOUD_BASE_URL` canonical test still green). Rollback is a revert of this commit.
