### PR TITLE
Remove unused TabPill prop modes

### DIFF
--- a/src/components/TabPill/TabPill.test.ts
+++ b/src/components/TabPill/TabPill.test.ts
@@ -1,6 +1,17 @@
-import { createElement } from "react";
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 import TabPill from ".";
 
@@ -14,6 +25,31 @@ function getButtonTag(markup: string, testId: string): string {
 }
 
 describe("TabPill", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
   it("paints pill selection and hover states on each button without a measured overlay", () => {
     const markup = renderToStaticMarkup(
       createElement(TabPill, {
@@ -33,5 +69,34 @@ describe("TabPill", () => {
     );
     expect(markup).not.toContain("data-seg");
     expect(markup).not.toContain("translateX(");
+  });
+
+  it("keeps exactly one uncontrolled tab active after selection", () => {
+    const onChange = vi.fn();
+    act(() => {
+      root.render(
+        createElement(TabPill, {
+          variant: "pill",
+          defaultActiveTab: "list",
+          onChange,
+          tabs: [
+            { key: "list", label: "List", dataTestId: "list-tab" },
+            { key: "board", label: "Board", dataTestId: "board-tab" },
+          ],
+        })
+      );
+    });
+
+    const boardTab = container.querySelector<HTMLButtonElement>(
+      '[data-testid="board-tab"]'
+    );
+    act(() => boardTab?.click());
+
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith("board");
+    expect(
+      container.querySelectorAll<HTMLButtonElement>('[data-active="true"]')
+    ).toHaveLength(1);
+    expect(boardTab?.dataset.active).toBe("true");
   });
 });

--- a/src/components/TabPill/index.tsx
+++ b/src/components/TabPill/index.tsx
@@ -21,8 +21,6 @@ const TabPill: React.FC<TabPillProps> = ({
   activeTab: controlledActiveTab,
   defaultActiveTab,
   onChange,
-  activeTabs,
-  onMultiChange,
   variant = "sidebar",
   color = "default",
   className = "",
@@ -33,11 +31,7 @@ const TabPill: React.FC<TabPillProps> = ({
   appearance = "default",
   buttonStyle = false,
   height,
-  onDropdownRef,
 }) => {
-  const isMulti = activeTabs !== undefined;
-  const activeTabsSet = isMulti ? new Set(activeTabs) : null;
-
   const normalizedTabs: TabPillItem[] = tabs.map((tab) =>
     typeof tab === "string" ? { key: tab, label: tab } : tab
   );
@@ -52,23 +46,12 @@ const TabPill: React.FC<TabPillProps> = ({
     (tab: TabPillItem) => {
       if (tab.disabled) return;
 
-      if (isMulti && onMultiChange) {
-        const current = new Set(activeTabs);
-        if (current.has(tab.key)) {
-          current.delete(tab.key);
-        } else {
-          current.add(tab.key);
-        }
-        onMultiChange(Array.from(current));
-        return;
-      }
-
       if (controlledActiveTab === undefined) {
         setInternalActiveTab(tab.key);
       }
       onChange?.(tab.key);
     },
-    [activeTabs, controlledActiveTab, isMulti, onChange, onMultiChange]
+    [controlledActiveTab, onChange]
   );
 
   const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -78,14 +61,6 @@ const TabPill: React.FC<TabPillProps> = ({
   const [dropdownPos, setDropdownPos] = useState({ top: 0, right: 0 });
 
   const dropdownTab = normalizedTabs.find((tab) => tab.dropdown);
-
-  const closeDropdown = useCallback(() => {
-    setDropdownOpen(false);
-    setDropdownPositioned(false);
-  }, []);
-  useEffect(() => {
-    onDropdownRef?.(closeDropdown);
-  }, [onDropdownRef, closeDropdown]);
 
   const updateDropdownPos = useCallback(() => {
     if (!dropdownTriggerRef.current) return;
@@ -193,11 +168,7 @@ const TabPill: React.FC<TabPillProps> = ({
               <SidebarTabButton
                 key={tab.key}
                 tab={tab}
-                isActive={
-                  activeTabsSet
-                    ? activeTabsSet.has(tab.key)
-                    : tab.key === activeTab
-                }
+                isActive={tab.key === activeTab}
                 onClick={() => handleTabClickWithDropdown(tab)}
                 iconOnly={iconOnly}
               />
@@ -217,9 +188,7 @@ const TabPill: React.FC<TabPillProps> = ({
   const tabButtons = normalizedTabs.map((tab) => {
     const hasDropdown = !!tab.dropdown;
     const isDropdownOpen = hasDropdown && dropdownOpen;
-    const isActive = activeTabsSet
-      ? activeTabsSet.has(tab.key)
-      : tab.key === activeTab;
+    const isActive = tab.key === activeTab;
 
     if (isSimple) {
       return (
@@ -335,9 +304,7 @@ const TabPill: React.FC<TabPillProps> = ({
                   : "bg-fill-1 font-semibold text-primary-6"
                 : isDropdownOpen
                   ? "bg-fill-1 text-text-1"
-                  : isMulti
-                    ? "bg-fill-1 text-text-2"
-                    : "bg-transparent text-text-1 hover:bg-surface-hover"
+                  : "bg-transparent text-text-1 hover:bg-surface-hover"
               : appearance === "layout"
                 ? isActive
                   ? size === "large"
@@ -345,9 +312,7 @@ const TabPill: React.FC<TabPillProps> = ({
                     : "bg-fill-2 font-semibold text-primary-6"
                   : isDropdownOpen
                     ? "bg-fill-1 text-text-1"
-                    : isMulti
-                      ? "bg-transparent text-text-2 hover:bg-fill-1"
-                      : "bg-transparent text-text-1 hover:bg-fill-1"
+                    : "bg-transparent text-text-1 hover:bg-fill-1"
                 : appearance === "muted"
                   ? isActive || isDropdownOpen
                     ? size === "large"
@@ -359,18 +324,14 @@ const TabPill: React.FC<TabPillProps> = ({
                       ? size === "large"
                         ? "bg-surface-hover font-semibold text-text-1"
                         : "bg-surface-hover font-semibold text-primary-6"
-                      : isMulti
-                        ? "bg-transparent text-text-2 hover:bg-surface-hover"
-                        : "bg-transparent text-text-1 hover:bg-surface-hover"
+                      : "bg-transparent text-text-1 hover:bg-surface-hover"
                     : isActive
                       ? size === "large"
                         ? "bg-primary-1 font-semibold text-text-1"
                         : "bg-primary-1 font-semibold text-primary-6"
                       : isDropdownOpen
                         ? "bg-fill-2 text-text-1"
-                        : isMulti
-                          ? "bg-fill-3 text-text-2"
-                          : "bg-transparent text-text-1 hover:bg-surface-hover",
+                        : "bg-transparent text-text-1 hover:bg-surface-hover",
           tab.disabled && "cursor-not-allowed opacity-50",
           fillWidth &&
             (usePillWrapGrid
@@ -385,8 +346,7 @@ const TabPill: React.FC<TabPillProps> = ({
           iconOnly,
           isPill,
           isActive || isDropdownOpen,
-          hoveredTabKey === tab.key,
-          !isMulti
+          hoveredTabKey === tab.key
         )}
       </button>
     );

--- a/src/components/TabPill/types.ts
+++ b/src/components/TabPill/types.ts
@@ -22,8 +22,6 @@ export interface TabPillProps {
   activeTab?: string;
   defaultActiveTab?: string;
   onChange?: (key: string) => void;
-  activeTabs?: string[];
-  onMultiChange?: (keys: string[]) => void;
   variant?: "sidebar" | "pill" | "simple";
   color?: "default" | "fill";
   className?: string;
@@ -42,5 +40,4 @@ export interface TabPillProps {
   buttonStyle?: boolean;
   /** Explicit outer control height in pixels for compact toolbar placement. */
   height?: number;
-  onDropdownRef?: (close: () => void) => void;
 }


### PR DESCRIPTION
## Problem

`TabPillProps` advertised `activeTabs`, `onMultiChange`, and `onDropdownRef`, but no tracked production or test call site supplied any of them. The unused surface kept an unreachable multi-select state machine, alternate inactive-tab styling branches, and an external dropdown-close ref effect inside a component whose live callers all use single selection and internal dropdown lifecycle handling.

## Solution

Remove the three unused props from `TabPillProps` and delete only the implementation paths they enabled. Tab activity now follows the existing `activeTab`/`defaultActiveTab` single-selection path directly, while dropdown toggling, outside-click/Escape handling, disabled buttons, styles, and the live `onChange` API remain unchanged. Add a focused component test proving an uncontrolled click leaves exactly one tab active and emits the selected key.

## Potential risks

An untracked or out-of-repository consumer that still supplies one of the removed props will receive a TypeScript error and must migrate to the live single-selection API; no such consumer exists in tracked production or test code. The change does not alter persistence, wire formats, background work, concurrency, platform behavior, or dependencies. If an external consumer is discovered, the narrow rollback is to revert this commit and restore the three prop branches.

## Audit

- Repository-wide tracked-file search found no `TabPill` production or test consumer of `activeTabs`, `onMultiChange`, or `onDropdownRef`. The sole remaining `activeTabs` text is an unrelated E2E diagnostic object key that reports currently active DOM tabs.
- Architecture audit covered acceptance criteria, the exported prop/type boundary, click and dropdown call chains, dead-code branches, and owning-boundary test coverage. Wire protocol, backend entry-point parity, and resolver layers were not applicable to this frontend-only component API cleanup.
- The unavailable `frontend-ui-audit` was applied manually in intent: the refactor adds no design-system bypass, arbitrary styling, accessibility change, or visual-pattern duplication. Native button semantics, disabled state, and every class on the reachable single-select path are retained.
- Screenshots are not useful for this cleanup because the removed modes had zero callers and were therefore unreachable. The live visual path is intentionally unchanged, and the retained ghost active/hover classes remain covered by the existing focused markup assertion.
- Final diff inspection found only the three owning TabPill files, with no secrets, personal paths, debug logs, artifacts, caches, lockfile churn, or unrelated formatting.

## Verification

- `pnpm install --frozen-lockfile` — passed; lockfile unchanged
- `pnpm exec vitest run src/components/TabPill/TabPill.test.ts` — passed (2 tests)
- `pnpm exec eslint src/components/TabPill/index.tsx src/components/TabPill/types.ts src/components/TabPill/TabPill.test.ts` — passed
- `pnpm typecheck` — passed
- `pnpm check:circular` — passed; no circular dependencies across 6,546 modules
- `pnpm build` — passed; webpack production build compiled in 97.7 seconds
- `git fetch origin develop && git rebase origin/develop` — passed; branch was already current
- `git diff --check origin/develop...HEAD` — passed
