### PR TITLE
perf(frontend): break down the startup bundle and bound frontend leaks

### DIFF
--- a/docs/memory-audit-2026-08-16/ram-optimization-findings.md
+++ b/docs/memory-audit-2026-08-16/ram-optimization-findings.md
@@ -1,0 +1,523 @@
+# RAM Optimization Audit — 2026-08-16
+
+**Goal:** get the idle app from the measured **~220 MB (Rust) + ~520 MB (WebContent)**
+down to the target **~80 MB + ~150 MB**. This document ranks every RAM lever
+found in the tree at `8ad1fedea`, with file:line evidence, by how much of that
+gap it closes. It builds on `docs/memory-audit-2026-07-13/webview-memory-findings.md`
+(status of that audit's `OPEN` items is in §6).
+
+**Status legend:** `MEASURED` (observed on the live v1.2.5 build) · `CONFIRMED`
+(read in code) · `LIKELY` (code shape, not yet measured).
+
+---
+
+## 0. Measured baseline
+
+Release build `/Applications/ORG2.app` v1.2.5 (Aug 9), macOS 26.3, cold
+launch, no interaction, sampled at 25–60 s (`ps`, `footprint`, `heap`,
+`malloc_history` with `MallocStackLogging=lite`). Data dir on this machine:
+`~/.orgii/sessions.db` = 3.7 GB (`events` table 2.4 GB), 526 native sessions.
+
+| Process             | Footprint                   | Notes                                                                                                            |
+| ------------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `org2` (Rust main)  | **222 MB** (RSS 287–359 MB) | 169 MB `MALLOC_SMALL` + 32 MB `MALLOC_LARGE` dirty; only **5 MB reclaimable**; 93 threads; **0 child processes** |
+| `WebKit.WebContent` | **521 MB**                  | **456 MB "WebKit malloc"** (JS heap + DOM), 13 MB JIT, 31 MB owned graphics + 95 MB reclaimable IOSurface        |
+| `WebKit.GPU`        | 46 MB                       | fixed WKWebView cost                                                                                             |
+| `WebKit.Networking` | 28 MB                       | fixed WKWebView cost                                                                                             |
+| **Total**           | **~820 MB**                 | target ≈ 230 MB + GPU/Networking                                                                                 |
+
+Two facts from the Rust side change how to read the 222 MB:
+
+- `heap` reports only **~40 MB of live malloc nodes** (25.9 MB "non-object from
+  org2"). The rest of the ~200 MB dirty heap is **freed-but-not-returned**
+  memory: footprint peaked at ~270 MB (tool overhead excluded) inside the first
+  minute — startup background jobs allocate, free, and macOS libmalloc keeps the
+  pages dirty in its free lists (only 5 MB is marked reclaimable). So the Rust
+  gap is roughly _"~40 MB live + ~130–160 MB leftover from the startup peak"_.
+- One 160 MB and one exactly-80 MiB allocation are live from startup but mostly
+  untouched (they don't show as dirty) — reserved capacity somewhere on the boot
+  path. Worth identifying once a symbolized build exists (§7).
+
+The startup log window shows what runs in that first minute: session-mirror
+reconcile (`reconcile_native_session_mirror` → `list_all_sessions` over every
+native session, `src/agent_sessions/session_directory/orgtrack_adapter.rs:32-65`),
+`backfill_session_usage` (limit 20 000), `agent_live_status::hydrate_from_disk`,
+codex write reconciliation, GitHub `list_prs` open+closed (2 × 100), event-store
+hydration of the restored session(s), memory-consolidation tick.
+
+---
+
+## 1. Rust process — ranked (222 MB → ~80 MB)
+
+### 1.1 `MEASURED` Startup peak leaves ~130+ MB of dirty free heap
+
+Two complementary fixes; do both.
+
+**(a) Return memory after bursts.** No `#[global_allocator]`, no trim anywhere
+(grep `global_allocator|mimalloc|jemalloc|malloc_trim|MALLOC_` → 0 hits).
+
+- Cheapest: call `libc::malloc_zone_pressure_relief(ptr::null_mut(), 0)` (macOS)
+  after the startup jobs finish and after each agent turn / big Tauri command
+  completes. One line, macOS-only, measurable with `footprint`.
+- Structural: `mimalloc` as `#[global_allocator]` behind a cargo feature
+  (`purge_delay` default 10 ms decommits freed pages promptly). A/B with
+  `footprint` after (i) cold launch, (ii) a heavy agent turn.
+
+**(b) Shrink the peak.** See 1.2, 1.4, 1.7 — each reduces what the startup
+burst allocates in the first place.
+
+### 1.2 `CONFIRMED` SQLite: 64 MB page cache per connection, no pool, 512-thread blocking pool
+
+- `crates/database/src/db/connection.rs:56-62` — `PRAGMA cache_size = -64000`
+  - `temp_store = MEMORY` on **every** connection.
+- `connection.rs:189-190` — `get_connection()` does `Connection::open` per call
+  (no pool despite the module doc "Database Connection Pools"). **611** call
+  sites, mostly inside `spawn_blocking` (821 sites), against the main Tauri
+  runtime's default **512** max blocking threads (no `Builder` configures it).
+- Against a 3.7 GB `sessions.db`, any connection that scans (`events`
+  aggregates, mirror reconcile, backfill, extractors) fills tens of MB of page
+  cache; N concurrent ones multiply it; all of it lands in the dirty free lists
+  of 1.1 when dropped.
+- Fix: `cache_size = -8000` (8 MB) — writers are already serialized by
+  `db::writer`, so a small reader pool (4–8) is low-risk if you want the perf
+  back; and hand Tauri a runtime with `max_blocking_threads(32)` +
+  `thread_stack_size(512 KiB)`.
+- Related: `crates/db-browser/src/pool.rs:11,45` — 16 conns × 8 MB (128 MB
+  ceiling) for the DB-browser panel; 4 + idle TTL is enough. Eviction at
+  `:31-34` uses `pool.keys().next()` (arbitrary, not FIFO as commented).
+
+### 1.3 `CONFIRMED` Both tiktoken encoders resident forever (~20–30 MB)
+
+- `crates/agent-core/src/core/model_context/tokenizer.rs:25,29` — `cl100k_base`
+  and `o200k_base` as process-lifetime `LazyLock<CoreBPE>` (each = 100k/200k
+  `HashMap<Vec<u8>,usize>` + reverse maps). Counts are already sampled above
+  50 KB (`:33-36`), so precision isn't the point.
+- Fix: instantiate only the encoder for the active provider family; use a byte
+  heuristic for non-OpenAI models.
+
+### 1.4 `CONFIRMED` Event store: count-only cap, duplicated payloads, deep clones at 10 Hz
+
+- Topology: `EventStoreState.stores: Mutex<HashMap<String, EventStore>>`
+  (`src/agent_sessions/event_pipeline/commands/state.rs:23`), LRU 15 idle / 25
+  total (`session_manager.rs:18,20`), **8000 events per session**
+  (`store/helpers.rs:12`) — a count cap with **no byte budget**.
+- `crates/types/src/session_event.rs:36-37,68` — each `SessionEvent` holds
+  `args`/`result` `serde_json::Value` **plus** `extracted: Option<ExtractedData>`,
+  a parsed copy of the same data (double storage).
+- `payload_compaction.rs:6-7,58` — `compact_event_for_snapshot` (64 KB → 8 KB
+  preview) runs only on the _outbound_ path (`commands/notify.rs:110,174,195`,
+  `derived.rs:313`); the in-memory store keeps full bodies that already live on
+  disk.
+- `commands/notify.rs:166-195` — `emit_snapshot` walks **all** events every
+  100 ms batch (`:21`) and deep-clones every simulator-visible one, plus 3 full
+  `Vec<String>` id clones (`:176-187`), while the delta tracker (`:167`) already
+  knows what changed.
+- `commands/snapshot.rs:35,51`, `cache_bridge.rs:108`, `agent_core_bridge.rs:150,348`
+  — `store.events().to_vec()` full clones (up to 8000 deep events) to read a
+  subset / render markdown.
+- `crates/agent-core/src/core/turn_executor/execute.rs:308-312` — the whole
+  LLM `messages` `Vec<Value>` (3–8 MB at 200k tokens) is cloned **every
+  iteration of every turn** for two transforms.
+- `commands/ingestion.rs:23` — `result.events.clone()` before append.
+- Fixes: byte budget next to `MAX_EVENTS`; compact at ingestion; make
+  `extracted` lazily derived; cache id lists + compacted simulator set in the
+  store and invalidate from the delta; project under the lock instead of
+  `to_vec()`; borrowed/streamed provider payload instead of `messages.clone()`.
+
+### 1.5 `CONFIRMED` Session / subprocess lifetimes are too long
+
+- `crates/agent-core/src/state/unified.rs:19,99,244-300` — `AgentAppState.sessions`
+  has **no count cap**, only a **1-hour** idle eviction; each `AgentSession`
+  transitively holds provider clients, tool registry, prompt cache, memory
+  state, wingman tickers (`session/wingman/loop_runner.rs:46,57`), a
+  `DialogScheduler` worker, and MCP clients.
+- MCP: shared singleton (`specialization/mcp/commands.rs:47-71`, good) but
+  `mcp_list_servers` → `ensure_connected_background` (`:181-187`) **connects
+  every configured stdio server** (one `node`/`npx` process each,
+  `mcp/client/connect.rs:182,194-223`) and nothing ever idle-disconnects
+  (`mcp/manager/lifecycle.rs:179-182,322-331`).
+- LSP: `crates/lsp/src/manager.rs:77` `servers: HashMap<(root, server_id), _>`
+  — spawned on file open (`src/services/lsp/LspClient.ts:71,175`), stopped only
+  by explicit `stop_server`/`lsp_shutdown` (`:714,518`); no idle TTL, no cap
+  (out-of-process, but rust-analyzer/tsserver are 0.3–3 GB each on the machine).
+- `crates/git/src/watch/watcher.rs:145` `watchers`, `state_store.rs:15` `states`
+  (full `GitStatusResponse` per repo), `debounce.rs:68,70` — all uncapped per
+  repo ever opened.
+- `crates/ui-indexer/src/commands.rs:19` `UiIndexState.indexes:
+HashMap<PathBuf, UiIndex>` — one full component index per repo ever indexed,
+  only manual `remove` (`:151`).
+- `crates/agent-core/src/foundation/flow_awareness/store.rs:36` `FlowStore.sessions`
+  — inner deque capped (100), outer map never pruned.
+- `crates/integrations/src/proxy/server.rs:59` `PROXY_SERVERS` — one listener +
+  task per cloud session, verify every teardown path releases.
+- `session_runner/helpers.rs:29` `SESSION_CONTROL_LOCKS` — tiny, never pruned.
+- Fixes: idle eviction 1 h → 10–15 min + live-session cap; MCP idle TTL + lazy
+  per-server connect; LSP idle TTL ("no open doc for root×lang for N min") +
+  live-server cap; LRU on watchers/states/UiIndex (2–4 repos); hook
+  `FlowStore::clear_session` into session eviction.
+
+### 1.6 `CONFIRMED` Channel depths and log buffers
+
+- `crates/agent-core/src/core/tools/impls/coding/exec/registry.rs:185,248,314`
+  — background-shell output tap `broadcast(512)` × `String` **per job** (retained
+  even with zero receivers; durable log is on disk). → 64–128.
+- `crates/agent-core/src/foundation/bus/mod.rs:60,86` — outbound bus
+  `broadcast(1000)` × `OutboundMessage`. → 128.
+- `crates/git/src/watch/watcher.rs:170` — `bounded(1000)` fs events with paths.
+  → 256.
+- `crates/agent-core/src/core/providers/cursor_native/client.rs:146,213` — two
+  `unbounded_channel::<Bytes>` on the streaming path (the only unbounded ones).
+  → `channel(256)`.
+- `src/lib.rs:291-292`, `src/infrastructure/frontend_log.rs:14-15` — two
+  `tracing_appender::non_blocking` with default `buffered_lines_limit =
+128_000` (crossbeam pre-allocates the slot array). → `.buffered_lines_limit(4096)`.
+  Also `lib.rs:296-304` enables `debug` for `key_vault` + `app_lib::agent_core`
+  in production.
+- `crates/lsp/src/codec.rs:40` `MAX_MESSAGE_BYTES = 32 MB` single-allocation
+  ceiling per server. → 8 MB unless a server needs more.
+- `crates/search/src/code/commands/cache.rs:52-63` — 20 × up to 10 000 matches
+  with context, no byte budget, `clone()` on hit. → byte budget + `Arc`.
+- `crates/search/src/file.rs:75-79` `FILE_INDEX_CACHE` — well-bounded but a
+  **64 MB** floor (4 repos × 32 MB); halve if @-file search still feels fine.
+- `crates/shared-state/src/screenshot_state.rs:18-19` — 20 entries / **32 MB**
+  floor, every entry also on disk. → 16 MB.
+
+### 1.7 `CONFIRMED` Startup work that could be deferred / narrowed
+
+- `src/agent_sessions/session_directory/orgtrack_adapter.rs:32-65` —
+  `reconcile_native_session_mirror` lists _every_ native session and re-upserts
+  all rows on **every** launch (metadata-only rows, but the whole set at once);
+  then `backfill_session_usage(limit 20 000)`. Both could be incremental
+  (updated_at watermark) and run after first paint with a lower priority.
+- `src/lib.rs:614-630`, `src/cli_managed_proxy.rs:82-84` + main runtime — three
+  tokio multi-thread runtimes; ~93 threads at idle. Stacks are cheap (2 MB dirty
+  total) but each runtime carries drivers/queues; consider running the IDE
+  server + proxy on the main runtime.
+- `src-tauri/src/main.rs:9-17` — external agent hooks re-exec the 113 MB
+  binary as `--session-provenance-hook`; a tiny separate hook binary avoids
+  paging in a large Mach-O per hook call.
+
+### 1.8 `CONFIRMED` Binary and static tables
+
+- Release profile is right (`src-tauri/Cargo.toml:615-624`: thin LTO, `panic =
+"abort"`, `strip = true`). Only 41 MB `__TEXT` was mapped clean at idle.
+- Binary is 113 MB (`__text` 68 MB, `__const` 38 MB): 1302 Tauri commands,
+  41 crates, tiktoken tables, 5 tree-sitter grammars (`crates/search/Cargo.toml:35-39`,
+  `crates/ui-indexer/Cargo.toml:18-19`), `chrono-tz`, sqlx (postgres+mysql) +
+  rusqlite, two `reqwest` stacks (0.12 via `tauri-plugin-updater`, 0.13). Mostly
+  demand-paged; run `cargo bloat --release --crates` before spending time here.
+
+---
+
+## 2. WebContent — ranked (521 MB → ~150 MB)
+
+### 2.1 `MEASURED` Initial JS is 9.3 MB because the dev-only eager import leaks into production
+
+- `src/index.tsx:183-185` — `isDev ? import(/* webpackMode: "eager" */ "@src/App") : import("@src/App")`.
+  `isDev` is a runtime `const` (`:27`); webpack parses **both** arms, `eager`
+  wins, and the whole `App` tree is inlined into the entry chunk. Verified on
+  `build/` (Aug 14): **no App chunk exists**; `main.*.js` = 4.82 MB, `vendors.*.js`
+  = 4.36 MB, executed synchronously before first paint (+351 KB CSS).
+- The comment (`:174-182`) describes the old `eval-cheap-module-source-map`
+  setup; `webpack.config.js:655` no longer uses it.
+- Fix: two literal `import()`s under `if (process.env.NODE_ENV === "development")`
+  (a folded constant), or drop the eager branch. This also lets `splitChunks`
+  move App-only vendors out of the initial `vendors` chunk.
+
+### 2.2 `CONFIRMED` Barrel leaks drag ~2 MB of heavy libs into the startup graph
+
+Same pattern `84e8f65e2` fixed inside ChatPanel; three consumers outside it:
+
+| Consumer wants              | Imports                                                                                | Which re-exports                                                            | Drags in                                                                                                                                             |
+| --------------------------- | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `RenameModal`               | `…/WorkstationSidebarConnector/SidebarDialogs.tsx:1` → `scaffold/ModalSystem/variants` | `variants/index.ts:13` → `ContentView` (`ContentView/index.tsx:5,9`)        | `react-syntax-highlighter` → **refractor 597 KB**                                                                                                    |
+| `WorkstationToolbarTooltip` | `SidebarSettingsMenuButton.tsx:44` → `modules/WorkStation/shared`                      | `shared/index.ts` → `GitFileDiffSplit/index.tsx:30` → `features/CodeMirror` | **all CodeMirror + 10 language packs + sql-formatter ≈ 1 MB** (`features/CodeMirror/shared/languageExtensions.ts:6-18`, `SqlEditor/index.tsx:11-18`) |
+| terminal sidebar rows       | `TerminalSidebarRows.tsx:14` → `engines/TerminalCore/exports`                          | `exports.ts:4` → `index.tsx:25` → `components/TerminalInteractive`          | **xterm + 6 addons incl. webgl ≈ 470 KB** (`terminalSetup.ts:1-6`)                                                                                   |
+
+Also in the startup graph: `framer-motion` via `useSetupWalkthroughTestShortcut.ts:5`
+← `GlobalShortcuts/index.tsx:4` ← `AppBootstrap.tsx:17` (137 KB);
+`@supabase/supabase-js` realtime via `useOrg2CloudRealtime` ← `AppBootstrap`
+(auth part is legitimately boot-critical). Fix: deep-import at the three sites,
+`React.lazy` the editor/terminal/highlighter surfaces; retire
+`react-syntax-highlighter` in favour of the existing `useShikiHighlight` hook
+(four highlighter stacks ship today: shiki, highlight.js, refractor,
+prism-react-renderer — only shiki is lazy-grammar).
+
+### 2.3 `MEASURED` `splitChunks` emits shared modules twice; `vendors` is one 4.36 MB blob
+
+- `webpack.config.js:398-406` (`initialVendors`, `chunks: "initial"`) and
+  `:407-462` (`asyncVendors`, `chunks: "async"`) are disjoint, so a module in
+  both graphs is emitted in both — verified for `react-dom` (`vendors`,
+  `async-vendors.react-dom`, and `main`), `zod`, `sql-formatter`. ≈ **3.3 MB** of
+  duplicate parse (refractor 597K, zod 390K, xterm 339K, sql-formatter 290K,
+  react-dom 225K, @codemirror/view 202K, …). Module cache is id-keyed, so it's
+  bytes + parse/compile, not double heap objects.
+- No `maxSize` on `initialVendors` → all-or-nothing parse.
+- Fix: `asyncVendors` → `chunks: "all"` (or merge groups); `maxSize ≈ 500 KB`.
+
+### 2.4 `CONFIRMED` Boot-time heap: 15 i18n namespaces + ~500 eager zod schema graphs
+
+- `src/index.tsx:238` awaits `i18nReady`, which loads **all 15 namespaces** of the
+  active language (`src/i18n/index.ts:240+`; ~600 KB JSON for `en`, retained in
+  i18next's store — 2–4 MB in-heap). Namespaces like `terms`, `geo`, `market`,
+  `builderProfile`, `teamRuntime`, `projects` are not needed for first paint.
+  → await `common` + `navigation` + `sessions`, lazy the rest.
+- `src/api/tauri/rpc/schemas/*` (27 files, 392 `z.object` at module scope) +
+  `src/config/settingsSchema/registry/*` (~102) are reachable from `index.tsx`
+  alone; zod v4 builds a live object graph per schema. → `z.lazy()` for
+  rarely-used RPC namespaces or validate at the call site.
+- 246 startup-reachable SVGs (284 KB raw) become React components via
+  `@svgr` (`webpack.config.js:280-303`); use `?url` for decorative art.
+- `main.css` 350 KB includes both CodeMirror token sheets (`src/index.scss:15-22`);
+  move them into the CodeMirror chunk.
+
+### 2.5 `CONFIRMED` Keep-alive surfaces (fixed floor) — what's still mounted at once
+
+- **Browser workstation: one live `WKWebView` per tab, never destroyed.**
+  `src/engines/BrowserCore/index.tsx:283-295` renders `<BrowserSessionWebview>`
+  for every `session`; inactive ones are staged offscreen at `x:-10000`
+  (`useInlineWebviewNativeVisibility.ts:41-45`, `useWebviewCommands.ts:329-335`),
+  and the tab list is persisted/restored (`BrowserContext.tsx:89,205`,
+  `useBrowserState.ts:144`). Each is a WebContent process (60–150 MB+). → LRU
+  (active + 2–3), destroy others and rehydrate from URL; cap the restore.
+  `src/features/SessionSetup/hooks/useEmbeddedWebview.ts:208` (auto-close on
+  hidden) is the template.
+- Workstation app latches: `AppShell/AppShellContent.tsx:128` (AgentStation —
+  new since the last audit), `:160` (Code), `:176` (Browser), `:194` (Project),
+  each `hasVisited* && display:none` (`AppShell/index.tsx:101-103`,
+  `hooks/useAppShellStationMode.ts:30-40`).
+- WorkStation + router `<Outlet/>` are always-mounted siblings
+  (`src/modules/index.tsx:404,431-434`).
+- Terminals: every initialized terminal stays mounted (`engines/TerminalCore/index.tsx:314-345`;
+  `initializedTerminalIdsAtom` grows unconditionally, `store/workstation/codeEditor/terminal/index.ts:367,407,442`;
+  localStorage restore uncapped `:98-101,133-140,158`; scrollback 5000); chat-panel
+  CLI tabs same pattern (`engines/ChatPanel/TabContent/UnifiedChatPanelTabContent.tsx:81-100`).
+- `ProjectManagerContentRouter.tsx:78-89` all work-item tabs mounted;
+  `modules/shared/layouts/GenericBottomPanel/index.tsx:146` all tabs mounted;
+  `useTabSidebar.tsx:209-226` warm sidebars (only Benchmark sets `keepAlive:true`,
+  `BenchmarkTabSidebar.tsx:332`).
+- Close = hide (`src/lib.rs:1173-1184`): nothing is released when the user
+  "closes" the window. → on hide, drop JS caches and discard browser webviews.
+- Window: `transparent: true` + `maximized: true` + `macOSPrivateApi` +
+  `NSVisualEffectView` material (`tauri.conf.json:13,23,28,29`,
+  `crates/app-window/src/lib.rs:241`) → extra full-size Retina backing stores
+  (the 31 MB owned graphics + 95 MB reclaimable IOSurface in WebContent, 54 MB
+  IOSurface in the Rust process). → opaque-window setting; measure the delta.
+
+### 2.6 `CONFIRMED` Runtime retention that grows with use
+
+- `src/modules/WorkStation/CodeEditor/hooks/fileContent/cache.ts:16`
+  `unsavedContentCache` — **unbounded**, two full copies of file text per edited
+  file + up to 100 edit ops; never evicted by `evictMetadataCache` (`:21-37`) or
+  `clearFileCache` (`:170`); only removed on revisit/save. → byte-aware cap +
+  clear on repo switch.
+- Persisted & parsed at boot (`getOnInit`), unbounded:
+  `src/features/Org2Cloud/org2CloudSyncAtoms.ts:172` `pushCursors` (one record
+  per session ever pushed, ~12 fields + frontier array) and `:196`
+  `pushedMetadata`; `features/TeamCollaboration/sessionOrgTagsAtom.ts:54`;
+  `store/session/tuiModeAtom.ts:15` (one localStorage key per session);
+  `engines/ChatPanel/InputArea/utils/imageDraftCache.ts:42` (base64 per session);
+  `hooks/files/useDocumentStorage.ts:198,364`;
+  `CodeEditor/hooks/output/useOutputChannels.ts:72-80` (rewrites every channel's
+  100 k-char content to sessionStorage on **every append**).
+- Pinned `atomFamily`s (no `.remove()`): `workstationPrAtom.ts:47-174` (9
+  families incl. ≤100 PR lists + closures), `workstationIssueAtom.ts:59,112`,
+  `workstationSelectedPrAtom.ts:118,132,197`, `planApprovalAtom.ts:57`,
+  `tuiModeAtom.ts:15`. → mount-gated GC as in
+  `sessionScopedChatEvents.ts:78-93`; release on repo switch.
+- `store/workstation/codeEditor/search/index.ts:49,125` `searchResultsAtom`
+  accumulates "load more" with no total cap; `store/ui/todoAtom.ts:92`
+  `sessionTodoMapAtom` never pruned on switch; `store/ui/inboxAtom.ts:84`
+  `inboxDbMessagesAtom` unbounded and apparently unread.
+- `scaffold/NavigationSidebar/blocks/SidebarGroup.tsx:144` — session sidebar is
+  not virtualized; paging `visibleCount` only grows. Verify
+  `resetScopedSectionPagination` (`sectionPagination.ts:62`) fires on every
+  scope switch.
+- `src/diagnostics/runtimeCounters.ts:32,43` — `durations` arrays unbounded on
+  every RPC; the only drain (`createDiagnosticsUsageSnapshot`,
+  `diagnostics/aggregate.ts:335`) has **no call site**.
+
+---
+
+## 3. Other processes
+
+- Sidecars: exactly one `externalBin` (`org2-pm`, never spawned by the app);
+  root-level `ORG2 Helper (Backend)-*` and `src-tauri/bin/*Helper (Semantic)*` are
+  dead symlinks to local `node` from `scripts/setup/sidecar-symlinks.js:49-65`
+  → delete. Agent CLIs are per-turn with process-group kill + boot orphan sweep
+  (`src/lib.rs:522-553`). Browser automation is command-mode (no resident
+  chromium). All good.
+- What _does_ multiply processes: browser-tab webviews (2.5), MCP `node`
+  servers (1.5), LSP servers (1.5), semantic embedder only in the `--semantic`
+  build.
+
+---
+
+## 4. Suggested order of work
+
+| #   | Item                                                                      | Expected win                              | Effort    |
+| --- | ------------------------------------------------------------------------- | ----------------------------------------- | --------- |
+| 1   | 2.1 un-eager `App` import                                                 | −4.3 MB initial JS, unblocks vendor split | tiny      |
+| 2   | 2.2 three deep-import fixes + lazy surfaces                               | −2 MB initial JS                          | small     |
+| 3   | 2.3 `asyncVendors: chunks:"all"` + `maxSize`                              | −3.3 MB duplicate parse                   | tiny      |
+| 4   | 1.2 `cache_size -64000 → -8000`, `max_blocking_threads(32)`               | lower startup peak → less dirty heap      | tiny      |
+| 5   | 1.1 `malloc_zone_pressure_relief` after startup/turns (then mimalloc A/B) | returns the ~130 MB leftover              | small     |
+| 6   | 1.3 single tiktoken encoder                                               | −20–30 MB Rust                            | small     |
+| 7   | 2.5 browser-tab webview LRU + terminal unmount/cap (prior §2.1)           | −60–150 MB per idle tab/terminal          | medium    |
+| 8   | 1.5 idle eviction 1 h → 15 min; MCP/LSP idle TTL                          | subprocess RAM, prompt caches             | medium    |
+| 9   | 2.4 i18n 3 namespaces at boot; lazy zod                                   | −2–4 MB heap, faster paint                | small     |
+| 10  | 1.4 event-store byte budget / compact-at-ingest / no full-walk emit       | −10s of MB per active session, less churn | medium    |
+| 11  | 2.6 `unsavedContentCache` cap; prune persisted cursors                    | stops slow growth                         | small     |
+| 12  | 1.6 channel depths, log buffers, search/screenshot floors                 | −5–20 MB                                  | tiny each |
+| 13  | 1.7 incremental mirror reconcile after first paint                        | lower startup peak                        | small     |
+
+---
+
+## 5. Already well-bounded — don't re-audit
+
+Terminal crate (80 KB redacted snapshot, 16-slot PTY taps, watermarks);
+screenshot store dual cap; LLM-history image budgets; orgtrack-core streaming
+readers + SQLite-backed imported-history index; session-persistence; prompt
+caches (`BoundedMap`); `file_tracker`; LSP diagnostics FIFO; auxiliary tokio
+runtimes (4 + 2 workers, explicit); rustls-only single TLS stack; feature-gated
+ML stack; strict CSP, no `withGlobalTauri`, no devtools in release; route-level
+`React.lazy` (100 sites), all file previewers, mermaid/recharts/highlight.js/
+mammoth/jszip/sucrase lazy; shiki singleton with lazy grammars; single lazy web
+worker (LRU 4 sessions); object-URL revocation; ~90 % of module caches carry
+`MAX_*` + eviction; streaming delta buffer; `SNAPSHOT_CACHE_MAX` now 5;
+`XtermOutput` WebGL now routed through the 8-slot budget; `KeepAliveRouteOutlet`
+removed; single sidebar; Source Control renders only when active; the
+`physical_footprint`-based RAM monitor (`crates/perf-utils/src/app_memory.rs`)
+sampling only while its panel is open.
+
+---
+
+## 6. Status of the 2026-07-13 audit's `OPEN` items
+
+| Item                                             | Status                                | Evidence                                                                                                                                         |
+| ------------------------------------------------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1.3 turn bodies stay loaded Rust-side            | **OPEN**                              | `SessionCore/turns/loadedTurnRegistry.ts:139-147` never calls `unloadTurnBody`; `pruneLoadedTurnBodies` (`:108-126`) only for the active session |
+| 1.4 estimator truncates at 5000 nodes            | **OPEN**                              | `core/store/memoryEstimation.ts:1,22`; duplicated in `hooks/perf/runtimeMemoryStats.ts:64`                                                       |
+| 2.1 terminals mounted forever / uncapped restore | **OPEN**                              | `engines/TerminalCore/index.tsx:314-345`; `terminal/index.ts:98-101,367`                                                                         |
+| 2.2 XtermOutput WebGL bypasses budget            | **FIXED** (`a2b68c1d7`)               | `components/XtermOutput/index.tsx:127-171`                                                                                                       |
+| 2.3 over-broad TUI heuristic                     | **OPEN**                              | `TerminalDisplay/utils/ansiProcessor.ts:86`                                                                                                      |
+| §3 WorkStation + Outlet both mounted             | OPEN (mechanism changed)              | `modules/index.tsx:404,431-434`                                                                                                                  |
+| §3 workstation app latches                       | OPEN (5 → 4 modes + new AgentStation) | `AppShellContent.tsx:128,160,176,194`                                                                                                            |
+| §3 `KeepAliveRouteOutlet max=12`                 | **FIXED** (removed)                   | `MainAppShell/index.tsx:42`                                                                                                                      |
+| §3 PM work-item tabs                             | OPEN                                  | `ProjectManagerContentRouter.tsx:78-89`                                                                                                          |
+| §3 Source Control overlay                        | **FIXED** (renders only when active)  | `EditorMainPane/index.tsx:461-466`; dead `opacity-0` branch at `:405-421`                                                                        |
+| §3 dual sidebar                                  | **FIXED**                             | `SidebarSelector.tsx:19-37`                                                                                                                      |
+| 4 `runtimeCounters` unbounded                    | OPEN (worse: no drain call site)      | `diagnostics/runtimeCounters.ts:32,43`, `aggregate.ts:335`                                                                                       |
+| 4 `useGlobalFlowTracker` raw listen              | OPEN (negligible)                     | `hooks/flowAwareness/useGlobalFlowTracker.ts:71-111`                                                                                             |
+
+RAM-monitor gaps: no row for mounted xterm instances / live WebGL contexts,
+`jotai-family` maps, or keep-alive surface count
+(`hooks/perf/useRuntimeRamStats.ts:161-283`).
+
+---
+
+## 7. How to measure (repeatable recipe)
+
+```bash
+# 1. Cold-launch baseline (release build)
+open -a /Applications/ORG2.app; sleep 45
+footprint -p $(pgrep -x org2)                       # Rust process categories
+footprint -p <WebContent pid owned by org2>          # "WebKit malloc" = JS heap + DOM
+heap $(pgrep -x org2) | head -30                     # live malloc nodes vs dirty pages
+
+# 2. Attribute the Rust heap (needs symbols: build once with strip=false, debug=1)
+MallocStackLogging=lite /path/to/org2 &
+sleep 60; malloc_history $(pgrep -x org2) -allBySize | head -60
+```
+
+For the webview, use the sidebar RAM monitor
+(`scaffold/NavigationSidebar/connectors/SidebarRamMonitorButton/`) — remember
+the "snapshots" row is under-reported until 1.4 above is fixed — and the WebKit
+heap profiler for retained size of `_latestSnapshots`, the `jotai-family` maps,
+`unsavedContentCache`, and the i18next store.
+
+---
+
+## Fix log
+
+### 2026-08-17 — frontend bundle break-down + leaks (branch `perf/frontend-bundle-and-leaks`)
+
+Measured with `webpack --mode production` at HEAD before/after (same machine,
+same cache namespace):
+
+| Metric                                         | Before                                               | After                                                |
+| ---------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------- |
+| Synchronous initial JS (`index.html` scripts)  | **8.37 MB** (`main` 4.74 + `vendors` 3.73 + runtime) | **0.98 MB** (`main` 0.32 + `vendors` 0.65 + runtime) |
+| JS loaded at boot (initial + `App` import set) | ≈ 8.4 MB                                             | ≈ **5.9 MB** (−2.5 MB / −29 %)                       |
+| Vendors loaded at boot                         | 3.73 MB                                              | ≈ 1.65 MB                                            |
+| Modules emitted in >1 chunk                    | 1 601 modules / **9.0 MB** redundant                 | 339 modules / 1.9 MB                                 |
+| Total `build/`                                 | 55 MB / 559 chunks                                   | 48 MB / 564 chunks                                   |
+
+What changed:
+
+- **2.1** `src/index.tsx` — the dev-only `webpackMode: "eager"` branch is now
+  gated on the inline `process.env.NODE_ENV` comparison (webpack can fold it),
+  so production ships `App` as an async chunk again instead of inlined into
+  `main.js`.
+- **2.3 root cause found and fixed** — the duplicate-vendor problem was _not_
+  the `splitChunks` config: the chat-projection **worker** entry statically
+  reached `rendering/registry/events/index.ts`, whose lazy renderer
+  `import()`s made 2 388 files (all of ChatPanel + every vendor) part of the
+  worker's chunk graph; since the worker's entry lacks `vendors`, webpack had
+  to copy react-dom/xterm/CodeMirror/zod/… into every shared async chunk.
+  `CONTEXT_CONFIG` + the chat-config helpers moved to
+  `registry/events/contextConfig.ts` (pure data); `ActionRegistry` and
+  `registryAccessors` import from it. Worker reach with async imports:
+  2 388 → 62 files. `splitChunks` left unchanged.
+- **2.2 barrel leaks** — deep imports at `SidebarDialogs.tsx` (`RenameModal`
+  → refractor/react-syntax-highlighter gone from boot; `ContentViewModal` has
+  no consumers), the four `NavigationSidebar` files that only wanted
+  `WorkstationToolbarTooltip` (CodeMirror + 10 langs + sql-formatter, xterm +
+  6 addons, framer-motion, virtuoso, dnd-kit gone from boot),
+  `ActionSystemContext.tsx` (`GUIAgentService` deep import; the `services`
+  barrel re-exported `EditorService` → @codemirror/\*),
+  `editorActions.zod.ts` (`EditorService` loaded on first action invocation),
+  `ModalSystem/index.tsx` and `routeGroups.tsx` (`layouts/blocks` barrel).
+  `components/Message` split: the framer-motion toast renderer is now
+  `MessageContainer.tsx`, `React.lazy`-loaded on the first toast; the
+  `Message` API surface is unchanged.
+  Still in the boot graph (deliberately): zod (settings/RPC schemas),
+  supabase auth, dnd-kit/virtuoso/tanstack-virtual (ChatPanel proper),
+  @tanstack/react-table (via `StatusDot` → `SettingsTable`, ~56 KB).
+- **2.6 leaks**
+  - `fileContent/cache.ts` `unsavedContentCache`: no longer stores the unused
+    `originalContent` copy (halves the entry), tracks `dirty`, and evicts
+    _clean_ entries past `MAX_UNSAVED_CONTENT_CACHE_SIZE = 32`; dirty
+    (truly unsaved) entries are never evicted.
+  - `diagnostics/runtimeCounters.ts`: per-operation `durations[]` replaced by
+    a running sum/count (same average, O(1) memory).
+  - `store/.../search/index.ts`: `searchAppendResultsAtom` enforces
+    `SEARCH_MAX_RETAINED_MATCHES = 20 000` (the sidebar's documented ceiling)
+    and clears `hasMore` at the cap.
+  - `store/ui/todoAtom.ts`: `sessionTodoMapAtom` LRU-capped at
+    `MAX_TODO_SESSION_SLOTS = 64` (never evicts the active session; slots are
+    rebuilt from the event store by `useTodoSync`).
+  - `useOutputChannels.ts`: channels capped at `MAX_OUTPUT_CHANNELS = 16`,
+    sessionStorage mirror debounced (500 ms trailing, flushed on unmount)
+    instead of re-serialising every channel on every appended line.
+- **2.5 keep-alive floors**
+  - Terminals (`engines/TerminalCore`): only the active pane plus the
+    `MAX_WARM_INACTIVE_TERMINALS = 4` most recently active ones stay mounted
+    (`terminalMountWindow.ts`); colder panes unmount (xterm + WebGL released)
+    and reattach via the existing `attach_pty_stream` + serialized-buffer
+    restore path. Restored-at-boot terminals no longer all instantiate.
+  - Browser tabs (`engines/BrowserCore`): **deliberately left as-is.** An
+    LRU on inactive tabs was prototyped (destroy cold tabs' native webviews,
+    recreate from URL) but reverted: a discarded tab comes back as a full
+    page reload (scroll, form input, SPA state lost; incognito sessions
+    lost), which is a worse trade than the 60–150 MB per idle tab. If this
+    is revisited, do it as idle-TTL + count with incognito exempt, not a
+    pure count.
+
+Left for follow-ups (not in this batch): persisted `pushCursors` /
+`pushedMetadata` pruning (cloud-sync correctness — needs the dual-instance
+protocol), repo-scoped workstation PR/issue atom families (small, high-risk
+multi-repo surface), browser-tab webview
+discarding (see 2.5 note above), chat-panel CLI terminal tabs (agent-owned, turn
+lifetime), i18n namespace deferral and lazy zod schemas (2.4), the 4 MB
+`App` static graph itself.

--- a/src/ActionSystem/ActionSystemContext.tsx
+++ b/src/ActionSystem/ActionSystemContext.tsx
@@ -18,7 +18,10 @@ import {
   initializeServices,
   registerCoreActions,
 } from "@src/modules/WorkStation/ActionSystem/registration/registerCoreActions";
-import { GUIAgentService } from "@src/services";
+// Deep import: the `@src/services` barrel re-exports EditorService, whose
+// static @codemirror/* imports would otherwise ride into the startup graph
+// through this app-lifetime provider.
+import { GUIAgentService } from "@src/services/guiAgent/GUIAgentService";
 
 import type { ActionResult } from "./schema/defineZodAction";
 import { zodActionRegistry } from "./schema/zodRegistry";

--- a/src/app/root/__tests__/startupGraph.test.ts
+++ b/src/app/root/__tests__/startupGraph.test.ts
@@ -1,0 +1,103 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  SRC_ROOT,
+  importersOfPackage,
+  reachableFilesMatching,
+  walkStaticImports,
+} from "@src/test/staticImportGraph";
+
+/**
+ * Startup-graph guards.
+ *
+ * Everything statically reachable from `src/index.tsx` and `src/App.tsx` is
+ * parsed and evaluated before first paint (index.tsx synchronously, App.tsx
+ * as the first async chunk). These tests pin the boundaries recovered in
+ * docs/memory-audit-2026-08-16/ram-optimization-findings.md so a future
+ * barrel re-export or "convenience" import cannot silently drag a heavy
+ * library back into boot. If a package below genuinely becomes a boot-time
+ * dependency, move it to the allow-list with a reason.
+ */
+describe("startup static import graph", () => {
+  const graph = walkStaticImports(["index.tsx", "App.tsx"]);
+
+  it("keeps heavy, feature-scoped packages out of the boot graph", () => {
+    const forbidden = [
+      // Terminal stack (~470 KB): only the Terminal panel needs it.
+      "@xterm/xterm",
+      "@xterm/addon-webgl",
+      "@xterm/addon-fit",
+      "@xterm/addon-search",
+      "@xterm/addon-serialize",
+      // CodeMirror editor stack (~1 MB with language packs).
+      "@codemirror/view",
+      "@codemirror/state",
+      "@codemirror/language",
+      "@codemirror/lang-javascript",
+      "@codemirror/lang-python",
+      "@codemirror/lang-rust",
+      "@codemirror/lang-sql",
+      "@codemirror/lang-markdown",
+      "@uiw/react-codemirror",
+      "@replit/codemirror-indentation-markers",
+      "sql-formatter",
+      // Highlighters other than the lazily-grammar'd shiki hook.
+      "react-syntax-highlighter",
+      "refractor",
+      "highlight.js",
+      // Animation / charts / document viewers.
+      "framer-motion",
+      "recharts",
+      "mermaid",
+      "mammoth",
+      "jszip",
+      "sucrase",
+    ];
+    const present = forbidden.filter((pkg) => graph.packages.has(pkg));
+    const explanation = present.map(
+      (pkg) => `${pkg}:\n    ${importersOfPackage(graph, pkg).join("\n    ")}`
+    );
+    expect(
+      explanation,
+      "heavy packages became statically reachable from the startup graph"
+    ).toEqual([]);
+  });
+
+  it("does not statically reach the editor / terminal / diff feature trees", () => {
+    const forbidden = reachableFilesMatching(
+      graph,
+      // Entry points that instantiate the heavy stacks (pure helpers such as
+      // `features/CodeMirror/config/nonce.ts` or `TerminalInteractive/bufferCache.ts`
+      // are fine to share).
+      /^(features\/CodeMirror\/(index\.ts|Editor\/|Diff\/|SqlEditor\/|shared\/languageExtensions\.ts|config\/extensions\.ts)|components\/TerminalInteractive\/(index\.tsx|terminalSetup\.ts)|engines\/TerminalCore\/index\.tsx|scaffold\/ModalSystem\/variants\/ContentView\/)/
+    );
+    expect(
+      forbidden.map((f) => graph.explain(f)),
+      "feature trees leaked into the startup graph (each line is the import chain)"
+    ).toEqual([]);
+  });
+
+  it("keeps the App entry import foldable so production emits an async App chunk", () => {
+    // webpack only constant-folds a DefinePlugin expression when it appears
+    // inline at the branch. `isDev ? import(/* eager */ …) : import(…)`
+    // is walked on both arms and the "eager" mode wins → App inlined into
+    // main.js (~4 MB of synchronous startup JS). Keep the inline form.
+    const source = readFileSync(path.join(SRC_ROOT, "index.tsx"), "utf8");
+    // The explanatory comment above the import mentions the magic comment
+    // too, so anchor on the last occurrence (the real `import()` call).
+    const eagerIndex = source.lastIndexOf('webpackMode: "eager"');
+    expect(eagerIndex).toBeGreaterThan(-1);
+    const window = source.slice(Math.max(0, eagerIndex - 400), eagerIndex);
+    const conditionIndex = window.lastIndexOf(
+      'process.env.NODE_ENV === "development"'
+    );
+    expect(
+      conditionIndex,
+      'the eager App import must be guarded by an inline `process.env.NODE_ENV === "development"` test'
+    ).toBeGreaterThan(-1);
+    const guardTail = window.slice(conditionIndex);
+    expect(guardTail).not.toMatch(/\bisDev\b/);
+  });
+});

--- a/src/components/Message/MessageContainer.tsx
+++ b/src/components/Message/MessageContainer.tsx
@@ -1,0 +1,245 @@
+/**
+ * Toast renderer for `Message` — split out of `index.tsx` so framer-motion
+ * (and lucide icons) load lazily on the first toast instead of sitting in
+ * the startup graph of every module that imports the `Message` API.
+ */
+import { AnimatePresence, motion } from "framer-motion";
+import {
+  AlertCircle,
+  AlertTriangle,
+  CheckCircle2,
+  Info,
+  X,
+} from "lucide-react";
+import type { FC } from "react";
+import { useCallback, useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+
+import {
+  DEFAULT_DURATION,
+  type MessageConfig,
+  type MessageItemProps,
+  type MessageType,
+} from "./types";
+
+// ============================================
+// Config
+// ============================================
+
+const ICONS: Record<MessageType, typeof CheckCircle2> = {
+  success: CheckCircle2,
+  error: AlertCircle,
+  warning: AlertTriangle,
+  info: Info,
+};
+
+const TYPE_STYLES: Record<MessageType, { border: string; icon: string }> = {
+  success: {
+    border: "border-success-6/30",
+    icon: "bg-success-6/15 text-success-6",
+  },
+  error: {
+    border: "border-danger-6/30",
+    icon: "bg-danger-6/15 text-danger-6",
+  },
+  warning: {
+    border: "border-warning-6/30",
+    icon: "bg-warning-6/15 text-warning-6",
+  },
+  info: {
+    border: "border-primary-6/30",
+    icon: "bg-primary-6/15 text-primary-6",
+  },
+};
+
+// ============================================
+// Message Item Component
+// ============================================
+
+const MessageItem = ({
+  id,
+  content,
+  title,
+  type = "info",
+  duration = DEFAULT_DURATION,
+  closable = true,
+  onClose,
+  onRemove,
+  icon,
+  className = "",
+  download,
+  cancel,
+  action,
+  ref,
+}: MessageItemProps) => {
+  const { t } = useTranslation();
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleClose = useCallback(() => {
+    onRemove(id);
+    onClose?.();
+  }, [id, onRemove, onClose]);
+
+  // Auto dismiss timer
+  useEffect(() => {
+    if (duration <= 0) return;
+
+    timerRef.current = setTimeout(() => {
+      handleClose();
+    }, duration);
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [duration, handleClose]);
+
+  const IconComponent = ICONS[type];
+  const typeStyle = TYPE_STYLES[type];
+  const iconNode = icon || <IconComponent size={18} />;
+  const hasDescription = Boolean(title || download || cancel || action);
+  const handleDownload = useCallback(() => {
+    const blob =
+      download?.content instanceof Blob
+        ? download.content
+        : new Blob([download?.content ?? ""], {
+            type: download?.mimeType ?? "text/plain;charset=utf-8",
+          });
+
+    const objectUrl = URL.createObjectURL(blob);
+    const downloadLink = document.createElement("a");
+    downloadLink.href = objectUrl;
+    downloadLink.download = download?.fileName ?? "message.txt";
+    document.body.appendChild(downloadLink);
+    downloadLink.click();
+    document.body.removeChild(downloadLink);
+    URL.revokeObjectURL(objectUrl);
+  }, [download]);
+  const handleCancelAction = useCallback(() => {
+    cancel?.onClick?.();
+    if (cancel?.closeOnClick !== false) {
+      handleClose();
+    }
+  }, [cancel, handleClose]);
+  const handlePrimaryAction = useCallback(() => {
+    action?.onClick();
+    if (action?.closeOnClick !== false) {
+      handleClose();
+    }
+  }, [action, handleClose]);
+
+  return (
+    <motion.div
+      ref={ref}
+      initial={{ opacity: 0, y: 16 }}
+      animate={{
+        opacity: 1,
+        y: 0,
+      }}
+      exit={{
+        opacity: 0,
+      }}
+      transition={{
+        duration: 0.2,
+        ease: "easeOut",
+      }}
+      className={`pointer-events-auto relative flex w-full cursor-default gap-3 overflow-hidden rounded-xl border bg-bg-2 p-[14px_16px] shadow-[0_2px_4px_rgba(0,0,0,0.04),0_12px_24px_rgba(0,0,0,0.08)] transition-[transform,box-shadow] duration-200 ease-out hover:-translate-y-px hover:shadow-[0_4px_8px_rgba(0,0,0,0.06),0_16px_32px_rgba(0,0,0,0.12)] max-[480px]:gap-2.5 max-[480px]:rounded-[10px] max-[480px]:p-[12px_14px] ${hasDescription ? "items-start" : "items-center"} ${typeStyle.border} ${className}`}
+    >
+      {/* Icon */}
+      <div
+        className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-lg max-[480px]:h-6 max-[480px]:w-6 max-[480px]:rounded-md ${typeStyle.icon}`}
+      >
+        {iconNode}
+      </div>
+
+      {/* Content */}
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        {title && (
+          <div className="text-[13px] font-semibold leading-[1.4] tracking-[-0.01em] text-text-1 max-[480px]:text-xs">
+            {title}
+          </div>
+        )}
+        <div
+          className={`break-words text-[13px] leading-[1.5] max-[480px]:text-xs ${
+            title ? "font-[450] text-text-2" : "font-medium text-text-1"
+          }`}
+        >
+          {content}
+        </div>
+        {(download || cancel || action) && (
+          <div className="mt-2 flex justify-end gap-3">
+            {cancel && (
+              <button
+                type="button"
+                className="cursor-pointer border-none bg-transparent p-0 text-xs font-medium leading-[1.2] text-primary-6 hover:text-primary-5 hover:underline"
+                onClick={handleCancelAction}
+              >
+                {cancel.label ?? t("actions.cancel")}
+              </button>
+            )}
+            {download && (
+              <button
+                type="button"
+                className="cursor-pointer border-none bg-transparent p-0 text-xs font-medium leading-[1.2] text-primary-6 hover:text-primary-5 hover:underline"
+                onClick={handleDownload}
+              >
+                {download.label ?? t("actions.download")}
+              </button>
+            )}
+            {action && (
+              <button
+                type="button"
+                className="cursor-pointer border-none bg-transparent p-0 text-xs font-semibold leading-[1.2] text-primary-6 hover:text-primary-5 hover:underline"
+                onClick={handlePrimaryAction}
+              >
+                {action.label}
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Close button */}
+      {closable && (
+        <button
+          className="my-[-2px] ml-1 mr-[-4px] flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-md border-none bg-transparent p-0 text-text-3 opacity-60 transition-all duration-150 ease-out hover:bg-white/10 hover:text-text-1 hover:opacity-100 active:scale-95"
+          onClick={handleClose}
+          aria-label={t("actions.close")}
+        >
+          <X size={14} />
+        </button>
+      )}
+    </motion.div>
+  );
+};
+
+MessageItem.displayName = "MessageItem";
+
+// ============================================
+// Message Container Component
+// ============================================
+
+interface MessageContainerProps {
+  messages: Map<string, MessageConfig>;
+  onRemove: (id: string) => void;
+}
+
+const MessageContainer: FC<MessageContainerProps> = ({
+  messages,
+  onRemove,
+}) => {
+  const messageArray = Array.from(messages.entries());
+
+  return (
+    <div className="flex w-auto max-w-[380px] flex-col-reverse items-end gap-2 max-[480px]:max-w-full">
+      <AnimatePresence>
+        {messageArray.map(([id, config]) => (
+          <MessageItem key={id} id={id} {...config} onRemove={onRemove} />
+        ))}
+      </AnimatePresence>
+    </div>
+  );
+};
+
+export default MessageContainer;

--- a/src/components/Message/__tests__/messageLazyContainer.test.ts
+++ b/src/components/Message/__tests__/messageLazyContainer.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import Message from "@src/components/Message";
+
+// framer-motion drives its enter animation from rAF; jsdom has rAF but the
+// motion values never settle in tests, so stub the animation primitives with
+// plain elements. The point of this test is the lazy module boundary, not
+// the animation.
+vi.mock("framer-motion", async () => {
+  const React = await import("react");
+  return {
+    AnimatePresence: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    motion: new Proxy(
+      {},
+      {
+        get: (_target, tag: string) =>
+          // eslint-disable-next-line react/display-name
+          React.forwardRef<HTMLElement, Record<string, unknown>>(
+            (props, ref) => {
+              // Drop the animation-only props so they don't hit the DOM.
+              const {
+                initial: _initial,
+                animate: _animate,
+                exit: _exit,
+                transition: _transition,
+                ...rest
+              } = props;
+              return React.createElement(tag, { ...rest, ref });
+            }
+          ),
+      }
+    ),
+  };
+});
+
+async function waitForToastText(text: string, timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+    const root = document.querySelector("[data-message-root]");
+    if (root?.textContent?.includes(text)) return;
+  }
+  throw new Error(`toast "${text}" did not render within ${timeoutMs}ms`);
+}
+
+describe("Message (lazy toast container)", () => {
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    act(() => Message.destroy());
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("renders a toast once the lazily loaded container resolves", async () => {
+    let id = "";
+    await act(async () => {
+      id = Message.success("saved ok", { duration: 0 });
+    });
+    expect(id).not.toBe("");
+
+    // Let the lazy `import("./MessageContainer")` settle and re-render.
+    await waitForToastText("saved ok");
+    const root = document.querySelector("[data-message-root]");
+    expect(root).not.toBeNull();
+    expect(root?.textContent).toContain("saved ok");
+  });
+
+  it("removes toasts and the container on destroy", async () => {
+    await act(async () => {
+      Message.info("temporary", { duration: 0 });
+    });
+    await waitForToastText("temporary");
+    act(() => Message.destroy());
+    expect(document.querySelector("[data-message-root]")).toBeNull();
+  });
+});

--- a/src/components/Message/index.tsx
+++ b/src/components/Message/index.tsx
@@ -20,286 +20,23 @@
  * Message.info({ content: "Info message", closable: true });
  * ```
  */
-import { AnimatePresence, motion } from "framer-motion";
-import {
-  AlertCircle,
-  AlertTriangle,
-  CheckCircle2,
-  Info,
-  X,
-} from "lucide-react";
-import type { FC, ReactNode, Ref } from "react";
-import { useCallback, useEffect, useRef } from "react";
+import type { ReactNode } from "react";
+import { Suspense, lazy } from "react";
 import { createRoot } from "react-dom/client";
-import { useTranslation } from "react-i18next";
 
-// ============================================
-// Types
-// ============================================
+import {
+  DEFAULT_DURATION,
+  type MessageConfig,
+  type MessageType,
+} from "./types";
 
-export type MessageType = "success" | "error" | "warning" | "info";
+export type { MessageConfig, MessageType } from "./types";
 
-export interface MessageConfig {
-  content: ReactNode;
-  type?: MessageType;
-  duration?: number;
-  closable?: boolean;
-  onClose?: () => void;
-  icon?: ReactNode;
-  className?: string;
-  id?: string;
-  /** Keep this message from being evicted by the three-message soft limit. */
-  persistent?: boolean;
-  /** Optional title for the message */
-  title?: string;
-  /** Optional download action shown in the toast */
-  download?: {
-    fileName: string;
-    content: string | Blob;
-    mimeType?: string;
-    label?: string;
-  };
-  /** Optional cancel action shown in the toast */
-  cancel?: {
-    label?: string;
-    onClick?: () => void;
-    closeOnClick?: boolean;
-  };
-  /** Optional primary action shown in the toast. */
-  action?: {
-    label: string;
-    onClick: () => void;
-    closeOnClick?: boolean;
-  };
-}
-
-interface MessageItemProps extends MessageConfig {
-  id: string;
-  onRemove: (id: string) => void;
-  ref?: Ref<HTMLDivElement>;
-}
-
-// ============================================
-// Config
-// ============================================
-
-const ICONS: Record<MessageType, typeof CheckCircle2> = {
-  success: CheckCircle2,
-  error: AlertCircle,
-  warning: AlertTriangle,
-  info: Info,
-};
-
-const TYPE_STYLES: Record<MessageType, { border: string; icon: string }> = {
-  success: {
-    border: "border-success-6/30",
-    icon: "bg-success-6/15 text-success-6",
-  },
-  error: {
-    border: "border-danger-6/30",
-    icon: "bg-danger-6/15 text-danger-6",
-  },
-  warning: {
-    border: "border-warning-6/30",
-    icon: "bg-warning-6/15 text-warning-6",
-  },
-  info: {
-    border: "border-primary-6/30",
-    icon: "bg-primary-6/15 text-primary-6",
-  },
-};
-
-const DEFAULT_DURATION = 1000;
-
-// ============================================
-// Message Item Component
-// ============================================
-
-const MessageItem = ({
-  id,
-  content,
-  title,
-  type = "info",
-  duration = DEFAULT_DURATION,
-  closable = true,
-  onClose,
-  onRemove,
-  icon,
-  className = "",
-  download,
-  cancel,
-  action,
-  ref,
-}: MessageItemProps) => {
-  const { t } = useTranslation();
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const handleClose = useCallback(() => {
-    onRemove(id);
-    onClose?.();
-  }, [id, onRemove, onClose]);
-
-  // Auto dismiss timer
-  useEffect(() => {
-    if (duration <= 0) return;
-
-    timerRef.current = setTimeout(() => {
-      handleClose();
-    }, duration);
-
-    return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
-      }
-    };
-  }, [duration, handleClose]);
-
-  const IconComponent = ICONS[type];
-  const typeStyle = TYPE_STYLES[type];
-  const iconNode = icon || <IconComponent size={18} />;
-  const hasDescription = Boolean(title || download || cancel || action);
-  const handleDownload = useCallback(() => {
-    const blob =
-      download?.content instanceof Blob
-        ? download.content
-        : new Blob([download?.content ?? ""], {
-            type: download?.mimeType ?? "text/plain;charset=utf-8",
-          });
-
-    const objectUrl = URL.createObjectURL(blob);
-    const downloadLink = document.createElement("a");
-    downloadLink.href = objectUrl;
-    downloadLink.download = download?.fileName ?? "message.txt";
-    document.body.appendChild(downloadLink);
-    downloadLink.click();
-    document.body.removeChild(downloadLink);
-    URL.revokeObjectURL(objectUrl);
-  }, [download]);
-  const handleCancelAction = useCallback(() => {
-    cancel?.onClick?.();
-    if (cancel?.closeOnClick !== false) {
-      handleClose();
-    }
-  }, [cancel, handleClose]);
-  const handlePrimaryAction = useCallback(() => {
-    action?.onClick();
-    if (action?.closeOnClick !== false) {
-      handleClose();
-    }
-  }, [action, handleClose]);
-
-  return (
-    <motion.div
-      ref={ref}
-      initial={{ opacity: 0, y: 16 }}
-      animate={{
-        opacity: 1,
-        y: 0,
-      }}
-      exit={{
-        opacity: 0,
-      }}
-      transition={{
-        duration: 0.2,
-        ease: "easeOut",
-      }}
-      className={`pointer-events-auto relative flex w-full cursor-default gap-3 overflow-hidden rounded-xl border bg-bg-2 p-[14px_16px] shadow-[0_2px_4px_rgba(0,0,0,0.04),0_12px_24px_rgba(0,0,0,0.08)] transition-[transform,box-shadow] duration-200 ease-out hover:-translate-y-px hover:shadow-[0_4px_8px_rgba(0,0,0,0.06),0_16px_32px_rgba(0,0,0,0.12)] max-[480px]:gap-2.5 max-[480px]:rounded-[10px] max-[480px]:p-[12px_14px] ${hasDescription ? "items-start" : "items-center"} ${typeStyle.border} ${className}`}
-    >
-      {/* Icon */}
-      <div
-        className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-lg max-[480px]:h-6 max-[480px]:w-6 max-[480px]:rounded-md ${typeStyle.icon}`}
-      >
-        {iconNode}
-      </div>
-
-      {/* Content */}
-      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        {title && (
-          <div className="text-[13px] font-semibold leading-[1.4] tracking-[-0.01em] text-text-1 max-[480px]:text-xs">
-            {title}
-          </div>
-        )}
-        <div
-          className={`break-words text-[13px] leading-[1.5] max-[480px]:text-xs ${
-            title ? "font-[450] text-text-2" : "font-medium text-text-1"
-          }`}
-        >
-          {content}
-        </div>
-        {(download || cancel || action) && (
-          <div className="mt-2 flex justify-end gap-3">
-            {cancel && (
-              <button
-                type="button"
-                className="cursor-pointer border-none bg-transparent p-0 text-xs font-medium leading-[1.2] text-primary-6 hover:text-primary-5 hover:underline"
-                onClick={handleCancelAction}
-              >
-                {cancel.label ?? t("actions.cancel")}
-              </button>
-            )}
-            {download && (
-              <button
-                type="button"
-                className="cursor-pointer border-none bg-transparent p-0 text-xs font-medium leading-[1.2] text-primary-6 hover:text-primary-5 hover:underline"
-                onClick={handleDownload}
-              >
-                {download.label ?? t("actions.download")}
-              </button>
-            )}
-            {action && (
-              <button
-                type="button"
-                className="cursor-pointer border-none bg-transparent p-0 text-xs font-semibold leading-[1.2] text-primary-6 hover:text-primary-5 hover:underline"
-                onClick={handlePrimaryAction}
-              >
-                {action.label}
-              </button>
-            )}
-          </div>
-        )}
-      </div>
-
-      {/* Close button */}
-      {closable && (
-        <button
-          className="my-[-2px] ml-1 mr-[-4px] flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-md border-none bg-transparent p-0 text-text-3 opacity-60 transition-all duration-150 ease-out hover:bg-white/10 hover:text-text-1 hover:opacity-100 active:scale-95"
-          onClick={handleClose}
-          aria-label={t("actions.close")}
-        >
-          <X size={14} />
-        </button>
-      )}
-    </motion.div>
-  );
-};
-
-MessageItem.displayName = "MessageItem";
-
-// ============================================
-// Message Container Component
-// ============================================
-
-interface MessageContainerProps {
-  messages: Map<string, MessageConfig>;
-  onRemove: (id: string) => void;
-}
-
-const MessageContainer: FC<MessageContainerProps> = ({
-  messages,
-  onRemove,
-}) => {
-  const messageArray = Array.from(messages.entries());
-
-  return (
-    <div className="flex w-auto max-w-[380px] flex-col-reverse items-end gap-2 max-[480px]:max-w-full">
-      <AnimatePresence>
-        {messageArray.map(([id, config]) => (
-          <MessageItem key={id} id={id} {...config} onRemove={onRemove} />
-        ))}
-      </AnimatePresence>
-    </div>
-  );
-};
+// The toast renderer (framer-motion + icons) is loaded on the first toast so
+// the ~170 KB animation stack stays out of the startup graph. Auto-dismiss
+// timers start on item mount, so deferring the first paint by one chunk load
+// does not shorten a toast's visible lifetime.
+const LazyMessageContainer = lazy(() => import("./MessageContainer"));
 
 // ============================================
 // Message Manager (Singleton)
@@ -342,13 +79,15 @@ class MessageManager {
     if (!this.root) return;
 
     this.root.render(
-      <MessageContainer
-        messages={new Map(this.messages)}
-        onRemove={(id) => {
-          this.messages.delete(id);
-          this.render();
-        }}
-      />
+      <Suspense fallback={null}>
+        <LazyMessageContainer
+          messages={new Map(this.messages)}
+          onRemove={(id) => {
+            this.messages.delete(id);
+            this.render();
+          }}
+        />
+      </Suspense>
     );
   }
 

--- a/src/components/Message/types.ts
+++ b/src/components/Message/types.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared types for the `Message` toast system.
+ */
+import type { ReactNode, Ref } from "react";
+
+export type MessageType = "success" | "error" | "warning" | "info";
+
+export interface MessageConfig {
+  content: ReactNode;
+  type?: MessageType;
+  duration?: number;
+  closable?: boolean;
+  onClose?: () => void;
+  icon?: ReactNode;
+  className?: string;
+  id?: string;
+  /** Keep this message from being evicted by the three-message soft limit. */
+  persistent?: boolean;
+  /** Optional title for the message */
+  title?: string;
+  /** Optional download action shown in the toast */
+  download?: {
+    fileName: string;
+    content: string | Blob;
+    mimeType?: string;
+    label?: string;
+  };
+  /** Optional cancel action shown in the toast */
+  cancel?: {
+    label?: string;
+    onClick?: () => void;
+    closeOnClick?: boolean;
+  };
+  /** Optional primary action shown in the toast. */
+  action?: {
+    label: string;
+    onClick: () => void;
+    closeOnClick?: boolean;
+  };
+}
+
+export interface MessageItemProps extends MessageConfig {
+  id: string;
+  onRemove: (id: string) => void;
+  ref?: Ref<HTMLDivElement>;
+}
+
+export const DEFAULT_DURATION = 1000;

--- a/src/diagnostics/runtimeCounters.ts
+++ b/src/diagnostics/runtimeCounters.ts
@@ -1,10 +1,17 @@
 import { bucketDurationMs } from "./buckets";
 import type { DiagnosticsRuntimeSummary } from "./types";
 
+/**
+ * Per-operation counter. Durations are folded into a running sum + sample
+ * count rather than an array: the summary only ever needs the average, and
+ * an array here grew unbounded (one entry per RPC/HTTP call) until a
+ * consumer drained it — which offline mode never does.
+ */
 interface RuntimeCounter {
   total: number;
   failure: number;
-  durations: number[];
+  durationSumMs: number;
+  durationSamples: number;
 }
 
 const rpcCounters = new Map<string, RuntimeCounter>();
@@ -16,7 +23,12 @@ function getCounter(
 ): RuntimeCounter {
   const existing = counters.get(operation);
   if (existing) return existing;
-  const created: RuntimeCounter = { total: 0, failure: 0, durations: [] };
+  const created: RuntimeCounter = {
+    total: 0,
+    failure: 0,
+    durationSumMs: 0,
+    durationSamples: 0,
+  };
   counters.set(operation, created);
   return created;
 }
@@ -29,7 +41,7 @@ export function recordDiagnosticsRpc(
   const counter = getCounter(rpcCounters, command);
   counter.total += 1;
   if (!ok) counter.failure += 1;
-  counter.durations.push(durationMs);
+  addDurationSample(counter, durationMs);
 }
 
 export function recordDiagnosticsHttp(
@@ -40,12 +52,18 @@ export function recordDiagnosticsHttp(
   const counter = getCounter(httpCounters, target);
   counter.total += 1;
   if (!ok) counter.failure += 1;
-  counter.durations.push(durationMs);
+  addDurationSample(counter, durationMs);
 }
 
-function average(values: number[]): number {
-  if (values.length === 0) return 0;
-  return values.reduce((sum, value) => sum + value, 0) / values.length;
+function addDurationSample(counter: RuntimeCounter, durationMs: number): void {
+  if (!Number.isFinite(durationMs)) return;
+  counter.durationSumMs += durationMs;
+  counter.durationSamples += 1;
+}
+
+function averageDurationMs(counter: RuntimeCounter): number {
+  if (counter.durationSamples === 0) return 0;
+  return counter.durationSumMs / counter.durationSamples;
 }
 
 function consumeDiagnosticsSummary(
@@ -62,7 +80,7 @@ function consumeDiagnosticsSummary(
       total: counter.total,
       success: counter.total - counter.failure,
       failure: counter.failure,
-      durationBucket: bucketDurationMs(average(counter.durations)),
+      durationBucket: bucketDurationMs(averageDurationMs(counter)),
     };
   }
 

--- a/src/engines/ChatPanel/ChatHistory/ActionRegistry.ts
+++ b/src/engines/ChatPanel/ChatHistory/ActionRegistry.ts
@@ -2,12 +2,16 @@
  * Action Registry
  *
  * Chat context component mappings from unified registry.
- * Now uses UNIFIED_EVENT_REGISTRY under the hood.
+ *
+ * Imports the pure metadata module directly (not the registry barrel): this
+ * file sits on the chat-projection worker's static import path, and the
+ * barrel re-exports `events/index.ts`, whose lazy renderer `import()`s would
+ * otherwise become part of the worker's bundle graph and force webpack to
+ * duplicate every shared vendor module into the async chunks.
  */
 
 export {
   getActionConfig,
-  shouldShowStatusLine,
   requiresItemIndex,
-  getRegisteredActionTypes,
-} from "@src/engines/SessionCore/rendering/registry";
+  shouldShowStatusLine,
+} from "@src/engines/SessionCore/rendering/registry/events/contextConfig";

--- a/src/engines/ChatPanel/ChatHistory/projection/__tests__/workerStaticGraph.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/projection/__tests__/workerStaticGraph.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  reachableFilesMatching,
+  walkStaticImports,
+} from "@src/test/staticImportGraph";
+
+/**
+ * Bundle-boundary guard for the chat-projection web worker.
+ *
+ * The worker is its own webpack entrypoint. Any dynamic `import()` reachable
+ * from its *static* graph becomes part of the worker's chunk graph; because
+ * the worker entry does not share the main app's `vendors` chunk, webpack
+ * then has to copy every vendor module those chunks need (react-dom, xterm,
+ * CodeMirror, zod, …) into the async chunks the main app also loads. When
+ * `ActionRegistry` imported the registry barrel — which re-exports
+ * `rendering/registry/events/index.ts` with its lazy renderer loaders — the
+ * worker statically reached 2 388 files and the production build carried
+ * ~9 MB of duplicated vendor code. See
+ * docs/memory-audit-2026-08-16/ram-optimization-findings.md (Fix log, 2.3).
+ */
+describe("chat projection worker static import graph", () => {
+  const graph = walkStaticImports([
+    "engines/ChatPanel/ChatHistory/projection/worker.ts",
+  ]);
+
+  it("does not reach the React event renderer loaders", () => {
+    const forbidden = reachableFilesMatching(
+      graph,
+      /^(engines\/SessionCore\/rendering\/registry\/events\/index\.tsx?|engines\/SessionCore\/rendering\/registry\/registryAccessors\.tsx?|engines\/ChatPanel\/events\/|engines\/ChatPanel\/rendering\/index\.tsx?)/
+    );
+    expect(
+      forbidden.map((f) => graph.explain(f)),
+      "worker graph reached renderer loaders (each line is the import chain)"
+    ).toEqual([]);
+  });
+
+  it("does not depend on react-dom or the DOM-only libraries", () => {
+    // `react` itself is tolerated (a ~10 KB core reached through the shared
+    // logger hook); react-dom and the editor/terminal stacks are not.
+    const heavy = [
+      "react-dom",
+      "@xterm/xterm",
+      "@codemirror/view",
+      "framer-motion",
+      "lucide-react",
+    ].filter((pkg) => graph.packages.has(pkg));
+    expect(heavy, "worker graph pulled in UI packages").toEqual([]);
+  });
+
+  it("stays small (regression tripwire for barrel re-exports)", () => {
+    // 39 files at the time of writing; the previous barrel import made it
+    // 47 static + 2 388 with dynamic edges. Bump deliberately if the worker
+    // genuinely needs more modules.
+    expect(graph.files.size).toBeLessThanOrEqual(80);
+  });
+});

--- a/src/engines/SessionCore/rendering/registry/__tests__/contextConfigBoundary.test.ts
+++ b/src/engines/SessionCore/rendering/registry/__tests__/contextConfigBoundary.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import * as actionRegistry from "@src/engines/ChatPanel/ChatHistory/ActionRegistry";
+import * as registryBarrel from "@src/engines/SessionCore/rendering/registry";
+import * as contextConfig from "@src/engines/SessionCore/rendering/registry/events/contextConfig";
+import * as eventsIndex from "@src/engines/SessionCore/rendering/registry/events/index";
+import * as registryAccessors from "@src/engines/SessionCore/rendering/registry/registryAccessors";
+
+/**
+ * `events/contextConfig.ts` is the pure-metadata half of the event registry,
+ * split out so the chat-projection worker can read chat config without the
+ * renderer loaders. These checks make sure the split stays a pure move: every
+ * public entry point still hands out the *same* functions/objects.
+ */
+describe("registry contextConfig boundary", () => {
+  it("events/index re-exports the context config unchanged", () => {
+    expect(eventsIndex.CONTEXT_CONFIG).toBe(contextConfig.CONTEXT_CONFIG);
+    expect(eventsIndex.getChatContextConfig).toBe(
+      contextConfig.getChatContextConfig
+    );
+    expect(eventsIndex.chatShowsStatusLine).toBe(
+      contextConfig.chatShowsStatusLine
+    );
+    expect(eventsIndex.chatRequiresItemIndex).toBe(
+      contextConfig.chatRequiresItemIndex
+    );
+  });
+
+  it("registryAccessors and the barrel expose the same action-config helpers", () => {
+    expect(registryAccessors.getActionConfig).toBe(
+      contextConfig.getActionConfig
+    );
+    expect(registryAccessors.shouldShowStatusLine).toBe(
+      contextConfig.shouldShowStatusLine
+    );
+    expect(registryAccessors.requiresItemIndex).toBe(
+      contextConfig.requiresItemIndex
+    );
+    expect(registryBarrel.getActionConfig).toBe(contextConfig.getActionConfig);
+    expect(registryBarrel.CONTEXT_CONFIG).toBe(contextConfig.CONTEXT_CONFIG);
+  });
+
+  it("ActionRegistry (worker-side entry) resolves the same helpers", () => {
+    expect(actionRegistry.getActionConfig).toBe(contextConfig.getActionConfig);
+    expect(actionRegistry.shouldShowStatusLine).toBe(
+      contextConfig.shouldShowStatusLine
+    );
+    expect(actionRegistry.requiresItemIndex).toBe(
+      contextConfig.requiresItemIndex
+    );
+  });
+
+  it("action config answers match the context table", () => {
+    expect(contextConfig.getActionConfig("read_file")).toEqual(
+      contextConfig.CONTEXT_CONFIG.read_file.chat
+    );
+    expect(contextConfig.shouldShowStatusLine("read_file")).toBe(true);
+    expect(contextConfig.requiresItemIndex("read_file")).toBe(false);
+    // Unknown types fall back to the permissive defaults.
+    expect(contextConfig.getActionConfig("definitely_not_a_tool")).toBeNull();
+    expect(contextConfig.shouldShowStatusLine("definitely_not_a_tool")).toBe(
+      true
+    );
+    expect(contextConfig.requiresItemIndex("definitely_not_a_tool")).toBe(
+      false
+    );
+  });
+});

--- a/src/engines/SessionCore/rendering/registry/events/contextConfig.ts
+++ b/src/engines/SessionCore/rendering/registry/events/contextConfig.ts
@@ -1,0 +1,263 @@
+/**
+ * Event Context Configuration
+ *
+ * Pure rendering metadata keyed by Rust's `ui_canonical` — no React, no
+ * dynamic imports. Kept separate from `./index.ts` (which owns the lazy
+ * `COMPONENT_LOADERS`) so non-UI consumers such as the chat-projection web
+ * worker can read chat/simulator config without pulling every event
+ * renderer's `import()` edge into their bundle graph.
+ */
+import { getCliUiCanonical } from "@src/engines/SessionCore/rendering/registry/initToolRegistry";
+import type {
+  ChatContextConfig,
+  SimulatorContextConfig,
+} from "@src/engines/SessionCore/rendering/registry/types";
+
+// ============================================
+// Context Configuration by ui_canonical
+// Metadata for rendering behavior (not loaders)
+// ============================================
+
+export interface ContextConfig {
+  chat?: ChatContextConfig;
+  simulator?: SimulatorContextConfig;
+}
+
+export const CONTEXT_CONFIG: Record<string, ContextConfig> = {
+  // File operations
+  read_file: {
+    chat: { requiresItemIndex: false, showStatusLine: true },
+    simulator: {
+      supportsSplitView: false,
+      supportsFullscreen: true,
+      supportsAutoScroll: true,
+    },
+  },
+  edit_file: {
+    chat: { requiresItemIndex: false, showStatusLine: true },
+    simulator: {
+      supportsSplitView: true,
+      supportsFullscreen: true,
+      supportsTypewriter: true,
+    },
+  },
+  delete_file: {
+    chat: { requiresItemIndex: false, showStatusLine: true },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+  list_dir: {
+    chat: { requiresItemIndex: false, showStatusLine: true },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+  tool_search: {
+    chat: { requiresItemIndex: false, showStatusLine: true },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+
+  // Terminal
+  run_shell: {
+    chat: { requiresItemIndex: false, showStatusLine: false },
+    simulator: { supportsSplitView: true, supportsFullscreen: true },
+  },
+
+  // Await output (background task monitor)
+  await_output: {
+    chat: { requiresItemIndex: false, showStatusLine: true },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+  inspect_terminals: {
+    chat: { requiresItemIndex: false, showStatusLine: true },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+
+  // Search
+  code_search: {
+    chat: { requiresItemIndex: false, showStatusLine: true },
+    simulator: { supportsSplitView: false, supportsFullscreen: true },
+  },
+  web_search: {
+    chat: { requiresItemIndex: false, showStatusLine: true },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+  glob_file_search: {
+    chat: { requiresItemIndex: false, showStatusLine: true },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+
+  // Conversation
+  agent_message: {
+    chat: { requiresItemIndex: true, showStatusLine: true },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+  thinking: {
+    chat: { requiresItemIndex: false, showStatusLine: false },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+  user: {
+    chat: { requiresItemIndex: false, showStatusLine: true },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+  ask_user_questions: {
+    chat: { requiresItemIndex: false, showStatusLine: true },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+  org_send_message: {
+    chat: { requiresItemIndex: false, showStatusLine: true },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+  // Approval
+  ask_user_permissions: {
+    chat: { requiresItemIndex: false, showStatusLine: true },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+
+  // Subagent / Task
+  subagent: {
+    chat: { requiresItemIndex: false, showStatusLine: false },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+  suggest_mode_switch: {
+    chat: { requiresItemIndex: false, showStatusLine: false },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+  manage_todo: {
+    chat: { requiresItemIndex: false, showStatusLine: false },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+  task_create: {
+    chat: { requiresItemIndex: false, showStatusLine: false },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+  task_update: {
+    chat: { requiresItemIndex: false, showStatusLine: false },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+  task_list: {
+    chat: { requiresItemIndex: false, showStatusLine: false },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+  task_get: {
+    chat: { requiresItemIndex: false, showStatusLine: false },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+
+  // Browser
+  browser: {
+    chat: { requiresItemIndex: false, showStatusLine: true },
+    simulator: { supportsSplitView: false, supportsFullscreen: true },
+  },
+  internal_browser: {
+    chat: { requiresItemIndex: false, showStatusLine: true },
+    simulator: { supportsSplitView: false, supportsFullscreen: true },
+  },
+
+  // MCP server tools
+  mcp_tool: {
+    chat: { requiresItemIndex: false, showStatusLine: true },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+
+  // Turn summary
+  turn_summary: {
+    chat: { requiresItemIndex: false, showStatusLine: false },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+
+  // Rate limit hint
+  rate_limit_hint: {
+    chat: { requiresItemIndex: false, showStatusLine: false },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+
+  // Compact boundary (context compacted marker)
+  context_compacted: {
+    chat: { requiresItemIndex: false, showStatusLine: false },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+
+  // Worktree
+  worktree: {
+    chat: { requiresItemIndex: false, showStatusLine: true },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+
+  // Setup repo
+  setup_repo: {
+    chat: { requiresItemIndex: false, showStatusLine: false },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+
+  // Canvas card
+  canvas_inline: {
+    chat: { requiresItemIndex: false, showStatusLine: false },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+
+  // Plan card
+  plan_approval: {
+    chat: { requiresItemIndex: false, showStatusLine: false },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+
+  // Generic fallback
+  tool_call: {
+    chat: { requiresItemIndex: false, showStatusLine: true },
+    simulator: { supportsSplitView: false, supportsFullscreen: false },
+  },
+};
+
+// ============================================
+// Chat Context Helpers
+// ============================================
+
+/**
+ * Get chat context config for an event type.
+ */
+export function getChatContextConfig(eventType: string): {
+  requiresItemIndex?: boolean;
+  showStatusLine?: boolean;
+} | null {
+  const uiCanonical = getCliUiCanonical(eventType);
+  return CONTEXT_CONFIG[uiCanonical]?.chat ?? null;
+}
+
+/**
+ * Check if an event type should show status line in chat context.
+ */
+export function chatShowsStatusLine(eventType: string): boolean {
+  return getChatContextConfig(eventType)?.showStatusLine ?? true;
+}
+
+/**
+ * Check if an event type requires itemIndex prop in chat context.
+ */
+export function chatRequiresItemIndex(eventType: string): boolean {
+  return getChatContextConfig(eventType)?.requiresItemIndex ?? false;
+}
+
+/**
+ * Get action configuration for chat context (alias used by the chat
+ * item pipeline / ActionRegistry).
+ */
+export function getActionConfig(actionType: string): {
+  requiresItemIndex?: boolean;
+  showStatusLine?: boolean;
+} | null {
+  return getChatContextConfig(actionType);
+}
+
+/**
+ * Check if action_type should show status line in chat
+ */
+export function shouldShowStatusLine(actionType: string): boolean {
+  const config = getActionConfig(actionType);
+  return config?.showStatusLine ?? true;
+}
+
+/**
+ * Check if component requires itemIndex prop
+ */
+export function requiresItemIndex(actionType: string): boolean {
+  const config = getActionConfig(actionType);
+  return config?.requiresItemIndex ?? false;
+}

--- a/src/engines/SessionCore/rendering/registry/events/index.ts
+++ b/src/engines/SessionCore/rendering/registry/events/index.ts
@@ -37,11 +37,7 @@ import {
   type EventCategory,
   getCategoryForUiCanonical,
 } from "@src/engines/SessionCore/rendering/registry/toolCategories";
-import type {
-  ChatContextConfig,
-  ComponentLoader,
-  SimulatorContextConfig,
-} from "@src/engines/SessionCore/rendering/registry/types";
+import type { ComponentLoader } from "@src/engines/SessionCore/rendering/registry/types";
 import { createLogger } from "@src/hooks/logger";
 
 // Re-export tool category utilities
@@ -49,6 +45,17 @@ export {
   getCategoryForUiCanonical,
   type EventCategory,
 } from "@src/engines/SessionCore/rendering/registry/toolCategories";
+
+// Context configuration (pure metadata) lives in ./contextConfig so that
+// non-UI consumers (e.g. the chat-projection worker) can import it without
+// dragging every renderer's dynamic import into their bundle graph.
+export {
+  CONTEXT_CONFIG,
+  type ContextConfig,
+  getChatContextConfig,
+  chatShowsStatusLine,
+  chatRequiresItemIndex,
+} from "./contextConfig";
 
 const log = createLogger("UnifiedRegistry");
 
@@ -171,199 +178,6 @@ export const COMPONENT_LOADERS: ComponentLoaderMap = {
         default: mod.ModeSwitchEvent as React.ComponentType<unknown>,
       })
     ),
-};
-
-// ============================================
-// Context Configuration by ui_canonical
-// Metadata for rendering behavior (not loaders)
-// ============================================
-
-export interface ContextConfig {
-  chat?: ChatContextConfig;
-  simulator?: SimulatorContextConfig;
-}
-
-export const CONTEXT_CONFIG: Record<string, ContextConfig> = {
-  // File operations
-  read_file: {
-    chat: { requiresItemIndex: false, showStatusLine: true },
-    simulator: {
-      supportsSplitView: false,
-      supportsFullscreen: true,
-      supportsAutoScroll: true,
-    },
-  },
-  edit_file: {
-    chat: { requiresItemIndex: false, showStatusLine: true },
-    simulator: {
-      supportsSplitView: true,
-      supportsFullscreen: true,
-      supportsTypewriter: true,
-    },
-  },
-  delete_file: {
-    chat: { requiresItemIndex: false, showStatusLine: true },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-  list_dir: {
-    chat: { requiresItemIndex: false, showStatusLine: true },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-  tool_search: {
-    chat: { requiresItemIndex: false, showStatusLine: true },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-
-  // Terminal
-  run_shell: {
-    chat: { requiresItemIndex: false, showStatusLine: false },
-    simulator: { supportsSplitView: true, supportsFullscreen: true },
-  },
-
-  // Await output (background task monitor)
-  await_output: {
-    chat: { requiresItemIndex: false, showStatusLine: true },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-  inspect_terminals: {
-    chat: { requiresItemIndex: false, showStatusLine: true },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-
-  // Search
-  code_search: {
-    chat: { requiresItemIndex: false, showStatusLine: true },
-    simulator: { supportsSplitView: false, supportsFullscreen: true },
-  },
-  web_search: {
-    chat: { requiresItemIndex: false, showStatusLine: true },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-  glob_file_search: {
-    chat: { requiresItemIndex: false, showStatusLine: true },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-
-  // Conversation
-  agent_message: {
-    chat: { requiresItemIndex: true, showStatusLine: true },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-  thinking: {
-    chat: { requiresItemIndex: false, showStatusLine: false },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-  user: {
-    chat: { requiresItemIndex: false, showStatusLine: true },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-  ask_user_questions: {
-    chat: { requiresItemIndex: false, showStatusLine: true },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-  org_send_message: {
-    chat: { requiresItemIndex: false, showStatusLine: true },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-  // Approval
-  ask_user_permissions: {
-    chat: { requiresItemIndex: false, showStatusLine: true },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-
-  // Subagent / Task
-  subagent: {
-    chat: { requiresItemIndex: false, showStatusLine: false },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-  suggest_mode_switch: {
-    chat: { requiresItemIndex: false, showStatusLine: false },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-  manage_todo: {
-    chat: { requiresItemIndex: false, showStatusLine: false },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-  task_create: {
-    chat: { requiresItemIndex: false, showStatusLine: false },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-  task_update: {
-    chat: { requiresItemIndex: false, showStatusLine: false },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-  task_list: {
-    chat: { requiresItemIndex: false, showStatusLine: false },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-  task_get: {
-    chat: { requiresItemIndex: false, showStatusLine: false },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-
-  // Browser
-  browser: {
-    chat: { requiresItemIndex: false, showStatusLine: true },
-    simulator: { supportsSplitView: false, supportsFullscreen: true },
-  },
-  internal_browser: {
-    chat: { requiresItemIndex: false, showStatusLine: true },
-    simulator: { supportsSplitView: false, supportsFullscreen: true },
-  },
-
-  // MCP server tools
-  mcp_tool: {
-    chat: { requiresItemIndex: false, showStatusLine: true },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-
-  // Turn summary
-  turn_summary: {
-    chat: { requiresItemIndex: false, showStatusLine: false },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-
-  // Rate limit hint
-  rate_limit_hint: {
-    chat: { requiresItemIndex: false, showStatusLine: false },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-
-  // Compact boundary (context compacted marker)
-  context_compacted: {
-    chat: { requiresItemIndex: false, showStatusLine: false },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-
-  // Worktree
-  worktree: {
-    chat: { requiresItemIndex: false, showStatusLine: true },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-
-  // Setup repo
-  setup_repo: {
-    chat: { requiresItemIndex: false, showStatusLine: false },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-
-  // Canvas card
-  canvas_inline: {
-    chat: { requiresItemIndex: false, showStatusLine: false },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-
-  // Plan card
-  plan_approval: {
-    chat: { requiresItemIndex: false, showStatusLine: false },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
-
-  // Generic fallback
-  tool_call: {
-    chat: { requiresItemIndex: false, showStatusLine: true },
-    simulator: { supportsSplitView: false, supportsFullscreen: false },
-  },
 };
 
 // ============================================
@@ -622,29 +436,4 @@ export function getChatComponent(
   eventType: string
 ): React.ComponentType<Record<string, unknown>> {
   return getEventComponentSync(eventType) ?? getChatLazyComponent(eventType);
-}
-
-/**
- * Get chat context config for an event type.
- */
-export function getChatContextConfig(eventType: string): {
-  requiresItemIndex?: boolean;
-  showStatusLine?: boolean;
-} | null {
-  const uiCanonical = getCliUiCanonical(eventType);
-  return CONTEXT_CONFIG[uiCanonical]?.chat ?? null;
-}
-
-/**
- * Check if an event type should show status line in chat context.
- */
-export function chatShowsStatusLine(eventType: string): boolean {
-  return getChatContextConfig(eventType)?.showStatusLine ?? true;
-}
-
-/**
- * Check if an event type requires itemIndex prop in chat context.
- */
-export function chatRequiresItemIndex(eventType: string): boolean {
-  return getChatContextConfig(eventType)?.requiresItemIndex ?? false;
 }

--- a/src/engines/SessionCore/rendering/registry/registryAccessors.ts
+++ b/src/engines/SessionCore/rendering/registry/registryAccessors.ts
@@ -15,7 +15,16 @@ import type { ComponentType, LazyExoticComponent } from "react";
 import { getToolIconComponent } from "@src/config/toolIcons";
 import { resolveToolName } from "@src/engines/SessionCore/rendering/registry/toolAliases";
 
-import { getAllEventTypes, getChatContextConfig } from "./events";
+import { getAllEventTypes } from "./events";
+
+// Chat-context accessors are pure metadata; re-exported from ./events/contextConfig
+// so `ActionRegistry` (and the chat-projection worker behind it) can import
+// them without touching the renderer loaders.
+export {
+  getActionConfig,
+  requiresItemIndex,
+  shouldShowStatusLine,
+} from "./events/contextConfig";
 
 export interface ComponentOption {
   id: string;
@@ -24,32 +33,6 @@ export interface ComponentOption {
   description: string;
   component: LazyExoticComponent<ComponentType<Record<string, unknown>>>;
 }
-/**
- * Get action configuration for chat context.
- */
-export function getActionConfig(actionType: string): {
-  requiresItemIndex?: boolean;
-  showStatusLine?: boolean;
-} | null {
-  return getChatContextConfig(actionType);
-}
-
-/**
- * Check if action_type should show status line in chat
- */
-export function shouldShowStatusLine(actionType: string): boolean {
-  const config = getActionConfig(actionType);
-  return config?.showStatusLine ?? true;
-}
-
-/**
- * Check if component requires itemIndex prop
- */
-export function requiresItemIndex(actionType: string): boolean {
-  const config = getActionConfig(actionType);
-  return config?.requiresItemIndex ?? false;
-}
-
 /**
  * Get all registered action types
  */

--- a/src/engines/SessionCore/rendering/registry/types.ts
+++ b/src/engines/SessionCore/rendering/registry/types.ts
@@ -5,7 +5,7 @@
  * Supports multiple contexts: chat, simulator, trajectory
  */
 import type { LucideIcon } from "lucide-react";
-import React from "react";
+import type React from "react";
 
 // ============================================
 // Component Types

--- a/src/engines/TerminalCore/__tests__/terminalMountWindow.test.ts
+++ b/src/engines/TerminalCore/__tests__/terminalMountWindow.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  MAX_WARM_INACTIVE_TERMINALS,
+  pushRecentTerminalId,
+  selectMountedTerminalSessions,
+} from "../terminalMountWindow";
+
+describe("pushRecentTerminalId", () => {
+  it("returns the same reference when the active id is already first", () => {
+    const prev = ["a", "b"];
+    expect(pushRecentTerminalId(prev, "a")).toBe(prev);
+  });
+
+  it("moves a re-activated id to the front without duplicating it", () => {
+    expect(pushRecentTerminalId(["a", "b", "c"], "c")).toEqual(["c", "a", "b"]);
+  });
+
+  it("bounds the list to the active slot plus the warm window", () => {
+    let list: readonly string[] = [];
+    for (let i = 0; i < MAX_WARM_INACTIVE_TERMINALS + 5; i++) {
+      list = pushRecentTerminalId(list, `t${i}`);
+    }
+    expect(list).toHaveLength(MAX_WARM_INACTIVE_TERMINALS + 1);
+    expect(list[0]).toBe(`t${MAX_WARM_INACTIVE_TERMINALS + 4}`);
+    expect(list).not.toContain("t0");
+  });
+});
+
+describe("selectMountedTerminalSessions", () => {
+  const sessions = ["a", "b", "c", "d"].map((id) => ({ id }));
+
+  it("always mounts the active session even before it is initialized", () => {
+    expect(
+      selectMountedTerminalSessions(sessions, "d", new Set(), []).map(
+        (s) => s.id
+      )
+    ).toEqual(["d"]);
+  });
+
+  it("only keeps initialized sessions inside the recent window mounted", () => {
+    const initialized = new Set(["a", "b", "c", "d"]);
+    const mounted = selectMountedTerminalSessions(sessions, "a", initialized, [
+      "a",
+      "c",
+    ]).map((s) => s.id);
+    // b and d are initialized (would previously stay mounted) but cold.
+    expect(mounted).toEqual(["a", "c"]);
+  });
+
+  it("does not mount recent-but-uninitialized sessions", () => {
+    expect(
+      selectMountedTerminalSessions(sessions, "a", new Set(["a"]), [
+        "a",
+        "b",
+      ]).map((s) => s.id)
+    ).toEqual(["a"]);
+  });
+});

--- a/src/engines/TerminalCore/index.tsx
+++ b/src/engines/TerminalCore/index.tsx
@@ -35,6 +35,10 @@ import {
 } from "@src/store/workstation/codeEditor/terminal/commandDetection";
 
 import { TerminalSearchPanel } from "./components/TerminalSearchPanel";
+import {
+  pushRecentTerminalId,
+  selectMountedTerminalSessions,
+} from "./terminalMountWindow";
 import type { UseTerminalStateReturn } from "./types";
 
 // Lazy-load the read-only terminal to keep xterm (~300KB) from doubling the chunk
@@ -111,6 +115,19 @@ export const TerminalCore: React.FC<TerminalCoreProps> = ({
   const terminalRefs = useRef<Map<string, TerminalViewHandle>>(new Map());
 
   const [searchOpen, setSearchOpen] = useState(false);
+
+  // Most-recently-active terminal ids (newest first) — see
+  // ./terminalMountWindow.ts for the mount policy this drives.
+  const [recentTerminalIds, setRecentTerminalIds] = useState<readonly string[]>(
+    []
+  );
+  // Derived-from-previous-render state (React's "storing information from
+  // previous renders" pattern): update synchronously during render instead
+  // of in an effect so the evicted pane never renders once with stale data.
+  if (activeSessionId) {
+    const nextRecent = pushRecentTerminalId(recentTerminalIds, activeSessionId);
+    if (nextRecent !== recentTerminalIds) setRecentTerminalIds(nextRecent);
+  }
 
   const [selection, setSelection] = useState<SelectionState>({
     visible: false,
@@ -310,9 +327,11 @@ export const TerminalCore: React.FC<TerminalCoreProps> = ({
 
   const bgColor = backgroundColor || "var(--cm-editor-background)";
 
-  const visibleSessions = sessions.filter(
-    (session) =>
-      initializedSessions.has(session.id) || session.id === activeSessionId
+  const visibleSessions = selectMountedTerminalSessions(
+    sessions,
+    activeSessionId,
+    initializedSessions,
+    recentTerminalIds
   );
 
   return (

--- a/src/engines/TerminalCore/terminalMountWindow.ts
+++ b/src/engines/TerminalCore/terminalMountWindow.ts
@@ -1,0 +1,50 @@
+/**
+ * Terminal mount window policy.
+ *
+ * Only the active terminal plus the `MAX_WARM_INACTIVE_TERMINALS` most
+ * recently active ones stay mounted. Everything else unmounts — releasing
+ * its xterm instance (5000-line scrollback) and WebGL context — and remounts
+ * on activation through the PTY attach/restore path in
+ * `TerminalInteractive/terminalPty.ts` (`attach_pty_stream` snapshot plus the
+ * serialized client buffer). Before this policy every initialized terminal,
+ * including every one restored from localStorage at boot, stayed mounted
+ * forever behind `display:none`.
+ */
+import { pushRecentId } from "@src/util/core/recentIdWindow";
+
+/**
+ * How many *inactive* terminals stay mounted (warm) in addition to the
+ * active one.
+ */
+export const MAX_WARM_INACTIVE_TERMINALS = 4;
+
+/**
+ * Push `activeId` to the front of the most-recently-active list, bounded to
+ * the active slot plus `maxWarm` inactive slots. Returns the same array
+ * reference when nothing changes so React state updates stay no-ops.
+ */
+export function pushRecentTerminalId(
+  prev: readonly string[],
+  activeId: string,
+  maxWarm: number = MAX_WARM_INACTIVE_TERMINALS
+): readonly string[] {
+  return pushRecentId(prev, activeId, maxWarm + 1);
+}
+
+/**
+ * Select which sessions should be mounted: the active one always, plus
+ * initialized sessions that are still inside the recent window.
+ */
+export function selectMountedTerminalSessions<T extends { id: string }>(
+  sessions: readonly T[],
+  activeSessionId: string,
+  initializedSessionIds: ReadonlySet<string>,
+  recentTerminalIds: readonly string[]
+): T[] {
+  const warm = new Set(recentTerminalIds);
+  return sessions.filter(
+    (session) =>
+      session.id === activeSessionId ||
+      (initializedSessionIds.has(session.id) && warm.has(session.id))
+  );
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -178,11 +178,18 @@ async function initializeApp() {
   // eager keeps the Promise-returning import() semantics (so the await below
   // still defers App module-tree evaluation until after the runtime-identity
   // config above has run) without emitting a loadable chunk. Production keeps
-  // the normal dynamic import — prod minifies and has no eval source maps, so
-  // the App chunk is small there.
-  const appModulePromise = isDev
-    ? import(/* webpackMode: "eager" */ "@src/App")
-    : import("@src/App");
+  // the normal dynamic import so App (and every vendor only App needs) lands
+  // in async chunks instead of the entry chunk.
+  //
+  // The condition MUST be the inline `process.env.NODE_ENV` comparison, not
+  // the `isDev` const: webpack only constant-folds a DefinePlugin expression
+  // it can evaluate at the branch itself. With a plain identifier it walks
+  // both arms, the "eager" mode wins, and production ships App inlined into
+  // main.js (~4 MB of extra synchronous startup JS).
+  const appModulePromise =
+    process.env.NODE_ENV === "development"
+      ? import(/* webpackMode: "eager" */ "@src/App")
+      : import("@src/App");
 
   // Clear stale opened repos from previous app session (main window only)
   // Secondary windows should not clear, as they'd wipe main window's registration

--- a/src/modules/WorkStation/ActionSystem/registration/actions/__tests__/editorActions.lazyService.test.ts
+++ b/src/modules/WorkStation/ActionSystem/registration/actions/__tests__/editorActions.lazyService.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  editorGoToLine,
+  editorUndo,
+} from "@src/modules/WorkStation/ActionSystem/registration/actions/editorActions.zod";
+
+const editorServiceMock = vi.hoisted(() => ({
+  loads: 0,
+  service: {
+    hasEditorView: vi.fn(() => false),
+    goToLine: vi.fn(() => false),
+    find: vi.fn(() => false),
+    replace: vi.fn(() => false),
+    undo: vi.fn(() => false),
+    redo: vi.fn(() => false),
+    format: vi.fn(() => false),
+    fold: vi.fn(() => false),
+    unfold: vi.fn(() => false),
+  },
+}));
+
+// The real EditorService statically imports @codemirror/{view,state,search,
+// commands}; the actions must reach it through a dynamic import so those
+// packages stay out of the startup graph (GlobalShortcuts → ActionSystem
+// registers these actions at boot).
+vi.mock("@src/services/workStation/EditorService", () => {
+  editorServiceMock.loads += 1;
+  return { EditorService: editorServiceMock.service };
+});
+
+describe("editor actions load EditorService lazily", () => {
+  beforeEach(() => {
+    editorServiceMock.service.goToLine.mockClear();
+    editorServiceMock.service.undo.mockClear();
+    editorServiceMock.service.hasEditorView.mockClear();
+  });
+
+  it("does not evaluate EditorService when the action module is imported", () => {
+    // Importing the actions module (as boot does) must not touch the service.
+    expect(editorServiceMock.loads).toBe(0);
+  });
+
+  it("loads the service on first execution and reports missing editor", async () => {
+    const result = await editorGoToLine.execute({ line: 42 });
+    expect(editorServiceMock.loads).toBe(1);
+    expect(editorServiceMock.service.goToLine).toHaveBeenCalledWith(42);
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("No editor is currently open");
+  });
+
+  it("succeeds when the service reports success", async () => {
+    editorServiceMock.service.undo.mockReturnValueOnce(true);
+    const result = await editorUndo.execute({});
+    expect(result.success).toBe(true);
+    // Still a single module evaluation across actions.
+    expect(editorServiceMock.loads).toBe(1);
+  });
+});

--- a/src/modules/WorkStation/ActionSystem/registration/actions/editorActions.zod.ts
+++ b/src/modules/WorkStation/ActionSystem/registration/actions/editorActions.zod.ts
@@ -8,7 +8,15 @@ import { z } from "zod";
 import { ACTION_ID } from "@src/ActionSystem/actionIds";
 import { defineZodAction } from "@src/ActionSystem/schema/defineZodAction";
 import { getShortcutKeys } from "@src/config/keyboard/shortcutDisplay";
-import { EditorService } from "@src/services/workStation/EditorService";
+
+// EditorService pulls @codemirror/{view,state,search,commands} statically.
+// These actions are registered at app boot (GlobalShortcuts → ActionSystem),
+// so load the service on first invocation instead of dragging CodeMirror
+// into the startup graph.
+const loadEditorService = () =>
+  import("@src/services/workStation/EditorService").then(
+    (mod) => mod.EditorService
+  );
 
 // ============================================
 // Editor Actions
@@ -30,6 +38,7 @@ export const editorGoToLine = defineZodAction(
     examples: ["go to line 42", "jump to line 100"],
   },
   async ({ line }) => {
+    const EditorService = await loadEditorService();
     const success = EditorService.goToLine(line);
     if (success) {
       return { success: true, message: `Went to line ${line}` };
@@ -63,6 +72,7 @@ export const editorFind = defineZodAction(
     examples: ["find TODO", "search for function"],
   },
   async ({ query, caseSensitive }) => {
+    const EditorService = await loadEditorService();
     const success = EditorService.find(query, { caseSensitive });
     if (success) {
       return { success: true, message: `Finding: ${query}` };
@@ -97,6 +107,7 @@ export const editorReplace = defineZodAction(
     examples: ["replace foo with bar"],
   },
   async ({ find, replace, all }) => {
+    const EditorService = await loadEditorService();
     const success = EditorService.replace(find, replace, { all });
     if (success) {
       return {
@@ -125,6 +136,7 @@ export const editorUndo = defineZodAction(
     examples: ["undo", "undo last change"],
   },
   async () => {
+    const EditorService = await loadEditorService();
     const success = EditorService.undo();
     if (success) {
       return { success: true, message: "Undone" };
@@ -148,6 +160,7 @@ export const editorRedo = defineZodAction(
     examples: ["redo", "redo last change"],
   },
   async () => {
+    const EditorService = await loadEditorService();
     const success = EditorService.redo();
     if (success) {
       return { success: true, message: "Redone" };
@@ -171,6 +184,7 @@ export const editorFormat = defineZodAction(
     examples: ["format document", "format code", "prettify"],
   },
   async () => {
+    const EditorService = await loadEditorService();
     const success = await EditorService.format();
     if (success) {
       return { success: true, message: "Document formatted" };
@@ -194,6 +208,7 @@ export const editorFold = defineZodAction(
     examples: ["fold all", "collapse code"],
   },
   async ({ all }) => {
+    const EditorService = await loadEditorService();
     const success = EditorService.fold(all);
     return success
       ? { success: true, message: "Code folded" }
@@ -212,6 +227,7 @@ export const editorUnfold = defineZodAction(
     examples: ["unfold all", "expand code"],
   },
   async ({ all }) => {
+    const EditorService = await loadEditorService();
     const success = EditorService.unfold(all);
     return success
       ? { success: true, message: "Code unfolded" }

--- a/src/modules/WorkStation/CodeEditor/hooks/fileContent/__tests__/cache.test.ts
+++ b/src/modules/WorkStation/CodeEditor/hooks/fileContent/__tests__/cache.test.ts
@@ -4,12 +4,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
+  _resetUnsavedContentCacheForTests,
   cacheFileMetadata,
   cacheUnsavedContent,
   clearFileCache,
   clearUnsavedContentCache,
   getCachedBinaryStatus,
   getCachedFileMetadata,
+  getUnsavedContentCacheStats,
   hasLoadedFileThisSession,
   invalidateFileCache,
   markFileLoadedThisSession,
@@ -18,11 +20,13 @@ import {
   subscribeToFileChanges,
   updateCachedFileMtime,
 } from "@src/modules/WorkStation/CodeEditor/hooks/fileContent/cache";
+import { MAX_UNSAVED_CONTENT_CACHE_SIZE } from "@src/modules/WorkStation/CodeEditor/hooks/fileContent/constants";
 
 describe("fileContent/cache", () => {
   beforeEach(() => {
     // Clear all caches before each test
     clearFileCache();
+    _resetUnsavedContentCacheForTests();
   });
 
   describe("cacheFileMetadata and getCachedFileMetadata", () => {
@@ -136,9 +140,58 @@ describe("fileContent/cache", () => {
       const cached = popUnsavedContent("/file.ts");
       expect(cached).not.toBeNull();
       expect(cached?.content).toBe("modified content");
-      expect(cached?.originalContent).toBe("original content");
+      expect(cached?.dirty).toBe(true);
       expect(cached?.version).toBe(2);
       expect(cached?.diskVersion).toBe(1);
+      // The disk baseline is re-read on restore, so it is not retained.
+      expect(cached).not.toHaveProperty("originalContent");
+    });
+
+    it("marks entries whose buffer equals disk as clean", () => {
+      cacheUnsavedContent("/file.ts", "same", "same", 3, 1, []);
+      expect(popUnsavedContent("/file.ts")?.dirty).toBe(false);
+    });
+
+    it("evicts only clean entries once the soft cap is exceeded", () => {
+      for (let i = 0; i < MAX_UNSAVED_CONTENT_CACHE_SIZE; i++) {
+        // Even indices dirty, odd indices clean.
+        const dirty = i % 2 === 0;
+        cacheUnsavedContent(
+          `/f${i}.ts`,
+          dirty ? `edited-${i}` : "same",
+          "same",
+          2,
+          1,
+          []
+        );
+      }
+      expect(getUnsavedContentCacheStats().entries).toBe(
+        MAX_UNSAVED_CONTENT_CACHE_SIZE
+      );
+
+      // Two more dirty entries push the cache over the cap.
+      cacheUnsavedContent("/extra-a.ts", "edited-a", "same", 2, 1, []);
+      cacheUnsavedContent("/extra-b.ts", "edited-b", "same", 2, 1, []);
+
+      const stats = getUnsavedContentCacheStats();
+      expect(stats.entries).toBe(MAX_UNSAVED_CONTENT_CACHE_SIZE);
+      // The oldest *clean* entries were evicted, dirty ones survived.
+      expect(popUnsavedContent("/f1.ts")).toBeNull();
+      expect(popUnsavedContent("/f3.ts")).toBeNull();
+      expect(popUnsavedContent("/f0.ts")).not.toBeNull();
+      expect(popUnsavedContent("/f2.ts")).not.toBeNull();
+      expect(popUnsavedContent("/extra-a.ts")).not.toBeNull();
+      expect(popUnsavedContent("/extra-b.ts")).not.toBeNull();
+    });
+
+    it("never evicts dirty entries even past the cap", () => {
+      const overCap = MAX_UNSAVED_CONTENT_CACHE_SIZE + 5;
+      for (let i = 0; i < overCap; i++) {
+        cacheUnsavedContent(`/d${i}.ts`, `edited-${i}`, "same", 2, 1, []);
+      }
+      const stats = getUnsavedContentCacheStats();
+      expect(stats.entries).toBe(overCap);
+      expect(stats.dirtyEntries).toBe(overCap);
     });
 
     it("does not cache when version equals disk version", () => {

--- a/src/modules/WorkStation/CodeEditor/hooks/fileContent/cache.ts
+++ b/src/modules/WorkStation/CodeEditor/hooks/fileContent/cache.ts
@@ -1,7 +1,11 @@
 import { createLogger } from "@src/hooks/logger";
 import type { EditOperation } from "@src/types/editor/document";
 
-import { MAX_LOADED_FILES_SIZE, MAX_METADATA_CACHE_SIZE } from "./constants";
+import {
+  MAX_LOADED_FILES_SIZE,
+  MAX_METADATA_CACHE_SIZE,
+  MAX_UNSAVED_CONTENT_CACHE_SIZE,
+} from "./constants";
 import type { UnsavedContentCache } from "./types";
 
 const log = createLogger("FileContent");
@@ -36,6 +40,22 @@ function evictMetadataCache(): void {
   }
 }
 
+/**
+ * Evict clean (non-dirty) entries, oldest first, until the cache is back
+ * under `MAX_UNSAVED_CONTENT_CACHE_SIZE`. Dirty entries are never evicted:
+ * they are the only copy of the user's unsaved edits.
+ */
+function evictUnsavedContentCache(): void {
+  if (unsavedContentCache.size <= MAX_UNSAVED_CONTENT_CACHE_SIZE) return;
+  let excess = unsavedContentCache.size - MAX_UNSAVED_CONTENT_CACHE_SIZE;
+  for (const [key, entry] of unsavedContentCache) {
+    if (excess <= 0) break;
+    if (entry.dirty) continue;
+    unsavedContentCache.delete(key);
+    excess -= 1;
+  }
+}
+
 export function cacheUnsavedContent(
   filePath: string,
   content: string,
@@ -45,13 +65,19 @@ export function cacheUnsavedContent(
   recentEdits: EditOperation[]
 ): void {
   if (version !== diskVersion) {
+    // Re-insert so Map iteration order doubles as LRU order for eviction.
+    unsavedContentCache.delete(filePath);
+    // `originalContent` is intentionally not retained: `useFileContent`
+    // re-baselines against fresh disk content on restore, so keeping a
+    // second full copy of the file text per entry only doubles the cost.
     unsavedContentCache.set(filePath, {
       content,
-      originalContent,
       version,
       diskVersion,
       recentEdits,
+      dirty: content !== originalContent,
     });
+    evictUnsavedContentCache();
   }
 }
 
@@ -128,6 +154,26 @@ export function invalidateFileCache(filePath: string): void {
 export function clearFileCache(): void {
   metadataCache.clear();
   loadedFilesThisSession.clear();
+}
+
+/** Test-only: drop every cached unsaved buffer. */
+export function _resetUnsavedContentCacheForTests(): void {
+  unsavedContentCache.clear();
+}
+
+/** Diagnostics hook for the RAM monitor / tests. */
+export function getUnsavedContentCacheStats(): {
+  entries: number;
+  dirtyEntries: number;
+  contentChars: number;
+} {
+  let dirtyEntries = 0;
+  let contentChars = 0;
+  for (const entry of unsavedContentCache.values()) {
+    if (entry.dirty) dirtyEntries += 1;
+    contentChars += entry.content.length;
+  }
+  return { entries: unsavedContentCache.size, dirtyEntries, contentChars };
 }
 
 export function updateCachedFileMtime(

--- a/src/modules/WorkStation/CodeEditor/hooks/fileContent/constants.ts
+++ b/src/modules/WorkStation/CodeEditor/hooks/fileContent/constants.ts
@@ -5,3 +5,11 @@ export const IDE_SERVER_URL = IDE_SERVER_HTTP_URL;
 export const FILE_API_BASE_URL = `${IDE_SERVER_URL}/git/api/file`;
 export const MAX_METADATA_CACHE_SIZE = 500;
 export const MAX_LOADED_FILES_SIZE = 1000;
+
+/**
+ * Soft cap on `unsavedContentCache` entries. Entries hold a full copy of the
+ * buffer text, so without a cap every dirty file ever switched away from is
+ * retained for the app lifetime. Only *clean* entries (buffer equal to disk
+ * at cache time) are evicted past this cap; dirty entries always survive.
+ */
+export const MAX_UNSAVED_CONTENT_CACHE_SIZE = 32;

--- a/src/modules/WorkStation/CodeEditor/hooks/fileContent/types.ts
+++ b/src/modules/WorkStation/CodeEditor/hooks/fileContent/types.ts
@@ -35,8 +35,14 @@ export interface UseFileContentReturn {
 
 export interface UnsavedContentCache {
   content: string;
-  originalContent: string;
   version: number;
   diskVersion: number;
   recentEdits: EditOperation[];
+  /**
+   * `true` when the buffer differed from its disk baseline at cache time.
+   * Dirty entries are never evicted for size (evicting them would lose the
+   * user's unsaved edits); clean entries (version bumped by an undo cycle,
+   * a reload, etc.) only preserve edit history and are eviction candidates.
+   */
+  dirty: boolean;
 }

--- a/src/modules/WorkStation/CodeEditor/hooks/output/__tests__/useOutputChannels.bounds.test.ts
+++ b/src/modules/WorkStation/CodeEditor/hooks/output/__tests__/useOutputChannels.bounds.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import {
+  type RefObject,
+  act,
+  createElement,
+  createRef,
+  forwardRef,
+  useImperativeHandle,
+} from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import {
+  MAX_OUTPUT_CHANNELS,
+  useOutputChannels,
+} from "@src/modules/WorkStation/CodeEditor/hooks/output/useOutputChannels";
+
+type OutputController = ReturnType<typeof useOutputChannels>;
+
+// Probe exposes the hook's return value through a ref (the repo pattern for
+// hook tests) so no module-level variable is reassigned during render.
+const Probe = forwardRef<OutputController>((_props, ref) => {
+  const output = useOutputChannels({ defaultMaxChars: 1000 });
+  useImperativeHandle(ref, () => output, [output]);
+  return null;
+});
+Probe.displayName = "OutputChannelsProbe";
+
+describe("useOutputChannels bounds", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let controllerRef: RefObject<OutputController | null>;
+  const controller = () => {
+    if (!controllerRef.current) throw new Error("probe not mounted");
+    return controllerRef.current;
+  };
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    sessionStorage.clear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    controllerRef = createRef<OutputController>();
+    act(() => root.render(createElement(Probe, { ref: controllerRef })));
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("drops the oldest non-active channels past MAX_OUTPUT_CHANNELS", () => {
+    const ids: string[] = [];
+    for (let i = 0; i < MAX_OUTPUT_CHANNELS + 4; i++) {
+      act(() => {
+        ids.push(controller().createChannel(`run ${i}`, "tasks"));
+      });
+    }
+    const remaining = controller().channels.map((c) => c.id);
+    expect(remaining).toHaveLength(MAX_OUTPUT_CHANNELS);
+    // Newest survive, oldest were evicted.
+    expect(remaining).toContain(ids[ids.length - 1]);
+    expect(remaining).not.toContain(ids[0]);
+  });
+
+  it("debounces sessionStorage writes instead of persisting per append", () => {
+    const setItem = vi.spyOn(Storage.prototype, "setItem");
+    let id = "";
+    act(() => {
+      id = controller().createChannel("build", "build");
+    });
+    act(() => {
+      controller().appendToChannel(id, "line 1\n");
+      controller().appendToChannel(id, "line 2\n");
+      controller().appendToChannel(id, "line 3\n");
+    });
+    // Nothing written synchronously.
+    expect(
+      setItem.mock.calls.filter(
+        ([key]) => key === "orgii_output_channels_history"
+      )
+    ).toHaveLength(0);
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    const writes = setItem.mock.calls.filter(
+      ([key]) => key === "orgii_output_channels_history"
+    );
+    expect(writes).toHaveLength(1);
+    expect(String(writes[0][1])).toContain("line 3");
+    setItem.mockRestore();
+  });
+});

--- a/src/modules/WorkStation/CodeEditor/hooks/output/useOutputChannels.ts
+++ b/src/modules/WorkStation/CodeEditor/hooks/output/useOutputChannels.ts
@@ -5,7 +5,7 @@
  * Similar to VS Code's Output panel.
  */
 import { nanoid } from "nanoid";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useRef, useState } from "react";
 
 import type {
   OutputChannel,
@@ -32,6 +32,21 @@ export interface UseOutputChannelsOptions {
 
 // Persistent storage key for channel history
 const HISTORY_STORAGE_KEY = "orgii_output_channels_history";
+
+/**
+ * Upper bound on retained output channels. Each channel keeps up to
+ * `maxChars` (100k by default) of text in memory *and* in sessionStorage,
+ * so an uncapped list — one channel per build/test/git run — grew without
+ * bound. Oldest non-active channels are dropped when a new one is created.
+ */
+export const MAX_OUTPUT_CHANNELS = 16;
+
+/**
+ * Debounce for mirroring channel content to sessionStorage. Persisting on
+ * every appended line serialized every channel's full content per line;
+ * trailing-edge writes keep history warm at a fraction of the churn.
+ */
+const HISTORY_PERSIST_DEBOUNCE_MS = 500;
 
 /**
  * Hook to manage multiple output channels
@@ -67,17 +82,39 @@ export function useOutputChannels(
   );
   const [activeChannelId, setActiveChannelId] = useState<string | null>(null);
 
-  // Persist channels to sessionStorage on changes
-  React.useEffect(() => {
-    if (!persistHistory || channelsMap.size === 0) return;
-
+  // Persist channels to sessionStorage (debounced; flushed on unmount)
+  const latestChannelsRef = useRef(channelsMap);
+  const persistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const flushHistory = useCallback(() => {
+    if (persistTimerRef.current) {
+      clearTimeout(persistTimerRef.current);
+      persistTimerRef.current = null;
+    }
+    const map = latestChannelsRef.current;
+    if (!persistHistory || map.size === 0) return;
     try {
-      const channelsObj = Object.fromEntries(channelsMap);
+      const channelsObj = Object.fromEntries(map);
       sessionStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(channelsObj));
     } catch (_error) {
       // Silently ignore history save failures
     }
-  }, [channelsMap, persistHistory]);
+  }, [persistHistory]);
+  React.useEffect(() => {
+    latestChannelsRef.current = channelsMap;
+    if (!persistHistory || channelsMap.size === 0) return;
+    if (persistTimerRef.current) clearTimeout(persistTimerRef.current);
+    persistTimerRef.current = setTimeout(
+      flushHistory,
+      HISTORY_PERSIST_DEBOUNCE_MS
+    );
+    return () => {
+      if (persistTimerRef.current) {
+        clearTimeout(persistTimerRef.current);
+        persistTimerRef.current = null;
+      }
+    };
+  }, [channelsMap, persistHistory, flushHistory]);
+  React.useEffect(() => flushHistory, [flushHistory]);
 
   // Convert map to array for rendering
   const channels = Array.from(channelsMap.values());
@@ -107,6 +144,14 @@ export function useOutputChannels(
       setChannelsMap((prev) => {
         const next = new Map(prev);
         next.set(channelId, newChannel);
+        // Bound the channel list: drop the oldest non-active channels first.
+        if (next.size > MAX_OUTPUT_CHANNELS) {
+          for (const [id, channel] of next) {
+            if (next.size <= MAX_OUTPUT_CHANNELS) break;
+            if (id === channelId || channel.active) continue;
+            next.delete(id);
+          }
+        }
         return next;
       });
 

--- a/src/router/routes/routeGroups.tsx
+++ b/src/router/routes/routeGroups.tsx
@@ -9,7 +9,7 @@ import {
 import { ROUTES } from "@src/config/routes";
 import { HOSTED_LOGIN_ENABLED } from "@src/config/serviceAuth";
 import MainAppShell from "@src/modules/shared/layouts/MainAppShell";
-import { Placeholder } from "@src/modules/shared/layouts/blocks";
+import { Placeholder } from "@src/modules/shared/layouts/blocks/Placeholder";
 import {
   AgentStudioPage,
   AuthCallback,

--- a/src/scaffold/ModalSystem/index.tsx
+++ b/src/scaffold/ModalSystem/index.tsx
@@ -18,11 +18,13 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import Button from "@src/components/Button";
-import {
+// Deep imports on purpose: the `layouts/blocks` barrel re-exports
+// SessionTable → SettingsTable → @tanstack/react-table, and Modal sits in the
+// startup graph (QuitConfirmationModal is mounted at boot).
+import PanelFooter from "@src/modules/shared/layouts/blocks/PanelFooter";
+import PanelHeader, {
   PANEL_HEADER_TOKENS,
-  PanelFooter,
-  PanelHeader,
-} from "@src/modules/shared/layouts/blocks";
+} from "@src/modules/shared/layouts/blocks/PanelHeader";
 import { useOverlayLayer } from "@src/store/ui/overlayLayerAtom";
 
 import "./index.scss";

--- a/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.tsx
@@ -41,7 +41,7 @@ import {
 } from "@src/hooks/dropdown";
 import { useAppNavigation } from "@src/hooks/navigation";
 import { useAppearanceState } from "@src/modules/MainApp/Settings/sections/useAppearanceState";
-import { WorkstationToolbarTooltip } from "@src/modules/WorkStation/shared";
+import { WorkstationToolbarTooltip } from "@src/modules/WorkStation/shared/WorkstationToolbarTooltip";
 import {
   DeveloperTestPanel,
   isDeveloperTestPanelEnabled,

--- a/src/scaffold/NavigationSidebar/connectors/SessionFilterButton.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/SessionFilterButton.tsx
@@ -19,7 +19,7 @@ import {
 } from "@src/components/Dropdown/tokens";
 import IconButton from "@src/components/IconButton";
 import { useDropdownEngine } from "@src/hooks/dropdown";
-import { WorkstationToolbarTooltip } from "@src/modules/WorkStation/shared";
+import { WorkstationToolbarTooltip } from "@src/modules/WorkStation/shared/WorkstationToolbarTooltip";
 
 import HoverAnimatedIcon, {
   triggerIconAnimation,

--- a/src/scaffold/NavigationSidebar/connectors/SidebarGuideButton.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/SidebarGuideButton.tsx
@@ -28,7 +28,7 @@ import {
   OrganizationStepIcon,
   ReadyStepIcon,
 } from "@src/modules/SetupWalkthrough/components/SetupStepIcons";
-import { WorkstationToolbarTooltip } from "@src/modules/WorkStation/shared";
+import { WorkstationToolbarTooltip } from "@src/modules/WorkStation/shared/WorkstationToolbarTooltip";
 import type { WizardStepIcon } from "@src/scaffold/WizardSystem/primitives/WizardStepNavigation";
 
 import {

--- a/src/scaffold/NavigationSidebar/connectors/SidebarOrgSelector.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/SidebarOrgSelector.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 
 import { DROPDOWN_CLASSES } from "@src/components/Dropdown/tokens";
 import Select, { type SelectOption } from "@src/components/Select";
-import { WorkstationToolbarTooltip } from "@src/modules/WorkStation/shared";
+import { WorkstationToolbarTooltip } from "@src/modules/WorkStation/shared/WorkstationToolbarTooltip";
 
 interface SidebarOrgSelectorProps {
   value: string;

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/SidebarDialogs.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/SidebarDialogs.tsx
@@ -1,4 +1,4 @@
-import { RenameModal } from "@/src/scaffold/ModalSystem/variants";
+import RenameModal from "@/src/scaffold/ModalSystem/variants/Rename";
 import React from "react";
 import { useTranslation } from "react-i18next";
 

--- a/src/store/ui/__tests__/todoSessionSlots.test.ts
+++ b/src/store/ui/__tests__/todoSessionSlots.test.ts
@@ -1,0 +1,60 @@
+import { createStore } from "jotai";
+import { describe, expect, it } from "vitest";
+
+import { workstationActiveSessionIdAtom } from "@src/store/session";
+import {
+  MAX_TODO_SESSION_SLOTS,
+  sessionTodoMapAtom,
+  updateTodosForSessionAtom,
+} from "@src/store/ui/todoAtom";
+
+describe("sessionTodoMapAtom slot cap", () => {
+  it("evicts the least-recently-updated inactive sessions past the cap", () => {
+    const store = createStore();
+    store.set(workstationActiveSessionIdAtom, "active");
+
+    // The active session writes first, so it would be the LRU victim if
+    // the cap didn't protect it.
+    store.set(updateTodosForSessionAtom, {
+      sessionId: "active",
+      todos: [{ id: "1", content: "keep me", status: "pending" }],
+    });
+    for (let i = 0; i < MAX_TODO_SESSION_SLOTS + 4; i++) {
+      store.set(updateTodosForSessionAtom, {
+        sessionId: `s${i}`,
+        todos: [{ id: "1", content: `todo ${i}`, status: "pending" }],
+      });
+    }
+
+    const map = store.get(sessionTodoMapAtom);
+    expect(map.size).toBe(MAX_TODO_SESSION_SLOTS);
+    expect(map.has("active")).toBe(true);
+    // Oldest inactive slots are gone, newest survive.
+    expect(map.has("s0")).toBe(false);
+    expect(map.has(`s${MAX_TODO_SESSION_SLOTS + 3}`)).toBe(true);
+  });
+
+  it("re-updating a session refreshes its LRU position", () => {
+    const store = createStore();
+    store.set(workstationActiveSessionIdAtom, null);
+    for (let i = 0; i < MAX_TODO_SESSION_SLOTS; i++) {
+      store.set(updateTodosForSessionAtom, {
+        sessionId: `s${i}`,
+        todos: [{ id: "1", content: `todo ${i}`, status: "pending" }],
+      });
+    }
+    // Touch s0 so it becomes most-recent, then overflow by one.
+    store.set(updateTodosForSessionAtom, {
+      sessionId: "s0",
+      todos: [{ id: "2", content: "touched", status: "pending" }],
+    });
+    store.set(updateTodosForSessionAtom, {
+      sessionId: "overflow",
+      todos: [{ id: "1", content: "new", status: "pending" }],
+    });
+    const map = store.get(sessionTodoMapAtom);
+    expect(map.size).toBe(MAX_TODO_SESSION_SLOTS);
+    expect(map.has("s0")).toBe(true);
+    expect(map.has("s1")).toBe(false);
+  });
+});

--- a/src/store/ui/todoAtom.ts
+++ b/src/store/ui/todoAtom.ts
@@ -172,10 +172,29 @@ export const updateTodosForSessionAtom = atom(
     };
 
     const nextMap = new Map(current);
+    // Re-insert so Map order doubles as LRU order for the cap below.
+    nextMap.delete(sessionId);
     nextMap.set(sessionId, nextState);
+    if (nextMap.size > MAX_TODO_SESSION_SLOTS) {
+      const activeId = get(workstationActiveSessionIdAtom);
+      for (const key of nextMap.keys()) {
+        if (nextMap.size <= MAX_TODO_SESSION_SLOTS) break;
+        if (key === sessionId || key === activeId) continue;
+        nextMap.delete(key);
+      }
+    }
     set(sessionTodoMapAtom, nextMap);
   }
 );
+
+/**
+ * Soft cap on retained per-session todo slots. Slots are rebuilt from the
+ * event store by `useTodoSync` whenever a session becomes active again, so
+ * evicting the least-recently-updated inactive sessions loses nothing; it
+ * only stops the map growing with every subagent/session that ever emitted
+ * a todo update during the app lifetime.
+ */
+export const MAX_TODO_SESSION_SLOTS = 64;
 
 /**
  * Clear a specific session's todos slot.

--- a/src/store/workstation/codeEditor/search/__tests__/searchAppendResults.test.ts
+++ b/src/store/workstation/codeEditor/search/__tests__/searchAppendResults.test.ts
@@ -1,0 +1,61 @@
+import { createStore } from "jotai";
+import { describe, expect, it } from "vitest";
+
+import {
+  SEARCH_MAX_RETAINED_MATCHES,
+  searchAppendResultsAtom,
+  searchHasMoreAtom,
+  searchResultsAtom,
+} from "@src/store/workstation/codeEditor/search";
+import type { SearchResultFile } from "@src/store/workstation/codeEditor/search/types";
+
+function file(path: string, matchCount: number): SearchResultFile {
+  return {
+    file_path: path,
+    matches: Array.from({ length: matchCount }, (_, idx) => ({
+      line: idx + 1,
+      column: 0,
+      end_line: idx + 1,
+      end_column: 5,
+      text: `match ${idx}`,
+      context_before: "",
+      context_after: "",
+    })),
+  };
+}
+
+describe("searchAppendResultsAtom", () => {
+  it("appends results while under the retained-match ceiling", () => {
+    const store = createStore();
+    store.set(searchHasMoreAtom, true);
+    store.set(searchAppendResultsAtom, [file("/a.ts", 10), file("/b.ts", 5)]);
+    expect(store.get(searchResultsAtom).map((f) => f.file_path)).toEqual([
+      "/a.ts",
+      "/b.ts",
+    ]);
+    expect(store.get(searchHasMoreAtom)).toBe(true);
+  });
+
+  it("stops accumulating at SEARCH_MAX_RETAINED_MATCHES and clears hasMore", () => {
+    const store = createStore();
+    store.set(searchHasMoreAtom, true);
+    const perFile = 1_000;
+    const filesToCap = SEARCH_MAX_RETAINED_MATCHES / perFile;
+    const batch: SearchResultFile[] = [];
+    for (let i = 0; i < filesToCap + 3; i++) {
+      batch.push(file(`/f${i}.ts`, perFile));
+    }
+    store.set(searchAppendResultsAtom, batch);
+
+    const retained = store.get(searchResultsAtom);
+    expect(retained).toHaveLength(filesToCap);
+    expect(
+      retained.reduce((sum, f) => sum + f.matches.length, 0)
+    ).toBeLessThanOrEqual(SEARCH_MAX_RETAINED_MATCHES);
+    expect(store.get(searchHasMoreAtom)).toBe(false);
+
+    // Further appends are no-ops once the ceiling is reached.
+    store.set(searchAppendResultsAtom, [file("/late.ts", 1)]);
+    expect(store.get(searchResultsAtom)).toHaveLength(filesToCap);
+  });
+});

--- a/src/store/workstation/codeEditor/search/index.ts
+++ b/src/store/workstation/codeEditor/search/index.ts
@@ -117,12 +117,36 @@ export const searchClearAtom = atom(null, (_get, set) => {
   set(searchActualTotalFilesAtom, 0);
 });
 
-/** Append more results */
+/**
+ * Hard ceiling on matches retained in `searchResultsAtom` across "load more"
+ * rounds. Mirrors `SEARCH_CONSTANTS.MAX_TOTAL_RESULTS` in the search sidebar
+ * (which already renders "20,000+" past this point) — without it, repeated
+ * load-more on a broad regex accumulated result rows without bound.
+ */
+export const SEARCH_MAX_RETAINED_MATCHES = 20_000;
+
+/** Append more results (bounded by `SEARCH_MAX_RETAINED_MATCHES`). */
 export const searchAppendResultsAtom = atom(
   null,
   (get, set, newResults: SearchResultFile[]) => {
     const current = get(searchResultsAtom);
-    set(searchResultsAtom, [...current, ...newResults]);
+    let retained = current.reduce((sum, file) => sum + file.matches.length, 0);
+    const accepted: SearchResultFile[] = [];
+    let truncated = false;
+    for (const file of newResults) {
+      if (retained >= SEARCH_MAX_RETAINED_MATCHES) {
+        truncated = true;
+        break;
+      }
+      accepted.push(file);
+      retained += file.matches.length;
+    }
+    if (accepted.length > 0) {
+      set(searchResultsAtom, [...current, ...accepted]);
+    }
+    if (truncated || retained >= SEARCH_MAX_RETAINED_MATCHES) {
+      set(searchHasMoreAtom, false);
+    }
   }
 );
 

--- a/src/test/staticImportGraph.ts
+++ b/src/test/staticImportGraph.ts
@@ -1,0 +1,186 @@
+/**
+ * Minimal static import-graph walker for bundle-boundary regression tests.
+ *
+ * Follows `import … from`, `export … from`, and bare `import "…"` edges
+ * across `src/` files, resolving `@src/`, `@/src/`, and relative specifiers.
+ * Deliberately IGNORES:
+ *   - `import type` / `export type` (erased by TypeScript),
+ *   - dynamic `import(...)` (a lazy chunk boundary),
+ *   - anything under node_modules (recorded as an external package name).
+ *
+ * It is not a full module resolver — it is fast (regex-based, milliseconds
+ * over thousands of files) and good enough to assert "module X is not
+ * statically reachable from entry Y", which is what keeps heavy libraries out
+ * of the startup graph and React renderers out of the worker graph.
+ */
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+export const SRC_ROOT = path.resolve(__dirname, "..");
+
+const EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs"] as const;
+
+const IMPORT_RE =
+  /(?:^|\n)\s*(?:import|export)\s+(?:type\s+)?(?:[^'";]*?\s+from\s+)?["']([^"']+)["']/g;
+
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+
+/** True when the statement is a type-only import/export (erased at build). */
+function isTypeOnlyStatement(statement: string): boolean {
+  return /^\s*(?:import|export)\s+type\s/.test(statement);
+}
+
+function resolveWithExtensions(base: string): string | null {
+  for (const ext of EXTENSIONS) {
+    const candidate = base + ext;
+    if (existsSync(candidate) && statSync(candidate).isFile()) return candidate;
+  }
+  if (existsSync(base) && statSync(base).isDirectory()) {
+    for (const ext of EXTENSIONS) {
+      const candidate = path.join(base, `index${ext}`);
+      if (existsSync(candidate)) return candidate;
+    }
+  }
+  if (existsSync(base) && statSync(base).isFile()) return base;
+  return null;
+}
+
+/** Resolve a specifier to an absolute src file, or null for externals. */
+export function resolveSpecifier(
+  specifier: string,
+  fromFile: string
+): string | null {
+  let base: string;
+  if (specifier.startsWith("@src/")) {
+    base = path.join(SRC_ROOT, specifier.slice("@src/".length));
+  } else if (specifier.startsWith("@/src/")) {
+    base = path.join(SRC_ROOT, specifier.slice("@/src/".length));
+  } else if (specifier.startsWith("@/")) {
+    // `@/*` maps to the repo root; anything outside src/ is external.
+    base = path.join(SRC_ROOT, "..", specifier.slice("@/".length));
+    if (!base.startsWith(SRC_ROOT + path.sep)) return null;
+  } else if (specifier.startsWith(".")) {
+    base = path.resolve(path.dirname(fromFile), specifier);
+  } else {
+    return null;
+  }
+  // Strip webpack resource queries (`?raw`, `?url`).
+  base = base.replace(/\?.*$/, "");
+  return resolveWithExtensions(base);
+}
+
+export interface StaticImportGraph {
+  /** Absolute paths of every statically reachable src file (incl. entries). */
+  files: Set<string>;
+  /** Bare package specifiers imported anywhere in the reachable set. */
+  packages: Set<string>;
+  /** Parent pointer for `explain()`. */
+  parent: Map<string, string>;
+  /** Human-readable import chain from an entry to `file`. */
+  explain(file: string): string;
+}
+
+/** Package name from a bare specifier (`@scope/pkg/sub` → `@scope/pkg`). */
+export function packageNameOf(specifier: string): string {
+  const parts = specifier.split("/");
+  return specifier.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0];
+}
+
+export function walkStaticImports(
+  entryFiles: readonly string[]
+): StaticImportGraph {
+  const files = new Set<string>();
+  const packages = new Set<string>();
+  const parent = new Map<string, string>();
+  const queue: string[] = [];
+  for (const entry of entryFiles) {
+    const abs = path.isAbsolute(entry) ? entry : path.join(SRC_ROOT, entry);
+    files.add(abs);
+    queue.push(abs);
+  }
+  while (queue.length > 0) {
+    const file = queue.shift()!;
+    if (!/\.(ts|tsx|js|jsx|mjs)$/.test(file)) continue;
+    let source: string;
+    try {
+      source = stripComments(readFileSync(file, "utf8"));
+    } catch {
+      continue;
+    }
+    for (const match of source.matchAll(IMPORT_RE)) {
+      if (isTypeOnlyStatement(match[0])) continue;
+      const specifier = match[1];
+      const resolved = resolveSpecifier(specifier, file);
+      if (resolved === null) {
+        // Style/asset imports are not packages either.
+        if (/^[a-zA-Z@]/.test(specifier))
+          packages.add(packageNameOf(specifier));
+        continue;
+      }
+      if (/\.(s?css|svg|png|jpe?g|gif|webp|mp4|json)$/.test(resolved)) continue;
+      if (!files.has(resolved)) {
+        files.add(resolved);
+        parent.set(resolved, file);
+        queue.push(resolved);
+      }
+    }
+  }
+  const rel = (f: string) => path.relative(SRC_ROOT, f);
+  return {
+    files,
+    packages,
+    parent,
+    explain(file: string): string {
+      const abs = path.isAbsolute(file) ? file : path.join(SRC_ROOT, file);
+      const chain = [rel(abs)];
+      let cursor = abs;
+      while (parent.has(cursor)) {
+        cursor = parent.get(cursor)!;
+        chain.push(rel(cursor));
+      }
+      return chain.join("  <-  ");
+    },
+  };
+}
+
+/** Relative (to src/) paths of reachable files matching `pattern`. */
+export function reachableFilesMatching(
+  graph: StaticImportGraph,
+  pattern: RegExp
+): string[] {
+  return [...graph.files]
+    .map((f) => path.relative(SRC_ROOT, f))
+    .filter((f) => pattern.test(f))
+    .sort();
+}
+
+/** Files in the reachable set that import a given package (for diagnostics). */
+export function importersOfPackage(
+  graph: StaticImportGraph,
+  packageName: string
+): string[] {
+  const out: string[] = [];
+  for (const file of graph.files) {
+    let source: string;
+    try {
+      source = stripComments(readFileSync(file, "utf8"));
+    } catch {
+      continue;
+    }
+    for (const match of source.matchAll(IMPORT_RE)) {
+      if (isTypeOnlyStatement(match[0])) continue;
+      if (
+        packageNameOf(match[1]) === packageName &&
+        !match[1].startsWith(".")
+      ) {
+        out.push(graph.explain(file));
+        break;
+      }
+    }
+  }
+  return out;
+}

--- a/src/util/core/recentIdWindow.ts
+++ b/src/util/core/recentIdWindow.ts
@@ -1,0 +1,16 @@
+/**
+ * Bounded most-recently-used id list.
+ *
+ * Shared by keep-alive surfaces that only want the active item plus a small
+ * window of recently active ones mounted (terminal panes, browser-tab
+ * webviews). Newest first. Returns the same reference when nothing changes
+ * so React state setters stay no-ops.
+ */
+export function pushRecentId(
+  prev: readonly string[],
+  id: string,
+  maxEntries: number
+): readonly string[] {
+  if (prev[0] === id) return prev;
+  return [id, ...prev.filter((entry) => entry !== id)].slice(0, maxEntries);
+}


### PR DESCRIPTION
## Summary

Frontend RAM pass, first batch: break down the startup bundle, fix the real cause of the duplicated-vendor chunks, and bound the frontend growth paths that were leaking — all behavior-preserving except the terminal mount window (see risks). Ranked audit with measured numbers lives in `docs/memory-audit-2026-08-16/ram-optimization-findings.md`.

Measured with `webpack --mode production` at HEAD before/after:

| | Before | After |
|---|---|---|
| Synchronous initial JS (`index.html` scripts) | **8.37 MB** (main 4.74 + vendors 3.73) | **0.98 MB** (main 0.32 + vendors 0.65) |
| JS loaded at boot (initial + `App` import set) | ≈ 8.4 MB | ≈ **5.9 MB** (−29 %) |
| Vendors loaded at boot | 3.73 MB | ≈ 1.65 MB |
| Modules emitted in >1 chunk | 1 601 / **9.0 MB** redundant | 339 / 1.9 MB |
| Total `build/` | 55 MB | 48 MB |

## Problem

- `src/index.tsx` chose between the dev-only `webpackMode: "eager"` App import and the normal one via an `isDev` const. Webpack can't fold that, walks both arms, and "eager" wins → production shipped `App` (and every vendor only App needs) inlined into `main.js` as ~8 MB of synchronous startup JS.
- The chat-projection **web worker** statically imported the registry barrel, which re-exports `rendering/registry/events/index.ts` and its lazy renderer `import()`s. That made 2 388 files part of the worker's chunk graph; since the worker entry has no `vendors`, webpack duplicated react-dom / xterm / CodeMirror / zod / sql-formatter into every shared async chunk (~9 MB).
- Four sidebar files, `SidebarDialogs`, `ModalSystem`, `ActionSystemContext` and the boot-registered editor actions imported barrels that dragged xterm + addons, all of CodeMirror + 10 language packs, sql-formatter, refractor (for a modal nobody renders) and framer-motion into the boot graph.
- Several frontend structures grew without bound: `unsavedContentCache` (two full copies of file text per edited file, never evicted), `runtimeCounters.durations[]` (one entry per RPC, no drain call site), search "load more" accumulation, per-session todo slots, output channels (+ a sessionStorage rewrite of every channel on every appended line), and every initialized terminal staying mounted forever (incl. all restored at boot).

## Solution

- Inline `process.env.NODE_ENV === "development"` at the App import branch.
- Move `CONTEXT_CONFIG` + chat-config helpers to `registry/events/contextConfig.ts` (pure data); `ActionRegistry`/`registryAccessors` import from it. Worker reach with async edges 2 388 → 62 files. `splitChunks` unchanged.
- Deep imports at the boot gateways; `Message` toast renderer split into a `React.lazy` `MessageContainer` (API unchanged); `EditorService` loaded on first editor-action invocation.
- Bounds: `unsavedContentCache` drops the never-read `originalContent`, tracks `dirty`, evicts only clean entries past 32 (dirty = truly unsaved edits are never evicted); `runtimeCounters` running sum/count; `searchAppendResultsAtom` enforces the documented 20 000-match ceiling; `sessionTodoMapAtom` LRU 64 (never the active session; rebuilt from events by `useTodoSync`); `useOutputChannels` capped at 16 channels with a debounced sessionStorage mirror.
- `TerminalCore` keeps the active pane + 4 most-recently-active mounted (`terminalMountWindow.ts`); colder panes unmount and reattach through the existing `attach_pty_stream` + serialized-buffer restore path.
- Regression guards: `src/test/staticImportGraph.ts` (fast static import walker) backs `startupGraph.test.ts` (heavy packages / feature trees stay out of the boot graph, eager import stays foldable) and `workerStaticGraph.test.ts` (worker never reaches the renderer loaders or react-dom again).

## Potential risks

- **Terminal mount window (only behavior change):** switching to a terminal that has been cold for 5+ activations remounts xterm — brief blank, scroll position/selection reset, and if output arrived while it was cold the restore is the Rust-side bounded snapshot rather than full scrollback. Browser-tab webviews were deliberately **not** touched (a prototype was reverted; documented in the audit).
- First toast loads its chunk lazily (local file, sub-ms in Tauri; auto-dismiss timers start on mount so no shortened lifetime).
- Editor actions (Go to line / Find / Undo …) do a one-time dynamic import of `EditorService` on first use.
- The static-graph guards are regex-based (not a full resolver); they'll fail loudly with the import chain if a barrel re-export sneaks a heavy lib back in — bump the allow-list with a reason if that's ever intended.

## Validation / Test plan

- `pnpm typecheck` clean; `eslint` clean on all touched files (pre-commit lint-staged passed).
- `pnpm test`: full suite green before the last test additions (1104 files / 8696 tests); new suites green: startup/worker graph guards, Message lazy container, cache/todo/search/output-channel bounds, terminal mount window, contextConfig boundary, lazy EditorService.
- Production builds before/after (table above); module-id duplication measured with an acorn walk over `build/`.
- Manual: open >5 terminals, cycle through them (reattach + restore), trigger toasts, Go-to-line/Find/Undo from the palette, sidebar rename/share dialogs, quit-confirmation modal.
