### PR TITLE
refactor(runtime): route turn producers through dispatcher

### DIFF
--- a/src/engines/ChatPanel/InputArea/ModeSwitchCard/useModeSwitchActions.test.ts
+++ b/src/engines/ChatPanel/InputArea/ModeSwitchCard/useModeSwitchActions.test.ts
@@ -3,21 +3,20 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { switchMode } from "./useModeSwitchActions";
 
 const storeGetSpy = vi.hoisted(() => vi.fn());
-const sendMessageSpy = vi.hoisted(() => vi.fn());
+const dispatchTurnSpy = vi.hoisted(() => vi.fn());
 const respondModeSwitchSpy = vi.hoisted(() => vi.fn());
 const rpcPatchSpy = vi.hoisted(() => vi.fn());
 const updateByIdSpy = vi.hoisted(() => vi.fn());
 const getSnapshotSpy = vi.hoisted(() => vi.fn());
 const upsertSessionSpy = vi.hoisted(() => vi.fn());
-const beginOptimisticTurnSpy = vi.hoisted(() => vi.fn());
 const isAgentSessionSpy = vi.hoisted(() => vi.fn());
 
 vi.mock("@src/util/core/state/instrumentedStore", () => ({
   getInstrumentedStore: () => ({ get: storeGetSpy }),
 }));
 
