### PR TITLE
test(frontend): cover composer realtime and team inbox

### DIFF
--- a/src/engines/ChatPanel/hooks/useInputArea/useSubmitMessage.test.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/useSubmitMessage.test.ts
@@ -1,0 +1,450 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement, useEffect } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  ComposerInputRef,
+  ComposerSnapshot,
+} from "@src/components/ComposerInput";
+import type { ChatImageAttachment } from "@src/store/ui/chatImageAtom";
+import { wpReadOnlyAtom } from "@src/store/ui/chatPanelAtom";
+import { type SmokeRoot, createSmokeRoot } from "@src/test/reactSmokeHarness";
+
+import type { InputAreaRefs } from "./types";
+import {
+  type UseSubmitMessageOptions,
+  useSubmitMessage,
+} from "./useSubmitMessage";
+
+const mocks = vi.hoisted(() => ({
+  addressCommentsRun: vi.fn(),
+  clearImageDraft: vi.fn(),
+  guardAgainstSecrets: vi.fn(),
+  interceptPendingQuestionBatches: vi.fn(),
+  messageError: vi.fn(),
+  messageInfo: vi.fn(),
+  messageWarning: vi.fn(),
+  parseAddressCommentsSlashCommand: vi.fn(),
+  parseCompactSlashCommand: vi.fn(),
+  projectOutgoingUserMessage: vi.fn(),
+  resolveMcpSlashCommand: vi.fn(),
+  runManualCompact: vi.fn(),
+  waitForPendingPills: vi.fn(),
+}));
+
+vi.mock("@src/components/Message", () => ({
+  default: {
+    error: mocks.messageError,
+    info: mocks.messageInfo,
+    warning: mocks.messageWarning,
+  },
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@src/hooks/logger", () => ({
+  createLogger: () => ({ warn: vi.fn() }),
+}));
+
+vi.mock("@src/hooks/security/useSecretScanGuard", () => ({
+  useSecretScanGuard: () => mocks.guardAgainstSecrets,
+}));
+
+vi.mock("@src/features/Org2Cloud/addressCommentsSlashToken", () => ({
+  parseAddressCommentsSlashCommand: mocks.parseAddressCommentsSlashCommand,
+}));
+
+vi.mock("@src/features/Org2Cloud/useAddressCommentsSlashCommand", () => ({
+  useAddressCommentsSlashCommand: () => ({ run: mocks.addressCommentsRun }),
+}));
+
+vi.mock("@src/engines/SessionCore", async () => {
+  const { atom } = await import("jotai/vanilla");
+  return { chatEventsAtom: atom([]) };
+});
+
+vi.mock("@src/store/session", async () => {
+  const { atom } = await import("jotai/vanilla");
+  return { sessionByIdAtom: () => atom(null) };
+});
+
+vi.mock("@src/store/ui/chatPanelAtom", async () => {
+  const { atom } = await import("jotai/vanilla");
+  return { wpReadOnlyAtom: atom(false) };
+});
+
+vi.mock("@src/util/contextPillContent", () => ({
+  waitForPendingPills: mocks.waitForPendingPills,
+}));
+
+vi.mock("@src/util/session/sessionDispatch", () => ({
+  isCliSession: () => false,
+}));
+
+vi.mock("@src/engines/ChatPanel/InputArea/utils/imageDraftCache", () => ({
+  clearImageDraft: mocks.clearImageDraft,
+}));
+
+vi.mock("@src/engines/ChatPanel/hooks/useManualCompact", async () => {
+  const { atom } = await import("jotai/vanilla");
+  return {
+    manualCompactInFlightSessionAtom: atom<string | null>(null),
+    parseCompactSlashCommand: mocks.parseCompactSlashCommand,
+    useManualCompact: () => ({ runManualCompact: mocks.runManualCompact }),
+  };
+});
+
+vi.mock("./mcpSlashCommand", () => ({
+  resolveMcpSlashCommand: mocks.resolveMcpSlashCommand,
+}));
+
+vi.mock("./outgoingTextTransforms", () => ({
+  expandSkillPills: (text: string) => ({
+    expanded: text,
+    hasSkillPills: false,
+  }),
+  stripContextPillBase64: (text: string) => text,
+}));
+
+vi.mock("./projectOutgoingUserMessage", () => ({
+  projectOutgoingUserMessage: mocks.projectOutgoingUserMessage,
+}));
+
+vi.mock("./questionIntercept", () => ({
+  interceptPendingQuestionBatches: mocks.interceptPendingQuestionBatches,
+}));
+
+interface EditorHarness {
+  editor: ComposerInputRef;
+  readText(): string;
+}
+
+function createEditor(initialText: string): EditorHarness {
+  let text = initialText;
+  const snapshot: ComposerSnapshot = {
+    parts: [{ kind: "text", text: initialText }],
+  };
+  const editor = {
+    getTextWithPills: vi.fn(() => text),
+    getTerminalPillTexts: vi.fn(() => ({})),
+    getSnapshot: vi.fn(() => snapshot),
+    clear: vi.fn(() => {
+      text = "";
+    }),
+    setContent: vi.fn((content: string | ComposerSnapshot) => {
+      text =
+        typeof content === "string"
+          ? content
+          : content.parts
+              .map((part) => (part.kind === "text" ? part.text : ""))
+              .join("");
+    }),
+  } as unknown as ComposerInputRef;
+  return { editor, readText: () => text };
+}
+
+function createRefs(editor: ComposerInputRef): InputAreaRefs {
+  return {
+    composerInputRef: { current: editor },
+    containerRef: { current: null },
+    contextMenuKeyboardHandlerRef: { current: null },
+    slashCommandKeyboardHandlerRef: { current: null },
+    plusSlashCommandKeyboardHandlerRef: { current: null },
+    hasContentRef: { current: true },
+    setHasContent: vi.fn(),
+  };
+}
+
+function image(id = "image-1"): ChatImageAttachment {
+  return {
+    id,
+    dataUrl: `data:image/png;base64,${id}`,
+    fileName: `${id}.png`,
+    size: 10,
+    width: 4,
+    height: 4,
+  };
+}
+
+let latestSubmit: ReturnType<typeof useSubmitMessage> | null = null;
+
+function Harness({ options }: { options: UseSubmitMessageOptions }): null {
+  const submit = useSubmitMessage(options);
+  useEffect(() => {
+    latestSubmit = submit;
+  }, [submit]);
+  return null;
+}
+
+describe("useSubmitMessage composer boundary", () => {
+  let root: SmokeRoot;
+  let store: ReturnType<typeof createStore>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    latestSubmit = null;
+    root = createSmokeRoot();
+    mocks.guardAgainstSecrets.mockResolvedValue(true);
+    mocks.parseAddressCommentsSlashCommand.mockReturnValue(null);
+    mocks.parseCompactSlashCommand.mockReturnValue(null);
+    mocks.projectOutgoingUserMessage.mockImplementation(
+      ({ displayText }: { displayText: string }) => ({
+        agentContent: `agent:${displayText}`,
+      })
+    );
+    mocks.resolveMcpSlashCommand.mockResolvedValue(null);
+    mocks.waitForPendingPills.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    await root.unmount();
+  });
+
+  async function mount(
+    options: UseSubmitMessageOptions,
+    initializeStore?: (nextStore: ReturnType<typeof createStore>) => void
+  ): Promise<void> {
+    store = createStore();
+    initializeStore?.(store);
+    await root.render(
+      createElement(Provider, { store }, createElement(Harness, { options }))
+    );
+    expect(latestSubmit).not.toBeNull();
+  }
+
+  function optionsFor(
+    editorHarness: EditorHarness,
+    overrides: Partial<UseSubmitMessageOptions> = {}
+  ): UseSubmitMessageOptions {
+    return {
+      refs: createRefs(editorHarness.editor),
+      draftSessionId: "session-1",
+      addressSessionId: "session-1",
+      replyTargetEventId: "reply-event-1",
+      flushDraft: vi.fn().mockResolvedValue(undefined),
+      clearReplyTarget: vi.fn().mockResolvedValue(undefined),
+      imageAttachment: {
+        hasImages: false,
+        images: [],
+        clearImages: vi.fn(),
+        restoreImages: vi.fn(),
+      },
+      citeCode: {
+        isCiteCode: false,
+        clearCiteCode: vi.fn(),
+        captureCiteCode: vi.fn(),
+        restoreCiteCode: vi.fn(),
+      },
+      handleSessChatSubmit: vi.fn().mockResolvedValue(undefined),
+      ...overrides,
+    };
+  }
+
+  it("delegates one in-flight send to workspace chat and clears durable composer state", async () => {
+    const editorHarness = createEditor("ship the fix");
+    let resolveDispatch!: () => void;
+    const pendingDispatch = new Promise<void>((resolve) => {
+      resolveDispatch = resolve;
+    });
+    const handleSessChatSubmit = vi.fn(() => pendingDispatch);
+    const flushDraft = vi.fn().mockResolvedValue(undefined);
+    const clearReplyTarget = vi.fn().mockResolvedValue(undefined);
+    const options = optionsFor(editorHarness, {
+      flushDraft,
+      clearReplyTarget,
+      handleSessChatSubmit,
+    });
+    await mount(options);
+
+    let first!: Promise<void>;
+    let duplicate!: Promise<void>;
+    act(() => {
+      first = latestSubmit!();
+      duplicate = latestSubmit!();
+    });
+    await vi.waitFor(() => expect(handleSessChatSubmit).toHaveBeenCalledOnce());
+    resolveDispatch();
+    await act(async () => {
+      await Promise.all([first, duplicate]);
+    });
+
+    expect(mocks.guardAgainstSecrets).toHaveBeenCalledWith("ship the fix");
+    expect(handleSessChatSubmit).toHaveBeenCalledWith(
+      undefined,
+      "ship the fix",
+      "agent:ship the fix",
+      undefined
+    );
+    expect(editorHarness.editor.clear).toHaveBeenCalledOnce();
+    expect(editorHarness.readText()).toBe("");
+    expect(options.refs.setHasContent).toHaveBeenCalledWith(false);
+    expect(flushDraft).toHaveBeenCalledWith("");
+    expect(clearReplyTarget).toHaveBeenCalledOnce();
+  });
+
+  it("allows a different captured message while the first dispatch is still in flight", async () => {
+    const editorHarness = createEditor("");
+    let resolveFirstDispatch!: () => void;
+    const firstDispatch = new Promise<void>((resolve) => {
+      resolveFirstDispatch = resolve;
+    });
+    const handleSessChatSubmit = vi
+      .fn()
+      .mockImplementationOnce(() => firstDispatch)
+      .mockResolvedValueOnce(undefined);
+    await mount(optionsFor(editorHarness, { handleSessChatSubmit }));
+
+    let first!: Promise<void>;
+    let second!: Promise<void>;
+    act(() => {
+      first = latestSubmit!({ capturedText: "first message" });
+      second = latestSubmit!({ capturedText: "second message" });
+    });
+    await vi.waitFor(
+      () => expect(handleSessChatSubmit).toHaveBeenCalledTimes(2),
+      { timeout: 5_000 }
+    );
+    resolveFirstDispatch();
+    await act(async () => {
+      await Promise.all([first, second]);
+    });
+
+    expect(handleSessChatSubmit.mock.calls).toEqual([
+      [undefined, "first message", "agent:first message", undefined],
+      [undefined, "second message", "agent:second message", undefined],
+    ]);
+  });
+
+  it("keeps the composer intact and releases the intent after the secret scan blocks it", async () => {
+    const editorHarness = createEditor("token-shaped text");
+    const handleSessChatSubmit = vi.fn().mockResolvedValue(undefined);
+    const flushDraft = vi.fn().mockResolvedValue(undefined);
+    mocks.guardAgainstSecrets.mockResolvedValueOnce(false);
+    await mount(
+      optionsFor(editorHarness, { handleSessChatSubmit, flushDraft })
+    );
+
+    await act(async () => {
+      await latestSubmit!();
+    });
+
+    expect(handleSessChatSubmit).not.toHaveBeenCalled();
+    expect(editorHarness.editor.clear).not.toHaveBeenCalled();
+    expect(editorHarness.readText()).toBe("token-shaped text");
+    expect(flushDraft).not.toHaveBeenCalled();
+
+    mocks.guardAgainstSecrets.mockResolvedValueOnce(true);
+    await act(async () => {
+      await latestSubmit!();
+    });
+
+    expect(handleSessChatSubmit).toHaveBeenCalledOnce();
+    expect(editorHarness.readText()).toBe("");
+  });
+
+  it("lets a read-only imported replay delegate to its fork-before-send override", async () => {
+    const editorHarness = createEditor("continue from this replay");
+    const onSubmitOverride = vi.fn().mockResolvedValue(true);
+    const handleSessChatSubmit = vi.fn().mockResolvedValue(undefined);
+    const clearReplyTarget = vi.fn().mockResolvedValue(undefined);
+    await mount(
+      optionsFor(editorHarness, {
+        onSubmitOverride,
+        handleSessChatSubmit,
+        clearReplyTarget,
+      }),
+      (nextStore) => nextStore.set(wpReadOnlyAtom, true)
+    );
+
+    await act(async () => {
+      await latestSubmit!();
+    });
+
+    expect(mocks.messageWarning).not.toHaveBeenCalled();
+    expect(onSubmitOverride).toHaveBeenCalledWith({
+      displayText: "continue from this replay",
+      agentContent: "agent:continue from this replay",
+      imageDataUrls: undefined,
+    });
+    expect(handleSessChatSubmit).not.toHaveBeenCalled();
+    expect(editorHarness.readText()).toBe("");
+    expect(clearReplyTarget).toHaveBeenCalledOnce();
+  });
+
+  it("restores text, images, cite state, and the durable draft after dispatch failure", async () => {
+    const editorHarness = createEditor("do not lose this");
+    const attachment = image();
+    const flushDraft = vi.fn().mockResolvedValue(undefined);
+    const imageAttachment = {
+      hasImages: true,
+      images: [attachment],
+      clearImages: vi.fn(),
+      restoreImages: vi.fn(),
+    };
+    const citeSnapshot = {
+      isCiteCode: true,
+      selectedCiteRange: { start: 1, end: 3 },
+      selectedCiteText: "const answer = 42",
+      citeFileName: "answer.ts",
+    };
+    const citeCode = {
+      isCiteCode: true,
+      clearCiteCode: vi.fn(),
+      captureCiteCode: vi.fn(() => citeSnapshot),
+      restoreCiteCode: vi.fn(),
+    };
+    const options = optionsFor(editorHarness, {
+      flushDraft,
+      imageAttachment,
+      citeCode,
+      handleSessChatSubmit: vi
+        .fn()
+        .mockRejectedValue(new Error("transport unavailable")),
+    });
+    await mount(options);
+
+    await act(async () => {
+      await latestSubmit!();
+      await Promise.resolve();
+    });
+
+    expect(editorHarness.editor.clear).toHaveBeenCalledOnce();
+    expect(editorHarness.editor.setContent).toHaveBeenCalledOnce();
+    expect(editorHarness.readText()).toBe("do not lose this");
+    expect(options.refs.setHasContent).toHaveBeenLastCalledWith(true);
+    expect(imageAttachment.clearImages).toHaveBeenCalledOnce();
+    expect(imageAttachment.restoreImages).toHaveBeenCalledWith([attachment]);
+    expect(citeCode.clearCiteCode).toHaveBeenCalledOnce();
+    expect(citeCode.restoreCiteCode).toHaveBeenCalledWith(citeSnapshot);
+    expect(flushDraft.mock.calls.map(([text]) => text)).toEqual([
+      "",
+      "do not lose this",
+    ]);
+    expect(mocks.messageError).toHaveBeenCalledWith(
+      "chat.failedToSendMessage: transport unavailable"
+    );
+  });
+
+  it("leaves the composer untouched while ordinary submission is disabled", async () => {
+    const editorHarness = createEditor("queued while busy");
+    const handleSessChatSubmit = vi.fn().mockResolvedValue(undefined);
+    const options = optionsFor(editorHarness, {
+      submitDisabled: true,
+      handleSessChatSubmit,
+    });
+    await mount(options);
+
+    await act(async () => {
+      await latestSubmit!();
+    });
+
+    expect(handleSessChatSubmit).not.toHaveBeenCalled();
+    expect(mocks.guardAgainstSecrets).not.toHaveBeenCalled();
+    expect(editorHarness.editor.clear).not.toHaveBeenCalled();
+    expect(editorHarness.readText()).toBe("queued while busy");
+    expect(options.flushDraft).not.toHaveBeenCalled();
+  });
+});

