### PR TITLE
fix(theme): survive OS scheme flips while the display is off

### DIFF
--- a/src/store/settings/settingsSync.ts
+++ b/src/store/settings/settingsSync.ts
@@ -132,9 +132,35 @@ export function useSettingsSync(): void {
           void cover.hide();
         });
     };
+
+    // WKWebView can drop the `prefers-color-scheme` change event entirely, or
+    // deliver it while the display is off and the swap machinery is paused
+    // (App Nap / occlusion). Re-check on every return to visibility so a
+    // scheme flip that happened during sleep always converges — without this,
+    // the app stays on the stale scheme until the user manually toggles the
+    // OS appearance twice.
+    const resyncSystemTheme = () => {
+      if (document.visibilityState === "hidden") return;
+      if (document.documentElement.dataset.theme === getSystemColorScheme()) {
+        return;
+      }
+      // Coverless: this runs at wake, where the mismatch is already visible;
+      // a veil would only add a second visual hiccup.
+      const resolvedThemeId = resolveGlobalThemePreference(themePreference);
+      const selectedTheme = getGlobalTheme(resolvedThemeId);
+      void swapThemeCss(selectedTheme.baseCssPath).then(() => {
+        setSystemColorScheme(getSystemColorScheme());
+      });
+    };
+
     mediaQuery.addEventListener("change", handleSystemThemeChange);
-    return () =>
+    document.addEventListener("visibilitychange", resyncSystemTheme);
+    window.addEventListener("focus", resyncSystemTheme);
+    return () => {
       mediaQuery.removeEventListener("change", handleSystemThemeChange);
+      document.removeEventListener("visibilitychange", resyncSystemTheme);
+      window.removeEventListener("focus", resyncSystemTheme);
+    };
   }, [settingsLoaded, settings, setSystemColorScheme]);
 
   // Sync language to i18next + localStorage after settings load from disk.

