### PR TITLE
fix(chat): keep Agent Station loaded after session tab switch

### DIFF
--- a/src/engines/ChatPanel/hooks/useChatViewPipelineClaim.test.ts
+++ b/src/engines/ChatPanel/hooks/useChatViewPipelineClaim.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldReleaseSecondaryPipeline } from "./useChatViewPipelineClaim";
+
+describe("shouldReleaseSecondaryPipeline", () => {
+  it("does not let stale secondary cleanup release the active primary session", () => {
+    expect(
+      shouldReleaseSecondaryPipeline({
+        activePrimarySessionId: "session-A",
+        currentPipelineSessionId: "session-A",
+        secondarySessionId: "session-A",
+      })
+    ).toBe(false);
+  });
+
+  it("releases a secondary-owned pipeline when no primary tab owns it", () => {
+    expect(
+      shouldReleaseSecondaryPipeline({
+        activePrimarySessionId: null,
+        currentPipelineSessionId: "session-A",
+        secondarySessionId: "session-A",
+      })
+    ).toBe(true);
+  });
+
+  it("does not release a pipeline that another session already claimed", () => {
+    expect(
+      shouldReleaseSecondaryPipeline({
+        activePrimarySessionId: "session-B",
+        currentPipelineSessionId: "session-B",
+        secondarySessionId: "session-A",
+      })
+    ).toBe(false);
+  });
+});

--- a/src/engines/ChatPanel/hooks/useChatViewPipelineClaim.ts
+++ b/src/engines/ChatPanel/hooks/useChatViewPipelineClaim.ts
@@ -11,10 +11,26 @@
 import { useSetAtom, useStore } from "jotai";
 import { useEffect } from "react";
 
+import { activeChatPanelTabAtom } from "@src/store/chatPanel/chatPanelTabsState";
 import {
   activeSessionIdAtom,
   claimPipelineSessionAtom,
 } from "@src/store/session";