--- a/src/engines/ChatPanel/hooks/useInputArea/useSubmitMessage.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/useSubmitMessage.ts
@@ -117,6 +117,7 @@ export function useSubmitMessage({
   const { t } = useTranslation("sessions");
   const store = useStore();
   const wpReadOnly = useAtomValue(wpReadOnlyAtom);
+  const submitAttemptsInFlightRef = useRef(new Set<string>());
   const submitInFlightKeyRef = useRef<string | null>(null);
   const { runManualCompact } = useManualCompact();
   const guardAgainstSecrets = useSecretScanGuard();
@@ -124,7 +125,7 @@ export function useSubmitMessage({
     draftSessionId || addressSessionId || null
   );
 
-  return useCallback(
+  const submitMessage = useCallback(
     async (options: SubmitMessageOptions = {}) => {
       // Imported teammate replays are intentionally read-only in the event
       // store, but their composer owns an onSubmitOverride that performs
@@ -502,6 +503,40 @@ export function useSubmitMessage({
       enableAgentInterceptors,
       runManualCompact,
       addressComments,
+    ]
+  );
+
+  return useCallback(
+    async (options?: SubmitMessageOptions) => {
+      // Lock before asynchronous preprocessing (secret scan, MCP expansion,
+      // pending-pill reads). A second Enter/click can otherwise start with the
+      // same live editor text, arrive at the late payload-key guard only after
+      // the first dispatch finishes, and send the same user intent twice.
+      const liveDisplayText =
+        refs.composerInputRef.current?.getTextWithPills() ?? "";
+      const displayText =
+        liveDisplayText.trim().length > 0
+          ? liveDisplayText
+          : (options?.capturedText ?? "");
+      const submitAttemptKey = JSON.stringify({
+        draftSessionId,
+        displayText,
+        imageDataUrls: imageAttachment.images.map((image) => image.dataUrl),
+      });
+      const inFlightAttempts = submitAttemptsInFlightRef.current;
+      if (inFlightAttempts.has(submitAttemptKey)) return;
+      inFlightAttempts.add(submitAttemptKey);
+      try {
+        await submitMessage(options);
+      } finally {
+        inFlightAttempts.delete(submitAttemptKey);
+      }
+    },
+    [
+      draftSessionId,
+      imageAttachment.images,
+      refs.composerInputRef,
+      submitMessage,
     ]
   );
 }

--- a/src/features/Org2Cloud/useOrg2CloudRealtime.test.ts
+++ b/src/features/Org2Cloud/useOrg2CloudRealtime.test.ts
@@ -1,0 +1,381 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { sessionsAtom } from "@src/store/session/sessionAtom/atoms";
+import { activeSessionIdAtom } from "@src/store/session/viewAtom";
+import { chatPanelSelectedCloudOrgAtom } from "@src/store/ui/chatPanelAtom";
+import { type SmokeRoot, createSmokeRoot } from "@src/test/reactSmokeHarness";
+
+import { org2CloudAuthAtom } from "./org2CloudAuthAtom";
+import {
+  type Org2CloudOrg,
+  org2CloudOrgsAtom,
+  sidebarActiveCloudOrgIdAtom,
+} from "./org2CloudOrgsAtom";
+import type {
+  Org2CloudPresenceHandle,
+  Org2CloudPresenceOptions,
+  Org2CloudRealtimeConnection,
+  Org2CloudSubscribeOptions,
+} from "./org2CloudRealtimeClient";
+import { useOrg2CloudRealtime } from "./useOrg2CloudRealtime";
+
+const mocks = vi.hoisted(() => ({
+  clearCloudOrgMembersCache: vi.fn(),
+  createConnection: vi.fn(),
+  ensureFreshSession: vi.fn(),
+  getCloudCapabilities: vi.fn(),
+  invalidateOrgInbound: vi.fn(),
+  refetchOrgs: vi.fn(),
+  refreshOrgEntitlement: vi.fn(),
+  registerCommentsBroadcaster: vi.fn(),
+  registerOrgControlBroadcaster: vi.fn(),
+  resumeOrg: vi.fn(),
+}));
+
+vi.mock("@src/hooks/logger", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+
+vi.mock("./org2CloudRealtimeClient", () => ({
+  createOrg2CloudRealtimeConnection: mocks.createConnection,
+}));
+
+vi.mock("./org2CloudRealtimeLease", () => ({
+  useOrg2CloudRealtimeLease: () => true,
+}));
+
+vi.mock("./org2CloudCapabilities", () => ({
+  getCloudCapabilities: mocks.getCloudCapabilities,
+}));
+
+vi.mock("./org2CloudClient", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./org2CloudClient")>()),
+  ensureFreshSession: mocks.ensureFreshSession,
+}));
+
+vi.mock("./org2CloudOrgsAtom", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./org2CloudOrgsAtom")>()),
+  useRefetchOrg2CloudOrgs: () => mocks.refetchOrgs,
+}));
+
+vi.mock("./org2CloudMembersCoordinator", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./org2CloudMembersCoordinator")>()),
+  clearCloudOrgMembersCache: mocks.clearCloudOrgMembersCache,
+}));
+
+vi.mock("./org2CloudEntitlementCoordinator", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("./org2CloudEntitlementCoordinator")
+  >()),
+  refreshOrgEntitlement: mocks.refreshOrgEntitlement,
+}));
+
+vi.mock("./org2CloudCommentsBus", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./org2CloudCommentsBus")>()),
+  registerCommentsBroadcaster: mocks.registerCommentsBroadcaster,
+}));
+
+vi.mock("./org2CloudControlBus", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./org2CloudControlBus")>()),
+  registerOrgControlBroadcaster: mocks.registerOrgControlBroadcaster,
+}));
+
+vi.mock("./org2CloudSyncEngine", () => ({
+  org2CloudSyncEngine: {
+    invalidateOrgInbound: mocks.invalidateOrgInbound,
+    resumeOrg: mocks.resumeOrg,
+  },
+}));
+
+interface ControlledSubscription {
+  options: Org2CloudSubscribeOptions;
+  unsubscribe: ReturnType<typeof vi.fn>;
+}
+
+interface ControlledPresence {
+  options: Org2CloudPresenceOptions;
+  handle: Org2CloudPresenceHandle & {
+    update: ReturnType<typeof vi.fn>;
+    send: ReturnType<typeof vi.fn>;
+    leave: ReturnType<typeof vi.fn>;
+  };
+}
+
+interface ControlledConnection extends Org2CloudRealtimeConnection {
+  subscriptions: ControlledSubscription[];
+  presences: ControlledPresence[];
+  setAuth: ReturnType<typeof vi.fn>;
+  dispose: ReturnType<typeof vi.fn>;
+}
+
+const connections: ControlledConnection[] = [];
+const broadcasterUnregisters: Array<ReturnType<typeof vi.fn>> = [];
+
+function createControlledConnection(): ControlledConnection {
+  const subscriptions: ControlledSubscription[] = [];
+  const presences: ControlledPresence[] = [];
+  const connection: ControlledConnection = {
+    subscriptions,
+    presences,
+    subscribe: vi.fn((options: Org2CloudSubscribeOptions) => {
+      const unsubscribe = vi.fn();
+      subscriptions.push({ options, unsubscribe });
+      return unsubscribe;
+    }),
+    joinPresence: vi.fn((options: Org2CloudPresenceOptions) => {
+      const handle = {
+        update: vi.fn(),
+        send: vi.fn(),
+        leave: vi.fn(),
+      };
+      presences.push({ options, handle });
+      return handle;
+    }),
+    setAuth: vi.fn(),
+    dispose: vi.fn(),
+  };
+  connections.push(connection);
+  return connection;
+}
+
+const AUTH = {
+  kind: "org2_cloud" as const,
+  supabaseUrl: "https://cloud.example.test",
+  supabaseAnonKey: "anon",
+  userId: "user-a",
+  accessToken: "access-a",
+  refreshToken: "refresh-a",
+  expiresAt: 4_102_444_800,
+  profile: { displayName: "Ada" },
+};
+
+function cloudOrg(orgId: string): Org2CloudOrg {
+  return { orgId, name: `Org ${orgId}`, role: "manager" };
+}
+
+function Harness(): null {
+  useOrg2CloudRealtime();
+  return null;
+}
+
+async function flushAsync(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe("useOrg2CloudRealtime lifecycle", () => {
+  let root: SmokeRoot;
+  let store: ReturnType<typeof createStore>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-21T12:00:00.000Z"));
+    vi.clearAllMocks();
+    connections.splice(0);
+    broadcasterUnregisters.splice(0);
+    localStorage.clear();
+    mocks.createConnection.mockImplementation(createControlledConnection);
+    mocks.ensureFreshSession.mockImplementation(async (auth) => auth);
+    mocks.getCloudCapabilities.mockResolvedValue({ broadcastSignals: false });
+    mocks.refetchOrgs.mockResolvedValue(undefined);
+    mocks.refreshOrgEntitlement.mockResolvedValue(undefined);
+    const registerBroadcaster = () => {
+      const unregister = vi.fn();
+      broadcasterUnregisters.push(unregister);
+      return unregister;
+    };
+    mocks.registerCommentsBroadcaster.mockImplementation(registerBroadcaster);
+    mocks.registerOrgControlBroadcaster.mockImplementation(registerBroadcaster);
+    store = createStore();
+    store.set(org2CloudAuthAtom, AUTH);
+    store.set(org2CloudOrgsAtom, [cloudOrg("org-a"), cloudOrg("org-b")]);
+    store.set(sidebarActiveCloudOrgIdAtom, "org-a");
+    store.set(chatPanelSelectedCloudOrgAtom, null);
+    store.set(activeSessionIdAtom, null);
+    store.set(sessionsAtom, []);
+    root = createSmokeRoot();
+  });
+
+  afterEach(async () => {
+    await root.unmount();
+    vi.useRealTimers();
+    localStorage.clear();
+  });
+
+  async function mount(): Promise<void> {
+    await root.render(
+      createElement(Provider, { store }, createElement(Harness))
+    );
+    await flushAsync();
+    expect(connections).toHaveLength(1);
+  }
+
+  function subscription(
+    connection: ControlledConnection,
+    table: string,
+    filter: string
+  ): ControlledSubscription {
+    const match = connection.subscriptions.find(
+      (entry) =>
+        entry.options.table === table && entry.options.filter === filter
+    );
+    expect(match).toBeDefined();
+    return match!;
+  }
+
+  it("owns only the active org subscriptions and disposes every resource on scope switch", async () => {
+    await mount();
+    const first = connections[0]!;
+
+    expect(first.subscriptions).toHaveLength(3);
+    subscription(first, "org_memberships", "user_id=eq.user-a");
+    subscription(first, "org_change_signals", "org_id=eq.org-a");
+    subscription(first, "org_memberships", "org_id=eq.org-a");
+    expect(first.presences).toHaveLength(1);
+    expect(first.presences[0]?.options).toMatchObject({
+      scope: "org:org-a",
+      key: "user-a",
+    });
+
+    await act(async () => {
+      store.set(sidebarActiveCloudOrgIdAtom, "org-b");
+    });
+    await flushAsync();
+
+    expect(connections).toHaveLength(2);
+    expect(first.dispose).toHaveBeenCalledOnce();
+    for (const entry of first.subscriptions) {
+      expect(entry.unsubscribe).toHaveBeenCalledOnce();
+    }
+    expect(first.presences[0]?.handle.leave).toHaveBeenCalledOnce();
+    for (const unregister of broadcasterUnregisters.slice(0, 2)) {
+      expect(unregister).toHaveBeenCalledOnce();
+    }
+
+    const second = connections[1]!;
+    subscription(second, "org_change_signals", "org_id=eq.org-b");
+    subscription(second, "org_memberships", "org_id=eq.org-b");
+    expect(second.presences[0]?.options.scope).toBe("org:org-b");
+  });
+
+  it("keeps the same connection on token rotation and nudges its auth callback", async () => {
+    await mount();
+    const connection = connections[0]!;
+    const initialSetAuthCalls = connection.setAuth.mock.calls.length;
+
+    await act(async () => {
+      store.set(org2CloudAuthAtom, { ...AUTH, accessToken: "access-rotated" });
+    });
+    await flushAsync();
+
+    expect(connections).toHaveLength(1);
+    expect(connection.dispose).not.toHaveBeenCalled();
+    expect(connection.setAuth).toHaveBeenCalledTimes(initialSetAuthCalls + 1);
+  });
+
+  it("fully rebinds realtime ownership when the authenticated identity and endpoint change", async () => {
+    await mount();
+    const first = connections[0]!;
+
+    await act(async () => {
+      store.set(org2CloudAuthAtom, {
+        ...AUTH,
+        supabaseUrl: "https://other-cloud.example.test",
+        userId: "user-b",
+        accessToken: "access-b",
+        refreshToken: "refresh-b",
+      });
+    });
+    await flushAsync();
+
+    expect(connections).toHaveLength(2);
+    expect(first.dispose).toHaveBeenCalledOnce();
+    for (const entry of first.subscriptions) {
+      expect(entry.unsubscribe).toHaveBeenCalledOnce();
+    }
+    expect(first.presences[0]?.handle.leave).toHaveBeenCalledOnce();
+
+    const second = connections[1]!;
+    subscription(second, "org_memberships", "user_id=eq.user-b");
+    expect(second.presences[0]?.options).toMatchObject({
+      scope: "org:org-a",
+      key: "user-b",
+    });
+  });
+
+  it("migrates from legacy change channels to the broadcast channel without replacing the socket", async () => {
+    mocks.getCloudCapabilities.mockResolvedValue({ broadcastSignals: true });
+    await mount();
+    const connection = connections[0]!;
+    const ownRoster = subscription(
+      connection,
+      "org_memberships",
+      "user_id=eq.user-a"
+    );
+    const legacySignal = subscription(
+      connection,
+      "org_change_signals",
+      "org_id=eq.org-a"
+    );
+    const legacyRoster = subscription(
+      connection,
+      "org_memberships",
+      "org_id=eq.org-a"
+    );
+
+    await vi.waitFor(() => expect(connection.presences).toHaveLength(2), {
+      timeout: 5_000,
+    });
+
+    expect(connections).toHaveLength(1);
+    expect(connection.dispose).not.toHaveBeenCalled();
+    expect(ownRoster.unsubscribe).not.toHaveBeenCalled();
+    expect(legacySignal.unsubscribe).toHaveBeenCalledOnce();
+    expect(legacyRoster.unsubscribe).toHaveBeenCalledOnce();
+    expect(connection.presences[0]?.handle.leave).toHaveBeenCalledOnce();
+
+    act(() => connection.presences[1]?.options.onStatus?.(true));
+    expect(mocks.invalidateOrgInbound).toHaveBeenCalledWith("org-a");
+  });
+
+  it("does not claim hidden subscribed-edge recovery and clears its safety timer on teardown", async () => {
+    const visibility = vi
+      .spyOn(document, "visibilityState", "get")
+      .mockReturnValue("hidden");
+    await mount();
+    const connection = connections[0]!;
+    const signalSubscription = subscription(
+      connection,
+      "org_change_signals",
+      "org_id=eq.org-a"
+    );
+    const baselineTimerCount = vi.getTimerCount();
+
+    act(() => signalSubscription.options.onStatus?.(true));
+    expect(mocks.invalidateOrgInbound).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(baselineTimerCount);
+
+    visibility.mockReturnValue("visible");
+    act(() => signalSubscription.options.onStatus?.(true));
+    expect(mocks.invalidateOrgInbound).toHaveBeenCalledWith("org-a", {
+      full: true,
+      pushSessions: true,
+    });
+    expect(vi.getTimerCount()).toBe(baselineTimerCount + 1);
+
+    await root.unmount();
+    expect(connection.dispose).toHaveBeenCalledOnce();
+    expect(connection.presences[0]?.handle.leave).toHaveBeenCalledOnce();
+    expect(vi.getTimerCount()).toBe(baselineTimerCount);
+  });
+});