--- a/src/util/ui/theme/__tests__/swapThemeCss.test.ts
+++ b/src/util/ui/theme/__tests__/swapThemeCss.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+/**
+ * Regression tests for the "OS switched appearance while the display was off"
+ * bug: WKWebView pauses `requestAnimationFrame` for occluded windows (and can
+ * leave it dead after system sleep), and `swapThemeCss` used to await two rAFs
+ * *after* clearing its safety timeout — so a scheme flip delivered during
+ * sleep stranded the swap forever: old+new stylesheets both attached,
+ * `data-theme` never synced, and the caller's `.finally` (which hides the
+ * transition cover) never ran.
+ *
+ * These tests pin the invariant: the swap promise settles and syncs the
+ * appearance even when no animation frame ever fires.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { swapThemeCss } from "../swapThemeCss";
+
+const THEME_LINK_SELECTOR = "link[data-orgii-theme]";
+
+function insertActiveThemeLink(cssPath: string): HTMLLinkElement {
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.type = "text/css";
+  link.href = cssPath;
+  link.setAttribute("data-orgii-theme", "");
+  document.head.appendChild(link);
+  return link;
+}
+
+function themeLinks(): HTMLLinkElement[] {
+  return Array.from(
+    document.head.querySelectorAll<HTMLLinkElement>(THEME_LINK_SELECTOR)
+  );
+}
+
+function findLink(cssPath: string): HTMLLinkElement {
+  const link = themeLinks().find((candidate) =>
+    candidate.href.endsWith(cssPath)
+  );
+  if (!link) throw new Error(`no theme link for ${cssPath}`);
+  return link;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  document.head.querySelectorAll("link").forEach((link) => link.remove());
+  delete document.documentElement.dataset.theme;
+  delete document.documentElement.dataset.themeId;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("swapThemeCss with animation frames never firing", () => {
+  beforeEach(() => {
+    // Dead rAF: the occluded / post-sleep WKWebView state.
+    vi.stubGlobal("requestAnimationFrame", () => 0);
+  });
+
+  it("promotes the loaded stylesheet and syncs the appearance", async () => {
+    const oldLink = insertActiveThemeLink("/orgii_main.css");
+
+    const swapPromise = swapThemeCss("/orgii_dark.css");
+    findLink("/orgii_dark.css").onload?.(new Event("load"));
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await swapPromise;
+
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(document.documentElement.dataset.themeId).toBe("github-dark");
+    expect(document.documentElement.style.colorScheme).toBe("dark");
+    expect(oldLink.isConnected).toBe(false);
+    expect(themeLinks()).toHaveLength(1);
+  });
+
+  it("settles a fresh-link swap and syncs the appearance", async () => {
+    const swapPromise = swapThemeCss("/orgii_dark.css");
+    findLink("/orgii_dark.css").onload?.(new Event("load"));
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await swapPromise;
+
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(themeLinks()).toHaveLength(1);
+  });
+
+  it("keeps the old theme consistent when the load times out", async () => {
+    const oldLink = insertActiveThemeLink("/orgii_dark.css");
+    document.documentElement.dataset.theme = "dark";
+
+    const swapPromise = swapThemeCss("/orgii_main.css");
+    // Never fire onload: suspended load that misses the swap timeout.
+    await vi.advanceTimersByTimeAsync(5000);
+    await swapPromise;
+
+    expect(oldLink.isConnected).toBe(true);
+    expect(themeLinks()).toHaveLength(1);
+    expect(document.documentElement.dataset.theme).toBe("dark");
+  });
+});
+
+describe("swapThemeCss with working animation frames", () => {
+  it("promotes exactly once when frames and the fallback timer race", async () => {
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      (callback: FrameRequestCallback): number => {
+        callback(0);
+        return 0;
+      }
+    );
+    const oldLink = insertActiveThemeLink("/orgii_main.css");
+
+    const swapPromise = swapThemeCss("/orgii_dark.css");
+    findLink("/orgii_dark.css").onload?.(new Event("load"));
+
+    // Let the (already-raced) fallback timer fire too: it must be a no-op.
+    await vi.advanceTimersByTimeAsync(1000);
+    await swapPromise;
+
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(oldLink.isConnected).toBe(false);
+    expect(themeLinks()).toHaveLength(1);
+  });
+});

--- a/src/util/ui/theme/__tests__/themeTransitionCover.test.ts
+++ b/src/util/ui/theme/__tests__/themeTransitionCover.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+/**
+ * Regression tests for the stuck theme-transition cover: the full-screen
+ * veil shown during a system theme swap used to depend on
+ * `requestAnimationFrame` to fade out, so a scheme flip delivered while the
+ * display was off (rAF paused/dead in WKWebView) left a pointer-blocking,
+ * semi-transparent cover over the whole app until the user manually toggled
+ * the OS appearance twice.
+ *
+ * Invariants pinned here: the cover always dies — with a dead rAF, without
+ * `hide()` ever being called (max-lifetime failsafe), and it is never created
+ * on a hidden document in the first place.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { showThemeTransitionCover } from "../themeTransitionCover";
+
+const COVER_SELECTOR = "[data-orgii-theme-transition-cover]";
+
+function coverElement(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(COVER_SELECTOR);
+}
+
+function setVisibilityState(state: DocumentVisibilityState): void {
+  Object.defineProperty(document, "visibilityState", {
+    value: state,
+    configurable: true,
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  // Dead rAF: the occluded / post-sleep WKWebView state.
+  vi.stubGlobal("requestAnimationFrame", () => 0);
+  setVisibilityState("visible");
+  document.querySelectorAll(COVER_SELECTOR).forEach((node) => node.remove());
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("showThemeTransitionCover", () => {
+  it("hides the cover even when animation frames never fire", async () => {
+    const handle = showThemeTransitionCover();
+    expect(coverElement()).not.toBeNull();
+
+    const hidePromise = handle.hide();
+    await vi.advanceTimersByTimeAsync(2000);
+    await hidePromise;
+
+    expect(coverElement()).toBeNull();
+  });
+
+  it("stops intercepting pointer events as soon as the fade starts", async () => {
+    const handle = showThemeTransitionCover();
+    const wrapper = coverElement();
+    expect(wrapper?.style.pointerEvents).toBe("auto");
+
+    const hidePromise = handle.hide();
+    // Past min-visible + frame fallback, inside the fade window.
+    await vi.advanceTimersByTimeAsync(400);
+    expect(wrapper?.style.pointerEvents).toBe("none");
+
+    await vi.advanceTimersByTimeAsync(2000);
+    await hidePromise;
+  });
+
+  it("self-destructs when hide is never called", async () => {
+    showThemeTransitionCover();
+    expect(coverElement()).not.toBeNull();
+
+    await vi.advanceTimersByTimeAsync(6000);
+
+    expect(coverElement()).toBeNull();
+  });
+
+  it("does not create a cover on a hidden document", async () => {
+    setVisibilityState("hidden");
+
+    const handle = showThemeTransitionCover();
+
+    expect(coverElement()).toBeNull();
+    await expect(handle.hide()).resolves.toBeUndefined();
+  });
+
+  it("adopts an existing cover so a later swap can hide it", async () => {
+    showThemeTransitionCover();
+    const adopted = showThemeTransitionCover();
+
+    expect(document.querySelectorAll(COVER_SELECTOR)).toHaveLength(1);
+
+    const hidePromise = adopted.hide();
+    await vi.advanceTimersByTimeAsync(2000);
+    await hidePromise;
+
+    expect(coverElement()).toBeNull();
+  });
+});

--- a/src/util/ui/theme/swapThemeCss.ts
+++ b/src/util/ui/theme/swapThemeCss.ts
@@ -98,10 +98,27 @@ function cssPathSelector(path: string): string {
   return path.replace(/"/g, '\\"');
 }
 
+/**
+ * WKWebView pauses `requestAnimationFrame` while the window is occluded or
+ * the display is asleep, and can leave it dead after system sleep until the
+ * next repaint. Waiting on frames must therefore never be unbounded: the
+ * timer keeps the swap moving when frames don't come (nobody is looking at
+ * the intermediate paint state in that case anyway).
+ */
+const PAINT_FALLBACK_MS = 250;
+
 function nextPaint(): Promise<void> {
   return new Promise((resolve) => {
+    let done = false;
+    const finish = () => {
+      if (done) return;
+      done = true;
+      clearTimeout(timerId);
+      resolve();
+    };
+    const timerId = setTimeout(finish, PAINT_FALLBACK_MS);
     requestAnimationFrame(() => {
-      requestAnimationFrame(() => resolve());
+      requestAnimationFrame(finish);
     });
   });
 }

