### PR TITLE
Maximize chat when closing the last Launchpad tab

### DIFF
--- a/src/store/workstation/tabRegistry/atoms.test.ts
+++ b/src/store/workstation/tabRegistry/atoms.test.ts
@@ -2,9 +2,12 @@ import { createStore } from "jotai/vanilla";
 import { describe, expect, it } from "vitest";
 
 import { workstationActiveSessionIdAtom } from "@src/store/session/viewAtom";
+import { chatPanelMaximizedAtom } from "@src/store/ui/chatPanelAtom";
+import { stationModeAtom } from "@src/store/ui/simulatorAtom";
 import { createBrowserSessionTab } from "@src/store/workstation/browser/tabs";
 import {
   type WorkStationTab,
+  createStartTab,
   workstationLayoutAtom,
   workstationTabsStateAtom,
 } from "@src/store/workstation/tabs";
@@ -29,6 +32,54 @@ function tab(id: string, orgId?: string): WorkStationTab {
     data: orgId ? { orgId } : {},
   };
 }
+
+describe("closeTabAtom", () => {
+  it("maximizes chat when the sole My Station Launchpad closes", () => {
+    const store = createStore();
+    const launchpad = createStartTab();
+    store.set(stationModeAtom, "my-station");
+    store.set(chatPanelMaximizedAtom, false);
+    store.set(workstationLayoutAtom, {
+      mainPane: { tabs: [launchpad], activeTabId: launchpad.id },
+    });
+
+    store.set(closeTabAtom, { tabId: launchpad.id });
+
+    expect(store.get(workstationLayoutAtom).mainPane).toEqual({
+      tabs: [],
+      activeTabId: null,
+    });
+    expect(store.get(chatPanelMaximizedAtom)).toBe(true);
+  });
+
+  it("does not maximize chat when a non-Launchpad last tab closes", () => {
+    const store = createStore();
+    const file = tab("file:/a.ts");
+    store.set(stationModeAtom, "my-station");
+    store.set(chatPanelMaximizedAtom, false);
+    store.set(workstationLayoutAtom, {
+      mainPane: { tabs: [file], activeTabId: file.id },
+    });
+
+    store.set(closeTabAtom, { tabId: file.id });
+
+    expect(store.get(chatPanelMaximizedAtom)).toBe(false);
+  });
+
+  it("does not maximize chat from Agent Station", () => {
+    const store = createStore();
+    const launchpad = createStartTab();
+    store.set(stationModeAtom, "agent-station");
+    store.set(chatPanelMaximizedAtom, false);
+    store.set(workstationLayoutAtom, {
+      mainPane: { tabs: [launchpad], activeTabId: launchpad.id },
+    });
+
+    store.set(closeTabAtom, { tabId: launchpad.id });
+
+    expect(store.get(chatPanelMaximizedAtom)).toBe(false);
+  });
+});
 
 describe("closeProjectOrgWorkStationTabsAtom", () => {
   it("closes every surface for the deleted org and keeps other tabs", () => {

--- a/src/store/workstation/tabRegistry/atoms.ts
+++ b/src/store/workstation/tabRegistry/atoms.ts
@@ -9,6 +9,9 @@
  */
 import { type Getter, type Setter, atom } from "jotai";
 
+import { chatPanelMaximizedAtom } from "@src/store/ui/chatPanelAtom";
+import { stationModeAtom } from "@src/store/ui/simulatorAtom";
+
 import {
   type PanelState,
   type WorkStationLayoutState,
@@ -87,12 +90,20 @@ focusTabAtom.debugLabel = "focusTabAtom";
 export const closeTabAtom = atom(null, (get, set, request: TabCloseRequest) => {
   const layout = get(workstationLayoutAtom);
   if (!layout) return;
+  const closesSoleLaunchpad =
+    get(stationModeAtom) === "my-station" &&
+    layout.mainPane.tabs.length === 1 &&
+    layout.mainPane.tabs[0]?.id === request.tabId &&
+    layout.mainPane.tabs[0].type === "start";
   closePresentedTabs(
     get,
     set,
     closeTabMutation(layout.mainPane, request.tabId),
     layout.mainPane
   );
+  if (closesSoleLaunchpad) {
+    set(chatPanelMaximizedAtom, true);
+  }
 });
 closeTabAtom.debugLabel = "closeTabAtom";
 


### PR DESCRIPTION
## Problem

When Launchpad is the only tab in My Station, closing it empties the workstation tab pool and the Launchpad fallback hook recreates it. My Station therefore remains visible instead of yielding the full surface to the chat panel.

The root cause is that the canonical workstation tab-close action only removed tabs; it did not model dismissal of My Station for the sole Launchpad case.

## Solution

The shared closeTabAtom now detects when the requested tab is the sole Launchpad in My Station. After closing that tab, it sets the existing chat-panel maximized atom to true. Because both the tab close button and the close-current-tab shortcut use this action, they now have consistent behavior.

The condition is intentionally limited to My Station, one remaining tab, and the start tab type. Closing ordinary last tabs or invoking a close while Agent Station is active keeps the existing behavior.

Regression tests cover the positive path and both scope guards.

## Potential risks

The chat-panel maximized preference is persisted by existing behavior, so dismissing My Station now intentionally updates that preference. Restoring My Station continues through the existing maximize and visibility controls.

No persistence format, public API, wire protocol, dependency, or data migration changes are involved. The main unverified path is a rendered desktop click-through; no screenshot is included because this reuses the existing maximized-chat layout and changes no visual styling.

## Verification

- pnpm vitest run src/store/workstation/tabRegistry/atoms.test.ts — passed, 8 tests
- pnpm eslint src/store/workstation/tabRegistry/atoms.ts src/store/workstation/tabRegistry/atoms.test.ts --max-warnings 0 --report-unused-disable-directives — passed
- pnpm typecheck — passed
- Repository pre-commit lint-staged, scoped TypeScript, and circular-dependency checks — passed
- git diff --check origin/develop...HEAD — passed

The final branch diff contains only:

- src/store/workstation/tabRegistry/atoms.ts
- src/store/workstation/tabRegistry/atoms.test.ts