### PR TITLE
perf(dev): gzip the dev webpack cache, use eval when source maps are off

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,8 +86,15 @@ module.exports = (env, argv) => {
       buildDependencies: {
         config: [__filename],
       },
-      // Don't compress - avoids sass serialization issues
-      compression: false,
+      // gzip the pack files. Uncompressed, webpack keeps the whole multi-GB
+      // pack buffer-mapped for lazy slices; gzip reads it back as a stream
+      // of small buffers that can be released as entries deserialize.
+      // Measured on a warm start of the dev server (9k modules, full source
+      // maps): kernel peak 4.7 GB -> 3.6 GB, idle 3.7 GB -> 2.4 GB, warm
+      // compile unchanged (~6 s). The old "avoids sass serialization issues"
+      // note predates sass-loader's modern API; scss caches round-trip fine.
+      // Production keeps the uncompressed pack (CI build cache unchanged).
+      compression: isProduction ? false : "gzip",
     },
     // Snapshot: use timestamps for node_modules instead of content hashing.
     // node_modules rarely change during a dev session; timestamp checks are much faster.
@@ -685,14 +692,21 @@ module.exports = (env, argv) => {
     // lazily-loaded .map files (`cheap-source-map`).
     //
     // Everywhere else: `eval-cheap-module-source-map` — webpack's cheapest
-    // dev devtool. No separate .map assets are generated or held in the dev
-    // server's memory FS, and rebuilds only re-eval the changed modules
-    // instead of re-mapping whole chunks. Light dev disables source maps
-    // entirely to reduce renderer and compiler memory.
+    // source-mapped dev devtool. No separate .map assets are generated or
+    // held in the dev server's memory FS, and rebuilds only re-eval the
+    // changed modules instead of re-mapping whole chunks.
+    //
+    // DEV_SOURCEMAPS=false (and light dev) trade original-line mapping for
+    // memory: plain `eval` keeps per-module eval (fast HMR) but emits no maps
+    // at all. Measured warm-start dev server: peak 3.6 GB -> 2.5 GB, idle
+    // 2.4 GB -> 1.7 GB, emitted JS 171 MB -> 92 MB, and the webview parses
+    // proportionally less. Linux keeps `false` there (WebKitGTK path).
     devtool: useDevSourceMaps
       ? eagerDevApp
         ? "cheap-source-map"
         : "eval-cheap-module-source-map"
-      : false,
+      : isProduction || eagerDevApp
+        ? false
+        : "eval",
   };
 };


### PR DESCRIPTION
Stacked on #868 (base branch is `perf/dev-webpack-memory`; retarget to `develop` once that merges).

## Summary

After the chunk de-duplication in #868, the webpack dev server's remaining memory peak was the **startup read of its filesystem cache**. This PR compresses the dev cache and tightens the no-source-maps mode. One file (`webpack.config.js`), dev-only; production bundling and the production cache are unchanged.

## Problem

- Uncompressed, webpack reads the whole pack (2.4 GB on disk here) into a buffer and keeps it mapped so lazily-deserialized entries can slice into it. That buffer stays resident for the life of the dev server: measured warm start peaked at **4.7 GB** and idled at **3.7 GB** for the compiler alone.
- `DEV_SOURCEMAPS=false` set `devtool: false`, which drops the per-module `eval` wrapper — larger re-renders on HMR and, as measured, *more* memory than plain `eval`.

## Solution

- `cache.compression: isProduction ? false : "gzip"` — the pack is read back as a stream of small buffers that are released as entries deserialize. The old comment ("avoids sass serialization issues") predates sass-loader's `api: "modern"`; a full cold → warm → HMR cycle with all 113 scss files round-trips cleanly.
- `DEV_SOURCEMAPS=false` / light dev → `devtool: "eval"` on non-Linux platforms. Linux (`eagerDevApp`) keeps `false` on that path, production keeps `false`.
- `cache.maxMemoryGenerations` was measured as well (1 vs default 5): no gain on top of gzip, so it is left alone.

## Validation / Test plan

Standalone dev-server harness (cold start to populate → warm start → serve every chunk → 60 s idle), kernel `phys_footprint` peak / idle:

| variant | peak | idle | emitted JS |
|---|---|---|---|
| maps, uncompressed (as #868) | 4.7 GB | 3.7 GB | 171 MB |
| maps + `maxMemoryGenerations: 1` | 4.2 GB | 3.6 GB | 171 MB |
| **maps + gzip (this PR's default)** | **3.6 GB** | **2.4 GB** | 171 MB |
| maps + gzip + maxgen 1 | 3.7 GB | 2.4 GB | 171 MB |
| `eval` + gzip (**`DEV_SOURCEMAPS=false`**) | 2.6 GB | 1.8 GB | 92 MB |
| devtool `false` + gzip (old `DEV_SOURCEMAPS=false`) | 2.9 GB | 1.9 GB | 87 MB |

Through the real `pnpm tauri:dev` (warm, same 3-edit HMR probe as #868):

| | #868 | + this PR |
|---|---|---|
| webpack warm compile | 14 s | 7.5 s |
| app launched / backend ready | 31 s / 50 s | 21 s / 37 s |
| webpack kernel peak | 6.5 GB | 3.7 GB |
| webpack steady | 3.8 GB | 2.35 GB |
| after 3 HMR edits | 3.3 GB | 2.8 GB |

- [x] `node --test scripts/dev/webpack-config-light.test.cjs` 3/3
- [x] Resolved config checked for dev darwin / darwin no-maps / linux / linux no-maps / light dev / production / production FAST_PROD (devtool + compression)
- [x] Cold (cache invalidated) → warm → HMR cycle through `tauri:dev`, app boots and HMR applies
- [ ] Linux smoke: gzip cache + unchanged `cheap-source-map` / `false` devtools

## Potential risks

- **gzip store cost on cold builds:** the first (cache-miss) store compresses the pack; cold compile measured 31–32 s both before and after, so it is within noise here, but slower disks may notice the first store.
- **`DEV_SOURCEMAPS=false` now uses `eval`:** stack traces point at transpiled module code inside `eval` instead of plain functions. This only affects the opt-in no-maps mode; the default keeps full `eval-cheap-module-source-map`.
- If anyone still hits a serialization warning from the cache (`PackFileCacheStrategy`), webpack falls back to rebuilding those entries — it degrades to a slower compile, not a broken build.
