### PR TITLE
Right-align shared dropdown menus by default

### DIFF
--- a/src/components/Dropdown/index.test.ts
+++ b/src/components/Dropdown/index.test.ts
@@ -1,0 +1,19 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import Dropdown from ".";
+
+describe("Dropdown", () => {
+  it("right-aligns the menu by default", () => {
+    const props: React.ComponentProps<typeof Dropdown> = {
+      defaultPopupVisible: true,
+      droplist: React.createElement("div", null, "Menu"),
+      children: React.createElement("button", { type: "button" }, "Open"),
+    };
+    const markup = renderToStaticMarkup(React.createElement(Dropdown, props));
+
+    expect(markup).toContain("top-full right-0 mt-2");
+    expect(markup).not.toContain("top-full left-0 mt-2");
+  });
+});

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -71,7 +71,7 @@ export interface DropdownProps {
   /**
    * Placement relative to the trigger. Vertical placements flip to their
    * mirror side automatically when the requested side cannot fit the panel.
-   * @default 'bottom-start'
+   * @default 'bottom-end'
    */
   position?: DropdownPosition;
 
@@ -147,7 +147,7 @@ export interface DropdownProps {
 const Dropdown: React.FC<DropdownProps> = ({
   droplist,
   children,
-  position = "bottom-start",
+  position = "bottom-end",
   trigger = "click",
   hoverCloseDelayMs = 100,
   popupVisible: controlledVisible,


### PR DESCRIPTION
## Problem

Shared dropdowns currently default to left alignment even though most toolbar and trailing-action triggers sit on the right edge. Callers must repeatedly override placement or risk panels extending away from their trigger.

## Solution

Change the shared Dropdown default from `bottom-start` to `bottom-end` and document the new default. Callers that require left alignment can continue to pass an explicit position.

## Potential risks

Any consumer relying implicitly on the previous left-aligned default will move to right alignment. Explicitly positioned dropdowns are unaffected. Because this is a shared visual default, the PR remains a draft pending broader desktop visual review.

## Verification

- `pnpm exec vitest run src/components/Dropdown/index.test.ts` — passed (1 test).
- `pnpm exec eslint src/components/Dropdown/index.tsx src/components/Dropdown/index.test.ts` — passed.
- `pnpm typecheck` — passed.
- Manual desktop verification was not run because local UI control was not authorized for this task.
