### PR TITLE
refactor(conversations): track continuation episodes

### DIFF
--- a/src/engines/ChatPanel/ConversationStreamProvider.tsx
+++ b/src/engines/ChatPanel/ConversationStreamProvider.tsx
@@ -7,6 +7,7 @@ import { useSessionCommentsContext } from "@src/features/Org2Cloud/SessionCommen
 import {
   activeConversationRunnersAtom,
   collectLandedTurnIds,
+  conversationRunnerRegistryKey,
   overlayableRunnerEvents,
   selectActiveRunners,
 } from "@src/features/Org2Cloud/SessionConversation/activeConversationRunnersAtom";
@@ -204,19 +205,20 @@ export function ConversationStreamProvider({
   const runnerRegistry = useAtomValue(activeConversationRunnersAtom);
   const setRunnerRegistry = useSetAtom(activeConversationRunnersAtom);
   const planeRootId = target?.sessionId ?? null;
+  const planeKey =
+    target && planeRootId
+      ? conversationRunnerRegistryKey(target.orgId, planeRootId)
+      : null;
   const landedTurnIds = useMemo(
     () => collectLandedTurnIds(plane.events),
     [plane.events]
   );
   const activeRunners = useMemo(() => {
-    if (!planeRootId) return [];
+    if (!planeKey) return [];
     // Drop a runner as soon as its agent tail is on the plane — the
     // authoritative rows take over with no double-render.
-    return selectActiveRunners(
-      runnerRegistry[planeRootId] ?? [],
-      landedTurnIds
-    );
-  }, [runnerRegistry, planeRootId, landedTurnIds]);
+    return selectActiveRunners(runnerRegistry[planeKey] ?? [], landedTurnIds);
+  }, [runnerRegistry, planeKey, landedTurnIds]);
   // The in-flight runner drives the chat footer's running/typing indicator
   // so a member's long turn shows "Thinking…" instead of a frozen screen.
   const activeRunnerScope =
@@ -224,18 +226,18 @@ export function ConversationStreamProvider({
       ? activeRunners[activeRunners.length - 1].runnerSessionId
       : null;
   useEffect(() => {
-    if (!planeRootId) return;
-    const list = runnerRegistry[planeRootId];
+    if (!planeKey) return;
+    const list = runnerRegistry[planeKey];
     if (!list?.length) return;
     const kept = selectActiveRunners(list, landedTurnIds);
     if (kept.length === list.length) return;
     setRunnerRegistry((current) => {
       const next = { ...current };
-      if (kept.length === 0) delete next[planeRootId];
-      else next[planeRootId] = kept;
+      if (kept.length === 0) delete next[planeKey];
+      else next[planeKey] = kept;
       return next;
     });
-  }, [planeRootId, runnerRegistry, landedTurnIds, setRunnerRegistry]);
+  }, [planeKey, runnerRegistry, landedTurnIds, setRunnerRegistry]);
   const [runnerEventsById, setRunnerEventsById] = useState<
     ReadonlyMap<string, readonly SessionEvent[]>
   >(() => new Map());

