### PR TITLE
fix(key-vault): make CLI OAuth autodetect reliable

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3922,6 +3922,7 @@ dependencies = [
  "dirs",
  "insta",
  "integrations",
+ "libc",
  "log",
  "nucleo-matcher",
  "orgtrack_core",
@@ -3939,6 +3940,7 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3937,10 +3937,12 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tracing",
+ "unicode-normalization",
  "url",
  "urlencoding",
  "uuid",
  "windows-sys 0.60.2",
+ "zeroize",
 ]
 
 [[package]]

--- a/src-tauri/crates/key-vault/Cargo.toml
+++ b/src-tauri/crates/key-vault/Cargo.toml
@@ -43,6 +43,8 @@ tracing = "0.1.37"
 uuid = { version = "1", features = ["v4"] }
 dirs = "6.0"
 sha2 = "0.10"
+unicode-normalization = "0.1"
+zeroize = "1.8"
 
 # `auto_detect/cursor.rs` reads the Cursor IDE's SQLite vault to capture the
 # user's existing session token; the encoded value is base64.
@@ -66,6 +68,7 @@ libc = "0.2"
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.60", features = [
     "Win32_Foundation",
+    "Win32_Security_Credentials",
     "Win32_System_Diagnostics_ToolHelp",
     "Win32_System_Threading",
 ] }

--- a/src-tauri/crates/key-vault/Cargo.toml
+++ b/src-tauri/crates/key-vault/Cargo.toml
@@ -43,8 +43,6 @@ tracing = "0.1.37"
 uuid = { version = "1", features = ["v4"] }
 dirs = "6.0"
 sha2 = "0.10"
-unicode-normalization = "0.1"
-zeroize = "1.8"
 
 # `auto_detect/cursor.rs` reads the Cursor IDE's SQLite vault to capture the
 # user's existing session token; the encoded value is base64.
@@ -66,6 +64,8 @@ arboard = "3"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
+unicode-normalization = "0.1"
+zeroize = "1.8"
 windows-sys = { version = "0.60", features = [
     "Win32_Foundation",
     "Win32_Security_Credentials",

--- a/src-tauri/crates/key-vault/Cargo.toml
+++ b/src-tauri/crates/key-vault/Cargo.toml
@@ -60,6 +60,16 @@ nucleo-matcher = "0.3"
 # permission is denied.
 arboard = "3"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.60", features = [
+    "Win32_Foundation",
+    "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_Threading",
+] }
+
 [dev-dependencies]
 tempfile = "3.13"
 insta = { version = "1", features = ["yaml", "redactions"] }

--- a/src-tauri/crates/key-vault/src/auto_detect/claude.rs
+++ b/src-tauri/crates/key-vault/src/auto_detect/claude.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::env;
 use std::fs;
-#[cfg(any(target_os = "macos", windows))]
+#[cfg(target_os = "macos")]
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -21,7 +21,6 @@ const CLAUDE_CODE_TOKEN_REFRESH_SKEW_SECONDS: i64 = 60;
 const CLAUDE_CODE_OAUTH_PROFILE_URL: &str = "https://api.anthropic.com/api/oauth/profile";
 const CLAUDE_CODE_OAUTH_BETA: &str = "oauth-2025-04-20";
 const CLAUDE_CODE_OAUTH_USER_AGENT: &str = "claude-cli/2.1.78 (orgii, cli)";
