### PR TITLE
fix(markdown): open file links at source locations

### DIFF
--- a/src/components/MarkDown/MarkdownLocalImage.test.ts
+++ b/src/components/MarkDown/MarkdownLocalImage.test.ts
@@ -175,6 +175,21 @@ describe("MarkdownLocalImage", () => {
     expect(mocks.openFileInWorkStation).not.toHaveBeenCalled();
   });
 
+  it("opens markdown file references at their line without including the suffix in the path", async () => {
+    await openLocalMarkdownRef(
+      "/Users/me/project/SessionCreatorChatPanelView.tsx:220",
+      false
+    );
+
+    expect(mocks.stat).toHaveBeenCalledWith(
+      "/Users/me/project/SessionCreatorChatPanelView.tsx"
+    );
+    expect(mocks.openFileInWorkStation).toHaveBeenCalledWith(
+      "/Users/me/project/SessionCreatorChatPanelView.tsx",
+      { line: 220 }
+    );
+  });
+
   it("falls back to the file tab when the path cannot be stat'ed", async () => {
     mocks.stat.mockRejectedValueOnce(new Error("gone"));
     await openLocalMarkdownRef("/Users/me/missing.png", false);

--- a/src/components/MarkDown/MarkdownLocalImage.tsx
+++ b/src/components/MarkDown/MarkdownLocalImage.tsx
@@ -21,6 +21,7 @@ import { getImageMimeType } from "@src/util/file/previewTypes";
 import { openFileInEditor } from "@src/util/ui/openFileInEditor";
 import { openFileInWorkStation } from "@src/util/ui/openFileInWorkStation";
 
+import { parseMarkdownFileRef } from "./markdownFileRef";
 import { classifyMarkdownImageSrc } from "./markdownImageSrc";
 
 export async function resolveLocalMarkdownPath(
@@ -39,7 +40,11 @@ export async function openLocalMarkdownRef(
   path: string,
   homeRelative: boolean
 ): Promise<void> {
-  const absolutePath = await resolveLocalMarkdownPath(path, homeRelative);
+  const fileRef = parseMarkdownFileRef(path);
+  const absolutePath = await resolveLocalMarkdownPath(
+    fileRef.path,
+    homeRelative
+  );
   let isDirectory = false;
   try {
     isDirectory = (await stat(absolutePath)).isDirectory;
@@ -48,6 +53,8 @@ export async function openLocalMarkdownRef(
   }
   if (isDirectory) {
     openFileInEditor(absolutePath, { isDirectory: true });
+  } else if (fileRef.line !== undefined) {
+    openFileInWorkStation(absolutePath, { line: fileRef.line });
   } else {
     openFileInWorkStation(absolutePath);
   }

--- a/src/components/MarkDown/markdownFileRef.test.ts
+++ b/src/components/MarkDown/markdownFileRef.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { parseMarkdownFileRef } from "./markdownFileRef";
+
+describe("parseMarkdownFileRef", () => {
+  it("separates a trailing line from a POSIX path", () => {
+    expect(parseMarkdownFileRef("/repo/src/View.tsx:220")).toEqual({
+      path: "/repo/src/View.tsx",
+      line: 220,
+    });
+  });
+
+  it("uses the line and discards an optional column", () => {
+    expect(parseMarkdownFileRef("C:\\repo\\src\\View.tsx:220:14")).toEqual({
+      path: "C:\\repo\\src\\View.tsx",
+      line: 220,
+    });
+  });
+
+  it("leaves ordinary paths and invalid 1-based lines unchanged", () => {
+    expect(parseMarkdownFileRef("C:\\repo\\src\\View.tsx")).toEqual({
+      path: "C:\\repo\\src\\View.tsx",
+    });
+    expect(parseMarkdownFileRef("/repo/src/View.tsx:0")).toEqual({
+      path: "/repo/src/View.tsx:0",
+    });
+  });
+});

--- a/src/components/MarkDown/markdownFileRef.ts
+++ b/src/components/MarkDown/markdownFileRef.ts
@@ -1,0 +1,23 @@
+export interface MarkdownFileRef {
+  path: string;
+  /** 1-based line parsed from a trailing `:line` or `:line:column`. */
+  line?: number;
+}
+
+/**
+ * Split the source location syntax used by agent-authored markdown links from
+ * the filesystem path that the WorkStation must open.
+ */
+export function parseMarkdownFileRef(ref: string): MarkdownFileRef {
+  const trimmed = ref.trim();
+  const locationMatch = /:([0-9]+)(?::[0-9]+)?$/.exec(trimmed);
+  if (!locationMatch || locationMatch.index === 0) return { path: trimmed };
+
+  const line = Number(locationMatch[1]);
+  if (!Number.isSafeInteger(line) || line < 1) return { path: trimmed };
+
+  return {
+    path: trimmed.slice(0, locationMatch.index),
+    line,
+  };
+}

--- a/src/components/MarkDown/markdownUrlTransform.test.ts
+++ b/src/components/MarkDown/markdownUrlTransform.test.ts
@@ -16,8 +16,25 @@ describe("markdown url transform", () => {
     expect(defaultUrlTransform(REFERENCE)).toBe("");
   });
 
+  it("proves the default sanitizer would drop supported local href forms", () => {
+    expect(defaultUrlTransform("file:///Users/me/project/View.tsx:220")).toBe(
+      ""
+    );
+    expect(defaultUrlTransform("C:\\repo\\src\\View.tsx:220")).toBe("");
+  });
+
   it("passes a valid session reference through on a link href", () => {
     expect(markdownUrlTransform(REFERENCE, "href")).toBe(REFERENCE);
+  });
+
+  it.each([
+    "/Users/me/project/View.tsx:220",
+    "file:///Users/me/project/View.tsx:220",
+    "C:\\repo\\src\\View.tsx:220",
+    "asset://localhost/Users/me/project/View.tsx:220",
+    "~/project/View.tsx:220",
+  ])("passes a supported local file reference through on href: %s", (href) => {
+    expect(markdownUrlTransform(href, "href")).toBe(href);
   });
 
   it("refuses the scheme on every non-href url attribute", () => {
@@ -25,6 +42,16 @@ describe("markdown url transform", () => {
     // link path has a chip renderer, so nothing else may carry the scheme.
     for (const key of ["src", "poster", "cite", "action", undefined]) {
       expect(markdownUrlTransform(REFERENCE, key)).toBe("");
+    }
+  });
+
+  it("keeps local-only schemes blocked on non-href attributes", () => {
+    for (const value of [
+      "file:///Users/me/project/View.tsx",
+      "C:\\repo\\src\\View.tsx",
+      "asset://localhost/Users/me/project/View.tsx",
+    ]) {
+      expect(markdownUrlTransform(value, "src")).toBe("");
     }
   });
 

--- a/src/components/MarkDown/markdownUrlTransform.ts
+++ b/src/components/MarkDown/markdownUrlTransform.ts
@@ -1,11 +1,11 @@
 /**
  * URL sanitizer for the markdown renderer.
  *
- * ORG2 session references ride the app's own `orgii:` scheme, which
+ * ORG2 session references and local filesystem references can use schemes
+ * (`orgii:`, `file:`, Windows drive letters, Tauri assets) that
  * react-markdown's default sanitizer rewrites to an empty href. Exactly the
- * references that validate pass through; every other URL keeps the default
- * protocol allowlist, so this widens the accepted surface by nothing else —
- * not even the capability-bearing `orgii://cloud/session?share=…` form.
+ * references handled by our link renderer pass through; every other URL keeps
+ * the default protocol allowlist.
  *
  * Scoped to `href` because react-markdown runs this over EVERY url-bearing
  * attribute (`src`, `poster`, `cite`, …). Only the link path has a chip
@@ -16,8 +16,13 @@ import { defaultUrlTransform } from "react-markdown";
 
 import { parseCloudSessionReference } from "@src/features/Org2Cloud/cloudSessionReference";
 
+import { classifyMarkdownImageSrc } from "./markdownImageSrc";
+
 export function markdownUrlTransform(value: string, key?: string): string {
-  return key === "href" && parseCloudSessionReference(value)
-    ? value
-    : defaultUrlTransform(value);
+  if (key === "href") {
+    if (parseCloudSessionReference(value)) return value;
+    if (classifyMarkdownImageSrc(value).kind === "local") return value;
+  }
+
+  return defaultUrlTransform(value);
 }

--- a/src/components/MarkDown/markdownUtils.test.ts
+++ b/src/components/MarkDown/markdownUtils.test.ts
@@ -1,6 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
-import { normalizeCopyableMarkdownDocumentFence } from "./markdownUtils";
+import {
+  detectCodeType,
+  normalizeCopyableMarkdownDocumentFence,
+  openFileInEditor,
+} from "./markdownUtils";
+
+const mocks = vi.hoisted(() => ({
+  openFileInEditor: vi.fn(),
+}));
+
+vi.mock("@src/util/ui/openFileInEditor", () => ({
+  openFileInEditor: mocks.openFileInEditor,
+}));
 
 describe("normalizeCopyableMarkdownDocumentFence", () => {
   it("uses a longer outer fence for markdown documents with nested fences", () => {
@@ -66,5 +78,23 @@ describe("normalizeCopyableMarkdownDocumentFence", () => {
     const input = ["```md", "## Summary", "Plain text", "```"].join("\n");
 
     expect(normalizeCopyableMarkdownDocumentFence(input)).toBe(input);
+  });
+});
+
+describe("detectCodeType", () => {
+  it("recognizes inline file paths with source location suffixes", () => {
+    expect(detectCodeType("src/components/View.tsx:220")).toBe("file");
+    expect(detectCodeType("src/components/View.tsx:220:14")).toBe("file");
+  });
+});
+
+describe("openFileInEditor", () => {
+  it("passes markdown source locations as a clean path and target line", () => {
+    openFileInEditor("src/components/View.tsx:220:14");
+
+    expect(mocks.openFileInEditor).toHaveBeenCalledWith(
+      "src/components/View.tsx",
+      { isDirectory: false, line: 220 }
+    );
   });
 });

--- a/src/components/MarkDown/markdownUtils.tsx
+++ b/src/components/MarkDown/markdownUtils.tsx
@@ -14,6 +14,8 @@ import React from "react";
 
 import { openFileInEditor as openFileInEditorShared } from "@src/util/ui/openFileInEditor";
 
+import { parseMarkdownFileRef } from "./markdownFileRef";
+
 type InlineCodeType = "file" | "directory" | null;
 
 const FILE_CONTENT_PATTERN =
@@ -373,26 +375,28 @@ export function detectCodeType(text: string): InlineCodeType {
   }
 
   let result: InlineCodeType = null;
+  const fileRefPath = parseMarkdownFileRef(trimmed).path;
 
   if (
-    !trimmed.includes("\n") &&
-    !trimmed.includes("  ") &&
-    !/[=<>!&|]/.test(trimmed)
+    !fileRefPath.includes("\n") &&
+    !fileRefPath.includes("  ") &&
+    !/[=<>!&|]/.test(fileRefPath)
   ) {
-    const hasPathSignal = trimmed.includes("/") || trimmed.endsWith("/");
+    const hasPathSignal =
+      fileRefPath.includes("/") || fileRefPath.endsWith("/");
 
-    if (hasPathSignal && /^[\w./-]+\/$/.test(trimmed)) {
+    if (hasPathSignal && /^[\w./-]+\/$/.test(fileRefPath)) {
       result = "directory";
     } else if (
       hasPathSignal &&
-      (/^\.{0,2}\//.test(trimmed) ||
-        (/\//.test(trimmed) && /\.\w+$/.test(trimmed)))
+      (/^\.{0,2}\//.test(fileRefPath) ||
+        (/\//.test(fileRefPath) && /\.\w+$/.test(fileRefPath)))
     ) {
       result = "file";
     } else if (
       hasPathSignal &&
-      /^[\w.-]+\/[\w./-]+$/.test(trimmed) &&
-      !/\.\w+$/.test(trimmed)
+      /^[\w.-]+\/[\w./-]+$/.test(fileRefPath) &&
+      !/\.\w+$/.test(fileRefPath)
     ) {
       result = "directory";
     }
@@ -405,7 +409,13 @@ export function detectCodeType(text: string): InlineCodeType {
 // ── openFileInEditor ──────────────────────────────────────────────────────────
 
 export function openFileInEditor(path: string, isDirectory: boolean = false) {
-  openFileInEditorShared(path, { isDirectory });
+  const fileRef = isDirectory
+    ? { path: path.trim() }
+    : parseMarkdownFileRef(path);
+  openFileInEditorShared(fileRef.path, {
+    isDirectory,
+    line: fileRef.line,
+  });
 }
 
 // ── Citation rendering ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Agent-authored markdown file links such as `/repo/src/View.tsx:220` passed the trailing source location into filesystem lookup and tab creation as part of the filename. The editor therefore tried to open a nonexistent `View.tsx:220` file instead of `View.tsx` at line 220. React Markdown also removed supported `file://`, Windows drive-letter, and Tauri asset hrefs before the local-link click handler could classify them.

## Solution

Parse trailing `:line` and `:line:column` syntax at the markdown file-reference boundary, keep the filesystem path clean, and pass the 1-based line through the existing editor target-line option. Apply the same parser to inline-code file navigation. Preserve supported local filesystem references during URL transformation only for `href`; non-link attributes and unsupported schemes continue through React Markdown's default sanitizer.

The resulting invariant is that markdown navigation sends path and source location as separate values. No persisted data or historical cleanup is involved.

## Potential risks

A POSIX filename that legitimately ends in `:<positive integer>` will be interpreted as a source-location reference when opened from chat markdown. Optional columns are accepted so the path is parsed correctly, but navigation currently targets the line only because the WorkStation tab contract has no target-column field. Workspace-relative markdown href behavior is unchanged.

Rollback is a straight revert of commit `04250d017`; there are no schema, dependency, persistence, API, or wire-format changes.

## Audit

Reviewed the adjacent markdown link pipeline for absolute POSIX paths, `file://` URLs, Windows drive-letter paths, Tauri asset URLs, home-relative paths, inline code, remote schemes, and non-href URL attributes. Relative href resolution remains intentionally out of scope because the current renderer does not infer a workspace root for links.

## Verification

- `npx vitest run src/components/MarkDown/markdownFileRef.test.ts src/components/MarkDown/MarkdownLocalImage.test.ts src/components/MarkDown/markdownUtils.test.ts src/components/MarkDown/markdownUrlTransform.test.ts` — 4 files, 28 tests passed.
- `npx prettier --check <8 changed files>` — passed.
- `npx eslint <8 changed files>` — passed.
- `npm run typecheck` — passed.
- `git diff --check` — passed.
- Commit hooks reran lint-staged formatting/lint and scoped TypeScript checks — passed.

No screenshot is included because this changes click navigation and target-line behavior without changing rendered appearance. The owning parser and editor-opening boundary are covered by regression tests.
