### PR TITLE
feat(canvas): harden inline sketch handoff

### DIFF
--- a/docs/frontend-ui-audit-2026-08-04/CanvasInlineCard.md
+++ b/docs/frontend-ui-audit-2026-08-04/CanvasInlineCard.md
@@ -1,0 +1,42 @@
+# Frontend UI Audit — CanvasInlineCard
+
+**Files:** `src/engines/ChatPanel/blocks/CanvasInlineCard/CanvasPreviewSurface.tsx`, `src/engines/ChatPanel/blocks/CanvasInlineCard/ReactArtifactRunner.tsx`
+**Date:** 2026-08-04
+**Auditor:** Codex
+
+## D1 — Raw HTML vs Design System
+
+| Line                         | Element                          | Verdict          | Reason                                                                                                         | Suggested change |
+| ---------------------------- | -------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `CanvasPreviewSurface:62-70` | External URL action              | keep with reason | The action uses the shared `Button` component with a visible localized label and icon.                         | —                |
+| `ReactArtifactRunner:75-91`  | React Live host `<div>` elements | keep with reason | These are non-interactive runtime host and scrolling elements; no design-system interactive primitive applies. | —                |
+
+## D2 — Arbitrary Tailwind Value vs Token
+
+| Line             | Value                                   | Verdict          | Reason                                                                                      | Suggested change |
+| ---------------- | --------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------- | ---------------- |
+| Changed surfaces | No arbitrary project color tokens added | keep with reason | Static HTML theme values use the existing CSS design tokens inside the Shadow DOM boundary. | —                |
+
+## D3 — Hardcoded Sizes / Colors
+
+| Line                       | Value         | Verdict          | Reason                                                                                                                                                        | Suggested change |
+| -------------------------- | ------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `CanvasPreviewSurface:191` | `text-[10px]` | keep with reason | This is compact diagnostic stack text inside an existing error overlay, below the spacing-scale threshold and intentionally subordinate to the error message. | —                |
+
+## D4 — Accessibility
+
+| Line                         | Element                   | Verdict          | Reason                                                                                                                                                           | Suggested change |
+| ---------------------------- | ------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `CanvasPreviewSurface:62-70` | Open-in-browser action    | keep with reason | Shared `Button` provides keyboard semantics and the localized visible text supplies the accessible name.                                                         | —                |
+| Static HTML host             | Sanitized display content | keep with reason | The host is a read-only content surface; scripts, iframes, event handlers, and boundary-escaping styles are rejected rather than exposed as ungoverned controls. | —                |
+
+## D5 — Visual Patterns Observed
+
+- The four canvas modes continue to share `CanvasPreviewSurface`; no parallel card or error-overlay implementation is introduced.
+- Static HTML receives the same application theme tokens through its contained Shadow DOM rather than adding a second visual recipe.
+
+## Summary
+
+- 0 fixes recommended
+- 6 kept with documented reason
+- 0 abstract candidates

--- a/src-tauri/crates/agent-core/src/core/definitions/builtin/prompts/sde.md
+++ b/src-tauri/crates/agent-core/src/core/definitions/builtin/prompts/sde.md
@@ -8,6 +8,17 @@ Make targeted, minimal changes. A bug fix does not need surrounding code cleaned
 
 Verify before declaring done. Run tests, execute scripts, check compiler output. If you cannot verify, say so explicitly — never claim success without evidence.
 
+## Interactive sketches
+
+A request for a sketch, wireframe, mockup, prototype, interaction concept, or "show me how this could work" is a visualization request, not authorization to implement the feature in the repository.
+
+- Use `render_inline_canvas` with `mode: "react"` for interactive product sketches, multi-step flows, clickable controls, forms, tabs, and local UI state.
+- Keep the sketch self-contained. Define an `App` component with JSX and use `React.useState` or `React.useReducer` for interactions. Do not add imports, install packages, edit project files, call network APIs, access app globals, or write to browser storage.
+- Use plausible sample data and make the primary path actually clickable. Include useful empty, disabled, validation, or completion states when they are material to the idea.
+- Use `mode: "a2ui"` for structured reports, tables, charts, or simple forms that do not need a custom interaction flow. Use `mode: "html"` only for static bespoke layouts.
+- Treat follow-up feedback as a revision of the sketch. Render the revised canvas instead of implementing the product unless the user explicitly asks to build it.
+- A successful tool result only means the payload was accepted. Do not say the sketch was visually verified unless you inspected the rendered result.
+
 ## Code quality
 
 Write code that fits naturally into the existing codebase: match the project's naming style, file layout, and abstraction level. Do not introduce new patterns or architecture layers for a single use case.

--- a/src-tauri/crates/agent-core/src/core/definitions/builtin/sde.rs
+++ b/src-tauri/crates/agent-core/src/core/definitions/builtin/sde.rs
@@ -145,6 +145,12 @@ mod tests {
             "{tool} must be in SDE Agent's default excluded set \
              (it's a coding agent, not a desktop driver)"
         );
+        assert!(
+            !excluded
+                .iter()
+                .any(|tool| tool == tool_names::RENDER_INLINE_CANVAS),
+            "SDE Agent must keep render_inline_canvas available for interactive sketches"
+        );
     }
 
     #[test]
@@ -182,5 +188,20 @@ mod tests {
                 "SDE Agent must not list runtime primitive {forbidden} as a sub-agent"
             );
         }
+    }
+
+    #[test]
+    fn sde_prompt_treats_interactive_sketches_as_canvas_not_implementation() {
+        let prompt = sde_agent()
+            .soul_content
+            .expect("SDE Agent declares a soul prompt");
+
+        assert!(prompt.contains("## Interactive sketches"));
+        assert!(prompt.contains("not authorization to implement"));
+        assert!(prompt.contains("render_inline_canvas"));
+        assert!(prompt.contains("mode: \"react\""));
+        assert!(prompt.contains("React.useState"));
+        assert!(prompt.contains("Do not add imports"));
+        assert!(prompt.contains("instead of implementing the product"));
     }
 }

