### PR TITLE
Stabilize GitHub detail loading states

### DIFF
--- a/docs/frontend-ui-audit-2026-08-06/GitHubDetailLoading.md
+++ b/docs/frontend-ui-audit-2026-08-06/GitHubDetailLoading.md
@@ -1,0 +1,36 @@
+# Frontend UI Audit — GitHub Detail Loading
+
+## Scope
+
+Initial loading for dedicated GitHub Issue and Pull Request tabs in both the
+chat pane and WorkStation, including lazy-renderer loading and first-detail
+fetches.
+
+The configured `frontend-ui-audit` skill file was unavailable at both documented
+locations, so this report applies the repository's audit format and the existing
+GitHub Issue/PR detail conventions directly.
+
+## Findings
+
+| Line                                | Element                       | Verdict          | Reason                                                                                                                                                           | Suggested change                                                                              |
+| ----------------------------------- | ----------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `GitHubDetailSkeleton/index.tsx:19` | Shared GitHub detail skeleton | abstract         | Issue and PR tabs need the same stable first-paint contract across chat and WorkStation; one kind-aware component prevents host-specific loading markup.         | Keep lazy-module and initial-data fallbacks routed through this shared component.             |
+| `GitHubDetailSkeleton/index.tsx:24` | Loading semantics             | keep with reason | `role="status"`, `aria-busy`, a localized accessible label, hidden decorative blocks, and reduced-motion support expose loading without spinner churn.           | Keep the skeleton non-interactive and preserve the motion-reduction path.                     |
+| `GitHubDetailSkeleton/index.tsx:50` | Detail content width          | keep with reason | `max-w-[920px]` intentionally matches the canonical Work Item thread column, preventing a width jump when an Issue skeleton resolves to real content.            | Retain the established detail-column width until a shared layout token is added.              |
+| `surfaceRenderers.tsx:95`           | Chat-pane lazy fallbacks      | fix              | `fallback={null}` painted an empty pane while the Issue/PR renderer chunk loaded and did not reserve the eventual detail hierarchy.                              | Render the matching GitHub detail skeleton immediately.                                       |
+| `UnifiedTabContent.tsx:34`          | WorkStation lazy fallbacks    | fix              | The generic full-pane loading placeholder used a centered spinner for dedicated GitHub detail tabs.                                                              | Select the Issue/PR skeleton by tab type while preserving other tab fallbacks.                |
+| `PrDetailPanel.tsx:442`             | PR first-fetch boundary       | fix              | Fresh PR state begins with `loading=false` and `detail=null`; painting the real layout before the effect flips loading caused the reported content flash.        | Treat unresolved, error-free detail as initial loading from the first render.                 |
+| `GitHubIssuePanelView.tsx:17`       | Issue first-fetch boundary    | keep with reason | Cold/persisted Issue tabs with a resolvable remote use the skeleton, while seeded issue data, explicit errors, and non-loadable empty states retain their paths. | Keep cached/seeded issue content immediate and use the skeleton only while a request can run. |
+
+## Verdict counts
+
+- fix: 3
+- keep with reason: 3
+- abstract: 1
+
+## Accessibility and visual-system notes
+
+The skeleton uses existing semantic color, border, radius, spacing, and surface
+tokens. It is announced as a localized busy status, all placeholder geometry is
+decorative, and pulse animation is disabled under reduced-motion preferences.
+No new interactive controls or arbitrary colors were introduced.

--- a/src/engines/ChatPanel/TabContent/surfaceRenderers.tsx
+++ b/src/engines/ChatPanel/TabContent/surfaceRenderers.tsx
@@ -10,6 +10,7 @@
 import { useSetAtom } from "jotai";
 import React, { Suspense, useCallback } from "react";
 
