### PR TITLE
Use semantic purple for merged pull requests

### DIFF
--- a/docs/frontend-ui-audit-2026-08-06/MergedPullRequestStatus.md
+++ b/docs/frontend-ui-audit-2026-08-06/MergedPullRequestStatus.md
@@ -1,0 +1,39 @@
+# Frontend UI Audit — Merged Pull Request Status
+
+**Files:** `src/components/Button/index.tsx`, `src/shared/pr/prStatus.ts`, `src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.tsx`, `src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/gitIndicator.tsx`
+**Date:** 2026-08-06
+**Auditor:** Codex PR audit
+
+## D1 — Raw HTML vs Design System
+
+| Line | Element       | Verdict          | Reason                                                                                                              | Suggested change |
+| ---- | ------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| —    | Merged action | keep with reason | Callers continue to use the shared `Button` and PR-status primitives; no new raw interactive element is introduced. | —                |
+
+## D2 — Arbitrary Tailwind Value vs Token
+
+| Line               | Value                               | Verdict          | Reason                                                                                                                               | Suggested change |
+| ------------------ | ----------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| `Button/index.tsx` | `bg-merged`, `text-merged-contrast` | keep with reason | The semantic button colors are mapped through Tailwind to theme-owned CSS variables, including hover, active, and foreground tokens. | —                |
+
+## D3 — Hardcoded Sizes / Colors
+
+| Line                 | Value                                 | Verdict          | Reason                                                                                                                | Suggested change |
+| -------------------- | ------------------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `public/orgii_*.css` | Purple scale and merged-button colors | keep with reason | Hex values live only in the canonical theme definitions; component code consumes semantic tokens instead of literals. | —                |
+
+## D4 — Accessibility
+
+| Line               | Element                      | Verdict | Reason                                                                                                                                                                                                            | Suggested change                                                           |
+| ------------------ | ---------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| `Button/index.tsx` | Solid merged button contrast | fix     | White text on the original dark/high-contrast `purple-6` backgrounds measured 3.35:1 and 1.77:1. Theme-specific merged foreground/background tokens now keep every normal, hover, and active pairing above 4.5:1. | Retain the semantic foreground token whenever merged button colors change. |
+
+## D5 — Visual Patterns Observed
+
+- Badge, dot, text, sidebar indicator, and action-button colors remain owned by the shared PR-status/Button boundaries; no third independent status map is introduced.
+
+## Summary
+
+- 1 fix recommended and applied
+- 3 kept with documented reason
+- 0 abstract candidates

