### PR TITLE
ci(pr-policy): enforce pull request contract

### DIFF
--- a/.cursor/rules/pr-policy.mdc
+++ b/.cursor/rules/pr-policy.mdc
@@ -1,0 +1,26 @@
+---
+description: Repository-wide pull request contract for every Cursor agent
+alwaysApply: true
+---
+
+# Pull Request Contract
+
+@PR_RULES.md
+
+Before creating or updating any pull request, read and follow
+`PR_RULES.md`. It is the tracked, repository-wide source of truth.
+
+Hard gates:
+
+- One pull request has one responsibility.
+- The title uses `type(lowercase-kebab-scope): summary`.
+- The description begins with `Problem`, `Solution`, and `Potential risks` in
+  that exact order and includes a non-empty `Verification` section.
+- Exactly one primary label matches the title type; no more than two area
+  labels are present.
+- The final diff, published description, labels, base, and draft state are
+  read back and verified before handoff.
+
+Do not treat these rules as optional formatting. GitHub automation enforces
+the machine-checkable subset, and the semantic requirements remain review
+gates.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,24 @@
-## Summary
+## Problem
 
--
+<!-- What is wrong, who or what is affected, and the root cause? -->
 
-## Test plan
+## Solution
 
--
+<!-- What changed, what invariant or behavior results, and why this approach? -->
+
+## Potential risks
+
+<!-- Name concrete risks and unverified paths. If none remain, explain why. -->
+
+## Verification
+
+<!-- List exact commands/manual checks and outcomes; state what did not run. -->
 
 ## Submit checklist
 
-- [ ] The PR is focused and has a scoped Conventional Commits title, such as `feat(scope): summary` or `fix(scope): summary`.
+- [ ] I read and followed `PR_RULES.md`.
+- [ ] The PR is focused and has a scoped Conventional Commit title, such as `feat(scope): summary` or `fix(scope): summary`.
+- [ ] Exactly one primary label matches the title type, with no more than two area labels.
 - [ ] I ran the relevant checks, or explained why they were not run.
 - [ ] No secrets, private config, generated output, or unrelated formatting changes are included.
 - [ ] Docs, screenshots, and locale updates are included when the change needs them.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
           node-version: "20"
           cache: "pnpm"
 
