### PR TITLE
fix(chat): make text selection precise and copyable

### DIFF
--- a/public/orgii_dark.css
+++ b/public/orgii_dark.css
@@ -54,6 +54,7 @@
   --cm-editor-foreground: #c9d1d9;
   --cm-editor-selection: #264f78;
   --cm-editor-caret: #43aafd;
+  --text-selection: #264f78;
   --terminal-selection: #264f78;
   --terminal-caret: #43aafd;
   --cm-editor-gutter-bg: var(--cm-editor-background);
@@ -232,6 +233,7 @@ body {
   --cm-editor-foreground: #c9d1d9;
   --cm-editor-selection: #264f78;
   --cm-editor-caret: #43aafd;
+  --text-selection: #264f78;
   --terminal-selection: #264f78;
   --terminal-caret: #43aafd;
   --cm-editor-gutter-bg: var(--cm-editor-background);

--- a/public/orgii_high_contrast.css
+++ b/public/orgii_high_contrast.css
@@ -51,6 +51,7 @@
   --cm-editor-foreground: #ffffff;
   --cm-editor-selection: #1c1c1c;
   --cm-editor-caret: #38bdf8;
+  --text-selection: #075985;
   --terminal-selection: #1c1c1c;
   --terminal-caret: #38bdf8;
   --cm-editor-gutter-bg: #050505;
@@ -222,6 +223,7 @@ body {
   --cm-editor-foreground: #ffffff;
   --cm-editor-selection: #1c1c1c;
   --cm-editor-caret: #38bdf8;
+  --text-selection: #075985;
   --terminal-selection: #1c1c1c;
   --terminal-caret: #38bdf8;
   --cm-editor-gutter-bg: #050505;

--- a/public/orgii_main.css
+++ b/public/orgii_main.css
@@ -54,6 +54,7 @@
   --cm-editor-foreground: #24292e;
   --cm-editor-selection: #efefef;
   --cm-editor-caret: #4f6dff;
+  --text-selection: #bfe8ff;
   --terminal-selection: #efefef;
   --terminal-caret: #4f6dff;
   --cm-editor-gutter-bg: var(--cm-editor-background);

--- a/src/engines/ChatPanel/ChatHistory/index.scss
+++ b/src/engines/ChatPanel/ChatHistory/index.scss
@@ -122,6 +122,29 @@
       td,
       th
     ),
+  .allow-select-deep
+    :is(
+      p,
+      span,
+      strong,
+      em,
+      b,
+      i,
+      a,
+      li,
+      h1,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6,
+      blockquote,
+      td,
+      th,
+      pre,
+      code,
+      time
+    ),
   .question-text,
   .question-text :is(span, strong, em, b, i, a),
   .terminal-output__pre,
@@ -140,16 +163,17 @@
     -webkit-user-select: text !important;
   }
 
-  // The transcript scroller owns one selection range. Older rules above
-  // deliberately made individual text leaves selectable while their wrappers
-  // stayed inert; that turns Markdown blocks and adjacent messages into
-  // separate selection islands. The shared deep-selection contract restores
-  // a continuous range, while explicit UI chrome can still opt out with
-  // `select-none`.
-  .allow-select-deep,
+  // Keep flex/grid/layout wrappers out of the selection range so WebKit does
+  // not paint empty message boxes as full-width lines or U-shaped outlines.
+  // Real text elements opt back in through the semantic allowlist above.
+  .allow-select-deep {
+    user-select: none !important;
+    -webkit-user-select: none !important;
+  }
+
   .allow-select-deep * {
-    user-select: text !important;
-    -webkit-user-select: text !important;
+    user-select: none !important;
+    -webkit-user-select: none !important;
   }
 
   .allow-select-deep .select-none,
@@ -232,17 +256,35 @@
   pre span::selection,
   code::selection,
   code span::selection {
-    background: var(--terminal-selection, var(--color-primary-1)) !important;
-    background-color: var(
-      --terminal-selection,
-      var(--color-primary-1)
-    ) !important;
+    background: var(--text-selection, var(--color-primary-2)) !important;
+    background-color: var(--text-selection, var(--color-primary-2)) !important;
   }
 
