### PR TITLE
fix(dropdown): auto-hide option scrollbar

### DIFF
--- a/docs/frontend-ui-audit-2026-08-04/DropdownOptionsRenderer.md
+++ b/docs/frontend-ui-audit-2026-08-04/DropdownOptionsRenderer.md
@@ -1,0 +1,36 @@
+# Frontend UI Audit — DropdownOptionsRenderer
+
+## D1 — Raw HTML vs Design System
+
+| Line / element | Verdict | Reason | Suggested change |
+| --- | --- | --- | --- |
+| `DropdownOptionsRenderer.tsx` options `<div>` | keep with reason | This is the shared Dropdown listbox renderer itself. It owns overflow and scroll behavior and is not a substitute for the Dropdown trigger or item primitives. | — |
+
+## D2 — Arbitrary Tailwind Value vs Token
+
+| Line / element | Verdict | Reason | Suggested change |
+| --- | --- | --- | --- |
+| `tokens.ts` 700ms hide delay | keep with reason | The value is centralized in the Dropdown panel token contract and consumed by both behavior and tests. | — |
+
+## D3 — Hardcoded Sizes / Colors
+
+| Line / element | Verdict | Reason | Suggested change |
+| --- | --- | --- | --- |
+| `index.scss` 6px scrollbar / 3px radius / 160ms transition | keep with reason | Browser scrollbar pseudo-elements cannot be expressed through current Tailwind utilities; values remain isolated under the shared Dropdown helper class and use theme color variables. | — |
+
+## D4 — Accessibility
+
+| Line / element | Verdict | Reason | Suggested change |
+| --- | --- | --- | --- |
+| `onScroll` visibility behavior | keep with reason | It changes only a visual scrollbar thumb class; option semantics, focus, keyboard navigation, and selection are unchanged. Reduced-motion CSS removes the fade transition. | — |
+
+## D5 — Visual Patterns Observed
+
+- One shared `dropdown-options-scrollbar` pattern is retained for every overflowing Dropdown option list.
+- No duplicate component or new visual primitive is introduced.
+
+## Summary
+
+- 0 fixes required
+- 4 kept with documented reason
+- 0 abstraction candidates

--- a/docs/org2-performance-guard-2026-08-04/DropdownAutoHideScrollbar.md
+++ b/docs/org2-performance-guard-2026-08-04/DropdownAutoHideScrollbar.md
@@ -1,0 +1,27 @@
+# Dropdown auto-hide scrollbar performance guard
+
+## Lifecycle matrix
+
+| Lifecycle | Behavior | Verdict |
+| --- | --- | --- |
+| Mount | Allocate one small mutable state object; no timer or external listener starts. | pass |
+| Scroll burst | Reuse one hide timer, clearing and restarting it for the latest event. | pass |
+| Quiet period | Remove the active class after 700ms and release the timer ID. | pass |
+| Close / unmount | Clear the timer, remove the class, and release the element reference. | pass |
+| Idle / hidden | No work runs without a scroll event; no poller, observer, worker, or subscription exists. | pass |
+| Multiple dropdowns | State and timer ownership are per mounted renderer; cleanup is local. | pass |
+
+## Resource findings
+
+| Area | Finding | Verdict | Reason / mitigation |
+| --- | --- | --- | --- |
+| CPU | A scroll event performs one class add, at most one timer clear, and one timer schedule. | keep | Work is constant-time and occurs only during direct user scrolling. |
+| Memory | One element reference and one timer ID are retained per active renderer. | keep | Both are released on timeout or unmount. |
+| Rendering | Visibility changes use a class directly and do not schedule React state updates or component renders. | keep | Avoids high-frequency React reconciliation. |
+| Cancellation | Component cleanup calls `disposeAutoHideScrollbar`. | keep | Unit and rendered-component tests assert zero timers after dispose/unmount. |
+
+## Verdict
+
+**Pass for lifecycle safety.** Manual WebKit visual verification is still required
+for thumb appearance and gutter stability, but no retained background work remains
+after the Dropdown closes.

