### PR TITLE
feat(sidebar): add top-level view switcher

### DIFF
--- a/docs/frontend-ui-audit-2026-08-03/WorkstationSidebarViewSwitcher.md
+++ b/docs/frontend-ui-audit-2026-08-03/WorkstationSidebarViewSwitcher.md
@@ -1,0 +1,23 @@
+# WorkstationSidebarViewSwitcher frontend UI audit
+
+Scope: the new icon-only Workstation view switcher rendered below the organization selector. The configured `frontend-ui-audit` skill was unavailable, so this report applies the repository's documented checks manually.
+
+| Line                                        | Element                                        | Verdict          | Reason                                                                                                                                                      | Suggested change |
+| ------------------------------------------- | ---------------------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `WorkstationSidebarViewSwitcher.tsx:48`     | Semantic navigation container                  | keep with reason | Uses a translated navigation label and remains directly on the existing sidebar surface without introducing a second container background or sidebar layer. | None.            |
+| `WorkstationSidebarViewSwitcher.tsx:29`     | Horizontal destination order                   | keep with reason | Work Items leads, History/Sessions occupies the central position, and Chat/Channels remains last, matching the requested information hierarchy.             | None.            |
+| `WorkstationSidebarViewSwitcher.tsx:53`     | Horizontal view row                            | keep with reason | Equal-width targets make the three icon-only destinations read as one balanced row while preserving the sidebar background around them.                     | None.            |
+| `WorkstationSidebarViewSwitcher.tsx:58`     | Delayed icon tooltips                          | keep with reason | Translated tooltip labels appear only after 1.5 seconds of hover, while `aria-label` keeps every icon-only destination immediately accessible.              | None.            |
+| `WorkstationSidebarViewSwitcher.tsx:67`     | View controls                                  | keep with reason | Uses 28px targets, visible keyboard focus, a 70%-opacity chat-pane selected surface, and the same `sidebar-selected` hover token as the menu rows below.    | None.            |
+| `SidebarOrgSelector.tsx:140`                | Organization selector tooltip                  | keep with reason | The existing selector tooltip remains disabled while its menu is open and now uses the same 1.5-second hover delay as the view tabs.                        | None.            |
+| `WorkstationSidebarConnector/index.tsx:589` | Organization selector and switcher composition | keep with reason | The organization selector stays in the sidebar chrome, while `preListContent` places the switcher directly below it and above the contextual list.          | None.            |
+| `WorkstationSidebarConnector/index.tsx:613` | Direct Work Items content                      | keep with reason | Work Items now uses the same list spacing and top-level switcher behavior as Channels and Sessions; no back header or nested navigation layer is rendered.  | None.            |
+| `workstationSidebarMenuItems.tsx:57`        | Sessions pinned actions                        | keep with reason | Sessions contains only session-level actions; Work Items is no longer duplicated there because the top-level switcher is its sole sidebar destination.      | None.            |
+
+## Verdict counts
+
+- Fix: 0
+- Keep with reason: 9
+- Abstract: 0
+
+No multi-file design-system sweep candidate was found.

--- a/src/modules/WorkStation/shared/WorkstationToolbarTooltip.tsx
+++ b/src/modules/WorkStation/shared/WorkstationToolbarTooltip.tsx
@@ -10,6 +10,7 @@ export interface WorkstationToolbarTooltipProps {
   shortcut?: string;
   shortcutId?: string;
   position?: TooltipProps["position"];
+  mouseEnterDelay?: TooltipProps["mouseEnterDelay"];
   disabled?: boolean;
   children: ReactNode;
 }
@@ -21,6 +22,7 @@ export const WorkstationToolbarTooltip: React.FC<WorkstationToolbarTooltipProps>
       shortcut,
       shortcutId,
       position = "bottom",
+      mouseEnterDelay = 200,
       disabled = false,
       children,
     }) => {
@@ -37,7 +39,7 @@ export const WorkstationToolbarTooltip: React.FC<WorkstationToolbarTooltipProps>
             />
           }
           position={position}
-          mouseEnterDelay={200}
+          mouseEnterDelay={mouseEnterDelay}
           framedPanel
           disabled={disabled}
           smartPlacement

