### PR TITLE
Add rolling 24-hour Team Runtime usage

### DIFF
--- a/docs/frontend-ui-audit-2026-08-06/RuntimeUsageCharts.md
+++ b/docs/frontend-ui-audit-2026-08-06/RuntimeUsageCharts.md
@@ -1,0 +1,26 @@
+# Runtime usage charts UI audit
+
+## Scope
+
+- `src/modules/shared/dataSource/TeamRuntimeToday.tsx`
+- `src/modules/shared/dataSource/TeamMemberDetail.tsx`
+
+The configured `frontend-ui-audit` skill file was unavailable, so this report
+uses the repository's documented audit columns and manually checks design-system
+reuse, arbitrary Tailwind values, accessibility, and duplicated visual patterns.
+
+## Findings
+
+| Line                       | Element                              | Verdict          | Reason                                                                                                                                                                                                               | Suggested change |
+| -------------------------- | ------------------------------------ | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `TeamRuntimeToday.tsx:258` | Rolling usage chart section          | keep with reason | Reuses the existing lazy-loaded `UsageTrendChart`, shared section heading classes, semantic color tokens, and existing localized range/title strings. The standard `h-72` fallback adds no arbitrary Tailwind value. | None.            |
+| `TeamRuntimeToday.tsx:284` | Per-member usage breakdown           | keep with reason | Reuses `SectionContainer`, `Avatar`, existing typography/border/fill tokens, and native buttons. `aria-pressed` exposes the selected member filter to assistive technology.                                          | None.            |
+| `TeamMemberDetail.tsx:315` | Source filter visibility in 24h mode | keep with reason | Reuses the existing `TabPill`; hiding it for the all-source hourly snapshot prevents a control from implying unsupported per-source hourly data.                                                                     | None.            |
+| `TeamMemberDetail.tsx:336` | Usage range selector                 | keep with reason | Reuses the shared `Select` and existing localized `24h` label, keeps the default daily controls intact, and adds a stable test id without introducing a parallel range component.                                    | None.            |
+
+## Summary
+
+- fix: 0
+- keep with reason: 4
+- abstract: 0
+- systematic sweep candidates: 0

--- a/src-tauri/crates/orgtrack-core/src/usage_dashboard.rs
+++ b/src-tauri/crates/orgtrack-core/src/usage_dashboard.rs
@@ -33,7 +33,7 @@ mod rounds;
 mod tests;
 
 use accumulator::UsageHeadlineAccumulator;
-pub use daily_rollup::{usage_daily_rollup, DailyRollup, DailyRollupRow};
+pub use daily_rollup::{usage_daily_rollup, DailyRollup, DailyRollupRow, RecentUsageSnapshot};
 pub use overview::{usage_overview, usage_rounds, usage_trends, UsageOverview};
 use rounds::visit_rounds;
 pub use rounds::UsageRoundRow;

--- a/src-tauri/crates/orgtrack-core/src/usage_dashboard/daily_rollup.rs
+++ b/src-tauri/crates/orgtrack-core/src/usage_dashboard/daily_rollup.rs
@@ -24,8 +24,11 @@ use std::collections::{BTreeMap, HashSet};
 use rusqlite::Connection;
 use serde::Serialize;
 
+use super::accumulator::UsageHeadlineAccumulator;
 use super::rounds::visit_rounds_windowed;
-use super::{TrendBucket, UsageFilter};
+use super::{TrendBucket, UsageFilter, UsageSummary, UsageTrendPoint};
+
+const RECENT_USAGE_WINDOW_MS: i64 = 86_400_000;
 
 /// One (UTC-day-floor, bucket) aggregate row.
 #[derive(Debug, Clone, Default, PartialEq, Serialize)]
@@ -60,6 +63,22 @@ pub struct DailyRollup {
     /// retains the windowed daily rows, so the lifetime figure has to ride
     /// along from the client.
     pub total_sessions: i64,
+    /// Rolling 24-hour headline + hourly series derived during the same
+    /// bounded round scan. The member-runtime scheduler attaches this to the
+    /// opaque status stats blob, so team viewers can render an accurate 24h
+    /// chart without another local scan or a cloud schema migration.
+    pub recent_usage_24h: RecentUsageSnapshot,
+}
+
+/// A bounded local usage snapshot suitable for the member-runtime status
+/// payload. Empty hourly buckets are omitted here and filled by the chart.
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecentUsageSnapshot {
+    pub start_ms: i64,
+    pub end_ms: i64,
+    pub summary: UsageSummary,
+    pub trends: Vec<UsageTrendPoint>,
 }
 
 #[derive(Default)]
