### PR TITLE
fix(chat-history): preserve turn identity across render modes

### DIFF
--- a/src/engines/ChatPanel/ChatHistory/components/ChatHistoryList.tsx
+++ b/src/engines/ChatPanel/ChatHistory/components/ChatHistoryList.tsx
@@ -38,6 +38,7 @@ import { useChatHistoryListActiveGroupReporter } from "./ChatHistoryListActiveGr
 import { sameChatHistoryListProps } from "./ChatHistoryListEquality";
 import {
   EMPTY_ROW_GROUP_META,
+  buildChatGroupRenderKeys,
   buildRowGroupMeta,
   isScrolledToContentBottom,
   resolveActiveGroupPinState,
@@ -132,6 +133,10 @@ const ChatHistoryList: React.FC<ChatHistoryListProps> = memo(
         return group;
       });
     }, [effectiveGroupCounts]);
+    const groupRenderKeys = useMemo(
+      () => buildChatGroupRenderKeys(turnIds),
+      [turnIds]
+    );
     const flatIndexToGroupIndex = useMemo(() => {
       const indexes: number[] = [];
       for (const group of virtualGroups) {
@@ -147,64 +152,10 @@ const ChatHistoryList: React.FC<ChatHistoryListProps> = memo(
       getScrollElement: () => virtualScrollerRef.current,
       estimateSize: () => 360,
       overscan: 4,
-      getItemKey: (index) => {
-        const group = virtualGroups[index];
-        if (!group) return `chat-group-${index}:0`;
-        const itemKeys = flatItems
-          .slice(group.startFlatIndex, group.startFlatIndex + group.itemCount)
-          .map((item) => {
-            const event = item.event;
-            const displayTextLength = event?.displayText?.length ?? 0;
-            return [
-              item.chunk_id,
-              event?.displayStatus ?? "",
-              event?.activityStatus ?? "",
-              displayTextLength,
-            ].join(":");
-          })
-          .join("|");
-        return `${index}:${group.itemCount}:${itemKeys}`;
-      },
+      getItemKey: (index) =>
+        groupRenderKeys[index] ?? `chat-group-index:${index}`,
     });
     const virtualItems = virtualizer.getVirtualItems();
-    const rowResizeObserverRef = useRef<ResizeObserver | null>(null);
-    const measuredRowHeightsRef = useRef(new WeakMap<Element, number>());
-    const observedRowsRef = useRef(new Set<Element>());
-    const measureVirtualRow = useCallback(
-      (node: HTMLDivElement | null) => {
-        if (!node) return;
-        if (!rowResizeObserverRef.current) {
-          rowResizeObserverRef.current = new ResizeObserver((entries) => {
-            for (const entry of entries) {
-              const target = entry.target;
-              const nextHeight =
-                entry.borderBoxSize[0]?.blockSize ??
-                target.getBoundingClientRect().height;
-              if (measuredRowHeightsRef.current.get(target) === nextHeight) {
-                continue;
-              }
-              measuredRowHeightsRef.current.set(target, nextHeight);
-              virtualizer.measureElement(target as HTMLElement);
-            }
-          });
-        }
-        virtualizer.measureElement(node);
-        if (!observedRowsRef.current.has(node)) {
-          observedRowsRef.current.add(node);
-          rowResizeObserverRef.current.observe(node);
-        }
-      },
-      [virtualizer]
-    );
-
-    useEffect(() => {
-      const observedRows = observedRowsRef.current;
-      return () => {
-        rowResizeObserverRef.current?.disconnect();
-        rowResizeObserverRef.current = null;
-        observedRows.clear();
-      };
-    }, [virtualListDataKey]);
 
     useEffect(() => {
       if (virtualItems.length === 0) return;
@@ -303,37 +254,21 @@ const ChatHistoryList: React.FC<ChatHistoryListProps> = memo(
 
     const staticGroups = useMemo(() => {
       if (!useStaticRendering) return [];
-      const seenGroupKeys = new Set<string>();
       let nextGroupStartFlatIndex = 0;
       return effectiveGroupCounts.map((groupItemCount, groupIndex) => {
         const groupStartFlatIndex = nextGroupStartFlatIndex;
         nextGroupStartFlatIndex += groupItemCount;
-        // Only a group that owns at least one item may borrow its identity from
-        // one. A zero-count group's start index points at the *next* group's
-        // first item, so reading it unconditionally makes both groups emit the
-        // same key ("Encountered two children with the same key"). Empty groups
-        // are produced by useChatGroupsProjection when a collapsed turn has no
-        // structural source.
-        const firstItem =
-          groupItemCount > 0 ? flatItems[groupStartFlatIndex] : undefined;
-        let groupKey =
-          firstItem?.event?.id ??
-          firstItem?.chunk_id ??
-          `static-group-${groupIndex}`;
-        if (seenGroupKeys.has(groupKey)) {
-          groupKey = `${groupKey}#${groupIndex}`;
-        }
-        seenGroupKeys.add(groupKey);
         return {
           groupIndex,
-          groupKey,
+          groupKey:
+            groupRenderKeys[groupIndex] ?? `chat-group-index:${groupIndex}`,
           itemIndexes: Array.from(
             { length: groupItemCount },
             (_, itemOffset) => groupStartFlatIndex + itemOffset
           ),
         };
       });
-    }, [useStaticRendering, effectiveGroupCounts, flatItems]);
+    }, [useStaticRendering, effectiveGroupCounts, groupRenderKeys]);
 
     const renderGroupItem = React.useCallback(
       (flatIndex: number, groupIndex: number) => {
@@ -397,97 +332,22 @@ const ChatHistoryList: React.FC<ChatHistoryListProps> = memo(
         hideActiveGroupHeader,
         onActiveGroupIndexChange,
       });
-
-    if (useStaticRendering) {
-      return (
-        <div
-          ref={staticScrollerRef}
-          className="allow-select-deep h-full overflow-y-auto overscroll-contain scrollbar-hide"
-          style={{ paddingTop: topPaddingPx }}
-          onScroll={(event) => {
-            const element = event.currentTarget;
-            onAtBottomStateChange(
-              isScrolledToContentBottom({
-                element,
-                footerSpacerHeight,
-                bottomInset,
-              })
-            );
-            scheduleReportActiveGroupIndex(element);
-          }}
-        >
-          <div
-            className={`mx-auto min-h-full w-full ${DETAIL_PANEL_TOKENS.contentMaxWidth}`}
-          >
-            {staticGroups.map(({ groupIndex, groupKey, itemIndexes }) => (
-              <div
-                key={groupKey}
-                className="relative"
-                data-chat-group-index={groupIndex}
-              >
-                <div data-chat-group-header>
-                  <div className="relative z-[30]">
-                    {renderGroupHeaderProp(groupIndex, "user")}
-                  </div>
-                  {renderGroupHeaderProp(groupIndex, "collapse")}
-                </div>
-                {itemIndexes.map((itemFlatIndex) => {
-                  if (itemFlatIndex >= flatItems.length) {
-                    return (
-                      <PlanningFooter
-                        key={`planning-footer-${itemFlatIndex}`}
-                        count={planningIndicatorCount}
-                        variantIndex={planningVariantIndex}
-                        mode={planningFooterMode}
-                      />
-                    );
-                  }
-                  const itemKey =
-                    flatItems[itemFlatIndex]?.chunk_id ??
-                    `static-chat-${itemFlatIndex}`;
-                  const rowMeta =
-                    rowGroupMeta[itemFlatIndex] ?? EMPTY_ROW_GROUP_META;
-                  return (
-                    <GroupItemRenderer
-                      key={itemKey}
-                      flatIndex={itemFlatIndex}
-                      groupIndex={groupIndex}
-                      turnId={turnIds[groupIndex] ?? null}
-                      assistantCopyEventIds={
-                        assistantCopyEventIdsByGroup[groupIndex] ?? []
-                      }
-                      resolveAssistantTurnCopyContent={
-                        resolveAssistantTurnCopyContent
-                      }
-                      chatItem={flatItems[itemFlatIndex]}
-                      previousChatItem={previousChatItems[itemFlatIndex]}
-                      lastAssistantFlatIndex={rowMeta.lastAssistantFlatIndex}
-                      isLastItemInGroup={rowMeta.isLastItemInGroup}
-                      isLastGroup={rowMeta.isLastGroup}
-                      isWpGeneWorking={false}
-                      isExploring={false}
-                      codeBlockContainerWidth={codeBlockContainerWidth}
-                      onRegenerate={onRegenerate}
-                      onSubmit={onSubmit}
-                      onSkip={onSkip}
-                      onEditUserMessage={onEditUserMessage}
-                      newEventDividerLabel={newEventDividerLabel}
-                    />
-                  );
-                })}
-              </div>
-            ))}
-            <div style={{ height: footerSpacerHeight }} />
-          </div>
-        </div>
-      );
-    }
+    const setScrollContainerRef = useCallback(
+      (node: HTMLDivElement | null) => {
+        if (useStaticRendering) {
+          if (staticScrollerRef) staticScrollerRef.current = node;
+          virtualScrollerRef.current = null;
+          return;
+        }
+        if (staticScrollerRef) staticScrollerRef.current = null;
+        virtualScrollerRef.current = node;
+      },
+      [staticScrollerRef, useStaticRendering, virtualScrollerRef]
+    );
 
     return (
       <div
-        ref={(node) => {
-          virtualScrollerRef.current = node;
-        }}
+        ref={setScrollContainerRef}
         data-testid="chat-history-scroll-container"
         className="allow-select-deep h-full w-full overflow-y-auto overscroll-contain scrollbar-hide"
         style={{ paddingTop: topPaddingPx }}
@@ -500,47 +360,119 @@ const ChatHistoryList: React.FC<ChatHistoryListProps> = memo(
           });
           onAtBottomStateChange(isAtBottom);
           scheduleReportActiveGroupIndex(element);
-          if (isAtBottom) onEndReached();
+          if (!useStaticRendering && isAtBottom) onEndReached();
         }}
       >
         <div
-          className={`relative mx-auto min-h-full w-full ${DETAIL_PANEL_TOKENS.contentMaxWidth}`}
-          style={{ height: virtualizer.getTotalSize() + footerSpacerHeight }}
+          className={`${useStaticRendering ? "mx-auto" : "relative mx-auto"} min-h-full w-full ${DETAIL_PANEL_TOKENS.contentMaxWidth}`}
+          style={
+            useStaticRendering
+              ? undefined
+              : { height: virtualizer.getTotalSize() + footerSpacerHeight }
+          }
         >
-          {virtualItems.map((virtualItem) => {
-            const group = virtualGroups[virtualItem.index];
-            if (!group) return null;
-            return (
-              <div
-                key={virtualItem.key}
-                ref={measureVirtualRow}
-                data-index={virtualItem.index}
-                data-chat-group-index={group.groupIndex}
-                className="absolute left-0 top-0 w-full"
-                style={{
-                  transform: `translateY(${virtualItem.start}px)`,
-                }}
-              >
-                <div data-chat-group-header>
-                  <div className="relative z-[30]">
-                    {renderGroupHeaderProp(group.groupIndex, "user")}
-                  </div>
-                  {renderGroupHeaderProp(group.groupIndex, "collapse")}
-                </div>
-                {Array.from({ length: group.itemCount }, (_, itemOffset) => {
-                  const flatIndex = group.startFlatIndex + itemOffset;
-                  return (
-                    <div
-                      key={`virtual-item-${flatIndex}`}
-                      data-item-index={flatIndex}
-                    >
-                      {renderGroupItem(flatIndex, group.groupIndex)}
+          {useStaticRendering
+            ? staticGroups.map(({ groupIndex, groupKey, itemIndexes }) => (
+                <div
+                  key={groupKey}
+                  className="relative"
+                  data-chat-group-index={groupIndex}
+                >
+                  <div data-chat-group-header>
+                    <div className="relative z-[30]">
+                      {renderGroupHeaderProp(groupIndex, "user")}
                     </div>
-                  );
-                })}
-              </div>
-            );
-          })}
+                    {renderGroupHeaderProp(groupIndex, "collapse")}
+                  </div>
+                  {itemIndexes.map((itemFlatIndex) => {
+                    if (itemFlatIndex >= flatItems.length) {
+                      return (
+                        <PlanningFooter
+                          key={`planning-footer-${itemFlatIndex}`}
+                          count={planningIndicatorCount}
+                          variantIndex={planningVariantIndex}
+                          mode={planningFooterMode}
+                        />
+                      );
+                    }
+                    const itemKey =
+                      flatItems[itemFlatIndex]?.chunk_id ??
+                      `static-chat-${itemFlatIndex}`;
+                    const rowMeta =
+                      rowGroupMeta[itemFlatIndex] ?? EMPTY_ROW_GROUP_META;
+                    return (
+                      <GroupItemRenderer
+                        key={itemKey}
+                        flatIndex={itemFlatIndex}
+                        groupIndex={groupIndex}
+                        turnId={turnIds[groupIndex] ?? null}
+                        assistantCopyEventIds={
+                          assistantCopyEventIdsByGroup[groupIndex] ?? []
+                        }
+                        resolveAssistantTurnCopyContent={
+                          resolveAssistantTurnCopyContent
+                        }
+                        chatItem={flatItems[itemFlatIndex]}
+                        previousChatItem={previousChatItems[itemFlatIndex]}
+                        lastAssistantFlatIndex={rowMeta.lastAssistantFlatIndex}
+                        isLastItemInGroup={rowMeta.isLastItemInGroup}
+                        isLastGroup={rowMeta.isLastGroup}
+                        isWpGeneWorking={false}
+                        isExploring={false}
+                        codeBlockContainerWidth={codeBlockContainerWidth}
+                        onRegenerate={onRegenerate}
+                        onSubmit={onSubmit}
+                        onSkip={onSkip}
+                        onEditUserMessage={onEditUserMessage}
+                        newEventDividerLabel={newEventDividerLabel}
+                      />
+                    );
+                  })}
+                </div>
+              ))
+            : virtualItems.map((virtualItem) => {
+                const group = virtualGroups[virtualItem.index];
+                if (!group) return null;
+                return (
+                  <div
+                    key={
+                      groupRenderKeys[group.groupIndex] ??
+                      `chat-group-index:${group.groupIndex}`
+                    }
+                    ref={virtualizer.measureElement}
+                    data-index={virtualItem.index}
+                    data-chat-group-index={group.groupIndex}
+                    className="absolute left-0 top-0 w-full"
+                    style={{
+                      transform: `translateY(${virtualItem.start}px)`,
+                    }}
+                  >
+                    <div data-chat-group-header>
+                      <div className="relative z-[30]">
+                        {renderGroupHeaderProp(group.groupIndex, "user")}
+                      </div>
+                      {renderGroupHeaderProp(group.groupIndex, "collapse")}
+                    </div>
+                    {Array.from(
+                      { length: group.itemCount },
+                      (_, itemOffset) => {
+                        const flatIndex = group.startFlatIndex + itemOffset;
+                        return (
+                          <div
+                            key={`virtual-item-${flatIndex}`}
+                            data-item-index={flatIndex}
+                          >
+                            {renderGroupItem(flatIndex, group.groupIndex)}
+                          </div>
+                        );
+                      }
+                    )}
+                  </div>
+                );
+              })}
+          {useStaticRendering ? (
+            <div style={{ height: footerSpacerHeight }} />
+          ) : null}
         </div>
       </div>
     );

--- a/src/engines/ChatPanel/ChatHistory/components/ChatHistoryListLayout.ts
+++ b/src/engines/ChatPanel/ChatHistory/components/ChatHistoryListLayout.ts
@@ -15,6 +15,26 @@ import type {
 
 const AT_BOTTOM_EPSILON_PX = 4;
 
+/**
+ * React identities for turn rows. A turn's visible body items change when the
+ * user expands/collapses it, so body-derived keys remount the unchanged header
+ * (including attached-image thumbnails). Keep identity on the turn instead.
+ *
+ * Headerless groups cannot participate in turn collapse because they have no
+ * turn id; their positional fallback is therefore stable for this interaction.
+ */
+export function buildChatGroupRenderKeys(
+  turnIds: readonly (string | null)[]
+): string[] {
+  const occurrences = new Map<string, number>();
+  return turnIds.map((turnId, groupIndex) => {
+    if (turnId === null) return `chat-group-index:${groupIndex}`;
+    const occurrence = occurrences.get(turnId) ?? 0;
+    occurrences.set(turnId, occurrence + 1);
+    return `chat-turn:${turnId}:occurrence:${occurrence}`;
+  });
+}
+
 export function isScrolledToContentBottom(params: {
   element: HTMLElement;
   footerSpacerHeight: number;

--- a/src/engines/ChatPanel/ChatHistory/components/__tests__/ChatHistoryListIdentity.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/components/__tests__/ChatHistoryListIdentity.test.ts
@@ -1,0 +1,219 @@
+// @vitest-environment jsdom
+import {
+  type MutableRefObject,
+  act,
+  createElement,
+  createRef,
+  useEffect,
+} from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import type { OptimizedChatItem } from "../../chatItemPipeline/types";
+import type { GroupHeaderRenderPart } from "../../renderers/GroupHeaderRenderer";
+import ChatHistoryList from "../ChatHistoryList";
+import { buildChatGroupRenderKeys } from "../ChatHistoryListLayout";
+import type {
+  ChatHistoryListHandle,
+  ChatHistoryListProps,
+} from "../ChatHistoryListTypes";
+
+const { measureElementSpy } = vi.hoisted(() => ({
+  measureElementSpy: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: (options: {
+    count: number;
+    getItemKey: (index: number) => string | number;
+  }) => {
+    const items = Array.from({ length: options.count }, (_, index) => ({
+      index,
+      key: options.getItemKey(index),
+      start: index * 360,
+    }));
+    return {
+      getTotalSize: () => options.count * 360,
+      getVirtualItems: () => items,
+      measureElement: measureElementSpy,
+      scrollToIndex: () => undefined,
+    };
+  },
+}));
+
+vi.mock("../../renderers", () => ({
+  GroupItemRenderer: () => null,
+}));
+
+function bodyItem(index: number): OptimizedChatItem {
+  return {
+    chunk_id: `body-${index}`,
+    type: "activity",
+    event: { id: `event-${index}` },
+  } as OptimizedChatItem;
+}
+
+describe("buildChatGroupRenderKeys", () => {
+  it("keeps turn identity independent from visible body items", () => {
+    expect(
+      buildChatGroupRenderKeys(["turn-with-image", null, "turn-with-image"])
+    ).toEqual([
+      "chat-turn:turn-with-image:occurrence:0",
+      "chat-group-index:1",
+      "chat-turn:turn-with-image:occurrence:1",
+    ]);
+  });
+});
+
+describe("ChatHistoryList turn identity", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let imageMounts = 0;
+  let imageUnmounts = 0;
+  let originalRequestAnimationFrame: typeof window.requestAnimationFrame;
+  let originalCancelAnimationFrame: typeof window.cancelAnimationFrame;
+
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+  const virtualListRef = createRef<ChatHistoryListHandle>();
+  const virtualScrollerRef: MutableRefObject<HTMLDivElement | null> = {
+    current: null,
+  };
+  const staticScrollerRef: MutableRefObject<HTMLDivElement | null> = {
+    current: null,
+  };
+  const noop = () => undefined;
+  const renderGroupHeader = (
+    _groupIndex: number,
+    renderPart: GroupHeaderRenderPart = "all"
+  ) => {
+    if (renderPart === "collapse") return null;
+    return createElement(HeaderImage);
+  };
+
+  function HeaderImage() {
+    useEffect(() => {
+      imageMounts += 1;
+      return () => {
+        imageUnmounts += 1;
+      };
+    }, []);
+    return createElement("img", {
+      "data-testid": "appended-image",
+      alt: "Attached",
+      src: "data:image/png;base64,AA==",
+    });
+  }
+
+  function listProps(
+    flatItems: OptimizedChatItem[],
+    virtualListDataKey: string
+  ): ChatHistoryListProps {
+    return {
+      flatItems,
+      groupCounts: [flatItems.length],
+      turnIds: ["turn-with-image"],
+      assistantCopyEventIdsByGroup: [[]],
+      resolveAssistantTurnCopyContent: () => "",
+      totalFlatItems: flatItems.length,
+      lastAssistantFlatIndexPerItem: flatItems.map(() => null),
+      codeBlockContainerWidth: 800,
+      footerSpacerHeight: 0,
+      bottomInset: 0,
+      topPaddingPx: 0,
+      planningIndicatorCount: 0,
+      planningVariantIndex: 0,
+      planningFooterMode: "planning",
+      virtualListRef,
+      virtualListDataKey,
+      getIsWpGeneWorking: () => false,
+      getIsExploring: () => false,
+      renderGroupHeader,
+      onAtBottomStateChange: noop,
+      onRangeChanged: noop,
+      onEndReached: noop,
+      onSubmit: noop,
+      onSkip: noop,
+      virtualScrollerRef,
+      staticScrollerRef,
+    };
+  }
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+    originalRequestAnimationFrame = window.requestAnimationFrame;
+    originalCancelAnimationFrame = window.cancelAnimationFrame;
+    window.requestAnimationFrame = () => 1;
+    window.cancelAnimationFrame = () => undefined;
+  });
+
+  beforeEach(() => {
+    imageMounts = 0;
+    imageUnmounts = 0;
+    measureElementSpy.mockClear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+    window.requestAnimationFrame = originalRequestAnimationFrame;
+    window.cancelAnimationFrame = originalCancelAnimationFrame;
+  });
+
+  it("preserves the appended image while collapse changes the body and render mode", () => {
+    const collapsedItems = [bodyItem(24)];
+    const expandedItems = Array.from({ length: 25 }, (_, index) =>
+      bodyItem(index)
+    );
+
+    act(() =>
+      root.render(
+        createElement(ChatHistoryList, listProps(collapsedItems, "collapsed"))
+      )
+    );
+    const originalImage = container.querySelector(
+      '[data-testid="appended-image"]'
+    );
+
+    act(() =>
+      root.render(
+        createElement(ChatHistoryList, listProps(expandedItems, "expanded"))
+      )
+    );
+    act(() =>
+      root.render(
+        createElement(
+          ChatHistoryList,
+          listProps(collapsedItems, "collapsed-again")
+        )
+      )
+    );
+
+    expect(imageMounts).toBe(1);
+    expect(imageUnmounts).toBe(0);
+    expect(container.querySelector('[data-testid="appended-image"]')).toBe(
+      originalImage
+    );
+    expect(measureElementSpy).toHaveBeenCalledWith(expect.any(HTMLDivElement));
+    expect(measureElementSpy.mock.calls.some(([node]) => node === null)).toBe(
+      true
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Chat turn groups derive React keys from their currently visible body items, and small versus virtualized histories render through separate root trees. Collapsing or expanding a turn can therefore change both the group key and render mode, remounting an unchanged user header and its attached-image thumbnail.

## Solution

Derive group identity from the durable turn id, keep duplicate handling deterministic, and render static and virtual groups under one stable scroll-container topology. Virtual rows now use the TanStack measurement ref directly. A lifecycle regression test crosses the 24-item render threshold and proves the same attached-image DOM node survives expand and collapse transitions.

## Potential risks

The shared container and measurement callback touch virtual-row sizing and scroll behavior near the static-to-virtual threshold. Focused pinning, pagination, collapse, copy, and identity tests cover the affected boundaries, but no runtime frame-time claim is made. Screenshots are not useful evidence for this change because the intended pixels are unchanged; the invariant is DOM-node identity, asserted directly by the regression test.

## Verification

- `pnpm exec vitest run src/engines/ChatPanel/ChatHistory/components/__tests__/ChatHistoryListIdentity.test.ts src/engines/ChatPanel/ChatHistory/components/__tests__/ChatHistoryListPinning.test.ts src/engines/ChatPanel/ChatHistory/hooks/__tests__/useTailTurnCollapse.test.ts src/engines/ChatPanel/ChatHistory/hooks/__tests__/useChatTurnPagination.test.ts src/engines/ChatPanel/ChatHistory/turnCopyContent.test.ts` — passed 28/28 after rebasing onto the latest `develop`
- `pnpm exec eslint src/engines/ChatPanel/ChatHistory/components/ChatHistoryList.tsx src/engines/ChatPanel/ChatHistory/components/ChatHistoryListLayout.ts src/engines/ChatPanel/ChatHistory/components/__tests__/ChatHistoryListIdentity.test.ts --max-warnings 0 --report-unused-disable-directives` — passed
- `pnpm typecheck` — passed
- `git diff --check origin/develop...HEAD` — passed

## React performance review

No timer, subscription, retained cache, or asynchronous work is added. Render keys require an ephemeral O(group count) map per changed turn-id array. Stable identity avoids lifecycle churn across render modes, but this PR makes no unmeasured runtime-performance claim.