--- a/src/scaffold/NavigationSidebar/connectors/SidebarOrgSelector.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/SidebarOrgSelector.tsx
@@ -140,6 +140,7 @@ const SidebarOrgSelector: React.FC<SidebarOrgSelectorProps> = React.memo(
         <WorkstationToolbarTooltip
           label={t("collaboration.switchOrg")}
           position="bottom"
+          mouseEnterDelay={1500}
           disabled={menuOpen}
         >
           <div className="w-full min-w-0">

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/WorkstationSidebarViewSwitcher.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/WorkstationSidebarViewSwitcher.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { WorkstationSidebarViewSwitcher } from "./WorkstationSidebarViewSwitcher";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      ({
+        "routes.channels": "Channels",
+        "labels.workItems": "Work Items",
+        "routes.sessions": "Sessions",
+        "sidebar.tabs.workstation": "Workstation",
+      })[key] ?? key,
+  }),
+}));
+
+vi.mock("@src/components/Tooltip", () => ({
+  default: ({
+    children,
+    mouseEnterDelay,
+  }: {
+    children: React.ReactNode;
+    mouseEnterDelay?: number;
+  }) =>
+    createElement(
+      "span",
+      { "data-tooltip-enter-delay": mouseEnterDelay },
+      children
+    ),
+}));
+
+const actEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+describe("WorkstationSidebarViewSwitcher", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("exposes three labeled destinations and marks the active view", () => {
+    act(() => {
+      root.render(
+        createElement(WorkstationSidebarViewSwitcher, {
+          activeKey: "sessions",
+          onChange: () => undefined,
+        })
+      );
+    });
+
+    expect(container.querySelector("nav")?.getAttribute("aria-label")).toBe(
+      "Workstation"
+    );
+    expect(container.querySelector("nav")?.classList.contains("pt-1")).toBe(
+      true
+    );
+    expect(
+      container.querySelector('[data-testid="sidebar-view-channels"]')
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="sidebar-view-work-items"]')
+    ).not.toBeNull();
+    expect(
+      container
+        .querySelector('[data-testid="sidebar-view-work-items"]')
+        ?.classList.contains("h-7")
+    ).toBe(true);
+    expect(
+      container
+        .querySelector('[data-testid="sidebar-view-sessions"]')
+        ?.getAttribute("aria-current")
+    ).toBe("page");
+    expect(
+      container
+        .querySelector('[data-testid="sidebar-view-sessions"]')
+        ?.classList.contains("bg-chat-pane/70")
+    ).toBe(true);
+    expect(
+      container
+        .querySelector('[data-testid="sidebar-view-channels"]')
+        ?.classList.contains("hover:bg-sidebar-selected")
+    ).toBe(true);
+    expect(container.querySelector("[title]")).toBeNull();
+    expect(
+      Array.from(
+        container.querySelectorAll('[data-tooltip-enter-delay="1500"]')
+      )
+    ).toHaveLength(3);
+    expect(
+      Array.from(container.querySelectorAll("button")).map((button) =>
+        button.getAttribute("data-testid")
+      )
+    ).toEqual([
+      "sidebar-view-work-items",
+      "sidebar-view-sessions",
+      "sidebar-view-channels",
+    ]);
+  });
+
+  it("dispatches destination changes", () => {
+    const onChange = vi.fn();
+    act(() => {
+      root.render(
+        createElement(WorkstationSidebarViewSwitcher, {
+          activeKey: "sessions",
+          onChange,
+        })
+      );
+    });
+
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="sidebar-view-channels"]'
+        )
+        ?.click();
+    });
+    expect(onChange).toHaveBeenCalledWith("channels");
+  });
+});

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/WorkstationSidebarViewSwitcher.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/WorkstationSidebarViewSwitcher.tsx
@@ -1,0 +1,92 @@
+import { Hash, History, ListTodo, type LucideIcon } from "lucide-react";
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import Tooltip from "@src/components/Tooltip";
+
+export type WorkstationSidebarViewKey = "channels" | "work-items" | "sessions";
+
+interface WorkstationSidebarViewSwitcherProps {
+  activeKey: WorkstationSidebarViewKey;
+  onChange: (key: WorkstationSidebarViewKey) => void;
+}
+
+interface ViewItem {
+  key: WorkstationSidebarViewKey;
+  label: string;
+  icon: LucideIcon;
+}
+
+const SWITCHER_ICON_SIZE = 17;
+const SELECTED_VIEW_STYLE: React.CSSProperties = {
+  boxShadow: "var(--sidebar-tab-pill-selected-shadow)",
+};
+
+/** Icon-only primary view switcher rendered below the organization selector. */
+export const WorkstationSidebarViewSwitcher: React.FC<WorkstationSidebarViewSwitcherProps> =
+  React.memo(({ activeKey, onChange }) => {
+    const { t } = useTranslation("navigation");
+    const items: ViewItem[] = [
+      {
+        key: "work-items",
+        label: t("labels.workItems"),
+        icon: ListTodo,
+      },
+      {
+        key: "sessions",
+        label: t("routes.sessions"),
+        icon: History,
+      },
+      {
+        key: "channels",
+        label: t("routes.channels"),
+        icon: Hash,
+      },
+    ];
+
+    return (
+      <nav
+        className="shrink-0 px-3 pb-1 pt-1"
+        aria-label={t("sidebar.tabs.workstation")}
+        data-workstation-sidebar-view-switcher
+      >
+        <div className="flex items-center gap-1">
+          {items.map((item) => {
+            const Icon = item.icon;
+            const selected = item.key === activeKey;
+            return (
+              <Tooltip
+                key={item.key}
+                content={item.label}
+                position="bottom"
+                mouseEnterDelay={1500}
+                showArrow={false}
+              >
+                <button
+                  type="button"
+                  className={`flex h-7 flex-1 items-center justify-center rounded-lg transition-[background-color,color,box-shadow] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-6/30 ${
+                    selected
+                      ? "cursor-default bg-chat-pane/70 text-primary-6"
+                      : "text-text-2 hover:bg-sidebar-selected hover:text-text-1"
+                  }`}
+                  style={selected ? SELECTED_VIEW_STYLE : undefined}
+                  aria-label={item.label}
+                  aria-current={selected ? "page" : undefined}
+                  data-testid={`sidebar-view-${item.key}`}
+                  onClick={() => onChange(item.key)}
+                >
+                  <Icon
+                    size={SWITCHER_ICON_SIZE}
+                    strokeWidth={selected ? 2 : 1.8}
+                    aria-hidden
+                  />
+                </button>
+              </Tooltip>
+            );
+          })}
+        </div>
+      </nav>
+    );
+  });
+
+WorkstationSidebarViewSwitcher.displayName = "WorkstationSidebarViewSwitcher";

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
@@ -32,6 +32,10 @@ import SidebarSettingsMenuButton from "../../blocks/SidebarSettingsMenuButton";
 import NavigationSidebar from "../../variants/NavigationSidebar";
 import { DEFAULT_COLLAPSED_SECTION_IDS } from "../workstationSidebarData";
 import { SidebarDialogs } from "./SidebarDialogs";