@@ -95,6 +114,7 @@ pub fn usage_daily_rollup(
     start_ms: i64,
     end_ms: i64,
 ) -> Result<DailyRollup, String> {
+    let recent_start_ms = start_ms.max(end_ms.saturating_sub(RECENT_USAGE_WINDOW_MS));
     let filter = UsageFilter {
         bucket: None,
         start_ms: Some(start_ms),
@@ -107,11 +127,15 @@ pub fn usage_daily_rollup(
 
     // BTreeMap keys give the required (day, bucket) output ordering for free.
     let mut cells: BTreeMap<(i64, String), RollupCell> = BTreeMap::new();
+    let mut recent = UsageHeadlineAccumulator::new(TrendBucket::Hour, true, true);
     visit_rounds_windowed(conn, &filter, |round| {
         // Rounds without a usable timestamp cannot be attributed to a UTC
         // day (mirrors the trend accumulator's `created_at_ms > 0` gate).
         if round.created_at_ms <= 0 {
             return Ok(());
+        }
+        if round.created_at_ms >= recent_start_ms {
+            recent.observe(&round);
         }
         let day_start_ms = TrendBucket::Day.floor(round.created_at_ms);
         let cell = cells
@@ -147,8 +171,16 @@ pub fn usage_daily_rollup(
         })
         .collect();
 
+    let (recent_summary, recent_trends) = recent.finish();
+
     Ok(DailyRollup {
         days,
         total_sessions: total_session_count(conn)?,
+        recent_usage_24h: RecentUsageSnapshot {
+            start_ms: recent_start_ms,
+            end_ms,
+            summary: recent_summary,
+            trends: recent_trends,
+        },
     })
 }

--- a/src-tauri/crates/orgtrack-core/src/usage_dashboard/tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/usage_dashboard/tests.rs
@@ -768,6 +768,60 @@ fn daily_rollup_window_clips_rounds() {
 }
 
 #[test]
+fn daily_rollup_derives_a_true_rolling_24h_snapshot_in_the_same_scan() {
+    let conn = fixture_conn();
+    insert_code_session(
+        &conn,
+        "rolling-claude",
+        "claude",
+        "Rolling window",
+        "2026-07-18T12:00:00+00:00",
+    );
+    insert_turn(
+        &conn,
+        "rolling-claude",
+        "claude-sonnet-4-5",
+        (100, 10, 0, 0),
+        "2026-07-17T11:59:59.999Z",
+    );
+    insert_turn(
+        &conn,
+        "rolling-claude",
+        "claude-sonnet-4-5",
+        (200, 20, 30, 40),
+        "2026-07-17T12:00:00Z",
+    );
+    recompute_session_usage(&conn, "rolling-claude")
+        .unwrap()
+        .expect("rolling session projected");
+
+    let end_ms = ms("2026-07-18T12:00:00Z");
+    let rollup = usage_daily_rollup(&conn, ms("2026-07-01T00:00:00Z"), end_ms)
+        .expect("daily + rolling rollup");
+
+    assert_eq!(rollup.recent_usage_24h.start_ms, ms("2026-07-17T12:00:00Z"));
+    assert_eq!(rollup.recent_usage_24h.end_ms, end_ms);
+    assert_eq!(rollup.recent_usage_24h.summary.input_tokens, 200);
+    assert_eq!(rollup.recent_usage_24h.summary.output_tokens, 20);
+    assert_eq!(rollup.recent_usage_24h.summary.cache_read_tokens, 30);
+    assert_eq!(rollup.recent_usage_24h.summary.cache_write_tokens, 40);
+    assert_eq!(rollup.recent_usage_24h.summary.session_count, 1);
+    assert_eq!(rollup.recent_usage_24h.summary.request_count, 1);
+    assert_eq!(rollup.recent_usage_24h.trends.len(), 1);
+    assert_eq!(
+        rollup.recent_usage_24h.trends[0].bucket_ms,
+        ms("2026-07-17T12:00:00Z")
+    );
+
+    // The daily sync window still contains both rounds; the rolling snapshot
+    // alone excludes the row one millisecond before the 24h boundary.
+    assert_eq!(
+        rollup.days.iter().map(|row| row.input_tokens).sum::<i64>(),
+        300
+    );
+}
+
+#[test]
 fn daily_rollup_skips_zero_usage_cells() {
     let conn = seeded_conn();
     // A zero-token turn on an otherwise idle day: the cell would carry a
@@ -1022,6 +1076,16 @@ fn daily_rollup_serializes_camel_case() {
     let json = serde_json::to_value(DailyRollup {
         days: vec![row],
         total_sessions: 42,
+        recent_usage_24h: RecentUsageSnapshot {
+            start_ms: 1_784_332_800_000,
+            end_ms: 1_784_419_200_000,
+            summary: UsageSummary::default(),
+            trends: vec![UsageTrendPoint {
+                bucket_ms: 1_784_332_800_000,
+                input_tokens: 5,
+                ..UsageTrendPoint::default()
+            }],
+        },
     })
     .expect("serialize rollup");
     assert_eq!(json["totalSessions"], 42);
@@ -1036,4 +1100,7 @@ fn daily_rollup_serializes_camel_case() {
     assert_eq!(row["costUsd"], 0.5);
     assert_eq!(row["sessions"], 1);
     assert_eq!(row["requests"], 2);
+    assert_eq!(json["recentUsage24h"]["startMs"], 1_784_332_800_000_i64);
+    assert_eq!(json["recentUsage24h"]["endMs"], 1_784_419_200_000_i64);
+    assert_eq!(json["recentUsage24h"]["trends"][0]["inputTokens"], 5);
 }

--- a/src-tauri/src/orgtrack/usage_dashboard_commands.rs
+++ b/src-tauri/src/orgtrack/usage_dashboard_commands.rs
@@ -207,9 +207,10 @@ pub async fn usage_dashboard_rounds(
     .map_err(|err| format!("Task join error: {err}"))?
 }
 
-/// Per-(UTC day, bucket) rollup for the member-runtime cloud push. Unlike the
-/// scoped desktop views above, this always spans ALL sources (the `other`
-/// bucket included) so the totals a member shares with their org are complete.
+/// Per-(UTC day, bucket) rollup plus rolling-24h snapshot for the
+/// member-runtime cloud push. Unlike the scoped desktop views above, this
+/// always spans ALL sources (the `other` bucket included) so the totals a
+/// member shares with their org are complete.
 #[tauri::command]
 pub async fn usage_dashboard_daily_rollup(
     start_ms: i64,

--- a/src/api/tauri/usageDashboard/index.ts
+++ b/src/api/tauri/usageDashboard/index.ts
@@ -59,6 +59,14 @@ export interface UsageTrendPoint {
   costUsd: number;
 }
 
+/** A bounded headline + trend snapshot captured at one instant. */
+export interface RecentUsageSnapshot {
+  startMs: number;
+  endMs: number;
+  summary: UsageSummary;
+  trends: UsageTrendPoint[];
+}
+
 export interface UsageSessionRow {
   sessionId: string;
   name: string;
@@ -302,14 +310,16 @@ export interface DailyRollupResult {
   days: DailyRollupRow[];
   /** Lifetime mirror-deduped session count — independent of the window. */
   totalSessions: number;
+  /** Rolling 24h usage derived during the same local round scan. */
+  recentUsage24h: RecentUsageSnapshot;
 }
 
 /**
  * Per-UTC-day, per-bucket rollup over `[startMs, endMs]` for the
  * member-runtime push (registered behind the same 1-permit semaphore as the
  * other dashboard scans, so a plain wrapper is enough — concurrent callers
- * queue in the backend). Also carries the lifetime session census the push
- * shares as `stats.totalSessions`.
+ * queue in the backend). Also carries the lifetime session census and a
+ * rolling-24h snapshot the push shares through its bounded status blob.
  */
 export async function usageDashboardDailyRollup(
   startMs: number,

--- a/src/features/Org2Cloud/memberRuntime/memberRuntimeClient.test.ts
+++ b/src/features/Org2Cloud/memberRuntime/memberRuntimeClient.test.ts
@@ -177,7 +177,45 @@ describe("listMemberRuntime", () => {
             reportedAt: "2026-07-29T09:00:00Z",
             machine: STATUS_INPUT.status?.machine,
             sample: STATUS_INPUT.status?.sample,
-            stats: { totalSessions: 321 },
+            stats: {
+              totalSessions: 321,
+              recentUsage24h: {
+                startMs: 1_753_000_000_000,
+                endMs: 1_753_086_400_000,
+                summary: {
+                  sessionCount: 2,
+                  requestCount: 3,
+                  inputTokens: 10,
+                  outputTokens: 20,
+                  cacheReadTokens: 30,
+                  cacheWriteTokens: 40,
+                  realTotalTokens: 100,
+                  totalTokens: 100,
+                  costUsd: 1.25,
+                  estimatedCostUsd: 1.25,
+                  recordedCostUsd: 0,
+                  cacheHitRate: 0.375,
+                  byBucket: [
+                    {
+                      bucket: "claude",
+                      sessionCount: 2,
+                      realTotalTokens: 100,
+                      costUsd: 1.25,
+                    },
+                  ],
+                },
+                trends: [
+                  {
+                    bucketMs: 1_753_000_000_000,
+                    inputTokens: 10,
+                    outputTokens: 20,
+                    cacheReadTokens: 30,
+                    cacheWriteTokens: 40,
+                    costUsd: 1.25,
+                  },
+                ],
+              },
+            },
             builderTypeCode: "MDFS",
             profile: { code: "MDFS", axes: [], extraFutureField: 1 },
             installedAgents: [{ id: "claude", status: "installed" }],
@@ -206,6 +244,10 @@ describe("listMemberRuntime", () => {
             reportedAt: null,
             machine: { totally: "malformed" },
             sample: "not-an-object",
+            stats: {
+              totalSessions: 7,
+              recentUsage24h: { startMs: "malformed" },
+            },
             builderTypeCode: null,
             profile: null,
             installedAgents: "garbage",
@@ -223,7 +265,9 @@ describe("listMemberRuntime", () => {
     expect(members[0].userId).toBe("user-1");
     expect(members[0].machine?.deviceId).toBe("dev-1");
     expect(members[0].sample?.cpuPercent).toBe(42.5);
-    expect(members[0].stats).toEqual({ totalSessions: 321 });
+    expect(members[0].stats?.totalSessions).toBe(321);
+    expect(members[0].stats?.recentUsage24h?.summary.realTotalTokens).toBe(100);
+    expect(members[0].stats?.recentUsage24h?.trends).toHaveLength(1);
     expect(members[0].profile?.code).toBe("MDFS");
     expect(members[0].installedAgents).toEqual([
       { id: "claude", status: "installed" },
@@ -234,7 +278,10 @@ describe("listMemberRuntime", () => {
     expect(members[1].displayName).toBeNull();
     expect(members[1].machine).toBeNull();
     expect(members[1].sample).toBeNull();
-    expect(members[1].stats).toBeNull();
+    expect(members[1].stats).toEqual({
+      totalSessions: 7,
+      recentUsage24h: undefined,
+    });
     expect(members[1].profile).toBeNull();
     expect(members[1].installedAgents).toEqual([]);
     expect(members[1].recentDays).toEqual([]);

--- a/src/features/Org2Cloud/memberRuntime/memberRuntimeClient.ts
+++ b/src/features/Org2Cloud/memberRuntime/memberRuntimeClient.ts
@@ -149,6 +149,51 @@ const MemberUsageDayWireSchema = z.object({
   requests: z.number().catch(0),
 });
 
+const NonNegativeNumberWireSchema = z.number().nonnegative().catch(0);
+
+const UsageBucketSummaryWireSchema = z.object({
+  bucket: z.string(),
+  sessionCount: NonNegativeNumberWireSchema,
+  realTotalTokens: NonNegativeNumberWireSchema,
+  costUsd: NonNegativeNumberWireSchema,
+});
+
+const UsageSummaryWireSchema = z.object({
+  sessionCount: NonNegativeNumberWireSchema,
+  requestCount: NonNegativeNumberWireSchema,
+  inputTokens: NonNegativeNumberWireSchema,
+  outputTokens: NonNegativeNumberWireSchema,
+  cacheReadTokens: NonNegativeNumberWireSchema,
+  cacheWriteTokens: NonNegativeNumberWireSchema,
+  realTotalTokens: NonNegativeNumberWireSchema,
+  totalTokens: NonNegativeNumberWireSchema,
+  costUsd: NonNegativeNumberWireSchema,
+  estimatedCostUsd: NonNegativeNumberWireSchema,
+  recordedCostUsd: NonNegativeNumberWireSchema,
+  cacheHitRate: z.number().min(0).max(1).catch(0),
+  byBucket: z
+    .array(UsageBucketSummaryWireSchema)
+    .max(TEAM_USAGE_BUCKETS.length)
+    .catch([])
+    .default([]),
+});
+
+const UsageTrendPointWireSchema = z.object({
+  bucketMs: z.number().nonnegative(),
+  inputTokens: NonNegativeNumberWireSchema,
+  outputTokens: NonNegativeNumberWireSchema,
+  cacheReadTokens: NonNegativeNumberWireSchema,
+  cacheWriteTokens: NonNegativeNumberWireSchema,
+  costUsd: NonNegativeNumberWireSchema,
+});
+
+const RecentUsageSnapshotWireSchema = z.object({
+  startMs: z.number().nonnegative(),
+  endMs: z.number().nonnegative(),
+  summary: UsageSummaryWireSchema,
+  trends: z.array(UsageTrendPointWireSchema).max(25).catch([]).default([]),
+});
+
 const optionalString = z
   .string()
   .nullish()
@@ -214,7 +259,13 @@ const MemberRuntimeListEntryWireSchema = z.object({
   reportedAt: z.string().nullish().catch(undefined),
   machine: MemberRuntimeMachineWireSchema.nullish().catch(undefined),
   sample: MemberRuntimeSampleWireSchema.nullish().catch(undefined),
-  stats: z.object({ totalSessions: z.number() }).nullish().catch(undefined),
+  stats: z
+    .object({
+      totalSessions: z.number(),
+      recentUsage24h: RecentUsageSnapshotWireSchema.optional().catch(undefined),
+    })
+    .nullish()
+    .catch(undefined),
   builderTypeCode: z.string().nullish().catch(undefined),
   profile: MemberBuilderProfileWireSchema.nullish().catch(undefined),
   installedAgents: z

--- a/src/features/Org2Cloud/memberRuntime/memberRuntimePushScheduler.test.ts
+++ b/src/features/Org2Cloud/memberRuntime/memberRuntimePushScheduler.test.ts
@@ -39,6 +39,7 @@ import {
   type MemberRuntimeSchedulerDeps,
 } from "./memberRuntimePushScheduler";
 import {
+  MEMBER_STATUS_MAX_BYTES,
   MEMBER_USAGE_DAYS_MAX_PER_PUSH,
   SHARE_RUNTIME_SETTING_KEY,
 } from "./types";
@@ -149,6 +150,32 @@ function makeRollupDays(count: number): DailyRollupResult["days"] {
   }));
 }
 
+function makeRecentUsage24h(
+  overrides: Partial<DailyRollupResult["recentUsage24h"]> = {}
+): DailyRollupResult["recentUsage24h"] {
+  return {
+    startMs: NOW - UTC_DAY_MS,
+    endMs: NOW,
+    summary: {
+      sessionCount: 0,
+      requestCount: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      realTotalTokens: 0,
+      totalTokens: 0,
+      costUsd: 0,
+      estimatedCostUsd: 0,
+      recordedCostUsd: 0,
+      cacheHitRate: 0,
+      byBucket: [],
+    },
+    trends: [],
+    ...overrides,
+  };
+}
+
 function makeDeps(
   overrides: Partial<MemberRuntimeSchedulerDeps> = {}
 ): MemberRuntimeSchedulerDeps {
@@ -171,7 +198,11 @@ function makeDeps(
       sampledOverMs: 1000,
       sampledAtMs: NOW,
     }),
-    getDailyRollup: vi.fn().mockResolvedValue({ days: [], totalSessions: 0 }),
+    getDailyRollup: vi.fn().mockResolvedValue({
+      days: [],
+      totalSessions: 0,
+      recentUsage24h: makeRecentUsage24h(),
+    }),
     getProfileOverview: vi.fn().mockResolvedValue(makeProfileOverview()),
     detectInstalledAgents: vi.fn().mockResolvedValue([]),
     upsert: vi.fn().mockResolvedValue(undefined),
@@ -545,9 +576,11 @@ describe("ORG2_RUNTIME_TOO_LARGE mitigation", () => {
     const upsert = vi.fn().mockResolvedValue(undefined);
     const deps = makeDeps({
       now: () => NOW,
-      getDailyRollup: vi
-        .fn()
-        .mockResolvedValue({ days: makeRollupDays(5), totalSessions: 5 }),
+      getDailyRollup: vi.fn().mockResolvedValue({
+        days: makeRollupDays(5),
+        totalSessions: 5,
+        recentUsage24h: makeRecentUsage24h(),
+      }),
       upsert,
     });
     const scheduler = asPrivate(new MemberRuntimePushScheduler(deps));
@@ -565,13 +598,127 @@ describe("ORG2_RUNTIME_TOO_LARGE mitigation", () => {
     expect(input.usageDays).toHaveLength(2);
   });
 
+  it("shares the bounded rolling-24h snapshot inside status stats", async () => {
+    const upsert = vi.fn().mockResolvedValue(undefined);
+    const trends = Array.from({ length: 25 }, (_, index) => ({
+      bucketMs: NOW - (24 - index) * 60 * 60_000,
+      inputTokens: 999_999_999,
+      outputTokens: 999_999_999,
+      cacheReadTokens: 999_999_999,
+      cacheWriteTokens: 999_999_999,
+      costUsd: 999_999.1234,
+    }));
+    const recentUsage24h = makeRecentUsage24h({
+      summary: {
+        sessionCount: 999_999,
+        requestCount: 999_999,
+        inputTokens: 999_999_999,
+        outputTokens: 999_999_999,
+        cacheReadTokens: 999_999_999,
+        cacheWriteTokens: 999_999_999,
+        realTotalTokens: 3_999_999_996,
+        totalTokens: 3_999_999_996,
+        costUsd: 999_999.1234,
+        estimatedCostUsd: 999_999.1234,
+        recordedCostUsd: 0,
+        cacheHitRate: 0.5,
+        byBucket: ["claude", "codex", "cursor", "org2", "other"].map(
+          (bucket) => ({
+            bucket,
+            sessionCount: 999_999,
+            realTotalTokens: 999_999_999,
+            costUsd: 999_999.1234,
+          })
+        ),
+      },
+      trends,
+    });
+    const deps = makeDeps({
+      now: () => NOW,
+      getDailyRollup: vi.fn().mockResolvedValue({
+        days: [],
+        totalSessions: 42,
+        recentUsage24h,
+      }),
+      upsert,
+    });
+    const scheduler = asPrivate(new MemberRuntimePushScheduler(deps));
+
+    await scheduler.pushOrg(
+      "token-1",
+      "identity-recent-usage",
+      makeOrg(),
+      async () => null
+    );
+
+    const input = upsert.mock.calls[0][2] as {
+      status?: { stats?: unknown };
+    };
+    expect(input.status?.stats).toEqual({
+      totalSessions: 42,
+      recentUsage24h,
+    });
+    expect(
+      new TextEncoder().encode(JSON.stringify(input.status)).byteLength
+    ).toBeLessThan(MEMBER_STATUS_MAX_BYTES);
+  });
+
+  it("drops only the additive snapshot when status would approach the server cap", async () => {
+    const upsert = vi.fn().mockResolvedValue(undefined);
+    const recentUsage24h = makeRecentUsage24h({
+      trends: Array.from({ length: 25 }, (_, index) => ({
+        bucketMs: NOW - index * 60 * 60_000,
+        inputTokens: 10,
+        outputTokens: 10,
+        cacheReadTokens: 10,
+        cacheWriteTokens: 10,
+        costUsd: 1,
+      })),
+    });
+    const deps = makeDeps({
+      now: () => NOW,
+      getMachine: vi.fn().mockResolvedValue({
+        deviceId: "device-1",
+        machineLabel: "x".repeat(5_000),
+        osName: "macOS",
+        osVersion: "15.0",
+        chipType: "Apple M3",
+        appVersion: "1.0.0",
+      }),
+      getDailyRollup: vi.fn().mockResolvedValue({
+        days: [],
+        totalSessions: 42,
+        recentUsage24h,
+      }),
+      upsert,
+    });
+    const scheduler = asPrivate(new MemberRuntimePushScheduler(deps));
+
+    await scheduler.pushOrg(
+      "token-1",
+      "identity-large-status",
+      makeOrg(),
+      async () => null
+    );
+
+    const status = upsert.mock.calls[0][2].status as {
+      stats?: { totalSessions: number; recentUsage24h?: unknown };
+    };
+    expect(status.stats).toEqual({ totalSessions: 42 });
+    expect(
+      new TextEncoder().encode(JSON.stringify(status)).byteLength
+    ).toBeLessThan(MEMBER_STATUS_MAX_BYTES);
+  });
+
   it("pushOrg drops profile/installed-agents once flagged, even though both changed", async () => {
     const upsert = vi.fn().mockResolvedValue(undefined);
     const deps = makeDeps({
       now: () => NOW,
-      getDailyRollup: vi
-        .fn()
-        .mockResolvedValue({ days: makeRollupDays(1), totalSessions: 1 }),
+      getDailyRollup: vi.fn().mockResolvedValue({
+        days: makeRollupDays(1),
+        totalSessions: 1,
+        recentUsage24h: makeRecentUsage24h(),
+      }),
       getProfileOverview: vi
         .fn()
         .mockResolvedValue(makeProfileOverview({ code: "EAWH", sessions: 10 })),

--- a/src/features/Org2Cloud/memberRuntime/memberRuntimePushScheduler.ts
+++ b/src/features/Org2Cloud/memberRuntime/memberRuntimePushScheduler.ts
@@ -101,6 +101,7 @@ import type {
 } from "./types";
 import {
   MEMBER_AGENTS_DETECT_MIN_INTERVAL_MS,
+  MEMBER_STATUS_MAX_BYTES,
   MEMBER_USAGE_DAYS_MAX_PER_PUSH,
   MEMBER_USAGE_ROLLUP_WINDOW_DAYS,
   SHARE_RUNTIME_SETTING_KEY,
@@ -116,6 +117,35 @@ export const MEMBER_RUNTIME_CAPABILITY_RECHECK_MS = 6 * 60 * 60 * 1000;
 /** Pass-level floor after a failed token refresh (org backoffs are per-org;
  * an auth failure blocks the whole pass and must not tight-loop). */
 const AUTH_RETRY_DELAY_MS = 5 * 60_000;
+/** Leave room for jsonb's canonical text spacing at the server-side cap. */
+const MEMBER_STATUS_SIZE_SAFETY_BYTES = 512;
+
+function statusWithBoundedRecentUsage(
+  machine: Awaited<ReturnType<typeof getMemberRuntimeMachineCached>>,
+  sample: Awaited<ReturnType<typeof collectMemberRuntimeSample>>,
+  rollup: DailyRollupResult
+): NonNullable<UpsertMemberRuntimeInput["status"]> {
+  const status: NonNullable<UpsertMemberRuntimeInput["status"]> = {
+    machine,
+    sample,
+    stats: {
+      totalSessions: rollup.totalSessions,
+      recentUsage24h: rollup.recentUsage24h,
+    },
+  };
+  const bytes = new TextEncoder().encode(JSON.stringify(status)).byteLength;
+  if (bytes <= MEMBER_STATUS_MAX_BYTES - MEMBER_STATUS_SIZE_SAFETY_BYTES) {
+    return status;
+  }
+  // Status is the heartbeat. If unusual machine labels plus the additive
+  // snapshot approach the server cap, keep the pre-feature census payload
+  // rather than turning every future push into ORG2_RUNTIME_TOO_LARGE.
+  return {
+    machine,
+    sample,
+    stats: { totalSessions: rollup.totalSessions },
+  };
+}
 
 /** Non-DOM contexts (workers and node-side tests) behave as visible. */
 function isDocumentHidden(): boolean {
@@ -545,7 +575,8 @@ export class MemberRuntimePushScheduler {
     const sample = await this.deps.getSample(nowMs);
 
     // Usage: recompute the rolling UTC-day window, delta-push changed rows.
-    // The same scan carries the lifetime session census for status.stats.
+    // The same scan carries the lifetime census and bounded rolling-24h
+    // snapshot for status.stats, so hourly sharing adds no second DB pass.
     const windowStartMs =
       utcDayFloorMs(nowMs) - (MEMBER_USAGE_ROLLUP_WINDOW_DAYS - 1) * UTC_DAY_MS;
     const rollup = await this.deps.getDailyRollup(windowStartMs, nowMs);
@@ -596,11 +627,7 @@ export class MemberRuntimePushScheduler {
     }
 
     const input: UpsertMemberRuntimeInput = {
-      status: {
-        machine,
-        sample,
-        stats: { totalSessions: rollup.totalSessions },
-      },
+      status: statusWithBoundedRecentUsage(machine, sample, rollup),
       ...(usagePlan.days.length > 0 ? { usageDays: usagePlan.days } : {}),
       ...(profilePart ? { profile: profilePart } : {}),
     };

--- a/src/features/Org2Cloud/memberRuntime/types.ts
+++ b/src/features/Org2Cloud/memberRuntime/types.ts
@@ -31,14 +31,19 @@
  *     - the full installed-agent inventory (which CLI providers are present
  *       and their detection status) — see `MemberInstalledAgent`;
  *     - per-day cost and token figures broken out by bucket — see
- *       `MemberUsageDay`.
+ *       `MemberUsageDay`;
+ *     - a rolling 24-hour token/cost series at hourly resolution, aggregated
+ *       across sources — see `MemberRuntimeStats.recentUsage24h`.
  *   These are exactly what let a teammate see "who's running low on RAM" or
  *   "who's spending the most on Claude this week"; they are not incidental
  *   leakage, but they are NOT covered by the "no session titles/repo
  *   paths/models" framing above and must be disclosed alongside it.
  */
 import type { BuilderProfile } from "@src/api/tauri/builderProfile";
-import type { UsageBucket } from "@src/api/tauri/usageDashboard";
+import type {
+  RecentUsageSnapshot,
+  UsageBucket,
+} from "@src/api/tauri/usageDashboard";
 
 // ---------------------------------------------------------------------------
 // Buckets & days
@@ -102,11 +107,15 @@ export interface MemberRuntimeSample {
   sampledAtMs: number;
 }
 
-/** Lifetime local-machine session totals, pushed with every status update
- * (the cloud only holds the retention-windowed daily rows, so a lifetime
- * count must come from the client). Mirror-deduped like the dashboard. */
+/** Bounded usage metadata pushed with every status update. The lifetime
+ * census must come from the client because cloud daily rows are retained only
+ * for a window; the rolling snapshot powers team hourly charts without
+ * storing per-request rows. */
 export interface MemberRuntimeStats {
   totalSessions: number;
+  /** Latest rolling 24h headline + hourly trend. Additive inside the opaque
+   * cloud status blob, so pre-feature peers simply omit it. */
+  recentUsage24h?: RecentUsageSnapshot;
 }
 
 /** One (UTC day, bucket) usage rollup row. */
@@ -200,12 +209,11 @@ export const MEMBER_RUNTIME_SIGNAL_KIND = "member_runtime" as const;
 export const MEMBER_RUNTIME_COMMANDS = {
   /** → `{ cpuPercent, memUsedMb, memTotalMb, gpuPercent, sampledOverMs }` */
   systemRuntimeSnapshot: "system_runtime_snapshot",
-  /** args `{ startMs, endMs }` → `{ days: DailyRollupRow[], totalSessions }`
-   * where a row is `{ dayStartMs, bucket, inputTokens, outputTokens,
-   * cacheReadTokens, cacheWriteTokens, totalTokens, costUsd, sessions,
-   * requests }` with UTC day floors and `all_sources: true` (includes
-   * `other`); `totalSessions` is the LIFETIME mirror-deduped session count,
-   * independent of the window. */
+  /** args `{ startMs, endMs }` → `{ days, totalSessions, recentUsage24h }`.
+   * Daily rows use UTC day floors and `all_sources: true` (includes `other`);
+   * `totalSessions` is the LIFETIME mirror-deduped session count, independent
+   * of the window; `recentUsage24h` is the all-source rolling headline and
+   * hourly series ending at `endMs`. */
   usageDailyRollup: "usage_dashboard_daily_rollup",
   /** → `{ deviceId, machineLabel }`, persisted at `~/.orgii/cloud_device_id`. */
   cloudDeviceIdentity: "cloud_device_identity",
@@ -242,6 +250,8 @@ export const MEMBER_STATUS_MAX_BYTES = 8_192;
 export const MEMBER_PROFILE_MAX_BYTES = 16_384;
 /** Retention for `member_usage_daily` (service-role GC). */
 export const MEMBER_USAGE_RETENTION_DAYS = 90;
+/** Rolling window carried in `stats.recentUsage24h`. */
+export const MEMBER_RECENT_USAGE_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 /** Launch catch-up jitter so an org coming online together doesn't stampede. */
 export const MEMBER_RUNTIME_CATCHUP_JITTER_MIN_MS = 30_000;

--- a/src/modules/shared/dataSource/TeamMemberDetail.tsx
+++ b/src/modules/shared/dataSource/TeamMemberDetail.tsx
@@ -1,8 +1,9 @@
 /**
  * Runtime → Team drilldown for one member: builder-profile card (axes +
  * confidence, reusing `AxisMeter` and the type-gallery card surface), a usage
- * range fetched via `getMemberUsage` and folded into the existing chart /
- * stat-card props, installed agents with labels, and machine details.
+ * daily range fetched via `getMemberUsage` (or the inline rolling-24h
+ * snapshot) and folded into the existing chart / stat-card props, installed
+ * agents with labels, and machine details.
  *
  * Rendered as a second layer over the roster (the `BuilderTypesPanel`
  * back-button idiom of this folder).
@@ -50,8 +51,8 @@ import { formatInt } from "./usageFormat";
 const SOURCE_ALL = "all";
 const UsageTrendChart = lazy(() => import("./UsageTrendChart"));
 
-const RANGE_OPTIONS = [7, 30, 90] as const;
-type MemberUsageRangeDays = (typeof RANGE_OPTIONS)[number];
+const RANGE_OPTIONS = ["24h", 7, 30, 90] as const;
+type MemberUsageRange = (typeof RANGE_OPTIONS)[number];
 
 interface TeamMemberDetailProps {
   entry: MemberRuntimeListEntry;
@@ -75,7 +76,7 @@ export default function TeamMemberDetail({
     keyPrefix: "kanban.dataSource",
   });
 
-  const [rangeDays, setRangeDays] = useState<MemberUsageRangeDays>(30);
+  const [usageRange, setUsageRange] = useState<MemberUsageRange>(7);
   const [bucket, setBucket] = useState<TeamUsageBucket | null>(null);
   const [days, setDays] = useState<MemberUsageDay[] | null>(null);
   const [range, setRange] = useState<{ fromDay: string; toDay: string } | null>(
@@ -97,12 +98,19 @@ export default function TeamMemberDetail({
   useEffect(() => {
     let cancelled = false;
     const seq = ++requestRef.current;
+    if (usageRange === "24h") {
+      setLoading(false);
+      setError(null);
+      return () => {
+        cancelled = true;
+      };
+    }
     void (async () => {
       setLoading(true);
       setError(null);
       try {
         const accessToken = await getFreshAccessToken();
-        const nextRange = memberUsageDayRange(Date.now(), rangeDays);
+        const nextRange = memberUsageDayRange(Date.now(), usageRange);
         const rows = await getMemberUsage(
           accessToken,
           orgId,
@@ -124,18 +132,42 @@ export default function TeamMemberDetail({
     return () => {
       cancelled = true;
     };
-  }, [entry.userId, orgId, rangeDays, retryNonce, getFreshAccessToken]);
+  }, [entry.userId, orgId, usageRange, retryNonce, getFreshAccessToken]);
+
+  const hourlySnapshot = entry.stats?.recentUsage24h ?? null;
+  const hourly = usageRange === "24h";
 
   const summary = useMemo(
-    () => (days ? foldMemberUsageSummary(days, bucket) : null),
-    [days, bucket]
+    () =>
+      hourly
+        ? (hourlySnapshot?.summary ?? null)
+        : days
+          ? foldMemberUsageSummary(days, bucket)
+          : null,
+    [bucket, days, hourly, hourlySnapshot]
   );
   const trendPoints = useMemo(
-    () => (days ? memberUsageDaysToTrendPoints(days, bucket) : []),
-    [days, bucket]
+    () =>
+      hourly
+        ? (hourlySnapshot?.trends ?? [])
+        : days
+          ? memberUsageDaysToTrendPoints(days, bucket)
+          : [],
+    [bucket, days, hourly, hourlySnapshot]
   );
-  const chartStartMs = range ? utcDayStartMs(range.fromDay) : null;
-  const chartEndMs = range ? utcDayStartMs(range.toDay) : null;
+  const chartStartMs = hourly
+    ? (hourlySnapshot?.startMs ?? null)
+    : range
+      ? utcDayStartMs(range.fromDay)
+      : null;
+  const chartEndMs = hourly
+    ? (hourlySnapshot?.endMs ?? null)
+    : range
+      ? utcDayStartMs(range.toDay)
+      : null;
+  const hasUsageData = hourly
+    ? hourlySnapshot !== null
+    : days !== null && days.length > 0;
 
   const bucketTabs = useMemo<TabPillItem[]>(
     () => [
@@ -151,9 +183,12 @@ export default function TeamMemberDetail({
     () =>
       RANGE_OPTIONS.map((preset) => ({
         value: String(preset),
-        label: t(`detail.range.${preset}`),
+        label:
+          preset === "24h"
+            ? tUsage("usage.range.24h")
+            : t(`detail.range.${preset}`),
       })),
-    [t]
+    [t, tUsage]
   );
 
   const displayName = entry.displayName ?? entry.userId;
@@ -256,31 +291,45 @@ export default function TeamMemberDetail({
       <div className="flex min-h-9 flex-wrap items-center justify-between gap-2">
         <h3 className={SECTION_SUBHEADING_CLASSES}>{t("detail.usageTitle")}</h3>
         <div className="flex min-w-0 items-center gap-2">
-          <TabPill
-            activeTab={bucket ?? SOURCE_ALL}
-            tabs={bucketTabs}
-            onChange={(key) =>
-              setBucket(key === SOURCE_ALL ? null : (key as TeamUsageBucket))
-            }
-            variant="pill"
-            size="mini"
-            colorScheme="ghost"
-            fillWidth={false}
-          />
-          <span
-            aria-hidden
-            className="pointer-events-none h-4 w-px shrink-0 bg-border-2"
-          />
+          {!hourly ? (
+            <>
+              <TabPill
+                activeTab={bucket ?? SOURCE_ALL}
+                tabs={bucketTabs}
+                onChange={(key) =>
+                  setBucket(
+                    key === SOURCE_ALL ? null : (key as TeamUsageBucket)
+                  )
+                }
+                variant="pill"
+                size="mini"
+                colorScheme="ghost"
+                fillWidth={false}
+              />
+              <span
+                aria-hidden
+                className="pointer-events-none h-4 w-px shrink-0 bg-border-2"
+              />
+            </>
+          ) : null}
           <Select
-            value={String(rangeDays)}
-            onChange={(value) =>
-              setRangeDays(
-                Number.parseInt(String(value), 10) as MemberUsageRangeDays
-              )
-            }
+            value={String(usageRange)}
+            onChange={(value) => {
+              const next = RANGE_OPTIONS.find(
+                (option) => String(option) === String(value)
+              );
+              if (next === undefined) return;
+              if (next === "24h") {
+                setBucket(null);
+                setUsageRange("24h");
+                return;
+              }
+              setUsageRange(next);
+            }}
             options={rangeOptions}
             variant="ghost"
             size="small"
+            dataTestId="team-member-usage-range"
           />
         </div>
       </div>
@@ -293,9 +342,9 @@ export default function TeamMemberDetail({
           subtitle={error}
           onRetry={() => setRetryNonce((nonce) => nonce + 1)}
         />
-      ) : loading || !summary ? (
+      ) : loading ? (
         <Placeholder variant="loading" placement="detail-panel" />
-      ) : days && days.length === 0 ? (
+      ) : !hasUsageData || !summary ? (
         <Placeholder
           variant="empty"
           placement="detail-panel"
@@ -311,7 +360,7 @@ export default function TeamMemberDetail({
           >
             <UsageTrendChart
               points={trendPoints}
-              hourly={false}
+              hourly={hourly}
               startMs={chartStartMs}
               endMs={chartEndMs}
               dataEndMs={chartEndMs}

--- a/src/modules/shared/dataSource/TeamRuntimePanel.test.ts
+++ b/src/modules/shared/dataSource/TeamRuntimePanel.test.ts
@@ -187,10 +187,23 @@ vi.mock("@src/components/SettingsTable", () => ({
 }));
 
 vi.mock("./UsageTrendChart", () => ({
-  default: ({ points }: { points: unknown[] }) =>
+  default: ({
+    points,
+    hourly,
+    startMs,
+    endMs,
+  }: {
+    points: unknown[];
+    hourly?: boolean;
+    startMs?: number | null;
+    endMs?: number | null;
+  }) =>
     createElement("div", {
       "data-testid": "team-usage-trend-chart",
       "data-points": JSON.stringify(points),
+      "data-hourly": hourly ? "true" : "false",
+      "data-start-ms": startMs == null ? "" : String(startMs),
+      "data-end-ms": endMs == null ? "" : String(endMs),
     }),
 }));
 
@@ -342,6 +355,42 @@ function usageDay(over: Partial<MemberUsageDay> = {}): MemberUsageDay {
     sessions: 1,
     requests: 4,
     ...over,
+  };
+}
+
+function recentUsage24h(
+  inputTokens: number,
+  costUsd: number,
+  bucketMs = Math.floor(Date.now() / 3_600_000) * 3_600_000
+): NonNullable<MemberRuntimeListEntry["stats"]>["recentUsage24h"] {
+  return {
+    startMs: Date.now() - 86_400_000,
+    endMs: Date.now(),
+    summary: {
+      sessionCount: 1,
+      requestCount: 1,
+      inputTokens,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+      realTotalTokens: inputTokens,
+      totalTokens: inputTokens,
+      costUsd,
+      estimatedCostUsd: costUsd,
+      recordedCostUsd: 0,
+      cacheHitRate: 0,
+      byBucket: [],
+    },
+    trends: [
+      {
+        bucketMs,
+        inputTokens,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        costUsd,
+      },
+    ],
   };
 }
 
@@ -562,6 +611,10 @@ describe("TeamRuntimePanel roster", () => {
       member({
         userId: "user-a",
         displayName: "Ada",
+        stats: {
+          totalSessions: 128,
+          recentUsage24h: recentUsage24h(1_000, 4),
+        },
         recentDays: [
           usageDay({
             day: today,
@@ -577,6 +630,10 @@ describe("TeamRuntimePanel roster", () => {
       member({
         userId: "user-b",
         displayName: "Lin",
+        stats: {
+          totalSessions: 64,
+          recentUsage24h: recentUsage24h(2_000, 6),
+        },
         recentDays: [
           usageDay({
             day: today,
@@ -631,6 +688,23 @@ describe("TeamRuntimePanel roster", () => {
     expect(titleRow?.textContent).toContain("overview.today");
     expect(titleRow?.textContent).not.toContain("overview.todayUtc");
     expect(titleRow?.textContent).not.toContain("overview.person");
+    const initialChart = container.querySelector(
+      '[data-testid="team-usage-trend-chart"]'
+    );
+    expect(initialChart?.getAttribute("data-hourly")).toBe("true");
+    const initialPoints = JSON.parse(
+      initialChart?.getAttribute("data-points") ?? "[]"
+    ) as Array<{ inputTokens: number; costUsd: number }>;
+    expect(initialPoints).toHaveLength(1);
+    expect(initialPoints[0]).toMatchObject({ inputTokens: 3_000, costUsd: 10 });
+    expect(
+      container.querySelectorAll('[data-testid^="team-runtime-member-usage-"]')
+    ).toHaveLength(2);
+    expect(
+      container.querySelector(
+        '[data-testid="team-runtime-member-usage-user-b"]'
+      )?.textContent
+    ).toContain("2.0K");
 
     const personSelect = container.querySelector<HTMLSelectElement>(
       '[data-testid="team-runtime-person-select"]'
@@ -650,6 +724,17 @@ describe("TeamRuntimePanel roster", () => {
         '[data-testid^="team-runtime-recent-session-"]'
       )
     ).toHaveLength(3);
+    const selectedPoints = JSON.parse(
+      container
+        .querySelector('[data-testid="team-usage-trend-chart"]')
+        ?.getAttribute("data-points") ?? "[]"
+    ) as Array<{ inputTokens: number; costUsd: number }>;
+    expect(selectedPoints[0]).toMatchObject({ inputTokens: 2_000, costUsd: 6 });
+    expect(
+      container
+        .querySelector('[data-testid="team-runtime-member-usage-user-b"]')
+        ?.getAttribute("aria-pressed")
+    ).toBe("true");
 
     await act(async () => {
       container
@@ -775,10 +860,17 @@ describe("TeamRuntimePanel roster", () => {
 });
 
 describe("TeamRuntimePanel drilldown", () => {
-  it("fetches a 30d range and maps days onto UTC-midnight trend points", async () => {
+  it("defaults to 7d daily usage and switches to the inline rolling-24h view", async () => {
     const today = utcDayFromMs(Date.now());
     const yesterday = utcDayFromMs(Date.now() - 86_400_000);
-    mocks.listMemberRuntime.mockResolvedValue([member()]);
+    mocks.listMemberRuntime.mockResolvedValue([
+      member({
+        stats: {
+          totalSessions: 128,
+          recentUsage24h: recentUsage24h(77, 1.5),
+        },
+      }),
+    ]);
     mocks.getMemberUsage.mockResolvedValue([
       usageDay({ day: yesterday, inputTokens: 10, costUsd: 1 }),
       usageDay({ day: today, inputTokens: 20, costUsd: 2 }),
@@ -807,7 +899,12 @@ describe("TeamRuntimePanel drilldown", () => {
     expect(orgId).toBe("org-1");
     expect(userId).toBe("user-a");
     expect(toDay).toBe(today);
-    expect(fromDay).toBe(utcDayFromMs(Date.now() - 29 * 86_400_000));
+    expect(fromDay).toBe(utcDayFromMs(Date.now() - 6 * 86_400_000));
+
+    const rangeSelect = container.querySelector<HTMLSelectElement>(
+      '[data-testid="team-member-usage-range"]'
+    );
+    expect(rangeSelect?.value).toBe("7");
 
     const chart = container.querySelector(
       '[data-testid="team-usage-trend-chart"]'
@@ -821,6 +918,22 @@ describe("TeamRuntimePanel drilldown", () => {
     expect(points[0].bucketMs).toBe(utcDayStartMs(yesterday));
     expect(points[1].bucketMs).toBe(utcDayStartMs(today));
     expect(points[1].inputTokens).toBe(25);
+
+    await act(async () => {
+      if (!rangeSelect) return;
+      rangeSelect.value = "24h";
+      rangeSelect.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    const hourlyChart = container.querySelector(
+      '[data-testid="team-usage-trend-chart"]'
+    );
+    expect(hourlyChart?.getAttribute("data-hourly")).toBe("true");
+    expect(
+      JSON.parse(hourlyChart?.getAttribute("data-points") ?? "[]")[0]
+        ?.inputTokens
+    ).toBe(77);
+    expect(mocks.getMemberUsage).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[data-testid="tab-pill"]')).toBeNull();
 
     // Member without a shared profile degrades gracefully.
     expect(
@@ -837,6 +950,38 @@ describe("TeamRuntimePanel drilldown", () => {
     expect(
       container.querySelector('[data-testid="team-runtime-grid"]')
     ).not.toBeNull();
+  });
+
+  it("shows an empty 24h state for a peer that has not pushed the additive snapshot yet", async () => {
+    mocks.listMemberRuntime.mockResolvedValue([member()]);
+    mocks.getMemberUsage.mockResolvedValue([usageDay()]);
+    await seedAtoms(AUTH, [org()]);
+    await mount({ view: "members" });
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="team-member-card-user-a"]'
+        )
+        ?.click();
+    });
+    await drainMicrotasks();
+
+    const rangeSelect = container.querySelector<HTMLSelectElement>(
+      '[data-testid="team-member-usage-range"]'
+    );
+    await act(async () => {
+      if (!rangeSelect) return;
+      rangeSelect.value = "24h";
+      rangeSelect.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    expect(
+      container.querySelector('[data-testid="placeholder-empty"]')?.textContent
+    ).toContain("detail.usageEmpty");
+    expect(
+      container.querySelector('[data-testid="placeholder-loading"]')
+    ).toBeNull();
   });
 });
 

--- a/src/modules/shared/dataSource/TeamRuntimeToday.tsx
+++ b/src/modules/shared/dataSource/TeamRuntimeToday.tsx
@@ -1,12 +1,14 @@
 /**
  * Runtime → organization → Today's analytical surface.
  *
- * Usage is folded from the roster's inline UTC-day aggregates. Recent
- * sessions are a read-only projection of the existing Team Sessions cache,
- * so this component owns no network request, timer, subscription, or cache.
+ * Headlines are folded from the roster's inline UTC-day aggregates; the
+ * rolling chart and member breakdown use its bounded `stats.recentUsage24h`
+ * snapshot. Recent sessions are a read-only projection of the existing Team
+ * Sessions cache, so this component owns no network request, timer,
+ * subscription, or cache.
  */
 import { MessageSquareText } from "lucide-react";
-import { type ReactNode, memo, useMemo } from "react";
+import { type ReactNode, Suspense, lazy, memo, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import Avatar from "@src/components/Avatar";
@@ -15,6 +17,7 @@ import type {
   MemberRuntimeListEntry,
   OrgRuntimeTelemetry,
 } from "@src/features/Org2Cloud/memberRuntime/types";
+import { MEMBER_RECENT_USAGE_WINDOW_MS } from "@src/features/Org2Cloud/memberRuntime/types";
 import type { CloudRemoteSessionsFetchState } from "@src/features/Org2Cloud/org2CloudRemoteSessionsAtom";
 import {
   SECTION_SUBHEADING_CLASSES,
@@ -24,6 +27,7 @@ import type { RemoteTeammateSessionMetadata } from "@src/store/collaboration/typ
 import { formatRelativeTime } from "@src/util/time/formatRelativeTime";
 
 import {
+  aggregateMemberRecentUsageTrends,
   buildOrgRuntimeTodaySnapshot,
   recentSharedSessions,
 } from "./teamRuntimeData";
@@ -37,6 +41,7 @@ import {
 
 const ALL_MEMBERS = "all";
 const RECENT_SESSION_LIMIT = 5;
+const UsageTrendChart = lazy(() => import("./UsageTrendChart"));
 
 interface TodayMetricProps {
   label: string;
@@ -134,6 +139,29 @@ function TeamRuntimeToday({
       ),
     [snapshot.usage.byBucket]
   );
+  const usageStartMs = nowMs - MEMBER_RECENT_USAGE_WINDOW_MS;
+  const usageTrendPoints = useMemo(
+    () => aggregateMemberRecentUsageTrends(scopedMembers, usageStartMs, nowMs),
+    [scopedMembers, usageStartMs, nowMs]
+  );
+  const memberUsage = useMemo(
+    () =>
+      members
+        .map((member) => ({
+          member,
+          summary: member.stats?.recentUsage24h?.summary ?? null,
+        }))
+        .sort((left, right) => {
+          const tokenDelta =
+            (right.summary?.realTotalTokens ?? 0) -
+            (left.summary?.realTotalTokens ?? 0);
+          if (tokenDelta !== 0) return tokenDelta;
+          return (left.member.displayName ?? left.member.userId).localeCompare(
+            right.member.displayName ?? right.member.userId
+          );
+        }),
+    [members]
+  );
 
   const systemSecondary = [
     snapshot.averageCpuPercent == null
@@ -226,6 +254,91 @@ function TeamRuntimeToday({
         </span>
         {systemSecondary ? <span>{systemSecondary}</span> : null}
       </div>
+
+      <section
+        className="flex min-w-0 flex-col gap-3"
+        data-testid="team-runtime-usage-trend"
+      >
+        <div className="flex items-center justify-between gap-3">
+          <h3 className={SECTION_SUBHEADING_CLASSES}>
+            {tUsage("usage.trends.title")}
+          </h3>
+          <span className="shrink-0 text-xs text-text-3">
+            {tUsage("usage.range.24h")}
+          </span>
+        </div>
+        <Suspense
+          fallback={<div aria-hidden className="h-72 rounded-xl bg-fill-1" />}
+        >
+          <UsageTrendChart
+            points={usageTrendPoints}
+            hourly
+            startMs={usageStartMs}
+            endMs={nowMs}
+            dataEndMs={nowMs}
+            language={language}
+          />
+        </Suspense>
+      </section>
+
+      <section
+        className="flex min-w-0 flex-col gap-3"
+        data-testid="team-runtime-member-usage"
+      >
+        <div className="flex items-center justify-between gap-3">
+          <h3 className={SECTION_SUBHEADING_CLASSES}>
+            {t("overview.members")}
+          </h3>
+          <span className="shrink-0 text-xs text-text-3">
+            {tUsage("usage.range.24h")}
+          </span>
+        </div>
+        <SectionContainer>
+          {memberUsage.length === 0 ? (
+            <div className="px-4 py-8 text-center text-sm text-text-3">
+              {t("detail.usageEmpty")}
+            </div>
+          ) : (
+            memberUsage.map(({ member, summary }) => {
+              const displayName = member.displayName ?? member.userId;
+              const selected = selectedMemberId === member.userId;
+              return (
+                <button
+                  key={member.userId}
+                  type="button"
+                  aria-pressed={selected}
+                  onClick={() =>
+                    onSelectMember(selected ? null : member.userId)
+                  }
+                  className={`flex w-full items-center gap-3 border-b border-border-1 px-4 py-3 text-left transition-colors last:border-b-0 hover:bg-fill-1 ${
+                    selected ? "bg-fill-1" : ""
+                  }`}
+                  data-testid={`team-runtime-member-usage-${member.userId}`}
+                >
+                  <Avatar size={28} src={member.avatarUrl ?? undefined}>
+                    {displayName.slice(0, 1).toUpperCase()}
+                  </Avatar>
+                  <span className="min-w-0 flex-1 truncate text-sm text-text-2">
+                    {displayName}
+                  </span>
+                  <span className="shrink-0 text-right text-xs text-text-3">
+                    {summary ? (
+                      <>
+                        <span className="font-medium text-text-1">
+                          {formatTokensShort(summary.realTotalTokens)}
+                        </span>{" "}
+                        · {formatUsd(summary.costUsd, 2)}
+                      </>
+                    ) : (
+                      "—"
+                    )}
+                  </span>
+                </button>
+              );
+            })
+          )}
+        </SectionContainer>
+      </section>
 
       <div className="grid grid-cols-1 gap-4 @[720px]:grid-cols-2">
         <section className="flex min-w-0 flex-col gap-3">

--- a/src/modules/shared/dataSource/teamRuntimeData.test.ts
+++ b/src/modules/shared/dataSource/teamRuntimeData.test.ts
@@ -7,6 +7,7 @@ import type {
 import type { RemoteTeammateSessionMetadata } from "@src/store/collaboration/types";
 
 import {
+  aggregateMemberRecentUsageTrends,
   buildOrgRuntimeTodaySnapshot,
   clampTelemetryInterval,
   foldMemberUsageSummary,
@@ -21,6 +22,24 @@ import {
   telemetrySelectValue,
   utcDayStartMs,
 } from "./teamRuntimeData";
+
+function usageSummary(realTotalTokens: number, costUsd: number) {
+  return {
+    sessionCount: 1,
+    requestCount: 1,
+    inputTokens: realTotalTokens,
+    outputTokens: 0,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    realTotalTokens,
+    totalTokens: realTotalTokens,
+    costUsd,
+    estimatedCostUsd: costUsd,
+    recordedCostUsd: 0,
+    cacheHitRate: 0,
+    byBucket: [],
+  };
+}
 
 function usageDay(over: Partial<MemberUsageDay> = {}): MemberUsageDay {
   return {
@@ -309,6 +328,64 @@ describe("buildOrgRuntimeTodaySnapshot", () => {
     expect(snapshot.currentSystems).toBe(2);
     expect(snapshot.averageCpuPercent).toBe(30);
     expect(snapshot.averageRamPercent).toBe(50);
+  });
+});
+
+describe("aggregateMemberRecentUsageTrends", () => {
+  it("merges matching member hours, clips the display window, and sorts", () => {
+    const startMs = Date.parse("2026-07-28T12:30:00Z");
+    const endMs = Date.parse("2026-07-29T12:30:00Z");
+    const firstHour = Date.parse("2026-07-28T12:00:00Z");
+    const laterHour = Date.parse("2026-07-29T10:00:00Z");
+    const outsideHour = Date.parse("2026-07-28T11:00:00Z");
+    const trend = (bucketMs: number, inputTokens: number, costUsd: number) => ({
+      bucketMs,
+      inputTokens,
+      outputTokens: 1,
+      cacheReadTokens: 2,
+      cacheWriteTokens: 3,
+      costUsd,
+    });
+    const withTrends = (userId: string, trends: ReturnType<typeof trend>[]) =>
+      member(userId, {
+        stats: {
+          totalSessions: 1,
+          recentUsage24h: {
+            startMs,
+            endMs,
+            summary: usageSummary(1, 1),
+            trends,
+          },
+        },
+      });
+
+    const points = aggregateMemberRecentUsageTrends(
+      [
+        withTrends("ada", [trend(laterHour, 10, 1), trend(firstHour, 20, 2)]),
+        withTrends("lin", [trend(laterHour, 30, 3), trend(outsideHour, 99, 9)]),
+      ],
+      startMs,
+      endMs
+    );
+
+    expect(points.map((point) => point.bucketMs)).toEqual([
+      firstHour,
+      laterHour,
+    ]);
+    expect(points[1]).toEqual({
+      bucketMs: laterHour,
+      inputTokens: 40,
+      outputTokens: 2,
+      cacheReadTokens: 4,
+      cacheWriteTokens: 6,
+      costUsd: 4,
+    });
+  });
+
+  it("is empty-safe for invalid bounds and peers without snapshots", () => {
+    expect(aggregateMemberRecentUsageTrends([member("ada")], 10, 0)).toEqual(
+      []
+    );
   });
 });
 

--- a/src/modules/shared/dataSource/teamRuntimeData.ts
+++ b/src/modules/shared/dataSource/teamRuntimeData.ts
@@ -32,6 +32,7 @@ import {
 import type { RemoteTeammateSessionMetadata } from "@src/store/collaboration/types";
 
 const DAY_MS = 86_400_000;
+const HOUR_MS = 3_600_000;
 
 // ---------------------------------------------------------------------------
 // Org record accessor (safe against the pre-plumbing orgs atom)
@@ -270,6 +271,58 @@ export function buildOrgRuntimeTodaySnapshot(
     averageCpuPercent: safeAverage(cpuPercents),
     averageRamPercent: safeAverage(ramPercents),
   };
+}
+
+/**
+ * Merge members' latest rolling-24h hourly series for the viewer's current
+ * display window. Member reports can land at slightly different instants, so
+ * the chart clips by hour bucket and adds matching buckets rather than
+ * assuming every peer reported on the same boundary.
+ */
+export function aggregateMemberRecentUsageTrends(
+  members: readonly MemberRuntimeListEntry[],
+  startMs: number,
+  endMs: number
+): UsageTrendPoint[] {
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs < startMs) {
+    return [];
+  }
+  const firstBucketMs = Math.floor(startMs / HOUR_MS) * HOUR_MS;
+  const lastBucketMs = Math.floor(endMs / HOUR_MS) * HOUR_MS;
+  const byHour = new Map<number, UsageTrendPoint>();
+
+  for (const member of members) {
+    for (const point of member.stats?.recentUsage24h?.trends ?? []) {
+      if (
+        !Number.isFinite(point.bucketMs) ||
+        point.bucketMs < firstBucketMs ||
+        point.bucketMs > lastBucketMs
+      ) {
+        continue;
+      }
+      let aggregate = byHour.get(point.bucketMs);
+      if (!aggregate) {
+        aggregate = {
+          bucketMs: point.bucketMs,
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          costUsd: 0,
+        };
+        byHour.set(point.bucketMs, aggregate);
+      }
+      aggregate.inputTokens += point.inputTokens;
+      aggregate.outputTokens += point.outputTokens;
+      aggregate.cacheReadTokens += point.cacheReadTokens;
+      aggregate.cacheWriteTokens += point.cacheWriteTokens;
+      aggregate.costUsd += point.costUsd;
+    }
+  }
+
+  return [...byHour.values()].sort(
+    (left, right) => left.bucketMs - right.bucketMs
+  );
 }
 
 /**


### PR DESCRIPTION
## Problem

Team Runtime can show UTC-day totals but cannot render a true rolling 24-hour usage chart or per-member 24-hour comparison. Re-querying each member's local history from the viewer is impossible, and adding another scheduler scan would increase idle I/O.

## Solution

Derive a rolling headline and hourly series inside the existing bounded Rust daily-rollup scan, serialize it through the existing Tauri result, and attach it to the scheduler's existing status heartbeat. The cloud status field is additive and optional for older peers, trends are capped at 25 points, and the entire status remains under the existing 8 KiB limit by dropping only the additive snapshot near the cap. Team Runtime aggregates the bounded peer snapshots for its 24-hour chart and lets member drilldowns switch between the inline 24-hour view and existing daily ranges.

## Potential risks

Peers on older builds omit the snapshot and appear with an empty 24-hour state until upgraded. Unusually large status metadata can intentionally drop the snapshot while preserving the heartbeat and lifetime census. The local Tauri result gains a required field, but frontend and backend ship together; the cloud wire addition remains optional and needs no schema migration. No CPU or wall-time improvement claim is made because runtime profiling was not performed; the implementation is structurally bounded and reuses the existing scan.

## Architecture audit

Covered all 10 architecture layers. Storage schema and identity are unchanged; aggregation ownership remains in `orgtrack_core`; camelCase serialization and Zod parsing are explicit; the local result has construction/serialization parity; the cloud protocol evolves additively; the rolling window is `[end - 24h, end]` with hourly bucketing; and old/malformed peer payloads degrade to an absent snapshot. No naming or control-flow sweep candidate was found outside this feature.

## Performance guard

Verdict: pass. Active/visible and active/hidden operation reuse the existing scheduler cadence and one bounded database scan; idle operation adds no timer, poll, subscription, or cache; repeated panel open/close creates no retained work; multi-instance behavior is unchanged; restart/cold-start behavior accepts peers without the new field. Memory and payload growth are capped by 25 hourly points, the fixed usage-bucket count, and the 8 KiB status limit. No additional I/O pass or unbounded loop was introduced.

## UI audit

Frontend UI audit: 0 fixes, 4 keep-with-reason decisions, and no abstraction or sweep candidate. The report is included at `docs/frontend-ui-audit-2026-08-06/RuntimeUsageCharts.md`.

## Verification

- Vitest for member-runtime client, scheduler, Team Runtime panel, and runtime data — passed (65 tests across 4 files).
- `cargo test -p orgtrack_core daily_rollup_` — passed (6 tests; 546 filtered out).
- `cargo clippy -p orgtrack_core --lib -- -D warnings` — passed.
- `rustfmt --edition 2021 --check` on the 4 changed Rust files — passed. Full `cargo fmt --all --check` was not used as evidence because it reports unrelated pre-existing formatting drift elsewhere in the workspace.
- ESLint on the 11 changed TypeScript/TSX implementation and test files — passed after formatting correction.
- `pnpm typecheck` — passed.
- Manual desktop verification was not run because local UI control was not authorized for this task.