--- a/src/util/ui/theme/themeTransitionCover.ts
+++ b/src/util/ui/theme/themeTransitionCover.ts
@@ -2,14 +2,41 @@ const THEME_TRANSITION_COVER_ATTR = "data-orgii-theme-transition-cover";
 const THEME_TRANSITION_FADE_MS = 180;
 const THEME_TRANSITION_MIN_VISIBLE_MS = 120;
 
+/**
+ * Failsafe: the cover blocks pointer events, so it must never be able to
+ * outlive a wedged swap. Must exceed swapThemeCss's SWAP_TIMEOUT_MS plus the
+ * fade windows so it only fires in genuinely stuck states, never during a
+ * legitimately slow swap.
+ */
+const THEME_TRANSITION_MAX_LIFETIME_MS = 6000;
+
 interface ThemeTransitionCoverHandle {
   hide: () => Promise<void>;
 }
 
+const NOOP_HANDLE: ThemeTransitionCoverHandle = {
+  hide: async () => {},
+};
+
+/**
+ * Resolve after two animation frames, or after the fallback timer if frames
+ * never come. WKWebView pauses `requestAnimationFrame` for occluded windows
+ * (and can leave it dead after system sleep), and an OS-initiated theme
+ * switch while the display is off runs exactly in that state — a bare rAF
+ * await here used to strand the cover on screen until the next theme change.
+ */
 function nextFrame(): Promise<void> {
   return new Promise((resolve) => {
+    let done = false;
+    const finish = () => {
+      if (done) return;
+      done = true;
+      clearTimeout(timerId);
+      resolve();
+    };
+    const timerId = setTimeout(finish, THEME_TRANSITION_FADE_MS);
     requestAnimationFrame(() => {
-      requestAnimationFrame(() => resolve());
+      requestAnimationFrame(finish);
     });
   });
 }
@@ -47,6 +74,13 @@ export function showThemeTransitionCover(): ThemeTransitionCoverHandle {
     };
   }
 
+  // Nobody can see a transition on a hidden window, and this is exactly the
+  // state (display off / occluded) where rAF and transitions stall — don't
+  // create a cover that can only get stuck.
+  if (document.visibilityState === "hidden") {
+    return NOOP_HANDLE;
+  }
+
   const shownAt = performance.now();
   const currentBackground = getOpaquePageBackground();
   const wrapper = document.createElement("div");
