### PR TITLE
refactor(ui): consolidate InlineAlert onto one neutral surface

### DIFF
--- a/src/components/Dropdown/tokens.ts
+++ b/src/components/Dropdown/tokens.ts
@@ -27,6 +27,12 @@ export const DROPDOWN_PANEL = {
   /** Box shadow - dark mode */
   shadowDark: "0 4px 16px rgba(0, 0, 0, 0.4), 0 2px 4px rgba(0, 0, 0, 0.3)",
 
+  /**
+   * Half-strength shadow for in-flow cards (e.g. InlineAlert) that want the
+   * same lift as a floating panel at half the intensity.
+   */
+  shadowSoftClass: "shadow-dropdown-soft",
+
   /** z-index for dropdown panels — must exceed Spotlight's containerZIndex (9999) */
   zIndex: 10000,
   zIndexClass: "z-[10000]",

--- a/src/components/InlineAlert/InlineAlert.test.ts
+++ b/src/components/InlineAlert/InlineAlert.test.ts
@@ -13,4 +13,34 @@ describe("InlineAlert", () => {
     expect(markup).toContain('role="alert"');
     expect(markup).toContain("Failed");
   });
+
+  it("renders one neutral surface for every type", () => {
+    const types = ["success", "danger", "warning", "info"] as const;
+
+    for (const type of types) {
+      const markup = renderToStaticMarkup(
+        createElement(InlineAlert, { type }, "Body")
+      );
+
+      expect(markup).toContain("border-border-1");
+      expect(markup).toContain("shadow-dropdown-soft");
+      expect(markup).not.toContain("border-danger-3");
+      expect(markup).not.toContain("border-warning-3");
+      expect(markup).not.toContain("text-danger-6");
+      expect(markup).not.toContain("text-warning-6");
+    }
+  });
+
+  it("makes title, body and subtitle text selectable", () => {
+    const markup = renderToStaticMarkup(
+      createElement(
+        InlineAlert,
+        { type: "danger", title: "Failed", subtitle: "Retry later" },
+        "Stack trace"
+      )
+    );
+
+    const selectableCount = markup.split("allow-select-deep").length - 1;
+    expect(selectableCount).toBe(3);
+  });
 });

