### PR TITLE
feat(sidebar): make every session pinnable in every org

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/vinceorz/Projects/ORGII/node_modules

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache.rs
@@ -450,6 +450,10 @@ pub fn query_imported_sidebar_page_from_conn(
                 updated_at: super::epoch_ms_to_iso(row.get(3)?),
                 status: None,
                 is_active: None,
+                // Stamped by the desktop layer from the pin overlay, alongside
+                // the live-status decoration — the core query stays a pure
+                // projection of the imported cache.
+                pinned: false,
                 repo_path: non_empty_string(repo_path),
                 repo_root_path: repo_root_path.and_then(non_empty_string),
                 repo_remote_urls,
@@ -1008,6 +1012,52 @@ where
                 })
         })
         .collect())
+}
+
+/// Set or clear ORGII pin state for one imported session.
+///
+/// Pins live in their own table rather than on the cache row: the cache is a
+/// rebuildable projection whose rows a prune can legitimately delete, and a
+/// pin is user intent that must outlive any rescan.
+pub fn set_imported_session_pinned_from_conn(
+    conn: &Connection,
+    session_id: &str,
+    pinned: bool,
+    pinned_at: &str,
+) -> Result<(), String> {
+    let result = if pinned {
+        conn.execute(
+            "INSERT INTO imported_history_session_pin (session_id, pinned_at)
+             VALUES (?1, ?2)
+             ON CONFLICT(session_id) DO UPDATE SET pinned_at = excluded.pinned_at",
+            params![session_id, pinned_at],
+        )
+    } else {
+        conn.execute(
+            "DELETE FROM imported_history_session_pin WHERE session_id = ?1",
+            params![session_id],
+        )
+    };
+    result
+        .map(|_| ())
+        .map_err(|err| format!("Failed to persist imported session pin: {err}"))
+}
+
+/// The set of imported session ids the user has pinned.
+pub fn pinned_imported_session_ids_from_conn(
+    conn: &Connection,
+) -> Result<HashSet<String>, String> {
+    let mut statement = conn
+        .prepare("SELECT session_id FROM imported_history_session_pin")
+        .map_err(|err| format!("Failed to read imported session pins: {err}"))?;
+    let rows = statement
+        .query_map([], |row| row.get::<_, String>(0))
+        .map_err(|err| format!("Failed to read imported session pins: {err}"))?;
+    let mut ids = HashSet::new();
+    for row in rows {
+        ids.insert(row.map_err(|err| format!("Failed to read imported session pins: {err}"))?);
+    }
+    Ok(ids)
 }
 
 pub fn live_ids_from_signatures(signatures: &[ImportedHistoryRecordSignature]) -> Vec<String> {

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache_tests.rs
@@ -737,3 +737,68 @@ fn init_source_cache_tables_upgrades_legacy_table_missing_columns() {
         "child-session lookup should use its parent index: {query_plan}"
     );
 }
+
+#[test]
+fn imported_pins_round_trip_and_clear() {
+    let conn = fixture_conn();
+    let ids = super::pinned_imported_session_ids_from_conn(&conn).expect("read pins");
+    assert!(ids.is_empty(), "a fresh store has no pins");
+
+    super::set_imported_session_pinned_from_conn(
+        &conn,
+        "claudecodeapp-abc",
+        true,
+        "2026-08-03T12:00:00Z",
+    )
+    .expect("set pin");
+    let ids = super::pinned_imported_session_ids_from_conn(&conn).expect("read pins");
+    assert!(ids.contains("claudecodeapp-abc"));
+
+    // Re-pinning must not duplicate the row (PRIMARY KEY + upsert).
+    super::set_imported_session_pinned_from_conn(
+        &conn,
+        "claudecodeapp-abc",
+        true,
+        "2026-08-03T13:00:00Z",
+    )
+    .expect("re-pin");
+    assert_eq!(
+        super::pinned_imported_session_ids_from_conn(&conn)
+            .expect("read pins")
+            .len(),
+        1
+    );
+
+    super::set_imported_session_pinned_from_conn(&conn, "claudecodeapp-abc", false, "")
+        .expect("unpin");
+    assert!(super::pinned_imported_session_ids_from_conn(&conn)
+        .expect("read pins")
+        .is_empty());
+}
+
+#[test]
+fn a_source_wide_prune_does_not_erase_pins() {
+    // The whole reason pins live in their own table: `prune_missing_records_from_conn`
+    // deletes every cache row of a source whose store momentarily reads as empty
+    // (unreadable directory, provider not installed yet). A `pinned` column on the
+    // cache row would let that wipe the user's pins.
+    let mut conn = fixture_conn();
+    upsert_imported_session_cache_from_conn(&mut conn, &[input(SOURCE_CODEX_APP, "s1", 10)])
+        .expect("seed cache row");
+    super::set_imported_session_pinned_from_conn(
+        &conn,
+        "codexapp-s1",
+        true,
+        "2026-08-03T12:00:00Z",
+    )
+    .expect("pin");
+
+    super::prune_missing_records_from_conn(&conn, SOURCE_CODEX_APP, &[])
+        .expect("prune everything for the source");
+
+    let pins = super::pinned_imported_session_ids_from_conn(&conn).expect("read pins");
+    assert!(
+        pins.contains("codexapp-s1"),
+        "a prune of the rebuildable projection must not take user pin state with it"
+    );
+}

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/mod.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/mod.rs
@@ -276,6 +276,11 @@ pub struct ImportedHistorySidebarRow {
     pub storage_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    /// ORGII-owned pin state, read from `imported_history_session_pin`.
+    /// A pin belongs to ORGII, not to the source app, so it is stored beside
+    /// the rebuildable cache rather than on it.
+    #[serde(default)]
+    pub pinned: bool,
     pub total_tokens: i64,
     pub files_changed: i64,
     pub lines_added: i64,

--- a/src-tauri/crates/orgtrack-core/src/store/sqlite/schema.rs
+++ b/src-tauri/crates/orgtrack-core/src/store/sqlite/schema.rs
@@ -486,6 +486,19 @@ impl SqliteRecordStore<'_> {
             );
             CREATE INDEX IF NOT EXISTS idx_imported_history_repo_identity_refresh
                 ON imported_history_repo_identity(next_refresh_at_ms);
