### PR TITLE
Align cloud session loading progress with the chat top bar

### DIFF
--- a/src/engines/ChatPanel/ChatHistory/components/ChatHistoryView.tsx
+++ b/src/engines/ChatPanel/ChatHistory/components/ChatHistoryView.tsx
@@ -409,22 +409,25 @@ const ChatHistoryView: React.FC<ChatHistoryViewProps> = ({
               )}
 
             {/* One pinned top-overlay slot: pagination shimmer and the
-                download progress/play card stack instead of overpainting
-                each other at the same z. A round-first skeleton renders the
-                transcript while segments are still streaming in — the
-                download card stays pinned above it; the empty/loading
-                branch mounts its own card. */}
+                download progress/play surface stack instead of overpainting
+                each other. Transcript items and pinned headers create local
+                z-layers up to 70, so this status-only layer sits above chat
+                content but below app modals (z-10000+). */}
             {(isLoadingMore ||
               (hasCloudDownloadProgress &&
                 activeProjectionHistory.length > 0)) && (
               <div
-                className={`absolute left-0 right-0 top-0 z-20 mx-auto ${surfaceBgClass} p-2 ${DETAIL_PANEL_TOKENS.contentMaxWidth}`}
+                className={`pointer-events-none absolute left-0 right-0 top-0 z-[9999] mx-auto p-2 ${DETAIL_PANEL_TOKENS.contentMaxWidth}`}
               >
                 {hasCloudDownloadProgress &&
                   activeProjectionHistory.length > 0 && (
                     <CloudSessionDownloadProgressCard sessionId={activeId} />
                   )}
-                {isLoadingMore && <ChatLoadingBlock />}
+                {isLoadingMore && (
+                  <div className={`pointer-events-auto ${surfaceBgClass}`}>
+                    <ChatLoadingBlock />
+                  </div>
+                )}
               </div>
             )}
 

--- a/src/features/Org2Cloud/CloudSessionDownloadProgressCard.test.ts
+++ b/src/features/Org2Cloud/CloudSessionDownloadProgressCard.test.ts
@@ -1,0 +1,97 @@
+import { Provider, createStore } from "jotai";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import CloudSessionDownloadProgressCard from "./CloudSessionDownloadProgressCard";
+import {
+  type CloudSessionDownloadProgress,
+  cloudSessionDownloadProgressAtom,
+} from "./cloudSessionDownloadProgressAtom";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      key: string,
+      options?: { eta?: string; loaded?: number; total?: number }
+    ) => {
+      if (key === "cloud.download.events") {
+        return `${options?.loaded} / ${options?.total} events`;
+      }
+      if (key === "cloud.download.eta") {
+        return `About ${options?.eta} remaining`;
+      }
+      return key;
+    },
+  }),
+}));
+
+function renderProgress(
+  overrides: Partial<CloudSessionDownloadProgress> = {}
+): string {
+  const store = createStore();
+  store.set(
+    cloudSessionDownloadProgressAtom,
+    new Map([
+      [
+        "session-1",
+        {
+          rowId: "row-1",
+          orgId: "org-1",
+          loadedEvents: 138,
+          totalEvents: 252,
+          startedAtMs: 1_000,
+          updatedAtMs: 11_000,
+          phase: "downloading",
+          ...overrides,
+        },
+      ],
+    ])
+  );
+
+  return renderToStaticMarkup(
+    createElement(
+      Provider,
+      { store },
+      createElement(CloudSessionDownloadProgressCard, {
+        sessionId: "session-1",
+      })
+    )
+  );
+}
+
+describe("CloudSessionDownloadProgressCard", () => {
+  it("renders progress and its pill together in one top-bar line", () => {
+    const markup = renderProgress();
+
+    expect(markup).toContain('role="progressbar"');
+    expect(markup).toContain('aria-valuenow="54"');
+    expect(markup).toContain("h-0.5");
+    expect(markup).toContain("!rounded-none");
+    expect(markup).toContain("min-w-10 flex-1");
+    expect(markup).toContain(
+      'data-testid="cloud-session-download-progress-pill"'
+    );
+    expect(markup).toContain("max-w-[75%]");
+    expect(markup).not.toContain("absolute inset-x-0 top-2");
+    expect(markup).toContain("rounded-full");
+    expect(markup).toContain("54%");
+    expect(markup).toContain("138 / 252 events");
+    expect(markup).toContain("About 8s remaining");
+  });
+
+  it("keeps paused progress and its resume action inside the pill", () => {
+    const markup = renderProgress({ phase: "paused" });
+
+    expect(markup).toContain("cloud.download.paused");
+    expect(markup).toContain('data-testid="cloud-session-download-resume"');
+    expect(markup).not.toContain("About 8s remaining");
+  });
+
+  it("keeps an indeterminate download label visible when no numbers exist", () => {
+    const markup = renderProgress({ loadedEvents: 0, totalEvents: null });
+
+    expect(markup).toContain("progress-bar--indeterminate");
+    expect(markup).toContain("cloud.download.title");
+  });
+});