--- a/src/components/Dropdown/DropdownOptionsRenderer.tsx
+++ b/src/components/Dropdown/DropdownOptionsRenderer.tsx
@@ -13,7 +13,12 @@ import { useTranslation } from "react-i18next";
 import Checkbox from "@src/components/Checkbox";
 
 import DropdownSelectedCheck from "./DropdownSelectedCheck";
-import { DROPDOWN_CLASSES, DROPDOWN_ITEM } from "./tokens";
+import {
+  createAutoHideScrollbarState,
+  disposeAutoHideScrollbar,
+  revealAutoHideScrollbar,
+} from "./autoHideScrollbar";
+import { DROPDOWN_CLASSES, DROPDOWN_ITEM, DROPDOWN_PANEL } from "./tokens";
 import type { DropdownOption, DropdownSelectValue } from "./types";
 
 export interface DropdownOptionsRendererProps {
@@ -46,6 +51,28 @@ const DropdownOptionsRenderer: React.FC<DropdownOptionsRendererProps> = ({
 }) => {
   const { t } = useTranslation();
   const isMultiple = mode === "multiple";
+  const autoHideScrollbarState = React.useMemo(
+    () => createAutoHideScrollbarState(),
+    []
+  );
+
+  const handleOptionsScroll = React.useCallback(
+    (event: React.UIEvent<HTMLDivElement>) => {
+      revealAutoHideScrollbar(
+        event.currentTarget,
+        autoHideScrollbarState,
+        DROPDOWN_PANEL.scrollbarHideDelayMs
+      );
+    },
+    [autoHideScrollbarState]
+  );
+
+  React.useEffect(
+    () => () => {
+      disposeAutoHideScrollbar(autoHideScrollbarState);
+    },
+    [autoHideScrollbarState]
+  );
 
   let content: React.ReactNode;
 
@@ -64,12 +91,13 @@ const DropdownOptionsRenderer: React.FC<DropdownOptionsRendererProps> = ({
     );
   } else {
     content = (
-      // No `select-options-overlay` here: its `scrollbar-width: thin` makes
-      // newer WebKit ignore the ::-webkit-scrollbar styling entirely and fall
-      // back to an auto-hiding overlay bar, so an overflowing option list
-      // (e.g. the sidebar org selector) shows no scroll affordance at all and
-      // reads as complete.
-      <div className={DROPDOWN_CLASSES.optionsContainerScrollbar}>
+      // Keep the scrollbar gutter stable, but reveal its thumb only while the
+      // user is actively scrolling. This avoids a permanently visible rail
+      // without changing list width when the thumb appears.
+      <div
+        className={DROPDOWN_CLASSES.optionsContainerScrollbar}
+        onScroll={handleOptionsScroll}
+      >
         <div className={DROPDOWN_CLASSES.itemsColumn}>
           {options.map((option, index) => {
             const isSelected = isMultiple

--- a/src/components/Dropdown/__tests__/DropdownOptionsRenderer.test.ts
+++ b/src/components/Dropdown/__tests__/DropdownOptionsRenderer.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import DropdownOptionsRenderer from "../DropdownOptionsRenderer";
+import { DROPDOWN_PANEL } from "../tokens";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe("DropdownOptionsRenderer auto-hiding scrollbar", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  const renderOptions = async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(DropdownOptionsRenderer, {
+          options: [
+            { label: "Blue", value: "blue" },
+            { label: "Purple", value: "purple" },
+          ],
+          value: "blue",
+          mode: "single",
+          highlightedIndex: 0,
+          keyboardNavigated: false,
+          onSelect: vi.fn(),
+        })
+      );
+    });
+
+    return container.querySelector<HTMLDivElement>(
+      ".dropdown-options-scrollbar"
+    );
+  };
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    expect(vi.getTimerCount()).toBe(0);
+    vi.useRealTimers();
+    container.remove();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("reveals the thumb during scroll and hides it after the quiet period", async () => {
+    const scrollContainer = await renderOptions();
+
+    expect(scrollContainer).not.toBeNull();
+    expect(
+      scrollContainer?.classList.contains("dropdown-options-scrollbar--active")
+    ).toBe(false);
+
+    act(() => {
+      scrollContainer?.dispatchEvent(new Event("scroll"));
+    });
+    expect(
+      scrollContainer?.classList.contains("dropdown-options-scrollbar--active")
+    ).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(DROPDOWN_PANEL.scrollbarHideDelayMs - 1);
+    });
+    expect(
+      scrollContainer?.classList.contains("dropdown-options-scrollbar--active")
+    ).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(
+      scrollContainer?.classList.contains("dropdown-options-scrollbar--active")
+    ).toBe(false);
+  });
+
+  it("restarts the hide delay on continued scrolling", async () => {
+    const scrollContainer = await renderOptions();
+
+    act(() => {
+      scrollContainer?.dispatchEvent(new Event("scroll"));
+      vi.advanceTimersByTime(DROPDOWN_PANEL.scrollbarHideDelayMs / 2);
+      scrollContainer?.dispatchEvent(new Event("scroll"));
+      vi.advanceTimersByTime(DROPDOWN_PANEL.scrollbarHideDelayMs - 1);
+    });
+
+    expect(
+      scrollContainer?.classList.contains("dropdown-options-scrollbar--active")
+    ).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(
+      scrollContainer?.classList.contains("dropdown-options-scrollbar--active")
+    ).toBe(false);
+  });
+});

