### PR TITLE
fix(react): correct effect dependency lifecycles

### DIFF
--- a/src/api/realtime/websocket/WSProvider.test.ts
+++ b/src/api/realtime/websocket/WSProvider.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment jsdom
+import { act, createElement, useEffect } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import {
+  type WSContextValue,
+  WSProvider,
+  type WSProviderProps,
+  useWSClient,
+} from "./WSProvider";
+
+const mocks = vi.hoisted(() => ({
+  destroyWSClient: vi.fn(),
+  initWSClient: vi.fn(),
+}));
+
+vi.mock("./client", () => ({
+  OrgiiaiWSClient: class OrgiiaiWSClient {},
+  destroyWSClient: mocks.destroyWSClient,
+  initWSClient: mocks.initWSClient,
+}));
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+function createClient() {
+  return {
+    connect: vi.fn(() => Promise.resolve()),
+    disconnect: vi.fn(),
+    on: vi.fn(() => vi.fn()),
+  };
+}
+
+describe("WSProvider lifecycle", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let latest: WSContextValue | null;
+
+  beforeAll(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    latest = null;
+    mocks.initWSClient.mockImplementation(() => createClient());
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(reactActEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  const Capture = () => {
+    const value = useWSClient();
+    useEffect(() => {
+      latest = value;
+    }, [value]);
+    return null;
+  };
+
+  async function render(options: { pingInterval?: number }) {
+    await act(async () => {
+      root.render(
+        createElement(
+          WSProvider,
+          {
+            serverUrl: "ws://example.test/api/ws",
+            sessionId: "session-1",
+            autoConnect: false,
+            options,
+          } as WSProviderProps,
+          createElement(Capture)
+        )
+      );
+      await Promise.resolve();
+    });
+  }
+
+  it("keeps the connection for equivalent option objects and rebuilds for option changes", async () => {
+    await render({ pingInterval: 1_000 });
+    const firstClient = mocks.initWSClient.mock.results[0]?.value;
+
+    expect(mocks.initWSClient).toHaveBeenCalledTimes(1);
+    expect(mocks.initWSClient).toHaveBeenLastCalledWith(
+      "ws://example.test/api/ws",
+      "session-1",
+      { debug: false, pingInterval: 1_000 }
+    );
+    expect(latest?.client).toBe(firstClient);
+
+    await render({ pingInterval: 1_000 });
+    expect(mocks.initWSClient).toHaveBeenCalledTimes(1);
+    expect(mocks.destroyWSClient).not.toHaveBeenCalled();
+
+    await render({ pingInterval: 2_000 });
+    expect(mocks.destroyWSClient).toHaveBeenCalledTimes(1);
+    expect(mocks.initWSClient).toHaveBeenCalledTimes(2);
+    expect(mocks.initWSClient).toHaveBeenLastCalledWith(
+      "ws://example.test/api/ws",
+      "session-1",
+      { debug: false, pingInterval: 2_000 }
+    );
+  });
+
+  it("does not pass undefined values that would overwrite client defaults", async () => {
+    await render({ pingInterval: undefined });
+
+    expect(mocks.initWSClient).toHaveBeenCalledWith(
+      "ws://example.test/api/ws",
+      "session-1",
+      { debug: false }
+    );
+  });
+});

--- a/src/api/realtime/websocket/WSProvider.tsx
+++ b/src/api/realtime/websocket/WSProvider.tsx
@@ -55,6 +55,15 @@ export const WSProvider: React.FC<WSProviderProps> = ({
   const [error, setError] = useState<string | null>(null);
   // Use state for client so context value updates when client is created
   const [client, setClient] = useState<OrgiiaiWSClient | null>(null);
+  const {
+    pingInterval,
+    maxReconnectAttempts,
+    initialReconnectDelay,
+    maxReconnectDelay,
+    debug,
+    startFrom,
+    onBeforeReconnect,
+  } = options ?? {};
 
   // Track which (serverUrl, sessionId) pair we've initialized.
   // IMPORTANT: must allow re-initialization when switching sessions.
@@ -71,11 +80,26 @@ export const WSProvider: React.FC<WSProviderProps> = ({
     }
     initializedKeyRef.current = key;
 
-    const wsClient = initWSClient(serverUrl, sessionId, {
-      debug: process.env.NODE_ENV === "development",
-      ...options,
-    });
+    const clientOptions: OrgiiaiWSClientOptions = {
+      debug: debug ?? process.env.NODE_ENV === "development",
+    };
+    if (pingInterval !== undefined) clientOptions.pingInterval = pingInterval;
+    if (maxReconnectAttempts !== undefined) {
+      clientOptions.maxReconnectAttempts = maxReconnectAttempts;
+    }
+    if (initialReconnectDelay !== undefined) {
+      clientOptions.initialReconnectDelay = initialReconnectDelay;
+    }
+    if (maxReconnectDelay !== undefined) {
+      clientOptions.maxReconnectDelay = maxReconnectDelay;
+    }
+    if (startFrom !== undefined) clientOptions.startFrom = startFrom;
+    if (onBeforeReconnect !== undefined) {
+      clientOptions.onBeforeReconnect = onBeforeReconnect;
+    }
+    const wsClient = initWSClient(serverUrl, sessionId, clientOptions);
     // Update state so context value re-computes with the client
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- the externally-owned WebSocket instance only exists after this lifecycle effect creates it; context consumers must receive that exact disposable instance
     setClient(wsClient);
 
     const unsubConnected = wsClient.on("connected", () => {
@@ -108,8 +132,18 @@ export const WSProvider: React.FC<WSProviderProps> = ({
       setConnected(false);
       setError(null);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [serverUrl, sessionId, autoConnect]);
+  }, [
+    serverUrl,
+    sessionId,
+    autoConnect,
+    pingInterval,
+    maxReconnectAttempts,
+    initialReconnectDelay,
+    maxReconnectDelay,
+    debug,
+    startFrom,
+    onBeforeReconnect,
+  ]);
 
   const connect = useCallback(async () => {
     if (client) {

--- a/src/components/ComposerInput/composerInput.nativeEvents.ts
+++ b/src/components/ComposerInput/composerInput.nativeEvents.ts
@@ -49,6 +49,13 @@ export function useComposerNativeEvents({
   redoAndNotify,
   updateCoveredPillSelection,
 }: UseComposerNativeEventsParams): void {
+  const {
+    markHistoryBoundary,
+    commitHistoryBoundary,
+    reconcilePillsFromDom,
+    insertTextAtCaret,
+  } = ops;
+
   useEffect(() => {
     const host = hostRef.current;
     if (!host) return;
@@ -77,15 +84,15 @@ export function useComposerNativeEvents({
         return;
       }
 
-      ops.markHistoryBoundary();
+      markHistoryBoundary();
       if (event.inputType.startsWith("deleteContent")) {
         const direction = event.inputType.endsWith("Forward")
           ? "forward"
           : "backward";
         if (removePillForDeleteDirection(host, direction, false)) {
           event.preventDefault();
-          ops.reconcilePillsFromDom();
-          ops.commitHistoryBoundary();
+          reconcilePillsFromDom();
+          commitHistoryBoundary();
           handleInput();
           return;
         }
@@ -94,16 +101,16 @@ export function useComposerNativeEvents({
         const sanitized = sanitizeText(event.data);
         if (sanitized !== event.data) {
           event.preventDefault();
-          if (sanitized) ops.insertTextAtCaret(sanitized);
-          ops.commitHistoryBoundary();
+          if (sanitized) insertTextAtCaret(sanitized);
+          commitHistoryBoundary();
           handleInput();
         }
       }
     };
     const handlePasteEvent = (event: ClipboardEvent) => {
-      ops.markHistoryBoundary();
+      markHistoryBoundary();
       if (handlePaste(event)) {
-        ops.commitHistoryBoundary();
+        commitHistoryBoundary();
         handleInput();
       }
     };
@@ -114,9 +121,9 @@ export function useComposerNativeEvents({
       // also insert the file name/path as raw text would corrupt the editor
       // and, in certain timing windows, produce an empty conversation round.
       event.preventDefault();
-      ops.markHistoryBoundary();
+      markHistoryBoundary();
       if (handleDrop(event)) {
-        ops.commitHistoryBoundary();
+        commitHistoryBoundary();
         handleInput();
       }
     };
@@ -167,11 +174,14 @@ export function useComposerNativeEvents({
         updateCoveredPillSelection
       );
     };
-    // ops is stable (object from useEditorOperations never changes identity).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     hostRef,
-    ops.insertTextAtCaret,
+    isComposingRef,
+    compositionEndedAtRef,
+    markHistoryBoundary,
+    commitHistoryBoundary,
+    reconcilePillsFromDom,
+    insertTextAtCaret,
     handlePaste,
     handleDrop,
     handleCut,

--- a/src/components/ComposerInput/index.tsx
+++ b/src/components/ComposerInput/index.tsx
@@ -241,8 +241,7 @@ const ComposerInput = forwardRef<ComposerInputRef, ComposerInputProps>(
             if (host) onContentChangeRef.current?.(extractPlainText(host));
           },
         }),
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [ops]
+      [hostRef, ops, updateEmptyState]
     );
 
     const handleCut = useMemo(
@@ -251,8 +250,6 @@ const ComposerInput = forwardRef<ComposerInputRef, ComposerInputProps>(
           reconcilePillsFromDom: ops.reconcilePillsFromDom,
           onAfterCut: handleInput,
         }),
-      // handleInput is stable (useCallback with stable deps); ops is stable.
-      // eslint-disable-next-line react-hooks/exhaustive-deps
       [ops.reconcilePillsFromDom, handleInput]
     );
 
@@ -360,17 +357,14 @@ const ComposerInput = forwardRef<ComposerInputRef, ComposerInputProps>(
         const host = hostRef.current;
         if (host) placeCaretAtEnd(host);
       }
-      // Only on mount — `setContent` covers later programmatic updates.
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- initialContent is mount-owned editor seed data; later changes must use the imperative setContent path so an ordinary parent render cannot overwrite user edits
     }, []);
 
     useEffect(() => {
       if (!autoFocus) return;
       const host = hostRef.current;
       if (host) placeCaretAtEnd(host);
-      // hostRef is a stable React ref — listing it would cause spurious re-runs.
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [autoFocus]);
+    }, [autoFocus, hostRef]);
 
     // ===== Imperative handle =====
     useImperativeHandle(
@@ -510,8 +504,7 @@ const ComposerInput = forwardRef<ComposerInputRef, ComposerInputProps>(
             placeCaretAtTextOffset(host, startOffset);
           },
         }),
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [ops, updateEmptyState]
+      [hostRef, ops, resetMentionState, updateEmptyState]
     );
 
     // ===== Pill portal targets =====

--- a/src/components/FileTreeContent/InlineRenameInput.tsx
+++ b/src/components/FileTreeContent/InlineRenameInput.tsx
@@ -104,8 +104,7 @@ export function InlineRenameInput({
     } else {
       applySelection(input, initialName, "basename");
     }
-    // Only run on mount - use initialName for initial selection
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- rename identity is mount-owned; a different file remounts this editor, and reselection mid-edit would discard the user's range
   }, []);
 
   const handleChange = useCallback(

--- a/src/components/System/RepoLoader.tsx
+++ b/src/components/System/RepoLoader.tsx
@@ -181,8 +181,7 @@ export const RepoLoader: FC = () => {
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentRepo, dispatchSetFolders]);
+  }, [currentRepo, activeWorkspaceId, dispatchSetFolders, setSavedWorkspaces]);
 
   useRecentFolderEvents({
     repos,

--- a/src/components/TerminalInteractive/index.tsx
+++ b/src/components/TerminalInteractive/index.tsx
@@ -28,7 +28,6 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
-  useMemo,
   useRef,
   useState,
 } from "react";
@@ -42,7 +41,6 @@ import {
 // Direct leaf import to avoid pulling @src/store's barrel — which transitively
 // reaches SidebarModules/Terminal → engines/TerminalCore → this file.
 import {
-  TerminalThemeName,
   terminalFontSizeAtom,
   terminalLetterSpacingAtom,
   terminalThemeAtom,
@@ -111,13 +109,17 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
     const sessionIdRef = useRef<string | null>(null);
     const unlistenOutputRef = useRef<(() => void) | null>(null);
     const unlistenExitRef = useRef<(() => void) | null>(null);
-    const initialThemeRef = useRef<TerminalThemeName | null>(null);
     const repoPathRef = useRef(repoPath);
-    repoPathRef.current = repoPath;
     const workingDirectoryRef = useRef(workingDirectory);
-    workingDirectoryRef.current = workingDirectory;
     const onOpenFileLinkRef = useRef(onOpenFileLink);
-    onOpenFileLinkRef.current = onOpenFileLink;
+    const onSessionInfoReadyRef = useRef(onSessionInfoReady);
+    const eventCallbacksRef = useRef({
+      onOutput,
+      onUserInput,
+      onSelectionChange,
+      onTitleChange,
+    });
+    const shellIntegrationRef = useRef(shellIntegration);
 
     const [_isConnecting, setIsConnecting] = useState(true);
     const [_isBrowserMode, setIsBrowserMode] = useState(false);
@@ -131,29 +133,54 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
     const appTheme = useAtomValue(themesAtom);
     const isDarkTheme = isThemeCssPathDark(appTheme);
 
-    if (initialThemeRef.current === null) {
-      initialThemeRef.current = terminalTheme;
-    }
+    const initialAppearanceRef = useRef({
+      terminalTheme,
+      terminalFontSize,
+      terminalLetterSpacing,
+      codeFontFamily,
+      backgroundColor,
+    });
+    const shellIntegrationEnabled = shellIntegration !== undefined;
 
-    const redrawTerminalAfterLayoutChange = useMemo(
-      () =>
-        createRedrawTerminalAfterLayoutChange({
-          containerRef,
-          terminalRef,
-          fitAddonRef,
-        }),
-      []
-    );
+    useEffect(() => {
+      repoPathRef.current = repoPath;
+      workingDirectoryRef.current = workingDirectory;
+      onOpenFileLinkRef.current = onOpenFileLink;
+      onSessionInfoReadyRef.current = onSessionInfoReady;
+      eventCallbacksRef.current = {
+        onOutput,
+        onUserInput,
+        onSelectionChange,
+        onTitleChange,
+      };
+      shellIntegrationRef.current = shellIntegration;
+    }, [
+      repoPath,
+      workingDirectory,
+      onOpenFileLink,
+      onSessionInfoReady,
+      onOutput,
+      onUserInput,
+      onSelectionChange,
+      onTitleChange,
+      shellIntegration,
+    ]);
 
-    const fitTerminal = useMemo(
-      () =>
-        createFitTerminal({
-          containerRef,
-          terminalRef,
-          fitAddonRef,
-        }),
-      []
-    );
+    const redrawTerminalAfterLayoutChange = useCallback(() => {
+      createRedrawTerminalAfterLayoutChange({
+        containerRef,
+        terminalRef,
+        fitAddonRef,
+      })();
+    }, []);
+
+    const fitTerminal = useCallback(() => {
+      createFitTerminal({
+        containerRef,
+        terminalRef,
+        fitAddonRef,
+      })();
+    }, []);
 
     useImperativeHandle(
       ref,
@@ -207,15 +234,12 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
           envOverride,
           forceRepoCwd,
           nameOverride,
-          onSessionInfoReady,
+          onSessionInfoReady: (info) => onSessionInfoReadyRef.current?.(info),
           setIsBrowserMode,
           setIsConnecting,
           abortSignal,
         });
       },
-      // repoPath and onSessionInfoReady use refs / mount-time semantics; avoid
-      // reinitializing xterm for parent callback identity changes.
-      // eslint-disable-next-line react-hooks/exhaustive-deps
       [
         sessionKey,
         isForeground,
@@ -233,14 +257,26 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
       if (!containerRef.current || terminalRef.current) return;
 
       const ptyAbortController = new AbortController();
+      const initialAppearance = initialAppearanceRef.current;
       const { terminal, fitAddon, searchAddon, serializeAddon } =
         createTerminalInstance({
-          terminalTheme: initialThemeRef.current || terminalTheme,
-          terminalFontSize,
-          terminalLetterSpacing,
-          codeFontFamily,
-          backgroundColor,
-          shellIntegration,
+          terminalTheme: initialAppearance.terminalTheme,
+          terminalFontSize: initialAppearance.terminalFontSize,
+          terminalLetterSpacing: initialAppearance.terminalLetterSpacing,
+          codeFontFamily: initialAppearance.codeFontFamily,
+          backgroundColor: initialAppearance.backgroundColor,
+          shellIntegration: shellIntegrationEnabled
+            ? {
+                onPromptStart: () =>
+                  shellIntegrationRef.current?.onPromptStart?.(),
+                onCommandExecuted: (commandLine) =>
+                  shellIntegrationRef.current?.onCommandExecuted?.(commandLine),
+                onCommandFinished: (exitCode) =>
+                  shellIntegrationRef.current?.onCommandFinished?.(exitCode),
+                onCwdChanged: (cwd) =>
+                  shellIntegrationRef.current?.onCwdChanged?.(cwd),
+              }
+            : undefined,
         });
 
       terminal.open(containerRef.current);
@@ -269,10 +305,12 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
         repoPathRef,
         workingDirectoryRef,
         onOpenFileLinkRef,
-        onOutput,
-        onUserInput,
-        onSelectionChange,
-        onTitleChange,
+        onOutput: () => eventCallbacksRef.current.onOutput?.(),
+        onUserInput: () => eventCallbacksRef.current.onUserInput?.(),
+        onSelectionChange: (selection) =>
+          eventCallbacksRef.current.onSelectionChange?.(selection),
+        onTitleChange: (title) =>
+          eventCallbacksRef.current.onTitleChange?.(title),
       });
 
       return () => {
@@ -296,10 +334,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
         searchAddonRef.current = null;
         serializeAddonRef.current = null;
       };
-      // Theme and callback props are intentionally omitted to preserve the
-      // existing terminal lifetime semantics documented at the top of this file.
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [fitTerminal, initPTY]);
+    }, [fitTerminal, initPTY, shellIntegrationEnabled]);
 
     // Scheduler foreground/background priority and tab-show backlog flush.
     // The sessionId is set during initPtyConnection which runs after mount;

