### PR TITLE
feat(updater): add update-now action to update-available toast

### DIFF
--- a/src/scaffold/AppUpdater/index.test.ts
+++ b/src/scaffold/AppUpdater/index.test.ts
@@ -197,6 +197,27 @@ describe("AppUpdater", () => {
     );
   });
 
+  it("offers an update-now action on the available-update notice", async () => {
+    const update = createUpdate();
+    mocks.check.mockResolvedValue(update);
+
+    await checkForUpdatesManually();
+
+    const checkNotices = mocks.messageInfo.mock.calls
+      .filter(([message]) => message?.id === "app-update-check")
+      .map(([message]) => message);
+    const availableNotice = checkNotices[checkNotices.length - 1];
+
+    expect(availableNotice).toEqual(
+      expect.objectContaining({
+        title: "Update available",
+        content: "Version 1.1.22 is ready to install.",
+        action: expect.objectContaining({ label: "Update now" }),
+      })
+    );
+    expect(typeof availableNotice?.action?.onClick).toBe("function");
+  });
+
   it("clears a stale available update after a failed manual check", async () => {
     const update = createUpdate();
     mocks.check

--- a/src/scaffold/AppUpdater/index.tsx
+++ b/src/scaffold/AppUpdater/index.tsx
@@ -172,6 +172,10 @@ function notifyCheckSuccess(
       title: "Update available",
       content: `Version ${update.version} is ready to install.`,
       duration: UPDATE_TOAST_DURATION_MS,
+      action: {
+        label: "Update now",
+        onClick: () => void installAvailableAppUpdate(),
+      },
     });
     return;
   }


### PR DESCRIPTION
## Problem

When users click "Check for updates" in Settings and a new version is available, the bottom-right toast only informs them that a new version exists ("Version X is ready to install.") with no way to act on it. Users must then hunt for the update entry point elsewhere (the sidebar update button), which is not discoverable — the toast that announced the update offers no path forward.

## Solution

Add a primary `action` button ("Update now") to the update-available toast in `notifyCheckSuccess` (`src/scaffold/AppUpdater/index.tsx`). Clicking it calls the already-exported `installAvailableAppUpdate()` — the same entry point the sidebar update button uses (`SidebarUpdateButton.tsx`), so both paths stay consistent.

The button reuses the existing, Windows-aware install flow: download (with progress toast) → "Install and restart" confirmation modal → install + relaunch. The two-step download/confirm split is intentional (installing can terminate the app on Windows), so this change introduces no new platform behavior.

The `Message` component already supported an `action` field (used elsewhere); this change simply populates it.

## Potential risks

- **No new platform-specific behavior**: the toast render path and the reused install entry point contain no OS branching. The actual install/relaunch mechanism remains owned by `@tauri-apps/plugin-updater`, unchanged by this PR.
- **Behavioral consistency**: the "Update now" action defaults to `closeOnClick: true` (Message component default), so clicking it dismisses the toast and immediately starts the download — identical to the sidebar button but with an added auto-dismiss of the announcing toast. This is the intended UX.
- **i18n**: the toast copy ("Update available", "Update now", "Version X is ready to install.") remains hardcoded English, matching all other AppUpdater toast strings, which are not yet i18n-keyed. Localizing these strings is out of scope for this single-concern change.

## Verification

- `npx eslint src/scaffold/AppUpdater/index.tsx src/scaffold/AppUpdater/index.test.ts` → exit 0.
- Pre-commit hooks passed on commit (lint-staged: eslint --fix + prettier --write; scoped TypeScript type check; circular-dependency check).
- `pnpm vitest run src/scaffold/AppUpdater/index.test.ts`:
  - New test `offers an update-now action on the available-update notice` → **passes** (asserts the toast carries `action: { label: "Update now" }` with a function `onClick`).
  - 6 other tests fail, but these are **pre-existing failures on the `develop` baseline** (confirmed via `git stash` + baseline rerun): root cause is a test-infrastructure defect where `index.test.ts` stubs a partial `window.localStorage` that poisons later tests' `clearSkippedUpdateVersion` calls. This PR does not touch that path and the failure count is identical with/without these changes. Fixing the test infrastructure is a separate concern.
- Cross-platform: source-level analysis confirms no OS branching in the changed path; the reused install flow was already adapted for Windows. Not manually run on Windows/Linux (no behavior change introduced by this PR beyond surfacing an existing function from a new button).
