### PR TITLE
refactor(agent): unify external MCP config loading

### DIFF
--- a/src-tauri/crates/agent-core/src/specialization/external_import/commands.rs
+++ b/src-tauri/crates/agent-core/src/specialization/external_import/commands.rs
@@ -3,6 +3,7 @@
 use std::path::{Path, PathBuf};
 
 use super::detect::detect_all;
+use super::mcp_config::load_external_mcp_config;
 use super::types::{
     frontmatter_declares_readonly, readonly_excluded_tool_names, DetectedItem, ImportItemReport,
     ImportReport, ImportSelection, ImportStatus, ItemKind, SourceScope,
@@ -367,50 +368,6 @@ fn copy_dir_recursive(from: &Path, to: &Path) -> Result<(), String> {
 // ============================================================
 // MCP import
 // ============================================================
-
-fn load_external_mcp_config(path: &Path) -> Result<McpConfigFile, String> {
-    let raw = std::fs::read_to_string(path)
-        .map_err(|err| format!("Failed to read MCP config {}: {}", path.display(), err))?;
-    let mut value: serde_json::Value = serde_json::from_str(&raw)
-        .map_err(|err| format!("Failed to parse MCP config {}: {}", path.display(), err))?;
-    let Some(servers) = value
-        .get_mut("mcpServers")
-        .and_then(|entry| entry.as_object_mut())
-    else {
-        return Ok(McpConfigFile::default());
-    };
-
-    for server in servers.values_mut() {
-        let Some(server_obj) = server.as_object_mut() else {
-            continue;
-        };
-        if !server_obj.contains_key("type") {
-            let inferred = if server_obj.contains_key("url") {
-                "streamableHttp"
-            } else {
-                "stdio"
-            };
-            server_obj.insert(
-                "type".to_string(),
-                serde_json::Value::String(inferred.to_string()),
-            );
-        }
-        if server_obj.get("type").and_then(|entry| entry.as_str()) == Some("http") {
-            server_obj.insert(
-                "type".to_string(),
-                serde_json::Value::String("streamableHttp".to_string()),
-            );
-        }
-    }
-
-    serde_json::from_value(value).map_err(|err| {
-        format!(
-            "Failed to parse MCP server entries {}: {}",
-            path.display(),
-            err
-        )
-    })
-}
 
 fn apply_mcp_import(
     selection: &ImportSelection,

--- a/src-tauri/crates/agent-core/src/specialization/external_import/detect/mcp.rs
+++ b/src-tauri/crates/agent-core/src/specialization/external_import/detect/mcp.rs
@@ -6,9 +6,10 @@
 
 use std::path::Path;
 
+use super::super::mcp_config::load_external_mcp_config;
 use super::super::types::{DetectedItem, ItemKind, ItemPreview, SourceAgent, SourceScope};
 use super::helpers::{home_dir, orgii_mcp_exists, path_has_denied_ancestor, MAX_ITEMS_PER_BATCH};
-use crate::specialization::mcp::config::{McpConfigFile, McpTransportType};
+use crate::specialization::mcp::config::McpTransportType;
 
 pub(super) fn detect_mcp_servers(repo_path: Option<&Path>) -> Vec<DetectedItem> {
     let mut out = Vec::new();
@@ -68,50 +69,6 @@ pub(super) fn detect_mcp_servers(repo_path: Option<&Path>) -> Vec<DetectedItem> 
 
     out.sort_by(|a, b| a.suggested_name.cmp(&b.suggested_name));
     out
-}
-
-fn load_external_mcp_config(path: &Path) -> Result<McpConfigFile, String> {
-    let raw = std::fs::read_to_string(path)
-        .map_err(|err| format!("Failed to read MCP config {}: {}", path.display(), err))?;
-    let mut value: serde_json::Value = serde_json::from_str(&raw)
-        .map_err(|err| format!("Failed to parse MCP config {}: {}", path.display(), err))?;
-    let Some(servers) = value
-        .get_mut("mcpServers")
-        .and_then(|entry| entry.as_object_mut())
-    else {
-        return Ok(McpConfigFile::default());
-    };
-
-    for server in servers.values_mut() {
-        let Some(server_obj) = server.as_object_mut() else {
-            continue;
-        };
-        if !server_obj.contains_key("type") {
-            let inferred = if server_obj.contains_key("url") {
-                "streamableHttp"
-            } else {
-                "stdio"
-            };
-            server_obj.insert(
-                "type".to_string(),
-                serde_json::Value::String(inferred.to_string()),
-            );
-        }
-        if server_obj.get("type").and_then(|entry| entry.as_str()) == Some("http") {
-            server_obj.insert(
-                "type".to_string(),
-                serde_json::Value::String("streamableHttp".to_string()),
-            );
-        }
-    }
-
-    serde_json::from_value(value).map_err(|err| {
-        format!(
-            "Failed to parse MCP server entries {}: {}",
-            path.display(),
-            err
-        )
-    })
 }
 
 fn scan_mcp_config_file(

--- a/src-tauri/crates/agent-core/src/specialization/external_import/mcp_config.rs
+++ b/src-tauri/crates/agent-core/src/specialization/external_import/mcp_config.rs
@@ -1,0 +1,105 @@
+use std::path::Path;
+
+use crate::specialization::mcp::config::McpConfigFile;
+
+/// Load an MCP config authored by another agent and normalize the transport
+/// spellings that ORGII accepts before deserializing it into the canonical
+/// config model.
+pub(super) fn load_external_mcp_config(path: &Path) -> Result<McpConfigFile, String> {
+    let raw = std::fs::read_to_string(path)
+        .map_err(|err| format!("Failed to read MCP config {}: {}", path.display(), err))?;
+    let mut value: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|err| format!("Failed to parse MCP config {}: {}", path.display(), err))?;
+    let Some(servers) = value
+        .get_mut("mcpServers")
+        .and_then(|entry| entry.as_object_mut())
+    else {
+        return Ok(McpConfigFile::default());
+    };
+
+    for server in servers.values_mut() {
+        let Some(server_obj) = server.as_object_mut() else {
+            continue;
+        };
+        if !server_obj.contains_key("type") {
+            let inferred = if server_obj.contains_key("url") {
+                "streamableHttp"
+            } else {
+                "stdio"
+            };
+            server_obj.insert(
+                "type".to_string(),
+                serde_json::Value::String(inferred.to_string()),
+            );
+        }
+        if server_obj.get("type").and_then(|entry| entry.as_str()) == Some("http") {
+            server_obj.insert(
+                "type".to_string(),
+                serde_json::Value::String("streamableHttp".to_string()),
+            );
+        }
+    }
+
+    serde_json::from_value(value).map_err(|err| {
+        format!(
+            "Failed to parse MCP server entries {}: {}",
+            path.display(),
+            err
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::specialization::mcp::config::McpTransportType;
+    use tempfile::TempDir;
+
+    #[test]
+    fn normalizes_external_transport_variants() {
+        let temp = TempDir::new().expect("create temp dir");
+        let path = temp.path().join("mcp.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "mcpServers": {
+                    "implicit-stdio": { "command": "server" },
+                    "implicit-http": { "url": "https://example.com/mcp" },
+                    "legacy-http": { "type": "http", "url": "https://example.com/legacy" },
+                    "explicit-sse": { "type": "sse", "url": "https://example.com/sse" }
+                }
+            }"#,
+        )
+        .expect("write config");
+
+        let config = load_external_mcp_config(&path).expect("load config");
+
+        assert_eq!(
+            config.mcp_servers["implicit-stdio"].transport_type,
+            McpTransportType::Stdio
+        );
+        assert_eq!(
+            config.mcp_servers["implicit-http"].transport_type,
+            McpTransportType::StreamableHttp
+        );
+        assert_eq!(
+            config.mcp_servers["legacy-http"].transport_type,
+            McpTransportType::StreamableHttp
+        );
+        assert_eq!(
+            config.mcp_servers["explicit-sse"].transport_type,
+            McpTransportType::Sse
+        );
+    }
+
+    #[test]
+    fn treats_missing_mcp_servers_as_empty() {
+        let temp = TempDir::new().expect("create temp dir");
+        let path = temp.path().join("mcp.json");
+        std::fs::write(&path, r#"{ "other": true }"#).expect("write config");
+
+        let config = load_external_mcp_config(&path).expect("load config");
+
+        assert!(config.mcp_servers.is_empty());
+    }
+}

--- a/src-tauri/crates/agent-core/src/specialization/external_import/mod.rs
+++ b/src-tauri/crates/agent-core/src/specialization/external_import/mod.rs
@@ -20,6 +20,7 @@
 
 pub mod commands;
 pub mod detect;
+mod mcp_config;
 pub mod types;
 
 // Wildcard re-export needed: `#[tauri::command]` generates hidden


### PR DESCRIPTION
## Problem

External MCP discovery and import each carried an identical JSON loader that inferred missing transport types and translated legacy `http` entries. Keeping those copies separate made it possible for detection to accept a config that import later interpreted differently.

## Solution

Move external MCP normalization into one private `external_import::mcp_config` module used by both detection and import. The shared boundary preserves the existing behavior and error messages: missing `type` becomes `stdio` or `streamableHttp` based on `url`, legacy `http` becomes `streamableHttp`, explicit supported types remain unchanged, and files without an object-valued `mcpServers` map are treated as empty. Focused tests now pin those compatibility rules.

## Potential risks

The risk is changing compatibility with third-party MCP JSON formats or error reporting. The implementation is a direct extraction of the two byte-for-byte-equivalent paths, and regression tests cover every normalization branch plus the empty-map fallback. It changes no persisted ORGII format, public API, or write path. Rollback is a single-commit revert.

## Architecture audit

- Covered module ownership, dependency direction, canonical MCP types, external wire normalization, detection/import parity, error semantics, and producing-boundary tests.
- Intentionally skipped UI/rendering, FSM, initialization lifecycle, retained background work, and persistence migration layers because this pure loader refactor does not touch them.

## Verification

- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check` — passed.
- `cargo test -p agent_core external_import --lib` — 25 passed, including the two new loader regressions.
- Repository commit hook — scoped `agent_core` Cargo clippy passed.
- `cargo clippy -p agent_core --all-targets -- -D warnings` — the full dependency-inclusive command was blocked by the pre-existing unchanged `crates/orgtrack-core/src/sources/imported_history/window.rs:189` `collapsible_else_if` warning; no warning originated in this diff.
- `git diff --check` — passed.
- No TypeScript or UI files changed, so frontend typecheck and visual evidence are not applicable.