### PR TITLE
Keep the GitHub issue composer within reach

### DIFF
--- a/src/components/PropertyField/PropertyDropdownField.test.ts
+++ b/src/components/PropertyField/PropertyDropdownField.test.ts
@@ -22,4 +22,26 @@ describe("PropertyDropdownField", () => {
 
     expect(renderOptions).not.toHaveBeenCalled();
   });
+
+  it("renders disabled options as unavailable", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(PropertyDropdownField, {
+        value: "open",
+        label: "Open",
+        icon: null,
+        active: true,
+        searchable: false,
+        options: [
+          { value: "open", label: "Open", disabled: true },
+          { value: "closed", label: "Closed" },
+        ],
+        dataTestId: "status",
+      })
+    );
+
+    expect(markup).toMatch(
+      /data-testid="status-option-open"[^>]*disabled=""[^>]*aria-disabled="true"/
+    );
+    expect(markup).toContain('data-testid="status-option-closed"');
+  });
 });

--- a/src/components/PropertyField/PropertyDropdownField.tsx
+++ b/src/components/PropertyField/PropertyDropdownField.tsx
@@ -20,6 +20,7 @@ export interface PropertyDropdownOption<T extends string> {
   label: string;
   icon?: React.ReactNode;
   iconColor?: string;
+  disabled?: boolean;
 }
 
 export type PropertyDropdownPlacement = "inline" | "portal";