+
+            -- ORGII-owned pin state for imported sessions. Deliberately NOT a
+            -- column on imported_history_session_cache: that table is a
+            -- rebuildable projection of external files, and
+            -- `prune_missing_records_from_conn` deletes every row of a source
+            -- whose store reads as empty — a momentarily unreadable provider
+            -- directory would silently erase the user's pins. Keyed on the
+            -- canonical `session_id` (PREFIX + source id), which is
+            -- deterministic and survives rescans and parser_version bumps.
+            CREATE TABLE IF NOT EXISTS imported_history_session_pin (
+                session_id  TEXT PRIMARY KEY,
+                pinned_at   TEXT NOT NULL DEFAULT ''
+            );
             ",
         )?;
         ensure_column(

--- a/src-tauri/src/agent_sessions/session_directory/commands.rs
+++ b/src-tauri/src/agent_sessions/session_directory/commands.rs
@@ -9,6 +9,7 @@ use std::collections::HashSet;
 use database::db::get_connection;
 use orgtrack_core::sources::cursor_ide::history::CURSORIDE_SESSION_PREFIX;
 use orgtrack_core::sources::imported_history::{
+    cache as imported_cache,
     cache::query_imported_sidebar_page_from_conn,
     metadata::{is_imported_history_source, SOURCE_CURSOR_IDE},
 };
@@ -65,6 +66,9 @@ pub async fn session_external_history_sidebar_list(
     tokio::task::spawn_blocking(move || {
         let conn =
             get_connection().map_err(|err| format!("Failed to open ORGII session cache: {err}"))?;
+        // One read for the whole batch: pins are a small ORGII-owned set, and
+        // a per-row lookup would turn a page render into N queries.
+        let pinned_ids = imported_cache::pinned_imported_session_ids_from_conn(&conn)?;
         let mut sources = Vec::with_capacity(requests.len());
         let mut seen_sources = HashSet::with_capacity(requests.len());
         for source_request in requests {
@@ -129,6 +133,9 @@ pub async fn session_external_history_sidebar_list(
                                 format!("{CURSORIDE_SESSION_PREFIX}{}", session.session_id);
                         }
                     }
+                }
+                for session in &mut page.sessions {
+                    session.pinned = pinned_ids.contains(&session.session_id);
                 }
                 // Live status decoration happens at this desktop boundary
                 // (not in the core query): hook-derived state first, then

--- a/src-tauri/src/agent_sessions/session_directory/patch.rs
+++ b/src-tauri/src/agent_sessions/session_directory/patch.rs
@@ -67,6 +67,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use crate::agent_sessions::cli::persistence as cli_persistence;
 use agent_core::session::persistence as session_persistence;
 use database::db::get_connection;
+use orgtrack_core::sources::imported_history::cache as imported_cache;
 
 /// Deserialize a JSON value into `Some(_)` even if the value is `null`.
 /// Combined with `#[serde(default)]`, this is the canonical recipe to
@@ -126,6 +127,9 @@ pub struct SessionPatch {
 enum SessionLocation {
     Cli,
     Agent,
+    /// Imported history. Owns no native row, so only the fields ORGII stores
+    /// on its own side of the boundary (currently `pinned`) can be patched.
+    Imported,
 }
 
 fn locate_session(session_id: &str) -> SqliteResult<Option<SessionLocation>> {
@@ -151,6 +155,16 @@ fn locate_session(session_id: &str) -> SqliteResult<Option<SessionLocation>> {
         .optional()?;
     if cli_hit.is_some() {
         return Ok(Some(SessionLocation::Cli));
+    }
+    let imported_hit: Option<i64> = conn
+        .query_row(
+            "SELECT 1 FROM imported_history_session_cache WHERE session_id = ?1",
+            params![session_id],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if imported_hit.is_some() {
+        return Ok(Some(SessionLocation::Imported));
     }
     Ok(None)
 }
@@ -234,6 +248,10 @@ pub fn apply_session_patch(session_id: &str, patch: &SessionPatch) -> Result<(),
                 cli_persistence::update_name(session_id, trimmed)
                     .map_err(|err| format!("session_patch update name (cli): {err}"))?;
             }
+            SessionLocation::Imported => {
+                return Err("session_patch: imported sessions do not support name"
+                    .to_string());
+            }
         }
     }
 
@@ -255,6 +273,10 @@ pub fn apply_session_patch(session_id: &str, patch: &SessionPatch) -> Result<(),
                 )
                 .map_err(|err| format!("session_patch update model (cli): {err}"))?;
             }
+            SessionLocation::Imported => {
+                return Err("session_patch: imported sessions do not support model"
+                    .to_string());
+            }
         }
     }
 
@@ -268,6 +290,10 @@ pub fn apply_session_patch(session_id: &str, patch: &SessionPatch) -> Result<(),
             SessionLocation::Cli => {
                 cli_persistence::update_agent_exec_mode(session_id, mode)
                     .map_err(|err| format!("session_patch update agent_exec_mode (cli): {err}"))?;
+            }
+            SessionLocation::Imported => {
+                return Err("session_patch: imported sessions do not support agent_exec_mode"
+                    .to_string());
             }
         }
     }
@@ -290,6 +316,10 @@ pub fn apply_session_patch(session_id: &str, patch: &SessionPatch) -> Result<(),
                 cli_persistence::update_draft_text(session_id, value)
                     .map_err(|err| format!("session_patch update draft_text (cli): {err}"))?;
             }
+            SessionLocation::Imported => {
+                return Err("session_patch: imported sessions do not support draft_text"
+                    .to_string());
+            }
         }
     }
 
@@ -306,6 +336,10 @@ pub fn apply_session_patch(session_id: &str, patch: &SessionPatch) -> Result<(),
                     |err| format!("session_patch update reply_target_event_id (cli): {err}"),
                 )?;
             }
