### PR TITLE
perf(highlight): explicit Prism/hljs grammar registration, no barrels

### DIFF
--- a/src/components/MarkDown/MarkDownImpl.tsx
+++ b/src/components/MarkDown/MarkDownImpl.tsx
@@ -17,7 +17,6 @@ import { Check, Copy, SquareArrowOutUpRight } from "lucide-react";
 import React, { memo, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import ReactMarkdown, { type Components } from "react-markdown";
-import { Prism as SyntaxHighlighterPrism } from "react-syntax-highlighter";
 import remarkGfm from "remark-gfm";
 
 import { isThemeCssPathDark } from "@src/config/appearance/globalThemes";
@@ -31,6 +30,7 @@ import { useCopyCheck } from "@src/hooks/ui";
 import { themesAtom } from "@src/store";
 import { activeWorkspaceRootAtom } from "@src/store/workspace";
 import { copyText } from "@src/util/data/clipboard";
+import { PrismLight as SyntaxHighlighterPrism } from "@src/util/language/prismLight";
 import { openFileInWorkStation } from "@src/util/ui/openFileInWorkStation";
 
 import LinkHoverCard from "./LinkHoverCard";

--- a/src/engines/GitWorkflow/GitHubDiff/DiffRow.tsx
+++ b/src/engines/GitWorkflow/GitHubDiff/DiffRow.tsx
@@ -4,9 +4,10 @@
  * Row rendering components for unified and split diff views
  * Inspired by GitHub Desktop's diff rendering
  */
-import hljs from "highlight.js";
 import { ChevronDown, ChevronRight, Minus, Plus } from "lucide-react";
 import React, { useMemo } from "react";
+
+import { hljs } from "@src/util/language/hljsLight";
 
 import type { DiffRowProps, SplitDiffRowProps } from "./types";
 

--- a/src/features/CodeViewer/DiffLineComponent.tsx
+++ b/src/features/CodeViewer/DiffLineComponent.tsx
@@ -11,9 +11,9 @@ import {
   Plus,
 } from "lucide-react";
 import React from "react";
-import { Prism as PrismHighlighter } from "react-syntax-highlighter";
 
 import { codeMirrorPrismTheme } from "@src/features/CodeMirror/themes/prism";
+import { PrismLight as PrismHighlighter } from "@src/util/language/prismLight";
 
 import type { DiffLine } from "./types";
 

--- a/src/features/CodeViewer/ModernCodeViewer.tsx
+++ b/src/features/CodeViewer/ModernCodeViewer.tsx
@@ -11,12 +11,12 @@
  * - Virtualization for large files
  */
 import React, { useMemo } from "react";
-import { Prism as PrismHighlighter } from "react-syntax-highlighter";
 import { Components, Virtuoso } from "react-virtuoso";
 
 import { getLanguageFromPath } from "@src/config/languageMap";
 import { codeMirrorPrismTheme } from "@src/features/CodeMirror/themes/prism";
 import { getLanguageFromFilePath } from "@src/util/editor/extension";
+import { PrismLight as PrismHighlighter } from "@src/util/language/prismLight";
 
 import "./index.scss";
 

--- a/src/features/CodeViewer/components/SplitRow.tsx
+++ b/src/features/CodeViewer/components/SplitRow.tsx
@@ -6,9 +6,9 @@
  */
 import { Check, Minus, Plus } from "lucide-react";
 import React from "react";
-import { Prism as PrismHighlighter } from "react-syntax-highlighter";
 
 import { codeMirrorPrismTheme } from "@src/features/CodeMirror/themes/prism";
+import { PrismLight as PrismHighlighter } from "@src/util/language/prismLight";
 
 import type { AlignedLine } from "../types";
 import { CherryPickCheckbox } from "./CherryPickCheckbox";

--- a/src/features/CodeViewer/diffUtils.ts
+++ b/src/features/CodeViewer/diffUtils.ts
@@ -4,7 +4,8 @@
  * Shared utility functions for diff computation and rendering
  */
 import { invoke } from "@tauri-apps/api/core";
-import hljs from "highlight.js";
+
+import { hljs } from "@src/util/language/hljsLight";
 
 import type { DiffLine } from "./types";
 

--- a/src/features/CodeViewer/utils/syntaxHighlight.ts
+++ b/src/features/CodeViewer/utils/syntaxHighlight.ts
@@ -1,7 +1,7 @@
 /**
  * Syntax highlighting utilities with caching
  */
-import hljs from "highlight.js";
+import { hljs } from "@src/util/language/hljsLight";
 
 import { MAX_CACHE_SIZE } from "../config";
 

--- a/src/scaffold/ModalSystem/variants/ContentView/index.tsx
+++ b/src/scaffold/ModalSystem/variants/ContentView/index.tsx
@@ -2,17 +2,15 @@ import Modal from "@/src/scaffold/ModalSystem";
 import { useAtomValue } from "jotai";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import React from "react";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import {
-  a11yDark,
-  oneLight,
-} from "react-syntax-highlighter/dist/esm/styles/prism";
+import a11yDark from "react-syntax-highlighter/dist/esm/styles/prism/a11y-dark";
+import oneLight from "react-syntax-highlighter/dist/esm/styles/prism/one-light";
 
 import Breadcrumb from "@src/components/Breadcrumb";
 import Markdown from "@src/components/MarkDown";
 import { isThemeCssPathDark } from "@src/config/appearance/globalThemes";
 import { themesAtom } from "@src/store";
 import { getLanguageFromFilePath } from "@src/util/editor/extension";
+import { PrismLight as SyntaxHighlighter } from "@src/util/language/prismLight";
 
 interface ContentViewModalProps {
   visible: boolean;

--- a/src/types/ambient/hljs-subpaths.d.ts
+++ b/src/types/ambient/hljs-subpaths.d.ts
@@ -1,0 +1,9 @@
+// highlight.js ships types only for its root entry and `lib/core`; the
+// per-language subpaths (`highlight.js/lib/languages/<name>`) resolve through
+// the package `exports` map but have no declaration files.
+declare module "highlight.js/lib/languages/*" {
+  import type { LanguageFn } from "highlight.js";
+
+  const language: LanguageFn;
+  export default language;
+}

--- a/src/types/ambient/react-syntax-highlighter-subpaths.d.ts
+++ b/src/types/ambient/react-syntax-highlighter-subpaths.d.ts
@@ -1,0 +1,7 @@
+// `@types/react-syntax-highlighter` declares the deep entry points
+// (`dist/esm/prism-light`, `dist/esm/languages/prism/*`, `dist/esm/styles/prism/*`)
+// as ambient modules inside its index.d.ts. TypeScript only loads that file
+// when something imports the package root, which nothing does any more
+// (src/util/language/prismLight.ts deliberately avoids the barrel), so pull
+// the declarations in explicitly.
+/// <reference types="react-syntax-highlighter" />

--- a/src/util/language/hljsLight.ts
+++ b/src/util/language/hljsLight.ts
@@ -1,0 +1,125 @@
+/**
+ * highlight.js core with an explicit language set.
+ *
+ * `import hljs from "highlight.js"` is the "all languages" build: ~190
+ * language modules registered at import time, most of which the diff views
+ * never ask for. `highlight.js/lib/core` starts empty; the languages below
+ * cover everything `src/config/languageMap.ts` can produce that highlight.js
+ * knows. Names it does not know ("shellscript", "typescriptreact", "hcl",
+ * ...) throw inside `hljs.highlight`, exactly as they did with the full
+ * build, and every caller already catches that and falls back to escaped
+ * text — so the visible behaviour is unchanged.
+ *
+ * Aliases (`html`/`xhtml` → xml, `ts` → typescript, `sh`/`zsh` → bash,
+ * `yml` → yaml, `toml` → ini, ...) are declared by the language modules.
+ */
+import type { LanguageFn } from "highlight.js";
+import hljs from "highlight.js/lib/core";
+import bash from "highlight.js/lib/languages/bash";
+import c from "highlight.js/lib/languages/c";
+import clojure from "highlight.js/lib/languages/clojure";
+import cmake from "highlight.js/lib/languages/cmake";
+import cpp from "highlight.js/lib/languages/cpp";
+import csharp from "highlight.js/lib/languages/csharp";
+import css from "highlight.js/lib/languages/css";
+import dart from "highlight.js/lib/languages/dart";
+import diff from "highlight.js/lib/languages/diff";
+import dockerfile from "highlight.js/lib/languages/dockerfile";
+import elixir from "highlight.js/lib/languages/elixir";
+import elm from "highlight.js/lib/languages/elm";
+import erlang from "highlight.js/lib/languages/erlang";
+import go from "highlight.js/lib/languages/go";
+import graphql from "highlight.js/lib/languages/graphql";
+import haskell from "highlight.js/lib/languages/haskell";
+import ini from "highlight.js/lib/languages/ini";
+import java from "highlight.js/lib/languages/java";
+import javascript from "highlight.js/lib/languages/javascript";
+import json from "highlight.js/lib/languages/json";
+import kotlin from "highlight.js/lib/languages/kotlin";
+import less from "highlight.js/lib/languages/less";
+import lua from "highlight.js/lib/languages/lua";
+import makefile from "highlight.js/lib/languages/makefile";
+import markdown from "highlight.js/lib/languages/markdown";
+import nginx from "highlight.js/lib/languages/nginx";
+import objectivec from "highlight.js/lib/languages/objectivec";
+import ocaml from "highlight.js/lib/languages/ocaml";
+import perl from "highlight.js/lib/languages/perl";
+import php from "highlight.js/lib/languages/php";
+import plaintext from "highlight.js/lib/languages/plaintext";
+import powershell from "highlight.js/lib/languages/powershell";
+import protobuf from "highlight.js/lib/languages/protobuf";
+import python from "highlight.js/lib/languages/python";
+import r from "highlight.js/lib/languages/r";
+import ruby from "highlight.js/lib/languages/ruby";
+import rust from "highlight.js/lib/languages/rust";
+import scala from "highlight.js/lib/languages/scala";
+import shell from "highlight.js/lib/languages/shell";
+import sql from "highlight.js/lib/languages/sql";
+import swift from "highlight.js/lib/languages/swift";
+import typescript from "highlight.js/lib/languages/typescript";
+import vim from "highlight.js/lib/languages/vim";
+import xml from "highlight.js/lib/languages/xml";
+import yaml from "highlight.js/lib/languages/yaml";
+
+import scss from "highlight.js/lib/languages/scss";
+
+/** Language name → definition. Keys are highlight.js canonical names. */
+const HLJS_LANGUAGES: Record<string, LanguageFn> = {
+  bash,
+  c,
+  clojure,
+  cmake,
+  cpp,
+  csharp,
+  css,
+  dart,
+  diff,
+  dockerfile,
+  elixir,
+  elm,
+  erlang,
+  go,
+  graphql,
+  haskell,
+  ini,
+  java,
+  javascript,
+  json,
+  kotlin,
+  less,
+  lua,
+  makefile,
+  markdown,
+  nginx,
+  objectivec,
+  ocaml,
+  perl,
+  php,
+  plaintext,
+  powershell,
+  protobuf,
+  python,
+  r,
+  ruby,
+  rust,
+  scala,
+  scss,
+  shell,
+  sql,
+  swift,
+  typescript,
+  vim,
+  xml,
+  yaml,
+};
+
+for (const [name, definition] of Object.entries(HLJS_LANGUAGES)) {
+  hljs.registerLanguage(name, definition);
+}
+
+/** Registered highlight.js language names (canonical names, no aliases). */
+export const HLJS_LIGHT_LANGUAGES: readonly string[] =
+  Object.keys(HLJS_LANGUAGES);
+
+/** Drop-in replacement for the default export of "highlight.js". */
+export { hljs };

--- a/src/util/language/prismLight.ts
+++ b/src/util/language/prismLight.ts
@@ -1,0 +1,141 @@
+/**
+ * Prism highlighter (react-syntax-highlighter) with an explicit grammar set.
+ *
+ * `import { Prism } from "react-syntax-highlighter"` resolves through the
+ * package barrel, which statically imports every refractor grammar (~280
+ * modules) plus the highlight.js build and the async-loader variants. In the
+ * webpack dev graph that was ~470 modules compiled and cached on every
+ * build for grammars the app never renders.
+ *
+ * The light entry starts empty; only the grammars registered below exist.
+ * Everything the app's language mappers can produce that Prism knows
+ * (`src/config/languageMap.ts`, `src/util/editor/extension.tsx`, markdown
+ * fence info strings) is covered. An unregistered language is not an error:
+ * react-syntax-highlighter checks `listLanguages()` first and renders the
+ * code as plain text, which is also what the full build did for names it
+ * did not know (e.g. "typescriptreact").
+ *
+ * Grammar aliases (`ts`, `js`, `html`, `xml`, `sh`, `yml`, `md`, ...) are
+ * declared by the grammars themselves, so they keep working.
+ */
+import bash from "react-syntax-highlighter/dist/esm/languages/prism/bash";
+import c from "react-syntax-highlighter/dist/esm/languages/prism/c";
+import clojure from "react-syntax-highlighter/dist/esm/languages/prism/clojure";
+import cmake from "react-syntax-highlighter/dist/esm/languages/prism/cmake";
+import cpp from "react-syntax-highlighter/dist/esm/languages/prism/cpp";
+import csharp from "react-syntax-highlighter/dist/esm/languages/prism/csharp";
+import css from "react-syntax-highlighter/dist/esm/languages/prism/css";
+import dart from "react-syntax-highlighter/dist/esm/languages/prism/dart";
+import diff from "react-syntax-highlighter/dist/esm/languages/prism/diff";
+import docker from "react-syntax-highlighter/dist/esm/languages/prism/docker";
+import elixir from "react-syntax-highlighter/dist/esm/languages/prism/elixir";
+import erlang from "react-syntax-highlighter/dist/esm/languages/prism/erlang";
+import git from "react-syntax-highlighter/dist/esm/languages/prism/git";
+import go from "react-syntax-highlighter/dist/esm/languages/prism/go";
+import graphql from "react-syntax-highlighter/dist/esm/languages/prism/graphql";
+import haskell from "react-syntax-highlighter/dist/esm/languages/prism/haskell";
+import hcl from "react-syntax-highlighter/dist/esm/languages/prism/hcl";
+import ini from "react-syntax-highlighter/dist/esm/languages/prism/ini";
+import java from "react-syntax-highlighter/dist/esm/languages/prism/java";
+import javascript from "react-syntax-highlighter/dist/esm/languages/prism/javascript";
+import json from "react-syntax-highlighter/dist/esm/languages/prism/json";
+import json5 from "react-syntax-highlighter/dist/esm/languages/prism/json5";
+import jsx from "react-syntax-highlighter/dist/esm/languages/prism/jsx";
+import kotlin from "react-syntax-highlighter/dist/esm/languages/prism/kotlin";
+import less from "react-syntax-highlighter/dist/esm/languages/prism/less";
+import lua from "react-syntax-highlighter/dist/esm/languages/prism/lua";
+import makefile from "react-syntax-highlighter/dist/esm/languages/prism/makefile";
+import markdown from "react-syntax-highlighter/dist/esm/languages/prism/markdown";
+import markup from "react-syntax-highlighter/dist/esm/languages/prism/markup";
+import nginx from "react-syntax-highlighter/dist/esm/languages/prism/nginx";
+import objectivec from "react-syntax-highlighter/dist/esm/languages/prism/objectivec";
+import ocaml from "react-syntax-highlighter/dist/esm/languages/prism/ocaml";
+import perl from "react-syntax-highlighter/dist/esm/languages/prism/perl";
+import php from "react-syntax-highlighter/dist/esm/languages/prism/php";
+import powershell from "react-syntax-highlighter/dist/esm/languages/prism/powershell";
+import protobuf from "react-syntax-highlighter/dist/esm/languages/prism/protobuf";
+import python from "react-syntax-highlighter/dist/esm/languages/prism/python";
+import r from "react-syntax-highlighter/dist/esm/languages/prism/r";
+import ruby from "react-syntax-highlighter/dist/esm/languages/prism/ruby";
+import rust from "react-syntax-highlighter/dist/esm/languages/prism/rust";
+import sass from "react-syntax-highlighter/dist/esm/languages/prism/sass";
+import scala from "react-syntax-highlighter/dist/esm/languages/prism/scala";
+import shellSession from "react-syntax-highlighter/dist/esm/languages/prism/shell-session";
+import sql from "react-syntax-highlighter/dist/esm/languages/prism/sql";
+import swift from "react-syntax-highlighter/dist/esm/languages/prism/swift";
+import toml from "react-syntax-highlighter/dist/esm/languages/prism/toml";
+import tsx from "react-syntax-highlighter/dist/esm/languages/prism/tsx";
+import typescript from "react-syntax-highlighter/dist/esm/languages/prism/typescript";
+import vim from "react-syntax-highlighter/dist/esm/languages/prism/vim";
+import yaml from "react-syntax-highlighter/dist/esm/languages/prism/yaml";
+import zig from "react-syntax-highlighter/dist/esm/languages/prism/zig";
+import SyntaxHighlighter from "react-syntax-highlighter/dist/esm/prism-light";
+
+import scss from "react-syntax-highlighter/dist/esm/languages/prism/scss";
+
+/** Grammar name → refractor grammar. Keys are Prism's canonical names. */
+const PRISM_GRAMMARS = {
+  bash,
+  c,
+  clojure,
+  cmake,
+  cpp,
+  csharp,
+  css,
+  dart,
+  diff,
+  docker,
+  elixir,
+  erlang,
+  git,
+  go,
+  graphql,
+  haskell,
+  hcl,
+  ini,
+  java,
+  javascript,
+  json,
+  json5,
+  jsx,
+  kotlin,
+  less,
+  lua,
+  makefile,
+  markdown,
+  markup,
+  nginx,
+  objectivec,
+  ocaml,
+  perl,
+  php,
+  powershell,
+  protobuf,
+  python,
+  r,
+  ruby,
+  rust,
+  sass,
+  scala,
+  scss,
+  "shell-session": shellSession,
+  sql,
+  swift,
+  toml,
+  tsx,
+  typescript,
+  vim,
+  yaml,
+  zig,
+} as const;
+
+for (const [name, grammar] of Object.entries(PRISM_GRAMMARS)) {
+  SyntaxHighlighter.registerLanguage(name, grammar);
+}
+
+/** Registered Prism grammar names (canonical names only, aliases excluded). */
+export const PRISM_LIGHT_LANGUAGES: readonly string[] =
+  Object.keys(PRISM_GRAMMARS);
+
+/** Drop-in replacement for `Prism` from "react-syntax-highlighter". */
+export { SyntaxHighlighter as PrismLight };


### PR DESCRIPTION
## Summary

Third step of the dev-RAM work (#868 → #870 → this). The two syntax-highlighting libraries were imported through their "everything" entry points, so every webpack build compiled and cached ~470 grammar/loader modules the app never renders. This PR keeps the same libraries and the same rendering, but registers an explicit grammar set through the light entry points. No UI change.

## Problem

- `import { Prism } from "react-syntax-highlighter"` (5 sites) goes through the package barrel: all ~280 refractor grammars, the highlight.js-based highlighter, and the async-loader variants (which in dev also emit a lazy chunk per language).
- `import hljs from "highlight.js"` (3 sites) is the all-languages build: ~190 language modules registered at import.
- Crawling the dev graph: `refractor` 279 modules, `highlight.js` 195, plus the barrel's own modules — ~5% of the 9k-module graph, on every compile, for grammars like ABAP or Brainfuck.

## Solution

- **`src/util/language/prismLight.ts`** — `react-syntax-highlighter/dist/esm/prism-light` + 52 registered grammars covering everything `src/config/languageMap.ts`, `src/util/editor/extension.tsx` and markdown fence strings can produce that Prism knows. Aliases (`ts`, `js`, `html`, `xml`, `sh`, `yml`, `md`, …) come from the grammars themselves. Unregistered names render as plain text — react-syntax-highlighter checks `listLanguages()` first — which is exactly what the full build did for names it didn't know (e.g. `typescriptreact`).
- **`src/util/language/hljsLight.ts`** — `highlight.js/lib/core` + 46 languages. Unknown names throw inside `hljs.highlight` as before; all three callers already catch and fall back to escaped text.
- The 8 call sites switch their import; ModalSystem `ContentView` imports `a11y-dark` / `one-light` directly instead of the all-styles barrel.
- Two ambient declaration files: `highlight.js/lib/languages/*` ships no d.ts, and `@types/react-syntax-highlighter` only loads when something imports the package root (tsconfig restricts `types`), which nothing does any more.

## Validation / Test plan

- [x] Dev-server graph crawl (all 601 chunks): **9,021 → 8,702 modules**; `refractor` 279 → 55, `highlight.js` 195 → 48, barrel/async-loader modules gone; emitted dev JS 171 → 166 MB
- [x] `pnpm typecheck` clean (with the new ambient declarations)
- [x] vitest: `src/features/CodeViewer`, `src/components/MarkDown`, `src/engines/GitWorkflow/GitHubDiff`, `src/scaffold/ModalSystem`, `src/util/language` — 13 files / 99 tests pass; `startupGraph.test.ts` still forbids these packages from the boot graph and passes
- [x] HMR rebuild of the running dev app succeeds; diff views / markdown code blocks render with the same Prism theme
- [ ] Eyeball a diff in a less common registered language (e.g. Kotlin, Elixir) and one unregistered one (e.g. ABAP — expected plain text, as before)

## Potential risks

- **Exotic languages lose highlighting:** anything Prism knew but is not in the registered set (ABAP, Agda, Brainfuck, …) now renders as plain text in the Prism views. The registered set was built from the app's own language mappers; adding one is a one-line import + entry in `PRISM_GRAMMARS`.
- **Registration order:** grammars with dependencies (`tsx` → `jsx` → `javascript`, `scss` → `css`, …) register their own dependencies through refractor, so order in the map does not matter; verified by the rendered output in dev.
- Memory impact of this PR alone was not isolated (it is ~3.5% of the module graph); the measured wins are the module counts above. The big reductions are in #868 and #870.