--- a/src/modules/MainApp/TeamInbox/useTeamInboxDataSource.test.ts
+++ b/src/modules/MainApp/TeamInbox/useTeamInboxDataSource.test.ts
@@ -1,0 +1,465 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement, useEffect } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ProjectData } from "@src/api/http/project";
+import { org2CloudAuthAtom } from "@src/features/Org2Cloud/org2CloudAuthAtom";
+import {
+  type Org2CloudOrg,
+  org2CloudOrgsAtom,
+  org2CloudRosterVersionAtom,
+  sidebarActiveCloudOrgIdAtom,
+} from "@src/features/Org2Cloud/org2CloudOrgsAtom";
+import { type SmokeRoot, createSmokeRoot } from "@src/test/reactSmokeHarness";
+
+import { teamInboxInvalidationAtom } from "./store";
+import type { TeamInboxCoordinatorScope } from "./teamInboxCoordinator";
+import {
+  __TEAM_INBOX_MEMBER_INTERNALS,
+  useTeamInboxDataSource,
+} from "./useTeamInboxDataSource";
+
+const mocks = vi.hoisted(() => ({
+  coordinatorEnsureScope: vi.fn(),
+  coordinatorInvalidate: vi.fn(),
+  coordinatorLoadMore: vi.fn(),
+  coordinatorMarkAllRead: vi.fn(),
+  coordinatorMarkRead: vi.fn(),
+  coordinatorMarkUnread: vi.fn(),
+  coordinatorReconcileItem: vi.fn(),
+  coordinatorRefresh: vi.fn(),
+  createWorkItemFromSession: vi.fn(),
+  invalidateProjectCache: vi.fn(),
+  loadCloudOrgMembers: vi.fn(),
+  loggerWarn: vi.fn(),
+  readMembers: vi.fn(),
+  readProject: vi.fn(),
+  readProjects: vi.fn(),
+  resolveCurrentUserMemberIds: vi.fn(),
+  sessionHandoffDraft: vi.fn(),
+  useProjectDataChanged: vi.fn(),
+}));
+
+vi.mock("@src/api/http/project", () => ({
+  invalidateProjectCache: mocks.invalidateProjectCache,
+  projectApi: {
+    readMembers: mocks.readMembers,
+    readProject: mocks.readProject,
+    readProjects: mocks.readProjects,
+  },
+}));
+
+vi.mock("@src/features/Org2Cloud/org2CloudMembersCoordinator", () => ({
+  loadCloudOrgMembers: mocks.loadCloudOrgMembers,
+}));
+
+vi.mock("@src/hooks/logger", () => ({
+  createLogger: () => ({ warn: mocks.loggerWarn }),
+}));
+
+vi.mock("@src/hooks/project", () => ({
+  useProjectDataChanged: mocks.useProjectDataChanged,
+}));
+
+vi.mock("@src/hooks/project/useCurrentUserMemberId", () => ({
+  useCurrentUserMemberIds: mocks.resolveCurrentUserMemberIds,
+}));
+
+vi.mock("./createWorkItemFromSession", () => ({
+  createWorkItemFromSession: mocks.createWorkItemFromSession,
+  sessionHandoffDraft: mocks.sessionHandoffDraft,
+}));
+
+vi.mock("./teamInboxCoordinator", () => ({
+  teamInboxCoordinator: {
+    ensureScope: mocks.coordinatorEnsureScope,
+    invalidate: mocks.coordinatorInvalidate,
+    loadMore: mocks.coordinatorLoadMore,
+    markAllRead: mocks.coordinatorMarkAllRead,
+    markRead: mocks.coordinatorMarkRead,
+    markUnread: mocks.coordinatorMarkUnread,
+    reconcileItem: mocks.coordinatorReconcileItem,
+    refresh: mocks.coordinatorRefresh,
+  },
+}));
+
+const AUTH = {
+  kind: "org2_cloud" as const,
+  supabaseUrl: "https://cloud.example.test",
+  supabaseAnonKey: "anon",
+  userId: "cloud-viewer",
+  accessToken: "access",
+  refreshToken: "refresh",
+  expiresAt: 4_102_444_800,
+};
+
+function project(slug: string): ProjectData {
+  return {
+    slug,
+    description: "",
+    meta: {
+      id: `project-${slug}`,
+      name: slug,
+      org_id: "local-org",
+      status: "active",
+      priority: "none",
+      health: "no_updates",
+      members: [],
+      labels: [],
+      linked_repos: [],
+      created_at: "2026-08-21T00:00:00.000Z",
+      updated_at: "2026-08-21T00:00:00.000Z",
+      next_work_item_id: 1,
+      work_item_prefix: "TST",
+      work_item_prefix_custom: false,
+    },
+  };
+}
+
+function cloudOrg(orgId: string): Org2CloudOrg {
+  return { orgId, name: `Org ${orgId}`, role: "manager" };
+}
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve(value: T): void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
+}
+
+let latestViewerMemberIds: readonly string[] = [];
+
+function Harness(): null {
+  const { viewerMemberIds } = useTeamInboxDataSource();
+  useEffect(() => {
+    latestViewerMemberIds = viewerMemberIds;
+  }, [viewerMemberIds]);
+  return null;
+}
+
+async function flushAsync(): Promise<void> {
+  await act(async () => {
+    for (let index = 0; index < 8; index += 1) {
+      await Promise.resolve();
+    }
+  });
+}
+
+function refreshScopes(): TeamInboxCoordinatorScope[] {
+  return mocks.coordinatorRefresh.mock.calls.map(
+    (call) => call[1] as TeamInboxCoordinatorScope
+  );
+}
+
+describe("useTeamInboxDataSource orchestration", () => {
+  let root: SmokeRoot;
+  let store: ReturnType<typeof createStore>;
+  let currentMemberIds: Set<string>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-21T12:00:00.000Z"));
+    vi.clearAllMocks();
+    localStorage.clear();
+    latestViewerMemberIds = [];
+    __TEAM_INBOX_MEMBER_INTERNALS.resetRequest();
+    currentMemberIds = new Set(["viewer-1"]);
+    mocks.resolveCurrentUserMemberIds.mockImplementation(() => ({
+      memberIds: currentMemberIds,
+      gitEmail: "viewer@example.test",
+      currentUser: null,
+    }));
+    mocks.readProjects.mockResolvedValue([]);
+    mocks.readMembers.mockResolvedValue({ members: [] });
+    mocks.readProject.mockResolvedValue(null);
+    mocks.loadCloudOrgMembers.mockResolvedValue(null);
+    mocks.coordinatorRefresh.mockResolvedValue(undefined);
+    mocks.coordinatorLoadMore.mockResolvedValue(undefined);
+    mocks.coordinatorMarkRead.mockResolvedValue(undefined);
+    mocks.coordinatorMarkUnread.mockResolvedValue(undefined);
+    mocks.coordinatorMarkAllRead.mockResolvedValue(undefined);
+    store = createStore();
+    store.set(org2CloudAuthAtom, null);
+    store.set(org2CloudOrgsAtom, []);
+    store.set(sidebarActiveCloudOrgIdAtom, null);
+    root = createSmokeRoot();
+  });
+
+  afterEach(async () => {
+    await root.unmount();
+    vi.useRealTimers();
+    localStorage.clear();
+  });
+
+  async function mount(): Promise<void> {
+    await root.render(
+      createElement(Provider, { store }, createElement(Harness))
+    );
+    await flushAsync();
+  }
+
+  it("retains usable members and reports a partial prerequisite failure", async () => {
+    mocks.readProjects.mockResolvedValue([project("alpha"), project("beta")]);
+    mocks.readMembers.mockImplementation(async (slug: string) => {
+      if (slug === "beta") throw new Error("beta members unavailable");
+      return {
+        members: [
+          {
+            id: "viewer-1",
+            name: "Viewer",
+            active: true,
+            last_commit_date: "2026-08-20T00:00:00.000Z",
+          },
+          { id: "teammate-1", name: "Lin", active: true },
+        ],
+      };
+    });
+
+    await mount();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+
+    const latestScope = refreshScopes().at(-1);
+    expect(latestScope).toMatchObject({
+      viewerMemberIds: ["viewer-1"],
+      activeCloudOrgId: null,
+      prerequisiteIssue: {
+        code: "partial_load",
+        detail: "1 project member file(s) could not be read",
+      },
+    });
+    expect(latestScope?.members).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "viewer-1", name: "Viewer" }),
+        expect.objectContaining({ id: "teammate-1", name: "Lin" }),
+      ])
+    );
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      "Skipped 1 project member file(s) while resolving Team Inbox identity"
+    );
+  });
+
+  it("rejects a late cloud roster after switching to a different org scope", async () => {
+    const orgA = deferred<{
+      members: Array<{
+        userId: string;
+        displayName: string;
+        role: "member";
+        status: string;
+      }>;
+    }>();
+    const orgB = deferred<{
+      members: Array<{
+        userId: string;
+        displayName: string;
+        role: "member";
+        status: string;
+      }>;
+    }>();
+    mocks.loadCloudOrgMembers.mockImplementation(
+      (_store: unknown, _auth: unknown, orgId: string) =>
+        orgId === "org-a" ? orgA.promise : orgB.promise
+    );
+    store.set(org2CloudAuthAtom, AUTH);
+    store.set(org2CloudOrgsAtom, [cloudOrg("org-a"), cloudOrg("org-b")]);
+    store.set(org2CloudRosterVersionAtom, { "org-a": 1, "org-b": 1 });
+    store.set(sidebarActiveCloudOrgIdAtom, "org-a");
+
+    await mount();
+    await act(async () => {
+      store.set(sidebarActiveCloudOrgIdAtom, "org-b");
+    });
+    await flushAsync();
+
+    orgB.resolve({
+      members: [
+        {
+          userId: "member-b",
+          displayName: "Member B",
+          role: "member",
+          status: "active",
+        },
+      ],
+    });
+    await flushAsync();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+
+    orgA.resolve({
+      members: [
+        {
+          userId: "member-a",
+          displayName: "Stale Member A",
+          role: "member",
+          status: "active",
+        },
+      ],
+    });
+    await flushAsync();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+
+    const orgBScopes = refreshScopes().filter(
+      (scope) => scope.activeCloudOrgId === "org-b"
+    );
+    expect(orgBScopes.length).toBeGreaterThan(0);
+    expect(orgBScopes.at(-1)?.members).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "member-b", name: "Member B" }),
+      ])
+    );
+    expect(
+      orgBScopes.some((scope) =>
+        scope.members.some((member) => member.id === "member-a")
+      )
+    ).toBe(false);
+    expect(latestViewerMemberIds).toEqual(["cloud-viewer", "viewer-1"]);
+  });
+
+  it("rejects a late roster from a previous authenticated identity in the same org", async () => {
+    const identityA = deferred<{
+      members: Array<{
+        userId: string;
+        displayName: string;
+        role: "member";
+        status: string;
+      }>;
+    }>();
+    const identityB = deferred<{
+      members: Array<{
+        userId: string;
+        displayName: string;
+        role: "member";
+        status: string;
+      }>;
+    }>();
+    mocks.loadCloudOrgMembers.mockImplementation(
+      (_store: unknown, auth: { userId: string }) =>
+        auth.userId === "cloud-viewer" ? identityA.promise : identityB.promise
+    );
+    store.set(org2CloudAuthAtom, AUTH);
+    store.set(org2CloudOrgsAtom, [cloudOrg("org-a")]);
+    store.set(org2CloudRosterVersionAtom, { "org-a": 1 });
+    store.set(sidebarActiveCloudOrgIdAtom, "org-a");
+
+    await mount();
+    await act(async () => {
+      store.set(org2CloudAuthAtom, {
+        ...AUTH,
+        supabaseUrl: "https://other-cloud.example.test",
+        userId: "cloud-viewer-b",
+        accessToken: "access-b",
+        refreshToken: "refresh-b",
+      });
+    });
+    await flushAsync();
+
+    identityB.resolve({
+      members: [
+        {
+          userId: "member-b",
+          displayName: "Current Member B",
+          role: "member",
+          status: "active",
+        },
+      ],
+    });
+    await flushAsync();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+
+    identityA.resolve({
+      members: [
+        {
+          userId: "member-a",
+          displayName: "Stale Member A",
+          role: "member",
+          status: "active",
+        },
+      ],
+    });
+    await flushAsync();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+
+    const identityBScopes = refreshScopes().filter((scope) =>
+      scope.viewerMemberIds.includes("cloud-viewer-b")
+    );
+    expect(identityBScopes.length).toBeGreaterThan(0);
+    expect(identityBScopes.at(-1)?.members).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "member-b", name: "Current Member B" }),
+      ])
+    );
+    expect(
+      identityBScopes.some((scope) =>
+        scope.members.some((member) => member.id === "member-a")
+      )
+    ).toBe(false);
+    expect(latestViewerMemberIds).toEqual(["cloud-viewer-b", "viewer-1"]);
+  });
+
+  it("shares one local roster request across concurrent mounted consumers", async () => {
+    const projects = deferred<ProjectData[]>();
+    mocks.readProjects.mockReturnValue(projects.promise);
+
+    await root.render(
+      createElement(
+        Provider,
+        { store },
+        createElement(
+          "div",
+          null,
+          createElement(Harness),
+          createElement(Harness)
+        )
+      )
+    );
+
+    expect(mocks.readProjects).toHaveBeenCalledOnce();
+    projects.resolve([]);
+    await flushAsync();
+    expect(mocks.readProjects).toHaveBeenCalledOnce();
+  });
+
+  it("coalesces invalidation bursts and cancels the trailing refresh on unmount", async () => {
+    await mount();
+    expect(mocks.coordinatorRefresh).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      store.set(teamInboxInvalidationAtom, 1);
+      store.set(teamInboxInvalidationAtom, 2);
+    });
+    await flushAsync();
+    expect(mocks.coordinatorRefresh).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+    expect(mocks.coordinatorRefresh).toHaveBeenCalledTimes(2);
+    expect(mocks.coordinatorRefresh.mock.calls.at(-1)?.[2]).toMatch(/^2:/);
+
+    await act(async () => {
+      store.set(teamInboxInvalidationAtom, 3);
+    });
+    await flushAsync();
+    const callsBeforeUnmount = mocks.coordinatorRefresh.mock.calls.length;
+    await root.unmount();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000);
+    });
+    expect(mocks.coordinatorRefresh).toHaveBeenCalledTimes(callsBeforeUnmount);
+  });
+});


