### PR TITLE
refactor(ui): extract split button from base button

### DIFF
--- a/src/components/Button/index.test.ts
+++ b/src/components/Button/index.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import Button from ".";
 
@@ -35,70 +35,13 @@ function contrastRatio(first: string, second: string): number {
   );
 }
 
-function renderSplitDropdownClassName(
-  variant:
-    | "primary"
-    | "secondary"
-    | "danger"
-    | "warning"
-    | "success"
-    | "merged",
-  dropdownVisible = false
-): string {
-  const markup = renderToStaticMarkup(
-    React.createElement(
-      Button,
-      {
-        variant,
-        dropdownMenu: React.createElement("div"),
-        onDropdownClick: vi.fn(),
-        dropdownVisible,
-      },
-      "Action"
-    )
-  );
-  const buttonClassNames = [...markup.matchAll(/<button[^>]*class="([^"]*)"/g)];
-  return buttonClassNames.at(-1)?.[1] ?? "";
-}
-
-describe("Button split dropdown segment", () => {
-  it("uses the success tone while hovered or open", () => {
-    expect(renderSplitDropdownClassName("success")).toContain(
-      "enabled:hover:bg-success-5"
-    );
-    expect(renderSplitDropdownClassName("success", true)).toContain(
-      "bg-success-5 enabled:hover:bg-success-5"
-    );
-  });
-
-  it("uses GitHub purple for the merged variant and its split state", () => {
-    expect(renderSplitDropdownClassName("merged")).toContain(
-      "enabled:hover:bg-merged-hover"
-    );
-    expect(renderSplitDropdownClassName("merged", true)).toContain(
-      "bg-merged-hover enabled:hover:bg-merged-hover"
-    );
+describe("Button", () => {
+  it("uses GitHub purple for the merged variant", () => {
     const markup = renderToStaticMarkup(
       React.createElement(Button, { variant: "merged" }, "Merged")
     );
     expect(markup).toContain("bg-merged");
     expect(markup).toContain("text-merged-contrast");
-  });
-
-  it.each([
-    ["primary", "primary"],
-    ["danger", "danger"],
-    ["warning", "warning"],
-  ] as const)("uses the %s tone for its semantic variant", (variant, tone) => {
-    expect(renderSplitDropdownClassName(variant)).toContain(
-      `enabled:hover:bg-${tone}-5`
-    );
-  });
-
-  it("keeps neutral solid split buttons neutral", () => {
-    expect(renderSplitDropdownClassName("secondary")).toContain(
-      "enabled:hover:bg-fill-3"
-    );
   });
 
   it.each(["orgii_main.css", "orgii_dark.css", "orgii_high_contrast.css"])(

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -31,19 +31,17 @@
  * <Button variant="primary" icon={<Plus size={14} />}>Add</Button>
  * ```
  */
-import { ChevronDown, Loader2 } from "lucide-react";
-import React, { forwardRef, useMemo } from "react";
+import React, { forwardRef } from "react";
 
-export type ButtonVariant =
-  | "primary"
-  | "secondary"
-  | "tertiary"
-  | "danger"
-  | "warning"
-  | "success"
-  | "merged";
+import {
+  type ButtonAppearance,
+  type ButtonShape,
+  type ButtonSize,
+  type ButtonVariant,
+  useButtonPresentation,
+} from "./presentation";
 
-export type ButtonAppearance = "solid" | "outline" | "dashed" | "ghost";
+export type { ButtonAppearance, ButtonVariant } from "./presentation";
 
 export interface ButtonProps extends Omit<
   React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -66,13 +64,13 @@ export interface ButtonProps extends Omit<
    * Button size
    * @default "default"
    */
-  size?: "mini" | "small" | "default" | "large";
+  size?: ButtonSize;
 
   /**
    * Button shape
    * @default "square"
    */
-  shape?: "square" | "round" | "circle";
+  shape?: ButtonShape;
 
   /** Loading state @default false */
   loading?: boolean;
@@ -116,163 +114,6 @@ export interface ButtonProps extends Omit<
 
   /** Children content */
   children?: React.ReactNode;
-
-  /** Dropdown menu for split button (VSCode style) */
-  dropdownMenu?: React.ReactNode;
-
-  /** Callback when dropdown arrow is clicked */
-  onDropdownClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
-
-  /** Whether the dropdown is visible (for split button) */
-  dropdownVisible?: boolean;
-
-  /** Optional main segment width for icon-only split buttons. */
-  splitIconOnlyMainWidth?: number;
-
-  /**
-   * Optional width (px) of the split-button dropdown caret segment. Overrides
-   * the default (`height / 2` for icon-only, `height` otherwise).
-   */
-  splitDropdownWidth?: number;
-
-  /** Align split-button content within the main segment or the full button. */
-  splitContentAlign?: "main" | "button";
-
-  /** Whether split buttons should fill the parent width or hug their content. */
-  splitWidthMode?: "fill" | "hug";
-}
-
-const SIZE_CONFIG = {
-  mini: { height: 24, padding: "0 8px", fontSize: 12, iconSize: 12 },
-  small: { height: 28, padding: "0 12px", fontSize: 13, iconSize: 14 },
-  default: { height: 32, padding: "0 14px", fontSize: 13, iconSize: 14 },
-  large: { height: 40, padding: "0 18px", fontSize: 14, iconSize: 16 },
-} as const;
-
-function defaultAppearanceFor(variant: ButtonVariant): ButtonAppearance {
-  switch (variant) {
-    case "primary":
-    case "danger":
-    case "warning":
-    case "success":
-    case "merged":
-      return "solid";
-    case "secondary":
-      return "outline";
-    case "tertiary":
-      return "solid";
-  }
-}
-
-/**
- * Static Tailwind class strings for each (variant, appearance) cell.
- * Class strings must be statically analyzable — no dynamic interpolation
- * of class names, only dynamic selection between fully-written strings.
- */
-function getStyleClasses(variant: ButtonVariant, appearance: ButtonAppearance) {
-  const base = (() => {
-    switch (variant) {
-      case "primary":
-        if (appearance === "solid") return "border-0 text-white bg-primary-6";
-        if (appearance === "outline")
-          return "border border-primary-6 bg-transparent text-primary-6";
-        if (appearance === "dashed")
-          return "border border-dashed border-primary-6/50 bg-transparent text-primary-6";
-        return "border-0 bg-transparent text-primary-6";
-      case "secondary":
-        if (appearance === "solid") return "border-0 bg-fill-2 text-text-1";
-        if (appearance === "outline")
-          return "border border-border-2 bg-bg-2 text-text-1";
-        if (appearance === "dashed")
-          return "border border-dashed border-border-2 bg-transparent text-text-1";
-        return "border-0 bg-transparent text-text-1";
-      case "tertiary":
-        if (appearance === "solid")
-          return "border-0 bg-transparent text-text-2";
-        if (appearance === "outline")
-          return "border border-border-2 bg-bg-2 text-text-2";
-        if (appearance === "dashed")
-          return "border border-dashed border-border-2 bg-transparent text-text-2";
-        return "border-0 bg-transparent text-text-2";
-      case "danger":
-        if (appearance === "solid") return "border-0 text-white bg-danger-6";
-        if (appearance === "outline")
-          return "border border-border-2 bg-bg-2 text-danger-6";
-        if (appearance === "dashed")
-          return "border border-dashed border-danger-6/50 bg-transparent text-danger-6";
-        return "border-0 bg-transparent text-danger-6";
-      case "warning":
-        if (appearance === "solid") return "border-0 text-white bg-warning-6";
-        if (appearance === "outline")
-          return "border border-border-2 bg-bg-2 text-warning-6";
-        if (appearance === "dashed")
-          return "border border-dashed border-warning-6/50 bg-transparent text-warning-6";
-        return "border-0 bg-transparent text-warning-6";
-      case "success":
-        if (appearance === "solid") return "border-0 text-white bg-success-6";
-        if (appearance === "outline")
-          return "border border-border-2 bg-bg-2 text-success-6";
-        if (appearance === "dashed")
-          return "border border-dashed border-success-6/50 bg-transparent text-success-6";
-        return "border-0 bg-transparent text-success-6";
-      case "merged":
-        if (appearance === "solid")
-          return "border-0 bg-merged text-merged-contrast";
-        if (appearance === "outline")
-          return "border border-purple-6 bg-transparent text-purple-6";
-        if (appearance === "dashed")
-          return "border border-dashed border-purple-6/50 bg-transparent text-purple-6";
-        return "border-0 bg-transparent text-purple-6";
-    }
-  })();
-
-  const hover = (() => {
-    if (appearance === "solid") {
-      switch (variant) {
-        case "primary":
-          return "enabled:hover:bg-primary-5 enabled:active:bg-primary-7";
-        case "danger":
-          return "enabled:hover:bg-danger-5 enabled:active:bg-danger-6";
-        case "warning":
-          return "enabled:hover:bg-warning-5 enabled:active:bg-warning-6";
-        case "success":
-          return "enabled:hover:bg-success-5 enabled:active:bg-success-6";
-        case "merged":
-          return "enabled:hover:bg-merged-hover enabled:active:bg-merged-active";
-        case "secondary":
-          return "enabled:hover:bg-fill-3";
-        case "tertiary":
-          return "enabled:hover:text-text-1 enabled:hover:bg-surface-hover focus-visible:text-text-1 focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_color-mix(in_srgb,var(--color-primary-6)_15%,transparent)]";
-      }
-    }
-    if (appearance === "outline" || appearance === "dashed") {
-      // Bordered variants: tint the border on hover for the neutral
-      // greys, and for colored ones we keep the existing focus ring.
-      if (variant === "secondary" || variant === "tertiary") {
-        return "hover:border-border-3 focus-visible:border-[var(--color-primary-6)] focus-visible:shadow-[0_0_0_2px_color-mix(in_srgb,var(--color-primary-6)_15%,transparent)]";
-      }
-      return "";
-    }
-    // appearance === "ghost"
-    switch (variant) {
-      case "primary":
-        return "enabled:hover:text-primary-5";
-      case "danger":
-        return "enabled:hover:text-danger-5";
-      case "warning":
-        return "enabled:hover:text-warning-5";
-      case "success":
-        return "enabled:hover:text-success-5";
-      case "merged":
-        return "enabled:hover:text-purple-5";
-      case "secondary":
-        return "enabled:hover:text-text-1";
-      case "tertiary":
-        return "enabled:hover:text-text-1";
-    }
-  })();
-
-  return [base, hover].filter(Boolean).join(" ");
 }
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
@@ -297,187 +138,27 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       className = "",
       style,
       onClick,
-      dropdownMenu,
-      onDropdownClick,
-      dropdownVisible,
-      splitIconOnlyMainWidth,
-      splitDropdownWidth,
-      splitContentAlign = "main",
-      splitWidthMode = "fill",
       ...rest
     },
     ref
   ) => {
-    const sizeConfig = SIZE_CONFIG[size];
-    const isDisabled = disabled || loading;
-    const hasSplitButton = dropdownMenu && onDropdownClick;
-    const resolvedAppearance = appearance ?? defaultAppearanceFor(variant);
-
-    const borderRadius = useMemo(() => {
-      if (shape === "circle") return "50%";
-      if (shape === "round") return "100px";
-      return "8px";
-    }, [shape]);
-
-    const buttonStyles = useMemo<React.CSSProperties>(() => {
-      const iconOnlySize =
-        iconOnly || shape === "circle" ? sizeConfig.height : undefined;
-      return {
-        height: sizeConfig.height,
-        padding: iconOnly || shape === "circle" ? "0" : sizeConfig.padding,
-        width: long ? "100%" : iconOnlySize,
-        minWidth: long ? 0 : undefined,
-        fontSize: sizeConfig.fontSize,
-        borderRadius,
-        ...style,
-      };
-    }, [sizeConfig, iconOnly, shape, long, borderRadius, style]);
-
-    // Icon↔label spacing lives on the icon itself (margin), NOT on a flex
-    // `gap` of the <button>: WebKit's button-internal (anonymous-box) layout
-    // can drop the gap, which rendered the loading spinner flush against /
-    // overlapping the label (e.g. the "Verify setup" button while verifying).
-    const iconSpacingClass =
-      children && !iconOnly ? (iconPosition === "right" ? "ml-2" : "mr-2") : "";
-
-    const renderIcon = () => {
-      if (loading) {
-        if (loadingSpinIcon && icon) {
-          return (
-            <span
-              className={`pointer-events-none inline-flex shrink-0 animate-spin items-center justify-center leading-none ${iconSpacingClass}`}
-            >
-              {icon}
-            </span>
-          );
-        }
-        // Wrapped in a span (like the icon branches): WKWebView's
-        // button-internal layout can drop margins set directly on the svg,
-        // which rendered the spinner on top of the label.
-        return (
-          <span
-            className={`pointer-events-none inline-flex shrink-0 items-center justify-center leading-none ${iconSpacingClass}`}
-          >
-            <Loader2 size={sizeConfig.iconSize} className="animate-spin" />
-          </span>
-        );
-      }
-      if (icon) {
-        if (typeof icon === "string") {
-          return (
-            <i
-              className={`${icon} inline-flex shrink-0 items-center justify-center leading-none ${iconSpacingClass}`}
-              style={{ fontSize: sizeConfig.iconSize }}
-            />
-          );
-        }
-        return (
-          <span
-            className={`pointer-events-none inline-flex shrink-0 items-center justify-center leading-none ${iconSpacingClass}`}
-          >
-            {icon}
-          </span>
-        );
-      }
-      return null;
-    };
-
-    const buttonContent = (
-      <>
-        {iconPosition === "left" && renderIcon()}
-        {!iconOnly && (
-          <span className="min-w-0 truncate leading-tight">{children}</span>
-        )}
-        {iconPosition === "right" && renderIcon()}
-      </>
-    );
-
-    const baseClasses =
-      "inline-flex items-center justify-center font-medium whitespace-nowrap select-none no-underline outline-none transition-[border-color,box-shadow,background-color,color,opacity] duration-150";
-    const disabledClasses = isDisabled
-      ? "cursor-not-allowed opacity-50"
-      : "cursor-pointer";
-
-    const splitWrapperHoverClass =
-      !isDisabled && variant === "tertiary" && resolvedAppearance === "solid"
-        ? "group-hover/button-split:bg-surface-hover group-hover/button-split:text-text-1"
-        : "";
-
-    const splitDropdownColorClass = (() => {
-      if (resolvedAppearance === "solid") {
-        switch (variant) {
-          case "primary":
-          case "danger":
-          case "warning":
-          case "success":
-            return "text-white";
-          case "merged":
-            return "text-merged-contrast";
-          case "secondary":
-            return "text-text-1";
-          case "tertiary":
-            return "text-text-2 group-hover/button-split:text-text-1";
-        }
-      }
-      switch (variant) {
-        case "primary":
-          return "text-primary-6";
-        case "danger":
-          return "text-danger-6";
-        case "warning":
-          return "text-warning-6";
-        case "success":
-          return "text-success-6";
-        case "merged":
-          return "text-purple-6";
-        case "secondary":
-          return "text-text-1";
-        case "tertiary":
-          return "text-text-2 group-hover/button-split:text-text-1";
-      }
-    })();
-
-    const splitDropdownStateClass = (() => {
-      if (isDisabled) return "";
-      if (resolvedAppearance === "solid") {
-        switch (variant) {
-          case "primary":
-            return dropdownVisible
-              ? "bg-primary-5 enabled:hover:bg-primary-5"
-              : "enabled:hover:bg-primary-5";
-          case "danger":
-            return dropdownVisible
-              ? "bg-danger-5 enabled:hover:bg-danger-5"
-              : "enabled:hover:bg-danger-5";
-          case "warning":
-            return dropdownVisible
-              ? "bg-warning-5 enabled:hover:bg-warning-5"
-              : "enabled:hover:bg-warning-5";
-          case "success":
-            return dropdownVisible
-              ? "bg-success-5 enabled:hover:bg-success-5"
-              : "enabled:hover:bg-success-5";
-          case "merged":
-            return dropdownVisible
-              ? "bg-merged-hover enabled:hover:bg-merged-hover"
-              : "enabled:hover:bg-merged-hover";
-          case "secondary":
-          case "tertiary":
-            break;
-        }
-      }
-      return "enabled:hover:bg-fill-3";
-    })();
-
-    const buttonClassName = [
-      "button",
-      baseClasses,
-      disabledClasses,
-      getStyleClasses(variant, resolvedAppearance),
-      className,
-    ]
-      .filter(Boolean)
-      .join(" ");
+    const { isDisabled, buttonStyles, buttonContent, buttonClassName } =
+      useButtonPresentation({
+        variant,
+        appearance,
+        size,
+        shape,
+        loading,
+        loadingSpinIcon,
+        disabled,
+        icon,
+        iconPosition,
+        iconOnly,
+        long,
+        children,
+        className,
+        style,
+      });
 
     if (href && !isDisabled) {
       return (
@@ -494,112 +175,6 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         >
           {buttonContent}
         </a>
-      );
-    }
-
-    if (hasSplitButton) {
-      const dropdownWidth =
-        splitDropdownWidth ??
-        (iconOnly ? sizeConfig.height / 2 : sizeConfig.height);
-      const splitMainWidth = iconOnly
-        ? (splitIconOnlyMainWidth ?? sizeConfig.height)
-        : undefined;
-      const splitButtonWidth = iconOnly
-        ? (splitMainWidth ?? sizeConfig.height) + dropdownWidth
-        : undefined;
-      const shouldHugSplit = splitWidthMode === "hug" && !iconOnly && !long;
-
-      return (
-        <div
-          className="button-split-wrapper group/button-split"
-          style={{
-            display: "flex",
-            position: "relative",
-            width: long ? "100%" : "auto",
-            minWidth: 0,
-          }}
-        >
-          <div
-            style={{
-              position: "relative",
-              flex: shouldHugSplit ? "none" : 1,
-              display: "flex",
-              minWidth: 0,
-            }}
-          >
-            <button
-              ref={ref}
-              type={htmlType}
-              disabled={isDisabled}
-              className={`${buttonClassName} ${splitWrapperHoverClass}`.trim()}
-              style={{
-                ...buttonStyles,
-                width: shouldHugSplit ? "auto" : (splitButtonWidth ?? "100%"),
-                minWidth: 0,
-                flex: iconOnly || shouldHugSplit ? "none" : 1,
-                paddingRight: iconOnly ? 0 : `${dropdownWidth}px`,
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                position: "relative",
-              }}
-              onClick={onClick}
-              {...rest}
-            >
-              {shouldHugSplit ? (
-                buttonContent
-              ) : (
-                <div
-                  style={{
-                    position: "absolute",
-                    left: 0,
-                    right: splitContentAlign === "button" ? 0 : dropdownWidth,
-                    top: 0,
-                    bottom: 0,
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    // Icon↔label spacing comes from the icon margin (see
-                    // iconSpacingClass) — no flex gap needed here either.
-                    pointerEvents: "none",
-                  }}
-                >
-                  {buttonContent}
-                </div>
-              )}
-            </button>
-
-            <button
-              type="button"
-              disabled={isDisabled}
-              className={`transition-colors ${splitDropdownStateClass} ${splitDropdownColorClass}`}
-              style={{
-                position: "absolute",
-                right: 0,
-                top: 0,
-                bottom: 0,
-                width: dropdownWidth,
-                height: "100%",
-                padding: 0,
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                border: "none",
-                borderTopRightRadius: borderRadius,
-                borderBottomRightRadius: borderRadius,
-                cursor: isDisabled
-                  ? "not-allowed"
-                  : "var(--interactive-cursor, default)",
-                opacity: isDisabled ? 0.5 : 1,
-              }}
-              onClick={onDropdownClick}
-            >
-              <ChevronDown size={12} />
-            </button>
-          </div>
-
-          {dropdownVisible && dropdownMenu}
-        </div>
       );
     }
 

--- a/src/components/Button/presentation.tsx
+++ b/src/components/Button/presentation.tsx
@@ -1,0 +1,286 @@
+import { Loader2 } from "lucide-react";
+import React, { useMemo } from "react";
+
+export type ButtonVariant =
+  | "primary"
+  | "secondary"
+  | "tertiary"
+  | "danger"
+  | "warning"
+  | "success"
+  | "merged";
+
+export type ButtonAppearance = "solid" | "outline" | "dashed" | "ghost";
+export type ButtonSize = "mini" | "small" | "default" | "large";
+export type ButtonShape = "square" | "round" | "circle";
+
+const BUTTON_SIZE_CONFIG = {
+  mini: { height: 24, padding: "0 8px", fontSize: 12, iconSize: 12 },
+  small: { height: 28, padding: "0 12px", fontSize: 13, iconSize: 14 },
+  default: { height: 32, padding: "0 14px", fontSize: 13, iconSize: 14 },
+  large: { height: 40, padding: "0 18px", fontSize: 14, iconSize: 16 },
+} as const;
+
+function defaultButtonAppearance(variant: ButtonVariant): ButtonAppearance {
+  switch (variant) {
+    case "primary":
+    case "danger":
+    case "warning":
+    case "success":
+    case "merged":
+      return "solid";
+    case "secondary":
+      return "outline";
+    case "tertiary":
+      return "solid";
+  }
+}
+
+/**
+ * Static Tailwind class strings for each (variant, appearance) cell.
+ * Class strings must be statically analyzable — no dynamic interpolation
+ * of class names, only dynamic selection between fully-written strings.
+ */
+function getButtonStyleClasses(
+  variant: ButtonVariant,
+  appearance: ButtonAppearance
+) {
+  const base = (() => {
+    switch (variant) {
+      case "primary":
+        if (appearance === "solid") return "border-0 text-white bg-primary-6";
+        if (appearance === "outline")
+          return "border border-primary-6 bg-transparent text-primary-6";
+        if (appearance === "dashed")
+          return "border border-dashed border-primary-6/50 bg-transparent text-primary-6";
+        return "border-0 bg-transparent text-primary-6";
+      case "secondary":
+        if (appearance === "solid") return "border-0 bg-fill-2 text-text-1";
+        if (appearance === "outline")
+          return "border border-border-2 bg-bg-2 text-text-1";
+        if (appearance === "dashed")
+          return "border border-dashed border-border-2 bg-transparent text-text-1";
+        return "border-0 bg-transparent text-text-1";
+      case "tertiary":
+        if (appearance === "solid")
+          return "border-0 bg-transparent text-text-2";
+        if (appearance === "outline")
+          return "border border-border-2 bg-bg-2 text-text-2";
+        if (appearance === "dashed")
+          return "border border-dashed border-border-2 bg-transparent text-text-2";
+        return "border-0 bg-transparent text-text-2";
+      case "danger":
+        if (appearance === "solid") return "border-0 text-white bg-danger-6";
+        if (appearance === "outline")
+          return "border border-border-2 bg-bg-2 text-danger-6";
+        if (appearance === "dashed")
+          return "border border-dashed border-danger-6/50 bg-transparent text-danger-6";
+        return "border-0 bg-transparent text-danger-6";
+      case "warning":
+        if (appearance === "solid") return "border-0 text-white bg-warning-6";
+        if (appearance === "outline")
+          return "border border-border-2 bg-bg-2 text-warning-6";
+        if (appearance === "dashed")
+          return "border border-dashed border-border-2 bg-transparent text-warning-6";
+        return "border-0 bg-transparent text-warning-6";
+      case "success":
+        if (appearance === "solid") return "border-0 text-white bg-success-6";
+        if (appearance === "outline")
+          return "border border-border-2 bg-bg-2 text-success-6";
+        if (appearance === "dashed")
+          return "border border-dashed border-success-6/50 bg-transparent text-success-6";
+        return "border-0 bg-transparent text-success-6";
+      case "merged":
+        if (appearance === "solid")
+          return "border-0 bg-merged text-merged-contrast";
+        if (appearance === "outline")
+          return "border border-purple-6 bg-transparent text-purple-6";
+        if (appearance === "dashed")
+          return "border border-dashed border-purple-6/50 bg-transparent text-purple-6";
+        return "border-0 bg-transparent text-purple-6";
+    }
+  })();
+
+  const hover = (() => {
+    if (appearance === "solid") {
+      switch (variant) {
+        case "primary":
+          return "enabled:hover:bg-primary-5 enabled:active:bg-primary-7";
+        case "danger":
+          return "enabled:hover:bg-danger-5 enabled:active:bg-danger-6";
+        case "warning":
+          return "enabled:hover:bg-warning-5 enabled:active:bg-warning-6";
+        case "success":
+          return "enabled:hover:bg-success-5 enabled:active:bg-success-6";
+        case "merged":
+          return "enabled:hover:bg-merged-hover enabled:active:bg-merged-active";
+        case "secondary":
+          return "enabled:hover:bg-fill-3";
+        case "tertiary":
+          return "enabled:hover:text-text-1 enabled:hover:bg-surface-hover focus-visible:text-text-1 focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_color-mix(in_srgb,var(--color-primary-6)_15%,transparent)]";
+      }
+    }
+    if (appearance === "outline" || appearance === "dashed") {
+      if (variant === "secondary" || variant === "tertiary") {
+        return "hover:border-border-3 focus-visible:border-[var(--color-primary-6)] focus-visible:shadow-[0_0_0_2px_color-mix(in_srgb,var(--color-primary-6)_15%,transparent)]";
+      }
+      return "";
+    }
+    switch (variant) {
+      case "primary":
+        return "enabled:hover:text-primary-5";
+      case "danger":
+        return "enabled:hover:text-danger-5";
+      case "warning":
+        return "enabled:hover:text-warning-5";
+      case "success":
+        return "enabled:hover:text-success-5";
+      case "merged":
+        return "enabled:hover:text-purple-5";
+      case "secondary":
+      case "tertiary":
+        return "enabled:hover:text-text-1";
+    }
+  })();
+
+  return [base, hover].filter(Boolean).join(" ");
+}
+
+interface ButtonPresentationOptions {
+  variant: ButtonVariant;
+  appearance?: ButtonAppearance;
+  size: ButtonSize;
+  shape: ButtonShape;
+  loading: boolean;
+  loadingSpinIcon: boolean;
+  disabled: boolean;
+  icon?: React.ReactNode | string;
+  iconPosition: "left" | "right";
+  iconOnly: boolean;
+  long: boolean;
+  children?: React.ReactNode;
+  className: string;
+  style?: React.CSSProperties;
+}
+
+export function useButtonPresentation({
+  variant,
+  appearance,
+  size,
+  shape,
+  loading,
+  loadingSpinIcon,
+  disabled,
+  icon,
+  iconPosition,
+  iconOnly,
+  long,
+  children,
+  className,
+  style,
+}: ButtonPresentationOptions) {
+  const sizeConfig = BUTTON_SIZE_CONFIG[size];
+  const isDisabled = disabled || loading;
+  const resolvedAppearance = appearance ?? defaultButtonAppearance(variant);
+
+  const borderRadius = useMemo(() => {
+    if (shape === "circle") return "50%";
+    if (shape === "round") return "100px";
+    return "8px";
+  }, [shape]);
+
+  const buttonStyles = useMemo<React.CSSProperties>(() => {
+    const iconOnlySize =
+      iconOnly || shape === "circle" ? sizeConfig.height : undefined;
+    return {
+      height: sizeConfig.height,
+      padding: iconOnly || shape === "circle" ? "0" : sizeConfig.padding,
+      width: long ? "100%" : iconOnlySize,
+      minWidth: long ? 0 : undefined,
+      fontSize: sizeConfig.fontSize,
+      borderRadius,
+      ...style,
+    };
+  }, [sizeConfig, iconOnly, shape, long, borderRadius, style]);
+
+  // Icon↔label spacing lives on the icon itself (margin), NOT on a flex
+  // `gap` of the <button>: WebKit's button-internal (anonymous-box) layout
+  // can drop the gap, which rendered the loading spinner flush against /
+  // overlapping the label (e.g. the "Verify setup" button while verifying).
+  const iconSpacingClass =
+    children && !iconOnly ? (iconPosition === "right" ? "ml-2" : "mr-2") : "";
+
+  const renderIcon = () => {
+    if (loading) {
+      if (loadingSpinIcon && icon) {
+        return (
+          <span
+            className={`pointer-events-none inline-flex shrink-0 animate-spin items-center justify-center leading-none ${iconSpacingClass}`}
+          >
+            {icon}
+          </span>
+        );
+      }
+      return (
+        <span
+          className={`pointer-events-none inline-flex shrink-0 items-center justify-center leading-none ${iconSpacingClass}`}
+        >
+          <Loader2 size={sizeConfig.iconSize} className="animate-spin" />
+        </span>
+      );
+    }
+    if (icon) {
+      if (typeof icon === "string") {
+        return (
+          <i
+            className={`${icon} inline-flex shrink-0 items-center justify-center leading-none ${iconSpacingClass}`}
+            style={{ fontSize: sizeConfig.iconSize }}
+          />
+        );
+      }
+      return (
+        <span
+          className={`pointer-events-none inline-flex shrink-0 items-center justify-center leading-none ${iconSpacingClass}`}
+        >
+          {icon}
+        </span>
+      );
+    }
+    return null;
+  };
+
+  const buttonContent = (
+    <>
+      {iconPosition === "left" && renderIcon()}
+      {!iconOnly && (
+        <span className="min-w-0 truncate leading-tight">{children}</span>
+      )}
+      {iconPosition === "right" && renderIcon()}
+    </>
+  );
+
+  const baseClasses =
+    "inline-flex items-center justify-center font-medium whitespace-nowrap select-none no-underline outline-none transition-[border-color,box-shadow,background-color,color,opacity] duration-150";
+  const disabledClasses = isDisabled
+    ? "cursor-not-allowed opacity-50"
+    : "cursor-pointer";
+  const buttonClassName = [
+    "button",
+    baseClasses,
+    disabledClasses,
+    getButtonStyleClasses(variant, resolvedAppearance),
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return {
+    sizeConfig,
+    isDisabled,
+    resolvedAppearance,
+    borderRadius,
+    buttonStyles,
+    buttonContent,
+    buttonClassName,
+  };
+}

--- a/src/components/SplitButton/index.test.ts
+++ b/src/components/SplitButton/index.test.ts
@@ -1,0 +1,123 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import SplitButton from ".";
+
+type SplitVariant =
+  | "primary"
+  | "secondary"
+  | "danger"
+  | "warning"
+  | "success"
+  | "merged";
+
+function renderSplitButton(variant: SplitVariant, menuOpen = false): string {
+  return renderToStaticMarkup(
+    React.createElement(
+      SplitButton,
+      {
+        variant,
+        menu: React.createElement("div", { "data-testid": "menu" }),
+        menuOpen,
+        onMenuButtonClick: vi.fn(),
+        menuButtonLabel: "More actions",
+      },
+      "Action"
+    )
+  );
+}
+
+function menuButtonClassName(markup: string): string {
+  const buttonClassNames = [...markup.matchAll(/<button[^>]*class="([^"]*)"/g)];
+  return buttonClassNames.at(-1)?.[1] ?? "";
+}
+
+describe("SplitButton", () => {
+  it("uses the success tone while hovered or open", () => {
+    expect(menuButtonClassName(renderSplitButton("success"))).toContain(
+      "enabled:hover:bg-success-5"
+    );
+    expect(menuButtonClassName(renderSplitButton("success", true))).toContain(
+      "bg-success-5 enabled:hover:bg-success-5"
+    );
+  });
+
+  it("uses GitHub purple for the merged variant and its open state", () => {
+    expect(menuButtonClassName(renderSplitButton("merged"))).toContain(
+      "enabled:hover:bg-merged-hover"
+    );
+    expect(menuButtonClassName(renderSplitButton("merged", true))).toContain(
+      "bg-merged-hover enabled:hover:bg-merged-hover"
+    );
+  });
+
+  it.each([
+    ["primary", "primary"],
+    ["danger", "danger"],
+    ["warning", "warning"],
+  ] as const)("uses the %s tone for its semantic variant", (variant, tone) => {
+    expect(menuButtonClassName(renderSplitButton(variant))).toContain(
+      `enabled:hover:bg-${tone}-5`
+    );
+  });
+
+  it("keeps neutral solid split buttons neutral", () => {
+    expect(menuButtonClassName(renderSplitButton("secondary"))).toContain(
+      "enabled:hover:bg-fill-3"
+    );
+  });
+
+  it("puts menu semantics and the accessible name on the menu trigger", () => {
+    const markup = renderSplitButton("primary", true);
+    const buttons = [...markup.matchAll(/<button([^>]*)>/g)];
+    const mainButton = buttons[0]?.[1] ?? "";
+    const menuButton = buttons[1]?.[1] ?? "";
+
+    expect(mainButton).not.toContain("aria-expanded");
+    expect(menuButton).toContain('aria-label="More actions"');
+    expect(menuButton).toContain('aria-haspopup="menu"');
+    expect(menuButton).toContain('aria-expanded="true"');
+  });
+
+  it("renders the controlled menu only while open", () => {
+    expect(renderSplitButton("primary")).not.toContain('data-testid="menu"');
+    expect(renderSplitButton("primary", true)).toContain('data-testid="menu"');
+  });
+
+  it("disables both segments while loading", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(
+        SplitButton,
+        {
+          loading: true,
+          menu: React.createElement("div"),
+          menuOpen: false,
+          onMenuButtonClick: vi.fn(),
+          menuButtonLabel: "More actions",
+        },
+        "Action"
+      )
+    );
+
+    expect([...markup.matchAll(/<button[^>]* disabled=""/g)]).toHaveLength(2);
+  });
+
+  it("preserves explicit icon-only segment widths", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(SplitButton, {
+        iconOnly: true,
+        icon: React.createElement("span"),
+        mainSegmentWidth: 40,
+        menuSegmentWidth: 20,
+        menu: React.createElement("div"),
+        menuOpen: false,
+        onMenuButtonClick: vi.fn(),
+        menuButtonLabel: "More actions",
+      })
+    );
+
+    expect(markup).toContain("width:60px");
+    expect(markup).toContain("width:20px");
+  });
+});

--- a/src/components/SplitButton/index.tsx
+++ b/src/components/SplitButton/index.tsx
@@ -1,0 +1,275 @@
+import { ChevronDown } from "lucide-react";
+import React, { forwardRef } from "react";
+
+import type { ButtonProps } from "@src/components/Button";
+import { useButtonPresentation } from "@src/components/Button/presentation";
+
+export interface SplitButtonProps extends Omit<
+  ButtonProps,
+  "href" | "target" | "rel" | "aria-expanded" | "aria-haspopup"
+> {
+  /** Menu anchor or portal rendered while the menu is open. */
+  menu: React.ReactNode;
+
+  /** Controlled menu visibility. */
+  menuOpen: boolean;
+
+  /** Activates the menu segment. */
+  onMenuButtonClick: React.MouseEventHandler<HTMLButtonElement>;
+
+  /** Accessible name for the menu segment. */
+  menuButtonLabel: string;
+
+  /** Optional main-segment width for icon-only split buttons. */
+  mainSegmentWidth?: number;
+
+  /**
+   * Optional menu-segment width in pixels. Defaults to half the button height
+   * for icon-only buttons and the full button height otherwise.
+   */
+  menuSegmentWidth?: number;
+
+  /** Centers content within the main segment or the whole split control. */
+  contentAlignment?: "main" | "whole";
+
+  /** Whether a labelled split button fills its parent or hugs its content. */
+  widthMode?: "fill" | "hug";
+}
+
+const SplitButton = forwardRef<HTMLButtonElement, SplitButtonProps>(
+  (
+    {
+      variant = "secondary",
+      appearance,
+      size = "default",
+      shape = "square",
+      loading = false,
+      loadingSpinIcon = false,
+      disabled = false,
+      icon,
+      iconPosition = "left",
+      iconOnly = false,
+      long = false,
+      htmlType = "button",
+      children,
+      className = "",
+      style,
+      onClick,
+      menu,
+      menuOpen,
+      onMenuButtonClick,
+      menuButtonLabel,
+      mainSegmentWidth,
+      menuSegmentWidth,
+      contentAlignment = "main",
+      widthMode = "fill",
+      ...rest
+    },
+    ref
+  ) => {
+    const {
+      sizeConfig,
+      isDisabled,
+      resolvedAppearance,
+      borderRadius,
+      buttonStyles,
+      buttonContent,
+      buttonClassName,
+    } = useButtonPresentation({
+      variant,
+      appearance,
+      size,
+      shape,
+      loading,
+      loadingSpinIcon,
+      disabled,
+      icon,
+      iconPosition,
+      iconOnly,
+      long,
+      children,
+      className,
+      style,
+    });
+
+    const wrapperHoverClass =
+      !isDisabled && variant === "tertiary" && resolvedAppearance === "solid"
+        ? "group-hover/button-split:bg-surface-hover group-hover/button-split:text-text-1"
+        : "";
+
+    const menuColorClass = (() => {
+      if (resolvedAppearance === "solid") {
+        switch (variant) {
+          case "primary":
+          case "danger":
+          case "warning":
+          case "success":
+            return "text-white";
+          case "merged":
+            return "text-merged-contrast";
+          case "secondary":
+            return "text-text-1";
+          case "tertiary":
+            return "text-text-2 group-hover/button-split:text-text-1";
+        }
+      }
+      switch (variant) {
+        case "primary":
+          return "text-primary-6";
+        case "danger":
+          return "text-danger-6";
+        case "warning":
+          return "text-warning-6";
+        case "success":
+          return "text-success-6";
+        case "merged":
+          return "text-purple-6";
+        case "secondary":
+          return "text-text-1";
+        case "tertiary":
+          return "text-text-2 group-hover/button-split:text-text-1";
+      }
+    })();
+
+    const menuStateClass = (() => {
+      if (isDisabled) return "";
+      if (resolvedAppearance === "solid") {
+        switch (variant) {
+          case "primary":
+            return menuOpen
+              ? "bg-primary-5 enabled:hover:bg-primary-5"
+              : "enabled:hover:bg-primary-5";
+          case "danger":
+            return menuOpen
+              ? "bg-danger-5 enabled:hover:bg-danger-5"
+              : "enabled:hover:bg-danger-5";
+          case "warning":
+            return menuOpen
+              ? "bg-warning-5 enabled:hover:bg-warning-5"
+              : "enabled:hover:bg-warning-5";
+          case "success":
+            return menuOpen
+              ? "bg-success-5 enabled:hover:bg-success-5"
+              : "enabled:hover:bg-success-5";
+          case "merged":
+            return menuOpen
+              ? "bg-merged-hover enabled:hover:bg-merged-hover"
+              : "enabled:hover:bg-merged-hover";
+          case "secondary":
+          case "tertiary":
+            break;
+        }
+      }
+      return "enabled:hover:bg-fill-3";
+    })();
+
+    const resolvedMenuWidth =
+      menuSegmentWidth ??
+      (iconOnly ? sizeConfig.height / 2 : sizeConfig.height);
+    const resolvedMainWidth = iconOnly
+      ? (mainSegmentWidth ?? sizeConfig.height)
+      : undefined;
+    const splitButtonWidth = iconOnly
+      ? (resolvedMainWidth ?? sizeConfig.height) + resolvedMenuWidth
+      : undefined;
+    const shouldHug = widthMode === "hug" && !iconOnly && !long;
+
+    return (
+      <div
+        className="button-split-wrapper group/button-split"
+        style={{
+          display: "flex",
+          position: "relative",
+          width: long ? "100%" : "auto",
+          minWidth: 0,
+        }}
+      >
+        <div
+          style={{
+            position: "relative",
+            flex: shouldHug ? "none" : 1,
+            display: "flex",
+            minWidth: 0,
+          }}
+        >
+          <button
+            ref={ref}
+            type={htmlType}
+            disabled={isDisabled}
+            className={`${buttonClassName} ${wrapperHoverClass}`.trim()}
+            style={{
+              ...buttonStyles,
+              width: shouldHug ? "auto" : (splitButtonWidth ?? "100%"),
+              minWidth: 0,
+              flex: iconOnly || shouldHug ? "none" : 1,
+              paddingRight: iconOnly ? 0 : `${resolvedMenuWidth}px`,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              position: "relative",
+            }}
+            onClick={onClick}
+            {...rest}
+          >
+            {shouldHug ? (
+              buttonContent
+            ) : (
+              <div
+                style={{
+                  position: "absolute",
+                  left: 0,
+                  right: contentAlignment === "whole" ? 0 : resolvedMenuWidth,
+                  top: 0,
+                  bottom: 0,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  pointerEvents: "none",
+                }}
+              >
+                {buttonContent}
+              </div>
+            )}
+          </button>
+
+          <button
+            type="button"
+            disabled={isDisabled}
+            aria-label={menuButtonLabel}
+            aria-haspopup="menu"
+            aria-expanded={menuOpen}
+            className={`transition-colors ${menuStateClass} ${menuColorClass}`}
+            style={{
+              position: "absolute",
+              right: 0,
+              top: 0,
+              bottom: 0,
+              width: resolvedMenuWidth,
+              height: "100%",
+              padding: 0,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              border: "none",
+              borderTopRightRadius: borderRadius,
+              borderBottomRightRadius: borderRadius,
+              cursor: isDisabled
+                ? "not-allowed"
+                : "var(--interactive-cursor, default)",
+              opacity: isDisabled ? 0.5 : 1,
+            }}
+            onClick={onMenuButtonClick}
+          >
+            <ChevronDown size={12} aria-hidden />
+          </button>
+        </div>
+
+        {menuOpen && menu}
+      </div>
+    );
+  }
+);
+
+SplitButton.displayName = "SplitButton";
+
+export default SplitButton;

--- a/src/engines/ChatPanel/blocks/MessageReferenceCards.tsx
+++ b/src/engines/ChatPanel/blocks/MessageReferenceCards.tsx
@@ -15,6 +15,7 @@ import Dropdown from "@src/components/Dropdown";
 import { openUrlInBrowserApp } from "@src/components/MarkDown/markdownUtils";
 import Menu from "@src/components/Menu";
 import Message from "@src/components/Message";
+import SplitButton from "@src/components/SplitButton";
 import { resolveAgentIcon } from "@src/config/agentIcons";
 import { replayModeAtom } from "@src/engines/SessionCore";
 import { AppType } from "@src/engines/Simulator/types/appTypes";
@@ -275,11 +276,11 @@ const MessageReferenceCard: React.FC<MessageReferenceCardProps> = ({
           />
         )}
         {isOpenable && (
-          <Button
+          <SplitButton
             variant="primary"
             size="small"
             onClick={handleOpen}
-            dropdownMenu={
+            menu={
               <Dropdown
                 droplist={
                   <Menu>
@@ -303,15 +304,16 @@ const MessageReferenceCard: React.FC<MessageReferenceCardProps> = ({
                 <div />
               </Dropdown>
             }
-            onDropdownClick={(event) => {
+            onMenuButtonClick={(event) => {
               event.stopPropagation();
               setDropdownVisible(!dropdownVisible);
             }}
-            dropdownVisible={dropdownVisible}
-            splitWidthMode="hug"
+            menuOpen={dropdownVisible}
+            menuButtonLabel={openLabel}
+            widthMode="hug"
           >
             {openLabel}
-          </Button>
+          </SplitButton>
         )}
       </div>
     </div>

--- a/src/modules/MainApp/Integrations/Skills/Table/SkillViewButton.tsx
+++ b/src/modules/MainApp/Integrations/Skills/Table/SkillViewButton.tsx
@@ -4,9 +4,9 @@ import { mkdir, writeTextFile } from "@tauri-apps/plugin-fs";
 import React, { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import Button from "@src/components/Button";
 import Dropdown from "@src/components/Dropdown";
 import Menu from "@src/components/Menu";
+import SplitButton from "@src/components/SplitButton";
 import { createLogger } from "@src/hooks/logger";
 import { SKILL_SOURCE } from "@src/types/extensions";
 import { getFileManagerRevealLabelKey } from "@src/util/platform/fileManagerLabels";
@@ -79,13 +79,13 @@ function SkillViewButton<TSkill extends SkillTableRow>({
   }, [isEmbeddedBuiltin, skill.path]);
 
   return (
-    <Button
+    <SplitButton
       variant={variant}
       size={size}
       disabled={!canOpen || opening}
       loading={opening}
       onClick={() => void handleOpen()}
-      dropdownMenu={
+      menu={
         <Dropdown
           droplist={
             <Menu>
@@ -117,17 +117,18 @@ function SkillViewButton<TSkill extends SkillTableRow>({
           <div />
         </Dropdown>
       }
-      onDropdownClick={(event) => {
+      onMenuButtonClick={(event) => {
         event.stopPropagation();
         if (canOpen) {
           setDropdownVisible((visible) => !visible);
         }
       }}
-      dropdownVisible={dropdownVisible}
-      splitWidthMode="hug"
+      menuOpen={dropdownVisible}
+      menuButtonLabel={t("common:actions.view")}
+      widthMode="hug"
     >
       {t("common:actions.view")}
-    </Button>
+    </SplitButton>
   );
 }
 

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemContent/GitHubIssueCloseButton.tsx
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemContent/GitHubIssueCloseButton.tsx
@@ -18,6 +18,7 @@ import {
   DROPDOWN_ITEM,
   DROPDOWN_WIDTHS,
 } from "@src/components/Dropdown/tokens";
+import SplitButton from "@src/components/SplitButton";
 
 import type {
   GitHubIssueInteractionConfig,
@@ -221,7 +222,7 @@ const GitHubIssueCloseButton: React.FC<GitHubIssueCloseButtonProps> = ({
   }
 
   return (
-    <Button
+    <SplitButton
       htmlType="button"
       variant="secondary"
       appearance="outline"
@@ -231,7 +232,7 @@ const GitHubIssueCloseButton: React.FC<GitHubIssueCloseButtonProps> = ({
       loading={busy}
       disabled={disabled}
       onClick={() => selectStatus({ stateReason: "completed" })}
-      dropdownMenu={
+      menu={
         <Dropdown
           droplist={menuLevel === "duplicate" ? duplicatePanel : actionsPanel}
           trigger="click"
@@ -250,18 +251,18 @@ const GitHubIssueCloseButton: React.FC<GitHubIssueCloseButtonProps> = ({
           <div />
         </Dropdown>
       }
-      onDropdownClick={(event) => {
+      onMenuButtonClick={(event) => {
         event.stopPropagation();
         setMenuVisible((visible) => !visible);
       }}
-      dropdownVisible={menuVisible}
-      splitWidthMode="hug"
-      splitDropdownWidth={28}
-      aria-expanded={menuVisible}
+      menuOpen={menuVisible}
+      menuButtonLabel={t("git.issues.composer.closeIssue")}
+      widthMode="hug"
+      menuSegmentWidth={28}
       data-testid="github-issue-comment-status-action"
     >
       {t("git.issues.composer.closeIssue")}
-    </Button>
+    </SplitButton>
   );
 };
 

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrLevelActions.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrLevelActions.tsx
@@ -26,6 +26,7 @@ import {
   DROPDOWN_WIDTHS,
 } from "@src/components/Dropdown/tokens";
 import Message from "@src/components/Message";
+import SplitButton from "@src/components/SplitButton";
 import {
   presentPullRequestActions,
   readRequestedReviewers,
@@ -314,6 +315,14 @@ export const PrLevelActions: React.FC<PrLevelActionsProps> = ({
     (!presentation.directMergeAvailable &&
       !presentation.autoMergeAction &&
       !canChangeDraftState);
+  const primaryActionLabel = localizedActionLabel(
+    t,
+    presentation.autoMergeAction?.kind === "disable" ||
+      (!presentation.directMergeAvailable &&
+        presentation.autoMergeAction?.kind === "enable")
+      ? presentation.autoMergeAction.label
+      : presentation.label
+  );
 
   return (
     <section
@@ -321,7 +330,7 @@ export const PrLevelActions: React.FC<PrLevelActionsProps> = ({
       aria-label={t("git.pr.actions.label", "Pull request actions")}
       data-testid="pr-level-actions"
     >
-      <Button
+      <SplitButton
         htmlType="button"
         variant={
           presentation.hasConflicts
@@ -360,7 +369,7 @@ export const PrLevelActions: React.FC<PrLevelActionsProps> = ({
           .join(" ")}
         title={localizedActionTooltip(t, presentation.tooltip)}
         onClick={runPrimaryMergeAction}
-        dropdownMenu={
+        menu={
           <Dropdown
             droplist={mergePanel}
             trigger="click"
@@ -372,25 +381,18 @@ export const PrLevelActions: React.FC<PrLevelActionsProps> = ({
             <div />
           </Dropdown>
         }
-        onDropdownClick={(event) => {
+        onMenuButtonClick={(event) => {
           event.stopPropagation();
           setMergeMenuVisible((visible) => !visible);
         }}
-        dropdownVisible={mergeMenuVisible}
-        splitWidthMode="hug"
-        splitDropdownWidth={28}
-        aria-expanded={mergeMenuVisible}
+        menuOpen={mergeMenuVisible}
+        menuButtonLabel={primaryActionLabel}
+        widthMode="hug"
+        menuSegmentWidth={28}
         data-testid="pr-merge-action"
       >
-        {localizedActionLabel(
-          t,
-          presentation.autoMergeAction?.kind === "disable" ||
-            (!presentation.directMergeAvailable &&
-              presentation.autoMergeAction?.kind === "enable")
-            ? presentation.autoMergeAction.label
-            : presentation.label
-        )}
-      </Button>
+        {primaryActionLabel}
+      </SplitButton>
 
       {presentation.status === "open" && !disabled ? (
         <Dropdown

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SourceControlContent/components/CommitSection.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/SourceControlContent/components/CommitSection.tsx
@@ -19,6 +19,7 @@ import { useTranslation } from "react-i18next";
 import Button from "@src/components/Button";
 import Dropdown from "@src/components/Dropdown";
 import Menu from "@src/components/Menu";
+import SplitButton from "@src/components/SplitButton";
 import Textarea from "@src/components/Textarea";
 
 import { SHORTCUTS } from "../../../hooks/useSourceControlShortcuts";
@@ -306,7 +307,7 @@ export const CommitSection: React.FC<CommitSectionProps> = memo(
             {sparkleButton}
           </div>
           {hasSyncActions ? (
-            <Button
+            <SplitButton
               variant="primary"
               size="small"
               className="w-full"
@@ -321,7 +322,7 @@ export const CommitSection: React.FC<CommitSectionProps> = memo(
                     : formatCommitCount("Pull", behind)
               }
               data-action="git.sync"
-              dropdownMenu={
+              menu={
                 <Dropdown
                   droplist={
                     <Menu>
@@ -379,14 +380,15 @@ export const CommitSection: React.FC<CommitSectionProps> = memo(
                   <div />
                 </Dropdown>
               }
-              onDropdownClick={(event) => {
+              onMenuButtonClick={(event) => {
                 event.stopPropagation();
                 setSyncDropdownVisible(!syncDropdownVisible);
               }}
-              dropdownVisible={syncDropdownVisible}
+              menuOpen={syncDropdownVisible}
+              menuButtonLabel={GIT_LABELS.syncChanges}
             >
               {getSyncLabel()}
-            </Button>
+            </SplitButton>
           ) : (
             <Button
               variant="primary"
@@ -450,7 +452,7 @@ export const CommitSection: React.FC<CommitSectionProps> = memo(
           </Button>
         ) : hasAdvancedActions ? (
           /* Commit button with dropdown */
-          <Button
+          <SplitButton
             variant="primary"
             size="small"
             className="w-full"
@@ -463,7 +465,7 @@ export const CommitSection: React.FC<CommitSectionProps> = memo(
                 : `Commit changes\n\nShortcut: ${SHORTCUTS.commit}`
             }
             data-action="git.commit"
-            dropdownMenu={
+            menu={
               <Dropdown
                 droplist={
                   <Menu>
@@ -515,15 +517,16 @@ export const CommitSection: React.FC<CommitSectionProps> = memo(
                 <div />
               </Dropdown>
             }
-            onDropdownClick={(event) => {
+            onMenuButtonClick={(event) => {
               event.stopPropagation();
               setDropdownVisible(!dropdownVisible);
             }}
-            dropdownVisible={dropdownVisible}
-            splitContentAlign="button"
+            menuOpen={dropdownVisible}
+            menuButtonLabel={commitButtonText}
+            contentAlignment="whole"
           >
             {commitButtonText}
-          </Button>
+          </SplitButton>
         ) : (
           /* Simple Commit Button */
           <Button

--- a/src/modules/WorkStation/shared/TerminalNewSessionSplitButton.tsx
+++ b/src/modules/WorkStation/shared/TerminalNewSessionSplitButton.tsx
@@ -10,6 +10,7 @@ import {
   DROPDOWN_ITEM,
   DROPDOWN_WIDTHS,
 } from "@src/components/Dropdown/tokens";
+import SplitButton from "@src/components/SplitButton";
 import { useDropdownEngine } from "@src/hooks/dropdown";
 import { useAvailableShells } from "@src/hooks/terminal";
 import type { ShellProfile } from "@src/types/terminal";
@@ -214,7 +215,7 @@ const TerminalNewSessionSplitButtonComponent: React.FC<
   }
 
   return (
-    <Button
+    <SplitButton
       ref={shellPickerTriggerRef}
       htmlType="button"
       variant="tertiary"
@@ -225,15 +226,17 @@ const TerminalNewSessionSplitButtonComponent: React.FC<
         event.stopPropagation();
         onNewTerminal();
       }}
+      aria-label={terminalTitle}
       title={terminalTitle}
       icon={<Plus size={DROPDOWN_ITEM.iconSize} strokeWidth={2} />}
-      dropdownMenu={shellPickerMenu ?? <div />}
-      onDropdownClick={(event) => {
+      menu={shellPickerMenu ?? <div />}
+      onMenuButtonClick={(event) => {
         event.stopPropagation();
         toggleShellPicker();
       }}
-      dropdownVisible={isShellPickerOpen}
-      splitIconOnlyMainWidth={splitMainWidth}
+      menuOpen={isShellPickerOpen}
+      menuButtonLabel={terminalTitle}
+      mainSegmentWidth={splitMainWidth}
     />
   );
 };

--- a/src/modules/shared/dataSource/RuntimeScanningPanelColumns.tsx
+++ b/src/modules/shared/dataSource/RuntimeScanningPanelColumns.tsx
@@ -20,6 +20,7 @@ import {
   SETTINGS_TABLE_COL,
   type SettingsTableColumn,
 } from "@src/components/SettingsTable";
+import SplitButton from "@src/components/SplitButton";
 import Switch from "@src/components/Switch";
 import Tag from "@src/components/Tag";
 import {
@@ -179,24 +180,26 @@ export function buildRuntimeScanningPanelColumns({
                 // Importable sources have a cache, so offer two rescan modes via
                 // a split button: the main click runs Update (incremental
                 // re-sync); the caret opens Update / Clear + rescan (full rebuild).
-                <Button
+                <SplitButton
                   variant="secondary"
                   size="small"
                   iconOnly
-                  splitDropdownWidth={22}
+                  menuSegmentWidth={22}
                   loading={row.rescanning}
                   loadingSpinIcon
                   icon={<RefreshCw size={14} />}
+                  aria-label={t("rescan")}
                   title={t("rescan")}
                   onClick={() => void handleRescan(row, false)}
-                  dropdownVisible={openRescanMenu === row.probe.sourceId}
-                  onDropdownClick={(event) => {
+                  menuOpen={openRescanMenu === row.probe.sourceId}
+                  menuButtonLabel={t("rescan")}
+                  onMenuButtonClick={(event) => {
                     event.stopPropagation();
                     setOpenRescanMenu((current) =>
                       current === row.probe.sourceId ? null : row.probe.sourceId
                     );
                   }}
-                  dropdownMenu={
+                  menu={
                     <Dropdown
                       trigger="click"
                       position="bottom-end"

--- a/src/scaffold/WizardSystem/shared/externalImport/useExternalImport.tsx
+++ b/src/scaffold/WizardSystem/shared/externalImport/useExternalImport.tsx
@@ -27,7 +27,6 @@ import type {
   SourceAgent,
 } from "@src/api/types/externalImport";
 import { CLI_AGENT, type ModelType } from "@src/api/types/keys";
-import Button from "@src/components/Button";
 import Checkbox from "@src/components/Checkbox";
 import Dropdown from "@src/components/Dropdown";
 import Menu from "@src/components/Menu";
@@ -37,6 +36,7 @@ import {
   SETTINGS_TABLE_COL,
   type SettingsTableColumn,
 } from "@src/components/SettingsTable";
+import SplitButton from "@src/components/SplitButton";
 import { createLogger } from "@src/hooks/logger";
 import type { CursorRepo } from "@src/hooks/policies";
 import { getFileManagerRevealLabelKey } from "@src/util/platform/fileManagerLabels";
@@ -493,11 +493,11 @@ export function useExternalImport({
           const actionKey = rowKey(row);
           const dropdownVisible = actionsDropdownRowKey === actionKey;
           return (
-            <Button
+            <SplitButton
               variant="secondary"
               size="small"
               onClick={() => handleOpen(row)}
-              dropdownMenu={
+              menu={
                 <Dropdown
                   droplist={
                     <Menu>
@@ -529,15 +529,16 @@ export function useExternalImport({
                   <div />
                 </Dropdown>
               }
-              onDropdownClick={(event) => {
+              onMenuButtonClick={(event) => {
                 event.stopPropagation();
                 setActionsDropdownRowKey(dropdownVisible ? null : actionKey);
               }}
-              dropdownVisible={dropdownVisible}
-              splitWidthMode="hug"
+              menuOpen={dropdownVisible}
+              menuButtonLabel={t("common:actions.view")}
+              widthMode="hug"
             >
               {t("common:actions.view")}
-            </Button>
+            </SplitButton>
           );
         },
       },


### PR DESCRIPTION
## Problem

The base `Button` API owns two unrelated control models: a single action and a compound split action. Seven optional split-only props (`dropdownMenu`, `onDropdownClick`, `dropdownVisible`, `splitIconOnlyMainWidth`, `splitDropdownWidth`, `splitContentAlign`, and `splitWidthMode`) make partial invalid configurations possible, hide a second native button inside the base component, and leave the dropdown trigger without its own accessible name or menu semantics. Nine live split render paths depend on that overloaded branch.

## Solution

- Add a focused canonical `SplitButton` that owns the two-segment layout, controlled menu visibility, segment sizing/alignment, open-state styling, disabled/loading propagation, and menu-trigger accessibility.
- Extract the visual/content presentation shared by `Button` and `SplitButton` into an internal presentation module so ordinary button styling remains one source of truth.
- Remove all split-only props and the split render branch from `Button`, then migrate all nine live callers atomically.
- Put `aria-haspopup`, `aria-expanded`, and a required accessible label on the actual menu trigger. Add explicit accessible names to the two migrated icon-only main actions.
- Move the existing split-specific tests to the owning component and add focused coverage for controlled menu rendering, semantics, disabled/loading propagation, widths, and variant state styling.

## Potential risks

The primary risk is a visual or interaction regression in one of the nine migrated controls because the compound DOM moved to a new owner. The extraction preserves the existing wrapper class, native-button order, inline dimensions, color/hover classes, caller test IDs, main-action refs, and controlled dropdown callbacks; focused caller suites, typecheck, and production build cover those paths. Menu visibility remains intentionally controlled by each caller so existing `Dropdown` synchronization is unchanged. There are no persistence, wire, dependency, or configuration changes. Rollback is a single-commit revert.

## Architecture audit

Applied `.orgii/skills/architecture-audit/SKILL.md` to component/API ownership, live call chains, semantic overload, naming, default branches, dead split-prop surface, and new-developer clarity. Backend wire, persistence, initialization, resolver, and runtime-lifecycle layers were skipped as inapplicable to this synchronous UI-only extraction.

The workspace has no `frontend-ui-audit` skill, so its intent was checked manually:

- Abstract: one global compound-button visual pattern into `SplitButton`.
- Fix: nine unnamed menu triggers now own menu semantics; two icon-only main actions now have explicit accessible names.
- Keep with reason: the terminal sidebar's local 20px native split control remains density-specific; routing it through the canonical 24px+ button size system would require a new visual mode and change that surface.
- No new arbitrary Tailwind values or design tokens were introduced.

## Verification

- `pnpm vitest run src/components/Button/index.test.ts src/components/SplitButton/index.test.ts src/modules/shared/dataSource/RuntimeScanningPanel.test.ts src/modules/ProjectManager/WorkItems/components/WorkItemContent/__tests__/GitHubIssueComposer.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.test.ts` — 5 files, 29 tests passed on the final rebased commit.
- `pnpm exec eslint` over all 13 changed TypeScript/TSX files — passed.
- `pnpm typecheck` — passed on the final rebased commit.
- `pnpm check:circular` — passed; no circular dependencies across 6,585 modules.
- `pnpm build` — passed; webpack production build compiled in 77,042 ms on the final rebased commit.
- Legacy split-prop sweep with `rg` — zero occurrences; `SplitButton` caller count and controlled `menuOpen` count are both nine.
- `pnpm check:unused-exports` — repository-wide check remains non-green on the pre-existing baseline of 1,204 modules with unused exports; a filtered rerun reported no `Button` or `SplitButton` findings.
- `git diff --check origin/develop...HEAD` and added-line secret/debug-path scan — clean.

## Visual evidence

Screenshots are omitted because this is a preservation-only component ownership refactor: the rendered wrapper class, two-button DOM order, sizing, spacing, state classes, and caller content are intentionally unchanged. Static markup tests plus owning interaction tests provide more precise evidence for the extracted boundary; the only user-observable delta is improved accessibility metadata.
