### PR TITLE
refactor(lsp): unify command detection

### DIFF
--- a/src-tauri/crates/lsp/src/command_detection.rs
+++ b/src-tauri/crates/lsp/src/command_detection.rs
@@ -1,0 +1,53 @@
+use std::process::Command;
+
+/// Check whether a command-line tool is available on the system PATH.
+///
+/// Forward PATH explicitly so app startup code that augments the process
+/// environment is reflected consistently across every LSP discovery surface.
+pub fn command_exists(command_name: &str) -> bool {
+    let current_path = std::env::var_os("PATH");
+
+    #[cfg(unix)]
+    let mut command = {
+        let mut command = Command::new("which");
+        command.arg(command_name);
+        command
+    };
+
+    #[cfg(windows)]
+    let mut command = {
+        let mut command = Command::new("where");
+        command.arg(command_name);
+        command
+    };
+
+    if let Some(path) = current_path {
+        command.env("PATH", path);
+    }
+    app_platform::hide_console(&mut command);
+    command
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_a_platform_shell() {
+        #[cfg(unix)]
+        assert!(command_exists("sh"));
+
+        #[cfg(windows)]
+        assert!(command_exists("cmd"));
+    }
+
+    #[test]
+    fn rejects_a_missing_command() {
+        assert!(!command_exists(
+            "orgii-command-detection-test-definitely-missing"
+        ));
+    }
+}

--- a/src-tauri/crates/lsp/src/commands/discovery.rs
+++ b/src-tauri/crates/lsp/src/commands/discovery.rs
@@ -2,8 +2,6 @@
 //!
 //! Tauri commands for detecting installed language servers and lint tools.
 
-use std::process::Command;
-
 use super::cache;
 use crate::lint_tools::LintToolInfo;
 use crate::server_defs::{servers, servers_for_language_id};
@@ -55,31 +53,7 @@ pub const LANGUAGE_DISPLAY_NAMES: &[(&str, &str)] = &[
     ("zig", "Zig"),
 ];
 
-/// Check if a command exists in PATH
-pub fn command_exists(cmd: &str) -> bool {
-    // Explicitly forward PATH so the login-shell-augmented PATH is visible.
-    let current_path = std::env::var("PATH").unwrap_or_default();
-    #[cfg(unix)]
-    {
-        Command::new("which")
-            .arg(cmd)
-            .env("PATH", &current_path)
-            .output()
-            .map(|output| output.status.success())
-            .unwrap_or(false)
-    }
-    #[cfg(windows)]
-    {
-        let mut command = Command::new("where");
-        command.arg(cmd).env("PATH", &current_path);
-        // Suppress console window on Windows.
-        app_platform::hide_console(&mut command);
-        command
-            .output()
-            .map(|output| output.status.success())
-            .unwrap_or(false)
-    }
-}
+pub use crate::command_detection::command_exists;
 
 /// Check if uninstall is supported based on install hint
 fn is_uninstall_supported(install_hint: &str) -> bool {

--- a/src-tauri/crates/lsp/src/commands/package_manager.rs
+++ b/src-tauri/crates/lsp/src/commands/package_manager.rs
@@ -3,7 +3,7 @@
 //! Utilities for detecting installed package managers and extracting
 //! package names from install hints.
 
-use super::discovery::command_exists;
+use crate::command_detection::command_exists;
 
 #[cfg(test)]
 #[path = "tests/package_manager_tests.rs"]

--- a/src-tauri/crates/lsp/src/install_pipeline.rs
+++ b/src-tauri/crates/lsp/src/install_pipeline.rs
@@ -16,7 +16,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use tokio::process::Command;
 
-use super::commands::discovery::command_exists;
+use super::command_detection::command_exists;
 use super::commands::package_manager::detect_package_manager;
 use app_paths::lsp_bin_dir;
 

--- a/src-tauri/crates/lsp/src/lib.rs
+++ b/src-tauri/crates/lsp/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod broadcast;
 pub mod codec;
+mod command_detection;
 pub mod commands;
 pub mod config;
 pub mod eslint;

--- a/src-tauri/crates/lsp/src/lint_tools.rs
+++ b/src-tauri/crates/lsp/src/lint_tools.rs
@@ -5,6 +5,8 @@
 use serde::{Deserialize, Serialize};
 use std::process::Command;
 
+use crate::command_detection::command_exists;
+
 /// Information about a lint tool
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -360,29 +362,6 @@ const LINT_TOOLS: &[LintToolConfig] = &[
         install_hint: "cargo install taplo-cli",
     },
 ];
