### PR TITLE
fix(sessions): show final replies for unloaded rounds

### DIFF
--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app/transcript.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app/transcript.rs
@@ -53,6 +53,7 @@ struct CodexTurnCatalogEntry {
     byte_offset: u64,
     started_at: String,
     user_preview: String,
+    last_agent_preview: Option<String>,
     following_line_count: usize,
 }
 
@@ -372,6 +373,7 @@ impl<'a> CodexTranscriptCollector<'a> {
     }
 
     fn compact_completed_turn(&mut self, completed: CompletedCodexTurn) {
+        let last_agent_preview = last_assistant_preview_from_chunks(&completed.chunks);
         if let Some(user_chunk) = completed.chunks.into_iter().find(is_codex_user_chunk) {
             let compacted_limit = match &self.mode {
                 CodexTranscriptCollectionMode::Initial { recent_turn_count } => {
@@ -392,6 +394,7 @@ impl<'a> CodexTranscriptCollector<'a> {
                     self.session_id,
                     &completed.summary,
                     completed.next_turn_id,
+                    last_agent_preview.as_deref(),
                 ),
             ]);
         }
@@ -423,6 +426,21 @@ fn is_codex_user_chunk(chunk: &ActivityChunk) -> bool {
     chunk.function == imported_history::FUNCTION_USER_MESSAGE
 }
 
+fn last_assistant_preview_from_chunks(chunks: &[ActivityChunk]) -> Option<String> {
+    chunks.iter().rev().find_map(|chunk| {
+        if chunk.function != imported_history::FUNCTION_ASSISTANT {
+            return None;
+        }
+        chunk
+            .result
+            .get("observation")
+            .or_else(|| chunk.result.get("content"))
+            .and_then(Value::as_str)
+            .filter(|message| !message.trim().is_empty())
+            .map(bounded_codex_turn_preview)
+    })
+}
+
 fn codex_sequence_from_chunk_id(chunk_id: &str) -> Option<i64> {
     chunk_id.rsplit('-').next()?.parse().ok()
 }
@@ -431,15 +449,22 @@ fn build_unloaded_turn_placeholder_chunk(
     session_id: &str,
     turn: &ProjectedTurnMetadata,
     next_turn_id: Option<String>,
+    last_agent_preview: Option<&str>,
 ) -> ActivityChunk {
+    let internal_placeholder = format!("Codex turn {} is not loaded yet.", turn.turn_id);
+    let display_content = last_agent_preview.unwrap_or(&internal_placeholder);
     let mut chunk = ActivityChunk::new(session_id, "assistant", "assistant");
     chunk.chunk_id = format!("codex-unloaded-turn-{}", turn.turn_id);
     chunk.created_at = turn
         .ended_at
         .clone()
         .unwrap_or_else(|| turn.started_at.clone());
+    if last_agent_preview.is_some() {
+        chunk.args = json!({ "turnPreviewOnly": true });
+    }
     chunk.result = json!({
-        "observation": format!("Codex turn {} is not loaded yet.", turn.turn_id),
+        "observation": display_content,
+        "content": display_content,
         "role": "assistant",
         "is_delta": false,
         "is_full_content": true,
@@ -579,11 +604,11 @@ pub fn load_codex_app_turn_from_path(
         sequence: initial_sequence,
     }];
     if start_offset > 0 {
-        if let Some(previous_offset) = find_recent_codex_user_offsets(path, start_offset, 1)?
+        if let Some(previous_entry) = find_recent_codex_user_offsets(path, start_offset, 1)?
             .into_iter()
             .next()
-            .map(|entry| entry.byte_offset)
         {
+            let previous_offset = previous_entry.byte_offset;
             if let Some((previous_user, mut previous_summary)) =
                 load_codex_turn_header(session_id, path, previous_offset)?
             {
@@ -602,6 +627,7 @@ pub fn load_codex_app_turn_from_path(
                     session_id,
                     &previous_summary,
                     Some(turn_id.to_string()),
+                    previous_entry.last_agent_preview.as_deref(),
                 ));
                 remembered_offsets.push(CodexTurnOffset {
                     turn_id: previous_summary.turn_id,
@@ -717,6 +743,7 @@ fn load_codex_app_initial_tail_window(
             session_id,
             &summary,
             next_turn_id,
+            entry.last_agent_preview.as_deref(),
         ));
         turns.push(summary);
     }
@@ -934,6 +961,7 @@ fn find_codex_user_offsets_in_range(
     let mut discarding_oversized_line = false;
     let mut entries = Vec::with_capacity(limit.min(CODEX_INITIAL_TURN_LIMIT));
     let mut lines_since_boundary = 0usize;
+    let mut last_agent_preview = None;
 
     while cursor > after_inclusive && entries.len() < limit {
         let block_start = cursor
@@ -965,6 +993,7 @@ fn find_codex_user_offsets_in_range(
                     &mut entries,
                     limit,
                     &mut lines_since_boundary,
+                    &mut last_agent_preview,
                 );
             } else {
                 skipped_boundary_fragment = true;
@@ -988,6 +1017,7 @@ fn find_codex_user_offsets_in_range(
                     &mut entries,
                     limit,
                     &mut lines_since_boundary,
+                    &mut last_agent_preview,
                 );
             }
         } else if discarding_oversized_line {
@@ -1010,12 +1040,43 @@ fn observe_codex_catalog_line(
     entries: &mut Vec<CodexTurnCatalogEntry>,
     limit: usize,
     lines_since_boundary: &mut usize,
+    last_agent_preview: &mut Option<String>,
 ) {
     const USER_MESSAGE_NEEDLE: &[u8] = b"\"user_message\"";
+    const AGENT_MESSAGE_NEEDLE: &[u8] = b"\"agent_message\"";
+    const ASSISTANT_ROLE_NEEDLE: &[u8] = b"\"assistant\"";
     if line.is_empty() {
         return;
     }
-    if entries.len() >= limit || memmem::find(line, USER_MESSAGE_NEEDLE).is_none() {
+    if entries.len() >= limit {
+        return;
+    }
+    if memmem::find(line, USER_MESSAGE_NEEDLE).is_none() {
+        if last_agent_preview.is_none()
+            && (memmem::find(line, AGENT_MESSAGE_NEEDLE).is_some()
+                || memmem::find(line, ASSISTANT_ROLE_NEEDLE).is_some())
+        {
+            if let Ok(parsed) = serde_json::from_slice::<CodexJsonlLine>(line) {
+                let payload_type = parsed.payload.get("type").and_then(Value::as_str);
+                let message = match payload_type {
+                    Some("agent_message") => parsed
+                        .payload
+                        .get("message")
+                        .and_then(Value::as_str)
+                        .map(ToString::to_string),
+                    Some("message")
+                        if parsed.payload.get("role").and_then(Value::as_str)
+                            == Some("assistant") =>
+                    {
+                        content_text_from_payload(&parsed.payload)
+                    }
+                    _ => None,
+                };
+                *last_agent_preview = message
+                    .filter(|message| !message.trim().is_empty())
+                    .map(|message| bounded_codex_turn_preview(&message));
+            }
+        }
         *lines_since_boundary = lines_since_boundary.saturating_add(1);
         return;
     }
@@ -1040,6 +1101,7 @@ fn observe_codex_catalog_line(
         byte_offset,
         started_at,
         user_preview: bounded_codex_turn_preview(&message),
+        last_agent_preview: last_agent_preview.take(),
         following_line_count: *lines_since_boundary,
     });
     *lines_since_boundary = 0;

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
@@ -258,11 +258,29 @@ fn codex_initial_window_catalogs_old_turns_and_loads_one_turn_on_demand() {
         Some(window.chunks[2].chunk_id.as_str())
     );
     assert_eq!(
+        window.chunks[1]
+            .result
+            .get("observation")
+            .and_then(Value::as_str),
+        Some("first reply")
+    );
+    assert_eq!(
+        window.chunks[1].args.get("turnPreviewOnly"),
+        Some(&Value::Bool(true))
+    );
+    assert_eq!(
         window.chunks[2]
             .result
             .pointer("/message/content")
             .and_then(Value::as_str),
         Some("second")
+    );
+    assert_eq!(
+        window.chunks[3]
+            .result
+            .get("observation")
+            .and_then(Value::as_str),
+        Some("second reply")
     );
     assert_eq!(
         window.chunks[4]
@@ -292,6 +310,13 @@ fn codex_initial_window_catalogs_old_turns_and_loads_one_turn_on_demand() {
     assert!(context_placeholder
         .chunk_id
         .starts_with("codex-unloaded-turn-"));
+    assert_eq!(
+        context_placeholder
+            .result
+            .get("observation")
+            .and_then(Value::as_str),
+        Some("first reply")
+    );
     assert_eq!(context_placeholder.created_at, turn.chunks[2].created_at);
     assert_ne!(context_placeholder.created_at, turn.chunks[0].created_at);
 
@@ -335,6 +360,13 @@ fn codex_current_rollout_reads_latest_turn_and_pages_backward_from_tail() {
         Some("first")
     );
     assert!(window.chunks[1].result.get("unloadedTurn").is_some());
+    assert_eq!(
+        window.chunks[1]
+            .result
+            .get("observation")
+            .and_then(Value::as_str),
+        Some("first reply")
+    );
     assert_eq!(
         window.chunks[2]
             .result
@@ -411,6 +443,18 @@ fn codex_initial_window_keeps_one_hundred_rounds_discoverable() {
             .filter(|chunk| chunk.result.get("unloadedTurn").is_some())
             .count(),
         99
+    );
+    assert!(window
+        .chunks
+        .iter()
+        .filter(|chunk| chunk.result.get("unloadedTurn").is_some())
+        .all(|chunk| chunk.args.get("turnPreviewOnly") == Some(&Value::Bool(true))));
+    assert_eq!(
+        window.chunks[197]
+            .result
+            .get("observation")
+            .and_then(Value::as_str),
+        Some("reply 98")
     );
     for (chunk_index, expected) in [(0, "round 0"), (98, "round 49"), (198, "round 99")] {
         assert_eq!(
@@ -494,6 +538,11 @@ fn codex_initial_window_real_fixture_catalog_stats() {
         .iter()
         .filter(|chunk| chunk.result.get("unloadedTurn").is_some())
         .count();
+    let preview_count = window
+        .chunks
+        .iter()
+        .filter(|chunk| chunk.args.get("turnPreviewOnly") == Some(&Value::Bool(true)))
+        .count();
 
     let warm_started = std::time::Instant::now();
     let warm = load_codex_app_initial_window_from_path("codexapp-real-catalog", path, 1)
@@ -511,7 +560,7 @@ fn codex_initial_window_real_fixture_catalog_stats() {
     assert_eq!(warm.turns.len(), window.turns.len());
     assert_eq!(placeholder_count, window.turns.len().saturating_sub(1));
     eprintln!(
-        "source_bytes={source_bytes} rounds={} chunks={} placeholders={placeholder_count} serialized_window_bytes={serialized_bytes} cold_ms={} warm_ms={}",
+        "source_bytes={source_bytes} rounds={} chunks={} placeholders={placeholder_count} previews={preview_count} serialized_window_bytes={serialized_bytes} cold_ms={} warm_ms={}",
         window.turns.len(),
         window.chunks.len(),
         cold_elapsed.as_millis(),

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/window.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/window.rs
@@ -13,9 +13,10 @@ use std::collections::{HashMap, HashSet};
 
 use crate::projectors::turn_metadata::{project_activity_chunks, ProjectedTurnMetadata};
 
-use super::{load_activity_chunks_for_session, FUNCTION_USER_MESSAGE};
+use super::{load_activity_chunks_for_session, FUNCTION_ASSISTANT, FUNCTION_USER_MESSAGE};
 
 const ORPHAN_INITIAL_CHUNK_LIMIT: usize = 200;
+const TURN_PREVIEW_MAX_BYTES: usize = 512;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -40,19 +41,52 @@ fn is_user_chunk(chunk: &ActivityChunk) -> bool {
     chunk.function == FUNCTION_USER_MESSAGE
 }
 
+fn bounded_turn_preview(message: &str) -> String {
+    if message.len() <= TURN_PREVIEW_MAX_BYTES {
+        return message.to_string();
+    }
+    let mut cut = TURN_PREVIEW_MAX_BYTES;
+    while !message.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    format!("{}…", &message[..cut])
+}
+
+fn assistant_preview_text(chunk: &ActivityChunk) -> Option<String> {
+    if chunk.function != FUNCTION_ASSISTANT {
+        return None;
+    }
+    chunk
+        .result
+        .get("observation")
+        .or_else(|| chunk.result.get("content"))
+        .or_else(|| chunk.result.pointer("/message/content"))
+        .or_else(|| chunk.args.get("content"))
+        .and_then(Value::as_str)
+        .filter(|message| !message.trim().is_empty())
+        .map(bounded_turn_preview)
+}
+
 fn build_unloaded_turn_placeholder_chunk(
     session_id: &str,
     turn: &ProjectedTurnMetadata,
     next_turn_id: Option<&str>,
+    last_agent_preview: Option<&str>,
 ) -> ActivityChunk {
+    let internal_placeholder = format!("Imported turn {} is not loaded yet.", turn.turn_id);
+    let display_content = last_agent_preview.unwrap_or(&internal_placeholder);
     let mut chunk = ActivityChunk::new(session_id, "assistant", "assistant");
     chunk.chunk_id = format!("imported-unloaded-turn-{}", turn.turn_id);
     chunk.created_at = turn
         .ended_at
         .clone()
         .unwrap_or_else(|| turn.started_at.clone());
+    if last_agent_preview.is_some() {
+        chunk.args = json!({ "turnPreviewOnly": true });
+    }
     chunk.result = json!({
-        "observation": format!("Imported turn {} is not loaded yet.", turn.turn_id),
+        "observation": display_content,
+        "content": display_content,
         "role": "assistant",
         "is_delta": false,
         "is_full_content": true,
@@ -155,18 +189,27 @@ pub fn build_initial_window_from_turns(
         } else {
             if let Some(turn) = turns.get(current_turn_index) {
                 window.push(build_user_preview_chunk(session_id, &chunk, turn));
+                let mut last_agent_preview = None;
+                while chunks.peek().is_some_and(|next| !is_user_chunk(next)) {
+                    if let Some(body) = chunks.next() {
+                        if let Some(preview) = assistant_preview_text(&body) {
+                            last_agent_preview = Some(preview);
+                        }
+                    }
+                }
                 window.push(build_unloaded_turn_placeholder_chunk(
                     session_id,
                     turn,
                     turns
                         .get(current_turn_index + 1)
                         .map(|next| next.turn_id.as_str()),
+                    last_agent_preview.as_deref(),
                 ));
             } else {
                 window.push(chunk);
-            }
-            while chunks.peek().is_some_and(|next| !is_user_chunk(next)) {
-                chunks.next();
+                while chunks.peek().is_some_and(|next| !is_user_chunk(next)) {
+                    chunks.next();
+                }
             }
         }
     }
@@ -320,6 +363,22 @@ mod tests {
         );
         assert!(window.chunks.iter().any(|chunk| chunk.chunk_id == "a3"));
         assert!(!window.chunks.iter().any(|chunk| chunk.chunk_id == "a1"));
+        let placeholders = window
+            .chunks
+            .iter()
+            .filter(|chunk| chunk.result.get("unloadedTurn").is_some())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            placeholders
+                .iter()
+                .filter_map(|chunk| chunk.result.get("observation"))
+                .filter_map(Value::as_str)
+                .collect::<Vec<_>>(),
+            vec!["answer one", "answer two"]
+        );
+        assert!(placeholders
+            .iter()
+            .all(|chunk| chunk.args.get("turnPreviewOnly") == Some(&Value::Bool(true))));
         let first_preview = window
             .chunks
             .iter()
@@ -329,6 +388,30 @@ mod tests {
             .expect("first preview");
         assert!(first_preview.len() <= 515);
         assert!(first_preview.ends_with('…'));
+    }
+
+    #[test]
+    fn initial_window_bounds_last_reply_preview_on_a_utf8_boundary() {
+        let long_reply = "🙂".repeat(200);
+        let chunks = vec![
+            chunk("u1", FUNCTION_USER_MESSAGE, "one"),
+            chunk("a1", FUNCTION_ASSISTANT, &long_reply),
+            chunk("u2", FUNCTION_USER_MESSAGE, "two"),
+            chunk("a2", FUNCTION_ASSISTANT, "answer two"),
+        ];
+
+        let window = build_initial_window("test-session", chunks, 1);
+        let preview = window.chunks[1]
+            .result
+            .get("observation")
+            .and_then(Value::as_str)
+            .expect("last reply preview");
+
+        assert!(preview.len() <= TURN_PREVIEW_MAX_BYTES + '…'.len_utf8());
+        assert!(preview.ends_with('…'));
+        assert!(preview[..preview.len() - '…'.len_utf8()]
+            .chars()
+            .all(|character| character == '🙂'));
     }
 
     #[test]

--- a/src/engines/ChatPanel/ChatHistory/hooks/__tests__/useChatGroups.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/__tests__/useChatGroups.test.ts
@@ -20,6 +20,7 @@ import { useChatGroups } from "../useChatGroups";
 import {
   type ChatGroupMeta,
   isTurnCollapseEligible,
+  isTurnPreviewItem,
   projectChatGroups,
 } from "../useChatGroupsProjection";
 
@@ -173,6 +174,26 @@ function turnPreviewItem(text: string): OptimizedChatItem {
   return preview;
 }
 
+function unloadedTurnPreviewItem(
+  turnId: string,
+  bodyEventCount: number,
+  text: string
+): OptimizedChatItem {
+  const preview = unloadedTurnItem(turnId, bodyEventCount);
+  preview.event!.functionName = "assistant";
+  preview.event!.actionType = "assistant";
+  preview.event!.source = "assistant";
+  preview.event!.displayText = text;
+  preview.event!.displayVariant = "message";
+  preview.event!.args = { turnPreviewOnly: true };
+  preview.event!.result = {
+    ...preview.event!.result,
+    observation: text,
+    content: text,
+  };
+  return preview;
+}
+
 function flatTexts(items: OptimizedChatItem[]): string[] {
   return items.map((entry) => entry.event?.displayText ?? "");
 }
@@ -264,6 +285,27 @@ describe("useChatGroups collapse — terminal error survival", () => {
     expect(result.groupMeta[0].unloadedTurn?.turnId).toBe(firstTurn.event!.id);
     expect(flatTexts(result.flatItems)).toContain("unloaded final reply");
     expect(flatTexts(result.flatItems)).not.toContain("Turn is not loaded yet");
+  });
+
+  it("shows a final-reply preview carried by the unloaded-turn placeholder", () => {
+    const firstTurn = userItem("first turn");
+    const preview = unloadedTurnPreviewItem(
+      firstTurn.event!.id,
+      12,
+      "bounded final reply"
+    );
+    const history = [
+      firstTurn,
+      preview,
+      userItem("current turn"),
+      assistantItem("current reply"),
+    ];
+
+    const result = useChatGroups(history);
+
+    expect(isTurnPreviewItem(preview)).toBe(true);
+    expect(result.groupMeta[0].unloadedTurn?.turnId).toBe(firstTurn.event!.id);
+    expect(flatTexts(result.flatItems)).toContain("bounded final reply");
   });
 
   it("keeps the error card when a collapsed turn has no completed assistant reply", () => {

--- a/src/engines/ChatPanel/ChatHistory/hooks/useChatGroups.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/useChatGroups.ts
@@ -16,6 +16,7 @@ import {
 export {
   getUnloadedTurnMeta,
   isTurnCollapseEligible,
+  isTurnPreviewItem,
 } from "./useChatGroupsProjection";
 export type {
   ChatGroupMeta,

--- a/src/engines/ChatPanel/ChatHistory/hooks/useChatGroupsProjection.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/useChatGroupsProjection.ts
@@ -100,7 +100,9 @@ function isUnloadedTurnItem(item: OptimizedChatItem | undefined): boolean {
   return getUnloadedTurnMeta(item) !== null;
 }
 
-function isTurnPreviewItem(item: OptimizedChatItem | undefined): boolean {
+export function isTurnPreviewItem(
+  item: OptimizedChatItem | undefined
+): boolean {
   return item?.event?.args?.turnPreviewOnly === true;
 }
 

--- a/src/engines/ChatPanel/ChatHistory/renderers/GroupItemRenderer.tsx
+++ b/src/engines/ChatPanel/ChatHistory/renderers/GroupItemRenderer.tsx
@@ -35,7 +35,7 @@ import type { OptimizedChatItem } from "../chatItemPipeline/types";
 import { NewEventDivider } from "../components/NewEventDivider";
 import TurnMetadataFooterSlot from "../components/TurnMetadataFooterSlot";
 import { CHAT_FOOTER_SPACER } from "../config/chatFooterSpacer";
-import { getUnloadedTurnMeta } from "../hooks/useChatGroups";
+import { getUnloadedTurnMeta, isTurnPreviewItem } from "../hooks/useChatGroups";
 import { ChatItemRenderer } from "./ChatItemRenderer";
 import ChatItemWrap from "./ChatItemWrap";
 
@@ -454,13 +454,15 @@ export const GroupItemRenderer: React.FC<GroupItemRendererProps> = memo(
     );
 
     const isStructuralUnloadedTurnItem = getUnloadedTurnMeta(chatItem) !== null;
+    const isHiddenUnloadedTurnItem =
+      isStructuralUnloadedTurnItem && !isTurnPreviewItem(chatItem);
     const isStructuralOnlyItem = chatItem?.structuralOnly === true;
     const groupMessageWrapClass = showGroupBubbleSenderChrome
       ? "!pt-2 !pb-0"
       : "!pt-1 !pb-0";
 
     const renderedItem =
-      chatItem && !isStructuralUnloadedTurnItem && !isStructuralOnlyItem ? (
+      chatItem && !isHiddenUnloadedTurnItem && !isStructuralOnlyItem ? (
         inboxTranscriptLabel && event ? (
           <ChatItemWrap variant="text" className="!py-1">
             <InboxTranscriptCard event={event} title={inboxTranscriptLabel} />

--- a/src/engines/ChatPanel/events/stream/agent-message/index.tsx
+++ b/src/engines/ChatPanel/events/stream/agent-message/index.tsx
@@ -342,11 +342,14 @@ export const AgentMessageEvent: React.FC<AgentMessageEventProps> = (props) => {
   );
 
   const variant = normalizedProps?.variant ?? props.variant;
+  const isTurnPreviewOnly =
+    props.event?.args?.turnPreviewOnly === true ||
+    normalizedProps?.args?.turnPreviewOnly === true;
 
   if (!normalizedProps && variant !== "chat") return null;
 
   if (variant === "chat") {
-    if (hasUnloadedTurnPayload(props)) return null;
+    if (hasUnloadedTurnPayload(props) && !isTurnPreviewOnly) return null;
 
     return (
       <ChatVariant


### PR DESCRIPTION
## Problem

Lazy-loaded external session history keeps each earlier round discoverable, but its unloaded placeholder discards the final assistant reply. The frontend then suppresses the placeholder as structural metadata, so collapsed historical rounds show only the Agent worked duration header even though the source transcript still contains the reply.

The regression began in `fb2e729d775638ac59f9223ca363bb8c8c55b831` when Codex history switched to one eagerly loaded recent body. Generic imported-history windows later inherited the same omission.

## Solution

Capture the last completed assistant message while constructing each unloaded historical round and carry a UTF-8-safe preview on the existing placeholder. Preview text is capped at 512 bytes and marked with `turnPreviewOnly`; only marked placeholders pass the two frontend structural-placeholder suppression gates.

The invariant is now: every unloaded round remains one user header plus one bounded placeholder, and that placeholder displays the last assistant reply when one exists. Expanding the round removes that same placeholder before merging the full body, preventing duplicate replies. Codex reverse catalogs, Codex backward paging context, and provider-neutral imported-history windows use the same wire contract.

No persisted transcript, database schema, public IPC shape, dependency, or lockfile changes are required. Existing histories are corrected when reloaded.

## Potential risks

- Replies longer than 512 bytes are intentionally truncated in the collapsed preview; expanding the round still loads the complete message.
- Interrupted rounds with no completed assistant message continue to show no reply preview.
- The Codex catalog retains up to 512 additional bytes per cataloged round, bounded by the existing 4,096-round cap. The existing path/signature cache scope and eviction behavior are unchanged.
- The renderer now permits only placeholders explicitly marked `turnPreviewOnly`; malformed or legacy structural placeholders remain hidden.
- Rollback is a revert of `e43155e82`; there is no stored-data remediation to reverse.

## Verification

- `cargo test -p orgtrack_core codex_initial_window_catalogs_old_turns_and_loads_one_turn_on_demand`
- `cargo test -p orgtrack_core codex_current_rollout_reads_latest_turn_and_pages_backward_from_tail`
- `cargo test -p orgtrack_core codex_initial_window_keeps_one_hundred_rounds_discoverable`
- `cargo test -p orgtrack_core sources::imported_history::window::tests`
- `cargo check -p orgtrack_core`
- `cargo clippy -p orgtrack_core --all-targets -- -D warnings`
- `pnpm vitest run src/engines/ChatPanel/ChatHistory/hooks/__tests__/useChatGroups.test.ts` — 18 passed
- Targeted ESLint for all changed frontend files
- `pnpm typecheck`
- `git diff --check`
- Real 13.35 MB Codex rollout: 49 rounds, 48 unloaded placeholders, 45 final-reply previews; the remaining three rounds had no completed assistant reply. Cold load 59 ms, warm load 19 ms.

## Audit

Architecture audit covered all 10 layers. The wire payload remains bounded, Codex and generic imported-history entry points use the same preview marker, and no default-branch, resolver, initialization, or cross-domain leakage issue was found.

Performance verdict: pass. No timer, polling, subscription, background scan, or extra rendered row was added. Visual automation was not run because repository policy prohibits Computer Use without explicit opt-in; backend real-fixture measurements and frontend projection tests cover the changed boundaries.