### PR TITLE
feat(session-creator): add repo chrome position menu

### DIFF
--- a/docs/architecture-audit-2026-08-22/SessionCreatorRepoChromePosition.md
+++ b/docs/architecture-audit-2026-08-22/SessionCreatorRepoChromePosition.md
@@ -1,0 +1,45 @@
+# Session Creator repository chrome position architecture audit
+
+## Acceptance criteria
+
+- Users can place the repository/branch/location chrome above or below the composer.
+- Right-clicking that chrome opens the native OS Up/Down menu instead of WebKit's browser menu.
+- An explicit choice persists across app restarts and every Session Creator entry point.
+- Existing first-run behavior remains unchanged: Launchpad defaults above and standard layouts default below.
+- Top and bottom presentations mirror the same outer and composer-seam padding.
+- The native context menu is the only position control; no duplicate visible switch is rendered.
+- Compact or hidden repository chrome does not expose an inapplicable position control.
+- Bottom chrome renders outside the complete composer frame and disables the launchpad input glow to avoid flashing across the chrome seam.
+
+## Ten-layer review
+
+| Layer                      | Verdict        | Evidence                                                                                                                                                                                                                                         |
+| -------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1. Compilation             | pass           | Full `tsc --noEmit`, focused ESLint, and the focused eight-test Vitest suite pass.                                                                                                                                                               |
+| 2. Dead code / duplication | pass           | The native context menu is the single position control; the coordinator resolves its persisted preference and the view uses that value for row order, glow behavior, and presentation classes. No parallel preference or layout state was added. |
+| 3. Naming                  | pass           | `CreatorRepoChromePosition`, `repoChromePosition`, and `RepoChromeRow` consistently refer only to the repository/branch/location strip.                                                                                                          |
+| 4. Semantic overloading    | pass           | The persisted value models spatial position (`top`/`bottom`) only; it does not encode layout kind, visibility, or dropdown direction.                                                                                                            |
+| 5. Default branches        | pass           | The unset preference is represented explicitly as `null`; Launchpad and standard fallbacks are selected explicitly. Malformed stored values normalize to `null` instead of silently becoming one position.                                       |
+| 6. Cross-domain leakage    | pass           | The session store owns the global preference; the Session Creator coordinator owns layout fallback; the presentational view owns DOM ordering and classes. No backend or unrelated Workstation concept is imported.                              |
+| 7. New-developer clarity   | pass           | The atom documents why `null` exists, the layout helper names the above-composer and breathing decisions, and the two native-menu options are localized as Up and Down.                                                                          |
+| 8. Wire protocol           | not applicable | The preference is local UI storage only; no Tauri, HTTP, database, or serialized external payload changes.                                                                                                                                       |
+| 9. Init parity             | pass           | Launchpad, standard, compact, and hidden-repository variants all enter through `SessionCreatorChatPanelContent` and read the same persisted atom. The entry-point matrix below records the intentional presentation differences.                 |
+| 10. Resolver symmetry      | not applicable | No multi-field resolver or fallback chain was introduced; one preference resolves against one layout-specific fallback.                                                                                                                          |
+
+## Entry-point matrix
+
+| Entry point                 | Unset preference        | Explicit preference        | Native menu |
+| --------------------------- | ----------------------- | -------------------------- | ----------- |
+| Launchpad repository chrome | Above composer          | Honored                    | Available   |
+| Standard repository chrome  | Below composer          | Honored                    | Available   |
+| Compact embedded chrome     | Existing compact header | Not applied while embedded | Unavailable |
+| Hidden repository chrome    | Not rendered            | Not applied while hidden   | Unavailable |
+
+## Term table
+
+| Term                | Meaning                                                                                        | Owner                       |
+| ------------------- | ---------------------------------------------------------------------------------------------- | --------------------------- |
+| repository chrome   | Repository, branch, and running-location control strip around the Session Creator composer     | Session Creator view        |
+| position preference | Persisted explicit `top` or `bottom`; `null` means no choice has been made                     | Session store atom          |
+| layout fallback     | Existing first-run position selected from Launchpad versus standard layout                     | Session Creator coordinator |
+| native context menu | Tauri OS menu that suppresses the WebView browser menu and writes the same position preference | Repository chrome row       |

