### PR TITLE
Clarify interactive references in chat messages

### DIFF
--- a/src/engines/ChatPanel/ChatHistory/components/UserMessageContent.tsx
+++ b/src/engines/ChatPanel/ChatHistory/components/UserMessageContent.tsx
@@ -552,6 +552,11 @@ const InlinePill: React.FC<{ segment: PillSegment }> = memo(({ segment }) => {
   return (
     <BasePill
       variant="editor"
+      className={
+        isClickable
+          ? "underline-offset-2 hover:underline focus-visible:underline active:underline"
+          : undefined
+      }
       iconNode={
         <PillIcon
           pillType={segment.pillType}

--- a/src/engines/ChatPanel/ChatHistory/components/__tests__/UserMessageContent.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/components/__tests__/UserMessageContent.test.ts
@@ -1,6 +1,8 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import {
+import UserMessageContent, {
   normalizeMarkdownReferencePills,
   parseUserMessage,
 } from "../UserMessageContent";
@@ -85,5 +87,29 @@ describe("external-history Markdown URL pills", () => {
     expect(normalizeMarkdownReferencePills(image)).toBe(image);
     expect(normalizeMarkdownReferencePills(escaped)).toBe(escaped);
     expect(normalizeMarkdownReferencePills(credentialed)).toBe(credentialed);
+  });
+});
+
+describe("message reference interactions", () => {
+  it("underlines clickable references on hover, press, and keyboard focus", () => {
+    const markup = renderToStaticMarkup(
+      createElement(UserMessageContent, {
+        text: "fixtures [folder:/tmp/fixtures]",
+      })
+    );
+
+    expect(markup).toContain("hover:underline");
+    expect(markup).toContain("active:underline");
+    expect(markup).toContain("focus-visible:underline");
+  });
+
+  it("does not add interaction underlines to non-clickable references", () => {
+    const markup = renderToStaticMarkup(
+      createElement(UserMessageContent, { text: "main [branch:main]" })
+    );
+
+    expect(markup).not.toContain("hover:underline");
+    expect(markup).not.toContain("active:underline");
+    expect(markup).not.toContain("focus-visible:underline");
   });
 });


### PR DESCRIPTION
## Problem

Clickable file and folder reference pills in user messages look the same as non-interactive pills, so their navigation affordance is easy to miss for mouse, keyboard, and touch users.

## Solution

Add underline feedback to clickable reference pills on hover, active press, and keyboard focus. Non-clickable reference types keep their current appearance, preserving the semantic distinction.

## Potential risks

The underline may slightly increase visual density for messages with many interactive references. The classes only activate during interaction states and do not change click targets or reference parsing. Manual desktop visual evidence is pending, so this PR remains a draft.

## Verification

- `pnpm exec vitest run src/engines/ChatPanel/ChatHistory/components/__tests__/UserMessageContent.test.ts` — passed (7 tests).
- `pnpm exec eslint src/engines/ChatPanel/ChatHistory/components/UserMessageContent.tsx src/engines/ChatPanel/ChatHistory/components/__tests__/UserMessageContent.test.ts` — passed.
- `pnpm typecheck` — passed.
- Manual desktop verification was not run because local UI control was not authorized for this task.
