### PR TITLE
Preserve work-item lists during partial repository loads

### DIFF
--- a/src/modules/MainApp/WorkManagement/useGitHubWorkItemsLoadLifecycle.test.ts
+++ b/src/modules/MainApp/WorkManagement/useGitHubWorkItemsLoadLifecycle.test.ts
@@ -4,10 +4,12 @@ import type { GitHubRepoPermissions } from "@src/api/tauri/github";
 
 import type { GitHubRepoSource } from "./githubWorkItemsTypes";
 import {
+  EMPTY_REPO_ISSUES,
   EMPTY_REPO_PRS,
   type GitHubWorkItemsLifecycleSnapshot,
   getGitHubLifecycleRetentionKey,
   loadRepoPermissions,
+  mergeRepoIssueLoadResults,
   retainGitHubWorkItemsLifecycleSnapshot,
 } from "./useGitHubWorkItemsLoadLifecycle";
 
@@ -67,6 +69,38 @@ describe("GitHub work-item permission loading", () => {
 });
 
 describe("GitHub work-item lifecycle retention", () => {
+  it("preserves cached issue lists for resolved repositories not loaded in the current pass", () => {
+    const secondSource: GitHubRepoSource = {
+      ...source,
+      repoId: "repo-2",
+      repoPath: "/repo-2",
+      repoFullName: "acme/repo-2",
+    };
+    const cachedSecondState = {
+      ...EMPTY_REPO_ISSUES,
+      openLoaded: true,
+    };
+    const loadedFirstState = {
+      ...EMPTY_REPO_ISSUES,
+      closedLoaded: true,
+    };
+
+    const next = mergeRepoIssueLoadResults(
+      {
+        [source.repoFullName]: EMPTY_REPO_ISSUES,
+        [secondSource.repoFullName]: cachedSecondState,
+        "acme/removed-repo": EMPTY_REPO_ISSUES,
+      },
+      [source, secondSource],
+      [{ source, ...loadedFirstState, error: null }]
+    );
+
+    expect(next).toEqual({
+      [source.repoFullName]: loadedFirstState,
+      [secondSource.repoFullName]: cachedSecondState,
+    });
+  });
+
   it("uses a stable scope key independent of repository input order", () => {
     const first = {
       id: "repo-1",

--- a/src/modules/MainApp/WorkManagement/useGitHubWorkItemsLoadLifecycle.ts
+++ b/src/modules/MainApp/WorkManagement/useGitHubWorkItemsLoadLifecycle.ts
@@ -89,7 +89,7 @@ const permissionRequestsByStore = new WeakMap<
   Map<string, Promise<GitHubRepoPermissions | null>>
 >();
 
-interface RepoIssueLoadResult extends RepoIssueState {
+export interface RepoIssueLoadResult extends RepoIssueState {
   source: GitHubRepoSource;
   error: string | null;
 }
@@ -218,6 +218,23 @@ export function mergeUniqueIssues(
     ...existingIssues,
     ...incomingIssues.filter((issue) => !seenIssueNumbers.has(issue.number)),
   ];
+}
+
+export function mergeRepoIssueLoadResults(
+  current: Record<string, RepoIssueState>,
+  resolvedSources: readonly GitHubRepoSource[],
+  results: readonly RepoIssueLoadResult[]
+): Record<string, RepoIssueState> {
+  const next = Object.fromEntries(
+    resolvedSources.map((source) => {
+      const key = getRepoIssueMapKey(source);
+      return [key, current[key] ?? EMPTY_REPO_ISSUES];
+    })
+  );
+  for (const { source, error: _error, ...state } of results) {
+    next[getRepoIssueMapKey(source)] = state;
+  }
+  return isEqual(current, next) ? current : next;
 }
 
 function getCachedRepoIssues(source: GitHubRepoSource): RepoIssueState {
@@ -615,14 +632,8 @@ export function useGitHubWorkItemsLoadLifecycle({
         }))
       );
       if (scope === "issue") {
-        setIfChanged(
-          setRepoIssueMap,
-          Object.fromEntries(
-            issueResults.map(({ source, error: _error, ...state }) => [
-              getRepoIssueMapKey(source),
-              state,
-            ])
-          )
+        setRepoIssueMap((current) =>
+          mergeRepoIssueLoadResults(current, resolvedSources, issueResults)
         );
       } else {
         setRepoPrMap((current) => {


### PR DESCRIPTION
## Problem

When an issue-loading pass resolves multiple repositories but returns results for only a subset, the lifecycle replaces the entire repository map with that subset. Previously loaded issue lists disappear even though their repositories remain in scope.

## Solution

Merge issue-load results into the current map for every resolved repository. Loaded repositories receive fresh state, unresolved repositories retain their cached state, and repositories removed from the resolved source set are pruned. The updater preserves object identity when the resulting map is unchanged.

## Potential risks

A stale list can remain visible for a repository that is still resolved but fails to return a new result in the current pass; this is intentional retention and the next successful load replaces it. Repositories no longer in scope are still removed, limiting cross-scope leakage.

## Verification

- `pnpm exec vitest run src/modules/MainApp/WorkManagement/useGitHubWorkItemsLoadLifecycle.test.ts` — passed (6 tests).
- `pnpm exec eslint src/modules/MainApp/WorkManagement/useGitHubWorkItemsLoadLifecycle.ts src/modules/MainApp/WorkManagement/useGitHubWorkItemsLoadLifecycle.test.ts` — passed.
- `pnpm typecheck` — passed.
