### PR TITLE
fix(source-control): unify diff views and focus state

### DIFF
--- a/docs/frontend-ui-audit-2026-08-05/DiffViewConsistency.md
+++ b/docs/frontend-ui-audit-2026-08-05/DiffViewConsistency.md
@@ -1,0 +1,74 @@
+# Frontend UI Audit: Diff View Consistency
+
+**Files:**
+
+- `src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.tsx`
+- `src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/index.tsx`
+- `src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainPane.tsx`
+- `src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/index.tsx`
+- `src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/FocusView.tsx`
+- `src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/AllChangesView.tsx`
+- `src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitDiffContent/index.tsx`
+- `src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitCommitDetailContent/index.tsx`
+- `src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrChangesTab.tsx`
+- `src/modules/WorkStation/Diff/SessionReplay/index.tsx`
+- `src/modules/WorkStation/Diff/SessionReplay/diffSessionReplay.useDetailContent.tsx`
+- `src/modules/WorkStation/shared/DiffFileSection/index.tsx`
+- `src/modules/WorkStation/shared/DiffSectionList/index.tsx`
+- `src/modules/shared/components/FileHeader/index.tsx`
+- `src/features/CodeMirror/Diff/index.tsx`
+- `src/features/CodeViewer/GitDiffViewer.tsx`
+
+**Date:** 2026-08-05
+
+**Auditor:** Codex
+
+## D1 — Design-system component usage
+
+| Line                                   | Element                         | Verdict          | Reason                                                                                                                 | Suggested change                                                                                                     |
+| -------------------------------------- | ------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `SourceControlHeaderContent.tsx:217`   | Unified / split selector        | keep with reason | Uses the existing `TabPill` design-system control, matching the file diff header interaction.                          | None.                                                                                                                |
+| `SessionReplay/index.tsx:269`          | Unified / split selector        | keep with reason | Uses the same `TabPill` control and shared preference as the other diff surfaces.                                      | None.                                                                                                                |
+| `GitCommitDetailContent/index.tsx:377` | Collapsed file-list rail button | keep with reason | The control occupies a full-height 24 px rail; the current design-system `Button` variants do not model that geometry. | Keep the raw semantic button until the rail pattern is abstracted.                                                   |
+| `PrChangesTab.tsx:214`                 | Collapsed file-list rail button | keep with reason | Same full-height rail geometry as commit details.                                                                      | Keep the raw semantic button until the rail pattern is abstracted.                                                   |
+| `DiffFileSection/index.tsx:418`        | Sticky expandable file header   | keep with reason | It is a full-width, multiline disclosure row rather than a standard action button.                                     | Continue using a semantic button; consider a dedicated diff-section header only if the pattern gains more consumers. |
+| `FocusView.tsx:51`                     | No-file Focus empty state       | keep with reason | Reuses the workstation `NoTabsPlaceholder` with a focused instruction instead of assembling a bespoke empty state.     | None.                                                                                                                |
+
+## D2 — Color and token usage
+
+| Line | Element                 | Verdict          | Reason                                                                                                                           | Suggested change |
+| ---- | ----------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| —    | Audited visible changes | keep with reason | New controls use existing semantic border, fill, and text tokens; no raw colors or duplicated token expressions were introduced. | None.            |
+
+## D3 — Spacing and typography
+
+| Line                                     | Element                                       | Verdict          | Reason                                                                                                                                     | Suggested change                                                                             |
+| ---------------------------------------- | --------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- |
+| `DiffSectionList/index.tsx:51`           | Virtual-list footer buffer `h-[100px]`        | keep with reason | This is an exact scroll affordance rather than visual component sizing, and the spacing scale has no exact 100 px token.                   | None.                                                                                        |
+| `DiffFileSection/index.tsx:321`          | Loading placeholder `h-[480px] min-h-[320px]` | fix              | Both values have exact Tailwind scale equivalents and are unrelated to the current diff-mode behavior.                                     | In a separate visual-cleanup sweep, use `h-120 min-h-80` and visually verify loading layout. |
+| `DiffFileSection/index.tsx:424`          | Chevron reservation `w-[14px]`                | keep with reason | The width deliberately matches the 14 px icon and has no exact standard spacing class.                                                     | None.                                                                                        |
+| `DiffFileSection/index.tsx:436-463`      | Dense diff metadata typography                | keep with reason | The 13 px filename and 11 px metadata match the established dense diff header hierarchy; the standard text scale has no exact equivalents. | Keep until diff typography is tokenized system-wide.                                         |
+| `SourceControlHeaderContent.tsx:119-123` | Dense source-control header typography        | keep with reason | The 11 px prefix and 13 px title preserve the existing editor-header hierarchy and were not introduced by this change.                     | Keep until editor header typography is tokenized system-wide.                                |
+
+## D4 — Accessibility basics
+
+| Line                                   | Element                            | Verdict          | Reason                                                                                                      | Suggested change                                                                                |
+| -------------------------------------- | ---------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `SourceControlHeaderContent.tsx:217`   | Unified / split selector           | keep with reason | Both options have visible translated labels and expose button semantics through `TabPill`.                  | None.                                                                                           |
+| `SessionReplay/index.tsx:269`          | Unified / split selector           | keep with reason | Both options have visible translated labels and expose button semantics through `TabPill`.                  | None.                                                                                           |
+| `GitCommitDetailContent/index.tsx:377` | Icon-only collapsed file-list rail | fix              | It has a tooltip title but no explicit accessible label.                                                    | Add the translated “show file list” string as `aria-label` in a coordinated rail-control sweep. |
+| `PrChangesTab.tsx:214`                 | Icon-only collapsed file-list rail | fix              | It has a tooltip title but no explicit accessible label.                                                    | Add the translated “show file list” string as `aria-label` in the same sweep.                   |
+| `DiffFileSection/index.tsx:418`        | Expandable file header             | keep with reason | The visible filename supplies an accessible name and `aria-expanded` communicates disclosure state.         | None.                                                                                           |
+| `FocusView.tsx:51`                     | No-file Focus empty state          | keep with reason | The translated caption explicitly tells the user to select a changed file and exposes no unrelated actions. | None.                                                                                           |
+
+## D5 — Duplication and abstraction candidates
+
+- **Abstract candidate:** the collapsed 24 px file-list rail appears in commit details, pull-request changes, and `GitFileDiffSplit`. A small shared rail-control component could centralize geometry, tooltip, and accessible naming. This is a multi-file sweep candidate and is intentionally not mixed into the diff-view consistency fix.
+- The new unified / split selectors intentionally reuse `TabPill` and one shared persisted atom; no new visual-pattern duplication was introduced.
+
+## Summary
+
+- **Fix candidates:** 3 (two rail-control accessible labels; one standardizable loading height)
+- **Keep with reason:** 12
+- **Abstract candidates:** 1
+- **Current change verdict:** the new controls follow the design system and introduce no new arbitrary colors, spacing, or inaccessible icon-only actions.

--- a/src/engines/GitWorkflow/GitHubDiff/types.ts
+++ b/src/engines/GitWorkflow/GitHubDiff/types.ts
@@ -3,6 +3,7 @@
  *
  * Type definitions for the diff viewer architecture.
  */
+import type { DiffViewMode } from "@src/types/git/types";
 
 // ============================================
 // Diff Line Types
