### PR TITLE
refactor(conversations): make execution identity provider neutral

### DIFF
--- a/src/engines/ChatPanel/hooks/useImportedSessionSubmitOverride.ts
+++ b/src/engines/ChatPanel/hooks/useImportedSessionSubmitOverride.ts
@@ -257,6 +257,7 @@ export function useImportedSessionSubmitOverride({
           const authIdentity = org2CloudAuthIdentityKey(auth);
           const executionIdentity = resolveCloudConversationExecutionIdentity({
             authIdentity,
+            cloudEndpoint: auth.supabaseUrl,
             cloudOrgId: planeInfo.orgId,
             rootSessionId: planeInfo.rootId,
             assignedAgentDefinitionId: rootRow?.agentDefinitionId,
@@ -304,6 +305,7 @@ export function useImportedSessionSubmitOverride({
             assignedAgentDefinitionId: rootRow?.agentDefinitionId,
             setupMemoryKey: executionIdentity.setupMemoryKey,
             executionScopeKey: executionIdentity.executorScopeKey,
+            executionRootKey: executionIdentity.rootKey,
             onRunnerReady: (runnerSessionId, turnId, turnIntentId) => {
               // Overlay the runner's LIVE events (thinking / tools / worked-for)
               // into the conversation until the plane carries this turn's
@@ -354,13 +356,14 @@ export function useImportedSessionSubmitOverride({
         if (!auth) return false;
         const executionIdentity = resolveCloudConversationExecutionIdentity({
           authIdentity: org2CloudAuthIdentityKey(auth),
+          cloudEndpoint: auth.supabaseUrl,
           cloudOrgId: planeInfo.orgId,
           rootSessionId: planeInfo.rootId,
         });
         const ownerCursor =
           loadStoredOwnerPlaneCursor(
             executionIdentity.executorScopeKey,
-            planeInfo.rootId
+            executionIdentity.rootKey
           )?.readThroughPlaneSeq ?? 0;
         let delta;
         try {
@@ -412,6 +415,7 @@ export function useImportedSessionSubmitOverride({
           turnIntentId,
           displayText: input.displayText,
           executorScope: executionIdentity.executorScopeKey,
+          executionRootKey: executionIdentity.rootKey,
           readThroughPlaneSeq: delta.lastSeq,
           onPushed: () => signalCloudConversationPlane(planeInfo.orgId),
         }).catch((error: unknown) => {

--- a/src/engines/SessionCore/conversations/conversationIdentity.test.ts
+++ b/src/engines/SessionCore/conversations/conversationIdentity.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import {
+  conversationExecutionKey,
+  conversationExecutorScopeKey,
+  conversationRootKey,
+  conversationSetupMemoryKey,
+  resolveImportedConversationExecutionIdentity,
+  resolveLocalSessionExecutionIdentity,
+} from "./conversationIdentity";
+
+describe("provider-neutral conversation identity", () => {
+  it("uses the same core key shape for local, imported, and remote roots", () => {
+    const local = conversationRootKey({
+      authority: "local-session",
+      authorityScope: [],
+      conversationId: "session-1",
+    });
+    const imported = conversationRootKey({
+      authority: "external-history",
+      authorityScope: ["claude_code"],
+      conversationId: "claude-session-1",
+    });
+    const remote = conversationRootKey({
+      authority: "remote-conversation",
+      authorityScope: ["deployment-a", "org-a"],
+      conversationId: "shared-root-1",
+    });
+
+    for (const key of [local, imported, remote]) {
+      expect(JSON.parse(key)).toEqual([
+        "org2-conversation-root",
+        1,
+        expect.any(String),
+        expect.any(Array),
+        expect.any(String),
+      ]);
+    }
+    expect(new Set([local, imported, remote])).toHaveProperty("size", 3);
+  });
+
+  it("does not make Work Items, models, workspaces, or agents root identity", () => {
+    const root = conversationRootKey({
+      authority: "external-history",
+      authorityScope: ["codex_app"],
+      conversationId: "rollout-1",
+    });
+    const executor = conversationExecutorScopeKey({
+      authority: "local-device",
+      authorityScope: [],
+    });
+
+    expect(conversationExecutionKey(executor, root)).toBe(
+      conversationExecutionKey(executor, root)
+    );
+    expect(
+      conversationSetupMemoryKey({
+        executorScope: executor,
+        rootKey: root,
+        agentDefinitionId: "agent-a",
+      })
+    ).not.toBe(
+      conversationSetupMemoryKey({
+        executorScope: executor,
+        rootKey: root,
+        agentDefinitionId: "agent-b",
+      })
+    );
+  });
+
+  it("isolates source authorities and local executor principals", () => {
+    const claude = conversationRootKey({
+      authority: "external-history",
+      authorityScope: ["claude_code"],
+      conversationId: "same-native-id",
+    });
+    const codex = conversationRootKey({
+      authority: "external-history",
+      authorityScope: ["codex_app"],
+      conversationId: "same-native-id",
+    });
+    const alice = conversationExecutorScopeKey({
+      authority: "remote-account",
+      authorityScope: ["alice", "org-a"],
+    });
+    const bob = conversationExecutorScopeKey({
+      authority: "remote-account",
+      authorityScope: ["bob", "org-a"],
+    });
+
+    expect(claude).not.toBe(codex);
+    expect(conversationExecutionKey(alice, claude)).not.toBe(
+      conversationExecutionKey(bob, claude)
+    );
+  });
+
+  it("rejects ambiguous empty or unbounded identity parts", () => {
+    expect(() =>
+      conversationRootKey({
+        authority: "",
+        authorityScope: [],
+        conversationId: "root",
+      })
+    ).toThrow("root authority is required");
+    expect(() =>
+      conversationRootKey({
+        authority: "source",
+        authorityScope: Array.from({ length: 17 }, (_, index) => `${index}`),
+        conversationId: "root",
+      })
+    ).toThrow("too many parts");
+  });
+
+  it("resolves a manual imported session without Cloud or a Work Item", () => {
+    const imported = resolveImportedConversationExecutionIdentity({
+      sourceKind: "claude_code",
+      sourceSessionId: "claudecodeapp-native-session",
+      agentDefinitionId: "local-agent",
+    });
+    const local = resolveLocalSessionExecutionIdentity({
+      sessionId: "normal-local-session",
+      agentDefinitionId: "local-agent",
+    });
+
+    expect(JSON.parse(imported.rootKey).slice(0, 3)).toEqual([
+      "org2-conversation-root",
+      1,
+      "external-history",
+    ]);
+    expect(JSON.parse(imported.executorScopeKey)).toEqual(
+      JSON.parse(local.executorScopeKey)
+    );
+    expect(imported.executionKey).not.toBe(local.executionKey);
+    expect(imported.setupMemoryKey).toContain("local-agent");
+  });
+});

--- a/src/engines/SessionCore/conversations/conversationIdentity.ts
+++ b/src/engines/SessionCore/conversations/conversationIdentity.ts
@@ -1,0 +1,184 @@
+/**
+ * Provider-neutral identity for a conversation and one local executor.
+ *
+ * The core deliberately treats authority/scope components as opaque strings.
+ * Cloud, imported-history, file-import, and ordinary local-session adapters
+ * decide what makes a source unique; Work Items and transport cursors are not
+ * part of execution identity.
+ */
+
+const ROOT_KEY_TAG = "org2-conversation-root" as const;
+const EXECUTOR_SCOPE_TAG = "org2-conversation-executor" as const;
+const SETUP_KEY_TAG = "org2-conversation-setup" as const;
+const KEY_VERSION = 1 as const;
+
+export type ConversationRootKey = string & {
+  readonly __conversationRootKey: unique symbol;
+};
+
+export type ConversationExecutorScopeKey = string & {
+  readonly __conversationExecutorScopeKey: unique symbol;
+};
+
+export interface ConversationRootLocator {
+  /** Adapter-owned namespace, for example `local-session` or `org2-cloud`. */
+  authority: string;
+  /** Stable authority partition; never include credentials or display labels. */
+  authorityScope: readonly string[];
+  /** Source-side root identity inside that authority partition. */
+  conversationId: string;
+}
+
+export interface ConversationExecutorLocator {
+  /** Runtime host/identity namespace. The local SQLite DB is already per device. */
+  authority: string;
+  /** Stable principal/partition components; never include API keys or tokens. */
+  authorityScope: readonly string[];
+}
+
+export interface ConversationExecutionIdentity {
+  rootKey: ConversationRootKey;
+  executorScopeKey: ConversationExecutorScopeKey;
+  executionKey: string;
+  setupMemoryKey: string;
+}
+
+function requireKeyPart(label: string, value: string): string {
+  if (value.length === 0) {
+    throw new Error(`conversation ${label} is required`);
+  }
+  if (value.length > 2_048) {
+    throw new Error(`conversation ${label} is too long`);
+  }
+  return value;
+}
+
+function requireScope(label: string, values: readonly string[]): string[] {
+  if (values.length > 16) {
+    throw new Error(`conversation ${label} has too many parts`);
+  }
+  return values.map((value, index) =>
+    requireKeyPart(`${label}[${index}]`, value)
+  );
+}
+
+/** Stable root key shared by every trigger and execution episode. */
+export function conversationRootKey(
+  locator: ConversationRootLocator
+): ConversationRootKey {
+  return JSON.stringify([
+    ROOT_KEY_TAG,
+    KEY_VERSION,
+    requireKeyPart("root authority", locator.authority),
+    requireScope("root authority scope", locator.authorityScope),
+    requireKeyPart("root id", locator.conversationId),
+  ]) as ConversationRootKey;
+}
+
+/** Local executor partition. Runtime/model/workspace belong to an episode. */
+export function conversationExecutorScopeKey(
+  locator: ConversationExecutorLocator
+): ConversationExecutorScopeKey {
+  return JSON.stringify([
+    EXECUTOR_SCOPE_TAG,
+    KEY_VERSION,
+    requireKeyPart("executor authority", locator.authority),
+    requireScope("executor authority scope", locator.authorityScope),
+  ]) as ConversationExecutorScopeKey;
+}
+
+/** Durable local execution row key: one executor, one canonical root. */
+export function conversationExecutionKey(
+  executorScope: string,
+  rootKey: string
+): string {
+  return JSON.stringify([
+    requireKeyPart("executor scope", executorScope),
+    requireKeyPart("root key", rootKey),
+  ]);
+}
+
+/** Runtime-selection memory is an adapter-independent view preference. */
+export function conversationSetupMemoryKey(input: {
+  executorScope: string;
+  rootKey: string;
+  agentDefinitionId?: string;
+}): string {
+  return JSON.stringify([
+    SETUP_KEY_TAG,
+    KEY_VERSION,
+    requireKeyPart("executor scope", input.executorScope),
+    requireKeyPart("root key", input.rootKey),
+    input.agentDefinitionId
+      ? requireKeyPart("agent definition", input.agentDefinitionId)
+      : "unassigned",
+  ]);
+}
+
+/** Resolve the complete persistence tuple once at an entry-surface boundary. */
+export function resolveConversationExecutionIdentity(input: {
+  root: ConversationRootLocator;
+  executor: ConversationExecutorLocator;
+  agentDefinitionId?: string;
+}): ConversationExecutionIdentity {
+  const rootKey = conversationRootKey(input.root);
+  const executorScopeKey = conversationExecutorScopeKey(input.executor);
+  return {
+    rootKey,
+    executorScopeKey,
+    executionKey: conversationExecutionKey(executorScopeKey, rootKey),
+    setupMemoryKey: conversationSetupMemoryKey({
+      executorScope: executorScopeKey,
+      rootKey,
+      agentDefinitionId: input.agentDefinitionId,
+    }),
+  };
+}
+
+/**
+ * Manual external-history imports need no Work Item, Cloud account, or remote
+ * transport. The imported cache/session id is the source-owned identity; an
+ * adapter may add a stable source-home/database scope when one provider can
+ * expose the same id from more than one authority.
+ */
+export function resolveImportedConversationExecutionIdentity(input: {
+  sourceKind: string;
+  sourceSessionId: string;
+  sourceAuthorityScope?: readonly string[];
+  agentDefinitionId?: string;
+}): ConversationExecutionIdentity {
+  return resolveConversationExecutionIdentity({
+    root: {
+      authority: "external-history",
+      authorityScope: [
+        requireKeyPart("imported source kind", input.sourceKind),
+        ...(input.sourceAuthorityScope ?? []),
+      ],
+      conversationId: input.sourceSessionId,
+    },
+    executor: {
+      authority: "local-device",
+      authorityScope: [],
+    },
+    agentDefinitionId: input.agentDefinitionId,
+  });
+}
+
+/** Existing writable local sessions are roots/episodes under the same model. */
+export function resolveLocalSessionExecutionIdentity(input: {
+  sessionId: string;
+  agentDefinitionId?: string;
+}): ConversationExecutionIdentity {
+  return resolveConversationExecutionIdentity({
+    root: {
+      authority: "local-session",
+      authorityScope: [],
+      conversationId: input.sessionId,
+    },
+    executor: {
+      authority: "local-device",
+      authorityScope: [],
+    },
+    agentDefinitionId: input.agentDefinitionId,
+  });
+}

--- a/src/engines/SessionCore/conversations/index.ts
+++ b/src/engines/SessionCore/conversations/index.ts
@@ -1,0 +1,1 @@
+export * from "./conversationIdentity";

--- a/src/engines/SessionCore/index.ts
+++ b/src/engines/SessionCore/index.ts
@@ -66,6 +66,9 @@ export type {
   SimulatorEventPreview,
 } from "./core/types";
 
+// Provider-neutral conversation root/executor identity.
+export * from "./conversations";
+
 // ============================================
 // Core Atoms
 // ============================================

--- a/src/features/Org2Cloud/SessionConversation/conversationExecutionIdentity.test.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationExecutionIdentity.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  conversationExecutionKey,
+  conversationExecutorScopeKey,
+  conversationRootKey,
+  conversationSetupMemoryKey,
+} from "@src/engines/SessionCore/conversations";
+
+import {
   continuationRuntimeFingerprint,
   conversationSetupChangesRuntime,
   conversationSetupRuntimeFingerprint,
@@ -26,43 +33,43 @@ describe("cloud conversation execution identity", () => {
   it("resolves transport, executor, execution, and setup keys from one tuple", () => {
     const identity = resolveCloudConversationExecutionIdentity({
       authIdentity: "https://cloud.example|user-a",
+      cloudEndpoint: "https://cloud.example/",
       cloudOrgId: "org-a",
       rootSessionId: "root-a",
       assignedAgentDefinitionId: "agent-a",
     });
 
+    const rootKey = conversationRootKey({
+      authority: "org2-cloud",
+      authorityScope: ["https://cloud.example", "org-a"],
+      conversationId: "root-a",
+    });
+    const executorScopeKey = conversationExecutorScopeKey({
+      authority: "org2-cloud-account",
+      authorityScope: ["https://cloud.example|user-a", "org-a"],
+    });
     expect(identity).toEqual({
       authIdentity: "https://cloud.example|user-a",
+      cloudEndpoint: "https://cloud.example",
       cloudOrgId: "org-a",
       rootSessionId: "root-a",
+      rootKey,
       assignedAgentDefinitionId: "agent-a",
       planeKey: "org-a:root-a",
-      executorScopeKey: JSON.stringify([
-        "cloud-conversation-executor",
-        "https://cloud.example|user-a",
-        "org-a",
-      ]),
-      executionKey: JSON.stringify([
-        JSON.stringify([
-          "cloud-conversation-executor",
-          "https://cloud.example|user-a",
-          "org-a",
-        ]),
-        "root-a",
-      ]),
-      setupMemoryKey: JSON.stringify([
-        "cloud-conversation-setup",
-        "https://cloud.example|user-a",
-        "org-a",
-        "root-a",
-        "agent-a",
-      ]),
+      executorScopeKey,
+      executionKey: conversationExecutionKey(executorScopeKey, rootKey),
+      setupMemoryKey: conversationSetupMemoryKey({
+        executorScope: executorScopeKey,
+        rootKey,
+        agentDefinitionId: "agent-a",
+      }),
     });
   });
 
   it("isolates setup by account, org, root, and assigned agent", () => {
     const base = {
       authIdentity: "cloud|user-a",
+      cloudEndpoint: "https://cloud.example",
       cloudOrgId: "org-a",
       rootSessionId: "root-a",
       assignedAgentDefinitionId: "agent-a",
@@ -70,6 +77,7 @@ describe("cloud conversation execution identity", () => {
     const key = resolveCloudConversationExecutionIdentity(base).setupMemoryKey;
     for (const changed of [
       { ...base, authIdentity: "cloud|user-b" },
+      { ...base, cloudEndpoint: "https://other.example" },
       { ...base, cloudOrgId: "org-b" },
       { ...base, rootSessionId: "root-b" },
       { ...base, assignedAgentDefinitionId: "agent-b" },
@@ -84,6 +92,7 @@ describe("cloud conversation execution identity", () => {
     expect(() =>
       resolveCloudConversationExecutionIdentity({
         authIdentity: "",
+        cloudEndpoint: "https://cloud.example",
         cloudOrgId: "org-a",
         rootSessionId: "root-a",
       })

--- a/src/features/Org2Cloud/SessionConversation/conversationExecutionIdentity.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationExecutionIdentity.ts
@@ -1,12 +1,12 @@
 /** Canonical local identity and runtime fingerprint for one cloud conversation. */
-import type { ForkSessionSetupSelection } from "@src/features/TeamCollaboration/components/ForkSessionSetupDialog";
-
 import {
-  type ConversationContinuationRecord,
-  cloudConversationExecutorScopeKey,
-  cloudConversationSetupMemoryKey,
-  conversationExecutionKey,
-} from "./conversationExecutionStore";
+  type ConversationExecutionIdentity,
+  resolveConversationExecutionIdentity,
+} from "@src/engines/SessionCore/conversations";
+import type { ForkSessionSetupSelection } from "@src/features/TeamCollaboration/components/ForkSessionSetupDialog";
+import { normalizeSourceEndpointUrl } from "@src/features/TeamCollaboration/engine/collabImportIdentity";
+
+import { type ConversationContinuationRecord } from "./conversationExecutionStore";
 
 export function cloudConversationPlaneKey(
   cloudOrgId: string,
@@ -15,19 +15,14 @@ export function cloudConversationPlaneKey(
   return `${cloudOrgId}:${rootSessionId}`;
 }
 
-export interface CloudConversationExecutionIdentity {
+export interface CloudConversationExecutionIdentity extends ConversationExecutionIdentity {
   authIdentity: string;
+  cloudEndpoint: string;
   cloudOrgId: string;
   rootSessionId: string;
   assignedAgentDefinitionId?: string;
   /** Shared transport/read identity. Never contains a local account. */
   planeKey: string;
-  /** Local executor boundary: signed-in cloud account plus cloud org. */
-  executorScopeKey: string;
-  /** Durable local execution row for this executor and root. */
-  executionKey: string;
-  /** Desired runtime selection for this executor, root, and assigned agent. */
-  setupMemoryKey: string;
 }
 
 function requireIdentityPart(label: string, value: string): string {
@@ -44,11 +39,15 @@ function requireIdentityPart(label: string, value: string): string {
  */
 export function resolveCloudConversationExecutionIdentity(input: {
   authIdentity: string;
+  cloudEndpoint: string;
   cloudOrgId: string;
   rootSessionId: string;
   assignedAgentDefinitionId?: string | null;
 }): CloudConversationExecutionIdentity {
   const authIdentity = requireIdentityPart("auth identity", input.authIdentity);
+  const cloudEndpoint = normalizeSourceEndpointUrl(
+    requireIdentityPart("cloud endpoint", input.cloudEndpoint)
+  );
   const cloudOrgId = requireIdentityPart("organization", input.cloudOrgId);
   const rootSessionId = requireIdentityPart(
     "root session",
@@ -56,24 +55,26 @@ export function resolveCloudConversationExecutionIdentity(input: {
   );
   const assignedAgentDefinitionId =
     input.assignedAgentDefinitionId || undefined;
-  const executorScopeKey = cloudConversationExecutorScopeKey(
-    authIdentity,
-    cloudOrgId
-  );
+  const execution = resolveConversationExecutionIdentity({
+    root: {
+      authority: "org2-cloud",
+      authorityScope: [cloudEndpoint, cloudOrgId],
+      conversationId: rootSessionId,
+    },
+    executor: {
+      authority: "org2-cloud-account",
+      authorityScope: [authIdentity, cloudOrgId],
+    },
+    agentDefinitionId: assignedAgentDefinitionId,
+  });
   return {
+    ...execution,
     authIdentity,
+    cloudEndpoint,
     cloudOrgId,
     rootSessionId,
     ...(assignedAgentDefinitionId ? { assignedAgentDefinitionId } : {}),
     planeKey: cloudConversationPlaneKey(cloudOrgId, rootSessionId),
-    executorScopeKey,
-    executionKey: conversationExecutionKey(executorScopeKey, rootSessionId),
-    setupMemoryKey: cloudConversationSetupMemoryKey(
-      authIdentity,
-      cloudOrgId,
-      rootSessionId,
-      assignedAgentDefinitionId
-    ),
   };
 }
 

--- a/src/features/Org2Cloud/SessionConversation/conversationExecutionStore.test.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationExecutionStore.test.ts
@@ -5,8 +5,6 @@ import {
   __CONVERSATION_EXECUTION_STORE_INTERNALS,
   advanceStoredContinuationReadThrough,
   advanceStoredOwnerPlaneCursor,
-  cloudConversationExecutorScopeKey,
-  cloudConversationSetupMemoryKey,
   collectStoredRunnerSessionIds,
   conversationExecutionKey,
   forgetStoredRunner,
@@ -41,52 +39,10 @@ function fakeStorage(): Storage {
 }
 
 describe("conversation execution store", () => {
-  it("keys execution by account, organization, and root session", () => {
-    const scope = cloudConversationExecutorScopeKey(
-      "https://cloud.example|user-b",
-      "cloud-org"
-    );
-
-    expect(scope).toBe(
-      JSON.stringify([
-        "cloud-conversation-executor",
-        "https://cloud.example|user-b",
-        "cloud-org",
-      ])
-    );
-    expect(conversationExecutionKey(scope, "root-a")).not.toBe(
-      conversationExecutionKey(scope, "root-b")
-    );
-    expect(
-      conversationExecutionKey(
-        cloudConversationExecutorScopeKey(
-          "https://cloud.example|user-c",
-          "cloud-org"
-        ),
-        "root-a"
-      )
-    ).not.toBe(conversationExecutionKey(scope, "root-a"));
-  });
-
   it("uses tuple keys without colon collisions", () => {
     expect(conversationExecutionKey("a:b", "c")).not.toBe(
       conversationExecutionKey("a", "b:c")
     );
-  });
-
-  it("shares setup memory across surfaces per account, root, and agent", () => {
-    const first = cloudConversationSetupMemoryKey(
-      "cloud|user",
-      "org",
-      "root",
-      "agent-a"
-    );
-    expect(
-      cloudConversationSetupMemoryKey("cloud|user", "org", "root", "agent-a")
-    ).toBe(first);
-    expect(
-      cloudConversationSetupMemoryKey("cloud|user", "org", "root", "agent-b")
-    ).not.toBe(first);
   });
 
   it("preserves runner, continuation, and owner cursor in one entry", () => {

--- a/src/features/Org2Cloud/SessionConversation/conversationExecutionStore.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationExecutionStore.ts
@@ -7,6 +7,9 @@
  * blob remains readable so an upgrade never exposes plumbing sessions in My
  * Sessions.
  */
+import { conversationExecutionKey } from "@src/engines/SessionCore/conversations";
+
+export { conversationExecutionKey };
 
 const STORE_VERSION = 2 as const;
 const STORAGE_KEY_PREFIX = "orgii:conversation-execution-v2:";
@@ -452,41 +455,6 @@ function allStorageKeys(backing: Storage | null): string[] {
 function readLegacyRunnerMap(backing: Storage | null): Record<string, unknown> {
   const parsed = readJson(backing, LEGACY_RUNNERS_KEY);
   return isObject(parsed) ? parsed : {};
-}
-
-export function conversationExecutionKey(
-  executorScope: string,
-  rootSessionId: string
-): string {
-  return JSON.stringify([executorScope, rootSessionId]);
-}
-
-/** One executor per signed-in cloud identity and organization. */
-export function cloudConversationExecutorScopeKey(
-  authIdentity: string,
-  cloudOrgId: string
-): string {
-  return JSON.stringify([
-    "cloud-conversation-executor",
-    authIdentity,
-    cloudOrgId,
-  ]);
-}
-
-/** Execution setup is shared by every surface targeting this agent/root. */
-export function cloudConversationSetupMemoryKey(
-  authIdentity: string,
-  cloudOrgId: string,
-  rootSessionId: string,
-  assignedAgentDefinitionId?: string
-): string {
-  return JSON.stringify([
-    "cloud-conversation-setup",
-    authIdentity,
-    cloudOrgId,
-    rootSessionId,
-    assignedAgentDefinitionId ?? "unassigned",
-  ]);
 }
 
 function keyFor(executorScope: string, rootSessionId: string): string {

--- a/src/features/Org2Cloud/SessionConversation/conversationOwnerPublisher.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationOwnerPublisher.ts
@@ -111,6 +111,8 @@ export interface PublishOwnerTurnParams {
   turnIntentId: string;
   displayText: string;
   executorScope: string;
+  /** Provider-neutral local persistence identity; not the Cloud transport id. */
+  executionRootKey: string;
   /** Plane head fetched and injected immediately before this dispatch. */
   readThroughPlaneSeq: number;
   /** Fires after each successful push (signal-bump hook). */
@@ -151,7 +153,7 @@ export async function publishOwnerTurn(
   if (outcome.status === "completed") {
     advanceStoredOwnerPlaneCursor(
       params.executorScope,
-      params.rootSessionId,
+      params.executionRootKey,
       params.readThroughPlaneSeq
     );
   }

--- a/src/features/Org2Cloud/SessionConversation/conversationRunnerSessions.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationRunnerSessions.ts
@@ -22,9 +22,9 @@ const log = createLogger("ConversationRunnerSessions");
 
 export function conversationRunnerKey(
   executorScope: string,
-  rootSessionId: string
+  rootKey: string
 ): string {
-  return conversationExecutionKey(executorScope, rootSessionId);
+  return conversationExecutionKey(executorScope, rootKey);
 }
 
 /** Every runner session id on this device — the My Sessions hide filter. */

--- a/src/features/Org2Cloud/SessionConversation/conversationTurnRunner.test.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationTurnRunner.test.ts
@@ -186,6 +186,7 @@ function params(
     getAccessToken: async () => "token",
     orgId: "org",
     rootSessionId: "root",
+    executionRootKey: "root",
     conversationTitle: "Conversation",
     displayText: "new request",
     executionScopeKey: "scope",

--- a/src/features/Org2Cloud/SessionConversation/conversationTurnRunner.ts
+++ b/src/features/Org2Cloud/SessionConversation/conversationTurnRunner.ts
@@ -205,6 +205,8 @@ export interface RunConversationTurnParams {
   setupMemoryKey?: string;
   /** Account-and-org-scoped local executor identity. */
   executionScopeKey: string;
+  /** Provider-neutral local persistence identity for the canonical root. */
+  executionRootKey: string;
   /** Stable logical id for durable redelivery; minted for ordinary chat. */
   turnIntentId?: string;
   /**
@@ -423,7 +425,7 @@ export async function runConversationTurn(
 ): Promise<RunConversationTurnResult> {
   const key = conversationRunnerKey(
     params.executionScopeKey,
-    params.rootSessionId
+    params.executionRootKey
   );
   return withConversationTurnLock(key, () =>
     runConversationTurnSerialized(params)
@@ -435,7 +437,7 @@ async function runConversationTurnSerialized(
 ): Promise<RunConversationTurnResult> {
   const key = conversationRunnerKey(
     params.executionScopeKey,
-    params.rootSessionId
+    params.executionRootKey
   );
   const request = params.agentContent ?? params.displayText;
   const deadlineMs = Date.now() + TURN_DEADLINE_MS;
@@ -451,7 +453,7 @@ async function runConversationTurnSerialized(
   };
   const record = loadContinuation(
     params.executionScopeKey,
-    params.rootSessionId
+    params.executionRootKey
   );
   const configuredSetup = loadForkSetupMemory(
     params.setupMemoryKey ?? params.sourceScopeKey
@@ -486,7 +488,7 @@ async function runConversationTurnSerialized(
     log.info(`rolling conversation continuation: ${decision.rollReason}`);
     retireContinuation(
       params.executionScopeKey,
-      params.rootSessionId,
+      params.executionRootKey,
       decision.rollReason
     );
     if (record) {
@@ -534,7 +536,7 @@ async function runConversationTurnSerialized(
       log.warn("continuation send rejected; rolling to a fresh runner", error);
       retireContinuation(
         params.executionScopeKey,
-        params.rootSessionId,
+        params.executionRootKey,
         "resume_transport_rejected",
         true
       );
@@ -704,7 +706,7 @@ async function startFreshEpisode(
   try {
     prepareContinuation(
       params.executionScopeKey,
-      params.rootSessionId,
+      params.executionRootKey,
       {
         continuationSessionId: runnerSessionId,
         readThroughPlaneSeq: 0,
@@ -745,7 +747,7 @@ async function dispatchBootstrapEpisode(
 ): Promise<RunConversationTurnResult> {
   const key = conversationRunnerKey(
     params.executionScopeKey,
-    params.rootSessionId
+    params.executionRootKey
   );
   await params.onRunnerReady?.(
     episode.runnerSessionId,
@@ -782,7 +784,7 @@ async function dispatchBootstrapEpisode(
     if (!params.preserveRunnerOnTransportFailure) {
       retireContinuation(
         params.executionScopeKey,
-        params.rootSessionId,
+        params.executionRootKey,
         "bootstrap_transport_rejected",
         true
       );
@@ -794,7 +796,7 @@ async function dispatchBootstrapEpisode(
   if (
     !markContinuationEstablished(
       params.executionScopeKey,
-      params.rootSessionId,
+      params.executionRootKey,
       episode.runnerSessionId,
       io.turnIntentId
     )
@@ -840,7 +842,7 @@ async function settleEpisode(
     if (outcome.status === "completed") {
       advanceContinuationReadThrough(
         params.executionScopeKey,
-        params.rootSessionId,
+        params.executionRootKey,
         Math.max(
           input.readThroughPlaneSeq,
           input.userRowLastSeq,
@@ -854,7 +856,7 @@ async function settleEpisode(
     } else {
       retireContinuation(
         params.executionScopeKey,
-        params.rootSessionId,
+        params.executionRootKey,
         `turn_${outcome.status}`,
         true
       );

--- a/src/features/Org2Cloud/SessionConversation/useConversationSetupPillBinding.test.ts
+++ b/src/features/Org2Cloud/SessionConversation/useConversationSetupPillBinding.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 
+import { conversationSetupMemoryKey } from "@src/engines/SessionCore/conversations";
+
 import { resolveConversationSetupPillIdentity } from "./useConversationSetupPillBinding";
 
 describe("conversation setup pill identity", () => {
@@ -18,19 +20,18 @@ describe("conversation setup pill identity", () => {
   it("uses the same account/org/root/agent setup tuple as execution", () => {
     const identity = resolveConversationSetupPillIdentity({
       authIdentity: "cloud|user-a",
+      cloudEndpoint: "https://cloud.example",
       importedFrom,
       rows,
     });
 
     expect(identity?.rootSessionId).toBe("root-a");
     expect(identity?.setupMemoryKey).toBe(
-      JSON.stringify([
-        "cloud-conversation-setup",
-        "cloud|user-a",
-        "org-a",
-        "root-a",
-        "agent-a",
-      ])
+      conversationSetupMemoryKey({
+        executorScope: identity?.executorScopeKey ?? "",
+        rootKey: identity?.rootKey ?? "",
+        agentDefinitionId: "agent-a",
+      })
     );
     expect(identity?.setupMemoryKey).not.toBe("repo-scope");
   });
@@ -38,11 +39,13 @@ describe("conversation setup pill identity", () => {
   it("does not expose another signed-in account's remembered setup", () => {
     const first = resolveConversationSetupPillIdentity({
       authIdentity: "cloud|user-a",
+      cloudEndpoint: "https://cloud.example",
       importedFrom,
       rows,
     });
     const second = resolveConversationSetupPillIdentity({
       authIdentity: "cloud|user-b",
+      cloudEndpoint: "https://cloud.example",
       importedFrom,
       rows,
     });
@@ -50,6 +53,7 @@ describe("conversation setup pill identity", () => {
     expect(
       resolveConversationSetupPillIdentity({
         authIdentity: null,
+        cloudEndpoint: "https://cloud.example",
         importedFrom,
         rows,
       })

--- a/src/features/Org2Cloud/SessionConversation/useConversationSetupPillBinding.ts
+++ b/src/features/Org2Cloud/SessionConversation/useConversationSetupPillBinding.ts
@@ -56,6 +56,7 @@ export interface ConversationSetupPillBinding {
 interface ImportedConversationIdentity {
   orgId: string;
   sourceSessionId: string;
+  sourceEndpointUrl?: string;
 }
 
 interface ConversationIdentityRow {
@@ -66,10 +67,13 @@ interface ConversationIdentityRow {
 
 export function resolveConversationSetupPillIdentity(input: {
   authIdentity: string | null;
+  cloudEndpoint: string | null;
   importedFrom: ImportedConversationIdentity | null | undefined;
   rows: readonly ConversationIdentityRow[] | null | undefined;
 }): CloudConversationExecutionIdentity | null {
-  if (!input.importedFrom || !input.authIdentity) return null;
+  if (!input.importedFrom || !input.authIdentity || !input.cloudEndpoint) {
+    return null;
+  }
   const source = input.rows?.find(
     (candidate) =>
       candidate.sourceSessionId === input.importedFrom?.sourceSessionId
@@ -81,6 +85,7 @@ export function resolveConversationSetupPillIdentity(input: {
   );
   return resolveCloudConversationExecutionIdentity({
     authIdentity: input.authIdentity,
+    cloudEndpoint: input.importedFrom.sourceEndpointUrl ?? input.cloudEndpoint,
     cloudOrgId: input.importedFrom.orgId,
     rootSessionId,
     assignedAgentDefinitionId: root?.agentDefinitionId,
@@ -108,10 +113,11 @@ export function useConversationSetupPillBinding(
   const executionIdentity = useMemo(() => {
     return resolveConversationSetupPillIdentity({
       authIdentity,
+      cloudEndpoint: auth?.supabaseUrl ?? null,
       importedFrom,
       rows: importedFrom ? remoteEntries[importedFrom.orgId]?.rows : undefined,
     });
-  }, [authIdentity, importedFrom, remoteEntries]);
+  }, [auth?.supabaseUrl, authIdentity, importedFrom, remoteEntries]);
 
   const selection = useMemo((): LastModelSelection | null => {
     if (!importedFrom) return null;

--- a/src/features/Org2Cloud/SessionConversation/workItemConversationTurnBridge.test.ts
+++ b/src/features/Org2Cloud/SessionConversation/workItemConversationTurnBridge.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 
+import {
+  conversationExecutorScopeKey,
+  conversationRootKey,
+} from "@src/engines/SessionCore/conversations";
+
 import type { Org2CloudAuthState } from "../org2CloudAuthAtom";
 import {
   type WorkItemConversationTurnDeps,
@@ -233,11 +238,17 @@ describe("handleWorkItemConversationTurnRequest", () => {
       preserveRunnerOnTransportFailure: true,
     });
     expect(deps.turnParams[0].executionScopeKey).toBe(
-      JSON.stringify([
-        "cloud-conversation-executor",
-        "https://cloud.example|user-b",
-        "cloud-org",
-      ])
+      conversationExecutorScopeKey({
+        authority: "org2-cloud-account",
+        authorityScope: ["https://cloud.example|user-b", "cloud-org"],
+      })
+    );
+    expect(deps.turnParams[0].executionRootKey).toBe(
+      conversationRootKey({
+        authority: "org2-cloud",
+        authorityScope: ["https://cloud.example", "cloud-org"],
+        conversationId: "root-remote",
+      })
     );
   });
 

--- a/src/features/Org2Cloud/SessionConversation/workItemConversationTurnBridge.ts
+++ b/src/features/Org2Cloud/SessionConversation/workItemConversationTurnBridge.ts
@@ -211,6 +211,7 @@ export async function handleWorkItemConversationTurnRequest(
   const authIdentity = org2CloudAuthIdentityKey(auth as Org2CloudAuthState);
   const executionIdentity = resolveCloudConversationExecutionIdentity({
     authIdentity,
+    cloudEndpoint: (auth as Org2CloudAuthState).supabaseUrl,
     cloudOrgId: resolvedOrgId,
     rootSessionId,
     assignedAgentDefinitionId: request.assignedAgentId,
@@ -244,6 +245,7 @@ export async function handleWorkItemConversationTurnRequest(
       assignedAgentDefinitionId: request.assignedAgentId ?? undefined,
       setupMemoryKey: executionIdentity.setupMemoryKey,
       executionScopeKey: executionIdentity.executorScopeKey,
+      executionRootKey: executionIdentity.rootKey,
       turnIntentId: request.runId,
       requiredRunnerSessionId: request.preparedRunnerSessionId ?? undefined,
       preserveRunnerOnTransportFailure: true,


### PR DESCRIPTION
## Problem

PR #965 canonicalizes Cloud entry surfaces, but the persistence tuple still treats a Cloud organization and bare root session ID as the execution model. That cannot represent a manually imported external-history session with no Work Item or Cloud account, and it lets transport identity leak into local continuation state.

## Solution

- Add a provider-neutral SessionCore identity contract for conversation roots, local executor scopes, execution rows, and setup memory.
- Add first-class resolvers for manual external-history imports and ordinary local sessions; neither accepts Work Item, owner, Cloud plane, model, workspace, or credentials as root identity.
- Make the Cloud adapter call the same resolver while retaining its separate transport plane key.
- Pass a distinct executionRootKey through the real composer, Work Item bridge, owner publisher, runner lock, and continuation persistence paths.
- Remove the duplicated Cloud-specific key builders from the local execution store.

This PR is stacked on #965.

## Potential risks

- The unmerged continuation stack now generates new localStorage keys for Cloud executions. The following SQLite persistence PR imports real legacy localStorage records and treats this unshipped draft key shape as replaceable.
- Endpoint normalization is now part of remote root authority, preventing collisions across Cloud deployments. A malformed historical endpoint could resolve to a different root; the existing normalized import endpoint is used when available.
- Rollback is the single commit in this PR; Cloud wire and database schemas are unchanged.

## Verification

- 59 focused Vitest tests pass, including a manual imported-session case with no Cloud or Work Item.
- pnpm typecheck passes.
- ESLint passes for every changed TypeScript file.
- Repository pre-commit hooks passed.