--- a/src/components/Dropdown/__tests__/TEST_CASES.md
+++ b/src/components/Dropdown/__tests__/TEST_CASES.md
@@ -1,0 +1,42 @@
+# Test Cases: Dropdown auto-hiding scrollbar
+
+## Preconditions
+
+- Open a Select/Dropdown with enough options to overflow vertically.
+- Test with a mouse wheel or trackpad in both light and dark appearance.
+
+## Happy Path
+
+| #   | Steps                                            | Expected Result                                                        |
+| --- | ------------------------------------------------ | ---------------------------------------------------------------------- |
+| 1   | Open the overflowing dropdown without scrolling. | The scrollbar gutter is stable and the thumb is hidden.                |
+| 2   | Scroll the option list.                          | The scrollbar thumb appears immediately and the list scrolls normally. |
+| 3   | Stop scrolling.                                  | The thumb hides after 700ms without changing the dropdown width.       |
+
+## Edge Cases
+
+| #   | Scenario                   | Steps                                           | Expected Result                                                                              |
+| --- | -------------------------- | ----------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| 1   | Rapid repeated scrolling   | Scroll repeatedly with gaps shorter than 700ms. | A single hide timer is restarted and the thumb remains visible until the final quiet period. |
+| 2   | Menu closes while visible  | Scroll, then close the dropdown immediately.    | The timer is cancelled and no retained listener or timer remains.                            |
+| 3   | Empty or short option list | Open a dropdown that does not overflow.         | No scrollbar thumb appears and option behavior is unchanged.                                 |
+
+## Error / Degraded States
+
+| #   | Scenario               | Steps                                      | Expected Result                                                           |
+| --- | ---------------------- | ------------------------------------------ | ------------------------------------------------------------------------- |
+| 1   | Reduced motion enabled | Enable reduced motion and scroll the list. | The visibility behavior remains usable; no layout movement is introduced. |
+
+## Accessibility
+
+- [ ] Keyboard navigation and selection behavior are unchanged.
+- [ ] Screen-reader option names and selection state are unchanged.
+- [ ] Focus remains on the dropdown trigger/listbox while scrolling.
+
+## Acceptance Criteria
+
+- [ ] The scrollbar thumb is transparent before the first scroll event.
+- [ ] The thumb is visible during active scrolling.
+- [ ] Continued scrolling restarts one bounded 700ms hide timer.
+- [ ] Closing/unmounting the dropdown clears the timer.
+- [ ] Showing or hiding the thumb causes no layout shift.