--- a/docs/frontend-ui-audit-2026-08-22/SessionCreatorRepoChromePosition.md
+++ b/docs/frontend-ui-audit-2026-08-22/SessionCreatorRepoChromePosition.md
@@ -1,0 +1,15 @@
+# Session Creator repository chrome position UI audit
+
+The documented `frontend-ui-audit` skill was unavailable at both the global and workspace paths. This manual fallback applies the repository's required design-system, spacing, localization, and accessibility checks to the changed UI.
+
+| Line / file                       | Element                            | Verdict          | Reason                                                                                                                                                            | Suggested change |
+| --------------------------------- | ---------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `RepoChromeRow.tsx`               | Secondary-click native menu        | keep with reason | Uses the shared Tauri native-menu lifecycle, prevents the WebView's Back/Reload/Inspect menu, and marks the current Up/Down choice with the native checked state. | None.            |
+| `SessionCreatorChatPanelView.tsx` | Stable composer/chrome slots       | keep with reason | Keeps the composer in a stable render slot while moving only the chrome; bottom chrome is outside the complete composer frame, preventing input remount flashes.  | None.            |
+| `repoChromeLayout.ts`             | Position-aware padding and glow    | keep with reason | Both sides mirror `1.5` outer / `2.5` seam padding, while the launchpad glow is intentionally limited to top chrome so it cannot paint across the bottom seam.    | None.            |
+| `index.scss`                      | Top and bottom composer attachment | keep with reason | The established negative seam overlap, corner radii, and z-order remain unchanged; the flashing fix does not alter the existing visual layering.                  | None.            |
+| `locales/*/sessions.json`         | Native-menu choices                | keep with reason | All supported locales define the two native-menu choices; no locale relies on raw English UI copy.                                                                | None.            |
+
+Verdict totals: **0 fix**, **5 keep with reason**, **0 abstract**.
+
+No multi-file sweep candidate was found: this is the only independently movable repository chrome in Session Creator, while Workstation panel position controls represent a different surface and axis.

--- a/src/features/SessionCreator/components/__tests__/TEST_CASES.md
+++ b/src/features/SessionCreator/components/__tests__/TEST_CASES.md
@@ -9,6 +9,17 @@
 | W3  | Choose New Worktree from the running-location picker | WorktreeSourceModal opens and the PR / issue / branch / name creation flow remains available                                                   |
 | W4  | Select a different Workspace                         | Pending new-worktree source state clears and running location returns to `local`; no path or source from the previous repository leaks forward |
 
+## Repository chrome position
+
+| #   | Steps                                                       | Expected Result                                                                                                                                    |
+| --- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| C1  | Right-click the repository chrome and choose **Up**         | Repository, branch, and running-location controls render above the composer with the established top corners and mirrored seam/outer padding       |
+| C2  | Right-click the repository chrome and choose **Down**       | The same controls render outside and below the complete composer, with matching bottom corners, the same total padding, and no input glow flashing |
+| C3  | Choose a position, close ORGII, then reopen Session Creator | The selected position is restored from `orgii:sessionCreator:repoChromePosition`                                                                   |
+| C4  | Open a layout with no saved position                        | Launchpad keeps its existing Up default; standard Session Creator keeps its existing Down default                                                  |
+| C5  | Open a compact/hidden repository-info Session Creator       | No position control appears because there is no independently movable repository chrome                                                            |
+| C6  | Right-click the repository/branch/location chrome           | WebKit's Back/Reload/Inspect menu is suppressed; a native OS menu opens with checked Up and Down actions, and choosing either persists the change  |
+
 Covers the worktree-source picker (`WorktreeSourceModal.tsx`) and the
 launch-payload wiring that turns the picked source into backend worktree
 fields (`getWorktreeFields` in `useSessionLaunch/launchPayload.ts`).

--- a/src/features/SessionCreator/variants/ChatPanel/RepoChromeRow.test.ts
+++ b/src/features/SessionCreator/variants/ChatPanel/RepoChromeRow.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { type ComponentProps, act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { popupNativeMenu } from "@src/util/platform/tauri/nativeMenuPopup";
+
+import RepoChromeRow from "./RepoChromeRow";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => (key.endsWith(".up") ? "Up" : "Down"),
+  }),
+}));
+
+vi.mock("@src/util/platform/tauri/nativeMenuPopup", () => ({
+  popupNativeMenu: vi.fn().mockResolvedValue({ status: "closed" }),
+}));
+
+const mockedPopupNativeMenu = vi.mocked(popupNativeMenu);
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+describe("RepoChromeRow", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mockedPopupNativeMenu.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  it("replaces the WebView menu with native checked Up/Down actions", async () => {
+    const onPositionChange = vi.fn();
+    act(() => {
+      root.render(
+        createElement(
+          RepoChromeRow,
+          {
+            position: "top",
+            onPositionChange,
+          } as unknown as ComponentProps<typeof RepoChromeRow>,
+          createElement("span", null, "repository chrome")
+        )
+      );
+    });
+
+    const row = container.querySelector<HTMLElement>(
+      '[data-testid="session-creator-repo-chrome"]'
+    );
+    expect(row).not.toBeNull();
+
+    const event = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+    });
+    act(() => row?.dispatchEvent(event));
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(mockedPopupNativeMenu).toHaveBeenCalledOnce();
+    const popupOptions = mockedPopupNativeMenu.mock.calls[0]?.[0];
+    expect(popupOptions?.source).toBe("session-creator-repo-chrome");
+
+    const items = await popupOptions?.buildItems();
+    const upItem = items?.[0] as
+      | { checked?: boolean; action?: () => void }
+      | undefined;
+    const downItem = items?.[1] as
+      | { checked?: boolean; action?: () => void }
+      | undefined;
+    expect(upItem?.checked).toBe(true);
+    expect(downItem?.checked).toBe(false);
+
+    act(() => downItem?.action?.());
+    expect(onPositionChange).toHaveBeenCalledWith("bottom");
+  });
+});

