### PR TITLE
fix(workstation): resolve bottom panel translation

### DIFF
--- a/src/modules/WorkStation/shared/TabBarTrailingControls.test.ts
+++ b/src/modules/WorkStation/shared/TabBarTrailingControls.test.ts
@@ -1,9 +1,12 @@
 // @vitest-environment jsdom
+import { createInstance } from "i18next";
 import { Provider, createStore } from "jotai";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
+import { I18nextProvider, initReactI18next } from "react-i18next";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 
+import enSessions from "@src/i18n/locales/en/sessions.json";
 import { workStationEditorSecondaryCollapsedAtom } from "@src/store/ui/workStationAtom";
 import {
   activeStatusBarAppAtom,
@@ -12,17 +15,25 @@ import {
 
 import { TabBarBottomPanelToggle } from "./TabBarTrailingControls";
 
-vi.mock("react-i18next", () => ({
-  useTranslation: () => ({
-    t: (key: string) => `localized:${key}`,
-  }),
-}));
-
 vi.mock("@src/components/Tooltip", () => ({
   default: ({ children }: { children: React.ReactNode }) => children,
 }));
 
 describe("TabBarBottomPanelToggle", () => {
+  const i18n = createInstance();
+
+  beforeAll(async () => {
+    await i18n.use(initReactI18next).init({
+      lng: "en",
+      fallbackLng: false,
+      defaultNS: "sessions",
+      ns: ["sessions"],
+      resources: { en: { sessions: enSessions } },
+      interpolation: { escapeValue: false },
+      react: { useSuspense: false },
+    });
+  });
+
   it("uses the localized bottom-panel label", () => {
     const store = createStore();
     store.set(activeStatusBarAppAtom, "code");
@@ -35,11 +46,19 @@ describe("TabBarBottomPanelToggle", () => {
     });
 
     const markup = renderToStaticMarkup(
-      createElement(Provider, { store }, createElement(TabBarBottomPanelToggle))
+      createElement(
+        I18nextProvider,
+        { i18n },
+        createElement(
+          Provider,
+          { store },
+          createElement(TabBarBottomPanelToggle)
+        )
+      )
     );
 
-    expect(markup).toContain('title="localized:titleBar.showBottomPanel"');
-    expect(markup).toContain('aria-label="localized:titleBar.showBottomPanel"');
-    expect(markup).not.toContain("Show bottom panel");
+    expect(markup).toContain('title="Show bottom panel"');
+    expect(markup).toContain('aria-label="Show bottom panel"');
+    expect(markup).not.toContain("titleBar.showBottomPanel");
   });
 });

--- a/src/modules/WorkStation/shared/TabBarTrailingControls.tsx
+++ b/src/modules/WorkStation/shared/TabBarTrailingControls.tsx
@@ -33,7 +33,7 @@ export const TabBarBottomPanelToggle: React.FC = memo(() => {
 
   return (
     <TabBarTrailingIconButton
-      title={t("titleBar.showBottomPanel")}
+      title={t("simulator.titleBar.showBottomPanel")}
       onClick={() => callbacks.onToggleBottomPanel?.()}
     >
       <PanelBottom size={HEADER_ICON_SIZE.md} strokeWidth={1.75} />


### PR DESCRIPTION
## Problem

The workstation bottom-panel toggle requested titleBar.showBottomPanel from the sessions namespace, but the authoritative locale data defines that label under simulator.titleBar.showBottomPanel in every supported locale. Depending on i18n fallback behavior, the tooltip and accessible label could expose the untranslated key instead of localized copy.

The existing test mocked every requested key as successful, so it could not detect this namespace-path mismatch.

## Solution

Point the toggle at simulator.titleBar.showBottomPanel and update the owning test to initialize a real i18next instance with the English sessions locale. The regression now asserts the rendered tooltip and aria-label contain “Show bottom panel” and do not contain the unresolved key.

## Potential risks

The change affects only the bottom-panel toggle label lookup. All supported sessions locale files contain the same nested key, and no locale content itself changes.

There are no state, persistence, database, network, dependency, IPC, lifecycle, or compatibility changes. Rollback is the single commit on this branch.

No screenshots were captured because local Computer Use is explicitly disabled unless requested. Static rendering verifies the visible and accessible label, but in-app visual placement was not manually exercised.

## Verification

- rg -n showBottomPanel src/i18n/locales/*/sessions.json — confirmed the nested key exists in all 13 supported locale files
- npx vitest run src/modules/WorkStation/shared/TabBarTrailingControls.test.ts — 1 test passed using real English i18n data
- npx eslint src/modules/WorkStation/shared/TabBarTrailingControls.test.ts src/modules/WorkStation/shared/TabBarTrailingControls.tsx --max-warnings 0 --report-unused-disable-directives — passed
- npx prettier --check src/modules/WorkStation/shared/TabBarTrailingControls.test.ts src/modules/WorkStation/shared/TabBarTrailingControls.tsx — passed
- npm run typecheck — passed
- Pre-commit lint, formatting, and scoped TypeScript gates — passed
- git diff origin/develop...HEAD --check — passed