### PR TITLE
perf(state): keep keyed Jotai atom identity stable under cache pressure

### DIFF
--- a/src/engines/SessionCore/core/atoms/__tests__/sessionHydrationAtom.test.ts
+++ b/src/engines/SessionCore/core/atoms/__tests__/sessionHydrationAtom.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   beginSessionHydrationAtom,
   endSessionHydrationAtom,
+  sessionHydrationByIdAtom,
   sessionHydrationCountMapAtom,
 } from "../metadata";
 
@@ -43,5 +44,15 @@ describe("session hydration state", () => {
     expect(
       store.get(sessionHydrationCountMapAtom).get("imported-session-1")
     ).toEqual({ count: 2, iconId: "codex" });
+  });
+
+  it("preserves a live scoped atom beyond the strong-cache limit", () => {
+    const retained = sessionHydrationByIdAtom("retained-session");
+
+    for (let index = 0; index < 120; index += 1) {
+      sessionHydrationByIdAtom(`cache-pressure-${index}`);
+    }
+
+    expect(sessionHydrationByIdAtom("retained-session")).toBe(retained);
   });
 });

--- a/src/engines/SessionCore/core/atoms/metadata.ts
+++ b/src/engines/SessionCore/core/atoms/metadata.ts
@@ -5,6 +5,8 @@
  */
 import { type Atom, atom } from "jotai";
 
+import { createStableWeakLruCache } from "@src/util/core/state/stableWeakLruCache";
+
 import type { SessionEvent, SessionLoadStatus, SessionSpec } from "../types";
 
 const MAX_SESSION_RELOAD_EPOCH_ENTRIES = 200;
@@ -71,30 +73,19 @@ export const sessionHydrationCountMapAtom = atom<
 >(new Map());
 sessionHydrationCountMapAtom.debugLabel = "session/hydrationCountMap";
 
-const SESSION_HYDRATION_BY_ID_CACHE_MAX = 100;
-const sessionHydrationByIdCache = new Map<
-  string,
-  Atom<SessionHydrationState | undefined>
->();
+const sessionHydrationByIdCache =
+  createStableWeakLruCache<Atom<SessionHydrationState | undefined>>(100);
 
 /** Narrow, LRU-bounded view used by the active Chat Pane and tab icons. */
 export function sessionHydrationByIdAtom(
   sessionId: string
 ): Atom<SessionHydrationState | undefined> {
   const cached = sessionHydrationByIdCache.get(sessionId);
-  if (cached) {
-    sessionHydrationByIdCache.delete(sessionId);
-    sessionHydrationByIdCache.set(sessionId, cached);
-    return cached;
-  }
+  if (cached) return cached;
   const scopedAtom = atom((get) =>
     get(sessionHydrationCountMapAtom).get(sessionId)
   );
   scopedAtom.debugLabel = `session/hydration:${sessionId}`;
-  if (sessionHydrationByIdCache.size >= SESSION_HYDRATION_BY_ID_CACHE_MAX) {
-    const oldest = sessionHydrationByIdCache.keys().next().value;
-    if (oldest !== undefined) sessionHydrationByIdCache.delete(oldest);
-  }
   sessionHydrationByIdCache.set(sessionId, scopedAtom);
   return scopedAtom;
 }

--- a/src/store/session/__tests__/sessionManagerAtom.test.ts
+++ b/src/store/session/__tests__/sessionManagerAtom.test.ts
@@ -1,7 +1,7 @@
 /**
  * Session atom derived values and helpers — pure logic tests.
  *
- * Tests the pure helpers (`isValidSessionUUID`, `sessionByIdAtom` LRU cache),
+ * Tests the pure helpers (`isValidSessionUUID`, `sessionByIdAtom` cache),
  * and derived atoms (`sessionsAtom`, `sessionMapAtom`, `validSessionIdsAtom`,
  * session count atoms) using a raw Jotai store to avoid React/hook machinery.
  */
@@ -195,5 +195,15 @@ describe("sessionByIdAtom", () => {
 
   it("returns stable atom instances for the same ID", () => {
     expect(sessionByIdAtom("foo")).toBe(sessionByIdAtom("foo"));
+  });
+
+  it("preserves a live atom identity beyond the strong-cache limit", () => {
+    const retained = sessionByIdAtom("retained-session");
+
+    for (let index = 0; index < 600; index += 1) {
+      sessionByIdAtom(`cache-pressure-${index}`);
+    }
+
+    expect(sessionByIdAtom("retained-session")).toBe(retained);
   });
 });

