### PR TITLE
fix(oauth): stabilize macOS embedded login popups

### DIFF
--- a/src-tauri/src/agent_sessions/cli/platform_adapters/claude_code/oauth.rs
+++ b/src-tauri/src/agent_sessions/cli/platform_adapters/claude_code/oauth.rs
@@ -4,9 +4,9 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tauri::webview::WebviewBuilder;
 use tauri::{AppHandle, Emitter, Manager, WebviewUrl};
-// Host-managed popup window is only built on macOS/Linux; Windows uses the
-// native WebView2 popup (NewWindowResponse::Allow) instead.
-#[cfg(not(target_os = "windows"))]
+// Host-managed popup windows are only built where wry has no native popup path
+// selected below. Windows and macOS preserve window.opener via `Allow`.
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
 use tauri::WebviewWindowBuilder;
 
 use crate::agent_sessions::cli::platform_adapters::webview_session::{
@@ -183,24 +183,21 @@ pub async fn create_claude_code_oauth_webview(
         let url_value = new_window_url.to_string();
         tracing::info!(url = %url_value, "[claude-code-oauth] new window requested");
         if is_google_accounts_url(&url_value) {
-            // Windows: hand the popup to WebView2 natively. wry maps `Allow` to
-            // `SetHandled(false)`, so WebView2 opens the popup as a real child of
-            // the caller webview — preserving `window.opener` and the shared
-            // session. Google's GIS popup needs that opener to postMessage the
-            // credential back to claude.ai. The host-managed `Create` path below
-            // uses a fresh environment with no opener, so on Windows the popup
-            // renders but sign-in fails with "There was an error logging you in".
-            #[cfg(target_os = "windows")]
+            // Hand the popup to wry's platform-native implementation. It creates
+            // the child from the caller's WebView2 environment / WKWebView
+            // configuration, preserving window.opener for Google's postMessage.
+            // It also avoids re-entering Tauri window construction from WebKit's
+            // synchronous createNewPage callback on macOS.
+            #[cfg(any(target_os = "windows", target_os = "macos"))]
             {
                 let _ = &features; // unused on this platform
-                tracing::info!(url = %url_value, "[claude-code-oauth] allowing native Google OAuth popup (Windows)");
+                tracing::info!(url = %url_value, "[claude-code-oauth] allowing native Google OAuth popup");
                 return tauri::webview::NewWindowResponse::Allow;
             }
 
-            // macOS/Linux: WKWebView / WebKitGTK drive a host-created popup to the
-            // requested URL and keep it related to the caller, so we manage it
-            // ourselves and watch its navigation to auto-close on completion.
-            #[cfg(not(target_os = "windows"))]
+            // Other desktop WebKit ports keep the host-managed popup path and
+            // navigation watcher used to close it after the callback.
+            #[cfg(not(any(target_os = "windows", target_os = "macos")))]
             {
                 let popup_label =
                     format!("{}-popup-{}", label_for_new_window, random_base64url(6));
@@ -324,16 +321,16 @@ fn is_google_accounts_url(value: &str) -> bool {
         .unwrap_or(false)
 }
 
-// Only used by the host-managed popup's navigation handler (macOS/Linux). On
-// Windows the native WebView2 popup is unmanaged, so these are not referenced.
-#[cfg(not(target_os = "windows"))]
+// Only used by the host-managed popup navigation handler. Native Windows/macOS
+// popups are owned by wry, so these helpers are not referenced there.
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
 fn is_claude_code_callback_url(value: &str) -> bool {
     url::Url::parse(value)
         .map(|url| url.as_str().starts_with(REDIRECT_URI))
         .unwrap_or(false)
 }
 
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
 fn is_google_gsi_transform_url(value: &str) -> bool {
     url::Url::parse(value)
         .map(|url| url.domain() == Some("accounts.google.com") && url.path() == "/gsi/transform")

--- a/src-tauri/src/agent_sessions/cli/platform_adapters/codex/oauth.rs
+++ b/src-tauri/src/agent_sessions/cli/platform_adapters/codex/oauth.rs
@@ -3,7 +3,9 @@ use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tauri::webview::WebviewBuilder;
-use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
+#[cfg(not(target_os = "macos"))]
+use tauri::WebviewWindowBuilder;
+use tauri::{AppHandle, Emitter, Manager, WebviewUrl};
 
 use crate::agent_sessions::cli::platform_adapters::webview_session::{
     clear_oauth_browser_session_native, COMMON_OAUTH_SESSION_DOMAINS,
@@ -152,54 +154,68 @@ pub async fn create_codex_oauth_webview(
         tracing::info!(url = %url_value, "[codex-oauth] new window requested");
 
         if should_open_oauth_popup(&url_value) {
-            let popup_label = format!("{}-popup-{}", label_for_new_window, random_base64url(6));
-            let app_for_popup_navigation = app_for_new_window.clone();
-            let app_for_popup_close = app_for_new_window.clone();
-            let label_for_popup_navigation = label_for_new_window.clone();
-            let popup_label_for_navigation = popup_label.clone();
-            let ownership_observation =
-                perf_utils::begin_webview_ownership_observation(popup_label.clone());
-            let builder = WebviewWindowBuilder::new(
-                &app_for_new_window,
-                popup_label,
-                WebviewUrl::External("about:blank".parse().expect("valid about:blank URL")),
-            )
-            .window_features(features)
-            .title("OpenAI Sign in")
-            .inner_size(560.0, 700.0)
-            .on_navigation(move |popup_navigation_url| {
-                let popup_url_value = popup_navigation_url.to_string();
-                let _ = app_for_popup_navigation.emit(
-                    "codex-oauth-url-changed",
-                    serde_json::json!({
-                        "url": popup_url_value,
-                        "webviewLabel": label_for_popup_navigation,
-                    }),
-                );
-                if is_codex_callback_url(&popup_url_value) {
-                    let app_for_async_close = app_for_popup_close.clone();
-                    let popup_label_for_async_close = popup_label_for_navigation.clone();
-                    tauri::async_runtime::spawn(async move {
-                        tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
-                        if let Some(popup) =
-                            app_for_async_close.get_webview_window(&popup_label_for_async_close)
-                        {
-                            let _ = popup.close();
-                        }
-                    });
-                }
-                true
-            });
+            // wry's native macOS popup reuses the caller WKWebView configuration
+            // and preserves window.opener. Building a second Tauri window inside
+            // WebKit's synchronous createNewPage callback can abort the process.
+            #[cfg(target_os = "macos")]
+            {
+                let _ = &features;
+                tracing::info!(url = %url_value, "[codex-oauth] allowing native OAuth popup");
+                return tauri::webview::NewWindowResponse::Allow;
+            }
 
-            match builder.build() {
-                Ok(window) => {
-                    ownership_observation.commit();
-                    tracing::info!(url = %url_value, "[codex-oauth] created OAuth popup");
-                    return tauri::webview::NewWindowResponse::Create { window };
-                }
-                Err(err) => {
-                    tracing::warn!(url = %url_value, error = %err, "[codex-oauth] failed to create OAuth popup");
-                    return tauri::webview::NewWindowResponse::Deny;
+            #[cfg(not(target_os = "macos"))]
+            {
+                let popup_label =
+                    format!("{}-popup-{}", label_for_new_window, random_base64url(6));
+                let app_for_popup_navigation = app_for_new_window.clone();
+                let app_for_popup_close = app_for_new_window.clone();
+                let label_for_popup_navigation = label_for_new_window.clone();
+                let popup_label_for_navigation = popup_label.clone();
+                let ownership_observation =
+                    perf_utils::begin_webview_ownership_observation(popup_label.clone());
+                let builder = WebviewWindowBuilder::new(
+                    &app_for_new_window,
+                    popup_label,
+                    WebviewUrl::External("about:blank".parse().expect("valid about:blank URL")),
+                )
+                .window_features(features)
+                .title("OpenAI Sign in")
+                .inner_size(560.0, 700.0)
+                .on_navigation(move |popup_navigation_url| {
+                    let popup_url_value = popup_navigation_url.to_string();
+                    let _ = app_for_popup_navigation.emit(
+                        "codex-oauth-url-changed",
+                        serde_json::json!({
+                            "url": popup_url_value,
+                            "webviewLabel": label_for_popup_navigation,
+                        }),
+                    );
+                    if is_codex_callback_url(&popup_url_value) {
+                        let app_for_async_close = app_for_popup_close.clone();
+                        let popup_label_for_async_close = popup_label_for_navigation.clone();
+                        tauri::async_runtime::spawn(async move {
+                            tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+                            if let Some(popup) =
+                                app_for_async_close.get_webview_window(&popup_label_for_async_close)
+                            {
+                                let _ = popup.close();
+                            }
+                        });
+                    }
+                    true
+                });
+
+                match builder.build() {
+                    Ok(window) => {
+                        ownership_observation.commit();
+                        tracing::info!(url = %url_value, "[codex-oauth] created OAuth popup");
+                        return tauri::webview::NewWindowResponse::Create { window };
+                    }
+                    Err(err) => {
+                        tracing::warn!(url = %url_value, error = %err, "[codex-oauth] failed to create OAuth popup");
+                        return tauri::webview::NewWindowResponse::Deny;
+                    }
                 }
             }
         }
@@ -270,6 +286,7 @@ fn should_open_oauth_popup(value: &str) -> bool {
         .unwrap_or(false)
 }
 
+#[cfg(not(target_os = "macos"))]
 fn is_codex_callback_url(value: &str) -> bool {
     url::Url::parse(value)
         .map(|url| {

--- a/src/features/SessionSetup/components/ClaudeCodeSessionSetup/index.tsx
+++ b/src/features/SessionSetup/components/ClaudeCodeSessionSetup/index.tsx
@@ -14,6 +14,7 @@ import Button from "@src/components/Button";
 import InlineAlert from "@src/components/InlineAlert";
 import { SPINNER_TOKENS } from "@src/config/spinnerTokens";
 import { useClaudeCodeOAuthCapture } from "@src/features/SessionSetup/hooks/useClaudeCodeOAuthCapture";
+import { useOAuthBrowserAutoStart } from "@src/features/SessionSetup/hooks/useOAuthBrowserAutoStart";
 import { useWebviewPositionSync } from "@src/features/SessionSetup/hooks/useWebviewPositionSync";
 import {
   SectionContainer,
@@ -107,15 +108,7 @@ const ClaudeCodeSessionSetup: React.FC<ClaudeCodeSessionSetupProps> = ({
     }
   }, [isSignedIn, isWebviewOpen]);
 
-  useEffect(() => {
-    if (!showBrowser || isWebviewOpen || isSigningIn) return;
-
-    const timer = setTimeout(() => {
-      void startLogin();
-    }, 100);
-
-    return () => clearTimeout(timer);
-  }, [isSigningIn, isWebviewOpen, showBrowser, startLogin]);
+  useOAuthBrowserAutoStart(showBrowser, startLogin);
 
   useWebviewPositionSync(containerRef, isWebviewOpen, updatePosition);
 

--- a/src/features/SessionSetup/components/CodexSessionSetup/index.tsx
+++ b/src/features/SessionSetup/components/CodexSessionSetup/index.tsx
@@ -14,6 +14,7 @@ import Button from "@src/components/Button";
 import InlineAlert from "@src/components/InlineAlert";
 import { SPINNER_TOKENS } from "@src/config/spinnerTokens";
 import { useCodexOAuthCapture } from "@src/features/SessionSetup/hooks/useCodexOAuthCapture";
+import { useOAuthBrowserAutoStart } from "@src/features/SessionSetup/hooks/useOAuthBrowserAutoStart";
 import { useWebviewPositionSync } from "@src/features/SessionSetup/hooks/useWebviewPositionSync";
 import {
   SectionContainer,
@@ -91,15 +92,7 @@ const CodexSessionSetup: React.FC<CodexSessionSetupProps> = ({
     }
   }, [isSignedIn, isWebviewOpen]);
 
-  useEffect(() => {
-    if (!showBrowser || isWebviewOpen || isSigningIn) return;
-
-    const timer = setTimeout(() => {
-      void startLogin();
-    }, 100);
-
-    return () => clearTimeout(timer);
-  }, [isSigningIn, isWebviewOpen, showBrowser, startLogin]);
+  useOAuthBrowserAutoStart(showBrowser, startLogin);
 
   useWebviewPositionSync(containerRef, isWebviewOpen, updatePosition);
 

--- a/src/features/SessionSetup/hooks/useEmbeddedWebview.test.ts
+++ b/src/features/SessionSetup/hooks/useEmbeddedWebview.test.ts
@@ -48,6 +48,8 @@ describe("useEmbeddedWebview visibility observation", () => {
   let container: HTMLDivElement;
   let host: HTMLDivElement;
   let hostVisible: boolean;
+  let pageVisibility: DocumentVisibilityState;
+  let originalVisibilityState: PropertyDescriptor | undefined;
   let notifyIntersection: (() => void) | null;
   let notifyResize: (() => void) | null;
   let root: Root;
@@ -63,6 +65,7 @@ describe("useEmbeddedWebview visibility observation", () => {
     notifyIntersection = null;
     notifyResize = null;
     hostVisible = true;
+    pageVisibility = "visible";
     container = document.createElement("div");
     host = document.createElement("div");
     document.body.append(container, host);
@@ -105,6 +108,14 @@ describe("useEmbeddedWebview visibility observation", () => {
       configurable: true,
       get: () => (hostVisible ? document.body : null),
     });
+    originalVisibilityState = Object.getOwnPropertyDescriptor(
+      document,
+      "visibilityState"
+    );
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => pageVisibility,
+    });
     host.getBoundingClientRect = () =>
       ({
         x: 0,
@@ -123,6 +134,15 @@ describe("useEmbeddedWebview visibility observation", () => {
     act(() => root.unmount());
     container.remove();
     host.remove();
+    if (originalVisibilityState) {
+      Object.defineProperty(
+        document,
+        "visibilityState",
+        originalVisibilityState
+      );
+    } else {
+      Reflect.deleteProperty(document, "visibilityState");
+    }
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
@@ -158,6 +178,17 @@ describe("useEmbeddedWebview visibility observation", () => {
     });
     expect(latest!.isOpen).toBe(true);
     expect(vi.getTimerCount()).toBe(0);
+
+    pageVisibility = "hidden";
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+      notifyIntersection!();
+      await Promise.resolve();
+    });
+    expect(latest!.isOpen).toBe(true);
+    expect(mocks.invoke).not.toHaveBeenCalledWith("close_test_webview", {
+      label: "test-webview-id",
+    });
 
     hostVisible = false;
     await act(async () => {

--- a/src/features/SessionSetup/hooks/useEmbeddedWebview.ts
+++ b/src/features/SessionSetup/hooks/useEmbeddedWebview.ts
@@ -205,7 +205,10 @@ export function useEmbeddedWebview({
     };
   }, [commands.urlChangedEvent, ignoreAboutBlank, log]);
 
-  // KeepAlive visibility observation — auto-close when host container is hidden
+  // KeepAlive visibility observation — auto-close when the host container is
+  // removed from layout. Do not use document.visibilityState here: macOS can
+  // report the parent document as hidden while a native child webview owns the
+  // active OAuth surface. Treating that as a hidden host closes the login view.
   const wasHiddenWhileOpen = useRef(false);
 
   useEffect(() => {
@@ -215,9 +218,7 @@ export function useEmbeddedWebview({
 
     const checkVisibility = () => {
       if (transitioning) return;
-      const isHidden =
-        document.visibilityState !== "visible" ||
-        container.offsetParent === null;
+      const isHidden = container.offsetParent === null;
 
       if (isHidden && isOpen) {
         transitioning = true;
@@ -243,13 +244,11 @@ export function useEmbeddedWebview({
     intersectionObserver.observe(container);
     const resizeObserver = new ResizeObserver(checkVisibility);
     resizeObserver.observe(container);
-    document.addEventListener("visibilitychange", checkVisibility);
     checkVisibility();
 
     return () => {
       intersectionObserver.disconnect();
       resizeObserver.disconnect();
-      document.removeEventListener("visibilitychange", checkVisibility);
     };
   }, [isOpen, containerRef, commands.close, currentUrl, openWebview]);
 

--- a/src/features/SessionSetup/hooks/useOAuthBrowserAutoStart.test.ts
+++ b/src/features/SessionSetup/hooks/useOAuthBrowserAutoStart.test.ts
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { StrictMode, act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { useOAuthBrowserAutoStart } from "./useOAuthBrowserAutoStart";
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+interface HarnessProps {
+  showBrowser: boolean;
+  startLogin: () => Promise<void>;
+}
+
+const Harness = ({ showBrowser, startLogin }: HarnessProps) => {
+  useOAuthBrowserAutoStart(showBrowser, startLogin);
+  return null;
+};
+
+const renderHarness = (props: HarnessProps) =>
+  createElement(StrictMode, null, createElement(Harness, props));
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeAll(() => {
+  reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+afterAll(() => {
+  Reflect.deleteProperty(reactActEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+});
+
+it("starts at most one PKCE attempt for each browser open", async () => {
+  const firstStart = vi.fn(() => Promise.resolve());
+  const replacementStart = vi.fn(() => Promise.resolve());
+
+  await act(async () => {
+    root.render(renderHarness({ showBrowser: true, startLogin: firstStart }));
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(100);
+  });
+  expect(firstStart).toHaveBeenCalledTimes(1);
+  expect(vi.getTimerCount()).toBe(0);
+
+  await act(async () => {
+    root.render(
+      renderHarness({
+        showBrowser: true,
+        startLogin: replacementStart,
+      })
+    );
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(500);
+  });
+  expect(replacementStart).not.toHaveBeenCalled();
+  expect(vi.getTimerCount()).toBe(0);
+
+  await act(async () => {
+    root.render(
+      renderHarness({
+        showBrowser: false,
+        startLogin: replacementStart,
+      })
+    );
+  });
+  await act(async () => {
+    root.render(
+      renderHarness({
+        showBrowser: true,
+        startLogin: replacementStart,
+      })
+    );
+  });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(100);
+  });
+  expect(replacementStart).toHaveBeenCalledTimes(1);
+  expect(vi.getTimerCount()).toBe(0);
+});

--- a/src/features/SessionSetup/hooks/useOAuthBrowserAutoStart.ts
+++ b/src/features/SessionSetup/hooks/useOAuthBrowserAutoStart.ts
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from "react";
+
+const OAUTH_BROWSER_MOUNT_DELAY_MS = 100;
+
+/**
+ * Starts one OAuth attempt after its browser surface is mounted.
+ *
+ * A native webview can close independently of the React surface. That must not
+ * create a new PKCE attempt automatically: retries are an explicit user action.
+ */
+export function useOAuthBrowserAutoStart(
+  showBrowser: boolean,
+  startLogin: () => Promise<void>
+): void {
+  const startLoginRef = useRef(startLogin);
+  const startedForCurrentOpenRef = useRef(false);
+
+  useEffect(() => {
+    startLoginRef.current = startLogin;
+  }, [startLogin]);
+
+  useEffect(() => {
+    if (!showBrowser) {
+      startedForCurrentOpenRef.current = false;
+      return;
+    }
+    if (startedForCurrentOpenRef.current) return;
+
+    const timer = window.setTimeout(() => {
+      if (startedForCurrentOpenRef.current) return;
+      startedForCurrentOpenRef.current = true;
+      void startLoginRef.current();
+    }, OAUTH_BROWSER_MOUNT_DELAY_MS);
+
+    return () => window.clearTimeout(timer);
+  }, [showBrowser]);
+}


### PR DESCRIPTION
## Problem

Closes #845.

On macOS, opening an embedded Claude Code or Codex OAuth surface could close and recreate the native webview in a loop. Commit `61a08e2a3` added `document.visibilityState` to the host visibility predicate; WKWebView can mark the parent document hidden while a native child webview owns the active login surface. The setup components then interpreted the closed webview as a signal to start a fresh login, repeatedly regenerating PKCE state and driving CPU usage to 75-95%.

Google sign-in also used `WebviewWindowBuilder::build()` synchronously inside the WebKit `createNewPage` callback on macOS. That reentrant window construction matches the reported SIGABRT path and could terminate ORG2 when Google requested a popup.

## Solution

- Treat an embedded webview host as hidden only when its container leaves layout, while retaining observer-driven close/reopen behavior for actual KeepAlive host changes.
- Add a shared OAuth browser auto-start hook that permits one PKCE attempt per browser open, survives React StrictMode effect replay, and leaves retries as an explicit user action.
- On macOS, hand Claude Google and Codex provider popups to Wry with `NewWindowResponse::Allow`. Wry reuses the caller WKWebView configuration, preserves `window.opener`, and avoids constructing a Tauri window from inside `createNewPage`.
- Add regression coverage for parent-document visibility and one-attempt-per-open lifecycle behavior.

The resulting invariants are: parent document visibility alone cannot close an active login surface; a mounted browser surface cannot start an unbounded sequence of PKCE attempts; and macOS OAuth popup callbacks do not synchronously build another Tauri window.

## Potential risks

- macOS provider popups are now owned by Wry, so ORG2 no longer observes popup navigation or applies its host-managed delayed close logic on that platform. The real Claude Code Google flow, including authorization completion and credential persistence, succeeded; other providers with different popup behavior were not authenticated end to end.
- The embedded OAuth webview remains allocated while the app is backgrounded if its host container is still mounted. This preserves the in-progress PKCE flow; measured idle CPU returned to 0-0.1% after closing, and RSS returned below its pre-cycle sample.
- Linux host-managed popup behavior and existing Windows behavior are unchanged. No storage schema, serialized payload, RPC contract, or historical data migration changes are included, so rollback is a normal code revert.
- Manual authorization created a persistent Claude Code OAuth credential only in isolated Instance 3. No credential values, account identifiers, or authorization codes are included in this PR or its logs.

## Verification

Automated checks:

- `pnpm vitest run src/features/SessionSetup/hooks/useEmbeddedWebview.test.ts src/features/SessionSetup/hooks/useOAuthBrowserAutoStart.test.ts src/features/SessionSetup/hooks/__tests__/useOAuthCapture.test.ts` — 22 passed.
- `cargo test --lib oauth::tests --no-fail-fast` — 7 passed.
- `pnpm typecheck` — passed.
- ESLint on all changed TypeScript files — passed.
- `pnpm run check:e2e-oauth-guards` — passed.
- `rustfmt --edition 2021 --check` on both changed OAuth adapters — passed.
- Commit hook `cargo clippy -p org2` — passed.
- `pnpm run tauri:build:fast -- --instance 3` — produced the isolated macOS instance app.

Manual checks on macOS 26.2 (25C56), isolated Instance 3:

- Claude login remained on one PKCE URL instead of looping; steady CPU was about 0.2% versus 75-95% on the released v1.2.6 build.
- Opened and closed the real `accounts.google.com` Claude popup three times without SIGABRT or crash logs.
- Opened and closed the full Claude OAuth surface three times; each open generated exactly one new PKCE attempt.
- Google popup CPU was 1.5-2.9%; after closing all OAuth surfaces CPU returned to 0-0.1% and RSS settled at about 165.7 MiB.
- Codex sign-in and its Google page also loaded without a crash.
- Performed a clean rebuild of version 1.2.6 from commit `4b6e228ad`; the resulting Instance 3 app rendered successfully from the isolated profile.
- A user completed the real Claude Code Google OAuth flow. The isolated credential store updated with an enabled Claude Code OAuth record, no validation error, zero refresh failures, and no upstream error status; credential values were not inspected or printed.
- The app remained alive after authorization. A post-login process sample showed about 1.5% CPU, and the recent macOS unified log contained no matching WebKit, SIGABRT, panic, abort, crash, or OAuth error event.

The full frontend and Rust test suites were not run; verification was scoped to the owning OAuth boundaries, full TypeScript checking, clippy, a complete macOS app build, and end-to-end Claude Code OAuth authorization.

## Audit

- Architecture audit: all 10 layers reviewed. The change is confined to control flow, lifecycle ownership, platform popup dispatch, and tests; domain shapes, public wire contracts, initialization, persistence, and serialization remain unchanged.
- Performance guard: pass. The only timer is a bounded 100 ms one-shot that is cleaned up; observers disconnect on cleanup; three repeated popup and surface cycles showed no CPU loop or retained-memory staircase.
- No screenshot is attached because there is no layout or styling change; the relevant evidence is native popup creation, process survival, stable PKCE state, successful authorization, and measured lifecycle behavior.