### PR TITLE
fix(chat): keep post-abort messages through stale replays and races

### DIFF
--- a/src-tauri/src/agent_sessions/cli/commands/run.rs
+++ b/src-tauri/src/agent_sessions/cli/commands/run.rs
@@ -115,6 +115,8 @@ pub async fn cli_agent_run(mut request: CliRunRequest) -> Result<(), String> {
         request.turn_intent_id.take(),
         request.client_message_id.take(),
     );
+    let control_lock = session_runner::session_control_lock(&request.session_id).await;
+    let _control_guard = control_lock.lock().await;
     run_turn(request, turn).await
 }
 
@@ -520,6 +522,11 @@ pub async fn cli_agent_message(request: CliMessageRequest) -> Result<CliRunRecei
         }
     }
 
+    // From the kill through run_turn acceptance this must not interleave
+    // with a cancel_session for the same session (see session_control_lock).
+    let control_lock = session_runner::session_control_lock(&session_id).await;
+    let control_guard = control_lock.lock().await;
+
     // Kill the existing agent process, Tokio task, and per-session proxy.
     tracing::info!(session_id = %session_id, "cli_agent_message: killing existing runner");
     session_runner::kill_running_agent(&session_id).await;
@@ -625,6 +632,7 @@ pub async fn cli_agent_message(request: CliMessageRequest) -> Result<CliRunRecei
         turn,
     )
     .await?;
