### PR TITLE
fix(work-management): preserve lists across tab switches

### DIFF
--- a/src/modules/MainApp/TeamInbox/useTeamInboxPullRequests.test.ts
+++ b/src/modules/MainApp/TeamInbox/useTeamInboxPullRequests.test.ts
@@ -2,12 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import { REPO_KIND, type Repo } from "@src/store/repo";
 
-import type { ManagedPrItem } from "../WorkManagement/githubManagedItemModel";
-import {
-  type TeamInboxPullRequestsSnapshot,
-  retainTeamInboxPullRequestsSnapshot,
-  selectTeamInboxPullRequestRepos,
-} from "./useTeamInboxPullRequests";
+import { selectTeamInboxPullRequestRepos } from "./useTeamInboxPullRequests";
 
 const repos: Repo[] = [
   {
@@ -78,71 +73,5 @@ describe("selectTeamInboxPullRequestRepos", () => {
       )
     ).toEqual([]);
     expect(matcher).not.toHaveBeenCalled();
-  });
-});
-
-describe("retainTeamInboxPullRequestsSnapshot", () => {
-  it("preserves the existing list reference when revalidation is unchanged", () => {
-    const items = [
-      { id: 42, title: "Same PR", timeAgo: "1m" },
-    ] as ManagedPrItem[];
-    const current: TeamInboxPullRequestsSnapshot = {
-      scopeKey: "local|repo-a",
-      items,
-      error: null,
-      loaded: true,
-    };
-
-    const next = retainTeamInboxPullRequestsSnapshot({
-      current,
-      scopeKey: "local|repo-a",
-      items: [{ id: 42, title: "Same PR", timeAgo: "2m" }] as ManagedPrItem[],
-      error: null,
-      loading: false,
-    });
-
-    expect(next).toBe(current);
-    expect(next.items).toBe(items);
-  });
-
-  it("publishes a new snapshot when a pull request really changes", () => {
-    const current: TeamInboxPullRequestsSnapshot = {
-      scopeKey: "local|repo-a",
-      items: [{ id: 42, title: "Before" }] as ManagedPrItem[],
-      error: null,
-      loaded: true,
-    };
-
-    const next = retainTeamInboxPullRequestsSnapshot({
-      current,
-      scopeKey: "local|repo-a",
-      items: [{ id: 42, title: "After" }] as ManagedPrItem[],
-      error: null,
-      loading: false,
-    });
-
-    expect(next).not.toBe(current);
-    expect(next.items[0]?.title).toBe("After");
-  });
-
-  it("bounds retained pull request rows", () => {
-    const items = Array.from({ length: 600 }, (_, id) => ({
-      id,
-    })) as ManagedPrItem[];
-
-    const next = retainTeamInboxPullRequestsSnapshot({
-      current: {
-        scopeKey: null,
-        items: [],
-        error: null,
-        loaded: false,
-      },
-      scopeKey: "local|many-repos",
-      items,
-      error: null,
-      loading: false,
-    });
-
-    expect(next.items).toHaveLength(500);
   });
 });

--- a/src/modules/MainApp/TeamInbox/useTeamInboxPullRequests.ts
+++ b/src/modules/MainApp/TeamInbox/useTeamInboxPullRequests.ts
@@ -1,6 +1,5 @@
-import { atom, useAtom, useAtomValue } from "jotai";
-import isEqual from "lodash/isEqual";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useAtomValue } from "jotai";
+import { useCallback, useMemo, useState } from "react";
 
 import type { PullRequestListState } from "@src/api/tauri/github";
 import { sidebarActiveCloudOrgIdAtom } from "@src/features/Org2Cloud/org2CloudOrgsAtom";
@@ -25,76 +24,12 @@ import { type Repo, reposAtom } from "@src/store/repo";
 
 const OPEN_PR_STATES: PullRequestListState[] = ["open"];
 const NO_ISSUE_STATES: GitHubIssuePageState[] = [];
-const MAX_RETAINED_TEAM_INBOX_PULL_REQUESTS = 500;
 
 export interface TeamInboxPullRequestsState {
   items: ManagedPrItem[];
   loading: boolean;
   error: string | null;
   refresh: () => void;
-}
-
-export interface TeamInboxPullRequestsSnapshot {
-  scopeKey: string | null;
-  items: ManagedPrItem[];
-  error: string | null;
-  loaded: boolean;
-}
-
-const EMPTY_TEAM_INBOX_PULL_REQUESTS_SNAPSHOT: TeamInboxPullRequestsSnapshot = {
-  scopeKey: null,
-  items: [],
-  error: null,
-  loaded: false,
-};
-
-// Store-local and bounded: survives an Inbox surface remount without leaking
-// GitHub rows across app stores or retaining every repository ever opened.
-const teamInboxPullRequestsSnapshotAtom = atom<TeamInboxPullRequestsSnapshot>(
-  EMPTY_TEAM_INBOX_PULL_REQUESTS_SNAPSHOT
-);
-
-function samePullRequestItems(
-  left: readonly ManagedPrItem[],
-  right: readonly ManagedPrItem[]
-): boolean {
-  if (left.length !== right.length) return false;
-  return left.every((item, index) => {
-    const candidate = right[index];
-    if (!candidate) return false;
-    const { timeAgo: _leftTimeAgo, ...leftData } = item;
-    const { timeAgo: _rightTimeAgo, ...rightData } = candidate;
-    return isEqual(leftData, rightData);
-  });
-}
-
-export function retainTeamInboxPullRequestsSnapshot({
-  current,
-  scopeKey,
-  items,
-  error,
-  loading,
-}: {
-  current: TeamInboxPullRequestsSnapshot;
-  scopeKey: string;
-  items: ManagedPrItem[];
-  error: string | null;
-  loading: boolean;
-}): TeamInboxPullRequestsSnapshot {
-  const boundedItems = items.slice(0, MAX_RETAINED_TEAM_INBOX_PULL_REQUESTS);
-  const sameScope = current.scopeKey === scopeKey;
-  const itemsUnchanged =
-    sameScope && samePullRequestItems(current.items, boundedItems);
-  const loaded = boundedItems.length > 0 || !loading;
-  if (itemsUnchanged && current.error === error && current.loaded === loaded) {
-    return current;
-  }
-  return {
-    scopeKey,
-    items: itemsUnchanged ? current.items : boundedItems,
-    error,
-    loaded,
-  };
 }
 
 type TeamInboxRepoScopeMatcher = (
@@ -140,22 +75,6 @@ export function useTeamInboxPullRequests(): TeamInboxPullRequestsState {
     () => new Set(scopedRepos.map((repo) => repo.id)),
     [scopedRepos]
   );
-  const scopeKey = useMemo(
-    () =>
-      [
-        activeCloudOrgId ?? "local",
-        ...scopedRepos
-          .map(
-            (repo) =>
-              `${repo.id}:${repo.repo_url ?? repo.fs_uri ?? repo.path ?? ""}`
-          )
-          .sort(),
-      ].join("|"),
-    [activeCloudOrgId, scopedRepos]
-  );
-  const [retainedSnapshot, setRetainedSnapshot] = useAtom(
-    teamInboxPullRequestsSnapshotAtom
-  );
   const { repoSources, repoPrMap, loading, loadError } =
     useGitHubWorkItemsLoadLifecycle({
       repos: scopedRepos,
@@ -175,31 +94,14 @@ export function useTeamInboxPullRequests(): TeamInboxPullRequestsState {
         .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt)),
     [repoPrMap, repoSources, scopedRepoIds]
   );
-  useEffect(() => {
-    if (loading && items.length === 0) return;
-    setRetainedSnapshot((current) =>
-      retainTeamInboxPullRequestsSnapshot({
-        current,
-        scopeKey,
-        items,
-        error: loadError,
-        loading,
-      })
-    );
-  }, [items, loadError, loading, scopeKey, setRetainedSnapshot]);
   const refresh = useCallback(() => {
     setRefreshNonce((current) => current + 1);
   }, []);
 
-  const visibleSnapshot =
-    retainedSnapshot.scopeKey === scopeKey
-      ? retainedSnapshot
-      : EMPTY_TEAM_INBOX_PULL_REQUESTS_SNAPSHOT;
-
   return {
-    items: visibleSnapshot.items,
-    loading: !visibleSnapshot.loaded && loading,
-    error: loadError ?? visibleSnapshot.error,
+    items,
+    loading,
+    error: loadError,
     refresh,
   };
 }

