### PR TITLE
ci(security): add dependency monitoring and fix 3 Rust advisories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,67 @@
+# Dependabot — security updates only.
+#
+# `open-pull-requests-limit: 0` disables *version* update PRs for an ecosystem
+# while leaving Dependabot security updates enabled, so this file adds no
+# routine dependency-bump traffic. Each ecosystem groups its security fixes
+# into a single PR; `applies-to: security-updates` is load-bearing, because a
+# `groups` block without it applies to version updates only (which are off).
+#
+# Repo settings must also have Dependabot alerts + security updates enabled —
+# this file alone does not turn them on.
+#
+# Not covered here, deliberately:
+#   - packages/*        pnpm-workspace.yaml declares `packages: ["."]`, so these
+#                       are not installed workspace members and have no lockfile.
+#   - tests/blackboard-poc/requirements.txt  proof-of-concept only.
+#   - github-actions    would need version updates to be useful; under a
+#                       security-only policy it would do almost nothing.
+version: 2
+
+updates:
+  # Desktop app frontend — pnpm-lock.yaml at the repo root.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "security"
+
+  # WebdriverIO E2E suite — installs separately from the root workspace.
+  # NOTE: this directory currently contains BOTH package-lock.json and
+  # pnpm-lock.yaml. Dependabot will resolve against one of them; the duplicate
+  # should be removed so the two cannot drift.
+  - package-ecosystem: "npm"
+    directory: "/tests/e2e"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      e2e-npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "security"
+
+  # Tauri backend — 44-crate workspace, ~1000 crates in the locked closure.
+  - package-ecosystem: "cargo"
+    directory: "/src-tauri"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+    groups:
+      cargo-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "security"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,3 +97,36 @@ jobs:
       - name: cargo test (workspace)
         working-directory: src-tauri
         run: cargo test --workspace --no-fail-fast
+
+  # ── Dependency audit ────────────────────────────────────────────────────────
+  # Only signal on the ~1000-crate Rust closure; nothing else watches Cargo.lock.
+  # Runs on its own runner rather than inside the `rust` job so an advisory
+  # cannot be masked by, or delay, a clippy/test failure. Ignored advisories and
+  # the reason each one is blocked live in src-tauri/.cargo/audit.toml.
+  cargo-audit:
+    name: Rust (cargo audit)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      # cargo-audit only parses Cargo.lock -- it never builds the workspace, so
+      # this needs no sidecar staging and no target cache.
+      - name: Cache cargo-audit binary
+        id: audit-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: cargo-audit-${{ runner.os }}-v1
+
+      - name: Install cargo-audit
+        if: steps.audit-cache.outputs.cache-hit != 'true'
+        run: cargo install cargo-audit --locked
+
+      - name: cargo audit
+        working-directory: src-tauri
+        run: cargo audit

