### PR TITLE
feat(browser): refine new tab experience

### DIFF
--- a/src/engines/BrowserCore/index.test.ts
+++ b/src/engines/BrowserCore/index.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import type { UseBrowserStateReturn } from "./hooks/useBrowserState";
+import BrowserCore from "./index";
+import type { BrowserSession } from "./types";
+
+vi.mock("jotai", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("jotai")>();
+  return {
+    ...actual,
+    useAtomValue: () => false,
+  };
+});
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@src/modules/shared/layouts/blocks", () => ({
+  Placeholder: ({
+    variant,
+    placement,
+    title,
+    subtitle,
+    fillParentHeight,
+    children,
+  }: {
+    variant: string;
+    placement: string;
+    title: string;
+    subtitle?: string;
+    fillParentHeight?: boolean;
+    children?: React.ReactNode;
+  }) =>
+    createElement(
+      "div",
+      {
+        "data-placeholder-variant": variant,
+        "data-placeholder-placement": placement,
+        "data-fill-parent-height": String(fillParentHeight),
+      },
+      title,
+      subtitle,
+      children
+    ),
+}));
+
+vi.mock("./BrowserSessionWebview", () => ({
+  default: () => null,
+}));
+
+function createBrowserState(
+  sessionOverrides: Partial<BrowserSession> = {}
+): UseBrowserStateReturn {
+  const session: BrowserSession = {
+    id: "browser-session-1",
+    url: "",
+    title: "New Tab",
+    history: [],
+    historyIndex: -1,
+    isLoading: false,
+    error: null,
+    ...sessionOverrides,
+  };
+
+  return {
+    sessions: [session],
+    activeSessionId: session.id,
+    activeSession: session,
+    addSession: vi.fn(),
+    closeSession: vi.fn(),
+    setActiveSession: vi.fn(),
+    updateSession: vi.fn(),
+  };
+}
+
+describe("BrowserCore blank tab placeholder", () => {
+  it("uses the standard detail-panel placeholder without the TLS note", () => {
+    const markup = renderToStaticMarkup(
+      createElement(BrowserCore, {
+        browserState: createBrowserState(),
+      })
+    );
+
+    expect(markup).toContain('data-placeholder-variant="empty"');
+    expect(markup).toContain('data-placeholder-placement="detail-panel"');
+    expect(markup).toContain('data-fill-parent-height="true"');
+    expect(markup).toContain("workstation.browserCore.enterUrlToStart");
+    expect(markup).not.toContain("workstation.browserCore.tlsDevNote");
+  });
+
+  it("keeps private-browsing and replay context in the shared placeholder", () => {
+    const markup = renderToStaticMarkup(
+      createElement(BrowserCore, {
+        browserState: createBrowserState({ incognito: true }),
+        showSimulatorNotice: true,
+      })
+    );
+
+    expect(markup).toContain(
+      "workstation.browserCore.privateBrowsingEmptyTitle"
+    );
+    expect(markup).toContain("workstation.browserCore.simulatorBrowserNotice");
+  });
+
+  it("renders a caller-provided complete blank-tab placeholder", () => {
+    const markup = renderToStaticMarkup(
+      createElement(BrowserCore, {
+        browserState: createBrowserState(),
+        blankTabPlaceholder: createElement(
+          "button",
+          { type: "button" },
+          "Open port 1998"
+        ),
+      })
+    );
+
+    expect(markup).toContain("Open port 1998");
+    expect(markup).not.toContain("workstation.browserCore.enterUrlToStart");
+  });
+
+  it("does not mount blank-tab options while hidden or after navigation", () => {
+    const option = createElement(
+      "button",
+      { type: "button" },
+      "Open port 1998"
+    );
+    const hiddenMarkup = renderToStaticMarkup(
+      createElement(BrowserCore, {
+        browserState: createBrowserState(),
+        blankTabPlaceholder: option,
+        hidden: true,
+      })
+    );
+    const navigatedMarkup = renderToStaticMarkup(
+      createElement(BrowserCore, {
+        browserState: createBrowserState({ url: "http://localhost:1998/" }),
+        blankTabPlaceholder: option,
+      })
+    );
+
+    expect(hiddenMarkup).not.toContain("Open port 1998");
+    expect(navigatedMarkup).not.toContain("Open port 1998");
+  });
+});

