### PR TITLE
fix(markdown): open relative repo file links

### DIFF
--- a/src/components/MarkDown/MarkDownImpl.tsx
+++ b/src/components/MarkDown/MarkDownImpl.tsx
@@ -37,7 +37,7 @@ import LinkHoverCard from "./LinkHoverCard";
 import MarkdownLocalImage, { openLocalMarkdownRef } from "./MarkdownLocalImage";
 import MermaidBlock from "./MermaidBlock";
 import "./index.scss";
-import { classifyMarkdownImageSrc } from "./markdownImageSrc";
+import { classifyMarkdownLinkTarget } from "./markdownLinkTarget";
 import { markdownUrlTransform } from "./markdownUrlTransform";
 import {
   detectCodeType,
@@ -411,21 +411,20 @@ const MarkdownComponent: React.FC<MarkdownProps> = ({
     (event: React.MouseEvent<HTMLAnchorElement>, href: string) => {
       event.preventDefault();
       event.stopPropagation();
-      // Local filesystem hrefs (agents link generated artifacts by path)
-      // open in the WorkStation / editor — the browser app cannot load a
-      // filesystem path. Workspace-relative hrefs are deliberately not
-      // resolved here: only unambiguous local refs are rerouted.
-      const localSource = classifyMarkdownImageSrc(href);
-      if (localSource.kind === "local") {
+      const linkTarget = classifyMarkdownLinkTarget(
+        href,
+        activeWorkspaceRootPath
+      );
+      if (linkTarget.kind === "local") {
         void openLocalMarkdownRef(
-          localSource.path,
-          localSource.homeRelative === true
+          linkTarget.path,
+          linkTarget.homeRelative === true
         );
         return;
       }
-      openUrlInBrowserApp(href);
+      openUrlInBrowserApp(linkTarget.url);
     },
-    []
+    [activeWorkspaceRootPath]
   );
 
   // Memoize dark mode calculation

--- a/src/components/MarkDown/markdownLinkTarget.test.ts
+++ b/src/components/MarkDown/markdownLinkTarget.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import { classifyMarkdownLinkTarget } from "./markdownLinkTarget";
+
+describe("classifyMarkdownLinkTarget", () => {
+  it.each([
+    "src/engines/ChatPanel/ChatHistory/components/TurnMetadataFooter/index.tsx:310",
+    "src/engines/ChatPanel/blocks/ToolCallBlock/cards/WebsiteCard.tsx:84",
+    "src/components/MarkDown/LinkHoverCard.tsx:80",
+    "src/modules/WorkStation/shared/StatusBar/PortsStatusMenu.tsx:128",
+    "src/engines/Simulator/components/Dock/config.ts:33",
+  ])("resolves a source-located repo href inside the workspace: %s", (href) => {
+    expect(classifyMarkdownLinkTarget(href, "/repo")).toEqual({
+      kind: "local",
+      path: `/repo/${href}`,
+    });
+  });
+
+  it("resolves a basename source href that generic URL parsing treats as a scheme", () => {
+    expect(classifyMarkdownLinkTarget("WebsiteCard.tsx:84", "/repo")).toEqual({
+      kind: "local",
+      path: "/repo/WebsiteCard.tsx:84",
+    });
+  });
+
+  it("resolves file-shaped repo hrefs without line suffixes", () => {
+    expect(classifyMarkdownLinkTarget("docs/architecture.md", "/repo")).toEqual(
+      { kind: "local", path: "/repo/docs/architecture.md" }
+    );
+    expect(classifyMarkdownLinkTarget("./package.json", "/repo")).toEqual({
+      kind: "local",
+      path: "/repo/package.json",
+    });
+    expect(classifyMarkdownLinkTarget("Dockerfile", "/repo")).toEqual({
+      kind: "local",
+      path: "/repo/Dockerfile",
+    });
+    expect(classifyMarkdownLinkTarget("src/My%20View.tsx:12", "/repo")).toEqual(
+      {
+        kind: "local",
+        path: "/repo/src/My View.tsx:12",
+      }
+    );
+  });
+
+  it("uses the active workspace's path separator", () => {
+    expect(
+      classifyMarkdownLinkTarget("src/components/View.tsx:12", "C:\\repo")
+    ).toEqual({
+      kind: "local",
+      path: "C:\\repo\\src\\components\\View.tsx:12",
+    });
+  });
+
+  it("keeps route-like relative hrefs, anchors, and queries in the browser", () => {
+    for (const href of [
+      "docs/getting-started",
+      "account/settings/",
+      "#verification",
+      "?tab=files",
+      "//example.com/docs/start",
+      "example.com/index.html",
+      "localhost:3000",
+      "mailto:source.ts",
+      "vscode:source.ts:12",
+    ]) {
+      expect(classifyMarkdownLinkTarget(href, "/repo")).toEqual({
+        kind: "browser",
+        url: href,
+      });
+    }
+  });
+
+  it("does not resolve traversal outside the active workspace", () => {
+    for (const href of [
+      "../../outside/secrets.txt:12",
+      "%2e%2e/%2e%2e/outside/secrets.txt:12",
+    ]) {
+      expect(classifyMarkdownLinkTarget(href, "/repo")).toEqual({
+        kind: "browser",
+        url: href,
+      });
+    }
+  });
+
+  it("preserves absolute local and remote link classification", () => {
+    expect(
+      classifyMarkdownLinkTarget("/Users/me/project/View.tsx:220", "/repo")
+    ).toEqual({ kind: "local", path: "/Users/me/project/View.tsx:220" });
+    expect(
+      classifyMarkdownLinkTarget("https://example.com/docs/start", "/repo")
+    ).toEqual({
+      kind: "browser",
+      url: "https://example.com/docs/start",
+    });
+  });
+
+  it("does not guess a relative filesystem path without an active workspace", () => {
+    expect(classifyMarkdownLinkTarget("src/View.tsx:12", "")).toEqual({
+      kind: "browser",
+      url: "src/View.tsx:12",
+    });
+  });
+});

--- a/src/components/MarkDown/markdownLinkTarget.ts
+++ b/src/components/MarkDown/markdownLinkTarget.ts
@@ -1,0 +1,110 @@
+import { parseMarkdownFileRef } from "./markdownFileRef";
+import {
+  type MarkdownImageSource,
+  classifyMarkdownImageSrc,
+} from "./markdownImageSrc";
+
+export type MarkdownLinkTarget =
+  | Extract<MarkdownImageSource, { kind: "local" }>
+  | { kind: "browser"; url: string };
+
+const WELL_KNOWN_REPO_FILENAMES = new Set([
+  "dockerfile",
+  "gemfile",
+  "license",
+  "makefile",
+  "notice",
+  "procfile",
+]);
+
+const SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:/i;
+
+function decodeMaybeEncodedHref(href: string): string {
+  if (!href.includes("%")) return href;
+  try {
+    return decodeURIComponent(href);
+  } catch {
+    return href;
+  }
+}
+
+function resolveWorkspaceRelativeHref(href: string, workspaceRoot: string) {
+  const separator = workspaceRoot.includes("\\") ? "\\" : "/";
+  const normalizedRoot = workspaceRoot.trim().replace(/[\\/]+$/, "");
+  const relativePath = decodeMaybeEncodedHref(href.trim())
+    .replace(/^\.([\\/])/, "")
+    .replace(/[\\/]/g, separator);
+  return `${normalizedRoot}${separator}${relativePath}`;
+}
+
+export function isWorkspaceRelativeMarkdownFileHref(href: string): boolean {
+  const trimmed = decodeMaybeEncodedHref(href.trim());
+  if (!trimmed || trimmed.startsWith("#") || trimmed.startsWith("?")) {
+    return false;
+  }
+
+  const fileRef = parseMarkdownFileRef(trimmed);
+  const normalizedPath = fileRef.path.replace(/\\/g, "/");
+  const segments = normalizedPath.split("/").filter(Boolean);
+  if (segments.length === 0 || segments.includes("..")) return false;
+  if (
+    segments.length > 1 &&
+    !segments[0].startsWith(".") &&
+    /^[a-z0-9-]+(?:\.[a-z0-9-]+)+$/i.test(segments[0])
+  ) {
+    return false;
+  }
+
+  const basename = segments[segments.length - 1]?.toLowerCase() ?? "";
+  const hasFileShapedBasename =
+    WELL_KNOWN_REPO_FILENAMES.has(basename) ||
+    /\.[a-z][a-z0-9.-]*$/i.test(basename);
+
+  // A basename with a source line (for example `WebsiteCard.tsx:84`) looks
+  // like a URI scheme to generic URL parsers. Admit that exact file shape,
+  // but keep real and nested schemes such as `mailto:` or `vscode:` remote.
+  if (
+    SCHEME_PATTERN.test(trimmed) &&
+    (fileRef.line === undefined ||
+      fileRef.path.includes(":") ||
+      !hasFileShapedBasename)
+  ) {
+    return false;
+  }
+
+  if (fileRef.line !== undefined) return true;
+  if (normalizedPath.startsWith("./")) return true;
+
+  return hasFileShapedBasename;
+}
+
+/**
+ * Classify a rendered markdown href without turning every relative web route
+ * into a workspace path. Agent-authored source references carry a line suffix
+ * or a file-shaped basename, which gives us a narrow local-file signal.
+ */
+export function classifyMarkdownLinkTarget(
+  href: string,
+  workspaceRootPath?: string | null
+): MarkdownLinkTarget {
+  if (/^\/\/[^/]/.test(href.trim())) {
+    return { kind: "browser", url: href };
+  }
+
+  const directSource = classifyMarkdownImageSrc(href);
+  if (directSource.kind === "local") return directSource;
+
+  const workspaceRoot = workspaceRootPath?.trim();
+  if (workspaceRoot && isWorkspaceRelativeMarkdownFileHref(href)) {
+    return {
+      kind: "local",
+      path: resolveWorkspaceRelativeHref(href, workspaceRoot),
+    };
+  }
+
+  if (directSource.kind === "remote") {
+    return { kind: "browser", url: directSource.src };
+  }
+
+  return { kind: "browser", url: href };
+}

--- a/src/components/MarkDown/markdownUrlTransform.test.ts
+++ b/src/components/MarkDown/markdownUrlTransform.test.ts
@@ -21,6 +21,7 @@ describe("markdown url transform", () => {
       ""
     );
     expect(defaultUrlTransform("C:\\repo\\src\\View.tsx:220")).toBe("");
+    expect(defaultUrlTransform("WebsiteCard.tsx:84")).toBe("");
   });
 
   it("passes a valid session reference through on a link href", () => {
@@ -34,6 +35,14 @@ describe("markdown url transform", () => {
     "asset://localhost/Users/me/project/View.tsx:220",
     "~/project/View.tsx:220",
   ])("passes a supported local file reference through on href: %s", (href) => {
+    expect(markdownUrlTransform(href, "href")).toBe(href);
+  });
+
+  it.each([
+    "WebsiteCard.tsx:84",
+    "src/components/MarkDown/LinkHoverCard.tsx:80",
+    "docs/architecture.md",
+  ])("preserves a workspace-relative file href: %s", (href) => {
     expect(markdownUrlTransform(href, "href")).toBe(href);
   });
 

--- a/src/components/MarkDown/markdownUrlTransform.ts
+++ b/src/components/MarkDown/markdownUrlTransform.ts
@@ -17,11 +17,13 @@ import { defaultUrlTransform } from "react-markdown";
 import { parseCloudSessionReference } from "@src/features/Org2Cloud/cloudSessionReference";
 
 import { classifyMarkdownImageSrc } from "./markdownImageSrc";
+import { isWorkspaceRelativeMarkdownFileHref } from "./markdownLinkTarget";
 
 export function markdownUrlTransform(value: string, key?: string): string {
   if (key === "href") {
     if (parseCloudSessionReference(value)) return value;
     if (classifyMarkdownImageSrc(value).kind === "local") return value;
+    if (isWorkspaceRelativeMarkdownFileHref(value)) return value;
   }
 
   return defaultUrlTransform(value);


### PR DESCRIPTION
## Problem

Follow-up to #847: relative repository file hrefs such as `src/components/MarkDown/LinkHoverCard.tsx:80` still bypassed local file navigation. The markdown click handler classified hrefs without the active workspace root, so relative targets fell through to `open-url-in-browser`. Basename references such as `WebsiteCard.tsx:84` were additionally removed by React Markdown's URL sanitizer because they resemble an unknown URI scheme.

This affected the file references shown in the reported chat response, including `TurnMetadataFooter/index.tsx:310`, `WebsiteCard.tsx:84`, `LinkHoverCard.tsx:80`, `PortsStatusMenu.tsx:128`, and `Dock/config.ts:33`.

## Solution

Add a markdown-link classifier that resolves source-located and file-shaped relative hrefs against the active workspace before dispatching the existing local file opener. Preserve those same hrefs through URL sanitization, including basename-plus-line references. The opener from #847 continues to split `:line` from the resolved path and target the correct editor line.

Keep route-like relative URLs, anchors, queries, domain-like paths, protocol-relative URLs, URI schemes, and links without an active workspace on the browser path. Reject literal and percent-encoded `..` traversal instead of resolving it outside the workspace. Normalize percent-encoded paths and Windows path separators when resolving approved file targets.

The resulting invariant is that a relative href is treated as a workspace file only when it has a source-line or file-shaped signal and passes the workspace-boundary checks.

## Potential risks

A relative web route ending in a file extension, such as `downloads/release.html`, will now be interpreted as a workspace file when a workspace is active. Domain-like first segments and route-like extensionless hrefs are explicitly kept as browser targets, but intent remains inherently ambiguous for extension-bearing relative links.

The classifier resolves the href supplied by markdown; it does not search the repository for an abbreviated or stale path. Such a target will show the existing file-not-found state rather than guessing among similarly named files. There are no dependency, persistence, schema, public API, or wire-format changes. Rollback is a straight revert of commit `e5a1ef5e3`.

## Audit

Reviewed absolute and relative POSIX paths, Windows paths, percent encoding, source-line suffixes, basename source references, ordinary HTTP(S) URLs, scheme-like links, anchors, query-only links, protocol-relative URLs, domain-like paths, missing workspace state, and traversal attempts.

This is a focused interaction bug fix touching one existing component rather than a component refactor or UI consistency sweep, so the repository's `frontend-ui-audit` exemption for single-file bug fixes applies.

## Verification

- `npx vitest run src/components/MarkDown/markdownLinkTarget.test.ts src/components/MarkDown/markdownUrlTransform.test.ts src/components/MarkDown/markdownFileRef.test.ts src/components/MarkDown/MarkdownLocalImage.test.ts` — 4 files, 37 tests passed.
- `npx prettier --check src/components/MarkDown/MarkDownImpl.tsx src/components/MarkDown/markdownLinkTarget.ts src/components/MarkDown/markdownLinkTarget.test.ts src/components/MarkDown/markdownUrlTransform.ts src/components/MarkDown/markdownUrlTransform.test.ts` — passed.
- `npx eslint src/components/MarkDown/MarkDownImpl.tsx src/components/MarkDown/markdownLinkTarget.ts src/components/MarkDown/markdownLinkTarget.test.ts src/components/MarkDown/markdownUrlTransform.ts src/components/MarkDown/markdownUrlTransform.test.ts` — passed.
- `npm run typecheck` — passed.
- `git diff --check` — passed.
- Commit hooks reran lint-staged formatting/lint and scoped TypeScript checks — passed.

No new screenshot is included because the rendered link appearance is unchanged; this corrects click routing. The exact href shapes from the supplied screenshot are regression-tested at the owning classifier boundary.
