### PR TITLE
fix(cloud): keep active Codex history advancing

### DIFF
--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app/index.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app/index.rs
@@ -21,7 +21,7 @@ use crate::store::{sqlite::SqliteRecordStore, RecordStore};
 
 use super::meta::{
     parse_codex_session_meta_with_title, resolve_codex_transcript_for_thread_id_near_path,
-    session_meta_to_cache_input,
+    resume_codex_session_meta_with_title, session_meta_to_cache_input, CodexSessionMetaParse,
 };
 use super::transcript::{
     load_codex_app_from_path, load_codex_app_initial_window_from_path,
@@ -35,7 +35,8 @@ use super::{
 /// Metadata discovery normally parses changed rollouts to derive repo, title,
 /// and rounds. Re-reading a very large rollout while Codex is still appending
 /// can allocate several times the file size and immediately become stale.
-/// Keep its existing cached row (if any) and parse it once after a quiet window.
+/// Such files may advance only through their validated incremental watermark;
+/// without one, keep the existing cached row and retry after a quiet window.
 const MAX_EAGER_ACTIVE_CODEX_METADATA_BYTES: i64 = 32 * 1024 * 1024;
 const ACTIVE_CODEX_METADATA_QUIET_NS: i64 = 10 * 60 * 1_000_000_000;
 
@@ -307,9 +308,6 @@ fn sync_codex_app_cache(conn: &mut Connection) -> Result<(), String> {
     let mut reparsed_ids = Vec::new();
     let now_ns = unix_epoch_now_ns();
     for record in changed {
-        if should_defer_active_codex_metadata(record, now_ns) {
-            continue;
-        }
         let stored_watermark = imported_history::watermark::read_parse_watermark_from_conn(
             conn,
             SOURCE_CODEX_APP,
@@ -322,8 +320,9 @@ fn sync_codex_app_cache(conn: &mut Connection) -> Result<(), String> {
         let Some(parse) = imported_history::skip_unparsable_record(
             SOURCE_CODEX_APP,
             &record.source_session_id,
-            parse_codex_session_meta_with_title(record, stored_watermark.as_ref(), external_title),
-        ) else {
+            parse_changed_codex_metadata(record, stored_watermark.as_ref(), external_title, now_ns),
+        )
+        .flatten() else {
             continue;
         };
         imported_history::watermark::write_parse_watermark_from_conn(
@@ -362,7 +361,20 @@ fn unix_epoch_now_ns() -> i64 {
         .unwrap_or(i64::MAX)
 }
 
-fn should_defer_active_codex_metadata(
+fn parse_changed_codex_metadata(
+    record: &ImportedHistoryDiscoveredRecord,
+    watermark: Option<&imported_history::watermark::ImportedParseWatermark>,
+    external_title: String,
+    now_ns: i64,
+) -> Result<Option<CodexSessionMetaParse>, String> {
+    if requires_resumable_active_codex_metadata(record, now_ns) {
+        resume_codex_session_meta_with_title(record, watermark, external_title)
+    } else {
+        parse_codex_session_meta_with_title(record, watermark, external_title).map(Some)
+    }
+}
+
+fn requires_resumable_active_codex_metadata(
     record: &ImportedHistoryDiscoveredRecord,
     now_ns: i64,
 ) -> bool {
@@ -736,15 +748,15 @@ mod tests {
     }
 
     #[test]
-    fn giant_active_codex_metadata_is_deferred_until_quiet() {
+    fn giant_active_codex_metadata_requires_a_valid_resume() {
         let now_ns = 1_750_000_000_000_000_000;
         let record = discovered_record(
             MAX_EAGER_ACTIVE_CODEX_METADATA_BYTES + 1,
             now_ns - ACTIVE_CODEX_METADATA_QUIET_NS + 1,
         );
 
-        assert!(should_defer_active_codex_metadata(&record, now_ns));
-        assert!(!should_defer_active_codex_metadata(
+        assert!(requires_resumable_active_codex_metadata(&record, now_ns));
+        assert!(!requires_resumable_active_codex_metadata(
             &discovered_record(
                 record.source_size_bytes,
                 now_ns - ACTIVE_CODEX_METADATA_QUIET_NS
@@ -758,7 +770,109 @@ mod tests {
         let now_ns = 1_750_000_000_000_000_000;
         let record = discovered_record(MAX_EAGER_ACTIVE_CODEX_METADATA_BYTES, now_ns);
 
-        assert!(!should_defer_active_codex_metadata(&record, now_ns));
+        assert!(!requires_resumable_active_codex_metadata(&record, now_ns));
+    }
+
+    #[test]
+    fn giant_active_codex_metadata_advances_from_its_watermark() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "orgii-codex-active-watermark-test-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+        let path = temp_dir.join("rollout-active-watermark.jsonl");
+        let prefix = concat!(
+            r#"{"timestamp":"2026-08-05T15:00:00.000Z","type":"session_meta","payload":{"cwd":"/tmp/org2","id":"active"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-08-05T15:00:01.000Z","type":"event_msg","payload":{"type":"user_message","message":"start"}}"#,
+            "\n"
+        );
+        std::fs::write(&path, prefix).expect("write prefix");
+
+        let record_for = |source_size_bytes: Option<i64>, source_mtime_ms: Option<i64>| {
+            let (actual_mtime_ms, actual_size_bytes) =
+                imported_paths::file_metadata_signature(&path, "Codex").expect("metadata");
+            ImportedHistoryDiscoveredRecord {
+                source_session_id: "rollout-active-watermark".to_string(),
+                source_path: path.clone(),
+                source_record_key: "rollout-active-watermark".to_string(),
+                source_mtime_ms: source_mtime_ms.unwrap_or(actual_mtime_ms),
+                source_size_bytes: source_size_bytes.unwrap_or(actual_size_bytes),
+                source_fingerprint: String::new(),
+                parser_version: CODEX_APP_METADATA_PARSER_VERSION,
+            }
+        };
+
+        let first_record = record_for(None, None);
+        let first = parse_changed_codex_metadata(
+            &first_record,
+            None,
+            String::new(),
+            first_record.source_mtime_ms + ACTIVE_CODEX_METADATA_QUIET_NS,
+        )
+        .expect("initial parse")
+        .expect("initial metadata");
+        assert!(!first.resumed);
+
+        let suffix = concat!(
+            r#"{"timestamp":"2026-08-05T15:01:00.000Z","type":"event_msg","payload":{"type":"user_message","message":"still active"}}"#,
+            "\n"
+        );
+        std::fs::write(&path, format!("{prefix}{suffix}")).expect("append suffix");
+        let now_ns = unix_epoch_now_ns();
+        // The logical size selects the exact >32 MiB production branch without
+        // making the unit fixture allocate a giant file. The reader still
+        // validates the real prefix seam and reads only the appended suffix.
+        let active_record = record_for(
+            Some(MAX_EAGER_ACTIVE_CODEX_METADATA_BYTES + 1),
+            Some(now_ns),
+        );
+        let resumed = parse_changed_codex_metadata(
+            &active_record,
+            Some(&first.watermark),
+            String::new(),
+            now_ns,
+        )
+        .expect("resume active parse")
+        .expect("resumed metadata");
+
+        assert!(resumed.resumed);
+        assert_eq!(
+            resumed.meta.expect("session metadata").updated_at_ms,
+            imported_history::parse_iso_to_epoch_ms_opt("2026-08-05T15:01:00.000Z")
+                .expect("fixture timestamp")
+        );
+
+        // If the file was rewritten instead of appended, the boundary check
+        // rejects the watermark and the active-file path must defer rather
+        // than silently rewind and parse the whole giant rollout.
+        let mutated = format!("{prefix}{suffix}").replace("start", "START");
+        std::fs::write(&path, mutated).expect("mutate prefix");
+        let mutated_record = record_for(
+            Some(MAX_EAGER_ACTIVE_CODEX_METADATA_BYTES + 1),
+            Some(now_ns + 1),
+        );
+        let rejected = parse_changed_codex_metadata(
+            &mutated_record,
+            Some(&resumed.watermark),
+            String::new(),
+            now_ns + 1,
+        )
+        .expect("reject invalid resume");
+        assert!(rejected.is_none());
+
+        std::fs::remove_dir_all(&temp_dir).expect("remove temp dir");
+    }
+
+    #[test]
+    fn giant_active_codex_metadata_without_a_watermark_stays_deferred() {
+        let now_ns = unix_epoch_now_ns();
+        let record = discovered_record(MAX_EAGER_ACTIVE_CODEX_METADATA_BYTES + 1, now_ns);
+
+        let parsed = parse_changed_codex_metadata(&record, None, String::new(), now_ns)
+            .expect("defer without opening the missing fixture");
+
+        assert!(parsed.is_none());
     }
 
     #[test]

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app/meta.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app/meta.rs
@@ -281,6 +281,35 @@ pub(crate) fn parse_codex_session_meta_with_title(
     watermark: Option<&ImportedParseWatermark>,
     external_title: String,
 ) -> Result<CodexSessionMetaParse, String> {
+    parse_codex_session_meta_with_title_inner(record, watermark, external_title, false)?
+        .ok_or_else(|| "Codex metadata parse unexpectedly required a resume watermark".to_string())
+}
+
+/// Resume a Codex metadata scan without ever falling back to a full-file read.
+///
+/// Large live rollouts may already be tens of megabytes. Their persisted
+/// watermark makes the normal path cheap, but a rotated file, changed boundary,
+/// corrupt state, or missing watermark would make `WatermarkedTranscriptReader`
+/// conservatively rewind to byte zero. Callers that are handling a large active
+/// rollout use this variant so losing resume eligibility defers the record until
+/// it is quiet instead of reintroducing the full-read CPU/RAM spike.
+pub(crate) fn resume_codex_session_meta_with_title(
+    record: &ImportedHistoryDiscoveredRecord,
+    watermark: Option<&ImportedParseWatermark>,
+    external_title: String,
+) -> Result<Option<CodexSessionMetaParse>, String> {
+    if watermark.is_none() {
+        return Ok(None);
+    }
+    parse_codex_session_meta_with_title_inner(record, watermark, external_title, true)
+}
+
+fn parse_codex_session_meta_with_title_inner(
+    record: &ImportedHistoryDiscoveredRecord,
+    watermark: Option<&ImportedParseWatermark>,
+    external_title: String,
+    resume_only: bool,
+) -> Result<Option<CodexSessionMetaParse>, String> {
     let mut reader = WatermarkedTranscriptReader::open(
         &record.source_path,
         "Codex",
@@ -298,6 +327,9 @@ pub(crate) fn parse_codex_session_meta_with_title(
                 resumed = true;
             }
             Err(_) => {
+                if resume_only {
+                    return Ok(None);
+                }
                 reader = WatermarkedTranscriptReader::open(
                     &record.source_path,
                     "Codex",
@@ -308,6 +340,8 @@ pub(crate) fn parse_codex_session_meta_with_title(
                 )?;
             }
         }
+    } else if resume_only {
+        return Ok(None);
     }
     let mut tail_state: Option<CodexSessionMetaState> = None;
     while let Some(line) = reader.next_line()? {
@@ -332,11 +366,11 @@ pub(crate) fn parse_codex_session_meta_with_title(
         state_json,
     );
     let meta = tail_state.unwrap_or(state).finish(record, external_title);
-    Ok(CodexSessionMetaParse {
+    Ok(Some(CodexSessionMetaParse {
         meta,
         watermark: next_watermark,
         resumed,
-    })
+    }))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

Codex sidechat history could stop advancing in ORG2 even with background upload enabled. The cloud activity trigger introduced by #680 watches imported sessions' `updated_at`, but the Codex metadata scanner skipped every changed rollout larger than 32 MiB while it had been modified within the last 10 minutes. That guard ran before the scanner loaded the persisted parse watermark, so a live large rollout never advanced its local cache version and the cloud layer had no new version to upload.

The guard predated Codex's watermarked incremental parser: a known rollout with a valid watermark can resume from a checked byte boundary and persisted parser state without rereading the file.

## Solution

Read the persisted Codex watermark before deciding how to handle a changed rollout.

For an active rollout larger than 32 MiB, use a resume-only metadata parser:

- a valid boundary and parser state reads only the appended suffix, then advances the cache row and watermark;
- a missing, corrupt, rotated, or invalidated watermark defers the record until the existing quiet-window path can safely perform a full parse;
- the active path never silently rewinds to byte zero.

Bounded and quiet rollouts retain the existing parser behavior. No timer, retry loop, persistence schema, wire contract, or UI behavior changes. Once the cache `updated_at` advances, the existing #680 roster observer schedules the normal 30-second cloud quiet-window pass.

## Potential risks

A first-discovered active rollout already larger than 32 MiB still waits until it has been quiet for 10 minutes because it has no trustworthy resume boundary. A rotated or rewritten large active file follows the same safe deferral. This preserves the RAM guard instead of accepting an unbounded full fallback.

Cloud network upload remains cursor-incremental; real-device verification kept the same epoch and advanced `pushedCount` from 5 to 7 for two appended events. The existing frontend upload-preparation path still materializes and hashes the full imported replay locally before sending the suffix. A worst-case synthetic 34 MiB single-message fixture produced a transient approximately 655 MiB RSS peak, then returned to approximately 149 MiB. This PR does not change that separate frontend path; it should be optimized independently.

No database or wire migration is present. Rollback is a normal revert; doing so restores the old behavior where active Codex rollouts larger than 32 MiB are deferred until quiet.

## Performance guard

| Area | Verdict | Evidence | Change or reason kept | Verification |
| --- | --- | --- | --- | --- |
| Background work | keep | No new timer, worker, subscription, or retry loop | The scan runs only in the existing external-history pass; cloud upload keeps its existing quiet-window scheduling | Hidden/minimized idle CPU sampled at 0.0–0.1% |
| Memory | fix | Active large rollouts use only a validated suffix resume; invalid or absent watermarks defer instead of falling back to byte zero | Prevents the changed scanner path from materializing an active file larger than 32 MiB | Unit coverage plus a 35,652,885-byte real file; app RSS was approximately 129 MiB through startup and incremental scan |
| Scope and isolation | keep | No cache key, profile root, or instance routing changes | Existing per-instance storage boundaries remain unchanged | Tested with isolated Instance 2 roots; primary profile was untouched and the fixture was cleaned up |
| Rendering and hot paths | keep | No TypeScript, React, or UI files changed | The Rust line reader consumes only the appended suffix on the new path | Rust suite, clippy, frontend typecheck/lint, and true-machine scan |

Performance verdict: pass for the changed Rust metadata-scan path. The unchanged frontend full-replay preparation peak is explicitly documented above as a separate follow-up.

## Verification

- `cargo test -p orgtrack_core --lib` — 535 passed, 0 failed, 8 ignored on the final rebased commit.
- `cargo clippy -p orgtrack_core --all-targets -- -D warnings` — passed.
- `cargo test -p orgtrack_core giant_active_codex_metadata --lib -- --nocapture` — 3 passed, 0 failed.
- `rustfmt --edition 2021 --check` on both changed Rust files — passed.
- `pnpm typecheck` — passed.
- `pnpm lint` — passed.
- `pnpm test` — all 929 files and 7,836 tests passed, but Vitest exited 1 because of the existing unhandled Undici WebSocket `Event` type error attributed to unchanged `useCloudOrgSyncStatus.test.ts`.
- Targeted cloud/scan Vitest run — all 4 files and 86 assertions passed; the same existing unhandled WebSocket error made the command exit 1.
- `pnpm run tauri:build:fast -- --instance 2` — passed before the final conflict-free rebase; full Rust tests, frontend typecheck, lint, and tests were rerun after rebasing.
- `git diff --check` — passed.
- Diff inspection found no secrets, personal paths, generated artifacts, or unrelated formatting changes.

## Real-device verification

- Built and launched an isolated Instance 2 using its own ORGII home and external-history root.
- A live Codex rollout advanced from a 551-byte seeded watermark through 35,652,552 bytes, then to 35,652,885 bytes after two small appended events. The cache source size and watermark byte offset matched the file exactly.
- The cloud push retained epoch 2 and advanced `pushedCount` from 5 to 7, confirming only the appended events crossed the network cursor.
- After upload, hidden/minimized RSS stabilized around 145–149 MiB and idle CPU sampled at 0.0–0.1%.
- The synthetic remote session was soft-deleted, the test app was stopped, and the isolated local profile was restored.

## UI evidence

No UI surface changed, so screenshots would not provide meaningful review evidence.
