### PR TITLE
test(core): make the orgtrack suite portable to Windows

### DIFF
--- a/src-tauri/crates/orgtrack-core/src/sources/copilot/history_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/copilot/history_tests.rs
@@ -86,9 +86,15 @@ fn build_fixture_root(tag: &str) -> PathBuf {
             r#"{"type":"user.message","data":{"content":"junk"},"id":"j1","timestamp":"2026-07-29T08:00:00.000Z","parentId":null}"#,
         ],
     );
-    // Junk: draft placeholder dir.
-    fs::create_dir_all(root.join("pending-session:draft:1966e2f4-b455-4969-a6ed-bcbc28a59056"))
-        .expect("create draft junk dir");
+    // Junk: draft placeholder dir. The exact macOS shape uses ':', which NTFS
+    // cannot create (it denotes an alternate data stream), so Windows
+    // exercises the same not-a-plain-session-id rejection with a legal
+    // separator while unix keeps the literal provider shape.
+    #[cfg(unix)]
+    let draft_junk = "pending-session:draft:1966e2f4-b455-4969-a6ed-bcbc28a59056";
+    #[cfg(not(unix))]
+    let draft_junk = "pending-session-draft-1966e2f4-b455-4969-a6ed-bcbc28a59056";
+    fs::create_dir_all(root.join(draft_junk)).expect("create draft junk dir");
     // Metadata-only dir (aborted/help invocation): plain id, no events.jsonl.
     let aborted = root.join("3c3c3c3c-1234-4123-8123-123412341234");
     fs::create_dir_all(&aborted).expect("create aborted dir");

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/scan_snapshot_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/scan_snapshot_tests.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, UNIX_EPOCH};
+use std::time::Duration;
 
 use rusqlite::Connection;
 
@@ -209,6 +209,9 @@ fn bounded_walker_does_not_follow_symlinked_files_or_directories() {
 #[test]
 fn bounded_walker_does_not_follow_a_symlink_from_a_reused_snapshot() {
     use std::os::unix::fs::symlink;
+    // Only this unix-gated test needs it; a top-level import is an unused
+    // import under `-D warnings` on Windows.
+    use std::time::UNIX_EPOCH;
 
     let root = temp_tree("bounded-reused-symlink");
     let outside = temp_tree("bounded-reused-symlink-outside");

--- a/src-tauri/crates/orgtrack-core/src/sources/kimi/history_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/kimi/history_tests.rs
@@ -528,22 +528,28 @@ fn failed_core_projection_keeps_the_record_retry_eligible() {
 
 #[test]
 fn kimi_code_home_override_stays_inside_external_history_identity() {
-    let home = Path::new("/isolated/history-home");
-    assert_eq!(kimi_code_home_for(home, None), home.join(".kimi-code"));
+    // Absolute fixtures must be platform-absolute: a unix-rooted "/x" is not
+    // absolute on Windows (`is_absolute` needs a drive prefix there), which
+    // silently routed the inside-home case through the fallback branch.
+    let base = std::env::temp_dir().join("orgii-kimi-home-identity-test");
+    let home = base.join("history-home");
+    assert_eq!(kimi_code_home_for(&home, None), home.join(".kimi-code"));
     assert_eq!(
-        kimi_code_home_for(home, Some(OsStr::new("custom-kimi"))),
+        kimi_code_home_for(&home, Some(OsStr::new("custom-kimi"))),
         home.join("custom-kimi")
     );
+    let inside = home.join("custom-kimi");
     assert_eq!(
-        kimi_code_home_for(home, Some(OsStr::new("/isolated/history-home/custom-kimi"))),
+        kimi_code_home_for(&home, Some(inside.as_os_str())),
         home.join("custom-kimi")
     );
+    let outside = base.join("primary-user").join(".kimi-code");
     assert_eq!(
-        kimi_code_home_for(home, Some(OsStr::new("/primary-user/.kimi-code"))),
+        kimi_code_home_for(&home, Some(outside.as_os_str())),
         home.join(".kimi-code")
     );
     assert_eq!(
-        kimi_code_home_for(home, Some(OsStr::new("../escape"))),
+        kimi_code_home_for(&home, Some(OsStr::new("../escape"))),
         home.join(".kimi-code")
     );
 }


### PR DESCRIPTION
## Problem

Windows runs of `cargo test -p orgtrack_core --lib` carried a permanent 8-failure baseline (7 copilot, 1 kimi) plus a clippy `-D warnings` failure, so local verification and real-machine test protocols on Windows could not distinguish new regressions from environment noise.

## Solution

All three are test-portability fixes; no production code changes.

- **copilot**: the shared fixture builder created the literal macOS draft-dir shape `pending-session:draft:<uuid>` — NTFS cannot create names containing `:`. Unix keeps the provider-exact literal; Windows exercises the same not-a-plain-session-id rejection through a legal separator.
- **kimi**: `kimi_code_home_override_stays_inside_external_history_identity` used unix-rooted absolute fixture paths, which are not `is_absolute` on Windows and silently exercised the fallback branch instead of the inside-home acceptance branch. Fixtures now derive platform-absolute paths from `temp_dir`.
- **scan_snapshot_tests**: `UNIX_EPOCH` was imported at the top level but only used inside a `#[cfg(unix)]` test; the import moves inside the gate, unblocking `-D warnings`.

## Verification

- Windows: `cargo test -p orgtrack_core --lib` — 537 passed, 0 failed, 8 ignored (first fully green Windows run).
- Windows: `cargo clippy -p orgtrack_core --all-targets -- -D warnings` — clean.
- The unix-only branches (the literal `:` draft shape, the symlink walker test) remain gated exactly as before, so macOS/Linux coverage is unchanged.