### PR TITLE
fix(chat): align creator and session composer chrome

### DIFF
--- a/src/config/composerStackTokens.test.ts
+++ b/src/config/composerStackTokens.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from "vitest";
 
-import { COMPOSER_BOTTOM_DOCK_PADDING_CLASS } from "./composerStackTokens";
+import {
+  COMPOSER_BOTTOM_DOCK_PADDING_CLASS,
+  COMPOSER_HORIZONTAL_GUTTER_CLASS,
+} from "./composerStackTokens";
 
 describe("composer stack tokens", () => {
   it("keeps every bottom-docked composer 12px from its surface edge", () => {
     expect(COMPOSER_BOTTOM_DOCK_PADDING_CLASS).toBe("pb-3");
+  });
+
+  it("keeps launchpad and in-chat composers on the same responsive gutter", () => {
+    expect(COMPOSER_HORIZONTAL_GUTTER_CLASS).toBe("px-2");
   });
 });

--- a/src/config/composerStackTokens.ts
+++ b/src/config/composerStackTokens.ts
@@ -15,6 +15,9 @@
 /** Shared distance between every bottom-docked input/composer and the page edge. */
 export const COMPOSER_BOTTOM_DOCK_PADDING_CLASS = "pb-3";
 
+/** Shared responsive horizontal inset for chat and creator composers. */
+export const COMPOSER_HORIZONTAL_GUTTER_CLASS = "px-2";
+
 /** Shell border — stacks above input; no bottom border. Matches composer card border weight. */
 export const CHAT_COMPOSER_STACK_BAR_SHELL_CLASSES =
   "border-x border-t border-solid border-border-2";

--- a/src/engines/ChatPanel/ChatFloatingComposer.tsx
+++ b/src/engines/ChatPanel/ChatFloatingComposer.tsx
@@ -5,7 +5,10 @@ import { useTranslation } from "react-i18next";
 import type { AgentOrgMemberIntervention } from "@src/api/tauri/agent";
 import Button from "@src/components/Button";
 import { PILL_CONTROL_IDLE_SURFACE_CLASS } from "@src/components/CompoundPill/config";
