### PR TITLE
feat(markdown-links): open GitHub pull requests in PR tabs

### DIFF
--- a/src/components/MarkDown/LinkHoverCard.helpers.test.ts
+++ b/src/components/MarkDown/LinkHoverCard.helpers.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { getHttpLinkPreview } from "./LinkHoverCard.helpers";
+import {
+  createGitHubPrTabDataFromLink,
+  getHttpLinkPreview,
+  remoteUrlsMatchGitHubPullRequest,
+} from "./LinkHoverCard.helpers";
 
 describe("getHttpLinkPreview", () => {
   it("builds a compact preview for HTTPS links", () => {
@@ -29,5 +33,56 @@ describe("getHttpLinkPreview", () => {
 
   it("does not create hover previews for template placeholders", () => {
     expect(getHttpLinkPreview("http://${host}:${port}/docs")).toBeNull();
+  });
+});
+
+describe("GitHub pull-request hover actions", () => {
+  const pullRequest = { owner: "org2AI", repo: "ORG2", number: 964 };
+
+  it("matches GitHub HTTPS and SSH remotes for the PR repository", () => {
+    expect(
+      remoteUrlsMatchGitHubPullRequest(pullRequest, [
+        "git@github.com:org2AI/ORG2.git",
+      ])
+    ).toBe(true);
+    expect(
+      remoteUrlsMatchGitHubPullRequest(pullRequest, [
+        "https://github.com/another/repository.git",
+      ])
+    ).toBe(false);
+  });
+
+  it("builds the existing PR-tab payload from GitHub detail", () => {
+    expect(
+      createGitHubPrTabDataFromLink({
+        url: "https://github.com/org2AI/ORG2/pull/964",
+        repoPath: "/repos/ORG2",
+        repoId: "repo-1",
+        detail: {
+          title: "Use split open action",
+          html_url: "https://github.com/org2AI/ORG2/pull/964",
+          state: "open",
+          draft: false,
+          merged: false,
+          head: { ref: "feature/split-open" },
+          base: { ref: "dev" },
+          updated_at: "2026-08-25T12:00:00Z",
+          additions: 12,
+          deletions: 3,
+        },
+      })
+    ).toEqual({
+      prNumber: 964,
+      prTitle: "Use split open action",
+      prUrl: "https://github.com/org2AI/ORG2/pull/964",
+      prStatus: "open",
+      headBranch: "feature/split-open",
+      baseBranch: "dev",
+      updatedAt: "2026-08-25T12:00:00Z",
+      additions: 12,
+      deletions: 3,
+      repoPath: "/repos/ORG2",
+      repoId: "repo-1",
+    });
   });
 });

--- a/src/components/MarkDown/LinkHoverCard.helpers.ts
+++ b/src/components/MarkDown/LinkHoverCard.helpers.ts
@@ -1,9 +1,88 @@
+import type { GitHubPrDetailTabData } from "@src/types/githubDetail";
+import {
+  type GitHubPullRequestRef,
+  parseGitHubPullRequestUrl,
+} from "@src/util/git/githubPullRequestUrl";
+import { resolveGithubRepoFullName } from "@src/util/git/githubRemote";
 import { normalizeHttpUrlCandidate } from "@src/util/url/validation";
 
 export interface HttpLinkPreview {
   url: string;
   host: string;
   displayUrl: string;
+}
+
+function readString(
+  source: Record<string, unknown> | null | undefined,
+  key: string
+): string | undefined {
+  const value = source?.[key];
+  return typeof value === "string" && value ? value : undefined;
+}
+
+function readNestedString(
+  source: Record<string, unknown>,
+  parentKey: string,
+  childKey: string
+): string | undefined {
+  const parent = source[parentKey];
+  if (!parent || typeof parent !== "object") return undefined;
+  return readString(parent as Record<string, unknown>, childKey);
+}
+
+function readNumber(
+  source: Record<string, unknown>,
+  key: string
+): number | undefined {
+  const value = source[key];
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function getPrStatus(detail: Record<string, unknown>): string {
+  if (detail.merged === true) return "merged";
+  if (detail.draft === true) return "draft";
+  return readString(detail, "state")?.toLowerCase() === "closed"
+    ? "closed"
+    : "open";
+}
+
+export function remoteUrlsMatchGitHubPullRequest(
+  pullRequest: GitHubPullRequestRef,
+  remoteUrls: readonly (string | null | undefined)[]
+): boolean {
+  const expected = `${pullRequest.owner}/${pullRequest.repo}`.toLowerCase();
+  return remoteUrls.some((remoteUrl) => {
+    if (!remoteUrl) return false;
+    return resolveGithubRepoFullName([remoteUrl])?.toLowerCase() === expected;
+  });
+}
+
+export function createGitHubPrTabDataFromLink(params: {
+  url: string;
+  repoPath: string;
+  repoId?: string;
+  detail: Record<string, unknown>;
+}): GitHubPrDetailTabData | null {
+  const pullRequest = parseGitHubPullRequestUrl(params.url);
+  if (!pullRequest) return null;
+
+  return {
+    prNumber: pullRequest.number,
+    prTitle:
+      readString(params.detail, "title") ??
+      `${pullRequest.owner}/${pullRequest.repo}`,
+    prUrl: readString(params.detail, "html_url") ?? params.url,
+    prStatus: getPrStatus(params.detail),
+    headBranch: readNestedString(params.detail, "head", "ref") ?? "",
+    baseBranch: readNestedString(params.detail, "base", "ref"),
+    updatedAt: readString(params.detail, "updated_at"),
+    additions: readNumber(params.detail, "additions"),
+    deletions: readNumber(params.detail, "deletions"),
+    repoPath: params.repoPath,
+    repoId: params.repoId,
+  };
 }
 
 const DISPLAY_URL_MAX_LENGTH = 88;

--- a/src/components/MarkDown/LinkHoverCard.tsx
+++ b/src/components/MarkDown/LinkHoverCard.tsx
@@ -1,30 +1,57 @@
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { Chromium, Copy } from "lucide-react";
-import React, { useCallback } from "react";
+import { useSetAtom } from "jotai";
+import { Chromium, Copy, GitPullRequest, PanelsTopLeft } from "lucide-react";
+import React, { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { getGitRemotes } from "@src/api/http/git/remotes";
+import { getPRLocal } from "@src/api/tauri/github";
 import Button from "@src/components/Button";
+import Dropdown from "@src/components/Dropdown";
+import Menu from "@src/components/Menu";
 import Message from "@src/components/Message";
 import HoverCardBase, {
   HoverCardPanel,
 } from "@src/components/SessionHoverCard/HoverCardBase";
+import SplitButton from "@src/components/SplitButton";
+import { openGitHubPrInChatPanelTabAtom } from "@src/store/chatPanel/chatPanelTabsAtom";
 import { copyText } from "@src/util/data/clipboard";
+import { parseGitHubPullRequestUrl } from "@src/util/git/githubPullRequestUrl";
 
 import {
   type HttpLinkPreview,
+  createGitHubPrTabDataFromLink,
   getHttpLinkPreview,
+  remoteUrlsMatchGitHubPullRequest,
 } from "./LinkHoverCard.helpers";
 import { openUrlInBrowserApp } from "./markdownUtils";
 
 interface LinkHoverCardProps {
   url: string;
   children: React.ReactElement;
+  workspaceRootPath?: string;
+  workspaceRootRepoId?: string;
+  workspaceRootRepoUrl?: string;
 }
 
-const LinkHoverCardContent: React.FC<{ preview: HttpLinkPreview }> = ({
+interface LinkHoverCardContentProps {
+  preview: HttpLinkPreview;
+  workspaceRootPath?: string;
+  workspaceRootRepoId?: string;
+  workspaceRootRepoUrl?: string;
+}
+
+const LinkHoverCardContent: React.FC<LinkHoverCardContentProps> = ({
   preview,
+  workspaceRootPath,
+  workspaceRootRepoId,
+  workspaceRootRepoUrl,
 }) => {
   const { t } = useTranslation("sessions");
+  const openPrInChatPanel = useSetAtom(openGitHubPrInChatPanelTabAtom);
+  const [openOptionsVisible, setOpenOptionsVisible] = useState(false);
+  const [openingPr, setOpeningPr] = useState(false);
+  const pullRequest = parseGitHubPullRequestUrl(preview.url);
 
   const handleCopy = useCallback(async () => {
     try {
@@ -35,9 +62,60 @@ const LinkHoverCardContent: React.FC<{ preview: HttpLinkPreview }> = ({
     }
   }, [preview.url, t]);
 
-  const handleOpenInApp = useCallback(() => {
+  const handleOpenAsWebPage = useCallback(() => {
     openUrlInBrowserApp(preview.url, { navigate: true });
+    setOpenOptionsVisible(false);
   }, [preview.url]);
+
+  const handleOpenAsPullRequest = useCallback(async () => {
+    if (!pullRequest || !workspaceRootPath || openingPr) return;
+
+    setOpeningPr(true);
+    try {
+      const repoFullName = `${pullRequest.owner}/${pullRequest.repo}`;
+      const [detail, remotes] = await Promise.all([
+        getPRLocal(repoFullName, pullRequest.number),
+        getGitRemotes({
+          repo_id: workspaceRootRepoId ?? "default",
+          repo_path: workspaceRootPath,
+        }),
+      ]);
+      const remoteUrls = [
+        workspaceRootRepoUrl,
+        ...(remotes?.remotes.flatMap((remote) => [
+          remote.url,
+          remote.fetch_url,
+        ]) ?? []),
+      ];
+      if (!remoteUrlsMatchGitHubPullRequest(pullRequest, remoteUrls)) {
+        throw new Error(
+          "The active workspace does not match this pull request"
+        );
+      }
+      const tabData = createGitHubPrTabDataFromLink({
+        url: preview.url,
+        repoPath: workspaceRootPath,
+        repoId: workspaceRootRepoId,
+        detail,
+      });
+      if (!tabData) throw new Error("Invalid GitHub pull request URL");
+      openPrInChatPanel(tabData);
+      setOpenOptionsVisible(false);
+    } catch {
+      Message.error(t("cards.url.openPullRequestFailed"));
+    } finally {
+      setOpeningPr(false);
+    }
+  }, [
+    openPrInChatPanel,
+    openingPr,
+    preview.url,
+    pullRequest,
+    t,
+    workspaceRootPath,
+    workspaceRootRepoId,
+    workspaceRootRepoUrl,
+  ]);
 
   const handleOpenExternal = useCallback(() => {
     void openUrl(preview.url).catch(() => {
@@ -46,7 +124,7 @@ const LinkHoverCardContent: React.FC<{ preview: HttpLinkPreview }> = ({
   }, [preview.url, t]);
 
   return (
-    <HoverCardPanel title={preview.host}>
+    <HoverCardPanel title={preview.host} allowOverflow>
       <div
         className="truncate text-[12px] leading-5 text-text-3"
         title={preview.url}
@@ -55,7 +133,7 @@ const LinkHoverCardContent: React.FC<{ preview: HttpLinkPreview }> = ({
       </div>
       <div className="flex items-center justify-end gap-1 border-t border-border-1 pt-2">
         <Button
-          variant="secondary"
+          variant="tertiary"
           size="mini"
           icon={<Copy size={13} />}
           iconOnly
@@ -64,7 +142,7 @@ const LinkHoverCardContent: React.FC<{ preview: HttpLinkPreview }> = ({
           onClick={handleCopy}
         />
         <Button
-          variant="secondary"
+          variant="tertiary"
           size="mini"
           icon={<Chromium size={13} strokeWidth={1.75} />}
           iconOnly
@@ -72,15 +150,65 @@ const LinkHoverCardContent: React.FC<{ preview: HttpLinkPreview }> = ({
           title={t("cards.actions.openWithDefaultBrowser")}
           onClick={handleOpenExternal}
         />
-        <Button variant="primary" size="mini" onClick={handleOpenInApp}>
-          {t("cards.actions.openInApp")}
-        </Button>
+        {pullRequest && workspaceRootPath ? (
+          <SplitButton
+            variant="primary"
+            size="mini"
+            loading={openingPr}
+            icon={<GitPullRequest size={13} strokeWidth={1.75} aria-hidden />}
+            onClick={() => void handleOpenAsPullRequest()}
+            menuOpen={openOptionsVisible}
+            menuButtonLabel={t("cards.actions.moreOpenOptions")}
+            onMenuButtonClick={(event) => {
+              event.stopPropagation();
+              setOpenOptionsVisible((visible) => !visible);
+            }}
+            menu={
+              <Dropdown
+                trigger="click"
+                position="bottom-end"
+                popupVisible={openOptionsVisible}
+                onVisibleChange={setOpenOptionsVisible}
+                droplist={
+                  <Menu>
+                    <Menu.Item
+                      key="pull-request"
+                      onClick={() => void handleOpenAsPullRequest()}
+                    >
+                      <GitPullRequest size={14} aria-hidden />
+                      {t("cards.actions.openAsPullRequest")}
+                    </Menu.Item>
+                    <Menu.Item key="web-page" onClick={handleOpenAsWebPage}>
+                      <PanelsTopLeft size={14} aria-hidden />
+                      {t("cards.actions.openAsWebPage")}
+                    </Menu.Item>
+                  </Menu>
+                }
+              >
+                <div />
+              </Dropdown>
+            }
+            widthMode="hug"
+          >
+            {t("input.pr.open")}
+          </SplitButton>
+        ) : (
+          <Button variant="primary" size="mini" onClick={handleOpenAsWebPage}>
+            {t("cards.actions.openAsWebPage")}
+          </Button>
+        )}
       </div>
     </HoverCardPanel>
   );
 };
 
-const LinkHoverCard: React.FC<LinkHoverCardProps> = ({ url, children }) => {
+const LinkHoverCard: React.FC<LinkHoverCardProps> = ({
+  url,
+  children,
+  workspaceRootPath,
+  workspaceRootRepoId,
+  workspaceRootRepoUrl,
+}) => {
   const preview = getHttpLinkPreview(url);
   if (!preview) return children;
 
@@ -89,7 +217,14 @@ const LinkHoverCard: React.FC<LinkHoverCardProps> = ({ url, children }) => {
       cardId={preview.url}
       position="bottom-start"
       mouseEnterDelay={350}
-      renderContent={() => <LinkHoverCardContent preview={preview} />}
+      renderContent={() => (
+        <LinkHoverCardContent
+          preview={preview}
+          workspaceRootPath={workspaceRootPath}
+          workspaceRootRepoId={workspaceRootRepoId}
+          workspaceRootRepoUrl={workspaceRootRepoUrl}
+        />
+      )}
     >
       {children}
     </HoverCardBase>

--- a/src/components/MarkDown/MarkDownImpl.tsx
+++ b/src/components/MarkDown/MarkDownImpl.tsx
@@ -441,7 +441,12 @@ const MarkdownComponent: React.FC<MarkdownProps> = ({
         );
         const linkHasIcon = hasMarkdownLinkIcon(url, linkTarget);
         return (
-          <LinkHoverCard url={url}>
+          <LinkHoverCard
+            url={url}
+            workspaceRootPath={activeWorkspaceRootPath}
+            workspaceRootRepoId={activeWorkspaceRoot?.repoId}
+            workspaceRootRepoUrl={activeWorkspaceRoot?.repo?.repo_url}
+          >
             <a
               {...props}
               className={
@@ -489,6 +494,7 @@ const MarkdownComponent: React.FC<MarkdownProps> = ({
     codeBlockContainerWidth,
     enableFileNavigation,
     handleLinkClick,
+    activeWorkspaceRoot,
     activeWorkspaceRootPath,
     disableCanvasInline,
   ]);

--- a/src/components/SessionHoverCard/HoverCardBase.tsx
+++ b/src/components/SessionHoverCard/HoverCardBase.tsx
@@ -57,6 +57,8 @@ interface HoverCardPortalProps {
 interface HoverCardPanelProps {
   title?: string;
   children: React.ReactNode;
+  /** Allow anchored child menus to extend beyond short hover-card panels. */
+  allowOverflow?: boolean;
 }
 
 interface HoverCardRowProps {
@@ -264,9 +266,12 @@ const HoverCardPortal: React.FC<HoverCardPortalProps> = ({
 export const HoverCardPanel: React.FC<HoverCardPanelProps> = ({
   title,
   children,
+  allowOverflow = false,
 }) => (
   <div
-    className="w-[280px] overflow-y-auto rounded-xl border border-border-2 bg-bg-2 p-3 shadow-dropdown"
+    className={`w-[280px] rounded-xl border border-border-2 bg-bg-2 p-3 shadow-dropdown ${
+      allowOverflow ? "overflow-visible" : "overflow-y-auto"
+    }`}
     style={{ maxHeight: `calc(100vh - ${VIEWPORT_PADDING_PX * 2}px)` }}
   >
     {title && (

--- a/src/i18n/locales/de/sessions.json
+++ b/src/i18n/locales/de/sessions.json
@@ -2758,6 +2758,8 @@
     },
     "actions": {
       "moreOpenOptions": "Weitere Öffnungsoptionen",
+      "openAsPullRequest": "PR-Tab",
+      "openAsWebPage": "Webseite",
       "openInApp": "In der App öffnen",
       "openWithDefaultBrowser": "Mit Standardbrowser öffnen",
       "revealInFinder": "In Finder anzeigen",
@@ -2769,6 +2771,7 @@
       "copyUrl": "URL kopieren",
       "copied": "URL kopiert",
       "openExternalFailed": "URL konnte nicht im Standardbrowser geöffnet werden",
+      "openPullRequestFailed": "Pull-Request-Tab konnte nicht geöffnet werden",
       "groupTitle": "Webseiten"
     },
     "path": {

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -2883,6 +2883,8 @@
     },
     "actions": {
       "moreOpenOptions": "More open options",
+      "openAsPullRequest": "PR tab",
+      "openAsWebPage": "Web page",
       "openInApp": "Open in app",
       "openWithDefaultBrowser": "Open with default browser",
       "revealInFinder": "Reveal in Finder",
@@ -2894,6 +2896,7 @@
       "copyUrl": "Copy URL",
       "copied": "URL copied",
       "openExternalFailed": "Failed to open URL in default browser",
+      "openPullRequestFailed": "Failed to open pull request tab",
       "groupTitle": "Web pages"
     },
     "path": {

--- a/src/i18n/locales/es/sessions.json
+++ b/src/i18n/locales/es/sessions.json
@@ -2760,6 +2760,8 @@
     },
     "actions": {
       "moreOpenOptions": "Más opciones de apertura",
+      "openAsPullRequest": "Pestaña PR",
+      "openAsWebPage": "Página web",
       "openInApp": "Abrir en la app",
       "openWithDefaultBrowser": "Abrir con el navegador predeterminado",
       "revealInFinder": "Mostrar en Finder",
@@ -2771,6 +2773,7 @@
       "copyUrl": "Copiar URL",
       "copied": "URL copiada",
       "openExternalFailed": "No se pudo abrir la URL en el navegador predeterminado",
+      "openPullRequestFailed": "No se pudo abrir la pestaña de pull request",
       "groupTitle": "Páginas web"
     },
     "path": {

--- a/src/i18n/locales/fr/sessions.json
+++ b/src/i18n/locales/fr/sessions.json
@@ -2760,6 +2760,8 @@
     },
     "actions": {
       "moreOpenOptions": "Plus d’options d’ouverture",
+      "openAsPullRequest": "Onglet PR",
+      "openAsWebPage": "Page web",
       "openInApp": "Ouvrir dans l’application",
       "openWithDefaultBrowser": "Ouvrir avec le navigateur par défaut",
       "revealInFinder": "Afficher dans Finder",
@@ -2771,6 +2773,7 @@
       "copyUrl": "Copier l'URL",
       "copied": "URL copiée",
       "openExternalFailed": "Impossible d’ouvrir l’URL dans le navigateur par défaut",
+      "openPullRequestFailed": "Impossible d’ouvrir l’onglet de pull request",
       "groupTitle": "Pages web"
     },
     "path": {

--- a/src/i18n/locales/ja/sessions.json
+++ b/src/i18n/locales/ja/sessions.json
@@ -2759,6 +2759,8 @@
     },
     "actions": {
       "moreOpenOptions": "その他の開くオプション",
+      "openAsPullRequest": "PR タブ",
+      "openAsWebPage": "ウェブページ",
       "openInApp": "アプリ内で開く",
       "openWithDefaultBrowser": "既定のブラウザで開く",
       "revealInFinder": "Finder に表示",
@@ -2770,6 +2772,7 @@
       "copyUrl": "URL をコピー",
       "copied": "URL をコピーしました",
       "openExternalFailed": "既定のブラウザで URL を開けませんでした",
+      "openPullRequestFailed": "Pull Request タブを開けませんでした",
       "groupTitle": "Web ページ"
     },
     "path": {

--- a/src/i18n/locales/ko/sessions.json
+++ b/src/i18n/locales/ko/sessions.json
@@ -2760,6 +2760,8 @@
     },
     "actions": {
       "moreOpenOptions": "추가 열기 옵션",
+      "openAsPullRequest": "PR 탭",
+      "openAsWebPage": "웹 페이지",
       "openInApp": "앱에서 열기",
       "openWithDefaultBrowser": "기본 브라우저로 열기",
       "revealInFinder": "Finder에서 보기",
@@ -2771,6 +2773,7 @@
       "copyUrl": "URL 복사",
       "copied": "URL이 복사되었습니다",
       "openExternalFailed": "기본 브라우저에서 URL을 열지 못했습니다",
+      "openPullRequestFailed": "풀 리퀘스트 탭을 열지 못했습니다",
       "groupTitle": "웹 페이지"
     },
     "path": {

--- a/src/i18n/locales/pl/sessions.json
+++ b/src/i18n/locales/pl/sessions.json
@@ -2797,6 +2797,8 @@
     },
     "actions": {
       "moreOpenOptions": "Więcej opcji otwierania",
+      "openAsPullRequest": "Karta PR",
+      "openAsWebPage": "Strona WWW",
       "openInApp": "Otwórz w aplikacji",
       "openWithDefaultBrowser": "Otwórz w domyślnej przeglądarce",
       "revealInFinder": "Pokaż w Finderze",
@@ -2808,6 +2810,7 @@
       "copyUrl": "Kopiuj URL",
       "copied": "Skopiowano URL",
       "openExternalFailed": "Nie udało się otworzyć URL w domyślnej przeglądarce",
+      "openPullRequestFailed": "Nie udało się otworzyć karty pull requestu",
       "groupTitle": "Strony internetowe"
     },
     "path": {

--- a/src/i18n/locales/pt/sessions.json
+++ b/src/i18n/locales/pt/sessions.json
@@ -2759,6 +2759,8 @@
     },
     "actions": {
       "moreOpenOptions": "Mais opções de abertura",
+      "openAsPullRequest": "Aba de PR",
+      "openAsWebPage": "Página web",
       "openInApp": "Abrir no app",
       "openWithDefaultBrowser": "Abrir com o navegador padrão",
       "revealInFinder": "Mostrar no Finder",
@@ -2770,6 +2772,7 @@
       "copyUrl": "Copiar URL",
       "copied": "URL copiado",
       "openExternalFailed": "Falha ao abrir URL no navegador padrão",
+      "openPullRequestFailed": "Falha ao abrir a aba do pull request",
       "groupTitle": "Páginas da web"
     },
     "path": {

--- a/src/i18n/locales/ru/sessions.json
+++ b/src/i18n/locales/ru/sessions.json
@@ -2804,6 +2804,8 @@
     },
     "actions": {
       "moreOpenOptions": "Другие параметры открытия",
+      "openAsPullRequest": "Вкладка PR",
+      "openAsWebPage": "Веб-страница",
       "openInApp": "Открыть в приложении",
       "openWithDefaultBrowser": "Открыть в браузере по умолчанию",
       "revealInFinder": "Показать в Finder",
@@ -2815,6 +2817,7 @@
       "copyUrl": "Скопировать URL",
       "copied": "URL скопирован",
       "openExternalFailed": "Не удалось открыть URL в браузере по умолчанию",
+      "openPullRequestFailed": "Не удалось открыть вкладку pull request",
       "groupTitle": "Веб-страницы"
     },
     "path": {

--- a/src/i18n/locales/tr/sessions.json
+++ b/src/i18n/locales/tr/sessions.json
@@ -2761,6 +2761,8 @@
     },
     "actions": {
       "moreOpenOptions": "Daha fazla açma seçeneği",
+      "openAsPullRequest": "PR sekmesi",
+      "openAsWebPage": "Web sayfası",
       "openInApp": "Uygulamada aç",
       "openWithDefaultBrowser": "Varsayılan tarayıcıyla aç",
       "revealInFinder": "Finder'da göster",
@@ -2772,6 +2774,7 @@
       "copyUrl": "URL'yi kopyala",
       "copied": "URL kopyalandı",
       "openExternalFailed": "URL varsayılan tarayıcıda açılamadı",
+      "openPullRequestFailed": "Pull request sekmesi açılamadı",
       "groupTitle": "Web sayfaları"
     },
     "path": {

--- a/src/i18n/locales/vi/sessions.json
+++ b/src/i18n/locales/vi/sessions.json
@@ -2757,6 +2757,8 @@
     },
     "actions": {
       "moreOpenOptions": "Thêm tùy chọn mở",
+      "openAsPullRequest": "Thẻ PR",
+      "openAsWebPage": "Trang web",
       "openInApp": "Mở trong ứng dụng",
       "openWithDefaultBrowser": "Mở bằng trình duyệt mặc định",
       "revealInFinder": "Hiển thị trong Finder",
@@ -2768,6 +2770,7 @@
       "copyUrl": "Sao chép URL",
       "copied": "Đã sao chép URL",
       "openExternalFailed": "Không thể mở URL trong trình duyệt mặc định",
+      "openPullRequestFailed": "Không thể mở thẻ pull request",
       "groupTitle": "Trang web"
     },
     "path": {

--- a/src/i18n/locales/zh-Hant/sessions.json
+++ b/src/i18n/locales/zh-Hant/sessions.json
@@ -2775,6 +2775,8 @@
     },
     "actions": {
       "moreOpenOptions": "更多開啟選項",
+      "openAsPullRequest": "PR 分頁",
+      "openAsWebPage": "網頁",
       "openInApp": "在應用程式內開啟",
       "openWithDefaultBrowser": "用預設瀏覽器開啟",
       "revealInFinder": "在 Finder 中顯示",
@@ -2786,6 +2788,7 @@
       "copyUrl": "複製 URL",
       "copied": "URL 複製",
       "openExternalFailed": "無法用預設瀏覽器開啟 URL",
+      "openPullRequestFailed": "無法開啟 Pull Request 分頁",
       "groupTitle": "網頁"
     },
     "path": {

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -2872,6 +2872,8 @@
     },
     "actions": {
       "moreOpenOptions": "更多打开选项",
+      "openAsPullRequest": "PR 标签页",
+      "openAsWebPage": "网页",
       "openInApp": "在应用内打开",
       "openWithDefaultBrowser": "用默认浏览器打开",
       "revealInFinder": "在 Finder 中显示",
@@ -2883,6 +2885,7 @@
       "copyUrl": "复制 URL",
       "copied": "URL 复制",
       "openExternalFailed": "无法用默认浏览器打开 URL",
+      "openPullRequestFailed": "无法打开 Pull Request 标签页",
       "groupTitle": "网页"
     },
     "path": {


### PR DESCRIPTION
## Problem

HTTP link hover cards only provide generic app and browser actions. GitHub pull request links cannot use the existing pull-request detail tab, the icon actions use bordered styling that does not match the hover treatment, and long action labels make the compact menu harder to scan.

## Solution

Recognize GitHub pull request URLs, validate that the active workspace remotes match the linked repository, fetch PR details, and open the existing PR tab as the default split-button action. The menu exposes concise `PR tab` and `Web page` alternatives. Copy and external-browser icons now use the design-system tertiary button behavior, and the hover-card panel allows its anchored menu to overflow. All 13 locales receive the new labels and failure message.

## Potential risks

Opening a PR tab depends on GitHub detail and git-remote calls; unavailable credentials, backend failures, or a mismatched active workspace show the localized error and leave the hover card available. No persistence, IPC contract, dependency, or wire-format change is introduced. Runtime visual evidence is still missing, so this PR remains Draft.

## Verification

- `pnpm exec vitest run src/components/MarkDown/LinkHoverCard.helpers.test.ts` — passed 6/6 after rebasing onto the latest `develop`
- `pnpm exec eslint src/components/MarkDown/LinkHoverCard.helpers.test.ts src/components/MarkDown/LinkHoverCard.helpers.ts src/components/MarkDown/LinkHoverCard.tsx src/components/MarkDown/MarkDownImpl.tsx src/components/SessionHoverCard/HoverCardBase.tsx --max-warnings 0 --report-unused-disable-directives` — passed
- `pnpm typecheck` — passed
- Parsed every `src/i18n/locales/*/sessions.json` file with `jq -e` — passed
- `git diff --check origin/develop...HEAD` — passed
- In-app visual and interaction verification was not run because desktop UI control was not authorized; this remains the Draft blocker

## UI audit

The workspace `frontend-ui-audit` skill is unavailable, so the changed components were checked manually. Existing Button, SplitButton, Dropdown, Menu, and hover-card primitives are reused; no new arbitrary design tokens were introduced; icon-only controls retain accessible labels; and the split menu exposes `aria-haspopup`, `aria-expanded`, and a localized accessible name.