### PR TITLE
feat(team-inbox): notify assignment recipients

### DIFF
--- a/docs/frontend-ui-audit-2026-07-30/TeamInboxAssignmentNotifications.md
+++ b/docs/frontend-ui-audit-2026-07-30/TeamInboxAssignmentNotifications.md
@@ -1,0 +1,46 @@
+# Frontend UI Audit — TeamInboxAssignmentNotifications
+
+**Files:** `src/components/Message/index.tsx`, `src/modules/MainApp/TeamInbox/TeamInboxView.tsx`, `src/modules/MainApp/TeamInbox/ConnectedTeamInboxView.tsx`
+**Date:** 2026-07-30
+**Auditor:** Codex
+
+## D1 — Raw HTML vs Design System
+
+| Line | Element | Verdict | Reason | Suggested change |
+|---|---|---|---|---|
+| `Message:232-270` | Inline toast action and close `<button>` elements | keep with reason | The text-link actions and 24px close hit area are part of the existing isolated toast-root pattern; the design-system `Button` adds container sizing/padding that does not cover these compact roles. All controls remain native buttons. | — |
+| `TeamInboxView` | No raw interactive elements added | keep with reason | Notification-driven selection composes the existing `TeamInboxList`, `Placeholder`, and `SplitViewLayout` design-system surfaces. | — |
+
+## D2 — Arbitrary Tailwind Value vs Token
+
+| Line | Value | Verdict | Reason | Suggested change |
+|---|---|---|---|---|
+| `Message:206` | Component-owned shadow/padding values | keep with reason | These values predate this feature and define the existing toast elevation and compact inset; the new action reuses that surface without adding another visual recipe. | — |
+| `TeamInboxView` | No arbitrary color/token values added | keep with reason | New focus-request behavior is state-only and introduces no styling. | — |
+
+## D3 — Hardcoded Sizes / Colors
+
+| Line | Value | Verdict | Reason | Suggested change |
+|---|---|---|---|---|
+| `Message:218-265,294` | Existing 13px toast type, 24px close target, and 380px max width | keep with reason | They are established toast-specific dimensions; this feature does not add or fork them. The new primary action uses the existing text-action scale. | — |
+| `TeamInboxView:451-453` | Existing split-view width presets | keep with reason | These are unchanged layout constraints owned by `SplitViewLayout`, not notification-specific styling. | — |
+
+## D4 — Accessibility
+
+| Line | Element | Verdict | Reason | Suggested change |
+|---|---|---|---|---|
+| `Message:249-256` | Primary toast action | keep with reason | Native button with a required visible localized label; keyboard activation is automatic. | — |
+| `Message:263-270` | Toast close action | keep with reason | Native button retains its localized `aria-label`. | — |
+| `TeamInboxView:158-190` | Notification-driven selection | keep with reason | It reuses the listbox/option semantics and existing detail surface; no modal or focus trap is introduced. | — |
+
+## D5 — Visual Patterns Observed
+
+- The feature extends the single shared `Message` toast implementation; it does not create a Team Inbox-specific popup.
+- Toast activation and native notification activation converge on the same Team Inbox focus-request state instead of duplicating navigation UI.
+- No new cross-file visual pattern reaches the abstraction threshold.
+
+## Summary
+
+- 0 fixes recommended
+- 8 kept with documented reason
+- 0 abstract candidates

--- a/docs/org2-performance-guard-2026-07-30/TeamInboxAssignmentNotifications.md
+++ b/docs/org2-performance-guard-2026-07-30/TeamInboxAssignmentNotifications.md
@@ -1,0 +1,10 @@
+# Team Inbox assignment notifications — performance guard
+
+| Area | Verdict | Evidence | Change or reason kept | Verification |
+| --- | --- | --- | --- | --- |
+| Background work | keep | `GlobalSessionSync` owns one notification-action listener; assignment delivery remains driven by Team Inbox cache changes and adds no poller or retry loop | Register once in the global hook and return the plugin disposer from the effect cleanup | Hook test proves the disposer runs on unmount; changed frontend files pass ESLint |
+| Memory | keep | The focus request atom retains one `{ itemKey, requestId }`; the existing per-store tracker uses a `WeakMap` and caps seen signatures at 1,000 | Keep constant-size focus state and the existing bounded/dereferenceable notification tracker | Tracker regression suite and notification hook tests pass |
+| Scope/isolation | keep | Notification metadata contains only the canonical Team Inbox item key; tracker ownership remains per Jotai store | Route the action into the current store and singleton Team Inbox tab without adding an app-global item cache | Tests verify the exact item key is focused and disabled notification categories emit neither native nor in-app alerts |
+| Rendering/hot path | keep | One toast is created only for a fresh assignment batch; no render-time scan, polling, or recurring timer was introduced beyond the toast component's bounded dismissal timer | Reuse the existing `Message` host and derive focused selection instead of synchronizing it through a render-triggering effect | View tests verify manual opening does not mark the first unread item and an explicit notification focus marks only its target |
+
+Performance verdict: pass

--- a/src-tauri/crates/project-management/src/team_inbox/store.rs
+++ b/src-tauri/crates/project-management/src/team_inbox/store.rs
@@ -10,7 +10,9 @@ use super::{
     schema::init_team_inbox_tables, TeamInboxActor, TeamInboxCursor, TeamInboxFilter,
     TeamInboxItem, TeamInboxItemKind, TeamInboxPage, TeamInboxPayload, TeamInboxTarget,
 };
-use crate::projects::types::{WorkItemHandoff, WorkItemHandoffStatus};
+use crate::projects::types::{
+    WorkItemHandoff, WorkItemHandoffStatus, WorkItemHistoryAction, WorkItemHistoryEvent,
+};
 
 const ASSIGNED_SOURCE_KIND: &str = "work_item_assigned";
 const COMMENT_MENTION_SOURCE_KIND: &str = "work_item_comment_mention";
@@ -61,6 +63,53 @@ fn handoff_actor(handoff: &WorkItemHandoff) -> TeamInboxActor {
         display_name,
         avatar_url: None,
     }