--- a/src/engines/ChatPanel/hooks/useImportedSessionSubmitOverride.ts
+++ b/src/engines/ChatPanel/hooks/useImportedSessionSubmitOverride.ts
@@ -274,7 +274,11 @@ export function useImportedSessionSubmitOverride({
             const runnerSessionId = liveRunnerSessionId;
             if (!runnerSessionId) return;
             liveRunnerSessionId = null;
-            settleCloudConversationRunner(planeInfo.rootId, runnerSessionId);
+            settleCloudConversationRunner(
+              planeInfo.orgId,
+              planeInfo.rootId,
+              runnerSessionId
+            );
           };
           const turnPromise = runConversationTurn({
             getAccessToken,

--- a/src/features/Org2Cloud/SessionConversation/activeConversationRunnersAtom.test.ts
+++ b/src/features/Org2Cloud/SessionConversation/activeConversationRunnersAtom.test.ts
@@ -4,9 +4,18 @@ import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 
 import {
   collectLandedTurnIds,
+  conversationRunnerRegistryKey,
   overlayableRunnerEvents,
   selectActiveRunners,
 } from "./activeConversationRunnersAtom";
+
+describe("conversationRunnerRegistryKey", () => {
+  it("isolates the same root id in different organizations", () => {
+    expect(conversationRunnerRegistryKey("org-a", "root")).not.toBe(
+      conversationRunnerRegistryKey("org-b", "root")
+    );
+  });
+});
 
 const row = (turnId: string, source: "user" | "assistant" | "system") => ({
   turnId,

--- a/src/features/Org2Cloud/SessionConversation/activeConversationRunnersAtom.ts
+++ b/src/features/Org2Cloud/SessionConversation/activeConversationRunnersAtom.ts
@@ -47,7 +47,15 @@ function dedupeByTurnId(
   return kept.reverse();
 }
 
-/** plane rootSessionId → this device's in-flight member runners. */
+/** Canonical in-memory plane identity. Root ids are not globally unique. */
+export function conversationRunnerRegistryKey(
+  orgId: string,
+  rootSessionId: string
+): string {
+  return JSON.stringify([orgId, rootSessionId]);
+}
+
+/** (organization, plane rootSessionId) → this device's in-flight runners. */
 const runnerRegistryStateAtom = atom<RunnerRegistry>({});
 export const activeConversationRunnersAtom = atom(
   (get) => get(runnerRegistryStateAtom),
@@ -59,8 +67,8 @@ export const activeConversationRunnersAtom = atom(
     const current = get(runnerRegistryStateAtom);
     const proposed = typeof update === "function" ? update(current) : update;
     const next: RunnerRegistry = {};
-    for (const [rootSessionId, runners] of Object.entries(proposed)) {
-      next[rootSessionId] = dedupeByTurnId(runners);
+    for (const [planeKey, runners] of Object.entries(proposed)) {
+      next[planeKey] = dedupeByTurnId(runners);
     }
     set(runnerRegistryStateAtom, next);
   }

--- a/src/features/Org2Cloud/SessionConversation/cloudConversationRuntime.ts
+++ b/src/features/Org2Cloud/SessionConversation/cloudConversationRuntime.ts
@@ -16,7 +16,10 @@ import {
   type ConversationEventWindow,
   listConversationEventsFrom,
 } from "../org2CloudConversationEventsClient";
-import { activeConversationRunnersAtom } from "./activeConversationRunnersAtom";
+import {
+  activeConversationRunnersAtom,
+  conversationRunnerRegistryKey,
+} from "./activeConversationRunnersAtom";
 import {
   bumpConversationPlaneSignal,
   conversationPlaneSignalAtom,
@@ -147,6 +150,10 @@ export function registerCloudConversationRunner(input: {
   turnIntentId: string;
 }): void {
   const store = getInstrumentedStore();
+  const planeKey = conversationRunnerRegistryKey(
+    input.orgId,
+    input.rootSessionId
+  );
   store.set(org2CloudAccessSettingsAtom, (current) =>
     withCloudSessionMode(
       current,
@@ -157,8 +164,8 @@ export function registerCloudConversationRunner(input: {
   );
   store.set(activeConversationRunnersAtom, (current) => ({
     ...current,
-    [input.rootSessionId]: [
-      ...(current[input.rootSessionId] ?? []),
+    [planeKey]: [
+      ...(current[planeKey] ?? []),
       {
         runnerSessionId: input.runnerSessionId,
         turnId: input.turnId,
@@ -169,20 +176,22 @@ export function registerCloudConversationRunner(input: {
 }
 
 export function settleCloudConversationRunner(
+  orgId: string,
   rootSessionId: string,
   runnerSessionId: string
 ): void {
   const store = getInstrumentedStore();
+  const planeKey = conversationRunnerRegistryKey(orgId, rootSessionId);
   store.set(activeConversationRunnersAtom, (current) => {
-    const list = current[rootSessionId];
+    const list = current[planeKey];
     if (!list) return current;
     const kept = list.filter(
       (runner) => runner.runnerSessionId !== runnerSessionId
     );
     if (kept.length === list.length) return current;
     const next = { ...current };
-    if (kept.length === 0) delete next[rootSessionId];
-    else next[rootSessionId] = kept;
+    if (kept.length === 0) delete next[planeKey];
+    else next[planeKey] = kept;
     return next;
   });
 }

--- a/src/features/Org2Cloud/SessionConversation/conversationContinuation.test.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationContinuation.test.ts
@@ -4,6 +4,7 @@ import type { ConversationContinuationRecord } from "./conversationContinuation"
 import { decideContinuation } from "./conversationContinuation";
 
 const established: ConversationContinuationRecord = {
+  episodeId: "conversation-episode:runner-1",
   continuationSessionId: "runner-1",
   readThroughPlaneSeq: 12,
   established: true,

--- a/src/features/Org2Cloud/SessionConversation/conversationContinuation.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationContinuation.ts
@@ -1,15 +1,19 @@
 /** Persistent local execution episode for a shared conversation. */
 import {
+  type ConversationContinuationInput,
+  type ConversationContinuationLineage,
   type ConversationContinuationRecord,
   advanceStoredContinuationReadThrough,
   clearStoredContinuation,
   loadStoredContinuation,
+  loadStoredContinuationLineage,
   markStoredContinuationEstablished,
   prepareStoredContinuation,
+  retireStoredContinuation,
   saveStoredContinuation,
 } from "./conversationExecutionStore";
 
-export type { ConversationContinuationRecord };
+export type { ConversationContinuationLineage, ConversationContinuationRecord };
 
 export function loadContinuation(
   executorScope: string,
@@ -22,7 +26,7 @@ export function loadContinuation(
 export function saveContinuation(
   executorScope: string,
   rootSessionId: string,
-  record: Omit<ConversationContinuationRecord, "updatedAt">,
+  record: ConversationContinuationInput,
   backing?: Storage | null
 ): void {
   saveStoredContinuation(executorScope, rootSessionId, record, backing);
@@ -31,7 +35,7 @@ export function saveContinuation(
 export function prepareContinuation(
   executorScope: string,
   rootSessionId: string,
-  record: Omit<ConversationContinuationRecord, "updatedAt">,
+  record: ConversationContinuationInput,
   preparedAt: string,
   backing?: Storage | null
 ): void {
@@ -40,6 +44,30 @@ export function prepareContinuation(
     rootSessionId,
     record,
     preparedAt,
+    backing
+  );
+}
+
+export function loadContinuationLineage(
+  executorScope: string,
+  rootSessionId: string,
+  backing?: Storage | null
+): ConversationContinuationLineage | null {
+  return loadStoredContinuationLineage(executorScope, rootSessionId, backing);
+}
+
+export function retireContinuation(
+  executorScope: string,
+  rootSessionId: string,
+  rollReason: string,
+  failed = false,
+  backing?: Storage | null
+): void {
+  retireStoredContinuation(
+    executorScope,
+    rootSessionId,
+    rollReason,
+    failed ? "failed" : "retired",
     backing
   );
 }

--- a/src/features/Org2Cloud/SessionConversation/conversationExecutionStore.test.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationExecutionStore.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  MAX_CONVERSATION_CONTINUATION_EPISODES,
   __CONVERSATION_EXECUTION_STORE_INTERNALS,
   advanceStoredContinuationReadThrough,
   advanceStoredOwnerPlaneCursor,
@@ -10,12 +11,14 @@ import {
   conversationExecutionKey,
   forgetStoredRunner,
   loadStoredContinuation,
+  loadStoredContinuationLineage,
   loadStoredOwnerPlaneCursor,
   loadStoredRunnerRegistryEntry,
   markStoredContinuationEstablished,
   markStoredRunnerTerminal,
   prepareStoredContinuation,
   registerStoredRunner,
+  retireStoredContinuation,
   saveStoredContinuation,
 } from "./conversationExecutionStore";
 
@@ -147,6 +150,222 @@ describe("conversation execution store", () => {
     expect(() =>
       advanceStoredOwnerPlaneCursor("scope", "root", -1, backing)
     ).toThrow("invalid conversation plane seq");
+  });
+
+  it("upgrades a legacy continuation into one authoritative episode", () => {
+    const backing = fakeStorage();
+    const key = conversationExecutionKey("scope", "root");
+    const legacyStorageKey =
+      __CONVERSATION_EXECUTION_STORE_INTERNALS.legacyEntryStorageKey(key);
+    const legacyRaw = JSON.stringify({
+      version: 1,
+      continuation: {
+        continuationSessionId: "legacy-runner",
+        readThroughPlaneSeq: 7,
+        established: true,
+        agentDefinitionId: "agent-a",
+        updatedAt: "2026-08-24T00:00:00Z",
+      },
+    });
+    backing.setItem(legacyStorageKey, legacyRaw);
+
+    expect(loadStoredContinuation("scope", "root", backing)).toMatchObject({
+      episodeId: "conversation-episode:legacy-runner",
+      continuationSessionId: "legacy-runner",
+      readThroughPlaneSeq: 7,
+    });
+    expect(
+      loadStoredContinuationLineage("scope", "root", backing)
+    ).toMatchObject({
+      activeEpisodeId: "conversation-episode:legacy-runner",
+      episodes: [
+        {
+          episodeId: "conversation-episode:legacy-runner",
+          state: "active",
+        },
+      ],
+    });
+
+    advanceStoredContinuationReadThrough("scope", "root", 8, backing);
+    const currentStorageKey =
+      __CONVERSATION_EXECUTION_STORE_INTERNALS.entryStorageKey(key);
+    const upgraded = JSON.parse(
+      backing.getItem(currentStorageKey) ?? "null"
+    ) as {
+      version?: number;
+      continuationLineage?: { activeEpisodeId?: string };
+    };
+    expect(upgraded.version).toBe(2);
+    expect(upgraded.continuationLineage?.activeEpisodeId).toBe(
+      "conversation-episode:legacy-runner"
+    );
+    expect(backing.getItem(legacyStorageKey)).toBe(legacyRaw);
+    expect(loadStoredContinuation("scope", "root", backing)).toMatchObject({
+      readThroughPlaneSeq: 8,
+    });
+
+    // Simulate an old window writing its v1 projection after v2 migration.
+    backing.setItem(
+      legacyStorageKey,
+      legacyRaw.replace('"readThroughPlaneSeq":7', '"readThroughPlaneSeq":99')
+    );
+    expect(loadStoredContinuation("scope", "root", backing)).toMatchObject({
+      readThroughPlaneSeq: 8,
+    });
+  });
+
+  it("fails closed when a correctness write is not durable", () => {
+    const values = new Map<string, string>();
+    const backing: Storage = {
+      get length() {
+        return values.size;
+      },
+      clear: () => values.clear(),
+      getItem: (key) => values.get(key) ?? null,
+      key: (index) => [...values.keys()][index] ?? null,
+      removeItem: (key) => values.delete(key),
+      setItem: () => undefined,
+    };
+
+    expect(() =>
+      prepareStoredContinuation(
+        "scope",
+        "root",
+        {
+          continuationSessionId: "runner-1",
+          readThroughPlaneSeq: 0,
+          established: false,
+          bootstrapTurnIntentId: "intent-1",
+          agentDefinitionId: "agent-a",
+        },
+        "2026-08-25T00:00:00Z",
+        backing
+      )
+    ).toThrow("conversation execution state did not persist");
+  });
+
+  it("fails closed when correctness storage is unavailable", () => {
+    expect(() =>
+      saveStoredContinuation(
+        "scope",
+        "root",
+        {
+          continuationSessionId: "runner-1",
+          readThroughPlaneSeq: 0,
+          established: true,
+          agentDefinitionId: "agent-a",
+        },
+        null
+      )
+    ).toThrow("conversation execution storage unavailable");
+  });
+
+  it("keeps the requested active episode when bounding malformed lineage", () => {
+    const backing = fakeStorage();
+    const key = conversationExecutionKey("scope", "root");
+    const episodes = Array.from({ length: 20 }, (_, index) => ({
+      episodeId: `episode-${index}`,
+      continuationSessionId: `runner-${index}`,
+      readThroughPlaneSeq: index,
+      established: true,
+      agentDefinitionId: "agent-a",
+      updatedAt: `2026-08-25T00:00:${String(index).padStart(2, "0")}Z`,
+      state: index === 0 ? "active" : "retired",
+      createdAt: `2026-08-25T00:00:${String(index).padStart(2, "0")}Z`,
+    }));
+    backing.setItem(
+      __CONVERSATION_EXECUTION_STORE_INTERNALS.entryStorageKey(key),
+      JSON.stringify({
+        version: 2,
+        continuationLineage: {
+          activeEpisodeId: "episode-0",
+          episodes,
+          updatedAt: "2026-08-25T00:01:00Z",
+        },
+      })
+    );
+
+    const lineage = loadStoredContinuationLineage("scope", "root", backing);
+    expect(lineage?.activeEpisodeId).toBe("episode-0");
+    expect(lineage?.episodes).toHaveLength(
+      MAX_CONVERSATION_CONTINUATION_EPISODES
+    );
+    expect(lineage?.episodes[0].episodeId).toBe("episode-0");
+  });
+
+  it("keeps a bounded, explainable episode lineage", () => {
+    const backing = fakeStorage();
+    for (
+      let index = 0;
+      index < MAX_CONVERSATION_CONTINUATION_EPISODES + 4;
+      index += 1
+    ) {
+      saveStoredContinuation(
+        "scope",
+        "root",
+        {
+          continuationSessionId: `runner-${index}`,
+          readThroughPlaneSeq: index,
+          established: true,
+          agentDefinitionId: "agent-a",
+        },
+        backing
+      );
+    }
+
+    const lineage = loadStoredContinuationLineage("scope", "root", backing);
+    expect(lineage?.episodes).toHaveLength(
+      MAX_CONVERSATION_CONTINUATION_EPISODES
+    );
+    expect(lineage?.episodes[0].continuationSessionId).toBe("runner-4");
+    expect(lineage?.episodes.at(-1)).toMatchObject({
+      continuationSessionId: `runner-${MAX_CONVERSATION_CONTINUATION_EPISODES + 3}`,
+      state: "active",
+    });
+    expect(
+      lineage?.episodes.filter((episode) => episode.state === "active")
+    ).toHaveLength(1);
+  });
+
+  it("retires the active episode with a durable reason", () => {
+    const backing = fakeStorage();
+    saveStoredContinuation(
+      "scope",
+      "root",
+      {
+        continuationSessionId: "runner-1",
+        readThroughPlaneSeq: 9,
+        established: true,
+        agentDefinitionId: "agent-a",
+      },
+      backing
+    );
+
+    expect(
+      retireStoredContinuation(
+        "scope",
+        "root",
+        "resume_transport_rejected",
+        "failed",
+        backing
+      )
+    ).toMatchObject({
+      continuationSessionId: "runner-1",
+      state: "failed",
+      rollReason: "resume_transport_rejected",
+    });
+    expect(loadStoredContinuation("scope", "root", backing)).toBeNull();
+    const lineage = loadStoredContinuationLineage("scope", "root", backing);
+    expect(lineage?.activeEpisodeId).toBeUndefined();
+    expect(lineage).toMatchObject({
+      episodes: [
+        {
+          continuationSessionId: "runner-1",
+          state: "failed",
+          rollReason: "resume_transport_rejected",
+        },
+      ],
+    });
   });
 
   it("establishes only the exact bootstrap runner and intent", () => {

--- a/src/features/Org2Cloud/SessionConversation/conversationExecutionStore.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationExecutionStore.ts
@@ -8,10 +8,13 @@
  * Sessions.
  */
 
-const STORE_VERSION = 1 as const;
-const STORAGE_KEY_PREFIX = "orgii:conversation-execution-v1:";
+const STORE_VERSION = 2 as const;
+const STORAGE_KEY_PREFIX = "orgii:conversation-execution-v2:";
+const LEGACY_EXECUTION_STORE_VERSION = 1 as const;
+const LEGACY_EXECUTION_STORAGE_KEY_PREFIX = "orgii:conversation-execution-v1:";
 const LEGACY_RUNNERS_KEY = "orgii:conversation-runners-v1";
 const UNKNOWN_UPDATED_AT = "1970-01-01T00:00:00.000Z";
+export const MAX_CONVERSATION_CONTINUATION_EPISODES = 16;
 
 export interface ConversationRunnerRegistryEntry {
   runnerSessionIds: string[];
@@ -20,6 +23,8 @@ export interface ConversationRunnerRegistryEntry {
 }
 
 export interface ConversationContinuationRecord {
+  /** Stable lineage node. Derived from the runner id for legacy records. */
+  episodeId: string;
   continuationSessionId: string;
   /** Highest plane seq this continuation has successfully consumed. */
   readThroughPlaneSeq: number;
@@ -35,6 +40,35 @@ export interface ConversationContinuationRecord {
   updatedAt: string;
 }
 
+export type ConversationContinuationEpisodeState =
+  | "prepared"
+  | "active"
+  | "retired"
+  | "failed";
+
+/**
+ * Immutable execution identity plus the mutable lifecycle/cursor of one
+ * native runner. Retired nodes remain as bounded metadata so a runtime roll
+ * is explainable without keeping old transcripts in localStorage.
+ */
+export interface ConversationContinuationEpisode extends ConversationContinuationRecord {
+  state: ConversationContinuationEpisodeState;
+  createdAt: string;
+  supersedesEpisodeId?: string;
+  rollReason?: string;
+}
+
+export interface ConversationContinuationLineage {
+  activeEpisodeId?: string;
+  episodes: ConversationContinuationEpisode[];
+  updatedAt: string;
+}
+
+export type ConversationContinuationInput = Omit<
+  ConversationContinuationRecord,
+  "episodeId" | "updatedAt"
+> & { episodeId?: string };
+
 export interface ConversationPlaneReadCursor {
   readThroughPlaneSeq: number;
   updatedAt: string;
@@ -43,8 +77,16 @@ export interface ConversationPlaneReadCursor {
 interface ConversationExecutionEnvelope {
   version: typeof STORE_VERSION;
   runners?: ConversationRunnerRegistryEntry;
-  continuation?: ConversationContinuationRecord;
+  /** Authoritative continuation state. */
+  continuationLineage?: ConversationContinuationLineage;
   /** Independent cursor for execution directly in the owner's root session. */
+  ownerPlaneCursor?: ConversationPlaneReadCursor;
+}
+
+interface LegacyConversationExecutionEnvelope {
+  version: typeof LEGACY_EXECUTION_STORE_VERSION;
+  runners?: ConversationRunnerRegistryEntry;
+  continuation?: ConversationContinuationRecord;
   ownerPlaneCursor?: ConversationPlaneReadCursor;
 }
 
@@ -132,6 +174,9 @@ function sanitizeContinuation(
     return null;
   }
   const record: ConversationContinuationRecord = {
+    episodeId:
+      optionalString(value, "episodeId") ??
+      episodeIdForRunner(continuationSessionId),
     continuationSessionId,
     readThroughPlaneSeq: value.readThroughPlaneSeq,
     established: value.established,
@@ -154,6 +199,110 @@ function sanitizeContinuation(
     record.workspaceRepoPath = value.workspaceRepoPath;
   }
   return record;
+}
+
+function episodeIdForRunner(continuationSessionId: string): string {
+  return `conversation-episode:${continuationSessionId}`;
+}
+
+function isEpisodeState(
+  value: unknown
+): value is ConversationContinuationEpisodeState {
+  return (
+    value === "prepared" ||
+    value === "active" ||
+    value === "retired" ||
+    value === "failed"
+  );
+}
+
+function sanitizeEpisode(
+  value: unknown
+): ConversationContinuationEpisode | null {
+  if (!isObject(value)) return null;
+  const record = sanitizeContinuation(value);
+  if (!record || !isEpisodeState(value.state)) return null;
+  if (
+    (value.state === "prepared" && record.established) ||
+    (value.state === "active" && !record.established)
+  ) {
+    return null;
+  }
+  const episode: ConversationContinuationEpisode = {
+    ...record,
+    state: value.state,
+    createdAt: optionalString(value, "createdAt") ?? record.updatedAt,
+  };
+  const supersedesEpisodeId = optionalString(value, "supersedesEpisodeId");
+  if (supersedesEpisodeId) episode.supersedesEpisodeId = supersedesEpisodeId;
+  const rollReason = optionalString(value, "rollReason");
+  if (rollReason) episode.rollReason = rollReason;
+  return episode;
+}
+
+function activeEpisode(
+  lineage: ConversationContinuationLineage | null | undefined
+): ConversationContinuationEpisode | null {
+  if (!lineage?.activeEpisodeId) return null;
+  const episode = lineage.episodes.find(
+    (candidate) => candidate.episodeId === lineage.activeEpisodeId
+  );
+  return episode && (episode.state === "prepared" || episode.state === "active")
+    ? episode
+    : null;
+}
+
+function sanitizeLineage(
+  value: unknown,
+  legacyContinuation: ConversationContinuationRecord | null
+): ConversationContinuationLineage | null {
+  if (isObject(value) && Array.isArray(value.episodes)) {
+    const seen = new Set<string>();
+    const sanitizedEpisodes = value.episodes
+      .map(sanitizeEpisode)
+      .filter((episode): episode is ConversationContinuationEpisode => {
+        if (!episode || seen.has(episode.episodeId)) return false;
+        seen.add(episode.episodeId);
+        return true;
+      });
+    const requestedActiveEpisodeId = optionalString(value, "activeEpisodeId");
+    const requestedActiveEpisode = sanitizedEpisodes.find(
+      (episode) =>
+        episode.episodeId === requestedActiveEpisodeId &&
+        (episode.state === "prepared" || episode.state === "active")
+    );
+    const recentEpisodes = sanitizedEpisodes.slice(
+      -MAX_CONVERSATION_CONTINUATION_EPISODES
+    );
+    const episodes =
+      requestedActiveEpisode && !recentEpisodes.includes(requestedActiveEpisode)
+        ? [
+            requestedActiveEpisode,
+            ...sanitizedEpisodes
+              .filter((episode) => episode !== requestedActiveEpisode)
+              .slice(-(MAX_CONVERSATION_CONTINUATION_EPISODES - 1)),
+          ]
+        : recentEpisodes;
+    const activeEpisodeId = requestedActiveEpisode?.episodeId;
+    if (episodes.length > 0) {
+      return {
+        ...(activeEpisodeId ? { activeEpisodeId } : {}),
+        episodes,
+        updatedAt: optionalString(value, "updatedAt") ?? UNKNOWN_UPDATED_AT,
+      };
+    }
+  }
+  if (!legacyContinuation) return null;
+  const legacyEpisode: ConversationContinuationEpisode = {
+    ...legacyContinuation,
+    state: legacyContinuation.established ? "active" : "prepared",
+    createdAt: legacyContinuation.updatedAt,
+  };
+  return {
+    activeEpisodeId: legacyEpisode.episodeId,
+    episodes: [legacyEpisode],
+    updatedAt: legacyEpisode.updatedAt,
+  };
 }
 
 function sanitizePlaneCursor(
@@ -185,37 +334,75 @@ function entryStorageKey(executionKey: string): string {
   return `${STORAGE_KEY_PREFIX}${encodeURIComponent(executionKey)}`;
 }
 
-function executionKeyFromStorageKey(storageKey: string): string | null {
-  if (!storageKey.startsWith(STORAGE_KEY_PREFIX)) return null;
+function legacyEntryStorageKey(executionKey: string): string {
+  return `${LEGACY_EXECUTION_STORAGE_KEY_PREFIX}${encodeURIComponent(
+    executionKey
+  )}`;
+}
+
+function executionKeyFromStorageKey(
+  storageKey: string,
+  prefix = STORAGE_KEY_PREFIX
+): string | null {
+  if (!storageKey.startsWith(prefix)) return null;
   try {
     return normalizeExecutionKey(
-      decodeURIComponent(storageKey.slice(STORAGE_KEY_PREFIX.length))
+      decodeURIComponent(storageKey.slice(prefix.length))
     );
   } catch {
     return null;
   }
 }
 
-function readEnvelope(
+function readCurrentEnvelope(
   backing: Storage | null,
   executionKey: string
 ): ConversationExecutionEnvelope | null {
   const parsed = readJson(backing, entryStorageKey(executionKey));
   if (!isObject(parsed) || parsed.version !== STORE_VERSION) return null;
   const runners = sanitizeRunners(parsed.runners);
-  const continuation = sanitizeContinuation(parsed.continuation);
+  const continuationLineage = sanitizeLineage(parsed.continuationLineage, null);
   const ownerPlaneCursor = sanitizePlaneCursor(parsed.ownerPlaneCursor);
   return {
     version: STORE_VERSION,
     ...(runners ? { runners } : {}),
-    ...(continuation ? { continuation } : {}),
+    ...(continuationLineage ? { continuationLineage } : {}),
     ...(ownerPlaneCursor ? { ownerPlaneCursor } : {}),
   };
 }
 
-function hasExecutionData(envelope: ConversationExecutionEnvelope): boolean {
-  return Boolean(
-    envelope.runners || envelope.continuation || envelope.ownerPlaneCursor
+function readLegacyExecutionEnvelope(
+  backing: Storage | null,
+  executionKey: string
+): ConversationExecutionEnvelope | null {
+  const parsed = readJson(backing, legacyEntryStorageKey(executionKey));
+  if (!isObject(parsed) || parsed.version !== LEGACY_EXECUTION_STORE_VERSION) {
+    return null;
+  }
+  const legacy = parsed as unknown as LegacyConversationExecutionEnvelope;
+  const runners = sanitizeRunners(legacy.runners);
+  const continuation = sanitizeContinuation(legacy.continuation);
+  const continuationLineage = sanitizeLineage(null, continuation);
+  const ownerPlaneCursor = sanitizePlaneCursor(legacy.ownerPlaneCursor);
+  return {
+    version: STORE_VERSION,
+    ...(runners ? { runners } : {}),
+    ...(continuationLineage ? { continuationLineage } : {}),
+    ...(ownerPlaneCursor ? { ownerPlaneCursor } : {}),
+  };
+}
+
+/**
+ * A valid v2 envelope owns the execution key, including an empty tombstone.
+ * The immutable v1 entry is consulted only until the first v2 mutation.
+ */
+function readEnvelope(
+  backing: Storage | null,
+  executionKey: string
+): ConversationExecutionEnvelope | null {
+  return (
+    readCurrentEnvelope(backing, executionKey) ??
+    readLegacyExecutionEnvelope(backing, executionKey)
   );
 }
 
@@ -224,15 +411,16 @@ function writeEnvelope(
   executionKey: string,
   envelope: ConversationExecutionEnvelope
 ): void {
-  if (!backing) return;
-  try {
-    if (!hasExecutionData(envelope)) {
-      backing.removeItem(entryStorageKey(executionKey));
-      return;
-    }
-    backing.setItem(entryStorageKey(executionKey), JSON.stringify(envelope));
-  } catch {
-    // Best-effort: a failed local persistence write rolls through recovery.
+  if (!backing) {
+    throw new Error("conversation execution storage unavailable");
+  }
+  // Persist an empty v2 tombstone as well. Removing it could expose a stale v1
+  // record written by an older window after this build retired the runner.
+  const storageKey = entryStorageKey(executionKey);
+  const serialized = JSON.stringify(envelope);
+  backing.setItem(storageKey, serialized);
+  if (backing.getItem(storageKey) !== serialized) {
+    throw new Error("conversation execution state did not persist");
   }
 }
 
@@ -305,17 +493,106 @@ function keyFor(executorScope: string, rootSessionId: string): string {
   return conversationExecutionKey(executorScope, rootSessionId);
 }
 
+function ensureLineage(
+  envelope: ConversationExecutionEnvelope,
+  updatedAt: string
+): ConversationContinuationLineage {
+  const lineage = envelope.continuationLineage ?? {
+    episodes: [],
+    updatedAt,
+  };
+  envelope.continuationLineage = lineage;
+  return lineage;
+}
+
+function continuationEpisodeFromRecord(
+  record: ConversationContinuationInput,
+  updatedAt: string,
+  previousActiveEpisodeId?: string
+): ConversationContinuationEpisode {
+  const episodeId =
+    record.episodeId || episodeIdForRunner(record.continuationSessionId);
+  return {
+    ...record,
+    episodeId,
+    state: record.established ? "active" : "prepared",
+    createdAt: updatedAt,
+    updatedAt,
+    ...(previousActiveEpisodeId && previousActiveEpisodeId !== episodeId
+      ? { supersedesEpisodeId: previousActiveEpisodeId }
+      : {}),
+  };
+}
+
+function installActiveEpisode(
+  envelope: ConversationExecutionEnvelope,
+  record: ConversationContinuationInput,
+  updatedAt: string
+): void {
+  const lineage = ensureLineage(envelope, updatedAt);
+  const previousActive = activeEpisode(lineage);
+  const nextEpisodeId =
+    record.episodeId || episodeIdForRunner(record.continuationSessionId);
+  if (previousActive && previousActive.episodeId !== nextEpisodeId) {
+    previousActive.state = "retired";
+    previousActive.rollReason ??= "superseded";
+    previousActive.updatedAt = updatedAt;
+  }
+  const episode = continuationEpisodeFromRecord(
+    record,
+    updatedAt,
+    previousActive?.episodeId
+  );
+  const existingIndex = lineage.episodes.findIndex(
+    (candidate) => candidate.episodeId === episode.episodeId
+  );
+  if (existingIndex >= 0) {
+    episode.createdAt = lineage.episodes[existingIndex].createdAt;
+    lineage.episodes[existingIndex] = episode;
+  } else {
+    lineage.episodes.push(episode);
+  }
+  lineage.activeEpisodeId = episode.episodeId;
+  lineage.updatedAt = updatedAt;
+  lineage.episodes = lineage.episodes.slice(
+    -MAX_CONVERSATION_CONTINUATION_EPISODES
+  );
+}
+
+function mutateActiveEpisode(
+  envelope: ConversationExecutionEnvelope,
+  mutate: (episode: ConversationContinuationEpisode) => boolean
+): boolean {
+  const episode = activeEpisode(envelope.continuationLineage);
+  if (!episode || !mutate(episode)) return false;
+  const now = new Date().toISOString();
+  episode.updatedAt = now;
+  if (envelope.continuationLineage) {
+    envelope.continuationLineage.updatedAt = now;
+  }
+  return true;
+}
+
 export function loadStoredContinuation(
   executorScope: string,
   rootSessionId: string,
   backing: Storage | null = defaultStorage()
 ): ConversationContinuationRecord | null {
   const key = keyFor(executorScope, rootSessionId);
-  return readEnvelope(backing, key)?.continuation ?? null;
+  return activeEpisode(readEnvelope(backing, key)?.continuationLineage);
+}
+
+export function loadStoredContinuationLineage(
+  executorScope: string,
+  rootSessionId: string,
+  backing: Storage | null = defaultStorage()
+): ConversationContinuationLineage | null {
+  const key = keyFor(executorScope, rootSessionId);
+  return readEnvelope(backing, key)?.continuationLineage ?? null;
 }
 
 function assertValidContinuationRecord(
-  record: Omit<ConversationContinuationRecord, "updatedAt">
+  record: ConversationContinuationInput
 ): void {
   if (
     !validPlaneSeq(record.readThroughPlaneSeq) ||
@@ -331,15 +608,12 @@ function assertValidContinuationRecord(
 export function saveStoredContinuation(
   executorScope: string,
   rootSessionId: string,
-  record: Omit<ConversationContinuationRecord, "updatedAt">,
+  record: ConversationContinuationInput,
   backing: Storage | null = defaultStorage()
 ): void {
   assertValidContinuationRecord(record);
   mutateEnvelope(backing, keyFor(executorScope, rootSessionId), (envelope) => {
-    envelope.continuation = {
-      ...record,
-      updatedAt: new Date().toISOString(),
-    };
+    installActiveEpisode(envelope, record, new Date().toISOString());
     return true;
   });
 }
@@ -348,7 +622,7 @@ export function saveStoredContinuation(
 export function prepareStoredContinuation(
   executorScope: string,
   rootSessionId: string,
-  record: Omit<ConversationContinuationRecord, "updatedAt">,
+  record: ConversationContinuationInput,
   preparedAt: string,
   backing: Storage | null = defaultStorage()
 ): void {
@@ -366,7 +640,7 @@ export function prepareStoredContinuation(
       terminalRunnerSessionIds: current?.terminalRunnerSessionIds ?? [],
       updatedAt: preparedAt,
     };
-    envelope.continuation = { ...record, updatedAt: preparedAt };
+    installActiveEpisode(envelope, record, preparedAt);
     return true;
   });
 }
@@ -377,10 +651,44 @@ export function clearStoredContinuation(
   backing: Storage | null = defaultStorage()
 ): void {
   mutateEnvelope(backing, keyFor(executorScope, rootSessionId), (envelope) => {
-    if (!envelope.continuation) return false;
-    delete envelope.continuation;
+    const lineage = envelope.continuationLineage;
+    const episode = activeEpisode(lineage);
+    if (!lineage || !episode) return false;
+    const now = new Date().toISOString();
+    episode.state = "retired";
+    episode.rollReason ??= "cleared";
+    episode.updatedAt = now;
+    delete lineage.activeEpisodeId;
+    lineage.updatedAt = now;
     return true;
   });
+}
+
+export function retireStoredContinuation(
+  executorScope: string,
+  rootSessionId: string,
+  rollReason: string,
+  state: Extract<
+    ConversationContinuationEpisodeState,
+    "retired" | "failed"
+  > = "retired",
+  backing: Storage | null = defaultStorage()
+): ConversationContinuationEpisode | null {
+  let retired: ConversationContinuationEpisode | null = null;
+  mutateEnvelope(backing, keyFor(executorScope, rootSessionId), (envelope) => {
+    const lineage = envelope.continuationLineage;
+    const episode = activeEpisode(lineage);
+    if (!lineage || !episode || !rollReason.trim()) return false;
+    const now = new Date().toISOString();
+    episode.state = state;
+    episode.rollReason = rollReason;
+    episode.updatedAt = now;
+    delete lineage.activeEpisodeId;
+    lineage.updatedAt = now;
+    retired = { ...episode };
+    return true;
+  });
+  return retired;
 }
 
 /** Fence bootstrap completion to the exact local runner and logical intent. */
@@ -393,7 +701,7 @@ export function markStoredContinuationEstablished(
 ): boolean {
   let established = false;
   mutateEnvelope(backing, keyFor(executorScope, rootSessionId), (envelope) => {
-    const continuation = envelope.continuation;
+    const continuation = activeEpisode(envelope.continuationLineage);
     if (
       !continuation ||
       continuation.continuationSessionId !== continuationSessionId ||
@@ -403,10 +711,10 @@ export function markStoredContinuationEstablished(
       return false;
     }
     continuation.established = true;
+    continuation.state = "active";
     delete continuation.bootstrapTurnIntentId;
-    continuation.updatedAt = new Date().toISOString();
     established = true;
-    return true;
+    return mutateActiveEpisode(envelope, () => true);
   });
   return established;
 }
@@ -421,13 +729,11 @@ export function advanceStoredContinuationReadThrough(
     throw new Error(`invalid conversation plane seq: ${planeSeq}`);
   }
   mutateEnvelope(backing, keyFor(executorScope, rootSessionId), (envelope) => {
-    const continuation = envelope.continuation;
-    if (!continuation || continuation.readThroughPlaneSeq >= planeSeq) {
-      return false;
-    }
-    continuation.readThroughPlaneSeq = planeSeq;
-    continuation.updatedAt = new Date().toISOString();
-    return true;
+    return mutateActiveEpisode(envelope, (continuation) => {
+      if (continuation.readThroughPlaneSeq >= planeSeq) return false;
+      continuation.readThroughPlaneSeq = planeSeq;
+      return true;
+    });
   });
 }
 
@@ -515,11 +821,25 @@ export function collectStoredRunnerSessionIds(
   backing: Storage | null = defaultStorage()
 ): Set<string> {
   const sessionIds = new Set<string>();
+  const currentExecutionKeys = new Set<string>();
   for (const storageKey of allStorageKeys(backing)) {
     const executionKey = executionKeyFromStorageKey(storageKey);
     if (!executionKey) continue;
-    for (const sessionId of readEnvelope(backing, executionKey)?.runners
-      ?.runnerSessionIds ?? []) {
+    const current = readCurrentEnvelope(backing, executionKey);
+    if (!current) continue;
+    currentExecutionKeys.add(executionKey);
+    for (const sessionId of current.runners?.runnerSessionIds ?? []) {
+      sessionIds.add(sessionId);
+    }
+  }
+  for (const storageKey of allStorageKeys(backing)) {
+    const executionKey = executionKeyFromStorageKey(
+      storageKey,
+      LEGACY_EXECUTION_STORAGE_KEY_PREFIX
+    );
+    if (!executionKey || currentExecutionKeys.has(executionKey)) continue;
+    for (const sessionId of readLegacyExecutionEnvelope(backing, executionKey)
+      ?.runners?.runnerSessionIds ?? []) {
       sessionIds.add(sessionId);
     }
   }
@@ -535,17 +855,26 @@ export function forgetStoredRunner(
   runnerSessionId: string,
   backing: Storage | null = defaultStorage()
 ): void {
+  const executionKeys = new Set<string>();
   for (const storageKey of allStorageKeys(backing)) {
-    const executionKey = executionKeyFromStorageKey(storageKey);
-    if (!executionKey) continue;
+    const executionKey =
+      executionKeyFromStorageKey(storageKey) ??
+      executionKeyFromStorageKey(
+        storageKey,
+        LEGACY_EXECUTION_STORAGE_KEY_PREFIX
+      );
+    if (executionKey) executionKeys.add(executionKey);
+  }
+  for (const executionKey of executionKeys) {
     const envelope = readEnvelope(backing, executionKey);
     const current = envelope?.runners;
     if (!envelope) continue;
     const removesRunner = Boolean(
       current?.runnerSessionIds.includes(runnerSessionId)
     );
+    const currentContinuation = activeEpisode(envelope.continuationLineage);
     const removesContinuation =
-      envelope.continuation?.continuationSessionId === runnerSessionId;
+      currentContinuation?.continuationSessionId === runnerSessionId;
     if (!removesRunner && !removesContinuation) continue;
     if (current && removesRunner) {
       const runnerSessionIds = current.runnerSessionIds.filter(
@@ -563,8 +892,13 @@ export function forgetStoredRunner(
         };
       }
     }
-    if (removesContinuation) {
-      delete envelope.continuation;
+    if (removesContinuation && envelope.continuationLineage) {
+      const now = new Date().toISOString();
+      currentContinuation.state = "failed";
+      currentContinuation.rollReason ??= "runner_deleted";
+      currentContinuation.updatedAt = now;
+      delete envelope.continuationLineage.activeEpisodeId;
+      envelope.continuationLineage.updatedAt = now;
     }
     writeEnvelope(backing, executionKey, envelope);
   }
@@ -606,6 +940,9 @@ export function forgetStoredRunner(
 export const __CONVERSATION_EXECUTION_STORE_INTERNALS = {
   STORE_VERSION,
   STORAGE_KEY_PREFIX,
+  LEGACY_EXECUTION_STORE_VERSION,
+  LEGACY_EXECUTION_STORAGE_KEY_PREFIX,
   LEGACY_RUNNERS_KEY,
   entryStorageKey,
+  legacyEntryStorageKey,
 };

--- a/src/features/Org2Cloud/SessionConversation/conversationTurnRunner.test.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationTurnRunner.test.ts
@@ -293,6 +293,47 @@ describe("conversation turn continuation", () => {
     ]);
   });
 
+  it("does not acknowledge an accepted turn after continuation storage loss", async () => {
+    const onTurnAccepted = vi.fn();
+    const onTransportAccepted = vi.fn();
+
+    await expect(
+      runConversationTurn(
+        params({
+          onRunnerReady: () => {
+            Object.defineProperty(globalThis, "localStorage", {
+              configurable: true,
+              value: fakeStorage(),
+            });
+          },
+          onTransportAccepted,
+          onTurnAccepted,
+        })
+      )
+    ).rejects.toThrow("continuation acceptance could not be persisted");
+
+    expect(onTransportAccepted).toHaveBeenCalledWith(
+      "fresh-runner",
+      "intent-1"
+    );
+    expect(onTurnAccepted).not.toHaveBeenCalled();
+    expect(state.cleaned).toEqual([]);
+  });
+
+  it("deletes a new runner when durable prepare cannot be persisted", async () => {
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: null,
+    });
+
+    await expect(runConversationTurn(params())).rejects.toThrow(
+      "conversation execution storage unavailable"
+    );
+
+    expect(sendReservedTurn).not.toHaveBeenCalled();
+    expect(state.cleaned).toEqual(["fresh-runner"]);
+  });
+
   it("reuses the runner, injects only new foreign rows, and advances the cursor", async () => {
     saveContinuation("scope", "root", {
       continuationSessionId: "runner-live",

--- a/src/features/Org2Cloud/SessionConversation/conversationTurnRunner.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationTurnRunner.ts
@@ -46,11 +46,11 @@ import {
 } from "../org2CloudConversationEventsClient";
 import {
   advanceContinuationReadThrough,
-  clearContinuation,
   decideContinuation,
   loadContinuation,
   markContinuationEstablished,
   prepareContinuation,
+  retireContinuation,
 } from "./conversationContinuation";
 import {
   cleanupConversationRunnerBestEffort,
@@ -219,6 +219,11 @@ export interface RunConversationTurnParams {
   onRunnerReady?: (
     runnerSessionId: string,
     turnId: string,
+    turnIntentId: string
+  ) => void | Promise<void>;
+  /** Adapter accepted the exact intent; failures after this point are ambiguous. */
+  onTransportAccepted?: (
+    runnerSessionId: string,
     turnIntentId: string
   ) => void | Promise<void>;
   /** Called after the adapter accepts the exact runtime intent. */
@@ -466,7 +471,11 @@ async function runConversationTurnSerialized(
   }
   if (decision.kind === "fresh" && decision.rollReason) {
     log.info(`rolling conversation continuation: ${decision.rollReason}`);
-    clearContinuation(params.executionScopeKey, params.rootSessionId);
+    retireContinuation(
+      params.executionScopeKey,
+      params.rootSessionId,
+      decision.rollReason
+    );
     if (record) {
       await cleanupConversationRunnerBestEffort(record.continuationSessionId);
     }
@@ -510,7 +519,12 @@ async function runConversationTurnSerialized(
     } catch (error) {
       if (params.preserveRunnerOnTransportFailure) throw error;
       log.warn("continuation send rejected; rolling to a fresh runner", error);
-      clearContinuation(params.executionScopeKey, params.rootSessionId);
+      retireContinuation(
+        params.executionScopeKey,
+        params.rootSessionId,
+        "resume_transport_rejected",
+        true
+      );
       await cleanupConversationRunnerBestEffort(
         decision.record.continuationSessionId
       );
@@ -521,6 +535,10 @@ async function runConversationTurnSerialized(
         userRowLastSeq,
       });
     }
+    await params.onTransportAccepted?.(
+      decision.record.continuationSessionId,
+      io.turnIntentId
+    );
     await params.onTurnAccepted?.(
       decision.record.continuationSessionId,
       io.turnIntentId
@@ -661,22 +679,27 @@ async function startFreshEpisode(
   }
 
   const runnerSessionId = created.sessionId;
-  prepareContinuation(
-    params.executionScopeKey,
-    params.rootSessionId,
-    {
-      continuationSessionId: runnerSessionId,
-      readThroughPlaneSeq: 0,
-      established: false,
-      bootstrapTurnIntentId: io.turnIntentId,
-      agentDefinitionId: setup.execution.agentDefinitionId,
-      cliAgentType: setup.execution.cliAgentType,
-      accountId: setup.execution.accountId,
-      model: setup.execution.model,
-      workspaceRepoPath: setup.workspaceRepoPath ?? null,
-    },
-    turn.dispatchIso
-  );
+  try {
+    prepareContinuation(
+      params.executionScopeKey,
+      params.rootSessionId,
+      {
+        continuationSessionId: runnerSessionId,
+        readThroughPlaneSeq: 0,
+        established: false,
+        bootstrapTurnIntentId: io.turnIntentId,
+        agentDefinitionId: setup.execution.agentDefinitionId,
+        cliAgentType: setup.execution.cliAgentType,
+        accountId: setup.execution.accountId,
+        model: setup.execution.model,
+        workspaceRepoPath: setup.workspaceRepoPath ?? null,
+      },
+      turn.dispatchIso
+    );
+  } catch (error) {
+    await cleanupConversationRunnerBestEffort(runnerSessionId);
+    throw error;
+  }
   return dispatchBootstrapEpisode(
     params,
     io,
@@ -735,11 +758,17 @@ async function dispatchBootstrapEpisode(
     });
   } catch (error) {
     if (!params.preserveRunnerOnTransportFailure) {
-      clearContinuation(params.executionScopeKey, params.rootSessionId);
+      retireContinuation(
+        params.executionScopeKey,
+        params.rootSessionId,
+        "bootstrap_transport_rejected",
+        true
+      );
       await cleanupConversationRunnerBestEffort(episode.runnerSessionId);
     }
     throw error;
   }
+  await params.onTransportAccepted?.(episode.runnerSessionId, io.turnIntentId);
   if (
     !markContinuationEstablished(
       params.executionScopeKey,
@@ -748,7 +777,7 @@ async function dispatchBootstrapEpisode(
       io.turnIntentId
     )
   ) {
-    log.warn("continuation acceptance could not be persisted");
+    throw new Error("continuation acceptance could not be persisted");
   }
   await params.onTurnAccepted?.(episode.runnerSessionId, io.turnIntentId);
   return settleEpisode(params, io, {
@@ -801,7 +830,12 @@ async function settleEpisode(
     if (outcome.status === "completed") {
       await cleanupRetiredConversationRunners(input.key, input.runnerSessionId);
     } else {
-      clearContinuation(params.executionScopeKey, params.rootSessionId);
+      retireContinuation(
+        params.executionScopeKey,
+        params.rootSessionId,
+        `turn_${outcome.status}`,
+        true
+      );
       await cleanupConversationRunnerBestEffort(input.runnerSessionId);
     }
   }

--- a/src/features/Org2Cloud/SessionConversation/workItemConversationTurnBridge.test.ts
+++ b/src/features/Org2Cloud/SessionConversation/workItemConversationTurnBridge.test.ts
@@ -129,6 +129,10 @@ function makeDeps(
         params.turnIntentId ?? "missing",
         params.turnIntentId ?? "missing"
       );
+      await params.onTransportAccepted?.(
+        "runner-1",
+        params.turnIntentId ?? "missing"
+      );
       await params.onTurnAccepted?.(
         "runner-1",
         params.turnIntentId ?? "missing"
@@ -144,8 +148,8 @@ function makeDeps(
     registerRunner: ({ orgId, rootSessionId, runnerSessionId }) => {
       calls.push(`runner:${orgId}:${rootSessionId}:${runnerSessionId}`);
     },
-    settleRunner: (rootSessionId, runnerSessionId) => {
-      calls.push(`settle:${rootSessionId}:${runnerSessionId}`);
+    settleRunner: (orgId, rootSessionId, runnerSessionId) => {
+      calls.push(`settle:${orgId}:${rootSessionId}:${runnerSessionId}`);
     },
     signalPlane: (orgId) => calls.push(`signal:${orgId}`),
     ...overrides,
@@ -213,7 +217,7 @@ describe("handleWorkItemConversationTurnRequest", () => {
       "prepare:run-1:claim-1:root-remote:runner-1",
       "ack:run-1:claim-1:root-remote:runner-1",
       "signal:cloud-org",
-      "settle:root-remote:runner-1",
+      "settle:cloud-org:root-remote:runner-1",
     ]);
     expect(deps.turnParams[0]).toMatchObject({
       orgId: "cloud-org",
@@ -283,7 +287,7 @@ describe("handleWorkItemConversationTurnRequest", () => {
       "accept:run-1:claim-1",
       "runner:cloud-org:root-remote:runner-1",
       "nack:run-1:claim-1:PM_RUN_ERR:INVALID_TRANSITION",
-      "settle:root-remote:runner-1",
+      "settle:cloud-org:root-remote:runner-1",
     ]);
   });
 
@@ -306,7 +310,28 @@ describe("handleWorkItemConversationTurnRequest", () => {
       "ack:run-1:claim-1:root-remote:runner-1",
       "signal:cloud-org",
       "release:run-1:claim-1",
-      "settle:root-remote:runner-1",
+      "settle:cloud-org:root-remote:runner-1",
+    ]);
+  });
+
+  it("releases instead of nacking after adapter acceptance", async () => {
+    const deps = makeDeps({
+      runTurn: async (params) => {
+        await params.onRunnerReady?.("runner-1", "run-1", "run-1");
+        await params.onTransportAccepted?.("runner-1", "run-1");
+        throw new Error("continuation persistence lost");
+      },
+    });
+
+    await expect(
+      handleWorkItemConversationTurnRequest(REQUEST, deps)
+    ).resolves.toBe("failed");
+    expect(deps.calls).toEqual([
+      "accept:run-1:claim-1",
+      "runner:cloud-org:root-remote:runner-1",
+      "prepare:run-1:claim-1:root-remote:runner-1",
+      "release:run-1:claim-1",
+      "settle:cloud-org:root-remote:runner-1",
     ]);
   });
 

--- a/src/features/Org2Cloud/SessionConversation/workItemConversationTurnBridge.ts
+++ b/src/features/Org2Cloud/SessionConversation/workItemConversationTurnBridge.ts
@@ -269,8 +269,10 @@ export async function handleWorkItemConversationTurnRequest(
           createdRunnerId
         );
       },
-      onTurnAccepted: async (acceptedRunnerId) => {
+      onTransportAccepted: () => {
         transportAccepted = true;
+      },
+      onTurnAccepted: async (acceptedRunnerId) => {
         try {
           await deps.ackRunner(
             request.runId,
@@ -309,7 +311,7 @@ export async function handleWorkItemConversationTurnRequest(
       }
     }
     if (runnerSessionId) {
-      deps.settleRunner(rootSessionId, runnerSessionId);
+      deps.settleRunner(resolvedOrgId, rootSessionId, runnerSessionId);
     }
   }
 }


### PR DESCRIPTION
## Problem

Persistent Work Item continuations only kept one mutable pointer. A runtime roll erased why it happened, old and new desktop windows could overwrite each other's storage format, accepted turns could be acknowledged after a failed persistence write, and live overlays were keyed only by root session id instead of organization plus root.

## Solution

- Model each reusable runner as a bounded prepared/active/retired/failed episode lineage, including supersession and explicit roll reasons.
- Persist the new envelope under an independent v2 key, read v2 first, migrate immutable v1 data on first mutation, and retain an empty v2 tombstone so stale v1 writes never reappear.
- Make correctness writes fail closed with exact read-after-write verification; do not acknowledge an adapter-accepted bootstrap if the active episode cannot be established durably.
- Scope live runner overlays by the canonical organization/root plane key.

## Potential risks

- The state is still backed by WebView localStorage in this PR; the next stack layer moves authoritative execution state into `sessions.db`. This PR prevents silent write failure but cannot recover storage deleted after a successful write or provide a cross-window transaction.
- v2 intentionally shadows later v1 writes. Rollback to an older build sees the untouched v1 snapshot, while returning to this build resumes v2.
- Rollback: revert commit 737bc8ca8; no server or database migration is included.

## Verification

- `pnpm exec vitest run src/features/Org2Cloud/SessionConversation/conversationContinuation.test.ts src/features/Org2Cloud/SessionConversation/activeConversationRunnersAtom.test.ts src/features/Org2Cloud/SessionConversation/conversationExecutionStore.test.ts src/features/Org2Cloud/SessionConversation/conversationTurnRunner.test.ts src/features/Org2Cloud/SessionConversation/workItemConversationTurnBridge.test.ts src/features/Org2Cloud/SessionConversation/cloudConversationRuntime.test.ts` (54 tests passed)
- `pnpm exec eslint` on all 13 changed TypeScript files
- `pnpm exec tsc --noEmit`
- Commit hook: lint-staged, scoped TypeScript check, staged-file audit passed

## Stack

Base: #951 (`codex/work-item-continuation-cli-account`)

This is the episode-lineage and correctness foundation for native checkpoint/rebase and encrypted device handoff follow-up PRs.
