### PR TITLE
fix(ui): align thread card rows and worktree source tabs

### DIFF
--- a/docs/frontend-ui-audit-2026-08-21/WorkItemThreadActionAlignment.md
+++ b/docs/frontend-ui-audit-2026-08-21/WorkItemThreadActionAlignment.md
@@ -1,0 +1,24 @@
+# Work Item thread action alignment
+
+## Scope
+
+Audited the custom-properties and sub-item thread cards for add-action consistency and shared horizontal axes between card headers and nested rows.
+
+## Findings
+
+| Line                                                                                              | Element                            | Verdict          | Reason                                                                                                                                                       | Suggested change                                                                         |
+| ------------------------------------------------------------------------------------------------- | ---------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
+| `src/modules/ProjectManager/WorkItems/components/WorkItemThread/tokens.ts:6`                      | Thread-card alignment tokens       | abstract         | Card bodies already own the 12px inset, so nested rows need zero additional horizontal padding plus stable 20px leading and 24px trailing slots.             | Keep future thread-card rows on these shared alignment tokens.                           |
+| `src/modules/ProjectManager/WorkItems/components/WorkItemThread/index.tsx:150`                    | Section-header icon slot           | abstract         | Header icons previously rendered at their intrinsic width while child status and checkbox icons used wider wrappers, producing different horizontal centers. | Wrap every section icon in the shared leading slot.                                      |
+| `src/modules/ProjectManager/WorkItems/components/WorkItemContent/CustomPropertiesSection.tsx:321` | Custom-properties actions and rows | fix              | The add/cancel header control retained text, while property and empty rows added an independent 8px inset inside the padded body.                            | Use the canonical icon-only action and remove nested horizontal padding.                 |
+| `src/modules/ProjectManager/WorkItems/components/WorkItemSubItems.tsx:425`                        | Sub-item actions and rows          | fix              | Header and empty-state add controls used different button structures; child state icons and chevrons were offset by nested row padding and unequal slots.    | Use icon-only actions plus shared leading/trailing slots and row padding.                |
+| `src/modules/shared/components/ActivityTimeline/index.tsx:37`                                     | Canonical header action primitive  | keep with reason | The existing primitive already provides a 24px icon-only target, accessible label/title, and shared hover treatment.                                         | Reuse it instead of introducing another Work Item-specific icon button.                  |
+
+## Summary
+
+- Fix: 2
+- Keep with reason: 1
+- Abstract: 2
+- Remaining cross-file sweep candidates: 0
+
+The configured `frontend-ui-audit` skill file was unavailable in both the referenced user-global and workspace locations. This report follows the repository's documented audit table convention and covers the changed UI surfaces directly.