### PR DESCRIPTION
## Problem

Three high-risk frontend orchestration boundaries had little or no direct coverage: Chat Composer submission, Org2 Cloud Realtime lifecycle ownership, and Team Inbox data loading. Regressions in these paths could duplicate a message, lose composer state, retain subscriptions across identity changes, accept stale roster data, or multiply background reads.

The composer tests exposed a concrete race: duplicate submit attempts could both enter asynchronous preprocessing, and the existing late payload guard could be cleared by the first fast dispatch before the second attempt reached it.

## Solution

Add 16 focused hook-level tests across the three boundaries.

- Chat Composer covers duplicate suppression, distinct concurrent intents, secret-scan rejection and retry, read-only fork delegation, durable state cleanup, failure restoration, and disabled submission.
- Cloud Realtime covers active-org ownership, teardown, token rotation, authenticated identity and endpoint switching, legacy-to-broadcast migration, hidden-state suppression, recovery cadence, and timer cleanup.
- Team Inbox covers partial roster failure, stale org and authenticated-identity rejection, cross-consumer roster single-flight behavior, invalidation coalescing, and unmount cleanup.
- Add an early per-intent in-flight key set in `useSubmitMessage`. Identical active intents are suppressed before asynchronous preprocessing, distinct intents remain allowed, and every key is removed in `finally`.

