### PR TITLE
fix(codex): parse paginated rollout user turns

### DIFF
--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app/meta.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app/meta.rs
@@ -21,7 +21,7 @@ use super::index::{
     codex_sessions_dir_for_session_path, codex_thread_id_from_file_stem,
     collect_codex_session_files,
 };
-use super::transcript::user_message_from_payload;
+use super::transcript::user_message_text_from_line;
 use super::{
     CodexAppSessionMeta, CodexAppSourceMetadata, CodexJsonlLine, CODEX_APP_METADATA_PARSER_VERSION,
 };
@@ -100,7 +100,7 @@ impl CodexSessionMetaState {
             }
         }
         if self.first_prompt.is_empty() {
-            if let Some(message) = user_message_from_payload(&parsed.payload) {
+            if let Some(message) = user_message_text_from_line(&parsed) {
                 self.first_prompt = message;
             }
         }

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app/mod.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app/mod.rs
@@ -49,8 +49,8 @@ pub(crate) use meta::{parse_codex_session_meta, parse_codex_session_meta_increme
 pub(crate) use serde_json::json;
 #[cfg(test)]
 pub(crate) use transcript::{
-    output_parts_for_tool_calls, pending_custom_tool_calls_from_payload,
-    strip_ignored_embedded_images, user_message_from_payload,
+    legacy_user_message_text_from_payload, output_parts_for_tool_calls,
+    pending_custom_tool_calls_from_payload, strip_ignored_embedded_images,
 };
 
 // v9: derive impact from authoritative `patch_apply_end` events (structured
@@ -60,7 +60,9 @@ pub(crate) use transcript::{
 // per-round deltas.
 // v11: retain Codex subagent spawn metadata and the child rollout's plaintext
 // first prompt so encrypted collaboration arguments can be reconstructed.
-const CODEX_APP_METADATA_PARSER_VERSION: i64 = 11;
+// v12: recognize paginated item_completed/UserMessage records as the canonical
+// user-turn boundary while retaining legacy event_msg/user_message support.
+const CODEX_APP_METADATA_PARSER_VERSION: i64 = 12;
 
 pub type CodexAppSessionRow = ImportedHistorySessionRow;
 pub type CodexAppSessionPage = ImportedHistorySessionPage;

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app/transcript.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app/transcript.rs
@@ -27,6 +27,8 @@ use super::CodexJsonlLine;
 const CODEX_PROVIDER_SLUG: &str = "codex";
 const CODEX_EMBEDDED_IMAGE_MARKER: &str = "\"image_url\":\"data:image/";
 const CODEX_OMITTED_IMAGE_VALUE: &str = "[embedded image omitted]";
+const CODEX_LEGACY_USER_MESSAGE_NEEDLE: &[u8] = b"\"user_message\"";
+const CODEX_PAGINATED_USER_MESSAGE_NEEDLE: &[u8] = b"\"UserMessage\"";
 const CODEX_TURN_OFFSET_CACHE_CAPACITY: usize = 8;
 const CODEX_TURN_OFFSET_LIMIT_PER_SESSION: usize = 4_096;
 const CODEX_INITIAL_TURN_LIMIT: usize = 4_096;
@@ -823,9 +825,6 @@ fn load_codex_turn_header(
             Ok(parsed) => parsed,
             Err(_) => continue,
         };
-        if parsed.payload.get("type").and_then(Value::as_str) != Some("user_message") {
-            continue;
-        }
         let created_at = parsed
             .timestamp
             .as_deref()
@@ -833,7 +832,7 @@ fn load_codex_turn_header(
             .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
         let sequence = codex_lazy_turn_sequence(byte_offset);
         let Some(user_chunk) =
-            user_message_chunk_from_payload(session_id, sequence, &created_at, &parsed.payload)
+            user_message_chunk_from_line(session_id, sequence, &created_at, &parsed)
         else {
             continue;
         };
@@ -1042,7 +1041,6 @@ fn observe_codex_catalog_line(
     lines_since_boundary: &mut usize,
     last_agent_preview: &mut Option<String>,
 ) {
-    const USER_MESSAGE_NEEDLE: &[u8] = b"\"user_message\"";
     const AGENT_MESSAGE_NEEDLE: &[u8] = b"\"agent_message\"";
     const ASSISTANT_ROLE_NEEDLE: &[u8] = b"\"assistant\"";
     if line.is_empty() {
@@ -1051,32 +1049,12 @@ fn observe_codex_catalog_line(
     if entries.len() >= limit {
         return;
     }
-    if memmem::find(line, USER_MESSAGE_NEEDLE).is_none() {
-        if last_agent_preview.is_none()
-            && (memmem::find(line, AGENT_MESSAGE_NEEDLE).is_some()
-                || memmem::find(line, ASSISTANT_ROLE_NEEDLE).is_some())
-        {
-            if let Ok(parsed) = serde_json::from_slice::<CodexJsonlLine>(line) {
-                let payload_type = parsed.payload.get("type").and_then(Value::as_str);
-                let message = match payload_type {
-                    Some("agent_message") => parsed
-                        .payload
-                        .get("message")
-                        .and_then(Value::as_str)
-                        .map(ToString::to_string),
-                    Some("message")
-                        if parsed.payload.get("role").and_then(Value::as_str)
-                            == Some("assistant") =>
-                    {
-                        content_text_from_payload(&parsed.payload)
-                    }
-                    _ => None,
-                };
-                *last_agent_preview = message
-                    .filter(|message| !message.trim().is_empty())
-                    .map(|message| bounded_codex_turn_preview(&message));
-            }
-        }
+    let may_contain_user = memmem::find(line, CODEX_LEGACY_USER_MESSAGE_NEEDLE).is_some()
+        || memmem::find(line, CODEX_PAGINATED_USER_MESSAGE_NEEDLE).is_some();
+    let may_contain_assistant = last_agent_preview.is_none()
+        && (memmem::find(line, AGENT_MESSAGE_NEEDLE).is_some()
+            || memmem::find(line, ASSISTANT_ROLE_NEEDLE).is_some());
+    if !may_contain_user && !may_contain_assistant {
         *lines_since_boundary = lines_since_boundary.saturating_add(1);
         return;
     }
@@ -1084,27 +1062,44 @@ fn observe_codex_catalog_line(
         *lines_since_boundary = lines_since_boundary.saturating_add(1);
         return;
     };
-    if parsed.payload.get("type").and_then(Value::as_str) != Some("user_message") {
-        *lines_since_boundary = lines_since_boundary.saturating_add(1);
-        return;
+    if may_contain_user {
+        if let Some(message) = user_message_from_line(&parsed) {
+            let started_at = parsed
+                .timestamp
+                .as_deref()
+                .map(imported_history::normalize_created_at)
+                .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
+            entries.push(CodexTurnCatalogEntry {
+                byte_offset,
+                started_at,
+                user_preview: bounded_codex_turn_preview(&message.text),
+                last_agent_preview: last_agent_preview.take(),
+                following_line_count: *lines_since_boundary,
+            });
+            *lines_since_boundary = 0;
+            return;
+        }
     }
-    let Some(message) = user_message_from_payload(&parsed.payload) else {
-        *lines_since_boundary = lines_since_boundary.saturating_add(1);
-        return;
-    };
-    let started_at = parsed
-        .timestamp
-        .as_deref()
-        .map(imported_history::normalize_created_at)
-        .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
-    entries.push(CodexTurnCatalogEntry {
-        byte_offset,
-        started_at,
-        user_preview: bounded_codex_turn_preview(&message),
-        last_agent_preview: last_agent_preview.take(),
-        following_line_count: *lines_since_boundary,
-    });
-    *lines_since_boundary = 0;
+    if may_contain_assistant {
+        let payload_type = parsed.payload.get("type").and_then(Value::as_str);
+        let message = match payload_type {
+            Some("agent_message") => parsed
+                .payload
+                .get("message")
+                .and_then(Value::as_str)
+                .map(ToString::to_string),
+            Some("message")
+                if parsed.payload.get("role").and_then(Value::as_str) == Some("assistant") =>
+            {
+                content_text_from_payload(&parsed.payload)
+            }
+            _ => None,
+        };
+        *last_agent_preview = message
+            .filter(|message| !message.trim().is_empty())
+            .map(|message| bounded_codex_turn_preview(&message));
+    }
+    *lines_since_boundary = lines_since_boundary.saturating_add(1);
 }
 
 type CodexTranscriptLoad = (
@@ -1184,13 +1179,10 @@ fn load_codex_app_from_path_with_mode<'a>(
                     .map(str::to_string);
                 pending_task_turn_offset = Some(line_start_offset);
             }
-            "user_message" => {
-                if let Some(user_chunk) = user_message_chunk_from_payload(
-                    session_id,
-                    sequence,
-                    &created_at,
-                    &parsed.payload,
-                ) {
+            "user_message" | "item_completed" => {
+                if let Some(user_chunk) =
+                    user_message_chunk_from_line(session_id, sequence, &created_at, &parsed)
+                {
                     let user_sequence = sequence;
                     sequence += 1;
                     if collector.start_turn(user_chunk) {
@@ -2049,7 +2041,7 @@ fn parse_rg_output_matches(output: &str) -> Vec<(String, i64, String)> {
         .collect()
 }
 
-pub(crate) fn user_message_from_payload(payload: &Value) -> Option<String> {
+pub(crate) fn legacy_user_message_text_from_payload(payload: &Value) -> Option<String> {
     let raw = payload.get("message").and_then(Value::as_str)?;
     let stripped = strip_orgii_exec_mode_bridge(raw);
     // Bridge-only messages carry no user-authored text: skip them entirely
@@ -2058,6 +2050,74 @@ pub(crate) fn user_message_from_payload(payload: &Value) -> Option<String> {
         return None;
     }
     Some(stripped.to_string())
+}
+
+#[derive(Debug)]
+struct CodexUserMessage {
+    text: String,
+    image_refs: Vec<String>,
+}
+
+fn user_message_from_line(parsed: &CodexJsonlLine) -> Option<CodexUserMessage> {
+    match parsed.payload.get("type").and_then(Value::as_str) {
+        Some("user_message") => {
+            let text = legacy_user_message_text_from_payload(&parsed.payload).unwrap_or_default();
+            let image_refs = user_image_refs_from_payload(&parsed.payload);
+            if text.is_empty() && image_refs.is_empty() {
+                return None;
+            }
+            Some(CodexUserMessage { text, image_refs })
+        }
+        Some("item_completed") => paginated_user_message_from_payload(&parsed.payload),
+        _ => None,
+    }
+}
+
+pub(super) fn user_message_text_from_line(parsed: &CodexJsonlLine) -> Option<String> {
+    user_message_from_line(parsed)
+        .map(|message| message.text)
+        .filter(|text| !text.trim().is_empty())
+}
+
+fn paginated_user_message_from_payload(payload: &Value) -> Option<CodexUserMessage> {
+    let item = payload.get("item")?;
+    if item.get("type").and_then(Value::as_str) != Some("UserMessage") {
+        return None;
+    }
+    let mut text_parts = Vec::new();
+    let mut image_refs = Vec::new();
+    for part in item.get("content").and_then(Value::as_array)? {
+        match part.get("type").and_then(Value::as_str) {
+            Some("text") => {
+                if let Some(text) = part.get("text").and_then(Value::as_str) {
+                    text_parts.push(text);
+                }
+            }
+            Some("image") => push_unique_string_field(&mut image_refs, part, "image_url"),
+            Some("local_image") => push_unique_string_field(&mut image_refs, part, "path"),
+            _ => {}
+        }
+    }
+    let raw_text = text_parts.join("\n");
+    let text = strip_orgii_exec_mode_bridge(&raw_text).to_string();
+    if text.trim().is_empty() && image_refs.is_empty() {
+        return None;
+    }
+    Some(CodexUserMessage { text, image_refs })
+}
+
+fn push_unique_string_field(values: &mut Vec<String>, object: &Value, field: &str) {
+    let Some(value) = object
+        .get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return;
+    };
+    if !values.iter().any(|existing| existing == value) {
+        values.push(value.to_string());
+    }
 }
 
 fn user_image_refs_from_payload(payload: &Value) -> Vec<String> {
@@ -2078,23 +2138,22 @@ fn user_image_refs_from_payload(payload: &Value) -> Vec<String> {
     refs
 }
 
-fn user_message_chunk_from_payload(
+fn user_message_chunk_from_line(
     session_id: &str,
     sequence: usize,
     created_at: &str,
-    payload: &Value,
+    parsed: &CodexJsonlLine,
 ) -> Option<ActivityChunk> {
-    let message = user_message_from_payload(payload)?;
+    let message = user_message_from_line(parsed)?;
     let mut chunk = imported_history::user_message_chunk(
         session_id,
         CODEX_PROVIDER_SLUG,
         sequence,
         created_at,
-        &message,
+        &message.text,
     );
-    let images = user_image_refs_from_payload(payload);
-    if !images.is_empty() {
-        chunk.result["images"] = json!(images);
+    if !message.image_refs.is_empty() {
+        chunk.result["images"] = json!(message.image_refs);
     }
     Some(chunk)
 }

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
@@ -161,7 +161,8 @@ fn parses_codex_jsonl_into_replay_chunks() {
         std::env::temp_dir().join(format!("orgii-codex-history-test-{}", std::process::id()));
     std::fs::create_dir_all(&temp_dir).expect("create temp dir");
     let path = temp_dir.join("rollout-test.jsonl");
-    let content = r#"{"timestamp":"2026-02-11T06:16:06.458Z","type":"event_msg","payload":{"type":"user_message","message":"hello codex","images":[],"local_images":[],"text_elements":[]}}
+    let content = r#"{"timestamp":"2026-02-11T06:16:06.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"model-only context"}]}}
+{"timestamp":"2026-02-11T06:16:06.458Z","type":"event_msg","payload":{"type":"user_message","message":"hello codex","images":[],"local_images":[],"text_elements":[]}}
 {"timestamp":"2026-02-11T06:16:07.000Z","type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{\"command\":\"pwd\"}","call_id":"call_1"}}
 {"timestamp":"2026-02-11T06:16:08.000Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_1","output":"/tmp/project"}}
 {"timestamp":"2026-02-11T06:16:09.000Z","type":"event_msg","payload":{"type":"agent_message","message":"done"}}
@@ -194,6 +195,135 @@ fn parses_codex_jsonl_into_replay_chunks() {
         imported_history::ACTION_TYPE_ASSISTANT
     );
     assert_eq!(chunks[2].function, imported_history::FUNCTION_ASSISTANT);
+
+    std::fs::remove_file(&path).expect("remove fixture");
+    std::fs::remove_dir(&temp_dir).expect("remove temp dir");
+}
+
+#[test]
+fn parses_paginated_codex_user_items_without_model_context_duplicates() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-codex-paginated-history-test-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+    let path = temp_dir.join("rollout-paginated.jsonl");
+    let content = r##"{"timestamp":"2026-08-18T01:00:00.000Z","type":"session_meta","payload":{"cwd":"/tmp/project","id":"thread-1","history_mode":"paginated"},"ordinal":0}
+{"timestamp":"2026-08-18T01:00:01.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"},"ordinal":1}
+{"timestamp":"2026-08-18T01:00:01.010Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"# AGENTS.md instructions"},{"type":"input_text","text":"<environment_context>internal</environment_context>"}],"internal_chat_message_metadata_passthrough":{"turn_id":"turn-1"}},"ordinal":2}
+{"timestamp":"2026-08-18T01:00:01.020Z","type":"turn_context","payload":{"turn_id":"turn-1","cwd":"/tmp/project","model":"gpt-5.3-codex"},"ordinal":3}
+{"timestamp":"2026-08-18T01:00:01.030Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"inspect the parser"}],"internal_chat_message_metadata_passthrough":{"turn_id":"turn-1"}},"ordinal":4}
+{"timestamp":"2026-08-18T01:00:01.040Z","type":"event_msg","payload":{"type":"item_completed","turn_id":"turn-1","item":{"type":"UserMessage","id":"user-1","content":[{"type":"text","text":"inspect the parser","text_elements":[]},{"type":"image","image_url":"https://example.com/input.png"},{"type":"local_image","path":"/tmp/input.png"}]}},"ordinal":5}
+{"timestamp":"2026-08-18T01:00:02.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"first reply"}]},"ordinal":6}
+{"timestamp":"2026-08-18T01:00:03.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-1"},"ordinal":7}
+{"timestamp":"2026-08-18T01:01:00.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-2"},"ordinal":8}
+{"timestamp":"2026-08-18T01:01:00.010Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>refreshed</environment_context>"}],"internal_chat_message_metadata_passthrough":{"turn_id":"turn-2"}},"ordinal":9}
+{"timestamp":"2026-08-18T01:01:00.020Z","type":"turn_context","payload":{"turn_id":"turn-2","cwd":"/tmp/project","model":"gpt-5.3-codex"},"ordinal":10}
+{"timestamp":"2026-08-18T01:01:00.030Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"report the result"}],"internal_chat_message_metadata_passthrough":{"turn_id":"turn-2"}},"ordinal":11}
+{"timestamp":"2026-08-18T01:01:00.040Z","type":"event_msg","payload":{"type":"item_completed","turn_id":"turn-2","item":{"type":"UserMessage","id":"user-2","content":[{"type":"text","text":"report the result","text_elements":[]}]}},"ordinal":12}
+{"timestamp":"2026-08-18T01:01:01.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"second reply"}]},"ordinal":13}
+{"timestamp":"2026-08-18T01:01:02.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-2"},"ordinal":14}
+"##;
+    std::fs::write(&path, content).expect("write fixture");
+
+    let chunks = load_codex_app_from_path("codexapp-rollout-paginated", &path).expect("parse");
+    let user_chunks = chunks
+        .iter()
+        .filter(|chunk| chunk.function == imported_history::FUNCTION_USER_MESSAGE)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        user_chunks
+            .iter()
+            .filter_map(|chunk| chunk.result.pointer("/message/content"))
+            .filter_map(Value::as_str)
+            .collect::<Vec<_>>(),
+        vec!["inspect the parser", "report the result"]
+    );
+    assert_eq!(
+        user_chunks[0].result["images"],
+        json!(["https://example.com/input.png", "/tmp/input.png"])
+    );
+
+    let window = load_codex_app_initial_window_from_path("codexapp-rollout-paginated", &path, 1)
+        .expect("window");
+    assert_eq!(window.turns.len(), 2);
+    assert_eq!(
+        window
+            .chunks
+            .iter()
+            .filter(|chunk| chunk.function == imported_history::FUNCTION_USER_MESSAGE)
+            .filter_map(|chunk| chunk.result.pointer("/message/content"))
+            .filter_map(Value::as_str)
+            .collect::<Vec<_>>(),
+        vec!["inspect the parser", "report the result"]
+    );
+
+    let (source_mtime_ms, source_size_bytes) =
+        imported_paths::file_metadata_signature(&path, "Codex").expect("metadata");
+    let record = ImportedHistoryDiscoveredRecord {
+        source_session_id: "rollout-paginated".to_string(),
+        source_path: path.clone(),
+        source_record_key: "rollout-paginated".to_string(),
+        source_mtime_ms,
+        source_size_bytes,
+        source_fingerprint: String::new(),
+        parser_version: CODEX_APP_METADATA_PARSER_VERSION,
+    };
+    let meta = parse_codex_session_meta(&record)
+        .expect("parse metadata")
+        .expect("session metadata");
+    assert_eq!(meta.name, "inspect the parser");
+
+    std::fs::remove_file(&path).expect("remove fixture");
+    std::fs::remove_dir(&temp_dir).expect("remove temp dir");
+}
+
+#[test]
+fn ignores_incomplete_paginated_model_input_until_user_item_is_committed() {
+    use std::io::Write;
+
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-codex-paginated-append-test-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+    let path = temp_dir.join("rollout-paginated-append.jsonl");
+    let prefix = r#"{"timestamp":"2026-08-18T01:00:00.000Z","type":"session_meta","payload":{"cwd":"/tmp/project","id":"thread-1","history_mode":"paginated"},"ordinal":0}
+{"timestamp":"2026-08-18T01:00:01.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"},"ordinal":1}
+{"timestamp":"2026-08-18T01:00:01.010Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>internal</environment_context>"}],"internal_chat_message_metadata_passthrough":{"turn_id":"turn-1"}},"ordinal":2}
+{"timestamp":"2026-08-18T01:00:01.020Z","type":"turn_context","payload":{"turn_id":"turn-1","cwd":"/tmp/project","model":"gpt-5.3-codex"},"ordinal":3}
+{"timestamp":"2026-08-18T01:00:01.030Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"real prompt"}],"internal_chat_message_metadata_passthrough":{"turn_id":"turn-1"}},"ordinal":4}
+"#;
+    std::fs::write(&path, prefix).expect("write fixture");
+
+    let incomplete = load_codex_app_initial_window_from_path("codexapp-paginated-append", &path, 1)
+        .expect("incomplete window");
+    assert!(incomplete.turns.is_empty());
+    assert!(incomplete
+        .chunks
+        .iter()
+        .all(|chunk| chunk.function != imported_history::FUNCTION_USER_MESSAGE));
+
+    let mut file = std::fs::OpenOptions::new()
+        .append(true)
+        .open(&path)
+        .expect("open fixture for append");
+    file.write_all(
+        b"{\"timestamp\":\"2026-08-18T01:00:01.040Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"item_completed\",\"turn_id\":\"turn-1\",\"item\":{\"type\":\"UserMessage\",\"id\":\"user-1\",\"content\":[{\"type\":\"text\",\"text\":\"real prompt\",\"text_elements\":[]}]}},\"ordinal\":5}\n",
+    )
+    .expect("append user item");
+    file.flush().expect("flush fixture");
+
+    let committed = load_codex_app_initial_window_from_path("codexapp-paginated-append", &path, 1)
+        .expect("committed window");
+    assert_eq!(committed.turns.len(), 1);
+    assert_eq!(
+        committed.chunks[0]
+            .result
+            .pointer("/message/content")
+            .and_then(Value::as_str),
+        Some("real prompt")
+    );
 
     std::fs::remove_file(&path).expect("remove fixture");
     std::fs::remove_dir(&temp_dir).expect("remove temp dir");
@@ -2290,14 +2420,17 @@ fn strips_orgii_exec_mode_bridge_from_codex_user_text() {
         "type": "user_message",
         "message": bridge_only,
     });
-    assert_eq!(user_message_from_payload(&bridge_only_payload), None);
+    assert_eq!(
+        legacy_user_message_text_from_payload(&bridge_only_payload),
+        None
+    );
 
     let prefixed_payload = serde_json::json!({
         "type": "user_message",
         "message": with_bridge,
     });
     assert_eq!(
-        user_message_from_payload(&prefixed_payload).as_deref(),
+        legacy_user_message_text_from_payload(&prefixed_payload).as_deref(),
         Some("fix the login bug")
     );
 }
@@ -2323,14 +2456,17 @@ fn strips_ide_context_from_codex_user_text() {
         "type": "user_message",
         "message": ide_only,
     });
-    assert_eq!(user_message_from_payload(&ide_only_payload), None);
+    assert_eq!(
+        legacy_user_message_text_from_payload(&ide_only_payload),
+        None
+    );
 
     let both_payload = serde_json::json!({
         "type": "user_message",
         "message": with_both,
     });
     assert_eq!(
-        user_message_from_payload(&both_payload).as_deref(),
+        legacy_user_message_text_from_payload(&both_payload).as_deref(),
         Some("fix the login bug")
     );
 }


### PR DESCRIPTION
## Problem

Codex 0.148 paginated rollouts commit user turns as `item_completed/UserMessage` records instead of the legacy `user_message` payload that ORGII recognizes. The Codex turn catalog therefore finds no boundaries, falls back to scanning the complete rollout body, and cannot reliably derive the first prompt or bounded replay window. Model-facing `response_item` user records are not a safe replacement because they also contain injected context and can duplicate the real prompt.

This affects imported local Codex history after the upstream rollout migration work in https://github.com/openai/codex/pull/37348 and prevents the bounded replay behavior tracked in #443 from activating for this format.

Closes #837.

## Solution

Introduce one canonical Codex user-message decoder that accepts both formats:

- retain legacy `payload.type = "user_message"` behavior;
- recognize committed paginated `payload.type = "item_completed"` records whose item type is `UserMessage`;
- normalize text, remote-image, and local-image content parts;
- use that decoder consistently for metadata/title extraction, turn catalog discovery, initial and per-turn windows, and full replay chunks;
- keep model-only `response_item` user context out of user-turn boundaries;
- bump the Codex metadata parser version so existing cache rows are re-evaluated.

The result restores the existing bounded turn-catalog/tail-window path without introducing a new pagination mechanism or changing other imported-history providers.

## Potential risks

- The decoder intentionally depends on the observed paginated discriminants `item_completed` and `UserMessage`. Unknown future item/content variants remain ignored rather than being misclassified; a future upstream rename would require another adapter update.
- Bumping the parser version causes a one-time incremental reparse of changed/stale Codex cache metadata. There is no database schema migration or persisted transcript rewrite; rollback is a revert of this commit, after which the parser-version mismatch will re-evaluate rows for the restored parser.
- Legacy and paginated files can coexist. Automated coverage exercises both, but real-machine verification was performed on Linux only; macOS and Windows were not rerun because the changed parser is platform-independent.
- Claude Code uses a separate parser and is not claimed as fixed by this PR. It was manually checked for regression only.

## Architecture audit

The `architecture-audit` review covered all 10 layers. Compilation, live call chains, naming, default branches, domain boundaries, and new-developer readability were checked directly. The same decoder now owns every Codex user-boundary entry point, with no duplicate parser path or cross-provider leakage. Wire serialization is unchanged, and init parity and multi-field resolver symmetry are not applicable because this change neither creates sessions nor resolves configuration.

## Performance audit

| Area | Verdict | Evidence | Change or reason kept | Verification |
| --- | --- | --- | --- | --- |
| Background work | keep | No timer, watcher, retry, subscription, or scan cadence changed | Existing demand-driven source scan remains the owner | Diff/call-chain audit |
| Memory | fix | Paginated files now produce a turn catalog instead of entering the complete-body fallback | Existing bounded tail-window and catalog cache activate for the new format | 31.5 MB real rollout test |
| Scope/isolation | keep | Decoder and parser-version change are contained under `sources/codex/app` | Claude and other providers retain their own readers and cache identities | Four-file final diff |
| Rendering/hot path | fix | Initial open returns catalog placeholders plus the recent body | No frontend or EventStore protocol change required | Real rollout serialized window was about 607 KB |

| Provider | Raw transition | App/UI state | Topology/boundary | Expected invariant | Observed evidence |
| --- | --- | --- | --- | --- | --- |
| Codex 0.148 | Existing 31.5 MB paginated rollout | Cold and warm initial open | Local provider artifact → Rust window loader | 19 committed user turns remain discoverable; initial body stays bounded | 19 rounds; 56 ms cold; 27 ms warm; 606,752-byte window |
| Codex paginated | Model context written before committed user item | Append/incomplete source | Raw JSONL fixture → parser | No user turn before `item_completed/UserMessage`; one afterward | Targeted Rust test passed |
| Codex legacy | Legacy `user_message` rollout | Clean load | Raw JSONL fixture → parser | Existing user turns and images remain intact | Targeted Codex suite passed |

Performance verdict: pass. The change adds no retained or idle work, restores the existing bounded window for the affected raw format, and has real-artifact evidence at the owning parser boundary.

## Verification

- `cargo test -p orgtrack_core 'sources::codex::app::'` — 59 passed, 1 intentionally ignored real-fixture test.
- `env ORGII_CODEX_ROLLOUT_FIXTURE=<redacted-local-rollout> ORGII_CODEX_EXPECTED_ROUNDS=19 cargo test -p orgtrack_core codex_initial_window_real_fixture_catalog_stats -- --ignored --nocapture` — passed; 31,558,605 source bytes, 19 rounds, 56 ms cold, 27 ms warm, 606,752 serialized window bytes. The local path is omitted for privacy.
- `cargo check -p orgtrack_core --all-targets` — passed.
- `cargo clippy -p orgtrack_core --all-targets -- -D warnings` — passed.
- `rustfmt --edition 2021 --check` over the four changed Rust files — passed.
- `git diff --check origin/develop...HEAD` — passed.
- Real Linux Tauri development build — reporter confirmed the affected Codex session now opens; a Claude Code session was also checked and remained functional.
- Full-workspace `cargo fmt --all -- --check` was not green because current `develop` contains unrelated pre-existing formatting differences in `agent-core`, `project-management`, and `session-persistence`; none is touched by this PR.
- No screenshot is included because there is no visual/UI design change; the relevant evidence is the parsed turn/window output.