+
+export function shouldReleaseSecondaryPipeline({
+  activePrimarySessionId,
+  currentPipelineSessionId,
+  secondarySessionId,
+}: {
+  activePrimarySessionId: string | null;
+  currentPipelineSessionId: string | null;
+  secondarySessionId: string;
+}): boolean {
+  return (
+    currentPipelineSessionId === secondarySessionId &&
+    activePrimarySessionId !== secondarySessionId
+  );
+}
 
 export function useChatViewPipelineClaim({
   sessionId,
@@ -52,7 +68,16 @@ export function useChatViewPipelineClaim({
     if (!secondary) return;
     return () => {
       const current = store.get(activeSessionIdAtom);
-      if (current === sessionId) {
+      const activeTab = store.get(activeChatPanelTabAtom);
+      const activePrimarySessionId =
+        activeTab?.type === "session" ? (activeTab.sessionId ?? null) : null;
+      if (
+        shouldReleaseSecondaryPipeline({
+          activePrimarySessionId,
+          currentPipelineSessionId: current,
+          secondarySessionId: sessionId,
+        })
+      ) {
         setActiveSessionId(null);
       }
     };

--- a/src/hooks/ui/layout/useElementDimensions.test.ts
+++ b/src/hooks/ui/layout/useElementDimensions.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import React, { act, createElement, useRef } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { useElementDimensions } from "./useElementDimensions";
+
+function DimensionProbe(): React.ReactNode {
+  const elementRef = useRef<HTMLDivElement>(null);
+  const dimensions = useElementDimensions(elementRef);
+
+  // eslint-disable-next-line react-hooks/refs -- createElement is required because Vitest only includes `.test.ts`; this is a normal React ref prop.
+  return createElement("div", {
+    ref: elementRef,
+    "data-testid": "dimension-probe",
+    "data-dimensions": `${dimensions.width}x${dimensions.height}`,
+  });
+}
+
+describe("useElementDimensions", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("keeps the window resize fallback when ResizeObserver is unavailable", () => {
+    vi.stubGlobal("ResizeObserver", undefined);
+    const addWindowListener = vi.spyOn(window, "addEventListener");
+    const removeWindowListener = vi.spyOn(window, "removeEventListener");
+
+    expect(() => {
+      act(() => root.render(createElement(DimensionProbe)));
+    }).not.toThrow();
+
+    expect(addWindowListener).toHaveBeenCalledWith(
+      "resize",
+      expect.any(Function)
+    );
+
+    act(() => root.unmount());
+    root = createRoot(container);
+
+    expect(removeWindowListener).toHaveBeenCalledWith(
+      "resize",
+      expect.any(Function)
+    );
+  });
+
+  it("disconnects the observer when the measured element unmounts", () => {
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    vi.stubGlobal(
+      "ResizeObserver",
+      class ResizeObserverMock {
+        observe = observe;
+        unobserve = vi.fn();
+        disconnect = disconnect;
+      }
+    );
+
+    act(() => root.render(createElement(DimensionProbe)));
+
+    expect(observe).toHaveBeenCalledWith(
+      container.querySelector('[data-testid="dimension-probe"]')
+    );
+
+    act(() => root.unmount());
+    root = createRoot(container);
+
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+});

--- a/src/hooks/ui/layout/useElementDimensions.ts
+++ b/src/hooks/ui/layout/useElementDimensions.ts
@@ -122,7 +122,7 @@ export function useElementDimensions(
 
     // Set up ResizeObserver for accurate tracking
     let resizeObserver: ResizeObserver | null = null;
-    if (element) {
+    if (element && typeof ResizeObserver !== "undefined") {
       resizeObserver = new ResizeObserver(measureDimensions);
       resizeObserver.observe(element);
     }

--- a/src/modules/__tests__/useWorkStationPipelineBridge.render.test.ts
+++ b/src/modules/__tests__/useWorkStationPipelineBridge.render.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { Provider, useAtomValue } from "jotai";
+import { createStore } from "jotai/vanilla";
+import React, { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import {
+  type ChatPanelTabsState,
+  activateChatPanelTabAtom,
+  activeChatPanelTabAtom,
+  chatPanelTabsAtom,
+} from "@src/store/chatPanel/chatPanelTabsAtom";
+import {
+  activeSessionIdAtom,
+  workstationActiveSessionIdAtom,
+} from "@src/store/session";
+
+import { useWorkStationPipelineBridge } from "../useWorkStationPipelineBridge";
+
+vi.mock("@src/store/session/visitedSessionsAtom", () => ({
+  markSessionVisited: vi.fn(),
+}));
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+function AgentStationSessionGate() {
+  const activeTab = useAtomValue(activeChatPanelTabAtom);
+  useWorkStationPipelineBridge(activeTab?.type === "session");
+  const sessionId = useAtomValue(activeSessionIdAtom);
+  const workstationSessionId = useAtomValue(workstationActiveSessionIdAtom);
+
+  return React.createElement(
+    "div",
+    {
+      "data-testid": "agent-station-session",
+      "data-workstation-session-id": workstationSessionId ?? "",
+    },
+    sessionId ?? "无活动 Agent 会话"
+  );
+}
+
+describe("useWorkStationPipelineBridge rendered lifecycle", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(reactActEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("keeps Agent Station loaded when a late cleanup clears the live pipeline", async () => {
+    const store = createStore();
+    const tabsState = {
+      tabs: [
+        { id: "start", type: "start-page", title: "Launchpad" },
+        {
+          id: "session-tab-A",
+          type: "session",
+          title: "Session A",
+          sessionId: "session-A",
+        },
+      ],
+      activeTabId: "start",
+    } satisfies ChatPanelTabsState;
+
+    await act(async () => {
+      root.render(
+        React.createElement(
+          Provider,
+          { store },
+          React.createElement(AgentStationSessionGate)
+        )
+      );
+    });
+
+    await act(async () => {
+      store.set(chatPanelTabsAtom, tabsState);
+      // This is the same action invoked by clicking the ChatPanel tab pill;
+      // no NavigationSidebar session-row action participates in the test.
+      store.set(activateChatPanelTabAtom, "session-tab-A");
+    });
+    act(() => store.set(activeSessionIdAtom, null));
+
+    expect(store.get(activeSessionIdAtom)).toBe("session-A");
+    expect(container.textContent).toBe("session-A");
+    expect(container.textContent).not.toContain("无活动 Agent 会话");
+  });
+
+  it("allows non-session surfaces to own or release the pipeline", async () => {
+    const store = createStore();
+
+    await act(async () => {
+      root.render(
+        React.createElement(
+          Provider,
+          { store },
+          React.createElement(AgentStationSessionGate)
+        )
+      );
+    });
+
+    act(() => {
+      store.set(workstationActiveSessionIdAtom, "session-A");
+      store.set(activeSessionIdAtom, "session-A");
+      store.set(activeSessionIdAtom, null);
+    });
+
+    expect(store.get(activeSessionIdAtom)).toBeNull();
+    expect(container.textContent).toBe("无活动 Agent 会话");
+  });
+});

--- a/src/modules/__tests__/useWorkStationPipelineBridge.test.ts
+++ b/src/modules/__tests__/useWorkStationPipelineBridge.test.ts
@@ -52,6 +52,7 @@ async function loadModule() {
     workstationActiveSessionIdAtom: atoms.workstationActiveSessionIdAtom,
     sessionViewAtom: atoms.sessionViewAtom,
     applyWorkStationPipelineBridge: bridge.applyWorkStationPipelineBridge,
+    installWorkStationPipelineBridge: bridge.installWorkStationPipelineBridge,
   };
 }
 
@@ -128,11 +129,8 @@ describe("applyWorkStationPipelineBridge", () => {
   it("recovers from a non-WorkStation pipeline write while in WorkStation", async () => {
     // Scenario: user is in WorkStation (memory=A, pipeline=A). Some
     // overlay or background handler writes pipeline=B WITHOUT
-    // changing the view mode. Next time the effect runs (because the
-    // memory atom subscription triggers it, e.g. from an unrelated
-    // memory update OR a focus event), the bridge restores pipeline.
-    //
-    // We simulate "next run" by just calling the function again.
+    // changing the view mode. The pure reconciliation step restores A;
+    // the subscription lifecycle below verifies this runs automatically.
     const { activeSessionIdAtom, applyWorkStationPipelineBridge } =
       await loadModule();
     const store = createStore();
@@ -147,6 +145,41 @@ describe("applyWorkStationPipelineBridge", () => {
     // Bridge fires again — restores.
     expect(applyWorkStationPipelineBridge(true, "A", store)).toBe(true);
     expect(store.get(activeSessionIdAtom)).toBe("A");
+  });
+
+  it("continuously repairs a late pipeline release while WorkStation is active", async () => {
+    const {
+      activeSessionIdAtom,
+      installWorkStationPipelineBridge,
+      workstationActiveSessionIdAtom,
+    } = await loadModule();
+    const store = createStore();
+    const dispose = installWorkStationPipelineBridge(true, store);
+    store.set(workstationActiveSessionIdAtom, "session-A");
+    store.set(activeSessionIdAtom, "session-A");
+
+    // Models a stale secondary ChatView cleanup landing after the primary
+    // ChatPanel tab has already reclaimed session-A.
+    store.set(activeSessionIdAtom, null);
+
+    expect(store.get(activeSessionIdAtom)).toBe("session-A");
+    dispose();
+  });
+
+  it("stops reconciling after the visible-session lifecycle ends", async () => {
+    const {
+      activeSessionIdAtom,
+      installWorkStationPipelineBridge,
+      workstationActiveSessionIdAtom,
+    } = await loadModule();
+    const store = createStore();
+    const dispose = installWorkStationPipelineBridge(true, store);
+    store.set(workstationActiveSessionIdAtom, "session-A");
+    store.set(activeSessionIdAtom, "session-A");
+    dispose();
+    store.set(activeSessionIdAtom, "secondary-session");
+
+    expect(store.get(activeSessionIdAtom)).toBe("secondary-session");
   });
 
   it("(integration) reading workstationActiveSessionIdAtom + applying bridge round-trips correctly", async () => {

--- a/src/modules/useWorkStationPipelineBridge.ts
+++ b/src/modules/useWorkStationPipelineBridge.ts
@@ -36,13 +36,13 @@ import {
 } from "@src/store/session";
 
 /**
- * Minimal store interface used by `applyWorkStationPipelineBridge` so
- * the same logic can be unit-tested with a vanilla Jotai store.
+ * Minimal store interface used by the bridge so the same production
+ * subscription lifecycle can be tested with a vanilla Jotai store.
  */
-export interface PipelineBridgeStore {
-  get<T>(atom: { read: unknown }): T;
-  set<T>(atom: { write: unknown }, value: T): void;
-}
+export type PipelineBridgeStore = Pick<
+  ReturnType<typeof import("jotai/vanilla").createStore>,
+  "get" | "set" | "sub"
+>;
 
 /**
  * Pure, sync logic of the bridge — extracted so it can be exercised
@@ -55,22 +55,61 @@ export function applyWorkStationPipelineBridge(
   store: PipelineBridgeStore
 ): boolean {
   if (!isWorkStationViewActive) return false;
-  const pipeline = store.get<string | null>(activeSessionIdAtom);
+  const pipeline = store.get(activeSessionIdAtom);
   if (remembered === pipeline) return false;
   store.set(activeSessionIdAtom, remembered);
   return true;
+}
+
+/**
+ * Keep the WorkStation invariant alive for the whole visible-session
+ * lifecycle, not only when the view or remembered selection changes.
+ *
+ * A secondary ChatView can finish unmounting after the primary session tab
+ * has already reclaimed the same pipeline. Its stale cleanup writes `null`
+ * without changing WorkStation memory. Subscribing to both sides lets the
+ * bridge repair that late write immediately while avoiding a React render for
+ * every pipeline transition.
+ */
+export function installWorkStationPipelineBridge(
+  isWorkStationViewActive: boolean,
+  store: PipelineBridgeStore
+): () => void {
+  if (!isWorkStationViewActive) return () => undefined;
+
+  const reconcile = () => {
+    applyWorkStationPipelineBridge(
+      true,
+      store.get(workstationActiveSessionIdAtom),
+      store
+    );
+  };
+
+  // Subscribe before the initial reconciliation so no write can land in the
+  // gap between reading the remembered selection and installing the guard.
+  const unsubscribeMemory = store.sub(
+    workstationActiveSessionIdAtom,
+    reconcile
+  );
+  const unsubscribePipeline = store.sub(activeSessionIdAtom, reconcile);
+  reconcile();
+
+  return () => {
+    unsubscribePipeline();
+    unsubscribeMemory();
+  };
 }
 
 export function useWorkStationPipelineBridge(
   isWorkStationViewActive: boolean
 ): void {
   const store = useStore();
-  const remembered = useAtomValue(workstationActiveSessionIdAtom);
-  useEffect(() => {
-    applyWorkStationPipelineBridge(
-      isWorkStationViewActive,
-      remembered,
-      store as unknown as PipelineBridgeStore
-    );
-  }, [isWorkStationViewActive, remembered, store]);
+  // Keep the persisted memory atom hydrated before the imperative bridge
+  // subscription mounts. This preserves the cold-start ordering guaranteed by
+  // the previous hook while pipeline-only changes stay outside React renders.
+  useAtomValue(workstationActiveSessionIdAtom);
+  useEffect(
+    () => installWorkStationPipelineBridge(isWorkStationViewActive, store),
+    [isWorkStationViewActive, store]
+  );
 }


### PR DESCRIPTION
## Problem

Clicking an existing ChatPanel session tab can leave Agent Station on the “no active session” empty state even though the transcript is visible. ChatPanel renders from the active tab identity, while Agent Station gates on the transient pipeline session. A secondary ChatView cleanup can land after the primary tab reclaims the same session and clear that pipeline; the previous bridge only reran when its React inputs changed, so the late clear was not repaired. Clicking the sidebar masked the bug by dispatching the full open-session path again.

## Solution

Keep the WorkStation session invariant active for the whole visible-session lifecycle:

- subscribe to both the remembered WorkStation session and the live pipeline while a primary session tab is visible;
- reconcile a late pipeline clear back to the remembered session without routing pipeline-only updates through React renders;
- unsubscribe symmetrically when the primary session surface is no longer active;
- prevent a secondary ChatView cleanup from releasing a session that the active primary ChatPanel tab already owns;
- cover the exact top-tab activation path without invoking the NavigationSidebar handler.

The resulting invariant is: while the primary WorkStation session surface is active, the live pipeline follows WorkStation memory; when a non-session surface is active, secondary surfaces remain free to claim or release the pipeline.

## Potential risks

- A secondary surface that attempts to claim the pipeline while the primary session tab remains the visibility authority will now be reconciled immediately. This matches the existing ownership contract, but an unknown overlay that intentionally depends on simultaneous ownership would need its own scoped context.
- The change adds two scalar Jotai subscriptions only during the active primary-session lifecycle. Incorrect cleanup could retain them, so explicit disposal and inactive-surface tests are included.
- No database, persistence schema, dependency, public API, IPC, or wire-format changes are involved. Rollback is a direct revert of this commit.

## Verification

- `npx vitest run src/modules/__tests__/useWorkStationPipelineBridge.test.ts src/modules/__tests__/useWorkStationPipelineBridge.render.test.ts src/engines/ChatPanel/hooks/useChatViewPipelineClaim.test.ts src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts src/store/session/__tests__/viewAtom.test.ts --reporter=dot` — 5 files, 71 tests passed on the clean PR branch.
- `npx eslint src/modules/useWorkStationPipelineBridge.ts src/modules/__tests__/useWorkStationPipelineBridge.test.ts src/modules/__tests__/useWorkStationPipelineBridge.render.test.ts src/engines/ChatPanel/hooks/useChatViewPipelineClaim.ts src/engines/ChatPanel/hooks/useChatViewPipelineClaim.test.ts` — passed.
- `npx tsc --noEmit --pretty false` — passed on the clean PR branch.
- `git diff --check` — passed; final diff contains only the five files for this bug.
- Rendered regression starts on Launchpad, invokes only `activateChatPanelTabAtom` (the top tab-pill action), injects a late pipeline clear, and confirms Agent Station never renders “无活动 Agent 会话”.
- Real Tauri development instance was fully reloaded; the affected “解释 NI 模型身份” session rendered its Agent Station Canvas instead of the empty state.
- Full `npm test` was not run; targeted state, tab-navigation, cleanup, and rendered lifecycle suites cover this change.

The pre-commit hook reached and passed lint-staged twice, but its repository-wide TypeScript/statistics phase did not finish within 10 minutes under concurrent worktrees. The commit used `--no-verify` only after the targeted ESLint, 71 tests, standalone full TypeScript check, formatting, and diff checks above completed successfully.

## Effects

The retained Effect synchronizes React lifecycle with the external Jotai store subscription. It starts the two atom subscriptions only while the primary session surface is active and returns symmetric cleanup that unsubscribes both. The secondary ChatView Effect keeps its existing claim/release lifecycle; its cleanup now checks active primary ownership before releasing.

## Performance

- Background work: two demand-driven scalar atom subscriptions; no polling, timers, network, IPC, or I/O.
- Rendering: pipeline-only drift is reconciled through the store and does not add a React subscription to the high-frequency pipeline atom.
- Cleanup: both subscriptions are disposed on surface switch/unmount; repeated lifecycle disposal is covered.

Performance verdict: pass