### PR TITLE
feat(session-creator): toggle pinned actions from chrome menu

### DIFF
--- a/docs/architecture-audit-2026-08-22/SessionCreatorRepoChromePosition.md
+++ b/docs/architecture-audit-2026-08-22/SessionCreatorRepoChromePosition.md
@@ -1,10 +1,14 @@
-# Session Creator repository chrome position architecture audit
+# Session Creator repository chrome menu architecture audit
 
 ## Acceptance criteria
 
 - Users can place the repository/branch/location chrome above or below the composer.
-- Right-clicking that chrome opens the native OS Up/Down menu instead of WebKit's browser menu.
-- An explicit choice persists across app restarts and every Session Creator entry point.
+- Right-clicking that chrome opens a native OS menu instead of WebKit's browser menu.
+- The menu offers only the applicable **Move to top** or **Move to bottom** command.
+- The same menu offers **Show pinned actions** or **Hide pinned actions** for pinned skill, tool, built-in, and Canvas pills.
+- An explicit position choice persists across app restarts and every Session Creator entry point.
+- The pinned-action visibility choice persists across app restarts and is applied wherever its native menu is available.
+- Hiding pinned actions preserves the pinned set and keeps the `…` management entry point available.
 - Existing first-run behavior remains unchanged: Launchpad defaults above and standard layouts default below.
 - Top and bottom presentations mirror the same outer and composer-seam padding.
 - The native context menu is the only position control; no duplicate visible switch is rendered.
@@ -13,33 +17,34 @@
 
 ## Ten-layer review
 
-| Layer                      | Verdict        | Evidence                                                                                                                                                                                                                                         |
-| -------------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 1. Compilation             | pass           | Full `tsc --noEmit`, focused ESLint, and the focused eight-test Vitest suite pass.                                                                                                                                                               |
-| 2. Dead code / duplication | pass           | The native context menu is the single position control; the coordinator resolves its persisted preference and the view uses that value for row order, glow behavior, and presentation classes. No parallel preference or layout state was added. |
-| 3. Naming                  | pass           | `CreatorRepoChromePosition`, `repoChromePosition`, and `RepoChromeRow` consistently refer only to the repository/branch/location strip.                                                                                                          |
-| 4. Semantic overloading    | pass           | The persisted value models spatial position (`top`/`bottom`) only; it does not encode layout kind, visibility, or dropdown direction.                                                                                                            |
-| 5. Default branches        | pass           | The unset preference is represented explicitly as `null`; Launchpad and standard fallbacks are selected explicitly. Malformed stored values normalize to `null` instead of silently becoming one position.                                       |
-| 6. Cross-domain leakage    | pass           | The session store owns the global preference; the Session Creator coordinator owns layout fallback; the presentational view owns DOM ordering and classes. No backend or unrelated Workstation concept is imported.                              |
-| 7. New-developer clarity   | pass           | The atom documents why `null` exists, the layout helper names the above-composer and breathing decisions, and the two native-menu options are localized as Up and Down.                                                                          |
-| 8. Wire protocol           | not applicable | The preference is local UI storage only; no Tauri, HTTP, database, or serialized external payload changes.                                                                                                                                       |
-| 9. Init parity             | pass           | Launchpad, standard, compact, and hidden-repository variants all enter through `SessionCreatorChatPanelContent` and read the same persisted atom. The entry-point matrix below records the intentional presentation differences.                 |
-| 10. Resolver symmetry      | not applicable | No multi-field resolver or fallback chain was introduced; one preference resolves against one layout-specific fallback.                                                                                                                          |
+| Layer                      | Verdict        | Evidence                                                                                                                                                                                                                          |
+| -------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1. Compilation             | pass           | Full `tsc --noEmit`, focused ESLint, and focused menu, pinned-action, and persistence suites pass.                                                                                                                                |
+| 2. Dead code / duplication | pass           | One native menu owns position and visibility commands. The coordinator reads two independent persisted preferences; the view projects them into chrome placement and pinned-pill presentation without duplicating the pinned set. |
+| 3. Naming                  | pass           | `CreatorRepoChromePosition` names spatial state, while `creatorPinnedActionsVisibleAtom` and `showPinnedActions` name presentation state. `RepoChromeRow` owns their shared native menu only.                                     |
+| 4. Semantic overloading    | pass           | Position (`top`/`bottom`) and pinned-action visibility (`boolean`) remain separate atoms. Visibility never means unpin, delete, disable, or hide unrelated setup controls.                                                        |
+| 5. Default branches        | pass           | An unset position keeps layout-specific fallbacks; pinned actions default visible. Malformed position values normalize to `null`, while malformed visibility values normalize to visible.                                         |
+| 6. Cross-domain leakage    | pass           | Session Creator owns the preference and effective compact/hidden fallback; shared `PinnedActionsBar` receives a presentation prop and does not import creator state.                                                              |
+| 7. New-developer clarity   | pass           | Contextual menu keys read as commands (`moveToTop`, `moveToBottom`, `showPinnedActions`, `hidePinnedActions`), and the visibility atom documents that it preserves pins.                                                          |
+| 8. Wire protocol           | not applicable | Both preferences are local UI storage only; no Tauri command schema, HTTP payload, database record, dependency, or lockfile changes.                                                                                              |
+| 9. Init parity             | pass           | Launchpad, standard, compact, and hidden-repository variants enter through `SessionCreatorChatPanelContent`. The matrix records where position and visibility preferences are intentionally applicable.                           |
+| 10. Resolver symmetry      | not applicable | Position has one explicit layout fallback; visibility has one safe visible fallback. No multi-field resolver or asymmetric fallback chain is introduced.                                                                          |
 
 ## Entry-point matrix
 
-| Entry point                 | Unset preference        | Explicit preference        | Native menu |
-| --------------------------- | ----------------------- | -------------------------- | ----------- |
-| Launchpad repository chrome | Above composer          | Honored                    | Available   |
-| Standard repository chrome  | Below composer          | Honored                    | Available   |
-| Compact embedded chrome     | Existing compact header | Not applied while embedded | Unavailable |
-| Hidden repository chrome    | Not rendered            | Not applied while hidden   | Unavailable |
+| Entry point                 | Unset position          | Explicit position          | Pinned-action visibility | Native menu |
+| --------------------------- | ----------------------- | -------------------------- | ------------------------ | ----------- |
+| Launchpad repository chrome | Above composer          | Honored                    | Honored                  | Available   |
+| Standard repository chrome  | Below composer          | Honored                    | Honored                  | Available   |
+| Compact embedded chrome     | Existing compact header | Not applied while embedded | Forced visible           | Unavailable |
+| Hidden repository chrome    | Not rendered            | Not applied while hidden   | Forced visible           | Unavailable |
 
 ## Term table
 
