### PR TITLE
refactor(session): unify simulator event classification

### DIFF
--- a/src/engines/SessionCore/core/atoms/actions.simulatorPreview.ts
+++ b/src/engines/SessionCore/core/atoms/actions.simulatorPreview.ts
@@ -6,6 +6,7 @@
  * the authoritative Rust snapshot arrives. Extracted from actions.ts.
  */
 import { isLiveRuntimeResourceEvent } from "../runningEventGate";
+import { getFallbackSimulatorEventFilterCategory } from "../simulatorEventFilterCategory";
 import type { SessionEvent, SimulatorEventPreview } from "../types";
 
 /**
@@ -34,33 +35,6 @@ export function isSimulatorVisibleApprox(event: SessionEvent): boolean {
   );
 }
 
-function getSimulatorFilterCategory(
-  event: SessionEvent
-): SimulatorEventPreview["filterCategory"] {
-  if (event.source === "user") return "key_interactions";
-  if (
-    event.uiCanonical === "edit_file" ||
-    event.uiCanonical === "delete_file"
-  ) {
-    return "file_changes";
-  }
-  if (event.command || event.uiCanonical === "run_shell") {
-    return "terminal_events";
-  }
-  if (
-    event.uiCanonical === "read_file" ||
-    event.uiCanonical === "list_dir" ||
-    event.uiCanonical === "code_search" ||
-    event.uiCanonical === "glob" ||
-    event.uiCanonical === "find_files" ||
-    event.uiCanonical === "search"
-  ) {
-    return "explore";
-  }
-  if (event.filePath) return "file_changes";
-  return "other";
-}
-
 function buildSimulatorPreview(event: SessionEvent): SimulatorEventPreview {
   return {
     id: event.id,
@@ -74,7 +48,7 @@ function buildSimulatorPreview(event: SessionEvent): SimulatorEventPreview {
     displayStatus: event.displayStatus,
     displayVariant: event.displayVariant,
     activityStatus: event.activityStatus,
-    filterCategory: getSimulatorFilterCategory(event),
+    filterCategory: getFallbackSimulatorEventFilterCategory(event),
     threadId: event.threadId,
     processId: event.processId,
     callId: event.callId,

--- a/src/engines/SessionCore/core/simulatorEventFilterCategory.ts
+++ b/src/engines/SessionCore/core/simulatorEventFilterCategory.ts
@@ -1,0 +1,42 @@
+import type { SessionEvent, SimulatorEventFilterValue } from "./types";
+
+export const SIMULATOR_EVENT_FILTER_VALUES = [
+  "key_interactions",
+  "file_changes",
+  "terminal_events",
+  "explore",
+  "other",
+] as const satisfies readonly SimulatorEventFilterValue[];
+
+/**
+ * Canonical fallback category used by every local simulator preview path.
+ * The backend-projected category remains authoritative once its snapshot
+ * arrives; this function keeps optimistic and materialized local previews in
+ * lockstep until then.
+ */
+export function getFallbackSimulatorEventFilterCategory(
+  event: SessionEvent
+): SimulatorEventFilterValue {
+  if (event.source === "user") return "key_interactions";
+  if (
+    event.uiCanonical === "edit_file" ||
+    event.uiCanonical === "delete_file"
+  ) {
+    return "file_changes";
+  }
+  if (event.command || event.uiCanonical === "run_shell") {
+    return "terminal_events";
+  }
+  if (
+    event.uiCanonical === "read_file" ||
+    event.uiCanonical === "list_dir" ||
+    event.uiCanonical === "code_search" ||
+    event.uiCanonical === "glob" ||
+    event.uiCanonical === "find_files" ||
+    event.uiCanonical === "search"
+  ) {
+    return "explore";
+  }
+  if (event.filePath) return "file_changes";
+  return "other";
+}

--- a/src/engines/SessionCore/core/store/snapshotMaterialization.simulatorPreview.ts
+++ b/src/engines/SessionCore/core/store/snapshotMaterialization.simulatorPreview.ts
@@ -7,39 +7,9 @@
  * objects are cached by event object identity so events untouched by a
  * delta reuse their preview across materializations.
  */
-import type {
-  SessionEvent,
-  SimulatorEventFilterValue,
-  SimulatorEventPreview,
-} from "../types";
+import { getFallbackSimulatorEventFilterCategory } from "../simulatorEventFilterCategory";
+import type { SessionEvent, SimulatorEventPreview } from "../types";
 import type { NormalizedSnapshotCache } from "./EventStoreProxyTypes";
