### PR TITLE
refactor(tooltip): normalize open state props

### DIFF
--- a/src/components/SelectorPill/index.tsx
+++ b/src/components/SelectorPill/index.tsx
@@ -296,8 +296,8 @@ export const SelectorPill = forwardRef<HTMLButtonElement, SelectorPillProps>(
     // We track hover/focus intent only; the effective visibility is gated on
     // `active` so no effect is needed to re-hide when the pill activates.
     const [hoverIntent, setHoverIntent] = useState(false);
-    const tooltipVisible = hoverIntent && !active;
-    const handleTooltipVisibleChange = useCallback((next: boolean) => {
+    const tooltipOpen = hoverIntent && !active;
+    const handleTooltipOpenChange = useCallback((next: boolean) => {
       setHoverIntent(next);
     }, []);
 
@@ -348,8 +348,8 @@ export const SelectorPill = forwardRef<HTMLButtonElement, SelectorPillProps>(
           content={tooltip}
           position={tooltipPosition}
           mouseEnterDelay={tooltipMouseEnterDelay}
-          popupVisible={tooltipVisible}
-          onVisibleChange={handleTooltipVisibleChange}
+          open={tooltipOpen}
+          onOpenChange={handleTooltipOpenChange}
           framedPanel={tooltipFramed}
           framedPanelWide={tooltipFramedWide}
         >

--- a/src/components/Tooltip/index.test.ts
+++ b/src/components/Tooltip/index.test.ts
@@ -49,3 +49,62 @@ describe("Tooltip child refs", () => {
     expect(container.querySelector("button")).toBe(button);
   });
 });
+
+describe("Tooltip open state", () => {
+  it("supports the defaultOpen uncontrolled contract", () => {
+    act(() => {
+      root.render(
+        createElement(
+          Tooltip,
+          { content: "Details", defaultOpen: true } as ComponentProps<
+            typeof Tooltip
+          >,
+          createElement("button", null, "Trigger")
+        )
+      );
+    });
+
+    expect(
+      document.body.querySelector(".native-tooltip-content-inner")?.textContent
+    ).toBe("Details");
+  });
+
+  it("reports click-triggered changes without mutating controlled state", async () => {
+    const onOpenChange = vi.fn();
+    const render = (open: boolean) =>
+      createElement(
+        Tooltip,
+        {
+          content: "Details",
+          trigger: "click",
+          open,
+          onOpenChange,
+          mouseEnterDelay: 0,
+          mouseLeaveDelay: 0,
+        } as unknown as ComponentProps<typeof Tooltip>,
+        createElement("button", null, "Trigger")
+      );
+
+    act(() => root.render(render(false)));
+    const button = container.querySelector("button");
+
+    await act(async () => {
+      button?.click();
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+    });
+
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    expect(document.body.querySelector(".native-tooltip")).toBeNull();
+
+    act(() => root.render(render(true)));
+    expect(document.body.querySelector(".native-tooltip")).not.toBeNull();
+
+    await act(async () => {
+      button?.click();
+      await new Promise((resolve) => window.setTimeout(resolve, 0));
+    });
+
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+    expect(document.body.querySelector(".native-tooltip")).not.toBeNull();
+  });
+});

--- a/src/components/Tooltip/index.tsx
+++ b/src/components/Tooltip/index.tsx
@@ -111,19 +111,19 @@ export interface TooltipProps {
   disabled?: boolean;
 
   /**
-   * Controlled visible state
+   * Controlled open state
    */
-  popupVisible?: boolean;
+  open?: boolean;
 
   /**
-   * Default visible state
+   * Default open state
    */
-  defaultPopupVisible?: boolean;
+  defaultOpen?: boolean;
 
   /**
-   * Visible change handler
+   * Open state change handler
    */
-  onVisibleChange?: (visible: boolean) => void;
+  onOpenChange?: (open: boolean) => void;
 
   /**
    * Additional class name
@@ -197,9 +197,9 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       mouseEnterDelay = 100,
       mouseLeaveDelay = 100,
       disabled = false,
-      popupVisible,
-      defaultPopupVisible = false,
-      onVisibleChange,
+      open,
+      defaultOpen = false,
+      onOpenChange,
       className = "",
       style,
       color = "dark",
@@ -214,7 +214,7 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
     },
     _ref
   ) => {
-    const [internalVisible, setInternalVisible] = useState(defaultPopupVisible);
+    const [internalOpen, setInternalOpen] = useState(defaultOpen);
     const [tooltipPosition, setTooltipPosition] = useState({ top: 0, left: 0 });
     const [arrowOffset, setArrowOffset] = useState({ left: 0, top: 0 });
     const [positionReady, setPositionReady] = useState(false);
@@ -245,8 +245,8 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       [childRef]
     );
 
-    const isControlled = popupVisible !== undefined;
-    const currentVisible = isControlled ? popupVisible : internalVisible;
+    const isControlled = open !== undefined;
+    const effectiveOpen = isControlled ? open : internalOpen;
     const usesFramedSurface = framedPanel || (!panelStyle && !backgroundColor);
 
     const updatePosition = useCallback(() => {
@@ -324,7 +324,7 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
     ]);
 
     useEffect(() => {
-      if (currentVisible) {
+      if (effectiveOpen) {
         // Reset position ready state and calculate position
         setPositionReady(false);
         // Use RAF to ensure tooltip is rendered before calculating position
@@ -342,7 +342,7 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       } else {
         setPositionReady(false);
       }
-    }, [currentVisible, updatePosition]);
+    }, [effectiveOpen, updatePosition]);
 
     const show = useCallback(() => {
       if (disabled) return;
@@ -350,11 +350,11 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       clearTimeout(leaveTimerRef.current);
       enterTimerRef.current = setTimeout(() => {
         if (!isControlled) {
-          setInternalVisible(true);
+          setInternalOpen(true);
         }
-        onVisibleChange?.(true);
+        onOpenChange?.(true);
       }, mouseEnterDelay);
-    }, [disabled, isControlled, onVisibleChange, mouseEnterDelay]);
+    }, [disabled, isControlled, onOpenChange, mouseEnterDelay]);
 
     // Force-hide when disabled flips true (e.g. the trigger entered an
     // "active"/open state and the tooltip would otherwise occlude a dropdown).
@@ -363,20 +363,20 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       clearTimeout(enterTimerRef.current);
       clearTimeout(leaveTimerRef.current);
       if (!isControlled) {
-        setInternalVisible(false);
+        setInternalOpen(false);
       }
-      onVisibleChange?.(false);
-    }, [disabled, isControlled, onVisibleChange]);
+      onOpenChange?.(false);
+    }, [disabled, isControlled, onOpenChange]);
 
     const hide = useCallback(() => {
       clearTimeout(enterTimerRef.current);
       leaveTimerRef.current = setTimeout(() => {
         if (!isControlled) {
-          setInternalVisible(false);
+          setInternalOpen(false);
         }
-        onVisibleChange?.(false);
+        onOpenChange?.(false);
       }, mouseLeaveDelay);
-    }, [isControlled, onVisibleChange, mouseLeaveDelay]);
+    }, [isControlled, onOpenChange, mouseLeaveDelay]);
 
     const handleMouseEnter = useCallback(() => {
       if (trigger === "hover") {
@@ -392,7 +392,7 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
 
     const handleClick = useCallback(() => {
       if (trigger === "click") {
-        if (currentVisible) {
+        if (effectiveOpen) {
           hide();
         } else {
           show();
@@ -405,15 +405,15 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       // (selected app, follow target, etc.) usually flipped, so the
       // label may no longer match what's under the cursor. Dismiss
       // immediately; the next mouse-leave/enter cycle re-evaluates.
-      if (trigger === "hover" && currentVisible) {
+      if (trigger === "hover" && effectiveOpen) {
         clearTimeout(enterTimerRef.current);
         clearTimeout(leaveTimerRef.current);
         if (!isControlled) {
-          setInternalVisible(false);
+          setInternalOpen(false);
         }
-        onVisibleChange?.(false);
+        onOpenChange?.(false);
       }
-    }, [trigger, currentVisible, show, hide, isControlled, onVisibleChange]);
+    }, [trigger, effectiveOpen, show, hide, isControlled, onOpenChange]);
 
     const handleFocus = useCallback(() => {
       if (trigger === "focus") {
@@ -496,7 +496,7 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       "native-tooltip",
       `native-tooltip-${position}`,
       `native-tooltip-${color}`,
-      currentVisible && positionReady && "native-tooltip-visible",
+      effectiveOpen && positionReady && "native-tooltip-visible",
       trigger === "click" && "native-tooltip-interactive",
       panelStyle && "native-tooltip-panel",
       usesFramedSurface && "native-tooltip-framed-panel",
@@ -512,7 +512,7 @@ const Tooltip = forwardRef<HTMLDivElement, TooltipProps>(
       ...(backgroundColor ? { backgroundColor } : {}),
     };
 
-    const tooltipContent = currentVisible ? (
+    const tooltipContent = effectiveOpen ? (
       <div
         ref={tooltipRef}
         className={tooltipClasses}


### PR DESCRIPTION
## Problem

`Tooltip` exposes controlled disclosure state through the Ant-style names `popupVisible`, `defaultPopupVisible`, and `onVisibleChange`. Other reusable disclosure controls are converging on `open`, `defaultOpen`, and `onOpenChange`, so the Tooltip contract forces callers to remember a component-specific vocabulary for the same state model.

Only `SelectorPill` controls Tooltip state directly, which makes this the narrow point to establish the canonical contract without a compatibility layer.

## Solution

Rename the Tooltip state props to `open`, `defaultOpen`, and `onOpenChange`, and migrate the controlled SelectorPill caller atomically.

Rename the internal effective-state variables to match the open-state domain while preserving controlled/uncontrolled behavior, trigger delays, click dismissal, disabled-state dismissal, positioning, portal rendering, and CSS classes.

Add focused tests for the uncontrolled `defaultOpen` path and for controlled click-trigger notifications that do not mutate controlled state.

## Potential risks

This is an intentional TypeScript API break for any untracked consumer still using the previous prop names. Repository-wide source search and full typecheck show no remaining tracked consumers, and no compatibility aliases are retained.

The runtime disclosure logic is unchanged, but renaming effective-state variables touches several timer and event-handler dependency arrays. Focused controlled/uncontrolled tests cover those paths. Reverting this PR restores the prior API without persistence, data, or wire-format migration.

## Verification

- `pnpm vitest run src/components/Tooltip/index.test.ts src/components/Tooltip/tooltipPlacement.test.ts` — 21/21 passed on the final base
- Changed-file ESLint and Prettier checks — passed
- `pnpm typecheck` — passed on the final `develop` base
- `pnpm build` — passed on the final base; webpack compiled in 43,664 ms
- `pnpm check:circular` — passed across 6,635 modules
- Repository search in Tooltip and SelectorPill — zero old state-prop names
- Final rebase, whitespace, scope, and diff checks — passed

No screenshot was captured because this is an identifier-only API migration: rendered markup, classes, timing, positions, themes, and visible states are unchanged. Manual Tauri UI verification was not run.

## Audit

The architecture audit covered API ownership, controlled/uncontrolled default branches, terminology overload, every tracked consumer, and new-developer clarity. Persistence, wire contracts, resolver graphs, and initialization parity were intentionally skipped because Tooltip state is local React UI state.

The configured `frontend-ui-audit` skill is absent, so its intent was applied manually. No design-system substitution, arbitrary styling, markup, or accessibility behavior changed.