--- a/src/features/Org2Cloud/CloudSessionDownloadProgressCard.tsx
+++ b/src/features/Org2Cloud/CloudSessionDownloadProgressCard.tsx
@@ -51,12 +51,27 @@ const DownloadBar: React.FC<{
   percent: number | null;
   paused?: boolean;
   className: string;
-}> = ({ percent, paused = false, className }) => (
+  compact?: boolean;
+  ariaLabel?: string;
+  ariaValuetext?: string;
+}> = ({
+  percent,
+  paused = false,
+  className,
+  compact = false,
+  ariaLabel,
+  ariaValuetext,
+}) => (
   <ProgressBar
     percent={percent ?? 0}
     indeterminate={percent === null}
+    ariaLabel={ariaLabel}
+    ariaValuetext={ariaValuetext}
     color={paused ? "bg-fill-4" : "bg-primary-6"}
+    height={compact ? "h-0.5" : undefined}
     width={className}
+    trackColor={compact ? "bg-transparent" : undefined}
+    className={compact ? "!rounded-none" : undefined}
   />
 );
 
@@ -112,7 +127,7 @@ const PendingPlay: React.FC<{
   }
   return (
     <div
-      className="mx-1 mb-2 flex items-center justify-between gap-2 rounded-md border border-border-2 bg-bg-2 p-3 text-xs text-text-2"
+      className="pointer-events-auto mx-1 mb-2 flex items-center justify-between gap-2 rounded-md border border-border-2 bg-bg-2 p-3 text-xs text-text-2"
       data-testid="cloud-session-download-pending"
     >
       <span className="tabular-nums text-text-3">{estimate}</span>
@@ -204,70 +219,92 @@ const CardProgress: React.FC<{
   const finalizing = progress.phase === "finalizing";
   const paused = progress.phase === "paused";
   const completed = progress.phase === "completed";
+  const statusLabel = finalizing
+    ? t("cloud.download.finalizing")
+    : completed
+      ? t("cloud.download.complete")
+      : paused
+        ? t("cloud.download.paused")
+        : t("cloud.download.title");
+  const eventsLabel =
+    progress.totalEvents !== null
+      ? t("cloud.download.events", {
+          loaded: progress.loadedEvents,
+          total: progress.totalEvents,
+        })
+      : null;
+  const etaLabel =
+    etaMs !== null && !finalizing && !paused && !completed
+      ? t("cloud.download.eta", { eta: formatCloudDownloadEta(etaMs) })
+      : null;
+  const progressValueText = [
+    statusLabel,
+    percent !== null ? `${percent}%` : null,
+    eventsLabel,
+    etaLabel,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+  const showStatusInPill =
+    finalizing || paused || completed || (!eventsLabel && percent === null);
+
   return (
     <div
-      className="mx-1 mb-2 rounded-md border border-border-2 bg-bg-2 p-3"
+      className="pointer-events-auto mx-1 mb-2 flex items-center gap-2"
       data-testid="cloud-session-download-progress"
     >
-      <div className="flex items-center justify-between gap-2 text-xs text-text-2">
-        <span>
-          {finalizing
-            ? t("cloud.download.finalizing")
-            : completed
-              ? t("cloud.download.complete")
-              : paused
-                ? t("cloud.download.paused")
-                : t("cloud.download.title")}
-        </span>
-        <span className="inline-flex items-center gap-2">
-          {percent !== null && (
-            <span className="tabular-nums text-text-3">{percent}%</span>
-          )}
-          {!finalizing &&
-            !completed &&
-            (paused ? (
-              <Button
-                variant="secondary"
-                size="mini"
-                data-testid="cloud-session-download-resume"
-                onClick={() =>
-                  requestStart({
-                    rowId: progress.rowId,
-                    orgId: progress.orgId,
-                  })
-                }
-              >
-                {t("cloud.download.resume")}
-              </Button>
-            ) : (
-              <Button
-                variant="tertiary"
-                size="mini"
-                data-testid="cloud-session-download-pause"
-                onClick={() => cancelCloudSessionDownload(progress.rowId)}
-              >
-                {t("cloud.download.pause")}
-              </Button>
-            ))}
-        </span>
-      </div>
-      <div className="mt-2">
-        <DownloadBar percent={percent} paused={paused} className="w-full" />
-      </div>
-      <div className="mt-1.5 flex items-center justify-between gap-2 text-[11px] text-text-3">
-        <span className="tabular-nums">
-          {progress.totalEvents !== null
-            ? t("cloud.download.events", {
-                loaded: progress.loadedEvents,
-                total: progress.totalEvents,
-              })
-            : null}
-        </span>
-        {etaMs !== null && !finalizing && !paused && !completed && (
-          <span>
-            {t("cloud.download.eta", { eta: formatCloudDownloadEta(etaMs) })}
+      <DownloadBar
+        percent={percent}
+        paused={paused}
+        className="min-w-10 flex-1"
+        compact
+        ariaLabel={statusLabel}
+        ariaValuetext={progressValueText}
+      />
+      <div
+        className="inline-flex min-w-0 max-w-[75%] shrink-0 items-center gap-2 rounded-full border border-border-2/80 bg-bg-2/95 px-3 py-1 text-[11px] text-text-3 shadow-lg backdrop-blur-md"
+        data-testid="cloud-session-download-progress-pill"
+      >
+        {showStatusInPill && (
+          <span className="shrink-0 text-text-2">{statusLabel}</span>
+        )}
+        {percent !== null && (
+          <span className="shrink-0 font-medium tabular-nums text-text-2">
+            {percent}%
           </span>
         )}
+        {eventsLabel && (
+          <span className="min-w-0 truncate tabular-nums" title={eventsLabel}>
+            {eventsLabel}
+          </span>
+        )}
+        {etaLabel && <span className="shrink-0">{etaLabel}</span>}
+        {!finalizing &&
+          !completed &&
+          (paused ? (
+            <Button
+              variant="secondary"
+              size="mini"
+              data-testid="cloud-session-download-resume"
+              onClick={() =>
+                requestStart({
+                  rowId: progress.rowId,
+                  orgId: progress.orgId,
+                })
+              }
+            >
+              {t("cloud.download.resume")}
+            </Button>
+          ) : (
+            <Button
+              variant="tertiary"
+              size="mini"
+              data-testid="cloud-session-download-pause"
+              onClick={() => cancelCloudSessionDownload(progress.rowId)}
+            >
+              {t("cloud.download.pause")}
+            </Button>
+          ))}
       </div>
     </div>
   );


### PR DESCRIPTION
## Problem

Cloud-session replay progress is rendered as a large pinned card at `z-20`. Transcript content and pinned headers can use higher local stacking layers, so messages can paint over the progress surface. The card presentation also does not match the compact loading line used by work-item surfaces.

## Solution

Render active cloud-session progress as one compact horizontal status row aligned to the chat content width: a thin determinate or indeterminate progress line followed by a rounded numeric/status pill containing percentage, event count, ETA, and pause/resume controls. Raise the chat-history status overlay to `z-[9999]`, keep its non-interactive area click-through, and keep application modals above it at `z-10000+`.

The progress bar now exposes an accessible label and value text, and focused render tests cover determinate, paused, and indeterminate states.

## Potential risks

The elevated overlay can intentionally cover the top edge of transcript content while a cloud session is downloading. The status pill is capped at 75% width and truncates the event label on narrow panes, so unusually long localized labels may be shortened. The layer remains below application modals, but a manual desktop visual check is still outstanding because computer-control access was not authorized; the PR remains draft for that reason.

## Verification

- `npm run typecheck` — passed on a clean worktree based on current `origin/develop`.
- `npx eslint src/features/Org2Cloud/CloudSessionDownloadProgressCard.tsx src/features/Org2Cloud/CloudSessionDownloadProgressCard.test.ts src/engines/ChatPanel/ChatHistory/components/ChatHistoryView.tsx` — passed.
- `npx vitest run src/features/Org2Cloud/CloudSessionDownloadProgressCard.test.ts src/features/Org2Cloud/cloudSessionDownloadProgressAtom.test.ts src/engines/ChatPanel/blocks/primitives/ChatLoadingBlock.test.ts` — 16 tests passed.
- `git diff --cached --check` — passed before commit.
- Pre-commit lint-staged and scoped TypeScript checks — passed.
- Manual desktop screenshot — not run; computer control is explicit opt-in in this repository.
