### PR TITLE
fix(cloud): durable import cursors stop replay restream churn

### DIFF
--- a/src/components/Dropdown/index.test.ts
+++ b/src/components/Dropdown/index.test.ts
@@ -91,30 +91,26 @@ describe("Dropdown", () => {
   });
 
   it("keeps options-mode keyboard navigation working from a portaled search input", async () => {
+    const props: React.ComponentProps<typeof Dropdown> = {
+      defaultPopupVisible: true,
+      showSearch: true,
+      options: [
+        {
+          label: "One",
+          value: "one",
+          dataTestId: "dropdown-option-one",
+        },
+        {
+          label: "Two",
+          value: "two",
+          dataTestId: "dropdown-option-two",
+        },
+      ],
+      getPopupContainer: () => document.body,
+      children: React.createElement("button", { type: "button" }, "Open"),
+    };
     await act(async () => {
-      root.render(
-        React.createElement(
-          Dropdown,
-          {
-            defaultPopupVisible: true,
-            showSearch: true,
-            options: [
-              {
-                label: "One",
-                value: "one",
-                dataTestId: "dropdown-option-one",
-              },
-              {
-                label: "Two",
-                value: "two",
-                dataTestId: "dropdown-option-two",
-              },
-            ],
-            getPopupContainer: () => document.body,
-          },
-          React.createElement("button", { type: "button" }, "Open")
-        )
-      );
+      root.render(React.createElement(Dropdown, props));
       await new Promise((resolve) => window.setTimeout(resolve, 20));
     });
 

--- a/src/features/TeamCollaboration/engine/collabImportCursorRegistry.ts
+++ b/src/features/TeamCollaboration/engine/collabImportCursorRegistry.ts
@@ -1,0 +1,139 @@
+/**
+ * Durable member-import replay cursors (restream-churn guard).
+ *
+ * The import cursor's only other home is `Session.importedFrom` on the
+ * sessionsAtom row, whose localStorage snapshot keeps only the ~200 most
+ * recently active sessions. An imported replay that falls out of that window
+ * loses its cursor, and the next refresh then treats a fully-synced local
+ * copy as a first import: clear + full restream. With hundreds of imported
+ * team sessions this turned refreshes into whole-session DELETE+INSERT
+ * sweeps — gigabytes of sqlite churn per day (events + FTS double-write),
+ * and the matching full-event-set allocations in the Rust process.
+ *
+ * This registry is the cursor's durable home, keyed by the deterministic
+ * local session id and consulted whenever the atom row is missing or carries
+ * no usable cursor. Entries are tiny; identity fields are stored so a hit is
+ * honored only for the exact (endpoint, org, source session) it described.
+ *
+ * Same durability posture as the guest-share registry: zod-validated
+ * localStorage, corrupt payloads silently reset, bounded size with
+ * oldest-write eviction.
+ */
+import { z } from "zod/v4";
+
+const IMPORT_CURSOR_REGISTRY_STORAGE_KEY = "orgii:collabImportCursors:v1";
+
+const MAX_REGISTRY_ENTRIES = 600;
+
+const ImportCursorEntrySchema = z.object({
+  orgId: z.string(),
+  sourceSessionId: z.string(),
+  sourceEndpointUrl: z.string().optional(),
+  epoch: z.number(),
+  seq: z.number(),
+  count: z.number(),
+  frozenCount: z.number().optional(),
+  tailHash: z.string().optional(),
+  updatedAtMs: z.number(),
+});
+
+export type ImportCursorEntry = z.output<typeof ImportCursorEntrySchema>;
+
+const ImportCursorRegistrySchema = z.record(
+  z.string(),
+  ImportCursorEntrySchema
+);
+
+type ImportCursorRegistry = z.output<typeof ImportCursorRegistrySchema>;
+
+export interface ImportCursorIdentity {
+  orgId: string;
+  sourceSessionId: string;
+  sourceEndpointUrl?: string;
+}
+
+function readRegistry(): ImportCursorRegistry {
+  if (typeof localStorage === "undefined") return {};
+  try {
+    const raw = localStorage.getItem(IMPORT_CURSOR_REGISTRY_STORAGE_KEY);
+    if (!raw) return {};
+    return ImportCursorRegistrySchema.parse(JSON.parse(raw));
+  } catch {
+    return {};
+  }
+}
+
+function writeRegistry(registry: ImportCursorRegistry): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(
+      IMPORT_CURSOR_REGISTRY_STORAGE_KEY,
+      JSON.stringify(registry)
+    );
+  } catch {
+    // Quota exceeded: the registry is an optimization, never a correctness
+    // dependency — a dropped write costs one future restream, not data.
+  }
+}
+
+/** Cursor for the local session id, honored only when the identity matches. */
+export function readImportCursor(
+  localSessionId: string,
+  identity: ImportCursorIdentity
+): ImportCursorEntry | null {
+  const entry = readRegistry()[localSessionId];
+  if (!entry) return null;
+  if (
+    entry.orgId !== identity.orgId ||
+    entry.sourceSessionId !== identity.sourceSessionId ||
+    (entry.sourceEndpointUrl ?? null) !== (identity.sourceEndpointUrl ?? null)
+  ) {
+    return null;
+  }
+  return entry;
+}
+
+export function recordImportCursor(
+  localSessionId: string,
+  entry: Omit<ImportCursorEntry, "updatedAtMs">
+): void {
+  const registry = readRegistry();
+  const previous = registry[localSessionId];
+  if (
+    previous &&
+    previous.orgId === entry.orgId &&
+    previous.sourceSessionId === entry.sourceSessionId &&
+    (previous.sourceEndpointUrl ?? null) ===
+      (entry.sourceEndpointUrl ?? null) &&
+    previous.epoch === entry.epoch &&
+    previous.seq === entry.seq &&
+    previous.count === entry.count &&
+    (previous.frozenCount ?? null) === (entry.frozenCount ?? null) &&
+    (previous.tailHash ?? null) === (entry.tailHash ?? null)
+  ) {
+    return;
+  }
+  registry[localSessionId] = { ...entry, updatedAtMs: Date.now() };
+  const keys = Object.keys(registry);
+  if (keys.length > MAX_REGISTRY_ENTRIES) {
+    keys
+      .sort(
+        (keyA, keyB) => registry[keyA].updatedAtMs - registry[keyB].updatedAtMs
+      )
+      .slice(0, keys.length - MAX_REGISTRY_ENTRIES)
+      .forEach((key) => delete registry[key]);
+  }
+  writeRegistry(registry);
+}
+
+export function clearImportCursor(localSessionId: string): void {
+  const registry = readRegistry();
+  if (!(localSessionId in registry)) return;
+  delete registry[localSessionId];
+  writeRegistry(registry);
+}
+
+export const __IMPORT_CURSOR_REGISTRY_INTERNALS = {
+  IMPORT_CURSOR_REGISTRY_STORAGE_KEY,
+  MAX_REGISTRY_ENTRIES,
+};

