### PR TITLE
fix(cloud): sweep ghost sessions in orgs outside the push-target set

### DIFF
--- a/src/features/Org2Cloud/org2CloudSessionSync.ts
+++ b/src/features/Org2Cloud/org2CloudSessionSync.ts
@@ -340,6 +340,18 @@ export class Org2CloudSessionSync extends Org2CloudSessionSyncState {
   }
 
   /** Soft-tombstone a prior push and clear every local pushed marker. */
+  /** Live server rows this ACCOUNT owns in the org, regardless of which
+   * device pushed them or whether local push markers survived. */
+  async listSelfOwnedLiveRemoteSessionIds(
+    auth: Org2CloudAuthState,
+    orgId: string
+  ): Promise<string[]> {
+    const result = await this.client.listOrgSessions(auth.accessToken, orgId);
+    return result.sessions
+      .filter((row) => row.ownerUserId === auth.userId && !row.deletedAt)
+      .map((row) => row.sourceSessionId);
+  }
+
   async retractSession(
     auth: Org2CloudAuthState,
     orgId: string,

--- a/src/features/Org2Cloud/org2CloudSyncEngine.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.ts
@@ -742,6 +742,29 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
       if (this.generation !== generation) return;
     }
 
+    // The GC above only covered `targets`, but stale rows outlive that set:
+    // an org the user switched away from (no background upload), whose
+    // scopes are unresolved this run, or that lost its last scope/tag keeps
+    // this device's push-marked ghosts forever — Team Sessions then shows a
+    // duplicate row per context-window continuation. Sweep every org with
+    // local push markers, same rails as the P2 reconcile below.
+    if (options.pushSessions) {
+      const markedOrgIds = orgsWithLocalPushMarkers(
+        store.get(org2CloudPushCursorsAtom),
+        store.get(org2CloudPushedMetadataAtom)
+      );
+      const sweptOrgIds = new Set(targets.map((org) => org.orgId));
+      for (const org of orgs) {
+        if (!markedOrgIds.has(org.orgId)) continue;
+        if (sweptOrgIds.has(org.orgId)) continue;
+        if (enabledByOrg[org.orgId] === false) continue;
+        if (this.generation !== generation) return;
+        if (getCloudEndpoint().supabaseUrl !== passSupabaseUrl) return;
+        await this.retractVanishedSessions(fresh, org.orgId, generation);
+        if (this.generation !== generation) return;
+      }
+    }
+
     // Projects / work items (cloud-parity Phase B), AFTER the session push.
     // Deliberately over ALL orgs, not the session `targets`: shared work
     // items are org-wide (no repo-scope selection), so an org with neither
@@ -984,7 +1007,13 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
           session.continuationLineageId === lineageId &&
           this.sessionSync.hasReplayPushed(orgId, session.session_id)
       );
-      if (!winner) continue;
+      if (!winner) {
+        log.info(
+          `superseded continuation ${sessionId} org ${orgId} kept: no ` +
+            `replay-pushed winner for lineage ${lineageId} on this device yet`
+        );
+        continue;
+      }
       const strikeKey = `${orgId}:${sessionId}`;
       const strikes = (this.supersededStrikes.get(strikeKey) ?? 0) + 1;
       if (strikes < VANISHED_SESSION_RETRACT_CONFIRMATIONS) {

--- a/src/features/Org2Cloud/org2CloudSyncEngine.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.ts
@@ -140,7 +140,9 @@ import { Org2CloudSessionColdStart } from "./org2CloudSyncEngine.sessionColdStar
 import {
   type ContinuationStatusResolver,
   type LocalSessionIdResolver,
+  type SupersededPushedSession,
   findSupersededPushedSessions,
+  findSupersededSelfOwnedRemoteSessions,
   findVanishedPushedSessionIds,
   resolveContinuationStatusesViaCache,
   resolveLocalSessionIdsViaAggregateList,
@@ -210,6 +212,12 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
   private readonly resolveContinuationStatuses: ContinuationStatusResolver;
   /** Per-org timestamp of the last vanished-session GC sweep. */
   private readonly lastVanishedSweepAtMs = new Map<string, number>();
+
+  /** Self-owned live remote session ids per org, captured from the
+   * cold-start listing so the ghost sweep can reuse it instead of paying a
+   * second listing for orgs the push loop already covered. Retracted ids
+   * are removed in place so a stale entry cannot re-suspect forever. */
+  private readonly selfOwnedRemoteIdsByOrg = new Map<string, Set<string>>();
   /** `${orgId}:${sessionId}` → consecutive sweeps confirmed absent. A
    * suspect retracts only at VANISHED_SESSION_RETRACT_CONFIRMATIONS, so one
    * empty lookup during a cache rebuild cannot mass-retract live rows. */
@@ -324,6 +332,7 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
     this.schemaGate.reset();
     this.lastVanishedSweepAtMs.clear();
     this.vanishedStrikes.clear();
+    this.selfOwnedRemoteIdsByOrg.clear();
   }
 
   protected override clearAllOrgBackoffs(): void {
@@ -465,6 +474,12 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
           (gen) => this.generation === gen
         );
       if (remoteSummaries === null) continue;
+      if (remoteSummaries instanceof Map) {
+        this.selfOwnedRemoteIdsByOrg.set(
+          org.orgId,
+          new Set(remoteSummaries.keys())
+        );
+      }
       for (const session of store.get(sessionsAtom)) {
         if (this.generation !== generation) return;
         if (!isCloudPushCandidate(session)) continue;
@@ -963,6 +978,7 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
         );
         await this.sessionSync.retractSession(fresh, orgId, sessionId);
         this.vanishedStrikes.delete(strikeKey);
+        this.selfOwnedRemoteIdsByOrg.get(orgId)?.delete(sessionId);
       } catch (error) {
         if (this.generation !== generation) return;
         if (isCloudSyncBackoffError(error)) {
@@ -992,20 +1008,59 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
       resolveStatuses: this.resolveContinuationStatuses,
     });
     if (this.generation !== generation) return;