--- a/src-tauri/.cargo/audit.toml
+++ b/src-tauri/.cargo/audit.toml
@@ -1,0 +1,44 @@
+# cargo-audit configuration for the ORGII Tauri workspace.
+#
+# `cargo audit` runs in CI against Cargo.lock (~1000 crates). It fails the build
+# on any RustSec advisory that is not listed here. Every entry below must say
+# what blocks the upgrade, so this list stays reviewable instead of becoming a
+# place advisories go to be forgotten.
+#
+# Re-check this list whenever a blocking parent is bumped. cargo-audit does NOT
+# report an ignore that has stopped matching, so a stale entry is silent. To see
+# the unfiltered set, run from the repo root so this config is not picked up:
+#     cargo audit -f src-tauri/Cargo.lock
+#
+# Warnings (unmaintained / unsound / yanked) are reported but do not fail the
+# build; there are ~31 of them, almost all in transitive build tooling.
+
+[advisories]
+ignore = [
+  # rsa 0.9.10 -- Marvin attack, timing sidechannel key recovery.
+  # No patched release exists in the 0.9 line.
+  # Reached only through sqlx-mysql, which hardwires the RSA stack for MySQL
+  # 8+'s caching_sha2_password auth plugin (no upstream feature toggle -- see
+  # the comment in crates/db-clients/Cargo.toml). Dropping it means dropping
+  # MySQL support from the DB browser, which is a product feature.
+  # Not remotely reachable in normal use: it requires an attacker-controlled
+  # MySQL server plus precise timing measurement against a user-initiated
+  # connection.
+  "RUSTSEC-2023-0071",
+
+  # quick-xml -- DoS: quadratic duplicate-attribute scan (0194) and unbounded
+  # namespace-declaration allocation (0195). Patched in >=0.41.0.
+  # Two versions are locked, neither reachable from our own manifests:
+  #   0.39.4 <- calamine 0.35 (direct dep; calamine 0.36.1 is available and is
+  #             the upgrade path, but it is a semver-breaking bump of an
+  #             untrusted-spreadsheet parser and needs its own testing)
+  #   0.37.5 <- plist 1.9 (pulled by tauri/tauri-codegen as a build dependency)
+  "RUSTSEC-2026-0194",
+  "RUSTSEC-2026-0195",
+
+  # lopdf 0.34.0 -- DoS: stack overflow on deeply nested PDF objects.
+  # Patched in >=0.42.0. Reached via pdf-extract 0.7 (crates/agent-core);
+  # pdf-extract 0.12.0 is the upgrade path but is several breaking releases
+  # ahead and needs its own testing against real PDFs.
+  "RUSTSEC-2026-0187",
+]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1136,6 +1136,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1505,9 +1516,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1906,7 +1917,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2206,7 +2217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2824,10 +2835,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3103,9 +3117,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4731,7 +4745,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5443,7 +5457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -6308,14 +6322,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg 0.10.2",
  "ring",
  "rustc-hash 2.1.2",
  "rustls",
@@ -6373,7 +6388,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
- "rand_pcg",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -6395,6 +6410,17 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -6455,6 +6481,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6470,6 +6502,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -6875,7 +6916,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6942,7 +6983,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7666,7 +7707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8741,7 +8782,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9440,7 +9481,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10094,7 +10135,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds the dependency monitoring this repo did not have, and fixes the three
Rust advisories that could be fixed immediately.

Before this PR: no `dependabot.yml`, no Renovate, no `cargo-audit`, no
`cargo-deny`, no `deny.toml`. Nothing watched either lockfile.

## Problem

**npm.** `pnpm audit --prod` reports **101 advisories in the production
closure — 2 critical, 42 high**. Worst offenders by count are `axios` (28),
`brace-expansion` (13), `tar` (12) and `node-forge` (4, including a
basicConstraints bypass and an Ed25519 signature-forgery issue).

**Cargo.** ~1000 crates in the locked closure with *zero* monitoring.
`cargo audit` had never been run here; it reports **9 vulnerabilities** plus
31 warnings.

## Solution

### 1. Three advisories fixed outright

All transitive, all resolvable to a semver-compatible release:

| Crate | Bump | Advisory |
| --- | --- | --- |
| `h2` | 0.4.14 → 0.4.18 | RUSTSEC-2026-0258 — unbounded empty DATA frames (DoS) |
| `quinn-proto` | 0.11.14 → 0.11.17 | RUSTSEC-2026-0185 — remote memory exhaustion (DoS) |
| `crossbeam-epoch` | 0.9.18 → 0.9.20 | RUSTSEC-2026-0204 — invalid pointer dereference |

Takes the workspace from 9 advisories to 6.

### 2. Dependabot, security-only

`dependabot.yml` covers npm (root), npm (`tests/e2e`) and cargo
(`src-tauri`). Every ecosystem sets `open-pull-requests-limit: 0`, which
disables *version* update PRs while leaving security updates enabled — so
this adds no routine dependency-bump traffic. Each group sets
`applies-to: security-updates` explicitly, because a `groups` block without
it applies only to version updates (which are off) and would silently do
nothing.

