### PR TITLE
fix(chat): stop dragging the viewport back to bottom while streaming (#811)

### DIFF
--- a/src/modules/WorkStation/Chat/Communication/MessageViewer.tsx
+++ b/src/modules/WorkStation/Chat/Communication/MessageViewer.tsx
@@ -26,6 +26,10 @@ import {
   NewMessageDivider,
 } from "./MessageViewer/MessageBubbleRenderer";
 import {
+  isViewportAtBottom,
+  resolveAutoFollowOnScroll,
+} from "./MessageViewer/autoFollow";
+import {
   DEFAULT_INITIAL_RENDERED_MESSAGE_COUNT,
   LOAD_MORE_MESSAGE_COUNT,
   MESSAGE_INITIAL_RENDERED_MESSAGE_COUNT,
@@ -205,12 +209,55 @@ export const MessageViewer: React.FC<MessageViewerProps> = ({
     scrollContainer.scrollTop = anchor.scrollTop + heightDelta;
   }, [renderedMessageCount, visibleMessages.length]);
 
+  const followBottomRef = useRef(true);
+  const lastScrollTopRef = useRef(0);
+
+  // Switching to a different view/replay window starts fresh at the bottom, so
+  // re-arm auto-follow whenever the view identity changes.
+  useEffect(() => {
+    followBottomRef.current = true;
+  }, [currentEventId, viewMode]);
+
   useEffect(() => {
     const scrollContainer = scrollContainerRef.current;
     if (!scrollContainer) return;
 
+    const handleScroll = () => {
+      followBottomRef.current = resolveAutoFollowOnScroll({
+        following: followBottomRef.current,
+        previousScrollTop: lastScrollTopRef.current,
+        metrics: {
+          scrollTop: scrollContainer.scrollTop,
+          scrollHeight: scrollContainer.scrollHeight,
+          clientHeight: scrollContainer.clientHeight,
+        },
+      });
+      lastScrollTopRef.current = scrollContainer.scrollTop;
+    };
+
+    scrollContainer.addEventListener("scroll", handleScroll, { passive: true });
+    return () => scrollContainer.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  useEffect(() => {
+    const scrollContainer = scrollContainerRef.current;
+    if (!scrollContainer) return;
+    // Respect a user who has scrolled up: only snap to the bottom while we are
+    // still following it (or already sitting at the bottom).
+    if (
+      !followBottomRef.current &&
+      !isViewportAtBottom({
+        scrollTop: scrollContainer.scrollTop,
+        scrollHeight: scrollContainer.scrollHeight,
+        clientHeight: scrollContainer.clientHeight,
+      })
+    ) {
+      return;
+    }
+
     const frameId = requestAnimationFrame(() => {
       scrollContainer.scrollTop = scrollContainer.scrollHeight;
+      lastScrollTopRef.current = scrollContainer.scrollTop;
     });
 
     return () => cancelAnimationFrame(frameId);

--- a/src/modules/WorkStation/Chat/Communication/MessageViewer/autoFollow.ts
+++ b/src/modules/WorkStation/Chat/Communication/MessageViewer/autoFollow.ts
@@ -1,0 +1,70 @@
+/**
+ * Auto-follow (stick-to-bottom) decision logic for the streaming message
+ * viewport.
+ *
+ * The message viewer snaps to the bottom whenever new content arrives so the
+ * latest streamed output stays visible. That is only desirable while the user
+ * is actually reading the tail: once they scroll up to review earlier content,
+ * continuing to force the viewport to the bottom drags them back on every
+ * delta and makes reading impossible (see the "scroll dragged back to bottom
+ * while streaming" bug).
+ *
+ * These pure helpers own the "should we still follow the bottom?" decision so
+ * it can be unit-tested without a DOM/render environment, matching the pure
+ * selection-logic tests used elsewhere in this module.
+ */
+
+/** Distance (px) from the bottom still treated as "at the bottom". */
+export const AUTO_FOLLOW_THRESHOLD_PX = 32;
+
+export interface ViewportMetrics {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+}
+
+/**
+ * Whether the viewport is within `threshold` pixels of the bottom.
+ *
+ * A container that cannot scroll (content shorter than the viewport) is always
+ * considered at the bottom.
+ */
+export function isViewportAtBottom(
+  metrics: ViewportMetrics,
+  threshold: number = AUTO_FOLLOW_THRESHOLD_PX
+): boolean {
+  const distanceFromBottom =
+    metrics.scrollHeight - metrics.scrollTop - metrics.clientHeight;
+  return distanceFromBottom <= threshold;
+}
+
+/**
+ * Resolve the auto-follow state in response to a scroll event.
+ *
+ * - Returning to the bottom re-arms auto-follow.
+ * - An upward scroll away from the bottom suspends auto-follow.
+ * - Any other movement (downward, or horizontal-only) preserves the current
+ *   state, so a programmatic snap-to-bottom does not accidentally re-arm while
+ *   the user is still reading above.
+ */
+export function resolveAutoFollowOnScroll(params: {
+  following: boolean;
+  previousScrollTop: number;
+  metrics: ViewportMetrics;
+  threshold?: number;
+}): boolean {
+  const {
+    following,
+    previousScrollTop,
+    metrics,
+    threshold = AUTO_FOLLOW_THRESHOLD_PX,
+  } = params;
+
+  if (isViewportAtBottom(metrics, threshold)) {
+    return true;
+  }
+  if (metrics.scrollTop < previousScrollTop) {
+    return false;
+  }
+  return following;
+}

--- a/src/modules/WorkStation/Chat/Communication/__tests__/autoFollow.test.ts
+++ b/src/modules/WorkStation/Chat/Communication/__tests__/autoFollow.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Regression tests for the streaming auto-follow (stick-to-bottom) decision.
+ *
+ * Bug: while a turn was streaming, scrolling up to read earlier content was
+ * repeatedly dragged back to the bottom because the viewport snapped to the
+ * bottom on every delta regardless of the user's scroll position. These tests
+ * exercise the pure decision helpers that now gate that snap, matching the
+ * pure selection-logic test style used elsewhere in this module (no DOM/render
+ * environment required).
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  AUTO_FOLLOW_THRESHOLD_PX,
+  isViewportAtBottom,
+  resolveAutoFollowOnScroll,
+} from "../MessageViewer/autoFollow";
+
+const CLIENT_HEIGHT = 400;
+const SCROLL_HEIGHT = 2000;
+const BOTTOM_SCROLL_TOP = SCROLL_HEIGHT - CLIENT_HEIGHT; // 1600
+
+describe("isViewportAtBottom", () => {
+  it("treats an exact-bottom viewport as at the bottom", () => {
+    expect(
+      isViewportAtBottom({
+        scrollTop: BOTTOM_SCROLL_TOP,
+        scrollHeight: SCROLL_HEIGHT,
+        clientHeight: CLIENT_HEIGHT,
+      })
+    ).toBe(true);
+  });
+
+  it("treats a viewport within the threshold as at the bottom", () => {
+    expect(
+      isViewportAtBottom({
+        scrollTop: BOTTOM_SCROLL_TOP - (AUTO_FOLLOW_THRESHOLD_PX - 1),
+        scrollHeight: SCROLL_HEIGHT,
+        clientHeight: CLIENT_HEIGHT,
+      })
+    ).toBe(true);
+  });
+
+  it("treats a viewport scrolled well above the bottom as not at the bottom", () => {
+    expect(
+      isViewportAtBottom({
+        scrollTop: 200,
+        scrollHeight: SCROLL_HEIGHT,
+        clientHeight: CLIENT_HEIGHT,
+      })
+    ).toBe(false);
+  });
+
+  it("treats a non-scrollable container as at the bottom", () => {
+    expect(
+      isViewportAtBottom({ scrollTop: 0, scrollHeight: 300, clientHeight: 400 })
+    ).toBe(true);
+  });
+});
+
+describe("resolveAutoFollowOnScroll", () => {
+  it("suspends auto-follow when the user scrolls up away from the bottom", () => {
+    const following = resolveAutoFollowOnScroll({
+      following: true,
+      previousScrollTop: BOTTOM_SCROLL_TOP,
+      metrics: {
+        scrollTop: 800,
+        scrollHeight: SCROLL_HEIGHT,
+        clientHeight: CLIENT_HEIGHT,
+      },
+    });
+    expect(following).toBe(false);
+  });
+
+  it("keeps auto-follow suspended across repeated streaming growth while scrolled up", () => {
+    // Simulate content growing (scrollHeight increasing) after the user has
+    // scrolled up: follow must stay false so the snap effect leaves them put.
+    let following = false;
+    let scrollHeight = SCROLL_HEIGHT;
+    const userScrollTop = 800;
+    for (let delta = 0; delta < 5; delta++) {
+      scrollHeight += 500; // more streamed content arrives
+      following = resolveAutoFollowOnScroll({
+        following,
+        previousScrollTop: userScrollTop,
+        metrics: {
+          scrollTop: userScrollTop, // user has not moved
+          scrollHeight,
+          clientHeight: CLIENT_HEIGHT,
+        },
+      });
+      expect(following).toBe(false);
+    }
+  });
+
+  it("re-arms auto-follow once the user returns to the bottom", () => {
+    let following = false;
+    following = resolveAutoFollowOnScroll({
+      following,
+      previousScrollTop: 800,
+      metrics: {
+        scrollTop: BOTTOM_SCROLL_TOP,
+        scrollHeight: SCROLL_HEIGHT,
+        clientHeight: CLIENT_HEIGHT,
+      },
+    });
+    expect(following).toBe(true);
+  });
+
+  it("does not re-arm on a downward scroll that stops short of the bottom", () => {
+    const following = resolveAutoFollowOnScroll({
+      following: false,
+      previousScrollTop: 400,
+      metrics: {
+        scrollTop: 900, // scrolled down, but still above the bottom
+        scrollHeight: SCROLL_HEIGHT,
+        clientHeight: CLIENT_HEIGHT,
+      },
+    });
+    expect(following).toBe(false);
+  });
+
+  it("stays following while the user sits at the bottom during streaming", () => {
+    const following = resolveAutoFollowOnScroll({
+      following: true,
+      previousScrollTop: BOTTOM_SCROLL_TOP,
+      metrics: {
+        scrollTop: BOTTOM_SCROLL_TOP,
+        scrollHeight: SCROLL_HEIGHT,
+        clientHeight: CLIENT_HEIGHT,
+      },
+    });
+    expect(following).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

While a turn is streaming output, scrolling up to read earlier content was repeatedly dragged back to the bottom (#811). The message viewport snapped to the bottom on every streaming delta regardless of where the user had scrolled, so any upward scroll was undone on the next chunk.

This change makes auto-follow stateful: once the user scrolls up, following is suspended and stays suspended until they return to the bottom (or the container returns to the bottom on its own). Streaming deltas then leave the reading position stable.

## Changes

- `MessageViewer.tsx`: track a `followBottom` flag from real scroll events; the snap-to-bottom effect now only runs while following (or already at the bottom). View/replay-window identity changes re-arm following so a fresh view starts pinned to the newest content, preserving the existing default behavior.
- `MessageViewer/autoFollow.ts`: new pure helpers (`isViewportAtBottom`, `resolveAutoFollowOnScroll`) that own the decision, so it is testable without a DOM/render environment.
- `__tests__/autoFollow.test.ts`: regression coverage proving an upward scroll suspends follow, repeated streaming growth keeps it suspended, returning to the bottom re-arms it, and a partial downward scroll does not re-arm.

## Test plan

- `pnpm exec vitest run src/modules/WorkStation/Chat/Communication` — 97 passed (10 files), including the 9 new auto-follow tests.
- `pnpm exec eslint` on the changed files — clean.
- `pnpm run typecheck` (`tsc --noEmit`) — 0 errors.

I have reviewed the design and implementation.

Fixes #811
