### PR TITLE
perf(workstation): release idle content hosts when the tab pool empties

### DIFF
--- a/src/modules/WorkStation/AppShell/AppShellContent.tsx
+++ b/src/modules/WorkStation/AppShell/AppShellContent.tsx
@@ -2,17 +2,31 @@ import { useAtomValue } from "jotai";
 import React, { Suspense } from "react";
 import { useTranslation } from "react-i18next";
 
+import { useBrowserContextOptional } from "@src/contexts/workstation/BrowserContext";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
 import { CODE_EDITOR_TOUR_TARGETS } from "@src/scaffold/Tutorials/codeEditorTourConfig";
+import {
+  mainPaneHasBrowserHostTabsAtom,
+  mainPaneHasRealTabsAtom,
+} from "@src/store/workstation/tabHost";
 import {
   activeWorkStationTabAtom,
   mainPaneTabsAtom,
 } from "@src/store/workstation/tabs";
+import {
+  workstationNewBrowserSessionConsumedTickAtom,
+  workstationNewBrowserSessionRequestAtom,
+} from "@src/store/workstation/workstationTabBarAtoms";
 
 import CodeEditor from "../CodeEditor";
 import { LspInstallPrompt } from "../CodeEditor/LspInstallPrompt";
 import { WORK_STATION_PLACEHOLDER_PAGE_BG_CLASS } from "../shared/tokens";
 import { WorkStationStartPage } from "./StartPage";