-| Term                | Meaning                                                                                        | Owner                       |
-| ------------------- | ---------------------------------------------------------------------------------------------- | --------------------------- |
-| repository chrome   | Repository, branch, and running-location control strip around the Session Creator composer     | Session Creator view        |
-| position preference | Persisted explicit `top` or `bottom`; `null` means no choice has been made                     | Session store atom          |
-| layout fallback     | Existing first-run position selected from Launchpad versus standard layout                     | Session Creator coordinator |
-| native context menu | Tauri OS menu that suppresses the WebView browser menu and writes the same position preference | Repository chrome row       |
+| Term                     | Meaning                                                                                              | Owner                       |
+| ------------------------ | ---------------------------------------------------------------------------------------------------- | --------------------------- |
+| repository chrome        | Repository, branch, and running-location control strip around the Session Creator composer           | Session Creator view        |
+| position preference      | Persisted explicit `top` or `bottom`; `null` means no choice has been made                           | Session store atom          |
+| pinned-action visibility | Persisted presentation choice; it never mutates `pinnedActionsAtom`                                  | Session store atom          |
+| layout fallback          | Existing first-run position selected from Launchpad versus standard layout                           | Session Creator coordinator |
+| native context menu      | Tauri OS menu that suppresses the WebView menu and emits the applicable move and visibility commands | Repository chrome row       |

--- a/docs/frontend-ui-audit-2026-08-22/SessionCreatorRepoChromePosition.md
+++ b/docs/frontend-ui-audit-2026-08-22/SessionCreatorRepoChromePosition.md
@@ -1,15 +1,16 @@
-# Session Creator repository chrome position UI audit
+# Session Creator repository chrome menu UI audit
 
 The documented `frontend-ui-audit` skill was unavailable at both the global and workspace paths. This manual fallback applies the repository's required design-system, spacing, localization, and accessibility checks to the changed UI.
 
-| Line / file                       | Element                            | Verdict          | Reason                                                                                                                                                            | Suggested change |
-| --------------------------------- | ---------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| `RepoChromeRow.tsx`               | Secondary-click native menu        | keep with reason | Uses the shared Tauri native-menu lifecycle, prevents the WebView's Back/Reload/Inspect menu, and marks the current Up/Down choice with the native checked state. | None.            |
-| `SessionCreatorChatPanelView.tsx` | Stable composer/chrome slots       | keep with reason | Keeps the composer in a stable render slot while moving only the chrome; bottom chrome is outside the complete composer frame, preventing input remount flashes.  | None.            |
-| `repoChromeLayout.ts`             | Position-aware padding and glow    | keep with reason | Both sides mirror `1.5` outer / `2.5` seam padding, while the launchpad glow is intentionally limited to top chrome so it cannot paint across the bottom seam.    | None.            |
-| `index.scss`                      | Top and bottom composer attachment | keep with reason | The established negative seam overlap, corner radii, and z-order remain unchanged; the flashing fix does not alter the existing visual layering.                  | None.            |
-| `locales/*/sessions.json`         | Native-menu choices                | keep with reason | All supported locales define the two native-menu choices; no locale relies on raw English UI copy.                                                                | None.            |
+| Line / file                       | Element                            | Verdict          | Reason                                                                                                                                                                     | Suggested change |
+| --------------------------------- | ---------------------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| `RepoChromeRow.tsx`               | Secondary-click native menu        | keep with reason | Uses the shared Tauri native-menu lifecycle, prevents the WebView menu, and exposes only the applicable move plus show/hide commands instead of redundant checked choices. | None.            |
+| `PinnedActionsBar/index.tsx`      | Hidden pinned-action presentation  | keep with reason | Hides only quick-action pills; the shared `…` manager and unrelated leading/trailing setup controls remain discoverable and keyboard-accessible.                           | None.            |
+| `SessionCreatorChatPanelView.tsx` | Creator visibility projection      | keep with reason | Applies the persisted choice only where the repository chrome menu can restore it; compact and hidden-repo creators keep pinned actions visible.                           | None.            |
+| `repoChromeLayout.ts`             | Position-aware padding and glow    | keep with reason | Both sides mirror `1.5` outer / `2.5` seam padding, while the launchpad glow is intentionally limited to top chrome so it cannot paint across the bottom seam.             | None.            |
+| `index.scss`                      | Top and bottom composer attachment | keep with reason | The established negative seam overlap, corner radii, and z-order remain unchanged; the follow-up does not alter visual layering.                                           | None.            |
+| `locales/*/sessions.json`         | Contextual native-menu commands    | keep with reason | All supported locales define Move to top/bottom and Show/Hide pinned actions; no locale relies on raw English UI copy.                                                     | None.            |
 
-Verdict totals: **0 fix**, **5 keep with reason**, **0 abstract**.
+Verdict totals: **0 fix**, **6 keep with reason**, **0 abstract**.
 
 No multi-file sweep candidate was found: this is the only independently movable repository chrome in Session Creator, while Workstation panel position controls represent a different surface and axis.