-
-/// Check if a command exists in PATH
-fn command_exists(cmd: &str) -> bool {
-    #[cfg(unix)]
-    {
-        Command::new("which")
-            .arg(cmd)
-            .output()
-            .map(|output| output.status.success())
-            .unwrap_or(false)
-    }
-    #[cfg(windows)]
-    {
-        let mut command = Command::new("where");
-        command.arg(cmd);
-        // Suppress console window on Windows.
-        app_platform::hide_console(&mut command);
-        command
-            .output()
-            .map(|output| output.status.success())
-            .unwrap_or(false)
-    }
-}
 
 /// Get version of a tool
 fn get_tool_version(config: &LintToolConfig) -> Option<String> {

--- a/src-tauri/crates/lsp/src/workspace_scan/mod.rs
+++ b/src-tauri/crates/lsp/src/workspace_scan/mod.rs
@@ -24,8 +24,9 @@ use std::path::Path;
 
 use types::{AvailableTool, SingleToolResult};
 
+use super::command_detection::command_exists;
 use super::workspace_config::is_lint_tool_enabled;
-use process::{command_exists, eslint_available};
+use process::eslint_available;
 
 // ============================================
 // Helpers for tool detection

--- a/src-tauri/crates/lsp/src/workspace_scan/orchestrator.rs
+++ b/src-tauri/crates/lsp/src/workspace_scan/orchestrator.rs
@@ -21,11 +21,12 @@ use super::clippy;
 use super::css;
 use super::eslint;
 use super::golangci_lint;
-use super::process::{command_exists, eslint_available};
+use super::process::eslint_available;
 use super::python;
 use super::shell;
 use super::types::{AvailableTool, SingleToolResult, WorkspaceDiagnostic};
 use super::typescript;
+use crate::command_detection::command_exists;
 use crate::workspace_config::is_lint_tool_enabled;
 
 // ============================================

--- a/src-tauri/crates/lsp/src/workspace_scan/process.rs
+++ b/src-tauri/crates/lsp/src/workspace_scan/process.rs
@@ -61,34 +61,11 @@ pub fn run_command_with_custom_timeout(
     }
 }
 
-/// Check whether a command-line tool is available on the system PATH.
-pub fn command_exists(cmd: &str) -> bool {
-    #[cfg(unix)]
-    {
-        Command::new("which")
-            .arg(cmd)
-            .output()
-            .map(|output| output.status.success())
-            .unwrap_or(false)
-    }
-    #[cfg(windows)]
-    {
-        let mut command = Command::new("where");
-        command.arg(cmd);
-        // Suppress console window on Windows.
-        app_platform::hide_console(&mut command);
-        command
-            .output()
-            .map(|output| output.status.success())
-            .unwrap_or(false)
-    }
-}
-
 /// Check whether ESLint is available (local node_modules or global).
 pub fn eslint_available(workspace_path: &str) -> bool {
     let local = Path::new(workspace_path)
         .join("node_modules")
         .join(".bin")
         .join("eslint");
-    local.exists() || command_exists("eslint")
+    local.exists() || crate::command_detection::command_exists("eslint")
 }


### PR DESCRIPTION
## Problem

The LSP crate had three independent implementations for checking whether a command exists. One explicitly forwarded the app-adjusted PATH while the lint and workspace-scan copies did not, so installed-tool results could differ by surface and future platform fixes had to be repeated.

## Solution

Introduce one crate-owned command detection helper and route LSP discovery, package-manager selection, install preflight, lint-tool detection, and both workspace scan paths through it. The helper explicitly forwards the current PATH, preserves Windows console suppression, and keeps the existing public `commands::discovery::command_exists` entry point as a re-export for compatibility. Regression tests cover a known platform shell and a guaranteed-missing command.

## Potential risks

Tool availability now consistently uses the explicit-PATH behavior that discovery already used. This could make a previously inconsistent lint surface recognize a tool added to the app process PATH, which is the intended convergence. Command execution count and timing remain unchanged; no cache was added, avoiding stale results after PATH changes. Rollback is a single-commit revert.

## Architecture and performance

- Covered ownership, public API compatibility, platform behavior, dependency direction, scan/install consumers, and test boundaries.
- Intentionally skipped wire types, persistence, FSM, UI/rendering, and initialization parity because they are unchanged.
- Performance verdict: pass/neutral. Foreground and orchestrated scans make the same number of lookup processes as before; no polling, retry loop, timer, subscription, cache, or retained state was added.
- Lifecycle matrix: active scan behavior is unchanged; idle, hidden, closed, and repeated-open states retain no command-detection resources.

## Verification

- `cargo fmt --all -- --check` — passed after formatting.
- `cargo test -p lsp --lib` — 112 passed.
- `cargo clippy -p lsp --all-targets --no-deps -- -D warnings` — passed.
- Repository commit hook — scoped LSP Cargo clippy passed.
- `git diff --check` — passed.
- No TypeScript or UI files changed, so frontend typecheck and visual evidence are not applicable.