### PR TITLE
fix(workstation): polish GitHub detail headers

### DIFF
--- a/src/components/Button/presentation.tsx
+++ b/src/components/Button/presentation.tsx
@@ -117,7 +117,7 @@ function getButtonStyleClasses(
         case "secondary":
           return "enabled:hover:bg-fill-3";
         case "tertiary":
-          return "enabled:hover:text-text-1 enabled:hover:bg-surface-hover focus-visible:text-text-1 focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_color-mix(in_srgb,var(--color-primary-6)_15%,transparent)]";
+          return "enabled:hover:text-text-1 enabled:hover:bg-surface-hover enabled:active:bg-surface-selected focus-visible:text-text-1 focus-visible:outline-none focus-visible:shadow-[0_0_0_2px_color-mix(in_srgb,var(--color-primary-6)_15%,transparent)]";
       }
     }
     if (appearance === "outline" || appearance === "dashed") {

--- a/src/engines/ChatPanel/panels/WorkItemPanelView.tsx
+++ b/src/engines/ChatPanel/panels/WorkItemPanelView.tsx
@@ -36,6 +36,7 @@ import {
   PropertiesRailFrame,
 } from "@src/modules/ProjectManager/shared";
 import { WorkstationToolbarTooltip } from "@src/modules/WorkStation/shared";
+import { ExternalBrowserButton } from "@src/modules/WorkStation/shared/ExternalBrowserButton";
 import {
   DetailHeaderTabs,
   WorkstationTrailIconButton,
@@ -361,6 +362,7 @@ export const WorkItemPanelView: React.FC<WorkItemPanelViewProps> = ({
     shortId: selectedWorkItem.shortId,
     stateScopeKey: `chat-panel-work-item:${selectedWorkItem.orgId ?? "local"}:${selectedWorkItem.projectSlug}:${selectedWorkItem.shortId}`,
   });
+  const githubIssueExternalUrl = githubIssueState.externalUrl;
   const projectSelectionReadonly =
     Boolean(selectedWorkItem.projectSlug) &&
     (projectSyncAdapterId === undefined || isGitHubSyncedProject);
@@ -424,6 +426,12 @@ export const WorkItemPanelView: React.FC<WorkItemPanelViewProps> = ({
             />
           </WorkstationToolbarTooltip>
         ) : null}
+        {githubIssueExternalUrl ? (
+          <ExternalBrowserButton
+            href={githubIssueExternalUrl}
+            dataTestId="chat-panel-work-item-open-external"
+          />
+        ) : null}
         <WorkstationToolbarTooltip label={propertiesToggleLabel}>
           <Button
             htmlType="button"
@@ -443,6 +451,7 @@ export const WorkItemPanelView: React.FC<WorkItemPanelViewProps> = ({
     ),
     [
       handleDeleteWorkItem,
+      githubIssueExternalUrl,
       isGitHubSyncedProject,
       projectSyncAdapterId,
       propertiesOpen,

--- a/src/engines/ChatPanel/panels/useWorkItemGitHubIssueState.test.ts
+++ b/src/engines/ChatPanel/panels/useWorkItemGitHubIssueState.test.ts
@@ -75,6 +75,7 @@ function Probe({
     "data-has-interaction": String(Boolean(state.interaction)),
     "data-loading": String(state.interaction?.loading),
     "data-timeline-count": String(state.timeline?.items.length ?? 0),
+    "data-external-url": state.externalUrl ?? "",
   });
 }
 
@@ -104,7 +105,12 @@ describe("useWorkItemGitHubIssueState", () => {
         remoteUrl?: string;
       }) => ({
         selectedState: {
-          issue: remoteUrl ? { number: issueNumber } : null,
+          issue: remoteUrl
+            ? {
+                number: issueNumber,
+                html_url: `https://github.com/org2AI/ORG2/issues/${issueNumber}`,
+              }
+            : null,
           timeline: remoteUrl ? [{ id: 1, event: "commented" }] : [],
           loading: false,
           timelineLoading: false,
@@ -175,6 +181,11 @@ describe("useWorkItemGitHubIssueState", () => {
         .querySelector("[data-testid='probe']")
         ?.getAttribute("data-timeline-count")
     ).toBe("1");
+    expect(
+      container
+        .querySelector("[data-testid='probe']")
+        ?.getAttribute("data-external-url")
+    ).toBe("https://github.com/org2AI/ORG2/issues/705");
   });
 
   it("does not resolve or expose GitHub state for local Work Items", () => {
@@ -186,6 +197,11 @@ describe("useWorkItemGitHubIssueState", () => {
         .querySelector("[data-testid='probe']")
         ?.getAttribute("data-has-interaction")
     ).toBe("false");
+    expect(
+      container
+        .querySelector("[data-testid='probe']")
+        ?.getAttribute("data-external-url")
+    ).toBe("");
   });
 
   it("does not expose a dead composer when no GitHub remote resolves", async () => {

--- a/src/engines/ChatPanel/panels/useWorkItemGitHubIssueState.ts
+++ b/src/engines/ChatPanel/panels/useWorkItemGitHubIssueState.ts
@@ -16,6 +16,7 @@ interface RemoteResolutionState {
 }
 
 interface WorkItemGitHubIssueState {
+  externalUrl?: string;
   timeline?: {
     items: GitHubIssueTimelineItem[];
     loading: boolean;
@@ -104,6 +105,9 @@ export function useWorkItemGitHubIssueState({
   );
 
   return {
+    externalUrl: hasMatchingIssue
+      ? detailState.selectedState.issue?.html_url
+      : undefined,
     timeline: {
       items: hasMatchingIssue ? detailState.selectedState.timeline : [],
       loading:

--- a/src/modules/MainApp/TeamInbox/__tests__/AssignedWorkItemDetail.test.ts
+++ b/src/modules/MainApp/TeamInbox/__tests__/AssignedWorkItemDetail.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { Globe, SquareArrowOutUpRight } from "lucide-react";
+import { Chrome, SquareArrowOutUpRight } from "lucide-react";
 import React, { act, createElement } from "react";
 import { type Root, createRoot } from "react-dom/client";
 import {
@@ -294,8 +294,8 @@ describe("AssignedWorkItemDetail navigation actions", () => {
           testId: string;
         }
       | undefined;
-    expect(browserAction?.label).toBe("previews.openInBrowser");
-    expect(browserAction?.icon.type).toBe(Globe);
+    expect(browserAction?.label).toBe("previews.openInExternalBrowser");
+    expect(browserAction?.icon.type).toBe(Chrome);
     expect(browserAction?.testId).toBe("team-inbox-open-github");
     const headerContent = mocks.detailLayoutProps?.headerContent;
     expect(React.isValidElement(headerContent)).toBe(true);
@@ -365,7 +365,7 @@ describe("AssignedWorkItemDetail navigation actions", () => {
     const browserAction = mocks.detailLayoutProps?.headerAuxiliaryAction as
       | { label: string; onClick: () => void }
       | undefined;
-    expect(browserAction?.label).toBe("previews.openInBrowser");
+    expect(browserAction?.label).toBe("previews.openInExternalBrowser");
     act(() => browserAction?.onClick());
     expect(mocks.openExternalLink).toHaveBeenCalledWith(
       "https://github.com/org2AI/ORG2/issues/61"

--- a/src/modules/MainApp/TeamInbox/__tests__/TeamInboxView.layout.test.ts
+++ b/src/modules/MainApp/TeamInbox/__tests__/TeamInboxView.layout.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { Globe, SquareArrowOutUpRight } from "lucide-react";
+import { Chrome, SquareArrowOutUpRight } from "lucide-react";
 import React, { act, createElement } from "react";
 import { type Root, createRoot } from "react-dom/client";
 import {
@@ -477,8 +477,8 @@ describe("TeamInboxView split layout", () => {
         testId: string;
       }>
     >;
-    expect(browserAction.props.label).toBe("previews.openInBrowser");
-    expect(browserAction.props.icon.type).toBe(Globe);
+    expect(browserAction.props.label).toBe("previews.openInExternalBrowser");
+    expect(browserAction.props.icon.type).toBe(Chrome);
     expect(browserAction.props.testId).toBe("team-inbox-open-github-pr");
     expect(tabAction.props.label).toBe("teamInbox.actions.openPullRequest");
     expect(tabAction.props.icon.type).toBe(SquareArrowOutUpRight);

--- a/src/modules/MainApp/TeamInbox/components/AssignedWorkItemDetail.tsx
+++ b/src/modules/MainApp/TeamInbox/components/AssignedWorkItemDetail.tsx
@@ -1,4 +1,4 @@
-import { ClipboardList, Globe, SquareArrowOutUpRight } from "lucide-react";
+import { Chrome, ClipboardList, SquareArrowOutUpRight } from "lucide-react";
 import React from "react";
 import { useTranslation } from "react-i18next";
 
@@ -357,8 +357,8 @@ const AssignedWorkItemDetail: React.FC<AssignedWorkItemDetailProps> = ({
       headerAuxiliaryAction={
         githubIssueUrl
           ? {
-              label: t("previews.openInBrowser"),
-              icon: <Globe size={14} strokeWidth={1.75} aria-hidden />,
+              label: t("previews.openInExternalBrowser"),
+              icon: <Chrome size={14} strokeWidth={1.75} aria-hidden />,
               onClick: () => void openExternalLink(githubIssueUrl),
               testId: "team-inbox-open-github",
             }

--- a/src/modules/MainApp/TeamInbox/components/TeamInboxDetailPane.tsx
+++ b/src/modules/MainApp/TeamInbox/components/TeamInboxDetailPane.tsx
@@ -5,7 +5,7 @@
  * load/empty placeholders, or the detail for the selected Inbox row.
  */
 import type { TFunction } from "i18next";
-import { Globe, SquareArrowOutUpRight } from "lucide-react";
+import { Chrome, SquareArrowOutUpRight } from "lucide-react";
 import React from "react";
 
 import type { ManagedPrItem } from "@src/modules/MainApp/WorkManagement/githubManagedItemModel";
@@ -74,8 +74,8 @@ export const TeamInboxDetailPane: React.FC<TeamInboxDetailPaneProps> = ({
               data-testid="team-inbox-pr-detail-actions"
             >
               <TeamInboxHeaderIconAction
-                label={t("previews.openInBrowser")}
-                icon={<Globe size={14} strokeWidth={1.75} aria-hidden />}
+                label={t("previews.openInExternalBrowser")}
+                icon={<Chrome size={14} strokeWidth={1.75} aria-hidden />}
                 onClick={() =>
                   void openExternalLink(selectedPullRequestIdentity.url)
                 }

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.tsx
@@ -22,6 +22,7 @@ import type { ReactNode } from "react";
 import type { GitHubIssue } from "@src/api/tauri/github";
 import Button from "@src/components/Button";
 import TabPill from "@src/components/TabPill";
+import { ExternalBrowserButton } from "@src/modules/WorkStation/shared/ExternalBrowserButton";
 import type { SourceControlFilterMode } from "@src/modules/WorkStation/shared/SidebarModules";
 import { HEADER_ICON_SIZE } from "@src/modules/WorkStation/shared/tokens";
 import type {
@@ -146,16 +147,15 @@ export const SourceControlHeaderContent: React.FC<
 
       <span className="ml-auto flex h-7 flex-shrink-0 items-center gap-px">
         {showIssueHeader && (
-          <a
+          <ExternalBrowserButton
             href={selectedIssue.html_url}
-            target="_blank"
-            rel="noreferrer"
-            className="flex h-7 w-7 items-center justify-center rounded text-text-3 transition-colors hover:bg-fill-2 hover:text-text-1"
-            title={t("common:actions.openOnGitHub", "Open on GitHub")}
+            label={t(
+              "common:previews.openInExternalBrowser",
+              "Open in external browser"
+            )}
+            className="flex-shrink-0"
             onClick={(e) => e.stopPropagation()}
-          >
-            <SquareArrowOutUpRight size={HEADER_ICON_SIZE.sm} />
-          </a>
+          />
         )}
         {historySelection &&
           (historySelection.type === "commit" ||

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/IssuesContent/IssueDetailPanel.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/IssuesContent/IssueDetailPanel.tsx
@@ -1,18 +1,14 @@
-import { SquareArrowOutUpRight } from "lucide-react";
 import React, { memo } from "react";
 
 import type {
   GitHubIssue,
   GitHubIssueTimelineItem,
 } from "@src/api/tauri/github";
-import Button from "@src/components/Button";
-import {
-  HEADER_CLASSES,
-  HEADER_ICON_SIZE,
-} from "@src/config/workstation/tokens";
+import { HEADER_CLASSES } from "@src/config/workstation/tokens";
 import { GitHubIssueThreadSurface } from "@src/modules/ProjectManager/WorkItems/components";
 import type { GitHubIssueInteractionConfig } from "@src/modules/ProjectManager/WorkItems/components/WorkItemContent/types";
 import type { WorkItemExternalAssigneeConfig } from "@src/modules/ProjectManager/WorkItems/components/WorkItemProperties/types";
+import { ExternalBrowserButton } from "@src/modules/WorkStation/shared/ExternalBrowserButton";
 import GitHubIssueHeaderContent from "@src/modules/shared/components/GitHubIssueHeaderContent";
 
 interface IssueDetailPanelProps {
@@ -31,26 +27,12 @@ export function getIssueDetailTitle(issue: GitHubIssue): string {
 
 export function IssueDetailExternalLinkButton({
   issue,
-  title = "Open on GitHub",
+  title,
 }: {
   issue: GitHubIssue;
   title?: string;
 }): React.ReactNode {
-  return (
-    <Button
-      href={issue.html_url}
-      target="_blank"
-      rel="noopener noreferrer"
-      variant="tertiary"
-      size="small"
-      iconOnly
-      icon={
-        <SquareArrowOutUpRight size={HEADER_ICON_SIZE.sm} strokeWidth={1.75} />
-      }
-      title={title}
-      aria-label={title}
-    />
-  );
+  return <ExternalBrowserButton href={issue.html_url} label={title} />;
 }
 
 export const IssueDetailPanel: React.FC<IssueDetailPanelProps> = memo(

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/IssuesContent/__tests__/IssueDetailExternalLinkButton.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/IssuesContent/__tests__/IssueDetailExternalLinkButton.test.ts
@@ -1,4 +1,5 @@
-import { createElement, forwardRef } from "react";
+// @vitest-environment jsdom
+import { type ReactNode, createElement, forwardRef } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
@@ -32,6 +33,10 @@ vi.mock("react-i18next", () => ({
 vi.mock("@src/components/IntegrationIcon", () => ({
   default: ({ type }: { type: string }) =>
     createElement("span", { "data-integration-icon": type }),
+}));
+
+vi.mock("@src/components/Tooltip", () => ({
+  default: ({ children }: { children: ReactNode }) => children,
 }));
 
 // The product renderer is lazy-loaded behind Suspense. These server-rendered
@@ -107,18 +112,17 @@ function createInteraction(): GitHubIssueInteractionConfig {
 }
 
 describe("IssueDetailExternalLinkButton", () => {
-  it("renders a tertiary globe action for the specific GitHub issue", () => {
+  it("renders a Chrome external-browser action for the specific GitHub issue", () => {
     const markup = renderToStaticMarkup(
       createElement(IssueDetailExternalLinkButton, { issue })
     );
 
-    expect(markup).toContain(
-      'href="https://github.com/openai/example/issues/42"'
-    );
-    expect(markup).toContain('target="_blank"');
-    expect(markup).toContain('aria-label="Open on GitHub"');
-    expect(markup).toContain('class="lucide lucide-square-arrow-out-up-right');
+    expect(markup).toContain('<button type="button"');
+    expect(markup).toContain('aria-label="Open in external browser"');
+    expect(markup).toContain('class="lucide lucide-chromium');
     expect(markup).toContain("enabled:hover:bg-surface-hover");
+    expect(markup).toContain("enabled:active:bg-surface-selected");
+    expect(markup).not.toContain("<a ");
   });
 
   it("uses the same inline Markdown issue UI as Inbox", () => {

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.test.ts
@@ -291,6 +291,55 @@ describe("PrDetailPanel tabs", () => {
     ).toBe("none");
   });
 
+  it("stacks a combined PR header below the detail-panel breakpoint without a separator", () => {
+    const store = createStore();
+    const scopeKey = workstationPrScopeKey(undefined, "/repo", 42);
+    store.set(workstationSelectedPrAtomFamily(scopeKey), {
+      ...initialSelectedPrState,
+      loading: false,
+      detail: {},
+    });
+
+    act(() => {
+      root.render(
+        createElement(
+          Provider,
+          { store },
+          createElement(PrDetailPanel, {
+            identity: {
+              number: 42,
+              title: "Use a responsive PR header",
+              url: "https://github.com/org/repo/pull/42",
+              status: "open",
+              headBranch: "feature/responsive-header",
+              baseBranch: "main",
+            },
+            repoPath: "/repo",
+            combineHeaderAndTabs: true,
+          })
+        )
+      );
+    });
+
+    const panel = container.firstElementChild;
+    const header = container.querySelector<HTMLElement>(
+      "[data-testid='pr-detail-header']"
+    );
+    const title = header?.querySelector<HTMLElement>(
+      "[data-testid='detail-header-title']"
+    );
+
+    expect(panel?.className).toContain("@container/detailheader");
+    expect(header?.className).toContain("!h-auto");
+    expect(header?.className).toContain("border-b");
+    expect(title?.parentElement?.className).toContain("flex-col");
+    expect(title?.parentElement?.className).toContain(
+      "@[960px]/detailheader:flex-row"
+    );
+    expect(header?.querySelector('[role="separator"]')).toBeNull();
+    expect(header?.querySelectorAll('[role="tab"]')).toHaveLength(4);
+  });
+
   it("keeps conflict styling while exposing the open-PR action dropdown", () => {
     const store = createStore();
     const scopeKey = workstationPrScopeKey(undefined, "/repo", 42);
@@ -569,16 +618,15 @@ describe("PrDetailPanel tabs", () => {
     expect(header?.className).toContain("!pr-[7px]");
     expect(header?.className).not.toContain("border-b");
     const externalLink = header?.querySelector(
-      'a[aria-label="Open on GitHub"]'
+      'button[aria-label="Open in external browser"]'
     );
-    expect(externalLink?.getAttribute("href")).toBe(
-      "https://github.com/org/repo/pull/42"
-    );
-    expect(externalLink?.getAttribute("target")).toBe("_blank");
+    expect(externalLink?.getAttribute("type")).toBe("button");
     expect(externalLink?.getAttribute("style")).toContain("height: 28px");
-    expect(externalLink?.querySelector(".lucide-globe")).not.toBeNull();
+    expect(externalLink?.querySelector(".lucide-chromium")).not.toBeNull();
     expect(
-      container.querySelectorAll('a[aria-label="Open on GitHub"]')
+      container.querySelectorAll(
+        'button[aria-label="Open in external browser"]'
+      )
     ).toHaveLength(1);
     expect(header?.textContent).toContain("Use compact PR metadata");
     const mergedStatus = header?.querySelector(

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.tsx
@@ -18,7 +18,6 @@ import {
   FileDiff,
   GitBranch,
   GitCommitHorizontal,
-  Globe,
   ListChecks,
   MessageCircle,
   MessagesSquare,
@@ -32,9 +31,8 @@ import {
   type PrFile,
 } from "@src/api/tauri/github";
 import Avatar from "@src/components/Avatar";
-import Button from "@src/components/Button";
 import { DETAIL_PANEL_TOKENS } from "@src/config/detailPanelTokens";
-import { HEADER_ICON_SIZE } from "@src/config/workstation/tokens";
+import { ExternalBrowserButton } from "@src/modules/WorkStation/shared/ExternalBrowserButton";
 import GitHubDetailSkeleton from "@src/modules/shared/components/GitHubDetailSkeleton";
 import {
   DetailHeaderTabs,
@@ -88,24 +86,12 @@ interface PrSummaryReviewer {
 
 export function PrDetailExternalLinkButton({
   identity,
-  title = "Open on GitHub",
+  title,
 }: {
   identity: PrIdentity;
   title?: string;
 }): React.ReactNode {
-  return (
-    <Button
-      href={identity.url}
-      target="_blank"
-      rel="noopener noreferrer"
-      variant="tertiary"
-      size="small"
-      iconOnly
-      icon={<Globe size={HEADER_ICON_SIZE.sm} strokeWidth={1.75} />}
-      title={title}
-      aria-label={title}
-    />
-  );
+  return <ExternalBrowserButton href={identity.url} label={title} />;
 }
 
 function readNumber(
@@ -491,25 +477,25 @@ export const PrDetailPanel: React.FC<PrDetailPanelProps> = ({
   }
 
   return (
-    <div className="allow-select-deep flex h-full min-h-0 flex-col overflow-hidden">
+    <div className="allow-select-deep flex h-full min-h-0 flex-col overflow-hidden @container/detailheader">
       {/* Header */}
       {showHeader ? (
         <PanelHeader
-          className={headerClassName ?? DETAIL_PANEL_TOKENS.headerPadding}
+          className={`${headerClassName ?? DETAIL_PANEL_TOKENS.headerPadding} ${
+            combineHeaderAndTabs
+              ? "!h-auto [&>div:last-child]:mt-1.5 [&>div:last-child]:self-start @[960px]/detailheader:[&>div:last-child]:mt-0 @[960px]/detailheader:[&>div:last-child]:self-auto"
+              : ""
+          }`.trim()}
           dataTestId="pr-detail-header"
           borderBottom={combineHeaderAndTabs}
           actions={
-            headerActions ?? (
-              <PrDetailExternalLinkButton
-                identity={identity}
-                title={t("actions.openOnGitHub", "Open on GitHub")}
-              />
-            )
+            headerActions ?? <PrDetailExternalLinkButton identity={identity} />
           }
         >
           {combineHeaderAndTabs ? (
             <DetailHeaderTabs
               title={<PrDetailHeaderContent identity={currentIdentity} />}
+              stackTabsBelow
               tabs={
                 <DetailTabStrip
                   activeTab={activeTab}

--- a/src/modules/WorkStation/shared/ExternalBrowserButton.test.ts
+++ b/src/modules/WorkStation/shared/ExternalBrowserButton.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { type ReactNode, act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { ExternalBrowserButton } from "./ExternalBrowserButton";
+
+const { openExternalLink } = vi.hoisted(() => ({
+  openExternalLink: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@src/util/platform/ipcRenderer", () => ({
+  openExternalLink,
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback: string) => fallback,
+  }),
+}));
+
+vi.mock("./WorkstationToolbarTooltip", () => ({
+  WorkstationToolbarTooltip: ({
+    label,
+    children,
+  }: {
+    label: string;
+    children: ReactNode;
+  }) =>
+    createElement("span", { "data-shortcut-tooltip-label": label }, children),
+}));
+
+describe("ExternalBrowserButton", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    openExternalLink.mockClear();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("renders a Chrome button with standard hover and pressed feedback", () => {
+    const markup = renderToStaticMarkup(
+      createElement(ExternalBrowserButton, {
+        href: "https://github.com/openai/example/pull/42",
+      })
+    );
+
+    expect(markup).toContain(
+      'data-shortcut-tooltip-label="Open in external browser"'
+    );
+    expect(markup).toContain('<button type="button"');
+    expect(markup).toContain('aria-label="Open in external browser"');
+    expect(markup).toContain('class="lucide lucide-chromium');
+    expect(markup).toContain("enabled:hover:bg-surface-hover");
+    expect(markup).toContain("enabled:active:bg-surface-selected");
+    expect(markup).not.toContain("<a ");
+    expect(markup).not.toContain('title="Open in external browser"');
+  });
+
+  it("opens the supplied URL through the external-browser API", async () => {
+    const onClick = vi.fn();
+    act(() => {
+      root.render(
+        createElement(ExternalBrowserButton, {
+          href: "https://github.com/openai/example/issues/42",
+          onClick,
+        })
+      );
+    });
+
+    await act(async () => {
+      container.querySelector("button")?.click();
+    });
+
+    expect(onClick).toHaveBeenCalledOnce();
+    expect(openExternalLink).toHaveBeenCalledWith(
+      "https://github.com/openai/example/issues/42"
+    );
+  });
+});

--- a/src/modules/WorkStation/shared/ExternalBrowserButton.tsx
+++ b/src/modules/WorkStation/shared/ExternalBrowserButton.tsx
@@ -1,0 +1,54 @@
+import { Chrome } from "lucide-react";
+import React, { memo } from "react";
+import { useTranslation } from "react-i18next";
+
+import Button, { type ButtonProps } from "@src/components/Button";
+import { HEADER_ICON_SIZE } from "@src/config/workstation/tokens";
+import { openExternalLink } from "@src/util/platform/ipcRenderer";
+
+import { WorkstationToolbarTooltip } from "./WorkstationToolbarTooltip";
+
+export interface ExternalBrowserButtonProps {
+  href: string;
+  label?: string;
+  className?: string;
+  dataTestId?: string;
+  onClick?: ButtonProps["onClick"];
+}
+
+/** Chrome-glyph header action with the standard shortcut-style tooltip. */
+export const ExternalBrowserButton = memo(function ExternalBrowserButton({
+  href,
+  label,
+  className,
+  dataTestId,
+  onClick,
+}: ExternalBrowserButtonProps) {
+  const { t } = useTranslation("common");
+  const resolvedLabel =
+    label ?? t("previews.openInExternalBrowser", "Open in external browser");
+  const handleClick: NonNullable<ButtonProps["onClick"]> = (event) => {
+    onClick?.(event);
+    if (!event.defaultPrevented) {
+      void openExternalLink(href);
+    }
+  };
+
+  return (
+    <WorkstationToolbarTooltip label={resolvedLabel} position="bottom-end">
+      <Button
+        htmlType="button"
+        variant="tertiary"
+        size="small"
+        iconOnly
+        className={className}
+        icon={<Chrome size={HEADER_ICON_SIZE.sm} strokeWidth={1.75} />}
+        aria-label={resolvedLabel}
+        data-testid={dataTestId}
+        onClick={handleClick}
+      />
+    </WorkstationToolbarTooltip>
+  );
+});
+
+ExternalBrowserButton.displayName = "ExternalBrowserButton";

--- a/src/modules/WorkStation/shared/TabBar/config.test.ts
+++ b/src/modules/WorkStation/shared/TabBar/config.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+import { TAB_PAIR_SEPARATOR_SLOT_CLASS } from "./config";
+
+describe("tab bar spacing", () => {
+  it("keeps a one-pixel separator with four pixels of space between pills", () => {
+    expect(TAB_PAIR_SEPARATOR_SLOT_CLASS).toContain("mx-0.5");
+    expect(TAB_PAIR_SEPARATOR_SLOT_CLASS).toContain("w-px");
+  });
+});

--- a/src/modules/WorkStation/shared/TabBar/config.ts
+++ b/src/modules/WorkStation/shared/TabBar/config.ts
@@ -1,19 +1,20 @@
 /**
  * Configuration for Tab Bar
  *
- * Shared by: CodeEditor, DatabaseManager
+ * Shared by: ChatPanel, CodeEditor, DatabaseManager, Browser, SessionReplay
  */
 
 /** Height of the tab bar in pixels */
 export const TAB_BAR_HEIGHT = 36;
 
 /**
- * Fixed 1×16px slot between every pair of tab pills (always rendered) so the strip
- * does not shift when selection changes. Apply `bg-border-2` when both neighbors are
- * inactive, otherwise `bg-transparent`.
+ * Fixed 1×16px rule with 2px side margins between every pair of tab pills
+ * (always rendered), providing 4px of clear space while keeping the divider
+ * itself crisp. Apply `bg-border-2` when both neighbors are inactive,
+ * otherwise `bg-transparent`.
  */
 export const TAB_PAIR_SEPARATOR_SLOT_CLASS =
-  "pointer-events-none shrink-0 self-center w-px h-4";
+  "pointer-events-none mx-0.5 h-4 w-px shrink-0 self-center";
 
 /**
  * Rule between the optional tab-row prefix (e.g. Control Tower groups) and

--- a/src/modules/WorkStation/shared/index.ts
+++ b/src/modules/WorkStation/shared/index.ts
@@ -10,6 +10,8 @@ export type { WorkStationShellProps } from "./WorkStationShell";
 export { WorkstationHeaderSectionSeparator } from "./WorkstationHeaderSectionSeparator";
 export { WorkstationToolbarTooltip } from "./WorkstationToolbarTooltip";
 export type { WorkstationToolbarTooltipProps } from "./WorkstationToolbarTooltip";
+export { ExternalBrowserButton } from "./ExternalBrowserButton";
+export type { ExternalBrowserButtonProps } from "./ExternalBrowserButton";
 
 // Shell configuration
 export {

--- a/src/modules/shared/layouts/blocks/DetailHeaderTabs.test.ts
+++ b/src/modules/shared/layouts/blocks/DetailHeaderTabs.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import DetailHeaderTabs from "./DetailHeaderTabs";
 
 describe("DetailHeaderTabs", () => {
-  it("keeps title, separator, and tabs in one 40px row", () => {
+  it("keeps title and tabs in one 40px row without a decorative separator", () => {
     const markup = renderToStaticMarkup(
       createElement(DetailHeaderTabs, {
         title: createElement("span", null, "Project title"),
@@ -15,7 +15,8 @@ describe("DetailHeaderTabs", () => {
 
     expect(markup).toContain("h-10");
     expect(markup).toContain('data-testid="detail-header-title"');
-    expect(markup).toContain('role="separator"');
+    expect(markup).not.toContain('role="separator"');
+    expect(markup).not.toContain("detail-header-tabs-separator");
     expect(markup).toContain('data-testid="detail-header-tabs"');
     expect(markup.indexOf("Project title")).toBeLessThan(
       markup.indexOf("Tabs")
@@ -28,6 +29,22 @@ describe("DetailHeaderTabs", () => {
     );
 
     expect(markup).toContain("flex-1");
+    expect(markup).not.toContain('role="separator"');
+  });
+
+  it("stacks title and tabs below the PR detail container breakpoint", () => {
+    const markup = renderToStaticMarkup(
+      createElement(DetailHeaderTabs, {
+        title: createElement("span", null, "Pull request title"),
+        tabs: createElement("span", null, "Pull request tabs"),
+        stackTabsBelow: true,
+      })
+    );
+
+    expect(markup).toContain("flex-col");
+    expect(markup).toContain("@[960px]/detailheader:flex-row");
+    expect(markup).toContain("@[960px]/detailheader:h-10");
+    expect(markup).toContain('data-testid="detail-header-tabs"');
     expect(markup).not.toContain('role="separator"');
   });
 });

--- a/src/modules/shared/layouts/blocks/DetailHeaderTabs.tsx
+++ b/src/modules/shared/layouts/blocks/DetailHeaderTabs.tsx
@@ -3,36 +3,49 @@ import type { ReactNode } from "react";
 export interface DetailHeaderTabsProps {
   title: ReactNode;
   tabs?: ReactNode;
+  /** Stack title and tabs below 960px of available detail-panel width. */
+  stackTabsBelow?: boolean;
 }
 
-/** Compact `title | tabs` composition for a shared 40px detail header. */
+/** Compact title + tabs composition for a shared detail header. */
 export default function DetailHeaderTabs({
   title,
   tabs,
+  stackTabsBelow = false,
 }: DetailHeaderTabsProps) {
+  const stacksAtNarrowWidth = Boolean(tabs && stackTabsBelow);
+
   return (
-    <div className="flex h-10 min-w-0 flex-1 items-center">
+    <div
+      className={`flex min-w-0 flex-1 ${
+        stacksAtNarrowWidth
+          ? "h-auto flex-col items-stretch @[960px]/detailheader:h-10 @[960px]/detailheader:flex-row @[960px]/detailheader:items-center @[960px]/detailheader:gap-2"
+          : "h-10 items-center gap-2"
+      }`}
+    >
       <div
-        className={`flex min-w-0 items-center ${tabs ? "max-w-xs shrink" : "flex-1"}`}
+        className={`flex min-w-0 items-center ${
+          tabs
+            ? stacksAtNarrowWidth
+              ? "h-10 w-full flex-none @[960px]/detailheader:h-auto @[960px]/detailheader:w-auto @[960px]/detailheader:max-w-xs @[960px]/detailheader:shrink"
+              : "max-w-xs shrink"
+            : "flex-1"
+        }`}
         data-testid="detail-header-title"
       >
         {title}
       </div>
       {tabs ? (
-        <>
-          <span
-            className="mx-2 h-4 w-px shrink-0 bg-border-2"
-            role="separator"
-            aria-hidden
-            data-testid="detail-header-tabs-separator"
-          />
-          <div
-            className="h-full min-w-0 flex-1"
-            data-testid="detail-header-tabs"
-          >
-            {tabs}
-          </div>
-        </>
+        <div
+          className={
+            stacksAtNarrowWidth
+              ? "h-10 w-full min-w-0 flex-none @[960px]/detailheader:h-full @[960px]/detailheader:w-auto @[960px]/detailheader:flex-1"
+              : "h-full min-w-0 flex-1"
+          }
+          data-testid="detail-header-tabs"
+        >
+          {tabs}
+        </div>
       ) : null}
     </div>
   );


### PR DESCRIPTION
## Problem

GitHub pull-request and issue detail headers had inconsistent layout and action behavior. The combined PR title/tab header kept an unused separator and forced tabs into one row at narrow widths, adjacent tab pills could visually touch, and external-browser actions used inconsistent glyphs and tooltips. Some external actions rendered through the anchor path of the shared Button component, so the button-only `:enabled` hover styles never applied; GitHub Work Item tabs also lacked the external-browser action entirely.

## Solution

Remove the decorative title/tab separator, stack combined PR header tabs below the title when the detail container is narrower than 960px, and preserve at least four pixels of clear space around shared tab-pair separators. Add a reusable Chrome-glyph external-browser button with the standard shortcut tooltip, native button semantics, the existing desktop external-link opener, accessible labels, and shared hover/pressed feedback. Use the canonical hydrated GitHub issue URL to expose the action in Work Item tabs, and apply the same external-browser presentation across PR, issue, Source Control, and Team Inbox headers.

## Potential risks

The 960px behavior uses a named CSS container on the PR detail surface, so unusual embedding widths may need breakpoint tuning after visual review. Adding a pressed background to solid tertiary buttons intentionally affects momentary active feedback anywhere that design-system variant is used, but does not add persistent selection state. The external action reuses the existing Tauri shell opener and changes no persistence, schema, IPC contract, dependencies, concurrency, or background lifecycle; a web-hosted fallback was not manually exercised. Rollback is a direct revert of commit `1b884c3a9`.

## Verification

- `npx vitest run src/modules/WorkStation/shared/ExternalBrowserButton.test.ts src/modules/WorkStation/shared/TabBar/config.test.ts src/modules/shared/layouts/blocks/DetailHeaderTabs.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/PullRequestContent/detail/PrDetailPanel.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/IssuesContent/__tests__/IssueDetailExternalLinkButton.test.ts src/engines/ChatPanel/panels/useWorkItemGitHubIssueState.test.ts src/modules/MainApp/TeamInbox/__tests__/AssignedWorkItemDetail.test.ts src/modules/MainApp/TeamInbox/__tests__/TeamInboxView.layout.test.ts src/modules/WorkStation/CodeEditor/Panels/EditorMainPane/components/SourceControlHeaderContent.test.ts` — passed, 9 files / 45 tests
- `npx eslint <all 20 changed TypeScript files> --max-warnings 0 --report-unused-disable-directives` — passed
- Commit hook scoped TypeScript check — passed
- `git diff --check origin/develop...HEAD` — passed
- Post-change screenshots were not captured because local UI-control verification requires explicit opt-in in this workspace; DOM structure, responsive classes, action semantics, opener dispatch, tooltip text, icons, and interaction-state classes are covered by automated tests. The PR remains draft pending visual evidence.

## Audit

The configured `frontend-ui-audit` skill is absent from this workspace. Its checks were applied manually: the change uses shared Button and tooltip primitives, preserves accessible names, introduces no arbitrary visual duplication, and consolidates external-browser presentation in one component.