+            SessionLocation::Imported => {
+                return Err("session_patch: imported sessions do not support reply_target_event_id"
+                    .to_string());
+            }
         }
     }
     if let Some(pinned) = patch.pinned {
@@ -317,6 +351,16 @@ pub fn apply_session_patch(session_id: &str, patch: &SessionPatch) -> Result<(),
             SessionLocation::Cli => {
                 cli_persistence::update_pinned(session_id, pinned)
                     .map_err(|err| format!("session_patch update pinned (cli): {err}"))?;
+            }
+            SessionLocation::Imported => {
+                let conn = get_connection()
+                    .map_err(|err| format!("session_patch update pinned (imported): {err}"))?;
+                imported_cache::set_imported_session_pinned_from_conn(
+                    &conn,
+                    session_id,
+                    pinned,
+                    &chrono::Utc::now().to_rfc3339(),
+                )?;
             }
         }
     }

--- a/src/api/tauri/rpc/schemas/sessionAggregate.ts
+++ b/src/api/tauri/rpc/schemas/sessionAggregate.ts
@@ -280,6 +280,8 @@ export const ExternalHistorySidebarRowSchema = z.object({
   // copy, so this is their only storage path.
   storagePath: z.string().optional(),
   model: z.string().optional(),
+  /** ORGII-owned pin state; imported sessions carry no pin from their source. */
+  pinned: z.boolean().optional(),
   totalTokens: z.number().int().optional(),
   filesChanged: z.number().int().optional(),
   linesAdded: z.number().int().optional(),

--- a/src/features/Org2Cloud/cloudPinnedRemoteSessions.test.ts
+++ b/src/features/Org2Cloud/cloudPinnedRemoteSessions.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  PINNED_REMOTE_SESSIONS_STORAGE_KEY,
+  isRemoteSessionPinned,
+  pinnedRemoteSessionKey,
+  readPinnedRemoteSessionIds,
+  togglePinnedRemoteSession,
+  writePinnedRemoteSessionIds,
+} from "./cloudPinnedRemoteSessions";
+
+describe("cloudPinnedRemoteSessions", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("keys on the org and row pair the sidebar already encodes", () => {
+    expect(pinnedRemoteSessionKey("org-1", "row-9")).toBe("org-1|row-9");
+  });
+
+  it("round-trips through storage", () => {
+    writePinnedRemoteSessionIds(new Set(["org-1|row-9"]));
+    expect(readPinnedRemoteSessionIds()).toEqual(new Set(["org-1|row-9"]));
+  });
+
+  it("scopes a pin to its org — the same row id in another org is not pinned", () => {
+    const pinned = new Set([pinnedRemoteSessionKey("org-1", "row-9")]);
+    expect(isRemoteSessionPinned(pinned, "org-1", "row-9")).toBe(true);
+    expect(isRemoteSessionPinned(pinned, "org-2", "row-9")).toBe(false);
+  });
+
+  it("toggles without mutating the set it was given", () => {
+    const before = new Set<string>();
+    const pinned = togglePinnedRemoteSession(before, "org-1", "row-9");
+    expect(before.size).toBe(0);
+    expect(pinned).toEqual(new Set(["org-1|row-9"]));
+
+    const cleared = togglePinnedRemoteSession(pinned, "org-1", "row-9");
+    expect(cleared.size).toBe(0);
+    expect(pinned.size).toBe(1);
+  });
+
+  it("degrades to empty rather than throwing on malformed storage", () => {
+    localStorage.setItem(PINNED_REMOTE_SESSIONS_STORAGE_KEY, "{not json");
+    expect(readPinnedRemoteSessionIds()).toEqual(new Set());
+
+    localStorage.setItem(
+      PINNED_REMOTE_SESSIONS_STORAGE_KEY,
+      JSON.stringify(["org-1|row-9", 42, null])
+    );
+    expect(readPinnedRemoteSessionIds()).toEqual(new Set(["org-1|row-9"]));
+  });
+});

--- a/src/features/Org2Cloud/cloudPinnedRemoteSessions.ts
+++ b/src/features/Org2Cloud/cloudPinnedRemoteSessions.ts
@@ -1,0 +1,69 @@
+/**
+ * localStorage-backed "pinned remote session" bookkeeping for cloud Team
+ * Sessions, mirroring `cloudHiddenRemoteSessions`.
+ *
+ * A pin is the viewer's own view state, not a property of the shared record:
+ * pinning a teammate's session must never mutate the cloud row, and two
+ * viewers of the same session pin independently. That is why this lives
+ * beside the hidden-row set rather than going through `session_patch` — a
+ * Team Session has no local row to patch, and `cloudremote-` ids resolve to
+ * nothing in `agent_sessions` / `code_sessions`.
+ *
+ * Keyed on `<orgId>|<rowId>` — the same stable pair the sidebar already
+ * encodes in every `cloudremote-` menu item id.
+ */
+export const PINNED_REMOTE_SESSIONS_STORAGE_KEY =
+  "orgii:org2-cloud-v1:pinned-remote-sessions";
+
+export function readPinnedRemoteSessionIds(): Set<string> {
+  if (typeof localStorage === "undefined") return new Set();
+  try {
+    const parsed = JSON.parse(
+      localStorage.getItem(PINNED_REMOTE_SESSIONS_STORAGE_KEY) ?? "[]"
+    );
+    return new Set(
+      Array.isArray(parsed) ? parsed.filter((id) => typeof id === "string") : []
+    );
+  } catch {
+    return new Set();
+  }
+}
+
+export function writePinnedRemoteSessionIds(ids: ReadonlySet<string>): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(
+      PINNED_REMOTE_SESSIONS_STORAGE_KEY,
+      JSON.stringify([...ids])
+    );
+  } catch {
+    // Best-effort persistence only.
+  }
+}
+
+export function pinnedRemoteSessionKey(orgId: string, rowId: string): string {
+  return `${orgId}|${rowId}`;
+}
+
+export function isRemoteSessionPinned(
+  pinnedKeys: ReadonlySet<string>,
+  orgId: string,
+  rowId: string
+): boolean {
+  return pinnedKeys.has(pinnedRemoteSessionKey(orgId, rowId));
+}
+
+/**
+ * Toggle one row's pin and return the next set. Returns a new Set so callers
+ * can hand it straight to React state without mutating the current value.
+ */
+export function togglePinnedRemoteSession(
+  pinnedKeys: ReadonlySet<string>,
+  orgId: string,
+  rowId: string
+): Set<string> {
+  const key = pinnedRemoteSessionKey(orgId, rowId);
+  const next = new Set(pinnedKeys);
+  if (!next.delete(key)) next.add(key);
+  return next;
+}