+import GitHubDetailSkeleton from "@src/modules/shared/components/GitHubDetailSkeleton";
 import {
   type ChatPanelTab,
   closeAndDestroyChatPanelTabAtom,
@@ -96,7 +97,7 @@ export function GitHubIssueSurfaceRenderer({
 }: ChatPanelSurfaceRendererProps): React.ReactNode {
   if (!tab.githubIssue) return null;
   return (
-    <Suspense fallback={null}>
+    <Suspense fallback={<GitHubDetailSkeleton kind="issue" showHeader />}>
       <GitHubIssuePanelView detail={tab.githubIssue} />
     </Suspense>
   );
@@ -107,7 +108,7 @@ export function GitHubPrSurfaceRenderer({
 }: ChatPanelSurfaceRendererProps): React.ReactNode {
   if (!tab.githubPr) return null;
   return (
-    <Suspense fallback={null}>
+    <Suspense fallback={<GitHubDetailSkeleton kind="pr" showHeader />}>
       <GitHubPrPanelView detail={tab.githubPr} />
     </Suspense>
   );

--- a/src/engines/ChatPanel/panels/GitHubIssuePanelView.test.ts
+++ b/src/engines/ChatPanel/panels/GitHubIssuePanelView.test.ts
@@ -1,0 +1,54 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  selectedState: {
+    issue: null,
+    timeline: [],
+    loading: false,
+    timelineLoading: false,
+    error: null,
+    submittingComment: false,
+  },
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@src/modules/shared/hooks/useGitHubIssueDetailState", () => ({
+  useGitHubIssueDetailState: () => ({
+    selectedState: mocks.selectedState,
+    interaction: {},
+    assigneeConfig: undefined,
+  }),
+}));
+
+vi.mock(
+  "@src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/IssuesContent/IssueDetailPanel",
+  () => ({
+    IssueDetailPanel: () => createElement("div", { "data-testid": "issue" }),
+  })
+);
+
+const { GitHubIssuePanelView } = await import("./GitHubIssuePanelView");
+
+describe("GitHubIssuePanelView loading", () => {
+  it("uses the issue skeleton on the cold first render", () => {
+    const markup = renderToStaticMarkup(
+      createElement(GitHubIssuePanelView, {
+        detail: {
+          issueNumber: 586,
+          issueTitle: "Fix initial loading",
+          repoPath: "/repo",
+          remoteUrl: "https://github.com/org/repo.git",
+        },
+      })
+    );
+
+    expect(markup).toContain('data-testid="github-issue-detail-skeleton"');
+    expect(markup).toContain('aria-busy="true"');
+    expect(markup).not.toContain("animate-spin");
+  });
+});

--- a/src/engines/ChatPanel/panels/GitHubIssuePanelView.tsx
+++ b/src/engines/ChatPanel/panels/GitHubIssuePanelView.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { IssueDetailPanel } from "@src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/IssuesContent/IssueDetailPanel";
+import GitHubDetailSkeleton from "@src/modules/shared/components/GitHubDetailSkeleton";
 import { useGitHubIssueDetailState } from "@src/modules/shared/hooks/useGitHubIssueDetailState";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
 import type { GitHubIssueDetailTabData } from "@src/types/githubDetail";
