### PR TITLE
fix(frontend): release listeners and registries that outlive owners

### DIFF
--- a/docs/memory-audit-2026-08-16/ram-optimization-findings.md
+++ b/docs/memory-audit-2026-08-16/ram-optimization-findings.md
@@ -564,3 +564,53 @@ fallback={null}`, matching neighbouring precedents): `SimulatorMessages` in
 Still statically reaching CodeMirror by design: `modules/WorkStation/index.tsx`
 (the code editor), `engines/Simulator/apps/canvas/CanvasApp` only via the lazy
 source viewer, and the editor-internal panes.
+
+### 2026-08-17 — lifecycle leaks (branch `perf/frontend-lifecycle-leaks`, stacked on the above)
+
+Two thorough lifecycle sweeps (effects without cleanup, module maps, registries
+holding DOM/xterm/EditorView, xterm/webview teardown, per-session families)
+found the codebase disciplined overall; the genuine defects fixed here, all
+behavior-neutral:
+
+- `SessionCore/core/store/snapshotCacheManager.ts` `subscribeSession` — the
+  disposer closed over the Set it was created with and deleted the registry
+  entry whenever _that_ Set emptied. After `evictSessionCache` (reload /
+  manual compact / edit-message / sidebar delete all reach it while
+  consumers are still mounted) a later subscriber installs a fresh Set; the
+  stale disposer then unregistered the live Set, so mounted consumers stopped
+  receiving pushes and pinned their last snapshot. Disposer now re-looks-up
+  the current Set and only removes the entry if it is its own.
+- `useSearchResults.loadMore` — the two Tauri listeners (`search-result`,
+  `search-complete`) were unlistened only on the success path; a rejected
+  `searchCodeStreaming` left both (each closing over the whole result set)
+  registered forever and running on every later event. Released in `finally`.
+- `store/workstation/codeEditor/terminal` — OSC-633 `commandDetectionMapAtom`
+  (up to 200 command entries per session) was never pruned;
+  `removeCommandDetectionAtom` had no callers. Now called from both
+  terminal-removal paths.
+- `store/workstation/tabs/editorCache.ts` — `disposeEditorCacheForSessionAtom`
+  drops the `session:<id>` editor cache + active-repo pointer when a session
+  is deleted (heap + localStorage blob parsed at boot); wired into the single
+  dispose callback both delete paths use.
+- `WorkStation/Chat/Communication/config.ts` — module-scope single-slot memo
+  (`_prevBuildEvents/_prevBuildResult`) pinned the last-built session's full
+  `SessionEvent[]` + `MessageEntry` trees after unmount; replaced by an
+  identity-keyed `WeakMap`.
+- `TerminalInteractive/terminalSetup.ts`, `XtermOutput/index.tsx` — a WebGL
+  addon that threw during `loadAddon`/`activate` was never disposed while its
+  budget slot was released (orphaned GL context); disposed on the throw path.
+- `ChatHistory/components/TurnMetadataFooterSlot.tsx` — the family was
+  touched with `sessionId ?? ""`, creating empty-session-id entries the
+  loader's GC never retains/removes; split into a wrapper that only mounts
+  the body with a real session id.
+
+Noted, not changed (would alter behavior or are sub-KB):
+LRU-capping `sessionWorkspaces` / `editorCacheByWorkspace` across _live_
+sessions (old sessions would lose saved tab layouts), `cursorIdeTurnSummariesAtomFamily`
+retention for browsed Cursor sessions (needs mount-gated GC — the sibling
+reload-state cleanup is in-flight bookkeeping, not teardown),
+`transcriptSourceBySession` / `cursorIdeSnapshotLastUpdatedAtBySession`
+(~100 B per session, reconcile semantics attached), `updateFileTrackingAtom`
+bypassing `MAX_TRACKED_REPOS` (module is unreferenced — dead code, with
+`search/cacheAtom.ts`; deletion candidates), `ChatView` `hydratedSessionIdsRef`,
+one-shot rAF/timeouts in `XtermOutput`/`useStrokeDraw`.

--- a/src/components/TerminalInteractive/terminalSetup.ts
+++ b/src/components/TerminalInteractive/terminalSetup.ts
@@ -116,21 +116,31 @@ export function loadTerminalWebgl(
     return;
   }
 
+  let webglAddon: WebglAddon | null = null;
   try {
-    const webglAddon = new WebglAddon();
-    webglAddon.onContextLoss(() => {
+    webglAddon = new WebglAddon();
+    const addon = webglAddon;
+    addon.onContextLoss(() => {
       log.warn("[Terminal] WebGL context lost, falling back to canvas");
-      webglAddon.dispose();
+      addon.dispose();
       webglAddonRef.current = null;
       releaseWebglSlot();
     });
-    terminal.loadAddon(webglAddon);
-    webglAddonRef.current = webglAddon;
+    terminal.loadAddon(addon);
+    webglAddonRef.current = addon;
   } catch (error) {
     log.warn(
       "[Terminal] WebGL addon failed to load, using canvas renderer:",
       error
     );
+    // If `loadAddon`/`activate` threw after the GL context was created, the
+    // addon still owns that context (10–30 MB GPU); dispose it before
+    // handing the budget slot back so the live-context count stays honest.
+    try {
+      webglAddon?.dispose();
+    } catch {
+      // Best effort — the addon may not have activated at all.
+    }
     releaseWebglSlot();
   }
 }

--- a/src/components/XtermOutput/index.tsx
+++ b/src/components/XtermOutput/index.tsx
@@ -136,17 +136,26 @@ const XtermOutput = memo(function XtermOutput({
     };
     if (shouldLoadTerminalWebgl() && acquireWebglSlot()) {
       webglSlotHeldRef.current = true;
+      let webglAddon: WebglAddon | null = null;
       try {
-        const webglAddon = new WebglAddon();
-        webglAddon.onContextLoss(() => {
-          webglAddon.dispose();
+        webglAddon = new WebglAddon();
+        const addon = webglAddon;
+        addon.onContextLoss(() => {
+          addon.dispose();
           webglAddonRef.current = null;
           releaseWebglSlotIfHeld();
         });
-        terminal.loadAddon(webglAddon);
-        webglAddonRef.current = webglAddon;
+        terminal.loadAddon(addon);
+        webglAddonRef.current = addon;
       } catch (error) {
         logger.warn("WebGL unavailable for XtermOutput, using canvas:", error);
+        // Dispose a partially activated addon so its GL context is not
+        // orphaned while the budget slot is released.
+        try {
+          webglAddon?.dispose();
+        } catch {
+          // Best effort.
+        }
         webglAddonRef.current = null;
         releaseWebglSlotIfHeld();
       }

--- a/src/engines/ChatPanel/ChatHistory/components/TurnMetadataFooterSlot.tsx
+++ b/src/engines/ChatPanel/ChatHistory/components/TurnMetadataFooterSlot.tsx
@@ -14,26 +14,47 @@ interface TurnMetadataFooterSlotProps {
   isLastGroup: boolean;
 }
 
-const TurnMetadataFooterSlot: React.FC<TurnMetadataFooterSlotProps> = memo(
-  ({ sessionId, turnId, isLastGroup }) => {
+interface TurnMetadataFooterSlotBodyProps {
+  sessionId: string;
+  turnId: string;
+  isLastGroup: boolean;
+}
+
+/**
+ * Inner body: only touches `turnMetadataAtomFamily` with a real session id.
+ * The outer slot used to call the family with `sessionId ?? ""`, creating
+ * `"\u0000<turnId>"` entries that `TurnMetadataLoader` (the family's GC
+ * owner) never retains or removes — pinned for the app lifetime, one per
+ * turn rendered while the session id was still null.
+ */
+const TurnMetadataFooterSlotBody: React.FC<TurnMetadataFooterSlotBodyProps> =
+  memo(({ sessionId, turnId, isLastGroup }) => {
     const summary = useAtomValue(
-      turnMetadataAtomFamily(turnMetadataKey(sessionId ?? "", turnId))
+      turnMetadataAtomFamily(turnMetadataKey(sessionId, turnId))
     );
     const hasLoadedMoreActivities = useAtomValue(hasLoadedMoreActivitiesAtom);
-    const turnMetadataVisible = useAtomValue(chatTurnMetadataVisibleAtom);
-    if (
-      !turnMetadataVisible ||
-      !sessionId ||
-      !summary ||
-      !isTerminalTurnStatus(summary.status)
-    )
-      return null;
+    if (!summary || !isTerminalTurnStatus(summary.status)) return null;
     return (
       <TurnMetadataFooter
         summary={summary}
         sessionId={sessionId}
         turnId={turnId}
         isPagedHistoryRound={hasLoadedMoreActivities && !isLastGroup}
+      />
+    );
+  });
+
+TurnMetadataFooterSlotBody.displayName = "TurnMetadataFooterSlotBody";
+
+const TurnMetadataFooterSlot: React.FC<TurnMetadataFooterSlotProps> = memo(
+  ({ sessionId, turnId, isLastGroup }) => {
+    const turnMetadataVisible = useAtomValue(chatTurnMetadataVisibleAtom);
+    if (!turnMetadataVisible || !sessionId) return null;
+    return (
+      <TurnMetadataFooterSlotBody
+        sessionId={sessionId}
+        turnId={turnId}
+        isLastGroup={isLastGroup}
       />
     );
   }

--- a/src/engines/SessionCore/core/store/__tests__/subscribeSessionDisposer.test.ts
+++ b/src/engines/SessionCore/core/store/__tests__/subscribeSessionDisposer.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { SessionListener } from "../EventStoreProxyTypes";
+import { SnapshotCacheManager } from "../snapshotCacheManager";
+
+type ListenerRegistry = Map<string, Set<SessionListener>>;
+
+function registryOf(manager: SnapshotCacheManager): ListenerRegistry {
+  return (manager as unknown as { _sessionListeners: ListenerRegistry })
+    ._sessionListeners;
+}
+
+/**
+ * Regression: the unsubscribe returned by `subscribeSession` used to close
+ * over the Set it was created with and delete the registry entry whenever
+ * *that* Set became empty. After `evictSessionCache` (which drops the entry)
+ * a later subscriber installs a fresh Set; the stale disposer then silently
+ * unregistered the live Set, so still-mounted consumers stopped receiving
+ * pushes and kept their last snapshot forever.
+ */
+describe("SnapshotCacheManager.subscribeSession disposer", () => {
+  it("does not unregister a newer live Set after evictSessionCache", () => {
+    const manager = new SnapshotCacheManager(vi.fn());
+    const registry = registryOf(manager);
+
+    const first = vi.fn();
+    const disposeFirst = manager.subscribeSession("s1", first);
+    const firstSet = registry.get("s1");
+    expect(firstSet?.has(first)).toBe(true);
+
+    manager.evictSessionCache("s1");
+    expect(registry.has("s1")).toBe(false);
+
+    const second = vi.fn();
+    const disposeSecond = manager.subscribeSession("s1", second);
+    const secondSet = registry.get("s1");
+    expect(secondSet).not.toBe(firstSet);
+    expect(secondSet?.has(second)).toBe(true);
+
+    // Stale disposer from before the eviction fires (e.g. old consumer
+    // unmounts). It must not touch the new registration.
+    disposeFirst();
+    expect(registry.get("s1")).toBe(secondSet);
+    expect(secondSet?.has(second)).toBe(true);
+
+    disposeSecond();
+    expect(registry.has("s1")).toBe(false);
+  });
+
+  it("removes the registry entry when the last live subscriber leaves", () => {
+    const manager = new SnapshotCacheManager(vi.fn());
+    const registry = registryOf(manager);
+    const a = manager.subscribeSession("s2", vi.fn());
+    const b = manager.subscribeSession("s2", vi.fn());
+    a();
+    expect(registry.has("s2")).toBe(true);
+    b();
+    expect(registry.has("s2")).toBe(false);
+  });
+});

--- a/src/engines/SessionCore/core/store/snapshotCacheManager.ts
+++ b/src/engines/SessionCore/core/store/snapshotCacheManager.ts
@@ -345,9 +345,15 @@ export class SnapshotCacheManager {
       this._sessionListeners.set(sessionId, listeners);
     }
     listeners.add(listener);
+    const subscribedSet = listeners;
     return () => {
-      listeners!.delete(listener);
-      if (listeners!.size === 0) {
+      subscribedSet.delete(listener);
+      // Only drop the registry entry if it is still *our* Set. After
+      // `evictSessionCache` (which deletes the entry) a later subscriber may
+      // have installed a fresh Set for the same session; a stale disposer
+      // must not unregister that live Set.
+      const current = this._sessionListeners.get(sessionId);
+      if (current === subscribedSet && current.size === 0) {
         this._sessionListeners.delete(sessionId);
       }
     };

--- a/src/modules/WorkStation/Chat/Communication/__tests__/utils.test.ts
+++ b/src/modules/WorkStation/Chat/Communication/__tests__/utils.test.ts
@@ -672,3 +672,37 @@ describe("truncateContent", () => {
     expect(out.length).toBeLessThanOrEqual(21);
   });
 });
+
+describe("deriveMessagesState memoization", () => {
+  it("reuses the built lists for the same events array identity", () => {
+    const events = [
+      minimalSessionEvent({
+        id: "m-1",
+        functionName: "assistant",
+        result: { observation: "hello" },
+      }),
+    ];
+    const first = deriveMessagesState(events, null);
+    const second = deriveMessagesState(events, null);
+    expect(second.chatMessages).toBe(first.chatMessages);
+  });
+
+  it("rebuilds for a new events array and keeps earlier results usable", () => {
+    // Regression for the old single-slot module memo: building for session B
+    // used to overwrite (and pin) session A's lists; the WeakMap memo keeps
+    // per-array results independent so an earlier array still hits its own
+    // memo — and can be garbage-collected once dropped.
+    const eventsA = [
+      minimalSessionEvent({ id: "a-1", result: { observation: "A" } }),
+    ];
+    const eventsB = [
+      minimalSessionEvent({ id: "b-1", result: { observation: "B" } }),
+    ];
+    const a1 = deriveMessagesState(eventsA, null);
+    const b1 = deriveMessagesState(eventsB, null);
+    expect(b1.chatMessages).not.toBe(a1.chatMessages);
+    const a2 = deriveMessagesState(eventsA, null);
+    expect(a2.chatMessages).toBe(a1.chatMessages);
+    expect(a2.chatMessages.map((m) => m.eventId)).toEqual(["a-1"]);
+  });
+});

--- a/src/modules/WorkStation/Chat/Communication/config.ts
+++ b/src/modules/WorkStation/Chat/Communication/config.ts
@@ -189,18 +189,27 @@ function findResolvedUnloadedTurnPlaceholderIds(
  * - "thinking" → Messages timeline
  * - "todo"     → Todo tab and Messages timeline
  */
-let _prevBuildEvents: SessionEvent[] = [];
-let _prevBuildResult: {
+interface MessageListsBuildResult {
   chatMessages: MessageEntry[];
   thinkMessages: MessageEntry[];
   todoMessages: MessageEntry[];
   interactionMessages: MessageEntry[];
   messageIndex: Map<string, MessageEntry>;
-} | null = null;
+}
 
-function buildMessageLists(events: SessionEvent[]) {
-  if (events === _prevBuildEvents && _prevBuildResult) return _prevBuildResult;
-  _prevBuildEvents = events;
+// Identity-keyed memo (same semantics as the previous single-slot
+// `_prevBuildEvents` / `_prevBuildResult` module variables) but held in a
+// WeakMap so the last-built session's full event array and MessageEntry
+// trees are released as soon as the events array itself is dropped, instead
+// of surviving unmount / session switch / session close.
+const buildMessageListsMemo = new WeakMap<
+  readonly SessionEvent[],
+  MessageListsBuildResult
+>();
+
+function buildMessageLists(events: SessionEvent[]): MessageListsBuildResult {
+  const memoized = buildMessageListsMemo.get(events);
+  if (memoized) return memoized;
 
   const chatMessages: MessageEntry[] = [];
   const thinkMessages: MessageEntry[] = [];
@@ -287,14 +296,15 @@ function buildMessageLists(events: SessionEvent[]) {
     }
   }
 
-  _prevBuildResult = {
+  const result: MessageListsBuildResult = {
     chatMessages,
     thinkMessages,
     todoMessages,
     interactionMessages: coalescedInteractionMessages,
     messageIndex,
   };
-  return _prevBuildResult;
+  buildMessageListsMemo.set(events, result);
+  return result;
 }
 
 /**

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SearchContent/useSearchContent/__tests__/useSearchResults.loadMoreListeners.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SearchContent/useSearchContent/__tests__/useSearchResults.loadMoreListeners.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import {
+  type RefObject,
+  act,
+  createElement,
+  createRef,
+  forwardRef,
+  useImperativeHandle,
+} from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import {
+  searchHasMoreAtom,
+  searchLoadingMoreAtom,
+} from "@src/store/workstation/codeEditor/search";
+
+import { useSearchResults } from "../useSearchResults";
+
+const listenerState = vi.hoisted(() => ({
+  unlistens: [] as Array<ReturnType<typeof vi.fn>>,
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async () => {
+    const unlisten = vi.fn();
+    listenerState.unlistens.push(unlisten);
+    return unlisten;
+  }),
+}));
+
+const searchApi = vi.hoisted(() => ({
+  searchCodeStreaming: vi.fn(),
+}));
+
+vi.mock("@src/api/tauri/search", () => ({
+  searchCodeStreaming: searchApi.searchCodeStreaming,
+}));
+
+type Controller = ReturnType<typeof useSearchResults>;
+
+const Probe = forwardRef<Controller>((_props, ref) => {
+  const results = useSearchResults();
+  useImperativeHandle(ref, () => results, [results]);
+  return null;
+});
+Probe.displayName = "SearchResultsProbe";
+
+const OPTIONS = {
+  caseSensitive: false,
+  wholeWord: false,
+  useRegex: false,
+  fileExtensions: [],
+  excludeDirs: [],
+  filesToInclude: "",
+  filesToExclude: "",
+  onlyOpenFiles: false,
+};
+
+/**
+ * Regression: the two per-request Tauri listeners registered by `loadMore`
+ * were only unlistened on the success path. A rejected `searchCodeStreaming`
+ * left both handlers — each closing over the whole current result set —
+ * registered for the process lifetime.
+ */
+describe("useSearchResults.loadMore listener lifecycle", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let controllerRef: RefObject<Controller | null>;
+  let store: ReturnType<typeof createStore>;
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    listenerState.unlistens.length = 0;
+    searchApi.searchCodeStreaming.mockReset();
+    store = createStore();
+    store.set(searchHasMoreAtom, true);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    controllerRef = createRef<Controller>();
+    act(() =>
+      root.render(
+        createElement(
+          Provider,
+          { store },
+          createElement(Probe, { ref: controllerRef })
+        )
+      )
+    );
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("releases both listeners when the streaming request rejects", async () => {
+    searchApi.searchCodeStreaming.mockRejectedValueOnce(
+      new Error("invalid regex")
+    );
+    await act(async () => {
+      await controllerRef.current!.loadMore("foo(", "/repo", OPTIONS);
+    });
+    expect(listenerState.unlistens).toHaveLength(2);
+    for (const unlisten of listenerState.unlistens) {
+      expect(unlisten).toHaveBeenCalledTimes(1);
+    }
+    expect(store.get(searchLoadingMoreAtom)).toBe(false);
+  });
+});

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SearchContent/useSearchContent/useSearchResults.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SearchContent/useSearchContent/useSearchResults.ts
@@ -5,7 +5,7 @@
  * Handles result memoization, load more (progressive loading),
  * and result clearing.
  */
-import { listen } from "@tauri-apps/api/event";
+import { type UnlistenFn, listen } from "@tauri-apps/api/event";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useMemo } from "react";
 
@@ -114,6 +114,14 @@ export function useSearchResults(): UseSearchResultsReturn {
       if (!hasMore || loadingMore || !query.trim()) return;
 
       setLoadingMore(true);
+      // Hoisted so `finally` can always drop both Tauri listeners. They used
+      // to be unlistened only on the success path; a rejected
+      // `searchCodeStreaming` (invalid regex, repo unmounted, …) left both
+      // handlers — each closing over the whole current result set —
+      // registered for the process lifetime and running on every later
+      // `search-result` event.
+      let resultUnlisten: UnlistenFn | null = null;
+      let completeUnlisten: UnlistenFn | null = null;
       try {
         const currentMatchCount = totalMatches;
         // Request a larger batch to get more results
@@ -125,7 +133,7 @@ export function useSearchResults(): UseSearchResultsReturn {
         const loadMoreResults: StoreSearchResultFile[] = [];
         let loadMoreComplete = false;
 
-        const resultUnlisten = await listen<SearchResultEvent>(
+        resultUnlisten = await listen<SearchResultEvent>(
           "search-result",
           (event) => {
             if (event.payload.search_id !== loadMoreSearchId) return;
@@ -140,7 +148,7 @@ export function useSearchResults(): UseSearchResultsReturn {
           }
         );
 
-        const completeUnlisten = await listen<SearchCompleteEvent>(
+        completeUnlisten = await listen<SearchCompleteEvent>(
           "search-complete",
           (event) => {
             if (event.payload.search_id !== loadMoreSearchId) return;
@@ -172,10 +180,6 @@ export function useSearchResults(): UseSearchResultsReturn {
           await new Promise((resolve) => setTimeout(resolve, 100));
         }
 
-        // Cleanup listeners
-        await resultUnlisten();
-        await completeUnlisten();
-
         // Append new results
         if (loadMoreResults.length > 0) {
           appendResults(loadMoreResults);
@@ -186,6 +190,9 @@ export function useSearchResults(): UseSearchResultsReturn {
         log.error("[useSearchResults] Load more error:", errorMessage);
         setError(errorMessage);
       } finally {
+        // Always release the per-request listeners (success, error, timeout).
+        resultUnlisten?.();
+        completeUnlisten?.();
         setLoadingMore(false);
       }
     },

--- a/src/scaffold/NavigationSidebar/connectors/useWorkstationSidebarHandlers.ts
+++ b/src/scaffold/NavigationSidebar/connectors/useWorkstationSidebarHandlers.ts
@@ -56,6 +56,7 @@ import {
 } from "@src/store/ui/chatPanelAtom";
 import {
   clearPendingFileOpensForSession,
+  disposeEditorCacheForSessionAtom,
   disposeWorkstationWorkspaceAtom,
 } from "@src/store/workstation/tabs";
 import { clearPendingCodeEditorTabForSession } from "@src/store/workstation/tabs/pendingCodeEditorTab";
@@ -148,8 +149,21 @@ export function useWorkstationSidebarHandlers({
   const setBenchmarkActiveBatchTaskId = useSetAtom(
     benchmarkActiveBatchTaskIdAtom
   );
-  const disposeWorkstationWorkspace = useSetAtom(
+  const disposeWorkstationTabsWorkspace = useSetAtom(
     disposeWorkstationWorkspaceAtom
+  );
+  const disposeEditorCacheForSession = useSetAtom(
+    disposeEditorCacheForSessionAtom
+  );
+  // Both session-delete paths (direct + Rust delete receipt) go through this
+  // one callback so the tab registry and the editor cache are released
+  // together.
+  const disposeWorkstationWorkspace = useCallback(
+    (sessionId: string) => {
+      disposeWorkstationTabsWorkspace(sessionId);
+      disposeEditorCacheForSession(sessionId);
+    },
+    [disposeWorkstationTabsWorkspace, disposeEditorCacheForSession]
   );
   const pagination = useAtomValue(sessionPaginationAtom);
   const cloudAuth = useAtomValue(org2CloudAuthAtom);

--- a/src/store/workstation/codeEditor/terminal/__tests__/commandDetectionLifecycle.test.ts
+++ b/src/store/workstation/codeEditor/terminal/__tests__/commandDetectionLifecycle.test.ts
@@ -1,0 +1,76 @@
+import { createStore } from "jotai/vanilla";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  commandDetectionMapAtom,
+  commandExecutedAtom,
+  commandPromptStartAtom,
+} from "../commandDetection";
+import {
+  activeTerminalIdAtom,
+  closeTerminalSessionAtom,
+  createAgentSessionTerminalAtom,
+  removeAgentSessionTerminalAtom,
+  terminalSessionsAtom,
+} from "../index";
+
+vi.mock("@src/util/platform/tauri/init", () => ({
+  invokeTauri: vi.fn().mockResolvedValue(undefined),
+  isTauriReady: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("@src/util/ui/terminal/creationThrottle", () => ({
+  tryBeginTerminalCreation: vi.fn().mockReturnValue(true),
+  notifyTerminalCreationCooldown: vi.fn(),
+}));
+
+vi.mock("@src/config/settingsSchema", () => ({
+  getSettingsDefaults: vi.fn().mockReturnValue({
+    "terminal.shellType": "default",
+    "terminal.customShellPath": "",
+  }),
+}));
+
+/**
+ * Regression: OSC-633 command-detection state (up to 200 command entries per
+ * terminal) was only ever added to; `removeCommandDetectionAtom` had no
+ * caller, so the map grew with every terminal session ever opened.
+ */
+describe("command detection lifecycle", () => {
+  let store: ReturnType<typeof createStore>;
+
+  beforeEach(() => {
+    store = createStore();
+    store.set(terminalSessionsAtom, [
+      { id: "t-1", name: "Terminal 1", isActive: true },
+      { id: "t-2", name: "Terminal 2", isActive: false },
+    ]);
+    store.set(activeTerminalIdAtom, "t-1");
+  });
+
+  it("drops a terminal's command history when the terminal is closed", async () => {
+    store.set(commandPromptStartAtom, "t-2");
+    store.set(commandExecutedAtom, { sessionId: "t-2", commandLine: "ls -la" });
+    expect(store.get(commandDetectionMapAtom).has("t-2")).toBe(true);
+
+    await store.set(closeTerminalSessionAtom, "t-2");
+
+    expect(store.get(commandDetectionMapAtom).has("t-2")).toBe(false);
+    // Other sessions untouched.
+    store.set(commandPromptStartAtom, "t-1");
+    expect(store.get(commandDetectionMapAtom).has("t-1")).toBe(true);
+  });
+
+  it("drops the history of a removed agent-session terminal tab", () => {
+    const tabId = store.set(createAgentSessionTerminalAtom, {
+      agentSessionId: "agent-1",
+      label: "Agent",
+    });
+    store.set(commandPromptStartAtom, tabId);
+    expect(store.get(commandDetectionMapAtom).has(tabId)).toBe(true);
+
+    // Takes the agent session id (the tab id is derived from it).
+    store.set(removeAgentSessionTerminalAtom, "agent-1");
+    expect(store.get(commandDetectionMapAtom).has(tabId)).toBe(false);
+  });
+});

--- a/src/store/workstation/codeEditor/terminal/index.ts
+++ b/src/store/workstation/codeEditor/terminal/index.ts
@@ -18,6 +18,7 @@ import { type Getter, type Setter, atom } from "jotai";
 import { getSettingsDefaults } from "@src/config/settingsSchema";
 import { createLogger } from "@src/hooks/logger";
 import { settingsAtom } from "@src/store/settings/settingsAtom";
+import { removeCommandDetectionAtom } from "@src/store/workstation/codeEditor/terminal/commandDetection";
 import { invokeTauri, isTauriReady } from "@src/util/platform/tauri/init";
 import { isChatPanelTerminalId } from "@src/util/ui/terminal/chatPanelSessionId";
 import {
@@ -258,6 +259,9 @@ function removeTerminalSessionLocalOnly(
     next.delete(sessionId);
     return next;
   });
+  // OSC-633 command history for the closed session (up to 200 entries) —
+  // nothing else ever removed it, so the map grew with every terminal opened.
+  set(removeCommandDetectionAtom, sessionId);
   set(terminalPersistAtom);
 }
 
@@ -460,6 +464,7 @@ export const removeAgentSessionTerminalAtom = atom(
       next.delete(tabId);
       return next;
     });
+    set(removeCommandDetectionAtom, tabId);
 
     set(terminalPersistAtom);
   }

--- a/src/store/workstation/tabs/__tests__/editorCache.test.ts
+++ b/src/store/workstation/tabs/__tests__/editorCache.test.ts
@@ -46,6 +46,7 @@ async function loadCacheAtoms() {
     editorCacheSizeAtom: cache.editorCacheSizeAtom,
     saveRepoCacheAtom: cache.saveRepoCacheAtom,
     clearAllEditorCacheAtom: cache.clearAllEditorCacheAtom,
+    disposeEditorCacheForSessionAtom: cache.disposeEditorCacheForSessionAtom,
   };
 }
 
@@ -169,5 +170,50 @@ describe("editor repo cache workspace scoping", () => {
     store.set(atoms.workstationActiveSessionIdAtom, "session-a");
     expect(store.get(atoms.activeEditorRepoAtom)).toBeNull();
     expect(store.get(atoms.editorCacheAtom)).toEqual({});
+  });
+});
+
+describe("disposeEditorCacheForSessionAtom", () => {
+  it("drops a deleted session's repo cache and active repo, in memory and storage", async () => {
+    const atoms = await loadCacheAtoms();
+    const store = createStore();
+
+    store.set(atoms.workstationActiveSessionIdAtom, "session-gone");
+    store.set(atoms.activeEditorRepoAtom, "/repo");
+    store.set(atoms.saveRepoCacheAtom, {
+      repoPath: "/repo",
+      fileTabs: [fileTab("x")],
+      activeFileTabId: "x",
+      lastAccessedAt: 1,
+    });
+    store.set(atoms.workstationActiveSessionIdAtom, "session-kept");
+    store.set(atoms.activeEditorRepoAtom, "/repo");
+    store.set(atoms.saveRepoCacheAtom, {
+      repoPath: "/repo",
+      fileTabs: [fileTab("y")],
+      activeFileTabId: "y",
+      lastAccessedAt: 2,
+    });
+
+    const persistedBefore = Object.entries(memoryStorage.values).find(([key]) =>
+      key.includes("editor-cache-by-workspace")
+    );
+    expect(persistedBefore?.[1]).toContain("session:session-gone");
+
+    store.set(atoms.disposeEditorCacheForSessionAtom, "session-gone");
+
+    // The kept session is untouched.
+    store.set(atoms.workstationActiveSessionIdAtom, "session-kept");
+    expect(
+      store.get(atoms.activeRepoCacheAtom)?.fileTabs.map((tab) => tab.id)
+    ).toEqual(["y"]);
+    // The deleted session's workspace is gone from memory and storage.
+    store.set(atoms.workstationActiveSessionIdAtom, "session-gone");
+    expect(store.get(atoms.editorCacheAtom)).toEqual({});
+    expect(store.get(atoms.activeEditorRepoAtom)).toBeNull();
+    const persistedAfter = Object.entries(memoryStorage.values).find(([key]) =>
+      key.includes("editor-cache-by-workspace")
+    );
+    expect(persistedAfter?.[1] ?? "").not.toContain("session:session-gone");
   });
 });

--- a/src/store/workstation/tabs/editorCache.ts
+++ b/src/store/workstation/tabs/editorCache.ts
@@ -277,6 +277,33 @@ export const clearAllEditorCacheAtom = atom(null, (_get, set) => {
 });
 clearAllEditorCacheAtom.debugLabel = "clearAllEditorCacheAtom";
 
+/**
+ * Drop a session workspace's editor cache (repo tab layouts) and its
+ * active-repo pointer. Called when the session itself is deleted; without
+ * this the `session:<id>` keys — heap + one localStorage blob parsed at
+ * boot — accumulated for every session ever opened in the WorkStation.
+ */
+export const disposeEditorCacheForSessionAtom = atom(
+  null,
+  (get, set, sessionId: string) => {
+    const workspaceId = workstationWorkspaceId({ kind: "session", sessionId });
+    const caches = get(editorCacheByWorkspaceAtom);
+    if (workspaceId in caches) {
+      const next = { ...caches };
+      delete next[workspaceId];
+      set(editorCacheByWorkspaceAtom, next);
+    }
+    const activeRepos = get(activeEditorRepoByWorkspaceAtom);
+    if (workspaceId in activeRepos) {
+      const next = { ...activeRepos };
+      delete next[workspaceId];
+      set(activeEditorRepoByWorkspaceAtom, next);
+    }
+  }
+);
+disposeEditorCacheForSessionAtom.debugLabel =
+  "disposeEditorCacheForSessionAtom";
+
 export const switchActiveRepoAtom = atom(
   null,
   (_get, set, repoPath: string | null) => {

--- a/src/store/workstation/tabs/index.ts
+++ b/src/store/workstation/tabs/index.ts
@@ -272,5 +272,6 @@ export {
   saveRepoCacheAtom,
   clearRepoCacheAtom,
   clearAllEditorCacheAtom,
+  disposeEditorCacheForSessionAtom,
   switchActiveRepoAtom,
 } from "./editorCache";


### PR DESCRIPTION
> Stacked on #830 (`perf/heavy-component-leaks`) → #829. Merge in order; this PR's diff is only the top commit.

## Summary

Third frontend RAM pass: two thorough lifecycle sweeps (effects without cleanup, module-scope maps, registries holding DOM/xterm/EditorView, xterm/webview teardown, per-session atom families) over WorkStation, engines, hooks and scaffold. The codebase turned out disciplined; this PR fixes the genuine defects found — every change is behavior-neutral (nothing a user can see changes; only what is retained after it should have been released). Each has a regression test.

## Problem

- `SnapshotCacheManager.subscribeSession` returned a disposer that captured the listener `Set` it was created with and deleted the registry entry whenever *that* Set emptied. `evictSessionCache` (reached by reload / manual compact / edit-message / sidebar delete while consumers are still mounted) drops the entry; a later subscriber installs a fresh Set, and the stale disposer then silently unregistered the **live** Set — mounted consumers stopped receiving `es:changed` pushes and pinned their last full snapshot.
- `useSearchResults.loadMore` unlistened its two Tauri listeners only on the success path; a rejected `searchCodeStreaming` (invalid regex, repo unmounted) left both — each closing over the entire current result set — registered for the process lifetime and running on every later `search-result` event.
- OSC-633 command-detection state (up to 200 command entries per terminal) was never pruned: `removeCommandDetectionAtom` had zero callers.
- Deleting a session disposed its tab workspace but not its `session:<id>` editor cache / active-repo pointer (heap + a localStorage blob parsed at boot).
- `Chat/Communication/config.ts` kept a module-scope single-slot memo of the last-built session's full `SessionEvent[]` and `MessageEntry` trees, outliving unmount / session switch / session close.
- A WebGL addon that threw inside `loadAddon`/`activate` was never disposed while its budget slot was returned (orphaned GL context; the 8-slot budget could be exceeded).
- `TurnMetadataFooterSlot` touched `turnMetadataAtomFamily` with `sessionId ?? ""`, creating empty-session-id entries that the loader's GC never retains or removes.

## Solution

- Disposer re-looks-up the current Set and only removes the registry entry when it is its own (`snapshotCacheManager.ts`).
- Listeners hoisted and released in `finally` (`useSearchResults.ts`).
- `removeCommandDetectionAtom` called from both terminal-removal paths (`terminal/index.ts`).
- New `disposeEditorCacheForSessionAtom` (`editorCache.ts`), wired into the single dispose callback both session-delete paths use (`useWorkstationSidebarHandlers.ts`).
- Memo → identity-keyed `WeakMap` (same hit semantics, no retention).
- `webglAddon?.dispose()` on the throw path in `terminalSetup.ts` and `XtermOutput/index.tsx`.
- `TurnMetadataFooterSlot` split into a wrapper (`null`/visibility gate) + body that only reads the family with a real session id.

## Potential risks

- Low. The disposer change only affects the *stale-disposer-after-evict* case; the normal last-subscriber-removes-entry path is unchanged and tested. `WeakMap` memo hits are a superset of the old single-slot memo (never stale — keyed by array identity). Everything else is cleanup on close/error paths.
- Not changed (documented in the audit fix log as follow-ups): LRU-capping saved tab layouts across *live* sessions (would drop old sessions' tab state), `cursorIdeTurnSummariesAtomFamily` retention for browsed Cursor sessions (needs mount-gated GC), two ~100 B/session maps with reconcile semantics, and the unreferenced `search/fileTrackingAtom.ts` + `search/cacheAtom.ts` modules (dead-code deletion candidates).

## Validation / Test plan

- `pnpm typecheck` clean; lint-staged (eslint + tsc) passed on commit.
- New tests: `subscribeSessionDisposer.test.ts` (stale disposer must not unregister a newer live Set), `useSearchResults.loadMoreListeners.test.ts` (both listeners released on rejection), `commandDetectionLifecycle.test.ts` (both removal paths prune), `editorCache.test.ts` dispose case (memory + storage), `utils.test.ts` memo identity/independence cases.
- 137 test files / 1 172 tests green across the touched areas (SessionCore store, terminal, XtermOutput, ChatHistory, Communication, EditorPrimarySidebar, NavigationSidebar, workstation store).
- Manual: reload / manual compact a session with subagents and confirm the chat keeps updating; trigger a failing search load-more then run further searches; open/close terminals; delete a session that had editor tabs.