--- a/docs/org2-performance-guard-2026-08-23/SessionCreatorPinnedActionsVisibility.md
+++ b/docs/org2-performance-guard-2026-08-23/SessionCreatorPinnedActionsVisibility.md
@@ -1,0 +1,30 @@
+# Session Creator pinned-action visibility performance guard
+
+## Runtime surface
+
+The feature adds one persisted boolean and one narrow React prop. It adds no timer, listener, worker, subscription, retry loop, IPC command, or unbounded collection. `PinnedActionsBar` already resolves pathless pinned skills through the bounded/coalesced slash-item scanner; hidden pills now produce an empty unresolved-skill key, so that automatic scan does not start. Opening the retained `…` manager remains an explicit demand-driven fetch.
+
+## Lifecycle matrix
+
+| State                        | Required behavior                                                                                             | Evidence                                                                   |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| App start / restart          | Hydrate one boolean; default or malformed values resolve to visible                                           | Atom persistence suite                                                     |
+| Visible idle                 | No scan while hidden; visible pathless skills retain the existing single bounded/coalesced resolution request | `getUnresolvedPinnedSkillsKey` unit coverage and existing scanner contract |
+| Hidden document              | No new document lifecycle or recurring work is introduced                                                     | Call-chain inspection                                                      |
+| Show → hide                  | Remove pills from rendering without deleting pins; stop new automatic resolution triggers                     | Component and helper tests                                                 |
+| Hide → show                  | Re-project the existing pinned set; unresolved visible skills may use the existing scanner                    | Component and persistence tests                                            |
+| Compact / hidden repo chrome | Force pills visible because no native menu is available to restore them                                       | View projection and documented test case                                   |
+| Multiple creator instances   | Each reads the same bounded persisted boolean; existing scanner coalescing remains unchanged                  | Atom ownership and shared scanner call-chain inspection                    |
+
+## Verdict
+
+| Area               | Verdict | Evidence                                                                                | Change or reason kept                                                                      | Verification                                |
+| ------------------ | ------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------- |
+| Background work    | fix     | Pathless pinned skills are the only automatic `fetchFresh` trigger in this path         | Hidden pills return an empty resolution key; explicit `…` management remains demand-driven | Focused helper/component tests              |
+| Memory             | keep    | One persisted boolean; existing pinned array and bounded slash-item cache are unchanged | No new collection or app-lifetime registry                                                 | Atom persistence test and source inspection |
+| Scope/isolation    | keep    | Session Creator owns the preference; shared bars default visible                        | Compact/hidden-repo surfaces force visible so the control cannot strand hidden UI          | View call-chain inspection                  |
+| Rendering/hot path | fix     | Hidden actions previously would still resolve and map pinned skills if only CSS-hidden  | Hidden mode returns no resolved action list and renders no quick-action pills              | PinnedActionsBar tests                      |
+
+No live CPU/RSS capture was run because the change introduces no recurring runtime resource and desktop UI control was not authorized.
+
+**Performance verdict: pass**

