### PR TITLE
fix(tests): stub ResizeObserver in WorkItemDescriptionEditing suite

### DIFF
--- a/src/modules/ProjectManager/WorkItems/components/WorkItemContent/__tests__/WorkItemDescriptionEditing.test.ts
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemContent/__tests__/WorkItemDescriptionEditing.test.ts
@@ -379,6 +379,16 @@ describe("WorkItemContent description editing", () => {
 
   beforeAll(() => {
     actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    vi.stubGlobal(
+      "ResizeObserver",
+      class ResizeObserverMock {
+        observe() {}
+
+        unobserve() {}
+
+        disconnect() {}
+      }
+    );
   });
 
   beforeEach(() => {
@@ -397,6 +407,7 @@ describe("WorkItemContent description editing", () => {
 
   afterAll(() => {
     Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+    vi.unstubAllGlobals();
   });
 
   function changeDescription(value: string, testId = "description-editor") {


### PR DESCRIPTION
## Problem

The `WorkItemDescriptionEditing.test.ts` suite added in #722 mounts `WorkItemContent`, whose `useElementDimensions` hook constructs a `ResizeObserver` in a layout effect (`src/hooks/ui/layout/useElementDimensions.ts:126`). jsdom provides no `ResizeObserver`, so 6 of the 16 cases throw `ReferenceError: ResizeObserver is not defined`.

Because PR checks run on the merge commit with develop, this fails the Frontend job of **every open PR** (first seen on #728, whose diff is unrelated).

## Fix

Add the same `vi.stubGlobal("ResizeObserver", …)` / `vi.unstubAllGlobals()` pair the sibling `HistoryTab.test.ts` suite already uses.

## Verification

- Repro on clean develop (bbc207c8f): `npx vitest run …/WorkItemDescriptionEditing.test.ts` → 6 failed / 10 passed, identical to CI.
- After fix: whole `__tests__/` dir → 14 files, 66/66 passed.