### PR TITLE
fix(session): exclude orphan org members from native pages

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -703,7 +703,7 @@ module.exports = (env, argv) => {
           process.env.ORGII_DEEP_LINK_SCHEME ?? "orgii"
         ),
         "process.env.ORGII_AGENT_ORG_REDESIGN": JSON.stringify(
-          isE2E ? "1" : (process.env.ORGII_AGENT_ORG_REDESIGN ?? "0")
+          isE2E ? "1" : (process.env.ORGII_AGENT_ORG_REDESIGN ?? "1")
         ),
         "process.env.E2E_BASE_URL": JSON.stringify(
           process.env.E2E_BASE_URL ??

--- a/scripts/dev/webpack-config-light.test.cjs
+++ b/scripts/dev/webpack-config-light.test.cjs
@@ -116,7 +116,7 @@ test("builds without --json keep the terse console stats", () => {
   assert.equal(config.stats.entrypoints, undefined);
 });
 
-test("WebDriver production bundles enable the E2E-only Agent Org gate", () => {
+test("WebDriver production bundles force-enable the Agent Org gate", () => {
   const config = withEnv(
     {
       ORGII_E2E: null,
@@ -133,11 +133,28 @@ test("WebDriver production bundles enable the E2E-only Agent Org gate", () => {
   );
 });
 
-test("ordinary production bundles keep the Agent Org rollout disabled", () => {
+test("ordinary production bundles enable the Agent Org rollout by default", () => {
   const config = withEnv(
     {
       ORGII_E2E: null,
       ORGII_AGENT_ORG_REDESIGN: null,
+      WEBDRIVER: null,
+    },
+    () => createWebpackConfig({}, { mode: "production" })
+  );
+
+  assert.equal(getDefinedValue(config, "process.env.ORGII_E2E"), '"0"');
+  assert.equal(
+    getDefinedValue(config, "process.env.ORGII_AGENT_ORG_REDESIGN"),
+    '"1"'
+  );
+});
+
+test("ordinary production bundles preserve an explicit Agent Org opt-out", () => {
+  const config = withEnv(
+    {
+      ORGII_E2E: null,
+      ORGII_AGENT_ORG_REDESIGN: "0",
       WEBDRIVER: null,
     },
     () => createWebpackConfig({}, { mode: "production" })

--- a/src-tauri/crates/agent-core/src/core/coordination/agent_org_runs/rollout.rs
+++ b/src-tauri/crates/agent-core/src/core/coordination/agent_org_runs/rollout.rs
@@ -1,14 +1,14 @@
 //! Single internal rollout gate for the long-lived Agent Org redesign.
 //!
 //! This is deliberately not persisted in Team definitions or exposed to
-//! model/tool context. Until the final stack PR changes the default, missing
-//! or malformed configuration fails closed.
+//! model/tool context. Missing configuration enables the completed redesign;
+//! explicit values still fail closed unless they are exactly `1`.
 
 const ENABLED_VALUE: &str = "1";
 const ROLLOUT_ENV: &str = "ORGII_AGENT_ORG_REDESIGN";
 
 fn configured_enabled(value: Option<&str>, test_build: bool) -> bool {
-    test_build || value.is_some_and(|value| value.trim() == ENABLED_VALUE)
+    test_build || value.is_none_or(|value| value.trim() == ENABLED_VALUE)
 }
 
 pub fn is_enabled() -> bool {
@@ -45,8 +45,8 @@ mod tests {
     }
 
     #[test]
-    fn production_gate_defaults_and_malformed_values_fail_closed() {
-        assert!(!super::configured_enabled(None, false));
+    fn production_gate_defaults_enabled_and_explicit_values_fail_closed() {
+        assert!(super::configured_enabled(None, false));
         assert!(!super::configured_enabled(Some("true"), false));
         assert!(!super::configured_enabled(Some("0"), false));
         assert!(super::configured_enabled(Some("1"), false));

--- a/src-tauri/crates/agent-core/src/core/session/persistence/crud/record.rs
+++ b/src-tauri/crates/agent-core/src/core/session/persistence/crud/record.rs
@@ -84,9 +84,10 @@ pub struct UnifiedSessionRecord {
     pub merge_status: Option<String>,
     pub project_slug: Option<String>,
     pub agent_definition_id: Option<String>,
-    /// Agent Org roster member id for `session_type::ORG_MEMBER` rows.
-    /// This identifies the member instance, while `agent_definition_id`
-    /// identifies which AgentDefinition that member runs.
+    /// Agent Org roster member id. Worker rows use `session_type::ORG_MEMBER`;
+    /// a coordinator root keeps its primary session type and uses the
+    /// coordinator member id. `agent_definition_id` identifies which
+    /// AgentDefinition that member runs.
     pub org_member_id: Option<String>,
 
     pub parent_session_id: Option<String>,

--- a/src-tauri/src/agent_sessions/session_directory/aggregation/native_sidebar.rs
+++ b/src-tauri/src/agent_sessions/session_directory/aggregation/native_sidebar.rs
@@ -140,6 +140,14 @@ fn list_pinned_native_sidebar_sessions(
           AND s.status != ?1
           AND s.parent_session_id IS NULL
           AND s.session_type IN (?2, ?3, ?4)
+          AND (
+              s.org_member_id IS NULL
+              OR EXISTS (
+                  SELECT 1
+                  FROM agent_org_runtime_runs r
+                  WHERE r.root_session_id = s.session_id
+              )
+          )
         {agent_cursor}
         UNION ALL
         SELECT c.session_id, c.updated_at, 'cli' AS source_kind
@@ -387,11 +395,29 @@ mod tests {
     }
 
     #[test]
-    fn pinned_native_page_merges_agent_and_cli_roots_in_stable_order() {
+    fn pinned_native_page_excludes_orphan_members_before_capacity() {
         let _sandbox = crate::test_utils::test_env::sandbox();
         let conn = get_connection().expect("sandbox database");
 
-        for (session_id, session_type, updated_at, pinned, parent, status) in [
+        for (session_id, session_type, updated_at, pinned, parent, status, member) in [
+            (
+                "orphan-coordinator-pinned",
+                session_type::CODING,
+                "2026-07-30T18:00:00Z",
+                true,
+                None,
+                "idle",
+                Some("coordinator"),
+            ),
+            (
+                "agent-org-root-pinned",
+                session_type::CODING,
+                "2026-07-30T17:00:00Z",
+                true,
+                None,
+                "idle",
+                Some("coordinator"),
+            ),
             (
                 "sdeagent-pinned",
                 session_type::CODING,
@@ -399,6 +425,7 @@ mod tests {
                 true,
                 None,
                 "idle",
+                None,
             ),
             (
                 "osagent-pinned",
@@ -407,6 +434,7 @@ mod tests {
                 true,
                 None,
                 "idle",
+                None,
             ),
             (
                 "humansession-pinned",
@@ -415,6 +443,7 @@ mod tests {
                 true,
                 None,
                 "completed",
+                None,
             ),
             (
                 "sdeagent-unpinned",
@@ -423,6 +452,7 @@ mod tests {
                 false,
                 None,
                 "idle",
+                None,
             ),
             (
                 "sdeagent-worker",
@@ -431,6 +461,7 @@ mod tests {
                 true,
                 Some("sdeagent-pinned"),
                 "running",
+                None,
             ),
             (
                 "sdeagent-archived",
@@ -439,6 +470,7 @@ mod tests {
                 true,
                 None,
                 "archived",
+                None,
             ),
         ] {
             session_persistence::upsert_session(&UnifiedSessionRecord {
@@ -447,6 +479,7 @@ mod tests {
                 status: status.to_string(),
                 session_type: session_type.to_string(),
                 parent_session_id: parent.map(str::to_string),
+                org_member_id: member.map(str::to_string),
                 created_at: updated_at.to_string(),
                 updated_at: updated_at.to_string(),
                 pinned,
@@ -454,6 +487,18 @@ mod tests {
             })
             .expect("seed native session");
         }
+        conn.execute(
+            "INSERT INTO agent_org_runtime_runs (
+                id, org_id, coordinator_agent_id, root_session_id,
+                entry_mode, status, created_at, updated_at
+             ) VALUES (
+                'run-agent-org-root-pinned', 'org-pinned', 'builtin:sde',
+                'agent-org-root-pinned', 'standalone_session', 'running',
+                '2026-07-30T17:00:00Z', '2026-07-30T17:00:00Z'
+             )",
+            [],
+        )
+        .expect("seed pinned Agent Org run");
 
         for (session_id, updated_at, pinned, parent) in [
             ("cliagent-pinned", "2026-07-30T13:00:00Z", true, None),
@@ -475,7 +520,7 @@ mod tests {
             .expect("seed CLI session");
         }
 
-        let page = list_native_sidebar_sessions(NativeSidebarSessionStream::PinnedNative, None, 10)
+        let page = list_native_sidebar_sessions(NativeSidebarSessionStream::PinnedNative, None, 4)
             .expect("load global pinned page");
 
         assert_eq!(
@@ -484,14 +529,89 @@ mod tests {
                 .map(|session| session.session_id.as_str())
                 .collect::<Vec<_>>(),
             vec![
+                "agent-org-root-pinned",
                 "sdeagent-pinned",
                 "cliagent-pinned",
                 "osagent-pinned",
-                "humansession-pinned",
             ]
         );
         assert!(page.sessions.iter().all(|session| session.pinned));
-        assert!(!page.has_more);
+        assert!(page
+            .sessions
+            .iter()
+            .all(|session| session.session_id != "orphan-coordinator-pinned"));
+        assert_eq!(page.sessions[0].agent_org_id.as_deref(), Some("org-pinned"));
+        assert!(page.has_more);
+        assert_eq!(
+            page.next_cursor.as_ref(),
+            Some(&NativeSidebarSessionCursor {
+                updated_at: "2026-07-30T12:00:00Z".to_string(),
+                session_id: "osagent-pinned".to_string(),
+            })
+        );
+
+        let second = list_native_sidebar_sessions(
+            NativeSidebarSessionStream::PinnedNative,
+            page.next_cursor.as_ref(),
+            4,
+        )
+        .expect("load second global pinned page");
+        assert_eq!(
+            second
+                .sessions
+                .iter()
+                .map(|session| session.session_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["humansession-pinned"]
+        );
+        assert!(!second.has_more);
+    }
+
+    #[test]
+    fn pinned_native_query_uses_bounded_order_and_root_membership_indexes() {
+        let _sandbox = crate::test_utils::test_env::sandbox();
+        let conn = get_connection().expect("sandbox database");
+        let mut stmt = conn
+            .prepare(
+                "EXPLAIN QUERY PLAN
+                 SELECT s.session_id, s.updated_at, 'agent' AS source_kind
+                 FROM agent_sessions s
+                 WHERE s.pinned = 1
+                   AND s.status != 'archived'
+                   AND s.parent_session_id IS NULL
+                   AND s.session_type IN ('sde', 'os', 'human')
+                   AND (
+                       s.org_member_id IS NULL
+                       OR EXISTS (
+                           SELECT 1
+                           FROM agent_org_runtime_runs r
+                           WHERE r.root_session_id = s.session_id
+                       )
+                   )
+                 UNION ALL
+                 SELECT c.session_id, c.updated_at, 'cli' AS source_kind
+                 FROM code_sessions c
+                 WHERE c.pinned = 1
+                   AND c.parent_session_id IS NULL
+                 ORDER BY updated_at DESC, session_id DESC
+                 LIMIT 11",
+            )
+            .expect("prepare pinned native query plan");
+        let details = stmt
+            .query_map([], |row| row.get::<_, String>(3))
+            .expect("read pinned native query plan")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("collect pinned native query plan")
+            .join("\n");
+
+        assert!(
+            details.contains("idx_agent_sessions_sidebar"),
+            "pinned agent page did not use ordered sidebar index:\n{details}"
+        );
+        assert!(
+            details.contains("idx_agent_org_runtime_runs_root_session"),
+            "pinned root membership probe did not use root-session index:\n{details}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Fixes #803.

The session sidebar paginates each native stream before rendering it. PR #1190 already fixes the standalone SDE stream so rows marked with `org_member_id` cannot consume that stream's page capacity unless they are represented as a persisted Agent Org root. The remaining gap was the global pinned-native stream: it accepted every pinned, top-level native row before applying the cursor and `LIMIT`.

Historical coordinator/member rows can retain `org_member_id` after their Agent Org runtime run is gone. Those orphan rows are not valid standalone sessions or valid Agent Org roots, but the pinned query let them displace real pinned SDE, OS, Human, and CLI sessions.

The completed Agent Org stack also remained hidden in ordinary release builds because both the frontend bundle and Rust runtime defaulted the rollout gate off. This top-stack commit makes the completed product available by default while preserving an explicit environment opt-out.

The authoritative session source is `agent_sessions`. A membership-marked row is a valid root only when `agent_org_runtime_runs.root_session_id` points to it.

## Solution

- Stack this PR directly on PR #1190 (`fix/issue-840-startup-compatibility`) and keep its standalone-stream fix unchanged.
- Filter pinned native rows before cursor ordering and page capacity. Rows without `org_member_id` remain eligible; membership-marked rows require a matching persisted runtime run.
- Preserve valid pinned coordinator roots and the existing cross-store pinned order.
- Clarify the persisted field contract: a coordinator root keeps its primary SDE session type while carrying the coordinator member id.
- Add regression coverage for first-page capacity, continuation cursors, second-page exhaustion, valid-root annotation, cross-store ordering, and indexed query plans.
- Default `ORGII_AGENT_ORG_REDESIGN` to `1` in ordinary frontend bundles, while preserving explicit `0`.
- Default the Rust rollout gate on when the variable is absent; explicit values remain fail-closed unless they are exactly `1`.
- Keep unit-test and WebDriver builds force-enabled, and add regression coverage for default-on and explicit opt-out behavior.

The pagination portion remains a read-path invariant fix. The rollout activation changes only build/runtime defaults; neither change modifies schemas, migrations, writers, RPC/wire formats, frontend filters, or persisted historical data.

## Potential risks

- Any pinned row that carries `org_member_id` but has no persisted runtime run will now be hidden. This is intentional: such a row violates the native-sidebar domain invariant and must not consume page capacity.
- Valid coordinator roots depend on `agent_org_runtime_runs.root_session_id`. Regression tests explicitly prove those roots remain visible and annotated.
- Historical orphan rows remain in SQLite. No destructive cleanup or migration is performed; rollback is a normal revert of this commit with no data recovery step.
- The added correlated membership probe runs once per bounded candidate row. Query-plan tests and a read-only real-database plan both show the existing sidebar index and root-session covering index are used.
- This PR depends on PR #1190 (`fix/issue-840-startup-compatibility`) and must be reviewed and merged as its child in the stack.
- The PR #1190 base rejects legacy databases with a partial Agent Org runtime schema. That inherited startup contract is outside this PR's scope; true-machine verification used a complete 33/33 runtime schema copied into an isolated profile.
- Agent Org now ships enabled by default. Operators can set `ORGII_AGENT_ORG_REDESIGN=0` to disable it; rollback is either that environment override or reverting the activation commit. Malformed explicit values remain disabled on both frontend and backend.
- macOS packaged-app behavior was exercised. Other platforms were covered by Rust boundary tests and static checks, but not by a packaged UI run.

## Verification

- `node --test scripts/dev/webpack-config-light.test.cjs` — 6 passed, including default-on, explicit opt-out, and WebDriver force-enable cases.
- `TAURI_CONFIG='{"bundle":{"externalBin":[]}}' cargo +1.98.0 test -p agent_core production_gate_defaults_enabled_and_explicit_values_fail_closed` — 1 passed.
- `TAURI_CONFIG='{"bundle":{"externalBin":[]}}' cargo +1.98.0 clippy -p agent_core --all-targets -- -D warnings` — passed.
- `rustfmt --edition 2021 --check crates/agent-core/src/core/coordination/agent_org_runs/rollout.rs` and Prettier on the changed test file — passed.
- `cargo test --manifest-path src-tauri/Cargo.toml -p agent_core core::session::persistence::sidebar::tests -- --nocapture` — 4 passed, 0 failed.
- `cargo test --manifest-path src-tauri/Cargo.toml -p org2 native_sidebar -- --nocapture` — 5 passed, 0 failed.
- `rustfmt --edition 2021 --check src-tauri/src/agent_sessions/session_directory/aggregation/native_sidebar.rs src-tauri/crates/agent-core/src/core/session/persistence/crud/record.rs` — passed.
- `git diff --check` — passed.
- `cargo check --manifest-path src-tauri/Cargo.toml -p agent_core -p org2 --all-targets` — passed.
- `cargo clippy --manifest-path src-tauri/Cargo.toml -p agent_core -p org2 --all-targets -- -D warnings` — passed. Cargo only reported the existing future-incompatibility notice for `block v0.1.6`.
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check` — not clean because PR #1190 already contains unrelated rustfmt differences; both files changed by this PR pass rustfmt independently.
- Read-only real database check — found 42 historical orphan top-level SDE rows. Under the old predicate, 27 of the first 51 rows were orphans; the fixed predicate returned a full 51-row eligible page. `EXPLAIN QUERY PLAN` used `idx_agent_sessions_sidebar` and `idx_agent_org_runtime_runs_root_session`.
- `ORGII_AGENT_ORG_REDESIGN=1 pnpm run tauri:build:fast` — passed and produced `src-tauri/target/dev-build/bundle/macos/ORG2.app`. Executable SHA-256: `5715ce2ecf55491aa206b501d65f3b146ecc50a26298833b2daee567d89a8dca`.
- Packaged-app true-machine test with an isolated profile — seeded 51 rows: 27 orphan rows and 24 eligible rows. The initial UI showed 10 valid pinned and 10 valid standalone rows with Load more; two Load more actions revealed all 12 valid pinned rows and all 12 valid unpinned/root rows, then removed the control. No orphan label appeared, while both valid roots remained visible.
- Packaged-app restart — normal Command-Q shutdown preserved `PRAGMA quick_check = ok`; reopening returned the same bounded first page and Load more state.
- Idle packaged-app samples — 0.0% CPU in three samples and approximately 158 MiB RSS. No session-sidebar RPC, database-open, or panic errors appeared in the isolated backend/frontend logs. The isolated run did show unrelated updater-network and code-editor WebSocket warnings.
- Pre-commit hook — scoped clippy passed for `agent_core` and `org2`; no TypeScript files were staged.

No screenshot is attached because this changes query membership and page capacity, not visual layout. The rendered macOS sidebar was exercised through Computer Use with explicit row and control assertions.