-  .allow-select-deep::selection,
-  .allow-select-deep *::selection {
-    background: var(--terminal-selection, var(--color-fill-2)) !important;
-    background-color: var(--terminal-selection, var(--color-fill-2)) !important;
+  .allow-select-deep
+    :is(
+      p,
+      span,
+      strong,
+      em,
+      b,
+      i,
+      a,
+      li,
+      h1,
+      h2,
+      h3,
+      h4,
+      h5,
+      h6,
+      blockquote,
+      td,
+      th,
+      pre,
+      code,
+      time
+    )::selection {
+    background: var(--text-selection, var(--color-primary-2)) !important;
+    background-color: var(--text-selection, var(--color-primary-2)) !important;
   }
 
   .chat-markdown-body {

--- a/src/engines/ChatPanel/ChatHistory/selectionStyles.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/selectionStyles.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("chat transcript selection styles", () => {
+  it("uses the shared text-selection token for specific Markdown selectors", () => {
+    const styles = readFileSync(resolve(__dirname, "index.scss"), "utf8");
+    const markdownSelectionRule = styles.match(
+      /\.chat-markdown-body[\s\S]*?code span::selection \{([\s\S]*?)\n\s{2}\}/
+    )?.[1];
+
+    expect(markdownSelectionRule).toContain("--text-selection");
+    expect(markdownSelectionRule).not.toContain("--terminal-selection");
+  });
+
+  it("does not paint selection backgrounds on layout wrappers", () => {
+    const styles = readFileSync(resolve(__dirname, "index.scss"), "utf8");
+    const deepSelectionRule = styles.match(
+      /\.allow-select-deep\s+:is\(([^)]*)\)::selection \{([\s\S]*?)\n\s{2}\}/
+    );
+
+    expect(deepSelectionRule?.[1]).toContain("span");
+    expect(deepSelectionRule?.[1]).not.toContain("*");
+    expect(deepSelectionRule?.[2]).toContain("--text-selection");
+    expect(styles).not.toContain(".allow-select-deep *::selection");
+  });
+
+  it("keeps layout wrappers inert while allowing semantic text elements", () => {
+    const styles = readFileSync(resolve(__dirname, "index.scss"), "utf8");
+    const wrapperRule = styles.match(
+      /\.allow-select-deep \* \{([\s\S]*?)\n\s{2}\}/
+    )?.[1];
+    const textAllowlist = styles.match(
+      /\.allow-select-deep\s+:is\(([^)]*)\),\n\s{2}\.question-text/
+    )?.[1];
+
+    expect(wrapperRule).toContain("user-select: none !important");
+    expect(textAllowlist).toContain("span");
+    expect(textAllowlist).toContain("time");
+  });
+
+  it.each(["orgii_main.css", "orgii_dark.css", "orgii_high_contrast.css"])(
+    "defines a visible text-selection color in %s",
+    (themeFile) => {
+      const theme = readFileSync(resolve("public", themeFile), "utf8");
+      expect(theme).toMatch(/--text-selection:\s*#[0-9a-f]{6}/i);
+    }
+  );
+});

--- a/src/engines/ChatPanel/InputArea/components/TurnCollapsePinBar.tsx
+++ b/src/engines/ChatPanel/InputArea/components/TurnCollapsePinBar.tsx
@@ -149,6 +149,8 @@ const TurnCollapsePinBar: React.FC<TurnCollapsePinBarProps> = memo(
         className="group/turn-collapse chat-block-header mt-1 flex h-8 w-full cursor-pointer items-center gap-2 rounded-lg border-0 bg-transparent px-2 text-left transition-colors hover:bg-fill-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-6/30"
         onClick={(event) => {
           event.stopPropagation();
+          const selection = window.getSelection();
+          if (selection && !selection.isCollapsed) return;
           void handleToggle();
         }}
       >
@@ -158,11 +160,13 @@ const TurnCollapsePinBar: React.FC<TurnCollapsePinBarProps> = memo(
           className="shrink-0 text-text-2 transition-colors group-hover/turn-collapse:text-text-1"
         />
         <span className="inline-flex min-w-0 flex-1 items-center gap-2 leading-tight">
-          <span className="shrink-0 whitespace-nowrap font-medium text-text-2 transition-colors group-hover/turn-collapse:text-text-1">
+          <span className="shrink-0 select-text whitespace-nowrap font-medium text-text-2 transition-colors group-hover/turn-collapse:text-text-1">
             {label}
           </span>
           {showRange && (
-            <span className="min-w-0 truncate text-text-3">{rangeLabel}</span>
+            <span className="min-w-0 select-text truncate text-text-3">
+              {rangeLabel}
+            </span>
           )}
         </span>
       </button>

--- a/src/engines/ChatPanel/blocks/primitives/BlockSection.tsx
+++ b/src/engines/ChatPanel/blocks/primitives/BlockSection.tsx
@@ -9,7 +9,7 @@ import React, { memo } from "react";
 
 // h-9 = 36px — matches EVENT_BLOCK_HEADER_HEIGHT / chat-block-header
 const SECTION_HEADER_CLASSES =
-  "flex h-9 select-none items-center gap-1.5 px-3 text-[11px] text-text-2";
+  "flex h-9 items-center gap-1.5 px-3 text-[11px] text-text-2";
 
 export interface BlockSectionProps {
   label: string;
@@ -31,9 +31,9 @@ const BlockSection: React.FC<BlockSectionProps> = memo(
       }
     >
       <div className={SECTION_HEADER_CLASSES}>
-        <span className="font-bold uppercase">{label}</span>
+        <span className="select-text font-bold uppercase">{label}</span>
         {headerAction && (
-          <div className="ml-auto flex items-center gap-0.5">
+          <div className="ml-auto flex select-none items-center gap-0.5">
             {headerAction}
           </div>
         )}

--- a/src/engines/ChatPanel/blocks/primitives/EventBlock.tsx
+++ b/src/engines/ChatPanel/blocks/primitives/EventBlock.tsx
@@ -35,7 +35,7 @@ export const EVENT_BLOCK_CONTAINER_CLASSES = `w-full max-w-full overflow-hidden 
  */
 /** Header row for the EventBlock shell (distinct from primitives/config `getEventBlockHeaderClasses`). */
 export const getEventBlockShellHeaderClasses = (_isCollapsed: boolean) =>
-  `flex cursor-pointer select-none items-center justify-between ${EVENT_BLOCK_CONTENT_BG} p-2 transition-all duration-150`;
+  `flex cursor-pointer items-center justify-between ${EVENT_BLOCK_CONTENT_BG} p-2 transition-all duration-150`;
 
 /**
  * Standard button classes for header action buttons (copy, expand, etc.)
@@ -165,23 +165,29 @@ export const EventBlock: React.FC<EventBlockProps> = ({
   children,
   onHeaderHoverChange,
 }) => {
+  const handleHeaderClick = () => {
+    const selection = window.getSelection();
+    if (selection && !selection.isCollapsed) return;
+    onToggleCollapse?.();
+  };
+
   return (
     <div className={`${EVENT_BLOCK_CONTAINER_CLASSES} ${containerClassName}`}>
       {/* Header */}
       <div
         className={`${getEventBlockShellHeaderClasses(isCollapsed)} ${headerClassName}`}
-        onClick={onToggleCollapse}
+        onClick={onToggleCollapse ? handleHeaderClick : undefined}
         onMouseEnter={() => onHeaderHoverChange?.(true)}
         onMouseLeave={() => onHeaderHoverChange?.(false)}
       >
         {/* Left content */}
-        <div className="flex min-w-0 flex-1 items-center gap-2">
+        <div className="flex min-w-0 flex-1 select-text items-center gap-2">
           {headerLeft}
         </div>
 
         {/* Right content */}
         {headerRight && (
-          <div className="flex flex-shrink-0 items-center gap-0.5">
+          <div className="flex flex-shrink-0 select-none items-center gap-0.5">
             {headerRight}
           </div>
         )}

--- a/src/engines/ChatPanel/blocks/primitives/EventBlockHeader.test.ts
+++ b/src/engines/ChatPanel/blocks/primitives/EventBlockHeader.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+import { type FC, type ReactNode, act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import EventBlockHeader from "./EventBlockHeader";
+import { EventBlockHeaderTitle } from "./EventBlockHeaderTextSlots";
+import type { EventBlockHeaderProps } from "./types";
+
+type TestHeaderProps = Omit<EventBlockHeaderProps, "children"> & {
+  children?: ReactNode;
+};
+const TestEventBlockHeader = EventBlockHeader as FC<TestHeaderProps>;
+
+describe("EventBlockHeader text selection", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterAll(() => {
+    delete actEnvironment.IS_REACT_ACT_ENVIRONMENT;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  it("keeps title text selectable without making the whole header selectable", () => {
+    act(() => {
+      root.render(
+        createElement(
+          TestEventBlockHeader,
+          { isCollapsed: false },
+          createElement(EventBlockHeaderTitle, null, "Thought")
+        )
+      );
+    });
+
+    const header = container.firstElementChild;
+    const title = container.querySelector("span");
+    expect(header?.classList.contains("select-none")).toBe(false);
+    expect(title?.classList.contains("select-text")).toBe(true);
+  });
+
+  it("does not toggle the header after dragging across its title", () => {
+    const onClick = vi.fn();
+    const selection = vi
+      .spyOn(window, "getSelection")
+      .mockReturnValue({ isCollapsed: false } as Selection);
+
+    act(() => {
+      root.render(
+        createElement(
+          TestEventBlockHeader,
+          { isCollapsed: false, onClick },
+          createElement(EventBlockHeaderTitle, null, "Thought")
+        )
+      );
+    });
+
+    act(() => {
+      container.firstElementChild?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true })
+      );
+    });
+    expect(onClick).not.toHaveBeenCalled();
+
+    selection.mockReturnValue({ isCollapsed: true } as Selection);
+    act(() => {
+      container.firstElementChild?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true })
+      );
+    });
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});

--- a/src/engines/ChatPanel/blocks/primitives/EventBlockHeader.tsx
+++ b/src/engines/ChatPanel/blocks/primitives/EventBlockHeader.tsx
@@ -31,11 +31,16 @@ export const EventBlockHeader: React.FC<EventBlockHeaderProps> = ({
   const isClickable = !!(onClick || onNavigate);
   const inSimulatorReplay = useContext(InSimulatorReplayContext);
   const showNavigate = !!onNavigate && !inSimulatorReplay;
+  const handleClick = () => {
+    const selection = window.getSelection();
+    if (selection && !selection.isCollapsed) return;
+    onClick?.();
+  };
 
   return (
     <div
       className={`group/chat-block-header ${getEventBlockHeaderClasses(isCollapsed, withHover, isClickable)} ${className}`}
-      onClick={onClick}
+      onClick={onClick ? handleClick : undefined}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
@@ -46,7 +51,7 @@ export const EventBlockHeader: React.FC<EventBlockHeaderProps> = ({
 
       {/* Right content + navigate icon */}
       {(showNavigate || rightContent) && (
-        <div className="flex flex-shrink-0 items-center gap-1">
+        <div className="flex flex-shrink-0 select-none items-center gap-1">
           {rightContent}
           {showNavigate && <EventNavigateIcon onClick={onNavigate} />}
         </div>

--- a/src/engines/ChatPanel/blocks/primitives/EventBlockHeaderTextSlots.tsx
+++ b/src/engines/ChatPanel/blocks/primitives/EventBlockHeaderTextSlots.tsx
@@ -66,7 +66,7 @@ export const EventBlockHeaderTitle: React.FC<EventBlockHeaderTitleProps> = ({
   className = "",
 }) => (
   <span
-    className={`inline-flex items-center leading-tight ${truncate ? "min-w-0 flex-initial truncate" : "shrink-0 whitespace-nowrap"} ${isLoading ? `font-bold ${EVENT_LOADING_SHIMMER_TEXT_CLASSES}` : "font-medium text-text-2"} ${className}`.trim()}
+    className={`inline-flex select-text items-center leading-tight ${truncate ? "min-w-0 flex-initial truncate" : "shrink-0 whitespace-nowrap"} ${isLoading ? `font-bold ${EVENT_LOADING_SHIMMER_TEXT_CLASSES}` : "font-medium text-text-2"} ${className}`.trim()}
     title={title}
   >
     {children}
@@ -79,7 +79,7 @@ export const EventBlockHeaderSubtitle: React.FC<
   EventBlockHeaderSubtitleProps
 > = ({ children, isLoading = false, title: titleAttr, className = "" }) => (
   <span
-    className={`inline-flex min-w-0 flex-initial items-center truncate leading-tight ${isLoading ? `font-bold ${EVENT_LOADING_SHIMMER_TEXT_CLASSES}` : "text-text-2"} ${className}`.trim()}
+    className={`inline-flex min-w-0 flex-initial select-text items-center truncate leading-tight ${isLoading ? `font-bold ${EVENT_LOADING_SHIMMER_TEXT_CLASSES}` : "text-text-2"} ${className}`.trim()}
     title={titleAttr}
   >
     {children}
@@ -94,7 +94,7 @@ export const EventBlockHeaderInfo: React.FC<EventBlockHeaderInfoProps> = ({
   className = "",
 }) => (
   <span
-    className={`shrink-0 ${isLoading ? `font-bold ${EVENT_LOADING_SHIMMER_TEXT_CLASSES}` : "text-text-3"} ${className}`.trim()}
+    className={`shrink-0 select-text ${isLoading ? `font-bold ${EVENT_LOADING_SHIMMER_TEXT_CLASSES}` : "text-text-3"} ${className}`.trim()}
   >
     {children}
   </span>

--- a/src/engines/ChatPanel/blocks/primitives/EventNavigateIcon.tsx
+++ b/src/engines/ChatPanel/blocks/primitives/EventNavigateIcon.tsx
@@ -12,9 +12,9 @@ import { ArrowUpRight, CircleArrowOutUpRight } from "lucide-react";
 import React, { memo } from "react";
 
 const BASE_CLASSES =
-  "flex h-5 cursor-pointer items-center justify-center rounded-md border-none bg-transparent text-text-3 transition-colors hover:bg-fill-2 hover:text-text-1";
+  "flex h-5 cursor-pointer select-none items-center justify-center rounded-md border-none bg-transparent text-text-3 transition-colors hover:bg-fill-2 hover:text-text-1";
 const CIRCLE_CLASSES =
-  "flex h-6 w-6 cursor-pointer items-center justify-center rounded-full border-none bg-fill-2/90 text-text-3 shadow-sm backdrop-blur-sm transition-colors hover:bg-fill-3 hover:text-text-1";
+  "flex h-6 w-6 cursor-pointer select-none items-center justify-center rounded-full border-none bg-fill-2/90 text-text-3 shadow-sm backdrop-blur-sm transition-colors hover:bg-fill-3 hover:text-text-1";
 
 const HEADER_VISIBILITY =
   "w-0 overflow-hidden opacity-0 transition-[width,opacity,background-color,color] group-hover/chat-block-header:w-5 group-hover/chat-block-header:opacity-100";

--- a/src/engines/ChatPanel/blocks/primitives/SimSection.tsx
+++ b/src/engines/ChatPanel/blocks/primitives/SimSection.tsx
@@ -40,11 +40,11 @@ export const SimSection = memo<SimSectionProps>(
       switch (variant) {
         case "card":
         case "terminal":
-          return "flex select-none items-center gap-2.5 px-4 py-2.5 border-b border-border-1 bg-event-block/80";
+          return "flex items-center gap-2.5 px-4 py-2.5 border-b border-border-1 bg-event-block/80";
         case "thinking":
-          return "flex select-none items-center gap-2.5 px-4 py-2.5 border-b border-success-6/20 bg-success-6/5";
+          return "flex items-center gap-2.5 px-4 py-2.5 border-b border-success-6/20 bg-success-6/5";
         default:
-          return "flex select-none items-center gap-2 mb-3";
+          return "flex items-center gap-2 mb-3";
       }
     }, [variant]);
 
@@ -87,7 +87,10 @@ export const SimSection = memo<SimSectionProps>(
             </span>
           )}
           {icon && <i className={`${icon} text-[13px] ${iconColor}`} />}
-          <span className={labelClass} style={{ fontFamily: FONT_SANS }}>
+          <span
+            className={`select-text ${labelClass}`}
+            style={{ fontFamily: FONT_SANS }}
+          >
             {label}
           </span>
           {variant === "default" && (

--- a/src/engines/ChatPanel/blocks/primitives/config.ts
+++ b/src/engines/ChatPanel/blocks/primitives/config.ts
@@ -281,7 +281,7 @@ export const getEventBlockHeaderClasses = (
   _withHover = true,
   clickable = true
 ) =>
-  `chat-block-header flex ${clickable ? "cursor-pointer" : "cursor-default"} select-none items-center justify-between px-2 h-[36px] transition-all duration-150`;
+  `chat-block-header flex ${clickable ? "cursor-pointer" : "cursor-default"} items-center justify-between px-2 h-[36px] transition-all duration-150`;
 
 /**
  * Standard header left section classes
@@ -349,7 +349,7 @@ export const EVENT_BLOCK_ELEVATED_BG = "bg-fill-3";
  * Uses CSS class for variable-based sizing
  */
 export const EVENT_BLOCK_ICON_WRAPPER_CLASSES =
-  "chat-block-icon inline-flex h-[14px] w-[14px] flex-shrink-0 items-center justify-center self-center text-text-2";
+  "chat-block-icon inline-flex h-[14px] w-[14px] flex-shrink-0 select-none items-center justify-center self-center text-text-2";
 
 /**
  * Larger hover target around the icon for chevron reveal.
@@ -357,7 +357,7 @@ export const EVENT_BLOCK_ICON_WRAPPER_CLASSES =
  * while keeping the visual icon size at 14×14.
  */
 export const EVENT_BLOCK_ICON_HOVER_AREA_CLASSES =
-  "inline-flex items-center justify-center p-1 -m-1 rounded-sm";
+  "inline-flex select-none items-center justify-center p-1 -m-1 rounded-sm";
 
 /**
  * Standard icon classes

--- a/src/index.scss
+++ b/src/index.scss
@@ -193,10 +193,10 @@ strong {
   font-weight: bold;
 }
 
-// Global text selection color — use the same neutral fill tone across
-// code, terminal, chat, markdown, and form surfaces.
+// Global text selection color. Text surfaces share one semantic, theme-aware
+// blue highlight; code editors and terminals keep their dedicated tokens.
 ::selection {
-  background: var(--terminal-selection, var(--color-fill-2));
+  background: var(--text-selection, var(--color-primary-2));
 }
 
 .cm-editor .cm-content {
@@ -630,12 +630,18 @@ html[data-host-desktop="windows"] [data-windows-top-bar="true"] {
 // Deep text-selection override: applies to the element AND all descendants.
 // Use this on content areas (e.g. chat messages) instead of scattering
 // `user-select: text !important` + `* { … }` hacks in every component.
-.allow-select-deep,
-.allow-select-deep * {
+.allow-select-deep {
   -webkit-user-select: text !important;
   -moz-user-select: text !important;
   -ms-user-select: text !important;
   user-select: text !important;
+}
+
+.allow-select-deep * {
+  -webkit-user-select: auto !important;
+  -moz-user-select: auto !important;
+  -ms-user-select: auto !important;
+  user-select: auto !important;
 }
 
 // Opt-out: event titles/headers (collapsible block headers, etc.) should not be selectable

--- a/src/modules/shared/components/ActivityTimeline/ActivityTimeline.test.ts
+++ b/src/modules/shared/components/ActivityTimeline/ActivityTimeline.test.ts
@@ -127,6 +127,21 @@ describe("activity timeline", () => {
     expect(body?.className).not.toContain("leading-5");
   });
 
+  it("keeps the complete rendered Markdown tree selectable", () => {
+    contentHeight = 120;
+
+    act(() => {
+      root.render(
+        createElement(MarkdownContent, {
+          body: "Paragraph with **nested emphasis**.",
+        })
+      );
+    });
+
+    const body = container.querySelector<HTMLElement>(".chat-text");
+    expect(body?.className).toContain("allow-select-deep");
+  });
+
   it("collapses long Markdown with an always-visible shared control", () => {
     contentHeight = 600;
 
@@ -224,6 +239,8 @@ describe("activity timeline", () => {
     expect(card?.firstElementChild?.className).toContain(
       "bg-primary-container"
     );
+    expect(card?.firstElementChild?.className).toContain("allow-select-deep");
+    expect(card?.children.item(1)?.className).toContain("allow-select-deep");
     expect(card?.lastElementChild?.getAttribute("data-testid")).toBe(
       "timeline-footer"
     );

--- a/src/modules/shared/components/ActivityTimeline/index.tsx
+++ b/src/modules/shared/components/ActivityTimeline/index.tsx
@@ -49,7 +49,7 @@ export function ActivityHeaderActionButton({
       icon={icon}
       title={label}
       aria-label={label}
-      className={`shrink-0 text-text-3 hover:bg-fill-2 hover:text-text-1 ${className}`.trim()}
+      className={`shrink-0 select-none text-text-3 hover:bg-fill-2 hover:text-text-1 ${className}`.trim()}
       {...buttonProps}
     />
   );
@@ -235,7 +235,7 @@ export function TimelineCard({
     <div
       className={`flex min-w-0 flex-1 flex-col overflow-hidden rounded-xl border border-border-1 bg-chat-pane ${className}`.trim()}
     >
-      <div className="flex min-w-0 select-text items-center justify-between gap-3 border-b border-border-1 bg-primary-container px-3 py-2">
+      <div className="allow-select-deep flex min-w-0 items-center justify-between gap-3 border-b border-border-1 bg-primary-container px-3 py-2">
         {header}
         {copyBody || actions ? (
           <div className="flex shrink-0 items-center gap-1">
@@ -244,7 +244,9 @@ export function TimelineCard({
           </div>
         ) : null}
       </div>
-      <div className={`min-w-0 select-text px-3 py-3 ${bodyClassName}`.trim()}>
+      <div
+        className={`allow-select-deep min-w-0 px-3 py-3 ${bodyClassName}`.trim()}
+      >
         {children}
       </div>
       {footer}

--- a/src/modules/shared/components/MarkdownContent/index.tsx
+++ b/src/modules/shared/components/MarkdownContent/index.tsx
@@ -56,7 +56,7 @@ export const MarkdownContent = memo(function MarkdownContent({
   if (!body.trim()) {
     return (
       <div
-        className={`chat-text select-text italic text-text-3 ${className}`.trim()}
+        className={`chat-text allow-select-deep italic text-text-3 ${className}`.trim()}
       >
         {emptyText}
       </div>
@@ -65,7 +65,7 @@ export const MarkdownContent = memo(function MarkdownContent({
 
   const content = (
     <div
-      className={`chat-text w-full min-w-0 select-text text-text-1 [&_.chat-markdown-body]:select-text ${className}`.trim()}
+      className={`chat-text allow-select-deep w-full min-w-0 text-text-1 ${className}`.trim()}
     >
       <Markdown textContent={normalizeMarkdownContent(body)} skipPreprocess />
     </div>


### PR DESCRIPTION
## Problem

Rendered chat and work-item text inherited the application-wide `user-select: none` reset. Nested Markdown, activity metadata, and event titles were therefore inconsistently selectable, while chat-specific selection rules still used a low-visibility neutral terminal color in the light theme.

A broad deep-selection override made the text selectable but also included flex and layout wrappers in the WebKit selection range. Selecting across messages then painted empty containers as full-width lines or U-shaped skeleton outlines. Collapsible title rows also treated drag-selection as a click.

## Solution

Introduce a theme-aware `--text-selection` token and use it consistently for normal text selection in light, dark, and high-contrast themes.

Apply deep selection at the shared Markdown and activity-card boundaries so descriptions, comments, inline code, links, and timeline metadata can be copied. In chat transcripts, keep layout and decorative wrappers non-selectable and opt semantic text elements back in through an explicit allowlist. Shared event title, subtitle, info, timing, and section-label primitives are selectable, while icons and action controls remain non-selectable. Collapsible headers ignore clicks produced while a non-collapsed text selection is active.

## Potential risks

The chat allowlist intentionally excludes generic layout elements. An uncommon renderer that places user-visible text directly inside a generic `div` instead of a semantic text element may remain non-selectable until it adopts a shared title/text primitive or wrapper. No persistence, API, IPC, wire-format, dependency, or migration behavior changes. Rollback is the single commit `db1a402ab`.

## Verification

- `pnpm exec vitest run src/engines/ChatPanel/ChatHistory/selectionStyles.test.ts src/engines/ChatPanel/blocks/primitives/EventBlockHeader.test.ts src/modules/shared/components/ActivityTimeline/ActivityTimeline.test.ts src/modules/ProjectManager/WorkItems/components/WorkItemContent/__tests__/WorkItemDescriptionEditing.test.ts` — 41 tests passed. The existing WorkItem suite emitted known React `act(...)` warnings but had no failures.
- `pnpm exec eslint` over all changed TypeScript and TSX files — passed.
- `pnpm exec sass --stdin --no-source-map < src/engines/ChatPanel/ChatHistory/index.scss > /dev/null` — passed.
- `pnpm typecheck` — passed.
- `git diff --check` — passed.
- Commit hooks reran staged linting and scoped TypeScript checks successfully.

## UI evidence

The supplied before screenshots cover the original non-selectable text, neutral selection color, wrapper outlines, and selectable skeleton artifacts. A final after-screenshot was not captured because desktop computer control was not authorized. The PR remains draft pending a manual visual pass in the running app across light and dark themes.

## Audit

The repository-routed `frontend-ui-audit` skill was unavailable at both documented workspace and user-global paths, so no audit report was fabricated. The diff was manually checked for shared-component consistency, secrets, debug logs, generated artifacts, and unrelated changes.