### PR TITLE
fix(claude): show distinct subagent session titles

### DIFF
--- a/src-tauri/crates/orgtrack-core/src/sources/claude_code/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/claude_code/history.rs
@@ -40,7 +40,9 @@ const CLAUDE_CODE_PROVIDER_SLUG: &str = "claudecode";
 // surface as data-URL attachments on the user bubble.
 // v11: capture compact-boundary ancestry markers so continuation families
 // survive Claude Code rewriting the first user message during compaction.
-const CLAUDE_CODE_METADATA_PARSER_VERSION: i64 = 11;
+// v12: name subagent rows from their small `.meta.json` sidecar instead of
+// the shared beginning of each child prompt.
+const CLAUDE_CODE_METADATA_PARSER_VERSION: i64 = 12;
 const MAX_COMPACT_BOUNDARY_MARKERS: usize = imported_cache::MAX_CONTINUATION_MARKERS - 1;
 
 pub type ClaudeCodeHistorySessionRow = ImportedHistorySessionRow;
@@ -187,6 +189,12 @@ struct ClaudeSessionMetadataFile {
     name: String,
     #[serde(default)]
     name_source: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClaudeSubagentMetadataFile {
+    #[serde(default)]
+    description: String,
 }
 
 #[derive(Debug, Clone)]
@@ -778,7 +786,10 @@ fn discover_claude_code_history_records(
             };
             let (source_mtime_ms, source_size_bytes) =
                 imported_paths::file_metadata_signature(&path, "Claude")?;
-            if let Some(title) = title_index.get(&file_stem) {
+            let subagent_title = claude_subagent_metadata_title(&path);
+            if let Some(title) = subagent_title.as_ref() {
+                external_titles.insert(file_stem.clone(), title.clone());
+            } else if let Some(title) = title_index.get(&file_stem) {
                 external_titles.insert(
                     file_stem.clone(),
                     imported_history::truncate_name(&title.name, 200),
@@ -790,7 +801,11 @@ fn discover_claude_code_history_records(
                 source_record_key: file_stem.clone(),
                 source_mtime_ms,
                 source_size_bytes,
-                source_fingerprint: claude_source_fingerprint(&file_stem, &title_index),
+                source_fingerprint: claude_source_fingerprint(
+                    &file_stem,
+                    &title_index,
+                    subagent_title.as_deref(),
+                ),
                 parser_version: CLAUDE_CODE_METADATA_PARSER_VERSION,
             });
         }
@@ -817,6 +832,22 @@ fn is_claude_workflow_journal_path(path: &Path) -> bool {
     components
         .windows(2)
         .any(|pair| pair == ["subagents", "workflows"])
+}
+
+fn claude_subagent_metadata_title(path: &Path) -> Option<String> {
+    if !path
+        .ancestors()
+        .any(|ancestor| ancestor.file_name().and_then(|name| name.to_str()) == Some("subagents"))
+    {
+        return None;
+    }
+    // This file is optional Claude Code metadata. A missing, unreadable, or
+    // malformed sidecar must not prevent the transcript itself from loading.
+    let metadata_path = path.with_extension("meta.json");
+    let contents = fs::read_to_string(metadata_path).ok()?;
+    let metadata = serde_json::from_str::<ClaudeSubagentMetadataFile>(&contents).ok()?;
+    let description = metadata.description.trim();
+    (!description.is_empty()).then(|| imported_history::truncate_name(description, 200))
 }
 
 fn collect_claude_session_files(
@@ -902,7 +933,11 @@ fn load_claude_session_titles(
 fn claude_source_fingerprint(
     file_stem: &str,
     title_index: &HashMap<String, ClaudeSessionTitle>,
+    subagent_title: Option<&str>,
 ) -> String {
+    if let Some(title) = subagent_title {
+        return format!("subagent-meta:{title}");
+    }
     title_index
         .get(file_stem)
         .map(|title| {

--- a/src-tauri/crates/orgtrack-core/src/sources/claude_code/history_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/claude_code/history_tests.rs
@@ -686,6 +686,7 @@ fn maps_claude_subagent_sidechain_to_parent_session_id() {
         .expect("session meta");
 
     assert_eq!(meta.session_id, format!("claudecodeapp-{file_stem}"));
+    assert_eq!(meta.name, "explore the codebase");
     assert_eq!(
         meta.parent_session_id.as_deref(),
         Some(format!("claudecodeapp-{parent_uuid}").as_str())
@@ -699,6 +700,125 @@ fn maps_claude_subagent_sidechain_to_parent_session_id() {
     );
 
     std::fs::remove_file(&path).expect("remove fixture");
+    std::fs::remove_dir_all(&temp_dir).expect("remove temp dir");
+}
+
+#[test]
+fn prefers_claude_subagent_metadata_description_over_prompt() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-claude-subagent-title-test-{}",
+        std::process::id()
+    ));
+    std::fs::remove_dir_all(&temp_dir).ok();
+    let projects_dir = temp_dir.join("projects");
+    let parent_uuid = "59fd4d4f-d556-412f-8b56-88cb8feebb39";
+    let child_source_id = "agent-a45f5a98a73073100";
+    let child_path = projects_dir
+        .join("-Users-example-proj")
+        .join(parent_uuid)
+        .join("subagents")
+        .join(format!("{child_source_id}.jsonl"));
+    std::fs::create_dir_all(child_path.parent().expect("child parent"))
+        .expect("create subagents dir");
+    std::fs::write(
+        &child_path,
+        format!(
+            r#"{{"type":"user","isSidechain":true,"sessionId":"{parent_uuid}","timestamp":"2026-08-06T18:00:02Z","message":{{"role":"user","content":"You are auditing part of the codebase. Your domain: work service transaction boundaries."}}}}
+"#
+        ),
+    )
+    .expect("write child fixture");
+    std::fs::write(
+        child_path.with_extension("meta.json"),
+        r#"{"agentType":"general-purpose","description":"Audit work service transactions","spawnDepth":1}"#,
+    )
+    .expect("write child metadata fixture");
+
+    let previous = HashMap::new();
+    let mut walker =
+        imported_history::scan_snapshot::SnapshotDirWalker::new(&previous, "jsonl", "Claude");
+    let discovery =
+        discover_claude_code_history_records(std::slice::from_ref(&projects_dir), &mut walker)
+            .expect("discover");
+    let record = discovery
+        .records
+        .iter()
+        .find(|record| record.source_session_id == child_source_id)
+        .expect("child record");
+    let title = discovery
+        .external_titles
+        .get(child_source_id)
+        .expect("metadata title");
+    assert_eq!(title, "Audit work service transactions");
+    assert_eq!(
+        record.source_fingerprint,
+        "subagent-meta:Audit work service transactions"
+    );
+
+    let meta = parse_claude_session_meta_with_title(record, None, title.clone())
+        .expect("parse child")
+        .meta
+        .expect("child meta");
+    assert_eq!(meta.name, "Audit work service transactions");
+    assert_eq!(
+        meta.parent_session_id.as_deref(),
+        Some(format!("claudecodeapp-{parent_uuid}").as_str())
+    );
+
+    std::fs::remove_dir_all(&temp_dir).expect("remove temp dir");
+}
+
+#[test]
+fn claude_subagent_metadata_change_invalidates_fingerprint() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-claude-subagent-title-fingerprint-test-{}",
+        std::process::id()
+    ));
+    std::fs::remove_dir_all(&temp_dir).ok();
+    let projects_dir = temp_dir.join("projects");
+    let child_path = projects_dir.join("-Users-example-proj/session/subagents/agent-a1.jsonl");
+    std::fs::create_dir_all(child_path.parent().expect("child parent"))
+        .expect("create subagents dir");
+    std::fs::write(
+        &child_path,
+        r#"{"type":"user","isSidechain":true,"sessionId":"parent","timestamp":"2026-08-06T18:00:02Z","message":{"role":"user","content":"shared prompt"}}
+"#,
+    )
+    .expect("write child fixture");
+    let metadata_path = child_path.with_extension("meta.json");
+    std::fs::write(
+        &metadata_path,
+        r#"{"description":"Audit work service transactions"}"#,
+    )
+    .expect("write first metadata");
+
+    let discover = || {
+        let previous = HashMap::new();
+        let mut walker =
+            imported_history::scan_snapshot::SnapshotDirWalker::new(&previous, "jsonl", "Claude");
+        discover_claude_code_history_records(std::slice::from_ref(&projects_dir), &mut walker)
+            .expect("discover")
+    };
+    let first = discover();
+    let first_fingerprint = first.records[0].source_fingerprint.clone();
+
+    std::fs::write(
+        &metadata_path,
+        r#"{"description":"Audit product mode implementation"}"#,
+    )
+    .expect("rewrite metadata");
+    let second = discover();
+    assert_ne!(first_fingerprint, second.records[0].source_fingerprint);
+    assert_eq!(
+        second.external_titles.get("agent-a1").map(String::as_str),
+        Some("Audit product mode implementation")
+    );
+
+    std::fs::write(&metadata_path, "{malformed").expect("write malformed metadata");
+    let malformed = discover();
+    assert!(!malformed.external_titles.contains_key("agent-a1"));
+    assert!(malformed.records[0].source_fingerprint.is_empty());
+
     std::fs::remove_dir_all(&temp_dir).expect("remove temp dir");
 }
 


### PR DESCRIPTION
## Problem

Claude Code creates one real transcript and one distinct `agent-*` source id for every subagent, but ORG2 named each imported child from the beginning of its first prompt. Parallel subagents commonly share that long prompt prefix, so the sidebar truncated several distinct sessions to the same apparent title and made them look duplicated.

Claude Code already writes the intended short description beside each child transcript in `agent-*.meta.json`; the importer ignored it.

## Solution

- Prefer the child sidecar's bounded `description` as the imported subagent title while preserving the existing `agent-*` source id and parent relationship.
- Include that title in the discovery fingerprint so a sidecar that appears or changes invalidates the cached row even when the JSONL transcript is unchanged.
- Bump the Claude metadata parser to v12 so existing cached child rows are refreshed once after upgrade.
- Treat the sidecar as optional: missing, unreadable, empty, or malformed metadata falls back to the existing first-prompt title and never blocks transcript import.

The implementation reads each child's own small sidecar directly. It does not parse the parent transcript, add a cross-session mapping, or introduce retained state.

## Potential risks

- Parser v12 causes a one-time local Claude metadata reindex. The imported cache is rebuildable and no schema, wire format, or source transcript is changed; reverting this commit restores the prior naming behavior.
- Discovery performs one optional small sidecar read per subagent. Real-home measurement over 2,483 Claude records remained bounded: cold discovery was 306 ms and warm discovery was 26 ms with all 664 directories reused and none re-enumerated.
- If Claude Code removes or corrupts a sidecar, that row deliberately returns to the prior prompt-derived fallback. The transcript remains available and its identity/parenting are unchanged.

## Architecture audit

Covered provider discovery, title precedence, cache fingerprint invalidation, parser-version refresh, parent/child identity, and missing/malformed metadata fallback. The chosen ownership boundary is the child sidecar itself; parent transcript parsing and cross-session coordinator state were intentionally rejected. Replay parsing, UI component structure, cloud sync, database schema, and other providers were unchanged.

## Performance audit

- No new timer, poller, subscription, worker, retry, cache, or retained mapping.
- Work is one bounded sidecar read only for paths under a `subagents` ancestor.
- Real-home benchmark: 2,483 records; cold 306.4 ms (664 directories enumerated), warm 26.4 ms (664 reused, 0 enumerated).
- Cmd+5 after a Sessions refresh reported 0 likely polling hotspots; two `claude_code_history_stat` calls completed in 0.00 s and 0.01 s.
- Final latest-develop app sampling over 10 seconds: CPU 0.0–1.6%; RSS 263,888–263,920 KB while the real parent replay and all child rows were visible.

## Verification

- `cargo test -p orgtrack_core --lib --no-fail-fast` on latest develop — 546 passed, 8 ignored.
- `cargo clippy -p orgtrack_core --lib -- -D warnings` on latest develop — passed.
- `ORGII_BENCH_REAL_HOME=1 cargo test -p orgtrack_core bench_real_home_claude_discovery_cold_vs_warm --lib -- --ignored --nocapture` — passed with the timings above.
- `pnpm run tauri:build:fast -- --instance 47` on latest develop — full webpack + macOS bundle succeeded.
- Real Claude fixture copied into an isolated external-history home: 10 cache rows, 10 distinct source ids, 9 child rows, and 9 distinct child titles. Every child fingerprint was `subagent-meta:<description>|managed=0`.
- Real UI expansion showed all nine distinct titles, including `Explore Multica server domain`, `Explore Multica daemon runtime`, `Audit CLI and frozen contract`, and `Audit work service transactions`.
- Restarted the isolated app and expanded the parent again; all nine child titles remained distinct.
- Missing and malformed sidecars are covered by unit tests and fall back without failing discovery.
- `git diff --check upstream/develop...HEAD` — passed.

## UI evidence

The final screenshot is saved locally at `/Users/vinceorz/Desktop/Claude-subagent-distinct-titles-final.jpeg`. It is not attached because it contains a real private transcript in the main pane; the exact nine accessibility-row labels and the 10-id/9-title SQLite result were recorded during verification. This PR changes provider-derived copy only and does not alter UI layout or styling.

## Security and scope

The diff contains only the Claude importer and its tests. It includes no credentials, personal filesystem paths, private fixture content, generated build output, dependency changes, or unrelated formatting.