-
-function getFallbackFilterCategory(
-  event: SessionEvent
-): SimulatorEventFilterValue {
-  if (event.source === "user") return "key_interactions";
-  if (
-    event.uiCanonical === "edit_file" ||
-    event.uiCanonical === "delete_file"
-  ) {
-    return "file_changes";
-  }
-  if (event.command || event.uiCanonical === "run_shell") {
-    return "terminal_events";
-  }
-  if (
-    event.uiCanonical === "read_file" ||
-    event.uiCanonical === "list_dir" ||
-    event.uiCanonical === "code_search" ||
-    event.uiCanonical === "glob" ||
-    event.uiCanonical === "find_files" ||
-    event.uiCanonical === "search"
-  ) {
-    return "explore";
-  }
-  if (event.filePath) return "file_changes";
-  return "other";
-}
 
 function buildSimulatorEventPreview(
   event: SessionEvent
@@ -56,7 +26,7 @@ function buildSimulatorEventPreview(
     displayStatus: event.displayStatus,
     displayVariant: event.displayVariant,
     activityStatus: event.activityStatus,
-    filterCategory: getFallbackFilterCategory(event),
+    filterCategory: getFallbackSimulatorEventFilterCategory(event),
     threadId: event.threadId,
     processId: event.processId,
     callId: event.callId,

--- a/src/engines/SessionCore/derived/simulatorEventFilters.ts
+++ b/src/engines/SessionCore/derived/simulatorEventFilters.ts
@@ -1,45 +1,14 @@
 import type {
-  SessionEvent,
   SimulatorEventFilterValue,
   SimulatorEventPreview,
 } from "../core/types";
 
-export const SIMULATOR_EVENT_FILTER_VALUES = [
-  "key_interactions",
-  "file_changes",
-  "terminal_events",
-  "explore",
-  "other",
-] as const satisfies readonly SimulatorEventFilterValue[];
+export {
+  SIMULATOR_EVENT_FILTER_VALUES,
+  getFallbackSimulatorEventFilterCategory,
+} from "../core/simulatorEventFilterCategory";
 
 export type { SimulatorEventFilterValue };
-
-export function getFallbackSimulatorEventFilterCategory(
-  event: SessionEvent
-): SimulatorEventFilterValue {
-  if (event.source === "user") return "key_interactions";
-  if (
-    event.uiCanonical === "edit_file" ||
-    event.uiCanonical === "delete_file"
-  ) {
-    return "file_changes";
-  }
-  if (event.command || event.uiCanonical === "run_shell") {
-    return "terminal_events";
-  }
-  if (
-    event.uiCanonical === "read_file" ||
-    event.uiCanonical === "list_dir" ||
-    event.uiCanonical === "code_search" ||
-    event.uiCanonical === "glob" ||
-    event.uiCanonical === "find_files" ||
-    event.uiCanonical === "search"
-  ) {
-    return "explore";
-  }
-  if (event.filePath) return "file_changes";
-  return "other";
-}
 
 export function isSimulatorEventVisibleForFilters(
   preview: SimulatorEventPreview,


### PR DESCRIPTION
## Problem

The same fallback simulator-event category decision was implemented independently in three production paths: normalized snapshot materialization, optimistic action previews, and derived filtering. A new or renamed event kind could therefore be categorized differently before and after the authoritative snapshot arrives, causing visible filter flicker or incorrect simulator grouping.

## Solution

Move the fallback category policy into a core-level `simulatorEventFilterCategory` module and wire all three consumers to that one function. The derived module re-exports the existing public API, so callers outside SessionCore keep the same import contract while lower-level core code no longer depends on an upper derived layer.

The canonical fallback remains intentionally exhaustive over known event shapes and preserves `other` as the safe category for unknown future events.

## Potential risks

This is a behavior-preserving consolidation, but import-layer mistakes could create a circular dependency or change the public export surface. The helper lives in the lower core layer, the existing derived export is preserved, and the full TypeScript check plus focused SessionCore tests cover those risks. Rollback is a normal revert of this commit.

## Verification

- `pnpm exec vitest run src/engines/SessionCore/derived/simulatorEventFilters.test.ts src/engines/SessionCore/core/atoms/__tests__/actions.test.ts src/engines/SessionCore/__tests__/simulatorEventMapping.test.ts` — 3 files, 103 tests passed.
- `pnpm exec eslint src/engines/SessionCore/core/simulatorEventFilterCategory.ts src/engines/SessionCore/core/store/snapshotMaterialization.simulatorPreview.ts src/engines/SessionCore/core/atoms/actions.simulatorPreview.ts src/engines/SessionCore/derived/simulatorEventFilters.ts` — passed.
- `pnpm typecheck` — full TypeScript check executed and passed.
- `git diff --check` — passed.
- The current `develop` snapshot does not contain the repository's newer `verify:quick` / `verify:final` scripts, so exact Vitest, ESLint, and `pnpm typecheck` entry points were used.

Effects: none added or modified. UI screenshots are not useful because this refactor intentionally preserves the existing category output and rendered appearance.
