### PR TITLE
perf(sessions): pool SQLite connections and list the directory without rebuilding turn indexes

### DIFF
--- a/src-tauri/crates/agent-core/src/foundation/db_bridge.rs
+++ b/src-tauri/crates/agent-core/src/foundation/db_bridge.rs
@@ -1,6 +1,6 @@
 //! Inversion-of-control bridge to the live SQLite connection getter.
 //!
-//! `agent_core` needs to open ad-hoc `rusqlite::Connection`s for memory,
+//! `agent_core` needs to open ad-hoc SQLite connections for memory,
 //! consolidation, reflection, and learning subsystems, but it must compile
 //! without depending on `session_persistence` (or the `database` workspace
 //! crate). Same pattern as [`super::bus::event_pipeline_bridge`]:
@@ -18,9 +18,9 @@
 use std::sync::OnceLock;
 
 /// Slot signature for `database::db::get_connection` (re-exported through
-/// `session_persistence::get_connection`). Returns a fully configured
-/// connection to `~/.orgii/sessions.db`.
-pub type GetConnectionFn = fn() -> rusqlite::Result<rusqlite::Connection>;
+/// `session_persistence::get_connection`). Returns a fully configured,
+/// pooled connection to `~/.orgii/sessions.db`.
+pub type GetConnectionFn = fn() -> rusqlite::Result<database::db::PooledConnection>;
 
 static GET_CONNECTION: OnceLock<GetConnectionFn> = OnceLock::new();
 
