### PR TITLE
feat(chat): view the raw prompt sent to the model per turn

### DIFF
--- a/src/engines/ChatPanel/ChatItems/RawPromptToggle.tsx
+++ b/src/engines/ChatPanel/ChatItems/RawPromptToggle.tsx
@@ -1,0 +1,202 @@
+/**
+ * RawPromptToggle
+ *
+ * Toolbar button + anchored panel that reveals the exact prompt string a user
+ * turn handed to the model.
+ *
+ * The bubble it sits under is a rendering of that prompt, not the prompt: pill
+ * tokens are drawn as badges, the auto-expanded reference block is stripped,
+ * and external-CLI envelopes are normalized away. When the question is *what
+ * the model actually read* — an injected SKILL.md, an expanded file, a paste
+ * that silently truncated — the bubble is the wrong artifact to inspect. This
+ * panel shows the wire content verbatim, in monospace, with a copy action.
+ *
+ * `Braces` is deliberate: it is already this app's glyph for "view raw" on the
+ * session-level transcript action (`SessionHeaderActionsMenu`), and this is the
+ * same idea one turn down.
+ */
+import { useAtomValue } from "jotai";
+import { Braces } from "lucide-react";
+import React, { memo, useCallback, useMemo, useRef } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+
+import {
+  CHAT_BUBBLE_TOOLBAR_BUTTON_CLASS,
+  ChatBubbleCopyButton,
+} from "@src/components/ChatBubble";
+import { DROPDOWN_CLASSES } from "@src/components/Dropdown/tokens";
+import { getDropdownPanelStyle } from "@src/hooks/dropdown/dropdownPanelStyle";
+import { useDropdownEngine } from "@src/hooks/dropdown/useDropdownEngine";
+import { sessionByIdAtom } from "@src/store/session/sessionAtom";
+import { toIntlLocaleTag } from "@src/util/data/formatters/date";
+
+import { describeModelLabel } from "./rawPromptModelLabel";
+
+/**
+ * Design cap for the panel. `getDropdownPanelStyle` only ever shrinks it, so a
+ * tall viewport cannot stretch the panel past the height intended here.
+ */
+const PANEL_MAX_HEIGHT = 420;
+
+/** Wide enough for an expanded file block without crowding the chat column. */
+const PANEL_WIDTH = "min(560px, calc(100vw - 24px))";
+
+interface RawPromptToggleProps {
+  /** Wire content for this turn — never the rendered bubble text. */
+  rawText: string;
+  /** Names the model in the panel header. */
+  sessionId: string;
+  /**
+   * Lifted so the hover-revealed toolbar can stay visible while the panel is
+   * open. Ancestor `opacity-0` cannot be undone by a descendant, so the
+   * trigger would otherwise vanish out from under its own panel the moment
+   * focus moved into the portal (e.g. selecting text).
+   */
+  onOpenChange?: (open: boolean) => void;
+}
+
+/**
+ * Panel body. Split out so the session subscription that names the model is
+ * mounted only while the panel is open — every user bubble in the history
+ * renders the trigger, but at most one panel exists at a time.
+ */
+const RawPromptPanelBody: React.FC<{ rawText: string; sessionId: string }> = ({
+  rawText,
+  sessionId,
+}) => {
+  const { t, i18n } = useTranslation("sessions");
+  const session = useAtomValue(sessionByIdAtom(sessionId));
+
+  // The session's model, not a per-turn record: nothing on the user-message
+  // event names the model that answered it. Accurate unless the model was
+  // switched after this turn ran. `variant` carries the reasoning effort for
+  // the ids that encode one, and is empty for the ids that do not.
+  const model = describeModelLabel(session?.model);
+
+  const lengthLabel = t("chat.rawPrompt.length", {
+    defaultValue: "{{length}} chars",
+    length: rawText.length.toLocaleString(
+      toIntlLocaleTag(i18n.resolvedLanguage)
+    ),
+  });
+
+  return (
+    <>
+      <div className="flex shrink-0 items-center gap-2 border-b border-border-2/60 px-3 py-1.5">
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-[12px] font-medium text-text-1">
+            {t("chat.rawPrompt.title", {
+              defaultValue: "Raw prompt sent to AI",
+            })}
+          </div>
+          <div className="flex items-center gap-1.5 text-[11px] text-text-3">
+            {model && (
+              <>
+                <span className="truncate">{model.name}</span>
+                {model.variant && (
+                  <span
+                    className="shrink-0 rounded bg-fill-2 px-1 text-text-2"
+                    data-testid="chat-message-raw-prompt-effort"
+                  >
+                    {model.variant}
+                  </span>
+                )}
+                <span aria-hidden="true">·</span>
+              </>
+            )}
+            <span className="shrink-0">{lengthLabel}</span>
+          </div>
+        </div>
+        <ChatBubbleCopyButton content={rawText} placement="toolbar" />
+      </div>
+      <pre className="allow-select scrollbar-overlay min-h-0 flex-1 overflow-auto whitespace-pre-wrap break-words px-3 py-2 font-mono text-[12px] leading-relaxed text-text-1">
+        {rawText}
+      </pre>
+    </>
+  );
+};
+
+const RawPromptToggleComponent: React.FC<RawPromptToggleProps> = ({
+  rawText,
+  sessionId,
+  onOpenChange,
+}) => {
+  const { t } = useTranslation("sessions");
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const { isOpen, isPositioned, toggle, panelRef, panelPosition } =
+    useDropdownEngine<HTMLButtonElement>({
+      anchorRef: buttonRef,
+      placement: "auto",
+      align: "right",
+      onOpenChange,
+    });
+
+  const panelStyle = useMemo<React.CSSProperties>(
+    () => ({
+      ...getDropdownPanelStyle(panelPosition, {
+        widthMode: "none",
+        maxHeightCap: PANEL_MAX_HEIGHT,
+      }),
+      width: PANEL_WIDTH,
+    }),
+    [panelPosition]
+  );
+
+  const label = t("chat.rawPrompt.view", { defaultValue: "View raw prompt" });
+
+  const handleClick = useCallback(
+    (event: React.MouseEvent) => {
+      event.stopPropagation();
+      toggle();
+    },
+    [toggle]
+  );
+
+  const stopPropagation = useCallback((event: React.MouseEvent) => {
+    event.stopPropagation();
+  }, []);
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        data-testid="chat-message-raw-prompt-toggle"
+        title={label}
+        aria-label={label}
+        aria-expanded={isOpen}
+        aria-haspopup="dialog"
+        className={`${CHAT_BUBBLE_TOOLBAR_BUTTON_CLASS} ${
+          isOpen ? "bg-fill-2 text-text-1" : "text-text-3 hover:text-text-1"
+        }`}
+        onClick={handleClick}
+      >
+        <Braces size={14} strokeWidth={1.75} />
+      </button>
+
+      {isOpen &&
+        isPositioned &&
+        createPortal(
+          <div
+            ref={panelRef}
+            role="dialog"
+            aria-label={label}
+            data-testid="chat-message-raw-prompt-panel"
+            className={`${DROPDOWN_CLASSES.menuPanelWithHeaderBase} fixed flex flex-col`}
+            style={panelStyle}
+            onClick={stopPropagation}
+          >
+            <RawPromptPanelBody rawText={rawText} sessionId={sessionId} />
+          </div>,
+          document.body
+        )}
+    </>
+  );
+};
+
+const RawPromptToggle = memo(RawPromptToggleComponent);
+RawPromptToggle.displayName = "RawPromptToggle";
+
+export default RawPromptToggle;

