### PR TITLE
refactor(cloud): unify session scope resolution

### DIFF
--- a/src/features/Org2Cloud/CloudSessionShareDialog/useCloudSessionShareDialog.ts
+++ b/src/features/Org2Cloud/CloudSessionShareDialog/useCloudSessionShareDialog.ts
@@ -9,11 +9,8 @@
 import { useAtomValue, useStore } from "jotai";
 import { useCallback, useMemo, useState, useSyncExternalStore } from "react";
 
-import { persistedScopeKeysForImportedSession } from "@src/features/TeamCollaboration/importedSessionScopeMatch";
 import {
   getShareableScopeKeyVersion,
-  peekShareableScopeKeys,
-  primeShareableScopeKey,
   subscribeShareableScopeKeys,
 } from "@src/features/TeamCollaboration/repoScopeResolver";
 import { sessionOrgTagsAtom } from "@src/features/TeamCollaboration/sessionOrgTagsAtom";
@@ -27,22 +24,8 @@ import {
 } from "../org2CloudOrgsAtom";
 import { org2CloudRepoScopesAtom } from "../org2CloudSyncAtoms";
 import { isCloudPushCandidate } from "../org2CloudSyncEngine";
+import { getSessionScopeKeys } from "../org2CloudSyncEngine.repoScopeSync";
 import { getActiveCloudShareOrgsForSession } from "./shareEligibility";
-
-/**
- * Resolved scope keys for one session, backed by the module-level resolver
- * cache the sync engine also feeds (same idiom as useSessionShareDialog:
- * `undefined` = still resolving → not eligible yet; the subscription
- * re-renders the consumer when the keys land).
- */
-function getSessionScopeKeys(session: Session): string[] | null | undefined {
-  const persistedKeys = persistedScopeKeysForImportedSession(session);
-  if (persistedKeys !== undefined) return persistedKeys;
-  if (!session.repoPath) return null;
-  const keys = peekShareableScopeKeys(session.repoPath);
-  if (keys === undefined) primeShareableScopeKey(session.repoPath);
-  return keys;
-}
 
 export interface UseCloudSessionShareDialogResult {
   /** Session the dialog is open for; null = closed. */


### PR DESCRIPTION
## Problem

The cloud share dialog duplicated the sync engine’s session-to-repository-scope resolution. Both copies currently followed the same persisted-import fallback, repo-path check, resolver-cache peek, and cache-prime sequence, but they could drift and make UI eligibility disagree with synchronization.

## Solution

Reuse the sync engine’s exported `getSessionScopeKeys` function from the share-dialog hook and remove the local copy. The shared invariant remains: prefer persisted imported-session scope keys, return `null` without a repository path, otherwise read the bounded resolver cache and prime exactly once on a miss. The existing `useSyncExternalStore` subscription remains the UI change signal.

## Potential risks

The main risk is an import cycle between the dialog and sync engine modules. The shared resolver lives in the lower-level repo-scope sync module and does not import the dialog, so the dependency remains one-way. Runtime cache ownership, async work, subscriptions, and rendering triggers are unchanged. Rollback is a single-commit revert.

## Architecture and performance

- Covered ownership/boundaries, dependency direction, state flow, async resolution, and lifecycle behavior.
- Kept the bounded LRU resolver cache and its single-flight in-progress maps unchanged.
- Kept the external-store subscription and its unsubscribe cleanup unchanged.
- Added no polling, timers, retries, retained state, or new render triggers.
- Effects: none added or modified.

## Verification

- `pnpm exec vitest run src/features/TeamCollaboration/repoScopeResolver.test.ts src/features/Org2Cloud/org2CloudSyncEngine.sessions.test.ts src/features/Org2Cloud/org2CloudSyncEngine.scopeConfirmation.test.ts src/features/Org2Cloud/CloudSessionShareDialog/shareEligibility.test.ts` — 4 files, 93 tests passed after rebasing onto the latest `develop`.
- `pnpm exec eslint src/features/Org2Cloud/CloudSessionShareDialog/useCloudSessionShareDialog.ts` — passed.
- `pnpm typecheck` — full TypeScript check executed and passed after the rebase.
- `git diff --check origin/develop...HEAD` — passed.
- The repository snapshot does not provide `verify:quick` or `verify:final`, so the equivalent focused tests/lint and full typecheck entry point were used.
- No visual evidence: this changes no rendered UI or user-visible behavior.