### PR TITLE
fix(dropdowns): align breadcrumb and menu spacing

### DIFF
--- a/src/components/Dropdown/tokens.ts
+++ b/src/components/Dropdown/tokens.ts
@@ -399,7 +399,7 @@ export const DROPDOWN_CLASSES = {
     DROPDOWN_ITEM.hoverBgClass,
   ].join(" "),
 
-  /** Separator between menu groups. */
+  /** Full-width structural separator. Row groups use `menuSeparatorInset`. */
   menuSeparator: ["border-t", "border-solid", "border-border-2"].join(" "),
 
   /** Inset separator between dropdown list groups. */

--- a/src/components/TreeRow/TreeRowBase.test.ts
+++ b/src/components/TreeRow/TreeRowBase.test.ts
@@ -1,0 +1,34 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { TreeRowBase } from "./TreeRowBase";
+
+const node = {
+  id: "src",
+  name: "src",
+  path: "src",
+  type: "directory" as const,
+};
+
+describe("TreeRowBase", () => {
+  it("lets a padded host own the row inset", () => {
+    const markup = renderToStaticMarkup(
+      createElement(TreeRowBase, { node, depth: 0, inset: false })
+    );
+
+    expect(markup).not.toContain(" mx-1 ");
+    expect(markup).toContain("padding-left:16px");
+    expect(markup).toContain("padding-right:8px");
+  });
+
+  it("keeps the sidebar inset by default", () => {
+    const markup = renderToStaticMarkup(
+      createElement(TreeRowBase, { node, depth: 0 })
+    );
+
+    expect(markup).toContain(" mx-1 ");
+    expect(markup).toContain("padding-left:12px");
+    expect(markup).toContain("padding-right:4px");
+  });
+});

