### PR TITLE
feat(session-creator): streamline worktree source selection

### DIFF
--- a/src/components/RunningLocationDropdownPanel/index.tsx
+++ b/src/components/RunningLocationDropdownPanel/index.tsx
@@ -130,7 +130,11 @@ const LocationOption: React.FC<LocationOptionProps> = ({
       } w-full justify-between`}
     >
       <div className="flex items-center gap-2">
-        <Icon size={DROPDOWN_ITEM.iconSize} strokeWidth={1.75} />
+        <Icon
+          size={DROPDOWN_ITEM.iconSize}
+          strokeWidth={1.75}
+          className={entry.iconClassName}
+        />
         <span>{label}</span>
       </div>
       {isSelected && <DropdownSelectedCheck />}

--- a/src/config/sessionCreatorConfig.ts
+++ b/src/config/sessionCreatorConfig.ts
@@ -10,9 +10,9 @@ import {
   Cloud,
   FolderKanban,
   Laptop,
-  ListPlus,
   ListTodo,
   Search,
+  Split,
 } from "lucide-react";
 
 // ============================================
@@ -189,6 +189,7 @@ export const DEFAULT_RUNNING_LOCATION: RunningLocation = "local";
 export interface RunningLocationEntry {
   id: RunningLocation;
   icon: typeof Laptop;
+  iconClassName?: string;
   i18nKey: string;
   name: string;
   description: string;
@@ -205,7 +206,8 @@ export const RUNNING_LOCATIONS: RunningLocationEntry[] = [
   },
   {
     id: "worktree",
-    icon: ListPlus,
+    icon: Split,
+    iconClassName: "rotate-90",
     i18nKey: "planner.runningLocation.worktree",
     name: "New Worktree",
     description: "Run in a new git worktree",

--- a/src/engines/ChatPanel/InputArea/components/RunningLocationPill.tsx
+++ b/src/engines/ChatPanel/InputArea/components/RunningLocationPill.tsx
@@ -136,7 +136,11 @@ const RunningLocationPill: React.FC<RunningLocationPillProps> = memo(
         <SelectorPill
           ref={triggerRef}
           icon={
-            <CurrentIcon size={14} strokeWidth={1.75} className="text-text-1" />
+            <CurrentIcon
+              size={14}
+              strokeWidth={1.75}
+              className={`text-text-1 ${currentOption.iconClassName ?? ""}`}
+            />
           }
           label={currentLabel}
           tooltip={

--- a/src/features/SessionCreator/components/SessionInfoLine.tsx
+++ b/src/features/SessionCreator/components/SessionInfoLine.tsx
@@ -2,7 +2,7 @@
  * SessionInfoLine Component
  *
  * Displays session configuration summary as a shared `PillGroup`:
- *   "[repo] | [branch]"  (resting, no border)
+ *   "[repo] | [location] | [branch]"  (resting, no border)
  * Hovering a segment promotes it to an independent pill and hides the
  * adjacent divider; the other segment stays transparent.
  *
@@ -46,7 +46,10 @@ import { WorkspaceDropdown } from "@src/scaffold/GlobalSpotlight/palettes/Worksp
 import { runGuardedCheckout } from "@src/services/git/operations/guardedCheckout";
 import { reposAtom } from "@src/store/repo";
 import { REPO_KIND, type RepoKind } from "@src/store/repo/types";
-import type { WorktreeLaunchSelection } from "@src/store/session/worktreeLaunchSourceAtom";
+import type {
+  WorktreeLaunchSelection,
+  WorktreeLaunchSource,
+} from "@src/store/session/worktreeLaunchSourceAtom";
 import { modelPickerStyleAtom } from "@src/store/ui/chatPanelAtom";
 import {
   branchSelectorOpenAtom,
@@ -63,7 +66,7 @@ import {
 } from "./SessionInfoLine/buildSessionInfoSegments";
 import { type LocationRow } from "./SessionInfoLine/locationConfig";
 import { useSystemPathRepoItems } from "./SessionInfoLine/useSystemPathRepoItems";
-import WorktreeSourceModal from "./WorktreeSourceModal";
+import WorktreeSourceSelector from "./WorktreeSourceSelector";
 
 // ============================================
 // Type Definitions
@@ -124,7 +127,9 @@ export interface SessionInfoLineProps {
    */
   worktreeLocation?: RunningLocation;
   selectedWorktreePath?: string | null;
+  worktreeLocationLabel?: string;
   worktreeSourceLabel?: string;
+  worktreeSource?: WorktreeLaunchSource | null;
   onWorktreeLocationChange?: (location: RunningLocation) => void;
   onWorktreeSourceSelect?: (selection: WorktreeLaunchSelection) => void;
 }
@@ -149,7 +154,7 @@ interface SelectorShortcutBridgeState {
   repoId?: string;
   worktreeLocation?: RunningLocation;
   isLocationDropdownOpen: boolean;
-  toggleLocation: () => void;
+  openLocationSelector: () => void;
 }
 
 interface SelectorShortcutBridgeParams extends SelectorShortcutBridgeState {
@@ -163,7 +168,7 @@ function useSelectorShortcutBridge({
   repoId,
   worktreeLocation,
   isLocationDropdownOpen,
-  toggleLocation,
+  openLocationSelector,
   openBranchSelector,
   openRepoSelector,
 }: SelectorShortcutBridgeParams): void {
@@ -183,7 +188,7 @@ function useSelectorShortcutBridge({
     repoId,
     worktreeLocation,
     isLocationDropdownOpen,
-    toggleLocation,
+    openLocationSelector,
   });
 
   useEffect(() => {
@@ -193,7 +198,7 @@ function useSelectorShortcutBridge({
       repoId,
       worktreeLocation,
       isLocationDropdownOpen,
-      toggleLocation,
+      openLocationSelector,
     };
   });
 
@@ -229,7 +234,7 @@ function useSelectorShortcutBridge({
       const s = bridgeStateRef.current;
       if (s.disabled || s.worktreeLocation === undefined) return;
       if (s.isLocationDropdownOpen) return;
-      s.toggleLocation();
+      s.openLocationSelector();
     });
     return () => {
       unsubBranch();
@@ -265,7 +270,9 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
   dropdownDirection = "down",
   worktreeLocation,
   selectedWorktreePath,
+  worktreeLocationLabel,
   worktreeSourceLabel,
+  worktreeSource,
   onWorktreeLocationChange,
   onWorktreeSourceSelect,
   disabled = false,
@@ -279,8 +286,6 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
 
   const [isRepoSelectorOpen, setIsRepoSelectorOpen] = useState(false);
   const [isBranchSelectorOpen, setIsBranchSelectorOpen] = useState(false);
-  const [isWorktreeSourceModalOpen, setIsWorktreeSourceModalOpen] =
-    useState(false);
 
   // Forward declaration: the actual `close` comes back from
   // `useDropdownEngine` below, but `handleLocationRowSelect` needs to
@@ -290,13 +295,12 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
 
   const handleLocationRowSelect = useCallback(
     (row: LocationRow) => {
-      if (row.id === "worktree" && onWorktreeSourceSelect) {
-        closeLocationRef.current();
-        setIsWorktreeSourceModalOpen(true);
-        return;
-      }
       onWorktreeLocationChange?.(row.id);
       closeLocationRef.current();
+      setIsBranchSelectorOpen(false);
+      if (row.id === "worktree" && onWorktreeSourceSelect) {
+        queueMicrotask(() => setIsBranchSelectorOpen(true));
+      }
     },
     [onWorktreeLocationChange, onWorktreeSourceSelect]
   );
@@ -339,13 +343,17 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
 
   const handleRepoTriggerClick = useCallback(() => {
     if (disabled) return;
+    closeLocation();
+    setIsBranchSelectorOpen(false);
     setIsRepoSelectorOpen((isOpen) => !isOpen);
-  }, [disabled]);
+  }, [closeLocation, disabled]);
 
   const handleBranchTriggerClick = useCallback(() => {
     if (disabled) return;
+    closeLocation();
+    setIsRepoSelectorOpen(false);
     setIsBranchSelectorOpen((isOpen) => !isOpen);
-  }, [disabled]);
+  }, [closeLocation, disabled]);
 
   const handleRepoSelected = useCallback(
     (selectedRepoId: string, repo: RepoItem) => {
@@ -499,18 +507,6 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
     [handleLocationRowSelect]
   );
 
-  const handleWorktreeSourceModalClose = useCallback(() => {
-    setIsWorktreeSourceModalOpen(false);
-  }, []);
-
-  const handleWorktreeSourceSelect = useCallback(
-    (selection: WorktreeLaunchSelection) => {
-      onWorktreeSourceSelect?.(selection);
-      setIsWorktreeSourceModalOpen(false);
-    },
-    [onWorktreeSourceSelect]
-  );
-
   // ============================================
   // Display
   // ============================================
@@ -555,18 +551,28 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
     ]
   );
 
+  const openLocationSelector = useCallback(() => {
+    setIsRepoSelectorOpen(false);
+    setIsBranchSelectorOpen(false);
+    toggleLocation();
+  }, [toggleLocation]);
+
   const handleLocationTriggerClick = useCallback(() => {
     if (disabled) return;
-    toggleLocation();
-  }, [disabled, toggleLocation]);
+    openLocationSelector();
+  }, [disabled, openLocationSelector]);
 
   const openRepoSelector = useCallback(() => {
+    closeLocation();
+    setIsBranchSelectorOpen(false);
     setIsRepoSelectorOpen(true);
-  }, []);
+  }, [closeLocation]);
 
   const openBranchSelector = useCallback(() => {
+    closeLocation();
+    setIsRepoSelectorOpen(false);
     setIsBranchSelectorOpen(true);
-  }, []);
+  }, [closeLocation]);
 
   useSelectorShortcutBridge({
     disabled,
@@ -574,7 +580,7 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
     repoId,
     worktreeLocation,
     isLocationDropdownOpen,
-    toggleLocation,
+    openLocationSelector,
     openBranchSelector,
     openRepoSelector,
   });
@@ -591,6 +597,7 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
     isBranchSelectorOpen,
     handleBranchTriggerClick,
     worktreeLocation,
+    worktreeLocationLabel,
     worktreeSourceLabel,
     isLocationDropdownOpen,
     handleLocationTriggerClick,
@@ -640,7 +647,23 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
       {/* Branch Selector */}
       {showBranchRow &&
         repoId &&
-        (useDropdownPicker ? (
+        (worktreeLocation === "worktree" && onWorktreeSourceSelect ? (
+          isBranchSelectorOpen ? (
+            <WorktreeSourceSelector
+              key={repoId || repoPath}
+              isOpen
+              presentation={useDropdownPicker ? "dropdown" : "spotlight"}
+              onClose={handleBranchClose}
+              onSelect={onWorktreeSourceSelect}
+              repoId={repoId}
+              repoPath={repoPath}
+              currentBranchName={branchName}
+              selectedSource={worktreeSource}
+              anchorRef={branchTriggerRef}
+              placement={dropdownDirection === "up" ? "top" : "bottom"}
+            />
+          ) : null
+        ) : useDropdownPicker ? (
           <BranchDropdown
             isOpen={isBranchSelectorOpen}
             onClose={handleBranchClose}
@@ -688,18 +711,6 @@ const SessionInfoLine: React.FC<SessionInfoLineProps> = ({
           />,
           document.body
         )}
-
-      {worktreeLocation !== undefined && isWorktreeSourceModalOpen && (
-        <WorktreeSourceModal
-          open
-          repoId={repoId}
-          repoName={repoName}
-          repoPath={repoPath}
-          branchName={branchName}
-          onClose={handleWorktreeSourceModalClose}
-          onSelect={handleWorktreeSourceSelect}
-        />
-      )}
     </>
   );
 };

--- a/src/features/SessionCreator/components/SessionInfoLine/buildSessionInfoSegments.tsx
+++ b/src/features/SessionCreator/components/SessionInfoLine/buildSessionInfoSegments.tsx
@@ -72,6 +72,7 @@ interface BuildSessionInfoSegmentsParams extends SessionInfoDisplayState {
   branchLoading?: boolean;
   branchName?: string;
   worktreeLocation?: RunningLocation;
+  worktreeLocationLabel?: string;
   worktreeSourceLabel?: string;
   isLocationDropdownOpen: boolean;
   locationTriggerRef: React.Ref<HTMLButtonElement>;
@@ -88,16 +89,17 @@ export function buildSessionInfoSegments({
   sourceDisplayName,
   isRepoSelectorOpen,
   handleRepoTriggerClick,
+  worktreeLocation,
+  worktreeLocationLabel,
+  isLocationDropdownOpen,
+  handleLocationTriggerClick,
+  locationTriggerRef,
   showBranchRow,
   branchLoading,
   branchName,
   isBranchSelectorOpen,
   handleBranchTriggerClick,
-  worktreeLocation,
   worktreeSourceLabel,
-  isLocationDropdownOpen,
-  handleLocationTriggerClick,
-  locationTriggerRef,
   disabled,
   t,
 }: BuildSessionInfoSegmentsParams): PillGroupSegment[] {
@@ -130,28 +132,6 @@ export function buildSessionInfoSegments({
     },
   ];
 
-  if (showBranchRow) {
-    segments.push({
-      id: "branch",
-      icon: <GitBranch size={14} strokeWidth={1.75} className="text-text-1" />,
-      label: branchLoading ? t("status.loading") : branchName || "",
-      maxLabelWidth: SESSION_INFO_LABEL_MAX_WIDTH,
-      active: isBranchSelectorOpen,
-      tooltip: disabled ? undefined : (
-        <KeyboardShortcutTooltipContent
-          label={t("selectors.sessionInfo.switchBranch")}
-          shortcut={getShortcutKeys("open_branch_selector")}
-        />
-      ),
-      tooltipFramed: true,
-      tooltipPosition: "bottom",
-      tooltipMouseEnterDelay: SESSION_INFO_SHORTCUT_TOOLTIP_DELAY_MS,
-      ariaLabel: t("selectors.sessionInfo.branchAria"),
-      disabled: disabled || branchLoading,
-      onClick: handleBranchTriggerClick,
-    });
-  }
-
   if (worktreeLocation !== undefined) {
     const locationEntry = RUNNING_LOCATIONS.find(
       (location) => location.id === worktreeLocation
@@ -160,8 +140,8 @@ export function buildSessionInfoSegments({
       id: "location",
       icon: LOCATION_ICONS[worktreeLocation],
       label:
-        worktreeLocation === "worktree" && worktreeSourceLabel
-          ? worktreeSourceLabel
+        worktreeLocation === "worktree" && worktreeLocationLabel
+          ? worktreeLocationLabel
           : t(`sessions:${locationEntry.i18nKey}`),
       maxLabelWidth: SESSION_INFO_LABEL_MAX_WIDTH,
       active: isLocationDropdownOpen,
@@ -178,6 +158,36 @@ export function buildSessionInfoSegments({
       disabled,
       buttonRef: locationTriggerRef,
       onClick: handleLocationTriggerClick,
+    });
+  }
+
+  if (showBranchRow) {
+    segments.push({
+      id: "branch",
+      icon: <GitBranch size={14} strokeWidth={1.75} className="text-text-1" />,
+      label: branchLoading
+        ? t("status.loading")
+        : worktreeLocation === "worktree" && worktreeSourceLabel
+          ? worktreeSourceLabel
+          : branchName || "",
+      maxLabelWidth: SESSION_INFO_LABEL_MAX_WIDTH,
+      active: isBranchSelectorOpen,
+      tooltip: disabled ? undefined : (
+        <KeyboardShortcutTooltipContent
+          label={
+            worktreeLocation === "worktree"
+              ? t("selectors.sessionInfo.selectWorktreeSource")
+              : t("selectors.sessionInfo.switchBranch")
+          }
+          shortcut={getShortcutKeys("open_branch_selector")}
+        />
+      ),
+      tooltipFramed: true,
+      tooltipPosition: "bottom",
+      tooltipMouseEnterDelay: SESSION_INFO_SHORTCUT_TOOLTIP_DELAY_MS,
+      ariaLabel: t("selectors.sessionInfo.branchAria"),
+      disabled: disabled || branchLoading,
+      onClick: handleBranchTriggerClick,
     });
   }
 

--- a/src/features/SessionCreator/components/SessionInfoLine/locationConfig.tsx
+++ b/src/features/SessionCreator/components/SessionInfoLine/locationConfig.tsx
@@ -1,11 +1,13 @@
-import { Cloud, GitBranch, Laptop } from "lucide-react";
+import { Cloud, Laptop, Split } from "lucide-react";
 import React from "react";
 
 import type { RunningLocation } from "@src/config/sessionCreatorConfig";
 
 export const LOCATION_ICONS: Record<RunningLocation, React.ReactNode> = {
   local: <Laptop size={14} strokeWidth={1.75} className="text-text-1" />,
-  worktree: <GitBranch size={14} strokeWidth={1.75} className="text-text-1" />,
+  worktree: (
+    <Split size={14} strokeWidth={1.75} className="rotate-90 text-text-1" />
+  ),
   cloud: <Cloud size={14} strokeWidth={1.75} className="text-text-1" />,
 };
 

--- a/src/features/SessionCreator/components/WorktreeSourceModal.tsx
+++ b/src/features/SessionCreator/components/WorktreeSourceModal.tsx
@@ -26,6 +26,7 @@ import {
   shouldOfferCustomRef,
   sourceKey,
 } from "./worktreeBranchSource";
+import { prToWorktreeOption } from "./worktreePrSource";
 import { type PrResolveMeta } from "./worktreeSmartInput";
 import type { GitHubWorktreeItem } from "./worktreeSourceModalTypes";
 import {
@@ -58,25 +59,14 @@ function normalizeBaseBranch(branchName?: string): string | undefined {
 }
 
 function githubPrToItem(pr: OpenPRItem): GitHubWorktreeItem {
-  const label = compactText(`#${pr.number} ${pr.title}`);
-  const detail = `${pr.head_branch} -> ${pr.base_branch}`;
+  const option = prToWorktreeOption(pr);
   return {
-    id: `pr:${pr.number}`,
+    id: option.id,
     icon: <GitPullRequest size={14} strokeWidth={1.75} />,
-    source: {
-      kind: "github",
-      label,
-      baseBranch: pr.head_branch || pr.base_branch,
-      sourceRef: `pr:${pr.number}`,
-      title: pr.title,
-    },
-    detail,
-    searchableText: `${label} ${detail}`,
-    pr: {
-      prNumber: pr.number,
-      headBranch: pr.head_branch || undefined,
-      baseBranch: pr.base_branch || undefined,
-    },
+    source: option.source,
+    detail: option.detail,
+    searchableText: option.searchableText,
+    pr: option.resolveMeta,
   };
 }
 

