### PR TITLE
feat(launchpad): add solve work item picker

### DIFF
--- a/src-tauri/crates/integrations/src/github/commands/pulls.rs
+++ b/src-tauri/crates/integrations/src/github/commands/pulls.rs
@@ -65,7 +65,16 @@ query PullRequestCiStatuses($ids: [ID!]!) {
       commits(last: 1) {
         nodes {
           commit {
-            statusCheckRollup { state }
+            statusCheckRollup {
+              state
+              contexts(first: 100) {
+                nodes {
+                  __typename
+                  ... on CheckRun { conclusion }
+                  ... on StatusContext { state }
+                }
+              }
+            }
           }
         }
       }
@@ -276,6 +285,23 @@ fn parse_pull_request_ci_status(node: &Value) -> PullRequestCiStatus {
     let rollup = &node["commits"]["nodes"][0]["commit"]["statusCheckRollup"];
     if rollup.is_null() {
         return PullRequestCiStatus::None;
+    }
+    let has_failed_context = rollup["contexts"]["nodes"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .any(|context| match context["__typename"].as_str() {
+            Some("CheckRun") => matches!(
+                context["conclusion"].as_str(),
+                Some("FAILURE" | "TIMED_OUT" | "ACTION_REQUIRED" | "CANCELLED" | "STARTUP_FAILURE")
+            ),
+            Some("StatusContext") => {
+                matches!(context["state"].as_str(), Some("FAILURE" | "ERROR"))
+            }
+            _ => false,
+        });
+    if has_failed_context {
+        return PullRequestCiStatus::Failure;
     }
     match rollup["state"].as_str() {
         Some("SUCCESS") => PullRequestCiStatus::Success,
@@ -888,12 +914,14 @@ mod open_pr_item_tests {
     #[test]
     fn maps_batched_pull_request_ci_rollups() {
         assert!(PULL_REQUEST_CI_STATUS_QUERY.contains("nodes(ids: $ids)"));
+        assert!(PULL_REQUEST_CI_STATUS_QUERY.contains("contexts(first: 100)"));
 
         let mut items = vec![
             parse_open_pr_item(&json!({ "number": 17 })),
             parse_open_pr_item(&json!({ "number": 18 })),
             parse_open_pr_item(&json!({ "number": 19 })),
             parse_open_pr_item(&json!({ "number": 20 })),
+            parse_open_pr_item(&json!({ "number": 21 })),
         ];
 
         apply_pull_request_ci_statuses(
@@ -917,6 +945,30 @@ mod open_pr_item_tests {
                                 "nodes": [{
                                     "commit": {
                                         "statusCheckRollup": { "state": "PENDING" }
+                                    }
+                                }]
+                            }
+                        },
+                        {
+                            "number": 21,
+                            "commits": {
+                                "nodes": [{
+                                    "commit": {
+                                        "statusCheckRollup": {
+                                            "state": "PENDING",
+                                            "contexts": {
+                                                "nodes": [
+                                                    {
+                                                        "__typename": "CheckRun",
+                                                        "conclusion": "FAILURE"
+                                                    },
+                                                    {
+                                                        "__typename": "CheckRun",
+                                                        "conclusion": null
+                                                    }
+                                                ]
+                                            }
+                                        }
                                     }
                                 }]
                             }
@@ -948,6 +1000,7 @@ mod open_pr_item_tests {
         assert_eq!(items[1].ci_status, PullRequestCiStatus::Pending);
         assert_eq!(items[2].ci_status, PullRequestCiStatus::None);
         assert_eq!(items[3].ci_status, PullRequestCiStatus::Failure);
+        assert_eq!(items[4].ci_status, PullRequestCiStatus::Failure);
     }
 
     #[test]

--- a/src/components/PrCiStatusIndicator.tsx
+++ b/src/components/PrCiStatusIndicator.tsx
@@ -4,7 +4,6 @@ import {
   CircleDashed,
   CircleSlash,
   Ellipsis,
-  Loader2,
   LoaderCircle,
   Minus,
   X,
@@ -41,7 +40,7 @@ const PrCiStatusIndicator: React.FC<PrCiStatusIndicatorProps> = ({
       ) : status === "failure" ? (
         <X {...iconProps} />
       ) : status === "pending" ? (
-        <Loader2 {...iconProps} className="animate-spin" />
+        <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-warning-6" />
       ) : status === "none" ? (
         <Minus {...iconProps} />
       ) : (

--- a/src/components/PrCiStatusIndicator.tsx
+++ b/src/components/PrCiStatusIndicator.tsx
@@ -1,0 +1,83 @@
+import {
+  Check,
+  CheckCircle2,
+  CircleDashed,
+  CircleSlash,
+  Ellipsis,
+  Loader2,
+  LoaderCircle,
+  Minus,
+  X,
+  XCircle,
+} from "lucide-react";
+import React from "react";
+
+import type { PullRequestCiStatus } from "@src/api/tauri/github";
+
+export interface PrCiStatusIndicatorProps {
+  appearance?: "circled" | "simple";
+  className?: string;
+  dataTestId?: string;
+  label: string;
+  showLabel?: boolean;
+  size?: number;
+  status: PullRequestCiStatus;
+}
+
+const PrCiStatusIndicator: React.FC<PrCiStatusIndicatorProps> = ({
+  appearance = "circled",
+  className = "",
+  dataTestId,
+  label,
+  showLabel = true,
+  size = 14,
+  status,
+}) => {
+  const iconProps = { size, strokeWidth: 1.8 } as const;
+  const icon =
+    appearance === "simple" ? (
+      status === "success" ? (
+        <Check {...iconProps} />
+      ) : status === "failure" ? (
+        <X {...iconProps} />
+      ) : status === "pending" ? (
+        <Loader2 {...iconProps} className="animate-spin" />
+      ) : status === "none" ? (
+        <Minus {...iconProps} />
+      ) : (
+        <Ellipsis {...iconProps} />
+      )
+    ) : status === "success" ? (
+      <CheckCircle2 {...iconProps} />
+    ) : status === "failure" ? (
+      <XCircle {...iconProps} />
+    ) : status === "pending" ? (
+      <LoaderCircle {...iconProps} className="animate-spin" />
+    ) : status === "none" ? (
+      <CircleSlash {...iconProps} />
+    ) : (
+      <CircleDashed {...iconProps} />
+    );
+  const colorClass =
+    status === "success"
+      ? "text-success-6"
+      : status === "failure"
+        ? "text-danger-6"
+        : status === "pending"
+          ? "text-warning-6"
+          : "text-text-3";
+
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap ${colorClass} ${className}`}
+      title={label}
+      aria-label={label}
+      data-testid={dataTestId}
+    >
+      {icon}
+      {showLabel && <span>{label}</span>}
+    </span>
+  );
+};
+
+export default PrCiStatusIndicator;

--- a/src/engines/ChatPanel/ChatPanelStartPage.tsx
+++ b/src/engines/ChatPanel/ChatPanelStartPage.tsx
@@ -1,13 +1,17 @@
 import type { TFunction } from "i18next";
-import { ChevronRight, Download, Gauge, Import, KeyRound } from "lucide-react";
+import { Download, Gauge, Import, KeyRound } from "lucide-react";
 import React, { useCallback, useState } from "react";
 
-import { PILL_CONTROL_IDLE_SURFACE_CLASS } from "@src/components/CompoundPill/config";
 import SegmentedTextPill from "@src/components/SegmentedTextPill";
 import Select, { type SelectOption } from "@src/components/Select";
 import TabPill from "@src/components/TabPill";
 import { DETAIL_PANEL_TOKENS } from "@src/config/detailPanelTokens";
 import ImportSharedSessionDialog from "@src/features/Org2Cloud/ImportSharedSessionDialog";
+import {
+  type LaunchpadAction,
+  LaunchpadActionCard,
+  LaunchpadActionGrid,
+} from "@src/features/SessionCreator/components/LaunchpadActionGrid";
 import { CreatorContentLayout } from "@src/modules/shared/layouts/blocks";
 import { useAvailableAppUpdate } from "@src/scaffold/AppUpdater";
 import {
@@ -15,44 +19,7 @@ import {
   type ChatPanelCreateTarget,
 } from "@src/store/ui/chatPanelAtom";
 
-type StartPageActionTone = "primary" | "neutral" | "success" | "warning";
-type StartPageActionPresentation = "card" | "pill";
 type StartPageView = "session" | "work-item" | "more";
-
-interface ChatPanelStartPageAction {
-  id: string;
-  title: React.ReactNode;
-  icon: React.ReactNode;
-  onClick: () => void;
-  tone: StartPageActionTone;
-}
-
-const START_PAGE_ACTION_TONE_CLASS: Record<StartPageActionTone, string> = {
-  primary:
-    "border-primary-6/20 bg-primary-6/5 hover:border-primary-6/30 hover:bg-primary-6/10",
-  neutral: `border-border-2 hover:border-border-3 ${PILL_CONTROL_IDLE_SURFACE_CLASS}`,
-  success:
-    "border-success-6/20 bg-success-6/5 hover:border-success-6/30 hover:bg-success-6/10",
-  warning:
-    "border-warning-6/20 bg-warning-6/5 hover:border-warning-6/30 hover:bg-warning-6/10",
-};
-
-const START_PAGE_ACTION_CARD_TONE_CLASS: Record<StartPageActionTone, string> = {
-  primary:
-    "border-primary-6/20 hover:border-primary-6/30 hover:bg-surface-hover",
-  neutral: "border-border-2 hover:border-border-3 hover:bg-surface-hover",
-  success:
-    "border-success-6/20 hover:border-success-6/30 hover:bg-surface-hover",
-  warning:
-    "border-warning-6/20 hover:border-warning-6/30 hover:bg-surface-hover",
-};
-
-const START_PAGE_ACTION_ICON_TONE_CLASS: Record<StartPageActionTone, string> = {
-  primary: "text-primary-6",
-  neutral: "text-text-2",
-  success: "text-success-6",
-  warning: "text-warning-6",
-};
 
 interface ChatPanelStartPageProps {
   className?: string;
@@ -109,108 +76,6 @@ function StartPageCreatorModeToggle({
   );
 }
 
-function StartPageActionCard({
-  action,
-  presentation = "pill",
-}: {
-  action: ChatPanelStartPageAction;
-  presentation?: StartPageActionPresentation;
-}): React.ReactNode {
-  if (presentation === "card") {
-    return (
-      <button
-        type="button"
-        className={`group flex min-h-[68px] w-full flex-col items-start justify-between rounded-lg border bg-transparent px-2.5 py-2 text-left shadow-sm transition-colors focus-visible:border-primary-6 focus-visible:outline-none ${START_PAGE_ACTION_CARD_TONE_CLASS[action.tone]}`}
-        onClick={action.onClick}
-        data-testid={`chat-panel-start-page-${action.id}`}
-      >
-        <span
-          className={`flex h-5 w-5 shrink-0 items-center justify-center ${START_PAGE_ACTION_ICON_TONE_CLASS[action.tone]}`}
-        >
-          {action.icon}
-        </span>
-        <span className="block text-[12px] font-medium leading-4 text-text-1">
-          {action.title}
-        </span>
-      </button>
-    );
-  }
-
-  return (
-    <button
-      type="button"
-      className={`group flex w-full items-center gap-2 rounded-full border px-2 py-1.5 text-left transition-colors focus-visible:border-primary-6 focus-visible:outline-none ${START_PAGE_ACTION_TONE_CLASS[action.tone]}`}
-      onClick={action.onClick}
-      data-testid={`chat-panel-start-page-${action.id}`}
-    >
-      <span
-        className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-bg-2 text-text-2 transition-colors ${
-          action.tone === "warning" ? "group-hover:bg-fill-3" : ""
-        }`}
-      >
-        {action.icon}
-      </span>
-      <span className="block min-w-0 flex-1 truncate text-[13px] font-semibold text-text-1">
-        {action.title}
-      </span>
-      <ChevronRight
-        size={14}
-        strokeWidth={1.8}
-        className="shrink-0 text-text-3 opacity-0 transition-opacity group-hover:opacity-100"
-      />
-    </button>
-  );
-}
-
-function StartPageActionGrid({
-  actions,
-  className = "",
-  presentation = "pill",
-}: {
-  actions: ChatPanelStartPageAction[];
-  className?: string;
-  presentation?: StartPageActionPresentation;
-}): React.ReactNode {
-  const cardWidthClass =
-    actions.length >= 4
-      ? "max-w-[600px]"
-      : actions.length === 3
-        ? "max-w-[480px]"
-        : "max-w-[320px]";
-  const cardColumnClass =
-    actions.length >= 4
-      ? "@[560px]/startactions:grid-cols-4"
-      : actions.length === 3
-        ? "@[440px]/startactions:grid-cols-3"
-        : "";
-
-  return (
-    <div
-      className={`@container/startactions ${
-        presentation === "card"
-          ? `hidden @[640px]/focusedchat:block ${cardWidthClass}`
-          : ""
-      } ${className}`}
-    >
-      <div
-        className={
-          presentation === "card"
-            ? `grid grid-cols-1 gap-2 @[300px]/startactions:grid-cols-2 ${cardColumnClass}`
-            : "grid grid-cols-1 gap-3 @[420px]/startactions:grid-cols-2 @[800px]/startactions:grid-cols-3"
-        }
-      >
-        {actions.map((action) => (
-          <StartPageActionCard
-            key={action.id}
-            action={action}
-            presentation={presentation}
-          />
-        ))}
-      </div>
-    </div>
-  );
-}
-
 export function ChatPanelStartPage({
   className,
   createTarget,
@@ -231,28 +96,28 @@ export function ChatPanelStartPage({
   const [isImportSessionDialogOpen, setIsImportSessionDialogOpen] =
     useState(false);
   const availableUpdate = useAvailableAppUpdate();
-  const importSessionAction: ChatPanelStartPageAction = {
+  const importSessionAction: LaunchpadAction = {
     id: "import-session",
     title: t("navigation:cloud.share.importEntry"),
     icon: <Import size={16} strokeWidth={1.8} />,
     onClick: () => setIsImportSessionDialogOpen(true),
     tone: "neutral",
   };
-  const addApiKeyAction: ChatPanelStartPageAction = {
+  const addApiKeyAction: LaunchpadAction = {
     id: "add-api-key",
     title: t("chat.startPage.addApiKey.title"),
     icon: <KeyRound size={16} strokeWidth={1.8} />,
     onClick: onAddApiKey,
     tone: "neutral",
   };
-  const showRuntimeAction: ChatPanelStartPageAction = {
+  const showRuntimeAction: LaunchpadAction = {
     id: "show-runtime",
     title: t("chat.startPage.showRuntime.title"),
     icon: <Gauge size={16} strokeWidth={1.8} />,
     onClick: onShowRuntime,
     tone: "neutral",
   };
-  const utilityActions: ChatPanelStartPageAction[] = availableUpdate?.available
+  const utilityActions: LaunchpadAction[] = availableUpdate?.available
     ? [
         {
           id: "install-latest-update",
@@ -277,12 +142,13 @@ export function ChatPanelStartPage({
       : createTarget === CHAT_PANEL_CREATE_TARGET.WORK_ITEM
         ? "work-item"
         : "more";
+  const suggestionCards = utilityActions.map((action) => (
+    <LaunchpadActionCard key={action.id} action={action} presentation="card" />
+  ));
   const suggestionPills = (
-    <StartPageActionGrid
-      actions={utilityActions}
-      className="mx-auto w-full"
-      presentation="card"
-    />
+    <LaunchpadActionGrid className="mx-auto w-full" presentation="card">
+      {suggestionCards}
+    </LaunchpadActionGrid>
   );
   const manualMiddleContent = (
     <div
@@ -311,7 +177,7 @@ export function ChatPanelStartPage({
       t={t}
     />
   );
-  const sessionLauncherContent = sessionLauncher?.(suggestionPills);
+  const sessionLauncherContent = sessionLauncher?.(suggestionCards);
   const workItemLauncherContent = workItemLauncher?.(
     suggestionPills,
     manualMiddleContent,
@@ -454,7 +320,11 @@ export function ChatPanelStartPage({
           className={`shrink-0 px-4 pb-5 pt-2 ${DETAIL_PANEL_TOKENS.headerWidth}`}
           data-testid="chat-panel-start-page-utility-actions"
         >
-          <StartPageActionGrid actions={utilityActions} className="w-full" />
+          <LaunchpadActionGrid className="w-full">
+            {utilityActions.map((action) => (
+              <LaunchpadActionCard key={action.id} action={action} />
+            ))}
+          </LaunchpadActionGrid>
         </div>
       )}
       {isImportSessionDialogOpen && (

--- a/src/features/SessionCreator/components/LaunchpadActionGrid.tsx
+++ b/src/features/SessionCreator/components/LaunchpadActionGrid.tsx
@@ -1,0 +1,162 @@
+import { ChevronRight } from "lucide-react";
+import React, { Children, forwardRef } from "react";
+
+import { PILL_CONTROL_IDLE_SURFACE_CLASS } from "@src/components/CompoundPill/config";
+
+export type LaunchpadActionTone = "primary" | "neutral" | "success" | "warning";
+export type LaunchpadActionPresentation = "card" | "pill";
+
+export interface LaunchpadAction {
+  id: string;
+  title: React.ReactNode;
+  icon: React.ReactNode;
+  onClick: () => void;
+  tone: LaunchpadActionTone;
+}
+
+const ACTION_TONE_CLASS: Record<LaunchpadActionTone, string> = {
+  primary:
+    "border-primary-6/20 bg-primary-6/5 hover:border-primary-6/30 hover:bg-primary-6/10",
+  neutral: `border-border-2 hover:border-border-3 ${PILL_CONTROL_IDLE_SURFACE_CLASS}`,
+  success:
+    "border-success-6/20 bg-success-6/5 hover:border-success-6/30 hover:bg-success-6/10",
+  warning:
+    "border-warning-6/20 bg-warning-6/5 hover:border-warning-6/30 hover:bg-warning-6/10",
+};
+
+const ACTION_CARD_TONE_CLASS: Record<LaunchpadActionTone, string> = {
+  primary:
+    "border-primary-6/20 hover:border-primary-6/30 hover:bg-surface-hover",
+  neutral: "border-border-2 hover:border-border-3 hover:bg-surface-hover",
+  success:
+    "border-success-6/20 hover:border-success-6/30 hover:bg-surface-hover",
+  warning:
+    "border-warning-6/20 hover:border-warning-6/30 hover:bg-surface-hover",
+};
+
+const ACTION_ICON_TONE_CLASS: Record<LaunchpadActionTone, string> = {
+  primary: "text-primary-6",
+  neutral: "text-text-2",
+  success: "text-success-6",
+  warning: "text-warning-6",
+};
+
+interface LaunchpadActionCardProps extends Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  "onClick"
+> {
+  action: LaunchpadAction;
+  presentation?: LaunchpadActionPresentation;
+}
+
+export const LaunchpadActionCard = forwardRef<
+  HTMLButtonElement,
+  LaunchpadActionCardProps
+>(function LaunchpadActionCard(
+  { action, presentation = "pill", ...buttonProps },
+  ref
+) {
+  if (presentation === "card") {
+    return (
+      <button
+        {...buttonProps}
+        ref={ref}
+        type="button"
+        className={`group flex min-h-[68px] w-full flex-col items-start justify-between rounded-lg border bg-transparent px-2.5 py-2 text-left shadow-sm transition-colors focus-visible:border-primary-6 focus-visible:outline-none ${ACTION_CARD_TONE_CLASS[action.tone]}`}
+        onClick={action.onClick}
+        data-testid={
+          buttonProps["data-testid"] ?? `chat-panel-start-page-${action.id}`
+        }
+      >
+        <span
+          className={`flex h-5 w-5 shrink-0 items-center justify-center ${ACTION_ICON_TONE_CLASS[action.tone]}`}
+        >
+          {action.icon}
+        </span>
+        <span className="block text-[12px] font-medium leading-4 text-text-1">
+          {action.title}
+        </span>
+      </button>
+    );
+  }
+
+  return (
+    <button
+      {...buttonProps}
+      ref={ref}
+      type="button"
+      className={`group flex w-full items-center gap-2 rounded-full border px-2 py-1.5 text-left transition-colors focus-visible:border-primary-6 focus-visible:outline-none ${ACTION_TONE_CLASS[action.tone]}`}
+      onClick={action.onClick}
+      data-testid={
+        buttonProps["data-testid"] ?? `chat-panel-start-page-${action.id}`
+      }
+    >
+      <span
+        className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-bg-2 text-text-2 transition-colors ${
+          action.tone === "warning" ? "group-hover:bg-fill-3" : ""
+        }`}
+      >
+        {action.icon}
+      </span>
+      <span className="block min-w-0 flex-1 truncate text-[13px] font-semibold text-text-1">
+        {action.title}
+      </span>
+      <ChevronRight
+        size={14}
+        strokeWidth={1.8}
+        className="shrink-0 text-text-3 opacity-0 transition-opacity group-hover:opacity-100"
+      />
+    </button>
+  );
+});
+
+interface LaunchpadActionGridProps {
+  cardWidthClassName?: string;
+  children: React.ReactNode;
+  className?: string;
+  layoutActionCount?: number;
+  presentation?: LaunchpadActionPresentation;
+}
+
+export function LaunchpadActionGrid({
+  cardWidthClassName,
+  children,
+  className = "",
+  layoutActionCount,
+  presentation = "pill",
+}: LaunchpadActionGridProps): React.ReactNode {
+  const actionCount = layoutActionCount ?? Children.count(children);
+  const cardWidthClass =
+    cardWidthClassName ??
+    (actionCount >= 4
+      ? "max-w-[600px]"
+      : actionCount === 3
+        ? "max-w-[480px]"
+        : "max-w-[320px]");
+  const cardColumnClass =
+    actionCount >= 4
+      ? "@[560px]/startactions:grid-cols-4"
+      : actionCount === 3
+        ? "@[440px]/startactions:grid-cols-3"
+        : "";
+
+  return (
+    <div
+      className={`@container/startactions ${
+        presentation === "card"
+          ? `hidden @[640px]/focusedchat:block ${cardWidthClass}`
+          : ""
+      } ${className}`}
+    >
+      <div
+        className={
+          presentation === "card"
+            ? `grid grid-cols-1 gap-2 @[300px]/startactions:grid-cols-2 ${cardColumnClass}`
+            : "grid grid-cols-1 gap-3 @[420px]/startactions:grid-cols-2 @[800px]/startactions:grid-cols-3"
+        }
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/features/SessionCreator/components/LaunchpadActionGrid.tsx
+++ b/src/features/SessionCreator/components/LaunchpadActionGrid.tsx
@@ -45,6 +45,7 @@ interface LaunchpadActionCardProps extends Omit<
   React.ButtonHTMLAttributes<HTMLButtonElement>,
   "onClick"
 > {
+  "data-testid"?: string;
   action: LaunchpadAction;
   presentation?: LaunchpadActionPresentation;
 }
@@ -53,7 +54,7 @@ export const LaunchpadActionCard = forwardRef<
   HTMLButtonElement,
   LaunchpadActionCardProps
 >(function LaunchpadActionCard(
-  { action, presentation = "pill", ...buttonProps },
+  { action, presentation = "pill", "data-testid": dataTestId, ...buttonProps },
   ref
 ) {
   if (presentation === "card") {
@@ -64,9 +65,7 @@ export const LaunchpadActionCard = forwardRef<
         type="button"
         className={`group flex min-h-[68px] w-full flex-col items-start justify-between rounded-lg border bg-transparent px-2.5 py-2 text-left shadow-sm transition-colors focus-visible:border-primary-6 focus-visible:outline-none ${ACTION_CARD_TONE_CLASS[action.tone]}`}
         onClick={action.onClick}
-        data-testid={
-          buttonProps["data-testid"] ?? `chat-panel-start-page-${action.id}`
-        }
+        data-testid={dataTestId ?? `chat-panel-start-page-${action.id}`}
       >
         <span
           className={`flex h-5 w-5 shrink-0 items-center justify-center ${ACTION_ICON_TONE_CLASS[action.tone]}`}
@@ -87,9 +86,7 @@ export const LaunchpadActionCard = forwardRef<
       type="button"
       className={`group flex w-full items-center gap-2 rounded-full border px-2 py-1.5 text-left transition-colors focus-visible:border-primary-6 focus-visible:outline-none ${ACTION_TONE_CLASS[action.tone]}`}
       onClick={action.onClick}
-      data-testid={
-        buttonProps["data-testid"] ?? `chat-panel-start-page-${action.id}`
-      }
+      data-testid={dataTestId ?? `chat-panel-start-page-${action.id}`}
     >
       <span
         className={`flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-bg-2 text-text-2 transition-colors ${

--- a/src/features/SessionCreator/components/useWorktreeSourceData.ts
+++ b/src/features/SessionCreator/components/useWorktreeSourceData.ts
@@ -149,6 +149,8 @@ export interface UseWorktreeSourceDataOptions {
   open: boolean;
   repoId?: string;
   repoPath?: string;
+  /** Skip branch I/O for consumers that only need the shared GitHub slice. */
+  loadBranches?: boolean;
 }
 
 export interface WorktreeGithubSlice {
@@ -179,11 +181,12 @@ export function useWorktreeSourceData({
   open,
   repoId,
   repoPath,
+  loadBranches = true,
 }: UseWorktreeSourceDataOptions): UseWorktreeSourceDataResult {
   const githubRepoKey = resolveWorktreeRepoKey(repoId, repoPath);
   // Branch cache is keyed by raw repoId (matching `BranchPalette` /
   // `useBranchFetch`) so both selectors share one entry; fall back to repoPath.
-  const branchKey = repoId || repoPath || null;
+  const branchKey = loadBranches ? repoId || repoPath || null : null;
 
   // ============ GITHUB ============
   const [githubCache, setGithubCache] = useAtom(worktreeGithubCacheAtom);

--- a/src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx
@@ -1,5 +1,5 @@
 import { Airplay, Network } from "lucide-react";
-import React, { useMemo } from "react";
+import React, { Children, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { DispatchCategory } from "@src/api/tauri/session";
@@ -14,6 +14,7 @@ import type { ScrollNavState } from "@src/engines/ChatPanel/ChatHistory";
 import CollapsedInlineRow from "@src/engines/ChatPanel/InputArea/components/CollapsedInlineRow";
 import PinnedActionsBar from "@src/engines/ChatPanel/InputArea/components/PinnedActionsBar";
 import type { SessionLaunchWorkItemContext } from "@src/engines/SessionCore/hooks/session/useSessionCreator/useSessionLaunch/types";
+import { LaunchpadActionGrid } from "@src/features/SessionCreator/components/LaunchpadActionGrid";
 import {
   CREATOR_BOTTOM_DOCK_PADDING_CLASS,
   CREATOR_MIDDLE_POSITION_STYLE,
@@ -101,7 +102,6 @@ interface SessionCreatorChatPanelViewProps {
   sessionInfoProps: React.ComponentProps<typeof SessionInfoLine>;
   showMissingGitAlert: boolean;
   workItemContext: SessionLaunchWorkItemContext | null;
-  workItemPanelHostRef: React.RefObject<HTMLDivElement | null>;
 }
 
 const SessionCreatorChatPanelView: React.FC<
@@ -151,7 +151,6 @@ const SessionCreatorChatPanelView: React.FC<
   sessionInfoProps,
   showMissingGitAlert,
   workItemContext,
-  workItemPanelHostRef,
 }) => {
   const { t } = useTranslation("sessions");
   const sessionInfoLine = (
@@ -216,6 +215,8 @@ const SessionCreatorChatPanelView: React.FC<
       ) : null,
     [browserElementScrollNav]
   );
+  const [isLaunchpadWorkItemPickerOpen, setIsLaunchpadWorkItemPickerOpen] =
+    useState(false);
   const sessionSetupActions = !hideSessionSetupControls ? (
     <div
       className={`mx-auto flex w-full items-center ${DETAIL_PANEL_TOKENS.contentMaxWidth}`}
@@ -233,12 +234,15 @@ const SessionCreatorChatPanelView: React.FC<
             {cliLaunchModeSwitch && (
               <div aria-hidden className="mx-1 h-4 w-px shrink-0 bg-border-2" />
             )}
-            {!hideWorkItemAttachmentControl && (
+            {!hideWorkItemAttachmentControl && !isLaunchpadLayout && (
               <WorkItemAttachmentControl
+                composerInputRef={composerInputRef}
                 currentWorkItemContext={workItemContext}
                 onCreateWorkItem={onCreateWorkItem}
-                panelHostRef={workItemPanelHostRef}
                 onWorkItemContextChange={onAttachedWorkItemContextChange}
+                repoId={sessionInfoProps.repoId}
+                repoPath={sessionInfoProps.repoPath}
+                mode="add"
               />
             )}
             {orgMembersPanelProps && (
@@ -281,15 +285,57 @@ const SessionCreatorChatPanelView: React.FC<
       onClick={onCategoryPickerOpen}
     />
   );
+  const launchpadSuggestionContent = hideWorkItemAttachmentControl ? (
+    heroFooterSlot
+  ) : (
+    <LaunchpadActionGrid
+      cardWidthClassName={
+        isLaunchpadWorkItemPickerOpen
+          ? DETAIL_PANEL_TOKENS.contentMaxWidth
+          : undefined
+      }
+      className={`mx-auto w-full ${
+        isLaunchpadWorkItemPickerOpen
+          ? "!flex min-h-0 flex-1 flex-col [&>div]:h-full [&>div]:min-h-0"
+          : ""
+      }`}
+      layoutActionCount={Children.count(heroFooterSlot) + 1}
+      presentation="card"
+    >
+      <WorkItemAttachmentControl
+        composerInputRef={composerInputRef}
+        currentWorkItemContext={workItemContext}
+        onWorkItemContextChange={onAttachedWorkItemContextChange}
+        onPickerOpenChange={setIsLaunchpadWorkItemPickerOpen}
+        repoId={sessionInfoProps.repoId}
+        repoPath={sessionInfoProps.repoPath}
+        mode="solve"
+        presentation="card"
+      />
+      {!isLaunchpadWorkItemPickerOpen && heroFooterSlot}
+    </LaunchpadActionGrid>
+  );
   const launchpadMiddleContent = isLaunchpadLayout ? (
     <div
-      className="session-creator-chat-panel-launchpad-middle absolute inset-x-0 flex -translate-y-1/2 flex-col items-center gap-4"
-      style={CREATOR_MIDDLE_POSITION_STYLE}
+      className={`session-creator-chat-panel-launchpad-middle flex flex-col items-center gap-4 ${
+        isLaunchpadWorkItemPickerOpen
+          ? "relative min-h-0 w-full flex-1 justify-center overflow-hidden"
+          : "absolute inset-x-0 -translate-y-1/2"
+      }`}
+      style={
+        isLaunchpadWorkItemPickerOpen
+          ? undefined
+          : CREATOR_MIDDLE_POSITION_STYLE
+      }
     >
       {agentHero}
-      {heroFooterSlot && (
-        <div className="session-creator-chat-panel-launchpad-suggestions w-full">
-          {heroFooterSlot}
+      {launchpadSuggestionContent && (
+        <div
+          className={`session-creator-chat-panel-launchpad-suggestions w-full ${
+            isLaunchpadWorkItemPickerOpen ? "flex min-h-0 flex-1 flex-col" : ""
+          }`}
+        >
+          {launchpadSuggestionContent}
         </div>
       )}
     </div>
@@ -327,6 +373,10 @@ const SessionCreatorChatPanelView: React.FC<
     <div
       className={`session-creator-chat-panel-wrapper ${
         isLaunchpadLayout ? "h-full" : ""
+      } ${
+        isLaunchpadWorkItemPickerOpen
+          ? "session-creator-chat-panel-work-item-picker-open"
+          : ""
       } ${className}`}
       data-testid="session-creator-chat-panel"
     >
@@ -411,15 +461,6 @@ const SessionCreatorChatPanelView: React.FC<
               </InlineAlert>
             </div>
           )}
-
-          {!hideSessionSetupControls &&
-            !hideWorkItemAttachmentControl &&
-            !onCreateWorkItem && (
-              <div
-                ref={workItemPanelHostRef}
-                className={`mx-auto w-full ${DETAIL_PANEL_TOKENS.contentMaxWidth}`}
-              />
-            )}
 
           {!hideSessionSetupControls &&
             orgMembersPanelProps &&

--- a/src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.test.ts
+++ b/src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.test.ts
@@ -90,6 +90,29 @@ vi.mock(
             base_branch: "main",
             draft: true,
             ci_status: "failure",
+            author_login: "octocat",
+          },
+          {
+            number: 44,
+            title: "Running checks",
+            state: "open",
+            url: "https://github.com/acme/app/pull/44",
+            head_branch: "checks/running",
+            base_branch: "main",
+            draft: false,
+            ci_status: "pending",
+            author_login: "check-author",
+          },
+          {
+            number: 45,
+            title: "Loading checks",
+            state: "open",
+            url: "https://github.com/acme/app/pull/45",
+            head_branch: "checks/loading",
+            base_branch: "main",
+            draft: false,
+            ci_status: "unavailable",
+            author_login: "load-author",
           },
         ],
         issues: [
@@ -99,6 +122,10 @@ vi.mock(
             state: "open",
             html_url: "https://github.com/acme/app/issues/42",
             labels: [{ name: "bug" }],
+            user: {
+              login: "issue-author",
+              avatar_url: "https://example.com/issue-author.png",
+            },
           },
         ],
         repoFullName: "acme/app",
@@ -250,6 +277,27 @@ describe("WorkItemAttachmentControl", () => {
         ?.querySelector("svg")
         ?.classList.contains("lucide-x")
     ).toBe(true);
+    expect(inlinePicker?.textContent).toContain("@octocat");
+    expect(inlinePicker?.textContent).toContain("@issue-author");
+    const prMetadataText = container.querySelector(
+      '[data-testid="work-item-picker-option-github_pr:https://github.com/acme/app/pull/43"] .work-item-picker-option-metadata'
+    )?.textContent;
+    expect(prMetadataText?.indexOf("@octocat") ?? -1).toBeLessThan(
+      prMetadataText?.indexOf("draft") ?? -1
+    );
+    expect(
+      container
+        .querySelector(
+          '[data-testid="work-item-picker-ci-github_pr:https://github.com/acme/app/pull/44"]'
+        )
+        ?.querySelector("span")
+        ?.classList.contains("animate-pulse")
+    ).toBe(true);
+    expect(
+      container.querySelector(
+        '[data-testid="work-item-picker-ci-github_pr:https://github.com/acme/app/pull/45"]'
+      )
+    ).toBeNull();
     expect(
       container.querySelector(
         '[data-testid="session-creator-work-item-picker-back"]'

--- a/src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.test.ts
+++ b/src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.test.ts
@@ -12,6 +12,8 @@ import {
   vi,
 } from "vitest";
 
+import type { ComposerInputRef } from "@src/components/ComposerInput";
+
 import WorkItemAttachmentControl from "./WorkItemAttachmentControl";
 
 const dropdownMocks = vi.hoisted(() => ({
@@ -20,9 +22,37 @@ const dropdownMocks = vi.hoisted(() => ({
 }));
 
 const projectApiMocks = vi.hoisted(() => ({
-  readProjects: vi.fn().mockResolvedValue([]),
-  readStandaloneWorkItems: vi.fn().mockResolvedValue([]),
-  readWorkItems: vi.fn().mockResolvedValue([]),
+  readWorkspaceWorkItemsData: vi.fn().mockResolvedValue({
+    projectEntries: [
+      {
+        project: {
+          slug: "project-a",
+          meta: {
+            id: "project-id",
+            name: "Project A",
+            org_id: "org-id",
+          },
+        },
+        workItems: [
+          {
+            shortId: "ABC-1",
+            title: "Fix local work",
+            status: "in_progress",
+            priority: "high",
+            body: "Local work item body",
+            labels: [{ name: "frontend" }],
+            todos: [],
+          },
+        ],
+      },
+    ],
+    standaloneWorkItems: [],
+    orgs: [],
+  }),
+}));
+
+const worktreeMocks = vi.hoisted(() => ({
+  githubRefresh: vi.fn(),
 }));
 
 vi.mock("react-i18next", () => ({
@@ -45,6 +75,55 @@ vi.mock("@src/api/http/project", () => ({
   projectApi: projectApiMocks,
 }));
 
+vi.mock(
+  "@src/features/SessionCreator/components/useWorktreeSourceData",
+  () => ({
+    useWorktreeSourceData: () => ({
+      github: {
+        prs: [
+          {
+            number: 43,
+            title: "Draft account fix",
+            state: "open",
+            url: "https://github.com/acme/app/pull/43",
+            head_branch: "fix/account",
+            base_branch: "main",
+            draft: true,
+            ci_status: "failure",
+          },
+        ],
+        issues: [
+          {
+            number: 42,
+            title: "Fix login bug",
+            state: "open",
+            html_url: "https://github.com/acme/app/issues/42",
+            labels: [{ name: "bug" }],
+          },
+        ],
+        repoFullName: "acme/app",
+        state: "ready",
+        error: null,
+        refreshing: false,
+        refresh: worktreeMocks.githubRefresh,
+      },
+      branch: {
+        options: [],
+        state: "idle",
+        error: null,
+        refreshing: false,
+        refresh: vi.fn(),
+      },
+    }),
+  })
+);
+
+function findButton(text: string): HTMLButtonElement | undefined {
+  return Array.from(
+    document.querySelectorAll<HTMLButtonElement>("button")
+  ).find((button) => button.textContent?.trim() === text);
+}
+
 describe("WorkItemAttachmentControl", () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -59,9 +138,8 @@ describe("WorkItemAttachmentControl", () => {
   beforeEach(() => {
     dropdownMocks.close.mockClear();
     dropdownMocks.toggle.mockClear();
-    projectApiMocks.readProjects.mockClear();
-    projectApiMocks.readStandaloneWorkItems.mockClear();
-    projectApiMocks.readWorkItems.mockClear();
+    projectApiMocks.readWorkspaceWorkItemsData.mockClear();
+    worktreeMocks.githubRefresh.mockClear();
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -76,7 +154,7 @@ describe("WorkItemAttachmentControl", () => {
     Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
   });
 
-  it("navigates directly to the Work Item creator when provided", () => {
+  it("navigates directly to the Work Item creator outside solve mode", () => {
     const onCreateWorkItem = vi.fn();
     act(() => {
       root.render(
@@ -89,29 +167,270 @@ describe("WorkItemAttachmentControl", () => {
     );
     expect(trigger?.getAttribute("aria-haspopup")).toBeNull();
     expect(document.querySelector('[role="menu"]')).toBeNull();
-    expect(
-      document.querySelector('[data-testid="work-item-create-inline-panel"]')
-    ).toBeNull();
 
     act(() => {
       trigger?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
 
     expect(onCreateWorkItem).toHaveBeenCalledOnce();
-    expect(dropdownMocks.toggle).not.toHaveBeenCalled();
+    expect(projectApiMocks.readWorkspaceWorkItemsData).not.toHaveBeenCalled();
   });
 
-  it("retains the live link-existing flow without exposing inline creation", async () => {
+  it("replaces the Launchpad card with an inline picker and Back restores it", async () => {
+    const onPickerOpenChange = vi.fn();
+    act(() => {
+      root.render(
+        createElement(WorkItemAttachmentControl, {
+          mode: "solve",
+          onPickerOpenChange,
+          presentation: "card",
+        })
+      );
+    });
+
+    const card = container.querySelector<HTMLButtonElement>(
+      '[data-testid="chat-panel-start-page-solve-work-item"]'
+    );
+    expect(card).not.toBeNull();
+    expect(card?.className).toContain("flex-col");
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+
+    await act(async () => {
+      card?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onPickerOpenChange).toHaveBeenLastCalledWith(true);
+    const inlinePicker = container.querySelector(
+      '[data-testid="session-creator-work-item-inline-picker"]'
+    );
+    expect(inlinePicker).not.toBeNull();
+    expect(inlinePicker?.className).not.toContain("bg-bg-1");
+    expect(inlinePicker?.className).toContain("h-auto");
+    expect((inlinePicker as HTMLElement | null)?.style.maxHeight).toBe(
+      "min(520px, 100%)"
+    );
+    expect(
+      container.querySelector('[data-testid="work-item-picker-list"]')
+        ?.className
+    ).not.toContain("max-h-64");
+    expect(
+      container.querySelector('[data-testid="work-item-picker-list"]')
+        ?.className
+    ).toContain("overscroll-contain");
+    expect(
+      container.querySelector(
+        '[data-testid="work-item-picker-option-workitem:project-a/ABC-1"]'
+      )?.className
+    ).toContain("work-item-picker-option");
+    expect(
+      container.querySelector('[data-testid="work-item-picker-list"]')
+        ?.className
+    ).toContain("gap-0");
+    expect(
+      container.querySelector('[data-testid="work-item-picker-filter-all"]')
+        ?.className
+    ).toContain("text-[12px]");
+    expect(
+      container.querySelector(
+        '[data-testid="work-item-picker-kind-github_pr:https://github.com/acme/app/pull/43"]'
+      )?.className
+    ).toContain("text-text-2");
+    expect(
+      container.querySelector(
+        '[data-testid="work-item-picker-ci-github_pr:https://github.com/acme/app/pull/43"]'
+      )?.className
+    ).toContain("text-danger-6");
+    expect(
+      container
+        .querySelector(
+          '[data-testid="work-item-picker-ci-github_pr:https://github.com/acme/app/pull/43"]'
+        )
+        ?.querySelector("svg")
+        ?.classList.contains("lucide-x")
+    ).toBe(true);
+    expect(
+      container.querySelector(
+        '[data-testid="session-creator-work-item-picker-back"]'
+      )?.parentElement?.className
+    ).not.toContain("border-b");
+    expect(
+      container.querySelector(
+        '[data-testid="session-creator-work-item-picker-back"]'
+      )?.textContent
+    ).toBe("");
+    expect(
+      container.querySelector(
+        '[data-testid="session-creator-work-item-picker-refresh"]'
+      )?.parentElement
+    ).toBe(
+      container.querySelector(
+        '[data-testid="session-creator-work-item-picker-back"]'
+      )?.parentElement
+    );
+    expect(
+      container.querySelector(
+        '[data-testid="chat-panel-start-page-solve-work-item"]'
+      )
+    ).toBeNull();
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="session-creator-work-item-picker-refresh"]'
+        )
+        ?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(projectApiMocks.readWorkspaceWorkItemsData).toHaveBeenCalledTimes(2);
+    expect(worktreeMocks.githubRefresh).toHaveBeenCalledOnce();
+
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>(
+          '[data-testid="session-creator-work-item-picker-back"]'
+        )
+        ?.click();
+    });
+
+    expect(onPickerOpenChange).toHaveBeenLastCalledWith(false);
+    expect(
+      container.querySelector(
+        '[data-testid="chat-panel-start-page-solve-work-item"]'
+      )
+    ).not.toBeNull();
+  });
+
+  it("loads lazily, filters sources, and inserts selected items as composer pills", async () => {
+    const insertFilePill = vi.fn();
+    const focus = vi.fn();
+    const onWorkItemContextChange = vi.fn();
+    const composerInputRef = {
+      current: {
+        focus,
+        getFilePills: vi.fn(() => []),
+        insertFilePill,
+      } as unknown as ComposerInputRef,
+    };
+    act(() => {
+      root.render(
+        createElement(WorkItemAttachmentControl, {
+          composerInputRef,
+          mode: "solve",
+          onWorkItemContextChange,
+          repoId: "repo-id",
+          repoPath: "/repo",
+        })
+      );
+    });
+
+    expect(projectApiMocks.readWorkspaceWorkItemsData).not.toHaveBeenCalled();
+    const trigger = container.querySelector<HTMLButtonElement>(
+      '[data-testid="session-creator-work-item-toggle"]'
+    );
+
+    await act(async () => {
+      trigger?.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(projectApiMocks.readWorkspaceWorkItemsData).toHaveBeenCalledOnce();
+    expect(projectApiMocks.readWorkspaceWorkItemsData).toHaveBeenCalledWith({
+      readBucket: "active",
+    });
+    expect(
+      document.querySelector('[data-testid="work-item-picker-panel"]')
+    ).not.toBeNull();
+
+    const localOption = document.querySelector(
+      '[data-testid="work-item-picker-option-workitem:project-a/ABC-1"]'
+    );
+    expect(localOption).not.toBeNull();
+    act(() => {
+      localOption
+        ?.querySelector<HTMLInputElement>('input[type="checkbox"]')
+        ?.click();
+    });
+
+    const issueFilter = document.querySelector<HTMLButtonElement>(
+      '[data-testid="work-item-picker-filter-github_issue"]'
+    );
+    act(() => issueFilter?.click());
+    expect(
+      document.querySelector(
+        '[data-testid="work-item-picker-option-workitem:project-a/ABC-1"]'
+      )
+    ).toBeNull();
+
+    const search = document.querySelector<HTMLInputElement>(
+      'input[type="search"]'
+    );
+    act(() => {
+      if (!search) return;
+      search.value = "login";
+      search.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    const githubOption = document.querySelector(
+      '[data-testid="work-item-picker-option-github_issue:https://github.com/acme/app/issues/42"]'
+    );
+    expect(githubOption).not.toBeNull();
+    act(() => {
+      githubOption
+        ?.querySelector<HTMLInputElement>('input[type="checkbox"]')
+        ?.click();
+    });
+
+    await act(async () => {
+      findButton("common:actions.add")?.click();
+      await Promise.resolve();
+    });
+
+    expect(insertFilePill).toHaveBeenCalledTimes(2);
+    expect(insertFilePill).toHaveBeenNthCalledWith(
+      1,
+      expect.stringMatching(/^workitem:\/\/project-a\/ABC-1\/\d+$/),
+      false,
+      "workitem",
+      "ABC-1 Fix local work"
+    );
+    expect(insertFilePill).toHaveBeenNthCalledWith(
+      2,
+      "https://github.com/acme/app/issues/42",
+      false,
+      "issue",
+      "#42 Fix login bug"
+    );
+    const workItemPillPath = insertFilePill.mock.calls[0]?.[0] as string;
+    expect(window.__orgiiTerminalPillTexts?.[workItemPillPath]).toContain(
+      "Local work item body"
+    );
+    expect(onWorkItemContextChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectSlug: "project-a",
+        workItemId: "ABC-1",
+      })
+    );
+    expect(focus).toHaveBeenCalledOnce();
+
+    await act(async () => {
+      trigger?.click();
+      await Promise.resolve();
+    });
+    expect(projectApiMocks.readWorkspaceWorkItemsData).toHaveBeenCalledTimes(2);
+  });
+
+  it("retains the link-existing menu outside Launchpad", async () => {
     act(() => {
       root.render(createElement(WorkItemAttachmentControl));
     });
 
     expect(document.querySelector('[role="menu"]')).not.toBeNull();
     expect(document.body.textContent).toContain("common:actions.link");
-    expect(document.body.textContent).not.toContain("common:actions.create");
-    expect(
-      document.querySelector('[data-testid="work-item-create-inline-panel"]')
-    ).toBeNull();
 
     const linkAction = Array.from(
       document.querySelectorAll<HTMLButtonElement>('[role="menuitem"]')
@@ -122,11 +441,8 @@ describe("WorkItemAttachmentControl", () => {
       await Promise.resolve();
     });
 
-    expect(dropdownMocks.close).toHaveBeenCalledOnce();
-    expect(projectApiMocks.readProjects).toHaveBeenCalledOnce();
-    expect(projectApiMocks.readStandaloneWorkItems).toHaveBeenCalledOnce();
     expect(
-      document.querySelector('[data-testid="work-item-link-inline-panel"]')
+      document.querySelector('[data-testid="work-item-picker-panel"]')
     ).not.toBeNull();
   });
 });

--- a/src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.tsx
@@ -1,97 +1,77 @@
-import { Link2, ListTodo, Search, X } from "lucide-react";
-import React, { useCallback, useMemo, useState } from "react";
+import { Link2, ListTodo, X } from "lucide-react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
-import { type WorkItemData, projectApi } from "@src/api/http/project";
 import Button from "@src/components/Button";
-import Checkbox from "@src/components/Checkbox";
+import type { ComposerInputRef } from "@src/components/ComposerInput";
 import { pillControlStateClass } from "@src/components/CompoundPill/config";
-import DropdownSearch from "@src/components/Dropdown/DropdownSearch";
 import { DropdownPanel } from "@src/components/Dropdown/exports";
 import {
   DROPDOWN_CLASSES,
   DROPDOWN_ITEM,
-  DROPDOWN_WIDTHS,
 } from "@src/components/Dropdown/tokens";
-import Message from "@src/components/Message";
 import type { SessionLaunchWorkItemContext } from "@src/engines/SessionCore/hooks/session/useSessionCreator/useSessionLaunch/types";
+import { LaunchpadActionCard } from "@src/features/SessionCreator/components/LaunchpadActionGrid";
+import { useWorktreeSourceData } from "@src/features/SessionCreator/components/useWorktreeSourceData";
 import { useDropdownEngine } from "@src/hooks/dropdown";
 import { createLogger } from "@src/hooks/logger";
+import { insertPillFromTabPayload } from "@src/shared/dnd/dropTargetUtils";
+
+import WorkItemPickerPanel from "./WorkItemPickerPanel";
+import {
+  type WorkItemPickerFilter,
+  type WorkItemPickerOption,
+  filterWorkItemPickerOptions,
+  githubWorkItemsToPickerOptions,
+  loadWorkspaceWorkItemOptions,
+} from "./workItemPickerModel";
 
 const logger = createLogger("WorkItemAttachmentControl");
-const WORK_ITEM_SEARCH_RESULT_LIMIT = 8;
-
-function getWorkItemOptionKey(item: ExistingWorkItemOption): string {
-  return `${item.projectSlug ?? "standalone"}:${item.shortId}`;
-}
-
-interface ExistingWorkItemOption {
-  shortId: string;
-  orgId?: string;
-  projectId?: string;
-  projectName?: string;
-  projectSlug?: string;
-  title: string;
-}
-
-type ExistingWorkItemSource =
-  | {
-      item: WorkItemData;
-      orgId: string;
-      projectId: string;
-      projectName: string;
-      projectSlug: string;
-    }
-  | {
-      item: WorkItemData;
-      projectSlug: undefined;
-    };
-
-function toExistingWorkItemOption(
-  source: ExistingWorkItemSource
-): ExistingWorkItemOption {
-  const projectMeta =
-    "orgId" in source
-      ? {
-          orgId: source.orgId,
-          projectId: source.projectId,
-          projectName: source.projectName,
-        }
-      : {};
-
-  return {
-    shortId: source.item.frontmatter.short_id || source.item.frontmatter.id,
-    ...projectMeta,
-    projectSlug: source.projectSlug,
-    title: source.item.frontmatter.title,
-  };
-}
+const INLINE_PICKER_MAX_HEIGHT = "min(520px, 100%)";
 
 export interface WorkItemAttachmentControlProps {
+  composerInputRef?: React.RefObject<ComposerInputRef | null>;
   currentWorkItemContext?: SessionLaunchWorkItemContext | null;
   /** Direct navigation to the owning Work Item creator when available. */
   onCreateWorkItem?: () => void;
   onWorkItemContextChange?: (
     context: SessionLaunchWorkItemContext | null
   ) => void;
-  panelHostRef?: React.RefObject<HTMLDivElement | null>;
+  onPickerOpenChange?: (open: boolean) => void;
+  repoId?: string;
+  repoPath?: string;
+  /** Launchpad opens the picker directly and uses the solve-oriented label. */
+  mode?: "add" | "solve";
+  presentation?: "button" | "card";
 }
 
 const WorkItemAttachmentControl: React.FC<WorkItemAttachmentControlProps> = ({
+  composerInputRef,
   currentWorkItemContext,
   onCreateWorkItem,
+  onPickerOpenChange,
   onWorkItemContextChange,
-  panelHostRef,
+  repoId,
+  repoPath,
+  mode = "add",
+  presentation = "button",
 }) => {
-  const { t } = useTranslation(["projects", "common"]);
-  const [isLinkPanelOpen, setIsLinkPanelOpen] = useState(false);
+  const { t } = useTranslation(["sessions", "projects", "common"]);
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const [workItems, setWorkItems] = useState<ExistingWorkItemOption[]>([]);
-  const [selectedWorkItemKeys, setSelectedWorkItemKeys] = useState<string[]>(
-    []
-  );
-  const [loadingSearch, setLoadingSearch] = useState(false);
+  const [sourceFilter, setSourceFilter] = useState<WorkItemPickerFilter>("all");
+  const [workItems, setWorkItems] = useState<WorkItemPickerOption[]>([]);
+  const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
+  const [loadingWorkItems, setLoadingWorkItems] = useState(false);
+  const [workItemError, setWorkItemError] = useState<string | null>(null);
+  const workItemLoadGenerationRef = useRef(0);
   const {
     isOpen,
     isPositioned,
@@ -101,196 +81,239 @@ const WorkItemAttachmentControl: React.FC<WorkItemAttachmentControlProps> = ({
     toggle,
     close,
   } = useDropdownEngine<HTMLButtonElement>({ placement: "top" });
+  const { github } = useWorktreeSourceData({
+    open: isPickerOpen && (presentation === "card" || isOpen),
+    repoId,
+    repoPath,
+    loadBranches: false,
+  });
 
-  const loadExistingWorkItems = useCallback(async () => {
-    setLoadingSearch(true);
-    try {
-      const [projects, standaloneItems] = await Promise.all([
-        projectApi.readProjects(),
-        projectApi.readStandaloneWorkItems(),
-      ]);
-      const projectItemGroups = await Promise.all(
-        projects.map(async (project) => {
-          const items = await projectApi.readWorkItems(project.slug);
-          return items.map((item) => ({
-            item,
-            orgId: project.meta.org_id,
-            projectId: project.meta.id,
-            projectName: project.meta.name,
-            projectSlug: project.slug,
-          }));
-        })
-      );
-      const allItems = [
-        ...standaloneItems.map((item) => ({ item, projectSlug: undefined })),
-        ...projectItemGroups.flat(),
-      ];
-      setWorkItems(allItems.map(toExistingWorkItemOption));
-    } catch (err) {
-      logger.error("Failed to load work items for linking", err);
-      Message.error(err instanceof Error ? err.message : String(err));
-    } finally {
-      setLoadingSearch(false);
-    }
+  const loadWorkItems = useCallback(() => {
+    const generation = workItemLoadGenerationRef.current + 1;
+    workItemLoadGenerationRef.current = generation;
+    setLoadingWorkItems(true);
+    setWorkItemError(null);
+    void loadWorkspaceWorkItemOptions()
+      .then((options) => {
+        if (workItemLoadGenerationRef.current === generation) {
+          setWorkItems(options);
+        }
+      })
+      .catch((error) => {
+        if (workItemLoadGenerationRef.current !== generation) return;
+        logger.error("Failed to load work items for solving", error);
+        setWorkItemError(
+          error instanceof Error ? error.message : String(error)
+        );
+      })
+      .finally(() => {
+        if (workItemLoadGenerationRef.current === generation) {
+          setLoadingWorkItems(false);
+        }
+      });
   }, []);
 
-  const handleLinkWorkItem = useCallback(() => {
-    setIsLinkPanelOpen(true);
-    close();
-    void loadExistingWorkItems();
-  }, [close, loadExistingWorkItems]);
-
-  const handleCloseLinkPanel = useCallback(() => {
-    setIsLinkPanelOpen(false);
-    setSearchQuery("");
-    setSelectedWorkItemKeys([]);
-  }, []);
-
-  const filteredWorkItems = useMemo(() => {
-    const query = searchQuery.trim().toLowerCase();
-    const filtered = query
-      ? workItems.filter(
-          (item) =>
-            item.title.toLowerCase().includes(query) ||
-            item.shortId.toLowerCase().includes(query)
-        )
-      : workItems;
-    return filtered.slice(0, WORK_ITEM_SEARCH_RESULT_LIMIT);
-  }, [searchQuery, workItems]);
-
-  const handleToggleWorkItemSelection = useCallback(
-    (item: ExistingWorkItemOption, checked: boolean) => {
-      const itemKey = getWorkItemOptionKey(item);
-      setSelectedWorkItemKeys((currentKeys) =>
-        checked
-          ? [...new Set([...currentKeys, itemKey])]
-          : currentKeys.filter((key) => key !== itemKey)
-      );
+  useEffect(
+    () => () => {
+      workItemLoadGenerationRef.current += 1;
     },
     []
   );
 
-  const handleAddLinkedWorkItems = useCallback(() => {
-    const selectedItems = workItems.filter((item) =>
-      selectedWorkItemKeys.includes(getWorkItemOptionKey(item))
-    );
-    const primaryItem = selectedItems[0];
-    if (!primaryItem) return;
+  const githubOptions = useMemo(
+    () => githubWorkItemsToPickerOptions(github),
+    [github]
+  );
+  const allOptions = useMemo(
+    () => [...workItems, ...githubOptions],
+    [githubOptions, workItems]
+  );
+  const filteredOptions = useMemo(
+    () => filterWorkItemPickerOptions(allOptions, sourceFilter, searchQuery),
+    [allOptions, searchQuery, sourceFilter]
+  );
 
-    onWorkItemContextChange?.({
-      orgId: primaryItem.orgId,
-      projectId: primaryItem.projectId,
-      projectName: primaryItem.projectName,
-      workItemId: primaryItem.shortId,
-      projectSlug: primaryItem.projectSlug,
-      agentRole: "custom",
-      metadata: {
-        linkedWorkItems: selectedItems.map((item) => ({
-          orgId: item.orgId,
-          projectId: item.projectId,
-          projectName: item.projectName,
-          workItemId: item.shortId,
-          projectSlug: item.projectSlug,
-          title: item.title,
-        })),
-      },
-    });
-    Message.success(primaryItem.title);
-    setIsLinkPanelOpen(false);
+  const localSourceRelevant =
+    sourceFilter === "all" || sourceFilter === "workitem";
+  const githubSourceRelevant =
+    sourceFilter === "all" || sourceFilter.startsWith("github_");
+  const relevantSourceLoading =
+    (localSourceRelevant && loadingWorkItems) ||
+    (githubSourceRelevant && github.state === "loading");
+  const relevantError = localSourceRelevant
+    ? (workItemError ?? (githubSourceRelevant ? github.error : null))
+    : github.error;
+
+  const resetPicker = useCallback(() => {
+    workItemLoadGenerationRef.current += 1;
+    setIsPickerOpen(false);
     setSearchQuery("");
-    setSelectedWorkItemKeys([]);
-  }, [onWorkItemContextChange, selectedWorkItemKeys, workItems]);
+    setSourceFilter("all");
+    setSelectedKeys([]);
+    onPickerOpenChange?.(false);
+  }, [onPickerOpenChange]);
+
+  const handleClosePicker = useCallback(() => {
+    resetPicker();
+    close();
+  }, [close, resetPicker]);
+
+  const handleOpenPicker = useCallback(() => {
+    if (isOpen && isPickerOpen) {
+      handleClosePicker();
+      return;
+    }
+    setIsPickerOpen(true);
+    onPickerOpenChange?.(true);
+    loadWorkItems();
+    if (presentation !== "card" && !isOpen) toggle();
+  }, [
+    handleClosePicker,
+    isOpen,
+    isPickerOpen,
+    loadWorkItems,
+    onPickerOpenChange,
+    presentation,
+    toggle,
+  ]);
+
+  const handleLinkWorkItem = useCallback(() => {
+    setIsPickerOpen(true);
+    loadWorkItems();
+  }, [loadWorkItems]);
+
+  const handleRefresh = useCallback(() => {
+    loadWorkItems();
+    github.refresh();
+  }, [github, loadWorkItems]);
+
+  const handleToggleSelection = useCallback((key: string, checked: boolean) => {
+    setSelectedKeys((current) =>
+      checked
+        ? current.includes(key)
+          ? current
+          : [...current, key]
+        : current.filter((candidate) => candidate !== key)
+    );
+  }, []);
+
+  const handleAddSelected = useCallback(() => {
+    const editor = composerInputRef?.current;
+    if (!editor) return;
+    const selected = allOptions.filter((option) =>
+      selectedKeys.includes(option.key)
+    );
+    const existingPaths = editor.getFilePills().map((pill) => pill.filePath);
+
+    for (const option of selected) {
+      const alreadyInserted =
+        option.kind === "workitem"
+          ? existingPaths.some((path) =>
+              path.startsWith(`workitem://${option.pillPath}/`)
+            )
+          : existingPaths.includes(option.pillPath);
+      if (alreadyInserted) continue;
+
+      insertPillFromTabPayload(composerInputRef, {
+        path: option.pillPath,
+        name: option.pillName,
+        iconType:
+          option.kind === "workitem"
+            ? "workitem"
+            : option.kind === "github_pr"
+              ? "pr"
+              : "issue",
+        contextText: option.contextText,
+        notify: false,
+      });
+    }
+
+    const selectedWorkItems = selected.filter(
+      (option) => option.kind === "workitem" && option.workItemContext
+    );
+    const primary = selectedWorkItems[0];
+    if (primary?.workItemContext) {
+      onWorkItemContextChange?.({
+        ...primary.workItemContext,
+        metadata: {
+          linkedWorkItems: selectedWorkItems.map((option) => ({
+            ...option.workItemContext,
+            title: option.title,
+          })),
+        },
+      });
+    }
+    handleClosePicker();
+    editor.focus();
+  }, [
+    allOptions,
+    composerInputRef,
+    handleClosePicker,
+    onWorkItemContextChange,
+    selectedKeys,
+  ]);
 
   const handleRemoveWorkItem = useCallback(() => {
     onWorkItemContextChange?.(null);
     close();
   }, [close, onWorkItemContextChange]);
 
-  const triggerActive =
-    isOpen || isLinkPanelOpen || Boolean(currentWorkItemContext);
+  const solveMode = mode === "solve";
+  const triggerLabel = solveMode
+    ? t("sessions:creator.solveWorkItem", {
+        defaultValue: "Solve Work Item",
+      })
+    : t("projects:workItems.addWorkItem");
+  const showDropdown =
+    presentation !== "card" && (!onCreateWorkItem || solveMode) && isOpen;
+  const pickerPanel = (
+    <WorkItemPickerPanel
+      error={relevantError}
+      expanded={presentation === "card"}
+      filteredOptions={filteredOptions}
+      loading={relevantSourceLoading}
+      onAdd={handleAddSelected}
+      onBack={presentation === "card" ? handleClosePicker : undefined}
+      onCancel={handleClosePicker}
+      onFilterChange={setSourceFilter}
+      onSearchChange={setSearchQuery}
+      onRefresh={handleRefresh}
+      onSelectionChange={handleToggleSelection}
+      searchQuery={searchQuery}
+      refreshing={
+        loadingWorkItems || github.state === "loading" || github.refreshing
+      }
+      selectedKeys={selectedKeys}
+      showCancel={presentation !== "card"}
+      sourceFilter={sourceFilter}
+    />
+  );
 
-  const linkPanelContent = isLinkPanelOpen ? (
-    <div
-      className="w-full rounded-xl border border-solid border-border-2"
-      data-testid="work-item-attachment-panel"
-    >
+  if (presentation === "card" && isPickerOpen) {
+    return (
       <div
-        className="w-full max-w-[520px]"
-        data-testid="work-item-link-inline-panel"
+        className="col-span-full flex h-auto min-h-0 flex-col overflow-hidden rounded-lg border border-border-2 shadow-sm"
+        style={{ maxHeight: INLINE_PICKER_MAX_HEIGHT }}
+        data-testid="session-creator-work-item-inline-picker"
       >
-        <DropdownSearch
-          value={searchQuery}
-          onChange={setSearchQuery}
-          placeholder={t("projects:workItems.searchPlaceholder")}
-          autoFocus
-        />
-        <div className="max-h-[180px] overflow-y-auto p-1 scrollbar-hide">
-          {loadingSearch ? (
-            <div className="flex h-16 items-center justify-center text-[12px] text-text-3">
-              {t("common:status.loading")}
-            </div>
-          ) : filteredWorkItems.length > 0 ? (
-            filteredWorkItems.map((item) => {
-              const itemKey = getWorkItemOptionKey(item);
-              const checked = selectedWorkItemKeys.includes(itemKey);
-              return (
-                <div
-                  key={itemKey}
-                  className={`${DROPDOWN_CLASSES.menuActionItem} w-full justify-start`}
-                >
-                  <Checkbox
-                    checked={checked}
-                    onChange={(nextChecked) =>
-                      handleToggleWorkItemSelection(item, nextChecked)
-                    }
-                    className="min-w-0 flex-1"
-                  >
-                    <span className="flex min-w-0 flex-1 items-center gap-2">
-                      <Search
-                        size={DROPDOWN_ITEM.iconSize}
-                        strokeWidth={1.75}
-                        className="shrink-0 text-text-2"
-                      />
-                      <span className="min-w-0 flex-1 truncate text-left">
-                        {item.title}
-                      </span>
-                      <span className="shrink-0 text-[11px] text-text-3">
-                        {item.shortId}
-                      </span>
-                    </span>
-                  </Checkbox>
-                </div>
-              );
-            })
-          ) : (
-            <div className="flex h-16 items-center justify-center text-[12px] text-text-3">
-              {t("projects:workItems.noResults")}
-            </div>
-          )}
-        </div>
-        <div className="flex justify-start gap-2 p-2">
-          <Button
-            variant="secondary"
-            size="small"
-            onClick={handleAddLinkedWorkItems}
-            disabled={selectedWorkItemKeys.length === 0}
-          >
-            {t("common:actions.add")}
-          </Button>
-          <Button
-            variant="tertiary"
-            size="small"
-            onClick={handleCloseLinkPanel}
-          >
-            {t("common:actions.cancel")}
-          </Button>
-        </div>
+        {pickerPanel}
       </div>
-    </div>
-  ) : null;
-
-  return (
-    <div className="relative shrink-0">
+    );
+  }
+  const trigger =
+    presentation === "card" ? (
+      <LaunchpadActionCard
+        ref={triggerRef}
+        action={{
+          id: "solve-work-item",
+          title: triggerLabel,
+          icon: <ListTodo size={16} strokeWidth={1.8} />,
+          onClick: handleOpenPicker,
+          tone: "neutral",
+        }}
+        presentation="card"
+      />
+    ) : (
       <Button
         ref={triggerRef}
         variant="secondary"
@@ -298,71 +321,80 @@ const WorkItemAttachmentControl: React.FC<WorkItemAttachmentControlProps> = ({
         size="small"
         shape="round"
         icon={<ListTodo size={14} strokeWidth={1.75} />}
-        aria-expanded={onCreateWorkItem ? undefined : isOpen}
-        aria-haspopup={onCreateWorkItem ? undefined : "menu"}
-        onClick={onCreateWorkItem ?? toggle}
-        className={`shrink-0 ${pillControlStateClass(triggerActive)}`}
+        aria-expanded={onCreateWorkItem && !solveMode ? undefined : isOpen}
+        aria-haspopup={onCreateWorkItem && !solveMode ? undefined : "dialog"}
+        onClick={solveMode ? handleOpenPicker : (onCreateWorkItem ?? toggle)}
+        className={`shrink-0 ${pillControlStateClass(
+          isOpen || Boolean(currentWorkItemContext)
+        )}`}
         data-testid="session-creator-work-item-toggle"
       >
-        {t("projects:workItems.addWorkItem")}
+        {triggerLabel}
       </Button>
+    );
 
-      {!onCreateWorkItem &&
-        isOpen &&
+  return (
+    <div className={presentation === "card" ? "contents" : "relative shrink-0"}>
+      {trigger}
+
+      {showDropdown &&
         isPositioned &&
         createPortal(
           <DropdownPanel
             ref={panelRef}
-            className={`fixed ${DROPDOWN_WIDTHS.menuClass}`}
+            className="fixed"
             animated={false}
-            maxHeight="none"
+            width="min(520px, calc(100vw - 32px))"
+            maxHeight={panelPosition.maxHeight}
             style={{
               ...(panelPosition.top !== undefined
                 ? { top: panelPosition.top }
                 : { bottom: panelPosition.bottom }),
               left: panelPosition.left,
             }}
-            role="menu"
+            role={isPickerOpen ? "dialog" : "menu"}
+            aria-label={isPickerOpen ? triggerLabel : undefined}
           >
-            <div className={DROPDOWN_CLASSES.itemsColumnPadded}>
-              {currentWorkItemContext ? (
+            {isPickerOpen ? (
+              pickerPanel
+            ) : (
+              <div className={DROPDOWN_CLASSES.itemsColumnPadded}>
+                {currentWorkItemContext ? (
+                  <button
+                    type="button"
+                    className={DROPDOWN_CLASSES.menuActionItem}
+                    role="menuitem"
+                    onClick={handleRemoveWorkItem}
+                  >
+                    <X
+                      size={DROPDOWN_ITEM.iconSize}
+                      strokeWidth={1.75}
+                      className="text-text-2"
+                    />
+                    <span>{t("common:actions.remove")}</span>
+                    <span className="ml-auto text-[11px] text-text-3">
+                      {currentWorkItemContext.workItemId}
+                    </span>
+                  </button>
+                ) : null}
                 <button
                   type="button"
                   className={DROPDOWN_CLASSES.menuActionItem}
                   role="menuitem"
-                  onClick={handleRemoveWorkItem}
+                  onClick={handleLinkWorkItem}
                 >
-                  <X
+                  <Link2
                     size={DROPDOWN_ITEM.iconSize}
                     strokeWidth={1.75}
                     className="text-text-2"
                   />
-                  <span>{t("common:actions.remove")}</span>
-                  <span className="ml-auto text-[11px] text-text-3">
-                    {currentWorkItemContext.workItemId}
-                  </span>
+                  <span>{t("common:actions.link")}</span>
                 </button>
-              ) : null}
-              <button
-                type="button"
-                className={DROPDOWN_CLASSES.menuActionItem}
-                role="menuitem"
-                onClick={handleLinkWorkItem}
-              >
-                <Link2
-                  size={DROPDOWN_ITEM.iconSize}
-                  strokeWidth={1.75}
-                  className="text-text-2"
-                />
-                <span>{t("common:actions.link")}</span>
-              </button>
-            </div>
+              </div>
+            )}
           </DropdownPanel>,
           document.body
         )}
-      {panelHostRef?.current && linkPanelContent
-        ? createPortal(linkPanelContent, panelHostRef.current)
-        : linkPanelContent}
     </div>
   );
 };

--- a/src/features/SessionCreator/variants/ChatPanel/WorkItemPickerPanel.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/WorkItemPickerPanel.tsx
@@ -213,6 +213,12 @@ const WorkItemPickerPanel: React.FC<WorkItemPickerPanelProps> = ({
                     : option.ciStatus === "none"
                       ? t("common:git.pr.checks.noneShort")
                       : t("common:git.pr.checks.unavailableShort");
+            const visibleCiStatus =
+              option.kind === "github_pr" &&
+              option.ciStatus !== undefined &&
+              option.ciStatus !== "unavailable"
+                ? option.ciStatus
+                : null;
             return (
               <div
                 key={option.key}
@@ -245,14 +251,32 @@ const WorkItemPickerPanel: React.FC<WorkItemPickerPanelProps> = ({
                     </span>
                     <span className="work-item-picker-option-metadata mt-1 flex min-w-0 items-center gap-1.5 pl-7 text-xs font-normal text-text-2">
                       <span className="min-w-0 truncate">{option.detail}</span>
-                      {option.kind === "github_pr" && option.ciStatus && (
+                      {option.openedBy && (
+                        <>
+                          <span className="shrink-0 text-text-3" aria-hidden>
+                            ·
+                          </span>
+                          <span className="min-w-0 truncate">
+                            @{option.openedBy}
+                          </span>
+                        </>
+                      )}
+                      {option.statusLabel && (
+                        <>
+                          <span className="shrink-0 text-text-3" aria-hidden>
+                            ·
+                          </span>
+                          <span className="shrink-0">{option.statusLabel}</span>
+                        </>
+                      )}
+                      {visibleCiStatus && (
                         <>
                           <span className="shrink-0 text-text-3" aria-hidden>
                             ·
                           </span>
                           <PrCiStatusIndicator
                             appearance="simple"
-                            status={option.ciStatus}
+                            status={visibleCiStatus}
                             label={ciLabel}
                             showLabel={false}
                             size={13}

--- a/src/features/SessionCreator/variants/ChatPanel/WorkItemPickerPanel.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/WorkItemPickerPanel.tsx
@@ -1,0 +1,303 @@
+import {
+  ArrowLeft,
+  CircleDot,
+  GitMerge,
+  GitPullRequest,
+  GitPullRequestClosed,
+  GitPullRequestDraft,
+  ListFilter,
+  ListTodo,
+  RefreshCw,
+} from "lucide-react";
+import React, { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+
+import Button from "@src/components/Button";
+import Checkbox from "@src/components/Checkbox";
+import { DROPDOWN_PANEL } from "@src/components/Dropdown/tokens";
+import { getListItemClasses } from "@src/components/ListPanel";
+import PrCiStatusIndicator from "@src/components/PrCiStatusIndicator";
+import SearchInput from "@src/components/SearchInput";
+import {
+  getPrStatusIconName,
+  getPrStatusVariant,
+} from "@src/shared/pr/prStatus";
+
+import type {
+  WorkItemPickerFilter,
+  WorkItemPickerOption,
+} from "./workItemPickerModel";
+
+interface WorkItemPickerPanelProps {
+  error: string | null;
+  expanded?: boolean;
+  filteredOptions: readonly WorkItemPickerOption[];
+  loading: boolean;
+  onAdd: () => void;
+  onBack?: () => void;
+  onCancel: () => void;
+  onFilterChange: (filter: WorkItemPickerFilter) => void;
+  onSearchChange: (query: string) => void;
+  onRefresh: () => void;
+  onSelectionChange: (key: string, selected: boolean) => void;
+  searchQuery: string;
+  refreshing: boolean;
+  selectedKeys: readonly string[];
+  showCancel?: boolean;
+  sourceFilter: WorkItemPickerFilter;
+}
+
+const WorkItemPickerPanel: React.FC<WorkItemPickerPanelProps> = ({
+  error,
+  expanded = false,
+  filteredOptions,
+  loading,
+  onAdd,
+  onBack,
+  onCancel,
+  onFilterChange,
+  onSearchChange,
+  onRefresh,
+  onSelectionChange,
+  searchQuery,
+  refreshing,
+  selectedKeys,
+  showCancel = true,
+  sourceFilter,
+}) => {
+  const { t } = useTranslation(["sessions", "projects", "common"]);
+  const searchInputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
+  useEffect(() => {
+    searchInputRef.current?.focus();
+  }, []);
+  const filters: Array<{
+    value: WorkItemPickerFilter;
+    label: string;
+    icon: React.ReactNode;
+  }> = [
+    {
+      value: "all",
+      label: t("common:actions.all"),
+      icon: <ListFilter size={14} strokeWidth={1.8} />,
+    },
+    {
+      value: "workitem",
+      label: t("projects:workItems.label"),
+      icon: <ListTodo size={14} strokeWidth={1.8} />,
+    },
+    {
+      value: "github_issue",
+      label: t("sessions:kanban.sidebar.githubIssues"),
+      icon: <CircleDot size={14} strokeWidth={1.8} />,
+    },
+    {
+      value: "github_pr",
+      label: t("sessions:kanban.sidebar.githubPrs"),
+      icon: <GitPullRequest size={14} strokeWidth={1.8} />,
+    },
+  ];
+
+  return (
+    <div
+      className="flex min-h-0 flex-1 flex-col overflow-hidden"
+      style={{ maxHeight: "inherit" }}
+      data-testid="work-item-picker-panel"
+    >
+      <div className="work-item-picker-toolbar flex shrink-0 items-center gap-2 px-2 pb-3 pt-2">
+        {onBack && (
+          <Button
+            variant="tertiary"
+            size="small"
+            icon={<ArrowLeft size={14} strokeWidth={1.8} />}
+            iconOnly
+            title={t("common:actions.back")}
+            aria-label={t("common:actions.back")}
+            data-testid="session-creator-work-item-picker-back"
+            onClick={onBack}
+          />
+        )}
+        <SearchInput
+          inputRef={searchInputRef}
+          variant="sidebar"
+          value={searchQuery}
+          onChange={onSearchChange}
+          placeholder={t("projects:workItems.searchPlaceholder")}
+          ariaLabel={t("projects:workItems.searchPlaceholder")}
+          showClearButton
+          className="min-w-0 flex-1"
+        />
+        <Button
+          variant="tertiary"
+          size="small"
+          icon={
+            <RefreshCw
+              size={14}
+              strokeWidth={1.8}
+              className={refreshing ? "animate-spin" : undefined}
+            />
+          }
+          iconOnly
+          title={t("common:actions.refresh")}
+          aria-label={t("common:actions.refresh")}
+          data-testid="session-creator-work-item-picker-refresh"
+          disabled={refreshing}
+          onClick={onRefresh}
+        />
+      </div>
+      <div
+        className="work-item-picker-tabs flex shrink-0 flex-wrap items-end gap-px border-b border-border-2 px-2"
+        role="tablist"
+        aria-label={t("common:actions.filter")}
+      >
+        {filters.map((filter) => {
+          const active = sourceFilter === filter.value;
+          return (
+            <button
+              key={filter.value}
+              type="button"
+              onClick={() => onFilterChange(filter.value)}
+              role="tab"
+              aria-selected={active}
+              className={`work-item-picker-tab relative -mb-px flex shrink-0 items-center gap-1.5 rounded-t-md border px-3 py-1.5 text-[12px] font-medium transition-colors ${
+                active
+                  ? "border-border-2 text-text-1 after:absolute after:-bottom-px after:left-0 after:right-0 after:h-px after:bg-chat-pane"
+                  : "border-transparent text-text-2 hover:bg-fill-1 hover:text-text-1"
+              }`}
+              data-testid={`work-item-picker-filter-${filter.value}`}
+            >
+              <span
+                className="flex h-4 w-4 shrink-0 items-center justify-center"
+                aria-hidden
+              >
+                {filter.icon}
+              </span>
+              <span>{filter.label}</span>
+            </button>
+          );
+        })}
+      </div>
+      <div
+        className={`work-item-picker-list flex min-h-0 flex-1 flex-col gap-0 overflow-y-auto overscroll-contain p-1 scrollbar-hide ${expanded ? "" : DROPDOWN_PANEL.maxHeightClass}`}
+        data-testid="work-item-picker-list"
+      >
+        {filteredOptions.length > 0 ? (
+          filteredOptions.map((option) => {
+            const checked = selectedKeys.includes(option.key);
+            const prStatus = option.prStatus ?? "open";
+            const prIconName = getPrStatusIconName(prStatus);
+            const Icon =
+              option.kind === "github_pr"
+                ? prIconName === "draft"
+                  ? GitPullRequestDraft
+                  : prIconName === "merge"
+                    ? GitMerge
+                    : prIconName === "closed"
+                      ? GitPullRequestClosed
+                      : GitPullRequest
+                : option.kind === "workitem"
+                  ? ListTodo
+                  : CircleDot;
+            const iconColorClass =
+              option.kind === "github_pr"
+                ? getPrStatusVariant(prStatus).textClass
+                : option.kind === "github_issue"
+                  ? "text-success-6"
+                  : "text-text-2";
+            const ciLabel =
+              option.ciStatus === "success"
+                ? t("common:git.pr.checks.passedShort")
+                : option.ciStatus === "failure"
+                  ? t("common:git.pr.checks.failedShort")
+                  : option.ciStatus === "pending"
+                    ? t("common:git.pr.checks.runningShort")
+                    : option.ciStatus === "none"
+                      ? t("common:git.pr.checks.noneShort")
+                      : t("common:git.pr.checks.unavailableShort");
+            return (
+              <div
+                key={option.key}
+                className={`work-item-picker-option ${getListItemClasses(checked)} !block w-full min-w-0 text-left`}
+                data-testid={`work-item-picker-option-${option.key}`}
+              >
+                <Checkbox
+                  size="mini"
+                  checked={checked}
+                  onChange={(nextChecked) =>
+                    onSelectionChange(option.key, nextChecked)
+                  }
+                  className="w-full min-w-0 flex-row-reverse items-start justify-between gap-2 [&_[data-checkbox-label]]:min-w-0 [&_[data-checkbox-label]]:flex-1"
+                >
+                  <span className="block min-w-0 flex-1 text-left">
+                    <span className="flex h-4 min-w-0 items-center gap-2">
+                      <span
+                        className={`flex h-4 w-5 shrink-0 items-center justify-center ${iconColorClass}`}
+                        aria-hidden
+                        data-testid={`work-item-picker-kind-${option.key}`}
+                      >
+                        <Icon size={14} strokeWidth={1.8} />
+                      </span>
+                      <span className="shrink-0 text-xs font-semibold text-text-3">
+                        {option.identifier}
+                      </span>
+                      <span className="min-w-0 flex-1 truncate text-xs font-medium text-text-1">
+                        {option.title}
+                      </span>
+                    </span>
+                    <span className="work-item-picker-option-metadata mt-1 flex min-w-0 items-center gap-1.5 pl-7 text-xs font-normal text-text-2">
+                      <span className="min-w-0 truncate">{option.detail}</span>
+                      {option.kind === "github_pr" && option.ciStatus && (
+                        <>
+                          <span className="shrink-0 text-text-3" aria-hidden>
+                            ·
+                          </span>
+                          <PrCiStatusIndicator
+                            appearance="simple"
+                            status={option.ciStatus}
+                            label={ciLabel}
+                            showLabel={false}
+                            size={13}
+                            dataTestId={`work-item-picker-ci-${option.key}`}
+                          />
+                        </>
+                      )}
+                    </span>
+                  </span>
+                </Checkbox>
+              </div>
+            );
+          })
+        ) : loading ? (
+          <div className="flex h-20 items-center justify-center text-xs text-text-3">
+            {t("common:status.loading")}
+          </div>
+        ) : (
+          <div className="flex h-20 items-center justify-center px-4 text-center text-xs text-text-3">
+            {error ?? t("projects:workItems.noResults")}
+          </div>
+        )}
+      </div>
+      <div className="work-item-picker-footer flex items-center justify-between gap-2 border-t border-border-1 p-2">
+        <span className="min-w-0 truncate text-xs text-text-3">
+          {error && filteredOptions.length > 0 ? error : null}
+        </span>
+        <div className="flex shrink-0 items-center gap-2">
+          {showCancel && (
+            <Button variant="tertiary" size="small" onClick={onCancel}>
+              {t("common:actions.cancel")}
+            </Button>
+          )}
+          <Button
+            variant="secondary"
+            size="small"
+            onClick={onAdd}
+            disabled={selectedKeys.length === 0}
+          >
+            {t("common:actions.add")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WorkItemPickerPanel;

--- a/src/features/SessionCreator/variants/ChatPanel/index.scss
+++ b/src/features/SessionCreator/variants/ChatPanel/index.scss
@@ -37,6 +37,55 @@
     .session-creator-chat-panel-launchpad-suggestions > * {
       margin-inline: 0;
     }
+
+    &.session-creator-chat-panel-work-item-picker-open {
+      .session-creator-chat-panel-content {
+        overflow: hidden;
+        padding-top: 12px;
+      }
+
+      .session-creator-chat-panel-launchpad-middle {
+        position: relative;
+        min-height: 0;
+        flex: 1 1 0%;
+        align-items: center;
+        overflow: hidden;
+      }
+
+      .session-creator-chat-panel-launchpad-suggestions {
+        display: flex;
+        min-height: 0;
+        flex: 1 1 0%;
+      }
+
+      .session-creator-chat-panel-launchpad-suggestions > * {
+        margin-inline: auto;
+      }
+
+      .work-item-picker-toolbar {
+        padding-top: 4px;
+        padding-bottom: 8px;
+      }
+
+      .work-item-picker-tab {
+        padding-top: 4px;
+        padding-bottom: 4px;
+      }
+
+      .work-item-picker-option {
+        padding-top: 6px;
+        padding-bottom: 6px;
+      }
+
+      .work-item-picker-option-metadata {
+        margin-top: 2px;
+      }
+
+      .work-item-picker-footer {
+        padding-top: 4px;
+        padding-bottom: 4px;
+      }
+    }
   }
 
   @media (max-height: 600px) {
@@ -51,6 +100,40 @@
     .session-creator-chat-panel-launchpad-suggestions {
       display: none;
     }
+
+    &.session-creator-chat-panel-work-item-picker-open {
+      .session-creator-chat-panel-launchpad-middle {
+        gap: 4px;
+      }
+
+      .session-creator-chat-panel-launchpad-suggestions {
+        display: flex;
+      }
+
+      .work-item-picker-toolbar {
+        padding-bottom: 4px;
+      }
+
+      .work-item-picker-option {
+        padding-top: 4px;
+        padding-bottom: 4px;
+      }
+    }
+  }
+
+  .work-item-picker-list {
+    scrollbar-width: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+      width: 0;
+      height: 0;
+    }
+  }
+
+  .work-item-picker-option {
+    padding-top: 6px;
+    padding-bottom: 6px;
   }
 
   .session-creator-chat-panel-fullscreen-composer {

--- a/src/features/SessionCreator/variants/ChatPanel/index.scss
+++ b/src/features/SessionCreator/variants/ChatPanel/index.scss
@@ -121,6 +121,15 @@
     }
   }
 
+  @media (min-height: 1000px) {
+    &.session-creator-chat-panel-work-item-picker-open {
+      .session-creator-chat-panel-launchpad-suggestions {
+        max-height: 520px;
+        flex: 0 1 520px;
+      }
+    }
+  }
+
   .work-item-picker-list {
     scrollbar-width: none;
 

--- a/src/features/SessionCreator/variants/ChatPanel/index.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/index.tsx
@@ -266,7 +266,6 @@ const SessionCreatorChatPanelContent: React.FC<
   }, [openCategoryPickerSignal]);
 
   const agentHeroRef = useRef<HTMLButtonElement>(null);
-  const workItemPanelHostRef = useRef<HTMLDivElement>(null);
   const modelPickerStyle = useAtomValue(modelPickerStyleAtom);
 
   // ── Handlers via extracted hook ───────────────────────────────────────────
@@ -579,7 +578,6 @@ const SessionCreatorChatPanelContent: React.FC<
       showMissingGitAlert={!isHumanMode && showMissingGitAlert}
       hideSessionSetupControls={isHumanMode}
       workItemContext={attachedWorkItemContext}
-      workItemPanelHostRef={workItemPanelHostRef}
     />
   );
 };

--- a/src/features/SessionCreator/variants/ChatPanel/workItemPickerModel.test.ts
+++ b/src/features/SessionCreator/variants/ChatPanel/workItemPickerModel.test.ts
@@ -118,6 +118,50 @@ describe("work item picker model", () => {
     });
   });
 
+  it("ranks GitHub issues and pull requests by descending number", () => {
+    const options = githubWorkItemsToPickerOptions({
+      issues: [
+        {
+          id: 41,
+          number: 41,
+          title: "Older issue",
+          body: null,
+          state: "open",
+          state_reason: null,
+          html_url: "https://github.com/acme/repo/issues/41",
+          created_at: "2026-08-10T00:00:00Z",
+          updated_at: "2026-08-10T00:00:00Z",
+          closed_at: null,
+          user: { login: "issue-author", avatar_url: "" },
+          labels: [],
+          assignees: [],
+          comments: 0,
+          milestone: null,
+        },
+      ],
+      prs: [
+        {
+          number: 43,
+          title: "Newer PR",
+          state: "open",
+          draft: false,
+          ci_status: "success",
+          author_login: "pr-author",
+          author_avatar_url: null,
+          requested_reviewer_logins: [],
+          url: "https://github.com/acme/repo/pull/43",
+          head_branch: "newer",
+          base_branch: "main",
+          created_at: "2026-08-10T00:00:00Z",
+          updated_at: "2026-08-10T00:00:00Z",
+        } satisfies OpenPRItem,
+      ],
+      repoFullName: "acme/repo",
+    });
+
+    expect(options.map((option) => option.identifier)).toEqual(["#43", "#41"]);
+  });
+
   it("shares concurrent workspace reads", async () => {
     let resolveRead: ((data: WorkspaceWorkItemsData) => void) | undefined;
     projectApiMocks.readWorkspaceWorkItemsData.mockReturnValue(

--- a/src/features/SessionCreator/variants/ChatPanel/workItemPickerModel.test.ts
+++ b/src/features/SessionCreator/variants/ChatPanel/workItemPickerModel.test.ts
@@ -99,6 +99,7 @@ describe("work item picker model", () => {
           state: "open",
           draft: true,
           ci_status: "failure",
+          author_login: "octocat",
           url: "https://github.com/acme/repo/pull/42",
           head_branch: "fix",
           base_branch: "main",
@@ -111,7 +112,9 @@ describe("work item picker model", () => {
       kind: "github_pr",
       prStatus: "draft",
       ciStatus: "failure",
-      detail: "acme/repo · draft",
+      detail: "acme/repo",
+      openedBy: "octocat",
+      statusLabel: "draft",
     });
   });
 

--- a/src/features/SessionCreator/variants/ChatPanel/workItemPickerModel.test.ts
+++ b/src/features/SessionCreator/variants/ChatPanel/workItemPickerModel.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  EnrichedWorkItem,
+  WorkspaceWorkItemsData,
+} from "@src/api/http/project";
+import type { OpenPRItem } from "@src/api/tauri/github";
+
+import {
+  type WorkItemPickerOption,
+  filterWorkItemPickerOptions,
+  githubWorkItemsToPickerOptions,
+  loadWorkspaceWorkItemOptions,
+  workspaceWorkItemsToPickerOptions,
+} from "./workItemPickerModel";
+
+const projectApiMocks = vi.hoisted(() => ({
+  readWorkspaceWorkItemsData: vi.fn(),
+}));
+
+vi.mock("@src/api/http/project", () => ({
+  projectApi: projectApiMocks,
+}));
+
+function enrichedWorkItem(index: number): EnrichedWorkItem {
+  return {
+    shortId: `WI-${index}`,
+    title: `Work item ${index}`,
+    status: "planned",
+    priority: "medium",
+    body: "",
+    labels: [],
+    todos: [],
+  } as unknown as EnrichedWorkItem;
+}
+
+function pickerOption(
+  index: number,
+  kind: WorkItemPickerOption["kind"] = "workitem"
+): WorkItemPickerOption {
+  return {
+    key: `${kind}:${index}`,
+    kind,
+    title: index === 2 ? "Fix login" : `Item ${index}`,
+    identifier: `#${index}`,
+    detail: "open",
+    searchableText: index === 2 ? "fix login open" : `item ${index} open`,
+    pillPath: `${kind}/${index}`,
+    pillName: `Item ${index}`,
+  };
+}
+
+describe("work item picker model", () => {
+  beforeEach(() => {
+    projectApiMocks.readWorkspaceWorkItemsData.mockReset();
+  });
+
+  it("bounds the retained workspace snapshot", () => {
+    const data = {
+      projectEntries: [
+        {
+          project: {
+            slug: "project",
+            meta: { id: "project-id", name: "Project", org_id: "org-id" },
+          },
+          workItems: Array.from({ length: 501 }, (_, index) =>
+            enrichedWorkItem(index)
+          ),
+        },
+      ],
+      standaloneWorkItems: [],
+      orgs: [],
+    } as unknown as WorkspaceWorkItemsData;
+
+    expect(workspaceWorkItemsToPickerOptions(data)).toHaveLength(500);
+  });
+
+  it("filters by source and query before applying the render cap", () => {
+    const options = [
+      ...Array.from({ length: 25 }, (_, index) => pickerOption(index)),
+      pickerOption(2, "github_issue"),
+    ];
+
+    expect(filterWorkItemPickerOptions(options, "all", "")).toHaveLength(20);
+    expect(
+      filterWorkItemPickerOptions(options, "github_issue", "login").map(
+        (option) => option.key
+      )
+    ).toEqual(["github_issue:2"]);
+  });
+
+  it("preserves GitHub PR type and check status for presentation", () => {
+    const [option] = githubWorkItemsToPickerOptions({
+      issues: [],
+      prs: [
+        {
+          number: 42,
+          title: "Draft fix",
+          state: "open",
+          draft: true,
+          ci_status: "failure",
+          url: "https://github.com/acme/repo/pull/42",
+          head_branch: "fix",
+          base_branch: "main",
+        } as OpenPRItem,
+      ],
+      repoFullName: "acme/repo",
+    });
+
+    expect(option).toMatchObject({
+      kind: "github_pr",
+      prStatus: "draft",
+      ciStatus: "failure",
+      detail: "acme/repo · draft",
+    });
+  });
+
+  it("shares concurrent workspace reads", async () => {
+    let resolveRead: ((data: WorkspaceWorkItemsData) => void) | undefined;
+    projectApiMocks.readWorkspaceWorkItemsData.mockReturnValue(
+      new Promise<WorkspaceWorkItemsData>((resolve) => {
+        resolveRead = resolve;
+      })
+    );
+
+    const first = loadWorkspaceWorkItemOptions();
+    const second = loadWorkspaceWorkItemOptions();
+    expect(projectApiMocks.readWorkspaceWorkItemsData).toHaveBeenCalledOnce();
+
+    resolveRead?.({
+      projectEntries: [],
+      standaloneWorkItems: [],
+      orgs: [],
+    });
+    await expect(Promise.all([first, second])).resolves.toEqual([[], []]);
+  });
+});

--- a/src/features/SessionCreator/variants/ChatPanel/workItemPickerModel.ts
+++ b/src/features/SessionCreator/variants/ChatPanel/workItemPickerModel.ts
@@ -31,6 +31,7 @@ export interface WorkItemPickerOption {
   searchableText: string;
   pillPath: string;
   pillName: string;
+  sourceNumber?: number;
   openedBy?: string;
   statusLabel?: string;
   prStatus?: string;
@@ -202,6 +203,7 @@ export function githubWorkItemsToPickerOptions({
       title: issue.title,
       identifier: `#${issue.number}`,
       detail: repoName,
+      sourceNumber: issue.number,
       openedBy: issue.user.login || undefined,
       statusLabel: issue.state,
       searchableText: [
@@ -228,6 +230,7 @@ export function githubWorkItemsToPickerOptions({
         title: pr.title,
         identifier: `#${pr.number}`,
         detail: repoName,
+        sourceNumber: pr.number,
         openedBy: pr.author_login || undefined,
         statusLabel: prStatus,
         searchableText: [
@@ -248,7 +251,7 @@ export function githubWorkItemsToPickerOptions({
         ciStatus: pr.ci_status,
       };
     }),
-  ];
+  ].sort((left, right) => (right.sourceNumber ?? 0) - (left.sourceNumber ?? 0));
 }
 
 export function filterWorkItemPickerOptions(

--- a/src/features/SessionCreator/variants/ChatPanel/workItemPickerModel.ts
+++ b/src/features/SessionCreator/variants/ChatPanel/workItemPickerModel.ts
@@ -1,0 +1,260 @@
+import type {
+  EnrichedWorkItem,
+  WorkItemData,
+  WorkspaceWorkItemsData,
+} from "@src/api/http/project";
+import { projectApi } from "@src/api/http/project";
+import type {
+  GitHubIssue,
+  OpenPRItem,
+  PullRequestCiStatus,
+} from "@src/api/tauri/github";
+import type { SessionLaunchWorkItemContext } from "@src/engines/SessionCore/hooks/session/useSessionCreator/useSessionLaunch/types";
+import { normalizePrStatus } from "@src/shared/pr/prStatus";
+
+export const WORK_ITEM_PICKER_RESULT_LIMIT = 20;
+const WORK_ITEM_CACHE_MAX_ITEMS = 500;
+
+export type WorkItemPickerFilter =
+  | "all"
+  | "workitem"
+  | "github_issue"
+  | "github_pr";
+export type WorkItemPickerOptionKind = Exclude<WorkItemPickerFilter, "all">;
+
+export interface WorkItemPickerOption {
+  key: string;
+  kind: WorkItemPickerOptionKind;
+  title: string;
+  identifier: string;
+  detail: string;
+  searchableText: string;
+  pillPath: string;
+  pillName: string;
+  prStatus?: string;
+  ciStatus?: PullRequestCiStatus;
+  contextText?: string;
+  workItemContext?: Omit<SessionLaunchWorkItemContext, "metadata">;
+}
+
+let workspaceWorkItemRequest: Promise<WorkItemPickerOption[]> | null = null;
+
+function formatTodoLines(
+  todos: ReadonlyArray<{ status: string; content: string }>
+): string {
+  if (todos.length === 0) return "";
+  return `\n## Todos\n${todos
+    .map(
+      (todo) => `- [${todo.status === "completed" ? "x" : " "}] ${todo.content}`
+    )
+    .join("\n")}`;
+}
+
+function formatWorkItemContext({
+  shortId,
+  title,
+  status,
+  priority,
+  body,
+  labels,
+  todos,
+}: {
+  shortId: string;
+  title: string;
+  status: string;
+  priority: string;
+  body: string;
+  labels: readonly string[];
+  todos: ReadonlyArray<{ status: string; content: string }>;
+}): string {
+  const parts = [
+    `[Work Item: ${shortId}]`,
+    `Title: ${title}`,
+    `Status: ${status}`,
+    `Priority: ${priority}`,
+  ];
+  if (labels.length > 0) parts.push(`Labels: ${labels.join(", ")}`);
+  if (body.trim()) parts.push(`\n## Description\n${body.trim()}`);
+  parts.push(formatTodoLines(todos));
+  return parts.filter(Boolean).join("\n");
+}
+
+function projectWorkItemOption(
+  project: WorkspaceWorkItemsData["projectEntries"][number]["project"],
+  item: EnrichedWorkItem
+): WorkItemPickerOption {
+  const path = `${project.slug}/${item.shortId}`;
+  return {
+    key: `workitem:${path}`,
+    kind: "workitem",
+    title: item.title,
+    identifier: item.shortId,
+    detail: `${project.meta.name} · ${item.status}`,
+    searchableText: [
+      item.shortId,
+      item.title,
+      item.status,
+      item.priority,
+      project.meta.name,
+      ...item.labels.map((label) => label.name),
+    ]
+      .join(" ")
+      .toLowerCase(),
+    pillPath: path,
+    pillName: `${item.shortId} ${item.title}`,
+    contextText: formatWorkItemContext({
+      shortId: item.shortId,
+      title: item.title,
+      status: item.status,
+      priority: item.priority,
+      body: item.body,
+      labels: item.labels.map((label) => label.name),
+      todos: item.todos,
+    }),
+    workItemContext: {
+      orgId: project.meta.org_id,
+      projectId: project.meta.id,
+      projectName: project.meta.name,
+      projectSlug: project.slug,
+      workItemId: item.shortId,
+      agentRole: "custom",
+    },
+  };
+}
+
+function standaloneWorkItemOption(item: WorkItemData): WorkItemPickerOption {
+  const shortId = item.frontmatter.short_id || item.frontmatter.id;
+  const path = `standalone/${shortId}`;
+  return {
+    key: `workitem:${path}`,
+    kind: "workitem",
+    title: item.frontmatter.title,
+    identifier: shortId,
+    detail: item.frontmatter.status,
+    searchableText: [
+      shortId,
+      item.frontmatter.title,
+      item.frontmatter.status,
+      item.frontmatter.priority,
+      ...item.frontmatter.labels,
+    ]
+      .join(" ")
+      .toLowerCase(),
+    pillPath: path,
+    pillName: `${shortId} ${item.frontmatter.title}`,
+    contextText: formatWorkItemContext({
+      shortId,
+      title: item.frontmatter.title,
+      status: item.frontmatter.status,
+      priority: item.frontmatter.priority,
+      body: item.body,
+      labels: item.frontmatter.labels,
+      todos: item.frontmatter.todos,
+    }),
+    workItemContext: {
+      workItemId: shortId,
+      agentRole: "custom",
+    },
+  };
+}
+
+export function workspaceWorkItemsToPickerOptions(
+  data: WorkspaceWorkItemsData
+): WorkItemPickerOption[] {
+  return [
+    ...data.projectEntries.flatMap(({ project, workItems }) =>
+      workItems.map((item) => projectWorkItemOption(project, item))
+    ),
+    ...data.standaloneWorkItems.map(standaloneWorkItemOption),
+  ].slice(0, WORK_ITEM_CACHE_MAX_ITEMS);
+}
+
+export async function loadWorkspaceWorkItemOptions(): Promise<
+  WorkItemPickerOption[]
+> {
+  if (workspaceWorkItemRequest) return workspaceWorkItemRequest;
+
+  workspaceWorkItemRequest = projectApi
+    .readWorkspaceWorkItemsData({ readBucket: "active" })
+    .then(workspaceWorkItemsToPickerOptions)
+    .finally(() => {
+      workspaceWorkItemRequest = null;
+    });
+  return workspaceWorkItemRequest;
+}
+
+export function githubWorkItemsToPickerOptions({
+  issues,
+  prs,
+  repoFullName,
+}: {
+  issues: readonly GitHubIssue[];
+  prs: readonly OpenPRItem[];
+  repoFullName: string | null;
+}): WorkItemPickerOption[] {
+  const repoName = repoFullName ?? "GitHub";
+  return [
+    ...issues.map((issue) => ({
+      key: `github_issue:${issue.html_url}`,
+      kind: "github_issue" as const,
+      title: issue.title,
+      identifier: `#${issue.number}`,
+      detail: `${repoName} · ${issue.state}`,
+      searchableText: [
+        issue.number,
+        issue.title,
+        issue.state,
+        repoName,
+        ...issue.labels.map((label) => label.name),
+      ]
+        .join(" ")
+        .toLowerCase(),
+      pillPath: issue.html_url,
+      pillName: `#${issue.number} ${issue.title}`,
+    })),
+    ...prs.map((pr) => {
+      const prStatus = normalizePrStatus({
+        state: pr.state,
+        draft: pr.draft,
+      });
+      return {
+        key: `github_pr:${pr.url}`,
+        kind: "github_pr" as const,
+        title: pr.title,
+        identifier: `#${pr.number}`,
+        detail: `${repoName} · ${prStatus}`,
+        searchableText: [
+          pr.number,
+          pr.title,
+          prStatus,
+          pr.ci_status,
+          repoName,
+          pr.head_branch,
+          pr.base_branch,
+        ]
+          .join(" ")
+          .toLowerCase(),
+        pillPath: pr.url,
+        pillName: `#${pr.number} ${pr.title}`,
+        prStatus,
+        ciStatus: pr.ci_status,
+      };
+    }),
+  ];
+}
+
+export function filterWorkItemPickerOptions(
+  options: readonly WorkItemPickerOption[],
+  filter: WorkItemPickerFilter,
+  searchQuery: string,
+  limit: number = WORK_ITEM_PICKER_RESULT_LIMIT
+): WorkItemPickerOption[] {
+  const query = searchQuery.trim().toLowerCase();
+  return options
+    .filter(
+      (option) =>
+        (filter === "all" || option.kind === filter) &&
+        (!query || option.searchableText.includes(query))
+    )
+    .slice(0, limit);
+}

--- a/src/features/SessionCreator/variants/ChatPanel/workItemPickerModel.ts
+++ b/src/features/SessionCreator/variants/ChatPanel/workItemPickerModel.ts
@@ -31,6 +31,8 @@ export interface WorkItemPickerOption {
   searchableText: string;
   pillPath: string;
   pillName: string;
+  openedBy?: string;
+  statusLabel?: string;
   prStatus?: string;
   ciStatus?: PullRequestCiStatus;
   contextText?: string;
@@ -199,11 +201,14 @@ export function githubWorkItemsToPickerOptions({
       kind: "github_issue" as const,
       title: issue.title,
       identifier: `#${issue.number}`,
-      detail: `${repoName} · ${issue.state}`,
+      detail: repoName,
+      openedBy: issue.user.login || undefined,
+      statusLabel: issue.state,
       searchableText: [
         issue.number,
         issue.title,
         issue.state,
+        issue.user.login,
         repoName,
         ...issue.labels.map((label) => label.name),
       ]
@@ -222,11 +227,14 @@ export function githubWorkItemsToPickerOptions({
         kind: "github_pr" as const,
         title: pr.title,
         identifier: `#${pr.number}`,
-        detail: `${repoName} · ${prStatus}`,
+        detail: repoName,
+        openedBy: pr.author_login || undefined,
+        statusLabel: prStatus,
         searchableText: [
           pr.number,
           pr.title,
           prStatus,
+          pr.author_login,
           pr.ci_status,
           repoName,
           pr.head_branch,

--- a/src/i18n/locales/de/sessions.json
+++ b/src/i18n/locales/de/sessions.json
@@ -2072,6 +2072,7 @@
     },
     "searchModels": "Modelle suchen...",
     "newItem": "Neues Element",
+    "solveWorkItem": "Arbeitselement lösen",
     "launchpadQuestion": "Was möchtest du mit",
     "launchpadQuestionSuffix": "erstellen?",
     "manualLaunchpadQuestion": "Was möchtest du erstellen?",

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -2152,6 +2152,7 @@
     },
     "searchModels": "Search models...",
     "newItem": "New Item",
+    "solveWorkItem": "Solve Work Item",
     "launchpadQuestion": "What do you want to build with",
     "launchpadQuestionSuffix": "?",
     "manualLaunchpadQuestion": "What do you want to build?",

--- a/src/i18n/locales/es/sessions.json
+++ b/src/i18n/locales/es/sessions.json
@@ -2074,6 +2074,7 @@
     },
     "searchModels": "Buscar modelos...",
     "newItem": "Nuevo elemento",
+    "solveWorkItem": "Resolver elemento de trabajo",
     "launchpadQuestion": "¿Qué quieres crear con",
     "launchpadQuestionSuffix": "?",
     "manualLaunchpadQuestion": "¿Qué quieres crear?",

--- a/src/i18n/locales/fr/sessions.json
+++ b/src/i18n/locales/fr/sessions.json
@@ -2074,6 +2074,7 @@
     },
     "searchModels": "Rechercher des modèles...",
     "newItem": "Nouvel élément",
+    "solveWorkItem": "Résoudre un élément de travail",
     "launchpadQuestion": "Que souhaitez-vous créer avec",
     "launchpadQuestionSuffix": " ?",
     "manualLaunchpadQuestion": "Que souhaitez-vous créer ?",

--- a/src/i18n/locales/ja/sessions.json
+++ b/src/i18n/locales/ja/sessions.json
@@ -2073,6 +2073,7 @@
     },
     "searchModels": "モデルを検索...",
     "newItem": "新しいアイテム",
+    "solveWorkItem": "作業項目を解決",
     "launchpadQuestion": "",
     "launchpadQuestionSuffix": "で何を作りますか？",
     "manualLaunchpadQuestion": "何を作りますか？",

--- a/src/i18n/locales/ko/sessions.json
+++ b/src/i18n/locales/ko/sessions.json
@@ -2073,6 +2073,7 @@
     },
     "searchModels": "모델 검색...",
     "newItem": "새 항목",
+    "solveWorkItem": "작업 항목 해결",
     "launchpadQuestion": "",
     "launchpadQuestionSuffix": "와 함께 무엇을 만들고 싶으신가요?",
     "manualLaunchpadQuestion": "무엇을 만들고 싶으신가요?",

--- a/src/i18n/locales/pl/sessions.json
+++ b/src/i18n/locales/pl/sessions.json
@@ -2127,6 +2127,7 @@
     },
     "searchModels": "Wyszukaj modele...",
     "newItem": "Nowy element",
+    "solveWorkItem": "Rozwiąż element pracy",
     "launchpadQuestion": "Co chcesz zbudować za pomocą",
     "launchpadQuestionSuffix": "?",
     "manualLaunchpadQuestion": "Co chcesz zbudować?",

--- a/src/i18n/locales/pt/sessions.json
+++ b/src/i18n/locales/pt/sessions.json
@@ -2089,6 +2089,7 @@
     },
     "searchModels": "Buscar modelos...",
     "newItem": "Novo item",
+    "solveWorkItem": "Resolver item de trabalho",
     "launchpadQuestion": "O que você quer criar com",
     "launchpadQuestionSuffix": "?",
     "manualLaunchpadQuestion": "O que você quer criar?",

--- a/src/i18n/locales/ru/sessions.json
+++ b/src/i18n/locales/ru/sessions.json
@@ -2117,6 +2117,7 @@
     },
     "searchModels": "Поиск моделей...",
     "newItem": "Новый элемент",
+    "solveWorkItem": "Решить рабочий элемент",
     "launchpadQuestion": "Что вы хотите создать с помощью",
     "launchpadQuestionSuffix": "?",
     "manualLaunchpadQuestion": "Что вы хотите создать?",

--- a/src/i18n/locales/tr/sessions.json
+++ b/src/i18n/locales/tr/sessions.json
@@ -2074,6 +2074,7 @@
     },
     "searchModels": "Model ara...",
     "newItem": "Yeni öğe",
+    "solveWorkItem": "İş öğesini çöz",
     "launchpadQuestion": "",
     "launchpadQuestionSuffix": "ile ne oluşturmak istersiniz?",
     "manualLaunchpadQuestion": "Ne oluşturmak istersiniz?",

--- a/src/i18n/locales/vi/sessions.json
+++ b/src/i18n/locales/vi/sessions.json
@@ -2071,6 +2071,7 @@
     },
     "searchModels": "Tìm kiếm mô hình...",
     "newItem": "Mục mới",
+    "solveWorkItem": "Giải quyết hạng mục công việc",
     "launchpadQuestion": "Bạn muốn xây dựng gì với",
     "launchpadQuestionSuffix": "?",
     "manualLaunchpadQuestion": "Bạn muốn xây dựng gì?",

--- a/src/i18n/locales/zh-Hant/sessions.json
+++ b/src/i18n/locales/zh-Hant/sessions.json
@@ -2088,6 +2088,7 @@
     },
     "searchModels": "搜索模型...",
     "newItem": "新建專案",
+    "solveWorkItem": "處理工作項",
     "launchpadQuestion": "你想使用",
     "launchpadQuestionSuffix": "建構什麼？",
     "manualLaunchpadQuestion": "你想建構什麼？",

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -2125,6 +2125,7 @@
     },
     "searchModels": "搜索模型...",
     "newItem": "新建项目",
+    "solveWorkItem": "处理工作项",
     "launchpadQuestion": "你想使用",
     "launchpadQuestionSuffix": "构建什么？",
     "manualLaunchpadQuestion": "你想构建什么？",

--- a/src/modules/MainApp/WorkManagement/GitHubWorkItemsView.tsx
+++ b/src/modules/MainApp/WorkManagement/GitHubWorkItemsView.tsx
@@ -1,18 +1,15 @@
 import {
   CheckCircle2,
-  CircleDashed,
   CircleDot,
   CircleSlash,
   Copy,
   GitMerge,
   GitPullRequestDraft,
-  LoaderCircle,
-  XCircle,
 } from "lucide-react";
 import React, { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { PullRequestCiStatus } from "@src/api/tauri/github";
+import PrCiStatusIndicator from "@src/components/PrCiStatusIndicator";
 import type { SelectOption } from "@src/components/Select";
 import type { SettingsTableSelectFilter } from "@src/components/SettingsTable";
 import {
@@ -127,49 +124,6 @@ interface GitHubWorkItemsViewProps {
     title: string,
     body: string
   ) => void;
-}
-
-function PrCiStatusCell({
-  prNumber,
-  status,
-  label,
-}: {
-  prNumber: number;
-  status: PullRequestCiStatus;
-  label: string;
-}): React.ReactNode {
-  const icon =
-    status === "success" ? (
-      <CheckCircle2 size={14} strokeWidth={1.8} />
-    ) : status === "failure" ? (
-      <XCircle size={14} strokeWidth={1.8} />
-    ) : status === "pending" ? (
-      <LoaderCircle size={14} strokeWidth={1.8} className="animate-spin" />
-    ) : status === "none" ? (
-      <CircleSlash size={14} strokeWidth={1.8} />
-    ) : (
-      <CircleDashed size={14} strokeWidth={1.8} />
-    );
-  const colorClass =
-    status === "success"
-      ? "text-success-6"
-      : status === "failure"
-        ? "text-danger-6"
-        : status === "pending"
-          ? "text-warning-6"
-          : "text-text-3";
-
-  return (
-    <span
-      className={`inline-flex items-center gap-1.5 whitespace-nowrap ${colorClass}`}
-      title={label}
-      aria-label={label}
-      data-testid={`github-pr-ci-${prNumber}`}
-    >
-      {icon}
-      <span>{label}</span>
-    </span>
-  );
 }
 
 export function GitHubWorkItemsView({
@@ -379,10 +333,10 @@ export function GitHubWorkItemsView({
               dataTestId: `github-pr-status-${item.id}`,
             },
             ciStatus: (
-              <PrCiStatusCell
-                prNumber={item.id}
+              <PrCiStatusIndicator
                 status={item.rawPr.ci_status}
                 label={prCiLabel}
+                dataTestId={`github-pr-ci-${item.id}`}
               />
             ),
             updated,

--- a/src/modules/shared/dataSource/TeamRuntimeToday.tsx
+++ b/src/modules/shared/dataSource/TeamRuntimeToday.tsx
@@ -31,7 +31,7 @@ import {
   buildOrgRuntimeTodaySnapshot,
   recentSharedSessions,
 } from "./teamRuntimeData";
-import { bucketLabelKey } from "./usageBuckets";
+import { BucketIcon, bucketLabelKey } from "./usageBuckets";
 import {
   formatInt,
   formatPercent,
@@ -357,8 +357,15 @@ function TeamRuntimeToday({
                   className="flex items-center justify-between gap-3 border-b border-border-1 px-4 py-3 last:border-b-0"
                   data-testid={`team-runtime-source-${source.bucket}`}
                 >
-                  <span className="min-w-0 truncate text-sm text-text-2">
-                    {tUsage(bucketLabelKey(source.bucket))}
+                  <span className="flex min-w-0 items-center gap-2 text-sm text-text-2">
+                    <BucketIcon
+                      bucket={source.bucket}
+                      size={16}
+                      className="shrink-0"
+                    />
+                    <span className="truncate">
+                      {tUsage(bucketLabelKey(source.bucket))}
+                    </span>
                   </span>
                   <span className="shrink-0 text-right text-xs text-text-3">
                     <span className="font-medium text-text-1">

--- a/src/shared/dnd/dropTargetUtils.ts
+++ b/src/shared/dnd/dropTargetUtils.ts
@@ -43,6 +43,8 @@ interface InsertPillOptions {
   pointerX?: number;
   pointerY?: number;
   contextText?: string;
+  /** Suppress the toast when a caller inserts several pills as one action. */
+  notify?: boolean;
 }
 
 function getDisplayName(path: string, name: string | undefined): string {
@@ -71,7 +73,7 @@ export function insertPillFromTabPayload(
   const isFolder = payload.isFolder ?? iconType === "folder";
   const displayName = getDisplayName(payload.path, payload.name);
 
-  if (payload.contextText) {
+  if (payload.contextText && iconType !== "workitem") {
     storePillText(payload.path, capPillText(payload.contextText));
   }
 
@@ -93,14 +95,21 @@ export function insertPillFromTabPayload(
 
   if (iconType === "workitem") {
     const pillPath = `workitem://${payload.path}/${Date.now()}`;
+    if (payload.contextText) {
+      storePillText(pillPath, capPillText(payload.contextText));
+    }
     composerInputRef.current.insertFilePill(
       pillPath,
       false,
       "workitem",
       displayName
     );
-    loadWorkItemPillContent(payload.path, pillPath);
-    Message.success(i18n.t("toasts.addedAsContext", { name: displayName }));
+    if (!payload.contextText) {
+      loadWorkItemPillContent(payload.path, pillPath);
+    }
+    if (payload.notify !== false) {
+      Message.success(i18n.t("toasts.addedAsContext", { name: displayName }));
+    }
     return;
   }
 
@@ -110,7 +119,9 @@ export function insertPillFromTabPayload(
     iconType,
     displayName
   );
-  Message.success(i18n.t("toasts.addedAsContext", { name: displayName }));
+  if (payload.notify !== false) {
+    Message.success(i18n.t("toasts.addedAsContext", { name: displayName }));
+  }
 }
 
 export function insertTabAsPill(


### PR DESCRIPTION
## Problem

The Launchpad had no direct way to choose an existing local Work Item or GitHub issue or pull request and attach it to a new session. The existing entry layout could overlap or force an outer scrollbar in short viewports, and duplicated card and pull-request status presentation made the new surface harder to keep consistent. Runtime usage rows also lacked visual source identification.

## Solution

- Added a first-class Solve Work Item card that replaces the Launchpad cards inline with a transparent, width-aligned picker instead of opening a modal.
- Added lazy, demand-driven loading for local Work Items and GitHub issues and pull requests, with search, source filters, refresh, multi-select, and composer-pill insertion.
- Reused the existing workspace IPC reader and repository-scoped GitHub cache, disabled unnecessary branch loading, bounded retained local data to 500 items, and capped rendered results at 20.
- Made the picker responsive to short viewports with compact controls and rows, a dynamic maximum height, contained internal scrolling, and hidden scrollbar chrome so the page itself does not scroll while the picker is open. On viewports at least 1000px tall, the title and picker are centered together in the space above the docked composer.
- Matched Inbox typography and alignment, moved selection controls to the row end, and ordered GitHub metadata as repository · opener · state · CI. Passed and failed checks use a simple check or X, pending checks use the sidebar breathing dot, and unavailable or loading checks stay hidden.
- Corrected GitHub CI ingestion so a failed check context overrides a still-pending aggregate rollup, and ranked GitHub issues and pull requests together by descending issue number.
- Extracted shared Launchpad action-card and pull-request CI indicator components to remove duplicated UI logic while preserving the existing Work Management presentation.
- Added source icons to Runtime usage rows and localized the new action label across the existing session locale files.

## Potential risks

- The picker depends on the existing workspace Work Item IPC payload and local GitHub integration. Repositories without an authenticated or detectable GitHub remote will continue to show local results and the existing source error state.
- Short-viewport and hidden-scrollbar behavior was reviewed from source and the supplied screenshots, but no new rendered screenshot or recording was captured because desktop UI control was not authorized. This is the main unverified path.
- There are no dependency, schema, persistence-format, migration, public API, or wire-format changes. Rollback is limited to reverting the six commits in this PR.

## Performance

- Loading is user-triggered only; the change adds no polling, timers, subscriptions, workers, or idle background work.
- Local reads are single-flight and generation-guarded. GitHub requests reuse the existing 45-second, eight-entry LRU cache and in-flight deduplication.
- Closing the picker invalidates stale local generations, branch I/O is disabled for picker loads, and list rendering is bounded to 20 rows.
- CI context enrichment remains in the existing single batched GraphQL request and requests only type, conclusion, and state enums, bounded to 100 contexts per pull request.

## Verification

- npx eslint src/components/PrCiStatusIndicator.tsx src/engines/ChatPanel/ChatPanelStartPage.tsx src/features/SessionCreator/components/LaunchpadActionGrid.tsx src/features/SessionCreator/components/useWorktreeSourceData.ts src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.test.ts src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.tsx src/features/SessionCreator/variants/ChatPanel/WorkItemPickerPanel.tsx src/features/SessionCreator/variants/ChatPanel/index.tsx src/features/SessionCreator/variants/ChatPanel/workItemPickerModel.test.ts src/features/SessionCreator/variants/ChatPanel/workItemPickerModel.ts src/modules/MainApp/WorkManagement/GitHubWorkItemsView.tsx src/modules/shared/dataSource/TeamRuntimeToday.tsx src/shared/dnd/dropTargetUtils.ts — passed.
- npx vitest run src/engines/ChatPanel/ChatPanelStartPage.test.ts src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.test.ts src/features/SessionCreator/variants/ChatPanel/workItemPickerModel.test.ts src/features/SessionCreator/components/__tests__/worktreeSourceCache.test.ts src/components/ComposerInput/__tests__/githubUrl.test.ts src/modules/MainApp/WorkManagement/GitHubWorkItemsView.test.ts — 32 tests passed across 6 files.
- Follow-up metadata verification: npx vitest run src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.test.ts src/features/SessionCreator/variants/ChatPanel/workItemPickerModel.test.ts src/modules/MainApp/WorkManagement/GitHubWorkItemsView.test.ts — 10 tests passed across 3 files.
- npx vitest run src/engines/ChatPanel/ChatPanelStartPage.test.ts src/features/SessionCreator/variants/ChatPanel/workItemPickerModel.test.ts src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.test.ts — 15 tests passed across 3 files.
- Tall-screen layout follow-up: npx vitest run src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.test.ts src/engines/ChatPanel/ChatPanelStartPage.test.ts — 10 tests passed across 2 files.
- cargo test --manifest-path src-tauri/Cargo.toml -p integrations open_pr_item_tests::maps_batched_pull_request_ci_rollups — passed.
- cargo clippy --manifest-path src-tauri/Cargo.toml -p integrations --lib -- -D warnings — passed.
- Live gh api GraphQL validation against PR #750 confirmed the bounded statusCheckRollup contexts query shape.
- Scoped staged TypeScript check — passed. A later full npm run typecheck rerun reaches only two existing src/util/optimization/__tests__/gifMetadata.test.ts errors; that file is unchanged from develop.
- git diff --check origin/develop...HEAD — passed.
- Parsed every existing src/i18n/locales/*/sessions.json file with JSON.parse — passed.
- Scanned the final diff for private keys, token patterns, personal paths, debug logging, and generated-artifact paths — no findings.
- Not run: rendered desktop visual validation, because Computer Use was not authorized.