### PR TITLE
refactor(turn-executor): modularize turn loop

### DIFF
--- a/src-tauri/crates/agent-core/src/core/turn_executor/execute.rs
+++ b/src-tauri/crates/agent-core/src/core/turn_executor/execute.rs
@@ -1,59 +1,35 @@
-//! The core agentic turn loop: `execute_turn` plus its two private helpers.
+//! State-machine coordinator for one agentic turn.
 //!
-//! Extracted from `turn_executor::mod` so the module root stays focused on
-//! mod declarations and the public re-export surface. This file is the
-//! generic LLM loop body itself (messages → (LLM + tools)* → final
-//! response), `strip_historical_media_blocks` (media-413 recovery), and
-//! `drain_steering_queue` (mid-turn steering injection) — both are only
-//! called from `execute_turn` and move with it.
+//! Each phase remains ordered exactly as the original loop: iteration input,
+//! provider request/recovery, usage and stream recovery, tool execution or
+//! completion, then the terminal result projection.
+
+mod completion;
+mod iteration_input;
+mod loop_state;
+mod provider_iteration;
+mod recovery;
+mod tool_iteration;
 
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use serde_json::Value;
-use tracing::{info, warn};
 
-use crate::providers::traits::{finish_reason as finish, LLMProvider, StreamDelta};
+use crate::providers::traits::LLMProvider;
 use crate::specialization::policies::activation::SessionScopedContextActivator;
 use crate::tools::policy::ResolvedToolPolicy;
 use crate::tools::registry::ToolRegistry;
 
-use super::stream_normalizer::{NormalizedStreamEvent, TurnStreamNormalizer};
-
-use crate::model_context::microcompact;
-
-use super::backoff::MAX_CONTEXT_RESCUE_ATTEMPTS;
-use super::context_accounting::ContextUsageSnapshot;
-use super::continuation::{
-    should_auto_continue, should_inject_todo_reminder, ANTI_RUSH_MIN_PERCENT, ANTI_RUSH_MIN_WINDOW,
-    MAX_AUTO_CONTINUATIONS,
-};
-use super::file_tracker;
-use super::helpers::{add_assistant_message, add_tool_result};
-use super::length_recovery::{maybe_recover_from_length, LengthRecoveryOutcome};
-#[cfg(debug_assertions)]
-use super::provider_request_capture;
-use super::repeat_guard::{RepeatGuard, RepeatVerdict};
-use super::screenshot::resolve_screenshot_markers;
-use super::stream_error_recovery::{handle_stream_error, RetryBudgets, StreamErrorOutcome};
-use super::tool_execution::{execute_tool_calls, is_cancelled, ToolBatchOutcome};
+use self::loop_state::{finish_turn, LoopControl, TurnLoopState};
 use super::types::{PermissionProvider, TurnConfig, TurnEventHandler, TurnResult};
-use super::usage_accumulator::UsageTotals;
-use super::usage_telemetry::UsageTelemetryCollector;
 
 /// Execute one agent turn: messages → (LLM + tools)* → final response.
 ///
