### PR TITLE
ci(rust-cache): warm shared cache on develop pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
 
+      # warm-rust-cache.yml publishes this same shared key from develop, so a
+      # PR's first run restores the base branch's cache instead of starting
+      # cold. Keep the key and workspace mapping in sync with that workflow.
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:

--- a/.github/workflows/warm-rust-cache.yml
+++ b/.github/workflows/warm-rust-cache.yml
@@ -1,0 +1,109 @@
+# Warm the shared Rust cache on every push to develop.
+#
+# CI runs only on pull_request, and GitHub scopes a cache saved during a PR
+# run to that PR's own merge ref. Nothing used to save a Rust cache on
+# develop itself, so the first CI run of every new PR started cold: measured
+# ~30-37 min for the Rust job versus ~15-21 min warm. PR runs may restore
+# caches created on their base branch, so populating develop's cache under
+# the same `ci-macos` shared key that ci.yml restores makes fresh PRs start
+# warm.
+#
+# This job only compiles — clippy plus `cargo test --no-run`, the same
+# artifact set the ci.yml Rust job needs. It never executes tests and denies
+# no warnings: develop was already gated by CI before merge, so this is a
+# cache producer, not a quality gate, and a red herring here must not block
+# cache publication (`cache-on-failure` below).
+#
+# Mirrors the toolchain setup in ci.yml (Rust stable, swatinem/rust-cache,
+# same workspace mapping and shared key). If ci.yml's Rust steps change,
+# change this file to match.
+
+name: "Warm Rust cache"
+
+on:
+  push:
+    branches:
+      - develop
+
+# Only the newest develop head is worth caching. Cancel an in-flight warm run
+# when another merge lands so macOS runner slots are not spent on stale SHAs.
+concurrency:
+  group: warm-rust-cache-develop
+  cancel-in-progress: true
+
+jobs:
+  # ── Change scope ────────────────────────────────────────────────────────────
+  # Frontend-only merges cannot invalidate any Rust artifact, so skip the
+  # macOS runner entirely. Reuses ci.yml's detection script to avoid drift.
+  changes:
+    name: Detect warm scope
+    runs-on: ubuntu-latest
+    outputs:
+      rust_required: ${{ steps.scope.outputs.rust_required }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect Rust-relevant changes
+        id: scope
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          # Branch creation and force pushes leave no usable `before` SHA.
+          # Warm rather than guess, matching the detect script's fail-closed
+          # stance on an empty diff.
+          if ! git cat-file -e "${BEFORE_SHA}" 2>/dev/null; then
+            echo "rust_required=true" >> "${GITHUB_OUTPUT}"
+            echo "Rust required: true (no usable before SHA)"
+            exit 0
+          fi
+          rust_required="$(
+            git diff --name-only -z "${BEFORE_SHA}" "${HEAD_SHA}" |
+              node scripts/ci/detect-rust-changes.cjs
+          )"
+          echo "rust_required=${rust_required}" >> "${GITHUB_OUTPUT}"
+          echo "Rust required: ${rust_required}"
+
+  # ── Warm ────────────────────────────────────────────────────────────────────
+  warm:
+    name: Rust (warm cache)
+    needs: changes
+    if: needs.changes.outputs.rust_required == 'true'
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      # Same workspace mapping and shared key as ci.yml so PR runs restoring
+      # from the base branch get an exact-key hit. `cache-on-failure` keeps a
+      # partially built dependency cache even if a compile step breaks — a
+      # partial warm still beats a cold start for the next run.
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: "./src-tauri -> target"
+          shared-key: "ci-macos"
+          cache-on-failure: true
+
+      - name: Stage org2-pm sidecar
+        run: node scripts/tauri/prepare-sidecars.cjs --profile debug
+
+      # Populates the check-mode dependency artifacts ci.yml's clippy step
+      # restores. No `-D warnings`: this job must publish a cache, not gate.
+      - name: cargo clippy (all targets)
+        working-directory: src-tauri
+        run: cargo clippy --workspace --all-targets
+
+      # Populates the codegen and link artifacts for every test target
+      # without spending runner time executing ~6800 already-gated tests.
+      - name: cargo test (build only)
+        working-directory: src-tauri
+        run: cargo test --workspace --no-run


