### PR TITLE
fix(chat): copy complete assistant turns

### DIFF
--- a/docs/frontend-ui-audit-2026-08-25/TurnCopyFooter.md
+++ b/docs/frontend-ui-audit-2026-08-25/TurnCopyFooter.md
@@ -1,0 +1,27 @@
+# Frontend UI Audit: Turn Copy Footer
+
+## Scope
+
+- `src/components/MessageFooter/index.tsx`
+- `src/engines/ChatPanel/blocks/AgentMessageBlock/index.tsx`
+- `src/engines/ChatPanel/ChatHistory/renderers/GroupItemRenderer.tsx`
+
+The configured `frontend-ui-audit` skill file is not present at the workspace path documented in `AGENTS.md`. This report applies the repository's stated audit dimensions directly: shared-component usage, design-token consistency, arbitrary Tailwind values, accessibility basics, and visual-pattern duplication.
+
+## Findings
+
+| Line                                                                    | Element               | Verdict          | Reason                                                                                                                                               | Suggested change                                                                      |
+| ----------------------------------------------------------------------- | --------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `src/components/MessageFooter/index.tsx:35`                             | copy action input     | fix              | A static message string bound the round-level action to the surviving rendered item, so collapsed projection silently changed copy semantics.        | Resolve the authoritative turn content lazily from the turn context on click.         |
+| `src/components/MessageFooter/index.tsx:49`                             | clipboard write       | fix              | Direct `navigator.clipboard` use had no fallback or user-visible failure state.                                                                      | Reuse the shared clipboard helper and keep the button retryable after an error toast. |
+| `src/engines/ChatPanel/blocks/AgentMessageBlock/index.tsx:139`          | accessible copy label | keep with reason | The native icon button keeps its keyboard/focus treatment and now uses the existing localized `Copy turn` label, which describes the action's scope. | None.                                                                                 |
+| `src/engines/ChatPanel/ChatHistory/renderers/GroupItemRenderer.tsx:441` | turn action ownership | keep with reason | Copy source ids and the resolver travel through the existing turn context instead of introducing a second DOM lookup or global UI state owner.       | None.                                                                                 |
+
+## Summary
+
+- Fix: 2
+- Keep with reason: 2
+- Abstract: 0
+- Multi-file sweep candidates: 0
+
+No new arbitrary Tailwind values, color literals, duplicate copy controls, or unlabeled interactive elements were introduced.

--- a/src/components/MessageFooter/MessageFooter.copy.test.ts
+++ b/src/components/MessageFooter/MessageFooter.copy.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+// Exercises the click boundary; static markup coverage lives in index.test.ts.
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import MessageFooter from ".";
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+beforeAll(() => {
+  reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+afterAll(() => {
+  Reflect.deleteProperty(reactActEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+});
+
+const mocks = vi.hoisted(() => ({
+  copyText: vi.fn<(...args: [string]) => Promise<void>>(),
+  error: vi.fn(),
+  success: vi.fn(),
+}));
+
+vi.mock("@src/util/data/clipboard", () => ({ copyText: mocks.copyText }));
+vi.mock("@src/components/Message", () => ({
+  default: { error: mocks.error, success: mocks.success },
+}));
+
+describe("MessageFooter copy behavior", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mocks.copyText.mockReset();
+    mocks.copyText.mockResolvedValue(undefined);
+    mocks.error.mockReset();
+    mocks.success.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("resolves the complete turn only when the user clicks copy", async () => {
+    const getCopyContent = vi.fn(() => "first update\n\nfinal answer");
+    await act(async () => {
+      root.render(
+        createElement(MessageFooter, {
+          getCopyContent,
+          timestamp: "2026-08-25T00:00:00.000Z",
+          timestampLabel: "08:00",
+          copyLabel: "Copy turn",
+          copiedLabel: "Copied",
+          copyFailedLabel: "Copy failed",
+        })
+      );
+    });
+
+    expect(getCopyContent).not.toHaveBeenCalled();
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>("[data-testid=message-footer-copy]")
+        ?.click();
+    });
+
+    expect(getCopyContent).toHaveBeenCalledTimes(1);
+    expect(mocks.copyText).toHaveBeenCalledWith("first update\n\nfinal answer");
+    expect(mocks.success).toHaveBeenCalledWith("Copied");
+    expect(mocks.error).not.toHaveBeenCalled();
+  });
+
+  it("keeps the action retryable when resolution or clipboard writing fails", async () => {
+    const getCopyContent = vi
+      .fn<() => string>()
+      .mockReturnValueOnce("")
+      .mockReturnValue("complete answer");
+    mocks.copyText.mockRejectedValueOnce(new Error("denied"));
+
+    await act(async () => {
+      root.render(
+        createElement(MessageFooter, {
+          getCopyContent,
+          timestamp: "",
+          timestampLabel: "",
+          copyLabel: "Copy turn",
+          copiedLabel: "Copied",
+          copyFailedLabel: "Copy failed",
+        })
+      );
+    });
+    const copyButton = container.querySelector<HTMLButtonElement>(
+      "[data-testid=message-footer-copy]"
+    );
+
+    await act(async () => copyButton?.click());
+    await act(async () => copyButton?.click());
+
+    expect(mocks.error).toHaveBeenCalledTimes(2);
+    expect(mocks.copyText).toHaveBeenCalledTimes(1);
+    expect(container.contains(copyButton)).toBe(true);
+  });
+});

