### PR TITLE
fix(chat): collapse failed terminals

### DIFF
--- a/src/engines/ChatPanel/blocks/TerminalBlock/collapsePolicy.test.ts
+++ b/src/engines/ChatPanel/blocks/TerminalBlock/collapsePolicy.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import TerminalBlock from ".";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@src/engines/ChatPanel/hooks/useChatEventReplay", () => ({
+  useChatEventReplay: () => ({
+    replayEventById: vi.fn(),
+    canReplay: false,
+  }),
+}));
+
+vi.mock("@src/engines/ChatPanel/blocks/primitives/useStrokeDraw", () => ({
+  useStrokeDraw: () => () => undefined,
+}));
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+describe("TerminalBlock collapse policy", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(reactActEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  function renderTerminal(props: {
+    exitCode?: number;
+    isError?: boolean;
+    isLoading?: boolean;
+  }) {
+    act(() => {
+      root.render(
+        createElement(TerminalBlock, {
+          command: "gh pr checks 964",
+          title: props.isLoading ? "Running command" : "Ran command",
+          ...props,
+        })
+      );
+    });
+  }
+
+  function commandBody(): Element | null {
+    return container.querySelector(".terminal-command__text");
+  }
+
+  it("keeps a historical failed command collapsed inside its group", () => {
+    renderTerminal({ exitCode: 8, isError: true });
+
+    expect(container.textContent).toContain("exit 8");
+    expect(commandBody()).toBeNull();
+  });
+
+  it("keeps a running command expanded", () => {
+    renderTerminal({ isLoading: true });
+
+    expect(commandBody()?.textContent).toBe("gh pr checks 964");
+  });
+
+  it("collapses a live command when it settles as failed", () => {
+    renderTerminal({ isLoading: true });
+    expect(commandBody()).not.toBeNull();
+
+    renderTerminal({ exitCode: 8, isError: true });
+
+    expect(container.textContent).toContain("exit 8");
+    expect(commandBody()).toBeNull();
+  });
+});

--- a/src/engines/ChatPanel/blocks/TerminalBlock/index.tsx
+++ b/src/engines/ChatPanel/blocks/TerminalBlock/index.tsx
@@ -153,16 +153,14 @@ const TerminalBlock: React.FC<TerminalBlockProps> = memo(
     toolUsage,
     tuiRendering,
   }) => {
-    const isErrorExit = exitCode !== undefined && exitCode !== 0;
     const isBackground = processStatus === "background";
     const isStillRunning = isLoading || isBackground;
     // Visibility policy:
     // - Caller-provided defaults always win.
-    // - Errors → expanded (need to see what failed).
     // - Still running OR backgrounded → expanded so progress remains visible.
-    // - Done & no error → collapse to a chip by default.
-    const effectiveDefaultCollapsed =
-      defaultCollapsed ?? (isErrorExit ? false : isStillRunning ? false : true);
+    // - Every settled command → collapsed; failures remain visible in the
+    //   header through their failed state and exit code, and can be expanded.
+    const effectiveDefaultCollapsed = defaultCollapsed ?? !isStillRunning;
 
     const {
       isCollapsed,
@@ -181,11 +179,11 @@ const TerminalBlock: React.FC<TerminalBlockProps> = memo(
 
     const wasStillRunningRef = useRef(isStillRunning);
     useEffect(() => {
-      if (wasStillRunningRef.current && !isStillRunning && !isErrorExit) {
+      if (wasStillRunningRef.current && !isStillRunning) {
         setIsCollapsed(true);
       }
       wasStillRunningRef.current = isStillRunning;
-    }, [isStillRunning, isErrorExit, setIsCollapsed]);
+    }, [isStillRunning, setIsCollapsed]);
 
     const { t } = useTranslation("sessions");
     const { t: tCommon } = useTranslation();


### PR DESCRIPTION
## Problem

Failed shell commands are already grouped into terminal activity stacks, but TerminalBlock explicitly defaults nonzero exits to expanded. Live commands also skip auto-collapse when they settle as failures. This makes failed terminals stand out from the compact group instead of remaining subsumed under it.

## Solution

Make every settled terminal default to collapsed unless a caller explicitly overrides the policy. Keep running and background commands expanded, then collapse them whenever they transition to a settled state, including failure. The compact header continues to show failure styling and exit code, and users can expand a failed terminal manually.

Add rendered lifecycle coverage for historical failure, unchanged running behavior, and the running-to-failed transition. Existing terminal grouping remains unchanged.

## Potential risks

Users who relied on failed output opening automatically now need one click to inspect it. Failure state and exit code remain visible, and explicit caller defaults and user expansion still work. There are no persistence, API, wire-format, data, dependency, or background lifecycle changes; rollback is a direct revert of the single commit.

## Verification

- `pnpm exec eslint src/engines/ChatPanel/blocks/TerminalBlock/index.tsx src/engines/ChatPanel/blocks/TerminalBlock/collapsePolicy.test.ts` — passed
- `pnpm exec vitest run src/engines/ChatPanel/blocks/TerminalBlock/collapsePolicy.test.ts src/engines/ChatPanel/blocks/TerminalBlock/shellReplay.test.ts src/engines/ChatPanel/blocks/TerminalBlock/stopLifecycle.test.ts src/engines/ChatPanel/blocks/TerminalActivityGroup.test.ts src/engines/ChatPanel/__tests__/pipeline.grouping.test.ts` — 40 tests passed
- `pnpm run typecheck` — passed
- `git diff --check origin/develop...HEAD` — passed
- Normal precommit hooks passed
- No screenshot is attached: compact collapse-state behavior is covered by rendered jsdom lifecycle tests, and the requester reviewed the target UI. No independent desktop-control capture was run.

This is a single-file UI bug fix with its owning regression test, so the repository guidance skips the broader frontend UI audit.