-/// This is the generic agentic loop shared by all agent sessions.
-/// The caller provides:
-/// - `messages`: the full message history (system + user + prior turns)
-/// - `provider`: the LLM provider to call
-/// - `tools`: the tool registry for execution
-/// - `policy`: resolved tool policy for this session
-/// - `config`: turn parameters (model, iterations, tokens, temperature)
-/// - `session_id`: session identifier for event correlation
-/// - `handler`: event handler for streaming, tool events, and persistence
-///
-/// Returns a `TurnResult` with the final content and accumulated token usage.
+/// This is the generic agentic loop shared by all agent sessions. The public
+/// signature and TurnResult contract are intentionally stable; private
+/// phases expose the loop transition order without creating new runtime
+/// owners.
 #[allow(clippy::too_many_arguments)]
 pub async fn execute_turn(
     messages: &mut Vec<Value>,
@@ -67,1183 +43,117 @@ pub async fn execute_turn(
     cancel_flag: Option<&Arc<AtomicBool>>,
     policy_context_activator: Option<&SessionScopedContextActivator>,
 ) -> Result<TurnResult, String> {
-    let mut iteration = 0u32;
-    let mut final_content: Option<String> = None;
-    // Set to true when the turn exits due to exhausted stream-error retries.
-    // Prevents the error text from being persisted into the conversation
-    // history (see TurnResult::is_stream_error).
-    let mut final_is_stream_error = false;
+    let mut state = TurnLoopState::new(config, messages);
 
-    let mut usage = UsageTotals::default();
-    let mut usage_telemetry = UsageTelemetryCollector::default();
-    let mut context_usage_snapshot: Option<ContextUsageSnapshot> = None;
-
-    let mut repeat_guard = RepeatGuard::default();
-    let mut consecutive_errors: u32 = 0;
-    let mut output_recovery_count: u32 = 0;
-    // True once we've burned the one silent Tier-1 escalation (max_tokens →
-    // ESCALATED_MAX_TOKENS). After that, subsequent truncations fall through
-    // to Tier 2 (user-visible auto-continue messages).
-    let mut tier1_escalated: bool = false;
-    // The effective max_tokens for the current LLM call; may be bumped once
-    // to ESCALATED_MAX_TOKENS on Tier-1 escalation.
-    let mut effective_max_tokens: u32 = config.max_tokens;
-    // Stream-error retry budgets (split across generic vs overloaded — see
-    // `stream_error_recovery` module for the full policy).
-    let mut retry_budgets = RetryBudgets::default();
-    // In-turn ContextTooLong rescue attempts already burned (see the
-    // `ContextTooLong` arm below).
-    let mut context_rescue_attempts = 0u32;
-    // One-shot flags for the two withhold-then-recover arms: lowering
-    // max_tokens on "input + max_tokens exceed" and stripping historical
-    // media blocks on media-413. Reset never — one attempt each per turn.
-    let mut max_tokens_lowered = false;
-    let mut media_stripped = false;
-    // Stop-hook blocking continuations already burned. Hard cap so a hook
-    // that always blocks cannot spin the loop forever (death-spiral guard).
-    let mut stop_hook_blocks = 0u32;
-    const MAX_STOP_HOOK_BLOCKS: u32 = 3;
-    // Auto-continue nudges already burned this turn, plus the cumulative
-    // completion-token count observed at the last nudge (the
-    // diminishing-returns baseline for `should_auto_continue`).
-    let mut auto_continuations = 0u32;
-    let mut auto_continue_completion_baseline: Option<i64> = None;
-    // One-shot model-side context-budget nudge for this turn. Set when a
-    // snapshot crosses the error tier; consumed (injected) at the top of the
-    // next iteration so it never lands between an assistant tool_use and its
-    // tool_result rows.
-    let mut budget_nudge_sent = false;
-    let mut pending_budget_nudge: Option<String> = None;
-    // One-shot anti-rush reassurance for large-window models (≥1M): fired
-    // past 25% fill so the model doesn't self-truncate long tasks.
-    let mut anti_rush_sent = false;
-
-    // In-loop stale-todo reminder (mirrors the reference harness): after
-    // `STALE_TODO_ITERATIONS` LLM iterations without a `manage_todo` call —
-    // throttled to at most one reminder per `STALE_TODO_ITERATIONS` — the
-    // open todo list is re-surfaced mid-turn. The turn-start nag in
-    // `processor/prompt.rs` only fires between user dispatches, which never
-    // helps a single long agentic run (the observed "created 0/5, finished
-    // the work, never updated" failure).
-    let mut iterations_since_todo_use: u32 = 0;
-    let mut iterations_since_todo_reminder: u32 = 0;
-
-    let mut file_tracker = file_tracker::FileTimeTracker::new();
-    // Read-before-edit is session-scoped: seed the fresh per-turn tracker
-    // with every file the transcript already read/wrote so cross-turn edits
-    // aren't false-rejected.
-    file_tracker.seed_from_history(messages);
-    let mc_config = microcompact::MicrocompactConfig::default();
-    let iteration_hook = config.iteration_hook.as_deref();
-
-    // Stamp all tools with this session's id so tools that carry internal
-    // session context (TodoTool, ExecTool, etc.) resolve to the correct
-    // session. Critical for subagents that inherit the parent's ToolRegistry
-    // — without this, shared tool instances still point at the parent id.
+    // Stamp shared tool instances with the child/current session before the
+    // first iteration, preserving the single pre-loop initialization point.
     tools.set_session_key(session_id).await;
 
     loop {
-        if let Some(max) = config.max_iterations {
-            if iteration >= max {
-                break;
-            }
-        }
-        if is_cancelled(cancel_flag) {
-            info!("[agent-core] Cancelled by user (session={})", session_id);
-            if config.persist_cancel_marker {
-                crate::core::session::persistence::mark_turn_cancelled(session_id);
-            }
-            final_content = None;
-            break;
-        }
-        iteration += 1;
-        if let Some(hook) = iteration_hook {
-            hook.before_llm_iteration(session_id, iteration, messages)
-                .await;
-        }
-
-        // Mid-turn steering: drain user messages that arrived while this
-        // turn was running and inject them into the current loop so the
-        // model can change course immediately instead of after the turn.
-        drain_steering_queue(&config.steering_queue, session_id, messages, handler).await;
-
-        // Deferred context-budget nudge from the previous iteration.
-        if let Some(nudge) = pending_budget_nudge.take() {
-            messages.push(serde_json::json!({
-                "role": "user",
-                "content": nudge,
-            }));
-        }
-
-        // Changed-files injector: tell the model when files it read this
-        // turn were modified externally (user edit, linter, another agent)
-        // instead of letting the next edit fail the stale-content guard.
-        let externally_changed = file_tracker.drain_externally_changed();
-        if !externally_changed.is_empty() {
-            info!(
-                "[agent-core] {} externally changed file(s) detected mid-turn (session={})",
-                externally_changed.len(),
-                session_id
-            );
-            messages.push(serde_json::json!({
-                "role": "user",
-                "content": format!(
-                    "<system-reminder>\nThe following file(s) were modified externally (by the user or another process) since you read them:\n{}\nRe-read any of these files before editing them — your remembered content is stale. Treat the external changes as intentional: take them into account and do NOT revert them unless the user asks you to.\n</system-reminder>",
-                    externally_changed
-                        .iter()
-                        .map(|path| format!("- {path}"))
-                        .collect::<Vec<_>>()
-                        .join("\n")
-                ),
-            }));
-        }
-
-        // Mid-turn background-job update: deliver job events that landed
-        // while this turn was already running — completions with unread
-        // output and shells latched as waiting for interactive input — so
-        // the model learns about them at the next iteration instead of
-        // polling or waiting for the next turn's reminder. Skipped on the
-        // first iteration: the turn-start Background Jobs reminder owns
-        // turn-boundary delivery. Claiming here consumes the same
-        // exactly-once flags as the idle wake, so an event delivered
-        // mid-turn never also wakes the session at turn end.
-        if iteration > 1
-            && crate::tools::impls::coding::exec::registry::claim_completion_wake_for_session(
-                session_id,
-            )
-        {
-            use crate::core::session::turn::background_reminder;
-            let jobs: Vec<_> =
-                crate::tools::impls::coding::exec::registry::list_jobs_for_reminder(session_id)
-                    .into_iter()
-                    .filter(|job| job.has_unread_output || job.stalled_waiting_input)
-                    .collect();
-            if !jobs.is_empty() {
-                info!(
-                    "[agent-core] mid-turn background-job note injected ({} job(s), session={})",
-                    jobs.len(),
-                    session_id
-                );
-                let note = background_reminder::build_completion_notification(&jobs);
-                crate::tools::impls::coding::exec::registry::acknowledge_outputs(
-                    &background_reminder::inlined_result_handles(&jobs),
-                );
-                messages.push(serde_json::json!({
-                    "role": "user",
-                    "content": note,
-                }));
-            }
-        }
-
-        // Stale-todo reminder: same injection point as the other mid-turn
-        // reminders above, so it never lands between an assistant tool_use
-        // and its tool_result rows.
-        iterations_since_todo_use = iterations_since_todo_use.saturating_add(1);
-        iterations_since_todo_reminder = iterations_since_todo_reminder.saturating_add(1);
-        if should_inject_todo_reminder(iterations_since_todo_use, iterations_since_todo_reminder) {
-            // Throttle even when the list turns out to be empty/completed —
-            // re-checking the DB every iteration afterwards buys nothing.
-            iterations_since_todo_reminder = 0;
-            let todos = tokio::task::block_in_place(|| {
-                crate::persistence::db_helpers::todos::get_todos(session_id).unwrap_or_default()
-            });
-            let has_open_todos = todos
-                .iter()
-                .any(|todo| todo.status != "completed" && todo.status != "cancelled");
-            if has_open_todos {
-                info!(
-                    "[agent-core] stale-todo reminder injected mid-turn ({} iterations since last manage_todo, session={})",
-                    iterations_since_todo_use, session_id
-                );
-                messages.push(serde_json::json!({
-                    "role": "user",
-                    "content":
-                        crate::tools::impls::coding::manage_todo::stale_todo_reminder(&todos),
-                }));
-            }
-        }
-
-        let limit_display = config
-            .max_iterations
-            .map_or("∞".to_string(), |m| m.to_string());
-        info!(
-            "[agent-core] iteration {}/{} (session={})",
-            iteration, limit_display, session_id
-        );
-
-        // Full-history pairing normalization before every provider call
-        // (reference parity): the dispatch-time pass in `processor` cannot
-        // see mid-turn corruption, so re-run it each iteration — orphan or
-        // duplicate tool rows would otherwise 400 every subsequent request
-        // in the session.
-        if crate::session::recovery::ensure_tool_result_pairing(messages) {
-            warn!(
-                "[agent-core] tool-pairing normalization repaired history mid-turn (session={})",
-                session_id
-            );
-        }
-
-        // Microcompact: clear old tool results when the prompt cache has expired
-        microcompact::microcompact_messages(messages, &mc_config);
-
-        // Cap recent tool-result screenshots (desktop-control, read_file on
-        // images, etc). Runs every turn — images inflate the wire payload
-        // faster than tokens, and the 1-hour time trigger above is too
-        // coarse for a fast agentic loop doing dozens of clicks in minutes.
-        microcompact::cap_recent_tool_images(messages);
-
-        let session_id_for_stream = session_id.to_string();
-        info!(
-            "[agent-core] collecting tool definitions (session={})",
-            session_id
-        );
-        let tool_defs = tools.get_definitions_budgeted(policy);
-        info!(
-            "[agent-core] collected {} tool definitions (session={})",
-            tool_defs.len(),
-            session_id
-        );
-
-        // Build LLM messages: resolve screenshots, then strip internal metadata
-        let mut llm_messages: Vec<Value> = if let Some(ref store) = config.screenshot_store {
-            resolve_screenshot_markers(messages, store, &config.model)
-        } else {
-            messages.clone()
-        };
-        microcompact::strip_timestamp_metadata(&mut llm_messages);
-        info!(
-            "[agent-core] built {} LLM messages for provider (session={})",
-            llm_messages.len(),
-            session_id
-        );
-
-        let stream_normalizer_for_cb = std::sync::Mutex::new(TurnStreamNormalizer::new());
-
-        provider.set_session_context(session_id);
-
-        #[cfg(debug_assertions)]
-        provider_request_capture::capture(
+        match iteration_input::prepare_iteration_input(
+            &mut state,
+            messages,
+            config,
             session_id,
-            iteration,
-            &config.model,
-            effective_max_tokens,
-            config.temperature,
-            &llm_messages,
-            &tool_defs,
+            handler,
+            cancel_flag,
+        )
+        .await
+        {
+            LoopControl::Proceed => {}
+            LoopControl::Continue => continue,
+            LoopControl::Break => break,
+        }
+
+        let request = provider_iteration::prepare_request(
+            &mut state, messages, tools, policy, config, session_id,
         );
-
-        let cancel_for_stream = cancel_flag.cloned();
-        let cancel_ref = cancel_flag.as_ref().map(|f| f.as_ref());
-        let stream_result =
-            if retry_budgets.non_streaming_fallback {
-                // Non-streaming fallback: the SSE path failed repeatedly with no
-                // partial output — request the whole response in one shot. No
-                // live deltas for this attempt; the assembled response flows
-                // through the normal completion path.
-                info!(
-                    "[agent-core] Using non-streaming request for this attempt (session={})",
-                    session_id
-                );
-                provider
-                    .chat(
-                        &llm_messages,
-                        Some(&tool_defs),
-                        &config.model,
-                        effective_max_tokens,
-                        config.temperature,
-                    )
-                    .await
-            } else {
-                provider
-                .chat_streaming(
-                &llm_messages,
-                Some(&tool_defs),
-                &config.model,
-                effective_max_tokens,
-                config.temperature,
-                &move |delta: StreamDelta| {
-                    if is_cancelled(cancel_for_stream.as_ref()) {
-                        return;
-                    }
-                    let normalized_events = match stream_normalizer_for_cb.lock() {
-                        Ok(mut normalizer) => normalizer.ingest_delta(delta),
-                        Err(_) => {
-                            warn!("[agent-core] stream normalizer lock poisoned; dropping delta");
-                            return;
-                        }
-                    };
-                    for event in normalized_events {
-                        match event {
-                            NormalizedStreamEvent::MessageDelta(content) => {
-                                handler.on_message_delta(&session_id_for_stream, &content);
-                            }
-                            NormalizedStreamEvent::ThinkingDelta(reasoning) => {
-                                handler.on_thinking_delta(&session_id_for_stream, &reasoning);
-                            }
-                            NormalizedStreamEvent::ToolCallDelta(tc_delta) => {
-                                handler.on_tool_call_delta(
-                                    &session_id_for_stream,
-                                    tc_delta.index,
-                                    tc_delta.id.as_deref(),
-                                    tc_delta.name.as_deref(),
-                                    tc_delta.arguments_delta.as_deref(),
-                                );
-                            }
-                            NormalizedStreamEvent::UnknownFrame {
-                                provider,
-                                event_type,
-                                sample,
-                            } => {
-                                warn!(
-                                    provider,
-                                    event_type,
-                                    sample,
-                                    "[agent-core] provider stream emitted unknown frame"
-                                );
-                            }
-                            NormalizedStreamEvent::Finish { .. }
-                            | NormalizedStreamEvent::FlushSegment(_) => {}
-                        }
-                    }
-                },
-                cancel_ref,
-            )
-            .await
-            };
-
-        let response = match stream_result {
-            Ok(resp) => resp,
-            Err(crate::providers::traits::ProviderError::Cancelled) => {
-                info!(
-                    "[agent-core] Stream cancelled by user (session={})",
-                    session_id
-                );
-                if config.persist_cancel_marker {
-                    crate::core::session::persistence::mark_turn_cancelled(session_id);
-                }
-                final_content = None;
-                break;
-            }
-            Err(err @ crate::providers::traits::ProviderError::ContextTooLong(_))
-                if context_rescue_attempts < MAX_CONTEXT_RESCUE_ATTEMPTS =>
-            {
-                // Self-rescue instead of aborting the whole turn (which
-                // discards every finding the agent accumulated — a 35-minute
-                // subagent run once died this way). First force-clear old
-                // tool results (cheap, no LLM); if that freed nothing, fall
-                // back to head-preserving hard truncation. Bounded by
-                // MAX_CONTEXT_RESCUE_ATTEMPTS.
-                context_rescue_attempts += 1;
-                warn!(
-                    "[agent-core] ContextTooLong (session={}), rescue attempt {}/{}: {}",
-                    session_id, context_rescue_attempts, MAX_CONTEXT_RESCUE_ATTEMPTS, err
-                );
-                let stats = microcompact::force_microcompact_messages(messages, &mc_config);
-                if stats.chars_saved == 0 && stats.images_cleared == 0 {
-                    // Nothing left to clear — hard-truncate the history while
-                    // keeping the head (system prompt + task statement).
-                    let window =
-                        crate::providers::model_capabilities::resolve_effective_context_window(
-                            &config.model,
-                            config.account_id.as_deref(),
-                            config.context_window_override,
-                        );
-                    let mut budget = window.saturating_mul(3) / 4;
-                    // The budget is denominated in ESTIMATED tokens but the
-                    // provider just rejected the ACTUAL prompt — calibrate by
-                    // the observed undercount (the error carries the real
-                    // count) or truncation can decide "already within budget"
-                    // and delete nothing, spinning through every rescue
-                    // attempt without progress.
-                    let estimated =
-                        crate::model_context::compaction::ContextCompactor::estimate_messages_tokens(
-                            messages,
-                        );
-                    if let Some(actual) =
-                        crate::model_context::compaction::ContextCompactor::parse_actual_tokens_from_error(
-                            &err.to_string(),
-                        )
-                    {
-                        budget = crate::model_context::compaction::ContextCompactor::calibrate_budget(
-                            budget, estimated, actual,
-                        );
-                    }
-                    let mut truncated =
-                        crate::model_context::compaction::ContextCompactor::simple_truncate(
-                            messages, budget,
-                        );
-                    // Progress guarantee: keep halving the budget until the
-                    // truncation actually drops something (or the budget is
-                    // too small to matter).
-                    while truncated.len() == messages.len() && budget > 10_000 {
-                        budget /= 2;
-                        truncated =
-                            crate::model_context::compaction::ContextCompactor::simple_truncate(
-                                messages, budget,
-                            );
-                    }
-                    warn!(
-                        "[agent-core] Context rescue truncation: {} -> {} messages, budget ~{} est-tokens (session={})",
-                        messages.len(),
-                        truncated.len(),
-                        budget,
-                        session_id
-                    );
-                    *messages = truncated;
-                }
-                continue;
-            }
-            Err(err @ crate::providers::traits::ProviderError::MaxTokensExceedContext(_))
-                if !max_tokens_lowered =>
-            {
-                // The PROMPT fits — only prompt + max_tokens overflows.
-                // Compacting history for this would destroy context for no
-                // reason; shrink the output budget for this turn instead.
-                // One-shot: a second overflow after halving means the prompt
-                // is genuinely at the edge and falls through to the
-                // ContextTooLong arm on retry.
-                max_tokens_lowered = true;
-                let lowered = (effective_max_tokens / 2).max(1024);
-                warn!(
-                    "[agent-core] max_tokens + input exceeds context (session={}); lowering max_tokens {} -> {} and retrying: {}",
-                    session_id, effective_max_tokens, lowered, err
-                );
-                effective_max_tokens = lowered;
-                continue;
-            }
-            Err(err @ crate::providers::traits::ProviderError::MediaTooLarge(_))
-                if !media_stripped =>
-            {
-                // Oversized base64 media (screenshot / PDF) in HISTORY is
-                // being re-sent on every request. Strip historical media
-                // blocks to text placeholders and retry — text compaction
-                // would not remove them and the model rarely needs the raw
-                // pixels of an old screenshot again. One-shot per turn.
-                media_stripped = true;
-                let stripped = strip_historical_media_blocks(messages);
-                warn!(
-                    "[agent-core] Media too large (session={}); stripped {} historical media block(s) and retrying: {}",
-                    session_id, stripped, err
-                );
-                if stripped == 0 {
-                    return Err(format!("LLM error: {}", err));
-                }
-                continue;
-            }
-            Err(err) => return Err(format!("LLM error: {}", err)),
+        let response = match provider_iteration::call_provider(
+            &state,
+            &request,
+            provider,
+            config,
+            session_id,
+            handler,
+            cancel_flag,
+        )
+        .await
+        {
+            Ok(response) => response,
+            Err(error) => match recovery::handle_provider_error(
+                error, &mut state, messages, config, session_id,
+            )? {
+                LoopControl::Continue => continue,
+                LoopControl::Break => break,
+                LoopControl::Proceed => continue,
+            },
         };
 
-        if is_cancelled(cancel_flag) {
-            info!(
-                "[agent-core] Cancelled after streaming (session={})",
-                session_id
-            );
-            // The response is fully assembled at this point — keep what the
-            // model already said in the transcript (mirrors the reference
-            // harness). Dropping it leaves the next turn's model unaware of
-            // its own partial answer and the user staring at a vanished
-            // message.
-            if let Some(partial) = response
-                .content
-                .as_deref()
-                .filter(|text| !text.trim().is_empty())
-            {
-                add_assistant_message(
-                    messages,
-                    Some(partial),
-                    None,
-                    response.reasoning_content.as_deref(),
-                );
-                handler.on_assistant_iteration_complete(
-                    session_id,
-                    Some(partial),
-                    false,
-                    &config.model,
-                );
-            }
-            if config.persist_cancel_marker {
-                crate::core::session::persistence::mark_turn_cancelled(session_id);
-            }
-            final_content = None;
+        if let LoopControl::Break = recovery::handle_post_stream_cancellation(
+            &response,
+            &mut state,
+            messages,
+            config,
+            session_id,
+            handler,
+            cancel_flag,
+        ) {
             break;
         }
 
-        if !response.usage.is_empty() {
-            usage.accumulate(&response.usage, session_id);
-            // Authoritative context window: FAMILY_RULES gives the model's
-            // nominal capability, optionally overridden by the provider's
-            // `/v1/models` context_length for this account (stored in
-            // KeyVault). This keeps the frontend gauge honest when a proxy
-            // caps a 1M model at 256K.
-            let context_window =
-                crate::core::providers::model_capabilities::resolve_effective_context_window(
-                    &config.model,
-                    config.account_id.as_deref(),
-                    config.context_window_override,
-                ) as i64;
-            let snapshot = ContextUsageSnapshot::from_payload(
-                &llm_messages,
-                &tool_defs,
-                usage.last_prompt,
-                usage.cache_read,
-                usage.cache_write,
-                Some(context_window),
-            );
-            handler.on_context_usage(session_id, &snapshot);
-            usage_telemetry.record_llm_span(
-                iteration as i64,
-                &response.usage,
-                usage.last_prompt,
-                &response.tool_calls,
-                Some(&snapshot),
-            );
+        recovery::record_usage(&response, &request, &mut state, config, session_id, handler);
 
-            // Model-side budget nudge (once per turn): past the error tier
-            // the model should wrap up instead of starting broad new work —
-            // pre-turn compaction will fire next turn, but mid-turn the
-            // model is otherwise blind to how close the window is. Queued
-            // here, injected at the top of the next iteration.
-            if !budget_nudge_sent {
-                if let Some(level @ ("error" | "blocking")) = snapshot.warning_level() {
-                    budget_nudge_sent = true;
-                    let percent = snapshot.percent_used.unwrap_or(0.0);
-                    pending_budget_nudge = Some(format!(
-                        "<system-reminder>\nContext window is {percent:.0}% full ({level}). Prioritize finishing the current task with the remaining budget: prefer targeted reads over broad exploration, avoid re-reading large files, and summarize instead of quoting long output. The system will compact older history automatically on the next turn.\n</system-reminder>"
-                    ));
-                    info!(
-                        "[agent-core] Queued context-budget nudge ({level}, {percent:.1}% used, session={session_id})"
-                    );
-                }
-            }
-
-            // Anti-rush reassurance for large-window models (mirrors the
-            // reference harness): past 25% on a ≥1M window, models start
-            // wrapping up prematurely even though compaction makes the
-            // conversation effectively unbounded. Once per turn; mutually
-            // exclusive with the budget nudge above (which supersedes it).
-            if !anti_rush_sent
-                && !budget_nudge_sent
-                && context_window >= ANTI_RUSH_MIN_WINDOW
-                && snapshot.percent_used.unwrap_or(0.0) >= ANTI_RUSH_MIN_PERCENT
-            {
-                anti_rush_sent = true;
-                pending_budget_nudge = Some(
-                    "<system-reminder>\nNote: automatic compaction is enabled — older messages will be summarized when the context window fills, so the conversation is not limited by it. There is no need to rush or wrap up early; continue working at full quality.\n</system-reminder>".to_string()
-                );
-            }
-
-            context_usage_snapshot = Some(snapshot);
+        match recovery::handle_stream_recovery(
+            &response,
+            &mut state,
+            messages,
+            cancel_flag,
+            session_id,
+            handler,
+        )
+        .await
+        {
+            LoopControl::Proceed => {}
+            LoopControl::Continue => continue,
+            LoopControl::Break => break,
         }
 
-        // Handle stream interruption.
-        //
-        // Stream errors happen when the upstream provider drops the connection
-        // mid-response (per-chunk read timeout, transport-level socket drop,
-        // provider 5xx error frame, HTTP 529 overload, etc.). The transport
-        // layer surfaces this as `finish_reason = stream_error` with a subtype
-        // in `stream_error_kind`, and we retry the whole iteration with an
-        // exponential backoff.
-        //
-        // Two independent budgets:
-        //   - `Overloaded` (HTTP 529 / `overloaded_error`): short budget of
-        //     `MAX_OVERLOADED_RETRIES = 3`. Capacity cascades recover slowly
-        //     and hammering makes them worse.
-        //   - Everything else: `MAX_STREAM_ERROR_RETRIES = 10`. Network flaps
-        //     and transient 5xx usually recover within a few retries.
-        //
-        // Exceeding either budget surfaces a user-visible error via
-        // `on_stream_error_exhausted` and breaks out of the loop with a
-        // final assistant message in `final_content`.
-        //
-        // Broadcast rule (intermediate attempts): NOTHING about the retry is
-        // visible as a chat bubble. Handlers get a low-key `on_stream_retry`
-        // callback for footer/status indicators only.
-        //
-        // Broadcast rule (final failure): the handler gets both a
-        // `on_stream_error_exhausted` callback (for the error footer) AND we
-        // persist a clean user-visible assistant message so the turn history
-        // reflects what the user saw.
-        //
-        // LLM message-history hygiene: we only add synthetic assistant +
-        // tool_result rows when tool calls were emitted before the failure,
-        // so the next API call stays OpenAI-compliant (assistant with
-        // `tool_calls` must be followed by matching `tool` rows). Partial
-        // text without tool_calls is discarded — the retry regenerates it.
-        if response.finish_reason == finish::STREAM_ERROR {
-            match handle_stream_error(
+        // Only a non-stream-error iteration resets both retry categories.
+        state.retry_budgets.reset_after_success(session_id);
+
+        let control = if response.has_tool_calls() {
+            tool_iteration::execute_tool_iteration(
                 &response,
-                &mut retry_budgets,
+                &mut state,
                 messages,
-                cancel_flag,
-                session_id,
-                handler,
-            )
-            .await
-            {
-                StreamErrorOutcome::BudgetExhausted { user_message } => {
-                    final_content = Some(user_message);
-                    final_is_stream_error = true;
-                    break;
-                }
-                StreamErrorOutcome::CancelledDuringBackoff => {
-                    final_content = None;
-                    break;
-                }
-                StreamErrorOutcome::Retry => continue,
-            }
-        }
-
-        // Successful iteration — reset both stream-error retry budgets. A
-        // single bad round doesn't carry a penalty forward into later
-        // iterations. We reset independently because an overload recovery
-        // shouldn't forgive a flapping connection from earlier in the turn.
-        retry_budgets.reset_after_success(session_id);
-
-        // Handle tool calls
-        if response.has_tool_calls() {
-            let current_signature: String = response
-                .tool_calls
-                .iter()
-                .map(|tc| format!("{}:{}", tc.name, tc.arguments))
-                .collect::<Vec<_>>()
-                .join("|");
-
-            // Progress probe for the repeat guard: tools that legitimately
-            // get re-invoked with identical args while an observed job
-            // advances (await_output) expose a fingerprint of that job's
-            // state. The batch carries a fingerprint when ANY call does, so
-            // an all-default batch keeps pure args-identity semantics.
-            let current_fingerprint: Option<String> = {
-                let parts: Vec<Option<String>> = response
-                    .tool_calls
-                    .iter()
-                    .map(|tc| {
-                        tools
-                            .get(&tc.name)
-                            .and_then(|tool| tool.progress_fingerprint(&tc.arguments))
-                    })
-                    .collect();
-                if parts.iter().any(Option::is_some) {
-                    Some(
-                        parts
-                            .into_iter()
-                            .map(|p| p.unwrap_or_default())
-                            .collect::<Vec<_>>()
-                            .join("|"),
-                    )
-                } else {
-                    None
-                }
-            };
-
-            if let RepeatVerdict::Break {
-                executed_attempts,
-                progress_aware,
-            } = repeat_guard.observe(current_signature.clone(), current_fingerprint)
-            {
-                let preview: String =
-                    crate::utils::safe_truncate_chars_to_string(&current_signature, 200);
-                warn!(
-                    "[agent-core] Breaking loop after {} identical no-progress tool calls (progress_aware={}): {}",
-                    executed_attempts, progress_aware, preview
-                );
-                final_content = Some(if progress_aware {
-                    format!(
-                        "The last {} checks of the same background job(s) found no new output or \
-                         status change, so I'm pausing this turn instead of continuing to poll. \
-                         If a job is still running, the session resumes automatically when it \
-                         completes; you can also send a message to continue sooner. The repeated \
-                         tool call was: {}",
-                        executed_attempts, preview
-                    )
-                } else {
-                    format!(
-                        "I called the same tool with identical arguments {} times in a row \
-                         without new information, so I stopped before repeating it again to \
-                         avoid an infinite loop. The last tool call was: {}",
-                        executed_attempts, preview
-                    )
-                });
-                break;
-            }
-
-            let tool_call_values: Vec<Value> = response
-                .tool_calls
-                .iter()
-                .map(|tc| {
-                    let mut obj = serde_json::json!({
-                        "id": tc.id,
-                        "type": "function",
-                        "function": {
-                            "name": tc.name,
-                            "arguments": tc.arguments.to_string(),
-                        }
-                    });
-                    if let Some(sig) = &tc.thought_signature {
-                        if sig.get("anthropic").is_some() {
-                            obj["extra_content"] = sig.clone();
-                        } else {
-                            obj["extra_content"] = serde_json::json!({
-                                "google": { "thought_signature": sig }
-                            });
-                        }
-                    }
-                    obj
-                })
-                .collect();
-
-            add_assistant_message(
-                messages,
-                response.content.as_deref(),
-                Some(&tool_call_values),
-                response.reasoning_content.as_deref(),
-            );
-            handler.on_assistant_iteration_complete(
-                session_id,
-                response.content.as_deref(),
-                true,
-                &config.model,
-            );
-
-            // The tool_use itself proves the model is engaging with the todo
-            // list — count from here, like the reference harness does.
-            if response
-                .tool_calls
-                .iter()
-                .any(|tc| tc.name == crate::tools::names::MANAGE_TODO)
-            {
-                iterations_since_todo_use = 0;
-            }
-
-            let (_count, tool_execution_usage, outcome) = execute_tool_calls(
-                messages,
-                &response.tool_calls,
                 tools,
                 policy,
+                config,
                 session_id,
-                &config.turn_intent_id,
-                &config.projected_inbox_ids,
                 handler,
                 permission_provider,
                 cancel_flag,
-                &mut file_tracker,
-                &mut consecutive_errors,
                 policy_context_activator,
-                config.max_tool_use_concurrency,
             )
-            .await;
-            usage_telemetry.record_tool_results(iteration as i64, tool_execution_usage);
-
-            // Backfill dummy results for any tool calls that don't have a
-            // result yet after EarlyExit.
-            let existing_ids: std::collections::HashSet<String> = messages
-                .iter()
-                .filter_map(|m| {
-                    m.get("tool_call_id")
-                        .and_then(|v| v.as_str())
-                        .map(String::from)
-                })
-                .collect();
-            for tc in &response.tool_calls {
-                if !existing_ids.contains(&tc.id) {
-                    // Backfill so the assistant tool_use has a matching
-                    // tool_result (Anthropic wire requires the pair).
-                    // Marked `is_error: true` so the model treats this
-                    // as a failed call rather than a successful no-op
-                    // — silent "" results have caused models to
-                    // hallucinate that the cancelled tool succeeded.
-                    add_tool_result(
-                        messages,
-                        &tc.id,
-                        &tc.name,
-                        "[cancelled — tool was not executed]",
-                        true,
-                    );
-                }
-            }
-
-            match outcome {
-                ToolBatchOutcome::Continue => {}
-                ToolBatchOutcome::EndTurn(content) => {
-                    final_content = Some(content);
-                    break;
-                }
-                ToolBatchOutcome::Cancelled => {
-                    if config.persist_cancel_marker {
-                        crate::core::session::persistence::mark_turn_cancelled(session_id);
-                    }
-                    final_content = None;
-                    break;
-                }
-                ToolBatchOutcome::ErrorLoop(msg) => {
-                    final_content = Some(msg);
-                    break;
-                }
-            }
-        } else if response.finish_reason == finish::LENGTH {
-            match maybe_recover_from_length(
-                &response,
-                messages,
-                &mut tier1_escalated,
-                effective_max_tokens,
-                config.max_tokens,
-                &mut output_recovery_count,
-                session_id,
-                &config.model,
-                handler,
-            ) {
-                LengthRecoveryOutcome::Continue {
-                    effective_max_tokens: new_max,
-                } => {
-                    effective_max_tokens = new_max;
-                    continue;
-                }
-                LengthRecoveryOutcome::Terminal => {
-                    final_content = response.content;
-                    break;
-                }
-            }
+            .await
         } else {
-            // Terminal non-tool, non-length, non-stream-error iteration.
-            //
-            // Final steering drain: a user message that arrived during the
-            // last LLM call must not be silently deferred to a turn that may
-            // never come — inject it and give the model another iteration.
-            if !is_cancelled(cancel_flag)
-                && drain_steering_queue(&config.steering_queue, session_id, messages, handler).await
-            {
-                if let Some(ref text) = response.content {
-                    if !text.trim().is_empty() {
-                        handler.on_assistant_iteration_complete(
-                            session_id,
-                            Some(text.as_str()),
-                            false,
-                            &config.model,
-                        );
-                        // Keep the in-memory list consistent with what was
-                        // persisted: the steering user message must FOLLOW
-                        // the assistant text the model just produced.
-                        let steering_msg = messages.pop();
-                        messages.push(serde_json::json!({
-                            "role": "assistant",
-                            "content": text,
-                        }));
-                        if let Some(steering_msg) = steering_msg {
-                            messages.push(steering_msg);
-                        }
-                    }
-                }
-                continue;
-            }
-
-            // Stop-hook gate first: user-defined `Stop` hooks may BLOCK this
-            // completion (stdout `{"decision":"block","message":...}`), in
-            // which case the feedback is persisted as the assistant text,
-            // the block message is injected as a user message, and the loop
-            // continues. Skipped for cancelled turns and capped at
-            // MAX_STOP_HOOK_BLOCKS to prevent a death spiral. Stream-error
-            // endings never reach this arm (they break earlier), so API
-            // failures cannot be blocked into a retry loop.
-            if stop_hook_blocks < MAX_STOP_HOOK_BLOCKS && !is_cancelled(cancel_flag) {
-                if let Some(feedback) = handler.on_turn_stop_check(session_id).await {
-                    stop_hook_blocks += 1;
-                    warn!(
-                        "[agent-core] Stop hook blocked turn completion ({}/{}) for session {}: {}",
-                        stop_hook_blocks,
-                        MAX_STOP_HOOK_BLOCKS,
-                        session_id,
-                        &feedback[..feedback.len().min(200)]
-                    );
-                    // Persist what the model said this iteration so the
-                    // transcript stays coherent before the injected feedback.
-                    if let Some(ref text) = response.content {
-                        if !text.trim().is_empty() {
-                            handler.on_assistant_iteration_complete(
-                                session_id,
-                                Some(text.as_str()),
-                                false,
-                                &config.model,
-                            );
-                            messages.push(serde_json::json!({
-                                "role": "assistant",
-                                "content": text,
-                            }));
-                        }
-                    }
-                    messages.push(serde_json::json!({
-                        "role": "user",
-                        "content": format!(
-                            "<system-reminder>\nA Stop hook blocked this completion:\n{}\nAddress the feedback and continue; do not stop until it is resolved.\n</system-reminder>",
-                            feedback
-                        ),
-                    }));
-                    continue;
-                }
-            }
-
-            // Auto-continue gate (feature-gated, default off): the model
-            // ended the turn with plain text while the context window still
-            // has real room. Long-horizon models sometimes "self-ration" —
-            // narrating that context is nearly exhausted and wrapping up /
-            // handing off when the window is actually < 90% used. When the
-            // agent opts in, inject a continue nudge and give the model
-            // another iteration. Guardrails live in `should_auto_continue`
-            // (per-turn cap + diminishing-returns check); cancelled turns
-            // never continue, and stream-error / length endings never reach
-            // this arm (they break earlier).
-            if !is_cancelled(cancel_flag) {
-                let context_percent = context_usage_snapshot
-                    .as_ref()
-                    .and_then(|snapshot| snapshot.percent_used);
-                let last_progress_tokens =
-                    auto_continue_completion_baseline.map(|baseline| usage.completion - baseline);
-                if should_auto_continue(
-                    config.auto_continue,
-                    auto_continuations,
-                    last_progress_tokens,
-                    context_percent,
-                ) {
-                    auto_continuations += 1;
-                    auto_continue_completion_baseline = Some(usage.completion);
-                    let pct = context_percent.unwrap_or(0.0).round() as i64;
-                    info!(
-                        "[agent-core] Auto-continue {}/{} injected (context {}% used, session={})",
-                        auto_continuations, MAX_AUTO_CONTINUATIONS, pct, session_id
-                    );
-                    // Persist what the model said this iteration so the
-                    // transcript stays coherent before the injected nudge
-                    // (same pattern as the stop-hook block above — the
-                    // user message must never land between an assistant
-                    // tool_use and its tool_result).
-                    if let Some(ref text) = response.content {
-                        if !text.trim().is_empty() {
-                            handler.on_assistant_iteration_complete(
-                                session_id,
-                                Some(text.as_str()),
-                                false,
-                                &config.model,
-                            );
-                            messages.push(serde_json::json!({
-                                "role": "assistant",
-                                "content": text,
-                            }));
-                        }
-                    }
-                    messages.push(serde_json::json!({
-                        "role": "user",
-                        "content": format!(
-                            "<system-reminder>\nContext window is only {pct}% used. Do not wrap up, summarize, or hand off — continue working on the task directly.\n</system-reminder>"
-                        ),
-                    }));
-                    continue;
-                }
-            }
-
-            // Normally `response.content` carries the model's final text.
-            // But some stop reasons end the turn with an EMPTY body — most
-            // notably Anthropic `stop_reason=refusal` (mapped to
-            // CONTENT_FILTER), which returns zero content and zero tool calls.
-            // Without a fail-safe here the turn breaks with `final_content =
-            // None`, nothing is persisted, no assistant row is written, and
-            // the UI spinner runs forever. Substitute a user-visible notice so
-            // the turn terminates cleanly and the user knows to retry.
-            let is_empty = response
-                .content
-                .as_ref()
-                .map(|c| c.trim().is_empty())
-                .unwrap_or(true);
-            if is_empty {
-                let notice = if response.finish_reason == finish::CONTENT_FILTER {
-                    "The model declined to respond to this turn (no output was \
-                     produced). This is usually triggered by the content of the \
-                     request — try rephrasing, splitting a large paste into \
-                     smaller parts, or resending."
-                } else {
-                    "The model ended this turn without producing any output. \
-                     You can send a follow-up message to continue."
-                };
-                final_content = Some(notice.to_string());
-            } else {
-                final_content = response.content;
-            }
-            break;
-        }
-    }
-
-    let mut hit_max_iterations = false;
-    if let Some(max) = config.max_iterations {
-        if final_content.is_none() && iteration >= max {
-            hit_max_iterations = true;
-            warn!(
-                "[agent-core] Hit max iterations ({}) for session {}",
-                max, session_id
-            );
-            final_content = Some(format!(
-                "I reached the maximum number of iterations ({}) for this turn. \
-                 The task may not be fully complete — you can send a follow-up message to continue.",
-                max
-            ));
-        }
-    }
-
-    usage.finalize();
-
-    // Persist the terminal assistant content exactly once. Cases:
-    //   1. The loop broke with `final_content = response.content` (pure-text
-    //      final iteration at the `else { ... break; }` arm) — this content
-    //      was NOT passed through `add_assistant_message`, so no earlier
-    //      `on_assistant_iteration_complete` hook captured it. We persist it
-    //      now so `load_llm_history` can replay the last thing the model said.
-    //   2. `final_content` is a semantic closure string (repeat-loop break,
-    //      max-iterations notice). These are synthetic but carry LLM-relevant
-    //      context: the model needs to know why the previous turn ended so it
-    //      can continue correctly. Persist them.
-    //   3. `final_content` is a stream-error exhausted message (is_stream_error
-    //      = true). This is a user-facing error notice with no LLM semantic
-    //      value — skip persistence (no-silent-error persistence). The text is surfaced via
-    //      on_stream_error_exhausted + agent:error / agent:complete events.
-    //
-    // The processor previously did this in `save_assistant_msg(response_text)`
-    // at its turn epilogue; that call is removed now that the hook owns the
-    // lifecycle end-to-end.
-    if let Some(ref text) = final_content {
-        if !text.is_empty() && !final_is_stream_error {
-            // Do NOT persist stream-error messages into conversation history.
-            // Error assistant messages are shown to the user but filtered
-            // from the API message list so they don't pollute the LLM's
-            // context on the next call. When is_stream_error = true the text
-            // was already surfaced via on_stream_error_exhausted +
-            // agent:error / agent:complete events.
-            handler.on_assistant_iteration_complete(
+            completion::complete_non_tool_iteration(
+                response,
+                &mut state,
+                messages,
+                config,
                 session_id,
-                Some(text.as_str()),
-                false,
-                &config.model,
-            );
-        }
-    }
-
-    Ok(TurnResult {
-        content: final_content,
-        messages: messages.clone(),
-        is_stream_error: final_is_stream_error,
-        hit_max_iterations,
-        prompt_tokens: usage.prompt,
-        completion_tokens: usage.completion,
-        total_tokens: usage.total,
-        context_tokens: usage.last_prompt,
-        context_usage_snapshot,
-        cache_read_tokens: usage.cache_read,
-        cache_write_tokens: usage.cache_write,
-        usage_telemetry: usage_telemetry.finish(),
-    })
-}
-
-/// Replace image/document content blocks in HISTORICAL messages with text
-/// placeholders. The LAST user message keeps its media (it is usually the
-/// input the current turn is about); everything older is fair game — old
-/// screenshots/PDFs are re-sent on every request and are the usual cause of
-/// media-size rejections. Returns the number of blocks replaced.
-fn strip_historical_media_blocks(messages: &mut [Value]) -> usize {
-    let last_user_idx = messages
-        .iter()
-        .rposition(|msg| msg.get("role").and_then(Value::as_str) == Some("user"));
-
-    let mut stripped = 0usize;
-    for (idx, msg) in messages.iter_mut().enumerate() {
-        if Some(idx) == last_user_idx {
-            continue;
-        }
-        let Some(blocks) = msg.get_mut("content").and_then(Value::as_array_mut) else {
-            continue;
+                handler,
+                cancel_flag,
+            )
+            .await
         };
-        for block in blocks.iter_mut() {
-            let block_type = block.get("type").and_then(Value::as_str).unwrap_or("");
-            if matches!(block_type, "image_url" | "image" | "document") {
-                *block = serde_json::json!({
-                    "type": "text",
-                    "text": "[media removed: this image/document was too large to keep re-sending. Re-read the source file if you need it again.]",
-                });
-                stripped += 1;
-            }
+
+        match control {
+            LoopControl::Proceed | LoopControl::Continue => continue,
+            LoopControl::Break => break,
         }
     }
-    stripped
-}
 
-/// Drain the mid-turn steering buffer into `messages`.
-///
-/// All pending steering messages are merged into ONE
-/// `<system-reminder>`-wrapped user message (keeping the injection a single
-/// list entry so terminal-arm reordering stays trivial). Each consumed
-/// injection is reported to the handler for persistence + intent lifecycle.
-/// Returns `true` when anything was injected.
-async fn drain_steering_queue(
-    steering_queue: &Option<crate::turn_executor::SteeringQueue>,
-    session_id: &str,
-    messages: &mut Vec<Value>,
-    handler: &dyn TurnEventHandler,
-) -> bool {
-    let Some(queue) = steering_queue else {
-        return false;
-    };
-    let drained: Vec<crate::turn_executor::SteeringInjection> = {
-        let mut guard = queue.lock().await;
-        std::mem::take(&mut *guard)
-    };
-    if drained.is_empty() {
-        return false;
-    }
-
-    info!(
-        "[agent-core] Injecting {} steering message(s) mid-turn (session={})",
-        drained.len(),
-        session_id
-    );
-    let mut bodies = Vec::with_capacity(drained.len());
-    for injection in &drained {
-        handler.on_steering_consumed(session_id, injection);
-        bodies.push(injection.content.clone());
-    }
-    messages.push(serde_json::json!({
-        "role": "user",
-        "content": format!(
-            "<system-reminder>\nThe user sent the following message(s) while you were working. Adjust course accordingly — this may change or refine the current task:\n\n{}\n\nIMPORTANT: After completing your current step, you MUST address the user's message(s) above. Do not ignore them.\n</system-reminder>",
-            bodies.join("\n\n---\n\n")
-        ),
-    }));
-    true
-}
-
-#[cfg(test)]
-mod media_strip_tests {
-    use super::strip_historical_media_blocks;
-    use serde_json::json;
-
-    #[test]
-    fn strips_old_media_keeps_last_user_media() {
-        let mut messages = vec![
-            json!({"role": "user", "content": [
-                {"type": "image_url", "image_url": {"url": "data:image/png;base64,OLD"}},
-                {"type": "text", "text": "old screenshot"},
-            ]}),
-            json!({"role": "assistant", "content": "looked at it"}),
-            json!({"role": "user", "content": [
-                {"type": "image_url", "image_url": {"url": "data:image/png;base64,NEW"}},
-                {"type": "text", "text": "new screenshot"},
-            ]}),
-        ];
-        let stripped = strip_historical_media_blocks(&mut messages);
-        assert_eq!(stripped, 1);
-        // Old media replaced with text placeholder.
-        assert_eq!(messages[0]["content"][0]["type"], "text");
-        // Latest user media untouched.
-        assert_eq!(messages[2]["content"][0]["type"], "image_url");
-    }
-
-    #[test]
-    fn no_media_returns_zero() {
-        let mut messages = vec![json!({"role": "user", "content": "plain text"})];
-        assert_eq!(strip_historical_media_blocks(&mut messages), 0);
-    }
+    Ok(finish_turn(state, messages, config, session_id, handler))
 }

--- a/src-tauri/crates/agent-core/src/core/turn_executor/execute/completion.rs
+++ b/src-tauri/crates/agent-core/src/core/turn_executor/execute/completion.rs
@@ -1,0 +1,185 @@
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use serde_json::Value;
+use tracing::{info, warn};
+
+use crate::providers::traits::{finish_reason as finish, LLMResponse};
+
+use super::super::continuation::{should_auto_continue, MAX_AUTO_CONTINUATIONS};
+use super::super::length_recovery::{maybe_recover_from_length, LengthRecoveryOutcome};
+use super::super::tool_execution::is_cancelled;
+use super::super::types::{TurnConfig, TurnEventHandler};
+use super::iteration_input::drain_steering_queue;
+use super::loop_state::{LoopControl, TurnLoopState};
+
+const MAX_STOP_HOOK_BLOCKS: u32 = 3;
+
+pub(super) async fn complete_non_tool_iteration(
+    response: LLMResponse,
+    state: &mut TurnLoopState,
+    messages: &mut Vec<Value>,
+    config: &TurnConfig,
+    session_id: &str,
+    handler: &dyn TurnEventHandler,
+    cancel_flag: Option<&Arc<AtomicBool>>,
+) -> LoopControl {
+    if response.finish_reason == finish::LENGTH {
+        return match maybe_recover_from_length(
+            &response,
+            messages,
+            &mut state.tier1_escalated,
+            state.effective_max_tokens,
+            config.max_tokens,
+            &mut state.output_recovery_count,
+            session_id,
+            &config.model,
+            handler,
+        ) {
+            LengthRecoveryOutcome::Continue {
+                effective_max_tokens,
+            } => {
+                state.effective_max_tokens = effective_max_tokens;
+                LoopControl::Continue
+            }
+            LengthRecoveryOutcome::Terminal => {
+                state.final_content = response.content;
+                LoopControl::Break
+            }
+        };
+    }
+
+    // A message arriving during the final provider call must not be silently
+    // deferred to a turn that may never come. Persist the assistant text,
+    // place the steering message after it, and iterate again.
+    if !is_cancelled(cancel_flag)
+        && drain_steering_queue(&config.steering_queue, session_id, messages, handler).await
+    {
+        if let Some(ref text) = response.content {
+            if !text.trim().is_empty() {
+                handler.on_assistant_iteration_complete(
+                    session_id,
+                    Some(text.as_str()),
+                    false,
+                    &config.model,
+                );
+                let steering_message = messages.pop();
+                messages.push(serde_json::json!({
+                    "role": "assistant",
+                    "content": text,
+                }));
+                if let Some(steering_message) = steering_message {
+                    messages.push(steering_message);
+                }
+            }
+        }
+        return LoopControl::Continue;
+    }
+
+    // User-defined Stop hooks may block completion, but only up to the same
+    // hard cap as before so a permanently blocking hook cannot spin forever.
+    if state.stop_hook_blocks < MAX_STOP_HOOK_BLOCKS && !is_cancelled(cancel_flag) {
+        if let Some(feedback) = handler.on_turn_stop_check(session_id).await {
+            state.stop_hook_blocks += 1;
+            warn!(
+                "[agent-core] Stop hook blocked turn completion ({}/{}) for session {}: {}",
+                state.stop_hook_blocks,
+                MAX_STOP_HOOK_BLOCKS,
+                session_id,
+                &feedback[..feedback.len().min(200)]
+            );
+            if let Some(ref text) = response.content {
+                if !text.trim().is_empty() {
+                    handler.on_assistant_iteration_complete(
+                        session_id,
+                        Some(text.as_str()),
+                        false,
+                        &config.model,
+                    );
+                    messages.push(serde_json::json!({
+                        "role": "assistant",
+                        "content": text,
+                    }));
+                }
+            }
+            messages.push(serde_json::json!({
+                "role": "user",
+                "content": format!(
+                    "<system-reminder>\nA Stop hook blocked this completion:\n{}\nAddress the feedback and continue; do not stop until it is resolved.\n</system-reminder>",
+                    feedback
+                ),
+            }));
+            return LoopControl::Continue;
+        }
+    }
+
+    // Feature-gated auto-continuation follows the stop-hook check and retains
+    // the per-turn cap plus diminishing-returns baseline.
+    if !is_cancelled(cancel_flag) {
+        let context_percent = state
+            .context_usage_snapshot
+            .as_ref()
+            .and_then(|snapshot| snapshot.percent_used);
+        let last_progress_tokens = state
+            .auto_continue_completion_baseline
+            .map(|baseline| state.usage.completion - baseline);
+        if should_auto_continue(
+            config.auto_continue,
+            state.auto_continuations,
+            last_progress_tokens,
+            context_percent,
+        ) {
+            state.auto_continuations += 1;
+            state.auto_continue_completion_baseline = Some(state.usage.completion);
+            let pct = context_percent.unwrap_or(0.0).round() as i64;
+            info!(
+                "[agent-core] Auto-continue {}/{} injected (context {}% used, session={})",
+                state.auto_continuations, MAX_AUTO_CONTINUATIONS, pct, session_id
+            );
+            if let Some(ref text) = response.content {
+                if !text.trim().is_empty() {
+                    handler.on_assistant_iteration_complete(
+                        session_id,
+                        Some(text.as_str()),
+                        false,
+                        &config.model,
+                    );
+                    messages.push(serde_json::json!({
+                        "role": "assistant",
+                        "content": text,
+                    }));
+                }
+            }
+            messages.push(serde_json::json!({
+                "role": "user",
+                "content": format!(
+                    "<system-reminder>\nContext window is only {pct}% used. Do not wrap up, summarize, or hand off — continue working on the task directly.\n</system-reminder>"
+                ),
+            }));
+            return LoopControl::Continue;
+        }
+    }
+
+    // Some terminal reasons (notably Anthropic refusal/content_filter) carry
+    // no body. Substitute the existing user-visible notice so the turn closes.
+    let is_empty = response
+        .content
+        .as_ref()
+        .map(|content| content.trim().is_empty())
+        .unwrap_or(true);
+    state.final_content = if is_empty {
+        let notice = if response.finish_reason == finish::CONTENT_FILTER {
+            "The model declined to respond to this turn (no output was \
+             produced). This is usually triggered by the content of the \
+             request — try rephrasing, splitting a large paste into \
+             smaller parts, or resending."
+        } else {
+            "The model ended this turn without producing any output. \
+             You can send a follow-up message to continue."
+        };
+        Some(notice.to_string())
+    } else {
+        response.content
+    };
+    LoopControl::Break
+}

--- a/src-tauri/crates/agent-core/src/core/turn_executor/execute/iteration_input.rs
+++ b/src-tauri/crates/agent-core/src/core/turn_executor/execute/iteration_input.rs
@@ -1,0 +1,183 @@
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use serde_json::Value;
+use tracing::info;
+
+use super::super::continuation::should_inject_todo_reminder;
+use super::super::tool_execution::is_cancelled;
+use super::super::types::{TurnConfig, TurnEventHandler};
+use super::loop_state::{LoopControl, TurnLoopState};
+
+/// Apply all start-of-iteration gates and inject pending user/system input in
+/// the same order as the monolithic loop.
+pub(super) async fn prepare_iteration_input(
+    state: &mut TurnLoopState,
+    messages: &mut Vec<Value>,
+    config: &TurnConfig,
+    session_id: &str,
+    handler: &dyn TurnEventHandler,
+    cancel_flag: Option<&Arc<AtomicBool>>,
+) -> LoopControl {
+    if let Some(max) = config.max_iterations {
+        if state.iteration >= max {
+            return LoopControl::Break;
+        }
+    }
+    if is_cancelled(cancel_flag) {
+        info!("[agent-core] Cancelled by user (session={})", session_id);
+        if config.persist_cancel_marker {
+            crate::core::session::persistence::mark_turn_cancelled(session_id);
+        }
+        state.final_content = None;
+        return LoopControl::Break;
+    }
+    state.iteration += 1;
+    if let Some(hook) = config.iteration_hook.as_deref() {
+        hook.before_llm_iteration(session_id, state.iteration, messages)
+            .await;
+    }
+
+    // Mid-turn steering arrives before every other reminder so user intent
+    // can redirect the next provider call immediately.
+    drain_steering_queue(&config.steering_queue, session_id, messages, handler).await;
+
+    // Deferred context-budget nudge from the previous iteration.
+    if let Some(nudge) = state.pending_budget_nudge.take() {
+        messages.push(serde_json::json!({
+            "role": "user",
+            "content": nudge,
+        }));
+    }
+
+    // Changed-files injector: tell the model when files it read this turn
+    // were modified externally instead of letting the next edit fail the
+    // stale-content guard.
+    let externally_changed = state.file_tracker.drain_externally_changed();
+    if !externally_changed.is_empty() {
+        info!(
+            "[agent-core] {} externally changed file(s) detected mid-turn (session={})",
+            externally_changed.len(),
+            session_id
+        );
+        messages.push(serde_json::json!({
+            "role": "user",
+            "content": format!(
+                "<system-reminder>\nThe following file(s) were modified externally (by the user or another process) since you read them:\n{}\nRe-read any of these files before editing them — your remembered content is stale. Treat the external changes as intentional: take them into account and do NOT revert them unless the user asks you to.\n</system-reminder>",
+                externally_changed
+                    .iter()
+                    .map(|path| format!("- {path}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            ),
+        }));
+    }
+
+    // Mid-turn background-job updates are skipped on the first iteration;
+    // the turn-start reminder owns turn-boundary delivery.
+    if state.iteration > 1
+        && crate::tools::impls::coding::exec::registry::claim_completion_wake_for_session(
+            session_id,
+        )
+    {
+        use crate::core::session::turn::background_reminder;
+        let jobs: Vec<_> =
+            crate::tools::impls::coding::exec::registry::list_jobs_for_reminder(session_id)
+                .into_iter()
+                .filter(|job| job.has_unread_output || job.stalled_waiting_input)
+                .collect();
+        if !jobs.is_empty() {
+            info!(
+                "[agent-core] mid-turn background-job note injected ({} job(s), session={})",
+                jobs.len(),
+                session_id
+            );
+            let note = background_reminder::build_completion_notification(&jobs);
+            crate::tools::impls::coding::exec::registry::acknowledge_outputs(
+                &background_reminder::inlined_result_handles(&jobs),
+            );
+            messages.push(serde_json::json!({
+                "role": "user",
+                "content": note,
+            }));
+        }
+    }
+
+    // Stale-todo reminder uses the same injection point so it never lands
+    // between an assistant tool_use and its tool_result rows.
+    state.iterations_since_todo_use = state.iterations_since_todo_use.saturating_add(1);
+    state.iterations_since_todo_reminder = state.iterations_since_todo_reminder.saturating_add(1);
+    if should_inject_todo_reminder(
+        state.iterations_since_todo_use,
+        state.iterations_since_todo_reminder,
+    ) {
+        // Throttle even when the list is empty/completed; rechecking every
+        // following iteration buys nothing.
+        state.iterations_since_todo_reminder = 0;
+        let todos = tokio::task::block_in_place(|| {
+            crate::persistence::db_helpers::todos::get_todos(session_id).unwrap_or_default()
+        });
+        let has_open_todos = todos
+            .iter()
+            .any(|todo| todo.status != "completed" && todo.status != "cancelled");
+        if has_open_todos {
+            info!(
+                "[agent-core] stale-todo reminder injected mid-turn ({} iterations since last manage_todo, session={})",
+                state.iterations_since_todo_use, session_id
+            );
+            messages.push(serde_json::json!({
+                "role": "user",
+                "content": crate::tools::impls::coding::manage_todo::stale_todo_reminder(&todos),
+            }));
+        }
+    }
+
+    let limit_display = config
+        .max_iterations
+        .map_or("∞".to_string(), |max| max.to_string());
+    info!(
+        "[agent-core] iteration {}/{} (session={})",
+        state.iteration, limit_display, session_id
+    );
+
+    LoopControl::Proceed
+}
+
+/// Drain the mid-turn steering buffer into one reminder-wrapped user message.
+/// Returns `true` when anything was injected.
+pub(super) async fn drain_steering_queue(
+    steering_queue: &Option<crate::turn_executor::SteeringQueue>,
+    session_id: &str,
+    messages: &mut Vec<Value>,
+    handler: &dyn TurnEventHandler,
+) -> bool {
+    let Some(queue) = steering_queue else {
+        return false;
+    };
+    let drained: Vec<crate::turn_executor::SteeringInjection> = {
+        let mut guard = queue.lock().await;
+        std::mem::take(&mut *guard)
+    };
+    if drained.is_empty() {
+        return false;
+    }
+
+    info!(
+        "[agent-core] Injecting {} steering message(s) mid-turn (session={})",
+        drained.len(),
+        session_id
+    );
+    let mut bodies = Vec::with_capacity(drained.len());
+    for injection in &drained {
+        handler.on_steering_consumed(session_id, injection);
+        bodies.push(injection.content.clone());
+    }
+    messages.push(serde_json::json!({
+        "role": "user",
+        "content": format!(
+            "<system-reminder>\nThe user sent the following message(s) while you were working. Adjust course accordingly — this may change or refine the current task:\n\n{}\n\nIMPORTANT: After completing your current step, you MUST address the user's message(s) above. Do not ignore them.\n</system-reminder>",
+            bodies.join("\n\n---\n\n")
+        ),
+    }));
+    true
+}

--- a/src-tauri/crates/agent-core/src/core/turn_executor/execute/loop_state.rs
+++ b/src-tauri/crates/agent-core/src/core/turn_executor/execute/loop_state.rs
@@ -1,0 +1,143 @@
+use serde_json::Value;
+
+use crate::model_context::microcompact;
+
+use super::super::context_accounting::ContextUsageSnapshot;
+use super::super::file_tracker;
+use super::super::repeat_guard::RepeatGuard;
+use super::super::stream_error_recovery::RetryBudgets;
+use super::super::types::{TurnConfig, TurnResult};
+use super::super::usage_accumulator::UsageTotals;
+use super::super::usage_telemetry::UsageTelemetryCollector;
+
+/// Mutable state owned by one `execute_turn` invocation.
+///
+/// Keeping every retry counter and one-shot flag together makes the loop's
+/// transition inputs explicit without changing their lifetime or reset rules.
+pub(super) struct TurnLoopState {
+    pub(super) iteration: u32,
+    pub(super) final_content: Option<String>,
+    pub(super) final_is_stream_error: bool,
+    pub(super) usage: UsageTotals,
+    pub(super) usage_telemetry: UsageTelemetryCollector,
+    pub(super) context_usage_snapshot: Option<ContextUsageSnapshot>,
+    pub(super) repeat_guard: RepeatGuard,
+    pub(super) consecutive_errors: u32,
+    pub(super) output_recovery_count: u32,
+    pub(super) tier1_escalated: bool,
+    pub(super) effective_max_tokens: u32,
+    pub(super) retry_budgets: RetryBudgets,
+    pub(super) context_rescue_attempts: u32,
+    pub(super) max_tokens_lowered: bool,
+    pub(super) media_stripped: bool,
+    pub(super) stop_hook_blocks: u32,
+    pub(super) auto_continuations: u32,
+    pub(super) auto_continue_completion_baseline: Option<i64>,
+    pub(super) budget_nudge_sent: bool,
+    pub(super) pending_budget_nudge: Option<String>,
+    pub(super) anti_rush_sent: bool,
+    pub(super) iterations_since_todo_use: u32,
+    pub(super) iterations_since_todo_reminder: u32,
+    pub(super) file_tracker: file_tracker::FileTimeTracker,
+    pub(super) microcompact_config: microcompact::MicrocompactConfig,
+}
+
+impl TurnLoopState {
+    pub(super) fn new(config: &TurnConfig, messages: &[Value]) -> Self {
+        let mut file_tracker = file_tracker::FileTimeTracker::new();
+        // Read-before-edit is session-scoped: seed the fresh per-turn tracker
+        // with every file the transcript already read/wrote so cross-turn edits
+        // aren't false-rejected.
+        file_tracker.seed_from_history(messages);
+
+        Self {
+            iteration: 0,
+            final_content: None,
+            final_is_stream_error: false,
+            usage: UsageTotals::default(),
+            usage_telemetry: UsageTelemetryCollector::default(),
+            context_usage_snapshot: None,
+            repeat_guard: RepeatGuard::default(),
+            consecutive_errors: 0,
+            output_recovery_count: 0,
+            tier1_escalated: false,
+            effective_max_tokens: config.max_tokens,
+            retry_budgets: RetryBudgets::default(),
+            context_rescue_attempts: 0,
+            max_tokens_lowered: false,
+            media_stripped: false,
+            stop_hook_blocks: 0,
+            auto_continuations: 0,
+            auto_continue_completion_baseline: None,
+            budget_nudge_sent: false,
+            pending_budget_nudge: None,
+            anti_rush_sent: false,
+            iterations_since_todo_use: 0,
+            iterations_since_todo_reminder: 0,
+            file_tracker,
+            microcompact_config: microcompact::MicrocompactConfig::default(),
+        }
+    }
+}
+
+/// Coordinator decision produced by one execution phase.
+pub(super) enum LoopControl {
+    Proceed,
+    Continue,
+    Break,
+}
+
+pub(super) fn finish_turn(
+    mut state: TurnLoopState,
+    messages: &[Value],
+    config: &TurnConfig,
+    session_id: &str,
+    handler: &dyn super::super::types::TurnEventHandler,
+) -> TurnResult {
+    let mut hit_max_iterations = false;
+    if let Some(max) = config.max_iterations {
+        if state.final_content.is_none() && state.iteration >= max {
+            hit_max_iterations = true;
+            tracing::warn!(
+                "[agent-core] Hit max iterations ({}) for session {}",
+                max,
+                session_id
+            );
+            state.final_content = Some(format!(
+                "I reached the maximum number of iterations ({}) for this turn. \
+                 The task may not be fully complete — you can send a follow-up message to continue.",
+                max
+            ));
+        }
+    }
+
+    state.usage.finalize();
+
+    // Persist terminal assistant content exactly once. Stream-error notices
+    // are user-facing transport errors and must not enter LLM history.
+    if let Some(ref text) = state.final_content {
+        if !text.is_empty() && !state.final_is_stream_error {
+            handler.on_assistant_iteration_complete(
+                session_id,
+                Some(text.as_str()),
+                false,
+                &config.model,
+            );
+        }
+    }
+
+    TurnResult {
+        content: state.final_content,
+        messages: messages.to_vec(),
+        is_stream_error: state.final_is_stream_error,
+        hit_max_iterations,
+        prompt_tokens: state.usage.prompt,
+        completion_tokens: state.usage.completion,
+        total_tokens: state.usage.total,
+        context_tokens: state.usage.last_prompt,
+        context_usage_snapshot: state.context_usage_snapshot,
+        cache_read_tokens: state.usage.cache_read,
+        cache_write_tokens: state.usage.cache_write,
+        usage_telemetry: state.usage_telemetry.finish(),
+    }
+}

--- a/src-tauri/crates/agent-core/src/core/turn_executor/execute/provider_iteration.rs
+++ b/src-tauri/crates/agent-core/src/core/turn_executor/execute/provider_iteration.rs
@@ -1,0 +1,177 @@
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use serde_json::Value;
+use tracing::{info, warn};
+
+use crate::model_context::microcompact;
+use crate::providers::traits::{LLMProvider, LLMResponse, ProviderError, StreamDelta};
+use crate::tools::policy::ResolvedToolPolicy;
+use crate::tools::registry::ToolRegistry;
+
+#[cfg(debug_assertions)]
+use super::super::provider_request_capture;
+use super::super::screenshot::resolve_screenshot_markers;
+use super::super::stream_normalizer::{NormalizedStreamEvent, TurnStreamNormalizer};
+use super::super::tool_execution::is_cancelled;
+use super::super::types::{TurnConfig, TurnEventHandler};
+use super::loop_state::TurnLoopState;
+
+/// Provider-visible request inputs after history repair, compaction, media
+/// resolution, metadata stripping, and tool-budget projection.
+pub(super) struct PreparedRequest {
+    pub(super) messages: Vec<Value>,
+    pub(super) tool_definitions: Vec<Value>,
+}
+
+pub(super) fn prepare_request(
+    state: &mut TurnLoopState,
+    messages: &mut Vec<Value>,
+    tools: &ToolRegistry,
+    policy: &ResolvedToolPolicy,
+    config: &TurnConfig,
+    session_id: &str,
+) -> PreparedRequest {
+    // Re-run full-history pairing normalization before every provider call;
+    // dispatch-time repair cannot see corruption introduced mid-turn.
+    if crate::session::recovery::ensure_tool_result_pairing(messages) {
+        warn!(
+            "[agent-core] tool-pairing normalization repaired history mid-turn (session={})",
+            session_id
+        );
+    }
+
+    microcompact::microcompact_messages(messages, &state.microcompact_config);
+    microcompact::cap_recent_tool_images(messages);
+
+    info!(
+        "[agent-core] collecting tool definitions (session={})",
+        session_id
+    );
+    let tool_definitions = tools.get_definitions_budgeted(policy);
+    info!(
+        "[agent-core] collected {} tool definitions (session={})",
+        tool_definitions.len(),
+        session_id
+    );
+
+    // Resolve screenshots, then remove internal timestamps before sending.
+    let mut provider_messages = if let Some(ref store) = config.screenshot_store {
+        resolve_screenshot_markers(messages, store, &config.model)
+    } else {
+        messages.clone()
+    };
+    microcompact::strip_timestamp_metadata(&mut provider_messages);
+    info!(
+        "[agent-core] built {} LLM messages for provider (session={})",
+        provider_messages.len(),
+        session_id
+    );
+
+    PreparedRequest {
+        messages: provider_messages,
+        tool_definitions,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn call_provider(
+    state: &TurnLoopState,
+    request: &PreparedRequest,
+    provider: &dyn LLMProvider,
+    config: &TurnConfig,
+    session_id: &str,
+    handler: &dyn TurnEventHandler,
+    cancel_flag: Option<&Arc<AtomicBool>>,
+) -> Result<LLMResponse, ProviderError> {
+    let stream_normalizer_for_cb = std::sync::Mutex::new(TurnStreamNormalizer::new());
+    provider.set_session_context(session_id);
+
+    #[cfg(debug_assertions)]
+    provider_request_capture::capture(
+        session_id,
+        state.iteration,
+        &config.model,
+        state.effective_max_tokens,
+        config.temperature,
+        &request.messages,
+        &request.tool_definitions,
+    );
+
+    let cancel_for_stream = cancel_flag.cloned();
+    let cancel_ref = cancel_flag.as_ref().map(|flag| flag.as_ref());
+    let session_id_for_stream = session_id.to_string();
+    if state.retry_budgets.non_streaming_fallback {
+        // Repeated SSE failure with no partial output gets one whole-response
+        // request; the assembled response follows the same completion path.
+        info!(
+            "[agent-core] Using non-streaming request for this attempt (session={})",
+            session_id
+        );
+        provider
+            .chat(
+                &request.messages,
+                Some(&request.tool_definitions),
+                &config.model,
+                state.effective_max_tokens,
+                config.temperature,
+            )
+            .await
+    } else {
+        provider
+            .chat_streaming(
+                &request.messages,
+                Some(&request.tool_definitions),
+                &config.model,
+                state.effective_max_tokens,
+                config.temperature,
+                &move |delta: StreamDelta| {
+                    if is_cancelled(cancel_for_stream.as_ref()) {
+                        return;
+                    }
+                    let normalized_events = match stream_normalizer_for_cb.lock() {
+                        Ok(mut normalizer) => normalizer.ingest_delta(delta),
+                        Err(_) => {
+                            warn!("[agent-core] stream normalizer lock poisoned; dropping delta");
+                            return;
+                        }
+                    };
+                    for event in normalized_events {
+                        match event {
+                            NormalizedStreamEvent::MessageDelta(content) => {
+                                handler.on_message_delta(&session_id_for_stream, &content);
+                            }
+                            NormalizedStreamEvent::ThinkingDelta(reasoning) => {
+                                handler.on_thinking_delta(&session_id_for_stream, &reasoning);
+                            }
+                            NormalizedStreamEvent::ToolCallDelta(delta) => {
+                                handler.on_tool_call_delta(
+                                    &session_id_for_stream,
+                                    delta.index,
+                                    delta.id.as_deref(),
+                                    delta.name.as_deref(),
+                                    delta.arguments_delta.as_deref(),
+                                );
+                            }
+                            NormalizedStreamEvent::UnknownFrame {
+                                provider,
+                                event_type,
+                                sample,
+                            } => {
+                                warn!(
+                                    provider,
+                                    event_type,
+                                    sample,
+                                    "[agent-core] provider stream emitted unknown frame"
+                                );
+                            }
+                            NormalizedStreamEvent::Finish { .. }
+                            | NormalizedStreamEvent::FlushSegment(_) => {}
+                        }
+                    }
+                },
+                cancel_ref,
+            )
+            .await
+    }
+}

--- a/src-tauri/crates/agent-core/src/core/turn_executor/execute/recovery.rs
+++ b/src-tauri/crates/agent-core/src/core/turn_executor/execute/recovery.rs
@@ -1,0 +1,318 @@
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use serde_json::Value;
+use tracing::{info, warn};
+
+use crate::model_context::microcompact;
+use crate::providers::traits::{finish_reason as finish, LLMResponse, ProviderError};
+
+use super::super::backoff::MAX_CONTEXT_RESCUE_ATTEMPTS;
+use super::super::context_accounting::ContextUsageSnapshot;
+use super::super::continuation::{ANTI_RUSH_MIN_PERCENT, ANTI_RUSH_MIN_WINDOW};
+use super::super::helpers::add_assistant_message;
+use super::super::stream_error_recovery::{handle_stream_error, StreamErrorOutcome};
+use super::super::tool_execution::is_cancelled;
+use super::super::types::{TurnConfig, TurnEventHandler};
+use super::loop_state::{LoopControl, TurnLoopState};
+use super::provider_iteration::PreparedRequest;
+
+pub(super) fn handle_provider_error(
+    error: ProviderError,
+    state: &mut TurnLoopState,
+    messages: &mut Vec<Value>,
+    config: &TurnConfig,
+    session_id: &str,
+) -> Result<LoopControl, String> {
+    match error {
+        ProviderError::Cancelled => {
+            info!(
+                "[agent-core] Stream cancelled by user (session={})",
+                session_id
+            );
+            if config.persist_cancel_marker {
+                crate::core::session::persistence::mark_turn_cancelled(session_id);
+            }
+            state.final_content = None;
+            Ok(LoopControl::Break)
+        }
+        error @ ProviderError::ContextTooLong(_)
+            if state.context_rescue_attempts < MAX_CONTEXT_RESCUE_ATTEMPTS =>
+        {
+            // First force-clear old tool results; if that frees nothing,
+            // fall back to head-preserving hard truncation.
+            state.context_rescue_attempts += 1;
+            warn!(
+                "[agent-core] ContextTooLong (session={}), rescue attempt {}/{}: {}",
+                session_id, state.context_rescue_attempts, MAX_CONTEXT_RESCUE_ATTEMPTS, error
+            );
+            let stats =
+                microcompact::force_microcompact_messages(messages, &state.microcompact_config);
+            if stats.chars_saved == 0 && stats.images_cleared == 0 {
+                let window = crate::providers::model_capabilities::resolve_effective_context_window(
+                    &config.model,
+                    config.account_id.as_deref(),
+                    config.context_window_override,
+                );
+                let mut budget = window.saturating_mul(3) / 4;
+                // Calibrate the estimated-token budget against the provider's
+                // actual rejected count so each rescue guarantees progress.
+                let estimated =
+                    crate::model_context::compaction::ContextCompactor::estimate_messages_tokens(
+                        messages,
+                    );
+                if let Some(actual) = crate::model_context::compaction::ContextCompactor::parse_actual_tokens_from_error(
+                    &error.to_string(),
+                ) {
+                    budget = crate::model_context::compaction::ContextCompactor::calibrate_budget(
+                        budget, estimated, actual,
+                    );
+                }
+                let mut truncated =
+                    crate::model_context::compaction::ContextCompactor::simple_truncate(
+                        messages, budget,
+                    );
+                while truncated.len() == messages.len() && budget > 10_000 {
+                    budget /= 2;
+                    truncated = crate::model_context::compaction::ContextCompactor::simple_truncate(
+                        messages, budget,
+                    );
+                }
+                warn!(
+                    "[agent-core] Context rescue truncation: {} -> {} messages, budget ~{} est-tokens (session={})",
+                    messages.len(),
+                    truncated.len(),
+                    budget,
+                    session_id
+                );
+                *messages = truncated;
+            }
+            Ok(LoopControl::Continue)
+        }
+        error @ ProviderError::MaxTokensExceedContext(_) if !state.max_tokens_lowered => {
+            // Prompt fits; lower only the output budget once before falling
+            // through to the provider error path on another overflow.
+            state.max_tokens_lowered = true;
+            let lowered = (state.effective_max_tokens / 2).max(1024);
+            warn!(
+                "[agent-core] max_tokens + input exceeds context (session={}); lowering max_tokens {} -> {} and retrying: {}",
+                session_id, state.effective_max_tokens, lowered, error
+            );
+            state.effective_max_tokens = lowered;
+            Ok(LoopControl::Continue)
+        }
+        error @ ProviderError::MediaTooLarge(_) if !state.media_stripped => {
+            state.media_stripped = true;
+            let stripped = strip_historical_media_blocks(messages);
+            warn!(
+                "[agent-core] Media too large (session={}); stripped {} historical media block(s) and retrying: {}",
+                session_id, stripped, error
+            );
+            if stripped == 0 {
+                return Err(format!("LLM error: {}", error));
+            }
+            Ok(LoopControl::Continue)
+        }
+        error => Err(format!("LLM error: {}", error)),
+    }
+}
+
+pub(super) fn handle_post_stream_cancellation(
+    response: &LLMResponse,
+    state: &mut TurnLoopState,
+    messages: &mut Vec<Value>,
+    config: &TurnConfig,
+    session_id: &str,
+    handler: &dyn TurnEventHandler,
+    cancel_flag: Option<&Arc<AtomicBool>>,
+) -> LoopControl {
+    if !is_cancelled(cancel_flag) {
+        return LoopControl::Proceed;
+    }
+
+    info!(
+        "[agent-core] Cancelled after streaming (session={})",
+        session_id
+    );
+    // Keep fully assembled partial text so the next turn sees what the user
+    // already saw before cancellation.
+    if let Some(partial) = response
+        .content
+        .as_deref()
+        .filter(|text| !text.trim().is_empty())
+    {
+        add_assistant_message(
+            messages,
+            Some(partial),
+            None,
+            response.reasoning_content.as_deref(),
+        );
+        handler.on_assistant_iteration_complete(session_id, Some(partial), false, &config.model);
+    }
+    if config.persist_cancel_marker {
+        crate::core::session::persistence::mark_turn_cancelled(session_id);
+    }
+    state.final_content = None;
+    LoopControl::Break
+}
+
+pub(super) fn record_usage(
+    response: &LLMResponse,
+    request: &PreparedRequest,
+    state: &mut TurnLoopState,
+    config: &TurnConfig,
+    session_id: &str,
+    handler: &dyn TurnEventHandler,
+) {
+    if response.usage.is_empty() {
+        return;
+    }
+
+    state.usage.accumulate(&response.usage, session_id);
+    let context_window =
+        crate::core::providers::model_capabilities::resolve_effective_context_window(
+            &config.model,
+            config.account_id.as_deref(),
+            config.context_window_override,
+        ) as i64;
+    let snapshot = ContextUsageSnapshot::from_payload(
+        &request.messages,
+        &request.tool_definitions,
+        state.usage.last_prompt,
+        state.usage.cache_read,
+        state.usage.cache_write,
+        Some(context_window),
+    );
+    handler.on_context_usage(session_id, &snapshot);
+    state.usage_telemetry.record_llm_span(
+        state.iteration as i64,
+        &response.usage,
+        state.usage.last_prompt,
+        &response.tool_calls,
+        Some(&snapshot),
+    );
+
+    // Queue one model-side budget nudge for the next safe injection point.
+    if !state.budget_nudge_sent {
+        if let Some(level @ ("error" | "blocking")) = snapshot.warning_level() {
+            state.budget_nudge_sent = true;
+            let percent = snapshot.percent_used.unwrap_or(0.0);
+            state.pending_budget_nudge = Some(format!(
+                "<system-reminder>\nContext window is {percent:.0}% full ({level}). Prioritize finishing the current task with the remaining budget: prefer targeted reads over broad exploration, avoid re-reading large files, and summarize instead of quoting long output. The system will compact older history automatically on the next turn.\n</system-reminder>"
+            ));
+            info!(
+                "[agent-core] Queued context-budget nudge ({level}, {percent:.1}% used, session={session_id})"
+            );
+        }
+    }
+
+    // Large-window anti-rush reassurance is once-per-turn and subordinate to
+    // the error-tier budget nudge.
+    if !state.anti_rush_sent
+        && !state.budget_nudge_sent
+        && context_window >= ANTI_RUSH_MIN_WINDOW
+        && snapshot.percent_used.unwrap_or(0.0) >= ANTI_RUSH_MIN_PERCENT
+    {
+        state.anti_rush_sent = true;
+        state.pending_budget_nudge = Some(
+            "<system-reminder>\nNote: automatic compaction is enabled — older messages will be summarized when the context window fills, so the conversation is not limited by it. There is no need to rush or wrap up early; continue working at full quality.\n</system-reminder>".to_string(),
+        );
+    }
+
+    state.context_usage_snapshot = Some(snapshot);
+}
+
+pub(super) async fn handle_stream_recovery(
+    response: &LLMResponse,
+    state: &mut TurnLoopState,
+    messages: &mut Vec<Value>,
+    cancel_flag: Option<&Arc<AtomicBool>>,
+    session_id: &str,
+    handler: &dyn TurnEventHandler,
+) -> LoopControl {
+    if response.finish_reason != finish::STREAM_ERROR {
+        return LoopControl::Proceed;
+    }
+
+    match handle_stream_error(
+        response,
+        &mut state.retry_budgets,
+        messages,
+        cancel_flag,
+        session_id,
+        handler,
+    )
+    .await
+    {
+        StreamErrorOutcome::BudgetExhausted { user_message } => {
+            state.final_content = Some(user_message);
+            state.final_is_stream_error = true;
+            LoopControl::Break
+        }
+        StreamErrorOutcome::CancelledDuringBackoff => {
+            state.final_content = None;
+            LoopControl::Break
+        }
+        StreamErrorOutcome::Retry => LoopControl::Continue,
+    }
+}
+
+/// Replace media in historical messages while retaining the latest user
+/// message media, which is usually the input the current turn is about.
+fn strip_historical_media_blocks(messages: &mut [Value]) -> usize {
+    let last_user_idx = messages
+        .iter()
+        .rposition(|message| message.get("role").and_then(Value::as_str) == Some("user"));
+
+    let mut stripped = 0usize;
+    for (index, message) in messages.iter_mut().enumerate() {
+        if Some(index) == last_user_idx {
+            continue;
+        }
+        let Some(blocks) = message.get_mut("content").and_then(Value::as_array_mut) else {
+            continue;
+        };
+        for block in blocks.iter_mut() {
+            let block_type = block.get("type").and_then(Value::as_str).unwrap_or("");
+            if matches!(block_type, "image_url" | "image" | "document") {
+                *block = serde_json::json!({
+                    "type": "text",
+                    "text": "[media removed: this image/document was too large to keep re-sending. Re-read the source file if you need it again.]",
+                });
+                stripped += 1;
+            }
+        }
+    }
+    stripped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_historical_media_blocks;
+    use serde_json::json;
+
+    #[test]
+    fn strips_old_media_keeps_last_user_media() {
+        let mut messages = vec![
+            json!({"role": "user", "content": [
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,OLD"}},
+                {"type": "text", "text": "old screenshot"},
+            ]}),
+            json!({"role": "assistant", "content": "looked at it"}),
+            json!({"role": "user", "content": [
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,NEW"}},
+                {"type": "text", "text": "new screenshot"},
+            ]}),
+        ];
+        let stripped = strip_historical_media_blocks(&mut messages);
+        assert_eq!(stripped, 1);
+        assert_eq!(messages[0]["content"][0]["type"], "text");
+        assert_eq!(messages[2]["content"][0]["type"], "image_url");
+    }
+
+    #[test]
+    fn no_media_returns_zero() {
+        let mut messages = vec![json!({"role": "user", "content": "plain text"})];
+        assert_eq!(strip_historical_media_blocks(&mut messages), 0);
+    }
+}

--- a/src-tauri/crates/agent-core/src/core/turn_executor/execute/tool_iteration.rs
+++ b/src-tauri/crates/agent-core/src/core/turn_executor/execute/tool_iteration.rs
@@ -1,0 +1,205 @@
+use std::collections::HashSet;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use serde_json::Value;
+use tracing::warn;
+
+use crate::providers::traits::LLMResponse;
+use crate::specialization::policies::activation::SessionScopedContextActivator;
+use crate::tools::policy::ResolvedToolPolicy;
+use crate::tools::registry::ToolRegistry;
+
+use super::super::helpers::{add_assistant_message, add_tool_result};
+use super::super::repeat_guard::RepeatVerdict;
+use super::super::tool_execution::{execute_tool_calls, ToolBatchOutcome};
+use super::super::types::{PermissionProvider, TurnConfig, TurnEventHandler};
+use super::loop_state::{LoopControl, TurnLoopState};
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn execute_tool_iteration(
+    response: &LLMResponse,
+    state: &mut TurnLoopState,
+    messages: &mut Vec<Value>,
+    tools: &ToolRegistry,
+    policy: &ResolvedToolPolicy,
+    config: &TurnConfig,
+    session_id: &str,
+    handler: &dyn TurnEventHandler,
+    permission_provider: Option<&dyn PermissionProvider>,
+    cancel_flag: Option<&Arc<AtomicBool>>,
+    policy_context_activator: Option<&SessionScopedContextActivator>,
+) -> LoopControl {
+    let current_signature = response
+        .tool_calls
+        .iter()
+        .map(|call| format!("{}:{}", call.name, call.arguments))
+        .collect::<Vec<_>>()
+        .join("|");
+
+    // Progress-aware tools can repeat identical arguments while the observed
+    // job advances. A batch fingerprint exists when any call supplies one.
+    let current_fingerprint = {
+        let parts: Vec<Option<String>> = response
+            .tool_calls
+            .iter()
+            .map(|call| {
+                tools
+                    .get(&call.name)
+                    .and_then(|tool| tool.progress_fingerprint(&call.arguments))
+            })
+            .collect();
+        if parts.iter().any(Option::is_some) {
+            Some(
+                parts
+                    .into_iter()
+                    .map(|part| part.unwrap_or_default())
+                    .collect::<Vec<_>>()
+                    .join("|"),
+            )
+        } else {
+            None
+        }
+    };
+
+    if let RepeatVerdict::Break {
+        executed_attempts,
+        progress_aware,
+    } = state
+        .repeat_guard
+        .observe(current_signature.clone(), current_fingerprint)
+    {
+        let preview = crate::utils::safe_truncate_chars_to_string(&current_signature, 200);
+        warn!(
+            "[agent-core] Breaking loop after {} identical no-progress tool calls (progress_aware={}): {}",
+            executed_attempts, progress_aware, preview
+        );
+        state.final_content = Some(if progress_aware {
+            format!(
+                "The last {} checks of the same background job(s) found no new output or \
+                 status change, so I'm pausing this turn instead of continuing to poll. \
+                 If a job is still running, the session resumes automatically when it \
+                 completes; you can also send a message to continue sooner. The repeated \
+                 tool call was: {}",
+                executed_attempts, preview
+            )
+        } else {
+            format!(
+                "I called the same tool with identical arguments {} times in a row \
+                 without new information, so I stopped before repeating it again to \
+                 avoid an infinite loop. The last tool call was: {}",
+                executed_attempts, preview
+            )
+        });
+        return LoopControl::Break;
+    }
+
+    let tool_call_values: Vec<Value> = response
+        .tool_calls
+        .iter()
+        .map(|call| {
+            let mut object = serde_json::json!({
+                "id": call.id,
+                "type": "function",
+                "function": {
+                    "name": call.name,
+                    "arguments": call.arguments.to_string(),
+                }
+            });
+            if let Some(signature) = &call.thought_signature {
+                if signature.get("anthropic").is_some() {
+                    object["extra_content"] = signature.clone();
+                } else {
+                    object["extra_content"] = serde_json::json!({
+                        "google": { "thought_signature": signature }
+                    });
+                }
+            }
+            object
+        })
+        .collect();
+
+    add_assistant_message(
+        messages,
+        response.content.as_deref(),
+        Some(&tool_call_values),
+        response.reasoning_content.as_deref(),
+    );
+    handler.on_assistant_iteration_complete(
+        session_id,
+        response.content.as_deref(),
+        true,
+        &config.model,
+    );
+
+    if response
+        .tool_calls
+        .iter()
+        .any(|call| call.name == crate::tools::names::MANAGE_TODO)
+    {
+        state.iterations_since_todo_use = 0;
+    }
+
+    let (_count, tool_execution_usage, outcome) = execute_tool_calls(
+        messages,
+        &response.tool_calls,
+        tools,
+        policy,
+        session_id,
+        &config.turn_intent_id,
+        &config.projected_inbox_ids,
+        handler,
+        permission_provider,
+        cancel_flag,
+        &mut state.file_tracker,
+        &mut state.consecutive_errors,
+        policy_context_activator,
+        config.max_tool_use_concurrency,
+    )
+    .await;
+    state
+        .usage_telemetry
+        .record_tool_results(state.iteration as i64, tool_execution_usage);
+
+    // Backfill every tool_use still missing a result after EarlyExit so the
+    // next provider request retains valid assistant/tool pairing.
+    let existing_ids: HashSet<String> = messages
+        .iter()
+        .filter_map(|message| {
+            message
+                .get("tool_call_id")
+                .and_then(Value::as_str)
+                .map(String::from)
+        })
+        .collect();
+    for call in &response.tool_calls {
+        if !existing_ids.contains(&call.id) {
+            add_tool_result(
+                messages,
+                &call.id,
+                &call.name,
+                "[cancelled — tool was not executed]",
+                true,
+            );
+        }
+    }
+
+    match outcome {
+        ToolBatchOutcome::Continue => LoopControl::Continue,
+        ToolBatchOutcome::EndTurn(content) => {
+            state.final_content = Some(content);
+            LoopControl::Break
+        }
+        ToolBatchOutcome::Cancelled => {
+            if config.persist_cancel_marker {
+                crate::core::session::persistence::mark_turn_cancelled(session_id);
+            }
+            state.final_content = None;
+            LoopControl::Break
+        }
+        ToolBatchOutcome::ErrorLoop(message) => {
+            state.final_content = Some(message);
+            LoopControl::Break
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The core execute_turn implementation combined 1,100-plus lines of per-turn state, input injection, request preparation, provider streaming, recovery, usage accounting, tool execution, completion gates, and result projection in one function. That made the exact transition order and ownership of bounded retry/continuation state difficult to review without changing behavior.

## Solution

Keep execute.rs as the stable public execute_turn facade and state-machine coordinator, with one TurnLoopState owner for all counters, one-shot flags, usage, retry budgets, repeat detection, and file tracking. Move cohesive phases into private modules for iteration input and reminders, provider request/stream execution, recovery and usage, tool iterations, and non-tool completion.

The coordinator preserves the original order: max-iteration and cancellation gates; hook, steering, budget, changed-file, background-job, and todo injection; pairing repair, compaction, image cap, tool projection, screenshot resolution, and metadata stripping; provider capture and streaming; provider/cancellation/context/max-token/media recovery; usage and stream retry; retry reset; tool execution and pairing backfill; length recovery; final steering, Stop hooks, auto-continuation, empty-response fallback; and terminal persistence/result assembly.

The public execute_turn signature and TurnResult contract are unchanged. Every private leaf is 318 lines or fewer, and no second loop, queue, timer, task, cache, or lifecycle owner was introduced.

## Potential risks

The primary risk is an accidental control-flow reorder at a helper boundary, especially around cancellation persistence, stream retry reset, assistant/tool pairing, Stop-hook continuation, and final assistant persistence. Targeted execute-turn retry tests, turn-executor tests, compile/Clippy checks, a phase-order audit, exact public-signature comparison, runtime-string parity, and one-for-one critical call counts cover those paths.

The async helper split changes the compiler-generated future layout, but it adds no new task, timer, backoff, lock, queue, or await-triggered operation. Existing request materialization, stream normalization, backoff, tool concurrency, repeat bounds, and per-turn allocation cadence remain attached to the same iteration and branch.

No provider payload schema, finish-reason string, persistence format, dependency, configuration, IPC contract, or migration changed. Rollback is a normal revert of this commit. Live provider streaming, cancellation during a real network request, and real tool execution were not manually exercised; those are the main unverified runtime paths.

## Audit

The architecture audit covered all 10 layers:

- Compilation correctness: agent_core all-target check and Clippy with warnings denied passed.
- Dead code and structural deduplication: one public coordinator owns the only loop; every new private phase is called from that coordinator; no parallel dispatcher or unused facade was added.
- Naming consistency: phase and state names describe the existing turn domain without renaming public types or commands.
- Semantic overloading: iteration, recovery, completion, cancellation, and retry retain one meaning each; the audit found no new overloaded domain term.
- Default branches: all ProviderError, finish-reason, tool-outcome, stream-outcome, empty-response, and optional-config fallbacks retain their original values and order.
- Cross-domain leakage: the implementation remains private beneath turn_executor and imports existing provider/tool/session owners rather than moving their responsibilities.
- New-developer clarity: the 159-line coordinator exposes the state machine, while cohesive leaves range from 143 to 318 lines.
- Wire protocol: provider-visible message/tool construction and stream normalization stay in the same order; the 141 runtime string literals match the base exactly as a multiset.
- Init parity: set_session_key remains the sole pre-loop initialization; set_session_context and debug request capture remain once per provider attempt and before dispatch.
- Resolver symmetry: both context recovery and usage accounting retain the same model, account, and context-window override inputs; every one-shot recovery and continuation field is initialized once in TurnLoopState and mutated only by its owning phase.

Performance guard:

| Area | Verdict | Evidence | Change or reason kept | Verification |
| --- | --- | --- | --- | --- |
| Background work | keep | No new task, timer, retry loop, poller, or listener | Existing stream backoff and heartbeat remain owned by stream_error_recovery | Retry tests and call-chain audit |
| Memory | keep | All new state is per-turn and bounded by existing caps | Existing Vec request materialization, retry budgets, repeat guard, and tool-result backfill remain per iteration | Runtime literal/call-count and ownership audit |
| Scope/isolation | keep | Session id, steering queue, file tracker, cancel flag, and tool registry inputs are unchanged | One TurnLoopState references existing owners without duplicating them | Signature and phase-order audit |
| Rendering/hot path | keep | Stream deltas still pass through one mutex-backed TurnStreamNormalizer and the same callbacks | No coalescing, allocation, payload, or callback cadence changed | Compile, Clippy, and targeted tests |

Performance verdict: pass. This is a structural refactor and does not claim a runtime performance improvement.

## Verification

- rustfmt --edition 2021 src-tauri/crates/agent-core/src/core/turn_executor/execute.rs src-tauri/crates/agent-core/src/core/turn_executor/execute/*.rs — passed
- cargo check --manifest-path src-tauri/Cargo.toml -p agent_core --all-targets — passed
- cargo test --manifest-path src-tauri/Cargo.toml -p agent_core core::turn_executor::execute:: — passed, 2 tests
- cargo test --manifest-path src-tauri/Cargo.toml -p agent_core core::turn_executor::retry_tests:: — passed, 3 tests
- cargo test --manifest-path src-tauri/Cargo.toml -p agent_core core::turn_executor::tests:: — passed, 31 tests
- cargo clippy --manifest-path src-tauri/Cargo.toml -p agent_core --all-targets -- -D warnings — passed; Cargo separately reported the pre-existing future-incompatibility notice for block 0.1.6
- git diff --check origin/develop...HEAD — passed
- Signature and runtime-literal audit — execute_turn parameters/result match exactly; all 141 runtime string literals match the base after Rust line-continuation normalization
- Critical call audit — cancellation markers, steering drains, pairing/compaction, provider capture/dispatch, stream recovery/reset, tool execution, assistant/tool writes, Stop hooks, and auto-continuation remain one-for-one
- Scope and secret audit — only the seven execute facade/module files changed; no credentials, private keys, personal paths, debug artifacts, caches, or unrelated formatting were found
- git fetch origin develop plus merge-base comparison — branch base matches current origin/develop at 31eba1f10a86f77d8ed5c97ed660e4434cf70143
- Not run: live provider, real cancellation, real tool, rendered desktop, or performance measurement; no UI changed and this PR makes no runtime-improvement claim
- The linked worktree does not contain the Husky bootstrap file, so the commit used core.hooksPath disabled after the equivalent required checks were run directly