--- a/src/engines/ChatPanel/ChatItems/UserChatItem.test.ts
+++ b/src/engines/ChatPanel/ChatItems/UserChatItem.test.ts
@@ -58,3 +58,56 @@ describe("UserChatItem shared sender presentation", () => {
     expect(markup).not.toContain("shared-message-sender-avatar");
   });
 });
+
+describe("UserChatItem raw prompt affordance", () => {
+  function renderUserMessage(
+    overrides: Parameters<typeof makeSessionEvent>[0]
+  ): string {
+    return renderToStaticMarkup(
+      createElement(UserChatItem, {
+        chatItem: makeChatItem(
+          makeSessionEvent({
+            id: "user-message-raw",
+            sessionId: "agentsession-local",
+            source: "user",
+            actionType: "raw",
+            functionName: "user_message",
+            displayVariant: "message",
+            ...overrides,
+          })
+        ),
+      })
+    );
+  }
+
+  it("offers the raw-prompt toggle on a turn that carries wire content", () => {
+    const markup = renderUserMessage({
+      displayText: "setup-repo [skill:/setup-repo]",
+      result: {
+        type: "user",
+        message: {
+          role: "user",
+          content:
+            "setup-repo [skill:/setup-repo]\n\n---\n**Referenced content (auto-expanded):**\n\nSKILL body",
+        },
+      },
+    });
+
+    expect(markup).toContain('data-testid="chat-message-raw-prompt-toggle"');
+    // Closed by default — the panel is portaled only once the user opens it.
+    expect(markup).not.toContain('data-testid="chat-message-raw-prompt-panel"');
+  });
+
+  it("omits the toggle when the turn has no prompt text to show", () => {
+    const markup = renderUserMessage({
+      displayText: "",
+      args: { cached_files: ["/tmp/screenshot.png"] },
+      result: { type: "user", message: { role: "user", content: "   " } },
+    });
+
+    expect(markup).toContain("screenshot.png");
+    expect(markup).not.toContain(
+      'data-testid="chat-message-raw-prompt-toggle"'
+    );
+  });
+});

--- a/src/engines/ChatPanel/ChatItems/UserChatItem.tsx
+++ b/src/engines/ChatPanel/ChatItems/UserChatItem.tsx
@@ -41,8 +41,10 @@ import { imageRefToRustPath } from "@src/util/file/imageRefs";
 import UserMessageContent from "../ChatHistory/components/UserMessageContent";
 import InputArea from "../InputArea";
 import { stripExpandedPillContent } from "../InputArea/utils/pillContentParser";
+import RawPromptToggle from "./RawPromptToggle";
 import { useSharedConversationSender } from "./SharedConversationSenderContext";
 import { normalizeUserMessageText } from "./normalizeUserMessageText";
+import { resolveRawUserPrompt } from "./rawUserPrompt";
 import { resolveUserMessageSide } from "./userMessageSide";
 
 const USER_MSG_MAX_LINES = 3;