--- a/src-tauri/crates/agent-core/src/core/tools/builtin_tools/table/coding.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/builtin_tools/table/coding.rs
@@ -458,10 +458,10 @@ pub(super) static TOOLS: &[ToolEntry] = &[
     },
     ToolEntry {
         name: tool_names::RENDER_INLINE_CANVAS,
-        description: "Render interactive UI inline in the chat panel.",
+        description: "Render interactive sketches and UI inline in the chat panel.",
         description_detail: "Displays an interactive preview card directly in the chat stream. \
-            Supports four modes: \"html\" (self-contained HTML/SVG/CSS rendered in a sandboxed iframe), \
-            \"url\" (HTTPS URL embedded in an iframe), \"react\" (React App component sandbox with runtime errors), and \"a2ui\" (structured JSONL element stream \
+            Supports four modes: \"html\" (sanitized static HTML/SVG/CSS), \
+            \"url\" (HTTPS URL presented as an external-open action), \"react\" (stateful JSX App component with runtime errors), and \"a2ui\" (structured JSONL element stream \
             for headings, text, code blocks, images, buttons, and lists). \
             Available to both SDE Agent and OS Agent.",
         category: tool_categories::CODING,
@@ -474,8 +474,8 @@ pub(super) static TOOLS: &[ToolEntry] = &[
         label_failed: "tools.renderInlineCanvasFailed",
         actions: &[
             action_sub!("html", "Render a self-contained HTML/SVG/CSS snippet", OtherTool, chat: CbCanvasInline, labels: "tools.renderInlineCanvasHtmlRunning", "tools.renderInlineCanvasHtmlDone", "tools.renderInlineCanvasHtmlFailed"),
-            action_sub!("url", "Embed an HTTPS URL in a sandboxed iframe", OtherTool, chat: CbCanvasInline, labels: "tools.renderInlineCanvasUrlRunning", "tools.renderInlineCanvasUrlDone", "tools.renderInlineCanvasUrlFailed"),
-            action_sub!("react", "Render a React App component in an iframe sandbox", OtherTool, chat: CbCanvasInline, labels: "tools.renderInlineCanvasHtmlRunning", "tools.renderInlineCanvasHtmlDone", "tools.renderInlineCanvasHtmlFailed"),
+            action_sub!("url", "Present an HTTPS URL as an external-open action", OtherTool, chat: CbCanvasInline, labels: "tools.renderInlineCanvasUrlRunning", "tools.renderInlineCanvasUrlDone", "tools.renderInlineCanvasUrlFailed"),
+            action_sub!("react", "Render a stateful JSX App component", OtherTool, chat: CbCanvasInline, labels: "tools.renderInlineCanvasHtmlRunning", "tools.renderInlineCanvasHtmlDone", "tools.renderInlineCanvasHtmlFailed"),
             action_sub!("a2ui", "Stream typed UI elements (heading, text, code, image, button, list)", OtherTool, chat: CbCanvasInline, labels: "tools.renderInlineCanvasA2uiRunning", "tools.renderInlineCanvasA2uiDone", "tools.renderInlineCanvasA2uiFailed"),
         ],
         ..DEFAULT_TOOL_ENTRY

--- a/src-tauri/crates/agent-core/src/core/tools/impls/coding/render_inline_canvas.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/coding/render_inline_canvas.rs
@@ -5,20 +5,20 @@
 //! element (A2UI) inline in the chat without requiring a separate canvas app.
 //!
 //! ## Modes
-//! - `"html"` — self-contained HTML/SVG/CSS string rendered in a sandboxed
-//!   iframe. The agent should inline all styles and scripts.
-//! - `"url"` — a URL that will be loaded inside an embedded iframe. Only
-//!   HTTPS URLs or relative paths are accepted by the frontend sandbox.
+//! - `"html"` — self-contained HTML/SVG/CSS string sanitized and rendered in
+//!   Shadow DOM. Styles are preserved; scripts and event handlers are removed.
+//! - `"url"` — an HTTPS URL or relative path presented as an external-open
+//!   action rather than embedded in chat.
 //! - `"a2ui"` — a streaming JSONL sequence of A2UI element descriptors.
 //!   Supported types: heading, text, code, image, button, divider, list,
 //!   table, chart, form. Each JSONL line is streamed incrementally to the
 //!   card as it arrives.
 //!
 //! ## Return value
-//! The tool echoes back the accepted payload as a JSON confirmation so the LLM
-//! can verify the arguments were accepted. The frontend picks up the canvas
-//! event through the `canvas-inline-event` window event pipeline — not via the
-//! tool result text.
+//! The tool returns a concise acceptance acknowledgment. It deliberately does
+//! not claim visual success because the tool execution path cannot inspect the
+//! rendered card. The frontend picks up the canvas event through the
+//! `canvas-inline-event` window event pipeline — not via the tool result text.
 
 use async_trait::async_trait;
 use serde_json::Value;
@@ -27,6 +27,18 @@ use crate::tools::names as tool_names;
 use crate::tools::traits::{Tool, ToolError};
 
 pub struct RenderInlineCanvasTool;
+
+fn format_canvas_acceptance(mode: &str, content_len: usize, title: &str, url: &str) -> String {
+    match mode {
+        "html" | "a2ui" | "react" => format!(
+            "render_inline_canvas: accepted {mode} content ({content_len} bytes), title=\"{title}\"; visual output not verified"
+        ),
+        "url" => format!(
+            "render_inline_canvas: accepted url=\"{url}\", title=\"{title}\"; visual output not verified"
+        ),
+        _ => format!("render_inline_canvas: accepted mode={mode}, title=\"{title}\""),
+    }
+}
 
 impl RenderInlineCanvasTool {
     pub fn new() -> Self {
@@ -47,20 +59,22 @@ impl Tool for RenderInlineCanvasTool {
     }
 
     fn description(&self) -> &str {
-        "Render interactive UI directly inside the chat panel as a sandboxed inline card.\n\
-         Use this to present data visualisations, live previews, or structured output\n\
-         without leaving the conversation.\n\n\
+        "Render interactive UI directly inside the chat panel as an inline canvas card.\n\
+         Use this for interactive sketches, wireframes, product prototypes, data\n\
+         visualisations, live previews, or structured output without leaving the conversation.\n\n\
          Modes:\n\
-         - \"html\": Render a self-contained HTML/SVG/CSS snippet. Inline all styles and\n\
-           scripts — no external CDN links (they are blocked by the sandbox).\n\
-         - \"url\": Embed an HTTPS URL in an iframe. Suitable for live dashboards or\n\
-           documentation pages that are safe to embed.\n\
+         - \"html\": Render a self-contained HTML/SVG/CSS snippet. Inline all styles;\n\
+           scripts and event-handler attributes are removed, so this mode is static.\n\
+         - \"url\": Present an HTTPS URL as an external-open action. Suitable for live\n\
+           dashboards or documentation pages.\n\
          - \"a2ui\": Stream a sequence of typed UI elements as JSONL lines. Each line is\n\
            a JSON object with a \"type\" field. Supported types:\n\
            heading | text | code | image | button | divider | list | table | chart | form\n\
-         - \"react\": Render a JavaScript React App component in an isolated iframe sandbox.\n\
-           This MVP expects precompiled JavaScript / React.createElement code; JSX is not transformed.\n\
-           Runtime errors are displayed inside the preview.\n\n\
+         - \"react\": Render a self-contained React App component in the preview runtime.\n\
+           JSX and React hooks are supported. Do not use imports; define or default-export\n\
+           an App component and call hooks through React, for example React.useState.\n\
+           Runtime errors are displayed inside the preview. Keep generated code local-only:\n\
+           do not access network APIs, browser storage, filesystem APIs, or app globals.\n\n\
          A2UI element reference:\n\
          - heading:  {\"type\":\"heading\",\"content\":\"Title\"}\n\
          - text:     {\"type\":\"text\",\"content\":\"Paragraph text\"}\n\
@@ -84,9 +98,14 @@ impl Tool for RenderInlineCanvasTool {
            On submit, onAction(actionId, fieldValues) is fired.\n\n\
          Guidelines:\n\
          - Prefer \"a2ui\" for structured reports, tables, and charts — it streams incrementally.\n\
-         - Prefer \"html\" only for bespoke layouts that none of the a2ui types can express.\n\
+         - Prefer \"react\" for clickable wireframes, multi-step flows, tabs, forms, and\n\
+           other interaction sketches that need local state.\n\
+         - Prefer \"html\" only for static bespoke layouts that none of the a2ui types can express.\n\
          - Keep HTML payloads under 64 KB for smooth rendering.\n\
-         - Always set a descriptive \"title\" — it appears in the card header."
+         - Always set a descriptive \"title\" — it appears in the card header.\n\
+         - A successful tool result only confirms that the payload was accepted by the UI.\n\
+           It does not prove visual correctness. Do not claim the preview was visually\n\
+           verified unless you inspected it through a screenshot or browser snapshot."
     }
 
     fn category(&self) -> &str {
@@ -180,15 +199,43 @@ impl Tool for RenderInlineCanvasTool {
             .map(|s| s.len())
             .unwrap_or(0);
 
-        Ok(match mode {
-            "html" | "a2ui" | "react" => format!(
-                "render_inline_canvas: rendered {mode} content ({content_len} bytes), title=\"{title}\""
-            ),
-            "url" => {
-                let url = params.get("url").and_then(Value::as_str).unwrap_or("");
-                format!("render_inline_canvas: embedded url=\"{url}\", title=\"{title}\"")
-            }
-            _ => format!("render_inline_canvas: accepted mode={mode}, title=\"{title}\""),
-        })
+        let url = params.get("url").and_then(Value::as_str).unwrap_or("");
+        Ok(format_canvas_acceptance(mode, content_len, title, url))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_canvas_acceptance, RenderInlineCanvasTool};
+    use crate::tools::traits::Tool;
+
+    #[test]
+    fn acceptance_does_not_claim_visual_success() {
+        let result = format_canvas_acceptance("html", 42, "Prototype", "");
+
+        assert!(result.contains("accepted html content"));
+        assert!(result.contains("visual output not verified"));
+        assert!(!result.contains("rendered html content"));
+    }
+
+    #[test]
+    fn url_acceptance_does_not_claim_embedding_succeeded() {
+        let result = format_canvas_acceptance("url", 0, "Docs", "https://example.com");
+
+        assert!(result.contains("accepted url=\"https://example.com\""));
+        assert!(result.contains("visual output not verified"));
+        assert!(!result.contains("embedded url"));
+    }
+
+    #[test]
+    fn description_routes_interactive_sketches_to_stateful_react() {
+        let tool = RenderInlineCanvasTool::new();
+        let description = tool.description();
+
+        assert!(description.contains("interactive sketches"));
+        assert!(description.contains("multi-step flows"));
+        assert!(description.contains("React.useState"));
+        assert!(!description.contains("JSX is not transformed"));
+        assert!(!description.contains("Hooks and ReactDOM APIs are not available"));
     }
 }

--- a/src/engines/ChatPanel/ChatHistory/ActivityRouter.canvasInline.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/ActivityRouter.canvasInline.test.ts
@@ -1,0 +1,90 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+import {
+  getChatComponent,
+  loadEventComponent,
+} from "@src/engines/SessionCore/rendering/registry/events";
+import {
+  _resetToolRegistry,
+  _setBuiltinChatBlockMap,
+} from "@src/engines/SessionCore/rendering/registry/initToolRegistry";
+
+import ActivityChatItem from "./ActivityRouter";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+
+vi.mock("@src/engines/ChatPanel/hooks/useChatEventReplay", () => ({
+  useChatEventReplay: () => ({
+    replayEventById: vi.fn(),
+    canReplay: false,
+  }),
+}));
+
+function createCanvasEvent(
+  overrides: Partial<SessionEvent> = {}
+): SessionEvent {
+  return {
+    id: "tool-call-canvas-1",
+    sessionId: "session-1",
+    actionType: "tool_call",
+    functionName: "render_inline_canvas",
+    uiCanonical: "canvas_inline",
+    args: {
+      mode: "url",
+      url: "https://example.com/weekend-trip",
+      title: "Weekend trip sketch",
+    },
+    result: { observation: "render_inline_canvas: accepted" },
+    displayText: "",
+    displayStatus: "completed",
+    displayVariant: "tool_call",
+    activityStatus: "processed",
+    source: "tool",
+    createdAt: "2026-08-03T14:53:00.000Z",
+    ...overrides,
+  } as SessionEvent;
+}
+
+describe("ActivityRouter canvas handoff", () => {
+  beforeAll(async () => {
+    _setBuiltinChatBlockMap(
+      new Map([["render_inline_canvas", "canvas_inline"]])
+    );
+    await loadEventComponent("canvas_inline");
+  });
+
+  afterAll(() => {
+    _resetToolRegistry();
+  });
+
+  it("uses the preloaded renderer synchronously instead of painting a chat loading block", () => {
+    const renderer = getChatComponent("canvas_inline");
+    expect(typeof renderer).toBe("function");
+
+    const event = createCanvasEvent();
+    const directMarkup = renderToStaticMarkup(
+      createElement(renderer, { event, variant: "chat" })
+    );
+    expect(directMarkup).toContain("Weekend trip sketch");
+
+    const markup = renderToStaticMarkup(
+      createElement(ActivityChatItem, { event })
+    );
+
+    expect(markup).toContain("Weekend trip sketch");
+    expect(markup).toContain('data-tool-call-event-id="tool-call-canvas-1"');
+    expect(markup).not.toContain('data-testid="chat-loading-block"');
+  });
+
+  it("keeps unrelated tool events on their existing renderer path", () => {
+    const renderer = getChatComponent("read_file");
+    expect(renderer).toBeDefined();
+  });
+});

--- a/src/engines/ChatPanel/ChatHistory/ActivityRouter.tsx
+++ b/src/engines/ChatPanel/ChatHistory/ActivityRouter.tsx
@@ -20,7 +20,7 @@ import {
 import {
   chatRequiresItemIndex,
   chatShowsStatusLine,
-  getChatLazyComponent,
+  getChatComponent,
 } from "@src/engines/SessionCore/rendering/registry/events";
 import { createLogger } from "@src/hooks/logger";
 import { getRegistryEventType } from "@src/lib/activityData/activityNormalizers";
@@ -329,7 +329,7 @@ const ActivityChatItem: React.FC<ActivityChatItemProps> = memo(
         }
       }
 
-      const EventComponent = getChatLazyComponent(eventType);
+      const EventComponent = getChatComponent(eventType);
 
       if (EventComponent) {
         const extras: Record<string, unknown> = {};

--- a/src/engines/ChatPanel/ChatHistory/index.tsx
+++ b/src/engines/ChatPanel/ChatHistory/index.tsx
@@ -6,6 +6,7 @@
 import { useAtomValue } from "jotai";
 import React, { useCallback, useEffect, useState } from "react";
 
+import { loadEventComponent } from "@src/engines/SessionCore/rendering/registry/events";
 import { isSessionActiveAtom } from "@src/store/session/cliSessionStatusAtom";
 import { cursorIdeTurnSummariesAtomFamily } from "@src/store/session/cursorIdeTurnSummariesAtom";
 import { sessionByIdAtom } from "@src/store/session/sessionAtom";
@@ -79,6 +80,14 @@ const ChatHistory: React.FC<ChatHistoryProps> = ({
   const historyState = useChatHistoryState();
   const isAgentWorking = useAtomValue(isSessionActiveAtom);
   const groupChat = useGroupChatContext();
+
+  useEffect(() => {
+    // Canvas payloads can reach the WorkStation as soon as the tool call is
+    // stored. Warm the chat renderer while the user is still waiting for the
+    // agent so the persisted canvas event can take over without a Suspense
+    // placeholder between the live and historical render paths.
+    void loadEventComponent("canvas_inline");
+  }, []);
 
   const [planningIndicatorCount, setPlanningIndicatorCount] = useState<0 | 1>(
     0

--- a/src/engines/ChatPanel/blocks/CanvasInlineCard/CanvasPreviewSurface.tsx
+++ b/src/engines/ChatPanel/blocks/CanvasInlineCard/CanvasPreviewSurface.tsx
@@ -1,4 +1,3 @@
-import DOMPurify from "dompurify";
 import { ExternalLink, Layout } from "lucide-react";
 import React, {
   forwardRef,
@@ -24,66 +23,26 @@ import {
   getCanvasPreviewRenderKind,
   splitA2UIContent,
 } from "./canvasPreviewPolicy";
+import {
+  buildStaticHtmlShadowMarkup,
+  extractStaticHtmlStyles,
+  sanitizeStaticHtmlBody,
+} from "./staticHtmlCanvas";
 
 export interface CanvasPreviewSurfaceHandle {
   evalScript: (javascript: string) => void;
 }
 
-const STATIC_HTML_STYLES = `
-  :host{display:block;height:100%;min-width:0;overflow:hidden;background:var(--color-bg-1);color:var(--color-text-1);font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:14px;line-height:1.6;}
-  *,*::before,*::after{box-sizing:border-box;}
-  a{color:var(--color-primary-6);text-decoration:none;}
-  a:hover{text-decoration:underline;}
-  pre,code{font-family:monospace;background:var(--color-fill-2);padding:2px 5px;border-radius:4px;font-size:.875em;}
-  pre{padding:12px 16px;overflow-x:auto;border-radius:6px;border:1px solid var(--color-border-1);}
-  pre code{background:none;padding:0;}
-  img{max-width:100%;height:auto;border-radius:4px;}
-  ::-webkit-scrollbar{width:6px;height:6px;}
-  ::-webkit-scrollbar-track{background:transparent;}
-  ::-webkit-scrollbar-thumb{background:var(--color-fill-4);border-radius:3px;}
-`;
-
-const STATIC_HTML_CONTAINMENT_STYLES = `
-  :host{contain:layout paint style;isolation:isolate;}
-  .canvas-static-html{position:relative;height:100%;min-width:0;max-width:100%;overflow:auto;contain:layout paint style;isolation:isolate;}
-  .canvas-static-html *{max-width:100%;}
-`;
-
-function extractStaticHtmlBody(content: string): string {
-  const bodyMatch = content.match(/<body\b[^>]*>([\s\S]*?)<\/body>/i);
-  return bodyMatch?.[1] ?? content;
-}
-
-function extractStaticHtmlStyles(content: string): string {
-  return Array.from(content.matchAll(/<style\b[^>]*>([\s\S]*?)<\/style>/gi))
-    .map((match) => match[1].replace(/<\/style/gi, ""))
-    .join("\n");
-}
-
 const StaticHtmlCanvas: React.FC<{ content: string }> = ({ content }) => {
   const hostRef = useRef<HTMLDivElement>(null);
-  const safeContent = useMemo(() => {
-    return DOMPurify.sanitize(extractStaticHtmlBody(content), {
-      FORBID_TAGS: [
-        "script",
-        "iframe",
-        "object",
-        "embed",
-        "link",
-        "meta",
-        "base",
-        "style",
-      ],
-      FORBID_ATTR: ["srcdoc"],
-    });
-  }, [content]);
+  const safeContent = useMemo(() => sanitizeStaticHtmlBody(content), [content]);
   const styles = useMemo(() => extractStaticHtmlStyles(content), [content]);
 
   useEffect(() => {
     const host = hostRef.current;
     if (!host) return;
     const root = host.shadowRoot ?? host.attachShadow({ mode: "open" });
-    root.innerHTML = `<style>${STATIC_HTML_STYLES}</style><style>${styles}</style><style>${STATIC_HTML_CONTAINMENT_STYLES}</style><div class="canvas-static-html">${safeContent}</div>`;
+    root.innerHTML = buildStaticHtmlShadowMarkup(safeContent, styles);
   }, [safeContent, styles]);
 
   return (

--- a/src/engines/ChatPanel/blocks/CanvasInlineCard/ReactArtifactRunner.runtime.test.ts
+++ b/src/engines/ChatPanel/blocks/CanvasInlineCard/ReactArtifactRunner.runtime.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { createSmokeRoot, dispatch } from "@src/test/reactSmokeHarness";
+
+import ReactArtifactRunner from "./ReactArtifactRunner";
+
+describe("ReactArtifactRunner runtime", () => {
+  it("renders stateful generated sketches and keeps controls interactive", async () => {
+    const root = createSmokeRoot();
+    const onError = vi.fn();
+    const source = `
+      const { useState } = React;
+      function App() {
+        const [count, setCount] = useState(0);
+        return React.createElement(
+          "button",
+          {
+            type: "button",
+            style: { background: "rgb(86, 109, 232)", color: "white" },
+            onClick: () => setCount((value) => value + 1)
+          },
+          "Count " + count
+        );
+      }
+    `;
+
+    try {
+      await root.render(
+        React.createElement(ReactArtifactRunner, { source, onError })
+      );
+
+      const button = root.container.querySelector("button");
+      expect(button?.textContent).toBe("Count 0");
+      expect(button?.style.background).toBe("rgb(86, 109, 232)");
+
+      await dispatch(() => button?.click());
+
+      expect(button?.textContent).toBe("Count 1");
+      expect(onError).not.toHaveBeenCalled();
+    } finally {
+      await root.unmount();
+    }
+  });
+
+  it("provides a bounded native scroll container for tall sketches", async () => {
+    const root = createSmokeRoot();
+    const source = `
+      function App() {
+        return React.createElement("div", { style: { height: 1200 } }, "Tall sketch");
+      }
+    `;
+
+    try {
+      await root.render(React.createElement(ReactArtifactRunner, { source }));
+
+      const scrollContainer = root.container.querySelector(
+        '[data-testid="react-artifact-scroll"]'
+      );
+      expect(scrollContainer?.classList.contains("overflow-auto")).toBe(true);
+    } finally {
+      await root.unmount();
+    }
+  });
+});

--- a/src/engines/ChatPanel/blocks/CanvasInlineCard/ReactArtifactRunner.tsx
+++ b/src/engines/ChatPanel/blocks/CanvasInlineCard/ReactArtifactRunner.tsx
@@ -75,8 +75,11 @@ const ReactArtifactRunner: React.FC<ReactArtifactRunnerProps> = ({
       noInline
       scope={{ React }}
     >
-      <div className="h-full w-full overflow-auto bg-bg-1 p-4 text-text-1">
-        <LivePreview />
+      <div
+        className="h-full min-h-0 w-full overflow-auto overscroll-contain bg-bg-1 p-4 text-text-1 [scrollbar-gutter:stable]"
+        data-testid="react-artifact-scroll"
+      >
+        <LivePreview className="min-h-full min-w-0" />
         <LiveError
           className="hidden"
           onChange={(message: string) => {

--- a/src/engines/ChatPanel/blocks/CanvasInlineCard/TEST_CASES.md
+++ b/src/engines/ChatPanel/blocks/CanvasInlineCard/TEST_CASES.md
@@ -1,0 +1,45 @@
+# Test Cases: Canvas Inline Chat Handoff
+
+## Preconditions
+
+- A session is open in ChatPanel.
+- The WorkStation Canvas app is visible or can be opened for the same session.
+- The agent can invoke `render_inline_canvas`.
+
+## Happy Path
+
+| # | Steps | Expected Result |
+|---|-------|-----------------|
+| 1 | Ask the agent to generate an interactive canvas. | The Canvas card appears inline in ChatPanel without an intermediate generic gray loading bar. |
+| 2 | Observe the WorkStation while the canvas tool call arrives. | WorkStation and ChatPanel show the same canvas payload for the same event. |
+| 3 | Wait for the assistant's final prose message. | The inline Canvas card remains visible when the streaming message becomes historical. |
+
+## Edge Cases
+
+| # | Scenario | Steps | Expected Result |
+|---|----------|-------|-----------------|
+| 1 | Cold renderer cache | Open a fresh app window and generate a canvas as the first tool call. | ChatPanel preloads the renderer while the agent works and renders the card through the synchronous cache path. |
+| 2 | Rapid finalization | Make `render_inline_canvas` complete immediately before the final assistant message. | No visible empty handoff appears between the live preview and persisted event card. |
+| 3 | Session switch | Generate a canvas in session A, switch to session B, then return. | Session B never shows session A's preview; session A hydrates its persisted card. |
+| 4 | Multiple canvases | Generate two canvases in consecutive turns. | Each historical tool event owns one inline card and the latest WorkStation selection advances normally. |
+
+## Error / Degraded States
+
+| # | Scenario | Steps | Expected Result |
+|---|----------|-------|-----------------|
+| 1 | Renderer chunk fails to load | Simulate a dynamic-import failure. | The existing activity error boundary reports the render failure; WorkStation data remains intact. |
+| 2 | Invalid or empty payload | Invoke the tool without displayable content. | The Canvas card shows its existing empty or failed state and does not remove unrelated messages. |
+
+## Accessibility
+
+- [ ] Canvas header remains keyboard-operable for collapse and navigation.
+- [ ] Loading and error states retain their existing accessible labels.
+- [ ] Focus is not moved when the live preview becomes a historical card.
+
+## Acceptance Criteria
+
+- [ ] A preloaded `canvas_inline` event renders synchronously in ChatPanel without `ChatLoadingBlock`.
+- [ ] WorkStation and ChatPanel continue to read the same persisted event payload.
+- [ ] Final assistant-message arrival does not create a visible empty handoff.
+- [ ] Canvas previews remain isolated by session.
+- [ ] Non-canvas activity renderers are unchanged.

--- a/src/engines/ChatPanel/blocks/CanvasInlineCard/staticHtmlCanvas.test.ts
+++ b/src/engines/ChatPanel/blocks/CanvasInlineCard/staticHtmlCanvas.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+
+import { IFRAME_STYLE_NONCE } from "@src/util/iframeCspNonce";
+
+import {
+  buildStaticHtmlShadowMarkup,
+  extractStaticHtmlBody,
+  extractStaticHtmlStyles,
+  sanitizeStaticHtmlBody,
+  sanitizeStaticHtmlStyles,
+} from "./staticHtmlCanvas";
+
+describe("static HTML canvas", () => {
+  it("extracts styles separately from a full HTML document", () => {
+    const content = `<!doctype html><html><head><style>.app{display:grid;background:red}</style></head><body><div class="app">Styled</div></body></html>`;
+
+    expect(extractStaticHtmlStyles(content)).toBe(
+      ".app{display:grid;background:red}"
+    );
+    expect(extractStaticHtmlBody(content)).toBe(
+      '<div class="app">Styled</div>'
+    );
+  });
+
+  it("keeps inline presentation while removing executable HTML", () => {
+    const body = sanitizeStaticHtmlBody(`
+      <div style="display:grid;background:#111" onclick="window.pwned=true">
+        Styled
+        <script>window.pwned=true</script>
+      </div>
+    `);
+
+    expect(body).toContain('style="display:grid;background:#111"');
+    expect(body).not.toContain("onclick");
+    expect(body).not.toContain("<script");
+  });
+
+  it("removes network-capable attributes and unsafe inline CSS", () => {
+    const body = sanitizeStaticHtmlBody(`
+      <a href="https://example.com/track">Remote</a>
+      <img src="https://example.com/pixel.png" srcset="https://example.com/2x.png 2x">
+      <div style="background:url(https://example.com/pixel);color:red">Styled</div>
+    `);
+
+    expect(body).not.toContain("https://example.com");
+    expect(body).not.toContain("srcset");
+    expect(body).not.toContain("style=");
+  });
+
+  it("keeps local fragments and bounded raster data images", () => {
+    const body = sanitizeStaticHtmlBody(`
+      <a href="#details">Details</a>
+      <img src="data:image/png;base64,iVBORw0KGgo=">
+    `);
+
+    expect(body).toContain('href="#details"');
+    expect(body).toContain('src="data:image/png;base64,iVBORw0KGgo="');
+  });
+
+  it("nonces every Shadow DOM style block for the Tauri WebKit CSP", () => {
+    const markup = buildStaticHtmlShadowMarkup(
+      '<div class="app">Styled</div>',
+      ".app{display:grid;background:red}"
+    );
+    const styleTags = markup.match(/<style\b[^>]*>/g) ?? [];
+
+    expect(styleTags).toHaveLength(3);
+    for (const styleTag of styleTags) {
+      expect(styleTag).toContain(`nonce="${IFRAME_STYLE_NONCE}"`);
+    }
+    expect(markup).toContain(".app{display:grid;background:red}");
+    expect(markup).toContain('<div class="app">Styled</div>');
+  });
+
+  it("neutralizes style terminators before building Shadow DOM markup", () => {
+    const styles = extractStaticHtmlStyles(
+      "<style>.safe{}<\\/style>.also-safe{}</style>"
+    );
+    const markup = buildStaticHtmlShadowMarkup("<div>Safe</div>", styles);
+
+    expect(markup.match(/<style\b[^>]*>/g)).toHaveLength(3);
+    expect(markup).not.toMatch(/<\/style[^>]*>\.also-safe/);
+  });
+
+  it.each([
+    '@import url("https://example.com/theme.css");',
+    ".leak{background:url(https://example.com/pixel)}",
+    ":host{position:absolute}",
+    ":host-context(.dark){color:white}",
+    ".overlay{position:fixed;inset:0}",
+    ".overlay{pos/**/ition:fixed;inset:0}",
+    ".toolbar{position: sticky;top:0}",
+    ".\\68 ost{position:absolute}",
+  ])("rejects CSS that can cross the Shadow DOM boundary: %s", (styles) => {
+    expect(sanitizeStaticHtmlStyles(styles)).toBe("");
+  });
+
+  it("keeps ordinary scoped presentation CSS", () => {
+    expect(
+      sanitizeStaticHtmlStyles(
+        ".app{display:grid;background:red}@media(min-width:600px){.app{gap:1rem}}"
+      )
+    ).toContain("display:grid");
+  });
+
+  it("pins critical containment on the wrapper with important inline styles", () => {
+    const markup = buildStaticHtmlShadowMarkup("<div>Safe</div>", "");
+
+    expect(markup).toContain("contain:layout paint style!important");
+    expect(markup).toContain("overflow:auto!important");
+  });
+});

--- a/src/engines/ChatPanel/blocks/CanvasInlineCard/staticHtmlCanvas.ts
+++ b/src/engines/ChatPanel/blocks/CanvasInlineCard/staticHtmlCanvas.ts
@@ -1,0 +1,153 @@
+import DOMPurify from "dompurify";
+
+import { IFRAME_STYLE_NONCE } from "@src/util/iframeCspNonce";
+
+export const STATIC_HTML_STYLES = `
+  :host{display:block;height:100%;min-width:0;overflow:hidden;background:var(--color-bg-1);color:var(--color-text-1);font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:14px;line-height:1.6;}
+  *,*::before,*::after{box-sizing:border-box;}
+  a{color:var(--color-primary-6);text-decoration:none;}
+  a:hover{text-decoration:underline;}
+  pre,code{font-family:monospace;background:var(--color-fill-2);padding:2px 5px;border-radius:4px;font-size:.875em;}
+  pre{padding:12px 16px;overflow-x:auto;border-radius:6px;border:1px solid var(--color-border-1);}
+  pre code{background:none;padding:0;}
+  img{max-width:100%;height:auto;border-radius:4px;}
+  ::-webkit-scrollbar{width:6px;height:6px;}
+  ::-webkit-scrollbar-track{background:transparent;}
+  ::-webkit-scrollbar-thumb{background:var(--color-fill-4);border-radius:3px;}
+`;
+
+export const STATIC_HTML_CONTAINMENT_STYLES = `
+  :host{contain:layout paint style;isolation:isolate;}
+  .canvas-static-html{position:relative;height:100%;min-width:0;max-width:100%;overflow:auto;contain:layout paint style;isolation:isolate;}
+  .canvas-static-html *{max-width:100%;}
+`;
+
+export function extractStaticHtmlBody(content: string): string {
+  const bodyMatch = content.match(/<body\b[^>]*>([\s\S]*?)<\/body>/i);
+  return bodyMatch?.[1] ?? content;
+}
+
+export function sanitizeStaticHtmlBody(content: string): string {
+  const sanitized = DOMPurify.sanitize(extractStaticHtmlBody(content), {
+    FORBID_TAGS: [
+      "script",
+      "iframe",
+      "object",
+      "embed",
+      "link",
+      "meta",
+      "base",
+      "style",
+    ],
+    // HTML mode is intentionally static. Keep presentational inline styles,
+    // while DOMPurify removes script tags and event-handler attributes.
+    // Interactive sketches belong in React mode.
+    FORBID_ATTR: ["srcdoc"],
+  });
+
+  if (typeof DOMParser === "undefined") {
+    return DOMPurify.sanitize(sanitized, {
+      FORBID_ATTR: [
+        "action",
+        "background",
+        "cite",
+        "formaction",
+        "href",
+        "poster",
+        "src",
+        "srcset",
+        "style",
+        "xlink:href",
+      ],
+    });
+  }
+
+  const document = new DOMParser().parseFromString(
+    `<body>${sanitized}</body>`,
+    "text/html"
+  );
+  for (const element of document.body.querySelectorAll("*")) {
+    const inlineStyle = element.getAttribute("style");
+    if (inlineStyle && containsBoundaryCrossingCss(inlineStyle)) {
+      element.removeAttribute("style");
+    }
+
+    for (const attribute of NETWORK_CAPABLE_ATTRIBUTES) {
+      const value = element.getAttribute(attribute);
+      if (value !== null && !isSafeEmbeddedResource(attribute, value)) {
+        element.removeAttribute(attribute);
+      }
+    }
+  }
+
+  return document.body.innerHTML;
+}
+
+const NETWORK_CAPABLE_ATTRIBUTES = [
+  "action",
+  "background",
+  "cite",
+  "formaction",
+  "href",
+  "poster",
+  "src",
+  "srcset",
+  "xlink:href",
+] as const;
+
+function isSafeEmbeddedResource(attribute: string, value: string): boolean {
+  const normalized = value.trim();
+  if (
+    (attribute === "href" || attribute === "xlink:href") &&
+    normalized.startsWith("#")
+  ) {
+    return true;
+  }
+  return (
+    attribute === "src" &&
+    /^data:image\/(?:png|gif|jpe?g|webp);base64,/i.test(normalized)
+  );
+}
+
+export function extractStaticHtmlStyles(content: string): string {
+  const styles = Array.from(
+    content.matchAll(/<style\b[^>]*>([\s\S]*?)<\/style>/gi)
+  )
+    .map((match) => match[1].replace(/<\/style/gi, ""))
+    .join("\n");
+  return sanitizeStaticHtmlStyles(styles);
+}
+
+/**
+ * Shadow DOM scopes selectors but is not a security boundary. Keep authored
+ * presentation CSS only when it cannot address the host, escape through fixed
+ * positioning, or trigger network loads. A rejected stylesheet degrades to the
+ * built-in canvas theme instead of weakening containment.
+ */
+export function sanitizeStaticHtmlStyles(styles: string): string {
+  return containsBoundaryCrossingCss(styles) ? "" : styles;
+}
+
+function containsBoundaryCrossingCss(styles: string): boolean {
+  const normalizedStyles = styles.replace(/\/\*[\s\S]*?\*\//g, "");
+  return /\\|@(?:import|namespace)\b|url\s*\(|:host(?:-context)?\b|(?:^|[;{])\s*position\s*:\s*(?:fixed|sticky)\b|expression\s*\(|behavior\s*:/i.test(
+    normalizedStyles
+  );
+}
+
+/**
+ * Build the Shadow DOM tree used by static HTML canvases.
+ *
+ * WKWebView applies the parent Tauri CSP to styles created through
+ * `shadowRoot.innerHTML`. Because the policy contains a nonce source, every
+ * style block must carry the canonical nonce or WebKit silently discards it.
+ */
+export function buildStaticHtmlShadowMarkup(
+  safeContent: string,
+  styles: string
+): string {
+  const styleTag = (css: string) =>
+    `<style nonce="${IFRAME_STYLE_NONCE}">${css}</style>`;
+
+  return `${styleTag(STATIC_HTML_STYLES)}${styleTag(styles)}${styleTag(STATIC_HTML_CONTAINMENT_STYLES)}<div class="canvas-static-html" style="position:relative!important;height:100%!important;min-width:0!important;max-width:100%!important;overflow:auto!important;contain:layout paint style!important;isolation:isolate!important">${safeContent}</div>`;
+}

--- a/src/engines/SessionCore/rendering/registry/__tests__/eventRegistry.test.ts
+++ b/src/engines/SessionCore/rendering/registry/__tests__/eventRegistry.test.ts
@@ -52,6 +52,7 @@ describe("COMPONENT_LOADERS", () => {
     "turn_summary",
     "worktree",
     "setup_repo",
+    "canvas_inline",
     "rate_limit_hint",
     "tool_call",
   ] as const;

--- a/src/engines/SessionCore/rendering/registry/events/index.ts
+++ b/src/engines/SessionCore/rendering/registry/events/index.ts
@@ -98,6 +98,7 @@ export const COMPONENT_LOADERS: ComponentLoaderMap = {
   internal_browser: chatBlockLoader,
   worktree: chatBlockLoader,
   setup_repo: chatBlockLoader,
+  canvas_inline: chatBlockLoader,
   tool_call: chatBlockLoader,
 
   // ── Stream events ──
@@ -346,6 +347,12 @@ export const CONTEXT_CONFIG: Record<string, ContextConfig> = {
     simulator: { supportsSplitView: false, supportsFullscreen: false },
   },
 
+  // Canvas card
+  canvas_inline: {
+    chat: { requiresItemIndex: false, showStatusLine: false },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+
   // Plan card
   plan_approval: {
     chat: { requiresItemIndex: false, showStatusLine: false },
@@ -371,6 +378,7 @@ export const PRELOAD_COMPONENTS = [
   "code_search",
   "thinking",
   "agent_message",
+  "canvas_inline",
 ] as const;
 
 // Category helpers moved to toolCategories.ts
@@ -601,6 +609,19 @@ export function getChatLazyComponent(
 
   _lazyComponentCache.set(uiCanonical, lazyComponent);
   return lazyComponent;
+}
+
+/**
+ * Return a chat renderer without introducing a new Suspense boundary when its
+ * module was already preloaded. This is especially important for canvas
+ * events: the WorkStation can display the payload immediately, so replacing a
+ * warm chat renderer with a fresh React.lazy wrapper creates a visible handoff
+ * gap even though no data is missing.
+ */
+export function getChatComponent(
+  eventType: string
+): React.ComponentType<Record<string, unknown>> {
+  return getEventComponentSync(eventType) ?? getChatLazyComponent(eventType);
 }
 
 /**


### PR DESCRIPTION
## Problem

Inline Canvas events can briefly fall back to a generic loading block during the live-to-history handoff, and the SDE tool contract overstates visual success. Static HTML rendering also needs an explicit containment policy now that it uses Shadow DOM rather than an iframe.

## Solution

Registers and preloads `canvas_inline` through the canonical event registry, reuses a warm renderer synchronously, and keeps ChatPanel and WorkStation on the same persisted event payload. The SDE prompt routes interactive sketches to React mode while tool acknowledgements say only that the payload was accepted. Static HTML is sanitized into a contained Shadow DOM: executable tags and handlers, boundary-crossing CSS, external URL attributes, and network-capable inline styles are removed; local fragments and bounded raster data images remain available.

## Potential risks

The existing React sketch runtime uses `react-live` in the application document and is not a true iframe security sandbox; this PR documents a local-only policy but does not technically prevent generated React from accessing browser globals. That remains a separate isolation project and is recorded here as an existing limitation; this PR narrows static HTML mode without claiming to sandbox the React runtime. Static HTML sanitization may remove remote images, links, sticky/fixed positioning, or authored CSS that previously rendered. URL mode intentionally opens externally instead of embedding. No persisted event schema changes are introduced.

## Verification

- `npx vitest run` over 6 Canvas/event-registry files — 6 files, 95 tests passed
- ESLint over all changed frontend TypeScript/TSX files — passed
- `npm run typecheck` — passed
- `rustfmt --edition 2021 --check` over changed Rust files — passed
- `cargo test --manifest-path src-tauri/Cargo.toml -p agent_core render_inline_canvas` — 3 tests passed
- `cargo test --manifest-path src-tauri/Cargo.toml -p agent_core sde_` — 29 tests passed
- `cargo check --manifest-path src-tauri/Cargo.toml -p agent_core` — passed
- `cargo clippy --manifest-path src-tauri/Cargo.toml -p agent_core --all-targets -- -D warnings` — blocked by 3 pre-existing `develop` diagnostics in `e2e_fake.rs`, `provider_request_capture.rs`, and `skills/loader/scanner/loading.rs`; no changed file was named
- Whole-workspace `cargo fmt --check` is blocked by 3 unrelated `develop` formatting diffs; changed Rust files pass direct rustfmt checking
- `git diff --check` — passed
- Packaged Tauri visual verification was not run.

## Audit

- Frontend UI audit: 0 fixes, 6 keep-with-reason, 0 abstraction candidates.
- Architecture layers 1–10 reviewed: compilation/tests covered the owning boundaries; new helpers are wired from production entries; naming/defaults were swept; `canvas_inline` remains the canonical event identity; payload schema, session initialization, and resolver chains are unchanged.

## Lifecycle

- Success: accepted tool payload persists as `canvas_inline` and renders through the warm canonical renderer.
- Empty/error: existing empty fallback and activity error boundary remain authoritative; React runtime errors stay attached to the matching source/reload key.
- Switch/remount: persisted events remain session-owned; renderer preloading does not create a second payload store.
- Static HTML rejection degrades to contained themed content rather than executing or fetching external resources.