### PR TITLE
fix(workspace): accept pasted local paths

### DIFF
--- a/src-tauri/crates/git/src/repos/mod.rs
+++ b/src-tauri/crates/git/src/repos/mod.rs
@@ -181,6 +181,34 @@ pub async fn server_create_folder(
     Ok(repo_record_to_json(&folder))
 }
 
+/// Validate an existing workspace directory and return its canonical path.
+///
+/// This runs in the Rust backend because the native folder dialog grants the
+/// frontend FS plugin a runtime scope that an equivalent pasted path lacks.
+#[tauri::command]
+pub async fn server_validate_workspace_path(path: String) -> Result<String, String> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return Err("Workspace path cannot be empty".to_string());
+    }
+
+    let candidate = std::path::Path::new(trimmed);
+    if !candidate.is_absolute() {
+        return Err("Workspace path must be absolute".to_string());
+    }
+
+    let metadata = std::fs::metadata(candidate)
+        .map_err(|err| format!("Unable to access workspace path: {err}"))?;
+    if !metadata.is_dir() {
+        return Err("Workspace path is not a directory".to_string());
+    }
+
+    candidate
+        .canonicalize()
+        .map(|path| path.to_string_lossy().into_owned())
+        .map_err(|err| format!("Unable to resolve workspace path: {err}"))
+}
+
 /// Check if a directory is a git repository (has .git subdirectory).
 #[tauri::command]
 pub async fn server_check_is_git_repo(path: String) -> Result<bool, String> {

--- a/src-tauri/src/commands/handler_list.inc
+++ b/src-tauri/src/commands/handler_list.inc
@@ -527,6 +527,7 @@ git::repos::server_check_github_visibility,
 git::repos::server_create_empty_repo,
 git::repos::server_import_folder,
 git::repos::server_create_folder,
+git::repos::server_validate_workspace_path,
 git::repos::server_check_is_git_repo,
 // Workspace preset commands
 git::repos::server_list_workspaces,

--- a/src/api/tauri/repo/index.ts
+++ b/src/api/tauri/repo/index.ts
@@ -258,6 +258,10 @@ export async function detectIDEs() {
 /**
  * Check if a directory is a git repository (has .git subdirectory).
  */
+export async function validateWorkspacePath(path: string): Promise<string> {
+  return invokeTauri<string>("server_validate_workspace_path", { path });
+}
+
 export async function checkIsGitRepo(path: string): Promise<boolean> {
   return invokeTauri<boolean>("server_check_is_git_repo", { path });
 }
@@ -281,6 +285,7 @@ export const repoApi = {
   createWorkFolder,
 
   // Detection
+  validateWorkspacePath,
   checkIsGitRepo,
 
   // Delete Repository

--- a/src/scaffold/GlobalSpotlight/palettes/WorkspacePalette/pathImport.test.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/WorkspacePalette/pathImport.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { repoApi } from "@src/api/tauri/repo";
+
+import { importWorkspacePath } from "./pathImport";
+
+vi.mock("@tauri-apps/api/path", () => ({ homeDir: vi.fn() }));
+vi.mock("@tauri-apps/plugin-dialog", () => ({ message: vi.fn() }));
+vi.mock("@src/api/tauri/repo", () => ({
+  repoApi: { validateWorkspacePath: vi.fn() },
+}));
+
+const validateWorkspacePath = vi.mocked(repoApi.validateWorkspacePath);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("importWorkspacePath", () => {
+  it("validates pasted paths through the backend and imports the canonical path", async () => {
+    validateWorkspacePath.mockResolvedValue("/canonical/repo");
+    const onImportWorkspace = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      importWorkspacePath({
+        candidatePath: "  /workspace/repo  ",
+        invalidPathTitle: "Invalid path",
+        invalidPathMessage: (path) => `Invalid: ${path}`,
+        onImportWorkspace,
+      })
+    ).resolves.toBe(true);
+
+    expect(validateWorkspacePath).toHaveBeenCalledWith("/workspace/repo");
+    expect(onImportWorkspace).toHaveBeenCalledWith("/canonical/repo");
+  });
+
+  it("reports a backend validation failure as an invalid path", async () => {
+    validateWorkspacePath.mockRejectedValue(new Error("not a directory"));
+    const onImportWorkspace = vi.fn();
+
+    await expect(
+      importWorkspacePath({
+        candidatePath: "/workspace/missing",
+        invalidPathTitle: "Invalid path",
+        invalidPathMessage: (path) => `Invalid: ${path}`,
+        onImportWorkspace,
+      })
+    ).resolves.toBe(true);
+
+    expect(onImportWorkspace).not.toHaveBeenCalled();
+  });
+});

--- a/src/scaffold/GlobalSpotlight/palettes/WorkspacePalette/pathImport.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/WorkspacePalette/pathImport.ts
@@ -1,6 +1,7 @@
 import { homeDir } from "@tauri-apps/api/path";
 import { message as showTauriMessage } from "@tauri-apps/plugin-dialog";
-import { stat } from "@tauri-apps/plugin-fs";
+
+import { repoApi } from "@src/api/tauri/repo";
 
 const ABSOLUTE_PATH_PATTERN = /^(?:~\/|\/|[A-Za-z]:[\\/])/;
 
@@ -57,16 +58,8 @@ export async function importWorkspacePath({
 
   try {
     const expandedPath = await expandHomePath(workspacePath);
-    const metadata = await stat(expandedPath);
-    if (!metadata.isDirectory) {
-      await showInvalidWorkspacePathDialog(
-        invalidPathTitle,
-        invalidPathMessage(workspacePath)
-      );
-      return true;
-    }
-
-    await onImportWorkspace(expandedPath);
+    const validatedPath = await repoApi.validateWorkspacePath(expandedPath);
+    await onImportWorkspace(validatedPath);
     return true;
   } catch {
     await showInvalidWorkspacePathDialog(


### PR DESCRIPTION
## Summary
- validate pasted workspace directories in the Rust backend instead of the Tauri frontend FS plugin
- import the canonical validated path
- add focused coverage for pasted-path validation and failure handling

## Root cause
Paths selected through the native folder dialog receive a runtime filesystem scope grant. Equivalent paths entered directly do not, so frontend `plugin-fs.stat()` rejected valid pasted directories and reported them as invalid.

## Validation
- `pnpm exec vitest run src/scaffold/GlobalSpotlight/palettes/WorkspacePalette/pathImport.test.ts`
- `pnpm run typecheck`
- `cargo check --manifest-path src-tauri/Cargo.toml -p git` (Docker Linux build image)
- `pnpm run tauri:build:fast -- --skip-frontend` (Docker Linux build image; produced `ORG2_1.2.6_amd64.deb`)