--- a/src/components/InlineAlert/index.tsx
+++ b/src/components/InlineAlert/index.tsx
@@ -1,9 +1,12 @@
 /**
  * InlineAlert — Shared inline alert/result card component.
  *
- * Outline-only treatment: a 1px border in the type's accent color with no
- * background fill, so alerts don't compete visually with surrounding
- * sections that already have their own surface color.
+ * Single neutral treatment for every type: a 1px `border-border-1` outline, the
+ * Workstation-trail radius and a half-strength dropdown shadow, with no
+ * background fill so alerts don't compete with sections that already have their
+ * own surface color.
+ * There is deliberately no danger / warning / success color variant — `type`
+ * only selects the leading icon.
  *
  * Padding (p-3), icon size 14. Header row: icon + title + optional action + close;
  * body (children) and subtitle render below the header.
@@ -20,25 +23,16 @@ import {
 import React from "react";
 
 import Button from "@src/components/Button";
+import { DROPDOWN_PANEL } from "@src/components/Dropdown/tokens";
 
-const STYLE_MAP = {
-  danger: {
-    border: "border-danger-3",
-    text: "text-danger-6",
-  },
-  success: {
-    border: "border-success-3",
-    text: "text-success-6",
-  },
-  warning: {
-    border: "border-warning-3",
-    text: "text-warning-6",
-  },
-  info: {
-    border: "border-primary-3",
-    text: "text-primary-6",
-  },
-} as const;
+/**
+ * Shared neutral surface — flat outline, no tone accent, and a half-strength
+ * Workstation-trail shadow for a little lift.
+ */
+const ALERT_SURFACE_CLASS = `border border-solid border-border-1 text-text-1 ${DROPDOWN_PANEL.shadowSoftClass}`;
+
+/** Matches the Workstation trail surface radius. Collapsed pills stay round. */
+const ALERT_RADIUS_CLASS = "rounded-xl";
 
 const DEFAULT_ICONS: Record<string, React.ReactNode> = {
   success: <Check size={14} className="flex-shrink-0" />,
@@ -47,10 +41,23 @@ const DEFAULT_ICONS: Record<string, React.ReactNode> = {
   info: <Info size={14} className="flex-shrink-0" />,
 };
 
+/**
+ * Alert copy is content, not chrome — opt back in to text selection over the
+ * global `* { user-select: none }` so users can select/copy titles, bodies and
+ * technical details. Interactive children opt out again with `select-none`.
+ */
+const SELECTABLE_TEXT_CLASS = "allow-select-deep";
+
+const INLINE_ALERT_BASE_TEXT = {
+  title: "block text-[13px] font-medium leading-[14px]",
+  body: "text-[12px] font-normal leading-snug",
+  subtitle: "mt-1 block text-[11px] opacity-70",
+} as const;
+
 const INLINE_ALERT_TOKENS = {
-  titleText: "block text-[13px] font-medium leading-[14px]",
-  bodyText: "text-[12px] font-normal leading-snug",
-  subtitleText: "mt-1 block text-[11px] opacity-70",
+  titleText: `${INLINE_ALERT_BASE_TEXT.title} ${SELECTABLE_TEXT_CLASS}`,
+  bodyText: `${INLINE_ALERT_BASE_TEXT.body} ${SELECTABLE_TEXT_CLASS}`,
+  subtitleText: `${INLINE_ALERT_BASE_TEXT.subtitle} ${SELECTABLE_TEXT_CLASS}`,
 } as const;
 
 export interface InlineAlertActionConfig {
@@ -74,8 +81,11 @@ function isActionConfig(
 }
 
 export interface InlineAlertProps {
-  /** "success" | "danger" | "warning" | "info" */
-  type: "success" | "danger" | "warning" | "info";
+  /**
+   * Selects the default leading icon only — all types share one neutral style.
+   * Defaults to "info".
+   */
+  type?: "success" | "danger" | "warning" | "info";
   /** Body text (below the header row) */
   children?: React.ReactNode;
   /** Title in the header row (same row as icon, action, close) */
@@ -107,7 +117,7 @@ export interface InlineAlertProps {
 }
 
 const InlineAlert: React.FC<InlineAlertProps> = ({
-  type,
+  type = "info",
   children,
   title,
   icon,
@@ -123,7 +133,6 @@ const InlineAlert: React.FC<InlineAlertProps> = ({
   role,
   dataTestId,
 }) => {
-  const styles = STYLE_MAP[type];
   const [expanded, setExpanded] = React.useState(presentation !== "pill");
   const isPill = presentation === "pill";
   const showContent = !isPill || expanded;
@@ -172,17 +181,29 @@ const InlineAlert: React.FC<InlineAlertProps> = ({
   const titleNode = (
     <div className="flex min-w-0 flex-1 items-center gap-1.5">
       {!hideIcon && (
-        <span className="flex h-[14px] shrink-0 items-center">
+        <span className="flex h-[14px] shrink-0 items-center text-text-3">
           {resolvedIcon}
         </span>
       )}
       <div className="min-w-0 flex-1">
         {hasTitle ? (
-          <span className={INLINE_ALERT_TOKENS.titleText}>{title}</span>
+          // Pill headers double as the expand/collapse hit area — keep their
+          // text non-selectable so a drag doesn't fight the toggle.
+          <span
+            className={
+              isPill
+                ? INLINE_ALERT_BASE_TEXT.title
+                : INLINE_ALERT_TOKENS.titleText
+            }
+          >
+            {title}
+          </span>
         ) : (
           showContent &&
           children && (
-            <span className={`block ${INLINE_ALERT_TOKENS.bodyText}`}>
+            <span
+              className={`block ${isPill ? INLINE_ALERT_BASE_TEXT.body : INLINE_ALERT_TOKENS.bodyText}`}
+            >
               {children}
             </span>
           )
@@ -195,7 +216,7 @@ const InlineAlert: React.FC<InlineAlertProps> = ({
     <div
       role={role}
       data-testid={dataTestId}
-      className={`border border-solid ${styles.border} ${isPill ? `inline-block w-fit max-w-full ${expanded ? "rounded-lg" : "rounded-full"} px-3 py-2` : "rounded-lg p-3"} ${styles.text} ${className ?? ""}`}
+      className={`${ALERT_SURFACE_CLASS} ${isPill ? `inline-block w-fit max-w-full ${expanded ? ALERT_RADIUS_CLASS : "rounded-full"} px-3 py-2` : `${ALERT_RADIUS_CLASS} p-3`} ${className ?? ""}`}
     >
       <div className={`flex items-center ${isPill ? "gap-1" : "gap-3"}`}>
         {isPill ? (

--- a/src/engines/ChatPanel/ChatItems/AgentErrorChatItem.tsx
+++ b/src/engines/ChatPanel/ChatItems/AgentErrorChatItem.tsx
@@ -1,9 +1,9 @@
 /**
  * AgentErrorChatItem — Displays LLM/agent errors inline in the chat panel.
  *
- * Rendered as a single InlineAlert (danger variant), so the error reads as
- * one bordered card instead of the split header / body / footer layout the
- * previous block-style render produced.
+ * Rendered as a single InlineAlert, so the error reads as one bordered card
+ * instead of the split header / body / footer layout the previous block-style
+ * render produced. InlineAlert has one neutral style for every type.
  *
  * IMPORTANT: This component must NOT subscribe to chatEventsAtom. It is
  * rendered inside the chat list which is itself driven by chatEventsAtom.
@@ -11,7 +11,8 @@
  * call stack when the session snapshot changes (e.g. on tab switch).
  */
 import { useAtomValue } from "jotai";
-import React, { memo } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import React, { memo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 
@@ -39,6 +40,7 @@ const AgentErrorChatItem: React.FC<AgentErrorChatItemProps> = memo(
     const location = useLocation();
     const sessionId = useAtomValue(sessionIdAtom);
     const session = useAtomValue(sessionByIdAtom(sessionId ?? ""));
+    const [detailsExpanded, setDetailsExpanded] = useState(false);
 
     const cleanMessage = sanitizeAgentErrorMessage(errorMessage);
     const needsCodexReauthentication =
@@ -64,14 +66,24 @@ const AgentErrorChatItem: React.FC<AgentErrorChatItemProps> = memo(
           {needsCodexReauthentication ? (
             <>
               <div>{t("errors.codexLoginExpiredDescription")}</div>
-              <details className="mt-2 opacity-70">
-                <summary className="cursor-pointer select-none">
-                  {t("errors.technicalDetails")}
-                </summary>
-                <div className="mt-1 whitespace-pre-wrap break-words">
+              <button
+                type="button"
+                onClick={() => setDetailsExpanded((expanded) => !expanded)}
+                aria-expanded={detailsExpanded}
+                className="mt-2 flex select-none items-center gap-1 text-text-3 transition-colors hover:text-text-1"
+              >
+                {detailsExpanded ? (
+                  <ChevronDown size={12} className="shrink-0" />
+                ) : (
+                  <ChevronRight size={12} className="shrink-0" />
+                )}
+                <span>{t("errors.technicalDetails")}</span>
+              </button>
+              {detailsExpanded && (
+                <div className="mt-1 whitespace-pre-wrap break-words text-text-2">
                   {cleanMessage}
                 </div>
-              </details>
+              )}
             </>
           ) : (
             <div className="whitespace-pre-wrap break-words">

--- a/src/index.scss
+++ b/src/index.scss
@@ -730,6 +730,15 @@ body.drag-over::after {
     0 2px 4px rgba(0, 0, 0, 0.3);
 }
 
+/* Half-strength companion to `shadow-dropdown` (see `boxShadow.dropdown-soft`
+ * in `tailwind.config.js`). Same reason for living here: the app toggles theme
+ * with `.theme-dark`, not Tailwind's `dark:` variant. */
+.theme-dark .shadow-dropdown-soft {
+  box-shadow:
+    0 4px 16px rgba(0, 0, 0, 0.2),
+    0 2px 4px rgba(0, 0, 0, 0.15);
+}
+
 /* Native overlay scrollbar for dropdown option lists (Settings > Timezone,
  * table selectors, etc.). In WebKit/Tauri, `scrollbar-width` opts back into
  * the platform scrollbar: it overlays the list without reserving a gutter and

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -95,6 +95,11 @@ module.exports = {
         // root class.
         dropdown:
           "0 4px 16px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.08)",
+        // Half-strength `dropdown` (same geometry, half the opacity) for
+        // in-flow cards that should sit slightly above the page without
+        // reading as a floating panel. Dark override also in `index.scss`.
+        "dropdown-soft":
+          "0 4px 16px rgba(0, 0, 0, 0.06), 0 2px 4px rgba(0, 0, 0, 0.04)",
         // Sticky header shadow - used in Git changes view file headers
         "sticky-header": "0 4px 8px -2px rgba(0, 0, 0, 0.3)",
         // Liquid Glass Pattern - Light Theme Shadows


### PR DESCRIPTION
## Summary

`InlineAlert` now renders one neutral card for every type — no danger / warning / success / info accent — and its copy is selectable. The Codex-reauth error card in the chat panel gets a lucide chevron disclosure instead of the native `<details>` marker.

## Problem

Inline alerts shouted. Each `type` painted its own accent border and text color (`border-danger-3` + `text-danger-6`, etc.), so an ordinary "Codex login expired" notice read as an alarm inside the chat transcript. On top of that:

- The technical-details disclosure used a raw `<details>/<summary>`, rendering the browser's default ▶ triangle — the only such marker in the app.
- The global `* { user-select: none }` in `index.scss` meant users could not select or copy an error message out of an alert.

## Solution

- **One surface for all types.** Dropped `STYLE_MAP` for a single `ALERT_SURFACE_CLASS`: `border-border-1` outline, no fill. `type` is now optional (defaults to `"info"`) and only picks the leading icon, which is muted to `text-text-3`. Kept the prop so the ~175 existing call sites keep compiling.
- **Workstation-trail geometry.** `rounded-xl` (matching `WORKSTATION_TRAIL_SURFACE_CLASS`) plus a new half-strength shadow — `boxShadow["dropdown-soft"]` in `tailwind.config.js`, same geometry as `dropdown` at half the opacity, with the `.theme-dark` override alongside the existing `shadow-dropdown` rule in `index.scss` and exposed as `DROPDOWN_PANEL.shadowSoftClass`.
- **Selectable copy.** Title, body and subtitle carry `allow-select-deep`. Pill headers are excluded — they double as the expand/collapse hit area, so a drag there would fight the toggle.
- **Chevron disclosure.** `AgentErrorChatItem` swaps `<details>` for a `useState` toggle with `ChevronRight`/`ChevronDown` at 12px and `aria-expanded`; the button is `select-none` so dragging across the card selects the error text only.

## Potential risks

- **Semantics vs. color.** Alerts no longer signal severity by color; they rely on the icon (`TriangleAlert` / `Check` / `Info`) and their copy. Anywhere a red border was doing the communicating, that cue is gone by design.
- **Tailwind rebuild required.** `shadow-dropdown-soft` is a new utility — a running dev server needs a restart to emit it. The dark-mode rule is SCSS and hot-reloads.
- **`allow-select-deep` is a deep override.** It applies to descendants too, including any custom `action` node passed as a `ReactNode`. Interactive children that should not be selectable need `select-none`, which the existing `.allow-select-deep .select-none` opt-out handles.
- **Not swept.** ~20 hand-rolled alert cards outside `InlineAlert` (wizard `externalImport`, `MonitorSection`, `WebhookPanel`, `ReachabilityPreview`, …) still use `border-danger-3 bg-danger-1` treatments, so tone-colored alerts persist elsewhere until those migrate. The ~86 call sites still passing `type="danger" | "warning"` are now icon-only hints and could be cleaned up mechanically in a follow-up.

## Validation

- `npx vitest run src/components/InlineAlert src/engines/ChatPanel/ChatItems` — 8 files, 39 tests pass, including two new cases: all four types render the neutral surface with `shadow-dropdown-soft` and none of the old accent classes; title/body/subtitle each carry `allow-select-deep`.
- `npx tsc --noEmit -p tsconfig.json` — clean.
- `npx eslint` over the changed files — clean.
- Pre-commit hook (lint-staged + prettier + scoped typecheck) passed.