-import { COMPOSER_BOTTOM_DOCK_PADDING_CLASS } from "@src/config/composerStackTokens";
+import {
+  COMPOSER_BOTTOM_DOCK_PADDING_CLASS,
+  COMPOSER_HORIZONTAL_GUTTER_CLASS,
+} from "@src/config/composerStackTokens";
 import { DETAIL_PANEL_TOKENS } from "@src/config/detailPanelTokens";
 import {
   ChatRetryBanner,
@@ -216,7 +219,7 @@ const ChatFloatingComposer: React.FC<ChatFloatingComposerProps> = memo(
     return (
       <div
         ref={composerRef}
-        className={`absolute bottom-0 left-0 right-0 z-50 flex w-full flex-shrink-0 flex-col items-center px-2 pt-1 ${COMPOSER_BOTTOM_DOCK_PADDING_CLASS}`}
+        className={`absolute bottom-0 left-0 right-0 z-50 flex w-full flex-shrink-0 flex-col items-center pt-1 ${COMPOSER_HORIZONTAL_GUTTER_CLASS} ${COMPOSER_BOTTOM_DOCK_PADDING_CLASS}`}
       >
         <div
           aria-hidden

--- a/src/engines/ChatPanel/InputArea/components/InputAreaChrome.test.ts
+++ b/src/engines/ChatPanel/InputArea/components/InputAreaChrome.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { act, createElement, createRef } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ComposerInputRef } from "@src/components/ComposerInput";
+
+import { InputAreaTopRows } from "./InputAreaChrome";
+
+vi.mock("../ChatHeader", () => ({ default: () => null }));
+vi.mock("./PlanTodoPill", () => ({ default: () => null }));
+vi.mock("./PinnedActionsBar", async () => {
+  const ReactModule = await import("react");
+  return {
+    default: ({ showPinnedActions }: { showPinnedActions?: boolean }) =>
+      ReactModule.createElement("div", {
+        "data-testid": "pinned-actions-bar",
+        "data-visible": String(showPinnedActions),
+      }),
+  };
+});
+
+const actEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+describe("InputAreaTopRows", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("applies the supplied pinned-action visibility inside a session", () => {
+    act(() => {
+      root.render(
+        createElement(InputAreaTopRows, {
+          composerInputRef: createRef<ComposerInputRef>(),
+          isEditMode: false,
+          omitChatHeader: true,
+          showPinnedActions: false,
+        })
+      );
+    });
+
+    const pinnedActions = container.querySelector(
+      '[data-testid="pinned-actions-bar"]'
+    );
+    expect(pinnedActions?.getAttribute("data-visible")).toBe("false");
+  });
+});

--- a/src/engines/ChatPanel/InputArea/components/InputAreaChrome.tsx
+++ b/src/engines/ChatPanel/InputArea/components/InputAreaChrome.tsx
@@ -18,6 +18,7 @@ interface TopRowsProps {
     typeof PinnedActionsBar
   >["composerInputRef"];
   sessionId?: string;
+  showPinnedActions: boolean;
   skillWorkspacePaths?: string[];
 }
 
@@ -28,28 +29,32 @@ export const InputAreaTopRows: React.FC<TopRowsProps> = ({
   topRowTrailingContent,
   composerInputRef,
   sessionId,
+  showPinnedActions,
   skillWorkspacePaths,
-}) => (
-  <>
-    {!isEditMode && !omitChatHeader && <ChatHeader />}
-    {!isEditMode && (
-      <div className="relative z-10 flex min-w-0 items-center gap-1 px-0.5 pb-1.5">
-        <PinnedActionsBar
-          composerInputRef={composerInputRef}
-          sessionId={sessionId}
-          workspacePaths={skillWorkspacePaths ?? undefined}
-          leadingContent={
-            <>
-              <PlanTodoPill sessionId={sessionId} />
-              {topRowPills}
-            </>
-          }
-          trailingContent={topRowTrailingContent}
-        />
-      </div>
-    )}
-  </>
-);
+}) => {
+  return (
+    <>
+      {!isEditMode && !omitChatHeader && <ChatHeader />}
+      {!isEditMode && (
+        <div className="relative z-10 flex min-w-0 items-center gap-1 px-0.5 pb-1.5">
+          <PinnedActionsBar
+            composerInputRef={composerInputRef}
+            sessionId={sessionId}
+            workspacePaths={skillWorkspacePaths ?? undefined}
+            leadingContent={
+              <>
+                <PlanTodoPill sessionId={sessionId} />
+                {topRowPills}
+              </>
+            }
+            trailingContent={topRowTrailingContent}
+            showPinnedActions={showPinnedActions}
+          />
+        </div>
+      )}
+    </>
+  );
+};
 
 interface QuietEditStatusProps {
   isEditMode: boolean;

--- a/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.test.ts
+++ b/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.test.ts
@@ -139,13 +139,15 @@ describe("PinnedActionsBar", () => {
     expect(focus).toHaveBeenCalledOnce();
   });
 
-  it("hides pinned pills without removing the management entry point", () => {
+  it("hides pinned pills together with the divider and management button", () => {
     const composerInputRef = createRef<ComposerInputRef>();
 
     act(() =>
       root.render(
         createElement(PinnedActionsBar, {
           composerInputRef,
+          leadingContent: createElement("span", null, "Setup controls"),
+          manageButtonPlacement: "before-actions",
           showPinnedActions: false,
         })
       )
@@ -158,7 +160,30 @@ describe("PinnedActionsBar", () => {
       container.querySelector<HTMLButtonElement>(
         'button[title="input.pinnedActions.manage"]'
       )
+    ).toBeNull();
+    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+    expect(container.textContent).toContain("Setup controls");
+  });
+
+  it("omits the leading divider when the preceding GUI/TUI control is absent", () => {
+    const composerInputRef = createRef<ComposerInputRef>();
+
+    act(() =>
+      root.render(
+        createElement(PinnedActionsBar, {
+          composerInputRef,
+          manageButtonPlacement: "before-actions",
+          showBeforeActionsSeparator: false,
+        })
+      )
+    );
+
+    expect(
+      container.querySelector<HTMLButtonElement>(
+        'button[title="input.pinnedActions.manage"]'
+      )
     ).not.toBeNull();
+    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
   });
 
   it("does not request skill resolution for hidden pinned pills", () => {

--- a/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.tsx
+++ b/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.tsx
@@ -126,7 +126,9 @@ export interface PinnedActionsBarProps {
   trailingContent?: React.ReactNode;
   manageButtonPlacement?: "after-actions" | "after-leading" | "before-actions";
   managePanelAlign?: "left" | "right";
-  /** Show pinned quick-action pills; the management button stays available. */
+  /** Show the divider before controls when `manageButtonPlacement` is `before-actions`. */
+  showBeforeActionsSeparator?: boolean;
+  /** Show the pinned quick-action pills and their management controls. */
   showPinnedActions?: boolean;
 }
 
@@ -151,6 +153,7 @@ const PinnedActionsBar: React.FC<PinnedActionsBarProps> = memo(
     trailingContent,
     manageButtonPlacement = "after-actions",
     managePanelAlign = "right",
+    showBeforeActionsSeparator = true,
     showPinnedActions = true,
   }) => {
     const { t } = useTranslation("sessions");
@@ -403,17 +406,26 @@ const PinnedActionsBar: React.FC<PinnedActionsBarProps> = memo(
               {leadingContent}
               {trailingContent}
             </div>
-            <div aria-hidden className="mx-1 h-4 w-px shrink-0 bg-border-2" />
-            <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto py-0.5 scrollbar-hide">
-              {manageButton}
-              {actionPills}
-            </div>
+            {showPinnedActions && (
+              <>
+                {showBeforeActionsSeparator && (
+                  <div
+                    aria-hidden
+                    className="mx-1 h-4 w-px shrink-0 bg-border-2"
+                  />
+                )}
+                <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto py-0.5 scrollbar-hide">
+                  {manageButton}
+                  {actionPills}
+                </div>
+              </>
+            )}
           </>
         ) : manageButtonPlacement === "after-leading" ? (
           <>
             <div className="flex shrink-0 items-center gap-1">
               {leadingContent}
-              {manageButton}
+              {showPinnedActions && manageButton}
             </div>
             {showTrailingSeparator && (
               <div aria-hidden className="mx-1 h-4 w-px shrink-0 bg-border-2" />
@@ -433,12 +445,12 @@ const PinnedActionsBar: React.FC<PinnedActionsBarProps> = memo(
               <div aria-hidden className="mx-1 h-4 w-px shrink-0 bg-border-2" />
             )}
             {trailingContent}
-            {manageButton}
+            {showPinnedActions && manageButton}
           </>
         )}
 
         <PinActionsPanel
-          visible={panelOpen}
+          visible={showPinnedActions && panelOpen}
           availableItems={availableItems}
           pinnedActions={pinnedActions}
           onTogglePin={handleTogglePin}

--- a/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/usePinnedActionsVisibilityContextMenu.test.ts
+++ b/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/usePinnedActionsVisibilityContextMenu.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { popupNativeMenu } from "@src/util/platform/tauri/nativeMenuPopup";
+
+import { usePinnedActionsVisibilityContextMenu } from "./usePinnedActionsVisibilityContextMenu";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      key.endsWith(".hidePinnedActions")
+        ? "Hide pinned actions"
+        : "Show pinned actions",
+  }),
+}));
+
+vi.mock("@src/util/platform/tauri/nativeMenuPopup", () => ({
+  popupNativeMenu: vi.fn().mockResolvedValue({ status: "closed" }),
+}));
+
+const mockedPopupNativeMenu = vi.mocked(popupNativeMenu);
+const actEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+function MenuTarget({
+  visible,
+  onVisibleChange,
+}: {
+  visible: boolean;
+  onVisibleChange: (visible: boolean) => void;
+}) {
+  const onContextMenu = usePinnedActionsVisibilityContextMenu({
+    visible,
+    onVisibleChange,
+  });
+  return createElement("div", { "data-testid": "target", onContextMenu });
+}
+
+describe("usePinnedActionsVisibilityContextMenu", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mockedPopupNativeMenu.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("opens the hide command from a composer context menu", async () => {
+    const onVisibleChange = vi.fn();
+    act(() => {
+      root.render(
+        createElement(MenuTarget, { visible: true, onVisibleChange })
+      );
+    });
+
+    const target = container.querySelector('[data-testid="target"]');
+    const event = new MouseEvent("contextmenu", {
+      bubbles: true,
+      cancelable: true,
+    });
+    act(() => target?.dispatchEvent(event));
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(mockedPopupNativeMenu).toHaveBeenCalledOnce();
+    const items = await mockedPopupNativeMenu.mock.calls[0]?.[0].buildItems();
+    const visibilityItem = items?.[0] as
+      | { text?: string; action?: () => void }
+      | undefined;
+    expect(visibilityItem?.text).toBe("Hide pinned actions");
+
+    act(() => visibilityItem?.action?.());
+    expect(onVisibleChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/usePinnedActionsVisibilityContextMenu.ts
+++ b/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/usePinnedActionsVisibilityContextMenu.ts
@@ -1,0 +1,44 @@
+import React, { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+
+import { createLogger } from "@src/hooks/logger";
+import { popupNativeMenu } from "@src/util/platform/tauri/nativeMenuPopup";
+
+const log = createLogger("PinnedActionsVisibilityContextMenu");
+
+interface UsePinnedActionsVisibilityContextMenuOptions {
+  visible: boolean;
+  onVisibleChange: (visible: boolean) => void;
+}
+
+/** Native show/hide menu shared by creator and active-session composers. */
+export function usePinnedActionsVisibilityContextMenu({
+  visible,
+  onVisibleChange,
+}: UsePinnedActionsVisibilityContextMenuOptions): React.MouseEventHandler<HTMLElement> {
+  const { t } = useTranslation("sessions");
+
+  return useCallback(
+    (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      void popupNativeMenu({
+        source: "pinned-actions-visibility",
+        buildItems: () => [
+          {
+            text: t(
+              visible
+                ? "creator.repoChromeMenu.hidePinnedActions"
+                : "creator.repoChromeMenu.showPinnedActions"
+            ),
+            action: () => onVisibleChange(!visible),
+          },
+        ],
+      }).catch((error) => {
+        log.error("Failed to show pinned-actions visibility menu:", error);
+      });
+    },
+    [onVisibleChange, t, visible]
+  );
+}

--- a/src/engines/ChatPanel/InputArea/index.tsx
+++ b/src/engines/ChatPanel/InputArea/index.tsx
@@ -1,4 +1,4 @@
-import { useAtomValue } from "jotai";
+import { useAtom, useAtomValue } from "jotai";
 import React, { memo, useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -19,6 +19,7 @@ import {
   useConversationSubmitOverride,
 } from "@src/features/Org2Cloud/SessionConversation/useConversationComposer";
 import { voiceInputEnabledAtom } from "@src/store/platform/voiceInputAtom";
+import { pinnedActionsVisibleAtom } from "@src/store/session";
 import type { SlashItemCategory } from "@src/types/extensions";
 import { isCursorIdeSession } from "@src/util/session/sessionDispatch";
 
@@ -37,6 +38,7 @@ import {
 } from "./components/InputComposerBars";
 import ModePill from "./components/ModePill";
 import ModelPill from "./components/ModelPill";
+import { usePinnedActionsVisibilityContextMenu } from "./components/PinnedActionsBar/usePinnedActionsVisibilityContextMenu";
 import SessionReadOnlyBar from "./components/SessionReadOnlyBar";
 import { useContainerDrag } from "./hooks/useContainerDrag";
 import { useEditMode } from "./hooks/useEditMode";
@@ -278,6 +280,14 @@ const InputAreaInteractive: React.FC<InputAreaProps> = memo(
       disableStopWhenEmpty && currentInputEmpty && !isWpGeneWorking;
     const mentionTreePosition = chatPanelPosition === "left" ? "right" : "left";
     const voiceFeatureEnabled = useAtomValue(voiceInputEnabledAtom);
+    const [pinnedActionsVisible, setPinnedActionsVisible] = useAtom(
+      pinnedActionsVisibleAtom
+    );
+    const handlePinnedActionsContextMenu =
+      usePinnedActionsVisibilityContextMenu({
+        visible: pinnedActionsVisible,
+        onVisibleChange: setPinnedActionsVisible,
+      });
     const isContextualPanel = presentation === "contextual";
     const isContextual = isContextualInputAreaPresentation(presentation);
 
@@ -411,6 +421,11 @@ const InputAreaInteractive: React.FC<InputAreaProps> = memo(
         onDragOver={handleContainerDragOver}
         onDragLeave={handleContainerDragLeave}
         onDrop={handleContainerDrop}
+        onContextMenu={
+          !isEditMode && !isContextual
+            ? handlePinnedActionsContextMenu
+            : undefined
+        }
       >
         <div className="relative flex flex-col gap-0.5">
           {!isContextual && (
@@ -421,6 +436,7 @@ const InputAreaInteractive: React.FC<InputAreaProps> = memo(
               topRowTrailingContent={topRowTrailingContent}
               composerInputRef={composerInputRef}
               sessionId={sessionId}
+              showPinnedActions={pinnedActionsVisible}
               skillWorkspacePaths={skillWorkspacePaths}
             />
           )}

--- a/src/engines/ChatPanel/SideChat/index.tsx
+++ b/src/engines/ChatPanel/SideChat/index.tsx
@@ -242,9 +242,9 @@ const SideChatWindow: React.FC<ChatPanelSideChatProps> = ({
         // `composer-breathing` shell, and forces dropdowns upward.
         // `hideWorkItemAttachmentControl` (with no `heroFooterSlot`) drops
         // the launchpad action-card grid — no room for it in this window.
-        // The scoped override narrows the creator's full-pane side padding
-        // (px-4) to fit the small floating surface.
-        <div className="flex min-h-0 flex-1 flex-col overflow-hidden [&_.session-creator-chat-panel-content]:px-2">
+        // The creator shares the same compact horizontal gutter as the
+        // in-chat composer, so this small floating surface needs no override.
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           <SessionCreatorSlot
             className="h-full min-h-0"
             layout="launchpad"

--- a/src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx
@@ -15,10 +15,12 @@ import type { ComposerInputRef } from "@src/components/ComposerInput";
 import { pillControlStateClass } from "@src/components/CompoundPill/config";
 import InlineAlert from "@src/components/InlineAlert";
 import SelectorPill from "@src/components/SelectorPill";
+import { COMPOSER_HORIZONTAL_GUTTER_CLASS } from "@src/config/composerStackTokens";
 import { DETAIL_PANEL_TOKENS } from "@src/config/detailPanelTokens";
 import type { ScrollNavState } from "@src/engines/ChatPanel/ChatHistory";
 import CollapsedInlineRow from "@src/engines/ChatPanel/InputArea/components/CollapsedInlineRow";
 import PinnedActionsBar from "@src/engines/ChatPanel/InputArea/components/PinnedActionsBar";
+import { usePinnedActionsVisibilityContextMenu } from "@src/engines/ChatPanel/InputArea/components/PinnedActionsBar/usePinnedActionsVisibilityContextMenu";
 import type { SessionLaunchWorkItemContext } from "@src/engines/SessionCore/hooks/session/useSessionCreator/useSessionLaunch/types";
 import { LaunchpadActionGrid } from "@src/features/SessionCreator/components/LaunchpadActionGrid";
 import {
@@ -179,6 +181,10 @@ const SessionCreatorChatPanelView: React.FC<
   workItemContext,
 }) => {
   const { t } = useTranslation(["sessions", "common"]);
+  const handlePinnedActionsContextMenu = usePinnedActionsVisibilityContextMenu({
+    visible: pinnedActionsVisible,
+    onVisibleChange: onPinnedActionsVisibleChange,
+  });
   const sessionInfoLine = (
     <SessionInfoLine
       {...sessionInfoProps}
@@ -255,11 +261,13 @@ const SessionCreatorChatPanelView: React.FC<
   const sessionSetupActions = !hideSessionSetupControls ? (
     <div
       className={`mx-auto flex w-full items-center ${DETAIL_PANEL_TOKENS.contentMaxWidth}`}
+      onContextMenu={handlePinnedActionsContextMenu}
     >
       <PinnedActionsBar
         composerInputRef={composerInputRef}
         manageButtonPlacement="before-actions"
         managePanelAlign="left"
+        showBeforeActionsSeparator={Boolean(cliLaunchModeSwitch)}
         showPinnedActions={showPinnedActionPills}
         trailingContent={pinnedActionsContent}
         leadingContent={
@@ -491,7 +499,7 @@ const SessionCreatorChatPanelView: React.FC<
       data-testid="session-creator-chat-panel"
     >
       <div
-        className={`session-creator-chat-panel-content flex min-h-0 flex-1 px-4 ${DETAIL_PANEL_TOKENS.headerWidth} ${
+        className={`session-creator-chat-panel-content flex min-h-0 flex-1 ${COMPOSER_HORIZONTAL_GUTTER_CLASS} ${DETAIL_PANEL_TOKENS.headerWidth} ${
           isLaunchpadLayout
             ? `session-creator-chat-panel-launchpad-content flex-col ${CREATOR_BOTTOM_DOCK_PADDING_CLASS}`
             : `items-center justify-center ${
@@ -532,7 +540,10 @@ const SessionCreatorChatPanelView: React.FC<
                 {cliVersionWarning}
               </>
             )}
-            <div className={composerGroupClassName}>
+            <div
+              className={composerGroupClassName}
+              onContextMenu={handlePinnedActionsContextMenu}
+            >
               <div className={composerFrameClassName}>
                 {compactHeader}
                 {isCliTuiMode && tuiComposerHeader}

--- a/src/features/SessionCreator/variants/ChatPanel/index.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/index.tsx
@@ -29,10 +29,10 @@ import {
   agentIconIdAtom,
   agentNameAtom,
   cliAgentTypeAtom,
-  creatorPinnedActionsVisibleAtom,
   creatorRepoChromePositionAtom,
   dispatchCategoryAtom,
   normalizeAgentOnlySessionCreatorState,
+  pinnedActionsVisibleAtom,
   resolveCreatorRepoChromePosition,
   selectedAgentDefinitionIdAtom,
   selectedAgentOrgIdAtom,
@@ -108,7 +108,7 @@ const SessionCreatorChatPanelContent: React.FC<
   const [repoChromePositionPreference, setRepoChromePositionPreference] =
     useAtom(creatorRepoChromePositionAtom);
   const [pinnedActionsVisible, setPinnedActionsVisible] = useAtom(
-    creatorPinnedActionsVisibleAtom
+    pinnedActionsVisibleAtom
   );
   const repoChromePosition = resolveCreatorRepoChromePosition(
     repoChromePositionPreference,

--- a/src/store/session/__tests__/creatorPinnedActionsVisibleAtom.test.ts
+++ b/src/store/session/__tests__/creatorPinnedActionsVisibleAtom.test.ts
@@ -2,45 +2,44 @@ import { createStore } from "jotai/vanilla";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import {
-  CREATOR_PINNED_ACTIONS_VISIBLE_STORAGE_KEY,
-  creatorPinnedActionsVisibleAtom,
+  PINNED_ACTIONS_VISIBLE_STORAGE_KEY,
+  pinnedActionsVisibleAtom,
 } from "../creatorPinnedActionsVisibleAtom";
 
 beforeEach(() => {
-  localStorage.removeItem(CREATOR_PINNED_ACTIONS_VISIBLE_STORAGE_KEY);
+  localStorage.removeItem(PINNED_ACTIONS_VISIBLE_STORAGE_KEY);
 });
 
 function hydratedStore(): ReturnType<typeof createStore> {
   const store = createStore();
-  store.sub(creatorPinnedActionsVisibleAtom, () => undefined);
+  store.sub(pinnedActionsVisibleAtom, () => undefined);
   return store;
 }
 
-describe("creatorPinnedActionsVisibleAtom", () => {
+describe("pinnedActionsVisibleAtom", () => {
   it("shows pinned actions by default", () => {
-    expect(hydratedStore().get(creatorPinnedActionsVisibleAtom)).toBe(true);
+    expect(hydratedStore().get(pinnedActionsVisibleAtom)).toBe(true);
   });
 
   it("persists a hidden choice and hydrates it in a new store", () => {
     const firstStore = hydratedStore();
-    firstStore.set(creatorPinnedActionsVisibleAtom, false);
+    firstStore.set(pinnedActionsVisibleAtom, false);
 
     expect(
       JSON.parse(
-        localStorage.getItem(CREATOR_PINNED_ACTIONS_VISIBLE_STORAGE_KEY) ??
-          "null"
+        localStorage.getItem(PINNED_ACTIONS_VISIBLE_STORAGE_KEY) ?? "null"
       )
     ).toBe(false);
 
-    expect(hydratedStore().get(creatorPinnedActionsVisibleAtom)).toBe(false);
+    expect(hydratedStore().get(pinnedActionsVisibleAtom)).toBe(false);
   });
 
   it("falls back to visible for malformed persisted values", () => {
     localStorage.setItem(
-      CREATOR_PINNED_ACTIONS_VISIBLE_STORAGE_KEY,
+      PINNED_ACTIONS_VISIBLE_STORAGE_KEY,
       JSON.stringify("hidden")
     );
 
-    expect(hydratedStore().get(creatorPinnedActionsVisibleAtom)).toBe(true);
+    expect(hydratedStore().get(pinnedActionsVisibleAtom)).toBe(true);
   });
 });

--- a/src/store/session/creatorPinnedActionsVisibleAtom.ts
+++ b/src/store/session/creatorPinnedActionsVisibleAtom.ts
@@ -1,32 +1,35 @@
 import { atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 
-export const CREATOR_PINNED_ACTIONS_VISIBLE_STORAGE_KEY =
+export const PINNED_ACTIONS_VISIBLE_STORAGE_KEY =
   "orgii:sessionCreator:pinnedActionsVisible";
+/** @deprecated Use `PINNED_ACTIONS_VISIBLE_STORAGE_KEY`. */
+export const CREATOR_PINNED_ACTIONS_VISIBLE_STORAGE_KEY =
+  PINNED_ACTIONS_VISIBLE_STORAGE_KEY;
 
-function normalizeCreatorPinnedActionsVisible(value: unknown): boolean {
+function normalizePinnedActionsVisible(value: unknown): boolean {
   return typeof value === "boolean" ? value : true;
 }
 
-const storedCreatorPinnedActionsVisibleAtom = atomWithStorage<unknown>(
-  CREATOR_PINNED_ACTIONS_VISIBLE_STORAGE_KEY,
+const storedPinnedActionsVisibleAtom = atomWithStorage<unknown>(
+  PINNED_ACTIONS_VISIBLE_STORAGE_KEY,
   true,
   undefined,
   { getOnInit: true }
 );
 
 /**
- * Session Creator preference for showing pinned quick-action pills.
+ * Shared composer preference for showing pinned quick-action pills and their
+ * management controls in the Session Creator and active sessions.
  *
  * The preference does not delete or unpin actions. Compact and hidden-repo
  * creator surfaces ignore it because they do not expose the native menu that
  * can restore visibility.
  */
-export const creatorPinnedActionsVisibleAtom = atom(
-  (get) =>
-    normalizeCreatorPinnedActionsVisible(
-      get(storedCreatorPinnedActionsVisibleAtom)
-    ),
-  (_get, set, visible: boolean) =>
-    set(storedCreatorPinnedActionsVisibleAtom, visible)
+export const pinnedActionsVisibleAtom = atom(
+  (get) => normalizePinnedActionsVisible(get(storedPinnedActionsVisibleAtom)),
+  (_get, set, visible: boolean) => set(storedPinnedActionsVisibleAtom, visible)
 );
+
+/** @deprecated Use `pinnedActionsVisibleAtom`. */
+export const creatorPinnedActionsVisibleAtom = pinnedActionsVisibleAtom;


### PR DESCRIPTION
## Problem

Creator and active-session composers exposed inconsistent pinned-action behavior and responsive geometry. Hiding pinned actions in the creator left the divider and management ellipsis visible, did not apply inside active sessions, and could only be toggled from the repository row. The launchpad also used a wider horizontal inset than the in-chat composer, causing controls to wrap at different widths in split My Station / Work Station layouts.

## Solution

Make pinned-action visibility a shared persisted composer preference while preserving the existing localStorage key for compatibility. Hidden state now removes pinned pills, their divider, the ellipsis trigger, and any open management panel in both creator and active-session composers. A shared native context-menu hook exposes Show/Hide pinned actions from right-clicks across the creator or active-session input shell; the repository row retains its additional move-position command.

Use one shared `px-2` horizontal composer gutter for launchpad and active chat so split layouts wrap consistently while the existing 900px maximum continues to govern fullscreen width. The creator separator before pinned controls is rendered only when the GUI/TUI switch exists.

## Potential risks

- Right-clicking a normal, non-edit, non-contextual composer now opens the pinned-actions visibility menu instead of the platform's default text context menu. Edit and contextual composers retain their existing behavior.
- The native Tauri menu lifecycle is covered with a mocked unit boundary, but an actual desktop visual/interaction pass has not been run. The PR remains Draft until that check and suitable after-change screenshots are captured.
- The narrower creator gutter intentionally gives split layouts 8px more usable width per side and can change where existing controls wrap. Fullscreen remains capped at 900px.
- Persisted data remains compatible because `orgii:sessionCreator:pinnedActionsVisible` is unchanged and legacy exports remain as aliases. Reverting this commit restores the previous UI without a data migration.

## Verification

- `pnpm vitest run src/config/composerStackTokens.test.ts src/store/session/__tests__/creatorPinnedActionsVisibleAtom.test.ts src/features/SessionCreator/variants/ChatPanel/RepoChromeRow.test.ts src/engines/ChatPanel/InputArea/components/InputAreaChrome.test.ts src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.test.ts src/engines/ChatPanel/InputArea/components/PinnedActionsBar/usePinnedActionsVisibilityContextMenu.test.ts` — passed: 6 files, 13 tests
- `pnpm eslint src/config/composerStackTokens.ts src/config/composerStackTokens.test.ts src/engines/ChatPanel/ChatFloatingComposer.tsx src/engines/ChatPanel/InputArea/components/InputAreaChrome.tsx src/engines/ChatPanel/InputArea/components/InputAreaChrome.test.ts src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.tsx src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.test.ts src/engines/ChatPanel/InputArea/components/PinnedActionsBar/usePinnedActionsVisibilityContextMenu.ts src/engines/ChatPanel/InputArea/components/PinnedActionsBar/usePinnedActionsVisibilityContextMenu.test.ts src/engines/ChatPanel/InputArea/index.tsx src/engines/ChatPanel/SideChat/index.tsx src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx src/features/SessionCreator/variants/ChatPanel/index.tsx src/store/session/creatorPinnedActionsVisibleAtom.ts src/store/session/__tests__/creatorPinnedActionsVisibleAtom.test.ts --max-warnings 0 --report-unused-disable-directives` — passed
- `pnpm typecheck` — passed
- `git diff --check origin/develop...HEAD` — passed
- Commit hook — passed staged ESLint/Prettier, scoped TypeScript, and circular-dependency checks
- Reviewed `origin/develop...HEAD`: all 15 changed files map to composer visibility, context-menu access, responsive gutter parity, or direct regression coverage; unrelated workspace changes are not included
- Not run: desktop Tauri visual/interaction validation and after-change screenshots, because local UI control was not authorized

## Performance audit

| Area | Verdict | Evidence |
| --- | --- | --- |
| Background work | Keep | Native menu creation is demand-driven by right-click and cleanup remains centralized in `popupNativeMenu` |
| Memory | Keep | No timers, caches, queues, or retained collections were added |
| Scope/isolation | Keep | One persisted boolean preference intentionally scopes across creator and active-session composers; storage compatibility is preserved |
| Rendering/hot path | Keep | One narrow Jotai boolean subscription is owned by the mounted interactive composer and cleans up on unmount |

Performance verdict: pass.