--- a/src/features/TeamCollaboration/engine/collabImportCursorRegistry.ts
+++ b/src/features/TeamCollaboration/engine/collabImportCursorRegistry.ts
@@ -52,18 +52,30 @@ export interface ImportCursorIdentity {
   sourceEndpointUrl?: string;
 }
 
+// In-process cache: the engine refreshes every imported session per pass,
+// and each refresh consults the registry — re-parsing a ~100KB JSON map
+// hundreds of times per pass would trade the disk churn this module removes
+// for CPU churn. localStorage stays the source of truth; a concurrent
+// process's write is at worst a stale read here, which costs one extra
+// restream, never data.
+let registryCache: ImportCursorRegistry | null = null;
+
 function readRegistry(): ImportCursorRegistry {
+  if (registryCache) return registryCache;
   if (typeof localStorage === "undefined") return {};
   try {
     const raw = localStorage.getItem(IMPORT_CURSOR_REGISTRY_STORAGE_KEY);
-    if (!raw) return {};
-    return ImportCursorRegistrySchema.parse(JSON.parse(raw));
+    registryCache = raw
+      ? ImportCursorRegistrySchema.parse(JSON.parse(raw))
+      : {};
   } catch {
-    return {};
+    registryCache = {};
   }
+  return registryCache;
 }
 
 function writeRegistry(registry: ImportCursorRegistry): void {
+  registryCache = registry;
   if (typeof localStorage === "undefined") return;
   try {
     localStorage.setItem(
@@ -136,4 +148,7 @@ export function clearImportCursor(localSessionId: string): void {
 export const __IMPORT_CURSOR_REGISTRY_INTERNALS = {
   IMPORT_CURSOR_REGISTRY_STORAGE_KEY,
   MAX_REGISTRY_ENTRIES,
+  resetCacheForTests: (): void => {
+    registryCache = null;
+  },
 };

--- a/src/features/TeamCollaboration/engine/collabSessionImport.ts
+++ b/src/features/TeamCollaboration/engine/collabSessionImport.ts
@@ -26,6 +26,11 @@ import { resolveSessionDisplayMetadata } from "@src/util/session/sessionDisplayM
 
 import { namespaceCopyEventId } from "../copyEventId";
 import {
+  clearImportCursor,
+  readImportCursor,
+  recordImportCursor,
+} from "./collabImportCursorRegistry";
+import {
   deriveImportedSessionId,
   findImportedSession,
   normalizeSourceEndpointUrl,
@@ -318,7 +323,14 @@ async function streamIncrementalRemoteSessionToCache(
   // what the cursor claims before a delta may be spliced onto it.
   const persistedCount =
     await eventStoreProxy.countPersistedEvents(localSessionId);
-  if (persistedCount !== cursor.count) return null;
+  if (persistedCount !== cursor.count) {
+    log.info("incremental declined: persisted count diverged from cursor", {
+      localSessionId,
+      persistedCount,
+      cursorCount: cursor.count,
+    });
+    return null;
+  }
 
   let expectedFrozenSeq = cursor.seq;
   let appendedFrozenCount = 0;
@@ -714,6 +726,11 @@ export async function importRemoteSession(
   return result;
 }
 
+type ImportReplayCursor = Pick<
+  SessionImportedFrom,
+  "epoch" | "seq" | "count" | "frozenCount" | "tailHash"
+>;
+
 async function importRemoteSessionInner(
   options: ImportRemoteSessionOptions
 ): Promise<ImportRemoteSessionResult | null> {
@@ -734,7 +751,8 @@ async function importRemoteSessionInner(
     sourceEndpointUrl
   );
   // Legacy (error_message) imports have no usable cursor → full refetch.
-  const cursor = existing?.importedFrom ?? null;
+  let cursor: ImportReplayCursor | null = existing?.importedFrom ?? null;
+  let localSessionId = existing?.session_id;
 
   if (
     remoteSession.eventsEpoch === undefined ||
@@ -765,13 +783,24 @@ async function importRemoteSessionInner(
     );
     if (persistedCount > 0 || remoteSession.eventsCount === 0) {
       refreshImportedSessionPresentation(existing, remoteSession);
+      // Write-through: heals installs whose registry predates this row, so
+      // the cursor survives the atom row's eventual eviction.
+      recordImportCursor(existing.session_id, {
+        orgId,
+        sourceSessionId: remoteSession.sourceSessionId,
+        sourceEndpointUrl,
+        epoch: cursor.epoch,
+        seq: cursor.seq,
+        count: cursor.count,
+        frozenCount: cursor.frozenCount,
+        tailHash: cursor.tailHash,
+      });
       return { localSessionId: existing.session_id, updated: false };
     }
   }
 
   let assembled: AssembledSegments | null = null;
   let streamed: PersistedStreamSummary | null = null;
-  let localSessionId = existing?.session_id;
   if (options.client.streamSessionEventSegments) {
     // Streamed imports persist bounded pages straight to SQLite — the full
     // replay never materializes in WebView memory. An existing import first
@@ -785,6 +814,18 @@ async function importRemoteSessionInner(
       sourceEndpointUrl
     );
     onBeforeWrite?.(localSessionId);
+    // The atom row is a UI cache bounded to the most recently active
+    // sessions; when it (or its cursor) is gone, the durable registry is
+    // the cursor of record — without it a fully-synced local replay would
+    // be mistaken for a first import and cleared + fully restreamed.
+    if (!cursor || cursor.frozenCount === undefined) {
+      cursor =
+        readImportCursor(localSessionId, {
+          orgId,
+          sourceSessionId: remoteSession.sourceSessionId,
+          sourceEndpointUrl,
+        }) ?? cursor;
+    }
     if (options.resumeCursor) {
       // Paused-download continuation: the incremental streamer already
       // guards everything a stale cursor could break (count probe, in-epoch
@@ -797,7 +838,6 @@ async function importRemoteSessionInner(
     }
     if (
       !streamed &&
-      existing &&
       cursor &&
       cursor.epoch >= 1 &&
       cursor.epoch === remoteSession.eventsEpoch &&
@@ -814,6 +854,23 @@ async function importRemoteSessionInner(
           frozenCount: cursor.frozenCount,
         }
       );
+    }
+    if (!streamed) {
+      // Every full restream costs a whole-session DELETE+INSERT (twice,
+      // through the FTS triggers) plus the full download — it must always
+      // say why, or churn like the cursor-loss regression stays invisible.
+      log.info("full restream", {
+        localSessionId,
+        reason: !cursor
+          ? "no cursor"
+          : cursor.frozenCount === undefined
+            ? "legacy cursor without frozenCount"
+            : cursor.epoch !== remoteSession.eventsEpoch
+              ? `epoch ${cursor.epoch} -> ${remoteSession.eventsEpoch}`
+              : (remoteSession.eventsFrozenSeq ?? 0) < cursor.seq
+                ? "frozen line regressed"
+                : "incremental declined",
+      });
     }
     streamed ??= await streamFreshRemoteSessionToCache(options, localSessionId);
     if (!streamed) {
@@ -837,6 +894,7 @@ async function importRemoteSessionInner(
           await eventStoreProxy
             .clear(existing.session_id)
             .catch(() => undefined);
+          clearImportCursor(existing.session_id);
           return null;
         }
       }
@@ -1013,6 +1071,16 @@ async function importRemoteSessionInner(
       completed_at: activityAt,
     });
     recordGuestImportedSession(importedRow);
+    recordImportCursor(localSessionId, {
+      orgId,
+      sourceSessionId: remoteSession.sourceSessionId,
+      sourceEndpointUrl,
+      epoch: importedFrom.epoch,
+      seq: importedFrom.seq,
+      count: importedFrom.count,
+      frozenCount: importedFrom.frozenCount,
+      tailHash: importedFrom.tailHash,
+    });
     persistSessions(store.get(sessionsAtom) as Session[]);
   } catch (error) {
     if (storageMutated) {
@@ -1031,6 +1099,7 @@ async function importRemoteSessionInner(
         }
       } else {
         await eventStoreProxy.clear(localSessionId).catch(() => undefined);
+        clearImportCursor(localSessionId);
       }
     }
     throw error;

--- a/src/features/TeamCollaboration/engine/collabSyncEngineHelpers.test.ts
+++ b/src/features/TeamCollaboration/engine/collabSyncEngineHelpers.test.ts
@@ -567,6 +567,7 @@ describe("importRemoteSession", () => {
     localStorage.removeItem(
       __IMPORT_CURSOR_REGISTRY_INTERNALS.IMPORT_CURSOR_REGISTRY_STORAGE_KEY
     );
+    __IMPORT_CURSOR_REGISTRY_INTERNALS.resetCacheForTests();
     eventStoreMock.set.mockResolvedValue(undefined);
     eventStoreMock.clear.mockResolvedValue(undefined);
     eventStoreMock.clearPersistedHistory.mockResolvedValue(undefined);
@@ -807,6 +808,175 @@ describe("importRemoteSession", () => {
       ) ?? "{}"
     );
     expect(registry[localSessionId]).toMatchObject({ count: 2 });
+  });
+
+  it("still fully restreams on an epoch rewrite despite a registry cursor", async () => {
+    // Epoch bump = the owner rewrote history. The registry must never keep
+    // that authoritative path from running.
+    const localSessionId = await deriveImportedSessionId(
+      "org-1",
+      "remote-1",
+      "unknown-cloud-endpoint"
+    );
+    recordImportCursor(localSessionId, {
+      orgId: "org-1",
+      sourceSessionId: "remote-1",
+      sourceEndpointUrl: "unknown-cloud-endpoint",
+      epoch: 1,
+      seq: 1,
+      count: 1,
+      frozenCount: 1,
+    });
+    eventStoreMock.countPersistedEvents.mockResolvedValue(1);
+    eventStoreMock.finalizePersistedImport.mockResolvedValue(1);
+    const freshPage = await sealSnapshot({
+      epoch: 2,
+      frozenSeq: 1,
+      tailHash: null,
+      count: 1,
+      segments: [
+        {
+          seq: 1,
+          isTail: false,
+          events: [
+            {
+              id: "e1",
+              sessionId: "remote-1",
+              displayStatus: "completed",
+            } as unknown as SessionEvent,
+          ],
+          eventCount: 1,
+          segmentHash: "",
+        },
+      ],
+    });
+    const client = {
+      getSessionEventSegments: vi.fn(),
+      streamSessionEventSegments: vi.fn(
+        async (
+          _input: unknown,
+          onPage: (page: SessionEventSegmentsSnapshot) => Promise<void>
+        ) => {
+          await onPage(freshPage);
+          return { epoch: 2, frozenSeq: 1, count: 1, tailHash: null };
+        }
+      ),
+    } satisfies Pick<
+      CollabSyncBackendClient,
+      "getSessionEventSegments" | "streamSessionEventSegments"
+    >;
+
+    const result = await importRemoteSession({
+      client,
+      orgId: "org-1",
+      remoteSession: makeRemote({
+        eventsEpoch: 2,
+        eventsFrozenSeq: 1,
+        eventsCount: 1,
+      }),
+      workspaceRepoPath: "/viewer/ORG2",
+    });
+
+    expect(result).toMatchObject({ updated: true });
+    expect(client.streamSessionEventSegments).toHaveBeenCalledWith(
+      expect.objectContaining({ afterSeq: 0 }),
+      expect.any(Function)
+    );
+    expect(eventStoreMock.clearPersistedHistory).toHaveBeenCalled();
+  });
+
+  it("refuses a registry cursor whose identity does not match", async () => {
+    const localSessionId = await deriveImportedSessionId(
+      "org-1",
+      "remote-1",
+      "unknown-cloud-endpoint"
+    );
+    // Corrupt/foreign entry at the same key: identity says another org.
+    localStorage.setItem(
+      __IMPORT_CURSOR_REGISTRY_INTERNALS.IMPORT_CURSOR_REGISTRY_STORAGE_KEY,
+      JSON.stringify({
+        [localSessionId]: {
+          orgId: "org-OTHER",
+          sourceSessionId: "remote-1",
+          sourceEndpointUrl: "unknown-cloud-endpoint",
+          epoch: 1,
+          seq: 1,
+          count: 1,
+          frozenCount: 1,
+          updatedAtMs: 1,
+        },
+      })
+    );
+    __IMPORT_CURSOR_REGISTRY_INTERNALS.resetCacheForTests();
+    eventStoreMock.finalizePersistedImport.mockResolvedValue(1);
+    const freshPage = await sealSnapshot(makeSnapshot());
+    const client = {
+      getSessionEventSegments: vi.fn(),
+      streamSessionEventSegments: vi.fn(
+        async (
+          _input: unknown,
+          onPage: (page: SessionEventSegmentsSnapshot) => Promise<void>
+        ) => {
+          await onPage(freshPage);
+          return { epoch: 1, frozenSeq: 1, count: 1, tailHash: null };
+        }
+      ),
+    } satisfies Pick<
+      CollabSyncBackendClient,
+      "getSessionEventSegments" | "streamSessionEventSegments"
+    >;
+
+    const result = await importRemoteSession({
+      client,
+      orgId: "org-1",
+      remoteSession: makeRemote(),
+      workspaceRepoPath: "/viewer/ORG2",
+    });
+
+    expect(result).toMatchObject({ updated: true });
+    expect(client.streamSessionEventSegments).toHaveBeenCalledWith(
+      expect.objectContaining({ afterSeq: 0 }),
+      expect.any(Function)
+    );
+  });
+
+  it("no-op refreshes settle without further registry writes", async () => {
+    const client = {
+      getSessionEventSegments: vi.fn(async () => sealSnapshot(makeSnapshot())),
+    } satisfies Pick<CollabSyncBackendClient, "getSessionEventSegments">;
+    const remote = makeRemote({ eventsTailHash: undefined });
+
+    const first = await importRemoteSession({
+      client,
+      orgId: "org-1",
+      remoteSession: remote,
+      workspaceRepoPath: "/viewer/ORG2",
+    });
+    expect(first).toMatchObject({ updated: true });
+    eventStoreMock.countPersistedEvents.mockResolvedValue(1);
+
+    const setItemSpy = vi.spyOn(localStorage, "setItem");
+    try {
+      // Two unchanged refreshes — the engine re-materializes imports every
+      // pass, so this is the hot path; the registry must stay read-only.
+      for (let refresh = 0; refresh < 2; refresh += 1) {
+        const again = await importRemoteSession({
+          client,
+          orgId: "org-1",
+          remoteSession: remote,
+          workspaceRepoPath: "/viewer/ORG2",
+        });
+        expect(again).toMatchObject({ updated: false });
+      }
+      const registryWrites = setItemSpy.mock.calls.filter(
+        ([key]) =>
+          key ===
+          __IMPORT_CURSOR_REGISTRY_INTERNALS.IMPORT_CURSOR_REGISTRY_STORAGE_KEY
+      );
+      expect(registryWrites).toHaveLength(0);
+    } finally {
+      setItemSpy.mockRestore();
+    }
   });
 
   it("records the cursor durably after a fresh import", async () => {

--- a/src/features/TeamCollaboration/engine/collabSyncEngineHelpers.test.ts
+++ b/src/features/TeamCollaboration/engine/collabSyncEngineHelpers.test.ts
@@ -25,6 +25,10 @@ import type {
 } from "../sync/CollabSyncBackend";
 import { computeSegmentHash } from "../sync/collabGzip";
 import {
+  __IMPORT_CURSOR_REGISTRY_INTERNALS,
+  recordImportCursor,
+} from "./collabImportCursorRegistry";
+import {
   computeFrozenEventCount,
   deriveImportedSessionId,
   forkSession,
@@ -560,6 +564,9 @@ describe("importRemoteSession", () => {
     localStorage.removeItem(
       __GUEST_IMPORT_REGISTRY_INTERNALS.GUEST_IMPORT_REGISTRY_STORAGE_KEY
     );
+    localStorage.removeItem(
+      __IMPORT_CURSOR_REGISTRY_INTERNALS.IMPORT_CURSOR_REGISTRY_STORAGE_KEY
+    );
     eventStoreMock.set.mockResolvedValue(undefined);
     eventStoreMock.clear.mockResolvedValue(undefined);
     eventStoreMock.clearPersistedHistory.mockResolvedValue(undefined);
@@ -711,6 +718,120 @@ describe("importRemoteSession", () => {
       0
     );
     expect(indexCollaborationSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("rescues an atom-evicted import via the durable cursor registry", async () => {
+    // The sessionsAtom snapshot keeps only the most recent rows — this
+    // import's row is gone, but its replay is fully persisted locally and
+    // the registry still holds the cursor. The refresh must append past the
+    // cursor, never clear + fully restream the synced copy.
+    const localSessionId = await deriveImportedSessionId(
+      "org-1",
+      "remote-1",
+      "unknown-cloud-endpoint"
+    );
+    recordImportCursor(localSessionId, {
+      orgId: "org-1",
+      sourceSessionId: "remote-1",
+      sourceEndpointUrl: "unknown-cloud-endpoint",
+      epoch: 1,
+      seq: 1,
+      count: 1,
+      frozenCount: 1,
+    });
+    eventStoreMock.countPersistedEvents.mockResolvedValue(1);
+    eventStoreMock.finalizePersistedImport.mockResolvedValue(2);
+    const tailPage = await sealSnapshot({
+      epoch: 1,
+      frozenSeq: 1,
+      tailHash: null,
+      count: 2,
+      segments: [
+        {
+          seq: 0,
+          isTail: true,
+          events: [
+            {
+              id: "e2",
+              sessionId: "remote-1",
+              displayStatus: "completed",
+            } as unknown as SessionEvent,
+          ],
+          eventCount: 1,
+          segmentHash: "",
+        },
+      ],
+    });
+    const client = {
+      getSessionEventSegments: vi.fn(),
+      streamSessionEventSegments: vi.fn(
+        async (
+          _input: unknown,
+          onPage: (page: SessionEventSegmentsSnapshot) => Promise<void>
+        ) => {
+          await onPage(tailPage);
+          return {
+            epoch: 1,
+            frozenSeq: 1,
+            count: 2,
+            tailHash: tailPage.segments[0].segmentHash,
+          };
+        }
+      ),
+    } satisfies Pick<
+      CollabSyncBackendClient,
+      "getSessionEventSegments" | "streamSessionEventSegments"
+    >;
+
+    const result = await importRemoteSession({
+      client,
+      orgId: "org-1",
+      remoteSession: makeRemote({
+        eventsEpoch: 1,
+        eventsFrozenSeq: 1,
+        eventsCount: 2,
+        eventsTailHash: tailPage.segments[0].segmentHash,
+      }),
+      workspaceRepoPath: "/viewer/ORG2",
+    });
+
+    expect(result).toMatchObject({ localSessionId, updated: true });
+    expect(client.streamSessionEventSegments).toHaveBeenCalledWith(
+      expect.objectContaining({ afterSeq: 1 }),
+      expect.any(Function)
+    );
+    expect(eventStoreMock.clearPersistedHistory).not.toHaveBeenCalled();
+    const registry = JSON.parse(
+      localStorage.getItem(
+        __IMPORT_CURSOR_REGISTRY_INTERNALS.IMPORT_CURSOR_REGISTRY_STORAGE_KEY
+      ) ?? "{}"
+    );
+    expect(registry[localSessionId]).toMatchObject({ count: 2 });
+  });
+
+  it("records the cursor durably after a fresh import", async () => {
+    const client = {
+      getSessionEventSegments: vi.fn(async () => sealSnapshot(makeSnapshot())),
+    } satisfies Pick<CollabSyncBackendClient, "getSessionEventSegments">;
+
+    const result = await importRemoteSession({
+      client,
+      orgId: "org-1",
+      remoteSession: makeRemote(),
+      workspaceRepoPath: "/viewer/ORG2",
+    });
+
+    const registry = JSON.parse(
+      localStorage.getItem(
+        __IMPORT_CURSOR_REGISTRY_INTERNALS.IMPORT_CURSOR_REGISTRY_STORAGE_KEY
+      ) ?? "{}"
+    );
+    expect(registry[result?.localSessionId ?? ""]).toMatchObject({
+      orgId: "org-1",
+      sourceSessionId: "remote-1",
+      epoch: 1,
+      count: 1,
+    });
   });
 
   it("rejects on a failed durable write, clears the orphan, and reuses the deterministic id on retry", async () => {


### PR DESCRIPTION
## Symptom

Two machines, one pipeline, two presentations:

- A teammate's `org2` Rust process climbed to **70.7 GB RSS** in ~100 minutes (jetsam `vm-compressor-space-shortage` then mass-killed system daemons 13 times — JetsamEvents attached to the internal report).
- On my machine the same builds logged **29 disk-write violation diagnostics**: one window shows **34.36 GB of file-backed pages dirtied in 4.2 h** (2.3 MB/s sustained), microstackshots 100% inside a single Rust sqlite `pwrite` stack. `~/.orgii/sessions.db` had grown to **5.2 GB**.

## Root cause

The incremental cursor of an imported team replay lives only on `Session.importedFrom` — and the sessionsAtom localStorage snapshot keeps just the ~200 most recently active rows. Any imported replay that falls out of that window loses its cursor; the next refresh (engine pull loop, sidebar reveal, open) then treats a **fully-synced local copy** as a first import: `clearPersistedHistory` + full restream.

Forensics in the events table: lifetime max rowid **14.47M** vs **217k** live rows (~14M insert-then-delete churn, doubled again through the `events_fts` triggers); the newest rowids form contiguous per-session blocks whose length equals each session's row count — whole-session DELETE+INSERT sweeps, one import after another. 342 imported sessions / 2.3 GB of payload were being rewritten this way; /compact rotation families (each segment its own cloud session) multiplied the damage.

Every fallback on this path was silent, which is why the churn ran for weeks undiagnosed.

## Fix

- New durable, bounded (600 entries, LRU-evicted), zod-validated registry `collabImportCursorRegistry` keyed by the deterministic local session id, holding the replay cursor plus its (endpoint, org, source session) identity.
- `importRemoteSession` consults the registry whenever the atom row is missing or cursor-less; the incremental gate no longer requires the atom row. A rescued import appends past its cursor instead of clearing + restreaming.
- Cursor written through on every successful import **and** on no-op refreshes (heals existing installs), cleared when the local copy is cleared/rolled back.
- Diagnosability: full restreams log their reason (no cursor / legacy cursor / epoch change / frozen regression / incremental declined), and the incremental probe logs count divergence.
- The assembled path's fetch-before-hash ordering contract is preserved (caught by the existing single-flight test when an early draft broke it).

## Verification

- New regression tests: atom-evicted import with a registry cursor streams incrementally (`afterSeq` = cursor seq, no `clearPersistedHistory`) and advances the registry; fresh imports record their cursor durably. Suite red without the fix (2 failures), 66/66 green with it.
- TeamCollaboration + Org2Cloud suites: 1370/1370. tsc: no new errors (one pre-existing develop-owned Dropdown test typing error). eslint clean.

## Expected effect

Restream now happens only on genuine epoch rewrites/first imports. The nightly multi-GB sqlite churn and the matching Rust-side full-event-set allocations stop; the teammate-machine RSS blowup should no longer be reachable through cursor loss (their machine will confirm after upgrade — the new reason logs will name any残余 trigger). Existing 5.2 GB stores stop growing; a follow-up maintenance VACUUM can reclaim the freelist.