--- a/src/components/TreeRow/VirtualizedListBase.tsx
+++ b/src/components/TreeRow/VirtualizedListBase.tsx
@@ -261,8 +261,7 @@ function VirtualizedListBaseInner<T>(
         isRestoringScrollRef.current = false;
       }, 50);
     });
-    // Only run on mount - initialScrollTop shouldn't change after
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- initialScrollTop is a mount-time restoration snapshot; later scroll ownership lives in lastScrollTopRef
   }, []);
 
   // SCROLL PRESERVATION: After any render, check if scroll was reset and restore

--- a/src/components/XtermOutput/index.tsx
+++ b/src/components/XtermOutput/index.tsx
@@ -183,7 +183,7 @@ const XtermOutput = memo(function XtermOutput({
       fitAddonRef.current = null;
       contentWrittenRef.current = "";
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: only runs on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- this effect owns one xterm instance; following effects patch content/theme/font changes without destroying its renderer or WebGL slot
   }, []);
 
   // Write new content when prop changes

--- a/src/engines/ChatPanel/panels/CloudOrgPanelView/useCloudOrgPanelState.ts
+++ b/src/engines/ChatPanel/panels/CloudOrgPanelView/useCloudOrgPanelState.ts
@@ -112,14 +112,13 @@ export function useCloudOrgPanelState(orgId: string) {
   const [draftScopes, setDraftScopes] = useState<string[]>(savedScopes);
 
   useEffect(() => {
-    setDraftScopes(repoScopesByOrg[orgId] ?? []);
+    setDraftScopes(store.get(org2CloudRepoScopesAtom)[orgId] ?? []);
     setScopeState(null);
     setScopesSaved(false);
     setScopesError(null);
     // The org id intentionally owns draft reseeding; atom hydration should
     // not overwrite an admin's in-flight edits.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [orgId]);
+  }, [orgId, store]);
 
   const scopesDirty = useMemo(
     () =>
@@ -244,8 +243,7 @@ export function useCloudOrgPanelState(orgId: string) {
   useEffect(() => {
     observedRosterVersionRef.current = rosterVersion;
     observedMembersRecoveryVersionRef.current = membersRecoveryVersion;
-    // A normal roster bump must reach the member-only fetch below.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- org switches snapshot the current counters; subsequent counter changes are consumed by the member-only fetch effect below
   }, [orgId]);
   useEffect(() => {
     if (!signedIn) return;

--- a/src/engines/SessionCore/core/store/hooks.ts
+++ b/src/engines/SessionCore/core/store/hooks.ts
@@ -47,6 +47,6 @@ export function useEventStoreSelector<T>(
 
     prevRef.current = { value: nextValue, version };
     return nextValue;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- event-store version is the selector clock; callback identity changes must not bypass equality or recompute without a store update
   }, [events, version]);
 }

--- a/src/engines/Simulator/components/CompactEventView/index.tsx
+++ b/src/engines/Simulator/components/CompactEventView/index.tsx
@@ -32,14 +32,14 @@ const CompactEventViewComponent: React.FC<CompactEventViewProps> = ({
 }) => {
   const { t } = useTranslation("sessions");
   const contentRef = useRef<HTMLDivElement>(null);
+  const eventId = event?.id;
 
   // Reset scroll when event changes
   useEffect(() => {
-    if (autoScroll && event) {
+    if (autoScroll && eventId) {
       contentRef.current?.scrollTo({ top: 0, behavior: "smooth" });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [event?.id, autoScroll]);
+  }, [eventId, autoScroll]);
 
   // Continuous auto-scroll during playback
   useEffect(() => {

--- a/src/features/CodeMirror/Diff/index.tsx
+++ b/src/features/CodeMirror/Diff/index.tsx
@@ -399,9 +399,7 @@ export const CodeMirrorDiff: React.FC<CodeMirrorDiffProps> = ({
       unifiedViewRef.current = null;
       unifiedContentRef.current = null;
     };
-    // `unifiedMergeView` binds the original side at construction. Modified
-    // content is updated by the effect below without destroying the editor.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- unified original/config inputs rebuild the editor; newValue is patched by the next effect, and every buildBaseExtensions input is listed explicitly
   }, [
     viewMode,
     oldValue,
@@ -510,7 +508,7 @@ export const CodeMirrorDiff: React.FC<CodeMirrorDiffProps> = ({
       splitMergeViewRef.current = null;
       splitContentRef.current = null;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- split configuration rebuilds the editor; old/new documents are patched by the next effect, and every buildBaseExtensions input is listed explicitly
   }, [
     viewMode,
     oldStartLine,

--- a/src/features/Org2Cloud/CloudSessionReferencePreview.tsx
+++ b/src/features/Org2Cloud/CloudSessionReferencePreview.tsx
@@ -59,7 +59,7 @@ export const CloudSessionReferencePreview = memo(
     // is unchanged. Keying this memo on the content key returns the array
     // captured when the key last changed, so unchanged chips skip
     // re-rendering while the user types around them.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- scannedKey encodes every reference field rendered by the chips, preserving array identity while that semantic set is unchanged
     const references = useMemo(() => scanned, [scannedKey]);
     if (references.length === 0) return null;
     return (

--- a/src/features/Org2Cloud/CloudSessionShareDialog/useCloudSessionShareDialog.ts
+++ b/src/features/Org2Cloud/CloudSessionShareDialog/useCloudSessionShareDialog.ts
@@ -79,8 +79,7 @@ export function useCloudSessionShareDialog(): UseCloudSessionShareDialogResult {
         repoScopesByOrg,
         getSessionScopeKeys(session)
       ),
-    // scopeKeyVersion is the cache's change signal, not an input value.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- scopeKeyVersion invalidates the module cache read inside getSessionScopeKeys; it is a signal, not a direct function input
     [
       activeCloudOrgId,
       cloudOrgs,

--- a/src/features/Org2Cloud/SessionConversation/conversationPlaneAtom.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationPlaneAtom.ts
@@ -4,7 +4,7 @@
  * server-assigned seq cursor. Capability-gated — a pre-0024 backend leaves
  * every entry "unsupported" and the fork-wire fallback stays in charge.
  */
-import { atom, useAtomValue, useSetAtom } from "jotai";
+import { atom, useAtomValue, useSetAtom, useStore } from "jotai";
 import { useEffect } from "react";
 
 import { createLogger } from "@src/hooks/logger";
@@ -85,20 +85,24 @@ export function useConversationPlaneEvents(
   target: SessionCommentTarget | null
 ): ConversationPlaneEntry {
   const auth = useAtomValue(org2CloudAuthAtom);
+  const store = useStore();
   const setAuth = useSetAtom(org2CloudAuthAtom);
   const entries = useAtomValue(conversationPlaneAtom);
   const setEntries = useSetAtom(conversationPlaneAtom);
   const signals = useAtomValue(conversationPlaneSignalAtom);
-  const signal = target ? (signals[target.orgId] ?? 0) : 0;
-  const key = target
-    ? conversationPlaneKey(target.orgId, target.sessionId)
-    : null;
+  const targetOrgId = target?.orgId;
+  const targetSessionId = target?.sessionId;
+  const signal = targetOrgId ? (signals[targetOrgId] ?? 0) : 0;
+  const key =
+    targetOrgId && targetSessionId
+      ? conversationPlaneKey(targetOrgId, targetSessionId)
+      : null;
   const entry = key ? (entries[key] ?? EMPTY_ENTRY) : EMPTY_ENTRY;
-  const lastSeq = entry.lastSeq;
-  const entryState = entry.state;
 
   useEffect(() => {
-    if (!target || !key || !auth) return;
+    if (!targetOrgId || !targetSessionId || !key || !auth) return;
+    const currentEntry = store.get(conversationPlaneAtom)[key] ?? EMPTY_ENTRY;
+    const entryState = currentEntry.state;
     if (entryState === "unsupported") return;
     if (inFlightByKey.has(key)) return;
     inFlightByKey.add(key);
@@ -117,11 +121,11 @@ export function useConversationPlaneEvents(
           }
           return;
         }
-        let afterSeq = lastSeq;
+        let afterSeq = currentEntry.lastSeq;
         for (;;) {
           const page = await listConversationEvents(fresh.accessToken, {
-            orgId: target.orgId,
-            rootSessionId: target.sessionId,
+            orgId: targetOrgId,
+            rootSessionId: targetSessionId,
             afterSeq,
           });
           setEntries((current) => {
@@ -145,17 +149,15 @@ export function useConversationPlaneEvents(
         inFlightByKey.delete(key);
       }
     })();
-    // lastSeq intentionally NOT a dep: each completed fetch updates it and
-    // would re-run the effect in a loop; `signal` is the refetch clock.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    target?.orgId,
-    target?.sessionId,
+    targetOrgId,
+    targetSessionId,
     key,
     auth,
     setAuth,
     setEntries,
     signal,
+    store,
   ]);
 
   return entry;

--- a/src/features/Org2Cloud/useOrg2CloudRealtime.ts
+++ b/src/features/Org2Cloud/useOrg2CloudRealtime.ts
@@ -371,6 +371,7 @@ export function useOrg2CloudRealtime(): void {
   const [broadcastSignals, setBroadcastSignals] = useState(false);
   useEffect(() => {
     let cancelled = false;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- clear the previous identity/endpoint capability before the asynchronous probe can publish a result
     setBroadcastSignals(false);
     const current = authRef.current;
     if (!userId || !current) return undefined;
@@ -463,7 +464,6 @@ export function useOrg2CloudRealtime(): void {
       connectionTeardownAtRef.current = Date.now();
     };
     // authRef (not auth) on purpose — see the ref comment above.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userId, endpointUrl, activeRealtimeOrgId]);
 
   // --- Nudge the socket to re-resolve its token as soon as the atom
@@ -817,7 +817,6 @@ export function useOrg2CloudRealtime(): void {
       }
     };
     // Connection identity follows the same activeRealtimeOrgId key in Slice A.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     activeRealtimeOrgId,
     userId,
@@ -826,6 +825,7 @@ export function useOrg2CloudRealtime(): void {
     bumpRosterVersion,
     scheduleCoarseSignalRefresh,
     runSignalEdgeRecovery,
+    setRosterRealtimeConnected,
   ]);
 
   // --- Slice C: org-level presence for the actively-used org only.
@@ -864,7 +864,9 @@ export function useOrg2CloudRealtime(): void {
     userId,
   ]);
   const viewingRef = useRef(viewing);
-  viewingRef.current = viewing;
+  useEffect(() => {
+    viewingRef.current = viewing;
+  }, [viewing]);
 
   const presenceHandlesRef = useRef(new Map<string, Org2CloudPresenceHandle>());
   const presencePayloadKeysRef = useRef(new Map<string, string | null>());
@@ -1046,7 +1048,6 @@ export function useOrg2CloudRealtime(): void {
       payloadKeys.clear();
     };
     // Same lifetime contract as Slice B (connection identity via Slice A).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     activeRealtimeOrgId,
     userId,
@@ -1062,6 +1063,8 @@ export function useOrg2CloudRealtime(): void {
     dispatchDbChangeSignal,
     scheduleCoarseSignalRefresh,
     runSignalEdgeRecovery,
+    refreshEntitlementForOrg,
+    setRosterRealtimeConnected,
   ]);
 
   // Keep awareness attached to the session while this foreground lease owns

--- a/src/features/PokerTable/PokerTableWindow.tsx
+++ b/src/features/PokerTable/PokerTableWindow.tsx
@@ -60,8 +60,7 @@ const PokerTableWindow: React.FC = () => {
       kind: "human",
       avatarHue: 212,
     }),
-    // The hero identity is fixed for the life of the table.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- the controller owns one immutable hero identity for the table lifetime; profile or locale changes apply only after reopening
     []
   );
 

--- a/src/features/SessionSetup/hooks/useEmbeddedWebview.ts
+++ b/src/features/SessionSetup/hooks/useEmbeddedWebview.ts
@@ -66,20 +66,21 @@ export interface UseEmbeddedWebviewReturn {
 }
 
 const INSET = 2;
+const EMPTY_CREATE_ARGS: Record<string, unknown> = {};
 
 export function useEmbeddedWebview({
   labelPrefix,
   containerRef,
   commands,
   debug = false,
-  extraCreateArgs = {},
+  extraCreateArgs = EMPTY_CREATE_ARGS,
   ignoreAboutBlank = false,
 }: UseEmbeddedWebviewOptions): UseEmbeddedWebviewReturn {
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [currentUrl, setCurrentUrl] = useState("");
 
-  const labelRef = useRef(`${labelPrefix}-${uuidv4()}`);
+  const [label] = useState(() => `${labelPrefix}-${uuidv4()}`);
   const urlListenerRef = useRef<UnlistenFn | null>(null);
 
   const log = useCallback(
@@ -113,7 +114,7 @@ export function useEmbeddedWebview({
         const frame = toNativeFrame(rect, INSET);
         await invoke(commands.create, {
           parentWindow: appWindow.label,
-          label: labelRef.current,
+          label,
           ...frame,
           ...(url ? { url } : {}),
           ...extraCreateArgs,
@@ -128,21 +129,19 @@ export function useEmbeddedWebview({
         throw err;
       }
     },
-    // extraCreateArgs intentionally excluded — callers should memoize it or pass a stable ref
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [containerRef, commands.create, log]
+    [containerRef, commands.create, extraCreateArgs, label, log]
   );
 
   const closeWebview = useCallback(async () => {
     try {
-      await invoke(commands.close, { label: labelRef.current });
+      await invoke(commands.close, { label });
       setIsOpen(false);
       setCurrentUrl("");
       log("Webview closed");
     } catch (err) {
       log("Failed to close webview:", err);
     }
-  }, [commands.close, log]);
+  }, [commands.close, label, log]);
 
   const updatePosition = useCallback(async () => {
     if (!isOpen || !containerRef?.current) return;
@@ -154,17 +153,17 @@ export function useEmbeddedWebview({
       const frame = toNativeFrame(rect, INSET);
       if (commands.updatePosition) {
         await invoke(commands.updatePosition, {
-          label: labelRef.current,
+          label,
           ...frame,
         });
       } else {
         // Close + recreate at new position
         const savedUrl = currentUrl;
-        await invoke(commands.close, { label: labelRef.current });
+        await invoke(commands.close, { label });
         const appWindow = getCurrentWindow();
         await invoke(commands.create, {
           parentWindow: appWindow.label,
-          label: labelRef.current,
+          label,
           url: savedUrl,
           ...frame,
           ...extraCreateArgs,
@@ -173,9 +172,7 @@ export function useEmbeddedWebview({
     } catch (err) {
       log("Failed to update position:", err);
     }
-    // extraCreateArgs intentionally excluded
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, containerRef, commands, currentUrl, log]);
+  }, [isOpen, containerRef, commands, currentUrl, extraCreateArgs, label, log]);
 
   // URL-change event listener
   useEffect(() => {
@@ -187,7 +184,7 @@ export function useEmbeddedWebview({
         (event) => {
           if (!isMounted) return;
           const { url, webviewLabel } = event.payload;
-          if (webviewLabel && webviewLabel !== labelRef.current) return;
+          if (webviewLabel && webviewLabel !== label) return;
           if (ignoreAboutBlank && url === "about:blank") return;
           setCurrentUrl(url);
           log("URL changed:", url);
@@ -203,7 +200,7 @@ export function useEmbeddedWebview({
       urlListenerRef.current?.();
       urlListenerRef.current = null;
     };
-  }, [commands.urlChangedEvent, ignoreAboutBlank, log]);
+  }, [commands.urlChangedEvent, ignoreAboutBlank, label, log]);
 
   // KeepAlive visibility observation — auto-close when the host container is
   // removed from layout. Do not use document.visibilityState here: macOS can
@@ -222,7 +219,7 @@ export function useEmbeddedWebview({
 
       if (isHidden && isOpen) {
         transitioning = true;
-        invoke(commands.close, { label: labelRef.current })
+        invoke(commands.close, { label })
           .catch(() => {})
           .finally(() => {
             transitioning = false;
@@ -250,23 +247,20 @@ export function useEmbeddedWebview({
       intersectionObserver.disconnect();
       resizeObserver.disconnect();
     };
-  }, [isOpen, containerRef, commands.close, currentUrl, openWebview]);
+  }, [isOpen, containerRef, commands.close, currentUrl, label, openWebview]);
 
   // Cleanup on unmount
   useEffect(() => {
-    const label = labelRef.current;
     return () => {
       invoke(commands.close, { label }).catch(() => {});
     };
-    // Only run on mount/unmount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [commands.close, label]);
 
   return {
     isOpen,
     isLoading,
     currentUrl,
-    label: labelRef.current,
+    label,
     openWebview,
     closeWebview,
     updatePosition,

--- a/src/hooks/async/useAsyncData.ts
+++ b/src/hooks/async/useAsyncData.ts
@@ -131,7 +131,7 @@ export function useAsyncData<T>(
     if (autoLoad && enabled) {
       refresh();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- callers explicitly own the refetch clock through deps; refresh stays current for manual calls without making fetcher identity an implicit trigger
   }, [autoLoad, enabled, ...deps]);
 
   return {

--- a/src/hooks/dom/useCallbackRefEffect.ts
+++ b/src/hooks/dom/useCallbackRefEffect.ts
@@ -267,7 +267,7 @@ export function useCallbackRefEffect<T extends Element>(
     // We don't return a cleanup here; the cleanup is owned by the
     // ref-callback lifecycle (which fires on element detach and on
     // unmount). Doing both would double-run the user cleanup.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- this hook intentionally forwards the caller-supplied dependency list and refreshes setup through CallbackRefEffectLifecycle
   }, deps);
 
   useEffect(() => {

--- a/src/hooks/git/useRepoSelection/useRepoLoader.ts
+++ b/src/hooks/git/useRepoSelection/useRepoLoader.ts
@@ -252,8 +252,7 @@ export function useRepoLoader(): UseRepoLoaderReturn {
       setLastUsedRepo(restoredRepo.id);
       setCachedRepos((prev) => updateCachedRepos(prev, restoredRepo));
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [repos.length]);
+  }, [repos, setSelectedRepoId, setLastUsedRepo, setCachedRepos]);
 
   return {
     repoLoading,

--- a/src/hooks/git/useRepoSelection/useRepoSelection.ts
+++ b/src/hooks/git/useRepoSelection/useRepoSelection.ts
@@ -162,6 +162,11 @@ export function useRepoSelection(
   // Store Tauri window label for cross-window tracking (resolved once on mount)
   const windowLabelRef = useRef<string | null>(null);
   const windowLabelResolvedRef = useRef(false);
+  const selectedRepoIdRef = useRef(selectedRepoId);
+
+  useEffect(() => {
+    selectedRepoIdRef.current = selectedRepoId;
+  }, [selectedRepoId]);
 
   // Resolve window label once on mount (static - never changes)
   useEffect(() => {
@@ -176,10 +181,9 @@ export function useRepoSelection(
         windowLabelRef.current = getWindowId();
       }
       // Register with the current repo after resolving
-      registerOpenedRepo(windowLabelRef.current, selectedRepoId);
+      registerOpenedRepo(windowLabelRef.current, selectedRepoIdRef.current);
     };
     resolveLabel();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Register repo changes (after label is resolved)
@@ -206,8 +210,7 @@ export function useRepoSelection(
   useEffect(() => {
     if (!selectedRepoId) return;
     loadCurrentBranchFast();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedRepoId]);
+  }, [selectedRepoId, loadCurrentBranchFast]);
 
   // Sync branch from the scoped current git status. The context only exposes a
   // status here after it has been confirmed to belong to the selected repo.

--- a/src/hooks/models/useResolvedModelLabel.ts
+++ b/src/hooks/models/useResolvedModelLabel.ts
@@ -60,11 +60,7 @@ export function useResolvedModelLabel(
       label: resolveModelDisplayLabel(sel, providers, fallback),
       title: resolveModelFullLabel(sel, fallback),
     };
-    // `aliasVersion` is read by the resolvers via the module-scope alias
-    // registry; include it as a dep so the labels recompute when the user
-    // edits an alias. eslint can't see the registry read, hence the
-    // intentional "unnecessary" dep.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- aliasVersion invalidates the module-scoped alias registry read performed inside the resolver helpers
   }, [selection, providers, fallback, aliasVersion]);
 }
 
@@ -83,6 +79,6 @@ export function useModelPillLabel(
       accountName: resolveModelPillAccountName(sel),
       displayParts,
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- aliasVersion invalidates the module-scoped alias registry read performed inside the resolver helpers
   }, [selection, fallback, aliasVersion]);
 }

--- a/src/hooks/platform/useDeepLinkHandler.ts
+++ b/src/hooks/platform/useDeepLinkHandler.ts
@@ -461,6 +461,7 @@ export function useDeepLinkHandler(): void {
     if (hasProcessedInitialDeepLink.current) {
       return;
     }
+    hasProcessedInitialDeepLink.current = true;
 
     const checkInitialDeepLink = async () => {
       if (!isTauriReady()) {
@@ -472,8 +473,6 @@ export function useDeepLinkHandler(): void {
         const initialUrls = await getCurrent();
 
         if (initialUrls && initialUrls.length > 0) {
-          hasProcessedInitialDeepLink.current = true;
-
           for (const url of initialUrls) {
             if (processedDeepLinks.current.has(url)) {
               continue;
@@ -568,8 +567,14 @@ export function useDeepLinkHandler(): void {
     };
 
     checkInitialDeepLink();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // Only run on mount, not on location change
+  }, [
+    navigate,
+    routeToCloudJoin,
+    routeToCloudSessionReference,
+    routeToCloudShare,
+    handleOrg2CloudAuthUrl,
+    handleBillingCompleteUrl,
+  ]);
 }
 
 export default useDeepLinkHandler;

--- a/src/hooks/ui/effects/useScrollToBottom.ts
+++ b/src/hooks/ui/effects/useScrollToBottom.ts
@@ -126,7 +126,7 @@ export function useScrollToBottom(
         scrollToBottom();
       });
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- callers explicitly provide the content-change clock; the remaining lifecycle inputs are appended here and scrollToBottom reads the current ref
   }, [...dependencies, enabled, forceScroll, scrollToBottom]);
 
   return {

--- a/src/modules/MainApp/AgentOrgs/config/customAgent/CustomAgentToolsSection.tsx
+++ b/src/modules/MainApp/AgentOrgs/config/customAgent/CustomAgentToolsSection.tsx
@@ -18,7 +18,7 @@
  *
  * Clicking a row expands inline details with description and commands.
  */
-import React, { useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import SettingsTable, {
@@ -220,37 +220,40 @@ const CustomAgentToolsSection: React.FC<CustomAgentToolsSectionProps> = ({
     });
   }, [allTools, activeFilter, searchQuery]);
 
-  const renderToolSwitch = (row: ToolDisplayRow) => {
-    const state: ToolEditorState = editor.toolState(row.name);
+  const renderToolSwitch = useCallback(
+    (row: ToolDisplayRow) => {
+      const state: ToolEditorState = editor.toolState(row.name);
 
-    if (state === "system_pinned") {
+      if (state === "system_pinned") {
+        return (
+          <div className="flex justify-center">
+            <Switch checked disabled ariaLabel={t("agentTools.systemPinned")} />
+          </div>
+        );
+      }
+
+      const checked = state === "enabled";
+      const onChange = (next: boolean) => {
+        if (editor.systemRestrictToTools !== null) {
+          editor.setUserAllowed(row.name, next);
+          if (!next) editor.setExcluded(row.name, false);
+        } else {
+          editor.setExcluded(row.name, !next);
+        }
+      };
+
       return (
         <div className="flex justify-center">
-          <Switch checked disabled ariaLabel={t("agentTools.systemPinned")} />
+          <Switch
+            checked={checked}
+            onChange={onChange}
+            dataTestId={`agent-orgs-tool-switch-${row.name}`}
+          />
         </div>
       );
-    }
-
-    const checked = state === "enabled";
-    const onChange = (next: boolean) => {
-      if (editor.systemRestrictToTools !== null) {
-        editor.setUserAllowed(row.name, next);
-        if (!next) editor.setExcluded(row.name, false);
-      } else {
-        editor.setExcluded(row.name, !next);
-      }
-    };
-
-    return (
-      <div className="flex justify-center">
-        <Switch
-          checked={checked}
-          onChange={onChange}
-          dataTestId={`agent-orgs-tool-switch-${row.name}`}
-        />
-      </div>
-    );
-  };
+    },
+    [editor, t]
+  );
 
   const columns = useMemo<SettingsTableColumn<ToolDisplayRow>[]>(
     () => [
@@ -289,8 +292,7 @@ const CustomAgentToolsSection: React.FC<CustomAgentToolsSectionProps> = ({
         renderCell: renderToolSwitch,
       },
     ],
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [t, tIntegrations, editor]
+    [t, renderToolSwitch]
   );
 
   const configLoading = toolsLoading || !editor.loaded;

--- a/src/modules/MainApp/AgentOrgs/hooks/useAgentDefinitions.ts
+++ b/src/modules/MainApp/AgentOrgs/hooks/useAgentDefinitions.ts
@@ -136,10 +136,7 @@ export function useAgentDefinitions() {
       changeListenerInstalled = false;
       void unlistenPromise.then((unlisten) => unlisten());
     };
-    // applyResult is stable per-mount; the module-level guard ensures a
-    // single live listener regardless.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [applyResult]);
 
   const builtInAgents = useMemo(
     () =>

--- a/src/modules/MainApp/Integrations/KeyVault/hooks/useKeyVaultPage.ts
+++ b/src/modules/MainApp/Integrations/KeyVault/hooks/useKeyVaultPage.ts
@@ -118,7 +118,7 @@ export function useKeyVaultPage() {
   // Initial load
   useEffect(() => {
     refresh();
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [refresh]);
 
   // Computed
   const agentTypes = useMemo(

--- a/src/modules/ProjectManager/WorkItems/hooks/useProjectData/useProjectData.ts
+++ b/src/modules/ProjectManager/WorkItems/hooks/useProjectData/useProjectData.ts
@@ -145,8 +145,7 @@ export function useProjectData(
     if (initialProjectId && initialProjectId !== selectedProjectId) {
       setSelectedProjectId(initialProjectId);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialProjectId]);
+  }, [initialProjectId, selectedProjectId]);
 
   const wasActiveRef = useRef(false);
   useEffect(() => {

--- a/src/modules/WorkStation/Browser/Panels/BrowserSecondaryPanel/components/WebDevTools/components/DesignPanel/CollapsibleSection.tsx
+++ b/src/modules/WorkStation/Browser/Panels/BrowserSecondaryPanel/components/WebDevTools/components/DesignPanel/CollapsibleSection.tsx
@@ -86,13 +86,11 @@ export const CollapsibleSection: React.FC<CollapsibleSectionProps> = memo(
 
     useEffect(() => {
       if (collapseAllKey !== undefined) close();
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [collapseAllKey]);
+    }, [collapseAllKey, close]);
 
     useEffect(() => {
       if (expandAllKey !== undefined) open();
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [expandAllKey]);
+    }, [expandAllKey, open]);
 
     return (
       <div className="mb-2 last:mb-0">

--- a/src/modules/WorkStation/Browser/hooks/useWebviewStyleEditor.ts
+++ b/src/modules/WorkStation/Browser/hooks/useWebviewStyleEditor.ts
@@ -191,7 +191,7 @@ export function useWebviewStyleEditor(
     } else {
       setStyles(null);
     }
-  }, [enabled, webviewLabel, selectedXPath]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [enabled, webviewLabel, selectedXPath, refresh]);
 
   // Set a single CSS property
   const setStyle = useCallback(

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorBottomPanel/content/OutputContent/OutputSearchPanel.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorBottomPanel/content/OutputContent/OutputSearchPanel.tsx
@@ -8,6 +8,7 @@ import React, {
   memo,
   useCallback,
   useEffect,
+  useEffectEvent,
   useMemo,
   useRef,
   useState,
@@ -120,13 +121,15 @@ export const OutputSearchPanel: React.FC<OutputSearchPanelProps> = memo(
       handleFindNext();
     }, [handleFindNext]);
 
-    // Re-search when options change
-    useEffect(() => {
+    const repeatSearchForOptions = useEffectEvent(() => {
       if (query && isOpen) {
         onFindNext(query, { caseSensitive, wholeWord, regex: useRegex });
       }
-      // Only re-trigger when toggle options change, not on every query keystroke
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+    });
+
+    // Re-search when options change
+    useEffect(() => {
+      repeatSearchForOptions();
     }, [caseSensitive, wholeWord, useRegex]);
 
     if (!isOpen) return null;

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/CodeMirrorSearchPanel/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/CodeMirrorSearchPanel/index.tsx
@@ -211,13 +211,13 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
 
   React.useEffect(() => {
     debouncedApplySearch();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     localQuery,
     localReplace,
     localCaseSensitive,
     localWholeWord,
     localUseRegex,
+    debouncedApplySearch,
   ]);
 
   // Update replace mode in state (no debounce needed)
@@ -225,8 +225,7 @@ const SearchPanel: React.FC<SearchPanelProps> = ({
     view.dispatch({
       effects: toggleReplaceEffect.of(localReplaceMode),
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [localReplaceMode]);
+  }, [localReplaceMode, view]);
 
   const handleClose = () => {
     // Close the search panel using CodeMirror's close function

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/GitHistoryContent/GitHistoryContextMenu.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/GitHistoryContent/GitHistoryContextMenu.tsx
@@ -109,21 +109,21 @@ function showResult(result: ActionResult, successLabel: string): void {
 export default function GitHistoryContextMenu(
   props: GitHistoryContextMenuProps
 ) {
-  const { onClose } = props;
+  const {
+    commit,
+    repoId,
+    repoPath,
+    isHeadCommit,
+    dispatch,
+    onOpenInNewTab,
+    onActionComplete,
+    onClose,
+  } = props;
   const hasShownMenu = useRef(false);
 
   useEffect(() => {
     if (hasShownMenu.current) return;
     hasShownMenu.current = true;
-
-    const {
-      commit,
-      repoId,
-      repoPath,
-      isHeadCommit,
-      dispatch,
-      onActionComplete,
-    } = props;
 
     async function showNativeMenu() {
       try {
@@ -222,7 +222,7 @@ export default function GitHistoryContextMenu(
               {
                 text: t("common:actions.openInNewTab"),
                 action: () => {
-                  props.onOpenInNewTab(commit);
+                  onOpenInNewTab(commit);
                 },
               },
               {
@@ -331,8 +331,16 @@ export default function GitHistoryContextMenu(
     }
 
     void showNativeMenu();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [
+    commit,
+    repoId,
+    repoPath,
+    isHeadCommit,
+    dispatch,
+    onOpenInNewTab,
+    onActionComplete,
+    onClose,
+  ]);
 
   return null;
 }

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SearchContent/useSearchContent/useSearchExecution.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SearchContent/useSearchContent/useSearchExecution.ts
@@ -297,7 +297,6 @@ export function useSearchExecution(
     } finally {
       setLoading(false);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- USE_FAST_SEARCH/USE_STREAMING_SEARCH are module-level constants
   }, [
     query,
     searchMode,
@@ -306,7 +305,6 @@ export function useSearchExecution(
     storeOptions,
     clearAtom,
     cleanupStreamingListeners,
-    appendResults,
     flushPendingResults,
     setLoading,
     setError,

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/FileSidebar.tsx
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/FileSidebar.tsx
@@ -151,7 +151,7 @@ const FileSidebarComponent: React.FC<FileSidebarProps> = ({
         filePath: op.filePath,
         fileName: op.fileName,
       })),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed by readFileKey
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- readFileKey encodes the immutable event identity/timestamp behind every rendered read item
     [readFileKey]
   );
 
@@ -194,7 +194,7 @@ const FileSidebarComponent: React.FC<FileSidebarProps> = ({
           statusColorClass: badge?.colorClass,
         };
       }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed by writeFileKey
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- writeFileKey encodes the identity, operation kind, baseline status, edit count, and timestamp rendered by write items
     [writeFileKey]
   );
 
@@ -210,7 +210,17 @@ const FileSidebarComponent: React.FC<FileSidebarProps> = ({
   );
 
   const shellItemsKey = useMemo(
-    () => shellOperations.map((op) => op.eventId).join(","),
+    () =>
+      JSON.stringify(
+        shellOperations.map((op) => ({
+          eventId: op.eventId,
+          commandKeywords: op.commandKeywords,
+          shortCommand: op.shortCommand,
+          functionName: op.event?.functionName,
+          isLoading: op.isLoading,
+          exitCode: op.exitCode,
+        }))
+      ),
     [shellOperations]
   );
 
@@ -227,7 +237,7 @@ const FileSidebarComponent: React.FC<FileSidebarProps> = ({
           statusColorClass: badge?.className,
         };
       }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed by shellItemsKey
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- shellItemsKey encodes every operation field rendered by this projection, including live status changes
     [shellItemsKey]
   );
 

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/ShellSidebar.tsx
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/ShellSidebar.tsx
@@ -45,7 +45,16 @@ const ShellSidebarComponent: React.FC<ShellSidebarProps> = ({
   const { t } = useTranslation("sessions");
   // Stable key: only rebuild when the actual set of operations changes
   const shellItemsKey = useMemo(
-    () => shellOperations.map((op) => op.eventId).join(","),
+    () =>
+      JSON.stringify(
+        shellOperations.map((op) => ({
+          eventId: op.eventId,
+          commandKeywords: op.commandKeywords,
+          shortCommand: op.shortCommand,
+          isLoading: op.isLoading,
+          exitCode: op.exitCode,
+        }))
+      ),
     [shellOperations]
   );
 
@@ -59,7 +68,7 @@ const ShellSidebarComponent: React.FC<ShellSidebarProps> = ({
         statusBadgeClass: badge?.className,
       };
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- shellItemsKey encodes every operation field rendered by this projection, preserving item identity for equivalent event arrays
   }, [shellItemsKey]);
 
   return (

--- a/src/modules/WorkStation/CodeEditor/hooks/gitOutputIntegration/useGitOutputIntegration.ts
+++ b/src/modules/WorkStation/CodeEditor/hooks/gitOutputIntegration/useGitOutputIntegration.ts
@@ -12,7 +12,7 @@
  * - Backend operation logging
  */
 import { useAtomValue } from "jotai";
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useCallback, useEffect } from "react";
 
 import { gitOperationAtom } from "@src/store/git";
 import type {
@@ -54,9 +54,8 @@ export function useGitOutputIntegration(
 
   // Subscribe to backend-detected git operations
   const gitOperation = useAtomValue(gitOperationAtom);
-
-  // Track if channel has been created
-  const channelCreatedRef = useRef(false);
+  const hasGitChannel = outputState.channels.some((ch) => ch.type === "git");
+  const { createChannel, setActiveChannel } = outputState;
 
   // ============================================
   // Channel Management
@@ -89,20 +88,12 @@ export function useGitOutputIntegration(
     return channel?.id;
   }, [outputState]);
 
-  // Create git channel on mount and set as active by default
+  // Ensure the current output owner has a git channel and select it when first created.
   useEffect(() => {
-    if (channelCreatedRef.current) return;
-
-    const existingChannel = outputState.channels.find(
-      (ch) => ch.type === "git"
-    );
-    if (!existingChannel) {
-      const channelId = outputState.createChannel("Git", "git");
-      outputState.setActiveChannel(channelId);
-      channelCreatedRef.current = true;
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    if (hasGitChannel) return;
+    const channelId = createChannel("Git", "git");
+    setActiveChannel(channelId);
+  }, [createChannel, hasGitChannel, setActiveChannel]);
 
   // ============================================
   // Backend Operation Logging

--- a/src/modules/WorkStation/CodeEditor/hooks/output/useFileWatchOutputIntegration.ts
+++ b/src/modules/WorkStation/CodeEditor/hooks/output/useFileWatchOutputIntegration.ts
@@ -45,7 +45,9 @@ export function useFileWatchOutputIntegration(
   // Store outputState functions in refs to avoid dependency issues
   // This prevents the infinite loop caused by outputState.channels changing on every append
   const outputStateRef = useRef(outputState);
-  outputStateRef.current = outputState;
+  useEffect(() => {
+    outputStateRef.current = outputState;
+  }, [outputState]);
 
   // Format timestamp - local time with subdued italic styling
   const formatTimestamp = useCallback(() => {
@@ -272,8 +274,7 @@ export function useFileWatchOutputIntegration(
         }
       }
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, repoId, repoPath]);
+  }, [enabled, repoId, repoPath, log]);
 
   // Listen for manual file save events (editor internal saves)
   useEffect(() => {
@@ -294,8 +295,7 @@ export function useFileWatchOutputIntegration(
     return () => {
       window.removeEventListener("filesync:file-saved", handleFileSaved);
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [enabled, repoPath]);
+  }, [enabled, repoPath, log]);
 
   return {};
 }

--- a/src/modules/WorkStation/Diff/SessionReplay/useSubmissionsData.ts
+++ b/src/modules/WorkStation/Diff/SessionReplay/useSubmissionsData.ts
@@ -497,10 +497,7 @@ export function useSubmissionsData({
     return () => {
       cancelled = true;
     };
-    // `prStatusFetchKey` already encodes the identity of every PR row;
-    // depending on it (instead of the full array) avoids re-fetching when
-    // upstream merely produces a new array reference with the same contents.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- prStatusFetchKey encodes every repo/name pair read below, avoiding network refetches for equivalent upstream arrays
   }, [prStatusFetchKey]);
 
   const pullRequestsWithStatus = useMemo(() => {

--- a/src/modules/shared/dataSource/useTeamRuntimeRoster.ts
+++ b/src/modules/shared/dataSource/useTeamRuntimeRoster.ts
@@ -119,7 +119,7 @@ export function useTeamRuntimeRoster(
   // memoization (it's a new object every render by construction).
   const telemetry = useMemo(
     () => rawTelemetry,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- enabled/intervalMinutes encode every telemetry field consumed downstream and preserve identity across equivalent parser objects
     [rawTelemetry?.enabled, rawTelemetry?.intervalMinutes]
   );
   const telemetryEnabled = telemetry?.enabled === true;

--- a/src/scaffold/ContextMenu/useContextMenu.ts
+++ b/src/scaffold/ContextMenu/useContextMenu.ts
@@ -290,8 +290,7 @@ export function useContextMenu(
       updateSearchResults([]);
       setSearchLoading(false);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchQuery, secondLayer, debouncedContextSearch]);
+  }, [searchQuery, secondLayer, debouncedContextSearch, updateSearchResults]);
 
   // Handle item selection - uses refs to avoid stale closures
   // Intercepts "project" clicks in the projects layer to drill in
@@ -316,7 +315,7 @@ export function useContextMenu(
       onSelectRef.current?.(type, value, displayName);
       onCloseRef.current?.();
     },
-    [secondLayer, performSearch] // eslint-disable-line react-hooks/exhaustive-deps
+    [secondLayer, performSearch]
   );
 
   // Go back — from drilled project to project list, or from project list to main menu

--- a/src/scaffold/GlobalSpotlight/palettes/BranchPalette/useBranchFetch.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/BranchPalette/useBranchFetch.ts
@@ -4,7 +4,7 @@
  * Handles fetching branches from both Rust/Python backends and GitHub API.
  * Implements caching strategy: show cached data immediately, refresh in background.
  */
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useStore } from "jotai";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { gitApi } from "@src/api/http/git";
@@ -26,6 +26,7 @@ import type { UseBranchFetchOptions } from "./types";
 const log = createLogger("useBranchFetch");
 
 export function useBranchFetch(options: UseBranchFetchOptions) {
+  const store = useStore();
   const {
     isOpen,
     repoId,
@@ -176,8 +177,10 @@ export function useBranchFetch(options: UseBranchFetchOptions) {
   useEffect(() => {
     if (!isOpen || !repoId || isGitHubRepo) return;
 
+    const loadingRepoIds = store.get(branchLoadingRepoIdsAtom);
     if (loadingRepoIds.has(repoId)) return;
 
+    const branchCache = store.get(branchCacheAtom);
     const cached = getBranchesFromCache(branchCache, repoId);
     const hasCachedData = cached && cached.branches.length > 0;
 
@@ -264,8 +267,16 @@ export function useBranchFetch(options: UseBranchFetchOptions) {
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, repoId, repoPath, refreshNonce]);
+  }, [
+    isOpen,
+    repoId,
+    repoPath,
+    isGitHubRepo,
+    refreshNonce,
+    setBranchCacheAtom,
+    setLoadingRepoIds,
+    store,
+  ]);
 
   const refresh = useCallback(() => {
     hasFetchedRef.current = null;

--- a/src/scaffold/GlobalSpotlight/palettes/EditorPalette/hooks/useFileMode.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/EditorPalette/hooks/useFileMode.ts
@@ -88,10 +88,7 @@ export function useFileMode({
         // Non-fatal — search will still work if prewarm fails.
       });
     }
-    // searchRootsKey is the stable joined-path proxy for searchRoots; adding
-    // searchRoots itself would re-fire whenever the array identity changes
-    // without the actual paths changing.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- searchRootsKey encodes every root path used by prewarmFileIndex and avoids repeated IPC for equivalent root arrays
   }, [enabled, searchRootsKey]);
 
   // Search files

--- a/src/scaffold/ModalSystem/variants/RouteDebug/index.tsx
+++ b/src/scaffold/ModalSystem/variants/RouteDebug/index.tsx
@@ -64,7 +64,7 @@ export const RouteDebugModal: React.FC = () => {
 
     // Reset the atom so the next Cmd+0 re-triggers
     getInstrumentedStore().set(routeDebugModalOpenAtom, false);
-  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [open, devMode, location.pathname, location.search, params, matches]);
 
   return null;
 };

--- a/src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/index.tsx
+++ b/src/scaffold/NavigationSidebar/components/NavigationMenu/NavigationMenu/index.tsx
@@ -27,15 +27,25 @@ const NavigationMenu: React.FC<NavigationMenuProps> = React.memo(
     const { t } = useTranslation();
 
     const itemsKey = useMemo(
-      () => items.map((item) => item.key).join(","),
+      () => JSON.stringify(items.map((item) => item.key)),
+      [items]
+    );
+    const submenuKeysKey = useMemo(
+      () =>
+        JSON.stringify(
+          items.map((item) => [
+            item.key,
+            item.children?.map((child) => child.key) ?? [],
+          ])
+        ),
       [items]
     );
     const defaultOpenKeysKey = useMemo(
-      () => defaultOpenKeys.join(","),
+      () => JSON.stringify(defaultOpenKeys),
       [defaultOpenKeys]
     );
     const selectedKeysKey = useMemo(
-      () => selectedKeys.join(","),
+      () => JSON.stringify(selectedKeys),
       [selectedKeys]
     );
 
@@ -62,7 +72,7 @@ const NavigationMenu: React.FC<NavigationMenuProps> = React.memo(
         if (!item.children) return false;
         return item.children.some((child) => selectedKeys.includes(child.key));
       },
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- selectedKeysKey is the semantic content clock; same-content array allocations must not recreate every menu-row callback
       [selectedKeysKey]
     );
 
@@ -77,7 +87,7 @@ const NavigationMenu: React.FC<NavigationMenuProps> = React.memo(
         prevKeysRef.current = { itemsKey, defaultOpenKeysKey };
         setOpenSubmenus(defaultOpenKeys);
       }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- these content keys own reset timing; depending on defaultOpenKeys identity would reset user-expanded state for equal parent arrays
     }, [itemsKey, defaultOpenKeysKey]);
 
     useEffect(() => {
@@ -92,8 +102,8 @@ const NavigationMenu: React.FC<NavigationMenuProps> = React.memo(
           });
         }
       });
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [itemsKey, selectedKeysKey]);
+      // eslint-disable-next-line react-hooks/exhaustive-deps -- submenuKeysKey and selectedKeysKey include every field this expansion pass reads while avoiding reruns for same-content menu arrays
+    }, [submenuKeysKey, selectedKeysKey]);
 
     const renderIcon = useCallback(
       (
@@ -155,8 +165,8 @@ const NavigationMenu: React.FC<NavigationMenuProps> = React.memo(
     );
 
     const renderMenuItem = useCallback(
-      (item: NavigationMenuItem, isChild = false) =>
-        renderNavigationMenuItem({
+      function renderMenuItem(item: NavigationMenuItem, isChild = false) {
+        return renderNavigationMenuItem({
           item,
           isChild,
           selectedKeys,
@@ -171,7 +181,8 @@ const NavigationMenu: React.FC<NavigationMenuProps> = React.memo(
           onRowMouseEnter: handleRowMouseEnter,
           onRowActionClick: handleRowActionClick,
           onToggleSubmenu: toggleSubmenu,
-        }),
+        });
+      },
       [
         selectedKeys,
         openSubmenus,

--- a/src/store/settings/settingsSync.ts
+++ b/src/store/settings/settingsSync.ts
@@ -91,7 +91,7 @@ export function useSettingsSync(): void {
       unlistenChange.then((unlisten) => unlisten());
       unlistenDelete.then((unlisten) => unlisten());
     };
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [initSettings, handleExternalChange, handleFileDeleted]);
 
   // Sync theme to resolved CSS after settings load from disk or external edits.
   useEffect(() => {


### PR DESCRIPTION
## Problem

Inline suppressions hid 86 `react-hooks/exhaustive-deps` diagnostics across the audited React surface. In this category's files, several were genuine lifecycle bugs: WebSocket option changes were ignored, asynchronous conversation and branch fetches captured stale snapshots, listeners/callbacks could keep old props, and mount-only effects mixed true ownership constraints with accidental omissions.

This PR owns 67 active diagnostics plus 3 stale directives in its non-overlapping file set. Companion low-risk and state-sync PRs own the remaining 19 active diagnostics.

## Solution

- Fixed 39 active dependency diagnostics with lifecycle-correct dependencies, primitive option keys, current-store reads for feedback-prone atoms, and event-time callback refs / `useEffectEvent` where resubscription would be wrong.
- Removed 3 stale, unused directives.
- Retained 26 intentional directives (28 diagnostics: two caller-dependency hooks each emit two) and added a precise `-- reason` to every one.
- Kept xterm/CodeMirror ownership stable: callback, content, theme, and font changes continue to patch existing instances instead of destroying renderers or WebGL slots.
- Added WSProvider lifecycle regression coverage: equivalent option objects do not reconnect, real primitive changes do, and `undefined` options no longer overwrite client defaults.
- Documented the newly exposed `set-state-in-effect` cases narrowly: WSProvider publishes an externally owned disposable client, and the realtime capability probe clears state before its async result.

## Potential risks

- WSProvider now intentionally recreates its client when an actual option primitive or `onBeforeReconnect` changes. Parents that change callback identity every render should stabilize that callback.
- Conversation/branch fetch effects now read the latest Jotai snapshot at trigger time. Existing in-flight and cancellation guards remain responsible for late results.
- The retained semantic keys are lifecycle contracts. If a projection begins reading another field, its key must be expanded with it.

## Retained exhaustive-deps suppressions

- Mount / identity ownership: `ComposerInput/index`, `InlineRenameInput`, `VirtualizedListBase`, `XtermOutput`, `PokerTableWindow`.
- Editor instance ownership: both `CodeMirror/Diff` construction effects.
- Semantic content / invalidation keys: `CloudSessionReferencePreview`, `CloudSessionShareDialog`, both resolved-model label hooks, three `FileSidebar` projections, `ShellSidebar`, `useSubmissionsData`, `useTeamRuntimeRoster`, `useFileMode`, and three `NavigationMenu` hooks.
- Caller / external clocks: `useCloudOrgPanelState`, `useEventStoreSelector`, `useAsyncData`, `useCallbackRefEffect`, and `useScrollToBottom`.

## Verification

- `pnpm exec eslint $(git diff --name-only origin/develop...HEAD --diff-filter=ACM | rg '\.(ts|tsx)$') --report-unused-disable-directives`
- `rg -l 'eslint-(disable|disable-next-line|disable-line).*react-hooks/exhaustive-deps' src | xargs pnpm exec eslint --no-inline-config --rule 'react-hooks/exhaustive-deps: warn' --format json` — 47 visible diagnostics: 28 intentional/reasoned here, 19 assigned to companion PRs.
- `pnpm typecheck`
- Focused Vitest run: 25 files / 203 tests passed across ComposerInput, TerminalInteractive, embedded webview, deep links, navigation selection, Org2 replay, and shell replay.
- `pnpm exec vitest run src/api/realtime/websocket/WSProvider.test.ts` — 2 tests passed.
- `git diff --check origin/develop...HEAD`
- Commit hooks: lint-staged and scoped TypeScript checks passed for all 48 files.

## Performance lifecycle evidence

| Lifecycle | Evidence | Churn outcome |
| --- | --- | --- |
| WebSocket client | Dependencies are option primitives, not the `options` object; regression test covers equal-object and changed-value renders. | No reconnect for equivalent option allocations; one rebuild for a real option change. |
| Terminal / xterm | Event callbacks read current refs; appearance effects patch the existing instance; shell integration only changes the mount key when availability changes. | No callback/theme/content-driven renderer rebuild or extra WebGL slot. |
| Conversation and branch fetches | Trigger effects read current atom snapshots instead of depending on atoms they update. | Avoids self-triggered fetch loops while preserving signal/repo clocks and cleanup guards. |
| Listeners and timers | Stable callbacks are included; every subscription still returns its original cleanup; debounce/scroll caller clocks remain explicit. | No added listener/timer ownership or resubscribe loop. |
| Semantic projections | Content keys were retained and strengthened where live status fields were missing. | Equivalent arrays preserve memo identity; real rendered-field changes invalidate. |

Performance verdict: **pass** for lifecycle/churn review and focused automated coverage. No live Tauri profiling claim is made in this PR.