-vi.mock("@src/engines/SessionCore/services/SessionService", () => ({
-  SessionService: { sendMessage: sendMessageSpy },
+vi.mock("@src/engines/SessionCore/services/TurnDispatchService", () => ({
+  dispatchTurn: dispatchTurnSpy,
 }));
 
 vi.mock("@src/api/tauri/agent", () => ({
@@ -26,11 +25,6 @@ vi.mock("@src/api/tauri/agent", () => ({
 
 vi.mock("@src/api/tauri/rpc", () => ({
   rpc: { sessionAggregate: { patch: rpcPatchSpy } },
-}));
-
-vi.mock("@src/engines/SessionCore/control/optimisticTurnStatus", () => ({
-  beginOptimisticTurn: beginOptimisticTurnSpy,
-  failOptimisticTurn: vi.fn(),
 }));
 
 vi.mock("@src/engines/SessionCore/core/atoms", () => ({
@@ -94,7 +88,7 @@ describe("switchMode → switchAgentMode resume", () => {
     isAgentSessionSpy.mockReturnValue(true);
     delete (window as { __ORGII_E2E_MODE_SWITCH_MOCK__?: boolean })
       .__ORGII_E2E_MODE_SWITCH_MOCK__;
-    sendMessageSpy.mockResolvedValue(undefined);
+    dispatchTurnSpy.mockResolvedValue(undefined);
     respondModeSwitchSpy.mockResolvedValue(undefined);
     rpcPatchSpy.mockResolvedValue(undefined);
     updateByIdSpy.mockResolvedValue(undefined);
@@ -109,16 +103,16 @@ describe("switchMode → switchAgentMode resume", () => {
 
     await switchMode("event-1", "plan");
 
-    expect(sendMessageSpy).toHaveBeenCalledTimes(1);
-    expect(sendMessageSpy).toHaveBeenCalledWith(
+    expect(dispatchTurnSpy).toHaveBeenCalledTimes(1);
+    expect(dispatchTurnSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionId: SESSION_ID,
         content: "",
         isResume: true,
+        turnIntentSource: "resume",
         mode: "plan",
       })
     );
-    expect(beginOptimisticTurnSpy).toHaveBeenCalledWith(SESSION_ID);
   });
 
   it("resumes the turn for an ordinary task prompt", async () => {
@@ -126,8 +120,8 @@ describe("switchMode → switchAgentMode resume", () => {
 
     await switchMode("event-2", "plan");
 
-    expect(sendMessageSpy).toHaveBeenCalledTimes(1);
-    expect(sendMessageSpy).toHaveBeenCalledWith(
+    expect(dispatchTurnSpy).toHaveBeenCalledTimes(1);
+    expect(dispatchTurnSpy).toHaveBeenCalledWith(
       expect.objectContaining({ content: "", isResume: true, mode: "plan" })
     );
   });
@@ -137,7 +131,16 @@ describe("switchMode → switchAgentMode resume", () => {
 
     await switchMode("event-3", "plan");
 
-    expect(sendMessageSpy).not.toHaveBeenCalled();
-    expect(beginOptimisticTurnSpy).not.toHaveBeenCalled();
+    expect(dispatchTurnSpy).not.toHaveBeenCalled();
+  });
+
+  it("propagates canonical dispatch failures", async () => {
+    setupStore({ lastUserText: "fix the parser" });
+    dispatchTurnSpy.mockRejectedValueOnce(new Error("transport down"));
+
+    await expect(switchMode("event-4", "plan")).rejects.toThrow(
+      "transport down"
+    );
+    expect(dispatchTurnSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/engines/ChatPanel/InputArea/ModeSwitchCard/useModeSwitchActions.ts
+++ b/src/engines/ChatPanel/InputArea/ModeSwitchCard/useModeSwitchActions.ts
@@ -13,10 +13,6 @@ import {
   ALL_AGENT_EXEC_MODES,
   type AgentExecMode,
 } from "@src/config/sessionCreatorConfig";
-import {
-  beginOptimisticTurn,
-  failOptimisticTurn,
-} from "@src/engines/SessionCore/control/optimisticTurnStatus";
 import { eventsAtom } from "@src/engines/SessionCore/core/atoms";
 import { eventStoreProxy } from "@src/engines/SessionCore/core/store/EventStoreProxy";
 import { creatorDefaultModelSelectionAtom } from "@src/store/session/creatorDefaultModelAtom";
@@ -72,13 +68,12 @@ export const MODE_LABELS: Record<string, string> = Object.fromEntries(
 // Actions
 // ============================================
 
-// Lazily import SessionService to avoid a static import cycle:
+// Lazily import TurnDispatchService to avoid a static import cycle:
 // SessionService -> sync (getAdapterForSession) -> ... -> toolHandlers ->
-// useModeSwitchActions. Loading it on demand inside the async action keeps the
-// runtime behaviour identical while removing the back-edge from the module graph.
-async function getSessionService() {
-  return (await import("@src/engines/SessionCore/services/SessionService"))
-    .SessionService;
+// useModeSwitchActions. Loading it on demand keeps the canonical dispatch
+// boundary without restoring that back-edge in the module graph.
+async function getTurnDispatchService() {
+  return import("@src/engines/SessionCore/services/TurnDispatchService");
 }
 
 async function markModeSwitchEventResolved(
@@ -185,25 +180,19 @@ async function switchAgentMode(
     : fallback;
   const { model, accountId } = resolveModelForMessage(lastModelSelection);
 
-  // Mode-switch re-runs bypass useMessageDispatch, so set the optimistic
-  // running status here (P3).
-  beginOptimisticTurn(sessionId);
-
-  try {
-    const SessionService = await getSessionService();
-    await SessionService.sendMessage({
-      sessionId,
-      content: "",
-      isResume: true,
-      turnIntentSource: "resume",
-      model,
-      accountId,
-      mode: targetMode,
-    });
-  } catch (error) {
-    failOptimisticTurn(sessionId);
-    throw error;
-  }
+  // This is a new provider execution turn, but Resume semantics deliberately
+  // keep it in the existing visible user round. Canonical dispatch supplies a
+  // fresh intent/generation and owns optimistic status plus exact finality.
+  const { dispatchTurn } = await getTurnDispatchService();
+  await dispatchTurn({
+    sessionId,
+    content: "",
+    isResume: true,
+    turnIntentSource: "resume",
+    model,
+    accountId,
+    mode: targetMode,
+  });
 }
 
 function isE2EModeSwitchMockEnabled(): boolean {

--- a/src/engines/ChatPanel/SideChat/SideChatLauncher.test.ts
+++ b/src/engines/ChatPanel/SideChat/SideChatLauncher.test.ts
@@ -1,8 +1,18 @@
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { SideChatLauncher } from ".";
+import { SideChatLauncher, dispatchSideChatMessage } from ".";
+
+const dispatchTurnSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("@src/engines/SessionCore/services/TurnDispatchService", () => ({
+  dispatchTurn: dispatchTurnSpy,
+}));
+
+beforeEach(() => {
+  dispatchTurnSpy.mockReset().mockResolvedValue(undefined);
+});
 
 describe("SideChatLauncher", () => {
   it("renders an accessible floating dialog trigger", () => {
@@ -18,5 +28,42 @@ describe("SideChatLauncher", () => {
     expect(markup).toContain('aria-haspopup="dialog"');
     expect(markup).toContain("bottom-4");
     expect(markup).toContain("right-4");
+  });
+});
+
+describe("dispatchSideChatMessage", () => {
+  it("routes an ordinary submit through canonical dispatch", async () => {
+    await expect(
+      dispatchSideChatMessage("sdeagent-side", {
+        displayText: "visible [skill:/review]",
+        agentContent: "expanded prompt",
+        imageDataUrls: ["data:image/png;base64,abc"],
+      })
+    ).resolves.toBe(true);
+
+    expect(dispatchTurnSpy).toHaveBeenCalledWith({
+      sessionId: "sdeagent-side",
+      content: "expanded prompt",
+      displayText: "visible [skill:/review]",
+      imageDataUrls: ["data:image/png;base64,abc"],
+      turnIntentSource: "user_submit",
+      directUserIntent: true,
+    });
+  });
+
+  it("does not reserve an empty submit", async () => {
+    await expect(
+      dispatchSideChatMessage("sdeagent-side", { displayText: "   " })
+    ).resolves.toBe(false);
+    expect(dispatchTurnSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns false when canonical transport rejects", async () => {
+    dispatchTurnSpy.mockRejectedValueOnce(new Error("offline"));
+
+    await expect(
+      dispatchSideChatMessage("sdeagent-side", { displayText: "hello" })
+    ).resolves.toBe(false);
+    expect(dispatchTurnSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/engines/ChatPanel/SideChat/index.tsx
+++ b/src/engines/ChatPanel/SideChat/index.tsx
@@ -19,8 +19,8 @@
  * `ChatSessionContext.Provider` + `ChatProvider` route `ChatHistory` to
  * `chatEventsForSessionAtomFamily(sessionId)` — a per-session snapshot
  * subscription that streams live without touching the global pipeline.
- * Sending goes through `SessionService.sendMessage`, which is adapter-
- * routed per session id, via the composer's `onSubmitOverride` (the
+ * Sending goes through the canonical turn-dispatch boundary (which delegates
+ * to the session-category adapter) via the composer's `onSubmitOverride` (the
  * `ChannelComposer` call shape).
  *
  * Two body modes, driven by `sideChatSessionIdAtom`:
@@ -42,7 +42,7 @@ import {
   HEADER_ICON_SIZE,
 } from "@src/config/workstation/tokens";
 import { ChatProvider } from "@src/contexts/workspace/ChatContext";
-import { SessionService } from "@src/engines/SessionCore/services/SessionService";
+import { dispatchTurn } from "@src/engines/SessionCore/services/TurnDispatchService";
 import { createLogger } from "@src/hooks/logger";
 import {
   activeChatPanelTabTypeAtom,
@@ -264,6 +264,28 @@ interface SideChatSessionBodyProps {
   isLive: boolean;
 }
 
+export async function dispatchSideChatMessage(
+  sessionId: string,
+  { displayText, agentContent, imageDataUrls }: SubmitOverrideInput
+): Promise<boolean> {
+  const content = agentContent ?? displayText;
+  if (!content.trim()) return false;
+  try {
+    await dispatchTurn({
+      sessionId,
+      content,
+      displayText,
+      imageDataUrls,
+      turnIntentSource: "user_submit",
+      directUserIntent: true,
+    });
+    return true;
+  } catch (error) {
+    log.error(`Failed to send side-chat message to ${sessionId}:`, error);
+    return false;
+  }
+}
+
 const SideChatSessionBody: React.FC<SideChatSessionBodyProps> = ({
   sessionId,
   isLive,
@@ -271,28 +293,7 @@ const SideChatSessionBody: React.FC<SideChatSessionBodyProps> = ({
   const turnPaginationEnabled = useAtomValue(chatTurnPaginationEnabledAtom);
 
   const handleSubmit = useCallback(
-    async ({
-      displayText,
-      agentContent,
-      imageDataUrls,
-    }: SubmitOverrideInput): Promise<boolean> => {
-      const content = agentContent ?? displayText;
-      if (!content.trim()) return false;
-      try {
-        await SessionService.sendMessage({
-          sessionId,
-          content,
-          displayText,
-          imageDataUrls,
-          turnIntentSource: "user_submit",
-          directUserIntent: true,
-        });
-        return true;
-      } catch (error) {
-        log.error(`Failed to send side-chat message to ${sessionId}:`, error);
-        return false;
-      }
-    },
+    (input: SubmitOverrideInput) => dispatchSideChatMessage(sessionId, input),
     [sessionId]
   );
 

--- a/src/engines/ChatPanel/hooks/useWorkspaceChat/useMessageDispatch.ts
+++ b/src/engines/ChatPanel/hooks/useWorkspaceChat/useMessageDispatch.ts
@@ -11,23 +11,13 @@ import { useCallback } from "react";
 
 import type { AgentExecMode } from "@src/config/sessionCreatorConfig";
 import { resolveSessionAgentExecMode } from "@src/config/sessionCreatorConfig";
-import {
-  beginOptimisticTurn,
-  failOptimisticTurn,
-} from "@src/engines/SessionCore/control/optimisticTurnStatus";
-import {
-  beginTurnDispatch,
-  confirmTurnRunning,
-  markTurnTerminal,
-} from "@src/engines/SessionCore/control/turnLifecycle";
 import { eventStoreProxy } from "@src/engines/SessionCore/core/store/EventStoreProxy";
-import { SessionService } from "@src/engines/SessionCore/services/SessionService";
-import { createSyntheticUserEvent } from "@src/engines/SessionCore/sync/adapters/shared";
-import { markSessionActive } from "@src/store/session";
 import {
-  lastUserMessageAtom,
-  setSessionRuntimeStatusAtom,
-} from "@src/store/session/cliSessionStatusAtom";
+  type ReservedTurnDispatch,
+  sendReservedTurn,
+} from "@src/engines/SessionCore/services/TurnDispatchService";
+import { createSyntheticUserEvent } from "@src/engines/SessionCore/sync/adapters/shared";
+import { lastUserMessageAtom } from "@src/store/session/cliSessionStatusAtom";
 import {
   type LastModelSelection,
   creatorDefaultModelSelectionAtom,
@@ -36,10 +26,8 @@ import { sessionMapAtom } from "@src/store/session/sessionAtom";
 import { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";
 import { resolveModelForMessage } from "@src/util/session/resolveModelForMessage";
 import { selectionFromSession } from "@src/util/session/selectionFromSession";
-import { isCursorIdeSession } from "@src/util/session/sessionDispatch";
 
 export function useMessageDispatch() {
-  const setSessionRuntimeStatus = useSetAtom(setSessionRuntimeStatusAtom);
   const setLastUserMessage = useSetAtom(lastUserMessageAtom);
 
   const addUserMessage = useCallback(
@@ -72,12 +60,11 @@ export function useMessageDispatch() {
     async (
       sessionId: string,
       content: string,
+      reservedDispatch: ReservedTurnDispatch,
       imageDataUrls?: string[],
       modelSelectionOverride?: LastModelSelection,
       displayText?: string,
-      clientMessageId?: string,
-      turnIntentId?: string,
-      reservedDispatchGeneration?: number
+      clientMessageId?: string
     ): Promise<void> => {
       // Read directly from the store at call time to avoid stale-closure
       // race: if the user changes the mode pill and immediately sends a
@@ -99,60 +86,20 @@ export function useMessageDispatch() {
       );
       const { model, accountId } = resolveModelForMessage(lastModelSelection);
 
-      // Synchronous turn reserve: every dispatch funnels through here, so the
-      // FSM observes the session as busy before the first await. A concurrent
-      // submit therefore queues instead of double-dispatching.
-      const dispatchGeneration =
-        reservedDispatchGeneration ?? beginTurnDispatch(sessionId);
-
-      beginOptimisticTurn(sessionId);
-
-      try {
-        await SessionService.sendMessage({
-          sessionId,
-          content,
-          displayText,
-          model,
-          accountId,
-          mode: agentExecMode,
-          imageDataUrls,
-          clientMessageId,
-          turnIntentId,
-          turnIntentSource: "user_submit",
-          directUserIntent: true,
-        });
-        // Backend accepted the message — the turn is running even if the
-        // provider's running ack has not been observed yet.
-        confirmTurnRunning(sessionId);
-        // Bump the row's `updated_at` to "now" so the sidebar /
-        // Kanban "recent activity" views float this session to the
-        // top immediately. The backend's authoritative timestamp
-        // lands on the next session list refresh and overwrites
-        // this — see `markSessionActive` doc for the policy.
-        markSessionActive(sessionId);
-        if (isCursorIdeSession(sessionId)) {
-          // Cursor IDE sessions have no turn lifecycle (the CDP stream has no
-          // terminal event) — close the turn right after a successful handoff.
-          setSessionRuntimeStatus({
-            sessionId,
-            status: "idle",
-            source: "dispatch",
-          });
-          markTurnTerminal(sessionId, "completed", {
-            generation: dispatchGeneration,
-          });
-        }
-      } catch (err) {
-        // IPC failed before Rust even received the message — reset so the UI
-        // does not stay stuck in the optimistic "running" state.
-        failOptimisticTurn(sessionId);
-        markTurnTerminal(sessionId, "failed", {
-          generation: dispatchGeneration,
-        });
-        throw err;
-      }
+      await sendReservedTurn({
+        dispatch: reservedDispatch,
+        content,
+        displayText,
+        model,
+        accountId,
+        mode: agentExecMode,
+        imageDataUrls,
+        clientMessageId,
+        turnIntentSource: "user_submit",
+        directUserIntent: true,
+      });
     },
-    [setSessionRuntimeStatus]
+    []
   );
 
   return {

--- a/src/engines/ChatPanel/hooks/useWorkspaceChat/useUserIntentSubmit.ts
+++ b/src/engines/ChatPanel/hooks/useWorkspaceChat/useUserIntentSubmit.ts
@@ -11,17 +11,13 @@ import { useCallback, useEffect } from "react";
 
 import type { AgentExecMode } from "@src/config/sessionCreatorConfig";
 import { resolveSessionAgentExecMode } from "@src/config/sessionCreatorConfig";
-import {
-  beginOptimisticTurn,
-  failOptimisticTurn,
-} from "@src/engines/SessionCore/control/optimisticTurnStatus";
-import { publishTurnIntentDispatch } from "@src/engines/SessionCore/control/turnIntentDispatchLifecycle";
-import {
-  beginTurnDispatch,
-  getTurnPhase,
-  markTurnTerminal,
-} from "@src/engines/SessionCore/control/turnLifecycle";
+import { beginOptimisticTurn } from "@src/engines/SessionCore/control/optimisticTurnStatus";
+import { getTurnPhase } from "@src/engines/SessionCore/control/turnLifecycle";
 import { eventStoreProxy } from "@src/engines/SessionCore/core/store/EventStoreProxy";
+import {
+  failReservedTurn,
+  reserveTurnDispatch,
+} from "@src/engines/SessionCore/services/TurnDispatchService";
 import { mintTurnIntentId } from "@src/engines/SessionCore/sync/adapters/shared/eventFactories";
 import {
   type SessionRuntimeStatusSource,
@@ -194,10 +190,6 @@ export function useUserIntentSubmit({
           session?.agentExecMode
         );
 
-        if (clearUserInitiatedCancelOnQueue && explicitPostStopSubmit) {
-          closePostStopDispatchEpisode(sessionId);
-        }
-
         enqueueMessage({
           id: `queued-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`,
           turnIntentId,
@@ -211,6 +203,15 @@ export function useUserIntentSubmit({
           status: "queued",
           createdAt: new Date().toISOString(),
         });
+        const queued = store
+          .get(messageQueueAtom)
+          .some((message) => message.turnIntentId === turnIntentId);
+        if (!queued) {
+          throw new Error("Message was not accepted by the queue");
+        }
+        if (clearUserInitiatedCancelOnQueue && explicitPostStopSubmit) {
+          closePostStopDispatchEpisode(sessionId);
+        }
         if (explicitPostStopSubmit) {
           setQueueFlushRequest((requestId) => requestId + 1);
         }
@@ -226,12 +227,11 @@ export function useUserIntentSubmit({
         displayContent,
         imageDataUrls: restoreImageDataUrls,
       });
-      const dispatchGeneration = beginTurnDispatch(sessionId);
-      publishTurnIntentDispatch(turnIntentId, {
+      const dispatch = reserveTurnDispatch({
         sessionId,
-        generation: dispatchGeneration,
+        turnIntentId,
+        optimisticSource: source,
       });
-      beginOptimisticTurn(sessionId, source);
       if (dedupeDirectSubmit) {
         sharedSubmitGuard.current = true;
         sharedSubmitPayload.current = submitPayloadKey;
@@ -253,12 +253,11 @@ export function useUserIntentSubmit({
         await dispatchMessageBySessionType(
           sessionId,
           contentForAgent,
+          dispatch,
           imageDataUrls,
           undefined,
           displayTextForDispatch,
-          `direct:${sessionId}:${stableSubmitHash(submitPayloadKey)}`,
-          turnIntentId,
-          dispatchGeneration
+          `direct:${sessionId}:${stableSubmitHash(submitPayloadKey)}`
         );
       } catch (error) {
         if (dedupeDirectSubmit) {
@@ -266,10 +265,7 @@ export function useUserIntentSubmit({
           sharedSubmitPayload.current = null;
         }
         if (!dispatchStarted) {
-          failOptimisticTurn(sessionId, source);
-          markTurnTerminal(sessionId, "failed", {
-            generation: dispatchGeneration,
-          });
+          failReservedTurn(dispatch);
         }
         if (userEventId) {
           try {

--- a/src/engines/SessionCore/hooks/session/__tests__/useQueueDispatch.intervention.test.ts
+++ b/src/engines/SessionCore/hooks/session/__tests__/useQueueDispatch.intervention.test.ts
@@ -9,6 +9,8 @@ import {
 } from "@src/store/ui/messageQueueAtom";
 import { type SmokeRoot, createSmokeRoot } from "@src/test/reactSmokeHarness";
 
+import { resetTurnIntentDispatchLifecycleForTests } from "../../../control/turnIntentDispatchLifecycle";
+import { resetTurnDispatchMonitorsForTests } from "../../../services/TurnDispatchService";
 import { useQueueDispatch } from "../useQueueDispatch";
 
 const SESSION_ID = "agent-builtin:sde-queued-worker";
@@ -21,7 +23,10 @@ const mocks = vi.hoisted(() => ({
   confirmTurnRunning: vi.fn(),
   failOptimisticTurn: vi.fn(),
   getSession: vi.fn(),
+  getTurnGeneration: vi.fn(),
   getTurnPhase: vi.fn(),
+  getTurnTerminal: vi.fn(),
+  getTurnIntentStatus: vi.fn(),
   markSessionActive: vi.fn(),
   markTurnTerminal: vi.fn(),
   messageError: vi.fn(),
@@ -55,7 +60,9 @@ vi.mock("@src/engines/SessionCore/control/turnLifecycle", async () => {
   return {
     beginTurnDispatch: mocks.beginTurnDispatch,
     confirmTurnRunning: mocks.confirmTurnRunning,
+    getTurnGeneration: mocks.getTurnGeneration,
     getTurnPhase: mocks.getTurnPhase,
+    getTurnTerminal: mocks.getTurnTerminal,
     markTurnTerminal: mocks.markTurnTerminal,
     turnLifecycleSignalAtom: atom(0),
   };
@@ -69,7 +76,10 @@ vi.mock("@src/engines/SessionCore/core/store/EventStoreProxy", () => ({
 }));
 
 vi.mock("@src/engines/SessionCore/services/SessionService", () => ({
-  SessionService: { sendMessage: mocks.sendMessage },
+  SessionService: {
+    getTurnIntentStatus: mocks.getTurnIntentStatus,
+    sendMessage: mocks.sendMessage,
+  },
 }));
 
 vi.mock("@src/engines/SessionCore/sync/adapters/shared", () => ({
@@ -145,19 +155,24 @@ describe("useQueueDispatch Agent Org intervention", () => {
     mocks.confirmTurnRunning.mockReset();
     mocks.failOptimisticTurn.mockReset();
     mocks.getSession.mockReset().mockResolvedValue(null);
+    mocks.getTurnGeneration.mockReset().mockReturnValue(11);
     mocks.getTurnPhase.mockReset().mockReturnValue("idle");
+    mocks.getTurnTerminal.mockReset().mockReturnValue(null);
+    mocks.getTurnIntentStatus.mockReset().mockResolvedValue(null);
     mocks.markSessionActive.mockReset();
     mocks.markTurnTerminal.mockReset();
     mocks.messageError.mockReset();
     mocks.messageWarning.mockReset();
     mocks.removeByIdPrefix.mockReset().mockResolvedValue(1);
-    mocks.sendMessage.mockReset().mockResolvedValue(undefined);
+    mocks.sendMessage.mockReset().mockResolvedValue({ duplicate: false });
     store = createStore();
     root = createSmokeRoot();
   });
 
   afterEach(async () => {
     await root.unmount();
+    resetTurnDispatchMonitorsForTests();
+    resetTurnIntentDispatchLifecycleForTests();
   });
 
   async function mountWithMessages(messages: QueuedMessage[]): Promise<void> {

--- a/src/engines/SessionCore/hooks/session/useQueueDispatch.ts
+++ b/src/engines/SessionCore/hooks/session/useQueueDispatch.ts
@@ -31,28 +31,22 @@ import {
   type AgentExecMode,
   resolveSessionAgentExecMode,
 } from "@src/config/sessionCreatorConfig";
-import {
-  beginOptimisticTurn,
-  failOptimisticTurn,
-} from "@src/engines/SessionCore/control/optimisticTurnStatus";
 import { cancelTurnForTimelineBoundary } from "@src/engines/SessionCore/control/sessionTimelineBoundary";
-import { publishTurnIntentDispatch } from "@src/engines/SessionCore/control/turnIntentDispatchLifecycle";
 import {
-  beginTurnDispatch,
-  confirmTurnRunning,
   getTurnPhase,
-  markTurnTerminal,
   turnLifecycleSignalAtom,
 } from "@src/engines/SessionCore/control/turnLifecycle";
 import { eventStoreProxy } from "@src/engines/SessionCore/core/store/EventStoreProxy";
-import { SessionService } from "@src/engines/SessionCore/services/SessionService";
+import {
+  failReservedTurn,
+  reserveTurnDispatch,
+  sendReservedTurn,
+} from "@src/engines/SessionCore/services/TurnDispatchService";
 import { createSyntheticUserEvent } from "@src/engines/SessionCore/sync/adapters/shared";
 import { createLogger } from "@src/hooks/logger";
-import { markSessionActive } from "@src/store/session";
 import {
   closePostStopDispatchEpisodeAtom,
   lastUserMessageAtom,
-  setSessionRuntimeStatusAtom,
 } from "@src/store/session/cliSessionStatusAtom";
 import {
   type LastModelSelection,
@@ -71,7 +65,6 @@ import { selectionFromSession } from "@src/util/session/selectionFromSession";
 import {
   isAgentSession,
   isCliSession,
-  isCursorIdeSession,
 } from "@src/util/session/sessionDispatch";
 
 import {
@@ -191,12 +184,12 @@ export function useQueueDispatch(): void {
         resolveSessionAgentExecMode(session?.agentExecMode);
       const { model, accountId } = resolveModelForMessage(lastModelSelection);
 
-      // Synchronous turn reserve BEFORE any await: from this instant every
-      // submit and every other dispatch pass observes the session as busy.
-      const dispatchGeneration = beginTurnDispatch(sessionId);
-      publishTurnIntentDispatch(msg.turnIntentId, {
+      // Reserve through the canonical dispatch boundary before the first
+      // transcript await so concurrent submits observe this session as busy.
+      const dispatch = reserveTurnDispatch({
         sessionId,
-        generation: dispatchGeneration,
+        turnIntentId: msg.turnIntentId,
+        optimisticSource: "queue",
       });
 
       // An explicit dispatch concludes any pending stop episode.
@@ -211,10 +204,9 @@ export function useQueueDispatch(): void {
         imageDataUrls,
       });
 
-      beginOptimisticTurn(sessionId, "queue");
-
       void (async () => {
         let userEventId: string | null = null;
+        let sendStarted = false;
         try {
           const userEvent = createSyntheticUserEvent(
             sessionId,
@@ -231,8 +223,9 @@ export function useQueueDispatch(): void {
           // the pill format and re-editing shows the pill, not the YAML.
           const displayTextForDispatch =
             content !== displayContent ? displayContent : undefined;
-          await SessionService.sendMessage({
-            sessionId,
+          sendStarted = true;
+          await sendReservedTurn({
+            dispatch,
             content,
             displayText: displayTextForDispatch,
             model,
@@ -240,32 +233,14 @@ export function useQueueDispatch(): void {
             mode: agentExecMode,
             imageDataUrls,
             clientMessageId: `queued:${sessionId}:${msg.id}`,
-            turnIntentId: msg.turnIntentId,
             turnIntentSource: msg.priority === "now" ? "force_send" : "queue",
             directUserIntent: true,
           });
-          // Backend accepted the message — confirm the turn as running.
-          confirmTurnRunning(sessionId);
-          // Bump activity timestamps so the just-flushed session surfaces in
-          // "recent activity" views without waiting for the next refresh.
-          markSessionActive(sessionId);
           rememberSentQueueId(msg.id);
           store.set(messageQueueAtom, (prev) =>
             prev.filter((item) => item.id !== msg.id)
           );
           onDone();
-          if (isCursorIdeSession(sessionId)) {
-            // Cursor IDE sessions have no turn lifecycle (no terminal event
-            // stream) — close the turn right after a successful handoff.
-            store.set(setSessionRuntimeStatusAtom, {
-              sessionId,
-              status: "idle",
-              source: "queue",
-            });
-            markTurnTerminal(sessionId, "completed", {
-              generation: dispatchGeneration,
-            });
-          }
         } catch (err) {
           log.error("[useQueueDispatch] dispatch failed:", err);
           if (userEventId) {
@@ -281,10 +256,7 @@ export function useQueueDispatch(): void {
           // IPC failed before the backend received the message: close the
           // reserved turn and park the message so it does not retry in a
           // tight loop — the user can fix the issue and press Send Now.
-          failOptimisticTurn(sessionId, "queue");
-          markTurnTerminal(sessionId, "failed", {
-            generation: dispatchGeneration,
-          });
+          if (!sendStarted) failReservedTurn(dispatch);
           store.set(messageQueueAtom, (prev) =>
             prev.map((item) =>
               item.id === msg.id

--- a/src/engines/SessionCore/services/PlanExecutionService.test.ts
+++ b/src/engines/SessionCore/services/PlanExecutionService.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PlanExecutionService } from "./PlanExecutionService";
+
+const dispatchTurnSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("./TurnDispatchService", () => ({
+  dispatchTurn: dispatchTurnSpy,
+}));
+
+describe("PlanExecutionService", () => {
+  beforeEach(() => {
+    dispatchTurnSpy.mockReset().mockResolvedValue(undefined);
+  });
+
+  it("dispatches a plan document with the explicit execution workspace", async () => {
+    await PlanExecutionService.executePlanDocument({
+      sessionId: "sdeagent-plan",
+      planContent: "  1. Change the parser\n2. Add tests  ",
+      mode: "build",
+      model: "claude-sonnet",
+      accountId: "acct-1",
+      workspacePath: "/workspace/repo-a",
+    });
+
+    expect(dispatchTurnSpy).toHaveBeenCalledWith({
+      sessionId: "sdeagent-plan",
+      content:
+        "Execute the following plan document. Implement each step in order and update the todo list as you complete each step.\n\n---\n\n1. Change the parser\n2. Add tests",
+      turnIntentSource: "user_submit",
+      mode: "build",
+      model: "claude-sonnet",
+      accountId: "acct-1",
+      workspacePath: "/workspace/repo-a",
+    });
+  });
+
+  it("dispatches todo steps and propagates canonical failures", async () => {
+    dispatchTurnSpy.mockRejectedValueOnce(new Error("transport down"));
+
+    await expect(
+      PlanExecutionService.executePlanFromTodos({
+        sessionId: "sdeagent-plan",
+        todos: [{ content: "First" }, { content: "Second" }],
+        mode: "build",
+      })
+    ).rejects.toThrow("transport down");
+
+    expect(dispatchTurnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content:
+          "Execute the following plan:\n\n1. First\n2. Second\n\nImplement each step in order. Update the todo list as you complete each step.",
+        turnIntentSource: "user_submit",
+      })
+    );
+  });
+});

--- a/src/engines/SessionCore/services/PlanExecutionService.ts
+++ b/src/engines/SessionCore/services/PlanExecutionService.ts
@@ -1,9 +1,4 @@
-import {
-  beginOptimisticTurn,
-  failOptimisticTurn,
-} from "@src/engines/SessionCore/control/optimisticTurnStatus";
-import { collectAdeContext } from "@src/services/context/collectors";
-import { retryInvokeTauri } from "@src/util/platform/tauri/retryInvoke";
+import { dispatchTurn } from "./TurnDispatchService";
 
 export interface ExecutePlanParams {
   sessionId: string;
@@ -26,34 +21,15 @@ async function sendPlanMessage(
   content: string,
   params: Omit<ExecutePlanParams, "sessionId">
 ): Promise<void> {
-  const adeContext = collectAdeContext({
-    expectedRepoPath: params.workspacePath ?? null,
+  await dispatchTurn({
     sessionId,
+    content,
+    turnIntentSource: "user_submit",
+    mode: params.mode,
+    model: params.model,
+    accountId: params.accountId,
+    workspacePath: params.workspacePath,
   });
-  // Raw invoke bypasses useMessageDispatch — without the optimistic running
-  // the planning indicator stays blank until Rust's first status event (#8).
-  beginOptimisticTurn(sessionId);
-  try {
-    await retryInvokeTauri(
-      "agent_send_message",
-      {
-        sessionId,
-        content,
-        turnIntentSource: "user_submit",
-        mode: params.mode,
-        ...(params.model ? { model: params.model } : {}),
-        ...(params.accountId ? { accountId: params.accountId } : {}),
-        ...(params.workspacePath
-          ? { workspacePath: params.workspacePath }
-          : {}),
-        ...(adeContext ? { ideContext: adeContext } : {}),
-      },
-      sessionId
-    );
-  } catch (error) {
-    failOptimisticTurn(sessionId);
-    throw error;
-  }
 }
 
 export const PlanExecutionService = {

--- a/src/features/Org2Cloud/addressCommentsRun.ts
+++ b/src/features/Org2Cloud/addressCommentsRun.ts
@@ -8,15 +8,8 @@
  */
 import { atom } from "jotai";
 
-import {
-  type TurnIntentDispatch,
-  waitForTurnIntentDispatch,
-} from "@src/engines/SessionCore/control/turnIntentDispatchLifecycle";
-import {
-  getLastTurnTerminal,
-  turnLifecycleSignalAtom,
-} from "@src/engines/SessionCore/control/turnLifecycle";
 import { eventStoreProxy } from "@src/engines/SessionCore/core/store/EventStoreProxy";
+import { waitForTurnIntentOutcome } from "@src/engines/SessionCore/services/TurnDispatchService";
 import { mintTurnIntentId } from "@src/engines/SessionCore/sync/adapters/shared/eventFactories";
 import { getSessionForkedFrom } from "@src/features/TeamCollaboration/forkSession";
 import { createLogger } from "@src/hooks/logger";
@@ -105,37 +98,6 @@ function beginRunActivity(
     else scheduledRunsBySession.set(localSessionId, remaining);
     publishRunActivity(localSessionId);
   };
-}
-
-async function waitForTurnTerminal(
-  dispatch: TurnIntentDispatch,
-  deadlineMs: number
-): Promise<void> {
-  const { sessionId, generation } = dispatch;
-  const isComplete = (): boolean =>
-    getLastTurnTerminal(sessionId)?.generation === generation;
-  if (isComplete()) return;
-  const store = getInstrumentedStore();
-  await new Promise<void>((resolve, reject) => {
-    const remainingMs = deadlineMs - Date.now();
-    if (remainingMs <= 0) {
-      reject(new Error("address-comments run timed out"));
-      return;
-    }
-    let unsubscribe: (() => void) | null = null;
-    const timer = setTimeout(() => {
-      unsubscribe?.();
-      reject(new Error("address-comments run timed out"));
-    }, remainingMs);
-    const check = (): void => {
-      if (!isComplete()) return;
-      clearTimeout(timer);
-      unsubscribe?.();
-      resolve();
-    };
-    unsubscribe = store.sub(turnLifecycleSignalAtom, check);
-    check();
-  });
 }
 
 function findActiveAddressRunForComment(
@@ -430,12 +392,13 @@ async function executeAddressCommentsRound(
       agentContent: buildAddressCommentsBriefing(threads, instruction),
       turnIntentId,
     });
-    const dispatch = await waitForTurnIntentDispatch(turnIntentId, deadlineMs);
-    if (dispatch.sessionId !== localSessionId) {
+    const outcome = await waitForTurnIntentOutcome(turnIntentId, deadlineMs);
+    if (outcome.sessionId !== localSessionId) {
       throw new Error("address-comments turn dispatched to the wrong session");
     }
-
-    await waitForTurnTerminal(dispatch, deadlineMs);
+    if (outcome.status !== "completed") {
+      throw new Error(`address-comments turn ${outcome.status}`);
+    }
     log.info(
       `address round on ${localSessionId}: ${threads.length} thread(s), ${run.replied.size} agent repl(ies)`
     );

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemContent/__tests__/discussionCommentForward.test.ts
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemContent/__tests__/discussionCommentForward.test.ts
@@ -1,11 +1,29 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { projectApi } from "@src/api/http/project";
 import type { LinkedSession } from "@src/api/http/project/types/agentWorkflow";
+import { dispatchTurn } from "@src/engines/SessionCore/services/TurnDispatchService";
 
 import {
   buildDiscussionForwardMessage,
   pickForwardTargetSession,
+  retryFailedLinkedSession,
 } from "../discussionCommentForward";
+
+vi.mock("@src/api/http/project", () => ({
+  projectApi: {
+    enqueueWorkItemRun: vi.fn(),
+    retryLatestWorkItemRun: vi.fn(),
+  },
+}));
+
+vi.mock("@src/engines/SessionCore/services/TurnDispatchService", () => ({
+  dispatchTurn: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
 
 function linked(overrides: Partial<LinkedSession>): LinkedSession {
   return {
@@ -68,5 +86,47 @@ describe("buildDiscussionForwardMessage", () => {
     expect(content).toContain("org2-pm work note WI-0042 --kind comment");
     expect(content).toContain("Do not change status");
     expect(displayText).toBe("💬 How far along is the export flow?");
+  });
+});
+
+describe("retryFailedLinkedSession", () => {
+  it("uses the typed durable retry without starting a local turn", async () => {
+    vi.mocked(projectApi.retryLatestWorkItemRun).mockResolvedValue({} as never);
+
+    await retryFailedLinkedSession({
+      orgId: "org-1",
+      projectSlug: "demo",
+      shortId: "WI-0042",
+      sessionId: "sdeagent-run",
+    });
+
+    expect(projectApi.retryLatestWorkItemRun).toHaveBeenCalledOnce();
+    expect(dispatchTurn).not.toHaveBeenCalled();
+  });
+
+  it("routes legacy-session fallback through canonical turn dispatch", async () => {
+    vi.mocked(projectApi.retryLatestWorkItemRun).mockRejectedValue(
+      new Error("PM_RUN_ERR:NOT_FOUND")
+    );
+    vi.mocked(dispatchTurn).mockResolvedValue({
+      accepted: true,
+      sessionId: "sdeagent-legacy",
+      turnIntentId: "intent-1",
+      generation: 1,
+      optimisticSource: "dispatch",
+    });
+
+    await retryFailedLinkedSession({
+      shortId: "WI-0042",
+      sessionId: "sdeagent-legacy",
+    });
+
+    expect(dispatchTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "sdeagent-legacy",
+        displayText: "↻ Retry WI-0042",
+        turnIntentSource: "user_submit",
+      })
+    );
   });
 });

--- a/src/modules/ProjectManager/WorkItems/components/WorkItemContent/discussionCommentForward.ts
+++ b/src/modules/ProjectManager/WorkItems/components/WorkItemContent/discussionCommentForward.ts
@@ -11,7 +11,7 @@
  */
 import { projectApi } from "@src/api/http/project";
 import type { LinkedSession } from "@src/api/http/project/types/agentWorkflow";
-import { SessionService } from "@src/engines/SessionCore/services/SessionService";
+import { dispatchTurn } from "@src/engines/SessionCore/services/TurnDispatchService";
 import { createLogger } from "@src/hooks/logger";
 
 const logger = createLogger("discussionCommentForward");
@@ -98,7 +98,7 @@ export async function retryFailedLinkedSession({
     "and deliver through org2-pm with exactly one Discussion receipt.",
   ].join("\n");
   try {
-    await SessionService.sendMessage({
+    await dispatchTurn({
       sessionId,
       content,
       displayText: `↻ Retry ${shortId}`,

--- a/src/scaffold/GlobalSpotlight/palettes/AgentControlPalette/useAgentControlPalette.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/AgentControlPalette/useAgentControlPalette.ts
@@ -14,12 +14,9 @@ import { useTranslation } from "react-i18next";
 import { sessionLaunch } from "@src/api/tauri/agent/session";
 import { DISPATCH_CATEGORY } from "@src/api/tauri/session";
 import Message from "@src/components/Message";
-import {
-  beginOptimisticTurn,
-  failOptimisticTurn,
-} from "@src/engines/SessionCore/control/optimisticTurnStatus";
 import { chatEventsForSessionAtomFamily } from "@src/engines/SessionCore/derived/sessionScopedChatEvents";
 import type { PendingSessionProposal } from "@src/engines/SessionCore/hooks/useAgentADEActions";
+import { dispatchTurn } from "@src/engines/SessionCore/services/TurnDispatchService";
 import type { AdvancedConfig } from "@src/features/SessionCreator/types";
 import { useHousekeeperUiControl } from "@src/hooks/housekeeper";
 import { useValidatedLastPair } from "@src/hooks/models/useValidatedLastPair";
@@ -32,7 +29,6 @@ import {
 } from "@src/store/session/creatorDefaultModelAtom";
 import { modelSelectorAtom } from "@src/store/ui/modelSelectorAtom";
 import { adeManagerEnabledAtom } from "@src/store/ui/uiAtom";
-import { invokeTauri } from "@src/util/platform/tauri";
 import { BUILTIN_ADE_MANAGER_DEF_ID } from "@src/util/session/sessionDispatch";
 
 import { useSelectorKernel } from "../core";
@@ -188,25 +184,13 @@ export function useAgentControlPalette({
         const adeContext = collectAdeContext({ expectedRepoPath: null });
         const existingSessionId = controlSessionIdRef.current;
         if (existingSessionId) {
-          // Raw invoke bypasses useMessageDispatch — if the control session
-          // is also open in the chat panel, the optimistic running keeps its
-          // planning indicator alive (#17). Gated no-op otherwise.
-          beginOptimisticTurn(existingSessionId);
-          try {
-            await invokeTauri("agent_send_message", {
-              sessionId: existingSessionId,
-              content: prompt,
-              turnIntentSource: "user_submit",
-              ...(modelConfig.model ? { model: modelConfig.model } : {}),
-              ...(modelConfig.accountId
-                ? { accountId: modelConfig.accountId }
-                : {}),
-              ideContext: adeContext,
-            });
-          } catch (sendError) {
-            failOptimisticTurn(existingSessionId);
-            throw sendError;
-          }
+          await dispatchTurn({
+            sessionId: existingSessionId,
+            content: prompt,
+            turnIntentSource: "user_submit",
+            model: modelConfig.model,
+            accountId: modelConfig.accountId,
+          });
         } else {
           const result = await sessionLaunch({
             category: DISPATCH_CATEGORY.RUST_AGENT,

--- a/src/store/session/sessionAtom/mutations.ts
+++ b/src/store/session/sessionAtom/mutations.ts
@@ -113,7 +113,7 @@ export const upsertSession = (session: Session) => {
  * Bump a session's activity timestamps to "now".
  *
  * Called when the user performs a real action against the session
- * (currently only sending a prompt — see `SessionService.sendMessage`).
+ * (currently only sending a prompt — see `TurnDispatchService`).
  * Updates `updated_at` / `updated_time` so views ordered by "recent
  * activity" (sidebar, Kanban) reflect the action immediately, without
  * waiting for the next session list refresh.

--- a/src/store/ui/messageQueueAtom.ts
+++ b/src/store/ui/messageQueueAtom.ts
@@ -19,7 +19,7 @@ export interface QueuedMessage {
    *
    *   QueuedMessage           (this field)
    *   createSyntheticUserEvent options.turnIntentId
-   *   SessionService.sendMessage params.turnIntentId
+   *   TurnDispatchService params.turnIntentId
    *   agent_send_message Tauri command turnIntentId
    *   ScheduledMessage.turn_intent_id
    *   TurnInput.turn_intent_id


### PR DESCRIPTION
## Problem

Agent turn producers currently own overlapping copies of optimistic status, turn-generation reservation, transport dispatch, activity timestamps, and terminal waiting. Composer, queue, side chat, mode-switch resume, plan execution, Work Item retry, and address-comments can therefore drift in idempotency and finality behavior.

## Solution

- Route interactive and headless Agent sends through the canonical `TurnDispatchService` introduced by the stacked dispatcher PR.
- Preserve UI-specific transcript writes at the producer boundary while deleting duplicated transport/FSM bookkeeping.
- Make address-comments wait for the exact dispatched intent outcome instead of maintaining a second terminal watcher.
- Keep durable WorkItemRun retry as the primary path and route only the legacy local-session fallback through canonical dispatch.
- Leave Team Chat and its human-message plane unchanged; audience routing remains owned by the separate routing PR.

## Potential risks

- This PR is intentionally stacked on #941 and should be reviewed or merged after #940 and #941.
- Headless paths now inherit durable receipt reconciliation and exact-generation finality from the dispatcher, so previously silent failed/cancelled address-comment turns are surfaced as failures.
- No cloud API, conversation-plane schema, Team Chat transport, or deployment workflow changes are included.

## Validation

- `pnpm typecheck`
- ESLint and Prettier on all 16 changed files
- 8 focused Vitest files, 40 tests passed
- Madge scan from the migrated entry points: 984 files, no circular dependency
- Repository commit hooks passed