-pub(super) const CLAUDE_SECURESTORAGE_CONFIG_DIR_ENV: &str = "CLAUDE_SECURESTORAGE_CONFIG_DIR";
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -234,6 +233,7 @@ async fn read_claude_config(path: &std::path::PathBuf) -> Option<DetectedKey> {
 }
 
 async fn detect_claude_code_oauth() -> Option<DetectedKey> {
+    #[cfg(windows)]
     // Credential Manager can require multiple bounded reads for Claude's
     // chunked format, so keep all local credential I/O off the async executor.
     let credentials_json = match tokio::task::spawn_blocking(read_local_claude_credentials).await {
@@ -246,6 +246,8 @@ async fn detect_claude_code_oauth() -> Option<DetectedKey> {
             return None;
         }
     };
+    #[cfg(not(windows))]
+    let credentials_json = read_local_claude_credentials()?;
     let credentials = parse_claude_oauth_credentials(&credentials_json)?;
     let access_token = credentials.access_token?.trim().to_string();
     if access_token.is_empty() {
@@ -318,9 +320,10 @@ fn read_local_claude_credentials() -> Option<String> {
     None
 }
 
+#[cfg(windows)]
 fn get_claude_credentials_paths() -> Vec<PathBuf> {
     let mut paths = vec![];
-    if let Ok(config_dir) = env::var(CLAUDE_SECURESTORAGE_CONFIG_DIR_ENV) {
+    if let Ok(config_dir) = env::var(super::claude_windows::CLAUDE_SECURESTORAGE_CONFIG_DIR_ENV) {
         let trimmed = config_dir.trim();
         if !trimmed.is_empty() {
             paths.push(PathBuf::from(trimmed).join(".credentials.json"));
@@ -340,6 +343,21 @@ fn get_claude_credentials_paths() -> Vec<PathBuf> {
         if !paths.contains(&path) {
             paths.push(path);
         }
+    }
+    paths
+}
+
+#[cfg(not(windows))]
+fn get_claude_credentials_paths() -> Vec<PathBuf> {
+    let mut paths = vec![];
+    if let Ok(config_dir) = env::var("CLAUDE_CONFIG_DIR") {
+        let trimmed = config_dir.trim();
+        if !trimmed.is_empty() {
+            paths.push(PathBuf::from(trimmed).join(".credentials.json"));
+        }
+    }
+    if let Some(home) = get_home_dir() {
+        paths.push(home.join(".claude/.credentials.json"));
     }
     paths
 }
@@ -520,37 +538,23 @@ fn read_claude_keychain_credentials() -> Option<String> {
 #[cfg(target_os = "macos")]
 fn get_claude_keychain_config_dirs() -> Vec<PathBuf> {
     let mut config_dirs = Vec::new();
-    if let Ok(config_dir) = env::var(CLAUDE_SECURESTORAGE_CONFIG_DIR_ENV) {
+    if let Ok(config_dir) = env::var("CLAUDE_CONFIG_DIR") {
         let trimmed = config_dir.trim();
         if !trimmed.is_empty() {
             config_dirs.push(PathBuf::from(trimmed));
         }
     }
-    if let Ok(config_dir) = env::var("CLAUDE_CONFIG_DIR") {
-        let trimmed = config_dir.trim();
-        if !trimmed.is_empty() {
-            let path = PathBuf::from(trimmed);
-            if !config_dirs.contains(&path) {
-                config_dirs.push(path);
-            }
-        }
-    }
     if let Some(home) = get_home_dir() {
-        let path = home.join(".claude");
-        if !config_dirs.contains(&path) {
-            config_dirs.push(path);
-        }
+        config_dirs.push(home.join(".claude"));
     }
     config_dirs
 }
 
-#[cfg(any(target_os = "macos", windows))]
-pub(super) fn scoped_claude_keychain_service(config_dir: &Path) -> String {
+#[cfg(target_os = "macos")]
+fn scoped_claude_keychain_service(config_dir: &Path) -> String {
     use sha2::{Digest, Sha256};
-    use unicode_normalization::UnicodeNormalization;
 
-    let normalized = config_dir.to_string_lossy().nfc().collect::<String>();
-    let suffix = Sha256::digest(normalized.as_bytes());
+    let suffix = Sha256::digest(config_dir.to_string_lossy().as_bytes());
     format!("Claude Code-credentials-{:x}", suffix)
         .chars()
         .take("Claude Code-credentials-".len() + 8)

--- a/src-tauri/crates/key-vault/src/auto_detect/claude.rs
+++ b/src-tauri/crates/key-vault/src/auto_detect/claude.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::env;
 use std::fs;
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", windows))]
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -21,6 +21,7 @@ const CLAUDE_CODE_TOKEN_REFRESH_SKEW_SECONDS: i64 = 60;
 const CLAUDE_CODE_OAUTH_PROFILE_URL: &str = "https://api.anthropic.com/api/oauth/profile";
 const CLAUDE_CODE_OAUTH_BETA: &str = "oauth-2025-04-20";
 const CLAUDE_CODE_OAUTH_USER_AGENT: &str = "claude-cli/2.1.78 (orgii, cli)";
+pub(super) const CLAUDE_SECURESTORAGE_CONFIG_DIR_ENV: &str = "CLAUDE_SECURESTORAGE_CONFIG_DIR";
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -233,7 +234,18 @@ async fn read_claude_config(path: &std::path::PathBuf) -> Option<DetectedKey> {
 }
 
 async fn detect_claude_code_oauth() -> Option<DetectedKey> {
-    let credentials_json = read_local_claude_credentials()?;
+    // Credential Manager can require multiple bounded reads for Claude's
+    // chunked format, so keep all local credential I/O off the async executor.
+    let credentials_json = match tokio::task::spawn_blocking(read_local_claude_credentials).await {
+        Ok(credentials) => credentials?,
+        Err(err) => {
+            tracing::warn!(
+                error = %err,
+                "auto_detect::claude: local OAuth credential task failed; skipping"
+            );
+            return None;
+        }
+    };
     let credentials = parse_claude_oauth_credentials(&credentials_json)?;
     let access_token = credentials.access_token?.trim().to_string();
     if access_token.is_empty() {
@@ -308,14 +320,26 @@ fn read_local_claude_credentials() -> Option<String> {
 
 fn get_claude_credentials_paths() -> Vec<PathBuf> {
     let mut paths = vec![];
-    if let Ok(config_dir) = env::var("CLAUDE_CONFIG_DIR") {
+    if let Ok(config_dir) = env::var(CLAUDE_SECURESTORAGE_CONFIG_DIR_ENV) {
         let trimmed = config_dir.trim();
         if !trimmed.is_empty() {
             paths.push(PathBuf::from(trimmed).join(".credentials.json"));
         }
     }
+    if let Ok(config_dir) = env::var("CLAUDE_CONFIG_DIR") {
+        let trimmed = config_dir.trim();
+        if !trimmed.is_empty() {
+            let path = PathBuf::from(trimmed).join(".credentials.json");
+            if !paths.contains(&path) {
+                paths.push(path);
+            }
+        }
+    }
     if let Some(home) = get_home_dir() {
-        paths.push(home.join(".claude/.credentials.json"));
+        let path = home.join(".claude/.credentials.json");
+        if !paths.contains(&path) {
+            paths.push(path);
+        }
     }
     paths
 }
@@ -483,7 +507,12 @@ fn read_claude_keychain_credentials() -> Option<String> {
     None
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(windows)]
+fn read_claude_keychain_credentials() -> Option<String> {
+    super::claude_windows::read_credentials()
+}
+
+#[cfg(not(any(target_os = "macos", windows)))]
 fn read_claude_keychain_credentials() -> Option<String> {
     None
 }
@@ -491,23 +520,37 @@ fn read_claude_keychain_credentials() -> Option<String> {
 #[cfg(target_os = "macos")]
 fn get_claude_keychain_config_dirs() -> Vec<PathBuf> {
     let mut config_dirs = Vec::new();
-    if let Ok(config_dir) = env::var("CLAUDE_CONFIG_DIR") {
+    if let Ok(config_dir) = env::var(CLAUDE_SECURESTORAGE_CONFIG_DIR_ENV) {
         let trimmed = config_dir.trim();
         if !trimmed.is_empty() {
             config_dirs.push(PathBuf::from(trimmed));
         }
     }
+    if let Ok(config_dir) = env::var("CLAUDE_CONFIG_DIR") {
+        let trimmed = config_dir.trim();
+        if !trimmed.is_empty() {
+            let path = PathBuf::from(trimmed);
+            if !config_dirs.contains(&path) {
+                config_dirs.push(path);
+            }
+        }
+    }
     if let Some(home) = get_home_dir() {
-        config_dirs.push(home.join(".claude"));
+        let path = home.join(".claude");
+        if !config_dirs.contains(&path) {
+            config_dirs.push(path);
+        }
     }
     config_dirs
 }
 
-#[cfg(target_os = "macos")]
-fn scoped_claude_keychain_service(config_dir: &Path) -> String {
+#[cfg(any(target_os = "macos", windows))]
+pub(super) fn scoped_claude_keychain_service(config_dir: &Path) -> String {
     use sha2::{Digest, Sha256};
+    use unicode_normalization::UnicodeNormalization;
 
-    let suffix = Sha256::digest(config_dir.to_string_lossy().as_bytes());
+    let normalized = config_dir.to_string_lossy().nfc().collect::<String>();
+    let suffix = Sha256::digest(normalized.as_bytes());
     format!("Claude Code-credentials-{:x}", suffix)
         .chars()
         .take("Claude Code-credentials-".len() + 8)

--- a/src-tauri/crates/key-vault/src/auto_detect/claude_windows.rs
+++ b/src-tauri/crates/key-vault/src/auto_detect/claude_windows.rs
@@ -1,0 +1,258 @@
+//! Claude Code OAuth credentials stored through Bun's Windows secrets backend.
+//!
+//! Bun maps `{ service, name }` to a generic Credential Manager target named
+//! `service/name`. Claude stores short JSON directly and larger JSON as a
+//! bounded base64 manifest plus numbered chunks. Detection is on-demand only,
+//! reads exact Claude-owned targets, and never enumerates unrelated credentials.
+
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use serde::Deserialize;
+use zeroize::Zeroizing;
+
+#[cfg(windows)]
+use super::claude::{scoped_claude_keychain_service, CLAUDE_SECURESTORAGE_CONFIG_DIR_ENV};
+
+const CREDENTIAL_ACCOUNT: &str = "claude-code-user";
+const CREDENTIAL_CHUNK_BYTES: usize = 2_400;
+const CREDENTIAL_MAX_CHUNKS: usize = 256;
+
+#[derive(Debug, Deserialize)]
+struct CredentialManifest {
+    n: usize,
+    l: usize,
+}
+
+#[cfg(windows)]
+pub(super) fn read_credentials() -> Option<String> {
+    let services = credential_services();
+    read_credentials_with(&services, read_windows_generic_credential)
+}
+
+#[cfg(windows)]
+fn credential_services() -> Vec<String> {
+    let configured_dir = std::env::var(CLAUDE_SECURESTORAGE_CONFIG_DIR_ENV)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            std::env::var("CLAUDE_CONFIG_DIR")
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        });
+    let mut services = configured_dir
+        .map(|config_dir| {
+            vec![scoped_claude_keychain_service(std::path::Path::new(
+                config_dir.trim(),
+            ))]
+        })
+        .unwrap_or_default();
+    services.push("Claude Code-credentials".to_string());
+    services
+}
+
+fn read_credentials_with<F>(services: &[String], mut read_credential: F) -> Option<String>
+where
+    F: FnMut(&str, usize) -> Option<Zeroizing<Vec<u8>>>,
+{
+    for service in services {
+        let target = format!("{service}/{CREDENTIAL_ACCOUNT}");
+        if let Some(credentials) = read_credential(&target, CREDENTIAL_CHUNK_BYTES)
+            .and_then(|bytes| credential_bytes_to_string(&bytes))
+        {
+            return Some(credentials);
+        }
+
+        let marker_target = format!("{target}#m");
+        let Some(marker) = read_credential(&marker_target, CREDENTIAL_CHUNK_BYTES) else {
+            continue;
+        };
+        let Ok(manifest) = serde_json::from_slice::<CredentialManifest>(&marker) else {
+            continue;
+        };
+        if manifest.n == 0
+            || manifest.n > CREDENTIAL_MAX_CHUNKS
+            || manifest.l == 0
+            || manifest.l > manifest.n.saturating_mul(CREDENTIAL_CHUNK_BYTES)
+        {
+            continue;
+        }
+
+        let mut encoded = Zeroizing::new(Vec::with_capacity(manifest.l));
+        let mut complete = true;
+        for chunk_index in 0..manifest.n {
+            let chunk_target = format!("{target}#{chunk_index}");
+            let Some(chunk) = read_credential(&chunk_target, CREDENTIAL_CHUNK_BYTES) else {
+                complete = false;
+                break;
+            };
+            encoded.extend_from_slice(&chunk);
+            if encoded.len() > manifest.l {
+                complete = false;
+                break;
+            }
+        }
+        if !complete || encoded.len() != manifest.l {
+            continue;
+        }
+
+        let Ok(decoded) = STANDARD.decode(encoded.as_slice()) else {
+            continue;
+        };
+        let decoded = Zeroizing::new(decoded);
+        if let Some(credentials) = credential_bytes_to_string(&decoded) {
+            return Some(credentials);
+        }
+    }
+
+    None
+}
+
+fn credential_bytes_to_string(bytes: &[u8]) -> Option<String> {
+    let value = std::str::from_utf8(bytes).ok()?.trim();
+    if value.is_empty()
+        || !serde_json::from_str::<serde_json::Value>(value)
+            .ok()?
+            .get("claudeAiOauth")?
+            .is_object()
+    {
+        return None;
+    }
+    Some(value.to_string())
+}
+
+#[cfg(windows)]
+fn read_windows_generic_credential(target: &str, max_bytes: usize) -> Option<Zeroizing<Vec<u8>>> {
+    use std::ptr;
+    use windows_sys::Win32::Foundation::{GetLastError, ERROR_NOT_FOUND};
+    use windows_sys::Win32::Security::Credentials::{
+        CredFree, CredReadW, CREDENTIALW, CRED_TYPE_GENERIC,
+    };
+
+    struct CredentialGuard(*mut CREDENTIALW);
+
+    impl Drop for CredentialGuard {
+        fn drop(&mut self) {
+            if !self.0.is_null() {
+                unsafe { CredFree(self.0.cast()) };
+            }
+        }
+    }
+
+    let target_wide = target
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect::<Vec<_>>();
+    let mut credential = ptr::null_mut();
+    if unsafe { CredReadW(target_wide.as_ptr(), CRED_TYPE_GENERIC, 0, &mut credential) } == 0 {
+        let error = unsafe { GetLastError() };
+        if error != ERROR_NOT_FOUND {
+            tracing::warn!(
+                error,
+                "auto_detect::claude: Windows Credential Manager read failed; skipping"
+            );
+        }
+        return None;
+    }
+
+    let credential = CredentialGuard(credential);
+    let value = unsafe { credential.0.as_ref() }?;
+    let blob_len = value.CredentialBlobSize as usize;
+    if blob_len == 0 || blob_len > max_bytes || value.CredentialBlob.is_null() {
+        return None;
+    }
+
+    let mut bytes = Zeroizing::new(vec![0_u8; blob_len]);
+    unsafe {
+        ptr::copy_nonoverlapping(value.CredentialBlob, bytes.as_mut_ptr(), blob_len);
+    }
+    Some(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    fn read_from(
+        entries: HashMap<String, Vec<u8>>,
+    ) -> impl FnMut(&str, usize) -> Option<Zeroizing<Vec<u8>>> {
+        move |target, max_bytes| {
+            entries
+                .get(target)
+                .and_then(|bytes| (bytes.len() <= max_bytes).then(|| Zeroizing::new(bytes.clone())))
+        }
+    }
+
+    #[test]
+    fn reads_direct_credential() {
+        let service = "Claude Code-credentials".to_string();
+        let target = format!("{service}/{CREDENTIAL_ACCOUNT}");
+        let credentials = r#"{"claudeAiOauth":{"accessToken":"access-token"}}"#;
+        let entries = HashMap::from([(target, credentials.as_bytes().to_vec())]);
+
+        let detected = read_credentials_with(&[service], read_from(entries));
+
+        assert_eq!(detected.as_deref(), Some(credentials));
+    }
+
+    #[test]
+    fn reassembles_chunked_credential() {
+        let service = "Claude Code-credentials".to_string();
+        let target = format!("{service}/{CREDENTIAL_ACCOUNT}");
+        let credentials = format!(
+            r#"{{"claudeAiOauth":{{"accessToken":"{}"}}}}"#,
+            "a".repeat(CREDENTIAL_CHUNK_BYTES)
+        );
+        let encoded = STANDARD.encode(credentials.as_bytes());
+        let chunks = encoded
+            .as_bytes()
+            .chunks(CREDENTIAL_CHUNK_BYTES)
+            .collect::<Vec<_>>();
+        let manifest = format!(r#"{{"n":{},"l":{}}}"#, chunks.len(), encoded.len());
+        let mut entries = HashMap::from([(format!("{target}#m"), manifest.into_bytes())]);
+        for (index, chunk) in chunks.into_iter().enumerate() {
+            entries.insert(format!("{target}#{index}"), chunk.to_vec());
+        }
+
+        let detected = read_credentials_with(&[service], read_from(entries));
+
+        assert_eq!(detected.as_deref(), Some(credentials.as_str()));
+    }
+
+    #[test]
+    fn ignores_incomplete_chunked_credential() {
+        let service = "Claude Code-credentials".to_string();
+        let target = format!("{service}/{CREDENTIAL_ACCOUNT}");
+        let entries = HashMap::from([(format!("{target}#m"), br#"{"n":2,"l":12}"#.to_vec())]);
+
+        let detected = read_credentials_with(&[service], read_from(entries));
+
+        assert!(detected.is_none());
+    }
+
+    #[test]
+    fn falls_through_to_next_service() {
+        let scoped = "Claude Code-credentials-deadbeef".to_string();
+        let default = "Claude Code-credentials".to_string();
+        let invalid_target = format!("{scoped}/{CREDENTIAL_ACCOUNT}");
+        let target = format!("{default}/{CREDENTIAL_ACCOUNT}");
+        let credentials = r#"{"claudeAiOauth":{"accessToken":"fallback"}}"#;
+        let entries = HashMap::from([
+            (invalid_target, b"not-json".to_vec()),
+            (target, credentials.as_bytes().to_vec()),
+        ]);
+
+        let detected = read_credentials_with(&[scoped, default], read_from(entries));
+
+        assert_eq!(detected.as_deref(), Some(credentials));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn scoped_service_normalizes_unicode_config_dir() {
+        let composed = scoped_claude_keychain_service(std::path::Path::new("C:\\caf\u{e9}"));
+        let decomposed = scoped_claude_keychain_service(std::path::Path::new("C:\\cafe\u{301}"));
+
+        assert_eq!(composed, decomposed);
+    }
+}

--- a/src-tauri/crates/key-vault/src/auto_detect/claude_windows.rs
+++ b/src-tauri/crates/key-vault/src/auto_detect/claude_windows.rs
@@ -9,12 +9,10 @@ use base64::{engine::general_purpose::STANDARD, Engine as _};
 use serde::Deserialize;
 use zeroize::Zeroizing;
 
-#[cfg(windows)]
-use super::claude::{scoped_claude_keychain_service, CLAUDE_SECURESTORAGE_CONFIG_DIR_ENV};
-
 const CREDENTIAL_ACCOUNT: &str = "claude-code-user";
 const CREDENTIAL_CHUNK_BYTES: usize = 2_400;
 const CREDENTIAL_MAX_CHUNKS: usize = 256;
+pub(super) const CLAUDE_SECURESTORAGE_CONFIG_DIR_ENV: &str = "CLAUDE_SECURESTORAGE_CONFIG_DIR";
 
 #[derive(Debug, Deserialize)]
 struct CredentialManifest {
@@ -47,6 +45,18 @@ fn credential_services() -> Vec<String> {
         .unwrap_or_default();
     services.push("Claude Code-credentials".to_string());
     services
+}
+
+fn scoped_claude_keychain_service(config_dir: &std::path::Path) -> String {
+    use sha2::{Digest, Sha256};
+    use unicode_normalization::UnicodeNormalization;
+
+    let normalized = config_dir.to_string_lossy().nfc().collect::<String>();
+    let suffix = Sha256::digest(normalized.as_bytes());
+    format!("Claude Code-credentials-{:x}", suffix)
+        .chars()
+        .take("Claude Code-credentials-".len() + 8)
+        .collect()
 }
 
 fn read_credentials_with<F>(services: &[String], mut read_credential: F) -> Option<String>

--- a/src-tauri/crates/key-vault/src/auto_detect/mod.rs
+++ b/src-tauri/crates/key-vault/src/auto_detect/mod.rs
@@ -6,6 +6,8 @@
 //! - OAuth tokens from local databases
 
 mod claude;
+#[cfg(any(windows, test))]
+mod claude_windows;
 mod codex;
 mod copilot;
 mod cursor;

--- a/src-tauri/crates/key-vault/src/auto_detect/mod.rs
+++ b/src-tauri/crates/key-vault/src/auto_detect/mod.rs
@@ -6,7 +6,7 @@
 //! - OAuth tokens from local databases
 
 mod claude;
-#[cfg(any(windows, test))]
+#[cfg(windows)]
 mod claude_windows;
 mod codex;
 mod copilot;

--- a/src-tauri/crates/key-vault/src/providers/codex/mod.rs
+++ b/src-tauri/crates/key-vault/src/providers/codex/mod.rs
@@ -13,7 +13,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::process::Command;
+use tokio::process::{Child, Command};
 
 /// ChatGPT usage API endpoint
 const USAGE_API_URL: &str = "https://chatgpt.com/backend-api/wham/usage";
@@ -21,6 +21,7 @@ const CODEX_MODELS_API_URL: &str = "https://chatgpt.com/backend-api/codex/models
 const CODEX_MODELS_CLIENT_VERSION: &str = "0.124.0";
 const CODEX_USER_AGENT: &str = "codex_cli_rs/0.124.0 (orgii, cli)";
 const APP_SERVER_TIMEOUT_SECS: u64 = 10;
+const APP_SERVER_SHUTDOWN_TIMEOUT_SECS: u64 = 2;
 
 #[derive(Debug, Deserialize)]
 struct CodexModelsResponse {
@@ -750,12 +751,19 @@ async fn run_codex_app_server_rpc<T: DeserializeOwned>(
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
 
+    // npm's `codex` entry point launches the native binary as a descendant.
+    // Isolate the wrapper tree so timeout cleanup cannot orphan the native
+    // app-server with our stdout/stderr handles still open.
+    #[cfg(unix)]
+    child.process_group(0);
+
     #[cfg(windows)]
     child.creation_flags(app_platform::CREATE_NO_WINDOW);
 
     let mut child = child
         .spawn()
         .map_err(|err| format!("Failed to start Codex app-server via {codex_binary}: {err}"))?;
+    let child_pid = child.id();
 
     let mut stdin = child
         .stdin
@@ -808,26 +816,196 @@ async fn run_codex_app_server_rpc<T: DeserializeOwned>(
             Err(_) => Err(format!("Codex app-server {operation} timed out")),
         };
 
-    if let Err(err) = child.kill().await {
-        log::debug!(
-            "[CodexAppServer] Failed to kill Codex app-server after {}: {}",
-            operation,
-            err,
-        );
-    }
-    let _ = child.wait().await;
+    drop(stdin);
+    terminate_codex_app_server_tree(&mut child, child_pid, operation).await;
 
-    if let Some(task) = stderr_task {
-        if let Ok(stderr_output) = task.await {
-            if let Err(ref error_message) = result {
-                if !stderr_output.trim().is_empty() {
-                    result = Err(format!("{error_message}: {}", stderr_output.trim()));
+    if let Some(mut task) = stderr_task {
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(APP_SERVER_SHUTDOWN_TIMEOUT_SECS),
+            &mut task,
+        )
+        .await
+        {
+            Ok(Ok(stderr_output)) => {
+                if let Err(ref error_message) = result {
+                    if !stderr_output.trim().is_empty() {
+                        result = Err(format!("{error_message}: {}", stderr_output.trim()));
+                    }
                 }
+            }
+            Ok(Err(err)) => log::debug!(
+                "[CodexAppServer] stderr reader failed after {}: {}",
+                operation,
+                err
+            ),
+            Err(_) => {
+                task.abort();
+                log::warn!(
+                    "[CodexAppServer] stderr pipe did not close after {}; reader aborted",
+                    operation
+                );
             }
         }
     }
 
     result
+}
+
+async fn terminate_codex_app_server_tree(
+    child: &mut Child,
+    child_pid: Option<u32>,
+    operation: &str,
+) {
+    #[cfg(unix)]
+    if let Some(pid) = child_pid {
+        // SAFETY: this child was spawned as the leader of a dedicated process
+        // group. Sending SIGKILL does not touch Rust-managed memory.
+        let status = unsafe { libc::kill(-(pid as libc::pid_t), libc::SIGKILL) };
+        if status != 0 {
+            log::debug!(
+                "[CodexAppServer] Failed to kill process group after {}: {}",
+                operation,
+                std::io::Error::last_os_error()
+            );
+        }
+    }
+
+    #[cfg(windows)]
+    if let Some(pid) = child_pid {
+        // The npm `cmd.exe` shim can exit before cleanup while node.exe and the
+        // native Codex binary keep its pipe handles open. A Toolhelp snapshot
+        // retains their original parent PIDs, so it can still find that orphaned
+        // tree after the wrapper is gone; `taskkill /T` cannot.
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(APP_SERVER_SHUTDOWN_TIMEOUT_SECS),
+            tokio::task::spawn_blocking(move || terminate_windows_process_tree(pid)),
+        )
+        .await
+        {
+            Ok(Ok(Ok(()))) => {}
+            Ok(Ok(Err(err))) => log::warn!(
+                "[CodexAppServer] Failed to terminate Windows process tree after {}: {}",
+                operation,
+                err
+            ),
+            Ok(Err(err)) => log::warn!(
+                "[CodexAppServer] Windows process cleanup task failed after {}: {}",
+                operation,
+                err
+            ),
+            Err(_) => log::warn!(
+                "[CodexAppServer] Windows process cleanup timed out after {}",
+                operation
+            ),
+        }
+    }
+
+    if let Err(err) = child.start_kill() {
+        log::debug!(
+            "[CodexAppServer] Direct child already stopped after {}: {}",
+            operation,
+            err
+        );
+    }
+    if tokio::time::timeout(
+        std::time::Duration::from_secs(APP_SERVER_SHUTDOWN_TIMEOUT_SECS),
+        child.wait(),
+    )
+    .await
+    .is_err()
+    {
+        log::warn!(
+            "[CodexAppServer] Direct child did not exit after {} within {}s",
+            operation,
+            APP_SERVER_SHUTDOWN_TIMEOUT_SECS
+        );
+    }
+}
+
+#[cfg(windows)]
+fn terminate_windows_process_tree(root_pid: u32) -> Result<(), String> {
+    use std::collections::HashSet;
+    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE};
+    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+        CreateToolhelp32Snapshot, Process32FirstW, Process32NextW, PROCESSENTRY32W,
+        TH32CS_SNAPPROCESS,
+    };
+    use windows_sys::Win32::System::Threading::{OpenProcess, TerminateProcess, PROCESS_TERMINATE};
+
+    const MAX_SNAPSHOT_PROCESSES: usize = 8_192;
+    const MAX_TREE_PROCESSES: usize = 32;
+
+    // SAFETY: the returned snapshot handle is checked and closed on every path.
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0) };
+    if snapshot == INVALID_HANDLE_VALUE {
+        return Err(format!(
+            "CreateToolhelp32Snapshot failed: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+
+    let mut processes = Vec::new();
+    let mut entry = PROCESSENTRY32W {
+        dwSize: std::mem::size_of::<PROCESSENTRY32W>() as u32,
+        ..Default::default()
+    };
+    // SAFETY: `entry` has the required size and remains valid while the snapshot
+    // is enumerated.
+    let mut has_entry = unsafe { Process32FirstW(snapshot, &mut entry) } != 0;
+    while has_entry {
+        if processes.len() >= MAX_SNAPSHOT_PROCESSES {
+            // SAFETY: `snapshot` is a valid handle owned by this function.
+            unsafe { CloseHandle(snapshot) };
+            return Err(format!(
+                "process snapshot exceeded {MAX_SNAPSHOT_PROCESSES} entries"
+            ));
+        }
+        processes.push((entry.th32ProcessID, entry.th32ParentProcessID));
+        // SAFETY: same initialized entry and valid snapshot as above.
+        has_entry = unsafe { Process32NextW(snapshot, &mut entry) } != 0;
+    }
+    // SAFETY: `snapshot` is a valid handle owned by this function.
+    unsafe { CloseHandle(snapshot) };
+
+    // Seed the traversal with the captured wrapper PID even when the wrapper has
+    // already exited and is absent from the snapshot.
+    let mut known = HashSet::from([root_pid]);
+    let mut frontier = HashSet::from([root_pid]);
+    let mut descendants = Vec::new();
+    let mut depth = 0usize;
+    while !frontier.is_empty() {
+        let mut next_frontier = HashSet::new();
+        for &(pid, parent_pid) in &processes {
+            if frontier.contains(&parent_pid) && known.insert(pid) {
+                if descendants.len() >= MAX_TREE_PROCESSES {
+                    return Err(format!(
+                        "process tree rooted at {root_pid} exceeded {MAX_TREE_PROCESSES} entries"
+                    ));
+                }
+                descendants.push((pid, depth + 1));
+                next_frontier.insert(pid);
+            }
+        }
+        frontier = next_frontier;
+        depth += 1;
+    }
+
+    descendants.sort_unstable_by_key(|&(_, process_depth)| std::cmp::Reverse(process_depth));
+    for (pid, _) in descendants {
+        // SAFETY: the handle is checked before use and closed after termination.
+        let process = unsafe { OpenProcess(PROCESS_TERMINATE, 0, pid) };
+        if process.is_null() {
+            continue;
+        }
+        // The process may exit between snapshot enumeration and this call. That
+        // is already the desired state, so termination failures are non-fatal.
+        unsafe {
+            TerminateProcess(process, 1);
+            CloseHandle(process);
+        }
+    }
+
+    Ok(())
 }
 
 async fn write_json_rpc_request<T: Serialize>(
@@ -1200,5 +1378,130 @@ mod model_discovery_tests {
         assert_eq!(models[0].default_effort.as_deref(), Some("high"));
         assert_eq!(models[0].supported_efforts, vec!["low", "high", "max"]);
         assert!(models[0].is_default);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn app_server_shutdown_terminates_wrapper_descendants() {
+        let mut command = Command::new("sh");
+        command
+            .args(["-c", "sleep 60 & helper=$!; echo $helper; wait"])
+            .process_group(0)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true);
+        let mut child = command.spawn().expect("spawn wrapper process");
+        let child_pid = child.id();
+        let stdout = child.stdout.take().expect("wrapper stdout");
+        let mut reader = BufReader::new(stdout).lines();
+        let helper_pid: i32 = reader
+            .next_line()
+            .await
+            .expect("read helper pid")
+            .expect("helper pid line")
+            .trim()
+            .parse()
+            .expect("numeric helper pid");
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(8),
+            terminate_codex_app_server_tree(&mut child, child_pid, "test shutdown"),
+        )
+        .await
+        .expect("bounded wrapper shutdown");
+
+        let mut helper_alive = true;
+        for _ in 0..20 {
+            // SAFETY: signal 0 performs an existence check only.
+            helper_alive = unsafe { libc::kill(helper_pid, 0) == 0 };
+            if !helper_alive {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(!helper_alive, "descendant process {helper_pid} survived");
+    }
+
+    #[cfg(windows)]
+    async fn windows_process_is_alive(pid: u32) -> bool {
+        let script = format!(
+            "if (Get-Process -Id {pid} -ErrorAction SilentlyContinue) {{ exit 0 }} else {{ exit 1 }}"
+        );
+        let mut command = Command::new("powershell.exe");
+        command
+            .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+            .creation_flags(app_platform::CREATE_NO_WINDOW);
+        command
+            .status()
+            .await
+            .map(|status| status.success())
+            .unwrap_or(false)
+    }
+
+    #[cfg(windows)]
+    #[tokio::test]
+    async fn app_server_shutdown_terminates_windows_wrapper_descendants() {
+        let script = r#"
+$pingPath = Join-Path $env:SystemRoot 'System32\ping.exe'
+$descendant = Start-Process -FilePath $pingPath -ArgumentList '-t','127.0.0.1' -NoNewWindow -PassThru
+[Console]::Out.WriteLine($descendant.Id)
+[Console]::Out.Flush()
+"#;
+        let mut command = Command::new("powershell.exe");
+        command
+            .args(["-NoProfile", "-NonInteractive", "-Command", script])
+            .creation_flags(app_platform::CREATE_NO_WINDOW)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true);
+        let mut child = command.spawn().expect("spawn Windows wrapper process");
+        let child_pid = child.id();
+        let stdout = child.stdout.take().expect("wrapper stdout");
+        let mut reader = BufReader::new(stdout).lines();
+        let descendant_pid: u32 = reader
+            .next_line()
+            .await
+            .expect("read descendant pid")
+            .expect("descendant pid line")
+            .trim()
+            .parse()
+            .expect("numeric descendant pid");
+        assert!(windows_process_is_alive(descendant_pid).await);
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), child.wait())
+            .await
+            .expect("wrapper wait stayed bounded")
+            .expect("wrapper exited");
+        assert!(
+            windows_process_is_alive(descendant_pid).await,
+            "test requires the descendant to outlive its wrapper"
+        );
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(8),
+            terminate_codex_app_server_tree(&mut child, child_pid, "test shutdown"),
+        )
+        .await
+        .expect("bounded Windows wrapper shutdown");
+
+        let mut descendant_alive = true;
+        for _ in 0..20 {
+            descendant_alive = windows_process_is_alive(descendant_pid).await;
+            if !descendant_alive {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        if descendant_alive {
+            let _ = Command::new("taskkill")
+                .args(["/PID", &descendant_pid.to_string(), "/T", "/F"])
+                .creation_flags(app_platform::CREATE_NO_WINDOW)
+                .output()
+                .await;
+        }
+        assert!(
+            !descendant_alive,
+            "descendant process {descendant_pid} survived"
+        );
     }
 }

--- a/src/scaffold/WizardSystem/variants/KeyVault/hooks/useApiSetupTokenDetection.test.ts
+++ b/src/scaffold/WizardSystem/variants/KeyVault/hooks/useApiSetupTokenDetection.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import type { TFunction } from "i18next";
+import { act, createElement, useEffect } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CLI_AGENT } from "@src/api/tauri/rpc/schemas/validation";
+
+import type { WizardData } from "../types";
+import { useApiSetupTokenDetection } from "./useApiSetupTokenDetection";
+
+const serviceMocks = vi.hoisted(() => ({
+  autoDetectKey: vi.fn(),
+  getOAuthModelCatalog: vi.fn(),
+  validateKey: vi.fn(),
+}));
+
+vi.mock("@src/api/services/keyValidation", () => serviceMocks);
+vi.mock("@src/hooks/logger", () => ({
+  createLogger: () => ({ error: vi.fn() }),
+}));
+vi.mock("./useProviderConfig", () => ({
+  useProviderConfig: () => ({ config: undefined }),
+}));
+
+type HookOptions = Parameters<typeof useApiSetupTokenDetection>[0];
+type HookResult = ReturnType<typeof useApiSetupTokenDetection>;
+
+function HookHarness({
+  options,
+  onResult,
+}: {
+  options: HookOptions;
+  onResult: (result: HookResult) => void;
+}) {
+  const result = useApiSetupTokenDetection(options);
+  useEffect(() => onResult(result), [onResult, result]);
+  return null;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  document.body.replaceChildren();
+});
+
+describe("useApiSetupTokenDetection", () => {
+  it("awaits catalog discovery, catches failure, and keeps detection single-flight", async () => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+
+    let rejectCatalog: ((reason: Error) => void) | undefined;
+    const pendingCatalog = new Promise<never>((_resolve, reject) => {
+      rejectCatalog = reject;
+    });
+    serviceMocks.autoDetectKey.mockResolvedValue({
+      success: true,
+      message: "Found 1 key(s)",
+      keys: [
+        {
+          auth_method: "oauth",
+          validated: true,
+          session_token: "test-access-token",
+          env_vars: {
+            OPENAI_REFRESH_TOKEN: "test-refresh-token",
+            OPENAI_ID_TOKEN: "test-id-token",
+          },
+        },
+      ],
+    });
+    serviceMocks.getOAuthModelCatalog.mockReturnValue(pendingCatalog);
+
+    const setDetectingToken = vi.fn();
+    const setTokenError = vi.fn();
+    const options: HookOptions = {
+      data: { agent_type: CLI_AGENT.CODEX } as WizardData,
+      onChange: vi.fn(),
+      t: ((key: string) => key) as TFunction<"integrations">,
+      isCursor: false,
+      isOAuthAgent: true,
+      isClaudeCode: false,
+      isCodex: true,
+      detectedKeys: [],
+      selectedCredentialIndex: 0,
+      setDetectingToken,
+      setTokenDetected: vi.fn(),
+      setTokenError,
+      setCursorSessionToken: vi.fn(),
+      setShowKeySelection: vi.fn(),
+      setDetectedKeys: vi.fn(),
+      setSelectedCredentialIndex: vi.fn(),
+    };
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    let hookResult: HookResult | undefined;
+    const onResult = (result: HookResult) => {
+      hookResult = result;
+    };
+    await act(async () => {
+      root.render(createElement(HookHarness, { options, onResult }));
+    });
+
+    let firstDetection: Promise<void> | undefined;
+    let duplicateDetection: Promise<void> | undefined;
+    await act(async () => {
+      firstDetection = hookResult?.handleAutoDetectToken();
+      duplicateDetection = hookResult?.handleAutoDetectToken();
+      await Promise.resolve();
+    });
+
+    expect(serviceMocks.autoDetectKey).toHaveBeenCalledTimes(1);
+    expect(serviceMocks.getOAuthModelCatalog).toHaveBeenCalledTimes(1);
+    expect(setDetectingToken).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      rejectCatalog?.(new Error("catalog unavailable"));
+      await Promise.all([firstDetection, duplicateDetection]);
+    });
+
+    expect(setTokenError).toHaveBeenLastCalledWith(
+      "keyVault.failedToDetectKeys"
+    );
+    expect(setDetectingToken.mock.calls.map(([value]) => value)).toEqual([
+      true,
+      false,
+    ]);
+
+    await act(async () => root.unmount());
+  });
+});

--- a/src/scaffold/WizardSystem/variants/KeyVault/hooks/useApiSetupTokenDetection.ts
+++ b/src/scaffold/WizardSystem/variants/KeyVault/hooks/useApiSetupTokenDetection.ts
@@ -1,5 +1,5 @@
 import type { TFunction } from "i18next";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 
 import {
   autoDetectKey,
@@ -94,6 +94,7 @@ export function useApiSetupTokenDetection({
   setDetectedKeys,
   setSelectedCredentialIndex,
 }: UseApiSetupTokenDetectionOptions) {
+  const detectionInFlightRef = useRef(false);
   // OpenCode's Zen/Go endpoints come from the Rust provider registry, same as
   // every other provider's — autodetect must not re-hardcode their URLs.
   const { config: openCodeConfig } = useProviderConfig(CLI_AGENT.OPENCODE);
@@ -163,6 +164,8 @@ export function useApiSetupTokenDetection({
   );
 
   const handleAutoDetectToken = useCallback(async () => {
+    if (detectionInFlightRef.current) return;
+    detectionInFlightRef.current = true;
     setDetectingToken(true);
     setTokenError(null);
     setTokenDetected(false);
@@ -228,11 +231,12 @@ export function useApiSetupTokenDetection({
         return;
       }
 
-      applySelectedKey(candidateKeys[0]);
+      await applySelectedKey(candidateKeys[0]);
     } catch (err) {
       log.error("[ApiSetup] Failed to auto-detect credentials:", err);
       setTokenError(t("keyVault.failedToDetectKeys"));
     } finally {
+      detectionInFlightRef.current = false;
       setDetectingToken(false);
     }
   }, [
@@ -250,12 +254,33 @@ export function useApiSetupTokenDetection({
     t,
   ]);
 
-  const handleConfirmKeySelection = useCallback(() => {
+  const handleConfirmKeySelection = useCallback(async () => {
+    if (detectionInFlightRef.current) return;
     const selected = detectedKeys[selectedCredentialIndex];
-    if (selected) {
-      applySelectedKey(selected);
+    if (!selected) return;
+
+    detectionInFlightRef.current = true;
+    setShowKeySelection(false);
+    setDetectingToken(true);
+    setTokenError(null);
+    try {
+      await applySelectedKey(selected);
+    } catch (err) {
+      log.error("[ApiSetup] Failed to apply detected credential:", err);
+      setTokenError(t("keyVault.failedToDetectKeys"));
+    } finally {
+      detectionInFlightRef.current = false;
+      setDetectingToken(false);
     }
-  }, [detectedKeys, selectedCredentialIndex, applySelectedKey]);
+  }, [
+    applySelectedKey,
+    detectedKeys,
+    selectedCredentialIndex,
+    setDetectingToken,
+    setShowKeySelection,
+    setTokenError,
+    t,
+  ]);
 
   return { handleAutoDetectToken, handleConfirmKeySelection };
 }


### PR DESCRIPTION
## Problem

Local CLI OAuth autodetect was unreliable for both supported subscription flows.

For Codex, the frontend did not await model discovery, so the detecting state ended early and later failures escaped its error handling. Backend timeout cleanup could also kill only the npm wrapper while leaving `node.exe` or the native Codex app-server alive with inherited pipes, causing a request to remain hung and repeated attempts to accumulate processes.

For Claude Code on Windows, ORGII only checked plaintext `.credentials.json`. Current Claude Code can instead store OAuth JSON through Bun's Windows secrets backend in Credential Manager, using direct or chunked generic credentials. ORGII therefore reported "No keys found" for a valid Windows-stored session.

## Solution

- Await Codex credential application/model discovery, keep detection single-flight, surface failures through the existing Key Vault error state, and bound all app-server/process-pipe cleanup.
- Read Claude Code's exact Credential Manager targets on Windows without enumerating unrelated credentials.
- Support Bun's direct and bounded chunked credential formats, including custom config-directory service hashes with Unicode NFC normalization.
- On Windows, keep Credential Manager and credential-file reads off the async executor with `spawn_blocking`, bound decoded input, and zero intermediate secret buffers.
- On Windows, preserve plaintext `.credentials.json` fallback and recognize `CLAUDE_SECURESTORAGE_CONFIG_DIR` alongside `CLAUDE_CONFIG_DIR`.

The resulting invariant is that one user-triggered CLI OAuth autodetect runs at a time, completes with either imported credentials or a visible error, and does not leave a background worker or subprocess behind.

## Potential risks

Claude Code's Credential Manager target and chunk manifest are an implementation-level contract with Claude Code/Bun rather than a public API. A future storage-format change may require detector updates. Reads are restricted to exact Claude-owned targets, direct values are capped at 2,400 bytes, and chunked input is capped at 256 chunks (about 600 KiB encoded) to bound both scope and memory.

The installed Claude Code `2.1.220` session was authenticated after implementation and the user confirmed successful Autodetect in the PR EXE's main-instance UI. The exact backend selected by Claude Code can vary between plaintext and Windows secure storage according to its rollout flags, so direct, chunked, incomplete, scoped-fallback, and Unicode-normalization paths remain covered by focused tests rather than assuming one local storage backend.

The Claude addition is now compile-time isolated to Windows. On macOS, the production detector, Keychain service lookup, file fallback order, and service hash are identical to the pre-Claude-fix commit; macOS still receives the earlier Codex Unix process-lifecycle change in this PR.

Codex Windows cleanup relies on process-snapshot parent PID data and force-terminates only descendants of the dedicated wrapper. PID reuse during the short cleanup window is theoretically possible; traversal is bounded to 32 descendants and cleanup applies to the process ORGII just spawned. The Unix lifecycle test remains unexecuted on this Windows host.

There is no database, persistence-format, public IPC, or wire-protocol change. The added Windows-only Rust dependencies were already present transitively in the lockfile. Rollback is a normal revert of the two feature commits; no migration or data recovery is required.

## Architecture audit

- Ownership and platform boundaries: Windows Credential Manager interop is isolated in `claude_windows.rs` and wired through the existing production Claude detector.
- State and fallback behavior: custom scoped storage, default secure storage, and plaintext file fallback have explicit order and corrupt/missing scoped entries fall through safely.
- Platform isolation: the Windows module owns secure-storage environment handling, NFC service hashing, chunk parsing, and Credential Manager interop; macOS retains its pre-change Keychain/file paths and hash behavior.
- Wire compatibility: existing Claude profile/model requests and returned Key Vault credential shape are unchanged.
- UI audit was not applicable: the Claude addition changes no TSX, layout, styling, or copy.

## Performance guard

| Path | Active bound | Idle/hidden behavior | Evidence |
| --- | --- | --- | --- |
| Codex autodetect | Single-flight; existing 10s RPC timeout | No retained worker | Duplicate invocation test and descendant cleanup tests pass |
| Codex cleanup | 8,192-process snapshot cap, 32-descendant cap, 2s task/join bounds | No polling or subscription | Dead-wrapper regression passed 5 consecutive cycles |
| Claude Windows credential read | Exact targets; 2,400-byte direct/chunk reads; at most 256 chunks | On-demand only; no timer, cache, subprocess, or background task | Focused direct/chunked/fallback tests pass |
| Desktop stable state | N/A | No detector work until Detect is clicked | 15s sample: 0.031 CPU seconds, 64.3 to 64.5 MiB working set, 29.7 to 30.2 MiB private memory |

Performance verdict: pass.

## Verification

Claude/combined change:

- `cargo test -p key_vault auto_detect::claude_windows::tests -- --nocapture` — 5 passed, 0 failed.
- `cargo check -p key_vault --all-targets` — passed; only pre-existing warnings were emitted.
- `cargo clippy -p key_vault --all-targets --no-deps -- -A unused-variables -A unused-mut -D warnings` — passed for `key_vault`; an existing dependency warning was still emitted by `integrations`.
- `cargo test -p key_vault` — 345 passed and 1 unrelated existing PATH-fingerprint test failed: `installation_fingerprint_changes_when_binary_appears_on_path`.
- `cargo test -p key_vault --lib -- --skip commands::registry::commands::tests::installation_fingerprint_changes_when_binary_appears_on_path --test-threads=1` — 345 passed, 0 failed, 1 filtered.
- `cargo build -p org2 --bin org2 --profile dev-build` — passed; Windows EXE version `1.2.3` built and launched from the isolated worktree.
- Isolated EXE manual/runtime check — launched with a separate `ORGII_HOME` and ports; process remained responsive. Stable-state sampling is recorded above.
- Authenticated Claude Code `2.1.220` manual check — after `claude auth login`, the user confirmed that the PR EXE main instance successfully detected the session through the UI.
- Platform diff review against pre-Claude-fix commit `5272d6c80` — macOS compiles the original synchronous detector, credential path order, Keychain configuration, and raw service hash; the new module and dependencies are `cfg(windows)` only.
- Rustfmt on changed Rust files and `git diff --check` — passed.
- Secret/path inspection — no tokens, private keys, personal paths, logs, caches, or build artifacts are in the diff.

Earlier Codex change:

- `pnpm vitest run src/scaffold/WizardSystem/variants/KeyVault/hooks/useApiSetupTokenDetection.test.ts` — 1 passed.
- Targeted ESLint and `pnpm exec tsc --noEmit --pretty false` — passed.
- Windows dead-wrapper lifecycle test — passed 5 consecutive targeted cycles and in the full Key Vault suite.
- Live Codex Pro probe — credential detected in 309 ms, 7 models discovered in 1,001 ms, and 0 app-server workers remained afterward.

No screenshot is included because this PR changes autodetect/error/lifecycle behavior rather than layout or styling.