@@ -98,7 +99,7 @@ export interface FileDiff {
 // ============================================
 
 /** The view mode for the diff */
-export type DiffViewMode = "unified" | "split";
+export type { DiffViewMode } from "@src/types/git/types";
 
 /** Expansion type for hunks */
 export type DiffHunkExpansionType = "up" | "down" | "short" | "full";

--- a/src/features/CodeMirror/Diff/index.tsx
+++ b/src/features/CodeMirror/Diff/index.tsx
@@ -31,6 +31,7 @@ import type { GitFileStatus } from "@src/config/gitStatus";
 import { createLogger } from "@src/hooks/logger";
 import { useEditorAppearanceSettings } from "@src/hooks/settings";
 import { EditorService } from "@src/services/workStation/EditorService";
+import type { DiffViewMode } from "@src/types/git/types";
 
 import { useSelectionExtension } from "../Editor/hooks/useSelectionExtension";
 import type { TextSelectionInfo } from "../Editor/types";
@@ -67,7 +68,7 @@ export interface CodeMirrorDiffProps {
   /** Container height */
   height?: string;
   /** Diff view mode: unified (inline) or split (side-by-side) */
-  viewMode?: "unified" | "split";
+  viewMode?: DiffViewMode;
   /** Read-only mode */
   readOnly?: boolean;
   /** Show merge controls (accept/reject buttons) */

--- a/src/features/CodeViewer/GitDiffViewer.tsx
+++ b/src/features/CodeViewer/GitDiffViewer.tsx
@@ -7,6 +7,7 @@
 import React, { useState } from "react";
 
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
+import type { DiffViewMode } from "@src/types/git/types";
 
 import { ModernSplitDiff } from "./ModernSplitDiff";
 import { VirtualizedModernDiff } from "./VirtualizedModernDiff";
@@ -15,7 +16,7 @@ import { VirtualizedModernDiff } from "./VirtualizedModernDiff";
 // Types
 // ============================================
 
-export type DiffViewMode = "unified" | "split";
+export type { DiffViewMode } from "@src/types/git/types";
 
 export interface GitDiffViewerProps {
   /** Original/old content */

--- a/src/hooks/ui/layout/useElementDimensions.test.ts
+++ b/src/hooks/ui/layout/useElementDimensions.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import React, { act, createElement, useRef } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { useElementDimensions } from "./useElementDimensions";
+
+function DimensionProbe(): React.ReactNode {
+  const elementRef = useRef<HTMLDivElement>(null);
+  const dimensions = useElementDimensions(elementRef);
+
+  // eslint-disable-next-line react-hooks/refs -- createElement is required because Vitest only includes `.test.ts`; this is a normal React ref prop.
+  return createElement("div", {
+    ref: elementRef,
+    "data-testid": "dimension-probe",
+    "data-dimensions": `${dimensions.width}x${dimensions.height}`,
+  });
+}
+
+describe("useElementDimensions", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("keeps the window resize fallback when ResizeObserver is unavailable", () => {
+    vi.stubGlobal("ResizeObserver", undefined);
+    const addWindowListener = vi.spyOn(window, "addEventListener");
+    const removeWindowListener = vi.spyOn(window, "removeEventListener");
+
+    expect(() => {
+      act(() => root.render(createElement(DimensionProbe)));
+    }).not.toThrow();
+
+    expect(addWindowListener).toHaveBeenCalledWith(
+      "resize",
+      expect.any(Function)
+    );
+
+    act(() => root.unmount());
+    root = createRoot(container);
+
+    expect(removeWindowListener).toHaveBeenCalledWith(
+      "resize",
+      expect.any(Function)
+    );
+  });
+
+  it("disconnects the observer when the measured element unmounts", () => {
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    vi.stubGlobal(
+      "ResizeObserver",
+      class ResizeObserverMock {
+        observe = observe;
+        unobserve = vi.fn();
+        disconnect = disconnect;
+      }
+    );
+
+    act(() => root.render(createElement(DimensionProbe)));
+
+    expect(observe).toHaveBeenCalledWith(
+      container.querySelector('[data-testid="dimension-probe"]')
+    );
+
+    act(() => root.unmount());
+    root = createRoot(container);
+
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+});

--- a/src/hooks/ui/layout/useElementDimensions.ts
+++ b/src/hooks/ui/layout/useElementDimensions.ts
@@ -122,7 +122,7 @@ export function useElementDimensions(
 
     // Set up ResizeObserver for accurate tracking
     let resizeObserver: ResizeObserver | null = null;
-    if (element) {
+    if (element && typeof ResizeObserver !== "undefined") {
       resizeObserver = new ResizeObserver(measureDimensions);
       resizeObserver.observe(element);
     }

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.test.ts
@@ -1,0 +1,82 @@
+import type { TFunction } from "i18next";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import type { WorkStationTab } from "@src/store/workstation/tabs";
+
+import { SourceControlHeaderContent } from "./SourceControlHeaderContent";
+
+vi.mock("@src/components/Button", () => ({
+  default: ({ title }: { title?: string }) =>
+    createElement("button", { "data-title": title }),
+}));
+
+vi.mock("@src/components/TabPill", () => ({
+  default: ({
+    activeTab,
+    tabs,
+  }: {
+    activeTab: string;
+    tabs: Array<{ key: string }>;
+  }) =>
+    createElement("div", {
+      "data-active-tab": activeTab,
+      "data-tabs": tabs.map((tab) => tab.key).join(","),
+    }),
+}));
+
+const t = ((key: string) => key) as TFunction;
+
+function sourceControlTab(mode: "focus" | "all-changes"): WorkStationTab {
+  return {
+    id: "source-control:changes",
+    type: "source-control",
+    title: "Review",
+    data: {
+      mode,
+      staged: false,
+      fileCount: 1,
+      focusPath: null,
+      historySelection: null,
+    },
+  } as WorkStationTab;
+}
+
+function renderHeader(mode: "focus" | "all-changes"): string {
+  return renderToStaticMarkup(
+    createElement(SourceControlHeaderContent, {
+      activeTab: sourceControlTab(mode),
+      sourceControlFilterMode: "uncommitted",
+      showSourceControlModePill: true,
+      gitReviewNavigationTotal: 0,
+      selectedIssue: null,
+      sourceControlRefreshSpinClass: undefined,
+      diffViewMode: "split",
+      t,
+      onDiffViewModeChange: vi.fn(),
+      onModeChange: vi.fn(),
+      onOpenHistoryInNewTab: vi.fn(),
+      onReviewPrevFile: vi.fn(),
+      onReviewNextFile: vi.fn(),
+      onCollapseAll: vi.fn(),
+      onRefresh: vi.fn(),
+    })
+  );
+}
+
+describe("SourceControlHeaderContent diff view controls", () => {
+  it("shows the shared unified/split control in All Changes", () => {
+    const markup = renderHeader("all-changes");
+
+    expect(markup).toContain('data-active-tab="split"');
+    expect(markup).toContain('data-tabs="unified,split"');
+  });
+
+  it("keeps the aggregate diff control out of Focus mode", () => {
+    const markup = renderHeader("focus");
+
+    expect(markup).not.toContain('data-tabs="unified,split"');
+    expect(markup).toContain('data-tabs="focus,all-changes"');
+  });
+});

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.tsx
@@ -28,6 +28,7 @@ import type {
   SourceControlHistorySelection,
   WorkStationTab,
 } from "@src/store/workstation/tabs";
+import type { DiffViewMode } from "@src/types/git/types";
 
 export interface SourceControlHeaderContentProps {
   /** The active `source-control` tab (host guarantees the type). */
@@ -40,7 +41,9 @@ export interface SourceControlHeaderContentProps {
   sourceControlHeaderLeadingSlot?: ReactNode;
   sourceControlHeaderTrailingSlot?: ReactNode;
   sourceControlRefreshSpinClass: string | undefined;
+  diffViewMode: DiffViewMode;
   t: TFunction;
+  onDiffViewModeChange: (mode: DiffViewMode) => void;
   onModeChange: (mode: "focus" | "all-changes") => void;
   onOpenHistoryInNewTab: (selection: SourceControlHistorySelection) => void;
   onReviewPrevFile: () => void;
@@ -60,7 +63,9 @@ export const SourceControlHeaderContent: React.FC<
   sourceControlHeaderLeadingSlot,
   sourceControlHeaderTrailingSlot,
   sourceControlRefreshSpinClass,
+  diffViewMode,
   t,
+  onDiffViewModeChange,
   onModeChange,
   onOpenHistoryInNewTab,
   onReviewPrevFile,
@@ -197,16 +202,35 @@ export const SourceControlHeaderContent: React.FC<
         )}
 
         {showCollapseAll && (
-          <Button
-            htmlType="button"
-            variant="tertiary"
-            size="small"
-            iconOnly
-            className="flex-shrink-0"
-            onClick={onCollapseAll}
-            title={t("actions.collapseAll")}
-            icon={<ListChevronsDownUp size={HEADER_ICON_SIZE.md} />}
-          />
+          <>
+            <TabPill
+              activeTab={diffViewMode}
+              tabs={[
+                { key: "unified", label: t("workstation.unified") },
+                { key: "split", label: t("workstation.split") },
+              ]}
+              onChange={(key) => onDiffViewModeChange(key as DiffViewMode)}
+              variant="pill"
+              color="fill"
+              fillWidth={false}
+              size="small"
+            />
+            <span
+              className="mx-1.5 h-4 w-px shrink-0 bg-border-2"
+              role="separator"
+              aria-hidden
+            />
+            <Button
+              htmlType="button"
+              variant="tertiary"
+              size="small"
+              iconOnly
+              className="flex-shrink-0"
+              onClick={onCollapseAll}
+              title={t("actions.collapseAll")}
+              icon={<ListChevronsDownUp size={HEADER_ICON_SIZE.md} />}
+            />
+          </>
         )}
         <Button
           htmlType="button"

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitCommitDetailContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitCommitDetailContent/index.tsx
@@ -23,7 +23,6 @@ import { gitFetchStream } from "@src/api/http/git/streaming";
 import type { GitFileStatus } from "@src/config/gitStatus";
 import { CodeMirrorDiff } from "@src/features/CodeMirror";
 import {
-  type DiffViewMode,
   FileHeader,
   GIT_FILE_LIST_MAX_WIDTH,
   GIT_FILE_LIST_MIN_WIDTH,
@@ -38,6 +37,7 @@ import {
   editorWordWrapAtom,
 } from "@src/store/ui/editorSettingsAtom";
 import { activeStatusBarCallbacksAtom } from "@src/store/ui/workStationAtom";
+import { diffViewModeAtom } from "@src/store/workstation/codeEditor";
 import type { GitFile } from "@src/types/git/types";
 import { decodeOctalPath } from "@src/util/file/pathUtils";
 
@@ -76,7 +76,7 @@ const GitCommitDetailContent: React.FC<GitCommitDetailContentProps> = ({
   const { t } = useTranslation();
 
   const [fileListCollapsed, setFileListCollapsed] = useState(false);
-  const [viewMode, setViewMode] = useState<DiffViewMode>("unified");
+  const [viewMode, setViewMode] = useAtom(diffViewModeAtom);
   const [lineNumbers, setLineNumbers] = useAtom(editorLineNumbersAtom);
   const [wordWrap, setWordWrap] = useAtom(editorWordWrapAtom);
   const [highlightActiveLine, setHighlightActiveLine] = useAtom(

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitDiffContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitDiffContent/index.tsx
@@ -32,11 +32,7 @@ import {
   hasConflictMarkers,
 } from "@src/features/CodeMirror";
 import { createLogger } from "@src/hooks/logger";
-import {
-  type DiffViewMode,
-  FileHeader,
-  FloatingBar,
-} from "@src/modules/WorkStation/shared";
+import { FileHeader, FloatingBar } from "@src/modules/WorkStation/shared";
 import { HUMANTOOLS_TEXT_KEYS } from "@src/modules/WorkStation/shared/textTokens";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
 import { EditorService } from "@src/services/workStation/EditorService";
@@ -48,6 +44,7 @@ import {
   editorLineNumbersAtom,
   editorWordWrapAtom,
 } from "@src/store/ui";
+import { diffViewModeAtom } from "@src/store/workstation/codeEditor";
 import type { GitFile } from "@src/types/git/types";
 import { isBinaryByExtension } from "@src/util/file/binaryDetection";
 import {
@@ -242,7 +239,7 @@ const GitDiffContentInner: React.FC<GitDiffContentProps> = ({
   });
 
   // View mode state for diff display
-  const [viewMode, setViewMode] = useState<DiffViewMode>("unified");
+  const [viewMode, setViewMode] = useAtom(diffViewModeAtom);
 
   // Local state for edited content
   const [editedContent, setEditedContent] = useState<string | null>(null);

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/AllChangesView.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/AllChangesView.tsx
@@ -18,7 +18,10 @@ import React, {
 import { useTranslation } from "react-i18next";
 
 import { DiffSectionList } from "@src/modules/WorkStation/shared";
-import { sourceControlFocusTargetAtom } from "@src/store/workstation/codeEditor";
+import {
+  diffViewModeAtom,
+  sourceControlFocusTargetAtom,
+} from "@src/store/workstation/codeEditor";
 import type { GitFile } from "@src/types/git/types";
 
 import { useAllChangesFiles } from "./allChanges/useAllChangesFiles";
@@ -51,6 +54,7 @@ const AllChangesView: React.FC<AllChangesViewProps> = ({
 }) => {
   const { t } = useTranslation();
   const focusTarget = useAtomValue(sourceControlFocusTargetAtom);
+  const viewMode = useAtomValue(diffViewModeAtom);
 
   const {
     sortedFiles,
@@ -136,6 +140,7 @@ const AllChangesView: React.FC<AllChangesViewProps> = ({
   return (
     <DiffSectionList
       sections={sections}
+      viewMode={viewMode}
       loading={loading}
       emptyTitle={
         staged ? t("placeholders.noStagedChanges") : t("placeholders.noChanges")

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/FocusView.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/FocusView.tsx
@@ -4,11 +4,9 @@
  * Single-file working-tree diff for the unified Source Control tab.
  */
 import React, { Suspense, memo } from "react";
+import { useTranslation } from "react-i18next";
 
-import {
-  NoTabsPlaceholder,
-  type QuickAction,
-} from "@src/modules/WorkStation/shared";
+import { NoTabsPlaceholder } from "@src/modules/WorkStation/shared";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
 import type { GitFile } from "@src/types/git/types";
 
@@ -37,8 +35,6 @@ export interface FocusViewProps {
   onUnsavedChange?: (hasUnsaved: boolean) => void;
   /** Render the file breadcrumb inside the main pane instead of the workstation header. */
   inlineFileHeader?: boolean;
-  /** Source Control navigation shown when no file is focused. */
-  emptyActions: QuickAction[];
 }
 
 const FocusView: React.FC<FocusViewProps> = ({
@@ -51,10 +47,13 @@ const FocusView: React.FC<FocusViewProps> = ({
   onClose,
   onUnsavedChange,
   inlineFileHeader = true,
-  emptyActions,
 }) => {
+  const { t } = useTranslation();
   const emptyPlaceholder = (
-    <NoTabsPlaceholder icon="source-control" actions={emptyActions} />
+    <NoTabsPlaceholder
+      icon="source-control"
+      caption={t("placeholders.selectFileToViewChanges")}
+    />
   );
 
   if (!hasFocus) {

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainContent/index.tsx
@@ -206,7 +206,6 @@ const SourceControlMainContent: React.FC<SourceControlMainContentProps> = ({
           onFileSelect={onFileSelect}
           onClose={onCloseFocus}
           onUnsavedChange={onGitDiffUnsavedChange}
-          emptyActions={emptyFocusActions}
         />
       ) : (
         <AllChangesView

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainPane.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/SourceControlMainPane.tsx
@@ -41,6 +41,7 @@ export interface SourceControlMainPaneProps {
   gitFilesByPath: Map<string, GitFile>;
   sourceControlFiles: GitFile[];
   sourceControlFilterMode: string;
+  activeRepoRoot: string;
   gitDiffLoading: boolean;
   sourceControlCollapseAllSignal?: number;
   sourceControlQuickActions: QuickAction[];
@@ -57,6 +58,7 @@ const SourceControlMainPane: React.FC<SourceControlMainPaneProps> = ({
   gitFilesByPath,
   sourceControlFiles,
   sourceControlFilterMode,
+  activeRepoRoot,
   gitDiffLoading,
   sourceControlCollapseAllSignal,
   sourceControlQuickActions,
@@ -76,13 +78,14 @@ const SourceControlMainPane: React.FC<SourceControlMainPaneProps> = ({
     stateScopeKey: scopeKey,
   });
 
-  const { mode, staged, focusPath, historySelection, allFiles, focusGitFile } =
+  const { mode, staged, historySelection, allFiles, focusGitFile, hasFocus } =
     deriveSourceControlMainProps({
       tabData,
       gitFilesByPath,
       sourceControlFiles,
       sourceControlFilterMode,
       repoPath,
+      activeRepoRoot,
     });
 
   if (sourceControlFilterMode === "issues") {
@@ -127,7 +130,7 @@ const SourceControlMainPane: React.FC<SourceControlMainPaneProps> = ({
         <SourceControlMainContent
           mode={mode}
           focusGitFile={focusGitFile}
-          hasFocus={Boolean(focusPath)}
+          hasFocus={hasFocus}
           onForceReload={onForceReload}
           onFileSelect={onFileSelect}
           onCloseFocus={onCloseFocus}

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/__tests__/FocusView.emptyState.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/__tests__/FocusView.emptyState.test.ts
@@ -1,0 +1,44 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import FocusView from "../SourceControlMainContent/FocusView";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@src/modules/WorkStation/shared", () => ({
+  NoTabsPlaceholder: ({
+    caption,
+    actions,
+  }: {
+    caption?: string;
+    actions?: unknown[];
+  }) =>
+    createElement("div", {
+      "data-caption": caption,
+      "data-action-count": actions?.length ?? 0,
+    }),
+}));
+
+vi.mock("@src/modules/shared/layouts/blocks", () => ({
+  Placeholder: () => null,
+}));
+
+describe("FocusView empty state", () => {
+  it("asks the user to select a file instead of showing unrelated navigation", () => {
+    const markup = renderToStaticMarkup(
+      createElement(FocusView, {
+        gitFile: null,
+        loading: false,
+        hasFocus: false,
+      })
+    );
+
+    expect(markup).toContain(
+      'data-caption="placeholders.selectFileToViewChanges"'
+    );
+    expect(markup).toContain('data-action-count="0"');
+  });
+});

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/__tests__/TEST_CASES.md
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/__tests__/TEST_CASES.md
@@ -13,23 +13,26 @@ its diff view, scroll position, and lazy chunk survive navigation.
 
 ## Happy Path
 
-| #   | Steps                                                                                                                  | Expected Result                                                                                                           |
-| --- | ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| 1   | Open Source Control tab, select a file in Focus mode, scroll the diff. Open a file tab, then return to Source Control. | Same focused diff is shown at the same scroll position; no loading flash (lazy chunk not re-imported).                    |
-| 2   | Open Source Control → All Changes, scroll partway down the list. Switch to a file tab and back.                        | All Changes list is preserved at the same scroll offset.                                                                  |
-| 3   | Never open Source Control during a session.                                                                            | The Source Control main pane chunk is not mounted/parsed (lazy — only mounts after first visit).                          |
-| 4   | Open Source Control Focus mode without selecting a file.                                                               | A Git-branch placeholder offers View Issues, View Git history, and View PRs; each action opens the matching sidebar mode. |
-| 5   | Open an empty History, Issues, or PR detail state.                                                                     | The current destination is omitted; View Source Control appears first, followed by the other destinations.                |
+| #   | Steps                                                                                                                  | Expected Result                                                                                                 |
+| --- | ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| 1   | Open Source Control tab, select a file in Focus mode, scroll the diff. Open a file tab, then return to Source Control. | Same focused diff is shown at the same scroll position; no loading flash (lazy chunk not re-imported).          |
+| 2   | Open Source Control → All Changes, scroll partway down the list. Switch to a file tab and back.                        | All Changes list is preserved at the same scroll offset.                                                        |
+| 3   | Never open Source Control during a session.                                                                            | The Source Control main pane chunk is not mounted/parsed (lazy — only mounts after first visit).                |
+| 4   | Open Source Control Focus mode without selecting a file.                                                               | A Git-branch placeholder asks the user to select a changed file and does not show unrelated navigation actions. |
+| 5   | Open an empty History, Issues, or PR detail state.                                                                     | The current destination is omitted; View Source Control appears first, followed by the other destinations.      |
+| 6   | Select Split in All Changes, then open Focus, a commit, or PR Changes.                                                 | Every text diff uses Split until the user switches back to Unified, including after remount/reload.             |
 
 ## Edge Cases
 
-| #   | Scenario                   | Steps                                                                                                    | Expected Result                                                                                          |
-| --- | -------------------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| 1   | Empty working tree         | Open Source Control with no changes.                                                                     | Empty placeholder shown; switching away/back keeps it stable.                                            |
-| 2   | Filter change while hidden | On Source Control, set filter to Staged. Switch to a file tab; stage a file via another surface; return. | Returning shows the staged-filtered list with the staged file (data stayed populated while hidden).      |
-| 3   | Terminal active            | Open a terminal tab while Source Control was previously visited.                                         | Source Control overlay is hidden (pointer-events none, aria-hidden); terminal renders normally.          |
-| 4   | Rapid tab switching        | Quickly toggle between a file tab and Source Control several times.                                      | No flash/remount; diff + scroll remain stable each return.                                               |
-| 5   | Repo switch                | Switch repos while Source Control is the active tab.                                                     | Pane updates to the new repo's status (focus target cleared by existing `useSourceControlSetup` effect). |
+| #   | Scenario                   | Steps                                                                                                    | Expected Result                                                                                                   |
+| --- | -------------------------- | -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| 1   | Empty working tree         | Open Source Control with no changes.                                                                     | Empty placeholder shown; switching away/back keeps it stable.                                                     |
+| 2   | Filter change while hidden | On Source Control, set filter to Staged. Switch to a file tab; stage a file via another surface; return. | Returning shows the staged-filtered list with the staged file (data stayed populated while hidden).               |
+| 3   | Terminal active            | Open a terminal tab while Source Control was previously visited.                                         | Source Control overlay is hidden (pointer-events none, aria-hidden); terminal renders normally.                   |
+| 4   | Rapid tab switching        | Quickly toggle between a file tab and Source Control several times.                                      | No flash/remount; diff + scroll remain stable each return.                                                        |
+| 5   | Repo switch                | Switch repos while Source Control is the active tab.                                                     | Pane updates to the new repo's status (focus target cleared by existing `useSourceControlSetup` effect).          |
+| 6   | Worktree scope switch      | Focus a host-repo file, then switch the scope picker to a linked worktree.                               | The host file is no longer rendered; All Changes contains only files whose `repoRoot` matches the worktree.       |
+| 7   | Filter invalidates focus   | Focus an unstaged file, then switch the Source Control filter to Staged.                                 | The stale unstaged file is not rendered; Focus shows the select-file placeholder until a staged file is selected. |
 
 ## Error / Degraded States
 
@@ -50,6 +53,8 @@ its diff view, scroll position, and lazy chunk survive navigation.
 - [ ] Users who never open Source Control do not pay the heavy chunk's mount cost.
 - [ ] `TabContentRenderer` no longer double-renders the `source-control` case (it is a no-op; the overlay owns rendering).
 - [ ] Empty Source Control detail states use Source Control navigation rather than editor/workspace actions.
+- [ ] Focus and All Changes never render files outside the active repo/worktree scope or staged/unstaged filter.
+- [ ] All Changes exposes the shared Unified/Split control; the selected mode is reused by Focus, commit, PR, and replay diffs.
 - [ ] No new TypeScript errors; no new lint warnings; `deriveSourceControlMainProps` / `getGitFileForPath` unit tests pass.
 
 ## Notes / Manual QA required

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/__tests__/sourceControlMainProps.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/__tests__/sourceControlMainProps.test.ts
@@ -26,6 +26,7 @@ function createInput(
     sourceControlFiles: [],
     sourceControlFilterMode: "uncommitted",
     repoPath: "/repo",
+    activeRepoRoot: "/repo",
     ...overrides,
   };
 }
@@ -129,6 +130,19 @@ describe("deriveSourceControlMainProps", () => {
     expect(result.allFiles).toEqual([s1, s2]);
   });
 
+  it("isolates All Changes to the active repo or worktree scope", () => {
+    const host = createGitFile({ path: "host.ts", repoRoot: "/repo" });
+    const worktree = createGitFile({ path: "wt.ts", repoRoot: "/wt" });
+    const result = deriveSourceControlMainProps(
+      createInput({
+        sourceControlFiles: [host, worktree],
+        activeRepoRoot: "/wt",
+      })
+    );
+
+    expect(result.allFiles).toEqual([worktree]);
+  });
+
   it("resolves the focus git file for the focus path", () => {
     const file = createGitFile({ path: "src/a.ts" });
     const result = deriveSourceControlMainProps(
@@ -139,5 +153,45 @@ describe("deriveSourceControlMainProps", () => {
     );
     expect(result.hasFocus).toBe(true);
     expect(result.focusGitFile).toBe(file);
+  });
+
+  it("does not render a remembered focus file from another scope", () => {
+    const host = createGitFile({ path: "src/a.ts", repoRoot: "/repo" });
+    const result = deriveSourceControlMainProps(
+      createInput({
+        tabData: { focusPath: "/repo/src/a.ts" },
+        gitFilesByPath: new Map([[host.path, host]]),
+        activeRepoRoot: "/wt",
+      })
+    );
+
+    expect(result.hasFocus).toBe(false);
+    expect(result.focusGitFile).toBeNull();
+  });
+
+  it("does not render a focus file excluded by the active staged filter", () => {
+    const unstaged = createGitFile({ path: "src/a.ts", staged: false });
+    const result = deriveSourceControlMainProps(
+      createInput({
+        tabData: { focusPath: "/repo/src/a.ts" },
+        gitFilesByPath: new Map([[unstaged.path, unstaged]]),
+        sourceControlFilterMode: "staged",
+      })
+    );
+
+    expect(result.hasFocus).toBe(false);
+    expect(result.focusGitFile).toBeNull();
+  });
+
+  it("keeps an in-scope focus path pending while its file is loading", () => {
+    const result = deriveSourceControlMainProps(
+      createInput({
+        tabData: { focusPath: "/wt/src/a.ts" },
+        activeRepoRoot: "/wt",
+      })
+    );
+
+    expect(result.hasFocus).toBe(true);
+    expect(result.focusGitFile).toBeNull();
   });
 });

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/sourceControlMainProps.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/sourceControlMainProps.ts
@@ -61,6 +61,8 @@ export interface DeriveSourceControlMainPropsInput {
   /** "uncommitted" | "staged" | "unstaged" | "history" | ... */
   sourceControlFilterMode: string;
   repoPath: string;
+  /** Repo/worktree root selected by the Source Control scope picker. */
+  activeRepoRoot: string;
 }
 
 export interface SourceControlMainDerivedProps {
@@ -73,6 +75,51 @@ export interface SourceControlMainDerivedProps {
   hasFocus: boolean;
 }
 
+function normalizeRepoPath(path: string): string {
+  return path.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function isPathInRepoScope(
+  filePath: string,
+  repoPath: string,
+  activeRepoRoot: string
+): boolean {
+  const normalizedPath = normalizeRepoPath(filePath);
+  const normalizedRepoPath = normalizeRepoPath(repoPath);
+  const normalizedActiveRoot = normalizeRepoPath(activeRepoRoot);
+  const isAbsolute =
+    normalizedPath.startsWith("/") || /^[A-Za-z]:\//.test(normalizedPath);
+
+  if (!isAbsolute) {
+    return normalizedActiveRoot === normalizedRepoPath;
+  }
+
+  return (
+    normalizedPath === normalizedActiveRoot ||
+    normalizedPath.startsWith(`${normalizedActiveRoot}/`)
+  );
+}
+
+function isFileInRepoScope(
+  file: GitFile,
+  repoPath: string,
+  activeRepoRoot: string
+): boolean {
+  return (
+    normalizeRepoPath(file.repoRoot ?? repoPath) ===
+    normalizeRepoPath(activeRepoRoot)
+  );
+}
+
+function matchesSourceControlFilter(
+  file: GitFile,
+  sourceControlFilterMode: string
+): boolean {
+  if (sourceControlFilterMode === "staged") return file.staged;
+  if (sourceControlFilterMode === "unstaged") return !file.staged;
+  return true;
+}
+
 /**
  * Derive every prop `SourceControlMainContent` needs from a Source Control tab
  * payload plus the current working-tree status / filters. Pure; no React.
@@ -83,6 +130,7 @@ export function deriveSourceControlMainProps({
   sourceControlFiles,
   sourceControlFilterMode,
   repoPath,
+  activeRepoRoot,
 }: DeriveSourceControlMainPropsInput): SourceControlMainDerivedProps {
   const focusPath = tabData.focusPath ?? null;
   const mode: SourceControlPillMode =
@@ -99,15 +147,27 @@ export function deriveSourceControlMainProps({
         ? gitStatusFiles
         : embeddedFiles;
 
-  const allFiles = unfilteredFiles.filter((file) => {
-    if (sourceControlFilterMode === "staged" && !file.staged) return false;
-    if (sourceControlFilterMode === "unstaged" && file.staged) return false;
-    return true;
-  });
+  const allFiles = unfilteredFiles.filter(
+    (file) =>
+      isFileInRepoScope(file, repoPath, activeRepoRoot) &&
+      matchesSourceControlFilter(file, sourceControlFilterMode)
+  );
 
-  const focusGitFile = focusPath
+  const resolvedFocusFile = focusPath
     ? (getGitFileForPath(focusPath, repoPath, gitFilesByPath) ?? null)
     : null;
+  const focusPathInActiveScope = focusPath
+    ? isPathInRepoScope(focusPath, repoPath, activeRepoRoot)
+    : false;
+  const focusGitFile =
+    resolvedFocusFile &&
+    isFileInRepoScope(resolvedFocusFile, repoPath, activeRepoRoot) &&
+    matchesSourceControlFilter(resolvedFocusFile, sourceControlFilterMode)
+      ? resolvedFocusFile
+      : null;
+  const hasFocus = Boolean(
+    focusPath && focusPathInActiveScope && (!resolvedFocusFile || focusGitFile)
+  );
 
   return {
     mode,
@@ -116,6 +176,6 @@ export function deriveSourceControlMainProps({
     historySelection,
     allFiles,
     focusGitFile,
-    hasFocus: Boolean(focusPath),
+    hasFocus,
   };
 }

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/hooks/useSourceControlPaneActions.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/hooks/useSourceControlPaneActions.ts
@@ -30,6 +30,10 @@ import {
 } from "@src/store/workstation/tabs";
 
 import {
+  type SourceControlMainMode,
+  setSourceControlMainMode,
+} from "../../../sourceControlStateTransitions";
+import {
   type SourceControlDestination,
   createSourceControlQuickActions,
 } from "../config";
@@ -51,7 +55,7 @@ export interface UseSourceControlPaneActionsReturn {
   handleSourceControlRefresh: () => void;
   /** Monotonic counter — bumping it tells All Changes to collapse every group */
   sourceControlCollapseAllSignal: number;
-  handleSourceControlModeChange: (mode: "focus" | "all-changes") => void;
+  handleSourceControlModeChange: (mode: SourceControlMainMode) => void;
   handleSourceControlCollapseAll: () => void;
   handleSourceControlCloseFocus: () => void;
   /** Current review-sequence snapshot (`{ current, total }`) */
@@ -94,28 +98,8 @@ export function useSourceControlPaneActions({
     useState(0);
 
   const handleSourceControlModeChange = useCallback(
-    (mode: "focus" | "all-changes") => {
-      updatePaneState((state) => {
-        const tabIndex = state.tabs.findIndex(
-          (item) => item.type === "source-control"
-        );
-        if (tabIndex === -1) return state;
-        const existing = state.tabs[tabIndex];
-        if (existing.data.mode === mode && !existing.data.historySelection) {
-          return state;
-        }
-        const nextTabs = [...state.tabs];
-        nextTabs[tabIndex] = {
-          ...existing,
-          data: {
-            ...existing.data,
-            mode,
-            historySelection: null,
-          },
-        };
-        return { ...state, tabs: nextTabs };
-      });
-    },
+    (mode: SourceControlMainMode) =>
+      updatePaneState((state) => setSourceControlMainMode(state, mode)),
     [updatePaneState]
   );
 

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/index.tsx
@@ -20,7 +20,7 @@
  * - types.ts     - TypeScript types
  * - config.ts    - Constants and configuration
  */
-import { useAtomValue } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import React, {
   Suspense,
   memo,
@@ -42,6 +42,7 @@ import UnifiedTabContent from "@src/modules/WorkStation/TabContent/UnifiedTabCon
 import { NoTabsPlaceholder } from "@src/modules/WorkStation/shared";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
 import { workStationPrimarySidebarCollapsedAtom } from "@src/store/ui/workStationAtom";
+import { diffViewModeAtom } from "@src/store/workstation/codeEditor";
 import { workstationSelectedIssueAtomFamily } from "@src/store/workstation/codeEditor/workstationIssueAtom";
 import { workstationRepoScopeKey } from "@src/store/workstation/codeEditor/workstationPrAtom";
 import type { GitFile } from "@src/types/git/types";
@@ -103,6 +104,7 @@ const EditorContent: React.FC<EditorContentProps> = memo(
     sourceControlHeaderLeadingSlot,
     sourceControlHeaderTrailingSlot,
     sourceControlFilterMode = "uncommitted",
+    sourceControlActiveRepoRoot = repoPath,
     showSourceControlModePill = true,
   }) => {
     // ============================================
@@ -116,6 +118,7 @@ const EditorContent: React.FC<EditorContentProps> = memo(
     const selectedIssueState = useAtomValue(
       workstationSelectedIssueAtomFamily(scopeKey)
     );
+    const [diffViewMode, setDiffViewMode] = useAtom(diffViewModeAtom);
 
     // ============================================
     // Pane State Management (extracted hook)
@@ -281,7 +284,9 @@ const EditorContent: React.FC<EditorContentProps> = memo(
           sourceControlHeaderLeadingSlot={sourceControlHeaderLeadingSlot}
           sourceControlHeaderTrailingSlot={sourceControlHeaderTrailingSlot}
           sourceControlRefreshSpinClass={sourceControlRefreshSpinClass}
+          diffViewMode={diffViewMode}
           t={t}
+          onDiffViewModeChange={setDiffViewMode}
           onModeChange={handleSourceControlModeChange}
           onOpenHistoryInNewTab={handleOpenSourceControlHistoryInNewTab}
           onReviewPrevFile={handleReviewPrevFile}
@@ -292,6 +297,7 @@ const EditorContent: React.FC<EditorContentProps> = memo(
       );
     }, [
       activeTab,
+      diffViewMode,
       gitReviewNavigation.total,
       handleOpenSourceControlHistoryInNewTab,
       handleReviewNextFile,
@@ -305,6 +311,7 @@ const EditorContent: React.FC<EditorContentProps> = memo(
       sourceControlHeaderLeadingSlot,
       sourceControlHeaderTrailingSlot,
       sourceControlRefreshSpinClass,
+      setDiffViewMode,
       t,
     ]);
 
@@ -464,6 +471,7 @@ const EditorContent: React.FC<EditorContentProps> = memo(
                     gitFilesByPath={gitFilesByPath}
                     sourceControlFiles={sourceControlBaseFiles}
                     sourceControlFilterMode={sourceControlFilterMode}
+                    activeRepoRoot={sourceControlActiveRepoRoot}
                     gitDiffLoading={gitDiffLoading}
                     sourceControlCollapseAllSignal={
                       sourceControlCollapseAllSignal

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/types.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/types.ts
@@ -78,6 +78,8 @@ export interface EditorContentProps {
   sourceControlHeaderLeadingSlot?: ReactNode;
   sourceControlHeaderTrailingSlot?: ReactNode;
   sourceControlFilterMode?: SourceControlFilterMode;
+  /** Repo/worktree root selected by the Source Control scope picker. */
+  sourceControlActiveRepoRoot?: string;
   showSourceControlModePill?: boolean;
 }
 

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrChangesTab.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrChangesTab.tsx
@@ -17,7 +17,6 @@ import type { GitHubReviewComment, PrFile } from "@src/api/tauri/github";
 import type { GitFileStatus } from "@src/config/gitStatus";
 import { CodeMirrorDiff } from "@src/features/CodeMirror";
 import {
-  type DiffViewMode,
   FileHeader,
   GIT_FILE_LIST_MAX_WIDTH,
   GIT_FILE_LIST_MIN_WIDTH,
@@ -32,6 +31,7 @@ import {
   editorWordWrapAtom,
 } from "@src/store/ui/editorSettingsAtom";
 import { activeStatusBarCallbacksAtom } from "@src/store/ui/workStationAtom";
+import { diffViewModeAtom } from "@src/store/workstation/codeEditor";
 import type { GitFile } from "@src/types/git/types";
 
 import { PrReviewThreadsPanel } from "./PrReviewThreadsPanel";
@@ -92,7 +92,7 @@ export const PrChangesTab: React.FC<PrChangesTabProps> = ({
   const { t } = useTranslation("common");
 
   const [fileListCollapsed, setFileListCollapsed] = useState(false);
-  const [viewMode, setViewMode] = useState<DiffViewMode>("unified");
+  const [viewMode, setViewMode] = useAtom(diffViewModeAtom);
   const [lineNumbers, setLineNumbers] = useAtom(editorLineNumbersAtom);
   const [wordWrap, setWordWrap] = useAtom(editorWordWrapAtom);
   const [highlightActiveLine, setHighlightActiveLine] = useAtom(

--- a/src/modules/WorkStation/CodeEditor/__tests__/TEST_CASES.md
+++ b/src/modules/WorkStation/CodeEditor/__tests__/TEST_CASES.md
@@ -12,9 +12,10 @@ resolver it now delegates to (`resolveGitDiffSelection`).
 
 | #   | Steps                                                                   | Expected Result                                                                                                                                                                  |
 | --- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | In Source Control "all changes" view, click a changed file              | Diff opens in focus target; `resolveGitDiffSelection` returns `isAllChangesView: true`, correct absolute + relative paths                                                        |
-| 2   | In Source Control focus/non-all-changes view, click a file              | Falls through to `handleGitFileSelect` (unified focus tab)                                                                                                                       |
-| 3   | Navigate between editor tabs repeatedly while Source Control stays warm | The warm Source Control tree does NOT re-render; `SidebarSlot` context identity stays stable because `handleDiffSidebarFileSelect` identity is stable across `activeTab` changes |
+| 1   | In Source Control "all changes" view, click a changed file              | Matching section opens and scrolls into view; the absolute path is remembered without leaving All Changes                                                                        |
+| 2   | Switch from All Changes to Focus after step 1                           | The remembered file opens as a single-file diff and exposes the unified / split toggle                                                                                           |
+| 3   | In Source Control focus/non-all-changes view, click a file              | Falls through to `handleGitFileSelect` and replaces the focused file                                                                                                             |
+| 4   | Navigate between editor tabs repeatedly while Source Control stays warm | The warm Source Control tree does NOT re-render; `SidebarSlot` context identity stays stable because `handleDiffSidebarFileSelect` identity is stable across `activeTab` changes |
 
 ## Edge Cases
 
@@ -24,6 +25,8 @@ resolver it now delegates to (`resolveGitDiffSelection`).
 | 2   | Already-absolute path     | File path begins with `/` and host repo prefix           | `absolutePath` unchanged, `relativePath` stripped of repo prefix                               |
 | 3   | Null/undefined active tab | Resolve with no active tab                               | `isAllChangesView` is `false` (routes to focus select)                                         |
 | 4   | Rapid navigation          | Switch tabs many times quickly                           | Callback identity unchanged each render (refs hold latest `activeTab` / `handleGitFileSelect`) |
+| 5   | Rapid file selection      | Click multiple All Changes files, then switch to Focus   | The most recently clicked file opens                                                           |
+| 6   | No previous selection     | Enter Focus before clicking any changed file             | Shows “Select a file to view changes”; no Issues / history / PR shortcuts                      |
 
 ## Error / Degraded States
 
@@ -41,6 +44,8 @@ resolver it now delegates to (`resolveGitDiffSelection`).
 - [x] `handleDiffSidebarFileSelect` no longer lists `activeTab` in its `useCallback` deps; reads it via `activeTabRef`.
 - [x] `handleGitFileSelect` (unstable — closes over per-render `gitDiffState`) read via `handleGitFileSelectRef`.
 - [x] `gitDiffState.setFile` destructured (stable) instead of depending on the whole `gitDiffState` object.
+- [x] All Changes selection persists `focusPath` without switching modes; Focus reuses it.
+- [x] The no-selection Focus render gate has a regression test for its explicit empty state.
 - [x] No new TypeScript / lint errors in touched files.
 
 ## Notes

--- a/src/modules/WorkStation/CodeEditor/__tests__/sourceControlStateTransitions.test.ts
+++ b/src/modules/WorkStation/CodeEditor/__tests__/sourceControlStateTransitions.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import type { PanelState, WorkStationTab } from "@src/store/workstation/tabs";
+import type { GitFile } from "@src/types/git/types";
+
+import { deriveSourceControlMainProps } from "../Panels/EditorMainPane/content/sourceControlMainProps";
+import {
+  rememberSourceControlFocusPath,
+  setSourceControlMainMode,
+} from "../sourceControlStateTransitions";
+
+function sourceControlTab(data: Record<string, unknown> = {}): WorkStationTab {
+  return {
+    id: "source-control",
+    type: "source-control",
+    title: "Source Control",
+    data,
+  } as WorkStationTab;
+}
+
+function fileTab(): WorkStationTab {
+  return {
+    id: "file:/repo/README.md",
+    type: "file",
+    title: "README.md",
+    data: { path: "/repo/README.md" },
+  } as WorkStationTab;
+}
+
+function panel(data: Record<string, unknown> = {}): PanelState {
+  return {
+    tabs: [fileTab(), sourceControlTab(data)],
+    activeTabId: "source-control",
+  };
+}
+
+function changedFile(path = "src/a.ts"): GitFile {
+  return {
+    id: `${path}-0`,
+    path,
+    status: "modified",
+    staged: false,
+    additions: 1,
+    deletions: 0,
+    original_path: null,
+  };
+}
+
+describe("Source Control Focus hand-off", () => {
+  it("opens the last file inspected in All Changes when Focus is selected", () => {
+    const file = changedFile();
+    const allChangesState = panel({ mode: "all-changes", focusPath: null });
+
+    const remembered = rememberSourceControlFocusPath(
+      allChangesState,
+      "/repo/src/a.ts"
+    );
+    const rememberedTab = remembered.tabs.find(
+      (tab) => tab.type === "source-control"
+    );
+    expect(rememberedTab?.data).toMatchObject({
+      mode: "all-changes",
+      focusPath: "/repo/src/a.ts",
+    });
+
+    const focused = setSourceControlMainMode(remembered, "focus");
+    const focusedTab = focused.tabs.find(
+      (tab) => tab.type === "source-control"
+    );
+    const view = deriveSourceControlMainProps({
+      tabData: focusedTab?.data ?? {},
+      gitFilesByPath: new Map([[file.path, file]]),
+      sourceControlFiles: [file],
+      sourceControlFilterMode: "uncommitted",
+      repoPath: "/repo",
+      activeRepoRoot: "/repo",
+    });
+
+    expect(view.mode).toBe("focus");
+    expect(view.hasFocus).toBe(true);
+    expect(view.focusGitFile).toBe(file);
+  });
+
+  it("uses the latest file after repeated All Changes selections", () => {
+    const first = rememberSourceControlFocusPath(
+      panel({ mode: "all-changes" }),
+      "/repo/src/a.ts"
+    );
+    const latest = rememberSourceControlFocusPath(first, "/repo/src/b.ts");
+    const sourceControl = latest.tabs.find(
+      (tab) => tab.type === "source-control"
+    );
+
+    expect(sourceControl?.data.focusPath).toBe("/repo/src/b.ts");
+    expect(sourceControl?.data.mode).toBe("all-changes");
+  });
+
+  it("retains the remembered file across mode switches and clears history detail", () => {
+    const initial = panel({
+      mode: "all-changes",
+      focusPath: "/repo/src/a.ts",
+      historySelection: { type: "commit", commitSha: "abc" },
+    });
+
+    const focused = setSourceControlMainMode(initial, "focus");
+    const allChanges = setSourceControlMainMode(focused, "all-changes");
+    const sourceControl = allChanges.tabs.find(
+      (tab) => tab.type === "source-control"
+    );
+
+    expect(sourceControl?.data).toMatchObject({
+      mode: "all-changes",
+      focusPath: "/repo/src/a.ts",
+      historySelection: null,
+    });
+  });
+
+  it("does not alter unrelated tabs or panels without Source Control", () => {
+    const initial = panel({ mode: "all-changes" });
+    const unrelatedTab = initial.tabs[0];
+    const updated = rememberSourceControlFocusPath(initial, "/repo/src/a.ts");
+    expect(updated.tabs[0]).toBe(unrelatedTab);
+    expect(updated.activeTabId).toBe(initial.activeTabId);
+
+    const withoutSourceControl: PanelState = {
+      tabs: [fileTab()],
+      activeTabId: "file:/repo/README.md",
+    };
+    expect(
+      rememberSourceControlFocusPath(withoutSourceControl, "/repo/src/a.ts")
+    ).toBe(withoutSourceControl);
+    expect(setSourceControlMainMode(withoutSourceControl, "focus")).toBe(
+      withoutSourceControl
+    );
+  });
+});

--- a/src/modules/WorkStation/CodeEditor/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/index.tsx
@@ -205,6 +205,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = memo(
     const {
       sourceControlFilterMode,
       sourceControlFilterCounts,
+      sourceControlActiveRepoRoot,
       sourceControlHeaderFilter,
       sourceControlHeaderScopePicker,
       tabSidebarExtraContext,
@@ -449,6 +450,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = memo(
             sourceControlHeaderLeadingSlot={editorSourceControlScopePicker}
             sourceControlHeaderTrailingSlot={editorSourceControlHeaderSlot}
             sourceControlFilterMode={editorSourceControlFilterMode}
+            sourceControlActiveRepoRoot={sourceControlActiveRepoRoot}
             showSourceControlModePill={editorShowSourceControlModePill}
           />
         </div>
@@ -479,6 +481,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = memo(
         editorSourceControlScopePicker,
         editorSourceControlHeaderSlot,
         editorSourceControlFilterMode,
+        sourceControlActiveRepoRoot,
         editorShowSourceControlModePill,
       ]
     );

--- a/src/modules/WorkStation/CodeEditor/sourceControlStateTransitions.ts
+++ b/src/modules/WorkStation/CodeEditor/sourceControlStateTransitions.ts
@@ -1,0 +1,63 @@
+import type { PanelState } from "@src/store/workstation/tabs";
+
+export type SourceControlMainMode = "focus" | "all-changes";
+
+/**
+ * Remember the last changed file the user inspected without leaving the current
+ * Source Control mode. All Changes uses this as the hand-off target when the
+ * user later switches to Focus.
+ */
+export function rememberSourceControlFocusPath(
+  state: PanelState,
+  focusPath: string
+): PanelState {
+  const tabIndex = state.tabs.findIndex(
+    (item) => item.type === "source-control"
+  );
+  if (tabIndex === -1) return state;
+
+  const existing = state.tabs[tabIndex];
+  if (existing.data.focusPath === focusPath) return state;
+
+  const nextTabs = [...state.tabs];
+  nextTabs[tabIndex] = {
+    ...existing,
+    data: {
+      ...existing.data,
+      focusPath,
+    },
+  };
+
+  return { ...state, tabs: nextTabs };
+}
+
+/**
+ * Switch the Source Control main surface while retaining its remembered file.
+ * History detail is mutually exclusive with the Focus / All Changes surfaces.
+ */
+export function setSourceControlMainMode(
+  state: PanelState,
+  mode: SourceControlMainMode
+): PanelState {
+  const tabIndex = state.tabs.findIndex(
+    (item) => item.type === "source-control"
+  );
+  if (tabIndex === -1) return state;
+
+  const existing = state.tabs[tabIndex];
+  if (existing.data.mode === mode && !existing.data.historySelection) {
+    return state;
+  }
+
+  const nextTabs = [...state.tabs];
+  nextTabs[tabIndex] = {
+    ...existing,
+    data: {
+      ...existing.data,
+      mode,
+      historySelection: null,
+    },
+  };
+
+  return { ...state, tabs: nextTabs };
+}

--- a/src/modules/WorkStation/CodeEditor/useSourceControlSetup.ts
+++ b/src/modules/WorkStation/CodeEditor/useSourceControlSetup.ts
@@ -38,6 +38,7 @@ import {
   resolveScopeRepoRoot,
 } from "./Panels/EditorPrimarySidebar/tabs/sourceControlScopePickerHelpers";
 import { resolveGitDiffSelection } from "./sourceControlSelection";
+import { rememberSourceControlFocusPath } from "./sourceControlStateTransitions";
 import { useStashCount } from "./useStashCount";
 
 interface UseSourceControlSetupParams {
@@ -53,6 +54,8 @@ interface UseSourceControlSetupParams {
 export interface UseSourceControlSetupReturn {
   sourceControlFilterMode: SourceControlFilterMode;
   sourceControlFilterCounts: SourceControlFilterCounts;
+  /** Repo/worktree root currently selected by the Source Control scope picker. */
+  sourceControlActiveRepoRoot: string;
   sourceControlHeaderFilter: React.ReactNode;
   sourceControlHeaderScopePicker: React.ReactNode;
   tabSidebarExtraContext: {
@@ -106,6 +109,10 @@ export function useSourceControlSetup({
     enabled: isGitInitialized === true && hasWorktrees,
     worktreesReady: !worktreesLoading,
   });
+  const sourceControlActiveRepoRoot = useMemo(
+    () => resolveScopeRepoRoot(scope, repoPath),
+    [repoPath, scope]
+  );
 
   const repoName = useMemo(() => {
     const segments = repoPath.replace(/\/+$/, "").split("/");
@@ -150,9 +157,8 @@ export function useSourceControlSetup({
     if (!repoPath) {
       return { uncommitted: 0, unstaged: 0, staged: 0 };
     }
-    const activeRepoRoot = resolveScopeRepoRoot(scope, repoPath);
     const files = Array.from(gitFilesByPath.values()).filter(
-      (file) => (file.repoRoot ?? repoPath) === activeRepoRoot
+      (file) => (file.repoRoot ?? repoPath) === sourceControlActiveRepoRoot
     );
     const staged = files.filter((file) => file.staged).length;
     return {
@@ -160,7 +166,7 @@ export function useSourceControlSetup({
       unstaged: files.length - staged,
       staged,
     };
-  }, [gitFilesByPath, repoPath, scope]);
+  }, [gitFilesByPath, repoPath, sourceControlActiveRepoRoot]);
 
   const sourceControlStashCount = useStashCount({
     repoPath,
@@ -383,17 +389,22 @@ export function useSourceControlSetup({
         path: relativePath,
         repoRoot: effectiveRepoPath,
       });
+      setPrimaryPanel((state) =>
+        rememberSourceControlFocusPath(state, absolutePath)
+      );
       setSourceControlFocusTarget({ path: absolutePath, nonce: Date.now() });
 
       // AllChangesView loads content only after its target section expands.
-      // This handler deliberately remains metadata-only.
+      // Keep the click metadata-only while remembering the same path for a
+      // later hand-off to Focus mode.
     },
-    [repoPath, setGitDiffFile, setSourceControlFocusTarget]
+    [repoPath, setGitDiffFile, setPrimaryPanel, setSourceControlFocusTarget]
   );
 
   return {
     sourceControlFilterMode,
     sourceControlFilterCounts,
+    sourceControlActiveRepoRoot,
     sourceControlHeaderFilter,
     sourceControlHeaderScopePicker,
     tabSidebarExtraContext,

--- a/src/modules/WorkStation/Diff/SessionReplay/diffSessionReplay.useDetailContent.tsx
+++ b/src/modules/WorkStation/Diff/SessionReplay/diffSessionReplay.useDetailContent.tsx
@@ -16,6 +16,7 @@ import {
 } from "@src/modules/WorkStation/shared";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
 import type { SourceControlHistorySelection } from "@src/store/workstation/tabs";
+import type { DiffViewMode } from "@src/types/git/types";
 
 import type { DiffReplayTab } from "./types";
 import type { SubmissionRepoContext } from "./useSubmissionsData";
@@ -36,6 +37,7 @@ export interface UseDiffDetailContentParams {
   focusedDiffPath: string | null;
   focusedDiffNonce: number;
   collapseAllSignal: number;
+  diffViewMode: DiffViewMode;
 }
 
 export function useDiffDetailContent({
@@ -49,6 +51,7 @@ export function useDiffDetailContent({
   focusedDiffPath,
   focusedDiffNonce,
   collapseAllSignal,
+  diffViewMode,
 }: UseDiffDetailContentParams): React.ReactNode {
   const { t } = useTranslation("sessions");
   const { t: tCommon } = useTranslation("common");
@@ -122,6 +125,7 @@ export function useDiffDetailContent({
     return (
       <DiffSectionList
         sections={consolidatedSections}
+        viewMode={diffViewMode}
         loading={orgtrackFinalDiffsLoading}
         emptyTitle={t(
           "simulator.replay.diffApp.emptyForFilter",
@@ -146,6 +150,7 @@ export function useDiffDetailContent({
     focusedDiffPath,
     focusedDiffNonce,
     collapseAllSignal,
+    diffViewMode,
     t,
   ]);
 }

--- a/src/modules/WorkStation/Diff/SessionReplay/index.tsx
+++ b/src/modules/WorkStation/Diff/SessionReplay/index.tsx
@@ -19,6 +19,7 @@ import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
+import TabPill from "@src/components/TabPill";
 import { SIMULATOR_PRIMARY_SIDEBAR } from "@src/config/simulatorPrimarySidebar";
 import { simulatorEventsAtom } from "@src/engines/SessionCore/derived/simulatorEvents";
 import type { SimulatorAppProps } from "@src/engines/Simulator/apps/core/types";
@@ -47,7 +48,9 @@ import {
   simulatorPrimarySidebarWidthAtom,
   simulatorPrimarySidebarWidthPersistAtom,
 } from "@src/store/ui/simulatorAtom";
+import { diffViewModeAtom } from "@src/store/workstation/codeEditor";
 import type { SourceControlHistorySelection } from "@src/store/workstation/tabs";
+import type { DiffViewMode } from "@src/types/git/types";
 import { confirmDestructiveAction } from "@src/util/dialogs/confirmDestructiveAction";
 
 import { isDiffScopeActive, resolveScopedSelectedPath } from "./diffScope";
@@ -82,6 +85,7 @@ const SessionReplayDiff: React.FC<SimulatorAppProps> = ({
   const [focusedDiffPath, setFocusedDiffPath] = useState<string | null>(null);
   const [focusedDiffNonce, setFocusedDiffNonce] = useState(0);
   const [collapseAllSignal, setCollapseAllSignal] = useState(0);
+  const [diffViewMode, setDiffViewMode] = useAtom(diffViewModeAtom);
   const simulatorEvents = useAtomValue(simulatorEventsAtom);
   const sessionId = useMemo(
     () =>
@@ -210,6 +214,23 @@ const SessionReplayDiff: React.FC<SimulatorAppProps> = ({
       trailing:
         activeTab === "diff" ? (
           <div className="flex items-center gap-px">
+            <TabPill
+              activeTab={diffViewMode}
+              tabs={[
+                { key: "unified", label: tCommon("workstation.unified") },
+                { key: "split", label: tCommon("workstation.split") },
+              ]}
+              onChange={(key) => setDiffViewMode(key as DiffViewMode)}
+              variant="pill"
+              color="fill"
+              fillWidth={false}
+              size="small"
+            />
+            <div
+              className="mx-1.5 h-4 w-px shrink-0 bg-border-2"
+              role="separator"
+              aria-hidden
+            />
             {canUndoAll ? (
               <Button
                 htmlType="button"
@@ -236,7 +257,15 @@ const SessionReplayDiff: React.FC<SimulatorAppProps> = ({
           </div>
         ) : undefined,
     }),
-    [activeTab, handleUndoAll, canUndoAll, handleCollapseAll, tCommon]
+    [
+      activeTab,
+      canUndoAll,
+      diffViewMode,
+      handleCollapseAll,
+      handleUndoAll,
+      setDiffViewMode,
+      tCommon,
+    ]
   );
 
   const hasSubmissions =
@@ -367,6 +396,7 @@ const SessionReplayDiff: React.FC<SimulatorAppProps> = ({
     focusedDiffPath,
     focusedDiffNonce,
     collapseAllSignal,
+    diffViewMode,
   });
 
   // A commit-detail selection (or a pending navigation request from a chat

--- a/src/modules/WorkStation/shared/DiffFileSection/index.tsx
+++ b/src/modules/WorkStation/shared/DiffFileSection/index.tsx
@@ -26,6 +26,7 @@ import {
   useTextSelectionDropdown,
 } from "@src/scaffold/ContextMenu/exports";
 import { addToAgentAtom } from "@src/store/ui/addToAgentAtom";
+import type { DiffViewMode } from "@src/types/git/types";
 import { isBinaryByExtension } from "@src/util/file/binaryDetection";
 import {
   getPreviewType,
@@ -84,6 +85,7 @@ export interface DiffFileSectionData {
 
 export interface DiffFileSectionProps {
   file: DiffFileSectionData;
+  viewMode: DiffViewMode;
   defaultExpanded?: boolean;
   expansionSignal?: number;
   repoPath?: string;
@@ -128,6 +130,7 @@ function getFileNameAndDir(path: string): {
 
 const DiffFileSection: React.FC<DiffFileSectionProps> = ({
   file,
+  viewMode,
   defaultExpanded = true,
   expansionSignal = 0,
   repoPath,
@@ -352,7 +355,7 @@ const DiffFileSection: React.FC<DiffFileSectionProps> = ({
             oldStartLine={resolvedDiff.oldStartLine}
             newStartLine={resolvedDiff.newStartLine}
             showLineNumbers={file.showLineNumbers !== false}
-            viewMode="unified"
+            viewMode={viewMode}
             readOnly={true}
             mergeControls={false}
             collapseUnchanged={true}

--- a/src/modules/WorkStation/shared/DiffSectionList/index.tsx
+++ b/src/modules/WorkStation/shared/DiffSectionList/index.tsx
@@ -2,6 +2,7 @@ import React, { memo, useCallback, useEffect, useMemo, useRef } from "react";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
+import type { DiffViewMode } from "@src/types/git/types";
 
 import DiffFileSection from "../DiffFileSection";
 import type { DiffFileSectionData } from "../DiffFileSection";
@@ -14,6 +15,7 @@ export interface DiffSectionListItem<TFile extends DiffFileSectionData> {
 
 export interface DiffSectionListProps<TFile extends DiffFileSectionData> {
   sections: Array<DiffSectionListItem<TFile>>;
+  viewMode: DiffViewMode;
   loading?: boolean;
   emptyTitle: string;
   emptySubtitle?: string;
@@ -53,6 +55,7 @@ const DIFF_LIST_COMPONENTS = { Footer: DiffListFooter };
 
 function DiffSectionListInner<TFile extends DiffFileSectionData>({
   sections,
+  viewMode,
   loading = false,
   emptyTitle,
   emptySubtitle,
@@ -197,6 +200,7 @@ function DiffSectionListInner<TFile extends DiffFileSectionData>({
             return (
               <DiffFileSection
                 file={section.file}
+                viewMode={viewMode}
                 defaultExpanded={
                   expandedOverride ??
                   getDefaultDiffSectionExpanded({

--- a/src/modules/shared/components/FileHeader/index.tsx
+++ b/src/modules/shared/components/FileHeader/index.tsx
@@ -28,6 +28,7 @@ import { HEADER_ICON_SIZE } from "@src/config/workstation/tokens";
 import { useRefreshSpin } from "@src/hooks/ui";
 import { type WorkstationTabHeaderHost } from "@src/hooks/workStation";
 import { PANEL_HEADER_TOKENS } from "@src/modules/shared/layouts/blocks/PanelHeader";
+import type { DiffViewMode } from "@src/types/git/types";
 import { copyText } from "@src/util/data/clipboard";
 
 import BreadcrumbFileHeader from "./BreadcrumbFileHeader";
@@ -36,7 +37,7 @@ import { FileHeaderShell } from "./FileHeaderShell";
 
 const RELOAD_MENU_COOLDOWN_MS = 1200;
 
-export type DiffViewMode = "unified" | "split";
+export type { DiffViewMode } from "@src/types/git/types";
 
 export interface ToggleOption {
   value: string;

--- a/src/store/workstation/codeEditor/diffViewModeAtom.test.ts
+++ b/src/store/workstation/codeEditor/diffViewModeAtom.test.ts
@@ -1,0 +1,42 @@
+import { createStore } from "jotai";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_DIFF_VIEW_MODE,
+  DIFF_VIEW_MODE_STORAGE_KEY,
+  diffViewModeAtom,
+  normalizeDiffViewMode,
+} from "./diffViewModeAtom";
+
+beforeEach(() => {
+  localStorage.removeItem(DIFF_VIEW_MODE_STORAGE_KEY);
+});
+
+describe("normalizeDiffViewMode", () => {
+  it("preserves supported persisted values", () => {
+    expect(normalizeDiffViewMode("unified")).toBe("unified");
+    expect(normalizeDiffViewMode("split")).toBe("split");
+  });
+
+  it("falls back safely when persisted data is stale or malformed", () => {
+    expect(normalizeDiffViewMode("side-by-side")).toBe(DEFAULT_DIFF_VIEW_MODE);
+    expect(normalizeDiffViewMode(null)).toBe(DEFAULT_DIFF_VIEW_MODE);
+  });
+
+  it("persists the latest user choice for a fresh store after reload", () => {
+    const writerStore = createStore();
+    const unsubscribeWriter = writerStore.sub(diffViewModeAtom, () => {});
+
+    writerStore.set(diffViewModeAtom, "split");
+
+    expect(localStorage.getItem(DIFF_VIEW_MODE_STORAGE_KEY)).toBe('"split"');
+    unsubscribeWriter();
+
+    const readerStore = createStore();
+    const unsubscribeReader = readerStore.sub(diffViewModeAtom, () => {});
+
+    expect(readerStore.get(diffViewModeAtom)).toBe("split");
+
+    unsubscribeReader();
+  });
+});

--- a/src/store/workstation/codeEditor/diffViewModeAtom.ts
+++ b/src/store/workstation/codeEditor/diffViewModeAtom.ts
@@ -1,0 +1,28 @@
+import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+
+import type { DiffViewMode } from "@src/types/git/types";
+
+export const DIFF_VIEW_MODE_STORAGE_KEY = "orgii:gitDiffViewMode";
+export const DEFAULT_DIFF_VIEW_MODE: DiffViewMode = "unified";
+
+export function normalizeDiffViewMode(value: unknown): DiffViewMode {
+  return value === "split" ? "split" : DEFAULT_DIFF_VIEW_MODE;
+}
+
+const persistedDiffViewModeAtom = atomWithStorage<unknown>(
+  DIFF_VIEW_MODE_STORAGE_KEY,
+  DEFAULT_DIFF_VIEW_MODE
+);
+
+/**
+ * Authoritative diff presentation preference shared by working-tree, commit,
+ * pull-request, aggregate, and replay diff surfaces.
+ */
+export const diffViewModeAtom = atom(
+  (get) => normalizeDiffViewMode(get(persistedDiffViewModeAtom)),
+  (_get, set, mode: DiffViewMode) => {
+    set(persistedDiffViewModeAtom, mode);
+  }
+);
+diffViewModeAtom.debugLabel = "codeEditor/diffViewMode";

--- a/src/store/workstation/codeEditor/index.ts
+++ b/src/store/workstation/codeEditor/index.ts
@@ -29,6 +29,9 @@ export * from "./workspacePortsAtom";
 // Git diff review bar (change list position)
 export * from "./gitReviewNavigationAtom";
 
+// Shared unified/split presentation preference for git diff surfaces
+export * from "./diffViewModeAtom";
+
 // Source Control focus target (sidebar click → scroll/expand in All Changes view)
 export * from "./sourceControlFocusTargetAtom";
 

--- a/src/types/git/types.ts
+++ b/src/types/git/types.ts
@@ -11,6 +11,9 @@
  */
 import type { GitFileStatus } from "@src/config/gitStatus";
 
+/** Shared presentation mode for Git review diff surfaces. */
+export type DiffViewMode = "unified" | "split";
+
 // Re-export GitFileStatus for convenience
 export type { GitFileStatus } from "@src/config/gitStatus";
 


### PR DESCRIPTION
## Problem

Source Control exposed inconsistent diff presentation controls: Focus, commit, and pull-request diffs owned separate local Unified/Split state, while All Changes and Session Replay were hard-coded to Unified and offered no switch. Focus could also show an unrelated Git navigation placeholder or retain a stale file when the active repo/worktree or staged filter changed.

## Solution

Introduce one persisted, normalized diff-view preference and use it across working-tree, commit, pull-request, aggregate, and replay diff surfaces. Add the Unified/Split selector to All Changes and Session Replay, and pass the selected mode through aggregate diff sections.

Model Source Control mode changes and remembered file selection as explicit transitions. All Changes now remembers the latest inspected file for Focus hand-off; Focus shows a select-file empty state when no valid target exists. Main-pane derivation now filters both aggregate files and focused files by the active repo/worktree root and staged/unstaged filter.

Add component, persistence, state-transition, scope, filter, and empty-state regression coverage, plus the required frontend UI audit report.

## Potential risks

- The Unified/Split choice is intentionally global across Git review surfaces; users who previously expected a per-surface choice will now see their latest choice reused everywhere.
- Worktree isolation relies on `GitFile.repoRoot`; a non-host worktree record without that metadata is excluded instead of being allowed to leak into the active scope.
- Malformed persisted values fall back to Unified. No existing persistence key, IPC contract, wire format, or backend schema is migrated.
- Compact provenance-table diffs remain intentionally Unified, and two unused legacy diff abstractions retain local defaults rather than introducing a shared-layer dependency on the workstation store.
- Browser-only visual verification is unavailable because ORGII requires Tauri window metadata during initialization. The changed behavior is covered at component and state boundaries, but final in-app visual QA is still recommended.

## Verification

- `pnpm exec vitest run src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.test.ts src/store/workstation/codeEditor/diffViewModeAtom.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/__tests__/sourceControlMainProps.test.ts src/modules/WorkStation/CodeEditor/__tests__/sourceControlStateTransitions.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/__tests__/FocusView.emptyState.test.ts src/hooks/workStation/git/__tests__/useGitDiffState.test.ts` — 6 files, 31 tests passed on the clean latest-develop worktree.
- ESLint over every changed `.ts` / `.tsx` file — passed locally.
- Prettier over all 34 changed files — passed locally.
- `git diff --check origin/develop...HEAD` — passed.
- GitHub CI Type check — passed.
- GitHub CI full-repository lint — passed.
- GitHub CI Rust clippy — passed.
- GitHub CI full unit suite — 986 files / 8079 tests passed; 6 tests in `WorkItemDescriptionEditing.test.ts` failed because `ResizeObserver` is absent in the CI test environment. This is the same pre-existing develop failure seen on merged PR #722 (982 files / 8065 tests passed with the identical 6 failures), and neither the failing test nor `useElementDimensions.ts` is changed here.
- Running the failing WorkItem test alone on a detached latest `origin/develop` worktree passed 9/9, confirming the failure is full-suite environment contamination rather than this Source Control diff.

## Audit

Frontend UI audit: `docs/frontend-ui-audit-2026-08-05/DiffViewConsistency.md`. Architecture review covered compiler/build health, source ownership, canonical types, state semantics, invalid persisted data, dependency direction, naming, and scope/filter resolver symmetry. Wire protocol and dual-runtime initialization layers were not applicable.