### PR TITLE
fix(sidebar): isolate imported-history source failures

### DIFF
--- a/.orgii/skills/dual-instance-verification/SKILL.md
+++ b/.orgii/skills/dual-instance-verification/SKILL.md
@@ -123,10 +123,29 @@ actions in the background, invisible to every existing cell.
   (lookup failure), kill the app mid-transfer (partial persist). The guard
   under test must defer/refuse — any destructive act under injected fault is
   a failure.
-- **Unexplained delta becomes a cell.** The first ledger delta, log line, or
-  resource pattern without a mechanism-level explanation is promoted to a
-  scenario in the CURRENT run — not noted for later. "Background sync noise"
-  is the phrase that hid a data-destroying storm.
+- **Unexplained delta becomes a cell.** The first ledger delta, log line,
+  resource pattern, or store-vs-UI discrepancy without a mechanism-level
+  explanation is promoted to a scenario in the CURRENT run — not noted for
+  later, and not handed to a background task. "Background sync noise" is the
+  phrase that hid a data-destroying storm; "pre-existing behavior" is the
+  phrase that hides everything the current PR did not happen to cause.
+- **Baseline A/B answers attribution, not existence.** Reproducing a symptom on
+  the develop baseline proves the PR under test did not CAUSE it. It proves
+  nothing about whether it is a bug, and it is not a disposition. Write the two
+  conclusions on separate lines — attribution (this PR / not this PR) and
+  verdict (defect / expected, with the mechanism) — and never let the first
+  supply the second. A symptom that survives A/B is either explained
+  mechanically in this run or recorded as an OPEN DEFECT with its evidence in
+  the delivery message; deferring it to a chip is the same escape as "noted for
+  later" above. Corollary signature: **the local store holds N rows and the UI
+  renders 0** is always a defect — chase it to the command and the filter that
+  ate the rows before moving on, because the two ends disagreeing is itself the
+  mechanism-level question. (2026-08-01: instance-2's sidebar OLDER section
+  rendered zero imported rows while `imported_history_session_cache` held 257
+  cursor_ide rows. A/B correctly cleared PRs #628/#576 of causing it; the
+  symptom was then downgraded to a background chip and is STILL unexplained as
+  of 2026-08-03, including after the unrelated #654 import-parse regression was
+  ruled out as its cause.)
 
 ## Ledger commands
 
