### PR TITLE
Hide leading shell chrome in GitHub detail tabs

### DIFF
--- a/src/modules/WorkStation/TabContent/renderers/githubIssueDetail.tsx
+++ b/src/modules/WorkStation/TabContent/renderers/githubIssueDetail.tsx
@@ -45,7 +45,7 @@ const GitHubIssueDetailTabRenderer: React.FC<UnifiedTabContentProps> = memo(
       content: {
         content: headerContent,
         trailing: headerTrailing,
-        sidebarToggleDisabled: true,
+        shellLeadingChromeHidden: true,
       },
     });
 

--- a/src/modules/WorkStation/TabContent/renderers/githubPrDetail.tsx
+++ b/src/modules/WorkStation/TabContent/renderers/githubPrDetail.tsx
@@ -92,7 +92,7 @@ const GitHubPrDetailTabRenderer: React.FC<UnifiedTabContentProps> = memo(
       content: {
         content: headerContent,
         trailing: headerTrailing,
-        sidebarToggleDisabled: true,
+        shellLeadingChromeHidden: true,
         joinWithFollowingRow: true,
       },
     });


### PR DESCRIPTION
## Problem

GitHub issue and pull-request detail tabs disable the sidebar toggle, but the surrounding shell still reserves and renders its leading chrome. That leaves an unnecessary control area in detail-only tabs.

## Solution

Mark both GitHub detail renderers with `shellLeadingChromeHidden` so the shell removes the entire leading chrome region while preserving the rest of each tab header configuration.

## Potential risks

The change is limited to GitHub issue and pull-request detail tabs. A shell implementation that does not honor `shellLeadingChromeHidden` would retain the old appearance, but no data or navigation behavior changes. Manual desktop visual evidence is still pending, so this PR remains a draft.

## Verification

- `pnpm exec eslint src/modules/WorkStation/TabContent/renderers/githubIssueDetail.tsx src/modules/WorkStation/TabContent/renderers/githubPrDetail.tsx` — passed.
- `pnpm typecheck` — passed.
- Manual desktop verification was not run because local UI control was not authorized for this task.