The PR changes only the composer hook and the three new test files.

## Potential risks

The composer guard intentionally suppresses an identical draft-session, text, and image payload only while that same intent is active. A defect in key construction could suppress a legitimate identical retry before the original completes; distinct captured text remains explicitly covered. The set is hook-owned and cleaned in `finally`, so it does not grow after attempts finish.

Realtime and Team Inbox verification uses controlled transport/coordinator mocks. It proves React lifecycle, ownership, stale-result, timer, and scope behavior but does not exercise a live Supabase connection or rendered Tauri application. There are no persistence, schema, public API, dependency, or wire-format changes, so rollback is reverting this commit.

## Verification

- `pnpm exec vitest run src/engines/ChatPanel/hooks/useInputArea/useSubmitMessage.test.ts src/features/Org2Cloud/useOrg2CloudRealtime.test.ts src/modules/MainApp/TeamInbox/useTeamInboxDataSource.test.ts --reporter=dot` — 3 files and 16 tests passed.
- Targeted V8 coverage — 64.72% lines for `useSubmitMessage.ts`, 66.52% for `useOrg2CloudRealtime.ts`, and 56.35% for `useTeamInboxDataSource.ts`.
- `pnpm exec prettier --check` on all four changed files — passed.
- `pnpm exec eslint` on all four changed files — passed.
- `pnpm typecheck` — passed.
- `git diff --check origin/develop...HEAD` — passed.
- Commit hooks ran lint-staged, TypeScript, circular dependency checks, and confirmed exactly four clean staged files.

## Performance guard

| Area | Verdict | Evidence |
| --- | --- | --- |
| Background work | keep | Subscription migration, hidden recovery, timer teardown, and 15-second refresh coalescing are covered. |
| Memory | keep | Presence resources and timers clean up; composer intent keys are removed in `finally`; local roster reads single-flight across consumers. |
| Scope/isolation | keep | Org, authenticated identity, and endpoint transitions reject stale resources and results. |
| Rendering/hot path | keep | No rendered UI changes; tests verify narrowed invalidation and bounded orchestration. |

Performance verdict: pass.

## Visual evidence

Not applicable. This PR changes hook orchestration and automated tests without changing rendered UI.