### PR TITLE
refactor(ui): use one Chromium glyph for the in-app Browser

### DIFF
--- a/src/components/MarkDown/LinkHoverCard.tsx
+++ b/src/components/MarkDown/LinkHoverCard.tsx
@@ -1,5 +1,5 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { Copy, SquareArrowOutUpRight } from "lucide-react";
+import { Chromium, Copy, SquareArrowOutUpRight } from "lucide-react";
 import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -74,7 +74,12 @@ const LinkHoverCardContent: React.FC<{ preview: HttpLinkPreview }> = ({
           title={t("cards.actions.openWithDefaultBrowser")}
           onClick={handleOpenExternal}
         />
-        <Button variant="primary" size="mini" onClick={handleOpenInApp}>
+        <Button
+          variant="primary"
+          size="mini"
+          icon={<Chromium size={13} strokeWidth={1.75} aria-hidden />}
+          onClick={handleOpenInApp}
+        >
           {t("cards.actions.openInApp")}
         </Button>
       </div>

--- a/src/config/segmentRegistry.ts
+++ b/src/config/segmentRegistry.ts
@@ -12,6 +12,7 @@ import {
   BadgeCent,
   Braces,
   CalendarArrowUp,
+  Chromium,
   ClipboardList,
   Cloud,
   Code,
@@ -20,7 +21,6 @@ import {
   FileText,
   FolderGit2,
   FolderOpen,
-  Globe,
   Hammer,
   Inbox,
   Key,
@@ -157,7 +157,7 @@ export const SEGMENT_REGISTRY: Record<string, SegmentRegistryEntry> = {
   // work-station roots
   workstation: { labelKey: "navigation:labels.workspace", icon: FolderOpen },
   code: { labelKey: "navigation:labels.codeEditor", icon: Code },
-  browser: { labelKey: "navigation:labels.browser", icon: Globe },
+  browser: { labelKey: "navigation:labels.browser", icon: Chromium },
   project: {
     labelKey: "navigation:labels.projectManager",
     icon: ClipboardList,

--- a/src/engines/ChatPanel/blocks/ToolCallBlock/cards/WebsiteCard.tsx
+++ b/src/engines/ChatPanel/blocks/ToolCallBlock/cards/WebsiteCard.tsx
@@ -1,4 +1,4 @@
-import { Globe, SquareArrowOutUpRight } from "lucide-react";
+import { Chromium, Globe } from "lucide-react";
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -81,7 +81,7 @@ const WebsiteCard: React.FC<WebsiteCardProps> = ({ card }) => {
         title={t("cards.openLink")}
         aria-label={t("cards.openLink")}
       >
-        <SquareArrowOutUpRight size={14} />
+        <Chromium size={14} strokeWidth={1.75} aria-hidden />
       </button>
     </div>
   );

--- a/src/engines/Simulator/components/Dock/__tests__/dockTitleCenter.test.ts
+++ b/src/engines/Simulator/components/Dock/__tests__/dockTitleCenter.test.ts
@@ -8,8 +8,8 @@ vi.mock("../config", () => ({
 }));
 
 vi.mock("lucide-react", () => ({
+  Chromium: "ChromiumIcon",
   Code: "CodeIcon",
-  Globe: "GlobeIcon",
   ListTodo: "ListTodoIcon",
 }));
 
@@ -22,7 +22,7 @@ describe("getWorkStationStationTitleCenter", () => {
       label: "labels.codeEditor",
     });
     expect(getWorkStationStationTitleCenter("browser", navigationT)).toEqual({
-      icon: "GlobeIcon",
+      icon: "ChromiumIcon",
       label: "labels.browser",
     });
     expect(getWorkStationStationTitleCenter("project", navigationT)).toEqual({

--- a/src/engines/Simulator/components/Dock/config.ts
+++ b/src/engines/Simulator/components/Dock/config.ts
@@ -6,9 +6,9 @@
 import type { LucideIcon } from "lucide-react";
 import {
   Infinity,
+  Chromium,
   Code,
   GitBranch,
-  Globe,
   Layout,
   ListTodo,
   MessageCircle,
@@ -30,7 +30,7 @@ export const DOCK_APP_SEGMENTS: DockApp[][] = [
   [
     { id: "CHANNELS", name: "Communication", icon: MessageCircle },
     { id: "CODE_EDITOR", name: "Code Editor", icon: Code },
-    { id: "BROWSER", name: "Browser", icon: Globe },
+    { id: "BROWSER", name: "Browser", icon: Chromium },
     { id: "STORY_MANAGER", name: "Project Manager", icon: ListTodo },
     { id: "CANVAS", name: "Canvas", icon: Layout },
   ],

--- a/src/engines/Simulator/components/Dock/dockTitleCenter.ts
+++ b/src/engines/Simulator/components/Dock/dockTitleCenter.ts
@@ -4,7 +4,7 @@
  */
 import type { TFunction } from "i18next";
 import type { LucideIcon } from "lucide-react";
-import { Code, Globe, ListTodo, MonitorDot, Package2 } from "lucide-react";
+import { Chromium, Code, ListTodo, MonitorDot, Package2 } from "lucide-react";
 
 import { APP_TYPE_PROJECT, AppType } from "../../types/appTypes";
 import { BACKGROUND_TASKS_DOCK_APP, getAppById } from "./config";
@@ -17,7 +17,7 @@ export function getWorkStationStationTitleCenter(
     case "code":
       return { icon: Code, label: t("labels.codeEditor") };
     case "browser":
-      return { icon: Globe, label: t("labels.browser") };
+      return { icon: Chromium, label: t("labels.browser") };
     case "chat":
       return { icon: Package2, label: t("labels.session") };
     case "project":

--- a/src/modules/WorkStation/shared/StatusBar/PortsStatusMenu.tsx
+++ b/src/modules/WorkStation/shared/StatusBar/PortsStatusMenu.tsx
@@ -2,14 +2,7 @@
  * Ports status-bar menu: workspace vs external listening ports.
  */
 import { useAtomValue, useSetAtom } from "jotai";
-import {
-  Copy,
-  Loader2,
-  Search,
-  SquareArrowOutUpRight,
-  Trash2,
-  Unplug,
-} from "lucide-react";
+import { Chromium, Copy, Loader2, Search, Trash2, Unplug } from "lucide-react";
 import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
@@ -132,7 +125,7 @@ const PortRow: React.FC<PortRowProps> = memo(
               onOpen(port);
             }}
           >
-            <SquareArrowOutUpRight size={MENU_ICON_SIZE} />
+            <Chromium size={MENU_ICON_SIZE} aria-hidden />
           </button>
           <button
             type="button"


### PR DESCRIPTION
## Summary

Routes every in-app Browser affordance through the `Chromium` glyph, and leaves `SquareArrowOutUpRight` to mean external-browser only.

## Problem

The workstation Browser was drawn two different ways depending on the surface:

- Navigation surfaces (segment registry, Dock, station title center) used `Globe`.
- Controls that open a URL *inside* that Browser (ports status menu, markdown link hover card, chat website card) used `SquareArrowOutUpRight`.

`SquareArrowOutUpRight` is also the app's glyph for "leave the app and open your default browser" — the hover card renders both meanings side by side, one per button. So the same icon carried two opposite destinations, and the destination the user actually got was not predictable from the icon.

## Solution

Use `Chromium` for both roles:

- `src/config/segmentRegistry.ts`, `Dock/config.ts`, `Dock/dockTitleCenter.ts` — the Browser app/segment icon.
- `PortsStatusMenu.tsx`, `LinkHoverCard.tsx`, `WebsiteCard.tsx` — the open-in-app-Browser action.

`LinkHoverCard`'s "open with default browser" button keeps `SquareArrowOutUpRight`, so the two buttons now read as two destinations.

Icon-only instances get `aria-hidden` where the surrounding control already carries a translated accessible name.

## Potential risks

- Purely presentational — no behavior, routing, or handler changes.
- `Chromium` is a brand glyph being used for a Chromium-based embedded WebView. On macOS that WebView is WKWebView, not Chromium, so the icon is a genre cue rather than a literal engine claim. Flagging in case that reads wrong; `Globe` remains available if preferred.
- Anything asserting on `.lucide-globe` in a Browser navigation context would need updating; the one such test is updated here.

## Validation

- `tsc --noEmit` clean.
- `eslint` clean on changed files.
- `vitest run src/engines/Simulator/components/Dock src/components/MarkDown` — 9 files, 65 tests passing (`dockTitleCenter.test.ts` updated to the new glyph).