### PR TITLE
fix(agent): block retired Brick workspace rules

### DIFF
--- a/src-tauri/crates/agent-core/src/core/session/prompt/helpers.rs
+++ b/src-tauri/crates/agent-core/src/core/session/prompt/helpers.rs
@@ -163,83 +163,6 @@ fn expand_memory_imports(content: &str, base_dir: &Path) -> String {
     out.join("\n")
 }
 
-#[cfg(test)]
-mod convention_tests {
-    use super::{load_conventions, strip_retired_brick_managed_blocks};
-
-    const RETIRED_BLOCK: &str = "<!-- brick:managed:start v=9 -->\nRun `brick explain src/main.rs:1` first.\n<!-- brick:managed:end -->";
-
-    #[test]
-    fn strips_complete_and_unterminated_retired_managed_blocks() {
-        let content = format!("Keep before.\n\n{RETIRED_BLOCK}\n\nKeep after.");
-        let sanitized = strip_retired_brick_managed_blocks(&content);
-        assert!(sanitized.contains("Keep before."));
-        assert!(sanitized.contains("Keep after."));
-        assert!(!sanitized.contains("brick explain"));
-
-        let repeated = format!("{RETIRED_BLOCK}\nKeep middle.\n{RETIRED_BLOCK}");
-        let sanitized = strip_retired_brick_managed_blocks(&repeated);
-        assert!(sanitized.contains("Keep middle."));
-        assert!(!sanitized.contains("brick:managed"));
-
-        let unterminated =
-            "Keep before.\n<!-- brick:managed:start v=9 -->\nRun `brick explain` forever.";
-        assert_eq!(
-            strip_retired_brick_managed_blocks(unterminated),
-            "Keep before.\n"
-        );
-    }
-
-    #[test]
-    fn workspace_instruction_loader_filters_retired_blocks_from_all_sources() {
-        let workspace = tempfile::tempdir().expect("workspace");
-        let orgii = workspace.path().join(".orgii");
-        std::fs::create_dir_all(&orgii).expect("create .orgii");
-        std::fs::write(
-            orgii.join("agent-rules.md"),
-            format!("{RETIRED_BLOCK}\n\nKeep native rule."),
-        )
-        .expect("write native rules");
-        std::fs::write(
-            workspace.path().join("CLAUDE.md"),
-            "Keep Claude rule.\n@retired-instructions.md",
-        )
-        .expect("write CLAUDE.md");
-        std::fs::write(
-            workspace.path().join("retired-instructions.md"),
-            RETIRED_BLOCK,
-        )
-        .expect("write imported rules");
-        std::fs::write(workspace.path().join("AGENTS.md"), RETIRED_BLOCK).expect("write AGENTS.md");
-        std::fs::write(
-            workspace.path().join("CLAUDE.local.md"),
-            format!("{RETIRED_BLOCK}\n\nKeep local rule."),
-        )
-        .expect("write local rules");
-
-        let loaded = load_conventions(workspace.path()).expect("remaining instructions");
-        assert!(loaded.contains("Keep native rule."));
-        assert!(loaded.contains("Keep Claude rule."));
-        assert!(loaded.contains("Keep local rule."));
-        assert!(!loaded.contains("brick explain"));
-        assert!(!loaded.contains("brick:managed"));
-        assert!(!loaded.contains(&format!(
-            "<!-- from {} -->",
-            workspace.path().join("AGENTS.md").display()
-        )));
-    }
-
-    #[test]
-    fn retired_only_native_rule_file_does_not_create_prompt_content() {
-        let workspace = tempfile::tempdir().expect("workspace");
-        let orgii = workspace.path().join(".orgii");
-        std::fs::create_dir_all(&orgii).expect("create .orgii");
-        std::fs::write(orgii.join("agent-rules.md"), RETIRED_BLOCK).expect("write native rules");
-
-        assert!(load_conventions(workspace.path()).is_none());
-    }
-}
-
 // ============================================
 // Text truncation / formatting
 // ============================================
@@ -369,5 +292,82 @@ pub(super) fn append_personal_workspace_context(lines: &mut Vec<String>, workspa
             slugs.len(),
             slugs.join(", ")
         ));
