### PR TITLE
Ignore stale collab tombstones on reborn work items

### DIFF
--- a/src-tauri/crates/project-management/src/sync/collab_bridge/apply.rs
+++ b/src-tauri/crates/project-management/src/sync/collab_bridge/apply.rs
@@ -721,16 +721,18 @@ fn apply_work_item(org_id: &str, entity: &CollabRemoteEntity) -> Result<bool, St
     }
 
     if let Some(deleted_at) = entity_deleted_at(entity) {
-        let Some((_, _, _, _, local_created_at)) = existing else {
+        let Some((_, _, _, synced_version, local_created_at)) = existing else {
             return Ok(false); // Created and deleted before we ever saw it.
         };
         let deleted_ms = iso_to_ms(Some(deleted_at)).unwrap_or_else(now_ms);
         // Entity ids are short-id derived, so a reused short id resurrects
-        // an old entity identity. A tombstone stamped BEFORE the local row
-        // was created belongs to that prior life — applying it would make
-        // a freshly created item invisible everywhere. Swallow it and
-        // record the version so the next pull does not replay it.
-        if local_created_at > deleted_ms {
+        // an old entity identity. A never-synced local row whose creation
+        // postdates the tombstone is such a rebirth — the delete belongs
+        // to the id's prior life, and applying it would make the fresh
+        // item invisible everywhere. Swallow it and record the version so
+        // the next pull does not replay it. Rows that have synced before
+        // share identity with the remote entity and delete normally.
+        if synced_version.is_none() && local_created_at > deleted_ms {
             tracing::warn!(
                 "[collab_bridge] ignoring stale delete for reborn work item {} \
                  (tombstone {} predates local creation {})",

--- a/src-tauri/crates/project-management/src/sync/collab_bridge/apply.rs
+++ b/src-tauri/crates/project-management/src/sync/collab_bridge/apply.rs
@@ -698,7 +698,7 @@ fn apply_work_item(org_id: &str, entity: &CollabRemoteEntity) -> Result<bool, St
 
     let existing = conn
         .query_row(
-            "SELECT project_id, short_id, deleted_at, collab_remote_version
+            "SELECT project_id, short_id, deleted_at, collab_remote_version, created_at
                FROM workitems WHERE id = ?1 AND org_id = ?2",
             params![&work_item_id, org_id],
             |row| {
@@ -707,23 +707,45 @@ fn apply_work_item(org_id: &str, entity: &CollabRemoteEntity) -> Result<bool, St
                     row.get::<_, String>(1)?,
                     row.get::<_, Option<i64>>(2)?,
                     row.get::<_, Option<i64>>(3)?,
+                    row.get::<_, i64>(4)?,
                 ))
             },
         )
         .optional()
         .map_err(|err| format!("DB error (apply work item probe): {}", err))?;
 
-    if let Some((_, _, _, Some(known_version))) = &existing {
+    if let Some((_, _, _, Some(known_version), _)) = &existing {
         if *known_version >= entity.version {
             return Ok(false);
         }
     }
 
     if let Some(deleted_at) = entity_deleted_at(entity) {
-        let Some(_) = existing else {
+        let Some((_, _, _, _, local_created_at)) = existing else {
             return Ok(false); // Created and deleted before we ever saw it.
         };
         let deleted_ms = iso_to_ms(Some(deleted_at)).unwrap_or_else(now_ms);
+        // Entity ids are short-id derived, so a reused short id resurrects
+        // an old entity identity. A tombstone stamped BEFORE the local row
+        // was created belongs to that prior life — applying it would make
+        // a freshly created item invisible everywhere. Swallow it and
+        // record the version so the next pull does not replay it.
+        if local_created_at > deleted_ms {
+            tracing::warn!(
+                "[collab_bridge] ignoring stale delete for reborn work item {} \
+                 (tombstone {} predates local creation {})",
+                work_item_id,
+                deleted_ms,
+                local_created_at
+            );
+            conn.execute(
+                "UPDATE workitems SET collab_remote_version = ?1
+                  WHERE id = ?2 AND org_id = ?3",
+                params![entity.version, &work_item_id, org_id],
+            )
+            .map_err(|err| format!("DB error (apply work item stale delete): {}", err))?;
+            return Ok(false);
+        }
         conn.execute(
             "UPDATE workitems
                 SET deleted_at = ?1, updated_at = ?2,
@@ -766,7 +788,7 @@ fn apply_work_item(org_id: &str, entity: &CollabRemoteEntity) -> Result<bool, St
     };
 
     match existing {
-        Some((local_project_id, short_id, local_deleted_at, _)) => {
+        Some((local_project_id, short_id, local_deleted_at, _, _)) => {
             // Remote revival of a locally soft-deleted row: the server
             // upsert cleared deleted_at, mirror that first so the partial
             // update below operates on a live row.

--- a/src-tauri/crates/project-management/src/sync/collab_bridge/tests.rs
+++ b/src-tauri/crates/project-management/src/sync/collab_bridge/tests.rs
@@ -330,6 +330,82 @@ fn ack_conflict_requeues_for_immediate_retry() {
 }
 
 #[test]
+fn stale_remote_tombstone_does_not_delete_a_reborn_work_item() {
+    let _sandbox = test_env::sandbox();
+    seed_collab_org();
+    seed_project("reborn");
+    write_work_item(
+        "reborn",
+        "RBN-0001",
+        &work_item_frontmatter("RBN-0001", "Second life"),
+        "fresh body",
+    )
+    .expect("write reborn item");
+
+    // A tombstone from the id's PRIOR life: stamped long before this row
+    // was created. Applying it would make the fresh item invisible.
+    let swallowed = apply_remote(
+        ORG,
+        None,
+        vec![CollabRemoteEntity {
+            kind: KIND_WORK_ITEM.to_string(),
+            payload: json!({ "id": "RBN-0001" }),
+            version: 7,
+            updated_by: Some("member-b".to_string()),
+            deleted_at: Some("2020-01-01T00:00:00Z".to_string()),
+        }],
+    )
+    .expect("apply stale tombstone");
+    assert_eq!(swallowed, 0, "stale tombstone must not count as applied");
+    let item = read_work_item("reborn", "RBN-0001").expect("item must stay visible");
+    assert_eq!(item.frontmatter.title, "Second life");
+
+    // The swallowed version is recorded: replaying the same tombstone is a no-op.
+    let replayed = apply_remote(
+        ORG,
+        None,
+        vec![CollabRemoteEntity {
+            kind: KIND_WORK_ITEM.to_string(),
+            payload: json!({ "id": "RBN-0001" }),
+            version: 7,
+            updated_by: Some("member-b".to_string()),
+            deleted_at: Some("2020-01-01T00:00:00Z".to_string()),
+        }],
+    )
+    .expect("replay stale tombstone");
+    assert_eq!(replayed, 0);
+
+    // A tombstone stamped AFTER local creation is a genuine delete and
+    // still applies.
+    let future_delete = chrono::Utc::now() + chrono::Duration::hours(1);
+    let applied = apply_remote(
+        ORG,
+        None,
+        vec![CollabRemoteEntity {
+            kind: KIND_WORK_ITEM.to_string(),
+            payload: json!({ "id": "RBN-0001" }),
+            version: 8,
+            updated_by: Some("member-b".to_string()),
+            deleted_at: Some(future_delete.to_rfc3339()),
+        }],
+    )
+    .expect("apply genuine tombstone");
+    assert_eq!(applied, 1, "a post-creation tombstone must still delete");
+    let conn = io::conn().expect("conn");
+    let deleted_at: Option<i64> = conn
+        .query_row(
+            "SELECT deleted_at FROM workitems WHERE id = 'RBN-0001' AND org_id = ?1",
+            params![ORG],
+            |row| row.get(0),
+        )
+        .expect("read deleted_at");
+    assert!(
+        deleted_at.is_some(),
+        "genuine tombstone must stamp deleted_at"
+    );
+}
+
+#[test]
 fn apply_remote_creates_entities_without_echo() {
     let _sandbox = test_env::sandbox();
     seed_collab_org();


### PR DESCRIPTION
## Summary

A freshly created work item could be invisible everywhere the moment it was created. Live-tested repro: work item entity ids are short-id derived (`build_frontmatter` uses the short id as the entity id), so deleting a project and later creating a new project with the same prefix in the same org reuses entity identities. The cloud allocator rejects the reused number (`ORG2_CONFLICT`), the local counter legitimately hands it out (the old rows are gone locally), and the next collab pull then applies the **prior life's delete tombstone** to the newborn row — `apply_work_item`'s delete branch stamped `deleted_at` unconditionally. The row ends up with `deleted_at` earlier than `created_at`, and every scope-based resolve (`deleted_at IS NULL`) reports the item as not found while the UI still shows it.

The fix adds a rebirth guard at the tombstone-apply boundary: a tombstone is swallowed only when the local row has **never synced** (`collab_remote_version IS NULL`) and its `created_at` postdates the tombstone — that combination means the delete belongs to the id's previous life. The swallowed version is recorded so later pulls do not replay it. Rows that have synced before share identity with the remote entity and delete normally, and the per-field merge path needs no change (local watermarks already outrank the prior life's mtimes).

## Verification

- New regression test `stale_remote_tombstone_does_not_delete_a_reborn_work_item`: stale tombstone swallowed + not replayed + a genuine post-creation tombstone still soft-deletes
- Full `collab_bridge` suite: 23 tests passing (including the pre-existing `apply_remote_tombstone_soft_deletes`, which caught and corrected the first guard draft that lacked the never-synced condition)
- `cargo clippy -p project_management --all-targets` clean

## Follow-up (out of scope)

Entity identity is still short-id derived; migrating creation to UUID entity ids would remove the rebirth class entirely and is tracked separately.


## Live verification (dual-instance, 2026-08-17)

Ran the full dual-instance protocol against the managed cloud with the fix build on the receiving side:

- **Remote delete still propagates**: a work item created on instance 1 and synced to instance 2 (`collab_remote_version = 1` both sides) was tombstoned from instance 2; instance 1 applied the tombstone on its next pass — `deleted_at` set, version advanced to 2. The guard does not over-block synced rows.
- **Reborn row survives a stale tombstone**: with a tombstone for the same entity id in the cloud, a never-synced local recreation (`collab_remote_version IS NULL`, `created_at` after the tombstone) was left alive on pull; the tombstone version was recorded so it is not replayed, and the warn fired verbatim: `ignoring stale delete for reborn work item ZET-0001 (tombstone 1786947491751 predates local creation 1786948284719)`.

Two pre-existing sync-engine issues surfaced during testing (steady-state pull starvation; a replay-object 409 upload loop in one org) — tracked separately, both reproduce on develop and are untouched by this change.