### PR TITLE
fix(workstation): tear down closed browser resources

### DIFF
--- a/src/hooks/platform/useInlineWebview/__tests__/useWebviewCommands.test.ts
+++ b/src/hooks/platform/useInlineWebview/__tests__/useWebviewCommands.test.ts
@@ -88,3 +88,61 @@ describe("useWebviewCommands reload", () => {
     expect(setIsLoading).not.toHaveBeenCalled();
   });
 });
+
+describe("useWebviewCommands lifecycle", () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+  });
+
+  it("shares overlapping create requests and releases one ref-count slot", async () => {
+    let finishCreate: (() => void) | undefined;
+    invokeMock.mockImplementation((command: string) => {
+      if (command === "create_inline_webview") {
+        return new Promise<void>((resolve) => {
+          finishCreate = resolve;
+        });
+      }
+      return Promise.resolve();
+    });
+
+    const { useWebviewCommands } = await import("../useWebviewCommands");
+    const rect = {
+      x: 0,
+      y: 0,
+      width: 800,
+      height: 600,
+      top: 0,
+      right: 800,
+      bottom: 600,
+      left: 0,
+      toJSON: () => ({}),
+    } as DOMRect;
+    const commands = useWebviewCommands(
+      createParams({
+        isWebviewCreated: false,
+        containerRef: { current: {} as HTMLDivElement },
+        getContainerRect: () => rect,
+      })
+    );
+
+    const first = commands.createWebview("https://example.com");
+    const second = commands.createWebview("https://example.com");
+
+    expect(second).toBe(first);
+    expect(
+      invokeMock.mock.calls.filter(([command]) =>
+        Object.is(command, "create_inline_webview")
+      )
+    ).toHaveLength(1);
+
+    finishCreate?.();
+    await Promise.all([first, second]);
+    await commands.destroy();
+
+    expect(
+      invokeMock.mock.calls.filter(([command]) =>
+        Object.is(command, "close_inline_webview")
+      )
+    ).toHaveLength(1);
+  });
+});

