### PR TITLE
perf(chat): defer diagnostics and event export work

### DIFF
--- a/src/engines/ChatPanel/ChatHistory/hooks/useChatHistoryProjectionModel.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/useChatHistoryProjectionModel.ts
@@ -7,8 +7,7 @@ import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 import { addressRunActiveAtom } from "@src/features/Org2Cloud/addressCommentsRun";
 import {
   estimateRuntimeValueBytes,
-  removeChatRenderedTreeMemoryEntry,
-  updateChatRenderedTreeMemoryEntry,
+  registerChatRenderedTreeMemoryEntry,
 } from "@src/hooks/perf/runtimeMemoryStats";
 import {
   collapseAllCommandAtom,
@@ -72,6 +71,13 @@ export function useChatHistoryProjectionModel({
   turnPaginationEnabled,
 }: UseChatHistoryProjectionModelOptions) {
   const memoryStatsKeyRef = useRef(Symbol("chat-rendered-tree-memory"));
+  const memoryStatsSourceRef = useRef<{
+    activeId: string | null;
+    activeProjectionHistory: unknown[];
+    flatItems: unknown[];
+    groupCount: number;
+    totalFlatItems: number;
+  } | null>(null);
   const turnCollapseOverrides = useAtomValue(turnCollapseOverrideAtom);
   const collapseAllCommand = useAtomValue(collapseAllCommandAtom);
   const selectedThreadId = useAtomValue(selectedExecutionThreadAtom);
@@ -153,25 +159,31 @@ export function useChatHistoryProjectionModel({
     lastAssistantFlatIndexPerItem: [],
   };
 
-  useEffect(() => {
-    const key = memoryStatsKeyRef.current;
-    updateChatRenderedTreeMemoryEntry(key, {
-      bytes:
-        estimateRuntimeValueBytes(activeProjectionHistory) +
-        estimateRuntimeValueBytes(flatItems) +
-        groupCounts.length * 8,
-      items: totalFlatItems,
-      label: activeId ?? "unknown",
-    });
-
-    return () => removeChatRenderedTreeMemoryEntry(key);
-  }, [
+  memoryStatsSourceRef.current = {
     activeId,
     activeProjectionHistory,
     flatItems,
-    groupCounts,
+    groupCount: groupCounts.length,
     totalFlatItems,
-  ]);
+  };
+
+  useEffect(() => {
+    const key = memoryStatsKeyRef.current;
+    return registerChatRenderedTreeMemoryEntry(key, () => {
+      const source = memoryStatsSourceRef.current;
+      if (!source) {
+        return { bytes: 0, items: 0, label: "unknown" };
+      }
+      return {
+        bytes:
+          estimateRuntimeValueBytes(source.activeProjectionHistory) +
+          estimateRuntimeValueBytes(source.flatItems) +
+          source.groupCount * 8,
+        items: source.totalFlatItems,
+        label: source.activeId ?? "unknown",
+      };
+    });
+  }, []);
 
   const {
     selectedTurnPageIndex,

--- a/src/engines/ChatPanel/hooks/useSessionHeaderActions.test.ts
+++ b/src/engines/ChatPanel/hooks/useSessionHeaderActions.test.ts
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement, useEffect } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { derivedSnapshotAtom } from "@src/engines/SessionCore/core/atoms/events";
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+
+import { useSessionHeaderActions } from "./useSessionHeaderActions";
+
+const dropdownMocks = vi.hoisted(() => ({
+  close: vi.fn(),
+  toggle: vi.fn(),
+}));
+
+vi.mock("@src/hooks/dropdown", () => ({
+  useDropdownEngine: () => ({
+    isOpen: false,
+    isPositioned: false,
+    toggle: dropdownMocks.toggle,
+    close: dropdownMocks.close,
+    triggerRef: { current: null },
+    panelRef: { current: null },
+    panelPosition: { left: 0, top: 0, width: 0, maxHeight: 0 },
+  }),
+}));
+
+vi.mock("@src/engines/SessionCore/core/store/EventStoreProxy", () => ({
+  eventStoreProxy: {
+    set: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+type HeaderActions = ReturnType<typeof useSessionHeaderActions>;
+
+let actions: HeaderActions | null = null;
+const onReady = vi.fn((value: HeaderActions) => {
+  actions = value;
+});
+
+function Harness({ onActions }: { onActions: (value: HeaderActions) => void }) {
+  const value = useSessionHeaderActions({ handleReloadSession: vi.fn() });
+  useEffect(() => onActions(value), [onActions, value]);
+  return null;
+}
+
+function event(id: string, displayText: string): SessionEvent {
+  return {
+    chunk_id: id,
+    id,
+    sessionId: "session-1",
+    createdAt: "2026-08-24T00:00:00.000Z",
+    functionName: "assistant_message",
+    uiCanonical: "assistant_message",
+    actionType: "assistant",
+    args: {},
+    result: { text: displayText },
+    source: "assistant",
+    displayText,
+    displayStatus: "completed",
+    displayVariant: "message",
+    activityStatus: "agent",
+  };
+}
+
+function snapshot(events: SessionEvent[]) {
+  return {
+    version: 1,
+    eventCount: events.length,
+    events,
+    chatEvents: events,
+    messagesEvents: [],
+    sortedSimulatorEvents: events,
+    lastEvent: events[events.length - 1] ?? null,
+    eventIndex: {},
+    chatEventCount: events.length,
+    hasRunningEvent: false,
+  };
+}
+
+describe("useSessionHeaderActions", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let store: ReturnType<typeof createStore>;
+  const writeText = vi.fn<() => Promise<void>>();
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    actions = null;
+    store = createStore();
+    store.set(
+      derivedSnapshotAtom,
+      snapshot([event("event-1", "Initial text")]) as never
+    );
+    writeText.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root.render(
+        createElement(
+          Provider,
+          { store },
+          createElement(Harness, { onActions: onReady })
+        )
+      );
+    });
+  });
+
+  afterEach(() => {
+    if (root) act(() => root.unmount());
+    container?.remove();
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("reads the latest events on demand without subscribing to event updates", async () => {
+    const latestEvents = [event("event-2", "Latest streamed text")];
+    const rendersBeforeEventUpdate = onReady.mock.calls.length;
+
+    act(() => store.set(derivedSnapshotAtom, snapshot(latestEvents) as never));
+
+    expect(onReady).toHaveBeenCalledTimes(rendersBeforeEventUpdate);
+
+    await act(async () => {
+      actions?.handleCopyEventJson();
+      await Promise.resolve();
+    });
+
+    expect(writeText).toHaveBeenCalledOnce();
+    expect(writeText).toHaveBeenCalledWith(
+      JSON.stringify(latestEvents, null, 2)
+    );
+    expect(dropdownMocks.close).toHaveBeenCalledOnce();
+    expect(actions?.copyEventJsonLabel).toBe("copied");
+
+    act(() => vi.advanceTimersByTime(2_000));
+    expect(actions?.copyEventJsonLabel).toBe("idle");
+  });
+});

--- a/src/engines/ChatPanel/hooks/useSessionHeaderActions.ts
+++ b/src/engines/ChatPanel/hooks/useSessionHeaderActions.ts
@@ -1,4 +1,4 @@
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useStore } from "jotai";
 import { useCallback, useRef, useState } from "react";
 
 import {
@@ -47,7 +47,7 @@ export function useSessionHeaderActions({
     chatTurnMetadataVisibleAtom
   );
   const eventCount = useAtomValue(eventCountAtom);
-  const events = useAtomValue(eventsAtom);
+  const store = useStore();
   const [copyEventJsonLabel, setCopyEventJsonLabel] = useState<
     "idle" | "copied" | "failed"
   >("idle");
@@ -87,7 +87,7 @@ export function useSessionHeaderActions({
   );
 
   const handleCopyEventJson = useCallback(() => {
-    const json = JSON.stringify(events, null, 2);
+    const json = JSON.stringify(store.get(eventsAtom), null, 2);
     navigator.clipboard
       .writeText(json)
       .then(() => {
@@ -99,7 +99,7 @@ export function useSessionHeaderActions({
         setTimeout(() => setCopyEventJsonLabel("idle"), 2000);
       });
     closeHeaderActionsMenu();
-  }, [closeHeaderActionsMenu, events]);
+  }, [closeHeaderActionsMenu, store]);
 
   return {
     closeHeaderActionsMenu,

--- a/src/hooks/perf/runtimeMemoryStats.test.ts
+++ b/src/hooks/perf/runtimeMemoryStats.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  getChatRenderedTreeMemoryStats,
+  registerChatRenderedTreeMemoryEntry,
+} from "./runtimeMemoryStats";
+
+describe("chat rendered-tree memory diagnostics", () => {
+  let unregister: (() => void) | null = null;
+
+  afterEach(() => {
+    unregister?.();
+    unregister = null;
+  });
+
+  it("reads and normalizes the latest entry only when statistics are requested", () => {
+    let reads = 0;
+    let current = { bytes: 10.4, items: 2.6, label: "session-1" };
+    unregister = registerChatRenderedTreeMemoryEntry(Symbol("test"), () => {
+      reads += 1;
+      return current;
+    });
+
+    expect(reads).toBe(0);
+    expect(getChatRenderedTreeMemoryStats()).toEqual({
+      bytes: 10,
+      entries: 1,
+      items: 3,
+      topEntries: [{ bytes: 10, items: 3, label: "session-1" }],
+    });
+    expect(reads).toBe(1);
+
+    current = { bytes: 25.8, items: 4.2, label: "session-2" };
+    expect(getChatRenderedTreeMemoryStats()).toEqual({
+      bytes: 26,
+      entries: 1,
+      items: 4,
+      topEntries: [{ bytes: 26, items: 4, label: "session-2" }],
+    });
+    expect(reads).toBe(2);
+
+    unregister();
+    unregister = null;
+    expect(getChatRenderedTreeMemoryStats()).toEqual({
+      bytes: 0,
+      entries: 0,
+      items: 0,
+      topEntries: [],
+    });
+  });
+});

--- a/src/hooks/perf/runtimeMemoryStats.ts
+++ b/src/hooks/perf/runtimeMemoryStats.ts
@@ -4,6 +4,8 @@ interface RuntimeMemoryEntry {
   label?: string;
 }
 
+type RuntimeMemoryEntryReader = () => RuntimeMemoryEntry;
+
 export interface RuntimeMemoryTopEntry {
   label: string;
   bytes: number;
@@ -59,7 +61,10 @@ interface SidebarMemoryEntry extends RuntimeMemoryEntry {
 
 const fileTreeMemoryEntries = new Map<symbol, RuntimeMemoryEntry>();
 const codeMirrorMemoryEntries = new Map<symbol, RuntimeMemoryEntry>();
-const chatRenderedTreeMemoryEntries = new Map<symbol, RuntimeMemoryEntry>();
+const chatRenderedTreeMemoryEntryReaders = new Map<
+  symbol,
+  RuntimeMemoryEntryReader
+>();
 const sidebarMemoryEntries = new Map<symbol, SidebarMemoryEntry>();
 
 const DEFAULT_ESTIMATION_NODE_LIMIT = 5_000;
@@ -332,19 +337,27 @@ export function getCodeMirrorMemoryStats(): RuntimeMemoryStats {
   return summarizeMemoryEntries(codeMirrorMemoryEntries);
 }
 
-export function updateChatRenderedTreeMemoryEntry(
+export function registerChatRenderedTreeMemoryEntry(
   key: symbol,
-  entry: RuntimeMemoryEntry
-): void {
-  chatRenderedTreeMemoryEntries.set(key, normalizeMemoryEntry(entry));
-}
-
-export function removeChatRenderedTreeMemoryEntry(key: symbol): void {
-  chatRenderedTreeMemoryEntries.delete(key);
+  readEntry: RuntimeMemoryEntryReader
+): () => void {
+  chatRenderedTreeMemoryEntryReaders.set(key, readEntry);
+  return () => {
+    if (chatRenderedTreeMemoryEntryReaders.get(key) === readEntry) {
+      chatRenderedTreeMemoryEntryReaders.delete(key);
+    }
+  };
 }
 
 export function getChatRenderedTreeMemoryStats(): RuntimeMemoryStats {
-  return summarizeMemoryEntries(chatRenderedTreeMemoryEntries);
+  const entries = Array.from(
+    chatRenderedTreeMemoryEntryReaders.values(),
+    (readEntry) => normalizeMemoryEntry(readEntry())
+  );
+  return summarizeRuntimeMemoryEntries(
+    entries,
+    chatRenderedTreeMemoryEntryReaders.size
+  );
 }
 
 export function updateSidebarMemoryEntry(


### PR DESCRIPTION
## Problem

The shared Chat Panel and My Station session header subscribed to the complete `eventsAtom` only so Copy Event JSON could serialize it later. Streaming snapshot replacements therefore woke the header-actions hook and its consumers even when the user had not requested an export.

Chat history memory accounting also recursively estimated the projected history and flattened render tree after every projection change. That diagnostic traversal ran during ordinary streaming even while the RAM monitor was closed.

## Solution

Read `eventsAtom` imperatively from the current Jotai provider store inside the Copy Event JSON click handler. This keeps the export scoped to the same store and guarantees it serializes the latest event array without a render subscription.

Register a lightweight chat-memory reader for each mounted projection and perform normalization and deep estimation only when the RAM monitor requests chat rendered-tree statistics. The reader points at the latest projection references and unregisters on unmount.

The clipboard JSON format, menu close behavior, copied/failed labels, two-second label reset, diagnostic labels, byte calculation, and item counts are unchanged.

## Potential risks

The imperative clipboard read must stay attached to the correct Jotai provider. The hook uses `useStore` from its existing provider, and the regression test replaces a same-sized session snapshot to prove there is no rerender while the subsequent copy still exports the replacement event.

The lazy diagnostic registry could retain a stale reader if component cleanup failed. Registration returns an identity-checked disposer, and the registry test verifies both latest-value reads and removal. No persistence, IPC, wire format, dependencies, or public UI contracts changed. The change can be rolled back by reverting commit `e511615c9`.

Live Tauri/WebView CPU and RAM profiling was not run, so this PR does not claim a measured frame-time or memory reduction. Screenshots are not useful because the rendered UI is unchanged.

## Verification

- `pnpm exec vitest run src/engines/ChatPanel/hooks/useSessionHeaderActions.test.ts src/hooks/perf/runtimeMemoryStats.test.ts` — passed, 2 files and 2 tests
- `pnpm run test` — passed, 1,205 files and 9,724 tests
- `pnpm run typecheck` — passed
- `pnpm run lint` — passed with zero warnings
- `pnpm run check:circular` — passed across 6,639 modules
- `git diff --check` — passed
- Pre-commit lint-staged and scoped TypeScript checks — passed

## Performance audit

| Area | Verdict | Evidence | Change or reason kept | Verification |
| --- | --- | --- | --- | --- |
| Rendering/hot path | fix | Session header subscribed to the full event array for a click-only action | Read the latest array from the current store on click | Same-sized snapshot replacement causes no hook commit; copied JSON contains replacement event |
| Memory diagnostics | fix | Projection effect recursively estimated two potentially large trees on every update | Register a reader and estimate only when statistics are requested | Reader remains idle before the getter, reports latest values, and unregisters |
| Scope/isolation | keep | Both surfaces already run under their owning Jotai provider | `useStore` preserves that provider boundary | Provider-backed hook regression test |
| Background work | keep | Existing two-second copy-label timers are user-action-triggered and bounded | Timing and success/failure behavior are unchanged | Copied label resets to idle after two seconds |