--- a/src/modules/MainApp/WorkManagement/useGitHubWorkItemsLoadLifecycle.test.ts
+++ b/src/modules/MainApp/WorkManagement/useGitHubWorkItemsLoadLifecycle.test.ts
@@ -3,7 +3,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GitHubRepoPermissions } from "@src/api/tauri/github";
 
 import type { GitHubRepoSource } from "./githubWorkItemsTypes";
-import { loadRepoPermissions } from "./useGitHubWorkItemsLoadLifecycle";
+import {
+  EMPTY_REPO_PRS,
+  type GitHubWorkItemsLifecycleSnapshot,
+  getGitHubLifecycleRetentionKey,
+  loadRepoPermissions,
+  retainGitHubWorkItemsLifecycleSnapshot,
+} from "./useGitHubWorkItemsLoadLifecycle";
 
 const mocks = vi.hoisted(() => ({
   getGitHubRepoPermissionsLocal: vi.fn(),
@@ -57,5 +63,77 @@ describe("GitHub work-item permission loading", () => {
     await loadRepoPermissions(source, "other-viewer", requests);
 
     expect(mocks.getGitHubRepoPermissionsLocal).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("GitHub work-item lifecycle retention", () => {
+  it("uses a stable scope key independent of repository input order", () => {
+    const first = {
+      id: "repo-1",
+      name: "one",
+      kind: "git",
+      path: "/one",
+      repo_url: "https://github.com/acme/one.git",
+    } as const;
+    const second = {
+      id: "repo-2",
+      name: "two",
+      kind: "git",
+      path: "/two",
+      repo_url: "https://github.com/acme/two.git",
+    } as const;
+
+    expect(getGitHubLifecycleRetentionKey([first, second], "pr")).toBe(
+      getGitHubLifecycleRetentionKey([second, first], "pr")
+    );
+    expect(getGitHubLifecycleRetentionKey([first], "pr")).not.toBe(
+      getGitHubLifecycleRetentionKey([first], "issue")
+    );
+  });
+
+  it("preserves references for unchanged revalidation results", () => {
+    const current: GitHubWorkItemsLifecycleSnapshot = {
+      viewerLogin: "viewer",
+      repoSources: [source],
+      repoIssueMap: {},
+      repoPrMap: { [source.repoFullName]: EMPTY_REPO_PRS },
+      loadError: null,
+    };
+
+    const next = retainGitHubWorkItemsLifecycleSnapshot({
+      current,
+      ...current,
+      repoSources: [{ ...source }],
+      repoPrMap: {
+        [source.repoFullName]: { ...EMPTY_REPO_PRS },
+      },
+    });
+
+    expect(next).toBe(current);
+    expect(next.repoSources).toBe(current.repoSources);
+    expect(next.repoPrMap).toBe(current.repoPrMap);
+  });
+
+  it("bounds the number of retained repositories", () => {
+    const sources = Array.from({ length: 10 }, (_, index) => ({
+      ...source,
+      repoId: `repo-${index}`,
+      repoPath: `/repo-${index}`,
+      repoFullName: `acme/repo-${index}`,
+    }));
+    const repoPrMap = Object.fromEntries(
+      sources.map((repoSource) => [repoSource.repoFullName, EMPTY_REPO_PRS])
+    );
+
+    const next = retainGitHubWorkItemsLifecycleSnapshot({
+      viewerLogin: "viewer",
+      repoSources: sources,
+      repoIssueMap: {},
+      repoPrMap,
+      loadError: null,
+    });
+
+    expect(next.repoSources).toHaveLength(8);
+    expect(Object.keys(next.repoPrMap)).toHaveLength(8);
   });
 });

--- a/src/modules/MainApp/WorkManagement/useGitHubWorkItemsLoadLifecycle.ts
+++ b/src/modules/MainApp/WorkManagement/useGitHubWorkItemsLoadLifecycle.ts
@@ -1,3 +1,7 @@
+import { useStore } from "jotai";
+import type { Store } from "jotai/vanilla/store";
+import isEqual from "lodash/isEqual";
+import type { Dispatch, SetStateAction } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { getGitRemotes } from "@src/api/http/git/remotes";
@@ -13,6 +17,7 @@ import type {
   PullRequestListState,
 } from "@src/api/tauri/github";
 import {
+  GITHUB_LIST_CACHE_TTL_MS,
   coalesceGitHubListRequest,
   getCachedIssues,
   getCachedPrs,
@@ -26,6 +31,7 @@ import { parseGithubRepoFullName } from "@src/services/git/operations/createPull
 import { fetchIssues } from "@src/services/git/operations/githubIssues";
 import { REPO_KIND } from "@src/store/repo";
 import type { Repo } from "@src/store/repo/types";
+import { StoreScopedSnapshotCache } from "@src/util/cache/storeScopedSnapshotCache";
 import { mapWithConcurrency } from "@src/util/collections/mapWithConcurrency";
 
 import type {
@@ -40,6 +46,10 @@ import {
 export const ISSUE_PAGE_SIZE = 50;
 const PR_PAGE_SIZE = 50;
 const GITHUB_SOURCE_CONCURRENCY = 4;
+const MAX_RETAINED_GITHUB_LIST_SCOPES = 4;
+const MAX_RETAINED_GITHUB_REPOS = 8;
+const MAX_RETAINED_ISSUES_PER_STATE = 100;
+const MAX_RETAINED_PRS_PER_STATE = 100;
 
 export interface RepoIssueState {
   openIssues: GitHubIssue[];
@@ -60,6 +70,24 @@ export interface RepoPrState {
   openError: string | null;
   closedError: string | null;
 }
+
+export interface GitHubWorkItemsLifecycleSnapshot {
+  viewerLogin: string;
+  repoSources: GitHubRepoSource[];
+  repoIssueMap: Record<string, RepoIssueState>;
+  repoPrMap: Record<string, RepoPrState>;
+  loadError: string | null;
+}
+
+const retainedLifecycleSnapshots = new StoreScopedSnapshotCache<
+  string,
+  GitHubWorkItemsLifecycleSnapshot
+>(MAX_RETAINED_GITHUB_LIST_SCOPES, GITHUB_LIST_CACHE_TTL_MS);
+const resolvedViewerByStore = new WeakMap<Store, string>();
+const permissionRequestsByStore = new WeakMap<
+  Store,
+  Map<string, Promise<GitHubRepoPermissions | null>>
+>();
 
 interface RepoIssueLoadResult extends RepoIssueState {
   source: GitHubRepoSource;
@@ -96,6 +124,81 @@ export const EMPTY_REPO_PRS: RepoPrState = {
 
 export function getRepoIssueMapKey(source: GitHubRepoSource): string {
   return source.repoFullName;
+}
+
+export function getGitHubLifecycleRetentionKey(
+  repos: readonly Repo[],
+  scope: Extract<GitHubQueryScope, "issue" | "pr">
+): string {
+  return JSON.stringify([
+    scope,
+    ...repos
+      .filter((repo) => repo.kind === REPO_KIND.GIT && repo.path)
+      .map((repo) => [repo.id, repo.path, repo.repo_url ?? "", repo.name])
+      .sort(([leftId], [rightId]) => leftId.localeCompare(rightId)),
+  ]);
+}
+
+function boundedIssueState(state: RepoIssueState): RepoIssueState {
+  return {
+    ...state,
+    openIssues: state.openIssues.slice(0, MAX_RETAINED_ISSUES_PER_STATE),
+    closedIssues: state.closedIssues.slice(0, MAX_RETAINED_ISSUES_PER_STATE),
+  };
+}
+
+function boundedPrState(state: RepoPrState): RepoPrState {
+  return {
+    ...state,
+    openPrs: state.openPrs.slice(0, MAX_RETAINED_PRS_PER_STATE),
+    closedPrs: state.closedPrs.slice(0, MAX_RETAINED_PRS_PER_STATE),
+  };
+}
+
+export function retainGitHubWorkItemsLifecycleSnapshot({
+  current,
+  viewerLogin,
+  repoSources,
+  repoIssueMap,
+  repoPrMap,
+  loadError,
+}: {
+  current?: GitHubWorkItemsLifecycleSnapshot;
+  viewerLogin: string;
+  repoSources: GitHubRepoSource[];
+  repoIssueMap: Record<string, RepoIssueState>;
+  repoPrMap: Record<string, RepoPrState>;
+  loadError: string | null;
+}): GitHubWorkItemsLifecycleSnapshot {
+  const boundedSources = repoSources.slice(0, MAX_RETAINED_GITHUB_REPOS);
+  const retainedRepoNames = new Set(
+    boundedSources.map((source) => source.repoFullName)
+  );
+  const boundedIssueMap = Object.fromEntries(
+    Object.entries(repoIssueMap)
+      .filter(([repoFullName]) => retainedRepoNames.has(repoFullName))
+      .map(([repoFullName, state]) => [repoFullName, boundedIssueState(state)])
+  );
+  const boundedPrMap = Object.fromEntries(
+    Object.entries(repoPrMap)
+      .filter(([repoFullName]) => retainedRepoNames.has(repoFullName))
+      .map(([repoFullName, state]) => [repoFullName, boundedPrState(state)])
+  );
+  const next = {
+    viewerLogin,
+    repoSources: boundedSources,
+    repoIssueMap: boundedIssueMap,
+    repoPrMap: boundedPrMap,
+    loadError,
+  };
+  return current && isEqual(current, next) ? current : next;
+}
+
+function setIfChanged<T>(
+  setValue: Dispatch<SetStateAction<T>>,
+  nextValue: T
+): void {
+  setValue((current) => (isEqual(current, nextValue) ? current : nextValue));
 }
 
 export function mergeUniqueIssues(
@@ -174,9 +277,13 @@ export async function loadRepoPermissions(
   const key = `${viewerLogin.toLowerCase()}:${source.repoFullName}`;
   let permissionRequest = permissionRequests.get(key);
   if (!permissionRequest) {
-    permissionRequest = getGitHubRepoPermissionsLocal(
-      source.repoFullName
-    ).catch(() => null);
+    permissionRequest = getGitHubRepoPermissionsLocal(source.repoFullName)
+      .catch(() => null)
+      .finally(() => {
+        if (permissionRequests.get(key) === permissionRequest) {
+          permissionRequests.delete(key);
+        }
+      });
     permissionRequests.set(key, permissionRequest);
   }
   return [source.repoFullName, await permissionRequest];
@@ -303,37 +410,86 @@ export function useGitHubWorkItemsLoadLifecycle({
   allReposValue?: string;
   currentWorkstationValue?: string;
 }) {
-  const [repoSources, setRepoSources] = useState<GitHubRepoSource[]>([]);
-  const [repoIssueMap, setRepoIssueMap] = useState<
-    Record<string, RepoIssueState>
-  >({});
-  const [repoPrMap, setRepoPrMap] = useState<Record<string, RepoPrState>>({});
-  const [loading, setLoading] = useState(true);
-  const [loadError, setLoadError] = useState<string | null>(null);
-  const handledRefreshNonceRef = useRef(0);
-  const permissionRequestsRef = useRef<
-    Map<string, Promise<GitHubRepoPermissions | null>>
-  >(new Map());
-  const permissionViewerRef = useRef<string | null>(null);
+  const store = useStore();
   const gitRepos = useMemo(
     () => repos.filter((repo) => repo.kind === REPO_KIND.GIT && repo.path),
     [repos]
   );
+  const retentionKey = useMemo(
+    () => getGitHubLifecycleRetentionKey(gitRepos, scope),
+    [gitRepos, scope]
+  );
+  const retainedSnapshot = useMemo(() => {
+    const currentViewer = resolvedViewerByStore.get(store);
+    const snapshot = retainedLifecycleSnapshots.get(store, retentionKey);
+    return snapshot && snapshot.viewerLogin === currentViewer ? snapshot : null;
+  }, [retentionKey, store]);
+  const [repoSources, setRepoSources] = useState<GitHubRepoSource[]>(
+    () => retainedSnapshot?.repoSources ?? []
+  );
+  const [repoIssueMap, setRepoIssueMap] = useState<
+    Record<string, RepoIssueState>
+  >(() => retainedSnapshot?.repoIssueMap ?? {});
+  const [repoPrMap, setRepoPrMap] = useState<Record<string, RepoPrState>>(
+    () => retainedSnapshot?.repoPrMap ?? {}
+  );
+  const [loading, setLoading] = useState(() => !retainedSnapshot);
+  const [loadError, setLoadError] = useState<string | null>(
+    () => retainedSnapshot?.loadError ?? null
+  );
+  const loadedRef = useRef(Boolean(retainedSnapshot));
+  const handledRefreshNonceRef = useRef(0);
+  const permissionRequests = useMemo(() => {
+    let requests = permissionRequestsByStore.get(store);
+    if (!requests) {
+      requests = new Map();
+      permissionRequestsByStore.set(store, requests);
+    }
+    return requests;
+  }, [store]);
+  const permissionViewerRef = useRef<string | null>(
+    retainedSnapshot?.viewerLogin ?? null
+  );
+
+  useEffect(() => {
+    const viewerLogin = permissionViewerRef.current;
+    if (!viewerLogin || !loadedRef.current || loading) return;
+    const current = retainedLifecycleSnapshots.get(store, retentionKey);
+    retainedLifecycleSnapshots.set(
+      store,
+      retentionKey,
+      retainGitHubWorkItemsLifecycleSnapshot({
+        current,
+        viewerLogin,
+        repoSources,
+        repoIssueMap,
+        repoPrMap,
+        loadError,
+      })
+    );
+  }, [
+    loadError,
+    loading,
+    repoIssueMap,
+    repoPrMap,
+    repoSources,
+    retentionKey,
+    store,
+  ]);
 
   useEffect(() => {
     let cancelled = false;
     const forceRefresh = refreshNonce !== handledRefreshNonceRef.current;
     handledRefreshNonceRef.current = refreshNonce;
-    if (forceRefresh) permissionRequestsRef.current.clear();
     void (async () => {
-      setLoading(true);
+      if (forceRefresh || !loadedRef.current) setLoading(true);
       setLoadError(null);
       if (gitRepos.length === 0) {
-        permissionRequestsRef.current.clear();
         permissionViewerRef.current = null;
-        setRepoSources([]);
-        setRepoIssueMap({});
-        setRepoPrMap({});
+        loadedRef.current = true;
+        setIfChanged(setRepoSources, []);
+        setIfChanged(setRepoIssueMap, {});
+        setIfChanged(setRepoPrMap, {});
         setLoading(false);
         return;
       }
@@ -358,33 +514,34 @@ export function useGitHubWorkItemsLoadLifecycle({
         .map((source) => ({ ...source, viewerLogin: viewerResult.login }));
       if (cancelled) return;
       if (!viewerResult.login) {
-        permissionRequestsRef.current.clear();
         permissionViewerRef.current = null;
-        setRepoSources(resolvedSources);
-        setRepoIssueMap({});
-        setRepoPrMap({});
+        resolvedViewerByStore.delete(store);
+        retainedLifecycleSnapshots.delete(store, retentionKey);
+        loadedRef.current = false;
+        setIfChanged(setRepoSources, resolvedSources);
+        setIfChanged(setRepoIssueMap, {});
+        setIfChanged(setRepoPrMap, {});
         setLoadError(
           viewerLoginError ?? "GitHub viewer identity is unavailable"
         );
         setLoading(false);
         return;
       }
+      const viewerChanged =
+        permissionViewerRef.current !== null &&
+        permissionViewerRef.current !== viewerResult.login;
       if (permissionViewerRef.current !== viewerResult.login) {
-        permissionRequestsRef.current.clear();
         permissionViewerRef.current = viewerResult.login;
       }
-      const permissionKeyPrefix = `${viewerResult.login.toLowerCase()}:`;
-      const activePermissionKeys = new Set(
-        resolvedSources.map(
-          (source) => `${permissionKeyPrefix}${source.repoFullName}`
-        )
-      );
-      for (const key of permissionRequestsRef.current.keys()) {
-        if (!activePermissionKeys.has(key)) {
-          permissionRequestsRef.current.delete(key);
-        }
+      resolvedViewerByStore.set(store, viewerResult.login);
+      if (viewerChanged) {
+        retainedLifecycleSnapshots.delete(store, retentionKey);
+        setIfChanged(setRepoSources, []);
+        setIfChanged(setRepoIssueMap, {});
+        setIfChanged(setRepoPrMap, {});
       }
-      setRepoIssueMap(
+      setIfChanged(
+        setRepoIssueMap,
         scope === "issue"
           ? Object.fromEntries(
               resolvedSources.map((source) => [
@@ -394,7 +551,8 @@ export function useGitHubWorkItemsLoadLifecycle({
             )
           : {}
       );
-      setRepoPrMap(
+      setIfChanged(
+        setRepoPrMap,
         scope === "pr"
           ? Object.fromEntries(
               resolvedSources.map((source) => [
@@ -405,7 +563,8 @@ export function useGitHubWorkItemsLoadLifecycle({
           : {}
       );
       if (resolvedSources.length === 0) {
-        setRepoSources([]);
+        loadedRef.current = true;
+        setIfChanged(setRepoSources, []);
         setLoading(false);
         return;
       }
@@ -418,11 +577,7 @@ export function useGitHubWorkItemsLoadLifecycle({
       });
       const [permissionResults, issueResults, prResults] = await Promise.all([
         mapWithConcurrency(sourcesToLoad, GITHUB_SOURCE_CONCURRENCY, (source) =>
-          loadRepoPermissions(
-            source,
-            viewerResult.login,
-            permissionRequestsRef.current
-          )
+          loadRepoPermissions(source, viewerResult.login, permissionRequests)
         ),
         scope === "issue"
           ? mapWithConcurrency(
@@ -443,14 +598,17 @@ export function useGitHubWorkItemsLoadLifecycle({
       ]);
       if (cancelled) return;
       const permissionByRepo = new Map(permissionResults);
-      setRepoSources(
+      loadedRef.current = true;
+      setIfChanged(
+        setRepoSources,
         resolvedSources.map((source) => ({
           ...source,
           permissions: permissionByRepo.get(source.repoFullName) ?? null,
         }))
       );
       if (scope === "issue") {
-        setRepoIssueMap(
+        setIfChanged(
+          setRepoIssueMap,
           Object.fromEntries(
             issueResults.map(({ source, error: _error, ...state }) => [
               getRepoIssueMapKey(source),
@@ -479,7 +637,7 @@ export function useGitHubWorkItemsLoadLifecycle({
                     closedError: result.error,
                   };
           }
-          return next;
+          return isEqual(current, next) ? current : next;
         });
       }
       setLoadError(
@@ -498,11 +656,14 @@ export function useGitHubWorkItemsLoadLifecycle({
     currentWorkstationValue,
     gitRepos,
     issueStates,
+    permissionRequests,
     prStates,
     refreshNonce,
     scope,
     selectedRepo,
     selectedRepoPath,
+    store,
+    retentionKey,
   ]);
 
   const updateIssueMap = useCallback(
@@ -510,7 +671,11 @@ export function useGitHubWorkItemsLoadLifecycle({
       update: (
         current: Record<string, RepoIssueState>
       ) => Record<string, RepoIssueState>
-    ) => setRepoIssueMap(update),
+    ) =>
+      setRepoIssueMap((current) => {
+        const next = update(current);
+        return isEqual(current, next) ? current : next;
+      }),
     []
   );
   const updatePrMap = useCallback(
@@ -518,7 +683,11 @@ export function useGitHubWorkItemsLoadLifecycle({
       update: (
         current: Record<string, RepoPrState>
       ) => Record<string, RepoPrState>
-    ) => setRepoPrMap(update),
+    ) =>
+      setRepoPrMap((current) => {
+        const next = update(current);
+        return isEqual(current, next) ? current : next;
+      }),
     []
   );
   const setListError = useCallback((error: string | null) => {

--- a/src/modules/MainApp/WorkManagement/useGitHubWorkItemsLoadLifecycle.ts
+++ b/src/modules/MainApp/WorkManagement/useGitHubWorkItemsLoadLifecycle.ts
@@ -134,7 +134,15 @@ export function getGitHubLifecycleRetentionKey(
     scope,
     ...repos
       .filter((repo) => repo.kind === REPO_KIND.GIT && repo.path)
-      .map((repo) => [repo.id, repo.path, repo.repo_url ?? "", repo.name])
+      .map(
+        (repo) =>
+          [
+            repo.id ?? "",
+            repo.path ?? "",
+            repo.repo_url ?? "",
+            repo.name,
+          ] as const
+      )
       .sort(([leftId], [rightId]) => leftId.localeCompare(rightId)),
   ]);
 }
@@ -196,7 +204,7 @@ export function retainGitHubWorkItemsLifecycleSnapshot({
 
 function setIfChanged<T>(
   setValue: Dispatch<SetStateAction<T>>,
-  nextValue: T
+  nextValue: NoInfer<T>
 ): void {
   setValue((current) => (isEqual(current, nextValue) ? current : nextValue));
 }

--- a/src/modules/ProjectManager/ProjectManagerLayout/components/useProjectWorkItemsTabContentWorkspaceData.test.ts
+++ b/src/modules/ProjectManager/ProjectManagerLayout/components/useProjectWorkItemsTabContentWorkspaceData.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { projectApi } from "@src/api/http/project";
+import type { WorkspaceWorkItemsData } from "@src/api/http/project";
+
+import type { AggregatedWorkItem } from "./ProjectWorkItemsTabContentTypes";
+import {
+  type ProjectWorkItemsWorkspaceSnapshot,
+  loadWorkspaceWorkItemsBucket,
+  retainProjectWorkItemsWorkspaceSnapshot,
+} from "./useProjectWorkItemsTabContentWorkspaceData";
+
+function item(id: string): AggregatedWorkItem {
+  return {
+    item: { session_id: id },
+    shortId: id,
+    orgId: "org-a",
+  } as AggregatedWorkItem;
+}
+
+describe("retainProjectWorkItemsWorkspaceSnapshot", () => {
+  it("preserves the snapshot and row references when data is unchanged", () => {
+    const rows = [item("WI-1")];
+    const current: ProjectWorkItemsWorkspaceSnapshot = {
+      workItemsByProject: rows,
+      projectOptions: [],
+      loaded: true,
+      error: null,
+      workspaceSourceMode: "local_only",
+      completedItemsLoaded: false,
+    };
+
+    const next = retainProjectWorkItemsWorkspaceSnapshot({
+      ...current,
+      current,
+      workItemsByProject: [item("WI-1")],
+    });
+
+    expect(next).toBe(current);
+    expect(next.workItemsByProject).toBe(rows);
+  });
+
+  it("publishes a changed list and bounds retained rows", () => {
+    const rows = Array.from({ length: 550 }, (_, index) => item(`WI-${index}`));
+
+    const next = retainProjectWorkItemsWorkspaceSnapshot({
+      workItemsByProject: rows,
+      projectOptions: [],
+      loaded: true,
+      error: null,
+      workspaceSourceMode: "local_only",
+      completedItemsLoaded: false,
+    });
+
+    expect(next.workItemsByProject).toHaveLength(500);
+    expect(next.workItemsByProject[499]?.shortId).toBe("WI-499");
+  });
+});
+
+describe("loadWorkspaceWorkItemsBucket", () => {
+  it("shares an equivalent in-flight read across rapid remounts", async () => {
+    let resolveWorkspace: (value: WorkspaceWorkItemsData) => void = () => {};
+    const workspaceRequest = new Promise<WorkspaceWorkItemsData>((resolve) => {
+      resolveWorkspace = resolve;
+    });
+    const readWorkspace = vi.fn(
+      (
+        _options?: Parameters<typeof projectApi.readWorkspaceWorkItemsData>[0]
+      ) => workspaceRequest
+    );
+    const readLinear = vi.fn(async () => []);
+    const options = {
+      orgId: "org-a",
+      includeExternalSources: false,
+    };
+
+    const first = loadWorkspaceWorkItemsBucket(options, {
+      readWorkspace,
+      readLinear,
+    });
+    const second = loadWorkspaceWorkItemsBucket(options, {
+      readWorkspace,
+      readLinear,
+    });
+
+    expect(second).toBe(first);
+    expect(readWorkspace).toHaveBeenCalledOnce();
+    expect(readLinear).not.toHaveBeenCalled();
+
+    resolveWorkspace({} as WorkspaceWorkItemsData);
+    await expect(first).resolves.toEqual({
+      workspaceData: {},
+      linearWorkItems: [],
+    });
+  });
+});

--- a/src/modules/ProjectManager/ProjectManagerLayout/components/useProjectWorkItemsTabContentWorkspaceData.ts
+++ b/src/modules/ProjectManager/ProjectManagerLayout/components/useProjectWorkItemsTabContentWorkspaceData.ts
@@ -6,12 +6,20 @@
  * and the local/external workspace-source toggle. Extracted to keep the
  * tab-content component under the 600-line limit.
  */
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useStore } from "jotai";
+import isEqual from "lodash/isEqual";
+import type { Dispatch, SetStateAction } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { projectApi } from "@src/api/http/project";
+import type {
+  WorkItemReadBucket,
+  WorkspaceWorkItemsData,
+} from "@src/api/http/project";
 import { useProjectDataChanged } from "@src/hooks/project";
 import { isWorkspaceCompletedWorkItem } from "@src/modules/ProjectManager/WorkItems/workItemsViewModel";
 import { loadWorkspaceLinearWorkItems } from "@src/modules/ProjectManager/workspaceAggregate";
+import { StoreScopedSnapshotCache } from "@src/util/cache/storeScopedSnapshotCache";
 
 import {
   WORKSPACE_ACTIVE_READ_BUCKET,
@@ -32,40 +40,201 @@ interface UseProjectWorkItemsTabContentWorkspaceDataParams {
   t: (key: string) => string;
 }
 
+interface WorkspaceProjectOption {
+  id: string;
+  name: string;
+  slug: string;
+  orgId: string;
+  orgName?: string;
+}
+
+export interface ProjectWorkItemsWorkspaceSnapshot {
+  workItemsByProject: AggregatedWorkItem[];
+  projectOptions: WorkspaceProjectOption[];
+  loaded: boolean;
+  error: string | null;
+  workspaceSourceMode: WorkspaceSourceMode;
+  completedItemsLoaded: boolean;
+}
+
+const MAX_RETAINED_WORK_ITEM_SCOPES = 4;
+const MAX_RETAINED_WORK_ITEMS = 500;
+const MAX_RETAINED_PROJECT_OPTIONS = 100;
+const RETAINED_WORK_ITEMS_TTL_MS = 10 * 60 * 1000;
+
+const retainedWorkspaceSnapshots = new StoreScopedSnapshotCache<
+  string,
+  ProjectWorkItemsWorkspaceSnapshot
+>(MAX_RETAINED_WORK_ITEM_SCOPES, RETAINED_WORK_ITEMS_TTL_MS);
+
+interface WorkspaceBucketLoadResult {
+  workspaceData: WorkspaceWorkItemsData;
+  linearWorkItems: Awaited<ReturnType<typeof loadWorkspaceLinearWorkItems>>;
+}
+
+interface WorkspaceBucketLoaders {
+  readWorkspace: typeof projectApi.readWorkspaceWorkItemsData;
+  readLinear: typeof loadWorkspaceLinearWorkItems;
+}
+
+const workspaceBucketRequests = new Map<
+  string,
+  Promise<WorkspaceBucketLoadResult>
+>();
+
+export function loadWorkspaceWorkItemsBucket(
+  {
+    orgId,
+    readBucket,
+    includeExternalSources,
+  }: {
+    orgId?: string;
+    readBucket?: WorkItemReadBucket;
+    includeExternalSources: boolean;
+  },
+  loaders: WorkspaceBucketLoaders = {
+    readWorkspace: projectApi.readWorkspaceWorkItemsData,
+    readLinear: loadWorkspaceLinearWorkItems,
+  }
+): Promise<WorkspaceBucketLoadResult> {
+  const key = JSON.stringify([
+    orgId ?? null,
+    readBucket ?? null,
+    includeExternalSources,
+  ]);
+  const pending = workspaceBucketRequests.get(key);
+  if (pending) return pending;
+
+  const request = Promise.all([
+    loaders.readWorkspace({ orgId, readBucket }),
+    includeExternalSources ? loaders.readLinear() : Promise.resolve([]),
+  ])
+    .then(([workspaceData, linearWorkItems]) => ({
+      workspaceData,
+      linearWorkItems,
+    }))
+    .finally(() => {
+      if (workspaceBucketRequests.get(key) === request) {
+        workspaceBucketRequests.delete(key);
+      }
+    });
+  workspaceBucketRequests.set(key, request);
+  return request;
+}
+
+export function retainProjectWorkItemsWorkspaceSnapshot({
+  current,
+  workItemsByProject,
+  projectOptions,
+  loaded,
+  error,
+  workspaceSourceMode,
+  completedItemsLoaded,
+}: {
+  current?: ProjectWorkItemsWorkspaceSnapshot;
+  workItemsByProject: AggregatedWorkItem[];
+  projectOptions: WorkspaceProjectOption[];
+  loaded: boolean;
+  error: string | null;
+  workspaceSourceMode: WorkspaceSourceMode;
+  completedItemsLoaded: boolean;
+}): ProjectWorkItemsWorkspaceSnapshot {
+  const next = {
+    workItemsByProject: workItemsByProject.slice(0, MAX_RETAINED_WORK_ITEMS),
+    projectOptions: projectOptions.slice(0, MAX_RETAINED_PROJECT_OPTIONS),
+    loaded,
+    error,
+    workspaceSourceMode,
+    completedItemsLoaded,
+  };
+  return current && isEqual(current, next) ? current : next;
+}
+
+function semanticStateSetter<T>(
+  setValue: Dispatch<SetStateAction<T>>
+): Dispatch<SetStateAction<T>> {
+  return (update) => {
+    setValue((current) => {
+      const next = typeof update === "function" ? update(current) : update;
+      return isEqual(current, next) ? current : next;
+    });
+  };
+}
+
 export function useProjectWorkItemsTabContentWorkspaceData({
   orgId,
   allowExternalSources,
   t,
 }: UseProjectWorkItemsTabContentWorkspaceDataParams) {
-  const [workItemsByProject, setWorkItemsByProject] = useState<
+  const store = useStore();
+  const retentionKey = `${orgId ?? "all-orgs"}:${allowExternalSources ? "external-allowed" : "local-only"}`;
+  const retainedSnapshot = useMemo(
+    () => retainedWorkspaceSnapshots.get(store, retentionKey),
+    [retentionKey, store]
+  );
+  const [workItemsByProject, setWorkItemsByProjectState] = useState<
     AggregatedWorkItem[]
-  >([]);
-  const [projectOptions, setProjectOptions] = useState<
-    Array<{
-      id: string;
-      name: string;
-      slug: string;
-      orgId: string;
-      orgName?: string;
-    }>
-  >([]);
-  const [loading, setLoading] = useState(true);
-  const [loaded, setLoaded] = useState(false);
-  const loadedRef = useRef(false);
+  >(() => retainedSnapshot?.workItemsByProject ?? []);
+  const setWorkItemsByProject = useMemo(
+    () => semanticStateSetter(setWorkItemsByProjectState),
+    []
+  );
+  const [projectOptions, setProjectOptionsState] = useState<
+    WorkspaceProjectOption[]
+  >(() => retainedSnapshot?.projectOptions ?? []);
+  const setProjectOptions = useMemo(
+    () => semanticStateSetter(setProjectOptionsState),
+    []
+  );
+  const [loading, setLoading] = useState(() => !retainedSnapshot?.loaded);
+  const [loaded, setLoaded] = useState(() => retainedSnapshot?.loaded ?? false);
+  const loadedRef = useRef(retainedSnapshot?.loaded ?? false);
   const loadGenerationRef = useRef(0);
-  const completedItemsLoadedRef = useRef(false);
+  const completedItemsLoadedRef = useRef(
+    retainedSnapshot?.completedItemsLoaded ?? false
+  );
   const [completedItemsLoading, setCompletedItemsLoading] = useState(false);
   const completedItemsLoadingRef = useRef(false);
   const completedLoadGenerationRef = useRef(0);
   const [completedItemsError, setCompletedItemsError] = useState<string | null>(
     null
   );
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(
+    () => retainedSnapshot?.error ?? null
+  );
   const [workspaceSourceMode, setWorkspaceSourceMode] =
-    useState<WorkspaceSourceMode>("local_only");
+    useState<WorkspaceSourceMode>(
+      () => retainedSnapshot?.workspaceSourceMode ?? "local_only"
+    );
 
   const includeExternalSources =
     allowExternalSources && workspaceSourceMode === "include_external";
+
+  useEffect(() => {
+    if (!loaded) return;
+    const current = retainedWorkspaceSnapshots.get(store, retentionKey);
+    retainedWorkspaceSnapshots.set(
+      store,
+      retentionKey,
+      retainProjectWorkItemsWorkspaceSnapshot({
+        current,
+        workItemsByProject,
+        projectOptions,
+        loaded,
+        error,
+        workspaceSourceMode,
+        completedItemsLoaded: completedItemsLoadedRef.current,
+      })
+    );
+  }, [
+    error,
+    loaded,
+    projectOptions,
+    retentionKey,
+    store,
+    workItemsByProject,
+    workspaceSourceMode,
+  ]);
 
   useEffect(() => {
     if (!allowExternalSources) {
@@ -73,7 +242,13 @@ export function useProjectWorkItemsTabContentWorkspaceData({
     }
   }, [allowExternalSources]);
 
+  const completedScopeRef = useRef(
+    `${orgId ?? "all-orgs"}:${includeExternalSources}`
+  );
   useEffect(() => {
+    const completedScope = `${orgId ?? "all-orgs"}:${includeExternalSources}`;
+    if (completedScopeRef.current === completedScope) return;
+    completedScopeRef.current = completedScope;
     completedLoadGenerationRef.current += 1;
     completedItemsLoadedRef.current = false;
     completedItemsLoadingRef.current = false;
@@ -82,20 +257,25 @@ export function useProjectWorkItemsTabContentWorkspaceData({
   }, [includeExternalSources, orgId]);
 
   const loadWorkItems = useCallback(
-    async (cancelled?: () => boolean) => {
+    async (
+      cancelled?: () => boolean,
+      options: { background?: boolean } = {}
+    ) => {
       const loadGeneration = loadGenerationRef.current + 1;
       loadGenerationRef.current = loadGeneration;
-      setLoading(true);
+      if (!options.background) setLoading(true);
       setError(null);
       try {
         const shouldLoadCompleted = completedItemsLoadedRef.current;
         const readBucket = shouldLoadCompleted
           ? undefined
           : WORKSPACE_ACTIVE_READ_BUCKET;
-        const [workspaceData, linearWorkItems] = await Promise.all([
-          projectApi.readWorkspaceWorkItemsData({ orgId, readBucket }),
-          includeExternalSources ? loadWorkspaceLinearWorkItems() : [],
-        ]);
+        const { workspaceData, linearWorkItems } =
+          await loadWorkspaceWorkItemsBucket({
+            orgId,
+            readBucket,
+            includeExternalSources,
+          });
         const entries = readWorkspaceBucket({
           workspaceData,
           orgId,
@@ -144,17 +324,23 @@ export function useProjectWorkItemsTabContentWorkspaceData({
           err instanceof Error ? err.message : t("projects.loadProjectsFailed")
         );
       } finally {
-        if (!cancelled?.() && loadGenerationRef.current === loadGeneration) {
+        if (
+          !options.background &&
+          !cancelled?.() &&
+          loadGenerationRef.current === loadGeneration
+        ) {
           setLoading(false);
         }
       }
     },
-    [includeExternalSources, orgId, t]
+    [includeExternalSources, orgId, setProjectOptions, setWorkItemsByProject, t]
   );
 
   useEffect(() => {
     let cancelled = false;
-    void loadWorkItems(() => cancelled);
+    void loadWorkItems(() => cancelled, {
+      background: loadedRef.current,
+    });
     return () => {
       cancelled = true;
     };
@@ -162,7 +348,7 @@ export function useProjectWorkItemsTabContentWorkspaceData({
 
   useProjectDataChanged(
     useCallback(() => {
-      void loadWorkItems();
+      void loadWorkItems(undefined, { background: loadedRef.current });
     }, [loadWorkItems])
   );
 
@@ -177,13 +363,12 @@ export function useProjectWorkItemsTabContentWorkspaceData({
     setCompletedItemsLoading(true);
     setCompletedItemsError(null);
     try {
-      const [workspaceData, linearWorkItems] = await Promise.all([
-        projectApi.readWorkspaceWorkItemsData({
+      const { workspaceData, linearWorkItems } =
+        await loadWorkspaceWorkItemsBucket({
           orgId,
           readBucket: WORKSPACE_COMPLETED_READ_BUCKET,
-        }),
-        includeExternalSources ? loadWorkspaceLinearWorkItems() : [],
-      ]);
+          includeExternalSources,
+        });
       const completedEntries = readWorkspaceBucket({
         workspaceData,
         orgId,
@@ -207,7 +392,7 @@ export function useProjectWorkItemsTabContentWorkspaceData({
         setCompletedItemsLoading(false);
       }
     }
-  }, [includeExternalSources, orgId, t]);
+  }, [includeExternalSources, orgId, setWorkItemsByProject, t]);
 
   return {
     workItemsByProject,

--- a/src/modules/ProjectManager/ProjectManagerLayout/components/useProjectWorkItemsTabContentWorkspaceData.ts
+++ b/src/modules/ProjectManager/ProjectManagerLayout/components/useProjectWorkItemsTabContentWorkspaceData.ts
@@ -155,7 +155,10 @@ function semanticStateSetter<T>(
 ): Dispatch<SetStateAction<T>> {
   return (update) => {
     setValue((current) => {
-      const next = typeof update === "function" ? update(current) : update;
+      const next =
+        typeof update === "function"
+          ? (update as (previous: T) => T)(current)
+          : update;
       return isEqual(current, next) ? current : next;
     });
   };

--- a/src/util/cache/__tests__/storeScopedSnapshotCache.test.ts
+++ b/src/util/cache/__tests__/storeScopedSnapshotCache.test.ts
@@ -1,0 +1,46 @@
+import { createStore } from "jotai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { StoreScopedSnapshotCache } from "../storeScopedSnapshotCache";
+
+describe("StoreScopedSnapshotCache", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("isolates values by Jotai store", () => {
+    const cache = new StoreScopedSnapshotCache<string, string>(2);
+    const firstStore = createStore();
+    const secondStore = createStore();
+
+    cache.set(firstStore, "list", "first");
+
+    expect(cache.get(firstStore, "list")).toBe("first");
+    expect(cache.get(secondStore, "list")).toBeUndefined();
+  });
+
+  it("evicts the least recently used entry at the configured bound", () => {
+    const cache = new StoreScopedSnapshotCache<string, number>(2);
+    const store = createStore();
+
+    cache.set(store, "first", 1);
+    cache.set(store, "second", 2);
+    expect(cache.get(store, "first")).toBe(1);
+    cache.set(store, "third", 3);
+
+    expect(cache.get(store, "second")).toBeUndefined();
+    expect(cache.get(store, "first")).toBe(1);
+    expect(cache.get(store, "third")).toBe(3);
+  });
+
+  it("expires retained snapshots on read", () => {
+    vi.useFakeTimers();
+    const cache = new StoreScopedSnapshotCache<string, number>(2, 1_000);
+    const store = createStore();
+
+    cache.set(store, "list", 1);
+    vi.advanceTimersByTime(1_001);
+
+    expect(cache.get(store, "list")).toBeUndefined();
+  });
+});

--- a/src/util/cache/storeScopedSnapshotCache.ts
+++ b/src/util/cache/storeScopedSnapshotCache.ts
@@ -1,0 +1,44 @@
+import type { Store } from "jotai/vanilla/store";
+
+import { LRUCache } from "./lruCache";
+
+/**
+ * Small retained snapshots that belong to a rendered Jotai store.
+ *
+ * The WeakMap prevents data from crossing app/test stores and lets an entire
+ * store be collected without an explicit teardown path. Each store's cache is
+ * independently bounded and optionally expires entries on read.
+ */
+export class StoreScopedSnapshotCache<K, V> {
+  private stores = new WeakMap<Store, LRUCache<K, V>>();
+
+  constructor(
+    private readonly maxEntries: number,
+    private readonly ttlMs?: number
+  ) {}
+
+  get(store: Store, key: K): V | undefined {
+    return this.stores.get(store)?.get(key);
+  }
+
+  set(store: Store, key: K, value: V): void {
+    let cache = this.stores.get(store);
+    if (!cache) {
+      cache = new LRUCache<K, V>(this.maxEntries, this.ttlMs);
+      this.stores.set(store, cache);
+    }
+    cache.set(key, value);
+  }
+
+  delete(store: Store, key: K): boolean {
+    return this.stores.get(store)?.delete(key) ?? false;
+  }
+
+  clear(store?: Store): void {
+    if (store) {
+      this.stores.delete(store);
+      return;
+    }
+    this.stores = new WeakMap<Store, LRUCache<K, V>>();
+  }
+}


### PR DESCRIPTION
## Problem

Switching away from the Work Management tab in the chat pane unmounts its surface. The GitHub pull-request/issue lifecycle and workspace Work Items hook kept their rendered rows only in component-local React state, so returning to the tab discarded the visible list and showed a loading state while the same small dataset was reconstructed. Team Inbox also had a separate PR retention layer, leaving two owners for the same GitHub list lifecycle.

## Solution

Add a reusable store-scoped snapshot cache and retain the last usable GitHub and workspace Work Items list snapshots at their shared data owners. Snapshots paint synchronously after a remount, revalidate in the background, and preserve existing references when the result is semantically unchanged.

The cache is memory-only: this change writes no additional localStorage data and introduces no persistence schema. Each Jotai store uses weak ownership, a 10-minute TTL, and hard LRU bounds. GitHub retention is capped at four scopes, eight repositories per scope, and 100 rows per state/repository; workspace retention is capped at four scopes, 500 Work Items, and 100 project options per scope. Equivalent GitHub permission and workspace bucket requests are single-flight during rapid remounts.

Remove the Team Inbox-specific PR snapshot so Inbox and Work Management now use the same GitHub lifecycle owner. GitHub snapshots are viewer-aware and are evicted when viewer resolution changes or authentication fails.

## Potential risks

- A retained snapshot can be briefly visible while background revalidation runs. This is intentional stale-while-revalidate behavior; explicit auth failure or a changed GitHub viewer clears the retained GitHub rows.
- The in-memory bounds retain up to the documented row limits for ten minutes. Entries are LRU-evicted, scoped per Jotai store, and the WeakMap releases the full per-store cache when that store is collected.
- No visual pixels changed, so screenshots would not demonstrate the behavioral difference. The live Tauri/WebView interaction was not manually exercised; regression coverage verifies cache isolation, bounds, reference preservation, single-flight reads, and affected list rendering.
- Rollback is a direct revert of this commit. There are no wire, database, localStorage, or persisted-format changes to migrate or recover.

## Verification

- `npx vitest run src/modules/MainApp/WorkManagement src/modules/MainApp/TeamInbox/useTeamInboxPullRequests.test.ts src/modules/MainApp/TeamInbox/__tests__/TeamInboxView.layout.test.ts src/modules/ProjectManager/ProjectManagerLayout/components/useProjectWorkItemsTabContentWorkspaceData.test.ts src/util/cache/__tests__/storeScopedSnapshotCache.test.ts` — 19 files passed, 73 tests passed.
- `npx tsc --noEmit --pretty false` — passed.
- Changed-file `npx eslint ...` — passed with zero warnings/errors.
- `git diff --check origin/develop...HEAD` — passed.
- Confirmed the PR diff contains only the eight list-retention implementation/test files and is based on the latest fetched `origin/develop`.

## Audit

- Performance guard: pass. Hidden Work Management remains unmounted; no hidden subscription, polling, timer, or persistent write was added. Retention is bounded/disposable, equivalent requests are single-flight, and stale completions retain the existing generation/cancellation guards.
- Architecture audit: all ten layers reviewed. The duplicate Inbox PR cache was removed; Inbox and Work Management now have entry-point parity through the shared GitHub lifecycle. Wire serialization and resolver fallback changes are not applicable.
