### PR TITLE
fix: dual-instance hunt batch — logging latch, fork sharing level, realtime edge recovery

### DIFF
--- a/src/features/Org2Cloud/org2CloudRealtimeLease.test.ts
+++ b/src/features/Org2Cloud/org2CloudRealtimeLease.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   REALTIME_LEASE_RELEASE_GRACE_MS,
+  createOrg2CloudLeaseMinimizeBridge,
   createOrg2CloudRealtimeLeaseController,
 } from "./org2CloudRealtimeLease";
 
@@ -122,5 +123,111 @@ describe("Org2Cloud Realtime connection lease", () => {
 
     expect(controller.isHeld()).toBe(true);
     expect(transitions).toEqual([]);
+  });
+});
+
+describe("minimize bridge (Windows minimize never reports visibility hidden)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function deferredBoolean() {
+    let resolve!: (value: boolean) => void;
+    const promise = new Promise<boolean>((r) => {
+      resolve = r;
+    });
+    return { promise, resolve };
+  }
+
+  it("flips to minimized when the probe resolves true and notifies once", async () => {
+    const reads: Array<ReturnType<typeof deferredBoolean>> = [];
+    const changes: boolean[] = [];
+    const bridge = createOrg2CloudLeaseMinimizeBridge(
+      () => {
+        const d = deferredBoolean();
+        reads.push(d);
+        return d.promise;
+      },
+      () => changes.push(bridge.isMinimized())
+    );
+
+    bridge.probe();
+    expect(bridge.isMinimized()).toBe(false);
+    reads[0].resolve(true);
+    await reads[0].promise;
+
+    expect(bridge.isMinimized()).toBe(true);
+    expect(changes).toEqual([true]);
+  });
+
+  it("releases the blurred lease immediately once the probe reports minimized", async () => {
+    let foreground = true;
+    const read = deferredBoolean();
+    const transitions: boolean[] = [];
+    const bridge = createOrg2CloudLeaseMinimizeBridge(
+      () => read.promise,
+      () => controller.refresh()
+    );
+    const controller = createOrg2CloudRealtimeLeaseController({
+      isForeground: () => foreground,
+      isHidden: () => bridge.isMinimized(),
+      onChange: (held) => transitions.push(held),
+    });
+
+    // Windows minimize: blur fires, visibility stays "visible".
+    foreground = false;
+    controller.refresh();
+    bridge.probe();
+    expect(controller.isHeld()).toBe(true);
+
+    read.resolve(true);
+    await read.promise;
+
+    // No grace wait: the probe resolution released the lease directly.
+    expect(controller.isHeld()).toBe(false);
+    expect(transitions).toEqual([false]);
+  });
+
+  it("clearOnFocus resets synchronously and drops stale probe results", async () => {
+    const first = deferredBoolean();
+    const changes: boolean[] = [];
+    const bridge = createOrg2CloudLeaseMinimizeBridge(
+      () => first.promise,
+      () => changes.push(bridge.isMinimized())
+    );
+
+    bridge.probe();
+    // Rapid minimize→restore: focus arrives before the probe resolves.
+    bridge.clearOnFocus();
+    first.resolve(true);
+    await first.promise;
+
+    // The stale `true` must not resurface after focus invalidated it.
+    expect(bridge.isMinimized()).toBe(false);
+    expect(changes).toEqual([]);
+  });
+
+  it("clearOnFocus notifies only when a minimized belief is actually reset", async () => {
+    const read = deferredBoolean();
+    const changes: boolean[] = [];
+    const bridge = createOrg2CloudLeaseMinimizeBridge(
+      () => read.promise,
+      () => changes.push(bridge.isMinimized())
+    );
+
+    bridge.clearOnFocus();
+    expect(changes).toEqual([]);
+
+    bridge.probe();
+    read.resolve(true);
+    await read.promise;
+    bridge.clearOnFocus();
+
+    expect(bridge.isMinimized()).toBe(false);
+    expect(changes).toEqual([true, false]);
   });
 });

--- a/src/features/Org2Cloud/org2CloudRealtimeLease.ts
+++ b/src/features/Org2Cloud/org2CloudRealtimeLease.ts
@@ -1,5 +1,7 @@
+import { getCurrentWindow } from "@tauri-apps/api/window";
 import { useEffect, useRef, useState } from "react";
 