+    }
+}
+
+#[cfg(test)]
+mod convention_tests {
+    use super::{load_conventions, strip_retired_brick_managed_blocks};
+
+    const RETIRED_BLOCK: &str = "<!-- brick:managed:start v=9 -->\nRun `brick explain src/main.rs:1` first.\n<!-- brick:managed:end -->";
+
+    #[test]
+    fn strips_complete_and_unterminated_retired_managed_blocks() {
+        let content = format!("Keep before.\n\n{RETIRED_BLOCK}\n\nKeep after.");
+        let sanitized = strip_retired_brick_managed_blocks(&content);
+        assert!(sanitized.contains("Keep before."));
+        assert!(sanitized.contains("Keep after."));
+        assert!(!sanitized.contains("brick explain"));
+
+        let repeated = format!("{RETIRED_BLOCK}\nKeep middle.\n{RETIRED_BLOCK}");
+        let sanitized = strip_retired_brick_managed_blocks(&repeated);
+        assert!(sanitized.contains("Keep middle."));
+        assert!(!sanitized.contains("brick:managed"));
+
+        let unterminated =
+            "Keep before.\n<!-- brick:managed:start v=9 -->\nRun `brick explain` forever.";
+        assert_eq!(
+            strip_retired_brick_managed_blocks(unterminated),
+            "Keep before.\n"
+        );
+    }
+
+    #[test]
+    fn workspace_instruction_loader_filters_retired_blocks_from_all_sources() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let orgii = workspace.path().join(".orgii");
+        std::fs::create_dir_all(&orgii).expect("create .orgii");
+        std::fs::write(
+            orgii.join("agent-rules.md"),
+            format!("{RETIRED_BLOCK}\n\nKeep native rule."),
+        )
+        .expect("write native rules");
+        std::fs::write(
+            workspace.path().join("CLAUDE.md"),
+            "Keep Claude rule.\n@retired-instructions.md",
+        )
+        .expect("write CLAUDE.md");
+        std::fs::write(
+            workspace.path().join("retired-instructions.md"),
+            RETIRED_BLOCK,
+        )
+        .expect("write imported rules");
+        std::fs::write(workspace.path().join("AGENTS.md"), RETIRED_BLOCK).expect("write AGENTS.md");
+        std::fs::write(
+            workspace.path().join("CLAUDE.local.md"),
+            format!("{RETIRED_BLOCK}\n\nKeep local rule."),
+        )
+        .expect("write local rules");
+
+        let loaded = load_conventions(workspace.path()).expect("remaining instructions");
+        assert!(loaded.contains("Keep native rule."));
+        assert!(loaded.contains("Keep Claude rule."));
+        assert!(loaded.contains("Keep local rule."));
+        assert!(!loaded.contains("brick explain"));
+        assert!(!loaded.contains("brick:managed"));
+        assert!(!loaded.contains(&format!(
+            "<!-- from {} -->",
+            workspace.path().join("AGENTS.md").display()
+        )));
+    }
+
+    #[test]
+    fn retired_only_native_rule_file_does_not_create_prompt_content() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let orgii = workspace.path().join(".orgii");
+        std::fs::create_dir_all(&orgii).expect("create .orgii");
+        std::fs::write(orgii.join("agent-rules.md"), RETIRED_BLOCK).expect("write native rules");
+
+        assert!(load_conventions(workspace.path()).is_none());
     }
 }

--- a/src-tauri/crates/agent-core/src/core/session/prompt/helpers.rs
+++ b/src-tauri/crates/agent-core/src/core/session/prompt/helpers.rs
@@ -21,6 +21,35 @@ const MEMORY_FILE_MAX_BYTES: usize = 40_000;
 /// Maximum `@import` expansions per memory file (guards cycles/abuse).
 const MEMORY_FILE_MAX_IMPORTS: usize = 8;
 
+// Brick was retired from ORGII, but older installs can leave this generated
+// block in ignored workspace instruction files. Strip the managed envelope at
+// the instruction ingestion boundary so every prompt path shares the same
+// compatibility behavior.
+const RETIRED_BRICK_BLOCK_START: &str = "<!-- brick:managed:start";
+const RETIRED_BRICK_BLOCK_END: &str = "<!-- brick:managed:end -->";
+
+/// Remove retired Brick-managed instruction blocks.
+///
+/// An unterminated managed block is removed through end-of-file. This fails
+/// closed: a partially uninstalled block must not leak stale commands into a
+/// prompt merely because its closing marker was damaged.
+pub(crate) fn strip_retired_brick_managed_blocks(content: &str) -> String {
+    let mut remaining = content;
+    let mut sanitized = String::with_capacity(content.len());
+
+    while let Some(start) = remaining.find(RETIRED_BRICK_BLOCK_START) {
+        sanitized.push_str(&remaining[..start]);
+        let managed = &remaining[start + RETIRED_BRICK_BLOCK_START.len()..];
+        let Some(end) = managed.find(RETIRED_BRICK_BLOCK_END) else {
+            return sanitized;
+        };
+        remaining = &managed[end + RETIRED_BRICK_BLOCK_END.len()..];
+    }
+
+    sanitized.push_str(remaining);
+    sanitized
+}
+
 /// Load project conventions for the system prompt.
 ///
 /// Layered merge (later layers append, never replace):
