### PR TITLE
feat(perf): app-memory schema v2 with resident/swapped split

### DIFF
--- a/docs/product/view-ram-native-memory-metrics-verification.md
+++ b/docs/product/view-ram-native-memory-metrics-verification.md
@@ -16,32 +16,94 @@ On macOS, an uncertain WebKit helper is excluded and the snapshot reports
 `attribution: "partial"`. This intentionally prefers a possible undercount to
 counting Safari or another application's helper.
 
-## Platform metrics
+## What the headline means (schema v2)
 
-| Platform | Primary effective metric                            | Compatibility/fallback                              |
-| -------- | --------------------------------------------------- | --------------------------------------------------- |
-| macOS    | `proc_pid_rusage(RUSAGE_INFO_V2).ri_phys_footprint` | per-process RSS                                     |
-| Windows  | `PROCESS_MEMORY_COUNTERS_EX2.PrivateWorkingSetSize` | Private Bytes, then per-process RSS                 |
-| Other    | per-process RSS                                     | unavailable if the process inventory cannot be read |
+The headline `effective_memory_bytes` is deliberately **the number the
+platform's own task manager shows**, so users can cross-check it:
+
+| Platform | Headline (`metric_kind`)                                 | Task-manager column                |
+| -------- | -------------------------------------------------------- | ---------------------------------- |
+| macOS    | `proc_pid_rusage(RUSAGE_INFO_V4).ri_phys_footprint`      | Activity Monitor → "Memory"        |
+| Windows  | `PROCESS_MEMORY_COUNTERS_EX2.PrivateWorkingSetSize`      | Task Manager → "Memory"            |
+| Windows  | `PrivateUsage` when EX2 is unavailable (`compatibility`) | Process Explorer → "Private Bytes" |
+| Linux    | `Pss` from `/proc/<pid>/smaps_rollup`                    | KDE System Monitor → "Memory"      |
+| Any      | per-process RSS (`rss_fallback`)                         | —                                  |
+
+That headline is **not** "RAM in use right now". On macOS, `phys_footprint`
+counts pages held by the memory compressor or on-disk swap at their
+_uncompressed_ size; on a machine under memory pressure the headline can be
+2–3× the physically resident figure. Schema v2 therefore adds a split per
+process and as snapshot totals:
+
+| Field                         | macOS (`vm_region_walk`)                                       | Windows (`working_set_commit`)                | Linux (`smaps_rollup`)        |
+| ----------------------------- | -------------------------------------------------------------- | --------------------------------------------- | ----------------------------- |
+| `resident_private_bytes`      | Σ `pri_private_pages_resident` over `PROC_PIDREGIONINFO`       | `PrivateWorkingSetSize`                       | `Private_Clean+Private_Dirty` |
+| `resident_shared_bytes`       | Σ `pri_pages_resident` − private                               | `WorkingSetSize` − private working set        | `Pss` − private               |
+| `swapped_bytes`               | Σ `pri_pages_swapped_out` over private / copy-on-write regions | `PrivateUsage` − `PrivateWorkingSetSize`      | `SwapPss`                     |
+| `peak_effective_memory_bytes` | `ri_lifetime_max_phys_footprint`                               | `PeakPagefileUsage` (private-bytes path only) | `null`                        |
+
+`resident_private_total_bytes` is the physical RAM the app exclusively holds;
+`swapped_total_bytes` is the part of the headline that is _not_ in RAM.
+`resident_shared_total_bytes` is diagnostic only — shared pages are counted
+once per process that maps them.
+
+The macOS region walk uses `proc_pidinfo(PROC_PIDREGIONINFO)`, which is an
+unprivileged same-user query (no task port) and therefore works against
+Apple's hardened `com.apple.WebKit.*` XPC services. It is bounded by
+`MACOS_MAX_VM_REGIONS` and reports `breakdown_kind: "unavailable"` when the
+walk returns nothing.
 
 `rss_mapped_total_bytes` is diagnostic metadata and is never substituted into
 the top value without changing the snapshot's `measurement` field.
 
 ## macOS acceptance check
 
-For every PID in `get_app_memory_snapshot_v1.processes`, collect its physical
-footprint using `vmmap <pid> -summary`, then compare the sum with
-`effective_total_bytes` from one snapshot.
+`/usr/bin/footprint` ships with the base OS (no Xcode Command Line Tools
+required) and reports the same kernel ledger Activity Monitor uses. For every
+PID in `get_app_memory_snapshot_v1.processes`:
 