--- a/src/features/SessionCreator/variants/ChatPanel/RepoChromeRow.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/RepoChromeRow.tsx
@@ -1,0 +1,68 @@
+import React, { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+
+import { createLogger } from "@src/hooks/logger";
+import type { CreatorRepoChromePosition } from "@src/store/session";
+import {
+  type NativeMenuItemOptions,
+  popupNativeMenu,
+} from "@src/util/platform/tauri/nativeMenuPopup";
+
+import { REPO_CHROME_POSITION_CLASS } from "./repoChromeLayout";
+
+const log = createLogger("RepoChromeRow");
+
+export interface RepoChromeRowProps {
+  children: React.ReactNode;
+  position: CreatorRepoChromePosition;
+  onPositionChange: (position: CreatorRepoChromePosition) => void;
+}
+
+/** Repository controls row with a native Up/Down secondary-click menu. */
+export const RepoChromeRow: React.FC<RepoChromeRowProps> = ({
+  children,
+  position,
+  onPositionChange,
+}) => {
+  const { t } = useTranslation("sessions");
+  const handleContextMenu = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      void popupNativeMenu({
+        source: "session-creator-repo-chrome",
+        buildItems: () => {
+          const items: NativeMenuItemOptions[] = [
+            {
+              text: t("creator.repoChromePosition.up"),
+              checked: position === "top",
+              action: () => onPositionChange("top"),
+            },
+            {
+              text: t("creator.repoChromePosition.down"),
+              checked: position === "bottom",
+              action: () => onPositionChange("bottom"),
+            },
+          ];
+          return items;
+        },
+      }).catch((error) => {
+        log.error("Failed to show repository chrome context menu:", error);
+      });
+    },
+    [onPositionChange, position, t]
+  );
+
+  return (
+    <div
+      className={`session-creator-chat-panel-fullscreen-repo-row px-1 ${REPO_CHROME_POSITION_CLASS[position]}`}
+      data-testid="session-creator-repo-chrome"
+      onContextMenu={handleContextMenu}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default RepoChromeRow;

--- a/src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx
@@ -31,12 +31,15 @@ import {
 } from "@src/scaffold/GlobalSpotlight/palettes/DispatchCategoryPalette";
 import { DispatchCategoryDropdown } from "@src/scaffold/GlobalSpotlight/palettes/DispatchCategoryPalette/DispatchCategoryDropdown";
 import { PresenceMenuButton } from "@src/scaffold/NavigationSidebar/blocks/SidebarBottomBar";
+import type { CreatorRepoChromePosition } from "@src/store/session";
 
 import { EditorArea, SessionInfoLine } from "../../components";
+import RepoChromeRow from "./RepoChromeRow";
 import ScreenPickerModal from "./ScreenPickerModal";
 import SessionCreatorAgentHero from "./SessionCreatorAgentHero";
 import SessionCreatorOrgMembersPanel from "./SessionCreatorOrgMembersPanel";
 import WorkItemAttachmentControl from "./WorkItemAttachmentControl";
+import { isRepoChromeAboveComposer } from "./repoChromeLayout";
 import type { SessionCreatorAgentHeroContent } from "./resolveSessionCreatorAgentHero";
 import type { SessionCreatorChatPanelHeaderLayout } from "./types";
 
@@ -105,12 +108,14 @@ interface SessionCreatorChatPanelViewProps {
   onCreateWorkItem?: () => void;
   onFileUpload: React.ChangeEventHandler<HTMLInputElement>;
   onLaunch: () => void;
+  onRepoChromePositionChange: (position: CreatorRepoChromePosition) => void;
   onShareScreen: () => Promise<unknown>;
   onToggleOrgMembers: () => void;
   orgMembersPanelProps?: React.ComponentProps<
     typeof SessionCreatorOrgMembersPanel
   >;
   pinnedActionsContent?: React.ReactNode;
+  repoChromePosition: CreatorRepoChromePosition;
   categoryPickerProps: CategoryPickerProps;
   screenPickerProps?: React.ComponentProps<typeof ScreenPickerModal>;
   sessionInfoProps: React.ComponentProps<typeof SessionInfoLine>;
@@ -157,10 +162,12 @@ const SessionCreatorChatPanelView: React.FC<
   onCreateWorkItem,
   onFileUpload,
   onLaunch,
+  onRepoChromePositionChange,
   onShareScreen,
   onToggleOrgMembers,
   orgMembersPanelProps,
   pinnedActionsContent,
+  repoChromePosition,
   categoryPickerProps,
   screenPickerProps,
   sessionInfoProps,
@@ -185,16 +192,14 @@ const SessionCreatorChatPanelView: React.FC<
       </div>
     </div>
   );
+  const repoChromeAboveComposer = isRepoChromeAboveComposer(repoChromePosition);
   const repoPillsRow = !hideRepoLine && headerLayout !== "compact" && (
-    <div
-      className={`session-creator-chat-panel-fullscreen-repo-row px-1 ${
-        isLaunchpadLayout
-          ? "session-creator-chat-panel-fullscreen-repo-row-above pb-2.5 pt-1.5"
-          : "pb-2 pt-3"
-      }`}
+    <RepoChromeRow
+      position={repoChromePosition}
+      onPositionChange={onRepoChromePositionChange}
     >
       {repoPills}
-    </div>
+    </RepoChromeRow>
   );
   const compactHeader = headerLayout === "compact" && (
     <div className="session-creator-chat-panel-compact-header flex w-full items-center justify-between gap-2 bg-bg-2 px-1 pb-2 pt-1">
@@ -232,8 +237,11 @@ const SessionCreatorChatPanelView: React.FC<
   );
   const [isLaunchpadWorkItemPickerOpen, setIsLaunchpadWorkItemPickerOpen] =
     useState(false);
+  const showWorkItemAttachmentControl =
+    !hideWorkItemAttachmentControl &&
+    (!isLaunchpadLayout || Boolean(multiRunnerContent));
   const hasSetupControlsAfterCliSwitch =
-    (!hideWorkItemAttachmentControl && !isLaunchpadLayout) ||
+    showWorkItemAttachmentControl ||
     Boolean(orgMembersPanelProps) ||
     Boolean(pinnedActionsContent);
   const sessionSetupActions = !hideSessionSetupControls ? (
@@ -253,18 +261,17 @@ const SessionCreatorChatPanelView: React.FC<
             {cliLaunchModeSwitch && hasSetupControlsAfterCliSwitch && (
               <div aria-hidden className="mx-1 h-4 w-px shrink-0 bg-border-2" />
             )}
-            {!hideWorkItemAttachmentControl &&
-              (!isLaunchpadLayout || Boolean(multiRunnerContent)) && (
-                <WorkItemAttachmentControl
-                  composerInputRef={composerInputRef}
-                  currentWorkItemContext={workItemContext}
-                  onCreateWorkItem={onCreateWorkItem}
-                  onWorkItemContextChange={onAttachedWorkItemContextChange}
-                  repoId={sessionInfoProps.repoId}
-                  repoPath={sessionInfoProps.repoPath}
-                  mode="add"
-                />
-              )}
+            {showWorkItemAttachmentControl && (
+              <WorkItemAttachmentControl
+                composerInputRef={composerInputRef}
+                currentWorkItemContext={workItemContext}
+                onCreateWorkItem={onCreateWorkItem}
+                onWorkItemContextChange={onAttachedWorkItemContextChange}
+                repoId={sessionInfoProps.repoId}
+                repoPath={sessionInfoProps.repoPath}
+                mode="add"
+              />
+            )}
             {orgMembersPanelProps && (
               <Button
                 variant="secondary"
@@ -436,7 +443,8 @@ const SessionCreatorChatPanelView: React.FC<
   const composerDockClassName = isLaunchpadLayout
     ? "mt-auto flex w-full shrink-0 flex-col gap-3"
     : "contents";
-  const composerFrameClassName = `session-creator-chat-panel-fullscreen-composer mx-auto w-full ${DETAIL_PANEL_TOKENS.contentMaxWidth} ${
+  const composerGroupClassName = `session-creator-chat-panel-fullscreen-composer-group mx-auto w-full ${DETAIL_PANEL_TOKENS.contentMaxWidth}`;
+  const composerFrameClassName = `session-creator-chat-panel-fullscreen-composer w-full ${
     headerLayout === "compact"
       ? "session-creator-chat-panel-fullscreen-composer-compact"
       : ""
@@ -515,12 +523,22 @@ const SessionCreatorChatPanelView: React.FC<
                 {cliVersionWarning}
               </>
             )}
-            <div className={composerFrameClassName}>
-              {compactHeader}
-              {isCliTuiMode && tuiComposerHeader}
-              {isLaunchpadLayout && repoPillsRow}
-              {composerBody}
-              {!isLaunchpadLayout && repoPillsRow}
+            <div className={composerGroupClassName}>
+              <div className={composerFrameClassName}>
+                {compactHeader}
+                {isCliTuiMode && tuiComposerHeader}
+                {/* Keep this slot mounted so moving only the chrome cannot
+                    shift or remount the composer input below it. */}
+                <div className="contents">
+                  {repoChromeAboveComposer && repoPillsRow}
+                </div>
+                {composerBody}
+              </div>
+              {/* The bottom slot sits outside the complete composer frame;
+                  its existing overlap, radii, and z-order stay in CSS. */}
+              <div className="contents">
+                {!repoChromeAboveComposer && repoPillsRow}
+              </div>
             </div>
           </div>
 

--- a/src/features/SessionCreator/variants/ChatPanel/index.scss
+++ b/src/features/SessionCreator/variants/ChatPanel/index.scss
@@ -193,8 +193,6 @@
   .session-creator-chat-panel-fullscreen-repo-row {
     position: relative;
     z-index: 1;
-    margin-top: -6px;
-    border-radius: 0 0 12px 12px;
     background: var(--color-chat-container);
     box-shadow: none;
   }
@@ -203,5 +201,10 @@
     margin-top: 0;
     margin-bottom: -6px;
     border-radius: 12px 12px 0 0;
+  }
+
+  .session-creator-chat-panel-fullscreen-repo-row-below {
+    margin-top: -6px;
+    border-radius: 0 0 12px 12px;
   }
 }

--- a/src/features/SessionCreator/variants/ChatPanel/index.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/index.tsx
@@ -1,4 +1,4 @@
-import { useAtomValue, useSetAtom, useStore } from "jotai";
+import { useAtom, useAtomValue, useSetAtom, useStore } from "jotai";
 import React, {
   useCallback,
   useEffect,
@@ -29,8 +29,10 @@ import {
   agentIconIdAtom,
   agentNameAtom,
   cliAgentTypeAtom,
+  creatorRepoChromePositionAtom,
   dispatchCategoryAtom,
   normalizeAgentOnlySessionCreatorState,
+  resolveCreatorRepoChromePosition,
   selectedAgentDefinitionIdAtom,
   selectedAgentOrgIdAtom,
   sessionCreatorStateAtom,
@@ -51,6 +53,7 @@ import ChatPanelHumanSessionHeader from "./ChatPanelHumanSessionHeader";
 import SessionCreatorChatPanelView from "./SessionCreatorChatPanelView";
 import { deriveChatPanelLaunchContext } from "./deriveLaunchContext";
 import "./index.scss";
+import { shouldUseCreatorComposerBreathing } from "./repoChromeLayout";
 import type { SessionCreatorChatPanelSingleProps } from "./types";
 import { useChatPanelAgentPresentation } from "./useChatPanelAgentPresentation";
 import { useChatPanelBranchSync } from "./useChatPanelBranchSync";
@@ -101,6 +104,12 @@ const SessionCreatorChatPanelContent: React.FC<
   const { t } = useTranslation("sessions");
   const browserAddToConversationNav = useBrowserAddToConversationAction();
   const { orgs } = useAgentOrgs();
+  const [repoChromePositionPreference, setRepoChromePositionPreference] =
+    useAtom(creatorRepoChromePositionAtom);
+  const repoChromePosition = resolveCreatorRepoChromePosition(
+    repoChromePositionPreference,
+    layout === "launchpad" ? "top" : "bottom"
+  );
 
   // Read atoms needed before useSessionCreator so we can pass derived values in.
   const dispatchCategory = useAtomValue(dispatchCategoryAtom);
@@ -534,7 +543,13 @@ const SessionCreatorChatPanelContent: React.FC<
         requestModelOpen: isHumanMode ? false : requestModelOpen,
         onModelOpenHandled: () => setRequestModelOpen(false),
         shellClassName: `session-creator-chat-panel-fullscreen-input-shell ${
-          layout === "launchpad" ? "composer-breathing" : ""
+          shouldUseCreatorComposerBreathing(
+            layout === "launchpad",
+            repoChromePosition,
+            !hideRepoLine && headerLayout !== "compact"
+          )
+            ? "composer-breathing"
+            : ""
         }`.trim(),
         initialContent: initialRestoreText || initialContent || undefined,
         autoFocus: !isHumanMode,
@@ -576,9 +591,11 @@ const SessionCreatorChatPanelContent: React.FC<
       onCreateWorkItem={onCreateWorkItem}
       onFileUpload={handleFileUpload}
       onLaunch={handleComposerLaunch}
+      onRepoChromePositionChange={setRepoChromePositionPreference}
       onShareScreen={() => handleShareScreenClick().catch(log.error)}
       onToggleOrgMembers={handleToggleOrgMembers}
       pinnedActionsContent={isHumanMode ? undefined : pinnedActionsContent}
+      repoChromePosition={repoChromePosition}
       orgMembersPanelProps={
         selectedOrg
           ? {

--- a/src/features/SessionCreator/variants/ChatPanel/repoChromeLayout.test.ts
+++ b/src/features/SessionCreator/variants/ChatPanel/repoChromeLayout.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  REPO_CHROME_POSITION_CLASS,
+  isRepoChromeAboveComposer,
+  shouldUseCreatorComposerBreathing,
+} from "./repoChromeLayout";
+
+describe("Session Creator repository chrome layout", () => {
+  it("places the chrome on the selected side of the composer", () => {
+    expect(isRepoChromeAboveComposer("top")).toBe(true);
+    expect(isRepoChromeAboveComposer("bottom")).toBe(false);
+  });
+
+  it("mirrors the same outer and seam padding in both positions", () => {
+    expect(REPO_CHROME_POSITION_CLASS.top).toContain("pt-1.5");
+    expect(REPO_CHROME_POSITION_CLASS.top).toContain("pb-2.5");
+    expect(REPO_CHROME_POSITION_CLASS.bottom).toContain("pt-2.5");
+    expect(REPO_CHROME_POSITION_CLASS.bottom).toContain("pb-1.5");
+  });
+
+  it("keeps the launchpad glow away from chrome placed below the composer", () => {
+    expect(shouldUseCreatorComposerBreathing(true, "top", true)).toBe(true);
+    expect(shouldUseCreatorComposerBreathing(true, "bottom", true)).toBe(false);
+    expect(shouldUseCreatorComposerBreathing(false, "top", true)).toBe(false);
+    expect(shouldUseCreatorComposerBreathing(true, "bottom", false)).toBe(true);
+  });
+});

--- a/src/features/SessionCreator/variants/ChatPanel/repoChromeLayout.ts
+++ b/src/features/SessionCreator/variants/ChatPanel/repoChromeLayout.ts
@@ -1,0 +1,23 @@
+import type { CreatorRepoChromePosition } from "@src/store/session";
+
+export const REPO_CHROME_POSITION_CLASS: Record<
+  CreatorRepoChromePosition,
+  string
+> = {
+  top: "session-creator-chat-panel-fullscreen-repo-row-above pb-2.5 pt-1.5",
+  bottom: "session-creator-chat-panel-fullscreen-repo-row-below pb-1.5 pt-2.5",
+};
+
+export function isRepoChromeAboveComposer(
+  position: CreatorRepoChromePosition
+): boolean {
+  return position === "top";
+}
+
+export function shouldUseCreatorComposerBreathing(
+  isLaunchpadLayout: boolean,
+  position: CreatorRepoChromePosition,
+  hasMovableRepoChrome: boolean
+): boolean {
+  return isLaunchpadLayout && (!hasMovableRepoChrome || position === "top");
+}

--- a/src/i18n/locales/de/sessions.json
+++ b/src/i18n/locales/de/sessions.json
@@ -2087,6 +2087,10 @@
     "immutableInSession": "Schlüsselquelle, Agent-Typ und Preisstufe sind beim Sitzungsstart festgelegt. Starten Sie eine neue Sitzung, um sie zu ändern."
   },
   "creator": {
+    "repoChromePosition": {
+      "up": "Oben",
+      "down": "Unten"
+    },
     "createTarget": {
       "agentSession": "Agent-Sitzung",
       "manageAgents": "Agents / Skills verwalten",

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -2167,6 +2167,10 @@
     "appliesNextTurn": "Account switched. The current reply still runs on the previous account; the new account takes effect from the next turn."
   },
   "creator": {
+    "repoChromePosition": {
+      "up": "Up",
+      "down": "Down"
+    },
     "createTarget": {
       "agentSession": "Agent session",
       "manageAgents": "Manage agents / skills",

--- a/src/i18n/locales/es/sessions.json
+++ b/src/i18n/locales/es/sessions.json
@@ -2089,6 +2089,10 @@
     "immutableInSession": "La fuente de clave, el tipo de Agent y el nivel de precio se fijan al iniciar la sesión. Inicia una nueva sesión para cambiarlos."
   },
   "creator": {
+    "repoChromePosition": {
+      "up": "Arriba",
+      "down": "Abajo"
+    },
     "createTarget": {
       "agentSession": "Sesión de Agent",
       "manageAgents": "Gestionar Agents / Skills",

--- a/src/i18n/locales/fr/sessions.json
+++ b/src/i18n/locales/fr/sessions.json
@@ -2089,6 +2089,10 @@
     "immutableInSession": "La source de clé, le type d'Agent et le palier tarifaire sont fixés au démarrage de la session. Démarrez une nouvelle session pour les modifier."
   },
   "creator": {
+    "repoChromePosition": {
+      "up": "Haut",
+      "down": "Bas"
+    },
     "createTarget": {
       "agentSession": "Session Agent",
       "manageAgents": "Gérer les Agents / Skills",

--- a/src/i18n/locales/ja/sessions.json
+++ b/src/i18n/locales/ja/sessions.json
@@ -2088,6 +2088,10 @@
     "immutableInSession": "キーソース、Agent タイプ、料金ティアはセッション開始時に固定されます。変更するには新しいセッションを開始してください。"
   },
   "creator": {
+    "repoChromePosition": {
+      "up": "上",
+      "down": "下"
+    },
     "createTarget": {
       "agentSession": "Agent セッション",
       "manageAgents": "Agents / Skills を管理",

--- a/src/i18n/locales/ko/sessions.json
+++ b/src/i18n/locales/ko/sessions.json
@@ -2088,6 +2088,10 @@
     "immutableInSession": "키 소스, Agent 유형 및 가격 티어는 세션 시작 시 고정됩니다. 변경하려면 새 세션을 시작하세요."
   },
   "creator": {
+    "repoChromePosition": {
+      "up": "위",
+      "down": "아래"
+    },
     "createTarget": {
       "agentSession": "Agent 세션",
       "manageAgents": "Agents / Skills 관리",

--- a/src/i18n/locales/pl/sessions.json
+++ b/src/i18n/locales/pl/sessions.json
@@ -2142,6 +2142,10 @@
     "immutableInSession": "Źródło klucza, typ Agenta i poziom cenowy są ustalane na początku sesji. Aby je zmienić, rozpocznij nową sesję."
   },
   "creator": {
+    "repoChromePosition": {
+      "up": "Góra",
+      "down": "Dół"
+    },
     "createTarget": {
       "agentSession": "Sesja Agent",
       "manageAgents": "Zarządzaj Agents / Skills",

--- a/src/i18n/locales/pt/sessions.json
+++ b/src/i18n/locales/pt/sessions.json
@@ -2104,6 +2104,10 @@
     "immutableInSession": "A origem da chave, o tipo de Agent e o nível de preço são fixados no início da sessão. Inicie uma nova sessão para alterá-los."
   },
   "creator": {
+    "repoChromePosition": {
+      "up": "Em cima",
+      "down": "Embaixo"
+    },
     "createTarget": {
       "agentSession": "Sessão de Agent",
       "manageAgents": "Gerenciar Agents / Skills",

--- a/src/i18n/locales/ru/sessions.json
+++ b/src/i18n/locales/ru/sessions.json
@@ -2132,6 +2132,10 @@
     "immutableInSession": "Источник ключа, тип Agent и тарифный уровень фиксируются при запуске сессии. Чтобы изменить их, начните новую сессию."
   },
   "creator": {
+    "repoChromePosition": {
+      "up": "Сверху",
+      "down": "Снизу"
+    },
     "createTarget": {
       "agentSession": "Сессия Agent",
       "manageAgents": "Управлять Agents / Skills",

--- a/src/i18n/locales/tr/sessions.json
+++ b/src/i18n/locales/tr/sessions.json
@@ -2089,6 +2089,10 @@
     "immutableInSession": "Anahtar kaynağı, Agent türü ve fiyat kademesi oturum başlangıcında sabittir. Değiştirmek için yeni bir oturum başlatın."
   },
   "creator": {
+    "repoChromePosition": {
+      "up": "Yukarı",
+      "down": "Aşağı"
+    },
     "createTarget": {
       "agentSession": "Agent oturumu",
       "manageAgents": "Agents / Skills yönet",

--- a/src/i18n/locales/vi/sessions.json
+++ b/src/i18n/locales/vi/sessions.json
@@ -2086,6 +2086,10 @@
     "immutableInSession": "Nguồn khóa, loại Agent và bậc giá được cố định khi bắt đầu phiên. Bắt đầu phiên mới để thay đổi."
   },
   "creator": {
+    "repoChromePosition": {
+      "up": "Trên",
+      "down": "Dưới"
+    },
     "createTarget": {
       "agentSession": "Phiên Agent",
       "manageAgents": "Quản lý Agents / Skills",

--- a/src/i18n/locales/zh-Hant/sessions.json
+++ b/src/i18n/locales/zh-Hant/sessions.json
@@ -2103,6 +2103,10 @@
     "immutableInSession": "密鑰來源、Agent 類型和價格檔位在會話啓動時已固定。如需更改請新建會話。"
   },
   "creator": {
+    "repoChromePosition": {
+      "up": "上",
+      "down": "下"
+    },
     "createTarget": {
       "agentSession": "Agent 會話",
       "manageAgents": "管理 Agent / Skills",

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -2140,6 +2140,10 @@
     "appliesNextTurn": "账号已切换。当前回复仍由原账号完成，新账号将从下一轮开始生效。"
   },
   "creator": {
+    "repoChromePosition": {
+      "up": "上",
+      "down": "下"
+    },
     "createTarget": {
       "agentSession": "Agent 会话",
       "manageAgents": "管理 Agent / Skills",

--- a/src/store/session/creatorRepoChromePositionAtom.test.ts
+++ b/src/store/session/creatorRepoChromePositionAtom.test.ts
@@ -1,0 +1,53 @@
+import { createStore } from "jotai/vanilla";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  CREATOR_REPO_CHROME_POSITION_STORAGE_KEY,
+  creatorRepoChromePositionAtom,
+  resolveCreatorRepoChromePosition,
+} from "./creatorRepoChromePositionAtom";
+
+beforeEach(() => {
+  localStorage.removeItem(CREATOR_REPO_CHROME_POSITION_STORAGE_KEY);
+});
+
+function hydratedStore(): ReturnType<typeof createStore> {
+  const store = createStore();
+  store.sub(creatorRepoChromePositionAtom, () => undefined);
+  return store;
+}
+
+describe("creatorRepoChromePositionAtom", () => {
+  it("preserves each layout's established position until the user chooses", () => {
+    expect(resolveCreatorRepoChromePosition(null, "top")).toBe("top");
+    expect(resolveCreatorRepoChromePosition(null, "bottom")).toBe("bottom");
+  });
+
+  it("lets an explicit preference override either layout fallback", () => {
+    expect(resolveCreatorRepoChromePosition("bottom", "top")).toBe("bottom");
+    expect(resolveCreatorRepoChromePosition("top", "bottom")).toBe("top");
+  });
+
+  it("persists an explicit position and hydrates it in a new store", () => {
+    const firstStore = hydratedStore();
+    firstStore.set(creatorRepoChromePositionAtom, "bottom");
+
+    expect(
+      JSON.parse(
+        localStorage.getItem(CREATOR_REPO_CHROME_POSITION_STORAGE_KEY) ?? "null"
+      )
+    ).toBe("bottom");
+
+    const secondStore = hydratedStore();
+    expect(secondStore.get(creatorRepoChromePositionAtom)).toBe("bottom");
+  });
+
+  it("rejects malformed persisted values at the storage boundary", () => {
+    localStorage.setItem(
+      CREATOR_REPO_CHROME_POSITION_STORAGE_KEY,
+      JSON.stringify("sideways")
+    );
+
+    expect(hydratedStore().get(creatorRepoChromePositionAtom)).toBeNull();
+  });
+});

--- a/src/store/session/creatorRepoChromePositionAtom.ts
+++ b/src/store/session/creatorRepoChromePositionAtom.ts
@@ -1,0 +1,43 @@
+import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+
+export const CREATOR_REPO_CHROME_POSITION_STORAGE_KEY =
+  "orgii:sessionCreator:repoChromePosition";
+
+export type CreatorRepoChromePosition = "top" | "bottom";
+
+function normalizeCreatorRepoChromePosition(
+  value: unknown
+): CreatorRepoChromePosition | null {
+  return value === "top" || value === "bottom" ? value : null;
+}
+
+const storedCreatorRepoChromePositionAtom = atomWithStorage<unknown>(
+  CREATOR_REPO_CHROME_POSITION_STORAGE_KEY,
+  null,
+  undefined,
+  { getOnInit: true }
+);
+
+/**
+ * Global creator preference for the repository/branch/location chrome.
+ *
+ * `null` preserves each creator layout's established first-run position. Once
+ * the user chooses a position, the explicit value is persisted across app
+ * restarts and shared by every Session Creator entry point.
+ */
+export const creatorRepoChromePositionAtom = atom(
+  (get) =>
+    normalizeCreatorRepoChromePosition(
+      get(storedCreatorRepoChromePositionAtom)
+    ),
+  (_get, set, position: CreatorRepoChromePosition) =>
+    set(storedCreatorRepoChromePositionAtom, position)
+);
+
+export function resolveCreatorRepoChromePosition(
+  preference: CreatorRepoChromePosition | null,
+  fallback: CreatorRepoChromePosition
+): CreatorRepoChromePosition {
+  return preference ?? fallback;
+}

--- a/src/store/session/index.ts
+++ b/src/store/session/index.ts
@@ -25,6 +25,7 @@ export * from "./creatorDefaultModelAtom";
 export * from "./recentModelEntriesAtom";
 export * from "./recentAgentSelectionsAtom";
 export * from "./creatorDefaultExecModeAtom";
+export * from "./creatorRepoChromePositionAtom";
 export * from "./cliUpdateAlertsAtom";
 
 // Session runtime (engine lifecycle, file review, shell processes)


### PR DESCRIPTION
## Problem

Session Creator fixed the repository, branch, and running-location chrome to a layout-specific side of the composer. Users could not persist their own Up or Down choice, and secondary-clicking the chrome opened the WebView Back/Reload/Inspect menu instead of an app action.

Naively moving the chrome between sibling positions could also shift or remount the composer input, producing a flash. The launchpad glow could paint across chrome placed below the composer.

## Solution

- Add a persisted, validated `top` / `bottom` Session Creator preference while preserving the existing first-run defaults: Launchpad uses Up and standard layouts use Down.
- Replace the WebView context menu on the repository chrome with a native Tauri menu containing checked, localized Up and Down actions. This right-click menu is the only position control; no visible switch is added.
- Keep stable chrome slots around the composer so changing position does not remount the input, and place Down chrome outside the complete composer frame.
- Disable the launchpad composer glow only while movable chrome is Down, while preserving the original seam overlap, corner radii, padding, and z-order.
- Add localization across all supported locales, focused regression tests, test-case documentation, and architecture/UI audit evidence.

## Potential risks

The new preference uses local storage only; malformed or absent values normalize to no explicit choice, so existing layout defaults remain compatible. Reverting this commit makes the stored key inert and requires no data migration.

If native-menu creation fails, the WebView menu remains suppressed for that interaction and the failure is logged; users can retry the secondary click. Compact and hidden repository chrome intentionally do not expose the position menu.

No live desktop screenshot or manual pointer interaction was captured because desktop UI control was not authorized. The exact visual integration therefore remains an unverified path, although source-level layout and menu behavior are covered by focused tests.

## Verification

- `pnpm exec vitest run src/features/SessionCreator/variants/ChatPanel/RepoChromeRow.test.ts src/features/SessionCreator/variants/ChatPanel/repoChromeLayout.test.ts src/store/session/creatorRepoChromePositionAtom.test.ts` — 3 files and 8 tests passed after rebasing onto current `origin/develop`
- `pnpm exec eslint src/features/SessionCreator/variants/ChatPanel/RepoChromeRow.tsx src/features/SessionCreator/variants/ChatPanel/RepoChromeRow.test.ts src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx src/features/SessionCreator/variants/ChatPanel/index.tsx src/features/SessionCreator/variants/ChatPanel/repoChromeLayout.ts src/features/SessionCreator/variants/ChatPanel/repoChromeLayout.test.ts src/store/session/creatorRepoChromePositionAtom.ts src/store/session/creatorRepoChromePositionAtom.test.ts` — passed
- `pnpm exec tsc --noEmit --pretty false` — passed after rebasing
- `pnpm exec prettier --check ...` over every changed source, locale, test, and audit file — passed
- `git diff --check origin/develop...HEAD` — passed
- Commit hooks: lint-staged and scoped TypeScript checks passed

## Audit

- Architecture audit: all applicable layers passed; wire protocol and resolver symmetry were not applicable
- UI audit fallback: 0 fix, 5 keep with reason, 0 abstract
