### PR TITLE
Prioritize GitHub lists in the work-items sidebar

### DIFF
--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/workItemsSidebarMenuItems.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/workItemsSidebarMenuItems.test.ts
@@ -28,15 +28,15 @@ describe("buildWorkItemsSidebarMenuItems", () => {
     });
 
     expect(items.map((item) => item.id)).toEqual([
+      WORK_ITEMS_GITHUB_PRS_MENU_ITEM_ID,
+      WORK_ITEMS_GITHUB_ISSUES_MENU_ITEM_ID,
       WORK_ITEMS_MENU_ITEM_ID,
       WORK_ITEMS_PROJECTS_MENU_ITEM_ID,
-      WORK_ITEMS_GITHUB_ISSUES_MENU_ITEM_ID,
-      WORK_ITEMS_GITHUB_PRS_MENU_ITEM_ID,
     ]);
     expect(items[0]).toMatchObject({
-      label: "Work Items",
-      iconName: "list-todo",
-      dataTestId: "sidebar-work-items",
+      label: "GitHub PRs",
+      iconName: "git-pull-request",
+      dataTestId: "sidebar-work-items-github-prs",
     });
   });
 

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/workItemsSidebarMenuItems.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/workItemsSidebarMenuItems.tsx
@@ -45,6 +45,22 @@ export function buildWorkItemsSidebarMenuItems(labels: {
 }): NavigationMenuItem[] {
   return [
     {
+      id: WORK_ITEMS_GITHUB_PRS_MENU_ITEM_ID,
+      key: WORK_ITEMS_GITHUB_PRS_MENU_ITEM_ID,
+      label: labels.githubPrs,
+      icon: GitPullRequest,
+      iconName: "git-pull-request",
+      dataTestId: "sidebar-work-items-github-prs",
+    },
+    {
+      id: WORK_ITEMS_GITHUB_ISSUES_MENU_ITEM_ID,
+      key: WORK_ITEMS_GITHUB_ISSUES_MENU_ITEM_ID,
+      label: labels.githubIssues,
+      icon: CircleDot,
+      iconName: "circle-dot",
+      dataTestId: "sidebar-work-items-github-issues",
+    },
+    {
       id: WORK_ITEMS_MENU_ITEM_ID,
       key: WORK_ITEMS_MENU_ITEM_ID,
       label: labels.workItems,
@@ -59,22 +75,6 @@ export function buildWorkItemsSidebarMenuItems(labels: {
       icon: Boxes,
       iconName: "boxes",
       dataTestId: "sidebar-work-items-projects",
-    },
-    {
-      id: WORK_ITEMS_GITHUB_ISSUES_MENU_ITEM_ID,
-      key: WORK_ITEMS_GITHUB_ISSUES_MENU_ITEM_ID,
-      label: labels.githubIssues,
-      icon: CircleDot,
-      iconName: "circle-dot",
-      dataTestId: "sidebar-work-items-github-issues",
-    },
-    {
-      id: WORK_ITEMS_GITHUB_PRS_MENU_ITEM_ID,
-      key: WORK_ITEMS_GITHUB_PRS_MENU_ITEM_ID,
-      label: labels.githubPrs,
-      icon: GitPullRequest,
-      iconName: "git-pull-request",
-      dataTestId: "sidebar-work-items-github-prs",
     },
   ];
 }


### PR DESCRIPTION
## Problem

The work-management sidebar places generic Work Items and Projects before the directly actionable GitHub pull-request and issue lists. This makes the most frequently used repository queues slower to reach.

## Solution

Reorder the existing menu entries to show GitHub PRs first, then GitHub Issues, followed by Work Items and Projects. IDs, icons, labels, and navigation targets remain unchanged.

## Potential risks

Users accustomed to the previous ordering may need to adjust their muscle memory. No route or persisted selection identifiers change. Manual desktop visual evidence is pending, so this PR remains a draft.

## Verification

- `pnpm exec vitest run src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/workItemsSidebarMenuItems.test.ts` — passed (3 tests).
- `pnpm exec eslint src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/workItemsSidebarMenuItems.tsx src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/workItemsSidebarMenuItems.test.ts` — passed.
- `pnpm typecheck` — passed.
- Manual desktop verification was not run because local UI control was not authorized for this task.