--- a/src/features/SessionCreator/components/WorktreeSourceSelector.tsx
+++ b/src/features/SessionCreator/components/WorktreeSourceSelector.tsx
@@ -1,0 +1,301 @@
+import { Cloud, Folder, GitBranch, GitPullRequest, Hash } from "lucide-react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useTranslation } from "react-i18next";
+
+import { resolvePrWorktreeBase } from "@src/api/tauri/github";
+import { useWorktreeMap } from "@src/scaffold/GlobalSpotlight/palettes/BranchPalette/useWorktreeMap";
+import type {
+  WorktreeLaunchSelection,
+  WorktreeLaunchSource,
+} from "@src/store/session/worktreeLaunchSourceAtom";
+import { resolveWorktreeSelectionRepoKey } from "@src/store/session/worktreeLaunchSourceAtom";
+
+import {
+  WorktreeSourceDropdownView,
+  type WorktreeSourceSelectorViewProps,
+  WorktreeSourceSpotlightView,
+} from "./WorktreeSourceSelectorViews";
+import { useWorktreeSourceData } from "./useWorktreeSourceData";
+import {
+  branchToLaunchSource,
+  customRefToLaunchSource,
+  filterBranchOptions,
+  formatBranchTimestamp,
+  groupBranchOptions,
+  shouldOfferCustomRef,
+  sourceKey,
+} from "./worktreeBranchSource";
+import { prToWorktreeOption } from "./worktreePrSource";
+import { mergeResolvedPrBase } from "./worktreeSourceResolve";
+import type {
+  WorktreeSourcePickerItem,
+  WorktreeSourcePickerMode,
+  WorktreeSourcePickerSection,
+} from "./worktreeSourceSelectorTypes";
+
+export type WorktreeSourcePickerPresentation = "dropdown" | "spotlight";
+
+export interface WorktreeSourceSelectorProps {
+  isOpen: boolean;
+  presentation: WorktreeSourcePickerPresentation;
+  anchorRef: React.RefObject<HTMLElement | null>;
+  placement?: "top" | "bottom" | "auto";
+  repoId?: string;
+  repoPath?: string;
+  currentBranchName?: string;
+  selectedSource?: WorktreeLaunchSource | null;
+  onClose: () => void;
+  onSelect: (selection: WorktreeLaunchSelection) => void;
+}
+
+const BRANCH_GROUP_LABEL_FALLBACK = {
+  recent: "Recent",
+  worktrees: "Worktrees",
+  otherBranches: "Other Branches",
+} as const;
+export const WorktreeSourceSelector: React.FC<WorktreeSourceSelectorProps> = ({
+  isOpen,
+  presentation,
+  anchorRef,
+  placement = "bottom",
+  repoId,
+  repoPath,
+  currentBranchName,
+  selectedSource,
+  onClose,
+  onSelect,
+}) => {
+  const { t } = useTranslation(["sessions", "common"]);
+  const [mode, setMode] = useState<WorktreeSourcePickerMode>("branch");
+  const [query, setQuery] = useState("");
+  const [resolveError, setResolveError] = useState<string | null>(null);
+  const [resolving, setResolving] = useState(false);
+  const resolveGenerationRef = useRef(0);
+
+  const selectionRepoKey = resolveWorktreeSelectionRepoKey(repoId, repoPath);
+  useEffect(
+    () => () => {
+      resolveGenerationRef.current += 1;
+    },
+    [isOpen, selectionRepoKey]
+  );
+
+  const { branch: branchData, github: githubData } = useWorktreeSourceData({
+    open: isOpen,
+    repoId,
+    repoPath,
+    loadBranches: mode === "branch",
+    loadGithub: mode === "pr",
+  });
+  const worktreeMap = useWorktreeMap({
+    enabled: isOpen && mode === "branch" && Boolean(repoPath),
+    repoId: repoId || "default",
+    repoPath,
+    isLocalRepo: true,
+  });
+
+  const branchSections = useMemo<WorktreeSourcePickerSection[]>(() => {
+    const filtered = filterBranchOptions(branchData.options, query);
+    const groups = groupBranchOptions(filtered, worktreeMap, currentBranchName);
+    const sections: WorktreeSourcePickerSection[] = [];
+    if (shouldOfferCustomRef(query, branchData.options)) {
+      const source = customRefToLaunchSource(query);
+      if (source) {
+        sections.push({
+          key: "custom-ref",
+          items: [
+            {
+              id: `custom:${source.baseBranch}`,
+              label: t("sessions:creator.worktreeSource.branchUseAsRef", {
+                value: source.baseBranch,
+                defaultValue: `Use "${source.baseBranch}" as ref`,
+              }),
+              detail: t("sessions:creator.worktreeSource.branchCustomRefHint", {
+                defaultValue: "Tag, commit, or any git ref",
+              }),
+              icon: Hash,
+              source,
+            },
+          ],
+        });
+      }
+    }
+    for (const group of groups) {
+      sections.push({
+        key: group.key,
+        label: t(`common:selectors.branch.labels.${group.labelKey}`, {
+          defaultValue: BRANCH_GROUP_LABEL_FALLBACK[group.labelKey],
+        }),
+        items: group.options.map((option) => {
+          const source = branchToLaunchSource(option);
+          return {
+            id: `branch:${option.name}`,
+            label: option.name,
+            meta: formatBranchTimestamp(option),
+            icon: option.worktreePath
+              ? Folder
+              : option.isRemote
+                ? Cloud
+                : GitBranch,
+            source,
+          };
+        }),
+      });
+    }
+    return sections;
+  }, [branchData.options, currentBranchName, query, t, worktreeMap]);
+
+  const prSections = useMemo<WorktreeSourcePickerSection[]>(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    const options = githubData.prs
+      .map(prToWorktreeOption)
+      .filter(
+        (option) =>
+          !normalizedQuery ||
+          option.searchableText.toLowerCase().includes(normalizedQuery)
+      )
+      .map<WorktreeSourcePickerItem>((option) => ({
+        id: option.id,
+        label: option.source.label,
+        detail: option.detail,
+        icon: GitPullRequest,
+        source: option.source,
+        resolveMeta: option.resolveMeta,
+      }));
+    return options.length > 0 ? [{ key: "pull-requests", items: options }] : [];
+  }, [githubData.prs, query]);
+
+  const sections = mode === "branch" ? branchSections : prSections;
+  const items = useMemo(
+    () => sections.flatMap((section) => section.items),
+    [sections]
+  );
+  const activeData = mode === "branch" ? branchData : githubData;
+  const activeError = resolveError ?? activeData.error;
+  const selectedSourceKey = selectedSource ? sourceKey(selectedSource) : null;
+
+  const handleModeChange = useCallback((nextMode: WorktreeSourcePickerMode) => {
+    setMode(nextMode);
+    setQuery("");
+    setResolveError(null);
+  }, []);
+
+  const handleSelect = useCallback(
+    async (item: WorktreeSourcePickerItem) => {
+      if (resolving) return;
+      setResolveError(null);
+      if (!selectionRepoKey) {
+        setResolveError(
+          t("sessions:creator.worktreeSource.selectRepository", {
+            defaultValue:
+              "Select a repository before choosing a worktree source",
+          })
+        );
+        return;
+      }
+
+      let source = item.source;
+      if (item.resolveMeta) {
+        if (!repoPath) {
+          setResolveError(
+            t("sessions:creator.worktreeSource.selectRepository", {
+              defaultValue:
+                "Select a repository before choosing a worktree source",
+            })
+          );
+          return;
+        }
+        const generation = ++resolveGenerationRef.current;
+        setResolving(true);
+        try {
+          const resolution = await resolvePrWorktreeBase({
+            repoPath,
+            prNumber: item.resolveMeta.prNumber,
+            headBranch: item.resolveMeta.headBranch,
+            baseBranch: item.resolveMeta.baseBranch,
+          });
+          if (generation !== resolveGenerationRef.current) return;
+          source = mergeResolvedPrBase(source, resolution);
+        } catch (error) {
+          if (generation !== resolveGenerationRef.current) return;
+          setResolveError(
+            error instanceof Error ? error.message : String(error)
+          );
+          return;
+        } finally {
+          if (generation === resolveGenerationRef.current) {
+            setResolving(false);
+          }
+        }
+      }
+
+      onSelect({ repoKey: selectionRepoKey, source });
+      onClose();
+    },
+    [onClose, onSelect, repoPath, resolving, selectionRepoKey, t]
+  );
+
+  const viewProps: WorktreeSourceSelectorViewProps = {
+    isOpen,
+    anchorRef,
+    placement,
+    mode,
+    query,
+    sections,
+    items,
+    selectedSourceKey,
+    effectiveCurrentBranchName: selectedSource ? undefined : currentBranchName,
+    loading: activeData.state === "loading",
+    refreshing: activeData.refreshing,
+    resolving,
+    error: activeError,
+    emptyMessage:
+      mode === "branch"
+        ? t("sessions:creator.worktreeSource.branchNoMatches", {
+            defaultValue: "No matching branches",
+          })
+        : t("sessions:creator.worktreeSource.prNoMatches", {
+            defaultValue: "No matching pull requests",
+          }),
+    loadingLabel: t("common:status.loading", { defaultValue: "Loading" }),
+    resolvingLabel: t("sessions:creator.worktreeSource.resolving", {
+      defaultValue: "Resolving PR…",
+    }),
+    searchPlaceholder:
+      mode === "branch"
+        ? t("sessions:creator.worktreeSource.branchSearch", {
+            defaultValue: "Search branches or enter a ref",
+          })
+        : t("sessions:creator.worktreeSource.prSearch", {
+            defaultValue: "Search pull requests",
+          }),
+    searchAriaLabel:
+      mode === "branch"
+        ? t("sessions:creator.worktreeSource.branchSearchAria", {
+            defaultValue: "Search branches or enter a base ref",
+          })
+        : t("sessions:creator.worktreeSource.prSearchAria", {
+            defaultValue: "Search pull requests",
+          }),
+    retryLabel: t("common:actions.retry", { defaultValue: "Retry" }),
+    onClose,
+    onModeChange: handleModeChange,
+    onQueryChange: setQuery,
+    onRetry: activeData.refresh,
+    onSelect: (item) => void handleSelect(item),
+  };
+
+  return presentation === "dropdown" ? (
+    <WorktreeSourceDropdownView {...viewProps} />
+  ) : (
+    <WorktreeSourceSpotlightView {...viewProps} />
+  );
+};
+
+export default WorktreeSourceSelector;