--- a/src/features/SessionCreator/components/WorktreeNameTab.tsx
+++ b/src/features/SessionCreator/components/WorktreeNameTab.tsx
@@ -27,7 +27,7 @@ export function WorktreeNameTab({
 }) {
   const { t } = useTranslation("sessions");
   return (
-    <div className="flex min-h-[250px] flex-col gap-2">
+    <div className="flex min-h-72 flex-col gap-2">
       <label
         htmlFor={NAME_INPUT_ID}
         className="text-[12px] font-medium text-text-3"
@@ -49,12 +49,19 @@ export function WorktreeNameTab({
       />
       {source && (
         <WorktreeSourceList>
-          <div className="flex flex-col gap-0.5">
+          <div className="flex flex-col gap-px">
             <WorktreeSourceRow
               icon={<CaseSensitive size={14} strokeWidth={1.75} />}
               title={source.title ?? source.label}
               detail={
-                source.baseBranch ? `Base: ${source.baseBranch}` : "Base: HEAD"
+                source.baseBranch
+                  ? t("creator.worktreeSource.nameBase", {
+                      branch: source.baseBranch,
+                      defaultValue: `Base: ${source.baseBranch}`,
+                    })
+                  : t("creator.worktreeSource.nameBaseHead", {
+                      defaultValue: "Base: HEAD",
+                    })
               }
               selected={selected}
               onClick={() => onSelect(source)}

--- a/src/features/SessionCreator/components/WorktreeSmartTab.tsx
+++ b/src/features/SessionCreator/components/WorktreeSmartTab.tsx
@@ -10,8 +10,7 @@ import {
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
-import { DROPDOWN_SEARCH } from "@src/components/Dropdown/tokens";
-import Input from "@src/components/Input";
+import SearchInput from "@src/components/SearchInput";
 import type { WorktreeLaunchSource } from "@src/store/session/worktreeLaunchSourceAtom";
 
 import {
@@ -24,8 +23,6 @@ import type {
   SmartSuggestion,
   SmartSuggestionKind,
 } from "./worktreeSmartInput";
-
-const SMART_INPUT_ID = "worktree-source-smart-input";
 
 function smartIcon(kind: SmartSuggestionKind): ReactNode {
   switch (kind) {
@@ -65,26 +62,16 @@ export function WorktreeSmartTab({
 }) {
   const { t } = useTranslation("sessions");
   return (
-    <div className="flex min-h-[250px] flex-col gap-2">
-      <label
-        htmlFor={SMART_INPUT_ID}
-        className="text-[12px] font-medium text-text-3"
-      >
-        {t("creator.worktreeSource.smartLabel", {
-          defaultValue: "Name, number, branch, or URL",
-        })}
-      </label>
-      <Input
-        id={SMART_INPUT_ID}
-        type="search"
+    <div className="flex min-h-72 flex-col gap-2">
+      <SearchInput
+        variant="sidebar"
         value={query}
         onChange={onQueryChange}
-        allowClear
-        prefix={<Sparkles size={DROPDOWN_SEARCH.iconSize} strokeWidth={1.75} />}
+        showClearButton
         placeholder={t("creator.worktreeSource.smartPlaceholder", {
           defaultValue: "Name, #1234, branch, or GitHub/GitLab URL",
         })}
-        aria-label={t("creator.worktreeSource.smartAria", {
+        ariaLabel={t("creator.worktreeSource.smartAria", {
           defaultValue: "Enter a name, PR number, branch, or GitHub/GitLab URL",
         })}
       />
@@ -113,7 +100,14 @@ export function WorktreeSmartTab({
               <WorktreeSourceRow
                 key={suggestion.id}
                 icon={smartIcon(suggestion.kind)}
-                title={suggestion.title}
+                title={
+                  suggestion.kind === "customRef"
+                    ? t("creator.worktreeSource.branchUseAsRef", {
+                        value: suggestion.source.baseBranch ?? "",
+                        defaultValue: `Use "${suggestion.source.baseBranch ?? ""}" as ref`,
+                      })
+                    : suggestion.title
+                }
                 selected={
                   sourceKey(fallbackSource ?? suggestion.source) ===
                   sourceKey(suggestion.source)

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemContent/CustomPropertiesSection.tsx
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemContent/CustomPropertiesSection.tsx
@@ -14,8 +14,12 @@ import Checkbox from "@src/components/Checkbox";
 import InlineAlert from "@src/components/InlineAlert";
 import Input from "@src/components/Input";
 import Select, { type SelectOption } from "@src/components/Select";
+import { ActivityHeaderActionButton } from "@src/modules/shared/components/ActivityTimeline";
 
-import { WorkItemThreadSection } from "../WorkItemThread";
+import {
+  WORK_ITEM_THREAD_TOKENS,
+  WorkItemThreadSection,
+} from "../WorkItemThread";
 
 interface CustomPropertiesSectionProps {
   projectSlug?: string | null;
@@ -316,21 +320,18 @@ const CustomPropertiesSection: React.FC<CustomPropertiesSectionProps> = ({
       }
       action={
         editable ? (
-          <Button
-            variant="tertiary"
-            appearance="ghost"
-            size="mini"
-            icon={showCreate ? <X size={13} /> : <Plus size={13} />}
-            className="!font-normal"
+          <ActivityHeaderActionButton
+            icon={showCreate ? <X size={12} /> : <Plus size={12} />}
+            label={
+              showCreate
+                ? t("common:actions.cancel", { defaultValue: "Cancel" })
+                : t("workItems.properties.add", {
+                    defaultValue: "Add property",
+                  })
+            }
             onClick={() => setShowCreate((current) => !current)}
             data-testid="work-item-property-add-toggle"
-          >
-            {showCreate
-              ? t("common:actions.cancel", { defaultValue: "Cancel" })
-              : t("workItems.properties.add", {
-                  defaultValue: "Add property",
-                })}
-          </Button>
+          />
         ) : null
       }
     >
@@ -398,13 +399,13 @@ const CustomPropertiesSection: React.FC<CustomPropertiesSectionProps> = ({
         ) : null}
 
         {isLoading ? (
-          <p className="px-2 py-2 text-[12px] text-text-3">
+          <p className="px-0 py-2 text-[12px] text-text-3">
             {t("workItems.properties.loading", {
               defaultValue: "Loading properties…",
             })}
           </p>
         ) : definitions.length === 0 ? (
-          <p className="px-2 py-2 text-[12px] text-text-3">
+          <p className="px-0 py-2 text-[12px] text-text-3">
             {t("workItems.properties.empty", {
               defaultValue: "No custom properties yet.",
             })}
@@ -414,7 +415,7 @@ const CustomPropertiesSection: React.FC<CustomPropertiesSectionProps> = ({
             {definitions.map((property) => (
               <div
                 key={property.id}
-                className="flex min-h-8 items-center gap-3 rounded-lg px-2 py-1"
+                className={`flex min-h-8 items-center gap-3 rounded-lg ${WORK_ITEM_THREAD_TOKENS.alignedRowPadding}`}
               >
                 <div className="w-36 shrink-0">
                   <p className="truncate text-[13px] font-medium leading-5 text-text-2">

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemContent/__tests__/CustomPropertiesSection.test.ts
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemContent/__tests__/CustomPropertiesSection.test.ts
@@ -94,9 +94,17 @@ describe("CustomPropertiesSection", () => {
     expect(section?.innerHTML).toContain("bg-primary-container px-3 py-2");
     expect(section?.innerHTML).toContain("bg-chat-pane px-3 py-2");
     expect(section?.innerHTML).not.toContain("bg-bg-2 p-3");
-    expect(row?.className).toContain("rounded-lg px-2 py-1");
+    expect(row?.className).toContain("rounded-lg px-0 py-1");
     expect(
       container.querySelector(".lucide-list-chevrons-up-down")
     ).not.toBeNull();
+
+    const addButton = container.querySelector<HTMLButtonElement>(
+      "[data-testid='work-item-property-add-toggle']"
+    );
+    expect(addButton?.textContent).toBe("");
+    expect(addButton?.getAttribute("aria-label")).toBe("Add property");
+    expect(addButton?.title).toBe("Add property");
+    expect(addButton?.querySelector(".lucide-plus")).not.toBeNull();
   });
 });

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemSubItems.test.ts
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemSubItems.test.ts
@@ -160,10 +160,32 @@ describe("WorkItemSubItems hierarchy UI", () => {
     expect(markup).toContain("bg-chat-pane px-3 py-2");
     expect(markup).toContain("flex flex-col gap-0.5");
     expect(markup).toContain("min-h-8 w-full");
-    expect(markup).toContain("rounded-lg px-2 py-1");
+    expect(markup).toContain("px-0 py-1");
     expect(markup).toContain("max-h-64 overflow-y-auto");
     expect(markup).not.toContain("!p-0");
     expect(markup).not.toContain("min-h-9");
     expect(markup).not.toContain("px-3 pb-3");
+  });
+
+  it("uses aligned icon-only add actions in headers and empty states", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(WorkItemSubItems, {
+        family: { parent: null, children: [] },
+        parentShortId: "WI-0001",
+      })
+    );
+    const headerButton = markup.match(
+      /<button[^>]*data-testid="work-item-sub-item-add"[^>]*>(.*?)<\/button>/
+    )?.[1];
+    const emptyButton = markup.match(
+      /<button[^>]*data-testid="work-item-sub-items-empty-add"[^>]*>(.*?)<\/button>/
+    )?.[1];
+
+    expect(headerButton).toContain("lucide-plus");
+    expect(headerButton).not.toContain("Add sub-item");
+    expect(emptyButton).toContain("lucide-plus");
+    expect(emptyButton).not.toContain("Add the first sub-item");
+    expect(markup).toContain('aria-label="Add sub-item"');
+    expect(markup).toContain('title="Add sub-item"');
   });
 });

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemSubItems.tsx
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemSubItems.tsx
@@ -21,8 +21,12 @@ import {
 } from "@src/features/Org2Cloud/cloudShortId";
 import { createLogger } from "@src/hooks/logger";
 import { useProjectDataChanged } from "@src/hooks/project";
+import { ActivityHeaderActionButton } from "@src/modules/shared/components/ActivityTimeline";
 
-import { WorkItemThreadSection } from "./WorkItemThread";
+import {
+  WORK_ITEM_THREAD_TOKENS,
+  WorkItemThreadSection,
+} from "./WorkItemThread";
 
 const logger = createLogger("WorkItemSubItems");
 
@@ -192,10 +196,7 @@ const SubItemStateIcon: React.FC<SubItemStateIconProps> = ({
   } as const;
 
   return (
-    <span
-      className="flex h-6 w-5 shrink-0 items-center justify-center"
-      title={label}
-    >
+    <span className={WORK_ITEM_THREAD_TOKENS.leadingIconSlot} title={label}>
       {state === "completed" ? (
         <CheckCircle2 {...commonProps} className="text-purple-6" />
       ) : state === "cancelled" ? (
@@ -422,24 +423,21 @@ const WorkItemSubItems: React.FC<WorkItemSubItemsProps> = ({
         ) : null
       }
       action={
-        <Button
-          variant="tertiary"
-          appearance="ghost"
-          size="mini"
-          icon={<Plus size={13} aria-hidden />}
-          className="!font-normal"
+        <ActivityHeaderActionButton
+          icon={<Plus size={12} aria-hidden />}
+          label={t("workItems.subItems.add", {
+            defaultValue: "Add sub-item",
+          })}
           disabled={adding}
           onClick={() => setAdding(true)}
           data-testid="work-item-sub-item-add"
-        >
-          {t("workItems.subItems.add", { defaultValue: "Add sub-item" })}
-        </Button>
+        />
       }
     >
       {parent ? (
         <button
           type="button"
-          className="group flex min-h-8 w-full cursor-pointer items-start gap-2 rounded-lg px-2 py-1 text-left transition-colors hover:bg-fill-1 disabled:cursor-default"
+          className={`group flex min-h-8 w-full cursor-pointer items-start gap-2 rounded-lg text-left transition-colors hover:bg-fill-1 disabled:cursor-default ${WORK_ITEM_THREAD_TOKENS.alignedRowPadding}`}
           onClick={() => onOpenWorkItem?.(parent)}
           disabled={!onOpenWorkItem}
           data-testid="work-item-parent-link"
@@ -454,7 +452,7 @@ const WorkItemSubItems: React.FC<WorkItemSubItemsProps> = ({
             {parent.frontmatter.short_id}
           </span>
           {onOpenWorkItem ? (
-            <span className="flex h-6 shrink-0 items-center">
+            <span className={WORK_ITEM_THREAD_TOKENS.trailingActionSlot}>
               <ChevronRight
                 size={14}
                 className="text-text-4 transition-colors group-hover:text-text-2"
@@ -470,7 +468,7 @@ const WorkItemSubItems: React.FC<WorkItemSubItemsProps> = ({
           {groupSubItemsByStage(children).map((group) => (
             <div key={group.key} className="flex flex-col gap-0.5">
               {group.label ? (
-                <div className="px-2 pb-1 pt-2 text-[10px] font-normal uppercase tracking-wide text-text-4">
+                <div className="px-0 pb-1 pt-2 text-[10px] font-normal uppercase tracking-wide text-text-4">
                   {group.stage !== undefined
                     ? t("workItems.subItems.stage", {
                         defaultValue: "Stage {{stage}}",
@@ -487,7 +485,7 @@ const WorkItemSubItems: React.FC<WorkItemSubItemsProps> = ({
                   <button
                     type="button"
                     key={child.frontmatter.short_id}
-                    className="group flex min-h-8 w-full cursor-pointer items-start gap-2 rounded-lg px-2 py-1 text-left transition-colors hover:bg-fill-1 disabled:cursor-default"
+                    className={`group flex min-h-8 w-full cursor-pointer items-start gap-2 rounded-lg text-left transition-colors hover:bg-fill-1 disabled:cursor-default ${WORK_ITEM_THREAD_TOKENS.alignedRowPadding}`}
                     onClick={() => onOpenWorkItem?.(child)}
                     disabled={!onOpenWorkItem}
                     data-sub-item-state={state}
@@ -504,7 +502,9 @@ const WorkItemSubItems: React.FC<WorkItemSubItemsProps> = ({
                       {child.frontmatter.short_id}
                     </span>
                     {onOpenWorkItem ? (
-                      <span className="flex h-6 shrink-0 items-center">
+                      <span
+                        className={WORK_ITEM_THREAD_TOKENS.trailingActionSlot}
+                      >
                         <ChevronRight
                           size={14}
                           className="text-text-4 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100"
@@ -520,21 +520,21 @@ const WorkItemSubItems: React.FC<WorkItemSubItemsProps> = ({
           {composer}
         </div>
       ) : (
-        <Button
-          variant="tertiary"
-          appearance="ghost"
-          size="small"
-          long
-          icon={<Plus size={13} aria-hidden />}
-          iconPosition="right"
-          className="!h-auto !justify-between !rounded-lg !px-2 !py-2 !text-left !text-[12px] !font-normal !text-text-3 hover:!bg-fill-1 hover:!text-text-2"
-          onClick={() => setAdding(true)}
-          data-testid="work-item-sub-items-empty-add"
-        >
-          {t("workItems.subItems.addFirst", {
-            defaultValue: "Add the first sub-item",
-          })}
-        </Button>
+        <div className={WORK_ITEM_THREAD_TOKENS.emptyActionRow}>
+          <span className="min-w-0 flex-1 truncate text-[12px] text-text-3">
+            {t("workItems.subItems.addFirst", {
+              defaultValue: "Add the first sub-item",
+            })}
+          </span>
+          <ActivityHeaderActionButton
+            icon={<Plus size={12} aria-hidden />}
+            label={t("workItems.subItems.addFirst", {
+              defaultValue: "Add the first sub-item",
+            })}
+            onClick={() => setAdding(true)}
+            data-testid="work-item-sub-items-empty-add"
+          />
+        </div>
       )}
     </WorkItemThreadSection>
   );

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemThread/__tests__/presentation.test.ts
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemThread/__tests__/presentation.test.ts
@@ -68,4 +68,11 @@ describe("work item thread metadata presentation", () => {
       classNames.some((className) => className.startsWith("rounded"))
     ).toBe(false);
   });
+
+  it("shares leading and trailing axes between headers and child rows", () => {
+    expect(WORK_ITEM_THREAD_TOKENS.alignedRowPadding).toBe("px-0 py-1");
+    expect(WORK_ITEM_THREAD_TOKENS.leadingIconSlot).toContain("w-5");
+    expect(WORK_ITEM_THREAD_TOKENS.trailingActionSlot).toContain("w-6");
+    expect(WORK_ITEM_THREAD_TOKENS.emptyActionRow).not.toContain("px-");
+  });
 });

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemThread/index.tsx
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemThread/index.tsx
@@ -149,7 +149,11 @@ export const WorkItemThreadSection: React.FC<WorkItemThreadSectionProps> = ({
     >
       <div className={WORK_ITEM_THREAD_TOKENS.cardHeader}>
         <div className="flex min-w-0 items-center gap-2">
-          {icon}
+          {icon ? (
+            <span className={WORK_ITEM_THREAD_TOKENS.leadingIconSlot}>
+              {icon}
+            </span>
+          ) : null}
           <span id={titleId} className="text-[13px] font-semibold text-text-1">
             {title}
           </span>

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemThread/tokens.ts
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemThread/tokens.ts
@@ -3,6 +3,10 @@ export const WORK_ITEM_THREAD_TOKENS = {
   cardHeader:
     "flex min-h-10 items-center justify-between gap-3 border-b border-border-1 bg-primary-container px-3 py-2",
   cardBody: "bg-chat-pane px-3 py-2",
+  alignedRowPadding: "px-0 py-1",
+  leadingIconSlot: "flex h-6 w-5 shrink-0 items-center justify-center",
+  trailingActionSlot: "flex h-6 w-6 shrink-0 items-center justify-center",
+  emptyActionRow: "flex min-h-8 items-center justify-between gap-2 py-1",
   collapsibleHeader:
     "!mb-0 !h-10 border-b border-border-1 bg-primary-container px-3",
   contentColumn:


### PR DESCRIPTION
## Summary

Two UI surfaces that had drifted from the design system in the same way — locally reinvented controls and arbitrary values where a shared primitive or scale value already existed.

## Problem

**Work Item thread cards.** Card bodies already own a 12px inset, but nested rows added another 8px of their own (`px-2`), so property rows, sub-item rows, and the parent link each sat on a different horizontal axis from their card header. Section header icons rendered at intrinsic width while child status icons and chevrons used wider wrappers, so the leading and trailing columns did not line up either. The two add controls were built from different buttons: a labelled ghost button in card headers, and a full-width labelled button carrying eight `!important` overrides in the sub-items empty state.

**Worktree source tabs.** The Smart tab hand-built a search field from a raw `Input` plus a standalone `<label>` instead of the `SearchInput` every other search surface uses. The Name tab hardcoded English `Base: …` detail text with no translation key. Custom-ref suggestions showed the bare ref instead of saying what selecting it does. Both tabs used an arbitrary `min-h-[250px]`.

## Solution

Thread cards:
- Add shared alignment tokens to `WORK_ITEM_THREAD_TOKENS` — `alignedRowPadding`, `leadingIconSlot` (20px), `trailingActionSlot` (24px), `emptyActionRow` — so header and child rows resolve to the same axes from one place.
- Wrap every section header icon in the leading slot.
- Move both add controls onto the canonical `ActivityHeaderActionButton`, which already provides a 24px icon-only target, a translated accessible name and title, and shared hover treatment. This removes the `!important` override block.

Worktree tabs:
- Smart tab onto `SearchInput` (sidebar variant, `showClearButton`), dropping the bespoke label and prefix wiring.
- Translation keys with English defaults for the base-branch detail and the custom-ref suggestion (`Use "<ref>" as ref`).
- `min-h-[250px]` → `min-h-72` on both tabs.

Audit report: `docs/frontend-ui-audit-2026-08-21/WorkItemThreadActionAlignment.md` (fix: 2, keep-with-reason: 1, abstract: 2, sweep candidates: 0).

## Potential risks

- **Add actions lose their visible text labels.** "Add sub-item", "Add the first sub-item", and "Add property" become icon-only buttons. Accessible names and tooltips are preserved and translated, but discoverability drops for sighted users who were scanning for the words. This is the change most worth a second opinion; it is what makes the actions align with the rest of the thread.
- The new tokens are string constants asserted by tests, not enforced by types — a future row can still hardcode its own padding. The audit report records them as the intended shared abstraction.
- The two translation keys ship with English `defaultValue`s and no locale entries yet, so non-English users see English until they are translated. Consistent with how the surrounding `creator.worktreeSource.*` keys already work.

## Validation

- `tsc --noEmit` clean.
- `eslint` clean on changed files.
- `vitest run src/modules/ProjectManager/WorkItems src/features/SessionCreator` — 54 files, 313 tests passing.
- Verified in an isolated `git worktree` so unrelated in-progress work in the local tree could not affect the result.
- New coverage: `presentation.test.ts` asserts the four alignment tokens; `CustomPropertiesSection.test.ts` and `WorkItemSubItems.test.ts` assert both add controls render icon-only with translated `aria-label`/`title`, and that rows carry `px-0 py-1`.
- Manual: open a Work Item thread with custom properties, sub-items, a parent link, and an empty sub-items state, and confirm icons and trailing chevrons share a vertical edge across all cards. Open the session creator worktree Name and Smart tabs and confirm the search field matches other search surfaces and the tab does not resize between them.

## Note

Originally split as two PRs (thread alignment, worktree tabs); combined here at review request. They share no files, so either half can be dropped from the branch cleanly if you would rather land them separately.