### PR TITLE
perf(dev): dedupe dev chunks and gate WebKitGTK workarounds to Linux

### DIFF
--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -13,6 +13,13 @@
 # For `tauri:build:fast:parallel`, webpack also runs concurrently — that
 # adds ~1 GB, so reduce back to 6 if you see memory pressure.
 #
+# 2026-08-22: set to 4 for 16 GB machines. `tauri:dev` runs this build next
+# to the webpack dev server (5-7 GB on its own), and the build's tail is
+# serialized on the two monolithic crates (agent-core, app_lib) anyway, so
+# extra early parallelism only widens the launch-time memory spike. This
+# file overrides the `jobs = 4` in ~/.cargo/config.toml, so it has to be
+# set here. Raise it locally on a 32 GB+ machine via CARGO_BUILD_JOBS.
+#
 # `incremental = false`: Incremental compilation is intentionally OFF.
 #
 # Symptom it eliminates:
@@ -51,7 +58,7 @@
 # cargo processes running. Re-enabling here permanently will bring
 # the "dep-graph.part.bin: No such file" errors back.
 [build]
-jobs = 8
+jobs = 4
 incremental = false
 
 # ── macOS / Apple Silicon target ─────────────────────────────────────────────

--- a/src/app/root/__tests__/startupGraph.test.ts
+++ b/src/app/root/__tests__/startupGraph.test.ts
@@ -84,6 +84,11 @@ describe("startup static import graph", () => {
     // inline at the branch. `isDev ? import(/* eager */ …) : import(…)`
     // is walked on both arms and the "eager" mode wins → App inlined into
     // main.js (~4 MB of synchronous startup JS). Keep the inline form.
+    //
+    // The guard is `process.env.ORGII_DEV_EAGER_APP`, a DefinePlugin constant
+    // from webpack.config.js that is "true" only for Linux dev (WebKitGTK
+    // cannot load App as a runtime dynamic-import chunk). Production and
+    // every other dev platform fold it to "false" and keep App async.
     const source = readFileSync(path.join(SRC_ROOT, "index.tsx"), "utf8");
     // The explanatory comment above the import mentions the magic comment
     // too, so anchor on the last occurrence (the real `import()` call).
@@ -91,13 +96,21 @@ describe("startup static import graph", () => {
     expect(eagerIndex).toBeGreaterThan(-1);
     const window = source.slice(Math.max(0, eagerIndex - 400), eagerIndex);
     const conditionIndex = window.lastIndexOf(
-      'process.env.NODE_ENV === "development"'
+      'process.env.ORGII_DEV_EAGER_APP === "true"'
     );
     expect(
       conditionIndex,
-      'the eager App import must be guarded by an inline `process.env.NODE_ENV === "development"` test'
+      'the eager App import must be guarded by an inline `process.env.ORGII_DEV_EAGER_APP === "true"` test'
     ).toBeGreaterThan(-1);
     const guardTail = window.slice(conditionIndex);
     expect(guardTail).not.toMatch(/\bisDev\b/);
+
+    // The constant has to exist, otherwise `undefined === "true"` is not
+    // foldable and webpack walks both arms again.
+    const webpackConfig = readFileSync(
+      path.join(SRC_ROOT, "..", "webpack.config.js"),
+      "utf8"
+    );
+    expect(webpackConfig).toContain('"process.env.ORGII_DEV_EAGER_APP"');
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -184,23 +184,25 @@ async function initializeApp() {
     // A focus event retries synchronization after React mounts.
     log.warn("[Init] Shared auth storage unavailable:", error);
   }
-  // In dev, bundle App into main.js (webpackMode: "eager") instead of emitting
-  // it as a separate runtime chunk. App is the aggregate entry and pulls in
-  // most of the app; with eval-cheap-module-source-map that chunk balloons to
-  // ~77MB and WebKitGTK fails the dynamic import → "Initialization Failed".
-  // eager keeps the Promise-returning import() semantics (so the await below
-  // still defers App module-tree evaluation until after the runtime-identity
-  // config above has run) without emitting a loadable chunk. Production keeps
-  // the normal dynamic import so App (and every vendor only App needs) lands
-  // in async chunks instead of the entry chunk.
+  // On Linux dev (ORGII_DEV_EAGER_APP, set by webpack.config.js), bundle App
+  // into main.js (webpackMode: "eager") instead of emitting it as a separate
+  // runtime chunk. App is the aggregate entry and pulls in most of the app;
+  // as a runtime dynamic-import chunk WebKitGTK fails to load it →
+  // "Initialization Failed". eager keeps the Promise-returning import()
+  // semantics (so the await below still defers App module-tree evaluation
+  // until after the runtime-identity config above has run) without emitting
+  // a loadable chunk. Every other platform — dev and production — keeps the
+  // normal dynamic import so App (and every vendor only App needs) lands in
+  // async chunks instead of the entry chunk, and a dev edit does not
+  // re-render a 31 MB main.js.
   //
-  // The condition MUST be the inline `process.env.NODE_ENV` comparison, not
-  // the `isDev` const: webpack only constant-folds a DefinePlugin expression
-  // it can evaluate at the branch itself. With a plain identifier it walks
-  // both arms, the "eager" mode wins, and production ships App inlined into
-  // main.js (~4 MB of extra synchronous startup JS).
+  // The condition MUST be the inline `process.env.ORGII_DEV_EAGER_APP`
+  // comparison, not a const: webpack only constant-folds a DefinePlugin
+  // expression it can evaluate at the branch itself. With a plain identifier
+  // it walks both arms, the "eager" mode wins, and production ships App
+  // inlined into main.js (~4 MB of extra synchronous startup JS).
   const appModulePromise =
-    process.env.NODE_ENV === "development"
+    process.env.ORGII_DEV_EAGER_APP === "true"
       ? import(/* webpackMode: "eager" */ "@src/App")
       : import("@src/App");
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,15 @@ module.exports = (env, argv) => {
     (process.env.ORGII_RETRY_MAIN_SCRIPT_LOAD === "true" ||
       (process.env.ORGII_RETRY_MAIN_SCRIPT_LOAD !== "false" &&
         process.platform === "linux"));
+  // WebKitGTK (Linux dev) cannot load App as a runtime dynamic-import chunk
+  // (see commit 291f95be6), so Linux keeps App inlined into main.js via
+  // `webpackMode: "eager"` in src/index.tsx. Every other platform loads App
+  // as a normal async chunk so an edit does not re-render a 31 MB entry.
+  const eagerDevApp =
+    !isProduction &&
+    (process.env.ORGII_DEV_EAGER_APP === "true" ||
+      (process.env.ORGII_DEV_EAGER_APP !== "false" &&
+        process.platform === "linux"));
 
   // FAST_PROD=true: use esbuild for transpilation + minification in production.
   // Saves ~30-40s vs the SWC+Terser path. Trades some dead-code elimination
@@ -525,7 +534,28 @@ module.exports = (env, argv) => {
             runtimeChunk: "single",
           }
         : {
-            splitChunks: false,
+            // Dev still needs chunk de-duplication. With 275+ dynamic-import
+            // boundaries and no splitChunks, every shared module (CodeMirror,
+            // xterm, shiki, ...) was copied into each async chunk that used it:
+            // 9k distinct modules became 43k emitted module instances (4.8x),
+            // 305 MB JS + 258 MB maps in the dev server's memory FS, and each
+            // HMR edit to a shared module re-rendered every copy. This group
+            // hoists any module used by >= 2 chunks into a shared chunk. No
+            // name() functions / regex cache groups on purpose (cheap to run).
+            splitChunks: {
+              chunks: "async",
+              minSize: 0,
+              minChunks: 2,
+              cacheGroups: {
+                default: false,
+                defaultVendors: false,
+                shared: {
+                  minChunks: 2,
+                  reuseExistingChunk: true,
+                  priority: 10,
+                },
+              },
+            },
             runtimeChunk: false,
           }),
       moduleIds: isProduction ? "deterministic" : "named",
@@ -564,6 +594,9 @@ module.exports = (env, argv) => {
         }),
       new webpack.DefinePlugin({
         "process.env.NODE_ENV": JSON.stringify(argv.mode),
+        // Inline-compared in src/index.tsx so webpack constant-folds the
+        // `webpackMode: "eager"` App import away on platforms that don't need it.
+        "process.env.ORGII_DEV_EAGER_APP": JSON.stringify(String(eagerDevApp)),
         // Local Rust IDE-server port, baked into the bundle so a second app
         // instance (dual-instance collab testing) talks to its own backend.
         // Must match the ORGII_IDE_SERVER_PORT the Rust side is launched with.
@@ -645,15 +678,21 @@ module.exports = (env, argv) => {
       // Only show minimal info in dev mode
       preset: isProduction ? "normal" : "minimal",
     },
-    // App is bundled into main.js via `webpackMode: "eager"` in dev
-    // (see src/index.tsx) so it is not emitted as a separate runtime chunk.
-    // With eval-cheap-module-source-map, that inlines every module's source
-    // into main.js, swelling it past 80MB — too large for some WebViews to
-    // load. So dev writes source maps to separate lazily-loaded .map files
-    // (`cheap-source-map`), keeping the executable bundle small while still
-    // giving line-level debuggability. Cost vs eval mode: incremental rebuilds
-    // are marginally slower (a .map file is written each time). Light dev
-    // disables source maps entirely to reduce renderer and compiler memory.
-    devtool: useDevSourceMaps ? "cheap-source-map" : false,
+    // Linux (eagerDevApp): App is bundled into main.js via `webpackMode:
+    // "eager"` (see src/index.tsx). With eval-cheap-module-source-map that
+    // inlines every module's source into main.js, swelling it past 80MB — too
+    // large for WebKitGTK to load. So Linux dev writes source maps to separate
+    // lazily-loaded .map files (`cheap-source-map`).
+    //
+    // Everywhere else: `eval-cheap-module-source-map` — webpack's cheapest
+    // dev devtool. No separate .map assets are generated or held in the dev
+    // server's memory FS, and rebuilds only re-eval the changed modules
+    // instead of re-mapping whole chunks. Light dev disables source maps
+    // entirely to reduce renderer and compiler memory.
+    devtool: useDevSourceMaps
+      ? eagerDevApp
+        ? "cheap-source-map"
+        : "eval-cheap-module-source-map"
+      : false,
   };
 };


### PR DESCRIPTION
## Summary

`pnpm tauri:dev` was RAM-bound on the **webpack dev server**, not Rust: 10 GB footprint / 13 GB peak after a long session on a 16 GB Mac, while the `org2` debug process sat at ~125 MB. This PR fixes the dominant cause in dev bundling and trims the launch-time Rust compile spike. Three files, no runtime/product behaviour change.

## Problem

- Dev disabled `splitChunks`. With 275+ dynamic-import boundaries, every shared module (CodeMirror, xterm, shiki, …) was copied into each async chunk that used it: **9,017 modules → 43,475 emitted instances (4.82×)**, 305 MB JS + 258 MB source maps held in the dev server's memory FS. `@codemirror/view` lived in 20 chunks, `@xterm/xterm` in 15, `jszip` in 27.
- One edit to a widely shared module re-rendered ~36 chunks: in a fresh baseline, three HMR edits took webpack from 5.8 GB to **13.3 GB peak**.
- The WebKitGTK workarounds from 291f95be6 (App inlined into `main.js` via `webpackMode: "eager"`, separate `cheap-source-map` files) applied on every platform, so each edit also regenerated a 31 MB entry chunk + 25 MB map on macOS/Windows.
- `src-tauri/.cargo/config.toml` set `jobs = 8` (its own comment: "fine on 32 GB, watch on 16 GB"), overriding the `jobs = 4` in `~/.cargo/config.toml`, and ran next to the webpack spike at launch.

## Solution

- **webpack.config.js** — minimal dev `splitChunks`: one `shared` cache group (`minChunks: 2`, `reuseExistingChunk`), no name functions or regex groups. Measured duplication **4.82× → 1.02×**, emitted output **563 MB → 171 MB**, all 9,021 modules still present.
- **webpack.config.js + src/index.tsx** — new `eagerDevApp` flag (Linux only; `ORGII_DEV_EAGER_APP=true|false` override, same shape as `ORGII_RETRY_MAIN_SCRIPT_LOAD`) exposed through DefinePlugin. Linux keeps eager App + `cheap-source-map`; everything else loads App as an async chunk and uses `eval-cheap-module-source-map`. The branch in `index.tsx` stays an inline constant comparison so webpack constant-folds the dead arm (production is unchanged: still a plain dynamic import).
- **src-tauri/.cargo/config.toml** — `jobs = 8 → 4` with a note explaining the override. The build's tail is serialized on `agent-core`/`app_lib` anyway, so the extra early parallelism only widened the spike.

## Validation / Test plan

Three fresh launches on a 16 GB M-series Mac, same probe each time (3 real edits to `src/services/git/scopedResourceCache.ts`, a module previously duplicated into 36 chunks), measured with `footprint -p` (kernel phys_footprint + lifetime peak):

| | baseline (old cfg, warm) | new cfg, cold cache | new cfg, warm cache |
|---|---|---|---|
| webpack initial compile | 28 s | 32 s | **14 s** |
| webpack steady state | 5.8 GB | 3.7 GB | **3.7 GB** |
| webpack after 3 HMR edits | 8.6 GB | 3.85 GB | **3.3 GB** |
| webpack lifetime peak | **13.3 GB** | 6.5 GB | 6.5 GB (once, at startup) |
| HMR rebuild time | 9 / 6 / 5 s | 5 / 4 / 3 s | **3 / 3 / 3 s** |
| rustc fleet peak | 3.3 GB @ 7 concurrent | 3.0 GB @ ≤4 | — |
| `main.js` | 31 MB | 10 MB | 10 MB |

- [x] `node --test scripts/dev/webpack-config-light.test.cjs` — 3/3 pass
- [x] Config resolves as intended for dev(darwin) / dev(`ORGII_DEV_EAGER_APP=true`) / light dev / production (devtool, cache groups, define value checked)
- [x] `pnpm typecheck` clean; lint-staged + scoped tsc in pre-commit green
- [x] App boots in the Tauri webview under the new config, connects to the dev-server HMR socket and the IDE server; HMR updates apply
- [ ] Linux dev (`process.platform === "linux"`) should behave exactly as before — eager App + `cheap-source-map` + retrying loader; a Linux smoke run would be welcome
- [ ] Windows dev smoke run (same path as macOS now)

## Potential risks

- **Renderer memory trade-off on macOS/Windows:** `eval-cheap-module-source-map` inlines maps into the eval'd chunks; WebContent steady state rose from ~0.63 GB to ~1.0 GB in the measurements. Net total still drops (≈6.4 GB → 4.7 GB steady, far more after edits). If renderer RAM matters more, switch the non-Linux devtool back to `cheap-source-map` — with dedup in place the separate maps would be ~⅓ of their previous size.
- **Chunk loading on other WebViews:** non-Linux dev now loads App as a ~50 MB async chunk (eval + inline maps). WKWebView handles it (verified); WebView2 should too but is unverified here. Linux is explicitly excluded because WebKitGTK could not load that chunk (291f95be6).
- **Cache invalidation:** the config change invalidates the dev filesystem cache once (cold compile ~32 s), and the on-disk pack shrinks from 3.4 GB to 2.4 GB.
- **Build time on big machines:** `jobs = 4` slightly lengthens cold Rust builds on 32 GB+ machines; override with `CARGO_BUILD_JOBS=8` locally.