@@ -13,15 +14,12 @@ export function GitHubIssuePanelView({
   const { selectedState, interaction } = useGitHubIssueDetailState(detail);
 
   if (!selectedState.issue) {
+    if (!selectedState.error && (selectedState.loading || detail.remoteUrl)) {
+      return <GitHubDetailSkeleton kind="issue" showHeader />;
+    }
     return (
       <Placeholder
-        variant={
-          selectedState.loading
-            ? "loading"
-            : selectedState.error
-              ? "error"
-              : "empty"
-        }
+        variant={selectedState.error ? "error" : "empty"}
         placement="detail-panel"
         subtitle={selectedState.error ?? undefined}
         fillParentHeight

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.test.ts
@@ -139,6 +139,7 @@ describe("PrDetailPanel tabs", () => {
     store.set(workstationSelectedPrAtomFamily(scopeKey), {
       ...initialSelectedPrState,
       loading: false,
+      detail: {},
       commits: [{}],
     });
 
@@ -215,6 +216,7 @@ describe("PrDetailPanel tabs", () => {
         selectedChangedFilePath: "src/index.ts",
       },
       loading: false,
+      detail: {},
       commits: [{ sha: "abc1234" }],
     });
     const panel = createElement(PrDetailPanel, {
@@ -354,5 +356,36 @@ describe("PrDetailPanel tabs", () => {
     expect(summary?.firstElementChild?.className).toContain("pt-4");
     expect(summary?.firstElementChild?.className).toContain("items-center");
     expect(summary?.firstElementChild?.className).not.toContain("py-4");
+  });
+
+  it("shows the PR skeleton on the first render before detail loading starts", () => {
+    const store = createStore();
+
+    act(() => {
+      root.render(
+        createElement(
+          Provider,
+          { store },
+          createElement(PrDetailPanel, {
+            identity: {
+              number: 42,
+              title: "Avoid the content-to-loading flash",
+              url: "https://github.com/org/repo/pull/42",
+              status: "open",
+              headBranch: "fix/loading-flash",
+              baseBranch: "main",
+            },
+            repoPath: "/repo",
+            showHeader: false,
+          })
+        )
+      );
+    });
+
+    expect(
+      container.querySelector("[data-testid='github-pr-detail-skeleton']")
+    ).not.toBeNull();
+    expect(container.querySelector('[role="tablist"]')).toBeNull();
+    expect(container.querySelector(".animate-spin")).toBeNull();
   });
 });

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.tsx
@@ -36,11 +36,8 @@ import Avatar from "@src/components/Avatar";
 import Button from "@src/components/Button";
 import { DETAIL_PANEL_TOKENS } from "@src/config/detailPanelTokens";
 import { HEADER_ICON_SIZE } from "@src/config/workstation/tokens";
-import {
-  PanelHeader,
-  Placeholder,
-  ScrollTrail,
-} from "@src/modules/shared/layouts/blocks";
+import GitHubDetailSkeleton from "@src/modules/shared/components/GitHubDetailSkeleton";
+import { PanelHeader, ScrollTrail } from "@src/modules/shared/layouts/blocks";
 import { resolvePullRequestDetailStatus } from "@src/shared/pr/prLevelActions";
 import {
   type PrIdentity,
@@ -442,14 +439,8 @@ export const PrDetailPanel: React.FC<PrDetailPanelProps> = ({
     ]
   );
 
-  if (state.loading) {
-    return (
-      <Placeholder
-        variant="loading"
-        placement="detail-panel"
-        fillParentHeight
-      />
-    );
+  if (state.loading || (state.detail === null && state.error === null)) {
+    return <GitHubDetailSkeleton kind="pr" showHeader={showHeader} />;
   }
 
   return (

--- a/src/modules/WorkStation/TabContent/UnifiedTabContent.tsx
+++ b/src/modules/WorkStation/TabContent/UnifiedTabContent.tsx
@@ -11,6 +11,7 @@
  */
 import React, { Suspense, memo } from "react";
 
+import GitHubDetailSkeleton from "@src/modules/shared/components/GitHubDetailSkeleton";
 import type { WorkStationTab } from "@src/store/workstation/tabs/types";
 
 import { TabLoadingPlaceholder } from "./TabLoadingPlaceholder";
@@ -30,8 +31,16 @@ export const UnifiedTabContent: React.FC<UnifiedTabContentDispatcherProps> =
       return <UnknownTabPlaceholder type={tab.type} />;
     }
     const { Component } = entry;
+    const fallback =
+      tab.type === "github-issue-detail" ? (
+        <GitHubDetailSkeleton kind="issue" showHeader={false} />
+      ) : tab.type === "github-pr-detail" ? (
+        <GitHubDetailSkeleton kind="pr" showHeader={false} />
+      ) : (
+        <TabLoadingPlaceholder />
+      );
     return (
-      <Suspense fallback={<TabLoadingPlaceholder />}>
+      <Suspense fallback={fallback}>
         <Component tab={tab} paneId={paneId} isActive={isActive} />
       </Suspense>
     );

--- a/src/modules/WorkStation/TabContent/renderers/githubIssueDetail.tsx
+++ b/src/modules/WorkStation/TabContent/renderers/githubIssueDetail.tsx
@@ -12,6 +12,7 @@ import {
   IssueDetailExternalLinkButton,
   IssueDetailPanel,
 } from "@src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/IssuesContent/IssueDetailPanel";
+import GitHubDetailSkeleton from "@src/modules/shared/components/GitHubDetailSkeleton";
 import GitHubIssueHeaderContent from "@src/modules/shared/components/GitHubIssueHeaderContent";
 import { useGitHubIssueDetailState } from "@src/modules/shared/hooks/useGitHubIssueDetailState";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
@@ -50,15 +51,15 @@ const GitHubIssueDetailTabRenderer: React.FC<UnifiedTabContentProps> = memo(
     });
 
     if (!selectedState.issue) {
+      if (
+        !selectedState.error &&
+        (selectedState.loading || tabData.remoteUrl)
+      ) {
+        return <GitHubDetailSkeleton kind="issue" showHeader={false} />;
+      }
       return (
         <Placeholder
-          variant={
-            selectedState.loading
-              ? "loading"
-              : selectedState.error
-                ? "error"
-                : "empty"
-          }
+          variant={selectedState.error ? "error" : "empty"}
           placement="detail-panel"
           subtitle={selectedState.error ?? undefined}
           fillParentHeight

--- a/src/modules/shared/components/GitHubDetailSkeleton/index.tsx
+++ b/src/modules/shared/components/GitHubDetailSkeleton/index.tsx
@@ -1,0 +1,116 @@
+import React, { memo } from "react";
+import { useTranslation } from "react-i18next";
+
+export interface GitHubDetailSkeletonProps {
+  kind: "issue" | "pr";
+  /** Match hosts that publish the detail title into a shell-owned header. */
+  showHeader?: boolean;
+}
+
+function SkeletonBar({ className }: { className: string }): React.ReactNode {
+  return <div aria-hidden className={`rounded bg-fill-2 ${className}`} />;
+}
+
+/**
+ * Stable first-paint frame for GitHub issue and pull-request detail tabs.
+ * It mirrors the detail hierarchy so lazy chunk loading and the initial data
+ * request never fall back to an empty pane or a page spinner.
+ */
+const GitHubDetailSkeleton: React.FC<GitHubDetailSkeletonProps> = memo(
+  ({ kind, showHeader = true }) => {
+    const { t } = useTranslation();
+
+    return (
+      <div
+        role="status"
+        aria-busy="true"
+        aria-label={t("status.loading")}
+        className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-chat-pane"
+        data-testid={`github-${kind}-detail-skeleton`}
+      >
+        {showHeader ? (
+          <div className="flex h-10 shrink-0 items-center gap-3 px-4">
+            <SkeletonBar className="h-5 w-5 rounded-full" />
+            <SkeletonBar className="h-3 w-16" />
+            <SkeletonBar className="h-4 w-2/5" />
+          </div>
+        ) : null}
+
+        {kind === "pr" ? (
+          <div className="flex h-10 shrink-0 items-end gap-2 border-b border-border-2 px-3 pb-1">
+            <SkeletonBar className="h-7 w-28 rounded-md" />
+            <SkeletonBar className="h-7 w-20 rounded-md" />
+            <SkeletonBar className="h-7 w-20 rounded-md" />
+            <SkeletonBar className="h-7 w-28 rounded-md" />
+          </div>
+        ) : null}
+
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          <div className="scrollbar-overlay min-h-0 min-w-0 flex-1 overflow-y-auto">
+            <div className="mx-auto flex w-full max-w-[920px] animate-pulse flex-col gap-3 px-5 py-5 motion-reduce:animate-none">
+              {kind === "issue" ? (
+                <div className="flex flex-wrap items-center gap-2">
+                  <SkeletonBar className="h-7 w-20 rounded-full" />
+                  <SkeletonBar className="h-7 w-24 rounded-full" />
+                  <SkeletonBar className="h-7 w-32 rounded-full" />
+                </div>
+              ) : (
+                <div className="grid grid-cols-2 gap-x-8 gap-y-4 px-1 py-2">
+                  <SkeletonBar className="h-4 w-full max-w-64" />
+                  <SkeletonBar className="h-4 w-full max-w-40" />
+                  <SkeletonBar className="h-4 w-full max-w-52" />
+                  <SkeletonBar className="h-4 w-full max-w-32" />
+                </div>
+              )}
+
+              <section className="overflow-hidden rounded-xl border border-border-1 bg-primary-container">
+                <div className="flex h-10 items-center gap-2 border-b border-border-1 px-3">
+                  <SkeletonBar className="h-4 w-4 rounded-full" />
+                  <SkeletonBar className="h-3 w-28" />
+                </div>
+                <div className="space-y-3 px-4 py-4">
+                  <SkeletonBar className="h-3 w-full" />
+                  <SkeletonBar className="h-3 w-11/12" />
+                  <SkeletonBar className="h-3 w-4/5" />
+                  <SkeletonBar className="h-3 w-2/3" />
+                </div>
+              </section>
+
+              <section className="overflow-hidden rounded-xl border border-border-1 bg-primary-container">
+                <div className="flex h-10 items-center gap-2 border-b border-border-1 px-3">
+                  <SkeletonBar className="h-4 w-4 rounded-full" />
+                  <SkeletonBar className="h-3 w-24" />
+                </div>
+                <div className="space-y-4 px-4 py-4">
+                  <div className="flex gap-3">
+                    <SkeletonBar className="h-8 w-8 shrink-0 rounded-full" />
+                    <div className="flex min-w-0 flex-1 flex-col gap-2">
+                      <SkeletonBar className="h-3 w-32" />
+                      <SkeletonBar className="h-3 w-full" />
+                      <SkeletonBar className="h-3 w-3/4" />
+                    </div>
+                  </div>
+                  <div className="flex gap-3">
+                    <SkeletonBar className="h-8 w-8 shrink-0 rounded-full" />
+                    <div className="flex min-w-0 flex-1 flex-col gap-2">
+                      <SkeletonBar className="h-3 w-24" />
+                      <SkeletonBar className="h-3 w-5/6" />
+                    </div>
+                  </div>
+                </div>
+              </section>
+            </div>
+          </div>
+
+          <div className="w-11 shrink-0 border-l border-border-1 px-3 py-5">
+            <SkeletonBar className="h-24 w-1 rounded-full" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+);
+
+GitHubDetailSkeleton.displayName = "GitHubDetailSkeleton";
+
+export default GitHubDetailSkeleton;


### PR DESCRIPTION
## Problem

GitHub issue and pull-request detail surfaces can paint an empty pane, a generic spinner, or briefly render unresolved content before their lazy module and initial data request complete. The inconsistent first frame causes visible flashes across chat and WorkStation hosts.

## Solution

Add one shared, accessible GitHub detail skeleton with issue and PR variants. Use it for chat and WorkStation suspense boundaries and for unresolved first-fetch states, while preserving explicit error and non-loadable empty states. The skeleton mirrors the eventual content hierarchy and disables pulse motion for reduced-motion users.

## Potential risks

The skeleton is an approximation of both detail layouts, so future layout changes could make its geometry drift. Cached or seeded issue content still renders immediately; only unresolved, error-free detail states take the skeleton path. Manual desktop evidence across themes and viewport sizes is pending, so this PR remains a draft.

## Audit

Frontend UI audit: 3 fixes, 3 keep-with-reason decisions, and 1 shared abstraction. The report is included at `docs/frontend-ui-audit-2026-08-06/GitHubDetailLoading.md`.

## Verification

- `pnpm exec vitest run src/engines/ChatPanel/panels/GitHubIssuePanelView.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.test.ts` — passed (5 tests).
- ESLint on the 8 changed TypeScript/TSX implementation and test files — passed.
- `pnpm typecheck` — passed.
- `git diff --cached --check` — passed before commit.
- Manual desktop verification was not run because local UI control was not authorized for this task.
