### PR TITLE
fix(cloud): serialize address-comments rounds per session

### DIFF
--- a/src/features/Org2Cloud/addressCommentsRun.test.ts
+++ b/src/features/Org2Cloud/addressCommentsRun.test.ts
@@ -226,6 +226,77 @@ describe("runAddressCommentsRound", () => {
     expect(result).toEqual({ status: "ran", threadCount: 1, replyCount: 1 });
   });
 
+  it("serializes overlapping rounds so replies validate against their own run", async () => {
+    const order: string[] = [];
+    let releaseFirst = (): void => {};
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    vi.mocked(listSessionComments).mockResolvedValue({
+      comments: [comment({ id: "c-1" }), comment({ id: "c-2" })],
+      viewerOwnsSession: true,
+    });
+    const first = runAddressCommentsRound({
+      orgId: "org-1",
+      cloudSessionId: "local-1",
+      localSessionId: "local-1",
+      selectedHeadIds: ["c-1"],
+      dispatchTurn: async ({ turnIntentId }) => {
+        order.push("dispatch-1");
+        const generation = beginTurnDispatch("local-1");
+        publishTurnIntentDispatch(turnIntentId, {
+          sessionId: "local-1",
+          generation,
+        });
+        void firstBlocked.then(async () => {
+          const reply = await replyViaActiveAddressRun(
+            "c-1",
+            "done",
+            "local-1"
+          );
+          order.push(`reply-1:${String(reply.success)}`);
+          markTurnTerminal("local-1", "completed", { generation });
+        });
+      },
+    });
+    await vi.waitFor(() => {
+      expect(order).toContain("dispatch-1");
+    });
+    // Second round starts while the first turn is still running. Without
+    // per-session serialization it would overwrite the first round's
+    // registration and the first run's reply would be rejected as unknown.
+    const second = runAddressCommentsRound({
+      orgId: "org-1",
+      cloudSessionId: "local-1",
+      localSessionId: "local-1",
+      selectedHeadIds: ["c-2"],
+      dispatchTurn: async ({ turnIntentId }) => {
+        order.push("dispatch-2");
+        const generation = beginTurnDispatch("local-1");
+        publishTurnIntentDispatch(turnIntentId, {
+          sessionId: "local-1",
+          generation,
+        });
+        markTurnTerminal("local-1", "completed", { generation });
+      },
+    });
+    releaseFirst();
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+    expect(firstResult).toEqual({
+      status: "ran",
+      threadCount: 1,
+      replyCount: 1,
+    });
+    expect(secondResult).toEqual({
+      status: "ran",
+      threadCount: 1,
+      replyCount: 0,
+    });
+    expect(order.indexOf("dispatch-2")).toBeGreaterThan(
+      order.indexOf("reply-1:true")
+    );
+  });
+
   it("does not dispatch when no unresolved selected thread exists", async () => {
     vi.mocked(listSessionComments).mockResolvedValue({
       comments: [comment({ id: "c-1", resolvedAt: "2026-07-11T10:00:00Z" })],

--- a/src/features/Org2Cloud/addressCommentsRun.ts
+++ b/src/features/Org2Cloud/addressCommentsRun.ts
@@ -320,7 +320,46 @@ function buildDisplayContent(threads: readonly AddressableThread[]): string {
   return `@agent Address ${threads.length} cloud comment threads`;
 }
 
+/**
+ * Rounds are SERIALIZED per local session: `activeAddressRuns` holds one
+ * registration per session, so a second round starting while one is in
+ * flight would overwrite it and cross-validate the running turn's
+ * `reply_session_comment` calls against the wrong head-id set (rejected as
+ * unknown, or booked into the wrong run's replied map). Queued rounds also
+ * list comments AFTER the prior round settles, so they see its replies and
+ * resolutions instead of re-addressing them.
+ */
+const roundChainBySession = new Map<string, Promise<unknown>>();
+
 export async function runAddressCommentsRound(
+  input: AddressRoundInput
+): Promise<AddressRoundResult> {
+  const { localSessionId } = input;
+  // Activity begins at ENQUEUE (the scheduled-runs map is a list precisely
+  // so a queued round's threads show as addressing while a prior round runs).
+  const finishRunActivity = beginRunActivity(
+    localSessionId,
+    input.selectedHeadIds
+  );
+  const prior = roundChainBySession.get(localSessionId) ?? Promise.resolve();
+  const round = prior.then(() => executeAddressCommentsRound(input));
+  // Park the settled chain — a failed round must never poison the next.
+  const parked = round.then(
+    () => undefined,
+    () => undefined
+  );
+  roundChainBySession.set(localSessionId, parked);
+  try {
+    return await round;
+  } finally {
+    finishRunActivity();
+    if (roundChainBySession.get(localSessionId) === parked) {
+      roundChainBySession.delete(localSessionId);
+    }
+  }
+}
+
+async function executeAddressCommentsRound(
   input: AddressRoundInput
 ): Promise<AddressRoundResult> {
   const {
@@ -331,7 +370,6 @@ export async function runAddressCommentsRound(
     selectedHeadIds,
     instruction,
   } = input;
-  const finishRunActivity = beginRunActivity(localSessionId, selectedHeadIds);
   let run: ActiveAddressRun | null = null;
   try {
     const listToken = await freshAccessToken();
@@ -410,7 +448,6 @@ export async function runAddressCommentsRound(
     if (run && activeAddressRuns.get(localSessionId) === run) {
       activeAddressRuns.delete(localSessionId);
     }
-    finishRunActivity();
     notifyAddressRunFinished();
   }
 }


### PR DESCRIPTION
## Problem

`runAddressCommentsRound` registers its capability window in `activeAddressRuns` — **one entry per local session** — but nothing prevented two rounds from overlapping: while round A's agent turn is running, the user can post another `@agent …` comment or hit Address All (neither affordance is gated on `addressRunActive`). Round B's registration then **overwrites** A's, and A's `reply_session_comment` calls validate against B's head-id set:

- B is a per-comment round → A's legitimate replies are rejected as *"Unknown commentId"* — A finishes with zero replies and the agent gets misleading tool feedback mid-turn.
- B is Address-All → A's replies pass but are booked into **B's** `replied` map, so B's own replies to those threads are later rejected as *"already posted"*.

Fails closed (no unauthorized write — same org/session/owner in all cases), but one round's replies are silently lost.

## Fix

Serialize rounds per local session with a promise chain: a new round waits for the prior round to settle, then lists comments **fresh** — so it also sees the prior round's replies/resolutions instead of re-addressing them. A failed round never poisons the chain. Activity bookkeeping moves to enqueue time so a queued round's threads show the addressing spinner immediately (the scheduled-runs map was already a list for exactly this).

## Verification

New test: two overlapping rounds on one session — the first round's mid-turn reply must validate against **its own** registration (`replyCount: 1`) and the second round's dispatch must happen after it; plus the ordering assertion. Full address-comments suites 23/23, repo typecheck + eslint clean.

Found by the session-comments plane audit (delayed-manifestation / concurrency lens).