+}
+
+#[derive(serde::Deserialize)]
+struct AssignmentHistoryProjection {
+    #[serde(default)]
+    history: Vec<WorkItemHistoryEvent>,
+}
+
+fn history_event_actor(event: &WorkItemHistoryEvent) -> Option<TeamInboxActor> {
+    let actor_id = event
+        .actor_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let actor_name = event
+        .actor_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let id = actor_id.or(actor_name)?;
+    Some(TeamInboxActor {
+        id: id.to_string(),
+        display_name: actor_name.unwrap_or(id).to_string(),
+        avatar_url: None,
+    })
+}
+
+/// Resolve the actor that produced the current human-assignment episode from
+/// the canonical Work Item history. Later status/body edits must not replace
+/// the assignment actor shown by Team Inbox.
+fn assignment_actor(extras_json: Option<&str>, assignee_member_id: &str) -> Option<TeamInboxActor> {
+    let history = serde_json::from_str::<AssignmentHistoryProjection>(extras_json?)
+        .ok()?
+        .history;
+    let assignment_event = history.iter().rev().find(|event| {
+        event.changes.iter().any(|change| {
+            change.field == "assignee" && change.new_value.as_str() == Some(assignee_member_id)
+        })
+    });
+    if let Some(event) = assignment_event {
+        return history_event_actor(event);
+    }
+
+    history
+        .iter()
+        .find(|event| event.action == WorkItemHistoryAction::Created)
+        .and_then(history_event_actor)
 }
 
 #[derive(Debug, Clone)]