--- a/src/components/MessageFooter/index.test.ts
+++ b/src/components/MessageFooter/index.test.ts
@@ -8,11 +8,12 @@ describe("MessageFooter", () => {
   it("renders a semantic timestamp and an icon-only hover copy action", () => {
     const markup = renderToStaticMarkup(
       createElement(MessageFooter, {
-        content: "Completed response",
+        getCopyContent: () => "Completed response",
         timestamp: "2026-07-15T06:45:00.000Z",
         timestampLabel: "14:45",
         copyLabel: "Copy",
         copiedLabel: "Copied",
+        copyFailedLabel: "Copy failed",
       })
     );
 
@@ -28,11 +29,11 @@ describe("MessageFooter", () => {
   it("does not render without copyable content or timestamp text", () => {
     const markup = renderToStaticMarkup(
       createElement(MessageFooter, {
-        content: "   ",
         timestamp: "",
         timestampLabel: "",
         copyLabel: "Copy",
         copiedLabel: "Copied",
+        copyFailedLabel: "Copy failed",
       })
     );
 

--- a/src/components/MessageFooter/index.tsx
+++ b/src/components/MessageFooter/index.tsx
@@ -9,6 +9,7 @@ import { Copy } from "lucide-react";
 import React, { memo, useCallback } from "react";
 
 import Message from "@src/components/Message";
+import { copyText } from "@src/util/data/clipboard";
 
 export interface MessageFooterTimestampProps {
   dateTime: string;
@@ -32,23 +33,30 @@ export const MessageFooterTimestamp: React.FC<MessageFooterTimestampProps> =
 MessageFooterTimestamp.displayName = "MessageFooterTimestamp";
 
 export interface MessageFooterCopyButtonProps {
-  content: string;
+  getCopyContent?: () => string;
   copyLabel: string;
   copiedLabel: string;
+  copyFailedLabel: string;
 }
 
 export const MessageFooterCopyButton: React.FC<MessageFooterCopyButtonProps> =
-  memo(({ content, copyLabel, copiedLabel }) => {
+  memo(({ getCopyContent, copyLabel, copiedLabel, copyFailedLabel }) => {
     const handleCopy = useCallback(
       async (event: React.MouseEvent<HTMLButtonElement>) => {
         event.stopPropagation();
-        await navigator.clipboard.writeText(content);
-        Message.success(copiedLabel);
+        try {
+          const content = getCopyContent?.() ?? "";
+          if (!content.trim()) throw new Error("Copy content is unavailable");
+          await copyText(content);
+          Message.success(copiedLabel);
+        } catch {
+          Message.error(copyFailedLabel);
+        }
       },
-      [content, copiedLabel]
+      [copiedLabel, copyFailedLabel, getCopyContent]
     );
 
-    if (!content.trim()) return null;
+    if (!getCopyContent) return null;
 
     return (
       <button
@@ -67,24 +75,26 @@ export const MessageFooterCopyButton: React.FC<MessageFooterCopyButtonProps> =
 MessageFooterCopyButton.displayName = "MessageFooterCopyButton";
 
 export interface MessageFooterProps {
-  content: string;
+  getCopyContent?: () => string;
   timestamp: string;
   timestampLabel: string;
   copyLabel: string;
   copiedLabel: string;
+  copyFailedLabel: string;
   className?: string;
 }
 
 const MessageFooter: React.FC<MessageFooterProps> = memo(
   ({
-    content,
+    getCopyContent,
     timestamp,
     timestampLabel,
     copyLabel,
     copiedLabel,
+    copyFailedLabel,
     className = "",
   }) => {
-    if (!content.trim() && !timestampLabel) return null;
+    if (!getCopyContent && !timestampLabel) return null;
 
     return (
       <div
@@ -93,9 +103,10 @@ const MessageFooter: React.FC<MessageFooterProps> = memo(
       >
         <MessageFooterTimestamp dateTime={timestamp} label={timestampLabel} />
         <MessageFooterCopyButton
-          content={content}
+          getCopyContent={getCopyContent}
           copyLabel={copyLabel}
           copiedLabel={copiedLabel}
+          copyFailedLabel={copyFailedLabel}
         />
       </div>
     );

--- a/src/engines/ChatPanel/ChatHistory/AgentTurnContext.tsx
+++ b/src/engines/ChatPanel/ChatHistory/AgentTurnContext.tsx
@@ -32,6 +32,10 @@ export interface AgentTurnContextValue {
    *  message event in the current group. `null` when no completed
    *  assistant message exists in the group yet. */
   lastAssistantFlatIndex: number | null;
+  /** Resident, completed assistant-message ids for copy-turn behavior. */
+  assistantCopyEventIds: readonly string[];
+  /** Resolves copy text lazily from the current uncollapsed projection. */
+  resolveAssistantTurnCopyContent: (eventIds: readonly string[]) => string;
   /** True when this turn is the most recent group in the chat — i.e. the
    *  user has not started a follow-up turn after it. Consumers that
    *  surface "resume this turn" affordances (AgentErrorChatItem's Resume

--- a/src/engines/ChatPanel/ChatHistory/TEST_CASES.md
+++ b/src/engines/ChatPanel/ChatHistory/TEST_CASES.md
@@ -65,7 +65,7 @@
 - [ ] User bubbles preserve keyboard access to copy/edit/restore controls in both pagination modes
 - [ ] Todo pill exposes its expanded state and closes with Escape or an outside click
 - [ ] Conversation minimap markers are keyboard-focusable, expose the selected turn with `aria-current`, and show previews on focus
-- [ ] Final-message Copy buttons are keyboard-focusable and have localized accessible labels
+- [ ] Final-message Copy turn buttons are keyboard-focusable and have localized accessible labels
 - [ ] Compare branch and linked-PR rows expose external-link actions; the collapsed PR icon includes its CI state in the accessible name
 - [ ] Focus trap not applicable (scrollable list, not a modal)
 
@@ -82,7 +82,8 @@
 - [ ] Search highlights matching turns
 - [ ] Empty session shows empty state
 - [ ] Duplicate events are deduplicated by the pipeline
-- [ ] Every completed round exposes one final-message footer with a timestamp and Copy action
+- [ ] Every completed resident round exposes one final-message footer whose Copy turn action includes all completed assistant messages regardless of turn or message clamping
+- [ ] An unloaded historical preview keeps its timestamp but withholds Copy turn until expansion loads the authoritative body
 - [ ] GitHub feature branches expose Compare branch; only an open PR matching the exact current branch exposes CI status
 - [ ] `pnpm test` passes with no new failures
 - [ ] No TypeScript errors (`pnpm typecheck`)

--- a/src/engines/ChatPanel/ChatHistory/components/ChatHistoryList.tsx
+++ b/src/engines/ChatPanel/ChatHistory/components/ChatHistoryList.tsx
@@ -67,6 +67,8 @@ const ChatHistoryList: React.FC<ChatHistoryListProps> = memo(
     flatItems,
     groupCounts,
     turnIds,
+    assistantCopyEventIdsByGroup,
+    resolveAssistantTurnCopyContent,
     totalFlatItems,
     lastAssistantFlatIndexPerItem,
     codeBlockContainerWidth,
@@ -266,6 +268,10 @@ const ChatHistoryList: React.FC<ChatHistoryListProps> = memo(
     rowGroupMetaRef.current = rowGroupMeta;
     const turnIdsRef = useRef(turnIds);
     turnIdsRef.current = turnIds;
+    const assistantCopyEventIdsByGroupRef = useRef(
+      assistantCopyEventIdsByGroup
+    );
+    assistantCopyEventIdsByGroupRef.current = assistantCopyEventIdsByGroup;
 
     // For each flat index, the nearest preceding qualifying item — non-structural,
     // non-unloaded, with an event. Pre-computed once per flatItems change so
@@ -349,6 +355,10 @@ const ChatHistoryList: React.FC<ChatHistoryListProps> = memo(
             flatIndex={flatIndex}
             groupIndex={groupIndex}
             turnId={turnIdsRef.current[groupIndex] ?? null}
+            assistantCopyEventIds={
+              assistantCopyEventIdsByGroupRef.current[groupIndex] ?? []
+            }
+            resolveAssistantTurnCopyContent={resolveAssistantTurnCopyContent}
             chatItem={currentFlatItems[flatIndex]}
             previousChatItem={previousChatItemsRef.current[flatIndex]}
             lastAssistantFlatIndex={rowMeta.lastAssistantFlatIndex}
@@ -374,6 +384,7 @@ const ChatHistoryList: React.FC<ChatHistoryListProps> = memo(
         onSkip,
         onEditUserMessage,
         newEventDividerLabel,
+        resolveAssistantTurnCopyContent,
       ]
     );
 
@@ -442,6 +453,12 @@ const ChatHistoryList: React.FC<ChatHistoryListProps> = memo(
                       flatIndex={itemFlatIndex}
                       groupIndex={groupIndex}
                       turnId={turnIds[groupIndex] ?? null}
+                      assistantCopyEventIds={
+                        assistantCopyEventIdsByGroup[groupIndex] ?? []
+                      }
+                      resolveAssistantTurnCopyContent={
+                        resolveAssistantTurnCopyContent
+                      }
                       chatItem={flatItems[itemFlatIndex]}
                       previousChatItem={previousChatItems[itemFlatIndex]}
                       lastAssistantFlatIndex={rowMeta.lastAssistantFlatIndex}

--- a/src/engines/ChatPanel/ChatHistory/components/ChatHistoryListEquality.ts
+++ b/src/engines/ChatPanel/ChatHistory/components/ChatHistoryListEquality.ts
@@ -44,6 +44,22 @@ function sameNullableStringArray(
   return left.every((value, index) => value === right[index]);
 }
 
+function sameStringMatrix(
+  left: readonly (readonly string[])[],
+  right: readonly (readonly string[])[]
+): boolean {
+  if (left === right) return true;
+  if (left.length !== right.length) return false;
+  return left.every((leftValues, index) => {
+    const rightValues = right[index];
+    return (
+      rightValues !== undefined &&
+      leftValues.length === rightValues.length &&
+      leftValues.every((value, valueIndex) => value === rightValues[valueIndex])
+    );
+  });
+}
+
 const RESULT_RENDER_KEYS = [
   "type",
   "message",
@@ -177,6 +193,18 @@ export function sameChatHistoryListProps(
     ["flatItems", sameFlatItems(previous.flatItems, next.flatItems)],
     ["groupCounts", sameNumberArray(previous.groupCounts, next.groupCounts)],
     ["turnIds", sameNullableStringArray(previous.turnIds, next.turnIds)],
+    [
+      "assistantCopyEventIdsByGroup",
+      sameStringMatrix(
+        previous.assistantCopyEventIdsByGroup,
+        next.assistantCopyEventIdsByGroup
+      ),
+    ],
+    [
+      "resolveAssistantTurnCopyContent",
+      previous.resolveAssistantTurnCopyContent ===
+        next.resolveAssistantTurnCopyContent,
+    ],
     ["totalFlatItems", previous.totalFlatItems === next.totalFlatItems],
     [
       "lastAssistantFlatIndexPerItem",

--- a/src/engines/ChatPanel/ChatHistory/components/ChatHistoryListTypes.ts
+++ b/src/engines/ChatPanel/ChatHistory/components/ChatHistoryListTypes.ts
@@ -32,6 +32,8 @@ export interface ChatHistoryListProps {
   flatItems: OptimizedChatItem[];
   groupCounts: number[];
   turnIds: (string | null)[];
+  assistantCopyEventIdsByGroup: readonly (readonly string[])[];
+  resolveAssistantTurnCopyContent: (eventIds: readonly string[]) => string;
   totalFlatItems: number;
   lastAssistantFlatIndexPerItem: (number | null)[];
   codeBlockContainerWidth: number;

--- a/src/engines/ChatPanel/ChatHistory/components/ChatHistoryView.tsx
+++ b/src/engines/ChatPanel/ChatHistory/components/ChatHistoryView.tsx
@@ -151,6 +151,7 @@ const ChatHistoryView: React.FC<ChatHistoryViewProps> = ({
     pages,
     planningIndicatorEnabled,
     projection: projectionResult,
+    resolveAssistantTurnCopyContent,
     selectTurnPage,
     setTurnPageListOpen,
     setTurnPageSortAscending,
@@ -210,6 +211,10 @@ const ChatHistoryView: React.FC<ChatHistoryViewProps> = ({
   const getIsExploring = useCallback(
     () => isExploringRef.current ?? false,
     [isExploringRef]
+  );
+  const assistantCopyEventIdsByGroup = useMemo(
+    () => displayGroupMeta.map((meta) => meta.assistantCopyEventIds),
+    [displayGroupMeta]
   );
   const hasCloudDownloadProgress = useCloudSessionHasDownloadSurface(activeId);
 
@@ -469,6 +474,12 @@ const ChatHistoryView: React.FC<ChatHistoryViewProps> = ({
                       flatItems={displayFlatItems}
                       groupCounts={displayGroupCounts}
                       turnIds={displayTurnIds}
+                      assistantCopyEventIdsByGroup={
+                        assistantCopyEventIdsByGroup
+                      }
+                      resolveAssistantTurnCopyContent={
+                        resolveAssistantTurnCopyContent
+                      }
                       totalFlatItems={displayTotalFlatItems}
                       lastAssistantFlatIndexPerItem={
                         displayLastAssistantFlatIndexPerItem

--- a/src/engines/ChatPanel/ChatHistory/hooks/__tests__/useChatGroups.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/__tests__/useChatGroups.test.ts
@@ -283,6 +283,8 @@ describe("useChatGroups collapse — terminal error survival", () => {
     const result = useChatGroups(history);
 
     expect(result.groupMeta[0].unloadedTurn?.turnId).toBe(firstTurn.event!.id);
+    expect(result.groupMeta[0].assistantCopyEventIds).toEqual([]);
+    expect(result.lastAssistantFlatIndexPerItem[0]).toBe(0);
     expect(flatTexts(result.flatItems)).toContain("unloaded final reply");
     expect(flatTexts(result.flatItems)).not.toContain("Turn is not loaded yet");
   });
@@ -396,6 +398,27 @@ describe("useChatGroups collapse — terminal error survival", () => {
     expect(flatTexts(result.flatItems)).toContain("all done");
   });
 
+  it("retains every assistant copy source when collapse hides earlier replies", () => {
+    const firstUpdate = assistantItem("first update");
+    const finalAnswer = assistantItem("final answer");
+    const history = [
+      userItem("first turn"),
+      firstUpdate,
+      toolItem(),
+      finalAnswer,
+      userItem("second turn"),
+      assistantItem("second reply"),
+    ];
+
+    const result = useChatGroups(history, { allTurnsCollapsed: true });
+
+    expect(flatTexts(result.flatItems)).not.toContain("first update");
+    expect(result.groupMeta[0].assistantCopyEventIds).toEqual([
+      firstUpdate.event?.id,
+      finalAnswer.event?.id,
+    ]);
+  });
+
   it("maps dropped items to the surviving error's flat index", () => {
     const history = [
       userItem("first turn"), // orig 0 (header)
@@ -483,6 +506,7 @@ describe("isTurnCollapseEligible — unloaded placeholder affordance", () => {
       durationMs: 0,
       itemCount: 0,
       previewText: "",
+      assistantCopyEventIds: [],
       startMs: null,
       endMs: null,
       unloadedTurn: null,

--- a/src/engines/ChatPanel/ChatHistory/hooks/__tests__/useChatTurnPagination.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/__tests__/useChatTurnPagination.test.ts
@@ -48,7 +48,11 @@ function paginate(
     group.userHeader ? fakeHeader() : null
   );
   const groupMeta = groups.map(
-    () => ({ turnId: null }) as unknown as ChatGroupMeta
+    (_, index) =>
+      ({
+        turnId: null,
+        assistantCopyEventIds: [`assistant-${index}`],
+      }) as unknown as ChatGroupMeta
   );
   const flatItems = groups.flatMap((group) =>
     Array.from({ length: group.agentItems }, fakeItem)
@@ -91,6 +95,9 @@ describe("useChatTurnPagination — default paging", () => {
     expect(result.pageCount).toBe(100);
     expect(result.currentPageIndex).toBe(49);
     expect(result.displayGroupHeaders).toHaveLength(1);
+    expect(result.displayGroupMeta[0].assistantCopyEventIds).toEqual([
+      "assistant-49",
+    ]);
   });
 });
 

--- a/src/engines/ChatPanel/ChatHistory/hooks/useChatGroupsProjection.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/useChatGroupsProjection.ts
@@ -6,6 +6,7 @@ import {
 import { isAgentErrorEvent } from "../chatItemPipeline/classifiers";
 import { isAssistantMessageEvent } from "../chatItemPipeline/dedup";
 import type { OptimizedChatItem } from "../chatItemPipeline/types";
+import { collectAssistantTurnCopyEventIds } from "../turnCopyContent";
 
 export interface UnloadedTurnMeta {
   turnId: string;
@@ -22,6 +23,8 @@ export interface ChatGroupMeta {
   durationMs: number;
   itemCount: number;
   previewText: string;
+  /** Completed assistant-message ids from the resident, uncollapsed body. */
+  assistantCopyEventIds: string[];
   startMs: number | null;
   endMs: number | null;
   unloadedTurn: UnloadedTurnMeta | null;
@@ -266,6 +269,9 @@ export function projectChatGroups(
       durationMs: unloadedTurn?.durationMs ?? durationMs,
       itemCount: group.items.length,
       previewText: headerEvent?.displayText ?? "",
+      assistantCopyEventIds: unloadedTurn
+        ? []
+        : collectAssistantTurnCopyEventIds(group.items),
       startMs: unloadedStartMs ?? startMs,
       endMs: unloadedEndMs ?? endMs,
       unloadedTurn,

--- a/src/engines/ChatPanel/ChatHistory/hooks/useChatHistoryProjectionModel.ts
+++ b/src/engines/ChatPanel/ChatHistory/hooks/useChatHistoryProjectionModel.ts
@@ -1,5 +1,5 @@
 import { useAtomValue } from "jotai";
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import type { CursorIdeTurnSummary } from "@src/api/tauri/externalHistory";
 import type { SessionLoadStatus } from "@src/engines/SessionCore";
@@ -19,6 +19,7 @@ import { isImportedHistorySession } from "@src/util/session/sessionDispatch";
 import type { GroupChatContextValue } from "../GroupChatView/GroupChatContext";
 import { resolveChatHistoryProjectionSource } from "../projection/source";
 import { useChatProjection } from "../projection/useChatProjection";
+import { formatAssistantTurnCopyContent } from "../turnCopyContent";
 import type { ChatGroupsProjectionOptions } from "./useChatGroupsProjection";
 import { useChatTurnPagination } from "./useChatTurnPagination";
 import { useTailTurnCollapse } from "./useTailTurnCollapse";
@@ -75,6 +76,7 @@ export function useChatHistoryProjectionModel({
     activeId: string | null;
     activeProjectionHistory: unknown[];
     flatItems: unknown[];
+    groupMeta: unknown[];
     groupCount: number;
     totalFlatItems: number;
   } | null>(null);
@@ -141,6 +143,19 @@ export function useChatHistoryProjectionModel({
     enabled: projectionSource.enabled,
   });
   const activeProjectionHistory = projection.optimizedChatHistory;
+  const activeProjectionHistoryRef = useRef(activeProjectionHistory);
+  activeProjectionHistoryRef.current = activeProjectionHistory;
+  // The resolver stays stable across projection ticks and scans only after an
+  // explicit copy click. This avoids duplicating transcript strings in group
+  // metadata or rebuilding a full event-id map while the assistant streams.
+  const resolveAssistantTurnCopyContent = useCallback(
+    (eventIds: readonly string[]) =>
+      formatAssistantTurnCopyContent(
+        activeProjectionHistoryRef.current,
+        eventIds
+      ),
+    []
+  );
   const {
     groupCounts,
     groupHeaders,
@@ -163,6 +178,7 @@ export function useChatHistoryProjectionModel({
     activeId,
     activeProjectionHistory,
     flatItems,
+    groupMeta,
     groupCount: groupCounts.length,
     totalFlatItems,
   };
@@ -178,6 +194,7 @@ export function useChatHistoryProjectionModel({
         bytes:
           estimateRuntimeValueBytes(source.activeProjectionHistory) +
           estimateRuntimeValueBytes(source.flatItems) +
+          estimateRuntimeValueBytes(source.groupMeta) +
           source.groupCount * 8,
         items: source.totalFlatItems,
         label: source.activeId ?? "unknown",
@@ -293,6 +310,7 @@ export function useChatHistoryProjectionModel({
     originalToFlatIndex,
     planningIndicatorEnabled,
     projection,
+    resolveAssistantTurnCopyContent,
     tailFollowKey,
     totalFlatItems,
     turnMetadataReloadKey,

--- a/src/engines/ChatPanel/ChatHistory/projection/__tests__/projection.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/projection/__tests__/projection.test.ts
@@ -78,7 +78,7 @@ describe("chat projection core", () => {
       },
     };
     expect(() => structuredClone(options)).not.toThrow();
-    expect(CHAT_PROJECTION_PROTOCOL_VERSION).toBe(2);
+    expect(CHAT_PROJECTION_PROTOCOL_VERSION).toBe(3);
   });
 
   it("keeps errors pinned when a completed turn is collapsed", () => {

--- a/src/engines/ChatPanel/ChatHistory/projection/protocol.ts
+++ b/src/engines/ChatPanel/ChatHistory/projection/protocol.ts
@@ -6,7 +6,7 @@ import type {
   ChatHistoryProjectionResult,
 } from "./core";
 
-export const CHAT_PROJECTION_PROTOCOL_VERSION = 2 as const;
+export const CHAT_PROJECTION_PROTOCOL_VERSION = 3 as const;
 
 export interface ProjectionEnvelope {
   protocolVersion: typeof CHAT_PROJECTION_PROTOCOL_VERSION;

--- a/src/engines/ChatPanel/ChatHistory/renderers/GroupItemRenderer.tsx
+++ b/src/engines/ChatPanel/ChatHistory/renderers/GroupItemRenderer.tsx
@@ -176,6 +176,13 @@ function areGroupItemRendererPropsEqual(
     previous.flatIndex === next.flatIndex &&
     previous.groupIndex === next.groupIndex &&
     previous.turnId === next.turnId &&
+    previous.assistantCopyEventIds.length ===
+      next.assistantCopyEventIds.length &&
+    previous.assistantCopyEventIds.every(
+      (eventId, index) => eventId === next.assistantCopyEventIds[index]
+    ) &&
+    previous.resolveAssistantTurnCopyContent ===
+      next.resolveAssistantTurnCopyContent &&
     sameChatItem(previous.chatItem, next.chatItem) &&
     // previousChatItem affects group-chat continuation window only (createdAt
     // comparison). Shallow-compare the event rather than the full item — the
@@ -284,6 +291,10 @@ export interface GroupItemRendererProps {
   flatIndex: number;
   groupIndex: number;
   turnId: string | null;
+  /** Assistant messages retained as the authoritative copy sources for this turn. */
+  assistantCopyEventIds: readonly string[];
+  /** Lazily resolves the ids against the uncollapsed projection on click. */
+  resolveAssistantTurnCopyContent: (eventIds: readonly string[]) => string;
   /** The item at `flatIndex`. Passed directly to avoid the full array reference. */
   chatItem: OptimizedChatItem | undefined;
   /**
@@ -341,6 +352,8 @@ export const GroupItemRenderer: React.FC<GroupItemRendererProps> = memo(
     flatIndex,
     groupIndex,
     turnId,
+    assistantCopyEventIds,
+    resolveAssistantTurnCopyContent,
     chatItem,
     previousChatItem,
     lastAssistantFlatIndex,
@@ -428,6 +441,8 @@ export const GroupItemRenderer: React.FC<GroupItemRendererProps> = memo(
     const turnContext = useMemo<AgentTurnContextValue>(
       () => ({
         lastAssistantFlatIndex,
+        assistantCopyEventIds,
+        resolveAssistantTurnCopyContent,
         isLastGroup,
         isLastItemInGroup,
         onRegenerate: onRegenerate
@@ -442,6 +457,8 @@ export const GroupItemRenderer: React.FC<GroupItemRendererProps> = memo(
       }),
       [
         lastAssistantFlatIndex,
+        assistantCopyEventIds,
+        resolveAssistantTurnCopyContent,
         isLastGroup,
         isLastItemInGroup,
         isWpGeneWorking,

--- a/src/engines/ChatPanel/ChatHistory/turnCopyContent.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/turnCopyContent.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+
+import type { OptimizedChatItem } from "./chatItemPipeline/types";
+import {
+  collectAssistantTurnCopyEventIds,
+  formatAssistantTurnCopyContent,
+} from "./turnCopyContent";
+
+function item(
+  id: string,
+  overrides: Partial<SessionEvent> = {}
+): OptimizedChatItem {
+  return {
+    chunk_id: id,
+    type: "activity",
+    event: {
+      id,
+      chunk_id: id,
+      sessionId: "session-a",
+      createdAt: `2026-08-25T00:00:${id.padStart(2, "0")}.000Z`,
+      functionName: "agent_message",
+      actionType: "assistant",
+      source: "assistant",
+      displayText: `assistant-${id}`,
+      displayStatus: "completed",
+      displayVariant: "message",
+      args: {},
+      result: {},
+      ...overrides,
+    } as SessionEvent,
+  };
+}
+
+describe("assistant turn copy content", () => {
+  it("collects every settled assistant message before collapse", () => {
+    const items = [
+      item("1", { displayText: "first update" }),
+      item("2", {
+        actionType: "tool_call",
+        functionName: "read_file",
+        displayVariant: "tool_call",
+      }),
+      item("3", { displayText: "still streaming", displayStatus: "running" }),
+      item("4", { displayText: "final answer" }),
+    ];
+
+    expect(collectAssistantTurnCopyEventIds(items)).toEqual(["1", "4"]);
+  });
+
+  it("formats visible assistant prose in source order at click time", () => {
+    const items = [
+      item("1", {
+        displayText: "fallback",
+        result: { message: "<think>private</think>First update" },
+      }),
+      item("2", { displayText: "Final answer" }),
+      item("3", { displayText: "unrelated answer" }),
+    ];
+
+    expect(formatAssistantTurnCopyContent(items, ["1", "2"])).toBe(
+      "First update\n\nFinal answer"
+    );
+  });
+
+  it("excludes unloaded previews and ignores stale event ids", () => {
+    const items = [
+      item("1", {
+        args: { turnPreviewOnly: true },
+        displayText: "bounded preview",
+      }),
+      item("2", { displayText: "resident answer" }),
+    ];
+
+    expect(collectAssistantTurnCopyEventIds(items)).toEqual(["2"]);
+    expect(formatAssistantTurnCopyContent(items, ["missing", "2"])).toBe(
+      "resident answer"
+    );
+  });
+});

--- a/src/engines/ChatPanel/ChatHistory/turnCopyContent.ts
+++ b/src/engines/ChatPanel/ChatHistory/turnCopyContent.ts
@@ -1,0 +1,61 @@
+import { stripThinkTags } from "@src/engines/SessionCore/sync/adapters/shared/streamingParsers";
+import { extractAssistantMessageContent } from "@src/lib/activityData/textExtractors";
+
+import { isAssistantMessageEvent } from "./chatItemPipeline/dedup";
+import type { OptimizedChatItem } from "./chatItemPipeline/types";
+
+/**
+ * A turn-copy source is a settled assistant message that belongs to the
+ * resident turn body. Tool activity and bounded unloaded-turn previews are
+ * intentionally excluded: the footer copies the assistant's readable reply,
+ * not operational cards or an incomplete historical approximation.
+ */
+export function isAssistantTurnCopySource(
+  item: OptimizedChatItem | undefined
+): boolean {
+  const event = item?.event;
+  return Boolean(
+    event &&
+    event.displayStatus === "completed" &&
+    event.args?.turnPreviewOnly !== true &&
+    isAssistantMessageEvent(event)
+  );
+}
+
+export function collectAssistantTurnCopyEventIds(
+  items: readonly OptimizedChatItem[]
+): string[] {
+  const eventIds: string[] = [];
+  for (const item of items) {
+    if (isAssistantTurnCopySource(item) && item.event?.id) {
+      eventIds.push(item.event.id);
+    }
+  }
+  return eventIds;
+}
+
+/**
+ * Resolve copy text lazily from the uncollapsed projection. Keeping only ids
+ * in group metadata avoids duplicating every assistant response string in the
+ * worker result and pays the O(n) scan only when the user actually copies.
+ */
+export function formatAssistantTurnCopyContent(
+  items: readonly OptimizedChatItem[],
+  eventIds: readonly string[]
+): string {
+  if (eventIds.length === 0) return "";
+
+  const requestedIds = new Set(eventIds);
+  const parts: string[] = [];
+  for (const item of items) {
+    const event = item.event;
+    if (!event?.id || !requestedIds.has(event.id)) continue;
+    if (!isAssistantTurnCopySource(item)) continue;
+
+    const rawContent = extractAssistantMessageContent(event);
+    if (!rawContent) continue;
+    const visibleContent = stripThinkTags(rawContent).trim();
+    if (visibleContent) parts.push(visibleContent);
+  }
+  return parts.join("\n\n");
+}

--- a/src/engines/ChatPanel/blocks/AgentMessageBlock/__tests__/agentMessageClamp.test.ts
+++ b/src/engines/ChatPanel/blocks/AgentMessageBlock/__tests__/agentMessageClamp.test.ts
@@ -1,6 +1,10 @@
+import { type ComponentProps, createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import {
+import { AgentTurnContext } from "@src/engines/ChatPanel/ChatHistory/AgentTurnContext";
+
+import AgentMessageBlock, {
   AGENT_MESSAGE_PREVIEW_MAX_HEIGHT,
   resolveAgentMessageClampEligibility,
   shouldShowAgentMessageFooter,
@@ -76,5 +80,39 @@ describe("shouldShowAgentMessageFooter", () => {
         lastAssistantFlatIndex: 0,
       })
     ).toBe(false);
+  });
+
+  it("offers complete-turn copy only when the resident turn sources exist", () => {
+    const render = (assistantCopyEventIds: readonly string[]) =>
+      renderToStaticMarkup(
+        createElement(
+          AgentTurnContext.Provider,
+          {
+            value: {
+              lastAssistantFlatIndex: 7,
+              assistantCopyEventIds,
+              resolveAssistantTurnCopyContent: () => "complete turn",
+              isLastGroup: false,
+              isLastItemInGroup: true,
+            },
+          },
+          createElement(
+            AgentMessageBlock,
+            {
+              itemIndex: 7,
+              messageContent: "visible final answer",
+              messageTimestamp: "2026-08-25T00:00:00.000Z",
+            } as ComponentProps<typeof AgentMessageBlock>,
+            "visible final answer"
+          )
+        )
+      );
+
+    expect(render(["assistant-1", "assistant-2"])).toContain(
+      'data-testid="message-footer-copy"'
+    );
+    const unloadedMarkup = render([]);
+    expect(unloadedMarkup).toContain('data-testid="message-footer"');
+    expect(unloadedMarkup).not.toContain('data-testid="message-footer-copy"');
   });
 });

--- a/src/engines/ChatPanel/blocks/AgentMessageBlock/index.tsx
+++ b/src/engines/ChatPanel/blocks/AgentMessageBlock/index.tsx
@@ -23,6 +23,7 @@
  */
 import React, {
   createContext,
+  useCallback,
   useContext,
   useLayoutEffect,
   useRef,
@@ -91,7 +92,7 @@ export interface AgentMessageBlockProps {
   rightContent?: React.ReactNode;
   /** Hide footer chrome while tokens are still streaming. */
   isStreaming?: boolean;
-  /** Content copied by the final-message footer. */
+  /** Visible content used to qualify the final-message footer. */
   messageContent?: string;
   /** Event timestamp displayed by the final-message footer. */
   messageTimestamp?: string;
@@ -108,7 +109,7 @@ const AgentMessageBlock: React.FC<AgentMessageBlockProps> = ({
   messageTimestamp = "",
   itemIndex,
 }) => {
-  const { t, i18n } = useTranslation("common");
+  const { t, i18n } = useTranslation(["common", "sessions"]);
   const fallbackClampEligible = useContext(AgentMessageClampContext);
   const turnContext = useAgentTurnContext();
   const showMessageFooter = shouldShowAgentMessageFooter({
@@ -124,13 +125,25 @@ const AgentMessageBlock: React.FC<AgentMessageBlockProps> = ({
           locale: toIntlLocaleTag(i18n.resolvedLanguage),
         })
       : "";
+  const getTurnCopyContent = useCallback(
+    () =>
+      turnContext?.resolveAssistantTurnCopyContent(
+        turnContext.assistantCopyEventIds
+      ) ?? "",
+    [turnContext]
+  );
+  const getCopyContent =
+    turnContext && turnContext.assistantCopyEventIds.length > 0
+      ? getTurnCopyContent
+      : undefined;
   const messageFooter = showMessageFooter ? (
     <MessageFooter
-      content={messageContent ?? ""}
+      getCopyContent={getCopyContent}
       timestamp={messageTimestamp}
       timestampLabel={timestampLabel}
-      copyLabel={t("actions.copy")}
+      copyLabel={t("sessions:chat.copyTurn")}
       copiedLabel={t("status.copied")}
+      copyFailedLabel={t("errors.failedToCopy")}
       className="mt-1"
     />
   ) : null;


### PR DESCRIPTION
## Problem

The “Copy turn” footer action received content from the single assistant block that survived turn collapsing. In turns with multiple completed assistant messages, collapse state could therefore change the clipboard payload and copy only the final rendered fragment. The footer also wrote directly through the browser clipboard API without the shared fallback or a visible failure state.

## Solution

Collect completed assistant-message event ids from the resident turn before collapse, carry those ids with the projected group metadata, and resolve their user-visible prose lazily from the current uncollapsed projection only when Copy turn is clicked. The resulting invariant is that collapse, expansion, long-message clamping, and pagination do not change the copied turn text.

Tool cards, internal thinking content, streaming messages, and bounded unloaded-turn previews are excluded. For an unloaded historical turn, the timestamp remains visible but Copy turn is withheld until the authoritative body is loaded. Clipboard writes now use the shared fallback helper and surface a retryable error toast on failure. The internal projection protocol version is bumped to keep worker/main payloads aligned.

## Potential risks

- A resident projection can change between rendering and clicking; stale event ids are ignored, and an empty resolution reports a copy error instead of writing partial content.
- Unloaded historical previews intentionally have no copy action until their full body is loaded; this avoids silently copying a bounded preview but adds that loading prerequisite.
- The worker payload shape changes internally. Both worker and main-thread paths share protocol version 3, so stale workers are rejected rather than consumed. There are no persistence, database, public API, or external wire-format changes.
- The real Tauri clipboard surface was not manually exercised. The shared clipboard helper is existing production code, and DOM tests cover exact payloads, resolution failures, clipboard rejection, and retryability.

## Audit

- Architecture audit covered compile safety, ownership, semantic scope, defaults, dependency direction, protocol parity, and collapsed/expanded/paginated state parity. No historical data remediation is needed because this was a presentation projection defect, not persisted-data corruption.
- Performance verdict: pass. Projection metadata stores event ids only; full text resolution is an explicit-click scan. The 50,000-event pressure fixture passed. No timer, subscription, cache, worker lifecycle, or background loop was added.
- Manual frontend UI audit (the configured skill file is absent): 2 fix, 2 keep with reason, 0 abstract. Report: `docs/frontend-ui-audit-2026-08-25/TurnCopyFooter.md`.

## Verification

- `./node_modules/.bin/tsc --noEmit --pretty false` — passed
- ESLint over all changed TypeScript/TSX files with `--max-warnings 0` — passed
- `./node_modules/.bin/vitest run src/components src/engines/ChatPanel/ChatHistory --config vitest.config.ts` — 119 files, 822 tests passed
- `./node_modules/.bin/vitest run src/engines/ChatPanel/ChatHistory/hooks/__tests__/useChatTurnPagination.test.ts --config vitest.config.ts` — 7 tests passed
- Repository pre-commit checks — lint-staged and scoped TypeScript check passed
- `git diff --check origin/develop...HEAD` — passed

No new screenshot is included because the footer layout and icon are unchanged; the corrected behavior is the clipboard payload and is covered at the DOM/action boundary.