### PR TITLE
fix(chat): preserve Launchpad creator intent

### DIFF
--- a/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
+++ b/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
@@ -1039,6 +1039,38 @@ describe("ChatPanel navigation tabs", () => {
     ).toHaveLength(1);
   });
 
+  it("keeps the Work Item creator selected after switching back to Launchpad", async () => {
+    const {
+      CHAT_PANEL_CREATE_TARGET,
+      chatPanelCreateTargetAtom,
+      chatPanelStartPageOpenAtom,
+      chatPanelTabsAtom,
+      openCreateTargetInChatPanelStartPageAtom,
+      openSessionInNewChatTabAtom,
+      store,
+      syncActiveChatPanelTabStateAtom,
+    } = await loadChatPanelTabAtoms();
+    const launchpadTabId = store.get(chatPanelTabsAtom).activeTabId;
+
+    store.set(openSessionInNewChatTabAtom, {
+      sessionId: "session-a",
+      sessionName: "Session A",
+    });
+    store.set(openCreateTargetInChatPanelStartPageAtom, {
+      target: CHAT_PANEL_CREATE_TARGET.WORK_ITEM,
+    });
+
+    // Mirrors ChatPanel's layout effect after the active tab changes from the
+    // session back to Launchpad.
+    store.set(syncActiveChatPanelTabStateAtom);
+
+    expect(store.get(chatPanelTabsAtom).activeTabId).toBe(launchpadTabId);
+    expect(store.get(chatPanelStartPageOpenAtom)).toBe(true);
+    expect(store.get(chatPanelCreateTargetAtom)).toBe(
+      CHAT_PANEL_CREATE_TARGET.WORK_ITEM
+    );
+  });
+
   it("collapses persisted duplicate start-page tabs into one", async () => {
     const { normalizePersistedChatPanelTabsState } =
       await loadChatPanelTabAtoms();

--- a/src/store/chatPanel/chatPanelTabPresentationAtoms.ts
+++ b/src/store/chatPanel/chatPanelTabPresentationAtoms.ts
@@ -9,6 +9,8 @@ import {
 } from "@src/store/session/viewAtom";
 import {
   CHAT_PANEL_SURFACE_KIND,
+  DEFAULT_CHAT_PANEL_CREATE_TARGET,
+  chatPanelCreateTargetAtom,
   chatPanelMaximizedAtom,
   chatPanelNavigateAtom,
   chatPanelStartPageOpenAtom,
@@ -158,9 +160,14 @@ export const syncActiveChatPanelTabStateAtom = atom(null, (get, set) => {
     state.tabs.find((tab) => tab.id === state.activeTabId) ?? null;
   // A start-page tab is also the host for non-session project surfaces.
   // Navigation deliberately closes the Launchpad before selecting one of
-  // those surfaces. Do not let the React reconciliation pass erase that
-  // newer navigation command after a switch away from Work Management.
-  if (activeTab?.type !== "start-page" || get(chatPanelStartPageOpenAtom)) {
+  // those surfaces. It also owns its pinned creator navigation. Do not let
+  // the React reconciliation pass erase either newer intent after activating
+  // Launchpad from another tab.
+  const startPageOwnsExplicitNavigation =
+    activeTab?.type === "start-page" &&
+    (!get(chatPanelStartPageOpenAtom) ||
+      get(chatPanelCreateTargetAtom) !== DEFAULT_CHAT_PANEL_CREATE_TARGET);
+  if (!startPageOwnsExplicitNavigation) {
     set(syncChatPanelTabNavigationAtom, activeTab);
   }
 


### PR DESCRIPTION
## Problem

When a user starts creating a Work Item while another ChatPanel tab is active, the creator entry point first focuses Launchpad and then selects the Work Item creator. The ChatPanel layout reconciliation triggered by that tab change subsequently replayed the default Launchpad navigation and reset the create target to Agent Session. As a result, Launchpad opened without automatically landing on the requested Work Item creator.

## Solution

Treat explicit navigation already owned by the active Launchpad as newer than the layout reconciliation pass. Reconciliation now skips the default start-page replay when Launchpad is hosting either a non-default creator target or a direct child surface. Normal explicit activation of the Launchpad tab still applies its Agent Session default before this guard runs.

A regression test reproduces the session-tab to Work Item creator transition and then invokes the same reconciliation atom used by the ChatPanel layout effect.

## Potential risks

The guard intentionally applies to every non-default Launchpad creator target, not only Work Item, so Project, GitHub Issues Project, and Add ORG entry points receive the same preservation behavior. The main regression risk is retaining a stale non-default creator, but explicit Launchpad tab activation continues to replay the default state before reconciliation, which bounds that risk. This changes only in-memory UI navigation; there are no persistence, data, API, IPC, dependency, or wire-format changes. Rollback is a direct revert of commit `a5a21c2`.

## Verification

- `pnpm vitest run src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts` — passed, 39 tests.
- `pnpm prettier --check src/store/chatPanel/chatPanelTabPresentationAtoms.ts src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts` — passed.
- `pnpm eslint src/store/chatPanel/chatPanelTabPresentationAtoms.ts src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts` — passed.
- `pnpm typecheck` — passed.
- Manual desktop clicking was not run in the clean PR clone. The changed behavior is covered at the owning atom boundary; there are no visual or layout changes for which screenshots would add evidence.

## Scope and audit

The diff is limited to the ChatPanel reconciliation guard and its regression test. Entry-point review confirmed all external non-default creator flows use the same canonical opener. The diff was inspected for unrelated changes, generated artifacts, personal paths, debug logs, and secrets; none are included.