+import {
+  type WorkstationSidebarViewKey,
+  WorkstationSidebarViewSwitcher,
+} from "./WorkstationSidebarViewSwitcher";
 import { useLocalChannelsSection } from "./localChannelsSection";
 import { useWorkstationSidebarBottomActions } from "./sidebarConnector.bottomActions";
 import { useWorkstationSidebarChatPanelAtoms } from "./sidebarConnector.chatPanelAtoms";
@@ -47,7 +51,10 @@ import { useWorkstationSidebarSelectionAndNavigation } from "./sidebarConnector.
 import { useWorkstationSidebarSessionAndProjectMenuItems } from "./sidebarConnector.sessionAndProjectMenuItems";
 import { useWorkstationSidebarSessionInteractionHandlers } from "./sidebarConnector.sessionInteractionHandlers";
 import { SidebarSearchShortcutTooltip } from "./sidebarTabs";
-import type { WorkstationSidebarKey } from "./types";
+import type {
+  WorkstationSidebarKey,
+  WorkstationSidebarSearchKey,
+} from "./types";
 
 /**
  * Workstation sidebar coordinator. The bulk of this connector's state,
@@ -118,23 +125,37 @@ export const WorkstationSidebarConnector: React.FC = () => {
   const { goToNewSession, navigateTo } = useAppNavigation();
   const [activeSidebarKey, setActiveSidebarKey] =
     useState<WorkstationSidebarKey>("workstation");
+  const [channelsOpen, setChannelsOpen] = useState(false);
   const [activeSessionMoreMenuId, setActiveSessionMoreMenuId] = useState("");
   const [projectsSelectedMenuItemId, setProjectsSelectedMenuItemId] =
     useState("");
   const [workItemsOpen, setWorkItemsOpen] = useState(false);
   const workItemsContentVisible =
     activeSidebarKey === "workstation" && workItemsOpen;
+  const channelSidebarVisible =
+    activeSidebarKey === "workstation" && channelsOpen;
   const projectsSidebarVisible =
     activeSidebarKey === "projects" || workItemsContentVisible;
-  const activeSidebarSearchKey: WorkstationSidebarKey = workItemsContentVisible
-    ? "projects"
-    : activeSidebarKey;
+  const activeSidebarSearchKey: WorkstationSidebarSearchKey =
+    workItemsContentVisible
+      ? "projects"
+      : channelSidebarVisible
+        ? "channels"
+        : activeSidebarKey;
   const [sidebarSearchQueries, setSidebarSearchQueries] = useState<
-    Record<WorkstationSidebarKey, string>
-  >({ workstation: "", projects: "" });
-  const handleSidebarLayerChange = useCallback((key: WorkstationSidebarKey) => {
-    setActiveSidebarKey(key);
+    Record<WorkstationSidebarSearchKey, string>
+  >({ workstation: "", projects: "", channels: "" });
+  const handleViewChange = useCallback((key: WorkstationSidebarViewKey) => {
+    setActiveSidebarKey("workstation");
+    setChannelsOpen(key === "channels");
+    setWorkItemsOpen(key === "work-items");
   }, []);
+  const activeViewKey: WorkstationSidebarViewKey =
+    activeSidebarKey === "projects" || workItemsContentVisible
+      ? "work-items"
+      : channelSidebarVisible
+        ? "channels"
+        : "sessions";
 
   const handleSidebarSearchChange = useCallback(
     (value: string) => {
@@ -208,7 +229,6 @@ export const WorkstationSidebarConnector: React.FC = () => {
     unpinFolderLabel,
     createProjectLabel,
     createWorkItemLabel,
-    workItemsLabel,
     runtimeLabel,
     teamInboxLabel,
     importGithubIssuesLabel,
@@ -220,6 +240,8 @@ export const WorkstationSidebarConnector: React.FC = () => {
 
   const {
     cloudMenuItems,
+    cloudSessionMenuItems,
+    channelMenuItems,
     selectedCloudMenuItemId,
     handleCloudSessionItemClick,
     resetCloudTeamPagination,
@@ -333,6 +355,7 @@ export const WorkstationSidebarConnector: React.FC = () => {
     setSidebarCollapsed,
     setActiveSidebarKey,
     setWorkItemsOpen,
+    setChannelsOpen,
     setSelectedOrgId,
     setSidebarSearchQueries,
     setExpandedSubagentParentIds,
@@ -449,8 +472,10 @@ export const WorkstationSidebarConnector: React.FC = () => {
     unpinFolderLabel,
     setActiveSessionMoreMenuId,
     subagentParentIds,
-    cloudMenuItems,
-    localChannelsMenuItems,
+    cloudSessionMenuItems,
+    channelSidebarMenuItems:
+      channelMenuItems.length > 0 ? channelMenuItems : localChannelsMenuItems,
+    channelSidebarVisible,
     sessionSidebarMenuItems,
     cloudMySessionsVisibleCount,
     activeSidebarKey,
@@ -478,17 +503,11 @@ export const WorkstationSidebarConnector: React.FC = () => {
 
   const {
     handleOpenSpotlight,
-    handleSubmenuOpenChange,
-    sidebarLayerHeader,
     sidebarOrgSelector,
     resolvedMenuItemClick,
     resolvedMenuItemContextMenu,
     resolvedRenderMenuItemWrapper,
   } = useWorkstationSidebarChrome({
-    setWorkItemsOpen,
-    handleSidebarLayerChange,
-    projectsSidebarVisible,
-    workItemsLabel,
     activeOrgId,
     orgSelectorOptions,
     addOrgLabel,
@@ -531,6 +550,7 @@ export const WorkstationSidebarConnector: React.FC = () => {
       resolvedOnCollapsedSectionIdsChange,
       sessions,
       workItemsContentVisible,
+      channelSidebarVisible,
       activeSidebarKey,
       projectsWorkItemsLoading,
       projectsSidebarMenuItems,
@@ -546,7 +566,7 @@ export const WorkstationSidebarConnector: React.FC = () => {
       selectedMenuItemId,
       activeSessionId,
       collapsedSectionIds,
-      pinnedMenuItems,
+      pinnedMenuItems: channelSidebarVisible ? [] : pinnedMenuItems,
     });
 
   return (
@@ -556,17 +576,21 @@ export const WorkstationSidebarConnector: React.FC = () => {
         activeKey={activeSidebarKey}
         onChange={() => undefined}
         menuItems={sidebarMenuItems}
-        pinnedMenuItems={pinnedMenuItems}
+        pinnedMenuItems={channelSidebarVisible ? [] : pinnedMenuItems}
         selectedKey={resolvedSelectedMenuItemId}
         onMenuItemClick={resolvedMenuItemClick}
-        onSubmenuOpenChange={handleSubmenuOpenChange}
         onMenuItemContextMenu={resolvedMenuItemContextMenu}
         renderMenuItemWrapper={resolvedRenderMenuItemWrapper}
         hostTopBarLeadingContent={sidebarOrgSelector}
         macTopBarFollowingContent={
           <div className="shrink-0 px-3 pt-1">{sidebarOrgSelector}</div>
         }
-        preListContent={sidebarLayerHeader}
+        preListContent={
+          <WorkstationSidebarViewSwitcher
+            activeKey={activeViewKey}
+            onChange={handleViewChange}
+          />
+        }
         onAddNew={handleOpenSpotlight}
         addIcon={Search}
         addLabel={tCommon("actions.search")}
@@ -586,7 +610,7 @@ export const WorkstationSidebarConnector: React.FC = () => {
           noResultsTitle: noSearchResultsTitle,
           showInput: false,
         }}
-        listTopPadding={!workItemsContentVisible}
+        listTopPadding
         bottomContent={
           <SidebarBottomBar
             leftContent={

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.bottomActions.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.bottomActions.ts
@@ -29,6 +29,7 @@ interface UseWorkstationSidebarBottomActionsParams {
   ) => void;
   sessions: Session[];
   workItemsContentVisible: boolean;
+  channelSidebarVisible: boolean;
   activeSidebarKey: WorkstationSidebarKey;
   projectsWorkItemsLoading: boolean;
   projectsSidebarMenuItems: NavigationMenuItem[];
@@ -49,6 +50,7 @@ export function useWorkstationSidebarBottomActions({
   resolvedOnCollapsedSectionIdsChange,
   sessions,
   workItemsContentVisible,
+  channelSidebarVisible,
   activeSidebarKey,
   projectsWorkItemsLoading,
   projectsSidebarMenuItems,
@@ -78,11 +80,12 @@ export function useWorkstationSidebarBottomActions({
       logger.warn("Failed to rescan sidebar sessions:", error);
     });
   }, []);
-  const isLoading =
-    workItemsContentVisible || activeSidebarKey === "projects"
+  const isLoading = channelSidebarVisible
+    ? false
+    : workItemsContentVisible || activeSidebarKey === "projects"
       ? projectsWorkItemsLoading && projectsSidebarMenuItems.length === 0
       : sessionsLoading && sessions.length === 0;
-  const sidebarBottomRightActions = useSidebarBottomRightActions({
+  const sessionBottomRightActions = useSidebarBottomRightActions({
     activeSidebarKey: workItemsContentVisible ? "projects" : activeSidebarKey,
     groupByMode,
     includeExternal,
@@ -92,6 +95,9 @@ export function useWorkstationSidebarBottomActions({
     setGroupByMode,
     setIncludeExternal,
   });
+  const sidebarBottomRightActions = channelSidebarVisible
+    ? null
+    : sessionBottomRightActions;
 
   const resolvedSelectedMenuItemId =
     activeSidebarKey === "workstation" && selectedCloudMenuItemId

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.chrome.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.chrome.tsx
@@ -2,20 +2,14 @@
  * Sidebar "chrome" for `WorkstationSidebarConnector` (`index.tsx`): the
  * single call site for the three tightly-sequenced hooks that build the
  * sidebar's header/menu-routing surface — `useWorkstationSidebarOrgSelectorActions`,
- * `useWorkstationSidebarMenuItemRouting`, and this file's own Work Items
- * submenu open/back handlers, back-nav header + org selector JSX, and the
+ * `useWorkstationSidebarMenuItemRouting`, the org selector JSX, and the
  * scope-resolved `NavigationSidebar` props (menu-item click, context menu,
  * row wrapper). Consolidated into one call so `index.tsx` doesn't have to
  * thread the org-selector/menu-routing handoff itself.
  */