--- a/public/orgii_dark.css
+++ b/public/orgii_dark.css
@@ -176,6 +176,13 @@ body {
   --color-primary-5: #349afd;
   --color-primary-6: #43aafd;
   --color-primary-7: #6ec2fe;
+  --color-purple-1: #271052;
+  --color-purple-2: #3c1e70;
+  --color-purple-3: #553098;
+  --color-purple-4: #6e40c9;
+  --color-purple-5: #8957e5;
+  --color-purple-6: #a371f7;
+  --color-purple-7: #bc8cff;
   --color-danger-1: #4d0000;
   --color-danger-2: #6f0f0f;
   --color-danger-3: #942020;

--- a/public/orgii_dark.css
+++ b/public/orgii_dark.css
@@ -183,6 +183,10 @@ body {
   --color-purple-5: #8957e5;
   --color-purple-6: #a371f7;
   --color-purple-7: #bc8cff;
+  --color-merged-button-bg: #a371f7;
+  --color-merged-button-hover: #bc8cff;
+  --color-merged-button-active: #d8b9ff;
+  --color-merged-button-contrast: #0d1117;
   --color-danger-1: #4d0000;
   --color-danger-2: #6f0f0f;
   --color-danger-3: #942020;

--- a/public/orgii_high_contrast.css
+++ b/public/orgii_high_contrast.css
@@ -166,6 +166,13 @@ body {
   --color-primary-5: #0ea5e9;
   --color-primary-6: #38bdf8;
   --color-primary-7: #7dd3fc;
+  --color-purple-1: #3b0764;
+  --color-purple-2: #581c87;
+  --color-purple-3: #6b21a8;
+  --color-purple-4: #7e22ce;
+  --color-purple-5: #9333ea;
+  --color-purple-6: #d8b4fe;
+  --color-purple-7: #e9d5ff;
   --color-danger-1: #5f1111;
   --color-danger-2: #7f1d1d;
   --color-danger-3: #991b1b;

--- a/public/orgii_high_contrast.css
+++ b/public/orgii_high_contrast.css
@@ -173,6 +173,10 @@ body {
   --color-purple-5: #9333ea;
   --color-purple-6: #d8b4fe;
   --color-purple-7: #e9d5ff;
+  --color-merged-button-bg: #d8b4fe;
+  --color-merged-button-hover: #e9d5ff;
+  --color-merged-button-active: #f3e8ff;
+  --color-merged-button-contrast: #000000;
   --color-danger-1: #5f1111;
   --color-danger-2: #7f1d1d;
   --color-danger-3: #991b1b;

--- a/public/orgii_main.css
+++ b/public/orgii_main.css
@@ -177,6 +177,13 @@ body {
   --color-primary-5: #45abfd;
   --color-primary-6: #1d8ffd;
   --color-primary-7: #126ed1;
+  --color-purple-1: #fbefff;
+  --color-purple-2: #ecd8ff;
+  --color-purple-3: #d8b9ff;
+  --color-purple-4: #c297ff;
+  --color-purple-5: #a475f9;
+  --color-purple-6: #8250df;
+  --color-purple-7: #6639ba;
   --color-danger-1: #ffeae8;
   --color-danger-2: #ffcdc7;
   --color-danger-3: #ffa499;

--- a/public/orgii_main.css
+++ b/public/orgii_main.css
@@ -184,6 +184,10 @@ body {
   --color-purple-5: #a475f9;
   --color-purple-6: #8250df;
   --color-purple-7: #6639ba;
+  --color-merged-button-bg: #8250df;
+  --color-merged-button-hover: #6639ba;
+  --color-merged-button-active: #553098;
+  --color-merged-button-contrast: #ffffff;
   --color-danger-1: #ffeae8;
   --color-danger-2: #ffcdc7;
   --color-danger-3: #ffa499;

--- a/src/components/Button/index.test.ts
+++ b/src/components/Button/index.test.ts
@@ -1,8 +1,39 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 import Button from ".";
+
+function readThemeColor(css: string, token: string): string {
+  const match = css.match(
+    new RegExp(`--color-${token}:\\s*(#[0-9a-f]{6})`, "i")
+  );
+  if (!match?.[1]) throw new Error(`Missing theme color: ${token}`);
+  return match[1];
+}
+
+function relativeLuminance(hex: string): number {
+  const channels = hex
+    .slice(1)
+    .match(/.{2}/g)
+    ?.map((channel) => Number.parseInt(channel, 16) / 255);
+  if (!channels || channels.length !== 3) return 0;
+  const [red, green, blue] = channels.map((channel) =>
+    channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
+  );
+  return red * 0.2126 + green * 0.7152 + blue * 0.0722;
+}
+
+function contrastRatio(first: string, second: string): number {
+  const firstLuminance = relativeLuminance(first);
+  const secondLuminance = relativeLuminance(second);
+  return (
+    (Math.max(firstLuminance, secondLuminance) + 0.05) /
+    (Math.min(firstLuminance, secondLuminance) + 0.05)
+  );
+}
 
 function renderSplitDropdownClassName(
   variant:
@@ -42,16 +73,16 @@ describe("Button split dropdown segment", () => {
 
   it("uses GitHub purple for the merged variant and its split state", () => {
     expect(renderSplitDropdownClassName("merged")).toContain(
-      "enabled:hover:bg-purple-5"
+      "enabled:hover:bg-merged-hover"
     );
     expect(renderSplitDropdownClassName("merged", true)).toContain(
-      "bg-purple-5 enabled:hover:bg-purple-5"
+      "bg-merged-hover enabled:hover:bg-merged-hover"
     );
-    expect(
-      renderToStaticMarkup(
-        React.createElement(Button, { variant: "merged" }, "Merged")
-      )
-    ).toContain("bg-purple-6");
+    const markup = renderToStaticMarkup(
+      React.createElement(Button, { variant: "merged" }, "Merged")
+    );
+    expect(markup).toContain("bg-merged");
+    expect(markup).toContain("text-merged-contrast");
   });
 
   it.each([
@@ -69,4 +100,23 @@ describe("Button split dropdown segment", () => {
       "enabled:hover:bg-fill-3"
     );
   });
+
+  it.each(["orgii_main.css", "orgii_dark.css", "orgii_high_contrast.css"])(
+    "keeps merged button states readable in %s",
+    (themeFile) => {
+      const css = readFileSync(resolve("public", themeFile), "utf8");
+      const foreground = readThemeColor(css, "merged-button-contrast");
+
+      for (const token of [
+        "merged-button-bg",
+        "merged-button-hover",
+        "merged-button-active",
+      ]) {
+        expect(
+          contrastRatio(foreground, readThemeColor(css, token)),
+          `${themeFile} ${token}`
+        ).toBeGreaterThanOrEqual(4.5);
+      }
+    }
+  );
 });

--- a/src/components/Button/index.test.ts
+++ b/src/components/Button/index.test.ts
@@ -1,0 +1,72 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import Button from ".";
+
+function renderSplitDropdownClassName(
+  variant:
+    | "primary"
+    | "secondary"
+    | "danger"
+    | "warning"
+    | "success"
+    | "merged",
+  dropdownVisible = false
+): string {
+  const markup = renderToStaticMarkup(
+    React.createElement(
+      Button,
+      {
+        variant,
+        dropdownMenu: React.createElement("div"),
+        onDropdownClick: vi.fn(),
+        dropdownVisible,
+      },
+      "Action"
+    )
+  );
+  const buttonClassNames = [...markup.matchAll(/<button[^>]*class="([^"]*)"/g)];
+  return buttonClassNames.at(-1)?.[1] ?? "";
+}
+
+describe("Button split dropdown segment", () => {
+  it("uses the success tone while hovered or open", () => {
+    expect(renderSplitDropdownClassName("success")).toContain(
+      "enabled:hover:bg-success-5"
+    );
+    expect(renderSplitDropdownClassName("success", true)).toContain(
+      "bg-success-5 enabled:hover:bg-success-5"
+    );
+  });
+
+  it("uses GitHub purple for the merged variant and its split state", () => {
+    expect(renderSplitDropdownClassName("merged")).toContain(
+      "enabled:hover:bg-purple-5"
+    );
+    expect(renderSplitDropdownClassName("merged", true)).toContain(
+      "bg-purple-5 enabled:hover:bg-purple-5"
+    );
+    expect(
+      renderToStaticMarkup(
+        React.createElement(Button, { variant: "merged" }, "Merged")
+      )
+    ).toContain("bg-purple-6");
+  });
+
+  it.each([
+    ["primary", "primary"],
+    ["danger", "danger"],
+    ["warning", "warning"],
+  ] as const)("uses the %s tone for its semantic variant", (variant, tone) => {
+    expect(renderSplitDropdownClassName(variant)).toContain(
+      `enabled:hover:bg-${tone}-5`
+    );
+  });
+
+  it("keeps neutral solid split buttons neutral", () => {
+    expect(renderSplitDropdownClassName("secondary")).toContain(
+      "enabled:hover:bg-fill-3"
+    );
+  });
+});

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -10,6 +10,7 @@
  *                 "danger"    = destructive
  *                 "warning"   = caution-required
  *                 "success"   = positive confirmation
+ *                 "merged"    = completed GitHub merge
  *
  *   appearance  — visual treatment
  *                 "solid"   = filled background
@@ -39,7 +40,8 @@ export type ButtonVariant =
   | "tertiary"
   | "danger"
   | "warning"
-  | "success";
+  | "success"
+  | "merged";
 
 export type ButtonAppearance = "solid" | "outline" | "dashed" | "ghost";
 
@@ -153,6 +155,7 @@ function defaultAppearanceFor(variant: ButtonVariant): ButtonAppearance {
     case "danger":
     case "warning":
     case "success":
+    case "merged":
       return "solid";
     case "secondary":
       return "outline";
@@ -212,6 +215,13 @@ function getStyleClasses(variant: ButtonVariant, appearance: ButtonAppearance) {
         if (appearance === "dashed")
           return "border border-dashed border-success-6/50 bg-transparent text-success-6";
         return "border-0 bg-transparent text-success-6";
+      case "merged":
+        if (appearance === "solid") return "border-0 text-white bg-purple-6";
+        if (appearance === "outline")
+          return "border border-purple-6 bg-transparent text-purple-6";
+        if (appearance === "dashed")
+          return "border border-dashed border-purple-6/50 bg-transparent text-purple-6";
+        return "border-0 bg-transparent text-purple-6";
     }
   })();
 
@@ -226,6 +236,8 @@ function getStyleClasses(variant: ButtonVariant, appearance: ButtonAppearance) {
           return "enabled:hover:bg-warning-5 enabled:active:bg-warning-6";
         case "success":
           return "enabled:hover:bg-success-5 enabled:active:bg-success-6";
+        case "merged":
+          return "enabled:hover:bg-purple-5 enabled:active:bg-purple-7";
         case "secondary":
           return "enabled:hover:bg-fill-3";
         case "tertiary":
@@ -250,6 +262,8 @@ function getStyleClasses(variant: ButtonVariant, appearance: ButtonAppearance) {
         return "enabled:hover:text-warning-5";
       case "success":
         return "enabled:hover:text-success-5";
+      case "merged":
+        return "enabled:hover:text-purple-5";
       case "secondary":
         return "enabled:hover:text-text-1";
       case "tertiary":
@@ -395,6 +409,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           case "danger":
           case "warning":
           case "success":
+          case "merged":
             return "text-white";
           case "secondary":
             return "text-text-1";
@@ -411,6 +426,8 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           return "text-warning-6";
         case "success":
           return "text-success-6";
+        case "merged":
+          return "text-purple-6";
         case "secondary":
           return "text-text-1";
         case "tertiary":
@@ -420,10 +437,32 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 
     const splitDropdownStateClass = (() => {
       if (isDisabled) return "";
-      if (resolvedAppearance === "solid" && variant === "primary") {
-        return dropdownVisible
-          ? "bg-primary-5 enabled:hover:bg-primary-5"
-          : "enabled:hover:bg-primary-5";
+      if (resolvedAppearance === "solid") {
+        switch (variant) {
+          case "primary":
+            return dropdownVisible
+              ? "bg-primary-5 enabled:hover:bg-primary-5"
+              : "enabled:hover:bg-primary-5";
+          case "danger":
+            return dropdownVisible
+              ? "bg-danger-5 enabled:hover:bg-danger-5"
+              : "enabled:hover:bg-danger-5";
+          case "warning":
+            return dropdownVisible
+              ? "bg-warning-5 enabled:hover:bg-warning-5"
+              : "enabled:hover:bg-warning-5";
+          case "success":
+            return dropdownVisible
+              ? "bg-success-5 enabled:hover:bg-success-5"
+              : "enabled:hover:bg-success-5";
+          case "merged":
+            return dropdownVisible
+              ? "bg-purple-5 enabled:hover:bg-purple-5"
+              : "enabled:hover:bg-purple-5";
+          case "secondary":
+          case "tertiary":
+            break;
+        }
       }
       return "enabled:hover:bg-fill-3";
     })();

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -216,7 +216,8 @@ function getStyleClasses(variant: ButtonVariant, appearance: ButtonAppearance) {
           return "border border-dashed border-success-6/50 bg-transparent text-success-6";
         return "border-0 bg-transparent text-success-6";
       case "merged":
-        if (appearance === "solid") return "border-0 text-white bg-purple-6";
+        if (appearance === "solid")
+          return "border-0 bg-merged text-merged-contrast";
         if (appearance === "outline")
           return "border border-purple-6 bg-transparent text-purple-6";
         if (appearance === "dashed")
@@ -237,7 +238,7 @@ function getStyleClasses(variant: ButtonVariant, appearance: ButtonAppearance) {
         case "success":
           return "enabled:hover:bg-success-5 enabled:active:bg-success-6";
         case "merged":
-          return "enabled:hover:bg-purple-5 enabled:active:bg-purple-7";
+          return "enabled:hover:bg-merged-hover enabled:active:bg-merged-active";
         case "secondary":
           return "enabled:hover:bg-fill-3";
         case "tertiary":
@@ -409,8 +410,9 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           case "danger":
           case "warning":
           case "success":
-          case "merged":
             return "text-white";
+          case "merged":
+            return "text-merged-contrast";
           case "secondary":
             return "text-text-1";
           case "tertiary":
@@ -457,8 +459,8 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
               : "enabled:hover:bg-success-5";
           case "merged":
             return dropdownVisible
-              ? "bg-purple-5 enabled:hover:bg-purple-5"
-              : "enabled:hover:bg-purple-5";
+              ? "bg-merged-hover enabled:hover:bg-merged-hover"
+              : "enabled:hover:bg-merged-hover";
           case "secondary":
           case "tertiary":
             break;

--- a/src/modules/MainApp/TeamInbox/components/TeamInboxList.tsx
+++ b/src/modules/MainApp/TeamInbox/components/TeamInboxList.tsx
@@ -352,10 +352,7 @@ const TeamInboxList: React.FC<TeamInboxListProps> = ({
         draft: pullRequest.rawPr.draft,
       });
       const PullRequestIcon = PULL_REQUEST_ICONS[getPrStatusIconName(status)];
-      const statusIconClass = getPrStatusVariant(status).dotClass.replace(
-        "bg-",
-        "text-"
-      );
+      const statusIconClass = getPrStatusVariant(status).textClass;
       return (
         <TeamInboxListItem
           key={key}

--- a/src/modules/MainApp/WorkManagement/GitHubWorkItemList.tsx
+++ b/src/modules/MainApp/WorkManagement/GitHubWorkItemList.tsx
@@ -69,7 +69,7 @@ export function GitHubWorkItemStateTabs({
           <CircleDot size={14} strokeWidth={1.8} aria-hidden="true" />
         </span>
       ) : (
-        <span className="text-purple-6 flex items-center">
+        <span className="flex items-center text-purple-6">
           <CheckCircle2 size={14} strokeWidth={1.8} aria-hidden="true" />
         </span>
       ),

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/__tests__/prCardHelpers.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/__tests__/prCardHelpers.test.ts
@@ -14,6 +14,7 @@ describe("getPrStatusVariant (re-exported from @src/shared/pr)", () => {
     expect(getPrStatusVariant("open")).toEqual({
       badgeClass: "bg-success-1 text-success-6",
       dotClass: "bg-success-6",
+      textClass: "text-success-6",
     });
   });
 
@@ -21,6 +22,7 @@ describe("getPrStatusVariant (re-exported from @src/shared/pr)", () => {
     expect(getPrStatusVariant("pending_review")).toEqual({
       badgeClass: "bg-fill-2 text-text-3",
       dotClass: "bg-text-3",
+      textClass: "text-text-3",
     });
   });
 });

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.test.ts
@@ -322,6 +322,11 @@ describe("PrDetailPanel tabs", () => {
       container.querySelectorAll('a[aria-label="Open on GitHub"]')
     ).toHaveLength(1);
     expect(header?.textContent).toContain("Use compact PR metadata");
+    const mergedBadge = Array.from(header?.querySelectorAll("span") ?? []).find(
+      (element) => element.textContent?.trim() === "merged"
+    );
+    expect(mergedBadge?.className).toContain("bg-purple-1");
+    expect(mergedBadge?.className).toContain("text-purple-6");
     expect(header?.textContent).not.toContain("develop");
     expect(header?.textContent).not.toContain(
       "fix/issue-556-delete-agent-org-workers"
@@ -349,6 +354,10 @@ describe("PrDetailPanel tabs", () => {
     expect(summary?.textContent).toContain("No CI checks");
     expect(summary?.textContent).toContain("Status");
     expect(summary?.textContent).toContain("merged");
+    const summaryStatus = Array.from(
+      summary?.querySelectorAll("div") ?? []
+    ).find((element) => element.textContent?.trim() === "merged");
+    expect(summaryStatus?.className).toContain("text-purple-6");
     expect(summary?.className).not.toContain("border-b");
     expect(summary?.firstElementChild?.className).toContain("px-6");
     expect(summary?.firstElementChild?.className).toContain("pt-4");

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.tsx
@@ -42,6 +42,7 @@ import {
   ScrollTrail,
 } from "@src/modules/shared/layouts/blocks";
 import { resolvePullRequestDetailStatus } from "@src/shared/pr/prLevelActions";
+import { getPrStatusVariant } from "@src/shared/pr/prStatus";
 import {
   type PrIdentity,
   workstationPrScopeKey,
@@ -192,6 +193,10 @@ export function PrDetailSummary({
     files.reduce((total, file) => total + file.deletions, 0);
   const commentCount = readNumber(detail, "comments") ?? conversationCount;
   const statusLabel = t(`git.pr.status.${identity.status}`, identity.status);
+  const statusColorClass = getPrStatusVariant(identity.status).dotClass.replace(
+    "bg-",
+    "text-"
+  );
 
   return (
     <section
@@ -274,13 +279,21 @@ export function PrDetailSummary({
 
         <div className="flex items-center gap-2 text-text-3">
           {identity.status === "merged" ? (
-            <GitMerge size={14} strokeWidth={1.75} />
+            <GitMerge
+              size={14}
+              strokeWidth={1.75}
+              className={statusColorClass}
+            />
           ) : (
-            <CircleDot size={14} strokeWidth={1.75} />
+            <CircleDot
+              size={14}
+              strokeWidth={1.75}
+              className={statusColorClass}
+            />
           )}
           <span>{t("git.pr.summary.status", "Status")}</span>
         </div>
-        <div className="capitalize text-text-1">{statusLabel}</div>
+        <div className={`capitalize ${statusColorClass}`}>{statusLabel}</div>
       </div>
     </section>
   );

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.tsx
@@ -193,10 +193,7 @@ export function PrDetailSummary({
     files.reduce((total, file) => total + file.deletions, 0);
   const commentCount = readNumber(detail, "comments") ?? conversationCount;
   const statusLabel = t(`git.pr.status.${identity.status}`, identity.status);
-  const statusColorClass = getPrStatusVariant(identity.status).dotClass.replace(
-    "bg-",
-    "text-"
-  );
+  const statusColorClass = getPrStatusVariant(identity.status).textClass;
 
   return (
     <section

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrLevelActions.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrLevelActions.tsx
@@ -221,7 +221,7 @@ export const PrLevelActions: React.FC<PrLevelActionsProps> = ({
     >
       <Button
         htmlType="button"
-        variant="success"
+        variant={presentation.status === "merged" ? "merged" : "success"}
         size="default"
         shape="round"
         icon={<GitMerge size={14} aria-hidden />}

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/menuItemBuilders.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/menuItemBuilders.test.ts
@@ -100,7 +100,7 @@ describe("buildSessionMenuItem PR state", () => {
   it.each([
     ["open", "Open PR #42: feature-x", "--color-success-6"],
     ["draft", "Draft PR #42: feature-x", "--color-text-3"],
-    ["merged", "Merged PR #42: feature-x", "--color-primary-6"],
+    ["merged", "Merged PR #42: feature-x", "--color-purple-6"],
     ["closed", "Closed PR #42: feature-x", "--color-danger-6"],
   ])("renders %s with its own icon color", (status, label, color) => {
     const html = prMarkup(status);

--- a/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/gitIndicator.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/gitIndicator.tsx
@@ -16,8 +16,9 @@ import {
 
 /**
  * Icon + color per PR state. Semantics match `shared/pr/prStatus` — open is
- * success, merged is primary, closed is danger, draft is neutral — so a row
- * marker and a PR badge elsewhere in the app never disagree about a state.
+ * success, merged is GitHub purple, closed is danger, draft is neutral — so
+ * a row marker and a PR badge elsewhere in the app never disagree about a
+ * state.
  */
 const PR_STATUS_PRESENTATION: Record<
   string,
@@ -35,7 +36,7 @@ const PR_STATUS_PRESENTATION: Record<
   },
   merged: {
     Icon: GitMerge,
-    color: "var(--color-primary-6)",
+    color: "var(--color-purple-6)",
     label: "Merged PR",
   },
   closed: {

--- a/src/shared/pr/__tests__/prStatus.test.ts
+++ b/src/shared/pr/__tests__/prStatus.test.ts
@@ -42,18 +42,22 @@ describe("getPrStatusVariant", () => {
     expect(getPrStatusVariant("open")).toEqual({
       badgeClass: "bg-success-1 text-success-6",
       dotClass: "bg-success-6",
+      textClass: "text-success-6",
     });
     expect(getPrStatusVariant("merged")).toEqual({
       badgeClass: "bg-purple-1 text-purple-6",
       dotClass: "bg-purple-6",
+      textClass: "text-purple-6",
     });
     expect(getPrStatusVariant("closed")).toEqual({
       badgeClass: "bg-danger-1 text-danger-6",
       dotClass: "bg-danger-6",
+      textClass: "text-danger-6",
     });
     expect(getPrStatusVariant("draft")).toEqual({
       badgeClass: "bg-warning-1 text-warning-6",
       dotClass: "bg-warning-6",
+      textClass: "text-warning-6",
     });
   });
 
@@ -61,6 +65,7 @@ describe("getPrStatusVariant", () => {
     expect(getPrStatusVariant("pending_review")).toEqual({
       badgeClass: "bg-fill-2 text-text-3",
       dotClass: "bg-text-3",
+      textClass: "text-text-3",
     });
   });
 
@@ -68,6 +73,7 @@ describe("getPrStatusVariant", () => {
     expect(getPrStatusVariant("")).toEqual({
       badgeClass: "bg-fill-2 text-text-3",
       dotClass: "bg-text-3",
+      textClass: "text-text-3",
     });
   });
 });

--- a/src/shared/pr/__tests__/prStatus.test.ts
+++ b/src/shared/pr/__tests__/prStatus.test.ts
@@ -44,8 +44,8 @@ describe("getPrStatusVariant", () => {
       dotClass: "bg-success-6",
     });
     expect(getPrStatusVariant("merged")).toEqual({
-      badgeClass: "bg-primary-1 text-primary-6",
-      dotClass: "bg-primary-6",
+      badgeClass: "bg-purple-1 text-purple-6",
+      dotClass: "bg-purple-6",
     });
     expect(getPrStatusVariant("closed")).toEqual({
       badgeClass: "bg-danger-1 text-danger-6",

--- a/src/shared/pr/prStatus.ts
+++ b/src/shared/pr/prStatus.ts
@@ -13,7 +13,7 @@
  * tokens, the label key onto `t(...)`, and the icon name onto a real icon.
  *
  * Semantic colors per PR state (kept consistent across every surface):
- *   open → success (green), merged → primary, closed → danger (red),
+ *   open → success (green), merged → GitHub purple, closed → danger (red),
  *   draft → warning (amber), unknown → neutral.
  */
 import type { PrStatus } from "@src/api/http/project/types/agentWorkflow";
@@ -36,8 +36,8 @@ export type PrStatusIconName = "pull-request" | "merge" | "closed" | "draft";
 const PR_STATUS_VARIANTS: Record<string, PrStatusVariant> = {
   open: { badgeClass: "bg-success-1 text-success-6", dotClass: "bg-success-6" },
   merged: {
-    badgeClass: "bg-primary-1 text-primary-6",
-    dotClass: "bg-primary-6",
+    badgeClass: "bg-purple-1 text-purple-6",
+    dotClass: "bg-purple-6",
   },
   closed: { badgeClass: "bg-danger-1 text-danger-6", dotClass: "bg-danger-6" },
   draft: {

--- a/src/shared/pr/prStatus.ts
+++ b/src/shared/pr/prStatus.ts
@@ -24,6 +24,8 @@ export interface PrStatusVariant {
   badgeClass: string;
   /** Tailwind classes for the small leading status dot. */
   dotClass: string;
+  /** Tailwind class for status text and status glyphs. */
+  textClass: string;
 }
 
 /**
@@ -34,15 +36,25 @@ export interface PrStatusVariant {
 export type PrStatusIconName = "pull-request" | "merge" | "closed" | "draft";
 
 const PR_STATUS_VARIANTS: Record<string, PrStatusVariant> = {
-  open: { badgeClass: "bg-success-1 text-success-6", dotClass: "bg-success-6" },
+  open: {
+    badgeClass: "bg-success-1 text-success-6",
+    dotClass: "bg-success-6",
+    textClass: "text-success-6",
+  },
   merged: {
     badgeClass: "bg-purple-1 text-purple-6",
     dotClass: "bg-purple-6",
+    textClass: "text-purple-6",
   },
-  closed: { badgeClass: "bg-danger-1 text-danger-6", dotClass: "bg-danger-6" },
+  closed: {
+    badgeClass: "bg-danger-1 text-danger-6",
+    dotClass: "bg-danger-6",
+    textClass: "text-danger-6",
+  },
   draft: {
     badgeClass: "bg-warning-1 text-warning-6",
     dotClass: "bg-warning-6",
+    textClass: "text-warning-6",
   },
 };
 
@@ -50,6 +62,7 @@ const PR_STATUS_VARIANTS: Record<string, PrStatusVariant> = {
 const FALLBACK_STATUS_VARIANT: PrStatusVariant = {
   badgeClass: "bg-fill-2 text-text-3",
   dotClass: "bg-text-3",
+  textClass: "text-text-3",
 };
 
 const PR_STATUS_ICONS: Record<string, PrStatusIconName> = {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -72,6 +72,12 @@ module.exports = {
         success: colorScale("success", COLOR_STEPS_6),
         warning: colorScale("warning", COLOR_STEPS_6),
         purple: colorScale("purple", COLOR_STEPS_7),
+        merged: {
+          DEFAULT: colorVariable("merged-button-bg"),
+          hover: colorVariable("merged-button-hover"),
+          active: colorVariable("merged-button-active"),
+          contrast: colorVariable("merged-button-contrast"),
+        },
       },
       spacing: {
         180: "180px",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -71,6 +71,7 @@ module.exports = {
         danger: colorScale("danger", COLOR_STEPS_6),
         success: colorScale("success", COLOR_STEPS_6),
         warning: colorScale("warning", COLOR_STEPS_6),
+        purple: colorScale("purple", COLOR_STEPS_7),
       },
       spacing: {
         180: "180px",


### PR DESCRIPTION
## Problem

Merged pull requests reuse the primary blue treatment, so their completed state is visually indistinguishable from ordinary primary actions and links across badges, summaries, sidebar indicators, and merge controls.

## Solution

Add a semantic purple scale for light, dark, and high-contrast themes and expose it through Tailwind. Map the shared merged PR presentation to purple, add a merged Button variant with matching split-button interaction states, and use the same semantic status color in detail summaries, action controls, and sidebar indicators.

## Potential risks

The new theme variables must remain present in every supported theme; missing variables in a downstream custom theme would cause merged treatments to lose color. Existing open, draft, and closed mappings are unchanged. Manual visual evidence for all three themes is pending, so this PR remains a draft.

## Audit

The configured `frontend-ui-audit` skill file was unavailable at both documented locations. A direct consistency pass confirmed that merged color ownership stays in the shared PR-status and Button primitives, with callers consuming semantic variants instead of duplicating raw color values.

## Verification

- Vitest for Button, PR status, session menu builders, and PR detail panel — passed (33 tests across 4 files).
- ESLint on all changed JS/TS/TSX files — passed; `tailwind.config.js` is ignored by the repository ESLint configuration and produced one warning.
- `pnpm typecheck` — passed.
- `git diff --cached --check` — passed before commit.
- Manual desktop verification was not run because local UI control was not authorized for this task.
