### PR TITLE
refactor(ui): normalize number input value callbacks

### DIFF
--- a/src/components/NumberInput/NumberInput.test.ts
+++ b/src/components/NumberInput/NumberInput.test.ts
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import NumberInput from ".";
+
+vi.mock("@src/util/ui/theme/themeUtils", () => ({
+  useCurrentTheme: () => ({ theme: "light", isDark: false }),
+}));
+
+function setInputValue(input: HTMLInputElement, value: string): void {
+  const valueSetter = Object.getOwnPropertyDescriptor(
+    HTMLInputElement.prototype,
+    "value"
+  )?.set;
+  valueSetter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+describe("NumberInput", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("delivers stepped values through onValueChange for keyboard and button controls", () => {
+    const onValueChange = vi.fn();
+    act(() => {
+      root.render(
+        React.createElement(NumberInput, {
+          value: 4,
+          min: 0,
+          max: 5,
+          step: 0.25,
+          onValueChange,
+          dataTestId: "number-input",
+        })
+      );
+    });
+
+    const input = container.querySelector<HTMLInputElement>(
+      '[data-testid="number-input"]'
+    );
+    expect(input).not.toBeNull();
+    expect(input?.type).toBe("text");
+    expect(input?.inputMode).toBe("decimal");
+
+    act(() => {
+      input?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowUp", bubbles: true })
+      );
+    });
+    act(() => {
+      container
+        .querySelector<HTMLButtonElement>(".number-input-btn-down")
+        ?.click();
+    });
+
+    expect(onValueChange).toHaveBeenNthCalledWith(1, 4.25);
+    expect(onValueChange).toHaveBeenNthCalledWith(2, 3.75);
+  });
+
+  it("preserves parse, step rounding, and clamping behavior on blur", () => {
+    const onValueChange = vi.fn();
+    act(() => {
+      root.render(
+        React.createElement(NumberInput, {
+          defaultValue: 1.2,
+          min: 1,
+          max: 2,
+          step: 0.1,
+          onValueChange,
+          dataTestId: "number-input",
+        })
+      );
+    });
+
+    const input = container.querySelector<HTMLInputElement>(
+      '[data-testid="number-input"]'
+    );
+    expect(input).not.toBeNull();
+
+    act(() => input?.focus());
+    act(() => {
+      if (input) setInputValue(input, "1.26");
+    });
+    act(() => input?.blur());
+
+    expect(onValueChange).toHaveBeenLastCalledWith(1.3);
+    expect(input?.value).toBe("1.3");
+
+    act(() => input?.focus());
+    act(() => {
+      if (input) setInputValue(input, "9");
+    });
+    act(() => input?.blur());
+
+    expect(onValueChange).toHaveBeenLastCalledWith(2);
+    expect(input?.value).toBe("2");
+  });
+
+  it("restores the current value without emitting when the draft is empty", () => {
+    const onValueChange = vi.fn();
+    act(() => {
+      root.render(
+        React.createElement(NumberInput, {
+          defaultValue: 1500,
+          onValueChange,
+          dataTestId: "number-input",
+        })
+      );
+    });
+
+    const input = container.querySelector<HTMLInputElement>(
+      '[data-testid="number-input"]'
+    );
+    expect(input?.value).toBe("1,500");
+
+    act(() => input?.focus());
+    expect(input?.value).toBe("1500");
+    act(() => {
+      if (input) setInputValue(input, "");
+    });
+    act(() => input?.blur());
+
+    expect(onValueChange).not.toHaveBeenCalled();
+    expect(input?.value).toBe("1,500");
+  });
+});

--- a/src/components/NumberInput/index.tsx
+++ b/src/components/NumberInput/index.tsx
@@ -14,7 +14,13 @@
  * ```tsx
  * import NumberInput from "@src/components/NumberInput";
  *
- * <NumberInput value={14} min={10} max={20} suffix="px" />
+ * <NumberInput
+ *   value={14}
+ *   min={10}
+ *   max={20}
+ *   suffix="px"
+ *   onValueChange={setFontSize}
+ * />
  * <NumberInput value={1.5} min={1} max={2} step={0.1} />
  * <NumberInput value={500} controlsPosition="sides" />
  * ```
