### PR TITLE
feat(markdown): refine link affordances

### DIFF
--- a/src/components/MarkDown/LinkHoverCard.tsx
+++ b/src/components/MarkDown/LinkHoverCard.tsx
@@ -1,5 +1,5 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { Chromium, Copy, SquareArrowOutUpRight } from "lucide-react";
+import { Chromium, Copy } from "lucide-react";
 import React, { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -48,15 +48,14 @@ const LinkHoverCardContent: React.FC<{ preview: HttpLinkPreview }> = ({
   return (
     <HoverCardPanel title={preview.host}>
       <div
-        className="line-clamp-2 break-all text-[12px] leading-5 text-text-3"
+        className="truncate text-[12px] leading-5 text-text-3"
         title={preview.url}
       >
         {preview.displayUrl}
       </div>
       <div className="flex items-center justify-end gap-1 border-t border-border-1 pt-2">
         <Button
-          variant="tertiary"
-          appearance="ghost"
+          variant="secondary"
           size="mini"
           icon={<Copy size={13} />}
           iconOnly
@@ -65,21 +64,15 @@ const LinkHoverCardContent: React.FC<{ preview: HttpLinkPreview }> = ({
           onClick={handleCopy}
         />
         <Button
-          variant="tertiary"
-          appearance="ghost"
+          variant="secondary"
           size="mini"
-          icon={<SquareArrowOutUpRight size={13} />}
+          icon={<Chromium size={13} strokeWidth={1.75} />}
           iconOnly
           aria-label={t("cards.actions.openWithDefaultBrowser")}
           title={t("cards.actions.openWithDefaultBrowser")}
           onClick={handleOpenExternal}
         />
-        <Button
-          variant="primary"
-          size="mini"
-          icon={<Chromium size={13} strokeWidth={1.75} aria-hidden />}
-          onClick={handleOpenInApp}
-        >
+        <Button variant="primary" size="mini" onClick={handleOpenInApp}>
           {t("cards.actions.openInApp")}
         </Button>
       </div>

--- a/src/components/MarkDown/MarkDownImpl.tsx
+++ b/src/components/MarkDown/MarkDownImpl.tsx
@@ -28,6 +28,7 @@ import { activeWorkspaceRootAtom } from "@src/store/workspace";
 
 import LinkHoverCard from "./LinkHoverCard";
 import CodeBlock from "./MarkdownCodeBlock";
+import MarkdownLinkIcon, { hasMarkdownLinkIcon } from "./MarkdownLinkIcon";
 import MarkdownLocalImage, { openLocalMarkdownRef } from "./MarkdownLocalImage";
 import MermaidBlock from "./MermaidBlock";
 import SessionReferenceCards from "./SessionReferenceCards";
@@ -434,14 +435,27 @@ const MarkdownComponent: React.FC<MarkdownProps> = ({
             </a>
           );
         }
+        const linkTarget = classifyMarkdownLinkTarget(
+          url,
+          activeWorkspaceRootPath
+        );
+        const linkHasIcon = hasMarkdownLinkIcon(url, linkTarget);
         return (
           <LinkHoverCard url={url}>
             <a
               {...props}
+              className={
+                linkHasIcon
+                  ? ["markdown-link-with-icon", props.className]
+                      .filter(Boolean)
+                      .join(" ")
+                  : props.className
+              }
               href={url}
               title={undefined}
               onClick={(event) => handleLinkClick(event, url)}
             >
+              <MarkdownLinkIcon href={url} target={linkTarget} />
               {children}
             </a>
           </LinkHoverCard>

--- a/src/components/MarkDown/MarkdownLinkIcon.test.ts
+++ b/src/components/MarkDown/MarkdownLinkIcon.test.ts
@@ -1,0 +1,83 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import MarkdownLinkIcon, {
+  hasMarkdownLinkIcon,
+  isGitHubMarkdownHref,
+} from "./MarkdownLinkIcon";
+import type { MarkdownLinkTarget } from "./markdownLinkTarget";
+
+vi.mock("@src/assets/channelIcons/github.svg", () => ({
+  default: () => createElement("svg", { "data-link-icon": "github" }),
+}));
+
+vi.mock("@src/components/FileTypeIcon", () => ({
+  default: ({ fileName }: { fileName: string }) =>
+    createElement("svg", {
+      "data-file-name": fileName,
+      "data-link-icon": "file",
+    }),
+}));
+
+function renderIcon(href: string, target: MarkdownLinkTarget): string {
+  return renderToStaticMarkup(
+    createElement(MarkdownLinkIcon, { href, target })
+  );
+}
+
+describe("MarkdownLinkIcon", () => {
+  it.each([
+    "https://github.com/org2AI/ORG2",
+    "https://www.github.com/org2AI/ORG2/pull/959",
+    "http://github.com/org2AI/ORG2/issues/1",
+  ])("renders the GitHub SVG for an exact GitHub host: %s", (href) => {
+    const markup = renderIcon(href, { kind: "browser", url: href });
+
+    expect(markup).toContain('data-link-icon="github"');
+    expect(markup).not.toContain('data-link-icon="file"');
+  });
+
+  it("renders the matching file icon without the source line suffix", () => {
+    const markup = renderIcon("src/i18n/navigation.json:42", {
+      kind: "local",
+      path: "/repo/src/i18n/navigation.json:42",
+    });
+
+    expect(markup).toContain('data-link-icon="file"');
+    expect(markup).toContain('data-file-name="/repo/src/i18n/navigation.json"');
+  });
+
+  it("leaves ordinary web links without a leading icon", () => {
+    const href = "https://example.com/docs";
+    const target = { kind: "browser", url: href } as const;
+
+    expect(renderIcon(href, target)).toBe("");
+    expect(hasMarkdownLinkIcon(href, target)).toBe(false);
+  });
+
+  it("reports icons for both GitHub and local-file links", () => {
+    const githubHref = "https://github.com/org/repo";
+
+    expect(
+      hasMarkdownLinkIcon(githubHref, {
+        kind: "browser",
+        url: githubHref,
+      })
+    ).toBe(true);
+    expect(
+      hasMarkdownLinkIcon("navigation.json", {
+        kind: "local",
+        path: "/repo/navigation.json",
+      })
+    ).toBe(true);
+  });
+
+  it("does not treat lookalike or non-web GitHub URLs as GitHub links", () => {
+    expect(isGitHubMarkdownHref("https://github.com.example.com/repo")).toBe(
+      false
+    );
+    expect(isGitHubMarkdownHref("mailto:hello@github.com")).toBe(false);
+    expect(isGitHubMarkdownHref("github.com/org/repo")).toBe(false);
+  });
+});

--- a/src/components/MarkDown/MarkdownLinkIcon.tsx
+++ b/src/components/MarkDown/MarkdownLinkIcon.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+
+import GitHubIcon from "@src/assets/channelIcons/github.svg";
+import FileTypeIcon from "@src/components/FileTypeIcon";
+
+import { parseMarkdownFileRef } from "./markdownFileRef";
+import type { MarkdownLinkTarget } from "./markdownLinkTarget";
+
+interface MarkdownLinkIconProps {
+  href: string;
+  target: MarkdownLinkTarget;
+}
+
+const ICON_WRAPPER_CLASS =
+  "markdown-link-icon mr-1 inline-flex shrink-0 items-center justify-center leading-none";
+
+export function isGitHubMarkdownHref(href: string): boolean {
+  try {
+    const url = new URL(href);
+    return (
+      (url.protocol === "http:" || url.protocol === "https:") &&
+      (url.hostname === "github.com" || url.hostname === "www.github.com")
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function hasMarkdownLinkIcon(
+  href: string,
+  target: MarkdownLinkTarget
+): boolean {
+  return target.kind === "local" || isGitHubMarkdownHref(href);
+}
+
+const MarkdownLinkIcon: React.FC<MarkdownLinkIconProps> = ({
+  href,
+  target,
+}) => {
+  if (isGitHubMarkdownHref(href)) {
+    return (
+      <span aria-hidden="true" className={ICON_WRAPPER_CLASS}>
+        <GitHubIcon width={12} height={12} />
+      </span>
+    );
+  }
+
+  if (target.kind !== "local") return null;
+
+  return (
+    <span aria-hidden="true" className={ICON_WRAPPER_CLASS}>
+      <FileTypeIcon
+        fileName={parseMarkdownFileRef(target.path).path}
+        size="tiny"
+      />
+    </span>
+  );
+};
+
+MarkdownLinkIcon.displayName = "MarkdownLinkIcon";
+
+export default MarkdownLinkIcon;

--- a/src/components/MarkDown/_base-elements.scss
+++ b/src/components/MarkDown/_base-elements.scss
@@ -47,6 +47,19 @@
   }
 }
 
+.chat-markdown-body a.markdown-link-with-icon {
+  font-weight: inherit;
+  transition: none;
+
+  &:hover {
+    opacity: 1;
+  }
+}
+
+.chat-markdown-body .markdown-link-icon {
+  vertical-align: -2px;
+}
+
 .chat-markdown-body abbr[title] {
   border-bottom: none;
   text-decoration: underline dotted;


### PR DESCRIPTION
## Problem

Markdown links provide little visual context for GitHub targets and local files. The link hover card also gives the in-app action extra icon weight, uses low-emphasis utility actions, and allows long URLs to wrap. Once inline icons were added, the generic opacity transition and font-metric alignment made their hover and first-paint position appear unstable.

## Solution

Add a dedicated Markdown link icon projection that uses the existing GitHub SVG for exact GitHub hosts and the existing FileTypeIcon for classified local files. Keep ordinary web links unchanged, strip source-line suffixes before selecting file icons, inherit surrounding text weight, and use a fixed baseline offset with a stable hover treatment.

Refine the hover card to show its URL on one truncated line, use secondary copy and browser actions, move the Chromium glyph to the browser action, and keep the primary in-app action text-only. Existing click routing, full-URL title text, and accessible icon-button labels are preserved.

## Potential risks

The fixed icon baseline offset may have small optical differences under uncommon custom UI fonts, although it avoids font-initialization movement. GitHub decoration intentionally recognizes only exact github.com and www.github.com HTTP(S) hosts, and file icons rely on the existing local-link classifier. There are no persistence, API, wire-format, or dependency changes; rollback is a direct revert of the single commit.

## Verification

- pnpm exec eslint src/components/MarkDown/MarkDownImpl.tsx src/components/MarkDown/MarkdownLinkIcon.tsx src/components/MarkDown/MarkdownLinkIcon.test.ts src/components/MarkDown/LinkHoverCard.tsx --max-warnings 0 --report-unused-disable-directives — passed
- pnpm exec vitest run src/components/MarkDown/MarkdownLinkIcon.test.ts src/components/MarkDown/markdownLinkTarget.test.ts src/components/MarkDown/markdownFileRef.test.ts src/components/MarkDown/markdownUrlTransform.test.ts src/components/MarkDown/LinkHoverCard.helpers.test.ts src/components/MarkDown/markdownRendererBoundary.test.ts — 45 tests passed
- pnpm run typecheck — passed before and after rebasing onto the latest develop
- git diff --check origin/develop...HEAD — passed
- Normal pre-commit hooks completed successfully

The requester reviewed the live rendering during iteration. No independent desktop-control capture was run, and no screenshot is attached for this compact inline change.

## UI consistency

The workspace frontend-ui-audit skill is unavailable, so its intent was applied manually: shared Button and FileTypeIcon components are used, icon-only actions retain accessible labels, decorative inline SVGs are hidden from assistive technology, and no new arbitrary Tailwind values or duplicate visual primitives were introduced.