### PR TITLE
refactor(spotlight): reuse fuzzy search utilities

### DIFF
--- a/src/scaffold/GlobalSpotlight/palettes/EditorPalette/hooks/useSymbolMode.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/EditorPalette/hooks/useSymbolMode.ts
@@ -28,6 +28,7 @@ import {
   SYMBOL_LABELS,
 } from "@src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/OutlineContent/config";
 import type { SymbolKind } from "@src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/OutlineContent/types";
+import { fuzzyMatch, fuzzyScore } from "@src/util/search/fuzzy";
 
 import type { SpotlightItem } from "../../../shared";
 
@@ -85,70 +86,6 @@ function normalizeSymbolKind(kind: string): SymbolKind {
   return VALID_SYMBOL_KINDS.includes(kind as SymbolKind)
     ? (kind as SymbolKind)
     : "function";
-}
-
-/** Simple fuzzy match - checks if all characters in query appear in name in order */
-function fuzzyMatch(query: string, name: string): boolean {
-  if (!query) return true;
-  const lowerQuery = query.toLowerCase();
-  const lowerName = name.toLowerCase();
-
-  let queryIdx = 0;
-  for (let nameIdx = 0; nameIdx < lowerName.length; nameIdx++) {
-    if (lowerName[nameIdx] === lowerQuery[queryIdx]) {
-      queryIdx++;
-      if (queryIdx === lowerQuery.length) return true;
-    }
-  }
-  return false;
-}
-
-/** Score a fuzzy match - higher is better */
-function fuzzyScore(query: string, name: string): number {
-  if (!query) return 0;
-  const lowerQuery = query.toLowerCase();
-  const lowerName = name.toLowerCase();
-
-  // Exact match gets highest score
-  if (lowerName === lowerQuery) return 1000;
-
-  // Starts with gets high score
-  if (lowerName.startsWith(lowerQuery)) return 500;
-
-  // Contains gets medium score
-  if (lowerName.includes(lowerQuery)) return 200;
-
-  // Fuzzy match scoring based on character positions
-  let score = 0;
-  let queryIdx = 0;
-  let prevMatchIdx = -2;
-
-  for (let nameIdx = 0; nameIdx < lowerName.length; nameIdx++) {
-    if (
-      queryIdx < lowerQuery.length &&
-      lowerName[nameIdx] === lowerQuery[queryIdx]
-    ) {
-      score += 10;
-      // Consecutive matches get bonus
-      if (nameIdx === prevMatchIdx + 1) {
-        score += 5;
-      }
-      // Start-of-word matches get bonus (after _, -, or uppercase boundary)
-      if (
-        nameIdx === 0 ||
-        name[nameIdx - 1] === "_" ||
-        name[nameIdx - 1] === "-" ||
-        (name[nameIdx] === name[nameIdx].toUpperCase() &&
-          name[nameIdx - 1] === name[nameIdx - 1].toLowerCase())
-      ) {
-        score += 3;
-      }
-      prevMatchIdx = nameIdx;
-      queryIdx++;
-    }
-  }
-
-  return score;
 }
 
 // ============================================


### PR DESCRIPTION
## Problem

Editor symbol search carried private copies of the same fuzzy-match and relevance-score algorithms already owned by `src/util/search/fuzzy.ts`. Any scoring change could make symbol results rank differently from other Spotlight and autocomplete surfaces.

## Solution

Delete the private copies and import the canonical `fuzzyMatch` and `fuzzyScore` utilities. The implementations were identical, so filtering, exact/prefix/substring priority, boundary bonuses, and sort order remain unchanged while the algorithm has one owner and one test suite.

## Potential risks

The only risk is an accidental dependency or import-resolution change in the Editor Palette bundle. The shared utility is already used by Chat input surfaces, has no runtime dependencies, and its focused tests plus full typecheck pass. No state, async request, cache, or rendered UI contract changed. Rollback is a single-commit revert.

## Architecture

- Covered algorithm ownership, dependency direction, scoring semantics, search consumer parity, and tests.
- Intentionally skipped UI consistency audit because no TSX/component structure or styling changed. Wire, persistence, FSM, initialization, and background lifecycle layers are also unchanged.
- Effects: none added or modified.
- Performance verdict: neutral; the same functions execute at the same filter/sort call sites with no new allocation, cache, or request.

## Verification

- `pnpm exec vitest run src/util/search/__tests__/fuzzy.test.ts` — 14 passed.
- `pnpm exec eslint src/scaffold/GlobalSpotlight/palettes/EditorPalette/hooks/useSymbolMode.ts` — passed.
- `pnpm typecheck` — full TypeScript check executed and passed.
- `git diff --check` — passed.
- The repository snapshot does not provide `verify:quick` or `verify:final`, so the focused algorithm suite/lint and full typecheck entry point were used.
- No visual evidence: rendered behavior is unchanged.