### PR TITLE
Fix React effect-driven state synchronization

### DIFF
--- a/src/components/DevPassport/PassportBook.test.ts
+++ b/src/components/DevPassport/PassportBook.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { advanceFlipState } from "./PassportBook";
+
+describe("advanceFlipState", () => {
+  it("keeps the current direction until the sheet changes", () => {
+    const state = { sheetIndex: 2, direction: "backward" as const };
+    expect(advanceFlipState(state, 2)).toBe(state);
+  });
+
+  it("derives forward and backward direction from the prop transition", () => {
+    const forward = advanceFlipState(
+      { sheetIndex: 1, direction: "backward" },
+      3
+    );
+    expect(forward).toEqual({ sheetIndex: 3, direction: "forward" });
+    expect(advanceFlipState(forward, 0)).toEqual({
+      sheetIndex: 0,
+      direction: "backward",
+    });
+  });
+});

--- a/src/components/DevPassport/PassportBook.tsx
+++ b/src/components/DevPassport/PassportBook.tsx
@@ -2,7 +2,7 @@
  * DevPassport Book Component
  */
 import { Code, Fingerprint } from "lucide-react";
-import React, { useLayoutEffect, useMemo, useRef, useState } from "react";
+import React, { useMemo, useState } from "react";
 
 // File type icons for passport watermark
 import GoIcon from "@src/assets/fileTypeIcons/go.svg";
@@ -15,6 +15,24 @@ import Stamp from "./Stamp";
 import type { PageContent, StampData, UserProfile } from "./types";
 
 const WATERMARK_ICONS = [TsIcon, ReactIcon, PythonIcon, GoIcon, RustIcon];