@@ -67,6 +101,10 @@ export function showThemeTransitionCover(): ThemeTransitionCoverHandle {
 
   document.body.appendChild(wrapper);
 
+  window.setTimeout(() => {
+    wrapper.remove();
+  }, THEME_TRANSITION_MAX_LIFETIME_MS);
+
   return {
     hide: async () => {
       await hideCover(wrapper, shownAt);
@@ -81,6 +119,9 @@ async function hideCover(wrapper: HTMLElement, shownAt: number): Promise<void> {
   }
   await nextFrame();
   wrapper.style.opacity = "0";
+  // Stop intercepting clicks the moment the fade starts: an invisible cover
+  // must not eat input if removal is delayed.
+  wrapper.style.pointerEvents = "none";
   await sleep(THEME_TRANSITION_FADE_MS);
   wrapper.remove();
 }


### PR DESCRIPTION
## Summary

Fixes the washed-out, mixed-light/dark UI with a stuck semi-transparent veil that appears when macOS auto-switches appearance while the display is off — the state users could only escape by manually toggling the OS appearance twice.

## Problem

With theme preference set to *system*, an OS scheme flip during display sleep is delivered to WKWebView while `requestAnimationFrame` is paused (and possibly dead until the next repaint — a long-standing WebKit-after-sleep behavior). Three defects in the live theme-switch path turned that into a persistent broken state:

1. **Swap stranded mid-promotion.** `swapThemeCss`'s `promoteLoadedLink`/`settle` cleared the 4s safety timeout and *then* awaited two rAFs, with no fallback left. The swap promise hung forever: old and new stylesheets both attached, `syncThemeAppearance` never ran (`data-theme`, `data-theme-id`, `color-scheme` stale → every `[data-theme=…]` rule and the native window material disagree with the base CSS), and the caller's `.finally` — which hides the transition cover — never ran.
2. **Cover could outlive everything.** The full-screen transition cover (`pointer-events: auto`, z-index 10050, painted with the old theme's semi-transparent macOS background) also waited on bare rAFs to fade out and had no failsafe. A stranded cover is exactly the milky veil in the user's screenshot, and it also blocked all clicks.
3. **No recovery path.** If WKWebView dropped the `prefers-color-scheme` change entirely (App Nap), nothing ever re-checked the system scheme — the app stayed on the stale theme until the next manual OS toggle.

Manually toggling dark → light healed it because the re-fired handler adopts the existing stuck cover and hides it after a swap that completes normally while the display is on — matching the user's report exactly.

## Solution

- `swapThemeCss`: `nextPaint()` now races its two-frame wait against a 250 ms timer, so promotion — and with it `syncThemeAppearance` and the caller's cover-hide — always runs even when frames never come.
- `themeTransitionCover`: the hide path uses the same frame-or-timer race; the cover stops intercepting pointer events the moment the fade starts; a 6 s max-lifetime failsafe (comfortably above the 4 s swap timeout, so it never fires on a legitimately slow swap) removes it unconditionally; and no cover is created on a hidden document at all — nobody can see a transition there, and it's precisely the state where it can only get stuck.
- `settingsSync`: on `visibilitychange` → visible and window `focus` (system preference only), compare the applied `data-theme` against `matchMedia` and re-run a coverless swap on mismatch. This heals all three mechanisms, including a fully dropped change event. The mismatch gate makes the frequent focus events free in the normal case.

## Potential risks

- The 250 ms paint fallback means a machine that is merely *slow* to produce frames could promote the new stylesheet before the two-frame settle, reintroducing a brief mixed-theme paint during a visible switch. Frames beat the timer whenever the compositor is alive, so this only changes behavior where the old code hung forever.
- The wake resync calls `swapThemeCss` on visibility/focus when the applied and expected schemes disagree; if `data-theme` were ever written by a new code path outside `syncThemeAppearance`, the gate could misjudge. Today `syncThemeAppearance` is the only writer.
- The cover self-destruct removes the veil without a fade if a swap genuinely exceeds ~6 s; the reveal shows the still-active old theme, which beats a permanent pointer-blocking overlay.

## Validation / Test plan

- New regression tests at the producing boundary (`src/util/ui/theme/__tests__/`): with `requestAnimationFrame` stubbed dead, the swap still settles, syncs the appearance exactly once, and removes the old link; the timeout path stays consistent on the old theme; the cover hides with dead rAF, self-destructs when `hide()` is never called, is never created on a hidden document, drops pointer-events at fade start, and a second `showThemeTransitionCover()` adopts and can hide a pre-existing cover (the "manual toggle heals" behavior).
- `npx vitest run src/util/ui/theme/__tests__/` → 14/14 passing; `npm run typecheck` → no errors in touched files (one pre-existing, unrelated error in `src/components/Dropdown/index.test.ts` on develop); eslint clean via lint-staged pre-commit.
- Manual: with preference = system, toggling macOS appearance repeatedly shows the covered transition with no stuck veil; simulated wake-with-stale-theme (editing `data-theme` in devtools, then re-focusing the window) triggers the coverless resync.

Note: the earlier startup-path hardening (`130e3dbb9`, themeInit sync-on-every-resolve) is still unmerged on `fix/windows10-window-chrome` — this PR covers the live-switch path and does not depend on it.