-import { ChevronLeft } from "lucide-react";
-import { useCallback } from "react";
-
 import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/components/NavigationMenu/config";
 
-import { SidebarHeaderNavButton } from "../../blocks";
 import SidebarOrgSelector from "../SidebarOrgSelector";
-import { WORK_ITEMS_MENU_ITEM_ID } from "../sidebarConnectorUtils";
 import { useWorkstationSidebarMenuItemRouting } from "./sidebarConnector.menuItemRouting";
 import { useWorkstationSidebarOrgSelectorActions } from "./sidebarConnector.orgSelectorActions";
 import type { WorkstationSidebarKey } from "./types";
@@ -29,10 +23,6 @@ type MenuItemRoutingParams = Parameters<
 >[0];
 
 interface UseWorkstationSidebarChromeParams {
-  setWorkItemsOpen: (open: boolean) => void;
-  handleSidebarLayerChange: (key: WorkstationSidebarKey) => void;
-  projectsSidebarVisible: boolean;
-  workItemsLabel: string;
   activeOrgId: SidebarOrgSelectorProps["value"];
   orgSelectorOptions: SidebarOrgSelectorProps["options"];
   addOrgLabel: string;
@@ -76,10 +66,6 @@ interface UseWorkstationSidebarChromeParams {
 }
 
 export function useWorkstationSidebarChrome({
-  setWorkItemsOpen,
-  handleSidebarLayerChange,
-  projectsSidebarVisible,
-  workItemsLabel,
   activeOrgId,
   orgSelectorOptions,
   addOrgLabel,
@@ -157,32 +143,6 @@ export function useWorkstationSidebarChrome({
     handleOpenInNewTab,
   });
 
-  const handleBackToSessionSidebar = useCallback(() => {
-    setWorkItemsOpen(false);
-    handleSidebarLayerChange("workstation");
-  }, [handleSidebarLayerChange, setWorkItemsOpen]);
-
-  const handleSubmenuOpenChange = useCallback(
-    (key: string, open: boolean) => {
-      // Opening the legacy submenu is the transition into the dedicated Work
-      // Items layer. Once entered, that layer owns its lifecycle: unmounting
-      // the parent submenu may report `open=false`, but only the visible Back
-      // action should navigate the user out again.
-      if (key === WORK_ITEMS_MENU_ITEM_ID && open) setWorkItemsOpen(true);
-    },
-    [setWorkItemsOpen]
-  );
-
-  const sidebarLayerHeader = !projectsSidebarVisible ? null : (
-    <div className="shrink-0 px-3">
-      <SidebarHeaderNavButton
-        icon={ChevronLeft}
-        label={workItemsLabel}
-        onClick={handleBackToSessionSidebar}
-      />
-    </div>
-  );
-
   const sidebarOrgSelector = (
     <SidebarOrgSelector
       value={activeOrgId}
@@ -213,8 +173,6 @@ export function useWorkstationSidebarChrome({
 
   return {
     handleOpenSpotlight,
-    handleSubmenuOpenChange,
-    sidebarLayerHeader,
     sidebarOrgSelector,
     resolvedMenuItemClick,
     resolvedMenuItemContextMenu,

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.cloudMenuData.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.cloudMenuData.ts
@@ -122,6 +122,8 @@ export function useWorkstationSidebarCloudMenuData({
 
   return {
     cloudMenuItems: mergedCloudMenuItems,
+    cloudSessionMenuItems: cloudMenuItems,
+    channelMenuItems: channelsMenuItems,
     // An open channel surface wins over the team-sessions selection: it is
     // the tab the pane is actually showing.
     selectedCloudMenuItemId:

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.menuDecoration.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.menuDecoration.ts
@@ -65,9 +65,9 @@ interface UseWorkstationSidebarMenuDecorationParams {
   unpinFolderLabel: string;
   setActiveSessionMoreMenuId: DecorateRowActionsParams["setActiveSessionMoreMenuId"];
   subagentParentIds: DecorateRowActionsParams["subagentParentIds"];
-  cloudMenuItems: NavigationMenuItem[];
-  /** Local-scope Channels section; empty while a cloud org is active. */
-  localChannelsMenuItems: NavigationMenuItem[];
+  cloudSessionMenuItems: NavigationMenuItem[];
+  channelSidebarMenuItems: NavigationMenuItem[];
+  channelSidebarVisible: boolean;
   sessionSidebarMenuItems: NavigationMenuItem[];
   cloudMySessionsVisibleCount: number;
   activeSidebarKey: WorkstationSidebarKey;
@@ -112,8 +112,9 @@ export function useWorkstationSidebarMenuDecoration({
   unpinFolderLabel,
   setActiveSessionMoreMenuId,
   subagentParentIds,
-  cloudMenuItems,
-  localChannelsMenuItems,
+  cloudSessionMenuItems,
+  channelSidebarMenuItems,
+  channelSidebarVisible,
   sessionSidebarMenuItems,
   cloudMySessionsVisibleCount,
   activeSidebarKey,
@@ -183,7 +184,7 @@ export function useWorkstationSidebarMenuDecoration({
   });
   const decoratedSessionSidebarMenuItems = useMemo(() => {
     const scoped = buildCloudScopedMenuItems({
-      cloudMenuItems,
+      cloudMenuItems: cloudSessionMenuItems,
       // Cloud rows already carry Replay/Fork actions, so only local rows
       // use the regular session action decoration.
       sessionMenuItems: decorateSessionRowActions(sessionSidebarMenuItems),
@@ -191,17 +192,11 @@ export function useWorkstationSidebarMenuDecoration({
       mySessionsVisibleCount: cloudMySessionsVisibleCount,
       loadMoreLabel: tCommon("common:actions.loadMore", "Load more"),
     });
-    // Local-scope Channels lead the list — the mirror of the cloud scope's
-    // channels-above-My-Sessions ordering. Empty whenever a cloud org is
-    // active, so the two channel sections can never co-render.
-    return localChannelsMenuItems.length === 0
-      ? scoped
-      : [...localChannelsMenuItems, ...scoped];
+    return scoped;
   }, [
-    cloudMenuItems,
+    cloudSessionMenuItems,
     cloudMySessionsVisibleCount,
     decorateSessionRowActions,
-    localChannelsMenuItems,
     sessionSidebarMenuItems,
     t,
     tCommon,
@@ -209,7 +204,9 @@ export function useWorkstationSidebarMenuDecoration({
   const sidebarMenuItems =
     activeSidebarKey === "projects" || workItemsContentVisible
       ? projectsSidebarMenuItems
-      : decoratedSessionSidebarMenuItems;
+      : channelSidebarVisible
+        ? channelSidebarMenuItems
+        : decoratedSessionSidebarMenuItems;
   const handleProjectsMenuItemClick = useProjectsMenuItemClick({
     activateMyStationRouteForProjectTabContent,
     activateMyStationRouteForProjectsContent,

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.revealNavigationEffects.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.revealNavigationEffects.ts
@@ -17,7 +17,10 @@ import { loadSidebarSessionById } from "@src/store/session";
 import type { SessionSidebarRevealRequest } from "@src/store/ui/sidebarAtom";
 
 import { findSidebarSectionIdForMenuItem } from "../workstationSidebarData";
-import type { WorkstationSidebarKey } from "./types";
+import type {
+  WorkstationSidebarKey,
+  WorkstationSidebarSearchKey,
+} from "./types";
 import { buildCloudOrgSelectorValue } from "./useSidebarOrgScope";
 
 const logger = createLogger("WorkstationSidebar");
@@ -27,13 +30,14 @@ interface UseWorkstationSidebarRevealNavigationEffectsParams {
   setSidebarCollapsed: (collapsed: boolean) => void;
   setActiveSidebarKey: (key: WorkstationSidebarKey) => void;
   setWorkItemsOpen: (open: boolean) => void;
+  setChannelsOpen: (open: boolean) => void;
   setSelectedOrgId: ReturnType<
     typeof useSetAtom<typeof sidebarSelectedOrgIdAtom>
   >;
   setSidebarSearchQueries: (
     updater: (
-      currentQueries: Record<WorkstationSidebarKey, string>
-    ) => Record<WorkstationSidebarKey, string>
+      currentQueries: Record<WorkstationSidebarSearchKey, string>
+    ) => Record<WorkstationSidebarSearchKey, string>
   ) => void;
   setExpandedSubagentParentIds: (
     updater: (previousIds: Set<string>) => Set<string>
@@ -50,6 +54,7 @@ export function useWorkstationSidebarRevealNavigationEffects({
   setSidebarCollapsed,
   setActiveSidebarKey,
   setWorkItemsOpen,
+  setChannelsOpen,
   setSelectedOrgId,
   setSidebarSearchQueries,
   setExpandedSubagentParentIds,
@@ -67,6 +72,7 @@ export function useWorkstationSidebarRevealNavigationEffects({
     const revealFrame = window.requestAnimationFrame(() => {
       setActiveSidebarKey("workstation");
       setWorkItemsOpen(false);
+      setChannelsOpen(false);
       if (sessionSidebarRevealRequest.cloudOrgId) {
         setSelectedOrgId(
           buildCloudOrgSelectorValue(sessionSidebarRevealRequest.cloudOrgId)
@@ -112,6 +118,7 @@ export function useWorkstationSidebarRevealNavigationEffects({
   }, [
     sessionSidebarRevealRequest,
     setActiveSidebarKey,
+    setChannelsOpen,
     setExpandedSubagentParentIds,
     setSelectedOrgId,
     setSidebarCollapsed,

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarMenuCollections.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarMenuCollections.ts
@@ -63,8 +63,6 @@ export function usePinnedMenuItems({
       buildPinnedMenuItems({
         newSessionLabel,
         newSessionShortcut: getShortcutKeys("new_session"),
-        workItemsLabel: t("labels.workItems"),
-        workItemDestinations,
         kanbanLabel,
         kanbanShortcut: getShortcutKeys("open_kanban"),
         runtimeLabel,
@@ -79,8 +77,6 @@ export function usePinnedMenuItems({
       teamInboxLabel,
       teamInboxUnreadCount,
       teamInboxUnreadAriaLabel,
-      workItemDestinations,
-      t,
     ]
   );
   const projectsPinnedMenuItems = useMemo<NavigationMenuItem[]>(

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/types.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/types.ts
@@ -1,1 +1,3 @@
 export type WorkstationSidebarKey = "workstation" | "projects";
+
+export type WorkstationSidebarSearchKey = WorkstationSidebarKey | "channels";

--- a/src/scaffold/NavigationSidebar/connectors/workstationSidebarMenuItems.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/workstationSidebarMenuItems.test.ts
@@ -5,7 +5,6 @@ import {
   KANBAN_MENU_ITEM_ID,
   RUNTIME_MENU_ITEM_ID,
   TEAM_INBOX_MENU_ITEM_ID,
-  WORK_ITEMS_MENU_ITEM_ID,
   WORK_ITEMS_PROJECTS_MENU_ITEM_ID,
 } from "./sidebarConnectorUtils";
 import {
@@ -14,18 +13,10 @@ import {
 } from "./workstationSidebarMenuItems";
 
 describe("buildPinnedMenuItems", () => {
-  it("renders Kanban separately from the expandable Work Items group", () => {
+  it("does not repeat the top-level Work Items tab inside Sessions", () => {
     const items = buildPinnedMenuItems({
       newSessionLabel: "New Session",
       newSessionShortcut: "⌘N",
-      workItemsLabel: "Work Items",
-      workItemDestinations: [
-        {
-          id: WORK_ITEMS_PROJECTS_MENU_ITEM_ID,
-          key: WORK_ITEMS_PROJECTS_MENU_ITEM_ID,
-          label: "Projects",
-        },
-      ],
       kanbanLabel: "Kanban",
       kanbanShortcut: "⌘O",
       runtimeLabel: "Runtime",
@@ -37,12 +28,7 @@ describe("buildPinnedMenuItems", () => {
       KANBAN_MENU_ITEM_ID,
       RUNTIME_MENU_ITEM_ID,
       TEAM_INBOX_MENU_ITEM_ID,
-      WORK_ITEMS_MENU_ITEM_ID,
     ]);
-    expect(items[4]?.children?.map((item) => item.id)).toEqual([
-      WORK_ITEMS_PROJECTS_MENU_ITEM_ID,
-    ]);
-    expect(items[4]?.routePath).toBeUndefined();
     expect(items[3]).toMatchObject({
       label: "Team Inbox",
       dataTestId: "sidebar-team-inbox",
@@ -58,8 +44,6 @@ describe("buildPinnedMenuItems", () => {
     const items = buildPinnedMenuItems({
       newSessionLabel: "New Session",
       newSessionShortcut: "⌘N",
-      workItemsLabel: "Work Items",
-      workItemDestinations: [],
       kanbanLabel: "Kanban",
       kanbanShortcut: "⌘O",
       runtimeLabel: "Runtime",
@@ -78,8 +62,6 @@ describe("buildPinnedMenuItems", () => {
     const items = buildPinnedMenuItems({
       newSessionLabel: "New Session",
       newSessionShortcut: "⌘N",
-      workItemsLabel: "Work Items",
-      workItemDestinations: [],
       kanbanLabel: "Kanban",
       kanbanShortcut: "⌘O",
       runtimeLabel: "Runtime",

--- a/src/scaffold/NavigationSidebar/connectors/workstationSidebarMenuItems.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/workstationSidebarMenuItems.tsx
@@ -4,7 +4,6 @@ import {
   Gauge,
   Github,
   Inbox,
-  ListTodo,
   Plus,
   SquarePen,
 } from "lucide-react";
@@ -23,7 +22,6 @@ import {
   PROJECTS_NEW_WORK_ITEM_MENU_ITEM_ID,
   RUNTIME_MENU_ITEM_ID,
   TEAM_INBOX_MENU_ITEM_ID,
-  WORK_ITEMS_MENU_ITEM_ID,
   getDraftMenuItemId,
   getDraftPreviewText,
 } from "./sidebarConnectorUtils";
@@ -31,8 +29,6 @@ import {
 interface BuildPinnedMenuItemsParams {
   newSessionLabel: string;
   newSessionShortcut: string;
-  workItemsLabel: string;
-  workItemDestinations: NavigationMenuItem[];
   kanbanLabel: string;
   kanbanShortcut: string;
   runtimeLabel: string;
@@ -51,8 +47,6 @@ interface BuildProjectsPinnedMenuItemsParams {
 export function buildPinnedMenuItems({
   newSessionLabel,
   newSessionShortcut,
-  workItemsLabel,
-  workItemDestinations,
   kanbanLabel,
   kanbanShortcut,
   runtimeLabel,
@@ -104,16 +98,6 @@ export function buildPinnedMenuItems({
             {teamInboxUnreadCount > 99 ? "99+" : teamInboxUnreadCount}
           </span>
         ) : undefined,
-    },
-    {
-      id: WORK_ITEMS_MENU_ITEM_ID,
-      key: WORK_ITEMS_MENU_ITEM_ID,
-      label: workItemsLabel,
-      icon: ListTodo,
-      iconName: "list-todo",
-      children: workItemDestinations,
-      disclosureFollowsLabel: true,
-      dataTestId: "sidebar-toggle-work-items",
     },
   ];
 }


### PR DESCRIPTION
## Problem

Channels, Work Items, and session history share one sidebar list, which makes primary navigation indirect and duplicates Work Items inside Sessions as a nested disclosure. Channels also inherit session-only pinned actions, filters, loading state, and search scope.

## Solution

Add a compact 28px icon-only switcher below the organization selector, ordered Work Items, History, and Chat. Each destination now renders its own list and search scope on the existing sidebar surface. Work Items renders directly with no back layer and is removed from Sessions. Channel mode hides session-only pinned actions and filters, while session reveal requests return the sidebar to History.

The selected tab uses a 70% chat-pane surface, hover matches the existing sidebar rows, and translated tab and organization tooltips use a 1.5-second delay. Accessible labels and current-page semantics remain available without waiting for the tooltip.

## Potential risks

Channels and sessions now render from separate menu collections. The main behavioral risk is missing or stale rows during less-common local/cloud organization transitions; existing channel menu and organization-switch tests passed. View and search selection state is local to the sidebar mount and is intentionally not persisted.

No schema, wire, persistence, dependency, or configuration formats changed. Rollback is a single commit revert.

Exact theme rendering remains an unverified path: no live-app screenshot was captured because workspace policy requires explicit user opt-in for desktop UI control. The implementation uses existing theme tokens, but automated checks do not validate appearance across themes.

## Verification

- `pnpm typecheck` — passed.
- `pnpm exec eslint src/modules/WorkStation/shared/WorkstationToolbarTooltip.tsx src/scaffold/NavigationSidebar/connectors/SidebarOrgSelector.tsx src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/WorkstationSidebarViewSwitcher.tsx src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/WorkstationSidebarViewSwitcher.test.ts` — passed with no warnings.
- `pnpm vitest run src/scaffold/NavigationSidebar` — 29 files passed, 154 tests passed.
- `pnpm build` — production webpack build passed.
- `git diff --check` — passed.
- Commit hooks — lint-staged and scoped TypeScript checks passed.

## Audit

The configured `frontend-ui-audit` skill was unavailable, so the repository checks were applied manually and recorded in `docs/frontend-ui-audit-2026-08-03/WorkstationSidebarViewSwitcher.md`.

- Fix: 0
- Keep with reason: 9
- Abstract: 0
- No multi-file design-system sweep candidate found.

## Visual evidence

No screenshot attached because desktop UI control was not authorized for this task. The PR remains draft so visual confirmation can be added before marking it ready.