### PR TITLE
Break the Source Control import cycle

### DIFF
--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/sourceControlScopePickerHelpers.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/sourceControlScopePickerHelpers.ts
@@ -1,14 +1,17 @@
 import type { GitWorktreeDiffSummary } from "@src/api/http/git/types";
+import type {
+  SourceControlScope,
+  SourceControlScopeMap,
+} from "@src/store/workstation/codeEditor/sourceControlTypes";
 import {
   formatRepoPathForDisplay,
   normalizeDisplayPath,
 } from "@src/util/file/repoPathDisplay";
 
-export type SourceControlScope =
-  | { kind: "local" }
-  | { kind: "worktree"; path: string };
-
-export type SourceControlScopeMap = Record<string, SourceControlScope>;
+export type {
+  SourceControlScope,
+  SourceControlScopeMap,
+} from "@src/store/workstation/codeEditor/sourceControlTypes";
 
 export interface ScopePickerDiffStats {
   additions: number;

--- a/src/modules/WorkStation/shared/SidebarModules/SourceControl/SourceControlFilterHeader.tsx
+++ b/src/modules/WorkStation/shared/SidebarModules/SourceControl/SourceControlFilterHeader.tsx
@@ -20,15 +20,9 @@ import Select from "@src/components/Select";
 import { useRefreshSpin } from "@src/hooks/ui";
 import { WorkstationToolbarTooltip } from "@src/modules/WorkStation/shared/WorkstationToolbarTooltip";
 import { HEADER_ICON_SIZE } from "@src/modules/WorkStation/shared/tokens";
+import type { SourceControlFilterMode } from "@src/store/workstation/codeEditor/sourceControlTypes";
 
-export type SourceControlFilterMode =
-  | "uncommitted"
-  | "unstaged"
-  | "staged"
-  | "stashed"
-  | "history"
-  | "pr"
-  | "issues";
+export type { SourceControlFilterMode } from "@src/store/workstation/codeEditor/sourceControlTypes";
 
 export interface SourceControlFilterCounts {
   uncommitted: number;

--- a/src/store/workstation/codeEditor/index.ts
+++ b/src/store/workstation/codeEditor/index.ts
@@ -38,6 +38,9 @@ export * from "./sourceControlFilterModeAtom";
 // Source Control worktree scope (host vs linked worktree)
 export * from "./sourceControlScopeAtom";
 
+// Source Control state contracts
+export * from "./sourceControlTypes";
+
 // Pinned Terminal tab target selection
 export * from "./terminalTargetAtom";
 

--- a/src/store/workstation/codeEditor/sourceControlFilterModeAtom.ts
+++ b/src/store/workstation/codeEditor/sourceControlFilterModeAtom.ts
@@ -1,9 +1,6 @@
 import { atom } from "jotai";
 
-// NOTE: Import directly from the leaf file (not the barrel) to avoid pulling
-// the whole SidebarModules tree — which transitively re-imports @src/store —
-// back into the store layer and creating a circular dependency.
-import type { SourceControlFilterMode } from "@src/modules/WorkStation/shared/SidebarModules/SourceControl/SourceControlFilterHeader";
+import type { SourceControlFilterMode } from "./sourceControlTypes";
 
 /** Active Source Control sidebar filter (file buckets or git history graph). */
 export const sourceControlFilterModeAtom =

--- a/src/store/workstation/codeEditor/sourceControlScopeAtom.ts
+++ b/src/store/workstation/codeEditor/sourceControlScopeAtom.ts
@@ -1,6 +1,6 @@
 import { atom } from "jotai";
 
-import type { SourceControlScopeMap } from "@src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/sourceControlScopePickerHelpers";
+import type { SourceControlScopeMap } from "./sourceControlTypes";
 
 /** Per-repo Source Control scope for the current app session (not persisted). */
 export const sourceControlScopeMapAtom = atom<SourceControlScopeMap>({});

--- a/src/store/workstation/codeEditor/sourceControlTypes.ts
+++ b/src/store/workstation/codeEditor/sourceControlTypes.ts
@@ -1,0 +1,17 @@
+/** Source Control sidebar dataset selected for the current workstation. */
+export type SourceControlFilterMode =
+  | "uncommitted"
+  | "unstaged"
+  | "staged"
+  | "stashed"
+  | "history"
+  | "pr"
+  | "issues";
+
+/** Repository root used by Source Control reads and mutations. */
+export type SourceControlScope =
+  | { kind: "local" }
+  | { kind: "worktree"; path: string };
+
+/** Per-repository Source Control scope for the current app session. */
+export type SourceControlScopeMap = Record<string, SourceControlScope>;


### PR DESCRIPTION
## Problem

Source Control state atoms imported their TypeScript contracts from rendered WorkStation modules. The filter-mode edge completed a nine-module cycle through the UI hook and workstation barrels, so the pre-commit project scan reported one circular dependency.

The same lower-layer-to-UI ownership pattern also existed for Source Control scope state, even though it had not yet completed another reported cycle.

## Solution

- Adds one dependency-free Source Control state-contract module owned by the workstation store.
- Moves filter-mode, scope, and scope-map types into that canonical module.
- Makes the atoms and rendered helpers depend on the canonical leaf module while preserving the existing UI type re-exports for callers.
- Sweeps the full store layer and removes both store-to-rendered-module imports.

The dependency graph now has zero circular dependencies across all 6,142 analyzed modules.

## Potential risks

This is a type-ownership and import-graph change only; runtime atom values, defaults, rendered behavior, persistence, and wire formats are unchanged. Existing imports through the UI helper modules remain compatible through type-only re-exports. The main compatibility risk would be a build tool mishandling type-only re-exports, which is covered by the TypeScript and production dependency-graph checks.

No screenshot was captured because the change has no user-visible UI behavior.

## Verification

- `pnpm check:circular` — passed; zero circular dependencies across 6,142 modules.
- Full-project `pnpm eslint src/ --format json` scan — zero errors and zero warnings.
- Targeted ESLint over all six changed files with `--max-warnings=0` — passed.
- `pnpm typecheck` — passed.
- `pnpm vitest run src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/__tests__/sourceControlScopePickerHelpers.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/__tests__/useSourceControlScope.test.ts` — 36 tests passed.
- `git diff --check origin/develop...HEAD` — passed.
- Commit hook trailer verified: `Total eslint: 0, total circular: 0`.

## Audit

Architecture layers 1–3 confirm compilation, one canonical live type definition, and unchanged domain naming. Layers 4–5 found no semantic or default-branch changes. Layer 6 is the owning fix: the store no longer imports rendered modules. Layer 7 now gives new contributors one state-owned contract location. Layers 8–10 are unchanged because this patch has no serialization, initialization, or resolver behavior. A systematic sweep confirms no `src/store` imports from `@src/modules` remain.

The frontend UI audit was intentionally skipped under its single-bug-fix rule because no rendered component behavior or styling changed.