--- a/src/engines/BrowserCore/index.tsx
+++ b/src/engines/BrowserCore/index.tsx
@@ -15,8 +15,6 @@
 import { useAtomValue } from "jotai";
 import {
   CloudOff,
-  Globe,
-  HatGlasses,
   Monitor,
   RefreshCw,
   SquareArrowOutUpRight,
@@ -25,7 +23,6 @@ import React, { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
-import { EDITOR_TAB_CANVAS_BG_CLASS } from "@src/config/workstation/tokens";
 import { createLogger } from "@src/hooks/logger";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
 import { webviewBlockedAtom } from "@src/store/ui/overlayAtom";
@@ -79,6 +76,8 @@ export interface BrowserCoreProps {
   className?: string;
   /** Show simulator-specific notice */
   showSimulatorNotice?: boolean;
+  /** Optional complete placeholder shown only on a visible blank tab */
+  blankTabPlaceholder?: React.ReactNode;
   /** Force hide all webviews (e.g., when designer mode is active) */
   hidden?: boolean;
   /**
@@ -106,6 +105,7 @@ export const BrowserCore: React.FC<BrowserCoreProps> = ({
   respectModalBlocking = true,
   className = "",
   showSimulatorNotice = false,
+  blankTabPlaceholder,
   hidden = false,
   manageWebviews = true,
   bypassStationModeBlocking = false,
@@ -179,7 +179,6 @@ export const BrowserCore: React.FC<BrowserCoreProps> = ({
   ]);
 
   const isLoadingRaw = currentSession?.isLoading || false;
-  const isIncognito = currentSession?.incognito || false;
   const displayError = currentSession?.error || null;
   const currentUrl = currentSession?.url;
   const [embeddedFallbackUrl, setEmbeddedFallbackUrl] = React.useState<
@@ -246,37 +245,24 @@ export const BrowserCore: React.FC<BrowserCoreProps> = ({
             aria-hidden="true"
           />
           {shouldShowUrlPlaceholder && (
-            <div
-              className={`browser-native-info ${EDITOR_TAB_CANVAS_BG_CLASS}`}
-            >
-              <div className="browser-native-placeholder">
-                {isIncognito ? (
-                  <HatGlasses
-                    size={64}
-                    strokeWidth={1.5}
-                    className="text-warning-6 opacity-80"
-                  />
-                ) : (
-                  <Globe
-                    size={64}
-                    strokeWidth={1.5}
-                    className="text-primary-6 opacity-80"
-                  />
-                )}
-                <h3>
-                  {isIncognito
-                    ? t("workstation.browserCore.privateBrowsingEmptyTitle")
-                    : t("workstation.browserCore.enterUrlToStart")}
-                </h3>
-                {showSimulatorNotice && (
-                  <p className="mt-2 text-xs font-semibold text-text-3">
-                    {t("workstation.browserCore.simulatorBrowserNotice")}
-                  </p>
-                )}
-                <p className="mt-2 text-xs text-text-3">
-                  {t("workstation.browserCore.tlsDevNote")}
-                </p>
-              </div>
+            <div className="browser-native-info">
+              {blankTabPlaceholder ?? (
+                <Placeholder
+                  variant="empty"
+                  placement="detail-panel"
+                  title={
+                    currentSession?.incognito
+                      ? t("workstation.browserCore.privateBrowsingEmptyTitle")
+                      : t("workstation.browserCore.enterUrlToStart")
+                  }
+                  subtitle={
+                    showSimulatorNotice
+                      ? t("workstation.browserCore.simulatorBrowserNotice")
+                      : undefined
+                  }
+                  fillParentHeight
+                />
+              )}
             </div>
           )}
 

--- a/src/modules/WorkStation/Browser/Panels/BrowserMainPane/components/WebUrlBar/index.tsx
+++ b/src/modules/WorkStation/Browser/Panels/BrowserMainPane/components/WebUrlBar/index.tsx
@@ -17,14 +17,12 @@ import {
   PenTool,
   PencilRuler,
   RefreshCw,
-  Search,
   X,
 } from "lucide-react";
 import React, { memo, useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
-import { FaviconIcon } from "@src/components/FaviconIcon";
 import { useTauriSelectAllShortcut } from "@src/hooks/keyboard";
 import {
   type WorkstationTabHeaderHost,
@@ -314,7 +312,7 @@ export const WebUrlBar: React.FC<WebUrlBarProps> = memo(
     );
 
     const inputContainerClass =
-      "relative flex h-7 min-w-0 flex-1 cursor-text items-center rounded-lg border border-transparent bg-transparent transition-[border-color,box-shadow,background-color] duration-150 hover:border-border-3 hover:bg-fill-2 focus-within:border-primary-6 focus-within:bg-fill-2 focus-within:shadow-[0_0_0_2px_color-mix(in_srgb,var(--color-primary-6)_15%,transparent)]";
+      "relative flex h-7 min-w-0 flex-1 cursor-text items-center rounded-lg border border-transparent bg-transparent transition-[border-color,box-shadow,background-color] duration-150 focus-within:border-primary-6 focus-within:bg-fill-2 focus-within:shadow-[0_0_0_2px_color-mix(in_srgb,var(--color-primary-6)_30%,transparent)] [&:not(:focus-within):hover]:border-border-3 [&:not(:focus-within):hover]:bg-fill-2";
     const reloadControlLabel = isLoading
       ? t("common:actions.stop")
       : t("common:actions.reload");
@@ -384,26 +382,6 @@ export const WebUrlBar: React.FC<WebUrlBarProps> = memo(
             }
           }}
         >
-          {/* Icon on left */}
-          <div className="pointer-events-none absolute left-3 flex items-center">
-            {inputValue ? (
-              <FaviconIcon
-                url={inputValue}
-                isIncognito={false}
-                isLoading={isLoading}
-                size={16}
-                fallbackColor="text-text-3"
-              />
-            ) : isLoading ? (
-              <Loader2
-                size={14}
-                className="shrink-0 animate-spin text-text-3"
-              />
-            ) : (
-              <Search size={14} className="shrink-0 text-text-3" />
-            )}
-          </div>
-
           {/* Input - keep real text selectable in both focused and unfocused states. */}
           <input
             ref={inputRef}
@@ -422,7 +400,7 @@ export const WebUrlBar: React.FC<WebUrlBarProps> = memo(
             onMouseMove={handleInputMouseMove}
             onMouseUp={handleInputMouseUp}
             placeholder={t("placeholders.enterUrlOrSearch")}
-            className="relative z-10 h-7 min-w-0 flex-1 select-text border-none bg-transparent pl-9 pr-3 text-[14px] text-text-1 outline-none placeholder:text-text-3"
+            className="relative z-10 h-7 min-w-0 flex-1 select-text border-none bg-transparent px-3 text-[14px] text-text-1 outline-none placeholder:text-text-3"
             style={NO_DRAG_STYLE}
             autoComplete="off"
             autoCorrect="off"

--- a/src/modules/WorkStation/Browser/Panels/BrowserMainPane/content/WebViewportContent/BlankTabPortOptions.test.ts
+++ b/src/modules/WorkStation/Browser/Panels/BrowserMainPane/content/WebViewportContent/BlankTabPortOptions.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import type { WorkspacePort } from "@src/api/tauri/workspacePorts";
+import { workspacePortsStateAtom } from "@src/store/workstation/codeEditor/workspacePortsAtom";
+
+import BlankTabPortOptions, {
+  BLANK_TAB_PORT_OPTION_LIMIT,
+} from "./BlankTabPortOptions";
+
+const mocks = vi.hoisted(() => ({ invoke: vi.fn() }));
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke: mocks.invoke }));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: { pid?: number }) =>
+      values?.pid == null ? key : `${key}:${values.pid}`,
+  }),
+}));
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+function createPort(
+  port: number,
+  kind: WorkspacePort["kind"] = "workspace"
+): WorkspacePort {
+  return {
+    id: `${kind}-${port}`,
+    bindHost: "0.0.0.0",
+    connectHost: "localhost",
+    port,
+    pid: port,
+    processName: `process-${port}`,
+    protocol: "http",
+    kind,
+    owner:
+      kind === "workspace"
+        ? {
+            folderId: "folder-1",
+            repoId: "repo-1",
+            displayName: "ORGII",
+            path: "/workspace/orgii",
+            confidence: "cwd",
+          }
+        : undefined,
+  };
+}
+
+describe("BlankTabPortOptions", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(reactActEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("shows a bounded cached workspace-port list and opens the selected URL", () => {
+    const store = createStore();
+    const workspacePorts = Array.from(
+      { length: BLANK_TAB_PORT_OPTION_LIMIT + 2 },
+      (_, index) => createPort(1998 + index)
+    );
+    store.set(workspacePortsStateAtom, {
+      result: {
+        platform: "test",
+        scannedAt: 1,
+        ports: [...workspacePorts, createPort(5432, "external")],
+      },
+      refreshing: false,
+      lastScanStartedAt: 1,
+    });
+    const onOpen = vi.fn();
+
+    act(() => {
+      root.render(
+        createElement(
+          Provider,
+          { store },
+          createElement(BlankTabPortOptions, { onOpen })
+        )
+      );
+    });
+
+    const options = container.querySelectorAll("button");
+    expect(options).toHaveLength(BLANK_TAB_PORT_OPTION_LIMIT);
+    expect(container.textContent).not.toContain("5432");
+
+    act(() => options[0].click());
+    expect(onOpen).toHaveBeenCalledOnce();
+    expect(onOpen).toHaveBeenCalledWith("http://localhost:1998/");
+    expect(mocks.invoke).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/WorkStation/Browser/Panels/BrowserMainPane/content/WebViewportContent/BlankTabPortOptions.tsx
+++ b/src/modules/WorkStation/Browser/Panels/BrowserMainPane/content/WebViewportContent/BlankTabPortOptions.tsx
@@ -1,0 +1,95 @@
+import { useAtomValue } from "jotai";
+import { SquareArrowOutUpRight } from "lucide-react";
+import React, { memo, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { WorkspacePort } from "@src/api/tauri/workspacePorts";
+import {
+  DROPDOWN_CLASSES,
+  DROPDOWN_ITEM,
+} from "@src/components/Dropdown/tokens";
+import {
+  addressForPort,
+  browserUrlForPort,
+  workspacePortsAtom,
+} from "@src/store/workstation/codeEditor/workspacePortsAtom";
+
+export const BLANK_TAB_PORT_OPTION_LIMIT = 6;
+
+export function selectBlankTabPortOptions(
+  ports: WorkspacePort[]
+): WorkspacePort[] {
+  return ports
+    .filter((port) => port.kind === "workspace")
+    .slice(0, BLANK_TAB_PORT_OPTION_LIMIT);
+}
+
+interface BlankTabPortOptionsProps {
+  onOpen: (url: string) => void;
+}
+
+const BlankTabPortOptions: React.FC<BlankTabPortOptionsProps> = memo(
+  ({ onOpen }) => {
+    const { t } = useTranslation();
+    const scannedPorts = useAtomValue(workspacePortsAtom);
+    const ports = useMemo(
+      () => selectBlankTabPortOptions(scannedPorts),
+      [scannedPorts]
+    );
+
+    if (ports.length === 0) {
+      return null;
+    }
+
+    return (
+      <div className="mt-4 w-80 max-w-full text-left">
+        <div className="mb-1 px-1.5 text-xs font-medium text-text-3">
+          {t("workstation.ports.workspaceSection")} · {ports.length}
+        </div>
+        <div className="flex flex-col gap-0.5">
+          {ports.map((port) => {
+            const address = addressForPort(port);
+            const processLabel =
+              port.processName ??
+              (port.pid != null
+                ? t("workstation.ports.pidLabel", { pid: port.pid })
+                : t("workstation.ports.unknownProcess"));
+            const openLabel = `${t("workstation.ports.openInBrowser")}: ${address}`;
+
+            return (
+              <button
+                key={port.id}
+                type="button"
+                className={`${DROPDOWN_CLASSES.menuControlItem} cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-6/30`}
+                aria-label={openLabel}
+                title={openLabel}
+                onClick={() => onOpen(browserUrlForPort(port))}
+              >
+                <span className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
+                  <span className="shrink-0 font-medium text-text-1">
+                    {port.port}
+                  </span>
+                  <span className="min-w-0 flex-1 truncate text-text-2">
+                    {processLabel}
+                  </span>
+                  <span className="w-28 shrink-0 truncate text-text-3">
+                    {address}
+                  </span>
+                </span>
+                <SquareArrowOutUpRight
+                  size={DROPDOWN_ITEM.iconSize}
+                  className="shrink-0 text-text-3"
+                  aria-hidden
+                />
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+);
+
+BlankTabPortOptions.displayName = "BlankTabPortOptions";
+
+export default BlankTabPortOptions;

--- a/src/modules/WorkStation/Browser/Panels/BrowserMainPane/content/WebViewportContent/BrowserBlankTabPlaceholder.test.ts
+++ b/src/modules/WorkStation/Browser/Panels/BrowserMainPane/content/WebViewportContent/BrowserBlankTabPlaceholder.test.ts
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+import { Provider, createStore } from "jotai";
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import type { WorkspacePort } from "@src/api/tauri/workspacePorts";
+import {
+  workStationBrowserSidebarCollapsedAtom,
+  workStationBrowserSidebarCollapsedPersistAtom,
+} from "@src/store/ui/workStationAtom";
+import { workspacePortsStateAtom } from "@src/store/workstation/codeEditor/workspacePortsAtom";
+
+import BrowserBlankTabPlaceholder from "./BrowserBlankTabPlaceholder";
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@src/modules/WorkStation/shared", () => ({
+  NoTabsPlaceholder: ({
+    icon,
+    caption,
+    actions,
+    children,
+  }: {
+    icon: string;
+    caption?: string;
+    actions?: Array<{
+      id: string;
+      label: string;
+      shortcut?: string;
+      onAction?: () => void;
+    }>;
+    children?: React.ReactNode;
+  }) =>
+    createElement(
+      "div",
+      { "data-placeholder-icon": icon, "data-caption": caption },
+      actions?.map((action) =>
+        createElement(
+          "button",
+          {
+            key: action.id,
+            type: "button",
+            "data-action-id": action.id,
+            "data-shortcut": action.shortcut,
+            onClick: action.onAction,
+          },
+          action.label
+        )
+      ),
+      children
+    ),
+}));
+
+vi.mock(
+  "@src/modules/WorkStation/shared/StatusBar/WorkspacePortScanner",
+  () => ({
+    WorkspacePortScanner: ({ enabled }: { enabled: boolean }) =>
+      createElement("span", {
+        "data-testid": "workspace-port-scanner",
+        "data-enabled": String(enabled),
+      }),
+  })
+);
+
+function createWorkspacePort(): WorkspacePort {
+  return {
+    id: "workspace-1998",
+    bindHost: "0.0.0.0",
+    connectHost: "localhost",
+    port: 1998,
+    pid: 1998,
+    processName: "node",
+    protocol: "http",
+    kind: "workspace",
+    owner: {
+      folderId: "folder-1",
+      repoId: "repo-1",
+      displayName: "ORGII",
+      path: "/workspace/orgii",
+      confidence: "cwd",
+    },
+  };
+}
+
+describe("BrowserBlankTabPlaceholder", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(reactActEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("shows the browser sidebar shortcut and cached scanned ports", () => {
+    const store = createStore();
+    store.set(workStationBrowserSidebarCollapsedPersistAtom, false);
+    store.set(workspacePortsStateAtom, {
+      result: {
+        platform: "test",
+        scannedAt: 1,
+        ports: [createWorkspacePort()],
+      },
+      refreshing: false,
+      lastScanStartedAt: 1,
+    });
+    const onOpen = vi.fn();
+
+    act(() => {
+      root.render(
+        createElement(
+          Provider,
+          { store },
+          createElement(BrowserBlankTabPlaceholder, { onOpen })
+        )
+      );
+    });
+
+    expect(
+      container
+        .querySelector('[data-testid="workspace-port-scanner"]')
+        ?.getAttribute("data-enabled")
+    ).toBe("true");
+    expect(container.querySelector('[data-placeholder-icon="browser"]')).not
+      .toBeNull;
+
+    const sidebarAction = container.querySelector<HTMLButtonElement>(
+      '[data-action-id="toggle-browser-sidebar"]'
+    );
+    expect(sidebarAction?.textContent).toBe("commands.hidePrimarySidebar");
+    expect(sidebarAction?.dataset.shortcut).toBeTruthy();
+
+    act(() => sidebarAction?.click());
+    expect(store.get(workStationBrowserSidebarCollapsedAtom)).toBe(true);
+
+    const portAction = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent?.includes("1998")
+    );
+    act(() => portAction?.click());
+    expect(onOpen).toHaveBeenCalledWith("http://localhost:1998/");
+  });
+});

--- a/src/modules/WorkStation/Browser/Panels/BrowserMainPane/content/WebViewportContent/BrowserBlankTabPlaceholder.tsx
+++ b/src/modules/WorkStation/Browser/Panels/BrowserMainPane/content/WebViewportContent/BrowserBlankTabPlaceholder.tsx
@@ -1,0 +1,67 @@
+import { useAtomValue, useSetAtom } from "jotai";
+import React, { memo, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+
+import { getShortcutKeys } from "@src/config/keyboard/shortcutDisplay";
+import {
+  NoTabsPlaceholder,
+  type QuickAction,
+} from "@src/modules/WorkStation/shared";
+import { WorkspacePortScanner } from "@src/modules/WorkStation/shared/StatusBar/WorkspacePortScanner";
+import {
+  workStationBrowserSidebarCollapsedAtom,
+  workStationBrowserSidebarCollapsedPersistAtom,
+} from "@src/store/ui/workStationAtom";
+
+import BlankTabPortOptions from "./BlankTabPortOptions";
+
+interface BrowserBlankTabPlaceholderProps {
+  isIncognito?: boolean;
+  onOpen: (url: string) => void;
+}
+
+const BrowserBlankTabPlaceholder: React.FC<BrowserBlankTabPlaceholderProps> =
+  memo(({ isIncognito = false, onOpen }) => {
+    const { t } = useTranslation();
+    const sidebarCollapsed = useAtomValue(
+      workStationBrowserSidebarCollapsedAtom
+    );
+    const setSidebarCollapsed = useSetAtom(
+      workStationBrowserSidebarCollapsedPersistAtom
+    );
+
+    const actions = useMemo<QuickAction[]>(
+      () => [
+        {
+          id: "toggle-browser-sidebar",
+          label: sidebarCollapsed
+            ? t("commands.showPrimarySidebar")
+            : t("commands.hidePrimarySidebar"),
+          shortcut: getShortcutKeys("browser_sidebar"),
+          onAction: () => setSidebarCollapsed("toggle"),
+        },
+      ],
+      [setSidebarCollapsed, sidebarCollapsed, t]
+    );
+
+    return (
+      <>
+        <WorkspacePortScanner enabled />
+        <NoTabsPlaceholder
+          icon="browser"
+          caption={
+            isIncognito
+              ? t("workstation.browserCore.privateBrowsingEmptyTitle")
+              : undefined
+          }
+          actions={actions}
+        >
+          <BlankTabPortOptions onOpen={onOpen} />
+        </NoTabsPlaceholder>
+      </>
+    );
+  });
+
+BrowserBlankTabPlaceholder.displayName = "BrowserBlankTabPlaceholder";
+
+export default BrowserBlankTabPlaceholder;

--- a/src/modules/WorkStation/Browser/Panels/BrowserMainPane/content/WebViewportContent/index.tsx
+++ b/src/modules/WorkStation/Browser/Panels/BrowserMainPane/content/WebViewportContent/index.tsx
@@ -8,11 +8,9 @@ import BrowserCore from "@/src/engines/BrowserCore";
 import type { UseBrowserStateReturn } from "@/src/engines/BrowserCore/hooks/useBrowserState";
 import { TabBar, type WorkStationTab } from "@/src/modules/WorkStation/shared";
 import { useSetAtom } from "jotai";
-import { Globe, HatGlasses } from "lucide-react";
 import React, { memo, useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-import { EDITOR_TAB_CANVAS_BG_CLASS } from "@src/config/workstation/tokens";
 import type { WorkstationTabHeaderHost } from "@src/hooks/tabHost/useWorkstationTabHeader";
 import { getSiteNameFromUrl } from "@src/store/ui/navigationSidebarTabsAtom";
 import {
@@ -25,13 +23,7 @@ import {
 
 import { useWebviewScreenshot } from "../../../../hooks/useWebviewScreenshot";
 import WebUrlBar, { focusBrowserUrlBar } from "../../components/WebUrlBar";
-
-const ABOUT_BLANK_URL = "about:blank";
-
-function isBlankBrowserUrl(url?: string): boolean {
-  const normalizedUrl = url?.trim().toLowerCase();
-  return !normalizedUrl || normalizedUrl.startsWith(ABOUT_BLANK_URL);
-}
+import BrowserBlankTabPlaceholder from "./BrowserBlankTabPlaceholder";
 
 // ============================================
 // Types
@@ -284,9 +276,6 @@ export const WebViewport: React.FC<WebViewportProps> = memo(
       webviewLabel: activeWebviewLabel,
     });
 
-    const shouldShowBlankTabPlaceholder =
-      !hideWebviews && activeSession && isBlankBrowserUrl(activeSession.url);
-
     return (
       <div className="flex h-full w-full flex-col overflow-hidden">
         {/* Tab Bar - uses the same component as Code Editor and Database Explorer */}
@@ -335,36 +324,15 @@ export const WebViewport: React.FC<WebViewportProps> = memo(
             respectModalBlocking={respectModalBlocking}
             manageWebviews={manageWebviews}
             hidden={hideWebviews}
+            blankTabPlaceholder={
+              publishUrlBarToHost === "browser" ? (
+                <BrowserBlankTabPlaceholder
+                  isIncognito={activeSession?.incognito}
+                  onOpen={handleNavigate}
+                />
+              ) : undefined
+            }
           />
-          {shouldShowBlankTabPlaceholder && (
-            <div
-              className={`absolute inset-0 z-30 flex items-center justify-center p-6 ${EDITOR_TAB_CANVAS_BG_CLASS}`}
-            >
-              <div className="flex max-w-[400px] flex-col items-center gap-4 text-center">
-                {activeSession.incognito ? (
-                  <HatGlasses
-                    size={64}
-                    strokeWidth={1.5}
-                    className="text-warning-6 opacity-80"
-                  />
-                ) : (
-                  <Globe
-                    size={64}
-                    strokeWidth={1.5}
-                    className="text-primary-6 opacity-80"
-                  />
-                )}
-                <h3 className="m-0 text-[20px] font-semibold text-text-1">
-                  {activeSession.incognito
-                    ? t("workstation.browserCore.privateBrowsingEmptyTitle")
-                    : t("workstation.browserCore.enterUrlToStart")}
-                </h3>
-                <p className="m-0 text-[14px] leading-relaxed text-text-2">
-                  {t("workstation.browserCore.tlsDevNote")}
-                </p>
-              </div>
-            </div>
-          )}
         </div>
       </div>
     );

--- a/src/modules/WorkStation/shared/NoTabsPlaceholder/NoTabsPlaceholder.test.ts
+++ b/src/modules/WorkStation/shared/NoTabsPlaceholder/NoTabsPlaceholder.test.ts
@@ -1,0 +1,32 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { NoTabsPlaceholder } from "./index";
+
+describe("NoTabsPlaceholder", () => {
+  it("renders contextual content below its shortcut actions", () => {
+    const markup = renderToStaticMarkup(
+      createElement(
+        NoTabsPlaceholder,
+        {
+          icon: "browser",
+          actions: [
+            {
+              id: "toggle-sidebar",
+              label: "Hide Sidebar",
+              shortcut: "Ctrl+Alt+U",
+            },
+          ],
+        },
+        createElement("button", { type: "button" }, "Open port 1998")
+      )
+    );
+
+    expect(markup).toContain("Hide Sidebar");
+    expect(markup).toContain("Open port 1998");
+    expect(markup.indexOf("Open port 1998")).toBeGreaterThan(
+      markup.indexOf("Hide Sidebar")
+    );
+  });
+});

--- a/src/modules/WorkStation/shared/NoTabsPlaceholder/index.tsx
+++ b/src/modules/WorkStation/shared/NoTabsPlaceholder/index.tsx
@@ -56,6 +56,8 @@ export interface NoTabsPlaceholderProps {
   actions?: QuickAction[];
   /** Optional click handler for actions */
   onActionClick?: (action: QuickAction) => void;
+  /** Optional contextual content rendered below the shortcut actions */
+  children?: React.ReactNode;
 }
 
 // ============================================
@@ -152,7 +154,7 @@ ToolIcon.displayName = "ToolIcon";
 // ============================================
 
 export const NoTabsPlaceholder: React.FC<NoTabsPlaceholderProps> = memo(
-  ({ icon, caption, actions, onActionClick }) => {
+  ({ icon, caption, actions, onActionClick, children }) => {
     return (
       <div
         className={`flex h-full w-full items-center justify-center ${EDITOR_TAB_CANVAS_BG_CLASS}`}
@@ -179,6 +181,8 @@ export const NoTabsPlaceholder: React.FC<NoTabsPlaceholderProps> = memo(
               ))}
             </div>
           )}
+
+          {children}
         </div>
       </div>
     );


### PR DESCRIPTION
## Problem

The browser blank tab used a duplicated custom empty state instead of the standard workstation NoTabsPlaceholder shown by tools such as the editor. Replacing only the visual shell still left no default shortcut rows.

The scanned-port child also disappeared whenever its cache was empty. The authoritative workspace-port scanner was mounted only in visible Code mode, so opening Browser first could never populate that cache. The URL field additionally reserved icon space and used a faint 15% primary-6 focus halo.

## Solution

The visible My Station browser blank tab now renders the shared NoTabsPlaceholder with the browser icon, the current Show or Hide Sidebar action, and the configured browser-sidebar keyboard shortcut. NoTabsPlaceholder accepts optional contextual content below its standard actions, where the browser renders up to six workspace-owned scanned ports as accessible openable buttons.

A BrowserBlankTabPlaceholder owns the existing WorkspacePortScanner only while the active My Station tab is blank and visible. It performs the existing initial scan and visibility-aware 60-second refresh, then unmounts and clears that lifecycle as soon as the browser is hidden or navigates away. Embedded and simulator browser hosts do not create another scanner.

The URL input no longer renders a search, favicon, or loading icon. Its padding is tightened, its primary-6 halo is increased to 30%, and neutral hover styling applies only while the field is not focused.

Regression coverage verifies the standard shortcut placeholder, browser-sidebar state toggle, scanner ownership, cached port rendering and navigation, the six-item workspace-only bound, and blank-tab unmounting after hide or navigation.

## Potential risks

- A visible blank Browser tab now performs workspace-port discovery. This uses the existing scanner cadence and process-listing IPC, stops when the tab is hidden or navigated, and pauses its interval while the document is hidden.
- Port options can remain stale until the next normal refresh and are intentionally bounded to six workspace-owned entries.
- Removing the URL-field icon also removes its inline favicon and loading indication; the existing reload or stop control remains available.
- The shared NoTabsPlaceholder gains an optional child slot. Existing consumers do not pass children and retain their current markup.
- Navigation reuses the current-tab path, so existing URL normalization behavior remains unchanged.
- No persistence, schema, wire protocol, dependency, or configuration format changes are included.
- Rollback is a single-commit revert of bd34ea11e.
- An interactive Tauri visual check and after-change screenshots were not produced because desktop computer control requires explicit opt-in and was not authorized for this task.

## Performance audit

| Area | Verdict | Evidence | Change or reason kept | Verification |
| --- | --- | --- | --- | --- |
| Background work | keep | Existing WorkspacePortScanner owns one immediate scan plus a 60-second visibility-aware interval | Mounted only inside the visible My Station blank-tab placeholder; navigation, hiding, or unmount disposes it | BrowserCore tests prove the placeholder is absent while hidden and after navigation; integration test proves one enabled scanner |
| Memory | keep | Port options derive from atom state and slice to six | Fixed upper render bound with no new retained cache | Selection test covers the six-item cap |
| Scope or isolation | keep | Filter requires port.kind to equal workspace | External ports are excluded and embedded hosts do not mount the placeholder | Port test includes and excludes an external port |
| Rendering or hot path | keep | Blank tab subscribes only to sidebar state and cached port state | No scan result cloning beyond the bounded filter and no content after navigation | Focused component tests pass |

Performance verdict: pass.

## UI consistency review

The frontend-ui-audit skill is unavailable in this workspace, so its intent was applied manually. The implementation now reuses NoTabsPlaceholder, KeyboardShortcut, Dropdown tokens, semantic buttons, and keyboard focus rings instead of maintaining a second browser-specific empty-state pattern.

## Verification

Passed on the final branch rebased onto the latest origin/develop:

- npm run typecheck
- npx vitest run src/engines/BrowserCore/index.test.ts src/modules/WorkStation/Browser/Panels/BrowserMainPane/content/WebViewportContent/BlankTabPortOptions.test.ts src/modules/WorkStation/Browser/Panels/BrowserMainPane/content/WebViewportContent/BrowserBlankTabPlaceholder.test.ts src/modules/WorkStation/shared/NoTabsPlaceholder/NoTabsPlaceholder.test.ts — 4 files, 7 tests passed
- npx eslint over the ten changed TypeScript files with --max-warnings 0 and --report-unused-disable-directives
- npx prettier --check over the ten changed TypeScript files
- git diff --check origin/develop...HEAD
- The focused Vitest command and npm run typecheck were repeated after rebasing onto the latest origin/develop

Not run: the full Vitest suite, production build, and interactive desktop visual verification. The focused suites and static checks cover the changed ownership and lifecycle boundaries; runtime visual evidence remains for reviewer or authorized manual validation.