+import { isTauriRuntimeHost } from "@src/hooks/logger/useLogger";
 import { isWindowFocused } from "@src/util/core/windowFocus";
 
 /**
@@ -98,6 +100,61 @@ export function createOrg2CloudRealtimeLeaseController({
 }
 
 /**
+ * Windows/WebView2 keeps `document.visibilityState` at "visible" across a
+ * minimize (verified on real hardware 2026-08-07), so the lease's
+ * immediate-release branch is unreachable there and a minimized window held
+ * its billable socket for the full blur grace. The bridge tracks OS-level
+ * minimize through the Tauri window handle instead: a blur re-probes
+ * asynchronously, a focus clears synchronously (a focused window is never
+ * minimized). The generation counter drops probe results that resolve after
+ * a newer probe or an intervening focus — a stale `true` from a rapid
+ * minimize→restore must not release a re-focused lease's socket.
+ */
+export interface Org2CloudLeaseMinimizeBridge {
+  /** Current belief; feeds the lease's `isHidden` alongside visibility. */
+  isMinimized(): boolean;
+  /** Async re-read of the OS minimize state; call on blur (and at setup). */
+  probe(): void;
+  /** Synchronous reset on focus; invalidates in-flight probes. */
+  clearOnFocus(): void;
+}
+
+export function createOrg2CloudLeaseMinimizeBridge(
+  readIsMinimized: () => Promise<boolean>,
+  onChange: () => void
+): Org2CloudLeaseMinimizeBridge {
+  let minimized = false;
+  let probeGeneration = 0;
+  return {
+    isMinimized: () => minimized,
+    probe: () => {
+      const generation = ++probeGeneration;
+      readIsMinimized().then(
+        (next) => {
+          if (generation !== probeGeneration || next === minimized) return;
+          minimized = next;
+          onChange();
+        },
+        () => undefined
+      );
+    },
+    clearOnFocus: () => {
+      probeGeneration += 1;
+      if (!minimized) return;
+      minimized = false;
+      onChange();
+    },
+  };
+}
+
+function readWindowMinimized(): Promise<boolean> {
+  if (typeof window === "undefined" || !isTauriRuntimeHost(window)) {
+    return Promise.resolve(false);
+  }
+  return getCurrentWindow().isMinimized();
+}
+
+/**
  * React binding for the connection lease. This hook owns browser lifecycle
  * listeners only; the caller remains the single owner of the Supabase client
  * and all of its channels.
@@ -110,9 +167,17 @@ export function useOrg2CloudRealtimeLease(): boolean {
     if (typeof window === "undefined" || typeof document === "undefined") {
       return undefined;
     }
+    // The bridge's change callback closes over `controller` declared below;
+    // probe resolutions are always asynchronous, so the reference is live by
+    // the time it can run.
+    const minimizeBridge = createOrg2CloudLeaseMinimizeBridge(
+      readWindowMinimized,
+      () => controller.refresh()
+    );
     const controller = createOrg2CloudRealtimeLeaseController({
       isForeground: isWindowFocused,
-      isHidden: () => document.visibilityState === "hidden",
+      isHidden: () =>
+        document.visibilityState === "hidden" || minimizeBridge.isMinimized(),
       // Preserve the render-time truth so a focus transition between render
       // and effect setup is reconciled instead of silently skipped.
       initialHeld: initialHeldRef.current,
@@ -121,16 +186,25 @@ export function useOrg2CloudRealtimeLease(): boolean {
 
     const refresh = () => controller.refresh();
     const release = () => controller.releaseImmediately();
-    window.addEventListener("focus", refresh);
-    window.addEventListener("blur", refresh);
+    const handleFocus = () => {
+      minimizeBridge.clearOnFocus();
+      controller.refresh();
+    };
+    const handleBlur = () => {
+      controller.refresh();
+      minimizeBridge.probe();
+    };
+    window.addEventListener("focus", handleFocus);
+    window.addEventListener("blur", handleBlur);
     window.addEventListener("pagehide", release);
     window.addEventListener("pageshow", refresh);
     document.addEventListener("visibilitychange", refresh);
+    minimizeBridge.probe();
     controller.refresh();
 
     return () => {
-      window.removeEventListener("focus", refresh);
-      window.removeEventListener("blur", refresh);
+      window.removeEventListener("focus", handleFocus);
+      window.removeEventListener("blur", handleBlur);
       window.removeEventListener("pagehide", release);
       window.removeEventListener("pageshow", refresh);
       document.removeEventListener("visibilitychange", refresh);

--- a/src/features/Org2Cloud/useOrg2CloudRealtime.ts
+++ b/src/features/Org2Cloud/useOrg2CloudRealtime.ts
@@ -129,8 +129,10 @@ const log = createLogger("Org2CloudRealtime");
  * `org_change_signals`, defined in the consolidated baseline with
  * `REPLICA IDENTITY FULL`, membership in `supabase_realtime`, and an
  * `is_org_member(org_id)` SELECT policy — the row-level authorization
- * Realtime needs. Server triggers bump one row per org on every
- * projects / work-items / comments change.
+ * Realtime needs. Server triggers bump one row per org on
+ * projects / work-items / comments / SESSIONS changes (session-row
+ * writes were verified to broadcast on 2026-08-06 — an earlier version
+ * of this comment under-claimed the coverage).
  */
 const CHANGE_SIGNALS_TABLE = "org_change_signals";
 
