### PR TITLE
fix(session-images): preserve shared attachment ownership

### DIFF
--- a/src-tauri/crates/agent-core/src/foundation/persistence/db_helpers/messages/cleanup.rs
+++ b/src-tauri/crates/agent-core/src/foundation/persistence/db_helpers/messages/cleanup.rs
@@ -1,17 +1,17 @@
-//! Image-aware deletion helpers for the `<prefix>_messages` table.
+//! Image-reference-aware deletion helpers for the `<prefix>_messages` table.
 //!
-//! Every public delete function here first walks the rows it is about
-//! to remove and asks `images::delete_image_files` to drop the on-disk
-//! payloads. Skipping the cleanup step would leak files in
-//! `~/.orgii/...` because the DB row is the only reference back.
+//! Image files are content-addressed and shared across sessions, so message
+//! deletion must never remove them eagerly. The global housekeeping pass owns
+//! physical deletion after enumerating every surviving reference source.
+//! These functions still validate serialized refs before deleting rows so a
+//! malformed persistence record fails loudly instead of being discarded.
 
 use rusqlite::{params, types::Type, Result as SqliteResult};
 
-use crate::persistence::images;
 use database::db::{get_connection, with_sessions_writer};
-/// Collect image file paths from messages matching a WHERE clause, then delete
-/// the corresponding files from disk. Called before deleting the DB rows.
-pub(super) fn cleanup_image_files_for_query(
+/// Validate image refs in messages matching a WHERE clause before deleting
+/// the corresponding DB rows.
+pub(super) fn validate_image_refs_for_query(
     prefix: &str,
     where_clause: &str,
     params: &[&dyn rusqlite::ToSql],
@@ -21,31 +21,20 @@ pub(super) fn cleanup_image_files_for_query(
         format!("SELECT images FROM {prefix}_messages WHERE {where_clause} AND images IS NOT NULL");
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map(params, |row| row.get::<_, String>(0))?;
-    let mut paths = Vec::new();
-
     for row in rows {
         let json_str = row?;
-        let image_paths: Vec<String> = serde_json::from_str(&json_str).map_err(|err| {
+        let _: Vec<String> = serde_json::from_str(&json_str).map_err(|err| {
             rusqlite::Error::FromSqlConversionFailure(0, Type::Text, Box::new(err))
         })?;
-        paths.extend(
-            image_paths
-                .into_iter()
-                .filter(|path| !path.starts_with("data:")),
-        );
-    }
-
-    if !paths.is_empty() {
-        images::delete_image_files(&paths);
     }
 
     Ok(())
 }
 
 /// Delete all messages for a session.
-/// Also cleans up any image files referenced by the deleted messages.
+/// Shared image files are reclaimed later by global housekeeping.
 pub fn clear_messages(prefix: &str, session_id: &str) -> SqliteResult<i64> {
-    cleanup_image_files_for_query(prefix, "session_id = ?1", &[&session_id])?;
+    validate_image_refs_for_query(prefix, "session_id = ?1", &[&session_id])?;
     with_sessions_writer(|| {
         let mut conn = get_connection()?;
         let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
@@ -67,7 +56,7 @@ pub fn clear_messages(prefix: &str, session_id: &str) -> SqliteResult<i64> {
 }
 
 /// Delete messages at or after a specific sequence number.
-/// Also cleans up any image files referenced by the deleted messages.
+/// Shared image files are reclaimed later by global housekeeping.
 ///
 /// Sequence is the **only** truncation coordinate for `<prefix>_messages`:
 /// it is assigned append-only and never rewritten, so `sequence >= ?`
@@ -79,7 +68,7 @@ pub fn truncate_messages_from_sequence(
     session_id: &str,
     from_sequence: i64,
 ) -> SqliteResult<i64> {
-    cleanup_image_files_for_query(
+    validate_image_refs_for_query(
         prefix,
         "session_id = ?1 AND sequence >= ?2",
         &[&session_id as &dyn rusqlite::ToSql, &from_sequence],

--- a/src-tauri/crates/agent-core/src/foundation/persistence/db_helpers/messages/mod.rs
+++ b/src-tauri/crates/agent-core/src/foundation/persistence/db_helpers/messages/mod.rs
@@ -1,4 +1,4 @@
-//! Message-table helpers: CRUD, image cleanup, builder shortcuts, and
+//! Message-table helpers: CRUD, image-reference validation, builder shortcuts, and
 //! LLM history reconstruction.
 //!
 //! Split out of a single 802-line `messages.rs` (Apr 2026). The parent
@@ -7,7 +7,7 @@
 //! continue to import via `agent_core::persistence::*`.
 //!
 //! Submodules:
-//! - `cleanup`  — image-file cleanup + table-level deletes
+//! - `cleanup`  — image-reference validation + table-level deletes
 //!   (`clear_messages`, `truncate_messages_from_sequence`).
 //! - `builders` — typed convenience constructors that wrap `insert_message_retry`
 //!   (`save_user_msg`, `save_assistant_msg`, `save_tool_call_msg`,

--- a/src-tauri/crates/agent-core/src/foundation/persistence/db_helpers/mod.rs
+++ b/src-tauri/crates/agent-core/src/foundation/persistence/db_helpers/mod.rs
@@ -93,54 +93,44 @@ mod tests {
     }
 }
 
-/// Collect all image file paths referenced by messages in a session.
-fn collect_session_image_paths(prefix: &str, session_id: &str) -> SqliteResult<Vec<String>> {
+/// Validate every serialized image-reference array in a session.
+fn validate_session_image_refs(prefix: &str, session_id: &str) -> SqliteResult<()> {
     let conn = get_connection()?;
-    collect_session_image_paths_with_connection(&conn, prefix, session_id)
+    validate_session_image_refs_with_connection(&conn, prefix, session_id)
 }
 
-fn collect_session_image_paths_with_connection(
+fn validate_session_image_refs_with_connection(
     conn: &rusqlite::Connection,
     prefix: &str,
     session_id: &str,
-) -> SqliteResult<Vec<String>> {
+) -> SqliteResult<()> {
     let sql = format!(
         "SELECT images FROM {prefix}_messages WHERE session_id = ?1 AND images IS NOT NULL"
     );
     let mut stmt = conn.prepare(&sql)?;
     let rows = stmt.query_map([session_id], |row| row.get::<_, String>(0))?;
-    let mut paths = Vec::new();
-
     for row in rows {
         let json_str = row?;
-        let image_paths: Vec<String> = serde_json::from_str(&json_str).map_err(|err| {
+        let _: Vec<String> = serde_json::from_str(&json_str).map_err(|err| {
             rusqlite::Error::FromSqlConversionFailure(0, Type::Text, Box::new(err))
         })?;
-        paths.extend(
-            image_paths
-                .into_iter()
-                .filter(|path| !path.starts_with("data:")),
-        );
     }
 
-    Ok(paths)
+    Ok(())
 }
 
 /// Delete all rows referencing `session_id` from each table in `tables`.
-/// Also deletes any image files on disk referenced by the session's messages.
+/// Shared image files are reclaimed later by global housekeeping.
 pub fn delete_session_cascade(session_id: &str, tables: &[&str]) -> SqliteResult<()> {
-    // Collect image file paths before deleting the rows. Infer the
-    // prefix from the first table that ends with "_messages".
+    // Validate image refs before deleting the rows. Infer the prefix from the
+    // first table that ends with "_messages".
     let prefix = tables
         .iter()
         .find(|t| t.ends_with("_messages"))
         .and_then(|t| t.strip_suffix("_messages"));
 
     if let Some(prefix) = prefix {
-        let image_paths = collect_session_image_paths(prefix, session_id)?;
-        if !image_paths.is_empty() {
-            super::images::delete_image_files(&image_paths);
-        }
+        validate_session_image_refs(prefix, session_id)?;
     }
 
     with_sessions_writer(|| {
@@ -164,18 +154,15 @@ pub(crate) fn delete_session_cascade_with_connection(
     session_id: &str,
     tables: &[&str],
 ) -> SqliteResult<()> {
-    // Collect image file paths before deleting the rows. Infer the
-    // prefix from the first table that ends with "_messages".
+    // Validate image refs before deleting the rows. Infer the prefix from the
+    // first table that ends with "_messages".
     let prefix = tables
         .iter()
         .find(|t| t.ends_with("_messages"))
         .and_then(|t| t.strip_suffix("_messages"));
 
     if let Some(prefix) = prefix {
-        let image_paths = collect_session_image_paths_with_connection(conn, prefix, session_id)?;
-        if !image_paths.is_empty() {
-            super::images::delete_image_files(&image_paths);
-        }
+        validate_session_image_refs_with_connection(conn, prefix, session_id)?;
     }
 
     delete_session_rows_with_connection(conn, session_id, tables)

--- a/src-tauri/src/agent_sessions/cli/mod.rs
+++ b/src-tauri/src/agent_sessions/cli/mod.rs
@@ -94,6 +94,19 @@ pub fn init_cli_agent_tables(conn: &Connection) -> SqliteResult<()> {
             reason     TEXT NOT NULL,
             mutated_at TEXT NOT NULL
         );
+
+        -- The native CLI transcript can be flushed after the attachment file is
+        -- created, so it cannot be the ownership index for session-images.
+        -- Keep a small session-level registry instead. A content-addressed file
+        -- may have multiple rows when several sessions attach identical bytes.
+        CREATE TABLE IF NOT EXISTS code_session_image_refs (
+            session_id TEXT NOT NULL REFERENCES code_sessions(session_id) ON DELETE CASCADE,
+            image_path TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            PRIMARY KEY (session_id, image_path)
+        );
+        CREATE INDEX IF NOT EXISTS idx_code_session_image_refs_path
+            ON code_session_image_refs(image_path);
         ",
     )?;
 
@@ -293,6 +306,24 @@ pub fn init_cli_agent_tables(conn: &Connection) -> SqliteResult<()> {
         [],
     )
     .ok();
+
+    // Files older than this registry cannot be classified safely: native CLI
+    // transcripts used to be their only owner, and some providers retain only
+    // a local path. Housekeeping uses this timestamp as a conservative legacy
+    // cutoff while all newly persisted CLI attachments register above.
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS _migrations (
+            name TEXT PRIMARY KEY,
+            applied_at TEXT NOT NULL
+        );",
+    )?;
+    conn.execute(
+        "INSERT OR IGNORE INTO _migrations (name, applied_at) VALUES (?1, ?2)",
+        rusqlite::params![
+            "code_session_image_refs_v1",
+            chrono::Utc::now().to_rfc3339()
+        ],
+    )?;
 
     Ok(())
 }

--- a/src-tauri/src/agent_sessions/cli/persistence/image_refs.rs
+++ b/src-tauri/src/agent_sessions/cli/persistence/image_refs.rs
@@ -1,0 +1,85 @@
+//! Durable ownership index for CLI chat-image files.
+//!
+//! Native CLI transcripts are eventually consistent with the managed
+//! session: the image file is needed before the child process starts, while
+//! the native transcript may not be flushed until later. Recording ownership
+//! here closes that gap and gives global housekeeping a provider-independent
+//! source of truth.
+
+use rusqlite::{params, Result as SqliteResult};
+
+use database::db::get_connection;
+
+use super::session_crud::now_iso;
+
+/// Register every non-inline image path as owned by `session_id`.
+///
+/// Ownership is session-level on purpose. Native transcript forks can retain
+/// older turns after a message edit, so per-turn deletion would again risk
+/// removing a file that a surviving native fork still references.
+pub fn record_session_image_refs(session_id: &str, image_paths: &[String]) -> SqliteResult<()> {
+    if image_paths.is_empty() {
+        return Ok(());
+    }
+
+    let mut conn = get_connection()?;
+    let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+    let created_at = now_iso();
+    for image_path in image_paths.iter().filter(|path| !path.starts_with("data:")) {
+        tx.execute(
+            "INSERT OR IGNORE INTO code_session_image_refs
+                (session_id, image_path, created_at)
+             VALUES (?1, ?2, ?3)",
+            params![session_id, image_path, created_at],
+        )?;
+    }
+    tx.commit()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::test_env;
+
+    #[test]
+    fn records_deduplicated_session_ownership() {
+        let _sandbox = test_env::sandbox();
+        let conn = get_connection().expect("connection");
+        crate::agent_sessions::cli::init_cli_agent_tables(&conn).expect("CLI schema");
+        let now = now_iso();
+        conn.execute(
+            "INSERT INTO code_sessions (session_id, created_at, updated_at)
+             VALUES (?1, ?2, ?2)",
+            params!["cliagent-image-owner", now],
+        )
+        .expect("session");
+
+        let paths = vec![
+            "/tmp/shared-image.png".to_string(),
+            "/tmp/shared-image.png".to_string(),
+            "data:image/png;base64,aGVsbG8=".to_string(),
+        ];
+        record_session_image_refs("cliagent-image-owner", &paths).expect("record refs");
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM code_session_image_refs WHERE session_id = ?1",
+                ["cliagent-image-owner"],
+                |row| row.get(0),
+            )
+            .expect("ref count");
+        assert_eq!(count, 1, "duplicates and inline data must not add owners");
+
+        conn.execute(
+            "DELETE FROM code_sessions WHERE session_id = ?1",
+            ["cliagent-image-owner"],
+        )
+        .expect("delete session");
+        let count_after_delete: i64 = conn
+            .query_row("SELECT COUNT(*) FROM code_session_image_refs", [], |row| {
+                row.get(0)
+            })
+            .expect("remaining ref count");
+        assert_eq!(count_after_delete, 0, "session deletion releases ownership");
+    }
+}

--- a/src-tauri/src/agent_sessions/cli/persistence/mod.rs
+++ b/src-tauri/src/agent_sessions/cli/persistence/mod.rs
@@ -1,11 +1,13 @@
 //! SQLite persistence for code sessions and chunks.
 
 mod chunk_ops;
+mod image_refs;
 mod session_crud;
 mod types;
 mod worktree_state;
 
 pub use chunk_ops::*;
+pub use image_refs::*;
 pub use session_crud::*;
 pub use types::*;
 pub use worktree_state::*;

--- a/src-tauri/src/agent_sessions/cli/session_runner/helpers.rs
+++ b/src-tauri/src/agent_sessions/cli/session_runner/helpers.rs
@@ -529,10 +529,12 @@ pub(super) async fn snapshot_cli_file_edit(
 pub(super) async fn persist_attached_images(
     session_id: &str,
     images: Option<&[String]>,
-) -> Vec<String> {
-    let Some(imgs) = images else { return vec![] };
+) -> Result<Vec<String>, String> {
+    let Some(imgs) = images else {
+        return Ok(vec![]);
+    };
     if imgs.is_empty() {
-        return vec![];
+        return Ok(vec![]);
     }
 
     let owned_images = imgs.to_vec();
@@ -543,10 +545,17 @@ pub(super) async fn persist_attached_images(
     {
         Ok(paths) => paths,
         Err(err) => {
-            tracing::warn!("[CodeSession] image persistence task failed: {err}");
-            Vec::new()
+            return Err(format!("Image persistence task failed: {err}"));
         }
     };
+
+    // Register ownership before launching the CLI. Native transcript writers
+    // are asynchronous and therefore cannot safely serve as the first durable
+    // reference to a file the child process is about to read.
+    if !paths.is_empty() {
+        crate::agent_sessions::cli::persistence::record_session_image_refs(session_id, &paths)
+            .map_err(|err| format!("Failed to register persisted chat images: {err}"))?;
+    }
 
     if !paths.is_empty() {
         tracing::info!(
@@ -555,7 +564,7 @@ pub(super) async fn persist_attached_images(
             session_id
         );
     }
-    paths
+    Ok(paths)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/agent_sessions/cli/session_runner/session.rs
+++ b/src-tauri/src/agent_sessions/cli/session_runner/session.rs
@@ -385,7 +385,7 @@ pub async fn run_session(
     let use_codex_app_server =
         super::launch_profiles::uses_codex_app_server(&agent, &launch_profile);
 
-    let image_paths = persist_attached_images(&session_id, images.as_deref()).await;
+    let image_paths = persist_attached_images(&session_id, images.as_deref()).await?;
 
     let lifecycle_hook_context = super::harness_hooks::prepare_turn(
         &session_id,

--- a/src-tauri/src/infrastructure/housekeeping.rs
+++ b/src-tauri/src/infrastructure/housekeeping.rs
@@ -20,8 +20,8 @@
 //! - Orphan `agent-worktrees/<repo_hash>/<session_id>/` eviction (session
 //!   no longer present in `agent_sessions` DB)
 //! - Orphan temp scratchpad eviction under `/tmp/orgii-{uid}/.../<session_id>/`
-//! - Orphan `session-images/<hash>.{ext}` eviction (hash no longer
-//!   referenced by any message's `images` column)
+//! - Orphan `session-images/<hash>.{ext}` eviction (aged hash no longer
+//!   referenced by any Rust-agent message or CLI-session image owner)
 //! - Orphan `gateway_bindings` row prune (target session no longer
 //!   present in `agent_sessions`)
 //! - Session-cache TTL prune (`sessions` + `events` for rows older than
@@ -119,7 +119,7 @@ pub struct HousekeepingStats {
     /// Per-session temp scratchpad dirs removed from `/tmp/orgii-{uid}/.../`.
     pub scratchpads_evicted: usize,
     /// Session-image files deleted from `~/.orgii/session-images/` because
-    /// no surviving message row still referenced their filename.
+    /// no surviving Rust-agent or CLI-session owner referenced their filename.
     pub session_images_evicted: usize,
     /// Gateway-binding DB rows deleted because `target_session_id` no
     /// longer exists in `agent_sessions`.
@@ -246,8 +246,8 @@ pub fn run_deferred_cleanup() -> HousekeepingStats {
         Err(err) => tracing::warn!("[housekeeping] merkle prune failed: {}", err),
     }
 
-    // Step 9: session-image orphan eviction — files whose filename no
-    // longer appears in any surviving message's `images` JSON array.
+    // Step 9: session-image orphan eviction — aged files whose filename no
+    // longer appears in any durable Rust-agent or CLI image-reference source.
     match evict_orphan_session_images() {
         Ok(n) => stats.session_images_evicted = n,
         Err(err) => tracing::warn!("[housekeeping] session-images orphan sweep failed: {}", err),
@@ -311,6 +311,21 @@ mod tests {
     fn with_sandbox<F: FnOnce(&Path)>(test: F) {
         let guard = test_env::sandbox();
         test(guard.path());
+    }
+
+    fn initialize_image_registry_with_legacy_cutoff(days_ago: i64) {
+        let conn = session_persistence::get_connection().unwrap();
+        crate::agent_sessions::cli::init_cli_agent_tables(&conn).unwrap();
+        let cutoff = chrono::Utc::now()
+            .checked_sub_signed(chrono::Duration::days(days_ago))
+            .unwrap()
+            .to_rfc3339();
+        conn.execute(
+            "UPDATE _migrations SET applied_at = ?1
+             WHERE name = 'code_session_image_refs_v1'",
+            [cutoff],
+        )
+        .unwrap();
     }
 
     #[test]
@@ -585,12 +600,14 @@ mod tests {
     fn evict_orphan_session_images_removes_unreferenced_files() {
         with_sandbox(|_| {
             agent_core::foundation::persistence::session_snapshots::ensure_tables().unwrap();
+            initialize_image_registry_with_legacy_cutoff(10);
             let dir = paths::session_images_dir();
             std::fs::create_dir_all(&dir).unwrap();
             let referenced = dir.join("live-hash.png");
             let orphan = dir.join("dead-hash.png");
             std::fs::write(&referenced, b"live").unwrap();
             std::fs::write(&orphan, b"dead").unwrap();
+            set_mtime_days_ago(&orphan, 2).unwrap();
 
             // Seed one message row referencing only `live-hash.png`.
             let conn = session_persistence::get_connection().unwrap();
@@ -609,6 +626,104 @@ mod tests {
             assert_eq!(removed, 1);
             assert!(referenced.exists(), "referenced image kept");
             assert!(!orphan.exists(), "orphan image deleted");
+        });
+    }
+
+    #[test]
+    fn evict_orphan_session_images_retains_fresh_unregistered_file() {
+        with_sandbox(|_| {
+            agent_core::foundation::persistence::session_snapshots::ensure_tables().unwrap();
+            initialize_image_registry_with_legacy_cutoff(10);
+            let dir = paths::session_images_dir();
+            std::fs::create_dir_all(&dir).unwrap();
+            let in_flight = dir.join("in-flight-hash.png");
+            std::fs::write(&in_flight, b"being attached").unwrap();
+
+            assert_eq!(evict_orphan_session_images().unwrap(), 0);
+            assert!(
+                in_flight.exists(),
+                "the ownership-commit race stays inside the grace window"
+            );
+        });
+    }
+
+    #[test]
+    fn evict_orphan_session_images_keeps_cli_registry_and_legacy_files() {
+        with_sandbox(|_| {
+            agent_core::foundation::persistence::session_snapshots::ensure_tables().unwrap();
+            initialize_image_registry_with_legacy_cutoff(10);
+            let dir = paths::session_images_dir();
+            std::fs::create_dir_all(&dir).unwrap();
+            let legacy_image = dir.join("legacy-native-hash.png");
+            let native_image = dir.join("native-hash.png");
+            let orphan = dir.join("unowned-hash.png");
+            for path in [&legacy_image, &native_image, &orphan] {
+                std::fs::write(path, b"image").unwrap();
+                set_mtime_days_ago(path, 2).unwrap();
+            }
+            // This file predates the ownership registry, so its native
+            // provider transcript may be the only durable reference.
+            set_mtime_days_ago(&legacy_image, 12).unwrap();
+
+            let conn = session_persistence::get_connection().unwrap();
+            let now = chrono::Utc::now().to_rfc3339();
+            conn.execute(
+                "INSERT INTO code_sessions (session_id, created_at, updated_at)
+                 VALUES ('cliagent-images', ?1, ?1)",
+                [&now],
+            )
+            .unwrap();
+            crate::agent_sessions::cli::persistence::record_session_image_refs(
+                "cliagent-images",
+                &[native_image.to_string_lossy().to_string()],
+            )
+            .unwrap();
+
+            let removed = evict_orphan_session_images().unwrap();
+            assert_eq!(removed, 1);
+            assert!(legacy_image.exists(), "pre-registry native image kept");
+            assert!(native_image.exists(), "native CLI registry image kept");
+            assert!(!orphan.exists(), "aged unowned image deleted");
+        });
+    }
+
+    #[test]
+    fn shared_image_survives_until_its_last_message_owner_is_deleted() {
+        with_sandbox(|_| {
+            agent_core::foundation::persistence::session_snapshots::ensure_tables().unwrap();
+            initialize_image_registry_with_legacy_cutoff(10);
+            let dir = paths::session_images_dir();
+            std::fs::create_dir_all(&dir).unwrap();
+            let shared = dir.join("shared-hash.png");
+            std::fs::write(&shared, b"same bytes").unwrap();
+            set_mtime_days_ago(&shared, 2).unwrap();
+
+            let conn = session_persistence::get_connection().unwrap();
+            let now = chrono::Utc::now().to_rfc3339();
+            let refs = serde_json::json!([shared.to_string_lossy().to_string()]).to_string();
+            conn.execute(
+                "INSERT INTO agent_messages
+                    (id, session_id, role, content, sequence, created_at, images)
+                 VALUES ('shared-1', 'sid-one', 'user', 'one', 0, ?1, ?2),
+                        ('shared-2', 'sid-two', 'user', 'two', 0, ?1, ?2)",
+                rusqlite::params![now, refs],
+            )
+            .unwrap();
+
+            agent_core::persistence::db_helpers::clear_messages("agent", "sid-one").unwrap();
+            assert!(
+                shared.exists(),
+                "message deletion must not remove shared bytes"
+            );
+            assert_eq!(evict_orphan_session_images().unwrap(), 0);
+            assert!(shared.exists(), "the surviving message still owns the file");
+
+            agent_core::persistence::db_helpers::clear_messages("agent", "sid-two").unwrap();
+            assert_eq!(evict_orphan_session_images().unwrap(), 1);
+            assert!(
+                !shared.exists(),
+                "last-owner removal makes the file reclaimable"
+            );
         });
     }
 }

--- a/src-tauri/src/infrastructure/housekeeping/housekeeping_orphans.rs
+++ b/src-tauri/src/infrastructure/housekeeping/housekeeping_orphans.rs
@@ -4,9 +4,15 @@
 //! (`run_deferred_cleanup`) calls them.
 
 use std::fs;
+use std::time::{Duration, SystemTime};
 
 use app_paths as paths;
 use core_types::session::CLI_SESSION_PREFIX;
+
+/// An unreferenced image must stay untouched for at least this long. Producers
+/// write the file before committing its durable owner, so immediate eviction
+/// would race an active turn even with a complete reference index.
+const SESSION_IMAGE_ORPHAN_GRACE: Duration = Duration::from_secs(24 * 60 * 60);
 
 /// Fetch every session_id currently present in both the `agent_sessions`
 /// table (Rust-native agents) and the `code_sessions` table (CLI agents).
@@ -283,10 +289,13 @@ pub(super) fn evict_orphan_agent_worktrees(
     Ok(removed)
 }
 
-/// Delete files under `~/.orgii/session-images/` whose `file_name()` is
-/// not referenced by any row in `agent_messages.images` (a JSON array
-/// of absolute paths). Image filenames are content-addressed hashes so
-/// once no message points to them they are irreclaimably dead.
+/// Delete aged files under `~/.orgii/session-images/` whose `file_name()` is
+/// absent from every durable image-reference source.
+///
+/// Image filenames are global content hashes, not session-owned files. The
+/// sweep therefore considers Rust-agent messages and the CLI session image
+/// registry together. It also retains pre-registry files conservatively
+/// because an older native transcript may be their only owner.
 ///
 /// Returns the number of files actually removed.
 pub(super) fn evict_orphan_session_images() -> std::io::Result<usize> {
@@ -306,6 +315,16 @@ pub(super) fn evict_orphan_session_images() -> std::io::Result<usize> {
             return Ok(0);
         }
     };
+    let legacy_cutoff = match session_image_registry_cutoff() {
+        Ok(cutoff) => cutoff,
+        Err(err) => {
+            tracing::warn!(
+                "[housekeeping] could not read image-registry cutoff: {}; skipping",
+                err
+            );
+            return Ok(0);
+        }
+    };
 
     let mut removed = 0;
     for entry in fs::read_dir(&images_dir)? {
@@ -318,6 +337,26 @@ pub(super) fn evict_orphan_session_images() -> std::io::Result<usize> {
             continue;
         };
         if referenced.contains(name) {
+            continue;
+        }
+        let modified = match entry.metadata().and_then(|metadata| metadata.modified()) {
+            Ok(modified) => modified,
+            Err(err) => {
+                tracing::warn!(
+                    "[housekeeping] could not read session-image mtime {}: {}; retaining",
+                    path.display(),
+                    err
+                );
+                continue;
+            }
+        };
+        if modified <= legacy_cutoff {
+            continue;
+        }
+        if SystemTime::now()
+            .duration_since(modified)
+            .map_or(true, |age| age < SESSION_IMAGE_ORPHAN_GRACE)
+        {
             continue;
         }
         if let Err(err) = fs::remove_file(&path) {
@@ -342,39 +381,95 @@ pub(super) fn evict_orphan_session_images() -> std::io::Result<usize> {
     Ok(removed)
 }
 
-/// Collect the `file_name()` of every path currently stored in
-/// `agent_messages.images` (a JSON-array column). We compare filenames
-/// rather than full paths because the column may store paths rooted at
-/// the previous install location (e.g. user moved `~/.orgii/`); the
-/// filename is a content hash and therefore stable across moves.
+/// Collect the `file_name()` of every path currently stored in a durable chat
+/// image reference. We compare filenames rather than full paths because old
+/// rows may be rooted at a previous install location; the content hash remains
+/// stable across moves.
 pub(super) fn live_session_image_filenames() -> Result<std::collections::HashSet<String>, String> {
     let conn =
         session_persistence::get_connection().map_err(|err| format!("get_connection: {}", err))?;
+    let mut names = std::collections::HashSet::new();
+
+    // Rust-native agent transcript owners.
     let mut stmt = conn
         .prepare("SELECT images FROM agent_messages WHERE images IS NOT NULL")
-        .map_err(|err| format!("prepare: {}", err))?;
+        .map_err(|err| format!("prepare agent message refs: {}", err))?;
     let rows = stmt
         .query_map([], |row| row.get::<_, String>(0))
-        .map_err(|err| format!("query_map: {}", err))?;
-
-    let mut names = std::collections::HashSet::new();
-    for row in rows.flatten() {
-        let Ok(image_paths) = serde_json::from_str::<Vec<String>>(&row) else {
-            continue;
-        };
+        .map_err(|err| format!("query agent message refs: {}", err))?;
+    for row in rows {
+        let row = row.map_err(|err| format!("decode agent message ref row: {}", err))?;
+        let image_paths = serde_json::from_str::<Vec<String>>(&row)
+            .map_err(|err| format!("decode agent message image refs: {}", err))?;
         for p in image_paths {
-            if p.starts_with("data:") {
-                continue;
-            }
-            if let Some(name) = std::path::Path::new(&p)
-                .file_name()
-                .and_then(|n| n.to_str())
-            {
-                names.insert(name.to_string());
-            }
+            insert_image_filename(&mut names, &p);
         }
     }
+
+    // Immediate provider-independent owners for every newly persisted CLI
+    // attachment, including native-transcript sessions and in-flight turns.
+    if table_exists(&conn, "code_session_image_refs")? {
+        let mut stmt = conn
+            .prepare("SELECT image_path FROM code_session_image_refs")
+            .map_err(|err| format!("prepare CLI image registry: {}", err))?;
+        let rows = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(|err| format!("query CLI image registry: {}", err))?;
+        for row in rows {
+            let image_path = row.map_err(|err| format!("decode CLI image registry: {}", err))?;
+            insert_image_filename(&mut names, &image_path);
+        }
+    }
+
     Ok(names)
+}
+
+fn insert_image_filename(names: &mut std::collections::HashSet<String>, image_path: &str) {
+    if image_path.starts_with("data:") {
+        return;
+    }
+    if let Some(name) = std::path::Path::new(image_path)
+        .file_name()
+        .and_then(|name| name.to_str())
+    {
+        names.insert(name.to_string());
+    }
+}
+
+fn table_exists(conn: &rusqlite::Connection, table_name: &str) -> Result<bool, String> {
+    conn.query_row(
+        "SELECT EXISTS(
+            SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1
+         )",
+        [table_name],
+        |row| row.get(0),
+    )
+    .map_err(|err| format!("check table {table_name}: {err}"))
+}
+
+/// Timestamp when immediate CLI image ownership was introduced. Files older
+/// than this may still belong to native transcripts written by prior builds,
+/// so the orphan sweep keeps them rather than guessing destructively.
+fn session_image_registry_cutoff() -> Result<SystemTime, String> {
+    let conn =
+        session_persistence::get_connection().map_err(|err| format!("get_connection: {}", err))?;
+    if !table_exists(&conn, "_migrations")? {
+        return Err("image registry migration table is absent".to_string());
+    }
+    let applied_at = match conn.query_row(
+        "SELECT applied_at FROM _migrations WHERE name = 'code_session_image_refs_v1'",
+        [],
+        |row| row.get::<_, String>(0),
+    ) {
+        Ok(value) => value,
+        Err(rusqlite::Error::QueryReturnedNoRows) => {
+            return Err("image registry migration marker is absent".to_string())
+        }
+        Err(err) => return Err(format!("read image registry migration: {err}")),
+    };
+    let parsed = chrono::DateTime::parse_from_rfc3339(&applied_at)
+        .map_err(|err| format!("parse image registry migration timestamp: {err}"))?;
+    Ok(SystemTime::from(parsed.to_utc()))
 }
 
 /// Delete `gateway_bindings` rows whose `target_session_id` is not in


### PR DESCRIPTION
## Problem

Session image files are content-addressed and can be shared by multiple messages and sessions, but agent-message deletion eagerly removes each referenced path. The deferred orphan sweep also recognizes only Rust-agent message rows, while native CLI transcripts are eventually consistent and do not provide an immediate durable owner. Deleting one owner or running housekeeping during that gap can therefore remove an attachment that a surviving session still needs.

## Solution

Make the database the authoritative ownership boundary. Agent-message deletion now validates serialized references but leaves physical deletion to global housekeeping. CLI image persistence records session-level ownership transactionally before launching the child process, with a foreign-key cascade when the session is deleted. Housekeeping unions Rust-message and CLI-registry owners, fails closed when ownership data is malformed or unavailable, preserves pre-registry files, and deletes only unreferenced post-cutoff files older than 24 hours. The resulting invariant is that a physical hash is reclaimed only after every durable owner is gone.

## Potential risks

This adds an idempotent table, index, and migration marker. Older builds safely ignore them, and rollback can revert the code while leaving the additive schema in place; dropping the table is neither required nor recommended. Pre-registry files are retained conservatively and may continue consuming disk space because they cannot be classified safely. New registry rows grow with unique session/path pairs but are deduplicated by primary key and cascade on session deletion. A registry write failure now blocks the CLI send instead of launching with an unowned attachment. Concurrent startup sweeps may race on the same already-orphaned file, but the 24-hour grace, fail-closed reads, and remove-error handling prevent deletion of a live owner.

## Verification

- `rustfmt --edition 2021 --check` over all 10 changed Rust files — passed
- `cargo test -p agent_core` — passed 3,181 tests with 0 failures before the final rebase; the rebase changed no Rust files
- `cargo test -p agent_core clear_messages_invalid_images_json_returns_err_and_preserves_rows` — passed on the final commit
- `cargo test -p agent_core delete_session_cascade_invalid_images_json_returns_err_and_preserves_rows` — passed on the final commit
- `cargo test --lib agent_sessions::cli::persistence::image_refs::tests::records_deduplicated_session_ownership` — passed 1/1
- `cargo test --lib infrastructure::housekeeping::tests::` — passed 14/14
- `cargo check` — passed
- `cargo clippy -p agent_core --all-targets -- -D warnings` — passed
- `cargo clippy --lib -- -D warnings` — passed
- `cargo clippy --all-targets --all-features -- -D warnings` — attempted; blocked by four pre-existing warnings in untouched `crates/advanced-search` files (`unused_enumerate_index`, `lines_filter_map_ok`, and two `collapsible_if` findings)
- `git diff --check origin/develop...HEAD` — passed
- Final diff scan found no secrets, personal paths, debug prints, build artifacts, caches, or unrelated formatting

## Architecture audit

Covered persistence authority, producer call paths, deletion ownership, error propagation, additive-schema compatibility, CLI initialization parity, session-cascade lifecycle, concurrency behavior, and source-boundary tests. FSM transitions, resolver hierarchy, public IPC/wire contracts, and frontend rendering were intentionally skipped because this diff does not touch them. Historical data is handled without destructive backfill: files at or before the registry cutoff remain preserved.

## Performance guard

| Area | Verdict | Evidence | Change or reason kept | Verification |
| --- | --- | --- | --- | --- |
| Background work | keep | Existing one-shot deferred cleanup remains the sole owner; no timer, retry, watcher, or subscription is added | One extra indexed owner query plus the existing image-directory scan; malformed state skips deletion | 14 housekeeping tests and `cargo check` |
| Memory | keep | Reference filenames live in a transient set for one cleanup pass | Growth follows durable reference rows and is released after the pass; no app-lifetime cache | Housekeeping tests exercise mixed Rust, CLI, legacy, fresh, and orphan files |
| Scope/isolation | fix | Hash filenames are global across Rust and CLI sessions | Union every durable owner and cascade CLI ownership only with its session | Shared-owner and CLI-cascade regression tests |
| Rendering/hot path | keep | No render, streaming, or steady-state hot path changed | Registration runs once per attachment send; cleanup remains deferred | Source trace plus targeted tests |

Performance verdict: pass. No runtime performance improvement is claimed; the evidence covers ownership, cadence, bounded lifetime, and deletion behavior at the changed boundaries.