### PR TITLE
fix(comments): unclip the member-mention dropdown in the notes dialog

### DIFF
--- a/src/features/Org2Cloud/SessionComments/CommentThreadList.tsx
+++ b/src/features/Org2Cloud/SessionComments/CommentThreadList.tsx
@@ -226,7 +226,13 @@ const CommentComposer: React.FC<ComposerProps> = ({
             "cloud.comments.searchMembers",
             "Search members"
           )}
-          position="top-start"
+          // Both hosts scroll (the notes dialog body and the chat
+          // transcript), and an in-flow panel is clipped by that scroll
+          // container — portal to the body so it can overhang. `top-end`
+          // anchors the panel's RIGHT edge to the trigger's, so a 280px
+          // panel opens inward instead of past the dialog's right edge.
+          getPopupContainer={() => document.body}
+          position="top-end"
           avoidViewportOverflow
           onVisibleChange={setMentionDropdownOpen}
           onSelect={(value) =>

--- a/src/features/Org2Cloud/SessionComments/SessionCommentsHeaderExtras.tsx
+++ b/src/features/Org2Cloud/SessionComments/SessionCommentsHeaderExtras.tsx
@@ -145,7 +145,7 @@ const SessionCommentsHeaderExtras: React.FC<
         title={t("cloud.comments.notesTitle")}
         onCancel={() => setOpen(false)}
         footer={null}
-        width={480}
+        width={640}
       >
         <div
           className="flex max-h-[60vh] flex-col gap-3 overflow-y-auto"


### PR DESCRIPTION
## Summary

The member-mention dropdown in the session-notes dialog (`会话备注`) was clipped: it lost its search row off the top and its right edge ran under the dialog boundary. Portals the panel out of the clipping scroll container and widens the dialog.

## Problem

`CommentComposer`'s mention `Dropdown` rendered **in-flow** (no `getPopupContainer`), so the panel is an `absolute` child inside the composer. Its nearest scrolling ancestor is the notes dialog body — `flex max-h-[60vh] flex-col gap-3 overflow-y-auto`. `overflow-y: auto` also clips horizontally, so the 280px-min panel was cut on **both** axes: the search header disappeared above the container's top edge, and the panel's right side ran past the 480px dialog.

`avoidViewportOverflow` did not help — it only clamps against the **viewport**, and on a desktop window the viewport was never the binding constraint; the dialog's scroll container was.

The turn-anchored composer (`TurnCommentChrome`) shares this component and had the same clipping from the chat transcript's scroller.

## Solution

`src/features/Org2Cloud/SessionComments/CommentThreadList.tsx`

- `getPopupContainer={() => document.body}` — portals the panel out of the scroll container. This is the established pattern in this codebase (~15 other call sites use exactly this).
- `position="top-start"` → `"top-end"` — anchors the panel's **right** edge to the trigger's right edge, so it opens inward instead of past the dialog's right side. The trigger sits in the composer's right-aligned trailing actions on both hosts.

`src/features/Org2Cloud/SessionComments/SessionCommentsHeaderExtras.tsx`

- Notes dialog `width` 480 → 640, so the composer toolbar (mode switch + mention + send) has room.

## Potential risks

Low, and contained to the mention dropdown.

- **Stacking**: the portal panel is `z-[10000]`; `ModalSystem` defaults to `zIndex: 9999`, so the panel renders above the dialog.
- **Dialog dismissal**: the panel now lives outside the modal's DOM subtree, but `ModalSystem` closes only on a direct mask click (`e.target === e.currentTarget`), so clicking the portaled panel cannot dismiss the dialog.
- **Outside-click close**: `Dropdown`'s own handler tests `dropdownRef.contains(target)`, and the ref is on the portal node, so selecting a member still does not close the panel.
- **Repositioning**: portal panels subscribe to capture-phase `scroll`, so the panel tracks the dialog body scrolling rather than detaching.
- No i18n, no API, no data-path changes.

## Validation

- `npx tsc --noEmit` — clean.
- `npx vitest run src/features/Org2Cloud/SessionComments/CommentThreadList.test.ts` — 3/3 pass.
- lint-staged (eslint + prettier + scoped tsc) passed on commit.
- Manual: reproduce in the screenshot from the issue — open a shared session → notes (`会话备注`) → `@ 提及成员`. Panel now renders fully inside the dialog with its search row visible; same check on the turn-anchored comment composer in the transcript.

Per `CLAUDE.md`, `frontend-ui-audit` was not run: this is a two-line single-surface bug fix, which the skill's own "When NOT To Use" excludes.
