### PR TITLE
test(markdown): stabilize issue SSR mocks

### DIFF
--- a/src/modules/ProjectManager/WorkItems/components/GitHubIssueThreadSurface.test.ts
+++ b/src/modules/ProjectManager/WorkItems/components/GitHubIssueThreadSurface.test.ts
@@ -15,7 +15,17 @@ vi.mock("@src/components/IntegrationIcon", () => ({
     React.createElement("span", { "data-integration-icon": type }),
 }));
 
+vi.mock("@src/components/MarkDown", () => ({
+  default: ({ textContent }: { textContent: string }) =>
+    React.createElement(
+      "div",
+      { "data-testid": "markdown-content" },
+      textContent
+    ),
+}));
+
 vi.mock("@src/modules/shared/components/RichMarkdownEditor", () => ({
+  RICH_MARKDOWN_COMPOSER_TOOLBAR_CLASS: "mock-toolbar-class",
   default: ({ dataTestId }: { dataTestId?: string }) =>
     React.createElement("div", { "data-testid": dataTestId }),
 }));

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/IssuesContent/__tests__/IssueDetailExternalLinkButton.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/IssuesContent/__tests__/IssueDetailExternalLinkButton.test.ts
@@ -33,7 +33,13 @@ vi.mock("@src/components/IntegrationIcon", () => ({
     createElement("span", { "data-integration-icon": type }),
 }));
 
+vi.mock("@src/components/MarkDown", () => ({
+  default: ({ textContent }: { textContent: string }) =>
+    createElement("div", { "data-testid": "markdown-content" }, textContent),
+}));
+
 vi.mock("@src/modules/shared/components/RichMarkdownEditor", () => ({
+  RICH_MARKDOWN_COMPOSER_TOOLBAR_CLASS: "mock-toolbar-class",
   default: forwardRef(function MockRichMarkdownEditor(
     {
       appearance,


### PR DESCRIPTION
## Problem

The current `develop` branch fails four synchronous SSR tests across the shared GitHub issue surface. Those tests render through the lazy `Markdown` entry without a synchronous test substitute, causing React to suspend inside `renderToStaticMarkup`. Once that suspension is removed, the same stale test mocks also omit the `RICH_MARKDOWN_COMPOSER_TOOLBAR_CLASS` export now consumed by the issue comment composer. The production UI has a Suspense host; the regression is in the test boundary and blocks frontend CI for unrelated PRs.

## Solution

Update the two affected SSR test modules to provide:

- a synchronous `MarkDown` substitute that still renders the supplied text content; and
- the public toolbar-class constant alongside the existing `RichMarkdownEditor` substitute.

The tests continue rendering the real issue/thread composition and exercising their original assertions; no production component or behavior changes.

## Potential risks

The synchronous Markdown substitute does not exercise lazy chunk loading or Markdown parsing in these two composition tests. Those concerns belong to the Markdown component's own tests; these tests verify issue metadata, controls, timeline composition, and shared surface structure. The patch changes only test mocks, with no UI, persistence, API, dependency, or runtime impact. Rollback is a normal revert of this commit.

## Verification

- Reproduced on unmodified `develop`: the two target files reported 4 failures / 5 passes due to synchronous suspension.
- `PATH=../../../node_modules/.bin:$PATH vitest run src/modules/ProjectManager/WorkItems/components/GitHubIssueThreadSurface.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/IssuesContent/__tests__/IssueDetailExternalLinkButton.test.ts` — passed, 9/9 tests after the fix.
- `PATH=../../../node_modules/.bin:$PATH tsc --noEmit` — passed.
- Prettier and `git diff --check` — passed.
- Final scope inspection — two test files, 16 added lines, no production changes, personal paths, secrets, artifacts, or debug output.
- GitHub CI is queued on the published head. Current `develop` still has the independent imported-history Rust Clippy baseline failure isolated in #752; this test-only PR intentionally does not absorb that unrelated production fix. After either baseline PR lands, the remaining PR must be rebased and rerun.
- UI screenshots were not captured because this is a test-boundary repair with no rendered product change.