+    drop(control_guard);
     Ok(CliRunReceipt {
         session_id,
         turn_intent_id,

--- a/src-tauri/src/agent_sessions/cli/commands/run.rs
+++ b/src-tauri/src/agent_sessions/cli/commands/run.rs
@@ -530,6 +530,10 @@ pub async fn cli_agent_message(request: CliMessageRequest) -> Result<CliRunRecei
     // Kill the existing agent process, Tokio task, and per-session proxy.
     tracing::info!(session_id = %session_id, "cli_agent_message: killing existing runner");
     session_runner::kill_running_agent(&session_id).await;
+    // The killed runner's finalize never runs (task aborted), so wake any
+    // parked approval long-poll here — otherwise it lingers until the 120s
+    // park timeout even though its process is gone.
+    super::super::hook_approvals::unregister_session(&session_id);
     tracing::info!(session_id = %session_id, "cli_agent_message: existing runner cleanup complete");
 
     // Resolve the resume id AFTER the old runner is dead — a slow runner

--- a/src-tauri/src/agent_sessions/cli/commands/transcript.rs
+++ b/src-tauri/src/agent_sessions/cli/commands/transcript.rs
@@ -20,33 +20,43 @@ fn load_native_transcript_chunks(session: &CodeSession) -> Option<Vec<ActivityCh
         .as_deref()
         .and_then(key_vault::key_store::ModelType::from_str)?;
     let binding = native_transcript::native_transcript_binding(&agent)?;
-    let cli_session_id =
-        persistence::latest_native_transcript_id(&session.session_id, binding.source)
-            .ok()
-            .flatten()
-            .or_else(|| session.cli_session_id.clone())?;
-    let imported_id = binding.imported_session_id(&cli_session_id);
-    let conn = database::db::get_connection().ok()?;
-    match orgtrack_core::sources::imported_history::load_activity_chunks_for_session(
-        &conn,
-        &imported_id,
-    ) {
-        Ok(Some(mut chunks)) if !chunks.is_empty() => {
-            // Loaders stamp the imported id; the frontend event store,
-            // WS merge, and snapshot keys all key on the managed id.
-            for chunk in &mut chunks {
-                chunk.session_id = session.session_id.clone();
-            }
-            Some(chunks)
-        }
-        Ok(_) => None,
-        Err(err) => {
-            tracing::warn!(
-                "[cli_agent_chunks] Native transcript load failed for {imported_id}: {err}"
-            );
-            None
+    // Walk the binding ledger newest→oldest instead of trusting only the
+    // newest id: an aborted follow-up can bind a fork whose file the killed
+    // CLI never flushed, and replaying "nothing" would blank turns that a
+    // superseded fork still holds.
+    let mut candidate_ids =
+        persistence::native_transcript_ids_newest_first(&session.session_id, binding.source)
+            .unwrap_or_default();
+    if let Some(cli_session_id) = session.cli_session_id.clone() {
+        if !candidate_ids.contains(&cli_session_id) {
+            candidate_ids.push(cli_session_id);
         }
     }
+    let conn = database::db::get_connection().ok()?;
+    for cli_session_id in candidate_ids {
+        let imported_id = binding.imported_session_id(&cli_session_id);
+        match orgtrack_core::sources::imported_history::load_activity_chunks_for_session(
+            &conn,
+            &imported_id,
+        ) {
+            Ok(Some(mut chunks)) if !chunks.is_empty() => {
+                // Loaders stamp the imported id; the frontend event store,
+                // WS merge, and snapshot keys all key on the managed id.
+                for chunk in &mut chunks {
+                    chunk.session_id = session.session_id.clone();
+                }
+                return Some(chunks);
+            }
+            Ok(_) => continue,
+            Err(err) => {
+                tracing::warn!(
+                    "[cli_agent_chunks] Native transcript load failed for {imported_id}: {err}"
+                );
+                continue;
+            }
+        }
+    }
+    None
 }
 
 /// Where a managed session's transcript of record lives, for display

--- a/src-tauri/src/agent_sessions/cli/persistence/mod.rs
+++ b/src-tauri/src/agent_sessions/cli/persistence/mod.rs
@@ -427,6 +427,26 @@ mod resume_state_tests {
     }
 
     #[test]
+    fn native_transcript_ledger_walks_forks_newest_first() {
+        let _sandbox = test_env::sandbox();
+        let session_id = "cli-native-ledger-order";
+        create_test_session(session_id, "account-a");
+        update_cli_session_id(session_id, "fork-1").expect("bind first fork");
+        update_cli_session_id(session_id, "fork-2").expect("bind second fork");
+        update_cli_session_id(session_id, "fork-3").expect("bind third fork");
+
+        let ids =
+            native_transcript_ids_newest_first(session_id, "claude_code").expect("load ledger");
+        assert_eq!(ids, vec!["fork-3", "fork-2", "fork-1"]);
+        assert_eq!(
+            latest_native_transcript_id(session_id, "claude_code")
+                .expect("load latest")
+                .as_deref(),
+            ids.first().map(String::as_str)
+        );
+    }
+
+    #[test]
     fn late_resume_id_write_after_delete_does_not_create_orphan_state() {
         let _sandbox = test_env::sandbox();
         let session_id = "cli-resume-delete-race";

--- a/src-tauri/src/agent_sessions/cli/persistence/session_crud.rs
+++ b/src-tauri/src/agent_sessions/cli/persistence/session_crud.rs
@@ -594,6 +594,25 @@ pub fn latest_native_transcript_id(session_id: &str, source: &str) -> SqliteResu
     .optional()
 }
 
+/// Every native transcript id ever bound to this managed session, newest
+/// first. Replay walks this list until it finds a fork whose store is
+/// actually readable — the newest binding can point at a file the CLI never
+/// flushed (killed right after the resume rotation).
+pub fn native_transcript_ids_newest_first(
+    session_id: &str,
+    source: &str,
+) -> SqliteResult<Vec<String>> {
+    let conn = get_connection()?;
+    let mut stmt = conn.prepare(
+        "SELECT source_session_id
+         FROM code_session_native_transcript_ids
+         WHERE session_id = ?1 AND source = ?2
+         ORDER BY bound_at DESC",
+    )?;
+    let rows = stmt.query_map(params![session_id, source], |row| row.get(0))?;
+    rows.collect()
+}
+
 pub fn get_cli_session_id_for_account(
     session_id: &str,
     account_id: Option<&str>,

--- a/src-tauri/src/agent_sessions/cli/session_runner/helpers.rs
+++ b/src-tauri/src/agent_sessions/cli/session_runner/helpers.rs
@@ -20,6 +20,23 @@ type RunningSessionsMap = HashMap<String, tokio::task::JoinHandle<()>>;
 pub static RUNNING_SESSIONS: std::sync::LazyLock<Arc<Mutex<RunningSessionsMap>>> =
     std::sync::LazyLock::new(|| Arc::new(Mutex::new(HashMap::new())));
 
+type SessionControlLocksMap = HashMap<String, Arc<Mutex<()>>>;
+
+/// Per-session serialization of lifecycle control (cancel vs. new-turn
+/// dispatch). Without it, a slow `cancel_session` can interleave with a
+/// follow-up `cli_agent_message` and cancel the NEW turn's intent / kill the
+/// new process. Lock order: control lock → RUNNING_SESSIONS.
+static SESSION_CONTROL_LOCKS: std::sync::LazyLock<Mutex<SessionControlLocksMap>> =
+    std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
+
+pub async fn session_control_lock(session_id: &str) -> Arc<Mutex<()>> {
+    let mut locks = SESSION_CONTROL_LOCKS.lock().await;
+    locks
+        .entry(session_id.to_string())
+        .or_insert_with(|| Arc::new(Mutex::new(())))
+        .clone()
+}
+
 /// Strip the `<ide_context>...</ide_context>` block from user input.
 /// IDE context is prepended by `inject_ide_context_into_prompt` for the CLI agent,
 /// but should not be stored in the DB or shown to the user in chat history.

--- a/src-tauri/src/agent_sessions/cli/session_runner/lifecycle.rs
+++ b/src-tauri/src/agent_sessions/cli/session_runner/lifecycle.rs
@@ -29,15 +29,25 @@ pub async fn terminate_process_tree(pid: i64, label: &str) {
         return;
     }
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
-    if process_tree_exists(pid) {
-        tracing::info!(
-            "[CodeSession] {} PID/group {} still alive after SIGTERM grace period, sending SIGKILL",
-            label,
-            pid
-        );
-        signal_process_tree(pid, libc::SIGKILL);
+    // Poll instead of one flat 3s sleep: the CLI usually dies within a few
+    // hundred ms, and every extra ms here delays the `cancelled` terminal
+    // the frontend is blocked on.
+    const SIGTERM_GRACE_MS: u64 = 3_000;
+    const POLL_INTERVAL_MS: u64 = 100;
+    let mut waited = 0;
+    while waited < SIGTERM_GRACE_MS {
+        tokio::time::sleep(tokio::time::Duration::from_millis(POLL_INTERVAL_MS)).await;
+        waited += POLL_INTERVAL_MS;
+        if !process_tree_exists(pid) {
+            return;
+        }
     }
+    tracing::info!(
+        "[CodeSession] {} PID/group {} still alive after SIGTERM grace period, sending SIGKILL",
+        label,
+        pid
+    );
+    signal_process_tree(pid, libc::SIGKILL);
 }
 
 #[cfg(windows)]
@@ -89,6 +99,13 @@ pub async fn kill_running_agent(session_id: &str) -> bool {
 /// The old token expires via the agent-proxy inactivity timeout or
 /// is released on session deletion.
 pub async fn cancel_session(session_id: &str, reason: CancelReason) -> Result<bool, String> {
+    // Serialize against `cli_agent_message` / `cli_agent_run` for this
+    // session: a cancel whose DB lookup lands after a follow-up turn was
+    // accepted would otherwise cancel the NEW intent and kill the new
+    // process ("stop then send loses both messages").
+    let control_lock = super::helpers::session_control_lock(session_id).await;
+    let _control_guard = control_lock.lock().await;
+
     // The previous `.ok().flatten()` collapsed a DB error and a
     // legitimate "session not found" into the same `None`. The
     // status_changed broadcast below would then ship without

--- a/src-tauri/src/agent_sessions/cli/session_runner/mod.rs
+++ b/src-tauri/src/agent_sessions/cli/session_runner/mod.rs
@@ -35,7 +35,7 @@ mod session;
 mod token_sync;
 
 pub(crate) use harness_hooks::stop_session as stop_session_hooks;
-pub use helpers::{flush_cli_streams_for_session, RUNNING_SESSIONS};
+pub use helpers::{flush_cli_streams_for_session, session_control_lock, RUNNING_SESSIONS};
 pub(crate) use input_assembly::forget_session_context;
 pub use lifecycle::{
     cancel_session, cleanup_cursor_config_dir, kill_running_agent, terminate_process_tree,

--- a/src-tauri/src/agent_sessions/event_pipeline/commands/batch_update.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/commands/batch_update.rs
@@ -61,14 +61,25 @@ pub async fn es_remove_by_id_prefix(
 }
 
 /// Remove frontend-injected user placeholders after the backend user turn arrives.
+/// `matching_contents` + `older_than` scope removal to placeholders that are
+/// echoed by one of those messages or predate the newest real user turn;
+/// omitted, every placeholder in the session is removed.
 #[tauri::command]
 pub async fn es_remove_synthetic_user_inputs(
     app: AppHandle,
     state: State<'_, EventStoreState>,
     session_id: Option<String>,
+    matching_contents: Option<Vec<String>>,
+    older_than: Option<String>,
 ) -> Result<usize, String> {
     let sid = state.resolve_session_id(session_id)?;
-    let removed = state.with_store_mut(&sid, |store| store.remove_synthetic_user_inputs());
+    let removed = state.with_store_mut(&sid, |store| {
+        store.remove_synthetic_user_inputs(
+            matching_contents
+                .as_deref()
+                .map(|contents| (contents, older_than.as_deref())),
+        )
+    });
     if removed > 0 {
         schedule_notify(&app, &state, &sid);
     }

--- a/src-tauri/src/agent_sessions/event_pipeline/ingestion/normalizer.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/ingestion/normalizer.rs
@@ -316,7 +316,7 @@ fn infer_display_status(
     EventDisplayStatus::Completed
 }
 
-fn is_ask_question_action(
+pub(crate) fn is_ask_question_action(
     action_type: &str,
     raw_function: &str,
     function_name: &str,

--- a/src-tauri/src/agent_sessions/event_pipeline/store/event_ops.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/store/event_ops.rs
@@ -7,8 +7,8 @@ use std::collections::HashSet;
 
 use super::helpers::{
     is_authoritative_transcript_message, is_completed_authoritative_stream_transcript,
-    is_synthetic_transcript_placeholder, normalized_event_text,
-    stream_placeholder_prefix_for_authoritative, transcript_message_key,
+    is_synthetic_transcript_placeholder, normalize_user_text, normalized_event_text,
+    stream_placeholder_prefix_for_authoritative, transcript_message_key, transcript_text,
 };
 use super::{
     active_shell_replays_for_session, bound_shell_replay_state, capture_shell_replay_bookmarks,
@@ -219,20 +219,48 @@ impl EventStore {
         self.remove_events_by_ids(existing_ids)
     }
 
-    pub fn remove_synthetic_user_inputs(&mut self) -> usize {
+    /// With no scope, removes every synthetic placeholder (legacy behavior).
+    /// A scope removes only placeholders that are echoed by one of the given
+    /// user-message contents, or that predate `older_than` (a placeholder
+    /// older than the newest real user turn can no longer receive an echo,
+    /// e.g. skill-pill messages whose wire content differs from the pill) —
+    /// a NEWER unmatched placeholder is a message whose echo has not arrived
+    /// yet and must survive history merges carrying older real user turns.
+    pub fn remove_synthetic_user_inputs(
+        &mut self,
+        scope: Option<(&[String], Option<&str>)>,
+    ) -> usize {
+        let scope = scope.map(|(contents, older_than)| {
+            let targets: std::collections::HashSet<String> = contents
+                .iter()
+                .map(|content| normalize_user_text(content))
+                .collect();
+            (targets, older_than.map(str::to_string))
+        });
+        let should_remove = |event: &SessionEvent| -> bool {
+            if event.source != EventSource::User || !is_synthetic_transcript_placeholder(event) {
+                return false;
+            }
+            let Some((targets, older_than)) = &scope else {
+                return true;
+            };
+            let content_matched = transcript_text(event)
+                .map(|text| targets.contains(&normalize_user_text(&text)))
+                .unwrap_or(false);
+            let predates_newest_real = older_than
+                .as_deref()
+                .is_some_and(|bound| !event.created_at.is_empty() && event.created_at.as_str() < bound);
+            content_matched || predates_newest_real
+        };
         let removed_ids: Vec<String> = self
             .events
             .iter()
-            .filter(|event| {
-                event.source == EventSource::User && is_synthetic_transcript_placeholder(event)
-            })
+            .filter(|event| should_remove(event))
             .map(|event| event.id.clone())
             .collect();
         let removed = removed_ids.len();
         if removed > 0 {
-            self.events.retain(|event| {
-                !(event.source == EventSource::User && is_synthetic_transcript_placeholder(event))
-            });
+            self.events.retain(|event| !should_remove(event));
             for event_id in removed_ids {
                 self.mark_removed(event_id);
             }

--- a/src-tauri/src/agent_sessions/event_pipeline/store/helpers.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/store/helpers.rs
@@ -57,6 +57,12 @@ pub(super) fn transcript_message_key(event: &SessionEvent) -> Option<(EventSourc
     }
 }
 
+/// Mirror of the frontend's `normalizeUserText` (collapse whitespace, trim)
+/// so content matching agrees across the IPC boundary.
+pub(super) fn normalize_user_text(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
 pub(super) fn normalized_event_text(event: &SessionEvent) -> String {
     event
         .display_text

--- a/src-tauri/src/agent_sessions/event_pipeline/store/repair.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/store/repair.rs
@@ -89,15 +89,28 @@ impl EventStore {
     /// the user can see the card but clicking it will fail because the backend
     /// has no corresponding pending entry to answer.
     ///
+    /// Managed-CLI question events are stamped `Pending` (not `AwaitingUser`)
+    /// by `infer_display_status`, so ask-question tool calls stuck in
+    /// `Pending` are swept too.
+    ///
     /// This method transitions those events directly to `Completed` and stamps
     /// a minimal `result` so `extractQuestionBatch` (FE) sees `displayStatus ==
     /// "completed"` and never renders a card for them.
     ///
     /// Returns the IDs of the cancelled events so callers can log / assert.
     pub fn cancel_orphan_interactive_events(&mut self) -> Vec<String> {
+        use crate::agent_sessions::event_pipeline::ingestion::normalizer::is_ask_question_action;
         let mut cancelled = Vec::new();
         for event in self.events.iter_mut() {
-            if event.display_status == EventDisplayStatus::AwaitingUser {
+            let is_orphan_question = event.display_status == EventDisplayStatus::AwaitingUser
+                || (event.display_status == EventDisplayStatus::Pending
+                    && is_ask_question_action(
+                        &event.action_type,
+                        &event.function_name,
+                        &event.ui_canonical,
+                        &event.args,
+                    ));
+            if is_orphan_question {
                 event.display_status = EventDisplayStatus::Completed;
                 // Stamp a minimal result so extractQuestionBatch treats it as
                 // answered (it checks result.success and result.error; a plain

--- a/src-tauri/src/agent_sessions/event_pipeline/tests/store_tests.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/tests/store_tests.rs
@@ -536,11 +536,73 @@ fn test_remove_synthetic_user_inputs_keeps_backend_user_input_ids() {
     backend.display_text = "authoritative different text".to_string();
 
     store.set(vec![synthetic, backend]);
-    let removed = store.remove_synthetic_user_inputs();
+    let removed = store.remove_synthetic_user_inputs(None);
 
     assert_eq!(removed, 1);
     assert!(store.get_by_id("user-input-synthetic").is_none());
     assert!(store.get_by_id("user-input-cliagent-real").is_some());
+}
+
+fn make_synthetic_user_event(id: &str, text: &str, created_at: &str) -> SessionEvent {
+    let mut event = make_event(id, "raw");
+    event.source = EventSource::User;
+    event.function_name = "user_message".to_string();
+    event.ui_canonical = "user_message".to_string();
+    event.result = serde_json::json!({
+        "type": "user",
+        "message": { "content": text, "role": "user" },
+        "syntheticUserInput": true,
+    });
+    event.chunk_id = None;
+    event.display_text = text.to_string();
+    event.created_at = created_at.to_string();
+    event
+}
+
+#[test]
+fn test_scoped_synthetic_removal_keeps_unechoed_newer_placeholder() {
+    let mut store = EventStore::new();
+    store.set(vec![
+        make_synthetic_user_event("user-input-echoed", "first message", "2026-08-14T10:00:00Z"),
+        make_synthetic_user_event(
+            "user-input-fresh",
+            "follow-up after abort",
+            "2026-08-14T10:05:00Z",
+        ),
+    ]);
+
+    // A history merge carrying only the FIRST turn's real user row (stale
+    // JSONL right after an abort) must evict the echoed placeholder but keep
+    // the fresh follow-up whose echo has not arrived yet.
+    let removed = store.remove_synthetic_user_inputs(Some((
+        &["first message".to_string()],
+        Some("2026-08-14T10:00:00Z"),
+    )));
+
+    assert_eq!(removed, 1);
+    assert!(store.get_by_id("user-input-echoed").is_none());
+    assert!(store.get_by_id("user-input-fresh").is_some());
+}
+
+#[test]
+fn test_scoped_synthetic_removal_drops_placeholder_predating_newest_real_turn() {
+    let mut store = EventStore::new();
+    store.set(vec![make_synthetic_user_event(
+        "user-input-stale-pill",
+        "/skill pill form",
+        "2026-08-14T09:00:00Z",
+    )]);
+
+    // A pill placeholder's wire content differs from its display text, so it
+    // can never content-match its echo — it is reaped by predating the
+    // newest real user turn instead.
+    let removed = store.remove_synthetic_user_inputs(Some((
+        &["expanded yaml payload".to_string()],
+        Some("2026-08-14T09:30:00Z"),
+    )));
+
+    assert_eq!(removed, 1);
+    assert!(store.get_by_id("user-input-stale-pill").is_none());
 }
 
 #[test]

--- a/src-tauri/src/agent_sessions/event_pipeline/tests/store_tests.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/tests/store_tests.rs
@@ -1385,6 +1385,33 @@ fn test_cancel_orphan_interactive_events_cancels_awaiting_user() {
 }
 
 #[test]
+fn test_cancel_orphan_interactive_events_sweeps_pending_cli_question() {
+    let mut store = EventStore::new();
+    // Managed-CLI question events are stamped Pending (not AwaitingUser) by
+    // infer_display_status; the restart sweep must catch them too.
+    let mut cli_question = make_tool_call("cli-ask-1", "call-cli-ask-1");
+    cli_question.function_name = "AskUserQuestion".to_string();
+    cli_question.ui_canonical = "ask_user_questions".to_string();
+    cli_question.display_status = EventDisplayStatus::Pending;
+    // A pending NON-question tool call must be left alone.
+    let mut pending_other = make_tool_call("other-1", "call-other-1");
+    pending_other.display_status = EventDisplayStatus::Pending;
+    store.set(vec![cli_question, pending_other]);
+
+    let cancelled = store.cancel_orphan_interactive_events();
+
+    assert_eq!(cancelled, vec!["cli-ask-1".to_string()]);
+    assert_eq!(
+        store.get_by_id("cli-ask-1").unwrap().display_status,
+        EventDisplayStatus::Completed
+    );
+    assert_eq!(
+        store.get_by_id("other-1").unwrap().display_status,
+        EventDisplayStatus::Pending
+    );
+}
+
+#[test]
 fn test_cancel_orphan_interactive_events_leaves_running_untouched() {
     let mut store = EventStore::new();
     let running = make_tool_call("run-1", "call-run-1");

--- a/src/api/tauri/rpc/procedures/sessionCore.ts
+++ b/src/api/tauri/rpc/procedures/sessionCore.ts
@@ -217,7 +217,7 @@ const eventStore = {
     .output(z.number())
     .build(),
   removeSyntheticUserInputs: defineProcedure("es_remove_synthetic_user_inputs")
-    .input(schemas.sessionCore.NullableSessionIdInput)
+    .input(schemas.sessionCore.RemoveSyntheticUserInputsInput)
     .output(z.number())
     .build(),
   replaceAndRemove: defineProcedure("es_replace_and_remove")

--- a/src/api/tauri/rpc/schemas/sessionCore.ts
+++ b/src/api/tauri/rpc/schemas/sessionCore.ts
@@ -260,6 +260,12 @@ export const NullableSessionIdInput = z.object({
   sessionId: z.string().nullable(),
 });
 
+export const RemoveSyntheticUserInputsInput = z.object({
+  sessionId: z.string().nullable(),
+  matchingContents: z.array(z.string()).optional(),
+  olderThan: z.string().optional(),
+});
+
 export const SessionIdInput = z.object({
   sessionId: z.string(),
 });

--- a/src/engines/ChatPanel/hooks/useInputArea/__tests__/questionIntercept.test.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/__tests__/questionIntercept.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { rejectQuestion, respondQuestion } from "@src/api/tauri/agent";
+import { markQuestionAnswered } from "@src/engines/ChatPanel/InputArea/AskQuestionCard/questionSubmitUtils";
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+
+import { interceptPendingQuestionBatches } from "../questionIntercept";
+
+vi.mock("@src/api/tauri/agent", () => ({
+  respondQuestion: vi.fn(),
+  rejectQuestion: vi.fn(),
+}));
+
+vi.mock(
+  "@src/engines/ChatPanel/InputArea/AskQuestionCard/questionSubmitUtils",
+  () => ({
+    markQuestionAnswered: vi.fn().mockResolvedValue(true),
+  })
+);
+
+function makeCliQuestionEvent(
+  options: string[][] = [["Option A", "Option B"]]
+): SessionEvent {
+  return {
+    id: "tool-call-ask-1",
+    chunk_id: null,
+    sessionId: "cliagent-1",
+    createdAt: "2026-08-14T10:00:00.000Z",
+    functionName: "ask_user_questions",
+    uiCanonical: "ask_user_questions",
+    actionType: "tool_call",
+    callId: "call-ask-1",
+    source: "assistant",
+    args: {
+      questions: options.map((opts, idx) => ({
+        question: `Question ${idx + 1}?`,
+        options: opts,
+      })),
+    },
+    result: {},
+    displayText: "",
+    displayStatus: "pending",
+    displayVariant: "tool",
+    activityStatus: "pending",
+  } as unknown as SessionEvent;
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe("interceptPendingQuestionBatches", () => {
+  beforeEach(() => {
+    vi.mocked(respondQuestion).mockReset().mockResolvedValue(undefined);
+    vi.mocked(rejectQuestion).mockReset().mockResolvedValue(undefined);
+    vi.mocked(markQuestionAnswered).mockClear();
+  });
+
+  it("finalizes an option-based CLI question locally when the native reject has no bridge", async () => {
+    vi.mocked(rejectQuestion).mockRejectedValue(
+      new Error("No session found for question reject")
+    );
+
+    interceptPendingQuestionBatches(
+      [makeCliQuestionEvent()],
+      "cliagent-1",
+      "just continue without my answer",
+      "Skipped"
+    );
+    await flushMicrotasks();
+
+    expect(rejectQuestion).toHaveBeenCalledWith("cliagent-1", "call-ask-1");
+    expect(markQuestionAnswered).toHaveBeenCalledWith(
+      "cliagent-1",
+      "tool-call-ask-1",
+      [["Skipped"]],
+      "rejected"
+    );
+  });
+
+  it("forwards the typed text as the answer for a free-text question and finalizes on failure", async () => {
+    vi.mocked(respondQuestion).mockRejectedValue(
+      new Error("No session found for question response")
+    );
+
+    interceptPendingQuestionBatches(
+      [makeCliQuestionEvent([[]])],
+      "cliagent-1",
+      "my typed answer",
+      "Skipped"
+    );
+    await flushMicrotasks();
+
+    expect(respondQuestion).toHaveBeenCalledWith("cliagent-1", "call-ask-1", [
+      ["my typed answer"],
+    ]);
+    expect(markQuestionAnswered).toHaveBeenCalledWith(
+      "cliagent-1",
+      "tool-call-ask-1",
+      [["my typed answer"]]
+    );
+  });
+
+  it("also finalizes locally when the native command succeeds (belt and braces)", async () => {
+    interceptPendingQuestionBatches(
+      [makeCliQuestionEvent()],
+      "cliagent-1",
+      "hello",
+      "Skipped"
+    );
+    await flushMicrotasks();
+
+    expect(markQuestionAnswered).toHaveBeenCalledWith(
+      "cliagent-1",
+      "tool-call-ask-1",
+      [["Skipped"]],
+      "rejected"
+    );
+  });
+
+  it("ignores events from other sessions and already-completed questions", async () => {
+    const otherSession = {
+      ...makeCliQuestionEvent(),
+      sessionId: "other-session",
+    };
+    const completed = {
+      ...makeCliQuestionEvent(),
+      id: "tool-call-ask-2",
+      displayStatus: "completed",
+    } as unknown as SessionEvent;
+
+    interceptPendingQuestionBatches(
+      [otherSession, completed],
+      "cliagent-1",
+      "hello",
+      "Skipped"
+    );
+    await flushMicrotasks();
+
+    expect(rejectQuestion).not.toHaveBeenCalled();
+    expect(respondQuestion).not.toHaveBeenCalled();
+    expect(markQuestionAnswered).not.toHaveBeenCalled();
+  });
+});

--- a/src/engines/ChatPanel/hooks/useInputArea/questionIntercept.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/questionIntercept.ts
@@ -1,0 +1,69 @@
+/**
+ * Question intercept for the main composer.
+ *
+ * When the agent asked a question (AskQuestionCard pending) and the user
+ * types into the main input instead of the card, the send finalizes the
+ * pending batch: free-text questions receive the typed text as the answer,
+ * option-based questions are skipped.
+ *
+ * The native commands (`agent_question_response` / `agent_question_reject`)
+ * have no CLI bridge — for managed CLI sessions they always fail with
+ * "No session found…" and no `agent:interaction_finalized` can ever arrive
+ * (there is no QuestionManager). The event store fallback below is therefore
+ * the ONLY closer on that path; without it the card lingers forever. Same
+ * resilience contract as the card's own click path (useQuestionSubmission).
+ */
+import { rejectQuestion, respondQuestion } from "@src/api/tauri/agent";
+import { extractQuestionBatch } from "@src/engines/ChatPanel/InputArea/AskQuestionCard/extractQuestionBatch";
+import { markQuestionAnswered } from "@src/engines/ChatPanel/InputArea/AskQuestionCard/questionSubmitUtils";
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+import { createLogger } from "@src/hooks/logger";
+
+const log = createLogger("questionIntercept");
+
+export function interceptPendingQuestionBatches(
+  events: SessionEvent[],
+  sessionId: string,
+  typedText: string,
+  skippedLabel: string
+): void {
+  for (const event of events) {
+    if (event.sessionId && event.sessionId !== sessionId) continue;
+    const batch = extractQuestionBatch(event);
+    if (!batch) continue;
+    const isFreeText = batch.questions.every(
+      (question) => question.options.length === 0
+    );
+    if (isFreeText) {
+      void respondQuestion(batch.sessionId, batch.questionId, [[typedText]])
+        .then(() =>
+          markQuestionAnswered(batch.sessionId, batch.chunkId, [[typedText]])
+        )
+        .catch((err: unknown) => {
+          log.warn("[questionIntercept] respondQuestion failed:", err);
+          void markQuestionAnswered(batch.sessionId, batch.chunkId, [
+            [typedText],
+          ]);
+        });
+    } else {
+      void rejectQuestion(batch.sessionId, batch.questionId)
+        .then(() =>
+          markQuestionAnswered(
+            batch.sessionId,
+            batch.chunkId,
+            [[skippedLabel]],
+            "rejected"
+          )
+        )
+        .catch((err: unknown) => {
+          log.warn("[questionIntercept] rejectQuestion failed:", err);
+          void markQuestionAnswered(
+            batch.sessionId,
+            batch.chunkId,
+            [[skippedLabel]],
+            "rejected"
+          );
+        });
+    }
+  }
+}

--- a/src/engines/ChatPanel/hooks/useInputArea/useSubmitMessage.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/useSubmitMessage.ts
@@ -18,9 +18,7 @@ import { useAtomValue, useStore } from "jotai";
 import React, { useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
-import { rejectQuestion, respondQuestion } from "@src/api/tauri/agent";
 import Message from "@src/components/Message";
-import { extractQuestionBatch } from "@src/engines/ChatPanel/InputArea/AskQuestionCard/extractQuestionBatch";
 import { chatEventsAtom } from "@src/engines/SessionCore";
 import { parseAddressCommentsSlashCommand } from "@src/features/Org2Cloud/addressCommentsSlashToken";
 import { useAddressCommentsSlashCommand } from "@src/features/Org2Cloud/useAddressCommentsSlashCommand";
@@ -40,6 +38,7 @@ import {
 import { resolveMcpSlashCommand } from "./mcpSlashCommand";
 import { expandSkillPills } from "./outgoingTextTransforms";
 import { projectOutgoingUserMessage } from "./projectOutgoingUserMessage";
+import { interceptPendingQuestionBatches } from "./questionIntercept";
 import type {
   CiteCodeSnapshot,
   InputAreaRefs,
@@ -214,31 +213,15 @@ export function useSubmitMessage({
       // ── Question intercept ────────────────────────────────────────────────
       // When the agent asked a question and the user typed a reply in the main
       // input, forward the typed text as the question answer before dispatching.
+      // Finalizes locally even when the native commands fail (no CLI bridge) —
+      // see questionIntercept.ts.
       if (enableAgentInterceptors && hasText && draftSessionId) {
-        const events = store.get(chatEventsAtom);
-        for (const event of events) {
-          if (event.sessionId && event.sessionId !== draftSessionId) continue;
-          const batch = extractQuestionBatch(event);
-          if (!batch) continue;
-          const isFreeText = batch.questions.every(
-            (question) => question.options.length === 0
-          );
-          if (isFreeText) {
-            void respondQuestion(batch.sessionId, batch.questionId, [
-              [displayText.trim()],
-            ]).catch((err: unknown) => {
-              log.warn("[useSubmitMessage] respondQuestion failed:", err);
-              Message.warning(t("chat.questionExpired"));
-            });
-          } else {
-            void rejectQuestion(batch.sessionId, batch.questionId).catch(
-              (err: unknown) => {
-                log.warn("[useSubmitMessage] rejectQuestion failed:", err);
-                Message.warning(t("chat.questionExpired"));
-              }
-            );
-          }
-        }
+        interceptPendingQuestionBatches(
+          store.get(chatEventsAtom),
+          draftSessionId,
+          displayText.trim(),
+          t("chat.skippedByUser")
+        );
       }
 
       // ── MCP slash-command resolution ─────────────────────────────────────

--- a/src/engines/SessionCore/core/atoms/__tests__/actions.test.ts
+++ b/src/engines/SessionCore/core/atoms/__tests__/actions.test.ts
@@ -446,6 +446,82 @@ describe("loadSessionAtom", () => {
     expect(store.get(transcriptReplaceEpochAtom)).toBe(epochBefore + 1);
   });
 
+  it("replace: keeps the just-sent synthetic when a stale replay carries only older turns (abort → send)", () => {
+    const store = createStore();
+    const replayUser = makeReplayEvent(
+      "claudecodeapp-user-0",
+      "first message",
+      "user",
+      "2026-05-16T00:00:01.000Z"
+    );
+    const replayAssistant = makeReplayEvent(
+      "claudecodeapp-asst-1",
+      "aborted partial answer",
+      "assistant",
+      "2026-05-16T00:00:02.000Z"
+    );
+    const freshSynthetic = {
+      ...makeUserMessageEvent("user-input-2", "follow-up after abort", {
+        synthetic: true,
+      }),
+      createdAt: "2026-05-16T00:00:05.000Z",
+    };
+
+    store.set(loadSessionAtom, {
+      sessionId: "session-1",
+      events: [replayUser, replayAssistant, freshSynthetic],
+    });
+    // Post-abort reconcile replays a JSONL that does not know about the
+    // follow-up yet — the fresh bubble must survive, after the history.
+    store.set(loadSessionAtom, {
+      sessionId: "session-1",
+      events: [replayUser, replayAssistant],
+      replace: true,
+    });
+
+    expect(store.get(eventsAtom).map((event) => event.id)).toEqual([
+      "claudecodeapp-user-0",
+      "claudecodeapp-asst-1",
+      "user-input-2",
+    ]);
+  });
+
+  it("merge: drops the echoed synthetic but keeps the fresh one still awaiting its echo", () => {
+    const store = createStore();
+    const echoedSynthetic = {
+      ...makeUserMessageEvent("user-input-1", "first message", {
+        synthetic: true,
+      }),
+      createdAt: "2026-05-16T00:00:00.500Z",
+    };
+    const freshSynthetic = {
+      ...makeUserMessageEvent("user-input-2", "follow-up after abort", {
+        synthetic: true,
+      }),
+      createdAt: "2026-05-16T00:00:05.000Z",
+    };
+    const replayUser = makeReplayEvent(
+      "claudecodeapp-user-0",
+      "first message",
+      "user",
+      "2026-05-16T00:00:01.000Z"
+    );
+
+    store.set(loadSessionAtom, {
+      sessionId: "session-1",
+      events: [echoedSynthetic, freshSynthetic],
+    });
+    store.set(loadSessionAtom, {
+      sessionId: "session-1",
+      events: [replayUser],
+    });
+
+    const ids = store.get(eventsAtom).map((event) => event.id);
+    expect(ids).toContain("user-input-2");
+    expect(ids).toContain("claudecodeapp-user-0");
+    expect(ids).not.toContain("user-input-1");
+  });
+
   it("replace: still recovers the synthetic user event when the replay has no backend user message yet", () => {
     const store = createStore();
     const synthetic = makeUserMessageEvent("user-input-1", "fix the bug", {

--- a/src/engines/SessionCore/core/atoms/actions.eventUpdates.ts
+++ b/src/engines/SessionCore/core/atoms/actions.eventUpdates.ts
@@ -12,6 +12,7 @@ import {
   isSyntheticUserInputEvent,
 } from "../../sync/utils/activityIds";
 import { eventStoreProxy } from "../store/EventStoreProxy";
+import { syntheticEvictionScopeForRealUserEvents } from "../store/eventStoreEvents";
 import type { SessionEvent } from "../types";
 import { isSimulatorVisibleApprox } from "./actions.simulatorPreview";
 import {
@@ -71,12 +72,12 @@ export const appendEventsAtom = atom(
       // placeholder so the user doesn't see a duplicate first message.
       // Use a semantic Rust-side removal instead of the getEvents→filter→set
       // pattern; events arriving between a TS-side read and write would be
-      // silently dropped.
-      const hasRealUserMessage = uniqueNewWithImages.some(
-        isBackendUserMessageEvent
-      );
-      if (hasRealUserMessage) {
-        eventStoreProxy.removeSyntheticUserInputEvents();
+      // silently dropped. Scoped to the echoed contents so a newer
+      // placeholder still awaiting its echo survives.
+      const evictionScope =
+        syntheticEvictionScopeForRealUserEvents(uniqueNewWithImages);
+      if (evictionScope) {
+        eventStoreProxy.removeSyntheticUserInputEvents(null, evictionScope);
       }
 
       // Incrementally extend the cached running-args map with new events

--- a/src/engines/SessionCore/core/atoms/actions.ts
+++ b/src/engines/SessionCore/core/atoms/actions.ts
@@ -26,6 +26,7 @@ import {
 } from "../../sync/utils/activityIds";
 import { isLiveRuntimeResourceEvent } from "../runningEventGate";
 import { eventStoreProxy } from "../store/EventStoreProxy";
+import { syntheticEvictionScopeForRealUserEvents } from "../store/eventStoreEvents";
 import type { SessionEvent, SessionSpec } from "../types";
 import {
   buildSimulatorPreviewFields,
@@ -37,6 +38,7 @@ import {
   getUserMessageImages,
   hasUserMessageImages,
   syntheticMatchesQueuedMessage,
+  syntheticSettledByScope,
   withUserMessageImages,
 } from "./actions.userMessageSync";
 import {
@@ -159,41 +161,58 @@ export const loadSessionAtom = atom(
       replace = false,
     } = payload;
 
-    // Preserve synthetic user events (injected by session launch) when the
-    // sync hooks reload from SQLite/API before the backend has persisted the
-    // user message. Without this, the first message disappears on navigation.
+    // Preserve synthetic user events (injected by session launch or a queue
+    // dispatch) when the sync hooks reload from SQLite/API/native transcript
+    // before the backend has persisted the user message. Without this, the
+    // just-sent message disappears on navigation or on a stale history
+    // replay right after an abort.
     //
     // Key distinction: synthetic events are frontend user_message rows with an
     // empty uiCanonical, while backend-echoed user turns normalize to
     // functionName/uiCanonical "user". IDs are not reliable because CLI backend
     // user events can also use the user-input-* prefix.
+    //
+    // A synthetic survives unless the incoming events prove it is settled:
+    // its echo is present (content match), or it predates the newest real
+    // user turn (its echo can no longer arrive; covers skill-pill messages
+    // whose wire content differs from the pill display).
     const currentSessionId = get(sessionIdAtom);
     const existingSameSessionEvents =
       currentSessionId === sessionId ? get(eventsAtom) : [];
-    const hasRealBackendUserMessages = events.some(isBackendUserMessageEvent);
+    const incomingEvictionScope =
+      syntheticEvictionScopeForRealUserEvents(events);
+    const isSettledByIncoming = (event: SessionEvent): boolean =>
+      syntheticSettledByScope(event, incomingEvictionScope);
     let syntheticUserEvents: SessionEvent[] = [];
 
     // Source 1: existing events in the store (same session, not yet cleared)
-    if (existingSameSessionEvents.length > 0 && !hasRealBackendUserMessages) {
-      syntheticUserEvents = existingSameSessionEvents.filter(
-        isSyntheticUserInputEvent
-      );
+    if (existingSameSessionEvents.length > 0) {
+      syntheticUserEvents = existingSameSessionEvents
+        .filter(isSyntheticUserInputEvent)
+        .filter((event) => !isSettledByIncoming(event));
     }
 
     // Source 2: pendingSyntheticEventAtom — survives clearSessionAtom so the
     // user message is recovered even after a session-switch clear.
-    if (syntheticUserEvents.length === 0 && !hasRealBackendUserMessages) {
-      const pending = get(pendingSyntheticEventAtom);
-      if (pending && pending.sessionId === sessionId) {
-        syntheticUserEvents = [pending];
-      }
+    const pending = get(pendingSyntheticEventAtom);
+    if (
+      syntheticUserEvents.length === 0 &&
+      pending &&
+      pending.sessionId === sessionId &&
+      !isSettledByIncoming(pending)
+    ) {
+      syntheticUserEvents = [pending];
     }
 
     // Only consume the pending event when the backend has echoed the real
     // user message. Until then, keep it around so subsequent loadSessionAtom
     // calls (from sync hooks) can recover it even if the async Rust store
     // write hasn't completed yet.
-    if (hasRealBackendUserMessages) {
+    if (
+      pending &&
+      pending.sessionId === sessionId &&
+      isSettledByIncoming(pending)
+    ) {
       set(pendingSyntheticEventAtom, null);
     }
 
@@ -307,10 +326,26 @@ export const loadSessionAtom = atom(
             syntheticMatchesQueuedMessage(evt, message)
           )
       );
-      mergedEvents =
-        uniqueSynthetic.length > 0
-          ? [...uniqueSynthetic, ...transcriptEvents]
-          : transcriptEvents;
+      if (uniqueSynthetic.length > 0) {
+        // A rescued synthetic newer than the replayed transcript is a
+        // just-sent follow-up — it belongs after the history, not before it
+        // (the prepend position is only right for the first-message case,
+        // where the transcript is empty).
+        const lastTranscriptAt =
+          transcriptEvents.length > 0
+            ? transcriptEvents[transcriptEvents.length - 1].createdAt
+            : undefined;
+        const trailing = uniqueSynthetic.filter(
+          (evt) =>
+            lastTranscriptAt !== undefined && evt.createdAt >= lastTranscriptAt
+        );
+        const leading = uniqueSynthetic.filter(
+          (evt) => !trailing.includes(evt)
+        );
+        mergedEvents = [...leading, ...transcriptEvents, ...trailing];
+      } else {
+        mergedEvents = transcriptEvents;
+      }
     } else {
       mergedEvents = transcriptEvents;
     }
@@ -330,8 +365,19 @@ export const loadSessionAtom = atom(
         }
       }
 
+      // Drop only synthetics the merged list proves are settled (echo
+      // present, or older than the newest real user turn). An unsettled
+      // synthetic is a just-sent message a stale replay does not know about
+      // yet — dropping it wholesale is exactly the "message disappears
+      // after abort" bug.
+      const mergedEvictionScope =
+        syntheticEvictionScopeForRealUserEvents(mergedEvents);
       mergedEvents = mergedEvents
-        .filter((event) => !isSyntheticUserInputEvent(event))
+        .filter(
+          (event) =>
+            !isSyntheticUserInputEvent(event) ||
+            !syntheticSettledByScope(event, mergedEvictionScope)
+        )
         .map((event) => {
           if (!isBackendUserMessageEvent(event)) return event;
           const content = getUserMessageContent(event);

--- a/src/engines/SessionCore/core/atoms/actions.userMessageSync.ts
+++ b/src/engines/SessionCore/core/atoms/actions.userMessageSync.ts
@@ -45,6 +45,29 @@ export function withUserMessageImages(
   };
 }
 
+/**
+ * Whether a synthetic user placeholder is settled by a batch of real backend
+ * user messages (summarized as a SyntheticEvictionScope): its echo is present
+ * (content match on either its display text or wire content), or it predates
+ * the newest real user turn so its echo can no longer arrive. Unsettled
+ * placeholders are messages still awaiting their echo and must be preserved.
+ */
+export function syntheticSettledByScope(
+  event: SessionEvent,
+  scope: { matchingContents: string[]; olderThan?: string } | null
+): boolean {
+  if (!scope) return false;
+  const targets = new Set(scope.matchingContents.map(normalizeUserText));
+  const eventTexts = [
+    normalizeUserText(event.displayText),
+    normalizeUserText(getUserMessageContent(event)),
+  ].filter((text) => text.length > 0);
+  if (eventTexts.some((text) => targets.has(text))) return true;
+  return Boolean(
+    scope.olderThan && event.createdAt && event.createdAt < scope.olderThan
+  );
+}
+
 export function syntheticMatchesQueuedMessage(
   event: SessionEvent,
   queued: { sessionId: string; content: string; displayContent: string }

--- a/src/engines/SessionCore/core/store/EventStoreProxy.ts
+++ b/src/engines/SessionCore/core/store/EventStoreProxy.ts
@@ -33,7 +33,11 @@ import type {
   SessionListener,
   Snapshot,
 } from "./EventStoreProxyTypes";
-import { inferSessionId, isRealUserEvent } from "./eventStoreEvents";
+import {
+  type SyntheticEvictionScope,
+  inferSessionId,
+  syntheticEvictionScopeForRealUserEvents,
+} from "./eventStoreEvents";
 import { SnapshotCacheManager } from "./snapshotCacheManager";
 
 export type {
@@ -173,9 +177,11 @@ class EventStoreProxyImpl {
     events: SessionEvent[],
     sessionId?: string | null
   ): Promise<void> {
-    if (!events.some(isRealUserEvent)) return;
+    const scope = syntheticEvictionScopeForRealUserEvents(events);
+    if (!scope) return;
     await this.removeSyntheticUserInputEvents(
-      sessionId ?? inferSessionId(events)
+      sessionId ?? inferSessionId(events),
+      scope
     );
   }
 
@@ -501,12 +507,20 @@ class EventStoreProxyImpl {
     });
   }
 
-  /** Remove frontend-injected user placeholders after backend echo arrives. */
+  /**
+   * Remove frontend-injected user placeholders after backend echo arrives.
+   * Without a scope every placeholder is removed; with one, only
+   * placeholders the scope proves are echoed/stale (see
+   * syntheticEvictionScopeForRealUserEvents).
+   */
   async removeSyntheticUserInputEvents(
-    sessionId?: string | null
+    sessionId?: string | null,
+    scope?: SyntheticEvictionScope
   ): Promise<number> {
     return rpc.sessionCore.eventStore.removeSyntheticUserInputs({
       sessionId: sessionId ?? null,
+      matchingContents: scope?.matchingContents,
+      olderThan: scope?.olderThan,
     });
   }
 

--- a/src/engines/SessionCore/core/store/eventStoreEvents.ts
+++ b/src/engines/SessionCore/core/store/eventStoreEvents.ts
@@ -14,3 +14,41 @@ export function inferSessionId(events: SessionEvent[]): string | null {
 export function isRealUserEvent(event: SessionEvent): boolean {
   return isBackendUserMessageEvent(event);
 }
+
+export interface SyntheticEvictionScope {
+  matchingContents: string[];
+  olderThan?: string;
+}
+
+/**
+ * Scope for evicting synthetic user placeholders when a batch carrying real
+ * backend user messages arrives: placeholders echoed by one of these
+ * contents, or predating the newest real user turn, are safe to remove. A
+ * newer unmatched placeholder is a just-sent message whose echo has not
+ * arrived (e.g. right after an abort, when history replays are stale) and
+ * must survive.
+ */
+export function syntheticEvictionScopeForRealUserEvents(
+  events: SessionEvent[]
+): SyntheticEvictionScope | null {
+  const contents = new Set<string>();
+  let olderThan: string | undefined;
+  for (const event of events) {
+    if (!isRealUserEvent(event)) continue;
+    if (event.displayText) contents.add(event.displayText);
+    const message = event.result?.message;
+    if (
+      typeof message === "object" &&
+      message !== null &&
+      "content" in message
+    ) {
+      const content = String(message.content ?? "");
+      if (content) contents.add(content);
+    }
+    if (event.createdAt && (!olderThan || event.createdAt > olderThan)) {
+      olderThan = event.createdAt;
+    }
+  }
+  if (contents.size === 0 && !olderThan) return null;
+  return { matchingContents: [...contents], olderThan };
+}

--- a/src/engines/SessionCore/sync/sessionSwitchOrchestrator.ts
+++ b/src/engines/SessionCore/sync/sessionSwitchOrchestrator.ts
@@ -9,6 +9,7 @@ import {
   isImportedHistorySession,
 } from "@src/util/session/sessionDispatch";
 
+import { isTurnActive } from "../control/turnLifecycle";
 import { getCursorIdeSnapshotLastUpdatedAt } from "./adapters/cursorIdeAdapter";
 import { isCursorIdeSessionId } from "./sessionSyncDerivedState";
 import { rehydratePendingPlanApproval } from "./sessionSyncPlanApproval";
@@ -127,7 +128,12 @@ async function handleCacheHit(
     : null;
   if (abortController.signal.aborted) return;
 
-  const cacheHitInFlight = isInFlightRunStatus(postResult?.runStatus);
+  // The DB status alone is not enough: right after an abort the row is
+  // terminal ("cancelled") while the frontend FSM is already dispatching the
+  // follow-up turn — treating that window as not-in-flight lets a stale
+  // history replace wipe the just-sent message.
+  const cacheHitInFlight =
+    isInFlightRunStatus(postResult?.runStatus) || isTurnActive(sessionId);
   let displayEvents = await eventStoreProxy.getEvents(sessionId);
   if (abortController.signal.aborted) return;
 
@@ -252,7 +258,8 @@ async function handleCacheMiss(
     : null;
   if (abortController.signal.aborted) return;
 
-  const missInFlight = isInFlightRunStatus(missPostResult?.runStatus);
+  const missInFlight =
+    isInFlightRunStatus(missPostResult?.runStatus) || isTurnActive(sessionId);
   const events = !missInFlight
     ? await loadPersistedHistory(adapter, sessionId, abortController.signal)
     : await adapter.loadHistory(sessionId, abortController.signal);

--- a/src/engines/SessionCore/sync/sessionSyncStateHelpers.ts
+++ b/src/engines/SessionCore/sync/sessionSyncStateHelpers.ts
@@ -3,6 +3,7 @@ import type { SetStateAction } from "react";
 import { wasRecentlyOptimisticallyStarted } from "@src/engines/SessionCore/control/optimisticTurnStatus";
 import { getTurnIntentDispatch } from "@src/engines/SessionCore/control/turnIntentDispatchLifecycle";
 import {
+  isTurnActive,
   markTurnRunning,
   markTurnTerminal,
   toTurnTerminalStatus,
@@ -158,6 +159,17 @@ export function applyPostLoadResult(
     actions.setSessionContextUsage(postResult.contextUsage);
   }
   if (postResult.runStatus !== undefined) {
+    if (
+      TERMINAL_HANDLER_STATUSES.has(postResult.runStatus) &&
+      isTurnActive(sessionId)
+    ) {
+      // postLoad reads a point-in-time DB status. Right after an abort the
+      // row is still terminal ("cancelled") while a follow-up turn is
+      // already dispatching/working — applying that stale terminal would
+      // close the live turn's FSM and flip the composer mid-run. The live
+      // status broadcast owns the transition; skip the stale snapshot.
+      return;
+    }
     actions.setSessionRuntimeStatus(toCliSessionStatus(postResult.runStatus));
     if (TERMINAL_HANDLER_STATUSES.has(postResult.runStatus)) {
       markTurnTerminal(sessionId, toTurnTerminalStatus(postResult.runStatus));


### PR DESCRIPTION
## Problem

Two related message-loss reports on managed CLI (native-transcript) sessions:

1. After stopping a running turn and immediately sending a new message, the new message sometimes vanished from the chat mid-run.
2. Sometimes both the new message and the aborted turn vanished, and after an app restart the aborted turn was gone entirely. Stopping also froze the UI for ~3 seconds.

## Root causes

Native-transcript sessions persist nothing app-side — the CLI's own JSONL is the transcript of record, and a just-sent message exists only as a frontend synthetic placeholder until a history replay happens to contain its echo.

- Any history batch carrying a real user row evicted **all** synthetic placeholders for the session (`loadSessionAtom` filter + `EventStoreProxy` blanket removal), so a stale replay right after an abort erased the freshly sent bubble.
- Session-switch in-flight guards keyed only on the DB status, which reads terminal (`cancelled`) during the abort-to-accept window; a stale terminal from `postLoad` could also close the live turn's FSM.
- `cancel_session` and `cli_agent_message` were not serialized. A slow cancel (its entry lookup is a `spawn_blocking` that queues under DB load) resolved "latest Running intent" **after** the follow-up turn was accepted — cancelling the new turn's intent and killing the new process.
- `terminate_process_tree` slept an unconditional 3s after SIGTERM before the `cancelled` terminal could broadcast — the post-Stop freeze.
- Replay resolved exactly one (the newest) native transcript binding; a fork whose file the killed CLI never flushed blanked the whole history after restart.

## Fixes

- Scope synthetic-placeholder eviction to placeholders that are provably settled: content-matched by an incoming real user row, or older than the newest real user turn (covers skill-pill messages whose wire content differs from the display text). `es_remove_synthetic_user_inputs` gains optional `matchingContents`/`olderThan`; all three TS call sites pass the scope. Rescued placeholders newer than the replayed transcript now append after the history instead of prepending.
- Session-switch orchestrator treats an active turn FSM as in-flight; `applyPostLoadResult` skips stale terminal DB statuses while a turn is active.
- Per-session control lock serializes `cancel_session` / `cli_agent_message` / `cli_agent_run`.
- SIGTERM grace is polled at 100ms (3s cap) instead of a flat 3s sleep.
- Native-transcript replay walks the binding ledger newest-first and falls back to the first readable, non-empty fork.

## Tests

- `loadSessionAtom`: stale replace-replay keeps the just-sent synthetic after the history; merge drops the echoed placeholder while keeping the fresh one (2 new cases).
- Rust store: scoped removal keeps a newer un-echoed placeholder; reaps a stale pill placeholder by age (2 new cases). Ledger ordering test for `native_transcript_ids_newest_first`.
- Full suites green: vitest 8553/8553, `cargo test` 1091/1091, workspace clippy clean, `tsc` clean.

## Live verification (dev build, real Claude Code CLI session)

- Stop mid-stream released the composer in under a second (previously a fixed ~3s freeze).
- Stop → immediate follow-up: message queued as "sending now", dispatched on the cancelled terminal, and completed; the aborted turn's intent read `cancelled` while the follow-up's read `completed` (the cancel no longer touches the new turn).
- Switching away and back during/after the follow-up kept every bubble.
- Force-kill + relaunch: all rounds survived, including the aborted turn's user message and its interrupt marker.

## Known remaining gap

Streamed partial text the killed CLI never flushed to its JSONL is still lost on restart — inherent to the native-transcript design (no app-side persistence). Fixing that would need persisting the streaming buffer at cancel and de-duplicating it against replay; left for a follow-up discussion.
