### PR TITLE
feat(chat-pane): gate Station access by tab and viewport

### DIFF
--- a/docs/frontend-ui-audit-2026-08-08/ChatPanelStationAvailability.md
+++ b/docs/frontend-ui-audit-2026-08-08/ChatPanelStationAvailability.md
@@ -23,7 +23,7 @@
 | ------------------------------- | ---------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
 | `ChatPanelHeader.tsx:266–270`   | Station/maximize icons       | keep with reason | Both icons continue to consume the shared `HEADER_ICON_SIZE.md` token and inherit the design-system button color states.                              | —                |
 | `TabLabelRowScrim/index.tsx:13` | Close-control scrim gradient | keep with reason | The fade continues to use the established `fill-2` surface token and transparent edge; only its mount/opacity lifecycle changes.                      | —                |
-| `chatPanelTabsModel.ts:130`     | Wide Station breakpoint      | keep with reason | The `1600px` product breakpoint is exposed as one named constant and consumed by the shared availability resolver, not repeated in component classes. | —                |
+| `chatPanelTabsModel.ts:130`     | Wide Station breakpoint      | keep with reason | The `1920px` product breakpoint is exposed as one named constant and consumed by the shared availability resolver, not repeated in component classes. | —                |
 
 ## D4 — Accessibility
 
@@ -36,7 +36,7 @@
 - Pattern: every Chat Panel tab keeps the trailing layout control in the same header position, avoiding tab-dependent toolbar shifts.
 - Pattern: disabled Station access uses the shared button's native disabled treatment rather than adding a one-off color or opacity class.
 - Pattern: full-screen ownership is derived from the active tab capability; the header and workbench layout consume the same decision.
-- Pattern: standalone tabs unlock Station splitting only at the shared `1600px` wide-desktop threshold; conversation tabs keep their existing behavior.
+- Pattern: standalone tabs unlock Station splitting only at the shared `1920px` wide-desktop threshold; conversation tabs keep their existing behavior.
 - Pattern: one parent viewport subscription feeds AppShell, AppLayout, and ChatPanel instead of adding parallel resize listeners; resize bursts are coalesced to one update per animation frame and pending work is canceled on unmount.
 - Pattern: narrow-layout focus owns one `ResizeObserver`; at idle it observes only the stable main-content width and adds the animated workbench target only during a direct divider drag.
 - Pattern: tab and close-control hover layers now share the same transition duration, preventing the scrim from flashing ahead of the tab surface.

--- a/docs/frontend-ui-audit-2026-08-08/ChatPanelStationAvailability.md
+++ b/docs/frontend-ui-audit-2026-08-08/ChatPanelStationAvailability.md
@@ -37,7 +37,8 @@
 - Pattern: disabled Station access uses the shared button's native disabled treatment rather than adding a one-off color or opacity class.
 - Pattern: full-screen ownership is derived from the active tab capability; the header and workbench layout consume the same decision.
 - Pattern: standalone tabs unlock Station splitting only at the shared `1600px` wide-desktop threshold; conversation tabs keep their existing behavior.
-- Pattern: one parent viewport subscription feeds AppShell, AppLayout, and ChatPanel instead of adding parallel resize listeners.
+- Pattern: one parent viewport subscription feeds AppShell, AppLayout, and ChatPanel instead of adding parallel resize listeners; resize bursts are coalesced to one update per animation frame and pending work is canceled on unmount.
+- Pattern: narrow-layout focus owns one `ResizeObserver`; at idle it observes only the stable main-content width and adds the animated workbench target only during a direct divider drag.
 - Pattern: tab and close-control hover layers now share the same transition duration, preventing the scrim from flashing ahead of the tab surface.
 
 ## Summary

--- a/docs/frontend-ui-audit-2026-08-08/ChatPanelStationAvailability.md
+++ b/docs/frontend-ui-audit-2026-08-08/ChatPanelStationAvailability.md
@@ -23,7 +23,7 @@
 | ------------------------------- | ---------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
 | `ChatPanelHeader.tsx:266–270`   | Station/maximize icons       | keep with reason | Both icons continue to consume the shared `HEADER_ICON_SIZE.md` token and inherit the design-system button color states.                              | —                |
 | `TabLabelRowScrim/index.tsx:13` | Close-control scrim gradient | keep with reason | The fade continues to use the established `fill-2` surface token and transparent edge; only its mount/opacity lifecycle changes.                      | —                |
-| `chatPanelTabsModel.ts:130`     | Wide Station breakpoint      | keep with reason | The `1440px` product breakpoint is exposed as one named constant and consumed by the shared availability resolver, not repeated in component classes. | —                |
+| `chatPanelTabsModel.ts:130`     | Wide Station breakpoint      | keep with reason | The `1600px` product breakpoint is exposed as one named constant and consumed by the shared availability resolver, not repeated in component classes. | —                |
 
 ## D4 — Accessibility
 
@@ -36,7 +36,7 @@
 - Pattern: every Chat Panel tab keeps the trailing layout control in the same header position, avoiding tab-dependent toolbar shifts.
 - Pattern: disabled Station access uses the shared button's native disabled treatment rather than adding a one-off color or opacity class.
 - Pattern: full-screen ownership is derived from the active tab capability; the header and workbench layout consume the same decision.
-- Pattern: standalone tabs unlock Station splitting only at the shared `1440px` wide-desktop threshold; conversation tabs keep their existing behavior.
+- Pattern: standalone tabs unlock Station splitting only at the shared `1600px` wide-desktop threshold; conversation tabs keep their existing behavior.
 - Pattern: one parent viewport subscription feeds AppShell, AppLayout, and ChatPanel instead of adding parallel resize listeners.
 - Pattern: tab and close-control hover layers now share the same transition duration, preventing the scrim from flashing ahead of the tab surface.
 

--- a/docs/frontend-ui-audit-2026-08-08/ChatPanelStationAvailability.md
+++ b/docs/frontend-ui-audit-2026-08-08/ChatPanelStationAvailability.md
@@ -1,6 +1,6 @@
 # Frontend UI Audit — Chat Panel Station Availability
 
-**Files:** `src/engines/ChatPanel/ChatPanelHeader.tsx`, `src/engines/ChatPanel/index.tsx`, `src/modules/index.tsx`, `src/modules/WorkStation/shared/TabBar/components/TabLabelRowScrim/index.tsx`
+**Files:** `src/engines/ChatPanel/ChatPanelHeader.tsx`, `src/engines/ChatPanel/index.tsx`, `src/modules/index.tsx`, `src/modules/shared/layouts/AppLayout.tsx`, `src/modules/WorkStation/shared/TabBar/components/TabLabelRowScrim/index.tsx`
 **Date:** 2026-08-08
 **Auditor:** Codex
 
@@ -19,10 +19,11 @@
 
 ## D3 — Hardcoded Sizes / Colors
 
-| Line                            | Value                        | Verdict          | Reason                                                                                                                           | Suggested change |
-| ------------------------------- | ---------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| `ChatPanelHeader.tsx:266–270`   | Station/maximize icons       | keep with reason | Both icons continue to consume the shared `HEADER_ICON_SIZE.md` token and inherit the design-system button color states.         | —                |
-| `TabLabelRowScrim/index.tsx:13` | Close-control scrim gradient | keep with reason | The fade continues to use the established `fill-2` surface token and transparent edge; only its mount/opacity lifecycle changes. | —                |
+| Line                            | Value                        | Verdict          | Reason                                                                                                                                                | Suggested change |
+| ------------------------------- | ---------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `ChatPanelHeader.tsx:266–270`   | Station/maximize icons       | keep with reason | Both icons continue to consume the shared `HEADER_ICON_SIZE.md` token and inherit the design-system button color states.                              | —                |
+| `TabLabelRowScrim/index.tsx:13` | Close-control scrim gradient | keep with reason | The fade continues to use the established `fill-2` surface token and transparent edge; only its mount/opacity lifecycle changes.                      | —                |
+| `chatPanelTabsModel.ts:130`     | Wide Station breakpoint      | keep with reason | The `1440px` product breakpoint is exposed as one named constant and consumed by the shared availability resolver, not repeated in component classes. | —                |
 
 ## D4 — Accessibility
 
@@ -35,10 +36,12 @@
 - Pattern: every Chat Panel tab keeps the trailing layout control in the same header position, avoiding tab-dependent toolbar shifts.
 - Pattern: disabled Station access uses the shared button's native disabled treatment rather than adding a one-off color or opacity class.
 - Pattern: full-screen ownership is derived from the active tab capability; the header and workbench layout consume the same decision.
+- Pattern: standalone tabs unlock Station splitting only at the shared `1440px` wide-desktop threshold; conversation tabs keep their existing behavior.
+- Pattern: one parent viewport subscription feeds AppShell, AppLayout, and ChatPanel instead of adding parallel resize listeners.
 - Pattern: tab and close-control hover layers now share the same transition duration, preventing the scrim from flashing ahead of the tab surface.
 
 ## Summary
 
 - 1 fix applied
-- 5 kept with documented reason
+- 6 kept with documented reason
 - 0 abstract candidates (>= 3 occurrences)

--- a/docs/frontend-ui-audit-2026-08-08/ChatPanelStationAvailability.md
+++ b/docs/frontend-ui-audit-2026-08-08/ChatPanelStationAvailability.md
@@ -1,0 +1,44 @@
+# Frontend UI Audit — Chat Panel Station Availability
+
+**Files:** `src/engines/ChatPanel/ChatPanelHeader.tsx`, `src/engines/ChatPanel/index.tsx`, `src/modules/index.tsx`, `src/modules/WorkStation/shared/TabBar/components/TabLabelRowScrim/index.tsx`
+**Date:** 2026-08-08
+**Auditor:** Codex
+
+## D1 — Raw HTML vs Design System
+
+| Line                          | Element                            | Verdict          | Reason                                                                                                                                       | Suggested change |
+| ----------------------------- | ---------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `ChatPanelHeader.tsx:257–272` | Station toggle wrapper and control | keep with reason | The wrapper only owns inline layout; the interactive control continues to use the shared `TabBarTrailingIconButton` and `Button` primitives. | —                |
+
+## D2 — Arbitrary Tailwind Value vs Token
+
+| Line                               | Value                            | Verdict          | Reason                                                                                                                   | Suggested change |
+| ---------------------------------- | -------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------ | ---------------- |
+| `ChatPanelHeader.tsx:252–257`      | Existing tab-bar toolbar spacing | keep with reason | The change reuses the established header height and spacing classes and introduces no arbitrary Tailwind values.         | —                |
+| `TabLabelRowScrim/index.tsx:13–15` | Hover fade timing                | keep with reason | The scrim uses the tab surface's existing `duration-150` transition timing, avoiding a one-off duration or easing value. | —                |
+
+## D3 — Hardcoded Sizes / Colors
+
+| Line                            | Value                        | Verdict          | Reason                                                                                                                           | Suggested change |
+| ------------------------------- | ---------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `ChatPanelHeader.tsx:266–270`   | Station/maximize icons       | keep with reason | Both icons continue to consume the shared `HEADER_ICON_SIZE.md` token and inherit the design-system button color states.         | —                |
+| `TabLabelRowScrim/index.tsx:13` | Close-control scrim gradient | keep with reason | The fade continues to use the established `fill-2` surface token and transparent edge; only its mount/opacity lifecycle changes. | —                |
+
+## D4 — Accessibility
+
+| Line                          | Element        | Verdict | Reason                                                                                                                               | Suggested change                                                                                             |
+| ----------------------------- | -------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `ChatPanelHeader.tsx:258–264` | Station toggle | fix     | A full-screen-only tab must expose the control as genuinely unavailable, and must not advertise a keyboard shortcut that cannot run. | Pass native `disabled`, remove the click handler, and omit the shortcut while Station access is unavailable. |
+
+## D5 — Visual Patterns Observed
+
+- Pattern: every Chat Panel tab keeps the trailing layout control in the same header position, avoiding tab-dependent toolbar shifts.
+- Pattern: disabled Station access uses the shared button's native disabled treatment rather than adding a one-off color or opacity class.
+- Pattern: full-screen ownership is derived from the active tab capability; the header and workbench layout consume the same decision.
+- Pattern: tab and close-control hover layers now share the same transition duration, preventing the scrim from flashing ahead of the tab surface.
+
+## Summary
+
+- 1 fix applied
+- 5 kept with documented reason
+- 0 abstract candidates (>= 3 occurrences)