@@ -223,6 +224,7 @@ export function PropertyDropdownField<T extends string>({
             iconColor={option.iconColor}
             label={option.label}
             isSelected={option.value === value}
+            disabled={option.disabled}
             onClick={() => handleSelect(option.value)}
             dataTestId={
               dataTestId ? `${dataTestId}-option-${option.value}` : undefined

--- a/src/components/PropertyField/PropertyFieldEditable.tsx
+++ b/src/components/PropertyField/PropertyFieldEditable.tsx
@@ -347,6 +347,7 @@ export interface OptionProps {
   iconColor?: string;
   label: string;
   isSelected?: boolean;
+  disabled?: boolean;
   onClick: () => void;
   children?: React.ReactNode;
   /** Stable selector for rendered UI tests. */
@@ -358,6 +359,7 @@ export const Option: React.FC<OptionProps> = ({
   iconColor,
   label,
   isSelected,
+  disabled = false,
   onClick,
   children,
   dataTestId,
@@ -367,13 +369,16 @@ export const Option: React.FC<OptionProps> = ({
     data-testid={dataTestId}
     className={[
       DROPDOWN_CLASSES.item,
-      DROPDOWN_CLASSES.itemHover,
+      !disabled && DROPDOWN_CLASSES.itemHover,
       "w-full justify-between text-left",
       isSelected && DROPDOWN_CLASSES.itemSelected,
+      disabled && DROPDOWN_CLASSES.itemDisabled,
     ]
       .filter(Boolean)
       .join(" ")}
     onClick={onClick}
+    disabled={disabled}
+    aria-disabled={disabled}
   >
     {children ? (
       <>

--- a/src/hooks/ui/layout/useElementDimensions.ts
+++ b/src/hooks/ui/layout/useElementDimensions.ts
@@ -28,6 +28,8 @@ export interface ElementDimensions {
 export interface UseElementDimensionsOptions {
   /** What to measure: 'width', 'height', or 'both' */
   dimension?: DimensionType;
+  /** Disable measurement and listener ownership while the element is absent. */
+  enabled?: boolean;
   /** Additional dependency to trigger re-measurement */
   deps?: unknown[];
 }
@@ -70,7 +72,7 @@ export function useElementDimensions(
   ref: RefObject<HTMLElement | null | { current?: HTMLElement | null }>,
   options: UseElementDimensionsOptions = {}
 ): number | ElementDimensions {
-  const { dimension = "both", deps = [] } = options;
+  const { dimension = "both", enabled = true, deps = [] } = options;
 
   const [dimensions, setDimensions] = useState<ElementDimensions>({
     width: 0,
@@ -78,6 +80,8 @@ export function useElementDimensions(
   });
 
   useIsomorphicLayoutEffect(() => {
+    if (!enabled) return;
+
     const measureDimensions = () => {
       // Handle nested ref objects
       const element =
@@ -130,7 +134,7 @@ export function useElementDimensions(
       window.removeEventListener("resize", measureDimensions);
       resizeObserver?.disconnect();
     };
-  }, [ref, ...deps]);
+  }, [ref, enabled, ...deps]);
 
   // Return based on requested dimension
   if (dimension === "width") return dimensions.width;

--- a/src/modules/ProjectManager/WorkItems/components/GitHubIssueThreadSurface.test.ts
+++ b/src/modules/ProjectManager/WorkItems/components/GitHubIssueThreadSurface.test.ts
@@ -162,6 +162,8 @@ describe("mapGitHubIssueToThreadWorkItem", () => {
       `data-testid="work-item-property-status-${issue.html_url}"`
     );
     expect(markup).toContain('data-testid="github-issue-inline-composer"');
+    expect(markup).toContain('data-testid="work-item-thread-floating-footer"');
+    expect(markup).toContain("padding-bottom:240px");
     expect(markup).not.toContain(
       'data-testid="work-item-thread-secondary-navigation"'
     );
@@ -183,7 +185,7 @@ describe("mapGitHubIssueToThreadWorkItem", () => {
     );
     expect(
       markup.match(/data-scroll-trail-target/g)?.length
-    ).toBeGreaterThanOrEqual(4);
+    ).toBeGreaterThanOrEqual(3);
   });
 
   it("toggles external assignees without duplicating login casing", () => {

--- a/src/modules/ProjectManager/WorkItems/components/GitHubIssueThreadSurface.tsx
+++ b/src/modules/ProjectManager/WorkItems/components/GitHubIssueThreadSurface.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
 
 import type {
   GitHubIssue,
@@ -73,6 +74,7 @@ const GitHubIssueThreadSurface: React.FC<GitHubIssueThreadSurfaceProps> = ({
   interaction,
   assigneeConfig,
 }) => {
+  const { t } = useTranslation("common");
   const workItem = useMemo(
     () => mapGitHubIssueToThreadWorkItem(issue),
     [issue]
@@ -99,8 +101,16 @@ const GitHubIssueThreadSurface: React.FC<GitHubIssueThreadSurfaceProps> = ({
         externalStatusConfig: {
           currentStatusId: issue.state,
           options: [
-            { id: "open", label: "Open" },
-            { id: "closed", label: "Closed" },
+            {
+              id: "open",
+              label: t("git.issues.status.open"),
+              color: "var(--color-success-6)",
+            },
+            {
+              id: "closed",
+              label: t("git.issues.status.closed"),
+              color: "var(--color-purple-6)",
+            },
           ],
           disabled: !interaction.canManageStatus || interaction.updatingStatus,
           onChangeStatusId: (statusId) => {

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemContent/GitHubIssueCloseButton.tsx
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemContent/GitHubIssueCloseButton.tsx
@@ -5,6 +5,7 @@ import {
   CircleDot,
   CircleSlash,
   Copy,
+  Loader2,
 } from "lucide-react";
 import React, { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -17,7 +18,6 @@ import {
   DROPDOWN_ITEM,
   DROPDOWN_WIDTHS,
 } from "@src/components/Dropdown/tokens";
-import { LoadingBar } from "@src/modules/shared/layouts/blocks";
 
 import type {
   GitHubIssueInteractionConfig,
@@ -106,8 +106,16 @@ const GitHubIssueCloseButton: React.FC<GitHubIssueCloseButtonProps> = ({
         autoFocus
       />
       {interaction.loadingDuplicateCandidates ? (
-        <div className="px-2 py-3">
-          <LoadingBar />
+        <div
+          className={DROPDOWN_CLASSES.listMessage}
+          data-testid="github-issue-duplicate-loading"
+        >
+          <Loader2
+            size={DROPDOWN_ITEM.iconSize}
+            className="animate-spin"
+            aria-hidden
+          />
+          <span>{t("actions.loading")}</span>
         </div>
       ) : interaction.duplicateCandidatesError ? (
         <div className={DROPDOWN_CLASSES.listMessage} role="status">
@@ -162,6 +170,8 @@ const GitHubIssueCloseButton: React.FC<GitHubIssueCloseButtonProps> = ({
         <DropdownItem
           icon={<CircleDot size={DROPDOWN_ITEM.iconSize} aria-hidden />}
           onClick={closeMenu}
+          disabled={interaction.issueState === "open"}
+          dataTestId="github-issue-status-open"
         >
           {t("git.issues.status.open")}
         </DropdownItem>

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemContent/GitHubIssueComposer.tsx
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemContent/GitHubIssueComposer.tsx
@@ -73,8 +73,25 @@ const GitHubIssueComposer: React.FC<GitHubIssueComposerProps> = ({
     <section
       data-testid="github-issue-inline-composer"
       aria-label={t("git.issues.composer.addComment")}
+      className="flex flex-col gap-2"
     >
-      <ComposerShell variant="default" className="!gap-0 overflow-visible !p-0">
+      {interaction.canManageStatus ? (
+        <div
+          className="flex min-h-9 flex-wrap items-center gap-2 px-1"
+          data-testid="github-issue-level-actions"
+        >
+          <GitHubIssueCloseButton
+            interaction={interaction}
+            onStatusChange={handleStatusChange}
+          />
+        </div>
+      ) : null}
+
+      <ComposerShell
+        variant="default"
+        className="!gap-0 overflow-visible !p-0"
+        data-testid="github-issue-comment-input"
+      >
         <RichMarkdownEditor
           value={commentBody}
           onChange={(markdown) => setCommentBody(markdown)}
@@ -84,6 +101,8 @@ const GitHubIssueComposer: React.FC<GitHubIssueComposerProps> = ({
           maxHeight={500}
           appearance="plain"
           toolbarMode="inline"
+          toolbarSize="mini"
+          toolbarDropdownPosition="top-start"
           editable={interaction.canComment && !interaction.submittingComment}
           dataTestId="github-issue-comment-editor"
         />
@@ -118,26 +137,18 @@ const GitHubIssueComposer: React.FC<GitHubIssueComposerProps> = ({
             </span>
           )}
 
-          <div className="flex flex-wrap items-center justify-end gap-2">
-            {interaction.canManageStatus ? (
-              <GitHubIssueCloseButton
-                interaction={interaction}
-                onStatusChange={handleStatusChange}
-              />
-            ) : null}
-            <Button
-              htmlType="button"
-              variant="primary"
-              size="default"
-              shape="round"
-              loading={interaction.submittingComment}
-              disabled={!hasComment || !interaction.canComment}
-              onClick={() => void handleComment()}
-              data-testid="github-issue-comment-submit"
-            >
-              {t("git.issues.composer.submitComment")}
-            </Button>
-          </div>
+          <Button
+            htmlType="button"
+            variant="primary"
+            size="default"
+            shape="round"
+            loading={interaction.submittingComment}
+            disabled={!hasComment || !interaction.canComment}
+            onClick={() => void handleComment()}
+            data-testid="github-issue-comment-submit"
+          >
+            {t("git.issues.composer.submitComment")}
+          </Button>
         </div>
       </ComposerShell>
     </section>

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemContent/HistoryTab.tsx
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemContent/HistoryTab.tsx
@@ -126,6 +126,8 @@ const HistoryTab: React.FC<HistoryTabProps> = ({
             maxHeight={120}
             appearance="plain"
             matchMarkdownPreview={false}
+            toolbarSize="mini"
+            toolbarDropdownPosition="top-start"
             dataTestId="work-item-comment-editor"
           />
           {submitButton}
@@ -150,6 +152,8 @@ const HistoryTab: React.FC<HistoryTabProps> = ({
           minHeight={60}
           maxHeight={120}
           appearance="outlined"
+          toolbarSize="mini"
+          toolbarDropdownPosition="top-start"
           dataTestId="work-item-comment-editor"
         />
         <div className="mt-2 flex items-center justify-end">{submitButton}</div>

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemContent/__tests__/GitHubIssueComposer.test.ts
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemContent/__tests__/GitHubIssueComposer.test.ts
@@ -131,6 +131,23 @@ describe("GitHubIssueComposer", () => {
     );
     expect(editor?.dataset.toolbarMode).toBe("inline");
     expect(editor?.dataset.minHeight).toBe("140");
+    const levelActions = container.querySelector(
+      "[data-testid='github-issue-level-actions']"
+    );
+    const input = container.querySelector(
+      "[data-testid='github-issue-comment-input']"
+    );
+    expect(levelActions?.nextElementSibling).toBe(input);
+    expect(input?.contains(levelActions as Node)).toBe(false);
+    expect(levelActions?.className).not.toContain("border-");
+    expect(
+      input?.querySelector("[data-testid='github-issue-comment-submit']")
+    ).not.toBeNull();
+    expect(
+      levelActions?.querySelector(
+        "[data-testid='github-issue-comment-status-action']"
+      )
+    ).not.toBeNull();
     act(() => {
       const valueSetter = Object.getOwnPropertyDescriptor(
         HTMLTextAreaElement.prototype,
@@ -201,6 +218,11 @@ describe("GitHubIssueComposer", () => {
     expect(
       document.querySelector("[data-testid='github-issue-close-menu']")
     ).not.toBeNull();
+    expect(
+      document
+        .querySelector("[data-testid='github-issue-status-open']")
+        ?.getAttribute("aria-disabled")
+    ).toBe("true");
     expect(config.onLoadDuplicateCandidates).not.toHaveBeenCalled();
 
     await act(async () => {
@@ -215,6 +237,34 @@ describe("GitHubIssueComposer", () => {
     expect(
       document.querySelector("[data-testid='github-issue-duplicate-picker']")
     ).not.toBeNull();
+  });
+
+  it("uses an inline spinner while duplicate issues load", async () => {
+    const config = interaction({ loadingDuplicateCandidates: true });
+    act(() => {
+      root.render(createElement(GitHubIssueComposer, { interaction: config }));
+    });
+
+    await act(async () => {
+      container
+        .querySelectorAll<HTMLButtonElement>(".button-split-wrapper button")[1]
+        ?.click();
+      await Promise.resolve();
+    });
+    act(() => {
+      document
+        .querySelector<HTMLElement>(
+          "[data-testid='github-issue-close-duplicate']"
+        )
+        ?.click();
+    });
+
+    const loading = document.querySelector(
+      "[data-testid='github-issue-duplicate-loading']"
+    );
+    expect(loading?.querySelector(".animate-spin")).not.toBeNull();
+    expect(loading?.textContent).toContain("actions.loading");
+    expect(config.onLoadDuplicateCandidates).not.toHaveBeenCalled();
   });
 
   it("closes as a duplicate with the selected canonical issue database ID", async () => {

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemContent/index.tsx
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemContent/index.tsx
@@ -553,6 +553,8 @@ const WorkItemContent: React.FC<WorkItemContentProps> = ({
                 maxHeight={360}
                 appearance="plain"
                 toolbarMode="inline"
+                toolbarSize="mini"
+                toolbarDropdownPosition="top-start"
                 editable={
                   canEditDescription && !githubIssueInteraction?.updatingBody
                 }
@@ -741,8 +743,19 @@ const WorkItemContent: React.FC<WorkItemContentProps> = ({
   );
 
   if (isThread) {
+    const githubIssueComposer =
+      activeThreadView === "overview" &&
+      isGitHubWorkItem &&
+      githubIssueInteraction ? (
+        <GitHubIssueComposer interaction={githubIssueInteraction} />
+      ) : undefined;
+
     return (
-      <WorkItemThreadLayout path={headerPath} properties={headerProperties}>
+      <WorkItemThreadLayout
+        path={headerPath}
+        properties={headerProperties}
+        floatingFooter={githubIssueComposer}
+      >
         {activeThreadView === "overview" ? (
           <>
             {handoffNotice}
@@ -751,13 +764,7 @@ const WorkItemContent: React.FC<WorkItemContentProps> = ({
               {todosSection}
             </ScrollTrailTarget>
             {threadLowerSection}
-            {isGitHubWorkItem && githubIssueInteraction ? (
-              <ScrollTrailTarget
-                label={t("common:git.issues.composer.addComment")}
-              >
-                <GitHubIssueComposer interaction={githubIssueInteraction} />
-              </ScrollTrailTarget>
-            ) : (
+            {!isGitHubWorkItem || !githubIssueInteraction ? (
               <ScrollTrailTarget
                 label={t("workItems.activity.discussionTitle")}
               >
@@ -777,7 +784,7 @@ const WorkItemContent: React.FC<WorkItemContentProps> = ({
                   />
                 </nav>
               </ScrollTrailTarget>
-            )}
+            ) : null}
           </>
         ) : (
           historyContent

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemProperties/EnumPropertyField.tsx
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemProperties/EnumPropertyField.tsx
@@ -10,6 +10,7 @@ interface EnumOption<T extends string> {
   value: T;
   icon?: React.ReactNode;
   color?: string;
+  disabled?: boolean;
 }
 
 interface EnumPropertyFieldProps<T extends string> {
@@ -51,6 +52,7 @@ export function EnumPropertyField<T extends string>({
       label: getLabel(option.value),
       icon: option.icon,
       iconColor: option.color,
+      disabled: option.disabled,
     })
   );
 

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemProperties/StatusPrioritySection.tsx
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemProperties/StatusPrioritySection.tsx
@@ -1,4 +1,4 @@
-import { Circle } from "lucide-react";
+import { CheckCircle2, Circle, CircleDot } from "lucide-react";
 import { useState } from "react";
 
 import type { FieldRowVariant } from "@src/components/PropertyField/PropertyFieldEditable";
@@ -63,9 +63,15 @@ export function StatusPrioritySection({
     externalStatusConfig?.options.map((option) => ({
       value: option.id,
       color: option.color,
-      icon: (
-        <Circle size={12} fill={option.color ?? "#6B7280"} strokeWidth={1.5} />
-      ),
+      disabled: option.id === externalStatusConfig.currentStatusId,
+      icon:
+        option.id === "open" ? (
+          <CircleDot size={13} strokeWidth={1.8} aria-hidden />
+        ) : option.id === "closed" ? (
+          <CheckCircle2 size={13} strokeWidth={1.8} aria-hidden />
+        ) : (
+          <Circle size={13} strokeWidth={1.8} aria-hidden />
+        ),
     })) ?? [];
   const currentExternalStatusOption = externalStatusConfig
     ? externalStatusOptions.find(

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemThread/WorkItemThreadLayout.test.ts
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemThread/WorkItemThreadLayout.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { type ComponentProps, type ReactNode, act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { WorkItemThreadLayout } from ".";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@src/modules/shared/layouts/blocks", () => ({
+  DetailPanelContainer: ({ children }: { children: ReactNode }) =>
+    createElement("div", null, children),
+  ScrollTrail: () => null,
+}));
+
+describe("WorkItemThreadLayout floating footer", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const observe = vi.fn();
+  const disconnect = vi.fn();
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    observe.mockClear();
+    disconnect.mockClear();
+    vi.stubGlobal(
+      "ResizeObserver",
+      class ResizeObserverMock {
+        observe = observe;
+        disconnect = disconnect;
+      }
+    );
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("reserves the footer inset and disposes its observer on unmount", () => {
+    const removeWindowListener = vi.spyOn(window, "removeEventListener");
+    const props: ComponentProps<typeof WorkItemThreadLayout> = {
+      floatingFooter: createElement("div", null, "Composer"),
+      children: createElement("div", null, "Timeline"),
+    };
+
+    act(() => {
+      root.render(createElement(WorkItemThreadLayout, props));
+    });
+
+    const footer = container.querySelector(
+      '[data-testid="work-item-thread-floating-footer"]'
+    );
+    const content = container.querySelector(
+      '[data-testid="work-item-thread-section"] > div'
+    );
+    expect(footer?.className).toContain("absolute");
+    expect(footer?.className).toContain("bottom-0");
+    expect(content?.getAttribute("style")).toContain("padding-bottom: 240px");
+    expect(observe).toHaveBeenCalledWith(footer);
+
+    act(() => root.unmount());
+    root = createRoot(container);
+
+    expect(disconnect).toHaveBeenCalledOnce();
+    expect(removeWindowListener).toHaveBeenCalledWith(
+      "resize",
+      expect.any(Function)
+    );
+  });
+
+  it("does not retain measurement resources without a floating footer", () => {
+    const addWindowListener = vi.spyOn(window, "addEventListener");
+
+    act(() => {
+      root.render(
+        createElement(
+          WorkItemThreadLayout,
+          null,
+          createElement("div", null, "Timeline")
+        )
+      );
+    });
+
+    expect(observe).not.toHaveBeenCalled();
+    expect(addWindowListener).not.toHaveBeenCalledWith(
+      "resize",
+      expect.any(Function)
+    );
+    expect(
+      container.querySelector(
+        '[data-testid="work-item-thread-floating-footer"]'
+      )
+    ).toBeNull();
+  });
+});

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemThread/index.tsx
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemThread/index.tsx
@@ -1,6 +1,7 @@
 import React, { useId, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
+import { useElementDimensions } from "@src/hooks/ui/layout/useElementDimensions";
 import {
   DetailPanelContainer,
   ScrollTrail,
@@ -13,16 +14,26 @@ interface WorkItemThreadLayoutProps {
   path?: React.ReactNode;
   properties?: React.ReactNode;
   children: React.ReactNode;
+  floatingFooter?: React.ReactNode;
 }
 
 export const WorkItemThreadLayout: React.FC<WorkItemThreadLayoutProps> = ({
   path,
   properties,
   children,
+  floatingFooter,
 }) => {
   const { t } = useTranslation(["projects", "common"]);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+  const floatingFooterRef = useRef<HTMLDivElement>(null);
+  const measuredFooterHeight = useElementDimensions(floatingFooterRef, {
+    dimension: "height",
+    enabled: Boolean(floatingFooter),
+  });
+  const footerBottomInset = floatingFooter
+    ? Math.max(240, measuredFooterHeight)
+    : undefined;
   const headerPolicy = resolveWorkItemThreadHeaderPolicy(
     Boolean(path),
     Boolean(properties)
@@ -30,7 +41,7 @@ export const WorkItemThreadLayout: React.FC<WorkItemThreadLayoutProps> = ({
 
   return (
     <DetailPanelContainer>
-      <div className="flex min-h-0 flex-1 overflow-hidden">
+      <div className="relative flex min-h-0 flex-1 overflow-hidden">
         <div
           ref={scrollContainerRef}
           className="scrollbar-overlay min-h-0 min-w-0 flex-1 overflow-y-auto @container"
@@ -39,6 +50,7 @@ export const WorkItemThreadLayout: React.FC<WorkItemThreadLayoutProps> = ({
           <div
             ref={contentRef}
             className={WORK_ITEM_THREAD_TOKENS.contentColumn}
+            style={{ paddingBottom: footerBottomInset }}
           >
             {headerPolicy.showHeader ? (
               <div className={WORK_ITEM_THREAD_TOKENS.metadataBand}>
@@ -57,6 +69,21 @@ export const WorkItemThreadLayout: React.FC<WorkItemThreadLayoutProps> = ({
             {children}
           </div>
         </div>
+        {floatingFooter ? (
+          <div
+            ref={floatingFooterRef}
+            className="absolute bottom-0 left-0 right-11 z-50 flex flex-col items-center px-2 pb-2 pt-1"
+            data-testid="work-item-thread-floating-footer"
+          >
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-x-0 bottom-0 top-[-28px] bg-gradient-to-t from-chat-pane via-chat-pane/90 to-transparent"
+            />
+            <div className="relative z-10 w-full max-w-[920px] px-3">
+              {floatingFooter}
+            </div>
+          </div>
+        ) : null}
         <div
           className="relative w-11 shrink-0"
           data-testid="work-item-thread-navigation-rail"

--- a/src/modules/ProjectManager/shared/components/ProjectContentEditor/index.tsx
+++ b/src/modules/ProjectManager/shared/components/ProjectContentEditor/index.tsx
@@ -389,6 +389,8 @@ const ProjectContentEditor = forwardRef<
               maxHeight={descriptionMaxHeight}
               editable={editable}
               toolbarClassName="work-item-toolbar"
+              toolbarSize="mini"
+              toolbarDropdownPosition="top-start"
               className={`noDrag flex-1 cursor-text rounded-md text-[14px] text-text-1 ${descriptionClassName}`.trim()}
             />
             <ContextMenuPortal

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/IssuesContent/NewIssueForm.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/IssuesContent/NewIssueForm.tsx
@@ -92,6 +92,8 @@ export const NewIssueForm: React.FC<NewIssueFormProps> = memo(
           minHeight={96}
           maxHeight={240}
           appearance="outlined"
+          toolbarSize="mini"
+          toolbarDropdownPosition="top-start"
           dataTestId="new-issue-body-editor"
         />
 


### PR DESCRIPTION
## Problem

GitHub issue comments sit at the end of long threads, mix issue-level status actions into the text-input footer, and allow users to select the already-current status. Duplicate-search loading also uses a full loading bar inside a compact dropdown.

## Solution

Pin the issue composer to the bottom of the thread with measured content padding, move issue-level status actions above the comment input, use compact upward-opening formatting controls, disable the current status option, and use an inline spinner for duplicate-search loading. Extend property options with a native disabled state and keep other work-item editors on the same compact toolbar configuration.

## Potential risks

The floating footer reserves at least 240 px and then tracks its measured height; unusually tall composers may reduce visible thread space until they collapse. Closed-issue coloring consumes the purple theme variables introduced by PR #716. This PR is stacked on PR #719 for the rich-text toolbar API and should merge after both dependencies. Manual narrow-panel, keyboard, and theme evidence is pending, so this PR remains a draft.

## Performance guard

Verdict: pass. A footer owns one ResizeObserver and one existing resize listener only while mounted; `enabled: false` prevents ownership when no footer exists, and cleanup is asserted on unmount. Hidden, idle, and repeated-open behavior adds no timer, poll, subscription, cache, or retained observer. Multi-instance behavior is per mounted thread and bounded to one observer per visible composer.

## Audit

The configured `frontend-ui-audit` skill file was unavailable at both documented locations. A direct pass confirmed reuse of Button, Dropdown, PropertyField, RichMarkdownEditor, and existing semantic tokens. Current status options are native disabled buttons with `aria-disabled`, and the floating composer remains a labeled section.

## Verification

- Vitest for PropertyDropdownField, GitHubIssueComposer, GitHubIssueThreadSurface, and WorkItemThreadLayout — passed (16 tests across 4 files).
- ESLint on all 17 changed TypeScript/TSX implementation and test files — passed.
- `pnpm typecheck` — passed after correcting the strict React test fixture.
- `git diff --cached --check` — passed before commit.
- Manual desktop verification was not run because local UI control was not authorized for this task.
