### PR TITLE
fix(git): unify transient error detection

### DIFF
--- a/src-tauri/crates/git-api/src/commands/streaming.rs
+++ b/src-tauri/crates/git-api/src/commands/streaming.rs
@@ -24,7 +24,7 @@ use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 
-use git::tokio_git_command;
+use git::{tokio_git_command, util::is_transient_error};
 
 use super::commit::append_orgii_coauthor_trailer;
 
@@ -165,15 +165,6 @@ pub struct CommitStreamQuery {
 pub struct StageStreamQuery {
     pub path: String,
     pub files: String, // JSON array of files
-}
-
-/// Check if an error is a transient system error that can be retried
-pub(crate) fn is_transient_error(error_msg: &str) -> bool {
-    error_msg.contains("Bad file descriptor")
-        || error_msg.contains("Resource temporarily unavailable")
-        || error_msg.contains("os error 9")
-        || error_msg.contains("Too many open files")
-        || error_msg.contains("os error 24")
 }
 
 /// Configure command with pre_exec to close inherited file descriptors on Unix

--- a/src-tauri/crates/git-api/src/commands/tests/streaming_tests.rs
+++ b/src-tauri/crates/git-api/src/commands/tests/streaming_tests.rs
@@ -1,4 +1,5 @@
-use crate::commands::streaming::{detect_error_type_from_output, is_transient_error};
+use crate::commands::streaming::detect_error_type_from_output;
+use git::util::is_transient_error;
 
 // ============================================
 // detect_error_type_from_output — push

--- a/src-tauri/crates/git/src/bundle.rs
+++ b/src-tauri/crates/git/src/bundle.rs
@@ -10,7 +10,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Stdio;
 
-use crate::util::{close_inherited_fds, git_command};
+use crate::util::{close_inherited_fds, git_command, is_transient_error};
 use tauri::Emitter;
 
 // ============================================
@@ -51,15 +51,6 @@ const MAX_BUNDLE_SIZE: u64 = 200 * 1024 * 1024;
 // ============================================
 // Helper Functions
 // ============================================
-
-/// Check if an error is a transient system error that can be retried
-fn is_transient_error(error_msg: &str) -> bool {
-    error_msg.contains("Bad file descriptor")
-        || error_msg.contains("Resource temporarily unavailable")
-        || error_msg.contains("os error 9")
-        || error_msg.contains("Too many open files")
-        || error_msg.contains("os error 24")
-}
 
 /// Helper to run git commands directly, closing inherited file descriptors
 /// Uses pre_exec on Unix to close FDs 3-1024 before exec to avoid WebView FD inheritance issues


### PR DESCRIPTION
## Problem

The required `cargo clippy --workspace --all-targets -- -D warnings` check fails on `develop` and on unrelated pull requests with `ambiguous glob re-exports` in `git_api::commands`. `streaming` exposed a crate-visible `is_transient_error` while `utils` re-exported the canonical `git::util::is_transient_error`; glob-exporting both modules made the command namespace ambiguous. `git::bundle` also carried a third byte-for-byte copy of the same predicate.

## Solution

Make `git::util::is_transient_error` the single implementation. The streaming and bundle paths now import that canonical helper, and the streaming tests exercise the canonical function directly. The existing public `git_api::commands::is_transient_error` path remains available through `utils`, so no caller-facing API changes.

The resulting invariant is one transient-error classifier for all Git retry paths and one unambiguous command export.

## Potential risks

Future edits to the canonical classifier now affect both streaming and bundle retry behavior together; that coupling is intentional, but changes to the shared predicate should keep both consumers in mind. The current predicates were byte-for-byte identical, so this PR does not change which errors are retried.

No dependency, lockfile, persistence, schema, wire-format, or UI behavior changes are included. Cross-platform runtime behavior was not manually exercised; workspace compilation covers all local targets, and CI remains the source for runner-platform validation. Rollback is a revert of commit `10b5aada7`.

## Verification

- Published PR CI [run 32420916073](https://github.com/org2AI/ORG2/actions/runs/32420916073) — Frontend typecheck/lint/unit tests passed; Rust workspace clippy passed; AI attribution passed.
- `node scripts/tauri/prepare-sidecars.cjs --profile debug` — passed; staged the sidecar required by the Tauri build script.
- `cargo test -p git --lib` — passed, 134/134.
- `cargo test -p git_api --lib` — passed, 90/90.
- `cargo check --workspace --all-targets` — passed.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed with the exact CI command and a worktree-local target directory.
- `rustfmt --edition 2021 --check crates/git/src/bundle.rs crates/git-api/src/commands/streaming.rs crates/git-api/src/commands/tests/streaming_tests.rs` — passed.
- Commit hook — passed scoped clippy for `git` and `git_api`.
- `cargo fmt --all -- --check` — not clean on the untouched `develop` baseline; it reports pre-existing formatting diffs outside these three changed files. The changed files pass the targeted `rustfmt --check` command above.
- UI screenshots are not applicable because this PR has no user-visible UI change.

## Audit

Architecture audit covered all 10 layers. Compilation and warnings pass; the duplicate implementation class was swept across the Rust workspace and reduced to the canonical helper; naming and ownership now point to the shared Git utility layer. No default branches, domain leakage, wire payloads, initialization paths, or multi-field resolvers are changed, so layers 5 and 8-10 are non-applicable beyond confirming the diff does not enter those boundaries.