### PR TITLE
perf(dev): gzip the dev webpack cache, use eval when source maps are off

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -86,8 +86,15 @@ module.exports = (env, argv) => {
       buildDependencies: {
         config: [__filename],
       },
-      // Don't compress - avoids sass serialization issues
-      compression: false,
+      // gzip the pack files. Uncompressed, webpack keeps the whole multi-GB
+      // pack buffer-mapped for lazy slices; gzip reads it back as a stream
+      // of small buffers that can be released as entries deserialize.
+      // Measured on a warm start of the dev server (9k modules, full source
+      // maps): kernel peak 4.7 GB -> 3.6 GB, idle 3.7 GB -> 2.4 GB, warm
+      // compile unchanged (~6 s). The old "avoids sass serialization issues"
+      // note predates sass-loader's modern API; scss caches round-trip fine.
+      // Production keeps the uncompressed pack (CI build cache unchanged).
+      compression: isProduction ? false : "gzip",
     },
     // Snapshot: use timestamps for node_modules instead of content hashing.
     // node_modules rarely change during a dev session; timestamp checks are much faster.
@@ -685,14 +692,21 @@ module.exports = (env, argv) => {
     // lazily-loaded .map files (`cheap-source-map`).
     //
     // Everywhere else: `eval-cheap-module-source-map` — webpack's cheapest
-    // dev devtool. No separate .map assets are generated or held in the dev
-    // server's memory FS, and rebuilds only re-eval the changed modules
-    // instead of re-mapping whole chunks. Light dev disables source maps
-    // entirely to reduce renderer and compiler memory.
+    // source-mapped dev devtool. No separate .map assets are generated or
+    // held in the dev server's memory FS, and rebuilds only re-eval the
+    // changed modules instead of re-mapping whole chunks.
+    //
+    // DEV_SOURCEMAPS=false (and light dev) trade original-line mapping for
+    // memory: plain `eval` keeps per-module eval (fast HMR) but emits no maps
+    // at all. Measured warm-start dev server: peak 3.6 GB -> 2.5 GB, idle
+    // 2.4 GB -> 1.7 GB, emitted JS 171 MB -> 92 MB, and the webview parses
+    // proportionally less. Linux keeps `false` there (WebKitGTK path).
     devtool: useDevSourceMaps
       ? eagerDevApp
         ? "cheap-source-map"
         : "eval-cheap-module-source-map"
-      : false,
+      : isProduction || eagerDevApp
+        ? false
+        : "eval",
   };
 };


### PR DESCRIPTION
Re-lands #870 onto `develop`.

#870 was stacked on `perf/dev-webpack-memory` and got merged into that branch *after* #868 had already merged into `develop`, so its commit (`6d5faef91`) never reached `develop`. This PR's diff against `develop` is exactly that one `webpack.config.js` change; see #870 for the full write-up and measurements.

## Summary

- `cache.compression: isProduction ? false : "gzip"` for the dev webpack filesystem cache.
- `DEV_SOURCEMAPS=false` / light dev → `devtool: "eval"` on non-Linux (Linux and production keep `false`).

## Validation

Same as #870: standalone harness peak 4.7 → 3.6 GB / idle 3.7 → 2.4 GB; through `pnpm tauri:dev` warm start peak 6.5 → 3.7 GB, steady 3.8 → 2.35 GB, warm compile 14 → 7.5 s. Config tests pass; cold → warm → HMR cycle verified.

## Potential risks

Unchanged from #870 (first cold store compresses the pack; `DEV_SOURCEMAPS=false` stack traces point into eval'd module code).
