### PR TITLE
fix(workstation): refresh submissions PR status, drop open guess

### DIFF
--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -470,7 +470,8 @@
       "open": "Open",
       "merged": "Merged",
       "closed": "Closed",
-      "draft": "Draft"
+      "draft": "Draft",
+      "unknown": "Unknown"
     },
     "operationLog": "Operation Log",
     "gitDashboard": "Dashboard",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -619,7 +619,8 @@
       "open": "開啟",
       "merged": "已合併",
       "closed": "已關閉",
-      "draft": "草稿"
+      "draft": "草稿",
+      "unknown": "未知"
     },
     "operationLog": "操作日誌",
     "gitDashboard": "儀表盤",

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -466,7 +466,8 @@
       "open": "开启",
       "merged": "已合并",
       "closed": "已关闭",
-      "draft": "草稿"
+      "draft": "草稿",
+      "unknown": "未知"
     },
     "operationLog": "操作日志",
     "gitDashboard": "仪表盘",

--- a/src/modules/WorkStation/Diff/SessionReplay/SubmissionsContent.tsx
+++ b/src/modules/WorkStation/Diff/SessionReplay/SubmissionsContent.tsx
@@ -12,6 +12,7 @@ import {
   TYPOGRAPHY,
 } from "@src/modules/WorkStation/shared/tokens";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
+import { PR_STATUS_UNKNOWN } from "@src/shared/pr/prStatus";
 
 export type SubmissionArtifactOrigin = "created" | "mentioned";
 
@@ -44,10 +45,12 @@ export interface PullRequestSubmission {
   sourceBranch?: string;
   targetBranch?: string;
   origin?: SubmissionArtifactOrigin;
-  /** Normalized PR status (`open` / `merged` / `closed` / `draft`).
-   * Injected by the parent after a batch GitHub fetch; defaults to `open` for
-   * rows whose status hasn't been resolved (in flight / no creds / missing
-   * repoFullName-or-prNumber). */
+  /** Normalized PR status (`open` / `merged` / `closed` / `draft`), or
+   * `unknown` when the GitHub read failed. Injected by the parent after a
+   * batch GitHub fetch; absent while the first read is in flight, or for rows
+   * missing repoFullName-or-prNumber, which can never be read. Those render as
+   * `unknown` too — never as `open`, which would assert a state nothing
+   * verified. */
   statusKey?: string;
 }
 