@@ -38,9 +44,9 @@ export interface NumberInputProps {
   defaultValue?: number;
 
   /**
-   * Change handler
+   * Called when a parsed, clamped value is committed
    */
-  onChange?: (value: number | undefined) => void;
+  onValueChange?: (value: number | undefined) => void;
 
   /**
    * Minimum value
@@ -113,7 +119,7 @@ const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
     {
       value,
       defaultValue,
-      onChange,
+      onValueChange,
       min,
       max,
       step = 1,
@@ -166,9 +172,9 @@ const NumberInput = forwardRef<HTMLInputElement, NumberInputProps>(
         if (!isControlled) {
           setInternalValue(newValue);
         }
-        onChange?.(newValue);
+        onValueChange?.(newValue);
       },
-      [isControlled, onChange]
+      [isControlled, onValueChange]
     );
 
     // While focused: just update the draft string, no parsing/clamping

--- a/src/modules/MainApp/AgentOrgs/config/shared/AgentModelsSection.tsx
+++ b/src/modules/MainApp/AgentOrgs/config/shared/AgentModelsSection.tsx
@@ -155,7 +155,7 @@ const AgentModelsSection: React.FC<AgentModelsSectionProps> = ({
               min={16000}
               step={1000}
               controlsPosition="sides"
-              onChange={(val) => {
+              onValueChange={(val) => {
                 if (val !== undefined) update("contextWindow", val);
               }}
               style={SECTION_CONTROL_STYLE}
@@ -173,7 +173,7 @@ const AgentModelsSection: React.FC<AgentModelsSectionProps> = ({
             max={65536}
             step={256}
             controlsPosition="sides"
-            onChange={(val) => {
+            onValueChange={(val) => {
               if (val !== undefined) update("maxTokens", val);
             }}
             style={SECTION_CONTROL_STYLE}
@@ -190,7 +190,7 @@ const AgentModelsSection: React.FC<AgentModelsSectionProps> = ({
             max={2}
             step={0.1}
             controlsPosition="sides"
-            onChange={(val) => {
+            onValueChange={(val) => {
               if (val !== undefined) update("temperature", val);
             }}
             style={SECTION_CONTROL_STYLE}
@@ -224,7 +224,7 @@ const AgentModelsSection: React.FC<AgentModelsSectionProps> = ({
             max={1.0}
             step={0.05}
             controlsPosition="sides"
-            onChange={(val) => {
+            onValueChange={(val) => {
               if (val !== undefined) update("compaction.triggerRatio", val);
             }}
             style={SECTION_CONTROL_STYLE}
@@ -269,7 +269,7 @@ const AgentModelsSection: React.FC<AgentModelsSectionProps> = ({
                 max={0.9}
                 step={0.05}
                 controlsPosition="sides"
-                onChange={(val) => {
+                onValueChange={(val) => {
                   if (val !== undefined) update("compaction.keepRatio", val);
                 }}
                 style={SECTION_CONTROL_STYLE}
@@ -288,7 +288,7 @@ const AgentModelsSection: React.FC<AgentModelsSectionProps> = ({
                 min={512}
                 step={256}
                 controlsPosition="sides"
-                onChange={(val) => {
+                onValueChange={(val) => {
                   if (val !== undefined)
                     update("compaction.summaryMaxTokens", val);
                 }}
@@ -307,7 +307,7 @@ const AgentModelsSection: React.FC<AgentModelsSectionProps> = ({
                 max={50}
                 step={1}
                 controlsPosition="sides"
-                onChange={(val) => {
+                onValueChange={(val) => {
                   if (val !== undefined) update("compaction.minMessages", val);
                 }}
                 style={SECTION_CONTROL_STYLE}
@@ -324,7 +324,7 @@ const AgentModelsSection: React.FC<AgentModelsSectionProps> = ({
                 min={4000}
                 step={1000}
                 controlsPosition="sides"
-                onChange={(val) => {
+                onValueChange={(val) => {
                   if (val !== undefined) update("compaction.floorTokens", val);
                 }}
                 style={SECTION_CONTROL_STYLE}
@@ -343,7 +343,7 @@ const AgentModelsSection: React.FC<AgentModelsSectionProps> = ({
                 min={1000}
                 step={1000}
                 controlsPosition="sides"
-                onChange={(val) => {
+                onValueChange={(val) => {
                   if (val !== undefined)
                     update("compaction.reservedSummaryTokens", val);
                 }}
@@ -361,7 +361,7 @@ const AgentModelsSection: React.FC<AgentModelsSectionProps> = ({
                 min={0}
                 step={1000}
                 controlsPosition="sides"
-                onChange={(val) => {
+                onValueChange={(val) => {
                   if (val !== undefined) update("compaction.bufferTokens", val);
                 }}
                 style={SECTION_CONTROL_STYLE}
@@ -407,7 +407,7 @@ const AgentModelsSection: React.FC<AgentModelsSectionProps> = ({
                 max={10}
                 step={1}
                 controlsPosition="sides"
-                onChange={(val) => {
+                onValueChange={(val) => {
                   if (val !== undefined) update("reliability.maxRetries", val);
                 }}
                 style={SECTION_CONTROL_STYLE}
@@ -426,7 +426,7 @@ const AgentModelsSection: React.FC<AgentModelsSectionProps> = ({
                 step={50}
                 suffix="ms"
                 controlsPosition="sides"
-                onChange={(val) => {
+                onValueChange={(val) => {
                   if (val !== undefined)
                     update("reliability.baseBackoffMs", val);
                 }}

--- a/src/modules/MainApp/AgentOrgs/config/shared/AgentRuntimeLimitsSection.tsx
+++ b/src/modules/MainApp/AgentOrgs/config/shared/AgentRuntimeLimitsSection.tsx
@@ -70,7 +70,7 @@ const AgentRuntimeLimitsSection: React.FC<AgentRuntimeLimitsSectionProps> = ({
           max={500}
           step={1}
           controlsPosition="sides"
-          onChange={(val) => {
+          onValueChange={(val) => {
             if (val !== undefined) update("maxIterations", val);
           }}
           style={SECTION_CONTROL_STYLE}
@@ -88,7 +88,7 @@ const AgentRuntimeLimitsSection: React.FC<AgentRuntimeLimitsSectionProps> = ({
           step={5}
           suffix={t("common:common.s")}
           controlsPosition="sides"
-          onChange={(val) => {
+          onValueChange={(val) => {
             if (val !== undefined) update("execTimeout", val);
           }}
           style={SECTION_CONTROL_STYLE}

--- a/src/modules/MainApp/AgentOrgs/config/shared/SubAgentsEditor.tsx
+++ b/src/modules/MainApp/AgentOrgs/config/shared/SubAgentsEditor.tsx
@@ -337,7 +337,7 @@ const SubAgentsEditor: React.FC<SubAgentsEditorProps> = ({
             min={MIN_TOOL_USE_CONCURRENCY}
             max={MAX_TOOL_USE_CONCURRENCY}
             step={1}
-            onChange={handleMaxToolUseConcurrencyChange}
+            onValueChange={handleMaxToolUseConcurrencyChange}
             style={SECTION_CONTROL_STYLE}
             dataTestId="agent-orgs-subagents-max-tool-use-concurrency-input"
           />

--- a/src/modules/MainApp/Integrations/Connections/Channels/configs/EmailConfig.tsx
+++ b/src/modules/MainApp/Integrations/Connections/Channels/configs/EmailConfig.tsx
@@ -243,7 +243,7 @@ const EmailConfig: React.FC<ChannelConfigProps> = ({
             max={3600}
             step={5}
             controlsPosition="sides"
-            onChange={(val) => {
+            onValueChange={(val) => {
               if (val !== undefined)
                 update(`${pathPrefix}.pollIntervalSeconds`, val);
             }}

--- a/src/modules/MainApp/Integrations/KeyVault/MyRoles/components/MyRolesStatusTab.tsx
+++ b/src/modules/MainApp/Integrations/KeyVault/MyRoles/components/MyRolesStatusTab.tsx
@@ -196,7 +196,7 @@ export const MyRolesStatusTab: React.FC = () => {
         >
           <NumberInput
             value={questionAutoSkipTimeoutByPresence[mode]}
-            onChange={handleQuestionAutoSkipTimeoutChange(mode)}
+            onValueChange={handleQuestionAutoSkipTimeoutChange(mode)}
             min={0}
             max={300}
             step={5}
@@ -217,7 +217,7 @@ export const MyRolesStatusTab: React.FC = () => {
         >
           <NumberInput
             value={planAutoApproveTimeoutByPresence[mode]}
-            onChange={handlePlanAutoApproveTimeoutChange(mode)}
+            onValueChange={handlePlanAutoApproveTimeoutChange(mode)}
             min={0}
             max={3600}
             step={10}
@@ -238,7 +238,7 @@ export const MyRolesStatusTab: React.FC = () => {
         >
           <NumberInput
             value={goalMaxTurnsByPresence[mode]}
-            onChange={handleGoalMaxTurnsChange(mode)}
+            onValueChange={handleGoalMaxTurnsChange(mode)}
             min={0}
             max={100}
             step={1}

--- a/src/modules/MainApp/MyRole/index.tsx
+++ b/src/modules/MainApp/MyRole/index.tsx
@@ -252,7 +252,7 @@ const MyRolePage: React.FC = () => {
         >
           <NumberInput
             value={values.questionAutoResolveSecs}
-            onChange={(value) =>
+            onValueChange={(value) =>
               value !== undefined &&
               onChange({ questionAutoResolveSecs: value })
             }
@@ -274,7 +274,7 @@ const MyRolePage: React.FC = () => {
         >
           <NumberInput
             value={values.planAutoApproveSecs}
-            onChange={(value) =>
+            onValueChange={(value) =>
               value !== undefined && onChange({ planAutoApproveSecs: value })
             }
             min={0}
@@ -312,7 +312,7 @@ const MyRolePage: React.FC = () => {
         >
           <NumberInput
             value={values.goalMaxTurns}
-            onChange={(value) =>
+            onValueChange={(value) =>
               value !== undefined && onChange({ goalMaxTurns: value })
             }
             min={0}

--- a/src/modules/MainApp/Settings/renderer/SettingsFieldRenderer.tsx
+++ b/src/modules/MainApp/Settings/renderer/SettingsFieldRenderer.tsx
@@ -50,7 +50,7 @@ const SettingsFieldRenderer: React.FC<SettingsFieldRendererProps> = ({
     return (
       <NumberInput
         value={typeof value === "number" ? value : 0}
-        onChange={(nextValue) => {
+        onValueChange={(nextValue) => {
           if (nextValue !== undefined) {
             setValue(nextValue as never);
           }

--- a/src/modules/MainApp/Settings/sections/ChatPanelAppearanceTab.tsx
+++ b/src/modules/MainApp/Settings/sections/ChatPanelAppearanceTab.tsx
@@ -27,7 +27,7 @@ export const ChatPanelAppearanceTab: React.FC = () => {
             step={1}
             suffix={tCommon("common.px")}
             controlsPosition="sides"
-            onChange={(value) => {
+            onValueChange={(value) => {
               updateChatAppearance({
                 fontSize: value ?? DEFAULT_CHAT_APPEARANCE.fontSize,
               });
@@ -44,7 +44,7 @@ export const ChatPanelAppearanceTab: React.FC = () => {
             step={1}
             suffix={tCommon("common.px")}
             controlsPosition="sides"
-            onChange={(value) => {
+            onValueChange={(value) => {
               updateChatAppearance({ codeFontSize: value ?? 13 });
             }}
             size="default"
@@ -59,7 +59,7 @@ export const ChatPanelAppearanceTab: React.FC = () => {
             step={0.1}
             suffix={tCommon("common.multiplier")}
             controlsPosition="sides"
-            onChange={(value) => {
+            onValueChange={(value) => {
               updateChatAppearance({ lineHeight: value ?? 1.6 });
             }}
             size="default"
@@ -92,7 +92,7 @@ export const ChatPanelAppearanceTab: React.FC = () => {
               max={50}
               suffix={tCommon("common.ms")}
               controlsPosition="sides"
-              onChange={(value) => {
+              onValueChange={(value) => {
                 updateChatAppearance({ typingSpeed: value ?? 5 });
               }}
               size="default"

--- a/src/modules/MainApp/Settings/sections/EditorSection/components/AppearanceSection.tsx
+++ b/src/modules/MainApp/Settings/sections/EditorSection/components/AppearanceSection.tsx
@@ -157,7 +157,9 @@ const AppearanceSection: React.FC = () => {
             step={1}
             suffix={tCommon("common.px")}
             controlsPosition="sides"
-            onChange={(value) => setFontSize((value ?? 13) as EditorFontSize)}
+            onValueChange={(value) =>
+              setFontSize((value ?? 13) as EditorFontSize)
+            }
             style={SECTION_CONTROL_STYLE}
           />
         </SectionRow>
@@ -170,7 +172,7 @@ const AppearanceSection: React.FC = () => {
             step={0.1}
             suffix={tCommon("common.multiplier")}
             controlsPosition="sides"
-            onChange={(value) =>
+            onValueChange={(value) =>
               setLineHeight((value ?? 1.5) as EditorLineHeight)
             }
             style={SECTION_CONTROL_STYLE}
@@ -185,7 +187,7 @@ const AppearanceSection: React.FC = () => {
             step={2}
             suffix={tCommon("common.spaces")}
             controlsPosition="sides"
-            onChange={(value) => setTabSize((value ?? 2) as EditorTabSize)}
+            onValueChange={(value) => setTabSize((value ?? 2) as EditorTabSize)}
             style={SECTION_CONTROL_STYLE}
           />
         </SectionRow>
@@ -200,7 +202,7 @@ const AppearanceSection: React.FC = () => {
             step={1}
             suffix={tCommon("common.px")}
             controlsPosition="sides"
-            onChange={(value) => setTerminalFontSize(value ?? 13)}
+            onValueChange={(value) => setTerminalFontSize(value ?? 13)}
             style={SECTION_CONTROL_STYLE}
           />
         </SectionRow>

--- a/src/modules/MainApp/Settings/subpages/EditorAppearancePage/index.tsx
+++ b/src/modules/MainApp/Settings/subpages/EditorAppearancePage/index.tsx
@@ -146,7 +146,9 @@ export const TypographySection: React.FC<{ showTitle?: boolean }> = ({
           step={1}
           suffix={tCommon("common.px")}
           controlsPosition="sides"
-          onChange={(value) => setFontSize((value ?? 13) as EditorFontSize)}
+          onValueChange={(value) =>
+            setFontSize((value ?? 13) as EditorFontSize)
+          }
           style={SECTION_CONTROL_STYLE}
         />
       </SectionRow>
@@ -159,7 +161,7 @@ export const TypographySection: React.FC<{ showTitle?: boolean }> = ({
           step={0.1}
           suffix={tCommon("common.multiplier")}
           controlsPosition="sides"
-          onChange={(value) =>
+          onValueChange={(value) =>
             setLineHeight((value ?? 1.5) as EditorLineHeight)
           }
           style={SECTION_CONTROL_STYLE}
@@ -174,7 +176,7 @@ export const TypographySection: React.FC<{ showTitle?: boolean }> = ({
           step={2}
           suffix={tCommon("common.spaces")}
           controlsPosition="sides"
-          onChange={(value) => setTabSize((value ?? 2) as EditorTabSize)}
+          onValueChange={(value) => setTabSize((value ?? 2) as EditorTabSize)}
           style={SECTION_CONTROL_STYLE}
         />
       </SectionRow>
@@ -201,7 +203,7 @@ export const TerminalSection: React.FC = () => {
           step={1}
           suffix={tCommon("common.px")}
           controlsPosition="sides"
-          onChange={(value) => setTerminalFontSize(value ?? 13)}
+          onValueChange={(value) => setTerminalFontSize(value ?? 13)}
           style={SECTION_CONTROL_STYLE}
         />
       </SectionRow>

--- a/src/scaffold/WizardSystem/variants/Agent/AgentWizard.tsx
+++ b/src/scaffold/WizardSystem/variants/Agent/AgentWizard.tsx
@@ -233,7 +233,7 @@ const AgentWizard: FC<AgentWizardProps> = ({ onSave, onCancel }) => {
                     <SectionRow label="" description="" indent>
                       <NumberInput
                         value={w.contextWindow}
-                        onChange={onChangeIfDefined(w.setContextWindow)}
+                        onValueChange={onChangeIfDefined(w.setContextWindow)}
                         min={16000}
                         step={1000}
                         controlsPosition="sides"
@@ -248,7 +248,7 @@ const AgentWizard: FC<AgentWizardProps> = ({ onSave, onCancel }) => {
                   >
                     <NumberInput
                       value={w.maxTokens}
-                      onChange={onChangeIfDefined(w.setMaxTokens)}
+                      onValueChange={onChangeIfDefined(w.setMaxTokens)}
                       min={256}
                       max={65536}
                       step={256}
@@ -263,7 +263,7 @@ const AgentWizard: FC<AgentWizardProps> = ({ onSave, onCancel }) => {
                   >
                     <NumberInput
                       value={w.temperature}
-                      onChange={onChangeIfDefined(w.setTemperature)}
+                      onValueChange={onChangeIfDefined(w.setTemperature)}
                       min={0}
                       max={2}
                       step={0.1}
@@ -299,7 +299,7 @@ const AgentWizard: FC<AgentWizardProps> = ({ onSave, onCancel }) => {
                       >
                         <NumberInput
                           value={w.compactionTriggerRatio}
-                          onChange={onChangeIfDefined(
+                          onValueChange={onChangeIfDefined(
                             w.setCompactionTriggerRatio
                           )}
                           min={0.1}
@@ -321,7 +321,9 @@ const AgentWizard: FC<AgentWizardProps> = ({ onSave, onCancel }) => {
                       >
                         <NumberInput
                           value={w.compactionKeepRatio}
-                          onChange={onChangeIfDefined(w.setCompactionKeepRatio)}
+                          onValueChange={onChangeIfDefined(
+                            w.setCompactionKeepRatio
+                          )}
                           min={0.1}
                           max={0.9}
                           step={0.05}
@@ -358,7 +360,7 @@ const AgentWizard: FC<AgentWizardProps> = ({ onSave, onCancel }) => {
                       >
                         <NumberInput
                           value={w.compactionSummaryMaxTokens}
-                          onChange={onChangeIfDefined(
+                          onValueChange={onChangeIfDefined(
                             w.setCompactionSummaryMaxTokens
                           )}
                           min={512}
@@ -379,7 +381,7 @@ const AgentWizard: FC<AgentWizardProps> = ({ onSave, onCancel }) => {
                       >
                         <NumberInput
                           value={w.compactionMinMessages}
-                          onChange={onChangeIfDefined(
+                          onValueChange={onChangeIfDefined(
                             w.setCompactionMinMessages
                           )}
                           min={1}
@@ -401,7 +403,7 @@ const AgentWizard: FC<AgentWizardProps> = ({ onSave, onCancel }) => {
                       >
                         <NumberInput
                           value={w.compactionFloorTokens}
-                          onChange={onChangeIfDefined(
+                          onValueChange={onChangeIfDefined(
                             w.setCompactionFloorTokens
                           )}
                           min={4000}
@@ -422,7 +424,7 @@ const AgentWizard: FC<AgentWizardProps> = ({ onSave, onCancel }) => {
                       >
                         <NumberInput
                           value={w.compactionReservedSummaryTokens}
-                          onChange={onChangeIfDefined(
+                          onValueChange={onChangeIfDefined(
                             w.setCompactionReservedSummaryTokens
                           )}
                           min={1000}
@@ -443,7 +445,7 @@ const AgentWizard: FC<AgentWizardProps> = ({ onSave, onCancel }) => {
                       >
                         <NumberInput
                           value={w.compactionBufferTokens}
-                          onChange={onChangeIfDefined(
+                          onValueChange={onChangeIfDefined(
                             w.setCompactionBufferTokens
                           )}
                           min={0}


### PR DESCRIPTION
## Problem

The canonical `NumberInput` reports parsed numeric values directly, but named that callback `onChange`. That generic name resembles a native DOM change event even though consumers receive `number | undefined`, making the controlled-value contract less explicit than the repository's `onValueChange` convention.

## Solution

Rename the canonical callback to `onValueChange` across `NumberInput`, its documentation example, all 45 internal JSX consumers, and focused tests. This is an atomic internal migration with no compatibility alias or shim.

The implementation still invokes the callback from the same `updateValue` boundary. `value` and `defaultValue`, controlled and uncontrolled behavior, parsing, comma handling, step precision, min/max clamping, button and keyboard behavior, DOM structure, styles, input semantics, and accessibility behavior are unchanged.

No `InputNumber` alias or re-export exists. `InlineNumberInput` is intentionally excluded because it is a separate Agent Orgs inline-editing control with its own implementation and interaction model, not an alias or wrapper of the canonical `NumberInput`.

## Potential risks

An untracked external consumer using `NumberInput onChange` would receive a TypeScript break. Repository-wide syntax-aware scanning found all 45 internal `NumberInput` elements migrated and zero remaining old props; no shim is included by design. A mechanical rename could accidentally alter callback delivery, so focused tests cover controlled keyboard/button steps, uncontrolled parsing, rounding, clamping, empty-draft restoration, and input semantics. There are no dependency, persistence, IPC, wire-format, or visual changes. Rollback is a direct revert of the single commit.

## Verification

- `pnpm exec vitest run src/components/NumberInput/NumberInput.test.ts` — 3 tests passed
- ESLint over all changed TypeScript/TSX files — passed
- Prettier check over all changed files — passed
- `pnpm typecheck` — passed
- `pnpm build` — production webpack build passed in 113,489 ms
- `pnpm check:circular` — passed; no circular dependencies across 6,583 modules
- Syntax-aware repository scan under `src`, `docs`, `.archive`, and `.storybook` — found 45 `NumberInput` elements and zero `onChange` props
- Canonical implementation search — no old callback declaration, invocation, or dependency entry remains; native `<input onChange>` handlers remain unchanged
- `git diff --check origin/develop...HEAD` — passed
- Final diff/security review — exactly 13 scoped files; no secrets, personal paths, debug artifacts, generated output, dependency, or lockfile changes
- Final `git fetch origin develop --prune` showed the branch directly on the latest `origin/develop`; no rebase was needed

## Audit

Applied all architecture-audit layers. Compilation, structural ownership, naming, semantic overloading, defaults, cross-domain leakage, and developer clarity were checked directly. Wire protocol, initialization parity, and resolver symmetry are not affected by this component-prop rename. The workspace has no `frontend-ui-audit` skill file, so its intent was checked manually: the existing design-system owner remains canonical, native input events were not renamed, DOM/accessibility behavior and visual styles are unchanged, and no duplicate visual abstraction was introduced.

## UI evidence

Screenshots are omitted because this is a behavior-preserving TypeScript prop rename with no rendered DOM, CSS, copy, layout, or visual-state changes. Screenshots would not demonstrate the callback contract; focused interaction tests provide the relevant evidence.
