### PR TITLE
test(images): fix GIF metadata type compatibility

### DIFF
--- a/src/util/optimization/__tests__/gifMetadata.test.ts
+++ b/src/util/optimization/__tests__/gifMetadata.test.ts
@@ -7,7 +7,7 @@ import {
   parseGifMetadata,
   readGifLogicalScreen,
 } from "../gifMetadata";
-import { ImageOptimizationError, optimizeImage } from "../imageOptimizer";
+import { optimizeImage } from "../imageOptimizer";
 
 function pushUint16Le(bytes: number[], value: number): void {
   bytes.push(value & 0xff, (value >> 8) & 0xff);
@@ -102,12 +102,13 @@ describe("GIF metadata inspection", () => {
   });
 
   it("rejects an unsafe animation before invoking the browser image decoder", async () => {
-    const file = new File([createGif(2048, 2048, 3)], "oversized.gif", {
+    const gif = createGif(2048, 2048, 3);
+    const file = new File([gif.buffer as ArrayBuffer], "oversized.gif", {
       type: "image/gif",
     });
 
-    await expect(optimizeImage(file)).rejects.toMatchObject<
-      Partial<ImageOptimizationError>
-    >({ code: "GIF_LIMIT_EXCEEDED" });
+    await expect(optimizeImage(file)).rejects.toMatchObject({
+      code: "GIF_LIMIT_EXCEEDED",
+    });
   });
 });


### PR DESCRIPTION
## Problem

The current `develop` branch fails `tsc --noEmit` in `gifMetadata.test.ts`. The synthetic GIF is typed as `Uint8Array<ArrayBufferLike>`, which is not accepted as a `BlobPart` by the current DOM types, and the current Vitest matcher no longer accepts an explicit generic type argument. These test-only type errors block frontend CI for every branch rebased onto `develop`.

## Solution

Pass the synthetic GIF's owned `ArrayBuffer` to `File` and remove the unsupported matcher generic plus its now-unused error-class import. The test assertion and production image optimization behavior are unchanged.

## Potential risks

This is limited to one test file and does not change production code, public APIs, persistence, dependencies, or UI behavior. The buffer cast is safe here because `createGif` returns a newly allocated `Uint8Array` whose backing buffer contains the complete fixture. Rollback is a normal revert of this commit.

## Verification

- `PATH=../../../node_modules/.bin:$PATH vitest run src/util/optimization/__tests__/gifMetadata.test.ts` — passed, 5/5 tests in the isolated worktree.
- `PATH=../../../node_modules/.bin:$PATH tsc --noEmit` — passed in the isolated worktree.
- `git diff --check` — passed.
- UI screenshots were not captured because this is a test-only type-compatibility fix with no rendered behavior change.