--- a/src/features/SessionCreator/components/WorktreeSourceSelectorViews.tsx
+++ b/src/features/SessionCreator/components/WorktreeSourceSelectorViews.tsx
@@ -1,0 +1,448 @@
+import { Check, RefreshCw } from "lucide-react";
+import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+
+import Button from "@src/components/Button";
+import {
+  DROPDOWN_CLASSES,
+  DROPDOWN_ITEM,
+  DROPDOWN_PANEL,
+} from "@src/components/Dropdown/tokens";
+import SegmentedTextPill from "@src/components/SegmentedTextPill";
+import {
+  type UseDropdownListNavigationReturn,
+  useDropdownEngine,
+} from "@src/hooks/dropdown";
+import { useTauriSelectAllShortcut } from "@src/hooks/keyboard";
+import { useSelectorKernel } from "@src/scaffold/GlobalSpotlight/palettes/core";
+import {
+  PaletteBody,
+  SpotlightShell,
+} from "@src/scaffold/GlobalSpotlight/shell";
+import type { SpotlightItem } from "@src/scaffold/GlobalSpotlight/types";
+import { getViewportSize } from "@src/util/ui/window/viewport";
+
+import { sourceKey } from "./worktreeBranchSource";
+import type {
+  WorktreeSourcePickerItem,
+  WorktreeSourcePickerMode,
+  WorktreeSourcePickerSection,
+} from "./worktreeSourceSelectorTypes";
+
+const LIST_MAX_HEIGHT = 360;
+const VIEWPORT_MARGIN = 12;
+const MIN_DROPDOWN_WIDTH = 360;
+
+function WorktreeSourceModeSwitch({
+  mode,
+  disabled,
+  onChange,
+}: {
+  mode: WorktreeSourcePickerMode;
+  disabled: boolean;
+  onChange: (mode: WorktreeSourcePickerMode) => void;
+}) {
+  const { t } = useTranslation("sessions");
+  return (
+    <SegmentedTextPill
+      ariaLabel={t("creator.worktreeSource.sourceTypeAria", {
+        defaultValue: "Select branch or pull request",
+      })}
+      dataTestId="worktree-source-mode-switch"
+      value={mode}
+      options={[
+        {
+          value: "branch",
+          label: t("creator.worktreeSource.tabs.branch", {
+            defaultValue: "Branch",
+          }),
+          disabled,
+        },
+        {
+          value: "pr",
+          label: t("creator.worktreeSource.tabs.pr", { defaultValue: "PR" }),
+          disabled,
+        },
+      ]}
+      onChange={onChange}
+    />
+  );
+}
+
+function SelectorError({
+  message,
+  retryLabel,
+  onRetry,
+}: {
+  message: string;
+  retryLabel: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className="flex min-h-40 flex-col items-center justify-center gap-3 px-4 text-center text-[13px] text-text-3"
+    >
+      <span>{message}</span>
+      <Button
+        variant="secondary"
+        size="small"
+        icon={<RefreshCw size={14} strokeWidth={1.8} />}
+        onClick={onRetry}
+      >
+        {retryLabel}
+      </Button>
+    </div>
+  );
+}
+
+export interface WorktreeSourceSelectorViewProps {
+  isOpen: boolean;
+  anchorRef: React.RefObject<HTMLElement | null>;
+  placement: "top" | "bottom" | "auto";
+  mode: WorktreeSourcePickerMode;
+  query: string;
+  sections: WorktreeSourcePickerSection[];
+  items: WorktreeSourcePickerItem[];
+  selectedSourceKey: string | null;
+  effectiveCurrentBranchName?: string;
+  loading: boolean;
+  refreshing: boolean;
+  resolving: boolean;
+  error: string | null;
+  emptyMessage: string;
+  loadingLabel: string;
+  resolvingLabel: string;
+  searchPlaceholder: string;
+  searchAriaLabel: string;
+  retryLabel: string;
+  onClose: () => void;
+  onModeChange: (mode: WorktreeSourcePickerMode) => void;
+  onQueryChange: (query: string) => void;
+  onRetry: () => void;
+  onSelect: (item: WorktreeSourcePickerItem) => void;
+}
+
+function isPickerItemSelected(
+  item: WorktreeSourcePickerItem,
+  selectedSourceKey: string | null,
+  effectiveCurrentBranchName?: string
+): boolean {
+  if (selectedSourceKey) return sourceKey(item.source) === selectedSourceKey;
+  return (
+    item.source.kind === "branch" &&
+    item.source.baseBranch === effectiveCurrentBranchName
+  );
+}
+
+export function WorktreeSourceSpotlightView({
+  isOpen,
+  mode,
+  query,
+  sections,
+  selectedSourceKey,
+  effectiveCurrentBranchName,
+  loading,
+  refreshing,
+  resolving,
+  error,
+  emptyMessage,
+  resolvingLabel,
+  searchPlaceholder,
+  searchAriaLabel,
+  retryLabel,
+  onClose,
+  onModeChange,
+  onQueryChange,
+  onRetry,
+  onSelect,
+}: WorktreeSourceSelectorViewProps) {
+  const spotlightItems = useMemo<SpotlightItem[]>(() => {
+    const result: SpotlightItem[] = [];
+    for (const section of sections) {
+      if (section.label) {
+        result.push({
+          id: `header:${section.key}`,
+          label: section.label,
+          icon: "",
+          type: "option",
+          data: { isHeader: true },
+          action: () => undefined,
+        });
+      }
+      for (const item of section.items) {
+        const selected = isPickerItemSelected(
+          item,
+          selectedSourceKey,
+          effectiveCurrentBranchName
+        );
+        result.push({
+          id: item.id,
+          label: item.label,
+          desc: item.detail,
+          icon: item.icon,
+          type: "option",
+          data: {
+            isSelector: true,
+            isCurrentSelection: selected,
+            rightLabel: item.meta,
+            disabled: resolving,
+          },
+          action: () => onSelect(item),
+        });
+      }
+    }
+    return result;
+  }, [
+    effectiveCurrentBranchName,
+    onSelect,
+    resolving,
+    sections,
+    selectedSourceKey,
+  ]);
+
+  const kernel = useSelectorKernel({
+    isOpen,
+    onClose,
+    items: spotlightItems,
+    isItemSelectable: (item) => !item.data?.isHeader && !item.data?.disabled,
+    externalSearchQuery: query,
+    externalSetSearchQuery: onQueryChange,
+  });
+
+  const contentOverride = error ? (
+    <SelectorError message={error} retryLabel={retryLabel} onRetry={onRetry} />
+  ) : !loading && spotlightItems.length === 0 ? (
+    <div className={DROPDOWN_CLASSES.listMessage}>{emptyMessage}</div>
+  ) : undefined;
+
+  return (
+    <SpotlightShell isOpen={isOpen} onClose={onClose}>
+      <PaletteBody
+        kernel={kernel}
+        items={spotlightItems}
+        inputLeadingSlot={
+          <WorktreeSourceModeSwitch
+            mode={mode}
+            disabled={resolving}
+            onChange={onModeChange}
+          />
+        }
+        placeholder={searchPlaceholder}
+        inputAriaLabel={searchAriaLabel}
+        isLoading={loading || refreshing || resolving}
+        fixedHeight
+        contentOverride={contentOverride}
+        hintSlot={
+          resolving ? (
+            <div
+              aria-live="polite"
+              className="border-t border-border-2 px-4 py-2 text-[12px] text-text-3"
+            >
+              {resolvingLabel}
+            </div>
+          ) : undefined
+        }
+      />
+    </SpotlightShell>
+  );
+}
+
+function WorktreeSourceDropdownRow({
+  item,
+  selected,
+  disabled,
+  keyboardProps,
+}: {
+  item: WorktreeSourcePickerItem;
+  selected: boolean;
+  disabled: boolean;
+  keyboardProps: ReturnType<UseDropdownListNavigationReturn["getItemProps"]>;
+}) {
+  const Icon = item.icon;
+  return (
+    <button
+      type="button"
+      data-testid={`worktree-source-row-${item.id}`}
+      {...keyboardProps}
+      disabled={disabled}
+      className={`${DROPDOWN_CLASSES.item} ${
+        selected ? DROPDOWN_CLASSES.itemSelected : DROPDOWN_CLASSES.itemHover
+      } w-full justify-start ${disabled ? "opacity-60" : ""}`}
+    >
+      <span className="flex h-5 w-5 shrink-0 items-center justify-center">
+        <Icon size={DROPDOWN_ITEM.iconSize} className="text-text-2" />
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col items-start">
+        <span className="w-full truncate text-[13px] text-text-1">
+          {item.label}
+        </span>
+        {item.detail && (
+          <span className="w-full truncate text-[11px] text-text-3">
+            {item.detail}
+          </span>
+        )}
+      </span>
+      {item.meta && (
+        <span className="shrink-0 text-[11px] tabular-nums text-text-3">
+          {item.meta}
+        </span>
+      )}
+      {selected && (
+        <Check
+          size={DROPDOWN_ITEM.iconSize}
+          strokeWidth={2.25}
+          className="shrink-0 text-primary-6"
+        />
+      )}
+    </button>
+  );
+}
+
+export function WorktreeSourceDropdownView({
+  isOpen,
+  anchorRef,
+  placement,
+  mode,
+  query,
+  sections,
+  items,
+  selectedSourceKey,
+  effectiveCurrentBranchName,
+  loading,
+  resolving,
+  error,
+  emptyMessage,
+  loadingLabel,
+  searchPlaceholder,
+  searchAriaLabel,
+  retryLabel,
+  onClose,
+  onModeChange,
+  onQueryChange,
+  onRetry,
+  onSelect,
+}: WorktreeSourceSelectorViewProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const tauriSelectAll = useTauriSelectAllShortcut();
+  const handleSelect = useCallback(
+    (item: WorktreeSourcePickerItem) => {
+      if (!resolving) onSelect(item);
+    },
+    [onSelect, resolving]
+  );
+  const { isPositioned, panelRef, panelPosition, keyboard } = useDropdownEngine<
+    HTMLElement,
+    WorktreeSourcePickerItem
+  >({
+    open: isOpen,
+    onOpenChange: (open) => {
+      if (!open) onClose();
+    },
+    anchorRef,
+    placement,
+    gap: DROPDOWN_PANEL.triggerGap,
+    listNavigation: {
+      items,
+      onSelect: handleSelect,
+      isItemSelectable: () => !resolving,
+      initialSelectedIndex: -1,
+    },
+  });
+
+  useEffect(() => {
+    if (!isOpen || !isPositioned) return;
+    const frame = requestAnimationFrame(() => inputRef.current?.focus());
+    return () => cancelAnimationFrame(frame);
+  }, [isOpen, isPositioned, mode]);
+
+  if (!isOpen || !isPositioned) return null;
+
+  const width = Math.max(MIN_DROPDOWN_WIDTH, panelPosition.width);
+  const { width: viewportWidth } = getViewportSize();
+  const left = Math.max(
+    VIEWPORT_MARGIN,
+    Math.min(panelPosition.left, viewportWidth - VIEWPORT_MARGIN - width)
+  );
+
+  return createPortal(
+    <div
+      ref={panelRef}
+      role="dialog"
+      aria-label={searchAriaLabel}
+      className={`${DROPDOWN_CLASSES.panel} fixed flex flex-col`}
+      style={{
+        top: panelPosition.top,
+        bottom: panelPosition.bottom,
+        left,
+        width,
+      }}
+    >
+      <div className={`${DROPDOWN_CLASSES.searchContainer} gap-2`}>
+        <WorktreeSourceModeSwitch
+          mode={mode}
+          disabled={resolving}
+          onChange={onModeChange}
+        />
+        <input
+          ref={inputRef}
+          value={query}
+          onChange={(event) => onQueryChange(event.target.value)}
+          onKeyDown={tauriSelectAll}
+          placeholder={searchPlaceholder}
+          aria-label={searchAriaLabel}
+          className={DROPDOWN_CLASSES.searchInput}
+          disabled={resolving}
+        />
+      </div>
+
+      <div
+        className={DROPDOWN_CLASSES.optionsContainerOverlay}
+        style={{ maxHeight: LIST_MAX_HEIGHT }}
+      >
+        {error ? (
+          <SelectorError
+            message={error}
+            retryLabel={retryLabel}
+            onRetry={onRetry}
+          />
+        ) : loading && items.length === 0 ? (
+          <div className={DROPDOWN_CLASSES.listMessage}>{loadingLabel}</div>
+        ) : items.length === 0 ? (
+          <div className={DROPDOWN_CLASSES.listMessage}>{emptyMessage}</div>
+        ) : (
+          sections.map((section) => (
+            <React.Fragment key={section.key}>
+              {section.label && (
+                <div className={DROPDOWN_CLASSES.sectionLabel}>
+                  {section.label}
+                </div>
+              )}
+              {section.items.map((item) => {
+                const index = items.findIndex(
+                  (visibleItem) => visibleItem.id === item.id
+                );
+                return (
+                  <WorktreeSourceDropdownRow
+                    key={item.id}
+                    item={item}
+                    selected={isPickerItemSelected(
+                      item,
+                      selectedSourceKey,
+                      effectiveCurrentBranchName
+                    )}
+                    disabled={resolving}
+                    keyboardProps={keyboard.getItemProps(index)}
+                  />
+                );
+              })}
+            </React.Fragment>
+          ))
+        )}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/features/SessionCreator/components/__tests__/TEST_CASES.md
+++ b/src/features/SessionCreator/components/__tests__/TEST_CASES.md
@@ -1,12 +1,12 @@
-# Test Cases: WorktreeSourceModal + worktree launch wiring
+# Test Cases: Worktree source selectors + worktree launch wiring
 
 ## Session info ownership (issue #332)
 
 | #   | Steps                                                | Expected Result                                                                                                                                |
 | --- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| W1  | Open Session Creator with a Git repository selected  | Session info renders Workspace → Branch → Running location; it does not add a Main checkout / Switch worktree segment                          |
+| W1  | Open Session Creator with a Git repository selected  | Session info renders Repository → Running location → Branch; it does not add a Main checkout / Switch worktree segment                         |
 | W2  | Open Session Creator while linked worktrees exist    | Linked worktrees are not listed in SessionInfoLine; global WorktreePalette remains the single place for switching the active checkout          |
-| W3  | Choose New Worktree from the running-location picker | WorktreeSourceModal opens and the PR / issue / branch / name creation flow remains available                                                   |
+| W3  | Choose New Worktree from the running-location picker | The final Branch control opens immediately as a Spotlight or anchored dropdown (matching the picker preference); no modal opens                |
 | W4  | Select a different Workspace                         | Pending new-worktree source state clears and running location returns to `local`; no path or source from the previous repository leaks forward |
 
 ## Repository chrome position
@@ -23,54 +23,55 @@
 | C8  | Reopen Session Creator after hiding pinned actions                    | Pinned quick-action pills remain hidden; choosing **Show pinned actions** restores the existing pins without repinning them                             |
 | C9  | Open compact/hidden repository-info creator after hiding              | Pinned quick actions remain visible because that surface has no repository chrome menu from which visibility could be restored                          |
 
-Covers the worktree-source picker (`WorktreeSourceModal.tsx`) and the
-launch-payload wiring that turns the picked source into backend worktree
-fields (`getWorktreeFields` in `useSessionLaunch/launchPayload.ts`).
+Covers the Session Creator picker (`WorktreeSourceSelector.tsx`), the legacy
+global-worktree creation modal (`WorktreeSourceModal.tsx`), and the
+launch-payload wiring that turns the picked source into backend worktree fields
+(`getWorktreeFields` in `useSessionLaunch/launchPayload.ts`).
 
 ## Preconditions
 
 - A repo is selected in the SessionCreator and the running location can be set
   to `worktree`.
-- For the GitHub tab: the repo has an `origin` remote whose URL parses to a
-  GitHub `owner/name`, and the local GitHub integration can list open PRs/issues.
-- For the Branch tab: `repoPath` is in scope so `getGitBranches` (Rust HTTP
+- For PR mode: the repo has an `origin` remote whose URL parses to a GitHub
+  `owner/name`, and the local GitHub integration can list open PRs.
+- For Branch mode: `repoPath` is in scope so `getGitBranches` (Rust HTTP
   `/repos/:id/branches`) can list local + remote branches. Remote branches come
   back in short-ref form (`origin/develop`) directly usable by `git worktree add`.
 
 ## Happy Path
 
-| #   | Steps                                                                    | Expected Result                                                                                                                                                                               |
-| --- | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | Open the position pill, choose "worktree" → modal opens on the Smart tab | Unified smart input with a mixed suggestion list (see "Smart tab" section); empty query shows the two smart default rows first; first row preselected; confirm enabled                        |
-| 2   | Switch to GitHub tab with several open PRs                               | PRs+issues load into a scrollable list; modal height stays stable (list capped, internal scroll)                                                                                              |
-| 3   | Pick a **same-repo** PR, confirm                                         | Confirm keeps a stable "Use worktree" label and width while its spinner shows during `worktree_resolve_pr_base`; on success pill shows PR label; source gains `resolvedBaseRef` = PR head SHA |
-| 4   | Launch the session                                                       | Payload carries `isolate: true` and `branch` = `resolvedBaseRef` (the fetched head SHA); backend creates `agent/<session>` from that SHA                                                      |
-| 5   | Branch tab: pick a branch from the list, confirm, launch                 | Payload `isolate: true`, `branch` = picked branch's resolvable ref (no resolve step — non-PR source)                                                                                          |
-| 6   | Pick a **fork / cross-repo** PR, confirm                                 | Resolver's branch fetch misses → falls back to `refs/pull/<n>/head`; success yields `resolvedBaseRef` = fork head SHA; launch uses that SHA                                                   |
+| #   | Steps                                                    | Expected Result                                                                                                                                                               |
+| --- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Open the running-location pill and choose "New Worktree" | The Branch selector opens immediately; the row remains ordered Repository → Running location → Branch and no modal appears                                                    |
+| 2   | Use the left-aligned Branch / PR switch and choose PR    | PR data loads on demand into the same Spotlight/dropdown surface; branch and PR requests are not both started while Branch mode is active                                     |
+| 3   | Pick a **same-repo** PR                                  | The selector stays open while `worktree_resolve_pr_base` runs; on success it closes, the Branch pill shows the PR label, and the source gains `resolvedBaseRef` = PR head SHA |
+| 4   | Launch the session                                       | Payload carries `isolate: true` and `branch` = `resolvedBaseRef` (the fetched head SHA); backend creates `agent/<session>` from that SHA                                      |
+| 5   | Branch mode: pick a branch from the list, then launch    | Selection commits immediately; payload `isolate: true`, `branch` = picked branch's resolvable ref (no PR resolve step)                                                        |
+| 6   | Pick a **fork / cross-repo** PR                          | Resolver's branch fetch misses → falls back to `refs/pull/<n>/head`; success yields `resolvedBaseRef` = fork head SHA; launch uses that SHA                                   |
 
-## Branch tab (grouped branch picker — aligned with the Spotlight "Switch Session Branch" selector)
+## Branch mode (grouped picker — aligned with the Spotlight "Switch Session Branch" selector)
 
-The Branch tab reuses the Spotlight selector's data + logic: `categorizeBranches` for the
+Branch mode reuses the Spotlight selector's data + logic: `groupBranchOptions` for the
 RECENT / WORKTREES / Other Branches sections, `useWorktreeMap` (`getGitWorktrees`) for the
 worktree section, and `formatRelativeTime(..., "short")` for the right-aligned timestamps.
-Rows are icon-first (worktree → `GitFork`, remote → `Cloud`, local → `GitBranch`) with **no
+Rows are icon-first (worktree → `Folder`, remote → `Cloud`, local → `GitBranch`) with **no
 text subtitle**. Pure grouping / timestamp logic is unit-tested in `worktreeBranchSource.test.ts`.
 
-| #   | Steps                                                            | Expected Result                                                                                                                                                                                                                                                                                                           |
-| --- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| B1  | Open Branch tab in a repo with branches                          | Branches load into a scrollable **grouped** list: `RECENT` (top ≤5 by commit date, current first), then `WORKTREES` (if any), then `Other Branches`; section headers use the uppercase `sectionLabel` style; current/most-recent branch preselected; confirm enabled; modal height stable (`max-h` cap + internal scroll) |
-| B1a | Inspect a branch row                                             | Single-line row: **left icon** by type (worktree `GitFork` / remote `Cloud` / local `GitBranch`), branch name, **right-aligned relative timestamp** ("Yesterday" / "4 hr ago" / "2 days ago"); **no** "Local branch" / "Remote branch" subtitle                                                                           |
-| B2  | Pick a **local** branch (e.g. `main`), confirm                   | Source `{ kind:"branch", baseBranch:"main", sourceRef:"branch:main" }`; launch `branch: "main"`                                                                                                                                                                                                                           |
-| B3  | Pick a **remote** branch (e.g. `origin/develop`), confirm        | `baseBranch:"origin/develop"` (short-ref form) → `git worktree add origin/develop` resolves without a bare unknown name                                                                                                                                                                                                   |
-| B3a | Pick a branch from the **WORKTREES** section, confirm            | Same `{ kind:"branch", baseBranch:"<branch>", sourceRef:"branch:<branch>" }` as any branch row — the worktree section is a display grouping, not a different source kind                                                                                                                                                  |
-| B4  | Type `dev` in the search box                                     | List filters case-insensitively to names containing `dev`, re-grouped into the same sections; non-matching branches hidden                                                                                                                                                                                                |
-| B5  | Type a ref with no exact branch match (tag / sha, e.g. `v1.2.0`) | A distinct **"Use \"v1.2.0\" as ref"** row (Hash icon + "Tag, commit, or any git ref" hint) appears at the top (above the sections); picking it yields `baseBranch:"v1.2.0"` — the custom-ref escape hatch preserved                                                                                                      |
-| B6  | Type a query that exactly matches an existing branch             | No custom-ref row shown (the real branch row already covers it); exact branch selectable                                                                                                                                                                                                                                  |
-| B7  | Clear the search (allowClear ✕)                                  | Full grouped branch list restored; selection resets to the first branch in the list                                                                                                                                                                                                                                       |
-| B8  | Open Branch tab in a repo with **no worktrees**                  | No `WORKTREES` section shown; only `RECENT` + `Other Branches`; no error (empty worktree map is best-effort)                                                                                                                                                                                                              |
-| B9  | Branch with no commit date                                       | Row renders with no right timestamp (blank), icon + name still shown                                                                                                                                                                                                                                                      |
+| #   | Steps                                                            | Expected Result                                                                                                                                                                                                                                |
+| --- | ---------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| B1  | Open Branch mode in a repo with branches                         | Branches load into a scrollable **grouped** list: `RECENT` (current/default first), then `WORKTREES` (if any), then `Other Branches`; section headers use the shared `sectionLabel` style; current branch is marked selected                   |
+| B1a | Inspect a branch row                                             | Single-line row: **left icon** by type (worktree `Folder` / remote `Cloud` / local `GitBranch`), branch name, **right-aligned relative timestamp** ("Yesterday" / "4 hr ago" / "2 days ago"); **no** "Local branch" / "Remote branch" subtitle |
+| B2  | Pick a **local** branch (e.g. `main`)                            | Source commits immediately as `{ kind:"branch", baseBranch:"main", sourceRef:"branch:main" }`; launch uses `main`                                                                                                                              |
+| B3  | Pick a **remote** branch (e.g. `origin/develop`)                 | `baseBranch:"origin/develop"` (short-ref form) → `git worktree add origin/develop` resolves without a bare unknown name                                                                                                                        |
+| B3a | Pick a branch from the **WORKTREES** section                     | Source carries the registered `existingWorktreePath`; launch reuses that checkout instead of creating another isolated worktree                                                                                                                |
+| B4  | Type `dev` in the search box                                     | List filters case-insensitively to names containing `dev`, re-grouped into the same sections; non-matching branches hidden                                                                                                                     |
+| B5  | Type a ref with no exact branch match (tag / sha, e.g. `v1.2.0`) | A distinct **"Use \"v1.2.0\" as ref"** row (Hash icon + "Tag, commit, or any git ref" hint) appears at the top (above the sections); picking it yields `baseBranch:"v1.2.0"` — the custom-ref escape hatch preserved                           |
+| B6  | Type a query that exactly matches an existing branch             | No custom-ref row shown (the real branch row already covers it); exact branch selectable                                                                                                                                                       |
+| B7  | Delete the current search query                                  | Full grouped branch list is restored                                                                                                                                                                                                           |
+| B8  | Open Branch mode in a repo with **no worktrees**                 | No `WORKTREES` section shown; only `RECENT` + `Other Branches`; no error (empty worktree map is best-effort)                                                                                                                                   |
+| B9  | Branch with no commit date                                       | Row renders with no right timestamp (blank), icon + name still shown                                                                                                                                                                           |
 
-## Smart tab (unified smart input — `worktreeSmartInput.ts`)
+## Legacy modal Smart tab (global WorktreePalette create action)
 
 Covers `parseSmartInput` (classification) + `buildSmartSuggestions` (mixed list) and the
 Smart-tab UI wiring. Pure logic is unit-tested in `worktreeSmartInput.test.ts`.
@@ -124,13 +125,17 @@ Smart-tab UI wiring. Pure logic is unit-tested in `worktreeSmartInput.test.ts`.
 
 ## Accessibility
 
-- [ ] Keyboard-navigable (Tab across tabs / rows, Enter to select, Escape closes) — see keep-with-reason in audit for raw-button gap
-- [ ] Confirm/Cancel are DS `Button`s with labels
-- [ ] Search input has a placeholder label
+- [x] Branch / PR segmented control exposes an accessible group label and pressed state
+- [x] Spotlight and dropdown variants use the shared keyboard-navigation engines; Enter selects and Escape closes
+- [x] Search inputs have explicit accessible labels; fetch/resolve failures use live alert semantics
 
 ## Acceptance Criteria
 
 - [x] A picked **same-repo PR** resolves to its head SHA (`worktree_resolve_pr_base` branch fetch) and that SHA drives worktree creation
+- [x] Session Creator renders Repository → Running location → Branch and opens no modal when New Worktree is chosen
+- [x] The worktree Branch selector follows the configured Spotlight/dropdown presentation and uses the agent-picker pattern: a left-aligned segmented pill for Branch / PR
+- [x] Branch data loads first; GitHub PR I/O begins only after PR mode is selected; both retain the existing bounded repo-scoped caches and in-flight dedupe
+- [x] Worktree source selection does not mutate or checkout the local session branch; switching back to This Mac restores the local branch context unchanged
 - [x] A picked **fork / cross-repo PR** resolves via `refs/pull/<n>/head` fallback and its head SHA drives worktree creation
 - [x] `resolvedBaseRef` (SHA) takes precedence over the label `baseBranch` in the launch payload `branch`
 - [x] Resolve failures surface an inline error and never silently launch on a synthetic id

--- a/src/features/SessionCreator/components/__tests__/WorktreeSourceSelector.test.ts
+++ b/src/features/SessionCreator/components/__tests__/WorktreeSourceSelector.test.ts
@@ -1,0 +1,367 @@
+// @vitest-environment jsdom
+import React, { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { resolvePrWorktreeBase } from "@src/api/tauri/github";
+
+import WorktreeSourceSelector from "../WorktreeSourceSelector";
+
+const testState = vi.hoisted(() => ({
+  loadOptions: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { defaultValue?: string; value?: string }) =>
+      options?.defaultValue ?? key,
+  }),
+}));
+
+vi.mock("@src/api/tauri/github", () => ({
+  resolvePrWorktreeBase: vi.fn(),
+}));
+
+vi.mock(
+  "@src/scaffold/GlobalSpotlight/palettes/BranchPalette/useWorktreeMap",
+  () => ({ useWorktreeMap: () => new Map() })
+);
+
+vi.mock("@src/hooks/dropdown", () => ({
+  useDropdownEngine: (options: {
+    listNavigation: {
+      items: unknown[];
+      onSelect: (item: unknown) => void;
+    };
+  }) => ({
+    isPositioned: true,
+    panelRef: { current: null },
+    panelPosition: { top: 20, left: 20, width: 360 },
+    keyboard: {
+      getItemProps: (index: number) => ({
+        "data-dropdown-item-index": index,
+        "aria-selected": false,
+        onMouseEnter: vi.fn(),
+        onClick: () =>
+          options.listNavigation.onSelect(options.listNavigation.items[index]),
+      }),
+    },
+  }),
+}));
+
+vi.mock("@src/scaffold/GlobalSpotlight/palettes/core", () => ({
+  useSelectorKernel: () => ({
+    searchQuery: "",
+    setSearchQuery: vi.fn(),
+    setSearchQueryRaw: vi.fn(),
+    selectedIndex: 0,
+    setSelectedIndex: vi.fn(),
+    inputRef: { current: null },
+    handleKeyDown: vi.fn(),
+    handleItemClick: vi.fn(),
+    focusInput: vi.fn(),
+    findFirstSelectable: () => 0,
+  }),
+}));
+
+vi.mock("../useWorktreeSourceData", () => ({
+  useWorktreeSourceData: (options: Record<string, unknown>) => {
+    testState.loadOptions.push(options);
+    return {
+      branch: {
+        options: [
+          {
+            name: "develop",
+            isCurrent: true,
+            isRemote: false,
+          },
+        ],
+        state: "ready",
+        error: null,
+        refreshing: false,
+        refresh: vi.fn(),
+      },
+      github: {
+        prs: [
+          {
+            number: 42,
+            title: "Fix launch flow",
+            head_branch: "fix/launch-flow",
+            base_branch: "develop",
+          },
+        ],
+        issues: [],
+        repoFullName: "acme/orgii",
+        state: "ready",
+        error: null,
+        refreshing: false,
+        refresh: vi.fn(),
+      },
+    };
+  },
+}));
+
+vi.mock("@src/scaffold/GlobalSpotlight/shell", async () => {
+  const ReactModule = await import("react");
+  return {
+    SpotlightShell: ({
+      isOpen,
+      children,
+    }: {
+      isOpen: boolean;
+      children: React.ReactNode;
+    }) =>
+      isOpen
+        ? ReactModule.createElement(
+            "div",
+            { "data-testid": "spotlight-shell" },
+            children
+          )
+        : null,
+    PaletteBody: ({
+      items,
+      inputLeadingSlot,
+    }: {
+      items: Array<{
+        id: string;
+        label: string;
+        data?: { isHeader?: boolean };
+        action?: () => void;
+      }>;
+      inputLeadingSlot?: React.ReactNode;
+    }) =>
+      ReactModule.createElement(
+        "div",
+        null,
+        inputLeadingSlot,
+        ...items.map((item) =>
+          item.data?.isHeader
+            ? ReactModule.createElement("div", { key: item.id }, item.label)
+            : ReactModule.createElement(
+                "button",
+                {
+                  key: item.id,
+                  type: "button",
+                  "data-testid": `source-item-${item.id}`,
+                  onClick: item.action,
+                },
+                item.label
+              )
+        )
+      ),
+  };
+});
+
+const mockedResolvePrWorktreeBase = vi.mocked(resolvePrWorktreeBase);
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+describe("WorktreeSourceSelector", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let onClose: ReturnType<typeof vi.fn>;
+  let onSelect: ReturnType<typeof vi.fn>;
+
+  beforeAll(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    testState.loadOptions.length = 0;
+    mockedResolvePrWorktreeBase.mockReset();
+    onClose = vi.fn();
+    onSelect = vi.fn();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    act(() => {
+      root.render(
+        createElement(WorktreeSourceSelector, {
+          isOpen: true,
+          presentation: "spotlight",
+          anchorRef: React.createRef<HTMLElement>(),
+          repoId: "repo-a",
+          repoPath: "/repo/a",
+          currentBranchName: "develop",
+          onClose,
+          onSelect,
+        })
+      );
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(reactActEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("loads branches first and commits a branch source directly", () => {
+    expect(testState.loadOptions.at(-1)).toMatchObject({
+      loadBranches: true,
+      loadGithub: false,
+    });
+
+    const row = container.querySelector<HTMLButtonElement>(
+      '[data-testid="source-item-branch:develop"]'
+    );
+    expect(row).not.toBeNull();
+
+    act(() => row?.click());
+
+    expect(onSelect).toHaveBeenCalledWith({
+      repoKey: "id:repo-a",
+      source: {
+        kind: "branch",
+        label: "Branch: develop",
+        baseBranch: "develop",
+        sourceRef: "branch:develop",
+        title: "develop",
+      },
+    });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("renders the same Branch / PR control in the anchored dropdown", () => {
+    act(() => {
+      root.render(
+        createElement(WorktreeSourceSelector, {
+          isOpen: true,
+          presentation: "dropdown",
+          anchorRef: React.createRef<HTMLElement>(),
+          repoId: "repo-a",
+          repoPath: "/repo/a",
+          currentBranchName: "develop",
+          onClose,
+          onSelect,
+        })
+      );
+    });
+
+    const dialog = document.querySelector('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+    expect(
+      document
+        .querySelector('[data-testid="worktree-source-mode-switch"]')
+        ?.getAttribute("aria-label")
+    ).toBe("Select branch or pull request");
+    expect(
+      dialog?.firstElementChild?.firstElementChild?.getAttribute("data-testid")
+    ).toBe("worktree-source-mode-switch");
+    expect(
+      document.querySelector(
+        '[data-testid="worktree-source-row-branch:develop"]'
+      )
+    ).not.toBeNull();
+  });
+
+  it("switches to PR mode lazily and resolves the selected PR head", async () => {
+    mockedResolvePrWorktreeBase.mockResolvedValue({
+      baseRef: "abc123",
+      headSha: "abc123",
+      branchNameOverride: "fix/launch-flow",
+      compareBaseRef: "refs/remotes/origin/develop",
+      source: "branch",
+    });
+
+    const prModeButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent === "PR"
+    );
+    expect(prModeButton).toBeDefined();
+
+    act(() => prModeButton?.click());
+    expect(testState.loadOptions.at(-1)).toMatchObject({
+      loadBranches: false,
+      loadGithub: true,
+    });
+
+    const prRow = container.querySelector<HTMLButtonElement>(
+      '[data-testid="source-item-pr:42"]'
+    );
+    expect(prRow?.textContent).toContain("#42 Fix launch flow");
+
+    await act(async () => {
+      prRow?.click();
+      await Promise.resolve();
+    });
+
+    expect(mockedResolvePrWorktreeBase).toHaveBeenCalledWith({
+      repoPath: "/repo/a",
+      prNumber: 42,
+      headBranch: "fix/launch-flow",
+      baseBranch: "develop",
+    });
+    expect(onSelect).toHaveBeenCalledWith({
+      repoKey: "id:repo-a",
+      source: expect.objectContaining({
+        sourceRef: "pr:42",
+        resolvedBaseRef: "abc123",
+        baseBranch: "fix/launch-flow",
+      }),
+    });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("ignores a PR resolution that finishes after the selector closes", async () => {
+    let finishResolution:
+      | ((value: Awaited<ReturnType<typeof resolvePrWorktreeBase>>) => void)
+      | undefined;
+    mockedResolvePrWorktreeBase.mockReturnValue(
+      new Promise((resolve) => {
+        finishResolution = resolve;
+      })
+    );
+
+    const prModeButton = [...container.querySelectorAll("button")].find(
+      (button) => button.textContent === "PR"
+    );
+    act(() => prModeButton?.click());
+
+    const prRow = container.querySelector<HTMLButtonElement>(
+      '[data-testid="source-item-pr:42"]'
+    );
+    act(() => prRow?.click());
+
+    act(() => {
+      root.render(
+        createElement(WorktreeSourceSelector, {
+          isOpen: false,
+          presentation: "spotlight",
+          anchorRef: React.createRef<HTMLElement>(),
+          repoId: "repo-a",
+          repoPath: "/repo/a",
+          currentBranchName: "develop",
+          onClose,
+          onSelect,
+        })
+      );
+    });
+
+    await act(async () => {
+      finishResolution?.({
+        baseRef: "abc123",
+        headSha: "abc123",
+        branchNameOverride: "fix/launch-flow",
+        compareBaseRef: "refs/remotes/origin/develop",
+        source: "branch",
+      });
+      await Promise.resolve();
+    });
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/SessionCreator/components/__tests__/buildSessionInfoSegments.test.ts
+++ b/src/features/SessionCreator/components/__tests__/buildSessionInfoSegments.test.ts
@@ -1,14 +1,32 @@
 import type { TFunction } from "i18next";
-import { Code } from "lucide-react";
+import { Code, Split } from "lucide-react";
 import React from "react";
 import { describe, expect, it, vi } from "vitest";
 
+import { RUNNING_LOCATIONS } from "@src/config/sessionCreatorConfig";
+
 import { buildSessionInfoSegments } from "../SessionInfoLine/buildSessionInfoSegments";
+import { LOCATION_ICONS } from "../SessionInfoLine/locationConfig";
 
 const t = ((key: string) => key) as TFunction;
 
 describe("buildSessionInfoSegments", () => {
-  it("keeps worktree switching out of the session info row", () => {
+  it("uses a clockwise split icon for New Worktree", () => {
+    const icon = LOCATION_ICONS.worktree as React.ReactElement<{
+      className?: string;
+    }>;
+
+    expect(icon.type).toBe(Split);
+    expect(icon.props.className).toContain("rotate-90");
+
+    const dropdownEntry = RUNNING_LOCATIONS.find(
+      (entry) => entry.id === "worktree"
+    );
+    expect(dropdownEntry?.icon).toBe(Split);
+    expect(dropdownEntry?.iconClassName).toBe("rotate-90");
+  });
+
+  it("orders setup as repository, running location, then branch", () => {
     const segments = buildSessionInfoSegments({
       SourceIcon: Code,
       hasSource: true,
@@ -29,11 +47,39 @@ describe("buildSessionInfoSegments", () => {
 
     expect(segments.map((segment) => segment.id)).toEqual([
       "repo",
-      "branch",
       "location",
+      "branch",
     ]);
     expect(segments.map((segment) => segment.tooltipMouseEnterDelay)).toEqual([
       2000, 2000, 2000,
+    ]);
+  });
+
+  it("shows the worktree source on the branch segment", () => {
+    const segments = buildSessionInfoSegments({
+      SourceIcon: Code,
+      hasSource: true,
+      sourceDisplayName: "ORGII",
+      showBranchRow: true,
+      isRepoSelectorOpen: false,
+      isBranchSelectorOpen: false,
+      branchName: "develop",
+      worktreeLocation: "worktree",
+      worktreeLocationLabel: "New Worktree",
+      worktreeSourceLabel: "#42 Fix launch flow",
+      isLocationDropdownOpen: false,
+      locationTriggerRef: React.createRef<HTMLButtonElement>(),
+      disabled: false,
+      t,
+      handleRepoTriggerClick: vi.fn(),
+      handleBranchTriggerClick: vi.fn(),
+      handleLocationTriggerClick: vi.fn(),
+    });
+
+    expect(segments.map((segment) => segment.label)).toEqual([
+      "ORGII",
+      "New Worktree",
+      "#42 Fix launch flow",
     ]);
   });
 });

--- a/src/features/SessionCreator/components/useWorktreeSourceData.ts
+++ b/src/features/SessionCreator/components/useWorktreeSourceData.ts
@@ -1,10 +1,10 @@
 /**
  * useWorktreeSourceData
  *
- * Data layer for `WorktreeSourceModal`. Preloads GitHub (PR/issue) and branch
- * data in parallel the moment the modal opens (as soon as `repoPath` is known),
- * so switching tabs never re-triggers a spinner. Results are cached per repo
- * key with a TTL and reused on reopen / tab-switch:
+ * Shared data layer for worktree-source pickers. Consumers can load GitHub and
+ * branch data together (the legacy modal) or demand-load only the active slice
+ * (the compact Branch / PR selector). Results are cached per repo key with a
+ * TTL and reused on reopen / mode switch:
  *
  * - **GitHub** → dedicated `worktreeGithubCacheAtom` (45s TTL, LRU-bounded).
  * - **Branches** → reuses the app-wide `branchCacheAtom` (`@src/store/repo`,
@@ -149,6 +149,8 @@ export interface UseWorktreeSourceDataOptions {
   open: boolean;
   repoId?: string;
   repoPath?: string;
+  /** Skip GitHub I/O until a consumer exposes PR/issue results. */
+  loadGithub?: boolean;
   /** Skip branch I/O for consumers that only need the shared GitHub slice. */
   loadBranches?: boolean;
 }
@@ -181,9 +183,12 @@ export function useWorktreeSourceData({
   open,
   repoId,
   repoPath,
+  loadGithub: shouldLoadGithub = true,
   loadBranches = true,
 }: UseWorktreeSourceDataOptions): UseWorktreeSourceDataResult {
-  const githubRepoKey = resolveWorktreeRepoKey(repoId, repoPath);
+  const githubRepoKey = shouldLoadGithub
+    ? resolveWorktreeRepoKey(repoId, repoPath)
+    : null;
   // Branch cache is keyed by raw repoId (matching `BranchPalette` /
   // `useBranchFetch`) so both selectors share one entry; fall back to repoPath.
   const branchKey = loadBranches ? repoId || repoPath || null : null;
@@ -204,7 +209,7 @@ export function useWorktreeSourceData({
       ? githubCache.get(githubKey)
       : undefined;
 
-  const loadGithub = useCallback(
+  const loadGithubData = useCallback(
     async (force: boolean) => {
       if (!repoPath || !githubRepoKey) return;
       const generation = ++githubGenerationRef.current;
@@ -296,18 +301,20 @@ export function useWorktreeSourceData({
   );
 
   useEffect(() => {
-    if (!open || !repoPath || !githubRepoKey) return;
-    void loadGithub(false);
+    if (!open || !shouldLoadGithub || !repoPath || !githubRepoKey) return;
+    void loadGithubData(false);
     return () => {
       githubGenerationRef.current += 1;
     };
-  }, [open, githubRepoKey, repoPath, loadGithub]);
+  }, [open, shouldLoadGithub, githubRepoKey, repoPath, loadGithubData]);
 
-  const githubState: WorktreeLoadState = !repoPath
-    ? "empty"
-    : githubEntry
-      ? githubEntry.state
-      : "loading";
+  const githubState: WorktreeLoadState = !shouldLoadGithub
+    ? "idle"
+    : !repoPath
+      ? "empty"
+      : githubEntry
+        ? githubEntry.state
+        : "loading";
 
   const githubError = githubEntry
     ? githubEntry.state === "error"
@@ -323,9 +330,9 @@ export function useWorktreeSourceData({
       state: githubState,
       error: githubError,
       refreshing: githubPending && Boolean(githubEntry),
-      refresh: () => void loadGithub(true),
+      refresh: () => void loadGithubData(true),
     }),
-    [githubEntry, githubState, githubError, githubPending, loadGithub]
+    [githubEntry, githubState, githubError, githubPending, loadGithubData]
   );
 
   // ============ BRANCHES (reuse app-wide branchCacheAtom) ============
@@ -411,17 +418,19 @@ export function useWorktreeSourceData({
     [branchEntry]
   );
 
-  const branchState: WorktreeLoadState = !repoPath
-    ? "empty"
-    : branchEntry
-      ? branchOptions.length > 0
-        ? "ready"
-        : "empty"
-      : branchPending
-        ? "loading"
-        : branchErrored
-          ? "error"
-          : "loading";
+  const branchState: WorktreeLoadState = !loadBranches
+    ? "idle"
+    : !repoPath
+      ? "empty"
+      : branchEntry
+        ? branchOptions.length > 0
+          ? "ready"
+          : "empty"
+        : branchPending
+          ? "loading"
+          : branchErrored
+            ? "error"
+            : "loading";
 
   const branch = useMemo<WorktreeBranchSlice>(
     () => ({

--- a/src/features/SessionCreator/components/worktreePrSource.ts
+++ b/src/features/SessionCreator/components/worktreePrSource.ts
@@ -1,0 +1,36 @@
+import type { OpenPRItem } from "@src/api/tauri/github";
+import type { WorktreeLaunchSource } from "@src/store/session/worktreeLaunchSourceAtom";
+
+import { compactText } from "./worktreeBranchSource";
+import type { PrResolveMeta } from "./worktreeSmartInput";
+
+export interface WorktreePrOption {
+  id: string;
+  source: WorktreeLaunchSource;
+  detail: string;
+  searchableText: string;
+  resolveMeta: PrResolveMeta;
+}
+
+/** Map an open GitHub PR to the canonical worktree-source shape. */
+export function prToWorktreeOption(pr: OpenPRItem): WorktreePrOption {
+  const label = compactText(`#${pr.number} ${pr.title}`);
+  const detail = `${pr.head_branch} -> ${pr.base_branch}`;
+  return {
+    id: `pr:${pr.number}`,
+    source: {
+      kind: "github",
+      label,
+      baseBranch: pr.head_branch || pr.base_branch,
+      sourceRef: `pr:${pr.number}`,
+      title: pr.title,
+    },
+    detail,
+    searchableText: `${label} ${detail}`,
+    resolveMeta: {
+      prNumber: pr.number,
+      headBranch: pr.head_branch || undefined,
+      baseBranch: pr.base_branch || undefined,
+    },
+  };
+}

--- a/src/features/SessionCreator/components/worktreeSourceSelectorTypes.ts
+++ b/src/features/SessionCreator/components/worktreeSourceSelectorTypes.ts
@@ -1,0 +1,25 @@
+import type { LucideIcon } from "lucide-react";
+
+import type { WorktreeLaunchSource } from "@src/store/session/worktreeLaunchSourceAtom";
+
+export type WorktreeSourcePickerMode = "branch" | "pr";
+
+export interface WorktreeSourcePickerItem {
+  id: string;
+  label: string;
+  detail?: string;
+  meta?: string;
+  icon: LucideIcon;
+  source: WorktreeLaunchSource;
+  resolveMeta?: {
+    prNumber: number;
+    headBranch?: string;
+    baseBranch?: string;
+  };
+}
+
+export interface WorktreeSourcePickerSection {
+  key: string;
+  label?: string;
+  items: WorktreeSourcePickerItem[];
+}

--- a/src/features/SessionCreator/variants/ChatPanel/index.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/index.tsx
@@ -264,7 +264,7 @@ const SessionCreatorChatPanelContent: React.FC<
     clearWorktreeLaunchSelection,
     handleWorktreeLocationChange,
     handleWorktreeSourceSelect,
-  } = useChatPanelWorktreeSelection({ effectiveSource, handleBranchChange });
+  } = useChatPanelWorktreeSelection({ effectiveSource });
 
   const agentVariant = getRustAgentType(selectedAgentDefId);
   const isRustMode = dispatchCategory === "rust_agent";
@@ -652,11 +652,15 @@ const SessionCreatorChatPanelContent: React.FC<
           : multiRunner.isActive
             ? "worktree"
             : runningLocation,
+        worktreeLocationLabel: multiRunner.worktreeSourceLabel,
         worktreeSourceLabel:
-          multiRunner.worktreeSourceLabel ??
-          (runningLocation === "worktree"
-            ? activeWorktreeSelection?.source.label
-            : undefined),
+          runningLocation === "worktree" || multiRunner.isActive
+            ? activeWorktreeSelection?.source.sourceRef?.startsWith("pr:")
+              ? activeWorktreeSelection.source.label
+              : (activeWorktreeSelection?.source.title ??
+                activeWorktreeSelection?.source.baseBranch)
+            : undefined,
+        worktreeSource: activeWorktreeSelection?.source,
         selectedWorktreePath:
           activeWorktreeSelection?.source.existingWorktreePath ?? null,
         onWorktreeLocationChange: multiRunner.handleWorktreeLocationChange,

--- a/src/features/SessionCreator/variants/ChatPanel/useChatPanelWorktreeSelection.ts
+++ b/src/features/SessionCreator/variants/ChatPanel/useChatPanelWorktreeSelection.ts
@@ -18,12 +18,10 @@ import { runningLocationAtom } from "@src/store/session/runningLocationAtom";
 
 interface UseChatPanelWorktreeSelectionOptions {
   effectiveSource: SessionSource | null;
-  handleBranchChange: (branch: string) => void;
 }
 
 export function useChatPanelWorktreeSelection({
   effectiveSource,
-  handleBranchChange,
 }: UseChatPanelWorktreeSelectionOptions) {
   const runningLocation = useAtomValue(runningLocationAtom);
   const setRunningLocation = useSetAtom(runningLocationAtom);
@@ -66,16 +64,8 @@ export function useChatPanelWorktreeSelection({
       }
       setWorktreeLaunchSelection(selection);
       setRunningLocation("worktree");
-      if (selection.source.baseBranch) {
-        handleBranchChange(selection.source.baseBranch);
-      }
     },
-    [
-      currentWorktreeRepoKey,
-      handleBranchChange,
-      setRunningLocation,
-      setWorktreeLaunchSelection,
-    ]
+    [currentWorktreeRepoKey, setRunningLocation, setWorktreeLaunchSelection]
   );
 
   return {

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1806,6 +1806,7 @@
       "switchNo": "No, use for this session only",
       "switchWorkspace": "Switch workspace",
       "switchBranch": "Switch branch",
+      "selectWorktreeSource": "Select worktree branch or pull request",
       "switchLocation": "Switch running location",
       "sessionWorkspace": "Switch Session Workspace",
       "locationAria": "Select running location",

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -2186,10 +2186,12 @@
       "resolving": "Resolving PR…",
       "selectRepository": "Select a repository before choosing a worktree source.",
       "sourceTabs": "Worktree source",
+      "sourceTypeAria": "Select branch or pull request",
       "tabs": {
         "smart": "Smart",
         "github": "GitHub",
         "branch": "Branch",
+        "pr": "PR",
         "name": "Name"
       },
       "smartPlaceholder": "Name, #1234, branch, or GitHub/GitLab URL",
@@ -2201,6 +2203,9 @@
       "githubError": "GitHub items could not be loaded.",
       "githubEmpty": "No open GitHub PRs or issues.",
       "githubNoMatches": "No matches.",
+      "prSearch": "Search pull requests",
+      "prSearchAria": "Search pull requests",
+      "prNoMatches": "No matching pull requests.",
       "refreshBranches": "Refresh branch list",
       "branchSearch": "Search branches or enter a ref",
       "branchSearchAria": "Search branches or enter a base ref",

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -1760,6 +1760,7 @@
       "switchNo": "否，仅本次会话使用",
       "switchWorkspace": "切换工作区",
       "switchBranch": "切换分支",
+      "selectWorktreeSource": "选择 Worktree 分支或拉取请求",
       "switchLocation": "切换运行位置",
       "sessionWorkspace": "切换 Session 工作区",
       "locationAria": "选择运行位置",

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -2159,10 +2159,12 @@
       "resolving": "正在解析 PR…",
       "selectRepository": "请先选择仓库，再选择工作树来源。",
       "sourceTabs": "工作树来源",
+      "sourceTypeAria": "选择分支或拉取请求",
       "tabs": {
         "smart": "智能",
         "github": "GitHub",
         "branch": "分支",
+        "pr": "PR",
         "name": "名称"
       },
       "smartPlaceholder": "名称、#1234、分支或 GitHub/GitLab URL",
@@ -2174,6 +2176,9 @@
       "githubError": "无法加载 GitHub 项目。",
       "githubEmpty": "没有开放的 GitHub PR 或议题。",
       "githubNoMatches": "没有匹配项。",
+      "prSearch": "搜索拉取请求",
+      "prSearchAria": "搜索拉取请求",
+      "prNoMatches": "没有匹配的拉取请求。",
       "refreshBranches": "刷新分支列表",
       "branchSearch": "搜索分支或输入引用",
       "branchSearchAria": "搜索分支或输入基础引用",

--- a/src/scaffold/GlobalSpotlight/components/SpotlightSearchBar.tsx
+++ b/src/scaffold/GlobalSpotlight/components/SpotlightSearchBar.tsx
@@ -25,6 +25,8 @@ export interface SpotlightSearchBarProps {
   onKeyDown: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   /** Placeholder text */
   placeholder: string;
+  /** Accessible name when the visible placeholder is insufficient. */
+  ariaLabel?: string;
   /** Whether data is loading */
   isLoading?: boolean;
   /** Whether countdown is active */
@@ -51,6 +53,7 @@ export const SpotlightSearchBar: React.FC<SpotlightSearchBarProps> = ({
   onSearchQueryChange,
   onKeyDown,
   placeholder,
+  ariaLabel,
   isLoading: _isLoading = false,
   isCountingDown = false,
   path,
@@ -181,6 +184,7 @@ export const SpotlightSearchBar: React.FC<SpotlightSearchBarProps> = ({
             onChange={(event) => onSearchQueryChange(event.target.value)}
             onKeyDown={onKeyDown}
             placeholder={placeholder}
+            aria-label={ariaLabel}
             className={`min-w-0 flex-1 bg-transparent ${SPOTLIGHT_TOKENS.inputFontSize} text-text-1 placeholder:text-text-1 focus:outline-none`}
             autoComplete="off"
             autoCorrect="off"

--- a/src/scaffold/GlobalSpotlight/shared/SpotlightInput.tsx
+++ b/src/scaffold/GlobalSpotlight/shared/SpotlightInput.tsx
@@ -18,6 +18,8 @@ export interface SpotlightInputProps {
   value: string;
   /** Change handler */
   onChange: (value: string) => void;
+  /** Accessible name when the visible placeholder is insufficient. */
+  ariaLabel?: string;
   /** Keydown handler */
   onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
   /** Placeholder text */
@@ -38,6 +40,7 @@ export const SpotlightInput: React.FC<SpotlightInputProps> = ({
   inputRef,
   value,
   onChange,
+  ariaLabel,
   onKeyDown,
   placeholder = "Search...",
   isLoading: _isLoading = false,
@@ -83,6 +86,7 @@ export const SpotlightInput: React.FC<SpotlightInputProps> = ({
           onChange={(event) => onChange(event.target.value)}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
+          aria-label={ariaLabel}
           className={`min-w-0 flex-1 bg-transparent ${SPOTLIGHT_TOKENS.inputFontSize} text-text-1 outline-none placeholder:text-text-2`}
           autoFocus={autoFocus}
           autoComplete="off"

--- a/src/scaffold/GlobalSpotlight/shell/PaletteBody.tsx
+++ b/src/scaffold/GlobalSpotlight/shell/PaletteBody.tsx
@@ -29,6 +29,8 @@ export interface PaletteBodyProps {
    */
   searchQuery?: string;
   placeholder: string;
+  /** Accessible name forwarded to the simple input variant. */
+  inputAriaLabel?: string;
 
   /** "searchBar" (default, breadcrumb-style) or "simple" (icon prefix). */
   inputVariant?: "searchBar" | "simple";
@@ -63,6 +65,7 @@ export const PaletteBody: React.FC<PaletteBodyProps> = ({
   items,
   searchQuery: searchQueryOverride,
   placeholder,
+  inputAriaLabel,
   inputVariant = "searchBar",
   path = [],
   onRemoveSegment,
@@ -89,6 +92,7 @@ export const PaletteBody: React.FC<PaletteBodyProps> = ({
           onChange={(value) => kernel.setSearchQuery(value)}
           onKeyDown={kernel.handleKeyDown}
           placeholder={placeholder}
+          ariaLabel={inputAriaLabel}
           isLoading={isLoading}
           icon={inputIcon}
           iconElement={inputIconElement}
@@ -101,6 +105,7 @@ export const PaletteBody: React.FC<PaletteBodyProps> = ({
           onSearchQueryChange={(value) => kernel.setSearchQuery(value)}
           onKeyDown={kernel.handleKeyDown}
           placeholder={placeholder}
+          ariaLabel={inputAriaLabel}
           isLoading={isLoading}
           isCountingDown={false}
           hideActionClose={hideActionClose}


### PR DESCRIPTION
## Problem

The Session Creator setup row presented repository, branch, and running location in an order that did not match the launch flow. Choosing New Worktree opened a separate modal, mixed worktree-source choice with running-location choice, and worktree source selection could overwrite the local checkout branch. The New Worktree icon also differed between the setup pill and the shared running-location dropdown.

## Solution

Render the setup row as Repository → Running location → Branch. Choosing New Worktree now commits the location and immediately opens the existing configured selector presentation: Spotlight or anchored dropdown. Both presentations place a left-aligned Branch / PR segmented control in the Agent Spotlight pattern; branch selections commit directly, while PR selections resolve the PR head before committing.

Keep local checkout branch state independent from worktree base selection, demand-load only the active Branch or PR data slice, reuse the existing repo-scoped TTL/LRU caches and in-flight deduplication, and ignore resolver completions after the picker closes. Use a shared rotated Split icon for New Worktree in the setup pill, dropdown rows, and standalone running-location pill. The legacy modal remains available to the global worktree creation flow.

## Potential risks

The new selector adds UI density to compact Session Creator surfaces, and PR selection still depends on GitHub authentication plus the existing PR-base resolver. The shared running-location icon metadata intentionally affects both Session Creator and active-session location pills. There are no dependency, persistence, IPC, wire-format, or backend changes, and existing cached data remains compatible. Rollback is a normal revert of commit `086617420`.

Rendered Tauri screenshots and desktop interaction QA have not been captured because repository policy requires explicit user opt-in before Computer Use. The PR is therefore opened as Draft pending visual evidence.

## Verification

- `pnpm exec prettier --check` over all 24 changed files — passed
- `pnpm exec eslint` over all 19 changed TypeScript/TSX files — passed with no warnings
- `pnpm exec vitest run src/features/SessionCreator/components/__tests__/WorktreeSourceSelector.test.ts src/features/SessionCreator/components/__tests__/buildSessionInfoSegments.test.ts src/features/SessionCreator/components/__tests__/WorktreeSourceModal.test.ts src/features/SessionCreator/components/__tests__/worktreeSourceResolve.test.ts src/features/SessionCreator/components/__tests__/worktreeBranchSource.test.ts src/features/SessionCreator/components/__tests__/worktreeSourceCache.test.ts` — 6 files and 60 tests passed
- `pnpm typecheck` — passed
- `pnpm run check:circular` — passed; no circular dependencies across 6,652 modules
- `git diff --check origin/develop...HEAD` — passed
- Commit pre-hook `lint-staged` plus scoped TypeScript verification — passed
- Final diff inspected for secrets, tokens, personal paths, private configuration, debug logs, generated artifacts, caches, and unrelated formatting; none found
- Not run: rendered Tauri visual QA/screenshots, pending explicit Computer Use opt-in

## Audit

- Architecture: all ten layers reviewed; ownership now separates local checkout state from worktree launch-source state, while wire, initialization, and resolver contracts remain unchanged
- Performance: pass; the selector is mounted only while open, loads only its active data slice, uses bounded existing caches/in-flight deduplication, and guards stale PR resolutions
- UI consistency: manually checked design-system controls, dropdown tokens, Spotlight composition, keyboard behavior, and accessible labels because the workspace-referenced `frontend-ui-audit` skill is unavailable
