### PR TITLE
fix(terminal): compile Linux tpgid tests under pty

### DIFF
--- a/src-tauri/crates/terminal/src/pty_commands/pty.rs
+++ b/src-tauri/crates/terminal/src/pty_commands/pty.rs
@@ -1080,6 +1080,30 @@ mod tests {
     use super::{collect_sweep_sids, leader_is_sweep_candidate, pending_exit_session_leaders};
     use std::collections::HashMap;
 
+    #[cfg(target_os = "linux")]
+    mod parse_tpgid_tests {
+        use super::super::parse_tpgid_from_stat;
+
+        #[test]
+        fn parses_standard_stat() {
+            // pid (comm) state ppid pgrp session tty_nr tpgid ...
+            let stat = "12345 (bash) S 1 12345 12345 34816 12400 4194304";
+            assert_eq!(parse_tpgid_from_stat(stat), Some(12400));
+        }
+
+        #[test]
+        fn parses_comm_with_spaces() {
+            let stat = "12345 (my shell) S 1 12345 12345 34816 99999 4194304";
+            assert_eq!(parse_tpgid_from_stat(stat), Some(99999));
+        }
+
+        #[test]
+        fn rejects_invalid_stat() {
+            assert_eq!(parse_tpgid_from_stat("garbage"), None);
+            assert_eq!(parse_tpgid_from_stat(""), None);
+        }
+    }
+
     // The session-leader registry is a process-global static shared across
     // tests; this helper drains it so each case starts from a known state.
     fn reset_registry() {

--- a/src-tauri/crates/terminal/src/pty_commands/tests/shells_tests.rs
+++ b/src-tauri/crates/terminal/src/pty_commands/tests/shells_tests.rs
@@ -174,31 +174,3 @@ fn test_shell_categories() {
     assert_eq!(ShellKind::Python.category(), ShellCategory::Repl);
     assert_eq!(ShellKind::Ruby.category(), ShellCategory::Repl);
 }
-
-// ============================================
-// Linux-specific: parse_tpgid_from_stat
-// ============================================
-
-#[cfg(target_os = "linux")]
-mod linux_tests {
-    use super::super::parse_tpgid_from_stat;
-
-    #[test]
-    fn test_parse_tpgid_standard() {
-        // pid (comm) state ppid pgrp session tty_nr tpgid ...
-        let stat = "12345 (bash) S 1 12345 12345 34816 12400 4194304";
-        assert_eq!(parse_tpgid_from_stat(stat), Some(12400));
-    }
-
-    #[test]
-    fn test_parse_tpgid_comm_with_spaces() {
-        let stat = "12345 (my shell) S 1 12345 12345 34816 99999 4194304";
-        assert_eq!(parse_tpgid_from_stat(stat), Some(99999));
-    }
-
-    #[test]
-    fn test_parse_tpgid_invalid() {
-        assert_eq!(parse_tpgid_from_stat("garbage"), None);
-        assert_eq!(parse_tpgid_from_stat(""), None);
-    }
-}


### PR DESCRIPTION
## Problem

On Linux, `cargo test --workspace --no-run` and Clippy with all targets fail before running tests with E0432: `shells_tests.rs` imports `parse_tpgid_from_stat` from the wrong module.

`shells.rs` mounts that file as `pty_commands::shells::tests`, so the nested Linux test module resolves `super::super` to `pty_commands::shells`. The private helper actually belongs to the sibling `pty_commands::pty` module, making the test target uncompilable on Linux.

## Solution

Move the three Linux `parse_tpgid_from_stat` tests into the existing `pty.rs` test module.

The tests are now descendants of the module that owns the private helper, so they can exercise it without widening production visibility. Runtime code and behavior are unchanged.

## Potential risks

The runtime risk is low because this changes only test placement and test names. Any external test filtering that referenced the old fully qualified test paths would need to use the new `pty_commands::pty::tests::parse_tpgid_tests` paths.

This PR does not clean the separate pre-existing Linux warnings or add Linux CI coverage. It was verified on Linux x86_64; macOS and Windows test execution was not repeated because the moved tests remain Linux-gated.

## Verification

- `cargo test -p terminal parse_tpgid` — passed: 3 passed, 0 failed.
- `cargo test --workspace --no-run` — passed and generated every workspace test executable; the previous E0432 is gone.
- `cargo clippy -p terminal --all-targets` — exited successfully; the separate pre-existing `get_process_name_ps` warning remains.
- `rustfmt --edition 2021 --check src-tauri/crates/terminal/src/pty_commands/pty.rs src-tauri/crates/terminal/src/pty_commands/tests/shells_tests.rs` — passed.
- `git diff --check origin/develop...HEAD` — passed.
- Commit hook scoped Clippy to `terminal` — passed.

The full `cargo test --workspace` suite was not executed; the workspace test targets were compiled with `--no-run`, and the three affected tests were executed directly.

## UI evidence

Not applicable: this PR changes only Rust test ownership and has no user-visible UI behavior.