@@ -227,12 +276,16 @@ fn list_assigned_items(
             let body: String = row.get(12)?;
             let extras_json: Option<String> = row.get(13)?;
             let handoff = handoff_from_extras(extras_json.as_deref());
+            let actor = handoff
+                .as_ref()
+                .map(handoff_actor)
+                .or_else(|| assignment_actor(extras_json.as_deref(), &assignee_member_id));
             Ok(TeamInboxItem {
                 id: assigned_item_id(&work_item_id),
                 kind: TeamInboxItemKind::WorkItemAssigned,
                 occurred_at: row.get(10)?,
                 read_at: row.get(11)?,
-                actor: handoff.as_ref().map(handoff_actor),
+                actor,
                 target: TeamInboxTarget::WorkItem {
                     work_item_id,
                     org_id: row.get(1)?,

--- a/src-tauri/crates/project-management/src/team_inbox/tests.rs
+++ b/src-tauri/crates/project-management/src/team_inbox/tests.rs
@@ -706,3 +706,76 @@ fn assigned_item_projects_durable_handoff_context() {
         other => panic!("expected assigned handoff payload, got {other:?}"),
     }
 }
+
+#[test]
+fn assigned_item_projects_the_actor_from_the_current_assignment_episode() {
+    let connection = database();
+    insert_project(&connection, "project-1", "alpha");
+    insert_work_item(
+        &connection,
+        WorkItemFixture {
+            id: "work-assigned",
+            short_id: "TST-11",
+            title: "Review notification flow",
+            project_id: Some("project-1"),
+            assigned_human_id: Some("member-recipient"),
+            assignee: Some("member-recipient"),
+            assignee_type: Some("member"),
+            updated_at: 30,
+            deleted_at: None,
+        },
+    );
+    connection
+        .execute(
+            "INSERT INTO workitem_extras (work_item_id, extras_json)
+             VALUES ('work-assigned', ?1)",
+            [json!({
+                "history": [
+                    {
+                        "id": "created",
+                        "action": "created",
+                        "timestamp": "2026-07-28T09:00:00Z",
+                        "actorId": "member-creator",
+                        "actorName": "Creator"
+                    },
+                    {
+                        "id": "assigned",
+                        "action": "updated",
+                        "timestamp": "2026-07-28T10:00:00Z",
+                        "actorId": "member-sender",
+                        "actorName": "Ada",
+                        "changes": [{
+                            "field": "assignee",
+                            "oldValue": null,
+                            "newValue": "member-recipient"
+                        }]
+                    },
+                    {
+                        "id": "status",
+                        "action": "updated",
+                        "timestamp": "2026-07-28T11:00:00Z",
+                        "actorId": "member-editor",
+                        "actorName": "Later editor",
+                        "changes": [{
+                            "field": "status",
+                            "oldValue": "todo",
+                            "newValue": "in_progress"
+                        }]
+                    }
+                ]
+            })
+            .to_string()],
+        )
+        .expect("insert assignment history");
+
+    let page = list_page_with_connection(&connection, options(&["member-recipient"], 10))
+        .expect("list assignment");
+    assert_eq!(
+        page.items[0].actor,
+        Some(TeamInboxActor {
+            id: "member-sender".into(),
+            display_name: "Ada".into(),
+            avatar_url: None,
+        })
+    );
+}

--- a/src/api/services/notification.test.ts
+++ b/src/api/services/notification.test.ts
@@ -5,10 +5,12 @@ import type { NotificationSettings } from "@src/types/ui/notification";
 import {
   checkNotificationPermission,
   disposeNotificationRuntime,
+  listenForSystemNotificationActions,
   notifyAgentApproval,
   notifyError,
   notifyTaskCompletion,
   notifyTeamInbox,
+  registerTeamInboxNotificationActionType,
   sendSystemNotification,
   sendTestNotification,
   setDockBadge,
@@ -20,6 +22,8 @@ const mocks = vi.hoisted(() => ({
   playNotificationSound: vi.fn(async () => true),
   requestPermission: vi.fn(),
   sendNotification: vi.fn(async () => undefined),
+  onAction: vi.fn(),
+  registerActionTypes: vi.fn(),
 }));
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -35,6 +39,8 @@ vi.mock("@tauri-apps/plugin-notification", () => ({
   isPermissionGranted: mocks.isPermissionGranted,
   requestPermission: mocks.requestPermission,
   sendNotification: mocks.sendNotification,
+  onAction: mocks.onAction,
+  registerActionTypes: mocks.registerActionTypes,
 }));
 
 vi.mock("@src/hooks/logger", () => ({
@@ -146,6 +152,67 @@ describe("notification service", () => {
       title: "Title",
       body: "Body",
     });
+  });
+
+  it("preserves navigation metadata and disposes native action listeners", async () => {
+    const unregister = vi.fn();
+    const handler = vi.fn();
+    mocks.onAction.mockResolvedValueOnce({ unregister });
+
+    await sendSystemNotification("Assigned", "Review it", {
+      orgiiTarget: "team-inbox",
+      teamInboxItemKey: "assigned_work_item:WI-1",
+    });
+
+    expect(mocks.sendNotification).toHaveBeenLastCalledWith({
+      title: "Assigned",
+      body: "Review it",
+      extra: {
+        orgiiTarget: "team-inbox",
+        teamInboxItemKey: "assigned_work_item:WI-1",
+      },
+      actionTypeId: undefined,
+      autoCancel: true,
+    });
+
+    const dispose = await listenForSystemNotificationActions(handler);
+    const nativeHandler = mocks.onAction.mock.calls[0]?.[0] as
+      | ((notification: { extra?: Record<string, unknown> }) => void)
+      | undefined;
+    nativeHandler?.({
+      extra: {
+        orgiiTarget: "team-inbox",
+        teamInboxItemKey: "assigned_work_item:WI-1",
+      },
+    });
+    expect(handler).toHaveBeenCalledWith({
+      extra: {
+        orgiiTarget: "team-inbox",
+        teamInboxItemKey: "assigned_work_item:WI-1",
+      },
+    });
+
+    dispose();
+    expect(unregister).toHaveBeenCalledOnce();
+  });
+
+  it("registers a foreground View action for Team Inbox notifications", async () => {
+    mocks.registerActionTypes.mockResolvedValueOnce(undefined);
+
+    await registerTeamInboxNotificationActionType("View");
+
+    expect(mocks.registerActionTypes).toHaveBeenCalledWith([
+      {
+        id: "orgii-team-inbox",
+        actions: [
+          {
+            id: "view-team-inbox",
+            title: "View",
+            foreground: true,
+          },
+        ],
+      },
+    ]);
   });
 
   it("projects positive and cleared dock badge values", async () => {

--- a/src/api/services/notification.ts
+++ b/src/api/services/notification.ts
@@ -2,6 +2,8 @@ import { invoke, isTauri } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
   isPermissionGranted,
+  onAction,
+  registerActionTypes,
   requestPermission,
   sendNotification,
 } from "@tauri-apps/plugin-notification";
@@ -41,6 +43,8 @@ export interface NotificationOptions {
   playSound?: boolean;
   context?: NotificationContext;
   summaryLabel?: string;
+  extra?: Record<string, unknown>;
+  actionTypeId?: string;
 }
 
 interface TerminalNotificationOptions {
@@ -77,6 +81,12 @@ export function terminalNotificationEventKey(
 ): string {
   return notificationRunTracker.terminalEventKey(sessionId, status);
 }
+
+export interface SystemNotificationAction {
+  extra: Record<string, unknown>;
+}
+
+export const TEAM_INBOX_NOTIFICATION_ACTION_TYPE_ID = "orgii-team-inbox";
 
 /**
  * Read the native permission tri-state without collapsing "not requested" into
@@ -133,10 +143,18 @@ export const requestNotificationPermission =
 
 export const sendSystemNotification = async (
   title: string,
-  body: string
+  body: string,
+  extra?: Record<string, unknown>,
+  actionTypeId?: string
 ): Promise<boolean> => {
   try {
-    await sendNotification({ title, body });
+    await sendNotification({
+      title,
+      body,
+      extra,
+      actionTypeId,
+      autoCancel: true,
+    });
     return true;
   } catch (error) {
     log.warn("[Notification] Send failed, trying Rust command:", error);
@@ -151,6 +169,39 @@ export const sendSystemNotification = async (
 };
 
 /** Project the authoritative Team Inbox unread count into the dock badge. */
+export const registerTeamInboxNotificationActionType = async (
+  viewLabel: string
+): Promise<void> => {
+  await registerActionTypes([
+    {
+      id: TEAM_INBOX_NOTIFICATION_ACTION_TYPE_ID,
+      actions: [
+        {
+          id: "view-team-inbox",
+          title: viewLabel,
+          foreground: true,
+        },
+      ],
+    },
+  ]);
+};
+
+/**
+ * Listen for native notification activation while the application process is
+ * alive. The returned disposer is safe to call during React effect cleanup.
+ */
+export const listenForSystemNotificationActions = async (
+  handler: (action: SystemNotificationAction) => void
+): Promise<() => void> => {
+  const listener = await onAction((notification) => {
+    handler({ extra: notification.extra ?? {} });
+  });
+  return () => listener.unregister();
+};
+
+/**
+ * Project the authoritative Team Inbox unread count into the dock badge.
+ */
 export const setDockBadge = async (count: number): Promise<boolean> => {
   try {
     await invoke("set_dock_badge", {
@@ -181,7 +232,12 @@ async function deliverNotification(
   Pick<NotificationDeliveryResult, "systemNotificationSent" | "soundPlayed">
 > {
   const systemNotificationSent = decision.sendSystemNotification
-    ? await sendSystemNotification(options.title, options.body)
+    ? await sendSystemNotification(
+        options.title,
+        options.body,
+        options.extra,
+        options.actionTypeId
+      )
     : false;
   const soundPlayed = decision.playSound
     ? await playNotificationSound({
@@ -382,17 +438,21 @@ export const notifyError = async (
 export const notifyTeamInbox = async (
   title: string,
   body: string,
-  settings: NotificationSettings
-): Promise<NotificationDeliveryResult> =>
-  notify(
+  settings: NotificationSettings,
+  extra?: Record<string, unknown>
+): Promise<NotificationDeliveryResult> => {
+  return notify(
     {
       title,
       body,
       category: "teamInbox",
       playSound: true,
+      extra,
+      actionTypeId: TEAM_INBOX_NOTIFICATION_ACTION_TYPE_ID,
     },
     settings
   );
+};
 
 /** Test the native channel and selected sound without changing saved settings. */
 export const sendTestNotification = async (

--- a/src/components/Message/index.tsx
+++ b/src/components/Message/index.tsx
@@ -65,6 +65,12 @@ export interface MessageConfig {
     onClick?: () => void;
     closeOnClick?: boolean;
   };
+  /** Optional primary action shown in the toast. */
+  action?: {
+    label: string;
+    onClick: () => void;
+    closeOnClick?: boolean;
+  };
 }
 
 interface MessageItemProps extends MessageConfig {
@@ -122,6 +128,7 @@ const MessageItem = ({
   className = "",
   download,
   cancel,
+  action,
   ref,
 }: MessageItemProps) => {
   const { t } = useTranslation();
@@ -150,7 +157,7 @@ const MessageItem = ({
   const IconComponent = ICONS[type];
   const typeStyle = TYPE_STYLES[type];
   const iconNode = icon || <IconComponent size={18} />;
-  const hasDescription = Boolean(title || download || cancel);
+  const hasDescription = Boolean(title || download || cancel || action);
   const handleDownload = useCallback(() => {
     const blob =
       download?.content instanceof Blob
@@ -174,6 +181,12 @@ const MessageItem = ({
       handleClose();
     }
   }, [cancel, handleClose]);
+  const handlePrimaryAction = useCallback(() => {
+    action?.onClick();
+    if (action?.closeOnClick !== false) {
+      handleClose();
+    }
+  }, [action, handleClose]);
 
   return (
     <motion.div
@@ -213,7 +226,7 @@ const MessageItem = ({
         >
           {content}
         </div>
-        {(download || cancel) && (
+        {(download || cancel || action) && (
           <div className="mt-2 flex justify-end gap-3">
             {cancel && (
               <button
@@ -231,6 +244,15 @@ const MessageItem = ({
                 onClick={handleDownload}
               >
                 {download.label ?? t("actions.download")}
+              </button>
+            )}
+            {action && (
+              <button
+                type="button"
+                className="cursor-pointer border-none bg-transparent p-0 text-xs font-semibold leading-[1.2] text-primary-6 hover:text-primary-5 hover:underline"
+                onClick={handlePrimaryAction}
+              >
+                {action.label}
               </button>
             )}
           </div>

--- a/src/modules/MainApp/TeamInbox/ConnectedTeamInboxView.tsx
+++ b/src/modules/MainApp/TeamInbox/ConnectedTeamInboxView.tsx
@@ -1,6 +1,8 @@
+import { useAtomValue } from "jotai";
 import React from "react";
 
 import TeamInboxView from "./TeamInboxView";
+import { teamInboxItemFocusRequestAtom } from "./store";
 import { useTeamInboxDataSource } from "./useTeamInboxDataSource";
 import { useTeamInboxNavigation } from "./useTeamInboxNavigation";
 import { useTeamInboxPullRequests } from "./useTeamInboxPullRequests";
@@ -8,10 +10,12 @@ import { useTeamInboxPullRequests } from "./useTeamInboxPullRequests";
 const ConnectedTeamInboxView: React.FC = () => {
   const { dataSource, viewerMemberIds } = useTeamInboxDataSource();
   const pullRequests = useTeamInboxPullRequests();
+  const focusRequest = useAtomValue(teamInboxItemFocusRequestAtom);
   const navigate = useTeamInboxNavigation();
   return (
     <TeamInboxView
       dataSource={dataSource}
+      focusRequest={focusRequest}
       viewerMemberIds={viewerMemberIds}
       onNavigate={navigate}
       pullRequests={pullRequests.items}

--- a/src/modules/MainApp/TeamInbox/TEST_CASES.md
+++ b/src/modules/MainApp/TeamInbox/TEST_CASES.md
@@ -52,6 +52,55 @@
 20. Top-level section headers follow the sidebar Session hierarchy with a denser treatment: 28px headers, uppercase 10px `text-text-2` labels, hover/focus disclosure chevrons, and 8px gaps between sections.
 21. Repository/source labels use only the final path segment (never `owner/repository`), strip URL/query/`.git` decoration, and are capped at the first 10 characters for both pull requests and Work Items. A projectless Work Item falls back to the localized `Issue` type without inventing a repository.
 
+## Assignment notification lifecycle
+
+### Preconditions
+
+- Two users resolve to distinct active member identities in the same project or Cloud Org.
+- Team Inbox notifications are enabled; native delivery additionally requires OS permission.
+- The recipient application is running so its push-driven Team Inbox coordinator can observe the assignment.
+
+### Happy Path
+
+| # | Steps | Expected Result |
+|---|-------|-----------------|
+| 1 | User A assigns a Work Item to user B. | B receives one right-bottom in-app toast naming A and the Work Item, plus the configured native notification/sound and updated Sidebar/Dock unread badges. |
+| 2 | B activates `View` in the toast. | The singleton Team Inbox tab opens or focuses, clears an obstructing filter/search, selects only that assignment, and marks it read through the existing receipt boundary. |
+| 3 | B activates the native notification while ORGII is running. | The app window shows/focuses and the same Team Inbox target is selected; no parallel navigation path is created. |
+| 4 | B opens Team Inbox manually without activating a notification or row. | No unread assignment is implicitly selected or marked read. |
+
+### Edge Cases
+
+| # | Scenario | Steps | Expected Result |
+|---|----------|-------|-----------------|
+| 1 | Historical unread rows | Start ORGII with existing unread assignments. | Rows and badges hydrate, but no toast/native notification is replayed. |
+| 2 | Batched assignments | Two new assignments arrive in one cache revision. | One aggregate notification and toast open Team Inbox without pretending one row is the unique target. |
+| 3 | Duplicate/remount | Re-emit the same item or remount the notification host. | The store-scoped tracker suppresses duplicate delivery. |
+| 4 | Disabled category | Disable Team Inbox notifications, then receive an assignment. | The Inbox row remains authoritative, but no toast, native notification, or sound is produced and the configured Dock badge is cleared. |
+| 5 | Long names/titles | Assign an item with a long sender name or body. | Existing toast wrapping applies and the native body is whitespace-folded and capped at 180 characters. |
+
+### Error / Degraded States
+
+| # | Scenario | Steps | Expected Result |
+|---|----------|-------|-----------------|
+| 1 | Native permission/send failure | Receive an assignment while OS notification delivery is unavailable. | The in-app toast, Inbox row, and Sidebar badge remain usable; failure is logged without rolling back domain state. |
+| 2 | Native action-listener failure | Listener registration rejects. | Assignment delivery continues; the in-app `View` action remains available. |
+| 3 | App fully exited | Assign while the recipient process is not running. | The assignment hydrates as unread on next launch without a fabricated late popup; realtime closed-app delivery remains a server-push/background-runtime requirement. |
+
+### Accessibility
+
+- [ ] Toast `View` is a native keyboard-focusable button with a visible localized label.
+- [ ] The close button retains its accessible name and does not trigger navigation.
+- [ ] Notification-driven selection lands on the existing Inbox detail without creating a second modal/focus trap.
+
+### Acceptance Criteria
+
+- [ ] Ordinary assignment notifications identify the assigning user.
+- [ ] Toast and native activation converge on one Team Inbox focus request.
+- [ ] Manual Inbox opening never marks the first unread row by default.
+- [ ] Only fresh unread arrivals notify; historical, duplicate, read, and unrelated native actions do not.
+- [ ] Listener lifecycle is single-owner and disposed on unmount.
+
 ## Session → Work Item drop
 
 | #   | Steps                                                                                                                        | Expected result                                                                                                                                                  |

--- a/src/modules/MainApp/TeamInbox/TeamInboxView.tsx
+++ b/src/modules/MainApp/TeamInbox/TeamInboxView.tsx
@@ -36,12 +36,14 @@ import {
   selectTeamInboxItems,
   toTeamInboxNavigationIntent,
 } from "./domain";
+import type { TeamInboxItemFocusRequest } from "./store";
 import { performTeamInboxReadTransition } from "./teamInboxReadTransitions";
 
 export interface TeamInboxViewProps {
   dataSource?: TeamInboxDataSource;
   onNavigate?: (intent: TeamInboxNavigationIntent) => void;
   initialFilter?: TeamInboxFilter;
+  focusRequest?: TeamInboxItemFocusRequest | null;
   pageSize?: number;
   viewerMemberIds?: readonly string[];
   pullRequests?: readonly ManagedPrItem[];
@@ -67,10 +69,16 @@ interface LoadState {
   message: string | null;
 }
 
+interface TeamInboxSelectionState {
+  itemId: string | null;
+  supersededFocusRequestId: number | null;
+}
+
 const TeamInboxView: React.FC<TeamInboxViewProps> = ({
   dataSource = EMPTY_TEAM_INBOX_DATA_SOURCE,
   onNavigate,
   initialFilter = "all",
+  focusRequest = null,
   pageSize = 50,
   viewerMemberIds = [],
   pullRequests = [],
@@ -84,10 +92,13 @@ const TeamInboxView: React.FC<TeamInboxViewProps> = ({
   const [items, setItems] = useState<TeamInboxItem[]>([]);
   const [authoritativeUnreadCounts, setAuthoritativeUnreadCounts] =
     useState<TeamInboxUnreadCounts | null>(null);
-  const [requestedItemId, setRequestedItemId] = useState<string | null>(null);
   const [selectedPullRequestKey, setSelectedPullRequestKey] = useState<
     string | null
   >(null);
+  const [selection, setSelection] = useState<TeamInboxSelectionState>({
+    itemId: null,
+    supersededFocusRequestId: null,
+  });
   const [loadState, setLoadState] = useState<LoadState>({
     status: "loading",
     message: null,
@@ -165,9 +176,21 @@ const TeamInboxView: React.FC<TeamInboxViewProps> = ({
     });
   }, [dataSource]);
 
+  const focusRequestActive =
+    focusRequest !== null &&
+    focusRequest.requestId !== selection.supersededFocusRequestId;
+  const visibleFilter = focusRequestActive ? "all" : filter;
+  const visibleQuery = focusRequestActive ? "" : query;
+  const requestedItemId = focusRequestActive
+    ? focusRequest.itemKey
+    : selection.itemId;
   const visibleItems = useMemo(
-    () => searchTeamInboxItems(selectTeamInboxItems(items, filter), query),
-    [filter, items, query]
+    () =>
+      searchTeamInboxItems(
+        selectTeamInboxItems(items, visibleFilter),
+        visibleQuery
+      ),
+    [items, visibleFilter, visibleQuery]
   );
   const loadedUnreadCounts = useMemo(
     () => countUnreadTeamInboxItemsByFilter(items),
@@ -202,11 +225,11 @@ const TeamInboxView: React.FC<TeamInboxViewProps> = ({
     [selectedPullRequest]
   );
   const selectedItem = useMemo(() => {
-    if (visibleItems.length === 0) return null;
+    if (!requestedItemId) return null;
     return (
       visibleItems.find(
         (item) => getTeamInboxItemKey(item) === requestedItemId
-      ) ?? visibleItems[0]
+      ) ?? null
     );
   }, [requestedItemId, visibleItems]);
   const selectedItemId =
@@ -280,11 +303,40 @@ const TeamInboxView: React.FC<TeamInboxViewProps> = ({
 
   const handleSelect = (item: TeamInboxItem) => {
     setSelectedPullRequestKey(null);
-    setRequestedItemId(getTeamInboxItemKey(item));
+    if (focusRequestActive) {
+      setFilter("all");
+      setQuery("");
+    }
+    setSelection({
+      itemId: getTeamInboxItemKey(item),
+      supersededFocusRequestId: focusRequest?.requestId ?? null,
+    });
+  };
+
+  const handleFilterChange = (nextFilter: TeamInboxFilter) => {
+    if (focusRequestActive) setQuery("");
+    setFilter(nextFilter);
+    setSelection((current) => ({
+      ...current,
+      supersededFocusRequestId: focusRequest?.requestId ?? null,
+    }));
+  };
+
+  const handleQueryChange = (nextQuery: string) => {
+    if (focusRequestActive) setFilter("all");
+    setQuery(nextQuery);
+    setSelection((current) => ({
+      ...current,
+      supersededFocusRequestId: focusRequest?.requestId ?? null,
+    }));
   };
 
   const handleSelectPullRequest = (pullRequest: ManagedPrItem) => {
     setSelectedPullRequestKey(getManagedPullRequestKey(pullRequest));
+    setSelection((current) => ({
+      ...current,
+      supersededFocusRequestId: focusRequest?.requestId ?? null,
+    }));
   };
 
   const handleMarkRead = (item: TeamInboxItem) => {
@@ -307,13 +359,13 @@ const TeamInboxView: React.FC<TeamInboxViewProps> = ({
 
   const handleMarkAllRead = () => {
     const filterUnreadCount =
-      filter === "all"
+      visibleFilter === "all"
         ? unreadCounts.all
-        : filter === "mentions"
+        : visibleFilter === "mentions"
           ? unreadCounts.mentions
           : unreadCounts.assigned;
     if (filterUnreadCount === 0) return;
-    void dataSource.markAllRead?.([], filter).catch(() => {
+    void dataSource.markAllRead?.([], visibleFilter).catch(() => {
       setLoadState({
         status: "error",
         message: t("teamInbox.errors.markAllRead"),
@@ -502,19 +554,19 @@ const TeamInboxView: React.FC<TeamInboxViewProps> = ({
               />
             ) : (
               <TeamInboxList
-                filter={filter}
+                filter={visibleFilter}
                 items={visibleItems}
                 selectedItemId={selectedItemId}
                 totalUnread={totalUnread}
                 unreadCounts={unreadCounts}
-                query={query}
+                query={visibleQuery}
                 loading={loadState.status === "loading" || pullRequestsLoading}
                 pullRequests={pullRequests}
                 pullRequestsLoading={pullRequestsLoading}
                 pullRequestsError={pullRequestsError}
                 selectedPullRequestKey={selectedPullRequestKey}
-                onQueryChange={setQuery}
-                onFilterChange={setFilter}
+                onQueryChange={handleQueryChange}
+                onFilterChange={handleFilterChange}
                 onSelectItem={handleSelect}
                 onSelectPullRequest={handleSelectPullRequest}
                 onRefresh={handleRefresh}

--- a/src/modules/MainApp/TeamInbox/__tests__/TeamInboxView.layout.test.ts
+++ b/src/modules/MainApp/TeamInbox/__tests__/TeamInboxView.layout.test.ts
@@ -203,6 +203,13 @@ describe("TeamInboxView split layout", () => {
       await Promise.resolve();
     });
 
+    act(() => {
+      const onSelectItem = componentProps.list?.onSelectItem as
+        | ((item: AssignedWorkItem) => void)
+        | undefined;
+      onSelectItem?.(assignedItem);
+    });
+
     const onWorkItemUpdated = componentProps.assignedDetail
       ?.onWorkItemUpdated as ((workItem: WorkItem) => void) | undefined;
     expect(onWorkItemUpdated).toBeTypeOf("function");
@@ -334,8 +341,7 @@ describe("TeamInboxView split layout", () => {
       await Promise.resolve();
     });
 
-    expect(markRead).toHaveBeenCalledOnce();
-    expect(markRead).toHaveBeenCalledWith(unreadItem);
+    expect(markRead).not.toHaveBeenCalled();
 
     await act(async () => {
       const onSelectItem = componentProps.list?.onSelectItem as
@@ -345,11 +351,64 @@ describe("TeamInboxView split layout", () => {
       await Promise.resolve();
     });
     expect(markRead).toHaveBeenCalledOnce();
+    expect(markRead).toHaveBeenCalledWith(unreadItem);
 
     await act(async () => {
       resolveMarkRead?.();
       await Promise.resolve();
     });
+  });
+
+  it("focuses and reads only the item explicitly requested by a notification", async () => {
+    const firstItem: AssignedWorkItem = {
+      id: "first",
+      kind: "assigned_work_item",
+      occurredAt: "2026-07-28T00:01:00.000Z",
+      readAt: null,
+      actor: { id: "member-1", displayName: "Yuki" },
+      target: {
+        kind: "work_item",
+        projectId: "demo",
+        workItemId: "AAA-0001",
+      },
+      payload: {
+        title: "First item",
+        status: "todo",
+        priority: "medium",
+        assigneeMemberId: "viewer",
+        updatedAt: "2026-07-28T00:01:00.000Z",
+      },
+    };
+    const requestedItem: AssignedWorkItem = {
+      ...firstItem,
+      id: "requested",
+      target: { ...firstItem.target, workItemId: "AAA-0002" },
+      payload: { ...firstItem.payload, title: "Requested item" },
+    };
+    const markRead = vi.fn().mockResolvedValue(undefined);
+
+    await act(async () => {
+      root.render(
+        createElement(TeamInboxView, {
+          dataSource: {
+            listPage: async () => ({
+              items: [firstItem, requestedItem],
+              nextCursor: null,
+            }),
+            markRead,
+          },
+          focusRequest: {
+            itemKey: "assigned_work_item:requested",
+            requestId: 1,
+          },
+        })
+      );
+      await Promise.resolve();
+    });
+
+    expect(markRead).toHaveBeenCalledOnce();
+    expect(markRead).toHaveBeenCalledWith(requestedItem);
+    expect(componentProps.assignedDetail?.item).toEqual(requestedItem);
   });
 
   it("retries the backing source instead of rereading a failed snapshot", async () => {

--- a/src/modules/MainApp/TeamInbox/__tests__/useTeamInboxNotifications.test.ts
+++ b/src/modules/MainApp/TeamInbox/__tests__/useTeamInboxNotifications.test.ts
@@ -13,24 +13,44 @@ import {
   vi,
 } from "vitest";
 
+import { chatPanelTabsAtom } from "@src/store/chatPanel/chatPanelTabsAtom";
 import { settingsAtom } from "@src/store/settings/settingsAtom";
 
 import type { TeamInboxItem } from "../domain";
-import { teamInboxCacheAtom } from "../store";
+import { teamInboxCacheAtom, teamInboxItemFocusRequestAtom } from "../store";
 import { useTeamInboxNotifications } from "../useTeamInboxNotifications";
 
 const mocks = vi.hoisted(() => ({
   notifyTeamInbox: vi.fn(),
   setDockBadge: vi.fn(),
+  listenForSystemNotificationActions: vi.fn(),
+  registerTeamInboxNotificationActionType: vi.fn(),
+  messageInfo: vi.fn(),
+  windowShow: vi.fn(),
+  windowSetFocus: vi.fn(),
 }));
 
 vi.mock("@src/api/services/notification", () => ({
+  listenForSystemNotificationActions: mocks.listenForSystemNotificationActions,
   notifyTeamInbox: mocks.notifyTeamInbox,
+  registerTeamInboxNotificationActionType:
+    mocks.registerTeamInboxNotificationActionType,
   setDockBadge: mocks.setDockBadge,
 }));
 
 vi.mock("@src/hooks/logger", () => ({
-  createLogger: () => ({ error: vi.fn() }),
+  createLogger: () => ({ error: vi.fn(), warn: vi.fn() }),
+}));
+
+vi.mock("@src/components/Message", () => ({
+  default: { info: mocks.messageInfo },
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    show: mocks.windowShow,
+    setFocus: mocks.windowSetFocus,
+  }),
 }));
 
 vi.mock("react-i18next", () => ({
@@ -84,6 +104,15 @@ describe("useTeamInboxNotifications", () => {
       soundPlayed: true,
     });
     mocks.setDockBadge.mockReset().mockResolvedValue(true);
+    mocks.listenForSystemNotificationActions
+      .mockReset()
+      .mockResolvedValue(vi.fn());
+    mocks.registerTeamInboxNotificationActionType
+      .mockReset()
+      .mockResolvedValue(undefined);
+    mocks.messageInfo.mockReset();
+    mocks.windowShow.mockReset().mockResolvedValue(undefined);
+    mocks.windowSetFocus.mockReset().mockResolvedValue(undefined);
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -137,13 +166,98 @@ describe("useTeamInboxNotifications", () => {
 
     expect(mocks.notifyTeamInbox).toHaveBeenCalledTimes(1);
     expect(mocks.notifyTeamInbox).toHaveBeenCalledWith(
-      "teamInbox.notifications.assignmentTitle",
+      "Ada · teamInbox.notifications.assignmentTitle",
       "Work new",
       expect.objectContaining({
         categories: expect.objectContaining({ teamInbox: true }),
-      })
+      }),
+      {
+        orgiiTarget: "team-inbox",
+        teamInboxItemKey: "assigned_work_item:new",
+      }
     );
+    expect(mocks.messageInfo).toHaveBeenCalledOnce();
+    const toast = mocks.messageInfo.mock.calls[0]?.[0] as
+      | {
+          title?: string;
+          action?: { label: string; onClick: () => void };
+        }
+      | undefined;
+    expect(toast).toMatchObject({
+      title: "Ada · teamInbox.notifications.assignmentTitle",
+      action: { label: "common:actions.view" },
+    });
+
+    act(() => toast?.action?.onClick());
+    expect(store.get(teamInboxItemFocusRequestAtom)?.itemKey).toBe(
+      "assigned_work_item:new"
+    );
+    expect(
+      store.get(chatPanelTabsAtom).tabs.some((tab) => tab.type === "team-inbox")
+    ).toBe(true);
     expect(mocks.setDockBadge).toHaveBeenLastCalledWith(2);
+  });
+
+  it("opens and focuses the matching Inbox item from a native notification action", async () => {
+    const store = createStore();
+    store.set(settingsAtom, {
+      ...store.get(settingsAtom),
+      "notifications.enabled": true,
+      "notifications.categories.teamInbox": true,
+    });
+    store.set(teamInboxCacheAtom, {
+      items: [assignment("old", new Date().toISOString())],
+      unreadCount: 1,
+      unreadCounts: { all: 1, assigned: 1, mentions: 0 },
+      loading: false,
+      issue: null,
+      revision: 1,
+      loadedForViewerKey: "viewer::org-a",
+      hasMore: false,
+    });
+
+    await act(async () => {
+      root.render(createElement(Provider, { store }, createElement(Harness)));
+    });
+
+    const nativeHandler = mocks.listenForSystemNotificationActions.mock
+      .calls[0]?.[0] as
+      | ((action: { extra: Record<string, unknown> }) => void)
+      | undefined;
+    await act(async () => {
+      nativeHandler?.({
+        extra: {
+          orgiiTarget: "team-inbox",
+          teamInboxItemKey: "assigned_work_item:old",
+        },
+      });
+      await Promise.resolve();
+    });
+
+    expect(store.get(teamInboxItemFocusRequestAtom)?.itemKey).toBe(
+      "assigned_work_item:old"
+    );
+    expect(
+      store.get(chatPanelTabsAtom).tabs.some((tab) => tab.type === "team-inbox")
+    ).toBe(true);
+    expect(mocks.windowShow).toHaveBeenCalledOnce();
+    expect(mocks.windowSetFocus).toHaveBeenCalledOnce();
+  });
+
+  it("releases the single native action listener when the global host unmounts", async () => {
+    const dispose = vi.fn();
+    mocks.listenForSystemNotificationActions.mockResolvedValueOnce(dispose);
+    const store = createStore();
+
+    await act(async () => {
+      root.render(createElement(Provider, { store }, createElement(Harness)));
+      await Promise.resolve();
+    });
+
+    act(() => root.unmount());
+    expect(dispose).toHaveBeenCalledOnce();
+
+    root = createRoot(container);
   });
 
   it("clears the badge and suppresses delivery when Team Inbox notifications are disabled", async () => {
@@ -171,5 +285,6 @@ describe("useTeamInboxNotifications", () => {
 
     expect(mocks.setDockBadge).toHaveBeenLastCalledWith(0);
     expect(mocks.notifyTeamInbox).not.toHaveBeenCalled();
+    expect(mocks.messageInfo).not.toHaveBeenCalled();
   });
 });

--- a/src/modules/MainApp/TeamInbox/store.ts
+++ b/src/modules/MainApp/TeamInbox/store.ts
@@ -43,6 +43,27 @@ export const invalidateTeamInboxAtom = atom(null, (get, set) => {
 });
 invalidateTeamInboxAtom.debugLabel = "invalidateTeamInboxAtom";
 
+export interface TeamInboxItemFocusRequest {
+  itemKey: string;
+  requestId: number;
+}
+
+const teamInboxItemFocusRequestSequenceAtom = atom(0);
+
+export const teamInboxItemFocusRequestAtom =
+  atom<TeamInboxItemFocusRequest | null>(null);
+teamInboxItemFocusRequestAtom.debugLabel = "teamInboxItemFocusRequestAtom";
+
+export const requestTeamInboxItemFocusAtom = atom(
+  null,
+  (get, set, itemKey: string) => {
+    const requestId = get(teamInboxItemFocusRequestSequenceAtom) + 1;
+    set(teamInboxItemFocusRequestSequenceAtom, requestId);
+    set(teamInboxItemFocusRequestAtom, { itemKey, requestId });
+  }
+);
+requestTeamInboxItemFocusAtom.debugLabel = "requestTeamInboxItemFocusAtom";
+
 export interface TeamInboxSessionHandoffRequest extends SessionReferenceOpen {
   requestId: number;
 }

--- a/src/modules/MainApp/TeamInbox/useTeamInboxNotifications.ts
+++ b/src/modules/MainApp/TeamInbox/useTeamInboxNotifications.ts
@@ -1,19 +1,34 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { TFunction } from "i18next";
 import { useAtomValue, useStore } from "jotai";
 import type { Store } from "jotai/vanilla/store";
 import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 
-import { notifyTeamInbox, setDockBadge } from "@src/api/services/notification";
+import {
+  listenForSystemNotificationActions,
+  notifyTeamInbox,
+  registerTeamInboxNotificationActionType,
+  setDockBadge,
+} from "@src/api/services/notification";
+import Message from "@src/components/Message";
 import { createLogger } from "@src/hooks/logger";
+import { openTeamInboxInChatPanelTabAtom } from "@src/store/chatPanel/chatPanelTabOpenAtoms";
 import { notificationSettingsAtom } from "@src/store/ui/notificationAtom";
 
+import { getTeamInboxItemKey } from "./domain";
 import type { TeamInboxItem } from "./domain";
-import { teamInboxCacheAtom } from "./store";
+import { requestTeamInboxItemFocusAtom, teamInboxCacheAtom } from "./store";
 import { TeamInboxNotificationTracker } from "./teamInboxNotificationTracker";
 
 const log = createLogger("TeamInboxNotifications");
 const trackerByStore = new WeakMap<Store, TeamInboxNotificationTracker>();
+const TEAM_INBOX_NOTIFICATION_TARGET = "team-inbox";
+const TEAM_INBOX_TOAST_DURATION_MS = 8_000;
+
+interface TeamInboxNotificationTarget {
+  itemKey: string | null;
+}
 
 function trackerForStore(store: Store): TeamInboxNotificationTracker {
   const existing = trackerByStore.get(store);
@@ -27,6 +42,51 @@ function compactNotificationBody(value: string): string {
   return value.replace(/\s+/g, " ").trim().slice(0, 180);
 }
 
+export function teamInboxNotificationExtra(
+  items: readonly TeamInboxItem[]
+): Record<string, unknown> {
+  const itemKey =
+    items.length === 1 ? getTeamInboxItemKey(items[0]) : undefined;
+  return {
+    orgiiTarget: TEAM_INBOX_NOTIFICATION_TARGET,
+    ...(itemKey ? { teamInboxItemKey: itemKey } : {}),
+  };
+}
+
+export function parseTeamInboxNotificationTarget(
+  extra: Record<string, unknown> | undefined
+): TeamInboxNotificationTarget | null {
+  if (extra?.orgiiTarget !== TEAM_INBOX_NOTIFICATION_TARGET) return null;
+  return {
+    itemKey:
+      typeof extra.teamInboxItemKey === "string" &&
+      extra.teamInboxItemKey.length > 0
+        ? extra.teamInboxItemKey
+        : null,
+  };
+}
+
+function openTeamInboxTarget(
+  store: Store,
+  title: string,
+  itemKey: string | null
+): void {
+  if (itemKey) {
+    store.set(requestTeamInboxItemFocusAtom, itemKey);
+  }
+  store.set(openTeamInboxInChatPanelTabAtom, title);
+}
+
+async function focusCurrentWindow(): Promise<void> {
+  try {
+    const currentWindow = getCurrentWindow();
+    await currentWindow.show();
+    await currentWindow.setFocus();
+  } catch (error) {
+    log.warn("Failed to focus ORGII after notification activation", error);
+  }
+}
+
 /**
  * Bridges the canonical Team Inbox projection to native notifications, sound,
  * and the dock badge. The tracker is store-scoped so remounts cannot replay
@@ -37,6 +97,41 @@ export function useTeamInboxNotifications(): void {
   const store = useStore();
   const cache = useAtomValue(teamInboxCacheAtom);
   const settings = useAtomValue(notificationSettingsAtom);
+  const teamInboxTitle = t("teamInbox.title");
+  const viewActionLabel = t("common:actions.view");
+
+  useEffect(() => {
+    let disposed = false;
+    let stopListening: (() => void) | null = null;
+
+    void registerTeamInboxNotificationActionType(viewActionLabel)
+      .catch((error: unknown) => {
+        log.error("Failed to register Team Inbox notification action", error);
+      })
+      .then(() =>
+        listenForSystemNotificationActions(({ extra }) => {
+          const target = parseTeamInboxNotificationTarget(extra);
+          if (!target) return;
+          openTeamInboxTarget(store, teamInboxTitle, target.itemKey);
+          void focusCurrentWindow();
+        })
+      )
+      .then((dispose) => {
+        if (disposed) {
+          dispose();
+        } else {
+          stopListening = dispose;
+        }
+      })
+      .catch((error: unknown) => {
+        log.error("Failed to listen for native notification actions", error);
+      });
+
+    return () => {
+      disposed = true;
+      stopListening?.();
+    };
+  }, [store, teamInboxTitle, viewActionLabel]);
 
   useEffect(() => {
     const badgeCount =
@@ -62,9 +157,27 @@ export function useTeamInboxNotifications(): void {
     if (newItems.length === 0) return;
 
     const { title, body } = notificationCopy(newItems, t);
-    void notifyTeamInbox(title, body, settings).catch((error: unknown) => {
-      log.error("Failed to deliver Team Inbox notification", error);
-    });
+    const extra = teamInboxNotificationExtra(newItems);
+    void notifyTeamInbox(title, body, settings, extra).catch(
+      (error: unknown) => {
+        log.error("Failed to deliver Team Inbox notification", error);
+      }
+    );
+
+    if (settings.enabled && settings.categories.teamInbox) {
+      const target = parseTeamInboxNotificationTarget(extra);
+      Message.info({
+        title,
+        content: body,
+        duration: TEAM_INBOX_TOAST_DURATION_MS,
+        closable: true,
+        action: {
+          label: viewActionLabel,
+          onClick: () =>
+            openTeamInboxTarget(store, teamInboxTitle, target?.itemKey ?? null),
+        },
+      });
+    }
   }, [
     cache.items,
     cache.loadedForViewerKey,
@@ -73,10 +186,12 @@ export function useTeamInboxNotifications(): void {
     settings,
     store,
     t,
+    teamInboxTitle,
+    viewActionLabel,
   ]);
 }
 
-function notificationCopy(
+export function notificationCopy(
   items: readonly TeamInboxItem[],
   t: TFunction
 ): { title: string; body: string } {
@@ -101,12 +216,16 @@ function notificationCopy(
 
   const pendingHandoff =
     item.payload.handoff?.status === "pending" ? item.payload.handoff : null;
+  const assignmentTitle = t("teamInbox.notifications.assignmentTitle");
+  const actorName = item.actor.displayName.trim();
   return {
     title: pendingHandoff
       ? t("teamInbox.notifications.handoffTitle", {
           name: pendingHandoff.senderName,
         })
-      : t("teamInbox.notifications.assignmentTitle"),
+      : actorName
+        ? `${actorName} · ${assignmentTitle}`
+        : assignmentTitle,
     body: compactNotificationBody(item.payload.title),
   };
 }


### PR DESCRIPTION
## Problem

Fresh Team Inbox assignments update the inbox, but assigned members do not receive a durable native/in-app notification that can take them directly to the relevant item. This makes handoffs easy to miss when the Team Inbox surface is not already open.

## Solution

Projects assignment episodes into the canonical Team Inbox item metadata, emits one deduplicated assignment notification per fresh batch, and routes both native and in-app actions through a store-scoped focus request. The existing global notification hook owns the single listener and disposes it on unmount; the Team Inbox view marks only an explicitly focused item as read.

## Potential risks

The main compatibility risk is malformed or stale notification metadata opening Team Inbox without selecting an item; the action parser rejects missing item keys and the view falls back to the normal list. Notification delivery depends on the existing OS permission path, which was not exercised in a packaged desktop build. No persistence schema or public wire format changes are introduced.

## Verification

- `npx vitest run src/api/services/notification.test.ts src/modules/MainApp/TeamInbox/__tests__/TeamInboxView.layout.test.ts src/modules/MainApp/TeamInbox/__tests__/useTeamInboxNotifications.test.ts` — 3 files, 22 tests passed
- ESLint over all changed frontend TypeScript/TSX files — passed
- `npm run typecheck` — passed
- `cargo test --manifest-path src-tauri/Cargo.toml -p project_management team_inbox` — 16 tests passed
- `git diff --check` — passed
- Packaged desktop native-notification activation was not run and remains follow-up verification; the notification metadata, deduplication, focus routing, listener lifecycle, and Rust projection boundaries are covered by targeted tests.

## Audit

- Frontend UI audit: 0 fixes, 8 keep-with-reason, 0 abstraction candidates.
- Performance guard: pass; one global listener with symmetric disposal, bounded/per-store deduplication, and no new poller or retry loop.