@@ -209,6 +228,14 @@ rollover or the window silently truncates.
   boot, and positional chunk ids turned the shuffle into a fresh hash chain
   each time. Within one app lifetime everything looked stable; only
   boot-vs-boot comparison of push decisions could see it. (#608 root cause.)
+- **"Pre-existing" used as a verdict**: a symptom reproduces on baseline, is
+  correctly cleared of THIS PR's authorship, and is then silently cleared of
+  being a bug at all — because the run's attention is scoped to the PR, and
+  attribution is the only question the run was asking. Nothing in the protocol
+  catches this: every other discipline here fires on something the run DID,
+  while this one fires on a verdict the run declined to reach. The tell is a
+  finding whose write-up names the PR it exonerates but never names a
+  mechanism.
 - **Waiting for a pass the engine will never run**: the session plane follows
   visible-org demand — an org's push/retract pass runs only while that org is
   the active workspace. A fix whose cleanup rides "the next pass" looks

--- a/src-tauri/src/agent_sessions/session_directory/commands.rs
+++ b/src-tauri/src/agent_sessions/session_directory/commands.rs
@@ -77,6 +77,7 @@ pub async fn session_external_history_sidebar_list(
             }
             let mut pages = Vec::with_capacity(source_request.buckets.len());
             let mut seen_buckets = HashSet::with_capacity(source_request.buckets.len());
+            let mut source_error: Option<String> = None;
             for request in source_request.buckets {
                 if !seen_buckets.insert(request.bucket) {
                     return Err("External history sidebar buckets must be unique".to_string());
@@ -96,14 +97,31 @@ pub async fn session_external_history_sidebar_list(
                     );
                 }
                 let limit = request.limit.min(EXTERNAL_HISTORY_SIDEBAR_BUCKET_MAX_LIMIT);
-                let mut page = query_imported_sidebar_page_from_conn(
+                // One provider's unreadable store must not decide whether the
+                // others are visible: this batch is the sidebar's only source
+                // of imported rows, so propagating here retired every source's
+                // rows at once. Contract violations above stay hard errors —
+                // those are caller bugs, not a provider's disk.
+                let mut page = match query_imported_sidebar_page_from_conn(
                     &conn,
                     &source,
                     request.start_ms,
                     request.end_ms,
                     limit,
                     request.offset,
-                )?;
+                ) {
+                    Ok(page) => page,
+                    Err(err) => {
+                        tracing::warn!(
+                            source = %source,
+                            bucket = ?request.bucket,
+                            error = %err,
+                            "external history sidebar: skipping source whose store failed to read"
+                        );
+                        source_error = Some(err);
+                        break;
+                    }
+                };
                 if source == SOURCE_CURSOR_IDE {
                     for session in &mut page.sessions {
                         if !session.session_id.starts_with(CURSORIDE_SESSION_PREFIX) {
@@ -134,7 +152,12 @@ pub async fn session_external_history_sidebar_list(
             }
             sources.push(ExternalHistorySidebarResponse {
                 source,
-                buckets: pages,
+                buckets: if source_error.is_some() {
+                    Vec::new()
+                } else {
+                    pages
+                },
+                error: source_error,
             });
         }
         Ok(ExternalHistorySidebarBatchResponse { sources })

--- a/src-tauri/src/agent_sessions/session_directory/types.rs
+++ b/src-tauri/src/agent_sessions/session_directory/types.rs
@@ -358,6 +358,12 @@ pub struct ExternalHistorySidebarBucketPage {
 pub struct ExternalHistorySidebarResponse {
     pub source: String,
     pub buckets: Vec<ExternalHistorySidebarBucketPage>,
+    /// Set when this source's own store could not be read. The other sources in
+    /// the batch still carry their rows, and the caller must treat a failed
+    /// source as "unknown", never as "empty" — an empty page would let the
+    /// sidebar retire every row this source owns.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/api/tauri/rpc/schemas/sessionAggregate.ts
+++ b/src/api/tauri/rpc/schemas/sessionAggregate.ts
@@ -296,6 +296,8 @@ export const ExternalHistorySidebarResponseSchema = z.object({
       hasMore: z.boolean(),
     })
   ),
+  /** Present when this source's store failed to read. Never treat it as empty. */
+  error: z.string().optional(),
 });
 
 export const ExternalHistorySidebarBatchResponseSchema = z.object({

--- a/src/store/session/sessionAtom/__tests__/sidebarLoaders.test.ts
+++ b/src/store/session/sessionAtom/__tests__/sidebarLoaders.test.ts
@@ -73,6 +73,56 @@ describe("loadSidebarSessions", () => {
     expect(loadSidebarSessions).toBe(loadSessionRoster);
   });
 
+  it("keeps healthy imported sources listed when one source's store fails", async () => {
+    mocks.sessionAggregateList.mockResolvedValue({ sessions: [] });
+    mocks.externalHistorySidebarList.mockResolvedValue({
+      sources: IMPORTED_HISTORY_SOURCES.map((source) =>
+        source.sourceId === "cursor_ide"
+          ? { source: source.sourceId, buckets: [], error: "disk on fire" }
+          : {
+              source: source.sourceId,
+              buckets: [
+                {
+                  bucket: "older",
+                  sessions:
+                    source.sourceId === "codex_app"
+                      ? [makeRow("codexapp-healthy", "2026-07-01T00:00:00Z")]
+                      : [],
+                  hasMore: false,
+                },
+              ],
+            }
+      ),
+    });
+
+    await loadSidebarSessions();
+
+    const pagination = mocks.store?.get(sessionPaginationAtom);
+    // The broken source is UNKNOWN, never an authoritative empty page.
+    expect(pagination?.["external_history:cursor_ide"].phase).toBe("error");
+    expect(pagination?.["external_history:cursor_ide"].generation).toBe(0);
+    // Its healthy siblings still publish their rows.
+    expect(pagination?.["external_history:codex_app"].sessionIds).toEqual([
+      "codexapp-healthy",
+    ]);
+  });
+
+  it("does not publish an authoritative empty page when the whole batch rejects", async () => {
+    mocks.sessionAggregateList.mockResolvedValue({ sessions: [] });
+    mocks.externalHistorySidebarList.mockRejectedValue(new Error("ipc down"));
+
+    await loadSidebarSessions();
+
+    const pagination = mocks.store?.get(sessionPaginationAtom);
+    for (const source of IMPORTED_HISTORY_SOURCES) {
+      const state = pagination?.[source.listCategory];
+      expect(state?.phase).toBe("error");
+      // generation must stay 0 — createSidebarRosterMatcher treats any
+      // generation > 0 as authoritative and would hide every imported row.
+      expect(state?.generation).toBe(0);
+    }
+  });
+
   it("refreshes gateway-created native rows without reloading imported sources", async () => {
     const imported = {
       session_id: "claude-code-imported",

--- a/src/store/session/sessionAtom/loaders.ts
+++ b/src/store/session/sessionAtom/loaders.ts
@@ -275,7 +275,8 @@ function importedHistoryPageResult(
 
 async function loadImportedHistorySourcePages(
   inputs: readonly ImportedHistoryPageInput[],
-  pageSize: number
+  pageSize: number,
+  failures: Map<string, string> = new Map()
 ): Promise<Map<string, FetchPageResult>> {
   const results = new Map<string, FetchPageResult>();
   const pending = inputs.flatMap(({ source, currentBuckets }) => {
@@ -312,6 +313,13 @@ async function loadImportedHistorySourcePages(
       throw new Error(
         `External history sidebar response omitted ${source.sourceId}`
       );
+    }
+    // A source whose store failed to read is UNKNOWN, not empty. Recording it
+    // as an empty page would publish an authoritative page of zero ids and
+    // retire every row that source owns.
+    if (sourceResponse.error) {
+      failures.set(source.sourceId, sourceResponse.error);
+      continue;
     }
     results.set(
       source.sourceId,
@@ -568,33 +576,47 @@ const performSidebarSessionLoad = async (options?: SidebarLoadOptions) => {
     const source = getImportedHistorySourceByListCategory(category);
     return source ? [{ category, source }] : [];
   });
+  // An errored stream must not publish a roster page. `setPaginationFor`
+  // merges, so writing `generation` while leaving `sessionIds` at its cold-start
+  // `[]` makes `createSidebarRosterMatcher` treat that empty set as
+  // authoritative and hide every row the stream owns. Native categories survive
+  // this because they share one `nativeIds` union; imported categories are each
+  // independently authoritative, so for them the blanking is total.
+  const markImportedStreamFailed = (category: SessionListCategory) => {
+    if (generation !== currentSidebarRosterGeneration(store)) return;
+    setPaginationFor(category, { cursor: null, phase: "error" });
+  };
+
   const importedTask = (async () => {
     if (importedCategories.length === 0) return;
+    const failures = new Map<string, string>();
     try {
       const pages = await loadImportedHistorySourcePages(
         importedCategories.map(({ source }) => ({ source })),
-        pageSize
+        pageSize,
+        failures
       );
       for (const { category, source } of importedCategories) {
+        const failure = failures.get(source.sourceId);
+        if (failure) {
+          log.warn(`[SessionAtom] ${category} initial page failed: ${failure}`);
+          markImportedStreamFailed(category);
+          continue;
+        }
         const page = pages.get(source.sourceId);
         if (!page) {
-          throw new Error(
-            `External history sidebar page missing ${source.sourceId}`
+          log.warn(
+            `[SessionAtom] external history sidebar page missing ${source.sourceId}`
           );
+          markImportedStreamFailed(category);
+          continue;
         }
         applyInitialPage(category, page);
       }
     } catch (error) {
       log.warn("[SessionAtom] external history initial pages failed:", error);
-      if (generation === currentSidebarRosterGeneration(store)) {
-        for (const { category } of importedCategories) {
-          setPaginationFor(category, {
-            cursor: null,
-            phase: "error",
-            generation,
-            dateBuckets: emptyDateBucketPagination(),
-          });
-        }
+      for (const { category } of importedCategories) {
+        markImportedStreamFailed(category);
       }
     }
   })();


### PR DESCRIPTION
## Problem

`session_external_history_sidebar_list` is the sidebar's only source of imported-history rows, and it is all-or-nothing: one provider's unreadable store fails the whole batch, so **every** imported source disappears from the sidebar at once.

This is the same failure class #654 just fixed one layer down — *"One provider's on-disk store no longer decides whether the other seventeen are visible"* — but the frontend/IPC path has the identical hole, and it makes the outage worse in two ways:

1. **The batch couples all sources.** `query_imported_sidebar_page_from_conn(...)?` propagates out of the per-source loop, so a single SQLite failure on one provider returns `Err` for the entire request.
2. **The error path then retires every row.** The catch writes `generation` but not `sessionIds`, and `setPaginationFor` *merges* (`loaders.ts:185`). On a cold start `sessionIds` is still `[]`, so `createSidebarRosterMatcher` sees `generation > 0`, treats that empty set as authoritative (`sidebarRoster.ts:54-55,76`), and hides every row the stream owns. Native categories survive the same code path only because they share one `nativeIds` union; imported categories are each independently authoritative, so for them the blanking is total.

Net effect of one provider's bad disk: the sidebar silently reports "you have no imported history" while the cache holds every row.

## Solution

**Rust — isolate data failures per source, keep contract failures hard.** A failing `query_imported_sidebar_page_from_conn` now warns and marks that one source with an `error`, leaving the other sources' pages intact in the same round-trip (no extra IPC). Contract violations — unknown source, duplicate source/bucket, zero limit, inverted range — stay hard errors, because those are caller bugs, not a provider's disk.

**Frontend — a failed source is UNKNOWN, never empty.** Returning an empty page for a broken source would be worse than the bug: it publishes an authoritative page of zero ids and retires that source's rows permanently. The loader records the failure separately, and the error path no longer writes `generation`, so the matcher keeps showing last-known rows (or, on cold start, stays out of the way at generation 0) instead of blanking the stream.

## Verification

- `src/store/session/sessionAtom/__tests__/sidebarLoaders.test.ts` — two new tests, both **verified to fail without the fix** (2 failed / 19 passed on a stashed source tree; 21/21 with it): one pins that a healthy sibling still publishes its rows while a broken source reports `error`, the other pins `generation === 0` for every imported stream when the whole batch rejects. The `generation` assertion is the one that catches this class.
- `src/store/session` suite: 183 passed. `pnpm typecheck` clean. `cargo test -p org2 external_history` green; rustfmt + clippy clean on the touched files.
- Live fault-injection on the desktop app follows in a comment.

## Risks

The response type gains an optional `error` field (additive, `skip_serializing_if`), so an older frontend against a newer backend still parses. A source that fails mid-batch returns no buckets, which the frontend deliberately does not merge into pagination — cursors for that source are left untouched for the next pass rather than reset. Rollback is a revert.

