### PR TITLE
fix(cloud): push live CLI session transcripts on share

### DIFF
--- a/src/features/Org2Cloud/org2CloudSessionSync.ts
+++ b/src/features/Org2Cloud/org2CloudSessionSync.ts
@@ -1,4 +1,5 @@
 import { getImportedHistorySourceBySessionId } from "@src/api/tauri/externalHistory";
+import { rpc } from "@src/api/tauri/rpc";
 import { eventStoreProxy } from "@src/engines/SessionCore/core/store/EventStoreProxy";
 import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 import { processChunksRust } from "@src/engines/SessionCore/ingestion/rustBridge";
@@ -7,7 +8,11 @@ import { createLogger } from "@src/hooks/logger";
 import { COLLAB_SESSION_ACCESS_MODE } from "@src/store/collaboration/types";
 import type { RemoteTeammateSessionMetadata } from "@src/store/collaboration/types";
 import type { Session } from "@src/store/session/sessionAtom/types";
-import { isImportedHistorySession } from "@src/util/session/sessionDispatch";
+import type { ActivityChunk } from "@src/types/session/session";
+import {
+  isCliSession,
+  isImportedHistorySession,
+} from "@src/util/session/sessionDispatch";
 
 import {
   sha256Hex,
@@ -323,7 +328,16 @@ export class Org2CloudSessionSync extends Org2CloudSessionSyncState {
       if (!Array.isArray(chunks) || chunks.length === 0) return [];
       return processChunksRust(chunks, sessionId);
     }
-    return eventStoreProxy.getPersistedEvents(sessionId);
+    const persisted = await eventStoreProxy.getPersistedEvents(sessionId);
+    if (persisted.length > 0 || !isCliSession(sessionId)) return persisted;
+    // Live CLI sessions keep their transcript of record in the CLI's native
+    // store (account-profile aware) and never write the events cache, so a
+    // persisted read alone pushes a hollow session: metadata with no replay,
+    // and the pass then stamps the event plane clean. Load the full native
+    // transcript through the same command the session-resume path uses.
+    const chunks = (await rpc.cli.chunks({ sessionId })) as ActivityChunk[];
+    if (!Array.isArray(chunks) || chunks.length === 0) return [];
+    return processChunksRust(chunks, sessionId);
   }
 
   private preparePushEventsForPass(

--- a/src/features/Org2Cloud/org2CloudSyncEngine.sessions.test.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.sessions.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { rpc } from "@src/api/tauri/rpc";
 import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 import type { Session } from "@src/store/session/sessionAtom/types";
 
@@ -88,6 +89,46 @@ describe("Org2CloudSyncEngine session publishing", () => {
       fullChunks,
       "cursoride-thread-1"
     );
+  });
+
+  it("publishes live CLI sessions from the native transcript when the events cache is empty", async () => {
+    eventStoreMock.getPersistedEvents.mockResolvedValueOnce([]);
+    const chunks = [{ id: "cli-chunk" }] as never;
+    const chunksSpy = vi.spyOn(rpc.cli, "chunks").mockResolvedValue(chunks);
+    const converted = [makeEvent("cli-event")];
+    processChunksRustMock.mockResolvedValueOnce(converted);
+
+    const events = await (
+      engine as unknown as {
+        loadPushEvents(sessionId: string): Promise<SessionEvent[]>;
+      }
+    ).loadPushEvents("cliagent-123-native");
+
+    expect(events).toEqual(converted);
+    expect(chunksSpy).toHaveBeenCalledWith({
+      sessionId: "cliagent-123-native",
+    });
+    expect(processChunksRustMock).toHaveBeenCalledWith(
+      chunks,
+      "cliagent-123-native"
+    );
+    chunksSpy.mockRestore();
+  });
+
+  it("prefers the persisted event cache for CLI sessions when it is populated", async () => {
+    const persisted = [makeEvent("persisted-cli-event")];
+    eventStoreMock.getPersistedEvents.mockResolvedValueOnce(persisted);
+    const chunksSpy = vi.spyOn(rpc.cli, "chunks");
+
+    const events = await (
+      engine as unknown as {
+        loadPushEvents(sessionId: string): Promise<SessionEvent[]>;
+      }
+    ).loadPushEvents("cliagent-123-native");
+
+    expect(events).toEqual(persisted);
+    expect(chunksSpy).not.toHaveBeenCalled();
+    chunksSpy.mockRestore();
   });
   it("pushes only scope-matched own sessions (metadata + epoch-1 rewrite)", async () => {
     store.set(sessionsAtom, [


### PR DESCRIPTION
## Problem

Sharing a **live CLI session** (`cliagent-*` — Claude Code, Codex CLI, … GUI sessions) publishes a permanently hollow cloud copy: the row is created with the right `access_mode`/visibility and metadata, but `events_count` stays 0, so the recipient forever sees "No activity yet — Session data may not have loaded" and Reload does nothing.

Root cause: `loadPushEvents` reads non-imported sessions from `eventStoreProxy.getPersistedEvents` (the SQLite events cache). Live CLI sessions never write that cache — their transcript of record is the CLI's native store (account-profile aware, e.g. `~/.orgii/claude-code-cli-profiles/<account>/projects/…jsonl`). The engine reads 0 events with no cursor, silently upserts metadata only, and then **stamps the event plane clean**, so subsequent passes skip the session entirely. The owner's own replay hydrates from the native transcript, which is why this is invisible on the sharing side and only the recipient breaks.

## Solution

When the persisted events cache is empty for a CLI session, load the full native transcript through `cli_agent_chunks` — the same profile-home-aware command the session-resume path uses — and convert with `processChunksRust`, mirroring the imported-history branch. A populated events cache still wins, so sessions that do persist (forks, cloud replays) keep their existing path, and non-CLI sessions are untouched.

## Verification

- Unit: two new tests in `org2CloudSyncEngine.sessions.test.ts` pin both directions (empty cache → native transcript chunks; populated cache → no chunks call). Full `src/features/Org2Cloud` suite: 1043 passed. `pnpm typecheck` clean.
- Live dual-instance, real reproduction: a live Claude Code session (3 rounds) shared from instance-1 sat at `events_count: 0` across restarts and new activity on the unfixed build. With this fix installed, the first sync pass pushed 7 events (`events_epoch: 1`), and the second instance (different cloud account) rendered the full replay — all three rounds navigable via the round switcher, correct owner attribution, no synthetic-round pollution.

## Risks

The fallback only fires when the events cache is empty AND the session id is `cliagent-*`. Chunk→event conversion is the same deterministic pipeline the imported-history push already relies on, so freeze-line/epoch/hash behavior is unchanged. Mid-turn reads produce a prefix snapshot; the next pass appends, as with imported sources. Rollback is a revert.