--- a/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.test.ts
+++ b/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.test.ts
@@ -14,7 +14,7 @@ import {
 
 import type { ComposerInputRef } from "@src/components/ComposerInput";
 
-import PinnedActionsBar from ".";
+import PinnedActionsBar, { getUnresolvedPinnedSkillsKey } from ".";
 
 vi.mock("jotai", async (importOriginal) => ({
   ...(await importOriginal<typeof import("jotai")>()),
@@ -81,7 +81,7 @@ vi.mock("./PinActionsPanel", () => ({
   default: () => null,
 }));
 
-describe("PinnedActionsBar Canvas action", () => {
+describe("PinnedActionsBar", () => {
   let container: HTMLDivElement;
   let root: Root;
   const actEnvironment = globalThis as typeof globalThis & {
@@ -137,5 +137,40 @@ describe("PinnedActionsBar Canvas action", () => {
       "canvas"
     );
     expect(focus).toHaveBeenCalledOnce();
+  });
+
+  it("hides pinned pills without removing the management entry point", () => {
+    const composerInputRef = createRef<ComposerInputRef>();
+
+    act(() =>
+      root.render(
+        createElement(PinnedActionsBar, {
+          composerInputRef,
+          showPinnedActions: false,
+        })
+      )
+    );
+
+    expect(
+      container.querySelector<HTMLButtonElement>('button[title="New Canvas"]')
+    ).toBeNull();
+    expect(
+      container.querySelector<HTMLButtonElement>(
+        'button[title="input.pinnedActions.manage"]'
+      )
+    ).not.toBeNull();
+  });
+
+  it("does not request skill resolution for hidden pinned pills", () => {
+    const unresolvedSkill = {
+      name: "review",
+      category: "skill" as const,
+      source: "workspace",
+    };
+
+    expect(getUnresolvedPinnedSkillsKey([unresolvedSkill], false)).toBe("");
+    expect(getUnresolvedPinnedSkillsKey([unresolvedSkill], true)).toBe(
+      "review"
+    );
   });
 });

--- a/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.tsx
+++ b/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.tsx
@@ -126,6 +126,20 @@ export interface PinnedActionsBarProps {
   trailingContent?: React.ReactNode;
   manageButtonPlacement?: "after-actions" | "after-leading" | "before-actions";
   managePanelAlign?: "left" | "right";
+  /** Show pinned quick-action pills; the management button stays available. */
+  showPinnedActions?: boolean;
+}
+
+export function getUnresolvedPinnedSkillsKey(
+  pinnedActions: PinnedAction[],
+  showPinnedActions: boolean
+): string {
+  if (!showPinnedActions) return "";
+  return pinnedActions
+    .filter((action) => action.category === "skill" && !action.skillPath)
+    .map((action) => action.skillName ?? action.name)
+    .sort()
+    .join("\0");
 }
 
 const PinnedActionsBar: React.FC<PinnedActionsBarProps> = memo(
@@ -137,6 +151,7 @@ const PinnedActionsBar: React.FC<PinnedActionsBarProps> = memo(
     trailingContent,
     manageButtonPlacement = "after-actions",
     managePanelAlign = "right",
+    showPinnedActions = true,
   }) => {
     const { t } = useTranslation("sessions");
     const [pinnedActions, setPinnedActions] = useAtom(pinnedActionsAtom);
@@ -225,13 +240,8 @@ const PinnedActionsBar: React.FC<PinnedActionsBarProps> = memo(
     // mounting the input stays free. The scan itself is bounded/coalesced by
     // the shared scanner, and the full "…" panel list still loads on open.
     const unresolvedPinnedSkillsKey = useMemo(
-      () =>
-        pinnedActions
-          .filter((action) => action.category === "skill" && !action.skillPath)
-          .map((action) => action.skillName ?? action.name)
-          .sort()
-          .join("\0"),
-      [pinnedActions]
+      () => getUnresolvedPinnedSkillsKey(pinnedActions, showPinnedActions),
+      [pinnedActions, showPinnedActions]
     );
 
     useEffect(() => {
@@ -254,19 +264,17 @@ const PinnedActionsBar: React.FC<PinnedActionsBarProps> = memo(
       setPanelOpen(false);
     }, []);
 
-    const hasPinnedActions = pinnedActions.length > 0;
-    const resolvedPinnedActions = useMemo(
-      () =>
-        pinnedActions.map((action) => {
-          if (action.category !== "skill" || action.skillPath) return action;
-          const skillPath = skillPathByName.get(
-            action.skillName ?? action.name
-          );
-          return skillPath ? { ...action, skillPath } : action;
-        }),
-      [pinnedActions, skillPathByName]
-    );
-    const showCanvasAction = showCanvasPill && !isCanvasTabOpen;
+    const hasPinnedActions = showPinnedActions && pinnedActions.length > 0;
+    const resolvedPinnedActions = useMemo(() => {
+      if (!showPinnedActions) return [];
+      return pinnedActions.map((action) => {
+        if (action.category !== "skill" || action.skillPath) return action;
+        const skillPath = skillPathByName.get(action.skillName ?? action.name);
+        return skillPath ? { ...action, skillPath } : action;
+      });
+    }, [pinnedActions, showPinnedActions, skillPathByName]);
+    const showCanvasAction =
+      showPinnedActions && showCanvasPill && !isCanvasTabOpen;
     const hasActionPills = showCanvasAction || hasPinnedActions;
     const hasTrailingContent = Boolean(trailingContent);
     const showTrailingSeparator = hasActionPills || hasTrailingContent;

--- a/src/features/SessionCreator/components/__tests__/TEST_CASES.md
+++ b/src/features/SessionCreator/components/__tests__/TEST_CASES.md
@@ -11,14 +11,17 @@
 
 ## Repository chrome position
 
-| #   | Steps                                                       | Expected Result                                                                                                                                    |
-| --- | ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| C1  | Right-click the repository chrome and choose **Up**         | Repository, branch, and running-location controls render above the composer with the established top corners and mirrored seam/outer padding       |
-| C2  | Right-click the repository chrome and choose **Down**       | The same controls render outside and below the complete composer, with matching bottom corners, the same total padding, and no input glow flashing |
-| C3  | Choose a position, close ORGII, then reopen Session Creator | The selected position is restored from `orgii:sessionCreator:repoChromePosition`                                                                   |
-| C4  | Open a layout with no saved position                        | Launchpad keeps its existing Up default; standard Session Creator keeps its existing Down default                                                  |
-| C5  | Open a compact/hidden repository-info Session Creator       | No position control appears because there is no independently movable repository chrome                                                            |
-| C6  | Right-click the repository/branch/location chrome           | WebKit's Back/Reload/Inspect menu is suppressed; a native OS menu opens with checked Up and Down actions, and choosing either persists the change  |
+| #   | Steps                                                                 | Expected Result                                                                                                                                         |
+| --- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| C1  | Right-click the lower repository chrome and choose **Move to top**    | Repository, branch, and running-location controls render above the composer with the established top corners and mirrored seam/outer padding            |
+| C2  | Right-click the upper repository chrome and choose **Move to bottom** | The same controls render outside and below the complete composer, with matching bottom corners, the same total padding, and no input glow flashing      |
+| C3  | Choose a position, close ORGII, then reopen Session Creator           | The selected position is restored from `orgii:sessionCreator:repoChromePosition`                                                                        |
+| C4  | Open a layout with no saved position                                  | Launchpad keeps its existing Up default; standard Session Creator keeps its existing Down default                                                       |
+| C5  | Open a compact/hidden repository-info Session Creator                 | No position control appears because there is no independently movable repository chrome                                                                 |
+| C6  | Right-click the repository/branch/location chrome                     | WebKit's Back/Reload/Inspect menu is suppressed; the native OS menu offers only the applicable **Move to top** or **Move to bottom** command            |
+| C7  | Choose **Hide pinned actions** in the native chrome menu              | Pinned skill, tool, built-in, and Canvas quick-action pills disappear; the `…` manager and unrelated GUI/TUI, work-item, org, and setup controls remain |
+| C8  | Reopen Session Creator after hiding pinned actions                    | Pinned quick-action pills remain hidden; choosing **Show pinned actions** restores the existing pins without repinning them                             |
+| C9  | Open compact/hidden repository-info creator after hiding              | Pinned quick actions remain visible because that surface has no repository chrome menu from which visibility could be restored                          |
 
 Covers the worktree-source picker (`WorktreeSourceModal.tsx`) and the
 launch-payload wiring that turns the picked source into backend worktree

--- a/src/features/SessionCreator/variants/ChatPanel/RepoChromeRow.test.ts
+++ b/src/features/SessionCreator/variants/ChatPanel/RepoChromeRow.test.ts
@@ -9,7 +9,12 @@ import RepoChromeRow from "./RepoChromeRow";
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
-    t: (key: string) => (key.endsWith(".up") ? "Up" : "Down"),
+    t: (key: string) => {
+      if (key.endsWith(".moveToTop")) return "Move to top";
+      if (key.endsWith(".moveToBottom")) return "Move to bottom";
+      if (key.endsWith(".showPinnedActions")) return "Show pinned actions";
+      return "Hide pinned actions";
+    },
   }),
 }));
 
@@ -40,14 +45,17 @@ describe("RepoChromeRow", () => {
     reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = false;
   });
 
-  it("replaces the WebView menu with native checked Up/Down actions", async () => {
+  it("offers direct move and pinned-action visibility commands", async () => {
     const onPositionChange = vi.fn();
+    const onPinnedActionsVisibleChange = vi.fn();
     act(() => {
       root.render(
         createElement(
           RepoChromeRow,
           {
+            pinnedActionsVisible: true,
             position: "top",
+            onPinnedActionsVisibleChange,
             onPositionChange,
           } as unknown as ComponentProps<typeof RepoChromeRow>,
           createElement("span", null, "repository chrome")
@@ -72,16 +80,64 @@ describe("RepoChromeRow", () => {
     expect(popupOptions?.source).toBe("session-creator-repo-chrome");
 
     const items = await popupOptions?.buildItems();
-    const upItem = items?.[0] as
-      | { checked?: boolean; action?: () => void }
+    const moveItem = items?.[0] as
+      | { text?: string; action?: () => void }
       | undefined;
-    const downItem = items?.[1] as
-      | { checked?: boolean; action?: () => void }
+    const pinnedActionsItem = items?.[2] as
+      | { text?: string; action?: () => void }
       | undefined;
-    expect(upItem?.checked).toBe(true);
-    expect(downItem?.checked).toBe(false);
+    expect(moveItem?.text).toBe("Move to bottom");
+    expect(pinnedActionsItem?.text).toBe("Hide pinned actions");
 
-    act(() => downItem?.action?.());
+    act(() => moveItem?.action?.());
     expect(onPositionChange).toHaveBeenCalledWith("bottom");
+
+    act(() => pinnedActionsItem?.action?.());
+    expect(onPinnedActionsVisibleChange).toHaveBeenCalledWith(false);
+  });
+
+  it("offers the inverse commands when chrome is below and actions are hidden", async () => {
+    const onPositionChange = vi.fn();
+    const onPinnedActionsVisibleChange = vi.fn();
+    act(() => {
+      root.render(
+        createElement(
+          RepoChromeRow,
+          {
+            pinnedActionsVisible: false,
+            position: "bottom",
+            onPinnedActionsVisibleChange,
+            onPositionChange,
+          } as unknown as ComponentProps<typeof RepoChromeRow>,
+          createElement("span", null, "repository chrome")
+        )
+      );
+    });
+
+    const row = container.querySelector<HTMLElement>(
+      '[data-testid="session-creator-repo-chrome"]'
+    );
+    const event = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+    });
+    act(() => row?.dispatchEvent(event));
+
+    const popupOptions = mockedPopupNativeMenu.mock.calls[0]?.[0];
+    const items = await popupOptions?.buildItems();
+    const moveItem = items?.[0] as
+      | { text?: string; action?: () => void }
+      | undefined;
+    const pinnedActionsItem = items?.[2] as
+      | { text?: string; action?: () => void }
+      | undefined;
+    expect(moveItem?.text).toBe("Move to top");
+    expect(pinnedActionsItem?.text).toBe("Show pinned actions");
+
+    act(() => moveItem?.action?.());
+    expect(onPositionChange).toHaveBeenCalledWith("top");
+
+    act(() => pinnedActionsItem?.action?.());
+    expect(onPinnedActionsVisibleChange).toHaveBeenCalledWith(true);
   });
 });

--- a/src/features/SessionCreator/variants/ChatPanel/RepoChromeRow.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/RepoChromeRow.tsx
@@ -14,14 +14,18 @@ const log = createLogger("RepoChromeRow");
 
 export interface RepoChromeRowProps {
   children: React.ReactNode;
+  pinnedActionsVisible: boolean;
   position: CreatorRepoChromePosition;
+  onPinnedActionsVisibleChange: (visible: boolean) => void;
   onPositionChange: (position: CreatorRepoChromePosition) => void;
 }
 
-/** Repository controls row with a native Up/Down secondary-click menu. */
+/** Repository controls row with a native layout/visibility secondary-click menu. */
 export const RepoChromeRow: React.FC<RepoChromeRowProps> = ({
   children,
+  pinnedActionsVisible,
   position,
+  onPinnedActionsVisibleChange,
   onPositionChange,
 }) => {
   const { t } = useTranslation("sessions");
@@ -35,14 +39,22 @@ export const RepoChromeRow: React.FC<RepoChromeRowProps> = ({
         buildItems: () => {
           const items: NativeMenuItemOptions[] = [
             {
-              text: t("creator.repoChromePosition.up"),
-              checked: position === "top",
-              action: () => onPositionChange("top"),
+              text: t(
+                position === "top"
+                  ? "creator.repoChromeMenu.moveToBottom"
+                  : "creator.repoChromeMenu.moveToTop"
+              ),
+              action: () =>
+                onPositionChange(position === "top" ? "bottom" : "top"),
             },
+            { item: "Separator" },
             {
-              text: t("creator.repoChromePosition.down"),
-              checked: position === "bottom",
-              action: () => onPositionChange("bottom"),
+              text: t(
+                pinnedActionsVisible
+                  ? "creator.repoChromeMenu.hidePinnedActions"
+                  : "creator.repoChromeMenu.showPinnedActions"
+              ),
+              action: () => onPinnedActionsVisibleChange(!pinnedActionsVisible),
             },
           ];
           return items;
@@ -51,7 +63,13 @@ export const RepoChromeRow: React.FC<RepoChromeRowProps> = ({
         log.error("Failed to show repository chrome context menu:", error);
       });
     },
-    [onPositionChange, position, t]
+    [
+      onPinnedActionsVisibleChange,
+      onPositionChange,
+      pinnedActionsVisible,
+      position,
+      t,
+    ]
   );
 
   return (

--- a/src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx
@@ -108,6 +108,7 @@ interface SessionCreatorChatPanelViewProps {
   onCreateWorkItem?: () => void;
   onFileUpload: React.ChangeEventHandler<HTMLInputElement>;
   onLaunch: () => void;
+  onPinnedActionsVisibleChange: (visible: boolean) => void;
   onRepoChromePositionChange: (position: CreatorRepoChromePosition) => void;
   onShareScreen: () => Promise<unknown>;
   onToggleOrgMembers: () => void;
@@ -115,6 +116,7 @@ interface SessionCreatorChatPanelViewProps {
     typeof SessionCreatorOrgMembersPanel
   >;
   pinnedActionsContent?: React.ReactNode;
+  pinnedActionsVisible: boolean;
   repoChromePosition: CreatorRepoChromePosition;
   categoryPickerProps: CategoryPickerProps;
   screenPickerProps?: React.ComponentProps<typeof ScreenPickerModal>;
@@ -162,11 +164,13 @@ const SessionCreatorChatPanelView: React.FC<
   onCreateWorkItem,
   onFileUpload,
   onLaunch,
+  onPinnedActionsVisibleChange,
   onRepoChromePositionChange,
   onShareScreen,
   onToggleOrgMembers,
   orgMembersPanelProps,
   pinnedActionsContent,
+  pinnedActionsVisible,
   repoChromePosition,
   categoryPickerProps,
   screenPickerProps,
@@ -193,9 +197,13 @@ const SessionCreatorChatPanelView: React.FC<
     </div>
   );
   const repoChromeAboveComposer = isRepoChromeAboveComposer(repoChromePosition);
-  const repoPillsRow = !hideRepoLine && headerLayout !== "compact" && (
+  const hasRepoChromeMenu = !hideRepoLine && headerLayout !== "compact";
+  const showPinnedActionPills = !hasRepoChromeMenu || pinnedActionsVisible;
+  const repoPillsRow = hasRepoChromeMenu && (
     <RepoChromeRow
+      pinnedActionsVisible={pinnedActionsVisible}
       position={repoChromePosition}
+      onPinnedActionsVisibleChange={onPinnedActionsVisibleChange}
       onPositionChange={onRepoChromePositionChange}
     >
       {repoPills}
@@ -252,6 +260,7 @@ const SessionCreatorChatPanelView: React.FC<
         composerInputRef={composerInputRef}
         manageButtonPlacement="before-actions"
         managePanelAlign="left"
+        showPinnedActions={showPinnedActionPills}
         trailingContent={pinnedActionsContent}
         leadingContent={
           <>

--- a/src/features/SessionCreator/variants/ChatPanel/index.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/index.tsx
@@ -29,6 +29,7 @@ import {
   agentIconIdAtom,
   agentNameAtom,
   cliAgentTypeAtom,
+  creatorPinnedActionsVisibleAtom,
   creatorRepoChromePositionAtom,
   dispatchCategoryAtom,
   normalizeAgentOnlySessionCreatorState,
@@ -106,6 +107,9 @@ const SessionCreatorChatPanelContent: React.FC<
   const { orgs } = useAgentOrgs();
   const [repoChromePositionPreference, setRepoChromePositionPreference] =
     useAtom(creatorRepoChromePositionAtom);
+  const [pinnedActionsVisible, setPinnedActionsVisible] = useAtom(
+    creatorPinnedActionsVisibleAtom
+  );
   const repoChromePosition = resolveCreatorRepoChromePosition(
     repoChromePositionPreference,
     layout === "launchpad" ? "top" : "bottom"
@@ -591,10 +595,12 @@ const SessionCreatorChatPanelContent: React.FC<
       onCreateWorkItem={onCreateWorkItem}
       onFileUpload={handleFileUpload}
       onLaunch={handleComposerLaunch}
+      onPinnedActionsVisibleChange={setPinnedActionsVisible}
       onRepoChromePositionChange={setRepoChromePositionPreference}
       onShareScreen={() => handleShareScreenClick().catch(log.error)}
       onToggleOrgMembers={handleToggleOrgMembers}
       pinnedActionsContent={isHumanMode ? undefined : pinnedActionsContent}
+      pinnedActionsVisible={pinnedActionsVisible}
       repoChromePosition={repoChromePosition}
       orgMembersPanelProps={
         selectedOrg

--- a/src/i18n/locales/de/sessions.json
+++ b/src/i18n/locales/de/sessions.json
@@ -2087,9 +2087,11 @@
     "immutableInSession": "Schlüsselquelle, Agent-Typ und Preisstufe sind beim Sitzungsstart festgelegt. Starten Sie eine neue Sitzung, um sie zu ändern."
   },
   "creator": {
-    "repoChromePosition": {
-      "up": "Oben",
-      "down": "Unten"
+    "repoChromeMenu": {
+      "moveToTop": "Nach oben verschieben",
+      "moveToBottom": "Nach unten verschieben",
+      "showPinnedActions": "Angeheftete Aktionen anzeigen",
+      "hidePinnedActions": "Angeheftete Aktionen ausblenden"
     },
     "createTarget": {
       "agentSession": "Agent-Sitzung",

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -2167,9 +2167,11 @@
     "appliesNextTurn": "Account switched. The current reply still runs on the previous account; the new account takes effect from the next turn."
   },
   "creator": {
-    "repoChromePosition": {
-      "up": "Up",
-      "down": "Down"
+    "repoChromeMenu": {
+      "moveToTop": "Move to top",
+      "moveToBottom": "Move to bottom",
+      "showPinnedActions": "Show pinned actions",
+      "hidePinnedActions": "Hide pinned actions"
     },
     "createTarget": {
       "agentSession": "Agent session",

--- a/src/i18n/locales/es/sessions.json
+++ b/src/i18n/locales/es/sessions.json
@@ -2089,9 +2089,11 @@
     "immutableInSession": "La fuente de clave, el tipo de Agent y el nivel de precio se fijan al iniciar la sesión. Inicia una nueva sesión para cambiarlos."
   },
   "creator": {
-    "repoChromePosition": {
-      "up": "Arriba",
-      "down": "Abajo"
+    "repoChromeMenu": {
+      "moveToTop": "Mover arriba",
+      "moveToBottom": "Mover abajo",
+      "showPinnedActions": "Mostrar acciones fijadas",
+      "hidePinnedActions": "Ocultar acciones fijadas"
     },
     "createTarget": {
       "agentSession": "Sesión de Agent",

--- a/src/i18n/locales/fr/sessions.json
+++ b/src/i18n/locales/fr/sessions.json
@@ -2089,9 +2089,11 @@
     "immutableInSession": "La source de clé, le type d'Agent et le palier tarifaire sont fixés au démarrage de la session. Démarrez une nouvelle session pour les modifier."
   },
   "creator": {
-    "repoChromePosition": {
-      "up": "Haut",
-      "down": "Bas"
+    "repoChromeMenu": {
+      "moveToTop": "Déplacer en haut",
+      "moveToBottom": "Déplacer en bas",
+      "showPinnedActions": "Afficher les actions épinglées",
+      "hidePinnedActions": "Masquer les actions épinglées"
     },
     "createTarget": {
       "agentSession": "Session Agent",

--- a/src/i18n/locales/ja/sessions.json
+++ b/src/i18n/locales/ja/sessions.json
@@ -2088,9 +2088,11 @@
     "immutableInSession": "キーソース、Agent タイプ、料金ティアはセッション開始時に固定されます。変更するには新しいセッションを開始してください。"
   },
   "creator": {
-    "repoChromePosition": {
-      "up": "上",
-      "down": "下"
+    "repoChromeMenu": {
+      "moveToTop": "上に移動",
+      "moveToBottom": "下に移動",
+      "showPinnedActions": "ピン留めしたアクションを表示",
+      "hidePinnedActions": "ピン留めしたアクションを非表示"
     },
     "createTarget": {
       "agentSession": "Agent セッション",

--- a/src/i18n/locales/ko/sessions.json
+++ b/src/i18n/locales/ko/sessions.json
@@ -2088,9 +2088,11 @@
     "immutableInSession": "키 소스, Agent 유형 및 가격 티어는 세션 시작 시 고정됩니다. 변경하려면 새 세션을 시작하세요."
   },
   "creator": {
-    "repoChromePosition": {
-      "up": "위",
-      "down": "아래"
+    "repoChromeMenu": {
+      "moveToTop": "위로 이동",
+      "moveToBottom": "아래로 이동",
+      "showPinnedActions": "고정된 작업 표시",
+      "hidePinnedActions": "고정된 작업 숨기기"
     },
     "createTarget": {
       "agentSession": "Agent 세션",

--- a/src/i18n/locales/pl/sessions.json
+++ b/src/i18n/locales/pl/sessions.json
@@ -2142,9 +2142,11 @@
     "immutableInSession": "Źródło klucza, typ Agenta i poziom cenowy są ustalane na początku sesji. Aby je zmienić, rozpocznij nową sesję."
   },
   "creator": {
-    "repoChromePosition": {
-      "up": "Góra",
-      "down": "Dół"
+    "repoChromeMenu": {
+      "moveToTop": "Przenieś na górę",
+      "moveToBottom": "Przenieś na dół",
+      "showPinnedActions": "Pokaż przypięte akcje",
+      "hidePinnedActions": "Ukryj przypięte akcje"
     },
     "createTarget": {
       "agentSession": "Sesja Agent",

--- a/src/i18n/locales/pt/sessions.json
+++ b/src/i18n/locales/pt/sessions.json
@@ -2104,9 +2104,11 @@
     "immutableInSession": "A origem da chave, o tipo de Agent e o nível de preço são fixados no início da sessão. Inicie uma nova sessão para alterá-los."
   },
   "creator": {
-    "repoChromePosition": {
-      "up": "Em cima",
-      "down": "Embaixo"
+    "repoChromeMenu": {
+      "moveToTop": "Mover para cima",
+      "moveToBottom": "Mover para baixo",
+      "showPinnedActions": "Mostrar ações fixadas",
+      "hidePinnedActions": "Ocultar ações fixadas"
     },
     "createTarget": {
       "agentSession": "Sessão de Agent",

--- a/src/i18n/locales/ru/sessions.json
+++ b/src/i18n/locales/ru/sessions.json
@@ -2132,9 +2132,11 @@
     "immutableInSession": "Источник ключа, тип Agent и тарифный уровень фиксируются при запуске сессии. Чтобы изменить их, начните новую сессию."
   },
   "creator": {
-    "repoChromePosition": {
-      "up": "Сверху",
-      "down": "Снизу"
+    "repoChromeMenu": {
+      "moveToTop": "Переместить вверх",
+      "moveToBottom": "Переместить вниз",
+      "showPinnedActions": "Показывать закреплённые действия",
+      "hidePinnedActions": "Скрыть закреплённые действия"
     },
     "createTarget": {
       "agentSession": "Сессия Agent",

--- a/src/i18n/locales/tr/sessions.json
+++ b/src/i18n/locales/tr/sessions.json
@@ -2089,9 +2089,11 @@
     "immutableInSession": "Anahtar kaynağı, Agent türü ve fiyat kademesi oturum başlangıcında sabittir. Değiştirmek için yeni bir oturum başlatın."
   },
   "creator": {
-    "repoChromePosition": {
-      "up": "Yukarı",
-      "down": "Aşağı"
+    "repoChromeMenu": {
+      "moveToTop": "Yukarı taşı",
+      "moveToBottom": "Aşağı taşı",
+      "showPinnedActions": "Sabitlenmiş eylemleri göster",
+      "hidePinnedActions": "Sabitlenmiş eylemleri gizle"
     },
     "createTarget": {
       "agentSession": "Agent oturumu",

--- a/src/i18n/locales/vi/sessions.json
+++ b/src/i18n/locales/vi/sessions.json
@@ -2086,9 +2086,11 @@
     "immutableInSession": "Nguồn khóa, loại Agent và bậc giá được cố định khi bắt đầu phiên. Bắt đầu phiên mới để thay đổi."
   },
   "creator": {
-    "repoChromePosition": {
-      "up": "Trên",
-      "down": "Dưới"
+    "repoChromeMenu": {
+      "moveToTop": "Di chuyển lên trên",
+      "moveToBottom": "Di chuyển xuống dưới",
+      "showPinnedActions": "Hiện hành động đã ghim",
+      "hidePinnedActions": "Ẩn hành động đã ghim"
     },
     "createTarget": {
       "agentSession": "Phiên Agent",

--- a/src/i18n/locales/zh-Hant/sessions.json
+++ b/src/i18n/locales/zh-Hant/sessions.json
@@ -2103,9 +2103,11 @@
     "immutableInSession": "密鑰來源、Agent 類型和價格檔位在會話啓動時已固定。如需更改請新建會話。"
   },
   "creator": {
-    "repoChromePosition": {
-      "up": "上",
-      "down": "下"
+    "repoChromeMenu": {
+      "moveToTop": "移到上方",
+      "moveToBottom": "移到下方",
+      "showPinnedActions": "顯示已釘選的動作",
+      "hidePinnedActions": "隱藏已釘選的動作"
     },
     "createTarget": {
       "agentSession": "Agent 會話",

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -2140,9 +2140,11 @@
     "appliesNextTurn": "账号已切换。当前回复仍由原账号完成，新账号将从下一轮开始生效。"
   },
   "creator": {
-    "repoChromePosition": {
-      "up": "上",
-      "down": "下"
+    "repoChromeMenu": {
+      "moveToTop": "移到上方",
+      "moveToBottom": "移到下方",
+      "showPinnedActions": "显示已固定的操作",
+      "hidePinnedActions": "隐藏已固定的操作"
     },
     "createTarget": {
       "agentSession": "Agent 会话",

--- a/src/store/session/__tests__/creatorPinnedActionsVisibleAtom.test.ts
+++ b/src/store/session/__tests__/creatorPinnedActionsVisibleAtom.test.ts
@@ -1,0 +1,46 @@
+import { createStore } from "jotai/vanilla";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  CREATOR_PINNED_ACTIONS_VISIBLE_STORAGE_KEY,
+  creatorPinnedActionsVisibleAtom,
+} from "../creatorPinnedActionsVisibleAtom";
+
+beforeEach(() => {
+  localStorage.removeItem(CREATOR_PINNED_ACTIONS_VISIBLE_STORAGE_KEY);
+});
+
+function hydratedStore(): ReturnType<typeof createStore> {
+  const store = createStore();
+  store.sub(creatorPinnedActionsVisibleAtom, () => undefined);
+  return store;
+}
+
+describe("creatorPinnedActionsVisibleAtom", () => {
+  it("shows pinned actions by default", () => {
+    expect(hydratedStore().get(creatorPinnedActionsVisibleAtom)).toBe(true);
+  });
+
+  it("persists a hidden choice and hydrates it in a new store", () => {
+    const firstStore = hydratedStore();
+    firstStore.set(creatorPinnedActionsVisibleAtom, false);
+
+    expect(
+      JSON.parse(
+        localStorage.getItem(CREATOR_PINNED_ACTIONS_VISIBLE_STORAGE_KEY) ??
+          "null"
+      )
+    ).toBe(false);
+
+    expect(hydratedStore().get(creatorPinnedActionsVisibleAtom)).toBe(false);
+  });
+
+  it("falls back to visible for malformed persisted values", () => {
+    localStorage.setItem(
+      CREATOR_PINNED_ACTIONS_VISIBLE_STORAGE_KEY,
+      JSON.stringify("hidden")
+    );
+
+    expect(hydratedStore().get(creatorPinnedActionsVisibleAtom)).toBe(true);
+  });
+});

--- a/src/store/session/creatorPinnedActionsVisibleAtom.ts
+++ b/src/store/session/creatorPinnedActionsVisibleAtom.ts
@@ -1,0 +1,32 @@
+import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+
+export const CREATOR_PINNED_ACTIONS_VISIBLE_STORAGE_KEY =
+  "orgii:sessionCreator:pinnedActionsVisible";
+
+function normalizeCreatorPinnedActionsVisible(value: unknown): boolean {
+  return typeof value === "boolean" ? value : true;
+}
+
+const storedCreatorPinnedActionsVisibleAtom = atomWithStorage<unknown>(
+  CREATOR_PINNED_ACTIONS_VISIBLE_STORAGE_KEY,
+  true,
+  undefined,
+  { getOnInit: true }
+);
+
+/**
+ * Session Creator preference for showing pinned quick-action pills.
+ *
+ * The preference does not delete or unpin actions. Compact and hidden-repo
+ * creator surfaces ignore it because they do not expose the native menu that
+ * can restore visibility.
+ */
+export const creatorPinnedActionsVisibleAtom = atom(
+  (get) =>
+    normalizeCreatorPinnedActionsVisible(
+      get(storedCreatorPinnedActionsVisibleAtom)
+    ),
+  (_get, set, visible: boolean) =>
+    set(storedCreatorPinnedActionsVisibleAtom, visible)
+);

--- a/src/store/session/index.ts
+++ b/src/store/session/index.ts
@@ -25,6 +25,7 @@ export * from "./creatorDefaultModelAtom";
 export * from "./recentModelEntriesAtom";
 export * from "./recentAgentSelectionsAtom";
 export * from "./creatorDefaultExecModeAtom";
+export * from "./creatorPinnedActionsVisibleAtom";
 export * from "./creatorRepoChromePositionAtom";
 export * from "./cliUpdateAlertsAtom";
 


### PR DESCRIPTION
## Problem

Pinned skill, tool, built-in, and Canvas quick-action pills are always visible in Session Creator, so a heavily pinned setup row can stay crowded with no persistent presentation choice. The repository chrome native menu also uses terse Up/Down checked labels instead of direct commands.

Hiding the row after rendering would be the wrong boundary: it could conceal unrelated GUI/TUI, work-item, org, and property controls while still allowing hidden pathless skills to trigger automatic resolution scans.

## Solution

- Extend the existing repository-chrome right-click menu with contextual commands only: **Move to top** or **Move to bottom**, plus **Show pinned actions** or **Hide pinned actions**.
- Persist one validated Session Creator visibility boolean. Existing and malformed storage defaults to visible, and hiding never removes entries from `pinnedActionsAtom`.
- Add a narrow `showPinnedActions` projection to `PinnedActionsBar`. It hides skill, tool, built-in, and Canvas quick-action pills while preserving the `…` manager and unrelated leading/trailing setup controls.
- Return an empty unresolved-skill key while pills are hidden, preventing automatic hidden skill-path resolution. Explicit `…` management remains demand-driven and uses the existing bounded/coalesced scanner.
- Force pinned actions visible in compact or hidden-repository creator variants because those surfaces do not expose the native chrome menu that restores visibility.
- Localize all four contextual commands across the 13 supported locales and update behavior, audit, and performance documentation.

## Potential risks

The feature adds the local-storage key `orgii:sessionCreator:pinnedActionsVisible`. It is a UI-only boolean with no database, API, IPC, dependency, lockfile, or schema migration. Invalid values safely resolve to visible. Reverting this commit restores always-visible pills; the unused stored key is inert and can be removed independently.

The shared `PinnedActionsBar` API changes only through an optional prop whose default is `true`, so non-Session-Creator consumers retain existing behavior. Compact and hidden-repository creator surfaces intentionally override a hidden preference to visible so users cannot be stranded without a restore control.

If native-menu creation fails, the WebView menu remains suppressed for that interaction and the failure is logged; users can retry the secondary click. No live desktop screenshot or manual pointer interaction was captured because desktop UI control was not authorized. The exact native-menu appearance remains an unverified visual path.

## Verification

- `pnpm exec vitest run src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.test.ts src/features/SessionCreator/variants/ChatPanel/RepoChromeRow.test.ts src/features/SessionCreator/variants/ChatPanel/repoChromeLayout.test.ts src/store/session/__tests__/creatorPinnedActionsVisibleAtom.test.ts src/store/session/__tests__/creatorRepoChromePositionAtom.test.ts` — 5 files and 15 tests passed
- `pnpm exec eslint src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.test.ts src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.tsx src/features/SessionCreator/variants/ChatPanel/RepoChromeRow.test.ts src/features/SessionCreator/variants/ChatPanel/RepoChromeRow.tsx src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx src/features/SessionCreator/variants/ChatPanel/index.tsx src/store/session/__tests__/creatorPinnedActionsVisibleAtom.test.ts src/store/session/creatorPinnedActionsVisibleAtom.ts src/store/session/index.ts` — passed
- `pnpm exec tsc --noEmit --pretty false` — passed
- Locale JSON validation — all 13 locales contain non-empty Move to top/bottom and Show/Hide pinned-actions commands, with the obsolete Up/Down copy removed
- `pnpm exec prettier --check ...` over every changed source, locale, test, and audit file — passed
- `git diff --check origin/develop...HEAD` — passed
- Commit hooks — lint-staged, scoped TypeScript, and circular-dependency checks passed

## UI audit

The workspace has no `frontend-ui-audit` skill file, so the required design-system, spacing, accessibility, localization, and duplication checks were applied manually.

Verdict totals: **0 fix**, **6 keep with reason**, **0 abstract**. No multi-file sweep candidate was found.

## Performance guard

| Area | Verdict | Evidence | Change or reason kept | Verification |
| ---- | ------- | -------- | --------------------- | ------------ |
| Background work | fix | Pathless pinned skills are the only automatic resolution trigger in this path | Hidden pills produce no resolution key; explicit management remains demand-driven | Focused helper/component tests |
| Memory | keep | One persisted boolean; existing pinned array and bounded slash-item cache are unchanged | No new collection or app-lifetime registry | Persistence test and source inspection |
| Scope/isolation | keep | Session Creator owns the preference; shared bars default visible | Compact/hidden-repo variants force visible | Call-chain inspection |
| Rendering/hot path | fix | Hidden pills no longer resolve or map pinned skills | Return no rendered quick-action list while hidden | PinnedActionsBar tests |

No live CPU/RSS capture was run because the change introduces no recurring runtime resource and desktop UI control was not authorized.

**Performance verdict: pass**