@@ -42,7 +71,12 @@ pub(crate) fn load_conventions(workspace_path: &Path) -> Option<String> {
 
     let conventions_path = workspace_path.join(".orgii").join("agent-rules.md");
     match std::fs::read_to_string(&conventions_path) {
-        Ok(content) => sections.push(content),
+        Ok(content) => {
+            let content = strip_retired_brick_managed_blocks(&content);
+            if !content.trim().is_empty() {
+                sections.push(content);
+            }
+        }
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
         Err(err) => {
             tracing::warn!(
@@ -60,11 +94,15 @@ pub(crate) fn load_conventions(workspace_path: &Path) -> Option<String> {
             let Some(current) = dir else { break };
             let candidate = current.join(name);
             if let Ok(content) = std::fs::read_to_string(&candidate) {
-                sections.push(format!(
-                    "<!-- from {} -->\n{}",
-                    candidate.display(),
-                    expand_memory_imports(&content, current)
-                ));
+                let content =
+                    strip_retired_brick_managed_blocks(&expand_memory_imports(&content, current));
+                if !content.trim().is_empty() {
+                    sections.push(format!(
+                        "<!-- from {} -->\n{}",
+                        candidate.display(),
+                        content
+                    ));
+                }
                 break;
             }
             dir = current.parent();
@@ -74,11 +112,11 @@ pub(crate) fn load_conventions(workspace_path: &Path) -> Option<String> {
     // CLAUDE.local.md: workspace root only (user-local, usually gitignored).
     let local = workspace_path.join("CLAUDE.local.md");
     if let Ok(content) = std::fs::read_to_string(&local) {
-        sections.push(format!(
-            "<!-- from {} -->\n{}",
-            local.display(),
-            expand_memory_imports(&content, workspace_path)
-        ));
+        let content =
+            strip_retired_brick_managed_blocks(&expand_memory_imports(&content, workspace_path));
+        if !content.trim().is_empty() {
+            sections.push(format!("<!-- from {} -->\n{}", local.display(), content));
+        }
     }
 
     if sections.is_empty() {
@@ -123,6 +161,83 @@ fn expand_memory_imports(content: &str, base_dir: &Path) -> String {
         }
     }
     out.join("\n")
+}
+
+#[cfg(test)]
+mod convention_tests {
+    use super::{load_conventions, strip_retired_brick_managed_blocks};
+
+    const RETIRED_BLOCK: &str = "<!-- brick:managed:start v=9 -->\nRun `brick explain src/main.rs:1` first.\n<!-- brick:managed:end -->";
+
+    #[test]
+    fn strips_complete_and_unterminated_retired_managed_blocks() {
+        let content = format!("Keep before.\n\n{RETIRED_BLOCK}\n\nKeep after.");
+        let sanitized = strip_retired_brick_managed_blocks(&content);
+        assert!(sanitized.contains("Keep before."));
+        assert!(sanitized.contains("Keep after."));
+        assert!(!sanitized.contains("brick explain"));
+
+        let repeated = format!("{RETIRED_BLOCK}\nKeep middle.\n{RETIRED_BLOCK}");
+        let sanitized = strip_retired_brick_managed_blocks(&repeated);
+        assert!(sanitized.contains("Keep middle."));
+        assert!(!sanitized.contains("brick:managed"));
+
+        let unterminated =
+            "Keep before.\n<!-- brick:managed:start v=9 -->\nRun `brick explain` forever.";
+        assert_eq!(
+            strip_retired_brick_managed_blocks(unterminated),
+            "Keep before.\n"
+        );
+    }
+
+    #[test]
+    fn workspace_instruction_loader_filters_retired_blocks_from_all_sources() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let orgii = workspace.path().join(".orgii");
+        std::fs::create_dir_all(&orgii).expect("create .orgii");
+        std::fs::write(
+            orgii.join("agent-rules.md"),
+            format!("{RETIRED_BLOCK}\n\nKeep native rule."),
+        )
+        .expect("write native rules");
+        std::fs::write(
+            workspace.path().join("CLAUDE.md"),
+            "Keep Claude rule.\n@retired-instructions.md",
+        )
+        .expect("write CLAUDE.md");
+        std::fs::write(
+            workspace.path().join("retired-instructions.md"),
+            RETIRED_BLOCK,
+        )
+        .expect("write imported rules");
+        std::fs::write(workspace.path().join("AGENTS.md"), RETIRED_BLOCK).expect("write AGENTS.md");
+        std::fs::write(
+            workspace.path().join("CLAUDE.local.md"),
+            format!("{RETIRED_BLOCK}\n\nKeep local rule."),
+        )
+        .expect("write local rules");
+
+        let loaded = load_conventions(workspace.path()).expect("remaining instructions");
+        assert!(loaded.contains("Keep native rule."));
+        assert!(loaded.contains("Keep Claude rule."));
+        assert!(loaded.contains("Keep local rule."));
+        assert!(!loaded.contains("brick explain"));
+        assert!(!loaded.contains("brick:managed"));
+        assert!(!loaded.contains(&format!(
+            "<!-- from {} -->",
+            workspace.path().join("AGENTS.md").display()
+        )));
+    }
+
+    #[test]
+    fn retired_only_native_rule_file_does_not_create_prompt_content() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let orgii = workspace.path().join(".orgii");
+        std::fs::create_dir_all(&orgii).expect("create .orgii");
+        std::fs::write(orgii.join("agent-rules.md"), RETIRED_BLOCK).expect("write native rules");
+
+        assert!(load_conventions(workspace.path()).is_none());
+    }
 }
 
 // ============================================

--- a/src-tauri/crates/agent-core/src/core/session/prompt/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/session/prompt/mod.rs
@@ -21,5 +21,11 @@ pub fn load_workspace_instructions(workspace_path: &std::path::Path) -> Option<S
     helpers::load_conventions(workspace_path)
 }
 
+/// Strip retired managed instruction blocks before an external adapter writes
+/// workspace conventions into a provider-native rules file.
+pub fn strip_retired_workspace_instruction_blocks(content: &str) -> String {
+    helpers::strip_retired_brick_managed_blocks(content)
+}
+
 #[cfg(test)]
 pub(crate) mod section_tests;

--- a/src-tauri/src/agent_sessions/cli/skill_sync.rs
+++ b/src-tauri/src/agent_sessions/cli/skill_sync.rs
@@ -89,10 +89,7 @@ pub fn cleanup_synced_skill_files(paths: &[PathBuf]) {
             continue;
         }
         // Safety check: only delete files containing our marker
-        let is_ours = fs::read_to_string(path)
-            .map(|content| content.contains(ORGII_MARKER))
-            .unwrap_or(false);
-        if !is_ours {
+        if !is_orgii_managed_file(path) {
             tracing::warn!(
                 "[skill_sync] Skipping cleanup of {} — missing orgii marker",
                 path.display()
@@ -107,6 +104,12 @@ pub fn cleanup_synced_skill_files(paths: &[PathBuf]) {
             );
         }
     }
+}
+
+fn is_orgii_managed_file(path: &Path) -> bool {
+    fs::read_to_string(path)
+        .map(|content| content.contains(ORGII_MARKER))
+        .unwrap_or(false)
 }
 
 /// Determine the rule file path(s) to write for a given agent.
@@ -330,24 +333,33 @@ fn format_markdown(content: &str) -> String {
 /// Replaces the old `sync_conventions_to_cursorrules()` which wrote to the
 /// deprecated `.cursorrules` file (which Cursor agent mode ignores).
 pub fn sync_conventions_for_agent(agent: &ModelType, workspace_path: &Path) -> Vec<PathBuf> {
+    let targets = convention_targets_for_agent(agent, workspace_path);
     let conventions_path = workspace_path.join(".orgii").join("agent-rules.md");
     let content = match fs::read_to_string(&conventions_path) {
-        Ok(content) if !content.trim().is_empty() => content,
-        _ => return Vec::new(),
+        Ok(content) => {
+            agent_core::session::prompt::strip_retired_workspace_instruction_blocks(&content)
+        }
+        Err(_) => String::new(),
     };
 
-    let targets = convention_targets_for_agent(agent, workspace_path);
+    // A missing/empty source must also remove an older ORGII-managed copy.
+    // Otherwise uninstalling the source leaves the provider's native rules
+    // active until some unrelated cleanup happens to find them.
+    if content.trim().is_empty() {
+        let stale_managed_targets = targets
+            .into_iter()
+            .filter(|target| is_orgii_managed_file(target))
+            .collect::<Vec<_>>();
+        cleanup_synced_skill_files(&stale_managed_targets);
+        return Vec::new();
+    }
+
     let mut written: Vec<PathBuf> = Vec::new();
 
     for target in targets {
         // Skip if a non-orgii file already exists at this path
-        if target.exists() {
-            let is_ours = fs::read_to_string(&target)
-                .map(|existing| existing.contains(ORGII_MARKER))
-                .unwrap_or(false);
-            if !is_ours {
-                continue;
-            }
+        if target.exists() && !is_orgii_managed_file(&target) {
+            continue;
         }
 
         match write_rule_file(&target, &content) {
@@ -397,7 +409,10 @@ fn convention_targets_for_agent(agent: &ModelType, workspace_path: &Path) -> Vec
 
 #[cfg(test)]
 mod tests {
-    use super::build_skills_prompt_injection;
+    use super::{build_skills_prompt_injection, sync_conventions_for_agent, ORGII_MARKER};
+    use key_vault::key_store::ModelType;
+
+    const RETIRED_BLOCK: &str = "<!-- brick:managed:start v=9 -->\nRun `brick explain src/main.rs:1` first.\n<!-- brick:managed:end -->";
 
     #[test]
     fn provider_skill_catalog_is_stable_bounded_and_keeps_load_paths() {
@@ -432,6 +447,58 @@ mod tests {
             first.chars().count() <= 12_000,
             "catalog must stay near its 8k entry budget: {} chars",
             first.chars().count()
+        );
+    }
+
+    #[test]
+    fn convention_sync_filters_retired_managed_blocks() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let orgii = workspace.path().join(".orgii");
+        std::fs::create_dir_all(&orgii).expect("create .orgii");
+        std::fs::write(
+            orgii.join("agent-rules.md"),
+            format!("{RETIRED_BLOCK}\n\nKeep this rule."),
+        )
+        .expect("write conventions");
+
+        let written = sync_conventions_for_agent(&ModelType::CursorCli, workspace.path());
+        assert_eq!(written.len(), 1);
+        let content = std::fs::read_to_string(&written[0]).expect("read synced rules");
+        assert!(content.contains("Keep this rule."));
+        assert!(!content.contains("brick explain"));
+        assert!(!content.contains("brick:managed"));
+    }
+
+    #[test]
+    fn retired_only_source_removes_stale_orgii_managed_copy() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let orgii = workspace.path().join(".orgii");
+        let target = workspace.path().join(".cursor/rules/orgii-conventions.mdc");
+        std::fs::create_dir_all(&orgii).expect("create .orgii");
+        std::fs::create_dir_all(target.parent().expect("target parent"))
+            .expect("create target parent");
+        std::fs::write(orgii.join("agent-rules.md"), RETIRED_BLOCK).expect("write conventions");
+        std::fs::write(&target, format!("{ORGII_MARKER}\n\nOld generated rules."))
+            .expect("write stale target");
+
+        let written = sync_conventions_for_agent(&ModelType::CursorCli, workspace.path());
+        assert!(written.is_empty());
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn empty_source_preserves_user_owned_native_rules_file() {
+        let workspace = tempfile::tempdir().expect("workspace");
+        let target = workspace.path().join(".cursor/rules/orgii-conventions.mdc");
+        std::fs::create_dir_all(target.parent().expect("target parent"))
+            .expect("create target parent");
+        std::fs::write(&target, "User-owned rule.").expect("write user target");
+
+        let written = sync_conventions_for_agent(&ModelType::CursorCli, workspace.path());
+        assert!(written.is_empty());
+        assert_eq!(
+            std::fs::read_to_string(target).expect("read user target"),
+            "User-owned rule."
         );
     }
 }


### PR DESCRIPTION
## Problem

Brick was retired from ORGII, but older installs could leave its generated block in the ignored `.orgii/agent-rules.md` file. The previous cleanup removed the CLI, configuration, adapters, and tests; because `.orgii/*` is ignored, Git-based validation did not detect this persisted instruction file.

The authoritative prompt path then read the file verbatim. `load_conventions` injected it into native prompts, subagent prompts, and the CLI fallback envelope, while `sync_conventions_for_agent` copied the same raw content into provider-native rule files. That sync returned early when the source became missing or empty, so an ORGII-generated Cursor, Claude, or Copilot copy could also outlive its source.

The producing path was the retired installer's managed-block write into `.orgii/agent-rules.md`; the current defect was that ORGII's instruction-ingestion boundary still trusted that legacy block and did not reconcile generated native copies when the source disappeared.

## Solution

Add one canonical compatibility sanitizer at the workspace-instruction owner boundary. It removes complete legacy managed blocks, removes repeated blocks, and fails closed on an unterminated block by excluding the remainder from prompt content. It runs on `.orgii/agent-rules.md`, `CLAUDE.md`, `AGENTS.md`, imported memory files, and `CLAUDE.local.md` before prompt assembly.

Expose that sanitizer through the existing public prompt facade so CLI convention sync uses the same semantics instead of duplicating parsing. When the sanitized source is empty or absent, sync now removes stale provider-native copies only when they carry ORGII's generated-file marker; user-owned files at those paths are preserved.

Resulting invariant: retired managed instructions cannot enter any ORGII prompt or provider-native convention file, and an absent source cannot leave an ORGII-generated convention copy active.

For the affected local workspace, the ignored managed rule file was deleted and the workspace-memory entries that mentioned or recommended the retired integration were removed or rewritten to use `sessions.db`, current source, and Git. Session transcripts, logs, and Git history remain intact as audit evidence.

## Potential risks

- Content inside the legacy managed markers is excluded even if someone manually edited that generated region. The source file is not rewritten; only prompt/sync output is sanitized, so recovery remains possible from the original file.
- An unterminated start marker excludes the remainder of that instruction file. This is intentional fail-closed behavior for a damaged generated block, but a malformed marker could hide valid trailing instructions until the file is repaired.
- Launch-time reconciliation removes only files containing ORGII's generated marker. Provider rule paths are shared by concurrent CLI sessions, so a newly launched session can remove a stale generated file while another process exists; the source is already absent in that case and provider CLIs normally load rules at startup.
- No schema, wire format, dependency, persisted database, or public API migration is involved. Rollback is `git revert 4b50f3323 7d0155d04`; restoring a removed local rule file is unnecessary because it contained only retired generated instructions.

## Architecture audit

- Layers 1-4: targeted compilation/tests passed; parsing is centralized; names distinguish managed legacy blocks from current conventions; source-vs-generated semantics are explicit.
- Layers 5-7: no new fallback match arms; ownership remains in `agent_core::session::prompt`; the app depends on its public facade; comments and boundary tests document the fail-closed choice.
- Layer 8: not applicable — no JSON, IPC, database, or wire payload changed.
- Layer 9: native parent prompts, subagent prompts, CLI fallback prompts, and provider-native rule sync now converge on the same sanitized instruction content.
- Layer 10: not applicable — no provider/model resolver or endpoint construction changed.

## Verification

- `cargo test -p agent_core convention_tests --lib` — 3 passed, 0 failed.
- `cargo test -p org2 skill_sync::tests --lib` — 4 passed, 0 failed. The independent worktree used a temporary ignored symlink to the existing `org2-pm-aarch64-apple-darwin` sidecar required by the Tauri build script; it was removed afterward.
- `cargo check -p agent_core` — passed.
- `cargo fmt --all -- --check` — passed.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed locally after staging the ignored sidecar; this is the exact CI command.
- Pre-commit hook: lint-staged had no matching Rust task; scoped `cargo clippy --lib --message-format=short -p agent_core -p org2` passed for the implementation commit, and the follow-up commit's `agent_core` scoped clippy passed.
- `git diff --check origin/develop...HEAD` — passed.
- `command -v brick` returned no executable; scans of active workspace rule/config locations found no remaining managed marker or retired command, and `.orgii/workspace-memory` has no remaining Brick references.
- GitHub CI run `31713853723` — `check` passed; Frontend typecheck, lint, and 8,396 unit tests passed; Rust all-target workspace clippy passed.

The initial clean-worktree `cargo check -p agent_core -p org2` did not reach compilation because the ignored Tauri sidecar was absent. The later `org2` unit-test build, exact full-workspace clippy command, and CI all compiled the app crate with the required sidecar staged. No broader Rust test suite was run; the change is limited to prompt ingestion and CLI convention sync, and both owning boundaries have targeted regression coverage. No UI evidence is included because this change has no rendered UI.