### PR DESCRIPTION
## Problem

The Rust CI job starts cold on the first run of every new pull request. CI only triggers on `pull_request`, and GitHub scopes a cache saved during a PR run to that PR's own merge ref — nothing ever saves a Rust cache on `develop` itself (`release.yaml` only runs on tags). PR runs are allowed to restore caches from their base branch, but there is nothing there to restore.

Measured impact on recent runs (`gh run view` step timings): first run of a PR takes ~30–37 min for the Rust job (sidecar staging 4–5 min, clippy 5–8 min, `cargo test --workspace` 20–24 min), while a re-push to the same PR — the only case that currently hits a cache — takes ~15–21 min. Every fresh PR pays the cold penalty on a limited macOS runner slot.

## Solution

Add `warm-rust-cache.yml`, which runs on every push to `develop` and publishes a Rust cache under the same `ci-macos` shared key that `ci.yml` restores. Fresh PRs then inherit develop's cache through base-branch cache scoping and start warm.

The warm job is a cache producer, not a quality gate:

- It only compiles — `cargo clippy --workspace --all-targets` (check-mode artifacts for ci.yml's clippy step) and `cargo test --workspace --no-run` (codegen/link artifacts for the test step). It never executes tests; develop was already fully gated by CI before merge.
- Clippy runs without `-D warnings` and the cache step sets `cache-on-failure: true`, so a stray warning or transient compile break still publishes a partial cache rather than leaving the next PR cold.
- It reuses `scripts/ci/detect-rust-changes.cjs` (same script as ci.yml's scope job) so frontend-only merges skip the macOS runner entirely. Branch creation and force pushes, where `github.event.before` is unusable, fail closed to warming.
- A `concurrency` group with `cancel-in-progress` keeps only the newest develop head warming when merges land back-to-back.

`ci.yml` gets a comment pointing at the new workflow so the shared-key contract between the two files is visible from both sides. No behavior in `ci.yml` changes.

PR quality signal is unchanged by design: `swatinem/rust-cache` prunes workspace-member artifacts before saving, so only third-party dependency artifacts (pinned by `Cargo.lock`, which is part of the cache key) are ever reused. Every PR still compiles all ORGII crates from its own source and still runs the full clippy `-D warnings` + ~6800-test suite.

## Potential risks

- **Push-triggered workflow cannot be exercised before merge.** The `pull_request` event on this PR will not run the new workflow; the first real execution happens on the merge of this PR itself. If it misbehaves, the failure mode is benign — PRs simply stay as cold as they are today — and the workflow can be reverted independently.
- **macOS runner spend on every Rust-relevant develop merge** (~15–30 min compile-only). Mitigated by the frontend-only skip, the concurrency cancel, and by not executing tests. This spend is repaid multiple times over by the first CI run of each subsequent PR.
- **GitHub's 10 GB repo cache limit / LRU eviction.** The develop cache shares the limit with existing per-PR caches. Because every fresh PR restores it, its last-used time is continuously refreshed, making it the least likely eviction candidate; if it is ever evicted, behavior degrades to today's cold start.
- **Drift between ci.yml and the warm workflow** (toolchain, shared key, workspace mapping). Both files now carry a comment naming the other as the thing to keep in sync. Drift again degrades to a cold start, not a wrong signal.

## Verification

- `python3 yaml.safe_load` parses both `warm-rust-cache.yml` and the edited `ci.yml` (actionlint not installed locally).
- Exercised the exact detection pipeline shape locally: `git diff --name-only -z <before> <head> | node scripts/ci/detect-rust-changes.cjs` returns `false` for recent frontend-only merges, `true` when the diff contains an `src-tauri/` path, and `true` on empty input (fail closed). Confirmed `git cat-file -e` on the all-zero SHA exits non-zero, so the branch-creation/force-push guard takes the fail-closed path.
- Did not run: the workflow end-to-end (push-triggered on develop only — see risks above) and a live cross-PR cache-restore observation, which can only be confirmed by watching the first fresh PR's `Rust cache` step after this merges (expect a ~25 s restore instead of 0–1 s miss).
