### PR TITLE
refactor(conversation): centralize execution registry

### DIFF
--- a/src/engines/ChatPanel/hooks/useImportedSessionSubmitOverride.ts
+++ b/src/engines/ChatPanel/hooks/useImportedSessionSubmitOverride.ts
@@ -12,6 +12,7 @@ import {
   type ConversationFamilyMember,
   resolveConversationFamily,
 } from "@src/features/Org2Cloud/SessionConversation/continuationEvents";
+import { cloudConversationExecutorScopeKey } from "@src/features/Org2Cloud/SessionConversation/conversationExecutionStore";
 import { publishOwnerTurn } from "@src/features/Org2Cloud/SessionConversation/conversationOwnerPublisher";
 import {
   bumpConversationPlaneSignal,
@@ -33,6 +34,7 @@ import {
 import {
   commitRefreshedAuth,
   org2CloudAuthAtom,
+  org2CloudAuthIdentityKey,
 } from "@src/features/Org2Cloud/org2CloudAuthAtom";
 import { ensureFreshSession } from "@src/features/Org2Cloud/org2CloudClient";
 import { org2CloudRemoteSessionsAtom } from "@src/features/Org2Cloud/org2CloudRemoteSessionsAtom";
@@ -320,6 +322,10 @@ export function useImportedSessionSubmitOverride({
             timeline,
             sourceScopeKey: rootRow?.repoScopeKey,
             sourceModel: currentSession?.model ?? rootRow?.model,
+            executionScopeKey: cloudConversationExecutorScopeKey(
+              org2CloudAuthIdentityKey(auth),
+              planeInfo.orgId
+            ),
             onRunnerReady: (runnerSessionId, turnId) => {
               // Plumbing session: never sync it to the cloud as a session.
               setAccessSettings((current) =>

--- a/src/features/Org2Cloud/SessionConversation/conversationExecutionStore.test.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationExecutionStore.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  __CONVERSATION_EXECUTION_STORE_INTERNALS,
+  cloudConversationExecutorScopeKey,
+  collectStoredRunnerSessionIds,
+  conversationExecutionKey,
+  forgetStoredRunner,
+  loadStoredRunnerRegistryEntry,
+  markStoredRunnerTerminal,
+  registerStoredRunner,
+} from "./conversationExecutionStore";
+
+function fakeStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: (key) => values.get(key) ?? null,
+    key: (index) => [...values.keys()][index] ?? null,
+    removeItem: (key) => {
+      values.delete(key);
+    },
+    setItem: (key, value) => {
+      values.set(key, value);
+    },
+  };
+}
+
+describe("conversation execution store", () => {
+  it("keys execution by account, organization, and root session", () => {
+    const scope = cloudConversationExecutorScopeKey(
+      "https://cloud.example|user-b",
+      "cloud-org"
+    );
+
+    expect(scope).toBe(
+      JSON.stringify([
+        "cloud-conversation-executor",
+        "https://cloud.example|user-b",
+        "cloud-org",
+      ])
+    );
+    expect(conversationExecutionKey(scope, "root-a")).not.toBe(
+      conversationExecutionKey(scope, "root-b")
+    );
+    expect(
+      conversationExecutionKey(
+        cloudConversationExecutorScopeKey(
+          "https://cloud.example|user-c",
+          "cloud-org"
+        ),
+        "root-a"
+      )
+    ).not.toBe(conversationExecutionKey(scope, "root-a"));
+  });
+
+  it("uses tuple keys without colon collisions", () => {
+    expect(conversationExecutionKey("a:b", "c")).not.toBe(
+      conversationExecutionKey("a", "b:c")
+    );
+  });
+
+  it("persists and sanitizes runner lifecycle per conversation", () => {
+    const backing = fakeStorage();
+    const key = conversationExecutionKey("scope", "root");
+
+    registerStoredRunner(key, "runner-1", "2026-08-25T00:00:00Z", backing);
+    registerStoredRunner(key, "runner-1", "2026-08-25T00:00:01Z", backing);
+    registerStoredRunner(key, "runner-2", "2026-08-25T00:00:02Z", backing);
+    markStoredRunnerTerminal(key, "runner-1", backing);
+
+    expect(loadStoredRunnerRegistryEntry(key, backing)).toMatchObject({
+      runnerSessionIds: ["runner-1", "runner-2"],
+      terminalRunnerSessionIds: ["runner-1"],
+    });
+    expect(collectStoredRunnerSessionIds(backing)).toEqual(
+      new Set(["runner-1", "runner-2"])
+    );
+  });
+
+  it("keeps legacy one-shot runner ids hidden after upgrade", () => {
+    const backing = fakeStorage();
+    backing.setItem(
+      __CONVERSATION_EXECUTION_STORE_INTERNALS.LEGACY_RUNNERS_KEY,
+      JSON.stringify({
+        "org:root": {
+          runnerSessionIds: ["legacy-runner", "legacy-runner", ""],
+          updatedAt: "2026-08-24T00:00:00Z",
+        },
+        broken: { runnerSessionIds: "not-an-array" },
+      })
+    );
+
+    expect(collectStoredRunnerSessionIds(backing)).toEqual(
+      new Set(["legacy-runner"])
+    );
+  });
+
+  it("isolates malformed entries and recovers on the next valid write", () => {
+    const backing = fakeStorage();
+    const key = conversationExecutionKey("scope", "root");
+    backing.setItem(
+      __CONVERSATION_EXECUTION_STORE_INTERNALS.entryStorageKey(key),
+      "{not-json"
+    );
+
+    expect(loadStoredRunnerRegistryEntry(key, backing)).toBeNull();
+    registerStoredRunner(key, "runner-1", "2026-08-25T00:00:00Z", backing);
+    expect(
+      loadStoredRunnerRegistryEntry(key, backing)?.runnerSessionIds
+    ).toEqual(["runner-1"]);
+  });
+
+  it("does not lose an unrelated window write during a nested write", () => {
+    const values = new Map<string, string>();
+    const first = conversationExecutionKey("scope", "first");
+    const second = conversationExecutionKey("scope", "second");
+    const firstStorageKey =
+      __CONVERSATION_EXECUTION_STORE_INTERNALS.entryStorageKey(first);
+    let nested = false;
+    const backing: Storage = {
+      get length() {
+        return values.size;
+      },
+      clear: () => values.clear(),
+      getItem: (key) => values.get(key) ?? null,
+      key: (index) => [...values.keys()][index] ?? null,
+      removeItem: (key) => {
+        values.delete(key);
+      },
+      setItem: (key, value) => {
+        if (key === firstStorageKey && !nested) {
+          nested = true;
+          registerStoredRunner(
+            second,
+            "runner-second",
+            "2026-08-25T00:00:01Z",
+            backing
+          );
+        }
+        values.set(key, value);
+      },
+    };
+
+    registerStoredRunner(
+      first,
+      "runner-first",
+      "2026-08-25T00:00:00Z",
+      backing
+    );
+
+    expect(
+      loadStoredRunnerRegistryEntry(first, backing)?.runnerSessionIds
+    ).toEqual(["runner-first"]);
+    expect(
+      loadStoredRunnerRegistryEntry(second, backing)?.runnerSessionIds
+    ).toEqual(["runner-second"]);
+  });
+
+  it("forgets current and legacy runners without touching siblings", () => {
+    const backing = fakeStorage();
+    const first = conversationExecutionKey("scope", "first");
+    const second = conversationExecutionKey("scope", "second");
+    registerStoredRunner(first, "remove-me", "2026-08-25T00:00:00Z", backing);
+    registerStoredRunner(
+      first,
+      "keep-current",
+      "2026-08-25T00:00:01Z",
+      backing
+    );
+    registerStoredRunner(second, "keep-other", "2026-08-25T00:00:02Z", backing);
+    backing.setItem(
+      __CONVERSATION_EXECUTION_STORE_INTERNALS.LEGACY_RUNNERS_KEY,
+      JSON.stringify({
+        "org:root": {
+          runnerSessionIds: ["remove-me", "keep-legacy"],
+          terminalRunnerSessionIds: ["remove-me"],
+          updatedAt: "2026-08-24T00:00:00Z",
+        },
+      })
+    );
+
+    forgetStoredRunner("remove-me", backing);
+
+    expect(collectStoredRunnerSessionIds(backing)).toEqual(
+      new Set(["keep-current", "keep-other", "keep-legacy"])
+    );
+    expect(loadStoredRunnerRegistryEntry(first, backing)).toMatchObject({
+      runnerSessionIds: ["keep-current"],
+      terminalRunnerSessionIds: [],
+    });
+  });
+});

--- a/src/features/Org2Cloud/SessionConversation/conversationExecutionStore.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationExecutionStore.ts
@@ -1,0 +1,306 @@
+/**
+ * The single local persistence boundary for shared-conversation execution.
+ *
+ * Each (executor scope, root session) has its own localStorage entry. Keeping
+ * entries split prevents an unrelated conversation write in another desktop
+ * window from replacing the whole registry blob. The legacy one-shot runner
+ * blob remains readable so an upgrade never exposes plumbing sessions in My
+ * Sessions.
+ */
+
+const STORE_VERSION = 1 as const;
+const STORAGE_KEY_PREFIX = "orgii:conversation-execution-v1:";
+const LEGACY_RUNNERS_KEY = "orgii:conversation-runners-v1";
+const UNKNOWN_UPDATED_AT = "1970-01-01T00:00:00.000Z";
+
+export interface ConversationRunnerRegistryEntry {
+  runnerSessionIds: string[];
+  terminalRunnerSessionIds: string[];
+  updatedAt: string;
+}
+
+interface ConversationExecutionEnvelope {
+  version: typeof STORE_VERSION;
+  runners?: ConversationRunnerRegistryEntry;
+}
+
+function defaultStorage(): Storage | null {
+  return typeof localStorage === "undefined" ? null : localStorage;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readJson(backing: Storage | null, key: string): unknown {
+  if (!backing) return null;
+  try {
+    const raw = backing.getItem(key);
+    return raw ? (JSON.parse(raw) as unknown) : null;
+  } catch {
+    return null;
+  }
+}
+
+function uniqueStrings(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return [
+    ...new Set(
+      value.filter(
+        (candidate): candidate is string =>
+          typeof candidate === "string" && candidate.length > 0
+      )
+    ),
+  ];
+}
+
+function sanitizeRunners(
+  value: unknown
+): ConversationRunnerRegistryEntry | null {
+  if (!isObject(value)) return null;
+  const runnerSessionIds = uniqueStrings(value.runnerSessionIds);
+  if (runnerSessionIds.length === 0) return null;
+  const registered = new Set(runnerSessionIds);
+  return {
+    runnerSessionIds,
+    terminalRunnerSessionIds: uniqueStrings(
+      value.terminalRunnerSessionIds
+    ).filter((sessionId) => registered.has(sessionId)),
+    updatedAt:
+      typeof value.updatedAt === "string"
+        ? value.updatedAt
+        : UNKNOWN_UPDATED_AT,
+  };
+}
+
+function normalizeExecutionKey(key: string): string | null {
+  try {
+    const parsed = JSON.parse(key) as unknown;
+    return Array.isArray(parsed) &&
+      parsed.length === 2 &&
+      parsed.every((part) => typeof part === "string" && part.length > 0)
+      ? JSON.stringify(parsed)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function entryStorageKey(executionKey: string): string {
+  return `${STORAGE_KEY_PREFIX}${encodeURIComponent(executionKey)}`;
+}
+
+function executionKeyFromStorageKey(storageKey: string): string | null {
+  if (!storageKey.startsWith(STORAGE_KEY_PREFIX)) return null;
+  try {
+    return normalizeExecutionKey(
+      decodeURIComponent(storageKey.slice(STORAGE_KEY_PREFIX.length))
+    );
+  } catch {
+    return null;
+  }
+}
+
+function readEnvelope(
+  backing: Storage | null,
+  executionKey: string
+): ConversationExecutionEnvelope | null {
+  const parsed = readJson(backing, entryStorageKey(executionKey));
+  if (!isObject(parsed) || parsed.version !== STORE_VERSION) return null;
+  const runners = sanitizeRunners(parsed.runners);
+  return {
+    version: STORE_VERSION,
+    ...(runners ? { runners } : {}),
+  };
+}
+
+function writeRunners(
+  backing: Storage | null,
+  executionKey: string,
+  runners: ConversationRunnerRegistryEntry | null
+): void {
+  if (!backing) return;
+  try {
+    if (!runners) {
+      backing.removeItem(entryStorageKey(executionKey));
+      return;
+    }
+    const envelope: ConversationExecutionEnvelope = {
+      version: STORE_VERSION,
+      runners,
+    };
+    backing.setItem(entryStorageKey(executionKey), JSON.stringify(envelope));
+  } catch {
+    // Best-effort: losing this registry only makes a plumbing row visible.
+  }
+}
+
+function allStorageKeys(backing: Storage | null): string[] {
+  if (!backing) return [];
+  const keys: string[] = [];
+  for (let index = 0; index < backing.length; index += 1) {
+    const key = backing.key(index);
+    if (key) keys.push(key);
+  }
+  return keys;
+}
+
+function readLegacyRunnerMap(backing: Storage | null): Record<string, unknown> {
+  const parsed = readJson(backing, LEGACY_RUNNERS_KEY);
+  return isObject(parsed) ? parsed : {};
+}
+
+export function conversationExecutionKey(
+  executorScope: string,
+  rootSessionId: string
+): string {
+  return JSON.stringify([executorScope, rootSessionId]);
+}
+
+/** One executor per signed-in cloud identity and organization. */
+export function cloudConversationExecutorScopeKey(
+  authIdentity: string,
+  cloudOrgId: string
+): string {
+  return JSON.stringify([
+    "cloud-conversation-executor",
+    authIdentity,
+    cloudOrgId,
+  ]);
+}
+
+export function loadStoredRunnerRegistryEntry(
+  key: string,
+  backing: Storage | null = defaultStorage()
+): ConversationRunnerRegistryEntry | null {
+  const normalized = normalizeExecutionKey(key);
+  return normalized
+    ? (readEnvelope(backing, normalized)?.runners ?? null)
+    : null;
+}
+
+export function registerStoredRunner(
+  key: string,
+  runnerSessionId: string,
+  updatedAt: string,
+  backing: Storage | null = defaultStorage()
+): void {
+  const normalized = normalizeExecutionKey(key);
+  if (!normalized)
+    throw new Error(`invalid conversation execution key: ${key}`);
+  const current = readEnvelope(backing, normalized)?.runners;
+  writeRunners(backing, normalized, {
+    runnerSessionIds: [
+      ...new Set([...(current?.runnerSessionIds ?? []), runnerSessionId]),
+    ],
+    terminalRunnerSessionIds: current?.terminalRunnerSessionIds ?? [],
+    updatedAt,
+  });
+}
+
+export function markStoredRunnerTerminal(
+  key: string,
+  runnerSessionId: string,
+  backing: Storage | null = defaultStorage()
+): void {
+  const normalized = normalizeExecutionKey(key);
+  if (!normalized) return;
+  const current = readEnvelope(backing, normalized)?.runners;
+  if (!current?.runnerSessionIds.includes(runnerSessionId)) return;
+  writeRunners(backing, normalized, {
+    ...current,
+    terminalRunnerSessionIds: [
+      ...new Set([...current.terminalRunnerSessionIds, runnerSessionId]),
+    ],
+    updatedAt: new Date().toISOString(),
+  });
+}
+
+/** Every current and legacy runner id on this device. */
+export function collectStoredRunnerSessionIds(
+  backing: Storage | null = defaultStorage()
+): Set<string> {
+  const sessionIds = new Set<string>();
+  for (const storageKey of allStorageKeys(backing)) {
+    const executionKey = executionKeyFromStorageKey(storageKey);
+    if (!executionKey) continue;
+    for (const sessionId of readEnvelope(backing, executionKey)?.runners
+      ?.runnerSessionIds ?? []) {
+      sessionIds.add(sessionId);
+    }
+  }
+  for (const value of Object.values(readLegacyRunnerMap(backing))) {
+    for (const sessionId of sanitizeRunners(value)?.runnerSessionIds ?? []) {
+      sessionIds.add(sessionId);
+    }
+  }
+  return sessionIds;
+}
+
+export function forgetStoredRunner(
+  runnerSessionId: string,
+  backing: Storage | null = defaultStorage()
+): void {
+  for (const storageKey of allStorageKeys(backing)) {
+    const executionKey = executionKeyFromStorageKey(storageKey);
+    if (!executionKey) continue;
+    const current = readEnvelope(backing, executionKey)?.runners;
+    if (!current?.runnerSessionIds.includes(runnerSessionId)) continue;
+    const runnerSessionIds = current.runnerSessionIds.filter(
+      (sessionId) => sessionId !== runnerSessionId
+    );
+    writeRunners(
+      backing,
+      executionKey,
+      runnerSessionIds.length > 0
+        ? {
+            ...current,
+            runnerSessionIds,
+            terminalRunnerSessionIds: current.terminalRunnerSessionIds.filter(
+              (sessionId) => sessionId !== runnerSessionId
+            ),
+          }
+        : null
+    );
+  }
+
+  if (!backing) return;
+  const legacy = readLegacyRunnerMap(backing);
+  let legacyChanged = false;
+  for (const [key, value] of Object.entries(legacy)) {
+    const current = sanitizeRunners(value);
+    if (!current?.runnerSessionIds.includes(runnerSessionId)) continue;
+    legacyChanged = true;
+    const runnerSessionIds = current.runnerSessionIds.filter(
+      (sessionId) => sessionId !== runnerSessionId
+    );
+    if (runnerSessionIds.length === 0) {
+      delete legacy[key];
+    } else {
+      legacy[key] = {
+        ...current,
+        runnerSessionIds,
+        terminalRunnerSessionIds: current.terminalRunnerSessionIds.filter(
+          (sessionId) => sessionId !== runnerSessionId
+        ),
+      };
+    }
+  }
+  if (!legacyChanged) return;
+  try {
+    if (Object.keys(legacy).length === 0) {
+      backing.removeItem(LEGACY_RUNNERS_KEY);
+    } else {
+      backing.setItem(LEGACY_RUNNERS_KEY, JSON.stringify(legacy));
+    }
+  } catch {
+    // Best-effort cleanup mirrors current-entry writes.
+  }
+}
+
+export const __CONVERSATION_EXECUTION_STORE_INTERNALS = {
+  STORE_VERSION,
+  STORAGE_KEY_PREFIX,
+  LEGACY_RUNNERS_KEY,
+  entryStorageKey,
+};

--- a/src/features/Org2Cloud/SessionConversation/conversationRunnerSessions.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationRunnerSessions.ts
@@ -1,0 +1,34 @@
+/** Local registry facade for invisible shared-conversation runners. */
+import {
+  collectStoredRunnerSessionIds,
+  conversationExecutionKey,
+  markStoredRunnerTerminal,
+  registerStoredRunner,
+} from "./conversationExecutionStore";
+
+export function conversationRunnerKey(
+  executorScope: string,
+  rootSessionId: string
+): string {
+  return conversationExecutionKey(executorScope, rootSessionId);
+}
+
+/** Every runner session id on this device — the My Sessions hide filter. */
+export function collectConversationRunnerSessionIds(): Set<string> {
+  return collectStoredRunnerSessionIds();
+}
+
+export function registerConversationRunner(
+  key: string,
+  runnerSessionId: string,
+  updatedAt: string
+): void {
+  registerStoredRunner(key, runnerSessionId, updatedAt);
+}
+
+export function markConversationRunnerTerminal(
+  key: string,
+  runnerSessionId: string
+): void {
+  markStoredRunnerTerminal(key, runnerSessionId);
+}

--- a/src/features/Org2Cloud/SessionConversation/conversationTurnRunner.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationTurnRunner.ts
@@ -44,54 +44,18 @@ import {
   pushConversationEvents,
   pushConversationEventsChunked,
 } from "../org2CloudConversationEventsClient";
+import {
+  conversationRunnerKey,
+  markConversationRunnerTerminal,
+  registerConversationRunner,
+} from "./conversationRunnerSessions";
 
 const log = createLogger("ConversationTurnRunner");
 
-const RUNNER_REGISTRY_KEY = "orgii:conversation-runners-v1";
 const TURN_DEADLINE_MS = 15 * 60_000;
 const CONTEXT_MAX_ENTRIES = 60;
 const CONTEXT_MAX_ENTRY_CHARS = 600;
 const CONTEXT_MAX_TOTAL_CHARS = 18_000;
-
-interface RunnerRegistryEntry {
-  /** Every one-shot runner this device created for the conversation. */
-  runnerSessionIds: string[];
-  updatedAt: string;
-}
-
-type RunnerRegistry = Record<string, RunnerRegistryEntry>;
-
-function registryKey(orgId: string, rootSessionId: string): string {
-  return `${orgId}:${rootSessionId}`;
-}
-
-function readRegistry(): RunnerRegistry {
-  if (typeof localStorage === "undefined") return {};
-  try {
-    const raw = localStorage.getItem(RUNNER_REGISTRY_KEY);
-    return raw ? (JSON.parse(raw) as RunnerRegistry) : {};
-  } catch {
-    return {};
-  }
-}
-
-function writeRegistry(registry: RunnerRegistry): void {
-  if (typeof localStorage === "undefined") return;
-  try {
-    localStorage.setItem(RUNNER_REGISTRY_KEY, JSON.stringify(registry));
-  } catch {
-    // Best-effort: losing the registry only means runners stop being hidden.
-  }
-}
-
-/** Every runner session id on this device — the My Sessions hide filter. */
-export function collectConversationRunnerSessionIds(): Set<string> {
-  const ids = new Set<string>();
-  for (const entry of Object.values(readRegistry())) {
-    for (const id of entry.runnerSessionIds ?? []) ids.add(id);
-  }
-  return ids;
-}
 
 /** Conversation timeline rendered as a bounded read-only context block. */
 export function renderConversationContext(
@@ -214,6 +178,8 @@ export interface RunConversationTurnParams {
   timeline: readonly SessionEvent[];
   sourceScopeKey?: string;
   sourceModel?: string;
+  /** Account-and-org-scoped local executor identity. */
+  executionScopeKey?: string;
   /**
    * Called as soon as the one-shot runner session id is known, with the
    * turnId the tail will be pushed under. The caller overlays the runner's
@@ -238,7 +204,10 @@ export interface RunConversationTurnResult {
 export async function runConversationTurn(
   params: RunConversationTurnParams
 ): Promise<RunConversationTurnResult> {
-  const key = registryKey(params.orgId, params.rootSessionId);
+  const key = conversationRunnerKey(
+    params.executionScopeKey ?? params.orgId,
+    params.rootSessionId
+  );
   const contextBlock = renderConversationContext(params.timeline);
   const request = params.agentContent ?? params.displayText;
   const deadlineMs = Date.now() + TURN_DEADLINE_MS;
@@ -312,17 +281,10 @@ export async function runConversationTurn(
     );
   }
   const runnerSessionId = created.sessionId;
-  const registry = readRegistry();
-  const entry = registry[key];
-  writeRegistry({
-    ...registry,
-    [key]: {
-      runnerSessionIds: [...(entry?.runnerSessionIds ?? []), runnerSessionId],
-      updatedAt: dispatchIso,
-    },
-  });
+  registerConversationRunner(key, runnerSessionId, dispatchIso);
   params.onRunnerReady?.(runnerSessionId, turnId);
   await waitForFirstTurnTerminal(runnerSessionId, deadlineMs);
+  markConversationRunnerTerminal(key, runnerSessionId);
 
   const persisted = await eventStoreProxy
     .getPersistedEvents(runnerSessionId)

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.tsx
@@ -34,7 +34,7 @@ import { useTranslation } from "react-i18next";
 import { deleteSession as deleteLocalSession } from "@src/api/tauri/agent";
 import { deleteOrgtrackCollaborationSession } from "@src/api/tauri/lineage";
 import Message from "@src/components/Message";
-import { collectConversationRunnerSessionIds } from "@src/features/Org2Cloud/SessionConversation/conversationTurnRunner";
+import { collectConversationRunnerSessionIds } from "@src/features/Org2Cloud/SessionConversation/conversationRunnerSessions";
 import {
   hiddenRemoteSessionKey,
   readHiddenRemoteSessionIds,


### PR DESCRIPTION
## Problem

Shared-conversation one-shot runners persist their hidden-session registry directly inside `conversationTurnRunner` as one global localStorage blob keyed with colon-concatenated organization and session ids. That couples execution to sidebar policy, permits key collisions, can lose an unrelated conversation update from another desktop window, and does not isolate records across cloud accounts.

## Solution

- Add one canonical local conversation execution store with a separate entry per `(executor scope, root session)` tuple.
- Scope new records by signed-in cloud identity plus organization, while preserving the root session as the second identity dimension.
- Move runner hiding and lifecycle registration behind a small `conversationRunnerSessions` facade.
- Keep reading the shipped legacy one-shot registry so upgrades never reveal plumbing sessions in My Sessions.
- Record proven terminal runners for later safe cleanup without adding continuation behavior in this PR.
- Leave Team Chat, audience routing, cloud schemas, Work Item dispatch, and the current one-shot execution semantics unchanged.

## Potential risks

- This PR is intentionally stacked on #942 and should be reviewed or merged after #940, #941, and #942.
- A failed localStorage write remains best-effort, matching current behavior; the visible failure mode is only a local plumbing row appearing in My Sessions.
- Legacy records are retained and read rather than destructively rewritten because the old key lacks account identity.

## Validation

- `pnpm typecheck`
- ESLint and Prettier on all 6 changed files
- 3 focused Vitest files, 29 tests passed
- Conversation execution-store suite: 7 tests covering account isolation, tuple collisions, legacy visibility, malformed data, nested window writes, lifecycle, and cleanup
- Madge scan from all changed entry points: 1220 files, no circular dependency
- Repository commit hooks passed
