### PR TITLE
fix(session-creator): simplify CLI upgrade notice

### DIFF
--- a/src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx
@@ -1,4 +1,4 @@
-import { Airplay, Network, RefreshCw } from "lucide-react";
+import { Airplay, CircleArrowUp, Network, RefreshCw } from "lucide-react";
 import React, { Children, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -279,6 +279,7 @@ const SessionCreatorChatPanelView: React.FC<
       <div className={`mx-auto w-full ${DETAIL_PANEL_TOKENS.contentMaxWidth}`}>
         <InlineAlert
           type="warning"
+          icon={<CircleArrowUp size={14} strokeWidth={1.8} />}
           onClose={cliVersionAlert.onClose}
           closeAriaLabel={t("common:actions.close")}
           action={
@@ -302,9 +303,6 @@ const SessionCreatorChatPanelView: React.FC<
           }
           title={t("creator.cliVersionOutdated.title", {
             cli: cliVersionAlert.cliDisplayName,
-          })}
-        >
-          {t("creator.cliVersionOutdated.body", {
             installed:
               cliVersionAlert.installedVersion ??
               t("creator.cliVersionOutdated.unknownVersion"),
@@ -312,7 +310,7 @@ const SessionCreatorChatPanelView: React.FC<
               cliVersionAlert.latestVersion ??
               t("creator.cliVersionOutdated.unknownVersion"),
           })}
-        </InlineAlert>
+        />
       </div>
     ) : null;
   const agentHero = headerLayout !== "compact" && (

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -2183,8 +2183,7 @@
       "body": "Git is not installed or could not be found. Ask ADE Manager or SDE Agent to install Git for this machine, then restart ORGII."
     },
     "cliVersionOutdated": {
-      "title": "{{cli}} CLI needs an upgrade",
-      "body": "Installed version: {{installed}}. Latest version: {{latest}}. Upgrade the CLI, then scan it again before using newer models",
+      "title": "{{cli}} needs an upgrade ({{installed}} > {{latest}})",
       "refresh": "Recheck {{cli}} CLI version",
       "unknownVersion": "unknown"
     },

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -2156,8 +2156,7 @@
       "body": "未安装 Git 或无法找到 Git。请让 ADE Manager 或 SDE Agent 为这台机器安装 Git，然后重启 ORGII。"
     },
     "cliVersionOutdated": {
-      "title": "{{cli}} CLI 需要升级",
-      "body": "当前安装版本：{{installed}}；最新版本：{{latest}}。请自行升级 CLI，再重新扫描后使用较新的模型",
+      "title": "{{cli}} 需要升级（{{installed}} > {{latest}}）",
       "refresh": "重新检查 {{cli}} CLI 版本",
       "unknownVersion": "未知"
     },


### PR DESCRIPTION
## Problem

CLI version upgrade notices use a generic warning icon and split the version information from the title into a verbose second line. This makes a routine upgrade prompt larger and harder to scan than necessary.

## Solution

Render the notice as a single line in the format `X needs an upgrade (installed > latest)`, keeping the installed and latest versions visible in the title. Replace the warning triangle with a `CircleArrowUp` icon that communicates an available upgrade. The refresh and dismiss actions are unchanged, and the English and Chinese locale entries follow the same one-line structure.

## Potential risks

Long CLI names or version strings may still wrap at narrow widths, although the notice no longer creates a separate body row. There are no persistence, API, IPC, dependency, or compatibility changes, so rollback is limited to reverting this commit.

## Verification

- `npx prettier --check src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx src/i18n/locales/en/sessions.json src/i18n/locales/zh/sessions.json` — passed.
- `npx eslint src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx` — passed.
- `npx vitest run src/components/InlineAlert/InlineAlert.test.ts` — passed, 4 tests.
- `npm run typecheck` — passed.
- Repository commit hooks, including lint-staged and the scoped TypeScript check — passed.
- `git diff --check` — passed.

## UI evidence

No screenshot was captured because the desktop app was not launched for this localized copy and icon change. The rendered structure was verified at the component boundary: the alert is title-only and retains its existing refresh and dismiss controls.