@@ -208,6 +210,7 @@ const UserChatItem = ({
   const [isEditing, setIsEditing] = useState(false);
 
   const [isExpanded, setIsExpanded] = useState(false);
+  const [isRawPromptOpen, setIsRawPromptOpen] = useState(false);
   const [previewFile, setPreviewFile] = useState<string | null>(null);
   // Editable copy of the message's attached images; seeded on edit entry so
   // the user can remove stale duplicates before resending.
@@ -275,6 +278,11 @@ const UserChatItem = ({
     if (textToCheck.split("\n").length > USER_MSG_MAX_LINES) return true;
     return textToCheck.length > USER_MSG_MAX_CHARS;
   }, [editedText, fullContent]);
+
+  // The wire prompt behind this bubble. `fullContent` is a rendering of it
+  // (pills as badges, expansion block stripped, envelope normalized), so the
+  // raw string is only reachable through the event itself.
+  const rawPrompt = useMemo(() => resolveRawUserPrompt(event), [event]);
 
   const prPillCards = useMemo(
     () => extractPrPillCards(fullContent),
@@ -483,18 +491,25 @@ const UserChatItem = ({
           )}
         </div>
       </div>
-      {(timestampLabel || fullContent || toolbarActions) && (
+      {(timestampLabel || fullContent || rawPrompt || toolbarActions) && (
         <div className="relative mt-1 flex min-h-6 items-center px-1 text-[11px] leading-none text-text-3">
-          {(fullContent || toolbarActions) && (
+          {(fullContent || rawPrompt || toolbarActions) && (
             <div
-              className={`absolute top-1/2 flex -translate-y-1/2 items-center gap-1 opacity-0 focus-within:opacity-100 group-hover/msg:opacity-100 ${
-                isRemoteSharedMessage ? "left-full ml-1" : "right-full mr-1"
-              }`}
+              className={`absolute top-1/2 flex -translate-y-1/2 items-center gap-1 focus-within:opacity-100 group-hover/msg:opacity-100 ${
+                isRawPromptOpen ? "opacity-100" : "opacity-0"
+              } ${isRemoteSharedMessage ? "left-full ml-1" : "right-full mr-1"}`}
             >
               {fullContent && (
                 <ChatBubbleCopyButton
                   content={fullContent}
                   placement="toolbar"
+                />
+              )}
+              {rawPrompt.trim() && event?.sessionId && (
+                <RawPromptToggle
+                  rawText={rawPrompt}
+                  sessionId={event.sessionId}
+                  onOpenChange={setIsRawPromptOpen}
                 />
               )}
               {isEditableDisplay && onRestoreCheckpoint && (

--- a/src/engines/ChatPanel/ChatItems/__tests__/RawPromptToggle.test.ts
+++ b/src/engines/ChatPanel/ChatItems/__tests__/RawPromptToggle.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+/**
+ * Interaction coverage for the per-turn raw-prompt panel.
+ *
+ * The SSR assertions in `UserChatItem.test.ts` only prove the trigger is
+ * wired; the panel is portaled and therefore only observable once opened
+ * under a real renderer.
+ */
+import { Provider, createStore } from "jotai";
+import { createElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Session } from "@src/store/session/sessionAtom/types";
+import { createSmokeRoot, dispatch } from "@src/test/reactSmokeHarness";
+
+// react-i18next has no instance bound in this suite; interpolate the one
+// placeholder the panel uses so the rendered header is assertable.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (
+      _key: string,
+      options?: { defaultValue?: string; length?: string }
+    ): string => {
+      const template = options?.defaultValue ?? _key;
+      return options?.length === undefined
+        ? template
+        : template.replace("{{length}}", options.length);
+    },
+    i18n: { resolvedLanguage: "en" },
+  }),
+}));
+
+const RAW_PROMPT = "audit the release [file:/repo/CHANGELOG.md]\nline two";
+
+function makeSession(overrides: Partial<Session>): Session {
+  return {
+    session_id: "agentsession-raw",
+    status: "completed",
+    created_at: "2026-08-01T00:00:00Z",
+    updated_at: "2026-08-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+async function mountToggle(session?: Session) {
+  const { sessionsAtom } = await import("@src/store/session/sessionAtom");
+  const { default: RawPromptToggle } =
+    await import("@src/engines/ChatPanel/ChatItems/RawPromptToggle");
+
+  const store = createStore();
+  store.set(sessionsAtom, session ? [session] : []);
+
+  const root = createSmokeRoot();
+  await root.render(
+    createElement(
+      Provider,
+      { store },
+      createElement(RawPromptToggle, {
+        rawText: RAW_PROMPT,
+        sessionId: "agentsession-raw",
+      })
+    )
+  );
+  return root;
+}
+
+function trigger(): HTMLButtonElement {
+  const element = document.querySelector<HTMLButtonElement>(
+    '[data-testid="chat-message-raw-prompt-toggle"]'
+  );
+  if (!element) throw new Error("raw prompt toggle not rendered");
+  return element;
+}
+
+function panel(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(
+    '[data-testid="chat-message-raw-prompt-panel"]'
+  );
+}
+
+function effortChip(): HTMLElement | null {
+  return document.querySelector<HTMLElement>(
+    '[data-testid="chat-message-raw-prompt-effort"]'
+  );
+}
+
+describe("RawPromptToggle", () => {
+  let root: Awaited<ReturnType<typeof mountToggle>> | null = null;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    await root?.unmount();
+    root = null;
+  });
+
+  it("keeps the panel closed until the trigger is pressed", async () => {
+    root = await mountToggle();
+
+    expect(panel()).toBeNull();
+    expect(trigger().getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("shows the wire prompt verbatim, with the model and its length", async () => {
+    root = await mountToggle(
+      makeSession({ model: "claude-opus-4.5-20251219" })
+    );
+
+    await dispatch(() => trigger().click());
+
+    const opened = panel();
+    expect(opened).not.toBeNull();
+    expect(trigger().getAttribute("aria-expanded")).toBe("true");
+    // Verbatim: the pill token is NOT rendered as a badge here.
+    expect(opened?.querySelector("pre")?.textContent).toBe(RAW_PROMPT);
+    expect(opened?.textContent).toContain("Opus 4.5 20251219");
+    expect(opened?.textContent).toContain(`${RAW_PROMPT.length} chars`);
+  });
+
+  it("surfaces the reasoning effort encoded in a variant model id", async () => {
+    root = await mountToggle(
+      makeSession({ model: "claude-opus-4-7-thinking-xhigh" })
+    );
+
+    await dispatch(() => trigger().click());
+
+    // The base name and the effort are separate: formatModelNameFull drops
+    // the suffix on Anthropic ids, so without the split there is no effort.
+    expect(panel()?.textContent).toContain("Opus 4.7");
+    expect(effortChip()?.textContent).toBe("Extra High · Thinking");
+  });
+
+  it("shows no effort chip for a model id that encodes none", async () => {
+    root = await mountToggle(
+      makeSession({ model: "claude-opus-4.5-20251219" })
+    );
+
+    await dispatch(() => trigger().click());
+
+    expect(panel()?.textContent).toContain("Opus 4.5 20251219");
+    expect(effortChip()).toBeNull();
+  });
+
+  it("falls back to the length alone when the session names no model", async () => {
+    root = await mountToggle(makeSession({}));
+
+    await dispatch(() => trigger().click());
+
+    expect(panel()?.textContent).toContain(`${RAW_PROMPT.length} chars`);
+    expect(panel()?.textContent).toContain("Raw prompt sent to AI");
+  });
+
+  it("closes again on a second press", async () => {
+    root = await mountToggle();
+
+    await dispatch(() => trigger().click());
+    expect(panel()).not.toBeNull();
+
+    await dispatch(() => trigger().click());
+    expect(panel()).toBeNull();
+  });
+});

--- a/src/engines/ChatPanel/ChatItems/__tests__/TEST_CASES.md
+++ b/src/engines/ChatPanel/ChatItems/__tests__/TEST_CASES.md
@@ -50,3 +50,71 @@ Covers the defensive display layer for agent/LLM error messages, primarily the
 - [x] Structured/plain messages are preserved unchanged.
 - [x] Output is length-bounded and whitespace-normalized.
 - [x] Logic is extracted to a tested `.ts` helper (`sanitizeAgentErrorMessage`).
+
+---
+
+# Test Cases: Raw prompt inspector (user turns)
+
+Covers the per-turn "view raw prompt" affordance on `UserChatItem`: the
+`resolveRawUserPrompt` reader that defines what "raw" means, and the
+`RawPromptToggle` button + panel that surfaces it.
+
+## Preconditions
+
+- A user turn is rendered as a `UserChatItem` bubble in chat history.
+- The turn's wire content lives on `event.result.message.content` (written by
+  `persist_user_message_event` for native turns, `user_message_chunk` for
+  imported ones). The bubble itself renders a _transformed_ copy of that
+  string: pills as badges, expansion block stripped, envelope normalized.
+
+## Happy Path
+
+| #   | Steps                                                                 | Expected Result                                                                  |
+| --- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| 1   | Hover a user turn that carries wire content                           | A `{}` (Braces) button appears in the message toolbar, beside Copy               |
+| 2   | Click it                                                              | A panel opens below, titled "Raw prompt sent to AI"                              |
+| 3   | Read the panel header                                                 | Subtitle reads `<model> [effort] · <n> chars`; Copy action sits at the right     |
+| 4   | Read the panel body                                                   | The wire string verbatim, monospace — pill tokens NOT rendered as badges         |
+| 5   | Click the trigger again, or press Escape, or click outside            | Panel closes                                                                     |
+| 6   | Open the panel on a turn whose pills were expanded by `pill_resolver` | The `**Referenced content (auto-expanded):**` block the bubble strips is present |
+
+## Edge Cases
+
+| #   | Scenario                                           | Steps                                                                               | Expected Result                                                        |
+| --- | -------------------------------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| 1   | `displayText` is the short pill form               | Wire content is `skill [skill:/x]` + expansion; `displayText` is `skill [skill:/x]` | Panel shows the wire content, not `displayText`                        |
+| 2   | External-CLI envelope                              | Wire content starts with `## Files mentioned by the user:`                          | Envelope kept verbatim (the bubble's normalizer does not apply)        |
+| 3   | Legacy event with no `result.message`              | Only `displayText` is persisted                                                     | Falls back to `displayText` (still closer to the wire than the bubble) |
+| 4   | `content` is `null`                                | `result.message.content = null`                                                     | Resolves to `""` → no trigger rendered                                 |
+| 5   | Whitespace-only prompt (e.g. attachment-only turn) | `content = "   "`, message carries only `cached_files`                              | No trigger rendered; the rest of the toolbar is unaffected             |
+| 6   | Session names no model                             | `session.model` unset                                                               | Header shows the length alone; no dangling `·` separator               |
+| 6a  | Model id encodes reasoning effort                  | `session.model = claude-opus-4-7-thinking-xhigh`                                    | Header reads `Opus 4.7` + chip `Extra High · Thinking`                 |
+| 6b  | Effort already present in the formatted id         | `session.model = gpt-5.3-codex-high`                                                | `GPT 5.3 Codex` + chip `High` — never `GPT 5.3 Codex High · High`      |
+| 6c  | Model id encodes no variant                        | `session.model = claude-opus-4.5-20251219`                                          | No effort chip at all (effort is per-model, not universal)             |
+| 6d  | Variant suffix parses but maps to no label         | `session.model = gpt-5.3-codex-minimal`                                             | Whole id formatted into the name; suffix is not silently dropped       |
+| 7   | Very long prompt (expanded SKILL.md / file block)  | 12k-char wire content                                                               | Panel caps at 420px tall and scrolls; page does not scroll             |
+| 8   | Panel opened near the viewport bottom / right edge | Trigger sits low or far right                                                       | `useDropdownEngine` flips above and clamps horizontally                |
+
+## Error / Degraded States
+
+| #   | Scenario                                             | Steps                                 | Expected Result                                                                               |
+| --- | ---------------------------------------------------- | ------------------------------------- | --------------------------------------------------------------------------------------------- |
+| 1   | Event has no `sessionId`                             | Synthetic/placeholder row             | No trigger rendered (the model lookup has no key)                                             |
+| 2   | Session row not yet in the store                     | Panel opened before session hydration | Header degrades to the length alone; body still shows the prompt                              |
+| 3   | Mouse leaves the message row while the panel is open | Move the pointer onto the panel       | Toolbar stays visible (`isRawPromptOpen`), so the trigger does not vanish under its own panel |
+
+## Accessibility
+
+- [x] Trigger is a real `<button>` with `aria-label`, `aria-expanded`, and `aria-haspopup="dialog"`.
+- [x] Panel is `role="dialog"` with an accessible name.
+- [x] Escape closes the panel (document-level handler in `useDropdownEngine`).
+- [x] Focus is not stolen from the trigger, so the hover-revealed toolbar stays visible via `focus-within`.
+- [x] Panel body is selectable text (`allow-select`), never injected HTML.
+
+## Acceptance Criteria
+
+- [x] The panel shows the exact string the model received — no pill rendering, no stripping, no normalization.
+- [x] The trigger is absent when there is no prompt text to show.
+- [x] Reasoning effort is shown for exactly the model ids that encode it, and is never duplicated into the model name.
+- [x] Opening the panel is the only thing that subscribes to the session (model lookup); closed bubbles pay nothing.
+- [x] Copy in the panel copies the raw string, not the bubble text.

--- a/src/engines/ChatPanel/ChatItems/__tests__/rawPromptModelLabel.test.ts
+++ b/src/engines/ChatPanel/ChatItems/__tests__/rawPromptModelLabel.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { describeModelLabel } from "@src/engines/ChatPanel/ChatItems/rawPromptModelLabel";
+
+describe("describeModelLabel", () => {
+  it("splits Anthropic effort out of the id formatter drops it from", () => {
+    // formatModelNameFull("claude-opus-4-7-thinking-xhigh") is just "Opus 4.7":
+    // without this split the effort would be invisible.
+    expect(describeModelLabel("claude-opus-4-7-thinking-xhigh")).toEqual({
+      name: "Opus 4.7",
+      variant: "Extra High · Thinking",
+    });
+  });
+
+  it("does not duplicate GPT effort the id formatter already keeps", () => {
+    // formatModelNameFull("gpt-5.3-codex-high") is "GPT 5.3 Codex High";
+    // naive appending would read "GPT 5.3 Codex High · High".
+    expect(describeModelLabel("gpt-5.3-codex-high")).toEqual({
+      name: "GPT 5.3 Codex",
+      variant: "High",
+    });
+  });
+
+  it("reports thinking with no reasoning level", () => {
+    expect(describeModelLabel("claude-sonnet-4-5-thinking")).toEqual({
+      name: "Sonnet 4.5",
+      variant: "Thinking",
+    });
+  });
+
+  it("reports the fast dimension", () => {
+    expect(describeModelLabel("composer-1-fast")).toEqual({
+      name: "Composer 1",
+      variant: "Fast",
+    });
+  });
+
+  it("leaves a plain dated model id with no variant", () => {
+    expect(describeModelLabel("claude-opus-4.5-20251219")).toEqual({
+      name: "Opus 4.5 20251219",
+      variant: "",
+    });
+  });
+
+  it("leaves a non-variant provider id alone", () => {
+    expect(describeModelLabel("gemini-2.0-flash")).toEqual({
+      name: "Gemini 2.0 Flash",
+      variant: "",
+    });
+  });
+
+  it("formats the whole id when no variant label survives", () => {
+    // Guards the base-model shortcut: an id whose suffix parses but yields no
+    // displayable segment must not lose that suffix from the name.
+    const label = describeModelLabel("gpt-5.3-codex-minimal");
+    expect(label?.variant).toBe("");
+    expect(label?.name).toContain("Minimal");
+  });
+
+  it("returns null for a missing or blank model", () => {
+    expect(describeModelLabel(undefined)).toBeNull();
+    expect(describeModelLabel(null)).toBeNull();
+    expect(describeModelLabel("   ")).toBeNull();
+  });
+});

--- a/src/engines/ChatPanel/ChatItems/__tests__/rawUserPrompt.test.ts
+++ b/src/engines/ChatPanel/ChatItems/__tests__/rawUserPrompt.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveRawUserPrompt } from "@src/engines/ChatPanel/ChatItems/rawUserPrompt";
+import { makeSessionEvent } from "@src/engines/SessionCore/rendering/props/__tests__/fixtures";
+
+const PILL_EXPANSION =
+  "\n\n---\n**Referenced content (auto-expanded):**\n\n# Setup Repo Skill\n\nDo stuff.";
+
+function userEvent(
+  overrides: Parameters<typeof makeSessionEvent>[0] = {}
+): ReturnType<typeof makeSessionEvent> {
+  return makeSessionEvent({
+    source: "user",
+    actionType: "raw",
+    functionName: "user_message",
+    displayVariant: "message",
+    ...overrides,
+  });
+}
+
+describe("resolveRawUserPrompt", () => {
+  it("returns the wire content, not the pill-format display text", () => {
+    const wire = `setup-repo [skill:/setup-repo]${PILL_EXPANSION}`;
+    const event = userEvent({
+      displayText: "setup-repo [skill:/setup-repo]",
+      result: { type: "user", message: { role: "user", content: wire } },
+    });
+
+    expect(resolveRawUserPrompt(event)).toBe(wire);
+  });
+
+  it("keeps the auto-expanded reference block the bubble strips", () => {
+    const wire = `look at this${PILL_EXPANSION}`;
+    const event = userEvent({
+      displayText: wire,
+      result: { type: "user", message: { role: "user", content: wire } },
+    });
+
+    expect(resolveRawUserPrompt(event)).toContain(
+      "Referenced content (auto-expanded)"
+    );
+  });
+
+  it("keeps the external-CLI envelope the bubble normalizes away", () => {
+    const wire = [
+      "## Files mentioned by the user:",
+      "### main.ts: /repo/main.ts",
+      "## My request for Codex:",
+      "explain this",
+    ].join("\n");
+    const event = userEvent({
+      result: { type: "user", message: { role: "user", content: wire } },
+    });
+
+    expect(resolveRawUserPrompt(event)).toBe(wire);
+  });
+
+  it("falls back to displayText for legacy events with no wire content", () => {
+    const event = userEvent({ displayText: "legacy prompt", result: {} });
+
+    expect(resolveRawUserPrompt(event)).toBe("legacy prompt");
+  });
+
+  it("returns an empty string for a null message content", () => {
+    const event = userEvent({
+      displayText: "",
+      result: { type: "user", message: { role: "user", content: null } },
+    });
+
+    expect(resolveRawUserPrompt(event)).toBe("");
+  });
+
+  it("returns an empty string when there is no event", () => {
+    expect(resolveRawUserPrompt(undefined)).toBe("");
+  });
+});

--- a/src/engines/ChatPanel/ChatItems/rawPromptModelLabel.ts
+++ b/src/engines/ChatPanel/ChatItems/rawPromptModelLabel.ts
@@ -1,0 +1,47 @@
+/**
+ * Model label for the raw-prompt panel header.
+ *
+ * Reasoning effort is not a stored field in ORGII — it is encoded in the model
+ * id itself as a variant suffix (`claude-opus-4-7-thinking-xhigh`,
+ * `gpt-5.3-codex-high`, `composer-1-fast`). `parseModelVariant` decodes it, so
+ * effort is visible for exactly those ids and absent for plain ones
+ * (`claude-opus-4.5-20251219`, `gemini-2.0-flash`).
+ *
+ * Splitting name from variant is what makes this more than a call to
+ * `formatModelNameFull`: that formatter *drops* the suffix on Anthropic ids
+ * ("Opus 4.7") but *keeps* it on GPT ids ("GPT 5.3 Codex High"), so appending
+ * the variant to its output would silently duplicate the effort on one
+ * provider and not the other. Formatting the base model instead makes both
+ * read the same — `Opus 4.7` + `Extra High · Thinking`, `GPT 5.3 Codex` +
+ * `High`.
+ */
+import { formatModelNameFull } from "@src/util/formatModelName";
+import {
+  formatVariantDisplayLabel,
+  parseModelVariant,
+} from "@src/util/modelVariants";
+
+export interface RawPromptModelLabel {
+  /** Base model display name, e.g. `Opus 4.7`. */
+  name: string;
+  /**
+   * Variant summary, e.g. `Extra High · Thinking`. Empty when the id encodes
+   * no recognized effort/thinking/fast suffix.
+   */
+  variant: string;
+}
+
+export function describeModelLabel(
+  model: string | undefined | null
+): RawPromptModelLabel | null {
+  const modelId = model?.trim();
+  if (!modelId) return null;
+
+  const variant = formatVariantDisplayLabel(modelId);
+  // No recognized variant — format the id whole so an unmapped suffix
+  // (`ModelVariantMetadata.rawSuffix`) is never dropped on the floor.
+  if (!variant) return { name: formatModelNameFull(modelId), variant: "" };
+
+  const baseModel = parseModelVariant(modelId)?.baseModel ?? modelId;
+  return { name: formatModelNameFull(baseModel), variant };
+}

--- a/src/engines/ChatPanel/ChatItems/rawUserPrompt.ts
+++ b/src/engines/ChatPanel/ChatItems/rawUserPrompt.ts
@@ -1,0 +1,29 @@
+/**
+ * Raw user-prompt resolution.
+ *
+ * A user bubble never renders the string the model received. `UserChatItem`
+ * prefers the pill-format `displayText`, drops the backend's auto-expanded
+ * reference block (`stripExpandedPillContent`), and runs the external-CLI
+ * envelope normalizer over the remainder. All three are display conveniences.
+ *
+ * What actually entered the LLM history is the wire content persisted next to
+ * it — `result.message.content`, written by `persist_user_message_event` for
+ * native turns and by `user_message_chunk` for imported ones. This module
+ * isolates that read so the "view raw prompt" affordance and its tests share
+ * one definition of "raw".
+ */
+import { getUserMessageContent } from "@src/engines/SessionCore/core/atoms/actions.userMessageSync";
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+
+/**
+ * The prompt text this turn handed to the model, or `""` when the event
+ * carries none (synthetic rows, image-only turns with no text part).
+ *
+ * Falls back to `displayText` for legacy events persisted before the wire
+ * content was stored: that fallback is still closer to the wire than the
+ * bubble, since it keeps the expansion block the bubble strips.
+ */
+export function resolveRawUserPrompt(event: SessionEvent | undefined): string {
+  if (!event) return "";
+  return getUserMessageContent(event);
+}

--- a/src/i18n/locales/de/sessions.json
+++ b/src/i18n/locales/de/sessions.json
@@ -1021,6 +1021,11 @@
       "copySuccess": "Rohtranskript kopiert",
       "copyFailed": "Rohtranskript konnte nicht kopiert werden"
     },
+    "rawPrompt": {
+      "title": "Roh-Prompt an die KI",
+      "view": "Roh-Prompt anzeigen",
+      "length": "{{length}} Zeichen"
+    },
     "linkWorkItem": {
       "menuItem": "Mit Work Item verknüpfen…",
       "title": "Sitzung mit Work Item verknüpfen",

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -1078,6 +1078,11 @@
       "copySuccess": "Raw transcript copied",
       "copyFailed": "Could not copy the raw transcript"
     },
+    "rawPrompt": {
+      "title": "Raw prompt sent to AI",
+      "view": "View raw prompt",
+      "length": "{{length}} chars"
+    },
     "trackAsProject": {
       "menuItem": "Track as Project",
       "success": "Session is now tracked as a Project"

--- a/src/i18n/locales/es/sessions.json
+++ b/src/i18n/locales/es/sessions.json
@@ -1023,6 +1023,11 @@
       "copySuccess": "Transcripción sin procesar copiada",
       "copyFailed": "No se pudo copiar la transcripción sin procesar"
     },
+    "rawPrompt": {
+      "title": "Prompt sin procesar enviado a la IA",
+      "view": "Ver prompt sin procesar",
+      "length": "{{length}} caracteres"
+    },
     "linkWorkItem": {
       "menuItem": "Vincular a un Work Item…",
       "title": "Vincular sesión a un Work Item",

--- a/src/i18n/locales/fr/sessions.json
+++ b/src/i18n/locales/fr/sessions.json
@@ -1023,6 +1023,11 @@
       "copySuccess": "Transcription brute copiée",
       "copyFailed": "Impossible de copier la transcription brute"
     },
+    "rawPrompt": {
+      "title": "Prompt brut envoyé à l'IA",
+      "view": "Afficher le prompt brut",
+      "length": "{{length}} caractères"
+    },
     "linkWorkItem": {
       "menuItem": "Lier à un Work Item…",
       "title": "Lier la session à un Work Item",

--- a/src/i18n/locales/ja/sessions.json
+++ b/src/i18n/locales/ja/sessions.json
@@ -1022,6 +1022,11 @@
       "copySuccess": "生トランスクリプトをコピーしました",
       "copyFailed": "生トランスクリプトをコピーできませんでした"
     },
+    "rawPrompt": {
+      "title": "AI に送信した生の Prompt",
+      "view": "生の Prompt を表示",
+      "length": "{{length}} 文字"
+    },
     "linkWorkItem": {
       "menuItem": "Work Item にリンク…",
       "title": "セッションを Work Item にリンク",

--- a/src/i18n/locales/ko/sessions.json
+++ b/src/i18n/locales/ko/sessions.json
@@ -1022,6 +1022,11 @@
       "copySuccess": "원시 트랜스크립트를 복사했습니다",
       "copyFailed": "원시 트랜스크립트를 복사할 수 없습니다"
     },
+    "rawPrompt": {
+      "title": "AI에 전송된 원본 Prompt",
+      "view": "원본 Prompt 보기",
+      "length": "{{length}}자"
+    },
     "linkWorkItem": {
       "menuItem": "Work Item에 연결…",
       "title": "세션을 Work Item에 연결",

--- a/src/i18n/locales/pl/sessions.json
+++ b/src/i18n/locales/pl/sessions.json
@@ -1024,6 +1024,11 @@
       "copySuccess": "Skopiowano surowy zapis",
       "copyFailed": "Nie udało się skopiować surowego zapisu"
     },
+    "rawPrompt": {
+      "title": "Surowy prompt wysłany do AI",
+      "view": "Pokaż surowy prompt",
+      "length": "{{length}} znaków"
+    },
     "linkWorkItem": {
       "menuItem": "Połącz z Work Item…",
       "title": "Połącz sesję z Work Item",

--- a/src/i18n/locales/pt/sessions.json
+++ b/src/i18n/locales/pt/sessions.json
@@ -1022,6 +1022,11 @@
       "copySuccess": "Transcrição bruta copiada",
       "copyFailed": "Não foi possível copiar a transcrição bruta"
     },
+    "rawPrompt": {
+      "title": "Prompt bruto enviado à IA",
+      "view": "Ver prompt bruto",
+      "length": "{{length}} caracteres"
+    },
     "linkWorkItem": {
       "menuItem": "Vincular a um Work Item…",
       "title": "Vincular sessão a um Work Item",

--- a/src/i18n/locales/ru/sessions.json
+++ b/src/i18n/locales/ru/sessions.json
@@ -1027,6 +1027,11 @@
       "copySuccess": "Необработанная расшифровка скопирована",
       "copyFailed": "Не удалось скопировать необработанную расшифровку"
     },
+    "rawPrompt": {
+      "title": "Исходный prompt, отправленный ИИ",
+      "view": "Показать исходный prompt",
+      "length": "{{length}} символов"
+    },
     "linkWorkItem": {
       "menuItem": "Связать с Work Item…",
       "title": "Связать сеанс с Work Item",

--- a/src/i18n/locales/tr/sessions.json
+++ b/src/i18n/locales/tr/sessions.json
@@ -1023,6 +1023,11 @@
       "copySuccess": "Ham döküm kopyalandı",
       "copyFailed": "Ham döküm kopyalanamadı"
     },
+    "rawPrompt": {
+      "title": "AI'ya gönderilen ham prompt",
+      "view": "Ham prompt'u görüntüle",
+      "length": "{{length}} karakter"
+    },
     "linkWorkItem": {
       "menuItem": "Work Item'a bağla…",
       "title": "Oturumu Work Item'a bağla",

--- a/src/i18n/locales/vi/sessions.json
+++ b/src/i18n/locales/vi/sessions.json
@@ -1020,6 +1020,11 @@
       "copySuccess": "Đã sao chép bản ghi thô",
       "copyFailed": "Không thể sao chép bản ghi thô"
     },
+    "rawPrompt": {
+      "title": "Prompt thô đã gửi cho AI",
+      "view": "Xem prompt thô",
+      "length": "{{length}} ký tự"
+    },
     "linkWorkItem": {
       "menuItem": "Liên kết với Work Item…",
       "title": "Liên kết phiên với Work Item",

--- a/src/i18n/locales/zh-Hant/sessions.json
+++ b/src/i18n/locales/zh-Hant/sessions.json
@@ -1037,6 +1037,11 @@
       "copySuccess": "已複製原始記錄",
       "copyFailed": "無法複製原始記錄"
     },
+    "rawPrompt": {
+      "title": "傳送給 AI 的原始 Prompt",
+      "view": "查看原始 Prompt",
+      "length": "{{length}} 個字元"
+    },
     "linkWorkItem": {
       "menuItem": "連結到工作項…",
       "title": "將會話連結到工作項",

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -1069,6 +1069,11 @@
       "copySuccess": "已复制原始记录",
       "copyFailed": "无法复制原始记录"
     },
+    "rawPrompt": {
+      "title": "发送给 AI 的原始 Prompt",
+      "view": "查看原始 Prompt",
+      "length": "{{length}} 个字符"
+    },
     "trackAsProject": {
       "menuItem": "追踪为项目",
       "success": "会话已作为项目追踪"


### PR DESCRIPTION
## Summary

- Adds a per-turn "view raw prompt" affordance to the user message toolbar in chat history: a `{}` button that opens a panel showing the exact string the model received, verbatim, with a copy action.
- The panel header names the session's model, its reasoning effort (for the model ids that encode one), and the prompt's character count.
- No backend change — the raw string was already persisted, just never surfaced.

## Problem

A user bubble renders a *transformed* copy of the prompt, never the prompt itself. `UserChatItem` prefers the pill-format `displayText`, strips the backend's auto-expanded reference block (`stripExpandedPillContent`), then runs the external-CLI envelope normalizer over the remainder. Three lossy display passes, and nothing in the UI exposed what the model actually read.

That matters when debugging an injected `SKILL.md`, an expanded file reference, or a paste that silently truncated: the bubble is the wrong artifact to inspect, and the session-level raw transcript is too coarse to answer "what did *this* turn send?".

## Solution

- **`rawUserPrompt.ts`** — isolates the definition of "raw": `result.message.content`, the string written by `persist_user_message_event` for native turns and `user_message_chunk` for imported ones. Falls back to `displayText` for legacy rows persisted before the wire content was stored (still closer to the wire than the bubble, since it keeps the expansion block).
- **`RawPromptToggle.tsx`** — trigger + portaled panel. `Braces` is deliberate: it is already this app's glyph for "View raw transcript" in `SessionHeaderActionsMenu`, and this is the same idea one turn down. Built on `useDropdownEngine` + `DROPDOWN_CLASSES.menuPanelWithHeaderBase`, so flip/clamp/Escape/click-outside come from the shared primitives.
- **`rawPromptModelLabel.ts`** — splits the model into name + variant. `formatModelNameFull` *drops* the variant suffix on Anthropic ids (`claude-opus-4-7-thinking-xhigh` → `Opus 4.7`) but *keeps* it on GPT ids (`gpt-5.3-codex-high` → `GPT 5.3 Codex High`), so appending the variant to its output would leave the effort invisible on one provider and stuttering (`GPT 5.3 Codex High · High`) on the other. Formatting the base model and returning the variant separately makes both read the same. It also declines the base-model shortcut when a suffix parses but maps to no label, so an unmapped suffix is never dropped.
- **i18n** — `chat.rawPrompt.{title,view,length}` across all 13 locales. Effort labels come from `formatReasoningLevel` and stay untranslated, matching how the rest of the app treats model nomenclature.

Header shape:

```
Raw prompt sent to AI                          [copy]
Opus 4.7  [Extra High · Thinking]  ·  12,431 chars
```

## Potential risks

- **The model shown is `session.model`, not a per-turn record.** Nothing on a user-message event names the model that answered it — `llmUsage.model` is attached only to the turn's assistant/thinking event, and `TurnSummary` carries no model field. A session whose model was switched after a turn ran will label that turn with the newer model. This is the one knowingly-approximate part of the change; recording the model per turn is the follow-up, and it matters most for exactly the workflow (comparing effort across turns) where it would mislead.
- **Toolbar visibility is now stateful.** The hover-revealed toolbar pins itself open while the panel is (`isRawPromptOpen`), because ancestor `opacity-0` cannot be undone by a descendant — without it the trigger vanishes out from under its own panel as soon as you click into it to select text. One extra `useState` in `UserChatItem`.
- **`UserChatItem.tsx` is now 593 lines**, against the repo's 600-line UI-component limit. The next feature touching it will need an extraction first. The three new modules were kept separate partly for this reason.
- **Blast radius is small**: one new toolbar button, three new files, and a 5-line addition per locale. No backend, no schema, no change to how prompts are built or sent.

## Test plan

- `npx tsc --noEmit` — clean.
- `npx eslint src/engines/ChatPanel/ChatItems/` — clean.
- `npx vitest run src/engines/ChatPanel src/util` — **238 files / 1890 tests pass**.
- New coverage:
  - `rawUserPrompt.test.ts` (6) — wire content preferred over pill-format `displayText`; expansion block and external-CLI envelope both preserved; legacy `displayText` fallback; `content: null` and missing-event → `""`.
  - `rawPromptModelLabel.test.ts` (8) — both provider shapes (Anthropic suffix-dropping, GPT suffix-keeping), thinking-only, fast-only, plain dated ids, non-variant providers, the unmapped-suffix guard, and blank input.
  - `RawPromptToggle.test.ts` (6, jsdom) — mounts and clicks the trigger: panel closed by default, pill token rendered **unrendered** in the body, model + effort chip present for a variant id, chip absent for a plain id, length label, and toggle-closed.
  - SSR assertions in `UserChatItem.test.ts` (2) — trigger present when the turn carries wire content, absent when there is no prompt text to show.
- `__tests__/TEST_CASES.md` updated: happy path, 12 edge cases (including all four model-label shapes), degraded states, and a11y checklist.
- Not done: no manual run of the packaged app. The panel is composed entirely of existing tokens and shared dropdown primitives, and the jsdom suite asserts the rendered DOM.

## Submit checklist

- [x] The PR is focused and has a scoped Conventional Commits title.
- [x] I ran the relevant checks, or explained why they were not run.
- [x] No secrets, private config, generated output, or unrelated formatting changes are included.
- [x] Docs, screenshots, and locale updates are included when the change needs them.