-    const supersededNow = new Set(superseded.map((entry) => entry.sessionId));
+    // Marker-free arm: judge the server's own list of this account's rows,
+    // so ghosts survive neither a clobbered marker map nor a same-account
+    // second device. The cold-start listing is reused when the push loop
+    // already fetched it; only never-targeted orgs pay their own listing.
+    // Listing failure = unknown; the arm just sits out.
+    let remoteSelfIds: Set<string> | null =
+      this.selfOwnedRemoteIdsByOrg.get(orgId) ?? null;
+    if (!remoteSelfIds) {
+      try {
+        remoteSelfIds = new Set(
+          await this.sessionSync.listSelfOwnedLiveRemoteSessionIds(fresh, orgId)
+        );
+        this.selfOwnedRemoteIdsByOrg.set(orgId, remoteSelfIds);
+      } catch (error) {
+        if (this.generation !== generation) return;
+        if (isCloudSyncBackoffError(error)) {
+          this.orgBackoff.backOffOrg(orgId, error);
+          return;
+        }
+        log.warn(`self-owned remote listing failed for org ${orgId}:`, error);
+      }
+    }
+    if (this.generation !== generation) return;
+    let remoteSuperseded: SupersededPushedSession[] = [];
+    if (remoteSelfIds) {
+      remoteSuperseded = await findSupersededSelfOwnedRemoteSessions({
+        orgId,
+        remoteSelfSessionIds: [...remoteSelfIds].filter(
+          (sessionId) => !markedSessionIds.has(sessionId)
+        ),
+        liveSessionIds,
+        resolveStatuses: this.resolveContinuationStatuses,
+      });
+      if (this.generation !== generation) return;
+    }
+    const allSuperseded = [...superseded, ...remoteSuperseded];
+    const supersededNow = new Set(
+      allSuperseded.map((entry) => entry.sessionId)
+    );
     for (const key of this.supersededStrikes.keys()) {
       if (!key.startsWith(`${orgId}:`)) continue;
       if (!supersededNow.has(key.slice(orgId.length + 1))) {
         this.supersededStrikes.delete(key);
       }
     }
