### PR TITLE
fix(ui): tolerate missing ResizeObserver

### DIFF
--- a/src/hooks/ui/layout/useElementDimensions.test.ts
+++ b/src/hooks/ui/layout/useElementDimensions.test.ts
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+import React, { act, createElement, useRef } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { useElementDimensions } from "./useElementDimensions";
+
+function DimensionProbe(): React.ReactNode {
+  const elementRef = useRef<HTMLDivElement>(null);
+  const dimensions = useElementDimensions(elementRef);
+
+  // eslint-disable-next-line react-hooks/refs -- createElement is required because Vitest only includes `.test.ts`; this is a normal React ref prop.
+  return createElement("div", {
+    ref: elementRef,
+    "data-testid": "dimension-probe",
+    "data-dimensions": `${dimensions.width}x${dimensions.height}`,
+  });
+}
+
+describe("useElementDimensions", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("keeps the window resize fallback when ResizeObserver is unavailable", () => {
+    vi.stubGlobal("ResizeObserver", undefined);
+    const addWindowListener = vi.spyOn(window, "addEventListener");
+    const removeWindowListener = vi.spyOn(window, "removeEventListener");
+
+    expect(() => {
+      act(() => root.render(createElement(DimensionProbe)));
+    }).not.toThrow();
+
+    expect(addWindowListener).toHaveBeenCalledWith(
+      "resize",
+      expect.any(Function)
+    );
+
+    act(() => root.unmount());
+    root = createRoot(container);
+
+    expect(removeWindowListener).toHaveBeenCalledWith(
+      "resize",
+      expect.any(Function)
+    );
+  });
+
+  it("disconnects the observer when the measured element unmounts", () => {
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    vi.stubGlobal(
+      "ResizeObserver",
+      class ResizeObserverMock {
+        observe = observe;
+        unobserve = vi.fn();
+        disconnect = disconnect;
+      }
+    );
+
+    act(() => root.render(createElement(DimensionProbe)));
+
+    expect(observe).toHaveBeenCalledWith(
+      container.querySelector('[data-testid="dimension-probe"]')
+    );
+
+    act(() => root.unmount());
+    root = createRoot(container);
+
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+});

--- a/src/hooks/ui/layout/useElementDimensions.ts
+++ b/src/hooks/ui/layout/useElementDimensions.ts
@@ -122,7 +122,7 @@ export function useElementDimensions(
 
     // Set up ResizeObserver for accurate tracking
     let resizeObserver: ResizeObserver | null = null;
-    if (element) {
+    if (element && typeof ResizeObserver !== "undefined") {
       resizeObserver = new ResizeObserver(measureDimensions);
       resizeObserver.observe(element);
     }


### PR DESCRIPTION
## Problem

The shared `useElementDimensions` hook constructs `ResizeObserver` unconditionally when an element mounts. jsdom does not provide that browser API, so `WorkItemDescriptionEditing.test.ts` crashes six tests across every PR based on current `develop`, including CI run 31110786799. The hook already owns a window-resize fallback but never reaches it when observer construction throws.

## Solution

Guard observer construction when `ResizeObserver` is unavailable while preserving the existing immediate measurement and window-resize fallback. Add lifecycle coverage for both the fallback path and observer disconnection on unmount.

## Potential risks

In environments without `ResizeObserver`, element-only size changes are detected on the next window resize rather than immediately. This is the existing documented fallback behavior; supported production browsers continue using `ResizeObserver` unchanged. Rollback is a clean revert of the single fix commit.

## Verification

- `npx vitest run src/hooks/ui/layout/useElementDimensions.test.ts src/modules/ProjectManager/WorkItems/components/WorkItemContent/__tests__/WorkItemDescriptionEditing.test.ts` — 18/18 passed.
- `npx eslint src/hooks/ui/layout/useElementDimensions.ts src/hooks/ui/layout/useElementDimensions.test.ts` — passed.
- `npm run typecheck` — passed.
- `npm test -- --reporter=dot` — all 8,073 assertions passed; Vitest reported two unrelated post-test WebSocket exceptions in cloud-org suites, so the aggregate command exited nonzero.
- `git diff --check` — passed.