@@ -178,7 +181,7 @@ const PullRequestSubmissionRow: React.FC<{
       ? `${pullRequest.sourceBranch} → ${pullRequest.targetBranch}`
       : pullRequest.sourceBranch
     : null;
-  const statusKey = pullRequest.statusKey ?? "open";
+  const statusKey = pullRequest.statusKey ?? PR_STATUS_UNKNOWN;
 
   return (
     <div className="border-b border-fill-2 px-3 py-2">

--- a/src/modules/WorkStation/Diff/SessionReplay/__tests__/SubmissionsContent.prStatusBadge.test.ts
+++ b/src/modules/WorkStation/Diff/SessionReplay/__tests__/SubmissionsContent.prStatusBadge.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+//
+// The user-visible half of the PR-status fix: a row whose status was never
+// resolved must not wear the green "open" badge. `statusKey` is injected
+// asynchronously by `useSubmissionsData`, so "absent" covers the in-flight
+// frame, a failed GitHub read, and rows with no repoFullName/prNumber to read.
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { getPrStatusVariant } from "@src/shared/pr/prStatus";
+
+import {
+  type PullRequestSubmission,
+  SubmissionPullRequestsContent,
+} from "../SubmissionsContent";
+
+const NEUTRAL = getPrStatusVariant("unknown");
+const OPEN = getPrStatusVariant("open");
+
+function renderRow(
+  overrides: Partial<PullRequestSubmission> = {}
+): HTMLElement {
+  const pullRequest: PullRequestSubmission = {
+    key: "pullRequest:acme/repo#42",
+    url: "https://github.com/acme/repo/pull/42",
+    repoFullName: "acme/repo",
+    prNumber: 42,
+    prTitle: "Add submissions tab",
+    origin: "mentioned",
+    ...overrides,
+  };
+  const container = document.createElement("div");
+  container.innerHTML = renderToStaticMarkup(
+    createElement(SubmissionPullRequestsContent, {
+      pullRequests: [pullRequest],
+      emptyLabel: "No pull requests",
+    })
+  );
+  return container;
+}
+
+describe("SubmissionPullRequestsContent PR status badge", () => {
+  it("renders a neutral badge, not an open one, when status is unresolved", () => {
+    const html = renderRow().innerHTML;
+
+    expect(html).toContain(NEUTRAL.badgeClass);
+    expect(html).toContain(NEUTRAL.dotClass);
+    // The regression: an unread status used to render as green "open".
+    expect(html).not.toContain(OPEN.badgeClass);
+    expect(html).not.toContain(OPEN.dotClass);
+  });
+
+  it("renders the injected status once it resolves", () => {
+    const merged = getPrStatusVariant("merged");
+    const html = renderRow({ statusKey: "merged" }).innerHTML;
+
+    expect(html).toContain(merged.badgeClass);
+    expect(html).not.toContain(NEUTRAL.badgeClass);
+  });
+
+  it("still renders a resolved open status as open", () => {
+    const html = renderRow({ statusKey: "open" }).innerHTML;
+
+    expect(html).toContain(OPEN.badgeClass);
+    expect(html).not.toContain(NEUTRAL.badgeClass);
+  });
+});

--- a/src/modules/WorkStation/Diff/SessionReplay/__tests__/useSubmissionsData.prStatus.test.ts
+++ b/src/modules/WorkStation/Diff/SessionReplay/__tests__/useSubmissionsData.prStatus.test.ts
@@ -1,0 +1,238 @@
+// @vitest-environment jsdom
+//
+// Probe harness for the PR-status branch of `useSubmissionsData`.
+//
+// The hook's PR-status effect is keyed on `prStatusFetchKey` — a sorted join
+// of `repoFullName#prNumber` — which by construction cannot observe a PR being
+// merged on GitHub. These tests pin the two behaviors that closes that hole:
+// `diffRefreshNonce` re-reads status, and a failed read publishes the explicit
+// `unknown` key instead of letting the row default to a green "open" badge.
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { getGitCommitDiff, getGitCommits } from "@src/api/http/git";
+import { getPRLocal } from "@src/api/tauri/github";
+import { getOrgtrackDiffReplayPreview } from "@src/api/tauri/lineage";
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+import { loadEvents } from "@src/engines/SessionCore/storage/cacheAdapter";
+import { PR_STATUS_UNKNOWN } from "@src/shared/pr/prStatus";
+import type { Repo } from "@src/store/repo/types";
+
+import type { SubmissionRepoContext } from "../submissionsArtifacts";
+import {
+  type UseSubmissionsDataResult,
+  useSubmissionsData,
+} from "../useSubmissionsData";
+
+vi.mock("@src/api/tauri/github", () => ({
+  getPRLocal: vi.fn(),
+}));
+
+vi.mock("@src/api/tauri/lineage", () => ({
+  getOrgtrackDiffReplayPreview: vi.fn(),
+}));
+
+vi.mock("@src/api/http/git", () => ({
+  getGitCommits: vi.fn(),
+  getGitCommitDiff: vi.fn(),
+}));
+
+vi.mock("@src/engines/SessionCore/storage/cacheAdapter", () => ({
+  loadEvents: vi.fn(),
+}));
+
+const getPRLocalMock = vi.mocked(getPRLocal);
+const getOrgtrackDiffReplayPreviewMock = vi.mocked(
+  getOrgtrackDiffReplayPreview
+);
+const getGitCommitsMock = vi.mocked(getGitCommits);
+const getGitCommitDiffMock = vi.mocked(getGitCommitDiff);
+const loadEventsMock = vi.mocked(loadEvents);
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+const REPO_FULL_NAME = "acme/repo";
+const PR_NUMBER = 42;
+const NO_REPOS: readonly Repo[] = [];
+
+/**
+ * An assistant message carrying a GitHub PR URL — the cheapest event shape
+ * that makes `collectSubmissionArtifacts` emit a `pullRequest` artifact.
+ */
+function prMentionEvent(): SessionEvent {
+  return {
+    chunk_id: "chunk-1",
+    id: "event-1",
+    sessionId: "session-1",
+    createdAt: "2026-08-23T00:00:00.000Z",
+    functionName: "assistant_message",
+    uiCanonical: "assistant_message",
+    actionType: "assistant",
+    args: {},
+    result: {},
+    source: "assistant",
+    displayText: `Opened https://github.com/${REPO_FULL_NAME}/pull/${PR_NUMBER} for review.`,
+    displayStatus: "completed",
+    displayVariant: "message",
+    activityStatus: "agent",
+  };
+}
+
+interface ProbeProps {
+  onValue: (value: UseSubmissionsDataResult) => void;
+  simulatorEvents: readonly SessionEvent[];
+  fallbackRepoContext: SubmissionRepoContext;
+  diffRefreshNonce: number;
+}
+
+function Probe({
+  onValue,
+  simulatorEvents,
+  fallbackRepoContext,
+  diffRefreshNonce,
+}: ProbeProps) {
+  onValue(
+    useSubmissionsData({
+      sessionId: "session-1",
+      simulatorEvents,
+      fallbackRepoContext,
+      repos: NO_REPOS,
+      diffRefreshNonce,
+    })
+  );
+  return null;
+}
+
+describe("useSubmissionsData PR status", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let latest: UseSubmissionsDataResult | null;
+  let events: readonly SessionEvent[];
+
+  beforeAll(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    // `reset`, not `clear`: these tests queue one-shot results with
+    // `mockResolvedValueOnce`, and an unconsumed one-shot survives
+    // `clearAllMocks` and leaks into the next test.
+    vi.resetAllMocks();
+    latest = null;
+    events = [prMentionEvent()];
+    getOrgtrackDiffReplayPreviewMock.mockResolvedValue({
+      finalDiffs: [],
+      submissionCommits: [],
+    });
+    loadEventsMock.mockResolvedValue([]);
+    // No git history and no direct SHA lookup: these fixtures carry a PR and no
+    // commits, so the resolve effect has nothing to upgrade.
+    getGitCommitsMock.mockResolvedValue(undefined);
+    getGitCommitDiffMock.mockResolvedValue(undefined);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  afterAll(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  /**
+   * Re-renders with a **fresh** `fallbackRepoContext` object every time, which
+   * is what the real host does: `SessionReplay/index.tsx` rebuilds it as an
+   * object literal on every replay-cursor step.
+   */
+  async function render(diffRefreshNonce: number): Promise<void> {
+    await act(async () => {
+      root.render(
+        createElement(Probe, {
+          onValue: (value) => {
+            latest = value;
+          },
+          simulatorEvents: events,
+          fallbackRepoContext: { repoId: "repo-1", repoPath: "/tmp/repo-1" },
+          diffRefreshNonce,
+        })
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+
+  function statusKey(): string | undefined {
+    const pullRequests = latest?.pullRequestsWithStatus ?? [];
+    expect(pullRequests).toHaveLength(1);
+    return pullRequests[0].statusKey;
+  }
+
+  it("re-reads GitHub status when diffRefreshNonce is bumped", async () => {
+    getPRLocalMock.mockResolvedValueOnce({ state: "open", merged: false });
+    await render(0);
+    expect(statusKey()).toBe("open");
+    expect(getPRLocalMock).toHaveBeenCalledTimes(1);
+
+    // The PR is merged on GitHub. Nothing about the local PR set changes, so
+    // `prStatusFetchKey` is byte-identical — only the nonce can force a re-read.
+    getPRLocalMock.mockResolvedValueOnce({ state: "closed", merged: true });
+    await render(1);
+
+    expect(getPRLocalMock).toHaveBeenCalledTimes(2);
+    expect(getPRLocalMock).toHaveBeenLastCalledWith(REPO_FULL_NAME, PR_NUMBER);
+    expect(statusKey()).toBe("merged");
+  });
+
+  it("reports unknown rather than open when the status read fails", async () => {
+    getPRLocalMock.mockRejectedValueOnce(new Error("no github credentials"));
+    await render(0);
+
+    // The point of the assertion: NOT "open". A green Open badge on a PR whose
+    // state was never read is a claim the hook has no basis for.
+    expect(statusKey()).toBe(PR_STATUS_UNKNOWN);
+  });
+
+  it("recovers a merged badge after a transient failure", async () => {
+    getPRLocalMock.mockRejectedValueOnce(new Error("rate limited"));
+    await render(0);
+    expect(statusKey()).toBe(PR_STATUS_UNKNOWN);
+
+    getPRLocalMock.mockResolvedValueOnce({ state: "closed", merged: true });
+    await render(1);
+
+    expect(statusKey()).toBe("merged");
+  });
+
+  it("does not re-fetch when only the replay cursor advances", async () => {
+    getPRLocalMock.mockResolvedValue({ state: "open", merged: false });
+    await render(0);
+    expect(getPRLocalMock).toHaveBeenCalledTimes(1);
+
+    // Same nonce, same PR set, but a new `fallbackRepoContext` identity and a
+    // new derived `pullRequests` array — the shape every replay-cursor step
+    // produces. Listing `submissionsData.pullRequests` in the effect deps would
+    // turn this into a `getPRLocal` call storm.
+    for (let step = 0; step < 3; step += 1) {
+      events = [prMentionEvent()];
+      await render(0);
+    }
+
+    expect(getPRLocalMock).toHaveBeenCalledTimes(1);
+    expect(statusKey()).toBe("open");
+  });
+});

--- a/src/modules/WorkStation/Diff/SessionReplay/useSubmissionsData.ts
+++ b/src/modules/WorkStation/Diff/SessionReplay/useSubmissionsData.ts
@@ -9,8 +9,10 @@
  *    fallback) — upgrades short SHAs to full SHAs and attaches real
  *    author/summary to commits surfaced by orgtrack or by chat/shell
  *    extraction.
- * 4. GitHub PR status (`getPRLocal`) — batch-fetched once per session and
- *    keyed by `repoFullName#prNumber` so duplicate rows share one request.
+ * 4. GitHub PR status (`getPRLocal`) — batch-fetched per session and keyed by
+ *    `repoFullName#prNumber` so duplicate rows share one request, re-read on
+ *    every `diffRefreshNonce` bump because a PR merged on GitHub changes no
+ *    local input the key could observe.
  *
  * Previously each of these was its own `useEffect` + `useState` pair living
  * in `SessionReplay/index.tsx`, with hand-written cancellation tokens and
@@ -31,7 +33,7 @@ import {
 import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 import { loadEvents } from "@src/engines/SessionCore/storage/cacheAdapter";
 import { createLogger } from "@src/hooks/logger";
-import { normalizePrStatus } from "@src/shared/pr/prStatus";
+import { PR_STATUS_UNKNOWN, normalizePrStatus } from "@src/shared/pr/prStatus";
 import type { Repo } from "@src/store/repo/types";
 
 import {
@@ -57,7 +59,9 @@ interface UseSubmissionsDataParams {
   fallbackRepoContext: SubmissionRepoContext;
   repos: readonly Repo[];
   /** Bumped on every chat→Diff navigation; forces a re-load of orgtrack
-   * commit links so a just-edited working tree isn't shown stale. */
+   * commit links so a just-edited working tree isn't shown stale, and a
+   * re-read of GitHub PR status so a PR merged since the last visit isn't
+   * still badged with its first-read state. */
   diffRefreshNonce: number;
 }
 
@@ -68,7 +72,9 @@ export interface UseSubmissionsDataResult {
   /** Dedup'd, resolved commit rows (orgtrack + shell-created + mention),
    * with author/summary upgraded from git history when possible. */
   submissionCommits: SubmissionCommit[];
-  /** PR rows with normalized GitHub status injected via `statusKey`. */
+  /** PR rows with normalized GitHub status injected via `statusKey`. Rows
+   * whose status read failed carry `PR_STATUS_UNKNOWN` rather than being left
+   * to a caller-side `?? "open"` guess. */
   pullRequestsWithStatus: PullRequestSubmission[];
   /** Raw `deriveSubmissionsData` output; exposed because the count-only
    * consumers (tab badge, hasSubmissions) prefer it over the
@@ -473,32 +479,42 @@ export function useSubmissionsData({
             const draft = pr.draft === true;
             return [key, normalizePrStatus({ state, merged, draft })] as const;
           } catch (error) {
-            // Status is cosmetic; a failed fetch (no creds, rate limit, private
-            // repo, network) shouldn't break the row. Skip — row falls back to
-            // "open" via `pullRequest.statusKey ?? "open"`.
+            // A failed fetch (no creds, rate limit, private repo, offline)
+            // must not be reported as "open": that is an assertion we never
+            // verified, and it renders a merged or closed PR with a green
+            // Open badge until the view is torn down. Publish the explicit
+            // unknown key instead so the row goes neutral.
             logger.warn("failed to fetch PR status", {
               error,
               repoFullName,
               prNumber,
             });
-            return null;
+            return [key, PR_STATUS_UNKNOWN] as const;
           }
         }
       )
     ).then((entries) => {
       if (cancelled) return;
-      const next = new Map<string, string>();
-      for (const entry of entries) {
-        if (entry) next.set(entry[0], entry[1]);
-      }
-      setPrStatusByKey(next);
+      setPrStatusByKey(new Map(entries));
     });
 
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- prStatusFetchKey encodes every repo/name pair read below, avoiding network refetches for equivalent upstream arrays
-  }, [prStatusFetchKey]);
+    // `submissionsData.pullRequests` stays out of the deps on purpose:
+    // `fallbackRepoContext` is a fresh object literal on every recompute, so
+    // the array gets a new identity on every replay-cursor step and listing it
+    // here would fire a `getPRLocal` storm. `prStatusFetchKey` already encodes
+    // every repo/number pair read below, which covers content changes.
+    //
+    // What the key cannot cover is GitHub-side change: merging a PR alters no
+    // local input, so the key is stable and the first read would be the only
+    // read for the life of the mounted view — a merged PR badged "open", or a
+    // PR stuck on `unknown` after one transient failure, with no retry.
+    // `diffRefreshNonce` is that refresh trigger: the same atom the orgtrack
+    // effect above uses, bumped on every chat→Diff navigation.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- prStatusFetchKey encodes every repo/number pair read below; diffRefreshNonce is the deliberate refresh trigger
+  }, [prStatusFetchKey, diffRefreshNonce]);
 
   const pullRequestsWithStatus = useMemo(() => {
     if (prStatusByKey.size === 0) return submissionsData.pullRequests;

--- a/src/shared/pr/__tests__/prStatus.test.ts
+++ b/src/shared/pr/__tests__/prStatus.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  PR_STATUS_UNKNOWN,
   getPrStatusIconName,
   getPrStatusLabelKey,
   getPrStatusVariant,
@@ -103,5 +104,39 @@ describe("getPrStatusIconName", () => {
 
   it("defaults to 'pull-request' for unknown states", () => {
     expect(getPrStatusIconName("pending_review")).toBe("pull-request");
+  });
+});
+
+describe("PR_STATUS_UNKNOWN", () => {
+  it("is not one of the real GitHub states", () => {
+    // It marks the absence of a status, so `normalizePrStatus` must never
+    // produce it: a PR GitHub actually answered for always has a real state.
+    expect(["open", "merged", "closed", "draft"]).not.toContain(
+      PR_STATUS_UNKNOWN
+    );
+    expect(normalizePrStatus({ state: "open" })).not.toBe(PR_STATUS_UNKNOWN);
+    expect(normalizePrStatus({})).not.toBe(PR_STATUS_UNKNOWN);
+  });
+
+  it("presents neutrally rather than as any state-bearing color", () => {
+    const unknown = getPrStatusVariant(PR_STATUS_UNKNOWN);
+
+    expect(unknown).toEqual({
+      badgeClass: "bg-fill-2 text-text-3",
+      dotClass: "bg-text-3",
+      textClass: "text-text-3",
+    });
+    // Specifically not green: a failed status read must not read as "open".
+    expect(unknown).not.toEqual(getPrStatusVariant("open"));
+    expect(getPrStatusIconName(PR_STATUS_UNKNOWN)).toBe("pull-request");
+  });
+
+  it("has a label key backed by a translation", async () => {
+    expect(getPrStatusLabelKey(PR_STATUS_UNKNOWN)).toBe(
+      "labels.prStatus.unknown"
+    );
+
+    const en = await import("@src/i18n/locales/en/common.json");
+    expect(en.default.labels.prStatus).toHaveProperty(PR_STATUS_UNKNOWN);
   });
 });

--- a/src/shared/pr/prStatus.ts
+++ b/src/shared/pr/prStatus.ts
@@ -58,6 +58,18 @@ const PR_STATUS_VARIANTS: Record<string, PrStatusVariant> = {
   },
 };
 
+/**
+ * Canonical key for "this PR's state was never successfully read".
+ *
+ * Deliberately not one of the {@link PrStatus} values: it is the absence of a
+ * status, not a fifth GitHub state. Surfaces that fetch status asynchronously
+ * use it as their fallback so a failed or in-flight read renders neutral
+ * instead of asserting `open` — an `open` fallback silently mislabels merged
+ * and closed PRs. Resolves to {@link FALLBACK_STATUS_VARIANT} and to the
+ * `labels.prStatus.unknown` i18n key.
+ */
+export const PR_STATUS_UNKNOWN = "unknown";
+
 /** Neutral fallback for unknown / custom states (e.g. "pending_review"). */
 const FALLBACK_STATUS_VARIANT: PrStatusVariant = {
   badgeClass: "bg-fill-2 text-text-3",


### PR DESCRIPTION
## Summary

The Diff → Submissions tab could show a PR's status wrong, indefinitely. This adds the missing refresh trigger and stops the UI from asserting `open` for a status it never actually read.

## Problem

`useSubmissionsData` fetches GitHub PR status from an effect whose dependency array is `[prStatusFetchKey]`. That key is a sorted join of `${repoFullName}#${prNumber}` pairs — derived entirely from local session data — so it changes only when the **set** of PRs changes, never when a PR's GitHub state changes. The effect ran once per mounted Diff view and never again.

Two consequences:

1. A PR merged or closed on GitHub after the first fetch kept rendering its stale badge for the entire life of the mounted view.
2. Worse: the catch block returned `null` on any failure (no credentials, rate limit, private repo, offline), and `SubmissionsContent` filled the gap with `pullRequest.statusKey ?? "open"`. A single transient failure therefore rendered a **merged** PR as a green **Open** badge indefinitely, with no retry path. The same applied permanently to rows missing `repoFullName`/`prNumber`, which can never be resolved at all.

## Solution

**Refresh trigger.** Add `diffRefreshNonce` to the effect's deps. The hook already received it as a param, and the sibling orgtrack effect in the same file already lists it — that atom exists precisely to force fresh reads on chat→Diff navigation. This reuses the established trigger rather than introducing polling.

`submissionsData.pullRequests` is deliberately **not** added. `fallbackRepoContext` (`SessionReplay/index.tsx`) returns a fresh object literal on every recompute, so `pullRequests` gets a new array identity on every replay-cursor step; listing it would cause a `getPRLocal` call storm. The existing suppression is load-bearing, and its comment now justifies both the omission and the addition.

**Honest fallback.** A failed fetch now publishes an explicit `PR_STATUS_UNKNOWN` key instead of `null`, and the row fallback uses it too. `getPrStatusVariant` already had a neutral variant for unknown states and `getPrStatusIconName` already defaulted to the plain PR glyph, so no new visual treatment is introduced — the badge just goes neutral gray instead of green. Only `en`/`zh`/`zh-Hant` gain a label, matching the locales that carry the `prStatus` group at all.

### Considered and rejected

`src/hooks/git/useBranchPullRequestStatus.ts` has a richer idiom (polling with backoff, `visibilitychange`, explicit `refresh()`), but it is not reusable here. It is branch-scoped: it resolves remotes → default branch → credentials for one `repoPath`, then finds the PR by head branch. This surface has an arbitrary set of `owner/repo#number` pairs harvested from session text, often for repos with no local checkout and no current branch. Reusing it would mean one hook instance per row with a `repoPath` that cannot be derived from `repoFullName`. It remains the right thing to copy if live CI tracking is ever wanted here.

## Potential risks

- **Extra GitHub requests.** Each chat→Diff navigation now re-reads PR status for the session's PRs. Bounded by the number of distinct PRs in the session (deduped by `repoFullName#prNumber`) and gated on a user navigation, not a timer. A test pins that replay-cursor stepping still produces exactly one call.
- **Visible behavior change on the first frame.** Rows now render a neutral badge before the first read resolves, where they previously rendered green "Open". This is intentional — the old green was a guess — but it is a visual difference on mount, and a persistent neutral badge is now the correct appearance for users with no GitHub credentials.
- **Untranslated label in 10 locales.** `labels.prStatus.*` only exists in `en`/`zh`/`zh-Hant`; the others fall back to the raw key's default value (`unknown`, capitalized by the badge's `capitalize` class). This matches the existing coverage of that key group rather than expanding it.

## Validation

- `tsc --noEmit` — clean, 0 errors.
- `eslint` — clean on all touched files.
- 104 tests green across the 14 related suites (`src/shared/pr`, `src/store/git`, `PullRequestContent`, `SessionReplay`).

### Tests added

`__tests__/useSubmissionsData.prStatus.test.ts` (4) — the repo has no React Testing Library, so this uses the existing `jsdom` + `createRoot` + `act` probe pattern from `useBranchPullRequestStatus.test.ts`, which runs effects for real:

- nonce bump re-reads status and flips `open` → `merged`
- a failed read yields `unknown`, not `open`
- recovery from a transient failure on the next nonce
- three replay-cursor steps (fresh `fallbackRepoContext` identity, same PR set) still produce exactly one `getPRLocal` call

`__tests__/SubmissionsContent.prStatusBadge.test.ts` (3) — the user-visible half, using the repo's `renderToStaticMarkup` idiom. Asserts on semantic badge/dot classes rather than label text, since color is what communicates state.

`src/shared/pr/__tests__/prStatus.test.ts` (+3) — the new constant's contract: `normalizePrStatus` can never produce it, it presents neutral and specifically not green, and its label key is backed by a real translation.

The first three hook tests and the neutral-badge render test were each confirmed to **fail** against the pre-fix code. The call-storm guard passes both before and after by design — it pins behavior that must not regress.
