### PR TITLE
fix(cloud): keep Codex history uploading in background

### DIFF
--- a/src/features/Org2Cloud/org2CloudSessionSync.state.ts
+++ b/src/features/Org2Cloud/org2CloudSessionSync.state.ts
@@ -156,11 +156,17 @@ export class Org2CloudSessionSyncState {
     const now = Date.now();
     const observed = this.externalHistoryVersions.get(sessionId);
     if (!observed || observed.sourceUpdatedAt !== session.updated_at) {
+      // A sessionsAtom observer can stamp the source change before the first
+      // cloud pass that sees this version. Preserve that timestamp so the
+      // already-armed quiet-window pass may publish immediately instead of
+      // requiring an unrelated second trigger. Direct/manual passes without a
+      // source notification retain the conservative two-observation behavior.
+      const activityAt = this.eventActivityAtMs.get(sessionId) ?? now;
       this.externalHistoryVersions.set(sessionId, {
         sourceUpdatedAt: session.updated_at,
-        observedAt: now,
+        observedAt: activityAt,
       });
-      return false;
+      return now - activityAt >= EXTERNAL_HISTORY_ACTIVITY_DEBOUNCE_MS;
     }
     const changedAt = Math.max(
       observed.observedAt,

--- a/src/features/Org2Cloud/org2CloudSyncEngine.sessions.test.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.sessions.test.ts
@@ -858,6 +858,71 @@ describe("Org2CloudSyncEngine session publishing", () => {
     expect(loadFullTranscriptChunks).toHaveBeenCalledTimes(1);
   });
 
+  it("publishes a roster-refreshed external replay in an inactive background org after one quiet timer", async () => {
+    const sessionId = "codexapp-background-thread-1";
+    const source = getImportedHistorySourceBySessionId(sessionId);
+    const loadFullTranscriptChunks = vi
+      .spyOn(source!, "loadFullTranscriptChunks")
+      .mockResolvedValue([] as never);
+    store.set(sidebarActiveCloudOrgIdAtom, null);
+    store.set(org2CloudOrgsAtom, [
+      {
+        orgId: "corg-1",
+        name: "Cloud Team",
+        role: "member",
+        offlineSyncEnabled: true,
+      },
+    ]);
+
+    // Drain the startup pass and isolate the sessionsAtom-driven trigger.
+    await vi.advanceTimersByTimeAsync(0);
+    await engine.runSyncPassAndWaitForDrain();
+    client.upsertSessionMetadata.mockClear();
+    client.rewriteSessionEvents.mockClear();
+    loadFullTranscriptChunks.mockClear();
+    let markBackgroundUpserted!: () => void;
+    const backgroundUpserted = new Promise<void>((resolve) => {
+      markBackgroundUpserted = resolve;
+    });
+    client.upsertSessionMetadata.mockImplementation(async () => {
+      markBackgroundUpserted();
+    });
+
+    store.set(sessionsAtom, [
+      {
+        ...SESSION,
+        session_id: sessionId,
+        orgId: "personal-org",
+        updated_at: "2026-08-04T15:00:00.000Z",
+      },
+    ]);
+
+    await vi.advanceTimersByTimeAsync(
+      EXTERNAL_HISTORY_ACTIVITY_DEBOUNCE_MS - 1
+    );
+    expect(client.upsertSessionMetadata).not.toHaveBeenCalled();
+    expect(loadFullTranscriptChunks).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(2);
+    await backgroundUpserted;
+    expect(client.upsertSessionMetadata).toHaveBeenCalledTimes(1);
+    expect(client.upsertSessionMetadata.mock.calls[0][2]).toBe(sessionId);
+    expect(loadFullTranscriptChunks).toHaveBeenCalledWith(sessionId);
+
+    const passCount = engine.startedPassCount;
+    engine.stop();
+    store.set(sessionsAtom, [
+      {
+        ...SESSION,
+        session_id: sessionId,
+        orgId: "personal-org",
+        updated_at: "2026-08-04T15:01:00.000Z",
+      },
+    ]);
+    await vi.advanceTimersByTimeAsync(EXTERNAL_HISTORY_ACTIVITY_DEBOUNCE_MS);
+    expect(engine.startedPassCount).toBe(passCount);
+  });
+
   it("seeds unchanged external replay state from the server after restart", async () => {
     const sessionId = "cursoride-thread-1";
     const source = getImportedHistorySourceBySessionId(sessionId);

--- a/src/features/Org2Cloud/org2CloudSyncEngine.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.ts
@@ -58,6 +58,7 @@ import { createLogger } from "@src/hooks/logger";
 import { sessionsAtom } from "@src/store/session/sessionAtom/atoms";
 import type { Session } from "@src/store/session/sessionAtom/types";
 import { chatPanelSelectedCloudOrgAtom } from "@src/store/ui/chatPanelAtom";
+import { isImportedHistorySession } from "@src/util/session/sessionDispatch";
 
 import type { ProjectSyncBridge } from "../TeamCollaboration/engine/projectSyncBridge";
 import { tauriProjectSyncBridge } from "../TeamCollaboration/engine/projectSyncBridge";
@@ -138,7 +139,10 @@ import {
   findVanishedPushedSessionIds,
   resolveLocalSessionIdsViaAggregateList,
 } from "./org2CloudSyncEngine.vanishedSessions";
-import { Org2CloudSyncLifecycle } from "./org2CloudSyncLifecycle";
+import {
+  type CloudStore,
+  Org2CloudSyncLifecycle,
+} from "./org2CloudSyncLifecycle";
 
 export {
   DATA_CHANGED_DEBOUNCE_MS,
@@ -161,6 +165,9 @@ export type { Org2CloudSchemaVersionProbe } from "./org2CloudSyncEngine.schemaGa
 const log = createLogger("Org2CloudSyncEngine");
 
 export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
+  /** Last roster version for each locally owned external-history session. */
+  private readonly externalHistoryRosterVersions = new Map<string, string>();
+  private sessionRosterUnsubscribe: (() => void) | null = null;
   /** Per-org entitlement backoff deadlines + notification state, split out
    * to `Org2CloudOrgBackoffTracker` — see that module for the per-map
    * rationale (kept together there since a policy signal touches more than
@@ -220,6 +227,57 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
     this.sessionColdStart = new Org2CloudSessionColdStart(client);
     this.schemaGate = new Org2CloudSchemaGate(probeSchemaVersion);
     this.resolveLocalSessionIds = resolveLocalSessionIds;
+  }
+
+  override start(store: CloudStore): void {
+    if (this.sessionRosterUnsubscribe) return;
+    super.start(store);
+    this.captureExternalHistoryRosterActivity(store);
+    this.sessionRosterUnsubscribe = store.sub(sessionsAtom, () => {
+      this.captureExternalHistoryRosterActivity(store);
+    });
+  }
+
+  override stop(): void {
+    this.sessionRosterUnsubscribe?.();
+    this.sessionRosterUnsubscribe = null;
+    this.externalHistoryRosterVersions.clear();
+    super.stop();
+  }
+
+  /**
+   * Imported providers refresh sessionsAtom directly instead of writing the
+   * EventStore. Convert only meaningful source-version changes into the same
+   * bounded quiet-window trigger used by native event notifications.
+   */
+  private captureExternalHistoryRosterActivity(store: CloudStore): void {
+    const nextVersions = new Map<string, string>();
+    const changedSessionIds: string[] = [];
+    for (const session of store.get(sessionsAtom)) {
+      if (
+        !isImportedHistorySession(session.session_id) ||
+        !isCloudPushCandidate(session)
+      ) {
+        continue;
+      }
+      const version = session.updated_at ?? "";
+      nextVersions.set(session.session_id, version);
+      if (
+        this.externalHistoryRosterVersions.get(session.session_id) !== version
+      ) {
+        changedSessionIds.push(session.session_id);
+      }
+    }
+    this.externalHistoryRosterVersions.clear();
+    for (const [sessionId, version] of nextVersions) {
+      this.externalHistoryRosterVersions.set(sessionId, version);
+    }
+    if (changedSessionIds.length === 0) return;
+    for (const sessionId of changedSessionIds) {
+      this.noteSessionEventActivity(sessionId);
+    }
+    // One timer coalesces every changed imported session into one cloud pass.
+    this.scheduleActivityPass(changedSessionIds[0]!);
   }
 
   protected override resetSyncState(): void {

--- a/src/features/Org2Cloud/org2CloudSyncLifecycle.ts
+++ b/src/features/Org2Cloud/org2CloudSyncLifecycle.ts
@@ -311,7 +311,7 @@ export abstract class Org2CloudSyncLifecycle {
   // window with an agent streaming is still producing local writes, and
   // teammates must see the transcript advance. Only inbound-only nudges wait
   // for visibility.
-  private scheduleActivityPass(sessionId: string): void {
+  protected scheduleActivityPass(sessionId: string): void {
     if (!this.started) return;
     const externalHistory = isImportedHistorySession(sessionId);
     const timer = externalHistory

--- a/src/features/Org2Cloud/useOrg2CloudSyncEngine.test.ts
+++ b/src/features/Org2Cloud/useOrg2CloudSyncEngine.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import type { Org2CloudOrg } from "./org2CloudOrgsAtom";
-import { buildOrg2CloudSyncRosterKey } from "./useOrg2CloudSyncEngine";
+import {
+  buildOrg2CloudSyncRosterKey,
+  shouldEnableExternalHistoryBackgroundScan,
+} from "./useOrg2CloudSyncEngine";
 
 describe("buildOrg2CloudSyncRosterKey", () => {
   const org: Org2CloudOrg = {
@@ -24,5 +27,25 @@ describe("buildOrg2CloudSyncRosterKey", () => {
     expect(buildOrg2CloudSyncRosterKey([org, other])).toBe(
       buildOrg2CloudSyncRosterKey([other, org])
     );
+  });
+
+  it("requires a loaded signed-in roster with at least one background org", () => {
+    const backgroundOrg = { ...org, offlineSyncEnabled: true };
+    expect(
+      shouldEnableExternalHistoryBackgroundScan("identity-1", true, [
+        backgroundOrg,
+      ])
+    ).toBe(true);
+    expect(
+      shouldEnableExternalHistoryBackgroundScan(null, true, [backgroundOrg])
+    ).toBe(false);
+    expect(
+      shouldEnableExternalHistoryBackgroundScan("identity-1", false, [
+        backgroundOrg,
+      ])
+    ).toBe(false);
+    expect(
+      shouldEnableExternalHistoryBackgroundScan("identity-1", true, [org])
+    ).toBe(false);
   });
 });

--- a/src/features/Org2Cloud/useOrg2CloudSyncEngine.ts
+++ b/src/features/Org2Cloud/useOrg2CloudSyncEngine.ts
@@ -11,9 +11,10 @@
  *    re-lists collab state under the new identity instead of trusting
  *    another account's in-memory cursors for the same org ids.
  */
-import { useAtomValue } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import { useEffect } from "react";
 
+import { externalHistoryBackgroundScanEnabledAtom } from "@src/store/session/dataSourceConfigAtom";
 import { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";
 
 import { memberRuntimePushScheduler } from "./memberRuntime/memberRuntimePushScheduler";
@@ -49,12 +50,41 @@ export function buildOrg2CloudSyncRosterKey(
   );
 }
 
+export function shouldEnableExternalHistoryBackgroundScan(
+  authIdentityKey: string | null,
+  orgsLoaded: boolean,
+  orgs: readonly Org2CloudOrg[]
+): boolean {
+  return Boolean(
+    authIdentityKey && orgsLoaded && orgs.some(isOrgBackgroundUploadEnabled)
+  );
+}
+
 export function useOrg2CloudSyncEngine(): void {
   const auth = useAtomValue(org2CloudAuthAtom);
   const authIdentityKey = auth ? org2CloudAuthIdentityKey(auth) : null;
   const orgs = useAtomValue(org2CloudOrgsAtom);
   const orgsLoaded = useAtomValue(org2CloudOrgsLoadedAtom);
+  const setExternalHistoryBackgroundScanEnabled = useSetAtom(
+    externalHistoryBackgroundScanEnabledAtom
+  );
   const rosterKey = buildOrg2CloudSyncRosterKey(orgs);
+  const externalHistoryBackgroundScanEnabled =
+    shouldEnableExternalHistoryBackgroundScan(
+      authIdentityKey,
+      orgsLoaded,
+      orgs
+    );
+
+  useEffect(() => {
+    setExternalHistoryBackgroundScanEnabled(
+      externalHistoryBackgroundScanEnabled
+    );
+    return () => setExternalHistoryBackgroundScanEnabled(false);
+  }, [
+    externalHistoryBackgroundScanEnabled,
+    setExternalHistoryBackgroundScanEnabled,
+  ]);
 
   useEffect(() => {
     // stop() is idempotent and also covers the A→B switch (no null between):

--- a/src/store/session/__tests__/useDataSourceAutoScan.test.ts
+++ b/src/store/session/__tests__/useDataSourceAutoScan.test.ts
@@ -560,4 +560,43 @@ describe("startDataSourceAutoScanScheduler", () => {
 
     scheduler.stop();
   });
+
+  it("keeps one hidden timer only while background history freshness is required", async () => {
+    vi.useFakeTimers();
+    const source = new VisibilitySourceStub();
+    source.visibilityState = "hidden";
+    const scan = vi.fn().mockResolvedValue(undefined);
+    let backgroundRequired = true;
+    const scheduler = startDataSourceAutoScanScheduler(
+      source,
+      scan,
+      () => 30_000,
+      30_000,
+      () => backgroundRequired
+    );
+
+    expect(scan).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(vi.getTimerCount()).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(scan).toHaveBeenCalledTimes(2);
+    expect(vi.getTimerCount()).toBe(1);
+
+    backgroundRequired = false;
+    scheduler.schedule();
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(scan).toHaveBeenCalledTimes(2);
+
+    backgroundRequired = true;
+    scheduler.schedule();
+    expect(vi.getTimerCount()).toBe(1);
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(scan).toHaveBeenCalledTimes(3);
+    expect(vi.getTimerCount()).toBe(1);
+
+    scheduler.stop();
+    expect(vi.getTimerCount()).toBe(0);
+  });
 });

--- a/src/store/session/dataSourceConfigAtom.ts
+++ b/src/store/session/dataSourceConfigAtom.ts
@@ -123,6 +123,19 @@ export const dataSourcePresenceAtom = atomWithStorage<
  */
 export const dataSourceRosterSignaturesAtom = atom<Record<string, string>>({});
 
+/**
+ * Runtime-only demand signal for keeping enabled external-history providers
+ * fresh while the document is hidden. Cloud collaboration raises this while
+ * at least one accessible org has Background upload enabled; the scanner owns
+ * the cadence and still honors the master switch, per-source enablement, and
+ * explicit manual frequency.
+ *
+ * This is deliberately not persisted: cloud policy is authoritative and is
+ * re-established after the signed-in roster loads. Keeping the atom in the
+ * data-source layer avoids a reverse dependency from the scanner into Cloud.
+ */
+export const externalHistoryBackgroundScanEnabledAtom = atom(false);
+
 const EXTERNAL_SESSIONS_ENABLED_STORAGE_KEY = "orgii:externalSessionsEnabled";
 
 /**

--- a/src/store/session/useDataSourceAutoScan.ts
+++ b/src/store/session/useDataSourceAutoScan.ts
@@ -16,8 +16,9 @@
  * at startup.
  *
  * Config is read straight from the shared store on each tick, so the interval is
- * armed once and always sees the latest values without re-arming. The timer is
- * paused while the document is hidden and catches up immediately on return.
+ * armed once and always sees the latest values without re-arming. Hidden windows
+ * pause by default; an explicit app-wide background-upload demand keeps one
+ * low-frequency timer alive and catches up immediately when it is enabled.
  */
 import { useEffect } from "react";
 
@@ -42,6 +43,7 @@ import {
   dataSourcePresenceAtom,
   dataSourceRosterSignaturesAtom,
   effectiveFrequency,
+  externalHistoryBackgroundScanEnabledAtom,
   externalSessionsEnabledAtom,
   getSourceConfig,
 } from "./dataSourceConfigAtom";
@@ -136,7 +138,10 @@ async function performDataSourceAutoScan(force: boolean): Promise<void> {
   const global = store.get(dataSourceGlobalFrequencyAtom);
   const now = Date.now();
 
-  const focused = isWindowFocused();
+  const focused =
+    (typeof document === "undefined" ||
+      document.visibilityState !== "hidden") &&
+    isWindowFocused();
   const candidates = IMPORTED_HISTORY_SOURCE_DESCRIPTORS.flatMap(
     ({ sourceId }) => {
       const cfg = getSourceConfig(cfgMap, sourceId);
@@ -284,15 +289,18 @@ interface DataSourceAutoScanScheduler {
 
 /**
  * Own the scheduler's one exact-deadline timeout. Hidden documents clear the
- * timer; becoming visible triggers one immediate due-check and re-arms the
- * chain. Failed scans retry after a bounded delay without creating a second
- * timer or overlapping an active scan.
+ * timer unless an explicit background consumer requires fresh external
+ * history; that path uses the same unfocused cadence floor. Becoming visible
+ * triggers one immediate due-check and re-arms the chain. Failed scans retry
+ * after a bounded delay without creating a second timer or overlapping an
+ * active scan.
  */
 export function startDataSourceAutoScanScheduler(
   source: DataSourceAutoScanVisibilitySource,
   scan: (force?: boolean) => Promise<void>,
   nextDelay: () => number | null,
-  failedScanRetryMs = FAILED_SCAN_RETRY_MS
+  failedScanRetryMs = FAILED_SCAN_RETRY_MS,
+  shouldScanWhileHidden: () => boolean = () => false
 ): DataSourceAutoScanScheduler {
   let stopped = false;
   let running = false;
@@ -304,9 +312,11 @@ export function startDataSourceAutoScanScheduler(
     clearTimeout(timeoutId);
     timeoutId = undefined;
   };
+  const hiddenAndPaused = () =>
+    source.visibilityState === "hidden" && !shouldScanWhileHidden();
   const schedule = () => {
     clearTimer();
-    if (stopped || running || source.visibilityState === "hidden") return;
+    if (stopped || running || hiddenAndPaused()) return;
     const delay = nextDelay();
     if (delay == null) return;
     timeoutId = setTimeout(
@@ -319,7 +329,7 @@ export function startDataSourceAutoScanScheduler(
   };
   const trigger = (force = false) => {
     clearTimer();
-    if (stopped || running || source.visibilityState === "hidden") return;
+    if (stopped || running || hiddenAndPaused()) return;
     running = true;
     void scan(force)
       .then(
@@ -337,7 +347,8 @@ export function startDataSourceAutoScanScheduler(
   };
   const onVisibilityChange = () => {
     clearTimer();
-    if (source.visibilityState !== "hidden") trigger();
+    if (source.visibilityState === "hidden") schedule();
+    else trigger();
   };
 
   source.addEventListener("visibilitychange", onVisibilityChange);
@@ -364,12 +375,14 @@ export function useDataSourceAutoScan(): void {
       () =>
         nextDataSourceAutoScanDelay(
           Date.now(),
-          isWindowFocused(),
+          document.visibilityState !== "hidden" && isWindowFocused(),
           store.get(externalSessionsEnabledAtom),
           store.get(dataSourceConfigAtom),
           store.get(dataSourcePresenceAtom),
           store.get(dataSourceGlobalFrequencyAtom)
-        )
+        ),
+      FAILED_SCAN_RETRY_MS,
+      () => store.get(externalHistoryBackgroundScanEnabledAtom)
     );
     // A visible but unfocused window retains the low-frequency background
     // safety floor. Regaining focus immediately checks foreground cadences.
@@ -381,6 +394,7 @@ export function useDataSourceAutoScan(): void {
       store.sub(dataSourcePresenceAtom, scheduler.schedule),
       store.sub(dataSourceGlobalFrequencyAtom, scheduler.schedule),
       store.sub(externalSessionsEnabledAtom, scheduler.schedule),
+      store.sub(externalHistoryBackgroundScanEnabledAtom, scheduler.schedule),
     ];
     return () => {
       unsubscribeFocus();


### PR DESCRIPTION
## Problem

Codex App and other imported-history sessions could stop advancing in ORG2 Cloud after the app window became hidden, even when an accessible organization had Background upload enabled.

The failure had three linked causes:

- the external-history scheduler paused whenever the document was hidden and did not consume Cloud background-upload policy;
- imported-history rescans update `sessionsAtom` directly, bypassing the EventStore activity signal used by Cloud sync;
- the 30-second imported-history quiet gate recorded its first observation inside the cloud pass, so publishing could require an unrelated second trigger.

The result was a successful-looking Cloud pass that could keep re-uploading stale imported metadata while fresh imported-provider data remained only on disk.

## Solution

- Derive a runtime-only external-history background demand signal from the authenticated, loaded org roster. It is enabled only while at least one accessible org has Background upload on.
- Let the existing single auto-scan scheduler retain one low-frequency hidden-window timer while that demand exists. The master external-session switch, per-source enablement, manual cadence, and the 10-minute unfocused floor remain authoritative.
- Observe locally owned imported-session roster versions in the concrete Cloud engine, stamp meaningful `updated_at` changes, and reuse the existing 30-second external-history quiet timer to coalesce them into one pass.
- Preserve the pre-stamped activity time when the delayed pass first sees a new imported version, allowing that pass to publish without waiting for an unrelated future event.
- Unsubscribe and clear the bounded roster-version map on engine stop.

The trigger is intentionally provider-agnostic through `isImportedHistorySession`; it covers Claude Code, Cursor, Codex, and the other imported-history adapters without provider-specific branches. This adds no database migration, persistence-format change, public API change, or wire-protocol change.

## Potential risks

- Hidden apps with Background upload enabled now perform the intended incremental external-history work. The default worst-case convergence is the existing 10-minute unfocused cadence plus the 30-second quiet window, so this intentionally trades bounded background I/O for convergence.
- The roster observer scans the current paginated `sessionsAtom` on roster writes. Its map is bounded to the current roster and is cleared on stop; it is not attached to the EventStore streaming hot path.
- Imported files larger than an adapter's existing safety threshold retain that adapter's quiet-period/parsing behavior. This PR does not relax those separate CPU/memory guards.
- A second-account viewer was not used to independently render the synthetic remote rows. Source discovery, provider-specific cache advancement, hidden-window trigger timing, and successful Managed Cloud passes were verified on-device; inactive-org selection and publishing are also covered at the Cloud client boundary by the regression test.
- Rollback is a normal revert of this commit; no stored data or schema recovery is required.

## Architecture audit

Covered compilation/types, control-flow ownership, naming/defaults, dependency direction, lifecycle teardown, wire compatibility, and root initialization parity. The scanner remains Cloud-agnostic through a neutral runtime atom, while the concrete Cloud engine owns the `sessionsAtom` subscription. No resolver, schema, or protocol layer changed.

## Performance guard

- Timer cardinality: one existing scan timeout and one existing coalesced external-history Cloud timeout; no new polling loop.
- Idle/hidden lifecycle: no hidden scan without authenticated background-upload demand; the 10-minute unfocused floor remains.
- Memory: one current-roster-bounded version map, rebuilt in place and cleared on stop.
- Isolation: the demand atom and version map are process/store local; secondary profiles retain their isolated external-history homes.
- Hot path: no EventStore stream subscription and no render-path work.

## Verification

Automated checks run successfully:

- `pnpm exec vitest run src/store/session/__tests__/useDataSourceAutoScan.test.ts src/features/Org2Cloud/useOrg2CloudSyncEngine.test.ts src/features/Org2Cloud/org2CloudSyncEngine.sessions.test.ts` — 3 files, 74 tests passed.
- `pnpm test` — full frontend test suite passed.
- `pnpm typecheck` — passed.
- `pnpm check:circular` — no circular dependencies across 6,144 modules.
- `pnpm build` — passed.
- `pnpm cargo:check` — passed.
- `pnpm cargo:clippy` — passed; only the existing future-incompatibility warning for dependency `block v0.1.6` remained.
- `git diff --check` — passed.
- GitHub CI: Frontend, Rust clippy, and attribution checks all passed.

Isolated real-app / Managed Cloud provider matrix:

- Built and ran a separate signed-in Instance 2 profile with its own external-history home; the primary app and real provider histories were not modified.
- Enabled Background upload for a scoped test org, then created synthetic Claude Code JSONL, Codex rollout JSONL, and Cursor `state.vscdb` histories pointing at the ORG2 repo.
- The real source adapters discovered one Ready session for each provider (`claude_code`, `codex_app`, `cursor_ide`).
- While the app was hidden, all three histories advanced in the imported cache: Claude Code to 3,690 bytes and 75/135 input/output tokens, Codex to 2,232 bytes, and Cursor to revision F with 210 input tokens.
- With the unmodified PR build hidden, the persisted successful Cloud-pass timestamp advanced at 11:28:05.364, 30.08 seconds after the three-provider cache write at 11:27:35, without clicking Sync now. The in-app sync log remained empty of warnings/errors.
- A five-sample hidden-idle process check reported CPU `3.2%, 0.0%, 0.0%, 0.0%, 0.0%` and RSS `181,456–181,696 KiB`; the first sample covered the just-hidden transition and the following four were idle.
- Restored the isolated profile's scan cadence from the temporary 60-second test value to the default 10 minutes before teardown.

No UI screenshot is attached because this PR changes background behavior only and introduces no user-visible component or state.
