### PR TITLE
fix(cloud): identify and filter member sync failures

### DIFF
--- a/docs/frontend-ui-audit-2026-08-03/CloudOrgSyncSection.md
+++ b/docs/frontend-ui-audit-2026-08-03/CloudOrgSyncSection.md
@@ -1,0 +1,20 @@
+# CloudOrgSyncSection UI audit
+
+Scope: member-attributed sync-log rows and the member filter introduced by PR #664. The configured `frontend-ui-audit` skill file was unavailable in both documented locations, so this report applies the repository's stated design-system, reuse, accessibility, and arbitrary-value checks directly.
+
+| Line                          | Element               | Verdict          | Reason                                                                                                                                                                                                                                   | Suggested change                                                                                                                              |
+| ----------------------------- | --------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CloudOrgSyncSection.tsx:524` | Member filter         | keep with reason | Reuses the shared `Select` component, including keyboard navigation, portal positioning, selected-state affordance, and the design-system `pill` radius. Search only appears for rosters above eight members.                            | None.                                                                                                                                         |
+| `CloudOrgSyncSection.tsx:169` | Member identity       | abstract         | Reuses `AvatarChip` for the visible member pill and keeps the stable `userId` in the tooltip/accessibility label instead of duplicating it in the row copy.                                                                              | Keep the journal-specific identity adapter local; promote it only if another diagnostics surface needs the same `SyncJournalMember` contract. |
+| `AvatarChip/index.tsx:9`      | Avatar fallback       | fix              | The shared chip previously rendered an empty avatar circle when no image existed. An explicit `avatarFallback` prop lets callers supply an initial or icon without changing existing call sites.                                         | Covered by the sync-log rendered test; no implicit fallback was added because labels may be non-text React nodes.                             |
+| `CloudOrgSyncSection.tsx:587` | Log card              | keep with reason | Border, background, radius, spacing, warning/error colors, and typography all use existing semantic tokens; no raw color or one-off CSS variable was introduced. The card boundary separates entries more clearly than whitespace alone. | None.                                                                                                                                         |
+| `CloudOrgSyncSection.tsx:616` | `member: message` row | keep with reason | The member pill precedes the message with a visible colon, supports wrapping, and preserves the un-attributed legacy row path. The pill has a full identity tooltip and accessible label.                                                | None.                                                                                                                                         |
+| `CloudOrgSyncSection.tsx:548` | Copy / clear actions  | keep with reason | Existing shared `Button` components and disabled states remain unchanged. Copy now follows the active member filter while clear intentionally clears the complete journal.                                                               | None.                                                                                                                                         |
+
+## Summary
+
+- fix: 1
+- keep with reason: 4
+- abstract: 1
+- arbitrary Tailwind colors/values introduced: 0
+- raw interactive elements introduced: 0

--- a/src/components/AvatarChip/index.tsx
+++ b/src/components/AvatarChip/index.tsx
@@ -8,6 +8,8 @@ export type AvatarChipSize = "xs" | "sm";
 
 interface AvatarChipProps {
   avatarSrc?: string;
+  /** Initials or icon shown when no avatar image is available. */
+  avatarFallback?: ReactNode;
   avatarSize?: number;
   label: ReactNode;
   variant?: AvatarChipVariant;
@@ -53,6 +55,7 @@ function getVisualClassName(
 
 const AvatarChip = memo(function AvatarChip({
   avatarSrc,
+  avatarFallback,
   avatarSize = 14,
   label,
   variant = "display",
@@ -74,7 +77,9 @@ const AvatarChip = memo(function AvatarChip({
 
   const content = (
     <>
-      <Avatar size={avatarSize} src={avatarSrc} />
+      <Avatar size={avatarSize} src={avatarSrc}>
+        {avatarFallback}
+      </Avatar>
       <span className={labelClass}>{label}</span>
     </>
   );

--- a/src/engines/ChatPanel/panels/CloudOrgPanelView/CloudOrgSyncSection.test.ts
+++ b/src/engines/ChatPanel/panels/CloudOrgPanelView/CloudOrgSyncSection.test.ts
@@ -502,6 +502,94 @@ describe("CloudOrgSyncSection bug logs", () => {
     ).toBeNull();
   });
 
+  it("renders an attributed member as a compact pill with the stable id in its tooltip", () => {
+    const root = renderSection({
+      entries: [
+        entry({
+          kind: "member_runtime",
+          member: { userId: "user-vanta", displayName: "VantaNode" },
+          message: "Runtime push failed; retrying in 300s",
+        }),
+      ],
+    });
+
+    const pill = root.querySelector(
+      '[data-testid="cloud-org-sync-log-member"]'
+    );
+    expect(pill?.textContent).toBe("VVantaNode");
+    expect(pill?.getAttribute("title")).toBe("VantaNode (user-vanta)");
+    expect(
+      root.querySelector('[data-testid="cloud-org-sync-log-entry"]')
+        ?.textContent
+    ).toContain("VantaNode:Runtime push failed; retrying in 300s");
+    expect(
+      root.querySelector('[data-testid="cloud-org-sync-logs-member-filter"]')
+        ?.textContent
+    ).toContain("cloud.sidebar.everyone");
+  });
+
+  it("filters the rendered and copied slice by the selected member", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    const root = createSmokeRoot();
+    try {
+      await root.render(
+        createElement(CloudOrgSyncSection, {
+          t,
+          status: status({
+            entries: [
+              entry({
+                id: "sync-vanta",
+                member: { userId: "user-vanta", displayName: "VantaNode" },
+                message: "vanta failure",
+              }),
+              entry({
+                id: "sync-ada",
+                member: { userId: "user-ada", displayName: "Ada" },
+                message: "ada failure",
+              }),
+              entry({ id: "sync-system", message: "system failure" }),
+            ],
+          }),
+        })
+      );
+
+      const filter = root.container.querySelector<HTMLElement>(
+        '[data-testid="cloud-org-sync-logs-member-filter"]'
+      );
+      await dispatch(() => filter?.click());
+      const adaOption = document.body.querySelector<HTMLElement>(
+        '[data-testid="cloud-org-sync-logs-member-user-ada"]'
+      );
+      expect(adaOption).not.toBeNull();
+      await dispatch(() => adaOption?.click());
+
+      const items = root.container.querySelectorAll(
+        '[data-testid="cloud-org-sync-log-entry"]'
+      );
+      expect(items).toHaveLength(1);
+      expect(items[0]?.textContent).toContain("Ada:ada failure");
+      expect(root.container.textContent).not.toContain("vanta failure");
+      expect(root.container.textContent).not.toContain("system failure");
+
+      const copyButton = root.container.querySelector<HTMLButtonElement>(
+        '[data-testid="cloud-org-sync-logs-copy"]'
+      );
+      await dispatch(() => copyButton?.click());
+      await vi.waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+      const copiedText = String(writeText.mock.calls[0]?.[0]);
+      expect(copiedText).toContain("member Ada (user-ada)");
+      expect(copiedText).toContain("ada failure");
+      expect(copiedText).not.toContain("vanta failure");
+      expect(copiedText).not.toContain("system failure");
+    } finally {
+      await root.unmount();
+    }
+  });
+
   it("renders at most the newest 50 entries", () => {
     const root = renderSection({
       entries: Array.from({ length: 100 }, (_, index) =>
@@ -547,6 +635,7 @@ describe("formatSyncJournalForCopy", () => {
         level: "warn",
         kind: "org_backoff",
         orgId: "org-1",
+        member: { userId: "user-vanta", displayName: "VantaNode" },
         code: "ORG2_SYNC_DISABLED",
         message: "backed off",
       }),
@@ -556,7 +645,7 @@ describe("formatSyncJournalForCopy", () => {
     const lines = text.split("\n");
     expect(lines).toHaveLength(2);
     expect(lines[0]).toContain(
-      "WARN | org_backoff | org-1 | ORG2_SYNC_DISABLED"
+      "WARN | org_backoff | org-1 | member VantaNode (user-vanta) | ORG2_SYNC_DISABLED"
     );
     expect(lines[0]?.endsWith("backed off")).toBe(true);
     expect(lines[1]).toContain("INFO | sync_pass");

--- a/src/engines/ChatPanel/panels/CloudOrgPanelView/CloudOrgSyncSection.tsx
+++ b/src/engines/ChatPanel/panels/CloudOrgPanelView/CloudOrgSyncSection.tsx
@@ -13,12 +13,19 @@
  * passed in, rendered, or copied.
  */
 import type { TFunction } from "i18next";
-import React, { useCallback, useMemo } from "react";
+import { UsersRound } from "lucide-react";
+import React, { useCallback, useMemo, useState } from "react";
 
+import Avatar from "@src/components/Avatar";
+import AvatarChip from "@src/components/AvatarChip";
 import Button from "@src/components/Button";
+import Select from "@src/components/Select";
 import type { CloudCapabilities } from "@src/features/Org2Cloud/org2CloudCapabilities";
 import type { RepoSyncCoverage } from "@src/features/Org2Cloud/org2CloudSyncCoverage";
-import type { SyncJournalEntry } from "@src/features/Org2Cloud/org2CloudSyncJournal";
+import type {
+  SyncJournalEntry,
+  SyncJournalMember,
+} from "@src/features/Org2Cloud/org2CloudSyncJournal";
 import { useCopyCheck } from "@src/hooks/ui/useCopyCheck";
 import {
   SECTION_ACTION_GAP_CLASSES,
@@ -32,6 +39,8 @@ import type { CloudOrgSyncStatus } from "./useCloudOrgSyncStatus";
 
 /** Newest slice actually rendered; the buffer itself holds up to 100. */
 const RENDERED_LOG_LIMIT = 50;
+const ALL_MEMBERS_FILTER_VALUE = "all";
+const MEMBER_FILTER_VALUE_PREFIX = "member:";
 
 const CAPABILITY_KEYS = [
   "broadcastSignals",
@@ -125,6 +134,62 @@ function formatAbsolute(atMs: number | null): string {
   }
 }
 
+function memberDisplayName(member: SyncJournalMember): string {
+  return member.displayName?.trim() || member.userId;
+}
+
+function memberInitial(member: SyncJournalMember): string {
+  return memberDisplayName(member).slice(0, 1).toLocaleUpperCase();
+}
+
+function memberFilterValue(userId: string): string {
+  return `${MEMBER_FILTER_VALUE_PREFIX}${userId}`;
+}
+
+interface SyncLogMemberOption {
+  userId: string;
+  displayName: string;
+}
+
+/** Newest label wins when a profile name changes within the local buffer. */
+function buildSyncLogMemberOptions(
+  entries: readonly SyncJournalEntry[]
+): SyncLogMemberOption[] {
+  const byUserId = new Map<string, string>();
+  for (const entry of entries) {
+    if (!entry.member || byUserId.has(entry.member.userId)) continue;
+    byUserId.set(entry.member.userId, memberDisplayName(entry.member));
+  }
+  return [...byUserId].map(([userId, displayName]) => ({
+    userId,
+    displayName,
+  }));
+}
+
+function SyncLogMemberPill({ member }: { member: SyncJournalMember }) {
+  const displayName = memberDisplayName(member);
+  const identityLabel =
+    displayName === member.userId
+      ? member.userId
+      : `${displayName} (${member.userId})`;
+  return (
+    <span
+      className="inline-flex max-w-full shrink-0"
+      title={identityLabel}
+      aria-label={identityLabel}
+      data-testid="cloud-org-sync-log-member"
+    >
+      <AvatarChip
+        size="xs"
+        avatarSize={14}
+        avatarFallback={memberInitial(member)}
+        label={displayName}
+        labelClassName="max-w-36"
+      />
+    </span>
+  );
+}
+
 /** Plain-text rendering of the journal, for the copy button. */
 export function formatSyncJournalForCopy(
   entries: readonly SyncJournalEntry[]
@@ -137,6 +202,14 @@ export function formatSyncJournalForCopy(
         entry.kind,
       ];
       if (entry.orgId) parts.push(entry.orgId);
+      if (entry.member) {
+        const displayName = memberDisplayName(entry.member);
+        parts.push(
+          displayName === entry.member.userId
+            ? `member ${entry.member.userId}`
+            : `member ${displayName} (${entry.member.userId})`
+        );
+      }
       if (entry.code) parts.push(entry.code);
       return `[${parts.join(" | ")}] ${entry.message}`;
     })
@@ -150,9 +223,46 @@ interface CloudOrgSyncSectionProps {
 
 /** Sync-tab connection, last-sync, manual trigger, and journal blocks. */
 export function CloudOrgSyncSection({ t, status }: CloudOrgSyncSectionProps) {
-  const visibleEntries = useMemo(
-    () => status.entries.slice(0, RENDERED_LOG_LIMIT),
+  const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
+  const memberOptions = useMemo(
+    () => buildSyncLogMemberOptions(status.entries),
     [status.entries]
+  );
+  const effectiveMemberId =
+    selectedMemberId !== null &&
+    memberOptions.some((option) => option.userId === selectedMemberId)
+      ? selectedMemberId
+      : null;
+  const visibleEntries = useMemo(
+    () =>
+      (effectiveMemberId === null
+        ? status.entries
+        : status.entries.filter(
+            (entry) => entry.member?.userId === effectiveMemberId
+          )
+      ).slice(0, RENDERED_LOG_LIMIT),
+    [effectiveMemberId, status.entries]
+  );
+  const memberFilterOptions = useMemo(
+    () => [
+      {
+        value: ALL_MEMBERS_FILTER_VALUE,
+        label: t("cloud.sidebar.everyone"),
+        icon: <UsersRound size={14} />,
+        dataTestId: "cloud-org-sync-logs-member-all",
+      },
+      ...memberOptions.map((member) => ({
+        value: memberFilterValue(member.userId),
+        label: member.displayName,
+        icon: (
+          <Avatar size={14}>
+            <span aria-hidden>{member.displayName.slice(0, 1)}</span>
+          </Avatar>
+        ),
+        dataTestId: `cloud-org-sync-logs-member-${member.userId}`,
+      })),
+    ],
+    [memberOptions, t]
   );
 
   const copyLog = useCallback(async () => {
@@ -414,6 +524,32 @@ export function CloudOrgSyncSection({ t, status }: CloudOrgSyncSectionProps) {
           light
         >
           <div className={`${SECTION_ACTION_GAP_CLASSES} flex-wrap`}>
+            {memberOptions.length > 0 ? (
+              <div className="w-40 max-w-full">
+                <Select
+                  value={
+                    effectiveMemberId === null
+                      ? ALL_MEMBERS_FILTER_VALUE
+                      : memberFilterValue(effectiveMemberId)
+                  }
+                  options={memberFilterOptions}
+                  size="mini"
+                  radius="pill"
+                  showSearch={memberOptions.length > 8}
+                  dropdownAlign="right"
+                  dropdownMinWidth={180}
+                  dataTestId="cloud-org-sync-logs-member-filter"
+                  onChange={(value) => {
+                    const nextValue = String(value);
+                    setSelectedMemberId(
+                      nextValue === ALL_MEMBERS_FILTER_VALUE
+                        ? null
+                        : nextValue.slice(MEMBER_FILTER_VALUE_PREFIX.length)
+                    );
+                  }}
+                />
+              </div>
+            ) : null}
             <Button
               htmlType="button"
               size="default"
@@ -455,12 +591,12 @@ export function CloudOrgSyncSection({ t, status }: CloudOrgSyncSectionProps) {
               {visibleEntries.map((entry) => (
                 <li
                   key={entry.id}
-                  className="flex flex-col gap-0.5"
+                  className="flex flex-col gap-1.5 rounded-lg border border-border-1 bg-bg-1 px-3 py-2.5"
                   data-testid="cloud-org-sync-log-entry"
                 >
-                  <div className="flex flex-wrap items-center gap-2 text-[11px]">
+                  <div className="flex flex-wrap items-center gap-1.5 text-[11px]">
                     <span
-                      className={`rounded px-1.5 py-0.5 font-medium ${LEVEL_CLASSES[entry.level]}`}
+                      className={`rounded-full px-1.5 py-0.5 font-medium ${LEVEL_CLASSES[entry.level]}`}
                       data-testid={`cloud-org-sync-log-level-${entry.level}`}
                     >
                       {t(LEVEL_LABEL_KEYS[entry.level])}
@@ -482,9 +618,17 @@ export function CloudOrgSyncSection({ t, status }: CloudOrgSyncSectionProps) {
                       </span>
                     ) : null}
                   </div>
-                  <span className="break-words text-[12px] text-text-2">
-                    {entry.message}
-                  </span>
+                  <div className="flex min-w-0 flex-wrap items-center gap-1 text-[12px] text-text-2">
+                    {entry.member ? (
+                      <>
+                        <SyncLogMemberPill member={entry.member} />
+                        <span aria-hidden className="text-text-3">
+                          :
+                        </span>
+                      </>
+                    ) : null}
+                    <span className="min-w-0 break-words">{entry.message}</span>
+                  </div>
                 </li>
               ))}
             </ul>

--- a/src/features/Org2Cloud/memberRuntime/memberRuntimePushScheduler.test.ts
+++ b/src/features/Org2Cloud/memberRuntime/memberRuntimePushScheduler.test.ts
@@ -457,25 +457,36 @@ describe("failure diagnostics", () => {
     clock.advanceBy(30_000);
     await scheduler.runPass(scheduler.generation);
 
-    expect(getSyncJournalSnapshot()[0]?.message).toBe(
-      "Member runtime push failed for Ada Lovelace (user-1); retrying in 300s: Cloud request timed out after 15000ms."
-    );
+    expect(getSyncJournalSnapshot()[0]).toMatchObject({
+      member: { userId: "user-1", displayName: "Ada Lovelace" },
+      message:
+        "Member runtime push failed; retrying in 300s: Cloud request timed out after 15000ms.",
+    });
     expect(mocks.logWarn.mock.calls[0]?.[0]).toContain(
       "member runtime push failed for Ada Lovelace (user-1) in org org-1"
     );
   });
 
-  it("falls back to the stable user id when the profile is unavailable", () => {
+  it("falls back to the stable user id without exposing a profile email", () => {
     const scheduler = asPrivate(new MemberRuntimePushScheduler(makeDeps()));
+    const authWithoutDisplayName: Org2CloudAuthState = {
+      ...AUTH,
+      profile: { primaryEmail: "private@example.test" },
+    };
 
     scheduler.noteOrgFailure(
       makeOrg(),
-      AUTH,
+      authWithoutDisplayName,
       new Error("Cloud request timed out after 15000ms.")
     );
 
-    expect(getSyncJournalSnapshot()[0]?.message).toContain(
-      "Member runtime push failed for user-1;"
+    expect(getSyncJournalSnapshot()[0]).toMatchObject({
+      member: { userId: "user-1" },
+      message:
+        "Member runtime push failed; retrying in 300s: Cloud request timed out after 15000ms.",
+    });
+    expect(mocks.logWarn.mock.calls[0]?.[0]).not.toContain(
+      "private@example.test"
     );
   });
 });

--- a/src/features/Org2Cloud/memberRuntime/memberRuntimePushScheduler.test.ts
+++ b/src/features/Org2Cloud/memberRuntime/memberRuntimePushScheduler.test.ts
@@ -23,6 +23,10 @@ import type { Org2CloudAuthState } from "../org2CloudAuthAtom";
 import { org2CloudAuthAtom } from "../org2CloudAuthAtom";
 import type { CloudCapabilitiesProbeResult } from "../org2CloudCapabilities";
 import { type Org2CloudOrg, org2CloudOrgsAtom } from "../org2CloudOrgsAtom";
+import {
+  getSyncJournalSnapshot,
+  resetSyncJournalForTests,
+} from "../org2CloudSyncJournal";
 import { MemberRuntimeError } from "./memberRuntimeClient";
 import {
   UTC_DAY_MS,
@@ -212,7 +216,11 @@ interface SchedulerTestAccess {
   capabilityRecheckAtMs: number;
   capabilityUnconfirmedFailures: number;
   runPass: (generation: number) => Promise<void>;
-  noteOrgFailure: (org: Org2CloudOrg, error: unknown) => void;
+  noteOrgFailure: (
+    org: Org2CloudOrg,
+    auth: Org2CloudAuthState,
+    error: unknown
+  ) => void;
   pushOrg: (
     accessToken: string,
     identityKey: string,
@@ -227,6 +235,7 @@ function asPrivate(scheduler: MemberRuntimePushScheduler): SchedulerTestAccess {
 
 beforeEach(() => {
   localStorage.clear();
+  resetSyncJournalForTests();
   mocks.logWarn.mockClear();
 });
 
@@ -424,6 +433,53 @@ describe("capability blackout: confirmed vs. unconfirmed", () => {
   });
 });
 
+describe("failure diagnostics", () => {
+  it("identifies the member at the scheduler boundary by display name and stable user id", async () => {
+    const clock = makeControllableClock(NOW);
+    const auth: Org2CloudAuthState = {
+      ...AUTH,
+      profile: {
+        displayName: "Ada Lovelace",
+        primaryEmail: "ada@example.test",
+      },
+    };
+    const deps = makeDeps({
+      now: clock.now,
+      upsert: vi
+        .fn()
+        .mockRejectedValue(new Error("Cloud request timed out after 15000ms.")),
+    });
+    const store = makeStore([makeOrg()]);
+    store.set(org2CloudAuthAtom, auth);
+    const scheduler = asPrivate(new MemberRuntimePushScheduler(deps));
+
+    scheduler.start(store);
+    clock.advanceBy(30_000);
+    await scheduler.runPass(scheduler.generation);
+
+    expect(getSyncJournalSnapshot()[0]?.message).toBe(
+      "Member runtime push failed for Ada Lovelace (user-1); retrying in 300s: Cloud request timed out after 15000ms."
+    );
+    expect(mocks.logWarn.mock.calls[0]?.[0]).toContain(
+      "member runtime push failed for Ada Lovelace (user-1) in org org-1"
+    );
+  });
+
+  it("falls back to the stable user id when the profile is unavailable", () => {
+    const scheduler = asPrivate(new MemberRuntimePushScheduler(makeDeps()));
+
+    scheduler.noteOrgFailure(
+      makeOrg(),
+      AUTH,
+      new Error("Cloud request timed out after 15000ms.")
+    );
+
+    expect(getSyncJournalSnapshot()[0]?.message).toContain(
+      "Member runtime push failed for user-1;"
+    );
+  });
+});
+
 describe("ORG2_RUNTIME_TOO_LARGE mitigation", () => {
   it("halves the org's usage-days cap on each TOO_LARGE failure, floored at 1", () => {
     // Guard against silent drift of the constant this test's expectations
@@ -438,7 +494,7 @@ describe("ORG2_RUNTIME_TOO_LARGE mitigation", () => {
 
     const expectedCaps = [20, 10, 5, 2, 1, 1];
     for (const expectedCap of expectedCaps) {
-      scheduler.noteOrgFailure(org, tooLarge);
+      scheduler.noteOrgFailure(org, AUTH, tooLarge);
       expect(scheduler.usageDaysCapByOrg.get("org-1")).toBe(expectedCap);
     }
   });
@@ -458,17 +514,19 @@ describe("ORG2_RUNTIME_TOO_LARGE mitigation", () => {
 
     // Five failures walk the cap 40 -> 20 -> 10 -> 5 -> 2 -> 1; none of
     // these should touch the optional-sections drop yet.
-    for (let i = 0; i < 5; i += 1) scheduler.noteOrgFailure(org, tooLarge);
+    for (let i = 0; i < 5; i += 1) {
+      scheduler.noteOrgFailure(org, AUTH, tooLarge);
+    }
     expect(scheduler.dropOptionalSectionsByOrg.has("org-1")).toBe(false);
     expect(dropWarnings()).toHaveLength(0);
 
     // Sixth failure: already at the floor (1) and still too large.
-    scheduler.noteOrgFailure(org, tooLarge);
+    scheduler.noteOrgFailure(org, AUTH, tooLarge);
     expect(scheduler.dropOptionalSectionsByOrg.has("org-1")).toBe(true);
     expect(dropWarnings()).toHaveLength(1);
 
     // A further failure at the floor must not log the transition again.
-    scheduler.noteOrgFailure(org, tooLarge);
+    scheduler.noteOrgFailure(org, AUTH, tooLarge);
     expect(dropWarnings()).toHaveLength(1);
   });
 

--- a/src/features/Org2Cloud/memberRuntime/memberRuntimePushScheduler.ts
+++ b/src/features/Org2Cloud/memberRuntime/memberRuntimePushScheduler.ts
@@ -437,12 +437,16 @@ export class MemberRuntimePushScheduler {
         );
         this.orgBackoff.delete(org.orgId);
       } catch (error) {
-        this.noteOrgFailure(org, error);
+        this.noteOrgFailure(org, fresh, error);
       }
     }
   }
 
-  private noteOrgFailure(org: Org2CloudOrg, error: unknown): void {
+  private noteOrgFailure(
+    org: Org2CloudOrg,
+    auth: Org2CloudAuthState,
+    error: unknown
+  ): void {
     if (isMemberRuntimeErrorCode(error, "ORG2_RUNTIME_DISABLED")) {
       // Server-authoritative: stop pushing this org until its roster record
       // changes. No backoff churn against a deliberate off switch.
@@ -466,8 +470,19 @@ export class MemberRuntimePushScheduler {
       notBeforeMs: this.deps.now() + delayMs,
     });
     const code = (error as { code?: MemberRuntimeErrorCode | null })?.code;
+    // The upsert RPC derives the member from this session's JWT, so the
+    // freshly authenticated profile is the authoritative identity for the
+    // failed push. Keep the stable user id visible even when names collide.
+    const memberName =
+      auth.profile?.displayName?.trim() ||
+      auth.profile?.primaryEmail?.trim() ||
+      auth.userId;
+    const memberIdentity =
+      memberName === auth.userId
+        ? auth.userId
+        : `${memberName} (${auth.userId})`;
     log.warn(
-      `member runtime push failed for org ${org.orgId}` +
+      `member runtime push failed for ${memberIdentity} in org ${org.orgId}` +
         `${code ? ` (${code})` : ""}; retrying in ${Math.round(delayMs / 1000)}s`,
       error
     );
@@ -477,7 +492,7 @@ export class MemberRuntimePushScheduler {
       level: "warn",
       kind: "member_runtime",
       orgId: org.orgId,
-      message: `Member runtime push failed; retrying in ${Math.round(delayMs / 1000)}s: ${described.message}`,
+      message: `Member runtime push failed for ${memberIdentity}; retrying in ${Math.round(delayMs / 1000)}s: ${described.message}`,
       code: described.code,
     });
   }

--- a/src/features/Org2Cloud/memberRuntime/memberRuntimePushScheduler.ts
+++ b/src/features/Org2Cloud/memberRuntime/memberRuntimePushScheduler.ts
@@ -473,10 +473,7 @@ export class MemberRuntimePushScheduler {
     // The upsert RPC derives the member from this session's JWT, so the
     // freshly authenticated profile is the authoritative identity for the
     // failed push. Keep the stable user id visible even when names collide.
-    const memberName =
-      auth.profile?.displayName?.trim() ||
-      auth.profile?.primaryEmail?.trim() ||
-      auth.userId;
+    const memberName = auth.profile?.displayName?.trim() || auth.userId;
     const memberIdentity =
       memberName === auth.userId
         ? auth.userId
@@ -492,7 +489,11 @@ export class MemberRuntimePushScheduler {
       level: "warn",
       kind: "member_runtime",
       orgId: org.orgId,
-      message: `Member runtime push failed for ${memberIdentity}; retrying in ${Math.round(delayMs / 1000)}s: ${described.message}`,
+      member: {
+        userId: auth.userId,
+        ...(memberName === auth.userId ? {} : { displayName: memberName }),
+      },
+      message: `Member runtime push failed; retrying in ${Math.round(delayMs / 1000)}s: ${described.message}`,
       code: described.code,
     });
   }

--- a/src/features/Org2Cloud/org2CloudSyncJournal.test.ts
+++ b/src/features/Org2Cloud/org2CloudSyncJournal.test.ts
@@ -67,6 +67,36 @@ describe("sync journal buffer", () => {
     expect(bare && "code" in bare).toBe(false);
   });
 
+  it("stores a normalized member identity without retaining the input object", () => {
+    const member = {
+      userId: "  user-1  ",
+      displayName: "  VantaNode  ",
+    };
+    recordSyncEvent({
+      level: "warn",
+      kind: "member_runtime",
+      message: "push failed",
+      member,
+    });
+    member.displayName = "changed later";
+
+    expect(getSyncJournalSnapshot()[0]?.member).toEqual({
+      userId: "user-1",
+      displayName: "VantaNode",
+    });
+  });
+
+  it("omits an unusable member identity instead of creating an empty filter", () => {
+    recordSyncEvent({
+      level: "warn",
+      kind: "member_runtime",
+      message: "push failed",
+      member: { userId: "   ", displayName: "VantaNode" },
+    });
+
+    expect(getSyncJournalSnapshot()[0]).not.toHaveProperty("member");
+  });
+
   it("clears entries and notifies subscribers", () => {
     const listener = vi.fn();
     const unsubscribe = subscribeSyncJournal(listener);

--- a/src/features/Org2Cloud/org2CloudSyncJournal.ts
+++ b/src/features/Org2Cloud/org2CloudSyncJournal.ts
@@ -38,6 +38,14 @@ export const SYNC_JOURNAL_LEVEL = {
 export type SyncJournalLevel =
   (typeof SYNC_JOURNAL_LEVEL)[keyof typeof SYNC_JOURNAL_LEVEL];
 
+/** Optional human identity attached to a sync event at its producer boundary. */
+export interface SyncJournalMember {
+  /** Stable identity used for filtering and copied diagnostics. */
+  userId: string;
+  /** Human-readable label. The UI falls back to `userId` when unavailable. */
+  displayName?: string;
+}
+
 export interface SyncJournalEntry {
   /** Monotonic per-process id — deterministic, unlike `Math.random`. */
   id: string;
@@ -46,6 +54,7 @@ export interface SyncJournalEntry {
   /** Coarse producer tag, e.g. `sync_pass`, `org_backoff`, `member_runtime`. */
   kind: string;
   orgId?: string;
+  member?: SyncJournalMember;
   message: string;
   /** Server error code when the source error carried one. */
   code?: string;
@@ -63,6 +72,8 @@ export const SYNC_JOURNAL_CAP = 100;
 
 /** Defensive bound on any single stringified message. */
 const MESSAGE_MAX_LENGTH = 500;
+const MEMBER_USER_ID_MAX_LENGTH = 256;
+const MEMBER_DISPLAY_NAME_MAX_LENGTH = 120;
 
 const LAST_SYNC_STORAGE_KEY = "orgii:org2-cloud-v1:syncLastPass";
 
@@ -129,6 +140,30 @@ function clampMessage(message: string): string {
   return `${trimmed.slice(0, MESSAGE_MAX_LENGTH - 1)}…`;
 }
 
+function clampIdentityField(value: string, maxLength: number): string {
+  return value.trim().slice(0, maxLength);
+}
+
+function normalizeMember(
+  member: SyncJournalMember | undefined
+): SyncJournalMember | undefined {
+  if (!member) return undefined;
+  const userId = clampIdentityField(
+    String(member.userId ?? ""),
+    MEMBER_USER_ID_MAX_LENGTH
+  );
+  if (!userId) return undefined;
+  const displayName = member.displayName
+    ? clampIdentityField(
+        String(member.displayName),
+        MEMBER_DISPLAY_NAME_MAX_LENGTH
+      )
+    : "";
+  return displayName && displayName !== userId
+    ? { userId, displayName }
+    : { userId };
+}
+
 /**
  * Coerce anything a `catch` can hand us into a flat `{ message, code }`.
  *
@@ -182,6 +217,7 @@ export type SyncJournalInput = Omit<SyncJournalEntry, "id" | "atMs"> & {
 
 /** Append one diagnostic entry, evicting the oldest past the cap. */
 export function recordSyncEvent(input: SyncJournalInput): void {
+  const member = normalizeMember(input.member);
   const entry: SyncJournalEntry = {
     id: nextId(),
     atMs: input.atMs ?? Date.now(),
@@ -189,6 +225,7 @@ export function recordSyncEvent(input: SyncJournalInput): void {
     kind: input.kind,
     message: clampMessage(String(input.message ?? "")) || "Unknown error",
     ...(input.orgId ? { orgId: input.orgId } : {}),
+    ...(member ? { member } : {}),
     ...(input.code ? { code: input.code.slice(0, 64) } : {}),
   };
   // A fresh array per mutation is what keeps `getSyncJournalSnapshot`


### PR DESCRIPTION
## Problem

Member-runtime push failures in the Cloud org sync log were unattributed, so a multi-member org could not tell which signed-in account produced a local failure. The scheduler still held the freshly authenticated profile used by the failed RPC, but the journal discarded that identity. Putting the identity directly into the error sentence made the row long and still gave users no way to isolate one member's failures.

## Solution

Attach a bounded, structured `member: { userId, displayName? }` identity to sync-journal entries at the scheduler failure boundary. The visible name uses `displayName` and falls back to the stable `userId`; profile email is deliberately not exposed. The error message remains identity-free.

The Sync log now:

- renders the member with the shared `AvatarChip` as a compact pill followed by `: message`;
- uses the shared pill-radius `Select` to filter by Everyone or one member;
- copies only the active filtered slice while preserving both display name and `userId` in plain-text diagnostics;
- keeps unattributed legacy/system entries unchanged under Everyone;
- falls back to Everyone automatically if the selected member disappears from the bounded journal.

`AvatarChip` gained an explicit avatar fallback slot so initials/icons can be rendered without an avatar URL. Journal identity fields are cloned, trimmed, and length-bounded before storage.

## Potential risks

The in-memory journal and its Copy action now contain a member display name and stable user ID. These values are never persisted or uploaded and the journal remains manually clearable and restart-cleared, but copied diagnostics remain account-identifying. Entries from an earlier in-process account can remain visible until clear/restart, matching the journal's existing local diagnostic lifetime.

The filter performs a memoized scan over the existing maximum of 100 entries and renders at most 50; no timer, retry cadence, subscription, network request, RPC, IPC, persisted schema, or payload format changed. Rollback is a straight revert of `c4df2d0c7` and `66d222fa8`.

## Architecture audit

| Layer | Verdict | Evidence |
| --- | --- | --- |
| 1. Compilation correctness | pass | Rebase-post checks: TypeScript, ESLint, targeted tests, and production webpack all pass. |
| 2. Dead code / duplication | pass | One scheduler failure boundary resolves the identity; one journal normalizer stores it; one renderer formats it. All new helpers are integrated and tested. |
| 3. Naming | pass | `SyncJournalMember` is explicitly a minimal journal identity, not a roster/member-runtime record. `selectedMemberId` and `memberFilterValue` distinguish state from Select transport values. |
| 4. Semantic overloading | pass | Human attribution is an optional structured field; the diagnostic `message` no longer doubles as filter metadata. |
| 5. Default branches | pass | No new enum/default match. Missing/invalid identity omits `member`; missing display name falls back to `userId`; missing selected identity falls back to Everyone. |
| 6. Cross-domain leakage | pass | The journal does not import auth or roster types. The scheduler maps fresh auth into the journal-owned minimal identity at the producer boundary. |
| 7. New-developer clarity | pass | Storage lifetime, stable-ID purpose, newest-label behavior, and fallback semantics are documented at their owning helpers. |
| 8. Wire / serialization | not applicable | Journal entries are process-local and in-memory; no wire, IPC, database, or persisted format changes. |
| 9. Initialization parity | pass | Production rejected-upsert and direct failure-handler tests both enter the same identity-recording method. No alternate journal renderer was added. |
| 10. Resolver symmetry | pass | Developer warning, visible pill, filter key, and copied output all derive from the same fresh auth identity; display-name absence consistently resolves to `userId`. |

## Frontend UI audit

Report: `docs/frontend-ui-audit-2026-08-03/CloudOrgSyncSection.md`.

- fix: 1
- keep with reason: 4
- abstract: 1
- new raw colors / raw interactive elements / arbitrary Tailwind values: 0

The configured `frontend-ui-audit` skill file was missing from both documented global/workspace locations, so the report applies its repository-specified design-system, reuse, accessibility, and arbitrary-value checks manually.

## Performance audit

| Area | Verdict | Evidence | Change or reason kept | Verification |
| --- | --- | --- | --- | --- |
| Background work | keep | The scheduler's existing failure/backoff path is the only producer touched. | No timer, cadence, retry, request, listener, or subscription change. | Source sweep plus 11 scheduler tests. |
| Memory | keep | Journal remains capped at 100 entries; message remains capped at 500 chars; member ID/name are capped at 256/120 chars. | Identity is copied into a flat object; no retained auth/profile object. | Journal bound/normalization tests. |
| Scope/isolation | keep | Identity comes from the same freshly authenticated session used for the failed upsert; journal stays process-local. | No cross-instance cache or persistence added. | Scheduler identity/fallback tests and isolated app run. |
| Rendering/hot path | keep | Member-option derivation scans at most 100 entries and rendering stays capped at 50. | `useMemo` recomputes only on journal/filter changes; idle UI does no work. | Filter render/copy test plus visible/hidden process samples. |

Performance verdict: pass

## Verification

- `npm test -- --run src/features/Org2Cloud/org2CloudSyncJournal.test.ts src/features/Org2Cloud/memberRuntime/memberRuntimePushScheduler.test.ts src/engines/ChatPanel/panels/CloudOrgPanelView/CloudOrgSyncSection.test.ts` — 53/53 passed after rebasing onto `372b5a2c0`.
- `npm run typecheck` — passed after rebase.
- `npx eslint <7 changed TS/TSX files>` — passed after rebase.
- `npm run build` — production webpack passed after rebase.
- `git diff --check upstream/develop...HEAD` — passed.
- Pre-commit lint-staged, scoped TypeScript check, and circular-dependency check — passed.
- `npm run tauri:build:fast:local` — macOS app bundle built successfully before the final rebase; the temporary demo-event injection was removed from source immediately after webpack captured the fixture.
- Full local Vitest was not rerun for this UI follow-up. The previous branch run completed all 7,671 assertions across 890 files but exited non-zero on the documented pre-existing undici WebSocket cleanup exception; fresh PR CI is the authoritative full-suite run.
- PR CI after the rebase and UI follow-up: Frontend (typecheck · lint · full unit tests), Rust clippy, and AI-attribution check all passed.

## Real-app UI and lifecycle verification

- Launched an isolated macOS Tauri instance and injected two local-only demo journal records (Ada and VantaNode) into the test bundle; no fixture/debug code is present in the PR diff.
- Confirmed both entries render as separate token-based cards with compact member pills and identity-free messages.
- Opened the member Select, confirmed Everyone / Ada / VantaNode options, selected VantaNode, and confirmed only VantaNode's entry remained.
- Unit-driven copy verification confirms the filtered text includes `member Ada (user-ada)` and excludes other-member/system records.
- Captured screenshots for Everyone and VantaNode-filtered states locally. They are not attached publicly because the full app window contains real account/session metadata.
- Visible idle samples over six seconds: `0.0 / 0.0 / 0.0%` CPU; RSS `126,704 / 126,688 / 126,688 KiB`.
- Minimized idle samples over six seconds: `0.1 / 0.0 / 0.0%` CPU; RSS `127,616 / 127,696 / 127,696 KiB`.
- Temporary test app was stopped and moved to Trash after verification; screenshots remain on the local Desktop for review.

## Existing dual-instance coverage

The scheduler attribution change was previously exercised with two isolated macOS instances using distinct data roots, ports, signed-in accounts, and the same Cloud org. Both completed manual sync, reported separate member runtime profiles, and stabilized at 0.0% CPU in repeated idle samples. This UI follow-up adds no shared process, cache, wire, or multi-instance state; each instance's journal and filter remain process-local.