--- a/src/components/TreeRow/TreeRowBase.tsx
+++ b/src/components/TreeRow/TreeRowBase.tsx
@@ -58,6 +58,7 @@ export const TreeRowBase = React.memo(
         showPathHint = false,
         showNativeTitle = true,
         rounded = true,
+        inset = true,
       },
       ref
     ) => {
@@ -91,11 +92,10 @@ export const TreeRowBase = React.memo(
         [onMouseLeave, resetCursor]
       );
 
-      // Calculate padding based on depth
-      // The row is inset from the sidebar edge, so subtract that same amount
-      // from its internal padding to keep all content at its original x-axis.
-      const paddingLeft =
-        depth * TREE_INDENT_PX + TREE_PADDING_X - TREE_ROW_INSET_X;
+      // Keep content aligned whether the row owns its outer inset or the host
+      // surface supplies that spacing (for example, a padded dropdown panel).
+      const rowInsetX = inset ? TREE_ROW_INSET_X : 0;
+      const paddingLeft = depth * TREE_INDENT_PX + TREE_PADDING_X - rowInsetX;
 
       // Determine text color based on ignored state and selection
       const getTextColorClass = () => {
@@ -112,7 +112,7 @@ export const TreeRowBase = React.memo(
         <div
           ref={ref}
           data-tree-path={dataPath}
-          className={`tree-row-base group/item relative ${TREE_ROW_INSET_CLASS} flex h-7 min-w-0 shrink-0 ${
+          className={`tree-row-base group/item relative ${inset ? TREE_ROW_INSET_CLASS : ""} flex h-7 min-w-0 shrink-0 ${
             isClickable && !cursorReset && !isHighlighted
               ? "cursor-pointer"
               : "cursor-default"
@@ -123,7 +123,7 @@ export const TreeRowBase = React.memo(
           } ${className}`}
           style={{
             paddingLeft: `${paddingLeft}px`,
-            paddingRight: `${TREE_PADDING_RIGHT - TREE_ROW_INSET_X}px`,
+            paddingRight: `${TREE_PADDING_RIGHT - rowInsetX}px`,
           }}
           onClick={isClickable ? handleRowClick : undefined}
           onContextMenu={onContextMenu}
@@ -143,7 +143,7 @@ export const TreeRowBase = React.memo(
                 key={level}
                 className={TREE_INDENT_GUIDE_CLASS}
                 style={{
-                  left: `${TREE_GUIDE_OFFSET_BASE - TREE_ROW_INSET_X + level * TREE_INDENT_PX}px`,
+                  left: `${TREE_GUIDE_OFFSET_BASE - rowInsetX + level * TREE_INDENT_PX}px`,
                 }}
               />
             ))}

--- a/src/components/TreeRow/types.ts
+++ b/src/components/TreeRow/types.ts
@@ -65,6 +65,12 @@ export interface TreeRowBaseProps {
   className?: string;
   /** Whether to show rounded corners (default: true) */
   rounded?: boolean;
+  /**
+   * Whether the row supplies its own horizontal outer inset (default: true).
+   * Disable this when the host surface, such as a padded dropdown panel,
+   * already owns the inset around interactive rows.
+   */
+  inset?: boolean;
   /** Icon rendered between the main icon (chevron) and the name text */
   prefixIcon?: ReactNode;
   /** Children to render after the name (e.g., action buttons) */

--- a/src/engines/ChatPanel/components/SessionHeaderActionsMenu.tsx
+++ b/src/engines/ChatPanel/components/SessionHeaderActionsMenu.tsx
@@ -346,7 +346,7 @@ export const SessionHeaderActionsMenu: React.FC<
                     {t("chat.importExport.exportAction")}
                   </span>
                 </button>
-                <div className="my-1 border-t border-solid border-border-2" />
+                <div className={DROPDOWN_CLASSES.menuSeparatorInset} />
                 <div
                   className={`${DROPDOWN_CLASSES.item} w-full justify-between text-left`}
                 >

--- a/src/engines/Simulator/components/SimulatorStatusBar/EventFilterDropdown.tsx
+++ b/src/engines/Simulator/components/SimulatorStatusBar/EventFilterDropdown.tsx
@@ -171,7 +171,7 @@ export const EventFilterDropdown: React.FC<EventFilterDropdownProps> = ({
                 </span>
               </div>
               <div
-                className={DROPDOWN_CLASSES.menuSeparator}
+                className={DROPDOWN_CLASSES.menuSeparatorInset}
                 role="separator"
               />
               {SIMULATOR_EVENT_FILTER_VALUES.map((filter) => {

--- a/src/modules/MainApp/Settings/components/SettingsHeaderActions.tsx
+++ b/src/modules/MainApp/Settings/components/SettingsHeaderActions.tsx
@@ -107,7 +107,10 @@ const CompactPlusDropdown: React.FC<CompactPlusDropdownProps> = ({
       {visibleItems.map((item) => {
         if (item.id === "divider") {
           return (
-            <div key={item.id} className={DROPDOWN_CLASSES.menuSeparator} />
+            <div
+              key={item.id}
+              className={DROPDOWN_CLASSES.menuSeparatorInset}
+            />
           );
         }
         const IconComponent = item.icon;

--- a/src/modules/ProjectManager/shared/components/ProjectManagerBreadcrumb/ProjectManagerBreadcrumb.test.ts
+++ b/src/modules/ProjectManager/shared/components/ProjectManagerBreadcrumb/ProjectManagerBreadcrumb.test.ts
@@ -31,7 +31,8 @@ describe("ProjectManagerBreadcrumb", () => {
     expect(markup).toContain(`${"p".repeat(23)}…`);
     expect(markup).toContain(`${"w".repeat(35)}…`);
     expect(markup).toContain('role="button"');
-    expect(markup).toContain("mx-0.5 flex-shrink-0 text-fill-4");
+    expect(markup).toContain("hover:underline hover:decoration-text-1");
+    expect(markup).toContain("mx-0 flex-shrink-0 text-fill-4");
   });
 
   it("keeps a fill-width segment untruncated", () => {

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/components/SourceControlMoreMenu.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/components/SourceControlMoreMenu.tsx
@@ -188,7 +188,7 @@ export const SourceControlMoreMenu: React.FC<SourceControlMoreMenuProps> = memo(
                       />
                       {t(SOURCE_CONTROL_MENU_KEYS.fetch)}
                     </div>
-                    <div className="my-0.5 border-t border-border-2" />
+                    <div className={DROPDOWN_CLASSES.menuSeparatorInset} />
                     <div
                       className={`${DROPDOWN_CLASSES.item} ${PRIMARY_SIDEBAR_HOVER.row}`}
                       onClick={() => handleItemClick(onSync)}

--- a/src/modules/WorkStation/shared/StatusBar/GitSyncStatusMenu.tsx
+++ b/src/modules/WorkStation/shared/StatusBar/GitSyncStatusMenu.tsx
@@ -289,7 +289,7 @@ export const GitSyncStatusMenu: React.FC<GitSyncStatusMenuProps> = memo(
                         </span>
                       </button>
                     )}
-                    <div className={DROPDOWN_CLASSES.menuSeparator} />
+                    <div className={DROPDOWN_CLASSES.menuSeparatorInset} />
                     <button
                       type="button"
                       className={DROPDOWN_CLASSES.menuActionItem}

--- a/src/modules/WorkStation/shared/StatusBar/PortsStatusMenu.tsx
+++ b/src/modules/WorkStation/shared/StatusBar/PortsStatusMenu.tsx
@@ -367,7 +367,7 @@ export const PortsStatusMenu: React.FC = memo(() => {
 
                   {externalPorts.length > 0 && (
                     <>
-                      <div className={DROPDOWN_CLASSES.menuSeparator} />
+                      <div className={DROPDOWN_CLASSES.menuSeparatorInset} />
                       <button
                         type="button"
                         className={classNames(

--- a/src/modules/WorkStation/shared/TerminalNewSessionSplitButton.tsx
+++ b/src/modules/WorkStation/shared/TerminalNewSessionSplitButton.tsx
@@ -110,7 +110,7 @@ const TerminalNewSessionSplitButtonComponent: React.FC<
             ))}
           {shellProfiles.some((profile) => profile.category === "repl") && (
             <>
-              <div className="my-1 border-t border-solid border-border-2" />
+              <div className={DROPDOWN_CLASSES.menuSeparatorInset} />
               {shellProfiles
                 .filter((profile) => profile.category === "repl")
                 .map((profile) => (

--- a/src/modules/shared/components/FileHeader/BreadcrumbFileHeader.tsx
+++ b/src/modules/shared/components/FileHeader/BreadcrumbFileHeader.tsx
@@ -241,7 +241,7 @@ const BreadcrumbFileHeader: React.FC<BreadcrumbFileHeaderProps> = ({
                       isLast && !segment.onClick
                         ? "font-medium text-text-1"
                         : isClickable
-                          ? "cursor-pointer text-text-2 hover:text-text-1"
+                          ? "cursor-pointer text-text-2 hover:text-text-1 hover:underline hover:decoration-text-1"
                           : "text-text-2"
                     }`
               } ${isActive && !disableNavigation ? "text-text-1 underline decoration-text-1" : ""} ${
@@ -278,7 +278,7 @@ const BreadcrumbFileHeader: React.FC<BreadcrumbFileHeaderProps> = ({
               <ChevronRight
                 size={14}
                 strokeWidth={1.75}
-                className="mx-0.5 flex-shrink-0 text-fill-4"
+                className="mx-0 flex-shrink-0 text-fill-4"
                 aria-hidden="true"
               />
             )}

--- a/src/modules/shared/components/FileHeader/FileDropdown.tsx
+++ b/src/modules/shared/components/FileHeader/FileDropdown.tsx
@@ -423,6 +423,7 @@ const FileDropdown: React.FC<FileDropdownProps> = ({
                     onClick={() => handleToggle(row.entry.path)}
                     className="bg-bg-2"
                     showIndentGuides
+                    inset={false}
                   >
                     <GitStatusBadge
                       status={getGitStatus(row.entry)}
@@ -465,6 +466,7 @@ const FileDropdown: React.FC<FileDropdownProps> = ({
                   gitStatus={gitStatus}
                   onClick={() => handleRowClick(row.entry)}
                   showIndentGuides
+                  inset={false}
                 >
                   <GitStatusBadge status={gitStatus} isDirectory={isDir} />
                 </TreeRowBase>

--- a/src/modules/shared/components/FileHeader/FileHeaderMoreMenu.tsx
+++ b/src/modules/shared/components/FileHeader/FileHeaderMoreMenu.tsx
@@ -225,7 +225,7 @@ export const FileHeaderMoreMenu: React.FC<FileHeaderMoreMenuProps> = ({
             {t("common:workstation.discardChanges")}
           </DropdownItem>
 
-          <div className={DROPDOWN_CLASSES.menuSeparator} />
+          <div className={DROPDOWN_CLASSES.menuSeparatorInset} />
 
           <DropdownItem
             icon={<Search size={HEADER_ICON_SIZE.sm} />}
@@ -288,7 +288,7 @@ export const FileHeaderMoreMenu: React.FC<FileHeaderMoreMenuProps> = ({
             {t("common:actions.refresh")}
           </DropdownItem>
 
-          <div className={DROPDOWN_CLASSES.menuSeparator} />
+          <div className={DROPDOWN_CLASSES.menuSeparatorInset} />
 
           {renderToggleRow({
             label: t("settings:editor.lineNumbers"),
@@ -325,7 +325,7 @@ export const FileHeaderMoreMenu: React.FC<FileHeaderMoreMenuProps> = ({
             onChange: onGitBlameChange,
           })}
 
-          <div className={DROPDOWN_CLASSES.menuSeparator} />
+          <div className={DROPDOWN_CLASSES.menuSeparatorInset} />
 
           <DropdownItem
             icon={<Settings size={HEADER_ICON_SIZE.sm} />}

--- a/src/scaffold/ContextMenu/variants/TextSelectionDropdown/index.tsx
+++ b/src/scaffold/ContextMenu/variants/TextSelectionDropdown/index.tsx
@@ -173,7 +173,7 @@ const SessionSelectorPanel: React.FC<SessionSelectorPanelProps> = memo(
 
           {/* Divider */}
           {sessions.length > 0 && (
-            <div className={DROPDOWN_CLASSES.menuSeparator} />
+            <div className={DROPDOWN_CLASSES.menuSeparatorInset} />
           )}
 
           {/* Existing sessions */}

--- a/src/scaffold/NavigationSidebar/blocks/SidebarBottomBar.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarBottomBar.tsx
@@ -226,7 +226,7 @@ export const PresenceMenuItems: React.FC<PresenceMenuItemsProps> = ({
 
       {customRoles.length > 0 && (
         <>
-          <div className={DROPDOWN_CLASSES.menuSeparator} />
+          <div className={DROPDOWN_CLASSES.menuSeparatorInset} />
           {customRoles.map((role) => {
             const RoleIcon = resolveCustomRoleIcon(role.iconId);
             const roleMode = buildCustomRoleMode(role.id);
@@ -255,7 +255,7 @@ export const PresenceMenuItems: React.FC<PresenceMenuItemsProps> = ({
 
       {mode === USER_PRESENCE_MODE.AWAY && (
         <>
-          <div className={DROPDOWN_CLASSES.menuSeparator} />
+          <div className={DROPDOWN_CLASSES.menuSeparatorInset} />
           <div className={DROPDOWN_CLASSES.sectionLabel}>
             {t("sidebar.presence.awayDurationHeading")}
           </div>

--- a/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.tsx
@@ -325,7 +325,7 @@ const SidebarSettingsMenuButton: React.FC = React.memo(() => {
                   variant={KEYBOARD_SHORTCUT_VARIANT.dropdown}
                 />
               </button>
-              <div className={DROPDOWN_CLASSES.menuSeparator} />
+              <div className={DROPDOWN_CLASSES.menuSeparatorInset} />
               {devModeEnabled && (
                 <>
                   <button
@@ -394,7 +394,7 @@ const SidebarSettingsMenuButton: React.FC = React.memo(() => {
                 />
                 <span>{t("sidebar.settingsMenu.tutorials")}</span>
               </button>
-              <div className={DROPDOWN_CLASSES.menuSeparator} />
+              <div className={DROPDOWN_CLASSES.menuSeparatorInset} />
               <button
                 type="button"
                 className={`${DROPDOWN_CLASSES.menuActionItem} ${activeSubmenu === "presence" ? DROPDOWN_CLASSES.itemActive : ""} justify-between`}
@@ -491,7 +491,7 @@ const SidebarSettingsMenuButton: React.FC = React.memo(() => {
                   className={MENU_ARROW_CLASS_NAME}
                 />
               </button>
-              <div className={DROPDOWN_CLASSES.menuSeparator} />
+              <div className={DROPDOWN_CLASSES.menuSeparatorInset} />
               <button
                 type="button"
                 className={`${DROPDOWN_CLASSES.menuActionItem} justify-between`}

--- a/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuSubmenus.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuSubmenus.tsx
@@ -128,7 +128,7 @@ export function SidebarSettingsMenuSubmenus({
               </button>
             );
           })}
-          <div className={DROPDOWN_CLASSES.menuSeparator} />
+          <div className={DROPDOWN_CLASSES.menuSeparatorInset} />
           <div className={DROPDOWN_CLASSES.sectionLabel}>
             {themePresetLabel}
           </div>

--- a/src/scaffold/NavigationSidebar/blocks/SidebarWorkstationSettingsSubmenu.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarWorkstationSettingsSubmenu.tsx
@@ -132,14 +132,14 @@ export const SidebarWorkstationSettingsSubmenu: React.FC<SidebarWorkstationSetti
             options={chatPositionOptions}
             onChange={handleStationChatPositionChange}
           />
-          <div className={DROPDOWN_CLASSES.menuSeparator} />
+          <div className={DROPDOWN_CLASSES.menuSeparatorInset} />
           <SelectionRow<ChatPanelPosition>
             label={t("layoutSettings.agentStation")}
             value={agentChatPosition}
             options={chatPositionOptions}
             onChange={setAgentChatPosition}
           />
-          <div className={DROPDOWN_CLASSES.menuSeparator} />
+          <div className={DROPDOWN_CLASSES.menuSeparatorInset} />
           <SwitchControlRow
             label={t("layoutSettings.chatPanelPagination")}
             checked={chatTurnPaginationEnabled}
@@ -154,7 +154,7 @@ export const SidebarWorkstationSettingsSubmenu: React.FC<SidebarWorkstationSetti
             options={chatPositionOptions}
             onChange={setLayoutModePersist}
           />
-          <div className={DROPDOWN_CLASSES.menuSeparator} />
+          <div className={DROPDOWN_CLASSES.menuSeparatorInset} />
           <SelectionRow<ModelPickerStyle>
             label={t("layoutSettings.modelPickerStyle")}
             value={modelPickerStyle}

--- a/src/scaffold/NavigationSidebar/connectors/SessionFilterButton.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/SessionFilterButton.tsx
@@ -189,7 +189,7 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
                     </DropdownItem>
                   );
                 })}
-                <div className={DROPDOWN_CLASSES.menuSeparator} />
+                <div className={DROPDOWN_CLASSES.menuSeparatorInset} />
                 <DropdownItem
                   selected={includeExternal}
                   onClick={handleToggleIncludeExternal}
@@ -198,7 +198,7 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
                 </DropdownItem>
                 {hasExtraActions && (
                   <>
-                    <div className={DROPDOWN_CLASSES.menuSeparator} />
+                    <div className={DROPDOWN_CLASSES.menuSeparatorInset} />
                     {onRefreshSessions && (
                       <DropdownItem
                         dataTestId="sidebar-refresh-sessions"

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.MemberFilterDropdown.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.MemberFilterDropdown.tsx
@@ -221,7 +221,7 @@ export function useCloudMemberFilterDropdown({
               })}
               {hiddenCountForOrg > 0 && (
                 <>
-                  <div className={DROPDOWN_CLASSES.menuSeparator} />
+                  <div className={DROPDOWN_CLASSES.menuSeparatorInset} />
                   <DropdownItem onClick={handleShowHidden}>
                     <span className="min-w-0 truncate">
                       {t("cloud.sidebar.showHidden", {


### PR DESCRIPTION
## Problem

File-header breadcrumbs and dropdown menus did not consistently follow the shared spacing model. Breadcrumb separators left excess horizontal space and interactive segments lacked a hover underline. The file-tree dropdown stacked the panel padding with `TreeRowBase`'s sidebar-specific outer inset. Menu group dividers across the app used either the full-width structural separator or raw border classes, so their lines did not align with padded rows.

## Solution

- Tighten breadcrumb chevron spacing and underline interactive segments on hover.
- Add an opt-out for `TreeRowBase`'s outer inset, defaulting to the existing sidebar behavior, and let the padded file-tree dropdown own that spacing.
- Move all 23 row-group dividers found by the dropdown sweep to `menuSeparatorInset`, including three raw-border implementations.
- Clarify that `menuSeparator` is reserved for full-width structural boundaries.

This leaves one horizontal-spacing owner per surface: dropdown panels own panel padding, rows own their internal content padding, and row-group dividers use the shared inset token.

## Potential risks

Inset separators add the token's standard vertical group margin, so affected menus are slightly taller and a very constrained menu may reach its scroll threshold sooner. `TreeRowBase` keeps `inset=true` by default, limiting the row-layout change to the file dropdown's normal and sticky rows. There are no data, persistence, IPC, dependency, concurrency, or platform-format changes, and rollback is a straightforward revert of this commit.

## Verification

- `npm run lint:file -- <21 implementation and focused-test files>` — passed with zero warnings or errors.
- `npm run lint:file -- src/modules/ProjectManager/shared/components/ProjectManagerBreadcrumb/ProjectManagerBreadcrumb.test.ts` — passed after updating the integration expectation identified by CI.
- `npm test -- --run src/modules/ProjectManager/shared/components/ProjectManagerBreadcrumb/ProjectManagerBreadcrumb.test.ts src/components/TreeRow/TreeRowBase.test.ts src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.test.ts` — passed: 3 files, 14 tests.
- `npm run typecheck` — passed.
- Repository pre-commit checks — lint-staged, Prettier, scoped TypeScript, and staged-file checks passed for the 21-file implementation commit and the follow-up integration-test commit.
- `rg -n --pcre2 "DROPDOWN_CLASSES\\.menuSeparator(?!Inset)" src --glob '*.{ts,tsx}'` — no remaining row-group uses of the full-width token.
- `git diff --check origin/develop...HEAD` — passed.
- GitHub `Frontend (typecheck · lint · test)` — passed in 13m37s after the integration-test update.
- Runtime screenshots were not captured because desktop UI control is explicit opt-in in this repository and was not authorized for this task. The PR remains Draft pending a visual smoke check of representative menus in the desktop app.

## Audit

The workspace's named `frontend-ui-audit` skill is unavailable, so its intent was applied manually. The sweep covered shared dropdown-token usage, row/panel padding ownership, raw Tailwind divider duplication, and separator semantics. Result: 23 fix candidates migrated, structural header/footer/content boundaries retained with full-width borders, and no new arbitrary Tailwind values or accessibility regressions introduced.
