### PR TITLE
feat(chat): floating side-chat launcher on chat-less surfaces

### DIFF
--- a/docs/frontend-ui-audit-2026-08-21/SideChatLauncher.md
+++ b/docs/frontend-ui-audit-2026-08-21/SideChatLauncher.md
@@ -1,0 +1,26 @@
+# Floating Side Chat launcher
+
+## Scope
+
+Audited the new global floating Side Chat trigger for design-system reuse, layering, accessibility, responsive placement, surface scoping, and duplication with the existing Side Chat window.
+
+## Findings
+
+| Line                                                              | Element                             | Verdict          | Reason                                                                                                                                                                       | Suggested change                                                                                                             |
+| ----------------------------------------------------------------- | ----------------------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `src/engines/ChatPanel/SideChat/index.tsx:116`                    | Floating Side Chat trigger          | fix              | The existing global Side Chat window had menu-only entry points and no persistent in-context affordance.                                                                     | Keep the launcher visible on surfaces that carry no chat of their own.                                                       |
+| `src/engines/ChatPanel/SideChat/index.tsx:123`                    | Circular action control             | abstract         | The trigger uses the shared `Button` component and workstation icon-size token instead of defining raw button behavior or local dimensions.                                  | Continue using the shared button variants for future launcher states.                                                        |
+| `src/engines/ChatPanel/SideChat/index.tsx:131`                    | Accessible name and popup semantics | keep with reason | The icon-only control has a translated title/accessible name, native button keyboard behavior, and declares that it opens a dialog-like panel.                               | Add focus restoration only if the Side Chat window later adopts modal focus management.                                      |
+| `src/engines/ChatPanel/SideChat/index.tsx:81`                     | Bottom-right floating placement     | keep with reason | Standard spacing-scale classes place the action above the full pane host; the existing pointer-event isolation prevents the overlay from blocking the workbench.             | Revisit placement when collision-aware multi-window docking is designed.                                                     |
+| `src/engines/ChatPanel/SideChat/index.tsx:149`                    | Surface scoping of the trigger      | fix              | An always-on launcher duplicated an affordance the surface underneath already owned: the launchpad _is_ a composer, and a session tab already shows that session's composer. | Keep the gate in `sideChatLauncherVisibility.ts` so the rule stays one testable predicate rather than inline JSX conditions. |
+| `src/engines/ChatPanel/SideChat/sideChatLauncherVisibility.ts:17` | Hidden-surface list                 | keep with reason | An explicit deny-list of `start-page` and `session` means a newly added tab type shows the launcher by default — the safe direction, since a chat-less surface is the norm.  | Revisit only if a future tab type ships its own composer.                                                                    |
+| `src/engines/ChatPanel/SideChat/index.tsx:145`                    | Active-surface subscription         | abstract         | Reads the primitive-valued `activeChatPanelTabTypeAtom` rather than the whole active-tab object, so title and payload patches do not re-render the launcher.                 | Reuse this selector for any other chrome that branches on surface kind.                                                      |
+
+## Summary
+
+- Fix: 2
+- Keep with reason: 3
+- Abstract: 3
+- Remaining cross-file sweep candidates: 0
+
+The configured `frontend-ui-audit` skill file was unavailable in both the referenced user-global and workspace locations. This report follows the repository's documented audit table convention and covers the changed UI surface directly.

--- a/src/engines/ChatPanel/SideChat/SideChatLauncher.test.ts
+++ b/src/engines/ChatPanel/SideChat/SideChatLauncher.test.ts
@@ -1,0 +1,22 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { SideChatLauncher } from ".";
+
+describe("SideChatLauncher", () => {
+  it("renders an accessible floating dialog trigger", () => {
+    const markup = renderToStaticMarkup(
+      createElement(SideChatLauncher, {
+        label: "Side Chat",
+        onOpen: vi.fn(),
+      })
+    );
+
+    expect(markup).toContain('data-testid="side-chat-floating-button"');
+    expect(markup).toContain('aria-label="Side Chat"');
+    expect(markup).toContain('aria-haspopup="dialog"');
+    expect(markup).toContain("bottom-4");
+    expect(markup).toContain("right-4");
+  });
+});