-    for (const { sessionId, lineageId } of superseded) {
+    for (const { sessionId, lineageId } of allSuperseded) {
       if (this.generation !== generation) return;
       const winner = liveSessions.find(
         (session) =>
           session.session_id !== sessionId &&
           session.continuationLineageId === lineageId &&
-          this.sessionSync.hasReplayPushed(orgId, session.session_id)
+          (this.sessionSync.hasReplayPushed(orgId, session.session_id) ||
+            remoteSelfIds?.has(session.session_id) === true)
       );
       if (!winner) {
         log.info(
@@ -1033,6 +1088,7 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
         );
         await this.sessionSync.retractSession(fresh, orgId, sessionId);
         this.supersededStrikes.delete(strikeKey);
+        this.selfOwnedRemoteIdsByOrg.get(orgId)?.delete(sessionId);
       } catch (error) {
         if (this.generation !== generation) return;
         if (isCloudSyncBackoffError(error)) {
@@ -1061,6 +1117,11 @@ export class Org2CloudSyncEngine extends Org2CloudSyncLifecycle {
     this.sessionColdStart.prune(currentOrgIds);
     for (const orgId of this.lastVanishedSweepAtMs.keys()) {
       if (!currentOrgIds.has(orgId)) this.lastVanishedSweepAtMs.delete(orgId);
+    }
+    for (const orgId of this.selfOwnedRemoteIdsByOrg.keys()) {
+      if (!currentOrgIds.has(orgId)) {
+        this.selfOwnedRemoteIdsByOrg.delete(orgId);
+      }
     }
     for (const key of this.vanishedStrikes.keys()) {
       const orgId = key.slice(0, key.indexOf(":"));

--- a/src/features/Org2Cloud/org2CloudSyncEngine.vanishedSessions.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.vanishedSessions.ts
@@ -127,7 +127,51 @@ export async function findSupersededPushedSessions({
   liveSessionIds: ReadonlySet<string>;
   resolveStatuses: ContinuationStatusResolver;
 }): Promise<SupersededPushedSession[]> {
-  const suspects = [...markedSessionIds].filter(
+  return findSupersededSessions(
+    orgId,
+    [...markedSessionIds],
+    liveSessionIds,
+    resolveStatuses
+  );
+}
+
+/**
+ * Marker-FREE arm of the superseded reconcile. Push markers live in a
+ * whole-map localStorage atom that every build sharing the bundle id
+ * read-modify-writes (a concurrent process can clobber entries), and rows
+ * pushed by the same account's OTHER device never had markers here — either
+ * way the marker-driven arms go blind while the server row lives on. The
+ * server listing is authoritative for "this account's rows in this org", so
+ * self-owned live rows absent from the roster are judged by the same local
+ * continuation election. The caller pre-filters to SELF-OWNED ids: rows
+ * owned by other users must never reach this function.
+ */
+export async function findSupersededSelfOwnedRemoteSessions({
+  orgId,
+  remoteSelfSessionIds,
+  liveSessionIds,
+  resolveStatuses,
+}: {
+  orgId: string;
+  remoteSelfSessionIds: readonly string[];
+  liveSessionIds: ReadonlySet<string>;
+  resolveStatuses: ContinuationStatusResolver;
+}): Promise<SupersededPushedSession[]> {
+  return findSupersededSessions(
+    orgId,
+    remoteSelfSessionIds,
+    liveSessionIds,
+    resolveStatuses
+  );
+}
+
+async function findSupersededSessions(
+  orgId: string,
+  candidateSessionIds: readonly string[],
+  liveSessionIds: ReadonlySet<string>,
+  resolveStatuses: ContinuationStatusResolver
+): Promise<SupersededPushedSession[]> {
+  const suspects = candidateSessionIds.filter(
     (sessionId) => !liveSessionIds.has(sessionId)
   );
   if (suspects.length === 0) return [];

--- a/src/features/Org2Cloud/org2CloudSyncEngine.vanishedSweep.test.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.vanishedSweep.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { RemoteTeammateSessionMetadata } from "@src/store/collaboration/types";
+
 import {
   VANISHED_SESSION_RETRACT_CONFIRMATIONS,
   VANISHED_SESSION_SWEEP_INTERVAL_MS,
@@ -11,6 +13,26 @@ import {
   engineTestDeps,
 } from "./org2CloudSyncEngine.testUtils";
 import type { EngineFixture } from "./org2CloudSyncEngine.testUtils";
+
+function remoteRow(
+  sessionId: string,
+  ownerUserId: string
+): RemoteTeammateSessionMetadata {
+  return {
+    id: sessionId,
+    orgId: "corg-1",
+    ownerMemberId: ownerUserId,
+    ownerUserId,
+    ownerDisplayName: ownerUserId,
+    ownerIdentityKind: "human",
+    sourceSessionId: sessionId,
+    title: sessionId,
+    eventsEpoch: 1,
+    eventsFrozenSeq: 0,
+    eventsCount: 1,
+    eventsTailHash: "hash",
+  };
+}
 
 const {
   Org2CloudSyncEngine,
@@ -222,5 +244,46 @@ describe("superseded-continuation reconcile", () => {
     await runSweepPass();
     const retractedIds = client.deleteSession.mock.calls.map((call) => call[2]);
     expect(retractedIds).not.toContain("old-sib");
+  });
+
+  it("retracts a self-owned remote ghost that has no local marker", async () => {
+    // No durable marker anywhere (a concurrent build clobbered the map, or
+    // the same account's other device pushed the row) — the server listing
+    // is the only witness. The row is self-owned, absent from the roster,
+    // and locally judged superseded; the winner is live on the server too.
+    store.set(org2CloudPushedMetadataAtom, {});
+    client.listOrgSessions.mockResolvedValue({
+      serverTime: "2026-07-01T12:00:00.000Z",
+      sessions: [remoteRow("old-sib", "user-1"), remoteRow("winner", "user-1")],
+    });
+    startSweepEngine();
+
+    await engine.runSyncPass();
+    expect(client.deleteSession).not.toHaveBeenCalled();
+
+    await runSweepPass();
+    expect(client.deleteSession).toHaveBeenCalledTimes(1);
+    expect(client.deleteSession).toHaveBeenCalledWith(
+      "jwt-1",
+      "corg-1",
+      "old-sib"
+    );
+  });
+
+  it("never judges rows owned by someone else", async () => {
+    store.set(org2CloudPushedMetadataAtom, {});
+    client.listOrgSessions.mockResolvedValue({
+      serverTime: "2026-07-01T12:00:00.000Z",
+      sessions: [remoteRow("their-sib", "teammate-9")],
+    });
+    resolveContinuationStatuses.mockResolvedValue([
+      { sessionId: "their-sib", lineageId: "lin-1", superseded: true },
+    ]);
+    startSweepEngine();
+
+    await engine.runSyncPass();
+    await runSweepPass();
+    await runSweepPass();
+    expect(client.deleteSession).not.toHaveBeenCalled();
   });
 });

--- a/src/features/Org2Cloud/org2CloudSyncEngine.vanishedSweep.test.ts
+++ b/src/features/Org2Cloud/org2CloudSyncEngine.vanishedSweep.test.ts
@@ -14,6 +14,7 @@ import type { EngineFixture } from "./org2CloudSyncEngine.testUtils";
 
 const {
   Org2CloudSyncEngine,
+  org2CloudOrgsAtom,
   org2CloudPushCursorsAtom,
   org2CloudPushedMetadataAtom,
   sessionsAtom,
@@ -76,6 +77,32 @@ describe("vanished-session sweep two-strike confirmation", () => {
     // no suspect left to confirm.
     await runSweepPass();
     expect(client.deleteSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("sweeps push-marked orgs that left the push-target set", async () => {
+    // corg-2 is neither the active org nor background-upload enabled, so it
+    // is not a push target — but this device's durable marker says it pushed
+    // ghost-2 there. The sweep must still cover it, or the ghost row (e.g. a
+    // superseded /compact continuation sibling) lingers for every teammate.
+    store.set(org2CloudOrgsAtom, [
+      { orgId: "corg-1", name: "Cloud Team", role: "member" },
+      { orgId: "corg-2", name: "Background Team", role: "member" },
+    ]);
+    store.set(org2CloudPushedMetadataAtom, { "corg-2:ghost-2": true });
+    startSweepEngine();
+
+    await engine.runSyncPass();
+    expect(client.deleteSession).not.toHaveBeenCalled();
+
+    for (let i = 1; i < VANISHED_SESSION_RETRACT_CONFIRMATIONS; i += 1) {
+      await runSweepPass();
+    }
+    expect(client.deleteSession).toHaveBeenCalledTimes(1);
+    expect(client.deleteSession).toHaveBeenCalledWith(
+      "jwt-1",
+      "corg-2",
+      "ghost-2"
+    );
   });
 
   it("restarts confirmation when the suspect resolves between sweeps", async () => {


### PR DESCRIPTION
## Symptom

Team Sessions shows the same conversation multiple times (screenshot: "Open source strategy" ×2, "Open source cursor strategy" ×5 in ORG2 OSS). These are real duplicate `cloud_sessions` rows, one per Claude Code context-window continuation (/compact rotates the session uuid; the external-history importer mints a new `claudecodeapp-<uuid>` per segment — by design, with a continuation election + superseded-row retraction supposed to keep exactly one live row per family).

## Root cause (reproduced, log-proven)

The vanished/superseded-continuation GC (`retractVanishedSessions`, added in d64cda291) runs only inside the push-target loop — active org or background-upload orgs that still hold a scope/tag. An org that drops out of that set keeps every ghost this device push-marked there, forever.

Live specimen: this device's continuation pair in org `34e24e9e` (CU New Target 0720). The same pair in `bfa7b134` (ORG2 OSS, the active org) was correctly retracted at 11:26 with suspect/retract log lines; `34e24e9e` fell out of the target set at 10:56 ("scope check deferred … network identity unresolved") and has zero sweep lines since — parent and child rows both still live on the server.

## Fix

- After the target loop, sweep every org with durable local push markers (`orgsWithLocalPushMarkers`), on the retract-reconcile's rails: sync-enabled, not backed off, TTL-throttled, push passes only.
- Log when a superseded suspect is kept because its lineage winner is not replay-pushed on this device — that skip was silent, making field diagnosis impossible (relevant to the teammate-owned duplicates, which their device must reconcile once on this build).

## Verification

- New regression test: push-marked org outside the target set gets swept and the ghost retracted after the two-strike confirmation — fails on the unfixed engine, passes with the fix.
- tsc clean; Org2Cloud suite 1120/1120; eslint clean.
- Live: instance rebuilt from this branch; the `34e24e9e` ghost is expected to retract within two sweep windows (will confirm on the ledger).

## Not changed (deliberate)

The winner guard still requires a replay-pushed sibling. A metadata-only family can therefore still never converge — flagged separately rather than silently changing the documented tradeoff.