### PR TITLE
fix(workstation): unify selected text add to chat

### DIFF
--- a/src/hooks/input/useAddToAgentInsertion.ts
+++ b/src/hooks/input/useAddToAgentInsertion.ts
@@ -2,10 +2,9 @@
  * useAddToAgentInsertion
  *
  * Shared hook consumed by both the active-session InputArea and the
- * SessionCreator. Watches `addToAgentAtom` for pending "add file/lines to
- * agent" requests written by the WorkStation code-editor text-selection
- * dropdown, inserts the appropriate pill/reference into the provided
- * ComposerInput ref, and then clears the atom.
+ * SessionCreator. Watches `addToAgentAtom` for pending context requests
+ * written by WorkStation surfaces, inserts the appropriate pill/reference
+ * into the provided ComposerInput ref, and then clears the atom.
  *
  * A scheduled retry loop handles both React's passive-effect timing and the
  * case where ComposerInput hasn't finished initialising yet (e.g. the chat panel just

--- a/src/modules/WorkStation/Chat/Communication/__tests__/SessionReplayMessages.selection.test.ts
+++ b/src/modules/WorkStation/Chat/Communication/__tests__/SessionReplayMessages.selection.test.ts
@@ -1,0 +1,146 @@
+import { Provider } from "jotai";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { SessionReplayMessages } from "..";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      key === "simulator.replay.channelsSidebar.messages" ? "Messages" : key,
+  }),
+}));
+
+vi.mock(
+  "@src/engines/ChatPanel/InputArea/components/useAgentOrgRunView",
+  () => ({
+    useAgentOrgRunView: () => ({ view: null }),
+  })
+);
+
+vi.mock("@src/engines/ChatPanel/adapters/EventWrapper", () => ({
+  default: ({ children }: { children?: React.ReactNode }) => children,
+}));
+
+vi.mock("@src/modules/WorkStation/shared", () => ({
+  FileHeader: () => React.createElement("header"),
+  SimulatorReplayChrome: ({ children }: { children?: React.ReactNode }) =>
+    children,
+  WorkStationShell: ({ content }: { content?: React.ReactNode }) => content,
+  buildPrimarySidebarConfig: (config: unknown) => config,
+}));
+
+vi.mock("@src/modules/WorkStation/shared/SelectedTextAddToChat", () => ({
+  SelectedTextAddToChat: ({
+    children,
+    displayName,
+    enabled,
+    scopeKey,
+  }: {
+    children?: React.ReactNode;
+    displayName: string;
+    enabled?: boolean;
+    scopeKey?: string | number;
+  }) =>
+    React.createElement(
+      "div",
+      {
+        "data-selected-text-owner": displayName,
+        "data-selection-enabled": enabled,
+        "data-selection-scope": scopeKey,
+      },
+      children
+    ),
+}));
+
+vi.mock("../components/CommunicationMessageContent", () => ({
+  CommunicationMessageContent: () =>
+    React.createElement("div", { "data-testid": "message-content" }),
+}));
+
+vi.mock("../hooks/usePlanReplayIntent", () => ({
+  usePlanReplayIntent: () => ({
+    effectiveViewMode: "chat",
+    effectivePreviewMode: false,
+    handleViewModeChange: vi.fn(),
+    handlePreviewModeChange: vi.fn(),
+  }),
+}));
+
+vi.mock("../messageViewModel", () => ({
+  buildCommunicationMessageViewModel: () => ({ previewMessages: [] }),
+  selectCommunicationMessages: () => [],
+}));
+
+vi.mock("../useMessages", () => ({
+  useMessages: () => ({
+    viewMode: "chat",
+    setViewMode: vi.fn(),
+    chatMessages: [],
+    interactionMessages: [],
+    state: {
+      thinkMessages: [],
+      todoMessages: [],
+      selectedMessage: null,
+      currentEventId: "event-1",
+    },
+    hasLocalSelection: false,
+    jumpToMessage: vi.fn(),
+  }),
+}));
+
+vi.mock("../usePlanApproval", () => ({
+  usePlanApproval: () => ({
+    activePlanMessage: null,
+    pendingPlanId: null,
+    planPath: null,
+    isPlanDoc: false,
+    isPlanPending: false,
+    isEditing: false,
+    editedContent: "",
+    submitting: false,
+    buildDisabled: false,
+    setEditedContent: vi.fn(),
+    handleEditToggle: vi.fn(),
+    handleSave: vi.fn(),
+  }),
+}));
+
+vi.mock("../useReplayTabs", () => ({
+  useReplayTabs: () => ({
+    replayTabs: [],
+    activeTabId: null,
+    handleTabClick: vi.fn(),
+  }),
+}));
+
+function renderMessages(mode: "interactive" | "simulation"): string {
+  return renderToStaticMarkup(
+    React.createElement(
+      Provider,
+      null,
+      React.createElement(SessionReplayMessages, {
+        mode,
+        sessionId: "session-a",
+      })
+    )
+  );
+}
+
+describe("SessionReplayMessages selected-text ownership", () => {
+  it("mounts the shared Add to Chat owner for simulation replay", () => {
+    const markup = renderMessages("simulation");
+
+    expect(markup).toContain('data-selected-text-owner="Messages"');
+    expect(markup).toContain('data-selection-enabled="true"');
+    expect(markup).toContain('data-selection-scope="session-a:chat"');
+    expect(markup).toContain('data-testid="message-content"');
+  });
+
+  it("keeps selection disabled in interactive mode", () => {
+    const markup = renderMessages("interactive");
+
+    expect(markup).toContain('data-selection-enabled="false"');
+  });
+});