--- a/src/engines/ChatPanel/ChatPanelHeader.tsx
+++ b/src/engines/ChatPanel/ChatPanelHeader.tsx
@@ -61,7 +61,8 @@ interface ChatPanelHeaderProps {
   tokenUsageVisible: boolean;
   turnMetadataVisible: boolean;
   shouldOffsetHeaderForCollapsedSidebar: boolean;
-  showChatFocusToggle: boolean;
+  /** Whether the active tab may reveal a Station beside the chat pane. */
+  stationAvailable: boolean;
   showHeader: boolean;
   showSessionContent: boolean;
   /** Owner-side share entry gate (design §6.3): own session + org in scope. */
@@ -112,7 +113,7 @@ export function ChatPanelHeader({
   tokenUsageVisible,
   turnMetadataVisible,
   shouldOffsetHeaderForCollapsedSidebar,
-  showChatFocusToggle,
+  stationAvailable,
   showHeader,
   showSessionContent,
   showCloudShareSettings,
@@ -253,23 +254,22 @@ export function ChatPanelHeader({
       style={CHAT_PANEL_HEADER_NO_DRAG_STYLE}
     >
       {tabStripPlus}
-      {showChatFocusToggle && (
-        <span className="inline-flex">
-          <TabBarTrailingIconButton
-            title={isChatFocus ? shrinkToWorkstationLabel : chatFocusLabel}
-            shortcutId="maximize_chat"
-            tooltipPosition="bottom-end"
-            nativeTitle={false}
-            onClick={handleChatFocusToggle}
-          >
-            {isChatFocus ? (
-              <PanelRight size={HEADER_ICON_SIZE.md} strokeWidth={1.75} />
-            ) : (
-              <Maximize2 size={HEADER_ICON_SIZE.md} strokeWidth={1.75} />
-            )}
-          </TabBarTrailingIconButton>
-        </span>
-      )}
+      <span className="inline-flex">
+        <TabBarTrailingIconButton
+          title={isChatFocus ? shrinkToWorkstationLabel : chatFocusLabel}
+          shortcutId={stationAvailable ? "maximize_chat" : undefined}
+          tooltipPosition="bottom-end"
+          nativeTitle={false}
+          onClick={stationAvailable ? handleChatFocusToggle : undefined}
+          disabled={!stationAvailable}
+        >
+          {isChatFocus ? (
+            <PanelRight size={HEADER_ICON_SIZE.md} strokeWidth={1.75} />
+          ) : (
+            <Maximize2 size={HEADER_ICON_SIZE.md} strokeWidth={1.75} />
+          )}
+        </TabBarTrailingIconButton>
+      </span>
     </div>
   );
 

--- a/src/engines/ChatPanel/ChatPanelTabBar.test.ts
+++ b/src/engines/ChatPanel/ChatPanelTabBar.test.ts
@@ -45,6 +45,9 @@ describe("ChatPanelTabBar", () => {
       /<div[^>]*work-station-editor-tab[^>]*role="tab"[^>]*>.*<button type="button"/s
     );
     expect(markup.match(/<button type="button"/g)).toHaveLength(1);
+    expect(markup).toMatch(
+      /bg-gradient-to-l[^"<]*transition-opacity[^"<]*duration-150[^"<]*opacity-0/
+    );
   });
 
   it("uses the GitHub SVG for a GitHub-imported project tab", () => {

--- a/src/engines/ChatPanel/hooks/useViewportWidth.test.ts
+++ b/src/engines/ChatPanel/hooks/useViewportWidth.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { useViewportWidth } from "./useViewportWidth";
+
+function ViewportWidthProbe() {
+  const width = useViewportWidth();
+  return React.createElement("div", { "data-width": width });
+}
+
+describe("useViewportWidth", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("coalesces resize bursts to one frame and cancels pending work on unmount", () => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1200,
+      writable: true,
+    });
+    let pendingFrame: FrameRequestCallback | null = null;
+    const requestFrame = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        pendingFrame = callback;
+        return 41;
+      });
+    const cancelFrame = vi.spyOn(window, "cancelAnimationFrame");
+
+    act(() => root.render(React.createElement(ViewportWidthProbe)));
+    expect(container.firstElementChild?.getAttribute("data-width")).toBe(
+      "1200"
+    );
+
+    window.innerWidth = 1599;
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(requestFrame).toHaveBeenCalledOnce();
+    expect(container.firstElementChild?.getAttribute("data-width")).toBe(
+      "1200"
+    );
+
+    act(() => pendingFrame?.(0));
+    expect(container.firstElementChild?.getAttribute("data-width")).toBe(
+      "1599"
+    );
+
+    window.innerWidth = 1600;
+    act(() => window.dispatchEvent(new Event("resize")));
+    expect(requestFrame).toHaveBeenCalledTimes(2);
+
+    act(() => root.unmount());
+    root = createRoot(container);
+    expect(cancelFrame).toHaveBeenCalledWith(41);
+
+    window.dispatchEvent(new Event("resize"));
+    expect(requestFrame).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/engines/ChatPanel/hooks/useViewportWidth.test.ts
+++ b/src/engines/ChatPanel/hooks/useViewportWidth.test.ts
@@ -66,7 +66,7 @@ describe("useViewportWidth", () => {
       "1200"
     );
 
-    window.innerWidth = 1599;
+    window.innerWidth = 1919;
     act(() => {
       window.dispatchEvent(new Event("resize"));
       window.dispatchEvent(new Event("resize"));
@@ -79,10 +79,10 @@ describe("useViewportWidth", () => {
 
     act(() => pendingFrame?.(0));
     expect(container.firstElementChild?.getAttribute("data-width")).toBe(
-      "1599"
+      "1919"
     );
 
-    window.innerWidth = 1600;
+    window.innerWidth = 1920;
     act(() => window.dispatchEvent(new Event("resize")));
     expect(requestFrame).toHaveBeenCalledTimes(2);
 

--- a/src/engines/ChatPanel/hooks/useViewportWidth.ts
+++ b/src/engines/ChatPanel/hooks/useViewportWidth.ts
@@ -6,12 +6,21 @@ export function useViewportWidth(): number | undefined {
   );
 
   useEffect(() => {
+    let frameId: number | null = null;
+
     const handleResize = () => {
-      setViewportWidth(window.innerWidth);
+      if (frameId !== null) return;
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null;
+        setViewportWidth(window.innerWidth);
+      });
     };
 
     window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      if (frameId !== null) window.cancelAnimationFrame(frameId);
+    };
   }, []);
 
   return viewportWidth;

--- a/src/engines/ChatPanel/index.tsx
+++ b/src/engines/ChatPanel/index.tsx
@@ -30,10 +30,13 @@ import {
   closeOrganizationChatPanelTabAtom,
   closeProjectOrgChatPanelTabsAtom,
   closeRevokedCloudChannelChatPanelTabsAtom,
+  effectiveChatPanelMaximizedAtom,
+  isChatPanelTabStationAvailable,
   openRuntimeInChatPanelTabAtom,
   openSessionInNewChatTabAtom,
   patchChatPanelWorkItemTabAtom,
   syncActiveChatPanelTabStateAtom,
+  toggleActiveChatPanelMaximizedAtom,
 } from "@src/store/chatPanel/chatPanelTabsAtom";
 import { projectListRefreshAtom } from "@src/store/project/projectAtom";
 import { sessionCreatorStateAtom } from "@src/store/session";
@@ -50,7 +53,6 @@ import {
   chatPanelCreateProjectContextAtom,
   chatPanelCreateTargetAtom,
   chatPanelExploreOpenAtom,
-  chatPanelMaximizedAtom,
   chatPanelSelectedCloudOrgAtom,
   chatPanelSelectedProjectAtom,
   chatPanelSelectedProjectOrgAtom,
@@ -58,7 +60,6 @@ import {
   chatPanelSelectedWorkspaceAtom,
   chatPanelStartPageOpenAtom,
   chatWidthAtom,
-  toggleChatPanelMaximizedAtom,
 } from "@src/store/ui/chatPanelAtom";
 import type { WorkItemDraft } from "@src/store/workstation/projectManager";
 import { isHumanSession } from "@src/util/session/sessionDispatch";
@@ -125,7 +126,7 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
       humanSession: humanSessionActive,
     });
 
-    const [contentMode, setContentMode] = useAtom(chatPanelContentModeAtom);
+    const contentMode = useAtomValue(chatPanelContentModeAtom);
     const [createTarget, setCreateTarget] = useAtom(chatPanelCreateTargetAtom);
     const setCollabOrgCreateIntent = useSetAtom(
       chatPanelCollabOrgCreateIntentAtom
@@ -167,10 +168,9 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
       if (selectedWorkItem) patchWorkItemTab(selectedWorkItem);
     }, [selectedWorkItem, patchWorkItemTab]);
 
-    const isChatFocus = useAtomValue(chatPanelMaximizedAtom);
+    const isChatFocus = useAtomValue(effectiveChatPanelMaximizedAtom);
     const syncActiveTabState = useSetAtom(syncActiveChatPanelTabStateAtom);
-    const toggleChatFocus = useSetAtom(toggleChatPanelMaximizedAtom);
-    const showChatFocusToggle = true;
+    const toggleChatFocus = useSetAtom(toggleActiveChatPanelMaximizedAtom);
     const rawChatWidth = useAtomValue(chatWidthAtom);
     const viewportWidth = useViewportWidth();
     const chatMaxWidth = getChatMaxWidth(viewportWidth);
@@ -282,6 +282,7 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
     });
     const isStandaloneToolTabActive =
       activeTab?.type === "work-management" || activeTab?.type === "runtime";
+    const stationAvailable = isChatPanelTabStationAvailable(activeTab);
     const [focusedWorkstationMenuHost, setFocusedWorkstationMenuHost] =
       useState<HTMLSpanElement | null>(null);
     const focusedWorkstationMenuHostRef = useCallback(
@@ -567,7 +568,7 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
         shouldOffsetHeaderForCollapsedSidebar={
           shouldOffsetHeaderForCollapsedSidebar
         }
-        showChatFocusToggle={showChatFocusToggle}
+        stationAvailable={stationAvailable}
         showHeader={contentState.showHeader || isStandaloneToolTabActive}
         showSessionContent={
           contentState.showSessionContent && !isStandaloneToolTabActive

--- a/src/engines/ChatPanel/index.tsx
+++ b/src/engines/ChatPanel/index.tsx
@@ -30,11 +30,11 @@ import {
   closeOrganizationChatPanelTabAtom,
   closeProjectOrgChatPanelTabsAtom,
   closeRevokedCloudChannelChatPanelTabsAtom,
-  effectiveChatPanelMaximizedAtom,
   isChatPanelTabStationAvailable,
   openRuntimeInChatPanelTabAtom,
   openSessionInNewChatTabAtom,
   patchChatPanelWorkItemTabAtom,
+  resolveChatPanelMaximizedForLayout,
   syncActiveChatPanelTabStateAtom,
   toggleActiveChatPanelMaximizedAtom,
 } from "@src/store/chatPanel/chatPanelTabsAtom";
@@ -53,6 +53,7 @@ import {
   chatPanelCreateProjectContextAtom,
   chatPanelCreateTargetAtom,
   chatPanelExploreOpenAtom,
+  chatPanelMaximizedAtom,
   chatPanelSelectedCloudOrgAtom,
   chatPanelSelectedProjectAtom,
   chatPanelSelectedProjectOrgAtom,
@@ -94,11 +95,11 @@ import { useChatPanelTabsController } from "./hooks/useChatPanelTabsController";
 import { usePanelTitle } from "./hooks/usePanelTitle";
 import { useProjectWorkItemHandlers } from "./hooks/useProjectWorkItemHandlers";
 import { useSessionViewMode } from "./hooks/useSessionViewMode";
-import { useViewportWidth } from "./hooks/useViewportWidth";
 import type { ChatPanelProps, ChatPanelRegionNotice } from "./types";
 
 const ChatPanel: React.FC<ChatPanelProps> = memo(
   ({
+    viewportWidth,
     useExternalWidth = false,
     embedded = false,
     active = true,
@@ -168,11 +169,10 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
       if (selectedWorkItem) patchWorkItemTab(selectedWorkItem);
     }, [selectedWorkItem, patchWorkItemTab]);
 
-    const isChatFocus = useAtomValue(effectiveChatPanelMaximizedAtom);
+    const userChatPanelMaximized = useAtomValue(chatPanelMaximizedAtom);
     const syncActiveTabState = useSetAtom(syncActiveChatPanelTabStateAtom);
     const toggleChatFocus = useSetAtom(toggleActiveChatPanelMaximizedAtom);
     const rawChatWidth = useAtomValue(chatWidthAtom);
-    const viewportWidth = useViewportWidth();
     const chatMaxWidth = getChatMaxWidth(viewportWidth);
     const backgroundConfig = useAtomValue(resolvedBackgroundConfigAtom);
     const chatPanelOpacityStyle = React.useMemo(
@@ -238,8 +238,8 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
     });
 
     const handleChatFocusToggle = useCallback(() => {
-      toggleChatFocus();
-    }, [toggleChatFocus]);
+      toggleChatFocus(viewportWidth);
+    }, [toggleChatFocus, viewportWidth]);
 
     const isCliAgentSession = currentSession?.category === "cli_agent";
     const [tuiMode, setTuiMode] = useAtom(tuiModeAtom(currentSessionId ?? ""));
@@ -282,7 +282,15 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
     });
     const isStandaloneToolTabActive =
       activeTab?.type === "work-management" || activeTab?.type === "runtime";
-    const stationAvailable = isChatPanelTabStationAvailable(activeTab);
+    const stationAvailable = isChatPanelTabStationAvailable(
+      activeTab,
+      viewportWidth
+    );
+    const isChatFocus = resolveChatPanelMaximizedForLayout(
+      userChatPanelMaximized,
+      activeTab,
+      viewportWidth
+    );
     const [focusedWorkstationMenuHost, setFocusedWorkstationMenuHost] =
       useState<HTMLSpanElement | null>(null);
     const focusedWorkstationMenuHostRef = useCallback(

--- a/src/engines/ChatPanel/types.ts
+++ b/src/engines/ChatPanel/types.ts
@@ -32,6 +32,8 @@ export interface ChatPanelCliTerminalLaunchOptions {
  * Props for the main ChatPanel component
  */
 export interface ChatPanelProps {
+  /** Current window viewport width shared by the parent layout. */
+  viewportWidth: number | undefined;
   /** Whether to use external width management */
   useExternalWidth?: boolean;
   /** Session sidebar width for layout calculations */

--- a/src/hooks/workStation/useNarrowChatFocus.test.ts
+++ b/src/hooks/workStation/useNarrowChatFocus.test.ts
@@ -1,6 +1,25 @@
-import { describe, expect, it } from "vitest";
+// @vitest-environment jsdom
+import { Provider } from "jotai";
+import { createStore } from "jotai/vanilla";
+import React, { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
-import { resolveWorkbenchEvaluationWidth } from "./useNarrowChatFocus";
+import { chatPanelDraggingAtom } from "@src/store/ui/chatPanelAtom";
+
+import {
+  resolveWorkbenchEvaluationWidth,
+  useNarrowChatFocus,
+} from "./useNarrowChatFocus";
 
 describe("resolveWorkbenchEvaluationWidth", () => {
   it("uses the projected target width during programmatic reopening", () => {
@@ -40,5 +59,103 @@ describe("resolveWorkbenchEvaluationWidth", () => {
         measuredWorkbenchWidth: 472,
       })
     ).toBe(472);
+  });
+});
+
+function NarrowChatFocusProbe() {
+  useNarrowChatFocus({ enabled: true });
+  return null;
+}
+
+describe("useNarrowChatFocus observer lifecycle", () => {
+  let container: HTMLDivElement;
+  let mainContent: HTMLDivElement;
+  let workbench: HTMLDivElement;
+  let root: Root;
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    mainContent = document.createElement("div");
+    workbench = document.createElement("div");
+    mainContent.setAttribute("data-main-content", "");
+    workbench.setAttribute("data-workbench-surface", "");
+    mainContent.appendChild(workbench);
+    document.body.append(container, mainContent);
+    root = createRoot(container);
+
+    vi.spyOn(mainContent, "getBoundingClientRect").mockReturnValue({
+      width: 1280,
+    } as DOMRect);
+    vi.spyOn(workbench, "getBoundingClientRect").mockReturnValue({
+      width: 760,
+    } as DOMRect);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    mainContent.remove();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("observes the workbench only during a direct divider drag", () => {
+    const observers: ResizeObserverMock[] = [];
+
+    class ResizeObserverMock {
+      readonly observed = new Set<Element>();
+      readonly observe = vi.fn((element: Element) => {
+        this.observed.add(element);
+      });
+      readonly unobserve = vi.fn((element: Element) => {
+        this.observed.delete(element);
+      });
+      readonly disconnect = vi.fn(() => {
+        this.observed.clear();
+      });
+
+      constructor(_callback: ResizeObserverCallback) {
+        observers.push(this);
+      }
+    }
+
+    vi.stubGlobal("ResizeObserver", ResizeObserverMock);
+    const store = createStore();
+
+    act(() => {
+      root.render(
+        React.createElement(
+          Provider,
+          { store },
+          React.createElement(NarrowChatFocusProbe)
+        )
+      );
+    });
+
+    expect(observers).toHaveLength(1);
+    expect(observers[0].observed.has(mainContent)).toBe(true);
+    expect(observers[0].observed.has(workbench)).toBe(false);
+
+    act(() => store.set(chatPanelDraggingAtom, true));
+    expect(observers[0].observed.has(workbench)).toBe(true);
+
+    act(() => store.set(chatPanelDraggingAtom, false));
+    expect(observers[0].observed.has(workbench)).toBe(false);
+    expect(observers[0].unobserve).toHaveBeenCalledWith(workbench);
+
+    act(() => root.unmount());
+    root = createRoot(container);
+    expect(observers[0].disconnect).toHaveBeenCalledOnce();
   });
 });

--- a/src/hooks/workStation/useNarrowChatFocus.ts
+++ b/src/hooks/workStation/useNarrowChatFocus.ts
@@ -25,11 +25,12 @@
  * un-maximize actions taken while narrow are preserved across the
  * next resize.
  *
- * Width sources (two of them, switched on direct manipulation):
+ * Width sources (switched on direct manipulation):
  *
  * - While the user drags the chat divider, `[data-workbench-surface]`
  *   provides the live width because the CSS variable intentionally leads
- *   the persisted chat-width atom.
+ *   the persisted chat-width atom. This target is observed only for the
+ *   duration of a direct drag.
  *
  * - At rest or during programmatic pane motion, derive the projected target
  *   width from `[data-main-content].contentRect.width - chatWidth`. This
@@ -154,6 +155,9 @@ export function useNarrowChatFocus({
   // run without waiting for the next ResizeObserver tick.
   const workbenchWidthRef = useRef<number>(0);
   const mainContentWidthRef = useRef<number>(0);
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+  const workbenchElementRef = useRef<Element | null>(null);
+  const workbenchObservedRef = useRef(false);
 
   useEffect(() => {
     if (!enabled) {
@@ -162,10 +166,7 @@ export function useNarrowChatFocus({
       return;
     }
 
-    let workbenchObserver: ResizeObserver | null = null;
-    let mainObserver: ResizeObserver | null = null;
-    let observedWorkbench: Element | null = null;
-    let observedMain: Element | null = null;
+    let resizeObserver: ResizeObserver | null = null;
     let lookupObserver: MutationObserver | null = null;
 
     const computeWorkbenchWidth = (): number => {
@@ -204,24 +205,23 @@ export function useNarrowChatFocus({
     };
 
     const attachObservers = (workbench: Element, main: Element) => {
-      observedWorkbench = workbench;
-      observedMain = main;
-
-      workbenchObserver = new ResizeObserver((entries) => {
+      workbenchElementRef.current = workbench;
+      resizeObserver = new ResizeObserver((entries) => {
         for (const entry of entries) {
-          workbenchWidthRef.current = entry.contentRect.width;
+          if (entry.target === main) {
+            mainContentWidthRef.current = entry.contentRect.width;
+          } else if (entry.target === workbench) {
+            workbenchWidthRef.current = entry.contentRect.width;
+          }
         }
         evaluate();
       });
-      mainObserver = new ResizeObserver((entries) => {
-        for (const entry of entries) {
-          mainContentWidthRef.current = entry.contentRect.width;
-        }
-        evaluate();
-      });
-
-      workbenchObserver.observe(workbench);
-      mainObserver.observe(main);
+      resizeObserverRef.current = resizeObserver;
+      resizeObserver.observe(main);
+      if (chatPanelDraggingRef.current) {
+        resizeObserver.observe(workbench);
+        workbenchObservedRef.current = true;
+      }
 
       workbenchWidthRef.current = workbench.getBoundingClientRect().width;
       mainContentWidthRef.current = main.getBoundingClientRect().width;
@@ -251,16 +251,34 @@ export function useNarrowChatFocus({
 
     return () => {
       lookupObserver?.disconnect();
-      if (workbenchObserver && observedWorkbench) {
-        workbenchObserver.unobserve(observedWorkbench);
-      }
-      if (mainObserver && observedMain) {
-        mainObserver.unobserve(observedMain);
-      }
-      workbenchObserver?.disconnect();
-      mainObserver?.disconnect();
+      resizeObserver?.disconnect();
+      resizeObserverRef.current = null;
+      workbenchElementRef.current = null;
+      workbenchObservedRef.current = false;
     };
   }, [enabled, setChatPanelMaximized]);
+
+  // The workbench's animated width is intentionally ignored outside direct
+  // manipulation. Observe it only while dragging so focus/unfocus animations
+  // do not wake this state machine once per frame with an unused measurement.
+  useEffect(() => {
+    if (!enabled) return;
+    const observer = resizeObserverRef.current;
+    const workbench = workbenchElementRef.current;
+    if (!observer || !workbench) return;
+
+    if (chatPanelDragging && !workbenchObservedRef.current) {
+      workbenchWidthRef.current = workbench.getBoundingClientRect().width;
+      observer.observe(workbench);
+      workbenchObservedRef.current = true;
+      return;
+    }
+
+    if (!chatPanelDragging && workbenchObservedRef.current) {
+      observer.unobserve(workbench);
+      workbenchObservedRef.current = false;
+    }
+  }, [chatPanelDragging, enabled]);
 
   // Atom-driven re-evaluations: chat width drag, chat visibility, or
   // maximize toggle changes shift the projected workbench width

--- a/src/modules/WorkStation/shared/TabBar/components/TabLabelRowScrim/index.tsx
+++ b/src/modules/WorkStation/shared/TabBar/components/TabLabelRowScrim/index.tsx
@@ -1,5 +1,5 @@
 export interface TabLabelRowScrimProps {
-  /** When true, scrim is rendered (e.g. tab hovered and close is available). */
+  /** When true, the mounted scrim fades in (e.g. tab hovered and close is available). */
   visible: boolean;
 }
 
@@ -8,10 +8,11 @@ export interface TabLabelRowScrimProps {
  * the absolute close control when the tab is hovered. Matches `SortableTab` / session tabs.
  */
 export function TabLabelRowScrim({ visible }: TabLabelRowScrimProps) {
-  if (!visible) return null;
   return (
     <div
-      className="pointer-events-none absolute inset-y-0 right-0 z-[2] w-20 bg-gradient-to-l from-fill-2 to-transparent"
+      className={`pointer-events-none absolute inset-y-0 right-0 z-[2] w-20 bg-gradient-to-l from-fill-2 to-transparent transition-opacity duration-150 ${
+        visible ? "opacity-100" : "opacity-0"
+      }`}
       aria-hidden
     />
   );

--- a/src/modules/index.tsx
+++ b/src/modules/index.tsx
@@ -42,7 +42,10 @@ import {
 import { GUIDE_TARGETS } from "@src/scaffold/Tutorials/guideTargets";
 import { TUTORIALS_OPEN_EVENT } from "@src/scaffold/Tutorials/tutorialRegistry";
 import { resolvedBackgroundConfigAtom } from "@src/store";
-import { activeChatPanelTabAtom } from "@src/store/chatPanel/chatPanelTabsAtom";
+import {
+  activeChatPanelTabAtom,
+  effectiveChatPanelMaximizedAtom,
+} from "@src/store/chatPanel/chatPanelTabsAtom";
 import { useSyncStatusBridge } from "@src/store/sync";
 import {
   type ChatPanelMode,
@@ -190,6 +193,9 @@ const AppShell = () => {
 
   const stationMode = useAtomValue(stationModeAtom);
   const chatPanelMaximized = useAtomValue(chatPanelMaximizedAtom);
+  const effectiveChatPanelMaximized = useAtomValue(
+    effectiveChatPanelMaximizedAtom
+  );
   const stationChatVisibility = useAtomValue(stationChatVisibilityAtom);
   const sidebarCollapsed = useAtomValue(sidebarCollapsedAtom);
   const sidebarWidth = useAtomValue(sidebarWidthAtom);
@@ -386,7 +392,7 @@ const AppShell = () => {
       ? sidebarWidth || DEFAULT_SIDEBAR_WIDTH
       : 0;
 
-  const effectiveChatFocus = chatPanelMaximized;
+  const effectiveChatFocus = effectiveChatPanelMaximized;
 
   return (
     <TerminalProvider>

--- a/src/modules/index.tsx
+++ b/src/modules/index.tsx
@@ -27,6 +27,7 @@ import {
   resolveHostDesktop,
 } from "@src/config/windowChromeRadius";
 import { BrowserProvider, TerminalProvider } from "@src/contexts/workstation";
+import { useViewportWidth } from "@src/engines/ChatPanel/hooks/useViewportWidth";
 import { useAgentADEActions } from "@src/engines/SessionCore/hooks/useAgentADEActions";
 import { useProjectDataChangedListener } from "@src/hooks/project";
 import { useBackgroundImage } from "@src/hooks/theme/useBackgroundImage";
@@ -44,7 +45,7 @@ import { TUTORIALS_OPEN_EVENT } from "@src/scaffold/Tutorials/tutorialRegistry";
 import { resolvedBackgroundConfigAtom } from "@src/store";
 import {
   activeChatPanelTabAtom,
-  effectiveChatPanelMaximizedAtom,
+  resolveChatPanelMaximizedForLayout,
 } from "@src/store/chatPanel/chatPanelTabsAtom";
 import { useSyncStatusBridge } from "@src/store/sync";
 import {
@@ -193,9 +194,7 @@ const AppShell = () => {
 
   const stationMode = useAtomValue(stationModeAtom);
   const chatPanelMaximized = useAtomValue(chatPanelMaximizedAtom);
-  const effectiveChatPanelMaximized = useAtomValue(
-    effectiveChatPanelMaximizedAtom
-  );
+  const viewportWidth = useViewportWidth();
   const stationChatVisibility = useAtomValue(stationChatVisibilityAtom);
   const sidebarCollapsed = useAtomValue(sidebarCollapsedAtom);
   const sidebarWidth = useAtomValue(sidebarWidthAtom);
@@ -392,7 +391,11 @@ const AppShell = () => {
       ? sidebarWidth || DEFAULT_SIDEBAR_WIDTH
       : 0;
 
-  const effectiveChatFocus = effectiveChatPanelMaximized;
+  const effectiveChatFocus = resolveChatPanelMaximizedForLayout(
+    chatPanelMaximized,
+    activeChatPanelTab,
+    viewportWidth
+  );
 
   return (
     <TerminalProvider>
@@ -410,6 +413,7 @@ const AppShell = () => {
 
           {/* Main layout with sidebar, toolbar, content, and chat panel */}
           <AppLayout
+            viewportWidth={viewportWidth}
             sidebar={<SidebarSelector />}
             floatingSidebar={<FloatingSidebar />}
             showChatPanel

--- a/src/modules/shared/layouts/AppLayout.tsx
+++ b/src/modules/shared/layouts/AppLayout.tsx
@@ -26,7 +26,6 @@ import {
   CHAT_WIDTH_CSS_VAR,
   clampChatWidth,
 } from "@src/engines/ChatPanel/config";
-import { useViewportWidth } from "@src/engines/ChatPanel/hooks/useViewportWidth";
 import type { SessionLaunchSuccessInfo } from "@src/engines/SessionCore/hooks/session/useSessionCreator/useSessionLaunch/types";
 import { pendingSessionProposal } from "@src/engines/SessionCore/hooks/useAgentADEActions";
 import SessionSyncProvider from "@src/engines/SessionCore/sync/SessionSyncProvider";
@@ -123,6 +122,8 @@ function WorkbenchActionSystemScope({
 // ============================================
 
 export interface AppLayoutProps {
+  /** Current window viewport width shared with the embedded Chat Panel. */
+  viewportWidth: number | undefined;
   /** Sidebar component to render (null = no sidebar) */
   sidebar?: React.ReactNode;
 
@@ -162,6 +163,7 @@ export interface AppLayoutProps {
 // ============================================
 
 const AppLayoutComponent: React.FC<AppLayoutProps> = ({
+  viewportWidth,
   sidebar,
   floatingSidebar,
   showChatPanel = false,
@@ -174,7 +176,6 @@ const AppLayoutComponent: React.FC<AppLayoutProps> = ({
   const rawChatWidth = useAtomValue(chatWidthAtom);
   const isChatPanelDragging = useAtomValue(chatPanelDraggingAtom);
   const backgroundConfig = useAtomValue(resolvedBackgroundConfigAtom);
-  const viewportWidth = useViewportWidth();
   const chatSlotRef = useRef<HTMLDivElement>(null);
   // Settings-in-slot must always have a usable width even if the user
   // previously dragged the chat to zero. Fall back to the configured
@@ -258,6 +259,7 @@ const AppLayoutComponent: React.FC<AppLayoutProps> = ({
       </React.Suspense>
     ) : (
       <ChatPanel
+        viewportWidth={viewportWidth}
         embedded
         active={showChatPanel}
         useExternalWidth={chatPanelMaximized}

--- a/src/services/workStation/WorkStationViewService.test.ts
+++ b/src/services/workStation/WorkStationViewService.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { ROUTES } from "@src/config/routes";
 import {
+  CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX,
   buildInitialChatPanelTabsState,
   chatPanelTabsAtom,
   openRuntimeInChatPanelTabAtom,
@@ -58,7 +59,7 @@ describe("WorkStationViewService work-management tabs", () => {
     expect(navigationEvents).toEqual([{ path: ROUTES.workStation.base.path }]);
   });
 
-  it("rejects Station-opening actions for wide-only tabs below 1440px", async () => {
+  it("rejects Station-opening actions for wide-only tabs below the threshold", async () => {
     const store = getInstrumentedStore();
     store.set(openRuntimeInChatPanelTabAtom, "Runtime");
 
@@ -72,10 +73,10 @@ describe("WorkStationViewService work-management tabs", () => {
     expect(store.get(stationModeAtom)).toBe("agent-station");
   });
 
-  it("allows Station-opening actions for wide-only tabs at 1440px", async () => {
+  it("allows Station-opening actions for wide-only tabs at the threshold", async () => {
     const store = getInstrumentedStore();
     store.set(openRuntimeInChatPanelTabAtom, "Runtime");
-    window.innerWidth = 1440;
+    window.innerWidth = CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX;
 
     expect(await WorkStationViewService.toggleChatPanelMaximized()).toBe(true);
     expect(store.get(chatPanelMaximizedAtom)).toBe(true);

--- a/src/services/workStation/WorkStationViewService.test.ts
+++ b/src/services/workStation/WorkStationViewService.test.ts
@@ -28,6 +28,11 @@ describe("WorkStationViewService work-management tabs", () => {
   };
 
   beforeEach(() => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1024,
+      writable: true,
+    });
     createInstrumentedStore();
     const store = getInstrumentedStore();
     store.set(stationModeAtom, "agent-station");
@@ -53,17 +58,32 @@ describe("WorkStationViewService work-management tabs", () => {
     expect(navigationEvents).toEqual([{ path: ROUTES.workStation.base.path }]);
   });
 
-  it("rejects Station-opening actions for Station-free chat tabs", async () => {
+  it("rejects Station-opening actions for wide-only tabs below 1440px", async () => {
     const store = getInstrumentedStore();
     store.set(openRuntimeInChatPanelTabAtom, "Runtime");
 
-    expect(store.get(chatPanelMaximizedAtom)).toBe(true);
+    expect(store.get(chatPanelMaximizedAtom)).toBe(false);
     expect(await WorkStationViewService.toggleChatPanelMaximized()).toBe(false);
     expect(await WorkStationViewService.showWorkStation()).toBe(false);
     expect(await WorkStationViewService.openStationMode("my-station")).toBe(
       false
     );
-    expect(store.get(chatPanelMaximizedAtom)).toBe(true);
+    expect(store.get(chatPanelMaximizedAtom)).toBe(false);
     expect(store.get(stationModeAtom)).toBe("agent-station");
+  });
+
+  it("allows Station-opening actions for wide-only tabs at 1440px", async () => {
+    const store = getInstrumentedStore();
+    store.set(openRuntimeInChatPanelTabAtom, "Runtime");
+    window.innerWidth = 1440;
+
+    expect(await WorkStationViewService.toggleChatPanelMaximized()).toBe(true);
+    expect(store.get(chatPanelMaximizedAtom)).toBe(true);
+    expect(await WorkStationViewService.showWorkStation()).toBe(true);
+    expect(store.get(chatPanelMaximizedAtom)).toBe(false);
+    expect(await WorkStationViewService.openStationMode("my-station")).toBe(
+      true
+    );
+    expect(store.get(stationModeAtom)).toBe("my-station");
   });
 });

--- a/src/services/workStation/WorkStationViewService.test.ts
+++ b/src/services/workStation/WorkStationViewService.test.ts
@@ -5,8 +5,12 @@ import { ROUTES } from "@src/config/routes";
 import {
   buildInitialChatPanelTabsState,
   chatPanelTabsAtom,
+  openRuntimeInChatPanelTabAtom,
 } from "@src/store/chatPanel/chatPanelTabsAtom";
-import { stationChatVisibilityAtom } from "@src/store/ui/chatPanelAtom";
+import {
+  chatPanelMaximizedAtom,
+  stationChatVisibilityAtom,
+} from "@src/store/ui/chatPanelAtom";
 import { stationModeAtom } from "@src/store/ui/simulatorAtom";
 import {
   createInstrumentedStore,
@@ -47,5 +51,19 @@ describe("WorkStationViewService work-management tabs", () => {
     await WorkStationViewService.openKanbanTab();
 
     expect(navigationEvents).toEqual([{ path: ROUTES.workStation.base.path }]);
+  });
+
+  it("rejects Station-opening actions for Station-free chat tabs", async () => {
+    const store = getInstrumentedStore();
+    store.set(openRuntimeInChatPanelTabAtom, "Runtime");
+
+    expect(store.get(chatPanelMaximizedAtom)).toBe(true);
+    expect(await WorkStationViewService.toggleChatPanelMaximized()).toBe(false);
+    expect(await WorkStationViewService.showWorkStation()).toBe(false);
+    expect(await WorkStationViewService.openStationMode("my-station")).toBe(
+      false
+    );
+    expect(store.get(chatPanelMaximizedAtom)).toBe(true);
+    expect(store.get(stationModeAtom)).toBe("agent-station");
   });
 });

--- a/src/services/workStation/WorkStationViewService.ts
+++ b/src/services/workStation/WorkStationViewService.ts
@@ -109,26 +109,24 @@ async function shouldToggleMaximizedForActiveTab(
 
 export const WorkStationViewService = {
   /**
-   * Toggle the chat-panel slot's maximized state. Slot mode (session vs.
-   * settings) is left untouched — un-maximize returns the user to whatever
-   * the underlying workbench was showing, without a "previous mode" round-trip.
+   * Toggle the chat-panel slot's maximized state when the active tab permits
+   * Station access. Slot mode (session vs. settings) is left untouched.
    */
   async toggleChatPanelMaximized(): Promise<boolean> {
     if (!isWorkbenchRoute()) return false;
 
-    const [{ toggleChatPanelMaximizedAtom }] = await Promise.all([
-      import("@src/store/ui/chatPanelAtom"),
-    ]);
+    const { toggleActiveChatPanelMaximizedAtom } =
+      await import("@src/store/chatPanel/chatPanelTabsAtom");
 
     const store = getStore();
-    store.set(toggleChatPanelMaximizedAtom);
-    return true;
+    return store.set(toggleActiveChatPanelMaximizedAtom);
   },
 
   async showWorkStation(): Promise<boolean> {
     if (!isWorkbenchRoute()) return false;
 
     const [
+      { activeChatPanelTabStationAvailableAtom },
       { stationModeAtom },
       {
         activeStationChatVisibleAtom,
@@ -136,11 +134,13 @@ export const WorkStationViewService = {
         stationChatVisibilityAtom,
       },
     ] = await Promise.all([
+      import("@src/store/chatPanel/chatPanelTabsAtom"),
       import("@src/store/ui/simulatorAtom"),
       import("@src/store/ui/chatPanelAtom"),
     ]);
 
     const store = getStore();
+    if (!store.get(activeChatPanelTabStationAvailableAtom)) return false;
     if (store.get(chatPanelMaximizedAtom)) {
       store.set(chatPanelMaximizedAtom, false);
     }
@@ -175,13 +175,23 @@ export const WorkStationViewService = {
   },
 
   async openStationMode(mode: StationMode): Promise<boolean> {
-    const [{ activeStationChatVisibleAtom }, { stationModeAtom }] =
-      await Promise.all([
-        import("@src/store/ui/chatPanelAtom"),
-        import("@src/store/ui/simulatorAtom"),
-      ]);
+    const [
+      { activeChatPanelTabStationAvailableAtom },
+      { activeStationChatVisibleAtom },
+      { stationModeAtom },
+    ] = await Promise.all([
+      import("@src/store/chatPanel/chatPanelTabsAtom"),
+      import("@src/store/ui/chatPanelAtom"),
+      import("@src/store/ui/simulatorAtom"),
+    ]);
 
     const store = getStore();
+    if (
+      isWorkbenchRoute() &&
+      !store.get(activeChatPanelTabStationAvailableAtom)
+    ) {
+      return false;
+    }
 
     store.set(stationModeAtom, mode);
 

--- a/src/services/workStation/WorkStationViewService.ts
+++ b/src/services/workStation/WorkStationViewService.ts
@@ -119,14 +119,14 @@ export const WorkStationViewService = {
       await import("@src/store/chatPanel/chatPanelTabsAtom");
 
     const store = getStore();
-    return store.set(toggleActiveChatPanelMaximizedAtom);
+    return store.set(toggleActiveChatPanelMaximizedAtom, window.innerWidth);
   },
 
   async showWorkStation(): Promise<boolean> {
     if (!isWorkbenchRoute()) return false;
 
     const [
-      { activeChatPanelTabStationAvailableAtom },
+      { activeChatPanelTabAtom, isChatPanelTabStationAvailable },
       { stationModeAtom },
       {
         activeStationChatVisibleAtom,
@@ -140,7 +140,14 @@ export const WorkStationViewService = {
     ]);
 
     const store = getStore();
-    if (!store.get(activeChatPanelTabStationAvailableAtom)) return false;
+    if (
+      !isChatPanelTabStationAvailable(
+        store.get(activeChatPanelTabAtom),
+        window.innerWidth
+      )
+    ) {
+      return false;
+    }
     if (store.get(chatPanelMaximizedAtom)) {
       store.set(chatPanelMaximizedAtom, false);
     }
@@ -176,7 +183,7 @@ export const WorkStationViewService = {
 
   async openStationMode(mode: StationMode): Promise<boolean> {
     const [
-      { activeChatPanelTabStationAvailableAtom },
+      { activeChatPanelTabAtom, isChatPanelTabStationAvailable },
       { activeStationChatVisibleAtom },
       { stationModeAtom },
     ] = await Promise.all([
@@ -188,7 +195,10 @@ export const WorkStationViewService = {
     const store = getStore();
     if (
       isWorkbenchRoute() &&
-      !store.get(activeChatPanelTabStationAvailableAtom)
+      !isChatPanelTabStationAvailable(
+        store.get(activeChatPanelTabAtom),
+        window.innerWidth
+      )
     ) {
       return false;
     }

--- a/src/store/chatPanel/__tests__/chatPanelTabStationAccess.test.ts
+++ b/src/store/chatPanel/__tests__/chatPanelTabStationAccess.test.ts
@@ -8,6 +8,10 @@ import {
 } from "../chatPanelTabsAtom";
 
 describe("Chat Panel tab Station access", () => {
+  it("uses 1600px as the wide Station breakpoint", () => {
+    expect(CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX).toBe(1600);
+  });
+
   it.each<ChatPanelTabType>(["session", "terminal", "start-page", "channel"])(
     "keeps Station access available for %s tabs at every viewport width",
     (type) => {
@@ -46,11 +50,19 @@ describe("Chat Panel tab Station access", () => {
     expect(resolveChatPanelMaximizedForLayout(false, "work-item", 1200)).toBe(
       true
     );
-    expect(resolveChatPanelMaximizedForLayout(false, "work-item", 1440)).toBe(
-      false
-    );
-    expect(resolveChatPanelMaximizedForLayout(true, "work-item", 1440)).toBe(
-      true
-    );
+    expect(
+      resolveChatPanelMaximizedForLayout(
+        false,
+        "work-item",
+        CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX
+      )
+    ).toBe(false);
+    expect(
+      resolveChatPanelMaximizedForLayout(
+        true,
+        "work-item",
+        CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX
+      )
+    ).toBe(true);
   });
 });

--- a/src/store/chatPanel/__tests__/chatPanelTabStationAccess.test.ts
+++ b/src/store/chatPanel/__tests__/chatPanelTabStationAccess.test.ts
@@ -8,8 +8,8 @@ import {
 } from "../chatPanelTabsAtom";
 
 describe("Chat Panel tab Station access", () => {
-  it("uses 1600px as the wide Station breakpoint", () => {
-    expect(CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX).toBe(1600);
+  it("uses 1920px as the wide Station breakpoint", () => {
+    expect(CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX).toBe(1920);
   });
 
   it.each<ChatPanelTabType>(["session", "terminal", "start-page", "channel"])(

--- a/src/store/chatPanel/__tests__/chatPanelTabStationAccess.test.ts
+++ b/src/store/chatPanel/__tests__/chatPanelTabStationAccess.test.ts
@@ -1,15 +1,18 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX,
   type ChatPanelTabType,
   isChatPanelTabStationAvailable,
+  resolveChatPanelMaximizedForLayout,
 } from "../chatPanelTabsAtom";
 
 describe("Chat Panel tab Station access", () => {
   it.each<ChatPanelTabType>(["session", "terminal", "start-page", "channel"])(
-    "keeps Station access available for %s tabs",
+    "keeps Station access available for %s tabs at every viewport width",
     (type) => {
-      expect(isChatPanelTabStationAvailable(type)).toBe(true);
+      expect(isChatPanelTabStationAvailable(type, 800)).toBe(true);
+      expect(isChatPanelTabStationAvailable(type, 2000)).toBe(true);
     }
   );
 
@@ -24,7 +27,30 @@ describe("Chat Panel tab Station access", () => {
     "github-pr",
     "project",
     "explore",
-  ])("makes %s tabs full-screen and Station-free", (type) => {
-    expect(isChatPanelTabStationAvailable(type)).toBe(false);
+  ])("unlocks %s tabs only on a wide viewport", (type) => {
+    expect(
+      isChatPanelTabStationAvailable(
+        type,
+        CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX - 1
+      )
+    ).toBe(false);
+    expect(
+      isChatPanelTabStationAvailable(
+        type,
+        CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX
+      )
+    ).toBe(true);
+  });
+
+  it("forces the effective layout full-screen without changing the saved preference", () => {
+    expect(resolveChatPanelMaximizedForLayout(false, "work-item", 1200)).toBe(
+      true
+    );
+    expect(resolveChatPanelMaximizedForLayout(false, "work-item", 1440)).toBe(
+      false
+    );
+    expect(resolveChatPanelMaximizedForLayout(true, "work-item", 1440)).toBe(
+      true
+    );
   });
 });

--- a/src/store/chatPanel/__tests__/chatPanelTabStationAccess.test.ts
+++ b/src/store/chatPanel/__tests__/chatPanelTabStationAccess.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type ChatPanelTabType,
+  isChatPanelTabStationAvailable,
+} from "../chatPanelTabsAtom";
+
+describe("Chat Panel tab Station access", () => {
+  it.each<ChatPanelTabType>(["session", "terminal", "start-page", "channel"])(
+    "keeps Station access available for %s tabs",
+    (type) => {
+      expect(isChatPanelTabStationAvailable(type)).toBe(true);
+    }
+  );
+
+  it.each<ChatPanelTabType>([
+    "runtime",
+    "team-inbox",
+    "work-management",
+    "workspace",
+    "organization",
+    "work-item",
+    "github-issue",
+    "github-pr",
+    "project",
+    "explore",
+  ])("makes %s tabs full-screen and Station-free", (type) => {
+    expect(isChatPanelTabStationAvailable(type)).toBe(false);
+  });
+});

--- a/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
+++ b/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
@@ -42,6 +42,7 @@ async function loadChatPanelTabAtoms() {
     activeWorkManagementSectionAtom,
     addChatPanelTerminalTabAtom,
     addChatPanelLaunchpadTabAtom,
+    CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX,
     chatPanelTabsAtom,
     isChatPanelTabStationAvailable,
     closeChatPanelTabAtom,
@@ -106,6 +107,7 @@ async function loadChatPanelTabAtoms() {
     CHAT_PANEL_CREATE_TARGET,
     CHAT_PANEL_COLLAB_ORG_MODE,
     CHAT_PANEL_COLLAB_ORG_SOURCE,
+    CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX,
     CHAT_PANEL_SURFACE_KIND,
     chatPanelTabsAtom,
     isChatPanelTabStationAvailable,
@@ -602,6 +604,7 @@ describe("openWorkManagementChatPanelTabAtom", () => {
   it("guards the Station toggle until Kanban has a wide viewport", async () => {
     const {
       activeChatPanelTabAtom,
+      CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX,
       chatPanelMaximizedAtom,
       isChatPanelTabStationAvailable,
       openWorkManagementChatPanelTabAtom,
@@ -615,9 +618,17 @@ describe("openWorkManagementChatPanelTabAtom", () => {
     expect(store.get(chatPanelMaximizedAtom)).toBe(false);
 
     expect(
-      isChatPanelTabStationAvailable(store.get(activeChatPanelTabAtom), 1439)
+      isChatPanelTabStationAvailable(
+        store.get(activeChatPanelTabAtom),
+        CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX - 1
+      )
     ).toBe(false);
-    expect(store.set(toggleActiveChatPanelMaximizedAtom, 1439)).toBe(false);
+    expect(
+      store.set(
+        toggleActiveChatPanelMaximizedAtom,
+        CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX - 1
+      )
+    ).toBe(false);
     expect(store.get(chatPanelMaximizedAtom)).toBe(false);
 
     // Reconciliation leaves the user's preference untouched; the effective
@@ -628,11 +639,16 @@ describe("openWorkManagementChatPanelTabAtom", () => {
       resolveChatPanelMaximizedForLayout(
         store.get(chatPanelMaximizedAtom),
         store.get(activeChatPanelTabAtom),
-        1439
+        CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX - 1
       )
     ).toBe(true);
 
-    expect(store.set(toggleActiveChatPanelMaximizedAtom, 1440)).toBe(true);
+    expect(
+      store.set(
+        toggleActiveChatPanelMaximizedAtom,
+        CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX
+      )
+    ).toBe(true);
     expect(store.get(chatPanelMaximizedAtom)).toBe(true);
   });
 

--- a/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
+++ b/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
@@ -38,12 +38,12 @@ async function loadChatPanelTabAtoms() {
     await import("@src/store/ui/workManagementCreatorAtom");
   const {
     activateChatPanelTabAtom,
-    activeChatPanelTabStationAvailableAtom,
+    activeChatPanelTabAtom,
     activeWorkManagementSectionAtom,
     addChatPanelTerminalTabAtom,
     addChatPanelLaunchpadTabAtom,
     chatPanelTabsAtom,
-    effectiveChatPanelMaximizedAtom,
+    isChatPanelTabStationAvailable,
     closeChatPanelTabAtom,
     closeOtherChatPanelTabsAtom,
     closeProjectOrgChatPanelTabsAtom,
@@ -65,6 +65,7 @@ async function loadChatPanelTabAtoms() {
     prevChatPanelTabAtom,
     setActiveWorkManagementSectionAtom,
     setChatPanelTabTitleAtom,
+    resolveChatPanelMaximizedForLayout,
     syncActiveChatPanelTabStateAtom,
     toggleActiveChatPanelMaximizedAtom,
   } = await import("../chatPanelTabsAtom");
@@ -96,7 +97,7 @@ async function loadChatPanelTabAtoms() {
 
   return {
     activateChatPanelTabAtom,
-    activeChatPanelTabStationAvailableAtom,
+    activeChatPanelTabAtom,
     activeWorkManagementSectionAtom,
     addChatPanelTerminalTabAtom,
     activeChatPanelSurfaceAtom,
@@ -107,7 +108,7 @@ async function loadChatPanelTabAtoms() {
     CHAT_PANEL_COLLAB_ORG_SOURCE,
     CHAT_PANEL_SURFACE_KIND,
     chatPanelTabsAtom,
-    effectiveChatPanelMaximizedAtom,
+    isChatPanelTabStationAvailable,
     chatPanelMaximizedAtom,
     chatPanelNavigateAtom,
     chatPanelCreateProjectContextAtom,
@@ -148,6 +149,7 @@ async function loadChatPanelTabAtoms() {
     prevChatPanelTabAtom,
     setActiveWorkManagementSectionAtom,
     setChatPanelTabTitleAtom,
+    resolveChatPanelMaximizedForLayout,
     syncActiveChatPanelTabStateAtom,
     toggleActiveChatPanelMaximizedAtom,
     terminalSessionsAtom,
@@ -438,10 +440,12 @@ describe("closeWorkItemChatPanelTabAtom", () => {
   it("restores a session's split Station layout after visiting a work item", async () => {
     const {
       activateChatPanelTabAtom,
-      activeChatPanelTabStationAvailableAtom,
+      activeChatPanelTabAtom,
       chatPanelMaximizedAtom,
+      isChatPanelTabStationAvailable,
       openSessionInNewChatTabAtom,
       openWorkItemInChatPanelTabAtom,
+      resolveChatPanelMaximizedForLayout,
       store,
     } = await loadChatPanelTabAtoms();
     const sessionTabId = store.set(openSessionInNewChatTabAtom, {
@@ -461,12 +465,23 @@ describe("closeWorkItemChatPanelTabAtom", () => {
       },
     } as never);
 
-    expect(store.get(activeChatPanelTabStationAvailableAtom)).toBe(false);
-    expect(store.get(chatPanelMaximizedAtom)).toBe(true);
+    expect(
+      isChatPanelTabStationAvailable(store.get(activeChatPanelTabAtom), 1200)
+    ).toBe(false);
+    expect(store.get(chatPanelMaximizedAtom)).toBe(false);
+    expect(
+      resolveChatPanelMaximizedForLayout(
+        store.get(chatPanelMaximizedAtom),
+        store.get(activeChatPanelTabAtom),
+        1200
+      )
+    ).toBe(true);
 
     store.set(activateChatPanelTabAtom, sessionTabId);
 
-    expect(store.get(activeChatPanelTabStationAvailableAtom)).toBe(true);
+    expect(
+      isChatPanelTabStationAvailable(store.get(activeChatPanelTabAtom), 1200)
+    ).toBe(true);
     expect(store.get(chatPanelMaximizedAtom)).toBe(false);
   });
 });
@@ -554,11 +569,13 @@ describe("openWorkManagementChatPanelTabAtom", () => {
     vi.useRealTimers();
   });
 
-  it("opens Kanban as a singleton Station-free management tab", async () => {
+  it("opens Kanban as a singleton wide-only Station tab", async () => {
     const {
+      activeChatPanelTabAtom,
       chatPanelMaximizedAtom,
       chatPanelTabsAtom,
       activeWorkManagementSectionAtom,
+      isChatPanelTabStationAvailable,
       openWorkManagementChatPanelTabAtom,
       WORK_MANAGEMENT_SECTION,
       store,
@@ -573,36 +590,49 @@ describe("openWorkManagementChatPanelTabAtom", () => {
         .get(chatPanelTabsAtom)
         .tabs.filter((tab) => tab.type === "work-management")
     ).toHaveLength(1);
-    expect(store.get(chatPanelMaximizedAtom)).toBe(true);
+    expect(store.get(chatPanelMaximizedAtom)).toBe(false);
+    expect(
+      isChatPanelTabStationAvailable(store.get(activeChatPanelTabAtom), 1200)
+    ).toBe(false);
     expect(store.get(activeWorkManagementSectionAtom)).toBe(
       WORK_MANAGEMENT_SECTION.KANBAN
     );
   });
 
-  it("keeps the Station unavailable while Kanban remains active", async () => {
+  it("guards the Station toggle until Kanban has a wide viewport", async () => {
     const {
-      activeChatPanelTabStationAvailableAtom,
+      activeChatPanelTabAtom,
       chatPanelMaximizedAtom,
-      effectiveChatPanelMaximizedAtom,
+      isChatPanelTabStationAvailable,
       openWorkManagementChatPanelTabAtom,
+      resolveChatPanelMaximizedForLayout,
       store,
       syncActiveChatPanelTabStateAtom,
       toggleActiveChatPanelMaximizedAtom,
     } = await loadChatPanelTabAtoms();
 
     store.set(openWorkManagementChatPanelTabAtom, {});
-    expect(store.get(chatPanelMaximizedAtom)).toBe(true);
+    expect(store.get(chatPanelMaximizedAtom)).toBe(false);
 
-    expect(store.get(activeChatPanelTabStationAvailableAtom)).toBe(false);
-    expect(store.set(toggleActiveChatPanelMaximizedAtom)).toBe(false);
-    expect(store.get(chatPanelMaximizedAtom)).toBe(true);
+    expect(
+      isChatPanelTabStationAvailable(store.get(activeChatPanelTabAtom), 1439)
+    ).toBe(false);
+    expect(store.set(toggleActiveChatPanelMaximizedAtom, 1439)).toBe(false);
+    expect(store.get(chatPanelMaximizedAtom)).toBe(false);
 
-    // A legacy direct writer cannot reveal the Station, and reconciliation
-    // repairs the stored preference for the next transition.
-    store.set(chatPanelMaximizedAtom, false);
-    expect(store.get(effectiveChatPanelMaximizedAtom)).toBe(true);
+    // Reconciliation leaves the user's preference untouched; the effective
+    // layout remains full-screen while the viewport is below the threshold.
     store.set(syncActiveChatPanelTabStateAtom);
+    expect(store.get(chatPanelMaximizedAtom)).toBe(false);
+    expect(
+      resolveChatPanelMaximizedForLayout(
+        store.get(chatPanelMaximizedAtom),
+        store.get(activeChatPanelTabAtom),
+        1439
+      )
+    ).toBe(true);
 
+    expect(store.set(toggleActiveChatPanelMaximizedAtom, 1440)).toBe(true);
     expect(store.get(chatPanelMaximizedAtom)).toBe(true);
   });
 
@@ -618,7 +648,6 @@ describe("openWorkManagementChatPanelTabAtom", () => {
 
     store.set(chatPanelMaximizedAtom, true);
     store.set(openWorkManagementChatPanelTabAtom, {});
-    store.set(chatPanelMaximizedAtom, false);
     store.set(activateChatPanelTabAtom, primaryTabId);
 
     expect(store.get(chatPanelMaximizedAtom)).toBe(true);
@@ -773,7 +802,7 @@ describe("openWorkManagementChatPanelTabAtom", () => {
     store.set(openWorkManagementChatPanelTabAtom, {
       section: WORK_MANAGEMENT_SECTION.PROJECTS,
     });
-    expect(store.get(chatPanelMaximizedAtom)).toBe(true);
+    expect(store.get(chatPanelMaximizedAtom)).toBe(false);
 
     store.set(activateChatPanelTabAtom, primaryTabId);
 
@@ -903,7 +932,7 @@ describe("ChatPanel navigation tabs", () => {
     ).toHaveLength(1);
   });
 
-  it("opens Runtime as its own singleton Station-free tab", async () => {
+  it("opens Runtime as its own singleton wide-only Station tab", async () => {
     const {
       chatPanelMaximizedAtom,
       chatPanelTabsAtom,
@@ -919,7 +948,7 @@ describe("ChatPanel navigation tabs", () => {
 
     expect(focusedTabId).toBe(runtimeTabId);
     expect(store.get(chatPanelTabsAtom).activeTabId).toBe(runtimeTabId);
-    expect(store.get(chatPanelMaximizedAtom)).toBe(true);
+    expect(store.get(chatPanelMaximizedAtom)).toBe(false);
     expect(store.get(chatPanelTabsAtom).tabs.map((tab) => tab.id)).toEqual([
       ...existingTabIds,
       runtimeTabId,
@@ -929,7 +958,7 @@ describe("ChatPanel navigation tabs", () => {
     ).toHaveLength(1);
   });
 
-  it("opens Team Inbox as its own singleton tab", async () => {
+  it("opens Team Inbox as its own singleton wide-only Station tab", async () => {
     const {
       chatPanelMaximizedAtom,
       chatPanelTabsAtom,
@@ -945,7 +974,7 @@ describe("ChatPanel navigation tabs", () => {
 
     expect(focusedTabId).toBe(teamInboxTabId);
     expect(store.get(chatPanelTabsAtom).activeTabId).toBe(teamInboxTabId);
-    expect(store.get(chatPanelMaximizedAtom)).toBe(true);
+    expect(store.get(chatPanelMaximizedAtom)).toBe(false);
     expect(
       store
         .get(chatPanelTabsAtom)

--- a/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
+++ b/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
@@ -38,10 +38,12 @@ async function loadChatPanelTabAtoms() {
     await import("@src/store/ui/workManagementCreatorAtom");
   const {
     activateChatPanelTabAtom,
+    activeChatPanelTabStationAvailableAtom,
     activeWorkManagementSectionAtom,
     addChatPanelTerminalTabAtom,
     addChatPanelLaunchpadTabAtom,
     chatPanelTabsAtom,
+    effectiveChatPanelMaximizedAtom,
     closeChatPanelTabAtom,
     closeOtherChatPanelTabsAtom,
     closeProjectOrgChatPanelTabsAtom,
@@ -64,6 +66,7 @@ async function loadChatPanelTabAtoms() {
     setActiveWorkManagementSectionAtom,
     setChatPanelTabTitleAtom,
     syncActiveChatPanelTabStateAtom,
+    toggleActiveChatPanelMaximizedAtom,
   } = await import("../chatPanelTabsAtom");
   const {
     createChatPanelTerminalAtom,
@@ -93,6 +96,7 @@ async function loadChatPanelTabAtoms() {
 
   return {
     activateChatPanelTabAtom,
+    activeChatPanelTabStationAvailableAtom,
     activeWorkManagementSectionAtom,
     addChatPanelTerminalTabAtom,
     activeChatPanelSurfaceAtom,
@@ -103,6 +107,7 @@ async function loadChatPanelTabAtoms() {
     CHAT_PANEL_COLLAB_ORG_SOURCE,
     CHAT_PANEL_SURFACE_KIND,
     chatPanelTabsAtom,
+    effectiveChatPanelMaximizedAtom,
     chatPanelMaximizedAtom,
     chatPanelNavigateAtom,
     chatPanelCreateProjectContextAtom,
@@ -144,6 +149,7 @@ async function loadChatPanelTabAtoms() {
     setActiveWorkManagementSectionAtom,
     setChatPanelTabTitleAtom,
     syncActiveChatPanelTabStateAtom,
+    toggleActiveChatPanelMaximizedAtom,
     terminalSessionsAtom,
     updateTerminalSessionInfoAtom,
     sessionViewAtom,
@@ -428,6 +434,41 @@ describe("closeWorkItemChatPanelTabAtom", () => {
     ).toBe(false);
     expect(store.get(chatPanelSelectedWorkItemAtom)).toBeNull();
   });
+
+  it("restores a session's split Station layout after visiting a work item", async () => {
+    const {
+      activateChatPanelTabAtom,
+      activeChatPanelTabStationAvailableAtom,
+      chatPanelMaximizedAtom,
+      openSessionInNewChatTabAtom,
+      openWorkItemInChatPanelTabAtom,
+      store,
+    } = await loadChatPanelTabAtoms();
+    const sessionTabId = store.set(openSessionInNewChatTabAtom, {
+      sessionId: "session-with-station",
+      sessionName: "Session with Station",
+    });
+    store.set(chatPanelMaximizedAtom, false);
+
+    store.set(openWorkItemInChatPanelTabAtom, {
+      shortId: "ORG-2",
+      projectSlug: "project-one",
+      projectId: "project-one",
+      projectName: "Project One",
+      workItem: {
+        session_id: "ORG-2",
+        name: "Full-screen work item",
+      },
+    } as never);
+
+    expect(store.get(activeChatPanelTabStationAvailableAtom)).toBe(false);
+    expect(store.get(chatPanelMaximizedAtom)).toBe(true);
+
+    store.set(activateChatPanelTabAtom, sessionTabId);
+
+    expect(store.get(activeChatPanelTabStationAvailableAtom)).toBe(true);
+    expect(store.get(chatPanelMaximizedAtom)).toBe(false);
+  });
 });
 
 describe("closeProjectOrgChatPanelTabsAtom", () => {
@@ -513,7 +554,7 @@ describe("openWorkManagementChatPanelTabAtom", () => {
     vi.useRealTimers();
   });
 
-  it("opens Kanban as a singleton default-fullscreen management tab", async () => {
+  it("opens Kanban as a singleton Station-free management tab", async () => {
     const {
       chatPanelMaximizedAtom,
       chatPanelTabsAtom,
@@ -538,24 +579,34 @@ describe("openWorkManagementChatPanelTabAtom", () => {
     );
   });
 
-  it("keeps a manual Workstation restore while Kanban remains active", async () => {
+  it("keeps the Station unavailable while Kanban remains active", async () => {
     const {
+      activeChatPanelTabStationAvailableAtom,
       chatPanelMaximizedAtom,
+      effectiveChatPanelMaximizedAtom,
       openWorkManagementChatPanelTabAtom,
       store,
       syncActiveChatPanelTabStateAtom,
+      toggleActiveChatPanelMaximizedAtom,
     } = await loadChatPanelTabAtoms();
 
     store.set(openWorkManagementChatPanelTabAtom, {});
     expect(store.get(chatPanelMaximizedAtom)).toBe(true);
 
+    expect(store.get(activeChatPanelTabStationAvailableAtom)).toBe(false);
+    expect(store.set(toggleActiveChatPanelMaximizedAtom)).toBe(false);
+    expect(store.get(chatPanelMaximizedAtom)).toBe(true);
+
+    // A legacy direct writer cannot reveal the Station, and reconciliation
+    // repairs the stored preference for the next transition.
     store.set(chatPanelMaximizedAtom, false);
+    expect(store.get(effectiveChatPanelMaximizedAtom)).toBe(true);
     store.set(syncActiveChatPanelTabStateAtom);
 
-    expect(store.get(chatPanelMaximizedAtom)).toBe(false);
+    expect(store.get(chatPanelMaximizedAtom)).toBe(true);
   });
 
-  it("preserves a manual Workstation restore after leaving Kanban", async () => {
+  it("restores the session's prior full-screen state after leaving Kanban", async () => {
     const {
       activateChatPanelTabAtom,
       chatPanelMaximizedAtom,
@@ -570,7 +621,7 @@ describe("openWorkManagementChatPanelTabAtom", () => {
     store.set(chatPanelMaximizedAtom, false);
     store.set(activateChatPanelTabAtom, primaryTabId);
 
-    expect(store.get(chatPanelMaximizedAtom)).toBe(false);
+    expect(store.get(chatPanelMaximizedAtom)).toBe(true);
   });
 
   it("keeps Kanban separate while reusing one tab for every Work dataset", async () => {
@@ -852,7 +903,7 @@ describe("ChatPanel navigation tabs", () => {
     ).toHaveLength(1);
   });
 
-  it("opens Runtime as its own singleton tab without replacing or maximizing other tabs", async () => {
+  it("opens Runtime as its own singleton Station-free tab", async () => {
     const {
       chatPanelMaximizedAtom,
       chatPanelTabsAtom,
@@ -868,7 +919,7 @@ describe("ChatPanel navigation tabs", () => {
 
     expect(focusedTabId).toBe(runtimeTabId);
     expect(store.get(chatPanelTabsAtom).activeTabId).toBe(runtimeTabId);
-    expect(store.get(chatPanelMaximizedAtom)).toBe(false);
+    expect(store.get(chatPanelMaximizedAtom)).toBe(true);
     expect(store.get(chatPanelTabsAtom).tabs.map((tab) => tab.id)).toEqual([
       ...existingTabIds,
       runtimeTabId,
@@ -879,8 +930,12 @@ describe("ChatPanel navigation tabs", () => {
   });
 
   it("opens Team Inbox as its own singleton tab", async () => {
-    const { chatPanelTabsAtom, openTeamInboxInChatPanelTabAtom, store } =
-      await loadChatPanelTabAtoms();
+    const {
+      chatPanelMaximizedAtom,
+      chatPanelTabsAtom,
+      openTeamInboxInChatPanelTabAtom,
+      store,
+    } = await loadChatPanelTabAtoms();
 
     const teamInboxTabId = store.set(
       openTeamInboxInChatPanelTabAtom,
@@ -890,6 +945,7 @@ describe("ChatPanel navigation tabs", () => {
 
     expect(focusedTabId).toBe(teamInboxTabId);
     expect(store.get(chatPanelTabsAtom).activeTabId).toBe(teamInboxTabId);
+    expect(store.get(chatPanelMaximizedAtom)).toBe(true);
     expect(
       store
         .get(chatPanelTabsAtom)

--- a/src/store/chatPanel/chatPanelTabLifecycleAtoms.ts
+++ b/src/store/chatPanel/chatPanelTabLifecycleAtoms.ts
@@ -12,10 +12,7 @@ import {
 import type { WorkManagementSection } from "@src/store/workstation";
 
 import { buildDefaultLaunchpadTab } from "./chatPanelTabFactories";
-import {
-  activateChatPanelTabAtom,
-  transitionChatPanelTabPresentationAtom,
-} from "./chatPanelTabPresentationAtoms";
+import { activateChatPanelTabAtom } from "./chatPanelTabPresentationAtoms";
 import {
   type ChatPanelSelectedChannel,
   getWorkManagementFallbackTitle,
@@ -95,10 +92,6 @@ export const closeChatPanelTabAtom = atom(null, (get, set, tabId: string) => {
 
   if (nextTabs.length === 0) {
     const launchpad = buildDefaultLaunchpadTab();
-    set(transitionChatPanelTabPresentationAtom, {
-      previousTab: tab,
-      nextTab: launchpad,
-    });
     set(chatPanelTabsAtom, {
       tabs: [launchpad],
       activeTabId: launchpad.id,
@@ -110,10 +103,6 @@ export const closeChatPanelTabAtom = atom(null, (get, set, tabId: string) => {
   if (state.activeTabId === tabId) {
     const nextIdx = Math.max(0, idx - 1);
     nextActiveId = nextTabs[Math.min(nextIdx, nextTabs.length - 1)].id;
-    set(transitionChatPanelTabPresentationAtom, {
-      previousTab: tab,
-      nextTab: nextTabs.find((candidate) => candidate.id === nextActiveId),
-    });
   }
 
   set(chatPanelTabsAtom, { tabs: nextTabs, activeTabId: nextActiveId });

--- a/src/store/chatPanel/chatPanelTabPresentationAtoms.ts
+++ b/src/store/chatPanel/chatPanelTabPresentationAtoms.ts
@@ -11,7 +11,6 @@ import {
   CHAT_PANEL_SURFACE_KIND,
   DEFAULT_CHAT_PANEL_CREATE_TARGET,
   chatPanelCreateTargetAtom,
-  chatPanelMaximizedAtom,
   chatPanelNavigateAtom,
   chatPanelStartPageOpenAtom,
   toggleChatPanelMaximizedAtom,
@@ -26,77 +25,24 @@ import {
   chatPanelTabsAtom,
 } from "./chatPanelTabsState";
 
-/** Maximize-state snapshot taken before entering a Station-free tab. */
-const stationUnavailableTabPriorMaximizedAtom = atom<boolean | null>(null);
-
-/** Whether the active tab may reveal a Station beside the chat pane. */
-export const activeChatPanelTabStationAvailableAtom = atom((get) => {
-  return isChatPanelTabStationAvailable(get(activeChatPanelTabAtom));
-});
-activeChatPanelTabStationAvailableAtom.debugLabel =
-  "activeChatPanelTabStationAvailable";
-
-/**
- * Layout-authoritative maximize state. Station-free tabs remain full-screen
- * even if an unrelated legacy writer changes the user's stored preference.
- */
-export const effectiveChatPanelMaximizedAtom = atom(
-  (get) =>
-    get(chatPanelMaximizedAtom) || !get(activeChatPanelTabStationAvailableAtom)
-);
-effectiveChatPanelMaximizedAtom.debugLabel = "effectiveChatPanelMaximized";
-
-/** User toggle guarded by the active tab's Station capability. */
-export const toggleActiveChatPanelMaximizedAtom = atom(null, (get, set) => {
-  if (!get(activeChatPanelTabStationAvailableAtom)) return false;
-  set(toggleChatPanelMaximizedAtom);
-  return true;
-});
-toggleActiveChatPanelMaximizedAtom.debugLabel =
-  "toggleActiveChatPanelMaximized";
-
-export const transitionChatPanelTabPresentationAtom = atom(
+/** User toggle guarded by the active tab and current viewport policy. */
+export const toggleActiveChatPanelMaximizedAtom = atom(
   null,
-  (
-    get,
-    set,
-    {
-      previousTab,
-      nextTab,
-    }: {
-      previousTab: ChatPanelTab | null | undefined;
-      nextTab: ChatPanelTab | null | undefined;
+  (get, set, viewportWidth: number | undefined) => {
+    if (
+      !isChatPanelTabStationAvailable(
+        get(activeChatPanelTabAtom),
+        viewportWidth
+      )
+    ) {
+      return false;
     }
-  ) => {
-    const previousStationAvailable =
-      isChatPanelTabStationAvailable(previousTab);
-    const nextStationAvailable = isChatPanelTabStationAvailable(nextTab);
-
-    if (!nextStationAvailable) {
-      if (
-        previousStationAvailable &&
-        get(stationUnavailableTabPriorMaximizedAtom) === null
-      ) {
-        set(
-          stationUnavailableTabPriorMaximizedAtom,
-          get(chatPanelMaximizedAtom)
-        );
-      }
-      if (!get(chatPanelMaximizedAtom)) {
-        set(chatPanelMaximizedAtom, true);
-      }
-      return;
-    }
-
-    if (!previousStationAvailable) {
-      const priorMaximized = get(stationUnavailableTabPriorMaximizedAtom);
-      if (priorMaximized !== null) {
-        set(chatPanelMaximizedAtom, priorMaximized);
-      }
-      set(stationUnavailableTabPriorMaximizedAtom, null);
-    }
+    set(toggleChatPanelMaximizedAtom);
+    return true;
   }
 );
+toggleActiveChatPanelMaximizedAtom.debugLabel =
+  "toggleActiveChatPanelMaximized";
 
 /** Make the active tab's legacy surface atoms match its canonical identity. */
 const syncChatPanelTabNavigationAtom = atom(
@@ -181,9 +127,8 @@ const syncChatPanelTabNavigationAtom = atom(
 
 /**
  * Reconcile legacy surface state after hydration or layout changes.
- * Station-free tabs are repaired to full-screen here as a hydration/layout
- * safety net; the effective layout atom also enforces the invariant at read
- * time so legacy direct writes cannot flash the Station open.
+ * Maximize behavior is derived at the layout boundary from the active tab and
+ * viewport, so reconciliation never mutates the user's persisted preference.
  */
 export const syncActiveChatPanelTabStateAtom = atom(null, (get, set) => {
   const state = get(chatPanelTabsAtom);
@@ -200,15 +145,6 @@ export const syncActiveChatPanelTabStateAtom = atom(null, (get, set) => {
       get(chatPanelCreateTargetAtom) !== DEFAULT_CHAT_PANEL_CREATE_TARGET);
   if (!startPageOwnsExplicitNavigation) {
     set(syncChatPanelTabNavigationAtom, activeTab);
-  }
-
-  if (!isChatPanelTabStationAvailable(activeTab)) {
-    if (get(stationUnavailableTabPriorMaximizedAtom) === null) {
-      set(stationUnavailableTabPriorMaximizedAtom, get(chatPanelMaximizedAtom));
-    }
-    if (!get(chatPanelMaximizedAtom)) {
-      set(chatPanelMaximizedAtom, true);
-    }
   }
 });
 syncActiveChatPanelTabStateAtom.debugLabel = "syncActiveChatPanelTabState";
@@ -236,17 +172,9 @@ export const activateChatPanelTabAtom = atom(
     const state = get(chatPanelTabsAtom);
     const tab = state.tabs.find((candidate) => candidate.id === tabId);
     if (!tab) return;
-    const previousTab =
-      state.tabs.find((candidate) => candidate.id === state.activeTabId) ??
-      null;
-
     if (state.activeTabId !== tabId) {
       set(chatPanelTabsAtom, { ...state, activeTabId: tabId });
     }
-    set(transitionChatPanelTabPresentationAtom, {
-      previousTab,
-      nextTab: tab,
-    });
 
     set(syncChatPanelTabNavigationAtom, tab);
 
@@ -298,7 +226,7 @@ interface AppendAndActivateChatPanelTabOptions {
   repoPath?: string;
 }
 
-/** Append a tab and run the same presentation/navigation activation chain. */
+/** Append a tab and run the same navigation activation chain. */
 export const appendAndActivateChatPanelTabAtom = atom(
   null,
   (
@@ -307,14 +235,6 @@ export const appendAndActivateChatPanelTabAtom = atom(
     { tab, sessionName, repoPath }: AppendAndActivateChatPanelTabOptions
   ) => {
     const state = get(chatPanelTabsAtom);
-    const previousTab =
-      state.tabs.find((candidate) => candidate.id === state.activeTabId) ??
-      null;
-
-    set(transitionChatPanelTabPresentationAtom, {
-      previousTab,
-      nextTab: tab,
-    });
     set(chatPanelTabsAtom, {
       tabs: [...state.tabs, tab],
       activeTabId: tab.id,

--- a/src/store/chatPanel/chatPanelTabPresentationAtoms.ts
+++ b/src/store/chatPanel/chatPanelTabPresentationAtoms.ts
@@ -14,16 +14,46 @@ import {
   chatPanelMaximizedAtom,
   chatPanelNavigateAtom,
   chatPanelStartPageOpenAtom,
+  toggleChatPanelMaximizedAtom,
 } from "@src/store/ui/chatPanelAtom";
 
 import {
   type ChatPanelTab,
-  isChatPanelTabDefaultFullscreen,
+  isChatPanelTabStationAvailable,
 } from "./chatPanelTabsModel";
-import { chatPanelTabsAtom } from "./chatPanelTabsState";
+import {
+  activeChatPanelTabAtom,
+  chatPanelTabsAtom,
+} from "./chatPanelTabsState";
 
-/** Maximize-state snapshot taken before entering a default-fullscreen tab. */
-const defaultFullscreenTabPriorMaximizedAtom = atom<boolean | null>(null);
+/** Maximize-state snapshot taken before entering a Station-free tab. */
+const stationUnavailableTabPriorMaximizedAtom = atom<boolean | null>(null);
+
+/** Whether the active tab may reveal a Station beside the chat pane. */
+export const activeChatPanelTabStationAvailableAtom = atom((get) => {
+  return isChatPanelTabStationAvailable(get(activeChatPanelTabAtom));
+});
+activeChatPanelTabStationAvailableAtom.debugLabel =
+  "activeChatPanelTabStationAvailable";
+
+/**
+ * Layout-authoritative maximize state. Station-free tabs remain full-screen
+ * even if an unrelated legacy writer changes the user's stored preference.
+ */
+export const effectiveChatPanelMaximizedAtom = atom(
+  (get) =>
+    get(chatPanelMaximizedAtom) || !get(activeChatPanelTabStationAvailableAtom)
+);
+effectiveChatPanelMaximizedAtom.debugLabel = "effectiveChatPanelMaximized";
+
+/** User toggle guarded by the active tab's Station capability. */
+export const toggleActiveChatPanelMaximizedAtom = atom(null, (get, set) => {
+  if (!get(activeChatPanelTabStationAvailableAtom)) return false;
+  set(toggleChatPanelMaximizedAtom);
+  return true;
+});
+toggleActiveChatPanelMaximizedAtom.debugLabel =
+  "toggleActiveChatPanelMaximized";
 
 export const transitionChatPanelTabPresentationAtom = atom(
   null,
@@ -38,14 +68,17 @@ export const transitionChatPanelTabPresentationAtom = atom(
       nextTab: ChatPanelTab | null | undefined;
     }
   ) => {
-    const previousDefaultFullscreen =
-      isChatPanelTabDefaultFullscreen(previousTab);
-    const nextDefaultFullscreen = isChatPanelTabDefaultFullscreen(nextTab);
+    const previousStationAvailable =
+      isChatPanelTabStationAvailable(previousTab);
+    const nextStationAvailable = isChatPanelTabStationAvailable(nextTab);
 
-    if (nextDefaultFullscreen) {
-      if (!previousDefaultFullscreen) {
+    if (!nextStationAvailable) {
+      if (
+        previousStationAvailable &&
+        get(stationUnavailableTabPriorMaximizedAtom) === null
+      ) {
         set(
-          defaultFullscreenTabPriorMaximizedAtom,
+          stationUnavailableTabPriorMaximizedAtom,
           get(chatPanelMaximizedAtom)
         );
       }
@@ -55,15 +88,12 @@ export const transitionChatPanelTabPresentationAtom = atom(
       return;
     }
 
-    if (previousDefaultFullscreen) {
-      const priorMaximized = get(defaultFullscreenTabPriorMaximizedAtom);
-      // A manual Workstation restore while Kanban is active is an
-      // explicit override. Preserve it instead of restoring an older
-      // maximized state when the user later changes tabs.
-      if (get(chatPanelMaximizedAtom) && priorMaximized !== null) {
+    if (!previousStationAvailable) {
+      const priorMaximized = get(stationUnavailableTabPriorMaximizedAtom);
+      if (priorMaximized !== null) {
         set(chatPanelMaximizedAtom, priorMaximized);
       }
-      set(defaultFullscreenTabPriorMaximizedAtom, null);
+      set(stationUnavailableTabPriorMaximizedAtom, null);
     }
   }
 );
@@ -151,8 +181,9 @@ const syncChatPanelTabNavigationAtom = atom(
 
 /**
  * Reconcile legacy surface state after hydration or layout changes.
- * Presentation defaults are applied only on tab entry so a manual Workstation
- * restore is not overwritten while Kanban remains active.
+ * Station-free tabs are repaired to full-screen here as a hydration/layout
+ * safety net; the effective layout atom also enforces the invariant at read
+ * time so legacy direct writes cannot flash the Station open.
  */
 export const syncActiveChatPanelTabStateAtom = atom(null, (get, set) => {
   const state = get(chatPanelTabsAtom);
@@ -171,11 +202,13 @@ export const syncActiveChatPanelTabStateAtom = atom(null, (get, set) => {
     set(syncChatPanelTabNavigationAtom, activeTab);
   }
 
-  if (
-    isChatPanelTabDefaultFullscreen(activeTab) &&
-    get(defaultFullscreenTabPriorMaximizedAtom) === null
-  ) {
-    set(defaultFullscreenTabPriorMaximizedAtom, get(chatPanelMaximizedAtom));
+  if (!isChatPanelTabStationAvailable(activeTab)) {
+    if (get(stationUnavailableTabPriorMaximizedAtom) === null) {
+      set(stationUnavailableTabPriorMaximizedAtom, get(chatPanelMaximizedAtom));
+    }
+    if (!get(chatPanelMaximizedAtom)) {
+      set(chatPanelMaximizedAtom, true);
+    }
   }
 });
 syncActiveChatPanelTabStateAtom.debugLabel = "syncActiveChatPanelTabState";

--- a/src/store/chatPanel/chatPanelTabsAtom.ts
+++ b/src/store/chatPanel/chatPanelTabsAtom.ts
@@ -69,9 +69,13 @@ export {
 } from "./chatPanelTabFactory";
 export {
   activateChatPanelTabAtom,
+  activeChatPanelTabStationAvailableAtom,
+  effectiveChatPanelMaximizedAtom,
   syncActiveChatPanelTabStateAtom,
+  toggleActiveChatPanelMaximizedAtom,
 } from "./chatPanelTabPresentationAtoms";
 export {
+  isChatPanelTabStationAvailable,
   normalizePersistedChatPanelTabsState,
   type ChatPanelSelectedChannel,
   type ChatPanelTab,

--- a/src/store/chatPanel/chatPanelTabsAtom.ts
+++ b/src/store/chatPanel/chatPanelTabsAtom.ts
@@ -69,14 +69,14 @@ export {
 } from "./chatPanelTabFactory";
 export {
   activateChatPanelTabAtom,
-  activeChatPanelTabStationAvailableAtom,
-  effectiveChatPanelMaximizedAtom,
   syncActiveChatPanelTabStateAtom,
   toggleActiveChatPanelMaximizedAtom,
 } from "./chatPanelTabPresentationAtoms";
 export {
+  CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX,
   isChatPanelTabStationAvailable,
   normalizePersistedChatPanelTabsState,
+  resolveChatPanelMaximizedForLayout,
   type ChatPanelSelectedChannel,
   type ChatPanelTab,
   type ChatPanelTabsState,

--- a/src/store/chatPanel/chatPanelTabsModel.ts
+++ b/src/store/chatPanel/chatPanelTabsModel.ts
@@ -127,7 +127,7 @@ type ChatPanelTabStationAccess = "always" | "wide-only";
  * Minimum viewport width at which standalone Chat Panel surfaces may share
  * the workbench with a Station pane.
  */
-export const CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX = 1600;
+export const CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX = 1920;
 
 /**
  * When a Chat Panel tab can share the workbench with a Station surface.

--- a/src/store/chatPanel/chatPanelTabsModel.ts
+++ b/src/store/chatPanel/chatPanelTabsModel.ts
@@ -127,7 +127,7 @@ type ChatPanelTabStationAccess = "always" | "wide-only";
  * Minimum viewport width at which standalone Chat Panel surfaces may share
  * the workbench with a Station pane.
  */
-export const CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX = 1440;
+export const CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX = 1600;
 
 /**
  * When a Chat Panel tab can share the workbench with a Station surface.

--- a/src/store/chatPanel/chatPanelTabsModel.ts
+++ b/src/store/chatPanel/chatPanelTabsModel.ts
@@ -121,34 +121,41 @@ export interface ChatPanelTabsState {
 /** Fixed id of the shared cloud/local organization management tab. */
 export const ORGANIZATION_TAB_ID = "chat-organization-management";
 
-type ChatPanelTabStationAccess = "available" | "unavailable";
+type ChatPanelTabStationAccess = "always" | "wide-only";
 
 /**
- * Whether a Chat Panel tab can share the workbench with a Station surface.
+ * Minimum viewport width at which standalone Chat Panel surfaces may share
+ * the workbench with a Station pane.
+ */
+export const CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX = 1440;
+
+/**
+ * When a Chat Panel tab can share the workbench with a Station surface.
  *
  * This record is intentionally exhaustive: a new tab type must make an
  * explicit layout decision instead of silently inheriting an unsafe default.
- * Conversation-oriented tabs can remain docked beside the Station; standalone
- * management and detail surfaces own the full content area.
+ * Conversation-oriented tabs can always remain docked beside the Station;
+ * standalone management and detail surfaces unlock the split layout only on
+ * a wide desktop viewport.
  */
 const CHAT_PANEL_TAB_STATION_ACCESS: Record<
   ChatPanelTabType,
   ChatPanelTabStationAccess
 > = {
-  session: "available",
-  terminal: "available",
-  "start-page": "available",
-  channel: "available",
-  runtime: "unavailable",
-  "team-inbox": "unavailable",
-  "work-management": "unavailable",
-  workspace: "unavailable",
-  organization: "unavailable",
-  "work-item": "unavailable",
-  "github-issue": "unavailable",
-  "github-pr": "unavailable",
-  project: "unavailable",
-  explore: "unavailable",
+  session: "always",
+  terminal: "always",
+  "start-page": "always",
+  channel: "always",
+  runtime: "wide-only",
+  "team-inbox": "wide-only",
+  "work-management": "wide-only",
+  workspace: "wide-only",
+  organization: "wide-only",
+  "work-item": "wide-only",
+  "github-issue": "wide-only",
+  "github-pr": "wide-only",
+  project: "wide-only",
+  explore: "wide-only",
 };
 
 /**
@@ -172,11 +179,29 @@ const PERSISTED_CHAT_PANEL_TAB_TYPES = new Set<ChatPanelTabType>([
 ]);
 
 export function isChatPanelTabStationAvailable(
-  tabOrType: ChatPanelTab | ChatPanelTabType | null | undefined
+  tabOrType: ChatPanelTab | ChatPanelTabType | null | undefined,
+  viewportWidth: number | undefined
 ): boolean {
   const type =
     typeof tabOrType === "string" ? tabOrType : (tabOrType?.type ?? null);
-  return type === null || CHAT_PANEL_TAB_STATION_ACCESS[type] === "available";
+  if (type === null) return true;
+  const access = CHAT_PANEL_TAB_STATION_ACCESS[type];
+  return (
+    access === "always" ||
+    (viewportWidth !== undefined &&
+      viewportWidth >= CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX)
+  );
+}
+
+/** Resolve the layout without mutating the user's persisted maximize choice. */
+export function resolveChatPanelMaximizedForLayout(
+  userMaximized: boolean,
+  tabOrType: ChatPanelTab | ChatPanelTabType | null | undefined,
+  viewportWidth: number | undefined
+): boolean {
+  return (
+    userMaximized || !isChatPanelTabStationAvailable(tabOrType, viewportWidth)
+  );
 }
 
 export function getWorkManagementFallbackTitle(

--- a/src/store/chatPanel/chatPanelTabsModel.ts
+++ b/src/store/chatPanel/chatPanelTabsModel.ts
@@ -121,9 +121,35 @@ export interface ChatPanelTabsState {
 /** Fixed id of the shared cloud/local organization management tab. */
 export const ORGANIZATION_TAB_ID = "chat-organization-management";
 
-const DEFAULT_FULLSCREEN_CHAT_PANEL_TAB_TYPES = new Set<ChatPanelTabType>([
-  "work-management",
-]);
+type ChatPanelTabStationAccess = "available" | "unavailable";
+
+/**
+ * Whether a Chat Panel tab can share the workbench with a Station surface.
+ *
+ * This record is intentionally exhaustive: a new tab type must make an
+ * explicit layout decision instead of silently inheriting an unsafe default.
+ * Conversation-oriented tabs can remain docked beside the Station; standalone
+ * management and detail surfaces own the full content area.
+ */
+const CHAT_PANEL_TAB_STATION_ACCESS: Record<
+  ChatPanelTabType,
+  ChatPanelTabStationAccess
+> = {
+  session: "available",
+  terminal: "available",
+  "start-page": "available",
+  channel: "available",
+  runtime: "unavailable",
+  "team-inbox": "unavailable",
+  "work-management": "unavailable",
+  workspace: "unavailable",
+  organization: "unavailable",
+  "work-item": "unavailable",
+  "github-issue": "unavailable",
+  "github-pr": "unavailable",
+  project: "unavailable",
+  explore: "unavailable",
+};
 
 /**
  * Tab types safe to restore from persisted state. Terminals are process-bound,
@@ -145,12 +171,12 @@ const PERSISTED_CHAT_PANEL_TAB_TYPES = new Set<ChatPanelTabType>([
   "channel",
 ]);
 
-export function isChatPanelTabDefaultFullscreen(
+export function isChatPanelTabStationAvailable(
   tabOrType: ChatPanelTab | ChatPanelTabType | null | undefined
 ): boolean {
   const type =
     typeof tabOrType === "string" ? tabOrType : (tabOrType?.type ?? null);
-  return type !== null && DEFAULT_FULLSCREEN_CHAT_PANEL_TAB_TYPES.has(type);
+  return type === null || CHAT_PANEL_TAB_STATION_ACCESS[type] === "available";
 }
 
 export function getWorkManagementFallbackTitle(

--- a/src/store/ui/chatPanelAtom.ts
+++ b/src/store/ui/chatPanelAtom.ts
@@ -721,10 +721,10 @@ export const activeChatPanelSurfaceAtom = atom<ChatPanelSurfaceState>((get) => {
 activeChatPanelSurfaceAtom.debugLabel = "activeChatPanelSurfaceAtom";
 
 /**
- * Whether the chat-panel slot covers the entire main content area.
- * Maximizing is purely a slot-side affordance; the underlying station
- * mode never changes, so un-maximize requires no bookkeeping. Persisted
- * so a maximized layout survives reloads.
+ * The user's persisted preference for whether the chat-panel slot covers the
+ * entire main content area. The active tab's Station capability may force the
+ * effective layout full-screen temporarily; that presentation layer snapshots
+ * and restores this preference without changing the underlying Station mode.
  */
 export const chatPanelMaximizedAtom = atomWithStorage<boolean>(
   "orgii:chatPanelMaximized",

--- a/src/store/ui/chatPanelAtom.ts
+++ b/src/store/ui/chatPanelAtom.ts
@@ -722,9 +722,9 @@ activeChatPanelSurfaceAtom.debugLabel = "activeChatPanelSurfaceAtom";
 
 /**
  * The user's persisted preference for whether the chat-panel slot covers the
- * entire main content area. The active tab's Station capability may force the
- * effective layout full-screen temporarily; that presentation layer snapshots
- * and restores this preference without changing the underlying Station mode.
+ * entire main content area. The active tab and viewport may force the effective
+ * layout full-screen temporarily, but that layout is derived without mutating
+ * this preference or the underlying Station mode.
  */
 export const chatPanelMaximizedAtom = atomWithStorage<boolean>(
   "orgii:chatPanelMaximized",


### PR DESCRIPTION
## Problem

Standalone ChatPane tabs such as Work Items, Team Inbox, Runtime, Work Management, and project/detail surfaces competed with Station for space on ordinary screens. Their Station controls and service actions remained available even when a split layout was not useful. The maximize state also doubled as both a saved user preference and a forced tab layout, which made it difficult to preserve a session's prior ChatPane + Station arrangement when navigating away and back.

Separately, the tab close-control scrim mounted at full opacity before the tab hover background completed its transition, producing a shade flash on first hover.

## Solution

Define one exhaustive Station-access policy for every ChatPane tab type:

- Conversation tabs (`session`, `terminal`, `start-page`, and `channel`) remain Station-capable at every viewport width.
- Standalone management/detail tabs are `wide-only`: below `1920px` they render full-screen with the Station control disabled and its shortcut omitted; at `1920px` and above the second pane is available again.

The rendered layout is now derived from the active tab, viewport width, and the user's persisted maximize preference. It never mutates that preference to force a layout, so switching from a split session to a work item and back restores the original split naturally; crossing the breakpoint behaves the same way. Header controls, global/service actions, and layout sizing all consume the same policy. The existing viewport-width ownership is consolidated into one AppShell subscription and passed down to AppLayout and ChatPanel. Resize bursts are coalesced to one animation-frame update. Narrow-layout focus owns one ResizeObserver: the stable main-content target remains observed at idle, while the animated workbench target is attached only during a direct divider drag.

Keep the close-control scrim mounted at zero opacity and fade it over the same 150 ms transition as the tab surface, eliminating the first-hover ordering mismatch. Focused regression tests cover the exhaustive capability matrix, the exact breakpoint, session restoration, guarded service actions, and hover lifecycle.

## Potential risks

`1920px` is a product breakpoint and may need tuning after visual review on dense or scaled displays. Crossing it can reveal or hide Station immediately when the saved preference is split; this is intentional and the saved preference remains unchanged. AppShell now receives the existing resize updates so the whole layout can make one consistent decision; this removes duplicate listeners, but no runtime profiling was performed, so resize rendering remains an explicitly unmeasured path.

No persistence format, database schema, wire protocol, backend, dependency, or destructive data changes are included. Rollback is a normal revert of commits `1f8a8ff40`, `747ccb0f9`, `5e37b61ac`, `e7cfe0b77`, and `04a7e47ea`. Rendered screenshots and desktop manual interaction were not run because this workspace requires explicit user opt-in for desktop UI control; automated component, state, and service coverage is included instead.

## Audit

Architecture audit covered compilation, live call paths/dead state, naming, semantic ownership, exhaustive defaults, cross-domain boundaries, developer clarity, wire protocol, initialization parity, and resolver symmetry. The final design removes the temporary snapshot/transition atoms, keeps the persisted preference distinct from effective layout, and centralizes the policy in an exhaustive typed record. Wire, initialization, and resolver-boundary layers are unaffected.

Frontend UI audit: 1 fix applied, 6 elements kept with documented reasons, and 0 abstraction candidates. See `docs/frontend-ui-audit-2026-08-08/ChatPanelStationAvailability.md`.

Performance-guard verdict: pass. Background work: no width polling, intervals, retries, or scans; one AppShell resize listener is requestAnimationFrame-coalesced and removes its listener/cancels a pending frame on unmount. Width observation: one ResizeObserver watches main content at idle, observes the workbench only during direct dragging, unobserves it when dragging ends, and disconnects on unmount; a MutationObserver exists only until the layout nodes first mount, then disconnects. Memory: fixed refs only, with no cache or per-tab snapshot growth. Scope/isolation: window-layout-only with no user/workspace identity sharing. Rendering: constant-time policy resolution and at most one React viewport update per frame. Lifecycle is unit-tested; runtime CPU/RSS was not manually profiled, so no measured performance-improvement claim is made.

## Verification

- `pnpm exec vitest run src/engines/ChatPanel/hooks/useViewportWidth.test.ts src/hooks/workStation/useNarrowChatFocus.test.ts src/store/chatPanel/__tests__/chatPanelTabStationAccess.test.ts src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts src/services/workStation/WorkStationViewService.test.ts` — 65 tests passed across 5 files, including listener/observer coalescing and cleanup.
- `pnpm exec vitest run src/engines/ChatPanel/ChatPanelTabBar.test.ts` — 4 tests passed; 69 focused tests passed in total.
- `pnpm exec eslint src/engines/ChatPanel/hooks/useViewportWidth.ts src/engines/ChatPanel/hooks/useViewportWidth.test.ts src/hooks/workStation/useNarrowChatFocus.ts src/hooks/workStation/useNarrowChatFocus.test.ts` — passed with no findings.
- `pnpm exec prettier --check docs/frontend-ui-audit-2026-08-08/ChatPanelStationAvailability.md src/engines/ChatPanel/hooks/useViewportWidth.ts src/engines/ChatPanel/hooks/useViewportWidth.test.ts src/hooks/workStation/useNarrowChatFocus.ts src/hooks/workStation/useNarrowChatFocus.test.ts` — passed.
- `pnpm typecheck` — passed.
- `pnpm exec eslint src/engines/ChatPanel/index.tsx src/engines/ChatPanel/types.ts src/modules/index.tsx src/modules/shared/layouts/AppLayout.tsx src/services/workStation/WorkStationViewService.test.ts src/services/workStation/WorkStationViewService.ts src/store/chatPanel/__tests__/chatPanelTabStationAccess.test.ts src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts src/store/chatPanel/chatPanelTabLifecycleAtoms.ts src/store/chatPanel/chatPanelTabPresentationAtoms.ts src/store/chatPanel/chatPanelTabsAtom.ts src/store/chatPanel/chatPanelTabsModel.ts src/store/ui/chatPanelAtom.ts` — passed with no findings.
- `pnpm exec prettier --check docs/frontend-ui-audit-2026-08-08/ChatPanelStationAvailability.md src/engines/ChatPanel/index.tsx src/engines/ChatPanel/types.ts src/modules/index.tsx src/modules/shared/layouts/AppLayout.tsx src/services/workStation/WorkStationViewService.test.ts src/services/workStation/WorkStationViewService.ts src/store/chatPanel/__tests__/chatPanelTabStationAccess.test.ts src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts src/store/chatPanel/chatPanelTabLifecycleAtoms.ts src/store/chatPanel/chatPanelTabPresentationAtoms.ts src/store/chatPanel/chatPanelTabsAtom.ts src/store/chatPanel/chatPanelTabsModel.ts src/store/ui/chatPanelAtom.ts` — passed.
- `git diff --check` and `git diff --cached --check` — passed.
- Commit hook `lint-staged` and its scoped TypeScript check — passed.
- `git fetch origin develop` plus `git rev-list --left-right --count origin/develop...HEAD` — branch was 0 commits behind its base before the follow-up commit.
- Final diff scan found no credentials, private paths, debug logs, build artifacts, caches, dependency changes, or unrelated files.
- Not run: rendered desktop screenshot/manual interaction, due to the repository's explicit opt-in requirement for UI control.