### 3. A `cargo audit` CI job

Runs on its own runner rather than inside the existing `rust` job, so an
advisory cannot be masked by or delayed behind a clippy/test failure. It
only parses `Cargo.lock`, so it needs no sidecar staging and no target
cache. The cargo-audit binary is cached between runs.

### 4. An explicit, documented ignore list

Six advisories cannot be fixed yet. Each is listed in
`src-tauri/.cargo/audit.toml` with the reason it is blocked:

- **`rsa` (RUSTSEC-2023-0071, Marvin attack)** — no patched release exists in
  the 0.9 line. Reached only via `sqlx-mysql`, which hardwires the RSA stack
  for MySQL 8's `caching_sha2_password` auth plugin; there is no upstream
  feature toggle, as `crates/db-clients/Cargo.toml` already documents.
  Dropping it means dropping MySQL support from the DB browser. Exploitation
  requires an attacker-controlled MySQL server plus precise timing
  measurement against a user-initiated connection.
- **`quick-xml` ×4 (RUSTSEC-2026-0194/0195, DoS)** — needs ≥0.41.0; held at
  0.39.4 by `calamine` 0.35 and 0.37.5 by `plist` (a Tauri build dependency).
- **`lopdf` (RUSTSEC-2026-0187, DoS)** — needs ≥0.42.0; held at 0.34 by
  `pdf-extract` 0.7.

`calamine` 0.36.1 and `pdf-extract` 0.12.0 are the upgrade paths, but both
are semver-breaking bumps of parsers that consume untrusted files and need
their own testing rather than riding along here.

## Potential risks

- **The `Cargo.lock` change is the only thing here that can break a build.**
  All three bumps are semver-compatible patch releases of transitive
  dependencies; verified locally with `cargo check --workspace --all-targets`
  (exit 0). CI re-runs clippy with `-D warnings` and the full test suite.
- **The audit job is green on this branch but will fail future PRs** that
  introduce a new advisory. That is the intent.
- **The ignore list is a suppression list, with the same rot risk as any
  other.** cargo-audit does *not* report an ignore that has stopped matching,
  so a stale entry is silent — unlike the ESLint directive check added in
  #893, this one still needs a human to re-read it when a parent moves. A
  scheduled unfiltered run that reports drift would close this; not done here.
- **`dependabot.yml` is inert until repo settings enable it.** Dependabot
  alerts and security updates must be switched on in Settings; this file
  alone does not turn them on.
- **npm advisories are not addressed by this PR.** Dependabot will start
  opening grouped security PRs for them once enabled; fixing 101 advisories
  by hand was out of scope.

## Test plan

- `cargo check --workspace --all-targets` — exit 0 with the updated lockfile.
- `cargo audit` in `src-tauri/` — exit 0 with the ignore list.
- `cargo audit -f src-tauri/Cargo.lock` from the repo root (bypasses the
  config) — still reports the 6 known advisories, confirming the list
  suppresses exactly those and nothing else.
- `dependabot.yml` and `ci.yml` both parse as valid YAML; the new job
  resolves as `cargo-audit` alongside `frontend` and `rust`.

## Follow-ups not in this PR

- `tests/e2e/` contains **both** `package-lock.json` and `pnpm-lock.yaml` for
  the same package. Dependabot will resolve against one of them and the two
  can drift; the duplicate should be removed, but which one survives is a
  call for that suite's owner.
- Upgrade `calamine` → 0.36.1 and `pdf-extract` → 0.12.0 to clear the
  remaining five advisories.
- 20 `unmaintained` and 10 `unsound` warnings are reported but not gated.

## Submit checklist

- [x] The PR is focused and has a scoped Conventional Commits title.
- [x] I ran the relevant checks.
- [x] No secrets, private config, generated output, or unrelated formatting changes are included.
- [ ] Docs, screenshots, and locale updates — not applicable.