+import {
+  shouldMountAgentStationHost,
+  shouldMountBrowserHost,
+  shouldMountWorkstationHost,
+} from "./hostMountPolicy";
 
 const ProjectManagerCore = React.lazy(
   () =>
@@ -36,6 +50,8 @@ interface AppShellContentProps {
   chatPanelFocused: boolean;
   isAgentStation: boolean;
   hasVisitedAgentStation: boolean;
+  /** Whether Agent Station has a live session attached (keep-alive gate). */
+  hasAgentStationSession: boolean;
   hasVisitedCode: boolean;
   hasVisitedBrowser: boolean;
   hasVisitedProject: boolean;
@@ -68,6 +84,7 @@ export function AppShellContent({
   chatPanelFocused,
   isAgentStation,
   hasVisitedAgentStation,
+  hasAgentStationSession,
   hasVisitedCode,
   hasVisitedBrowser,
   hasVisitedProject,
@@ -87,6 +104,49 @@ export function AppShellContent({
   // launcher paint over it.
   const showStartPage =
     !isBrowserMode && (activeTab?.type === "start" || noTabs);
+
+  // ── Host mount policy ────────────────────────────────────────────────
+  // Bounded keep-alive: hosts stay mounted (hidden) between real tabs so
+  // switches are instant, but the empty Launchpad releases every host — see
+  // `hostMountPolicy.ts`. The Browser host has extra mount triggers because
+  // it owns side effects the other hosts don't: the new-session request
+  // consumer (consumed-tick effect in BrowserLayout, which is remount-safe)
+  // and the engine-sessions ↔ tab-strip sync.
+  const hasRealTabs = useAtomValue(mainPaneHasRealTabsAtom);
+  const hasBrowserHostTabs = useAtomValue(mainPaneHasBrowserHostTabsAtom);
+  const newBrowserSessionRequest = useAtomValue(
+    workstationNewBrowserSessionRequestAtom
+  );
+  const newBrowserSessionConsumedTick = useAtomValue(
+    workstationNewBrowserSessionConsumedTickAtom
+  );
+  // Optional: AppShellContent always sits under BrowserProvider in the app,
+  // but isolated mounts (tests) shouldn't crash — no provider ⇒ no sessions.
+  const browserContextValue = useBrowserContextOptional();
+  const mountAgentStationHost = shouldMountAgentStationHost({
+    isAgentStation,
+    hasVisited: hasVisitedAgentStation,
+    hasActiveSession: hasAgentStationSession,
+  });
+  const mountCodeHost = shouldMountWorkstationHost({
+    hasRealTabs,
+    isActiveHost: isCodeMode,
+    hasVisited: hasVisitedCode,
+  });
+  const mountProjectHost = shouldMountWorkstationHost({
+    hasRealTabs,
+    isActiveHost: isProjectMode,
+    hasVisited: hasVisitedProject,
+  });
+  const mountBrowserHost = shouldMountBrowserHost({
+    hasRealTabs,
+    isActiveHost: isBrowserMode,
+    hasVisited: hasVisitedBrowser,
+    hasBrowserHostTabs,
+    hasBrowserSessions: (browserContextValue?.sessions.length ?? 0) > 0,
+    hasPendingNewSessionRequest:
+      newBrowserSessionRequest.tick > newBrowserSessionConsumedTick,
+  });
   const activeTabCanRenderWithoutRepo =
     activeTab?.type === "agent-config" ||
     activeTab?.type === "chat-session" ||
@@ -125,7 +185,7 @@ export function AppShellContent({
 
   return (
     <>
-      {(isAgentStation || hasVisitedAgentStation) && (
+      {mountAgentStationHost && (
         <div
           className="h-full w-full"
           style={{
@@ -143,21 +203,19 @@ export function AppShellContent({
         style={{ display: isAgentStation ? "none" : "contents" }}
       >
         {/*
-          Empty-pool start page. The hosts below stay MOUNTED (hidden) even
-          when the launcher is showing so their side effects keep running —
-          in particular the Browser host owns the new-session effect that
-          turns a "New Browser Tab" request into a live session. We toggle
-          visibility against the start page rather than unmounting them.
+          Empty-pool start page. While it shows, no host is mounted at all
+          (see the mount policy above) — the empty pool has nothing to keep
+          warm, and cross-surface requests (e.g. "New Browser Tab") travel
+          through remount-safe atoms that mount their host on demand. While
+          real tabs exist, visited hosts stay mounted (hidden) so tab
+          switches are instant.
         */}
-        {!isAgentStation && (
-          <div
-            className="h-full w-full"
-            style={{ display: showStartPage ? "block" : "none" }}
-          >
+        {!isAgentStation && showStartPage && (
+          <div className="h-full w-full">
             <WorkStationStartPage />
           </div>
         )}
-        {(isCodeMode || hasVisitedCode) && (
+        {mountCodeHost && (
           <div
             className="relative h-full w-full"
             data-tour-target={CODE_EDITOR_TOUR_TARGETS.editorSurface}
@@ -173,7 +231,7 @@ export function AppShellContent({
           </div>
         )}
 
-        {(isBrowserMode || hasVisitedBrowser) && (
+        {mountBrowserHost && (
           <div
             className="h-full w-full"
             style={{
@@ -191,7 +249,7 @@ export function AppShellContent({
           </div>
         )}
 
-        {(isProjectMode || hasVisitedProject) && (
+        {mountProjectHost && (
           <div
             className="h-full w-full"
             style={{

--- a/src/modules/WorkStation/AppShell/hooks/useAppShellDock.ts
+++ b/src/modules/WorkStation/AppShell/hooks/useAppShellDock.ts
@@ -1,71 +1,63 @@
 import { useAtomValue } from "jotai";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { activeHostAtom } from "@src/store/workstation";
+import { mainPaneHasRealTabsAtom } from "@src/store/workstation/tabHost";
 import { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";
 
 export interface AppShellDockState {
   visitedModes: Set<string>;
 }
 
+/**
+ * Tracks which content hosts have been visited since the tab pool last held
+ * real work, so `AppShellContent` can keep them mounted-but-hidden for
+ * instant tab switches.
+ *
+ * The keep-alive is bounded: when the pool empties down to the Launchpad the
+ * visited set is cleared and every host unmounts, releasing its subtree (and
+ * idle background work like the file-tree autoload). This is safe because the
+ * ACTIVE host never depends on this set — `AppShellContent` mounts it through
+ * the synchronous `is*Mode` branch the moment a tab activates — and because
+ * cross-surface requests travel through atoms that survive host remounts.
+ *
+ * The old unconditional Browser pre-mount (so a "New Browser" click had a
+ * mounted consumer) is gone: `AppShellContent` now mounts the Browser host
+ * whenever a new-session request is pending or engine sessions exist — see
+ * `shouldMountBrowserHost` in `../hostMountPolicy`.
+ */
 export function useAppShellDock(): AppShellDockState {
   const activeHost = useAtomValue(activeHostAtom);
+  const hasRealTabs = useAtomValue(mainPaneHasRealTabsAtom);
 
-  // Seed `visitedModes` with `"code"` (the fallback host for empty workstation
-  // state) AND the active tab's host on first render. Without the eager seed
-  // the host pane that owns the active tab mounts one frame late, leaving its
-  // 40px header slot null and the global strip visibly blank until the rAF
-  // below fires.
+  // Seed with the active tab's host on first render so the host pane that
+  // owns a restored active tab is kept warm from the same commit (no blank
+  // 40px header strip when switching away and back within the first frame).
   const [visitedModes, setVisitedModes] = useState<Set<string>>(() => {
-    const initial = new Set<string>(["code"]);
+    if (!hasRealTabs) return new Set();
     try {
       const store = getInstrumentedStore();
-      initial.add(store.get(activeHostAtom));
+      return new Set([store.get(activeHostAtom)]);
     } catch {
       // Store not yet available in some test environments — fine.
+      return new Set(["code"]);
     }
-    return initial;
   });
 
-  // Track which hosts we've already enqueued to mount; lets us still use rAF
-  // deferral for non-blocking first paint without re-running the effect on
-  // every state change (see remix-run loop guidance).
-  const enqueuedRef = useRef<Set<string>>(new Set(visitedModes));
-
-  // `eager === true` flips the host synchronously so the keep-alive `<div>`
-  // mounts in the same commit that swapped `activeHost`; the rAF path defers
-  // hosts the user has not directly asked for yet, to avoid blocking first
-  // paint with extra subtree work.
-  const queueVisit = useCallback((host: string, eager: boolean) => {
-    if (enqueuedRef.current.has(host)) return;
-    enqueuedRef.current.add(host);
-    if (eager) {
-      setVisitedModes((prev) =>
-        prev.has(host) ? prev : new Set([...prev, host])
-      );
+  useEffect(() => {
+    if (!hasRealTabs) {
+      // Empty pool (Launchpad only): release every kept-alive host. The next
+      // real tab re-mounts its host synchronously via the `is*Mode` branch in
+      // AppShellContent, so clearing here never delays a visible surface.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setVisitedModes((prev) => (prev.size === 0 ? prev : new Set()));
       return;
     }
-    requestAnimationFrame(() => {
-      setVisitedModes((prev) =>
-        prev.has(host) ? prev : new Set([...prev, host])
-      );
-    });
-  }, []);
-
-  // The unified surface renders the host derived from the active mainPane tab.
-  // Mark it visited synchronously so the keep-alive `<div>` for
-  // browser/project mounts in the same commit and the 40px header strip never
-  // flickers blank between tab clicks. Browser is a special case: the unified
-  // "+" menu's "New Browser" entry bumps `workstationNewBrowserSessionRequestAtom`,
-  // which only turns into a real session once `BrowserLayout` has mounted (it
-  // owns the engine state). Pre-mount Browser (deferred, off the first-paint
-  // path) so that action works even when no browser tab is active yet.
-  useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    queueVisit(activeHost, true);
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    queueVisit("browser", false);
-  }, [activeHost, queueVisit]);
+    setVisitedModes((prev) =>
+      prev.has(activeHost) ? prev : new Set([...prev, activeHost])
+    );
+  }, [activeHost, hasRealTabs]);
 
   return { visitedModes };
 }

--- a/src/modules/WorkStation/AppShell/hostMountPolicy.test.ts
+++ b/src/modules/WorkStation/AppShell/hostMountPolicy.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  shouldMountAgentStationHost,
+  shouldMountBrowserHost,
+  shouldMountWorkstationHost,
+} from "./hostMountPolicy";
+
+describe("shouldMountWorkstationHost", () => {
+  it("unmounts everything on the empty Launchpad, even previously visited hosts", () => {
+    expect(
+      shouldMountWorkstationHost({
+        hasRealTabs: false,
+        isActiveHost: true,
+        hasVisited: true,
+      })
+    ).toBe(false);
+  });
+
+  it("mounts the host that owns the active tab", () => {
+    expect(
+      shouldMountWorkstationHost({
+        hasRealTabs: true,
+        isActiveHost: true,
+        hasVisited: false,
+      })
+    ).toBe(true);
+  });
+
+  it("keeps a visited host warm while real tabs remain", () => {
+    expect(
+      shouldMountWorkstationHost({
+        hasRealTabs: true,
+        isActiveHost: false,
+        hasVisited: true,
+      })
+    ).toBe(true);
+  });
+
+  it("does not mount an unvisited, inactive host", () => {
+    expect(
+      shouldMountWorkstationHost({
+        hasRealTabs: true,
+        isActiveHost: false,
+        hasVisited: false,
+      })
+    ).toBe(false);
+  });
+});
+
+describe("shouldMountBrowserHost", () => {
+  const idle = {
+    hasRealTabs: false,
+    isActiveHost: false,
+    hasVisited: false,
+    hasBrowserHostTabs: false,
+    hasBrowserSessions: false,
+    hasPendingNewSessionRequest: false,
+  };
+
+  it("stays unmounted on the empty Launchpad with no sessions or requests", () => {
+    expect(shouldMountBrowserHost(idle)).toBe(false);
+  });
+
+  it("mounts for a pending New Browser request even with no tabs (Launchpad flow)", () => {
+    expect(
+      shouldMountBrowserHost({ ...idle, hasPendingNewSessionRequest: true })
+    ).toBe(true);
+  });
+
+  it("stays mounted while engine sessions exist, bridging request → tab sync", () => {
+    // After the consumed-tick effect fires, the request is no longer pending
+    // but the browser-session tab has not been created yet — the session
+    // itself must hold the host mounted through that gap.
+    expect(shouldMountBrowserHost({ ...idle, hasBrowserSessions: true })).toBe(
+      true
+    );
+  });
+
+  it("mounts for background browser-session tabs before first activation", () => {
+    expect(
+      shouldMountBrowserHost({
+        ...idle,
+        hasRealTabs: true,
+        hasBrowserHostTabs: true,
+      })
+    ).toBe(true);
+  });
+
+  it("follows the shared keep-alive policy otherwise", () => {
+    expect(
+      shouldMountBrowserHost({ ...idle, hasRealTabs: true, hasVisited: true })
+    ).toBe(true);
+    expect(shouldMountBrowserHost({ ...idle, hasRealTabs: true })).toBe(false);
+  });
+});
+
+describe("shouldMountAgentStationHost", () => {
+  it("always mounts while Agent Station is the visible surface", () => {
+    expect(
+      shouldMountAgentStationHost({
+        isAgentStation: true,
+        hasVisited: false,
+        hasActiveSession: false,
+      })
+    ).toBe(true);
+  });
+
+  it("keeps the hidden simulator warm only while a session is attached", () => {
+    expect(
+      shouldMountAgentStationHost({
+        isAgentStation: false,
+        hasVisited: true,
+        hasActiveSession: true,
+      })
+    ).toBe(true);
+    expect(
+      shouldMountAgentStationHost({
+        isAgentStation: false,
+        hasVisited: true,
+        hasActiveSession: false,
+      })
+    ).toBe(false);
+  });
+
+  it("never mounts an unvisited, hidden simulator", () => {
+    expect(
+      shouldMountAgentStationHost({
+        isAgentStation: false,
+        hasVisited: false,
+        hasActiveSession: true,
+      })
+    ).toBe(false);
+  });
+});

--- a/src/modules/WorkStation/AppShell/hostMountPolicy.ts
+++ b/src/modules/WorkStation/AppShell/hostMountPolicy.ts
@@ -1,0 +1,78 @@
+/**
+ * hostMountPolicy — pure predicates deciding which WorkStation content hosts
+ * (code / browser / project / Agent Station simulator) are mounted at all.
+ *
+ * The AppShell keeps previously-visited hosts mounted-but-hidden so tab
+ * switches stay instant. That keep-alive used to be monotonic: once a host
+ * mounted it never unmounted, the code host was mounted from launch, and the
+ * Browser host was unconditionally pre-mounted. These predicates bound the
+ * keep-alive instead: with no real tabs there is nothing to keep warm, so
+ * every host unmounts and the Launchpad owns the surface — releasing the
+ * hidden subtrees (file tree, sidebars, simulator grid) and their idle
+ * background work.
+ *
+ * The predicates are pure so the mount matrix is unit-testable; the atoms
+ * feeding them live in `@src/store/workstation/tabHost`.
+ */
+
+/** Code / project hosts: mounted while active, or kept warm between real tabs. */
+export function shouldMountWorkstationHost(options: {
+  /** Any non-Launchpad tab in the main pane (`mainPaneHasRealTabsAtom`). */
+  hasRealTabs: boolean;
+  /** The active tab projects onto this host. */
+  isActiveHost: boolean;
+  /** The host was visited since the pool last emptied. */
+  hasVisited: boolean;
+}): boolean {
+  const { hasRealTabs, isActiveHost, hasVisited } = options;
+  return hasRealTabs && (isActiveHost || hasVisited);
+}
+
+/**
+ * Browser host: the shared policy plus three extra mount triggers that
+ * preserve its side-effect ownership without the old unconditional
+ * pre-mount:
+ *
+ *  - `hasBrowserHostTabs` — background `browser-session` tabs need the
+ *    host's sessions ↔ tab-strip sync running before first activation;
+ *  - `hasBrowserSessions` — engine sessions (including ones restored from
+ *    storage, or just created from a request) must keep their owner mounted
+ *    until the tab sync catches up;
+ *  - `hasPendingNewSessionRequest` — a "New Browser" click (Launchpad or the
+ *    unified "+" menu) must mount the host so BrowserLayout's consumed-tick
+ *    effect can turn the request into a live session.
+ */
+export function shouldMountBrowserHost(options: {
+  hasRealTabs: boolean;
+  isActiveHost: boolean;
+  hasVisited: boolean;
+  hasBrowserHostTabs: boolean;
+  hasBrowserSessions: boolean;
+  hasPendingNewSessionRequest: boolean;
+}): boolean {
+  const {
+    hasRealTabs,
+    isActiveHost,
+    hasVisited,
+    hasBrowserHostTabs,
+    hasBrowserSessions,
+    hasPendingNewSessionRequest,
+  } = options;
+  if (hasPendingNewSessionRequest || hasBrowserSessions) return true;
+  return hasRealTabs && (isActiveHost || hasVisited || hasBrowserHostTabs);
+}
+
+/**
+ * Agent Station simulator: always mounted while Agent Station is the visible
+ * surface; kept warm while hidden only for as long as a session is attached,
+ * so my-station ↔ agent-station toggles stay instant mid-session but an idle
+ * simulator releases its subtree.
+ */
+export function shouldMountAgentStationHost(options: {
+  isAgentStation: boolean;
+  hasVisited: boolean;
+  hasActiveSession: boolean;
+}): boolean {
+  const { isAgentStation, hasVisited, hasActiveSession } = options;
+  return isAgentStation || (hasVisited && hasActiveSession);
+}

--- a/src/modules/WorkStation/AppShell/index.tsx
+++ b/src/modules/WorkStation/AppShell/index.tsx
@@ -165,6 +165,7 @@ const AppShell = React.memo(
                 chatPanelFocused={chatPanelFocused}
                 isAgentStation={isAgentStation}
                 hasVisitedAgentStation={hasVisitedAgentStation}
+                hasAgentStationSession={!!workstationActiveSessionId}
                 hasVisitedCode={hasVisitedCode}
                 hasVisitedBrowser={hasVisitedBrowser}
                 hasVisitedProject={hasVisitedProject}

--- a/src/store/workstation/tabHost.ts
+++ b/src/store/workstation/tabHost.ts
@@ -10,7 +10,7 @@
  */
 import { atom } from "jotai";
 
-import { activeWorkStationTabAtom } from "./tabs";
+import { activeWorkStationTabAtom, mainPaneTabsAtom } from "./tabs";
 import type {
   WorkStationTab,
   WorkStationTabCategory,
@@ -85,3 +85,33 @@ export const activeHostAtom = atom<WorkstationTabHost>((get) => {
   return activeTab ? tabToHost(activeTab) : "code";
 });
 activeHostAtom.debugLabel = "activeHostAtom";
+
+/**
+ * Launchpad (`start`) tabs are ephemeral placeholders seeded whenever the
+ * pool empties (see `useLaunchpadTab`); they never count as real work.
+ */
+export function isRealWorkstationTab(tab: WorkStationTab): boolean {
+  return tab.type !== "start";
+}
+
+/**
+ * True when the main pane holds any tab besides the ephemeral Launchpad.
+ * Derived boolean so subscribers only re-render when the answer flips, not
+ * on every tab-pool mutation. The AppShell uses this to release every
+ * kept-alive content host once the pool empties.
+ */
+export const mainPaneHasRealTabsAtom = atom<boolean>((get) =>
+  get(mainPaneTabsAtom).some(isRealWorkstationTab)
+);
+mainPaneHasRealTabsAtom.debugLabel = "mainPaneHasRealTabsAtom";
+
+/**
+ * True when any main-pane tab projects onto the browser host. Background
+ * `browser-session` tabs need the Browser host mounted even before their
+ * first activation — its sessions ↔ tab-strip sync lives inside
+ * `BrowserLayout`.
+ */
+export const mainPaneHasBrowserHostTabsAtom = atom<boolean>((get) =>
+  get(mainPaneTabsAtom).some((tab) => tabToHost(tab) === "browser")
+);
+mainPaneHasBrowserHostTabsAtom.debugLabel = "mainPaneHasBrowserHostTabsAtom";


### PR DESCRIPTION
## Summary

Bounds the AppShell's host keep-alive so an idle WorkStation stops holding every previously-visited surface in memory. With no real tabs (Launchpad only), the code / browser / project hosts and the hidden Agent Station simulator all unmount; while real tabs exist, visited hosts stay mounted-but-hidden exactly as before so tab switches remain instant.

## Problem

The keep-alive in `AppShellContent` was monotonic: once a host mounted it never unmounted (`visitedModes` only ever grew), the code host was mounted from launch even on the empty Launchpad (file-tree autoload, git/diff/diagnostics/output hooks all live), the Browser host was unconditionally pre-mounted one frame after startup, and the Agent Station simulator stayed mounted forever after one visit — even back in My Station with no session. An idle window paid RAM and background-work costs for surfaces showing nothing.

## Solution

- New pure policy module `AppShell/hostMountPolicy.ts` + unit tests covering the mount matrix.
- New derived booleans `mainPaneHasRealTabsAtom` / `mainPaneHasBrowserHostTabsAtom` in `store/workstation/tabHost.ts` (Launchpad `start` tabs never count as real work; subscribers only re-render when the boolean flips).
- `useAppShellDock` clears the visited set when the pool empties and drops the deferred Browser pre-mount; the active host still mounts synchronously via the `is*Mode` branch, so first-tab-open latency is unchanged.
- Browser host mounts on any of: active/visited (with real tabs), background `browser-session` tabs, live engine sessions, or a pending New-Browser request — the request consumer in `BrowserLayout` was already remount-safe via the module-scoped consumed-tick atom, and the engine-sessions trigger bridges the gap between request consumption and the sessions ↔ tab-strip sync creating the tab.
- Agent Station simulator: mounted while visible; kept warm while hidden only when a session is attached (`workstationActiveSessionIdAtom`), so mid-session My Station ↔ Agent Station toggles stay instant but an idle simulator releases its subtree.
- The Launchpad itself now unmounts while real tabs are shown (it was previously kept hidden in the DOM).

## Potential risks

- Opening the first real tab from the Launchpad now cold-mounts its host: one file-tree reload IPC and the known one-frame blank in the 40px header strip (same as the current very first launch frame). No grace delay was added for close-last-tab → reopen churn; can be added later if it's noticeable.
- The Browser host's lifecycle has the most triggers; the launchpad New-Browser flow, restored localStorage sessions, and background browser-session tabs are each covered by an explicit mount trigger, but this is the area to watch in manual testing.
- Component-local state inside a host (e.g. editor right-panel width) resets after a full pool-empty cycle; persisted atom state (sidebar widths, layout mode) is unaffected.
- RAM savings are unmeasured in this PR (heap snapshot on the idle Launchpad before/after is the right check); the structural claim — fewer mounted subtrees and no idle file-tree autoload with zero tabs — holds by construction.

## Validation / Test plan

- `tsc --noEmit` clean; eslint clean on touched files.
- `vitest run src/modules/WorkStation/AppShell/ src/store/workstation/` — 23 files, 228 tests passed, including the new `hostMountPolicy.test.ts` matrix (empty-pool release, pending-request mount, session-bridge gap, agent-station session gating).
- Manual checks recommended before merge: New Browser from empty Launchpad; restart with restored browser sessions; close last tab → Launchpad → reopen file tab; Agent Station toggle with and without a live session.