--- a/src/engines/ChatPanel/SideChat/index.tsx
+++ b/src/engines/ChatPanel/SideChat/index.tsx
@@ -29,10 +29,11 @@
  *                  background launch adopts the new session in place.
  */
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import { SquareArrowOutUpRight, SquarePen } from "lucide-react";
+import { MessageCircle, SquareArrowOutUpRight, SquarePen } from "lucide-react";
 import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
+import Button from "@src/components/Button";
 import DetailPanelHeader from "@src/components/DetailPanelHeader";
 import FloatingWindow from "@src/components/FloatingWindow";
 import { SESSION_CONFIG } from "@src/config/sessionCreatorConfig";
@@ -43,7 +44,10 @@ import {
 import { ChatProvider } from "@src/contexts/workspace/ChatContext";
 import { SessionService } from "@src/engines/SessionCore/services/SessionService";
 import { createLogger } from "@src/hooks/logger";
-import { openOrFocusSessionInChatPanelTabAtom } from "@src/store/chatPanel/chatPanelTabsAtom";
+import {
+  activeChatPanelTabTypeAtom,
+  openOrFocusSessionInChatPanelTabAtom,
+} from "@src/store/chatPanel/chatPanelTabsAtom";
 import { sessionMapAtom } from "@src/store/session";
 import {
   chatTurnPaginationEnabledAtom,
@@ -52,6 +56,7 @@ import {
 } from "@src/store/ui/chatPanelAtom";
 import {
   closeSideChatAtom,
+  openSideChatAtom,
   sideChatSessionIdAtom,
   sideChatVisibleAtom,
 } from "@src/store/ui/sideChatAtom";
@@ -63,6 +68,7 @@ import { ChatSessionContext } from "../ChatSessionContext";
 import InputArea from "../InputArea";
 import type { SubmitOverrideInput } from "../hooks/useInputArea/types";
 import type { ChatPanelProps } from "../types";
+import { shouldShowSideChatLauncher } from "./sideChatLauncherVisibility";
 
 const log = createLogger("ChatPanelSideChat");
 
@@ -72,6 +78,8 @@ const log = createLogger("ChatPanelSideChat");
 // overlays (z-[60]).
 const SIDE_CHAT_OVERLAY_CLASS =
   "pointer-events-none absolute inset-0 z-[70] flex items-end justify-end p-3";
+const SIDE_CHAT_LAUNCHER_CLASS =
+  "pointer-events-none absolute bottom-4 right-4 z-[70]";
 
 // Initial fluid geometry: bottom-right corner, px-capped (kanban preview
 // pattern: fill small panes, stop growing past the cap on large ones). The
@@ -100,11 +108,48 @@ export interface ChatPanelSideChatProps {
   SessionCreatorSlot?: ChatPanelProps["sessionCreatorSlot"];
 }
 
+interface SideChatLauncherProps {
+  label: string;
+  onOpen: () => void;
+}
+
+export function SideChatLauncher({
+  label,
+  onOpen,
+}: SideChatLauncherProps): React.ReactNode {
+  return (
+    <div className={SIDE_CHAT_LAUNCHER_CLASS}>
+      <Button
+        variant="primary"
+        size="large"
+        shape="circle"
+        iconOnly
+        icon={<MessageCircle size={HEADER_ICON_SIZE.md} strokeWidth={1.9} />}
+        onClick={onOpen}
+        title={label}
+        aria-label={label}
+        aria-haspopup="dialog"
+        data-testid="side-chat-floating-button"
+        className="pointer-events-auto shadow-lg"
+      />
+    </div>
+  );
+}
+
 const ChatPanelSideChat: React.FC<ChatPanelSideChatProps> = ({
   SessionCreatorSlot,
 }) => {
+  const { t } = useTranslation("sessions");
   const visible = useAtomValue(sideChatVisibleAtom);
-  if (!visible) return null;
+  const activeTabType = useAtomValue(activeChatPanelTabTypeAtom);
+  const openSideChat = useSetAtom(openSideChatAtom);
+  const handleOpen = useCallback(() => openSideChat(null), [openSideChat]);
+  if (!visible) {
+    // Launchpad and session surfaces already own a composer — no launcher.
+    return shouldShowSideChatLauncher(activeTabType) ? (
+      <SideChatLauncher label={t("chat.sideChat.title")} onOpen={handleOpen} />
+    ) : null;
+  }
   return <SideChatWindow SessionCreatorSlot={SessionCreatorSlot} />;
 };
 

--- a/src/engines/ChatPanel/SideChat/sideChatLauncherVisibility.test.ts
+++ b/src/engines/ChatPanel/SideChat/sideChatLauncherVisibility.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChatPanelTabType } from "@src/store/chatPanel/chatPanelTabsAtom";
+
+import { shouldShowSideChatLauncher } from "./sideChatLauncherVisibility";
+
+describe("shouldShowSideChatLauncher", () => {
+  it("hides the launcher on surfaces that already own a composer", () => {
+    expect(shouldShowSideChatLauncher("start-page")).toBe(false);
+    expect(shouldShowSideChatLauncher("session")).toBe(false);
+  });
+
+  it("shows the launcher on chat-less work surfaces", () => {
+    const surfaces: ChatPanelTabType[] = [
+      "work-item",
+      "work-management",
+      "project",
+      "runtime",
+      "workspace",
+      "organization",
+      "github-issue",
+      "github-pr",
+      "explore",
+      "channel",
+      "run-group",
+      "team-inbox",
+      "terminal",
+    ];
+
+    for (const type of surfaces) {
+      expect(shouldShowSideChatLauncher(type)).toBe(true);
+    }
+  });
+
+  it("hides the launcher when no tab is active", () => {
+    expect(shouldShowSideChatLauncher(null)).toBe(false);
+    expect(shouldShowSideChatLauncher(undefined)).toBe(false);
+  });
+});

--- a/src/engines/ChatPanel/SideChat/sideChatLauncherVisibility.ts
+++ b/src/engines/ChatPanel/SideChat/sideChatLauncherVisibility.ts
@@ -1,0 +1,30 @@
+/**
+ * Which pane surfaces get the floating side-chat launcher.
+ *
+ * The launcher only earns its corner on surfaces that carry no chat of their
+ * own — work items, work management, projects, runtime, GitHub views,
+ * terminals. The launchpad already *is* a composer for starting a session,
+ * and a session tab already shows that session's transcript and composer, so
+ * a floating "chat here" button on either is pure duplication over a surface
+ * that already owns the same affordance.
+ *
+ * This gates the button only. An already-open side chat keeps floating across
+ * tab switches — it is a picture-in-picture window the user placed, not a
+ * property of the surface underneath it.
+ */
+import type { ChatPanelTabType } from "@src/store/chatPanel/chatPanelTabsAtom";
+
+const LAUNCHER_HIDDEN_TAB_TYPES: ReadonlySet<ChatPanelTabType> = new Set([
+  "start-page",
+  "session",
+]);
+
+/**
+ * `null` (no active tab) reads as hidden: the pane re-seeds a launchpad tab
+ * whenever the last one closes, so an empty pane is a launchpad in waiting.
+ */
+export function shouldShowSideChatLauncher(
+  tabType: ChatPanelTabType | null | undefined
+): boolean {
+  return tabType != null && !LAUNCHER_HIDDEN_TAB_TYPES.has(tabType);
+}

--- a/src/store/chatPanel/chatPanelTabsAtom.ts
+++ b/src/store/chatPanel/chatPanelTabsAtom.ts
@@ -85,6 +85,7 @@ export {
 } from "./chatPanelTabsModel";
 export {
   activeChatPanelTabAtom,
+  activeChatPanelTabTypeAtom,
   activeWorkManagementSectionAtom,
   chatPanelTabCountAtom,
   chatPanelTabsAtom,

--- a/src/store/chatPanel/chatPanelTabsState.ts
+++ b/src/store/chatPanel/chatPanelTabsState.ts
@@ -76,3 +76,14 @@ activeWorkManagementSectionAtom.debugLabel = "activeWorkManagementSection";
 export const chatPanelTabCountAtom = atom(
   (get) => get(chatPanelTabsAtom).tabs.length
 );
+
+/**
+ * Active tab's type only. Primitive-valued so consumers that merely branch on
+ * which kind of surface is showing (e.g. the floating side-chat launcher)
+ * re-render on a real tab switch instead of on every title or payload patch
+ * that rebuilds the tab objects.
+ */
+export const activeChatPanelTabTypeAtom = atom(
+  (get) => get(activeChatPanelTabAtom)?.type ?? null
+);
+activeChatPanelTabTypeAtom.debugLabel = "activeChatPanelTabType";


### PR DESCRIPTION
## Summary

Adds a persistent bottom-right trigger for the global side chat, scoped to pane surfaces that do not already own a composer — Work Items, Work Management, projects, runtime, GitHub views, terminals.

## Problem

The floating side chat (`f953f2404`) could only be reached from the tab-bar plus menu or a tab context menu. On a surface with no chat of its own — a Work Item, a kanban board — there was nothing to click, which is exactly where a second session is most useful.

The naive fix, a launcher that is always visible while the window is closed, has the opposite failure: on the launchpad and on a session tab it duplicates an affordance the surface underneath already provides. The launchpad *is* a composer for starting a session; a session tab already shows that session's transcript and composer. A floating "chat here" button on either is noise sitting on top of the real thing.

## Solution

- `SideChatLauncher` — a circular icon-only trigger using the shared `Button` component and the workstation icon-size token, positioned with the existing `pointer-events-none` overlay so it never blocks the workbench beneath it. It opens the existing window through `openSideChatAtom`; no parallel chat state model.
- `sideChatLauncherVisibility.ts` keeps the scoping rule as one pure, testable predicate over the active tab type rather than inline JSX conditions. It deny-lists `start-page` and `session`, so a newly added tab type shows the launcher by default — the safe direction, since a chat-less surface is the norm.
- `activeChatPanelTabTypeAtom` is a new primitive-valued selector over `activeChatPanelTabAtom`. The launcher branches only on surface *kind*, so selecting the string keeps it from re-rendering on every title or payload patch that rebuilds the tab objects.

Gating covers the button only. An already-open window keeps floating across tab switches — it is a picture-in-picture surface the user placed, not a property of the surface underneath it.

## Validation / Test plan

- [x] `pnpm typecheck` clean across the repo
- [x] ESLint clean on all changed files
- [x] `sideChatLauncherVisibility.test.ts` — hidden on `start-page` / `session`, shown across all 13 other tab types, hidden when no tab is active
- [x] `SideChatLauncher.test.ts` — accessible name, `aria-haspopup="dialog"`, stable test id, corner placement
- [x] `vitest run src/store/chatPanel/ src/engines/ChatPanel/SideChat/ src/engines/ChatPanel/ChatPanelTabBar.test.ts` — 6 files / 77 tests pass
- [x] `check:circular` reports no cycles (its non-zero exit is the two pre-existing unresolved `?raw` node_modules imports on `develop`)
- [x] `frontend-ui-audit` report at `docs/frontend-ui-audit-2026-08-21/SideChatLauncher.md` — 2 fix / 3 keep-with-reason / 3 abstract, 0 cross-file sweep candidates

## Potential risks

- **Settings-in-slot.** When the chat slot renders Settings, the active tab type is still whatever it was, so the launcher follows that tab rather than the visible Settings surface. Left as-is because the side chat is hosted over the whole pane surface by design, but it is the one case where "active tab" and "what you are looking at" diverge.
- **Terminal tabs count as chat-less** and get the launcher. Defensible — a terminal has no chat composer — but if it reads as clutter, moving `terminal` into the deny-list is a one-line change in the predicate.
- The trigger sits at `z-[70]`, the same layer as the side-chat window and above the kanban tab's own overlays. Any future full-pane overlay will need to sit above that or explicitly account for it.