--- a/src/modules/WorkStation/Chat/Communication/components/CommunicationMessageContent.tsx
+++ b/src/modules/WorkStation/Chat/Communication/components/CommunicationMessageContent.tsx
@@ -6,7 +6,6 @@ import MessageViewer from "../MessageViewer";
 import type { MessageViewerProps } from "../MessageViewer";
 
 interface CommunicationMessageContentProps {
-  containerRef: React.RefObject<HTMLDivElement | null>;
   chatFontSize: number;
   chatCodeFontSize: number | null | undefined;
   chatLineHeight: number | null | undefined;
@@ -15,7 +14,6 @@ interface CommunicationMessageContentProps {
 
 /** Owns the simulator typography bridge and replay context around MessageViewer. */
 export function CommunicationMessageContent({
-  containerRef,
   chatFontSize,
   chatCodeFontSize,
   chatLineHeight,
@@ -25,7 +23,6 @@ export function CommunicationMessageContent({
   return (
     <InSimulatorReplayContext.Provider value={true}>
       <div
-        ref={containerRef}
         className="flex h-full w-full flex-col overflow-hidden"
         style={
           {

--- a/src/modules/WorkStation/Chat/Communication/index.tsx
+++ b/src/modules/WorkStation/Chat/Communication/index.tsx
@@ -1,5 +1,5 @@
-import { useAtomValue, useSetAtom } from "jotai";
-import React, { memo, useCallback, useMemo, useRef } from "react";
+import { useAtomValue } from "jotai";
+import React, { memo, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import { EDITOR_TAB_CANVAS_BG_CLASS } from "@src/config/workstation/tokens";
@@ -14,16 +14,12 @@ import {
 } from "@src/engines/SessionCore/derived/planDisplayEvents";
 import { AppType } from "@src/engines/Simulator/types/appTypes";
 import { matchesCanvasEvent } from "@src/modules/WorkStation/Canvas/config";
-import {
-  TextSelectionDropdown,
-  useTextSelectionDropdown,
-} from "@src/scaffold/ContextMenu/exports";
+import { SelectedTextAddToChat } from "@src/modules/WorkStation/shared/SelectedTextAddToChat";
 import {
   chatCodeFontSizeAtom,
   chatFontSizeAtom,
   chatLineHeightAtom,
 } from "@src/store/config/configAtom";
-import { addToAgentAtom } from "@src/store/ui/addToAgentAtom";
 import { simulatorEffectiveDockAppAtom } from "@src/store/ui/simulatorAtom";
 import type { BackendEvent } from "@src/types/session/steps";
 import { openFileInWorkStation } from "@src/util/ui/openFileInWorkStation";
@@ -66,8 +62,6 @@ const SimulatorMessagesComponent: React.FC<SimulatorMessagesProps> = ({
 }) => {
   const { t } = useTranslation("sessions");
   const effectiveDockApp = useAtomValue(simulatorEffectiveDockAppAtom);
-  const setAddToAgent = useSetAtom(addToAgentAtom);
-  const selectionContainerRef = useRef<HTMLDivElement>(null);
   const chatFontSize = useAtomValue(chatFontSizeAtom);
   const chatCodeFontSize = useAtomValue(chatCodeFontSizeAtom);
   const chatLineHeight = useAtomValue(chatLineHeightAtom);
@@ -154,22 +148,6 @@ const SimulatorMessagesComponent: React.FC<SimulatorMessagesProps> = ({
 
   const sessionEvent = currentEvent as SessionEvent | undefined;
   const isCanvasEvent = matchesCanvasEvent(sessionEvent?.functionName ?? "");
-  const handleSelectedTextAddToChat = useCallback(
-    (text: string, _sessionId: string | null) => {
-      setAddToAgent({
-        type: "terminal",
-        text,
-        displayName: headerBreadcrumbLabel,
-      });
-    },
-    [headerBreadcrumbLabel, setAddToAgent]
-  );
-  const selectionDropdown = useTextSelectionDropdown({
-    source: "terminal",
-    containerRef: selectionContainerRef,
-    onAddToContext: handleSelectedTextAddToChat,
-    enabled: mode === "simulation" && !isCanvasEvent,
-  });
 
   const handleMessageClick = useCallback(
     (messageId: string) => {
@@ -217,33 +195,39 @@ const SimulatorMessagesComponent: React.FC<SimulatorMessagesProps> = ({
   }
 
   const messageContent = (
-    <CommunicationMessageContent
-      containerRef={selectionContainerRef}
-      chatFontSize={chatFontSize}
-      chatCodeFontSize={chatCodeFontSize}
-      chatLineHeight={chatLineHeight}
-      viewerProps={{
-        messages: currentMessages,
-        viewMode: effectiveViewMode,
-        setViewMode: handleViewModeChange,
-        orgMembers,
-        agentOrgTasks: agentOrgRunView?.tasks,
-        sessionReplayMode: mode,
-        planPreviewMode: isPlanDoc ? effectivePreviewMode : undefined,
-        planEditState:
-          isPlanDoc && isPlanPending && isEditing
-            ? { value: editedContent, onChange: setEditedContent }
-            : undefined,
-        planDocPending: isPlanDoc && isPlanPending,
-        activePlanMessage,
-        selectedMessage: state.selectedMessage,
-        previewSelectedPlan:
-          effectiveViewMode === "preview" &&
-          (hasLocalSelection || selectedMessageIsPlan),
-        onMessageClick: handleMessageClick,
-        currentEventId: state.currentEventId,
-      }}
-    />
+    <SelectedTextAddToChat
+      displayName={headerBreadcrumbLabel}
+      enabled={mode === "simulation"}
+      scopeKey={`${sessionId ?? "session"}:${effectiveViewMode}`}
+      className="h-full min-h-0 w-full min-w-0"
+    >
+      <CommunicationMessageContent
+        chatFontSize={chatFontSize}
+        chatCodeFontSize={chatCodeFontSize}
+        chatLineHeight={chatLineHeight}
+        viewerProps={{
+          messages: currentMessages,
+          viewMode: effectiveViewMode,
+          setViewMode: handleViewModeChange,
+          orgMembers,
+          agentOrgTasks: agentOrgRunView?.tasks,
+          sessionReplayMode: mode,
+          planPreviewMode: isPlanDoc ? effectivePreviewMode : undefined,
+          planEditState:
+            isPlanDoc && isPlanPending && isEditing
+              ? { value: editedContent, onChange: setEditedContent }
+              : undefined,
+          planDocPending: isPlanDoc && isPlanPending,
+          activePlanMessage,
+          selectedMessage: state.selectedMessage,
+          previewSelectedPlan:
+            effectiveViewMode === "preview" &&
+            (hasLocalSelection || selectedMessageIsPlan),
+          onMessageClick: handleMessageClick,
+          currentEventId: state.currentEventId,
+        }}
+      />
+    </SelectedTextAddToChat>
   );
 
   return (
@@ -287,14 +271,6 @@ const SimulatorMessagesComponent: React.FC<SimulatorMessagesProps> = ({
             appClassName="session-replay-messages"
           />
         </div>
-        <TextSelectionDropdown
-          visible={selectionDropdown.visible}
-          position={selectionDropdown.position}
-          selectedText={selectionDropdown.selectedText}
-          source="terminal"
-          onClose={selectionDropdown.hideDropdown}
-          onAddToContext={handleSelectedTextAddToChat}
-        />
       </SimulatorReplayChrome>
     </EventWrapper>
   );

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/CodePanel/__tests__/CodePanel.selection.test.ts
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/CodePanel/__tests__/CodePanel.selection.test.ts
@@ -1,0 +1,128 @@
+import { Provider } from "jotai";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+
+import { CodePanel } from "..";
+import { FILE_OPERATION_TYPE, type FileOperationEntry } from "../../types";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@src/engines/SessionCore/rendering/registry/initToolRegistry", () => ({
+  getToolDisplayBehavior: () => "wait_for_result",
+}));
+
+vi.mock("@src/features/CodeViewer/VirtualizedModernDiff", () => ({
+  VirtualizedModernDiff: () =>
+    React.createElement("div", { "data-testid": "single-diff" }),
+}));
+
+vi.mock("@src/modules/shared/components/FileHeader", () => ({
+  FileHeader: () => React.createElement("header"),
+  default: () => React.createElement("header"),
+}));
+
+vi.mock("@src/modules/WorkStation/shared", () => ({
+  NoTabsPlaceholder: () => React.createElement("div"),
+  useSimulatorAwaitingAgentCaption: () => "Awaiting agent",
+  useSimulatorPlaceholderActions: () => [],
+}));
+
+vi.mock("@src/modules/WorkStation/shared/SelectedTextAddToChat", () => ({
+  SelectedTextAddToChat: ({
+    children,
+    displayName,
+    scopeKey,
+  }: {
+    children?: React.ReactNode;
+    displayName: string;
+    scopeKey?: string | number;
+  }) =>
+    React.createElement(
+      "div",
+      {
+        "data-selected-text-owner": displayName,
+        "data-selection-scope": scopeKey,
+      },
+      children
+    ),
+}));
+
+vi.mock("../CombinedDiffView", () => ({
+  CombinedDiffView: () =>
+    React.createElement("div", { "data-testid": "combined-diff" }),
+}));
+
+vi.mock("../useLiveReadFileContent", () => ({
+  useLiveReadFileContent: () => ({ content: undefined, status: "idle" }),
+}));
+
+const EVENT: SessionEvent = {
+  chunk_id: null,
+  id: "event-1",
+  sessionId: "session-1",
+  createdAt: "2026-08-24T00:00:00.000Z",
+  functionName: "edit_file",
+  uiCanonical: "edit_file",
+  actionType: "tool_call",
+  args: {},
+  result: {},
+  source: "assistant",
+  displayText: "Edit file",
+  displayStatus: "completed",
+  displayVariant: "tool_call",
+  activityStatus: "agent",
+};
+
+function makeWriteOperation(
+  overrides: Partial<FileOperationEntry> = {}
+): FileOperationEntry {
+  return {
+    filePath: "/repo/src/example.ts",
+    fileName: "example.ts",
+    directory: "/repo/src",
+    type: FILE_OPERATION_TYPE.WRITE,
+    event: EVENT,
+    eventId: "event-1",
+    isCurrent: true,
+    oldContent: "const before = 1;",
+    newContent: "const after = 2;",
+    ...overrides,
+  };
+}
+
+function renderPanel(operation: FileOperationEntry): string {
+  return renderToStaticMarkup(
+    React.createElement(
+      Provider,
+      null,
+      React.createElement(CodePanel, { operation })
+    )
+  );
+}
+
+describe("CodePanel selected-text ownership", () => {
+  it("mounts the shared Add to Chat owner around a single edit diff", () => {
+    const markup = renderPanel(makeWriteOperation());
+
+    expect(markup).toContain('data-selected-text-owner="example.ts"');
+    expect(markup).toContain('data-selection-scope="event-1"');
+    expect(markup).toContain('data-testid="single-diff"');
+  });
+
+  it("mounts the same owner around combined edit diffs", () => {
+    const first = makeWriteOperation({ eventId: "event-0", isCurrent: false });
+    const current = makeWriteOperation({
+      relatedOperations: [first, makeWriteOperation()],
+    });
+    const markup = renderPanel(current);
+
+    expect(markup).toContain('data-selected-text-owner="example.ts"');
+    expect(markup).toContain('data-selection-scope="event-1"');
+    expect(markup).toContain('data-testid="combined-diff"');
+  });
+});

--- a/src/modules/WorkStation/CodeEditor/SessionReplay/CodePanel/index.tsx
+++ b/src/modules/WorkStation/CodeEditor/SessionReplay/CodePanel/index.tsx
@@ -20,10 +20,12 @@ import {
   useSimulatorAwaitingAgentCaption,
   useSimulatorPlaceholderActions,
 } from "@src/modules/WorkStation/shared";
+import { SelectedTextAddToChat } from "@src/modules/WorkStation/shared/SelectedTextAddToChat";
 import { HEADER_ICON_SIZE } from "@src/modules/WorkStation/shared/tokens";
 import { FileHeader } from "@src/modules/shared/components/FileHeader";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
 import { simulatorEffectiveDockAppAtom } from "@src/store/ui/simulatorAtom";
+import { getFileName } from "@src/util/file/pathUtils";
 import {
   getPreviewType,
   supportsPreviewToggle,
@@ -305,6 +307,7 @@ export const CodePanel: React.FC<CodePanelProps> = memo(
     }
 
     const { filePath, type, language, relatedOperations } = operation;
+    const selectionDisplayName = getFileName(filePath) || filePath;
     const operationIsLoading = operation.isLoading || isLoading;
     const showDiffLineNumbers = shouldTrustDiffStartLines(operation.event);
 
@@ -400,26 +403,38 @@ export const CodePanel: React.FC<CodePanelProps> = memo(
               />
             )
           ) : hasMultipleEdits ? (
-            <CombinedDiffView
-              operations={relatedOperations}
-              filePath={filePath}
-            />
+            <SelectedTextAddToChat
+              displayName={selectionDisplayName}
+              scopeKey={operation.eventId}
+              className="min-w-0"
+            >
+              <CombinedDiffView
+                operations={relatedOperations}
+                filePath={filePath}
+              />
+            </SelectedTextAddToChat>
           ) : oldContent !== undefined || newContent !== undefined ? (
-            <VirtualizedModernDiff
-              oldValue={oldContent || ""}
-              newValue={newContent || ""}
-              filePath={filePath}
-              height="100%"
-              oldStartLine={resolvedPayload?.oldStartLine}
-              newStartLine={resolvedPayload?.newStartLine}
-              showLineNumbers={showDiffLineNumbers}
-              contextLines={3}
-              collapseUnchanged={true}
-              showFilePath={false}
-              showStatsBar={false}
-              noWrapper={true}
-              internalScroll={true}
-            />
+            <SelectedTextAddToChat
+              displayName={selectionDisplayName}
+              scopeKey={operation.eventId}
+              className="h-full min-h-0 min-w-0"
+            >
+              <VirtualizedModernDiff
+                oldValue={oldContent || ""}
+                newValue={newContent || ""}
+                filePath={filePath}
+                height="100%"
+                oldStartLine={resolvedPayload?.oldStartLine}
+                newStartLine={resolvedPayload?.newStartLine}
+                showLineNumbers={showDiffLineNumbers}
+                contextLines={3}
+                collapseUnchanged={true}
+                showFilePath={false}
+                showStatsBar={false}
+                noWrapper={true}
+                internalScroll={true}
+              />
+            </SelectedTextAddToChat>
           ) : (
             <div className="p-4 text-[13px] text-success-6">
               {t("simulator.replay.ide.codePanel.fileEditedSuccess")}

--- a/src/modules/WorkStation/shared/DiffFileSection/index.test.ts
+++ b/src/modules/WorkStation/shared/DiffFileSection/index.test.ts
@@ -9,6 +9,26 @@ vi.mock("@src/components/FileTypeIcon", () => ({
   default: () => React.createElement("span", { "data-file-icon": true }),
 }));
 
+vi.mock("../SelectedTextAddToChat", () => ({
+  SelectedTextAddToChat: ({
+    children,
+    displayName,
+    enabled,
+  }: {
+    children?: React.ReactNode;
+    displayName: string;
+    enabled?: boolean;
+  }) =>
+    React.createElement(
+      "div",
+      {
+        "data-selected-text-owner": displayName,
+        "data-selection-enabled": enabled,
+      },
+      children
+    ),
+}));
+
 const FILE = {
   path: "src/index.tsx",
   status: "modified" as const,
@@ -43,5 +63,28 @@ describe("DiffFileSection header gutter", () => {
 
     expect(markup).toContain("px-2");
     expect(markup).not.toContain("px-3");
+  });
+});
+
+describe("DiffFileSection selected-text ownership", () => {
+  it("mounts the shared Add to Chat owner around expanded diff content", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(
+        Provider,
+        null,
+        React.createElement(DiffFileSection, {
+          file: {
+            ...FILE,
+            oldContent: "const before = 1;",
+            newContent: "const after = 2;",
+          },
+          viewMode: "unified",
+          defaultExpanded: true,
+        })
+      )
+    );
+
+    expect(markup).toContain('data-selected-text-owner="index.tsx"');
+    expect(markup).toContain('data-selection-enabled="true"');
   });
 });

--- a/src/modules/WorkStation/shared/DiffFileSection/index.tsx
+++ b/src/modules/WorkStation/shared/DiffFileSection/index.tsx
@@ -1,4 +1,3 @@
-import { useSetAtom } from "jotai";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import React, {
   Suspense,
@@ -21,17 +20,14 @@ import {
 import { EDITOR_TAB_CANVAS_BG_CLASS } from "@src/config/workstation/tokens";
 import { FileHeader } from "@src/modules/shared/components/FileHeader";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
-import {
-  TextSelectionDropdown,
-  useTextSelectionDropdown,
-} from "@src/scaffold/ContextMenu/exports";
-import { addToAgentAtom } from "@src/store/ui/addToAgentAtom";
 import type { DiffViewMode } from "@src/types/git/types";
 import { isBinaryByExtension } from "@src/util/file/binaryDetection";
 import {
   getPreviewType,
   supportsSourceControlWorkingCopyPreview,
 } from "@src/util/file/previewTypes";
+
+import { SelectedTextAddToChat } from "../SelectedTextAddToChat";
 
 const LazyImagePreview = React.lazy(
   () =>
@@ -157,37 +153,6 @@ const DiffFileSection: React.FC<DiffFileSectionProps> = ({
       ? manualExpanded.value
       : defaultExpanded;
   const previousExpandedRef = useRef(expanded);
-
-  const containerRef = useRef<HTMLDivElement>(null);
-  const setAddToAgent = useSetAtom(addToAgentAtom);
-
-  const { fileName: displayName } = useMemo(
-    () => getFileNameAndDir(getDisplayPath(file.path, repoPath)),
-    [file.path, repoPath]
-  );
-
-  const handleAddToContext = useCallback(
-    (text: string, _sessionId: string | null) => {
-      setAddToAgent({
-        type: "terminal",
-        text,
-        displayName: displayName || file.path,
-      });
-    },
-    [setAddToAgent, displayName, file.path]
-  );
-
-  const {
-    visible: dropdownVisible,
-    position: dropdownPosition,
-    selectedText,
-    hideDropdown,
-  } = useTextSelectionDropdown({
-    source: "terminal",
-    containerRef,
-    onAddToContext: handleAddToContext,
-    enabled: expanded,
-  });
 
   const isDeleted = file.status === "deleted";
 
@@ -319,7 +284,11 @@ const DiffFileSection: React.FC<DiffFileSectionProps> = ({
       : null;
 
   const diffContent = (
-    <div ref={containerRef}>
+    <SelectedTextAddToChat
+      displayName={fileName || file.path}
+      enabled={expanded}
+      scopeKey={file.path}
+    >
       {previewContent ? (
         <div className="h-[480px] min-h-[320px] overflow-hidden">
           <Suspense
@@ -379,106 +348,86 @@ const DiffFileSection: React.FC<DiffFileSectionProps> = ({
           title={t("placeholders.loadingChanges")}
         />
       )}
-    </div>
+    </SelectedTextAddToChat>
   );
 
   if (flat) {
     return (
-      <>
-        <div
-          ref={sectionRef}
-          className={showBottomBorder ? "border-b border-border-2" : undefined}
-          data-diff-section-path={dataPath}
-        >
-          <FileHeader
-            filePath={file.path}
-            repoPath={repoPath}
-            additions={additions}
-            deletions={deletions}
-            publishEnabled={false}
-          />
-          {diffContent}
-        </div>
-        <TextSelectionDropdown
-          visible={dropdownVisible}
-          position={dropdownPosition}
-          selectedText={selectedText}
-          source="terminal"
-          onClose={hideDropdown}
-          onAddToContext={handleAddToContext}
-        />
-      </>
-    );
-  }
-
-  return (
-    <>
       <div
         ref={sectionRef}
         className={showBottomBorder ? "border-b border-border-2" : undefined}
         data-diff-section-path={dataPath}
       >
-        <button
-          className={`sticky top-0 z-10 flex w-full min-w-0 items-center gap-2 py-2 text-left hover:bg-fill-2 disabled:cursor-default disabled:hover:bg-transparent ${compactHeaderGutter ? "px-2" : "px-3"} ${EDITOR_TAB_CANVAS_BG_CLASS}`}
-          onClick={toggleExpanded}
-          disabled={isDeleted}
-        >
-          {isDeleted ? (
-            <span className="inline-block w-[14px] shrink-0" aria-hidden />
-          ) : expanded ? (
-            <ChevronDown size={14} className="shrink-0 text-text-3" />
-          ) : (
-            <ChevronRight size={14} className="shrink-0 text-text-3" />
-          )}
-          <FileTypeIcon
-            fileName={file.path}
-            size="small"
-            className="shrink-0 text-text-2"
-          />
-          <div className="flex min-w-0 flex-1 items-baseline gap-1.5 overflow-hidden">
-            <span className="shrink-0 text-[13px] font-medium text-text-1">
-              {fileName}
-            </span>
-            {!hideDirectory && dirPath ? (
-              <span className="min-w-0 truncate text-[11px] text-text-2">
-                {dirPath}
-              </span>
-            ) : null}
-            {renamePath ? (
-              <>
-                <span className="shrink-0 text-[11px] text-text-3" aria-hidden>
-                  ←
-                </span>
-                <span
-                  className="min-w-0 truncate text-[11px] text-text-2"
-                  title={`${displayPath} ← ${renamePath}`}
-                >
-                  {renamePath}
-                </span>
-              </>
-            ) : null}
-          </div>
-          <DiffStatsBadge
-            additions={additions}
-            deletions={deletions}
-            variant="compact"
-          />
-          <span className={`shrink-0 text-[11px] font-medium ${statusColor}`}>
-            {statusLetter}
-          </span>
-        </button>
-
-        {!isDeleted && expanded && diffContent}
+        <FileHeader
+          filePath={file.path}
+          repoPath={repoPath}
+          additions={additions}
+          deletions={deletions}
+          publishEnabled={false}
+        />
+        {diffContent}
       </div>
-      <TextSelectionDropdown
-        visible={dropdownVisible}
-        position={dropdownPosition}
-        selectedText={selectedText}
-        source="terminal"
-        onClose={hideDropdown}
-        onAddToContext={handleAddToContext}
-      />
-    </>
+    );
+  }
+
+  return (
+    <div
+      ref={sectionRef}
+      className={showBottomBorder ? "border-b border-border-2" : undefined}
+      data-diff-section-path={dataPath}
+    >
+      <button
+        className={`sticky top-0 z-10 flex w-full min-w-0 items-center gap-2 py-2 text-left hover:bg-fill-2 disabled:cursor-default disabled:hover:bg-transparent ${compactHeaderGutter ? "px-2" : "px-3"} ${EDITOR_TAB_CANVAS_BG_CLASS}`}
+        onClick={toggleExpanded}
+        disabled={isDeleted}
+      >
+        {isDeleted ? (
+          <span className="inline-block w-[14px] shrink-0" aria-hidden />
+        ) : expanded ? (
+          <ChevronDown size={14} className="shrink-0 text-text-3" />
+        ) : (
+          <ChevronRight size={14} className="shrink-0 text-text-3" />
+        )}
+        <FileTypeIcon
+          fileName={file.path}
+          size="small"
+          className="shrink-0 text-text-2"
+        />
+        <div className="flex min-w-0 flex-1 items-baseline gap-1.5 overflow-hidden">
+          <span className="shrink-0 text-[13px] font-medium text-text-1">
+            {fileName}
+          </span>
+          {!hideDirectory && dirPath ? (
+            <span className="min-w-0 truncate text-[11px] text-text-2">
+              {dirPath}
+            </span>
+          ) : null}
+          {renamePath ? (
+            <>
+              <span className="shrink-0 text-[11px] text-text-3" aria-hidden>
+                ←
+              </span>
+              <span
+                className="min-w-0 truncate text-[11px] text-text-2"
+                title={`${displayPath} ← ${renamePath}`}
+              >
+                {renamePath}
+              </span>
+            </>
+          ) : null}
+        </div>
+        <DiffStatsBadge
+          additions={additions}
+          deletions={deletions}
+          variant="compact"
+        />
+        <span className={`shrink-0 text-[11px] font-medium ${statusColor}`}>
+          {statusLetter}
+        </span>
+      </button>
+
+      {!isDeleted && expanded && diffContent}
+    </div>
   );
 };
 

--- a/src/modules/WorkStation/shared/SelectedTextAddToChat/SelectedTextAddToChat.test.ts
+++ b/src/modules/WorkStation/shared/SelectedTextAddToChat/SelectedTextAddToChat.test.ts
@@ -1,0 +1,237 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import React, { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { addToAgentAtom } from "@src/store/ui/addToAgentAtom";
+
+import { SelectedTextAddToChat } from ".";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) =>
+      key === "selectionMenu.addToChat" ? "Add to Chat" : key,
+  }),
+}));
+
+describe("SelectedTextAddToChat", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const store = createStore();
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    store.set(addToAgentAtom, null);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    window.getSelection()?.removeAllRanges();
+    container.remove();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  function renderSurface({
+    displayName = "example.ts",
+    enabled = true,
+    scopeKey = "scope-a",
+  }: {
+    displayName?: string;
+    enabled?: boolean;
+    scopeKey?: string;
+  } = {}): void {
+    act(() => {
+      root.render(
+        React.createElement(
+          Provider,
+          { store },
+          React.createElement(
+            SelectedTextAddToChat,
+            { displayName, enabled, scopeKey },
+            React.createElement("span", { id: "first" }, "const first = 1;"),
+            React.createElement("span", { id: "second" }, "const second = 2;")
+          )
+        )
+      );
+    });
+  }
+
+  async function selectText(elementId: string): Promise<void> {
+    const target = container.querySelector(`#${elementId}`);
+    const selection = window.getSelection();
+    if (!target || !selection) throw new Error("Selection fixture unavailable");
+
+    const range = document.createRange();
+    range.selectNodeContents(target);
+    selection.removeAllRanges();
+    selection.addRange(range);
+
+    await act(async () => {
+      target.dispatchEvent(
+        new MouseEvent("mouseup", {
+          bubbles: true,
+          clientX: 40,
+          clientY: 60,
+        })
+      );
+      await vi.advanceTimersByTimeAsync(100);
+    });
+  }
+
+  function clickAddToChat(): void {
+    const menuItem = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        ".text-selection-dropdown .cursor-pointer"
+      )
+    ).find((element) => element.textContent?.trim() === "Add to Chat");
+
+    expect(menuItem).toBeDefined();
+    act(() => menuItem?.click());
+  }
+
+  it("adds selected DOM text to chat with the owning surface label", async () => {
+    renderSurface();
+    await selectText("first");
+
+    expect(
+      document.querySelector(".text-selection-dropdown")?.textContent
+    ).toContain("Add to Chat");
+
+    clickAddToChat();
+
+    expect(store.get(addToAgentAtom)).toEqual({
+      type: "terminal",
+      text: "const first = 1;",
+      displayName: "example.ts",
+    });
+  });
+
+  it("does not let a closing timer erase a newer selection", async () => {
+    renderSurface();
+    await selectText("first");
+    clickAddToChat();
+    store.set(addToAgentAtom, null);
+
+    await selectText("second");
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+    clickAddToChat();
+
+    expect(store.get(addToAgentAtom)).toEqual({
+      type: "terminal",
+      text: "const second = 2;",
+      displayName: "example.ts",
+    });
+  });
+
+  it("does not install selection behavior while disabled", async () => {
+    renderSurface({ enabled: false });
+    await selectText("first");
+
+    expect(document.querySelector(".text-selection-dropdown")).toBeNull();
+    expect(store.get(addToAgentAtom)).toBeNull();
+
+    renderSurface({ enabled: true });
+    await selectText("first");
+    expect(document.querySelector(".text-selection-dropdown")).not.toBeNull();
+  });
+
+  it("ignores a selection owned by another surface", async () => {
+    renderSurface();
+    const outside = document.createElement("span");
+    outside.textContent = "outside selection";
+    document.body.appendChild(outside);
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(outside);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    await act(async () => {
+      container
+        .querySelector("#first")
+        ?.dispatchEvent(
+          new MouseEvent("mouseup", { bubbles: true, clientX: 40, clientY: 60 })
+        );
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(document.querySelector(".text-selection-dropdown")).toBeNull();
+    expect(store.get(addToAgentAtom)).toBeNull();
+    outside.remove();
+  });
+
+  it("dismisses the active selection menu with Escape", async () => {
+    renderSurface();
+    await selectText("first");
+    expect(document.querySelector(".text-selection-dropdown")).not.toBeNull();
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+
+    expect(document.querySelector(".text-selection-dropdown")).toBeNull();
+    expect(store.get(addToAgentAtom)).toBeNull();
+  });
+
+  it("dismisses the active selection menu on outside click", async () => {
+    renderSurface();
+    await selectText("first");
+    expect(document.querySelector(".text-selection-dropdown")).not.toBeNull();
+
+    act(() => {
+      document.body.dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true })
+      );
+    });
+
+    expect(document.querySelector(".text-selection-dropdown")).toBeNull();
+    expect(store.get(addToAgentAtom)).toBeNull();
+  });
+
+  it("resets only selection state when the owning scope changes", async () => {
+    renderSurface({ displayName: "first.ts", scopeKey: "scope-a" });
+    const childBeforeScopeChange = container.querySelector("#first");
+    await selectText("first");
+    expect(document.querySelector(".text-selection-dropdown")).not.toBeNull();
+
+    renderSurface({ displayName: "second.ts", scopeKey: "scope-b" });
+
+    expect(container.querySelector("#first")).toBe(childBeforeScopeChange);
+    expect(document.querySelector(".text-selection-dropdown")).toBeNull();
+
+    await selectText("second");
+    clickAddToChat();
+    expect(store.get(addToAgentAtom)).toEqual({
+      type: "terminal",
+      text: "const second = 2;",
+      displayName: "second.ts",
+    });
+  });
+});

--- a/src/modules/WorkStation/shared/SelectedTextAddToChat/index.tsx
+++ b/src/modules/WorkStation/shared/SelectedTextAddToChat/index.tsx
@@ -1,0 +1,85 @@
+/**
+ * Shared owner for DOM text-selection → "Add to Chat" behavior.
+ *
+ * The wrapped surface owns only its rendered content. This component owns the
+ * selection listener, dropdown lifecycle, and addToAgent write boundary.
+ */
+import { useSetAtom } from "jotai";
+import React, { memo, useCallback, useRef } from "react";
+
+import {
+  TextSelectionDropdown,
+  useTextSelectionDropdown,
+} from "@src/scaffold/ContextMenu/exports";
+import { addToAgentAtom } from "@src/store/ui/addToAgentAtom";
+
+interface SelectionControllerProps {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  displayName: string;
+}
+
+const SelectionController: React.FC<SelectionControllerProps> = memo(
+  ({ containerRef, displayName }) => {
+    const setAddToAgent = useSetAtom(addToAgentAtom);
+    const { visible, position, selectedText, hideDropdown } =
+      useTextSelectionDropdown({ containerRef });
+
+    const handleAddToChat = useCallback(
+      (text: string, _sessionId: string | null) => {
+        setAddToAgent({
+          type: "terminal",
+          text,
+          displayName,
+        });
+      },
+      [displayName, setAddToAgent]
+    );
+
+    return (
+      <TextSelectionDropdown
+        visible={visible}
+        position={position}
+        selectedText={selectedText}
+        source="terminal"
+        onClose={hideDropdown}
+        onAddToContext={handleAddToChat}
+      />
+    );
+  }
+);
+
+SelectionController.displayName = "SelectedTextAddToChatController";
+
+export interface SelectedTextAddToChatProps {
+  children?: React.ReactNode;
+  displayName: string;
+  enabled?: boolean;
+  /** Remounts only the selection controller when the rendered scope changes. */
+  scopeKey?: string | number;
+  className?: string;
+}
+
+export const SelectedTextAddToChat: React.FC<SelectedTextAddToChatProps> = memo(
+  ({ children, displayName, enabled = true, scopeKey, className }) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    return (
+      <>
+        <div ref={containerRef} className={className}>
+          {children}
+        </div>
+        {enabled ? (
+          <SelectionController
+            key={scopeKey ?? "default"}
+            containerRef={containerRef}
+            displayName={displayName}
+          />
+        ) : null}
+      </>
+    );
+  }
+);
+
+SelectedTextAddToChat.displayName = "SelectedTextAddToChat";
+
+export default SelectedTextAddToChat;

--- a/src/scaffold/ContextMenu/variants/TextSelectionDropdown/types.ts
+++ b/src/scaffold/ContextMenu/variants/TextSelectionDropdown/types.ts
@@ -5,7 +5,7 @@
  */
 import type { RefObject } from "react";
 
-import { DropdownAction, SessionItem } from "./config";
+import type { SessionItem } from "./config";
 
 // ============================================
 // Component Props
@@ -39,16 +39,8 @@ export interface TextSelectionDropdownProps {
 // ============================================
 
 export interface UseTextSelectionDropdownOptions {
-  /** Whether the dropdown functionality is enabled */
-  enabled?: boolean;
   /** Container element to watch for selections */
   containerRef?: RefObject<HTMLElement | null>;
-  /** Source type for the selection */
-  source: "terminal" | "browser" | "editor";
-  /** Callback when "Ask Agent" is triggered */
-  onAskAgent?: (text: string) => void;
-  /** Callback when "Add to Session Context" is triggered */
-  onAddToContext?: (text: string, sessionId: string | null) => void;
 }
 
 export interface UseTextSelectionDropdownReturn {
@@ -62,8 +54,6 @@ export interface UseTextSelectionDropdownReturn {
   showDropdown: (position: { x: number; y: number }, text: string) => void;
   /** Hide the dropdown */
   hideDropdown: () => void;
-  /** Handle action selection */
-  handleAction: (action: DropdownAction, sessionId?: string | null) => void;
 }
 
 // ============================================

--- a/src/scaffold/ContextMenu/variants/TextSelectionDropdown/useTextSelectionDropdown.ts
+++ b/src/scaffold/ContextMenu/variants/TextSelectionDropdown/useTextSelectionDropdown.ts
@@ -1,25 +1,23 @@
 /**
  * useTextSelectionDropdown Hook
  *
- * Manages text selection dropdown state for terminal and browser views.
- * Detects text selection and provides handlers for dropdown actions.
+ * Detects DOM text selection within an optional container and owns the
+ * dropdown's transient position/text/visibility lifecycle.
  *
  * Features:
  * - Listens for mouseup events to detect text selection
  * - Calculates dropdown position based on selection
- * - Provides action handlers for Ask Agent and Add to Context
+ * - Closes on Escape; the dropdown component owns outside-click dismissal
+ * - Cancels debounced and delayed cleanup work on unmount
  *
  * @example
- * const { visible, position, selectedText, hideDropdown, handleAction } = useTextSelectionDropdown({
- *   source: 'terminal',
- *   enabled: true,
- *   onAskAgent: (text) => */
+ * const selection = useTextSelectionDropdown({ containerRef });
+ */
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useDebouncedCallback } from "@src/hooks/perf";
 import { getUiScaleFromCssVar } from "@src/lib/dndKit";
 
-import { DropdownAction } from "./config";
 import {
   UseTextSelectionDropdownOptions,
   UseTextSelectionDropdownReturn,
@@ -30,6 +28,7 @@ import {
 // ============================================
 
 const SELECTION_DEBOUNCE_MS = 100;
+const SELECTION_CLEAR_DELAY_MS = 200;
 
 // ============================================
 // Hook Implementation
@@ -38,53 +37,49 @@ const SELECTION_DEBOUNCE_MS = 100;
 export function useTextSelectionDropdown(
   options: UseTextSelectionDropdownOptions
 ): UseTextSelectionDropdownReturn {
-  const { enabled = true, containerRef, onAskAgent, onAddToContext } = options;
+  const { containerRef } = options;
 
   // State
   const [visible, setVisible] = useState(false);
-  const visibleRef = useRef(visible);
-  useEffect(() => {
-    visibleRef.current = visible;
-  }, [visible]);
   const [position, setPosition] = useState({ x: 0, y: 0 });
   const [selectedText, setSelectedText] = useState("");
+  const clearSelectionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+
+  const cancelSelectionClear = useCallback(() => {
+    if (clearSelectionTimerRef.current === null) return;
+    clearTimeout(clearSelectionTimerRef.current);
+    clearSelectionTimerRef.current = null;
+  }, []);
 
   // Show dropdown at position
   const showDropdown = useCallback(
     (newPosition: { x: number; y: number }, text: string) => {
-      if (!enabled || !text.trim()) return;
+      if (!text.trim()) return;
 
+      cancelSelectionClear();
       setSelectedText(text.trim());
       setPosition(newPosition);
       setVisible(true);
     },
-    [enabled]
+    [cancelSelectionClear]
   );
 
   // Hide dropdown
   const hideDropdown = useCallback(() => {
     setVisible(false);
     // Keep text for animation exit
-    setTimeout(() => {
+    cancelSelectionClear();
+    clearSelectionTimerRef.current = setTimeout(() => {
       setSelectedText("");
-    }, 200);
-  }, []);
+      clearSelectionTimerRef.current = null;
+    }, SELECTION_CLEAR_DELAY_MS);
+  }, [cancelSelectionClear]);
 
-  // Handle action selection
-  const handleAction = useCallback(
-    (action: DropdownAction, sessionId?: string | null) => {
-      if (!selectedText) return;
-
-      if (action === "ask-agent") {
-        onAskAgent?.(selectedText);
-      } else if (action === "add-to-context") {
-        onAddToContext?.(selectedText, sessionId ?? null);
-      }
-
-      hideDropdown();
-    },
-    [selectedText, onAskAgent, onAddToContext, hideDropdown]
-  );
+  useEffect(() => {
+    return () => cancelSelectionClear();
+  }, [cancelSelectionClear]);
 
   const debouncedHandleMouseUp = useDebouncedCallback((event: MouseEvent) => {
     const selection = window.getSelection();
@@ -120,49 +115,30 @@ export function useTextSelectionDropdown(
 
   // Listen for mouseup events to detect selection
   useEffect(() => {
-    if (!enabled) return;
-
     const handleMouseUp = (event: MouseEvent) => {
       debouncedHandleMouseUp(event);
     };
 
-    // Handle click outside to close dropdown
-    const handleClickOutside = (event: MouseEvent) => {
-      if (visibleRef.current) {
-        const target = event.target;
-        if (!(target instanceof Node)) return;
-        const dropdown = document.querySelector(".text-selection-dropdown");
-        if (dropdown && !dropdown.contains(target)) {
-          hideDropdown();
-        }
-      }
-    };
-
-    // Handle escape key
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape" && visibleRef.current) {
-        hideDropdown();
-      }
-    };
-
     const container = containerRef?.current ?? document;
     container.addEventListener("mouseup", handleMouseUp as EventListener);
-    document.addEventListener("mousedown", handleClickOutside);
-    document.addEventListener("keydown", handleKeyDown);
 
     return () => {
       debouncedHandleMouseUp.cancel();
       container.removeEventListener("mouseup", handleMouseUp as EventListener);
-      document.removeEventListener("mousedown", handleClickOutside);
-      document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [
-    enabled,
-    containerRef,
-    showDropdown,
-    hideDropdown,
-    debouncedHandleMouseUp,
-  ]);
+  }, [containerRef, debouncedHandleMouseUp]);
+
+  // Keep the only document-level listener demand-driven while the menu is open.
+  useEffect(() => {
+    if (!visible) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") hideDropdown();
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [hideDropdown, visible]);
 
   return {
     visible,
@@ -170,7 +146,6 @@ export function useTextSelectionDropdown(
     selectedText,
     showDropdown,
     hideDropdown,
-    handleAction,
   };
 }
 

--- a/src/store/ui/addToAgentAtom.ts
+++ b/src/store/ui/addToAgentAtom.ts
@@ -26,9 +26,13 @@ export type AddToAgentRequest =
     }
   | {
       type: "terminal";
-      /** Raw selected text from the terminal */
+      /**
+       * Raw selected text from a terminal or read-only DOM surface. The
+       * historical discriminator is retained because it maps to the existing
+       * terminal-style raw-text pill protocol.
+       */
       text: string;
-      /** Display label for the pill (e.g. "Terminal (1-12)") */
+      /** Display label for the pill (e.g. a file/view name or "Terminal (1-12)") */
       displayName?: string;
       /** 1-based buffer row where the selection starts */
       lineStart?: number;


### PR DESCRIPTION
## Problem

Session Replay edit diffs no longer owned the DOM text-selection flow that opens “Add to Chat”, so selecting code in single or combined replay diffs produced no action. Similar ownership was duplicated across replay messages and shared diff sections, which allowed the surfaces to drift.

## Solution

Add `SelectedTextAddToChat` as the shared owner for container-scoped selection detection, dropdown lifecycle, and the `addToAgentAtom` raw-text write. Use it for single and combined replay diffs, `DiffFileSection`, and simulation-mode communication content. A `scopeKey` resets only transient selection state when the viewed event or channel changes while preserving rendered child identity.

The existing `terminal` request discriminator is retained for compatibility with the raw-text pill protocol; no persistence, IPC, or wire-format changes are introduced.

## Potential risks

- The shared owner adds one wrapper element around each enabled DOM-selection surface. Existing flex and height constraints were carried onto the wrappers and parent render-gate tests cover all three surfaces, but the final Tauri desktop layout was not visually re-captured.
- Downstream insertion continues to interpret DOM selections through the historical `terminal` raw-text request shape. This is intentional compatibility behavior, but a later protocol rename would need all raw-text consumers migrated together.
- Selection detection remains mouseup-based, matching the prior supported behavior; this PR does not add a separate keyboard-only selection trigger.
- Rollback is a normal code revert; there are no stored-data or schema changes.

## Verification

- `./node_modules/.bin/vitest run src/modules/WorkStation/shared/SelectedTextAddToChat/SelectedTextAddToChat.test.ts src/modules/WorkStation/shared/DiffFileSection/index.test.ts src/modules/WorkStation/CodeEditor/SessionReplay/CodePanel src/modules/WorkStation/Chat/Communication/__tests__/SessionReplayMessages.selection.test.ts --config vitest.config.ts` — 6 files and 37 tests passed.
- `git diff --name-only -z origin/develop -- '*.ts' '*.tsx' | xargs -0 ./node_modules/.bin/eslint --max-warnings 0` — passed with zero warnings.
- `./node_modules/.bin/tsc --noEmit --pretty false` — passed.
- `git diff origin/develop --check` — passed.
- `git merge-tree --write-tree HEAD origin/develop` — completed without conflicts.
- The production diff scan found no secrets, debug statements, personal paths, generated artifacts, or unrelated formatting changes.

## UI evidence

No Tauri desktop screenshot was captured because the ordinary browser harness does not provide the app's Tauri metadata. Behavioral coverage includes the selection-to-atom flow, outside-click and Escape dismissal, disabled mode, scope switching, single and combined replay diffs, shared diff sections, and simulation-versus-interactive message gates.
