### PR TITLE
feat(chat-panel): move eligible tabs to My Station

### DIFF
--- a/src/engines/ChatPanel/ChatPanelTabBar/index.tsx
+++ b/src/engines/ChatPanel/ChatPanelTabBar/index.tsx
@@ -53,9 +53,11 @@ import { useSessionTabDropTarget } from "@src/shared/dnd/useSessionTabDropTarget
 import { openTeamInboxInChatPanelTabAtom } from "@src/store/chatPanel/chatPanelTabOpenAtoms";
 import {
   activateChatPanelTabAtom,
+  canMoveChatPanelTabToWorkstation,
   chatPanelTabsAtom,
   closeAndDestroyChatPanelTabAtom,
   closeOtherChatPanelTabsAtom,
+  moveChatPanelTabToWorkstationAtom,
   reorderChatPanelTabsAtom,
 } from "@src/store/chatPanel/chatPanelTabsAtom";
 import { moveSessionTabAtom } from "@src/store/session/sessionTabPlacementAtom";
@@ -78,6 +80,7 @@ export function ChatPanelTabBar(): React.ReactNode {
   const closeTab = useSetAtom(closeAndDestroyChatPanelTabAtom);
   const closeOtherTabs = useSetAtom(closeOtherChatPanelTabsAtom);
   const reorderTabs = useSetAtom(reorderChatPanelTabsAtom);
+  const moveTabToWorkstation = useSetAtom(moveChatPanelTabToWorkstationAtom);
   const moveSessionTab = useSetAtom(moveSessionTabAtom);
   const openTeamInbox = useSetAtom(openTeamInboxInChatPanelTabAtom);
   const requestSessionHandoff = useSetAtom(requestTeamInboxSessionHandoffAtom);
@@ -209,6 +212,12 @@ export function ChatPanelTabBar(): React.ReactNode {
     () => setContextMenuTabId(null),
     []
   );
+  const handleMoveToWorkstation = useCallback(
+    (tabId: string) => {
+      moveTabToWorkstation(tabId);
+    },
+    [moveTabToWorkstation]
+  );
   const handleCreateWorkItem = useCallback(
     (reference: SessionReferenceOpen) => {
       requestSessionHandoff(reference);
@@ -318,6 +327,11 @@ export function ChatPanelTabBar(): React.ReactNode {
           }
           onCreateWorkItem={handleCreateWorkItem}
           onOpenInSideChat={handleOpenInSideChat}
+          onMoveToWorkstation={
+            canMoveChatPanelTabToWorkstation(contextMenuTab)
+              ? handleMoveToWorkstation
+              : undefined
+          }
           onCloseTab={closeTab}
           onCloseOtherTabs={closeOtherTabs}
           onDismiss={handleDismissContextMenu}

--- a/src/engines/ChatPanel/ChatPanelTabContextMenu.test.ts
+++ b/src/engines/ChatPanel/ChatPanelTabContextMenu.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { popupNativeMenu } from "@src/util/platform/tauri/nativeMenuPopup";
+
+import ChatPanelTabContextMenu from "./ChatPanelTabContextMenu";
+
+vi.mock("i18next", () => ({
+  default: {
+    t: (_key: string, options?: { defaultValue?: string }) =>
+      options?.defaultValue ?? _key,
+  },
+}));
+
+vi.mock("@src/util/platform/tauri/nativeMenuPopup", () => ({
+  popupNativeMenu: vi.fn().mockResolvedValue({ status: "busy" }),
+}));
+
+const mockedPopupNativeMenu = vi.mocked(popupNativeMenu);
+const actEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+describe("ChatPanelTabContextMenu", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mockedPopupNativeMenu.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("offers Move to My Station when the tab supports it", async () => {
+    const onMoveToWorkstation = vi.fn();
+    const onDismiss = vi.fn();
+    await act(async () => {
+      root.render(
+        createElement(ChatPanelTabContextMenu, {
+          tabId: "chat-pr",
+          onMoveToWorkstation,
+          onCloseTab: vi.fn(),
+          onCloseOtherTabs: vi.fn(),
+          onDismiss,
+        })
+      );
+    });
+
+    expect(mockedPopupNativeMenu).toHaveBeenCalledOnce();
+    const items = await mockedPopupNativeMenu.mock.calls[0]?.[0].buildItems();
+    const moveItem = items?.[0] as
+      | { text?: string; action?: () => void }
+      | undefined;
+
+    expect(moveItem?.text).toBe("Move to My Station");
+    act(() => moveItem?.action?.());
+    expect(onMoveToWorkstation).toHaveBeenCalledWith("chat-pr");
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+});

--- a/src/engines/ChatPanel/ChatPanelTabContextMenu.tsx
+++ b/src/engines/ChatPanel/ChatPanelTabContextMenu.tsx
@@ -14,6 +14,7 @@ export interface ChatPanelTabContextMenuProps {
   tabId: string;
   onCloseTab: (tabId: string) => void | Promise<void>;
   onCloseOtherTabs: (tabId: string) => void | Promise<void>;
+  onMoveToWorkstation?: (tabId: string) => void | Promise<void>;
   sessionReference?: SessionReferenceOpen;
   onCreateWorkItem?: (reference: SessionReferenceOpen) => void;
   onOpenInSideChat?: (reference: SessionReferenceOpen) => void;
@@ -43,6 +44,18 @@ export function ChatPanelTabContextMenu(
           buildItems: () => {
             const translate = i18next.t.bind(i18next);
             const items: NativeMenuItemOptions[] = [];
+            if (propsRef.current.onMoveToWorkstation) {
+              items.push({
+                text: translate("sessions:chat.moveToWorkstation", {
+                  defaultValue: "Move to My Station",
+                }),
+                action: () => {
+                  const current = propsRef.current;
+                  void current.onMoveToWorkstation?.(current.tabId);
+                  current.onDismiss();
+                },
+              });
+            }
             const sessionReference = propsRef.current.sessionReference;
             if (sessionReference) {
               items.push({

--- a/src/engines/ChatPanel/components/SessionHeaderActionsMenu.tsx
+++ b/src/engines/ChatPanel/components/SessionHeaderActionsMenu.tsx
@@ -222,7 +222,7 @@ export const SessionHeaderActionsMenu: React.FC<
               <span className="flex-1 truncate">
                 {moveToWorkstation
                   ? t("chat.moveToWorkstation", {
-                      defaultValue: "Move to My Workstation",
+                      defaultValue: "Move to My Station",
                     })
                   : t("chat.moveToChatPanel", {
                       defaultValue: "Move to Chat Panel",

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -1066,7 +1066,7 @@
     "copyEventJson": "Copy event JSON",
     "copyEventJsonCopied": "Copied!",
     "copyEventJsonFailed": "Copy failed",
-    "moveToWorkstation": "Move to My Workstation",
+    "moveToWorkstation": "Move to My Station",
     "moveToChatPanel": "Move to Chat Panel",
     "rawTranscript": {
       "title": "Raw session transcript",

--- a/src/store/chatPanel/__tests__/chatPanelTabPlacementAtom.test.ts
+++ b/src/store/chatPanel/__tests__/chatPanelTabPlacementAtom.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  type ChatPanelTabsState,
+  chatPanelTabsAtom,
+} from "@src/store/chatPanel/chatPanelTabsAtom";
+import { sessionsAtom } from "@src/store/session/sessionAtom";
+import type { Session } from "@src/store/session/sessionAtom/types";
+import { workstationActiveSessionIdAtom } from "@src/store/session/viewAtom";
+import { chatPanelMaximizedAtom } from "@src/store/ui/chatPanelAtom";
+import { STATION_MODE, stationModeAtom } from "@src/store/ui/simulatorAtom";
+import { workstationLayoutAtom } from "@src/store/workstation/tabs";
+import type {
+  GitHubIssueDetailTabData,
+  GitHubPrDetailTabData,
+} from "@src/types/githubDetail";
+import { createInstrumentedStore } from "@src/util/core/state/instrumentedStore";
+
+import {
+  canMoveChatPanelTabToWorkstation,
+  moveChatPanelTabToWorkstationAtom,
+} from "../chatPanelTabPlacementAtom";
+
+function resetWorkstation(
+  store: ReturnType<typeof createInstrumentedStore>
+): void {
+  store.set(workstationActiveSessionIdAtom, null);
+  store.set(workstationLayoutAtom, {
+    mainPane: { tabs: [], activeTabId: null },
+  });
+  store.set(chatPanelMaximizedAtom, true);
+  store.set(stationModeAtom, STATION_MODE.AGENT_STATION);
+}
+
+function stateWith(
+  tab: ChatPanelTabsState["tabs"][number]
+): ChatPanelTabsState {
+  return {
+    tabs: [tab, { id: "launchpad", type: "start-page", title: "Launchpad" }],
+    activeTabId: tab.id,
+  };
+}
+
+describe("Chat Panel tab placement", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("moves a PR tab into the equivalent My Station detail tab", () => {
+    const store = createInstrumentedStore();
+    const githubPr: GitHubPrDetailTabData = {
+      prNumber: 964,
+      prTitle: "Maximize chat when closing the last Launchpad tab",
+      prUrl: "https://github.com/org/repo/pull/964",
+      prStatus: "open",
+      headBranch: "fix/chat",
+      baseBranch: "main",
+      additions: 14,
+      deletions: 3,
+      repoPath: "/repo",
+      repoId: "org/repo",
+    };
+    store.set(
+      chatPanelTabsAtom,
+      stateWith({
+        id: "chat-pr",
+        type: "github-pr",
+        title: "#964",
+        githubPr,
+      })
+    );
+    resetWorkstation(store);
+
+    const moved = store.set(moveChatPanelTabToWorkstationAtom, "chat-pr");
+
+    expect(moved).toBe(true);
+    expect(store.get(chatPanelTabsAtom).tabs).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: "chat-pr" })])
+    );
+    expect(store.get(workstationLayoutAtom).mainPane).toMatchObject({
+      activeTabId: "github-pr-detail:/repo:964",
+      tabs: [
+        expect.objectContaining({
+          id: "github-pr-detail:/repo:964",
+          type: "github-pr-detail",
+          data: githubPr,
+        }),
+      ],
+    });
+    expect(store.get(chatPanelMaximizedAtom)).toBe(false);
+    expect(store.get(stationModeAtom)).toBe(STATION_MODE.MY_STATION);
+  });
+
+  it("moves an issue tab into the equivalent My Station detail tab", () => {
+    const store = createInstrumentedStore();
+    const githubIssue: GitHubIssueDetailTabData = {
+      issueNumber: 42,
+      issueTitle: "Keep tab ownership stable",
+      repoPath: "/repo",
+      remoteUrl: "https://github.com/org/repo/issues/42",
+      stateScopeKey: "org/repo",
+      authScope: "github.com",
+      viewerLogin: "octocat",
+    };
+    store.set(
+      chatPanelTabsAtom,
+      stateWith({
+        id: "chat-issue",
+        type: "github-issue",
+        title: "#42",
+        githubIssue,
+      })
+    );
+    resetWorkstation(store);
+
+    const moved = store.set(moveChatPanelTabToWorkstationAtom, "chat-issue");
+
+    expect(moved).toBe(true);
+    expect(store.get(workstationLayoutAtom).mainPane).toMatchObject({
+      activeTabId: "github-issue-detail:/repo:42",
+      tabs: [
+        expect.objectContaining({
+          id: "github-issue-detail:/repo:42",
+          type: "github-issue-detail",
+          data: githubIssue,
+        }),
+      ],
+    });
+    expect(store.get(stationModeAtom)).toBe(STATION_MODE.MY_STATION);
+  });
+
+  it("moves a session through the canonical session transfer", () => {
+    const store = createInstrumentedStore();
+    const session: Session = {
+      session_id: "session-1",
+      name: "Live session",
+      status: "completed",
+      created_at: "2026-08-25T00:00:00.000Z",
+      updated_at: "2026-08-25T00:00:00.000Z",
+      repoPath: "/repo",
+    };
+    store.set(sessionsAtom, [session]);
+    store.set(
+      chatPanelTabsAtom,
+      stateWith({
+        id: "chat-session",
+        type: "session",
+        title: "Live session",
+        sessionId: session.session_id,
+      })
+    );
+    resetWorkstation(store);
+
+    const moved = store.set(moveChatPanelTabToWorkstationAtom, "chat-session");
+
+    expect(moved).toBe(true);
+    expect(store.get(workstationLayoutAtom).mainPane.activeTabId).toBe(
+      "chat-session:session-1"
+    );
+    expect(store.get(stationModeAtom)).toBe(STATION_MODE.MY_STATION);
+  });
+
+  it("does not offer or move tabs without a lossless My Station mapping", () => {
+    const store = createInstrumentedStore();
+    const launchpad = {
+      id: "launchpad",
+      type: "start-page" as const,
+      title: "Launchpad",
+    };
+    store.set(chatPanelTabsAtom, {
+      tabs: [launchpad],
+      activeTabId: launchpad.id,
+    });
+    resetWorkstation(store);
+
+    expect(canMoveChatPanelTabToWorkstation(launchpad)).toBe(false);
+    expect(store.set(moveChatPanelTabToWorkstationAtom, launchpad.id)).toBe(
+      false
+    );
+    expect(store.get(chatPanelTabsAtom).tabs).toEqual([launchpad]);
+    expect(store.get(workstationLayoutAtom).mainPane.tabs).toEqual([]);
+    expect(store.get(stationModeAtom)).toBe(STATION_MODE.AGENT_STATION);
+  });
+});

--- a/src/store/chatPanel/chatPanelTabPlacementAtom.ts
+++ b/src/store/chatPanel/chatPanelTabPlacementAtom.ts
@@ -1,0 +1,105 @@
+import { atom } from "jotai";
+
+import { openSessionInWorkstationAtom } from "@src/store/session/sessionTabPlacementAtom";
+import { chatPanelMaximizedAtom } from "@src/store/ui/chatPanelAtom";
+import { STATION_MODE, stationModeAtom } from "@src/store/ui/simulatorAtom";
+import {
+  type WorkStationTab,
+  githubIssueDetailTabFactory,
+  githubPrDetailTabFactory,
+  openWorkstationTabAtom,
+  presentedWorkstationWorkspaceKeyAtom,
+} from "@src/store/workstation/tabs";
+
+import { closeChatPanelTabAtom } from "./chatPanelTabLifecycleAtoms";
+import type { ChatPanelTab, ChatPanelTabType } from "./chatPanelTabsModel";
+import { chatPanelTabsAtom } from "./chatPanelTabsState";
+
+type WorkstationTransferKind = "session" | "github-issue" | "github-pr";
+
+/**
+ * Lossless Chat Panel -> My Station mappings. The record is exhaustive so a
+ * new Chat Panel tab type must make an explicit transfer decision.
+ */
+const WORKSTATION_TRANSFER_KIND: Record<
+  ChatPanelTabType,
+  WorkstationTransferKind | null
+> = {
+  session: "session",
+  terminal: null,
+  "start-page": null,
+  runtime: null,
+  "team-inbox": null,
+  "work-management": null,
+  workspace: null,
+  organization: null,
+  "work-item": null,
+  "github-issue": "github-issue",
+  "github-pr": "github-pr",
+  project: null,
+  explore: null,
+  channel: null,
+  "run-group": null,
+};
+
+export function canMoveChatPanelTabToWorkstation(
+  tab: ChatPanelTab | undefined
+): boolean {
+  if (!tab) return false;
+
+  switch (WORKSTATION_TRANSFER_KIND[tab.type]) {
+    case "session":
+      return Boolean(tab.sessionId?.trim());
+    case "github-issue":
+      return tab.githubIssue !== undefined;
+    case "github-pr":
+      return tab.githubPr !== undefined;
+    case null:
+      return false;
+  }
+}
+
+function createWorkstationDetailTab(tab: ChatPanelTab): WorkStationTab | null {
+  switch (WORKSTATION_TRANSFER_KIND[tab.type]) {
+    case "github-issue":
+      return tab.githubIssue
+        ? githubIssueDetailTabFactory(tab.githubIssue)
+        : null;
+    case "github-pr":
+      return tab.githubPr ? githubPrDetailTabFactory(tab.githubPr) : null;
+    case "session":
+    case null:
+      return null;
+  }
+}
+
+/** Move one losslessly representable Chat Panel tab into My Station. */
+export const moveChatPanelTabToWorkstationAtom = atom(
+  null,
+  (get, set, tabId: string): boolean => {
+    const tab = get(chatPanelTabsAtom).tabs.find(
+      (candidate) => candidate.id === tabId
+    );
+    if (!tab || !canMoveChatPanelTabToWorkstation(tab)) return false;
+
+    if (tab.type === "session" && tab.sessionId) {
+      return set(openSessionInWorkstationAtom, {
+        sessionId: tab.sessionId,
+        title: tab.title,
+      });
+    }
+
+    const workstationTab = createWorkstationDetailTab(tab);
+    if (!workstationTab) return false;
+
+    set(openWorkstationTabAtom, {
+      workspace: get(presentedWorkstationWorkspaceKeyAtom),
+      tab: workstationTab,
+    });
+    set(closeChatPanelTabAtom, tab.id);
+    set(chatPanelMaximizedAtom, false);
+    set(stationModeAtom, STATION_MODE.MY_STATION);
+    return true;
+  }
+);
+moveChatPanelTabToWorkstationAtom.debugLabel = "moveChatPanelTabToWorkstation";

--- a/src/store/chatPanel/chatPanelTabsAtom.ts
+++ b/src/store/chatPanel/chatPanelTabsAtom.ts
@@ -90,3 +90,7 @@ export {
   chatPanelTabCountAtom,
   chatPanelTabsAtom,
 } from "./chatPanelTabsState";
+export {
+  canMoveChatPanelTabToWorkstation,
+  moveChatPanelTabToWorkstationAtom,
+} from "./chatPanelTabPlacementAtom";

--- a/src/store/session/__tests__/sessionTabPlacementAtom.test.ts
+++ b/src/store/session/__tests__/sessionTabPlacementAtom.test.ts
@@ -11,6 +11,7 @@ import {
   workstationActiveSessionIdAtom,
 } from "@src/store/session/viewAtom";
 import { chatPanelMaximizedAtom } from "@src/store/ui/chatPanelAtom";
+import { STATION_MODE, stationModeAtom } from "@src/store/ui/simulatorAtom";
 import {
   createChatSessionTab,
   workstationLayoutAtom,
@@ -68,6 +69,7 @@ describe("session tab placement", () => {
       mainPane: { tabs: [], activeTabId: null },
     });
     store.set(chatPanelMaximizedAtom, true);
+    store.set(stationModeAtom, STATION_MODE.AGENT_STATION);
 
     const moved = store.set(moveSessionTabAtom, {
       source: "chat-panel",
@@ -92,6 +94,7 @@ describe("session tab placement", () => {
       ],
     });
     expect(store.get(chatPanelMaximizedAtom)).toBe(false);
+    expect(store.get(stationModeAtom)).toBe(STATION_MODE.MY_STATION);
     expect(store.get(activeSessionIdAtom)).toBe("session-1");
   });
 

--- a/src/store/session/sessionTabPlacementAtom.ts
+++ b/src/store/session/sessionTabPlacementAtom.ts
@@ -1,12 +1,11 @@
 import { atom } from "jotai";
 
 import type { SessionTabTransfer } from "@src/shared/dnd/sessionTabDrag";
-import {
-  chatPanelTabsAtom,
-  closeChatPanelTabAtom,
-  openOrFocusSessionInChatPanelTabAtom,
-} from "@src/store/chatPanel/chatPanelTabsAtom";
+import { closeChatPanelTabAtom } from "@src/store/chatPanel/chatPanelTabLifecycleAtoms";
+import { openOrFocusSessionInChatPanelTabAtom } from "@src/store/chatPanel/chatPanelTabOpenAtoms";
+import { chatPanelTabsAtom } from "@src/store/chatPanel/chatPanelTabsState";
 import { chatPanelMaximizedAtom } from "@src/store/ui/chatPanelAtom";
+import { STATION_MODE, stationModeAtom } from "@src/store/ui/simulatorAtom";
 import {
   closeTab,
   createChatSessionTab,
@@ -66,6 +65,7 @@ export const openSessionInWorkstationAtom = atom(
       ),
     });
     set(chatPanelMaximizedAtom, false);
+    set(stationModeAtom, STATION_MODE.MY_STATION);
     set(claimPipelineSessionAtom, sessionId);
     return true;
   }


### PR DESCRIPTION
## Problem

Chat Panel tab context menus only offer close actions, so users cannot move existing GitHub pull request, issue, or session tabs into My Station. The existing session move path also opens the workstation tab without switching away from Agent Station, which can leave the destination hidden.

## Solution

Add an exhaustive Chat Panel-to-My Station transfer policy for tabs with lossless first-class counterparts: GitHub pull requests, GitHub issues, and sessions. Eligible tab context menus now show **Move to My Station**. Detail tabs retain their complete payload, session moves continue through the canonical single-owner path, and every successful move reveals My Station and restores docked chat presentation. The existing session dropdown uses the same corrected session path, and its English label now matches the product term **My Station**.

## Potential risks

Moving a tab intentionally makes its My Station counterpart active in the currently presented workstation workspace and removes the Chat Panel owner. Unsupported tab types remain in the Chat Panel because they do not have a lossless counterpart. There are no persistence-schema, API, IPC, or dependency changes. Rollback is a revert of commit `656f09c75`. Native-menu behavior is unit-tested, but in-app visual verification and screenshots were not captured because desktop computer control was not authorized; the PR remains in Draft for that outstanding UI evidence.

## Architecture audit

Covered compilation boundaries, canonical state ownership, exhaustive tab-type eligibility, naming, failure behavior, entry-point parity, and cleanup. Wire-protocol and initialization layers were not applicable because this is a frontend presentation transfer with no serialized contract changes.

## Verification

- `pnpm exec vitest run src/store/chatPanel/__tests__/chatPanelTabPlacementAtom.test.ts src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts src/store/session/__tests__/sessionTabPlacementAtom.test.ts src/engines/ChatPanel/ChatPanelTabContextMenu.test.ts` — 52 tests passed
- Focused ESLint over all changed TypeScript and TSX files — passed with zero warnings
- `pnpm typecheck` — passed
- `pnpm check:circular` — passed; no circular dependencies across 6,551 modules
- Repository pre-commit gate — lint-staged and scoped TypeScript checks passed
- `git diff --check` — passed

## UI evidence

Not captured. The change uses the existing native context-menu system and localized session action copy, but desktop UI control requires explicit opt-in.