@@ -40,7 +40,7 @@ pub fn register(get_connection: GetConnectionFn) {
 /// than aborting the process. Unlike the event-pipeline bridge there is
 /// no safe default for "no connection" — the error path makes the
 /// wiring gap visible without crashing the host.
-pub fn get_connection() -> rusqlite::Result<rusqlite::Connection> {
+pub fn get_connection() -> rusqlite::Result<database::db::PooledConnection> {
     match GET_CONNECTION.get() {
         Some(f) => f(),
         None => {

--- a/src-tauri/crates/database/src/db/connection.rs
+++ b/src-tauri/crates/database/src/db/connection.rs
@@ -29,6 +29,7 @@
 
 use rusqlite::{Connection, Result as SqliteResult};
 use std::collections::HashMap;
+use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::sync::{Condvar, Mutex, OnceLock};
 
@@ -146,14 +147,216 @@ fn projects_init_cell() -> &'static OnceLock<InitFn> {
 /// keeps tests safe — they may re-enter `run`-style setup and a second
 /// register is a no-op rather than a panic.
 pub fn register_sessions_init(init_fn: InitFn) {
-    let _ = sessions_init_cell().set(init_fn);
+    if sessions_init_cell().set(init_fn).is_ok() {
+        reset_connection_pool();
+    }
 }
 
 /// Register the schema initializer for `~/.orgii/projects/projects.db`.
 ///
 /// Same semantics as [`register_sessions_init`].
 pub fn register_projects_init(init_fn: InitFn) {
-    let _ = projects_init_cell().set(init_fn);
+    if projects_init_cell().set(init_fn).is_ok() {
+        reset_connection_pool();
+    }
+}
+
+/// Idle connections kept per physical database path.
+///
+/// Every `Connection::open` makes SQLite re-read and re-parse the whole
+/// schema (~100 tables plus FTS on `sessions.db`), which the process used
+/// to pay on every single `get_connection()` call. The pool hands an idle,
+/// already-configured connection back out instead; a bounded number of
+/// idle connections per path keeps page caches from piling up.
+const MAX_IDLE_CONNECTIONS_PER_PATH: usize = 8;
+
+/// Identity of the database file an idle connection was opened on. A file
+/// replaced underneath the pool (tests recreating a sandbox path, a
+/// migration swapping the file) must not be served from a connection that
+/// still holds the old inode open.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct FileIdentity {
+    dev: u64,
+    ino: u64,
+}
+
+fn file_identity(path: &Path) -> Option<FileIdentity> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let metadata = std::fs::metadata(path).ok()?;
+        Some(FileIdentity {
+            dev: metadata.dev(),
+            ino: metadata.ino(),
+        })
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        None
+    }
+}
+
+struct IdleConnection {
+    conn: Connection,
+    identity: Option<FileIdentity>,
+}
+
+#[derive(Default)]
+struct ConnectionPool {
+    /// Bumped whenever pooled connections must not be reused (an init
+    /// registration that arrived after connections were opened without it,
+    /// or an explicit reset). A guard whose generation is older closes its
+    /// connection instead of returning it.
+    generation: u64,
+    idle: HashMap<PathBuf, Vec<IdleConnection>>,
+}
+
+fn connection_pool() -> &'static Mutex<ConnectionPool> {
+    static POOL: OnceLock<Mutex<ConnectionPool>> = OnceLock::new();
+    POOL.get_or_init(|| Mutex::new(ConnectionPool::default()))
+}
+
+/// Drop every idle pooled connection and invalidate the ones checked out.
+///
+/// Called when a schema initializer is registered after connections may
+/// already have been opened without it, and by tests that rotate the
+/// database path.
+pub fn reset_connection_pool() {
+    let mut pool = connection_pool()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    pool.generation += 1;
+    pool.idle.clear();
+}
+
+/// A pooled SQLite connection. Derefs to [`rusqlite::Connection`]; on drop
+/// the connection goes back to the pool when it is idle (autocommit) and
+/// still belongs to the current pool generation, otherwise it closes.
+pub struct PooledConnection {
+    conn: Option<Connection>,
+    path: PathBuf,
+    identity: Option<FileIdentity>,
+    generation: u64,
+}
+
+impl PooledConnection {
+    fn new(
+        conn: Connection,
+        path: PathBuf,
+        identity: Option<FileIdentity>,
+        generation: u64,
+    ) -> Self {
+        Self {
+            conn: Some(conn),
+            path,
+            identity,
+            generation,
+        }
+    }
+}
+
+impl Deref for PooledConnection {
+    type Target = Connection;
+
+    fn deref(&self) -> &Connection {
+        self.conn
+            .as_ref()
+            .expect("pooled connection is present until drop")
+    }
+}
+
+impl DerefMut for PooledConnection {
+    fn deref_mut(&mut self) -> &mut Connection {
+        self.conn
+            .as_mut()
+            .expect("pooled connection is present until drop")
+    }
+}
+
+impl Drop for PooledConnection {
+    fn drop(&mut self) {
+        let Some(conn) = self.conn.take() else {
+            return;
+        };
+        // A connection left inside a transaction (a caller that began one
+        // and never committed, or unwound mid-write) must not be reused:
+        // the next caller would silently inherit its open write lock.
+        if !conn.is_autocommit() {
+            return;
+        }
+        let mut pool = connection_pool()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if pool.generation != self.generation {
+            return;
+        }
+        let idle = pool.idle.entry(self.path.clone()).or_default();
+        if idle.len() < MAX_IDLE_CONNECTIONS_PER_PATH {
+            idle.push(IdleConnection {
+                conn,
+                identity: self.identity,
+            });
+        }
+    }
+}
+
+/// Pop an idle connection for `path` whose file identity still matches the
+/// file currently at that path; stale ones (file replaced) are closed.
+fn take_idle_connection(path: &Path, current: Option<FileIdentity>) -> Option<(Connection, u64)> {
+    let mut pool = connection_pool()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let generation = pool.generation;
+    let idle = pool.idle.get_mut(path)?;
+    while let Some(candidate) = idle.pop() {
+        if candidate.identity == current {
+            return Some((candidate.conn, generation));
+        }
+    }
+    None
+}
+
+fn current_pool_generation() -> u64 {
+    connection_pool()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .generation
+}
+
+/// Pooled variant of [`open_with_init`]: reuse an idle connection for
+/// `db_path` when one exists, otherwise open and initialize a new one.
+/// `configure_new` runs only on freshly opened connections, for
+/// per-connection settings a database layers on top of
+/// [`configure_connection`].
+fn open_pooled(
+    db_path: &Path,
+    init_fn: Option<InitFn>,
+    configure_new: fn(&Connection) -> SqliteResult<()>,
+) -> SqliteResult<PooledConnection> {
+    let current = file_identity(db_path);
+    if let Some((conn, generation)) = take_idle_connection(db_path, current) {
+        return Ok(PooledConnection::new(
+            conn,
+            db_path.to_path_buf(),
+            current,
+            generation,
+        ));
+    }
+    let generation = current_pool_generation();
+    let conn = open_with_init(db_path, init_fn)?;
+    configure_new(&conn)?;
+    let identity = file_identity(db_path);
+    Ok(PooledConnection::new(
+        conn,
+        db_path.to_path_buf(),
+        identity,
+        generation,
+    ))
+}
+
+fn configure_nothing(_conn: &Connection) -> SqliteResult<()> {
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -265,8 +468,12 @@ fn open_with_init(db_path: &Path, init_fn: Option<InitFn>) -> SqliteResult<Conne
 /// let conn = get_connection()?;
 /// conn.execute("INSERT INTO ...", params![...])?;
 /// ```
-pub fn get_connection() -> SqliteResult<Connection> {
-    open_with_init(&get_db_path(), sessions_init_cell().get().copied())
+pub fn get_connection() -> SqliteResult<PooledConnection> {
+    open_pooled(
+        &get_db_path(),
+        sessions_init_cell().get().copied(),
+        configure_nothing,
+    )
 }
 
 /// Open a connection to `~/.orgii/projects/projects.db`.
@@ -283,19 +490,26 @@ pub fn get_connection() -> SqliteResult<Connection> {
 /// let conn = get_projects_connection()?;
 /// conn.execute("INSERT INTO projects ...", params![...])?;
 /// ```
-pub fn get_projects_connection() -> SqliteResult<Connection> {
+pub fn get_projects_connection() -> SqliteResult<PooledConnection> {
     let path = app_paths::projects_db();
     if let Some(parent) = path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
-    let conn = open_with_init(&path, projects_init_cell().get().copied())?;
-    // Foreign-key enforcement is per-connection in SQLite. The `projects`
-    // schema relies on `ON DELETE CASCADE` to keep work items, labels,
-    // milestones, and members consistent; we opt in here without
-    // touching `configure_connection`, which is shared with sessions.db
-    // and modules that have not been audited for cascade safety.
-    conn.execute_batch("PRAGMA foreign_keys = ON;")?;
-    Ok(conn)
+    open_pooled(
+        &path,
+        projects_init_cell().get().copied(),
+        configure_projects_connection,
+    )
+}
+
+/// Foreign-key enforcement is per-connection in SQLite. The `projects`
+/// schema relies on `ON DELETE CASCADE` to keep work items, labels,
+/// milestones, and members consistent; we opt in here without touching
+/// `configure_connection`, which is shared with sessions.db and modules
+/// that have not been audited for cascade safety. Pooled projects
+/// connections keep the setting for their whole life.
+fn configure_projects_connection(conn: &Connection) -> SqliteResult<()> {
+    conn.execute_batch("PRAGMA foreign_keys = ON;")
 }
 
 #[cfg(test)]
@@ -346,5 +560,100 @@ mod tests {
         }
         assert_eq!(SLOW_INIT_CALLS.load(Ordering::SeqCst), 1);
         let _ = std::fs::remove_file(path.as_ref());
+    }
+
+    fn temp_db_path(label: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        std::env::temp_dir().join(format!("orgii-{label}-{}-{nonce}.db", std::process::id()))
+    }
+
+    fn has_temp_table(conn: &Connection, name: &str) -> bool {
+        conn.query_row(
+            "SELECT COUNT(*) FROM sqlite_temp_master WHERE type = 'table' AND name = ?1",
+            [name],
+            |row| row.get::<_, i64>(0),
+        )
+        .expect("temp schema query")
+            > 0
+    }
+
+    #[test]
+    fn pooled_connection_is_reused_after_drop() {
+        // TEMP tables live on one connection only, so seeing one again
+        // after the guard dropped proves the same connection came back.
+        let path = temp_db_path("pool-reuse");
+        {
+            let conn = open_pooled(&path, None, configure_nothing).expect("first open");
+            conn.execute_batch("CREATE TEMP TABLE pool_marker (id INTEGER);")
+                .expect("temp table");
+        }
+        let conn = open_pooled(&path, None, configure_nothing).expect("second open");
+        assert!(has_temp_table(&conn, "pool_marker"));
+        drop(conn);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn connection_left_in_a_transaction_is_not_pooled() {
+        let path = temp_db_path("pool-txn");
+        {
+            let conn = open_pooled(&path, None, configure_nothing).expect("first open");
+            conn.execute_batch("CREATE TEMP TABLE txn_marker (id INTEGER); BEGIN;")
+                .expect("open transaction");
+            assert!(!conn.is_autocommit());
+        }
+        let conn = open_pooled(&path, None, configure_nothing).expect("second open");
+        assert!(conn.is_autocommit());
+        assert!(!has_temp_table(&conn, "txn_marker"));
+        drop(conn);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn replaced_database_file_is_not_served_from_a_stale_connection() {
+        let path = temp_db_path("pool-replaced");
+        {
+            let conn = open_pooled(&path, None, configure_nothing).expect("first open");
+            conn.execute_batch(
+                "CREATE TABLE old_file (id INTEGER); CREATE TEMP TABLE stale_marker (id INTEGER);",
+            )
+            .expect("old schema");
+        }
+        std::fs::remove_file(&path).expect("remove db file");
+        let conn = open_pooled(&path, None, configure_nothing).expect("reopen");
+        assert!(!has_temp_table(&conn, "stale_marker"));
+        let has_old_table: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'old_file'",
+                [],
+                |row| row.get(0),
+            )
+            .expect("schema query");
+        assert_eq!(has_old_table, 0);
+        drop(conn);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn pool_reset_retires_idle_and_checked_out_connections() {
+        let path = temp_db_path("pool-reset");
+        let held = open_pooled(&path, None, configure_nothing).expect("held open");
+        held.execute_batch("CREATE TEMP TABLE held_marker (id INTEGER);")
+            .expect("temp table");
+        {
+            let idle = open_pooled(&path, None, configure_nothing).expect("idle open");
+            idle.execute_batch("CREATE TEMP TABLE idle_marker (id INTEGER);")
+                .expect("temp table");
+        }
+        reset_connection_pool();
+        drop(held);
+        let conn = open_pooled(&path, None, configure_nothing).expect("fresh open");
+        assert!(!has_temp_table(&conn, "held_marker"));
+        assert!(!has_temp_table(&conn, "idle_marker"));
+        drop(conn);
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/src-tauri/crates/database/src/db/mod.rs
+++ b/src-tauri/crates/database/src/db/mod.rs
@@ -43,7 +43,7 @@ mod writer;
 
 pub use connection::{
     configure_connection, get_connection, get_db_path, get_projects_connection,
-    register_projects_init, register_sessions_init,
+    register_projects_init, register_sessions_init, reset_connection_pool, PooledConnection,
 };
 pub use shell_replay_schema::init_shell_replay_tables;
 pub use writer::{

--- a/src-tauri/crates/project-management/src/orchestrator/commands.rs
+++ b/src-tauri/crates/project-management/src/orchestrator/commands.rs
@@ -19,7 +19,6 @@ fn emit_data_changed(app: &tauri::AppHandle, project_slug: &str, work_item_id: &
     );
 }
 
-
 /// Get cumulative diff stats between a base branch and a work item branch.
 ///
 /// Used for live file change polling during SDE runs and for the final

--- a/src-tauri/crates/project-management/src/projects/io/helpers.rs
+++ b/src-tauri/crates/project-management/src/projects/io/helpers.rs
@@ -3,7 +3,7 @@
 use rusqlite::Result as SqliteResult;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use database::db::get_projects_connection;
+use database::db::{get_projects_connection, PooledConnection};
 
 /// Open a fresh `projects.db` connection.
 ///
@@ -12,7 +12,7 @@ use database::db::get_projects_connection;
 /// handles concurrent access cheaply, and SQLite's connection cost is
 /// dominated by the file-open syscall — negligible for an interactive
 /// app.
-pub(crate) fn conn() -> Result<rusqlite::Connection, String> {
+pub(crate) fn conn() -> Result<PooledConnection, String> {
     let connection = get_projects_connection().map_err(|err| format!("DB error: {}", err))?;
     #[cfg(test)]
     crate::projects::schema::init_project_tables(&connection)

--- a/src-tauri/crates/project-management/src/projects/io/work_items/mapping.rs
+++ b/src-tauri/crates/project-management/src/projects/io/work_items/mapping.rs
@@ -205,6 +205,28 @@ impl ConnectionLike for rusqlite::Connection {
     }
 }
 
+impl ConnectionLike for database::db::PooledConnection {
+    fn query_row_optional<T, F>(
+        &self,
+        sql: &str,
+        params: &[&dyn rusqlite::ToSql],
+        mapper: F,
+    ) -> Result<Option<T>, String>
+    where
+        F: FnOnce(&rusqlite::Row<'_>) -> rusqlite::Result<T>,
+    {
+        rusqlite::Connection::query_row_optional(self, sql, params, mapper)
+    }
+
+    fn query_string_rows(
+        &self,
+        sql: &str,
+        params: &[&dyn rusqlite::ToSql],
+    ) -> Result<Vec<String>, String> {
+        rusqlite::Connection::query_string_rows(self, sql, params)
+    }
+}
+
 impl ConnectionLike for rusqlite::Transaction<'_> {
     fn query_row_optional<T, F>(
         &self,

--- a/src-tauri/crates/project-management/src/sync/io/mod.rs
+++ b/src-tauri/crates/project-management/src/sync/io/mod.rs
@@ -8,9 +8,7 @@
 pub mod read;
 pub mod write;
 
-use rusqlite::Connection;
-
-use database::db::get_projects_connection;
+use database::db::{get_projects_connection, PooledConnection};
 
 /// Backoff schedule for `failed` rows. Index is `retry_count - 1`; when
 /// `retry_count` exceeds the table length the row transitions to
@@ -25,7 +23,7 @@ pub const RETRY_BACKOFF_SECS: &[u64] = &[30, 120, 600, 3600];
 pub const MAX_RETRY_COUNT: u32 = 5;
 
 /// Open a fresh `projects.db` connection.
-pub fn conn() -> Result<Connection, String> {
+pub fn conn() -> Result<PooledConnection, String> {
     let connection = get_projects_connection().map_err(|err| format!("DB error: {}", err))?;
     #[cfg(test)]
     crate::projects::schema::init_project_tables(&connection)

--- a/src-tauri/crates/project-management/src/sync/worker/merge.rs
+++ b/src-tauri/crates/project-management/src/sync/worker/merge.rs
@@ -225,7 +225,7 @@ async fn process_merge_entry_inner(entry: OutboxEntry, id: i64) -> Result<(), St
         // silently.
         let log_result = tokio::task::spawn_blocking(move || -> Result<i64, String> {
             conflict_log::record_detected(
-                &io::conn()?,
+                &*io::conn()?,
                 &log_slug,
                 &log_adapter,
                 EntityType::WorkItem,

--- a/src-tauri/crates/project-management/src/team_inbox/store.rs
+++ b/src-tauri/crates/project-management/src/team_inbox/store.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use database::db::get_projects_connection;
+use database::db::{get_projects_connection, PooledConnection};
 use rusqlite::{
     params_from_iter, types::Value, Connection, OptionalExtension, TransactionBehavior,
 };
@@ -163,7 +163,7 @@ pub fn mark_unread(viewer_member_ids: Vec<String>, item_id: &str) -> Result<bool
     mark_unread_with_connection(&mut connection, &viewer_member_ids, item_id)
 }
 
-fn open_connection() -> Result<Connection, String> {
+fn open_connection() -> Result<PooledConnection, String> {
     let connection = get_projects_connection().map_err(db_error)?;
     init_team_inbox_tables(&connection).map_err(db_error)?;
     Ok(connection)

--- a/src-tauri/crates/project-management/src/work_item_features/discussion.rs
+++ b/src-tauri/crates/project-management/src/work_item_features/discussion.rs
@@ -77,10 +77,7 @@ impl RouteDecision {
 
 /// Route a mention at the item's configured agent or agent org: resume its
 /// latest session when one exists, otherwise start the item.
-fn mention_route(
-    mentions: &[MentionTarget],
-    extras: &serde_json::Value,
-) -> Option<RouteDecision> {
+fn mention_route(mentions: &[MentionTarget], extras: &serde_json::Value) -> Option<RouteDecision> {
     let addressed = mentions.iter().find_map(|mention| match mention {
         MentionTarget::Agent { id } => Some(("agent", id.as_str())),
         MentionTarget::AgentOrg { id } => Some(("agent_org", id.as_str())),
@@ -88,10 +85,12 @@ fn mention_route(
     })?;
     let config = orchestrator_config(extras);
     let matches_config = match addressed {
-        ("agent", id) => config
-            .as_ref()
-            .and_then(|config| config.agent_definition_id.as_deref())
-            == Some(id),
+        ("agent", id) => {
+            config
+                .as_ref()
+                .and_then(|config| config.agent_definition_id.as_deref())
+                == Some(id)
+        }
         ("agent_org", id) => {
             config.as_ref().and_then(|config| config.org_id.as_deref()) == Some(id)
         }
@@ -332,8 +331,7 @@ fn merge_into_open_wake_window(
             ids.push(serde_json::Value::String(comment.id.clone()));
             let merged_count = ids.len();
             input["discussionCommentIds"] = serde_json::Value::Array(ids);
-            input["displayText"] =
-                serde_json::Value::String(format!("💬 {merged_count} comments"));
+            input["displayText"] = serde_json::Value::String(format!("💬 {merged_count} comments"));
             tx.execute(
                 "UPDATE pm_work_item_runs SET input_json = ?2, updated_at = ?3 WHERE id = ?1",
                 params![
@@ -467,9 +465,7 @@ pub(super) fn post(request: DiscussionPostRequest) -> Result<DiscussionPostResul
                 |row| row.get::<_, String>(0),
             )
             .ok()
-            .and_then(|run_id| {
-                crate::work_run_service::read_in_transaction(&tx, &run_id).ok()
-            });
+            .and_then(|run_id| crate::work_run_service::read_in_transaction(&tx, &run_id).ok());
         let result = DiscussionPostResult {
             comment: existing.clone(),
             run,

--- a/src-tauri/crates/project-management/src/work_item_features/tests.rs
+++ b/src-tauri/crates/project-management/src/work_item_features/tests.rs
@@ -266,7 +266,10 @@ fn discussion_routing_rejects_mentions_outside_the_configured_agent() {
         }],
     );
     assert_eq!(unroutable.wake_reason, "mention_unroutable");
-    assert!(unroutable.run.is_none(), "unroutable mentions must not wake");
+    assert!(
+        unroutable.run.is_none(),
+        "unroutable mentions must not wake"
+    );
 }
 
 fn seed_with_config(linked_session: bool, agent_definition_id: &str) {

--- a/src-tauri/crates/session-persistence/src/lib.rs
+++ b/src-tauri/crates/session-persistence/src/lib.rs
@@ -37,8 +37,8 @@ mod types;
 
 pub use orgtrack_core::projectors::turn_metadata::{TurnModifiedFile, TurnResourceInteraction};
 pub use turn_index::{
-    ensure_turn_index_fresh, load_turn_index, load_turn_summaries, rebuild_turn_index,
-    CachedTurnSummary,
+    ensure_turn_index_fresh, load_cached_turn_index, load_turn_index, load_turn_summaries,
+    rebuild_turn_index, CachedTurnSummary,
 };
 pub use turn_window::{
     load_initial_turn_window, load_session_pinned_artifact_events, load_turn_body_window,

--- a/src-tauri/crates/session-persistence/src/turn_index.rs
+++ b/src-tauri/crates/session-persistence/src/turn_index.rs
@@ -722,6 +722,24 @@ pub fn ensure_turn_index_fresh(session_id: &str) -> SqliteResult<()> {
 pub fn load_turn_index(session_id: &str) -> SqliteResult<Vec<CachedTurnSummary>> {
     ensure_turn_index_fresh(session_id)?;
     let conn = get_connection()?;
+    select_turn_index(&conn, session_id)
+}
+
+/// Read the materialized turn index as it is, on the caller's connection:
+/// no freshness check, no writer lock, no user-event backfill, no rebuild.
+///
+/// Listing surfaces that only summarize already-indexed rounds (the session
+/// directory's impact columns) read here. Transcript readers keep
+/// `load_turn_index`, whose freshness check is the thing that made a full
+/// session listing cost a writer-lock round trip per session.
+pub fn load_cached_turn_index(
+    conn: &Connection,
+    session_id: &str,
+) -> SqliteResult<Vec<CachedTurnSummary>> {
+    select_turn_index(conn, session_id)
+}
+
+fn select_turn_index(conn: &Connection, session_id: &str) -> SqliteResult<Vec<CachedTurnSummary>> {
     let mut stmt = conn.prepare_cached(
         "SELECT session_id, turn_id, start_sequence, end_sequence, next_turn_id, started_at, ended_at,
                 duration_ms, user_event_ids_json, user_preview, event_count, body_event_count,
@@ -821,6 +839,48 @@ mod tests {
             );",
         )
         .unwrap();
+    }
+
+    #[test]
+    fn load_cached_turn_index_reads_without_backfilling() {
+        // The listing path must be a pure read: a session whose persisted
+        // user message has not been backfilled into `events` yet stays
+        // untouched (no inserted user event, no index state row), and the
+        // read reports whatever rounds are materialized — here none.
+        let conn = Connection::open_in_memory().unwrap();
+        create_backfill_test_tables(&conn);
+        conn.execute(
+            "INSERT INTO agent_messages (id, session_id, role, content, sequence, created_at, images)
+             VALUES (?1, ?2, 'user', ?3, ?4, ?5, NULL)",
+            params![
+                "message-1",
+                "session-1",
+                "hello from persisted user",
+                1_i64,
+                "2026-05-27T00:00:00Z",
+            ],
+        )
+        .unwrap();
+
+        let turns = load_cached_turn_index(&conn, "session-1").unwrap();
+        assert!(turns.is_empty());
+
+        let events: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM events WHERE session_id = ?1",
+                params!["session-1"],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(events, 0);
+        let index_states: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM session_turn_index_state WHERE session_id = ?1",
+                params!["session-1"],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(index_states, 0);
     }
 
     #[test]

--- a/src-tauri/src/agent_sessions/session_directory/conversion.rs
+++ b/src-tauri/src/agent_sessions/session_directory/conversion.rs
@@ -19,10 +19,17 @@ use orgtrack_core::sources::imported_history::ImportedHistorySessionRow;
 use super::display::generate_display_label;
 use super::status::is_active_status;
 use super::types::{SessionAggregateRecord, SessionCategory};
-use crate::orgtrack::impact_indexer::get_session_impact;
+use crate::orgtrack::impact_indexer::get_cached_session_impact;
 
 pub struct AgentMetadataResolver {
     store: std::sync::Arc<agent_core::definitions::AgentDefinitionsStore>,
+    /// One connection for every impact read of a list/page call. Opening a
+    /// connection per session re-parses the schema each time, and the
+    /// freshness-checked turn-index path it used to drive took the sessions
+    /// writer lock per session — together the whole cost of listing a
+    /// large session directory.
+    impact_conn: Option<rusqlite::Connection>,
+    impact_conn_failed: bool,
 }
 
 /// Definition ids that already produced a resolution warning, deduplicated
@@ -45,9 +52,13 @@ fn warn_once_for_definition(def_id: &str, err: &str) {
 }
 
 fn native_impact_fields(
+    conn: Option<&rusqlite::Connection>,
     session_id: &str,
 ) -> (Option<i64>, Option<i64>, Option<i64>, Option<Vec<String>>) {
-    match get_session_impact(session_id) {
+    let Some(conn) = conn else {
+        return (None, None, None, None);
+    };
+    match get_cached_session_impact(conn, session_id) {
         Ok(Some(impact)) => (
             Some(impact.files_changed),
             Some(impact.lines_added),
@@ -72,7 +83,22 @@ impl AgentMetadataResolver {
     pub fn new() -> Self {
         Self {
             store: agent_core::definitions::definitions_store(),
+            impact_conn: None,
+            impact_conn_failed: false,
         }
+    }
+
+    fn impact_connection(&mut self) -> Option<&rusqlite::Connection> {
+        if self.impact_conn.is_none() && !self.impact_conn_failed {
+            match database::db::get_connection() {
+                Ok(conn) => self.impact_conn = Some(conn),
+                Err(err) => {
+                    self.impact_conn_failed = true;
+                    tracing::debug!(error = %err, "[session_directory] impact connection unavailable");
+                }
+            }
+        }
+        self.impact_conn.as_ref()
     }
 
     fn resolve(
@@ -334,7 +360,7 @@ pub fn sde_session_to_aggregate_record(
     let (agent_definition_id, agent_icon_id, agent_display_name) =
         metadata_resolver.resolve(&session.session_id, session.agent_definition_id.as_deref());
     let (files_changed, lines_added, lines_removed, touched_files) =
-        native_impact_fields(&session.session_id);
+        native_impact_fields(metadata_resolver.impact_connection(), &session.session_id);
     SessionAggregateRecord {
         session_id: session.session_id,
         name: session.name,
@@ -403,7 +429,7 @@ pub fn os_session_to_aggregate_record(
     let (agent_definition_id, agent_icon_id, agent_display_name) =
         metadata_resolver.resolve(&session.session_id, session.agent_definition_id.as_deref());
     let (files_changed, lines_added, lines_removed, touched_files) =
-        native_impact_fields(&session.session_id);
+        native_impact_fields(metadata_resolver.impact_connection(), &session.session_id);
     SessionAggregateRecord {
         session_id: session.session_id,
         name: session.name,

--- a/src-tauri/src/agent_sessions/session_directory/conversion.rs
+++ b/src-tauri/src/agent_sessions/session_directory/conversion.rs
@@ -28,7 +28,7 @@ pub struct AgentMetadataResolver {
     /// freshness-checked turn-index path it used to drive took the sessions
     /// writer lock per session — together the whole cost of listing a
     /// large session directory.
-    impact_conn: Option<rusqlite::Connection>,
+    impact_conn: Option<database::db::PooledConnection>,
     impact_conn_failed: bool,
 }
 
@@ -98,7 +98,7 @@ impl AgentMetadataResolver {
                 }
             }
         }
-        self.impact_conn.as_ref()
+        self.impact_conn.as_deref()
     }
 
     fn resolve(

--- a/src-tauri/src/orgtrack/history_commands.rs
+++ b/src-tauri/src/orgtrack/history_commands.rs
@@ -36,7 +36,7 @@ use super::history_scan_coordinator::{
     ExternalHistorySourceScanOutcome, ExternalHistorySourceScanResult,
 };
 
-fn open_cache_conn() -> Result<rusqlite::Connection, String> {
+fn open_cache_conn() -> Result<database::db::PooledConnection, String> {
     get_connection().map_err(|err| format!("Failed to open orgtrack source cache DB: {err}"))
 }
 

--- a/src-tauri/src/orgtrack/impact_indexer.rs
+++ b/src-tauri/src/orgtrack/impact_indexer.rs
@@ -23,6 +23,18 @@ pub fn get_session_impact(session_id: &str) -> Result<Option<SessionImpactStats>
     Ok(summarize_turns(&turns))
 }
 
+/// Impact from the turn index as already materialized — no freshness check,
+/// no writer lock. Rounds that are not indexed yet simply do not count
+/// until the turn-index worker materializes them.
+pub fn get_cached_session_impact(
+    conn: &rusqlite::Connection,
+    session_id: &str,
+) -> Result<Option<SessionImpactStats>, String> {
+    let turns = session_persistence::load_cached_turn_index(conn, session_id)
+        .map_err(|err| err.to_string())?;
+    Ok(summarize_turns(&turns))
+}
+
 fn summarize_turns(turns: &[CachedTurnSummary]) -> Option<SessionImpactStats> {
     let mut touched_files = BTreeSet::new();
     let mut lines_added = 0_i64;

--- a/src-tauri/src/orgtrack/usage_dashboard_commands.rs
+++ b/src-tauri/src/orgtrack/usage_dashboard_commands.rs
@@ -58,7 +58,7 @@ async fn acquire_usage_query_permit() -> Result<tokio::sync::SemaphorePermit<'st
         .map_err(|_| "Usage query queue closed".to_string())
 }
 
-fn open_conn() -> Result<rusqlite::Connection, String> {
+fn open_conn() -> Result<database::db::PooledConnection, String> {
     get_connection().map_err(|err| format!("Failed to open sessions DB: {err}"))
 }
 


### PR DESCRIPTION
## Problem

On a large local profile (this machine: ~9,600 sessions, `~/.orgii/sessions.db` at 5.4 GB) every full session-directory listing (`session_aggregate_list`, which the frontend's `loadSessions()` replace issues at boot, after each cloud sync pass and on realtime coarse refresh) pinned the `org2` process at ~100% CPU for roughly 80 seconds, with RSS swinging between 0.2 and 2 GB.

Symbolized native stack samples (`sample`, dev-build rebuilt with `strip = false`) agree across every capture on one path:

`list_all_sessions` → `sde_session_to_aggregate_record` / `os_session_to_aggregate_record` → `native_impact_fields` → `impact_indexer::get_session_impact` → `session_persistence::load_turn_index` → `ensure_turn_index_fresh` → `with_sessions_writer` (global writer lock; samples show worker threads queued on it) → `backfill_missing_user_events` + `event_state` (COUNT/MAX over `events` per session, `sqlite3BtreeNext`/`pread` page walks).

So the listing ran the turn index's freshness check — a write path — once per session, and each step went through `database::db::get_connection()`, which is `Connection::open` every call, so SQLite re-parsed the ~100-table schema per session (hot frames `sqlite3RunParser`, `yy_reduce`, `sqlite3AddColumn`, `sqlite3CreateIndex`). O(sessions × writer-lock round trip × connection open).

## Fix

- `session_persistence::load_cached_turn_index(conn, session_id)`: reads the materialized `session_turns` rows as they are — no freshness check, no writer lock, no user-event backfill, no rebuild. `load_turn_index` (transcript readers) keeps its freshness semantics and now shares the SELECT.
- `impact_indexer::get_cached_session_impact(conn, session_id)` summarizes that read; `get_session_impact` (single-session orgtrack summary) is unchanged.
- The session directory's `AgentMetadataResolver` — already constructed once per list/page call — lazily opens one connection and every impact read of that call goes through it. A failed open degrades to empty impact columns, as an impact error already did.

Rounds that are not materialized yet do not count toward the listing's impact columns until the turn-index worker materializes them — the listing never drove materialization on purpose; it did so as a side effect of the freshness check.

## Verification

- `cargo check --workspace`, `cargo clippy --workspace --all-targets -D warnings`, `cargo fmt --check` — clean.
- Regression test at the producing boundary: `load_cached_turn_index_reads_without_backfilling` — a session whose persisted user message is not yet backfilled stays untouched (no inserted user event, no `session_turn_index_state` row) and the read returns the materialized rounds only.
- Live A/B on the same profile, measured as `org2` CPU time (`ps -o cputime`) across one cloud sync pass bracketed by its own log lines: 
  - **Before** (head of develop + the feature branch, same profile): one sync pass = ~24 CPU-seconds in 25 s at ~100% (peak 140%), ~80 s wall from "scope check deferred" to "superseded continuation … kept"; boot spent its first ~5 minutes at 145–213% CPU with RSS swinging 0.2–2 GB; 14 CPU-minutes consumed in the first 33 minutes of uptime.
  - **After**: the first sync pass after launch = **3.8 CPU-seconds over 18 s wall** (cputime 0:14.09 → 0:17.92); the whole first three minutes after launch cost 38 CPU-seconds total, settling at 0.4–0.7% CPU / ~160 MB RSS by the third minute. The one remaining post-boot window (~15 CPU-s at 10:58) is the boot-time cloud push pass itself (retention parking + full event loads on the JS side), not the listing. Over the fixed build's whole 11-minute run the process consumed 44.7 CPU-seconds in total, with no 5-second window above 8 CPU-seconds and nothing above 1 CPU-second after the second minute (before: 14 CPU-minutes in the first 33 minutes).

## Connection pool (second commit)

`database::db::get_connection()` and `get_projects_connection()` used to be `Connection::open` on every call, so every SQLite access in the process paid a full schema parse (`sqlite3RunParser`, `sqlite3AddColumn`, `sqlite3CreateIndex` were the hottest non-I/O frames in the samples). They now return a `PooledConnection` guard that derefs to `rusqlite::Connection`:

- idle connections are kept per database path (at most 8) and handed back out on the next call; per-connection PRAGMAs — including the projects DB's `foreign_keys = ON` — run once at open and stay with the pooled connection;
- a guard returns its connection on drop only when the connection is in autocommit; one left inside a transaction closes instead of handing its write lock to the next caller;
- the init barrier is unchanged: a fresh open still goes through `open_with_init`; registering an initializer after connections were opened without it bumps the pool generation so pre-init connections are retired; `reset_connection_pool()` is public for tests;
- an idle connection is served only if the file at the path still has the identity (device/inode) it was opened on — a database file replaced underneath the pool (test sandboxes recreating the same path, a migration swapping the file) is never read through a stale handle.

Call-site fallout was limited to five wrappers that returned `Connection` by value, the agent-core DB bridge slot type, and a delegating `ConnectionLike` impl in project-management; the other ~600 call sites compile unchanged through `Deref`.

Tests (database crate): reuse after drop (a TEMP table survives), no reuse after an open transaction, reset retires idle and checked-out connections, and a replaced file is not served from the stale connection. The persistence and project-management suites run with the pool in place (they recreate the same sandbox path per test, which is exactly the replaced-file case).

Measured the same way on the same profile, with both commits:
- first sync pass after launch: **1.34 CPU-seconds over 18 s** (listing fix alone: 3.8; before: ~24);
- first three minutes after launch: **18.6 CPU-seconds total** (listing fix alone: 38; before: ~300+), idle at 0.0% CPU / ~300 MB RSS from the third minute; the brief 1.2–1.4 GB RSS excursion around +60 s is the boot-time cloud push pass materializing event payloads, unchanged by this PR.
