### PR TITLE
fix(memory): bound background job lifecycle

### DIFF
--- a/src-tauri/crates/agent-core/src/core/definitions/commands.rs
+++ b/src-tauri/crates/agent-core/src/core/definitions/commands.rs
@@ -49,6 +49,15 @@ pub async fn agent_definitions_remove(
 ) -> Result<bool, String> {
     let removed = state.remove(&agent_id)?;
     if removed {
+        let cancelled_memory_jobs =
+            crate::memory::background::cancel_memory_jobs_for_agent(&agent_id);
+        if cancelled_memory_jobs > 0 {
+            tracing::info!(
+                agent_id = %agent_id,
+                cancelled_memory_jobs,
+                "[agent_def_remove] cancelled background memory jobs for removed agent"
+            );
+        }
         app_state
             .invalidate_prompt_caches_for_agent_definition(
                 &agent_id,
@@ -277,6 +286,15 @@ pub async fn agent_def_update_patch(
     } else {
         state.update(&agent_id, |def| patch.apply(def))
     }?;
+    let cancelled_memory_jobs =
+        crate::memory::background::cancel_disabled_memory_jobs_for_agent(&agent_id);
+    if cancelled_memory_jobs > 0 {
+        tracing::info!(
+            agent_id = %agent_id,
+            cancelled_memory_jobs,
+            "[agent_def_update] cancelled background memory jobs disabled by hot policy update"
+        );
+    }
     app_state
         .invalidate_prompt_caches_for_agent_definition(
             &agent_id,
@@ -297,6 +315,15 @@ pub async fn agent_def_reset_builtin(
     agent_id: String,
 ) -> Result<AgentDefinition, String> {
     state.reset_builtin(&agent_id)?;
+    let cancelled_memory_jobs =
+        crate::memory::background::cancel_disabled_memory_jobs_for_agent(&agent_id);
+    if cancelled_memory_jobs > 0 {
+        tracing::info!(
+            agent_id = %agent_id,
+            cancelled_memory_jobs,
+            "[agent_def_reset] cancelled background memory jobs disabled by reset policy"
+        );
+    }
     let definition = state
         .get(&agent_id)
         .ok_or_else(|| format!("builtin '{}' missing after reset", agent_id))?;

--- a/src-tauri/crates/agent-core/src/core/model_context/session_memory/compact.rs
+++ b/src-tauri/crates/agent-core/src/core/model_context/session_memory/compact.rs
@@ -2,7 +2,7 @@
 //! SM markdown summary.
 //!
 //! Algorithm:
-//! 1. Start at `last_summarized_msg_idx + 1`
+//! 1. Start at the resolved anchor index + 1
 //! 2. If the tail is already large enough, use it
 //! 3. Otherwise expand backwards until min thresholds are met
 //! 4. Never exceed `max_tokens_to_keep`
@@ -14,7 +14,6 @@ use tracing::info;
 
 use super::config::{SessionMemoryCompactConfig, SessionMemoryConfig};
 use super::sections::truncate_for_compact;
-use super::state::SessionMemoryState;
 use crate::core::model_context::compaction::ContextCompactor;
 
 /// Attempt to compact the conversation using session memory.
@@ -23,21 +22,25 @@ use crate::core::model_context::compaction::ContextCompactor;
 /// SM is not available and the caller should fall through to legacy LLM
 /// compaction.
 ///
-/// **Zero API calls** — the summary is taken directly from `state.content`.
+/// `last_summarized_idx` is the anchor already resolved into `messages`'
+/// own frame (see [`super::resolve_summarized_boundary_idx`]); callers on
+/// different frames (turn tail, freshly loaded history) each resolve the
+/// durable sequence anchor themselves.
+///
+/// **Zero API calls** — the summary is the pre-extracted SM markdown.
 pub fn try_sm_compact(
     messages: &[Value],
-    state: &SessionMemoryState,
+    sm_content: Option<&str>,
+    last_summarized_idx: Option<usize>,
     compact_config: &SessionMemoryCompactConfig,
-    _context_window: usize,
 ) -> Option<Vec<Value>> {
-    let sm_content = state.content.as_ref()?;
+    let sm_content = sm_content?;
 
     if sm_content.trim().is_empty() {
         return None;
     }
 
-    let keep_from =
-        calculate_messages_to_keep_index(messages, state.last_summarized_msg_idx, compact_config);
+    let keep_from = calculate_messages_to_keep_index(messages, last_summarized_idx, compact_config);
 
     if keep_from >= messages.len() {
         return None;

--- a/src-tauri/crates/agent-core/src/core/model_context/session_memory/extract.rs
+++ b/src-tauri/crates/agent-core/src/core/model_context/session_memory/extract.rs
@@ -5,6 +5,7 @@
 //! - [`find_last_safe_boundary`] — picks the highest message index safe to mark
 //!   as the SM boundary (avoids splitting a tool_use → tool_result pair)
 
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use serde_json::Value;
@@ -101,6 +102,7 @@ pub async fn extract_session_memory(
     config: &SessionMemoryConfig,
     provider: &dyn LLMProvider,
     model: &str,
+    cancel_flag: Option<&Arc<AtomicBool>>,
 ) -> Result<String, String> {
     use crate::core::model_context::summarization;
 
@@ -226,7 +228,14 @@ pub async fn extract_session_memory(
         "content": user_content,
     })];
 
-    let result = side_query::side_query(provider, &user_messages, &sq_config, model).await;
+    let result = side_query::side_query_with_options(
+        provider,
+        &user_messages,
+        &sq_config,
+        model,
+        cancel_flag,
+    )
+    .await;
 
     // ── Finalize: brief lock to merge the result back. Concurrent
     // `record_tool_calls` increments that arrived while the LLM was running

--- a/src-tauri/crates/agent-core/src/core/model_context/session_memory/extract.rs
+++ b/src-tauri/crates/agent-core/src/core/model_context/session_memory/extract.rs
@@ -15,9 +15,20 @@ use tracing::{info, warn};
 use super::config::SessionMemoryConfig;
 use super::sections::{analyze_section_sizes, generate_section_reminders};
 use super::state::SessionMemoryState;
-use crate::core::model_context::tokenizer;
 use crate::core::side_query::{self, SideQueryConfig, StructuredOutput};
 use crate::providers::traits::LLMProvider;
+
+/// Resolve a sequence anchor to "index of the last summarized message" in the
+/// frame described by `start_seqs`. `None` when nothing in the frame is at or
+/// below the anchor (or no anchor exists) — callers then treat the whole
+/// frame as unsummarized.
+pub fn resolve_summarized_boundary_idx(
+    anchor_seq: Option<i64>,
+    start_seqs: &[i64],
+) -> Option<usize> {
+    let seq = anchor_seq?;
+    start_seqs.partition_point(|s| *s <= seq).checked_sub(1)
+}
 
 /// SM extraction system prompt — 9-section template.
 const SM_EXTRACTION_SYSTEM_PROMPT: &str = r#"You are a session memory extractor. Your job is to maintain a structured summary of an ongoing conversation between a user and an AI coding assistant.
@@ -96,12 +107,15 @@ pub fn should_extract(
 ///
 /// Makes a single LLM side-call with the SM system prompt, current SM
 /// content, and recent messages. Returns the updated SM markdown.
+#[allow(clippy::too_many_arguments)]
 pub async fn extract_session_memory(
     messages: &[Value],
+    start_seqs: &[i64],
     sm_state: Arc<Mutex<SessionMemoryState>>,
     config: &SessionMemoryConfig,
     provider: &dyn LLMProvider,
     model: &str,
+    current_tokens: usize,
     cancel_flag: Option<&Arc<AtomicBool>>,
 ) -> Result<String, String> {
     use crate::core::model_context::summarization;
@@ -114,8 +128,8 @@ pub async fn extract_session_memory(
         let mut state = sm_state.lock().await;
         state.extraction_in_progress = true;
         let start_idx = state
-            .last_summarized_msg_idx
-            .map(|idx| idx + 1)
+            .last_summarized_seq
+            .map(|seq| start_seqs.partition_point(|s| *s <= seq))
             .unwrap_or(0);
         (
             start_idx,
@@ -258,20 +272,22 @@ pub async fn extract_session_memory(
                 sq_result.content
             };
             state.content = Some(sm_content.clone());
-            state.tokens_at_last_extraction = tokenizer::count_messages_tokens(messages);
+            state.tokens_at_last_extraction = current_tokens;
             state.tool_calls_since_extraction = state
                 .tool_calls_since_extraction
                 .saturating_sub(consumed_tool_calls);
             state.initialized = true;
 
             if let Some(last_safe_idx) = find_last_safe_boundary(messages) {
-                state.last_summarized_msg_idx = Some(last_safe_idx);
+                if let Some(seq) = start_seqs.get(last_safe_idx) {
+                    state.last_summarized_seq = Some(*seq);
+                }
             }
 
             info!(
-                "[session_memory] Extraction complete ({} chars, boundary={})",
+                "[session_memory] Extraction complete ({} chars, boundary_seq={})",
                 sm_content.len(),
-                state.last_summarized_msg_idx.unwrap_or(0),
+                state.last_summarized_seq.unwrap_or(-1),
             );
 
             Ok(sm_content)

--- a/src-tauri/crates/agent-core/src/core/model_context/session_memory/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/model_context/session_memory/mod.rs
@@ -40,5 +40,5 @@ pub use compact::{
     last_turn_has_tool_calls, parse_compact_boundary_content, try_sm_compact, ParsedCompactBoundary,
 };
 pub use config::{SessionMemoryCompactConfig, SessionMemoryConfig};
-pub use extract::{extract_session_memory, should_extract};
+pub use extract::{extract_session_memory, resolve_summarized_boundary_idx, should_extract};
 pub use state::SessionMemoryState;

--- a/src-tauri/crates/agent-core/src/core/model_context/session_memory/state.rs
+++ b/src-tauri/crates/agent-core/src/core/model_context/session_memory/state.rs
@@ -5,9 +5,10 @@
 pub struct SessionMemoryState {
     /// Current SM markdown content (`None` = never extracted).
     pub content: Option<String>,
-    /// Index of the last message that was summarized into SM.
-    /// SM-compact keeps messages after this index.
-    pub last_summarized_msg_idx: Option<usize>,
+    /// Durable start-sequence of the last message summarized into SM.
+    /// Frame-independent: extraction (bounded durable suffix) and SM-compact
+    /// (in-turn tail) each resolve it to an index in their own array.
+    pub last_summarized_seq: Option<i64>,
     /// Total context tokens at the time of the last extraction.
     pub tokens_at_last_extraction: usize,
     /// Tool calls seen since the last extraction.

--- a/src-tauri/crates/agent-core/src/core/model_context/tests/session_memory_tests.rs
+++ b/src-tauri/crates/agent-core/src/core/model_context/tests/session_memory_tests.rs
@@ -2,11 +2,23 @@
 //! message preservation, and API invariant handling.
 
 use crate::model_context::session_memory::{
-    last_turn_has_tool_calls, should_extract, try_sm_compact, SessionMemoryCompactConfig,
-    SessionMemoryConfig, SessionMemoryState,
+    last_turn_has_tool_calls, resolve_summarized_boundary_idx, should_extract, try_sm_compact,
+    SessionMemoryCompactConfig, SessionMemoryConfig, SessionMemoryState,
 };
 use crate::test_support::{assistant_msg, assistant_with_tool_calls, tool_msg, user_msg};
 use serde_json::{json, Value};
+
+/// Test shim: identity start-sequences (seq == index) so the pre-seq test
+/// fixtures keep their meaning while also exercising the anchor resolver.
+fn sm_compact(
+    messages: &[Value],
+    state: &SessionMemoryState,
+    config: &SessionMemoryCompactConfig,
+) -> Option<Vec<Value>> {
+    let start_seqs: Vec<i64> = (0..messages.len() as i64).collect();
+    let anchor_idx = resolve_summarized_boundary_idx(state.last_summarized_seq, &start_seqs);
+    try_sm_compact(messages, state.content.as_deref(), anchor_idx, config)
+}
 
 fn message_text(msg: &Value) -> &str {
     let content = msg.get("content").expect("message content");
@@ -53,7 +65,7 @@ fn compact_config_defaults_match_spec() {
 fn state_default_is_empty() {
     let state = SessionMemoryState::default();
     assert!(state.content.is_none());
-    assert!(state.last_summarized_msg_idx.is_none());
+    assert!(state.last_summarized_seq.is_none());
     assert_eq!(state.tokens_at_last_extraction, 0);
     assert_eq!(state.tool_calls_since_extraction, 0);
     assert!(!state.initialized);
@@ -200,7 +212,7 @@ fn sm_compact_no_content_returns_none() {
     let state = SessionMemoryState::default();
     let config = SessionMemoryCompactConfig::default();
     let messages = vec![user_msg("hello"), assistant_msg("hi")];
-    assert!(try_sm_compact(&messages, &state, &config, 100_000).is_none());
+    assert!(sm_compact(&messages, &state, &config).is_none());
 }
 
 #[test]
@@ -211,7 +223,7 @@ fn sm_compact_empty_content_returns_none() {
     };
     let config = SessionMemoryCompactConfig::default();
     let messages = vec![user_msg("hello"), assistant_msg("hi")];
-    assert!(try_sm_compact(&messages, &state, &config, 100_000).is_none());
+    assert!(sm_compact(&messages, &state, &config).is_none());
 }
 
 #[test]
@@ -224,7 +236,7 @@ fn sm_compact_produces_summary_plus_recent() {
 
     let state = SessionMemoryState {
         content: Some("# Session Summary\n\nWorking on project X".to_string()),
-        last_summarized_msg_idx: Some(20),
+        last_summarized_seq: Some(20),
         ..Default::default()
     };
     let config = SessionMemoryCompactConfig {
@@ -233,7 +245,7 @@ fn sm_compact_produces_summary_plus_recent() {
         max_tokens_to_keep: 5_000,
     };
 
-    let result = try_sm_compact(&messages, &state, &config, 200_000);
+    let result = sm_compact(&messages, &state, &config);
     assert!(result.is_some());
 
     let compacted = result.unwrap();
@@ -271,12 +283,12 @@ fn sm_compact_preserves_tool_pairs() {
 
     let state = SessionMemoryState {
         content: Some("# Summary\n\nDoing things".to_string()),
-        last_summarized_msg_idx: Some(5),
+        last_summarized_seq: Some(5),
         ..Default::default()
     };
     let config = SessionMemoryCompactConfig::default();
 
-    let result = try_sm_compact(&messages, &state, &config, 200_000);
+    let result = sm_compact(&messages, &state, &config);
     if let Some(compacted) = result {
         for (idx, msg) in compacted.iter().enumerate() {
             let role = msg.get("role").and_then(|val| val.as_str()).unwrap_or("");
@@ -312,12 +324,12 @@ fn sm_compact_no_boundary_keeps_from_start() {
 
     let state = SessionMemoryState {
         content: Some("# Summary\n\nStarting work".to_string()),
-        last_summarized_msg_idx: None,
+        last_summarized_seq: None,
         ..Default::default()
     };
     let config = SessionMemoryCompactConfig::default();
 
-    let result = try_sm_compact(&messages, &state, &config, 200_000);
+    let result = sm_compact(&messages, &state, &config);
     if let Some(compacted) = result {
         assert!(
             compacted[0].get("role").and_then(|val| val.as_str()) == Some("user"),
@@ -334,13 +346,13 @@ fn sm_compact_no_boundary_keeps_from_start() {
 fn sm_compact_single_message_expands_to_all() {
     let state = SessionMemoryState {
         content: Some("Summary".to_string()),
-        last_summarized_msg_idx: Some(0),
+        last_summarized_seq: Some(0),
         ..Default::default()
     };
     let config = SessionMemoryCompactConfig::default();
     let messages = vec![user_msg("single")];
 
-    let result = try_sm_compact(&messages, &state, &config, 200_000);
+    let result = sm_compact(&messages, &state, &config);
     // With one tiny message and default min thresholds, backward expansion
     // goes to index 0 — nothing gets dropped, so the result is still valid
     // (summary + all messages).
@@ -357,13 +369,13 @@ fn sm_compact_single_message_expands_to_all() {
 fn sm_compact_boundary_beyond_messages_still_compacts() {
     let state = SessionMemoryState {
         content: Some("Summary of old work".to_string()),
-        last_summarized_msg_idx: Some(100),
+        last_summarized_seq: Some(100),
         ..Default::default()
     };
     let config = SessionMemoryCompactConfig::default();
     let messages = vec![user_msg("a"), assistant_msg("b")];
 
-    let result = try_sm_compact(&messages, &state, &config, 200_000);
+    let result = sm_compact(&messages, &state, &config);
     // Boundary is clamped to messages.len(), so backward expansion keeps
     // all messages. The result has summary + all original messages.
     if let Some(compacted) = &result {
@@ -386,19 +398,19 @@ fn restore_sm_state_from_persisted_data() {
     let mut state = SessionMemoryState::default();
     assert!(!state.initialized);
     assert!(state.content.is_none());
-    assert!(state.last_summarized_msg_idx.is_none());
+    assert!(state.last_summarized_seq.is_none());
 
     // Simulate restoring from PersistedSessionMemoryState
     let persisted_content = Some("## Session Title\nMigration task".to_string());
-    let persisted_idx = Some(42_usize);
+    let persisted_seq = Some(42_i64);
 
     state.content = persisted_content.clone();
-    state.last_summarized_msg_idx = persisted_idx;
+    state.last_summarized_seq = persisted_seq;
     state.initialized = true;
 
     assert!(state.initialized);
     assert_eq!(state.content, persisted_content);
-    assert_eq!(state.last_summarized_msg_idx, Some(42));
+    assert_eq!(state.last_summarized_seq, Some(42));
     // Counters remain zero — they track in-session activity only
     assert_eq!(state.tokens_at_last_extraction, 0);
     assert_eq!(state.tool_calls_since_extraction, 0);
@@ -408,7 +420,7 @@ fn restore_sm_state_from_persisted_data() {
 fn restored_sm_state_enables_sm_compact() {
     let state = SessionMemoryState {
         content: Some("## Current State\nWorking on file X".to_string()),
-        last_summarized_msg_idx: Some(5),
+        last_summarized_seq: Some(5),
         initialized: true,
         ..Default::default()
     };
@@ -423,7 +435,7 @@ fn restored_sm_state_enables_sm_compact() {
         }
     }
 
-    let result = try_sm_compact(&messages, &state, &config, 200_000);
+    let result = sm_compact(&messages, &state, &config);
     assert!(
         result.is_some(),
         "SM-compact should work with restored state"
@@ -653,7 +665,7 @@ fn sm_compact_respects_boundary_floor() {
 
     let state = SessionMemoryState {
         content: Some("Session summary".to_string()),
-        last_summarized_msg_idx: Some(8),
+        last_summarized_seq: Some(8),
         ..Default::default()
     };
 
@@ -663,7 +675,7 @@ fn sm_compact_respects_boundary_floor() {
         max_tokens_to_keep: 999_999,
     };
 
-    let result = try_sm_compact(&messages, &state, &config, 200_000);
+    let result = sm_compact(&messages, &state, &config);
     assert!(result.is_some());
     let compacted = result.unwrap();
 

--- a/src-tauri/crates/agent-core/src/core/session/persistence/messages.rs
+++ b/src-tauri/crates/agent-core/src/core/session/persistence/messages.rs
@@ -381,9 +381,17 @@ pub fn load_llm_history(session_id: &str) -> SqliteResult<Vec<serde_json::Value>
     shared::load_llm_history(SESSION_TABLE_PREFIX, session_id)
 }
 
-/// Load text/tool-only LLM history without hydrating image payloads.
-pub fn load_llm_history_text_only(session_id: &str) -> SqliteResult<Vec<serde_json::Value>> {
+/// Load text/tool-only LLM history without hydrating image payloads, plus
+/// each message's first-row durable sequence for cursor anchoring.
+pub fn load_llm_history_text_only(
+    session_id: &str,
+) -> SqliteResult<(Vec<serde_json::Value>, Vec<i64>)> {
     shared::load_llm_history_text_only(SESSION_TABLE_PREFIX, session_id)
+}
+
+/// First-row durable sequence per visible LLM message, in history order.
+pub fn load_llm_history_start_sequences(session_id: &str) -> SqliteResult<Vec<i64>> {
+    shared::load_llm_history_start_sequences(SESSION_TABLE_PREFIX, session_id)
 }
 
 /// Map "keep the last `tail_len` LLM messages visible" onto a durable
@@ -803,7 +811,7 @@ pub fn save_subagent_transcript(
 /// Persisted session memory state (content + boundary index).
 pub struct PersistedSessionMemoryState {
     pub content: Option<String>,
-    pub last_msg_idx: Option<usize>,
+    pub last_seq: Option<i64>,
 }
 
 // ============================================
@@ -866,31 +874,31 @@ pub fn take_turn_cancelled(session_id: &str) -> bool {
 }
 
 /// Persist session memory state to the `agent_sessions` table.
+///
+/// `last_seq` is the durable start-sequence of the last summarized message —
+/// frame-independent, unlike the array index it replaced, so truncated or
+/// compacted views resolve it to their own coordinates at read time.
 pub fn save_session_memory_state(
     session_id: &str,
     content: &str,
-    last_msg_idx: Option<usize>,
+    last_seq: Option<i64>,
 ) -> SqliteResult<()> {
     with_sessions_writer(|| -> SqliteResult<()> {
         let conn = get_connection()?;
         conn.execute(
-            "UPDATE agent_sessions SET sm_content = ?2, sm_last_msg_idx = ?3 WHERE session_id = ?1",
-            rusqlite::params![session_id, content, last_msg_idx.map(|idx| idx as i64),],
+            "UPDATE agent_sessions SET sm_content = ?2, sm_last_seq = ?3 WHERE session_id = ?1",
+            rusqlite::params![session_id, content, last_seq],
         )?;
         Ok(())
     })
 }
 
 /// Clear persisted session memory state after the durable transcript has been compacted.
-///
-/// A compacted transcript already contains the durable boundary/summary. Keeping an
-/// old bare message index would make the next process start apply that index to a
-/// shorter, rewritten transcript.
 pub fn clear_session_memory_state(session_id: &str) -> SqliteResult<()> {
     with_sessions_writer(|| -> SqliteResult<()> {
         let conn = get_connection()?;
         conn.execute(
-            "UPDATE agent_sessions SET sm_content = NULL, sm_last_msg_idx = NULL WHERE session_id = ?1",
+            "UPDATE agent_sessions SET sm_content = NULL, sm_last_seq = NULL WHERE session_id = ?1",
             [session_id],
         )?;
         Ok(())
@@ -901,22 +909,19 @@ pub fn clear_session_memory_state(session_id: &str) -> SqliteResult<()> {
 pub fn load_session_memory_state(session_id: &str) -> SqliteResult<PersistedSessionMemoryState> {
     let conn = get_connection()?;
     let result = conn.query_row(
-        "SELECT sm_content, sm_last_msg_idx FROM agent_sessions WHERE session_id = ?1",
+        "SELECT sm_content, sm_last_seq FROM agent_sessions WHERE session_id = ?1",
         [session_id],
         |row| {
             let content: Option<String> = row.get(0)?;
-            let last_msg_idx: Option<i64> = row.get(1)?;
-            Ok(PersistedSessionMemoryState {
-                content,
-                last_msg_idx: last_msg_idx.map(|idx| idx as usize),
-            })
+            let last_seq: Option<i64> = row.get(1)?;
+            Ok(PersistedSessionMemoryState { content, last_seq })
         },
     );
     match result {
         Ok(state) => Ok(state),
         Err(rusqlite::Error::QueryReturnedNoRows) => Ok(PersistedSessionMemoryState {
             content: None,
-            last_msg_idx: None,
+            last_seq: None,
         }),
         Err(err) => Err(err),
     }
@@ -953,7 +958,7 @@ mod tests {
         .expect("create session/message tables");
         conn.execute(
             "INSERT OR IGNORE INTO agent_sessions
-             (session_id, session_type, status, created_at, updated_at, sm_content, sm_last_msg_idx)
+             (session_id, session_type, status, created_at, updated_at, sm_content, sm_last_seq)
              VALUES (?1, 'agent', 'running', datetime('now'), datetime('now'), NULL, NULL)",
             [session_id],
         )
@@ -1024,7 +1029,7 @@ mod tests {
 
         let sm_state = load_session_memory_state(session_id).expect("load cleared sm");
         assert!(sm_state.content.is_none());
-        assert!(sm_state.last_msg_idx.is_none());
+        assert!(sm_state.last_seq.is_none());
     }
 
     /// Incident reproduction (2026-06-11 transcript wipe): compaction

--- a/src-tauri/crates/agent-core/src/core/session/persistence/messages.rs
+++ b/src-tauri/crates/agent-core/src/core/session/persistence/messages.rs
@@ -381,6 +381,11 @@ pub fn load_llm_history(session_id: &str) -> SqliteResult<Vec<serde_json::Value>
     shared::load_llm_history(SESSION_TABLE_PREFIX, session_id)
 }
 
+/// Load text/tool-only LLM history without hydrating image payloads.
+pub fn load_llm_history_text_only(session_id: &str) -> SqliteResult<Vec<serde_json::Value>> {
+    shared::load_llm_history_text_only(SESSION_TABLE_PREFIX, session_id)
+}
+
 /// Map "keep the last `tail_len` LLM messages visible" onto a durable
 /// sequence cutoff for [`append_compact_boundary`].
 pub fn compact_cutoff_sequence(session_id: &str, tail_len: usize) -> SqliteResult<i64> {

--- a/src-tauri/crates/agent-core/src/core/session/persistence/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/session/persistence/mod.rs
@@ -45,13 +45,13 @@ pub use sidebar::{
 pub use messages::{
     anchor_at_or_after_created_at, append_compact_boundary, clear_messages,
     clear_session_memory_state, compact_cutoff_sequence,
-    load_agent_org_inbox_transcript_materializations, load_llm_history, load_messages,
-    load_session_memory_state, mark_turn_cancelled, materialize_agent_org_inbox_transcript,
-    message_anchor, message_created_at, save_assistant_msg, save_compact_summary_msg,
-    save_session_memory_state, save_snapshot, save_subagent_transcript, save_tool_call_msg,
-    save_tool_result_msg, save_user_msg, save_user_msg_with_id, seed_session_with_messages,
-    take_turn_cancelled, truncate_messages_from_sequence, update_compact_boundary_token_delta,
-    AgentOrgInboxTranscriptMaterialization, MessageAnchor,
+    load_agent_org_inbox_transcript_materializations, load_llm_history, load_llm_history_text_only,
+    load_messages, load_session_memory_state, mark_turn_cancelled,
+    materialize_agent_org_inbox_transcript, message_anchor, message_created_at, save_assistant_msg,
+    save_compact_summary_msg, save_session_memory_state, save_snapshot, save_subagent_transcript,
+    save_tool_call_msg, save_tool_result_msg, save_user_msg, save_user_msg_with_id,
+    seed_session_with_messages, take_turn_cancelled, truncate_messages_from_sequence,
+    update_compact_boundary_token_delta, AgentOrgInboxTranscriptMaterialization, MessageAnchor,
 };
 
 use rusqlite::{Connection, Result as SqliteResult};

--- a/src-tauri/crates/agent-core/src/core/session/persistence/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/session/persistence/mod.rs
@@ -45,13 +45,14 @@ pub use sidebar::{
 pub use messages::{
     anchor_at_or_after_created_at, append_compact_boundary, clear_messages,
     clear_session_memory_state, compact_cutoff_sequence,
-    load_agent_org_inbox_transcript_materializations, load_llm_history, load_llm_history_text_only,
-    load_messages, load_session_memory_state, mark_turn_cancelled,
-    materialize_agent_org_inbox_transcript, message_anchor, message_created_at, save_assistant_msg,
-    save_compact_summary_msg, save_session_memory_state, save_snapshot, save_subagent_transcript,
-    save_tool_call_msg, save_tool_result_msg, save_user_msg, save_user_msg_with_id,
-    seed_session_with_messages, take_turn_cancelled, truncate_messages_from_sequence,
-    update_compact_boundary_token_delta, AgentOrgInboxTranscriptMaterialization, MessageAnchor,
+    load_agent_org_inbox_transcript_materializations, load_llm_history,
+    load_llm_history_start_sequences, load_llm_history_text_only, load_messages,
+    load_session_memory_state, mark_turn_cancelled, materialize_agent_org_inbox_transcript,
+    message_anchor, message_created_at, save_assistant_msg, save_compact_summary_msg,
+    save_session_memory_state, save_snapshot, save_subagent_transcript, save_tool_call_msg,
+    save_tool_result_msg, save_user_msg, save_user_msg_with_id, seed_session_with_messages,
+    take_turn_cancelled, truncate_messages_from_sequence, update_compact_boundary_token_delta,
+    AgentOrgInboxTranscriptMaterialization, MessageAnchor,
 };
 
 use rusqlite::{Connection, Result as SqliteResult};

--- a/src-tauri/crates/agent-core/src/core/session/turn/post_turn.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/post_turn.rs
@@ -13,6 +13,7 @@ use tokio::sync::Mutex;
 use tracing::info;
 
 use super::super::persistence as unified_persistence;
+use super::streaming::broadcast_agent_warning;
 use crate::config::ReliabilityConfig;
 use crate::memory::background::{
     bridge_cancel_flag, memory_job_is_enabled, submit_memory_job, MemoryJob, MemoryJobKind,
@@ -53,13 +54,24 @@ async fn fresh_fork_provider(spec: &ForkProviderSpec) -> Result<Arc<dyn LLMProvi
     .map_err(|err| format!("Failed to create fork provider: {err}"))
 }
 
-fn load_durable_history(session_id: &str) -> Result<Vec<serde_json::Value>, String> {
-    let messages = unified_persistence::load_llm_history_text_only(session_id)
+fn load_durable_history(session_id: &str) -> Result<(Vec<serde_json::Value>, Vec<i64>), String> {
+    let (messages, start_seqs) = unified_persistence::load_llm_history_text_only(session_id)
         .map_err(|err| format!("Failed to load durable memory transcript: {err}"))?;
     Ok(bound_memory_transcript(
         messages,
+        start_seqs,
         MEMORY_TRANSCRIPT_MAX_BYTES,
     ))
+}
+
+/// SQLite loads are synchronous; keep them off the async runtime threads,
+/// matching every other async caller of the history loaders.
+async fn load_durable_history_blocking(
+    session_id: String,
+) -> Result<(Vec<serde_json::Value>, Vec<i64>), String> {
+    tokio::task::spawn_blocking(move || load_durable_history(&session_id))
+        .await
+        .map_err(|err| format!("history loader worker failed: {err}"))?
 }
 
 fn message_estimated_bytes(message: &serde_json::Value) -> usize {
@@ -70,30 +82,44 @@ fn message_estimated_bytes(message: &serde_json::Value) -> usize {
 /// assistant tool-call row together with all immediately following tool rows.
 /// An oversized newest group is kept intact: structural validity beats a hard
 /// byte cut that would make every provider retry fail.
+///
+/// `start_seqs` is truncated in lockstep so sequence anchors stay aligned
+/// with the surviving suffix.
 fn bound_memory_transcript(
     messages: Vec<serde_json::Value>,
+    start_seqs: Vec<i64>,
     max_bytes: usize,
-) -> Vec<serde_json::Value> {
+) -> (Vec<serde_json::Value>, Vec<i64>) {
     if messages.is_empty() || max_bytes == 0 {
-        return messages;
+        return (messages, start_seqs);
     }
 
-    let mut groups: Vec<Vec<serde_json::Value>> = Vec::new();
+    let mut paired: Vec<(serde_json::Value, i64)> = Vec::with_capacity(messages.len());
+    let mut seqs = start_seqs.into_iter();
     for message in messages {
-        let role = message.get("role").and_then(|value| value.as_str());
+        let seq = seqs.next().unwrap_or(i64::MAX);
+        paired.push((message, seq));
+    }
+
+    let mut groups: Vec<Vec<(serde_json::Value, i64)>> = Vec::new();
+    for entry in paired {
+        let role = entry.0.get("role").and_then(|value| value.as_str());
         if role == Some("tool") {
             if let Some(last) = groups.last_mut() {
-                last.push(message);
+                last.push(entry);
                 continue;
             }
         }
-        groups.push(vec![message]);
+        groups.push(vec![entry]);
     }
 
-    let mut kept: Vec<Vec<serde_json::Value>> = Vec::new();
+    let mut kept: Vec<Vec<(serde_json::Value, i64)>> = Vec::new();
     let mut used = 0usize;
     for group in groups.into_iter().rev() {
-        let group_bytes = group.iter().map(message_estimated_bytes).sum::<usize>();
+        let group_bytes = group
+            .iter()
+            .map(|(message, _)| message_estimated_bytes(message))
+            .sum::<usize>();
         if !kept.is_empty() && used.saturating_add(group_bytes) > max_bytes {
             break;
         }
@@ -101,7 +127,7 @@ fn bound_memory_transcript(
         kept.push(group);
     }
     kept.reverse();
-    kept.into_iter().flatten().collect()
+    kept.into_iter().flatten().unzip()
 }
 
 // ── Session memory extraction (step 9b) ─────────────────────────────
@@ -109,26 +135,27 @@ fn bound_memory_transcript(
 pub(super) struct SessionMemoryExtractionInput<'a> {
     pub session_id: &'a str,
     pub agent_id: Option<String>,
-    pub prompt_tokens: i64,
-    pub tool_calls_count: u32,
+    pub current_tokens: usize,
     pub sm_state: Arc<Mutex<SessionMemoryState>>,
     pub sm_config: SessionMemoryConfig,
     pub fork_provider: ForkProviderSpec,
 }
 
+/// The extraction gate and counter bookkeeping already ran at dispatch
+/// (`post_turn_dispatch` 9b), so the job body only loads, extracts, and
+/// persists. SM is context-pipeline state — no learnings policy check here.
 pub(super) fn spawn_session_memory_extraction(input: SessionMemoryExtractionInput<'_>) {
     let SessionMemoryExtractionInput {
         session_id,
         agent_id,
-        prompt_tokens,
-        tool_calls_count,
+        current_tokens,
         sm_state,
         sm_config,
         fork_provider,
     } = input;
     let sid = session_id.to_string();
     let job_sid = sid.clone();
-    let job_agent_id = agent_id.clone();
+    let cleanup_sid = sid.clone();
     let cleanup_state = Arc::clone(&sm_state);
 
     let job = MemoryJob::new(
@@ -137,31 +164,7 @@ pub(super) fn spawn_session_memory_extraction(input: SessionMemoryExtractionInpu
         MemoryJobKind::SessionMemory,
         SESSION_MEMORY_TIMEOUT,
         move |cancel| async move {
-            if let Some(agent_id) = job_agent_id.as_deref() {
-                if !memory_job_is_enabled(agent_id, MemoryJobKind::SessionMemory) {
-                    return Ok(());
-                }
-            }
-
-            let messages = load_durable_history(&job_sid)?;
-            let current_tokens = if prompt_tokens > 0 {
-                prompt_tokens as usize
-            } else {
-                crate::model_context::tokenizer::count_messages_tokens(&messages)
-            };
-            let has_tool_calls = session_memory::last_turn_has_tool_calls(&messages);
-            {
-                let mut state = sm_state.lock().await;
-                state.record_tool_calls(tool_calls_count as usize);
-                if !session_memory::should_extract(
-                    &state,
-                    &sm_config,
-                    current_tokens,
-                    has_tool_calls,
-                ) {
-                    return Ok(());
-                }
-            }
+            let (messages, start_seqs) = load_durable_history_blocking(job_sid.clone()).await?;
 
             info!(
                 session_id = %job_sid,
@@ -172,22 +175,39 @@ pub(super) fn spawn_session_memory_extraction(input: SessionMemoryExtractionInpu
             let cancel_bridge = bridge_cancel_flag(cancel);
             let result = session_memory::extract_session_memory(
                 &messages,
+                &start_seqs,
                 Arc::clone(&sm_state),
                 &sm_config,
                 provider.as_ref(),
                 &fork_provider.model,
+                current_tokens,
                 Some(cancel_bridge.flag()),
             )
             .await;
 
             let content = result?;
-            let last_idx = sm_state.lock().await.last_summarized_msg_idx;
-            unified_persistence::save_session_memory_state(&job_sid, &content, last_idx)
-                .map_err(|err| format!("Failed to persist session memory state: {err}"))?;
+            let last_seq = sm_state.lock().await.last_summarized_seq;
+            let persist_sid = job_sid.clone();
+            tokio::task::spawn_blocking(move || {
+                unified_persistence::save_session_memory_state(&persist_sid, &content, last_seq)
+            })
+            .await
+            .map_err(|err| format!("SM persist worker failed: {err}"))?
+            .map_err(|err| format!("Failed to persist session memory state: {err}"))?;
             Ok(())
         },
     )
     .with_cleanup(move |outcome| async move {
+        match outcome {
+            MemoryJobOutcome::Completed | MemoryJobOutcome::Cancelled => {}
+            MemoryJobOutcome::Failed | MemoryJobOutcome::TimedOut => {
+                broadcast_agent_warning(
+                    &cleanup_sid,
+                    "Session memory extraction did not complete; it will retry on a later turn",
+                    "session_memory",
+                );
+            }
+        }
         if outcome != MemoryJobOutcome::Completed {
             cleanup_state.lock().await.extraction_in_progress = false;
         }
@@ -232,12 +252,13 @@ pub(super) fn spawn_extract_memories(input: ExtractMemoriesInput<'_>) {
                 }
             }
 
-            let messages = load_durable_history(&job_sid)?;
+            let (messages, start_seqs) = load_durable_history_blocking(job_sid.clone()).await?;
             let main_wrote = {
                 let mut state = em_state.lock().await;
                 extract_memories::skip_if_main_agent_wrote_memory(
                     &mut state,
                     &messages,
+                    &start_seqs,
                     ws_path.as_path(),
                 )
             };
@@ -245,11 +266,14 @@ pub(super) fn spawn_extract_memories(input: ExtractMemoriesInput<'_>) {
                 false
             } else {
                 let state = em_state.lock().await;
-                extract_memories::should_extract(&state, &messages, Some(ws_path.as_path()))
+                extract_memories::should_extract(
+                    &state,
+                    &messages,
+                    &start_seqs,
+                    Some(ws_path.as_path()),
+                )
             };
             if !should_run {
-                let mut state = em_state.lock().await;
-                extract_memories::record_turn(&mut state);
                 return Ok(());
             }
 
@@ -265,8 +289,7 @@ pub(super) fn spawn_extract_memories(input: ExtractMemoriesInput<'_>) {
                 definitions_store: None,
                 cancel_flag: Some(cancel_bridge.flag()),
             };
-            let result = extract_memories::run_extraction(Arc::clone(&em_state), params).await;
-            result
+            extract_memories::run_extraction(Arc::clone(&em_state), params, &start_seqs).await
         },
     )
     .with_cleanup(move |outcome| async move {
@@ -320,7 +343,7 @@ pub(super) fn spawn_auto_dream(input: AutoDreamInput<'_>) {
                 state.mark_scan_now();
             }
 
-            let messages = load_durable_history(&job_sid)?;
+            let (messages, _start_seqs) = load_durable_history_blocking(job_sid.clone()).await?;
             let provider = fresh_fork_provider(&fork_provider).await?;
             let cancel_bridge = bridge_cancel_flag(cancel);
             let params = crate::memory::MemoryAgentParams {
@@ -333,8 +356,7 @@ pub(super) fn spawn_auto_dream(input: AutoDreamInput<'_>) {
                 definitions_store: None,
                 cancel_flag: Some(cancel_bridge.flag()),
             };
-            let result = auto_dream::run_consolidation(params).await;
-            result
+            auto_dream::run_consolidation(params).await
         },
     );
     submit_memory_job(job);
@@ -351,10 +373,11 @@ mod tests {
             serde_json::json!({"role": "assistant", "content": "middle"}),
             serde_json::json!({"role": "user", "content": "new"}),
         ];
-        let bounded = bound_memory_transcript(messages, 100);
+        let (bounded, seqs) = bound_memory_transcript(messages, vec![10, 20, 30], 100);
         assert_eq!(bounded.len(), 2);
         assert_eq!(bounded[0]["content"], "middle");
         assert_eq!(bounded[1]["content"], "new");
+        assert_eq!(seqs, vec![20, 30], "seqs truncate in lockstep");
     }
 
     #[test]
@@ -368,9 +391,10 @@ mod tests {
             }),
             serde_json::json!({"role": "tool", "tool_call_id": "call-1", "content": "result"}),
         ];
-        let bounded = bound_memory_transcript(messages, 1);
+        let (bounded, seqs) = bound_memory_transcript(messages, vec![1, 2, 2], 1);
         assert_eq!(bounded.len(), 2, "newest oversized group stays intact");
         assert_eq!(bounded[0]["role"], "assistant");
         assert_eq!(bounded[1]["role"], "tool");
+        assert_eq!(seqs, vec![2, 2]);
     }
 }

--- a/src-tauri/crates/agent-core/src/core/session/turn/post_turn.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/post_turn.rs
@@ -1,25 +1,23 @@
-//! Post-turn background work.
+//! Post-turn memory/evolution dispatch.
 //!
-//! Fire-and-forget tasks that run after the user has received `agent:complete`:
-//! session-memory extraction, workspace-memory extraction, and auto-dream consolidation.
-//! Each helper is a thin wrapper around a `tokio::spawn` block — kept out of
-//! `processor::process` so the core turn orchestration stays readable.
-//!
-//! All post-turn work is gated by `should_run_post_turn_work` on the caller
-//! side; cancelled turns skip every branch (never do background LLM work for
-//! a turn the user explicitly stopped).
+//! The turn path submits lightweight jobs to the process-wide memory
+//! coordinator. The coordinator owns admission, per-session coalescing,
+//! deadlines and cancellation. Full transcripts are loaded from the canonical
+//! message store only after a job obtains the global memory permit.
 
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use serde_json::Value;
 use tokio::sync::Mutex;
-use tracing::{info, warn};
+use tracing::info;
 
 use super::super::persistence as unified_persistence;
-use super::streaming::broadcast_agent_warning;
 use crate::config::ReliabilityConfig;
+use crate::memory::background::{
+    bridge_cancel_flag, memory_job_is_enabled, submit_memory_job, MemoryJob, MemoryJobKind,
+    MemoryJobOutcome,
+};
 use crate::memory::workspace_memory::auto_dream::{self as auto_dream, AutoDreamState};
 use crate::memory::workspace_memory::extract::{self as extract_memories, ExtractMemoriesState};
 use crate::model_context::session_memory::{self, SessionMemoryConfig, SessionMemoryState};
@@ -27,6 +25,11 @@ use crate::providers::LLMProvider;
 use crate::session::workspace::SessionWorkspace;
 use crate::tools::registry::ToolRegistry;
 use core_types::providers::NativeHarnessType;
+
+const SESSION_MEMORY_TIMEOUT: Duration = Duration::from_secs(60);
+const WORKSPACE_EXTRACTION_TIMEOUT: Duration = Duration::from_secs(180);
+const AUTO_DREAM_TIMEOUT: Duration = Duration::from_secs(300);
+const MEMORY_TRANSCRIPT_MAX_BYTES: usize = 512 * 1024;
 
 #[derive(Clone)]
 pub(super) struct ForkProviderSpec {
@@ -50,12 +53,62 @@ async fn fresh_fork_provider(spec: &ForkProviderSpec) -> Result<Arc<dyn LLMProvi
     .map_err(|err| format!("Failed to create fork provider: {err}"))
 }
 
+fn load_durable_history(session_id: &str) -> Result<Vec<serde_json::Value>, String> {
+    let messages = unified_persistence::load_llm_history_text_only(session_id)
+        .map_err(|err| format!("Failed to load durable memory transcript: {err}"))?;
+    Ok(bound_memory_transcript(
+        messages,
+        MEMORY_TRANSCRIPT_MAX_BYTES,
+    ))
+}
+
+fn message_estimated_bytes(message: &serde_json::Value) -> usize {
+    serde_json::to_vec(message).map_or(0, |encoded| encoded.len())
+}
+
+/// Keep a recent suffix under the memory-job input budget while preserving an
+/// assistant tool-call row together with all immediately following tool rows.
+/// An oversized newest group is kept intact: structural validity beats a hard
+/// byte cut that would make every provider retry fail.
+fn bound_memory_transcript(
+    messages: Vec<serde_json::Value>,
+    max_bytes: usize,
+) -> Vec<serde_json::Value> {
+    if messages.is_empty() || max_bytes == 0 {
+        return messages;
+    }
+
+    let mut groups: Vec<Vec<serde_json::Value>> = Vec::new();
+    for message in messages {
+        let role = message.get("role").and_then(|value| value.as_str());
+        if role == Some("tool") {
+            if let Some(last) = groups.last_mut() {
+                last.push(message);
+                continue;
+            }
+        }
+        groups.push(vec![message]);
+    }
+
+    let mut kept: Vec<Vec<serde_json::Value>> = Vec::new();
+    let mut used = 0usize;
+    for group in groups.into_iter().rev() {
+        let group_bytes = group.iter().map(message_estimated_bytes).sum::<usize>();
+        if !kept.is_empty() && used.saturating_add(group_bytes) > max_bytes {
+            break;
+        }
+        used = used.saturating_add(group_bytes);
+        kept.push(group);
+    }
+    kept.reverse();
+    kept.into_iter().flatten().collect()
+}
+
 // ── Session memory extraction (step 9b) ─────────────────────────────
 
-/// Input bundle for [`spawn_session_memory_extraction`].
 pub(super) struct SessionMemoryExtractionInput<'a> {
     pub session_id: &'a str,
-    pub messages: &'a [Value],
+    pub agent_id: Option<String>,
     pub prompt_tokens: i64,
     pub tool_calls_count: u32,
     pub sm_state: Arc<Mutex<SessionMemoryState>>,
@@ -63,380 +116,261 @@ pub(super) struct SessionMemoryExtractionInput<'a> {
     pub fork_provider: ForkProviderSpec,
 }
 
-/// Spawn the session-memory extractor if `should_extract` returns true.
-///
-/// Runs with a 60s timeout. Persists the result to the SM-state DB on success;
-/// broadcasts `agent:warning` on failure or timeout.
-pub(super) async fn spawn_session_memory_extraction(input: SessionMemoryExtractionInput<'_>) {
+pub(super) fn spawn_session_memory_extraction(input: SessionMemoryExtractionInput<'_>) {
     let SessionMemoryExtractionInput {
         session_id,
-        messages,
+        agent_id,
         prompt_tokens,
         tool_calls_count,
         sm_state,
         sm_config,
         fork_provider,
     } = input;
+    let sid = session_id.to_string();
+    let job_sid = sid.clone();
+    let job_agent_id = agent_id.clone();
+    let cleanup_state = Arc::clone(&sm_state);
 
-    // Everything below — including the `sm_state.lock()` gate pre-check —
-    // runs inside a detached task. This is the turn-completion hot path:
-    // `dispatch_post_turn_work` awaits this fn and the scheduler only emits
-    // the idle queue-status (which hides the "Planning…" footer) AFTER
-    // `process()` returns. The previous version `await`ed the `sm_state.lock()`
-    // pre-check directly here, so when the PRIOR turn's extractor still held
-    // that lock across its (up-to-60s) LLM round-trip, this turn's completion
-    // signal was blocked for the whole extraction. Spawning the entire body
-    // keeps the function a true fire-and-forget so completion is instant.
-    let sm_messages = messages.to_vec();
-    let sm_session_id = session_id.to_string();
+    let job = MemoryJob::new(
+        sid,
+        agent_id,
+        MemoryJobKind::SessionMemory,
+        SESSION_MEMORY_TIMEOUT,
+        move |cancel| async move {
+            if let Some(agent_id) = job_agent_id.as_deref() {
+                if !memory_job_is_enabled(agent_id, MemoryJobKind::SessionMemory) {
+                    return Ok(());
+                }
+            }
 
-    tokio::spawn(async move {
-        let current_tokens = if prompt_tokens > 0 {
-            prompt_tokens as usize
-        } else {
-            crate::model_context::tokenizer::count_messages_tokens(&sm_messages)
-        };
-        let has_tool_calls = session_memory::last_turn_has_tool_calls(&sm_messages);
-        let mut sm_state_guard = sm_state.lock().await;
+            let messages = load_durable_history(&job_sid)?;
+            let current_tokens = if prompt_tokens > 0 {
+                prompt_tokens as usize
+            } else {
+                crate::model_context::tokenizer::count_messages_tokens(&messages)
+            };
+            let has_tool_calls = session_memory::last_turn_has_tool_calls(&messages);
+            {
+                let mut state = sm_state.lock().await;
+                state.record_tool_calls(tool_calls_count as usize);
+                if !session_memory::should_extract(
+                    &state,
+                    &sm_config,
+                    current_tokens,
+                    has_tool_calls,
+                ) {
+                    return Ok(());
+                }
+            }
 
-        sm_state_guard.record_tool_calls(tool_calls_count as usize);
-
-        if !session_memory::should_extract(
-            &sm_state_guard,
-            &sm_config,
-            current_tokens,
-            has_tool_calls,
-        ) {
-            return;
-        }
-
-        info!(
-            "[unified_processor] Spawning async SM extraction for session {} (tokens={}, tc_since={})",
-            sm_session_id, current_tokens, sm_state_guard.tool_calls_since_extraction
-        );
-        drop(sm_state_guard);
-
-        const SM_TIMEOUT: Duration = Duration::from_secs(60);
-
-        let extraction = async {
+            info!(
+                session_id = %job_sid,
+                current_tokens,
+                "[memory_background] starting session-memory extraction"
+            );
             let provider = fresh_fork_provider(&fork_provider).await?;
-            // `extract_session_memory` now manages the `sm_state` lock
-            // internally (brief prepare + finalize, never across the LLM
-            // call), so we pass the Arc instead of holding the guard here.
+            let cancel_bridge = bridge_cancel_flag(cancel);
             let result = session_memory::extract_session_memory(
-                &sm_messages,
-                sm_state.clone(),
+                &messages,
+                Arc::clone(&sm_state),
                 &sm_config,
                 provider.as_ref(),
                 &fork_provider.model,
+                Some(cancel_bridge.flag()),
             )
             .await;
 
-            if let Ok(ref sm_content) = result {
-                let sid = sm_session_id.clone();
-                let content = sm_content.clone();
-                let last_idx = sm_state.lock().await.last_summarized_msg_idx;
-                tokio::task::block_in_place(|| {
-                    if let Err(err) =
-                        unified_persistence::save_session_memory_state(&sid, &content, last_idx)
-                    {
-                        warn!("[sm_extraction] Failed to persist SM state: {}", err);
-                    }
-                });
-            }
-            result
-        };
-
-        match tokio::time::timeout(SM_TIMEOUT, extraction).await {
-            Ok(Ok(_)) => {
-                info!("[sm_extraction] Completed for session {}", sm_session_id);
-            }
-            Ok(Err(err)) => {
-                warn!(
-                    "[sm_extraction] Failed for session {}: {}",
-                    sm_session_id, err
-                );
-                broadcast_agent_warning(
-                    &sm_session_id,
-                    &format!("Session memory extraction failed: {}", err),
-                    "session_memory",
-                );
-            }
-            Err(_elapsed) => {
-                warn!(
-                    "[sm_extraction] Timed out after {}s for session {}",
-                    SM_TIMEOUT.as_secs(),
-                    sm_session_id
-                );
-                broadcast_agent_warning(
-                    &sm_session_id,
-                    &format!(
-                        "Session memory extraction timed out after {}s",
-                        SM_TIMEOUT.as_secs()
-                    ),
-                    "session_memory",
-                );
-            }
+            let content = result?;
+            let last_idx = sm_state.lock().await.last_summarized_msg_idx;
+            unified_persistence::save_session_memory_state(&job_sid, &content, last_idx)
+                .map_err(|err| format!("Failed to persist session memory state: {err}"))?;
+            Ok(())
+        },
+    )
+    .with_cleanup(move |outcome| async move {
+        if outcome != MemoryJobOutcome::Completed {
+            cleanup_state.lock().await.extraction_in_progress = false;
         }
     });
+    submit_memory_job(job);
 }
 
-// ── Extract memories (step 9c) ──────────────────────────────────────
+// ── Workspace-memory extraction (step 9c) ──────────────────────────
 
-/// Input bundle for [`spawn_extract_memories`].
 pub(super) struct ExtractMemoriesInput<'a> {
     pub session_id: &'a str,
+    pub agent_id: Option<String>,
     pub ws_path: PathBuf,
-    pub messages: &'a [Value],
-    pub final_text: Option<&'a str>,
     pub em_state: Arc<Mutex<ExtractMemoriesState>>,
     pub fork_provider: ForkProviderSpec,
     pub tool_registry: Arc<ToolRegistry>,
 }
 
-/// Spawn the workspace-memory extractor agent if the gate conditions pass.
-///
-/// Gate stages:
-/// 1. Skip if the main agent already wrote `memory_*` this turn — its
-///    edits already captured the relevant facts; just advance the cursor
-///    and return.
-/// 2. If `should_extract` says no, stash-on-in-progress so a trailing run
-///    picks up this transcript when the current fork completes. This is
-///    what guarantees we never silently drop a transcript that arrived
-///    while an extraction was already running.
-/// 3. Spawn the fork; the task loops so it drains any pending trailing
-///    transcript after its main extraction finishes, restoring the
-///    "at most one extractor in flight, no transcript left behind"
-///    invariant.
-pub(super) async fn spawn_extract_memories(input: ExtractMemoriesInput<'_>) {
+pub(super) fn spawn_extract_memories(input: ExtractMemoriesInput<'_>) {
     let ExtractMemoriesInput {
         session_id,
+        agent_id,
         ws_path,
-        messages,
-        final_text,
         em_state,
         fork_provider,
         tool_registry,
     } = input;
-
-    // Build synthetic transcript that includes the assistant's final reply.
-    // For text-only turns execute_turn does NOT append the assistant message,
-    // so count_new_messages would under-count and gate us off.
-    let mut em_messages = messages.to_vec();
-    if let Some(text) = final_text {
-        if !text.is_empty() {
-            em_messages.push(serde_json::json!({
-                "role": "assistant",
-                "content": text,
-            }));
-        }
-    }
-    let messages = em_messages;
-
-    // Everything below — including the gate pre-checks that lock `em_state` —
-    // runs inside a detached task. This is the turn-completion hot path:
-    // `dispatch_post_turn_work` awaits this fn, and the scheduler only
-    // broadcasts the idle queue-status (which hides the "Planning…" footer)
-    // AFTER `process()` returns. The previous version `await`ed the
-    // `em_state.lock()` gate pre-checks directly here, so when the PRIOR
-    // turn's extractor still held that lock across its (minutes-long) LLM
-    // round-trip, this turn's completion signal was blocked for the whole
-    // extraction — the footer kept spinning "Figuring out what to do next…"
-    // long after the agent had clearly finished. Spawning the entire body
-    // keeps the function a true fire-and-forget so completion is instant.
     let sid = session_id.to_string();
-    tokio::spawn(async move {
-        run_extract_memories_task(RunExtractMemoriesTask {
-            session_id: sid,
-            ws_path,
-            messages,
-            em_state,
-            fork_provider,
-            tool_registry,
-        })
-        .await;
+    let job_sid = sid.clone();
+    let job_agent_id = agent_id.clone();
+    let cleanup_state = Arc::clone(&em_state);
+
+    let job = MemoryJob::new(
+        sid,
+        agent_id,
+        MemoryJobKind::WorkspaceExtraction,
+        WORKSPACE_EXTRACTION_TIMEOUT,
+        move |cancel| async move {
+            if let Some(agent_id) = job_agent_id.as_deref() {
+                if !memory_job_is_enabled(agent_id, MemoryJobKind::WorkspaceExtraction) {
+                    return Ok(());
+                }
+            }
+
+            let messages = load_durable_history(&job_sid)?;
+            let main_wrote = {
+                let mut state = em_state.lock().await;
+                extract_memories::skip_if_main_agent_wrote_memory(
+                    &mut state,
+                    &messages,
+                    ws_path.as_path(),
+                )
+            };
+            let should_run = if main_wrote {
+                false
+            } else {
+                let state = em_state.lock().await;
+                extract_memories::should_extract(&state, &messages, Some(ws_path.as_path()))
+            };
+            if !should_run {
+                let mut state = em_state.lock().await;
+                extract_memories::record_turn(&mut state);
+                return Ok(());
+            }
+
+            let provider = fresh_fork_provider(&fork_provider).await?;
+            let cancel_bridge = bridge_cancel_flag(cancel);
+            let params = crate::memory::MemoryAgentParams {
+                messages: &messages,
+                provider,
+                model: &fork_provider.model,
+                workspace: &ws_path,
+                parent_tools: tool_registry,
+                session_id: &job_sid,
+                definitions_store: None,
+                cancel_flag: Some(cancel_bridge.flag()),
+            };
+            let result = extract_memories::run_extraction(Arc::clone(&em_state), params).await;
+            result
+        },
+    )
+    .with_cleanup(move |outcome| async move {
+        if outcome != MemoryJobOutcome::Completed {
+            cleanup_state.lock().await.clear_in_progress();
+        }
     });
+    submit_memory_job(job);
 }
 
-struct RunExtractMemoriesTask {
-    session_id: String,
-    ws_path: PathBuf,
-    messages: Vec<Value>,
-    em_state: Arc<Mutex<ExtractMemoriesState>>,
-    fork_provider: ForkProviderSpec,
-    tool_registry: Arc<ToolRegistry>,
-}
+// ── Auto-dream consolidation (step 9d) ─────────────────────────────
 
-/// Owned-data body of [`spawn_extract_memories`], run inside a detached task.
-///
-/// Performs the gate pre-checks (Stages 1–2) and then the extraction loop.
-/// All `em_state` lock contention lives here, off the turn-completion path.
-async fn run_extract_memories_task(task: RunExtractMemoriesTask) {
-    let RunExtractMemoriesTask {
-        session_id,
-        ws_path,
-        messages,
-        em_state,
-        fork_provider,
-        tool_registry,
-    } = task;
-
-    // Stage 1: main agent wrote memory → skip + advance cursor.
-    let main_wrote = {
-        let mut state = em_state.lock().await;
-        extract_memories::skip_if_main_agent_wrote_memory(&mut state, &messages, ws_path.as_path())
-    };
-
-    let should_run = if main_wrote {
-        false
-    } else {
-        let state = em_state.lock().await;
-        extract_memories::should_extract(&state, &messages, Some(ws_path.as_path()))
-    };
-
-    // Stage 2: in_progress blocked us → stash for a trailing run.
-    let stashed_for_trailing = !should_run && !main_wrote && {
-        let state = em_state.lock().await;
-        state.is_in_progress()
-    };
-    if stashed_for_trailing {
-        let mut state = em_state.lock().await;
-        extract_memories::stash_pending(&mut state, &messages);
-        info!(
-            "[extract_memories] Stashed trailing-run context for session {}",
-            session_id
-        );
-    }
-
-    if !should_run {
-        let mut state = em_state.lock().await;
-        extract_memories::record_turn(&mut state);
-        return;
-    }
-
-    let sid = session_id;
-    info!(
-        "[unified_processor] Spawning extract_memories for session {}",
-        sid
-    );
-
-    // Already inside a detached task (see `spawn_extract_memories`); run the
-    // extraction loop inline. Loop until no pending trailing transcript
-    // remains. Each iteration runs the extractor on the current transcript
-    // and, if a new transcript was stashed while we were running, picks it up
-    // on the next pass — guaranteeing every transcript is processed even when
-    // extractions arrive faster than they finish.
-    let mut current_msgs = messages;
-    loop {
-        // `fresh_fork_provider` and `run_extraction` both run WITHOUT holding
-        // `em_state` — provider creation can do a network preflight and the
-        // extractor runs a multi-iteration forked agent, neither of which may
-        // block the next turn's brief `em_state` reads. `run_extraction`
-        // manages the lock internally (brief prepare + finalize).
-        let provider = match fresh_fork_provider(&fork_provider).await {
-            Ok(provider) => provider,
-            Err(err) => {
-                warn!("[extract_memories] Failed for session {}: {}", sid, err);
-                em_state.lock().await.clear_in_progress();
-                break;
-            }
-        };
-        let params = crate::memory::MemoryAgentParams {
-            messages: &current_msgs,
-            provider,
-            model: &fork_provider.model,
-            workspace: &ws_path,
-            parent_tools: tool_registry.clone(),
-            session_id: &sid,
-            definitions_store: None,
-        };
-        if let Err(err) = extract_memories::run_extraction(em_state.clone(), params).await {
-            warn!("[extract_memories] Failed for session {}: {}", sid, err);
-            // Still drain pending to avoid stashed work becoming stuck.
-        }
-        let trailing = {
-            let mut state = em_state.lock().await;
-            extract_memories::take_pending(&mut state)
-        };
-        match trailing {
-            Some(next) => {
-                info!(
-                    "[extract_memories] Running trailing extraction for session {}",
-                    sid
-                );
-                current_msgs = next;
-            }
-            None => break,
-        }
-    }
-}
-
-// ── Auto-dream consolidation (step 9d) ──────────────────────────────
-
-/// Input bundle for [`spawn_auto_dream`].
 pub(super) struct AutoDreamInput<'a> {
     pub session_id: &'a str,
+    pub agent_id: Option<String>,
     pub ws_path: PathBuf,
-    pub messages: Vec<Value>,
     pub ad_state: Arc<Mutex<AutoDreamState>>,
     pub fork_provider: ForkProviderSpec,
     pub tool_registry: Arc<ToolRegistry>,
 }
 
-/// Spawn periodic auto-dream consolidation if the gate says so.
-pub(super) async fn spawn_auto_dream(input: AutoDreamInput<'_>) {
+pub(super) fn spawn_auto_dream(input: AutoDreamInput<'_>) {
     let AutoDreamInput {
         session_id,
+        agent_id,
         ws_path,
-        messages,
         ad_state,
         fork_provider,
         tool_registry,
     } = input;
-
-    // Everything below — including the `ad_state.lock()` gate pre-check —
-    // runs inside a detached task. This is the turn-completion hot path:
-    // `dispatch_post_turn_work` awaits this fn and the scheduler only emits
-    // the idle queue-status (which hides the "Planning…" footer) AFTER
-    // `process()` returns. The previous version `await`ed the `ad_state.lock()`
-    // pre-check directly here, so when the PRIOR turn's consolidation still
-    // held that lock across its (minutes-long) LLM round-trip, this turn's
-    // completion signal was blocked. Spawning the entire body keeps the
-    // function a true fire-and-forget so completion is instant.
     let sid = session_id.to_string();
-    tokio::spawn(async move {
-        // Brief lock ONLY for the throttle gate + advance — never held across
-        // the consolidation LLM call below.
-        {
-            let mut state = ad_state.lock().await;
-            if !auto_dream::should_attempt(&state, &ws_path) {
-                return;
-            }
-            state.mark_scan_now();
-        }
+    let job_sid = sid.clone();
+    let job_agent_id = agent_id.clone();
 
-        info!(
-            "[unified_processor] Spawning auto_dream for session {}",
-            sid
-        );
-
-        let params = crate::memory::MemoryAgentParams {
-            messages: &messages,
-            provider: match fresh_fork_provider(&fork_provider).await {
-                Ok(provider) => provider,
-                Err(err) => {
-                    warn!("[auto_dream] Failed for session {}: {}", sid, err);
-                    return;
+    let job = MemoryJob::new(
+        sid,
+        agent_id,
+        MemoryJobKind::AutoDream,
+        AUTO_DREAM_TIMEOUT,
+        move |cancel| async move {
+            if let Some(agent_id) = job_agent_id.as_deref() {
+                if !memory_job_is_enabled(agent_id, MemoryJobKind::AutoDream) {
+                    return Ok(());
                 }
-            },
-            model: &fork_provider.model,
-            workspace: &ws_path,
-            parent_tools: tool_registry,
-            session_id: &sid,
-            definitions_store: None,
-        };
-        if let Err(err) = auto_dream::run_consolidation(params).await {
-            warn!("[auto_dream] Failed for session {}: {}", sid, err);
-        }
-    });
+            }
+            {
+                let mut state = ad_state.lock().await;
+                if !auto_dream::should_attempt(&state, &ws_path) {
+                    return Ok(());
+                }
+                state.mark_scan_now();
+            }
+
+            let messages = load_durable_history(&job_sid)?;
+            let provider = fresh_fork_provider(&fork_provider).await?;
+            let cancel_bridge = bridge_cancel_flag(cancel);
+            let params = crate::memory::MemoryAgentParams {
+                messages: &messages,
+                provider,
+                model: &fork_provider.model,
+                workspace: &ws_path,
+                parent_tools: tool_registry,
+                session_id: &job_sid,
+                definitions_store: None,
+                cancel_flag: Some(cancel_bridge.flag()),
+            };
+            let result = auto_dream::run_consolidation(params).await;
+            result
+        },
+    );
+    submit_memory_job(job);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transcript_budget_keeps_recent_suffix() {
+        let messages = vec![
+            serde_json::json!({"role": "user", "content": "old".repeat(100)}),
+            serde_json::json!({"role": "assistant", "content": "middle"}),
+            serde_json::json!({"role": "user", "content": "new"}),
+        ];
+        let bounded = bound_memory_transcript(messages, 100);
+        assert_eq!(bounded.len(), 2);
+        assert_eq!(bounded[0]["content"], "middle");
+        assert_eq!(bounded[1]["content"], "new");
+    }
+
+    #[test]
+    fn transcript_budget_never_splits_tool_group() {
+        let messages = vec![
+            serde_json::json!({"role": "user", "content": "old".repeat(100)}),
+            serde_json::json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{"id": "call-1", "type": "function", "function": {"name": "read_file", "arguments": "{}"}}]
+            }),
+            serde_json::json!({"role": "tool", "tool_call_id": "call-1", "content": "result"}),
+        ];
+        let bounded = bound_memory_transcript(messages, 1);
+        assert_eq!(bounded.len(), 2, "newest oversized group stays intact");
+        assert_eq!(bounded[0]["role"], "assistant");
+        assert_eq!(bounded[1]["role"], "tool");
+    }
 }

--- a/src-tauri/crates/agent-core/src/core/session/turn/post_turn.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/post_turn.rs
@@ -3,7 +3,10 @@
 //! The turn path submits lightweight jobs to the process-wide memory
 //! coordinator. The coordinator owns admission, per-session coalescing,
 //! deadlines and cancellation. Full transcripts are loaded from the canonical
-//! message store only after a job obtains the global memory permit.
+//! message store only once a job actually runs: session-memory extraction
+//! starts right after its turn (context-pipeline work, never queued behind
+//! evolution jobs), while the heavy forked agents wait for the bounded
+//! global memory permit.
 
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/src-tauri/crates/agent-core/src/core/session/turn/processor/compaction.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/processor/compaction.rs
@@ -62,15 +62,19 @@ fn append_compacted_tail(prefix: &[Value], tail: Vec<Value>) -> Vec<Value> {
     rebuilt
 }
 
-fn adjust_sm_state_for_compactable_tail(
-    state: &SessionMemoryState,
-    prefix_len: usize,
-) -> SessionMemoryState {
-    let mut adjusted = state.clone();
-    adjusted.last_summarized_msg_idx = state
-        .last_summarized_msg_idx
-        .and_then(|idx| idx.checked_sub(prefix_len));
-    adjusted
+/// Resolve the persisted sequence anchor into an index of the current
+/// compactable tail. The tail's leading region mirrors the durable visible
+/// history (same reconstruct rules, same boundary), so an index resolved
+/// against the durable start-sequences is valid for slicing the tail. This
+/// replaced the old `prefix_len`/`checked_sub(1)` frame-shift arithmetic —
+/// sequences do not move when a frame gains a prefix or loses a suffix.
+fn resolve_sm_anchor_idx(session_id: &str, sm_state: &SessionMemoryState) -> Option<usize> {
+    sm_state.content.as_ref()?;
+    let start_seqs = tokio::task::block_in_place(|| {
+        unified_persistence::load_llm_history_start_sequences(session_id)
+    })
+    .unwrap_or_default();
+    session_memory::resolve_summarized_boundary_idx(sm_state.last_summarized_seq, &start_seqs)
 }
 
 /// Outcome of [`UnifiedMessageProcessor::run_pre_turn_compaction`].
@@ -219,12 +223,12 @@ impl UnifiedMessageProcessor {
         let sm_compacted = {
             let sm_state = self.sm_state.lock().await;
             if self.sm_config.enabled {
-                let adjusted_sm_state = adjust_sm_state_for_compactable_tail(&sm_state, prefix_len);
+                let anchor_idx = resolve_sm_anchor_idx(session_id, &sm_state);
                 session_memory::try_sm_compact(
                     &compactable_tail,
-                    &adjusted_sm_state,
+                    sm_state.content.as_deref(),
+                    anchor_idx,
                     &self.sm_compact_config,
-                    context_window,
                 )
             } else {
                 None
@@ -266,7 +270,7 @@ impl UnifiedMessageProcessor {
                 };
             }
             let mut sm_state = self.sm_state.lock().await;
-            sm_state.last_summarized_msg_idx = None;
+            sm_state.last_summarized_seq = None;
         } else {
             // No fork-form here (unlike pre-turn): reactive compaction runs
             // right after the provider REJECTED this exact prefix as too
@@ -280,7 +284,7 @@ impl UnifiedMessageProcessor {
             *messages = append_compacted_tail(&prefix, cleaned);
             outcome = llm_outcome;
             let mut sm_state = self.sm_state.lock().await;
-            sm_state.last_summarized_msg_idx = None;
+            sm_state.last_summarized_seq = None;
         }
 
         crate::model_context::file_reinjection::reinject_files_after_compaction(
@@ -420,12 +424,12 @@ impl UnifiedMessageProcessor {
         let sm_compacted = {
             let sm_state = self.sm_state.lock().await;
             if self.sm_config.enabled {
-                let adjusted_sm_state = adjust_sm_state_for_compactable_tail(&sm_state, prefix_len);
+                let anchor_idx = resolve_sm_anchor_idx(session_id, &sm_state);
                 session_memory::try_sm_compact(
                     &compactable_tail,
-                    &adjusted_sm_state,
+                    sm_state.content.as_deref(),
+                    anchor_idx,
                     &self.sm_compact_config,
-                    context_window,
                 )
             } else {
                 None
@@ -463,7 +467,7 @@ impl UnifiedMessageProcessor {
                 need_llm_compact = false;
 
                 let mut sm_state = self.sm_state.lock().await;
-                sm_state.last_summarized_msg_idx = None;
+                sm_state.last_summarized_seq = None;
             }
         }
 
@@ -528,7 +532,7 @@ impl UnifiedMessageProcessor {
             *messages = append_compacted_tail(&prefix, cleaned_tail);
 
             let mut sm_state = self.sm_state.lock().await;
-            sm_state.last_summarized_msg_idx = None;
+            sm_state.last_summarized_seq = None;
         }
 
         // Post-compact file re-injection
@@ -647,11 +651,12 @@ impl UnifiedMessageProcessor {
         match persist_result {
             Ok(Ok(())) => {
                 // Keep SM content (memory quality survives compaction; the next
-                // SM-compact can still use it) but reset the message-index
-                // pointer — indices refer to the pre-compact message list and
-                // would be dangling against the rebuilt one.
+                // SM-compact can still use it) but reset the sequence
+                // anchor — the summarized region is now folded into the
+                // compact summary, so the old anchor describes rows the
+                // visible window no longer contains.
                 let mut sm_state = self.sm_state.lock().await;
-                sm_state.last_summarized_msg_idx = None;
+                sm_state.last_summarized_seq = None;
                 let persist_outcome = match sm_state.content.as_deref() {
                     Some(content) if !content.trim().is_empty() => {
                         unified_persistence::save_session_memory_state(session_id, content, None)
@@ -732,29 +737,32 @@ mod tests {
     }
 
     #[test]
-    fn sm_boundary_is_shifted_from_provider_messages_to_tail_messages() {
-        let state = SessionMemoryState {
-            content: Some("summary".to_string()),
-            last_summarized_msg_idx: Some(7),
-            ..SessionMemoryState::default()
-        };
+    fn sm_anchor_resolution_is_frame_independent() {
+        let start_seqs = vec![3, 5, 9, 12];
 
-        let adjusted = adjust_sm_state_for_compactable_tail(&state, 2);
-
-        assert_eq!(adjusted.last_summarized_msg_idx, Some(5));
-        assert_eq!(adjusted.content.as_deref(), Some("summary"));
-    }
-
-    #[test]
-    fn sm_boundary_before_system_prefix_is_not_reused_for_tail() {
-        let state = SessionMemoryState {
-            content: Some("summary".to_string()),
-            last_summarized_msg_idx: Some(1),
-            ..SessionMemoryState::default()
-        };
-
-        let adjusted = adjust_sm_state_for_compactable_tail(&state, 2);
-
-        assert_eq!(adjusted.last_summarized_msg_idx, None);
+        assert_eq!(
+            session_memory::resolve_summarized_boundary_idx(Some(9), &start_seqs),
+            Some(2),
+            "anchor on an exact start-sequence points at that message"
+        );
+        assert_eq!(
+            session_memory::resolve_summarized_boundary_idx(Some(10), &start_seqs),
+            Some(2),
+            "anchor between messages points at the last covered one"
+        );
+        assert_eq!(
+            session_memory::resolve_summarized_boundary_idx(Some(1), &start_seqs),
+            None,
+            "anchor older than the window means nothing here is summarized"
+        );
+        assert_eq!(
+            session_memory::resolve_summarized_boundary_idx(Some(99), &start_seqs),
+            Some(3),
+            "anchor beyond the window covers everything"
+        );
+        assert_eq!(
+            session_memory::resolve_summarized_boundary_idx(None, &start_seqs),
+            None
+        );
     }
 }

--- a/src-tauri/crates/agent-core/src/core/session/turn/processor/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/processor/mod.rs
@@ -230,6 +230,8 @@ impl UnifiedMessageProcessor {
             session.id.clone()
         });
 
+        let sm_state = Arc::clone(&session.sm_state);
+
         Self {
             runtime,
             session,
@@ -243,7 +245,7 @@ impl UnifiedMessageProcessor {
             screenshot_store,
             event_handler_config,
             compaction_state: tokio::sync::Mutex::new(CompactionState::default()),
-            sm_state: Arc::new(tokio::sync::Mutex::new(SessionMemoryState::default())),
+            sm_state,
             sm_config: SessionMemoryConfig::default(),
             sm_compact_config: SessionMemoryCompactConfig::default(),
             replacement_state: tokio::sync::Mutex::new(ReplacementState::new()),
@@ -509,6 +511,12 @@ impl UnifiedMessageProcessor {
         // Anchor for the receipt-fallback audit window: CLI writes during
         // this turn carry occurred_at >= this instant.
         let turn_started_at_ms = chrono::Utc::now().timestamp_millis();
+
+        // Any newly accepted turn means the session is active again. Cancel
+        // coordinator generations left by the prior turn (especially the
+        // quiescence-debounced reflection/observation jobs) before they can
+        // race the new transcript.
+        crate::memory::background::cancel_memory_jobs_for_session(session_id);
 
         // 0b. Restore persisted SM state on first turn (lazy init)
         if self.sm_config.enabled {
@@ -1025,7 +1033,6 @@ impl UnifiedMessageProcessor {
             session_id,
             turn_id: &turn_id,
             response_text: &response_text,
-            messages: &messages,
             result: &result,
             tool_calls_count,
             final_turn_state,

--- a/src-tauri/crates/agent-core/src/core/session/turn/processor/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/processor/mod.rs
@@ -534,7 +534,7 @@ impl UnifiedMessageProcessor {
                             persisted.content.as_ref().map(|c| c.len()).unwrap_or(0),
                         );
                         sm_state.content = persisted.content;
-                        sm_state.last_summarized_msg_idx = persisted.last_msg_idx;
+                        sm_state.last_summarized_seq = persisted.last_seq;
                         sm_state.initialized = true;
                     }
                 }
@@ -1029,6 +1029,16 @@ impl UnifiedMessageProcessor {
 
         // 9–10. Post-turn dispatch (broadcast, Stop hook, CU lock,
         // session-memory / extract-memories / auto-dream / digest spawns).
+        // The SM gate inputs are computed here because the dispatcher no
+        // longer sees the in-memory transcript: provider-reported prompt
+        // tokens when available, a local count only as fallback.
+        let sm_current_tokens = if result.prompt_tokens > 0 {
+            result.prompt_tokens as usize
+        } else {
+            crate::model_context::tokenizer::count_messages_tokens(&messages)
+        };
+        let sm_last_turn_has_tool_calls =
+            crate::model_context::session_memory::last_turn_has_tool_calls(&messages);
         self.dispatch_post_turn_work(post_turn_dispatch::PostTurnInputs {
             session_id,
             turn_id: &turn_id,
@@ -1037,6 +1047,8 @@ impl UnifiedMessageProcessor {
             tool_calls_count,
             final_turn_state,
             turn_started_at_ms,
+            sm_current_tokens,
+            sm_last_turn_has_tool_calls,
         })
         .await;
 

--- a/src-tauri/crates/agent-core/src/core/session/turn/processor/post_turn_dispatch.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/processor/post_turn_dispatch.rs
@@ -1,13 +1,13 @@
-//! Post-turn dispatch: broadcasts, hooks, locks, fire-and-forget jobs.
+//! Post-turn dispatch: broadcasts, hooks, locks, and bounded background submissions.
 //!
 //! Runs after `turn_executor::execute_turn` returns. Order matters:
 //!
 //! 1. **`agent:complete` broadcast** — first, so the user sees "done"
 //!    before any background work fires.
 //! 2. **Computer Use lock release** — best-effort, no-op if not held.
-//! 3. **Session memory extraction** — fire-and-forget, 60s timeout.
-//! 4. **Extract memories** — forked extractor agent, fire-and-forget.
-//! 5. **Auto-dream** — periodic memory consolidation, fire-and-forget.
+//! 3. **Session memory extraction** — coordinator-owned, 60s timeout.
+//! 4. **Extract memories** — coordinator-owned forked extractor.
+//! 5. **Auto-dream** — coordinator-owned periodic consolidation.
 //!
 //! (`HookEvent::Stop` no longer fires here — it runs *inside* the turn
 //! loop as a blocking gate; see `on_turn_stop_check`.)
@@ -34,7 +34,6 @@ pub(super) struct PostTurnInputs<'a> {
     pub session_id: &'a str,
     pub turn_id: &'a str,
     pub response_text: &'a str,
-    pub messages: &'a [serde_json::Value],
     pub result: &'a TurnResult,
     pub tool_calls_count: u32,
     pub final_turn_state: DialogTurnState,
@@ -43,13 +42,12 @@ pub(super) struct PostTurnInputs<'a> {
 
 impl UnifiedMessageProcessor {
     /// Runs every post-turn step (broadcast, Stop hook, CU lock release,
-    /// four fire-and-forget spawns) in order.
+    /// bounded memory submissions) in order.
     pub(super) async fn dispatch_post_turn_work(&self, inputs: PostTurnInputs<'_>) {
         let PostTurnInputs {
             session_id,
             turn_id,
             response_text,
-            messages,
             result,
             tool_calls_count,
             final_turn_state,
@@ -99,59 +97,59 @@ impl UnifiedMessageProcessor {
             workspace: self.runtime.workspace_state.read().clone(),
         };
 
-        // 9b. Session memory extraction (fire-and-forget, 60s timeout).
-        if should_run_post_turn_work(self.sm_config.enabled, final_turn_state) {
+        // 9b. Coordinator-owned session-memory extraction.
+        if should_run_post_turn_work(self.sm_config.enabled, final_turn_state)
+            && self.runtime.resolved.learnings.enabled
+        {
             post_turn_jobs::spawn_session_memory_extraction(
                 post_turn_jobs::SessionMemoryExtractionInput {
                     session_id,
-                    messages,
+                    agent_id: self.runtime.agent_definition_id.clone(),
                     prompt_tokens: result.prompt_tokens,
                     tool_calls_count,
                     sm_state: self.sm_state.clone(),
                     sm_config: self.sm_config.clone(),
                     fork_provider: fork_provider.clone(),
                 },
-            )
-            .await;
+            );
         }
 
         // 9c. Extract memories — forked extractor agent (fire-and-forget).
         // Subagents bypass this branch structurally (they don't go through
         // UnifiedMessageProcessor), so no explicit agent_id check is needed.
         if should_run_post_turn_work(
-            self.runtime.resolved.learnings.extract_memories_enabled,
+            self.runtime.resolved.learnings.enabled
+                && self.runtime.resolved.learnings.extract_memories_enabled,
             final_turn_state,
         ) && !result.is_stream_error
         {
             if let Some(ws_path) = self.workspace_root() {
                 post_turn_jobs::spawn_extract_memories(post_turn_jobs::ExtractMemoriesInput {
                     session_id,
+                    agent_id: self.runtime.agent_definition_id.clone(),
                     ws_path,
-                    messages,
-                    final_text: result.content.as_deref(),
                     em_state: self.session.em_state.clone(),
                     fork_provider: fork_provider.clone(),
                     tool_registry: self.runtime.tool_registry.clone(),
-                })
-                .await;
+                });
             }
         }
 
         // 9d. Auto-dream — periodic memory consolidation (fire-and-forget).
         if should_run_post_turn_work(
-            self.runtime.resolved.learnings.auto_dream_enabled,
+            self.runtime.resolved.learnings.enabled
+                && self.runtime.resolved.learnings.auto_dream_enabled,
             final_turn_state,
         ) {
             if let Some(ws_path) = self.workspace_root() {
                 post_turn_jobs::spawn_auto_dream(post_turn_jobs::AutoDreamInput {
                     session_id,
+                    agent_id: self.runtime.agent_definition_id.clone(),
                     ws_path,
-                    messages: messages.to_vec(),
                     ad_state: self.session.ad_state.clone(),
                     fork_provider: fork_provider.clone(),
                     tool_registry: self.runtime.tool_registry.clone(),
-                })
-                .await;
+                });
             }
         }
 

--- a/src-tauri/crates/agent-core/src/core/session/turn/processor/post_turn_dispatch.rs
+++ b/src-tauri/crates/agent-core/src/core/session/turn/processor/post_turn_dispatch.rs
@@ -38,6 +38,8 @@ pub(super) struct PostTurnInputs<'a> {
     pub tool_calls_count: u32,
     pub final_turn_state: DialogTurnState,
     pub turn_started_at_ms: i64,
+    pub sm_current_tokens: usize,
+    pub sm_last_turn_has_tool_calls: bool,
 }
 
 impl UnifiedMessageProcessor {
@@ -52,6 +54,8 @@ impl UnifiedMessageProcessor {
             tool_calls_count,
             final_turn_state,
             turn_started_at_ms,
+            sm_current_tokens,
+            sm_last_turn_has_tool_calls,
         } = inputs;
 
         // 9. Broadcast completion FIRST — user sees "done" immediately.
@@ -97,26 +101,42 @@ impl UnifiedMessageProcessor {
             workspace: self.runtime.workspace_state.read().clone(),
         };
 
-        // 9b. Coordinator-owned session-memory extraction.
-        if should_run_post_turn_work(self.sm_config.enabled, final_turn_state)
-            && self.runtime.resolved.learnings.enabled
-        {
-            post_turn_jobs::spawn_session_memory_extraction(
-                post_turn_jobs::SessionMemoryExtractionInput {
-                    session_id,
-                    agent_id: self.runtime.agent_definition_id.clone(),
-                    prompt_tokens: result.prompt_tokens,
-                    tool_calls_count,
-                    sm_state: self.sm_state.clone(),
-                    sm_config: self.sm_config.clone(),
-                    fork_provider: fork_provider.clone(),
-                },
-            );
+        // 9b. Coordinator-owned session-memory extraction. SM is part of the
+        // context-window pipeline, not long-term memory, so it is gated by
+        // `sm_config.enabled` alone — never by the learnings policy. The gate
+        // and counter bookkeeping run here at dispatch: a job cancelled while
+        // queued can no longer lose them, and only due extractions are ever
+        // submitted.
+        if should_run_post_turn_work(self.sm_config.enabled, final_turn_state) {
+            let should_extract_now = {
+                let mut sm_state = self.sm_state.lock().await;
+                sm_state.record_tool_calls(tool_calls_count as usize);
+                crate::model_context::session_memory::should_extract(
+                    &sm_state,
+                    &self.sm_config,
+                    sm_current_tokens,
+                    sm_last_turn_has_tool_calls,
+                )
+            };
+            if should_extract_now {
+                post_turn_jobs::spawn_session_memory_extraction(
+                    post_turn_jobs::SessionMemoryExtractionInput {
+                        session_id,
+                        agent_id: self.runtime.agent_definition_id.clone(),
+                        current_tokens: sm_current_tokens,
+                        sm_state: self.sm_state.clone(),
+                        sm_config: self.sm_config.clone(),
+                        fork_provider: fork_provider.clone(),
+                    },
+                );
+            }
         }
 
         // 9c. Extract memories — forked extractor agent (fire-and-forget).
         // Subagents bypass this branch structurally (they don't go through
         // UnifiedMessageProcessor), so no explicit agent_id check is needed.
+        // The turn counter advances here at dispatch so cancelled or
+        // coalesced jobs cannot lose it; the job body no longer records.
         if should_run_post_turn_work(
             self.runtime.resolved.learnings.enabled
                 && self.runtime.resolved.learnings.extract_memories_enabled,
@@ -124,6 +144,10 @@ impl UnifiedMessageProcessor {
         ) && !result.is_stream_error
         {
             if let Some(ws_path) = self.workspace_root() {
+                {
+                    let mut em_state = self.session.em_state.lock().await;
+                    crate::memory::workspace_memory::extract::record_turn(&mut em_state);
+                }
                 post_turn_jobs::spawn_extract_memories(post_turn_jobs::ExtractMemoriesInput {
                     session_id,
                     agent_id: self.runtime.agent_definition_id.clone(),

--- a/src-tauri/crates/agent-core/src/core/side_query.rs
+++ b/src-tauri/crates/agent-core/src/core/side_query.rs
@@ -17,6 +17,9 @@
 //!
 //! Ref: claude_code/utils/sideQuery.ts
 
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
 use serde_json::Value;
 use tracing::{info, warn};
 
@@ -187,7 +190,18 @@ pub async fn side_query(
     config: &SideQueryConfig,
     default_model: &str,
 ) -> Result<SideQueryResult, String> {
-    side_query_typed(provider, user_messages, config, default_model)
+    side_query_with_options(provider, user_messages, config, default_model, None).await
+}
+
+/// Cancellation-aware side query used by coordinator-owned background jobs.
+pub async fn side_query_with_options(
+    provider: &dyn LLMProvider,
+    user_messages: &[Value],
+    config: &SideQueryConfig,
+    default_model: &str,
+    cancel_flag: Option<&Arc<AtomicBool>>,
+) -> Result<SideQueryResult, String> {
+    side_query_typed_with_options(provider, user_messages, config, default_model, cancel_flag)
         .await
         .map_err(|err| err.to_string())
 }
@@ -197,6 +211,16 @@ pub async fn side_query_typed(
     user_messages: &[Value],
     config: &SideQueryConfig,
     default_model: &str,
+) -> Result<SideQueryResult, SideQueryError> {
+    side_query_typed_with_options(provider, user_messages, config, default_model, None).await
+}
+
+pub async fn side_query_typed_with_options(
+    provider: &dyn LLMProvider,
+    user_messages: &[Value],
+    config: &SideQueryConfig,
+    default_model: &str,
+    cancel_flag: Option<&Arc<AtomicBool>>,
 ) -> Result<SideQueryResult, SideQueryError> {
     let model = config.model.as_deref().unwrap_or(default_model);
 
@@ -243,6 +267,12 @@ pub async fn side_query_typed(
         skip_cache_write: config.skip_cache_write,
     };
 
+    if cancel_flag.is_some_and(|flag| flag.load(Ordering::SeqCst)) {
+        return Err(SideQueryError::Provider(ProviderError::RequestFailed(
+            "side query cancelled".to_string(),
+        )));
+    }
+
     // First attempt
     let response = provider
         .chat_with_options(
@@ -281,6 +311,11 @@ pub async fn side_query_typed(
     }
 
     // Retry: pad max_tokens, drop tool_choice override (some proxies reject it)
+    if cancel_flag.is_some_and(|flag| flag.load(Ordering::SeqCst)) {
+        return Err(SideQueryError::Provider(ProviderError::RequestFailed(
+            "side query cancelled".to_string(),
+        )));
+    }
     let retry_max_tokens = config.max_tokens.saturating_add(2048);
     info!(
         "[side-query] Retry: max_tokens={} → {}, no tool_choice override",

--- a/src-tauri/crates/agent-core/src/foundation/persistence/db_helpers/messages/load_llm.rs
+++ b/src-tauri/crates/agent-core/src/foundation/persistence/db_helpers/messages/load_llm.rs
@@ -173,6 +173,21 @@ pub fn load_llm_history(
     Ok(result)
 }
 
+/// Rebuild the durable conversation without hydrating image files into base64.
+/// Background memory agents consume text/tool evidence only; loading image
+/// payloads there creates a large, short-lived duplicate with no extraction
+/// value.
+pub fn load_llm_history_text_only(
+    prefix: &str,
+    session_id: &str,
+) -> rusqlite::Result<Vec<serde_json::Value>> {
+    let mut messages = load_messages(prefix, session_id)?;
+    for message in &mut messages {
+        message.images = None;
+    }
+    Ok(reconstruct(&visible_rows(&messages)))
+}
+
 /// Sequence of the first row contributing to each reconstructed LLM
 /// message, in output order. Mirrors the grouping rules of
 /// [`reconstruct`] (consecutive tool_call/tool_result rows form one
@@ -550,6 +565,35 @@ mod tests {
         );
         assert_eq!(history[1]["content"], "recent follow-up");
         assert_eq!(history[2]["content"], "recent answer");
+    }
+
+    #[test]
+    fn text_only_history_does_not_hydrate_images() {
+        let _sandbox = test_env::sandbox();
+        create_message_table(DB_PREFIX);
+        let conn = get_connection().expect("get connection");
+        conn.execute(
+            &format!(
+                "INSERT INTO {DB_PREFIX}_messages
+                 (id, session_id, role, content, sequence, created_at, images)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)"
+            ),
+            rusqlite::params![
+                "image-msg",
+                DB_SESSION,
+                message_role::USER,
+                "inspect this",
+                1,
+                "2024-01-01T00:00:00Z",
+                serde_json::to_string(&vec!["data:image/png;base64,AAAA"]).unwrap(),
+            ],
+        )
+        .expect("insert image row");
+
+        let history = load_llm_history_text_only(DB_PREFIX, DB_SESSION).expect("text history");
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0]["content"], "inspect this");
+        assert!(history[0]["content"].is_string());
     }
 
     #[test]

--- a/src-tauri/crates/agent-core/src/foundation/persistence/db_helpers/messages/load_llm.rs
+++ b/src-tauri/crates/agent-core/src/foundation/persistence/db_helpers/messages/load_llm.rs
@@ -177,15 +177,34 @@ pub fn load_llm_history(
 /// Background memory agents consume text/tool evidence only; loading image
 /// payloads there creates a large, short-lived duplicate with no extraction
 /// value.
+///
+/// Returns the reconstructed messages together with each message's first-row
+/// durable sequence (same order/length), so callers can anchor cursors by
+/// sequence instead of array index.
 pub fn load_llm_history_text_only(
     prefix: &str,
     session_id: &str,
-) -> rusqlite::Result<Vec<serde_json::Value>> {
+) -> rusqlite::Result<(Vec<serde_json::Value>, Vec<i64>)> {
     let mut messages = load_messages(prefix, session_id)?;
     for message in &mut messages {
         message.images = None;
     }
-    Ok(reconstruct(&visible_rows(&messages)))
+    let visible = visible_rows(&messages);
+    let refs: Vec<&AgentMessageRow> = visible.iter().collect();
+    Ok((reconstruct(&visible), llm_message_start_sequences(&refs)))
+}
+
+/// First-row durable sequence for each message of the current visible LLM
+/// history, in [`load_llm_history`] output order. Lets compaction resolve a
+/// sequence anchor to an index in whatever frame it holds.
+pub fn load_llm_history_start_sequences(
+    prefix: &str,
+    session_id: &str,
+) -> rusqlite::Result<Vec<i64>> {
+    let messages = load_messages(prefix, session_id)?;
+    let visible = visible_rows(&messages);
+    let refs: Vec<&AgentMessageRow> = visible.iter().collect();
+    Ok(llm_message_start_sequences(&refs))
 }
 
 /// Sequence of the first row contributing to each reconstructed LLM
@@ -590,10 +609,12 @@ mod tests {
         )
         .expect("insert image row");
 
-        let history = load_llm_history_text_only(DB_PREFIX, DB_SESSION).expect("text history");
+        let (history, start_seqs) =
+            load_llm_history_text_only(DB_PREFIX, DB_SESSION).expect("text history");
         assert_eq!(history.len(), 1);
         assert_eq!(history[0]["content"], "inspect this");
         assert!(history[0]["content"].is_string());
+        assert_eq!(start_seqs, vec![1], "start sequences mirror the messages");
     }
 
     #[test]

--- a/src-tauri/crates/agent-core/src/foundation/persistence/db_helpers/messages/mod.rs
+++ b/src-tauri/crates/agent-core/src/foundation/persistence/db_helpers/messages/mod.rs
@@ -27,4 +27,7 @@ pub use builders::{
     save_tool_result_msg, save_user_msg, save_user_msg_with_id,
 };
 pub use cleanup::{clear_messages, truncate_messages_from_sequence};
-pub use load_llm::{compact_cutoff_sequence, load_llm_history, turns_since_last_tool_call};
+pub use load_llm::{
+    compact_cutoff_sequence, load_llm_history, load_llm_history_text_only,
+    turns_since_last_tool_call,
+};

--- a/src-tauri/crates/agent-core/src/foundation/persistence/db_helpers/messages/mod.rs
+++ b/src-tauri/crates/agent-core/src/foundation/persistence/db_helpers/messages/mod.rs
@@ -28,6 +28,6 @@ pub use builders::{
 };
 pub use cleanup::{clear_messages, truncate_messages_from_sequence};
 pub use load_llm::{
-    compact_cutoff_sequence, load_llm_history, load_llm_history_text_only,
-    turns_since_last_tool_call,
+    compact_cutoff_sequence, load_llm_history, load_llm_history_start_sequences,
+    load_llm_history_text_only, turns_since_last_tool_call,
 };

--- a/src-tauri/crates/agent-core/src/foundation/persistence/session_snapshots.rs
+++ b/src-tauri/crates/agent-core/src/foundation/persistence/session_snapshots.rs
@@ -210,10 +210,17 @@ pub fn ensure_tables_with(conn: &Connection) -> SqliteResult<()> {
         conn,
         "ALTER TABLE agent_sessions ADD COLUMN sm_content TEXT",
     );
+    // The SM boundary anchor is a durable message start-sequence. The legacy
+    // `sm_last_msg_idx` column stored an array index recorded against a
+    // specific in-memory frame; readers on other frames (truncated durable
+    // suffix, prefix-stripped compaction tail) misresolved it, so it is
+    // dropped rather than reinterpreted — existing sessions re-anchor on
+    // their next extraction.
     try_migrate(
         conn,
-        "ALTER TABLE agent_sessions ADD COLUMN sm_last_msg_idx INTEGER",
+        "ALTER TABLE agent_sessions ADD COLUMN sm_last_seq INTEGER",
     );
+    try_drop_column(conn, "agent_sessions", "sm_last_msg_idx");
 
     // L3 rebuild: the per-session learning toggle was replaced by a per-agent
     // `learnings.enabled` flag on `AgentDefinition`

--- a/src-tauri/crates/agent-core/src/foundation/persistence/test_schema.rs
+++ b/src-tauri/crates/agent-core/src/foundation/persistence/test_schema.rs
@@ -49,7 +49,7 @@ pub(crate) const AGENT_SESSIONS_TEST_DDL: &str = r#"
         reply_target_event_id TEXT,
         pinned INTEGER NOT NULL DEFAULT 0,
         sm_content TEXT,
-        sm_last_msg_idx INTEGER
+        sm_last_seq INTEGER
     );
     CREATE TABLE IF NOT EXISTS session_token_usage (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -151,7 +151,7 @@ pub(crate) fn ensure_agent_sessions_schema(conn: &rusqlite::Connection) {
         ),
         ("key_source", "key_source TEXT NOT NULL DEFAULT 'own_key'"),
         ("sm_content", "sm_content TEXT"),
-        ("sm_last_msg_idx", "sm_last_msg_idx INTEGER"),
+        ("sm_last_seq", "sm_last_seq INTEGER"),
     ] {
         if !existing.contains(column) {
             let _ = conn.execute(&format!("ALTER TABLE agent_sessions ADD COLUMN {decl}"), []);

--- a/src-tauri/crates/agent-core/src/lifecycle.rs
+++ b/src-tauri/crates/agent-core/src/lifecycle.rs
@@ -529,20 +529,24 @@ pub async fn finalize_session(
     load_workspace_resources: bool,
     terminal_turn: Option<TerminalTurnSignal>,
 ) -> AgentSessionStatus {
-    let is_agent_org_member_session = {
+    let (is_agent_org_member_session, session_agent_definition_id) = {
         let sid = session_id.to_string();
         tokio::task::spawn_blocking(move || {
             session_persistence::get_session(&sid)
                 .ok()
                 .flatten()
                 .map(|record| {
-                    record.session_type == crate::session::persistence::session_type::ORG_MEMBER
-                        || record.org_member_id.is_some()
+                    (
+                        record.session_type
+                            == crate::session::persistence::session_type::ORG_MEMBER
+                            || record.org_member_id.is_some(),
+                        record.agent_definition_id,
+                    )
                 })
-                .unwrap_or(false)
+                .unwrap_or((false, None))
         })
         .await
-        .unwrap_or(false)
+        .unwrap_or((false, None))
     };
 
     let final_status = if response.is_ok() {
@@ -670,58 +674,76 @@ pub async fn finalize_session(
         }
     }
 
-    // Post-session reflection: fire-and-forget.
-    // Gating (per-agent `learnings.enabled`) lives inside
-    // `maybe_reflect_on_session` — see reflection.rs. This keeps the decision
-    // close to the `AgentDefinition` resolver and out of the lifecycle path.
+    // Post-session reflection and active observation are coordinator-owned.
+    // The current policy is checked after admission and again inside each
+    // subsystem before any LLM call, so the settings switch is a hot gate.
     if final_status == AgentSessionStatus::Completed && !e2e_background_llm_disabled() {
+        const REFLECTION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(120);
+        const SESSION_QUIESCENCE_DELAY: std::time::Duration =
+            std::time::Duration::from_secs(5 * 60);
         let sid = session_id.to_string();
-        tokio::spawn(async move {
-            match crate::memory::reflection::maybe_reflect_on_session(&sid).await {
-                Ok(count) => {
+        let agent_id = session_agent_definition_id.clone();
+        let job_agent_id = agent_id.clone();
+        crate::memory::background::submit_memory_job(
+            crate::memory::background::MemoryJob::new(
+                sid.clone(),
+                agent_id,
+                crate::memory::background::MemoryJobKind::Reflection,
+                REFLECTION_TIMEOUT,
+                move |_cancel| async move {
+                    if let Some(agent_id) = job_agent_id.as_deref() {
+                        if !crate::memory::background::memory_job_is_enabled(
+                            agent_id,
+                            crate::memory::background::MemoryJobKind::Reflection,
+                        ) {
+                            return Ok(());
+                        }
+                    }
+                    let count = crate::memory::reflection::maybe_reflect_on_session(&sid).await?;
                     tracing::info!(
                         "[lifecycle] Post-session reflection stored {} learnings for {}",
                         count,
                         sid
                     );
-                }
-                Err(err) => {
-                    tracing::info!(
-                        "[lifecycle] Post-session reflection skipped for {}: {}",
-                        sid,
-                        err
-                    );
-                }
-            }
-        });
+                    Ok(())
+                },
+            )
+            .with_debounce(SESSION_QUIESCENCE_DELAY),
+        );
 
-        // Active observation: sibling L3 write path for tool-failure →
-        // user-intervention patterns. Same gating semantics as reflection
-        // (agent scope, `learningsEnabled`, `reflection_blacklist`); spawn
-        // independently so reflection + observation can run in parallel
-        // and neither blocks the session-end code path. See
-        // `active_learning::maybe_observe_tool_failures`.
         let sid = session_id.to_string();
-        tokio::spawn(async move {
-            match crate::memory::reflection::active_learning::maybe_observe_tool_failures(&sid)
-                .await
-            {
-                Ok(count) => {
+        let agent_id = session_agent_definition_id;
+        let job_agent_id = agent_id.clone();
+        crate::memory::background::submit_memory_job(
+            crate::memory::background::MemoryJob::new(
+                sid.clone(),
+                agent_id,
+                crate::memory::background::MemoryJobKind::ActiveObservation,
+                REFLECTION_TIMEOUT,
+                move |_cancel| async move {
+                    if let Some(agent_id) = job_agent_id.as_deref() {
+                        if !crate::memory::background::memory_job_is_enabled(
+                            agent_id,
+                            crate::memory::background::MemoryJobKind::ActiveObservation,
+                        ) {
+                            return Ok(());
+                        }
+                    }
+                    let count =
+                        crate::memory::reflection::active_learning::maybe_observe_tool_failures(
+                            &sid,
+                        )
+                        .await?;
                     tracing::info!(
                         "[lifecycle] Post-session active observation stored {} learnings for {}",
                         count,
                         sid
                     );
-                }
-                Err(err) => {
-                    tracing::info!(
-                        "[lifecycle] Post-session active observation skipped for {}: {}",
-                        sid,
-                        err
-                    );
-                }
-            }
-        });
+                    Ok(())
+                },
+            )
+            .with_debounce(SESSION_QUIESCENCE_DELAY),
+        );
     }
 
     final_status

--- a/src-tauri/crates/agent-core/src/specialization/memory/background.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/background.rs
@@ -39,7 +39,6 @@ pub enum MemoryJobKind {
     AutoDream,
     Reflection,
     ActiveObservation,
-    LearningsConsolidation,
 }
 
 impl MemoryJobKind {
@@ -50,7 +49,6 @@ impl MemoryJobKind {
             Self::AutoDream => "auto_dream",
             Self::Reflection => "reflection",
             Self::ActiveObservation => "active_observation",
-            Self::LearningsConsolidation => "learnings_consolidation",
         }
     }
 }
@@ -217,7 +215,14 @@ impl MemoryJobCoordinator {
         let mut replaced_slot = None;
         let (slot_id, cancel) = {
             let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
-            if job.replace_existing && state.slots.contains_key(&key) {
+            // A cancelled slot is torn down by its own drive loop; coalescing
+            // into it would silently drop the new job when the loop exits.
+            // Replace it with a fresh generation instead.
+            let existing_cancelled = state
+                .slots
+                .get(&key)
+                .is_some_and(|slot| slot.cancel.is_cancelled());
+            if (job.replace_existing || existing_cancelled) && state.slots.contains_key(&key) {
                 replaced_slot = state.slots.remove(&key);
             } else if let Some(slot) = state.slots.get_mut(&key) {
                 slot.agent_id = job.agent_id.clone();
@@ -482,18 +487,23 @@ pub fn memory_job_metrics() -> MemoryJobMetricsSnapshot {
     coordinator().metrics()
 }
 
-/// Resolve the current (not session-snapshotted) agent policy immediately
-/// before expensive work. This makes the settings switch a real hot gate.
-pub fn memory_job_is_enabled(agent_id: &str, kind: MemoryJobKind) -> bool {
-    let config = crate::definitions::resolve_learnings_for(agent_id);
+/// Single source of truth for "does this agent's learnings policy allow this
+/// job kind". Session memory is context-pipeline state, not long-term
+/// memory, so it is never policy-gated here — its own gate is
+/// `sm_config.enabled` at post-turn dispatch.
+fn kind_enabled(config: &crate::definitions::AgentLearningsConfig, kind: MemoryJobKind) -> bool {
     match kind {
-        MemoryJobKind::SessionMemory
-        | MemoryJobKind::Reflection
-        | MemoryJobKind::ActiveObservation
-        | MemoryJobKind::LearningsConsolidation => config.enabled,
+        MemoryJobKind::SessionMemory => true,
+        MemoryJobKind::Reflection | MemoryJobKind::ActiveObservation => config.enabled,
         MemoryJobKind::WorkspaceExtraction => config.enabled && config.extract_memories_enabled,
         MemoryJobKind::AutoDream => config.enabled && config.auto_dream_enabled,
     }
+}
+
+/// Resolve the current (not session-snapshotted) agent policy immediately
+/// before expensive work. This makes the settings switch a real hot gate.
+pub fn memory_job_is_enabled(agent_id: &str, kind: MemoryJobKind) -> bool {
+    kind_enabled(&crate::definitions::resolve_learnings_for(agent_id), kind)
 }
 
 /// Cancel only the kinds that the agent's freshly persisted policy disables.
@@ -502,17 +512,7 @@ pub fn memory_job_is_enabled(agent_id: &str, kind: MemoryJobKind) -> bool {
 pub fn cancel_disabled_memory_jobs_for_agent(agent_id: &str) -> usize {
     let config = crate::definitions::resolve_learnings_for(agent_id);
     coordinator().cancel_where(|key, slot| {
-        slot.agent_id.as_deref() == Some(agent_id)
-            && match key.kind {
-                MemoryJobKind::SessionMemory
-                | MemoryJobKind::Reflection
-                | MemoryJobKind::ActiveObservation
-                | MemoryJobKind::LearningsConsolidation => !config.enabled,
-                MemoryJobKind::WorkspaceExtraction => {
-                    !config.enabled || !config.extract_memories_enabled
-                }
-                MemoryJobKind::AutoDream => !config.enabled || !config.auto_dream_enabled,
-            }
+        slot.agent_id.as_deref() == Some(agent_id) && !kind_enabled(&config, key.kind)
     })
 }
 

--- a/src-tauri/crates/agent-core/src/specialization/memory/background.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/background.rs
@@ -1,0 +1,769 @@
+//! Bounded ownership for background memory/evolution work.
+//!
+//! Memory jobs used to be detached directly from turn/session finalization.
+//! That made the spawned future the accidental owner of providers, tool
+//! registries and full transcripts, with no global admission control and no
+//! lifecycle cancellation. This coordinator is the single ownership boundary:
+//!
+//! - one active job per `(session_id, job_kind)`;
+//! - one latest pending job per key (new submissions replace stale pending work);
+//! - a process-wide semaphore for expensive memory LLM work;
+//! - hard deadlines and explicit cancellation;
+//! - an always-run cleanup hook so subsystem state cannot remain stuck after a
+//!   timeout or cancellation.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+use tokio::sync::{Notify, Semaphore};
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+type JobFuture = Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'static>>;
+type CleanupFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+type JobRunner = Box<dyn FnOnce(CancellationToken) -> JobFuture + Send + 'static>;
+type JobCleanup = Box<dyn FnOnce(MemoryJobOutcome) -> CleanupFuture + Send + 'static>;
+
+const DEFAULT_MAX_CONCURRENT_JOBS: usize = 1;
+const MAX_CONFIGURED_CONCURRENT_JOBS: usize = 4;
+
+/// Stable kind used in the coordinator ownership key and metrics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MemoryJobKind {
+    SessionMemory,
+    WorkspaceExtraction,
+    AutoDream,
+    Reflection,
+    ActiveObservation,
+    LearningsConsolidation,
+}
+
+impl MemoryJobKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SessionMemory => "session_memory",
+            Self::WorkspaceExtraction => "workspace_extraction",
+            Self::AutoDream => "auto_dream",
+            Self::Reflection => "reflection",
+            Self::ActiveObservation => "active_observation",
+            Self::LearningsConsolidation => "learnings_consolidation",
+        }
+    }
+}
+
+/// Terminal status passed to the mandatory cleanup hook.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryJobOutcome {
+    Completed,
+    Failed,
+    Cancelled,
+    TimedOut,
+}
+
+/// Lightweight coordinator counters. These count jobs, not turns.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MemoryJobMetricsSnapshot {
+    pub submitted: u64,
+    pub coalesced: u64,
+    pub started: u64,
+    pub completed: u64,
+    pub failed: u64,
+    pub cancelled: u64,
+    pub timed_out: u64,
+}
+
+#[derive(Default)]
+struct MemoryJobMetrics {
+    submitted: AtomicU64,
+    coalesced: AtomicU64,
+    started: AtomicU64,
+    completed: AtomicU64,
+    failed: AtomicU64,
+    cancelled: AtomicU64,
+    timed_out: AtomicU64,
+}
+
+impl MemoryJobMetrics {
+    fn snapshot(&self) -> MemoryJobMetricsSnapshot {
+        MemoryJobMetricsSnapshot {
+            submitted: self.submitted.load(Ordering::Relaxed),
+            coalesced: self.coalesced.load(Ordering::Relaxed),
+            started: self.started.load(Ordering::Relaxed),
+            completed: self.completed.load(Ordering::Relaxed),
+            failed: self.failed.load(Ordering::Relaxed),
+            cancelled: self.cancelled.load(Ordering::Relaxed),
+            timed_out: self.timed_out.load(Ordering::Relaxed),
+        }
+    }
+}
+
+/// One submitted unit of work. Callers should capture only lightweight source
+/// identifiers/configuration here; expensive transcripts are loaded by `run`
+/// after the coordinator grants a global permit.
+pub struct MemoryJob {
+    session_id: String,
+    agent_id: Option<String>,
+    kind: MemoryJobKind,
+    timeout: Duration,
+    delay: Duration,
+    replace_existing: bool,
+    run: JobRunner,
+    cleanup: Option<JobCleanup>,
+}
+
+impl MemoryJob {
+    pub fn new<F, Fut>(
+        session_id: impl Into<String>,
+        agent_id: Option<String>,
+        kind: MemoryJobKind,
+        timeout: Duration,
+        run: F,
+    ) -> Self
+    where
+        F: FnOnce(CancellationToken) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<(), String>> + Send + 'static,
+    {
+        Self {
+            session_id: session_id.into(),
+            agent_id,
+            kind,
+            timeout,
+            delay: Duration::ZERO,
+            replace_existing: false,
+            run: Box::new(move |cancel| Box::pin(run(cancel))),
+            cleanup: None,
+        }
+    }
+
+    /// Debounce this job: a later submission for the same key cancels the
+    /// current waiting/running generation and replaces it. Used for
+    /// session-quiescence reflection, where every new turn rearms the delay.
+    pub fn with_debounce(mut self, delay: Duration) -> Self {
+        self.delay = delay;
+        self.replace_existing = true;
+        self
+    }
+
+    pub fn with_cleanup<F, Fut>(mut self, cleanup: F) -> Self
+    where
+        F: FnOnce(MemoryJobOutcome) -> Fut + Send + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        self.cleanup = Some(Box::new(move |outcome| Box::pin(cleanup(outcome))));
+        self
+    }
+
+    fn key(&self) -> JobKey {
+        JobKey {
+            session_id: self.session_id.clone(),
+            kind: self.kind,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct JobKey {
+    session_id: String,
+    kind: MemoryJobKind,
+}
+
+struct JobSlot {
+    id: u64,
+    agent_id: Option<String>,
+    cancel: CancellationToken,
+    pending: Option<MemoryJob>,
+}
+
+#[derive(Default)]
+struct CoordinatorState {
+    next_slot_id: u64,
+    slots: HashMap<JobKey, JobSlot>,
+}
+
+/// Result of a non-blocking submission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemoryJobSubmission {
+    Started,
+    Coalesced,
+}
+
+/// Process-wide coordinator. It owns every detached memory job spawned through
+/// [`submit_memory_job`].
+struct MemoryJobCoordinator {
+    state: Mutex<CoordinatorState>,
+    permits: Arc<Semaphore>,
+    metrics: MemoryJobMetrics,
+    idle_notify: Notify,
+}
+
+impl MemoryJobCoordinator {
+    fn new(max_concurrent_jobs: usize) -> Arc<Self> {
+        Arc::new(Self {
+            state: Mutex::new(CoordinatorState::default()),
+            permits: Arc::new(Semaphore::new(max_concurrent_jobs.max(1))),
+            metrics: MemoryJobMetrics::default(),
+            idle_notify: Notify::new(),
+        })
+    }
+
+    fn submit(self: &Arc<Self>, job: MemoryJob) -> MemoryJobSubmission {
+        self.metrics.submitted.fetch_add(1, Ordering::Relaxed);
+        let key = job.key();
+
+        let mut replaced_slot = None;
+        let (slot_id, cancel) = {
+            let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            if job.replace_existing && state.slots.contains_key(&key) {
+                replaced_slot = state.slots.remove(&key);
+            } else if let Some(slot) = state.slots.get_mut(&key) {
+                slot.agent_id = job.agent_id.clone();
+                slot.pending = Some(job);
+                self.metrics.coalesced.fetch_add(1, Ordering::Relaxed);
+                info!(
+                    session_id = %key.session_id,
+                    job_kind = key.kind.as_str(),
+                    "[memory_background] coalesced latest pending job"
+                );
+                return MemoryJobSubmission::Coalesced;
+            }
+
+            state.next_slot_id = state.next_slot_id.wrapping_add(1).max(1);
+            let slot_id = state.next_slot_id;
+            let cancel = CancellationToken::new();
+            state.slots.insert(
+                key.clone(),
+                JobSlot {
+                    id: slot_id,
+                    agent_id: job.agent_id.clone(),
+                    cancel: cancel.clone(),
+                    pending: None,
+                },
+            );
+            (slot_id, cancel)
+        };
+
+        if let Some(replaced) = replaced_slot {
+            replaced.cancel.cancel();
+            self.metrics.coalesced.fetch_add(1, Ordering::Relaxed);
+        }
+        let coordinator = Arc::clone(self);
+        tokio::spawn(async move {
+            coordinator.drive_slot(key, slot_id, cancel, job).await;
+        });
+        MemoryJobSubmission::Started
+    }
+
+    async fn drive_slot(
+        self: Arc<Self>,
+        key: JobKey,
+        slot_id: u64,
+        cancel: CancellationToken,
+        mut job: MemoryJob,
+    ) {
+        loop {
+            let outcome = self.run_one(&key, &cancel, &mut job).await;
+            if let Some(cleanup) = job.cleanup.take() {
+                cleanup(outcome).await;
+            }
+
+            let next = {
+                let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+                match state.slots.get_mut(&key) {
+                    None => None,
+                    Some(slot) if slot.id != slot_id || cancel.is_cancelled() => {
+                        if slot.id == slot_id {
+                            state.slots.remove(&key);
+                        }
+                        None
+                    }
+                    Some(slot) => {
+                        if let Some(next) = slot.pending.take() {
+                            Some(next)
+                        } else {
+                            state.slots.remove(&key);
+                            None
+                        }
+                    }
+                }
+            };
+
+            match next {
+                Some(next) => job = next,
+                None => {
+                    self.idle_notify.notify_waiters();
+                    break;
+                }
+            }
+        }
+    }
+
+    async fn run_one(
+        &self,
+        key: &JobKey,
+        slot_cancel: &CancellationToken,
+        job: &mut MemoryJob,
+    ) -> MemoryJobOutcome {
+        if !job.delay.is_zero() {
+            tokio::select! {
+                biased;
+                _ = slot_cancel.cancelled() => {
+                    self.metrics.cancelled.fetch_add(1, Ordering::Relaxed);
+                    return MemoryJobOutcome::Cancelled;
+                }
+                _ = tokio::time::sleep(job.delay) => {}
+            }
+        }
+
+        let permit = tokio::select! {
+            biased;
+            _ = slot_cancel.cancelled() => {
+                self.metrics.cancelled.fetch_add(1, Ordering::Relaxed);
+                return MemoryJobOutcome::Cancelled;
+            }
+            permit = Arc::clone(&self.permits).acquire_owned() => match permit {
+                Ok(permit) => permit,
+                Err(_) => {
+                    self.metrics.cancelled.fetch_add(1, Ordering::Relaxed);
+                    return MemoryJobOutcome::Cancelled;
+                }
+            }
+        };
+
+        if slot_cancel.is_cancelled() {
+            drop(permit);
+            self.metrics.cancelled.fetch_add(1, Ordering::Relaxed);
+            return MemoryJobOutcome::Cancelled;
+        }
+
+        self.metrics.started.fetch_add(1, Ordering::Relaxed);
+        let started_at = std::time::Instant::now();
+        let run_cancel = slot_cancel.child_token();
+        let run = std::mem::replace(&mut job.run, Box::new(|_| Box::pin(async { Ok(()) })));
+        let mut future = Box::pin(run(run_cancel.clone()));
+
+        let outcome = tokio::select! {
+            biased;
+            _ = slot_cancel.cancelled() => {
+                run_cancel.cancel();
+                MemoryJobOutcome::Cancelled
+            }
+            result = tokio::time::timeout(job.timeout, &mut future) => match result {
+                Ok(Ok(())) => MemoryJobOutcome::Completed,
+                Ok(Err(err)) => {
+                    warn!(
+                        session_id = %key.session_id,
+                        job_kind = key.kind.as_str(),
+                        error = %err,
+                        "[memory_background] job failed"
+                    );
+                    MemoryJobOutcome::Failed
+                }
+                Err(_) => {
+                    run_cancel.cancel();
+                    warn!(
+                        session_id = %key.session_id,
+                        job_kind = key.kind.as_str(),
+                        timeout_ms = job.timeout.as_millis(),
+                        "[memory_background] job timed out"
+                    );
+                    MemoryJobOutcome::TimedOut
+                }
+            }
+        };
+        drop(future);
+        drop(permit);
+
+        match outcome {
+            MemoryJobOutcome::Completed => {
+                self.metrics.completed.fetch_add(1, Ordering::Relaxed);
+            }
+            MemoryJobOutcome::Failed => {
+                self.metrics.failed.fetch_add(1, Ordering::Relaxed);
+            }
+            MemoryJobOutcome::Cancelled => {
+                self.metrics.cancelled.fetch_add(1, Ordering::Relaxed);
+            }
+            MemoryJobOutcome::TimedOut => {
+                self.metrics.timed_out.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        info!(
+            session_id = %key.session_id,
+            job_kind = key.kind.as_str(),
+            outcome = ?outcome,
+            elapsed_ms = started_at.elapsed().as_millis(),
+            "[memory_background] job finished"
+        );
+        outcome
+    }
+
+    fn cancel_where(&self, mut predicate: impl FnMut(&JobKey, &JobSlot) -> bool) -> usize {
+        let tokens = {
+            let state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            state
+                .slots
+                .iter()
+                .filter_map(|(key, slot)| predicate(key, slot).then_some(slot.cancel.clone()))
+                .collect::<Vec<_>>()
+        };
+        for token in &tokens {
+            token.cancel();
+        }
+        if !tokens.is_empty() {
+            self.idle_notify.notify_waiters();
+        }
+        tokens.len()
+    }
+
+    fn cancel_session(&self, session_id: &str) -> usize {
+        self.cancel_where(|key, _| key.session_id == session_id)
+    }
+
+    fn cancel_agent(&self, agent_id: &str) -> usize {
+        self.cancel_where(|_, slot| slot.agent_id.as_deref() == Some(agent_id))
+    }
+
+    fn metrics(&self) -> MemoryJobMetricsSnapshot {
+        self.metrics.snapshot()
+    }
+
+    #[cfg(test)]
+    async fn wait_for_idle(&self) {
+        loop {
+            let notified = self.idle_notify.notified();
+            if self
+                .state
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .slots
+                .is_empty()
+            {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+fn configured_concurrency() -> usize {
+    std::env::var("ORGII_MEMORY_BACKGROUND_CONCURRENCY")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .map(|value| value.clamp(1, MAX_CONFIGURED_CONCURRENT_JOBS))
+        .unwrap_or(DEFAULT_MAX_CONCURRENT_JOBS)
+}
+
+fn coordinator() -> &'static Arc<MemoryJobCoordinator> {
+    static COORDINATOR: OnceLock<Arc<MemoryJobCoordinator>> = OnceLock::new();
+    COORDINATOR.get_or_init(|| MemoryJobCoordinator::new(configured_concurrency()))
+}
+
+/// Submit a memory job without blocking the caller.
+pub fn submit_memory_job(job: MemoryJob) -> MemoryJobSubmission {
+    coordinator().submit(job)
+}
+
+/// Cancel active and coalesced memory jobs owned by one session.
+pub fn cancel_memory_jobs_for_session(session_id: &str) -> usize {
+    coordinator().cancel_session(session_id)
+}
+
+/// Cancel active and coalesced memory jobs for every live session backed by an
+/// agent definition. Used by the hot learnings switch.
+pub fn cancel_memory_jobs_for_agent(agent_id: &str) -> usize {
+    coordinator().cancel_agent(agent_id)
+}
+
+pub fn memory_job_metrics() -> MemoryJobMetricsSnapshot {
+    coordinator().metrics()
+}
+
+/// Resolve the current (not session-snapshotted) agent policy immediately
+/// before expensive work. This makes the settings switch a real hot gate.
+pub fn memory_job_is_enabled(agent_id: &str, kind: MemoryJobKind) -> bool {
+    let config = crate::definitions::resolve_learnings_for(agent_id);
+    match kind {
+        MemoryJobKind::SessionMemory
+        | MemoryJobKind::Reflection
+        | MemoryJobKind::ActiveObservation
+        | MemoryJobKind::LearningsConsolidation => config.enabled,
+        MemoryJobKind::WorkspaceExtraction => config.enabled && config.extract_memories_enabled,
+        MemoryJobKind::AutoDream => config.enabled && config.auto_dream_enabled,
+    }
+}
+
+/// Cancel only the kinds that the agent's freshly persisted policy disables.
+/// Called after an Agent Definition update so running work observes the switch
+/// immediately instead of waiting for the next session launch.
+pub fn cancel_disabled_memory_jobs_for_agent(agent_id: &str) -> usize {
+    let config = crate::definitions::resolve_learnings_for(agent_id);
+    coordinator().cancel_where(|key, slot| {
+        slot.agent_id.as_deref() == Some(agent_id)
+            && match key.kind {
+                MemoryJobKind::SessionMemory
+                | MemoryJobKind::Reflection
+                | MemoryJobKind::ActiveObservation
+                | MemoryJobKind::LearningsConsolidation => !config.enabled,
+                MemoryJobKind::WorkspaceExtraction => {
+                    !config.enabled || !config.extract_memories_enabled
+                }
+                MemoryJobKind::AutoDream => !config.enabled || !config.auto_dream_enabled,
+            }
+    })
+}
+
+/// RAII bridge from a coordinator cancellation token into the atomic flag
+/// consumed by `execute_turn` and side-query retries.
+pub struct CancelFlagBridge {
+    flag: Arc<std::sync::atomic::AtomicBool>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl CancelFlagBridge {
+    pub fn flag(&self) -> &Arc<std::sync::atomic::AtomicBool> {
+        &self.flag
+    }
+}
+
+impl Drop for CancelFlagBridge {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+pub fn bridge_cancel_flag(cancel: CancellationToken) -> CancelFlagBridge {
+    let flag = Arc::new(std::sync::atomic::AtomicBool::new(cancel.is_cancelled()));
+    let task_flag = Arc::clone(&flag);
+    let task = tokio::spawn(async move {
+        cancel.cancelled().await;
+        task_flag.store(true, Ordering::SeqCst);
+    });
+    CancelFlagBridge { flag, task }
+}
+
+/// Acquire the same global memory budget for an inline owner such as the
+/// single consolidation tick. The returned permit releases on drop.
+pub async fn acquire_memory_permit() -> Result<tokio::sync::OwnedSemaphorePermit, String> {
+    Arc::clone(&coordinator().permits)
+        .acquire_owned()
+        .await
+        .map_err(|_| "memory background coordinator is shutting down".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn test_job<F, Fut>(session: &str, kind: MemoryJobKind, run: F) -> MemoryJob
+    where
+        F: FnOnce(CancellationToken) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<(), String>> + Send + 'static,
+    {
+        MemoryJob::new(
+            session,
+            Some("agent:test".to_string()),
+            kind,
+            Duration::from_secs(2),
+            run,
+        )
+    }
+
+    #[tokio::test]
+    async fn global_permit_caps_parallel_jobs() {
+        let coordinator = MemoryJobCoordinator::new(1);
+        let running = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+
+        for session in ["a", "b"] {
+            let running = Arc::clone(&running);
+            let peak = Arc::clone(&peak);
+            coordinator.submit(test_job(
+                session,
+                MemoryJobKind::Reflection,
+                move |_| async move {
+                    let now = running.fetch_add(1, Ordering::SeqCst) + 1;
+                    peak.fetch_max(now, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(40)).await;
+                    running.fetch_sub(1, Ordering::SeqCst);
+                    Ok(())
+                },
+            ));
+        }
+
+        coordinator.wait_for_idle().await;
+        assert_eq!(peak.load(Ordering::SeqCst), 1);
+        assert_eq!(coordinator.metrics().completed, 2);
+    }
+
+    #[tokio::test]
+    async fn same_key_keeps_only_latest_pending_job() {
+        let coordinator = MemoryJobCoordinator::new(1);
+        let gate = Arc::new(Notify::new());
+        let seen = Arc::new(Mutex::new(Vec::new()));
+
+        let gate_first = Arc::clone(&gate);
+        let seen_first = Arc::clone(&seen);
+        assert_eq!(
+            coordinator.submit(test_job(
+                "s",
+                MemoryJobKind::WorkspaceExtraction,
+                move |_| async move {
+                    seen_first.lock().unwrap().push(1);
+                    gate_first.notified().await;
+                    Ok(())
+                }
+            )),
+            MemoryJobSubmission::Started
+        );
+
+        tokio::task::yield_now().await;
+        for value in [2, 3] {
+            let seen = Arc::clone(&seen);
+            assert_eq!(
+                coordinator.submit(test_job(
+                    "s",
+                    MemoryJobKind::WorkspaceExtraction,
+                    move |_| async move {
+                        seen.lock().unwrap().push(value);
+                        Ok(())
+                    }
+                )),
+                MemoryJobSubmission::Coalesced
+            );
+        }
+        gate.notify_waiters();
+
+        coordinator.wait_for_idle().await;
+        assert_eq!(*seen.lock().unwrap(), vec![1, 3]);
+        assert_eq!(coordinator.metrics().coalesced, 2);
+    }
+
+    #[tokio::test]
+    async fn session_cancel_stops_active_and_drops_pending() {
+        let coordinator = MemoryJobCoordinator::new(1);
+        let cleanup_outcome = Arc::new(Mutex::new(None));
+        let cleanup = Arc::clone(&cleanup_outcome);
+        let active = test_job(
+            "s",
+            MemoryJobKind::SessionMemory,
+            move |cancel| async move {
+                cancel.cancelled().await;
+                Ok(())
+            },
+        )
+        .with_cleanup(move |outcome| async move {
+            *cleanup.lock().unwrap() = Some(outcome);
+        });
+        coordinator.submit(active);
+        coordinator.submit(test_job("s", MemoryJobKind::SessionMemory, |_| async {
+            Ok(())
+        }));
+
+        tokio::task::yield_now().await;
+        assert_eq!(coordinator.cancel_session("s"), 1);
+        coordinator.wait_for_idle().await;
+
+        assert_eq!(
+            *cleanup_outcome.lock().unwrap(),
+            Some(MemoryJobOutcome::Cancelled)
+        );
+        assert_eq!(coordinator.metrics().started, 1);
+        assert_eq!(coordinator.metrics().completed, 0);
+    }
+
+    #[tokio::test]
+    async fn submissions_hold_only_lightweight_captures_until_admitted() {
+        let coordinator = MemoryJobCoordinator::new(1);
+        let gate = Arc::new(Notify::new());
+        let gate_first = Arc::clone(&gate);
+        coordinator.submit(test_job(
+            "busy",
+            MemoryJobKind::SessionMemory,
+            move |_| async move {
+                gate_first.notified().await;
+                Ok(())
+            },
+        ));
+        tokio::task::yield_now().await;
+
+        let transcript_owner = Arc::new(vec![0_u8; 1024 * 1024]);
+        let weak = Arc::downgrade(&transcript_owner);
+        let lightweight_id = "session-id-only".to_string();
+        coordinator.submit(test_job(
+            "queued",
+            MemoryJobKind::WorkspaceExtraction,
+            move |_| async move {
+                assert_eq!(lightweight_id, "session-id-only");
+                Ok(())
+            },
+        ));
+        drop(transcript_owner);
+
+        assert!(
+            weak.upgrade().is_none(),
+            "queued job must not retain an in-memory transcript"
+        );
+        gate.notify_waiters();
+        coordinator.wait_for_idle().await;
+    }
+
+    #[tokio::test]
+    async fn debounce_replaces_waiting_generation() {
+        let coordinator = MemoryJobCoordinator::new(1);
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let first = Arc::clone(&seen);
+        coordinator.submit(
+            test_job("s", MemoryJobKind::Reflection, move |_| async move {
+                first.lock().unwrap().push(1);
+                Ok(())
+            })
+            .with_debounce(Duration::from_millis(50)),
+        );
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        let second = Arc::clone(&seen);
+        coordinator.submit(
+            test_job("s", MemoryJobKind::Reflection, move |_| async move {
+                second.lock().unwrap().push(2);
+                Ok(())
+            })
+            .with_debounce(Duration::from_millis(20)),
+        );
+
+        coordinator.wait_for_idle().await;
+        assert_eq!(*seen.lock().unwrap(), vec![2]);
+        assert_eq!(coordinator.metrics().completed, 1);
+    }
+
+    #[tokio::test]
+    async fn timeout_runs_cleanup() {
+        let coordinator = MemoryJobCoordinator::new(1);
+        let cleanup_outcome = Arc::new(Mutex::new(None));
+        let cleanup = Arc::clone(&cleanup_outcome);
+        let job = MemoryJob::new(
+            "s",
+            Some("agent:test".to_string()),
+            MemoryJobKind::AutoDream,
+            Duration::from_millis(20),
+            |_| async {
+                std::future::pending::<()>().await;
+                Ok(())
+            },
+        )
+        .with_cleanup(move |outcome| async move {
+            *cleanup.lock().unwrap() = Some(outcome);
+        });
+        coordinator.submit(job);
+
+        coordinator.wait_for_idle().await;
+        assert_eq!(
+            *cleanup_outcome.lock().unwrap(),
+            Some(MemoryJobOutcome::TimedOut)
+        );
+        assert_eq!(coordinator.metrics().timed_out, 1);
+    }
+}

--- a/src-tauri/crates/agent-core/src/specialization/memory/background.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/background.rs
@@ -51,6 +51,16 @@ impl MemoryJobKind {
             Self::ActiveObservation => "active_observation",
         }
     }
+
+    /// Session-memory extraction is context-pipeline work: one bounded side
+    /// query to the fast sibling model with a 60s deadline, needed promptly
+    /// so SM-compact has fresh content. It runs as soon as its turn ends —
+    /// still slot-owned (latest-only, cancelled by new turns/teardown) but
+    /// never queued behind minutes-long evolution jobs. The heavy forked
+    /// agents keep sharing the bounded global permit.
+    fn uses_global_permit(self) -> bool {
+        !matches!(self, Self::SessionMemory)
+    }
 }
 
 /// Terminal status passed to the mandatory cleanup hook.
@@ -323,19 +333,24 @@ impl MemoryJobCoordinator {
             }
         }
 
-        let permit = tokio::select! {
-            biased;
-            _ = slot_cancel.cancelled() => {
-                self.metrics.cancelled.fetch_add(1, Ordering::Relaxed);
-                return MemoryJobOutcome::Cancelled;
-            }
-            permit = Arc::clone(&self.permits).acquire_owned() => match permit {
-                Ok(permit) => permit,
-                Err(_) => {
+        let permit = if key.kind.uses_global_permit() {
+            let permit = tokio::select! {
+                biased;
+                _ = slot_cancel.cancelled() => {
                     self.metrics.cancelled.fetch_add(1, Ordering::Relaxed);
                     return MemoryJobOutcome::Cancelled;
                 }
-            }
+                permit = Arc::clone(&self.permits).acquire_owned() => match permit {
+                    Ok(permit) => permit,
+                    Err(_) => {
+                        self.metrics.cancelled.fetch_add(1, Ordering::Relaxed);
+                        return MemoryJobOutcome::Cancelled;
+                    }
+                }
+            };
+            Some(permit)
+        } else {
+            None
         };
 
         if slot_cancel.is_cancelled() {
@@ -737,6 +752,49 @@ mod tests {
         coordinator.wait_for_idle().await;
         assert_eq!(*seen.lock().unwrap(), vec![2]);
         assert_eq!(coordinator.metrics().completed, 1);
+    }
+
+    #[tokio::test]
+    async fn session_memory_bypasses_global_permit() {
+        let coordinator = MemoryJobCoordinator::new(1);
+        let gate = Arc::new(Notify::new());
+        let gate_heavy = Arc::clone(&gate);
+        coordinator.submit(test_job(
+            "heavy",
+            MemoryJobKind::WorkspaceExtraction,
+            move |_| async move {
+                gate_heavy.notified().await;
+                Ok(())
+            },
+        ));
+        tokio::task::yield_now().await;
+
+        let sm_done = Arc::new(AtomicUsize::new(0));
+        let sm_flag = Arc::clone(&sm_done);
+        coordinator.submit(test_job(
+            "sm",
+            MemoryJobKind::SessionMemory,
+            move |_| async move {
+                sm_flag.store(1, Ordering::SeqCst);
+                Ok(())
+            },
+        ));
+
+        for _ in 0..100 {
+            if sm_done.load(Ordering::SeqCst) == 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(
+            sm_done.load(Ordering::SeqCst),
+            1,
+            "session-memory job must run while the heavy job holds the only permit"
+        );
+
+        gate.notify_waiters();
+        coordinator.wait_for_idle().await;
+        assert_eq!(coordinator.metrics().completed, 2);
     }
 
     #[tokio::test]

--- a/src-tauri/crates/agent-core/src/specialization/memory/commands.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/commands.rs
@@ -92,7 +92,14 @@ pub async fn session_trigger_reflection(
     state: tauri::State<'_, AgentAppState>,
     session_id: String,
 ) -> Result<ReflectionResult, String> {
-    let _permit = crate::memory::background::acquire_memory_permit().await?;
+    let _permit = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        crate::memory::background::acquire_memory_permit(),
+    )
+    .await
+    .map_err(|_| {
+        "Memory system is busy with background work; try again in a moment".to_string()
+    })??;
     let count = tokio::time::timeout(
         std::time::Duration::from_secs(120),
         crate::memory::reflection::maybe_reflect_on_session(&session_id),

--- a/src-tauri/crates/agent-core/src/specialization/memory/commands.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/commands.rs
@@ -92,7 +92,13 @@ pub async fn session_trigger_reflection(
     state: tauri::State<'_, AgentAppState>,
     session_id: String,
 ) -> Result<ReflectionResult, String> {
-    let count = crate::memory::reflection::maybe_reflect_on_session(&session_id).await?;
+    let _permit = crate::memory::background::acquire_memory_permit().await?;
+    let count = tokio::time::timeout(
+        std::time::Duration::from_secs(120),
+        crate::memory::reflection::maybe_reflect_on_session(&session_id),
+    )
+    .await
+    .map_err(|_| "Manual reflection timed out after 120s".to_string())??;
     if count > 0 {
         state
             .invalidate_prompt_caches(PromptCacheInvalidationReason::LearningsChanged)

--- a/src-tauri/crates/agent-core/src/specialization/memory/consolidation/tick.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/consolidation/tick.rs
@@ -134,12 +134,32 @@ async fn drive_scopes(conn: &Connection, scopes: Vec<String>, forced: bool, idle
             scope,
             trigger.as_str()
         );
-        if let Err(err) = consolidate(&scope, trigger).await {
-            warn!(
-                "[consolidation] tick scope={} consolidate failed: {}",
-                scope, err
-            );
-        }
+        let consolidation = async {
+            let _permit = match crate::memory::background::acquire_memory_permit().await {
+                Ok(permit) => permit,
+                Err(err) => {
+                    warn!(
+                        "[consolidation] tick scope={} admission failed: {}",
+                        scope, err
+                    );
+                    return;
+                }
+            };
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(300),
+                consolidate(&scope, trigger),
+            )
+            .await
+            {
+                Ok(Ok(_)) => {}
+                Ok(Err(err)) => warn!(
+                    "[consolidation] tick scope={} consolidate failed: {}",
+                    scope, err
+                ),
+                Err(_) => warn!("[consolidation] tick scope={} timed out after 300s", scope),
+            }
+        };
+        consolidation.await;
     }
 }
 

--- a/src-tauri/crates/agent-core/src/specialization/memory/mod.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/mod.rs
@@ -35,6 +35,7 @@
 //! `core/model_context/session_memory.rs` because it is part of the
 //! per-turn context-window pipeline, not long-term memory.
 
+pub mod background;
 pub mod commands;
 pub mod consolidation;
 pub mod embeddings;
@@ -52,4 +53,8 @@ pub struct MemoryAgentParams<'a> {
     pub parent_tools: std::sync::Arc<crate::tools::registry::ToolRegistry>,
     pub session_id: &'a str,
     pub definitions_store: Option<std::sync::Arc<crate::definitions::AgentDefinitionsStore>>,
+    /// Coordinator-owned cancellation for this exact background job. Memory
+    /// agent turn loops receive this flag so disabling/teardown stops provider
+    /// retries and tool iterations instead of merely dropping the outer future.
+    pub cancel_flag: Option<&'a std::sync::Arc<std::sync::atomic::AtomicBool>>,
 }

--- a/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/auto_dream.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/auto_dream.rs
@@ -109,9 +109,10 @@ pub async fn run_consolidation(params: super::super::MemoryAgentParams<'_>) -> R
         return Ok(());
     }
 
-    // Lock gate: try to acquire
-    let prior_mtime = match consolidation_lock::try_acquire(workspace) {
-        Ok(Some(prior)) => prior,
+    // Lock gate: the RAII lease rolls back on provider failure, timeout or
+    // coordinator cancellation. Only the success arm commits it.
+    let lease = match consolidation_lock::try_acquire_lease(workspace) {
+        Ok(Some(lease)) => lease,
         Ok(None) => {
             info!("[auto_dream] skip — lock held by another process");
             return Ok(());
@@ -130,7 +131,6 @@ pub async fn run_consolidation(params: super::super::MemoryAgentParams<'_>) -> R
 
     // Ensure memory dir exists
     if let Err(err) = std::fs::create_dir_all(&mem_dir) {
-        consolidation_lock::rollback(workspace, prior_mtime);
         return Err(format!("Failed to create memory dir: {}", err));
     }
 
@@ -140,7 +140,6 @@ pub async fn run_consolidation(params: super::super::MemoryAgentParams<'_>) -> R
         {
             Ok(def) => def,
             Err(err) => {
-                consolidation_lock::rollback(workspace, prior_mtime);
                 return Err(format!("Agent def not found: {}", err));
             }
         };
@@ -214,14 +213,14 @@ pub async fn run_consolidation(params: super::super::MemoryAgentParams<'_>) -> R
         &subagent_session_id,
         &handler,
         None,
-        None,
+        params.cancel_flag,
         None,
     )
     .await;
 
     match result {
         Ok(turn_result) => {
-            // Lock mtime already advanced by write — consolidation recorded.
+            lease.commit();
             info!(
                 "[auto_dream] Completed: session={}, tokens={}",
                 session_id, turn_result.total_tokens
@@ -229,8 +228,7 @@ pub async fn run_consolidation(params: super::super::MemoryAgentParams<'_>) -> R
             Ok(())
         }
         Err(err) => {
-            warn!("[auto_dream] Error: {}, rolling back lock", err);
-            consolidation_lock::rollback(workspace, prior_mtime);
+            warn!("[auto_dream] Error: {}", err);
             Err(format!("Consolidation failed: {}", err))
         }
     }

--- a/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/extract/gating.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/extract/gating.rs
@@ -36,6 +36,7 @@ const EXTRACTION_INTERVAL: u32 = 1;
 pub fn should_extract(
     state: &ExtractMemoriesState,
     messages: &[Value],
+    start_seqs: &[i64],
     workspace: Option<&Path>,
 ) -> bool {
     if state.in_progress {
@@ -46,16 +47,23 @@ pub fn should_extract(
         return false;
     }
 
-    let new_count = count_new_messages(messages, state.last_processed_idx);
+    let new_count = count_new_messages(start_seqs, state.last_processed_seq);
     if new_count < MIN_NEW_MESSAGES {
         return false;
     }
 
-    if has_memory_writes_since(messages, state.last_processed_idx, workspace.unwrap()) {
+    if has_memory_writes_since(
+        messages,
+        start_seqs,
+        state.last_processed_seq,
+        workspace.unwrap(),
+    ) {
         return false;
     }
 
-    state.turns_since_extraction + 1 >= EXTRACTION_INTERVAL
+    // The turn counter advances at post-turn dispatch (before this gate
+    // runs), so the current turn is already included — no `+ 1` here.
+    state.turns_since_extraction >= EXTRACTION_INTERVAL
 }
 
 /// Returns true if the current turn should be skipped *because the main
@@ -70,13 +78,14 @@ pub fn should_extract(
 pub fn skip_if_main_agent_wrote_memory(
     state: &mut ExtractMemoriesState,
     messages: &[Value],
+    start_seqs: &[i64],
     workspace: &Path,
 ) -> bool {
-    if !has_memory_writes_since(messages, state.last_processed_idx, workspace) {
+    if !has_memory_writes_since(messages, start_seqs, state.last_processed_seq, workspace) {
         return false;
     }
-    if !messages.is_empty() {
-        state.last_processed_idx = Some(messages.len() - 1);
+    if let Some(last_seq) = start_seqs.last() {
+        state.last_processed_seq = Some(*last_seq);
     }
     true
 }
@@ -87,16 +96,20 @@ pub fn record_turn(state: &mut ExtractMemoriesState) {
     state.turns_since_extraction += 1;
 }
 
-/// Count new messages since the cursor (any role).
+/// Count new messages since the sequence cursor (any role).
 ///
 /// Tool-heavy agents append many `tool_use` / `tool_result` blocks per turn;
 /// counting only user+assistant prevented `extract_memories` from ever firing.
-pub(super) fn count_new_messages(messages: &[Value], since_idx: Option<usize>) -> usize {
-    let start = match since_idx {
-        Some(idx) => idx + 1,
+pub(super) fn count_new_messages(start_seqs: &[i64], since_seq: Option<i64>) -> usize {
+    start_seqs.len() - cursor_start(start_seqs, since_seq)
+}
+
+/// First index in the frame that is *after* the sequence cursor.
+fn cursor_start(start_seqs: &[i64], since_seq: Option<i64>) -> usize {
+    match since_seq {
+        Some(seq) => start_seqs.partition_point(|s| *s <= seq),
         None => 0,
-    };
-    messages.get(start..).map(|slice| slice.len()).unwrap_or(0)
+    }
 }
 
 /// Check if any assistant message after the cursor wrote to memory files.
@@ -116,11 +129,13 @@ pub(super) fn count_new_messages(messages: &[Value], since_idx: Option<usize>) -
 /// returned `false` in production and mutual exclusion was effectively
 /// disabled — a main-agent write would still trigger the extract fork,
 /// which then raced / overwrote the main agent's file.
-fn has_memory_writes_since(messages: &[Value], since_idx: Option<usize>, workspace: &Path) -> bool {
-    let start = match since_idx {
-        Some(idx) => idx + 1,
-        None => 0,
-    };
+fn has_memory_writes_since(
+    messages: &[Value],
+    start_seqs: &[i64],
+    since_seq: Option<i64>,
+    workspace: &Path,
+) -> bool {
+    let start = cursor_start(start_seqs, since_seq);
 
     let Some(new_messages) = messages.get(start..) else {
         return false;
@@ -195,6 +210,10 @@ mod tests {
         serde_json::json!({ "role": role, "content": content })
     }
 
+    fn seqs_for(messages: &[Value]) -> Vec<i64> {
+        (0..messages.len() as i64).collect()
+    }
+
     fn openai_edit_file_message(file_path: &str) -> Value {
         serde_json::json!({
             "role": "assistant",
@@ -222,10 +241,11 @@ mod tests {
             make_message("assistant", "Good!"),
         ];
 
-        assert_eq!(count_new_messages(&messages, None), 5);
-        assert_eq!(count_new_messages(&messages, Some(0)), 4);
-        assert_eq!(count_new_messages(&messages, Some(2)), 2);
-        assert_eq!(count_new_messages(&messages, Some(4)), 0);
+        let seqs = seqs_for(&messages);
+        assert_eq!(count_new_messages(&seqs, None), 5);
+        assert_eq!(count_new_messages(&seqs, Some(0)), 4);
+        assert_eq!(count_new_messages(&seqs, Some(2)), 2);
+        assert_eq!(count_new_messages(&seqs, Some(4)), 0);
     }
 
     #[test]
@@ -238,13 +258,15 @@ mod tests {
             serde_json::json!({ "role": "tool_result", "content": "file content" }),
         ];
 
-        assert_eq!(count_new_messages(&messages, None), 5);
-        assert_eq!(count_new_messages(&messages, Some(1)), 3);
+        let seqs = seqs_for(&messages);
+        assert_eq!(count_new_messages(&seqs, None), 5);
+        assert_eq!(count_new_messages(&seqs, Some(1)), 3);
     }
 
     #[test]
     fn test_should_extract_basic() {
         let mut state = ExtractMemoriesState::default();
+        record_turn(&mut state);
         let messages = vec![
             make_message("system", "system"),
             make_message("user", "hello"),
@@ -252,10 +274,12 @@ mod tests {
             make_message("user", "question"),
             make_message("assistant", "answer"),
         ];
+        let seqs = seqs_for(&messages);
 
         assert!(should_extract(
             &state,
             &messages,
+            &seqs,
             Some(Path::new("/tmp/workspace"))
         ));
 
@@ -263,21 +287,25 @@ mod tests {
         assert!(!should_extract(
             &state,
             &messages,
+            &seqs,
             Some(Path::new("/tmp/workspace"))
         ));
         state.in_progress = false;
 
-        assert!(!should_extract(&state, &messages, None));
+        assert!(!should_extract(&state, &messages, &seqs, None));
     }
 
     #[test]
     fn test_should_extract_not_enough_messages() {
-        let state = ExtractMemoriesState::default();
+        let mut state = ExtractMemoriesState::default();
+        record_turn(&mut state);
         let messages = vec![make_message("system", "system")];
+        let seqs = seqs_for(&messages);
 
         assert!(!should_extract(
             &state,
             &messages,
+            &seqs,
             Some(Path::new("/tmp/workspace"))
         ));
     }
@@ -292,9 +320,20 @@ mod tests {
             openai_edit_file_message("/home/user/workspace/.orgii/workspace-memory/prefs.md"),
         ];
 
-        assert!(has_memory_writes_since(&messages, None, workspace));
-        assert!(has_memory_writes_since(&messages, Some(0), workspace));
-        assert!(!has_memory_writes_since(&messages, Some(2), workspace));
+        let seqs = seqs_for(&messages);
+        assert!(has_memory_writes_since(&messages, &seqs, None, workspace));
+        assert!(has_memory_writes_since(
+            &messages,
+            &seqs,
+            Some(0),
+            workspace
+        ));
+        assert!(!has_memory_writes_since(
+            &messages,
+            &seqs,
+            Some(2),
+            workspace
+        ));
     }
 
     #[test]
@@ -305,7 +344,13 @@ mod tests {
             openai_edit_file_message("/home/user/workspace/.orgii/workspace-memory/prefs.md"),
         ];
 
-        assert!(!has_memory_writes_since(&messages, Some(231), workspace));
+        let seqs = seqs_for(&messages);
+        assert!(!has_memory_writes_since(
+            &messages,
+            &seqs,
+            Some(231),
+            workspace
+        ));
     }
 
     #[test]
@@ -317,7 +362,12 @@ mod tests {
             openai_edit_file_message("/home/user/workspace/src/main.rs"),
         ];
 
-        assert!(!has_memory_writes_since(&messages, None, workspace));
+        assert!(!has_memory_writes_since(
+            &messages,
+            &seqs_for(&messages),
+            None,
+            workspace
+        ));
     }
 
     #[test]
@@ -347,7 +397,12 @@ mod tests {
             }]
         })];
 
-        assert!(!has_memory_writes_since(&messages, None, workspace));
+        assert!(!has_memory_writes_since(
+            &messages,
+            &seqs_for(&messages),
+            None,
+            workspace
+        ));
     }
 
     #[test]
@@ -358,7 +413,12 @@ mod tests {
             "/home/user/workspace/.orgii/workspace-memory/subdir/nested.md",
         )];
 
-        assert!(has_memory_writes_since(&messages, None, workspace));
+        assert!(has_memory_writes_since(
+            &messages,
+            &seqs_for(&messages),
+            None,
+            workspace
+        ));
     }
 
     #[test]
@@ -378,7 +438,12 @@ mod tests {
             }]
         })];
 
-        assert!(!has_memory_writes_since(&messages, None, workspace));
+        assert!(!has_memory_writes_since(
+            &messages,
+            &seqs_for(&messages),
+            None,
+            workspace
+        ));
     }
 
     #[test]
@@ -440,18 +505,19 @@ mod tests {
             openai_edit_file_message("/home/user/workspace/.orgii/workspace-memory/prefs.md"),
         ];
 
+        let seqs = seqs_for(&messages);
         assert!(
-            skip_if_main_agent_wrote_memory(&mut state, &messages, workspace),
+            skip_if_main_agent_wrote_memory(&mut state, &messages, &seqs, workspace),
             "main-agent write should trigger skip"
         );
         assert_eq!(
-            state.last_processed_idx,
-            Some(messages.len() - 1),
+            state.last_processed_seq,
+            seqs.last().copied(),
             "cursor must advance to end of transcript"
         );
 
         assert!(
-            !skip_if_main_agent_wrote_memory(&mut state, &messages, workspace),
+            !skip_if_main_agent_wrote_memory(&mut state, &messages, &seqs, workspace),
             "cursor advance prevents re-detection next turn"
         );
     }
@@ -468,11 +534,16 @@ mod tests {
         ];
 
         assert!(
-            !skip_if_main_agent_wrote_memory(&mut state, &messages, workspace),
+            !skip_if_main_agent_wrote_memory(
+                &mut state,
+                &messages,
+                &seqs_for(&messages),
+                workspace
+            ),
             "non-memory edits must not trigger skip"
         );
         assert!(
-            state.last_processed_idx.is_none(),
+            state.last_processed_seq.is_none(),
             "cursor must NOT move when skip is not triggered"
         );
     }

--- a/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/extract/gating.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/extract/gating.rs
@@ -1,9 +1,8 @@
 //! Gating + cursor-advance helpers for the extraction subsystem.
 //!
-//! Pure logic over `ExtractMemoriesState` + the in-memory message slice —
-//! decides "should we even fork an extractor this turn?", advances the
-//! cursor past main-agent memory writes, and coalesces the
-//! trailing-run stash.
+//! Pure logic over `ExtractMemoriesState` + a durable message snapshot —
+//! decides whether to fork an extractor and advances the cursor past
+//! main-agent memory writes.
 
 use serde_json::Value;
 use std::path::Path;
@@ -80,31 +79,6 @@ pub fn skip_if_main_agent_wrote_memory(
         state.last_processed_idx = Some(messages.len() - 1);
     }
     true
-}
-
-/// Stash the latest messages while an extraction is in flight.
-///
-/// Called by the processor when `in_progress` has blocked a would-be
-/// extraction. Overwrites any prior stash — only the *latest* transcript
-/// matters because it already contains the older ones as a prefix.
-///
-/// Returns `true` if there was no existing stash (informational only; the
-/// coalesce behavior does not depend on it).
-pub fn stash_pending(state: &mut ExtractMemoriesState, messages: &[Value]) -> bool {
-    let was_empty = state.pending_messages.is_none();
-    state.pending_messages = Some(messages.to_vec());
-    was_empty
-}
-
-/// Drain the stashed trailing-run messages, if any.
-///
-/// The processor's spawned extraction task calls this after each
-/// `run_extraction` completes. When `Some`, the task issues one more
-/// extraction round with those messages. This is the key fix for the
-/// "second turn during a long extraction silently vanishes" hole that
-/// a drop-on-conflict policy would have.
-pub fn take_pending(state: &mut ExtractMemoriesState) -> Option<Vec<Value>> {
-    state.pending_messages.take()
 }
 
 /// Record a turn (increment counter). Call this every turn regardless
@@ -453,31 +427,6 @@ mod tests {
             }
         });
         assert_eq!(extract_written_path(&malformed), None);
-    }
-
-    #[test]
-    fn test_stash_pending_overwrites_latest() {
-        let mut state = ExtractMemoriesState::default();
-
-        let first = vec![make_message("user", "one")];
-        assert!(
-            stash_pending(&mut state, &first),
-            "first stash should report empty prior state"
-        );
-
-        let second = vec![
-            make_message("user", "one"),
-            make_message("assistant", "ack"),
-            make_message("user", "two"),
-        ];
-        assert!(
-            !stash_pending(&mut state, &second),
-            "subsequent stash should report already-stashed"
-        );
-
-        let drained = take_pending(&mut state).expect("pending should be present");
-        assert_eq!(drained.len(), 3, "latest stash wins — coalesce semantics");
-        assert!(take_pending(&mut state).is_none(), "take_pending drains");
     }
 
     #[test]

--- a/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/extract/mod.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/extract/mod.rs
@@ -8,8 +8,7 @@
 //!   fields are `pub(super)` so only the gating helpers and the runner can
 //!   mutate them.
 //! - **`gating`** — `should_extract`, `skip_if_main_agent_wrote_memory`,
-//!   `stash_pending`, `take_pending`, `record_turn`, plus the cursor /
-//!   memory-write inspection helpers.
+//!   `record_turn`, plus the cursor / memory-write inspection helpers.
 //! - **`runner`** — `run_extraction` (the forked-agent invocation),
 //!   prompt building, and the allow-list tool policy.
 //!
@@ -21,9 +20,7 @@ mod gating;
 mod runner;
 mod state;
 
-pub use gating::{
-    record_turn, should_extract, skip_if_main_agent_wrote_memory, stash_pending, take_pending,
-};
+pub use gating::{record_turn, should_extract, skip_if_main_agent_wrote_memory};
 pub use runner::run_extraction;
 pub use state::ExtractMemoriesState;
 

--- a/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/extract/runner.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/extract/runner.rs
@@ -32,18 +32,19 @@ const MAX_EXTRACTION_TURNS: u32 = 5;
 pub async fn run_extraction(
     em_state: Arc<Mutex<ExtractMemoriesState>>,
     params: super::super::super::MemoryAgentParams<'_>,
+    start_seqs: &[i64],
 ) -> Result<(), String> {
     // ── Prepare: brief lock to flag in-progress + read the cursor. The mutex
     // is NOT held across the fork/LLM call below — otherwise the next turn's
-    // brief `em_state` reads (the gate pre-check that decides whether to
-    // stash) would block for the whole extraction. The `in_progress` flag
-    // (kept true until finalize) is what preserves the "at most one extractor"
-    // invariant during the lock-free window.
-    let last_processed_idx = {
+    // brief `em_state` reads (the gate pre-check) would block for the whole
+    // extraction. The `in_progress` flag (kept true until finalize) is what
+    // preserves the "at most one extractor" invariant during the lock-free
+    // window.
+    let last_processed_seq = {
         let mut state = em_state.lock().await;
         state.in_progress = true;
         state.turns_since_extraction = 0;
-        state.last_processed_idx
+        state.last_processed_seq
     };
 
     let workspace = params.workspace;
@@ -67,7 +68,7 @@ pub async fn run_extraction(
         };
 
     let messages = params.messages;
-    let new_count = count_new_messages(messages, last_processed_idx);
+    let new_count = count_new_messages(start_seqs, last_processed_seq);
     let existing_memories =
         super::super::format_memory_manifest(&super::super::scan_memory_files(&mem_dir));
     let user_prompt = build_extraction_prompt(new_count, &existing_memories, &mem_dir);
@@ -145,7 +146,9 @@ pub async fn run_extraction(
 
     match result {
         Ok(turn_result) => {
-            state.last_processed_idx = Some(messages.len().saturating_sub(1));
+            if let Some(last_seq) = start_seqs.last() {
+                state.last_processed_seq = Some(*last_seq);
+            }
 
             info!(
                 "[extract_memories] Completed: session={}, tokens={}",

--- a/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/extract/runner.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/extract/runner.rs
@@ -133,7 +133,7 @@ pub async fn run_extraction(
         &subagent_session_id,
         &handler,
         None,
-        None,
+        params.cancel_flag,
         None,
     )
     .await;

--- a/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/extract/state.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/extract/state.rs
@@ -8,9 +8,11 @@
 /// Per-session state for memory extraction. Held on `AgentSession`.
 #[derive(Debug, Default)]
 pub struct ExtractMemoriesState {
-    /// Index of the last message processed (cursor).
+    /// Durable start-sequence of the last message processed (cursor).
     /// `None` means no extraction has run yet for this session.
-    pub(super) last_processed_idx: Option<usize>,
+    /// Sequence-anchored so the bounded durable suffix each job loads can
+    /// shift without invalidating the cursor.
+    pub(super) last_processed_seq: Option<i64>,
 
     /// True while extraction is in progress (overlap guard).
     pub(super) in_progress: bool,
@@ -27,7 +29,7 @@ pub struct ExtractMemoriesState {
 /// fields as plain values that can be serialized over HTTP.
 #[derive(Debug, Clone, Copy)]
 pub struct ExtractMemoriesStateSnapshot {
-    pub last_processed_idx: Option<usize>,
+    pub last_processed_seq: Option<i64>,
     pub in_progress: bool,
     pub turns_since_extraction: u32,
 }
@@ -40,7 +42,7 @@ impl ExtractMemoriesState {
     /// needs an observable, not just a "behavior should happen" claim.
     pub fn snapshot(&self) -> ExtractMemoriesStateSnapshot {
         ExtractMemoriesStateSnapshot {
-            last_processed_idx: self.last_processed_idx,
+            last_processed_seq: self.last_processed_seq,
             in_progress: self.in_progress,
             turns_since_extraction: self.turns_since_extraction,
         }
@@ -68,7 +70,7 @@ mod tests {
     #[test]
     fn test_state_default() {
         let state = ExtractMemoriesState::default();
-        assert!(state.last_processed_idx.is_none());
+        assert!(state.last_processed_seq.is_none());
         assert!(!state.in_progress);
         assert_eq!(state.turns_since_extraction, 0);
     }

--- a/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/extract/state.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/extract/state.rs
@@ -5,10 +5,7 @@
 //! that can mutate its fields. External callers go through the public
 //! `snapshot()` getter or the `is_in_progress` accessor below.
 
-/// Per-session state for memory extraction. Held inside the processor.
-///
-/// The `pending_messages` field carries coalesce semantics — see
-/// `gating::stash_pending` / `gating::take_pending`.
+/// Per-session state for memory extraction. Held on `AgentSession`.
 #[derive(Debug, Default)]
 pub struct ExtractMemoriesState {
     /// Index of the last message processed (cursor).
@@ -20,13 +17,6 @@ pub struct ExtractMemoriesState {
 
     /// Turns since last successful extraction (for throttling).
     pub(super) turns_since_extraction: u32,
-
-    /// Messages stashed by a turn that arrived while extraction was still
-    /// running. The processor's spawned task drains this after each run
-    /// and, if present, loops for a trailing extraction. Always holds the
-    /// *latest* stash — older stashes are overwritten since only the most
-    /// recent transcript matters.
-    pub(super) pending_messages: Option<Vec<serde_json::Value>>,
 }
 
 /// Read-only snapshot of [`ExtractMemoriesState`] for debug / E2E endpoints.
@@ -40,7 +30,6 @@ pub struct ExtractMemoriesStateSnapshot {
     pub last_processed_idx: Option<usize>,
     pub in_progress: bool,
     pub turns_since_extraction: u32,
-    pub pending_messages_len: Option<usize>,
 }
 
 impl ExtractMemoriesState {
@@ -54,7 +43,6 @@ impl ExtractMemoriesState {
             last_processed_idx: self.last_processed_idx,
             in_progress: self.in_progress,
             turns_since_extraction: self.turns_since_extraction,
-            pending_messages_len: self.pending_messages.as_ref().map(|v| v.len()),
         }
     }
 
@@ -83,7 +71,6 @@ mod tests {
         assert!(state.last_processed_idx.is_none());
         assert!(!state.in_progress);
         assert_eq!(state.turns_since_extraction, 0);
-        assert!(state.pending_messages.is_none());
     }
 
     #[test]

--- a/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/lock.rs
+++ b/src-tauri/crates/agent-core/src/specialization/memory/workspace_memory/lock.rs
@@ -53,6 +53,41 @@ pub fn hours_since_last_consolidation(workspace: &Path) -> f64 {
     (now_ms.saturating_sub(last_at)) as f64 / 3_600_000.0
 }
 
+/// RAII lease for an acquired auto-dream lock. Unless committed after a
+/// successful consolidation, dropping the lease restores the prior lock
+/// timestamp. This also covers outer task timeout/cancellation, where the
+/// consolidation future is dropped before its explicit error arm runs.
+pub struct ConsolidationLease {
+    workspace: PathBuf,
+    prior_mtime_ms: u64,
+    committed: bool,
+}
+
+impl ConsolidationLease {
+    pub fn commit(mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for ConsolidationLease {
+    fn drop(&mut self) {
+        if !self.committed {
+            rollback(&self.workspace, self.prior_mtime_ms);
+        }
+    }
+}
+
+/// Try to acquire the consolidation lock as an RAII lease.
+pub fn try_acquire_lease(workspace: &Path) -> Result<Option<ConsolidationLease>, String> {
+    try_acquire(workspace).map(|prior| {
+        prior.map(|prior_mtime_ms| ConsolidationLease {
+            workspace: workspace.to_path_buf(),
+            prior_mtime_ms,
+            committed: false,
+        })
+    })
+}
+
 /// Try to acquire the consolidation lock.
 ///
 /// Returns `Ok(prior_mtime_ms)` on success, `Ok(None)` if blocked by
@@ -322,6 +357,29 @@ mod tests {
         rollback(tmp.path(), 0);
 
         assert_eq!(read_last_consolidated_at(tmp.path()), 0);
+    }
+
+    #[test]
+    fn dropped_lease_rolls_back_fresh_lock() {
+        let tmp = TempDir::new().unwrap();
+        {
+            let lease = try_acquire_lease(tmp.path())
+                .expect("acquire lease")
+                .expect("lease available");
+            assert!(read_last_consolidated_at(tmp.path()) > 0);
+            drop(lease);
+        }
+        assert_eq!(read_last_consolidated_at(tmp.path()), 0);
+    }
+
+    #[test]
+    fn committed_lease_keeps_success_timestamp() {
+        let tmp = TempDir::new().unwrap();
+        let lease = try_acquire_lease(tmp.path())
+            .expect("acquire lease")
+            .expect("lease available");
+        lease.commit();
+        assert!(read_last_consolidated_at(tmp.path()) > 0);
     }
 
     #[test]

--- a/src-tauri/crates/agent-core/src/state/commands/session/compaction.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/session/compaction.rs
@@ -12,7 +12,6 @@ use crate::core::session::compaction::persist;
 use crate::core::session::scheduler::{ScheduledKind, ScheduledMessage};
 use crate::core::turn_executor::context_accounting::ContextUsageSnapshot;
 use crate::model_context::session_memory;
-use crate::model_context::session_memory::SessionMemoryState;
 use crate::session::persistence as unified_persistence;
 use crate::state::{AgentAppState, AgentSession};
 
@@ -267,11 +266,13 @@ async fn run_manual_compact_exclusive(
             unified_persistence::load_llm_history(&sid_for_load).map_err(|err| err.to_string())?;
         let sm_state = unified_persistence::load_session_memory_state(&sid_for_load)
             .map_err(|err| err.to_string())?;
-        Ok::<_, String>((history, sm_state))
+        let start_seqs = unified_persistence::load_llm_history_start_sequences(&sid_for_load)
+            .map_err(|err| err.to_string())?;
+        Ok::<_, String>((history, sm_state, start_seqs))
     })
     .await;
 
-    let (history, sm_persisted) = match loaded {
+    let (history, sm_persisted, sm_start_seqs) = match loaded {
         Ok(Ok(pair)) => pair,
         Ok(Err(err)) => {
             let reason = format!("load session state failed: {}", err);
@@ -325,24 +326,15 @@ async fn run_manual_compact_exclusive(
     // is pre-extracted and cannot honor them.
     let mut compacted: Option<Vec<Value>> = None;
     if custom_instructions.is_none() {
-        let sm_state = SessionMemoryState {
-            content: sm_persisted.content,
-            // `sm_last_msg_idx` was recorded against the turn frame
-            // (`[runtime system message] + durable history`, see
-            // processor/mod.rs frame assembly); `history` here is
-            // `load_llm_history` output with no such prefix, so shift by
-            // the frame's one-message runtime-system prefix — the same
-            // conversion `adjust_sm_state_for_compactable_tail` performs
-            // on the auto paths. Without it the kept tail starts past
-            // messages the SM summary never covered.
-            last_summarized_msg_idx: sm_persisted.last_msg_idx.and_then(|idx| idx.checked_sub(1)),
-            ..Default::default()
-        };
+        // `history` is `load_llm_history` output — the same visible durable
+        // frame `sm_start_seqs` describes, so the anchor resolves exactly.
+        let anchor_idx =
+            session_memory::resolve_summarized_boundary_idx(sm_persisted.last_seq, &sm_start_seqs);
         if let Some(sm_view) = session_memory::try_sm_compact(
             &history,
-            &sm_state,
+            sm_persisted.content.as_deref(),
+            anchor_idx,
             &session_memory::SessionMemoryCompactConfig::default(),
-            0, // context window is unused by try_sm_compact
         ) {
             let candidate = finalize_compacted_view(&history, sm_view);
             if ContextCompactor::estimate_messages_tokens(&candidate) < tokens_before {

--- a/src-tauri/crates/agent-core/src/state/commands/session/persistence.rs
+++ b/src-tauri/crates/agent-core/src/state/commands/session/persistence.rs
@@ -92,12 +92,14 @@ pub async fn agent_delete_session(
     .map_err(|err| format!("session deletion planning worker failed: {err}"))??;
 
     let Some(plan) = plan else {
+        crate::memory::background::cancel_memory_jobs_for_session(&session_id);
         let deleted_session_id = session_id.clone();
         tokio::task::spawn_blocking(move || {
             session_persistence::delete_session(&deleted_session_id).map_err(|err| err.to_string())
         })
         .await
         .map_err(|err| format!("session deletion worker failed: {err}"))??;
+        state.remove_session(&session_id).await;
         return Ok(DeleteSessionReceipt {
             deleted_session_ids: vec![session_id],
         });

--- a/src-tauri/crates/agent-core/src/state/session_runtime.rs
+++ b/src-tauri/crates/agent-core/src/state/session_runtime.rs
@@ -216,7 +216,7 @@ pub struct AgentSession {
     pub ad_state: Arc<tokio::sync::Mutex<AutoDreamState>>,
     /// Per-session state for the background extract-memories hook.
     ///
-    /// Carries the message cursor (`last_processed_idx`), the in-progress
+    /// Carries the message cursor (`last_processed_seq`), the in-progress
     /// overlap guard, and the turns-since-last-extraction throttle counter.
     /// Pending work is lightweight and coordinator-owned; this state never
     /// retains transcript copies across turns.

--- a/src-tauri/crates/agent-core/src/state/session_runtime.rs
+++ b/src-tauri/crates/agent-core/src/state/session_runtime.rs
@@ -15,6 +15,7 @@ use crate::memory::workspace_memory::auto_dream::AutoDreamState;
 use crate::memory::workspace_memory::extract::ExtractMemoriesState;
 use crate::memory::workspace_memory::surface_state::WorkspaceMemorySurfaceState;
 use crate::model_context::compaction::CompactionState;
+use crate::model_context::session_memory::SessionMemoryState;
 use crate::providers::traits::LLMProvider;
 use crate::session::plan_mode::{
     LastNonPlanModeCache, PlanSlotCache, PrePlanModeCache, RequestedExecModeCache,
@@ -202,6 +203,10 @@ pub struct AgentSession {
     /// Wingman mode state — holds the active background observation loop.
     /// `None` handle inside means Wingman is not currently running.
     pub wingman: WingmanSessionState,
+    /// L1 session-memory state. This must share the AgentSession lifetime:
+    /// the processor is reconstructed per turn, while extraction is
+    /// coordinator-owned and may finish after that processor is dropped.
+    pub sm_state: Arc<tokio::sync::Mutex<SessionMemoryState>>,
     /// Per-session state for the background auto-dream (consolidation) hook.
     ///
     /// Carries the `last_scan_at` scan-throttle timestamp across turns.
@@ -212,9 +217,9 @@ pub struct AgentSession {
     /// Per-session state for the background extract-memories hook.
     ///
     /// Carries the message cursor (`last_processed_idx`), the in-progress
-    /// overlap guard, the turns-since-last-extraction throttle counter,
-    /// and the `pending_messages` stash across turns. Held on the session
-    /// for the same reason as `ad_state`.
+    /// overlap guard, and the turns-since-last-extraction throttle counter.
+    /// Pending work is lightweight and coordinator-owned; this state never
+    /// retains transcript copies across turns.
     pub em_state: Arc<tokio::sync::Mutex<ExtractMemoriesState>>,
     /// Rendered stable system-prompt sections for this live session.
     ///
@@ -312,6 +317,7 @@ impl AgentSession {
             active_turn_generation: Arc::new(parking_lot::RwLock::new(None)),
             scheduler: DialogScheduler::new(session_id_for_scheduler, 32),
             steering_queue: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+            sm_state: Arc::new(tokio::sync::Mutex::new(SessionMemoryState::default())),
             em_state: Arc::new(tokio::sync::Mutex::new(ExtractMemoriesState::default())),
             ad_state: Arc::new(tokio::sync::Mutex::new(AutoDreamState::default())),
             prompt_cache: Arc::new(tokio::sync::Mutex::new(SessionPromptCache::default())),

--- a/src-tauri/crates/agent-core/src/state/unified.rs
+++ b/src-tauri/crates/agent-core/src/state/unified.rs
@@ -341,7 +341,12 @@ impl AgentAppState {
     pub async fn remove_session(&self, session_id: &str) {
         let mut sessions = self.sessions.lock().await;
         sessions.remove(session_id);
-        info!("[agent-state] Removed session: {}", session_id);
+        let cancelled_memory_jobs =
+            crate::memory::background::cancel_memory_jobs_for_session(session_id);
+        info!(
+            "[agent-state] Removed session: {} (cancelled_memory_jobs={})",
+            session_id, cancelled_memory_jobs
+        );
     }
 
     /// Remove several sessions while holding the registry lock once.
@@ -353,6 +358,16 @@ impl AgentAppState {
         for session_id in session_ids {
             sessions.remove(session_id);
             info!("[agent-state] Removed session: {}", session_id);
+        }
+        let cancelled_memory_jobs = session_ids
+            .iter()
+            .map(|session_id| crate::memory::background::cancel_memory_jobs_for_session(session_id))
+            .sum::<usize>();
+        if cancelled_memory_jobs > 0 {
+            info!(
+                cancelled_memory_jobs,
+                "[agent-state] Cancelled memory jobs for removed sessions"
+            );
         }
     }
 

--- a/src-tauri/crates/e2e-test/src/harness.rs
+++ b/src-tauri/crates/e2e-test/src/harness.rs
@@ -739,7 +739,7 @@ pub async fn fetch_ready_todos(
 /// survive across turns.
 #[derive(Debug, Clone)]
 pub struct EmStateSnapshot {
-    pub last_processed_idx: Option<i64>,
+    pub last_processed_seq: Option<i64>,
     pub in_progress: bool,
     pub turns_since_extraction: u32,
 }
@@ -773,7 +773,7 @@ pub async fn fetch_em_state(cfg: &Config, session_id: &str) -> Result<EmStateSna
         .get("em_state")
         .ok_or_else(|| "response missing em_state field".to_string())?;
 
-    let last_processed_idx = em.get("last_processed_idx").and_then(|v| v.as_i64());
+    let last_processed_seq = em.get("last_processed_seq").and_then(|v| v.as_i64());
     let in_progress = em
         .get("in_progress")
         .and_then(|v| v.as_bool())
@@ -784,7 +784,7 @@ pub async fn fetch_em_state(cfg: &Config, session_id: &str) -> Result<EmStateSna
         .unwrap_or(0) as u32;
 
     Ok(EmStateSnapshot {
-        last_processed_idx,
+        last_processed_seq,
         in_progress,
         turns_since_extraction,
     })

--- a/src-tauri/crates/e2e-test/src/harness.rs
+++ b/src-tauri/crates/e2e-test/src/harness.rs
@@ -742,7 +742,6 @@ pub struct EmStateSnapshot {
     pub last_processed_idx: Option<i64>,
     pub in_progress: bool,
     pub turns_since_extraction: u32,
-    pub pending_messages_len: Option<i64>,
 }
 
 /// Fetch the per-session `ExtractMemoriesState` snapshot.
@@ -783,13 +782,11 @@ pub async fn fetch_em_state(cfg: &Config, session_id: &str) -> Result<EmStateSna
         .get("turns_since_extraction")
         .and_then(|v| v.as_u64())
         .unwrap_or(0) as u32;
-    let pending_messages_len = em.get("pending_messages_len").and_then(|v| v.as_i64());
 
     Ok(EmStateSnapshot {
         last_processed_idx,
         in_progress,
         turns_since_extraction,
-        pending_messages_len,
     })
 }
 

--- a/src-tauri/crates/e2e-test/src/sde/auto_dream.rs
+++ b/src-tauri/crates/e2e-test/src/sde/auto_dream.rs
@@ -22,7 +22,12 @@ use crate::harness;
 use super::tmp_workspace_path;
 
 const MIN_SESSIONS: usize = 5;
-const WAIT_AFTER_TURN_SECS: u64 = 10;
+/// Auto-dream is coordinator-owned and serializes behind the session's own
+/// session-memory and workspace-extraction jobs on the global memory permit,
+/// so the lock can take tens of seconds to appear. Poll instead of a fixed
+/// short sleep.
+const LOCK_POLL_TIMEOUT_SECS: u64 = 120;
+const LOCK_POLL_INTERVAL_SECS: u64 = 2;
 
 fn seed_fake_sessions(workspace: &Path, count: usize) -> Result<(), String> {
     let session_dir = workspace.join(".orgii").join("sessions");
@@ -124,8 +129,13 @@ pub async fn auto_dream_from_config(cfg: &Config) -> bool {
         println!("  [warn] turn failed: {err}");
     }
 
-    println!("  [step 4] Waiting {WAIT_AFTER_TURN_SECS}s for background auto-dream...");
-    tokio::time::sleep(Duration::from_secs(WAIT_AFTER_TURN_SECS)).await;
+    println!(
+        "  [step 4] Polling up to {LOCK_POLL_TIMEOUT_SECS}s for the coordinator-queued auto-dream..."
+    );
+    let poll_deadline = std::time::Instant::now() + Duration::from_secs(LOCK_POLL_TIMEOUT_SECS);
+    while !lock_path.exists() && std::time::Instant::now() < poll_deadline {
+        tokio::time::sleep(Duration::from_secs(LOCK_POLL_INTERVAL_SECS)).await;
+    }
 
     let lock_exists = lock_path.exists();
     // Same reasoning as the first assertion site: surface read

--- a/src-tauri/crates/e2e-test/src/sde/extract_memories_config_path.rs
+++ b/src-tauri/crates/e2e-test/src/sde/extract_memories_config_path.rs
@@ -15,7 +15,7 @@
 //!      `extract_memories_enabled=true`.
 //!   2. Send a tool-heavy SDE turn with the `enable_extract_memories`
 //!      HTTP flag left **off**.
-//!   3. Assert `em_state.last_processed_idx` advances — only possible
+//!   3. Assert `em_state.last_processed_seq` advances — only possible
 //!      if the resolver honored the overlay.
 //!
 //! Positive+negative assertion compliance: teardown resets the overlay so the next scenario
@@ -123,7 +123,7 @@ pub async fn extract_memories_agent_def_opts_in(cfg: &Config) -> bool {
     loop {
         match harness::fetch_em_state(cfg, &session_id).await {
             Ok(snap) => {
-                let advanced = snap.last_processed_idx.is_some();
+                let advanced = snap.last_processed_seq.is_some();
                 last_snapshot = Some(snap);
                 if advanced {
                     break;
@@ -141,10 +141,10 @@ pub async fn extract_memories_agent_def_opts_in(cfg: &Config) -> bool {
 
     let (cursor_advanced, snap_repr) = match last_snapshot.as_ref() {
         Some(snap) => (
-            snap.last_processed_idx.is_some(),
+            snap.last_processed_seq.is_some(),
             format!(
-                "last_processed_idx={:?} in_progress={} turns_since_extraction={}",
-                snap.last_processed_idx, snap.in_progress, snap.turns_since_extraction,
+                "last_processed_seq={:?} in_progress={} turns_since_extraction={}",
+                snap.last_processed_seq, snap.in_progress, snap.turns_since_extraction,
             ),
         ),
         None => (false, "em_state fetch never succeeded".to_string()),

--- a/src-tauri/crates/e2e-test/src/sde/extract_memories_fs.rs
+++ b/src-tauri/crates/e2e-test/src/sde/extract_memories_fs.rs
@@ -91,7 +91,7 @@ pub async fn extract_memories_tool_heavy(cfg: &Config) -> bool {
     println!("  [step 1] Sending tool-heavy SDE turn (no_cleanup=true)...");
     // Keep the session alive so the debug em-state endpoint can read
     // the shared `ExtractMemoriesState` after the background fork
-    // finishes. The assertion on `last_processed_idx` is the most
+    // finishes. The assertion on `last_processed_seq` is the most
     // reliable signal that the gate actually cleared — it is only
     // written by `run_extraction` on success, so if the fork was
     // skipped (bug 1 regression: `count_new_messages` under-counting
@@ -136,7 +136,7 @@ pub async fn extract_memories_tool_heavy(cfg: &Config) -> bool {
     loop {
         match harness::fetch_em_state(cfg, &session_id).await {
             Ok(snap) => {
-                let advanced = snap.last_processed_idx.is_some();
+                let advanced = snap.last_processed_seq.is_some();
                 last_snapshot = Some(snap);
                 if advanced {
                     break;
@@ -162,11 +162,11 @@ pub async fn extract_memories_tool_heavy(cfg: &Config) -> bool {
 
     let (cursor_advanced, not_in_progress, snap_repr) = match last_snapshot.as_ref() {
         Some(snap) => {
-            let cursor_advanced = snap.last_processed_idx.is_some();
+            let cursor_advanced = snap.last_processed_seq.is_some();
             let not_in_progress = !snap.in_progress;
             let repr = format!(
-                "last_processed_idx={:?} in_progress={} turns_since_extraction={}",
-                snap.last_processed_idx, snap.in_progress, snap.turns_since_extraction,
+                "last_processed_seq={:?} in_progress={} turns_since_extraction={}",
+                snap.last_processed_seq, snap.in_progress, snap.turns_since_extraction,
             );
             (cursor_advanced, not_in_progress, repr)
         }
@@ -227,8 +227,8 @@ pub async fn extract_memories_tool_heavy(cfg: &Config) -> bool {
 // Regression pin for the em_state persistence bug: before the fix,
 // `integration::process_message` rebuilt `UnifiedMessageProcessor` on
 // every turn and constructed a fresh `ExtractMemoriesState::default()`
-// each time, so `last_processed_idx`, `in_progress`,
-// `turns_since_extraction`, and the `pending_messages` stash never
+// each time, so `last_processed_seq`, `in_progress`, and
+// `turns_since_extraction` never
 // carried over. The gating / throttle / overlap logic all appeared to
 // work in isolation (unit tests passed) but was effectively disabled
 // at runtime.
@@ -242,12 +242,12 @@ pub async fn extract_memories_tool_heavy(cfg: &Config) -> bool {
 //   1. Sends two tool-heavy SDE turns in the same session, keeping
 //      the session alive between them (`no_cleanup=true` on turn 1).
 //   2. Reads `GET /agent/test/em-state/:session_id` after turn 2 (also
-//      kept alive) and asserts that `last_processed_idx` has advanced
+//      kept alive) and asserts that `last_processed_seq` has advanced
 //      past zero.
 //   3. Asserts `in_progress == false` (no orphaned overlap guard) and
 //      sanity-checks `turns_since_extraction`.
 //
-// Before the fix: `last_processed_idx` would come back as `None` every
+// Before the fix: `last_processed_seq` would come back as `None` every
 // turn because the state object was freshly-defaulted. After the fix:
 // the cursor is whatever the last extraction landed at.
 
@@ -343,7 +343,7 @@ pub async fn extract_memories_cursor_advances(cfg: &Config) -> bool {
     let em: Result<harness::EmStateSnapshot, String> = loop {
         match harness::fetch_em_state(cfg, &session_id).await {
             Ok(snap) => {
-                if snap.last_processed_idx.is_some() {
+                if snap.last_processed_seq.is_some() {
                     break Ok(snap);
                 }
                 if std::time::Instant::now() >= deadline {
@@ -363,17 +363,17 @@ pub async fn extract_memories_cursor_advances(cfg: &Config) -> bool {
         println!("  [warn] fetch_em_state final error: {err}");
     }
 
-    // Primary assertion: `last_processed_idx` must have been
+    // Primary assertion: `last_processed_seq` must have been
     // advanced past `None`. This is the most reliable
     // cross-turn persistence signal in the current code shape:
     //
     //   - Before the fix, every turn rebuilt `UnifiedMessageProcessor`
     //     with a fresh `ExtractMemoriesState::default()`, so
-    //     `last_processed_idx` was `None` every turn the debug
+    //     `last_processed_seq` was `None` every turn the debug
     //     endpoint observed it.
     //   - After the fix, `AgentSession` owns the `Arc<Mutex<…>>` and
     //     the background extract fork spawned by turn 1 writes back
-    //     `last_processed_idx = Some(messages.len()-1)` into that
+    //     the end-of-transcript sequence cursor into that
     //     shared state. Turn 2 (and the debug endpoint) then see a
     //     `Some(_)` cursor.
     //
@@ -385,11 +385,11 @@ pub async fn extract_memories_cursor_advances(cfg: &Config) -> bool {
     // reliable persistence signal in practice.
     let (cursor_advanced, not_in_progress, snap_repr) = match em.as_ref() {
         Ok(snap) => {
-            let cursor_advanced = snap.last_processed_idx.is_some();
+            let cursor_advanced = snap.last_processed_seq.is_some();
             let not_in_progress = !snap.in_progress;
             let repr = format!(
-                "last_processed_idx={:?} in_progress={} turns_since_extraction={}",
-                snap.last_processed_idx, snap.in_progress, snap.turns_since_extraction,
+                "last_processed_seq={:?} in_progress={} turns_since_extraction={}",
+                snap.last_processed_seq, snap.in_progress, snap.turns_since_extraction,
             );
             (cursor_advanced, not_in_progress, repr)
         }
@@ -413,7 +413,7 @@ pub async fn extract_memories_cursor_advances(cfg: &Config) -> bool {
             ("Turn 2 was tool-heavy", turn2_tool_calls >= 1),
             ("em_state fetch returned ok", em.is_ok()),
             (
-                "last_processed_idx advanced past None (state persists across turns)",
+                "last_processed_seq advanced past None (state persists across turns)",
                 cursor_advanced,
             ),
             (

--- a/src-tauri/crates/e2e-test/src/sde/extract_memories_fs.rs
+++ b/src-tauri/crates/e2e-test/src/sde/extract_memories_fs.rs
@@ -304,9 +304,16 @@ pub async fn extract_memories_cursor_advances(cfg: &Config) -> bool {
     }
     println!("  [info] turn1_ok={turn1_ok} turn1_tool_calls={turn1_tool_calls}");
 
-    // Give the background extract fork a moment to land and advance
-    // the cursor before we send turn 2.
-    tokio::time::sleep(Duration::from_secs(10)).await;
+    // Let the coordinator-owned extract fork land and advance the cursor
+    // before turn 2 — a new turn cancels an in-flight extraction, so poll
+    // until the fork is done instead of sleeping a fixed interval.
+    let fork_deadline = std::time::Instant::now() + Duration::from_secs(90);
+    while std::time::Instant::now() < fork_deadline {
+        match harness::fetch_em_state(cfg, &session_id).await {
+            Ok(snap) if !snap.in_progress && snap.last_processed_seq.is_some() => break,
+            _ => tokio::time::sleep(Duration::from_secs(2)).await,
+        }
+    }
 
     // Turn 2: another tool-heavy exchange, also no_cleanup=true so the
     // em-state endpoint can still see the session afterwards.

--- a/src-tauri/crates/e2e-test/src/sde/extract_memories_fs.rs
+++ b/src-tauri/crates/e2e-test/src/sde/extract_memories_fs.rs
@@ -165,11 +165,8 @@ pub async fn extract_memories_tool_heavy(cfg: &Config) -> bool {
             let cursor_advanced = snap.last_processed_idx.is_some();
             let not_in_progress = !snap.in_progress;
             let repr = format!(
-                "last_processed_idx={:?} in_progress={} turns_since_extraction={} pending_len={:?}",
-                snap.last_processed_idx,
-                snap.in_progress,
-                snap.turns_since_extraction,
-                snap.pending_messages_len,
+                "last_processed_idx={:?} in_progress={} turns_since_extraction={}",
+                snap.last_processed_idx, snap.in_progress, snap.turns_since_extraction,
             );
             (cursor_advanced, not_in_progress, repr)
         }
@@ -391,11 +388,8 @@ pub async fn extract_memories_cursor_advances(cfg: &Config) -> bool {
             let cursor_advanced = snap.last_processed_idx.is_some();
             let not_in_progress = !snap.in_progress;
             let repr = format!(
-                "last_processed_idx={:?} in_progress={} turns_since_extraction={} pending_len={:?}",
-                snap.last_processed_idx,
-                snap.in_progress,
-                snap.turns_since_extraction,
-                snap.pending_messages_len,
+                "last_processed_idx={:?} in_progress={} turns_since_extraction={}",
+                snap.last_processed_idx, snap.in_progress, snap.turns_since_extraction,
             );
             (cursor_advanced, not_in_progress, repr)
         }

--- a/src-tauri/crates/e2e-test/src/sde/session_memory_db.rs
+++ b/src-tauri/crates/e2e-test/src/sde/session_memory_db.rs
@@ -14,7 +14,7 @@ use rusqlite::{Connection, OpenFlags};
 use std::time::Duration;
 
 const SM_MIN_CONTENT_LEN: usize = 50;
-const SM_WAIT_AFTER_LAST_TURN_SECS: u64 = 8;
+const SM_WAIT_AFTER_LAST_TURN_SECS: u64 = 120;
 
 /// Build a ~12KB filler payload that dominates the turn's token footprint
 /// so `current_tokens` reliably crosses `min_tokens_to_init = 10_000`.
@@ -120,10 +120,19 @@ pub async fn session_memory_persisted(cfg: &Config) -> bool {
     .await;
     let turn3_ok = turn3.is_ok();
 
-    // SM extraction is spawned async after each turn. Give it time to land.
-    tokio::time::sleep(Duration::from_secs(SM_WAIT_AFTER_LAST_TURN_SECS)).await;
-
-    let db_read = read_sm_state(&session_id);
+    // SM extraction is coordinator-owned and can queue behind other
+    // sessions' memory jobs on the global permit, so poll the durable row
+    // instead of sleeping a fixed interval.
+    let poll_deadline =
+        std::time::Instant::now() + Duration::from_secs(SM_WAIT_AFTER_LAST_TURN_SECS);
+    let mut db_read = read_sm_state(&session_id);
+    while std::time::Instant::now() < poll_deadline {
+        if matches!(&db_read, Ok((Some(_), _))) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        db_read = read_sm_state(&session_id);
+    }
 
     // Clean up the session so we don't leak runtime state.
     let _ = harness::cleanup_sde_session(cfg, &session_id).await;

--- a/src-tauri/crates/e2e-test/src/sde/session_memory_db.rs
+++ b/src-tauri/crates/e2e-test/src/sde/session_memory_db.rs
@@ -37,7 +37,7 @@ fn sessions_db_path() -> std::path::PathBuf {
         .join("sessions.db")
 }
 
-/// Returns `(sm_content, sm_last_msg_idx)`; both `None` if row missing or columns null.
+/// Returns `(sm_content, sm_last_seq)`; both `None` if row missing or columns null.
 fn read_sm_state(session_id: &str) -> Result<(Option<String>, Option<i64>), String> {
     let path = sessions_db_path();
     let conn = Connection::open_with_flags(
@@ -47,7 +47,7 @@ fn read_sm_state(session_id: &str) -> Result<(Option<String>, Option<i64>), Stri
     .map_err(|err| format!("open {}: {}", path.display(), err))?;
 
     let row = conn.query_row(
-        "SELECT sm_content, sm_last_msg_idx FROM agent_sessions WHERE session_id = ?1",
+        "SELECT sm_content, sm_last_seq FROM agent_sessions WHERE session_id = ?1",
         [session_id],
         |row| {
             let content: Option<String> = row.get(0)?;
@@ -155,7 +155,7 @@ pub async fn session_memory_persisted(cfg: &Config) -> bool {
                 &format!("sm_content length >= {SM_MIN_CONTENT_LEN} (got {content_len})"),
                 content_non_trivial,
             ),
-            ("sm_last_msg_idx persisted (non-null)", idx_set),
+            ("sm_last_seq persisted (non-null)", idx_set),
         ],
     )
 }

--- a/src-tauri/src/api/agent/test/sde.rs
+++ b/src-tauri/src/api/agent/test/sde.rs
@@ -1532,7 +1532,7 @@ pub async fn test_em_state_get(
         "ok": true,
         "session_id": session_id,
         "em_state": {
-            "last_processed_idx": em_snap.last_processed_idx,
+            "last_processed_seq": em_snap.last_processed_seq,
             "in_progress": em_snap.in_progress,
             "turns_since_extraction": em_snap.turns_since_extraction,
         },

--- a/src-tauri/src/api/agent/test/sde.rs
+++ b/src-tauri/src/api/agent/test/sde.rs
@@ -1535,7 +1535,6 @@ pub async fn test_em_state_get(
             "last_processed_idx": em_snap.last_processed_idx,
             "in_progress": em_snap.in_progress,
             "turns_since_extraction": em_snap.turns_since_extraction,
-            "pending_messages_len": em_snap.pending_messages_len,
         },
     }))
 }


### PR DESCRIPTION
## Problem

Automatic memory and evolution work was launched from multiple detached post-turn paths without a shared owner, global admission limit, or complete session lifecycle cancellation. Concurrent turns could retain full transcripts and image payloads while queued, duplicate equivalent work, ignore live learnings-policy changes, and leave extraction or consolidation state stuck after cancellation or timeout. Reflection and active observation also ran immediately after each completed turn instead of waiting for session quiescence.

On top of that, the session-memory and workspace-extraction cursors were bare array indexes recorded against one specific in-memory frame and resolved against others (the runtime-prefix turn frame, the prefix-stripped compaction tail, and the new bounded durable suffix). Three hand-maintained shift conversions papered over the divergence, and the bounded-suffix frame had none — long sessions past the input bound would re-summarize covered content and misplace the compaction keep-window.

## Solution

Introduce a process-wide memory background coordinator keyed by session and job kind. It provides latest-only coalescing, a bounded global permit pool, hard deadlines, cancellation, cleanup, metrics, and debounced quiescence jobs. Route session-memory extraction, workspace extraction, auto-dream, reflection, and active observation through the shared ownership boundary.

Background jobs load canonical durable history only after admission, use a text-only loader that does not rehydrate image payloads, and bound memory-agent transcript input to a recent 512 KiB suffix while preserving tool-call/result structure. Agent-definition updates act as live policy gates for learnings work, new turns and session teardown cancel obsolete work, and auto-dream uses an RAII consolidation lease so failed or cancelled work rolls back its lock.

Memory cursors are anchored by durable message start-sequence instead of array index, mirroring the reference implementation's identity-anchor design (store identity, resolve to an index per frame at use time). `llm_message_start_sequences` is exposed alongside the text-only loader, the transcript bound truncates messages and sequences in lockstep, and `try_sm_compact` receives an anchor already resolved into its own frame — deleting all three frame-shift conversions. Because sequences are ordered, an anchor whose row was compacted away still resolves to an exact boundary.

Session-memory extraction is context-window pipeline work, not long-term memory, so its gate is `sm_config.enabled` alone; the learnings policy no longer disables it. It also runs outside the global permit — one bounded fast-model side query starting as soon as its turn ends, still slot-owned (latest-only, cancelled by new turns/teardown, 60s deadline) — so SM-compact always has fresh content while the heavy forked agents queue on the bounded permit. The extraction gate and counter bookkeeping (SM tool-call counts, workspace-extraction turn counter) run at post-turn dispatch, so jobs cancelled while queued cannot lose state and only due extractions are submitted. Job bodies route SQLite reads and writes through `spawn_blocking`, failed or timed-out session-memory jobs broadcast an `agent:warning` again, submissions never coalesce into an already-cancelled slot, and the manual reflection command bounds its permit wait.

## Potential risks

- `agent_sessions` gains an `sm_last_seq` column and drops the legacy `sm_last_msg_idx` (an index it would be unsafe to reinterpret). Existing sessions re-anchor on their next due extraction: one extraction per old session covers the whole visible window (bounded at 512 KiB, rendered with 500-char truncation, routed to the fast sibling model), after which incremental anchoring resumes. Rolling back to an older build is safe — its column migration re-adds the old column and treats the NULL value as "no anchor".
- Memory-agent inputs larger than 512 KiB are intentionally truncated to a recent structurally valid suffix, so very old un-compacted details may no longer be visible to a single extraction job.
- Heavy automatic memory LLM work (workspace extraction, auto-dream, reflection, observation, consolidation) defaults to one concurrent job process-wide; operators can set `ORGII_MEMORY_BACKGROUND_CONCURRENCY` from 1 to 4. Session-memory extraction is exempt: it is one small fast-model call per completed turn, bounded by per-session latest-only slots and its 60s deadline.
- Cancellation depends on providers and side-query loops observing their cancellation flag. The coordinator enforces a hard outer deadline, but a provider implementation performing non-cooperative blocking work may release underlying resources later than the coordinator outcome.
- No public IPC payload, dependency, lockfile, or UI behavior is changed. The debug-only `/agent/test` snapshot renames `last_processed_idx` → `last_processed_seq`; the e2e harness is updated in the same commits.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings` (the full-workspace scope that CI runs)
- `cargo test -p agent_core --lib` — 3163 passed
- Targeted suites: coordinator (`specialization::memory::background`), post-turn transcript budget, sequence-anchor resolver, SM extraction/compact (`core::model_context::session_memory`), workspace extraction gating/state, auto-dream lock and lease, side-query cancellation, text-only history loader
- `git diff --check`; pre-commit hook: lint-staged + scoped clippy passed

Live testing on the development app against the production 5.2 GB sessions DB (13.7k sessions, 2.5k with SM state):

- Column migration applied cleanly: `sm_last_seq` added, legacy column dropped, all 2,536 `sm_content` values preserved, anchors reset for one-time re-anchoring.
- e2e `--group memory` (real LLM): 6/7 scenarios pass. Coordinator logs show session-memory, workspace-extraction, and auto-dream jobs completing per session; a mid-extraction follow-up turn produced `outcome=Cancelled` on the in-flight job and a clean resubmit; `sm_last_seq` advances on real sessions.
- The permit-exempt session-memory path was verified live: an SM job and a workspace-extraction job for the same session completed concurrently under a 1-permit coordinator.
- The remaining scenario failure (`extract-memories-main-agent-wrote`) reproduces identically with two different models and root-causes to `run_shell` shell-replay seeding failing in test-endpoint sessions plus `edit_file` not creating parent directories — both outside this PR's changed paths; tracked separately.
- e2e memory probes were updated in-branch to poll for coordinator-queued artifacts instead of sleeping fixed intervals.

## Architecture and performance audit

- Confirmed one coordinator owns automatic memory/evolution jobs and one slot exists per `(session_id, job_kind)`; submissions into a cancelled slot start a fresh generation instead of being dropped.
- Confirmed automatic production entry points route through the coordinator or its shared permit, and queued jobs do not retain full transcripts or image payloads.
- Confirmed live learnings-policy checks occur after admission for learnings work, session-memory is decoupled from the learnings switch, and session lifecycle paths cancel obsolete jobs.
- Confirmed cursor anchors are frame-independent: extraction (bounded durable suffix) and SM-compact (turn tail, freshly loaded history) resolve the same persisted sequence against their own arrays; all previous index-shift arithmetic is deleted.
- Confirmed gate bookkeeping survives cancellation by running at dispatch; blocking SQLite work in job bodies goes through `spawn_blocking`, matching the rest of the codebase.
- Confirmed bounded concurrency, hard timeout, latest-only debounce, cleanup, and lock rollback behavior with targeted tests.