+      - name: Test CI policy helpers
+        run: node --test scripts/ci/*.test.cjs
+
       - name: Cache node_modules
         uses: actions/cache@v5
         with:

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -1,0 +1,45 @@
+name: PR policy
+
+on:
+  pull_request_target:
+    branches: [develop, release, master]
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+      - converted_to_draft
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: pr-policy-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  enforce:
+    name: Enforce PR contract
+    runs-on: ubuntu-latest
+
+    steps:
+      # pull_request_target has write permissions, so never execute code from
+      # the contributor's head branch. This explicitly checks out trusted base.
+      - name: Checkout trusted policy
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Test policy helper
+        run: node --test scripts/ci/pr-policy.test.cjs
+
+      - name: Reconcile labels and enforce contract
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/ci/pr-policy.cjs

--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,13 @@ data.json
 
 # IDE / tool artifacts
 .eslintcache
-.cursor/
+# Keep local Cursor state ignored while allowing repository-wide rules shared
+# by every contributor and agent.
+.cursor/*
+!.cursor/rules/
+.cursor/rules/*
+!.cursor/rules/root-cause-first.mdc
+!.cursor/rules/pr-policy.mdc
 # Keep local ORGII state ignored while allowing explicitly vendored workspace skills.
 .orgii/*
 !.orgii/skills/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,15 @@ Run `org2-performance-guard` whenever a change adds or modifies polling, timers,
 ### Pull request contract
 
 Every pull request created or updated by an agent MUST follow these rules.
+Before touching a pull request, read `PR_RULES.md`; it is the tracked,
+repository-wide source of truth shared by Codex, Claude, Cursor, and human
+contributors. If this section and `PR_RULES.md` ever differ, follow
+`PR_RULES.md` and fix the stale adapter in the same pull request.
+
+Hard gates: one responsibility; a scoped Conventional Commit title; the
+required `Problem`, `Solution`, `Potential risks`, and `Verification` sections;
+exactly one matching primary label; no more than two area labels; and a final
+GitHub read-back of the published pull request.
 
 #### Single responsibility
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.md — Agent Skill Routing for ORGII
 
+@PR_RULES.md
+
 This file orients Claude / orgii agents working in this repo. It tells you **which audit / methodology skill to invoke** for which kind of task, and what to deliver before declaring work done.
 
 > Test conventions — where a test file belongs, how to name it, and what each
@@ -7,6 +9,10 @@ This file orients Claude / orgii agents working in this repo. It tells you **whi
 > This file does not restate them; it is about skill routing.
 
 This is **advisory**, not a hard contract. Use judgment based on PR size and risk.
+
+The exception is pull request policy: `PR_RULES.md` is mandatory, not
+advisory, for every pull request created or updated by Claude or a Claude-based
+agent.
 
 ---
 
@@ -58,6 +64,18 @@ Review gate: any UI predicate introduced to hide malformed data must cite an exp
 ---
 
 ## Default Delivery Flow
+
+### Pull requests
+
+Before creating or updating any pull request, read and follow `PR_RULES.md`.
+It is the tracked source of truth shared by Claude, Codex, Cursor, and human
+contributors.
+
+Hard gates: one responsibility; a scoped Conventional Commit title; the
+required `Problem`, `Solution`, `Potential risks`, and `Verification` sections;
+exactly one matching primary label; no more than two area labels; and a final
+GitHub read-back of the published pull request. If this summary and
+`PR_RULES.md` differ, follow `PR_RULES.md` and fix this adapter.
 
 ### Touching `*.tsx` files (UI work)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,11 @@ For deeper guidance, read:
 
 ## Commits and pull requests
 
+The complete, repository-wide pull request contract is in
+[`PR_RULES.md`](PR_RULES.md). It applies to human contributors and coding
+agents. GitHub automation enforces its machine-checkable title, description,
+and label rules.
+
 Commit messages and PR titles must use scoped Conventional Commits:
 
 ```text
@@ -152,7 +157,7 @@ Do not remove this trailer, and do not bypass hooks with `--no-verify`, `HUSKY=0
 
 Before requesting review, make sure the PR has:
 
-- A clear title, description, and test plan.
+- A title, description, and labels that comply with [`PR_RULES.md`](PR_RULES.md).
 - One focused issue, feature, or fix.
 - Relevant checks passing, or a note explaining what could not be run.
 - CLA Assistant passing, plus screenshots or docs when the change needs them.

--- a/PR_RULES.md
+++ b/PR_RULES.md
@@ -1,0 +1,132 @@
+# ORGII Pull Request Rules
+
+This tracked file is the repository-wide source of truth for pull requests.
+It applies to humans and to every coding agent, including Codex, Claude, and
+Cursor. Agent-specific instruction files may add implementation guidance, but
+they must not weaken or contradict this policy.
+
+## Single responsibility
+
+- One pull request solves one problem or delivers one feature.
+- Do not combine unrelated features, bug fixes, refactors, cleanup,
+  formatting, or documentation.
+- Supporting tests and documentation belong in the same pull request only
+  when they directly verify or explain its single change.
+- Put unrelated follow-up work in a separate branch and pull request.
+- Before handoff, compare the final branch against its base and confirm every
+  changed file belongs to the stated problem or solution.
+
+## Title
+
+Pull request titles must use a scoped Conventional Commit form:
+
+```text
+type(lowercase-kebab-scope): short imperative summary
+```
+
+Allowed types and their required primary labels are:
+
+| Title type                                | Primary label   |
+| ----------------------------------------- | --------------- |
+| `feat`                                    | `enhancement`   |
+| `fix`                                     | `bug`           |
+| `refactor`                                | `refactor`      |
+| `perf`                                    | `performance`   |
+| `test`                                    | `tests`         |
+| `docs`                                    | `documentation` |
+| `chore`, `build`, `ci`, `style`, `revert` | `maintenance`   |
+
+The scope is mandatory and must be lowercase kebab-case. Examples:
+`feat(chat): add pinned actions` and `fix(session-replay): preserve turns`.
+
+## Description
+
+The description must begin with these top-level sections in this exact order:
+
+```markdown
+## Problem
+
+<What is wrong, who or what is affected, and the root cause.>
+
+## Solution
+
+<What changed, the resulting invariant or behavior, and why this approach was chosen.>
+
+## Potential risks
+
+<Concrete regressions, compatibility concerns, unverified paths, or operational tradeoffs.>
+```
+
+All three sections must contain meaningful content. If no material risk
+remains, say why. Do not replace them with `Summary`, `Overview`, or
+`Test plan`.
+
+A non-empty `## Verification` section is also required after the three
+sections. It must list the exact commands and meaningful manual checks that
+actually ran, their outcomes, and any relevant checks that did not run.
+Additional sections such as `Audit`, screenshots, rollout notes, or rollback
+details may follow the required sections.
+
+## Labels
+
+- Every pull request must have exactly one primary label from `bug`,
+  `enhancement`, `refactor`, `performance`, `maintenance`, `tests`, or
+  `documentation`.
+- The primary label is derived from the title type. Automation reconciles it
+  whenever the pull request title or labels change.
+- Add no more than two area labels: `agent`, `chat`, `sessions`,
+  `project-management`, `workstation`, `cloud-collaboration`, `frontend-ui`,
+  or `dev-tooling`.
+- Add `security` or `UX` only when that concern materially affects review.
+- Do not create new repository labels as part of ordinary pull request work.
+  Propose taxonomy changes separately.
+
+## Base and diff integrity
+
+- Start from the intended target branch and fetch its latest state before
+  handoff.
+- Resolve integration conflicts and rerun affected checks.
+- Keep the published description synchronized with the final diff.
+- Avoid unrelated merge commits, generated churn, and history rewrites after
+  review begins. If history must change, tell reviewers what changed.
+
+## Risk and verification evidence
+
+- Verification must be proportional to risk and cover behavior at its owning
+  boundary, not only a helper or selector.
+- `Potential risks` must address applicable compatibility, data, concurrency,
+  lifecycle, platform, rollout, and unverified-path concerns.
+- Dependency, lockfile, database/schema, configuration, persistence,
+  public-API, IPC, and wire changes must explain necessity, compatibility, and
+  rollback or recovery.
+- Destructive or difficult-to-reverse behavior requires an explicit rollback
+  or recovery plan.
+- User-visible UI changes need suitable screenshots or recordings, including
+  relevant themes, viewport constraints, and loading/empty/error states. If
+  visual evidence is not useful, explain why.
+- Inspect the final diff for secrets, tokens, personal paths, private config,
+  debug logs, build artifacts, caches, and unrelated formatting changes.
+
+## Draft and review lifecycle
+
+- Keep a pull request in Draft while material design choices, known blockers,
+  migrations, or risk-proportionate verification remain incomplete.
+- Mark it ready only when acceptance criteria are met and the description
+  reflects the implementation.
+- If scope or behavior changes materially after review starts, update the
+  description and notify reviewers.
+
+## Agent handoff
+
+Any agent that creates or updates a pull request must:
+
+1. Read this file before mutating the pull request.
+2. Bring the title, description, labels, base, and draft state into compliance
+   in the same operation.
+3. Read the published pull request back from GitHub and verify the result.
+4. Report exact verification evidence and anything still incomplete.
+
+The GitHub `PR policy` workflow enforces the machine-checkable title,
+description, and label rules. Repository branch protection should require its
+`Enforce PR contract` check before merge. The remaining semantic rules are
+mandatory review criteria even when automation cannot prove them.

--- a/scripts/ci/pr-policy.cjs
+++ b/scripts/ci/pr-policy.cjs
@@ -1,0 +1,332 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+
+const PRIMARY_LABEL_BY_TYPE = Object.freeze({
+  feat: "enhancement",
+  fix: "bug",
+  refactor: "refactor",
+  perf: "performance",
+  test: "tests",
+  docs: "documentation",
+  chore: "maintenance",
+  build: "maintenance",
+  ci: "maintenance",
+  style: "maintenance",
+  revert: "maintenance",
+});
+
+const PRIMARY_LABELS = Object.freeze([
+  "bug",
+  "enhancement",
+  "refactor",
+  "performance",
+  "maintenance",
+  "tests",
+  "documentation",
+]);
+
+const AREA_LABELS = Object.freeze([
+  "agent",
+  "chat",
+  "sessions",
+  "project-management",
+  "workstation",
+  "cloud-collaboration",
+  "frontend-ui",
+  "dev-tooling",
+]);
+
+const AREA_BY_SCOPE = Object.freeze([
+  [
+    "agent",
+    /^(agent(?:-.+)?|memory|housekeep(?:ing)?|side-query|skill|plan|codex(?:-.+)?|claude(?:-.+)?|cli-subagent|hermes|gemini|opencode.*|providers?)$/,
+  ],
+  [
+    "chat",
+    /^(chat(?:panel|-panel|-pane|-history)?|markdown|composer|canvas|terminal|browser|tooltip)$/,
+  ],
+  [
+    "sessions",
+    /^(sessions?|session-.+|history|imported-history|replay|sidebar|journey|worktree|workspace|cursor|warp)$/,
+  ],
+  [
+    "project-management",
+    /^(pm|project(?:-manager|-management)?|projects|work-items|work-management|work|orgtrack.*|routines|team-inbox|kanban|github|comments|todo|launchpad)$/,
+  ],
+  [
+    "workstation",
+    /^(workstation|source-control|lsp|code-editor|status-bar|highlight)$/,
+  ],
+  [
+    "cloud-collaboration",
+    /^(cloud|org2cloud|cloud-sync|collab|channels?|realtime|oauth|orgs|notifications?|feishu|runtime)$/,
+  ],
+  [
+    "frontend-ui",
+    /^(ui|frontend|react|components?|theme|layout|hovercard|dropdown|a11y|profile|settings(?:-.+)?|onboarding|spotlight|webview|windows|macos|app|poker)$/,
+  ],
+  [
+    "dev-tooling",
+    /^(dev|build|ci|deps|tooling|rust|quality|e2e|tests?|benchmark|diagnostics?|profiling|bundle|renderer|release|updater|lint|codegen|repo|cache|polling|streaming|ingest|perf)$/,
+  ],
+]);
+
+const REQUIRED_FIRST_SECTIONS = Object.freeze([
+  "Problem",
+  "Solution",
+  "Potential risks",
+]);
+
+const TITLE_PATTERN =
+  /^(feat|fix|refactor|perf|test|docs|chore|build|ci|style|revert)\(([a-z0-9]+(?:-[a-z0-9]+)*)\): (\S.*)$/;
+
+function parseTitle(title) {
+  const match = TITLE_PATTERN.exec(title || "");
+  if (!match) return null;
+
+  const [, type, scope, summary] = match;
+  return {
+    type,
+    scope,
+    summary,
+    primaryLabel: PRIMARY_LABEL_BY_TYPE[type],
+  };
+}
+
+function inferAreaLabel(scope) {
+  return AREA_BY_SCOPE.find(([, pattern]) => pattern.test(scope))?.[0] || null;
+}
+
+function markdownSections(body) {
+  const source = body || "";
+  const matches = [...source.matchAll(/^##[ \t]+(.+?)[ \t]*\r?$/gm)];
+
+  return matches.map((match, index) => ({
+    title: match[1],
+    content: source.slice(
+      match.index + match[0].length,
+      matches[index + 1]?.index ?? source.length
+    ),
+  }));
+}
+
+function hasMeaningfulContent(content) {
+  const withoutComments = content.replace(/<!--[\s\S]*?-->/g, "").trim();
+  return withoutComments.length > 0 && !/^[-_*`\s]+$/.test(withoutComments);
+}
+
+function validateDescription(body) {
+  const sections = markdownSections(body);
+  const errors = [];
+  const firstTitles = sections.slice(0, 3).map(({ title }) => title);
+
+  if (
+    firstTitles.length !== REQUIRED_FIRST_SECTIONS.length ||
+    firstTitles.some((title, index) => title !== REQUIRED_FIRST_SECTIONS[index])
+  ) {
+    errors.push(
+      "The description must begin with ## Problem, ## Solution, and ## Potential risks in that exact order."
+    );
+  }
+
+  for (const title of REQUIRED_FIRST_SECTIONS) {
+    const section = sections.find((candidate) => candidate.title === title);
+    if (!section || !hasMeaningfulContent(section.content)) {
+      errors.push(`The ## ${title} section must contain meaningful content.`);
+    }
+  }
+
+  const verification = sections.find(
+    (section) => section.title === "Verification"
+  );
+  if (!verification || !hasMeaningfulContent(verification.content)) {
+    errors.push("A non-empty ## Verification section is required.");
+  }
+
+  return errors;
+}
+
+function validateLabels(labels, parsedTitle) {
+  const errors = [];
+  const primary = labels.filter((label) => PRIMARY_LABELS.includes(label));
+  const areas = labels.filter((label) => AREA_LABELS.includes(label));
+
+  if (primary.length !== 1) {
+    errors.push(
+      `Exactly one primary label is required; found ${primary.length}: ${primary.join(", ") || "none"}.`
+    );
+  } else if (parsedTitle && primary[0] !== parsedTitle.primaryLabel) {
+    errors.push(
+      `Primary label ${primary[0]} does not match title type ${parsedTitle.type}; expected ${parsedTitle.primaryLabel}.`
+    );
+  }
+
+  if (areas.length > 2) {
+    errors.push(
+      `No more than two area labels are allowed; found ${areas.length}: ${areas.join(", ")}.`
+    );
+  }
+
+  return errors;
+}
+
+function validatePullRequest({ title, body, labels }) {
+  const parsedTitle = parseTitle(title);
+  const errors = [];
+
+  if (!parsedTitle) {
+    errors.push(
+      "Title must use type(lowercase-kebab-scope): summary with an allowed Conventional Commit type."
+    );
+  }
+
+  errors.push(...validateDescription(body));
+  errors.push(...validateLabels(labels, parsedTitle));
+  return errors;
+}
+
+async function githubRequest({ apiUrl, token, method = "GET", path, body }) {
+  const response = await fetch(`${apiUrl}${path}`, {
+    method,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(
+      `GitHub API ${method} ${path} failed (${response.status}): ${detail}`
+    );
+  }
+
+  if (response.status === 204) return null;
+  return response.json();
+}
+
+async function reconcileLabels({
+  pullRequest,
+  repository,
+  token,
+  apiUrl,
+  request = githubRequest,
+}) {
+  const parsedTitle = parseTitle(pullRequest.title);
+  if (!parsedTitle) {
+    return pullRequest.labels.map(({ name }) => name);
+  }
+
+  const issuePath = `/repos/${repository}/issues/${pullRequest.number}`;
+  const current = await request({ apiUrl, token, path: issuePath });
+  const labels = new Set(current.labels.map(({ name }) => name));
+
+  for (const label of PRIMARY_LABELS) {
+    if (label !== parsedTitle.primaryLabel && labels.has(label)) {
+      await request({
+        apiUrl,
+        token,
+        method: "DELETE",
+        path: `${issuePath}/labels/${encodeURIComponent(label)}`,
+      });
+      labels.delete(label);
+    }
+  }
+
+  const toAdd = [];
+  if (!labels.has(parsedTitle.primaryLabel)) {
+    toAdd.push(parsedTitle.primaryLabel);
+  }
+
+  const inferredArea = inferAreaLabel(parsedTitle.scope);
+  const existingAreaCount = [...labels].filter((label) =>
+    AREA_LABELS.includes(label)
+  ).length;
+  if (inferredArea && !labels.has(inferredArea) && existingAreaCount < 2) {
+    toAdd.push(inferredArea);
+  }
+
+  if (toAdd.length > 0) {
+    await request({
+      apiUrl,
+      token,
+      method: "POST",
+      path: `${issuePath}/labels`,
+      body: { labels: toAdd },
+    });
+  }
+
+  const verified = await request({ apiUrl, token, path: issuePath });
+  return verified.labels.map(({ name }) => name);
+}
+
+function workflowError(message) {
+  const escaped = message
+    .replaceAll("%", "%25")
+    .replaceAll("\r", "%0D")
+    .replaceAll("\n", "%0A");
+  console.error(`::error::${escaped}`);
+}
+
+async function main() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  const token = process.env.GITHUB_TOKEN;
+  const repository = process.env.GITHUB_REPOSITORY;
+  const apiUrl = process.env.GITHUB_API_URL || "https://api.github.com";
+
+  if (!eventPath || !token || !repository) {
+    throw new Error(
+      "GITHUB_EVENT_PATH, GITHUB_TOKEN, and GITHUB_REPOSITORY are required."
+    );
+  }
+
+  const event = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+  if (!event.pull_request) {
+    throw new Error("The PR policy workflow requires a pull_request event.");
+  }
+
+  const labels = await reconcileLabels({
+    pullRequest: event.pull_request,
+    repository,
+    token,
+    apiUrl,
+  });
+  const errors = validatePullRequest({
+    title: event.pull_request.title,
+    body: event.pull_request.body || "",
+    labels,
+  });
+
+  if (errors.length > 0) {
+    errors.forEach(workflowError);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `PR #${event.pull_request.number} satisfies the tracked PR contract.`
+  );
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    workflowError(error.stack || error.message);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  AREA_LABELS,
+  PRIMARY_LABELS,
+  inferAreaLabel,
+  markdownSections,
+  parseTitle,
+  reconcileLabels,
+  validateDescription,
+  validateLabels,
+  validatePullRequest,
+};

--- a/scripts/ci/pr-policy.test.cjs
+++ b/scripts/ci/pr-policy.test.cjs
@@ -1,0 +1,163 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  inferAreaLabel,
+  parseTitle,
+  reconcileLabels,
+  validateDescription,
+  validateLabels,
+  validatePullRequest,
+} = require("./pr-policy.cjs");
+
+const VALID_BODY = `## Problem
+
+Session replay could lose the final turn after a reconnect.
+
+## Solution
+
+Persist the authoritative cursor before replay resumes.
+
+## Potential risks
+
+Older sessions keep their existing cursor until the next successful replay.
+
+## Verification
+
+- \`node --test scripts/ci/*.test.cjs\` — passed
+`;
+
+test("maps every allowed title type to its primary label", () => {
+  const expected = {
+    feat: "enhancement",
+    fix: "bug",
+    refactor: "refactor",
+    perf: "performance",
+    test: "tests",
+    docs: "documentation",
+    chore: "maintenance",
+    build: "maintenance",
+    ci: "maintenance",
+    style: "maintenance",
+    revert: "maintenance",
+  };
+
+  for (const [type, primaryLabel] of Object.entries(expected)) {
+    assert.deepEqual(parseTitle(`${type}(session-replay): verify policy`), {
+      type,
+      scope: "session-replay",
+      summary: "verify policy",
+      primaryLabel,
+    });
+  }
+});
+
+test("rejects unscoped, uppercase, and malformed titles", () => {
+  assert.equal(parseTitle("fix: missing scope"), null);
+  assert.equal(parseTitle("Fix(session): uppercase type"), null);
+  assert.equal(parseTitle("fix(Session): uppercase scope"), null);
+  assert.equal(parseTitle("fix(session) missing colon"), null);
+});
+
+test("infers stable area labels from title scopes", () => {
+  assert.equal(inferAreaLabel("agent-org"), "agent");
+  assert.equal(inferAreaLabel("chat"), "chat");
+  assert.equal(inferAreaLabel("session-creator"), "sessions");
+  assert.equal(inferAreaLabel("project-management"), "project-management");
+  assert.equal(inferAreaLabel("workstation"), "workstation");
+  assert.equal(inferAreaLabel("org2cloud"), "cloud-collaboration");
+  assert.equal(inferAreaLabel("ui"), "frontend-ui");
+  assert.equal(inferAreaLabel("rust"), "dev-tooling");
+  assert.equal(inferAreaLabel("unmapped-domain"), null);
+});
+
+test("accepts the required description structure and evidence", () => {
+  assert.deepEqual(validateDescription(VALID_BODY), []);
+});
+
+test("rejects reordered, missing, or placeholder-only sections", () => {
+  const errors = validateDescription(`## Solution
+
+Implemented it.
+
+## Problem
+
+<!-- TODO -->
+
+## Potential risks
+
+-
+`);
+
+  assert.ok(errors.some((error) => error.includes("exact order")));
+  assert.ok(errors.some((error) => error.includes("## Problem")));
+  assert.ok(errors.some((error) => error.includes("## Potential risks")));
+  assert.ok(errors.some((error) => error.includes("## Verification")));
+});
+
+test("requires one matching primary label and at most two areas", () => {
+  const parsed = parseTitle("fix(session): preserve final turns");
+
+  assert.deepEqual(validateLabels(["bug", "sessions"], parsed), []);
+  assert.ok(validateLabels([], parsed)[0].includes("Exactly one"));
+  assert.ok(
+    validateLabels(["bug", "enhancement"], parsed)[0].includes("Exactly one")
+  );
+  assert.ok(
+    validateLabels(["enhancement"], parsed)[0].includes("does not match")
+  );
+  assert.ok(
+    validateLabels(["bug", "sessions", "chat", "agent"], parsed)[0].includes(
+      "No more than two"
+    )
+  );
+});
+
+test("validates a complete pull request contract", () => {
+  assert.deepEqual(
+    validatePullRequest({
+      title: "fix(session): preserve final turns",
+      body: VALID_BODY,
+      labels: ["bug", "sessions"],
+    }),
+    []
+  );
+});
+
+test("reconciles the primary label and adds a scoped area", async () => {
+  const labels = new Set(["bug"]);
+  const calls = [];
+  const request = async ({ method = "GET", path, body }) => {
+    calls.push({ method, path, body });
+    if (method === "DELETE") {
+      labels.delete(decodeURIComponent(path.split("/").at(-1)));
+    }
+    if (method === "POST") {
+      body.labels.forEach((label) => labels.add(label));
+    }
+    return { labels: [...labels].map((name) => ({ name })) };
+  };
+
+  const reconciled = await reconcileLabels({
+    pullRequest: {
+      number: 42,
+      title: "refactor(ui): share button primitives",
+      labels: [{ name: "bug" }],
+    },
+    repository: "org2AI/ORG2",
+    token: "test-token",
+    apiUrl: "https://api.github.test",
+    request,
+  });
+
+  assert.deepEqual(new Set(reconciled), new Set(["refactor", "frontend-ui"]));
+  assert.ok(calls.some((call) => call.method === "DELETE"));
+  assert.ok(
+    calls.some(
+      (call) =>
+        call.method === "POST" &&
+        call.body.labels.includes("refactor") &&
+        call.body.labels.includes("frontend-ui")
+    )
+  );
+});


### PR DESCRIPTION
## Problem

Pull request requirements were duplicated across contributor and agent guidance without one tracked source of truth or an automated enforcement path. Titles, required description sections, primary labels, and area-label limits could drift between tools and reach review in inconsistent states.

## Solution

Add PR_RULES.md as the repository-wide contract and point the GitHub template, contributor guide, Codex/Claude guidance, and Cursor rule at it. Add a tested Node policy helper that validates scoped Conventional Commit titles, required description sections, one matching primary label, and at most two area labels.

A pull_request_target workflow checks out only the trusted base revision, tests the trusted helper, reconciles title-derived labels, and then enforces the contract. The existing frontend CI job also runs all CI policy-helper tests.

## Potential risks

The new workflow can add or remove repository labels on pull requests, so an incorrect title-to-label mapping could alter review metadata. Unit tests cover every primary title type, area inference, label reconciliation, and invalid contract shapes.

Because pull_request_target has write-capable issue permissions, executing untrusted head code would be security-sensitive. The workflow explicitly checks out the base SHA with persisted credentials disabled and never executes contributor code. After merge, existing open pull requests become subject to the policy when one of the configured PR events fires.

There are no application runtime, dependency, database, schema, persistence, IPC, or user-data changes. Rollback consists of reverting this commit, which removes the workflow and restores the previous advisory-only behavior.

## Verification

- node --test scripts/ci/pr-policy.test.cjs — 8 tests passed before and after commit formatting
- node --check scripts/ci/pr-policy.cjs and node --check scripts/ci/pr-policy.test.cjs — passed
- npx prettier --check on the Markdown, YAML, JavaScript, and contributor-guidance files — passed
- npx prettier --check --parser markdown .cursor/rules/pr-policy.mdc — passed
- git diff origin/develop...HEAD --check — passed
- Manual workflow review confirmed pull_request_target checks out github.event.pull_request.base.sha, disables persisted credentials, and does not execute head-branch code
- .gitignore has no inferred Prettier parser; it was verified through the diff check
- No screenshots were captured because this is repository policy and CI tooling with no application UI change