### PR TITLE
refactor(conversations): canonicalize execution identity

### DIFF
--- a/src/engines/ChatPanel/hooks/useImportedSessionSubmitOverride.ts
+++ b/src/engines/ChatPanel/hooks/useImportedSessionSubmitOverride.ts
@@ -17,11 +17,8 @@ import {
   type ConversationFamilyMember,
   resolveConversationFamily,
 } from "@src/features/Org2Cloud/SessionConversation/continuationEvents";
-import {
-  cloudConversationExecutorScopeKey,
-  cloudConversationSetupMemoryKey,
-  loadStoredOwnerPlaneCursor,
-} from "@src/features/Org2Cloud/SessionConversation/conversationExecutionStore";
+import { resolveCloudConversationExecutionIdentity } from "@src/features/Org2Cloud/SessionConversation/conversationExecutionIdentity";
+import { loadStoredOwnerPlaneCursor } from "@src/features/Org2Cloud/SessionConversation/conversationExecutionStore";
 import { publishOwnerTurn } from "@src/features/Org2Cloud/SessionConversation/conversationOwnerPublisher";
 import {
   conversationPlaneAtom,
@@ -252,19 +249,18 @@ export function useImportedSessionSubmitOverride({
               planeInfo.rootId,
               auth.supabaseUrl
             );
-          // The root row's repo scope keys the setup memory AND resolves the
-          // runner's local checkout — without it the dialog reappears and a
-          // workspace-requiring agent cannot launch at all.
-          const rootRow = familyOrgId
-            ? remoteEntries[familyOrgId]?.rows?.find(
-                (candidate) => candidate.sourceSessionId === planeInfo.rootId
-              )
-            : undefined;
-          const authIdentity = org2CloudAuthIdentityKey(auth);
-          const executorScope = cloudConversationExecutorScopeKey(
-            authIdentity,
-            planeInfo.orgId
+          // The root row supplies workspace/model/agent hints. The canonical
+          // account/org/root/agent tuple below owns setup persistence.
+          const rootRow = remoteEntries[planeInfo.orgId]?.rows?.find(
+            (candidate) => candidate.sourceSessionId === planeInfo.rootId
           );
+          const authIdentity = org2CloudAuthIdentityKey(auth);
+          const executionIdentity = resolveCloudConversationExecutionIdentity({
+            authIdentity,
+            cloudOrgId: planeInfo.orgId,
+            rootSessionId: planeInfo.rootId,
+            assignedAgentDefinitionId: rootRow?.agentDefinitionId,
+          });
           let publishResolve!: () => void;
           const userPublished = new Promise<void>((resolve) => {
             publishResolve = resolve;
@@ -306,13 +302,8 @@ export function useImportedSessionSubmitOverride({
             sourceScopeKey: rootRow?.repoScopeKey,
             sourceModel: currentSession?.model ?? rootRow?.model,
             assignedAgentDefinitionId: rootRow?.agentDefinitionId,
-            setupMemoryKey: cloudConversationSetupMemoryKey(
-              authIdentity,
-              planeInfo.orgId,
-              planeInfo.rootId,
-              rootRow?.agentDefinitionId
-            ),
-            executionScopeKey: executorScope,
+            setupMemoryKey: executionIdentity.setupMemoryKey,
+            executionScopeKey: executionIdentity.executorScopeKey,
             onRunnerReady: (runnerSessionId, turnId, turnIntentId) => {
               // Overlay the runner's LIVE events (thinking / tools / worked-for)
               // into the conversation until the plane carries this turn's
@@ -361,13 +352,16 @@ export function useImportedSessionSubmitOverride({
         // Group-chat routing owns its own sends.
         if (await onFallbackSubmit(input)) return true;
         if (!auth) return false;
-        const executorScope = cloudConversationExecutorScopeKey(
-          org2CloudAuthIdentityKey(auth),
-          planeInfo.orgId
-        );
+        const executionIdentity = resolveCloudConversationExecutionIdentity({
+          authIdentity: org2CloudAuthIdentityKey(auth),
+          cloudOrgId: planeInfo.orgId,
+          rootSessionId: planeInfo.rootId,
+        });
         const ownerCursor =
-          loadStoredOwnerPlaneCursor(executorScope, planeInfo.rootId)
-            ?.readThroughPlaneSeq ?? 0;
+          loadStoredOwnerPlaneCursor(
+            executionIdentity.executorScopeKey,
+            planeInfo.rootId
+          )?.readThroughPlaneSeq ?? 0;
         let delta;
         try {
           delta = await loadCloudConversationPlaneDelta(
@@ -417,7 +411,7 @@ export function useImportedSessionSubmitOverride({
           sessionId,
           turnIntentId,
           displayText: input.displayText,
-          executorScope,
+          executorScope: executionIdentity.executorScopeKey,
           readThroughPlaneSeq: delta.lastSeq,
           onPushed: () => signalCloudConversationPlane(planeInfo.orgId),
         }).catch((error: unknown) => {
@@ -533,7 +527,6 @@ export function useImportedSessionSubmitOverride({
       currentSession?.importedFrom,
       currentSession?.name,
       currentSession?.model,
-      familyOrgId,
       forkImportedSession,
       getAccessToken,
       onFallbackSubmit,

--- a/src/features/Org2Cloud/SessionConversation/conversationContinuation.test.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationContinuation.test.ts
@@ -39,6 +39,17 @@ describe("decideContinuation", () => {
     ).toEqual({ kind: "fresh", rollReason: "assigned_agent_changed" });
   });
 
+  it("rolls when the desired local runtime changes", () => {
+    expect(
+      decideContinuation({
+        record: established,
+        turnIntentId: "intent-2",
+        assignedAgentDefinitionId: "agent-a",
+        runtimeSetupChanged: true,
+      })
+    ).toEqual({ kind: "fresh", rollReason: "runtime_setup_changed" });
+  });
+
   it("retries only the exact unestablished bootstrap intent", () => {
     const prepared: ConversationContinuationRecord = {
       ...established,

--- a/src/features/Org2Cloud/SessionConversation/conversationContinuation.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationContinuation.ts
@@ -119,6 +119,7 @@ export function decideContinuation(input: {
   record: ConversationContinuationRecord | null;
   turnIntentId: string;
   assignedAgentDefinitionId?: string;
+  runtimeSetupChanged?: boolean;
 }): ContinuationDecision {
   const { record } = input;
   if (!record) return { kind: "fresh" };
@@ -127,6 +128,9 @@ export function decideContinuation(input: {
     input.assignedAgentDefinitionId !== record.agentDefinitionId
   ) {
     return { kind: "fresh", rollReason: "assigned_agent_changed" };
+  }
+  if (input.runtimeSetupChanged) {
+    return { kind: "fresh", rollReason: "runtime_setup_changed" };
   }
   if (!record.established) {
     return record.bootstrapTurnIntentId === input.turnIntentId

--- a/src/features/Org2Cloud/SessionConversation/conversationExecutionIdentity.test.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationExecutionIdentity.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  continuationRuntimeFingerprint,
+  conversationSetupChangesRuntime,
+  conversationSetupRuntimeFingerprint,
+  isRunnableConversationSetup,
+  resolveCloudConversationExecutionIdentity,
+} from "./conversationExecutionIdentity";
+import type { ConversationContinuationRecord } from "./conversationExecutionStore";
+
+const continuation: ConversationContinuationRecord = {
+  episodeId: "episode-a",
+  continuationSessionId: "runner-a",
+  readThroughPlaneSeq: 4,
+  established: true,
+  agentDefinitionId: "agent-a",
+  cliAgentType: "codex",
+  accountId: "account-a",
+  model: "gpt-a",
+  workspaceRepoPath: "/repo/a",
+  updatedAt: "2026-08-25T00:00:00Z",
+};
+
+describe("cloud conversation execution identity", () => {
+  it("resolves transport, executor, execution, and setup keys from one tuple", () => {
+    const identity = resolveCloudConversationExecutionIdentity({
+      authIdentity: "https://cloud.example|user-a",
+      cloudOrgId: "org-a",
+      rootSessionId: "root-a",
+      assignedAgentDefinitionId: "agent-a",
+    });
+
+    expect(identity).toEqual({
+      authIdentity: "https://cloud.example|user-a",
+      cloudOrgId: "org-a",
+      rootSessionId: "root-a",
+      assignedAgentDefinitionId: "agent-a",
+      planeKey: "org-a:root-a",
+      executorScopeKey: JSON.stringify([
+        "cloud-conversation-executor",
+        "https://cloud.example|user-a",
+        "org-a",
+      ]),
+      executionKey: JSON.stringify([
+        JSON.stringify([
+          "cloud-conversation-executor",
+          "https://cloud.example|user-a",
+          "org-a",
+        ]),
+        "root-a",
+      ]),
+      setupMemoryKey: JSON.stringify([
+        "cloud-conversation-setup",
+        "https://cloud.example|user-a",
+        "org-a",
+        "root-a",
+        "agent-a",
+      ]),
+    });
+  });
+
+  it("isolates setup by account, org, root, and assigned agent", () => {
+    const base = {
+      authIdentity: "cloud|user-a",
+      cloudOrgId: "org-a",
+      rootSessionId: "root-a",
+      assignedAgentDefinitionId: "agent-a",
+    };
+    const key = resolveCloudConversationExecutionIdentity(base).setupMemoryKey;
+    for (const changed of [
+      { ...base, authIdentity: "cloud|user-b" },
+      { ...base, cloudOrgId: "org-b" },
+      { ...base, rootSessionId: "root-b" },
+      { ...base, assignedAgentDefinitionId: "agent-b" },
+    ]) {
+      expect(
+        resolveCloudConversationExecutionIdentity(changed).setupMemoryKey
+      ).not.toBe(key);
+    }
+  });
+
+  it("rejects incomplete execution identities", () => {
+    expect(() =>
+      resolveCloudConversationExecutionIdentity({
+        authIdentity: "",
+        cloudOrgId: "org-a",
+        rootSessionId: "root-a",
+      })
+    ).toThrow("auth identity");
+  });
+});
+
+describe("conversation runtime fingerprint", () => {
+  const matchingSetup = {
+    workspaceRepoPath: "/repo/a",
+    execution: {
+      agentDefinitionId: "agent-a",
+      cliAgentType: "codex" as const,
+      accountId: "account-a",
+      model: "gpt-a",
+    },
+  };
+
+  it("matches the exact runtime used to launch an episode", () => {
+    expect(conversationSetupRuntimeFingerprint(matchingSetup)).toBe(
+      continuationRuntimeFingerprint(continuation)
+    );
+    expect(conversationSetupChangesRuntime(continuation, matchingSetup)).toBe(
+      false
+    );
+  });
+
+  it.each([
+    ["agent", { execution: { agentDefinitionId: "agent-b" } }],
+    ["runtime", { execution: { cliAgentType: "claude_code" as const } }],
+    ["account", { execution: { accountId: "account-b" } }],
+    ["model", { execution: { model: "gpt-b" } }],
+    ["workspace", { workspaceRepoPath: "/repo/b" }],
+  ])("rolls for a changed %s", (_label, override) => {
+    const setup = {
+      ...matchingSetup,
+      ...override,
+      execution: {
+        ...matchingSetup.execution,
+        ...("execution" in override ? override.execution : {}),
+      },
+    };
+    expect(conversationSetupChangesRuntime(continuation, setup)).toBe(true);
+  });
+
+  it("requires an explicit account for a remembered External CLI", () => {
+    expect(
+      isRunnableConversationSetup({
+        workspaceRepoPath: null,
+        execution: {
+          agentDefinitionId: "agent-a",
+          cliAgentType: "codex",
+        },
+      })
+    ).toBe(false);
+    expect(isRunnableConversationSetup(matchingSetup)).toBe(true);
+  });
+});

--- a/src/features/Org2Cloud/SessionConversation/conversationExecutionIdentity.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationExecutionIdentity.ts
@@ -1,0 +1,135 @@
+/** Canonical local identity and runtime fingerprint for one cloud conversation. */
+import type { ForkSessionSetupSelection } from "@src/features/TeamCollaboration/components/ForkSessionSetupDialog";
+
+import {
+  type ConversationContinuationRecord,
+  cloudConversationExecutorScopeKey,
+  cloudConversationSetupMemoryKey,
+  conversationExecutionKey,
+} from "./conversationExecutionStore";
+
+export function cloudConversationPlaneKey(
+  cloudOrgId: string,
+  rootSessionId: string
+): string {
+  return `${cloudOrgId}:${rootSessionId}`;
+}
+
+export interface CloudConversationExecutionIdentity {
+  authIdentity: string;
+  cloudOrgId: string;
+  rootSessionId: string;
+  assignedAgentDefinitionId?: string;
+  /** Shared transport/read identity. Never contains a local account. */
+  planeKey: string;
+  /** Local executor boundary: signed-in cloud account plus cloud org. */
+  executorScopeKey: string;
+  /** Durable local execution row for this executor and root. */
+  executionKey: string;
+  /** Desired runtime selection for this executor, root, and assigned agent. */
+  setupMemoryKey: string;
+}
+
+function requireIdentityPart(label: string, value: string): string {
+  if (value.length === 0) {
+    throw new Error(`conversation ${label} is required`);
+  }
+  return value;
+}
+
+/**
+ * Every entry surface must call this resolver instead of rebuilding only a
+ * subset of the tuple. That keeps Work Items, imported replay composers, the
+ * setup pill, and future checkpoint handoff on the exact same local identity.
+ */
+export function resolveCloudConversationExecutionIdentity(input: {
+  authIdentity: string;
+  cloudOrgId: string;
+  rootSessionId: string;
+  assignedAgentDefinitionId?: string | null;
+}): CloudConversationExecutionIdentity {
+  const authIdentity = requireIdentityPart("auth identity", input.authIdentity);
+  const cloudOrgId = requireIdentityPart("organization", input.cloudOrgId);
+  const rootSessionId = requireIdentityPart(
+    "root session",
+    input.rootSessionId
+  );
+  const assignedAgentDefinitionId =
+    input.assignedAgentDefinitionId || undefined;
+  const executorScopeKey = cloudConversationExecutorScopeKey(
+    authIdentity,
+    cloudOrgId
+  );
+  return {
+    authIdentity,
+    cloudOrgId,
+    rootSessionId,
+    ...(assignedAgentDefinitionId ? { assignedAgentDefinitionId } : {}),
+    planeKey: cloudConversationPlaneKey(cloudOrgId, rootSessionId),
+    executorScopeKey,
+    executionKey: conversationExecutionKey(executorScopeKey, rootSessionId),
+    setupMemoryKey: cloudConversationSetupMemoryKey(
+      authIdentity,
+      cloudOrgId,
+      rootSessionId,
+      assignedAgentDefinitionId
+    ),
+  };
+}
+
+interface ConversationRuntimeIdentity {
+  agentDefinitionId: string;
+  cliAgentType?: string;
+  accountId?: string;
+  model?: string;
+  workspaceRepoPath?: string | null;
+}
+
+/** Stable, non-secret comparison value. It is not a credential or wire id. */
+export function conversationRuntimeFingerprint(
+  runtime: ConversationRuntimeIdentity
+): string {
+  return JSON.stringify([
+    "conversation-runtime-v1",
+    runtime.agentDefinitionId,
+    runtime.cliAgentType ?? "native",
+    runtime.accountId ?? null,
+    runtime.model ?? null,
+    runtime.workspaceRepoPath ?? null,
+  ]);
+}
+
+export function conversationSetupRuntimeFingerprint(
+  setup: ForkSessionSetupSelection
+): string {
+  return conversationRuntimeFingerprint({
+    ...setup.execution,
+    workspaceRepoPath: setup.workspaceRepoPath,
+  });
+}
+
+export function continuationRuntimeFingerprint(
+  continuation: ConversationContinuationRecord
+): string {
+  return conversationRuntimeFingerprint(continuation);
+}
+
+/** Mirrors the runner's launch precondition for a remembered CLI setup. */
+export function isRunnableConversationSetup(
+  setup: ForkSessionSetupSelection | null
+): setup is ForkSessionSetupSelection {
+  return Boolean(
+    setup?.execution.agentDefinitionId &&
+    (!setup.execution.cliAgentType || setup.execution.accountId)
+  );
+}
+
+export function conversationSetupChangesRuntime(
+  continuation: ConversationContinuationRecord,
+  setup: ForkSessionSetupSelection
+): boolean {
+  return (
+    continuationRuntimeFingerprint(continuation) !==
+    conversationSetupRuntimeFingerprint(setup)
+  );
+}

--- a/src/features/Org2Cloud/SessionConversation/conversationPlaneAtom.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationPlaneAtom.ts
@@ -17,6 +17,7 @@ import {
   listConversationEvents,
 } from "../org2CloudConversationEventsClient";
 import type { SessionCommentTarget } from "../sessionCommentTarget";
+import { cloudConversationPlaneKey } from "./conversationExecutionIdentity";
 
 const log = createLogger("ConversationPlane");
 
@@ -40,12 +41,7 @@ const EMPTY_ENTRY: ConversationPlaneEntry = {
   lastSeq: 0,
 };
 
-export function conversationPlaneKey(
-  orgId: string,
-  rootSessionId: string
-): string {
-  return `${orgId}:${rootSessionId}`;
-}
+export const conversationPlaneKey = cloudConversationPlaneKey;
 
 export const conversationPlaneAtom = atom<
   Record<string, ConversationPlaneEntry>

--- a/src/features/Org2Cloud/SessionConversation/conversationTurnRunner.test.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationTurnRunner.test.ts
@@ -10,7 +10,11 @@ import {
 } from "@src/features/TeamCollaboration/forkSetupMemory";
 
 import type { CloudConversationEvent } from "../org2CloudConversationEventsClient";
-import { loadContinuation, saveContinuation } from "./conversationContinuation";
+import {
+  loadContinuation,
+  loadContinuationLineage,
+  saveContinuation,
+} from "./conversationContinuation";
 import {
   CONVERSATION_TURN_LOCK_UNAVAILABLE,
   type RunConversationTurnParams,
@@ -403,6 +407,59 @@ describe("conversation turn continuation", () => {
     expect(SessionService.create).toHaveBeenCalledTimes(1);
     expect(state.pushes.filter((push) => push.kind === "user")).toHaveLength(1);
     expect(state.cleaned).toContain("runner-dead");
+  });
+
+  it("rolls at the next serialized turn when desired runtime setup changes", async () => {
+    saveContinuation("scope", "root", {
+      continuationSessionId: "runner-old-runtime",
+      readThroughPlaneSeq: 10,
+      established: true,
+      agentDefinitionId: "agent-a",
+      cliAgentType: "codex",
+      accountId: "account-a",
+      model: "model-a",
+      workspaceRepoPath: "/repo-a",
+    });
+    vi.mocked(loadForkSetupMemory).mockReturnValueOnce({
+      workspaceRepoPath: "/repo-b",
+      execution: {
+        agentDefinitionId: "agent-a",
+        cliAgentType: "codex",
+        accountId: "account-b",
+        model: "model-b",
+      },
+    });
+    state.persistedBatches = [
+      [],
+      [
+        event("user-1", "user", "new request", "intent-1"),
+        event("agent-1", "assistant", "new runtime answer"),
+      ],
+    ];
+
+    const result = await runConversationTurn(
+      params({ setupMemoryKey: "canonical-setup" })
+    );
+
+    expect(result.runnerSessionId).toBe("fresh-runner");
+    expect(state.cleaned).toContain("runner-old-runtime");
+    expect(SessionService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoPath: "/repo-b",
+        cliAgentType: "codex",
+        accountId: "account-b",
+        model: "model-b",
+      })
+    );
+    expect(loadContinuationLineage("scope", "root")?.episodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          continuationSessionId: "runner-old-runtime",
+          state: "retired",
+          rollReason: "runtime_setup_changed",
+        }),
+      ])
+    );
   });
 
   it("keeps a durably prepared resume on transport ambiguity", async () => {

--- a/src/features/Org2Cloud/SessionConversation/conversationTurnRunner.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationTurnRunner.ts
@@ -11,7 +11,7 @@
  * The first turn prepares an idle local runner and dispatches through the
  * canonical turn boundary. Later turns reuse that same session and inject
  * only the plane delta after its monotonic read cursor. A failed episode or
- * assigned-agent change rolls to a fresh runner.
+ * assigned-agent or desired runtime change rolls to a fresh runner.
  *
  * Push order is Slack-shaped: the user's message row goes out FIRST (every
  * client sees it instantly), the agent tail follows under the same turnId
@@ -28,6 +28,7 @@ import {
 } from "@src/engines/SessionCore/services/TurnDispatchService";
 import { mintTurnIntentId } from "@src/engines/SessionCore/sync/adapters/shared/eventFactories";
 import { loadAuthoritativeSessionEvents } from "@src/engines/SessionCore/sync/authoritativeSessionEvents";
+import type { ForkSessionSetupSelection } from "@src/features/TeamCollaboration/components/ForkSessionSetupDialog";
 import { requestForkSessionSetup } from "@src/features/TeamCollaboration/forkSession";
 import {
   clearForkSetupMemory,
@@ -52,6 +53,10 @@ import {
   prepareContinuation,
   retireContinuation,
 } from "./conversationContinuation";
+import {
+  conversationSetupChangesRuntime,
+  isRunnableConversationSetup,
+} from "./conversationExecutionIdentity";
 import {
   cleanupConversationRunnerBestEffort,
   cleanupRetiredConversationRunners,
@@ -448,6 +453,9 @@ async function runConversationTurnSerialized(
     params.executionScopeKey,
     params.rootSessionId
   );
+  const configuredSetup = loadForkSetupMemory(
+    params.setupMemoryKey ?? params.sourceScopeKey
+  );
   if (
     params.requiredRunnerSessionId &&
     record?.continuationSessionId !== params.requiredRunnerSessionId
@@ -462,6 +470,11 @@ async function runConversationTurnSerialized(
     record,
     turnIntentId,
     assignedAgentDefinitionId: params.assignedAgentDefinitionId,
+    runtimeSetupChanged: Boolean(
+      record &&
+      isRunnableConversationSetup(configuredSetup) &&
+      conversationSetupChangesRuntime(record, configuredSetup)
+    ),
   });
   if (params.requiredRunnerSessionId && decision.kind === "fresh") {
     throw new Error(
@@ -528,12 +541,18 @@ async function runConversationTurnSerialized(
       await cleanupConversationRunnerBestEffort(
         decision.record.continuationSessionId
       );
-      return startFreshEpisode(params, io, {
-        request,
-        deadlineMs,
-        dispatchIso,
-        userRowLastSeq,
-      });
+      return startFreshEpisode(
+        params,
+        io,
+        {
+          request,
+          deadlineMs,
+          dispatchIso,
+          userRowLastSeq,
+        },
+        undefined,
+        configuredSetup
+      );
     }
     await params.onTransportAccepted?.(
       decision.record.continuationSessionId,
@@ -581,7 +600,8 @@ async function runConversationTurnSerialized(
       deadlineMs,
       dispatchIso,
     },
-    initialContext
+    initialContext,
+    configuredSetup
   );
 }
 
@@ -604,7 +624,8 @@ async function startFreshEpisode(
   params: RunConversationTurnParams,
   io: TurnPushIo,
   turn: BootstrapTurn,
-  loadedContext?: ConversationInitialContext
+  loadedContext?: ConversationInitialContext,
+  configuredSetup?: ForkSessionSetupSelection | null
 ): Promise<RunConversationTurnResult> {
   const setupMemoryKey = params.setupMemoryKey ?? params.sourceScopeKey;
   const requestSetup = () =>
@@ -616,12 +637,13 @@ async function startFreshEpisode(
       allowCliRuntime: true,
       lockSourceAgent: Boolean(params.assignedAgentDefinitionId),
     });
-  const rememberedCandidate = loadForkSetupMemory(setupMemoryKey);
-  const remembered =
-    rememberedCandidate?.execution.cliAgentType &&
-    !rememberedCandidate.execution.accountId
-      ? null
-      : rememberedCandidate;
+  const rememberedCandidate =
+    configuredSetup === undefined
+      ? loadForkSetupMemory(setupMemoryKey)
+      : configuredSetup;
+  const remembered = isRunnableConversationSetup(rememberedCandidate)
+    ? rememberedCandidate
+    : null;
   if (rememberedCandidate && !remembered) {
     clearForkSetupMemory(setupMemoryKey);
   }

--- a/src/features/Org2Cloud/SessionConversation/useConversationSetupPillBinding.test.ts
+++ b/src/features/Org2Cloud/SessionConversation/useConversationSetupPillBinding.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveConversationSetupPillIdentity } from "./useConversationSetupPillBinding";
+
+describe("conversation setup pill identity", () => {
+  const importedFrom = { orgId: "org-a", sourceSessionId: "member-turn" };
+  const rows = [
+    {
+      sourceSessionId: "member-turn",
+      forkedFrom: { rootSessionId: "root-a" },
+    },
+    {
+      sourceSessionId: "root-a",
+      agentDefinitionId: "agent-a",
+    },
+  ];
+
+  it("uses the same account/org/root/agent setup tuple as execution", () => {
+    const identity = resolveConversationSetupPillIdentity({
+      authIdentity: "cloud|user-a",
+      importedFrom,
+      rows,
+    });
+
+    expect(identity?.rootSessionId).toBe("root-a");
+    expect(identity?.setupMemoryKey).toBe(
+      JSON.stringify([
+        "cloud-conversation-setup",
+        "cloud|user-a",
+        "org-a",
+        "root-a",
+        "agent-a",
+      ])
+    );
+    expect(identity?.setupMemoryKey).not.toBe("repo-scope");
+  });
+
+  it("does not expose another signed-in account's remembered setup", () => {
+    const first = resolveConversationSetupPillIdentity({
+      authIdentity: "cloud|user-a",
+      importedFrom,
+      rows,
+    });
+    const second = resolveConversationSetupPillIdentity({
+      authIdentity: "cloud|user-b",
+      importedFrom,
+      rows,
+    });
+    expect(second?.setupMemoryKey).not.toBe(first?.setupMemoryKey);
+    expect(
+      resolveConversationSetupPillIdentity({
+        authIdentity: null,
+        importedFrom,
+        rows,
+      })
+    ).toBeNull();
+  });
+});

--- a/src/features/Org2Cloud/SessionConversation/useConversationSetupPillBinding.ts
+++ b/src/features/Org2Cloud/SessionConversation/useConversationSetupPillBinding.ts
@@ -5,9 +5,10 @@
  * composer used to be a fork entry), so the stock pill reads "Select
  * model" forever, and a manual pick patches the imported row — which the
  * next family refresh wipes. On the conversation plane the model that
- * actually executes a member's turn is the remembered runner setup
- * (`forkSetupMemory`, the same record `runConversationTurn` launches
- * with), so the pill mirrors THAT: display the remembered model, and
+ * will execute a member's next turn is the remembered runner setup
+ * (`forkSetupMemory`, the same record `runConversationTurn` launches with).
+ * A changed setup rolls the active episode under the next serialized turn,
+ * so the pill mirrors that desired runtime: display the remembered model, and
  * route picks back into the memory so they stick across sends,
  * refreshes, and restarts.
  */
@@ -25,8 +26,16 @@ import {
 import type { LastModelSelection } from "@src/store/session/creatorDefaultModelAtom";
 import { sessionByIdAtom } from "@src/store/session/sessionAtom";
 
+import {
+  org2CloudAuthAtom,
+  org2CloudAuthIdentityKey,
+} from "../org2CloudAuthAtom";
 import type { CloudOrgRemoteSessionsEntry } from "../org2CloudRemoteSessionsAtom";
 import { org2CloudRemoteSessionsAtom } from "../org2CloudRemoteSessionsAtom";
+import {
+  type CloudConversationExecutionIdentity,
+  resolveCloudConversationExecutionIdentity,
+} from "./conversationExecutionIdentity";
 
 const detachedRemoteSessionsAtom = atom<
   Record<string, CloudOrgRemoteSessionsEntry>
@@ -44,10 +53,45 @@ export interface ConversationSetupPillBinding {
   applyModelPick: (config: AdvancedConfig) => boolean;
 }
 
+interface ImportedConversationIdentity {
+  orgId: string;
+  sourceSessionId: string;
+}
+
+interface ConversationIdentityRow {
+  sourceSessionId: string;
+  agentDefinitionId?: string;
+  forkedFrom?: { rootSessionId?: string } | null;
+}
+
+export function resolveConversationSetupPillIdentity(input: {
+  authIdentity: string | null;
+  importedFrom: ImportedConversationIdentity | null | undefined;
+  rows: readonly ConversationIdentityRow[] | null | undefined;
+}): CloudConversationExecutionIdentity | null {
+  if (!input.importedFrom || !input.authIdentity) return null;
+  const source = input.rows?.find(
+    (candidate) =>
+      candidate.sourceSessionId === input.importedFrom?.sourceSessionId
+  );
+  const rootSessionId =
+    source?.forkedFrom?.rootSessionId ?? input.importedFrom.sourceSessionId;
+  const root = input.rows?.find(
+    (candidate) => candidate.sourceSessionId === rootSessionId
+  );
+  return resolveCloudConversationExecutionIdentity({
+    authIdentity: input.authIdentity,
+    cloudOrgId: input.importedFrom.orgId,
+    rootSessionId,
+    assignedAgentDefinitionId: root?.agentDefinitionId,
+  });
+}
+
 export function useConversationSetupPillBinding(
   sessionId: string | null | undefined
 ): ConversationSetupPillBinding | null {
   const session = useAtomValue(sessionByIdAtom(sessionId ?? ""));
+  const auth = useAtomValue(org2CloudAuthAtom);
   const importedFrom = session?.importedFrom;
   const remoteEntries = useAtomValue(
     importedFrom ? org2CloudRemoteSessionsAtom : detachedRemoteSessionsAtom
@@ -58,40 +102,37 @@ export function useConversationSetupPillBinding(
     forkSetupMemoryVersion
   );
 
-  // Same derivation the plane submit path uses for its setup lookup: the
-  // conversation ROOT row's repo scope keys the memory record.
-  const scopeKey = useMemo(() => {
-    if (!importedFrom) return undefined;
-    const rows = remoteEntries[importedFrom.orgId]?.rows;
-    const row = rows?.find(
-      (candidate) => candidate.sourceSessionId === importedFrom.sourceSessionId
-    );
-    const rootId =
-      row?.forkedFrom?.rootSessionId ?? importedFrom.sourceSessionId;
-    const rootRow = rows?.find(
-      (candidate) => candidate.sourceSessionId === rootId
-    );
-    return rootRow?.repoScopeKey;
-  }, [importedFrom, remoteEntries]);
+  const authIdentity = auth ? org2CloudAuthIdentityKey(auth) : null;
+  // Resolve the exact account/org/root/agent tuple used by both plane submit
+  // paths. A repository scope is a workspace hint, never an executor identity.
+  const executionIdentity = useMemo(() => {
+    return resolveConversationSetupPillIdentity({
+      authIdentity,
+      importedFrom,
+      rows: importedFrom ? remoteEntries[importedFrom.orgId]?.rows : undefined,
+    });
+  }, [authIdentity, importedFrom, remoteEntries]);
 
   const selection = useMemo((): LastModelSelection | null => {
     if (!importedFrom) return null;
     void memoryVersion;
-    const remembered = loadForkSetupMemory(scopeKey);
+    if (!executionIdentity) return null;
+    const remembered = loadForkSetupMemory(executionIdentity.setupMemoryKey);
     if (!remembered) return null;
     return {
       keySource: KEY_SOURCE.OWN,
       model: remembered.execution.model,
       selectedAccountId: remembered.execution.accountId,
     };
-  }, [importedFrom, scopeKey, memoryVersion]);
+  }, [executionIdentity, importedFrom, memoryVersion]);
 
   const applyModelPick = useCallback(
     (config: AdvancedConfig): boolean => {
       if (isHostedKey(config.keySource) || !config.model) return false;
-      const current = loadForkSetupMemory(scopeKey);
+      if (!executionIdentity) return false;
+      const current = loadForkSetupMemory(executionIdentity.setupMemoryKey);
       if (!current) return false;
-      saveForkSetupMemory(scopeKey, {
+      saveForkSetupMemory(executionIdentity.setupMemoryKey, {
         ...current,
         execution: {
           ...current.execution,
@@ -101,7 +142,7 @@ export function useConversationSetupPillBinding(
       });
       return true;
     },
-    [scopeKey]
+    [executionIdentity]
   );
 
   return useMemo(

--- a/src/features/Org2Cloud/SessionConversation/workItemConversationTurnBridge.ts
+++ b/src/features/Org2Cloud/SessionConversation/workItemConversationTurnBridge.ts
@@ -22,10 +22,7 @@ import {
   settleCloudConversationRunner,
   signalCloudConversationPlane,
 } from "./cloudConversationRuntime";
-import {
-  cloudConversationExecutorScopeKey,
-  cloudConversationSetupMemoryKey,
-} from "./conversationExecutionStore";
+import { resolveCloudConversationExecutionIdentity } from "./conversationExecutionIdentity";
 import {
   type ConversationInitialContext,
   type RunConversationTurnParams,
@@ -212,10 +209,12 @@ export async function handleWorkItemConversationTurnRequest(
   const resolvedOrgId = decision.cloudOrgId;
   const rootSessionId = request.rootSessionId;
   const authIdentity = org2CloudAuthIdentityKey(auth as Org2CloudAuthState);
-  const executionScopeKey = cloudConversationExecutorScopeKey(
+  const executionIdentity = resolveCloudConversationExecutionIdentity({
     authIdentity,
-    resolvedOrgId
-  );
+    cloudOrgId: resolvedOrgId,
+    rootSessionId,
+    assignedAgentDefinitionId: request.assignedAgentId,
+  });
   let runnerSessionId: string | null = null;
   let transportAccepted = false;
   let acknowledged = false;
@@ -243,13 +242,8 @@ export async function handleWorkItemConversationTurnRequest(
       sourceScopeKey: root.repoScopeKey,
       sourceModel: root.model,
       assignedAgentDefinitionId: request.assignedAgentId ?? undefined,
-      setupMemoryKey: cloudConversationSetupMemoryKey(
-        authIdentity,
-        resolvedOrgId,
-        rootSessionId,
-        request.assignedAgentId ?? undefined
-      ),
-      executionScopeKey,
+      setupMemoryKey: executionIdentity.setupMemoryKey,
+      executionScopeKey: executionIdentity.executorScopeKey,
       turnIntentId: request.runId,
       requiredRunnerSessionId: request.preparedRunnerSessionId ?? undefined,
       preserveRunnerOnTransportFailure: true,


### PR DESCRIPTION
## Problem

Conversation execution identity was reconstructed independently by the imported-session composer, Work Item bridge, owner publisher, and model pill. The execution paths used an account/org/root/assigned-agent key, while the pill still looked up setup by repository scope. That could display or edit a different account's setup. A changed model/account/runtime/workspace also did not roll the already-active episode, so the UI could advertise a desired model while the next turn silently resumed the old runner.

## Solution

- Add one canonical resolver for the conversation plane key, executor scope, durable execution key, and setup-memory key.
- Route imported member turns, owner cursors, Work Item turns, and the setup pill through the same `(cloud account, org, root, assigned agent)` identity.
- Add a non-secret runtime fingerprint covering agent, native/CLI runtime, account, model, and local workspace.
- Treat setup edits as desired runtime state. At the next serialized turn boundary, retire and clean the old episode before launching the new runtime; an in-flight turn is never interrupted.
- Preserve the exact-runner fence for durable Work Item redelivery: a changed desired runtime makes an incompatible prepared runner fail closed instead of silently replacing it.

## Potential risks

- Existing pill-only setup stored under a repository-scope key is intentionally not migrated because it is not account/org/root isolated. The authoritative execution path was already using the safer canonical key; affected users may need to confirm setup once.
- A model/account/runtime/workspace edit now creates a new continuation episode on the next turn. The prior episode is retained as bounded lineage metadata and its hidden runner is cleaned through the existing lifecycle.
- Rollback is the single commit in this PR. Reverting it restores the previous key derivation and resume behavior without changing cloud data or native session formats.

## Verification

- `pnpm exec vitest run src/features/Org2Cloud/SessionConversation/conversationExecutionIdentity.test.ts src/features/Org2Cloud/SessionConversation/useConversationSetupPillBinding.test.ts src/features/Org2Cloud/SessionConversation/conversationContinuation.test.ts src/features/Org2Cloud/SessionConversation/conversationTurnRunner.test.ts src/features/Org2Cloud/SessionConversation/workItemConversationTurnBridge.test.ts` — 44 tests passed.
- `pnpm typecheck` — passed.
- Targeted ESLint over all 11 changed TypeScript files with zero warnings — passed.
- Repository pre-commit hook, including lint-staged and staged TypeScript check — passed.
- `git diff --check` — passed.
