### PR TITLE
test(chat): use a valid session icon fixture

### DIFF
--- a/src/engines/ChatPanel/components/SessionIdentityIcon.test.ts
+++ b/src/engines/ChatPanel/components/SessionIdentityIcon.test.ts
@@ -59,7 +59,13 @@ describe("resolveSessionIdentityIconSource", () => {
   it("keeps pending remote identity authoritative over a stale local row", () => {
     expect(
       resolveSessionIdentityIconSource(
-        { session_id: "pending-session", agentIconId: "orgii" },
+        {
+          session_id: "pending-session",
+          status: "running",
+          created_at: "2026-08-14T00:00:00.000Z",
+          updated_at: "2026-08-14T00:00:00.000Z",
+          agentIconId: "orgii",
+        },
         "pending-session",
         "codex",
         undefined


### PR DESCRIPTION
## Problem

The latest `develop` branch fails the frontend CI typecheck in `SessionIdentityIcon.test.ts`. The stale-local-session fixture supplies only `session_id` and `agentIconId`, but the production helper accepts a complete `Session`, whose required fields also include `status`, `created_at`, and `updated_at`. This prevents every newly opened PR from getting a green frontend check even when its own diff is unrelated.

## Solution

Complete the test fixture with the three required `Session` fields. The fixture now respects the production type contract while continuing to exercise the same pending-remote-icon precedence behavior. No runtime code or behavior changes.

## Potential risks

The added status and timestamps are inert for this test path because the helper only observes session identity metadata. A future change that makes icon precedence depend on lifecycle timestamps would require this fixture to be revisited. Rollback is a normal one-commit revert; there is no API, persistence, dependency, or UI change.

## Verification

- `pnpm install --frozen-lockfile` — completed successfully; the optional legacy `node-sass` install emitted a local Node/Python compatibility warning, but package installation and all following checks completed.
- `pnpm typecheck` — passed.
- `pnpm exec vitest run src/engines/ChatPanel/components/SessionIdentityIcon.test.ts` — passed, 1 file / 6 tests.
- `pnpm exec eslint src/engines/ChatPanel/components/SessionIdentityIcon.test.ts` — passed.
- `pnpm exec prettier --check src/engines/ChatPanel/components/SessionIdentityIcon.test.ts` — passed.
- `git diff --check` — passed.
- Repository commit hook — passed lint-staged and scoped TypeScript checking.

No screenshot is included because this changes only a typed unit-test fixture and has no rendered UI effect.