### PR TITLE
ci(frontend-cache): warm dependency caches on develop pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Test CI policy helpers
         run: node --test scripts/ci/*.test.cjs
 
+      # warm-frontend-cache.yml publishes this same key from develop after
+      # lockfile-changing merges, so a PR's first run restores the base
+      # branch's cache. Keep the key in sync with that workflow.
       - name: Cache node_modules
         uses: actions/cache@v5
         with:

--- a/.github/workflows/warm-frontend-cache.yml
+++ b/.github/workflows/warm-frontend-cache.yml
@@ -1,0 +1,64 @@
+# Warm the frontend dependency caches on develop pushes that change the
+# lockfile.
+#
+# CI runs only on pull_request, and GitHub scopes a cache saved during a PR
+# run to that PR's own merge ref. Nothing used to save the node_modules or
+# pnpm-store caches on develop itself, so after any lockfile-changing merge
+# the first CI run of every subsequent PR reinstalled dependencies from a
+# cold cache. PR runs may restore caches created on their base branch, so
+# publishing develop's caches under the same keys ci.yml uses makes fresh
+# PRs start warm. (warm-rust-cache.yml is the same pattern for the Rust job.)
+#
+# Both cache keys are pure functions of pnpm-lock.yaml, so the `paths`
+# filter skips merges that cannot produce a new key: the existing cache
+# already matches and a run would restore, no-op, and skip its save.
+#
+# Mirrors the frontend setup in ci.yml (pnpm action, Node 20, identical
+# node_modules key). If ci.yml's frontend cache steps change, change this
+# file to match.
+
+name: "Warm frontend cache"
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - "pnpm-lock.yaml"
+
+# Only the newest develop head is worth caching; cancel an in-flight warm run
+# when another lockfile-changing merge lands.
+concurrency:
+  group: warm-frontend-cache-develop
+  cancel-in-progress: true
+
+jobs:
+  warm:
+    name: Frontend (warm cache)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      # `cache: "pnpm"` also publishes the pnpm store cache setup-node
+      # manages, which has the same base-branch gap as node_modules.
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      # Identical key expression to ci.yml so PR runs restoring from the base
+      # branch get an exact-key hit.
+      - name: Cache node_modules
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Problem

The frontend CI job has the same base-branch cache gap that PR #976 fixes for Rust. CI only triggers on `pull_request`, and GitHub scopes a cache saved during a PR run to that PR's own merge ref — nothing ever saves the `node_modules` cache (or the pnpm store cache that `setup-node` manages) on `develop` itself. PR runs are allowed to restore caches from their base branch, but there is nothing there to restore.

Concretely: after any merge that changes `pnpm-lock.yaml`, the first CI run of every subsequent fresh PR misses both caches and pays a cold `pnpm install --frozen-lockfile` (~1–2 min) plus a cold pnpm-store download. Only re-pushes to the same PR currently benefit.

## Solution

Add `warm-frontend-cache.yml`, which runs on pushes to `develop` and publishes both frontend caches under the same keys `ci.yml` restores: the `node_modules` cache (identical key expression, verified byte-for-byte against ci.yml) and the pnpm store cache via `setup-node`'s `cache: "pnpm"`. Fresh PRs then inherit develop's caches through base-branch cache scoping.

Because both cache keys are pure functions of `pnpm-lock.yaml`, the workflow uses a `paths: ["pnpm-lock.yaml"]` filter: merges that don't touch the lockfile cannot produce a new key (the existing cache already matches), so they skip the runner entirely. A `concurrency` group with `cancel-in-progress` collapses back-to-back lockfile-changing merges to the newest head.

The job is a cache producer, not a gate — it only checks out, sets up pnpm/Node 20 exactly as ci.yml does, and runs `pnpm install --frozen-lockfile`. `ci.yml` gets a comment at its `Cache node_modules` step pointing at the new workflow so the shared-key contract is visible from both sides; no ci.yml behavior changes.

Same design guarantee as the Rust warm workflow: PR quality signal is unchanged. Every PR still runs the full typecheck/lint/test suite; the cache only changes whether dependencies are downloaded or restored, and `pnpm install --frozen-lockfile` still runs and validates on every PR either way.

## Potential risks

- **Push-triggered workflow cannot be exercised before merge.** The `pull_request` event on this PR will not run it; the first real execution happens on the next lockfile-changing merge to develop. Failure mode is benign — PRs simply stay as cold as they are today — and the workflow is independently revertable.
- **Runner spend is negligible by construction**: ubuntu (not the scarce macOS pool), only on lockfile-changing merges, a few minutes per run.
- **GitHub's 10 GB repo cache limit / LRU eviction**: adds one node_modules entry plus one pnpm-store entry per lockfile hash. Every fresh PR restore refreshes their last-used time; eviction degrades to today's cold start, never to a wrong signal.
- **Drift between ci.yml and this workflow** (key expression, Node/pnpm versions). Both files now carry a comment naming the other as the thing to keep in sync; drift degrades to a cache miss, not a wrong signal.
- **Merge-order note**: this PR and #976 both add a comment to `ci.yml` in different, non-adjacent hunks (frontend cache step vs Rust cache step), so they merge independently without conflict.

## Verification

- `python3 yaml.safe_load` parses both `warm-frontend-cache.yml` and the edited `ci.yml` (actionlint not installed locally).
- Diffed the `node-modules-…` key expression between ci.yml and the new workflow — byte-identical.
- Did not run: the workflow end-to-end (push-triggered on develop only — see risks). The payoff is observable after the next lockfile-changing merge: the first fresh PR afterward should show a hit on its `Cache node_modules` step instead of a cold `pnpm install`.