--- a/src/components/Dropdown/__tests__/autoHideScrollbar.test.ts
+++ b/src/components/Dropdown/__tests__/autoHideScrollbar.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  AUTO_HIDE_SCROLLBAR_ACTIVE_CLASS,
+  createAutoHideScrollbarState,
+  disposeAutoHideScrollbar,
+  revealAutoHideScrollbar,
+} from "../autoHideScrollbar";
+
+describe("auto-hide dropdown scrollbar", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps one hide timer and restarts it for continued scrolling", () => {
+    const element = document.createElement("div");
+    const state = createAutoHideScrollbarState();
+
+    revealAutoHideScrollbar(element, state, 700);
+    expect(element.classList.contains(AUTO_HIDE_SCROLLBAR_ACTIVE_CLASS)).toBe(
+      true
+    );
+    expect(vi.getTimerCount()).toBe(1);
+
+    vi.advanceTimersByTime(350);
+    revealAutoHideScrollbar(element, state, 700);
+    expect(vi.getTimerCount()).toBe(1);
+
+    vi.advanceTimersByTime(699);
+    expect(element.classList.contains(AUTO_HIDE_SCROLLBAR_ACTIVE_CLASS)).toBe(
+      true
+    );
+
+    vi.advanceTimersByTime(1);
+    expect(element.classList.contains(AUTO_HIDE_SCROLLBAR_ACTIVE_CLASS)).toBe(
+      false
+    );
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("removes the active class and timer when disposed", () => {
+    const element = document.createElement("div");
+    const state = createAutoHideScrollbarState();
+
+    revealAutoHideScrollbar(element, state, 700);
+    disposeAutoHideScrollbar(state);
+
+    expect(element.classList.contains(AUTO_HIDE_SCROLLBAR_ACTIVE_CLASS)).toBe(
+      false
+    );
+    expect(state.activeElement).toBeNull();
+    expect(state.hideTimer).toBeUndefined();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/components/Dropdown/autoHideScrollbar.ts
+++ b/src/components/Dropdown/autoHideScrollbar.ts
@@ -1,0 +1,46 @@
+export const AUTO_HIDE_SCROLLBAR_ACTIVE_CLASS =
+  "dropdown-options-scrollbar--active";
+
+export interface AutoHideScrollbarState {
+  activeElement: HTMLElement | null;
+  hideTimer: number | undefined;
+}
+
+export function createAutoHideScrollbarState(): AutoHideScrollbarState {
+  return {
+    activeElement: null,
+    hideTimer: undefined,
+  };
+}
+
+export function revealAutoHideScrollbar(
+  element: HTMLElement,
+  state: AutoHideScrollbarState,
+  hideDelayMs: number
+): void {
+  if (state.activeElement && state.activeElement !== element) {
+    state.activeElement.classList.remove(AUTO_HIDE_SCROLLBAR_ACTIVE_CLASS);
+  }
+
+  element.classList.add(AUTO_HIDE_SCROLLBAR_ACTIVE_CLASS);
+  state.activeElement = element;
+
+  if (state.hideTimer !== undefined) {
+    window.clearTimeout(state.hideTimer);
+  }
+
+  state.hideTimer = window.setTimeout(() => {
+    element.classList.remove(AUTO_HIDE_SCROLLBAR_ACTIVE_CLASS);
+    if (state.activeElement === element) state.activeElement = null;
+    state.hideTimer = undefined;
+  }, hideDelayMs);
+}
+
+export function disposeAutoHideScrollbar(state: AutoHideScrollbarState): void {
+  if (state.hideTimer !== undefined) {
+    window.clearTimeout(state.hideTimer);
+  }
+  state.activeElement?.classList.remove(AUTO_HIDE_SCROLLBAR_ACTIVE_CLASS);
+  state.activeElement = null;
+  state.hideTimer = undefined;
+}

--- a/src/components/Dropdown/tokens.ts
+++ b/src/components/Dropdown/tokens.ts
@@ -81,6 +81,9 @@ export const DROPDOWN_PANEL = {
   /** Animation duration */
   animationDuration: "0.2s",
 
+  /** Keep the scrollbar thumb visible briefly after option-list scrolling stops. */
+  scrollbarHideDelayMs: 700,
+
   /** Background and border (use Tailwind classes) */
   bgClass: "bg-bg-2",
   borderClass: "border border-solid border-border-2",

--- a/src/index.scss
+++ b/src/index.scss
@@ -707,12 +707,9 @@ body.drag-over::after {
     0 2px 4px rgba(0, 0, 0, 0.3);
 }
 
-/* Visible thin scrollbar for dropdown option lists (Settings > Timezone,
- * table selectors, etc.). Tailwind has no first-class scrollbar pseudo
- * utilities, so we expose this as a global helper class. No `scrollbar-width`
- * here: once WebKit/Chromium support it, its presence makes them IGNORE the
- * ::-webkit-scrollbar rules below and fall back to an auto-hiding overlay
- * bar — an overflowing dropdown then shows no scroll affordance at all. */
+/* Auto-hiding thin scrollbar for dropdown option lists. The gutter remains
+ * stable, while the thumb appears during scroll and fades after it stops.
+ * Do not add `scrollbar-width`: newer WebKit then ignores these pseudo rules. */
 .dropdown-options-scrollbar {
   &::-webkit-scrollbar {
     width: 6px;
@@ -723,12 +720,23 @@ body.drag-over::after {
   }
 
   &::-webkit-scrollbar-thumb {
-    background: var(--color-fill-3);
+    background: transparent;
     border-radius: 3px;
+    transition: background-color 160ms ease;
   }
 
-  &::-webkit-scrollbar-thumb:hover {
+  &.dropdown-options-scrollbar--active::-webkit-scrollbar-thumb {
+    background: var(--color-fill-3);
+  }
+
+  &.dropdown-options-scrollbar--active::-webkit-scrollbar-thumb:hover {
     background: var(--color-fill-4);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dropdown-options-scrollbar::-webkit-scrollbar-thumb {
+    transition: none;
   }
 }
 


### PR DESCRIPTION
## Problem

Overflowing Dropdown option lists keep a visible scrollbar thumb even when the user is not interacting with the list. The permanent rail adds visual weight, while removing the scrollbar entirely would hide the overflow affordance and can change layout width across WebKit variants.

## Solution

Keep the Dropdown scrollbar gutter stable and make only the thumb transparent at rest. A shared auto-hide helper reveals the thumb on scroll, restarts one bounded 700ms quiet-period timer, and removes the active class after scrolling stops. Component cleanup clears the timer and element reference. Reduced-motion users get the same behavior without the fade transition.

## Potential risks

Scrollbar pseudo-element behavior differs between WebKit versions, and the global helper intentionally avoids `scrollbar-width` because newer WebKit can ignore the custom pseudo rules when it is present. Automated tests verify timer ownership and class behavior, but packaged desktop visual QA has not confirmed thumb contrast, hover appearance, and gutter stability in light/dark themes. That packaged visual pass remains follow-up evidence; the timer lifecycle, rendered class behavior, reduced-motion rule, and rollback boundary are covered by the committed tests and audit. Rollback is a source-only revert with no persisted state or API change.

## Audits

- Frontend UI audit: `docs/frontend-ui-audit-2026-08-04/DropdownOptionsRenderer.md` — 0 fixes required, 4 keep-with-reason findings, 0 abstraction candidates.
- Performance guard: `docs/org2-performance-guard-2026-08-04/DropdownAutoHideScrollbar.md` — lifecycle-safe; one per-renderer timer is released on timeout or unmount, with no idle work or React state updates during scrolling.

## Verification

- `npx vitest run src/components/Dropdown/__tests__/autoHideScrollbar.test.ts src/components/Dropdown/__tests__/DropdownOptionsRenderer.test.ts` — 2 files, 4 tests passed.
- `npx eslint` over all changed Dropdown TypeScript/TSX files — passed.
- `npm run typecheck` — passed.
- `git diff --cached --check` before commit — passed.
- Compared the file list with current `origin/develop`; every change maps to Dropdown scrollbar visibility or its direct tests/audits.

Not run: packaged desktop manual visual checks in light/dark modes, overflowing and non-overflowing lists, and reduced-motion mode. The manual cases are documented in `src/components/Dropdown/__tests__/TEST_CASES.md`.