--- a/src/hooks/platform/useInlineWebview/useWebviewCommands.ts
+++ b/src/hooks/platform/useInlineWebview/useWebviewCommands.ts
@@ -78,89 +78,111 @@ export function useWebviewCommands(
   // (and therefore incremented the Rust ref-count). Only when this is true should
   // we call close_inline_webview to decrement the ref-count on destroy.
   const hasIncrementedRefCount = useRef(false);
+  const createInFlightRef = useRef<Promise<void> | null>(null);
   const lifecycleGenerationRef = useRef(0);
 
   const createWebview = useCallback(
-    async (targetUrl: string) => {
+    (targetUrl: string): Promise<void> => {
       if (
         !isWebviewAvailable ||
         !containerRef.current ||
         isDestroyedRef.current
       ) {
         log("Cannot create WebView - not available or no container");
-        return;
+        return Promise.resolve();
+      }
+
+      // A single React owner must hold exactly one Rust ref-count slot. Effect
+      // restarts (for example, Station visibility changing while creation is
+      // still awaiting IPC) may call this again before state reflects success.
+      if (hasIncrementedRefCount.current) {
+        return Promise.resolve();
+      }
+      if (createInFlightRef.current) {
+        return createInFlightRef.current;
       }
 
       const rect = getContainerRect();
       if (!rect || rect.width === 0 || rect.height === 0) {
         log("Container has no dimensions, skipping WebView creation");
-        return;
+        return Promise.resolve();
       }
 
-      try {
-        if (!isUnmountedRef.current) {
-          setIsLoading(true);
-          setError(null);
-        }
+      const operation = (async () => {
+        try {
+          if (!isUnmountedRef.current) {
+            setIsLoading(true);
+            setError(null);
+          }
 
-        const appWindow = getCurrentWindow();
-        const parentLabel = appWindow.label;
-        const generation = Math.max(
-          lifecycleGenerationRef.current + 1,
-          Date.now()
-        );
-        lifecycleGenerationRef.current = generation;
+          const appWindow = getCurrentWindow();
+          const parentLabel = appWindow.label;
+          const generation = Math.max(
+            lifecycleGenerationRef.current + 1,
+            Date.now()
+          );
+          lifecycleGenerationRef.current = generation;
 
-        log("Creating WebView via Rust command at rect:", rect);
+          log("Creating WebView via Rust command at rect:", rect);
 
-        const frame = toNativeFrame(rect);
-        await invoke("create_inline_webview", {
-          parentWindow: parentLabel,
-          label: labelRef.current,
-          url: targetUrl,
-          ...frame,
-          userAgent: userAgent,
-          incognito: incognito,
-          generation,
-          visible: isVisible,
-        });
-
-        // Mark that this instance has a ref-count slot. Even if we are already
-        // unmounted at this point we still need to release it.
-        hasIncrementedRefCount.current = true;
-
-        // create_inline_webview returns with the webview staged offscreen.
-        // Rust uses the generation to prevent stale creates from becoming visible.
-        if (isUnmountedRef.current) {
-          // Unmounted while create was in-flight. Release the ref-count so the
-          // offscreen webview is destroyed without ever being shown.
-          void invoke("close_inline_webview", {
+          const frame = toNativeFrame(rect);
+          await invoke("create_inline_webview", {
+            parentWindow: parentLabel,
             label: labelRef.current,
+            url: targetUrl,
+            ...frame,
+            userAgent: userAgent,
+            incognito: incognito,
             generation,
+            visible: isVisible,
           });
-          return;
+
+          // Mark that this instance has a ref-count slot. Even if we are already
+          // unmounted at this point we still need to release it.
+          hasIncrementedRefCount.current = true;
+
+          // create_inline_webview returns with the webview staged offscreen.
+          // Rust uses the generation to prevent stale creates from becoming visible.
+          if (isUnmountedRef.current) {
+            // Unmounted while create was in-flight. Release the ref-count so the
+            // offscreen webview is destroyed without ever being shown.
+            hasIncrementedRefCount.current = false;
+            await invoke("close_inline_webview", {
+              label: labelRef.current,
+              generation,
+            });
+            return;
+          }
+
+          setIsWebviewCreated(true);
+          setCurrentUrl(targetUrl);
+          lastPolledUrlRef.current = targetUrl;
+
+          log("WebView created successfully with label:", labelRef.current);
+
+          const webviewProxy = {
+            label: () => labelRef.current,
+          } as unknown as Webview;
+          onCreated?.(webviewProxy);
+
+          setIsLoading(false);
+        } catch (err) {
+          if (isUnmountedRef.current) return;
+          const error = err instanceof Error ? err : new Error(String(err));
+          log("Failed to create WebView:", error);
+          setError(error);
+          setIsLoading(false);
+          onError?.(error);
         }
+      })();
 
-        setIsWebviewCreated(true);
-        setCurrentUrl(targetUrl);
-        lastPolledUrlRef.current = targetUrl;
-
-        log("WebView created successfully with label:", labelRef.current);
-
-        const webviewProxy = {
-          label: () => labelRef.current,
-        } as unknown as Webview;
-        onCreated?.(webviewProxy);
-
-        setIsLoading(false);
-      } catch (err) {
-        if (isUnmountedRef.current) return;
-        const error = err instanceof Error ? err : new Error(String(err));
-        log("Failed to create WebView:", error);
-        setError(error);
-        setIsLoading(false);
-        onError?.(error);
-      }
+      createInFlightRef.current = operation;
+      void operation.finally(() => {
+        if (createInFlightRef.current === operation) {
+          createInFlightRef.current = null;
+        }
+      });
+      return operation;
     },
     [
       isWebviewAvailable,

--- a/src/services/workStation/EditorTabService.ts
+++ b/src/services/workStation/EditorTabService.ts
@@ -13,6 +13,7 @@ import {
   closeOtherTabs as closeOtherTabsHelper,
   closeSavedTabs as closeSavedTabsHelper,
   closeWorkstationTabAtom,
+  closeWorkstationTabsAtom,
   createExplorerTab,
   focusWorkstationTabAtom,
   openWorkstationTabAtom,
@@ -34,30 +35,23 @@ function getMainPane(workspace = currentWorkspace()): PanelState {
   return selectWorkstationPanel(store.get(workstationTabsStateAtom), workspace);
 }
 
-function updateMainPane(
+function closeFromMainPane(
   updater: (state: PanelState) => PanelState,
   workspace = currentWorkspace()
 ): void {
   const before = getMainPane(workspace);
   const after = updater(before);
   if (after === before) return;
-  // Compatibility path for compound operations. Simple open/close/focus/reorder
-  // methods below use explicit scoped actions so delayed callers can freeze key.
   const store = getStore();
-  for (const tab of before.tabs) {
-    if (!after.tabs.some((candidate) => candidate.id === tab.id)) {
-      store.set(closeWorkstationTabAtom, { workspace, tabId: tab.id });
-    }
-  }
-  for (const tab of after.tabs) {
-    store.set(openWorkstationTabAtom, { workspace, tab });
-  }
-  if (after.activeTabId) {
-    store.set(focusWorkstationTabAtom, {
-      workspace,
-      tabId: after.activeTabId,
-    });
-  }
+  const remainingIds = new Set(after.tabs.map((tab) => tab.id));
+  const tabIds = before.tabs
+    .filter((tab) => !remainingIds.has(tab.id))
+    .map((tab) => tab.id);
+  store.set(closeWorkstationTabsAtom, {
+    workspace,
+    tabIds,
+    activeTabId: after.activeTabId,
+  });
 }
 
 export const EditorTabService = {
@@ -107,18 +101,18 @@ export const EditorTabService = {
   },
 
   closeAllTabs(): boolean {
-    updateMainPane(closeAllTabsHelper);
+    closeFromMainPane(closeAllTabsHelper);
     return true;
   },
 
   closeOtherTabs(tabId: string): boolean {
     if (!this.hasTab(tabId)) return false;
-    updateMainPane((paneState) => closeOtherTabsHelper(paneState, tabId));
+    closeFromMainPane((paneState) => closeOtherTabsHelper(paneState, tabId));
     return true;
   },
 
   closeSavedTabs(): boolean {
-    updateMainPane(closeSavedTabsHelper);
+    closeFromMainPane(closeSavedTabsHelper);
     return true;
   },
 

--- a/src/store/workstation/browser/tabs/__tests__/sharedWorkspaceIntegration.test.ts
+++ b/src/store/workstation/browser/tabs/__tests__/sharedWorkspaceIntegration.test.ts
@@ -12,6 +12,8 @@ import type {
 import {
   browserTabsAtom,
   closeBrowserTabAtom,
+  closeOtherBrowserTabsAtom,
+  closeSavedBrowserTabsAtom,
   createBrowserSessionTab,
   removeBrowserResourceTabAtom,
   sharedBrowserTabsAtom,
@@ -208,5 +210,22 @@ describe("browserTabsAtom shared-resource integration", () => {
     store.set(removeBrowserResourceTabAtom, browserTab.id);
 
     expect(store.get(workstationTabsStateAtom).shared.tabs).toEqual([]);
+  });
+
+  it("tears down omitted resources through browser-owned bulk close actions", () => {
+    const store = createStore();
+    const browserA = createBrowserSessionTab("browser-1", "One");
+    const browserB = createBrowserSessionTab("browser-2", "Two");
+    const browserC = createBrowserSessionTab("browser-3", "Three");
+    store.set(browserTabsAtom, {
+      tabs: [browserA, browserB, browserC],
+      activeTabId: browserB.id,
+    });
+
+    store.set(closeOtherBrowserTabsAtom, browserA.id);
+    expect(store.get(sharedBrowserTabsAtom)).toEqual([browserA]);
+
+    store.set(closeSavedBrowserTabsAtom);
+    expect(store.get(sharedBrowserTabsAtom)).toEqual([]);
   });
 });

--- a/src/store/workstation/browser/tabs/index.ts
+++ b/src/store/workstation/browser/tabs/index.ts
@@ -19,6 +19,7 @@ import { getSiteNameFromUrl } from "@src/store/ui/navigationSidebarTabsAtom";
 import type { PanelState } from "@src/store/workstation/tabs";
 import {
   removeSharedWorkstationTabAtom,
+  removeSharedWorkstationTabsAtom,
   workstationLayoutAtom,
   workstationTabsStateAtom,
 } from "@src/store/workstation/tabs/atoms";
@@ -373,7 +374,12 @@ export const closeOtherBrowserTabsAtom = atom(
   null,
   (get, set, tabId: string) => {
     const state = get(browserTabsAtom);
-    set(browserTabsAtom, closeOtherTabsMutation(state, tabId));
+    const next = closeOtherTabsMutation(state, tabId);
+    const nextIds = new Set(next.tabs.map((tab) => tab.id));
+    set(
+      removeSharedWorkstationTabsAtom,
+      state.tabs.filter((tab) => !nextIds.has(tab.id)).map((tab) => tab.id)
+    );
   }
 );
 
@@ -382,7 +388,12 @@ export const closeOtherBrowserTabsAtom = atom(
  */
 export const closeSavedBrowserTabsAtom = atom(null, (get, set) => {
   const state = get(browserTabsAtom);
-  set(browserTabsAtom, closeSavedTabsMutation(state));
+  const next = closeSavedTabsMutation(state);
+  const nextIds = new Set(next.tabs.map((tab) => tab.id));
+  set(
+    removeSharedWorkstationTabsAtom,
+    state.tabs.filter((tab) => !nextIds.has(tab.id)).map((tab) => tab.id)
+  );
 });
 
 /**

--- a/src/store/workstation/tabRegistry/atoms.test.ts
+++ b/src/store/workstation/tabRegistry/atoms.test.ts
@@ -1,10 +1,25 @@
+import { createStore } from "jotai/vanilla";
 import { describe, expect, it } from "vitest";
 
-import { workstationLayoutAtom } from "@src/store/workstation/tabs";
-import type { WorkStationTab } from "@src/store/workstation/tabs";
-import { createInstrumentedStore } from "@src/util/core/state/instrumentedStore";
+import { workstationActiveSessionIdAtom } from "@src/store/session/viewAtom";
+import { createBrowserSessionTab } from "@src/store/workstation/browser/tabs";
+import {
+  type WorkStationTab,
+  workstationLayoutAtom,
+  workstationTabsStateAtom,
+} from "@src/store/workstation/tabs";
+import {
+  WORKSTATION_V3_SHARED_KEY,
+  emptyWorkstationTabsState,
+} from "@src/store/workstation/tabs/storage";
 
-import { closeProjectOrgWorkStationTabsAtom } from "./atoms";
+import {
+  closeActiveWorkStationTabAtom,
+  closeOtherTabsAtom,
+  closeProjectOrgWorkStationTabsAtom,
+  closeSavedTabsAtom,
+  closeTabAtom,
+} from "./atoms";
 
 function tab(id: string, orgId?: string): WorkStationTab {
   return {
@@ -17,7 +32,7 @@ function tab(id: string, orgId?: string): WorkStationTab {
 
 describe("closeProjectOrgWorkStationTabsAtom", () => {
   it("closes every surface for the deleted org and keeps other tabs", () => {
-    const store = createInstrumentedStore();
+    const store = createStore();
     store.set(workstationLayoutAtom, {
       mainPane: {
         tabs: [
@@ -38,5 +53,123 @@ describe("closeProjectOrgWorkStationTabsAtom", () => {
     expect(store.get(workstationLayoutAtom).mainPane.activeTabId).toBe(
       "live-org"
     );
+  });
+});
+
+describe("live shared-resource close semantics", () => {
+  function fileTab(id: string, hasUnsavedChanges = false): WorkStationTab {
+    return {
+      id,
+      type: "file",
+      title: id,
+      data: { filePath: id.replace("file:", "") },
+      hasUnsavedChanges,
+    };
+  }
+
+  function sharedTab(
+    id: string,
+    type: "settings" | "terminal"
+  ): WorkStationTab {
+    return { id, type, title: id, data: {} };
+  }
+
+  it("tears down a browser resource through the unified TabBar close path", () => {
+    const store = createStore();
+    const state = emptyWorkstationTabsState();
+    const browser = createBrowserSessionTab("browser-1", "Example");
+    const local = fileTab("file:/a.ts");
+    state.shared.tabs = [browser];
+    state.sessionWorkspaces.A = {
+      tabs: [local],
+      activeTabRef: { partition: "shared", tabId: browser.id },
+      tabOrder: [
+        { partition: "shared", tabId: browser.id },
+        { partition: "workspace", tabId: local.id },
+      ],
+    };
+    state.sessionWorkspaces.B = {
+      tabs: [],
+      activeTabRef: { partition: "shared", tabId: browser.id },
+      tabOrder: [{ partition: "shared", tabId: browser.id }],
+    };
+    store.set(workstationTabsStateAtom, state);
+    store.set(workstationActiveSessionIdAtom, "A");
+
+    store.set(closeTabAtom, { tabId: browser.id });
+
+    const next = store.get(workstationTabsStateAtom);
+    expect(next.shared.tabs).toEqual([]);
+    expect(next.sessionWorkspaces.A.tabOrder).toEqual([
+      { partition: "workspace", tabId: local.id },
+    ]);
+    expect(next.sessionWorkspaces.B.tabOrder).toEqual([]);
+    expect(
+      JSON.parse(localStorage.getItem(WORKSTATION_V3_SHARED_KEY) ?? "null")
+    ).toEqual({ tabs: [] });
+
+    store.set(workstationActiveSessionIdAtom, "B");
+    expect(store.get(workstationLayoutAtom).mainPane.tabs).toEqual([]);
+  });
+
+  it("uses the same resource teardown for the active-tab shortcut path", () => {
+    const store = createStore();
+    const browser = createBrowserSessionTab("browser-1", "Example");
+    store.set(workstationLayoutAtom, {
+      mainPane: { tabs: [browser], activeTabId: browser.id },
+    });
+
+    expect(store.set(closeActiveWorkStationTabAtom)).toBe(true);
+
+    expect(store.get(workstationTabsStateAtom).shared.tabs).toEqual([]);
+  });
+
+  it("batch-closes live resources once while retaining hidden lightweight shared tabs", () => {
+    const store = createStore();
+    const browserA = createBrowserSessionTab("browser-1", "One");
+    const browserB = createBrowserSessionTab("browser-2", "Two");
+    const terminal = sharedTab("terminal:main", "terminal");
+    const settings = sharedTab("settings:main", "settings");
+    const dirtyFile = fileTab("file:/dirty.ts", true);
+    store.set(workstationLayoutAtom, {
+      mainPane: {
+        tabs: [browserA, browserB, terminal, settings, dirtyFile],
+        activeTabId: browserB.id,
+      },
+    });
+
+    store.set(closeSavedTabsAtom);
+
+    const next = store.get(workstationTabsStateAtom);
+    expect(next.shared.tabs).toEqual([settings]);
+    expect(store.get(workstationLayoutAtom).mainPane).toEqual({
+      tabs: [dirtyFile],
+      activeTabId: dirtyFile.id,
+    });
+  });
+
+  it("removes every omitted live resource through Close Others", () => {
+    const store = createStore();
+    const browserA = createBrowserSessionTab("browser-1", "One");
+    const browserB = createBrowserSessionTab("browser-2", "Two");
+    const terminal = sharedTab("terminal:main", "terminal");
+    const settings = sharedTab("settings:main", "settings");
+    store.set(workstationLayoutAtom, {
+      mainPane: {
+        tabs: [browserA, browserB, terminal, settings],
+        activeTabId: browserB.id,
+      },
+    });
+
+    store.set(closeOtherTabsAtom, { keepTabId: browserA.id });
+
+    expect(store.get(workstationTabsStateAtom).shared.tabs).toEqual([
+      browserA,
+      settings,
+    ]);
+    expect(store.get(workstationLayoutAtom).mainPane).toEqual({
+      tabs: [browserA],
+      activeTabId: browserA.id,
+    });
   });
 });

--- a/src/store/workstation/tabRegistry/atoms.ts
+++ b/src/store/workstation/tabRegistry/atoms.ts
@@ -7,7 +7,7 @@
  * - Writers never mutate the registry directly; they all route through
  *   `workstationLayoutAtom` so persistence and read paths stay coherent.
  */
-import { atom } from "jotai";
+import { type Getter, type Setter, atom } from "jotai";
 
 import {
   type PanelState,
@@ -15,6 +15,8 @@ import {
   closeOtherTabs as closeOtherTabsMutation,
   closeSavedTabs as closeSavedTabsMutation,
   closeTab as closeTabMutation,
+  closeWorkstationTabsAtom,
+  presentedWorkstationWorkspaceKeyAtom,
   reorderTabs as reorderTabsMutation,
   switchTab as switchTabMutation,
   workstationLayoutAtom,
@@ -53,6 +55,24 @@ function setMainPane(
   return { ...layout, mainPane: next };
 }
 
+function closePresentedTabs(
+  get: Getter,
+  set: Setter,
+  nextPane: PanelState,
+  previousPane: PanelState
+): void {
+  const nextIds = new Set(nextPane.tabs.map((tab) => tab.id));
+  const tabIds = previousPane.tabs
+    .filter((tab) => !nextIds.has(tab.id))
+    .map((tab) => tab.id);
+  if (tabIds.length === 0) return;
+  set(closeWorkstationTabsAtom, {
+    workspace: get(presentedWorkstationWorkspaceKeyAtom),
+    tabIds,
+    activeTabId: nextPane.activeTabId,
+  });
+}
+
 export const focusTabAtom = atom(null, (get, set, request: TabFocusRequest) => {
   const layout = get(workstationLayoutAtom);
   if (!layout) return;
@@ -67,9 +87,11 @@ focusTabAtom.debugLabel = "focusTabAtom";
 export const closeTabAtom = atom(null, (get, set, request: TabCloseRequest) => {
   const layout = get(workstationLayoutAtom);
   if (!layout) return;
-  set(
-    workstationLayoutAtom,
-    setMainPane(layout, closeTabMutation(layout.mainPane, request.tabId))
+  closePresentedTabs(
+    get,
+    set,
+    closeTabMutation(layout.mainPane, request.tabId),
+    layout.mainPane
   );
 });
 closeTabAtom.debugLabel = "closeTabAtom";
@@ -105,7 +127,7 @@ export const closeProjectOrgWorkStationTabsAtom = atom(
     for (const tabId of tabIds) {
       nextPane = closeTabMutation(nextPane, tabId);
     }
-    set(workstationLayoutAtom, setMainPane(layout, nextPane));
+    closePresentedTabs(get, set, nextPane, layout.mainPane);
   }
 );
 closeProjectOrgWorkStationTabsAtom.debugLabel =
@@ -138,12 +160,11 @@ export const closeOtherTabsAtom = atom(
   (get, set, request: TabCloseOtherRequest) => {
     const layout = get(workstationLayoutAtom);
     if (!layout) return;
-    set(
-      workstationLayoutAtom,
-      setMainPane(
-        layout,
-        closeOtherTabsMutation(layout.mainPane, request.keepTabId)
-      )
+    closePresentedTabs(
+      get,
+      set,
+      closeOtherTabsMutation(layout.mainPane, request.keepTabId),
+      layout.mainPane
     );
   }
 );
@@ -152,9 +173,11 @@ closeOtherTabsAtom.debugLabel = "closeOtherTabsAtom";
 export const closeSavedTabsAtom = atom(null, (get, set) => {
   const layout = get(workstationLayoutAtom);
   if (!layout) return;
-  set(
-    workstationLayoutAtom,
-    setMainPane(layout, closeSavedTabsMutation(layout.mainPane))
+  closePresentedTabs(
+    get,
+    set,
+    closeSavedTabsMutation(layout.mainPane),
+    layout.mainPane
   );
 });
 closeSavedTabsAtom.debugLabel = "closeSavedTabsAtom";

--- a/src/store/workstation/tabs/__tests__/workspaceState.test.ts
+++ b/src/store/workstation/tabs/__tests__/workspaceState.test.ts
@@ -24,6 +24,7 @@ import {
   type WorkstationTabOwnership,
   type WorkstationTabsStateV3,
   type WorkstationWorkspaceState,
+  closesSharedResourceOnDismiss,
   getWorkstationTabOwnership,
 } from "../types";
 
@@ -132,6 +133,9 @@ describe("WorkStation tab ownership policy", () => {
     expect(getWorkstationTabOwnership("terminal-content")).toBe(
       "workspace-local"
     );
+    expect(closesSharedResourceOnDismiss("browser-session")).toBe(true);
+    expect(closesSharedResourceOnDismiss("terminal")).toBe(true);
+    expect(closesSharedResourceOnDismiss("settings")).toBe(false);
   });
 });
 

--- a/src/store/workstation/tabs/atoms.ts
+++ b/src/store/workstation/tabs/atoms.ts
@@ -23,6 +23,7 @@ import {
   type WorkstationTabsStateV3,
   type WorkstationWorkspaceKey,
   type WorkstationWorkspaceState,
+  closesSharedResourceOnDismiss,
   getWorkstationTabOwnership,
 } from "./types";
 
@@ -257,6 +258,13 @@ export interface ScopedWorkstationTabRequest {
   tab: WorkStationTab;
 }
 
+export interface CloseWorkstationTabsRequest {
+  workspace: WorkstationWorkspaceKey;
+  tabIds: readonly string[];
+  /** Preserve bulk-close selection semantics when the active tab is removed. */
+  activeTabId?: string | null;
+}
+
 function updateScopedPanel(
   state: WorkstationTabsStateV3,
   workspace: WorkstationWorkspaceKey,
@@ -280,20 +288,100 @@ export const openWorkstationTabAtom = atom(
 );
 openWorkstationTabAtom.debugLabel = "openWorkstationTabAtom";
 
+function removeSharedTabsFromState(
+  state: WorkstationTabsStateV3,
+  tabIds: ReadonlySet<string>
+): WorkstationTabsStateV3 {
+  if (
+    tabIds.size === 0 ||
+    !state.shared.tabs.some((tab) => tabIds.has(tab.id))
+  ) {
+    return state;
+  }
+
+  const removeRefs = (
+    workspace: WorkstationWorkspaceState
+  ): WorkstationWorkspaceState => {
+    const tabOrder = workspace.tabOrder.filter(
+      (ref) => !(ref.partition === "shared" && tabIds.has(ref.tabId))
+    );
+    const activeTabRef =
+      workspace.activeTabRef?.partition === "shared" &&
+      tabIds.has(workspace.activeTabRef.tabId)
+        ? (tabOrder[0] ?? null)
+        : workspace.activeTabRef;
+    return { ...workspace, activeTabRef, tabOrder };
+  };
+
+  return {
+    ...state,
+    shared: {
+      tabs: state.shared.tabs.filter((tab) => !tabIds.has(tab.id)),
+    },
+    globalWorkspace: removeRefs(state.globalWorkspace),
+    sessionWorkspaces: Object.fromEntries(
+      Object.entries(state.sessionWorkspaces).map(([sessionId, workspace]) => [
+        sessionId,
+        removeRefs(workspace),
+      ])
+    ),
+  };
+}
+
+/**
+ * Canonical explicit-close path. Workspace-local and lightweight shared tabs
+ * are removed only from the requested workspace. Live Browser/Terminal tabs
+ * also lose their global resource record, which drives owner teardown.
+ */
+export const closeWorkstationTabsAtom = atom(
+  null,
+  (get, set, request: CloseWorkstationTabsRequest) => {
+    const state = get(workstationTabsStateAtom);
+    const panel = composePanel(state, request.workspace);
+    const requestedIds = new Set(request.tabIds);
+    const tabsToClose = panel.tabs.filter((tab) => requestedIds.has(tab.id));
+    if (tabsToClose.length === 0) return;
+
+    let nextPanel = panel;
+    for (const tab of tabsToClose) {
+      nextPanel = closeTabMutation(nextPanel, tab.id);
+    }
+    if (request.activeTabId !== undefined) {
+      const requestedActiveExists = nextPanel.tabs.some(
+        (tab) => tab.id === request.activeTabId
+      );
+      nextPanel = {
+        ...nextPanel,
+        activeTabId: requestedActiveExists ? request.activeTabId : null,
+      };
+    }
+
+    const resourceIds = new Set(
+      tabsToClose
+        .filter((tab) => closesSharedResourceOnDismiss(tab.type))
+        .map((tab) => tab.id)
+    );
+
+    const nextState = removeSharedTabsFromState(
+      splitPanel(state, request.workspace, nextPanel),
+      resourceIds
+    );
+    setAndPersist(set, nextState);
+  }
+);
+closeWorkstationTabsAtom.debugLabel = "closeWorkstationTabsAtom";
+
 export const closeWorkstationTabAtom = atom(
   null,
   (
-    get,
+    _get,
     set,
     request: { workspace: WorkstationWorkspaceKey; tabId: string }
   ) => {
-    const state = get(workstationTabsStateAtom);
-    setAndPersist(
-      set,
-      updateScopedPanel(state, request.workspace, (panel) =>
-        closeTabMutation(panel, request.tabId)
-      )
-    );
+    set(closeWorkstationTabsAtom, {
+      workspace: request.workspace,
+      tabIds: [request.tabId],
+    });
   }
 );
 closeWorkstationTabAtom.debugLabel = "closeWorkstationTabAtom";
@@ -305,38 +393,23 @@ closeWorkstationTabAtom.debugLabel = "closeWorkstationTabAtom";
  */
 export const removeSharedWorkstationTabAtom = atom(
   null,
-  (get, set, tabId: string) => {
-    const state = get(workstationTabsStateAtom);
-    if (!state.shared.tabs.some((tab) => tab.id === tabId)) return;
-    const removeRef = (workspace: WorkstationWorkspaceState) => {
-      const tabOrder = workspace.tabOrder.filter(
-        (ref) => !(ref.partition === "shared" && ref.tabId === tabId)
-      );
-      return {
-        ...workspace,
-        activeTabRef:
-          workspace.activeTabRef?.partition === "shared" &&
-          workspace.activeTabRef.tabId === tabId
-            ? (tabOrder[0] ?? null)
-            : workspace.activeTabRef,
-        tabOrder,
-      };
-    };
-    setAndPersist(set, {
-      ...state,
-      shared: {
-        tabs: state.shared.tabs.filter((tab) => tab.id !== tabId),
-      },
-      globalWorkspace: removeRef(state.globalWorkspace),
-      sessionWorkspaces: Object.fromEntries(
-        Object.entries(state.sessionWorkspaces).map(
-          ([sessionId, workspace]) => [sessionId, removeRef(workspace)]
-        )
-      ),
-    });
+  (_get, set, tabId: string) => {
+    set(removeSharedWorkstationTabsAtom, [tabId]);
   }
 );
 removeSharedWorkstationTabAtom.debugLabel = "removeSharedWorkstationTabAtom";
+
+/** Remove multiple shared resources and every workspace reference in one write. */
+export const removeSharedWorkstationTabsAtom = atom(
+  null,
+  (get, set, tabIds: readonly string[]) => {
+    const state = get(workstationTabsStateAtom);
+    const next = removeSharedTabsFromState(state, new Set(tabIds));
+    if (next === state) return;
+    setAndPersist(set, next);
+  }
+);
+removeSharedWorkstationTabsAtom.debugLabel = "removeSharedWorkstationTabsAtom";
 
 export const focusWorkstationTabAtom = atom(
   null,

--- a/src/store/workstation/tabs/index.ts
+++ b/src/store/workstation/tabs/index.ts
@@ -33,10 +33,13 @@ export type {
   ToolTabType,
 } from "./types";
 
+export type { CloseWorkstationTabsRequest } from "./atoms";
+
 export {
   FILE_TAB_TYPES,
   TOOL_TAB_TYPES,
   getWorkstationTabOwnership,
+  closesSharedResourceOnDismiss,
 } from "./types";
 
 // ============================================
@@ -52,7 +55,9 @@ export {
   claimLegacyWorkstationSeedAtom,
   disposeWorkstationWorkspaceAtom,
   openWorkstationTabAtom,
+  closeWorkstationTabsAtom,
   closeWorkstationTabAtom,
+  removeSharedWorkstationTabsAtom,
   removeSharedWorkstationTabAtom,
   focusWorkstationTabAtom,
   updateWorkstationTabDataAtom,

--- a/src/store/workstation/tabs/types.ts
+++ b/src/store/workstation/tabs/types.ts
@@ -208,6 +208,17 @@ export interface WorkstationTabsStateV3 {
 export type WorkstationTabOwnership = "workspace-local" | "shared-resource";
 
 /**
+ * Closing most shared tabs only hides them from the current task workspace.
+ * Browser and Terminal tabs are different: they own live sessions, so an
+ * explicit user close must tear the resource down globally as well.
+ */
+export function closesSharedResourceOnDismiss(
+  type: WorkStationTabType
+): boolean {
+  return type === "browser-session" || type === "terminal";
+}
+
+/**
  * Exhaustive ownership policy. There is intentionally no default: adding a
  * tab type must include an explicit product decision about its owner.
  */


### PR DESCRIPTION
## Problem

Closing a Browser tab from the unified Workstation TabBar removed only the current workspace reference. The shared browser resource and persisted BrowserContext session remained, so switching from My Station to Agent's Station and back remounted the owner and restored the supposedly closed tab.

The same divergent semantics existed in Close Others, Close Saved, active-tab shortcuts, and EditorTabService compound closes. Station visibility changes could also restart inline-WebView creation while the first IPC call was still in flight, acquiring more than one Rust ref-count slot for one React owner.

## Solution

Add one canonical batch close path for Workstation tabs and route every explicit close entry point through it.

Browser and Terminal tabs own live shared resources, so explicit dismissal now removes the global resource, all workspace references, and persisted state in one write. Lightweight shared tabs such as Settings retain the existing workspace-hide behavior. Browser-owned bulk actions use the same resource teardown.

Inline-WebView creation is now single-flight per React owner. Overlapping create requests share one promise and acquire exactly one Rust ref-count slot; an unmount during creation releases that slot after IPC completes.

## Potential risks

Explicitly closing a Browser or Terminal tab now closes that live resource globally across Workstation workspaces. This is intentional and matches the owner lifecycle, but callers that only want to hide a shared tab must continue to use workspace projection updates instead of the explicit close action.

There are no dependency, storage-format, public API, IPC-schema, or Rust changes. Rollback is a revert of commit f3ed5d35a; persisted V3 state remains compatible.

## Audit

Architecture review covered ownership, state transitions, close entry points, persistence, React/Tauri lifecycle, and resource teardown. Wire-format and migration layers were skipped because they are unchanged.

Performance guard verdict: pass. The close path performs one persisted batch write, adds no polling, timers, subscriptions, scans, or caches, and prevents duplicate WebView ref-count acquisition.

## Verification

- pnpm exec vitest run src/store/workstation/tabRegistry/atoms.test.ts src/store/workstation/browser/tabs/__tests__/sharedWorkspaceIntegration.test.ts src/store/workstation/tabs/__tests__/workspaceState.test.ts src/hooks/platform/useInlineWebview/__tests__/useWebviewCommands.test.ts --reporter=dot
  - 4 files passed; 26 tests passed.
- pnpm exec tsc --noEmit --pretty false
  - Passed.
- ESLint and Prettier checks on all 11 changed files
  - Passed.
- git diff --check
  - Passed.
- pnpm run tauri:build:fast -- --instance 3
  - Optimized macOS app bundle built successfully.
- Manual macOS verification in an independently identified ORG2 Instance 3:
  - Closed the selected page with the real top TabBar X.
  - Repeated My Station to Agent's Station to My Station five times; the closed page never returned.
  - Native logs showed the target WebView move from ref_count=1 to remaining=0.
  - Cmd+5 opened API Calls / No API calls yet and closed correctly; five repeated cycles did not accumulate physical footprint.
  - The temporary test instance was closed afterward.

The full repository test suite was not run; verification targeted the owning state/lifecycle boundaries and included an optimized desktop build. No screenshot is attached because the fix changes close/lifecycle behavior without changing rendered UI.