@@ -579,10 +581,17 @@ export function useOrg2CloudRealtime(): void {
   // signal channel's SUBSCRIBED edge. 0005: the org broadcast channel's edge.
   const runSignalEdgeRecovery = useCallback(
     (orgId: string) => {
-      const now = Date.now();
-      signalCoalescerRef.current.markHandled(ALL_SIGNAL_PLANES);
-      controlPlaneRefreshAtRef.current = now;
+      // Hidden check FIRST: an edge that races a visibility flip must not
+      // stamp the control-plane throttle or mark the coalescer handled while
+      // skipping the actual refreshes — that claimed a recovery that never
+      // ran and muted the next real one for up to the 5-min window.
       if (isDocumentHidden()) return;
+      signalCoalescerRef.current.markHandled(ALL_SIGNAL_PLANES);
+      controlPlaneRefreshAtRef.current = Date.now();
+      // Broadcast signals are at-most-once: a frame lost with no follow-up
+      // signal would otherwise never arm any convergence path. One trailing
+      // coarse refresh per control-plane window bounds that staleness.
+      armCoarseSignalSafetyNet();
       // A LONG gap forces complete listings so tombstone-free absences
       // (revoked projects / retention shifts) are observed; a short gap or
       // a rejoin storm keeps the delta cursors, which already merge
@@ -625,6 +634,7 @@ export function useOrg2CloudRealtime(): void {
       bumpChannelMessagesVersion(orgId);
     },
     [
+      armCoarseSignalSafetyNet,
       bumpRemoteSessionsVersion,
       bumpOrgCommentsSignal,
       bumpActiveSessionCommentsSignal,
@@ -881,6 +891,12 @@ export function useOrg2CloudRealtime(): void {
         // status while suppressing normal CLOSED teardown. Do not duplicate
         // that diagnostic here from the lossy boolean edge.
         if (!subscribed) return;
+        // The 0005 path previously logged NOTHING on success — "is realtime
+        // up" was unanswerable from logs (legacy postgres_changes logs its
+        // subscribe at the same spot). One line per true-edge, like legacy.
+        log.info(
+          `realtime: org broadcast channel subscribed for active org ${orgId}`
+        );
         bumpRosterVersion(orgId);
         runSignalEdgeRecovery(orgId);
       },

--- a/src/features/TeamCollaboration/engine/collabSegmentPlanning.ts
+++ b/src/features/TeamCollaboration/engine/collabSegmentPlanning.ts
@@ -223,17 +223,42 @@ export function computeFrozenEventCount(
   const lastCreatedAt = Date.parse(events[events.length - 1]?.createdAt ?? "");
   const sessionStillAppending =
     Number.isFinite(lastCreatedAt) && lastCreatedAt >= horizonFloor;
-  if (sessionStillAppending) {
-    const pendingScanFloor = Math.max(
-      0,
-      events.length - FREEZE_PENDING_TOOL_MAX_HOLDBACK_EVENTS
-    );
-    for (let index = pendingScanFloor; index < line; index += 1) {
-      if (isUnresolvedToolCallStart(events[index])) {
-        line = index;
-        break;
-      }
+  const holdbackScanFloor = Math.max(
+    0,
+    events.length - FREEZE_PENDING_TOOL_MAX_HOLDBACK_EVENTS
+  );
+  // Position-unstable trailing events must never freeze. Some reader-emitted
+  // chunks FLOAT at the stream end (observed: a synthetic task_create pinned
+  // at count-2 whose positional seq — embedded in the event id — shifts on
+  // every append); freezing one guarantees a chain mismatch on the next read
+  // while the file grows, which is exactly the every-pass epoch-rewrite
+  // bleed. Floaters betray themselves by timestamp inversion: an event
+  // created long before the maximum createdAt already seen upstream is
+  // sitting far from its chronological position. The horizon-sized slack
+  // keeps ms-level interleaving inversions (parallel writers, clock jitter)
+  // from triggering. This holdback applies even to quiescent sessions — a
+  // floater frozen while quiet would still move (and pay a rewrite) on the
+  // next reactivation append.
+  let maxSeenCreatedAtMs = 0;
+  for (let index = 0; index < holdbackScanFloor; index += 1) {
+    const t = Date.parse(events[index]?.createdAt ?? "");
+    if (Number.isFinite(t) && t > maxSeenCreatedAtMs) maxSeenCreatedAtMs = t;
+  }
+  for (let index = holdbackScanFloor; index < line; index += 1) {
+    const event = events[index];
+    const t = Date.parse(event?.createdAt ?? "");
+    const floating =
+      Number.isFinite(t) &&
+      maxSeenCreatedAtMs > 0 &&
+      t < maxSeenCreatedAtMs - FREEZE_MUTATION_HORIZON_MS;
+    if (
+      floating ||
+      (sessionStillAppending && isUnresolvedToolCallStart(event))
+    ) {
+      line = index;
+      break;
     }
+    if (Number.isFinite(t) && t > maxSeenCreatedAtMs) maxSeenCreatedAtMs = t;
   }
   let held = 0;
   while (line > 0 && held < FREEZE_HORIZON_MAX_EVENTS) {

--- a/src/features/TeamCollaboration/engine/collabSegmentPlanning.ts
+++ b/src/features/TeamCollaboration/engine/collabSegmentPlanning.ts
@@ -169,6 +169,39 @@ const FREEZE_MUTATION_HORIZON_MS = 10 * 60_000;
  * beyond this cap freeze even while the session is live. */
 const FREEZE_HORIZON_MAX_EVENTS = 40;
 
+/**
+ * Rust stamps an unpaired tool_call start (no result chunk in the file yet)
+ * as "completed" so historical sessions never render a permanent spinner
+ * (`infer_display_status`, normalizer.rs). That stamp is a UI kindness, not
+ * an immutability proof: when the result lands in a later scan,
+ * `merge_tool_call_pairs` rewrites the START event in place (args and result
+ * fuse, the end chunk vanishes, later indices shift). Freezing such an event
+ * turns every late tool completion into a full O(total) epoch rewrite —
+ * background shells, subagents, and task notifications routinely complete
+ * tens of minutes and dozens of events after their start, far beyond the
+ * mutation horizon; live external-history sessions paid one rewrite per boot
+ * this way (diagnosed 2026-08-07 on real transcripts). While the session is
+ * still appending, the freeze line therefore stops at the first unresolved
+ * pairing. A quiescent session freezes through them: results only arrive
+ * while the file is growing, so its orphans are permanent. The cap bounds
+ * the holdback so one abandoned call inside a busy live session cannot pin
+ * the line into quadratic tail re-uploads — deeper orphans freeze, and a
+ * late completion there pays the (rare) epoch rewrite as before.
+ */
+const FREEZE_PENDING_TOOL_MAX_HOLDBACK_EVENTS = 200;
+
+/** A tool-call start whose pairing merge may still arrive (mirrors the Rust
+ * merger's `is_tool_call_start`: call identity present, result still empty). */
+function isUnresolvedToolCallStart(event: SessionEvent): boolean {
+  const isToolCallLike =
+    event.actionType === "tool_call" ||
+    (typeof event.callId === "string" && event.callId.length > 0);
+  if (!isToolCallLike) return false;
+  const result = event.result as Record<string, unknown> | null | undefined;
+  if (result == null) return true;
+  return Object.keys(result).length === 0;
+}
+
 export function computeFrozenEventCount(
   events: SessionEvent[],
   nowMs: number = Date.now()
@@ -187,6 +220,21 @@ export function computeFrozenEventCount(
     }
   }
   const horizonFloor = nowMs - FREEZE_MUTATION_HORIZON_MS;
+  const lastCreatedAt = Date.parse(events[events.length - 1]?.createdAt ?? "");
+  const sessionStillAppending =
+    Number.isFinite(lastCreatedAt) && lastCreatedAt >= horizonFloor;
+  if (sessionStillAppending) {
+    const pendingScanFloor = Math.max(
+      0,
+      events.length - FREEZE_PENDING_TOOL_MAX_HOLDBACK_EVENTS
+    );
+    for (let index = pendingScanFloor; index < line; index += 1) {
+      if (isUnresolvedToolCallStart(events[index])) {
+        line = index;
+        break;
+      }
+    }
+  }
   let held = 0;
   while (line > 0 && held < FREEZE_HORIZON_MAX_EVENTS) {
     // Only a PROVABLY recent event is held back; a missing/invalid

--- a/src/features/TeamCollaboration/engine/collabSyncEngineHelpers.test.ts
+++ b/src/features/TeamCollaboration/engine/collabSyncEngineHelpers.test.ts
@@ -169,6 +169,87 @@ describe("computeFrozenEventCount frozen line + stuck-sentinel skip-over", () =>
     expect(computeFrozenEventCount(events, now)).toBe(20);
   });
 
+  function unresolvedToolStart(createdAt: string): SessionEvent {
+    // Rust stamps unpaired starts "completed" (orphan kindness); the pairing
+    // merge can still land and rewrite this event in place.
+    return event({
+      functionName: "run_shell",
+      uiCanonical: "run_shell",
+      actionType: "tool_call",
+      callId: "call-bg-1",
+      args: { command: "sleep 600" },
+      result: {},
+      displayStatus: "completed",
+      createdAt,
+    });
+  }
+
+  it("holds the freeze line at an unresolved tool start while the session is appending", () => {
+    const now = Date.parse("2026-07-25T12:00:00Z");
+    const old = "2026-07-25T11:00:00Z";
+    const events = [
+      event({ createdAt: old }),
+      unresolvedToolStart(old),
+      event({ createdAt: old }),
+      event({ createdAt: "2026-07-25T11:55:00Z" }),
+    ];
+    expect(computeFrozenEventCount(events, now)).toBe(1);
+  });
+
+  it("treats a null result like an empty one for pairing detection", () => {
+    const now = Date.parse("2026-07-25T12:00:00Z");
+    const old = "2026-07-25T11:00:00Z";
+    const events = [
+      event({
+        actionType: "tool_call",
+        result: null as never,
+        createdAt: old,
+      }),
+      event({ createdAt: "2026-07-25T11:55:00Z" }),
+    ];
+    expect(computeFrozenEventCount(events, now)).toBe(0);
+  });
+
+  it("freezes through unresolved tool starts once the session is quiescent", () => {
+    const now = Date.parse("2026-07-25T12:00:00Z");
+    const old = "2026-07-25T11:00:00Z";
+    const events = [
+      event({ createdAt: old }),
+      unresolvedToolStart(old),
+      event({ createdAt: old }),
+    ];
+    expect(computeFrozenEventCount(events, now)).toBe(3);
+  });
+
+  it("does not hold the line for a tool call whose pairing already merged", () => {
+    const now = Date.parse("2026-07-25T12:00:00Z");
+    const old = "2026-07-25T11:00:00Z";
+    const events = [
+      event({ createdAt: old }),
+      event({
+        actionType: "tool_call",
+        callId: "call-bg-1",
+        args: { command: "echo hi" },
+        result: { content: "hi" },
+        createdAt: old,
+      }),
+      event({ createdAt: old }),
+      event({ createdAt: "2026-07-25T11:55:00Z" }),
+    ];
+    expect(computeFrozenEventCount(events, now)).toBe(3);
+  });
+
+  it("bounds unresolved-start holdback so a deep abandoned call cannot pin a live session", () => {
+    const now = Date.parse("2026-07-25T12:00:00Z");
+    const old = "2026-07-25T11:00:00Z";
+    const events = [
+      unresolvedToolStart(old),
+      ...Array.from({ length: 200 }, () => event({ createdAt: old })),
+      event({ createdAt: "2026-07-25T11:59:00Z" }),
+    ];
+    expect(computeFrozenEventCount(events, now)).toBe(201);
+  });
+
   it("counts a missing displayStatus as terminal (hash chain catches mutation)", () => {
     const events = [event({ displayStatus: undefined as never }), event({})];
     expect(computeFrozenEventCount(events)).toBe(2);

--- a/src/features/TeamCollaboration/engine/collabSyncEngineHelpers.test.ts
+++ b/src/features/TeamCollaboration/engine/collabSyncEngineHelpers.test.ts
@@ -250,6 +250,54 @@ describe("computeFrozenEventCount frozen line + stuck-sentinel skip-over", () =>
     expect(computeFrozenEventCount(events, now)).toBe(201);
   });
 
+  it("never freezes a floating trailing event sitting far before its neighbors", () => {
+    // Reader-emitted synthetic chunks float at the stream end: their
+    // createdAt is hours old but their position tracks the growing tail,
+    // so freezing one guarantees a chain mismatch on the next read.
+    const now = Date.parse("2026-07-25T12:00:00Z");
+    const events = [
+      event({ createdAt: "2026-07-25T10:00:00Z" }),
+      event({ createdAt: "2026-07-25T10:30:00Z" }),
+      event({ createdAt: "2026-07-25T11:00:00Z" }),
+      event({
+        functionName: "task_create",
+        createdAt: "2026-07-25T08:00:00Z",
+        result: { status: "created" },
+      }),
+      event({ createdAt: "2026-07-25T11:55:00Z" }),
+    ];
+    expect(computeFrozenEventCount(events, now)).toBe(3);
+  });
+
+  it("holds a floater back even when the session is quiescent", () => {
+    // A floater frozen while the session sleeps still moves (and pays an
+    // epoch rewrite) on the next reactivation append — hold it always.
+    const now = Date.parse("2026-07-25T12:00:00Z");
+    const events = [
+      event({ createdAt: "2026-07-25T09:00:00Z" }),
+      event({ createdAt: "2026-07-25T10:00:00Z" }),
+      event({
+        functionName: "task_create",
+        createdAt: "2026-07-25T07:00:00Z",
+        result: { status: "created" },
+      }),
+      event({ createdAt: "2026-07-25T10:00:05Z" }),
+    ];
+    expect(computeFrozenEventCount(events, now)).toBe(2);
+  });
+
+  it("tolerates small timestamp inversions from interleaved writers", () => {
+    // ms/second-level inversions are normal (parallel writers, clock
+    // jitter); only horizon-scale displacement marks a floater.
+    const now = Date.parse("2026-07-25T12:00:00Z");
+    const events = [
+      event({ createdAt: "2026-07-25T11:00:10Z" }),
+      event({ createdAt: "2026-07-25T11:00:09Z" }),
+      event({ createdAt: "2026-07-25T11:00:11Z" }),
+    ];
+    expect(computeFrozenEventCount(events, now)).toBe(3);
+  });
+
   it("counts a missing displayStatus as terminal (hash chain catches mutation)", () => {
     const events = [event({ displayStatus: undefined as never }), event({})];
     expect(computeFrozenEventCount(events)).toBe(2);

--- a/src/features/TeamCollaboration/forkSession.test.ts
+++ b/src/features/TeamCollaboration/forkSession.test.ts
@@ -5,6 +5,7 @@ import { deleteSession, saveSession } from "@src/api/tauri/agent";
 import Message from "@src/components/Message";
 import { eventStoreProxy } from "@src/engines/SessionCore/core/store/EventStoreProxy";
 import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+import { org2CloudAccessSettingsAtom } from "@src/features/Org2Cloud/org2CloudAccessSettings";
 import { org2CloudOrgsAtom } from "@src/features/Org2Cloud/org2CloudOrgsAtom";
 import { COLLAB_IDENTITY_KIND } from "@src/store/collaboration/types";
 import type { RemoteTeammateSessionMetadata } from "@src/store/collaboration/types";
@@ -183,6 +184,7 @@ beforeEach(() => {
   store.set(sessionsAtom, []);
   store.set(reposAtom, []);
   store.set(org2CloudOrgsAtom, []);
+  store.set(org2CloudAccessSettingsAtom, {});
   store.set(sessionOrgTagsAtom, {});
   store.set(forkCheckoutRequestAtom, null);
   store.set(forkSessionSetupRequestAtom, null);
@@ -391,6 +393,37 @@ describe("forkTeammateSession (design §16.11 relay completion)", () => {
     expect(
       tokensForSession(store.get(sessionOrgTagsAtom), "agentsession-fork-1")
     ).toEqual(["cloud:org-1"]);
+  });
+
+  it("inherits the SOURCE's sharing level as the fork's per-session intent", async () => {
+    store.set(org2CloudOrgsAtom, [
+      { orgId: "org-1", name: "Cloud Team", role: "member" },
+    ]);
+
+    await forkTeammateSession(makeForkOptions({ accessMode: "full_replay" }));
+
+    // Without this stamp a fork in a floor=off org has no ladder entry,
+    // floors to metadata_only on the wire, and teammates can never open
+    // its replay — with no error anywhere.
+    expect(
+      store.get(org2CloudAccessSettingsAtom)["org-1"]?.sessionModes?.[
+        "agentsession-fork-1"
+      ]
+    ).toBe("full_replay");
+  });
+
+  it("stamps no sharing level when the source row carries none", async () => {
+    store.set(org2CloudOrgsAtom, [
+      { orgId: "org-1", name: "Cloud Team", role: "member" },
+    ]);
+
+    await forkTeammateSession(makeForkOptions({ accessMode: undefined }));
+
+    expect(
+      store.get(org2CloudAccessSettingsAtom)["org-1"]?.sessionModes?.[
+        "agentsession-fork-1"
+      ]
+    ).toBeUndefined();
   });
 
   it("NEVER auto-tags a GUEST (share-token) fork to the owner's org", async () => {

--- a/src/features/TeamCollaboration/forkSession.ts
+++ b/src/features/TeamCollaboration/forkSession.ts
@@ -43,6 +43,10 @@ import type { SessionMeta } from "@src/api/tauri/agent";
 import Message from "@src/components/Message";
 import { eventStoreProxy } from "@src/engines/SessionCore/core/store/EventStoreProxy";
 import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+import {
+  org2CloudAccessSettingsAtom,
+  withCloudSessionMode,
+} from "@src/features/Org2Cloud/org2CloudAccessSettings";
 import { org2CloudOrgsAtom } from "@src/features/Org2Cloud/org2CloudOrgsAtom";
 import i18n from "@src/i18n";
 import type { RemoteTeammateSessionMetadata } from "@src/store/collaboration/types";
@@ -574,6 +578,22 @@ export async function forkTeammateSession(
       store.set(sessionOrgTagsAtom, (current) =>
         withTag(current, result.localSessionId, cloudOrgToken(orgId))
       );
+      // Inherit the SOURCE's sharing level as the fork's explicit per-session
+      // intent. Without it, a fork in a floor=off org has no ladder entry and
+      // silently floors to metadata_only — teammates see the fork row but can
+      // never open its replay, and nobody errors (the "defaults silently
+      // degrading shares" escape class). The stamp is just the default the
+      // per-session dialog would show; the user can change it there.
+      if (remoteSession.accessMode) {
+        store.set(org2CloudAccessSettingsAtom, (current) =>
+          withCloudSessionMode(
+            current,
+            orgId,
+            result.localSessionId,
+            remoteSession.accessMode ?? null
+          )
+        );
+      }
     }
     if (workspaceRepoPath === null && !hasWorkspaceOverride) {
       // Non-blocking: the fork opened fine, it just has no workspace until

--- a/src/hooks/logger/useLogger.test.ts
+++ b/src/hooks/logger/useLogger.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, it } from "vitest";
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { isTauriRuntimeHost } from "./useLogger";
+
+const invokeMock = vi.hoisted(() => vi.fn());
+vi.mock("@tauri-apps/api/core", () => ({ invoke: invokeMock }));
 
 describe("isTauriRuntimeHost", () => {
   it("recognizes the Tauri v2 runtime marker", () => {
@@ -10,5 +14,78 @@ describe("isTauriRuntimeHost", () => {
   it("does not depend on the removed Tauri v1 global", () => {
     expect(isTauriRuntimeHost({ __TAURI__: {} })).toBe(false);
     expect(isTauriRuntimeHost(undefined)).toBe(false);
+  });
+});
+
+describe("backend log persistence latch", () => {
+  // The shared vitest setup transitively imports this module before any
+  // test-file mock can apply, freezing a logger bound to the REAL invoke.
+  // A fresh module graph per suite gets one bound to the mock instead.
+  let mod: typeof import("./useLogger");
+  let log: import("./useLogger").Logger;
+  let RETRY_MS: number;
+  const backendCalls = () =>
+    invokeMock.mock.calls.filter(([cmd]) => cmd === "write_frontend_log");
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    invokeMock.mockReset();
+    vi.resetModules();
+    (globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+    mod = await import("./useLogger");
+    mod.__resetLogBackendStateForTests();
+    log = mod.createLogger("LatchTest");
+    RETRY_MS = mod.LOG_BACKEND_TRANSIENT_RETRY_MS;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("keeps writing after a transient transport failure (short cooldown only)", async () => {
+    // One "Failed to fetch" — the IPC custom-protocol → postMessage
+    // switchover signature — must NOT kill file logging for the process.
+    invokeMock.mockRejectedValueOnce(new TypeError("Failed to fetch"));
+    invokeMock.mockResolvedValue(undefined);
+
+    log.info("line during the blip");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(backendCalls()).toHaveLength(1);
+
+    // Inside the cooldown: lines are dropped without touching the bridge.
+    log.info("line inside cooldown");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(backendCalls()).toHaveLength(1);
+
+    // After the cooldown: persistence resumes.
+    await vi.advanceTimersByTimeAsync(RETRY_MS + 1);
+    log.info("line after cooldown");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(backendCalls()).toHaveLength(2);
+  });
+
+  it("latches permanently only when the command does not exist", async () => {
+    invokeMock.mockRejectedValue(
+      new Error("Command write_frontend_log not found")
+    );
+
+    log.info("first line");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(backendCalls()).toHaveLength(1);
+
+    // Far beyond any cooldown: still latched — the command will never appear
+    // in this process.
+    await vi.advanceTimersByTimeAsync(10 * RETRY_MS);
+    log.info("later line");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(backendCalls()).toHaveLength(1);
+  });
+
+  it("persists every line while the bridge is healthy", async () => {
+    invokeMock.mockResolvedValue(undefined);
+    log.info("one");
+    log.warn("two");
+    await vi.advanceTimersByTimeAsync(0);
+    expect(backendCalls()).toHaveLength(2);
   });
 });

--- a/src/hooks/logger/useLogger.ts
+++ b/src/hooks/logger/useLogger.ts
@@ -107,8 +107,15 @@ export function isTauriRuntimeHost(value: unknown): boolean {
   );
 }
 
-const isTauriRuntime =
-  typeof window !== "undefined" && isTauriRuntimeHost(window);
+// Lazily cached: the Tauri marker exists before any page script runs in the
+// webview, but import order must not freeze a false negative (test setups
+// import this module transitively before their environment stubs run).
+let tauriRuntimeCached: boolean | null = null;
+function isTauriRuntime(): boolean {
+  tauriRuntimeCached ??=
+    typeof window !== "undefined" && isTauriRuntimeHost(window);
+  return tauriRuntimeCached;
+}
 const isDev = process.env.NODE_ENV === "development";
 const forceDebugFromUrl =
   typeof window !== "undefined" &&
@@ -187,18 +194,42 @@ function formatArgs(args: unknown[]): string {
 // ============================================================================
 
 let backendUnavailable = false;
+let backendRetryAtMs = 0;
+
+/** Cooldown after a transient IPC failure before file logging resumes. */
+export const LOG_BACKEND_TRANSIENT_RETRY_MS = 5_000;
 
 function writeToBackend(
   level: LevelName,
   namespace: string,
   message: string
 ): void {
-  if (backendUnavailable || !isTauriRuntime) return;
-  invoke("write_frontend_log", { level, namespace, message }).catch(() => {
-    // The Rust command may not exist yet on first launch / older binary.
-    // Stop trying after the first failure so we don't spam the IPC bridge.
-    backendUnavailable = true;
-  });
+  if (backendUnavailable || !isTauriRuntime()) return;
+  if (Date.now() < backendRetryAtMs) return;
+  invoke("write_frontend_log", { level, namespace, message }).catch(
+    (error: unknown) => {
+      if (/\bcommand\b.*\bnot found\b/i.test(String(error))) {
+        // The Rust command does not exist (first launch / older binary) —
+        // that is permanent for this process, stop trying.
+        backendUnavailable = true;
+        return;
+      }
+      // Anything else is a TRANSIENT transport failure — e.g. the IPC
+      // custom-protocol → postMessage switchover throws one "Failed to
+      // fetch". Latching here killed file logging for the rest of the app's
+      // lifetime while every later invoke worked fine, which blinded every
+      // post-incident investigation. Drop this line, pause briefly, and
+      // keep the channel alive.
+      backendRetryAtMs = Date.now() + LOG_BACKEND_TRANSIENT_RETRY_MS;
+    }
+  );
+}
+
+/** Test seam: reset the backend-persistence latch/cooldown/runtime state. */
+export function __resetLogBackendStateForTests(): void {
+  backendUnavailable = false;
+  backendRetryAtMs = 0;
+  tauriRuntimeCached = null;
 }
 
 // ============================================================================


### PR DESCRIPTION
Rolling fix branch for the 2026-08-06 dual-instance session-sharing + realtime hunt (consolidated per review guidance while GitHub Actions is unstable). Three commits, each independently verified.

## Fix 1 — fix(logging): stop one transient IPC failure killing file logs

`writeToBackend` latched `backendUnavailable` on **any** invoke rejection; the one transient `Failed to fetch` thrown during Tauri's IPC custom-protocol → postMessage switchover silently killed file logging for the process lifetime. Both hunt instances went log-dark mid-investigation this way. Now: permanent latch only on `Command … not found`; other failures drop one line + 5s cooldown; Tauri-runtime gate evaluated lazily. 3 new tests.
**Real-machine verified**: rebuilt binaries kept logging through reloads and IPC degradation for the rest of the hunt.

## Fix 2 — fix(collab): inherit source sharing level on cloud fork

A cloud fork never wrote a sharing-ladder entry: in a floor=off org it floored to **metadata_only** on the wire — teammates saw the fork row but could never open its replay, nothing errored. Observed live (source full_replay/4ev → fork metadata_only/0ev). The fork now stamps the source row's access mode as its explicit per-session intent (user-editable; guest forks unstamped). 2 new tests.
**Real-machine verified end-to-end**: post-fix fork landed `full_replay`/4 events on the wire and the second instance opened the replay with the final round rendering verbatim.

## Fix 3 — fix(realtime): edge-recovery race, silent subscribe, lost-frame net

From the realtime-plane audit: (a) `runSignalEdgeRecovery` stamped the control-plane throttle + marked all coalescer planes handled **before** its hidden check — an edge racing a visibility flip claimed a recovery that never ran and muted the next one for up to 5 min; hidden check now first. (b) The 0005 broadcast path logged nothing on successful subscribe (legacy logs at the same spot) — one INFO per true-edge now. (c) Broadcast signals are at-most-once and the safety net armed only on an arriving signal — a lost frame with no follow-up never converged; the subscribe edge now arms one trailing coarse refresh per window. Plus a stale docstring (server triggers cover session-row writes too — verified empirically). Realtime suites 31/31.

## Protocol coverage for the batch

Fleet ledger (3 orgs, invariants: no epoch>1 on current-build rows; teammate old-build scars separately reported), two-boot determinism PASS, receiver-depth on source AND fork PASS, idle resource curves PASS. UNCOVERED (recorded): guest fork, /compact mid-share, real-OS focus-event reliability, broadcast frame-loss injection.

## Fix 4 — fix(sync): minimize-aware lease + hold freeze line at pending tools

Both from closing the previously-UNCOVERED cells on real hardware (2026-08-07).

**4a — Windows minimize left the lease's immediate-release branch unreachable.** Windows/WebView2 never flips `document.visibilityState` to `hidden` on minimize (verified with real `ShowWindow(SW_MINIMIZE)` OS events), so a minimized window held its billable realtime socket for the full 45s blur grace instead of releasing immediately. A minimize bridge now tracks OS-level minimize through the Tauri window handle — async probe on blur, synchronous clear on focus, generation guard so a stale probe from a rapid minimize→restore can never release a re-focused lease. 4 new tests.

**4b — the freeze planner froze unpaired tool_call starts, making every late tool completion a full epoch rewrite.** Root cause of the "epoch rewrite on every boot" ledger scars, pinned by discriminator: byte-identical static transcript + reboot → no rewrite; `touch -m` + two forced passes → no rewrite; all 8 historical rewrites coincided with file growth; merger reassembly is index-deterministic. Mechanism: Rust stamps an unpaired start `completed` (orphan spinner kindness), the planner froze it, then the result chunk landed in a later scan and `merge_tool_call_pairs` rewrote the start event in place (content + index shift) → chain mismatch → O(total) re-upload. Background shells/subagents/task notifications routinely complete far beyond the 10-min horizon. Now: while the session is still appending, the freeze line stops at the first unresolved pairing (200-event cap so an abandoned call cannot pin a live session into quadratic tail re-uploads); quiescent sessions freeze through permanent orphans unchanged. 5 new tests; one transitional epoch rewrite per already-frozen session is expected on first pass after upgrade.

## Uncovered-cell closure (all PASS, real machine)

- **U1 real-OS focus**: real minimize/restore events; hasFocus propagates correctly; found the minimize≠hidden gap → Fix 4a. Lease release proven via subscribe-line count.
- **U2 stale-token dead-join**: corrupted persisted accessToken + reload → boot restores last-good token from the Rust shared-auth store before the join path ever sees it; subscribe succeeds same second as focus, zero CHANNEL_ERROR.
- **U3 ≥5min full recovery**: 6m40s lease gap → recovery battery is full listings (no delta cursors) + entitlement refresh; channel rebuilt (subscribe count 5→6); post-recovery delta correctly ordered after.
- **U4 lost-frame net**: exactly one trailing coarse wave at signal+5min, then silence.
- **Guest fork (link share)**: non-member resolve via JWT+token, import lands untagged in Personal, unstamped, zero push-back, replay renders; share revoked after.
- **/compact mid-share**: organically covered by the live transcripts' in-place compactions; their cloud rows survived — the epoch-rewrite cost they exposed is Fix 4b.

### Fix 4b addendum — the real bleed was a position-floating synthetic chunk

The pending-pair holdback alone did NOT stop the per-pass rewrites (falsified on real hardware: #12/#13 landed on the fixed build). Two normalized-event snapshots 66 minutes apart (CDP → `claude_code_history_chunks` + `es_process_chunks`, per-event digests) pinned it: the entire prefix below one event was byte-stable across an hour of growth, while a single reader-emitted synthetic `task_create` chunk floats at count-2 forever — createdAt hours old, positional seq (embedded in the event id) shifting on every append. Frozen once (its old createdAt sails past the 10-min horizon), it moves by the next read → chain mismatch → O(total) epoch rewrite, every 10-minute pass. Timestamp-inversion detection over the trailing window flagged exactly this one event in 1426 (zero false positives). The freeze line now also stops at any trailing event displaced more than the horizon before the running createdAt maximum, quiescent or not; ms-level interleaving inversions freeze normally.
