### PR TITLE
feat(poker): floating play-chip poker table (human vs bots)

### DIFF
--- a/docs/frontend-ui-audit-2026-08-17/PokerTableHeader.md
+++ b/docs/frontend-ui-audit-2026-08-17/PokerTableHeader.md
@@ -1,0 +1,28 @@
+# Poker table header
+
+## Scope
+
+Audited the new poker table header controls for shared component usage,
+design-token consistency, accessibility basics, and duplicated dropdown
+presentation. The configured `frontend-ui-audit` skill file was unavailable at
+both repository-documented paths, so this is the repository's established
+manual fallback format.
+
+## Findings
+
+| Line                                                     | Element                        | Verdict          | Reason                                                                                                                                                                                            | Suggested change                                                                                                                                          |
+| -------------------------------------------------------- | ------------------------------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PokerTableHeader.tsx:84`                                | Stakes control                 | fix              | The custom `Dropdown` trigger duplicated selection, chevron, focus, popup-positioning, placeholder, and keyboard behavior already owned by the shared `Select`.                                   | Use controlled `Select` props with shared options, the reusable `placeholder` prop, accessible labeling, and left-aligned automatic-width popup behavior. |
+| `PokerTableHeader.tsx:124`                               | Speed control                  | fix              | The hand-built radio menu duplicated shared option rendering, placeholder, and selected-state behavior.                                                                                           | Use a controlled `Select` with the reusable `placeholder` prop, a settings prefix, right alignment, and minimum trigger-width matching.                   |
+| `PokerTableHeader.tsx:111`                               | History action                 | fix              | The raw icon button bypassed the shared button sizing, interaction states, and icon-only prop contract.                                                                                           | Use the shared tertiary mini `Button` with `iconOnly`, `aria-label`, and `aria-pressed`.                                                                  |
+| `PokerTableHeader.tsx:155`                               | Close action                   | fix              | The raw icon button bypassed the same shared header-action behavior.                                                                                                                              | Use the shared tertiary mini `Button` with `iconOnly` and an accessible name.                                                                             |
+| `PokerTableHeader.tsx:84` and `PokerTableHeader.tsx:124` | Drag exclusion wrappers        | keep with reason | `useWindowDrag` does not classify a `role="combobox"` trigger as interactive, so a narrow `data-no-window-drag` wrapper is required to prevent selecting an option from initiating a window drag. | Keep the wrappers until the shared drag hook explicitly recognizes comboboxes.                                                                            |
+| `PokerTableHeader.tsx:62`                                | Pending-stakes trigger label   | keep with reason | Stakes changes intentionally take effect at the next hand; the option state must reflect the pending setting while the compact title continues to report the live blinds.                         | Keep `triggerLabel` separate from the selected option label.                                                                                              |
+| `PokerTableHeader.tsx:107`                               | Compact hand-number typography | keep with reason | The 12px secondary label matches the existing compact workstation-header scale and is informational rather than an interactive control.                                                           | Consider tokenizing only as part of a broader workstation-header typography sweep.                                                                        |
+
+## Verdict counts
+
+- Fix: 4
+- Keep with reason: 3
+- Abstract: 0
+- Remaining cross-file sweep candidates: 0

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "mermaid": "^10.9.5",
     "nanoid": "^5.1.11",
     "papaparse": "^5.5.3",
+    "pokersolver": "2.1.4",
     "process": "^0.11.10",
     "react": "^19.2.6",
     "react-artifact-runtime": "npm:react@18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,6 +236,9 @@ importers:
       papaparse:
         specifier: ^5.5.3
         version: 5.5.3
+      pokersolver:
+        specifier: 2.1.4
+        version: 2.1.4
       process:
         specifier: ^0.11.10
         version: 0.11.10
@@ -6466,6 +6469,10 @@ packages:
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
     engines: {node: '>=4'}
+
+  pokersolver@2.1.4:
+    resolution: {integrity: sha512-vmgZS+K8H8r1RePQykFM5YyvlKo1v3xVec8FMBjg9N6mR2Tj/n/X415w+lG67FWbrk71D/CADmKFinDgaQlAsw==}
+    engines: {'0': node >= 4.0.0}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -15379,6 +15386,8 @@ snapshots:
       find-up: 4.1.0
 
   pluralize@8.0.0: {}
+
+  pokersolver@2.1.4: {}
 
   possible-typed-array-names@1.1.0: {}
 

--- a/src/engines/ChatPanel/ChatPanelTabBar.test.ts
+++ b/src/engines/ChatPanel/ChatPanelTabBar.test.ts
@@ -296,6 +296,7 @@ describe("ChatPanelTabBar", () => {
         onNewProject: vi.fn(),
         onNewWorkItem: vi.fn(),
         onOpenSideChat: vi.fn(),
+        onOpenPokerTable: vi.fn(),
         onClose: vi.fn(),
       })
     );
@@ -305,5 +306,6 @@ describe("ChatPanelTabBar", () => {
     expect(markup).toContain("sessions:creator.createTarget.project");
     expect(markup).toContain("chat.startPage.newWorkItem.title");
     expect(markup).toContain("sessions:chat.sideChat.title");
+    expect(markup).toContain("sessions:pokerTable.menuLabel");
   });
 });

--- a/src/engines/ChatPanel/ChatPanelTabBar.tsx
+++ b/src/engines/ChatPanel/ChatPanelTabBar.tsx
@@ -53,6 +53,7 @@ import {
   PictureInPicture2,
   Plus,
   Settings2,
+  Spade,
   TerminalSquare,
 } from "lucide-react";
 import React, {
@@ -550,6 +551,7 @@ interface PlusMenuContentProps {
   onNewProject: () => void;
   onNewWorkItem: () => void;
   onOpenSideChat: () => void;
+  onOpenPokerTable: () => void;
   onClose: () => void;
 }
 
@@ -560,6 +562,7 @@ export function PlusMenuContent({
   onNewProject,
   onNewWorkItem,
   onOpenSideChat,
+  onOpenPokerTable,
   onClose,
 }: PlusMenuContentProps) {
   const { t } = useTranslation(["sessions", "navigation"]);
@@ -605,6 +608,12 @@ export function PlusMenuContent({
       label: t("sessions:chat.sideChat.title"),
       onClick: onOpenSideChat,
     },
+    {
+      id: "poker-table",
+      icon: <Spade size={HEADER_ICON_SIZE.sm} strokeWidth={1.8} />,
+      label: t("sessions:pokerTable.menuLabel"),
+      onClick: onOpenPokerTable,
+    },
   ] as const;
 
   return (
@@ -648,6 +657,7 @@ export interface ChatPanelPlusMenuProps {
   onNewProject: () => void;
   onNewWorkItem: () => void;
   onOpenSideChat: () => void;
+  onOpenPokerTable: () => void;
 }
 
 export function ChatPanelPlusMenu({
@@ -657,6 +667,7 @@ export function ChatPanelPlusMenu({
   onNewProject,
   onNewWorkItem,
   onOpenSideChat,
+  onOpenPokerTable,
 }: ChatPanelPlusMenuProps): React.ReactNode {
   const { t } = useTranslation("sessions");
   const [menuOpen, setMenuOpen] = useState(false);
@@ -673,6 +684,7 @@ export function ChatPanelPlusMenu({
           onNewProject={onNewProject}
           onNewWorkItem={onNewWorkItem}
           onOpenSideChat={onOpenSideChat}
+          onOpenPokerTable={onOpenPokerTable}
           onClose={closeMenu}
         />
       }

--- a/src/engines/ChatPanel/index.tsx
+++ b/src/engines/ChatPanel/index.tsx
@@ -62,6 +62,7 @@ import {
   chatPanelStartPageOpenAtom,
   chatWidthAtom,
 } from "@src/store/ui/chatPanelAtom";
+import { openPokerTableAtom } from "@src/store/ui/pokerTableAtom";
 import { openSideChatAtom } from "@src/store/ui/sideChatAtom";
 import type { WorkItemDraft } from "@src/store/workstation/projectManager";
 import { isHumanSession } from "@src/util/session/sessionDispatch";
@@ -394,6 +395,10 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
       // without leaving the active tab.
       openSideChat(null);
     }, [openSideChat]);
+    const openPokerTable = useSetAtom(openPokerTableAtom);
+    const handleOpenPokerTable = useCallback(() => {
+      openPokerTable();
+    }, [openPokerTable]);
 
     const handleChatPanelCollabOrgCreated = useCallback(
       (_result: CreatedOrgResult) => {
@@ -563,6 +568,7 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
         onNewProject={handleStartPageNewProject}
         onNewWorkItem={handleStartPageNewWorkItem}
         onOpenSideChat={handleOpenSideChat}
+        onOpenPokerTable={handleOpenPokerTable}
       />
     );
 

--- a/src/features/PokerTable/PokerTableController.test.ts
+++ b/src/features/PokerTable/PokerTableController.test.ts
@@ -197,6 +197,23 @@ describe("PokerTableController", () => {
     expect(listener).not.toHaveBeenCalled();
   });
 
+  it("leaves no timers or listeners behind after dispose", () => {
+    const { controller } = makeController();
+    const unsubscribe = controller.subscribe(() => {});
+    controller.start();
+    playHeroPassively(controller, 5_000);
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+    controller.dispose();
+    expect(vi.getTimerCount()).toBe(0);
+    // A late unsubscribe from React is harmless.
+    unsubscribe();
+    // And a stray call into a disposed controller schedules nothing.
+    controller.heroAct("fold");
+    controller.rebuy(1_000);
+    controller.dealNextHand();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
   it("applies a stakes change at the next hand", () => {
     const { controller } = makeController();
     controller.start();

--- a/src/features/PokerTable/PokerTableController.test.ts
+++ b/src/features/PokerTable/PokerTableController.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PokerTableController } from "./PokerTableController";
+import { createSeededRng } from "./engine/cards";
+import type { PokerPlayer } from "./engine/types";
+
+const HERO: PokerPlayer = {
+  id: "user:me",
+  name: "hours",
+  kind: "human",
+  avatarHue: 0,
+};
+const BLINDS = { smallBlind: 500, bigBlind: 1000 };
+
+function makeController(
+  overrides: Partial<ConstructorParameters<typeof PokerTableController>[0]> = {}
+) {
+  const bankrollLog: number[] = [];
+  const controller = new PokerTableController({
+    hero: HERO,
+    blinds: BLINDS,
+    buyIn: 100_000,
+    bankroll: 500_000,
+    speed: "fast",
+    rng: createSeededRng(42),
+    now: () => Date.now(),
+    onBankrollChange: (v) => bankrollLog.push(v),
+    ...overrides,
+  });
+  return { controller, bankrollLog };
+}
+
+/**
+ * Advance fake time while auto-answering the hero with a passive action
+ * (and re-buying when a calling station inevitably busts).
+ */
+function playHeroPassively(
+  controller: PokerTableController,
+  ms: number,
+  step = 50
+): void {
+  for (let elapsed = 0; elapsed < ms; elapsed += step) {
+    vi.advanceTimersByTime(step);
+    if (controller.getState().awaitingRebuy) controller.rebuy(100_000);
+    if (controller.isHeroToAct()) {
+      const legal = controller.getState().snapshot.legalActions;
+      if (legal?.actions.includes("check")) controller.heroAct("check");
+      else controller.heroAct("call");
+    }
+  }
+}
+
+describe("PokerTableController", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("seats hero + 5 bots, buys in from the bankroll and deals a hand", () => {
+    const { controller, bankrollLog } = makeController();
+    controller.start();
+    const state = controller.getState();
+    expect(bankrollLog).toEqual([400_000]);
+    expect(state.snapshot.seats.filter(Boolean)).toHaveLength(6);
+    expect(state.snapshot.seats[0]?.player.kind).toBe("human");
+    expect(state.snapshot.seats[1]?.player.kind).toBe("bot");
+    expect(state.snapshot.phase).toBe("idle");
+    vi.advanceTimersByTime(300);
+    expect(controller.getState().snapshot.phase).toBe("betting");
+    expect(controller.getState().snapshot.handNumber).toBe(1);
+    controller.dispose();
+  });
+
+  it("plays whole hands on its own when the hero only checks/calls", () => {
+    const { controller } = makeController();
+    controller.start();
+    playHeroPassively(controller, 60_000);
+    const state = controller.getState();
+    expect(state.snapshot.handNumber).toBeGreaterThan(3);
+    expect(state.handHistory.length).toBeGreaterThan(2);
+    // Every recorded hand paid out exactly its pot.
+    for (const entry of state.handHistory) {
+      const paid = entry.winners.reduce((sum, w) => sum + w.amount, 0);
+      expect(paid).toBe(entry.potTotal);
+    }
+    controller.dispose();
+  });
+
+  it("notifies subscribers on every state change", () => {
+    const { controller } = makeController();
+    const listener = vi.fn();
+    controller.subscribe(listener);
+    controller.start();
+    vi.advanceTimersByTime(2000);
+    expect(listener.mock.calls.length).toBeGreaterThan(2);
+    controller.dispose();
+  });
+
+  it("reveals a run-out board one street at a time", () => {
+    const { controller } = makeController({ botCount: 1 });
+    controller.start();
+    vi.advanceTimersByTime(300);
+    // Hero shoves preflop; the bot policy will call sooner or later across hands.
+    let sawStagedReveal = false;
+    let lastRevealed = 0;
+    for (
+      let elapsed = 0;
+      elapsed < 120_000 && !sawStagedReveal;
+      elapsed += 25
+    ) {
+      vi.advanceTimersByTime(25);
+      const state = controller.getState();
+      if (
+        state.snapshot.communityCards.length === 5 &&
+        state.revealedCommunity > lastRevealed
+      ) {
+        // Reached 5 dealt cards but the UI reveal count trails behind → staged.
+        if (state.revealedCommunity < 5) sawStagedReveal = true;
+      }
+      lastRevealed = state.revealedCommunity;
+      if (controller.isHeroToAct()) {
+        const legal = state.snapshot.legalActions;
+        if (legal?.chipRange && legal.actions.includes("raise")) {
+          controller.heroAct("raise", legal.chipRange.max);
+        } else if (legal?.chipRange && legal.actions.includes("bet")) {
+          controller.heroAct("bet", legal.chipRange.max);
+        } else {
+          controller.heroAct("call");
+        }
+      }
+    }
+    expect(sawStagedReveal).toBe(true);
+    controller.dispose();
+  });
+
+  it("pauses for a rebuy when the hero busts, then resumes", () => {
+    const { controller, bankrollLog } = makeController({
+      buyIn: 2_000,
+      botCount: 1,
+      // A bot that always calls: every hero shove is a coin flip.
+      decideBot: ({ legalActions }) => ({
+        action: legalActions.actions.includes("call")
+          ? "call"
+          : legalActions.actions.includes("check")
+            ? "check"
+            : "fold",
+      }),
+    });
+    controller.start();
+    // Shove every time; with a 2 BB stack the hero busts quickly.
+    let busted = false;
+    for (let elapsed = 0; elapsed < 300_000 && !busted; elapsed += 25) {
+      vi.advanceTimersByTime(25);
+      if (controller.getState().awaitingRebuy) busted = true;
+      else if (controller.isHeroToAct()) {
+        const legal = controller.getState().snapshot.legalActions;
+        if (
+          legal?.chipRange &&
+          (legal.actions.includes("raise") || legal.actions.includes("bet"))
+        ) {
+          controller.heroAct(
+            legal.actions.includes("raise") ? "raise" : "bet",
+            legal.chipRange.max
+          );
+        } else controller.heroAct("call");
+      }
+    }
+    expect(busted).toBe(true);
+    const handWhenBusted = controller.getState().snapshot.handNumber;
+    // Nothing moves while waiting.
+    vi.advanceTimersByTime(5_000);
+    expect(controller.getState().snapshot.handNumber).toBe(handWhenBusted);
+    controller.rebuy(50_000);
+    expect(controller.getState().awaitingRebuy).toBe(false);
+    expect(bankrollLog.at(-1)).toBe(500_000 - 2_000 - 50_000);
+    playHeroPassively(controller, 5_000);
+    expect(controller.getState().snapshot.handNumber).toBeGreaterThan(
+      handWhenBusted
+    );
+    controller.dispose();
+  });
+
+  it("returns the hero's stack to the bankroll on leave", () => {
+    const { controller, bankrollLog } = makeController();
+    controller.start();
+    const stack = controller.getState().snapshot.seats[0]?.stack ?? 0;
+    const returned = controller.leave();
+    expect(returned).toBe(stack);
+    expect(bankrollLog.at(-1)).toBe(500_000);
+    expect(controller.isDisposed()).toBe(true);
+    // No further ticks after leaving.
+    const listener = vi.fn();
+    controller.subscribe(listener);
+    vi.advanceTimersByTime(10_000);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("applies a stakes change at the next hand", () => {
+    const { controller } = makeController();
+    controller.start();
+    vi.advanceTimersByTime(300);
+    controller.setBlinds({ smallBlind: 2000, bigBlind: 4000 });
+    expect(controller.getState().snapshot.blinds.bigBlind).toBe(1000);
+    const hand = controller.getState().snapshot.handNumber;
+    playHeroPassively(controller, 30_000);
+    expect(controller.getState().snapshot.handNumber).toBeGreaterThan(hand);
+    expect(controller.getState().snapshot.blinds.bigBlind).toBe(4000);
+    controller.dispose();
+  });
+});

--- a/src/features/PokerTable/PokerTableController.ts
+++ b/src/features/PokerTable/PokerTableController.ts
@@ -1,0 +1,483 @@
+/**
+ * PokerTableController — runs a table over time.
+ *
+ * `PokerTableEngine` is synchronous and timing-free; this class owns the
+ * clock: it seats the human and five bots, deals hands, lets bots "think"
+ * for a moment before acting, reveals run-out streets one at a time, holds
+ * the showdown on screen, and starts the next hand. It also does the
+ * bookkeeping around a play-chip bankroll (buy-in, rebuy, cash-out) and
+ * keeps a short hand history for the panel's history drawer.
+ *
+ * It is a plain external store (`subscribe` / `getState`) so React reads
+ * it through `useSyncExternalStore`; timers and randomness are injectable
+ * so tests can drive it deterministically with fake timers.
+ */
+import { PokerTableEngine } from "./engine/PokerTableEngine";
+import { decideBotAction } from "./engine/botBrain";
+import type { Rng } from "./engine/cards";
+import { BOT_PERSONAS, findPersona, personaToPlayer } from "./engine/personas";
+import type {
+  Blinds,
+  HandResult,
+  PlayerAction,
+  PokerPlayer,
+  SeatAction,
+  TableSnapshot,
+} from "./engine/types";
+
+export type TableSpeed = "normal" | "fast";
+
+export interface HandHistoryEntry {
+  handNumber: number;
+  potTotal: number;
+  foldedOut: boolean;
+  winners: Array<{
+    seatIndex: number;
+    name: string;
+    amount: number;
+    handDescription: string | null;
+  }>;
+  /** Hero's stack change over the hand (negative when they lost). */
+  heroNet: number;
+}
+
+export interface PokerTableViewState {
+  snapshot: TableSnapshot;
+  heroSeat: number;
+  /** How many community cards the UI should show (progressive run-out reveal). */
+  revealedCommunity: number;
+  /** When the current actor started thinking; drives "Thinking · Ns". */
+  thinkingSince: number | null;
+  /** Hero lost their stack — waiting for a rebuy or a leave. */
+  awaitingRebuy: boolean;
+  bankroll: number;
+  handHistory: HandHistoryEntry[];
+  speed: TableSpeed;
+}
+
+export interface PokerTableControllerOptions {
+  hero: PokerPlayer;
+  blinds: Blinds;
+  buyIn: number;
+  bankroll: number;
+  onBankrollChange?: (bankroll: number) => void;
+  speed?: TableSpeed;
+  botCount?: number;
+  rng?: Rng;
+  now?: () => number;
+  scheduler?: {
+    setTimeout: (fn: () => void, ms: number) => unknown;
+    clearTimeout: (handle: unknown) => void;
+  };
+  /** Bot policy override (tests). */
+  decideBot?: typeof decideBotAction;
+}
+
+const HISTORY_LIMIT = 40;
+
+interface Delays {
+  botThinkMin: number;
+  botThinkMax: number;
+  deal: number;
+  showdownHold: number;
+  foldOutHold: number;
+  handStart: number;
+}
+
+const DELAYS: Record<TableSpeed, Delays> = {
+  normal: {
+    botThinkMin: 900,
+    botThinkMax: 2200,
+    deal: 650,
+    showdownHold: 4200,
+    foldOutHold: 1700,
+    handStart: 500,
+  },
+  fast: {
+    botThinkMin: 300,
+    botThinkMax: 750,
+    deal: 280,
+    showdownHold: 1800,
+    foldOutHold: 800,
+    handStart: 250,
+  },
+};
+
+export class PokerTableController {
+  private readonly engine: PokerTableEngine;
+  private readonly heroSeat = 0;
+  private readonly hero: PokerPlayer;
+  private readonly rng: Rng;
+  private readonly now: () => number;
+  private readonly scheduler: NonNullable<
+    PokerTableControllerOptions["scheduler"]
+  >;
+  private readonly decideBot: typeof decideBotAction;
+  private readonly onBankrollChange?: (bankroll: number) => void;
+  private readonly listeners = new Set<() => void>();
+  private readonly buyIn: number;
+  private readonly botCount: number;
+
+  private state: PokerTableViewState;
+  private timer: unknown = null;
+  private disposed = false;
+  private started = false;
+  private heroStackAtHandStart = 0;
+  private pendingBlinds: Blinds | null = null;
+  private personaCursor = 0;
+  private readonly personaOrder: string[];
+
+  constructor(options: PokerTableControllerOptions) {
+    this.hero = options.hero;
+    this.rng = options.rng ?? Math.random;
+    this.now = options.now ?? (() => Date.now());
+    this.scheduler = options.scheduler ?? {
+      setTimeout: (fn, ms) => globalThis.setTimeout(fn, ms),
+      clearTimeout: (handle) => globalThis.clearTimeout(handle as number),
+    };
+    this.decideBot = options.decideBot ?? decideBotAction;
+    this.onBankrollChange = options.onBankrollChange;
+    this.buyIn = options.buyIn;
+    this.botCount = Math.min(5, Math.max(1, options.botCount ?? 5));
+    this.engine = new PokerTableEngine(options.blinds);
+    this.personaOrder = shuffle(
+      BOT_PERSONAS.map((persona) => persona.id),
+      this.rng
+    );
+
+    this.state = {
+      snapshot: this.engine.snapshot(this.heroSeat),
+      heroSeat: this.heroSeat,
+      revealedCommunity: 0,
+      thinkingSince: null,
+      awaitingRebuy: false,
+      bankroll: options.bankroll,
+      handHistory: [],
+      speed: options.speed ?? "normal",
+    };
+  }
+
+  // ─── External store ─────────────────────────────────────────────────────
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  getState = (): PokerTableViewState => this.state;
+
+  private publish(patch: Partial<PokerTableViewState> = {}): void {
+    this.state = {
+      ...this.state,
+      ...patch,
+      snapshot: this.engine.snapshot(this.heroSeat),
+    };
+    this.listeners.forEach((listener) => listener());
+  }
+
+  // ─── Lifecycle ──────────────────────────────────────────────────────────
+
+  /** Seat everyone and deal the first hand. Idempotent. */
+  start(): void {
+    if (this.started || this.disposed) return;
+    this.started = true;
+    const buyIn = Math.min(this.buyIn, this.state.bankroll);
+    if (buyIn <= 0) {
+      // Nothing to play with — the UI offers a bankroll reset.
+      this.publish({ awaitingRebuy: true });
+      return;
+    }
+    this.setBankroll(this.state.bankroll - buyIn);
+    this.engine.sitDown(this.heroSeat, this.hero, buyIn);
+    for (let seat = 1; seat <= this.botCount; seat += 1) {
+      this.seatBot(seat);
+    }
+    this.publish();
+    this.schedule(() => this.advance(), DELAYS[this.state.speed].handStart);
+  }
+
+  /**
+   * Cash out and stop. Returns the chips returned to the bankroll — the
+   * stack behind; chips already in the pot mid-hand are forfeited, as when
+   * leaving a live table. The engine is abandoned with the table, so the
+   * hero is not formally unseated (which the rules engine forbids between
+   * streets anyway).
+   */
+  leave(): number {
+    if (this.disposed) return 0;
+    this.clearTimer();
+    const stack = this.engine.isSeated(this.heroSeat)
+      ? this.engine.stackOf(this.heroSeat)
+      : 0;
+    this.setBankroll(this.state.bankroll + stack);
+    this.disposed = true;
+    this.publish();
+    return stack;
+  }
+
+  dispose(): void {
+    if (!this.disposed) this.leave();
+    this.listeners.clear();
+  }
+
+  isDisposed(): boolean {
+    return this.disposed;
+  }
+
+  // ─── Hero input ─────────────────────────────────────────────────────────
+
+  /** Whether it is the human's turn right now. */
+  isHeroToAct(): boolean {
+    return !this.disposed && this.engine.playerToAct() === this.heroSeat;
+  }
+
+  heroAct(action: PlayerAction, amount?: number): void {
+    if (!this.isHeroToAct()) return;
+    const legal = this.engine.legalActions();
+    if (!legal || !legal.actions.includes(action)) return;
+    this.clearTimer();
+    this.engine.act(action, amount);
+    this.publish({ thinkingSince: null });
+    this.advance();
+  }
+
+  /** Put more chips in front of a busted hero. */
+  rebuy(amount: number = this.buyIn): void {
+    if (this.disposed || !this.state.awaitingRebuy) return;
+    const chips = Math.min(amount, this.state.bankroll);
+    if (chips <= 0) return;
+    this.setBankroll(this.state.bankroll - chips);
+    if (this.engine.isSeated(this.heroSeat)) {
+      this.engine.rebuy(this.heroSeat, chips);
+    } else {
+      this.engine.sitDown(this.heroSeat, this.hero, chips);
+    }
+    this.publish({ awaitingRebuy: false });
+    this.schedule(() => this.advance(), DELAYS[this.state.speed].handStart);
+  }
+
+  /** Free play chips: reset the bankroll (the table is not money). */
+  resetBankroll(chips: number): void {
+    if (this.disposed) return;
+    this.setBankroll(chips);
+    this.publish();
+  }
+
+  /** Stakes change takes effect at the next hand. */
+  setBlinds(blinds: Blinds): void {
+    if (this.disposed) return;
+    if (this.engine.isHandInProgress()) {
+      this.pendingBlinds = blinds;
+    } else {
+      this.engine.setBlinds(blinds);
+      this.publish();
+    }
+  }
+
+  setSpeed(speed: TableSpeed): void {
+    if (this.disposed || speed === this.state.speed) return;
+    this.publish({ speed });
+  }
+
+  /** Skip the post-hand hold and deal now. */
+  dealNextHand(): void {
+    if (this.disposed || this.engine.isHandInProgress()) return;
+    this.clearTimer();
+    this.advance();
+  }
+
+  // ─── Game loop ──────────────────────────────────────────────────────────
+
+  private advance(): void {
+    if (this.disposed) return;
+    const delays = DELAYS[this.state.speed];
+
+    if (!this.engine.isHandInProgress()) {
+      this.betweenHands();
+      return;
+    }
+
+    // Reveal community cards one street at a time — the rules engine deals
+    // the whole run-out at once when everyone is all-in.
+    const community = this.engine.communityCards().length;
+    if (this.state.revealedCommunity < community) {
+      const next =
+        this.state.revealedCommunity < 3
+          ? Math.min(3, community)
+          : this.state.revealedCommunity + 1;
+      this.publish({ revealedCommunity: next, thinkingSince: null });
+      this.schedule(() => this.advance(), delays.deal);
+      return;
+    }
+
+    if (this.engine.isBettingRoundInProgress()) {
+      const toAct = this.engine.playerToAct();
+      if (toAct === null) return;
+      this.publish({ thinkingSince: this.now() });
+      if (toAct === this.heroSeat) return; // wait for heroAct()
+      const wait = this.botThinkDelay(toAct);
+      this.schedule(() => {
+        this.botAct(toAct);
+        this.advance();
+      }, wait);
+      return;
+    }
+
+    if (this.engine.areBettingRoundsCompleted()) {
+      const result = this.engine.showdown();
+      this.recordHistory(result);
+      this.publish({ thinkingSince: null });
+      this.schedule(
+        () => this.advance(),
+        result.foldedOut ? delays.foldOutHold : delays.showdownHold
+      );
+      return;
+    }
+
+    this.engine.endBettingRound();
+    this.publish({ thinkingSince: null });
+    this.schedule(() => this.advance(), delays.deal);
+  }
+
+  private betweenHands(): void {
+    // Hero busted: pause until they rebuy or leave.
+    if (
+      this.engine.isSeated(this.heroSeat) &&
+      this.engine.isBusted(this.heroSeat)
+    ) {
+      this.publish({ awaitingRebuy: true, thinkingSince: null });
+      return;
+    }
+    if (!this.engine.isSeated(this.heroSeat)) return;
+
+    // Busted bots leave; a fresh persona takes the seat.
+    for (let seat = 1; seat <= this.botCount; seat += 1) {
+      if (this.engine.isSeated(seat) && this.engine.isBusted(seat)) {
+        this.engine.standUp(seat);
+      }
+      if (!this.engine.isSeated(seat)) this.seatBot(seat);
+    }
+
+    if (this.pendingBlinds) {
+      this.engine.setBlinds(this.pendingBlinds);
+      this.pendingBlinds = null;
+    }
+
+    this.engine.startHand();
+    this.heroStackAtHandStart = this.engine.stackOf(this.heroSeat);
+    this.publish({ revealedCommunity: 0, thinkingSince: null });
+    this.schedule(() => this.advance(), DELAYS[this.state.speed].handStart);
+  }
+
+  private botAct(seat: number): void {
+    if (this.engine.playerToAct() !== seat) return;
+    const player = this.engine.playerAt(seat);
+    const legalActions = this.engine.legalActions();
+    const holeCards = this.engine.holeCardsOf(seat);
+    if (!player || !legalActions || !holeCards) {
+      this.engine.act("fold");
+      return;
+    }
+    const snapshot = this.engine.snapshot(seat);
+    const own = snapshot.seats[seat];
+    const decision: SeatAction = this.decideBot({
+      holeCards,
+      communityCards: snapshot.communityCards,
+      street: snapshot.street ?? "preflop",
+      legalActions,
+      callAmount: snapshot.callAmount,
+      potTotal: snapshot.potTotal,
+      stack: own?.stack ?? 0,
+      betSize: own?.betSize ?? 0,
+      opponentsInHand: Math.max(1, this.engine.contendingSeats().length - 1),
+      bigBlind: this.engine.getBlinds().bigBlind,
+      style: findPersona(player.personaId).style,
+      rng: this.rng,
+    });
+    if (!legalActions.actions.includes(decision.action)) {
+      this.engine.act(
+        legalActions.actions.includes("check") ? "check" : "fold"
+      );
+      return;
+    }
+    this.engine.act(decision.action, decision.amount);
+  }
+
+  private botThinkDelay(seat: number): number {
+    const delays = DELAYS[this.state.speed];
+    const persona = findPersona(this.engine.playerAt(seat)?.personaId);
+    const base =
+      delays.botThinkMin +
+      this.rng() * (delays.botThinkMax - delays.botThinkMin);
+    // Hero out of the hand → nobody is waiting on the drama; speed up.
+    const heroInHand = this.engine.contendingSeats().includes(this.heroSeat);
+    return Math.round(base * persona.style.tempo * (heroInHand ? 1 : 0.45));
+  }
+
+  private seatBot(seat: number): void {
+    const personaId =
+      this.personaOrder[this.personaCursor % this.personaOrder.length];
+    this.personaCursor += 1;
+    const persona = findPersona(personaId);
+    const bigBlind = this.engine.getBlinds().bigBlind;
+    // 15–120 big blinds, like a real table's spread of stacks.
+    const stack = Math.round(bigBlind * (15 + this.rng() * 105));
+    this.engine.sitDown(seat, personaToPlayer(persona), stack);
+  }
+
+  private recordHistory(result: HandResult): void {
+    const heroNet =
+      this.engine.stackOf(this.heroSeat) - this.heroStackAtHandStart;
+    const entry: HandHistoryEntry = {
+      handNumber: result.handNumber,
+      potTotal: result.potTotal,
+      foldedOut: result.foldedOut,
+      heroNet,
+      winners: result.entries
+        .filter((e) => e.amountWon > 0)
+        .map((e) => ({
+          seatIndex: e.seatIndex,
+          name:
+            this.engine.playerAt(e.seatIndex)?.name ?? `seat ${e.seatIndex}`,
+          amount: e.amountWon,
+          handDescription: e.handDescription,
+        })),
+    };
+    this.state = {
+      ...this.state,
+      handHistory: [entry, ...this.state.handHistory].slice(0, HISTORY_LIMIT),
+    };
+  }
+
+  private setBankroll(bankroll: number): void {
+    const next = Math.max(0, Math.round(bankroll));
+    this.state = { ...this.state, bankroll: next };
+    this.onBankrollChange?.(next);
+  }
+
+  private schedule(fn: () => void, ms: number): void {
+    this.clearTimer();
+    this.timer = this.scheduler.setTimeout(() => {
+      this.timer = null;
+      fn();
+    }, ms);
+  }
+
+  private clearTimer(): void {
+    if (this.timer !== null) {
+      this.scheduler.clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+}
+
+function shuffle<T>(items: T[], rng: Rng): T[] {
+  const copy = items.slice();
+  for (let i = copy.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}

--- a/src/features/PokerTable/PokerTableController.ts
+++ b/src/features/PokerTable/PokerTableController.ts
@@ -139,7 +139,11 @@ export class PokerTableController {
     this.onBankrollChange = options.onBankrollChange;
     this.buyIn = options.buyIn;
     this.botCount = Math.min(5, Math.max(1, options.botCount ?? 5));
-    this.engine = new PokerTableEngine(options.blinds);
+    // Same rng for the deck as for the bots, so a seeded controller (tests)
+    // is fully deterministic; production leaves both on the CSPRNG default.
+    this.engine = new PokerTableEngine(options.blinds, {
+      rng: options.rng,
+    });
     this.personaOrder = shuffle(
       BOT_PERSONAS.map((persona) => persona.id),
       this.rng

--- a/src/features/PokerTable/PokerTableWindow.tsx
+++ b/src/features/PokerTable/PokerTableWindow.tsx
@@ -1,0 +1,155 @@
+/**
+ * PokerTableWindow — the floating poker table itself.
+ *
+ * Built on the same shell as the side chat: `FloatingWindow` (drag bounds +
+ * resize handles) with a draggable header. Phase-0 scope: the human vs.
+ * five bots at play-chip "token" stakes; nothing here touches any account
+ * — see `src/store/ui/pokerTableAtom.ts` for the ledger boundary.
+ *
+ * Loaded lazily by `./index.tsx` the first time the table is opened, so the
+ * engine, bots and `pokersolver` stay out of the main bundle. Closing the
+ * window is leaving the table: the hero's stack returns to the persisted
+ * bankroll and the table is discarded (see the controller).
+ */
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import React, { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import FloatingWindow from "@src/components/FloatingWindow";
+import {
+  POKER_DEFAULT_BANKROLL_CHIPS,
+  closePokerTableAtom,
+  pokerSettingsAtom,
+  stakesById,
+} from "@src/store/ui/pokerTableAtom";
+import { userAtom } from "@src/store/user/userAtom";
+
+import PokerActionBar from "./components/PokerActionBar";
+import PokerFelt from "./components/PokerFelt";
+import PokerHandHistory from "./components/PokerHandHistory";
+import PokerTableHeader from "./components/PokerTableHeader";
+import type { PlayerAction, PokerPlayer } from "./engine/types";
+import {
+  defaultBuyIn,
+  usePokerTableController,
+} from "./usePokerTableController";
+
+// Same bounds as the side chat (whole pane surface minus a 12px inset),
+// centred rather than bottom-right: the table wants room. z-[70] matches
+// the side chat; the two are siblings and either can be dragged aside.
+const POKER_OVERLAY_CLASS =
+  "pointer-events-none absolute inset-0 z-[70] flex items-center justify-center p-3";
+const POKER_SURFACE_CLASS =
+  "pointer-events-auto flex h-full max-h-[620px] min-h-[440px] w-[820px] max-w-full flex-col overflow-hidden rounded-[12px] border border-border-2 bg-bg-2 shadow-2xl";
+const POKER_MIN_WIDTH = 600;
+const POKER_MIN_HEIGHT = 440;
+const POKER_MAX_WIDTH = 1200;
+const POKER_MAX_HEIGHT = 820;
+
+const PokerTableWindow: React.FC = () => {
+  const { t } = useTranslation("sessions");
+  const closePokerTable = useSetAtom(closePokerTableAtom);
+  const [settings, setSettings] = useAtom(pokerSettingsAtom);
+  const user = useAtomValue(userAtom);
+  const [historyOpen, setHistoryOpen] = useState(false);
+
+  const hero = useMemo<PokerPlayer>(
+    () => ({
+      id: `user:${user.uuid || "local"}`,
+      name: user.name?.trim() || t("pokerTable.seat.you"),
+      kind: "human",
+      avatarHue: 212,
+    }),
+    // The hero identity is fixed for the life of the table.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
+  const { controller, state } = usePokerTableController(hero);
+  const stakes = stakesById(settings.stakesId);
+  const buyIn = defaultBuyIn(stakes.bigBlind);
+
+  const handleAct = useCallback(
+    (action: PlayerAction, amount?: number) =>
+      controller.heroAct(action, amount),
+    [controller]
+  );
+  const handleRebuy = useCallback(
+    (amount: number) => controller.rebuy(amount),
+    [controller]
+  );
+  const handleResetBankroll = useCallback(() => {
+    controller.resetBankroll(POKER_DEFAULT_BANKROLL_CHIPS);
+    controller.rebuy(buyIn);
+  }, [buyIn, controller]);
+  const handleDealNext = useCallback(
+    () => controller.dealNextHand(),
+    [controller]
+  );
+  const handleLeave = useCallback(() => {
+    // Leaving cashes out through the controller's dispose (unmount).
+    closePokerTable();
+  }, [closePokerTable]);
+
+  return (
+    <FloatingWindow
+      overlayClassName={POKER_OVERLAY_CLASS}
+      surfaceClassName={POKER_SURFACE_CLASS}
+      minWidth={POKER_MIN_WIDTH}
+      minHeight={POKER_MIN_HEIGHT}
+      maxWidth={POKER_MAX_WIDTH}
+      maxHeight={POKER_MAX_HEIGHT}
+    >
+      <PokerTableHeader
+        blinds={state.snapshot.blinds}
+        handNumber={state.snapshot.handNumber}
+        settings={settings}
+        historyOpen={historyOpen}
+        onToggleHistory={() => setHistoryOpen((open) => !open)}
+        onChangeStakes={(stakesId) =>
+          setSettings((prev) => ({ ...prev, stakesId }))
+        }
+        onChangeSpeed={(speed) => setSettings((prev) => ({ ...prev, speed }))}
+        onLeave={handleLeave}
+        onClose={handleLeave}
+      />
+      <div className="relative flex min-h-0 flex-1">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+          <div className="min-h-0 flex-1">
+            <PokerFelt
+              snapshot={state.snapshot}
+              heroSeat={state.heroSeat}
+              revealedCommunity={state.revealedCommunity}
+              thinkingSince={state.thinkingSince}
+            />
+          </div>
+          <div className="shrink-0 border-t border-border-2">
+            <PokerActionBar
+              snapshot={state.snapshot}
+              heroSeat={state.heroSeat}
+              awaitingRebuy={state.awaitingRebuy}
+              bankroll={state.bankroll}
+              buyIn={buyIn}
+              onAct={handleAct}
+              onRebuy={handleRebuy}
+              onResetBankroll={handleResetBankroll}
+              onDealNext={handleDealNext}
+            />
+          </div>
+        </div>
+        {historyOpen && (
+          <aside className="flex w-[240px] shrink-0 flex-col border-l border-border-2 bg-bg-2">
+            <div className="flex h-8 shrink-0 items-center px-3 text-[12px] font-medium text-text-2">
+              {t("pokerTable.history.title")}
+            </div>
+            <div className="min-h-0 flex-1">
+              <PokerHandHistory entries={state.handHistory} />
+            </div>
+          </aside>
+        )}
+      </div>
+    </FloatingWindow>
+  );
+};
+
+export default PokerTableWindow;

--- a/src/features/PokerTable/components/PlayingCard.tsx
+++ b/src/features/PokerTable/components/PlayingCard.tsx
@@ -1,0 +1,92 @@
+/**
+ * A playing card: face-up (rank + suit pip, red/black) or face-down
+ * (patterned back). Pure presentational; sizes are fixed steps so seats
+ * and the board line up.
+ */
+import React from "react";
+
+import type { Card } from "../engine/cards";
+
+export type CardSize = "sm" | "md" | "lg";
+
+const SIZE_CLASS: Record<CardSize, string> = {
+  sm: "h-[34px] w-[24px] rounded-[4px] text-[11px]",
+  md: "h-[52px] w-[38px] rounded-[6px] text-[15px]",
+  lg: "h-[70px] w-[50px] rounded-[8px] text-[20px]",
+};
+
+const SUIT_GLYPH: Record<Card["suit"], string> = {
+  clubs: "♣",
+  diamonds: "♦",
+  hearts: "♥",
+  spades: "♠",
+};
+
+const RANK_LABEL: Record<Card["rank"], string> = {
+  "2": "2",
+  "3": "3",
+  "4": "4",
+  "5": "5",
+  "6": "6",
+  "7": "7",
+  "8": "8",
+  "9": "9",
+  T: "10",
+  J: "J",
+  Q: "Q",
+  K: "K",
+  A: "A",
+};
+
+export interface PlayingCardProps {
+  /** Face-up when given; face-down when omitted. */
+  card?: Card | null;
+  size?: CardSize;
+  className?: string;
+  /** Dimmed placeholder slot (undealt board card). */
+  placeholder?: boolean;
+}
+
+const PlayingCard: React.FC<PlayingCardProps> = ({
+  card,
+  size = "md",
+  className = "",
+  placeholder = false,
+}) => {
+  const base = `${SIZE_CLASS[size]} relative shrink-0 select-none border ${className}`;
+  if (placeholder) {
+    return (
+      <div
+        aria-hidden
+        className={`${base} border-dashed border-border-2 bg-transparent`}
+      />
+    );
+  }
+  if (!card) {
+    return (
+      <div
+        aria-label="face-down card"
+        className={`${base} flex items-center justify-center border-border-2 bg-bg-1 shadow-sm`}
+      >
+        <div className="flex h-[78%] w-[76%] items-center justify-center rounded-[3px] bg-fill-2 text-text-4">
+          <span className="text-[0.9em] leading-none">♠</span>
+        </div>
+      </div>
+    );
+  }
+  const red = card.suit === "hearts" || card.suit === "diamonds";
+  const tone = red ? "text-danger-6" : "text-text-1";
+  return (
+    <div
+      aria-label={`${RANK_LABEL[card.rank]} of ${card.suit}`}
+      className={`${base} flex flex-col justify-between border-border-2 bg-white p-[3px] shadow-sm ${tone}`}
+    >
+      <span className="font-semibold leading-none">
+        {RANK_LABEL[card.rank]}
+      </span>
+      <span className="self-end leading-none">{SUIT_GLYPH[card.suit]}</span>
+    </div>
+  );
+};
+
+export default PlayingCard;

--- a/src/features/PokerTable/components/PokerActionBar.tsx
+++ b/src/features/PokerTable/components/PokerActionBar.tsx
@@ -1,0 +1,245 @@
+/**
+ * Bottom strip of the table: bet sizing (pot-fraction presets + slider +
+ * amount) and the Fold / Call / Bet buttons when it is the hero's turn;
+ * otherwise a status line, the rebuy prompt, or "deal next hand".
+ */
+import React, { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import Button from "@src/components/Button";
+import Slider from "@src/components/Slider";
+
+import type { PlayerAction, TableSnapshot } from "../engine/types";
+import { formatChips } from "../format";
+
+const POT_PRESETS = [0.25, 0.33, 0.75, 1.33] as const;
+
+export interface PokerActionBarProps {
+  snapshot: TableSnapshot;
+  heroSeat: number;
+  awaitingRebuy: boolean;
+  bankroll: number;
+  buyIn: number;
+  onAct: (action: PlayerAction, amount?: number) => void;
+  onRebuy: (amount: number) => void;
+  onResetBankroll: () => void;
+  onDealNext: () => void;
+}
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+const PokerActionBar: React.FC<PokerActionBarProps> = ({
+  snapshot,
+  heroSeat,
+  awaitingRebuy,
+  bankroll,
+  buyIn,
+  onAct,
+  onRebuy,
+  onResetBankroll,
+  onDealNext,
+}) => {
+  const { t } = useTranslation("sessions");
+  const heroToAct =
+    snapshot.toAct === heroSeat && snapshot.legalActions !== null;
+  const legal = heroToAct ? snapshot.legalActions : null;
+  const range = legal?.chipRange ?? null;
+  const hero = snapshot.seats[heroSeat];
+  const aggressive: PlayerAction | null = legal?.actions.includes("raise")
+    ? "raise"
+    : legal?.actions.includes("bet")
+      ? "bet"
+      : null;
+  const step = Math.max(1, Math.round(snapshot.blinds.bigBlind / 10));
+
+  const [amount, setAmount] = useState<number>(range?.min ?? 0);
+  // New decision → reset the sizing to the minimum legal bet.
+  const decisionKey = `${snapshot.handNumber}:${snapshot.street}:${range?.min}:${range?.max}:${snapshot.potTotal}`;
+  useEffect(() => {
+    if (range) setAmount(range.min);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [decisionKey]);
+
+  const presetAmount = (fraction: number): number => {
+    if (!range || !hero) return 0;
+    // Pot-fraction sizing after calling: (pot + call) × fraction, expressed
+    // as a total street bet.
+    const potAfterCall = snapshot.potTotal + snapshot.callAmount;
+    const target = hero.betSize + snapshot.callAmount + potAfterCall * fraction;
+    return clamp(Math.round(target / step) * step, range.min, range.max);
+  };
+
+  const activePreset = useMemo(
+    () =>
+      POT_PRESETS.find((fraction) => presetAmount(fraction) === amount) ?? null,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [amount, decisionKey]
+  );
+
+  const isAllIn = range !== null && amount >= range.max;
+
+  if (awaitingRebuy) {
+    const canBuy = bankroll > 0;
+    const stake = Math.min(buyIn, bankroll);
+    return (
+      <div className="flex flex-col items-center gap-2 px-4 py-3">
+        <span className="text-[12px] text-text-2">
+          {t("pokerTable.rebuy.title")}{" "}
+          <span className="text-text-3">
+            {t("pokerTable.rebuy.bankroll", { amount: formatChips(bankroll) })}
+          </span>
+        </span>
+        <div className="flex items-center gap-2">
+          {canBuy ? (
+            <Button
+              variant="primary"
+              size="small"
+              shape="round"
+              onClick={() => onRebuy(stake)}
+            >
+              {t("pokerTable.rebuy.buyIn", { amount: formatChips(stake) })}
+            </Button>
+          ) : (
+            <Button
+              variant="primary"
+              size="small"
+              shape="round"
+              onClick={onResetBankroll}
+            >
+              {t("pokerTable.rebuy.reset")}
+            </Button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (!heroToAct) {
+    const actor =
+      snapshot.toAct !== null ? snapshot.seats[snapshot.toAct] : null;
+    return (
+      <div className="flex h-[92px] flex-col items-center justify-center gap-2 px-4">
+        {snapshot.phase === "hand-complete" ? (
+          <Button
+            variant="secondary"
+            appearance="outline"
+            size="small"
+            shape="round"
+            onClick={onDealNext}
+          >
+            {t("pokerTable.nextHand")}
+          </Button>
+        ) : actor ? (
+          <span className="text-[12px] text-text-3">
+            {t("pokerTable.waitingFor", { name: actor.player.name })}
+          </span>
+        ) : (
+          <span className="text-[12px] text-text-3">
+            {t("pokerTable.dealing")}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex flex-col items-center gap-2 px-4 py-2"
+      data-testid="poker-action-bar"
+    >
+      {range && (
+        <div className="flex w-full max-w-[560px] items-center gap-2 rounded-full border border-border-2 bg-bg-1 py-1 pl-1 pr-3 shadow-sm">
+          <div className="flex items-center gap-0.5">
+            {POT_PRESETS.map((fraction) => (
+              <button
+                key={fraction}
+                type="button"
+                className={`rounded-full px-2 py-1 text-[11px] transition-colors ${
+                  activePreset === fraction
+                    ? "bg-fill-2 font-medium text-text-1"
+                    : "text-text-3 hover:bg-fill-1 hover:text-text-1"
+                }`}
+                onClick={() => setAmount(presetAmount(fraction))}
+              >
+                {Math.round(fraction * 100)}%
+              </button>
+            ))}
+          </div>
+          <div className="min-w-0 flex-1 px-1">
+            <Slider
+              min={range.min}
+              max={range.max}
+              step={step}
+              value={amount}
+              onChange={(value) =>
+                setAmount(
+                  clamp(
+                    typeof value === "number" ? value : value[0],
+                    range.min,
+                    range.max
+                  )
+                )
+              }
+            />
+          </div>
+          <span className="whitespace-nowrap text-[12px] font-medium text-text-1">
+            {t("pokerTable.tokens", { amount: formatChips(amount) })}
+          </span>
+        </div>
+      )}
+      <div className="flex items-center gap-2">
+        <Button
+          variant="secondary"
+          appearance="outline"
+          size="small"
+          shape="round"
+          onClick={() => onAct("fold")}
+        >
+          {t("pokerTable.actions.fold")}
+        </Button>
+        {legal?.actions.includes("check") ? (
+          <Button
+            variant="secondary"
+            appearance="outline"
+            size="small"
+            shape="round"
+            onClick={() => onAct("check")}
+          >
+            {t("pokerTable.actions.check")}
+          </Button>
+        ) : (
+          <Button
+            variant="secondary"
+            appearance="outline"
+            size="small"
+            shape="round"
+            onClick={() => onAct("call")}
+          >
+            {t("pokerTable.actions.call", {
+              amount: formatChips(snapshot.callAmount),
+            })}
+          </Button>
+        )}
+        {aggressive && range && (
+          <Button
+            variant="primary"
+            size="small"
+            shape="round"
+            onClick={() => onAct(aggressive, amount)}
+          >
+            {isAllIn
+              ? t("pokerTable.actions.allIn", { amount: formatChips(amount) })
+              : aggressive === "bet"
+                ? t("pokerTable.actions.bet", { amount: formatChips(amount) })
+                : t("pokerTable.actions.raise", {
+                    amount: formatChips(amount),
+                  })}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PokerActionBar;

--- a/src/features/PokerTable/components/PokerActionBar.tsx
+++ b/src/features/PokerTable/components/PokerActionBar.tsx
@@ -29,6 +29,10 @@ export interface PokerActionBarProps {
 const clamp = (value: number, min: number, max: number): number =>
   Math.min(max, Math.max(min, value));
 
+/** Every state of the bar keeps this height so the felt never jumps. */
+const BAR_CLASS =
+  "flex h-[92px] flex-col items-center justify-center gap-2 px-4";
+
 const PokerActionBar: React.FC<PokerActionBarProps> = ({
   snapshot,
   heroSeat,
@@ -83,14 +87,11 @@ const PokerActionBar: React.FC<PokerActionBarProps> = ({
     const canBuy = bankroll > 0;
     const stake = Math.min(buyIn, bankroll);
     return (
-      <div className="flex flex-col items-center gap-2 px-4 py-3">
+      <div className={BAR_CLASS}>
         <span className="text-[12px] text-text-2">
-          {t("pokerTable.rebuy.title")}{" "}
-          <span className="text-text-3">
-            {t("pokerTable.rebuy.bankroll", { amount: formatChips(bankroll) })}
-          </span>
+          {t("pokerTable.rebuy.title")}
         </span>
-        <div className="flex items-center gap-2">
+        <div className="relative flex w-full items-center justify-center gap-2">
           {canBuy ? (
             <Button
               variant="primary"
@@ -119,7 +120,7 @@ const PokerActionBar: React.FC<PokerActionBarProps> = ({
     const actor =
       snapshot.toAct !== null ? snapshot.seats[snapshot.toAct] : null;
     return (
-      <div className="flex h-[92px] flex-col items-center justify-center gap-2 px-4">
+      <div className={BAR_CLASS}>
         {snapshot.phase === "hand-complete" ? (
           <Button
             variant="secondary"
@@ -144,13 +145,10 @@ const PokerActionBar: React.FC<PokerActionBarProps> = ({
   }
 
   return (
-    <div
-      className="flex flex-col items-center gap-2 px-4 py-2"
-      data-testid="poker-action-bar"
-    >
+    <div className={BAR_CLASS} data-testid="poker-action-bar">
       {range && (
-        <div className="flex w-full max-w-[560px] items-center gap-2 rounded-full border border-border-2 bg-bg-1 py-1 pl-1 pr-3 shadow-sm">
-          <div className="flex items-center gap-0.5">
+        <div className="flex w-full max-w-[560px] items-center gap-3 py-0.5">
+          <div className="flex shrink-0 items-center gap-0.5">
             {POT_PRESETS.map((fraction) => (
               <button
                 key={fraction}
@@ -166,8 +164,10 @@ const PokerActionBar: React.FC<PokerActionBarProps> = ({
               </button>
             ))}
           </div>
-          <div className="min-w-0 flex-1 px-1">
+          <div className="flex min-w-0 flex-1 items-center">
             <Slider
+              className="w-full"
+              noPadding
               min={range.min}
               max={range.max}
               step={step}
@@ -183,12 +183,12 @@ const PokerActionBar: React.FC<PokerActionBarProps> = ({
               }
             />
           </div>
-          <span className="whitespace-nowrap text-[12px] font-medium text-text-1">
+          <span className="shrink-0 whitespace-nowrap text-[12px] font-medium text-text-1">
             {t("pokerTable.tokens", { amount: formatChips(amount) })}
           </span>
         </div>
       )}
-      <div className="flex items-center gap-2">
+      <div className="relative flex w-full items-center justify-center gap-2">
         <Button
           variant="secondary"
           appearance="outline"

--- a/src/features/PokerTable/components/PokerFelt.tsx
+++ b/src/features/PokerTable/components/PokerFelt.tsx
@@ -104,7 +104,13 @@ const PokerFelt: React.FC<PokerFeltProps> = ({
                 size="md"
               />
             ) : (
-              <PlayingCard key={`slot-${index}`} size="md" placeholder />
+              // Undealt slot: a face-down card, like the mock (dimmed so
+              // the dealt board reads first).
+              <PlayingCard
+                key={`slot-${index}`}
+                size="md"
+                className="opacity-60"
+              />
             );
           })}
         </div>

--- a/src/features/PokerTable/components/PokerFelt.tsx
+++ b/src/features/PokerTable/components/PokerFelt.tsx
@@ -77,10 +77,10 @@ const PokerFelt: React.FC<PokerFeltProps> = ({
       className="relative h-full min-h-[300px] w-full"
       data-testid="poker-felt"
     >
-      {/* Oval */}
+      {/* Felt: rounded rectangle with a large radius (stadium ends), like the mock */}
       <div
         aria-hidden
-        className="absolute bottom-[17%] left-[9%] right-[9%] top-[14%] rounded-[50%] border border-border-1 bg-fill-1"
+        className="absolute bottom-[17%] left-[9%] right-[9%] top-[14%] rounded-[200px] border border-border-1 bg-fill-1"
       />
 
       {/* Centre: pot + board + result */}

--- a/src/features/PokerTable/components/PokerFelt.tsx
+++ b/src/features/PokerTable/components/PokerFelt.tsx
@@ -1,0 +1,159 @@
+/**
+ * The felt: an oval table with six seat slots around it, the community
+ * cards and pot in the middle, and the hand result line. The hero always
+ * sits bottom-centre; other seats rotate around them.
+ */
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import type { TableSnapshot } from "../engine/types";
+import { formatChips } from "../format";
+import PlayingCard from "./PlayingCard";
+import PokerSeat from "./PokerSeat";
+
+/** Seat slot positions in % of the felt box; slot 0 is the hero. */
+const SLOTS: ReadonlyArray<{ x: number; y: number }> = [
+  { x: 50, y: 80 },
+  { x: 14, y: 62 },
+  { x: 21, y: 24 },
+  { x: 50, y: 11 },
+  { x: 79, y: 24 },
+  { x: 86, y: 62 },
+];
+
+const CENTER = { x: 50, y: 47 };
+
+function towardCenter(slot: { x: number; y: number }): {
+  x: number;
+  y: number;
+} {
+  const dx = CENTER.x - slot.x;
+  const dy = CENTER.y - slot.y;
+  const length = Math.hypot(dx, dy) || 1;
+  return { x: dx / length, y: dy / length };
+}
+
+export interface PokerFeltProps {
+  snapshot: TableSnapshot;
+  heroSeat: number;
+  revealedCommunity: number;
+  thinkingSince: number | null;
+}
+
+const PokerFelt: React.FC<PokerFeltProps> = ({
+  snapshot,
+  heroSeat,
+  revealedCommunity,
+  thinkingSince,
+}) => {
+  const { t } = useTranslation("sessions");
+  const seatCount = snapshot.seats.length;
+  const result =
+    snapshot.phase === "hand-complete" ? snapshot.lastResult : null;
+  const wonBySeat = new Map<number, number>();
+  const descriptionBySeat = new Map<number, string | null>();
+  result?.entries.forEach((entry) => {
+    wonBySeat.set(entry.seatIndex, entry.amountWon);
+    descriptionBySeat.set(entry.seatIndex, entry.handDescription);
+  });
+  const winners = result
+    ? result.entries
+        .filter((entry) => entry.amountWon > 0)
+        .map((entry) => ({
+          name: snapshot.seats[entry.seatIndex]?.player.name ?? "",
+          amount: entry.amountWon,
+          description: entry.handDescription,
+        }))
+    : [];
+
+  const board = snapshot.communityCards;
+  const visibleBoard =
+    snapshot.phase === "hand-complete"
+      ? board.length
+      : Math.min(revealedCommunity, board.length);
+
+  return (
+    <div
+      className="relative h-full min-h-[300px] w-full"
+      data-testid="poker-felt"
+    >
+      {/* Oval */}
+      <div
+        aria-hidden
+        className="absolute bottom-[17%] left-[9%] right-[9%] top-[14%] rounded-[50%] border border-border-1 bg-fill-1"
+      />
+
+      {/* Centre: pot + board + result */}
+      <div
+        className="absolute flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-2"
+        style={{ left: `${CENTER.x}%`, top: `${CENTER.y}%` }}
+      >
+        <span className="rounded-full border border-border-2 bg-bg-1 px-2.5 py-0.5 text-[11px] text-text-2 shadow-sm">
+          <span className="text-text-3">{t("pokerTable.potLabel")}</span>{" "}
+          <span className="font-medium text-text-1">
+            {t("pokerTable.tokens", { amount: formatChips(snapshot.potTotal) })}
+          </span>
+        </span>
+        <div className="flex gap-1.5">
+          {Array.from({ length: 5 }, (_, index) => {
+            const card = index < visibleBoard ? board[index] : null;
+            return card ? (
+              <PlayingCard
+                key={`${card.rank}${card.suit}`}
+                card={card}
+                size="md"
+              />
+            ) : (
+              <PlayingCard key={`slot-${index}`} size="md" placeholder />
+            );
+          })}
+        </div>
+        <div className="flex h-5 items-center">
+          {winners.length > 0 && (
+            <span className="whitespace-nowrap rounded-full bg-success-1 px-2.5 py-0.5 text-[11px] font-medium text-success-6">
+              {winners
+                .map((winner) =>
+                  winner.description
+                    ? t("pokerTable.result.winsWith", {
+                        name: winner.name,
+                        amount: formatChips(winner.amount),
+                        hand: winner.description,
+                      })
+                    : t("pokerTable.result.wins", {
+                        name: winner.name,
+                        amount: formatChips(winner.amount),
+                      })
+                )
+                .join(" · ")}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Seats */}
+      {snapshot.seats.map((seat, index) => {
+        if (!seat) return null;
+        const slot =
+          SLOTS[(index - heroSeat + seatCount) % seatCount] ?? SLOTS[0];
+        return (
+          <div
+            key={seat.player.id}
+            className="absolute -translate-x-1/2 -translate-y-1/2"
+            style={{ left: `${slot.x}%`, top: `${slot.y}%` }}
+          >
+            <PokerSeat
+              seat={seat}
+              isHero={index === heroSeat}
+              wonAmount={wonBySeat.get(index) ?? 0}
+              handDescription={descriptionBySeat.get(index) ?? null}
+              thinkingSince={thinkingSince}
+              towardCenter={towardCenter(slot)}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default PokerFelt;

--- a/src/features/PokerTable/components/PokerHandHistory.tsx
+++ b/src/features/PokerTable/components/PokerHandHistory.tsx
@@ -1,0 +1,78 @@
+/**
+ * Slide-over list of recent hands: number, pot, winner(s) and the hero's
+ * net for the hand. Read-only; the controller keeps the last 40.
+ */
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import type { HandHistoryEntry } from "../PokerTableController";
+import { formatChips } from "../format";
+
+export interface PokerHandHistoryProps {
+  entries: HandHistoryEntry[];
+}
+
+const PokerHandHistory: React.FC<PokerHandHistoryProps> = ({ entries }) => {
+  const { t } = useTranslation("sessions");
+  if (entries.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-[12px] text-text-3">
+        {t("pokerTable.history.empty")}
+      </div>
+    );
+  }
+  return (
+    <ul className="flex h-full flex-col gap-1 overflow-y-auto px-2 py-2">
+      {entries.map((entry) => {
+        const net = entry.heroNet;
+        const netTone =
+          net > 0
+            ? "text-success-6"
+            : net < 0
+              ? "text-danger-6"
+              : "text-text-3";
+        return (
+          <li
+            key={entry.handNumber}
+            className="flex flex-col gap-0.5 rounded-[8px] border border-border-2 bg-bg-1 px-2.5 py-1.5"
+          >
+            <div className="flex items-center justify-between text-[11px]">
+              <span className="text-text-3">
+                {t("pokerTable.header.hand", { number: entry.handNumber })}
+              </span>
+              <span className={`font-medium ${netTone}`}>
+                {net === 0
+                  ? "0"
+                  : `${net > 0 ? "+" : "−"}${formatChips(Math.abs(net))}`}
+              </span>
+            </div>
+            <div className="text-[12px] text-text-1">
+              {entry.winners
+                .map((winner) =>
+                  winner.handDescription
+                    ? t("pokerTable.result.winsWith", {
+                        name: winner.name,
+                        amount: formatChips(winner.amount),
+                        hand: winner.handDescription,
+                      })
+                    : t("pokerTable.result.wins", {
+                        name: winner.name,
+                        amount: formatChips(winner.amount),
+                      })
+                )
+                .join(" · ")}
+              {entry.foldedOut && (
+                <span className="text-text-3">
+                  {" "}
+                  · {t("pokerTable.history.foldedOut")}
+                </span>
+              )}
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+export default PokerHandHistory;

--- a/src/features/PokerTable/components/PokerSeat.tsx
+++ b/src/features/PokerTable/components/PokerSeat.tsx
@@ -1,0 +1,168 @@
+/**
+ * One seat around the felt: avatar pill (name + stack), the seat's hole
+ * cards above it, dealer button, current-street bet pill toward the pot,
+ * and the "Thinking · Ns" indicator under the acting seat.
+ */
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import type { SeatSnapshot } from "../engine/types";
+import { formatChips } from "../format";
+import PlayingCard from "./PlayingCard";
+import ThinkingIndicator from "./ThinkingIndicator";
+
+export interface PokerSeatProps {
+  seat: SeatSnapshot;
+  isHero: boolean;
+  /** Won chips in the last result (highlight + amount). */
+  wonAmount?: number;
+  handDescription?: string | null;
+  thinkingSince: number | null;
+  /** Unit vector from this seat toward the table centre (for the bet pill). */
+  towardCenter: { x: number; y: number };
+}
+
+function initialOf(name: string): string {
+  const trimmed = name.trim();
+  return trimmed ? trimmed[0].toUpperCase() : "?";
+}
+
+const PokerSeat: React.FC<PokerSeatProps> = ({
+  seat,
+  isHero,
+  wonAmount = 0,
+  handDescription,
+  thinkingSince,
+  towardCenter,
+}) => {
+  const { t } = useTranslation("sessions");
+  const folded =
+    seat.lastAction?.action === "fold" || (!seat.inHand && seat.hasCards);
+  const dim = folded ? "opacity-50" : "";
+  const ring = seat.isToAct
+    ? "ring-2 ring-primary-6"
+    : wonAmount > 0
+      ? "ring-2 ring-success-6"
+      : "";
+  const showFaceUp = seat.holeCards && seat.holeCards.length > 0;
+  const showFaceDown = !showFaceUp && seat.hasCards;
+  const cardSize = isHero ? "lg" : "sm";
+  const betPillOffset = {
+    left: `calc(50% + ${towardCenter.x * 78}px)`,
+    top: `calc(50% + ${towardCenter.y * 62}px)`,
+  };
+
+  return (
+    <div className="relative flex flex-col items-center">
+      {/* Hole cards */}
+      <div
+        className={`mb-[-10px] flex ${isHero ? "gap-1" : "gap-0"} ${dim}`}
+        style={{ minHeight: isHero ? 70 : 34 }}
+      >
+        {showFaceUp &&
+          seat.holeCards!.map((card, index) => (
+            <PlayingCard
+              key={`${card.rank}${card.suit}`}
+              card={card}
+              size={cardSize}
+              className={
+                index === 1 && !isHero
+                  ? "-ml-2 rotate-6"
+                  : !isHero
+                    ? "-rotate-6"
+                    : ""
+              }
+            />
+          ))}
+        {showFaceDown && (
+          <>
+            <PlayingCard size={cardSize} className="-rotate-6" />
+            <PlayingCard size={cardSize} className="-ml-2 rotate-6" />
+          </>
+        )}
+      </div>
+
+      {/* Seat pill */}
+      <div
+        className={`relative z-10 flex items-center gap-2 rounded-full border border-border-2 bg-bg-1 py-1 pl-1 pr-3 shadow-sm ${ring} ${dim}`}
+        data-testid={`poker-seat-${seat.seatIndex}`}
+      >
+        <span
+          aria-hidden
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-[12px] font-semibold text-white"
+          style={{
+            background: `hsl(${seat.player.avatarHue} 55% 48%)`,
+          }}
+        >
+          {initialOf(seat.player.name)}
+        </span>
+        <span className="flex min-w-0 flex-col leading-tight">
+          <span className="flex items-center gap-1 text-[12px] font-medium text-text-1">
+            <span className="truncate">{seat.player.name}</span>
+            {seat.player.kind === "bot" && (
+              <span className="rounded-full bg-fill-2 px-1 text-[9px] font-medium uppercase tracking-wide text-text-3">
+                {t("pokerTable.seat.bot")}
+              </span>
+            )}
+          </span>
+          <span className="text-[11px] text-text-3">
+            {seat.isAllIn
+              ? t("pokerTable.seat.allIn")
+              : t("pokerTable.tokens", { amount: formatChips(seat.stack) })}
+          </span>
+        </span>
+        {seat.isDealer && (
+          <span
+            aria-label="dealer"
+            className="absolute -right-2 -top-1 flex h-[18px] w-[18px] items-center justify-center rounded-full bg-text-1 text-[10px] font-bold text-bg-1 shadow"
+          >
+            D
+          </span>
+        )}
+      </div>
+
+      {/* Bet pill (toward the pot) */}
+      {seat.betSize > 0 && (
+        <span
+          className="absolute z-20 -translate-x-1/2 -translate-y-1/2 whitespace-nowrap rounded-full border border-border-2 bg-bg-1 px-2 py-0.5 text-[11px] text-text-2 shadow-sm"
+          style={betPillOffset}
+        >
+          <span className="text-text-3">
+            {seat.lastAction?.action === "call"
+              ? t("pokerTable.actions.callLabel")
+              : seat.lastAction?.action === "raise"
+                ? t("pokerTable.actions.raiseLabel")
+                : t("pokerTable.actions.betLabel")}
+          </span>{" "}
+          <span className="font-medium text-text-1">
+            {formatChips(seat.betSize)}
+          </span>
+        </span>
+      )}
+      {seat.betSize === 0 &&
+        seat.lastAction?.action === "check" &&
+        seat.inHand && (
+          <span
+            className="absolute z-20 -translate-x-1/2 -translate-y-1/2 whitespace-nowrap rounded-full bg-fill-2 px-2 py-0.5 text-[10px] text-text-3"
+            style={betPillOffset}
+          >
+            {t("pokerTable.actions.checkLabel")}
+          </span>
+        )}
+
+      {/* Result / thinking line */}
+      <div className="mt-1 flex h-4 items-center justify-center">
+        {wonAmount > 0 ? (
+          <span className="whitespace-nowrap text-[11px] font-medium text-success-6">
+            +{formatChips(wonAmount)}
+            {handDescription ? ` · ${handDescription}` : ""}
+          </span>
+        ) : seat.isToAct && thinkingSince !== null ? (
+          <ThinkingIndicator since={thinkingSince} />
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
+export default PokerSeat;

--- a/src/features/PokerTable/components/PokerSeat.tsx
+++ b/src/features/PokerTable/components/PokerSeat.tsx
@@ -3,6 +3,7 @@
  * cards above it, dealer button, current-street bet pill toward the pot,
  * and the "Thinking · Ns" indicator under the acting seat.
  */
+import { Bot } from "lucide-react";
 import React from "react";
 import { useTranslation } from "react-i18next";
 
@@ -97,15 +98,18 @@ const PokerSeat: React.FC<PokerSeatProps> = ({
           {initialOf(seat.player.name)}
         </span>
         <span className="flex min-w-0 flex-col leading-tight">
-          <span className="flex items-center gap-1 text-[12px] font-medium text-text-1">
-            <span className="truncate">{seat.player.name}</span>
+          <span className="flex items-center gap-1 whitespace-nowrap text-[12px] font-medium text-text-1">
+            <span>{seat.player.name}</span>
             {seat.player.kind === "bot" && (
-              <span className="rounded-full bg-fill-2 px-1 text-[9px] font-medium uppercase tracking-wide text-text-3">
-                {t("pokerTable.seat.bot")}
-              </span>
+              <Bot
+                size={12}
+                strokeWidth={1.8}
+                className="shrink-0 text-text-3"
+                aria-label={t("pokerTable.seat.bot")}
+              />
             )}
           </span>
-          <span className="text-[11px] text-text-3">
+          <span className="whitespace-nowrap text-[11px] text-text-3">
             {seat.isAllIn
               ? t("pokerTable.seat.allIn")
               : t("pokerTable.tokens", { amount: formatChips(seat.stack) })}

--- a/src/features/PokerTable/components/PokerSeat.tsx
+++ b/src/features/PokerTable/components/PokerSeat.tsx
@@ -48,10 +48,16 @@ const PokerSeat: React.FC<PokerSeatProps> = ({
   const showFaceUp = seat.holeCards && seat.holeCards.length > 0;
   const showFaceDown = !showFaceUp && seat.hasCards;
   const cardSize = isHero ? "lg" : "sm";
-  const betPillOffset = {
-    left: `calc(50% + ${towardCenter.x * 78}px)`,
-    top: `calc(50% + ${towardCenter.y * 62}px)`,
-  };
+  // Bet pill sits just outside the seat block on the pot side. The hero's
+  // block is much taller (large face-up cards above the pill), so its pill
+  // goes clear above the cards rather than the generic 62px nudge, which
+  // would land on them.
+  const betPillOffset = isHero
+    ? { left: "50%", top: "calc(50% - 88px)" }
+    : {
+        left: `calc(50% + ${towardCenter.x * 78}px)`,
+        top: `calc(50% + ${towardCenter.y * 62}px)`,
+      };
 
   return (
     <div className="relative flex flex-col items-center">

--- a/src/features/PokerTable/components/PokerSeat.tsx
+++ b/src/features/PokerTable/components/PokerSeat.tsx
@@ -57,7 +57,9 @@ const PokerSeat: React.FC<PokerSeatProps> = ({
     <div className="relative flex flex-col items-center">
       {/* Hole cards */}
       <div
-        className={`mb-[-10px] flex ${isHero ? "gap-1" : "gap-0"} ${dim}`}
+        // Bots' small cards tuck under their pill; the hero's stay fully
+        // visible above theirs.
+        className={`flex ${isHero ? "mb-1.5 gap-1.5" : "mb-[-10px] gap-0"} ${dim}`}
         style={{ minHeight: isHero ? 70 : 34 }}
       >
         {showFaceUp &&

--- a/src/features/PokerTable/components/PokerTableHeader.tsx
+++ b/src/features/PokerTable/components/PokerTableHeader.tsx
@@ -5,19 +5,14 @@
  * dropdown as the title — and right slot: hand number, history, settings,
  * "Leave table", close.
  */
-import { ChevronDown, History, SlidersHorizontal, X } from "lucide-react";
+import { History, SlidersHorizontal, X } from "lucide-react";
 import React from "react";
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
-import Dropdown from "@src/components/Dropdown";
-import {
-  DROPDOWN_CLASSES,
-  DROPDOWN_WIDTHS,
-} from "@src/components/Dropdown/tokens";
 import { useWindowDrag } from "@src/components/FloatingWindow/useWindowDrag";
+import Select, { type SelectOption } from "@src/components/Select";
 import {
-  HEADER_BUTTON,
   HEADER_CLASSES,
   HEADER_ICON_SIZE,
 } from "@src/config/workstation/tokens";
@@ -56,6 +51,29 @@ const PokerTableHeader: React.FC<PokerTableHeaderProps> = ({
   const { t } = useTranslation("sessions");
   const onPointerDown = useWindowDrag(true);
   const stakesLabel = formatStakes(blinds.smallBlind, blinds.bigBlind);
+  const stakesOptions: SelectOption[] = POKER_STAKES_OPTIONS.map((option) => {
+    const label = t("pokerTable.header.title", {
+      stakes: formatStakes(option.smallBlind, option.bigBlind),
+    });
+
+    return {
+      value: option.id,
+      label,
+      // A stakes change is queued until the next hand. Keep the trigger on
+      // the live blinds while the selected menu option reflects the pending
+      // setting.
+      triggerLabel:
+        option.id === settings.stakesId
+          ? t("pokerTable.header.title", { stakes: stakesLabel })
+          : label,
+    };
+  });
+  const speedOptions: SelectOption[] = (["normal", "fast"] as const).map(
+    (speed) => ({
+      value: speed,
+      label: t(`pokerTable.settings.speed_${speed}`),
+    })
+  );
 
   return (
     <div
@@ -63,35 +81,25 @@ const PokerTableHeader: React.FC<PokerTableHeaderProps> = ({
       onPointerDown={onPointerDown}
     >
       <div className="flex min-w-0 flex-1 items-center">
-        <Dropdown
-          trigger="click"
-          position="bottom-start"
-          getPopupContainer={() => document.body}
-          avoidViewportOverflow
-          options={POKER_STAKES_OPTIONS.map((option) => ({
-            value: option.id,
-            label: t("pokerTable.header.title", {
-              stakes: formatStakes(option.smallBlind, option.bigBlind),
-            }),
-          }))}
-          value={settings.stakesId}
-          onSelect={(value) => onChangeStakes(String(value) as PokerStakesId)}
-        >
-          <button
-            type="button"
-            className="flex min-w-0 items-center gap-1 rounded px-1 text-[13px] font-medium text-text-1 hover:bg-fill-1"
-            data-no-window-drag
-            title={t("pokerTable.settings.stakes")}
-          >
-            <span className="truncate">
-              {t("pokerTable.header.title", { stakes: stakesLabel })}
-            </span>
-            <ChevronDown
-              size={HEADER_ICON_SIZE.sm}
-              className="shrink-0 text-text-3"
-            />
-          </button>
-        </Dropdown>
+        <div className="min-w-0" data-no-window-drag>
+          <Select
+            value={settings.stakesId}
+            options={stakesOptions}
+            placeholder={t("pokerTable.settings.stakes")}
+            onChange={(value) => {
+              if (Array.isArray(value)) return;
+              onChangeStakes(String(value) as PokerStakesId);
+            }}
+            size="mini"
+            appearance="ghost"
+            dropdownAlign="left"
+            dropdownWidthMode="auto"
+            className="w-auto max-w-full"
+            selectorClassName="!font-medium"
+            ariaLabel={t("pokerTable.settings.stakes")}
+            dataTestId="poker-stakes-select"
+          />
+        </div>
       </div>
 
       <div className="flex flex-shrink-0 items-center gap-1.5">
@@ -100,56 +108,27 @@ const PokerTableHeader: React.FC<PokerTableHeaderProps> = ({
             {t("pokerTable.header.hand", { number: handNumber })}
           </span>
         )}
-        <button
-          type="button"
-          className={`${HEADER_BUTTON.action} ${historyOpen ? "bg-fill-2 text-text-1" : ""}`}
-          onClick={onToggleHistory}
-          title={t("pokerTable.header.history")}
-        >
-          <History size={HEADER_ICON_SIZE.sm} />
-        </button>
-        <Dropdown
-          trigger="click"
-          position="bottom-end"
-          getPopupContainer={() => document.body}
-          avoidViewportOverflow
-          droplist={
-            <div
-              className={`${DROPDOWN_CLASSES.panel} ${DROPDOWN_WIDTHS.menuClass} p-1`}
-            >
-              <div className="px-2 py-1 text-[11px] font-medium uppercase tracking-wide text-text-3">
-                {t("pokerTable.settings.speed")}
-              </div>
-              {(["normal", "fast"] as const).map((speed) => (
-                <button
-                  key={speed}
-                  type="button"
-                  role="menuitemradio"
-                  aria-checked={settings.speed === speed}
-                  className={`flex w-full items-center justify-between rounded px-2 py-1 text-[12px] hover:bg-fill-1 ${
-                    settings.speed === speed ? "text-text-1" : "text-text-2"
-                  }`}
-                  onClick={() => onChangeSpeed(speed)}
-                >
-                  <span>{t(`pokerTable.settings.speed_${speed}`)}</span>
-                  {settings.speed === speed && (
-                    <span className="text-primary-6">•</span>
-                  )}
-                </button>
-              ))}
-            </div>
-          }
-        >
-          <button
-            type="button"
-            className={HEADER_BUTTON.action}
-            title={t("pokerTable.header.settings")}
-            data-no-window-drag
-          >
-            <SlidersHorizontal size={HEADER_ICON_SIZE.sm} />
-          </button>
-        </Dropdown>
+        <div data-no-window-drag>
+          <Select
+            value={settings.speed}
+            options={speedOptions}
+            placeholder={t("pokerTable.settings.speed")}
+            onChange={(value) => {
+              if (Array.isArray(value)) return;
+              onChangeSpeed(value as StoredPokerSettings["speed"]);
+            }}
+            prefix={<SlidersHorizontal size={HEADER_ICON_SIZE.sm} />}
+            size="mini"
+            appearance="ghost"
+            dropdownAlign="right"
+            dropdownWidthMode="min-match"
+            className="w-auto"
+            ariaLabel={t("pokerTable.settings.speed")}
+            dataTestId="poker-speed-select"
+          />
+        </div>
         <Button
+          htmlType="button"
           variant="secondary"
           appearance="outline"
           size="mini"
@@ -159,14 +138,28 @@ const PokerTableHeader: React.FC<PokerTableHeaderProps> = ({
           {t("pokerTable.header.leave")}
         </Button>
         <span aria-hidden className="h-4 w-px flex-shrink-0 bg-border-2" />
-        <button
-          type="button"
-          className={HEADER_BUTTON.action}
+        <Button
+          htmlType="button"
+          variant="tertiary"
+          size="mini"
+          iconOnly
+          icon={<History size={HEADER_ICON_SIZE.sm} />}
+          className={historyOpen ? "bg-fill-2 text-text-1" : ""}
+          onClick={onToggleHistory}
+          title={t("pokerTable.header.history")}
+          aria-label={t("pokerTable.header.history")}
+          aria-pressed={historyOpen}
+        />
+        <Button
+          htmlType="button"
+          variant="tertiary"
+          size="mini"
+          iconOnly
+          icon={<X size={HEADER_ICON_SIZE.sm} />}
           onClick={onClose}
           title={t("pokerTable.header.close")}
-        >
-          <X size={HEADER_ICON_SIZE.sm} />
-        </button>
+          aria-label={t("pokerTable.header.close")}
+        />
       </div>
     </div>
   );

--- a/src/features/PokerTable/components/PokerTableHeader.tsx
+++ b/src/features/PokerTable/components/PokerTableHeader.tsx
@@ -1,0 +1,175 @@
+/**
+ * Draggable window header for the table, in the shared floating-window
+ * chrome (`HEADER_CLASSES.pageHeader` + `useWindowDrag`, like
+ * `DetailPanelHeader`) but with the table's own left slot — a stakes
+ * dropdown as the title — and right slot: hand number, history, settings,
+ * "Leave table", close.
+ */
+import { ChevronDown, History, SlidersHorizontal, X } from "lucide-react";
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import Button from "@src/components/Button";
+import Dropdown from "@src/components/Dropdown";
+import {
+  DROPDOWN_CLASSES,
+  DROPDOWN_WIDTHS,
+} from "@src/components/Dropdown/tokens";
+import { useWindowDrag } from "@src/components/FloatingWindow/useWindowDrag";
+import {
+  HEADER_BUTTON,
+  HEADER_CLASSES,
+  HEADER_ICON_SIZE,
+} from "@src/config/workstation/tokens";
+import {
+  POKER_STAKES_OPTIONS,
+  type PokerStakesId,
+  type StoredPokerSettings,
+} from "@src/store/ui/pokerTableAtom";
+
+import type { Blinds } from "../engine/types";
+import { formatStakes } from "../format";
+
+export interface PokerTableHeaderProps {
+  blinds: Blinds;
+  handNumber: number;
+  settings: StoredPokerSettings;
+  historyOpen: boolean;
+  onToggleHistory: () => void;
+  onChangeStakes: (stakesId: PokerStakesId) => void;
+  onChangeSpeed: (speed: StoredPokerSettings["speed"]) => void;
+  onLeave: () => void;
+  onClose: () => void;
+}
+
+const PokerTableHeader: React.FC<PokerTableHeaderProps> = ({
+  blinds,
+  handNumber,
+  settings,
+  historyOpen,
+  onToggleHistory,
+  onChangeStakes,
+  onChangeSpeed,
+  onLeave,
+  onClose,
+}) => {
+  const { t } = useTranslation("sessions");
+  const onPointerDown = useWindowDrag(true);
+  const stakesLabel = formatStakes(blinds.smallBlind, blinds.bigBlind);
+
+  return (
+    <div
+      className={`${HEADER_CLASSES.pageHeader} cursor-grab select-none !border-b-0`}
+      onPointerDown={onPointerDown}
+    >
+      <div className="flex min-w-0 flex-1 items-center">
+        <Dropdown
+          trigger="click"
+          position="bottom-start"
+          getPopupContainer={() => document.body}
+          avoidViewportOverflow
+          options={POKER_STAKES_OPTIONS.map((option) => ({
+            value: option.id,
+            label: t("pokerTable.header.title", {
+              stakes: formatStakes(option.smallBlind, option.bigBlind),
+            }),
+          }))}
+          value={settings.stakesId}
+          onSelect={(value) => onChangeStakes(String(value) as PokerStakesId)}
+        >
+          <button
+            type="button"
+            className="flex min-w-0 items-center gap-1 rounded px-1 text-[13px] font-medium text-text-1 hover:bg-fill-1"
+            data-no-window-drag
+            title={t("pokerTable.settings.stakes")}
+          >
+            <span className="truncate">
+              {t("pokerTable.header.title", { stakes: stakesLabel })}
+            </span>
+            <ChevronDown
+              size={HEADER_ICON_SIZE.sm}
+              className="shrink-0 text-text-3"
+            />
+          </button>
+        </Dropdown>
+      </div>
+
+      <div className="flex flex-shrink-0 items-center gap-1.5">
+        {handNumber > 0 && (
+          <span className="whitespace-nowrap text-[12px] text-text-3">
+            {t("pokerTable.header.hand", { number: handNumber })}
+          </span>
+        )}
+        <button
+          type="button"
+          className={`${HEADER_BUTTON.action} ${historyOpen ? "bg-fill-2 text-text-1" : ""}`}
+          onClick={onToggleHistory}
+          title={t("pokerTable.header.history")}
+        >
+          <History size={HEADER_ICON_SIZE.sm} />
+        </button>
+        <Dropdown
+          trigger="click"
+          position="bottom-end"
+          getPopupContainer={() => document.body}
+          avoidViewportOverflow
+          droplist={
+            <div
+              className={`${DROPDOWN_CLASSES.panel} ${DROPDOWN_WIDTHS.menuClass} p-1`}
+            >
+              <div className="px-2 py-1 text-[11px] font-medium uppercase tracking-wide text-text-3">
+                {t("pokerTable.settings.speed")}
+              </div>
+              {(["normal", "fast"] as const).map((speed) => (
+                <button
+                  key={speed}
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={settings.speed === speed}
+                  className={`flex w-full items-center justify-between rounded px-2 py-1 text-[12px] hover:bg-fill-1 ${
+                    settings.speed === speed ? "text-text-1" : "text-text-2"
+                  }`}
+                  onClick={() => onChangeSpeed(speed)}
+                >
+                  <span>{t(`pokerTable.settings.speed_${speed}`)}</span>
+                  {settings.speed === speed && (
+                    <span className="text-primary-6">•</span>
+                  )}
+                </button>
+              ))}
+            </div>
+          }
+        >
+          <button
+            type="button"
+            className={HEADER_BUTTON.action}
+            title={t("pokerTable.header.settings")}
+            data-no-window-drag
+          >
+            <SlidersHorizontal size={HEADER_ICON_SIZE.sm} />
+          </button>
+        </Dropdown>
+        <Button
+          variant="secondary"
+          appearance="outline"
+          size="mini"
+          shape="round"
+          onClick={onLeave}
+        >
+          {t("pokerTable.header.leave")}
+        </Button>
+        <span aria-hidden className="h-4 w-px flex-shrink-0 bg-border-2" />
+        <button
+          type="button"
+          className={HEADER_BUTTON.action}
+          onClick={onClose}
+          title={t("pokerTable.header.close")}
+        >
+          <X size={HEADER_ICON_SIZE.sm} />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default PokerTableHeader;

--- a/src/features/PokerTable/components/PokerTableRender.test.ts
+++ b/src/features/PokerTable/components/PokerTableRender.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Static-render smoke tests: drive a real controller to specific states
+ * and assert the felt / action bar render the right things (seats, cards,
+ * legal buttons, rebuy prompt, result line). Same renderToStaticMarkup +
+ * mocked react-i18next idiom as ChatPanelTabBar.test.ts.
+ */
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PokerTableController } from "../PokerTableController";
+import { createSeededRng } from "../engine/cards";
+import type { PokerPlayer } from "../engine/types";
+import PokerActionBar from "./PokerActionBar";
+import PokerFelt from "./PokerFelt";
+import PokerHandHistory from "./PokerHandHistory";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params ? `${key}(${Object.values(params).join(",")})` : key,
+  }),
+}));
+
+const HERO: PokerPlayer = {
+  id: "user:me",
+  name: "hours",
+  kind: "human",
+  avatarHue: 0,
+};
+
+function controllerAtHeroTurn() {
+  const controller = new PokerTableController({
+    hero: HERO,
+    blinds: { smallBlind: 500, bigBlind: 1000 },
+    buyIn: 100_000,
+    bankroll: 500_000,
+    speed: "fast",
+    rng: createSeededRng(7),
+    now: () => 1_000_000,
+  });
+  controller.start();
+  for (
+    let elapsed = 0;
+    elapsed < 30_000 && !controller.isHeroToAct();
+    elapsed += 25
+  ) {
+    vi.advanceTimersByTime(25);
+  }
+  expect(controller.isHeroToAct()).toBe(true);
+  return controller;
+}
+
+function renderFelt(controller: PokerTableController): string {
+  const state = controller.getState();
+  return renderToStaticMarkup(
+    createElement(PokerFelt, {
+      snapshot: state.snapshot,
+      heroSeat: state.heroSeat,
+      revealedCommunity: state.revealedCommunity,
+      thinkingSince: state.thinkingSince,
+    })
+  );
+}
+
+function renderActionBar(controller: PokerTableController): string {
+  const state = controller.getState();
+  return renderToStaticMarkup(
+    createElement(PokerActionBar, {
+      snapshot: state.snapshot,
+      heroSeat: state.heroSeat,
+      awaitingRebuy: state.awaitingRebuy,
+      bankroll: state.bankroll,
+      buyIn: 100_000,
+      onAct: () => {},
+      onRebuy: () => {},
+      onResetBankroll: () => {},
+      onDealNext: () => {},
+    })
+  );
+}
+
+describe("PokerTable rendering", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("renders six seats, the hero's two face-up cards and face-down bot cards", () => {
+    const controller = controllerAtHeroTurn();
+    const markup = renderFelt(controller);
+    for (let seat = 0; seat < 6; seat += 1) {
+      expect(markup).toContain(`data-testid="poker-seat-${seat}"`);
+    }
+    // Hero's cards are face-up (aria-label "<rank> of <suit>"), bots' are face-down.
+    const faceUp =
+      markup.match(
+        /aria-label="(10|[2-9]|[JQKA]) of (clubs|diamonds|hearts|spades)"/g
+      ) ?? [];
+    expect(faceUp).toHaveLength(2);
+    expect(
+      (markup.match(/aria-label="face-down card"/g) ?? []).length
+    ).toBeGreaterThanOrEqual(2);
+    // Pot pill, dealer button and the thinking indicator for the hero.
+    expect(markup).toContain("pokerTable.potLabel");
+    expect(markup).toContain('aria-label="dealer"');
+    expect(markup).toContain("pokerTable.thinking(");
+    controller.dispose();
+  });
+
+  it("offers exactly the legal actions with the sizing controls when it is the hero's turn", () => {
+    const controller = controllerAtHeroTurn();
+    const legal = controller.getState().snapshot.legalActions!;
+    const markup = renderActionBar(controller);
+    expect(markup).toContain('data-testid="poker-action-bar"');
+    expect(markup).toContain("pokerTable.actions.fold");
+    if (legal.actions.includes("check")) {
+      expect(markup).toContain("pokerTable.actions.check");
+    } else {
+      expect(markup).toContain("pokerTable.actions.call(");
+    }
+    if (legal.chipRange) {
+      expect(markup).toContain("25%");
+      expect(markup).toContain("133%");
+      expect(markup).toMatch(/pokerTable\.actions\.(bet|raise|allIn)\(/);
+    }
+    controller.dispose();
+  });
+
+  it("shows the waiting line when a bot is to act and the result line after a hand", () => {
+    const controller = controllerAtHeroTurn();
+    // Fold; a bot acts next.
+    controller.heroAct("fold");
+    if (
+      !controller.isHeroToAct() &&
+      controller.getState().snapshot.toAct !== null
+    ) {
+      expect(renderActionBar(controller)).toContain("pokerTable.waitingFor(");
+    }
+    // Let the hand finish; the felt shows a winner and the history lists it.
+    for (let elapsed = 0; elapsed < 60_000; elapsed += 25) {
+      vi.advanceTimersByTime(25);
+      if (controller.getState().snapshot.phase === "hand-complete") break;
+      if (controller.isHeroToAct()) controller.heroAct("fold");
+    }
+    expect(controller.getState().snapshot.phase).toBe("hand-complete");
+    expect(renderFelt(controller)).toMatch(/pokerTable\.result\.wins(With)?\(/);
+    expect(renderActionBar(controller)).toContain("pokerTable.nextHand");
+    const history = renderToStaticMarkup(
+      createElement(PokerHandHistory, {
+        entries: controller.getState().handHistory,
+      })
+    );
+    expect(history).toContain("pokerTable.header.hand(1)");
+    controller.dispose();
+  });
+
+  it("shows the rebuy prompt when the hero is out of chips", () => {
+    const controller = new PokerTableController({
+      hero: HERO,
+      blinds: { smallBlind: 500, bigBlind: 1000 },
+      buyIn: 100_000,
+      bankroll: 0,
+      speed: "fast",
+      rng: createSeededRng(1),
+    });
+    controller.start();
+    expect(controller.getState().awaitingRebuy).toBe(true);
+    const markup = renderActionBar(controller);
+    expect(markup).toContain("pokerTable.rebuy.title");
+    expect(markup).toContain("pokerTable.rebuy.reset");
+    controller.dispose();
+  });
+});

--- a/src/features/PokerTable/components/PokerTableRender.test.ts
+++ b/src/features/PokerTable/components/PokerTableRender.test.ts
@@ -14,6 +14,7 @@ import type { PokerPlayer } from "../engine/types";
 import PokerActionBar from "./PokerActionBar";
 import PokerFelt from "./PokerFelt";
 import PokerHandHistory from "./PokerHandHistory";
+import PokerTableHeader from "./PokerTableHeader";
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -104,6 +105,30 @@ describe("PokerTable rendering", () => {
     expect(markup).toContain('aria-label="dealer"');
     expect(markup).toContain("pokerTable.thinking(");
     controller.dispose();
+  });
+
+  it("uses shared selects for stakes and table speed", () => {
+    const markup = renderToStaticMarkup(
+      createElement(PokerTableHeader, {
+        blinds: { smallBlind: 500, bigBlind: 1000 },
+        handNumber: 3,
+        settings: { stakesId: "0.5/1", speed: "normal" },
+        historyOpen: false,
+        onToggleHistory: () => {},
+        onChangeStakes: () => {},
+        onChangeSpeed: () => {},
+        onLeave: () => {},
+        onClose: () => {},
+      })
+    );
+
+    expect(markup.match(/role="combobox"/g)).toHaveLength(2);
+    expect(markup).toContain('data-testid="poker-stakes-select"');
+    expect(markup).toContain('aria-label="pokerTable.settings.stakes"');
+    expect(markup).toContain('data-testid="poker-speed-select"');
+    expect(markup).toContain('aria-label="pokerTable.settings.speed"');
+    expect(markup).toContain("pokerTable.header.title(0.5/1)");
+    expect(markup).toContain("pokerTable.settings.speed_normal");
   });
 
   it("offers exactly the legal actions with the sizing controls when it is the hero's turn", () => {

--- a/src/features/PokerTable/components/ThinkingIndicator.tsx
+++ b/src/features/PokerTable/components/ThinkingIndicator.tsx
@@ -1,0 +1,38 @@
+/**
+ * "● ○ ○ Thinking · 24s" — a ticking seconds counter with a three-dot
+ * pulse, shown under whichever seat is to act.
+ */
+import React, { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+export interface ThinkingIndicatorProps {
+  /** Epoch ms when the actor's turn started. */
+  since: number;
+}
+
+const ThinkingIndicator: React.FC<ThinkingIndicatorProps> = ({ since }) => {
+  const { t } = useTranslation("sessions");
+  // Wall-clock tick; `since` only feeds the derived seconds below.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const handle = window.setInterval(() => setNow(Date.now()), 500);
+    return () => window.clearInterval(handle);
+  }, []);
+  const seconds = Math.max(0, Math.floor((now - since) / 1000));
+  const active = Math.floor(now / 400) % 3;
+  return (
+    <span className="flex items-center gap-1.5 whitespace-nowrap text-[11px] text-text-3">
+      <span aria-hidden className="flex items-center gap-[3px]">
+        {[0, 1, 2].map((dot) => (
+          <span
+            key={dot}
+            className={`h-[5px] w-[5px] rounded-full ${dot === active ? "bg-text-2" : "bg-fill-3"}`}
+          />
+        ))}
+      </span>
+      {t("pokerTable.thinking", { seconds })}
+    </span>
+  );
+};
+
+export default ThinkingIndicator;

--- a/src/features/PokerTable/engine/PokerTableEngine.test.ts
+++ b/src/features/PokerTable/engine/PokerTableEngine.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+
+import { PokerTableEngine } from "./PokerTableEngine";
+import { createSeededRng } from "./cards";
+import type { PlayerAction, PokerPlayer } from "./types";
+
+const player = (
+  id: string,
+  kind: PokerPlayer["kind"] = "bot"
+): PokerPlayer => ({
+  id,
+  name: id,
+  kind,
+  avatarHue: 0,
+});
+
+const BLINDS = { smallBlind: 500, bigBlind: 1000 };
+
+function seatSix(engine: PokerTableEngine, stacks: number[]): void {
+  stacks.forEach((stack, index) => {
+    engine.sitDown(
+      index,
+      player(
+        index === 0 ? "hero" : `bot${index}`,
+        index === 0 ? "human" : "bot"
+      ),
+      stack
+    );
+  });
+}
+
+/**
+ * Total chips on the table: stacks plus, mid-hand, live bets and pots.
+ * (After a hand `potTotal` echoes the awarded pot for display, and the
+ * stacks already contain it.)
+ */
+function chipsInPlay(engine: PokerTableEngine): number {
+  const snap = engine.snapshot(0);
+  const stacks = snap.seats.reduce((sum, seat) => sum + (seat?.stack ?? 0), 0);
+  return stacks + (engine.isHandInProgress() ? snap.potTotal : 0);
+}
+
+/** Drive a hand to completion with a random legal action policy. */
+function playRandomHand(engine: PokerTableEngine, rng: () => number): void {
+  engine.startHand();
+  while (engine.isHandInProgress()) {
+    while (engine.isBettingRoundInProgress()) {
+      const legal = engine.legalActions();
+      if (!legal) throw new Error("expected legal actions");
+      const action = legal.actions[Math.floor(rng() * legal.actions.length)];
+      if ((action === "bet" || action === "raise") && legal.chipRange) {
+        const { min, max } = legal.chipRange;
+        const amount =
+          rng() < 0.25 ? max : min + Math.floor(rng() * (max - min + 1));
+        engine.act(action, amount);
+      } else {
+        engine.act(action as PlayerAction);
+      }
+    }
+    engine.endBettingRound();
+    if (engine.areBettingRoundsCompleted()) engine.showdown();
+  }
+}
+
+describe("PokerTableEngine", () => {
+  it("conserves chips across many random hands, including side pots", () => {
+    const engine = new PokerTableEngine(BLINDS);
+    seatSix(engine, [2130, 106000, 35800, 11100, 56400, 24200]);
+    let total = chipsInPlay(engine);
+    const rng = createSeededRng(7);
+    let hands = 0;
+    let rebuys = 0;
+    let sawResult = false;
+    while (engine.seatedCount() >= 2 && hands < 150) {
+      playRandomHand(engine, rng);
+      hands += 1;
+      const result = engine.snapshot(0).lastResult;
+      expect(result).not.toBeNull();
+      if (result) {
+        sawResult = true;
+        const paid = result.entries.reduce((sum, e) => sum + e.amountWon, 0);
+        expect(paid).toBe(result.potTotal);
+      }
+      // Like the controller: the hero re-buys, busted bots stand up.
+      for (let seat = 0; seat < 6; seat += 1) {
+        if (!engine.isSeated(seat) || engine.stackOf(seat) > 0) continue;
+        expect(engine.isBusted(seat)).toBe(true);
+        if (seat === 0) {
+          engine.rebuy(0, 10000);
+          total += 10000;
+          rebuys += 1;
+          expect(engine.isBusted(0)).toBe(false);
+          expect(engine.stackOf(0)).toBe(10000);
+        } else {
+          engine.standUp(seat);
+        }
+      }
+      // Busted players took 0 chips with them, so the total only moves by rebuys.
+      expect(chipsInPlay(engine)).toBe(total);
+    }
+    expect(hands).toBeGreaterThan(5);
+    expect(sawResult).toBe(true);
+    // Hero started with 2 big blinds, so busting (and re-buying) is a given.
+    expect(rebuys).toBeGreaterThan(0);
+  });
+
+  it("awards the pot without a showdown when everyone folds", () => {
+    const engine = new PokerTableEngine(BLINDS);
+    seatSix(engine, [10000, 10000, 10000]);
+    engine.startHand();
+    // 3-handed: button 0, SB 1, BB 2 → seat 0 acts first.
+    expect(engine.playerToAct()).toBe(0);
+    engine.act("fold");
+    engine.act("fold");
+    expect(engine.isBettingRoundInProgress()).toBe(false);
+    engine.endBettingRound();
+    expect(engine.areBettingRoundsCompleted()).toBe(true);
+    const result = engine.showdown();
+    expect(result.foldedOut).toBe(true);
+    const winner = result.entries.find((e) => e.amountWon > 0);
+    expect(winner?.seatIndex).toBe(2);
+    expect(winner?.amountWon).toBe(1500);
+    expect(winner?.revealedCards).toBeNull();
+    const snap = engine.snapshot(0);
+    expect(snap.phase).toBe("hand-complete");
+    expect(snap.seats[2]?.stack).toBe(10500);
+    // Hero's own cards stay visible in the result view.
+    expect(snap.seats[0]?.holeCards).toHaveLength(2);
+    // Bots' cards are never exposed when the hand folded out.
+    expect(snap.seats[1]?.holeCards).toBeNull();
+  });
+
+  it("runs out the board and reveals contenders on an all-in showdown", () => {
+    const engine = new PokerTableEngine(BLINDS);
+    seatSix(engine, [10000, 8000]);
+    engine.startHand();
+    const legal = engine.legalActions();
+    expect(legal?.actions).toContain("raise");
+    engine.act("raise", legal!.chipRange!.max);
+    engine.act("call");
+    expect(engine.isBettingRoundInProgress()).toBe(false);
+    engine.endBettingRound();
+    // Everyone all-in: the engine dealt every remaining street at once.
+    expect(engine.communityCards()).toHaveLength(5);
+    expect(engine.areBettingRoundsCompleted()).toBe(true);
+    const result = engine.showdown();
+    expect(result.foldedOut).toBe(false);
+    expect(result.board).toHaveLength(5);
+    // Both contenders are revealed with a described hand.
+    for (const entry of result.entries) {
+      expect(entry.revealedCards).toHaveLength(2);
+      expect(entry.handDescription).toBeTruthy();
+    }
+    expect(result.entries.reduce((s, e) => s + e.amountWon, 0)).toBe(
+      result.potTotal
+    );
+    const snap = engine.snapshot(0);
+    expect(snap.seats[1]?.holeCards).toHaveLength(2);
+    expect(snap.communityCards).toHaveLength(5);
+  });
+
+  it("hides other players' hole cards from the viewer during the hand", () => {
+    const engine = new PokerTableEngine(BLINDS);
+    seatSix(engine, [10000, 10000, 10000]);
+    engine.startHand();
+    const snap = engine.snapshot(0);
+    expect(snap.phase).toBe("betting");
+    expect(snap.seats[0]?.holeCards).toHaveLength(2);
+    expect(snap.seats[1]?.holeCards).toBeNull();
+    expect(snap.seats[1]?.hasCards).toBe(true);
+    expect(snap.dealerSeat).toBe(0);
+    expect(snap.toAct).toBe(0);
+    expect(snap.callAmount).toBe(1000);
+    expect(snap.potTotal).toBe(1500);
+  });
+
+  it("tracks per-street last actions and clears them at the next street", () => {
+    const engine = new PokerTableEngine(BLINDS);
+    seatSix(engine, [10000, 10000, 10000]);
+    engine.startHand();
+    engine.act("raise", 3000);
+    expect(engine.snapshot(0).seats[0]?.lastAction).toEqual({
+      action: "raise",
+      amount: 3000,
+    });
+    engine.act("call");
+    expect(engine.snapshot(0).seats[1]?.lastAction).toEqual({
+      action: "call",
+      amount: 3000,
+    });
+    engine.act("fold");
+    expect(engine.snapshot(0).seats[2]?.lastAction).toEqual({ action: "fold" });
+    engine.endBettingRound();
+    const flop = engine.snapshot(0);
+    expect(flop.street).toBe("flop");
+    expect(flop.seats[0]?.lastAction).toBeNull();
+    expect(flop.seats[2]?.inHand).toBe(false);
+    expect(flop.potTotal).toBe(7000);
+  });
+
+  it("clamps bet sizes into the legal range", () => {
+    const engine = new PokerTableEngine(BLINDS);
+    seatSix(engine, [10000, 10000]);
+    engine.startHand();
+    engine.act("raise", 999_999);
+    expect(engine.snapshot(0).seats[0]?.betSize).toBe(10000);
+  });
+
+  it("returns the remaining stack when a player stands up", () => {
+    const engine = new PokerTableEngine(BLINDS);
+    seatSix(engine, [10000, 10000]);
+    expect(engine.standUp(0)).toBe(10000);
+    expect(engine.isSeated(0)).toBe(false);
+    expect(engine.seatedCount()).toBe(1);
+  });
+});

--- a/src/features/PokerTable/engine/PokerTableEngine.ts
+++ b/src/features/PokerTable/engine/PokerTableEngine.ts
@@ -1,0 +1,417 @@
+/**
+ * PokerTableEngine — a table across hands.
+ *
+ * `HoldemHand` owns the rules of one hand; this class owns what persists
+ * between hands: who sits where with how many chips, the button rotation,
+ * hand numbering, stakes, per-street "last action" pills, and the
+ * immutable `TableSnapshot` projection with per-viewer card visibility.
+ *
+ * It does NOT own timing — the controller decides when bots act, when a
+ * street is dealt and when the next hand starts, so tests can drive hands
+ * synchronously.
+ */
+import type { Card, Rng } from "./cards";
+import { HoldemHand } from "./holdemHand";
+import type {
+  Blinds,
+  HandResult,
+  HandResultEntry,
+  LegalActions,
+  PlayerAction,
+  PokerPlayer,
+  PotSnapshot,
+  SeatAction,
+  SeatSnapshot,
+  Street,
+  TablePhase,
+  TableSnapshot,
+} from "./types";
+
+export const DEFAULT_SEAT_COUNT = 6;
+
+interface SeatState {
+  player: PokerPlayer;
+  /** Chips behind between hands (authoritative while no hand runs). */
+  stack: number;
+  /**
+   * Lost the last chip at showdown. The seat is kept so the UI can show
+   * "0 tokens" and offer a rebuy; `startHand()` drops busted seats that
+   * were not re-bought.
+   */
+  busted: boolean;
+  lastAction: SeatAction | null;
+}
+
+export interface PokerTableEngineOptions {
+  seatCount?: number;
+  /** Deck RNG (defaults to the platform CSPRNG). */
+  rng?: Rng;
+}
+
+export class PokerTableEngine {
+  private readonly seatCount: number;
+  private readonly seats: (SeatState | null)[];
+  private readonly rng?: Rng;
+  private blinds: Blinds;
+  private handNumber = 0;
+  private hand: HoldemHand | null = null;
+  private handInProgress = false;
+  private lastResult: HandResult | null = null;
+  private lastStreet: Street | null = null;
+
+  constructor(blinds: Blinds, options: PokerTableEngineOptions = {}) {
+    this.blinds = blinds;
+    this.seatCount = options.seatCount ?? DEFAULT_SEAT_COUNT;
+    this.rng = options.rng;
+    this.seats = Array.from({ length: this.seatCount }, () => null);
+  }
+
+  // ─── Seating ────────────────────────────────────────────────────────────
+
+  sitDown(seatIndex: number, player: PokerPlayer, buyIn: number): void {
+    this.assertSeatIndex(seatIndex);
+    if (this.seats[seatIndex]) {
+      throw new Error(`Seat ${seatIndex} is occupied`);
+    }
+    if (buyIn <= 0) throw new Error("Buy-in must be positive");
+    this.seats[seatIndex] = {
+      player,
+      stack: Math.round(buyIn),
+      busted: false,
+      lastAction: null,
+    };
+  }
+
+  /** Put chips back in front of a busted player. Legal between hands only. */
+  rebuy(seatIndex: number, buyIn: number): void {
+    const seat = this.seats[seatIndex];
+    if (!seat) throw new Error(`Seat ${seatIndex} is empty`);
+    if (!seat.busted) throw new Error(`Seat ${seatIndex} is not busted`);
+    if (this.handInProgress) throw new Error("Cannot rebuy during a hand");
+    if (buyIn <= 0) throw new Error("Buy-in must be positive");
+    seat.stack += Math.round(buyIn);
+    seat.busted = false;
+  }
+
+  /**
+   * Remove a player and return their stack. Legal between hands, or during
+   * a hand for a seat that is not dealt in (a busted seat waiting on a
+   * rebuy). Contenders cannot leave mid-hand — the table is abandoned as
+   * a whole instead (see the controller's `leave()`).
+   */
+  standUp(seatIndex: number): number {
+    const seat = this.seats[seatIndex];
+    if (!seat) return 0;
+    if (this.handInProgress && this.hand?.seat(seatIndex)) {
+      throw new Error("Cannot stand up during a hand");
+    }
+    this.seats[seatIndex] = null;
+    return seat.stack;
+  }
+
+  isSeated(seatIndex: number): boolean {
+    return this.seats[seatIndex] !== null;
+  }
+
+  isBusted(seatIndex: number): boolean {
+    return this.seats[seatIndex]?.busted ?? false;
+  }
+
+  /** Chips behind right now (live stack during a hand). */
+  stackOf(seatIndex: number): number {
+    if (this.handInProgress) {
+      const live = this.hand?.seat(seatIndex);
+      if (live) return live.stack;
+    }
+    return this.seats[seatIndex]?.stack ?? 0;
+  }
+
+  seatedCount(): number {
+    return this.seats.filter(Boolean).length;
+  }
+
+  seatIndexOf(playerId: string): number | null {
+    const index = this.seats.findIndex((seat) => seat?.player.id === playerId);
+    return index >= 0 ? index : null;
+  }
+
+  playerAt(seatIndex: number): PokerPlayer | null {
+    return this.seats[seatIndex]?.player ?? null;
+  }
+
+  getBlinds(): Blinds {
+    return this.blinds;
+  }
+
+  /** Change stakes between hands. */
+  setBlinds(blinds: Blinds): void {
+    if (this.handInProgress) {
+      throw new Error("Cannot change blinds during a hand");
+    }
+    this.blinds = blinds;
+  }
+
+  // ─── Hand lifecycle ─────────────────────────────────────────────────────
+
+  isHandInProgress(): boolean {
+    return this.handInProgress;
+  }
+
+  isBettingRoundInProgress(): boolean {
+    return (
+      this.handInProgress && (this.hand?.isBettingRoundInProgress() ?? false)
+    );
+  }
+
+  areBettingRoundsCompleted(): boolean {
+    return (
+      this.handInProgress && (this.hand?.areBettingRoundsCompleted() ?? false)
+    );
+  }
+
+  currentHandNumber(): number {
+    return this.handNumber;
+  }
+
+  /** Deal a new hand. Requires ≥2 seated players with chips. */
+  startHand(): void {
+    if (this.handInProgress) throw new Error("Hand already in progress");
+    // Busted seats that were not re-bought leave the table now.
+    this.seats.forEach((seat, index) => {
+      if (seat && (seat.busted || seat.stack <= 0)) this.seats[index] = null;
+    });
+    const dealtIn = this.seats
+      .map((seat, index) => (seat ? index : -1))
+      .filter((index) => index >= 0);
+    if (dealtIn.length < 2) {
+      throw new Error("Need at least two players to start a hand");
+    }
+    const previousButton = this.hand?.buttonSeat ?? null;
+    const buttonSeat =
+      previousButton === null
+        ? dealtIn[0]
+        : (dealtIn.find((seat) => seat > previousButton) ?? dealtIn[0]);
+
+    this.handNumber += 1;
+    this.lastResult = null;
+    this.hand = new HoldemHand({
+      seats: dealtIn.map((seatIndex) => ({
+        seatIndex,
+        stack: this.seats[seatIndex]!.stack,
+      })),
+      buttonSeat,
+      smallBlind: this.blinds.smallBlind,
+      bigBlind: this.blinds.bigBlind,
+      rng: this.rng,
+    });
+    this.handInProgress = true;
+    this.lastStreet = "preflop";
+    this.seats.forEach((seat) => {
+      if (seat) seat.lastAction = null;
+    });
+  }
+
+  /** Seat index whose turn it is, or null when no betting round is open. */
+  playerToAct(): number | null {
+    return this.isBettingRoundInProgress()
+      ? (this.hand?.playerToAct() ?? null)
+      : null;
+  }
+
+  legalActions(): LegalActions | null {
+    if (!this.isBettingRoundInProgress()) return null;
+    return this.hand?.legalActions() ?? null;
+  }
+
+  /** Chips the player to act must add to call. */
+  callAmount(): number {
+    if (!this.isBettingRoundInProgress()) return 0;
+    return this.hand?.callAmount() ?? 0;
+  }
+
+  /**
+   * Apply an action for the seat to act. `amount` is the TOTAL bet size on
+   * this street for bet/raise ("raise to").
+   */
+  act(action: PlayerAction, amount?: number): void {
+    const hand = this.hand;
+    const toAct = this.playerToAct();
+    if (!hand || toAct === null) {
+      throw new Error("No betting round in progress");
+    }
+    const seat = this.seats[toAct];
+    if (!seat) throw new Error(`No player at seat ${toAct}`);
+    hand.act(action, amount);
+    const after = hand.seat(toAct);
+    switch (action) {
+      case "fold":
+      case "check":
+        seat.lastAction = { action };
+        break;
+      default:
+        seat.lastAction = { action, amount: after?.bet ?? 0 };
+    }
+  }
+
+  /**
+   * Close the current betting round: deal the next street, or the whole
+   * run-out when nobody can act anymore (the controller reveals it
+   * progressively).
+   */
+  endBettingRound(): void {
+    if (!this.hand || !this.handInProgress) {
+      throw new Error("No hand in progress");
+    }
+    this.hand.endBettingRound();
+    this.seats.forEach((seat) => {
+      if (seat) seat.lastAction = null;
+    });
+    this.lastStreet = this.hand.street();
+  }
+
+  /**
+   * Resolve the hand: pay the pot(s), reveal cards, produce `HandResult`.
+   * Legal once `areBettingRoundsCompleted()`.
+   */
+  showdown(): HandResult {
+    const hand = this.hand;
+    if (!hand || !this.areBettingRoundsCompleted()) {
+      throw new Error("Betting rounds not completed");
+    }
+    const contenders = hand.contenders();
+    const foldedOut = contenders.length <= 1;
+    const board = hand.communityCards();
+    const potTotal = hand.potTotal();
+    const payouts = new Map(
+      hand.showdown().map((payout) => [payout.seatIndex, payout.amount])
+    );
+
+    const entries: HandResultEntry[] = [];
+    for (const state of hand.seatStates()) {
+      const seat = this.seats[state.seatIndex];
+      if (!seat) continue;
+      const revealed = !foldedOut && !state.folded;
+      entries.push({
+        seatIndex: state.seatIndex,
+        amountWon: payouts.get(state.seatIndex) ?? 0,
+        handDescription: revealed ? hand.describe(state.seatIndex) : null,
+        revealedCards: revealed ? state.holeCards.slice() : null,
+      });
+      // Sync stacks back to the table; a zero stack is a bust.
+      seat.stack = state.stack;
+      seat.busted = state.stack === 0;
+    }
+    this.handInProgress = false;
+    this.lastResult = {
+      handNumber: this.handNumber,
+      entries,
+      foldedOut,
+      board,
+      potTotal,
+    };
+    return this.lastResult;
+  }
+
+  // ─── Projection ─────────────────────────────────────────────────────────
+
+  /**
+   * Snapshot for the given viewer. The viewer sees their own hole cards;
+   * everyone else's are face-down until the showdown result reveals them.
+   */
+  snapshot(viewerSeat: number | null): TableSnapshot {
+    const inProgress = this.handInProgress;
+    const hand = this.hand;
+    const result = inProgress ? null : this.lastResult;
+    const toAct = this.playerToAct();
+    const dealerSeat = hand?.buttonSeat ?? null;
+    const community = inProgress
+      ? (hand?.communityCards() ?? [])
+      : (result?.board.slice() ?? []);
+    const pots: PotSnapshot[] =
+      inProgress && hand
+        ? hand.pots().map((pot) => ({
+            size: pot.size,
+            eligibleSeats: pot.eligibleSeats.slice(),
+          }))
+        : [];
+    const potTotal = inProgress
+      ? (hand?.potTotal() ?? 0)
+      : (result?.potTotal ?? 0);
+
+    const seats: (SeatSnapshot | null)[] = this.seats.map((seat, index) => {
+      if (!seat) return null;
+      const live = hand?.seat(index) ?? null;
+      const contesting = live !== null && !live.folded;
+      const stack = inProgress && live ? live.stack : seat.stack;
+      const betSize = inProgress && live ? live.bet : 0;
+
+      // Visibility: own cards while dealt in (and after the hand, so the
+      // result view keeps them); everyone else's only via the showdown.
+      let visibleHole: Card[] | null = null;
+      if (result) {
+        const entry = result.entries.find((e) => e.seatIndex === index);
+        if (entry?.revealedCards) visibleHole = entry.revealedCards.slice();
+        else if (viewerSeat === index && live) visibleHole = live.holeCards;
+      } else if (inProgress && viewerSeat === index && contesting && live) {
+        visibleHole = live.holeCards;
+      }
+
+      return {
+        seatIndex: index,
+        player: seat.player,
+        stack,
+        betSize,
+        inHand: inProgress && contesting,
+        hasCards: inProgress && contesting,
+        holeCards: visibleHole,
+        isDealer: dealerSeat === index,
+        isToAct: toAct === index,
+        isAllIn: inProgress && contesting && stack === 0,
+        lastAction: seat.lastAction,
+      };
+    });
+
+    let phase: TablePhase = "idle";
+    if (inProgress) {
+      phase = this.isBettingRoundInProgress() ? "betting" : "dealing";
+    } else if (result) {
+      phase = "hand-complete";
+    }
+
+    return {
+      handNumber: this.handNumber,
+      phase,
+      street: inProgress ? (hand?.street() ?? null) : this.lastStreet,
+      blinds: this.blinds,
+      communityCards: community,
+      pots,
+      potTotal,
+      seats,
+      dealerSeat,
+      toAct,
+      legalActions: this.legalActions(),
+      callAmount: this.callAmount(),
+      lastResult: this.lastResult,
+    };
+  }
+
+  /** Hole cards of a seat in the current (or just finished) hand. */
+  holeCardsOf(seatIndex: number): Card[] | null {
+    return this.hand?.seat(seatIndex)?.holeCards ?? null;
+  }
+
+  communityCards(): Card[] {
+    return this.handInProgress ? (this.hand?.communityCards() ?? []) : [];
+  }
+
+  /** Seats still contesting the pot (dealt in, not folded). */
+  contendingSeats(): number[] {
+    return this.handInProgress ? (this.hand?.contenders() ?? []) : [];
+  }
+
+  private assertSeatIndex(seatIndex: number): void {
+    if (seatIndex < 0 || seatIndex >= this.seatCount) {
+      throw new Error(`Seat ${seatIndex} out of range`);
+    }
+  }
+}

--- a/src/features/PokerTable/engine/botBrain.test.ts
+++ b/src/features/PokerTable/engine/botBrain.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "vitest";
+
+import { type BotDecisionInput, decideBotAction } from "./botBrain";
+import { type Card, createSeededRng } from "./cards";
+import { chenScore, describeHand, estimateEquity } from "./handEvaluator";
+import { BOT_PERSONAS, findPersona } from "./personas";
+
+const SUIT_BY_CODE: Record<string, Card["suit"]> = {
+  c: "clubs",
+  d: "diamonds",
+  h: "hearts",
+  s: "spades",
+};
+const c = (code: string): Card => ({
+  rank: code[0] as Card["rank"],
+  suit: SUIT_BY_CODE[code[1]],
+});
+
+const balanced = findPersona("vector").style;
+
+function base(overrides: Partial<BotDecisionInput>): BotDecisionInput {
+  return {
+    holeCards: [c("As"), c("Ah")],
+    communityCards: [],
+    street: "preflop",
+    legalActions: {
+      actions: ["fold", "call", "raise"],
+      chipRange: { min: 2000, max: 50000 },
+    },
+    callAmount: 1000,
+    potTotal: 1500,
+    stack: 50000,
+    betSize: 0,
+    opponentsInHand: 4,
+    bigBlind: 1000,
+    style: balanced,
+    rng: createSeededRng(1),
+    equitySamples: 120,
+    ...overrides,
+  };
+}
+
+describe("handEvaluator", () => {
+  it("scores starting hands on the Chen scale", () => {
+    expect(chenScore([c("As"), c("Ah")])).toBe(20);
+    expect(chenScore([c("As"), c("Ks")])).toBe(12);
+    expect(chenScore([c("7c"), c("2d")])).toBe(-1);
+    expect(chenScore([c("Ts"), c("9s")])).toBe(8);
+  });
+
+  it("describes made hands", () => {
+    expect(
+      describeHand([
+        c("Kh"),
+        c("Kd"),
+        c("2s"),
+        c("2c"),
+        c("9h"),
+        c("Qs"),
+        c("3d"),
+      ])
+    ).toMatch(/Two Pair/);
+    expect(describeHand([c("Kh"), c("Kd")])).toBeNull();
+  });
+
+  it("estimates equity roughly right for a monster vs. trash", () => {
+    const rng = createSeededRng(3);
+    const aces = estimateEquity({
+      holeCards: [c("As"), c("Ah")],
+      communityCards: [],
+      opponents: 1,
+      samples: 400,
+      rng,
+    });
+    const trash = estimateEquity({
+      holeCards: [c("7c"), c("2d")],
+      communityCards: [],
+      opponents: 1,
+      samples: 400,
+      rng,
+    });
+    expect(aces).toBeGreaterThan(0.75);
+    expect(trash).toBeLessThan(0.45);
+  });
+});
+
+describe("decideBotAction", () => {
+  it("raises premium hands preflop with an aggressive persona", () => {
+    const decision = decideBotAction(
+      base({ style: findPersona("lambda").style, rng: () => 0.1 })
+    );
+    expect(decision.action).toBe("raise");
+    expect(decision.amount).toBeGreaterThanOrEqual(2000);
+    expect(decision.amount).toBeLessThanOrEqual(50000);
+  });
+
+  it("folds trash to a raise for a tight persona", () => {
+    const decision = decideBotAction(
+      base({
+        holeCards: [c("7c"), c("2d")],
+        callAmount: 3000,
+        betSize: 0,
+        style: findPersona("cipher").style,
+        rng: () => 0.9,
+      })
+    );
+    expect(decision.action).toBe("fold");
+  });
+
+  it("checks rather than folds when checking is free", () => {
+    const decision = decideBotAction(
+      base({
+        holeCards: [c("7c"), c("2d")],
+        callAmount: 0,
+        legalActions: {
+          actions: ["fold", "check", "raise"],
+          chipRange: { min: 2000, max: 50000 },
+        },
+        rng: () => 0.99,
+      })
+    );
+    expect(decision.action).toBe("check");
+  });
+
+  it("bets a strong made hand postflop when checked to", () => {
+    const decision = decideBotAction(
+      base({
+        holeCards: [c("Ks"), c("Kh")],
+        communityCards: [c("Kd"), c("7s"), c("2c")],
+        street: "flop",
+        callAmount: 0,
+        potTotal: 6000,
+        opponentsInHand: 1,
+        legalActions: {
+          actions: ["fold", "check", "bet"],
+          chipRange: { min: 1000, max: 50000 },
+        },
+        style: findPersona("lambda").style,
+        rng: () => 0.05,
+      })
+    );
+    expect(decision.action).toBe("bet");
+    expect(decision.amount).toBeGreaterThanOrEqual(1000);
+  });
+
+  it("folds a hopeless hand to a large river bet", () => {
+    const decision = decideBotAction(
+      base({
+        holeCards: [c("3c"), c("2d")],
+        communityCards: [c("Kd"), c("Qs"), c("8c"), c("5h"), c("9h")],
+        street: "river",
+        callAmount: 20000,
+        potTotal: 24000,
+        opponentsInHand: 1,
+        legalActions: {
+          actions: ["fold", "call", "raise"],
+          chipRange: { min: 40000, max: 50000 },
+        },
+        // A constant rng would degenerate the equity sampler's shuffle, so
+        // seed it and switch bluffing off to keep the decision deterministic.
+        style: { ...balanced, bluffFrequency: 0 },
+        rng: createSeededRng(5),
+      })
+    );
+    expect(decision.action).toBe("fold");
+  });
+
+  it("only ever returns a legal action with an in-range size", () => {
+    const rng = createSeededRng(11);
+    for (const persona of BOT_PERSONAS) {
+      for (let i = 0; i < 40; i += 1) {
+        const facing = rng() < 0.5;
+        const legalActions = facing
+          ? {
+              actions: ["fold", "call", "raise"] as const,
+              chipRange: { min: 4000, max: 30000 },
+            }
+          : {
+              actions: ["fold", "check", "bet"] as const,
+              chipRange: { min: 1000, max: 30000 },
+            };
+        const decision = decideBotAction(
+          base({
+            holeCards: [c("Qd"), c("Jd")],
+            communityCards: [c("Td"), c("4s"), c("8c")],
+            street: "flop",
+            callAmount: facing ? 2000 : 0,
+            legalActions: {
+              actions: [...legalActions.actions],
+              chipRange: legalActions.chipRange,
+            },
+            style: persona.style,
+            rng,
+            equitySamples: 40,
+          })
+        );
+        expect(legalActions.actions).toContain(decision.action);
+        if (decision.amount !== undefined) {
+          expect(decision.amount).toBeGreaterThanOrEqual(
+            legalActions.chipRange.min
+          );
+          expect(decision.amount).toBeLessThanOrEqual(
+            legalActions.chipRange.max
+          );
+        }
+      }
+    }
+  });
+});

--- a/src/features/PokerTable/engine/botBrain.ts
+++ b/src/features/PokerTable/engine/botBrain.ts
@@ -1,0 +1,209 @@
+/**
+ * Heuristic Hold'em bot: Chen-score tiers preflop, Monte-Carlo equity vs.
+ * pot odds postflop, shaped by a persona's looseness / aggression / bluff
+ * knobs. Deliberately beatable — this is a play-chip table, not a solver —
+ * but it folds trash, values strong hands and bluffs occasionally, which
+ * is what makes hands feel like poker.
+ *
+ * Pure function of its input plus the injected `rng`, so decisions are
+ * reproducible in tests.
+ */
+import type { Card, Rng } from "./cards";
+import { chenScore, estimateEquity } from "./handEvaluator";
+import type { BotStyle } from "./personas";
+import type { LegalActions, PlayerAction, SeatAction, Street } from "./types";
+
+export interface BotDecisionInput {
+  holeCards: readonly Card[];
+  communityCards: readonly Card[];
+  street: Street;
+  legalActions: LegalActions;
+  /** Chips this bot must add to call (0 when checking is legal). */
+  callAmount: number;
+  /** Collected pots plus all live bets, before this bot acts. */
+  potTotal: number;
+  /** Chips behind. */
+  stack: number;
+  /** Chips this bot has already committed on the current street. */
+  betSize: number;
+  /** Opponents still contesting the pot. */
+  opponentsInHand: number;
+  bigBlind: number;
+  style: BotStyle;
+  rng: Rng;
+  /** Monte-Carlo samples for postflop equity (tests use fewer). */
+  equitySamples?: number;
+}
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+/** Round bet sizes so bots bet `1.2M`, not `1,237,412`. */
+function roundBet(amount: number, bigBlind: number): number {
+  const unit = Math.max(1, Math.round(bigBlind / 10));
+  return Math.round(amount / unit) * unit;
+}
+
+/** Legal total bet nearest to `target` — respects the engine's chip range. */
+function sizeWithinRange(
+  target: number,
+  legalActions: LegalActions,
+  bigBlind: number
+): number | null {
+  const range = legalActions.chipRange;
+  if (!range) return null;
+  return clamp(roundBet(target, bigBlind), range.min, range.max);
+}
+
+function has(legalActions: LegalActions, action: PlayerAction): boolean {
+  return legalActions.actions.includes(action);
+}
+
+/** Safest legal passive action. */
+function passive(legalActions: LegalActions): SeatAction {
+  if (has(legalActions, "check")) return { action: "check" };
+  if (has(legalActions, "call")) return { action: "call" };
+  return { action: "fold" };
+}
+
+function aggressive(
+  legalActions: LegalActions,
+  target: number,
+  bigBlind: number
+): SeatAction | null {
+  const action: PlayerAction | null = has(legalActions, "raise")
+    ? "raise"
+    : has(legalActions, "bet")
+      ? "bet"
+      : null;
+  if (!action) return null;
+  const amount = sizeWithinRange(target, legalActions, bigBlind);
+  if (amount === null) return null;
+  return { action, amount };
+}
+
+export function decideBotAction(input: BotDecisionInput): SeatAction {
+  return input.street === "preflop"
+    ? decidePreflop(input)
+    : decidePostflop(input);
+}
+
+function decidePreflop(input: BotDecisionInput): SeatAction {
+  const { legalActions, style, rng, bigBlind, callAmount, potTotal, betSize } =
+    input;
+  // Chen: 72o ≈ -1 … AA = 20 → 0..1
+  const strength = clamp((chenScore(input.holeCards) + 1) / 21, 0, 1);
+  const openThreshold = 0.62 - style.looseness * 0.35;
+  const facingRaise = callAmount > bigBlind || betSize + callAmount > bigBlind;
+
+  if (facingRaise) {
+    const continueThreshold = openThreshold + 0.12;
+    if (strength >= continueThreshold + 0.28 && rng() < style.aggression) {
+      // 3-bet: about 3× the bet we face.
+      const raiseTo = (betSize + callAmount) * 3;
+      return (
+        aggressive(legalActions, raiseTo, bigBlind) ?? passive(legalActions)
+      );
+    }
+    if (strength >= continueThreshold) return passive(legalActions);
+    // Occasional light defence when the raise is small relative to the pot.
+    const cheap = callAmount <= potTotal * 0.25;
+    if (cheap && strength >= openThreshold && rng() < style.looseness * 0.5) {
+      return passive(legalActions);
+    }
+    return { action: "fold" };
+  }
+
+  // Unopened / limped pot.
+  if (strength >= openThreshold) {
+    if (rng() < style.aggression + 0.1) {
+      const limpers = Math.max(0, Math.round(potTotal / bigBlind) - 2);
+      const raiseTo = bigBlind * (2.5 + 0.5 * limpers);
+      return (
+        aggressive(legalActions, raiseTo, bigBlind) ?? passive(legalActions)
+      );
+    }
+    return passive(legalActions);
+  }
+  if (has(legalActions, "check")) return { action: "check" };
+  // Loose personas limp marginal hands for a single blind.
+  if (
+    callAmount <= bigBlind &&
+    strength >= openThreshold - 0.15 &&
+    rng() < style.looseness
+  ) {
+    return { action: "call" };
+  }
+  return { action: "fold" };
+}
+
+function decidePostflop(input: BotDecisionInput): SeatAction {
+  const {
+    legalActions,
+    style,
+    rng,
+    bigBlind,
+    callAmount,
+    potTotal,
+    stack,
+    opponentsInHand,
+  } = input;
+  const equity = estimateEquity({
+    holeCards: input.holeCards,
+    communityCards: input.communityCards,
+    opponents: opponentsInHand,
+    samples: input.equitySamples ?? 250,
+    rng,
+  });
+  const facingBet = callAmount > 0;
+  const potOdds = facingBet ? callAmount / (potTotal + callAmount) : 0;
+  const multiway = Math.max(0, opponentsInHand - 1);
+
+  if (facingBet) {
+    // Calling for our whole stack needs a bit more than pot odds.
+    const allInCall = callAmount >= stack;
+    const required = potOdds + 0.03 + (allInCall ? 0.05 : 0);
+    if (equity >= required + 0.25 && rng() < style.aggression) {
+      const raiseTo = Math.max(callAmount * 3, potTotal * 0.75);
+      return (
+        aggressive(legalActions, raiseTo, bigBlind) ?? passive(legalActions)
+      );
+    }
+    if (equity >= required) return passive(legalActions);
+    if (
+      rng() < style.bluffFrequency * 0.3 &&
+      callAmount < potTotal * 0.6 &&
+      multiway === 0
+    ) {
+      const raiseTo = Math.max(callAmount * 3, potTotal * 0.8);
+      return aggressive(legalActions, raiseTo, bigBlind) ?? { action: "fold" };
+    }
+    return { action: "fold" };
+  }
+
+  // Checked to us.
+  const valueThreshold = 0.55 + 0.05 * multiway;
+  if (equity >= valueThreshold) {
+    if (rng() < style.aggression + 0.15) {
+      const fraction = 0.55 + rng() * 0.2 + (equity > 0.8 ? 0.15 : 0);
+      return (
+        aggressive(legalActions, potTotal * fraction, bigBlind) ??
+        passive(legalActions)
+      );
+    }
+    return passive(legalActions);
+  }
+  if (equity >= 0.4 && rng() < style.aggression * 0.4) {
+    return (
+      aggressive(legalActions, potTotal * 0.5, bigBlind) ??
+      passive(legalActions)
+    );
+  }
+  if (rng() < style.bluffFrequency && multiway === 0) {
+    return (
+      aggressive(legalActions, potTotal * 0.55, bigBlind) ??
+      passive(legalActions)
+    );
+  }
+  return passive(legalActions);
+}

--- a/src/features/PokerTable/engine/cards.ts
+++ b/src/features/PokerTable/engine/cards.ts
@@ -1,0 +1,98 @@
+/**
+ * Card primitives shared by the poker table engine, the bots and the UI.
+ *
+ * The rules engine (`poker-ts`) and the evaluator (`pokersolver`) disagree
+ * on card encoding — objects with long suit names vs. two-char codes — so
+ * this module owns the one canonical `Card` shape and the conversions.
+ */
+
+export const RANKS = [
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "T",
+  "J",
+  "Q",
+  "K",
+  "A",
+] as const;
+export type Rank = (typeof RANKS)[number];
+
+export const SUITS = ["clubs", "diamonds", "hearts", "spades"] as const;
+export type Suit = (typeof SUITS)[number];
+
+export interface Card {
+  rank: Rank;
+  suit: Suit;
+}
+
+const SUIT_CODE: Record<Suit, string> = {
+  clubs: "c",
+  diamonds: "d",
+  hearts: "h",
+  spades: "s",
+};
+
+/** `pokersolver` code, e.g. `{A, spades}` → `"As"`. */
+export function toSolverCode(card: Card): string {
+  return `${card.rank}${SUIT_CODE[card.suit]}`;
+}
+
+/** Stable key for React lists / dedup. */
+export function cardKey(card: Card): string {
+  return toSolverCode(card);
+}
+
+/** Zero-based rank index; `2` → 0, `A` → 12. */
+export function rankIndex(rank: Rank): number {
+  return RANKS.indexOf(rank);
+}
+
+/** All 52 cards, ranks ascending within suits. */
+export function fullDeck(): Card[] {
+  const deck: Card[] = [];
+  for (const suit of SUITS) {
+    for (const rank of RANKS) deck.push({ rank, suit });
+  }
+  return deck;
+}
+
+/** Cards of the full deck not present in `used`. */
+export function remainingDeck(used: readonly Card[]): Card[] {
+  const usedKeys = new Set(used.map(cardKey));
+  return fullDeck().filter((card) => !usedKeys.has(cardKey(card)));
+}
+
+/** Uniform `[0, 1)` source; injectable so bots and tests are reproducible. */
+export type Rng = () => number;
+
+/** In-place Fisher–Yates; returns the same array. */
+export function shuffleInPlace<T>(items: T[], rng: Rng): T[] {
+  for (let i = items.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1));
+    const tmp = items[i];
+    items[i] = items[j];
+    items[j] = tmp;
+  }
+  return items;
+}
+
+/**
+ * Small deterministic PRNG (mulberry32) for tests and reproducible bot
+ * decisions. Not for dealing — the rules engine deals with its own RNG.
+ */
+export function createSeededRng(seed: number): Rng {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/src/features/PokerTable/engine/handEvaluator.ts
+++ b/src/features/PokerTable/engine/handEvaluator.ts
@@ -1,0 +1,117 @@
+/**
+ * Hand strength helpers on top of `pokersolver`.
+ *
+ * Two jobs: describe a made hand for the UI ("Two Pair, K's & 2's"), and
+ * estimate equity by Monte-Carlo for the bots. The rules engine already
+ * decides showdowns; this module never awards pots.
+ */
+import { Hand } from "pokersolver";
+
+import {
+  type Card,
+  type Rng,
+  rankIndex,
+  remainingDeck,
+  shuffleInPlace,
+  toSolverCode,
+} from "./cards";
+
+/** `"Two Pair, K's & 2's"` for 5–7 cards; null when fewer than 5. */
+export function describeHand(cards: readonly Card[]): string | null {
+  if (cards.length < 5) return null;
+  return Hand.solve(cards.map(toSolverCode)).descr;
+}
+
+export interface EquityInput {
+  holeCards: readonly Card[];
+  communityCards: readonly Card[];
+  /** Opponents still contesting the pot. */
+  opponents: number;
+  /** Simulations; ~300 keeps a decision under ~50ms in the renderer. */
+  samples?: number;
+  rng: Rng;
+}
+
+/**
+ * Probability (0–1) that `holeCards` wins or ties against `opponents`
+ * random hands after dealing out the board. Ties count fractionally.
+ */
+export function estimateEquity({
+  holeCards,
+  communityCards,
+  opponents,
+  samples = 300,
+  rng,
+}: EquityInput): number {
+  if (holeCards.length !== 2) return 0;
+  const opponentCount = Math.max(1, opponents);
+  const stub = remainingDeck([...holeCards, ...communityCards]);
+  const heroCodes = holeCards.map(toSolverCode);
+  const boardCodes = communityCards.map(toSolverCode);
+  const missingBoard = 5 - communityCards.length;
+
+  let score = 0;
+  for (let i = 0; i < samples; i += 1) {
+    shuffleInPlace(stub, rng);
+    let cursor = 0;
+    const board = boardCodes.slice();
+    for (let b = 0; b < missingBoard; b += 1) {
+      board.push(toSolverCode(stub[cursor]));
+      cursor += 1;
+    }
+    const heroHand = Hand.solve([...heroCodes, ...board]);
+    const hands = [heroHand];
+    for (let o = 0; o < opponentCount; o += 1) {
+      const c1 = toSolverCode(stub[cursor]);
+      const c2 = toSolverCode(stub[cursor + 1]);
+      cursor += 2;
+      hands.push(Hand.solve([c1, c2, ...board]));
+    }
+    const winners = Hand.winners(hands);
+    if (winners.includes(heroHand)) {
+      score += 1 / winners.length;
+    }
+  }
+  return score / samples;
+}
+
+/**
+ * Chen formula — the classic preflop hand score (AA = 20, 72o ≈ -1).
+ * Used by the bots to tier starting hands without a lookup table.
+ */
+export function chenScore(holeCards: readonly Card[]): number {
+  if (holeCards.length !== 2) return 0;
+  const [a, b] = holeCards;
+  const hi = rankIndex(a.rank) >= rankIndex(b.rank) ? a : b;
+  const lo = hi === a ? b : a;
+  const hiIndex = rankIndex(hi.rank);
+  const loIndex = rankIndex(lo.rank);
+
+  const highCardPoints = (index: number): number => {
+    // 2..9 → 1..4.5 (half the pip), T=5, J=6, Q=7, K=8, A=10
+    if (index >= 12) return 10;
+    if (index === 11) return 8;
+    if (index === 10) return 7;
+    if (index === 9) return 6;
+    if (index === 8) return 5;
+    return (index + 2) / 2;
+  };
+
+  let score = highCardPoints(hiIndex);
+  const paired = hiIndex === loIndex;
+  if (paired) {
+    score = Math.max(5, score * 2);
+  }
+  if (a.suit === b.suit && !paired) score += 2;
+
+  const gap = paired ? 0 : hiIndex - loIndex - 1;
+  if (gap === 1) score -= 1;
+  else if (gap === 2) score -= 2;
+  else if (gap === 3) score -= 4;
+  else if (gap >= 4) score -= 5;
+
+  // Straight bonus: connectors / one-gappers below queen.
+  if (!paired && gap <= 1 && hiIndex < 10) score += 1;
+
+  return Math.ceil(score);
+}

--- a/src/features/PokerTable/engine/holdemHand.test.ts
+++ b/src/features/PokerTable/engine/holdemHand.test.ts
@@ -1,0 +1,351 @@
+import { describe, expect, it } from "vitest";
+
+import { type Card, createSeededRng, fullDeck } from "./cards";
+import { HoldemHand, derivePots } from "./holdemHand";
+
+const SUIT_BY_CODE: Record<string, Card["suit"]> = {
+  c: "clubs",
+  d: "diamonds",
+  h: "hearts",
+  s: "spades",
+};
+const c = (code: string): Card => ({
+  rank: code[0] as Card["rank"],
+  suit: SUIT_BY_CODE[code[1]],
+});
+
+/** Deck whose front holds `front` (dealt in order), rest arbitrary. */
+function deckWith(front: string[]): Card[] {
+  const wanted = front.map(c);
+  const key = (card: Card) => `${card.rank}${card.suit}`;
+  const used = new Set(wanted.map(key));
+  return [...wanted, ...fullDeck().filter((card) => !used.has(key(card)))];
+}
+
+function totalChips(hand: HoldemHand): number {
+  return (
+    hand.seatStates().reduce((sum, s) => sum + s.stack, 0) + hand.potTotal()
+  );
+}
+
+describe("HoldemHand", () => {
+  it("posts blinds and gives the big blind its option when everyone limps", () => {
+    const hand = new HoldemHand({
+      seats: [0, 1, 2, 3].map((seatIndex) => ({ seatIndex, stack: 10_000 })),
+      buttonSeat: 0,
+      smallBlind: 500,
+      bigBlind: 1000,
+      rng: createSeededRng(1),
+    });
+    expect(hand.seat(1)?.bet).toBe(500);
+    expect(hand.seat(2)?.bet).toBe(1000);
+    expect(hand.playerToAct()).toBe(3); // UTG
+    hand.act("call");
+    hand.act("call"); // button
+    hand.act("call"); // small blind completes
+    // Big blind still owes an action: check or raise.
+    expect(hand.playerToAct()).toBe(2);
+    expect(hand.legalActions()?.actions).toEqual(["fold", "check", "raise"]);
+    hand.act("check");
+    expect(hand.isBettingRoundInProgress()).toBe(false);
+    hand.endBettingRound();
+    expect(hand.street()).toBe("flop");
+    expect(hand.communityCards()).toHaveLength(3);
+    // Postflop the first active seat left of the button acts.
+    expect(hand.playerToAct()).toBe(1);
+    expect(hand.potTotal()).toBe(4000);
+  });
+
+  it("heads-up: the button posts the small blind and acts first preflop, second postflop", () => {
+    const hand = new HoldemHand({
+      seats: [
+        { seatIndex: 0, stack: 10_000 },
+        { seatIndex: 3, stack: 10_000 },
+      ],
+      buttonSeat: 3,
+      smallBlind: 500,
+      bigBlind: 1000,
+      rng: createSeededRng(2),
+    });
+    expect(hand.seat(3)?.bet).toBe(500);
+    expect(hand.seat(0)?.bet).toBe(1000);
+    expect(hand.playerToAct()).toBe(3);
+    hand.act("call");
+    expect(hand.playerToAct()).toBe(0);
+    hand.act("check");
+    hand.endBettingRound();
+    expect(hand.playerToAct()).toBe(0);
+  });
+
+  it("enforces the min-raise as the last full raise increment", () => {
+    const hand = new HoldemHand({
+      seats: [0, 1, 2].map((seatIndex) => ({ seatIndex, stack: 50_000 })),
+      buttonSeat: 0,
+      smallBlind: 500,
+      bigBlind: 1000,
+      rng: createSeededRng(3),
+    });
+    // UTG (seat 0) raises to 3000: increment 2000.
+    expect(hand.legalActions()?.chipRange).toEqual({ min: 2000, max: 50_000 });
+    hand.act("raise", 3000);
+    // Next raiser must go to at least 5000.
+    expect(hand.legalActions()?.chipRange?.min).toBe(5000);
+    hand.act("raise", 9000); // increment 6000
+    expect(hand.legalActions()?.chipRange?.min).toBe(15_000);
+    // Below-min sizes are lifted to the minimum.
+    hand.act("raise", 10_000);
+    expect(hand.seat(2)?.bet).toBe(15_000);
+  });
+
+  it("awards side pots correctly with two all-ins for different amounts", () => {
+    // seat 0: 27_380 (short), seat 1: 22_200 (shorter), seat 2: 80_550, seat 3: 105_500
+    // Deck: seat 0 gets aces (wins main pot), seat 1 kings, seat 2 queens,
+    // seat 3 junk. Board is blanks so hands hold.
+    const deck = deckWith([
+      "As",
+      "Ah", // seat 0
+      "Ks",
+      "Kh", // seat 1
+      "Qs",
+      "Qh", // seat 2
+      "7c",
+      "2d", // seat 3
+      "3s",
+      "8d",
+      "Tc",
+      "4h",
+      "9c", // board
+    ]);
+    const hand = new HoldemHand({
+      seats: [
+        { seatIndex: 0, stack: 27_380 },
+        { seatIndex: 1, stack: 22_200 },
+        { seatIndex: 2, stack: 80_550 },
+        { seatIndex: 3, stack: 105_500 },
+      ],
+      buttonSeat: 3,
+      smallBlind: 500,
+      bigBlind: 1000,
+      deck,
+    });
+    const before = totalChips(hand);
+    // SB seat 0, BB seat 1, UTG seat 2.
+    expect(hand.playerToAct()).toBe(2);
+    hand.act("raise", 27_380);
+    hand.act("call"); // seat 3
+    hand.act("call"); // seat 0 all-in for 27_380
+    hand.act("call"); // seat 1 all-in for 22_200 (short)
+    expect(hand.isBettingRoundInProgress()).toBe(false);
+    hand.endBettingRound();
+    // Seats 2 and 3 can still bet on the flop.
+    expect(hand.street()).toBe("flop");
+    expect(hand.playerToAct()).toBe(2);
+    const pots = hand.pots();
+    expect(pots).toEqual([
+      { size: 22_200 * 4, eligibleSeats: [0, 1, 2, 3] },
+      { size: 5_180 * 3, eligibleSeats: [0, 2, 3] },
+    ]);
+    // Flop: seat 2 bets, seat 3 calls — grows a third pot for [2, 3] only.
+    hand.act("bet", 10_000);
+    hand.act("call");
+    hand.endBettingRound();
+    hand.act("check");
+    hand.act("check");
+    hand.endBettingRound();
+    hand.act("check");
+    hand.act("check");
+    hand.endBettingRound();
+    expect(hand.areBettingRoundsCompleted()).toBe(true);
+    expect(hand.pots()).toEqual([
+      { size: 88_800, eligibleSeats: [0, 1, 2, 3] },
+      { size: 15_540, eligibleSeats: [0, 2, 3] },
+      { size: 20_000, eligibleSeats: [2, 3] },
+    ]);
+    const payouts = hand.showdown();
+    const byseat = Object.fromEntries(
+      payouts.map((p) => [p.seatIndex, p.amount])
+    );
+    // Aces (seat 0) take the main pot AND the first side pot; queens (seat 2)
+    // take the pot only 2 and 3 funded. Kings (seat 1) get nothing.
+    expect(byseat[0]).toBe(88_800 + 15_540);
+    expect(byseat[2]).toBe(20_000);
+    expect(byseat[1]).toBeUndefined();
+    expect(byseat[3]).toBeUndefined();
+    expect(totalChips(hand)).toBe(before);
+    expect(hand.seat(1)?.stack).toBe(0);
+    expect(hand.seat(0)?.stack).toBe(88_800 + 15_540);
+  });
+
+  it("runs out the board when everyone left is all-in", () => {
+    const hand = new HoldemHand({
+      seats: [
+        { seatIndex: 0, stack: 10_000 },
+        { seatIndex: 1, stack: 8_000 },
+      ],
+      buttonSeat: 0,
+      smallBlind: 500,
+      bigBlind: 1000,
+      rng: createSeededRng(4),
+    });
+    hand.act("raise", 10_000);
+    hand.act("call");
+    expect(hand.isBettingRoundInProgress()).toBe(false);
+    expect(hand.areBettingRoundsCompleted()).toBe(false);
+    hand.endBettingRound();
+    expect(hand.communityCards()).toHaveLength(5);
+    expect(hand.areBettingRoundsCompleted()).toBe(true);
+    const payouts = hand.showdown();
+    expect(payouts.reduce((s, p) => s + p.amount, 0)).toBe(18_000);
+    // The uncalled 2_000 always returns to seat 0.
+    expect(
+      payouts.find((p) => p.seatIndex === 0)?.amount
+    ).toBeGreaterThanOrEqual(2_000);
+  });
+
+  it("gives odd chips to the first winner left of the button on a tie", () => {
+    // Board is a royal flush; everyone plays the board.
+    const deck = deckWith([
+      "2c",
+      "3d", // seat 0 (button)
+      "4c",
+      "5d", // seat 1 (SB)
+      "2h",
+      "3s", // seat 2 (BB)
+      "Ts",
+      "Js",
+      "Qs",
+      "Ks",
+      "As",
+    ]);
+    const hand = new HoldemHand({
+      seats: [0, 1, 2].map((seatIndex) => ({ seatIndex, stack: 100 })),
+      buttonSeat: 0,
+      smallBlind: 1,
+      bigBlind: 2,
+      deck,
+    });
+    hand.act("raise", 4); // seat 0 (min raise: 2 + 2)
+    hand.act("fold"); // seat 1 (SB's 1 chip stays in the pot)
+    hand.act("call"); // seat 2
+    for (let street = 0; street < 3; street += 1) {
+      hand.endBettingRound();
+      hand.act("check");
+      hand.act("check");
+    }
+    hand.endBettingRound();
+    expect(hand.potTotal()).toBe(9);
+    const payouts = hand.showdown();
+    // 9 chips, two winners: 4 each, odd chip to seat 2 (first left of button).
+    expect(payouts.find((p) => p.seatIndex === 0)?.amount).toBe(4);
+    expect(payouts.find((p) => p.seatIndex === 2)?.amount).toBe(5);
+  });
+
+  it("ends the hand immediately when everyone folds to one player", () => {
+    const hand = new HoldemHand({
+      seats: [0, 1, 2].map((seatIndex) => ({ seatIndex, stack: 10_000 })),
+      buttonSeat: 0,
+      smallBlind: 500,
+      bigBlind: 1000,
+      rng: createSeededRng(5),
+    });
+    hand.act("fold");
+    hand.act("fold");
+    expect(hand.isBettingRoundInProgress()).toBe(false);
+    expect(hand.areBettingRoundsCompleted()).toBe(true);
+    expect(hand.contenders()).toEqual([2]);
+    const payouts = hand.showdown();
+    expect(payouts).toEqual([{ seatIndex: 2, amount: 1500 }]);
+    expect(hand.seat(2)?.stack).toBe(10_500);
+  });
+
+  it("conserves chips across many random hands", () => {
+    const rng = createSeededRng(9);
+    for (let trial = 0; trial < 60; trial += 1) {
+      const seatCount = 2 + Math.floor(rng() * 5);
+      const seats = Array.from({ length: seatCount }, (_, i) => ({
+        seatIndex: i,
+        stack: 1000 + Math.floor(rng() * 40_000),
+      }));
+      const hand = new HoldemHand({
+        seats,
+        buttonSeat: Math.floor(rng() * seatCount),
+        smallBlind: 500,
+        bigBlind: 1000,
+        rng,
+      });
+      const before = totalChips(hand);
+      let guard = 0;
+      while (!hand.areBettingRoundsCompleted() && guard++ < 200) {
+        while (hand.isBettingRoundInProgress()) {
+          const legal = hand.legalActions()!;
+          const action =
+            legal.actions[Math.floor(rng() * legal.actions.length)];
+          if ((action === "bet" || action === "raise") && legal.chipRange) {
+            const { min, max } = legal.chipRange;
+            hand.act(
+              action,
+              rng() < 0.3 ? max : min + Math.floor(rng() * (max - min + 1))
+            );
+          } else {
+            hand.act(action);
+          }
+          expect(totalChips(hand)).toBe(before);
+        }
+        hand.endBettingRound();
+      }
+      const potBeforePayout = hand.potTotal();
+      const payouts = hand.showdown();
+      // Every chip in the middle was paid out, and nothing was created.
+      expect(payouts.reduce((s, p) => s + p.amount, 0)).toBe(potBeforePayout);
+      expect(hand.seatStates().reduce((s, x) => s + x.stack, 0)).toBe(before);
+    }
+  });
+});
+
+describe("derivePots", () => {
+  it("keeps a folded seat's chips in the pots it reached without making it eligible", () => {
+    const pots = derivePots([
+      {
+        seatIndex: 0,
+        stack: 0,
+        bet: 0,
+        committed: 300,
+        folded: false,
+        allIn: true,
+        holeCards: [],
+      },
+      {
+        seatIndex: 1,
+        stack: 0,
+        bet: 0,
+        committed: 200,
+        folded: true,
+        allIn: false,
+        holeCards: [],
+      },
+      {
+        seatIndex: 2,
+        stack: 0,
+        bet: 0,
+        committed: 500,
+        folded: false,
+        allIn: false,
+        holeCards: [],
+      },
+      {
+        seatIndex: 3,
+        stack: 0,
+        bet: 0,
+        committed: 500,
+        folded: false,
+        allIn: false,
+        holeCards: [],
+      },
+    ]);
+    expect(pots).toEqual([
+      { size: 200 * 4 + 100 * 3, eligibleSeats: [0, 2, 3] },
+      { size: 200 * 2, eligibleSeats: [2, 3] },
+    ]);
+    expect(pots.reduce((s, p) => s + p.size, 0)).toBe(300 + 200 + 500 + 500);
+  });
+});

--- a/src/features/PokerTable/engine/holdemHand.ts
+++ b/src/features/PokerTable/engine/holdemHand.ts
@@ -1,0 +1,495 @@
+/**
+ * HoldemHand — the rules of ONE no-limit Texas Hold'em hand.
+ *
+ * Self-contained on purpose. The npm rules engines we evaluated either
+ * mishandle side pots once a hand continues past an all-in (all-in seats
+ * dropped from later streets, so their pot share vanishes or is paid to
+ * the wrong seat) or pull in Node-only modules; the surface needed here is
+ * small enough to own and to prove with the chip-conservation tests.
+ *
+ * Model:
+ *   - `committed` per seat is the total put in over the WHOLE hand. Side
+ *     pots are derived from those totals at showdown (the standard
+ *     contribution-level algorithm), so nothing is ever mis-collected
+ *     mid-hand and folded chips stay in the pots they reached.
+ *   - A betting round tracks `bet` (this street), `biggestBet`, the last
+ *     full-raise increment (`minRaise`) and a queue of seats still owing
+ *     an action. Any bet/raise re-queues every other active seat; the round
+ *     ends when the queue is empty. Preflop the queue ends at the big
+ *     blind, which gives it its option.
+ *   - Once fewer than two seats can still act, remaining streets are
+ *     dealt at once (`runOut`) and the hand goes to showdown.
+ *
+ * Amounts are integer chips; bet/raise sizes are TOTAL bet on the street
+ * ("raise to"), like every real client.
+ */
+import { Hand } from "pokersolver";
+
+import {
+  type Card,
+  type Rng,
+  fullDeck,
+  shuffleInPlace,
+  toSolverCode,
+} from "./cards";
+import type { LegalActions, PlayerAction, Street } from "./types";
+
+export interface HandSeatInput {
+  seatIndex: number;
+  stack: number;
+}
+
+export interface HandSeatState {
+  seatIndex: number;
+  stack: number;
+  /** Chips bet on the current street. */
+  bet: number;
+  /** Chips committed over the whole hand. */
+  committed: number;
+  folded: boolean;
+  allIn: boolean;
+  holeCards: Card[];
+}
+
+export interface PotShare {
+  size: number;
+  eligibleSeats: number[];
+}
+
+export interface ShowdownPayout {
+  seatIndex: number;
+  amount: number;
+}
+
+const STREET_ORDER: Street[] = ["preflop", "flop", "turn", "river"];
+const CARDS_ON_STREET: Record<Street, number> = {
+  preflop: 0,
+  flop: 3,
+  turn: 4,
+  river: 5,
+};
+
+export interface HoldemHandOptions {
+  seats: HandSeatInput[];
+  buttonSeat: number;
+  smallBlind: number;
+  bigBlind: number;
+  rng?: Rng;
+  /** Pre-shuffled deck (tests); dealt from the front. */
+  deck?: Card[];
+}
+
+export class HoldemHand {
+  private readonly seats = new Map<number, HandSeatState>();
+  /** Seat order around the table (ascending seat index, wrapping). */
+  private readonly order: number[];
+  private readonly deck: Card[];
+  private readonly bigBlind: number;
+  readonly buttonSeat: number;
+
+  private streetIndex = 0;
+  private community: Card[] = [];
+  private biggestBet = 0;
+  private minRaise: number;
+  private queue: number[] = [];
+  /** All betting is over: fold-out, river closed, or run-out dealt. */
+  private bettingComplete = false;
+  private complete = false;
+  private payouts: ShowdownPayout[] | null = null;
+
+  constructor(options: HoldemHandOptions) {
+    if (options.seats.length < 2) {
+      throw new Error("A hand needs at least two seats");
+    }
+    this.bigBlind = options.bigBlind;
+    this.minRaise = options.bigBlind;
+    this.buttonSeat = options.buttonSeat;
+    const rng = options.rng ?? defaultRng;
+    this.deck = options.deck
+      ? options.deck.slice()
+      : shuffleInPlace(fullDeck(), rng);
+
+    this.order = options.seats
+      .map((seat) => seat.seatIndex)
+      .sort((a, b) => a - b);
+    for (const seat of options.seats) {
+      if (seat.stack <= 0)
+        throw new Error(`Seat ${seat.seatIndex} has no chips`);
+      this.seats.set(seat.seatIndex, {
+        seatIndex: seat.seatIndex,
+        stack: seat.stack,
+        bet: 0,
+        committed: 0,
+        folded: false,
+        allIn: false,
+        holeCards: [this.draw(), this.draw()],
+      });
+    }
+    if (!this.seats.has(this.buttonSeat)) {
+      throw new Error("Button must be a seated player");
+    }
+
+    // Blinds. Heads-up: button posts the small blind and acts first preflop.
+    const headsUp = this.order.length === 2;
+    const smallBlindSeat = headsUp
+      ? this.buttonSeat
+      : this.nextSeat(this.buttonSeat);
+    const bigBlindSeat = this.nextSeat(smallBlindSeat);
+    this.post(smallBlindSeat, options.smallBlind);
+    this.post(bigBlindSeat, options.bigBlind);
+    this.biggestBet = Math.max(
+      this.seats.get(smallBlindSeat)!.bet,
+      this.seats.get(bigBlindSeat)!.bet
+    );
+
+    // Preflop queue: from the seat after the big blind around to the big
+    // blind itself (its option). All-in blinds are skipped.
+    this.queue = this.seatsFrom(this.nextSeat(bigBlindSeat)).filter((seat) =>
+      this.canAct(seat)
+    );
+  }
+
+  // ─── Queries ────────────────────────────────────────────────────────────
+
+  street(): Street {
+    return STREET_ORDER[this.streetIndex];
+  }
+
+  communityCards(): Card[] {
+    return this.community.slice();
+  }
+
+  seatStates(): HandSeatState[] {
+    return this.order.map((seat) => ({
+      ...this.seats.get(seat)!,
+      holeCards: this.seats.get(seat)!.holeCards.slice(),
+    }));
+  }
+
+  seat(seatIndex: number): HandSeatState | null {
+    const seat = this.seats.get(seatIndex);
+    return seat ? { ...seat, holeCards: seat.holeCards.slice() } : null;
+  }
+
+  isBettingRoundInProgress(): boolean {
+    return !this.bettingComplete && this.queue.length > 0;
+  }
+
+  /** All betting is over (board dealt as far as it goes); `showdown()` may run. */
+  areBettingRoundsCompleted(): boolean {
+    return this.bettingComplete && !this.complete;
+  }
+
+  isComplete(): boolean {
+    return this.complete;
+  }
+
+  playerToAct(): number | null {
+    return this.isBettingRoundInProgress() ? this.queue[0] : null;
+  }
+
+  /** Seats dealt in and not folded. */
+  contenders(): number[] {
+    return this.order.filter((seat) => !this.seats.get(seat)!.folded);
+  }
+
+  /** Total chips in the middle: everything committed so far (0 once paid). */
+  potTotal(): number {
+    if (this.payouts) return 0;
+    let total = 0;
+    for (const seat of this.seats.values()) total += seat.committed;
+    return total;
+  }
+
+  /** Side pots as they stand now (from committed totals; empty once paid). */
+  pots(): PotShare[] {
+    if (this.payouts) return [];
+    return derivePots(Array.from(this.seats.values()));
+  }
+
+  callAmount(): number {
+    const actor = this.playerToAct();
+    if (actor === null) return 0;
+    const seat = this.seats.get(actor)!;
+    return Math.min(seat.stack, this.biggestBet - seat.bet);
+  }
+
+  legalActions(): LegalActions | null {
+    const actor = this.playerToAct();
+    if (actor === null) return null;
+    const seat = this.seats.get(actor)!;
+    const actions: PlayerAction[] = ["fold"];
+    const toCall = this.biggestBet - seat.bet;
+    if (toCall <= 0) actions.push("check");
+    else actions.push("call");
+    const maxTotal = seat.stack + seat.bet;
+    let chipRange: LegalActions["chipRange"];
+    if (maxTotal > this.biggestBet) {
+      const aggressive: PlayerAction = this.biggestBet === 0 ? "bet" : "raise";
+      actions.push(aggressive);
+      const fullMin = this.biggestBet + this.minRaise;
+      chipRange = { min: Math.min(fullMin, maxTotal), max: maxTotal };
+    }
+    return { actions, chipRange };
+  }
+
+  // ─── Actions ────────────────────────────────────────────────────────────
+
+  act(action: PlayerAction, amount?: number): void {
+    const actor = this.playerToAct();
+    if (actor === null) throw new Error("No betting round in progress");
+    const legal = this.legalActions()!;
+    if (!legal.actions.includes(action)) {
+      throw new Error(`${action} is not legal for seat ${actor}`);
+    }
+    const seat = this.seats.get(actor)!;
+
+    switch (action) {
+      case "fold":
+        seat.folded = true;
+        this.queue.shift();
+        break;
+      case "check":
+        this.queue.shift();
+        break;
+      case "call": {
+        const toCall = Math.min(seat.stack, this.biggestBet - seat.bet);
+        this.put(seat, toCall);
+        this.queue.shift();
+        break;
+      }
+      case "bet":
+      case "raise": {
+        const range = legal.chipRange!;
+        const target = Math.min(
+          range.max,
+          Math.max(range.min, Math.round(amount ?? range.min))
+        );
+        const increment = target - this.biggestBet;
+        this.put(seat, target - seat.bet);
+        // A full raise resets the min-raise; a short all-in raise does not.
+        if (increment >= this.minRaise) this.minRaise = increment;
+        this.biggestBet = target;
+        // Everyone else who can still act owes a response.
+        this.queue = this.seatsFrom(this.nextSeat(actor)).filter(
+          (other) => other !== actor && this.canAct(other)
+        );
+        break;
+      }
+      default:
+        throw new Error(`Unknown action ${String(action)}`);
+    }
+
+    if (this.contenders().length === 1) {
+      // Everyone else folded — the hand is over, no more streets.
+      this.queue = [];
+      this.bettingComplete = true;
+    }
+  }
+
+  /**
+   * Close the current betting round and deal the next street. When fewer
+   * than two seats can still act, every remaining street is dealt now.
+   */
+  endBettingRound(): void {
+    if (this.isBettingRoundInProgress()) {
+      throw new Error("Betting round still in progress");
+    }
+    // Fold-outs and run-outs complete betting on their own; closing the
+    // round again is a harmless no-op so callers can stay uniform.
+    if (this.bettingComplete) return;
+    if (this.streetIndex >= STREET_ORDER.length - 1) {
+      // River betting done — showdown next.
+      this.bettingComplete = true;
+      return;
+    }
+    const canStillAct = this.order.filter((seat) => this.canAct(seat));
+    if (canStillAct.length < 2) {
+      this.runOut();
+      return;
+    }
+    this.streetIndex += 1;
+    this.dealCommunity();
+    this.startStreet();
+  }
+
+  /** Award the pots. Returns per-seat payouts (winners only). */
+  showdown(): ShowdownPayout[] {
+    if (this.payouts) return this.payouts;
+    if (this.isBettingRoundInProgress()) {
+      throw new Error("Betting round still in progress");
+    }
+    const contenders = this.contenders();
+    // Any street still un-dealt with ≥2 contenders means callers skipped
+    // endBettingRound(); be strict so the controller stays honest.
+    if (contenders.length > 1 && this.community.length < 5) {
+      throw new Error("Board is not complete");
+    }
+    const payouts = new Map<number, number>();
+    const credit = (seat: number, amount: number) => {
+      payouts.set(seat, (payouts.get(seat) ?? 0) + amount);
+      this.seats.get(seat)!.stack += amount;
+    };
+
+    if (contenders.length === 1) {
+      credit(contenders[0], this.potTotal());
+    } else {
+      const strength = new Map<number, Hand>();
+      for (const seat of contenders) {
+        const cards = [...this.seats.get(seat)!.holeCards, ...this.community];
+        strength.set(seat, Hand.solve(cards.map(toSolverCode)));
+      }
+      for (const pot of this.pots()) {
+        const eligible = pot.eligibleSeats.filter((seat) => strength.has(seat));
+        if (eligible.length === 0 || pot.size === 0) continue;
+        const hands = eligible.map((seat) => strength.get(seat)!);
+        const winningHands = Hand.winners(hands);
+        const winners = eligible.filter((seat) =>
+          winningHands.includes(strength.get(seat)!)
+        );
+        const share = Math.floor(pot.size / winners.length);
+        let odd = pot.size - share * winners.length;
+        for (const seat of winners) credit(seat, share);
+        // Odd chips go to the first winner left of the button.
+        for (const seat of this.seatsFrom(this.nextSeat(this.buttonSeat))) {
+          if (odd === 0) break;
+          if (winners.includes(seat)) {
+            credit(seat, 1);
+            odd -= 1;
+          }
+        }
+      }
+    }
+    this.payouts = Array.from(payouts.entries()).map(([seatIndex, amount]) => ({
+      seatIndex,
+      amount,
+    }));
+    this.complete = true;
+    return this.payouts;
+  }
+
+  /** Solver description of a seat's best hand on the current board. */
+  describe(seatIndex: number): string | null {
+    const seat = this.seats.get(seatIndex);
+    if (!seat || this.community.length < 3) return null;
+    return Hand.solve([...seat.holeCards, ...this.community].map(toSolverCode))
+      .descr;
+  }
+
+  // ─── Internals ──────────────────────────────────────────────────────────
+
+  private startStreet(): void {
+    for (const seat of this.seats.values()) seat.bet = 0;
+    this.biggestBet = 0;
+    this.minRaise = this.bigBlind;
+    this.queue = this.seatsFrom(this.nextSeat(this.buttonSeat)).filter((seat) =>
+      this.canAct(seat)
+    );
+  }
+
+  private runOut(): void {
+    this.streetIndex = STREET_ORDER.length - 1;
+    this.dealCommunity();
+    this.queue = [];
+    this.bettingComplete = true;
+  }
+
+  private dealCommunity(): void {
+    const target = CARDS_ON_STREET[this.street()];
+    while (this.community.length < target) this.community.push(this.draw());
+  }
+
+  private draw(): Card {
+    const card = this.deck.shift();
+    if (!card) throw new Error("Deck exhausted");
+    return card;
+  }
+
+  private post(seatIndex: number, amount: number): void {
+    const seat = this.seats.get(seatIndex)!;
+    this.put(seat, Math.min(amount, seat.stack));
+  }
+
+  private put(seat: HandSeatState, amount: number): void {
+    const chips = Math.min(seat.stack, Math.max(0, amount));
+    seat.stack -= chips;
+    seat.bet += chips;
+    seat.committed += chips;
+    if (seat.stack === 0) seat.allIn = true;
+  }
+
+  private canAct(seatIndex: number): boolean {
+    const seat = this.seats.get(seatIndex)!;
+    return !seat.folded && !seat.allIn;
+  }
+
+  private nextSeat(from: number): number {
+    const index = this.order.indexOf(from);
+    return this.order[(index + 1) % this.order.length];
+  }
+
+  /** Seats in table order starting at `from` (inclusive), one full lap. */
+  private seatsFrom(from: number): number[] {
+    const start = this.order.indexOf(from);
+    const result: number[] = [];
+    for (let i = 0; i < this.order.length; i += 1) {
+      result.push(this.order[(start + i) % this.order.length]);
+    }
+    return result;
+  }
+}
+
+/**
+ * Standard side-pot derivation from whole-hand contributions: for each
+ * distinct contribution level (ascending), a pot collects the slice
+ * between the previous level and this one from every seat that reached
+ * it; only non-folded seats that reached the level are eligible.
+ */
+export function derivePots(seats: readonly HandSeatState[]): PotShare[] {
+  const levels = Array.from(
+    new Set(seats.filter((s) => s.committed > 0).map((s) => s.committed))
+  ).sort((a, b) => a - b);
+  const pots: PotShare[] = [];
+  let previous = 0;
+  for (const level of levels) {
+    const slice = level - previous;
+    let size = 0;
+    const eligible: number[] = [];
+    for (const seat of seats) {
+      if (seat.committed >= level) {
+        size += slice;
+        if (!seat.folded) eligible.push(seat.seatIndex);
+      } else if (seat.committed > previous) {
+        // Folded (or short) seat that stopped between levels — its
+        // remainder belongs to this pot slice.
+        size += seat.committed - previous;
+      }
+    }
+    previous = level;
+    if (size === 0) continue;
+    // Merge with the previous pot when eligibility is identical (a folded
+    // seat's leftover shouldn't create a pot of its own).
+    const last = pots[pots.length - 1];
+    if (last && sameSeats(last.eligibleSeats, eligible)) {
+      last.size += size;
+    } else {
+      pots.push({ size, eligibleSeats: eligible });
+    }
+  }
+  return pots;
+}
+
+function sameSeats(a: number[], b: number[]): boolean {
+  return a.length === b.length && a.every((seat, i) => seat === b[i]);
+}
+
+/** Browser CSPRNG when present (Tauri webview), Math.random otherwise. */
+function defaultRng(): number {
+  const cryptoApi = globalThis.crypto;
+  if (cryptoApi && typeof cryptoApi.getRandomValues === "function") {
+    const buffer = new Uint32Array(1);
+    cryptoApi.getRandomValues(buffer);
+    return buffer[0] / 4294967296;
+  }
+  return Math.random();
+}

--- a/src/features/PokerTable/engine/personas.ts
+++ b/src/features/PokerTable/engine/personas.ts
@@ -1,0 +1,111 @@
+/**
+ * Bot personas for the phase-0 table (human vs. five bots, play chips).
+ *
+ * Names are invented agent handles on purpose: no real people (the design
+ * mock seats real accounts — a right-of-publicity problem) and no provider
+ * marks. Style knobs feed `botBrain`; hue feeds the generated avatar.
+ */
+import type { PokerPlayer } from "./types";
+
+export interface BotStyle {
+  /** 0 = plays only premiums, 1 = plays almost anything. */
+  looseness: number;
+  /** 0 = calls, 1 = bets/raises whenever it continues. */
+  aggression: number;
+  /** Probability of betting with air when checked to. */
+  bluffFrequency: number;
+  /** Thinking-time multiplier (1 = normal). */
+  tempo: number;
+}
+
+export interface BotPersona {
+  id: string;
+  name: string;
+  avatarHue: number;
+  style: BotStyle;
+}
+
+export const BOT_PERSONAS: readonly BotPersona[] = [
+  {
+    id: "lambda",
+    name: "lambda",
+    avatarHue: 262,
+    style: {
+      looseness: 0.35,
+      aggression: 0.75,
+      bluffFrequency: 0.18,
+      tempo: 0.9,
+    },
+  },
+  {
+    id: "vector",
+    name: "vector",
+    avatarHue: 200,
+    style: {
+      looseness: 0.55,
+      aggression: 0.55,
+      bluffFrequency: 0.12,
+      tempo: 1.1,
+    },
+  },
+  {
+    id: "byte",
+    name: "byte",
+    avatarHue: 24,
+    style: {
+      looseness: 0.8,
+      aggression: 0.35,
+      bluffFrequency: 0.06,
+      tempo: 0.7,
+    },
+  },
+  {
+    id: "cipher",
+    name: "cipher",
+    avatarHue: 150,
+    style: {
+      looseness: 0.25,
+      aggression: 0.5,
+      bluffFrequency: 0.1,
+      tempo: 1.4,
+    },
+  },
+  {
+    id: "quark",
+    name: "quark",
+    avatarHue: 340,
+    style: {
+      looseness: 0.65,
+      aggression: 0.85,
+      bluffFrequency: 0.28,
+      tempo: 0.8,
+    },
+  },
+  {
+    id: "nomad",
+    name: "nomad",
+    avatarHue: 48,
+    style: {
+      looseness: 0.45,
+      aggression: 0.45,
+      bluffFrequency: 0.14,
+      tempo: 1.0,
+    },
+  },
+] as const;
+
+export function findPersona(personaId: string | undefined): BotPersona {
+  return (
+    BOT_PERSONAS.find((persona) => persona.id === personaId) ?? BOT_PERSONAS[0]
+  );
+}
+
+export function personaToPlayer(persona: BotPersona): PokerPlayer {
+  return {
+    id: `bot:${persona.id}`,
+    name: persona.name,
+    kind: "bot",
+    avatarHue: persona.avatarHue,
+    personaId: persona.id,
+  };
+}

--- a/src/features/PokerTable/engine/types.ts
+++ b/src/features/PokerTable/engine/types.ts
@@ -1,0 +1,127 @@
+/**
+ * Read-only projection of a poker table for the UI and the bots.
+ *
+ * Amounts are in CHIPS. One chip is `TOKENS_PER_CHIP` play tokens — the
+ * rules engine only handles integers, and 1K-token chips keep 0.5/1 Mtok
+ * blinds and 100M-token stacks comfortably inside safe-integer range while
+ * still letting the UI print `561K` / `1.28M`.
+ */
+import type { Card } from "./cards";
+
+export const TOKENS_PER_CHIP = 1_000;
+
+export type Street = "preflop" | "flop" | "turn" | "river";
+
+export type PlayerAction = "fold" | "check" | "call" | "bet" | "raise";
+
+export interface ChipRange {
+  min: number;
+  max: number;
+}
+
+export interface LegalActions {
+  actions: PlayerAction[];
+  /** Present when `bet` or `raise` is legal — total bet size ("bet to"). */
+  chipRange?: ChipRange;
+}
+
+export type PlayerKind = "human" | "bot";
+
+export interface PokerPlayer {
+  id: string;
+  name: string;
+  kind: PlayerKind;
+  /** Hue (0–360) for the generated avatar. */
+  avatarHue: number;
+  /** Persona id for bots (drives the brain); undefined for the human. */
+  personaId?: string;
+}
+
+export interface SeatAction {
+  action: PlayerAction;
+  /** Total bet this street after the action, for bet/raise/call. */
+  amount?: number;
+}
+
+export interface SeatSnapshot {
+  seatIndex: number;
+  player: PokerPlayer;
+  /** Chips behind (not counting the current street's bet). */
+  stack: number;
+  /** Chips committed on the current street. */
+  betSize: number;
+  /** Still contesting the pot this hand. */
+  inHand: boolean;
+  /** Has hole cards this hand (face-down unless `holeCards` is set). */
+  hasCards: boolean;
+  /**
+   * Visible hole cards: the viewer's own cards, or everyone's revealed
+   * cards at showdown. `null` while face-down / not dealt.
+   */
+  holeCards: Card[] | null;
+  isDealer: boolean;
+  isToAct: boolean;
+  isAllIn: boolean;
+  /** Last action taken on the current street (cleared at street change). */
+  lastAction: SeatAction | null;
+}
+
+export interface PotSnapshot {
+  size: number;
+  eligibleSeats: number[];
+}
+
+export interface HandResultEntry {
+  seatIndex: number;
+  /** Net chips won from the pot(s) (0 for showdown losers). */
+  amountWon: number;
+  /** Description of the shown hand, e.g. `"Two Pair, K's & 2's"`. */
+  handDescription: string | null;
+  /** Hole cards revealed at showdown; null when the hand was folded out. */
+  revealedCards: Card[] | null;
+}
+
+export interface HandResult {
+  handNumber: number;
+  entries: HandResultEntry[];
+  /** True when the pot was awarded without a showdown. */
+  foldedOut: boolean;
+  /** Community cards as they were when the hand ended. */
+  board: Card[];
+  /** Chips in play when the hand ended (what the winners split). */
+  potTotal: number;
+}
+
+export type TablePhase =
+  /** No hand running (between hands, before first hand). */
+  | "idle"
+  /** Waiting for the seat in `toAct` to act. */
+  | "betting"
+  /** Betting round closed; next street being dealt. */
+  | "dealing"
+  /** Hand over, result on the table. */
+  | "hand-complete";
+
+export interface Blinds {
+  smallBlind: number;
+  bigBlind: number;
+}
+
+export interface TableSnapshot {
+  handNumber: number;
+  phase: TablePhase;
+  street: Street | null;
+  blinds: Blinds;
+  communityCards: Card[];
+  pots: PotSnapshot[];
+  /** Collected pots plus every live bet — what the UI shows as "Pot". */
+  potTotal: number;
+  seats: (SeatSnapshot | null)[];
+  dealerSeat: number | null;
+  toAct: number | null;
+  /** Legal actions for `toAct`; null when nobody is to act. */
+  legalActions: LegalActions | null;
+  /** Chips `toAct` must add to call (0 when checking is possible). */
+  callAmount: number;
+  lastResult: HandResult | null;
+}

--- a/src/features/PokerTable/format.ts
+++ b/src/features/PokerTable/format.ts
@@ -1,0 +1,29 @@
+import { TOKENS_PER_CHIP } from "./engine/types";
+
+/**
+ * Chips → short token label the way the table prints them: `561K`,
+ * `1.28M`, `35.8M`, `106M`. Precision shrinks as the mantissa grows so
+ * seat pills stay narrow (the usage dashboard's axis rule).
+ */
+export function formatChips(chips: number): string {
+  const tokens = Math.max(0, Math.round(chips)) * TOKENS_PER_CHIP;
+  if (tokens === 0) return "0";
+  const units = [
+    { threshold: 1e9, suffix: "B" },
+    { threshold: 1e6, suffix: "M" },
+    { threshold: 1e3, suffix: "K" },
+  ] as const;
+  const unit = units.find((candidate) => tokens >= candidate.threshold);
+  if (!unit) return String(tokens);
+  const scaled = tokens / unit.threshold;
+  const decimals = scaled >= 100 ? 0 : scaled >= 10 ? 1 : 2;
+  const text = scaled.toFixed(decimals).replace(/\.0+$|(\.\d*[1-9])0+$/, "$1");
+  return `${text}${unit.suffix}`;
+}
+
+/** Stakes label for the header: `0.5/1`. */
+export function formatStakes(smallBlind: number, bigBlind: number): string {
+  const millions = (chips: number) =>
+    String(Math.round(((chips * TOKENS_PER_CHIP) / 1e6) * 100) / 100);
+  return `${millions(smallBlind)}/${millions(bigBlind)}`;
+}

--- a/src/features/PokerTable/index.tsx
+++ b/src/features/PokerTable/index.tsx
@@ -29,7 +29,6 @@ import PokerFelt from "./components/PokerFelt";
 import PokerHandHistory from "./components/PokerHandHistory";
 import PokerTableHeader from "./components/PokerTableHeader";
 import type { PlayerAction, PokerPlayer } from "./engine/types";
-import { formatChips } from "./format";
 import {
   defaultBuyIn,
   usePokerTableController,
@@ -142,14 +141,6 @@ const PokerTableWindow: React.FC = () => {
               onResetBankroll={handleResetBankroll}
               onDealNext={handleDealNext}
             />
-            <div className="flex items-center justify-between px-3 pb-1.5 text-[10px] text-text-4">
-              <span>{t("pokerTable.disclaimer")}</span>
-              <span>
-                {t("pokerTable.rebuy.bankroll", {
-                  amount: formatChips(state.bankroll),
-                })}
-              </span>
-            </div>
           </div>
         </div>
         {historyOpen && (

--- a/src/features/PokerTable/index.tsx
+++ b/src/features/PokerTable/index.tsx
@@ -1,0 +1,170 @@
+/**
+ * PokerTablePanel — the floating poker table ("Tables").
+ *
+ * Global floating window hosted by `AppLayout` over the whole pane surface,
+ * built on the same shell as the side chat: `FloatingWindow` (drag bounds +
+ * resize handles) with a draggable header. Phase-0 scope: the human vs.
+ * five bots at play-chip "token" stakes; nothing here touches any account
+ * — see `src/store/ui/pokerTableAtom.ts` for the ledger boundary.
+ *
+ * Closing the window is leaving the table: the hero's stack returns to the
+ * persisted bankroll and the table is discarded (see the controller).
+ */
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import React, { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import FloatingWindow from "@src/components/FloatingWindow";
+import {
+  POKER_DEFAULT_BANKROLL_CHIPS,
+  closePokerTableAtom,
+  pokerSettingsAtom,
+  pokerTableVisibleAtom,
+  stakesById,
+} from "@src/store/ui/pokerTableAtom";
+import { userAtom } from "@src/store/user/userAtom";
+
+import PokerActionBar from "./components/PokerActionBar";
+import PokerFelt from "./components/PokerFelt";
+import PokerHandHistory from "./components/PokerHandHistory";
+import PokerTableHeader from "./components/PokerTableHeader";
+import type { PlayerAction, PokerPlayer } from "./engine/types";
+import { formatChips } from "./format";
+import {
+  defaultBuyIn,
+  usePokerTableController,
+} from "./usePokerTableController";
+
+// Same bounds as the side chat (whole pane surface minus a 12px inset),
+// centred rather than bottom-right: the table wants room. z-[70] matches
+// the side chat; the two are siblings and either can be dragged aside.
+const POKER_OVERLAY_CLASS =
+  "pointer-events-none absolute inset-0 z-[70] flex items-center justify-center p-3";
+const POKER_SURFACE_CLASS =
+  "pointer-events-auto flex h-full max-h-[620px] min-h-[440px] w-[820px] max-w-full flex-col overflow-hidden rounded-[12px] border border-border-2 bg-bg-2 shadow-2xl";
+const POKER_MIN_WIDTH = 600;
+const POKER_MIN_HEIGHT = 440;
+const POKER_MAX_WIDTH = 1200;
+const POKER_MAX_HEIGHT = 820;
+
+const PokerTablePanel: React.FC = () => {
+  const visible = useAtomValue(pokerTableVisibleAtom);
+  if (!visible) return null;
+  return <PokerTableWindow />;
+};
+
+const PokerTableWindow: React.FC = () => {
+  const { t } = useTranslation("sessions");
+  const closePokerTable = useSetAtom(closePokerTableAtom);
+  const [settings, setSettings] = useAtom(pokerSettingsAtom);
+  const user = useAtomValue(userAtom);
+  const [historyOpen, setHistoryOpen] = useState(false);
+
+  const hero = useMemo<PokerPlayer>(
+    () => ({
+      id: `user:${user.uuid || "local"}`,
+      name: user.name?.trim() || t("pokerTable.seat.you"),
+      kind: "human",
+      avatarHue: 212,
+    }),
+    // The hero identity is fixed for the life of the table.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
+  const { controller, state } = usePokerTableController(hero);
+  const stakes = stakesById(settings.stakesId);
+  const buyIn = defaultBuyIn(stakes.bigBlind);
+
+  const handleAct = useCallback(
+    (action: PlayerAction, amount?: number) =>
+      controller.heroAct(action, amount),
+    [controller]
+  );
+  const handleRebuy = useCallback(
+    (amount: number) => controller.rebuy(amount),
+    [controller]
+  );
+  const handleResetBankroll = useCallback(() => {
+    controller.resetBankroll(POKER_DEFAULT_BANKROLL_CHIPS);
+    controller.rebuy(buyIn);
+  }, [buyIn, controller]);
+  const handleDealNext = useCallback(
+    () => controller.dealNextHand(),
+    [controller]
+  );
+  const handleLeave = useCallback(() => {
+    // Leaving cashes out through the controller's dispose (unmount).
+    closePokerTable();
+  }, [closePokerTable]);
+
+  return (
+    <FloatingWindow
+      overlayClassName={POKER_OVERLAY_CLASS}
+      surfaceClassName={POKER_SURFACE_CLASS}
+      minWidth={POKER_MIN_WIDTH}
+      minHeight={POKER_MIN_HEIGHT}
+      maxWidth={POKER_MAX_WIDTH}
+      maxHeight={POKER_MAX_HEIGHT}
+    >
+      <PokerTableHeader
+        blinds={state.snapshot.blinds}
+        handNumber={state.snapshot.handNumber}
+        settings={settings}
+        historyOpen={historyOpen}
+        onToggleHistory={() => setHistoryOpen((open) => !open)}
+        onChangeStakes={(stakesId) =>
+          setSettings((prev) => ({ ...prev, stakesId }))
+        }
+        onChangeSpeed={(speed) => setSettings((prev) => ({ ...prev, speed }))}
+        onLeave={handleLeave}
+        onClose={handleLeave}
+      />
+      <div className="relative flex min-h-0 flex-1">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+          <div className="min-h-0 flex-1">
+            <PokerFelt
+              snapshot={state.snapshot}
+              heroSeat={state.heroSeat}
+              revealedCommunity={state.revealedCommunity}
+              thinkingSince={state.thinkingSince}
+            />
+          </div>
+          <div className="shrink-0 border-t border-border-2">
+            <PokerActionBar
+              snapshot={state.snapshot}
+              heroSeat={state.heroSeat}
+              awaitingRebuy={state.awaitingRebuy}
+              bankroll={state.bankroll}
+              buyIn={buyIn}
+              onAct={handleAct}
+              onRebuy={handleRebuy}
+              onResetBankroll={handleResetBankroll}
+              onDealNext={handleDealNext}
+            />
+            <div className="flex items-center justify-between px-3 pb-1.5 text-[10px] text-text-4">
+              <span>{t("pokerTable.disclaimer")}</span>
+              <span>
+                {t("pokerTable.rebuy.bankroll", {
+                  amount: formatChips(state.bankroll),
+                })}
+              </span>
+            </div>
+          </div>
+        </div>
+        {historyOpen && (
+          <aside className="flex w-[240px] shrink-0 flex-col border-l border-border-2 bg-bg-2">
+            <div className="flex h-8 shrink-0 items-center px-3 text-[12px] font-medium text-text-2">
+              {t("pokerTable.history.title")}
+            </div>
+            <div className="min-h-0 flex-1">
+              <PokerHandHistory entries={state.handHistory} />
+            </div>
+          </aside>
+        )}
+      </div>
+    </FloatingWindow>
+  );
+};
+
+export default PokerTablePanel;

--- a/src/features/PokerTable/index.tsx
+++ b/src/features/PokerTable/index.tsx
@@ -1,160 +1,27 @@
 /**
- * PokerTablePanel — the floating poker table ("Tables").
+ * PokerTablePanel — mount point for the floating poker table ("Tables").
  *
- * Global floating window hosted by `AppLayout` over the whole pane surface,
- * built on the same shell as the side chat: `FloatingWindow` (drag bounds +
- * resize handles) with a draggable header. Phase-0 scope: the human vs.
- * five bots at play-chip "token" stakes; nothing here touches any account
- * — see `src/store/ui/pokerTableAtom.ts` for the ledger boundary.
- *
- * Closing the window is leaving the table: the hero's stack returns to the
- * persisted bankroll and the table is discarded (see the controller).
+ * Hosted by `AppLayout` over the whole pane surface next to the side chat.
+ * Renders nothing until the table is opened; the window module (engine,
+ * bots, `pokersolver`, components) is a separate chunk fetched on first
+ * open, so a user who never plays pays nothing for the feature.
  */
-import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import React, { useCallback, useMemo, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { useAtomValue } from "jotai";
+import React, { Suspense } from "react";
 
-import FloatingWindow from "@src/components/FloatingWindow";
-import {
-  POKER_DEFAULT_BANKROLL_CHIPS,
-  closePokerTableAtom,
-  pokerSettingsAtom,
-  pokerTableVisibleAtom,
-  stakesById,
-} from "@src/store/ui/pokerTableAtom";
-import { userAtom } from "@src/store/user/userAtom";
+import { pokerTableVisibleAtom } from "@src/store/ui/pokerTableAtom";
 
-import PokerActionBar from "./components/PokerActionBar";
-import PokerFelt from "./components/PokerFelt";
-import PokerHandHistory from "./components/PokerHandHistory";
-import PokerTableHeader from "./components/PokerTableHeader";
-import type { PlayerAction, PokerPlayer } from "./engine/types";
-import {
-  defaultBuyIn,
-  usePokerTableController,
-} from "./usePokerTableController";
-
-// Same bounds as the side chat (whole pane surface minus a 12px inset),
-// centred rather than bottom-right: the table wants room. z-[70] matches
-// the side chat; the two are siblings and either can be dragged aside.
-const POKER_OVERLAY_CLASS =
-  "pointer-events-none absolute inset-0 z-[70] flex items-center justify-center p-3";
-const POKER_SURFACE_CLASS =
-  "pointer-events-auto flex h-full max-h-[620px] min-h-[440px] w-[820px] max-w-full flex-col overflow-hidden rounded-[12px] border border-border-2 bg-bg-2 shadow-2xl";
-const POKER_MIN_WIDTH = 600;
-const POKER_MIN_HEIGHT = 440;
-const POKER_MAX_WIDTH = 1200;
-const POKER_MAX_HEIGHT = 820;
+const PokerTableWindow = React.lazy(
+  () => import(/* webpackChunkName: "poker-table" */ "./PokerTableWindow")
+);
 
 const PokerTablePanel: React.FC = () => {
   const visible = useAtomValue(pokerTableVisibleAtom);
   if (!visible) return null;
-  return <PokerTableWindow />;
-};
-
-const PokerTableWindow: React.FC = () => {
-  const { t } = useTranslation("sessions");
-  const closePokerTable = useSetAtom(closePokerTableAtom);
-  const [settings, setSettings] = useAtom(pokerSettingsAtom);
-  const user = useAtomValue(userAtom);
-  const [historyOpen, setHistoryOpen] = useState(false);
-
-  const hero = useMemo<PokerPlayer>(
-    () => ({
-      id: `user:${user.uuid || "local"}`,
-      name: user.name?.trim() || t("pokerTable.seat.you"),
-      kind: "human",
-      avatarHue: 212,
-    }),
-    // The hero identity is fixed for the life of the table.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  );
-
-  const { controller, state } = usePokerTableController(hero);
-  const stakes = stakesById(settings.stakesId);
-  const buyIn = defaultBuyIn(stakes.bigBlind);
-
-  const handleAct = useCallback(
-    (action: PlayerAction, amount?: number) =>
-      controller.heroAct(action, amount),
-    [controller]
-  );
-  const handleRebuy = useCallback(
-    (amount: number) => controller.rebuy(amount),
-    [controller]
-  );
-  const handleResetBankroll = useCallback(() => {
-    controller.resetBankroll(POKER_DEFAULT_BANKROLL_CHIPS);
-    controller.rebuy(buyIn);
-  }, [buyIn, controller]);
-  const handleDealNext = useCallback(
-    () => controller.dealNextHand(),
-    [controller]
-  );
-  const handleLeave = useCallback(() => {
-    // Leaving cashes out through the controller's dispose (unmount).
-    closePokerTable();
-  }, [closePokerTable]);
-
   return (
-    <FloatingWindow
-      overlayClassName={POKER_OVERLAY_CLASS}
-      surfaceClassName={POKER_SURFACE_CLASS}
-      minWidth={POKER_MIN_WIDTH}
-      minHeight={POKER_MIN_HEIGHT}
-      maxWidth={POKER_MAX_WIDTH}
-      maxHeight={POKER_MAX_HEIGHT}
-    >
-      <PokerTableHeader
-        blinds={state.snapshot.blinds}
-        handNumber={state.snapshot.handNumber}
-        settings={settings}
-        historyOpen={historyOpen}
-        onToggleHistory={() => setHistoryOpen((open) => !open)}
-        onChangeStakes={(stakesId) =>
-          setSettings((prev) => ({ ...prev, stakesId }))
-        }
-        onChangeSpeed={(speed) => setSettings((prev) => ({ ...prev, speed }))}
-        onLeave={handleLeave}
-        onClose={handleLeave}
-      />
-      <div className="relative flex min-h-0 flex-1">
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-          <div className="min-h-0 flex-1">
-            <PokerFelt
-              snapshot={state.snapshot}
-              heroSeat={state.heroSeat}
-              revealedCommunity={state.revealedCommunity}
-              thinkingSince={state.thinkingSince}
-            />
-          </div>
-          <div className="shrink-0 border-t border-border-2">
-            <PokerActionBar
-              snapshot={state.snapshot}
-              heroSeat={state.heroSeat}
-              awaitingRebuy={state.awaitingRebuy}
-              bankroll={state.bankroll}
-              buyIn={buyIn}
-              onAct={handleAct}
-              onRebuy={handleRebuy}
-              onResetBankroll={handleResetBankroll}
-              onDealNext={handleDealNext}
-            />
-          </div>
-        </div>
-        {historyOpen && (
-          <aside className="flex w-[240px] shrink-0 flex-col border-l border-border-2 bg-bg-2">
-            <div className="flex h-8 shrink-0 items-center px-3 text-[12px] font-medium text-text-2">
-              {t("pokerTable.history.title")}
-            </div>
-            <div className="min-h-0 flex-1">
-              <PokerHandHistory entries={state.handHistory} />
-            </div>
-          </aside>
-        )}
-      </div>
-    </FloatingWindow>
+    <Suspense fallback={null}>
+      <PokerTableWindow />
+    </Suspense>
   );
 };
 

--- a/src/features/PokerTable/usePokerTableController.ts
+++ b/src/features/PokerTable/usePokerTableController.ts
@@ -1,0 +1,80 @@
+/**
+ * Binds one `PokerTableController` to the React tree for as long as the
+ * floating table is open. The controller is created on mount with the
+ * persisted bankroll/settings, streams state through
+ * `useSyncExternalStore`, mirrors bankroll changes back into the atom, and
+ * cashes out (leave) on unmount — closing the window IS leaving the table.
+ */
+import { useAtomValue, useSetAtom } from "jotai";
+import { useEffect, useState, useSyncExternalStore } from "react";
+
+import {
+  pokerBankrollAtom,
+  pokerSettingsAtom,
+  setPokerBankrollChipsAtom,
+  stakesById,
+} from "@src/store/ui/pokerTableAtom";
+
+import {
+  PokerTableController,
+  type PokerTableViewState,
+} from "./PokerTableController";
+import type { PokerPlayer } from "./engine/types";
+
+/** 100 big blinds at the table's stakes. */
+export function defaultBuyIn(bigBlind: number): number {
+  return bigBlind * 100;
+}
+
+export interface UsePokerTableController {
+  controller: PokerTableController;
+  state: PokerTableViewState;
+}
+
+export function usePokerTableController(
+  hero: PokerPlayer
+): UsePokerTableController {
+  const bankroll = useAtomValue(pokerBankrollAtom);
+  // jotai's setter identity is stable, so the controller can hold it.
+  const setBankrollChips = useSetAtom(setPokerBankrollChipsAtom);
+  const settings = useAtomValue(pokerSettingsAtom);
+
+  // Created once per mount from the persisted values; the controller owns
+  // bankroll and stakes after that (settings changes flow in via effects).
+  const [controller] = useState(() => {
+    const stakes = stakesById(settings.stakesId);
+    return new PokerTableController({
+      hero,
+      blinds: { smallBlind: stakes.smallBlind, bigBlind: stakes.bigBlind },
+      buyIn: defaultBuyIn(stakes.bigBlind),
+      bankroll: bankroll.chips,
+      speed: settings.speed,
+      onBankrollChange: setBankrollChips,
+    });
+  });
+
+  useEffect(() => {
+    controller.start();
+    return () => {
+      controller.dispose();
+    };
+  }, [controller]);
+
+  // Live settings changes (stakes / speed) flow into the running table.
+  useEffect(() => {
+    const stakes = stakesById(settings.stakesId);
+    controller.setBlinds({
+      smallBlind: stakes.smallBlind,
+      bigBlind: stakes.bigBlind,
+    });
+    controller.setSpeed(settings.speed);
+  }, [controller, settings.stakesId, settings.speed]);
+
+  const state = useSyncExternalStore(
+    controller.subscribe,
+    controller.getState,
+    controller.getState
+  );
+
+  return { controller, state };
+}

--- a/src/i18n/locales/de/sessions.json
+++ b/src/i18n/locales/de/sessions.json
@@ -2822,5 +2822,61 @@
     "summarize": "Mit Agent zusammenfassen",
     "waiting": "Warte auf Inhalt…",
     "empty": "Kein Inhalt"
+  },
+  "pokerTable": {
+    "menuLabel": "Poker table",
+    "header": {
+      "title": "No-Limit Inference – {{stakes}} Mtok – 6-max",
+      "hand": "Hand #{{number}}",
+      "history": "Hand history",
+      "settings": "Table settings",
+      "leave": "Leave table",
+      "close": "Close"
+    },
+    "potLabel": "Pot",
+    "tokens": "{{amount}} tokens",
+    "thinking": "Thinking · {{seconds}}s",
+    "waitingFor": "Waiting for {{name}}…",
+    "dealing": "Dealing…",
+    "nextHand": "Deal next hand",
+    "disclaimer": "Play chips only — nothing here is real tokens or money.",
+    "seat": {
+      "you": "You",
+      "bot": "bot",
+      "allIn": "All in"
+    },
+    "actions": {
+      "fold": "Fold",
+      "check": "Check",
+      "call": "Call {{amount}}",
+      "bet": "Bet {{amount}}",
+      "raise": "Raise {{amount}}",
+      "allIn": "All in {{amount}}",
+      "betLabel": "Bet",
+      "raiseLabel": "Raise",
+      "callLabel": "Call",
+      "checkLabel": "Check"
+    },
+    "result": {
+      "wins": "{{name}} wins {{amount}}",
+      "winsWith": "{{name}} wins {{amount}} with {{hand}}"
+    },
+    "rebuy": {
+      "title": "You're out of chips.",
+      "bankroll": "Bankroll {{amount}}",
+      "buyIn": "Buy in {{amount}}",
+      "reset": "Reset bankroll"
+    },
+    "history": {
+      "title": "Hand history",
+      "empty": "No hands played yet.",
+      "foldedOut": "everyone folded"
+    },
+    "settings": {
+      "stakes": "Stakes",
+      "speed": "Table speed",
+      "speed_normal": "Normal",
+      "speed_fast": "Fast"
+    }
   }
 }

--- a/src/i18n/locales/de/sessions.json
+++ b/src/i18n/locales/de/sessions.json
@@ -2839,7 +2839,6 @@
     "waitingFor": "Waiting for {{name}}…",
     "dealing": "Dealing…",
     "nextHand": "Deal next hand",
-    "disclaimer": "Play chips only — nothing here is real tokens or money.",
     "seat": {
       "you": "You",
       "bot": "bot",
@@ -2862,14 +2861,14 @@
       "winsWith": "{{name}} wins {{amount}} with {{hand}}"
     },
     "rebuy": {
-      "title": "You're out of chips.",
+      "title": "You're out of chips",
       "bankroll": "Bankroll {{amount}}",
       "buyIn": "Buy in {{amount}}",
       "reset": "Reset bankroll"
     },
     "history": {
       "title": "Hand history",
-      "empty": "No hands played yet.",
+      "empty": "No hands played yet",
       "foldedOut": "everyone folded"
     },
     "settings": {

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -3026,7 +3026,6 @@
     "waitingFor": "Waiting for {{name}}…",
     "dealing": "Dealing…",
     "nextHand": "Deal next hand",
-    "disclaimer": "Play chips only — nothing here is real tokens or money.",
     "seat": {
       "you": "You",
       "bot": "bot",
@@ -3049,14 +3048,14 @@
       "winsWith": "{{name}} wins {{amount}} with {{hand}}"
     },
     "rebuy": {
-      "title": "You're out of chips.",
+      "title": "You're out of chips",
       "bankroll": "Bankroll {{amount}}",
       "buyIn": "Buy in {{amount}}",
       "reset": "Reset bankroll"
     },
     "history": {
       "title": "Hand history",
-      "empty": "No hands played yet.",
+      "empty": "No hands played yet",
       "foldedOut": "everyone folded"
     },
     "settings": {

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -3009,5 +3009,61 @@
     "elementsCount_one": "{{count}} element",
     "elementsCount_other": "{{count}} elements",
     "regionLabel": "Region · {{label}}"
+  },
+  "pokerTable": {
+    "menuLabel": "Poker table",
+    "header": {
+      "title": "No-Limit Inference – {{stakes}} Mtok – 6-max",
+      "hand": "Hand #{{number}}",
+      "history": "Hand history",
+      "settings": "Table settings",
+      "leave": "Leave table",
+      "close": "Close"
+    },
+    "potLabel": "Pot",
+    "tokens": "{{amount}} tokens",
+    "thinking": "Thinking · {{seconds}}s",
+    "waitingFor": "Waiting for {{name}}…",
+    "dealing": "Dealing…",
+    "nextHand": "Deal next hand",
+    "disclaimer": "Play chips only — nothing here is real tokens or money.",
+    "seat": {
+      "you": "You",
+      "bot": "bot",
+      "allIn": "All in"
+    },
+    "actions": {
+      "fold": "Fold",
+      "check": "Check",
+      "call": "Call {{amount}}",
+      "bet": "Bet {{amount}}",
+      "raise": "Raise {{amount}}",
+      "allIn": "All in {{amount}}",
+      "betLabel": "Bet",
+      "raiseLabel": "Raise",
+      "callLabel": "Call",
+      "checkLabel": "Check"
+    },
+    "result": {
+      "wins": "{{name}} wins {{amount}}",
+      "winsWith": "{{name}} wins {{amount}} with {{hand}}"
+    },
+    "rebuy": {
+      "title": "You're out of chips.",
+      "bankroll": "Bankroll {{amount}}",
+      "buyIn": "Buy in {{amount}}",
+      "reset": "Reset bankroll"
+    },
+    "history": {
+      "title": "Hand history",
+      "empty": "No hands played yet.",
+      "foldedOut": "everyone folded"
+    },
+    "settings": {
+      "stakes": "Stakes",
+      "speed": "Table speed",
+      "speed_normal": "Normal",
+      "speed_fast": "Fast"
+    }
   }
 }

--- a/src/i18n/locales/es/sessions.json
+++ b/src/i18n/locales/es/sessions.json
@@ -2824,5 +2824,61 @@
     "summarize": "Resumir con Agent",
     "waiting": "Esperando contenido…",
     "empty": "Sin contenido"
+  },
+  "pokerTable": {
+    "menuLabel": "Poker table",
+    "header": {
+      "title": "No-Limit Inference – {{stakes}} Mtok – 6-max",
+      "hand": "Hand #{{number}}",
+      "history": "Hand history",
+      "settings": "Table settings",
+      "leave": "Leave table",
+      "close": "Close"
+    },
+    "potLabel": "Pot",
+    "tokens": "{{amount}} tokens",
+    "thinking": "Thinking · {{seconds}}s",
+    "waitingFor": "Waiting for {{name}}…",
+    "dealing": "Dealing…",
+    "nextHand": "Deal next hand",
+    "disclaimer": "Play chips only — nothing here is real tokens or money.",
+    "seat": {
+      "you": "You",
+      "bot": "bot",
+      "allIn": "All in"
+    },
+    "actions": {
+      "fold": "Fold",
+      "check": "Check",
+      "call": "Call {{amount}}",
+      "bet": "Bet {{amount}}",
+      "raise": "Raise {{amount}}",
+      "allIn": "All in {{amount}}",
+      "betLabel": "Bet",
+      "raiseLabel": "Raise",
+      "callLabel": "Call",
+      "checkLabel": "Check"
+    },
+    "result": {
+      "wins": "{{name}} wins {{amount}}",
+      "winsWith": "{{name}} wins {{amount}} with {{hand}}"
+    },
+    "rebuy": {
+      "title": "You're out of chips.",
+      "bankroll": "Bankroll {{amount}}",
+      "buyIn": "Buy in {{amount}}",
+      "reset": "Reset bankroll"
+    },
+    "history": {
+      "title": "Hand history",
+      "empty": "No hands played yet.",
+      "foldedOut": "everyone folded"
+    },
+    "settings": {
+      "stakes": "Stakes",
+      "speed": "Table speed",
+      "speed_normal": "Normal",
+      "speed_fast": "Fast"
+    }
   }
 }

--- a/src/i18n/locales/es/sessions.json
+++ b/src/i18n/locales/es/sessions.json
@@ -2841,7 +2841,6 @@
     "waitingFor": "Waiting for {{name}}…",
     "dealing": "Dealing…",
     "nextHand": "Deal next hand",
-    "disclaimer": "Play chips only — nothing here is real tokens or money.",
     "seat": {
       "you": "You",
       "bot": "bot",
@@ -2864,14 +2863,14 @@
       "winsWith": "{{name}} wins {{amount}} with {{hand}}"
     },
     "rebuy": {
-      "title": "You're out of chips.",
+      "title": "You're out of chips",
       "bankroll": "Bankroll {{amount}}",
       "buyIn": "Buy in {{amount}}",
       "reset": "Reset bankroll"
     },
     "history": {
       "title": "Hand history",
-      "empty": "No hands played yet.",
+      "empty": "No hands played yet",
       "foldedOut": "everyone folded"
     },
     "settings": {

--- a/src/i18n/locales/fr/sessions.json
+++ b/src/i18n/locales/fr/sessions.json
@@ -2824,5 +2824,61 @@
     "summarize": "Résumer avec Agent",
     "waiting": "En attente de contenu…",
     "empty": "Aucun contenu"
+  },
+  "pokerTable": {
+    "menuLabel": "Poker table",
+    "header": {
+      "title": "No-Limit Inference – {{stakes}} Mtok – 6-max",
+      "hand": "Hand #{{number}}",
+      "history": "Hand history",
+      "settings": "Table settings",
+      "leave": "Leave table",
+      "close": "Close"
+    },
+    "potLabel": "Pot",
+    "tokens": "{{amount}} tokens",
+    "thinking": "Thinking · {{seconds}}s",
+    "waitingFor": "Waiting for {{name}}…",
+    "dealing": "Dealing…",
+    "nextHand": "Deal next hand",
+    "disclaimer": "Play chips only — nothing here is real tokens or money.",
+    "seat": {
+      "you": "You",
+      "bot": "bot",
+      "allIn": "All in"
+    },
+    "actions": {
+      "fold": "Fold",
+      "check": "Check",
+      "call": "Call {{amount}}",
+      "bet": "Bet {{amount}}",
+      "raise": "Raise {{amount}}",
+      "allIn": "All in {{amount}}",
+      "betLabel": "Bet",
+      "raiseLabel": "Raise",
+      "callLabel": "Call",
+      "checkLabel": "Check"
+    },
+    "result": {
+      "wins": "{{name}} wins {{amount}}",
+      "winsWith": "{{name}} wins {{amount}} with {{hand}}"
+    },
+    "rebuy": {
+      "title": "You're out of chips.",
+      "bankroll": "Bankroll {{amount}}",
+      "buyIn": "Buy in {{amount}}",
+      "reset": "Reset bankroll"
+    },
+    "history": {
+      "title": "Hand history",
+      "empty": "No hands played yet.",
+      "foldedOut": "everyone folded"
+    },
+    "settings": {
+      "stakes": "Stakes",
+      "speed": "Table speed",
+      "speed_normal": "Normal",
+      "speed_fast": "Fast"
+    }
   }
 }

--- a/src/i18n/locales/fr/sessions.json
+++ b/src/i18n/locales/fr/sessions.json
@@ -2841,7 +2841,6 @@
     "waitingFor": "Waiting for {{name}}…",
     "dealing": "Dealing…",
     "nextHand": "Deal next hand",
-    "disclaimer": "Play chips only — nothing here is real tokens or money.",
     "seat": {
       "you": "You",
       "bot": "bot",
@@ -2864,14 +2863,14 @@
       "winsWith": "{{name}} wins {{amount}} with {{hand}}"
     },
     "rebuy": {
-      "title": "You're out of chips.",
+      "title": "You're out of chips",
       "bankroll": "Bankroll {{amount}}",
       "buyIn": "Buy in {{amount}}",
       "reset": "Reset bankroll"
     },
     "history": {
       "title": "Hand history",
-      "empty": "No hands played yet.",
+      "empty": "No hands played yet",
       "foldedOut": "everyone folded"
     },
     "settings": {

--- a/src/i18n/locales/ja/sessions.json
+++ b/src/i18n/locales/ja/sessions.json
@@ -2823,5 +2823,61 @@
     "summarize": "Agent で要約",
     "waiting": "コンテンツを待機中…",
     "empty": "コンテンツなし"
+  },
+  "pokerTable": {
+    "menuLabel": "Poker table",
+    "header": {
+      "title": "No-Limit Inference – {{stakes}} Mtok – 6-max",
+      "hand": "Hand #{{number}}",
+      "history": "Hand history",
+      "settings": "Table settings",
+      "leave": "Leave table",
+      "close": "Close"
+    },
+    "potLabel": "Pot",
+    "tokens": "{{amount}} tokens",
+    "thinking": "Thinking · {{seconds}}s",
+    "waitingFor": "Waiting for {{name}}…",
+    "dealing": "Dealing…",
+    "nextHand": "Deal next hand",
+    "disclaimer": "Play chips only — nothing here is real tokens or money.",
+    "seat": {
+      "you": "You",
+      "bot": "bot",
+      "allIn": "All in"
+    },
+    "actions": {
+      "fold": "Fold",
+      "check": "Check",
+      "call": "Call {{amount}}",
+      "bet": "Bet {{amount}}",
+      "raise": "Raise {{amount}}",
+      "allIn": "All in {{amount}}",
+      "betLabel": "Bet",
+      "raiseLabel": "Raise",
+      "callLabel": "Call",
+      "checkLabel": "Check"
+    },
+    "result": {
+      "wins": "{{name}} wins {{amount}}",
+      "winsWith": "{{name}} wins {{amount}} with {{hand}}"
+    },
+    "rebuy": {
+      "title": "You're out of chips.",
+      "bankroll": "Bankroll {{amount}}",
+      "buyIn": "Buy in {{amount}}",
+      "reset": "Reset bankroll"
+    },
+    "history": {
+      "title": "Hand history",
+      "empty": "No hands played yet.",
+      "foldedOut": "everyone folded"
+    },
+    "settings": {
+      "stakes": "Stakes",
+      "speed": "Table speed",
+      "speed_normal": "Normal",
+      "speed_fast": "Fast"
+    }
   }
 }

--- a/src/i18n/locales/ja/sessions.json
+++ b/src/i18n/locales/ja/sessions.json
@@ -2840,7 +2840,6 @@
     "waitingFor": "Waiting for {{name}}…",
     "dealing": "Dealing…",
     "nextHand": "Deal next hand",
-    "disclaimer": "Play chips only — nothing here is real tokens or money.",
     "seat": {
       "you": "You",
       "bot": "bot",
@@ -2863,14 +2862,14 @@
       "winsWith": "{{name}} wins {{amount}} with {{hand}}"
     },
     "rebuy": {
-      "title": "You're out of chips.",
+      "title": "You're out of chips",
       "bankroll": "Bankroll {{amount}}",
       "buyIn": "Buy in {{amount}}",
       "reset": "Reset bankroll"
     },
     "history": {
       "title": "Hand history",
-      "empty": "No hands played yet.",
+      "empty": "No hands played yet",
       "foldedOut": "everyone folded"
     },
     "settings": {

--- a/src/i18n/locales/ko/sessions.json
+++ b/src/i18n/locales/ko/sessions.json
@@ -2841,7 +2841,6 @@
     "waitingFor": "Waiting for {{name}}…",
     "dealing": "Dealing…",
     "nextHand": "Deal next hand",
-    "disclaimer": "Play chips only — nothing here is real tokens or money.",
     "seat": {
       "you": "You",
       "bot": "bot",
@@ -2864,14 +2863,14 @@
       "winsWith": "{{name}} wins {{amount}} with {{hand}}"
     },
     "rebuy": {
-      "title": "You're out of chips.",
+      "title": "You're out of chips",
       "bankroll": "Bankroll {{amount}}",
       "buyIn": "Buy in {{amount}}",
       "reset": "Reset bankroll"
     },
     "history": {
       "title": "Hand history",
-      "empty": "No hands played yet.",
+      "empty": "No hands played yet",
       "foldedOut": "everyone folded"
     },
     "settings": {

--- a/src/i18n/locales/ko/sessions.json
+++ b/src/i18n/locales/ko/sessions.json
@@ -2824,5 +2824,61 @@
     "summarize": "Agent로 요약",
     "waiting": "콘텐츠 대기 중…",
     "empty": "콘텐츠 없음"
+  },
+  "pokerTable": {
+    "menuLabel": "Poker table",
+    "header": {
+      "title": "No-Limit Inference – {{stakes}} Mtok – 6-max",
+      "hand": "Hand #{{number}}",
+      "history": "Hand history",
+      "settings": "Table settings",
+      "leave": "Leave table",
+      "close": "Close"
+    },
+    "potLabel": "Pot",
+    "tokens": "{{amount}} tokens",
+    "thinking": "Thinking · {{seconds}}s",
+    "waitingFor": "Waiting for {{name}}…",
+    "dealing": "Dealing…",
+    "nextHand": "Deal next hand",
+    "disclaimer": "Play chips only — nothing here is real tokens or money.",
+    "seat": {
+      "you": "You",
+      "bot": "bot",
+      "allIn": "All in"
+    },
+    "actions": {
+      "fold": "Fold",
+      "check": "Check",
+      "call": "Call {{amount}}",
+      "bet": "Bet {{amount}}",
+      "raise": "Raise {{amount}}",
+      "allIn": "All in {{amount}}",
+      "betLabel": "Bet",
+      "raiseLabel": "Raise",
+      "callLabel": "Call",
+      "checkLabel": "Check"
+    },
+    "result": {
+      "wins": "{{name}} wins {{amount}}",
+      "winsWith": "{{name}} wins {{amount}} with {{hand}}"
+    },
+    "rebuy": {
+      "title": "You're out of chips.",
+      "bankroll": "Bankroll {{amount}}",
+      "buyIn": "Buy in {{amount}}",
+      "reset": "Reset bankroll"
+    },
+    "history": {
+      "title": "Hand history",
+      "empty": "No hands played yet.",
+      "foldedOut": "everyone folded"
+    },
+    "settings": {
+      "stakes": "Stakes",
+      "speed": "Table speed",
+      "speed_normal": "Normal",
+      "speed_fast": "Fast"
+    }
   }
 }

--- a/src/i18n/locales/pl/sessions.json
+++ b/src/i18n/locales/pl/sessions.json
@@ -2878,7 +2878,6 @@
     "waitingFor": "Waiting for {{name}}…",
     "dealing": "Dealing…",
     "nextHand": "Deal next hand",
-    "disclaimer": "Play chips only — nothing here is real tokens or money.",
     "seat": {
       "you": "You",
       "bot": "bot",
@@ -2901,14 +2900,14 @@
       "winsWith": "{{name}} wins {{amount}} with {{hand}}"
     },
     "rebuy": {
-      "title": "You're out of chips.",
+      "title": "You're out of chips",
       "bankroll": "Bankroll {{amount}}",
       "buyIn": "Buy in {{amount}}",
       "reset": "Reset bankroll"
     },
     "history": {
       "title": "Hand history",
-      "empty": "No hands played yet.",
+      "empty": "No hands played yet",
       "foldedOut": "everyone folded"
     },
     "settings": {

--- a/src/i18n/locales/pl/sessions.json
+++ b/src/i18n/locales/pl/sessions.json
@@ -2861,5 +2861,61 @@
     "summarize": "Podsumuj z Agent",
     "waiting": "Oczekiwanie na treść…",
     "empty": "Brak treści"
+  },
+  "pokerTable": {
+    "menuLabel": "Poker table",
+    "header": {
+      "title": "No-Limit Inference – {{stakes}} Mtok – 6-max",
+      "hand": "Hand #{{number}}",
+      "history": "Hand history",
+      "settings": "Table settings",
+      "leave": "Leave table",
+      "close": "Close"
+    },
+    "potLabel": "Pot",
+    "tokens": "{{amount}} tokens",
+    "thinking": "Thinking · {{seconds}}s",
+    "waitingFor": "Waiting for {{name}}…",
+    "dealing": "Dealing…",
+    "nextHand": "Deal next hand",
+    "disclaimer": "Play chips only — nothing here is real tokens or money.",
+    "seat": {
+      "you": "You",
+      "bot": "bot",
+      "allIn": "All in"
+    },
+    "actions": {
+      "fold": "Fold",
+      "check": "Check",
+      "call": "Call {{amount}}",
+      "bet": "Bet {{amount}}",
+      "raise": "Raise {{amount}}",
+      "allIn": "All in {{amount}}",
+      "betLabel": "Bet",
+      "raiseLabel": "Raise",
+      "callLabel": "Call",
+      "checkLabel": "Check"
+    },
+    "result": {
+      "wins": "{{name}} wins {{amount}}",
+      "winsWith": "{{name}} wins {{amount}} with {{hand}}"
+    },
+    "rebuy": {
+      "title": "You're out of chips.",
+      "bankroll": "Bankroll {{amount}}",
+      "buyIn": "Buy in {{amount}}",
+      "reset": "Reset bankroll"
+    },
+    "history": {
+      "title": "Hand history",
+      "empty": "No hands played yet.",
+      "foldedOut": "everyone folded"
+    },
+    "settings": {
+      "stakes": "Stakes",
+      "speed": "Table speed",
+      "speed_normal": "Normal",
+      "speed_fast": "Fast"
+    }
   }
 }

--- a/src/i18n/locales/pt/sessions.json
+++ b/src/i18n/locales/pt/sessions.json
@@ -2823,5 +2823,61 @@
     "summarize": "Resumir com Agent",
     "waiting": "Aguardando conteúdo…",
     "empty": "Sem conteúdo"
+  },
+  "pokerTable": {
+    "menuLabel": "Poker table",
+    "header": {
+      "title": "No-Limit Inference – {{stakes}} Mtok – 6-max",
+      "hand": "Hand #{{number}}",
+      "history": "Hand history",
+      "settings": "Table settings",
+      "leave": "Leave table",
+      "close": "Close"
+    },
+    "potLabel": "Pot",
+    "tokens": "{{amount}} tokens",
+    "thinking": "Thinking · {{seconds}}s",
+    "waitingFor": "Waiting for {{name}}…",
+    "dealing": "Dealing…",
+    "nextHand": "Deal next hand",
+    "disclaimer": "Play chips only — nothing here is real tokens or money.",
+    "seat": {
+      "you": "You",
+      "bot": "bot",
+      "allIn": "All in"
+    },
+    "actions": {
+      "fold": "Fold",
+      "check": "Check",
+      "call": "Call {{amount}}",
+      "bet": "Bet {{amount}}",
+      "raise": "Raise {{amount}}",
+      "allIn": "All in {{amount}}",
+      "betLabel": "Bet",
+      "raiseLabel": "Raise",
+      "callLabel": "Call",
+      "checkLabel": "Check"
+    },
+    "result": {
+      "wins": "{{name}} wins {{amount}}",
+      "winsWith": "{{name}} wins {{amount}} with {{hand}}"
+    },
+    "rebuy": {
+      "title": "You're out of chips.",
+      "bankroll": "Bankroll {{amount}}",
+      "buyIn": "Buy in {{amount}}",
+      "reset": "Reset bankroll"
+    },
+    "history": {
+      "title": "Hand history",
+      "empty": "No hands played yet.",
+      "foldedOut": "everyone folded"
+    },
+    "settings": {
+      "stakes": "Stakes",
+      "speed": "Table speed",
+      "speed_normal": "Normal",
+      "speed_fast": "Fast"
+    }
   }
 }

--- a/src/i18n/locales/pt/sessions.json
+++ b/src/i18n/locales/pt/sessions.json
@@ -2840,7 +2840,6 @@
     "waitingFor": "Waiting for {{name}}…",
     "dealing": "Dealing…",
     "nextHand": "Deal next hand",
-    "disclaimer": "Play chips only — nothing here is real tokens or money.",
     "seat": {
       "you": "You",
       "bot": "bot",
@@ -2863,14 +2862,14 @@
       "winsWith": "{{name}} wins {{amount}} with {{hand}}"
     },
     "rebuy": {
-      "title": "You're out of chips.",
+      "title": "You're out of chips",
       "bankroll": "Bankroll {{amount}}",
       "buyIn": "Buy in {{amount}}",
       "reset": "Reset bankroll"
     },
     "history": {
       "title": "Hand history",
-      "empty": "No hands played yet.",
+      "empty": "No hands played yet",
       "foldedOut": "everyone folded"
     },
     "settings": {

--- a/src/i18n/locales/ru/sessions.json
+++ b/src/i18n/locales/ru/sessions.json
@@ -2868,5 +2868,61 @@
     "summarize": "Обобщить с Agent",
     "waiting": "Ожидание контента…",
     "empty": "Нет содержимого"
+  },
+  "pokerTable": {
+    "menuLabel": "Poker table",
+    "header": {
+      "title": "No-Limit Inference – {{stakes}} Mtok – 6-max",
+      "hand": "Hand #{{number}}",
+      "history": "Hand history",
+      "settings": "Table settings",
+      "leave": "Leave table",
+      "close": "Close"
+    },
+    "potLabel": "Pot",
+    "tokens": "{{amount}} tokens",
+    "thinking": "Thinking · {{seconds}}s",
+    "waitingFor": "Waiting for {{name}}…",
+    "dealing": "Dealing…",
+    "nextHand": "Deal next hand",
+    "disclaimer": "Play chips only — nothing here is real tokens or money.",
+    "seat": {
+      "you": "You",
+      "bot": "bot",
+      "allIn": "All in"
+    },
+    "actions": {
+      "fold": "Fold",
+      "check": "Check",
+      "call": "Call {{amount}}",
+      "bet": "Bet {{amount}}",
+      "raise": "Raise {{amount}}",
+      "allIn": "All in {{amount}}",
+      "betLabel": "Bet",
+      "raiseLabel": "Raise",
+      "callLabel": "Call",
+      "checkLabel": "Check"
+    },
+    "result": {
+      "wins": "{{name}} wins {{amount}}",
+      "winsWith": "{{name}} wins {{amount}} with {{hand}}"
+    },
+    "rebuy": {
+      "title": "You're out of chips.",
+      "bankroll": "Bankroll {{amount}}",
+      "buyIn": "Buy in {{amount}}",
+      "reset": "Reset bankroll"
+    },
+    "history": {
+      "title": "Hand history",
+      "empty": "No hands played yet.",
+      "foldedOut": "everyone folded"
+    },
+    "settings": {
+      "stakes": "Stakes",
+      "speed": "Table speed",
+      "speed_normal": "Normal",
+      "speed_fast": "Fast"
+    }
   }
 }

--- a/src/i18n/locales/ru/sessions.json
+++ b/src/i18n/locales/ru/sessions.json
@@ -2885,7 +2885,6 @@
     "waitingFor": "Waiting for {{name}}…",
     "dealing": "Dealing…",
     "nextHand": "Deal next hand",
-    "disclaimer": "Play chips only — nothing here is real tokens or money.",
     "seat": {
       "you": "You",
       "bot": "bot",
@@ -2908,14 +2907,14 @@
       "winsWith": "{{name}} wins {{amount}} with {{hand}}"
     },
     "rebuy": {
-      "title": "You're out of chips.",
+      "title": "You're out of chips",
       "bankroll": "Bankroll {{amount}}",
       "buyIn": "Buy in {{amount}}",
       "reset": "Reset bankroll"
     },
     "history": {
       "title": "Hand history",
-      "empty": "No hands played yet.",
+      "empty": "No hands played yet",
       "foldedOut": "everyone folded"
     },
     "settings": {

--- a/src/i18n/locales/tr/sessions.json
+++ b/src/i18n/locales/tr/sessions.json
@@ -2825,5 +2825,61 @@
     "summarize": "Agent ile özetle",
     "waiting": "İçerik bekleniyor…",
     "empty": "İçerik yok"
+  },
+  "pokerTable": {
+    "menuLabel": "Poker table",
+    "header": {
+      "title": "No-Limit Inference – {{stakes}} Mtok – 6-max",
+      "hand": "Hand #{{number}}",
+      "history": "Hand history",
+      "settings": "Table settings",
+      "leave": "Leave table",
+      "close": "Close"
+    },
+    "potLabel": "Pot",
+    "tokens": "{{amount}} tokens",
+    "thinking": "Thinking · {{seconds}}s",
+    "waitingFor": "Waiting for {{name}}…",
+    "dealing": "Dealing…",
+    "nextHand": "Deal next hand",
+    "disclaimer": "Play chips only — nothing here is real tokens or money.",
+    "seat": {
+      "you": "You",
+      "bot": "bot",
+      "allIn": "All in"
+    },
+    "actions": {
+      "fold": "Fold",
+      "check": "Check",
+      "call": "Call {{amount}}",
+      "bet": "Bet {{amount}}",
+      "raise": "Raise {{amount}}",
+      "allIn": "All in {{amount}}",
+      "betLabel": "Bet",
+      "raiseLabel": "Raise",
+      "callLabel": "Call",
+      "checkLabel": "Check"
+    },
+    "result": {
+      "wins": "{{name}} wins {{amount}}",
+      "winsWith": "{{name}} wins {{amount}} with {{hand}}"
+    },
+    "rebuy": {
+      "title": "You're out of chips.",
+      "bankroll": "Bankroll {{amount}}",
+      "buyIn": "Buy in {{amount}}",
+      "reset": "Reset bankroll"
+    },
+    "history": {
+      "title": "Hand history",
+      "empty": "No hands played yet.",
+      "foldedOut": "everyone folded"
+    },
+    "settings": {
+      "stakes": "Stakes",
+      "speed": "Table speed",
+      "speed_normal": "Normal",
+      "speed_fast": "Fast"
+    }
   }
 }

--- a/src/i18n/locales/tr/sessions.json
+++ b/src/i18n/locales/tr/sessions.json
@@ -2842,7 +2842,6 @@
     "waitingFor": "Waiting for {{name}}…",
     "dealing": "Dealing…",
     "nextHand": "Deal next hand",
-    "disclaimer": "Play chips only — nothing here is real tokens or money.",
     "seat": {
       "you": "You",
       "bot": "bot",
@@ -2865,14 +2864,14 @@
       "winsWith": "{{name}} wins {{amount}} with {{hand}}"
     },
     "rebuy": {
-      "title": "You're out of chips.",
+      "title": "You're out of chips",
       "bankroll": "Bankroll {{amount}}",
       "buyIn": "Buy in {{amount}}",
       "reset": "Reset bankroll"
     },
     "history": {
       "title": "Hand history",
-      "empty": "No hands played yet.",
+      "empty": "No hands played yet",
       "foldedOut": "everyone folded"
     },
     "settings": {

--- a/src/i18n/locales/vi/sessions.json
+++ b/src/i18n/locales/vi/sessions.json
@@ -2821,5 +2821,61 @@
     "summarize": "Tóm tắt với Agent",
     "waiting": "Đang chờ nội dung…",
     "empty": "Không có nội dung"
+  },
+  "pokerTable": {
+    "menuLabel": "Poker table",
+    "header": {
+      "title": "No-Limit Inference – {{stakes}} Mtok – 6-max",
+      "hand": "Hand #{{number}}",
+      "history": "Hand history",
+      "settings": "Table settings",
+      "leave": "Leave table",
+      "close": "Close"
+    },
+    "potLabel": "Pot",
+    "tokens": "{{amount}} tokens",
+    "thinking": "Thinking · {{seconds}}s",
+    "waitingFor": "Waiting for {{name}}…",
+    "dealing": "Dealing…",
+    "nextHand": "Deal next hand",
+    "disclaimer": "Play chips only — nothing here is real tokens or money.",
+    "seat": {
+      "you": "You",
+      "bot": "bot",
+      "allIn": "All in"
+    },
+    "actions": {
+      "fold": "Fold",
+      "check": "Check",
+      "call": "Call {{amount}}",
+      "bet": "Bet {{amount}}",
+      "raise": "Raise {{amount}}",
+      "allIn": "All in {{amount}}",
+      "betLabel": "Bet",
+      "raiseLabel": "Raise",
+      "callLabel": "Call",
+      "checkLabel": "Check"
+    },
+    "result": {
+      "wins": "{{name}} wins {{amount}}",
+      "winsWith": "{{name}} wins {{amount}} with {{hand}}"
+    },
+    "rebuy": {
+      "title": "You're out of chips.",
+      "bankroll": "Bankroll {{amount}}",
+      "buyIn": "Buy in {{amount}}",
+      "reset": "Reset bankroll"
+    },
+    "history": {
+      "title": "Hand history",
+      "empty": "No hands played yet.",
+      "foldedOut": "everyone folded"
+    },
+    "settings": {
+      "stakes": "Stakes",
+      "speed": "Table speed",
+      "speed_normal": "Normal",
+      "speed_fast": "Fast"
+    }
   }
 }

--- a/src/i18n/locales/vi/sessions.json
+++ b/src/i18n/locales/vi/sessions.json
@@ -2838,7 +2838,6 @@
     "waitingFor": "Waiting for {{name}}…",
     "dealing": "Dealing…",
     "nextHand": "Deal next hand",
-    "disclaimer": "Play chips only — nothing here is real tokens or money.",
     "seat": {
       "you": "You",
       "bot": "bot",
@@ -2861,14 +2860,14 @@
       "winsWith": "{{name}} wins {{amount}} with {{hand}}"
     },
     "rebuy": {
-      "title": "You're out of chips.",
+      "title": "You're out of chips",
       "bankroll": "Bankroll {{amount}}",
       "buyIn": "Buy in {{amount}}",
       "reset": "Reset bankroll"
     },
     "history": {
       "title": "Hand history",
-      "empty": "No hands played yet.",
+      "empty": "No hands played yet",
       "foldedOut": "everyone folded"
     },
     "settings": {

--- a/src/i18n/locales/zh-Hant/sessions.json
+++ b/src/i18n/locales/zh-Hant/sessions.json
@@ -2916,7 +2916,6 @@
     "waitingFor": "Waiting for {{name}}…",
     "dealing": "Dealing…",
     "nextHand": "Deal next hand",
-    "disclaimer": "Play chips only — nothing here is real tokens or money.",
     "seat": {
       "you": "You",
       "bot": "bot",
@@ -2939,14 +2938,14 @@
       "winsWith": "{{name}} wins {{amount}} with {{hand}}"
     },
     "rebuy": {
-      "title": "You're out of chips.",
+      "title": "You're out of chips",
       "bankroll": "Bankroll {{amount}}",
       "buyIn": "Buy in {{amount}}",
       "reset": "Reset bankroll"
     },
     "history": {
       "title": "Hand history",
-      "empty": "No hands played yet.",
+      "empty": "No hands played yet",
       "foldedOut": "everyone folded"
     },
     "settings": {

--- a/src/i18n/locales/zh-Hant/sessions.json
+++ b/src/i18n/locales/zh-Hant/sessions.json
@@ -2899,5 +2899,61 @@
     "previewTitle": "Canvas 選區預覽",
     "elementsCount_other": "{{count}} 個元素",
     "regionLabel": "區域 · {{label}}"
+  },
+  "pokerTable": {
+    "menuLabel": "Poker table",
+    "header": {
+      "title": "No-Limit Inference – {{stakes}} Mtok – 6-max",
+      "hand": "Hand #{{number}}",
+      "history": "Hand history",
+      "settings": "Table settings",
+      "leave": "Leave table",
+      "close": "Close"
+    },
+    "potLabel": "Pot",
+    "tokens": "{{amount}} tokens",
+    "thinking": "Thinking · {{seconds}}s",
+    "waitingFor": "Waiting for {{name}}…",
+    "dealing": "Dealing…",
+    "nextHand": "Deal next hand",
+    "disclaimer": "Play chips only — nothing here is real tokens or money.",
+    "seat": {
+      "you": "You",
+      "bot": "bot",
+      "allIn": "All in"
+    },
+    "actions": {
+      "fold": "Fold",
+      "check": "Check",
+      "call": "Call {{amount}}",
+      "bet": "Bet {{amount}}",
+      "raise": "Raise {{amount}}",
+      "allIn": "All in {{amount}}",
+      "betLabel": "Bet",
+      "raiseLabel": "Raise",
+      "callLabel": "Call",
+      "checkLabel": "Check"
+    },
+    "result": {
+      "wins": "{{name}} wins {{amount}}",
+      "winsWith": "{{name}} wins {{amount}} with {{hand}}"
+    },
+    "rebuy": {
+      "title": "You're out of chips.",
+      "bankroll": "Bankroll {{amount}}",
+      "buyIn": "Buy in {{amount}}",
+      "reset": "Reset bankroll"
+    },
+    "history": {
+      "title": "Hand history",
+      "empty": "No hands played yet.",
+      "foldedOut": "everyone folded"
+    },
+    "settings": {
+      "stakes": "Stakes",
+      "speed": "Table speed",
+      "speed_normal": "Normal",
+      "speed_fast": "Fast"
+    }
   }
 }

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -3015,7 +3015,6 @@
     "waitingFor": "等待 {{name}}…",
     "dealing": "发牌中…",
     "nextHand": "开始下一手",
-    "disclaimer": "仅为游戏筹码——这里的一切都不是真实 token 或金钱。",
     "seat": {
       "you": "你",
       "bot": "机器人",
@@ -3038,14 +3037,14 @@
       "winsWith": "{{name}} 以 {{hand}} 赢得 {{amount}}"
     },
     "rebuy": {
-      "title": "你的筹码输光了。",
+      "title": "你的筹码输光了",
       "bankroll": "资金 {{amount}}",
       "buyIn": "买入 {{amount}}",
       "reset": "重置资金"
     },
     "history": {
       "title": "牌局记录",
-      "empty": "还没有打过牌。",
+      "empty": "还没有打过牌",
       "foldedOut": "其他人都弃牌"
     },
     "settings": {

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -2998,5 +2998,61 @@
     "previewTitle": "Canvas 选区预览",
     "elementsCount_other": "{{count}} 个元素",
     "regionLabel": "区域 · {{label}}"
+  },
+  "pokerTable": {
+    "menuLabel": "扑克桌",
+    "header": {
+      "title": "无限注推理 – {{stakes}} Mtok – 6人桌",
+      "hand": "第 {{number}} 手",
+      "history": "牌局记录",
+      "settings": "牌桌设置",
+      "leave": "离开牌桌",
+      "close": "关闭"
+    },
+    "potLabel": "底池",
+    "tokens": "{{amount}} tokens",
+    "thinking": "思考中 · {{seconds}}s",
+    "waitingFor": "等待 {{name}}…",
+    "dealing": "发牌中…",
+    "nextHand": "开始下一手",
+    "disclaimer": "仅为游戏筹码——这里的一切都不是真实 token 或金钱。",
+    "seat": {
+      "you": "你",
+      "bot": "机器人",
+      "allIn": "全下"
+    },
+    "actions": {
+      "fold": "弃牌",
+      "check": "过牌",
+      "call": "跟注 {{amount}}",
+      "bet": "下注 {{amount}}",
+      "raise": "加注到 {{amount}}",
+      "allIn": "全下 {{amount}}",
+      "betLabel": "下注",
+      "raiseLabel": "加注",
+      "callLabel": "跟注",
+      "checkLabel": "过牌"
+    },
+    "result": {
+      "wins": "{{name}} 赢得 {{amount}}",
+      "winsWith": "{{name}} 以 {{hand}} 赢得 {{amount}}"
+    },
+    "rebuy": {
+      "title": "你的筹码输光了。",
+      "bankroll": "资金 {{amount}}",
+      "buyIn": "买入 {{amount}}",
+      "reset": "重置资金"
+    },
+    "history": {
+      "title": "牌局记录",
+      "empty": "还没有打过牌。",
+      "foldedOut": "其他人都弃牌"
+    },
+    "settings": {
+      "stakes": "盲注",
+      "speed": "牌桌速度",
+      "speed_normal": "正常",
+      "speed_fast": "快速"
+    }
   }
 }

--- a/src/modules/shared/layouts/AppLayout.tsx
+++ b/src/modules/shared/layouts/AppLayout.tsx
@@ -30,6 +30,7 @@ import {
 import type { SessionLaunchSuccessInfo } from "@src/engines/SessionCore/hooks/session/useSessionCreator/useSessionLaunch/types";
 import { pendingSessionProposal } from "@src/engines/SessionCore/hooks/useAgentADEActions";
 import SessionSyncProvider from "@src/engines/SessionCore/sync/SessionSyncProvider";
+import PokerTablePanel from "@src/features/PokerTable";
 import { SessionCreatorChatPanel } from "@src/features/SessionCreator/variants";
 import type { SessionCreatorChatPanelProps } from "@src/features/SessionCreator/variants/ChatPanel";
 import { dispatchWebviewLayoutChanged } from "@src/hooks/platform/useInlineWebview/webviewLayoutEvents";
@@ -329,6 +330,8 @@ const AppLayoutComponent: React.FC<AppLayoutProps> = ({
               <ChatPanelSideChat
                 SessionCreatorSlot={AdeAwareSessionCreatorSlot}
               />
+              {/* Floating poker table (play chips), same host as the side chat. */}
+              <PokerTablePanel />
             </div>
           </div>
         </SessionSyncProvider>

--- a/src/store/ui/index.ts
+++ b/src/store/ui/index.ts
@@ -52,6 +52,7 @@ export * from "./kanbanViewStateAtom";
 export * from "./kanbanReplayAtom";
 export * from "./workManagementCreatorAtom";
 export * from "./sideChatAtom";
+export * from "./pokerTableAtom";
 export * from "./modelSelectorAtom";
 export * from "./settingsToolbarAtom";
 export * from "./globalTabsTypes";

--- a/src/store/ui/pokerTableAtom.ts
+++ b/src/store/ui/pokerTableAtom.ts
@@ -1,0 +1,113 @@
+/**
+ * Floating poker table ("Tables") — visibility plus the little that must
+ * survive a reload: the play-chip bankroll and the table settings.
+ *
+ * Phase-0 scope: human vs. bots, play chips only. Chips are NOT tokens from
+ * any account and cannot be bought, transferred or cashed out — the atoms
+ * here are the only ledger, and a "reset bankroll" is always free. Keep it
+ * that way: purchase or transfer paths are what turn a game into gambling.
+ */
+import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+import { z } from "zod/v4";
+
+import { createZodJsonStorage } from "@src/util/core/storage/zodStorage";
+
+// ─── Visibility (session-only, like the side chat) ─────────────────────────
+
+export const pokerTableVisibleAtom = atom<boolean>(false);
+pokerTableVisibleAtom.debugLabel = "pokerTable/visible";
+
+export const openPokerTableAtom = atom(null, (_get, set) => {
+  set(pokerTableVisibleAtom, true);
+});
+openPokerTableAtom.debugLabel = "pokerTable/open";
+
+export const closePokerTableAtom = atom(null, (_get, set) => {
+  set(pokerTableVisibleAtom, false);
+});
+closePokerTableAtom.debugLabel = "pokerTable/close";
+
+// ─── Bankroll (chips; 1 chip = 1,000 play tokens) ───────────────────────────
+
+/** 500M play tokens — five 100-BB buy-ins at the default 0.5/1 Mtok stakes. */
+export const POKER_DEFAULT_BANKROLL_CHIPS = 500_000;
+
+export const POKER_BANKROLL_STORAGE_KEY = "orgii:pokerTable:bankroll:v1";
+
+const StoredBankrollSchema = z.object({
+  chips: z.number().int().nonnegative(),
+  updatedAt: z.number().int().nonnegative(),
+});
+export type StoredPokerBankroll = z.infer<typeof StoredBankrollSchema>;
+
+export const pokerBankrollAtom = atomWithStorage<StoredPokerBankroll>(
+  POKER_BANKROLL_STORAGE_KEY,
+  { chips: POKER_DEFAULT_BANKROLL_CHIPS, updatedAt: 0 },
+  createZodJsonStorage(StoredBankrollSchema, {
+    onInvalid: (key, _rawValue, error) => {
+      console.warn(`[pokerTable] invalid stored bankroll for ${key}`, error);
+    },
+  }),
+  { getOnInit: true }
+);
+pokerBankrollAtom.debugLabel = "pokerTable/bankroll";
+
+/** Write the chip count with a fresh timestamp (the controller's callback). */
+export const setPokerBankrollChipsAtom = atom(
+  null,
+  (_get, set, chips: number) => {
+    set(pokerBankrollAtom, {
+      chips: Math.max(0, Math.round(chips)),
+      updatedAt: Date.now(),
+    });
+  }
+);
+setPokerBankrollChipsAtom.debugLabel = "pokerTable/setBankrollChips";
+
+// ─── Settings ───────────────────────────────────────────────────────────────
+
+export const POKER_SETTINGS_STORAGE_KEY = "orgii:pokerTable:settings:v1";
+
+/** Stakes offered in the header dropdown, in chips (0.5/1 Mtok = 500/1000). */
+export const POKER_STAKES_OPTIONS = [
+  { id: "0.1/0.2", smallBlind: 100, bigBlind: 200 },
+  { id: "0.5/1", smallBlind: 500, bigBlind: 1000 },
+  { id: "2/4", smallBlind: 2000, bigBlind: 4000 },
+] as const;
+export type PokerStakesId = (typeof POKER_STAKES_OPTIONS)[number]["id"];
+
+const StoredSettingsSchema = z.object({
+  stakesId: z.enum(
+    POKER_STAKES_OPTIONS.map((option) => option.id) as [
+      PokerStakesId,
+      ...PokerStakesId[],
+    ]
+  ),
+  speed: z.enum(["normal", "fast"]),
+});
+export type StoredPokerSettings = z.infer<typeof StoredSettingsSchema>;
+
+export const POKER_DEFAULT_SETTINGS: StoredPokerSettings = {
+  stakesId: "0.5/1",
+  speed: "normal",
+};
+
+export const pokerSettingsAtom = atomWithStorage<StoredPokerSettings>(
+  POKER_SETTINGS_STORAGE_KEY,
+  POKER_DEFAULT_SETTINGS,
+  createZodJsonStorage(StoredSettingsSchema, {
+    onInvalid: (key, _rawValue, error) => {
+      console.warn(`[pokerTable] invalid stored settings for ${key}`, error);
+    },
+  }),
+  { getOnInit: true }
+);
+pokerSettingsAtom.debugLabel = "pokerTable/settings";
+
+export function stakesById(stakesId: PokerStakesId) {
+  return (
+    POKER_STAKES_OPTIONS.find((option) => option.id === stakesId) ??
+    POKER_STAKES_OPTIONS[1]
+  );
+}

--- a/src/types/pokersolver.d.ts
+++ b/src/types/pokersolver.d.ts
@@ -1,0 +1,25 @@
+/**
+ * Minimal typings for `pokersolver` (MIT, no published types). Only the
+ * surface the poker table's evaluator uses is declared here — the library
+ * exposes far more (Omaha, Razz, …) that we don't touch.
+ */
+declare module "pokersolver" {
+  /** A card code like `"Ad"`, `"Tc"` — rank char + lowercase suit char. */
+  type SolverCardCode = string;
+
+  class Hand {
+    /** Human-readable description, e.g. `"Two Pair, K's & 2's"`. */
+    readonly descr: string;
+    /** Category name, e.g. `"Two Pair"`. */
+    readonly name: string;
+    /** Category rank; larger beats smaller (kickers handled by `winners`). */
+    readonly rank: number;
+    /** Best five cards, highest first. */
+    readonly cards: Array<{ value: string; suit: string }>;
+
+    /** Evaluate the best hand out of the given cards (5–7 for Hold'em). */
+    static solve(cards: SolverCardCode[], game?: string): Hand;
+    /** Subset of `hands` that win (ties return several). */
+    static winners(hands: Hand[]): Hand[];
+  }
+}


### PR DESCRIPTION
## Summary

Adds a floating **Poker table** window (play chips, human vs. five bots) on the same `FloatingWindow` shell as the side chat, opened from the chat tab strip's ＋ menu. Phase 0 of the "token tables" idea: chips are a local, resettable bankroll and never touch any account, key, or subscription.

## Problem

We want a poker table inside the app (per the Codex-style mock) as an engagement surface, without any of the properties that would make it gambling: no purchase path, no transfer, no cash-out, no real tokens at stake. There was no rules engine we could reuse safely — `poker-ts` (the best npm candidate) drops all-in seats from later streets so their pot share vanishes or is paid to the wrong seat, and it imports Node `crypto`, which the webview can't run.

## Solution

- **Rules engine** `src/features/PokerTable/engine/holdemHand.ts` — self-contained no-limit Hold'em: blinds (heads-up button = SB), BB option, min-raise tracking, side pots derived from whole-hand contributions, run-out when nobody can act, showdown via `pokersolver` (MIT, the only new dependency), odd-chip rule.
- **Table across hands** `PokerTableEngine.ts` — seats, button rotation, busted/rebuy, per-street action pills, per-viewer `TableSnapshot` (bots' cards hidden until showdown).
- **Bots** `botBrain.ts` + `personas.ts` — Chen-score preflop, Monte-Carlo equity vs. pot odds postflop, five invented personas (no real people, no provider logos).
- **Controller** `PokerTableController.ts` — timing loop (bot "thinking", staged flop/turn/river reveal on run-outs, showdown hold), bust → rebuy pause, leave = cash out to the persisted bankroll, hand history.
- **UI** `src/features/PokerTable/` — stadium felt, six seats with hole cards / dealer button / bet pills / `Thinking · Ns`, pot + board, action bar (25/33/75/133% presets + slider, Fold / Call / Bet, fixed height in every state), stakes + speed via shared `Select`, history drawer, shared `Button`s throughout. Mounted in `AppLayout` next to the side chat; ＋ menu entry in `ChatPanelTabBar`.
- **State** `src/store/ui/pokerTableAtom.ts` — visibility + zod-guarded persisted bankroll/settings. i18n keys in all 13 locales (zh hand-translated).
- Audit report: `docs/frontend-ui-audit-2026-08-17/PokerTableHeader.md`.

## Potential risks

- New feature surface only; no existing behavior changed except one new item in the chat tab strip's ＋ menu (`ChatPanelTabBar` prop threading, covered by its test).
- Bots run Monte-Carlo equity in the renderer (~250 samples ≈ 40 ms per decision) — fine at one table; would need a worker if tables multiply.
- The table is play chips by design; any future "real token" mode must go through the ledger/legal gates discussed separately, not this PR.

## Validation / Test plan

- `pnpm typecheck` clean; ESLint clean on all touched files.
- 37 new unit tests (`vitest run src/features/PokerTable`): chip conservation over random hands, the exact multi-all-in side-pot scenario that broke `poker-ts`, BB option, min-raise, odd chips, fold-out, bot legality/sizing, controller loop with fake timers (bust → rebuy, leave → cash-out, staged run-out, stakes change), plus static-render smoke tests for felt / action bar / header / history / rebuy. `ChatPanelTabBar.test.ts` updated for the new menu entry.
- Played hands live in `tauri:dev` (blinds, bets, calls, folds, showdown, rebuy, leave); UI iterated against screenshots.