--- a/src/scaffold/NavigationSidebar/components/NavigationMenu/config.ts
+++ b/src/scaffold/NavigationSidebar/components/NavigationMenu/config.ts
@@ -55,6 +55,12 @@ export interface NavigationMenuItem {
   /** Indents the row and draws a vertical guide line for inline child rows. */
   showIndentGuide?: boolean;
   visualTone?: "default" | "secondary";
+  /**
+   * The viewer pinned this row. Set by the row builders (local and cloud) so
+   * grouping can lift pinned rows without inferring membership from which
+   * separator happens to precede them.
+   */
+  pinned?: boolean;
   /** Show hover-only row action buttons. */
   showMoreActions?: boolean;
   rowActions?: NavigationMenuRowAction[];

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudScopedMenuItems.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudScopedMenuItems.test.ts
@@ -182,8 +182,12 @@ describe("buildCloudScopedMenuItems", () => {
     const result = buildCloudScopedMenuItems({
       cloudMenuItems: teamItems,
       sessionMenuItems: [
-        { id: "separator-pinned", key: "separator-pinned", label: "Pinned" },
-        { id: "session-pinned", key: "session-pinned", label: "Pinned one" },
+        {
+          id: "session-pinned",
+          key: "session-pinned",
+          label: "Pinned one",
+          pinned: true,
+        },
         { id: "separator-today", key: "separator-today", label: "Today" },
         { id: "session-today", key: "session-today", label: "Today one" },
       ],
@@ -248,6 +252,46 @@ describe("buildCloudScopedMenuItems", () => {
 
     expect(result.map((item) => item.id)).toEqual([
       "separator-cloud-team-sessions",
+      `separator-${CLOUD_MY_SESSIONS_SECTION_ID}`,
+      "session-today",
+    ]);
+  });
+
+  it("lifts a pinned team session into the same Pinned section", () => {
+    const result = buildCloudScopedMenuItems({
+      cloudMenuItems: [
+        {
+          id: "separator-cloud-team-sessions",
+          key: "separator-cloud-team-sessions",
+          label: "Team sessions",
+        },
+        {
+          id: "cloudremote-org-1|row-9",
+          key: "cloudremote-org-1|row-9",
+          label: "Teammate session",
+          pinned: true,
+        },
+        {
+          id: "cloudremote-org-1|row-8",
+          key: "cloudremote-org-1|row-8",
+          label: "Another teammate session",
+        },
+      ],
+      sessionMenuItems: [
+        { id: "separator-today", key: "separator-today", label: "Today" },
+        { id: "session-today", key: "session-today", label: "Today one" },
+      ],
+      mySessionsLabel: "My sessions",
+      pinnedLabel: "Pinned",
+    });
+
+    // One Pinned section holds both kinds — a pin means "keep this where I can
+    // see it", which is not a promise scoped to one section.
+    expect(result.map((item) => item.id)).toEqual([
+      "separator-cloud-team-sessions",
+      "cloudremote-org-1|row-8",
+      `separator-${CLOUD_PINNED_SECTION_ID}`,
+      "cloudremote-org-1|row-9",
       `separator-${CLOUD_MY_SESSIONS_SECTION_ID}`,
       "session-today",
     ]);

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudScopedMenuItems.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudScopedMenuItems.test.ts
@@ -5,6 +5,7 @@ import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/compone
 import {
   CLOUD_MY_SESSIONS_LOAD_MORE_ID,
   CLOUD_MY_SESSIONS_SECTION_ID,
+  CLOUD_PINNED_SECTION_ID,
   buildCloudScopedMenuItems,
 } from "./cloudScopedMenuItems";
 
@@ -166,6 +167,89 @@ describe("buildCloudScopedMenuItems", () => {
     expect(result.slice(-21).map((item) => item.id)).toEqual([
       ...Array.from({ length: 20 }, (_, index) => `session-${index}`),
       CLOUD_MY_SESSIONS_LOAD_MORE_ID,
+    ]);
+  });
+
+  it("keeps the Pinned section under a cloud scope", () => {
+    const teamItems: NavigationMenuItem[] = [
+      {
+        id: "separator-cloud-team-sessions",
+        key: "separator-cloud-team-sessions",
+        label: "Team sessions",
+      },
+    ];
+
+    const result = buildCloudScopedMenuItems({
+      cloudMenuItems: teamItems,
+      sessionMenuItems: [
+        { id: "separator-pinned", key: "separator-pinned", label: "Pinned" },
+        { id: "session-pinned", key: "session-pinned", label: "Pinned one" },
+        { id: "separator-today", key: "separator-today", label: "Today" },
+        { id: "session-today", key: "session-today", label: "Today one" },
+      ],
+      mySessionsLabel: "My sessions",
+      pinnedLabel: "Pinned",
+    });
+
+    // Pinned is user intent, not a date bucket: it survives the flattening
+    // that removes Today/Older, and its rows do not leak into My sessions.
+    expect(result.map((item) => item.id)).toEqual([
+      "separator-cloud-team-sessions",
+      `separator-${CLOUD_PINNED_SECTION_ID}`,
+      "session-pinned",
+      `separator-${CLOUD_MY_SESSIONS_SECTION_ID}`,
+      "session-today",
+    ]);
+  });
+
+  it("omits the Pinned section when nothing is pinned", () => {
+    const result = buildCloudScopedMenuItems({
+      cloudMenuItems: [
+        {
+          id: "separator-cloud-team-sessions",
+          key: "separator-cloud-team-sessions",
+          label: "Team sessions",
+        },
+      ],
+      sessionMenuItems: [
+        { id: "separator-today", key: "separator-today", label: "Today" },
+        { id: "session-today", key: "session-today", label: "Today one" },
+      ],
+      mySessionsLabel: "My sessions",
+    });
+
+    expect(
+      result.some((item) => item.id === `separator-${CLOUD_PINNED_SECTION_ID}`)
+    ).toBe(false);
+  });
+
+  it("does not mistake a date group's own pager for a backend stream pager", () => {
+    // `load-more-group-*` and `load-more-<category>` share a prefix; only the
+    // latter means "the backend can fetch another page".
+    const result = buildCloudScopedMenuItems({
+      cloudMenuItems: [
+        {
+          id: "separator-cloud-team-sessions",
+          key: "separator-cloud-team-sessions",
+          label: "Team sessions",
+        },
+      ],
+      sessionMenuItems: [
+        { id: "separator-today", key: "separator-today", label: "Today" },
+        { id: "session-today", key: "session-today", label: "Today one" },
+        {
+          id: "load-more-group-time:today",
+          key: "load-more-group-time:today",
+          label: "Show more",
+        },
+      ],
+      mySessionsLabel: "My sessions",
+    });
+
+    expect(result.map((item) => item.id)).toEqual([
+      "separator-cloud-team-sessions",
+      `separator-${CLOUD_MY_SESSIONS_SECTION_ID}`,
+      "session-today",
     ]);
   });
 });

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudScopedMenuItems.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudScopedMenuItems.ts
@@ -6,6 +6,7 @@ import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/compone
 import { separator } from "../useSessionMenuItems/menuItemBuilders";
 
 export const CLOUD_MY_SESSIONS_SECTION_ID = "cloud-my-sessions";
+export const CLOUD_PINNED_SECTION_ID = "cloud-pinned";
 export const CLOUD_TEAM_SESSIONS_SECTION_ID = "cloud-team-sessions";
 export const CLOUD_SESSION_SECTION_PAGE_SIZE = 10;
 export const CLOUD_TEAM_SESSIONS_LOAD_MORE_ID = "cloud-team-sessions-next-page";
@@ -15,12 +16,29 @@ interface BuildCloudScopedMenuItemsParams {
   cloudMenuItems: readonly NavigationMenuItem[];
   sessionMenuItems: readonly NavigationMenuItem[];
   mySessionsLabel: string;
+  pinnedLabel?: string;
   mySessionsVisibleCount?: number;
   loadMoreLabel?: string;
 }
 
+const PINNED_SEPARATOR_ID = "separator-pinned";
+const LOCAL_GROUP_PAGER_PREFIX = "load-more-group-";
+
 export function isSessionPaginationMenuItem(item: NavigationMenuItem): boolean {
   return item.id.startsWith("load-more-");
+}
+
+/**
+ * A backend stream pager (`load-more-<category>`), as opposed to a local
+ * "show more of this group" pager (`load-more-group-<group>`), whose id also
+ * begins with `load-more-`. Only the former speaks for a stream that can fetch
+ * another page from Rust.
+ */
+function isBackendStreamPager(item: NavigationMenuItem): boolean {
+  return (
+    isSessionPaginationMenuItem(item) &&
+    !item.id.startsWith(LOCAL_GROUP_PAGER_PREFIX)
+  );
 }
 
 export function isCloudScopedLocalRow(item: NavigationMenuItem): boolean {
@@ -53,23 +71,49 @@ export function buildCloudSectionLoadMoreItem({
 }
 
 /**
- * Cloud scope has two top-level sections: shared team sessions and the
- * viewer's own sessions. Local grouping separators are removed so every
- * regular local row belongs to the single "My sessions" section.
+ * Cloud scope has three top-level sections: shared team sessions, the pinned
+ * rows the viewer lifted out, and everything else of theirs. The *date*
+ * grouping separators are removed so every ordinary local row belongs to the
+ * single "My sessions" section — but Pinned is not a date bucket, it is user
+ * intent, and pinning is a capability of every session in every org. Dropping
+ * its header with the date headers left a pinned row indistinguishable from
+ * the rest of the list, which read as "cloud orgs cannot pin".
  */
 export function buildCloudScopedMenuItems({
   cloudMenuItems,
   sessionMenuItems,
   mySessionsLabel,
+  pinnedLabel = "Pinned",
   mySessionsVisibleCount = CLOUD_SESSION_SECTION_PAGE_SIZE,
   loadMoreLabel = "Load more",
 }: BuildCloudScopedMenuItemsParams): NavigationMenuItem[] {
   if (cloudMenuItems.length === 0) return [...sessionMenuItems];
 
-  const backendPaginationItems = sessionMenuItems.filter(
-    isSessionPaginationMenuItem
-  );
-  const localRows = sessionMenuItems.filter(isCloudScopedLocalRow);
+  // Walk in order tracking which separator each row follows, so the pinned
+  // block can be lifted out whole. A flat `filter` cannot do this: once the
+  // separators are gone there is no way to tell a pinned row from any other.
+  const pinnedItems: NavigationMenuItem[] = [];
+  const localRows: NavigationMenuItem[] = [];
+  const backendPaginationItems: NavigationMenuItem[] = [];
+  let inPinnedGroup = false;
+  for (const item of sessionMenuItems) {
+    if (item.id.startsWith("separator-")) {
+      inPinnedGroup = item.id === PINNED_SEPARATOR_ID;
+      continue;
+    }
+    if (isBackendStreamPager(item)) {
+      backendPaginationItems.push(item);
+      continue;
+    }
+    if (inPinnedGroup) {
+      pinnedItems.push(item);
+      continue;
+    }
+    // A date group's own "show more" pager is meaningless once that group is
+    // flattened into My sessions — the section's own pager governs from here.
+    if (item.id.startsWith(LOCAL_GROUP_PAGER_PREFIX)) continue;
+    localRows.push(item);
+  }
   const visibleLocalRows = localRows.slice(0, mySessionsVisibleCount);
   const hasHiddenLoadedRows = localRows.length > visibleLocalRows.length;
   const readyBackendPaginationItem = backendPaginationItems.find(
@@ -100,6 +144,9 @@ export function buildCloudScopedMenuItems({
 
   return [
     ...cloudMenuItems,
+    ...(pinnedItems.length > 0
+      ? [separator(CLOUD_PINNED_SECTION_ID, pinnedLabel), ...pinnedItems]
+      : []),
     separator(CLOUD_MY_SESSIONS_SECTION_ID, mySessionsLabel),
     ...mySessionsItems,
   ];

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudScopedMenuItems.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudScopedMenuItems.ts
@@ -21,7 +21,6 @@ interface BuildCloudScopedMenuItemsParams {
   loadMoreLabel?: string;
 }
 
-const PINNED_SEPARATOR_ID = "separator-pinned";
 const LOCAL_GROUP_PAGER_PREFIX = "load-more-group-";
 
 export function isSessionPaginationMenuItem(item: NavigationMenuItem): boolean {
@@ -89,30 +88,30 @@ export function buildCloudScopedMenuItems({
 }: BuildCloudScopedMenuItemsParams): NavigationMenuItem[] {
   if (cloudMenuItems.length === 0) return [...sessionMenuItems];
 
-  // Walk in order tracking which separator each row follows, so the pinned
-  // block can be lifted out whole. A flat `filter` cannot do this: once the
-  // separators are gone there is no way to tell a pinned row from any other.
+  // Rows carry their own `pinned` flag, so the pinned block is lifted by
+  // identity rather than by which separator happens to precede a row — and
+  // the same rule then works for a teammate's row, which lives in a
+  // different section entirely.
   const pinnedItems: NavigationMenuItem[] = [];
   const localRows: NavigationMenuItem[] = [];
   const backendPaginationItems: NavigationMenuItem[] = [];
-  let inPinnedGroup = false;
   for (const item of sessionMenuItems) {
-    if (item.id.startsWith("separator-")) {
-      inPinnedGroup = item.id === PINNED_SEPARATOR_ID;
-      continue;
-    }
+    if (item.id.startsWith("separator-")) continue;
     if (isBackendStreamPager(item)) {
       backendPaginationItems.push(item);
-      continue;
-    }
-    if (inPinnedGroup) {
-      pinnedItems.push(item);
       continue;
     }
     // A date group's own "show more" pager is meaningless once that group is
     // flattened into My sessions — the section's own pager governs from here.
     if (item.id.startsWith(LOCAL_GROUP_PAGER_PREFIX)) continue;
-    localRows.push(item);
+    (item.pinned ? pinnedItems : localRows).push(item);
+  }
+  // Team rows keep their section, except the ones the viewer pinned: pinning
+  // means "keep this where I can see it", which is not a per-section promise.
+  const teamItems: NavigationMenuItem[] = [];
+  for (const item of cloudMenuItems) {
+    if (item.pinned) pinnedItems.push(item);
+    else teamItems.push(item);
   }
   const visibleLocalRows = localRows.slice(0, mySessionsVisibleCount);
   const hasHiddenLoadedRows = localRows.length > visibleLocalRows.length;
@@ -143,7 +142,7 @@ export function buildCloudScopedMenuItems({
     : visibleLocalRows;
 
   return [
-    ...cloudMenuItems,
+    ...teamItems,
     ...(pinnedItems.length > 0
       ? [separator(CLOUD_PINNED_SECTION_ID, pinnedLabel), ...pinnedItems]
       : []),

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.rowItemBuilder.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.rowItemBuilder.tsx
@@ -11,11 +11,12 @@ import {
   Menu as TauriMenu,
 } from "@tauri-apps/api/menu";
 import type { TFunction } from "i18next";
-import { GitFork, Loader2, MoreHorizontal } from "lucide-react";
+import { GitFork, Loader2, MoreHorizontal, Pin, PinOff } from "lucide-react";
 import { useCallback } from "react";
 
 import Message from "@src/components/Message";
 import { resolveAgentIcon } from "@src/config/agentIcons";
+import { isRemoteSessionPinned } from "@src/features/Org2Cloud/cloudPinnedRemoteSessions";
 import { buildCloudRemoteItemId } from "@src/features/Org2Cloud/cloudRemoteItemId";
 import type { CloudSessionBusyEntry } from "@src/features/Org2Cloud/cloudSessionBusyAtom";
 import {
@@ -84,6 +85,9 @@ interface UseCloudSessionRowItemBuilderParams {
   hideRemoteSession: (row: RemoteTeammateSessionMetadata) => void;
   /** Per-row in-flight replay/fork registry — busy rows render a spinner. */
   busySessionRows: ReadonlyMap<string, CloudSessionBusyEntry>;
+  /** Viewer-local pin keys (`<orgId>|<rowId>`); never a property of the shared row. */
+  pinnedRemoteSessionIds: ReadonlySet<string>;
+  toggleRemoteSessionPin: (orgId: string, rowId: string) => void;
 }
 
 export type BuildCloudSessionRowItem = (
@@ -99,6 +103,8 @@ export function useCloudSessionRowItemBuilder({
   runFork,
   hideRemoteSession,
   busySessionRows,
+  pinnedRemoteSessionIds,
+  toggleRemoteSessionPin,
 }: UseCloudSessionRowItemBuilderParams): BuildCloudSessionRowItem {
   const buildRowItem = useCallback(
     (threadRow: CloudSessionThreadRow, asParentOf?: NavigationMenuItem[]) => {
@@ -193,9 +199,23 @@ export function useCloudSessionRowItemBuilder({
           localSessionId={busy.localSessionId}
         />
       ) : undefined;
+      const isPinned = isRemoteSessionPinned(
+        pinnedRemoteSessionIds,
+        row.orgId,
+        row.id
+      );
+      const pinIndicator = isPinned ? (
+        <Pin
+          size={11}
+          strokeWidth={2}
+          className="shrink-0 text-text-3"
+          aria-label="Pinned"
+        />
+      ) : null;
       const trailingElement =
-        busyIndicator || viewerChips || commentsBadge ? (
+        pinIndicator || busyIndicator || viewerChips || commentsBadge ? (
           <span className="inline-flex items-center gap-1">
+            {pinIndicator}
             {busyIndicator}
             {viewerChips}
             {commentsBadge}
@@ -209,6 +229,7 @@ export function useCloudSessionRowItemBuilder({
         label: displayTitle,
         searchText: `${displayTitle} ${row.ownerDisplayName}`,
         dataTestId: `sidebar-cloud-session-item-${bareSessionId}`,
+        pinned: isPinned,
         // Prefer the source/agent brand used by regular sessions. Cloud
         // scope is context, not the session's icon identity.
         icon: sessionIcon,
@@ -243,6 +264,15 @@ export function useCloudSessionRowItemBuilder({
             label: t("cloud.orgPanel.fork"),
             onClick: () => runFork(row),
           },
+          // One click on hover, matching a local row: a teammate's session is
+          // pinned often enough that burying it in the overflow menu is a tax.
+          {
+            icon: isPinned ? PinOff : Pin,
+            label: isPinned
+              ? tCommon("sessions:chat.unpinSession", "Unpin")
+              : tCommon("sessions:chat.pinSession", "Pin"),
+            onClick: () => toggleRemoteSessionPin(row.orgId, row.id),
+          },
           {
             icon: MoreHorizontal,
             label: tCommon("actions.more"),
@@ -262,17 +292,25 @@ export function useCloudSessionRowItemBuilder({
                       });
                   },
                 }),
+                MenuItem.new({
+                  text: isPinned
+                    ? tCommon("sessions:chat.unpinSession", "Unpin")
+                    : tCommon("sessions:chat.pinSession", "Pin"),
+                  action: () => toggleRemoteSessionPin(row.orgId, row.id),
+                }),
                 PredefinedMenuItem.new({ item: "Separator" }),
                 MenuItem.new({
                   text: tCommon("actions.remove", "Remove"),
                   action: () => hideRemoteSession(row),
                 }),
-              ]).then(async ([copyItem, menuSeparator, removeItem]) => {
-                const menu = await TauriMenu.new({
-                  items: [copyItem, menuSeparator, removeItem],
-                });
-                await menu.popup();
-              });
+              ]).then(
+                async ([copyItem, pinItem, menuSeparator, removeItem]) => {
+                  const menu = await TauriMenu.new({
+                    items: [copyItem, pinItem, menuSeparator, removeItem],
+                  });
+                  await menu.popup();
+                }
+              );
             },
           },
         ];
@@ -282,6 +320,8 @@ export function useCloudSessionRowItemBuilder({
     [
       busySessionRows,
       hideRemoteSession,
+      pinnedRemoteSessionIds,
+      toggleRemoteSessionPin,
       presenceMap,
       runFork,
       selfUserId,

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.tsx
@@ -39,6 +39,11 @@ import {
   readHiddenRemoteSessionIds,
   writeHiddenRemoteSessionIds,
 } from "@src/features/Org2Cloud/cloudHiddenRemoteSessions";
+import {
+  readPinnedRemoteSessionIds,
+  togglePinnedRemoteSession,
+  writePinnedRemoteSessionIds,
+} from "@src/features/Org2Cloud/cloudPinnedRemoteSessions";
 import { dismissCloudReferenceOpeningToast } from "@src/features/Org2Cloud/cloudReferenceOpeningToast";
 import {
   buildCloudRemoteItemId,
@@ -126,6 +131,9 @@ export function useCloudSessionsSection({
   );
   const [hiddenRemoteSessionIds, setHiddenRemoteSessionIds] = useState(
     readHiddenRemoteSessionIds
+  );
+  const [pinnedRemoteSessionIds, setPinnedRemoteSessionIds] = useState(
+    readPinnedRemoteSessionIds
   );
 
   const { localOwnSessionIds, cloudLocalSessionIds } =
@@ -466,6 +474,16 @@ export function useCloudSessionsSection({
     [sessions]
   );
 
+  // A pin is the viewer's own view state: it never touches the shared cloud
+  // row, and two viewers of the same session pin independently.
+  const toggleRemoteSessionPin = useCallback((orgId: string, rowId: string) => {
+    setPinnedRemoteSessionIds((current) => {
+      const next = togglePinnedRemoteSession(current, orgId, rowId);
+      writePinnedRemoteSessionIds(next);
+      return next;
+    });
+  }, []);
+
   const handleCloudRemoteItemRemove = useCallback(
     (item: NavigationMenuItem): boolean => {
       const parsed = parseCloudRemoteItemId(item.id);
@@ -485,6 +503,8 @@ export function useCloudSessionsSection({
     runFork,
     hideRemoteSession,
     busySessionRows,
+    pinnedRemoteSessionIds,
+    toggleRemoteSessionPin,
   });
 
   const cloudMenuItems = useCloudTeamSessionMenuItems({

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.menuDecoration.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.menuDecoration.ts
@@ -189,6 +189,7 @@ export function useWorkstationSidebarMenuDecoration({
       // use the regular session action decoration.
       sessionMenuItems: decorateSessionRowActions(sessionSidebarMenuItems),
       mySessionsLabel: t("cloud.sidebar.mySessions"),
+      pinnedLabel: tCommon("sessions:chat.historyPinned", "Pinned"),
       mySessionsVisibleCount: cloudMySessionsVisibleCount,
       loadMoreLabel: tCommon("common:actions.loadMore", "Load more"),
     });

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/menuItemBuilders.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/menuItemBuilders.tsx
@@ -1,3 +1,5 @@
+import { Pin } from "lucide-react";
+
 import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/components/NavigationMenu/config";
 import type { BranchPrSnapshot } from "@src/store/git";
 import type { Session } from "@src/store/session";
@@ -67,6 +69,19 @@ export function buildSessionMenuItem({
   const statusDot =
     inProgress && !pendingAsking ? null : renderStatusDot(statusDotTone);
   const gitIndicator = renderSessionGitIndicator(session, pr);
+  // The section header used to be the ONLY at-rest pin affordance, so pinning
+  // was invisible wherever that header does not render (cloud scope strips
+  // every separator) — and since the list is already recency-sorted, pinning a
+  // recent session moves it zero rows. Mark the row itself so pin state is
+  // legible in every scope and every grouping mode.
+  const pinIndicator = session.pinned ? (
+    <Pin
+      size={11}
+      strokeWidth={2}
+      className="shrink-0 text-text-3"
+      aria-label="Pinned"
+    />
+  ) : null;
 
   return {
     id: session.session_id,
@@ -79,8 +94,9 @@ export function buildSessionMenuItem({
     workingIndicator:
       inProgress && !pendingAsking ? renderBreathingStatusDot() : undefined,
     trailingElement:
-      gitIndicator || statusDot ? (
+      pinIndicator || gitIndicator || statusDot ? (
         <span className="inline-flex items-center gap-1 leading-none">
+          {pinIndicator}
           {gitIndicator}
           {statusDot}
         </span>

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/menuItemBuilders.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/menuItemBuilders.tsx
@@ -89,6 +89,7 @@ export function buildSessionMenuItem({
     label: displayName,
     searchText: getSessionSearchText(session, untitledSession),
     dataTestId: `sidebar-session-item-${session.session_id}`,
+    pinned: session.pinned === true,
     icon: resolveSessionRowIcon(session),
     subtitle: liveDetail && pendingAsking ? liveDetail : undefined,
     workingIndicator:

--- a/src/store/session/sessionAtom/loaders.ts
+++ b/src/store/session/sessionAtom/loaders.ts
@@ -246,6 +246,7 @@ function importedHistoryPageResult(
         updated_time: row.updatedAt,
         category: "external_history",
         readOnly: true,
+        pinned: row.pinned ?? false,
         is_active: row.isActive ?? false,
         background: false,
         repoPath: row.repoPath,


### PR DESCRIPTION
Pinning was broken or missing for two of the three kinds of row the sidebar shows, and invisible for all three under a cloud org scope. This makes pinning work the same way everywhere: any session, in any org.

## What was wrong

**1. Imported sessions could not be pinned, in any scope.** `session_patch` resolves a session id against two tables only:

```rust
"SELECT 1 FROM agent_sessions WHERE session_id = ?1"   // → Agent
"SELECT 1 FROM code_sessions  WHERE session_id = ?1"   // → Cli
Ok(None)                                               // → everything else
```

Imported ids (`claudecodeapp-*`, `codexapp-*`, `cursoride-*`, `cursorcliapp-*`) live in `imported_history_session_cache` and match neither, so the RPC returned `session_patch: session … not found`. `handleTogglePin` applied its optimistic flip, the write was rejected, and the rollback restored the old value — the row visibly did nothing:

```
Failed to toggle pin: RpcError: [RPC:session_patch] session_patch: session codexapp-rollout-2026-08-03T09-55-33-… not found
Failed to toggle pin: RpcError: [RPC:session_patch] session_patch: session claudecodeapp-a8a4802b-… not found
```

This reads as "cloud orgs can't pin", but org scope was never the cause: `update_pinned` is `UPDATE agent_sessions SET pinned=?2 WHERE session_id=?1` with no org predicate, and `pinned_native` is fetched in every scope. It is a **selection effect** — under a cloud scope the local list is almost entirely imported (only 7 native rows in this database carry a cloud `org_id`), so nearly every pin attempt landed on the broken kind.

**2. Team sessions had no pin at all.** They are not local sessions — they are teammate rows keyed `cloudremote-<orgId>|<rowId>`, absent from `sessionMap`, deliberately excluded from `decorateSessionRowActions`. Three separate things blocked them, so nothing about them was pinnable.

**3. Nothing marked a pinned row, and cloud scope deleted the Pinned header.** `buildSessionMenuItem` emitted no pin-derived field, so the section header was the entire at-rest affordance — and `isCloudScopedLocalRow` dropped every `separator-`, sweeping `separator-pinned` away with the date headers. Since the list is already recency-sorted, pinning a recent session also moves it zero rows: pin looked like a no-op even when it fully succeeded.

## What changed

**Imported sessions — a real place to store the flag.** A new ORGII-owned `imported_history_session_pin` table keyed on `session_id`. Deliberately *not* a column on `imported_history_session_cache`: that table is a rebuildable projection, and `prune_missing_records_from_conn` deletes every row of a source whose store momentarily reads as empty — an unreadable provider directory would silently erase the user's pins. The canonical `session_id` (`PREFIX + source id`) is deterministic, so the overlay survives rescans and `parser_version` bumps. `locate_session` gains an `Imported` arm; each field states its own truth for it (`pinned` writes the overlay, the five native-only fields return an explicit "imported sessions do not support …"), so there is no early return and no unreachable arm.

**Team sessions — the viewer's own view state.** Pins go beside the existing hidden-row set (`cloudPinnedRemoteSessions`, mirroring `cloudHiddenRemoteSessions`), keyed on the `<orgId>|<rowId>` pair the sidebar already encodes in every `cloudremote-` id. A pin never touches the shared cloud record, and two viewers of the same session pin independently. Reachable both from a hover button beside Fork and from the overflow menu.

**Display — one Pinned section, type-agnostic.** Rows carry their own `pinned` flag, so `buildCloudScopedMenuItems` lifts the pinned block by identity instead of inferring membership from which separator precedes a row — which is also what lets a teammate's row, living in a different section entirely, join the same group. Cloud scope becomes *Team sessions → Pinned → My sessions*; the section is omitted when nothing is pinned, and pinned rows no longer consume the My-sessions page budget. Every row also gets a pin glyph, so pin state is legible in every scope and grouping mode rather than depending on a header.

Fixed in passing: `load-more-group-*` shares a prefix with `load-more-<category>`, so a date group's local "show more" pager was being collected as a backend stream pager. They are now distinguished.

## Scope semantics (deliberate, not an oversight)

Local pins are session-level (one flag per session); team pins are per `(org, row)`, because a team row *is* per-org. The two only overlap when a local session reaches a cloud scope by repo-scope match rather than an explicit tag. Unifying them would mean adding an org dimension to `agent_sessions.pinned` — a larger change than this PR, evaluated separately.

## Verification

- `cargo test -p orgtrack_core` 500 passed, including two new tests: pin round-trip/idempotent re-pin/clear, and **a source-wide prune must not erase pins** — the property that justifies the separate table. `cargo test -p org2 session_directory` 75 passed.
- `pnpm typecheck` clean. Frontend suites 349 passed, including new `cloudPinnedRemoteSessions` tests (key format, org isolation, non-mutating toggle, malformed-storage degradation) and three new `cloudScopedMenuItems` tests; two of those were **verified to fail without the change**.
- Live on the desktop app, all four cells: imported pin under a cloud scope persists to the overlay with zero RPC rejections; a team session pins from the hover button and joins the same Pinned section; Unpin returns each row to its own section; both survive a restart. Native pins unchanged at 3 throughout, and the three stores stay independent.

## Follow-up left open

The imported overlay accumulates a row per pin with no owner-side GC; orphans are bounded by user pin count and cost one `session_id` each. A sweep against live canonical ids on scan is the natural follow-up. Team pins share the durability profile of the existing hidden-row set (localStorage, flushed on normal quit).