+
+type FlipDirection = "forward" | "backward";
+
+interface FlipState {
+  sheetIndex: number;
+  direction: FlipDirection;
+}
+
+export function advanceFlipState(
+  previous: FlipState,
+  sheetIndex: number
+): FlipState {
+  if (previous.sheetIndex === sheetIndex) return previous;
+  return {
+    sheetIndex,
+    direction: sheetIndex > previous.sheetIndex ? "forward" : "backward",
+  };
+}
 
 interface PassportBookProps {
   user: UserProfile;
@@ -292,21 +310,18 @@ export const PassportBook: React.FC<PassportBookProps> = ({
 
   const totalSheets = 1 + contentSheets.length + 1;
 
-  // Track flip direction for Z-index logic
-  const prevSheetIndexRef = useRef(currentSheetIndex);
-  const [direction, setDirection] = useState<"forward" | "backward">("forward");
-
-  // Update direction when currentSheetIndex changes
-  // Using useLayoutEffect since this affects layout (z-index)
-  useLayoutEffect(() => {
-    if (currentSheetIndex !== prevSheetIndexRef.current) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setDirection(
-        currentSheetIndex > prevSheetIndexRef.current ? "forward" : "backward"
-      );
-      prevSheetIndexRef.current = currentSheetIndex;
-    }
-  }, [currentSheetIndex]);
+  // Direction is part of the prop transition itself. Adjust it during render
+  // so the z-index is correct in the same commit as the new sheet index,
+  // without a layout-effect render cascade.
+  const [flipState, setFlipState] = useState<FlipState>(() => ({
+    sheetIndex: currentSheetIndex,
+    direction: "forward",
+  }));
+  const nextFlipState = advanceFlipState(flipState, currentSheetIndex);
+  if (nextFlipState !== flipState) {
+    setFlipState(nextFlipState);
+  }
+  const direction = nextFlipState.direction;
 
   const getSheetStyle = (index: number) => {
     const isOpen = index <= currentSheetIndex;

--- a/src/components/MarkDown/MarkdownLocalImage.test.ts
+++ b/src/components/MarkDown/MarkdownLocalImage.test.ts
@@ -52,6 +52,14 @@ const reactActEnvironment = globalThis as typeof globalThis & {
   IS_REACT_ACT_ENVIRONMENT?: boolean;
 };
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
 describe("MarkdownLocalImage", () => {
   let container: HTMLDivElement;
   let root: Root;
@@ -221,5 +229,36 @@ describe("MarkdownLocalImage", () => {
     expect(
       container.querySelector('[data-testid="image-preview-overlay"]')
     ).toBeNull();
+  });
+
+  it("does not show a stale image after the local source changes", async () => {
+    const first = deferred<Uint8Array>();
+    const second = deferred<Uint8Array>();
+    mocks.readFile
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    act(() => {
+      root.render(
+        createElement(MarkdownLocalImage, { src: "/repo/first.png" })
+      );
+    });
+    act(() => {
+      root.render(
+        createElement(MarkdownLocalImage, { src: "/repo/second.png" })
+      );
+    });
+
+    await act(async () => {
+      first.resolve(new Uint8Array([1]));
+      await first.promise;
+    });
+    expect(container.querySelector("img")).toBeNull();
+
+    await act(async () => {
+      second.resolve(new Uint8Array([2]));
+      await second.promise;
+    });
+    expect(container.querySelector("img")?.src).toContain("Ag==");
   });
 });

--- a/src/components/MarkDown/MarkdownLocalImage.tsx
+++ b/src/components/MarkDown/MarkdownLocalImage.tsx
@@ -12,7 +12,7 @@
 import { homeDir, join } from "@tauri-apps/api/path";
 import { readFile, stat } from "@tauri-apps/plugin-fs";
 import { ImageIcon, ImageOff } from "lucide-react";
-import React, { memo, useCallback, useEffect, useState } from "react";
+import React, { memo, useCallback, useEffect, useMemo, useState } from "react";
 
 import FileTypeIcon from "@src/components/FileTypeIcon";
 import ImagePreviewOverlay from "@src/components/ImagePreviewOverlay";
@@ -87,37 +87,71 @@ interface MarkdownLocalImageProps {
   workspaceRootPath?: string | null;
 }
 
+interface LocalImageState {
+  sourceKey: string | null;
+  asyncSrc: string | null;
+  failed: boolean;
+  showOverlay: boolean;
+}
+
+function createLocalImageState(sourceKey: string | null): LocalImageState {
+  return { sourceKey, asyncSrc: null, failed: false, showOverlay: false };
+}
+
 const MarkdownLocalImage: React.FC<MarkdownLocalImageProps> = memo(
   ({ src, alt, workspaceRootPath }) => {
-    const [asyncSrc, setAsyncSrc] = useState<string | null>(null);
-    const [failed, setFailed] = useState(false);
-    const [showOverlay, setShowOverlay] = useState(false);
-
-    const source = classifyMarkdownImageSrc(src, workspaceRootPath);
+    const source = useMemo(
+      () => classifyMarkdownImageSrc(src, workspaceRootPath),
+      [src, workspaceRootPath]
+    );
     const localIsImage =
       source.kind === "local" && getImageMimeType(source.path) !== undefined;
+    const sourceKey =
+      source.kind === "local" && localIsImage
+        ? `${source.homeRelative === true ? "home" : "absolute"}:${source.path}`
+        : null;
+    const [imageState, setImageState] = useState<LocalImageState>(() =>
+      createLocalImageState(sourceKey)
+    );
+    const nextImageState =
+      imageState.sourceKey === sourceKey
+        ? imageState
+        : createLocalImageState(sourceKey);
+    if (nextImageState !== imageState) {
+      setImageState(nextImageState);
+    }
+    const { asyncSrc, failed, showOverlay } = nextImageState;
 
     useEffect(() => {
       if (source.kind !== "local" || !localIsImage) return;
       let cancelled = false;
-      setAsyncSrc(null);
-      setFailed(false);
       loadLocalImage(source.path, source.homeRelative === true)
         .then((dataUrl) => {
-          if (!cancelled) setAsyncSrc(dataUrl);
+          if (!cancelled) {
+            setImageState((current) =>
+              current.sourceKey === sourceKey
+                ? { ...current, asyncSrc: dataUrl, failed: false }
+                : current
+            );
+          }
         })
         .catch(() => {
-          if (!cancelled) setFailed(true);
+          if (!cancelled) {
+            setImageState((current) =>
+              current.sourceKey === sourceKey
+                ? { ...current, asyncSrc: null, failed: true }
+                : current
+            );
+          }
         });
       return () => {
         cancelled = true;
       };
-      // eslint-disable-next-line react-hooks/exhaustive-deps -- `source` is derived from src/workspaceRootPath; keying on them avoids re-running on every render for an unmemoized object.
-    }, [src, workspaceRootPath, localIsImage]);
+    }, [localIsImage, source, sourceKey]);
 
     const handleImageClick = useCallback((event: React.MouseEvent) => {
       containClick(event);
-      setShowOverlay(true);
+      setImageState((current) => ({ ...current, showOverlay: true }));
     }, []);
 
     const handleFileChipClick = useCallback(
@@ -126,12 +160,11 @@ const MarkdownLocalImage: React.FC<MarkdownLocalImageProps> = memo(
         if (source.kind !== "local") return;
         void openLocalMarkdownRef(source.path, source.homeRelative === true);
       },
-      // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed on the scalars behind `source`.
-      [src, workspaceRootPath]
+      [source]
     );
 
     const handleClose = useCallback(() => {
-      setShowOverlay(false);
+      setImageState((current) => ({ ...current, showOverlay: false }));
     }, []);
 
     if (source.kind === "skip") {

--- a/src/engines/ChatPanel/blocks/TerminalBlock/index.tsx
+++ b/src/engines/ChatPanel/blocks/TerminalBlock/index.tsx
@@ -47,6 +47,46 @@ import { useBlockHeader } from "../useBlockLocate";
 const TERMINAL_OUTPUT_PREVIEW_MAX_HEIGHT = 72;
 const TERMINAL_OUTPUT_EXPAND_LINE_THRESHOLD = 3;
 
+interface TerminalStopButtonProps {
+  pid: number;
+  onStop?: (pid: number) => void;
+  title: string;
+}
+
+export const TerminalStopButton: React.FC<TerminalStopButtonProps> = ({
+  pid,
+  onStop,
+  title,
+}) => {
+  const [isStopping, setIsStopping] = useState(false);
+  const handleStop = useCallback(
+    (event: React.MouseEvent) => {
+      event.stopPropagation();
+      if (!onStop || isStopping) return;
+      setIsStopping(true);
+      onStop(pid);
+    },
+    [isStopping, onStop, pid]
+  );
+
+  return (
+    <button
+      type="button"
+      className="flex h-5 w-0 shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-full border-none bg-text-2 text-white transition-colors hover:bg-text-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 group-hover/chat-block-header:w-5"
+      onClick={handleStop}
+      disabled={isStopping}
+      title={title}
+      aria-label={title}
+    >
+      {isStopping ? (
+        <div className="h-2.5 w-2.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+      ) : (
+        <Square size={10} fill="currentColor" strokeWidth={0} />
+      )}
+    </button>
+  );
+};
+
 export interface TerminalBlockProps {
   command?: string;
   output?: string;
@@ -177,28 +217,11 @@ const TerminalBlock: React.FC<TerminalBlockProps> = memo(
       [formattedCommand]
     );
 
-    // Stop button state — reset when process finishes.
-    //
     // Gate on `isLoading` so backgrounded shell cards keep their status/PID
-    // visible without showing an inline stop/end control.
-    const [isStopping, setIsStopping] = useState(false);
-    useEffect(() => {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      if (!isStillRunning) setIsStopping(false);
-    }, [isStillRunning]);
-    const effectiveIsStopping = isStopping && isStillRunning;
+    // visible without showing an inline stop/end control. The button owns the
+    // request state and unmounts at the end of the stoppable lifecycle, so a
+    // later run (even with a reused PID) always starts enabled.
     const canStop = pid !== undefined && isLoading && !isBackground;
-
-    const handleStop = useCallback(
-      (event: React.MouseEvent) => {
-        event.stopPropagation();
-        if (pid && onStop && !effectiveIsStopping) {
-          setIsStopping(true);
-          onStop(pid);
-        }
-      },
-      [pid, onStop, effectiveIsStopping]
-    );
 
     const statusLabel = useMemo(() => {
       if (processStatus === "killed") {
@@ -227,20 +250,12 @@ const TerminalBlock: React.FC<TerminalBlockProps> = memo(
           {toolUsage && <ToolUsageBadge usage={toolUsage} />}
           {statusLabel}
           {canStop && (
-            <button
-              type="button"
-              className="flex h-5 w-0 shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-full border-none bg-text-2 text-white transition-colors hover:bg-text-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 group-hover/chat-block-header:w-5"
-              onClick={handleStop}
-              disabled={effectiveIsStopping}
+            <TerminalStopButton
+              key={pid}
+              pid={pid}
+              onStop={onStop}
               title={tCommon("common:actions.stop")}
-              aria-label={tCommon("common:actions.stop")}
-            >
-              {effectiveIsStopping ? (
-                <div className="h-2.5 w-2.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
-              ) : (
-                <Square size={10} fill="currentColor" strokeWidth={0} />
-              )}
-            </button>
+            />
           )}
         </div>
       ) : undefined;

--- a/src/engines/ChatPanel/blocks/TerminalBlock/stopLifecycle.test.ts
+++ b/src/engines/ChatPanel/blocks/TerminalBlock/stopLifecycle.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { TerminalStopButton } from ".";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+describe("TerminalBlock stop lifecycle", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(reactActEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  function render(onStop: (pid: number) => void) {
+    act(() => {
+      root.render(
+        createElement(TerminalStopButton, {
+          pid: 42,
+          onStop,
+          title: "common:actions.stop",
+        })
+      );
+    });
+  }
+
+  it("resets a stop request when the stoppable run ends and restarts", () => {
+    const onStop = vi.fn();
+    render(onStop);
+
+    const firstButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="common:actions.stop"]'
+    );
+    act(() => firstButton?.click());
+    expect(onStop).toHaveBeenCalledWith(42);
+    expect(firstButton?.disabled).toBe(true);
+
+    act(() => root.render(null));
+    expect(
+      container.querySelector('[aria-label="common:actions.stop"]')
+    ).toBeNull();
+
+    render(onStop);
+    const restartedButton = container.querySelector<HTMLButtonElement>(
+      '[aria-label="common:actions.stop"]'
+    );
+    expect(restartedButton?.disabled).toBe(false);
+  });
+});

--- a/src/engines/Simulator/components/SubagentPipCard.state.test.ts
+++ b/src/engines/Simulator/components/SubagentPipCard.state.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { advanceSubagentViewState } from "./SubagentPipCard";
+
+describe("advanceSubagentViewState", () => {
+  it("preserves navigation for the same monitored session set", () => {
+    const state = {
+      sessionKeySignature: "a,b",
+      pageIndex: 2,
+      gridExpanded: true,
+      expandedSessionId: "session-a",
+    };
+    expect(advanceSubagentViewState(state, "a,b")).toBe(state);
+  });
+
+  it("resets sticky navigation when the monitored session set changes", () => {
+    expect(
+      advanceSubagentViewState(
+        {
+          sessionKeySignature: "a,b",
+          pageIndex: 2,
+          gridExpanded: true,
+          expandedSessionId: "session-a",
+        },
+        "c,d"
+      )
+    ).toEqual({
+      sessionKeySignature: "c,d",
+      pageIndex: 0,
+      gridExpanded: false,
+      expandedSessionId: null,
+    });
+  });
+});

--- a/src/engines/Simulator/components/SubagentPipCard.tsx
+++ b/src/engines/Simulator/components/SubagentPipCard.tsx
@@ -55,6 +55,26 @@ const SUBAGENT_GRID_PAGE_SIZE = 4;
 // so the cell highlights while the cursor is on those pre-spawn events.
 const HIGHLIGHT_LEAD_MS = 90_000;
 
+interface SubagentViewState {
+  sessionKeySignature: string;
+  pageIndex: number;
+  gridExpanded: boolean;
+  expandedSessionId: string | null;
+}
+
+export function advanceSubagentViewState(
+  previous: SubagentViewState,
+  sessionKeySignature: string
+): SubagentViewState {
+  if (previous.sessionKeySignature === sessionKeySignature) return previous;
+  return {
+    sessionKeySignature,
+    pageIndex: 0,
+    gridExpanded: false,
+    expandedSessionId: null,
+  };
+}
+
 // ── SubagentPipCard — vertically split main + banner strip ────────────────
 
 interface SubagentPipCardProps {
@@ -87,8 +107,28 @@ const SubagentPipCard: React.FC<SubagentPipCardProps> = ({
   liveFollow = false,
 }) => {
   const { t } = useTranslation("sessions");
-  const [pageIndex, setPageIndex] = useState(0);
-  const [gridExpanded, setGridExpanded] = useState(false);
+  const sessionKeySignature = useMemo(
+    () =>
+      activeSessions
+        .map((sub) => sub.key)
+        .sort()
+        .join(","),
+    [activeSessions]
+  );
+  const [viewState, setViewState] = useState<SubagentViewState>(() => ({
+    sessionKeySignature,
+    pageIndex: 0,
+    gridExpanded: false,
+    expandedSessionId: null,
+  }));
+  const nextViewState = advanceSubagentViewState(
+    viewState,
+    sessionKeySignature
+  );
+  if (nextViewState !== viewState) {
+    setViewState(nextViewState);
+  }
+  const { pageIndex, gridExpanded, expandedSessionId } = nextViewState;
   const pageSize = gridExpanded
     ? SUBAGENT_GRID_PAGE_SIZE
     : SUBAGENT_STRIP_PAGE_SIZE;
@@ -187,32 +227,7 @@ const SubagentPipCard: React.FC<SubagentPipCardProps> = ({
   }, [isBannerCollapsed]);
 
   // ── Expand state — which cell (by sessionId) is currently fullscreen ──────
-  const [expandedSessionId, setExpandedSessionId] = useState<string | null>(
-    null
-  );
   const isAnyExpanded = expandedSessionId !== null || gridExpanded;
-
-  // Sticky-state reset: gridExpanded / expandedSessionId survive re-renders
-  // by design, but when the SET of monitored sessions changes (a batch
-  // finished, a new turn spawned different workers) a stale 2x2 grid or a
-  // fullscreen cell from the previous batch is disorienting — the banner
-  // appears "stuck as two rows". Reset to the plain strip on set change.
-  const sessionKeySignature = useMemo(
-    () =>
-      activeSessions
-        .map((sub) => sub.key)
-        .sort()
-        .join(","),
-    [activeSessions]
-  );
-  const prevSignatureRef = useRef(sessionKeySignature);
-  useEffect(() => {
-    if (prevSignatureRef.current === sessionKeySignature) return;
-    prevSignatureRef.current = sessionKeySignature;
-    setGridExpanded(false);
-    setExpandedSessionId(null);
-    setPageIndex(0);
-  }, [sessionKeySignature]);
 
   const expandBannerImmediately = useCallback(() => {
     const bannerPane = bannerPaneRef.current;
@@ -226,36 +241,41 @@ const SubagentPipCard: React.FC<SubagentPipCardProps> = ({
 
   const handleExpand = useCallback(
     (sessionId: string) => {
-      setGridExpanded(false);
-      setExpandedSessionId((prev) => {
-        const nextExpandedSessionId = prev === sessionId ? null : sessionId;
-        if (nextExpandedSessionId) {
-          expandBannerImmediately();
-        }
-        return nextExpandedSessionId;
-      });
+      const nextExpandedSessionId =
+        expandedSessionId === sessionId ? null : sessionId;
+      if (nextExpandedSessionId) expandBannerImmediately();
+      setViewState((current) => ({
+        ...current,
+        gridExpanded: false,
+        expandedSessionId: nextExpandedSessionId,
+      }));
     },
-    [expandBannerImmediately]
+    [expandBannerImmediately, expandedSessionId]
   );
   const handlePreviousPage = useCallback(() => {
-    setExpandedSessionId(null);
-    setPageIndex((current) => Math.max(0, current - 1));
+    setViewState((current) => ({
+      ...current,
+      expandedSessionId: null,
+      pageIndex: Math.max(0, current.pageIndex - 1),
+    }));
   }, []);
   const handleNextPage = useCallback(() => {
-    setExpandedSessionId(null);
-    setPageIndex((current) => Math.min(pageCount - 1, current + 1));
+    setViewState((current) => ({
+      ...current,
+      expandedSessionId: null,
+      pageIndex: Math.min(pageCount - 1, current.pageIndex + 1),
+    }));
   }, [pageCount]);
 
   const handleToggleGridExpanded = useCallback(() => {
-    setExpandedSessionId(null);
-    setGridExpanded((current) => {
-      const nextGridExpanded = !current;
-      if (nextGridExpanded) {
-        expandBannerImmediately();
-      }
-      return nextGridExpanded;
-    });
-  }, [expandBannerImmediately]);
+    const nextGridExpanded = !gridExpanded;
+    if (nextGridExpanded) expandBannerImmediately();
+    setViewState((current) => ({
+      ...current,
+      expandedSessionId: null,
+      gridExpanded: nextGridExpanded,
+    }));
+  }, [expandBannerImmediately, gridExpanded]);
   // ── Vertical split (top / bottom) ──────────────────────────────────────
   const containerRef = useRef<HTMLDivElement>(null);
   const topPaneRef = useRef<HTMLDivElement>(null);
@@ -269,8 +289,11 @@ const SubagentPipCard: React.FC<SubagentPipCardProps> = ({
 
   const handleBannerChevronClick = useCallback(() => {
     if (isAnyExpanded) {
-      setExpandedSessionId(null);
-      setGridExpanded(false);
+      setViewState((current) => ({
+        ...current,
+        expandedSessionId: null,
+        gridExpanded: false,
+      }));
       setIsBannerCollapsed(true);
       const containerHeight =
         containerRef.current?.getBoundingClientRect().height;
@@ -313,8 +336,6 @@ const SubagentPipCard: React.FC<SubagentPipCardProps> = ({
     });
     ro.observe(el);
     return () => ro.disconnect();
-    // topHeight deliberately excluded — we only want to set it once (null → value).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const getVConstraints = useCallback(() => {

--- a/src/features/PokerTable/components/PokerActionBar.tsx
+++ b/src/features/PokerTable/components/PokerActionBar.tsx
@@ -3,7 +3,7 @@
  * amount) and the Fold / Call / Bet buttons when it is the hero's turn;
  * otherwise a status line, the rebuy prompt, or "deal next hand".
  */
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
@@ -33,6 +33,23 @@ const clamp = (value: number, min: number, max: number): number =>
 const BAR_CLASS =
   "flex h-[92px] flex-col items-center justify-center gap-2 px-4";
 
+interface BetAmountState {
+  decisionKey: string;
+  amount: number;
+}
+
+export function advanceBetAmountState(
+  previous: BetAmountState,
+  decisionKey: string,
+  minimum: number | undefined
+): BetAmountState {
+  if (previous.decisionKey === decisionKey) return previous;
+  return {
+    decisionKey,
+    amount: minimum ?? previous.amount,
+  };
+}
+
 const PokerActionBar: React.FC<PokerActionBarProps> = ({
   snapshot,
   heroSeat,
@@ -57,13 +74,24 @@ const PokerActionBar: React.FC<PokerActionBarProps> = ({
       : null;
   const step = Math.max(1, Math.round(snapshot.blinds.bigBlind / 10));
 
-  const [amount, setAmount] = useState<number>(range?.min ?? 0);
   // New decision → reset the sizing to the minimum legal bet.
   const decisionKey = `${snapshot.handNumber}:${snapshot.street}:${range?.min}:${range?.max}:${snapshot.potTotal}`;
-  useEffect(() => {
-    if (range) setAmount(range.min);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [decisionKey]);
+  const [amountState, setAmountState] = useState<BetAmountState>(() => ({
+    decisionKey,
+    amount: range?.min ?? 0,
+  }));
+  const nextAmountState = advanceBetAmountState(
+    amountState,
+    decisionKey,
+    range?.min
+  );
+  if (nextAmountState !== amountState) {
+    setAmountState(nextAmountState);
+  }
+  const amount = nextAmountState.amount;
+  const setAmount = (nextAmount: number) => {
+    setAmountState((current) => ({ ...current, amount: nextAmount }));
+  };
 
   const presetAmount = (fraction: number): number => {
     if (!range || !hero) return 0;
@@ -74,12 +102,8 @@ const PokerActionBar: React.FC<PokerActionBarProps> = ({
     return clamp(Math.round(target / step) * step, range.min, range.max);
   };
 
-  const activePreset = useMemo(
-    () =>
-      POT_PRESETS.find((fraction) => presetAmount(fraction) === amount) ?? null,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [amount, decisionKey]
-  );
+  const activePreset =
+    POT_PRESETS.find((fraction) => presetAmount(fraction) === amount) ?? null;
 
   const isAllIn = range !== null && amount >= range.max;
 

--- a/src/features/PokerTable/components/PokerTableRender.test.ts
+++ b/src/features/PokerTable/components/PokerTableRender.test.ts
@@ -11,7 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PokerTableController } from "../PokerTableController";
 import { createSeededRng } from "../engine/cards";
 import type { PokerPlayer } from "../engine/types";
-import PokerActionBar from "./PokerActionBar";
+import PokerActionBar, { advanceBetAmountState } from "./PokerActionBar";
 import PokerFelt from "./PokerFelt";
 import PokerHandHistory from "./PokerHandHistory";
 import PokerTableHeader from "./PokerTableHeader";
@@ -148,6 +148,16 @@ describe("PokerTable rendering", () => {
       expect(markup).toMatch(/pokerTable\.actions\.(bet|raise|allIn)\(/);
     }
     controller.dispose();
+  });
+
+  it("keeps a manual bet within one decision and resets for the next decision", () => {
+    const manual = { decisionKey: "hand-1:flop", amount: 3_000 };
+
+    expect(advanceBetAmountState(manual, "hand-1:flop", 2_000)).toBe(manual);
+    expect(advanceBetAmountState(manual, "hand-1:turn", 2_000)).toEqual({
+      decisionKey: "hand-1:turn",
+      amount: 2_000,
+    });
   });
 
   it("shows the waiting line when a bot is to act and the result line after a hand", () => {

--- a/src/modules/MainApp/Integrations/BuiltInTools/useAgentToolMatrix.test.ts
+++ b/src/modules/MainApp/Integrations/BuiltInTools/useAgentToolMatrix.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import {
+  builtInAgentsAtom,
+  customAgentsAtom,
+} from "@src/modules/MainApp/AgentOrgs/store/builtInAgentsAtom";
+import type { AgentDefinition } from "@src/modules/MainApp/AgentOrgs/types";
+
+import {
+  type UseAgentToolMatrixReturn,
+  useAgentToolMatrix,
+} from "./useAgentToolMatrix";
+
+const mocks = vi.hoisted(() => ({
+  updatePatch: vi.fn(),
+}));
+
+vi.mock("@src/api/tauri/rpc", () => ({
+  rpc: { agentDef: { updatePatch: mocks.updatePatch } },
+}));
+
+vi.mock("@src/modules/MainApp/AgentOrgs/hooks/useEnsureAgentDefs", () => ({
+  useEnsureAgentDefs: () => true,
+}));
+
+vi.mock("@src/hooks/logger", () => ({
+  createLogger: () => ({ error: vi.fn(), warn: vi.fn() }),
+}));
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+function Probe({
+  onValue,
+}: {
+  onValue: (value: UseAgentToolMatrixReturn) => void;
+}) {
+  onValue(useAgentToolMatrix());
+  return null;
+}
+
+describe("useAgentToolMatrix", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let store: ReturnType<typeof createStore>;
+  let latest: UseAgentToolMatrixReturn;
+
+  const agent: AgentDefinition = {
+    id: "builtin:sde",
+    name: "SDE",
+    builtIn: true,
+    tools: {},
+  };
+
+  beforeAll(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    store = createStore();
+    store.set(builtInAgentsAtom, [agent]);
+    store.set(customAgentsAtom, []);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root.render(
+        createElement(
+          Provider,
+          { store },
+          createElement(Probe, { onValue: (value) => (latest = value) })
+        )
+      );
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(reactActEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("updates the shared atom optimistically and applies the saved definition", async () => {
+    const saved = {
+      ...agent,
+      tools: { excludedTools: ["read_file"], userAllowedTools: [] },
+    };
+    mocks.updatePatch.mockResolvedValueOnce(saved);
+
+    let request!: Promise<void>;
+    act(() => {
+      request = latest.toggle("builtin:sde", "read_file", false);
+    });
+
+    expect(latest.rowsByTool("read_file")[0]?.enabled).toBe(false);
+    expect(store.get(builtInAgentsAtom)[0]?.tools?.excludedTools).toEqual([
+      "read_file",
+    ]);
+
+    await act(async () => request);
+    expect(store.get(builtInAgentsAtom)[0]).toEqual(saved);
+  });
+
+  it("rolls back the shared atom when persistence fails", async () => {
+    mocks.updatePatch.mockRejectedValueOnce(new Error("write failed"));
+
+    await act(async () => {
+      await latest.toggle("builtin:sde", "read_file", false);
+    });
+
+    expect(latest.rowsByTool("read_file")[0]?.enabled).toBe(true);
+    expect(store.get(builtInAgentsAtom)[0]).toEqual(agent);
+  });
+});

--- a/src/modules/MainApp/Integrations/BuiltInTools/useAgentToolMatrix.ts
+++ b/src/modules/MainApp/Integrations/BuiltInTools/useAgentToolMatrix.ts
@@ -11,8 +11,8 @@
  * lazily from `agent_definitions_list_all` so this hook does not refetch
  * on every selection change.
  */
-import { useAtomValue } from "jotai";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useAtomValue, useSetAtom } from "jotai";
+import { useCallback, useMemo } from "react";
 
 import { rpc } from "@src/api/tauri/rpc";
 import { createLogger } from "@src/hooks/logger";
@@ -41,6 +41,7 @@ export interface AgentToolStateRow {
 }
 
 interface AgentRecord {
+  definition: AgentDefinition;
   id: string;
   name: string;
   builtIn: boolean;
@@ -55,6 +56,7 @@ interface AgentRecord {
 function parseAgent(def: AgentDefinition): AgentRecord {
   const tools: AgentToolSelection = def.tools ?? {};
   return {
+    definition: def,
     id: def.id,
     name: def.name || def.id,
     builtIn: Boolean(def.builtIn),
@@ -87,29 +89,31 @@ function resolveState(record: AgentRecord, toolName: string) {
 }
 
 export function useAgentToolMatrix() {
-  const [records, setRecords] = useState<AgentRecord[]>([]);
-
   // Ensure definitions are loaded (no-op if useAgentDefinitions is already mounted)
   const defsLoaded = useEnsureAgentDefs();
   const builtInAgents = useAtomValue(builtInAgentsAtom);
   const customAgents = useAtomValue(customAgentsAtom);
+  const setBuiltInAgents = useSetAtom(builtInAgentsAtom);
+  const setCustomAgents = useSetAtom(customAgentsAtom);
+  const records = useMemo(
+    () => [...builtInAgents, ...customAgents].map(parseAgent),
+    [builtInAgents, customAgents]
+  );
 
-  // Build records whenever the underlying atom data changes.
-  // The setState here is intentional — it derives from stable external
-  // atom state, not from another setState, so cascading renders are
-  // bounded to a single re-render.
-  useEffect(() => {
-    const all: AgentDefinition[] = [...builtInAgents, ...customAgents];
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setRecords(all.map(parseAgent));
-  }, [builtInAgents, customAgents]);
-
-  // refresh re-reads atom values (which useAgentDefinitions keeps up-to-date);
-  // exposed for callers that need an imperative refetch after CRUD.
-  const refresh = useCallback(() => {
-    const all: AgentDefinition[] = [...builtInAgents, ...customAgents];
-    setRecords(all.map(parseAgent));
-  }, [builtInAgents, customAgents]);
+  const applyDefinition = useCallback(
+    (definition: AgentDefinition) => {
+      const update = (current: AgentDefinition[]) =>
+        current.map((entry) =>
+          entry.id === definition.id ? definition : entry
+        );
+      if (definition.builtIn) {
+        setBuiltInAgents(update);
+      } else {
+        setCustomAgents(update);
+      }
+    },
+    [setBuiltInAgents, setCustomAgents]
+  );
 
   const rowsByTool = useCallback(
     (toolName: string): AgentToolStateRow[] => {
@@ -150,46 +154,44 @@ export function useAgentToolMatrix() {
         }
       }
 
-      const nextRecord: AgentRecord = {
-        ...record,
-        userAllowedTools: userAllowed,
-        excludedTools: excluded,
+      const nextTools: AgentToolSelection = {
+        ...record.toolsRaw,
+        userAllowedTools: Array.from(userAllowed),
+        excludedTools: Array.from(excluded),
+      };
+      const nextDefinition: AgentDefinition = {
+        ...record.definition,
+        tools: nextTools,
       };
 
-      setRecords((prev) =>
-        prev.map((entry) => (entry.id === agentId ? nextRecord : entry))
-      );
+      // The shared atoms are the frontend source of truth. Apply the
+      // interaction optimistically there instead of mirroring the same data in
+      // effect-synchronized component state.
+      applyDefinition(nextDefinition);
 
       try {
-        await rpc.agentDef.updatePatch({
+        const savedDefinition = await rpc.agentDef.updatePatch({
           agentId,
           patch: {
-            tools: {
-              ...record.toolsRaw,
-              userAllowedTools: Array.from(userAllowed),
-              excludedTools: Array.from(excluded),
-            },
+            tools: nextTools,
           },
         });
+        applyDefinition(savedDefinition as unknown as AgentDefinition);
       } catch (error) {
         log.error("[useAgentToolMatrix] toggle failed:", error);
-        // Roll back.
-        setRecords((prev) =>
-          prev.map((entry) => (entry.id === agentId ? record : entry))
-        );
+        applyDefinition(record.definition);
       }
     },
-    [records]
+    [applyDefinition, records]
   );
 
-  const agentCount = useMemo(() => records.length, [records]);
+  const agentCount = records.length;
 
   return {
     loaded: defsLoaded,
     rowsByTool,
     toggle,
     agentCount,
-    refresh,
   };
 }
 

--- a/src/modules/MainApp/Integrations/RulesMemoryEvolution/Memory/useWorkspaceMemoryData.test.ts
+++ b/src/modules/MainApp/Integrations/RulesMemoryEvolution/Memory/useWorkspaceMemoryData.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import type { WorkspaceMemoryEntry } from "@src/api/tauri/rpc/schemas/workspaceMemory";
+
+import {
+  MEMORY_SORT_NEWEST,
+  type UseWorkspaceMemoryDataOptions,
+  type UseWorkspaceMemoryDataReturn,
+  useWorkspaceMemoryData,
+} from "./useWorkspaceMemoryData";
+
+const mocks = vi.hoisted(() => ({
+  list: vi.fn(),
+  t: (key: string) => key,
+}));
+
+vi.mock("@src/api/tauri/rpc", () => ({
+  rpc: {
+    workspaceMemory: {
+      list: mocks.list,
+      read: vi.fn(),
+      index: vi.fn(),
+      delete: vi.fn(),
+      clear: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({ ask: vi.fn() }));
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: mocks.t }),
+}));
+vi.mock("@src/components/Message", () => ({
+  default: { error: vi.fn(), success: vi.fn() },
+}));
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+function Probe({
+  options,
+  onValue,
+}: {
+  options: UseWorkspaceMemoryDataOptions;
+  onValue: (value: UseWorkspaceMemoryDataReturn) => void;
+}) {
+  onValue(useWorkspaceMemoryData(options));
+  return null;
+}
+
+describe("useWorkspaceMemoryData", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let latest: UseWorkspaceMemoryDataReturn;
+
+  const entry = (filename: string): WorkspaceMemoryEntry =>
+    ({ filename, mtimeMs: 1, ageDisplay: "now" }) as WorkspaceMemoryEntry;
+
+  beforeAll(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(reactActEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  function render(workspace: string) {
+    const options: UseWorkspaceMemoryDataOptions = {
+      workspace,
+      searchQuery: "",
+      sortKey: MEMORY_SORT_NEWEST,
+      typeFilter: "all",
+      onRefreshStatus: vi.fn(),
+    };
+    act(() => {
+      root.render(
+        createElement(Probe, {
+          options,
+          onValue: (value) => (latest = value),
+        })
+      );
+    });
+  }
+
+  it("resets on workspace change and rejects a stale list completion", async () => {
+    const workspaceA = deferred<WorkspaceMemoryEntry[]>();
+    const workspaceB = deferred<WorkspaceMemoryEntry[]>();
+    mocks.list
+      .mockReturnValueOnce(workspaceA.promise)
+      .mockReturnValueOnce(workspaceB.promise);
+
+    render("/repo/a");
+    expect(latest.loading).toBe(true);
+    render("/repo/b");
+    expect(latest.files).toEqual([]);
+    expect(latest.loading).toBe(true);
+
+    await act(async () => workspaceA.resolve([entry("from-a.md")]));
+    expect(latest.files).toEqual([]);
+    expect(latest.loading).toBe(true);
+
+    await act(async () => workspaceB.resolve([entry("from-b.md")]));
+    expect(latest.files.map((file) => file.filename)).toEqual(["from-b.md"]);
+    expect(latest.loading).toBe(false);
+  });
+});

--- a/src/modules/MainApp/Integrations/RulesMemoryEvolution/Memory/useWorkspaceMemoryData.ts
+++ b/src/modules/MainApp/Integrations/RulesMemoryEvolution/Memory/useWorkspaceMemoryData.ts
@@ -15,7 +15,7 @@
  * of filter/sort state that drives filter Select rendering.
  */
 import { ask } from "@tauri-apps/plugin-dialog";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer } from "react";
 import { useTranslation } from "react-i18next";
 
 import { rpc } from "@src/api/tauri/rpc";
@@ -71,6 +71,91 @@ export interface UseWorkspaceMemoryDataReturn {
   fetchFiles: () => void;
 }
 
+interface WorkspaceMemoryState {
+  workspace: string | null | undefined;
+  files: WorkspaceMemoryEntry[];
+  selectedFile: string | null;
+  detail: WorkspaceMemoryDetail | null;
+  memoryIndex: string;
+  loading: boolean;
+  showIndex: boolean;
+  expandedFileKeys: string[];
+}
+
+type WorkspaceMemoryAction =
+  | {
+      type: "resetWorkspace";
+      workspace: string | null | undefined;
+    }
+  | { type: "beginList"; workspace: string }
+  | {
+      type: "receiveFiles";
+      workspace: string;
+      files: WorkspaceMemoryEntry[];
+    }
+  | { type: "finishList"; workspace: string }
+  | { type: "selectFile"; filename: string | null }
+  | {
+      type: "setDetail";
+      detail: WorkspaceMemoryDetail | null;
+      workspace?: string;
+    }
+  | { type: "setMemoryIndex"; workspace: string; value: string }
+  | { type: "setShowIndex"; show: boolean }
+  | { type: "setExpandedFileKeys"; keys: string[] };
+
+function createWorkspaceMemoryState(
+  workspace: string | null | undefined
+): WorkspaceMemoryState {
+  return {
+    workspace,
+    files: [],
+    selectedFile: null,
+    detail: null,
+    memoryIndex: "",
+    loading: Boolean(workspace),
+    showIndex: false,
+    expandedFileKeys: [],
+  };
+}
+
+export function reduceWorkspaceMemoryState(
+  state: WorkspaceMemoryState,
+  action: WorkspaceMemoryAction
+): WorkspaceMemoryState {
+  switch (action.type) {
+    case "resetWorkspace":
+      return createWorkspaceMemoryState(action.workspace);
+    case "beginList":
+      return state.workspace === action.workspace
+        ? { ...state, loading: true }
+        : state;
+    case "receiveFiles":
+      return state.workspace === action.workspace
+        ? { ...state, files: action.files }
+        : state;
+    case "finishList":
+      return state.workspace === action.workspace
+        ? { ...state, loading: false }
+        : state;
+    case "selectFile":
+      return { ...state, selectedFile: action.filename };
+    case "setDetail":
+      return action.workspace === undefined ||
+        state.workspace === action.workspace
+        ? { ...state, detail: action.detail }
+        : state;
+    case "setMemoryIndex":
+      return state.workspace === action.workspace
+        ? { ...state, memoryIndex: action.value }
+        : state;
+    case "setShowIndex":
+      return { ...state, showIndex: action.show };
+    case "setExpandedFileKeys":
+      return { ...state, expandedFileKeys: action.keys };
+  }
+}
+
 export function useWorkspaceMemoryData({
   workspace,
   searchQuery,
@@ -81,30 +166,71 @@ export function useWorkspaceMemoryData({
   const { t } = useTranslation("settings");
   const mountedRef = useMounted();
 
-  const [files, setFiles] = useState<WorkspaceMemoryEntry[]>([]);
-  const [selectedFile, setSelectedFile] = useState<string | null>(null);
-  const [detail, setDetail] = useState<WorkspaceMemoryDetail | null>(null);
-  const [memoryIndex, setMemoryIndex] = useState<string>("");
-  const [loading, setLoading] = useState(false);
-  const [showIndex, setShowIndex] = useState(false);
-  const [expandedFileKeys, setExpandedFileKeys] = useState<string[]>([]);
+  const [memoryState, dispatch] = useReducer(
+    reduceWorkspaceMemoryState,
+    workspace,
+    createWorkspaceMemoryState
+  );
+  const nextMemoryState =
+    memoryState.workspace === workspace
+      ? memoryState
+      : createWorkspaceMemoryState(workspace);
+  if (nextMemoryState !== memoryState) {
+    dispatch({ type: "resetWorkspace", workspace });
+  }
+  const {
+    files,
+    selectedFile,
+    detail,
+    memoryIndex,
+    loading,
+    showIndex,
+    expandedFileKeys,
+  } = nextMemoryState;
 
-  const fetchFiles = useCallback(() => {
+  const setSelectedFile = useCallback((filename: string | null) => {
+    dispatch({ type: "selectFile", filename });
+  }, []);
+  const setDetail = useCallback((nextDetail: WorkspaceMemoryDetail | null) => {
+    dispatch({ type: "setDetail", detail: nextDetail });
+  }, []);
+  const setShowIndex = useCallback((show: boolean) => {
+    dispatch({ type: "setShowIndex", show });
+  }, []);
+  const setExpandedFileKeys = useCallback((keys: string[]) => {
+    dispatch({ type: "setExpandedFileKeys", keys });
+  }, []);
+
+  const requestFiles = useCallback(() => {
     if (!workspace) return;
-    setLoading(true);
+    const requestWorkspace = workspace;
     rpc.workspaceMemory
-      .list({ workspace })
+      .list({ workspace: requestWorkspace })
       .then((entries: WorkspaceMemoryEntry[]) => {
-        if (mountedRef.current) setFiles(entries);
+        if (mountedRef.current) {
+          dispatch({
+            type: "receiveFiles",
+            workspace: requestWorkspace,
+            files: entries,
+          });
+        }
       })
       .catch(() => {
         if (mountedRef.current)
           Message.error(t("indexing.workspaceMemoryListFailed"));
       })
       .finally(() => {
-        if (mountedRef.current) setLoading(false);
+        if (mountedRef.current) {
+          dispatch({ type: "finishList", workspace: requestWorkspace });
+        }
       });
   }, [workspace, mountedRef, t]);
+
+  const fetchFiles = useCallback(() => {
+    if (!workspace) return;
+    dispatch({ type: "beginList", workspace });
+    requestFiles();
+  }, [requestFiles, workspace]);
 
   const { spinClass, handleClick: handleRefreshClick } = useRefreshSpin(
     fetchFiles,
@@ -112,29 +238,31 @@ export function useWorkspaceMemoryData({
   );
 
   useEffect(() => {
-    // setLoading(true) inside fetchFiles is intentional — it's the standard
-    // fetch-on-mount pattern. The setState call is not a cascade risk here
-    // because it fires synchronously only to show the loading indicator before
-    // the async RPC call resolves.
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    fetchFiles();
-  }, [fetchFiles]);
+    requestFiles();
+  }, [requestFiles]);
 
   const loadFileDetail = useCallback(
     (filename: string) => {
       if (!workspace) return;
+      const requestWorkspace = workspace;
       setDetail(null);
       rpc.workspaceMemory
-        .read({ workspace, filename })
+        .read({ workspace: requestWorkspace, filename })
         .then((detailResult: WorkspaceMemoryDetail) => {
-          if (mountedRef.current) setDetail(detailResult);
+          if (mountedRef.current) {
+            dispatch({
+              type: "setDetail",
+              workspace: requestWorkspace,
+              detail: detailResult,
+            });
+          }
         })
         .catch(() => {
           if (mountedRef.current)
             Message.error(t("indexing.workspaceMemoryReadFailed"));
         });
     },
-    [workspace, mountedRef, t]
+    [workspace, mountedRef, setDetail, t]
   );
 
   const setSingleExpandedFile = useCallback(
@@ -151,7 +279,14 @@ export function useWorkspaceMemoryData({
         setDetail(null);
       }
     },
-    [expandedFileKeys, loadFileDetail]
+    [
+      expandedFileKeys,
+      loadFileDetail,
+      setDetail,
+      setExpandedFileKeys,
+      setSelectedFile,
+      setShowIndex,
+    ]
   );
 
   const handleShowIndex = useCallback(() => {
@@ -163,13 +298,23 @@ export function useWorkspaceMemoryData({
     rpc.workspaceMemory
       .index({ workspace })
       .then((indexText: string) => {
-        if (mountedRef.current) setMemoryIndex(indexText);
+        if (mountedRef.current) {
+          dispatch({ type: "setMemoryIndex", workspace, value: indexText });
+        }
       })
       .catch(() => {
         if (mountedRef.current)
           Message.error(t("indexing.workspaceMemoryIndexFailed"));
       });
-  }, [workspace, mountedRef, t]);
+  }, [
+    workspace,
+    mountedRef,
+    setDetail,
+    setExpandedFileKeys,
+    setSelectedFile,
+    setShowIndex,
+    t,
+  ]);
 
   const handleDelete = useCallback(
     (filename: string) => {
@@ -195,7 +340,17 @@ export function useWorkspaceMemoryData({
           });
       });
     },
-    [workspace, mountedRef, selectedFile, fetchFiles, onRefreshStatus, t]
+    [
+      workspace,
+      mountedRef,
+      selectedFile,
+      fetchFiles,
+      onRefreshStatus,
+      setDetail,
+      setExpandedFileKeys,
+      setSelectedFile,
+      t,
+    ]
   );
 
   const handleClearAll = useCallback(() => {
@@ -224,7 +379,18 @@ export function useWorkspaceMemoryData({
           Message.error(t("indexing.workspaceMemoryClearFailed"));
         });
     });
-  }, [workspace, files.length, mountedRef, fetchFiles, onRefreshStatus, t]);
+  }, [
+    workspace,
+    files.length,
+    mountedRef,
+    fetchFiles,
+    onRefreshStatus,
+    setDetail,
+    setExpandedFileKeys,
+    setSelectedFile,
+    setShowIndex,
+    t,
+  ]);
 
   const filteredFiles = useMemo(() => {
     let result = files;

--- a/src/modules/ProjectManager/ProjectManagerLayout/components/ProjectWorkItemsTabContent.tsx
+++ b/src/modules/ProjectManager/ProjectManagerLayout/components/ProjectWorkItemsTabContent.tsx
@@ -28,6 +28,7 @@ import {
   filterWorkspaceWorkItemsByStatus,
   getWorkItemStatus,
   getWorkspaceStatusFilterKeysForWorkItems,
+  normalizeWorkspaceStatusFilter,
 } from "@src/modules/ProjectManager/WorkItems/workItemsViewModel";
 import {
   GITHUB_ISSUE_STATUS_OPTIONS,
@@ -125,19 +126,20 @@ export const ProjectWorkItemsTabContent: React.FC<
     () => getWorkspaceStatusFilterKeysForWorkItems(workItems),
     [workItems]
   );
-  useEffect(() => {
-    if (!statusFilterKeys.includes(statusFilter)) {
-      // Pre-existing reset behavior, unchanged by the file split. The analyzer
-      // only surfaces this now that the component is small enough to fully
-      // analyze; fixing it would be an out-of-scope behavior change.
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setStatusFilter("all");
-    }
-  }, [statusFilter, statusFilterKeys]);
+  const effectiveStatusFilter = normalizeWorkspaceStatusFilter(
+    statusFilter,
+    statusFilterKeys
+  );
+  if (effectiveStatusFilter !== statusFilter) {
+    // Normalize the selection in the same render that observes a changed
+    // result set. This prevents one committed frame with an impossible filter
+    // and avoids a post-commit effect cascade.
+    setStatusFilter(effectiveStatusFilter);
+  }
 
   const filteredWorkItems = useMemo(
-    () => filterWorkspaceWorkItemsByStatus(workItems, statusFilter),
-    [statusFilter, workItems]
+    () => filterWorkspaceWorkItemsByStatus(workItems, effectiveStatusFilter),
+    [effectiveStatusFilter, workItems]
   );
 
   const visibleWorkItems = useMemo(
@@ -145,7 +147,7 @@ export const ProjectWorkItemsTabContent: React.FC<
     [filteredWorkItems, searchQuery]
   );
   const completedStatusSelected =
-    statusFilter === "done" || statusFilter === "closed";
+    effectiveStatusFilter === "done" || effectiveStatusFilter === "closed";
 
   const {
     kanbanTasks,
@@ -418,7 +420,7 @@ export const ProjectWorkItemsTabContent: React.FC<
     const filters: SettingsTableSelectFilter[] = [
       {
         key: "status",
-        value: statusFilter,
+        value: effectiveStatusFilter,
         defaultValue: "all",
         options: statusFilterKeys.map((key) => {
           const label = t(`workItems.statusFilters.${key}`);
@@ -460,7 +462,7 @@ export const ProjectWorkItemsTabContent: React.FC<
     allowExternalSources,
     setWorkspaceSourceMode,
     statusCounts,
-    statusFilter,
+    effectiveStatusFilter,
     statusFilterKeys,
     t,
     workspaceSourceMode,
@@ -473,7 +475,7 @@ export const ProjectWorkItemsTabContent: React.FC<
         {activeViewTab === "Kanban" ? (
           <>
             <WorkItemsStatusFilterSelect
-              value={statusFilter}
+              value={effectiveStatusFilter}
               onChange={setStatusFilter}
               statusCounts={statusCounts}
               filterKeys={statusFilterKeys}
@@ -499,7 +501,7 @@ export const ProjectWorkItemsTabContent: React.FC<
       orgSurfaceControls,
       sourceModeSwitch,
       statusCounts,
-      statusFilter,
+      effectiveStatusFilter,
       statusFilterKeys,
       workItemsViewSwitch,
     ]

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemsSettings/index.tsx
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemsSettings/index.tsx
@@ -17,7 +17,7 @@ import {
   User,
   Users,
 } from "lucide-react";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { MemberEntry } from "@src/api/http/project";
@@ -80,16 +80,28 @@ export interface WorkItemsSettingsProps {
   /** Navigate to repo-level settings for full member management */
   onOpenRepoSettings?: () => void;
   /**
-   * Section to focus on mount or when the parent re-routes a deep-link
-   * request (Phase 4.8 Track D). Falls back to "general" when omitted.
+   * Deep-link request to apply. The monotonic stamp lets repeat requests for
+   * the same section remain distinct without resetting ordinary navigation.
    */
-  initialSection?: SettingsSectionId;
-  /**
-   * Called once after `initialSection` has been applied to local state,
-   * so the parent can clear its pending request and avoid re-applying
-   * the same section on subsequent renders.
-   */
-  onSectionConsumed?: () => void;
+  sectionRequest?: { section: SettingsSectionId; stamp: number };
+}
+
+interface SettingsSectionState {
+  activeSection: SettingsSectionId;
+  appliedRequestStamp: number | null;
+}
+
+export function advanceSettingsSectionState(
+  previous: SettingsSectionState,
+  request: WorkItemsSettingsProps["sectionRequest"]
+): SettingsSectionState {
+  if (!request || request.stamp === previous.appliedRequestStamp) {
+    return previous;
+  }
+  return {
+    activeSection: request.section,
+    appliedRequestStamp: request.stamp,
+  };
 }
 
 // ============================================
@@ -215,26 +227,25 @@ const WorkItemsSettings: React.FC<WorkItemsSettingsProps> = ({
   projectMembers,
   onUpdateProjectMembers,
   onOpenRepoSettings,
-  initialSection,
-  onSectionConsumed,
+  sectionRequest,
 }) => {
-  const [activeSection, setActiveSection] = useState<SettingsSectionId>(
-    initialSection ?? SETTINGS_SECTION_IDS.GENERAL
+  const [sectionState, setSectionState] = useState<SettingsSectionState>(
+    () => ({
+      activeSection: sectionRequest?.section ?? SETTINGS_SECTION_IDS.GENERAL,
+      appliedRequestStamp: sectionRequest?.stamp ?? null,
+    })
   );
-
-  // When the parent routes a new deep-link request, sync local state
-  // and notify it so the pending value is cleared in the same tick.
-  // The dependency on `initialSection` means a fresh request value
-  // (e.g. "sync") triggers exactly one update; clearing it on the
-  // parent side then stops the loop. The setState below is guarded
-  // by the early return + the parent clearing the prop synchronously,
-  // so cascading renders are bounded to one extra pass.
-  useEffect(() => {
-    if (initialSection === undefined) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setActiveSection(initialSection);
-    onSectionConsumed?.();
-  }, [initialSection, onSectionConsumed]);
+  const nextSectionState = advanceSettingsSectionState(
+    sectionState,
+    sectionRequest
+  );
+  if (nextSectionState !== sectionState) {
+    setSectionState(nextSectionState);
+  }
+  const activeSection = nextSectionState.activeSection;
+  const handleSectionClick = (section: SettingsSectionId) => {
+    setSectionState((current) => ({ ...current, activeSection: section }));
+  };
 
   const activeSectionConfig = SECTIONS.find(
     (section) => section.id === activeSection
@@ -270,7 +281,7 @@ const WorkItemsSettings: React.FC<WorkItemsSettingsProps> = ({
         listContent={
           <SettingsSidebar
             activeSection={activeSection}
-            onSectionClick={setActiveSection}
+            onSectionClick={handleSectionClick}
           />
         }
         mainContent={

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemsSettings/sectionState.test.ts
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemsSettings/sectionState.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { advanceSettingsSectionState } from ".";
+
+describe("advanceSettingsSectionState", () => {
+  it("applies each stamped deep-link request exactly once", () => {
+    const initial = {
+      activeSection: "general" as const,
+      appliedRequestStamp: null,
+    };
+    const first = advanceSettingsSectionState(initial, {
+      section: "sync",
+      stamp: 1,
+    });
+    expect(first).toEqual({
+      activeSection: "sync",
+      appliedRequestStamp: 1,
+    });
+    expect(
+      advanceSettingsSectionState(
+        { ...first, activeSection: "labels" },
+        { section: "sync", stamp: 1 }
+      )
+    ).toEqual({ activeSection: "labels", appliedRequestStamp: 1 });
+  });
+
+  it("reapplies the same section for a newer request stamp", () => {
+    expect(
+      advanceSettingsSectionState(
+        { activeSection: "labels", appliedRequestStamp: 1 },
+        { section: "sync", stamp: 2 }
+      )
+    ).toEqual({ activeSection: "sync", appliedRequestStamp: 2 });
+  });
+});

--- a/src/modules/ProjectManager/WorkItems/index.tsx
+++ b/src/modules/ProjectManager/WorkItems/index.tsx
@@ -41,7 +41,6 @@ import {
   WorkItemsPageHeader,
   WorkItemsTabContent,
 } from "./components";
-import type { SettingsSectionId } from "./components/WorkItemsSettings";
 import { getEffectiveWorkItemPrefix } from "./config";
 import { useBufferedProjectProperties } from "./hooks/useBufferedProjectProperties";
 import { useMultiSelect } from "./hooks/useMultiSelect";
@@ -238,34 +237,26 @@ const WorkItemsPage: React.FC<WorkItemsPageProps> = ({
     WORK_ITEMS_KANBAN_GROUP.STATUS
   );
 
-  // Pending Settings section forwarded to `WorkItemsSettings` once the
-  // user clicks the status-bar sync widget. Cleared on consumption so
-  // the same value never re-fires when the user later picks a
-  // different section in the sidebar.
-  const [pendingSettingsSection, setPendingSettingsSection] = useState<
-    SettingsSectionId | undefined
-  >(undefined);
-
-  // Deep-link consumer (Phase 4.8 Track D) — when the widget writes a
-  // request whose slug matches this project, switch to the Settings
-  // view, store the section to focus, and clear the atom in the same
-  // tick so a stale request never opens the wrong project's section.
-  // The setState calls below are guarded so they fire at most once per
-  // request value: the atom is cleared in the same effect run, so the
-  // next render exits early at the `!deepLinkRequest` check.
+  // Deep-link consumer (Phase 4.8 Track D) — keep the request available until
+  // the Settings view has rendered it once. Clearing it in the same effect as
+  // the tab switch would remove the request before WorkItemsSettings mounts.
+  const settingsSectionRequest =
+    deepLinkRequest && resolvedSlug && deepLinkRequest.slug === resolvedSlug
+      ? deepLinkRequest
+      : undefined;
   useEffect(() => {
-    if (!deepLinkRequest) return;
-    if (!resolvedSlug || deepLinkRequest.slug !== resolvedSlug) return;
-
-    handlers.handleTabChange("Settings");
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setPendingSettingsSection(deepLinkRequest.section);
+    if (!settingsSectionRequest) return;
+    if (state.activeTab !== "Settings") {
+      handleTabChange("Settings");
+      return;
+    }
     setDeepLinkRequest(null);
-  }, [deepLinkRequest, resolvedSlug, handlers, setDeepLinkRequest]);
-
-  const handleSettingsSectionConsumed = useCallback(() => {
-    setPendingSettingsSection(undefined);
-  }, []);
+  }, [
+    handleTabChange,
+    setDeepLinkRequest,
+    settingsSectionRequest,
+    state.activeTab,
+  ]);
 
   const confirmWorkItemDelete = useCallback(
     async (name?: string) =>
@@ -626,8 +617,7 @@ const WorkItemsPage: React.FC<WorkItemsPageProps> = ({
         projectMembers={displayProject.members ?? []}
         onUpdateProjectMembers={handleUpdateProjectMembers}
         onOpenRepoSettings={onOpenRepoSettings}
-        initialSection={pendingSettingsSection}
-        onSectionConsumed={handleSettingsSectionConsumed}
+        sectionRequest={settingsSectionRequest}
       />
     </Suspense>
   );

--- a/src/modules/ProjectManager/WorkItems/workItemsViewModel.ts
+++ b/src/modules/ProjectManager/WorkItems/workItemsViewModel.ts
@@ -185,6 +185,13 @@ export function getWorkspaceStatusFilterKeysForWorkItems(
   ];
 }
 
+export function normalizeWorkspaceStatusFilter(
+  statusFilter: StatusFilterType,
+  statusFilterKeys: readonly StatusFilterType[]
+): StatusFilterType {
+  return statusFilterKeys.includes(statusFilter) ? statusFilter : "all";
+}
+
 function mergeWorkspaceCompletedGroups<TWorkItem extends WorkItem>(
   groups: WorkItemGroup<TWorkItem>[]
 ): WorkItemGroup<TWorkItem>[] {

--- a/src/modules/ProjectManager/WorkItems/workspaceWorkItemsViewModel.test.ts
+++ b/src/modules/ProjectManager/WorkItems/workspaceWorkItemsViewModel.test.ts
@@ -7,6 +7,7 @@ import {
   filterWorkspaceWorkItemsByStatus,
   getWorkspaceStatusFilterKeysForWorkItems,
   groupWorkspaceWorkItemsForStatusFilter,
+  normalizeWorkspaceStatusFilter,
 } from "./workItemsViewModel";
 
 function workItem(id: string, status: WorkItemStatus): WorkItem {
@@ -64,6 +65,13 @@ describe("workspace work item status model", () => {
 
     expect(groups.find((group) => group.status === "completed")?.items).toEqual(
       []
+    );
+  });
+
+  it("normalizes a filter that disappears when the result set changes", () => {
+    expect(normalizeWorkspaceStatusFilter("done", ["all", "open"])).toBe("all");
+    expect(normalizeWorkspaceStatusFilter("open", ["all", "open"])).toBe(
+      "open"
     );
   });
 

--- a/src/modules/WorkStation/AppShell/hooks/useAppShellDock.test.ts
+++ b/src/modules/WorkStation/AppShell/hooks/useAppShellDock.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { advanceAppShellDockSnapshot } from "./useAppShellDock";
+
+describe("advanceAppShellDockSnapshot", () => {
+  it("accumulates each visited host without replacing the bounded set", () => {
+    const code = {
+      activeHost: "code",
+      hasRealTabs: true,
+      visitedModes: new Set(["code"]),
+    };
+    const browser = advanceAppShellDockSnapshot(code, "browser", true);
+    const project = advanceAppShellDockSnapshot(browser, "project", true);
+
+    expect([...project.visitedModes]).toEqual(["code", "browser", "project"]);
+    expect(advanceAppShellDockSnapshot(project, "project", true)).toBe(project);
+  });
+
+  it("releases every retained host when the real-tab pool empties", () => {
+    const cleared = advanceAppShellDockSnapshot(
+      {
+        activeHost: "project",
+        hasRealTabs: true,
+        visitedModes: new Set(["code", "project"]),
+      },
+      "code",
+      false
+    );
+
+    expect(cleared.visitedModes.size).toBe(0);
+  });
+});

--- a/src/modules/WorkStation/AppShell/hooks/useAppShellDock.ts
+++ b/src/modules/WorkStation/AppShell/hooks/useAppShellDock.ts
@@ -1,12 +1,46 @@
 import { useAtomValue } from "jotai";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { activeHostAtom } from "@src/store/workstation";
 import { mainPaneHasRealTabsAtom } from "@src/store/workstation/tabHost";
-import { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";
 
 export interface AppShellDockState {
   visitedModes: Set<string>;
+}
+
+interface AppShellDockSnapshot extends AppShellDockState {
+  activeHost: string;
+  hasRealTabs: boolean;
+}
+
+export function advanceAppShellDockSnapshot(
+  previous: AppShellDockSnapshot,
+  activeHost: string,
+  hasRealTabs: boolean
+): AppShellDockSnapshot {
+  if (
+    previous.activeHost === activeHost &&
+    previous.hasRealTabs === hasRealTabs
+  ) {
+    return previous;
+  }
+  if (!hasRealTabs) {
+    return {
+      activeHost,
+      hasRealTabs,
+      visitedModes:
+        previous.visitedModes.size === 0
+          ? previous.visitedModes
+          : new Set<string>(),
+    };
+  }
+  return {
+    activeHost,
+    hasRealTabs,
+    visitedModes: previous.visitedModes.has(activeHost)
+      ? previous.visitedModes
+      : new Set([...previous.visitedModes, activeHost]),
+  };
 }
 
 /**
@@ -30,34 +64,22 @@ export function useAppShellDock(): AppShellDockState {
   const activeHost = useAtomValue(activeHostAtom);
   const hasRealTabs = useAtomValue(mainPaneHasRealTabsAtom);
 
-  // Seed with the active tab's host on first render so the host pane that
-  // owns a restored active tab is kept warm from the same commit (no blank
-  // 40px header strip when switching away and back within the first frame).
-  const [visitedModes, setVisitedModes] = useState<Set<string>>(() => {
-    if (!hasRealTabs) return new Set();
-    try {
-      const store = getInstrumentedStore();
-      return new Set([store.get(activeHostAtom)]);
-    } catch {
-      // Store not yet available in some test environments — fine.
-      return new Set(["code"]);
-    }
-  });
+  // Seed and advance the host history in render so a newly active host is
+  // available in the same commit. The set is bounded by the three host names
+  // and is cleared synchronously when the real-tab pool empties.
+  const [snapshot, setSnapshot] = useState<AppShellDockSnapshot>(() => ({
+    activeHost,
+    hasRealTabs,
+    visitedModes: hasRealTabs ? new Set([activeHost]) : new Set(),
+  }));
+  const nextSnapshot = advanceAppShellDockSnapshot(
+    snapshot,
+    activeHost,
+    hasRealTabs
+  );
+  if (nextSnapshot !== snapshot) {
+    setSnapshot(nextSnapshot);
+  }
 
-  useEffect(() => {
-    if (!hasRealTabs) {
-      // Empty pool (Launchpad only): release every kept-alive host. The next
-      // real tab re-mounts its host synchronously via the `is*Mode` branch in
-      // AppShellContent, so clearing here never delays a visible surface.
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setVisitedModes((prev) => (prev.size === 0 ? prev : new Set()));
-      return;
-    }
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    setVisitedModes((prev) =>
-      prev.has(activeHost) ? prev : new Set([...prev, activeHost])
-    );
-  }, [activeHost, hasRealTabs]);
-
-  return { visitedModes };
+  return { visitedModes: nextSnapshot.visitedModes };
 }

--- a/src/modules/WorkStation/Browser/hooks/browserDiagnosticsLifecycle.test.ts
+++ b/src/modules/WorkStation/Browser/hooks/browserDiagnosticsLifecycle.test.ts
@@ -136,6 +136,51 @@ describe("browser diagnostics lifecycle", () => {
     expect(latest!.entries).toEqual([]);
   });
 
+  it("switches console sessions directly to each cached snapshot", () => {
+    let latest: UseBrowserConsoleReturn | null = null;
+    const Harness = ({
+      onValue,
+      ...options
+    }: UseBrowserConsoleOptions & {
+      onValue: (value: UseBrowserConsoleReturn) => void;
+    }) => {
+      const value = useBrowserConsole(options);
+      useEffect(() => onValue(value), [onValue, value]);
+      return null;
+    };
+    const capture = (value: UseBrowserConsoleReturn) => {
+      latest = value;
+    };
+
+    act(() => {
+      root.render(
+        createElement(Harness, {
+          enabled: true,
+          sessionId: "session-1",
+          webviewLabel: "browser-session-1",
+          pollInterval: 0,
+          onValue: capture,
+        })
+      );
+    });
+    act(() => latest!.addEntry("log", "session one"));
+    expect(latest!.entries.map((entry) => entry.message)).toEqual([
+      "session one",
+    ]);
+
+    act(() => latest!.setSessionId("session-2"));
+    expect(latest!.entries).toEqual([]);
+    act(() => latest!.addEntry("warn", "session two"));
+    expect(latest!.entries.map((entry) => entry.message)).toEqual([
+      "session two",
+    ]);
+
+    act(() => latest!.setSessionId("session-1"));
+    expect(latest!.entries.map((entry) => entry.message)).toEqual([
+      "session one",
+    ]);
+  });
+
   it("releases network rows and rejects a poll that finishes after close", async () => {
     let latest: UseBrowserNetworkLogsReturn | null = null;
     const request = deferred<

--- a/src/modules/WorkStation/Browser/hooks/useBrowserConsole.ts
+++ b/src/modules/WorkStation/Browser/hooks/useBrowserConsole.ts
@@ -9,12 +9,20 @@
  * are not available inside inline webviews loading external URLs.
  */
 import { invoke } from "@tauri-apps/api/core";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 
 import { createLogger } from "@src/hooks/logger";
 import { startVisibilityAwarePoller } from "@src/shared/scheduling/visibilityAwarePoller";
 
 const log = createLogger("useBrowserConsole");
+const EMPTY_CONSOLE_ENTRIES: ConsoleEntry[] = [];
 
 // ============================================
 // Types
@@ -115,8 +123,29 @@ export function useBrowserConsole(
   const MAX_SESSION_CACHE = 10;
   const cacheRef = useRef<Map<string, SessionLogCache>>(new Map());
 
-  // Current session's entries (state)
-  const [entries, setEntries] = useState<ConsoleEntry[]>([]);
+  // Cache contents are authoritative. Expose them through the external-store
+  // contract so a session switch reads its cached snapshot in the same render,
+  // while poll/event mutations notify only this hook's consumer.
+  const entryListenersRef = useRef(new Set<() => void>());
+  const subscribeEntries = useCallback((listener: () => void) => {
+    entryListenersRef.current.add(listener);
+    return () => entryListenersRef.current.delete(listener);
+  }, []);
+  const getEntriesSnapshot = useCallback(
+    () =>
+      enabled && sessionId
+        ? (cacheRef.current.get(sessionId)?.entries ?? EMPTY_CONSOLE_ENTRIES)
+        : EMPTY_CONSOLE_ENTRIES,
+    [enabled, sessionId]
+  );
+  const entries = useSyncExternalStore(
+    subscribeEntries,
+    getEntriesSnapshot,
+    getEntriesSnapshot
+  );
+  const notifyEntriesChange = useCallback(() => {
+    for (const listener of entryListenersRef.current) listener();
+  }, []);
   const pollGenerationRef = useRef(0);
 
   const entryIdCounter = useRef(0);
@@ -161,18 +190,11 @@ export function useBrowserConsole(
 
       // Update state if this is the current session
       if (sid === sessionId) {
-        setEntries(newEntries);
+        notifyEntriesChange();
       }
     },
-    [sessionId, getSessionCache]
+    [sessionId, getSessionCache, notifyEntriesChange]
   );
-
-  // Sync entries with cache when sessionId changes
-  useEffect(() => {
-    const cache = sessionId ? getSessionCache(sessionId) : null;
-    setEntries(cache ? cache.entries : []);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionId]); // Deliberately omit getSessionCache to avoid re-running on every render
 
   // Add entry manually
   const addEntry = useCallback(
@@ -210,18 +232,18 @@ export function useBrowserConsole(
   const clearAllEntries = useCallback(() => {
     pollGenerationRef.current += 1;
     cacheRef.current.clear();
-    setEntries([]);
-  }, []);
+    notifyEntriesChange();
+  }, [notifyEntriesChange]);
 
   const clearSessionEntries = useCallback(
     (closedSessionId: string) => {
       cacheRef.current.delete(closedSessionId);
       if (closedSessionId === sessionId) {
         pollGenerationRef.current += 1;
-        setEntries([]);
+        notifyEntriesChange();
       }
     },
-    [sessionId]
+    [notifyEntriesChange, sessionId]
   );
 
   // Truncate message if too long
@@ -358,7 +380,6 @@ export function useBrowserConsole(
     const generation = ++pollGenerationRef.current;
     if (!enabled) {
       cacheRef.current.clear();
-      setEntries([]);
     }
     return () => {
       if (generation === pollGenerationRef.current) {

--- a/src/modules/WorkStation/Browser/hooks/useBrowserNetworkLogs.ts
+++ b/src/modules/WorkStation/Browser/hooks/useBrowserNetworkLogs.ts
@@ -6,12 +6,20 @@
  * Caches logs per session/tab for persistence when switching.
  */
 import { invoke } from "@tauri-apps/api/core";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 
 import { createLogger } from "@src/hooks/logger";
 import { startVisibilityAwarePoller } from "@src/shared/scheduling/visibilityAwarePoller";
 
 const log = createLogger("useBrowserNetworkLogs");
+const EMPTY_NETWORK_ENTRIES: NetworkEntry[] = [];
 
 // ============================================
 // Types
@@ -103,8 +111,29 @@ export function useBrowserNetworkLogs(
   const MAX_SESSION_CACHE = 10;
   const cacheRef = useRef<Map<string, SessionNetworkCache>>(new Map());
 
-  // Current session's entries (state)
-  const [entries, setEntries] = useState<NetworkEntry[]>([]);
+  // Cache contents are authoritative. Expose them through the external-store
+  // contract so a session switch reads its cached snapshot in the same render,
+  // while poll/event mutations notify only this hook's consumer.
+  const entryListenersRef = useRef(new Set<() => void>());
+  const subscribeEntries = useCallback((listener: () => void) => {
+    entryListenersRef.current.add(listener);
+    return () => entryListenersRef.current.delete(listener);
+  }, []);
+  const getEntriesSnapshot = useCallback(
+    () =>
+      enabled && sessionId
+        ? (cacheRef.current.get(sessionId)?.entries ?? EMPTY_NETWORK_ENTRIES)
+        : EMPTY_NETWORK_ENTRIES,
+    [enabled, sessionId]
+  );
+  const entries = useSyncExternalStore(
+    subscribeEntries,
+    getEntriesSnapshot,
+    getEntriesSnapshot
+  );
+  const notifyEntriesChange = useCallback(() => {
+    for (const listener of entryListenersRef.current) listener();
+  }, []);
   const pollGenerationRef = useRef(0);
 
   // Get or create cache entry for a session
@@ -138,18 +167,11 @@ export function useBrowserNetworkLogs(
 
       // Update state if this is the current session
       if (sid === sessionId) {
-        setEntries(newEntries);
+        notifyEntriesChange();
       }
     },
-    [sessionId, getSessionCache]
+    [sessionId, getSessionCache, notifyEntriesChange]
   );
-
-  // Sync entries with cache when sessionId changes
-  useEffect(() => {
-    const cache = sessionId ? getSessionCache(sessionId) : null;
-    setEntries(cache ? cache.entries : []);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionId]); // Deliberately omit getSessionCache to avoid re-running on every render
 
   // Clear entries for current session
   const clearEntries = useCallback(() => {
@@ -162,18 +184,18 @@ export function useBrowserNetworkLogs(
   const clearAllEntries = useCallback(() => {
     pollGenerationRef.current += 1;
     cacheRef.current.clear();
-    setEntries([]);
-  }, []);
+    notifyEntriesChange();
+  }, [notifyEntriesChange]);
 
   const clearSessionEntries = useCallback(
     (closedSessionId: string) => {
       cacheRef.current.delete(closedSessionId);
       if (closedSessionId === sessionId) {
         pollGenerationRef.current += 1;
-        setEntries([]);
+        notifyEntriesChange();
       }
     },
-    [sessionId]
+    [notifyEntriesChange, sessionId]
   );
 
   // Poll for network logs from webview
@@ -236,7 +258,6 @@ export function useBrowserNetworkLogs(
     const generation = ++pollGenerationRef.current;
     if (!enabled) {
       cacheRef.current.clear();
-      setEntries([]);
     }
     return () => {
       if (generation === pollGenerationRef.current) {

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitDiffContent/useGitDiffLoader.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitDiffContent/useGitDiffLoader.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { act, createElement, useEffect } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import type { GitFile } from "@src/types/git/types";
+
+import { useGitDiffLoader } from "./useGitDiffLoader";
+
+const mocks = vi.hoisted(() => ({ loadWorkingTreeDiff: vi.fn() }));
+
+vi.mock("@src/services/git/workingTreeDiffResource", () => ({
+  loadWorkingTreeDiff: mocks.loadWorkingTreeDiff,
+}));
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function gitFile(id: string): GitFile {
+  return {
+    id,
+    path: `/repo/${id}.ts`,
+    status: "modified",
+    additions: 1,
+    deletions: 1,
+    staged: false,
+  };
+}
+
+describe("useGitDiffLoader", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(reactActEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("ignores an obsolete request after the selected file changes", async () => {
+    const first = deferred<{
+      oldContent: string;
+      newContent: string;
+      additions: number;
+      deletions: number;
+      binary: boolean;
+    } | null>();
+    const second = deferred<{
+      oldContent: string;
+      newContent: string;
+      additions: number;
+      deletions: number;
+      binary: boolean;
+    } | null>();
+    mocks.loadWorkingTreeDiff
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    let latest: ReturnType<typeof useGitDiffLoader> | null = null;
+    const Harness = ({ file }: { file: GitFile }) => {
+      const value = useGitDiffLoader({ gitFile: file, repoPath: "/repo" });
+      useEffect(() => {
+        latest = value;
+      }, [value]);
+      return null;
+    };
+
+    act(() => root.render(createElement(Harness, { file: gitFile("a") })));
+    expect(latest!.selfFetching).toBe(true);
+
+    act(() => root.render(createElement(Harness, { file: gitFile("b") })));
+    await act(async () => {
+      first.resolve({
+        oldContent: "old a",
+        newContent: "new a",
+        additions: 1,
+        deletions: 1,
+        binary: false,
+      });
+      await first.promise;
+    });
+    expect(latest!.effectiveGitFile?.path).toBe("/repo/b.ts");
+    expect(latest!.effectiveGitFile?.oldContent).toBeUndefined();
+    expect(latest!.selfFetching).toBe(true);
+
+    await act(async () => {
+      second.resolve({
+        oldContent: "old b",
+        newContent: "new b",
+        additions: 2,
+        deletions: 3,
+        binary: false,
+      });
+      await second.promise;
+    });
+    expect(latest!.effectiveGitFile).toMatchObject({
+      path: "/repo/b.ts",
+      oldContent: "old b",
+      newContent: "new b",
+      additions: 2,
+      deletions: 3,
+    });
+    expect(latest!.selfFetching).toBe(false);
+  });
+});

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitDiffContent/useGitDiffLoader.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/content/GitDiffContent/useGitDiffLoader.ts
@@ -12,7 +12,10 @@
 import { useEffect, useMemo, useState } from "react";
 
 import { createLogger } from "@src/hooks/logger";
-import { loadWorkingTreeDiff } from "@src/services/git/workingTreeDiffResource";
+import {
+  type WorkingTreeDiffRequest,
+  loadWorkingTreeDiff,
+} from "@src/services/git/workingTreeDiffResource";
 import type { GitFile } from "@src/types/git/types";
 
 const log = createLogger("GitDiffContent");
@@ -37,84 +40,144 @@ interface UseGitDiffLoaderResult {
   selfFetching: boolean;
 }
 
+interface DiffLoadState {
+  requestKey: string | null;
+  fetchedDiff: FetchedDiff | null;
+  selfFetching: boolean;
+}
+
+function getDiffRequestKey(gitFile: GitFile | null, repoPath: string) {
+  if (!gitFile || !repoPath || gitFile.oldContent !== undefined) return null;
+  if (gitFile.id?.startsWith("timeline:")) return null;
+  return JSON.stringify([
+    repoPath,
+    gitFile.id,
+    gitFile.path,
+    gitFile.original_path,
+    gitFile.status,
+    gitFile.staged,
+    gitFile.repoRoot,
+  ]);
+}
+
+function getDiffRequest(
+  requestKey: string | null
+): WorkingTreeDiffRequest | null {
+  if (!requestKey) return null;
+  const [repoPath, , path, originalPath, status, staged, repoRoot] = JSON.parse(
+    requestKey
+  ) as [
+    string,
+    string,
+    string,
+    string | null,
+    GitFile["status"],
+    boolean,
+    string | null,
+  ];
+  return {
+    repoPath,
+    file: {
+      path,
+      original_path: originalPath,
+      status,
+      staged,
+      repoRoot: repoRoot ?? undefined,
+    },
+  };
+}
+
 export function useGitDiffLoader({
   gitFile,
   repoPath,
 }: UseGitDiffLoaderOptions): UseGitDiffLoaderResult {
-  const [fetchedDiff, setFetchedDiff] = useState<FetchedDiff | null>(null);
-  const [selfFetching, setSelfFetching] = useState(false);
+  const requestKey = getDiffRequestKey(gitFile, repoPath);
+  const diffRequest = useMemo(() => getDiffRequest(requestKey), [requestKey]);
+  const [loadState, setLoadState] = useState<DiffLoadState>(() => ({
+    requestKey,
+    fetchedDiff: null,
+    selfFetching: requestKey !== null,
+  }));
+  const nextLoadState =
+    loadState.requestKey === requestKey
+      ? loadState
+      : {
+          requestKey,
+          fetchedDiff: null,
+          selfFetching: requestKey !== null,
+        };
+  if (nextLoadState !== loadState) {
+    setLoadState(nextLoadState);
+  }
+  const { fetchedDiff, selfFetching } = nextLoadState;
 
-  // Reset cached diff when file path changes.
   useEffect(() => {
-    setFetchedDiff(null);
-  }, [gitFile?.path]);
-
-  useEffect(() => {
-    if (!gitFile || !repoPath) return;
-    if (gitFile.oldContent !== undefined) return;
-    // Timeline diffs are keyed by tab id and are populated synchronously by
-    // `handleTimelineCommitClick`; a working-tree fetch would be wrong.
-    if (gitFile.id?.startsWith("timeline:")) return;
-    if (fetchedDiff?.path === gitFile.path) return;
+    if (!requestKey || !diffRequest) return;
+    const diffPath = diffRequest.file.path;
+    if (fetchedDiff?.path === diffPath) return;
 
     let cancelled = false;
-    setSelfFetching(true);
-    loadWorkingTreeDiff({
-      repoPath,
-      file: gitFile,
-    })
+    loadWorkingTreeDiff(diffRequest)
       .then((diff) => {
         if (cancelled) return;
         if (!diff) {
-          setFetchedDiff({
-            path: gitFile.path,
-            oldContent: "",
-            newContent: "",
-            additions: 0,
-            deletions: 0,
-          });
+          setLoadState((current) =>
+            current.requestKey === requestKey
+              ? {
+                  ...current,
+                  fetchedDiff: {
+                    path: diffPath,
+                    oldContent: "",
+                    newContent: "",
+                    additions: 0,
+                    deletions: 0,
+                  },
+                  selfFetching: false,
+                }
+              : current
+          );
           return;
         }
-        setFetchedDiff({
-          path: gitFile.path,
-          oldContent: diff.oldContent,
-          newContent: diff.newContent,
-          additions: diff.additions,
-          deletions: diff.deletions,
-        });
+        setLoadState((current) =>
+          current.requestKey === requestKey
+            ? {
+                ...current,
+                fetchedDiff: {
+                  path: diffPath,
+                  oldContent: diff.oldContent,
+                  newContent: diff.newContent,
+                  additions: diff.additions,
+                  deletions: diff.deletions,
+                },
+                selfFetching: false,
+              }
+            : current
+        );
       })
       .catch((error) => {
         if (cancelled) return;
         log.error("[GitDiffContent] Self-fetch failed:", error);
-        setFetchedDiff({
-          path: gitFile.path,
-          oldContent: "",
-          newContent: "",
-          additions: 0,
-          deletions: 0,
-        });
-      })
-      .finally(() => {
-        if (!cancelled) setSelfFetching(false);
+        setLoadState((current) =>
+          current.requestKey === requestKey
+            ? {
+                ...current,
+                fetchedDiff: {
+                  path: diffPath,
+                  oldContent: "",
+                  newContent: "",
+                  additions: 0,
+                  deletions: 0,
+                },
+                selfFetching: false,
+              }
+            : current
+        );
       });
 
     return () => {
       cancelled = true;
     };
-    // We intentionally depend on the narrow set of fields that determine
-    // whether a fetch is needed, not on the full gitFile reference, to avoid
-    // re-firing whenever the parent passes a new object identity.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    gitFile?.path,
-    gitFile?.oldContent,
-    gitFile?.id,
-    gitFile?.original_path,
-    gitFile?.status,
-    gitFile?.staged,
-    repoPath,
-    fetchedDiff?.path,
-  ]);
+  }, [diffRequest, fetchedDiff?.path, requestKey]);
 
   // Effective gitFile = prop ∪ self-fetched override (when prop content is missing).
   const effectiveGitFile = useMemo<GitFile | null>(() => {

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SearchContent/components/SearchResults.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SearchContent/components/SearchResults.tsx
@@ -15,10 +15,8 @@ import React, {
   forwardRef,
   memo,
   useCallback,
-  useEffect,
   useImperativeHandle,
   useMemo,
-  useRef,
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
@@ -54,6 +52,10 @@ import {
   useIsSearchResultSelected,
 } from "@src/store/ui/searchResultSelectionAtom";
 
+import {
+  advanceSearchResultCollapseState,
+  createSearchResultCollapseState,
+} from "./searchResultCollapseState";
 import type { SearchMatch, SearchResultFile } from "./types";
 import { formatSearchMatch } from "./utils";
 
@@ -272,58 +274,27 @@ const SearchResultsInner = forwardRef<SearchResultsHandle, SearchResultsProps>(
       [results]
     );
 
-    const [collapsedFiles, setCollapsedFiles] = useState<Set<string>>(
-      new Set()
+    const [collapseState, setCollapseState] = useState(() =>
+      createSearchResultCollapseState(
+        results,
+        totalMatches,
+        AUTO_COLLAPSE_THRESHOLD
+      )
     );
-    const prevFirstFileRef = useRef<string>("");
-    const prevResultCountRef = useRef(0);
-    const isInitializedRef = useRef(false);
-
-    // Auto-collapse logic:
-    // - On new search: if > threshold, collapse all
-    // - On load more: if > threshold, collapse newly added files
-    useEffect(() => {
-      const firstFile = results[0]?.file_path || "";
-      const prevFirstFile = prevFirstFileRef.current;
-      const prevResultCount = prevResultCountRef.current;
-
-      prevFirstFileRef.current = firstFile;
-      prevResultCountRef.current = results.length;
-
-      if (!isInitializedRef.current) {
-        isInitializedRef.current = true;
-        if (totalMatches > AUTO_COLLAPSE_THRESHOLD) {
-          const allPaths = new Set(results.map((result) => result.file_path));
-          setCollapsedFiles(allPaths);
-        }
-        return;
-      }
-
-      const isNewSearch = firstFile !== prevFirstFile && firstFile !== "";
-      const isLoadMore = results.length > prevResultCount && !isNewSearch;
-
-      if (isNewSearch) {
-        // New search - collapse all if above threshold, otherwise expand all
-        if (totalMatches > AUTO_COLLAPSE_THRESHOLD) {
-          const allPaths = new Set(results.map((result) => result.file_path));
-          setCollapsedFiles(allPaths);
-        } else {
-          setCollapsedFiles(new Set());
-        }
-      } else if (isLoadMore && totalMatches > AUTO_COLLAPSE_THRESHOLD) {
-        // Loading more results while above threshold - collapse new files
-        setCollapsedFiles((prev) => {
-          const newPaths = new Set(prev);
-          for (const result of results) {
-            if (!prev.has(result.file_path)) {
-              newPaths.add(result.file_path);
-            }
-          }
-          return newPaths;
-        });
-      }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [results.length, totalMatches]);
+    const nextCollapseState = advanceSearchResultCollapseState(
+      collapseState,
+      results,
+      totalMatches,
+      AUTO_COLLAPSE_THRESHOLD,
+      true
+    );
+    if (nextCollapseState !== collapseState) {
+      setCollapseState(nextCollapseState);
+    }
+    const collapsedFiles = nextCollapseState.collapsedFiles;
+    const setCollapsedFiles = (next: Set<string>) => {
+      setCollapseState((current) => ({ ...current, collapsedFiles: next }));
+    };
 
     useImperativeHandle(
       ref,
@@ -337,14 +308,15 @@ const SearchResultsInner = forwardRef<SearchResultsHandle, SearchResultsProps>(
     );
 
     const toggleFile = useCallback((filePath: string) => {
-      setCollapsedFiles((prev) => {
+      setCollapseState((current) => {
+        const prev = current.collapsedFiles;
         const next = new Set(prev);
         if (next.has(filePath)) {
           next.delete(filePath);
         } else {
           next.add(filePath);
         }
-        return next;
+        return { ...current, collapsedFiles: next };
       });
     }, []);
 

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SearchContent/components/VirtualizedSearchResults.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SearchContent/components/VirtualizedSearchResults.tsx
@@ -15,10 +15,8 @@ import React, {
   forwardRef,
   memo,
   useCallback,
-  useEffect,
   useImperativeHandle,
   useMemo,
-  useRef,
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
@@ -53,6 +51,10 @@ import {
   useIsSearchResultSelected,
 } from "@src/store/ui/searchResultSelectionAtom";
 
+import {
+  advanceSearchResultCollapseState,
+  createSearchResultCollapseState,
+} from "./searchResultCollapseState";
 import type { SearchMatch, SearchResultFile } from "./types";
 import { formatSearchMatch } from "./utils";
 
@@ -283,38 +285,27 @@ const VirtualizedSearchResultsInner = forwardRef<
       [results]
     );
 
-    const [collapsedFiles, setCollapsedFiles] = useState<Set<string>>(
-      new Set()
+    const [collapseState, setCollapseState] = useState(() =>
+      createSearchResultCollapseState(
+        results,
+        totalMatches,
+        AUTO_COLLAPSE_THRESHOLD
+      )
     );
-    const prevFirstFileRef = useRef<string>("");
-    const isInitializedRef = useRef(false);
-
-    // Auto-collapse on new searches
-    useEffect(() => {
-      const firstFile = results[0]?.file_path || "";
-      const prevFirstFile = prevFirstFileRef.current;
-      prevFirstFileRef.current = firstFile;
-
-      if (!isInitializedRef.current) {
-        isInitializedRef.current = true;
-        if (totalMatches > AUTO_COLLAPSE_THRESHOLD) {
-          const allPaths = new Set(results.map((result) => result.file_path));
-          setCollapsedFiles(allPaths);
-        }
-        return;
-      }
-
-      const isNewSearch = firstFile !== prevFirstFile && firstFile !== "";
-      if (isNewSearch) {
-        if (totalMatches > AUTO_COLLAPSE_THRESHOLD) {
-          const allPaths = new Set(results.map((result) => result.file_path));
-          setCollapsedFiles(allPaths);
-        } else {
-          setCollapsedFiles(new Set());
-        }
-      }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [results.length, totalMatches]);
+    const nextCollapseState = advanceSearchResultCollapseState(
+      collapseState,
+      results,
+      totalMatches,
+      AUTO_COLLAPSE_THRESHOLD,
+      false
+    );
+    if (nextCollapseState !== collapseState) {
+      setCollapseState(nextCollapseState);
+    }
+    const collapsedFiles = nextCollapseState.collapsedFiles;
+    const setCollapsedFiles = (next: Set<string>) => {
+      setCollapseState((current) => ({ ...current, collapsedFiles: next }));
+    };
 
     useImperativeHandle(
       ref,
@@ -334,14 +325,15 @@ const VirtualizedSearchResultsInner = forwardRef<
     );
 
     const toggleFile = useCallback((filePath: string) => {
-      setCollapsedFiles((prev) => {
+      setCollapseState((current) => {
+        const prev = current.collapsedFiles;
         const next = new Set(prev);
         if (next.has(filePath)) {
           next.delete(filePath);
         } else {
           next.add(filePath);
         }
-        return next;
+        return { ...current, collapsedFiles: next };
       });
     }, []);
 

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SearchContent/components/searchResultCollapseState.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SearchContent/components/searchResultCollapseState.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  advanceSearchResultCollapseState,
+  createSearchResultCollapseState,
+} from "./searchResultCollapseState";
+import type { SearchResultFile } from "./types";
+
+const result = (filePath: string, matchCount: number): SearchResultFile => ({
+  file_path: filePath,
+  matches: Array.from({ length: matchCount }, () => ({
+    line: 1,
+    column: 1,
+    text: "match",
+    context_before: "",
+    context_after: "",
+  })),
+});
+
+describe("search result collapse state", () => {
+  it("auto-collapses an oversized initial result without a post-commit reset", () => {
+    const state = createSearchResultCollapseState(
+      [result("a.ts", 20), result("b.ts", 20)],
+      40,
+      25
+    );
+    expect([...state.collapsedFiles]).toEqual(["a.ts", "b.ts"]);
+  });
+
+  it("resets user collapse state for a new small search", () => {
+    const previous = {
+      firstFile: "a.ts",
+      resultCount: 2,
+      collapsedFiles: new Set(["a.ts", "b.ts"]),
+    };
+    const next = advanceSearchResultCollapseState(
+      previous,
+      [result("new.ts", 1)],
+      1,
+      25,
+      true
+    );
+    expect(next.collapsedFiles.size).toBe(0);
+  });
+
+  it("collapses newly loaded files only on the load-more surface", () => {
+    const previous = {
+      firstFile: "a.ts",
+      resultCount: 1,
+      collapsedFiles: new Set<string>(),
+    };
+    const results = [result("a.ts", 20), result("b.ts", 20)];
+    expect(
+      advanceSearchResultCollapseState(previous, results, 40, 25, true)
+        .collapsedFiles
+    ).toEqual(new Set(["a.ts", "b.ts"]));
+    expect(
+      advanceSearchResultCollapseState(previous, results, 40, 25, false)
+        .collapsedFiles
+    ).toEqual(new Set());
+  });
+});

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SearchContent/components/searchResultCollapseState.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SearchContent/components/searchResultCollapseState.ts
@@ -1,0 +1,67 @@
+import type { SearchResultFile } from "./types";
+
+export interface SearchResultCollapseState {
+  firstFile: string;
+  resultCount: number;
+  collapsedFiles: Set<string>;
+}
+
+function allResultPaths(results: SearchResultFile[]): Set<string> {
+  return new Set(results.map((result) => result.file_path));
+}
+
+export function createSearchResultCollapseState(
+  results: SearchResultFile[],
+  totalMatches: number,
+  autoCollapseThreshold: number
+): SearchResultCollapseState {
+  return {
+    firstFile: results[0]?.file_path ?? "",
+    resultCount: results.length,
+    collapsedFiles:
+      totalMatches > autoCollapseThreshold
+        ? allResultPaths(results)
+        : new Set(),
+  };
+}
+
+export function advanceSearchResultCollapseState(
+  previous: SearchResultCollapseState,
+  results: SearchResultFile[],
+  totalMatches: number,
+  autoCollapseThreshold: number,
+  collapseNewFilesOnLoadMore: boolean
+): SearchResultCollapseState {
+  const firstFile = results[0]?.file_path ?? "";
+  if (
+    previous.firstFile === firstFile &&
+    previous.resultCount === results.length
+  ) {
+    return previous;
+  }
+
+  const isNewSearch = firstFile !== previous.firstFile && firstFile !== "";
+  const isLoadMore = results.length > previous.resultCount && !isNewSearch;
+  let collapsedFiles = previous.collapsedFiles;
+  if (isNewSearch) {
+    collapsedFiles =
+      totalMatches > autoCollapseThreshold
+        ? allResultPaths(results)
+        : new Set();
+  } else if (
+    collapseNewFilesOnLoadMore &&
+    isLoadMore &&
+    totalMatches > autoCollapseThreshold
+  ) {
+    collapsedFiles = new Set(previous.collapsedFiles);
+    for (const result of results) {
+      collapsedFiles.add(result.file_path);
+    }
+  }
+
+  return {
+    firstFile,
+    resultCount: results.length,
+    collapsedFiles,
+  };
+}

--- a/src/modules/shared/DevTools/ComponentIssueModal/index.tsx
+++ b/src/modules/shared/DevTools/ComponentIssueModal/index.tsx
@@ -38,8 +38,11 @@ const ModalComponentIssue: React.FC<ComponentIssueModalExtendedProps> = ({
   onClose,
   onNavigate,
 }) => {
-  const [searchQuery, setSearchQuery] = useState("");
-  const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
+  const [searchState, setSearchState] = useState({
+    query: "",
+    currentMatchIndex: 0,
+  });
+  const { query: searchQuery, currentMatchIndex } = searchState;
   const searchInputRef = useRef<HTMLInputElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
 
@@ -121,7 +124,10 @@ const ModalComponentIssue: React.FC<ComponentIssueModalExtendedProps> = ({
           : currentMatchIndex <= 0
             ? matches.length - 1
             : currentMatchIndex - 1;
-      setCurrentMatchIndex(newIndex);
+      setSearchState((current) => ({
+        ...current,
+        currentMatchIndex: newIndex,
+      }));
       scrollToMatch(newIndex);
     },
     [currentMatchIndex, getMatchingSections, scrollToMatch]
@@ -164,44 +170,45 @@ const ModalComponentIssue: React.FC<ComponentIssueModalExtendedProps> = ({
   }, [visible, onClose, onNavigate, searchQuery, navigateMatch]);
 
   useEffect(() => {
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    setCurrentMatchIndex(0);
-    if (searchQuery.trim()) setTimeout(() => scrollToMatch(0), 50);
+    if (!searchQuery.trim()) return;
+    const timer = setTimeout(() => scrollToMatch(0), 50);
+    return () => clearTimeout(timer);
   }, [searchQuery, scrollToMatch]);
 
   useEffect(() => {
-    if (visible && searchInputRef.current) {
-      setTimeout(() => {
-        let inputElement: HTMLInputElement | null = null;
-        const ref = searchInputRef.current;
-        if (ref instanceof HTMLInputElement) {
-          inputElement = ref;
-        } else if (ref && typeof ref === "object" && "dom" in ref) {
-          inputElement = (ref as { dom?: HTMLInputElement }).dom || null;
-        } else if (ref && typeof ref === "object" && "querySelector" in ref) {
-          inputElement = (ref as HTMLElement).querySelector("input");
-        }
-        inputElement?.focus();
-      }, 50);
-    }
-    if (!visible) {
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      setSearchQuery("");
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      setCurrentMatchIndex(0);
-    }
+    if (!visible || !searchInputRef.current) return;
+    const timer = setTimeout(() => {
+      let inputElement: HTMLInputElement | null = null;
+      const ref = searchInputRef.current;
+      if (ref instanceof HTMLInputElement) {
+        inputElement = ref;
+      } else if (ref && typeof ref === "object" && "dom" in ref) {
+        inputElement = (ref as { dom?: HTMLInputElement }).dom || null;
+      } else if (ref && typeof ref === "object" && "querySelector" in ref) {
+        inputElement = (ref as HTMLElement).querySelector("input");
+      }
+      inputElement?.focus();
+    }, 50);
+    return () => clearTimeout(timer);
   }, [visible]);
 
-  const [matchCount, setMatchCount] = useState(0);
+  const [matchMeasurement, setMatchMeasurement] = useState({
+    query: "",
+    count: 0,
+  });
+  const matchCount =
+    visible && searchQuery.trim() && matchMeasurement.query === searchQuery
+      ? matchMeasurement.count
+      : 0;
   useEffect(() => {
-    if (!searchQuery.trim() || !visible) {
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      setMatchCount(0);
-      return;
-    }
-    setTimeout(() => {
-      setMatchCount(getMatchingSections().length);
+    if (!searchQuery.trim() || !visible) return;
+    const timer = setTimeout(() => {
+      setMatchMeasurement({
+        query: searchQuery,
+        count: getMatchingSections().length,
+      });
     }, 0);
+    return () => clearTimeout(timer);
   }, [searchQuery, getMatchingSections, visible]);
 
   if (!visible) return null;
@@ -225,7 +232,9 @@ const ModalComponentIssue: React.FC<ComponentIssueModalExtendedProps> = ({
               className="component-issue-search-input"
               placeholder="Search sections..."
               value={searchQuery}
-              onChange={(value) => setSearchQuery(value)}
+              onChange={(value) =>
+                setSearchState({ query: value, currentMatchIndex: 0 })
+              }
               allowClear
             />
             {searchQuery.trim() && (
@@ -330,14 +339,14 @@ export const ComponentIssueModalProvider: React.FC = () => {
     };
   }, [updatePayloadFromElement]);
 
-  return (
+  return visible ? (
     <ModalComponentIssue
-      visible={visible}
+      visible
       payload={payload}
       onClose={() => setVisible(false)}
       onNavigate={handleNavigate}
     />
-  );
+  ) : null;
 };
 
 export default ModalComponentIssue;

--- a/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/index.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/index.tsx
@@ -36,6 +36,7 @@ import type { SpotlightItem } from "../../types";
 import { buildPathSegment } from "../config";
 import { useSelectorKernel } from "../core";
 import { TwoColumnModelBody } from "./TwoColumnModelBody";
+import { advancePaletteSearchState } from "./searchState";
 import type { UnifiedModelPaletteProps } from "./types";
 import {
   MODEL_SECTION,
@@ -89,11 +90,24 @@ export const UnifiedModelPalette: React.FC<UnifiedModelPaletteProps> = ({
   // ============ SEARCH ============
   // The query is owned here so we can filter the list before handing it to
   // the kernel — the kernel must navigate the filtered (visible) rows.
-  const [searchQuery, setSearchQuery] = useState("");
-
-  useEffect(() => {
-    if (isOpen) setSearchQuery("");
-  }, [isOpen]);
+  const [searchState, setSearchState] = useState({ isOpen, query: "" });
+  const nextSearchState = advancePaletteSearchState(searchState, isOpen);
+  if (nextSearchState !== searchState) {
+    setSearchState(nextSearchState);
+  }
+  const searchQuery = nextSearchState.query;
+  const setSearchQuery = useCallback(
+    (nextQuery: React.SetStateAction<string>) => {
+      setSearchState((current) => ({
+        ...current,
+        query:
+          typeof nextQuery === "function"
+            ? nextQuery(current.query)
+            : nextQuery,
+      }));
+    },
+    []
+  );
 
   const isItemSelectable = useCallback((item: SpotlightItem) => {
     const data = item.data as Record<string, unknown> | undefined;
@@ -242,6 +256,7 @@ export const UnifiedModelPalette: React.FC<UnifiedModelPaletteProps> = ({
     externalSetSearchQuery: setSearchQuery,
     externalHandleKeyDown,
   });
+  const focusModelInput = kernel.focusInput;
 
   // Keep the keyboard-focused model previewed in the right column. The ref
   // gate ensures previewModel (which resets the source cursor) only fires
@@ -272,9 +287,8 @@ export const UnifiedModelPalette: React.FC<UnifiedModelPaletteProps> = ({
     // yanks the caret from the composer (same class of bug as the
     // WorkspacePalette focus loop).
     if (!isOpen) return;
-    kernel.focusInput();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeColumn, isOpen]);
+    focusModelInput();
+  }, [activeColumn, focusModelInput, isOpen]);
 
   const handleRemovePathSegment = useCallback(() => {
     onClose();

--- a/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/searchState.test.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/searchState.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { advancePaletteSearchState } from "./searchState";
+
+describe("advancePaletteSearchState", () => {
+  it("clears a stale query in the same render that reopens the palette", () => {
+    const closed = { isOpen: false, query: "claude" };
+
+    expect(advancePaletteSearchState(closed, false)).toBe(closed);
+    expect(advancePaletteSearchState(closed, true)).toEqual({
+      isOpen: true,
+      query: "",
+    });
+  });
+
+  it("preserves the query while closing", () => {
+    expect(
+      advancePaletteSearchState({ isOpen: true, query: "gpt" }, false)
+    ).toEqual({ isOpen: false, query: "gpt" });
+  });
+});

--- a/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/searchState.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/searchState.ts
@@ -1,0 +1,15 @@
+export interface PaletteSearchState {
+  isOpen: boolean;
+  query: string;
+}
+
+export function advancePaletteSearchState(
+  previous: PaletteSearchState,
+  isOpen: boolean
+): PaletteSearchState {
+  if (previous.isOpen === isOpen) return previous;
+  return {
+    isOpen,
+    query: isOpen ? "" : previous.query,
+  };
+}


### PR DESCRIPTION
## Problem

React state in 18 production modules was being mirrored or reset from effects. That produced post-commit render cascades, transient stale UI, and lifecycle races across workspace/session/file changes. Several real diagnostics were hidden behind broad or stale `react-hooks` suppressions.

## Solution

- Derive or guardedly adjust transition state during render for passport flips, poker decisions, search collapse state, status filters, app-shell hosts, subagent sessions, settings deep links, and model-palette search.
- Move stop-button reset to component lifecycle and make modal close reset state through unmount.
- Make workspace-memory, local-image, and git-diff async results request-keyed so obsolete completions cannot update the current surface.
- Publish browser console/network cache snapshots through `useSyncExternalStore` instead of effect-mirroring the cache into local state.
- Make the shared agent-definition atoms the tool matrix source of truth, with optimistic updates, persisted server results, and rollback.
- Remove the affected `set-state-in-effect` and stale `exhaustive-deps` suppressions and add focused lifecycle regressions.

## Potential risks

- Several components now use React's guarded render-time state adjustment pattern; each transition is identity-guarded and covered by pure state-transition tests.
- Browser diagnostic state now follows an external-store contract. The cache remains hook-local and bounded, and tests cover close-time invalidation plus session switching.
- Tool-matrix writes are optimistic; failed persistence restores the prior shared definition, and both success and rollback are covered.
- The Sync deep link remains in its atom until the Settings view has rendered the stamped request, then is cleared on the following effect.
- Automated lifecycle checks were run, but no real Tauri/WebView UI profiling was performed in this change.

## Verification

- `pnpm typecheck`
- ESLint on all 35 changed TypeScript files with `--report-unused-disable-directives`
- Focused Vitest suite: 14 files, 41 tests passed
- `git diff --check`
- Repository pre-commit hooks: lint-staged, scoped TypeScript check, and circular-import stats passed

## Performance guard

| Area | Verdict | Evidence | Change | Verification |
| --- | --- | --- | --- | --- |
| Background work | Pass | Browser polling remains visibility-aware at the existing cadence; git diff loading still uses the shared single-flight resource | No timer or polling cadence added | Browser and git-diff lifecycle tests |
| Memory bounds | Pass | Browser caches remain capped at 10 sessions and 500 console / 200 network rows; app-shell history is bounded by host cardinality; existing git cache remains byte/entry bounded | Removed mirrored entry arrays and stale UI state | Source inspection, focused tests |
| Scope isolation | Pass | Workspace, image source, browser session, git request, and settings request stamp are explicit state keys | Obsolete async completions are ignored | Workspace/image/browser/git regression tests |
| Rendering | Pass | Transition state is derived in the same render and effect-driven reset cascades were removed | Fewer post-commit synchronization renders | Targeted ESLint and state-transition tests |
| Cleanup | Pass | Modal timers are cancelled and stop/search/modal state resets through lifecycle boundaries | No orphan timer or retained closed-modal state | Focused lifecycle tests |

Performance verdict: **PASS** for the affected invariants. This PR does not claim measured runtime speedups; it removes redundant render cascades without increasing background cadence or retention bounds.