--- a/src/store/session/sessionAtom/atoms.ts
+++ b/src/store/session/sessionAtom/atoms.ts
@@ -6,6 +6,7 @@
 import { type Atom, atom } from "jotai";
 
 import { isActiveStatus, isTerminalStatus } from "@src/types/session/session";
+import { createStableWeakLruCache } from "@src/util/core/state/stableWeakLruCache";
 
 import { loadPersistedSessions } from "./persistence";
 import type { Session, SessionGroups } from "./types";
@@ -110,20 +111,15 @@ getSessionByIdAtom.debugLabel = "getSessionByIdAtom";
  * session object reference is unchanged (which `sessionMapAtom`
  * guarantees via its reference-stability cache).
  */
-// LRU cap: evict the oldest entry when the cache exceeds this size.
-// Without a cap the Map grows by one Jotai atom per unique sessionId ever
-// seen — an unbounded leak for long-running sessions over multiple days.
-const SESSION_BY_ID_CACHE_MAX = 500;
-const _sessionByIdCache = new Map<string, Atom<Session | undefined>>();
+// Evicting an atom object that still has a mounted React subscriber makes
+// Jotai re-subscribe on every cache-pressure render. The strong tier remains
+// bounded while the weak tier preserves the identity of live atoms.
+const sessionByIdAtomCache =
+  createStableWeakLruCache<Atom<Session | undefined>>(500);
 
 export function sessionByIdAtom(sessionId: string): Atom<Session | undefined> {
-  const cached = _sessionByIdCache.get(sessionId);
-  if (cached) {
-    // Move to end (most-recently-used) by re-inserting.
-    _sessionByIdCache.delete(sessionId);
-    _sessionByIdCache.set(sessionId, cached);
-    return cached;
-  }
+  const cached = sessionByIdAtomCache.get(sessionId);
+  if (cached) return cached;
 
   const derived = atom<Session | undefined>((get) => {
     const sessionMap = get(sessionMapAtom);
@@ -131,13 +127,7 @@ export function sessionByIdAtom(sessionId: string): Atom<Session | undefined> {
   });
   derived.debugLabel = `session:${sessionId}`;
 
-  if (_sessionByIdCache.size >= SESSION_BY_ID_CACHE_MAX) {
-    // Evict least-recently-used (first inserted) entry.
-    const lruKey = _sessionByIdCache.keys().next().value;
-    if (lruKey !== undefined) _sessionByIdCache.delete(lruKey);
-  }
-
-  _sessionByIdCache.set(sessionId, derived);
+  sessionByIdAtomCache.set(sessionId, derived);
   return derived;
 }
 

--- a/src/util/core/state/stableWeakLruCache.ts
+++ b/src/util/core/state/stableWeakLruCache.ts
@@ -1,0 +1,114 @@
+interface WeakReferenceLike<T extends object> {
+  deref(): T | undefined;
+}
+
+type WeakReferenceConstructorLike = new <T extends object>(
+  target: T
+) => WeakReferenceLike<T>;
+
+interface FinalizationRegistryLike<HeldValue> {
+  register(target: object, heldValue: HeldValue): void;
+}
+
+type FinalizationRegistryConstructorLike = new <HeldValue>(
+  cleanup: (heldValue: HeldValue) => void
+) => FinalizationRegistryLike<HeldValue>;
+
+interface WeakCacheEntry<T extends object> {
+  reference: WeakReferenceLike<T>;
+  token: number;
+}
+
+interface FinalizedCacheEntry {
+  key: string;
+  token: number;
+}
+
+export interface StableWeakLruCache<T extends object> {
+  get(key: string): T | undefined;
+  set(key: string, value: T): void;
+}
+
+/**
+ * Bounded strong LRU with a weak identity tier.
+ *
+ * The strong tier bounds retained hot values. Values evicted from that tier
+ * keep their identity for as long as another owner still references them;
+ * once the last owner releases one, the weak entry is finalized too. This is
+ * intended for keyed React/Jotai objects whose identity must not change while
+ * mounted merely because more keys were visited.
+ */
+export function createStableWeakLruCache<T extends object>(
+  maxStrongEntries: number
+): StableWeakLruCache<T> {
+  if (!Number.isInteger(maxStrongEntries) || maxStrongEntries < 1) {
+    throw new Error("maxStrongEntries must be a positive integer");
+  }
+
+  const weakReferenceConstructor = (
+    globalThis as typeof globalThis & {
+      WeakRef?: WeakReferenceConstructorLike;
+    }
+  ).WeakRef;
+  const finalizationRegistryConstructor = (
+    globalThis as typeof globalThis & {
+      FinalizationRegistry?: FinalizationRegistryConstructorLike;
+    }
+  ).FinalizationRegistry;
+  const strongCache = new Map<string, T>();
+  const weakCache = new Map<string, WeakCacheEntry<T>>();
+  let weakToken = 0;
+
+  const finalizationRegistry = finalizationRegistryConstructor
+    ? new finalizationRegistryConstructor<FinalizedCacheEntry>(
+        ({ key, token }) => {
+          if (weakCache.get(key)?.token === token) {
+            weakCache.delete(key);
+          }
+        }
+      )
+    : null;
+
+  const retain = (key: string, value: T): void => {
+    strongCache.delete(key);
+    strongCache.set(key, value);
+
+    while (strongCache.size > maxStrongEntries) {
+      const lruKey = strongCache.keys().next().value;
+      if (lruKey === undefined) break;
+      strongCache.delete(lruKey);
+    }
+  };
+
+  return {
+    get(key) {
+      const stronglyCached = strongCache.get(key);
+      if (stronglyCached) {
+        retain(key, stronglyCached);
+        return stronglyCached;
+      }
+
+      const weaklyCached = weakCache.get(key);
+      const liveWeakValue = weaklyCached?.reference.deref();
+      if (liveWeakValue) {
+        retain(key, liveWeakValue);
+        return liveWeakValue;
+      }
+      if (weaklyCached) weakCache.delete(key);
+      return undefined;
+    },
+    set(key, value) {
+      const token = ++weakToken;
+      const reference = weakReferenceConstructor
+        ? new weakReferenceConstructor(value)
+        : // WeakRef is present in every supported Tauri WebView. Preserve
+          // identity on an older host rather than reverting to unsafe live
+          // eviction; the strong tier remains bounded either way.
+          { deref: () => value };
+
+      weakCache.set(key, { reference, token });
+      finalizationRegistry?.register(value, { key, token });
+      retain(key, value);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Replaces the hand-rolled LRU behind `sessionByIdAtom` and `sessionHydrationByIdAtom` with a shared bounded-strong + weak-identity cache, so a derived atom that still has mounted subscribers can never be evicted out from under them.

## Problem

Both factories cached their derived atoms in a plain `Map` with a size cap (500 and 100 respectively), evicting the least-recently-used entry on overflow. The cap is necessary — without it the map grows by one Jotai atom per unique session id ever seen — but eviction is keyed on recency, not on whether anything is still using the atom.

Once the cap is reached, visiting new session ids evicts atom objects that still have mounted React subscribers. The next render of those components calls the factory again, gets a **different** atom object for the same session id, and Jotai re-subscribes. With enough distinct sessions in play, ordinary navigation turns into repeated unsubscribe/resubscribe churn on components that never changed.

## Solution

Add `createStableWeakLruCache` (`src/util/core/state/stableWeakLruCache.ts`): a bounded strong tier plus a weak tier.

- The strong tier keeps hot values alive and stays capped exactly as before, so retained memory is unchanged.
- Values pushed out of the strong tier move to a `WeakRef`, keeping their identity for as long as any other owner still references them. A mounted subscriber is such an owner.
- A `FinalizationRegistry` drops the weak entry once the last owner releases it, so the leak the original cap existed to prevent still cannot happen.
- Token-matched finalization means a re-`set` key is never removed by the previous value's finalizer.

Both factories now call `get`/`set` and drop their inline recency bookkeeping.

## Potential risks

- **Memory.** The weak tier holds a `WeakRef` and a registry entry per evicted key. These are small and collectible, but the map of weak entries is only pruned on finalization or on a `get` that observes a dead reference. Bounded in practice by the number of distinct session ids visited in one app run.
- **Host support.** `WeakRef`/`FinalizationRegistry` exist in every supported Tauri WebView. On a host missing them the cache falls back to holding the value in a `deref` closure — identity is preserved and the strong tier stays bounded, but those entries are not reclaimed. This is deliberately biased toward correctness over reclamation; the alternative was reverting to live eviction.
- **GC timing is not observable.** Finalization is non-deterministic, so tests assert identity preservation, not reclamation.

## Validation

- `tsc --noEmit` clean.
- `eslint` clean on changed files.
- `vitest run src/store/session src/engines/SessionCore/core/atoms` — 24 files, 222 tests passing.
- New coverage: both factories asserted to return the same atom instance for a retained key after 600 / 120 other keys are visited — a direct regression test for the eviction-under-pressure case, which fails against the previous `Map` implementation.