-The check passes when:
-
-```text
-absolute_difference <= max(vmmap_sum * 0.10, 50 MiB)
+```bash
+/usr/bin/footprint -p <pid> [-p <pid> …] --json footprint.json --swapped --noCategories
 ```
 
-Use a quiet, stable app state and collect the snapshot and `vmmap` readings as
-close together as possible. A `partial` snapshot remains valid only as an
-undercount: skipped ambiguous PIDs must not be added to the comparison sum.
+Compare, from the same quiet app state and as close in time as possible:
+
+1. Σ `processes[].auxiliary.phys_footprint` from the JSON versus
+   `effective_total_bytes`. Passes when
+   `absolute_difference <= max(footprint_sum * 0.10, 50 MiB)`.
+2. `resident_private_total_bytes + swapped_total_bytes` versus the same
+   footprint sum. Passes when the split never exceeds the headline; the
+   remainder is graphics / IOKit / purgeable memory that has no resident or
+   swapped page behind it (the WebKit GPU helper is mostly IOSurfaces, so its
+   own split is legitimately small).
+
+Do **not** compare `swapped_total_bytes` with `summary.total.swapped`: the
+`--swapped` column counts every region including the shared dyld cache, while
+`swapped_bytes` counts private / copy-on-write regions only so that it stays
+consistent with `phys_footprint`, which likewise ignores shared-cache pages.
+Measured on 2026-08-22 (ORG2 dev, 16 GB Mac with 8.7 GB swap in use):
+
+| Process    | `footprint` | region walk | resident private | swapped |
+| ---------- | ----------: | ----------: | ---------------: | ------: |
+| WebContent |     675 MiB |     673 MiB |          106 MiB | 438 MiB |
+| backend    |     119 MiB |     119 MiB |           15 MiB |  92 MiB |
+| GPU        |      20 MiB |      20 MiB |            3 MiB |   3 MiB |
+
+`footprint` takes ~0.3 s and several cores per call, which is why the app
+polls the region walk instead of shelling out to it. A `partial` snapshot
+remains valid only as an undercount: skipped ambiguous PIDs must not be added
+to the comparison sum.
+
+For an ad-hoc comparison against any live PID without the app:
+
+```bash
+ORG2_MEMORY_PROBE_PID=<pid> cargo test -p perf_utils probe_live -- --ignored --nocapture
+```
+
+To confirm ownership, `launchctl print pid/<backend pid>` must list exactly
+the `com.apple.WebKit.{WebContent,GPU,Networking}.<uuid>` instances that
+appear in `processes`; WebKit helpers of other apps on the machine must be
+absent from the snapshot.
 
 ## Windows acceptance check
 
@@ -50,3 +112,11 @@ Newer systems should report Private Working Set. If EX2 is unavailable, the
 snapshot must say `compatibility` and use Private Bytes. Any per-process query
 failure must be visible as `mixed` or `rss_fallback`, never silently relabeled
 as native.
+
+## Linux acceptance check
+
+For each reported PID, compare `effective_memory_bytes` with the `Pss:` line
+of `/proc/<pid>/smaps_rollup` and `swapped_bytes` with `SwapPss:`. Because PSS
+apportions shared pages, the sum across `WebKitWebProcess` instances must not
+exceed the sum of their `Rss:` lines. On kernels without `smaps_rollup`
+(< 4.14) the snapshot must report `rss_fallback`.

--- a/src-tauri/crates/perf-utils/Cargo.toml
+++ b/src-tauri/crates/perf-utils/Cargo.toml
@@ -44,7 +44,7 @@ similar = "2.6"
 # Process metrics
 sysinfo = { workspace = true }
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]

--- a/src-tauri/crates/perf-utils/src/app_memory.rs
+++ b/src-tauri/crates/perf-utils/src/app_memory.rs
@@ -3,6 +3,12 @@
 //! The user-facing total deliberately excludes shell, agent CLI, and tool
 //! helpers. Those processes are returned by a separate diagnostic command so
 //! they can never be accidentally folded into `effective_total_bytes`.
+//!
+//! Schema v2 adds a resident / swapped split and a lifetime peak per process.
+//! The headline `effective_memory_bytes` stays the metric the platform's own
+//! task manager shows (macOS `phys_footprint`, Windows private working set,
+//! Linux PSS); the split explains how much of that headline is physically
+//! resident right now versus held by the memory compressor or swap.
 
 #[cfg(target_os = "macos")]
 mod macos_services;
@@ -11,14 +17,14 @@ use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
-#[cfg(target_os = "macos")]
+#[cfg(unix)]
 use sysinfo::UpdateKind;
 use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
 use tauri::AppHandle;
 #[cfg(windows)]
 use tauri::Manager;
 
-const SNAPSHOT_SCHEMA_VERSION: u16 = 1;
+const SNAPSHOT_SCHEMA_VERSION: u16 = 2;
 const INVENTORY_CACHE_TTL: Duration = Duration::from_millis(750);
 
 #[cfg(target_os = "macos")]
@@ -27,15 +33,58 @@ const MACOS_OBSERVATION_WINDOW: Duration = Duration::from_secs(3);
 const MACOS_EAGER_OBSERVATION_SCANS: usize = 8;
 #[cfg(target_os = "macos")]
 const MACOS_EAGER_OBSERVATION_INTERVAL: Duration = Duration::from_millis(250);
+/// Upper bound on VM regions walked per process. Real processes have a few
+/// thousand regions; the bound only guards against a kernel that never
+/// advances the cursor.
+#[cfg(target_os = "macos")]
+const MACOS_MAX_VM_REGIONS: usize = 200_000;
 
 /// The metric used as the effective-memory value for one process.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MemoryMetricKind {
+    /// macOS `ri_phys_footprint` — Activity Monitor's "Memory" column.
     PhysicalFootprint,
+    /// Windows `PrivateWorkingSetSize` — Task Manager's "Memory" column.
     PrivateWorkingSet,
+    /// Windows `PrivateUsage` (commit charge) when EX2 counters are unavailable.
     PrivateBytes,
+    /// Linux proportional set size from `/proc/<pid>/smaps_rollup`.
+    Pss,
     RssFallback,
+}
+
+/// How the resident / swapped split of one process was measured.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoryBreakdownKind {
+    /// macOS `proc_pidinfo(PROC_PIDREGIONINFO)` walk over the process VM map.
+    VmRegionWalk,
+    /// Linux `/proc/<pid>/smaps_rollup`.
+    SmapsRollup,
+    /// Windows working-set vs. private-commit counters.
+    WorkingSetCommit,
+    Unavailable,
+}
+
+/// Resident / swapped split of one process. All values are bytes; swapped
+/// pages are counted at their uncompressed size so that
+/// `resident_private + swapped` approximates the private part of the headline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MemoryBreakdown {
+    resident_private_bytes: u64,
+    resident_shared_bytes: u64,
+    swapped_bytes: u64,
+    kind: MemoryBreakdownKind,
+}
+
+impl MemoryBreakdown {
+    const UNAVAILABLE: Self = Self {
+        resident_private_bytes: 0,
+        resident_shared_bytes: 0,
+        swapped_bytes: 0,
+        kind: MemoryBreakdownKind::Unavailable,
+    };
 }
 
 /// Summary of how the effective total was measured.
@@ -79,9 +128,23 @@ pub struct AppMemoryProcess {
     pub process_instance_id: String,
     pub name: String,
     pub role: AppMemoryProcessRole,
+    /// Headline metric — what the platform's own task manager shows.
     pub effective_memory_bytes: u64,
     pub metric_kind: MemoryMetricKind,
     pub rss_bytes: u64,
+    /// Physically resident pages private to this process.
+    pub resident_private_bytes: u64,
+    /// Physically resident pages shared with other processes (shared
+    /// libraries, dyld cache, shared memory). Not summable across processes.
+    pub resident_shared_bytes: u64,
+    /// Private pages currently held by the memory compressor or swap, at
+    /// uncompressed size. Windows: private commit that is not resident.
+    pub swapped_bytes: u64,
+    pub breakdown_kind: MemoryBreakdownKind,
+    /// Lifetime peak of `effective_memory_bytes` when the OS tracks one
+    /// (macOS `ri_lifetime_max_phys_footprint`, Windows `PeakPagefileUsage`
+    /// for the private-bytes path). `None` where no matching peak exists.
+    pub peak_effective_memory_bytes: Option<u64>,
 }
 
 /// Atomic application-memory snapshot consumed by every frontend surface.
@@ -92,6 +155,14 @@ pub struct AppMemorySnapshot {
     pub processes: Vec<AppMemoryProcess>,
     pub effective_total_bytes: u64,
     pub rss_mapped_total_bytes: u64,
+    /// Sum of `resident_private_bytes` — physical RAM exclusively held by
+    /// the app right now.
+    pub resident_private_total_bytes: u64,
+    /// Sum of `resident_shared_bytes` — diagnostic only; shared pages are
+    /// counted once per process that maps them.
+    pub resident_shared_total_bytes: u64,
+    /// Sum of `swapped_bytes` — the part of the headline that is *not* in RAM.
+    pub swapped_total_bytes: u64,
     pub measurement: EffectiveMeasurement,
     pub attribution: AttributionStatus,
     pub skipped_ambiguous_pids: Vec<u32>,
@@ -105,6 +176,9 @@ impl AppMemorySnapshot {
             processes: Vec::new(),
             effective_total_bytes: 0,
             rss_mapped_total_bytes: 0,
+            resident_private_total_bytes: 0,
+            resident_shared_total_bytes: 0,
+            swapped_total_bytes: 0,
             measurement: EffectiveMeasurement::Unavailable,
             attribution,
             skipped_ambiguous_pids: Vec::new(),
@@ -145,7 +219,7 @@ struct ProcessDescriptor {
     executable: Option<String>,
     rss_bytes: u64,
     virtual_memory_bytes: u64,
-    #[cfg(target_os = "macos")]
+    #[cfg(unix)]
     belongs_to_current_user: bool,
 }
 
@@ -176,13 +250,13 @@ impl ProcessInventoryCache {
 
         let refresh_kind = ProcessRefreshKind::nothing().with_memory();
         #[cfg(target_os = "macos")]
-        let refresh_kind = refresh_kind
-            .with_exe(UpdateKind::OnlyIfNotSet)
-            .with_user(UpdateKind::OnlyIfNotSet);
+        let refresh_kind = refresh_kind.with_exe(UpdateKind::OnlyIfNotSet);
+        #[cfg(unix)]
+        let refresh_kind = refresh_kind.with_user(UpdateKind::OnlyIfNotSet);
         self.system
             .refresh_processes_specifics(ProcessesToUpdate::All, true, refresh_kind);
 
-        #[cfg(target_os = "macos")]
+        #[cfg(unix)]
         let current_uid = sysinfo::Uid::try_from(unsafe { libc::getuid() } as usize).ok();
 
         self.descriptors = self
@@ -198,7 +272,7 @@ impl ProcessInventoryCache {
                 executable: process.exe().map(|path| path.to_string_lossy().to_string()),
                 rss_bytes: process.memory(),
                 virtual_memory_bytes: process.virtual_memory(),
-                #[cfg(target_os = "macos")]
+                #[cfg(unix)]
                 belongs_to_current_user: current_uid
                     .as_ref()
                     .is_some_and(|uid| process.user_id() == Some(uid)),
@@ -246,19 +320,133 @@ struct EffectiveProcessMemory {
     bytes: u64,
     kind: MemoryMetricKind,
     birth_token: u64,
+    breakdown: MemoryBreakdown,
+    peak_bytes: Option<u64>,
+}
+
+impl EffectiveProcessMemory {
+    fn rss_fallback(descriptor: &ProcessDescriptor, birth_token: u64) -> Self {
+        Self {
+            bytes: descriptor.rss_bytes,
+            kind: MemoryMetricKind::RssFallback,
+            birth_token,
+            breakdown: MemoryBreakdown::UNAVAILABLE,
+            peak_bytes: None,
+        }
+    }
 }
 
 #[cfg(target_os = "macos")]
-fn macos_rusage(pid: u32) -> Option<libc::rusage_info_v2> {
-    let mut usage = std::mem::MaybeUninit::<libc::rusage_info_v2>::zeroed();
+fn macos_rusage(pid: u32) -> Option<libc::rusage_info_v4> {
+    let mut usage = std::mem::MaybeUninit::<libc::rusage_info_v4>::zeroed();
     let result = unsafe {
         libc::proc_pid_rusage(
             pid as libc::c_int,
-            libc::RUSAGE_INFO_V2,
+            libc::RUSAGE_INFO_V4,
             usage.as_mut_ptr().cast(),
         )
     };
     (result == 0).then(|| unsafe { usage.assume_init() })
+}
+
+/// `struct proc_regioninfo` from `<sys/proc_info.h>`; not exported by the
+/// `libc` crate. Layout is stable ABI (used by `vmmap`, `footprint`, `lsof`).
+#[cfg(target_os = "macos")]
+#[repr(C)]
+#[derive(Default, Clone, Copy)]
+struct ProcRegionInfo {
+    pri_protection: u32,
+    pri_max_protection: u32,
+    pri_inheritance: u32,
+    pri_flags: u32,
+    pri_offset: u64,
+    pri_behavior: u32,
+    pri_user_wired_count: u32,
+    pri_user_tag: u32,
+    pri_pages_resident: u32,
+    pri_pages_shared_now_private: u32,
+    pri_pages_swapped_out: u32,
+    pri_pages_dirtied: u32,
+    pri_ref_count: u32,
+    pri_shadow_depth: u32,
+    pri_share_mode: u32,
+    pri_private_pages_resident: u32,
+    pri_shared_pages_resident: u32,
+    pri_obj_id: u32,
+    pri_depth: u32,
+    pri_address: u64,
+    pri_size: u64,
+}
+
+#[cfg(target_os = "macos")]
+const PROC_PIDREGIONINFO: libc::c_int = 7;
+/// `SM_*` share modes from `<mach/vm_region.h>` whose pages belong to this
+/// process rather than to a shared object (shared cache, shared memory).
+#[cfg(target_os = "macos")]
+const SM_COW: u32 = 1;
+#[cfg(target_os = "macos")]
+const SM_PRIVATE: u32 = 2;
+#[cfg(target_os = "macos")]
+const SM_PRIVATE_ALIASED: u32 = 6;
+#[cfg(target_os = "macos")]
+const SM_LARGE_PAGE: u32 = 8;
+
+/// Walk the VM map of `pid` with `proc_pidinfo(PROC_PIDREGIONINFO)`. This is
+/// an unprivileged, same-user query (no task port), so it works against
+/// Apple's hardened WebKit XPC helpers. Resident counts come straight from the
+/// per-region extended info; swapped pages are those held by the compressor
+/// or on-disk swap and are counted only for private / copy-on-write regions
+/// so that the shared dyld cache does not inflate the app's own number.
+#[cfg(target_os = "macos")]
+fn macos_region_breakdown(pid: u32) -> MemoryBreakdown {
+    let page_size = unsafe { libc::vm_page_size } as u64;
+    let mut address: u64 = 0;
+    let mut resident_pages: u64 = 0;
+    let mut private_pages: u64 = 0;
+    let mut swapped_pages: u64 = 0;
+    let mut regions = 0_usize;
+    loop {
+        let mut info = ProcRegionInfo::default();
+        let size = std::mem::size_of::<ProcRegionInfo>() as libc::c_int;
+        let written = unsafe {
+            libc::proc_pidinfo(
+                pid as libc::c_int,
+                PROC_PIDREGIONINFO,
+                address,
+                (&mut info as *mut ProcRegionInfo).cast(),
+                size,
+            )
+        };
+        if written != size {
+            break;
+        }
+        regions += 1;
+        resident_pages += u64::from(info.pri_pages_resident);
+        private_pages += u64::from(info.pri_private_pages_resident);
+        if matches!(
+            info.pri_share_mode,
+            SM_COW | SM_PRIVATE | SM_PRIVATE_ALIASED | SM_LARGE_PAGE
+        ) {
+            swapped_pages += u64::from(info.pri_pages_swapped_out);
+        }
+        let next = info.pri_address.saturating_add(info.pri_size);
+        if next <= address || regions >= MACOS_MAX_VM_REGIONS {
+            break;
+        }
+        address = next;
+    }
+    if regions == 0 {
+        return MemoryBreakdown::UNAVAILABLE;
+    }
+    let resident_private_bytes = private_pages.saturating_mul(page_size);
+    MemoryBreakdown {
+        resident_private_bytes,
+        resident_shared_bytes: resident_pages
+            .saturating_sub(private_pages)
+            .saturating_mul(page_size),
+        swapped_bytes: swapped_pages.saturating_mul(page_size),
+        kind: MemoryBreakdownKind::VmRegionWalk,
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -287,23 +475,91 @@ fn collect_effective_memory(descriptor: &ProcessDescriptor) -> EffectiveProcessM
             bytes: usage.ri_phys_footprint,
             kind: MemoryMetricKind::PhysicalFootprint,
             birth_token: usage.ri_proc_start_abstime,
+            breakdown: macos_region_breakdown(descriptor.pid),
+            peak_bytes: (usage.ri_lifetime_max_phys_footprint > 0)
+                .then_some(usage.ri_lifetime_max_phys_footprint),
         }
     } else {
-        EffectiveProcessMemory {
-            bytes: descriptor.rss_bytes,
-            kind: MemoryMetricKind::RssFallback,
-            birth_token: descriptor.start_time_secs,
-        }
+        EffectiveProcessMemory::rss_fallback(descriptor, descriptor.start_time_secs)
     }
 }
 
-#[cfg(not(any(target_os = "macos", windows)))]
-fn collect_effective_memory(descriptor: &ProcessDescriptor) -> EffectiveProcessMemory {
-    EffectiveProcessMemory {
-        bytes: descriptor.rss_bytes,
-        kind: MemoryMetricKind::RssFallback,
-        birth_token: descriptor.start_time_secs,
+/// Parsed subset of `/proc/<pid>/smaps_rollup` (Linux ≥ 4.14). Values in bytes.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct SmapsRollup {
+    pss: u64,
+    private_clean: u64,
+    private_dirty: u64,
+    swap_pss: u64,
+}
+
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+fn parse_smaps_rollup(text: &str) -> Option<SmapsRollup> {
+    let mut rollup = SmapsRollup::default();
+    let mut saw_pss = false;
+    for line in text.lines() {
+        let Some((key, rest)) = line.split_once(':') else {
+            continue;
+        };
+        let mut fields = rest.split_whitespace();
+        let Some(value) = fields.next().and_then(|value| value.parse::<u64>().ok()) else {
+            continue;
+        };
+        let bytes = match fields.next() {
+            Some("kB") | Some("KB") => value.saturating_mul(1024),
+            Some("mB") | Some("MB") => value.saturating_mul(1024 * 1024),
+            Some(_) | None => value,
+        };
+        match key.trim() {
+            "Pss" => {
+                rollup.pss = bytes;
+                saw_pss = true;
+            }
+            "Private_Clean" => rollup.private_clean = bytes,
+            "Private_Dirty" => rollup.private_dirty = bytes,
+            "SwapPss" => rollup.swap_pss = bytes,
+            _ => {}
+        }
     }
+    saw_pss.then_some(rollup)
+}
+
+#[cfg(target_os = "linux")]
+fn linux_smaps_rollup(pid: u32) -> Option<SmapsRollup> {
+    let text = std::fs::read_to_string(format!("/proc/{pid}/smaps_rollup")).ok()?;
+    parse_smaps_rollup(&text)
+}
+
+#[cfg(target_os = "linux")]
+fn collect_effective_memory(descriptor: &ProcessDescriptor) -> EffectiveProcessMemory {
+    match linux_smaps_rollup(descriptor.pid) {
+        Some(rollup) => {
+            let resident_private_bytes = rollup
+                .private_clean
+                .saturating_add(rollup.private_dirty);
+            EffectiveProcessMemory {
+                bytes: rollup.pss,
+                kind: MemoryMetricKind::Pss,
+                birth_token: descriptor.start_time_secs,
+                breakdown: MemoryBreakdown {
+                    resident_private_bytes,
+                    // PSS already counts shared pages proportionally, so the
+                    // remainder is this process's fair share of shared pages.
+                    resident_shared_bytes: rollup.pss.saturating_sub(resident_private_bytes),
+                    swapped_bytes: rollup.swap_pss,
+                    kind: MemoryBreakdownKind::SmapsRollup,
+                },
+                peak_bytes: None,
+            }
+        }
+        None => EffectiveProcessMemory::rss_fallback(descriptor, descriptor.start_time_secs),
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", windows)))]
+fn collect_effective_memory(descriptor: &ProcessDescriptor) -> EffectiveProcessMemory {
+    EffectiveProcessMemory::rss_fallback(descriptor, descriptor.start_time_secs)
 }
 
 fn build_process(descriptor: &ProcessDescriptor, role: AppMemoryProcessRole) -> AppMemoryProcess {
@@ -325,6 +581,11 @@ fn build_process(descriptor: &ProcessDescriptor, role: AppMemoryProcessRole) -> 
         effective_memory_bytes: effective.bytes,
         metric_kind: effective.kind,
         rss_bytes: descriptor.rss_bytes,
+        resident_private_bytes: effective.breakdown.resident_private_bytes,
+        resident_shared_bytes: effective.breakdown.resident_shared_bytes,
+        swapped_bytes: effective.breakdown.swapped_bytes,
+        breakdown_kind: effective.breakdown.kind,
+        peak_effective_memory_bytes: effective.peak_bytes,
     }
 }
 
@@ -373,6 +634,15 @@ fn aggregate_snapshot(
     let rss_mapped_total_bytes = processes.iter().fold(0_u64, |total, process| {
         total.saturating_add(process.rss_bytes)
     });
+    let resident_private_total_bytes = processes.iter().fold(0_u64, |total, process| {
+        total.saturating_add(process.resident_private_bytes)
+    });
+    let resident_shared_total_bytes = processes.iter().fold(0_u64, |total, process| {
+        total.saturating_add(process.resident_shared_bytes)
+    });
+    let swapped_total_bytes = processes.iter().fold(0_u64, |total, process| {
+        total.saturating_add(process.swapped_bytes)
+    });
     let all_rss = processes
         .iter()
         .all(|process| process.metric_kind == MemoryMetricKind::RssFallback);
@@ -382,7 +652,9 @@ fn aggregate_snapshot(
     let all_native = processes.iter().all(|process| {
         matches!(
             process.metric_kind,
-            MemoryMetricKind::PhysicalFootprint | MemoryMetricKind::PrivateWorkingSet
+            MemoryMetricKind::PhysicalFootprint
+                | MemoryMetricKind::PrivateWorkingSet
+                | MemoryMetricKind::Pss
         )
     });
     let measurement = if all_native {
@@ -401,6 +673,9 @@ fn aggregate_snapshot(
         processes,
         effective_total_bytes,
         rss_mapped_total_bytes,
+        resident_private_total_bytes,
+        resident_shared_total_bytes,
+        swapped_total_bytes,
         measurement,
         attribution,
         skipped_ambiguous_pids,
@@ -689,6 +964,25 @@ fn resolve_macos_service_ownership(
     (owned, skipped, attribution)
 }
 
+/// WebKitGTK helper roles by executable name. `sysinfo` reports the kernel
+/// `comm` name, which is truncated to 15 bytes ("WebKitNetworkPr"), so match
+/// on prefixes rather than whole names.
+#[cfg(not(any(target_os = "macos", windows)))]
+fn webkitgtk_role(name: &str) -> Option<AppMemoryProcessRole> {
+    let lower = name.to_ascii_lowercase();
+    if lower.starts_with("webkitwebproc") {
+        Some(AppMemoryProcessRole::Renderer)
+    } else if lower.starts_with("webkitnetworkp") {
+        Some(AppMemoryProcessRole::Network)
+    } else if lower.starts_with("webkitgpuproc") {
+        Some(AppMemoryProcessRole::Gpu)
+    } else if lower.contains("webprocess") || lower.contains("webkit") {
+        Some(AppMemoryProcessRole::Utility)
+    } else {
+        None
+    }
+}
+
 #[cfg(not(any(target_os = "macos", windows)))]
 fn owned_webview_processes(
     inventory: &[ProcessDescriptor],
@@ -700,14 +994,15 @@ fn owned_webview_processes(
     let root_pid = std::process::id();
     let mut owned = HashMap::new();
     for descriptor in inventory {
-        let lower = descriptor.name.to_ascii_lowercase();
-        if descendant_depth(descriptor.pid, root_pid, inventory).is_some()
-            && (lower.contains("webprocess") || lower.contains("webkit"))
-        {
-            owned.insert(
-                process_instance_key(descriptor),
-                AppMemoryProcessRole::Renderer,
-            );
+        #[cfg(unix)]
+        if !descriptor.belongs_to_current_user {
+            continue;
+        }
+        if descendant_depth(descriptor.pid, root_pid, inventory).is_none() {
+            continue;
+        }
+        if let Some(role) = webkitgtk_role(&descriptor.name) {
+            owned.insert(process_instance_key(descriptor), role);
         }
     }
     (owned, Vec::new(), AttributionStatus::Complete)
@@ -902,6 +1197,11 @@ mod tests {
             effective_memory_bytes: bytes,
             metric_kind: kind,
             rss_bytes: bytes.saturating_add(10),
+            resident_private_bytes: bytes / 2,
+            resident_shared_bytes: 5,
+            swapped_bytes: bytes - bytes / 2,
+            breakdown_kind: MemoryBreakdownKind::VmRegionWalk,
+            peak_effective_memory_bytes: Some(bytes.saturating_mul(2)),
         }
     }
 
@@ -919,6 +1219,61 @@ mod tests {
         assert_eq!(snapshot.measurement, EffectiveMeasurement::Native);
         assert_eq!(snapshot.effective_total_bytes, 150);
         assert_eq!(snapshot.rss_mapped_total_bytes, 170);
+        assert_eq!(snapshot.resident_private_total_bytes, 75);
+        assert_eq!(snapshot.resident_shared_total_bytes, 10);
+        assert_eq!(snapshot.swapped_total_bytes, 75);
+    }
+
+    #[test]
+    fn aggregate_treats_pss_as_native() {
+        let snapshot = aggregate_snapshot(
+            10,
+            vec![process(1, 100, MemoryMetricKind::Pss)],
+            AttributionStatus::Complete,
+            Vec::new(),
+        );
+        assert_eq!(snapshot.measurement, EffectiveMeasurement::Native);
+    }
+
+    #[test]
+    fn aggregate_split_totals_saturate() {
+        let mut huge = process(1, u64::MAX, MemoryMetricKind::RssFallback);
+        huge.resident_private_bytes = u64::MAX;
+        huge.swapped_bytes = u64::MAX;
+        let mut other = process(2, 1, MemoryMetricKind::RssFallback);
+        other.resident_private_bytes = 1;
+        other.swapped_bytes = 1;
+        let snapshot =
+            aggregate_snapshot(10, vec![huge, other], AttributionStatus::Complete, Vec::new());
+        assert_eq!(snapshot.resident_private_total_bytes, u64::MAX);
+        assert_eq!(snapshot.swapped_total_bytes, u64::MAX);
+    }
+
+    #[test]
+    fn smaps_rollup_parser_reads_pss_private_and_swap() {
+        let text = "\
+00400000-7fff0000 ---p 00000000 00:00 0                          [rollup]
+Rss:              123456 kB
+Pss:               98304 kB
+Pss_Dirty:         90000 kB
+Pss_Anon:          80000 kB
+Shared_Clean:      20000 kB
+Private_Clean:      4096 kB
+Private_Dirty:     81920 kB
+Swap:              12288 kB
+SwapPss:            8192 kB
+";
+        let rollup = parse_smaps_rollup(text).expect("rollup parses");
+        assert_eq!(rollup.pss, 98304 * 1024);
+        assert_eq!(rollup.private_clean, 4096 * 1024);
+        assert_eq!(rollup.private_dirty, 81920 * 1024);
+        assert_eq!(rollup.swap_pss, 8192 * 1024);
+    }
+
+    #[test]
+    fn smaps_rollup_parser_requires_pss() {
+        assert_eq!(parse_smaps_rollup("Rss: 10 kB\nPrivate_Dirty: 5 kB\n"), None);
+        assert_eq!(parse_smaps_rollup(""), None);
     }
 
     #[test]
@@ -994,11 +1349,26 @@ mod tests {
             vec![22],
         );
         let value = serde_json::to_value(snapshot).expect("snapshot serializes");
-        assert_eq!(value["schema_version"], 1);
+        assert_eq!(value["schema_version"], 2);
         assert_eq!(value["measurement"], "native");
         assert_eq!(value["attribution"], "partial");
         assert_eq!(value["processes"][0]["metric_kind"], "physical_footprint");
+        assert_eq!(value["processes"][0]["breakdown_kind"], "vm_region_walk");
+        assert_eq!(value["processes"][0]["resident_private_bytes"], 50);
+        assert_eq!(value["processes"][0]["swapped_bytes"], 50);
+        assert_eq!(value["processes"][0]["peak_effective_memory_bytes"], 200);
+        assert_eq!(value["resident_private_total_bytes"], 50);
+        assert_eq!(value["swapped_total_bytes"], 50);
         assert!(value["processes"][0].get("memory_mb").is_none());
+    }
+
+    #[test]
+    fn wire_contract_serializes_missing_peak_as_null() {
+        let mut no_peak = process(1, 100, MemoryMetricKind::Pss);
+        no_peak.peak_effective_memory_bytes = None;
+        let value = serde_json::to_value(no_peak).expect("process serializes");
+        assert!(value["peak_effective_memory_bytes"].is_null());
+        assert_eq!(value["metric_kind"], "pss");
     }
 
     #[cfg(target_os = "macos")]
@@ -1073,5 +1443,67 @@ mod tests {
         let usage = macos_rusage(std::process::id()).expect("current process rusage");
         assert!(usage.ri_phys_footprint > 0);
         assert!(usage.ri_proc_start_abstime > 0);
+        assert!(usage.ri_lifetime_max_phys_footprint >= usage.ri_phys_footprint);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_region_walk_splits_current_process() {
+        // Pin a private allocation so the walk has something unambiguous to find.
+        let pinned = vec![7_u8; 32 * 1024 * 1024];
+        std::hint::black_box(&pinned);
+        let breakdown = macos_region_breakdown(std::process::id());
+        assert_eq!(breakdown.kind, MemoryBreakdownKind::VmRegionWalk);
+        assert!(
+            breakdown.resident_private_bytes >= 32 * 1024 * 1024,
+            "private resident {} should cover the pinned 32 MiB",
+            breakdown.resident_private_bytes
+        );
+        assert!(breakdown.resident_shared_bytes > 0, "dyld cache must be shared-resident");
+        let usage = macos_rusage(std::process::id()).expect("current process rusage");
+        // footprint ≈ private resident + private swapped (+ graphics / purgeable).
+        let explained = breakdown
+            .resident_private_bytes
+            .saturating_add(breakdown.swapped_bytes);
+        assert!(
+            explained * 2 >= usage.ri_phys_footprint,
+            "split {explained} explains less than half of footprint {}",
+            usage.ri_phys_footprint
+        );
+        drop(pinned);
+    }
+
+    /// Manual cross-check against a live process, e.g. a WebContent helper
+    /// owned by a running ORG2:
+    /// `ORG2_MEMORY_PROBE_PID=<pid> cargo test -p perf_utils probe_live -- --ignored --nocapture`
+    /// then compare with `/usr/bin/footprint -p <pid> --swapped --noCategories`.
+    #[cfg(target_os = "macos")]
+    #[test]
+    #[ignore]
+    fn macos_region_walk_probe_live_pid() {
+        let pid: u32 = std::env::var("ORG2_MEMORY_PROBE_PID")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .expect("set ORG2_MEMORY_PROBE_PID");
+        let usage = macos_rusage(pid).expect("rusage for probe pid");
+        let breakdown = macos_region_breakdown(pid);
+        let mib = |bytes: u64| bytes as f64 / (1024.0 * 1024.0);
+        println!(
+            "pid {pid}: footprint {:.0} MiB (peak {:.0}) | resident private {:.0} MiB, shared {:.0} MiB, swapped {:.0} MiB [{:?}]",
+            mib(usage.ri_phys_footprint),
+            mib(usage.ri_lifetime_max_phys_footprint),
+            mib(breakdown.resident_private_bytes),
+            mib(breakdown.resident_shared_bytes),
+            mib(breakdown.swapped_bytes),
+            breakdown.kind
+        );
+        assert_eq!(breakdown.kind, MemoryBreakdownKind::VmRegionWalk);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_region_walk_reports_unavailable_for_dead_pid() {
+        // PID 0 is the kernel task; proc_pidinfo refuses it for user callers.
+        assert_eq!(macos_region_breakdown(0).kind, MemoryBreakdownKind::Unavailable);
     }
 }

--- a/src-tauri/crates/perf-utils/src/app_memory.rs
+++ b/src-tauri/crates/perf-utils/src/app_memory.rs
@@ -1449,25 +1449,36 @@ SwapPss:            8192 kB
     #[cfg(target_os = "macos")]
     #[test]
     fn macos_region_walk_splits_current_process() {
-        // Pin a private allocation so the walk has something unambiguous to find.
-        let pinned = vec![7_u8; 32 * 1024 * 1024];
+        // Dirty a private allocation so the walk has something unambiguous to
+        // find. Under memory pressure the kernel may compress these pages
+        // immediately, so the invariant is "resident or swapped", never
+        // "resident" alone.
+        const PINNED: u64 = 32 * 1024 * 1024;
+        let pinned = vec![7_u8; PINNED as usize];
         std::hint::black_box(&pinned);
         let breakdown = macos_region_breakdown(std::process::id());
         assert_eq!(breakdown.kind, MemoryBreakdownKind::VmRegionWalk);
-        assert!(
-            breakdown.resident_private_bytes >= 32 * 1024 * 1024,
-            "private resident {} should cover the pinned 32 MiB",
-            breakdown.resident_private_bytes
-        );
-        assert!(breakdown.resident_shared_bytes > 0, "dyld cache must be shared-resident");
-        let usage = macos_rusage(std::process::id()).expect("current process rusage");
-        // footprint ≈ private resident + private swapped (+ graphics / purgeable).
-        let explained = breakdown
+        let private = breakdown
             .resident_private_bytes
             .saturating_add(breakdown.swapped_bytes);
         assert!(
-            explained * 2 >= usage.ri_phys_footprint,
-            "split {explained} explains less than half of footprint {}",
+            private >= PINNED,
+            "private resident {} + swapped {} should cover the pinned 32 MiB",
+            breakdown.resident_private_bytes,
+            breakdown.swapped_bytes
+        );
+        assert!(breakdown.resident_shared_bytes > 0, "dyld cache must be shared-resident");
+        // A struct-layout mismatch would read addresses or sizes as page
+        // counts and produce absurd totals; the real split stays in the same
+        // order of magnitude as the kernel's own footprint ledger.
+        let usage = macos_rusage(std::process::id()).expect("current process rusage");
+        let ceiling = usage
+            .ri_phys_footprint
+            .saturating_mul(2)
+            .saturating_add(64 * 1024 * 1024);
+        assert!(
+            private <= ceiling,
+            "split {private} is implausibly larger than footprint {}",
             usage.ri_phys_footprint
         );
         drop(pinned);

--- a/src-tauri/crates/perf-utils/src/app_memory/windows_impl.rs
+++ b/src-tauri/crates/perf-utils/src/app_memory/windows_impl.rs
@@ -53,7 +53,7 @@ fn process_birth_token(handle: HANDLE) -> Option<u64> {
         .map(|()| filetime_value(creation))
 }
 
-fn query_private_working_set(handle: HANDLE) -> Option<u64> {
+fn query_counters_ex2(handle: HANDLE) -> Option<PROCESS_MEMORY_COUNTERS_EX2> {
     let mut counters = PROCESS_MEMORY_COUNTERS_EX2 {
         cb: std::mem::size_of::<PROCESS_MEMORY_COUNTERS_EX2>() as u32,
         ..Default::default()
@@ -66,10 +66,10 @@ fn query_private_working_set(handle: HANDLE) -> Option<u64> {
         )
     }
     .ok()
-    .map(|()| counters.PrivateWorkingSetSize as u64)
+    .map(|()| counters)
 }
 
-fn query_private_bytes(handle: HANDLE) -> Option<u64> {
+fn query_counters_ex(handle: HANDLE) -> Option<PROCESS_MEMORY_COUNTERS_EX> {
     let mut counters = PROCESS_MEMORY_COUNTERS_EX {
         cb: std::mem::size_of::<PROCESS_MEMORY_COUNTERS_EX>() as u32,
         ..Default::default()
@@ -82,12 +82,62 @@ fn query_private_bytes(handle: HANDLE) -> Option<u64> {
         )
     }
     .ok()
-    .map(|()| counters.PrivateUsage as u64)
+    .map(|()| counters)
+}
+
+/// Task Manager parity: headline = private working set; resident shared =
+/// the rest of the working set; "swapped" = private commit that is not
+/// currently resident (an upper bound on pages in the pagefile).
+fn private_working_set_memory(
+    counters: &PROCESS_MEMORY_COUNTERS_EX2,
+    birth_token: u64,
+) -> EffectiveProcessMemory {
+    let private_working_set = counters.PrivateWorkingSetSize as u64;
+    let working_set = counters.WorkingSetSize as u64;
+    let private_commit = counters.PrivateUsage as u64;
+    EffectiveProcessMemory {
+        bytes: private_working_set,
+        kind: MemoryMetricKind::PrivateWorkingSet,
+        birth_token,
+        breakdown: MemoryBreakdown {
+            resident_private_bytes: private_working_set,
+            resident_shared_bytes: working_set.saturating_sub(private_working_set),
+            swapped_bytes: private_commit.saturating_sub(private_working_set),
+            kind: MemoryBreakdownKind::WorkingSetCommit,
+        },
+        // The OS tracks peak working set and peak commit, but no peak of the
+        // private working set, so no matching peak is reported.
+        peak_bytes: None,
+    }
+}
+
+/// Compatibility path when EX2 counters are unavailable: headline = private
+/// commit. The working set is not split into private / shared here, so the
+/// resident figure is capped at the commit it explains.
+fn private_bytes_memory(
+    counters: &PROCESS_MEMORY_COUNTERS_EX,
+    birth_token: u64,
+) -> EffectiveProcessMemory {
+    let private_commit = counters.PrivateUsage as u64;
+    let working_set = counters.WorkingSetSize as u64;
+    let resident_private = working_set.min(private_commit);
+    EffectiveProcessMemory {
+        bytes: private_commit,
+        kind: MemoryMetricKind::PrivateBytes,
+        birth_token,
+        breakdown: MemoryBreakdown {
+            resident_private_bytes: resident_private,
+            resident_shared_bytes: working_set.saturating_sub(resident_private),
+            swapped_bytes: private_commit.saturating_sub(resident_private),
+            kind: MemoryBreakdownKind::WorkingSetCommit,
+        },
+        peak_bytes: Some(counters.PeakPagefileUsage as u64),
+    }
 }
 
 fn detect_capability() -> WindowsMemoryCapability {
     ProcessHandle::open(std::process::id())
-        .and_then(|handle| query_private_working_set(handle.0))
+        .and_then(|handle| query_counters_ex2(handle.0))
         .map(|_| WindowsMemoryCapability::PrivateWorkingSet)
         .unwrap_or(WindowsMemoryCapability::PrivateBytes)
 }
@@ -104,36 +154,16 @@ pub(super) fn process_instance_key(descriptor: &ProcessDescriptor) -> ProcessIns
 
 pub(super) fn collect_effective_memory(descriptor: &ProcessDescriptor) -> EffectiveProcessMemory {
     let Some(handle) = ProcessHandle::open(descriptor.pid) else {
-        return EffectiveProcessMemory {
-            bytes: descriptor.rss_bytes,
-            kind: MemoryMetricKind::RssFallback,
-            birth_token: descriptor.start_time_secs,
-        };
+        return EffectiveProcessMemory::rss_fallback(descriptor, descriptor.start_time_secs);
     };
     let birth_token = process_birth_token(handle.0).unwrap_or(descriptor.start_time_secs);
     match *WINDOWS_MEMORY_CAPABILITY.get_or_init(detect_capability) {
-        WindowsMemoryCapability::PrivateWorkingSet => query_private_working_set(handle.0)
-            .map(|bytes| EffectiveProcessMemory {
-                bytes,
-                kind: MemoryMetricKind::PrivateWorkingSet,
-                birth_token,
-            })
-            .unwrap_or(EffectiveProcessMemory {
-                bytes: descriptor.rss_bytes,
-                kind: MemoryMetricKind::RssFallback,
-                birth_token,
-            }),
-        WindowsMemoryCapability::PrivateBytes => query_private_bytes(handle.0)
-            .map(|bytes| EffectiveProcessMemory {
-                bytes,
-                kind: MemoryMetricKind::PrivateBytes,
-                birth_token,
-            })
-            .unwrap_or(EffectiveProcessMemory {
-                bytes: descriptor.rss_bytes,
-                kind: MemoryMetricKind::RssFallback,
-                birth_token,
-            }),
+        WindowsMemoryCapability::PrivateWorkingSet => query_counters_ex2(handle.0)
+            .map(|counters| private_working_set_memory(&counters, birth_token))
+            .unwrap_or_else(|| EffectiveProcessMemory::rss_fallback(descriptor, birth_token)),
+        WindowsMemoryCapability::PrivateBytes => query_counters_ex(handle.0)
+            .map(|counters| private_bytes_memory(&counters, birth_token))
+            .unwrap_or_else(|| EffectiveProcessMemory::rss_fallback(descriptor, birth_token)),
     }
 }
 

--- a/src/hooks/perf/appMemorySnapshot.test.ts
+++ b/src/hooks/perf/appMemorySnapshot.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type { AppMemorySnapshotV1 } from "./appMemorySnapshot";
+import type { AppMemoryProcess, AppMemorySnapshot } from "./appMemorySnapshot";
 import {
+  describeAppMemoryMeasurement,
+  getAppMemoryMetricKind,
   getAppMemoryTotals,
   refreshAppMemorySnapshot,
 } from "./appMemorySnapshot";
@@ -10,50 +12,150 @@ const mocks = vi.hoisted(() => ({ invoke: vi.fn() }));
 
 vi.mock("@tauri-apps/api/core", () => ({ invoke: mocks.invoke }));
 
+function process(overrides: Partial<AppMemoryProcess>): AppMemoryProcess {
+  return {
+    pid: 1,
+    parent_pid: null,
+    process_instance_id: "1:1",
+    name: "ORG2 backend",
+    role: "backend",
+    effective_memory_bytes: 100,
+    metric_kind: "physical_footprint",
+    rss_bytes: 150,
+    resident_private_bytes: 40,
+    resident_shared_bytes: 20,
+    swapped_bytes: 60,
+    breakdown_kind: "vm_region_walk",
+    peak_effective_memory_bytes: 200,
+    ...overrides,
+  };
+}
+
+function snapshotWith(
+  processes: AppMemoryProcess[],
+  overrides: Partial<AppMemorySnapshot> = {}
+): AppMemorySnapshot {
+  return {
+    schema_version: 2,
+    captured_at_ms: 123,
+    processes,
+    effective_total_bytes: processes.reduce(
+      (sum, item) => sum + item.effective_memory_bytes,
+      0
+    ),
+    rss_mapped_total_bytes: processes.reduce(
+      (sum, item) => sum + item.rss_bytes,
+      0
+    ),
+    resident_private_total_bytes: processes.reduce(
+      (sum, item) => sum + item.resident_private_bytes,
+      0
+    ),
+    resident_shared_total_bytes: processes.reduce(
+      (sum, item) => sum + item.resident_shared_bytes,
+      0
+    ),
+    swapped_total_bytes: processes.reduce(
+      (sum, item) => sum + item.swapped_bytes,
+      0
+    ),
+    measurement: "native",
+    attribution: "complete",
+    skipped_ambiguous_pids: [],
+    ...overrides,
+  };
+}
+
+const translate = (key: string) => `<${key}>`;
+
 describe("app-memory snapshot store", () => {
   it("derives the top total only from the authoritative app snapshot", () => {
-    const snapshot = {
-      schema_version: 1,
-      captured_at_ms: 123,
-      processes: [
-        {
-          pid: 1,
-          parent_pid: null,
-          process_instance_id: "1:1",
-          name: "ORG2 backend",
-          role: "backend",
-          effective_memory_bytes: 100,
-          metric_kind: "physical_footprint",
-          rss_bytes: 150,
-        },
-        {
-          pid: 2,
-          parent_pid: null,
-          process_instance_id: "2:2",
-          name: "WebView renderer",
-          role: "renderer",
-          effective_memory_bytes: 50,
-          metric_kind: "physical_footprint",
-          rss_bytes: 75,
-        },
-      ],
-      effective_total_bytes: 150,
-      rss_mapped_total_bytes: 225,
-      measurement: "native",
-      attribution: "complete",
-      skipped_ambiguous_pids: [],
-    } satisfies AppMemorySnapshotV1;
+    const snapshot = snapshotWith([
+      process({}),
+      process({
+        pid: 2,
+        process_instance_id: "2:2",
+        name: "WebView renderer",
+        role: "renderer",
+        effective_memory_bytes: 50,
+        rss_bytes: 75,
+        resident_private_bytes: 10,
+        resident_shared_bytes: 5,
+        swapped_bytes: 40,
+      }),
+    ]);
 
     expect(getAppMemoryTotals(snapshot)).toEqual({
       totalBytes: 150,
       backendBytes: 100,
       webviewHelperBytes: 50,
+      residentPrivateBytes: 50,
+      residentSharedBytes: 25,
+      swappedBytes: 100,
+      hasBreakdown: true,
     });
   });
 
+  it("reports no breakdown when every process lacks a split", () => {
+    const snapshot = snapshotWith([
+      process({
+        metric_kind: "rss_fallback",
+        breakdown_kind: "unavailable",
+        resident_private_bytes: 0,
+        resident_shared_bytes: 0,
+        swapped_bytes: 0,
+        peak_effective_memory_bytes: null,
+      }),
+    ]);
+    expect(getAppMemoryTotals(snapshot).hasBreakdown).toBe(false);
+    expect(getAppMemoryTotals(null)).toEqual({
+      totalBytes: 0,
+      backendBytes: 0,
+      webviewHelperBytes: 0,
+      residentPrivateBytes: 0,
+      residentSharedBytes: 0,
+      swappedBytes: 0,
+      hasBreakdown: false,
+    });
+  });
+
+  it("uses the backend metric kind as the headline metric", () => {
+    const snapshot = snapshotWith([
+      process({
+        pid: 2,
+        role: "renderer",
+        metric_kind: "rss_fallback",
+      }),
+      process({ metric_kind: "private_working_set" }),
+    ]);
+    expect(getAppMemoryMetricKind(snapshot)).toBe("private_working_set");
+    expect(getAppMemoryMetricKind(null)).toBeNull();
+    expect(getAppMemoryMetricKind(snapshotWith([]))).toBeNull();
+  });
+
+  it("describes the measurement with the OS metric and any caveats", () => {
+    expect(
+      describeAppMemoryMeasurement(snapshotWith([process({})]), translate)
+    ).toBe("<monitor.metricKinds.physical_footprint>");
+    expect(
+      describeAppMemoryMeasurement(
+        snapshotWith([process({})], {
+          measurement: "mixed",
+          attribution: "partial",
+        }),
+        translate
+      )
+    ).toBe(
+      "<monitor.metricKinds.physical_footprint> · <monitor.measurementKinds.mixed> · <monitor.attributionPartial>"
+    );
+    expect(describeAppMemoryMeasurement(null, translate)).toBe(
+      "<monitor.measurementKinds.unavailable>"
+    );
+  });
+
   it("shares one in-flight native snapshot request across consumers", async () => {
-    let resolveRequest!: (snapshot: AppMemorySnapshotV1) => void;
-    const request = new Promise<AppMemorySnapshotV1>((resolve) => {
+    let resolveRequest!: (snapshot: AppMemorySnapshot) => void;
+    const request = new Promise<AppMemorySnapshot>((resolve) => {
       resolveRequest = resolve;
     });
     mocks.invoke.mockReturnValue(request);
@@ -64,16 +166,12 @@ describe("app-memory snapshot store", () => {
     expect(mocks.invoke).toHaveBeenCalledTimes(1);
     expect(mocks.invoke).toHaveBeenCalledWith("get_app_memory_snapshot_v1");
 
-    const snapshot: AppMemorySnapshotV1 = {
-      schema_version: 1,
-      captured_at_ms: 123,
-      processes: [],
+    const snapshot = snapshotWith([], {
       effective_total_bytes: 456,
       rss_mapped_total_bytes: 789,
-      measurement: "native",
       attribution: "partial",
       skipped_ambiguous_pids: [42],
-    };
+    });
     resolveRequest(snapshot);
 
     await expect(first).resolves.toBe(snapshot);

--- a/src/hooks/perf/appMemorySnapshot.ts
+++ b/src/hooks/perf/appMemorySnapshot.ts
@@ -6,11 +6,23 @@ import { createLogger } from "@src/hooks/logger";
 const log = createLogger("AppMemorySnapshot");
 const POLL_INTERVAL_MS = 15_000;
 
+/**
+ * Headline metric per process — always the value the platform's own task
+ * manager shows (Activity Monitor "Memory", Task Manager "Memory", PSS).
+ */
 export type MemoryMetricKind =
   | "physical_footprint"
   | "private_working_set"
   | "private_bytes"
+  | "pss"
   | "rss_fallback";
+
+/** How the resident / swapped split was measured. */
+export type MemoryBreakdownKind =
+  | "vm_region_walk"
+  | "smaps_rollup"
+  | "working_set_commit"
+  | "unavailable";
 
 export type EffectiveMeasurement =
   | "native"
@@ -38,14 +50,26 @@ export interface AppMemoryProcess {
   effective_memory_bytes: number;
   metric_kind: MemoryMetricKind;
   rss_bytes: number;
+  /** Physically resident pages private to this process. */
+  resident_private_bytes: number;
+  /** Resident pages shared with other processes; not summable. */
+  resident_shared_bytes: number;
+  /** Private pages in the compressor / swap, at uncompressed size. */
+  swapped_bytes: number;
+  breakdown_kind: MemoryBreakdownKind;
+  /** Lifetime peak of `effective_memory_bytes`, when the OS tracks one. */
+  peak_effective_memory_bytes: number | null;
 }
 
-export interface AppMemorySnapshotV1 {
-  schema_version: 1;
+export interface AppMemorySnapshot {
+  schema_version: 2;
   captured_at_ms: number;
   processes: AppMemoryProcess[];
   effective_total_bytes: number;
   rss_mapped_total_bytes: number;
+  resident_private_total_bytes: number;
+  resident_shared_total_bytes: number;
+  swapped_total_bytes: number;
   measurement: EffectiveMeasurement;
   attribution: AttributionStatus;
   skipped_ambiguous_pids: number[];
@@ -65,19 +89,28 @@ export interface ToolProcessMemoryDiagnostic {
 }
 
 export interface AppMemorySnapshotState {
-  snapshot: AppMemorySnapshotV1 | null;
+  snapshot: AppMemorySnapshot | null;
   errorMessage: string | null;
   isLoading: boolean;
 }
 
 export interface AppMemoryTotals {
+  /** Headline total — sum of each process's task-manager metric. */
   totalBytes: number;
   backendBytes: number;
   webviewHelperBytes: number;
+  /** Physical RAM exclusively held by the app right now. */
+  residentPrivateBytes: number;
+  /** Diagnostic only; shared pages are counted once per mapping process. */
+  residentSharedBytes: number;
+  /** Part of the headline that is not in RAM (compressor / swap). */
+  swappedBytes: number;
+  /** True when at least one process reported a resident / swapped split. */
+  hasBreakdown: boolean;
 }
 
 export function getAppMemoryTotals(
-  snapshot: AppMemorySnapshotV1 | null
+  snapshot: AppMemorySnapshot | null
 ): AppMemoryTotals {
   const totalBytes = snapshot?.effective_total_bytes ?? 0;
   const backendBytes =
@@ -88,7 +121,69 @@ export function getAppMemoryTotals(
     totalBytes,
     backendBytes,
     webviewHelperBytes: Math.max(0, totalBytes - backendBytes),
+    residentPrivateBytes: snapshot?.resident_private_total_bytes ?? 0,
+    residentSharedBytes: snapshot?.resident_shared_total_bytes ?? 0,
+    swappedBytes: snapshot?.swapped_total_bytes ?? 0,
+    hasBreakdown:
+      snapshot?.processes.some(
+        (process) => process.breakdown_kind !== "unavailable"
+      ) ?? false,
   };
+}
+
+/**
+ * The metric kind that describes the headline. The backend process is the
+ * reference; helpers normally share its kind, and `measurement` reports when
+ * they do not.
+ */
+export function getAppMemoryMetricKind(
+  snapshot: AppMemorySnapshot | null
+): MemoryMetricKind | null {
+  if (!snapshot || snapshot.processes.length === 0) return null;
+  const backend = snapshot.processes.find(
+    (process) => process.role === "backend"
+  );
+  return (backend ?? snapshot.processes[0]).metric_kind;
+}
+
+/** Settings-namespace i18n key for a process role label. */
+export function getAppMemoryRoleLabelKey(role: AppMemoryProcessRole): string {
+  switch (role) {
+    case "backend":
+      return "monitor.appBackend";
+    case "renderer":
+      return "monitor.categoryWebview";
+    case "gpu":
+      return "monitor.categoryGpu";
+    case "network":
+      return "monitor.categoryNetwork";
+    case "browser":
+      return "monitor.categoryBrowser";
+    case "utility":
+      return "monitor.categoryOther";
+  }
+}
+
+/**
+ * Human-readable measurement line: the concrete OS metric first, then any
+ * caveat (mixed / fallback metrics, partial attribution).
+ */
+export function describeAppMemoryMeasurement(
+  snapshot: AppMemorySnapshot | null,
+  translate: (key: string) => string
+): string {
+  const metricKind = getAppMemoryMetricKind(snapshot);
+  if (!snapshot || metricKind === null) {
+    return translate("monitor.measurementKinds.unavailable");
+  }
+  const parts = [translate(`monitor.metricKinds.${metricKind}`)];
+  if (snapshot.measurement !== "native") {
+    parts.push(translate(`monitor.measurementKinds.${snapshot.measurement}`));
+  }
+  if (snapshot.attribution === "partial") {
+    parts.push(translate("monitor.attributionPartial"));
+  }
+  return parts.join(" · ");
 }
 
 const EMPTY_STATE: AppMemorySnapshotState = {
@@ -100,7 +195,7 @@ const EMPTY_STATE: AppMemorySnapshotState = {
 let state = EMPTY_STATE;
 let activeConsumers = 0;
 let timeoutId: ReturnType<typeof setTimeout> | null = null;
-let inFlight: Promise<AppMemorySnapshotV1 | null> | null = null;
+let inFlight: Promise<AppMemorySnapshot | null> | null = null;
 const listeners = new Set<() => void>();
 
 function emit(nextState: AppMemorySnapshotState): void {
@@ -121,7 +216,7 @@ function getServerSnapshot(): AppMemorySnapshotState {
   return EMPTY_STATE;
 }
 
-export function refreshAppMemorySnapshot(): Promise<AppMemorySnapshotV1 | null> {
+export function refreshAppMemorySnapshot(): Promise<AppMemorySnapshot | null> {
   if (inFlight) return inFlight;
   if (
     typeof document !== "undefined" &&
@@ -131,7 +226,7 @@ export function refreshAppMemorySnapshot(): Promise<AppMemorySnapshotV1 | null> 
   }
 
   emit({ ...state, isLoading: true });
-  inFlight = invoke<AppMemorySnapshotV1>("get_app_memory_snapshot_v1")
+  inFlight = invoke<AppMemorySnapshot>("get_app_memory_snapshot_v1")
     .then((snapshot) => {
       emit({ snapshot, errorMessage: null, isLoading: false });
       return snapshot;

--- a/src/hooks/perf/index.ts
+++ b/src/hooks/perf/index.ts
@@ -22,16 +22,20 @@ export {
 } from "./runtimeMemoryStats";
 export { useSidebarMemoryEntry } from "./useSidebarMemoryEntry";
 export {
+  describeAppMemoryMeasurement,
   refreshAppMemorySnapshot,
+  getAppMemoryMetricKind,
+  getAppMemoryRoleLabelKey,
   getAppMemoryTotals,
   useAppMemorySnapshot,
   type AppMemoryProcess,
   type AppMemoryProcessRole,
   type AppMemorySnapshotState,
   type AppMemoryTotals,
-  type AppMemorySnapshotV1,
+  type AppMemorySnapshot,
   type AttributionStatus,
   type EffectiveMeasurement,
+  type MemoryBreakdownKind,
   type MemoryMetricKind,
   type ToolProcessCategory,
   type ToolProcessMemoryDiagnostic,

--- a/src/i18n/locales/de/settings.json
+++ b/src/i18n/locales/de/settings.json
@@ -844,6 +844,18 @@
       "rss_fallback": "RSS fallback",
       "unavailable": "Unavailable"
     },
+    "metricKinds": {
+      "physical_footprint": "phys_footprint · entspricht „Speicher“ in der Aktivitätsanzeige",
+      "private_working_set": "Privates Arbeitsset · entspricht „Arbeitsspeicher“ im Task-Manager",
+      "private_bytes": "Private Bytes (Commit)",
+      "pss": "PSS (anteilige Speichergröße)",
+      "rss_fallback": "RSS-Fallback"
+    },
+    "attributionPartial": "teilweise Zuordnung",
+    "residentPrivate": "Im RAM resident (privat)",
+    "swappedMemory": "Komprimiert / ausgelagert",
+    "peakSuffix": "Spitze {{value}}",
+    "categoryBrowser": "WebView-Browserprozess",
     "toolProcessDiagnostics": "Terminal, CLI & tool processes (RSS diagnostic)",
     "excludedFromAppMemory": "excluded from App memory",
     "noToolProcesses": "No terminal, CLI, MCP, or tool processes detected",

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -857,6 +857,18 @@
       "rss_fallback": "RSS fallback",
       "unavailable": "Unavailable"
     },
+    "metricKinds": {
+      "physical_footprint": "phys_footprint · matches Activity Monitor “Memory”",
+      "private_working_set": "Private working set · matches Task Manager “Memory”",
+      "private_bytes": "Private bytes (commit charge)",
+      "pss": "PSS (proportional set size)",
+      "rss_fallback": "RSS fallback"
+    },
+    "attributionPartial": "partial attribution",
+    "residentPrivate": "Resident in RAM (private)",
+    "swappedMemory": "Compressed / swapped",
+    "peakSuffix": "peak {{value}}",
+    "categoryBrowser": "WebView browser process",
     "toolProcessDiagnostics": "Terminal, CLI & tool processes (RSS diagnostic)",
     "excludedFromAppMemory": "excluded from App memory",
     "noToolProcesses": "No terminal, CLI, MCP, or tool processes detected",

--- a/src/i18n/locales/es/settings.json
+++ b/src/i18n/locales/es/settings.json
@@ -844,6 +844,18 @@
       "rss_fallback": "RSS fallback",
       "unavailable": "Unavailable"
     },
+    "metricKinds": {
+      "physical_footprint": "phys_footprint · coincide con «Memoria» del Monitor de Actividad",
+      "private_working_set": "Conjunto de trabajo privado · coincide con «Memoria» del Administrador de tareas",
+      "private_bytes": "Bytes privados (commit)",
+      "pss": "PSS (tamaño proporcional)",
+      "rss_fallback": "Respaldo RSS"
+    },
+    "attributionPartial": "atribución parcial",
+    "residentPrivate": "Residente en RAM (privada)",
+    "swappedMemory": "Comprimida / intercambiada",
+    "peakSuffix": "pico {{value}}",
+    "categoryBrowser": "Proceso navegador de WebView",
     "toolProcessDiagnostics": "Terminal, CLI & tool processes (RSS diagnostic)",
     "excludedFromAppMemory": "excluded from App memory",
     "noToolProcesses": "No terminal, CLI, MCP, or tool processes detected",

--- a/src/i18n/locales/fr/settings.json
+++ b/src/i18n/locales/fr/settings.json
@@ -844,6 +844,18 @@
       "rss_fallback": "RSS fallback",
       "unavailable": "Unavailable"
     },
+    "metricKinds": {
+      "physical_footprint": "phys_footprint · identique à « Mémoire » du Moniteur d'activité",
+      "private_working_set": "Plage de travail privée · identique à « Mémoire » du Gestionnaire des tâches",
+      "private_bytes": "Octets privés (commit)",
+      "pss": "PSS (taille proportionnelle)",
+      "rss_fallback": "Repli RSS"
+    },
+    "attributionPartial": "attribution partielle",
+    "residentPrivate": "Résidente en RAM (privée)",
+    "swappedMemory": "Compressée / échangée",
+    "peakSuffix": "pic {{value}}",
+    "categoryBrowser": "Processus navigateur WebView",
     "toolProcessDiagnostics": "Terminal, CLI & tool processes (RSS diagnostic)",
     "excludedFromAppMemory": "excluded from App memory",
     "noToolProcesses": "No terminal, CLI, MCP, or tool processes detected",

--- a/src/i18n/locales/ja/settings.json
+++ b/src/i18n/locales/ja/settings.json
@@ -844,6 +844,18 @@
       "rss_fallback": "RSS fallback",
       "unavailable": "Unavailable"
     },
+    "metricKinds": {
+      "physical_footprint": "phys_footprint · アクティビティモニタの「メモリ」列と一致",
+      "private_working_set": "プライベートワーキングセット · タスクマネージャーの「メモリ」列と一致",
+      "private_bytes": "プライベートバイト（コミット）",
+      "pss": "PSS（比例セットサイズ）",
+      "rss_fallback": "RSS フォールバック"
+    },
+    "attributionPartial": "一部のみ帰属",
+    "residentPrivate": "RAM 常駐（プライベート）",
+    "swappedMemory": "圧縮 / スワップ済み",
+    "peakSuffix": "ピーク {{value}}",
+    "categoryBrowser": "WebView ブラウザプロセス",
     "toolProcessDiagnostics": "Terminal, CLI & tool processes (RSS diagnostic)",
     "excludedFromAppMemory": "excluded from App memory",
     "noToolProcesses": "No terminal, CLI, MCP, or tool processes detected",

--- a/src/i18n/locales/ko/settings.json
+++ b/src/i18n/locales/ko/settings.json
@@ -844,6 +844,18 @@
       "rss_fallback": "RSS fallback",
       "unavailable": "Unavailable"
     },
+    "metricKinds": {
+      "physical_footprint": "phys_footprint · 활성 상태 보기의 “메모리” 열과 동일",
+      "private_working_set": "개인 작업 집합 · 작업 관리자의 “메모리” 열과 동일",
+      "private_bytes": "개인 바이트(커밋)",
+      "pss": "PSS(비례 집합 크기)",
+      "rss_fallback": "RSS 대체"
+    },
+    "attributionPartial": "부분 귀속",
+    "residentPrivate": "RAM 상주(개인)",
+    "swappedMemory": "압축 / 스왑됨",
+    "peakSuffix": "최대 {{value}}",
+    "categoryBrowser": "WebView 브라우저 프로세스",
     "toolProcessDiagnostics": "Terminal, CLI & tool processes (RSS diagnostic)",
     "excludedFromAppMemory": "excluded from App memory",
     "noToolProcesses": "No terminal, CLI, MCP, or tool processes detected",

--- a/src/i18n/locales/pl/settings.json
+++ b/src/i18n/locales/pl/settings.json
@@ -844,6 +844,18 @@
       "rss_fallback": "RSS fallback",
       "unavailable": "Unavailable"
     },
+    "metricKinds": {
+      "physical_footprint": "phys_footprint · zgodne z „Pamięć” w Monitorze aktywności",
+      "private_working_set": "Prywatny zestaw roboczy · zgodne z „Pamięć” w Menedżerze zadań",
+      "private_bytes": "Bajty prywatne (commit)",
+      "pss": "PSS (proporcjonalny rozmiar zestawu)",
+      "rss_fallback": "Zapasowe RSS"
+    },
+    "attributionPartial": "częściowe przypisanie",
+    "residentPrivate": "Rezydentne w RAM (prywatne)",
+    "swappedMemory": "Skompresowane / wymienione",
+    "peakSuffix": "szczyt {{value}}",
+    "categoryBrowser": "Proces przeglądarki WebView",
     "toolProcessDiagnostics": "Terminal, CLI & tool processes (RSS diagnostic)",
     "excludedFromAppMemory": "excluded from App memory",
     "noToolProcesses": "No terminal, CLI, MCP, or tool processes detected",

--- a/src/i18n/locales/pt/settings.json
+++ b/src/i18n/locales/pt/settings.json
@@ -844,6 +844,18 @@
       "rss_fallback": "RSS fallback",
       "unavailable": "Unavailable"
     },
+    "metricKinds": {
+      "physical_footprint": "phys_footprint · igual a “Memória” no Monitor de Atividade",
+      "private_working_set": "Conjunto de trabalho privado · igual a “Memória” no Gerenciador de Tarefas",
+      "private_bytes": "Bytes privados (commit)",
+      "pss": "PSS (tamanho proporcional)",
+      "rss_fallback": "Fallback RSS"
+    },
+    "attributionPartial": "atribuição parcial",
+    "residentPrivate": "Residente na RAM (privada)",
+    "swappedMemory": "Comprimida / em swap",
+    "peakSuffix": "pico {{value}}",
+    "categoryBrowser": "Processo navegador do WebView",
     "toolProcessDiagnostics": "Terminal, CLI & tool processes (RSS diagnostic)",
     "excludedFromAppMemory": "excluded from App memory",
     "noToolProcesses": "No terminal, CLI, MCP, or tool processes detected",

--- a/src/i18n/locales/ru/settings.json
+++ b/src/i18n/locales/ru/settings.json
@@ -844,6 +844,18 @@
       "rss_fallback": "RSS fallback",
       "unavailable": "Unavailable"
     },
+    "metricKinds": {
+      "physical_footprint": "phys_footprint · совпадает с «Память» в Мониторинге системы",
+      "private_working_set": "Частный рабочий набор · совпадает с «Память» в Диспетчере задач",
+      "private_bytes": "Частные байты (commit)",
+      "pss": "PSS (пропорциональный размер)",
+      "rss_fallback": "Резерв RSS"
+    },
+    "attributionPartial": "частичная атрибуция",
+    "residentPrivate": "Резидентно в ОЗУ (частная)",
+    "swappedMemory": "Сжато / выгружено",
+    "peakSuffix": "пик {{value}}",
+    "categoryBrowser": "Процесс браузера WebView",
     "toolProcessDiagnostics": "Terminal, CLI & tool processes (RSS diagnostic)",
     "excludedFromAppMemory": "excluded from App memory",
     "noToolProcesses": "No terminal, CLI, MCP, or tool processes detected",

--- a/src/i18n/locales/tr/settings.json
+++ b/src/i18n/locales/tr/settings.json
@@ -844,6 +844,18 @@
       "rss_fallback": "RSS fallback",
       "unavailable": "Unavailable"
     },
+    "metricKinds": {
+      "physical_footprint": "phys_footprint · Etkinlik Monitörü “Bellek” sütunuyla aynı",
+      "private_working_set": "Özel çalışma kümesi · Görev Yöneticisi “Bellek” sütunuyla aynı",
+      "private_bytes": "Özel bayt (commit)",
+      "pss": "PSS (orantılı küme boyutu)",
+      "rss_fallback": "RSS yedeği"
+    },
+    "attributionPartial": "kısmi atıf",
+    "residentPrivate": "RAM'de yerleşik (özel)",
+    "swappedMemory": "Sıkıştırılmış / takaslanmış",
+    "peakSuffix": "tepe {{value}}",
+    "categoryBrowser": "WebView tarayıcı işlemi",
     "toolProcessDiagnostics": "Terminal, CLI & tool processes (RSS diagnostic)",
     "excludedFromAppMemory": "excluded from App memory",
     "noToolProcesses": "No terminal, CLI, MCP, or tool processes detected",

--- a/src/i18n/locales/vi/settings.json
+++ b/src/i18n/locales/vi/settings.json
@@ -844,6 +844,18 @@
       "rss_fallback": "RSS fallback",
       "unavailable": "Unavailable"
     },
+    "metricKinds": {
+      "physical_footprint": "phys_footprint · khớp cột “Bộ nhớ” trong Activity Monitor",
+      "private_working_set": "Working set riêng · khớp cột “Bộ nhớ” trong Task Manager",
+      "private_bytes": "Private bytes (commit)",
+      "pss": "PSS (kích thước tỷ lệ)",
+      "rss_fallback": "Dự phòng RSS"
+    },
+    "attributionPartial": "quy thuộc một phần",
+    "residentPrivate": "Thường trú trong RAM (riêng)",
+    "swappedMemory": "Đã nén / hoán đổi",
+    "peakSuffix": "đỉnh {{value}}",
+    "categoryBrowser": "Tiến trình trình duyệt WebView",
     "toolProcessDiagnostics": "Terminal, CLI & tool processes (RSS diagnostic)",
     "excludedFromAppMemory": "excluded from App memory",
     "noToolProcesses": "No terminal, CLI, MCP, or tool processes detected",

--- a/src/i18n/locales/zh-Hant/settings.json
+++ b/src/i18n/locales/zh-Hant/settings.json
@@ -856,6 +856,18 @@
       "rss_fallback": "RSS 回退口徑",
       "unavailable": "暫不可用"
     },
+    "metricKinds": {
+      "physical_footprint": "phys_footprint · 與活動監視器「記憶體」欄一致",
+      "private_working_set": "專用工作集 · 與工作管理員「記憶體」欄一致",
+      "private_bytes": "Private Bytes（認可量）",
+      "pss": "PSS（按比例共享集）",
+      "rss_fallback": "RSS 回退口徑"
+    },
+    "attributionPartial": "部分歸屬",
+    "residentPrivate": "實際駐留 RAM（私有）",
+    "swappedMemory": "已壓縮 / 交換",
+    "peakSuffix": "峰值 {{value}}",
+    "categoryBrowser": "WebView 瀏覽器處理程序",
     "toolProcessDiagnostics": "終端、CLI 與工具程序（RSS 診斷）",
     "excludedFromAppMemory": "不計入應用程式記憶體",
     "noToolProcesses": "未偵測到終端、CLI、MCP 或工具程序",

--- a/src/i18n/locales/zh/settings.json
+++ b/src/i18n/locales/zh/settings.json
@@ -857,6 +857,18 @@
       "rss_fallback": "RSS 回退口径",
       "unavailable": "暂不可用"
     },
+    "metricKinds": {
+      "physical_footprint": "phys_footprint · 与活动监视器「内存」列一致",
+      "private_working_set": "专用工作集 · 与任务管理器「内存」列一致",
+      "private_bytes": "Private Bytes（提交量）",
+      "pss": "PSS（按比例共享集）",
+      "rss_fallback": "RSS 回退口径"
+    },
+    "attributionPartial": "部分归属",
+    "residentPrivate": "实际驻留 RAM（私有）",
+    "swappedMemory": "已压缩 / 交换",
+    "peakSuffix": "峰值 {{value}}",
+    "categoryBrowser": "WebView 浏览器进程",
     "toolProcessDiagnostics": "终端、CLI 与工具进程（RSS 诊断）",
     "excludedFromAppMemory": "不计入应用内存",
     "noToolProcesses": "未检测到终端、CLI、MCP 或工具进程",

--- a/src/modules/MainApp/Settings/sections/MonitorSection.tsx
+++ b/src/modules/MainApp/Settings/sections/MonitorSection.tsx
@@ -19,6 +19,8 @@ import SettingsTable, {
 } from "@src/components/SettingsTable";
 import {
   type ToolProcessMemoryDiagnostic,
+  describeAppMemoryMeasurement,
+  getAppMemoryRoleLabelKey,
   getAppMemoryTotals,
 } from "@src/hooks/perf";
 
@@ -61,6 +63,13 @@ const MonitorSection: React.FC<MonitorSectionProps> = ({
   const totalMemoryMb = appMemoryTotals.totalBytes / (1024 * 1024);
   const backendMemoryMb = appMemoryTotals.backendBytes / (1024 * 1024);
   const webviewMemoryMb = appMemoryTotals.webviewHelperBytes / (1024 * 1024);
+  const residentPrivateMb =
+    appMemoryTotals.residentPrivateBytes / (1024 * 1024);
+  const swappedMb = appMemoryTotals.swappedBytes / (1024 * 1024);
+  const measurementLabel = describeAppMemoryMeasurement(
+    appMemorySnapshot,
+    (key) => t(key)
+  );
   const toolProcessMemoryMb =
     toolProcesses.reduce((sum, process) => sum + process.rss_bytes, 0) /
     (1024 * 1024);
@@ -100,6 +109,30 @@ const MonitorSection: React.FC<MonitorSectionProps> = ({
         megabytes: webviewMemoryMb,
         totalMb: totalMemoryMb,
       },
+      ...appMemorySnapshot.processes
+        .filter((process) => process.role !== "backend")
+        .map((process) => ({
+          key: `helper-${process.process_instance_id}`,
+          label: `${t(getAppMemoryRoleLabelKey(process.role))} · PID ${process.pid}`,
+          megabytes: process.effective_memory_bytes / (1024 * 1024),
+          totalMb: totalMemoryMb,
+        })),
+      ...(appMemoryTotals.hasBreakdown
+        ? [
+            {
+              key: "residentPrivate",
+              label: t("monitor.residentPrivate"),
+              megabytes: residentPrivateMb,
+              totalMb: totalMemoryMb,
+            },
+            {
+              key: "swappedMemory",
+              label: t("monitor.swappedMemory"),
+              megabytes: swappedMb,
+              totalMb: totalMemoryMb,
+            },
+          ]
+        : []),
       {
         key: "rssMappedDiagnostic",
         label: t("monitor.rssMappedDiagnostic"),
@@ -108,7 +141,16 @@ const MonitorSection: React.FC<MonitorSectionProps> = ({
       },
     ];
     return rows;
-  }, [appMemorySnapshot, backendMemoryMb, totalMemoryMb, webviewMemoryMb, t]);
+  }, [
+    appMemorySnapshot,
+    appMemoryTotals.hasBreakdown,
+    backendMemoryMb,
+    residentPrivateMb,
+    swappedMb,
+    totalMemoryMb,
+    webviewMemoryMb,
+    t,
+  ]);
 
   const breakdownColumns = useMemo<SettingsTableColumn<BreakdownRow>[]>(
     () => [
@@ -264,11 +306,7 @@ const MonitorSection: React.FC<MonitorSectionProps> = ({
                   />
                   <div className="flex items-center justify-between gap-3 text-xs text-text-3">
                     <span>{t("monitor.measurement")}</span>
-                    <span>
-                      {t(
-                        `monitor.measurementKinds.${appMemorySnapshot?.measurement ?? "unavailable"}`
-                      )}
-                    </span>
+                    <span>{measurementLabel}</span>
                   </div>
                   {appMemoryState.errorMessage && (
                     <div className="text-danger-7 rounded-md border border-solid border-danger-3 bg-danger-1 px-3 py-2 text-xs">

--- a/src/scaffold/NavigationSidebar/connectors/SidebarRamMonitorButton/MemoryBreakdownSection.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/SidebarRamMonitorButton/MemoryBreakdownSection.tsx
@@ -22,10 +22,7 @@ export const MemoryBreakdownSection: React.FC<MemoryBreakdownSectionProps> = ({
   <>
     {rows.map((row) => {
       const isAttributionHeader = row.key === "attributionHintsGroup";
-      const isAttributionDetail =
-        !isAttributionHeader &&
-        row.key !== "backendGroup" &&
-        row.key !== "webkitGroup";
+      const isAttributionDetail = !isAttributionHeader && !row.alwaysVisible;
 
       if (isAttributionHeader) return null;
       if (isAttributionDetail && !showAttributionHints) return null;

--- a/src/scaffold/NavigationSidebar/connectors/SidebarRamMonitorButton/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/SidebarRamMonitorButton/index.tsx
@@ -8,7 +8,12 @@ import {
   DROPDOWN_PANEL,
 } from "@src/components/Dropdown/tokens";
 import { useDropdownEngine } from "@src/hooks/dropdown";
-import { formatRuntimeBytes, getAppMemoryTotals } from "@src/hooks/perf";
+import {
+  describeAppMemoryMeasurement,
+  formatRuntimeBytes,
+  getAppMemoryRoleLabelKey,
+  getAppMemoryTotals,
+} from "@src/hooks/perf";
 
 import HoverAnimatedIcon, {
   triggerIconAnimation,
@@ -47,8 +52,40 @@ export const SidebarRamMonitorPanel: React.FC<SidebarRamMonitorPanelProps> = ({
     totalBytes: totalAppMemoryBytes,
     backendBytes: backendEffectiveBytes,
     webviewHelperBytes: webviewEffectiveBytes,
+    residentPrivateBytes,
+    swappedBytes,
+    hasBreakdown,
   } = getAppMemoryTotals(appMemorySnapshot);
   const totalAppRamMb = totalAppMemoryBytes / (1024 * 1024);
+  const translateSettings = (key: string) => tSettings(key);
+  const measurementLabel = describeAppMemoryMeasurement(
+    appMemorySnapshot,
+    translateSettings
+  );
+  const withPeak = (label: string, peakBytes: number | null): string =>
+    peakBytes
+      ? `${label} · ${tSettings("monitor.peakSuffix", {
+          value: formatRuntimeBytes(peakBytes),
+        })}`
+      : label;
+  const backendProcess = appMemorySnapshot?.processes.find(
+    (process) => process.role === "backend"
+  );
+  const helperProcessRows: MemoryBreakdownRow[] = (
+    appMemorySnapshot?.processes ?? []
+  )
+    .filter((process) => process.role !== "backend")
+    .map((process) => ({
+      key: `helper-${process.process_instance_id}`,
+      label: withPeak(
+        tSettings(getAppMemoryRoleLabelKey(process.role)),
+        process.peak_effective_memory_bytes
+      ),
+      value: formatRuntimeBytes(process.effective_memory_bytes),
+      bytes: process.effective_memory_bytes,
+      indentLevel: 1,
+      alwaysVisible: true,
+    }));
   const fileCacheMb = snapshot.memoryBreakdown?.file_cache_mb ?? 0;
   const terminalPtyBufferBytes = snapshot.ptyMemory.reduce(
     (sum, ptyInfo) => sum + ptyInfo.buffer_bytes,
@@ -69,9 +106,13 @@ export const SidebarRamMonitorPanel: React.FC<SidebarRamMonitorPanelProps> = ({
   const ramBreakdownRows: MemoryBreakdownRow[] = [
     {
       key: "backendGroup",
-      label: tSettings("monitor.appBackend"),
+      label: withPeak(
+        tSettings("monitor.appBackend"),
+        backendProcess?.peak_effective_memory_bytes ?? null
+      ),
       value: formatRuntimeBytes(backendEffectiveBytes),
       bytes: backendEffectiveBytes,
+      alwaysVisible: true,
     },
     {
       key: "backendFileCache",
@@ -85,7 +126,9 @@ export const SidebarRamMonitorPanel: React.FC<SidebarRamMonitorPanelProps> = ({
       label: tSettings("monitor.appWebviewHelpers"),
       value: formatRuntimeBytes(webviewEffectiveBytes),
       bytes: webviewEffectiveBytes,
+      alwaysVisible: true,
     },
+    ...helperProcessRows,
     {
       key: "rssMappedTotal",
       label: tSettings("monitor.rssMappedDiagnostic"),
@@ -199,11 +242,23 @@ export const SidebarRamMonitorPanel: React.FC<SidebarRamMonitorPanelProps> = ({
                     : undefined
                 }
               />
+              {hasBreakdown && (
+                <>
+                  <MemoryStatRow
+                    label={tSettings("monitor.residentPrivate")}
+                    value={formatRuntimeBytes(residentPrivateBytes)}
+                    indentLevel={1}
+                  />
+                  <MemoryStatRow
+                    label={tSettings("monitor.swappedMemory")}
+                    value={formatRuntimeBytes(swappedBytes)}
+                    indentLevel={1}
+                  />
+                </>
+              )}
               <MemoryStatRow
                 label={tSettings("monitor.measurement")}
-                value={tSettings(
-                  `monitor.measurementKinds.${appMemorySnapshot?.measurement ?? "unavailable"}`
-                )}
+                value={measurementLabel}
               />
               <MemoryStatRow
                 label={tSettings("monitor.webViewDomNodes")}

--- a/src/scaffold/NavigationSidebar/connectors/SidebarRamMonitorButton/types.ts
+++ b/src/scaffold/NavigationSidebar/connectors/SidebarRamMonitorButton/types.ts
@@ -43,6 +43,8 @@ export interface MemoryBreakdownRow {
   detail?: string;
   emphasized?: boolean;
   indentLevel?: number;
+  /** Shown even when attribution hints are collapsed. */
+  alwaysVisible?: boolean;
 }
 
 export interface SidebarRamMonitorPanelProps {


### PR DESCRIPTION
## Summary

App-memory snapshot **schema v2**: the headline stays the platform task-manager metric, but every process now also reports how much of it is physically resident vs. compressed/swapped, plus its lifetime peak. The RAM panel shows the split, one row per owned WebView helper, and names the concrete OS metric instead of "native effective memory". Linux moves from RSS to PSS.

## Problem

The "应用内存 / App memory" number looked wrong on macOS. Measured on this 16 GB Mac with 8.7 GB of swap in use:

| Process    | `phys_footprint` (what we showed) | actually resident (private) | compressed / swapped |
| ---------- | --------------------------------: | --------------------------: | -------------------: |
| WebContent |                           673 MiB |                     106 MiB |              438 MiB |
| backend    |                           119 MiB |                      15 MiB |               92 MiB |

The per-process number was *correct* (it matches Activity Monitor's "Memory" column to the MiB and `launchctl print pid/` attributes exactly the right 3 helpers), but `phys_footprint` counts compressor/swap pages at uncompressed size, so under memory pressure the headline is 2–3× the RAM actually occupied and swings with *system* pressure rather than app behaviour. The panel labelled this "系统原生有效内存", which told the user nothing, and collapsed WebContent/GPU/Networking into one line. Linux summed RSS, which double-counts shared libraries across `WebKitWebProcess` instances.

## Solution

**Rust (`perf-utils/app_memory.rs`)**
- macOS: walk the process VM map with `proc_pidinfo(PROC_PIDREGIONINFO)` — an unprivileged, same-user query (no task port) that works against Apple's hardened `com.apple.WebKit.*` XPC helpers. Resident private/shared from the per-region counts; swapped from `pri_pages_swapped_out` over private/COW regions only (so the shared dyld cache doesn't inflate it, consistent with how `phys_footprint` itself ignores shared-cache pages). Bounded at 200k regions; ~2k syscalls per helper, single-digit ms. Peak from `RUSAGE_INFO_V4.ri_lifetime_max_phys_footprint`.
- Linux: `Pss` from `/proc/<pid>/smaps_rollup` as headline (`metric_kind: "pss"`, treated as native), `Private_Clean+Private_Dirty` resident, `SwapPss` swapped; inventory filtered to the current uid; WebKitGTK helpers mapped to renderer/network/GPU roles by `comm` prefix (15-byte truncation aware). RSS fallback when `smaps_rollup` is absent.
- Windows: headline unchanged (private working set); resident shared = working set − PWS, swapped = private commit − PWS; `PeakPagefileUsage` as peak on the private-bytes compatibility path. `libc` dep widened from macOS-only to `cfg(unix)`.
- Snapshot: `schema_version: 2`, new per-process `resident_private_bytes` / `resident_shared_bytes` / `swapped_bytes` / `breakdown_kind` / `peak_effective_memory_bytes`, new totals. Command name `get_app_memory_snapshot_v1` unchanged; all additions are additive.

**Frontend**
- `appMemorySnapshot.ts`: v2 types, totals gain resident/swapped/`hasBreakdown`; new `getAppMemoryMetricKind`, `getAppMemoryRoleLabelKey`, `describeAppMemoryMeasurement` (OS metric first, then mixed/partial caveats).
- Sidebar RAM panel: "实际驻留 RAM（私有）" and "已压缩 / 交换" lines under the headline; per-helper rows (WebContent / GPU / Networking) with their peaks, always visible; backend row shows its peak. `MemoryBreakdownSection` now keys visibility off an explicit `alwaysVisible` flag instead of hard-coded row keys.
- Settings → Monitor: same per-helper and split rows in the breakdown table; measurement line uses the same description.
- i18n: `monitor.metricKinds.*`, `attributionPartial`, `residentPrivate`, `swappedMemory`, `peakSuffix`, `categoryBrowser` in all 13 locales.

**Docs**: `docs/product/view-ram-native-memory-metrics-verification.md` rewritten for v2 — what the headline means per platform, the split's source per platform, and a macOS acceptance check that uses `/usr/bin/footprint --json` (ships with the base OS, no CLT) instead of `vmmap -summary`, plus a Linux check.

Architecture-audit layers walked: types/wire protocol (additive v2, snake_case, `Option` → `null`), platform parity (each `cfg` arm returns the same struct; fallback paths preserved), init/ownership (unchanged — `launchctl` attribution is correct and was kept), naming (`swapped_bytes` documented as compressor-or-swap on mac / SwapPss / commit-not-resident on win). Skipped: FSM, dead-code sweep (no state machine touched).

## Potential risks

- **Windows and Linux arms are not compiled here** (macOS host, no cross targets). The Windows change is a refactor of the existing `GetProcessMemoryInfo` calls into two helpers returning the full counters struct; the Linux arm is new but small and its parser is unit-tested on every platform. CI matrix should catch any slip.
- `ProcRegionInfo` is a hand-declared `repr(C)` of `struct proc_regioninfo` (not in the `libc` crate). Layout is stable ABI used by `vmmap`/`footprint`/`lsof`; the live test asserts the walk explains ≥ half of `phys_footprint` on the test binary, which would fail on a layout mismatch.
- `swapped_bytes` is an approximation by design (private/COW regions only) and is documented as such; the headline is untouched, so no existing number changes — rows are only added.
- Region walk adds ~2k `proc_pidinfo` syscalls per owned process every 15 s poll while the panel is open. Measured well under 10 ms per process.

## Validation / Test plan

- `cargo test -p perf_utils app_memory`: 20 tests pass (+1 opt-in live probe, `--ignored`), including a live region walk on the test process; `cargo clippy -p perf_utils --tests` clean. Full `cargo check` of the app crate passes (only the pre-existing `block` crate deprecation warning).
- Live cross-check against the running ORG2 dev app with `ORG2_MEMORY_PROBE_PID=<pid> cargo test -p perf_utils probe_live -- --ignored --nocapture` vs. `/usr/bin/footprint`: headline 673 / 675 MiB (WebContent), 119 / 119 (backend), 20 / 20 (GPU); split never exceeds the headline.
- `vitest run src/hooks/perf/appMemorySnapshot.test.ts`: 5 pass (totals, breakdown flag, metric-kind selection, measurement description, shared in-flight request).
- `tsc --noEmit` clean; eslint clean on changed files; all 13 locale JSONs re-parsed after insertion.
- Not done: visual check of the panel in a running build (worktree has no frontend dist). Reviewer: open the sidebar gauge and Settings → Monitor; expect the two new lines under App memory and three helper rows with peaks.
