### PR TITLE
feat(continuation): secure portable checkpoint envelopes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,52 @@ jobs:
         working-directory: src-tauri
         run: cargo test --workspace --no-fail-fast
 
+  # The continuation handoff wire and secure staging code are security
+  # boundaries with an explicit MSRV and Windows-only DACL implementation.
+  # Keep both promises executable instead of relying on macOS cross-checks.
+  continuation-crypto-msrv:
+    name: Continuation crypto (Rust 1.85 MSRV)
+    needs: changes
+    if: needs.changes.outputs.rust_required == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust 1.85
+        uses: dtolnay/rust-toolchain@1.85.0
+
+      - name: Check continuation crypto at MSRV
+        working-directory: src-tauri
+        run: cargo check --locked -p continuation_crypto --all-targets
+
+      - name: Reject OpenSSL and native-tls in the secure leaf
+        working-directory: src-tauri
+        shell: bash
+        run: |
+          if cargo tree -p continuation_crypto --edges normal | grep -Eiq 'openssl|native-tls'; then
+            echo "continuation_crypto must stay on native OS stores and RustCrypto"
+            exit 1
+          fi
+
+  continuation-crypto-windows:
+    name: Continuation crypto (Windows DACL tests)
+    needs: changes
+    if: needs.changes.outputs.rust_required == 'true'
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Test continuation crypto on Windows
+        working-directory: src-tauri
+        run: cargo test --locked -p continuation_crypto
+
   # ── Dependency audit ────────────────────────────────────────────────────────
   # Only signal on the ~1000-crate Rust closure; nothing else watches Cargo.lock.
   # Runs on its own runner rather than inside the `rust` job so an advisory

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -41,6 +41,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +59,49 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "age"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "047a482d1843edf1ce76ada63183698144030fe1191bd5ddba6e41e164e0bc43"
+dependencies = [
+ "age-core",
+ "base64 0.21.7",
+ "bech32 0.9.1",
+ "chacha20poly1305",
+ "cookie-factory",
+ "hmac",
+ "i18n-embed",
+ "i18n-embed-fl",
+ "lazy_static",
+ "nom",
+ "pin-project",
+ "rand 0.8.6",
+ "rust-embed",
+ "scrypt",
+ "sha2 0.10.9",
+ "subtle",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "age-core"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2bf6a89c984ca9d850913ece2da39e1d200563b0a94b002b253beee4c5acf99"
+dependencies = [
+ "base64 0.21.7",
+ "chacha20poly1305",
+ "cookie-factory",
+ "hkdf",
+ "io_tee",
+ "nom",
+ "rand 0.8.6",
+ "secrecy",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -65,7 +118,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "tauri",
  "tempfile",
  "tokio",
@@ -91,7 +144,7 @@ dependencies = [
  "bytes",
  "chrono",
  "chrono-tz",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics 0.24.0",
  "core_types",
  "croner",
@@ -134,7 +187,7 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "settings",
- "sha2",
+ "sha2 0.10.9",
  "shared_state",
  "similar",
  "tauri",
@@ -305,6 +358,15 @@ dependencies = [
  "percent-encoding",
  "windows-sys 0.60.2",
  "x11rb",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -668,6 +730,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
+name = "bech32"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+
+[[package]]
 name = "bin_gateway_chat_cli"
 version = "0.1.0"
 dependencies = [
@@ -786,6 +869,24 @@ name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
 ]
@@ -1070,6 +1171,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,6 +1247,17 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
@@ -1144,6 +1265,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -1176,8 +1310,9 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -1244,7 +1379,7 @@ dependencies = [
  "bitflags 2.13.0",
  "block",
  "cocoa-foundation",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics 0.24.0",
  "foreign-types",
  "libc",
@@ -1259,7 +1394,7 @@ checksum = "81411967c50ee9a1fc11365f8c585f863a22a9697c89239c452292c40ba79b0d"
 dependencies = [
  "bitflags 2.13.0",
  "block",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "objc",
 ]
@@ -1321,6 +1456,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1366,6 +1507,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "continuation_crypto"
+version = "0.1.0"
+dependencies = [
+ "age",
+ "base64 0.22.1",
+ "bech32 0.11.1",
+ "ed25519-dalek",
+ "flate2",
+ "hex",
+ "keyring",
+ "libc",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+ "tempfile",
+ "thiserror 2.0.18",
+ "uuid",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "conversation-portability"
 version = "0.1.0"
 dependencies = [
@@ -1373,7 +1535,7 @@ dependencies = [
  "ryu",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -1390,6 +1552,25 @@ checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie-factory"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
+dependencies = [
+ "futures",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1415,7 +1596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -1428,7 +1609,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
  "libc",
@@ -1441,7 +1622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -1566,6 +1747,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.29.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,6 +1841,33 @@ name = "ctor-proc-macro"
 version = "0.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "cxx"
@@ -1789,6 +2006,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2 0.10.9",
+ "zeroize",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1824,7 +2070,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1904,10 +2150,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1928,7 +2185,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2107,12 +2364,37 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
  "tokio-rustls",
  "tracing-subscriber",
  "urlencoding",
  "uuid",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2228,7 +2510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2340,6 +2622,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "field-offset"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2391,6 +2679,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-crate"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
+dependencies = [
+ "toml 0.5.11",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2435,6 +2732,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "fluent"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a"
+dependencies = [
+ "fluent-bundle",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-bundle"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493"
+dependencies = [
+ "fluent-langneg",
+ "fluent-syntax",
+ "intl-memoizer",
+ "intl_pluralrules",
+ "rustc-hash 1.1.0",
+ "self_cell 0.10.3",
+ "smallvec",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-langneg"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eebbe59450baee8282d71676f3bfed5689aeab00b27545e83e5f14b1195e8b0"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-syntax"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2908,7 +3249,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tauri",
  "tokio",
  "tracing",
@@ -3266,7 +3607,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3376,6 +3717,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3464,6 +3814,72 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
+]
+
+[[package]]
+name = "i18n-config"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e06b90c8a0d252e203c94344b21e35a30f3a3a85dc7db5af8f8df9f3e0c63ef"
+dependencies = [
+ "basic-toml",
+ "log",
+ "serde",
+ "serde_derive",
+ "thiserror 1.0.69",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "669ffc2c93f97e6ddf06ddbe999fcd6782e3342978bb85f7d3c087c7978404c4"
+dependencies = [
+ "arc-swap",
+ "fluent",
+ "fluent-langneg",
+ "fluent-syntax",
+ "i18n-embed-impl",
+ "intl-memoizer",
+ "log",
+ "parking_lot 0.12.5",
+ "rust-embed",
+ "thiserror 1.0.69",
+ "unic-langid",
+ "walkdir",
+]
+
+[[package]]
+name = "i18n-embed-fl"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04b2969d0b3fc6143776c535184c19722032b43e6a642d710fa3f88faec53c2d"
+dependencies = [
+ "find-crate",
+ "fluent",
+ "fluent-syntax",
+ "i18n-config",
+ "i18n-embed",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed-impl"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2cc0e0523d1fe6fc2c6f66e5038624ea8091b3e7748b5e8e0c84b1698db6c2"
+dependencies = [
+ "find-crate",
+ "i18n-config",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3728,6 +4144,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -3788,6 +4205,31 @@ dependencies = [
  "urlencoding",
  "webpki-roots 1.0.7",
 ]
+
+[[package]]
+name = "intl-memoizer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f"
+dependencies = [
+ "type-map",
+ "unic-langid",
+]
+
+[[package]]
+name = "intl_pluralrules"
+version = "7.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "io_tee"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3f7cef34251886990511df1c61443aa928499d598a9473929ab5a90a527304"
 
 [[package]]
 name = "ipnet"
@@ -4038,7 +4480,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tauri",
  "tempfile",
  "tokio",
@@ -4061,6 +4503,22 @@ dependencies = [
  "bitflags 2.13.0",
  "serde",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "secret-service",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
 ]
 
 [[package]]
@@ -4139,6 +4597,15 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libgit2-sys"
@@ -4480,7 +4947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4660,6 +5127,19 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
 version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
@@ -4728,7 +5208,7 @@ dependencies = [
  "mac-notification-sys",
  "serde",
  "tauri-winrt-notification",
- "zbus",
+ "zbus 5.16.0",
 ]
 
 [[package]]
@@ -4756,7 +5236,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4926,7 +5406,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "url",
 ]
@@ -5221,6 +5701,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "open"
 version = "5.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5294,7 +5780,7 @@ dependencies = [
  "cc",
  "chrono",
  "container",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics 0.24.0",
  "core_types",
  "csv",
@@ -5336,7 +5822,7 @@ dependencies = [
  "serde_json",
  "session_persistence",
  "settings",
- "sha2",
+ "sha2 0.10.9",
  "shared_state",
  "system_services",
  "tar",
@@ -5404,7 +5890,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "toml 0.8.2",
 ]
@@ -5427,7 +5913,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "similar",
  "tracing",
 ]
@@ -5458,7 +5944,7 @@ dependencies = [
  "chrono",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5468,7 +5954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5588,7 +6074,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
 ]
 
@@ -5648,7 +6134,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "simd-json",
  "similar",
  "sysinfo",
@@ -5699,7 +6185,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5917,6 +6403,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6017,6 +6523,17 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -6146,6 +6663,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6201,7 +6740,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "serial_test",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "tauri",
  "tauri-plugin-opener",
@@ -6429,7 +6968,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.1",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]
@@ -6840,8 +7379,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -6866,6 +7405,41 @@ dependencies = [
  "hashlink 0.9.1",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust-embed"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e7760e252aaba7b09f4be00e36476cf585bdb68a53552ac954cdf504ab4bc9"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bcfc4d6f53af43755f7a723e4b6b8794fcce052a178dd8c6c1dadc5f5343097"
+dependencies = [
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.117",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ffa149f6aa81b58a5b3011d01a857c4ed12c7a732d2c51947a4c7c692185f0"
+dependencies = [
+ "sha2 0.11.0",
+ "walkdir",
 ]
 
 [[package]]
@@ -6927,7 +7501,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6954,7 +7528,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -6982,7 +7556,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni 0.22.4",
  "log",
@@ -6991,10 +7565,10 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7025,6 +7599,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "same-file"
@@ -7121,6 +7704,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "search"
 version = "0.1.0"
 dependencies = [
@@ -7151,13 +7745,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "sha2 0.10.9",
+ "zbus 4.4.0",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.13.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -7209,6 +7844,21 @@ dependencies = [
  "servo_arc 0.4.3",
  "smallvec",
 ]
+
+[[package]]
+name = "self_cell"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d"
+dependencies = [
+ "self_cell 1.3.0",
+]
+
+[[package]]
+name = "self_cell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "semver"
@@ -7508,7 +8158,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -7519,7 +8169,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -7622,7 +8283,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -7718,7 +8379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7827,7 +8488,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -7865,7 +8526,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -7887,7 +8548,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -7908,7 +8569,7 @@ dependencies = [
  "rsa",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -7945,7 +8606,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -7996,6 +8657,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "streaming-iterator"
@@ -8169,7 +8836,7 @@ dependencies = [
  "app_platform",
  "app_window",
  "chrono",
- "core-foundation",
+ "core-foundation 0.10.1",
  "dispatch2",
  "futures",
  "git",
@@ -8198,7 +8865,7 @@ checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
 dependencies = [
  "bitflags 2.13.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics 0.25.0",
  "crossbeam-channel",
  "dispatch2",
@@ -8347,7 +9014,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "syn 2.0.117",
  "tauri-utils",
  "thiserror 2.0.18",
@@ -8555,7 +9222,7 @@ dependencies = [
  "thiserror 2.0.18",
  "url",
  "windows 0.61.3",
- "zbus",
+ "zbus 5.16.0",
 ]
 
 [[package]]
@@ -8602,7 +9269,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "windows-sys 0.60.2",
- "zbus",
+ "zbus 5.16.0",
 ]
 
 [[package]]
@@ -8793,7 +9460,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8994,6 +9661,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -9088,6 +9756,15 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -9452,6 +10129,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash 2.1.2",
+]
+
+[[package]]
 name = "type1-encoding-parser"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9492,7 +10178,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9531,6 +10217,25 @@ name = "unic-common"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
+
+[[package]]
+name = "unic-langid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
+dependencies = [
+ "unic-langid-impl",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
+dependencies = [
+ "serde",
+ "tinystr",
+]
 
 [[package]]
 name = "unic-ucd-ident"
@@ -9602,6 +10307,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"
@@ -10146,7 +10861,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10979,7 +11694,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
- "sha2",
+ "sha2 0.10.9",
  "soup3",
  "tao-macros",
  "thiserror 2.0.18",
@@ -11032,6 +11747,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11057,6 +11784,16 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11102,6 +11839,38 @@ dependencies = [
 
 [[package]]
 name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix 0.29.0",
+ "ordered-stream",
+ "rand 0.8.6",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros 4.4.0",
+ "zbus_names 3.0.0",
+ "zvariant 4.2.0",
+]
+
+[[package]]
+name = "zbus"
 version = "5.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
@@ -11130,9 +11899,22 @@ dependencies = [
  "uuid",
  "windows-sys 0.61.2",
  "winnow 1.0.3",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "zbus_macros 5.16.0",
+ "zbus_names 4.3.2",
+ "zvariant 5.12.0",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -11145,9 +11927,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
+ "zbus_names 4.3.2",
+ "zvariant 5.12.0",
+ "zvariant_utils 3.4.0",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -11158,7 +11951,7 @@ checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
  "winnow 1.0.3",
- "zvariant",
+ "zvariant 5.12.0",
 ]
 
 [[package]]
@@ -11239,6 +12032,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",
@@ -11380,6 +12174,19 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive 4.2.0",
+]
+
+[[package]]
+name = "zvariant"
 version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
@@ -11388,8 +12195,21 @@ dependencies = [
  "enumflags2",
  "serde",
  "winnow 1.0.3",
- "zvariant_derive",
- "zvariant_utils",
+ "zvariant_derive 5.12.0",
+ "zvariant_utils 3.4.0",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -11402,7 +12222,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "zvariant_utils",
+ "zvariant_utils 3.4.0",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/browser",
     "crates/container",
     "crates/conversation-portability",
+    "crates/continuation-crypto",
     "crates/ui-indexer",
     "crates/database",
     "crates/db-browser",

--- a/src-tauri/crates/continuation-crypto/Cargo.toml
+++ b/src-tauri/crates/continuation-crypto/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "continuation_crypto"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.85.0"
+description = "OS-secure device identity and bounded ORG2 Cloud E2EE continuation handoff primitives."
+publish = false
+
+[lib]
+name = "continuation_crypto"
+path = "src/lib.rs"
+
+[dependencies]
+# Standard age-encryption.org/v1 X25519 streaming encryption. No SSH,
+# armor, CLI, async, or network-facing feature surface is needed here.
+age = { version = "0.11.5", default-features = false }
+bech32 = { version = "0.11", default-features = false, features = ["std"] }
+base64 = "0.22"
+ed25519-dalek = { version = "2.2", default-features = false, features = ["fast", "rand_core", "std", "zeroize"] }
+flate2 = { version = "1.1.9", default-features = false, features = ["rust_backend"] }
+hex = "0.4"
+rand_core = { version = "0.6", features = ["getrandom"] }
+sha2 = "0.10"
+tempfile = "3.13"
+thiserror = "2"
+uuid = { version = "1.18", default-features = false, features = ["std"] }
+zeroize = { version = "1.8", features = ["derive"] }
+
+# `keyring` v3 has no default backend. Select exactly one native OS store per
+# target and keep Linux on RustCrypto so this leaf never links OpenSSL or
+# native-tls. Unsupported desktop targets compile a fail-closed adapter.
+[target.'cfg(target_os = "macos")'.dependencies]
+keyring = { version = "3.6.3", default-features = false, features = ["apple-native"] }
+
+[target.'cfg(windows)'.dependencies]
+keyring = { version = "3.6.3", default-features = false, features = ["windows-native"] }
+windows-sys = { version = "0.60", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+    "Win32_Storage_FileSystem",
+    "Win32_System_IO",
+    "Win32_System_Memory",
+    "Win32_System_Threading",
+] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+keyring = { version = "3.6.3", default-features = false, features = ["sync-secret-service", "crypto-rust"] }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/src-tauri/crates/continuation-crypto/WIRE.md
+++ b/src-tauri/crates/continuation-crypto/WIRE.md
@@ -1,0 +1,223 @@
+# ORG2 Cloud continuation handoff envelope v1
+
+This is the byte-level contract shared by the Rust device crate and the Cloud
+prepare/commit implementation. It is specifically an optional Cloud E2EE
+transport. Provider-neutral local continuation state belongs to the portable
+IR layer and does not use this header. No signed field is encoded as JSON.
+
+## Device fingerprint
+
+```text
+SHA256(
+  UTF8("ORG2-CONTINUATION-DEVICE-V1") ||
+  0x00 ||
+  raw_x25519_public_key[32] ||
+  raw_ed25519_public_key[32]
+)
+```
+
+The external form is lowercase hexadecimal. Golden input
+`x25519 = 00..1f`, `ed25519 = 20..3f` produces:
+
+```text
+3b7ec85045344de1f5b326e474baab6f293a211bbcb41e50b95aaa9ea10c6a9a
+```
+
+## Complete object
+
+All integers are unsigned big-endian. UUIDs are canonical RFC 4122 raw 16-byte
+values (the same bytes returned by PostgreSQL `uuid_send`). `string16` is a
+big-endian `u16` byte length followed by nonempty canonical UTF-8 bytes.
+
+```text
+magic[8]                 = "ORG2HND\0"
+envelope_version:u16     = 1
+canonical_header_len:u32
+canonical_header[canonical_header_len]
+age_ciphertext[header.age_ciphertext_len]
+ed25519_signature[64]
+end_magic[8]             = "ORG2END\0"
+```
+
+`age_ciphertext` is exactly one standard binary age-encryption.org/v1 file,
+without armor, containing one X25519 recipient stanza for every signed
+recipient entry. It is never one object per recipient. `object_size` and
+`object_sha256` cover every byte above, including prefix, header, signature,
+and end marker. They are Cloud storage/path/quota metadata and cannot be inside
+the signed header without a circular digest.
+
+The only public artifact profile caps this complete object at 16 MiB. Broader
+test-only limits are not constructible by upload/download code.
+
+## Canonical signed header
+
+Fields occur in this exact order:
+
+```text
+encryption_algorithm:u8       = 1 (age X25519)
+signature_algorithm:u8        = 1 (Ed25519)
+compression_algorithm:u8      = 1 (gzip)
+hash_algorithm:u8             = 1 (SHA-256)
+org_id:uuid[16]
+checkpoint_id:uuid[16]
+root_session_id:string16
+source_episode_id:string16
+source_runtime:string16
+target_runtime:string16
+recipient_scope:u8             = 1 (audience) | 2 (explicit subset)
+sender_user_id:uuid[16]
+sender_device_id:uuid[16]
+sender_key_version:u32
+sender_x25519_public_key[32]
+sender_ed25519_public_key[32]
+sender_fingerprint[32]
+recipient_count:u16            = 1..64
+recipient_set_sha256[32]
+recipient[recipient_count] {
+  recipient_user_id:uuid[16]
+  recipient_device_id:uuid[16]
+  recipient_key_version:u32
+  recipient_x25519_public_key[32]
+  recipient_ed25519_public_key[32]
+  recipient_fingerprint[32]
+}
+age_ciphertext_sha256[32]
+created_at_unix_ms:u64
+expires_at_unix_ms:u64
+age_ciphertext_len:u64
+```
+
+Recipients are in strict ascending raw-byte order by
+`(recipient_user_id, recipient_device_id, key_version)`. The `u32` key is
+compared numerically and encoded big-endian, matching PostgreSQL `int4send` for
+the allowed positive `int4` range. The encoder sorts; the decoder rejects
+noncanonical order. Entries are unique, and one device cannot appear under
+multiple users or key versions in a newly encrypted object. Historical objects
+remain decryptable with their snapshotted old key.
+
+The exact recipient-set digest is:
+
+```text
+SHA256(
+  UTF8("ORG2-CONTINUATION-RECIPIENT-SET-V1") ||
+  0x00 ||
+  be_u16(recipient_count) ||
+  for each canonical recipient:
+    recipient_user_id[16] ||
+    recipient_device_id[16] ||
+    be_u32(recipient_key_version) ||
+    recipient_x25519_public_key[32] ||
+    recipient_ed25519_public_key[32] ||
+    recipient_fingerprint[32]
+)
+```
+
+`audience` means the server resolved the complete current root audience;
+`subset` means an explicit handoff. Either way, the exact resulting array is
+signed. Cloud stores common object metadata once and one small receipt row per
+recipient. A decryptor first verifies the immutable object, full canonical
+recipient set, sender signature, and committed object row; only then may it
+select a caller receipt whose `(user, device, key version, keys, fingerprint)`
+exactly equals an entry and whose private key reproduces that public identity.
+
+Cloud mirrors the following common object fields and must compare every one to
+the decoded header or complete-object snapshot before decrypt:
+
+```text
+checkpoint_id, org_id, root_session_id, source_episode_id,
+sender_user_id, sender_device_id, sender_key_version,
+sender_x25519_public_key, sender_ed25519_public_key, sender_fingerprint,
+source_runtime, target_runtime, recipient_scope, recipient_count,
+recipient_set_sha256, client_created_at_unix_ms, expires_at_unix_ms,
+age_ciphertext_len, age_ciphertext_sha256, footer_signature,
+object_size, object_sha256, canonical_header
+```
+
+Each receipt mirrors:
+
+```text
+checkpoint_id, org_id, recipient_user_id, recipient_device_id,
+recipient_key_version, recipient_x25519_public_key,
+recipient_ed25519_public_key, recipient_fingerprint
+```
+
+SQL UUID text accepted by the Rust boundary is lowercase canonical hyphenated
+form; it is decoded back to the raw 16 signed bytes. Key versions are
+`1..=2147483647`. Runtime IDs match
+`^[a-z0-9][a-z0-9._-]{0,63}$`. Hashes are lowercase 64-hex, public keys are
+canonical unpadded base64url raw-32, and the footer signature is canonical
+unpadded base64url raw-64.
+
+`created_at_unix_ms` is supplied and signed by the client; Cloud validates it
+against bounded clock skew instead of replacing it with server time. The
+sender public keys and fingerprint are snapshotted on the committed object
+row, so a later key revocation does not make an already committed artifact
+cryptographically unverifiable. Recipient keys are snapshotted on receipts.
+The outer header contains no plaintext hash; that digest is inside the
+encrypted manifest.
+
+## One signature, two storage locations
+
+The exact Ed25519 message is:
+
+```text
+UTF8("ORG2-CONTINUATION-ENVELOPE-SIGNATURE-V1") ||
+0x00 ||
+be_u32(canonical_header_len) ||
+canonical_header ||
+age_ciphertext_sha256[32]
+```
+
+The resulting 64 bytes are written verbatim in the object footer and sent
+verbatim as the Cloud RPC signature. There is no separately encoded or
+separately computed RPC signature.
+
+The shared real-UUID golden is frozen in
+`canonical_header_and_signed_bytes_have_exact_golden_vector`:
+
+```text
+org_id                    = 10000000-0000-0000-0000-000000000001
+checkpoint_id             = 40000000-0000-0000-0000-000000000001
+root_session_id           = root-session-a
+source_episode_id         = episode-a
+sender_user_id            = 20000000-0000-0000-0000-000000000001
+sender_device_id          = 30000000-0000-0000-0000-000000000001
+recipient_scope           = audience (1)
+recipient users/devices   = (...0002/...0002 key 9), (...0003/...0003 key 11)
+recipient_set_sha256      = 9ddfed1c641fa7cd2e0b93511b878361a3bedf8485708c75f0057ab6429ecbb7
+canonical_header_len      = 565
+canonical_header_sha256   = 7de14a7d826b915bd19d55bac5255fcc25786fb93a36d268bececa68df451d59
+SHA256(signed_message)    = 0dd738152b0fbfad87462a770b3c614e828112fe6506052e46e2399001796ad7
+Ed25519 seed              = 9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60
+signature                 = b5f125019861b57d0745ec4d9917208bace0c245850c68ad9f114ebcf0107f88d31f86d551d3b3c6809bebcff5bdd81fe0fd18bbd5869da108725c2b5e04fb03
+```
+
+The test also freezes the complete 565-byte canonical header hex. The signed
+message is reconstructed by the formula above; its digest and signature are
+independently asserted for Cloud migration tests.
+
+## Encrypted inner stream
+
+After age decryption, gzip decompression yields:
+
+```text
+inner_magic[8]          = "ORG2CPS\0"
+inner_version:u16       = 1
+manifest_frame
+event_or_blob_frame...
+footer_frame
+```
+
+Every frame is `tag:u8 || payload_len:u32 || payload`. Tags are manifest `1`,
+event `2`, blob `3`, and footer `255`. The encrypted manifest and footer carry
+the SHA-256 of the canonical raw event/blob frames (including each frame tag
+and length, excluding manifest/footer). Each blob also carries and verifies its
+own SHA-256. Readers enforce per-frame, per-event, per-blob, record-count, blob
+count, total decompressed-byte, and complete-object limits before allocation or
+delivery, and reject unsafe or ambiguous relative paths.
+
+Blob paths use forward-slash-separated printable ASCII components. They reject
+absolute/empty/dot components, Windows-reserved characters and device names,
+trailing dot/space, and case-insensitive duplicates. This deliberately avoids
+cross-platform Unicode normalization and case-fold collisions when a handoff
+is restored on a different filesystem.

--- a/src-tauri/crates/continuation-crypto/WIRE.md
+++ b/src-tauri/crates/continuation-crypto/WIRE.md
@@ -63,7 +63,8 @@ checkpoint_id:uuid[16]
 root_session_id:string16
 source_episode_id:string16
 source_runtime:string16
-target_runtime:string16
+payload_schema:string16
+payload_schema_version:u16
 recipient_scope:u8             = 1 (audience) | 2 (explicit subset)
 sender_user_id:uuid[16]
 sender_device_id:uuid[16]
@@ -127,7 +128,8 @@ the decoded header or complete-object snapshot before decrypt:
 checkpoint_id, org_id, root_session_id, source_episode_id,
 sender_user_id, sender_device_id, sender_key_version,
 sender_x25519_public_key, sender_ed25519_public_key, sender_fingerprint,
-source_runtime, target_runtime, recipient_scope, recipient_count,
+source_runtime, payload_schema, payload_schema_version, recipient_scope,
+recipient_count,
 recipient_set_sha256, client_created_at_unix_ms, expires_at_unix_ms,
 age_ciphertext_len, age_ciphertext_sha256, footer_signature,
 object_size, object_sha256, canonical_header
@@ -144,7 +146,9 @@ recipient_ed25519_public_key, recipient_fingerprint
 SQL UUID text accepted by the Rust boundary is lowercase canonical hyphenated
 form; it is decoded back to the raw 16 signed bytes. Key versions are
 `1..=2147483647`. Runtime IDs match
-`^[a-z0-9][a-z0-9._-]{0,63}$`. Hashes are lowercase 64-hex, public keys are
+`^[a-z0-9][a-z0-9._-]{0,63}$`. Payload schema IDs are non-empty canonical
+UTF-8 without control bytes (maximum 128 bytes), and schema versions are
+positive `u16`. Hashes are lowercase 64-hex, public keys are
 canonical unpadded base64url raw-32, and the footer signature is canonical
 unpadded base64url raw-64.
 
@@ -180,19 +184,22 @@ org_id                    = 10000000-0000-0000-0000-000000000001
 checkpoint_id             = 40000000-0000-0000-0000-000000000001
 root_session_id           = root-session-a
 source_episode_id         = episode-a
+source_runtime            = codex
+payload_schema            = org2.portable_conversation
+payload_schema_version    = 2
 sender_user_id            = 20000000-0000-0000-0000-000000000001
 sender_device_id          = 30000000-0000-0000-0000-000000000001
 recipient_scope           = audience (1)
 recipient users/devices   = (...0002/...0002 key 9), (...0003/...0003 key 11)
 recipient_set_sha256      = 9ddfed1c641fa7cd2e0b93511b878361a3bedf8485708c75f0057ab6429ecbb7
-canonical_header_len      = 565
-canonical_header_sha256   = 7de14a7d826b915bd19d55bac5255fcc25786fb93a36d268bececa68df451d59
-SHA256(signed_message)    = 0dd738152b0fbfad87462a770b3c614e828112fe6506052e46e2399001796ad7
+canonical_header_len      = 587
+canonical_header_sha256   = 4bd4bde95b64e5a2230068bcf672184c3e4f64df6a010af1e1132d174841a5e1
+SHA256(signed_message)    = eca71c52611d9317c51a0a4526a1f86bc68655dbaec73c35a7dfdd1f2f3fa10c
 Ed25519 seed              = 9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60
-signature                 = b5f125019861b57d0745ec4d9917208bace0c245850c68ad9f114ebcf0107f88d31f86d551d3b3c6809bebcff5bdd81fe0fd18bbd5869da108725c2b5e04fb03
+signature                 = b612ae200776267d65b3635502e5044bd0910d5584d6d9cbeabf05823ee13927a946b1273b8527e3c767ef4effcd9cdc5242674b9c665993b8b5983874c7bd07
 ```
 
-The test also freezes the complete 565-byte canonical header hex. The signed
+The test also freezes the complete 587-byte canonical header hex. The signed
 message is reconstructed by the formula above; its digest and signature are
 independently asserted for Cloud migration tests.
 

--- a/src-tauri/crates/continuation-crypto/src/atomic_file.rs
+++ b/src-tauri/crates/continuation-crypto/src/atomic_file.rs
@@ -1,0 +1,257 @@
+use std::{fs::File, io::Read, path::PathBuf};
+
+use sha2::{Digest, Sha256};
+
+use crate::{staging::sync_directory, ContinuationCryptoError, PrivateStagingDirectory};
+
+pub(crate) struct AtomicCiphertextFile {
+    destination: PathBuf,
+    temp: Option<tempfile::NamedTempFile>,
+}
+
+impl AtomicCiphertextFile {
+    pub(crate) fn create(
+        staging: &PrivateStagingDirectory,
+        job_id: &str,
+        destination: &std::path::Path,
+    ) -> Result<Self, ContinuationCryptoError> {
+        let destination = staging.validate_destination(destination)?;
+        let temp = staging.named_ciphertext(job_id)?;
+        Ok(Self {
+            destination,
+            temp: Some(temp),
+        })
+    }
+
+    pub(crate) fn file_mut(&mut self) -> &mut File {
+        self.temp
+            .as_mut()
+            .expect("staging file is available until publish")
+            .as_file_mut()
+    }
+
+    pub(crate) fn publish(
+        mut self,
+        expected_size: u64,
+        expected_sha256: &[u8; 32],
+    ) -> Result<(), ContinuationCryptoError> {
+        self.publish_impl(expected_size, expected_sha256, PublishFault::None)
+    }
+
+    fn publish_impl(
+        &mut self,
+        expected_size: u64,
+        expected_sha256: &[u8; 32],
+        fault: PublishFault,
+    ) -> Result<(), ContinuationCryptoError> {
+        self.temp
+            .as_mut()
+            .expect("staging file is available until publish")
+            .as_file_mut()
+            .sync_all()
+            .map_err(|error| ContinuationCryptoError::io("fsyncing ciphertext", error))?;
+        if fault == PublishFault::AfterTempFsync {
+            return Err(ContinuationCryptoError::io(
+                "simulated crash after ciphertext fsync",
+                std::io::Error::other("fault injection"),
+            ));
+        }
+        let parent = self
+            .destination
+            .parent()
+            .ok_or(ContinuationCryptoError::InvalidEnvelope(
+                "destination has no parent directory",
+            ))?
+            .to_owned();
+        let temp = self
+            .temp
+            .take()
+            .expect("staging file is consumed exactly once");
+        let persisted = match temp.persist_noclobber(&self.destination) {
+            Ok(file) => file,
+            Err(error) if error.error.kind() == std::io::ErrorKind::AlreadyExists => {
+                if let Some(existing) =
+                    open_verified_existing(&self.destination, expected_size, expected_sha256)?
+                {
+                    // A prior attempt may have renamed successfully and then
+                    // crashed before the directory entry became durable. Sync
+                    // the exact file handle that was hashed, then complete the
+                    // parent-directory barrier before reporting idempotent
+                    // success.
+                    existing.sync_all().map_err(|error| {
+                        ContinuationCryptoError::io("fsyncing reconciled ciphertext", error)
+                    })?;
+                    if fault == PublishFault::AfterReconciledFileFsyncBeforeDirectoryFsync {
+                        return Err(ContinuationCryptoError::io(
+                            "simulated crash while reconciling ciphertext rename",
+                            std::io::Error::other("fault injection"),
+                        ));
+                    }
+                    sync_directory(&parent)?;
+                    return Ok(());
+                }
+                return Err(ContinuationCryptoError::DestinationExists(
+                    self.destination.display().to_string(),
+                ));
+            }
+            Err(error) => {
+                return Err(ContinuationCryptoError::io(
+                    "atomically publishing ciphertext",
+                    error.error,
+                ));
+            }
+        };
+        persisted
+            .sync_all()
+            .map_err(|error| ContinuationCryptoError::io("fsyncing published ciphertext", error))?;
+        if fault == PublishFault::AfterRenameBeforeDirectoryFsync {
+            return Err(ContinuationCryptoError::io(
+                "simulated crash after ciphertext rename",
+                std::io::Error::other("fault injection"),
+            ));
+        }
+        sync_directory(&parent)?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PublishFault {
+    None,
+    AfterTempFsync,
+    AfterRenameBeforeDirectoryFsync,
+    AfterReconciledFileFsyncBeforeDirectoryFsync,
+}
+
+fn open_verified_existing(
+    path: &std::path::Path,
+    expected_size: u64,
+    expected_sha256: &[u8; 32],
+) -> Result<Option<File>, ContinuationCryptoError> {
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        ContinuationCryptoError::io("inspecting existing ciphertext path", error)
+    })?;
+    if !metadata.is_file() || metadata.file_type().is_symlink() {
+        return Err(ContinuationCryptoError::InvalidStaging(
+            "existing ciphertext destination is not a regular file",
+        ));
+    }
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.custom_flags(libc::O_NOFOLLOW);
+    }
+    let mut file = options
+        .open(path)
+        .map_err(|error| ContinuationCryptoError::io("opening existing ciphertext", error))?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| ContinuationCryptoError::io("inspecting existing ciphertext", error))?;
+    if !metadata.is_file() || metadata.len() != expected_size {
+        return Ok(None);
+    }
+    let mut digest = Sha256::new();
+    let mut remaining = expected_size;
+    let mut buffer = [0u8; 64 * 1024];
+    while remaining > 0 {
+        let requested = remaining.min(buffer.len() as u64) as usize;
+        file.read_exact(&mut buffer[..requested])
+            .map_err(|error| ContinuationCryptoError::io("hashing existing ciphertext", error))?;
+        digest.update(&buffer[..requested]);
+        remaining -= requested as u64;
+    }
+    let mut trailing = [0u8; 1];
+    if file
+        .read(&mut trailing)
+        .map_err(|error| ContinuationCryptoError::io("checking existing ciphertext EOF", error))?
+        != 0
+    {
+        return Ok(None);
+    }
+    if digest.finalize().as_slice() != expected_sha256 {
+        return Ok(None);
+    }
+    Ok(Some(file))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+
+    #[test]
+    fn crash_faults_are_recoverable_and_reconcile_by_hash() {
+        let temp = tempfile::tempdir().unwrap();
+        let staging = PrivateStagingDirectory::create(temp.path()).unwrap();
+        let destination = temp.path().join("fault-checkpoint.age");
+        let bytes = b"ciphertext-only-test";
+        let digest: [u8; 32] = Sha256::digest(bytes).into();
+
+        let mut before_rename =
+            AtomicCiphertextFile::create(&staging, "fault-a", &destination).unwrap();
+        before_rename.file_mut().write_all(bytes).unwrap();
+        assert!(before_rename
+            .publish_impl(bytes.len() as u64, &digest, PublishFault::AfterTempFsync)
+            .is_err());
+        assert!(!destination.exists());
+
+        let mut after_rename =
+            AtomicCiphertextFile::create(&staging, "fault-b", &destination).unwrap();
+        after_rename.file_mut().write_all(bytes).unwrap();
+        assert!(after_rename
+            .publish_impl(
+                bytes.len() as u64,
+                &digest,
+                PublishFault::AfterRenameBeforeDirectoryFsync,
+            )
+            .is_err());
+        assert_eq!(std::fs::read(&destination).unwrap(), bytes);
+
+        let mut interrupted_retry =
+            AtomicCiphertextFile::create(&staging, "fault-c", &destination).unwrap();
+        interrupted_retry.file_mut().write_all(bytes).unwrap();
+        assert!(interrupted_retry
+            .publish_impl(
+                bytes.len() as u64,
+                &digest,
+                PublishFault::AfterReconciledFileFsyncBeforeDirectoryFsync,
+            )
+            .is_err());
+
+        let mut completed_retry =
+            AtomicCiphertextFile::create(&staging, "fault-d", &destination).unwrap();
+        completed_retry.file_mut().write_all(bytes).unwrap();
+        completed_retry
+            .publish(bytes.len() as u64, &digest)
+            .unwrap();
+        assert_eq!(std::fs::read(&destination).unwrap(), bytes);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn idempotent_reconcile_never_follows_an_existing_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().unwrap();
+        let staging = PrivateStagingDirectory::create(temp.path()).unwrap();
+        let outside = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(outside.path(), b"ciphertext-only-test").unwrap();
+        let destination = temp.path().join("symlink-checkpoint.age");
+        symlink(outside.path(), &destination).unwrap();
+        let bytes = b"ciphertext-only-test";
+        let digest: [u8; 32] = Sha256::digest(bytes).into();
+        let mut atomic =
+            AtomicCiphertextFile::create(&staging, "symlink-fault", &destination).unwrap();
+        atomic.file_mut().write_all(bytes).unwrap();
+        assert!(matches!(
+            atomic.publish(bytes.len() as u64, &digest),
+            Err(ContinuationCryptoError::InvalidStaging(
+                "existing ciphertext destination is not a regular file"
+            ))
+        ));
+        assert_eq!(std::fs::read(outside.path()).unwrap(), bytes);
+    }
+}

--- a/src-tauri/crates/continuation-crypto/src/envelope.rs
+++ b/src-tauri/crates/continuation-crypto/src/envelope.rs
@@ -1,0 +1,1307 @@
+use std::{
+    cell::Cell,
+    fs::File,
+    io::{BufReader, Read, Seek, SeekFrom, Write},
+    marker::PhantomData,
+    path::Path,
+    rc::Rc,
+};
+
+use age::{Decryptor, Encryptor};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use flate2::{read::MultiGzDecoder, write::GzEncoder, Compression};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+use zeroize::Zeroizing;
+
+use crate::{
+    atomic_file::AtomicCiphertextFile,
+    canonical_header_bytes,
+    framed_stream::{read_checkpoint_stream, CheckpointRecordWriter, CheckpointStreamWriter},
+    identity::{age_recipient_from_raw, verify_signature},
+    signature_message,
+    wire::{
+        decode_canonical_header, ENVELOPE_END_MAGIC, ENVELOPE_MAGIC, ENVELOPE_VERSION,
+        MAX_CANONICAL_HEADER_BYTES, MAX_CREATED_AT_FUTURE_SKEW_MS, PREFIX_BYTES, SIGNATURE_BYTES,
+        SUFFIX_BYTES,
+    },
+    CheckpointFooter, CheckpointLimits, CheckpointManifest, CheckpointSink, CloudRecipient,
+    CloudRecipientSet, CompressionAlgorithm, ContinuationCryptoError, ContinuationEnvelopeHeader,
+    DevicePrivateIdentity, DevicePublicIdentity, EncryptionAlgorithm, HashAlgorithm, LimitKind,
+    PrivateStagingDirectory, RecipientScope, SignatureAlgorithm, CLOUD_CHECKPOINT_LIMITS,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CloudEnvelopeMetadata {
+    org_id: Uuid,
+    checkpoint_id: Uuid,
+    root_session_id: String,
+    source_episode_id: String,
+    source_runtime: String,
+    target_runtime: String,
+    recipient_scope: RecipientScope,
+    sender_user_id: Uuid,
+    /// Client timestamp that is signed before upload and must be validated by
+    /// the cloud prepare RPC rather than replaced with server time.
+    created_at_unix_ms: u64,
+    expires_at_unix_ms: u64,
+}
+
+impl CloudEnvelopeMetadata {
+    #[allow(clippy::too_many_arguments)]
+    pub fn try_new(
+        org_id: Uuid,
+        checkpoint_id: Uuid,
+        root_session_id: String,
+        source_episode_id: String,
+        source_runtime: String,
+        target_runtime: String,
+        recipient_scope: RecipientScope,
+        sender_user_id: Uuid,
+        created_at_unix_ms: u64,
+        expires_at_unix_ms: u64,
+        validation_now_unix_ms: u64,
+    ) -> Result<Self, ContinuationCryptoError> {
+        let metadata = Self {
+            org_id,
+            checkpoint_id,
+            root_session_id,
+            source_episode_id,
+            source_runtime,
+            target_runtime,
+            recipient_scope,
+            sender_user_id,
+            created_at_unix_ms,
+            expires_at_unix_ms,
+        };
+        metadata.validate_fresh(validation_now_unix_ms)?;
+        Ok(metadata)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn try_from_sql(
+        org_id: &str,
+        checkpoint_id: &str,
+        root_session_id: String,
+        source_episode_id: String,
+        source_runtime: String,
+        target_runtime: String,
+        recipient_scope: &str,
+        sender_user_id: &str,
+        created_at_unix_ms: u64,
+        expires_at_unix_ms: u64,
+        validation_now_unix_ms: u64,
+    ) -> Result<Self, ContinuationCryptoError> {
+        Self::try_new(
+            parse_canonical_uuid(org_id)?,
+            parse_canonical_uuid(checkpoint_id)?,
+            root_session_id,
+            source_episode_id,
+            source_runtime,
+            target_runtime,
+            parse_recipient_scope(recipient_scope)?,
+            parse_canonical_uuid(sender_user_id)?,
+            created_at_unix_ms,
+            expires_at_unix_ms,
+            validation_now_unix_ms,
+        )
+    }
+
+    fn validate_fresh(&self, now_unix_ms: u64) -> Result<(), ContinuationCryptoError> {
+        let header = self.header_with_identities(
+            placeholder_identity(Uuid::from_u128(1)),
+            CloudRecipientSet::try_new(vec![CloudRecipient::try_new(
+                Uuid::from_u128(2),
+                placeholder_identity(Uuid::from_u128(3)),
+            )?])?,
+            [1; 32],
+            1,
+        );
+        header.validate()?;
+        if self.created_at_unix_ms.abs_diff(now_unix_ms) > MAX_CREATED_AT_FUTURE_SKEW_MS {
+            return Err(ContinuationCryptoError::InvalidEnvelope(
+                "client creation time exceeds five-minute freshness skew",
+            ));
+        }
+        if self.expires_at_unix_ms <= now_unix_ms {
+            return Err(ContinuationCryptoError::InvalidEnvelope(
+                "expiry must be in the future",
+            ));
+        }
+        Ok(())
+    }
+
+    fn header_with_identities(
+        &self,
+        sender: DevicePublicIdentity,
+        recipients: CloudRecipientSet,
+        age_ciphertext_sha256: [u8; 32],
+        age_ciphertext_len: u64,
+    ) -> ContinuationEnvelopeHeader {
+        ContinuationEnvelopeHeader {
+            encryption_algorithm: EncryptionAlgorithm::AgeX25519,
+            signature_algorithm: SignatureAlgorithm::Ed25519,
+            compression_algorithm: CompressionAlgorithm::Gzip,
+            hash_algorithm: HashAlgorithm::Sha256,
+            org_id: self.org_id,
+            checkpoint_id: self.checkpoint_id,
+            root_session_id: self.root_session_id.clone(),
+            source_episode_id: self.source_episode_id.clone(),
+            source_runtime: self.source_runtime.clone(),
+            target_runtime: self.target_runtime.clone(),
+            recipient_scope: self.recipient_scope,
+            sender_user_id: self.sender_user_id,
+            sender,
+            recipient_set_sha256: recipients.sha256(),
+            recipients,
+            age_ciphertext_sha256,
+            created_at_unix_ms: self.created_at_unix_ms,
+            expires_at_unix_ms: self.expires_at_unix_ms,
+            age_ciphertext_len,
+        }
+    }
+
+    pub fn org_id(&self) -> Uuid {
+        self.org_id
+    }
+    pub fn checkpoint_id(&self) -> Uuid {
+        self.checkpoint_id
+    }
+    pub fn root_session_id(&self) -> &str {
+        &self.root_session_id
+    }
+    pub fn source_episode_id(&self) -> &str {
+        &self.source_episode_id
+    }
+    pub fn source_runtime(&self) -> &str {
+        &self.source_runtime
+    }
+    pub fn target_runtime(&self) -> &str {
+        &self.target_runtime
+    }
+    pub fn recipient_scope(&self) -> RecipientScope {
+        self.recipient_scope
+    }
+    pub fn sender_user_id(&self) -> Uuid {
+        self.sender_user_id
+    }
+    pub fn created_at_unix_ms(&self) -> u64 {
+        self.created_at_unix_ms
+    }
+    pub fn expires_at_unix_ms(&self) -> u64 {
+        self.expires_at_unix_ms
+    }
+}
+
+struct EnvelopeWriteRequest<'a> {
+    pub metadata: CloudEnvelopeMetadata,
+    pub sender: &'a DevicePrivateIdentity,
+    pub recipients: CloudRecipientSet,
+    pub manifest: CheckpointManifest,
+    pub limits: CheckpointLimits,
+}
+
+#[cfg(test)]
+pub(crate) struct LocalEnvelopeWriteRequest<'a> {
+    pub metadata: CloudEnvelopeMetadata,
+    pub sender: &'a DevicePrivateIdentity,
+    pub recipients: CloudRecipientSet,
+    pub manifest: CheckpointManifest,
+    pub limits: CheckpointLimits,
+}
+
+/// Cloud upload request with no caller-controlled limit profile.
+///
+/// This separate type makes it impossible for Cloud code to pass the broader
+/// local-file defaults by mistake.
+pub struct CloudEnvelopeWriteRequest<'a> {
+    pub metadata: CloudEnvelopeMetadata,
+    pub sender: &'a DevicePrivateIdentity,
+    pub recipients: CloudRecipientSet,
+    pub manifest: CheckpointManifest,
+}
+
+/// All trusted Cloud snapshots required to decrypt one immutable object.
+///
+/// Grouping them prevents a call site from accidentally omitting the caller's
+/// receipt or confusing its current key with the committed sender snapshot.
+pub struct CloudCheckpointDecryptRequest<'a> {
+    pub expected: &'a CommittedCloudEnvelope,
+    pub receipt: &'a CommittedRecipientReceipt,
+    pub trusted_sender: &'a DevicePublicIdentity,
+    pub recipient: &'a DevicePrivateIdentity,
+    pub now_unix_ms: u64,
+}
+
+/// The two non-interchangeable digest domains needed by Cloud storage.
+///
+/// `header.age_ciphertext_*` covers only the standard age payload and is
+/// authenticated by `signature`. `object_*` covers the complete on-disk
+/// artifact (prefix, canonical header, age payload, signature, end marker)
+/// and is used for object-store path/integrity/quota checks.
+mod profile_sealed {
+    pub trait Sealed {}
+}
+
+pub trait EnvelopeProfile: profile_sealed::Sealed {}
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum LocalProfile {}
+#[cfg(test)]
+impl profile_sealed::Sealed for LocalProfile {}
+#[cfg(test)]
+impl EnvelopeProfile for LocalProfile {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+/// The only artifact profile exported by this crate.
+///
+/// Provider-neutral local continuation uses portable IR, not this transport:
+///
+/// ```compile_fail
+/// use continuation_crypto::{EnvelopeArtifact, LocalProfile};
+/// fn upload_local(_: EnvelopeArtifact<LocalProfile>) {}
+/// ```
+pub enum CloudProfile {}
+impl profile_sealed::Sealed for CloudProfile {}
+impl EnvelopeProfile for CloudProfile {}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EnvelopeArtifact<P: EnvelopeProfile> {
+    header: ContinuationEnvelopeHeader,
+    /// Exact opaque canonical header bytes sent to the Cloud prepare RPC.
+    canonical_header: Vec<u8>,
+    /// Exact Ed25519 bytes present in the file footer and sent to Cloud.
+    signature: [u8; 64],
+    object_size: u64,
+    object_sha256: [u8; 32],
+    profile: PhantomData<fn() -> P>,
+}
+
+impl<P: EnvelopeProfile> EnvelopeArtifact<P> {
+    pub fn header(&self) -> &ContinuationEnvelopeHeader {
+        &self.header
+    }
+    pub fn canonical_header(&self) -> &[u8] {
+        &self.canonical_header
+    }
+    pub fn signature(&self) -> &[u8; 64] {
+        &self.signature
+    }
+    pub fn object_size(&self) -> u64 {
+        self.object_size
+    }
+    pub fn object_sha256(&self) -> &[u8; 32] {
+        &self.object_sha256
+    }
+}
+
+impl EnvelopeArtifact<CloudProfile> {
+    /// Produce the immutable row descriptor accepted by Cloud upload code.
+    ///
+    /// The crate exports no provider-neutral/local artifact profile; generic
+    /// local continuation state belongs to the portable IR layer.
+    pub fn cloud_upload_descriptor(&self) -> CommittedCloudEnvelope {
+        CommittedCloudEnvelope::from_cloud_artifact(self)
+    }
+}
+
+/// Exact immutable SQL row snapshot needed before Cloud decryption.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CommittedCloudEnvelope {
+    pub(crate) header: ContinuationEnvelopeHeader,
+    pub(crate) canonical_header: Vec<u8>,
+    pub(crate) signature: [u8; 64],
+    pub(crate) object_size: u64,
+    pub(crate) object_sha256: [u8; 32],
+}
+
+/// SQL-facing committed row. Every textual encoding is revalidated as its
+/// unique canonical form before the object path is opened.
+pub struct CommittedCloudEnvelopeSql<'a> {
+    pub checkpoint_id: &'a str,
+    pub org_id: &'a str,
+    pub root_session_id: &'a str,
+    pub source_episode_id: &'a str,
+    pub client_created_at_unix_ms: u64,
+    pub sender_user_id: &'a str,
+    pub sender_device_id: &'a str,
+    pub sender_key_version: i32,
+    pub source_runtime: &'a str,
+    pub target_runtime: &'a str,
+    pub recipient_scope: &'a str,
+    pub recipient_count: i32,
+    pub recipient_set_sha256: &'a str,
+    pub object_size: i64,
+    pub object_sha256: &'a str,
+    pub age_ciphertext_len: i64,
+    pub age_ciphertext_sha256: &'a str,
+    pub footer_signature: &'a str,
+    pub expires_at_unix_ms: u64,
+    pub canonical_header: &'a [u8],
+    pub sender_encryption_public_key: &'a str,
+    pub sender_signing_public_key: &'a str,
+    pub sender_fingerprint: &'a str,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CommittedRecipientReceipt {
+    org_id: Uuid,
+    checkpoint_id: Uuid,
+    recipient: CloudRecipient,
+}
+
+pub struct CommittedRecipientReceiptSql<'a> {
+    pub org_id: &'a str,
+    pub checkpoint_id: &'a str,
+    pub recipient_user_id: &'a str,
+    pub recipient_device_id: &'a str,
+    pub recipient_key_version: i32,
+    pub recipient_encryption_public_key: &'a str,
+    pub recipient_signing_public_key: &'a str,
+    pub recipient_fingerprint: &'a str,
+}
+
+impl CommittedRecipientReceipt {
+    pub fn try_from_sql(
+        row: CommittedRecipientReceiptSql<'_>,
+    ) -> Result<Self, ContinuationCryptoError> {
+        let identity = DevicePublicIdentity::try_new(
+            parse_canonical_uuid(row.recipient_device_id)?,
+            positive_sql_key_version(row.recipient_key_version)?,
+            decode_base64url(
+                row.recipient_encryption_public_key,
+                "recipient X25519 public key",
+            )?,
+            decode_base64url(
+                row.recipient_signing_public_key,
+                "recipient Ed25519 public key",
+            )?,
+            decode_lower_hex(row.recipient_fingerprint, "recipient fingerprint")?,
+        )?;
+        let org_id = parse_canonical_uuid(row.org_id)?;
+        let checkpoint_id = parse_canonical_uuid(row.checkpoint_id)?;
+        if org_id.is_nil() || checkpoint_id.is_nil() {
+            return Err(ContinuationCryptoError::InvalidEnvelope(
+                "receipt routing UUIDs must be non-nil",
+            ));
+        }
+        Ok(Self {
+            org_id,
+            checkpoint_id,
+            recipient: CloudRecipient::try_new(
+                parse_canonical_uuid(row.recipient_user_id)?,
+                identity,
+            )?,
+        })
+    }
+
+    pub fn recipient(&self) -> &CloudRecipient {
+        &self.recipient
+    }
+
+    pub fn org_id(&self) -> Uuid {
+        self.org_id
+    }
+
+    pub fn checkpoint_id(&self) -> Uuid {
+        self.checkpoint_id
+    }
+}
+
+impl CommittedCloudEnvelope {
+    pub fn from_cloud_artifact(artifact: &EnvelopeArtifact<CloudProfile>) -> Self {
+        Self {
+            header: artifact.header.clone(),
+            canonical_header: artifact.canonical_header.clone(),
+            signature: artifact.signature,
+            object_size: artifact.object_size,
+            object_sha256: artifact.object_sha256,
+        }
+    }
+
+    pub fn header(&self) -> &ContinuationEnvelopeHeader {
+        &self.header
+    }
+    pub fn canonical_header(&self) -> &[u8] {
+        &self.canonical_header
+    }
+    pub fn signature(&self) -> &[u8; 64] {
+        &self.signature
+    }
+    pub fn object_size(&self) -> u64 {
+        self.object_size
+    }
+    pub fn object_sha256(&self) -> &[u8; 32] {
+        &self.object_sha256
+    }
+
+    pub fn try_from_sql(
+        row: CommittedCloudEnvelopeSql<'_>,
+        validation_now_unix_ms: u64,
+    ) -> Result<Self, ContinuationCryptoError> {
+        let object_size = positive_sql_i64(row.object_size, "object size")?;
+        if object_size > CLOUD_CHECKPOINT_LIMITS.max_envelope_bytes {
+            return Err(ContinuationCryptoError::limit(
+                LimitKind::EnvelopeBytes,
+                CLOUD_CHECKPOINT_LIMITS.max_envelope_bytes,
+                object_size,
+            ));
+        }
+        let age_ciphertext_len = positive_sql_i64(row.age_ciphertext_len, "age ciphertext length")?;
+        let object_sha256 = decode_lower_hex::<32>(row.object_sha256, "object SHA-256")?;
+        let age_ciphertext_sha256 =
+            decode_lower_hex::<32>(row.age_ciphertext_sha256, "age ciphertext SHA-256")?;
+        let signature = decode_base64url::<64>(row.footer_signature, "footer signature")?;
+        let sender = DevicePublicIdentity::try_new(
+            parse_canonical_uuid(row.sender_device_id)?,
+            positive_sql_key_version(row.sender_key_version)?,
+            decode_base64url(row.sender_encryption_public_key, "sender X25519 public key")?,
+            decode_base64url(row.sender_signing_public_key, "sender Ed25519 public key")?,
+            decode_lower_hex(row.sender_fingerprint, "sender fingerprint")?,
+        )?;
+        let recipient_count = u16::try_from(row.recipient_count)
+            .ok()
+            .filter(|value| (1..=64).contains(value))
+            .ok_or(ContinuationCryptoError::InvalidEnvelope(
+                "recipient count must be between one and 64",
+            ))?;
+        let recipient_set_sha256 =
+            decode_lower_hex::<32>(row.recipient_set_sha256, "recipient set SHA-256")?;
+        let header = decode_canonical_header(row.canonical_header)?;
+        if header.org_id != parse_canonical_uuid(row.org_id)?
+            || header.checkpoint_id != parse_canonical_uuid(row.checkpoint_id)?
+            || header.root_session_id != row.root_session_id
+            || header.source_episode_id != row.source_episode_id
+            || header.source_runtime != row.source_runtime
+            || header.target_runtime != row.target_runtime
+            || header.recipient_scope != parse_recipient_scope(row.recipient_scope)?
+            || header.sender_user_id != parse_canonical_uuid(row.sender_user_id)?
+            || header.created_at_unix_ms != row.client_created_at_unix_ms
+            || header.expires_at_unix_ms != row.expires_at_unix_ms
+            || header.sender != sender
+            || header.recipients.as_slice().len() != recipient_count as usize
+            || header.recipient_set_sha256 != recipient_set_sha256
+            || header.age_ciphertext_len != age_ciphertext_len
+            || header.age_ciphertext_sha256 != age_ciphertext_sha256
+        {
+            return Err(ContinuationCryptoError::CloudMetadataMismatch(
+                "committed SQL fields",
+            ));
+        }
+        if header.created_at_unix_ms
+            > validation_now_unix_ms.saturating_add(MAX_CREATED_AT_FUTURE_SKEW_MS)
+            || header.expires_at_unix_ms <= validation_now_unix_ms
+        {
+            return Err(ContinuationCryptoError::CloudMetadataMismatch(
+                "committed SQL timestamps",
+            ));
+        }
+        let expected_object_size = (PREFIX_BYTES as u64)
+            .checked_add(row.canonical_header.len() as u64)
+            .and_then(|value| value.checked_add(age_ciphertext_len))
+            .and_then(|value| value.checked_add(SUFFIX_BYTES as u64))
+            .ok_or(ContinuationCryptoError::InvalidEnvelope(
+                "committed object size overflow",
+            ))?;
+        if object_size != expected_object_size {
+            return Err(ContinuationCryptoError::CloudMetadataMismatch(
+                "object and age lengths",
+            ));
+        }
+        Ok(Self {
+            header,
+            canonical_header: row.canonical_header.to_vec(),
+            signature,
+            object_size,
+            object_sha256,
+        })
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedEnvelope<P: EnvelopeProfile> {
+    artifact: EnvelopeArtifact<P>,
+    pub manifest: CheckpointManifest,
+    pub footer: CheckpointFooter,
+}
+
+impl<P: EnvelopeProfile> VerifiedEnvelope<P> {
+    pub fn artifact(&self) -> &EnvelopeArtifact<P> {
+        &self.artifact
+    }
+}
+
+fn parse_canonical_uuid(value: &str) -> Result<Uuid, ContinuationCryptoError> {
+    let parsed = Uuid::parse_str(value)
+        .map_err(|_| ContinuationCryptoError::InvalidEnvelope("invalid canonical UUID"))?;
+    if parsed.to_string() != value {
+        return Err(ContinuationCryptoError::InvalidEnvelope(
+            "UUID must be lowercase canonical hyphenated text",
+        ));
+    }
+    Ok(parsed)
+}
+
+fn positive_sql_i64(value: i64, label: &'static str) -> Result<u64, ContinuationCryptoError> {
+    u64::try_from(value)
+        .ok()
+        .filter(|value| *value > 0)
+        .ok_or(ContinuationCryptoError::InvalidEnvelope(label))
+}
+
+fn positive_sql_key_version(value: i32) -> Result<u32, ContinuationCryptoError> {
+    u32::try_from(value).ok().filter(|value| *value > 0).ok_or(
+        ContinuationCryptoError::InvalidIdentity("key version must be in positive SQL int range"),
+    )
+}
+
+fn parse_recipient_scope(value: &str) -> Result<RecipientScope, ContinuationCryptoError> {
+    match value {
+        "audience" => Ok(RecipientScope::Audience),
+        "subset" => Ok(RecipientScope::Subset),
+        _ => Err(ContinuationCryptoError::InvalidEnvelope(
+            "recipient scope must be audience or subset",
+        )),
+    }
+}
+
+fn decode_lower_hex<const N: usize>(
+    value: &str,
+    label: &'static str,
+) -> Result<[u8; N], ContinuationCryptoError> {
+    if value.len() != N * 2
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(ContinuationCryptoError::InvalidEnvelope(label));
+    }
+    hex::decode(value)
+        .map_err(|_| ContinuationCryptoError::InvalidEnvelope(label))?
+        .try_into()
+        .map_err(|_| ContinuationCryptoError::InvalidEnvelope(label))
+}
+
+fn decode_base64url<const N: usize>(
+    value: &str,
+    label: &'static str,
+) -> Result<[u8; N], ContinuationCryptoError> {
+    let decoded = Zeroizing::new(
+        URL_SAFE_NO_PAD
+            .decode(value)
+            .map_err(|_| ContinuationCryptoError::InvalidEnvelope(label))?,
+    );
+    if URL_SAFE_NO_PAD.encode(decoded.as_slice()) != value {
+        return Err(ContinuationCryptoError::InvalidEnvelope(label));
+    }
+    decoded
+        .as_slice()
+        .try_into()
+        .map_err(|_| ContinuationCryptoError::InvalidEnvelope(label))
+}
+
+fn placeholder_identity(device_id: Uuid) -> DevicePublicIdentity {
+    // Only used to reuse the canonical header validator for route metadata.
+    // These fixed keys are valid X25519/Ed25519 public encodings.
+    let encryption = [1u8; 32];
+    let signing = ed25519_dalek::SigningKey::from_bytes(&[1u8; 32])
+        .verifying_key()
+        .to_bytes();
+    DevicePublicIdentity::try_new(
+        device_id,
+        1,
+        encryption,
+        signing,
+        crate::device_fingerprint(&encryption, &signing),
+    )
+    .expect("fixed placeholder identity is valid")
+}
+
+/// Write a checkpoint without ever materializing plaintext on disk.
+///
+/// The sibling staging file is owner-only from creation, contains only the
+/// public envelope prefix plus age ciphertext, is fsynced, and is atomically
+/// published without clobbering an existing checkpoint object.
+#[cfg(test)]
+pub(crate) fn write_local_checkpoint_atomic<F>(
+    destination: &Path,
+    staging: &PrivateStagingDirectory,
+    job_id: &str,
+    request: LocalEnvelopeWriteRequest<'_>,
+    write_records: F,
+) -> Result<EnvelopeArtifact<LocalProfile>, ContinuationCryptoError>
+where
+    F: FnOnce(&mut dyn CheckpointRecordWriter) -> Result<(), ContinuationCryptoError>,
+{
+    write_checkpoint_atomic_impl::<LocalProfile, _>(
+        destination,
+        staging,
+        job_id,
+        EnvelopeWriteRequest {
+            metadata: request.metadata,
+            sender: request.sender,
+            recipients: request.recipients,
+            manifest: request.manifest,
+            limits: request.limits,
+        },
+        write_records,
+    )
+}
+
+/// Cloud-safe writer with a non-overridable 16 MiB complete-object ceiling.
+///
+/// The explicitly local writer is for offline artifacts. Code that uploads an
+/// artifact must call this entry point so the 512 MiB local defaults cannot
+/// leak into the Cloud object plane.
+pub fn write_cloud_checkpoint_atomic<F>(
+    destination: &Path,
+    staging: &PrivateStagingDirectory,
+    job_id: &str,
+    request: CloudEnvelopeWriteRequest<'_>,
+    write_records: F,
+) -> Result<EnvelopeArtifact<CloudProfile>, ContinuationCryptoError>
+where
+    F: FnOnce(&mut dyn CheckpointRecordWriter) -> Result<(), ContinuationCryptoError>,
+{
+    write_checkpoint_atomic_impl::<CloudProfile, _>(
+        destination,
+        staging,
+        job_id,
+        EnvelopeWriteRequest {
+            metadata: request.metadata,
+            sender: request.sender,
+            recipients: request.recipients,
+            manifest: request.manifest,
+            limits: CLOUD_CHECKPOINT_LIMITS,
+        },
+        write_records,
+    )
+}
+
+fn write_checkpoint_atomic_impl<P, F>(
+    destination: &Path,
+    staging: &PrivateStagingDirectory,
+    job_id: &str,
+    request: EnvelopeWriteRequest<'_>,
+    write_records: F,
+) -> Result<EnvelopeArtifact<P>, ContinuationCryptoError>
+where
+    P: EnvelopeProfile,
+    F: FnOnce(&mut dyn CheckpointRecordWriter) -> Result<(), ContinuationCryptoError>,
+{
+    let sender = request.sender.public_identity()?;
+    let mut header = request.metadata.header_with_identities(
+        sender,
+        request.recipients.clone(),
+        [0; 32],
+        // A positive fixed-width placeholder keeps header validation and
+        // canonical byte length stable until age finishes streaming.
+        1,
+    );
+    let placeholder_header = canonical_header_bytes(&header)?;
+    let header_len = u32::try_from(placeholder_header.len())
+        .map_err(|_| ContinuationCryptoError::InvalidEnvelope("header length overflow"))?;
+    let fixed_object_bytes = (PREFIX_BYTES as u64)
+        .checked_add(placeholder_header.len() as u64)
+        .and_then(|value| value.checked_add(SUFFIX_BYTES as u64))
+        .ok_or(ContinuationCryptoError::InvalidEnvelope(
+            "envelope length overflow",
+        ))?;
+    let minimum_object_bytes =
+        fixed_object_bytes
+            .checked_add(1)
+            .ok_or(ContinuationCryptoError::InvalidEnvelope(
+                "envelope length overflow",
+            ))?;
+    if minimum_object_bytes > request.limits.max_envelope_bytes {
+        return Err(ContinuationCryptoError::limit(
+            LimitKind::EnvelopeBytes,
+            request.limits.max_envelope_bytes,
+            minimum_object_bytes,
+        ));
+    }
+    let max_ciphertext_for_object = request.limits.max_envelope_bytes - fixed_object_bytes;
+    let ciphertext_write_limit = request
+        .limits
+        .max_ciphertext_bytes
+        .min(max_ciphertext_for_object);
+    let ciphertext_limit_kind = if max_ciphertext_for_object <= request.limits.max_ciphertext_bytes
+    {
+        LimitKind::EnvelopeBytes
+    } else {
+        LimitKind::CiphertextBytes
+    };
+    let ciphertext_limit_hit = Rc::new(Cell::new(false));
+    let mut atomic = AtomicCiphertextFile::create(staging, job_id, destination)?;
+
+    let encryption_result: Result<(u64, [u8; 32]), ContinuationCryptoError> = (|| {
+        let file = atomic.file_mut();
+        file.write_all(ENVELOPE_MAGIC)
+            .map_err(|error| ContinuationCryptoError::io("writing envelope magic", error))?;
+        file.write_all(&ENVELOPE_VERSION.to_be_bytes())
+            .map_err(|error| ContinuationCryptoError::io("writing envelope version", error))?;
+        file.write_all(&header_len.to_be_bytes()).map_err(|error| {
+            ContinuationCryptoError::io("writing envelope header length", error)
+        })?;
+        file.write_all(&placeholder_header)
+            .map_err(|error| ContinuationCryptoError::io("writing envelope header", error))?;
+
+        let age_recipients = request
+            .recipients
+            .as_slice()
+            .iter()
+            .map(|recipient| age_recipient_from_raw(&recipient.identity().encryption_public_key))
+            .collect::<Result<Vec<_>, _>>()?;
+        let encryptor = Encryptor::with_recipients(
+            age_recipients
+                .iter()
+                .map(|recipient| recipient as &dyn age::Recipient),
+        )
+        .map_err(|error| ContinuationCryptoError::AgeEncrypt(error.to_string()))?;
+        let ciphertext_writer = HashingWriter::new(
+            file,
+            ciphertext_write_limit,
+            Rc::clone(&ciphertext_limit_hit),
+        );
+        let age_writer = encryptor
+            .wrap_output(ciphertext_writer)
+            .map_err(|error| ContinuationCryptoError::AgeEncrypt(error.to_string()))?;
+        let gzip_writer = GzEncoder::new(age_writer, Compression::new(6));
+        let mut frame_writer =
+            CheckpointStreamWriter::new(gzip_writer, request.manifest, request.limits)?;
+        write_records(&mut frame_writer)?;
+        let gzip_writer = frame_writer.finish()?;
+        let age_writer = gzip_writer
+            .finish()
+            .map_err(|error| ContinuationCryptoError::InvalidCompression(error.to_string()))?;
+        let ciphertext_writer = age_writer
+            .finish()
+            .map_err(|error| ContinuationCryptoError::AgeEncrypt(error.to_string()))?;
+        let (_file, ciphertext_len, ciphertext_sha256) = ciphertext_writer.finish();
+        Ok((ciphertext_len, ciphertext_sha256))
+    })();
+    if ciphertext_limit_hit.get() {
+        let (limit, actual) = if ciphertext_limit_kind == LimitKind::EnvelopeBytes {
+            (
+                request.limits.max_envelope_bytes,
+                request.limits.max_envelope_bytes.saturating_add(1),
+            )
+        } else {
+            (
+                request.limits.max_ciphertext_bytes,
+                request.limits.max_ciphertext_bytes.saturating_add(1),
+            )
+        };
+        return Err(ContinuationCryptoError::limit(
+            ciphertext_limit_kind,
+            limit,
+            actual,
+        ));
+    }
+    let (age_ciphertext_len, age_ciphertext_sha256) = encryption_result?;
+
+    if age_ciphertext_len > request.limits.max_ciphertext_bytes {
+        return Err(ContinuationCryptoError::limit(
+            LimitKind::CiphertextBytes,
+            request.limits.max_ciphertext_bytes,
+            age_ciphertext_len,
+        ));
+    }
+    header.age_ciphertext_len = age_ciphertext_len;
+    header.age_ciphertext_sha256 = age_ciphertext_sha256;
+    let raw_header = canonical_header_bytes(&header)?;
+    if raw_header.len() != placeholder_header.len() {
+        return Err(ContinuationCryptoError::InvalidEnvelope(
+            "patched header changed canonical length",
+        ));
+    }
+    let signature = request
+        .sender
+        .sign(&signature_message(&raw_header, &age_ciphertext_sha256)?);
+    let expected_object_size = (PREFIX_BYTES as u64)
+        .checked_add(raw_header.len() as u64)
+        .and_then(|value| value.checked_add(age_ciphertext_len))
+        .and_then(|value| value.checked_add(SUFFIX_BYTES as u64))
+        .ok_or(ContinuationCryptoError::InvalidEnvelope(
+            "envelope length overflow",
+        ))?;
+    if expected_object_size > request.limits.max_envelope_bytes {
+        return Err(ContinuationCryptoError::limit(
+            LimitKind::EnvelopeBytes,
+            request.limits.max_envelope_bytes,
+            expected_object_size,
+        ));
+    }
+    {
+        let file = atomic.file_mut();
+        file.seek(SeekFrom::Start(PREFIX_BYTES as u64))
+            .map_err(|error| ContinuationCryptoError::io("seeking to envelope header", error))?;
+        file.write_all(&raw_header)
+            .map_err(|error| ContinuationCryptoError::io("patching envelope header", error))?;
+        let suffix_offset = (PREFIX_BYTES as u64)
+            .checked_add(raw_header.len() as u64)
+            .and_then(|value| value.checked_add(age_ciphertext_len))
+            .ok_or(ContinuationCryptoError::InvalidEnvelope(
+                "envelope length overflow",
+            ))?;
+        file.seek(SeekFrom::Start(suffix_offset))
+            .map_err(|error| ContinuationCryptoError::io("seeking to envelope signature", error))?;
+        file.write_all(&signature)
+            .map_err(|error| ContinuationCryptoError::io("writing envelope signature", error))?;
+        file.write_all(ENVELOPE_END_MAGIC)
+            .map_err(|error| ContinuationCryptoError::io("writing envelope footer magic", error))?;
+    }
+    let (object_size, object_sha256) = hash_complete_object(atomic.file_mut())?;
+    if object_size != expected_object_size {
+        return Err(ContinuationCryptoError::InvalidEnvelope(
+            "written envelope size does not match its canonical layout",
+        ));
+    }
+    atomic.publish(object_size, &object_sha256)?;
+    Ok(EnvelopeArtifact {
+        header,
+        canonical_header: raw_header,
+        signature,
+        object_size,
+        object_sha256,
+        profile: PhantomData,
+    })
+}
+
+/// Verify the public envelope before invoking age, then decrypt and parse its
+/// bounded inner stream into the supplied sink.
+#[cfg(test)]
+pub(crate) fn decrypt_local_checkpoint(
+    source: &Path,
+    staging: &PrivateStagingDirectory,
+    trusted_sender: &DevicePublicIdentity,
+    recipient: &DevicePrivateIdentity,
+    now_unix_ms: u64,
+    limits: CheckpointLimits,
+    sink: &mut dyn CheckpointSink,
+) -> Result<VerifiedEnvelope<LocalProfile>, ContinuationCryptoError> {
+    let context = DecryptContext {
+        expected: None,
+        receipt: None,
+        trusted_sender,
+        recipient,
+        now_unix_ms,
+        limits,
+    };
+    decrypt_checkpoint_impl::<LocalProfile, _>(source, staging, &context, sink, || {})
+}
+
+/// Verify and decrypt an object obtained from ORG2 Cloud.
+///
+/// Unlike the local entry point, this always applies the 16 MiB full-object
+/// preset and requires the committed row's full-object digest, exact opaque
+/// header, and exact footer/RPC signature to match before decryption.
+pub fn decrypt_cloud_checkpoint(
+    source: &Path,
+    staging: &PrivateStagingDirectory,
+    request: CloudCheckpointDecryptRequest<'_>,
+    sink: &mut dyn CheckpointSink,
+) -> Result<VerifiedEnvelope<CloudProfile>, ContinuationCryptoError> {
+    let context = DecryptContext {
+        expected: Some(request.expected),
+        receipt: Some(request.receipt),
+        trusted_sender: request.trusted_sender,
+        recipient: request.recipient,
+        now_unix_ms: request.now_unix_ms,
+        limits: CLOUD_CHECKPOINT_LIMITS,
+    };
+    decrypt_checkpoint_impl::<CloudProfile, _>(source, staging, &context, sink, || {})
+}
+
+#[derive(Clone, Copy)]
+struct DecryptContext<'a> {
+    expected: Option<&'a CommittedCloudEnvelope>,
+    receipt: Option<&'a CommittedRecipientReceipt>,
+    trusted_sender: &'a DevicePublicIdentity,
+    recipient: &'a DevicePrivateIdentity,
+    now_unix_ms: u64,
+    limits: CheckpointLimits,
+}
+
+fn decrypt_checkpoint_impl<P, H>(
+    source: &Path,
+    staging: &PrivateStagingDirectory,
+    context: &DecryptContext<'_>,
+    sink: &mut dyn CheckpointSink,
+    after_verified_snapshot: H,
+) -> Result<VerifiedEnvelope<P>, ContinuationCryptoError>
+where
+    P: EnvelopeProfile,
+    H: FnOnce(),
+{
+    let mut verified = verify_outer_envelope::<P>(source, staging, context)?;
+    after_verified_snapshot();
+    verified
+        .snapshot
+        .seek(SeekFrom::Start(verified.ciphertext_offset))
+        .map_err(|error| ContinuationCryptoError::io("seeking to age ciphertext", error))?;
+    let ciphertext = (&mut verified.snapshot).take(verified.artifact.header.age_ciphertext_len);
+    let decryptor = Decryptor::new(BufReader::new(ciphertext))
+        .map_err(|error| ContinuationCryptoError::AgeDecrypt(error.to_string()))?;
+    let age_identity = context.recipient.age_identity()?;
+    let decrypted = decryptor
+        .decrypt(std::iter::once(&age_identity as &dyn age::Identity))
+        .map_err(|error| ContinuationCryptoError::AgeDecrypt(error.to_string()))?;
+    // MultiGzDecoder consumes all members and rejects trailing non-gzip bytes;
+    // the framed reader independently caps every frame and total output.
+    let gzip = MultiGzDecoder::new(decrypted);
+    sink.begin_transaction()?;
+    match read_checkpoint_stream(gzip, context.limits, sink) {
+        Ok((manifest, footer)) => {
+            if let Err(error) = sink.commit_transaction() {
+                sink.abort_transaction();
+                return Err(error);
+            }
+            Ok(VerifiedEnvelope {
+                artifact: verified.artifact,
+                manifest,
+                footer,
+            })
+        }
+        Err(error) => {
+            sink.abort_transaction();
+            Err(error)
+        }
+    }
+}
+
+struct VerifiedOuter<P: EnvelopeProfile> {
+    artifact: EnvelopeArtifact<P>,
+    ciphertext_offset: u64,
+    snapshot: File,
+}
+
+fn verify_outer_envelope<P: EnvelopeProfile>(
+    source: &Path,
+    staging: &PrivateStagingDirectory,
+    context: &DecryptContext<'_>,
+) -> Result<VerifiedOuter<P>, ContinuationCryptoError> {
+    let DecryptContext {
+        expected,
+        receipt,
+        trusted_sender,
+        recipient,
+        now_unix_ms,
+        limits,
+    } = *context;
+    trusted_sender.validate()?;
+    let (mut snapshot, object_size, object_sha256) =
+        copy_source_to_snapshot(source, staging, limits.max_envelope_bytes)?;
+    if expected.is_some_and(|value| object_size != value.object_size) {
+        return Err(ContinuationCryptoError::ObjectHashMismatch);
+    }
+    if expected.is_some_and(|value| object_sha256 != value.object_sha256) {
+        return Err(ContinuationCryptoError::ObjectHashMismatch);
+    }
+    let mut prefix = [0u8; PREFIX_BYTES];
+    snapshot
+        .read_exact(&mut prefix)
+        .map_err(|error| ContinuationCryptoError::io("reading envelope prefix", error))?;
+    if &prefix[..ENVELOPE_MAGIC.len()] != ENVELOPE_MAGIC {
+        return Err(ContinuationCryptoError::InvalidEnvelope(
+            "bad envelope magic",
+        ));
+    }
+    let version = u16::from_be_bytes(
+        prefix[ENVELOPE_MAGIC.len()..ENVELOPE_MAGIC.len() + 2]
+            .try_into()
+            .map_err(|_| ContinuationCryptoError::InvalidEnvelope("truncated version"))?,
+    );
+    if version != ENVELOPE_VERSION {
+        return Err(ContinuationCryptoError::UnsupportedEnvelopeVersion(version));
+    }
+    let header_len = u32::from_be_bytes(
+        prefix[ENVELOPE_MAGIC.len() + 2..PREFIX_BYTES]
+            .try_into()
+            .map_err(|_| ContinuationCryptoError::InvalidEnvelope("truncated header length"))?,
+    ) as usize;
+    if header_len == 0 || header_len > MAX_CANONICAL_HEADER_BYTES {
+        return Err(ContinuationCryptoError::limit(
+            LimitKind::HeaderBytes,
+            MAX_CANONICAL_HEADER_BYTES as u64,
+            header_len as u64,
+        ));
+    }
+    let mut raw_header = vec![0u8; header_len];
+    snapshot
+        .read_exact(&mut raw_header)
+        .map_err(|error| ContinuationCryptoError::io("reading canonical header", error))?;
+    let header = decode_canonical_header(&raw_header)?;
+    if expected.is_some_and(|value| value.canonical_header.as_slice() != raw_header) {
+        return Err(ContinuationCryptoError::CloudMetadataMismatch(
+            "canonical header",
+        ));
+    }
+    if header.sender != *trusted_sender {
+        return Err(ContinuationCryptoError::UntrustedSender);
+    }
+    if expected.is_some_and(|value| value.header != header) {
+        return Err(ContinuationCryptoError::CloudMetadataMismatch(
+            "signed routing or key snapshot fields",
+        ));
+    }
+    if header.age_ciphertext_len > limits.max_ciphertext_bytes {
+        return Err(ContinuationCryptoError::limit(
+            LimitKind::CiphertextBytes,
+            limits.max_ciphertext_bytes,
+            header.age_ciphertext_len,
+        ));
+    }
+    let expected_len = (PREFIX_BYTES as u64)
+        .checked_add(header_len as u64)
+        .and_then(|value| value.checked_add(header.age_ciphertext_len))
+        .and_then(|value| value.checked_add(SUFFIX_BYTES as u64))
+        .ok_or(ContinuationCryptoError::InvalidEnvelope(
+            "envelope length overflow",
+        ))?;
+    if object_size != expected_len {
+        return Err(ContinuationCryptoError::InvalidEnvelope(
+            "envelope file length does not match header",
+        ));
+    }
+    let ciphertext_offset = (PREFIX_BYTES + header_len) as u64;
+    let mut remaining = header.age_ciphertext_len;
+    let mut age_ciphertext_digest = Sha256::new();
+    let mut buffer = [0u8; 64 * 1024];
+    while remaining > 0 {
+        let requested = usize::try_from(remaining.min(buffer.len() as u64))
+            .map_err(|_| ContinuationCryptoError::InvalidEnvelope("read size overflow"))?;
+        snapshot
+            .read_exact(&mut buffer[..requested])
+            .map_err(|error| ContinuationCryptoError::io("hashing age ciphertext", error))?;
+        let chunk = &buffer[..requested];
+        age_ciphertext_digest.update(chunk);
+        remaining -= requested as u64;
+    }
+    let age_ciphertext_sha256: [u8; 32] = age_ciphertext_digest.finalize().into();
+    if age_ciphertext_sha256 != header.age_ciphertext_sha256 {
+        return Err(ContinuationCryptoError::CiphertextHashMismatch);
+    }
+    let mut signature = [0u8; SIGNATURE_BYTES];
+    snapshot
+        .read_exact(&mut signature)
+        .map_err(|error| ContinuationCryptoError::io("reading envelope signature", error))?;
+    if expected.is_some_and(|value| value.signature != signature) {
+        return Err(ContinuationCryptoError::CloudMetadataMismatch("signature"));
+    }
+    let mut end_magic = [0u8; 8];
+    snapshot
+        .read_exact(&mut end_magic)
+        .map_err(|error| ContinuationCryptoError::io("reading envelope end marker", error))?;
+    if &end_magic != ENVELOPE_END_MAGIC {
+        return Err(ContinuationCryptoError::InvalidEnvelope(
+            "bad envelope end marker",
+        ));
+    }
+    verify_signature(
+        trusted_sender,
+        &signature_message(&raw_header, &age_ciphertext_sha256)?,
+        &signature,
+    )?;
+    let own_public = recipient.public_identity()?;
+    if let Some(receipt) = receipt {
+        if receipt.org_id != header.org_id || receipt.checkpoint_id != header.checkpoint_id {
+            return Err(ContinuationCryptoError::CloudMetadataMismatch(
+                "recipient receipt routing",
+            ));
+        }
+        if !header
+            .recipients
+            .as_slice()
+            .iter()
+            .any(|entry| entry == &receipt.recipient)
+        {
+            return Err(ContinuationCryptoError::CloudMetadataMismatch(
+                "recipient receipt snapshot",
+            ));
+        }
+        recipient.verify_own_public(receipt.recipient.identity())?;
+    } else if !header
+        .recipients
+        .as_slice()
+        .iter()
+        .any(|entry| entry.identity() == &own_public)
+    {
+        return Err(ContinuationCryptoError::WrongRecipient);
+    }
+    if header.created_at_unix_ms > now_unix_ms.saturating_add(MAX_CREATED_AT_FUTURE_SKEW_MS) {
+        return Err(ContinuationCryptoError::CreatedInFuture);
+    }
+    if header.expires_at_unix_ms <= now_unix_ms {
+        return Err(ContinuationCryptoError::Expired(header.expires_at_unix_ms));
+    }
+    Ok(VerifiedOuter {
+        artifact: EnvelopeArtifact {
+            header,
+            canonical_header: raw_header,
+            signature,
+            object_size,
+            object_sha256,
+            profile: PhantomData,
+        },
+        ciphertext_offset,
+        snapshot,
+    })
+}
+
+fn copy_source_to_snapshot(
+    source: &Path,
+    staging: &PrivateStagingDirectory,
+    max_bytes: u64,
+) -> Result<(File, u64, [u8; 32]), ContinuationCryptoError> {
+    let mut source_file = File::open(source)
+        .map_err(|error| ContinuationCryptoError::io("opening continuation envelope", error))?;
+    let mut snapshot = staging.anonymous_ciphertext()?;
+    let mut digest = Sha256::new();
+    let mut object_size = 0u64;
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let read = source_file
+            .read(&mut buffer)
+            .map_err(|error| ContinuationCryptoError::io("snapshotting ciphertext", error))?;
+        if read == 0 {
+            break;
+        }
+        let next = object_size.checked_add(read as u64).ok_or(
+            ContinuationCryptoError::InvalidEnvelope("snapshot length overflow"),
+        )?;
+        if next > max_bytes {
+            return Err(ContinuationCryptoError::limit(
+                LimitKind::EnvelopeBytes,
+                max_bytes,
+                next,
+            ));
+        }
+        let chunk = &buffer[..read];
+        snapshot
+            .write_all(chunk)
+            .map_err(|error| ContinuationCryptoError::io("writing ciphertext snapshot", error))?;
+        digest.update(chunk);
+        object_size = next;
+    }
+    snapshot
+        .flush()
+        .map_err(|error| ContinuationCryptoError::io("flushing ciphertext snapshot", error))?;
+    snapshot
+        .seek(SeekFrom::Start(0))
+        .map_err(|error| ContinuationCryptoError::io("rewinding ciphertext snapshot", error))?;
+    Ok((snapshot, object_size, digest.finalize().into()))
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn decrypt_local_checkpoint_with_hook<H>(
+    source: &Path,
+    staging: &PrivateStagingDirectory,
+    trusted_sender: &DevicePublicIdentity,
+    recipient: &DevicePrivateIdentity,
+    now_unix_ms: u64,
+    limits: CheckpointLimits,
+    sink: &mut dyn CheckpointSink,
+    after_verified_snapshot: H,
+) -> Result<VerifiedEnvelope<LocalProfile>, ContinuationCryptoError>
+where
+    H: FnOnce(),
+{
+    let context = DecryptContext {
+        expected: None,
+        receipt: None,
+        trusted_sender,
+        recipient,
+        now_unix_ms,
+        limits,
+    };
+    decrypt_checkpoint_impl::<LocalProfile, _>(
+        source,
+        staging,
+        &context,
+        sink,
+        after_verified_snapshot,
+    )
+}
+
+struct HashingWriter<W> {
+    inner: W,
+    digest: Sha256,
+    bytes_written: u64,
+    max_bytes: u64,
+    limit_hit: Rc<Cell<bool>>,
+}
+
+fn hash_complete_object(file: &mut File) -> Result<(u64, [u8; 32]), ContinuationCryptoError> {
+    file.flush()
+        .map_err(|error| ContinuationCryptoError::io("flushing envelope before hashing", error))?;
+    file.seek(SeekFrom::Start(0))
+        .map_err(|error| ContinuationCryptoError::io("rewinding envelope for hashing", error))?;
+    let mut digest = Sha256::new();
+    let mut size = 0u64;
+    let mut buffer = [0u8; 64 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|error| ContinuationCryptoError::io("hashing complete envelope", error))?;
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+        size = size
+            .checked_add(read as u64)
+            .ok_or(ContinuationCryptoError::InvalidEnvelope(
+                "full object length overflow",
+            ))?;
+    }
+    Ok((size, digest.finalize().into()))
+}
+
+impl<W> HashingWriter<W> {
+    fn new(inner: W, max_bytes: u64, limit_hit: Rc<Cell<bool>>) -> Self {
+        Self {
+            inner,
+            digest: Sha256::new(),
+            bytes_written: 0,
+            max_bytes,
+            limit_hit,
+        }
+    }
+
+    fn finish(self) -> (W, u64, [u8; 32]) {
+        (
+            self.inner,
+            self.bytes_written,
+            self.digest.finalize().into(),
+        )
+    }
+}
+
+impl<W: Write> Write for HashingWriter<W> {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        let requested_end = self
+            .bytes_written
+            .checked_add(bytes.len() as u64)
+            .ok_or_else(|| std::io::Error::other("ciphertext length overflow"))?;
+        if requested_end > self.max_bytes {
+            self.limit_hit.set(true);
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::FileTooLarge,
+                "ciphertext byte limit exceeded",
+            ));
+        }
+        let written = self.inner.write(bytes)?;
+        self.digest.update(&bytes[..written]);
+        self.bytes_written = self
+            .bytes_written
+            .checked_add(written as u64)
+            .ok_or_else(|| std::io::Error::other("ciphertext length overflow"))?;
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}

--- a/src-tauri/crates/continuation-crypto/src/envelope.rs
+++ b/src-tauri/crates/continuation-crypto/src/envelope.rs
@@ -38,7 +38,8 @@ pub struct CloudEnvelopeMetadata {
     root_session_id: String,
     source_episode_id: String,
     source_runtime: String,
-    target_runtime: String,
+    payload_schema: String,
+    payload_schema_version: u16,
     recipient_scope: RecipientScope,
     sender_user_id: Uuid,
     /// Client timestamp that is signed before upload and must be validated by
@@ -55,7 +56,8 @@ impl CloudEnvelopeMetadata {
         root_session_id: String,
         source_episode_id: String,
         source_runtime: String,
-        target_runtime: String,
+        payload_schema: String,
+        payload_schema_version: u16,
         recipient_scope: RecipientScope,
         sender_user_id: Uuid,
         created_at_unix_ms: u64,
@@ -68,7 +70,8 @@ impl CloudEnvelopeMetadata {
             root_session_id,
             source_episode_id,
             source_runtime,
-            target_runtime,
+            payload_schema,
+            payload_schema_version,
             recipient_scope,
             sender_user_id,
             created_at_unix_ms,
@@ -85,7 +88,8 @@ impl CloudEnvelopeMetadata {
         root_session_id: String,
         source_episode_id: String,
         source_runtime: String,
-        target_runtime: String,
+        payload_schema: String,
+        payload_schema_version: u16,
         recipient_scope: &str,
         sender_user_id: &str,
         created_at_unix_ms: u64,
@@ -98,7 +102,8 @@ impl CloudEnvelopeMetadata {
             root_session_id,
             source_episode_id,
             source_runtime,
-            target_runtime,
+            payload_schema,
+            payload_schema_version,
             parse_recipient_scope(recipient_scope)?,
             parse_canonical_uuid(sender_user_id)?,
             created_at_unix_ms,
@@ -148,7 +153,8 @@ impl CloudEnvelopeMetadata {
             root_session_id: self.root_session_id.clone(),
             source_episode_id: self.source_episode_id.clone(),
             source_runtime: self.source_runtime.clone(),
-            target_runtime: self.target_runtime.clone(),
+            payload_schema: self.payload_schema.clone(),
+            payload_schema_version: self.payload_schema_version,
             recipient_scope: self.recipient_scope,
             sender_user_id: self.sender_user_id,
             sender,
@@ -176,8 +182,11 @@ impl CloudEnvelopeMetadata {
     pub fn source_runtime(&self) -> &str {
         &self.source_runtime
     }
-    pub fn target_runtime(&self) -> &str {
-        &self.target_runtime
+    pub fn payload_schema(&self) -> &str {
+        &self.payload_schema
+    }
+    pub fn payload_schema_version(&self) -> u16 {
+        self.payload_schema_version
     }
     pub fn recipient_scope(&self) -> RecipientScope {
         self.recipient_scope
@@ -328,7 +337,8 @@ pub struct CommittedCloudEnvelopeSql<'a> {
     pub sender_device_id: &'a str,
     pub sender_key_version: i32,
     pub source_runtime: &'a str,
-    pub target_runtime: &'a str,
+    pub payload_schema: &'a str,
+    pub payload_schema_version: i32,
     pub recipient_scope: &'a str,
     pub recipient_count: i32,
     pub recipient_set_sha256: &'a str,
@@ -474,7 +484,8 @@ impl CommittedCloudEnvelope {
             || header.root_session_id != row.root_session_id
             || header.source_episode_id != row.source_episode_id
             || header.source_runtime != row.source_runtime
-            || header.target_runtime != row.target_runtime
+            || header.payload_schema != row.payload_schema
+            || i32::from(header.payload_schema_version) != row.payload_schema_version
             || header.recipient_scope != parse_recipient_scope(row.recipient_scope)?
             || header.sender_user_id != parse_canonical_uuid(row.sender_user_id)?
             || header.created_at_unix_ms != row.client_created_at_unix_ms
@@ -690,6 +701,13 @@ where
     P: EnvelopeProfile,
     F: FnOnce(&mut dyn CheckpointRecordWriter) -> Result<(), ContinuationCryptoError>,
 {
+    if request.manifest.schema_id != request.metadata.payload_schema
+        || request.manifest.schema_version != request.metadata.payload_schema_version
+    {
+        return Err(ContinuationCryptoError::InvalidEnvelope(
+            "manifest schema does not match signed payload schema",
+        ));
+    }
     let sender = request.sender.public_identity()?;
     let mut header = request.metadata.header_with_identities(
         sender,
@@ -954,6 +972,15 @@ where
     sink.begin_transaction()?;
     match read_checkpoint_stream(gzip, context.limits, sink) {
         Ok((manifest, footer)) => {
+            if manifest.schema_id != verified.artifact.header.payload_schema
+                || manifest.schema_version
+                    != verified.artifact.header.payload_schema_version
+            {
+                sink.abort_transaction();
+                return Err(ContinuationCryptoError::InvalidEnvelope(
+                    "decrypted manifest schema does not match signed payload schema",
+                ));
+            }
             if let Err(error) = sink.commit_transaction() {
                 sink.abort_transaction();
                 return Err(error);

--- a/src-tauri/crates/continuation-crypto/src/error.rs
+++ b/src-tauri/crates/continuation-crypto/src/error.rs
@@ -1,0 +1,138 @@
+use std::io;
+
+use thiserror::Error;
+
+/// Secure-store failures never contain the value being stored or loaded.
+#[derive(Debug, Error)]
+pub enum SecretStoreError {
+    #[error("the operating-system secure store is unavailable (backend detail redacted)")]
+    Unavailable,
+    #[error("the operating-system secure store denied access (backend detail redacted)")]
+    AccessDenied,
+    #[error("the operating-system secure store returned ambiguous identity data")]
+    Ambiguous,
+    #[error("the operating-system secure store rejected the operation (backend detail redacted)")]
+    Rejected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LimitKind {
+    HeaderBytes,
+    FrameBytes,
+    TotalDecompressedBytes,
+    Records,
+    Events,
+    EventBytes,
+    Blobs,
+    BlobBytes,
+    PathBytes,
+    ManifestBytes,
+    CiphertextBytes,
+    EnvelopeBytes,
+}
+
+impl std::fmt::Display for LimitKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = match self {
+            Self::HeaderBytes => "header bytes",
+            Self::FrameBytes => "frame bytes",
+            Self::TotalDecompressedBytes => "total decompressed bytes",
+            Self::Records => "records",
+            Self::Events => "events",
+            Self::EventBytes => "event bytes",
+            Self::Blobs => "blobs",
+            Self::BlobBytes => "blob bytes",
+            Self::PathBytes => "path bytes",
+            Self::ManifestBytes => "manifest bytes",
+            Self::CiphertextBytes => "ciphertext bytes",
+            Self::EnvelopeBytes => "full envelope bytes",
+        };
+        f.write_str(value)
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum ContinuationCryptoError {
+    #[error(transparent)]
+    SecretStore(#[from] SecretStoreError),
+    #[error("I/O failure while {operation}: {source}")]
+    Io {
+        operation: &'static str,
+        #[source]
+        source: io::Error,
+    },
+    #[error("invalid device identity: {0}")]
+    InvalidIdentity(&'static str),
+    #[error("device identity has not been initialized")]
+    IdentityMissing,
+    #[error("device key version {0} is not retained")]
+    KeyVersionMissing(u32),
+    #[error("device key version cannot advance past the positive SQL int range")]
+    KeyVersionExhausted,
+    #[error("device identity changed during a compare-and-swap transaction")]
+    IdentityConflict,
+    #[error("secure device identity record is corrupt: {0}")]
+    CorruptIdentity(&'static str),
+    #[error("invalid continuation envelope: {0}")]
+    InvalidEnvelope(&'static str),
+    #[error("invalid private staging capability: {0}")]
+    InvalidStaging(&'static str),
+    #[error("unsupported continuation envelope version {0}")]
+    UnsupportedEnvelopeVersion(u16),
+    #[error("unsupported {kind} algorithm id {value}")]
+    UnsupportedAlgorithm { kind: &'static str, value: u8 },
+    #[error("continuation checkpoint expired at {0}")]
+    Expired(u64),
+    #[error("continuation checkpoint was created implausibly far in the future")]
+    CreatedInFuture,
+    #[error("continuation checkpoint sender does not match the trusted device key")]
+    UntrustedSender,
+    #[error("continuation checkpoint is not addressed to this device key")]
+    WrongRecipient,
+    #[error("continuation checkpoint age-ciphertext SHA-256 does not match its signed header")]
+    CiphertextHashMismatch,
+    #[error(
+        "continuation checkpoint full-object size or SHA-256 does not match the committed row"
+    )]
+    ObjectHashMismatch,
+    #[error("continuation checkpoint Cloud metadata does not match its {0}")]
+    CloudMetadataMismatch(&'static str),
+    #[error("continuation checkpoint plaintext hash does not match its framed stream")]
+    PlaintextHashMismatch,
+    #[error("continuation checkpoint signature is invalid")]
+    InvalidSignature,
+    #[error("age encryption failed: {0}")]
+    AgeEncrypt(String),
+    #[error("age decryption failed: {0}")]
+    AgeDecrypt(String),
+    #[error("gzip stream is invalid: {0}")]
+    InvalidCompression(String),
+    #[error("checkpoint frame stream is invalid: {0}")]
+    InvalidFrame(&'static str),
+    #[error("checkpoint blob path is unsafe: {0}")]
+    UnsafePath(String),
+    #[error("checkpoint sink did not consume the complete blob payload")]
+    BlobNotConsumed,
+    #[error("{kind} limit exceeded: {actual} > {limit}")]
+    LimitExceeded {
+        kind: LimitKind,
+        limit: u64,
+        actual: u64,
+    },
+    #[error("destination already exists: {0}")]
+    DestinationExists(String),
+}
+
+impl ContinuationCryptoError {
+    pub(crate) fn io(operation: &'static str, source: io::Error) -> Self {
+        Self::Io { operation, source }
+    }
+
+    pub(crate) fn limit(kind: LimitKind, limit: u64, actual: u64) -> Self {
+        Self::LimitExceeded {
+            kind,
+            limit,
+            actual,
+        }
+    }
+}

--- a/src-tauri/crates/continuation-crypto/src/framed_stream.rs
+++ b/src-tauri/crates/continuation-crypto/src/framed_stream.rs
@@ -1,0 +1,1389 @@
+use std::{
+    collections::HashSet,
+    io::{Read, Write},
+};
+
+use sha2::{Digest, Sha256};
+
+use crate::{ContinuationCryptoError, LimitKind};
+
+pub const INNER_STREAM_MAGIC: &[u8; 8] = b"ORG2CPS\0";
+pub const INNER_STREAM_VERSION: u16 = 1;
+
+const FRAME_MANIFEST: u8 = 1;
+const FRAME_EVENT: u8 = 2;
+const FRAME_BLOB: u8 = 3;
+const FRAME_FOOTER: u8 = 255;
+const MAX_SCHEMA_ID_BYTES: usize = 128;
+const MAX_EVENT_ID_BYTES: usize = 256;
+const MAX_EVENT_KIND_BYTES: usize = 128;
+const MAX_MEDIA_TYPE_BYTES: usize = 128;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CheckpointLimits {
+    pub max_manifest_bytes: u64,
+    pub max_frame_bytes: u64,
+    pub max_total_decompressed_bytes: u64,
+    pub max_records: u32,
+    pub max_events: u32,
+    pub max_event_bytes: u64,
+    pub max_blobs: u32,
+    pub max_blob_bytes: u64,
+    pub max_path_bytes: u64,
+    /// Maximum complete envelope size, including the public prefix/header,
+    /// age ciphertext, Ed25519 signature, and end marker.
+    pub max_envelope_bytes: u64,
+    pub max_ciphertext_bytes: u64,
+}
+
+/// Limits for explicitly local/offline checkpoint artifacts.
+pub const LOCAL_CHECKPOINT_LIMITS: CheckpointLimits = CheckpointLimits {
+    max_manifest_bytes: 64 * 1024,
+    max_frame_bytes: 64 * 1024 * 1024,
+    max_total_decompressed_bytes: 256 * 1024 * 1024,
+    max_records: 100_000,
+    max_events: 100_000,
+    max_event_bytes: 4 * 1024 * 1024,
+    max_blobs: 1_024,
+    max_blob_bytes: 64 * 1024 * 1024,
+    max_path_bytes: 1_024,
+    max_envelope_bytes: 512 * 1024 * 1024,
+    max_ciphertext_bytes: 512 * 1024 * 1024,
+};
+
+/// Mandatory limits for artifacts crossing the ORG2 Cloud object plane.
+///
+/// Cloud integrations must use the typed cloud read/write entry points, which
+/// apply this preset and therefore cannot accidentally inherit the 512 MiB
+/// local-file ceiling.
+pub const CLOUD_CHECKPOINT_LIMITS: CheckpointLimits = CheckpointLimits {
+    max_manifest_bytes: 64 * 1024,
+    max_frame_bytes: 16 * 1024 * 1024,
+    max_total_decompressed_bytes: 64 * 1024 * 1024,
+    max_records: 100_000,
+    max_events: 100_000,
+    max_event_bytes: 4 * 1024 * 1024,
+    max_blobs: 1_024,
+    max_blob_bytes: 16 * 1024 * 1024,
+    max_path_bytes: 1_024,
+    max_envelope_bytes: 16 * 1024 * 1024,
+    max_ciphertext_bytes: 16 * 1024 * 1024,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CheckpointManifest {
+    pub schema_id: String,
+    pub schema_version: u16,
+    pub expected_event_count: u32,
+    pub expected_blob_count: u32,
+    pub expected_logical_bytes: u64,
+    /// SHA-256 of canonical raw Event and Blob frames, excluding Manifest and
+    /// Footer. It is encrypted inside age and never appears in the public
+    /// envelope header.
+    pub plaintext_sha256: [u8; 32],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CheckpointEvent {
+    pub sequence: u64,
+    pub event_id: String,
+    pub event_kind: String,
+    pub payload: Vec<u8>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BlobMetadata {
+    pub relative_path: String,
+    pub media_type: String,
+    pub content_len: u64,
+    pub sha256: [u8; 32],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CheckpointFooter {
+    pub event_count: u32,
+    pub blob_count: u32,
+    pub record_count: u32,
+    pub logical_bytes: u64,
+    pub plaintext_sha256: [u8; 32],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CheckpointPlaintextSummary {
+    pub event_count: u32,
+    pub blob_count: u32,
+    pub logical_bytes: u64,
+    pub plaintext_sha256: [u8; 32],
+}
+
+impl CheckpointPlaintextSummary {
+    pub fn manifest(&self, schema_id: String, schema_version: u16) -> CheckpointManifest {
+        CheckpointManifest {
+            schema_id,
+            schema_version,
+            expected_event_count: self.event_count,
+            expected_blob_count: self.blob_count,
+            expected_logical_bytes: self.logical_bytes,
+            plaintext_sha256: self.plaintext_sha256,
+        }
+    }
+}
+
+/// First-pass canonical digest builder for the encrypted manifest.
+///
+/// Production snapshot sources are replayable files/event stores, so they can
+/// be read once for this digest and again for age streaming without writing a
+/// plaintext staging file. The envelope writer independently recomputes and
+/// checks the same digest during the second pass.
+pub struct CheckpointPlaintextHasher {
+    limits: CheckpointLimits,
+    digest: Sha256,
+    event_count: u32,
+    blob_count: u32,
+    record_count: u32,
+    logical_bytes: u64,
+    last_event_sequence: Option<u64>,
+    blob_paths: HashSet<String>,
+}
+
+impl CheckpointPlaintextHasher {
+    pub fn new(limits: CheckpointLimits) -> Self {
+        Self {
+            limits,
+            digest: Sha256::new(),
+            event_count: 0,
+            blob_count: 0,
+            record_count: 0,
+            logical_bytes: 0,
+            last_event_sequence: None,
+            blob_paths: HashSet::new(),
+        }
+    }
+
+    pub fn update_event(
+        &mut self,
+        sequence: u64,
+        event_id: &str,
+        event_kind: &str,
+        payload: &[u8],
+    ) -> Result<(), ContinuationCryptoError> {
+        validate_text("event id", event_id, MAX_EVENT_ID_BYTES)?;
+        validate_text("event kind", event_kind, MAX_EVENT_KIND_BYTES)?;
+        if self
+            .last_event_sequence
+            .is_some_and(|previous| sequence <= previous)
+        {
+            return Err(ContinuationCryptoError::InvalidFrame(
+                "event sequences must be strictly increasing",
+            ));
+        }
+        ensure_limit(
+            LimitKind::EventBytes,
+            self.limits.max_event_bytes,
+            payload.len() as u64,
+        )?;
+        let event_count =
+            self.event_count
+                .checked_add(1)
+                .ok_or(ContinuationCryptoError::InvalidFrame(
+                    "event count overflow",
+                ))?;
+        ensure_limit(
+            LimitKind::Events,
+            self.limits.max_events as u64,
+            event_count as u64,
+        )?;
+        let record_count = next_read_record(self.record_count, self.limits)?;
+        let body = encode_event_payload(sequence, event_id, event_kind, payload)?;
+        ensure_limit(
+            LimitKind::FrameBytes,
+            self.limits.max_frame_bytes,
+            body.len() as u64,
+        )?;
+        hash_frame(&mut self.digest, FRAME_EVENT, &body)?;
+        self.event_count = event_count;
+        self.record_count = record_count;
+        self.logical_bytes =
+            add_read_logical(self.logical_bytes, payload.len() as u64, self.limits)?;
+        self.last_event_sequence = Some(sequence);
+        Ok(())
+    }
+
+    pub fn update_blob(
+        &mut self,
+        metadata: &BlobMetadata,
+        content: &mut dyn Read,
+    ) -> Result<(), ContinuationCryptoError> {
+        validate_relative_path(&metadata.relative_path, self.limits.max_path_bytes)?;
+        if !self
+            .blob_paths
+            .insert(portable_path_key(&metadata.relative_path))
+        {
+            return Err(ContinuationCryptoError::InvalidFrame("duplicate blob path"));
+        }
+        validate_text("media type", &metadata.media_type, MAX_MEDIA_TYPE_BYTES)?;
+        ensure_limit(
+            LimitKind::BlobBytes,
+            self.limits.max_blob_bytes,
+            metadata.content_len,
+        )?;
+        let blob_count = self
+            .blob_count
+            .checked_add(1)
+            .ok_or(ContinuationCryptoError::InvalidFrame("blob count overflow"))?;
+        ensure_limit(
+            LimitKind::Blobs,
+            self.limits.max_blobs as u64,
+            blob_count as u64,
+        )?;
+        let record_count = next_read_record(self.record_count, self.limits)?;
+        let prefix = encode_blob_prefix(metadata)?;
+        let payload_len = (prefix.len() as u64)
+            .checked_add(metadata.content_len)
+            .ok_or(ContinuationCryptoError::InvalidFrame(
+                "blob frame length overflow",
+            ))?;
+        ensure_limit(
+            LimitKind::FrameBytes,
+            self.limits.max_frame_bytes,
+            payload_len,
+        )?;
+        self.digest.update([FRAME_BLOB]);
+        self.digest.update(
+            u32::try_from(payload_len)
+                .map_err(|_| ContinuationCryptoError::InvalidFrame("blob frame exceeds u32"))?
+                .to_be_bytes(),
+        );
+        self.digest.update(&prefix);
+        let mut blob_digest = Sha256::new();
+        read_exact_chunks(content, metadata.content_len, |bytes| {
+            self.digest.update(bytes);
+            blob_digest.update(bytes);
+            Ok(())
+        })?;
+        let actual_sha256: [u8; 32] = blob_digest.finalize().into();
+        if actual_sha256 != metadata.sha256 {
+            return Err(ContinuationCryptoError::InvalidFrame(
+                "blob SHA-256 mismatch",
+            ));
+        }
+        self.blob_count = blob_count;
+        self.record_count = record_count;
+        self.logical_bytes =
+            add_read_logical(self.logical_bytes, metadata.content_len, self.limits)?;
+        Ok(())
+    }
+
+    pub fn finish(self) -> CheckpointPlaintextSummary {
+        CheckpointPlaintextSummary {
+            event_count: self.event_count,
+            blob_count: self.blob_count,
+            logical_bytes: self.logical_bytes,
+            plaintext_sha256: self.digest.finalize().into(),
+        }
+    }
+}
+
+pub trait CheckpointRecordWriter {
+    fn write_event(
+        &mut self,
+        sequence: u64,
+        event_id: &str,
+        event_kind: &str,
+        payload: &[u8],
+    ) -> Result<(), ContinuationCryptoError>;
+
+    fn write_blob(
+        &mut self,
+        metadata: &BlobMetadata,
+        content: &mut dyn Read,
+    ) -> Result<(), ContinuationCryptoError>;
+}
+
+pub trait CheckpointSink {
+    /// Begin an invisible staging transaction. No staged record may become
+    /// externally visible before `commit_transaction`.
+    fn begin_transaction(&mut self) -> Result<(), ContinuationCryptoError> {
+        Ok(())
+    }
+
+    fn stage_manifest(
+        &mut self,
+        _manifest: &CheckpointManifest,
+    ) -> Result<(), ContinuationCryptoError> {
+        Ok(())
+    }
+
+    fn stage_event(&mut self, event: &CheckpointEvent) -> Result<(), ContinuationCryptoError>;
+
+    /// The implementation must consume exactly `metadata.content_len` bytes.
+    /// Returning early is rejected so no later frame can be misinterpreted.
+    fn stage_blob(
+        &mut self,
+        metadata: &BlobMetadata,
+        content: &mut dyn Read,
+    ) -> Result<(), ContinuationCryptoError>;
+
+    fn stage_footer(&mut self, _footer: &CheckpointFooter) -> Result<(), ContinuationCryptoError> {
+        Ok(())
+    }
+
+    /// Atomically publish the staged checkpoint after footer/hash/EOF checks.
+    fn commit_transaction(&mut self) -> Result<(), ContinuationCryptoError> {
+        Ok(())
+    }
+
+    /// Discard every staged side effect. This must be idempotent and must not
+    /// expose any staged record.
+    fn abort_transaction(&mut self) {}
+}
+
+pub(crate) struct CheckpointStreamWriter<W: Write> {
+    inner: W,
+    manifest: CheckpointManifest,
+    limits: CheckpointLimits,
+    content_digest: Sha256,
+    event_count: u32,
+    blob_count: u32,
+    record_count: u32,
+    logical_bytes: u64,
+    total_bytes: u64,
+    last_event_sequence: Option<u64>,
+    blob_paths: HashSet<String>,
+}
+
+impl<W: Write> CheckpointStreamWriter<W> {
+    pub(crate) fn new(
+        inner: W,
+        manifest: CheckpointManifest,
+        limits: CheckpointLimits,
+    ) -> Result<Self, ContinuationCryptoError> {
+        validate_manifest(&manifest, limits)?;
+        let mut writer = Self {
+            inner,
+            manifest,
+            limits,
+            content_digest: Sha256::new(),
+            event_count: 0,
+            blob_count: 0,
+            record_count: 0,
+            logical_bytes: 0,
+            total_bytes: 0,
+            last_event_sequence: None,
+            blob_paths: HashSet::new(),
+        };
+        writer.write_counted(INNER_STREAM_MAGIC)?;
+        writer.write_counted(&INNER_STREAM_VERSION.to_be_bytes())?;
+        let manifest_payload = encode_manifest(&writer.manifest)?;
+        writer.ensure_limit(
+            LimitKind::ManifestBytes,
+            writer.limits.max_manifest_bytes,
+            manifest_payload.len() as u64,
+        )?;
+        writer.write_frame_plain(FRAME_MANIFEST, &manifest_payload)?;
+        Ok(writer)
+    }
+
+    pub(crate) fn finish(mut self) -> Result<W, ContinuationCryptoError> {
+        let plaintext_sha256: [u8; 32] = self.content_digest.clone().finalize().into();
+        let footer = CheckpointFooter {
+            event_count: self.event_count,
+            blob_count: self.blob_count,
+            record_count: self.record_count,
+            logical_bytes: self.logical_bytes,
+            plaintext_sha256,
+        };
+        if footer.event_count != self.manifest.expected_event_count
+            || footer.blob_count != self.manifest.expected_blob_count
+            || footer.record_count
+                != self
+                    .manifest
+                    .expected_event_count
+                    .checked_add(self.manifest.expected_blob_count)
+                    .ok_or(ContinuationCryptoError::InvalidFrame(
+                        "record count overflow",
+                    ))?
+            || footer.logical_bytes != self.manifest.expected_logical_bytes
+            || footer.plaintext_sha256 != self.manifest.plaintext_sha256
+        {
+            return Err(ContinuationCryptoError::InvalidFrame(
+                "actual records do not match the encrypted manifest",
+            ));
+        }
+        self.write_frame_plain(FRAME_FOOTER, &encode_footer(&footer))?;
+        self.inner.flush().map_err(|error| {
+            ContinuationCryptoError::io("flushing checkpoint frame stream", error)
+        })?;
+        Ok(self.inner)
+    }
+
+    fn write_event_impl(
+        &mut self,
+        sequence: u64,
+        event_id: &str,
+        event_kind: &str,
+        payload: &[u8],
+    ) -> Result<(), ContinuationCryptoError> {
+        validate_text("event id", event_id, MAX_EVENT_ID_BYTES)?;
+        validate_text("event kind", event_kind, MAX_EVENT_KIND_BYTES)?;
+        if self
+            .last_event_sequence
+            .is_some_and(|previous| sequence <= previous)
+        {
+            return Err(ContinuationCryptoError::InvalidFrame(
+                "event sequences must be strictly increasing",
+            ));
+        }
+        self.ensure_limit(
+            LimitKind::EventBytes,
+            self.limits.max_event_bytes,
+            payload.len() as u64,
+        )?;
+        let event_count =
+            self.event_count
+                .checked_add(1)
+                .ok_or(ContinuationCryptoError::InvalidFrame(
+                    "event count overflow",
+                ))?;
+        self.ensure_limit(
+            LimitKind::Events,
+            self.limits.max_events as u64,
+            event_count as u64,
+        )?;
+        let record_count = self.next_record_count()?;
+        let body = encode_event_payload(sequence, event_id, event_kind, payload)?;
+        self.write_content_frame(FRAME_EVENT, &body)?;
+        self.event_count = event_count;
+        self.record_count = record_count;
+        self.last_event_sequence = Some(sequence);
+        self.add_logical_bytes(payload.len() as u64)?;
+        Ok(())
+    }
+
+    fn write_blob_impl(
+        &mut self,
+        metadata: &BlobMetadata,
+        content: &mut dyn Read,
+    ) -> Result<(), ContinuationCryptoError> {
+        validate_relative_path(&metadata.relative_path, self.limits.max_path_bytes)?;
+        if !self
+            .blob_paths
+            .insert(portable_path_key(&metadata.relative_path))
+        {
+            return Err(ContinuationCryptoError::InvalidFrame("duplicate blob path"));
+        }
+        validate_text("media type", &metadata.media_type, MAX_MEDIA_TYPE_BYTES)?;
+        self.ensure_limit(
+            LimitKind::BlobBytes,
+            self.limits.max_blob_bytes,
+            metadata.content_len,
+        )?;
+        let blob_count = self
+            .blob_count
+            .checked_add(1)
+            .ok_or(ContinuationCryptoError::InvalidFrame("blob count overflow"))?;
+        self.ensure_limit(
+            LimitKind::Blobs,
+            self.limits.max_blobs as u64,
+            blob_count as u64,
+        )?;
+        let record_count = self.next_record_count()?;
+
+        let prefix = encode_blob_prefix(metadata)?;
+        let payload_len = (prefix.len() as u64)
+            .checked_add(metadata.content_len)
+            .ok_or(ContinuationCryptoError::InvalidFrame(
+                "blob frame length overflow",
+            ))?;
+        self.ensure_frame(payload_len)?;
+        let payload_len_u32 = u32::try_from(payload_len)
+            .map_err(|_| ContinuationCryptoError::InvalidFrame("blob frame exceeds u32"))?;
+        let frame_header = [
+            [FRAME_BLOB].as_slice(),
+            payload_len_u32.to_be_bytes().as_slice(),
+        ]
+        .concat();
+        self.write_content_bytes(&frame_header)?;
+        self.write_content_bytes(&prefix)?;
+
+        let mut blob_digest = Sha256::new();
+        read_exact_chunks(content, metadata.content_len, |chunk| {
+            blob_digest.update(chunk);
+            self.write_content_bytes(chunk)
+        })?;
+        let actual_sha256: [u8; 32] = blob_digest.finalize().into();
+        if actual_sha256 != metadata.sha256 {
+            return Err(ContinuationCryptoError::InvalidFrame(
+                "blob SHA-256 mismatch",
+            ));
+        }
+        self.blob_count = blob_count;
+        self.record_count = record_count;
+        self.add_logical_bytes(metadata.content_len)?;
+        Ok(())
+    }
+
+    fn next_record_count(&self) -> Result<u32, ContinuationCryptoError> {
+        let next =
+            self.record_count
+                .checked_add(1)
+                .ok_or(ContinuationCryptoError::InvalidFrame(
+                    "record count overflow",
+                ))?;
+        self.ensure_limit(
+            LimitKind::Records,
+            self.limits.max_records as u64,
+            next as u64,
+        )?;
+        Ok(next)
+    }
+
+    fn add_logical_bytes(&mut self, bytes: u64) -> Result<(), ContinuationCryptoError> {
+        self.logical_bytes =
+            self.logical_bytes
+                .checked_add(bytes)
+                .ok_or(ContinuationCryptoError::InvalidFrame(
+                    "logical byte count overflow",
+                ))?;
+        self.ensure_limit(
+            LimitKind::TotalDecompressedBytes,
+            self.limits.max_total_decompressed_bytes,
+            self.logical_bytes,
+        )
+    }
+
+    fn ensure_frame(&self, payload_len: u64) -> Result<(), ContinuationCryptoError> {
+        self.ensure_limit(
+            LimitKind::FrameBytes,
+            self.limits.max_frame_bytes,
+            payload_len,
+        )
+    }
+
+    fn ensure_limit(
+        &self,
+        kind: LimitKind,
+        limit: u64,
+        actual: u64,
+    ) -> Result<(), ContinuationCryptoError> {
+        if actual > limit {
+            Err(ContinuationCryptoError::limit(kind, limit, actual))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn write_frame_plain(
+        &mut self,
+        tag: u8,
+        payload: &[u8],
+    ) -> Result<(), ContinuationCryptoError> {
+        self.ensure_frame(payload.len() as u64)?;
+        self.write_counted(&[tag])?;
+        self.write_counted(
+            &u32::try_from(payload.len())
+                .map_err(|_| ContinuationCryptoError::InvalidFrame("frame exceeds u32"))?
+                .to_be_bytes(),
+        )?;
+        self.write_counted(payload)
+    }
+
+    fn write_content_frame(
+        &mut self,
+        tag: u8,
+        payload: &[u8],
+    ) -> Result<(), ContinuationCryptoError> {
+        self.ensure_frame(payload.len() as u64)?;
+        self.write_content_bytes(&[tag])?;
+        self.write_content_bytes(
+            &u32::try_from(payload.len())
+                .map_err(|_| ContinuationCryptoError::InvalidFrame("frame exceeds u32"))?
+                .to_be_bytes(),
+        )?;
+        self.write_content_bytes(payload)
+    }
+
+    fn write_content_bytes(&mut self, bytes: &[u8]) -> Result<(), ContinuationCryptoError> {
+        self.content_digest.update(bytes);
+        self.write_counted(bytes)
+    }
+
+    fn write_counted(&mut self, bytes: &[u8]) -> Result<(), ContinuationCryptoError> {
+        let next = self.total_bytes.checked_add(bytes.len() as u64).ok_or(
+            ContinuationCryptoError::InvalidFrame("decompressed byte count overflow"),
+        )?;
+        self.ensure_limit(
+            LimitKind::TotalDecompressedBytes,
+            self.limits.max_total_decompressed_bytes,
+            next,
+        )?;
+        self.inner
+            .write_all(bytes)
+            .map_err(|error| ContinuationCryptoError::io("writing checkpoint frame", error))?;
+        self.total_bytes = next;
+        Ok(())
+    }
+}
+
+impl<W: Write> CheckpointRecordWriter for CheckpointStreamWriter<W> {
+    fn write_event(
+        &mut self,
+        sequence: u64,
+        event_id: &str,
+        event_kind: &str,
+        payload: &[u8],
+    ) -> Result<(), ContinuationCryptoError> {
+        self.write_event_impl(sequence, event_id, event_kind, payload)
+    }
+
+    fn write_blob(
+        &mut self,
+        metadata: &BlobMetadata,
+        content: &mut dyn Read,
+    ) -> Result<(), ContinuationCryptoError> {
+        self.write_blob_impl(metadata, content)
+    }
+}
+
+pub(crate) fn read_checkpoint_stream<R: Read>(
+    mut reader: R,
+    limits: CheckpointLimits,
+    sink: &mut dyn CheckpointSink,
+) -> Result<(CheckpointManifest, CheckpointFooter), ContinuationCryptoError> {
+    let mut total_bytes = 0u64;
+    let magic = read_array_counted::<8, _>(&mut reader, &mut total_bytes, limits)?;
+    if &magic != INNER_STREAM_MAGIC {
+        return Err(ContinuationCryptoError::InvalidFrame(
+            "bad inner stream magic",
+        ));
+    }
+    let version = u16::from_be_bytes(read_array_counted::<2, _>(
+        &mut reader,
+        &mut total_bytes,
+        limits,
+    )?);
+    if version != INNER_STREAM_VERSION {
+        return Err(ContinuationCryptoError::InvalidFrame(
+            "unsupported inner stream version",
+        ));
+    }
+
+    let (tag, length, raw_header) = read_frame_header(&mut reader, &mut total_bytes, limits)?;
+    if tag != FRAME_MANIFEST {
+        return Err(ContinuationCryptoError::InvalidFrame(
+            "manifest must be the first frame",
+        ));
+    }
+    ensure_limit(
+        LimitKind::ManifestBytes,
+        limits.max_manifest_bytes,
+        length as u64,
+    )?;
+    let manifest_bytes = read_vec_counted(&mut reader, length as usize, &mut total_bytes, limits)?;
+    let manifest = decode_manifest(&manifest_bytes)?;
+    validate_manifest(&manifest, limits)?;
+    let _ = raw_header;
+    sink.stage_manifest(&manifest)?;
+
+    let mut content_digest = Sha256::new();
+    let mut event_count = 0u32;
+    let mut blob_count = 0u32;
+    let mut record_count = 0u32;
+    let mut logical_bytes = 0u64;
+    let mut last_event_sequence = None;
+    let mut blob_paths = HashSet::new();
+
+    let footer = loop {
+        let (tag, length, raw_header) = read_frame_header(&mut reader, &mut total_bytes, limits)?;
+        ensure_limit(LimitKind::FrameBytes, limits.max_frame_bytes, length as u64)?;
+        match tag {
+            FRAME_EVENT => {
+                content_digest.update(raw_header);
+                let payload = read_vec_counted_and_hash(
+                    &mut reader,
+                    length as usize,
+                    &mut total_bytes,
+                    limits,
+                    &mut content_digest,
+                )?;
+                let event = decode_event(&payload, limits)?;
+                if last_event_sequence.is_some_and(|previous| event.sequence <= previous) {
+                    return Err(ContinuationCryptoError::InvalidFrame(
+                        "event sequences must be strictly increasing",
+                    ));
+                }
+                event_count =
+                    event_count
+                        .checked_add(1)
+                        .ok_or(ContinuationCryptoError::InvalidFrame(
+                            "event count overflow",
+                        ))?;
+                ensure_limit(
+                    LimitKind::Events,
+                    limits.max_events as u64,
+                    event_count as u64,
+                )?;
+                record_count = next_read_record(record_count, limits)?;
+                logical_bytes =
+                    add_read_logical(logical_bytes, event.payload.len() as u64, limits)?;
+                last_event_sequence = Some(event.sequence);
+                sink.stage_event(&event)?;
+            }
+            FRAME_BLOB => {
+                content_digest.update(raw_header);
+                let mut prefix = BlobPrefixReader::new(
+                    &mut reader,
+                    &mut total_bytes,
+                    limits,
+                    &mut content_digest,
+                    length as u64,
+                );
+                let metadata = prefix.read_metadata()?;
+                if !blob_paths.insert(portable_path_key(&metadata.relative_path)) {
+                    return Err(ContinuationCryptoError::InvalidFrame("duplicate blob path"));
+                }
+                blob_count = blob_count
+                    .checked_add(1)
+                    .ok_or(ContinuationCryptoError::InvalidFrame("blob count overflow"))?;
+                ensure_limit(LimitKind::Blobs, limits.max_blobs as u64, blob_count as u64)?;
+                record_count = next_read_record(record_count, limits)?;
+                logical_bytes = add_read_logical(logical_bytes, metadata.content_len, limits)?;
+                let mut content = prefix.content_reader(&metadata)?;
+                sink.stage_blob(&metadata, &mut content)?;
+                if content.remaining != 0 {
+                    return Err(ContinuationCryptoError::BlobNotConsumed);
+                }
+                let actual_sha256: [u8; 32] = content.blob_digest.clone().finalize().into();
+                if actual_sha256 != metadata.sha256 {
+                    return Err(ContinuationCryptoError::InvalidFrame(
+                        "blob SHA-256 mismatch",
+                    ));
+                }
+            }
+            FRAME_FOOTER => {
+                let bytes =
+                    read_vec_counted(&mut reader, length as usize, &mut total_bytes, limits)?;
+                break decode_footer(&bytes)?;
+            }
+            FRAME_MANIFEST => {
+                return Err(ContinuationCryptoError::InvalidFrame(
+                    "duplicate manifest frame",
+                ));
+            }
+            _ => return Err(ContinuationCryptoError::InvalidFrame("unknown frame tag")),
+        }
+    };
+
+    let plaintext_sha256: [u8; 32] = content_digest.finalize().into();
+    if footer.event_count != event_count
+        || footer.blob_count != blob_count
+        || footer.record_count != record_count
+        || footer.logical_bytes != logical_bytes
+        || footer.plaintext_sha256 != plaintext_sha256
+        || manifest.expected_event_count != event_count
+        || manifest.expected_blob_count != blob_count
+        || manifest.expected_logical_bytes != logical_bytes
+        || manifest.plaintext_sha256 != plaintext_sha256
+    {
+        return Err(ContinuationCryptoError::PlaintextHashMismatch);
+    }
+    sink.stage_footer(&footer)?;
+    let mut trailing = [0u8; 1];
+    let read = reader
+        .read(&mut trailing)
+        .map_err(|error| ContinuationCryptoError::io("checking framed stream end", error))?;
+    if read != 0 {
+        return Err(ContinuationCryptoError::InvalidFrame(
+            "trailing bytes after footer",
+        ));
+    }
+    Ok((manifest, footer))
+}
+
+fn validate_manifest(
+    manifest: &CheckpointManifest,
+    limits: CheckpointLimits,
+) -> Result<(), ContinuationCryptoError> {
+    validate_text("schema id", &manifest.schema_id, MAX_SCHEMA_ID_BYTES)?;
+    if manifest.schema_version == 0 {
+        return Err(ContinuationCryptoError::InvalidFrame(
+            "schema version must be positive",
+        ));
+    }
+    ensure_limit(
+        LimitKind::Events,
+        limits.max_events as u64,
+        manifest.expected_event_count as u64,
+    )?;
+    ensure_limit(
+        LimitKind::Blobs,
+        limits.max_blobs as u64,
+        manifest.expected_blob_count as u64,
+    )?;
+    let records = manifest
+        .expected_event_count
+        .checked_add(manifest.expected_blob_count)
+        .ok_or(ContinuationCryptoError::InvalidFrame(
+            "manifest record count overflow",
+        ))?;
+    ensure_limit(
+        LimitKind::Records,
+        limits.max_records as u64,
+        records as u64,
+    )?;
+    ensure_limit(
+        LimitKind::TotalDecompressedBytes,
+        limits.max_total_decompressed_bytes,
+        manifest.expected_logical_bytes,
+    )
+}
+
+fn encode_manifest(manifest: &CheckpointManifest) -> Result<Vec<u8>, ContinuationCryptoError> {
+    let mut bytes = Vec::with_capacity(64 + manifest.schema_id.len());
+    put_string(&mut bytes, &manifest.schema_id)?;
+    bytes.extend_from_slice(&manifest.schema_version.to_be_bytes());
+    bytes.extend_from_slice(&manifest.expected_event_count.to_be_bytes());
+    bytes.extend_from_slice(&manifest.expected_blob_count.to_be_bytes());
+    bytes.extend_from_slice(&manifest.expected_logical_bytes.to_be_bytes());
+    bytes.extend_from_slice(&manifest.plaintext_sha256);
+    Ok(bytes)
+}
+
+fn decode_manifest(bytes: &[u8]) -> Result<CheckpointManifest, ContinuationCryptoError> {
+    let mut cursor = PayloadCursor::new(bytes);
+    let manifest = CheckpointManifest {
+        schema_id: cursor.string(MAX_SCHEMA_ID_BYTES)?,
+        schema_version: cursor.u16()?,
+        expected_event_count: cursor.u32()?,
+        expected_blob_count: cursor.u32()?,
+        expected_logical_bytes: cursor.u64()?,
+        plaintext_sha256: cursor.array()?,
+    };
+    cursor.finish()?;
+    if encode_manifest(&manifest)? != bytes {
+        return Err(ContinuationCryptoError::InvalidFrame(
+            "non-canonical manifest encoding",
+        ));
+    }
+    Ok(manifest)
+}
+
+fn decode_event(
+    bytes: &[u8],
+    limits: CheckpointLimits,
+) -> Result<CheckpointEvent, ContinuationCryptoError> {
+    let mut cursor = PayloadCursor::new(bytes);
+    let sequence = cursor.u64()?;
+    let event_id = cursor.string(MAX_EVENT_ID_BYTES)?;
+    let event_kind = cursor.string(MAX_EVENT_KIND_BYTES)?;
+    let payload_len = cursor.u32()? as usize;
+    ensure_limit(
+        LimitKind::EventBytes,
+        limits.max_event_bytes,
+        payload_len as u64,
+    )?;
+    let payload = cursor.take(payload_len)?.to_vec();
+    cursor.finish()?;
+    Ok(CheckpointEvent {
+        sequence,
+        event_id,
+        event_kind,
+        payload,
+    })
+}
+
+fn encode_footer(footer: &CheckpointFooter) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(52);
+    bytes.extend_from_slice(&footer.event_count.to_be_bytes());
+    bytes.extend_from_slice(&footer.blob_count.to_be_bytes());
+    bytes.extend_from_slice(&footer.record_count.to_be_bytes());
+    bytes.extend_from_slice(&footer.logical_bytes.to_be_bytes());
+    bytes.extend_from_slice(&footer.plaintext_sha256);
+    bytes
+}
+
+fn decode_footer(bytes: &[u8]) -> Result<CheckpointFooter, ContinuationCryptoError> {
+    let mut cursor = PayloadCursor::new(bytes);
+    let footer = CheckpointFooter {
+        event_count: cursor.u32()?,
+        blob_count: cursor.u32()?,
+        record_count: cursor.u32()?,
+        logical_bytes: cursor.u64()?,
+        plaintext_sha256: cursor.array()?,
+    };
+    cursor.finish()?;
+    if encode_footer(&footer) != bytes {
+        return Err(ContinuationCryptoError::InvalidFrame(
+            "non-canonical footer encoding",
+        ));
+    }
+    Ok(footer)
+}
+
+fn read_frame_header<R: Read>(
+    reader: &mut R,
+    total: &mut u64,
+    limits: CheckpointLimits,
+) -> Result<(u8, u32, [u8; 5]), ContinuationCryptoError> {
+    let raw = read_array_counted::<5, _>(reader, total, limits)?;
+    let length = u32::from_be_bytes(
+        raw[1..5]
+            .try_into()
+            .map_err(|_| ContinuationCryptoError::InvalidFrame("truncated frame length"))?,
+    );
+    ensure_limit(LimitKind::FrameBytes, limits.max_frame_bytes, length as u64)?;
+    Ok((raw[0], length, raw))
+}
+
+fn read_array_counted<const N: usize, R: Read>(
+    reader: &mut R,
+    total: &mut u64,
+    limits: CheckpointLimits,
+) -> Result<[u8; N], ContinuationCryptoError> {
+    let mut bytes = [0u8; N];
+    read_exact_counted(reader, &mut bytes, total, limits)?;
+    Ok(bytes)
+}
+
+fn read_vec_counted<R: Read>(
+    reader: &mut R,
+    length: usize,
+    total: &mut u64,
+    limits: CheckpointLimits,
+) -> Result<Vec<u8>, ContinuationCryptoError> {
+    let mut bytes = vec![0u8; length];
+    read_exact_counted(reader, &mut bytes, total, limits)?;
+    Ok(bytes)
+}
+
+fn read_vec_counted_and_hash<R: Read>(
+    reader: &mut R,
+    length: usize,
+    total: &mut u64,
+    limits: CheckpointLimits,
+    digest: &mut Sha256,
+) -> Result<Vec<u8>, ContinuationCryptoError> {
+    let bytes = read_vec_counted(reader, length, total, limits)?;
+    digest.update(&bytes);
+    Ok(bytes)
+}
+
+fn read_exact_counted<R: Read>(
+    reader: &mut R,
+    bytes: &mut [u8],
+    total: &mut u64,
+    limits: CheckpointLimits,
+) -> Result<(), ContinuationCryptoError> {
+    let next =
+        total
+            .checked_add(bytes.len() as u64)
+            .ok_or(ContinuationCryptoError::InvalidFrame(
+                "decompressed byte count overflow",
+            ))?;
+    ensure_limit(
+        LimitKind::TotalDecompressedBytes,
+        limits.max_total_decompressed_bytes,
+        next,
+    )?;
+    reader
+        .read_exact(bytes)
+        .map_err(|error| ContinuationCryptoError::io("reading checkpoint frame", error))?;
+    *total = next;
+    Ok(())
+}
+
+struct BlobPrefixReader<'a, R> {
+    reader: &'a mut R,
+    total: &'a mut u64,
+    limits: CheckpointLimits,
+    content_digest: &'a mut Sha256,
+    frame_remaining: u64,
+}
+
+impl<'a, R: Read> BlobPrefixReader<'a, R> {
+    fn new(
+        reader: &'a mut R,
+        total: &'a mut u64,
+        limits: CheckpointLimits,
+        content_digest: &'a mut Sha256,
+        frame_remaining: u64,
+    ) -> Self {
+        Self {
+            reader,
+            total,
+            limits,
+            content_digest,
+            frame_remaining,
+        }
+    }
+
+    fn read_metadata(&mut self) -> Result<BlobMetadata, ContinuationCryptoError> {
+        let relative_path = self.string(self.limits.max_path_bytes as usize)?;
+        validate_relative_path(&relative_path, self.limits.max_path_bytes)?;
+        let media_type = self.string(MAX_MEDIA_TYPE_BYTES)?;
+        validate_text("media type", &media_type, MAX_MEDIA_TYPE_BYTES)?;
+        let content_len = u64::from_be_bytes(self.array()?);
+        ensure_limit(
+            LimitKind::BlobBytes,
+            self.limits.max_blob_bytes,
+            content_len,
+        )?;
+        let sha256 = self.array()?;
+        if self.frame_remaining != content_len {
+            return Err(ContinuationCryptoError::InvalidFrame(
+                "blob frame length does not match declared content",
+            ));
+        }
+        Ok(BlobMetadata {
+            relative_path,
+            media_type,
+            content_len,
+            sha256,
+        })
+    }
+
+    fn content_reader(
+        self,
+        metadata: &BlobMetadata,
+    ) -> Result<BlobContentReader<'a, R>, ContinuationCryptoError> {
+        let final_total = (*self.total).checked_add(metadata.content_len).ok_or(
+            ContinuationCryptoError::InvalidFrame("decompressed byte count overflow"),
+        )?;
+        ensure_limit(
+            LimitKind::TotalDecompressedBytes,
+            self.limits.max_total_decompressed_bytes,
+            final_total,
+        )?;
+        Ok(BlobContentReader {
+            reader: self.reader,
+            total: self.total,
+            limits: self.limits,
+            content_digest: self.content_digest,
+            blob_digest: Sha256::new(),
+            remaining: metadata.content_len,
+        })
+    }
+
+    fn string(&mut self, max: usize) -> Result<String, ContinuationCryptoError> {
+        let length = u16::from_be_bytes(self.array()?) as usize;
+        if length == 0 || length > max {
+            return Err(ContinuationCryptoError::InvalidFrame(
+                "invalid blob metadata string length",
+            ));
+        }
+        let bytes = self.take(length)?;
+        String::from_utf8(bytes)
+            .map_err(|_| ContinuationCryptoError::InvalidFrame("blob metadata is not UTF-8"))
+    }
+
+    fn array<const N: usize>(&mut self) -> Result<[u8; N], ContinuationCryptoError> {
+        self.take(N)?
+            .try_into()
+            .map_err(|_| ContinuationCryptoError::InvalidFrame("truncated blob metadata array"))
+    }
+
+    fn take(&mut self, length: usize) -> Result<Vec<u8>, ContinuationCryptoError> {
+        if length as u64 > self.frame_remaining {
+            return Err(ContinuationCryptoError::InvalidFrame(
+                "blob metadata exceeds frame length",
+            ));
+        }
+        let bytes = read_vec_counted(self.reader, length, self.total, self.limits)?;
+        self.content_digest.update(&bytes);
+        self.frame_remaining -= length as u64;
+        Ok(bytes)
+    }
+}
+
+struct BlobContentReader<'a, R> {
+    reader: &'a mut R,
+    total: &'a mut u64,
+    limits: CheckpointLimits,
+    content_digest: &'a mut Sha256,
+    blob_digest: Sha256,
+    remaining: u64,
+}
+
+impl<R: Read> Read for BlobContentReader<'_, R> {
+    fn read(&mut self, output: &mut [u8]) -> std::io::Result<usize> {
+        if self.remaining == 0 || output.is_empty() {
+            return Ok(0);
+        }
+        let requested = output.len().min(self.remaining as usize);
+        let next_total = self.total.checked_add(requested as u64).ok_or_else(|| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, "byte limit overflow")
+        })?;
+        if next_total > self.limits.max_total_decompressed_bytes {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "total decompressed byte limit exceeded",
+            ));
+        }
+        let read = self.reader.read(&mut output[..requested])?;
+        if read == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "truncated blob content",
+            ));
+        }
+        let bytes = &output[..read];
+        self.content_digest.update(bytes);
+        self.blob_digest.update(bytes);
+        self.remaining -= read as u64;
+        *self.total += read as u64;
+        Ok(read)
+    }
+}
+
+struct PayloadCursor<'a> {
+    bytes: &'a [u8],
+    position: usize,
+}
+
+impl<'a> PayloadCursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, position: 0 }
+    }
+
+    fn take(&mut self, length: usize) -> Result<&'a [u8], ContinuationCryptoError> {
+        let end =
+            self.position
+                .checked_add(length)
+                .ok_or(ContinuationCryptoError::InvalidFrame(
+                    "payload length overflow",
+                ))?;
+        let value =
+            self.bytes
+                .get(self.position..end)
+                .ok_or(ContinuationCryptoError::InvalidFrame(
+                    "truncated frame payload",
+                ))?;
+        self.position = end;
+        Ok(value)
+    }
+
+    fn u16(&mut self) -> Result<u16, ContinuationCryptoError> {
+        Ok(u16::from_be_bytes(self.array()?))
+    }
+
+    fn u32(&mut self) -> Result<u32, ContinuationCryptoError> {
+        Ok(u32::from_be_bytes(self.array()?))
+    }
+
+    fn u64(&mut self) -> Result<u64, ContinuationCryptoError> {
+        Ok(u64::from_be_bytes(self.array()?))
+    }
+
+    fn array<const N: usize>(&mut self) -> Result<[u8; N], ContinuationCryptoError> {
+        self.take(N)?
+            .try_into()
+            .map_err(|_| ContinuationCryptoError::InvalidFrame("truncated payload array"))
+    }
+
+    fn string(&mut self, max: usize) -> Result<String, ContinuationCryptoError> {
+        let length = self.u16()? as usize;
+        if length == 0 || length > max {
+            return Err(ContinuationCryptoError::InvalidFrame(
+                "invalid payload string length",
+            ));
+        }
+        String::from_utf8(self.take(length)?.to_vec())
+            .map_err(|_| ContinuationCryptoError::InvalidFrame("payload string is not UTF-8"))
+    }
+
+    fn finish(&self) -> Result<(), ContinuationCryptoError> {
+        if self.position == self.bytes.len() {
+            Ok(())
+        } else {
+            Err(ContinuationCryptoError::InvalidFrame(
+                "trailing frame payload bytes",
+            ))
+        }
+    }
+}
+
+fn put_string(bytes: &mut Vec<u8>, value: &str) -> Result<(), ContinuationCryptoError> {
+    let length = u16::try_from(value.len())
+        .map_err(|_| ContinuationCryptoError::InvalidFrame("string exceeds u16"))?;
+    bytes.extend_from_slice(&length.to_be_bytes());
+    bytes.extend_from_slice(value.as_bytes());
+    Ok(())
+}
+
+fn encode_event_payload(
+    sequence: u64,
+    event_id: &str,
+    event_kind: &str,
+    payload: &[u8],
+) -> Result<Vec<u8>, ContinuationCryptoError> {
+    let mut body = Vec::with_capacity(16 + event_id.len() + event_kind.len() + payload.len());
+    body.extend_from_slice(&sequence.to_be_bytes());
+    put_string(&mut body, event_id)?;
+    put_string(&mut body, event_kind)?;
+    body.extend_from_slice(
+        &u32::try_from(payload.len())
+            .map_err(|_| ContinuationCryptoError::InvalidFrame("event payload too large"))?
+            .to_be_bytes(),
+    );
+    body.extend_from_slice(payload);
+    Ok(body)
+}
+
+fn encode_blob_prefix(metadata: &BlobMetadata) -> Result<Vec<u8>, ContinuationCryptoError> {
+    let mut prefix = Vec::with_capacity(
+        2 + metadata.relative_path.len() + 2 + metadata.media_type.len() + 8 + 32,
+    );
+    put_string(&mut prefix, &metadata.relative_path)?;
+    put_string(&mut prefix, &metadata.media_type)?;
+    prefix.extend_from_slice(&metadata.content_len.to_be_bytes());
+    prefix.extend_from_slice(&metadata.sha256);
+    Ok(prefix)
+}
+
+fn hash_frame(digest: &mut Sha256, tag: u8, payload: &[u8]) -> Result<(), ContinuationCryptoError> {
+    digest.update([tag]);
+    digest.update(
+        u32::try_from(payload.len())
+            .map_err(|_| ContinuationCryptoError::InvalidFrame("frame exceeds u32"))?
+            .to_be_bytes(),
+    );
+    digest.update(payload);
+    Ok(())
+}
+
+fn read_exact_chunks<F>(
+    content: &mut dyn Read,
+    mut remaining: u64,
+    mut consume: F,
+) -> Result<(), ContinuationCryptoError>
+where
+    F: FnMut(&[u8]) -> Result<(), ContinuationCryptoError>,
+{
+    let mut buffer = [0u8; 64 * 1024];
+    while remaining > 0 {
+        let requested = usize::try_from(remaining.min(buffer.len() as u64))
+            .map_err(|_| ContinuationCryptoError::InvalidFrame("blob read size overflow"))?;
+        let read = content
+            .read(&mut buffer[..requested])
+            .map_err(|error| ContinuationCryptoError::io("reading checkpoint blob", error))?;
+        if read == 0 {
+            return Err(ContinuationCryptoError::InvalidFrame(
+                "blob ended before its declared length",
+            ));
+        }
+        consume(&buffer[..read])?;
+        remaining -= read as u64;
+    }
+    let mut extra = [0u8; 1];
+    if content
+        .read(&mut extra)
+        .map_err(|error| ContinuationCryptoError::io("checking checkpoint blob length", error))?
+        != 0
+    {
+        return Err(ContinuationCryptoError::InvalidFrame(
+            "blob exceeds its declared length",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_text(
+    label: &'static str,
+    value: &str,
+    max: usize,
+) -> Result<(), ContinuationCryptoError> {
+    if value.is_empty()
+        || value.len() > max
+        || value
+            .bytes()
+            .any(|byte| byte == 0 || byte.is_ascii_control())
+    {
+        return Err(ContinuationCryptoError::InvalidFrame(label));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_relative_path(
+    path: &str,
+    max_path_bytes: u64,
+) -> Result<(), ContinuationCryptoError> {
+    ensure_limit(LimitKind::PathBytes, max_path_bytes, path.len() as u64)?;
+    if path.is_empty()
+        || !path.is_ascii()
+        || path.starts_with('/')
+        || path.ends_with('/')
+        || path
+            .bytes()
+            .any(|byte| byte == 0 || byte.is_ascii_control() || b"<>:\\|?*".contains(&byte))
+        || path.split('/').any(|segment| {
+            segment.is_empty()
+                || segment == "."
+                || segment == ".."
+                || segment.ends_with('.')
+                || segment.ends_with(' ')
+                || is_windows_reserved_segment(segment)
+        })
+    {
+        return Err(ContinuationCryptoError::UnsafePath(path.to_owned()));
+    }
+    Ok(())
+}
+
+fn portable_path_key(path: &str) -> String {
+    // Cloud handoffs may be restored on a case-insensitive filesystem even if
+    // they were produced on Linux. ASCII-only validation above makes this
+    // lowercase mapping deterministic without locale or Unicode-normalization
+    // ambiguity.
+    path.to_ascii_lowercase()
+}
+
+fn is_windows_reserved_segment(segment: &str) -> bool {
+    let stem = segment
+        .split('.')
+        .next()
+        .unwrap_or_default()
+        .to_ascii_uppercase();
+    matches!(stem.as_str(), "CON" | "PRN" | "AUX" | "NUL")
+        || (stem.len() == 4
+            && matches!(&stem[..3], "COM" | "LPT")
+            && matches!(stem.as_bytes()[3], b'1'..=b'9'))
+}
+
+fn next_read_record(
+    current: u32,
+    limits: CheckpointLimits,
+) -> Result<u32, ContinuationCryptoError> {
+    let next = current
+        .checked_add(1)
+        .ok_or(ContinuationCryptoError::InvalidFrame(
+            "record count overflow",
+        ))?;
+    ensure_limit(LimitKind::Records, limits.max_records as u64, next as u64)?;
+    Ok(next)
+}
+
+fn add_read_logical(
+    current: u64,
+    bytes: u64,
+    limits: CheckpointLimits,
+) -> Result<u64, ContinuationCryptoError> {
+    let next = current
+        .checked_add(bytes)
+        .ok_or(ContinuationCryptoError::InvalidFrame(
+            "logical byte count overflow",
+        ))?;
+    ensure_limit(
+        LimitKind::TotalDecompressedBytes,
+        limits.max_total_decompressed_bytes,
+        next,
+    )?;
+    Ok(next)
+}
+
+fn ensure_limit(kind: LimitKind, limit: u64, actual: u64) -> Result<(), ContinuationCryptoError> {
+    if actual > limit {
+        Err(ContinuationCryptoError::limit(kind, limit, actual))
+    } else {
+        Ok(())
+    }
+}

--- a/src-tauri/crates/continuation-crypto/src/identity.rs
+++ b/src-tauri/crates/continuation-crypto/src/identity.rs
@@ -1,0 +1,650 @@
+use std::{str::FromStr, sync::Mutex};
+
+use age::secrecy::ExposeSecret;
+use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
+use rand_core::OsRng;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+use zeroize::Zeroizing;
+
+use crate::{
+    ContinuationCryptoError, DeviceSecretStore, PrivateStagingDirectory, SecretBytes,
+    SecretStoreError,
+};
+
+pub const DEVICE_FINGERPRINT_DOMAIN: &[u8] = b"ORG2-CONTINUATION-DEVICE-V1";
+const PRIVATE_KEY_CHECKSUM_DOMAIN: &[u8] = b"ORG2-CONTINUATION-PRIVATE-KEY-CHECKSUM-V1";
+const ACTIVE_POINTER_CHECKSUM_DOMAIN: &[u8] = b"ORG2-CONTINUATION-ACTIVE-KEY-CHECKSUM-V1";
+const KEY_RECORD_MAGIC: &[u8; 8] = b"ORG2KEY\0";
+const ACTIVE_POINTER_MAGIC: &[u8; 8] = b"ORG2ACT\0";
+const SECRET_RECORD_VERSION: u16 = 1;
+const MAX_AGE_SECRET_BYTES: usize = 256;
+const SQL_MAX_KEY_VERSION: u32 = i32::MAX as u32;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DevicePublicIdentity {
+    pub device_id: Uuid,
+    pub key_version: u32,
+    pub encryption_public_key: [u8; 32],
+    pub signing_public_key: [u8; 32],
+    pub fingerprint: [u8; 32],
+}
+
+impl DevicePublicIdentity {
+    pub fn try_new(
+        device_id: Uuid,
+        key_version: u32,
+        encryption_public_key: [u8; 32],
+        signing_public_key: [u8; 32],
+        fingerprint: [u8; 32],
+    ) -> Result<Self, ContinuationCryptoError> {
+        if device_id.is_nil() {
+            return Err(ContinuationCryptoError::InvalidIdentity(
+                "device UUID must be non-nil",
+            ));
+        }
+        validate_key_version(key_version)?;
+        let expected = device_fingerprint(&encryption_public_key, &signing_public_key);
+        if fingerprint != expected {
+            return Err(ContinuationCryptoError::InvalidIdentity(
+                "public-key fingerprint mismatch",
+            ));
+        }
+        if encryption_public_key == [0; 32] {
+            return Err(ContinuationCryptoError::InvalidIdentity(
+                "X25519 public key must be nonzero",
+            ));
+        }
+        let verifying_key = VerifyingKey::from_bytes(&signing_public_key).map_err(|_| {
+            ContinuationCryptoError::InvalidIdentity("invalid Ed25519 verifying key")
+        })?;
+        if verifying_key.is_weak() {
+            return Err(ContinuationCryptoError::InvalidIdentity(
+                "weak Ed25519 verifying key",
+            ));
+        }
+        age_recipient_from_raw(&encryption_public_key)?;
+        Ok(Self {
+            device_id,
+            key_version,
+            encryption_public_key,
+            signing_public_key,
+            fingerprint,
+        })
+    }
+
+    pub fn fingerprint_hex(&self) -> String {
+        hex::encode(self.fingerprint)
+    }
+
+    pub fn validate(&self) -> Result<(), ContinuationCryptoError> {
+        Self::try_new(
+            self.device_id,
+            self.key_version,
+            self.encryption_public_key,
+            self.signing_public_key,
+            self.fingerprint,
+        )
+        .map(|_| ())
+    }
+}
+
+/// Private device identity. Intentionally not `Clone`, `Debug`, or serde.
+pub struct DevicePrivateIdentity {
+    device_id: Uuid,
+    key_version: u32,
+    age_secret: Zeroizing<String>,
+    signing_secret: Zeroizing<[u8; 32]>,
+}
+
+impl DevicePrivateIdentity {
+    pub fn device_id(&self) -> Uuid {
+        self.device_id
+    }
+
+    pub fn key_version(&self) -> u32 {
+        self.key_version
+    }
+
+    pub fn public_identity(&self) -> Result<DevicePublicIdentity, ContinuationCryptoError> {
+        let age_identity = self.age_identity()?;
+        let encryption_public_key = raw_age_recipient(&age_identity.to_public())?;
+        let signing_key = SigningKey::from_bytes(&self.signing_secret);
+        let signing_public_key = signing_key.verifying_key().to_bytes();
+        let fingerprint = device_fingerprint(&encryption_public_key, &signing_public_key);
+        DevicePublicIdentity::try_new(
+            self.device_id,
+            self.key_version,
+            encryption_public_key,
+            signing_public_key,
+            fingerprint,
+        )
+    }
+
+    pub(crate) fn age_identity(&self) -> Result<age::x25519::Identity, ContinuationCryptoError> {
+        age::x25519::Identity::from_str(self.age_secret.as_str())
+            .map_err(|_| ContinuationCryptoError::CorruptIdentity("invalid age X25519 secret"))
+    }
+
+    pub(crate) fn sign(&self, message: &[u8]) -> [u8; 64] {
+        SigningKey::from_bytes(&self.signing_secret)
+            .sign(message)
+            .to_bytes()
+    }
+
+    pub(crate) fn verify_own_public(
+        &self,
+        public: &DevicePublicIdentity,
+    ) -> Result<(), ContinuationCryptoError> {
+        if self.public_identity()? == *public {
+            Ok(())
+        } else {
+            Err(ContinuationCryptoError::WrongRecipient)
+        }
+    }
+}
+
+pub(crate) fn verify_signature(
+    public: &DevicePublicIdentity,
+    message: &[u8],
+    signature: &[u8; 64],
+) -> Result<(), ContinuationCryptoError> {
+    let key = VerifyingKey::from_bytes(&public.signing_public_key)
+        .map_err(|_| ContinuationCryptoError::InvalidSignature)?;
+    let signature = ed25519_dalek::Signature::from_bytes(signature);
+    key.verify_strict(message, &signature)
+        .map_err(|_| ContinuationCryptoError::InvalidSignature)
+}
+
+pub fn device_fingerprint(
+    encryption_public_key: &[u8; 32],
+    signing_public_key: &[u8; 32],
+) -> [u8; 32] {
+    let mut digest = Sha256::new();
+    digest.update(DEVICE_FINGERPRINT_DOMAIN);
+    digest.update([0]);
+    digest.update(encryption_public_key);
+    digest.update(signing_public_key);
+    digest.finalize().into()
+}
+
+fn raw_age_recipient(
+    recipient: &age::x25519::Recipient,
+) -> Result<[u8; 32], ContinuationCryptoError> {
+    let encoded = recipient.to_string();
+    let (hrp, bytes) = bech32::decode(&encoded).map_err(|_| {
+        ContinuationCryptoError::CorruptIdentity("invalid age X25519 recipient encoding")
+    })?;
+    if hrp.as_str() != "age" || bytes.len() != 32 {
+        return Err(ContinuationCryptoError::CorruptIdentity(
+            "unexpected age X25519 recipient encoding",
+        ));
+    }
+    bytes.try_into().map_err(|_| {
+        ContinuationCryptoError::CorruptIdentity("unexpected age X25519 public-key length")
+    })
+}
+
+pub(crate) fn age_recipient_from_raw(
+    raw: &[u8; 32],
+) -> Result<age::x25519::Recipient, ContinuationCryptoError> {
+    let hrp = bech32::Hrp::parse("age")
+        .map_err(|_| ContinuationCryptoError::InvalidIdentity("invalid age recipient HRP"))?;
+    let encoded = bech32::encode::<bech32::Bech32>(hrp, raw)
+        .map_err(|_| ContinuationCryptoError::InvalidIdentity("cannot encode age recipient"))?;
+    age::x25519::Recipient::from_str(&encoded)
+        .map_err(|_| ContinuationCryptoError::InvalidIdentity("invalid age X25519 public key"))
+}
+
+fn generate_key(device_id: Uuid, key_version: u32) -> StoredKey {
+    let age_identity = age::x25519::Identity::generate();
+    let age_secret = age_identity.to_string();
+    let signing_key = SigningKey::generate(&mut OsRng);
+    StoredKey {
+        key_version,
+        age_secret: Zeroizing::new(age_secret.expose_secret().to_owned()),
+        signing_secret: Zeroizing::new(signing_key.to_bytes()),
+        device_id,
+    }
+}
+
+struct StoredKey {
+    key_version: u32,
+    age_secret: Zeroizing<String>,
+    signing_secret: Zeroizing<[u8; 32]>,
+    device_id: Uuid,
+}
+
+impl StoredKey {
+    fn into_private(self) -> DevicePrivateIdentity {
+        DevicePrivateIdentity {
+            device_id: self.device_id,
+            key_version: self.key_version,
+            age_secret: self.age_secret,
+            signing_secret: self.signing_secret,
+        }
+    }
+
+    fn encode(&self) -> Result<SecretBytes, ContinuationCryptoError> {
+        let age_bytes = self.age_secret.as_bytes();
+        if age_bytes.is_empty() || age_bytes.len() > MAX_AGE_SECRET_BYTES {
+            return Err(ContinuationCryptoError::CorruptIdentity(
+                "invalid age secret length",
+            ));
+        }
+        let public = self.public_identity()?;
+        let mut bytes = Zeroizing::new(Vec::with_capacity(384));
+        bytes.extend_from_slice(KEY_RECORD_MAGIC);
+        bytes.extend_from_slice(&SECRET_RECORD_VERSION.to_be_bytes());
+        bytes.extend_from_slice(self.device_id.as_bytes());
+        bytes.extend_from_slice(&self.key_version.to_be_bytes());
+        bytes.extend_from_slice(&(age_bytes.len() as u16).to_be_bytes());
+        bytes.extend_from_slice(age_bytes);
+        bytes.extend_from_slice(self.signing_secret.as_slice());
+        bytes.extend_from_slice(&public.fingerprint);
+        let checksum = record_checksum(PRIVATE_KEY_CHECKSUM_DOMAIN, &bytes);
+        bytes.extend_from_slice(&checksum);
+        Ok(SecretBytes::new(std::mem::take(&mut *bytes)))
+    }
+
+    fn decode(
+        expected_device_id: Uuid,
+        expected_version: u32,
+        secret: &SecretBytes,
+    ) -> Result<Self, ContinuationCryptoError> {
+        let bytes = secret.as_slice();
+        if bytes.len() < 8 + 2 + 16 + 4 + 2 + 1 + 32 + 32 + 32 {
+            return Err(ContinuationCryptoError::CorruptIdentity(
+                "truncated private key record",
+            ));
+        }
+        let (body, encoded_checksum) = bytes.split_at(bytes.len() - 32);
+        if record_checksum(PRIVATE_KEY_CHECKSUM_DOMAIN, body).as_slice() != encoded_checksum {
+            return Err(ContinuationCryptoError::CorruptIdentity(
+                "private key record checksum mismatch",
+            ));
+        }
+        let mut cursor = SecretCursor::new(body);
+        if cursor.take(8)? != KEY_RECORD_MAGIC || cursor.u16()? != SECRET_RECORD_VERSION {
+            return Err(ContinuationCryptoError::CorruptIdentity(
+                "unsupported private key record",
+            ));
+        }
+        let device_id = Uuid::from_bytes(cursor.array()?);
+        let key_version = cursor.u32()?;
+        if device_id != expected_device_id || key_version != expected_version {
+            return Err(ContinuationCryptoError::CorruptIdentity(
+                "private key record identity mismatch",
+            ));
+        }
+        validate_key_version(key_version)?;
+        let age_len = cursor.u16()? as usize;
+        if age_len == 0 || age_len > MAX_AGE_SECRET_BYTES {
+            return Err(ContinuationCryptoError::CorruptIdentity(
+                "invalid age secret length",
+            ));
+        }
+        let age_secret = Zeroizing::new(
+            std::str::from_utf8(cursor.take(age_len)?)
+                .map_err(|_| ContinuationCryptoError::CorruptIdentity("age secret is not UTF-8"))?
+                .to_owned(),
+        );
+        let signing_secret = Zeroizing::new(cursor.array()?);
+        let encoded_fingerprint: [u8; 32] = cursor.array()?;
+        if !cursor.is_empty() {
+            return Err(ContinuationCryptoError::CorruptIdentity(
+                "trailing private key record bytes",
+            ));
+        }
+        let key = Self {
+            key_version,
+            age_secret,
+            signing_secret,
+            device_id,
+        };
+        if key.public_identity()?.fingerprint != encoded_fingerprint {
+            return Err(ContinuationCryptoError::CorruptIdentity(
+                "private key public fingerprint mismatch",
+            ));
+        }
+        Ok(key)
+    }
+
+    fn public_identity(&self) -> Result<DevicePublicIdentity, ContinuationCryptoError> {
+        let age_identity = age::x25519::Identity::from_str(self.age_secret.as_str())
+            .map_err(|_| ContinuationCryptoError::CorruptIdentity("invalid age X25519 secret"))?;
+        let encryption_public_key = raw_age_recipient(&age_identity.to_public())?;
+        let signing_public_key = SigningKey::from_bytes(&self.signing_secret)
+            .verifying_key()
+            .to_bytes();
+        DevicePublicIdentity::try_new(
+            self.device_id,
+            self.key_version,
+            encryption_public_key,
+            signing_public_key,
+            device_fingerprint(&encryption_public_key, &signing_public_key),
+        )
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct ActivePointer {
+    device_id: Uuid,
+    active_version: u32,
+    generation: u64,
+    active_fingerprint: [u8; 32],
+}
+
+impl ActivePointer {
+    fn encode(&self) -> SecretBytes {
+        let mut bytes = Zeroizing::new(Vec::with_capacity(102));
+        bytes.extend_from_slice(ACTIVE_POINTER_MAGIC);
+        bytes.extend_from_slice(&SECRET_RECORD_VERSION.to_be_bytes());
+        bytes.extend_from_slice(self.device_id.as_bytes());
+        bytes.extend_from_slice(&self.active_version.to_be_bytes());
+        bytes.extend_from_slice(&self.generation.to_be_bytes());
+        bytes.extend_from_slice(&self.active_fingerprint);
+        let checksum = record_checksum(ACTIVE_POINTER_CHECKSUM_DOMAIN, &bytes);
+        bytes.extend_from_slice(&checksum);
+        SecretBytes::new(std::mem::take(&mut *bytes))
+    }
+
+    fn decode(
+        expected_device_id: Uuid,
+        secret: &SecretBytes,
+    ) -> Result<Self, ContinuationCryptoError> {
+        let bytes = secret.as_slice();
+        const BODY_LEN: usize = 8 + 2 + 16 + 4 + 8 + 32;
+        if bytes.len() != BODY_LEN + 32 {
+            return Err(ContinuationCryptoError::CorruptIdentity(
+                "active pointer has wrong length",
+            ));
+        }
+        let (body, encoded_checksum) = bytes.split_at(BODY_LEN);
+        if record_checksum(ACTIVE_POINTER_CHECKSUM_DOMAIN, body).as_slice() != encoded_checksum {
+            return Err(ContinuationCryptoError::CorruptIdentity(
+                "active pointer checksum mismatch",
+            ));
+        }
+        let mut cursor = SecretCursor::new(body);
+        if cursor.take(8)? != ACTIVE_POINTER_MAGIC || cursor.u16()? != SECRET_RECORD_VERSION {
+            return Err(ContinuationCryptoError::CorruptIdentity(
+                "unsupported active pointer",
+            ));
+        }
+        let pointer = Self {
+            device_id: Uuid::from_bytes(cursor.array()?),
+            active_version: cursor.u32()?,
+            generation: cursor.u64()?,
+            active_fingerprint: cursor.array()?,
+        };
+        if pointer.device_id != expected_device_id || pointer.generation == 0 || !cursor.is_empty()
+        {
+            return Err(ContinuationCryptoError::CorruptIdentity(
+                "invalid active pointer fields",
+            ));
+        }
+        validate_key_version(pointer.active_version)?;
+        Ok(pointer)
+    }
+}
+
+fn record_checksum(domain: &[u8], bytes: &[u8]) -> [u8; 32] {
+    let mut digest = Sha256::new();
+    digest.update(domain);
+    digest.update([0]);
+    digest.update(bytes);
+    digest.finalize().into()
+}
+
+struct SecretCursor<'a> {
+    bytes: &'a [u8],
+    position: usize,
+}
+
+impl<'a> SecretCursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, position: 0 }
+    }
+
+    fn take(&mut self, length: usize) -> Result<&'a [u8], ContinuationCryptoError> {
+        let end =
+            self.position
+                .checked_add(length)
+                .ok_or(ContinuationCryptoError::CorruptIdentity(
+                    "identity length overflow",
+                ))?;
+        let value =
+            self.bytes
+                .get(self.position..end)
+                .ok_or(ContinuationCryptoError::CorruptIdentity(
+                    "truncated identity record",
+                ))?;
+        self.position = end;
+        Ok(value)
+    }
+
+    fn array<const N: usize>(&mut self) -> Result<[u8; N], ContinuationCryptoError> {
+        self.take(N)?.try_into().map_err(|_| {
+            ContinuationCryptoError::CorruptIdentity("truncated fixed-width identity field")
+        })
+    }
+
+    fn u16(&mut self) -> Result<u16, ContinuationCryptoError> {
+        Ok(u16::from_be_bytes(self.array()?))
+    }
+    fn u32(&mut self) -> Result<u32, ContinuationCryptoError> {
+        Ok(u32::from_be_bytes(self.array()?))
+    }
+    fn u64(&mut self) -> Result<u64, ContinuationCryptoError> {
+        Ok(u64::from_be_bytes(self.array()?))
+    }
+    fn is_empty(&self) -> bool {
+        self.position == self.bytes.len()
+    }
+}
+
+/// Serialized identity manager with a per-profile cross-process lock and CAS.
+pub struct DeviceIdentityManager<S> {
+    store: S,
+    staging: PrivateStagingDirectory,
+    operation_gate: Mutex<()>,
+}
+
+impl<S: DeviceSecretStore> DeviceIdentityManager<S> {
+    pub fn new(store: S, staging: PrivateStagingDirectory) -> Self {
+        Self {
+            store,
+            staging,
+            operation_gate: Mutex::new(()),
+        }
+    }
+
+    pub fn load_current(
+        &self,
+        device_id: Uuid,
+    ) -> Result<DevicePrivateIdentity, ContinuationCryptoError> {
+        let _guard = self.lock_in_process()?;
+        let _process_lock = self.lock_profile(device_id)?;
+        let pointer = self
+            .load_pointer(device_id)?
+            .ok_or(ContinuationCryptoError::IdentityMissing)?;
+        self.load_pointer_key(&pointer)
+    }
+
+    pub fn load_version(
+        &self,
+        device_id: Uuid,
+        key_version: u32,
+    ) -> Result<DevicePrivateIdentity, ContinuationCryptoError> {
+        validate_key_version(key_version)?;
+        let _guard = self.lock_in_process()?;
+        let _process_lock = self.lock_profile(device_id)?;
+        self.load_key(device_id, key_version)?
+            .map(StoredKey::into_private)
+            .ok_or(ContinuationCryptoError::KeyVersionMissing(key_version))
+    }
+
+    pub fn load_or_create(
+        &self,
+        device_id: Uuid,
+    ) -> Result<DevicePrivateIdentity, ContinuationCryptoError> {
+        let _guard = self.lock_in_process()?;
+        let _process_lock = self.lock_profile(device_id)?;
+        if let Some(pointer) = self.load_pointer(device_id)? {
+            return self.load_pointer_key(&pointer);
+        }
+        let key = match self.load_key(device_id, 1)? {
+            Some(key) => key,
+            None => {
+                let key = generate_key(device_id, 1);
+                self.persist_key_if_absent(&key)?;
+                self.load_key(device_id, 1)?
+                    .ok_or(SecretStoreError::Unavailable)?
+            }
+        };
+        let public = key.public_identity()?;
+        let next = ActivePointer {
+            device_id,
+            active_version: 1,
+            generation: 1,
+            active_fingerprint: public.fingerprint,
+        };
+        self.store_pointer_cas(device_id, None, &next)?;
+        self.load_pointer_key(&next)
+    }
+
+    pub fn rotate(
+        &self,
+        device_id: Uuid,
+    ) -> Result<DevicePrivateIdentity, ContinuationCryptoError> {
+        let _guard = self.lock_in_process()?;
+        let _process_lock = self.lock_profile(device_id)?;
+        let current = self
+            .load_pointer(device_id)?
+            .ok_or(ContinuationCryptoError::IdentityMissing)?;
+        let next_version = current
+            .active_version
+            .checked_add(1)
+            .filter(|value| *value <= SQL_MAX_KEY_VERSION)
+            .ok_or(ContinuationCryptoError::KeyVersionExhausted)?;
+        let key = match self.load_key(device_id, next_version)? {
+            Some(key) => key,
+            None => {
+                let key = generate_key(device_id, next_version);
+                self.persist_key_if_absent(&key)?;
+                self.load_key(device_id, next_version)?
+                    .ok_or(SecretStoreError::Unavailable)?
+            }
+        };
+        let next = ActivePointer {
+            device_id,
+            active_version: next_version,
+            generation: current
+                .generation
+                .checked_add(1)
+                .ok_or(ContinuationCryptoError::KeyVersionExhausted)?,
+            active_fingerprint: key.public_identity()?.fingerprint,
+        };
+        self.store_pointer_cas(device_id, Some(&current), &next)?;
+        self.load_pointer_key(&next)
+    }
+
+    fn lock_in_process(&self) -> Result<std::sync::MutexGuard<'_, ()>, SecretStoreError> {
+        self.operation_gate
+            .lock()
+            .map_err(|_| SecretStoreError::Unavailable)
+    }
+
+    fn lock_profile(&self, device_id: Uuid) -> Result<std::fs::File, ContinuationCryptoError> {
+        self.staging.transaction_lock_file(&device_id.to_string())
+    }
+
+    fn load_pointer(
+        &self,
+        device_id: Uuid,
+    ) -> Result<Option<ActivePointer>, ContinuationCryptoError> {
+        self.store
+            .load(&active_entry_id(device_id))?
+            .map(|secret| ActivePointer::decode(device_id, &secret))
+            .transpose()
+    }
+
+    fn load_key(
+        &self,
+        device_id: Uuid,
+        key_version: u32,
+    ) -> Result<Option<StoredKey>, ContinuationCryptoError> {
+        self.store
+            .load(&key_entry_id(device_id, key_version))?
+            .map(|secret| StoredKey::decode(device_id, key_version, &secret))
+            .transpose()
+    }
+
+    fn load_pointer_key(
+        &self,
+        pointer: &ActivePointer,
+    ) -> Result<DevicePrivateIdentity, ContinuationCryptoError> {
+        let key = self
+            .load_key(pointer.device_id, pointer.active_version)?
+            .ok_or(ContinuationCryptoError::KeyVersionMissing(
+                pointer.active_version,
+            ))?;
+        if key.public_identity()?.fingerprint != pointer.active_fingerprint {
+            return Err(ContinuationCryptoError::CorruptIdentity(
+                "active pointer fingerprint mismatch",
+            ));
+        }
+        Ok(key.into_private())
+    }
+
+    fn persist_key_if_absent(&self, key: &StoredKey) -> Result<(), ContinuationCryptoError> {
+        let entry_id = key_entry_id(key.device_id, key.key_version);
+        if self.store.load(&entry_id)?.is_some() {
+            return Err(ContinuationCryptoError::IdentityConflict);
+        }
+        self.store.store(&entry_id, &key.encode()?)?;
+        let persisted = self
+            .store
+            .load(&entry_id)?
+            .ok_or(SecretStoreError::Unavailable)?;
+        let decoded = StoredKey::decode(key.device_id, key.key_version, &persisted)?;
+        if decoded.public_identity()? != key.public_identity()? {
+            return Err(ContinuationCryptoError::IdentityConflict);
+        }
+        Ok(())
+    }
+
+    fn store_pointer_cas(
+        &self,
+        device_id: Uuid,
+        expected: Option<&ActivePointer>,
+        next: &ActivePointer,
+    ) -> Result<(), ContinuationCryptoError> {
+        if self.load_pointer(device_id)?.as_ref() != expected {
+            return Err(ContinuationCryptoError::IdentityConflict);
+        }
+        self.store
+            .store(&active_entry_id(device_id), &next.encode())?;
+        if self.load_pointer(device_id)?.as_ref() != Some(next) {
+            return Err(ContinuationCryptoError::IdentityConflict);
+        }
+        Ok(())
+    }
+}
+
+fn active_entry_id(device_id: Uuid) -> String {
+    format!("device:{device_id}:active")
+}
+fn key_entry_id(device_id: Uuid, key_version: u32) -> String {
+    format!("device:{device_id}:key:{key_version}")
+}
+
+fn validate_key_version(key_version: u32) -> Result<(), ContinuationCryptoError> {
+    if key_version == 0 || key_version > SQL_MAX_KEY_VERSION {
+        return Err(ContinuationCryptoError::InvalidIdentity(
+            "key version must be in positive SQL int range",
+        ));
+    }
+    Ok(())
+}

--- a/src-tauri/crates/continuation-crypto/src/lib.rs
+++ b/src-tauri/crates/continuation-crypto/src/lib.rs
@@ -1,0 +1,60 @@
+//! Secure local foundations for portable continuation checkpoints.
+//!
+//! This crate deliberately contains no Tauri commands, network client, cloud
+//! schema, Work Item activation, or agent-runtime policy. It owns only:
+//!
+//! - OS-secure device identity persistence and key rotation;
+//! - the versioned raw-binary handoff envelope contract;
+//! - standard age X25519 streaming encryption plus Ed25519 authentication;
+//! - a bounded gzip-compressed manifest/event/blob/footer stream; and
+//! - crash-safe owner-only ciphertext publication.
+//!
+//! Encryption, compression, secure-store access, fsync, and decryption are
+//! synchronous blocking operations. Async/Tauri integrations must run them on
+//! a dedicated blocking worker rather than an executor or render-critical
+//! thread.
+//!
+//! Private key material never implements `Debug` or serde traits and is kept
+//! in [`zeroize::Zeroizing`] containers whenever it is represented as bytes.
+
+mod atomic_file;
+mod envelope;
+mod error;
+mod framed_stream;
+mod identity;
+mod secret_store;
+mod staging;
+mod wire;
+
+pub use envelope::{
+    decrypt_cloud_checkpoint, write_cloud_checkpoint_atomic, CloudCheckpointDecryptRequest,
+    CloudEnvelopeMetadata, CloudEnvelopeWriteRequest, CloudProfile, CommittedCloudEnvelope,
+    CommittedCloudEnvelopeSql, CommittedRecipientReceipt, CommittedRecipientReceiptSql,
+    EnvelopeArtifact, VerifiedEnvelope,
+};
+#[cfg(test)]
+pub(crate) use envelope::{
+    decrypt_local_checkpoint, write_local_checkpoint_atomic, LocalEnvelopeWriteRequest,
+    LocalProfile,
+};
+pub use error::{ContinuationCryptoError, LimitKind, SecretStoreError};
+pub use framed_stream::{
+    BlobMetadata, CheckpointEvent, CheckpointFooter, CheckpointLimits, CheckpointManifest,
+    CheckpointPlaintextHasher, CheckpointPlaintextSummary, CheckpointRecordWriter, CheckpointSink,
+    CLOUD_CHECKPOINT_LIMITS, LOCAL_CHECKPOINT_LIMITS,
+};
+pub use identity::{
+    device_fingerprint, DeviceIdentityManager, DevicePrivateIdentity, DevicePublicIdentity,
+    DEVICE_FINGERPRINT_DOMAIN,
+};
+pub use secret_store::{DeviceSecretStore, KeyringDeviceSecretStore, SecretBytes};
+pub use staging::PrivateStagingDirectory;
+pub use wire::{
+    canonical_header_bytes, signature_message, CloudRecipient, CloudRecipientSet,
+    CompressionAlgorithm, ContinuationEnvelopeHeader, EncryptionAlgorithm, HashAlgorithm,
+    RecipientScope, SignatureAlgorithm, ENVELOPE_END_MAGIC, ENVELOPE_MAGIC, ENVELOPE_VERSION,
+    MAX_ENVELOPE_RECIPIENTS, RECIPIENT_SET_HASH_DOMAIN, SIGNATURE_BYTES, SIGNATURE_DOMAIN,
+};
+
+#[cfg(test)]
+mod tests;

--- a/src-tauri/crates/continuation-crypto/src/secret_store.rs
+++ b/src-tauri/crates/continuation-crypto/src/secret_store.rs
@@ -1,0 +1,111 @@
+use std::sync::{Mutex, OnceLock};
+
+use zeroize::Zeroizing;
+
+use crate::SecretStoreError;
+
+const KEYRING_SERVICE: &str = "ai.org2.continuation-device";
+
+pub(crate) mod sealed {
+    pub trait Sealed {}
+}
+
+/// Secret bytes with deterministic zeroization and no `Debug`/serde surface.
+pub struct SecretBytes(Zeroizing<Vec<u8>>);
+
+impl SecretBytes {
+    pub fn new(bytes: Vec<u8>) -> Self {
+        Self(Zeroizing::new(bytes))
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}
+
+/// Minimal secure-store capability required by the identity manager.
+///
+/// `Ok(None)` means the named device has never initialized an identity.
+/// Backend lock, availability, permission, and corruption failures are errors;
+/// implementations must never silently fall back to a file or memory secret.
+pub trait DeviceSecretStore: sealed::Sealed + Send + Sync {
+    fn load(&self, entry_id: &str) -> Result<Option<SecretBytes>, SecretStoreError>;
+    fn store(&self, entry_id: &str, secret: &SecretBytes) -> Result<(), SecretStoreError>;
+}
+
+/// Production secure store backed by Keychain, Windows Credential Manager, or
+/// Linux Secret Service according to the compilation target.
+#[derive(Clone, Copy, Default)]
+pub struct KeyringDeviceSecretStore;
+
+impl sealed::Sealed for KeyringDeviceSecretStore {}
+
+fn keyring_access_gate() -> &'static Mutex<()> {
+    static GATE: OnceLock<Mutex<()>> = OnceLock::new();
+    GATE.get_or_init(|| Mutex::new(()))
+}
+
+#[cfg(any(target_os = "macos", windows, target_os = "linux"))]
+fn entry(device_id: &str) -> Result<keyring::Entry, SecretStoreError> {
+    keyring::Entry::new(KEYRING_SERVICE, device_id).map_err(|_| SecretStoreError::Unavailable)
+}
+
+#[cfg(any(target_os = "macos", windows, target_os = "linux"))]
+fn map_load_error(error: keyring::Error) -> Result<Option<SecretBytes>, SecretStoreError> {
+    match error {
+        keyring::Error::NoEntry => Ok(None),
+        keyring::Error::Ambiguous(_) => Err(SecretStoreError::Ambiguous),
+        keyring::Error::PlatformFailure(_) => Err(SecretStoreError::Unavailable),
+        keyring::Error::NoStorageAccess(_) => Err(SecretStoreError::AccessDenied),
+        _ => Err(SecretStoreError::Unavailable),
+    }
+}
+
+impl DeviceSecretStore for KeyringDeviceSecretStore {
+    fn load(&self, device_id: &str) -> Result<Option<SecretBytes>, SecretStoreError> {
+        #[cfg(any(target_os = "macos", windows, target_os = "linux"))]
+        {
+            let _guard = keyring_access_gate()
+                .lock()
+                .map_err(|_| SecretStoreError::Unavailable)?;
+            match entry(device_id)?.get_secret() {
+                Ok(secret) => Ok(Some(SecretBytes::new(secret))),
+                Err(error) => map_load_error(error),
+            }
+        }
+
+        #[cfg(not(any(target_os = "macos", windows, target_os = "linux")))]
+        {
+            let _ = device_id;
+            Err(SecretStoreError::Unavailable)
+        }
+    }
+
+    fn store(&self, device_id: &str, secret: &SecretBytes) -> Result<(), SecretStoreError> {
+        #[cfg(any(target_os = "macos", windows, target_os = "linux"))]
+        {
+            let _guard = keyring_access_gate()
+                .lock()
+                .map_err(|_| SecretStoreError::Unavailable)?;
+            entry(device_id)?
+                .set_secret(secret.as_slice())
+                .map_err(|_| SecretStoreError::Rejected)
+        }
+
+        #[cfg(not(any(target_os = "macos", windows, target_os = "linux")))]
+        {
+            let _ = (device_id, secret);
+            Err(SecretStoreError::Unavailable)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn production_service_name_is_nonempty_and_domain_scoped() {
+        assert_eq!(KEYRING_SERVICE, "ai.org2.continuation-device");
+    }
+}

--- a/src-tauri/crates/continuation-crypto/src/staging.rs
+++ b/src-tauri/crates/continuation-crypto/src/staging.rs
@@ -1,0 +1,875 @@
+use std::{
+    fs::File,
+    path::{Path, PathBuf},
+};
+
+use crate::ContinuationCryptoError;
+
+const MAX_JOB_ID_BYTES: usize = 64;
+const MAX_ARTIFACT_NAME_BYTES: usize = 128;
+
+/// Validated capability for an app-private continuation staging directory.
+///
+/// Construction canonicalizes the directory and verifies that it is owned by
+/// the current OS user and inaccessible to other users. A missing final
+/// directory is created owner-only under an existing parent; production never
+/// chmods or rewrites the ACL of an existing caller-supplied directory. All
+/// named staging and anonymous snapshot files are created through this
+/// capability.
+#[derive(Clone)]
+pub struct PrivateStagingDirectory {
+    root: PathBuf,
+}
+
+impl PrivateStagingDirectory {
+    pub fn create(path: &Path) -> Result<Self, ContinuationCryptoError> {
+        if !path.is_absolute() {
+            return Err(ContinuationCryptoError::InvalidStaging(
+                "staging directory must be absolute",
+            ));
+        }
+        let created = !path.exists();
+        if created {
+            create_private_directory(path)?;
+            // Defense in depth after owner-only creation; the subsequent
+            // read-back verification remains authoritative.
+            secure_private_directory(path)?;
+        }
+        let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+            ContinuationCryptoError::io("inspecting private staging directory", error)
+        })?;
+        if !metadata.is_dir() || metadata.file_type().is_symlink() {
+            return Err(ContinuationCryptoError::InvalidStaging(
+                "staging capability must name a real directory",
+            ));
+        }
+        // Unit tests use `tempfile` roots whose inherited Windows ACL is not
+        // owner-only. Production never mutates an existing directory: it must
+        // already be an app-private capability or construction fails closed.
+        #[cfg(test)]
+        if !created {
+            secure_private_directory(path)?;
+        }
+        let root = std::fs::canonicalize(path).map_err(|error| {
+            ContinuationCryptoError::io("canonicalizing private staging directory", error)
+        })?;
+        verify_private_directory(&root)?;
+        Ok(Self { root })
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn cleanup_job(&self, job_id: &str) -> Result<u32, ContinuationCryptoError> {
+        validate_job_id(job_id)?;
+        let prefix = format!(".org2-continuation-{job_id}-");
+        let mut removed = 0u32;
+        let entries = std::fs::read_dir(&self.root).map_err(|error| {
+            ContinuationCryptoError::io("scanning continuation staging directory", error)
+        })?;
+        for entry in entries {
+            let entry = entry.map_err(|error| {
+                ContinuationCryptoError::io("reading continuation staging entry", error)
+            })?;
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else {
+                continue;
+            };
+            if !name.starts_with(&prefix) || !name.ends_with(".ciphertext.tmp") {
+                continue;
+            }
+            let metadata = std::fs::symlink_metadata(entry.path()).map_err(|error| {
+                ContinuationCryptoError::io("inspecting continuation staging entry", error)
+            })?;
+            if !metadata.is_file() || metadata.file_type().is_symlink() {
+                return Err(ContinuationCryptoError::InvalidStaging(
+                    "job staging entry is not a regular file",
+                ));
+            }
+            std::fs::remove_file(entry.path()).map_err(|error| {
+                ContinuationCryptoError::io("removing stale job ciphertext", error)
+            })?;
+            removed = removed
+                .checked_add(1)
+                .ok_or(ContinuationCryptoError::InvalidStaging(
+                    "staging cleanup count overflow",
+                ))?;
+        }
+        sync_directory(&self.root)?;
+        Ok(removed)
+    }
+
+    pub(crate) fn named_ciphertext(
+        &self,
+        job_id: &str,
+    ) -> Result<tempfile::NamedTempFile, ContinuationCryptoError> {
+        validate_job_id(job_id)?;
+        let prefix = format!(".org2-continuation-{job_id}-");
+        let mut builder = tempfile::Builder::new();
+        builder.prefix(&prefix).suffix(".ciphertext.tmp");
+        #[cfg(unix)]
+        let temp = builder.tempfile_in(&self.root).map_err(|error| {
+            ContinuationCryptoError::io("creating private ciphertext staging file", error)
+        })?;
+        #[cfg(windows)]
+        let temp = builder
+            .make_in(&self.root, |path| {
+                windows_security::create_private_file(path, false)
+            })
+            .map_err(|error| {
+                ContinuationCryptoError::io("creating private ciphertext staging file", error)
+            })?;
+        secure_owner_only_file(temp.path())?;
+        Ok(temp)
+    }
+
+    pub(crate) fn anonymous_ciphertext(&self) -> Result<File, ContinuationCryptoError> {
+        #[cfg(unix)]
+        let file = tempfile::tempfile_in(&self.root).map_err(|error| {
+            ContinuationCryptoError::io("creating anonymous ciphertext snapshot", error)
+        })?;
+        #[cfg(windows)]
+        let file = tempfile::Builder::new()
+            .prefix(".org2-continuation-snapshot-")
+            .suffix(".ciphertext.tmp")
+            .make_in(&self.root, |path| {
+                windows_security::create_private_file(path, true)
+            })
+            .map_err(|error| {
+                ContinuationCryptoError::io("creating delete-on-close ciphertext snapshot", error)
+            })?
+            .into_file();
+        verify_owner_only_file(&file)?;
+        Ok(file)
+    }
+
+    pub(crate) fn validate_destination(
+        &self,
+        destination: &Path,
+    ) -> Result<PathBuf, ContinuationCryptoError> {
+        let parent = destination
+            .parent()
+            .ok_or(ContinuationCryptoError::InvalidStaging(
+                "artifact destination has no parent",
+            ))?;
+        let canonical_parent = std::fs::canonicalize(parent).map_err(|error| {
+            ContinuationCryptoError::io("canonicalizing artifact destination parent", error)
+        })?;
+        if canonical_parent != self.root {
+            return Err(ContinuationCryptoError::InvalidStaging(
+                "artifact destination must be inside the private staging capability",
+            ));
+        }
+        let artifact_name = destination
+            .file_name()
+            .and_then(|value| value.to_str())
+            .ok_or(ContinuationCryptoError::InvalidStaging(
+                "artifact destination name is not canonical UTF-8",
+            ))?;
+        validate_artifact_name(artifact_name)?;
+        Ok(self.root.join(artifact_name))
+    }
+
+    pub(crate) fn transaction_lock_file(
+        &self,
+        profile_id: &str,
+    ) -> Result<File, ContinuationCryptoError> {
+        validate_job_id(profile_id)?;
+        let path = self.root.join(format!(".identity-{profile_id}.lock"));
+        #[cfg(unix)]
+        let file = {
+            let mut options = std::fs::OpenOptions::new();
+            options.read(true).write(true).create(true);
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+            options.open(&path).map_err(|error| {
+                ContinuationCryptoError::io("opening profile transaction lock", error)
+            })?
+        };
+        #[cfg(windows)]
+        let file = windows_security::open_private_lock_file(&path).map_err(|error| {
+            ContinuationCryptoError::io("opening profile transaction lock", error)
+        })?;
+        secure_owner_only_file(&path)?;
+        lock_profile_file(&file)?;
+        Ok(file)
+    }
+}
+
+#[cfg(unix)]
+fn lock_profile_file(file: &File) -> Result<(), ContinuationCryptoError> {
+    use std::os::fd::AsRawFd;
+    let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(ContinuationCryptoError::io(
+            "locking identity profile",
+            std::io::Error::last_os_error(),
+        ))
+    }
+}
+
+#[cfg(windows)]
+fn lock_profile_file(_file: &File) -> Result<(), ContinuationCryptoError> {
+    // `open_private_lock_file` acquires the range lock on the same handle
+    // before returning it. Keeping that handle alive is the lock guard.
+    Ok(())
+}
+
+fn validate_job_id(value: &str) -> Result<(), ContinuationCryptoError> {
+    if value.is_empty()
+        || value.len() > MAX_JOB_ID_BYTES
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+    {
+        return Err(ContinuationCryptoError::InvalidStaging(
+            "job/profile id must be lowercase ASCII alphanumeric or hyphen",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_artifact_name(value: &str) -> Result<(), ContinuationCryptoError> {
+    let mut bytes = value.bytes();
+    let Some(first) = bytes.next() else {
+        return Err(ContinuationCryptoError::InvalidStaging(
+            "artifact name must be one bounded portable path component",
+        ));
+    };
+    if value.len() > MAX_ARTIFACT_NAME_BYTES
+        || !(first.is_ascii_lowercase() || first.is_ascii_digit())
+        || value.ends_with('.')
+        || value.contains("..")
+        || !bytes.all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'_' | b'-')
+        })
+    {
+        return Err(ContinuationCryptoError::InvalidStaging(
+            "artifact name must match the lowercase portable allowlist",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn create_private_directory(path: &Path) -> Result<(), ContinuationCryptoError> {
+    use std::os::unix::fs::DirBuilderExt;
+    let mut builder = std::fs::DirBuilder::new();
+    // Never recursively create or chmod an unresolved ancestor. The caller
+    // must supply an existing app-private parent capability.
+    builder.recursive(false).mode(0o700);
+    builder
+        .create(path)
+        .map_err(|error| ContinuationCryptoError::io("creating private staging directory", error))
+}
+
+#[cfg(windows)]
+fn create_private_directory(path: &Path) -> Result<(), ContinuationCryptoError> {
+    windows_security::create_or_secure_private_directory(path)
+        .map_err(|error| ContinuationCryptoError::io("creating private staging directory", error))
+}
+
+#[cfg(unix)]
+fn secure_private_directory(path: &Path) -> Result<(), ContinuationCryptoError> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+        .map_err(|error| ContinuationCryptoError::io("securing staging directory", error))
+}
+
+#[cfg(unix)]
+fn verify_private_directory(path: &Path) -> Result<(), ContinuationCryptoError> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+    let metadata = std::fs::metadata(path)
+        .map_err(|error| ContinuationCryptoError::io("verifying staging directory", error))?;
+    if metadata.uid() != unsafe { libc::geteuid() } || metadata.permissions().mode() & 0o077 != 0 {
+        return Err(ContinuationCryptoError::InvalidStaging(
+            "staging directory is not current-user private",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn secure_owner_only_file(path: &Path) -> Result<(), ContinuationCryptoError> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+        .map_err(|error| ContinuationCryptoError::io("securing staging file", error))?;
+    let file = File::open(path)
+        .map_err(|error| ContinuationCryptoError::io("opening secured staging file", error))?;
+    verify_owner_only_file(&file)
+}
+
+#[cfg(unix)]
+fn verify_owner_only_file(file: &File) -> Result<(), ContinuationCryptoError> {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+    let metadata = file
+        .metadata()
+        .map_err(|error| ContinuationCryptoError::io("verifying staging file", error))?;
+    if metadata.uid() != unsafe { libc::geteuid() } || metadata.permissions().mode() & 0o077 != 0 {
+        return Err(ContinuationCryptoError::InvalidStaging(
+            "staging file is not current-user private",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn secure_private_directory(path: &Path) -> Result<(), ContinuationCryptoError> {
+    windows_security::apply_owner_only_acl(path, true)
+        .map_err(|error| ContinuationCryptoError::io("securing staging directory DACL", error))
+}
+
+#[cfg(windows)]
+fn verify_private_directory(path: &Path) -> Result<(), ContinuationCryptoError> {
+    windows_security::verify_owner_only_acl(path, true)
+}
+
+#[cfg(windows)]
+fn secure_owner_only_file(path: &Path) -> Result<(), ContinuationCryptoError> {
+    windows_security::apply_owner_only_acl(path, false)
+        .map_err(|error| ContinuationCryptoError::io("securing staging file DACL", error))?;
+    windows_security::verify_owner_only_acl(path, false)
+}
+
+#[cfg(windows)]
+fn verify_owner_only_file(file: &File) -> Result<(), ContinuationCryptoError> {
+    windows_security::verify_owner_only_file_handle(file)
+}
+
+#[cfg(unix)]
+pub(crate) fn sync_directory(path: &Path) -> Result<(), ContinuationCryptoError> {
+    File::open(path)
+        .and_then(|directory| directory.sync_all())
+        .map_err(|error| ContinuationCryptoError::io("fsyncing staging directory", error))
+}
+
+#[cfg(windows)]
+pub(crate) fn sync_directory(path: &Path) -> Result<(), ContinuationCryptoError> {
+    windows_security::sync_directory(path)
+        .map_err(|error| ContinuationCryptoError::io("fsyncing staging directory", error))
+}
+
+#[cfg(windows)]
+mod windows_security {
+    use std::{
+        ffi::c_void,
+        fs::File,
+        mem::{size_of, zeroed},
+        os::windows::{
+            ffi::OsStrExt,
+            io::{AsRawHandle, FromRawHandle},
+        },
+        path::Path,
+        ptr::{null, null_mut},
+    };
+
+    use windows_sys::Win32::{
+        Foundation::{
+            CloseHandle, GetLastError, LocalFree, ERROR_ALREADY_EXISTS, ERROR_INSUFFICIENT_BUFFER,
+            HANDLE, INVALID_HANDLE_VALUE,
+        },
+        Security::{
+            AclSizeInformation,
+            Authorization::{
+                GetNamedSecurityInfoW, SetEntriesInAclW, SetNamedSecurityInfoW, EXPLICIT_ACCESS_W,
+                SET_ACCESS, SE_FILE_OBJECT, TRUSTEE_IS_SID, TRUSTEE_IS_USER,
+            },
+            CopySid, EqualSid, GetAce, GetAclInformation, GetLengthSid,
+            GetSecurityDescriptorControl, GetSecurityDescriptorDacl, GetTokenInformation,
+            InitializeSecurityDescriptor, IsValidAcl, SetSecurityDescriptorControl,
+            SetSecurityDescriptorDacl, SetSecurityDescriptorOwner, TokenUser, ACCESS_ALLOWED_ACE,
+            ACL_SIZE_INFORMATION, CONTAINER_INHERIT_ACE, DACL_SECURITY_INFORMATION, INHERITED_ACE,
+            OBJECT_INHERIT_ACE, OWNER_SECURITY_INFORMATION, PROTECTED_DACL_SECURITY_INFORMATION,
+            PSECURITY_DESCRIPTOR, PSID, SECURITY_ATTRIBUTES, SECURITY_DESCRIPTOR,
+            SE_DACL_PROTECTED, TOKEN_QUERY, TOKEN_USER,
+        },
+        Storage::FileSystem::{
+            CreateDirectoryW, CreateFileW, FlushFileBuffers, LockFileEx, CREATE_NEW,
+            FILE_ALL_ACCESS, FILE_ATTRIBUTE_NORMAL, FILE_ATTRIBUTE_TEMPORARY,
+            FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_DELETE_ON_CLOSE, FILE_GENERIC_READ,
+            FILE_GENERIC_WRITE, FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+            LOCKFILE_EXCLUSIVE_LOCK, OPEN_ALWAYS, OPEN_EXISTING,
+        },
+        System::{
+            Threading::{GetCurrentProcess, OpenProcessToken},
+            IO::OVERLAPPED,
+        },
+    };
+
+    use crate::ContinuationCryptoError;
+
+    struct OwnedHandle(HANDLE);
+
+    impl Drop for OwnedHandle {
+        fn drop(&mut self) {
+            if !self.0.is_null() && self.0 != INVALID_HANDLE_VALUE {
+                unsafe { CloseHandle(self.0) };
+            }
+        }
+    }
+
+    struct LocalAllocation(*mut c_void);
+
+    impl Drop for LocalAllocation {
+        fn drop(&mut self) {
+            if !self.0.is_null() {
+                unsafe { LocalFree(self.0) };
+            }
+        }
+    }
+
+    struct OwnerSecurity {
+        _sid: Vec<u8>,
+        acl: LocalAllocation,
+        _descriptor: Box<SECURITY_DESCRIPTOR>,
+        attributes: SECURITY_ATTRIBUTES,
+    }
+
+    impl OwnerSecurity {
+        fn new(directory: bool) -> std::io::Result<Self> {
+            let mut sid = current_user_sid()?;
+            let mut entry = EXPLICIT_ACCESS_W::default();
+            entry.grfAccessPermissions = FILE_ALL_ACCESS;
+            entry.grfAccessMode = SET_ACCESS;
+            entry.grfInheritance = if directory {
+                OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE
+            } else {
+                0
+            };
+            entry.Trustee.TrusteeForm = TRUSTEE_IS_SID;
+            entry.Trustee.TrusteeType = TRUSTEE_IS_USER;
+            entry.Trustee.ptstrName = sid.as_mut_ptr().cast();
+            let mut acl = null_mut();
+            let status = unsafe { SetEntriesInAclW(1, &entry, null(), &mut acl) };
+            if status != 0 {
+                return Err(std::io::Error::from_raw_os_error(status as i32));
+            }
+            let acl = LocalAllocation(acl.cast());
+            let mut descriptor = Box::new(unsafe { zeroed::<SECURITY_DESCRIPTOR>() });
+            let descriptor_ptr = (&mut *descriptor as *mut SECURITY_DESCRIPTOR).cast();
+            if unsafe { InitializeSecurityDescriptor(descriptor_ptr, 1) } == 0
+                || unsafe { SetSecurityDescriptorOwner(descriptor_ptr, sid.as_mut_ptr().cast(), 0) }
+                    == 0
+                || unsafe { SetSecurityDescriptorDacl(descriptor_ptr, 1, acl.0.cast(), 0) } == 0
+                || unsafe {
+                    SetSecurityDescriptorControl(
+                        descriptor_ptr,
+                        SE_DACL_PROTECTED,
+                        SE_DACL_PROTECTED,
+                    )
+                } == 0
+            {
+                return Err(std::io::Error::last_os_error());
+            }
+            let attributes = SECURITY_ATTRIBUTES {
+                nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
+                lpSecurityDescriptor: descriptor_ptr,
+                bInheritHandle: 0,
+            };
+            Ok(Self {
+                _sid: sid,
+                acl,
+                _descriptor: descriptor,
+                attributes,
+            })
+        }
+
+        fn attributes(&self) -> *const SECURITY_ATTRIBUTES {
+            &self.attributes
+        }
+
+        fn acl(&self) -> *const windows_sys::Win32::Security::ACL {
+            self.acl.0.cast()
+        }
+
+        fn owner_sid(&self) -> PSID {
+            self._sid.as_ptr().cast_mut().cast()
+        }
+    }
+
+    pub(super) fn create_or_secure_private_directory(path: &Path) -> std::io::Result<()> {
+        if path.exists() {
+            return apply_owner_only_acl(path, true);
+        }
+        let parent = path
+            .parent()
+            .ok_or_else(|| std::io::Error::other("staging directory has no parent"))?;
+        if !parent.is_dir() {
+            return Err(std::io::Error::other(
+                "staging directory parent must already exist",
+            ));
+        }
+        let wide = wide_path(path);
+        let security = OwnerSecurity::new(true)?;
+        if unsafe { CreateDirectoryW(wide.as_ptr(), security.attributes()) } == 0 {
+            let error = unsafe { GetLastError() };
+            if error != ERROR_ALREADY_EXISTS {
+                return Err(std::io::Error::from_raw_os_error(error as i32));
+            }
+        }
+        verify_owner_only_acl(path, true).map_err(to_io)
+    }
+
+    pub(super) fn create_private_file(path: &Path, delete_on_close: bool) -> std::io::Result<File> {
+        let security = OwnerSecurity::new(false)?;
+        let wide = wide_path(path);
+        let mut flags = FILE_ATTRIBUTE_TEMPORARY;
+        if delete_on_close {
+            flags |= FILE_FLAG_DELETE_ON_CLOSE;
+        }
+        let handle = unsafe {
+            CreateFileW(
+                wide.as_ptr(),
+                FILE_GENERIC_READ | FILE_GENERIC_WRITE | FILE_ALL_ACCESS,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                security.attributes(),
+                CREATE_NEW,
+                flags,
+                null_mut(),
+            )
+        };
+        if handle == INVALID_HANDLE_VALUE {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(unsafe { File::from_raw_handle(handle) })
+    }
+
+    pub(super) fn open_private_lock_file(path: &Path) -> std::io::Result<File> {
+        let security = OwnerSecurity::new(false)?;
+        let wide = wide_path(path);
+        let handle = unsafe {
+            CreateFileW(
+                wide.as_ptr(),
+                FILE_GENERIC_READ | FILE_GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                security.attributes(),
+                OPEN_ALWAYS,
+                FILE_ATTRIBUTE_NORMAL,
+                null_mut(),
+            )
+        };
+        if handle == INVALID_HANDLE_VALUE {
+            return Err(std::io::Error::last_os_error());
+        }
+        let file = unsafe { File::from_raw_handle(handle) };
+        apply_owner_only_acl(path, false)?;
+        let mut overlapped = unsafe { zeroed::<OVERLAPPED>() };
+        if unsafe {
+            LockFileEx(
+                file.as_raw_handle(),
+                LOCKFILE_EXCLUSIVE_LOCK,
+                0,
+                u32::MAX,
+                u32::MAX,
+                &mut overlapped,
+            )
+        } == 0
+        {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(file)
+    }
+
+    pub(super) fn sync_directory(path: &Path) -> std::io::Result<()> {
+        let wide = wide_path(path);
+        let handle = unsafe {
+            CreateFileW(
+                wide.as_ptr(),
+                FILE_GENERIC_READ | FILE_GENERIC_WRITE,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                null(),
+                OPEN_EXISTING,
+                FILE_FLAG_BACKUP_SEMANTICS,
+                null_mut(),
+            )
+        };
+        if handle == INVALID_HANDLE_VALUE {
+            return Err(std::io::Error::last_os_error());
+        }
+        let handle = OwnedHandle(handle);
+        if unsafe { FlushFileBuffers(handle.0) } == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    pub(super) fn apply_owner_only_acl(path: &Path, directory: bool) -> std::io::Result<()> {
+        let wide = wide_path(path);
+        let security = OwnerSecurity::new(directory)?;
+        let status = unsafe {
+            SetNamedSecurityInfoW(
+                wide.as_ptr().cast_mut(),
+                SE_FILE_OBJECT,
+                OWNER_SECURITY_INFORMATION
+                    | DACL_SECURITY_INFORMATION
+                    | PROTECTED_DACL_SECURITY_INFORMATION,
+                security.owner_sid(),
+                null_mut(),
+                security.acl(),
+                null(),
+            )
+        };
+        if status != 0 {
+            return Err(std::io::Error::from_raw_os_error(status as i32));
+        }
+        verify_owner_only_acl(path, directory).map_err(to_io)
+    }
+
+    pub(super) fn verify_owner_only_file_handle(
+        file: &File,
+    ) -> Result<(), ContinuationCryptoError> {
+        let path = final_path_from_handle(file)?;
+        verify_owner_only_acl(&path, false)
+    }
+
+    pub(super) fn verify_owner_only_acl(
+        path: &Path,
+        directory: bool,
+    ) -> Result<(), ContinuationCryptoError> {
+        let wide = wide_path(path);
+        let mut owner = null_mut();
+        let mut dacl = null_mut();
+        let mut descriptor: PSECURITY_DESCRIPTOR = null_mut();
+        let status = unsafe {
+            GetNamedSecurityInfoW(
+                wide.as_ptr(),
+                SE_FILE_OBJECT,
+                OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
+                &mut owner,
+                null_mut(),
+                &mut dacl,
+                null_mut(),
+                &mut descriptor,
+            )
+        };
+        if status != 0 {
+            return Err(ContinuationCryptoError::io(
+                "reading Windows owner DACL",
+                std::io::Error::from_raw_os_error(status as i32),
+            ));
+        }
+        let _descriptor = LocalAllocation(descriptor);
+        let expected_sid = current_user_sid()
+            .map_err(|error| ContinuationCryptoError::io("reading Windows user SID", error))?;
+        if owner.is_null()
+            || dacl.is_null()
+            || unsafe { EqualSid(owner, expected_sid.as_ptr().cast_mut().cast()) } == 0
+            || unsafe { IsValidAcl(dacl) } == 0
+        {
+            return Err(ContinuationCryptoError::InvalidStaging(
+                "Windows staging owner or DACL is invalid",
+            ));
+        }
+        let mut present = 0;
+        let mut descriptor_dacl = null_mut();
+        let mut defaulted = 0;
+        if unsafe {
+            GetSecurityDescriptorDacl(
+                descriptor,
+                &mut present,
+                &mut descriptor_dacl,
+                &mut defaulted,
+            )
+        } == 0
+            || present == 0
+            || descriptor_dacl != dacl
+        {
+            return Err(ContinuationCryptoError::InvalidStaging(
+                "Windows staging DACL is absent",
+            ));
+        }
+        let mut control = 0u16;
+        let mut revision = 0u32;
+        if unsafe { GetSecurityDescriptorControl(descriptor, &mut control, &mut revision) } == 0
+            || control & SE_DACL_PROTECTED == 0
+        {
+            return Err(ContinuationCryptoError::InvalidStaging(
+                "Windows staging DACL permits inheritance",
+            ));
+        }
+        let mut info = ACL_SIZE_INFORMATION::default();
+        if unsafe {
+            GetAclInformation(
+                dacl,
+                (&mut info as *mut ACL_SIZE_INFORMATION).cast(),
+                size_of::<ACL_SIZE_INFORMATION>() as u32,
+                AclSizeInformation,
+            )
+        } == 0
+            || info.AceCount != 1
+        {
+            return Err(ContinuationCryptoError::InvalidStaging(
+                "Windows staging DACL must contain exactly one ACE",
+            ));
+        }
+        let mut ace_ptr = null_mut();
+        if unsafe { GetAce(dacl, 0, &mut ace_ptr) } == 0 || ace_ptr.is_null() {
+            return Err(ContinuationCryptoError::InvalidStaging(
+                "Windows staging DACL ACE is unreadable",
+            ));
+        }
+        let ace = unsafe { &*(ace_ptr.cast::<ACCESS_ALLOWED_ACE>()) };
+        let ace_sid = (&ace.SidStart as *const u32).cast_mut().cast();
+        let expected_flags = if directory {
+            (OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE) as u8
+        } else {
+            0
+        };
+        if ace.Header.AceType != 0
+            || ace.Header.AceFlags & INHERITED_ACE as u8 != 0
+            || ace.Header.AceFlags & expected_flags != expected_flags
+            || ace.Mask & FILE_ALL_ACCESS != FILE_ALL_ACCESS
+            || unsafe { EqualSid(ace_sid, expected_sid.as_ptr().cast_mut().cast()) } == 0
+        {
+            return Err(ContinuationCryptoError::InvalidStaging(
+                "Windows staging DACL is not owner-only full control",
+            ));
+        }
+        Ok(())
+    }
+
+    fn current_user_sid() -> std::io::Result<Vec<u8>> {
+        let mut token = null_mut();
+        if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) } == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let token = OwnedHandle(token);
+        let mut required = 0u32;
+        unsafe {
+            GetTokenInformation(token.0, TokenUser, null_mut(), 0, &mut required);
+        }
+        if required == 0 || unsafe { GetLastError() } != ERROR_INSUFFICIENT_BUFFER {
+            return Err(std::io::Error::last_os_error());
+        }
+        let mut token_info = vec![0u8; required as usize];
+        if unsafe {
+            GetTokenInformation(
+                token.0,
+                TokenUser,
+                token_info.as_mut_ptr().cast(),
+                required,
+                &mut required,
+            )
+        } == 0
+        {
+            return Err(std::io::Error::last_os_error());
+        }
+        let token_user = unsafe { &*(token_info.as_ptr().cast::<TOKEN_USER>()) };
+        let sid_len = unsafe { GetLengthSid(token_user.User.Sid) };
+        if sid_len == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        let mut sid = vec![0u8; sid_len as usize];
+        if unsafe { CopySid(sid_len, sid.as_mut_ptr().cast(), token_user.User.Sid) } == 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(sid)
+    }
+
+    fn final_path_from_handle(file: &File) -> Result<std::path::PathBuf, ContinuationCryptoError> {
+        use windows_sys::Win32::Storage::FileSystem::{
+            GetFinalPathNameByHandleW, FILE_NAME_NORMALIZED,
+        };
+        let mut buffer = vec![0u16; 32_768];
+        let length = unsafe {
+            GetFinalPathNameByHandleW(
+                file.as_raw_handle(),
+                buffer.as_mut_ptr(),
+                buffer.len() as u32,
+                FILE_NAME_NORMALIZED,
+            )
+        };
+        if length == 0 || length as usize >= buffer.len() {
+            return Err(ContinuationCryptoError::io(
+                "resolving Windows staging file handle",
+                std::io::Error::last_os_error(),
+            ));
+        }
+        buffer.truncate(length as usize);
+        let path = String::from_utf16(&buffer).map_err(|_| {
+            ContinuationCryptoError::InvalidStaging("Windows staging path is not UTF-16")
+        })?;
+        let path = path.strip_prefix(r"\\?\").unwrap_or(&path);
+        Ok(std::path::PathBuf::from(path))
+    }
+
+    fn wide_path(path: &Path) -> Vec<u16> {
+        path.as_os_str().encode_wide().chain(Some(0)).collect()
+    }
+
+    fn to_io(error: ContinuationCryptoError) -> std::io::Error {
+        std::io::Error::other(error.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::*;
+
+    #[test]
+    fn cleanup_is_scoped_to_one_validated_job() {
+        let temp = tempfile::tempdir().unwrap();
+        let staging = PrivateStagingDirectory::create(temp.path()).unwrap();
+        let mut first = staging.named_ciphertext("job-one").unwrap();
+        first.write_all(b"ciphertext-one").unwrap();
+        let (_first_file, first_path) = first.keep().unwrap();
+        let mut second = staging.named_ciphertext("job-two").unwrap();
+        second.write_all(b"ciphertext-two").unwrap();
+        let (_second_file, second_path) = second.keep().unwrap();
+        std::fs::write(temp.path().join("unrelated.txt"), b"keep").unwrap();
+
+        assert_eq!(staging.cleanup_job("job-one").unwrap(), 1);
+        assert!(!first_path.exists());
+        assert!(second_path.exists());
+        assert!(temp.path().join("unrelated.txt").exists());
+        assert_eq!(staging.cleanup_job("job-two").unwrap(), 1);
+        assert!(!second_path.exists());
+    }
+
+    #[test]
+    fn destination_capability_uses_a_lowercase_single_component_allowlist() {
+        let temp = tempfile::tempdir().unwrap();
+        let staging = PrivateStagingDirectory::create(temp.path()).unwrap();
+        assert!(staging
+            .validate_destination(&temp.path().join("checkpoint-01.age"))
+            .is_ok());
+        for name in [
+            "Checkpoint.age",
+            ".hidden.age",
+            "checkpoint..age",
+            "checkpoint age",
+            "checkpoint$.age",
+        ] {
+            assert!(staging
+                .validate_destination(&temp.path().join(name))
+                .is_err());
+        }
+        assert!(staging
+            .validate_destination(&temp.path().join("..").join("outside.age"))
+            .is_err());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_creates_and_verifies_owner_only_dacl_for_every_staging_handle() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("app-private-continuation");
+        assert!(!root.exists());
+        let staging = PrivateStagingDirectory::create(&root).unwrap();
+        windows_security::verify_owner_only_acl(staging.path(), true).unwrap();
+
+        let named = staging.named_ciphertext("windows-test").unwrap();
+        windows_security::verify_owner_only_acl(named.path(), false).unwrap();
+        let anonymous = staging.anonymous_ciphertext().unwrap();
+        windows_security::verify_owner_only_file_handle(&anonymous).unwrap();
+        let lock = staging
+            .transaction_lock_file("30000000-0000-0000-0000-000000000001")
+            .unwrap();
+        windows_security::verify_owner_only_file_handle(&lock).unwrap();
+    }
+}

--- a/src-tauri/crates/continuation-crypto/src/tests.rs
+++ b/src-tauri/crates/continuation-crypto/src/tests.rs
@@ -1,0 +1,1764 @@
+use std::{
+    collections::HashMap,
+    io::{Cursor, Read},
+    ops::Deref,
+    path::Path,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+    },
+};
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use ed25519_dalek::{Signer, SigningKey};
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::*;
+
+const NOW_MS: u64 = 1_800_000_000_000;
+
+#[derive(Clone, Default)]
+struct MemorySecretStore {
+    values: Arc<Mutex<HashMap<String, Vec<u8>>>>,
+}
+
+impl crate::secret_store::sealed::Sealed for MemorySecretStore {}
+
+impl DeviceSecretStore for MemorySecretStore {
+    fn load(&self, device_id: &str) -> Result<Option<SecretBytes>, SecretStoreError> {
+        Ok(self
+            .values
+            .lock()
+            .map_err(|_| SecretStoreError::Unavailable)?
+            .get(device_id)
+            .cloned()
+            .map(SecretBytes::new))
+    }
+
+    fn store(&self, device_id: &str, secret: &SecretBytes) -> Result<(), SecretStoreError> {
+        self.values
+            .lock()
+            .map_err(|_| SecretStoreError::Unavailable)?
+            .insert(device_id.to_owned(), secret.as_slice().to_vec());
+        Ok(())
+    }
+}
+
+struct UnavailableSecretStore;
+
+impl crate::secret_store::sealed::Sealed for UnavailableSecretStore {}
+
+impl DeviceSecretStore for UnavailableSecretStore {
+    fn load(&self, _device_id: &str) -> Result<Option<SecretBytes>, SecretStoreError> {
+        Err(SecretStoreError::Unavailable)
+    }
+
+    fn store(&self, _device_id: &str, _secret: &SecretBytes) -> Result<(), SecretStoreError> {
+        Err(SecretStoreError::Unavailable)
+    }
+}
+
+#[derive(Clone)]
+struct FailActivePointerStore {
+    inner: MemorySecretStore,
+    fail_next_active_store: Arc<AtomicBool>,
+}
+
+impl crate::secret_store::sealed::Sealed for FailActivePointerStore {}
+
+impl DeviceSecretStore for FailActivePointerStore {
+    fn load(&self, entry_id: &str) -> Result<Option<SecretBytes>, SecretStoreError> {
+        self.inner.load(entry_id)
+    }
+
+    fn store(&self, entry_id: &str, secret: &SecretBytes) -> Result<(), SecretStoreError> {
+        if entry_id.ends_with(":active")
+            && self.fail_next_active_store.swap(false, Ordering::SeqCst)
+        {
+            return Err(SecretStoreError::Rejected);
+        }
+        self.inner.store(entry_id, secret)
+    }
+}
+
+struct NonConsumingSink;
+
+impl CheckpointSink for NonConsumingSink {
+    fn stage_event(&mut self, _event: &CheckpointEvent) -> Result<(), ContinuationCryptoError> {
+        Ok(())
+    }
+
+    fn stage_blob(
+        &mut self,
+        _metadata: &BlobMetadata,
+        _content: &mut dyn Read,
+    ) -> Result<(), ContinuationCryptoError> {
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct CollectingSink {
+    manifest: Option<CheckpointManifest>,
+    events: Vec<CheckpointEvent>,
+    blobs: Vec<(BlobMetadata, Vec<u8>)>,
+    footer: Option<CheckpointFooter>,
+    pending: Option<StagedCollection>,
+    begin_count: u32,
+    commit_count: u32,
+    abort_count: u32,
+    fail_after_staging_event: bool,
+}
+
+#[derive(Default)]
+struct StagedCollection {
+    manifest: Option<CheckpointManifest>,
+    events: Vec<CheckpointEvent>,
+    blobs: Vec<(BlobMetadata, Vec<u8>)>,
+    footer: Option<CheckpointFooter>,
+}
+
+impl CheckpointSink for CollectingSink {
+    fn begin_transaction(&mut self) -> Result<(), ContinuationCryptoError> {
+        self.begin_count += 1;
+        self.pending = Some(StagedCollection::default());
+        Ok(())
+    }
+
+    fn stage_manifest(
+        &mut self,
+        manifest: &CheckpointManifest,
+    ) -> Result<(), ContinuationCryptoError> {
+        self.pending
+            .as_mut()
+            .ok_or(ContinuationCryptoError::InvalidFrame(
+                "test sink transaction not started",
+            ))?
+            .manifest = Some(manifest.clone());
+        Ok(())
+    }
+
+    fn stage_event(&mut self, event: &CheckpointEvent) -> Result<(), ContinuationCryptoError> {
+        self.pending
+            .as_mut()
+            .ok_or(ContinuationCryptoError::InvalidFrame(
+                "test sink transaction not started",
+            ))?
+            .events
+            .push(event.clone());
+        if self.fail_after_staging_event {
+            return Err(ContinuationCryptoError::InvalidFrame(
+                "simulated transactional sink failure",
+            ));
+        }
+        Ok(())
+    }
+
+    fn stage_blob(
+        &mut self,
+        metadata: &BlobMetadata,
+        content: &mut dyn Read,
+    ) -> Result<(), ContinuationCryptoError> {
+        let mut bytes = Vec::new();
+        content
+            .read_to_end(&mut bytes)
+            .map_err(|error| ContinuationCryptoError::io("collecting test blob", error))?;
+        self.pending
+            .as_mut()
+            .ok_or(ContinuationCryptoError::InvalidFrame(
+                "test sink transaction not started",
+            ))?
+            .blobs
+            .push((metadata.clone(), bytes));
+        Ok(())
+    }
+
+    fn stage_footer(&mut self, footer: &CheckpointFooter) -> Result<(), ContinuationCryptoError> {
+        self.pending
+            .as_mut()
+            .ok_or(ContinuationCryptoError::InvalidFrame(
+                "test sink transaction not started",
+            ))?
+            .footer = Some(footer.clone());
+        Ok(())
+    }
+
+    fn commit_transaction(&mut self) -> Result<(), ContinuationCryptoError> {
+        let staged = self
+            .pending
+            .take()
+            .ok_or(ContinuationCryptoError::InvalidFrame(
+                "test sink transaction not started",
+            ))?;
+        self.manifest = staged.manifest;
+        self.events = staged.events;
+        self.blobs = staged.blobs;
+        self.footer = staged.footer;
+        self.commit_count += 1;
+        Ok(())
+    }
+
+    fn abort_transaction(&mut self) {
+        self.pending = None;
+        self.abort_count += 1;
+    }
+}
+
+struct Fixture<'a> {
+    event_payload: &'a [u8],
+    blob_payload: &'a [u8],
+    blob: BlobMetadata,
+    manifest: CheckpointManifest,
+}
+
+fn fixture<'a>(event_payload: &'a [u8], blob_payload: &'a [u8]) -> Fixture<'a> {
+    let blob = BlobMetadata {
+        relative_path: "attachments/native-transcript.jsonl".into(),
+        media_type: "application/x-ndjson".into(),
+        content_len: blob_payload.len() as u64,
+        sha256: Sha256::digest(blob_payload).into(),
+    };
+    let mut hasher = CheckpointPlaintextHasher::new(LOCAL_CHECKPOINT_LIMITS);
+    hasher
+        .update_event(7, "event-7", "agent-event", event_payload)
+        .expect("hash event");
+    hasher
+        .update_blob(&blob, &mut Cursor::new(blob_payload))
+        .expect("hash blob");
+    let manifest = hasher
+        .finish()
+        .manifest("org2.continuation.checkpoint".into(), 1);
+    Fixture {
+        event_payload,
+        blob_payload,
+        blob,
+        manifest,
+    }
+}
+
+fn write_fixture(
+    destination: &Path,
+    sender: &DevicePrivateIdentity,
+    recipient: &DevicePublicIdentity,
+    fixture: &Fixture<'_>,
+) -> Result<EnvelopeArtifact<LocalProfile>, ContinuationCryptoError> {
+    let staging = staging_for(destination);
+    write_local_checkpoint_atomic(
+        destination,
+        &staging,
+        "fixture-job",
+        LocalEnvelopeWriteRequest {
+            metadata: test_metadata(),
+            sender,
+            recipients: test_recipient_set(recipient.clone()),
+            manifest: fixture.manifest.clone(),
+            limits: LOCAL_CHECKPOINT_LIMITS,
+        },
+        |writer| {
+            writer.write_event(7, "event-7", "agent-event", fixture.event_payload)?;
+            writer.write_blob(&fixture.blob, &mut Cursor::new(fixture.blob_payload))
+        },
+    )
+}
+
+fn staging_for(path: &Path) -> PrivateStagingDirectory {
+    PrivateStagingDirectory::create(path.parent().expect("fixture path has parent"))
+        .expect("private staging directory")
+}
+
+fn test_uuid(value: u128) -> Uuid {
+    Uuid::from_u128(value)
+}
+
+fn test_recipient_set(identity: DevicePublicIdentity) -> CloudRecipientSet {
+    CloudRecipientSet::try_new(vec![CloudRecipient::try_new(
+        test_uuid(0x20000000000000000000000000000002),
+        identity,
+    )
+    .unwrap()])
+    .unwrap()
+}
+
+fn test_metadata() -> CloudEnvelopeMetadata {
+    CloudEnvelopeMetadata::try_new(
+        test_uuid(0x10000000000000000000000000000001),
+        test_uuid(0x40000000000000000000000000000001),
+        "root-session-a".into(),
+        "episode-a".into(),
+        "codex".into(),
+        "claude".into(),
+        RecipientScope::Audience,
+        test_uuid(0x20000000000000000000000000000001),
+        NOW_MS,
+        NOW_MS + 3_600_000,
+        NOW_MS,
+    )
+    .unwrap()
+}
+
+struct MemoryIdentityManager {
+    _temp: tempfile::TempDir,
+    manager: DeviceIdentityManager<MemorySecretStore>,
+}
+
+impl Deref for MemoryIdentityManager {
+    type Target = DeviceIdentityManager<MemorySecretStore>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.manager
+    }
+}
+
+fn memory_manager(store: MemorySecretStore) -> MemoryIdentityManager {
+    let temp = tempfile::tempdir().unwrap();
+    let staging = PrivateStagingDirectory::create(temp.path()).unwrap();
+    let manager = DeviceIdentityManager::new(store, staging);
+    MemoryIdentityManager {
+        _temp: temp,
+        manager,
+    }
+}
+
+fn identities() -> (
+    MemoryIdentityManager,
+    DevicePrivateIdentity,
+    DevicePrivateIdentity,
+) {
+    let store = MemorySecretStore::default();
+    let manager = memory_manager(store);
+    let sender = manager
+        .load_or_create(test_uuid(0x30000000000000000000000000000001))
+        .expect("sender identity");
+    let recipient = manager
+        .load_or_create(test_uuid(0x30000000000000000000000000000002))
+        .expect("recipient identity");
+    (manager, sender, recipient)
+}
+
+#[test]
+fn cloud_fingerprint_golden_vector_matches_raw_key_contract() {
+    let encryption: [u8; 32] = std::array::from_fn(|index| index as u8);
+    let signing: [u8; 32] = std::array::from_fn(|index| (index + 32) as u8);
+    assert_eq!(
+        hex::encode(device_fingerprint(&encryption, &signing)),
+        "3b7ec85045344de1f5b326e474baab6f293a211bbcb41e50b95aaa9ea10c6a9a"
+    );
+}
+
+#[test]
+fn canonical_header_and_signed_bytes_have_exact_golden_vector() {
+    let encryption_sender: [u8; 32] = std::array::from_fn(|index| index as u8);
+    let encryption_recipient: [u8; 32] = std::array::from_fn(|index| (index + 32) as u8);
+    let sender_signing_public: [u8; 32] =
+        hex::decode("d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a")
+            .unwrap()
+            .try_into()
+            .unwrap();
+    let recipient_signing_public: [u8; 32] =
+        hex::decode("3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c")
+            .unwrap()
+            .try_into()
+            .unwrap();
+    let sender = DevicePublicIdentity::try_new(
+        test_uuid(0x30000000000000000000000000000001),
+        7,
+        encryption_sender,
+        sender_signing_public,
+        device_fingerprint(&encryption_sender, &sender_signing_public),
+    )
+    .unwrap();
+    let recipient = DevicePublicIdentity::try_new(
+        test_uuid(0x30000000000000000000000000000002),
+        9,
+        encryption_recipient,
+        recipient_signing_public,
+        device_fingerprint(&encryption_recipient, &recipient_signing_public),
+    )
+    .unwrap();
+    let encryption_recipient_two: [u8; 32] = std::array::from_fn(|index| (index + 64) as u8);
+    let recipient_two_signing_public = SigningKey::from_bytes(&[3; 32]).verifying_key().to_bytes();
+    let recipient_two = DevicePublicIdentity::try_new(
+        test_uuid(0x30000000000000000000000000000003),
+        11,
+        encryption_recipient_two,
+        recipient_two_signing_public,
+        device_fingerprint(&encryption_recipient_two, &recipient_two_signing_public),
+    )
+    .unwrap();
+    // Constructor input is deliberately reversed; canonicalization is raw
+    // `(user UUID, device UUID, key version)` byte ordering.
+    let recipients = CloudRecipientSet::try_new(vec![
+        CloudRecipient::try_new(test_uuid(0x20000000000000000000000000000003), recipient_two)
+            .unwrap(),
+        CloudRecipient::try_new(test_uuid(0x20000000000000000000000000000002), recipient).unwrap(),
+    ])
+    .unwrap();
+    let recipient_set_sha256 = recipients.sha256();
+    let digest = [0xa5; 32];
+    let header = ContinuationEnvelopeHeader {
+        encryption_algorithm: EncryptionAlgorithm::AgeX25519,
+        signature_algorithm: SignatureAlgorithm::Ed25519,
+        compression_algorithm: CompressionAlgorithm::Gzip,
+        hash_algorithm: HashAlgorithm::Sha256,
+        org_id: test_uuid(0x10000000000000000000000000000001),
+        checkpoint_id: test_uuid(0x40000000000000000000000000000001),
+        root_session_id: "root-session-a".into(),
+        source_episode_id: "episode-a".into(),
+        source_runtime: "codex".into(),
+        target_runtime: "claude".into(),
+        recipient_scope: RecipientScope::Audience,
+        sender_user_id: test_uuid(0x20000000000000000000000000000001),
+        sender,
+        recipients,
+        recipient_set_sha256,
+        age_ciphertext_sha256: digest,
+        created_at_unix_ms: NOW_MS,
+        expires_at_unix_ms: NOW_MS + 3_600_000,
+        age_ciphertext_len: 1_234,
+    };
+    let raw_header = canonical_header_bytes(&header).unwrap();
+    let signed = signature_message(&raw_header, &digest).unwrap();
+    let signing_seed: [u8; 32] =
+        hex::decode("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60")
+            .unwrap()
+            .try_into()
+            .unwrap();
+    let signature = SigningKey::from_bytes(&signing_seed).sign(&signed);
+
+    assert_eq!(
+        header.recipients.as_slice()[0].identity().fingerprint_hex(),
+        "d137b40d6290e550801d7481ebaab1ca9ca2f1936e89ddb26ede2b663a0d57db"
+    );
+    assert_eq!(
+        header.recipients.as_slice()[1].identity().fingerprint_hex(),
+        "0aa1f475680f3504f42465144b415100ab0d25b787494a1860ccca47af8197b4"
+    );
+    assert_eq!(
+        hex::encode(recipient_set_sha256),
+        "9ddfed1c641fa7cd2e0b93511b878361a3bedf8485708c75f0057ab6429ecbb7"
+    );
+    assert_eq!(raw_header.len(), 565);
+    assert_eq!(
+        hex::encode(&raw_header),
+        "010101011000000000000000000000000000000140000000000000000000000000000001000e726f6f742d73657373696f6e2d610009657069736f64652d610005636f6465780006636c6175646501200000000000000000000000000000013000000000000000000000000000000100000007000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1fd75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a5c63ff72e6ce93d42fe2dab5ef6a11bc9aeba024d6176910d9dfb8d9460c397a00029ddfed1c641fa7cd2e0b93511b878361a3bedf8485708c75f0057ab6429ecbb7200000000000000000000000000000023000000000000000000000000000000200000009202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660cd137b40d6290e550801d7481ebaab1ca9ca2f1936e89ddb26ede2b663a0d57db20000000000000000000000000000003300000000000000000000000000000030000000b404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5fed4928c628d1c2c6eae90338905995612959273a5c63f93636c14614ac8737d10aa1f475680f3504f42465144b415100ab0d25b787494a1860ccca47af8197b4a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5000001a3185c5000000001a318933e8000000000000004d2"
+    );
+    assert_eq!(
+        hex::encode(Sha256::digest(&raw_header)),
+        "7de14a7d826b915bd19d55bac5255fcc25786fb93a36d268bececa68df451d59"
+    );
+    assert_eq!(
+        hex::encode(Sha256::digest(&signed)),
+        "0dd738152b0fbfad87462a770b3c614e828112fe6506052e46e2399001796ad7"
+    );
+    assert_eq!(
+        hex::encode(signature.to_bytes()),
+        "b5f125019861b57d0745ec4d9917208bace0c245850c68ad9f114ebcf0107f88d31f86d551d3b3c6809bebcff5bdd81fe0fd18bbd5869da108725c2b5e04fb03"
+    );
+}
+
+#[test]
+fn recipient_sets_sort_and_reject_ambiguous_device_routes_or_excess_entries() {
+    let (manager, _sender, recipient_one) = identities();
+    let recipient_two = manager
+        .load_or_create(test_uuid(0x30000000000000000000000000000003))
+        .unwrap();
+    let first = CloudRecipient::try_new(
+        test_uuid(0x20000000000000000000000000000002),
+        recipient_one.public_identity().unwrap(),
+    )
+    .unwrap();
+    let second = CloudRecipient::try_new(
+        test_uuid(0x20000000000000000000000000000003),
+        recipient_two.public_identity().unwrap(),
+    )
+    .unwrap();
+    let sorted = CloudRecipientSet::try_new(vec![second.clone(), first.clone()]).unwrap();
+    assert_eq!(sorted.as_slice(), &[first.clone(), second]);
+
+    assert!(CloudRecipientSet::try_new(vec![
+        first.clone(),
+        CloudRecipient::try_new(
+            test_uuid(0x20000000000000000000000000000003),
+            first.identity().clone(),
+        )
+        .unwrap(),
+    ])
+    .is_err());
+
+    let old = manager
+        .load_or_create(test_uuid(0x30000000000000000000000000000004))
+        .unwrap();
+    let current = manager.rotate(old.device_id()).unwrap();
+    assert!(CloudRecipientSet::try_new(vec![
+        CloudRecipient::try_new(
+            test_uuid(0x20000000000000000000000000000004),
+            old.public_identity().unwrap(),
+        )
+        .unwrap(),
+        CloudRecipient::try_new(
+            test_uuid(0x20000000000000000000000000000004),
+            current.public_identity().unwrap(),
+        )
+        .unwrap(),
+    ])
+    .is_err());
+
+    let too_many = (1..=65)
+        .map(|index| {
+            let encryption = [index as u8; 32];
+            let signing = SigningKey::from_bytes(&[index as u8; 32])
+                .verifying_key()
+                .to_bytes();
+            let identity = DevicePublicIdentity::try_new(
+                Uuid::from_u128(0x50000000000000000000000000000000 + index),
+                1,
+                encryption,
+                signing,
+                device_fingerprint(&encryption, &signing),
+            )
+            .unwrap();
+            CloudRecipient::try_new(
+                Uuid::from_u128(0x60000000000000000000000000000000 + index),
+                identity,
+            )
+            .unwrap()
+        })
+        .collect();
+    assert!(CloudRecipientSet::try_new(too_many).is_err());
+}
+
+#[test]
+fn cloud_routing_metadata_and_receipt_sql_encodings_are_strict() {
+    let valid = || {
+        CloudEnvelopeMetadata::try_from_sql(
+            "10000000-0000-0000-0000-000000000001",
+            "40000000-0000-0000-0000-000000000001",
+            "root-session-a".into(),
+            "episode-a".into(),
+            "codex".into(),
+            "claude".into(),
+            "audience",
+            "20000000-0000-0000-0000-000000000001",
+            NOW_MS,
+            NOW_MS + 3_600_000,
+            NOW_MS,
+        )
+    };
+    assert!(valid().is_ok());
+    assert!(CloudEnvelopeMetadata::try_from_sql(
+        "10000000-0000-0000-0000-000000000001",
+        "40000000-0000-0000-0000-000000000001",
+        "root-session-a".into(),
+        "episode-a".into(),
+        "Codex".into(),
+        "claude".into(),
+        "audience",
+        "20000000-0000-0000-0000-000000000001",
+        NOW_MS,
+        NOW_MS + 3_600_000,
+        NOW_MS,
+    )
+    .is_err());
+    assert!(CloudEnvelopeMetadata::try_from_sql(
+        "10000000-0000-0000-0000-000000000001",
+        "40000000-0000-0000-0000-000000000001",
+        "x".repeat(201),
+        "episode-a".into(),
+        "codex".into(),
+        "claude".into(),
+        "subset",
+        "20000000-0000-0000-0000-000000000001",
+        NOW_MS,
+        NOW_MS + 3_600_000,
+        NOW_MS,
+    )
+    .is_err());
+    assert!(CloudEnvelopeMetadata::try_from_sql(
+        "10000000-0000-0000-0000-000000000001",
+        "40000000-0000-0000-0000-000000000001",
+        "root-session-a".into(),
+        "episode-a".into(),
+        "codex".into(),
+        "claude".into(),
+        "all",
+        "20000000-0000-0000-0000-000000000001",
+        NOW_MS,
+        NOW_MS + 3_600_000,
+        NOW_MS,
+    )
+    .is_err());
+    assert!(CloudEnvelopeMetadata::try_from_sql(
+        "10000000-0000-0000-0000-000000000001",
+        "40000000-0000-0000-0000-000000000001",
+        "root-session-a".into(),
+        "episode-a".into(),
+        "codex".into(),
+        "claude".into(),
+        "audience",
+        "20000000-0000-0000-0000-000000000001",
+        NOW_MS,
+        NOW_MS + 299_999,
+        NOW_MS,
+    )
+    .is_err());
+
+    let (_manager, _sender, recipient) = identities();
+    let identity = recipient.public_identity().unwrap();
+    let device_id = identity.device_id.to_string();
+    let encryption = URL_SAFE_NO_PAD.encode(identity.encryption_public_key);
+    let signing = URL_SAFE_NO_PAD.encode(identity.signing_public_key);
+    let fingerprint = identity.fingerprint_hex();
+    let receipt = |user_id: &str, key_version: i32, encryption_key: &str| {
+        CommittedRecipientReceipt::try_from_sql(CommittedRecipientReceiptSql {
+            org_id: "10000000-0000-0000-0000-000000000001",
+            checkpoint_id: "40000000-0000-0000-0000-000000000001",
+            recipient_user_id: user_id,
+            recipient_device_id: &device_id,
+            recipient_key_version: key_version,
+            recipient_encryption_public_key: encryption_key,
+            recipient_signing_public_key: &signing,
+            recipient_fingerprint: &fingerprint,
+        })
+    };
+    assert!(receipt(
+        "20000000-0000-0000-0000-000000000002",
+        identity.key_version as i32,
+        &encryption,
+    )
+    .is_ok());
+    assert!(receipt("20000000-0000-0000-0000-000000000002", 0, &encryption,).is_err());
+    let padded = format!("{encryption}=");
+    assert!(receipt(
+        "20000000-0000-0000-0000-000000000002",
+        identity.key_version as i32,
+        &padded,
+    )
+    .is_err());
+    assert!(receipt(
+        "20000000-0000-0000-0000-00000000000A",
+        identity.key_version as i32,
+        &encryption,
+    )
+    .is_err());
+}
+
+#[test]
+fn secure_store_round_trip_and_sixteen_rotations_preserve_version_one() {
+    let store = MemorySecretStore::default();
+    let manager = memory_manager(store);
+    let device_id = test_uuid(0x3000000000000000000000000000000a);
+    let first = manager.load_or_create(device_id).unwrap();
+    let first_public = first.public_identity().unwrap();
+    assert_eq!(first_public.key_version, 1);
+    let again = manager.load_or_create(device_id).unwrap();
+    assert_eq!(again.public_identity().unwrap(), first_public);
+
+    for expected in 2..=17 {
+        let rotated = manager.rotate(device_id).unwrap();
+        assert_eq!(rotated.key_version(), expected);
+    }
+    assert_eq!(manager.load_version(device_id, 1).unwrap().key_version(), 1);
+    assert_eq!(manager.load_version(device_id, 3).unwrap().key_version(), 3);
+    assert_eq!(manager.load_current(device_id).unwrap().key_version(), 17);
+}
+
+#[test]
+fn independent_managers_serialize_rotation_to_versions_two_then_three() {
+    let temp = tempfile::tempdir().unwrap();
+    let staging = PrivateStagingDirectory::create(temp.path()).unwrap();
+    let store = MemorySecretStore::default();
+    let first_manager = DeviceIdentityManager::new(store.clone(), staging.clone());
+    let second_manager = DeviceIdentityManager::new(store.clone(), staging.clone());
+    let device_id = test_uuid(0x3000000000000000000000000000000b);
+    first_manager.load_or_create(device_id).unwrap();
+    let barrier = Arc::new(std::sync::Barrier::new(3));
+    let first_barrier = Arc::clone(&barrier);
+    let first = std::thread::spawn(move || {
+        first_barrier.wait();
+        first_manager.rotate(device_id).unwrap().key_version()
+    });
+    let second_barrier = Arc::clone(&barrier);
+    let second = std::thread::spawn(move || {
+        second_barrier.wait();
+        second_manager.rotate(device_id).unwrap().key_version()
+    });
+    barrier.wait();
+    let mut versions = [first.join().unwrap(), second.join().unwrap()];
+    versions.sort_unstable();
+    assert_eq!(versions, [2, 3]);
+    let verifier = DeviceIdentityManager::new(store, staging);
+    assert_eq!(
+        verifier.load_version(device_id, 1).unwrap().key_version(),
+        1
+    );
+    assert_eq!(verifier.load_current(device_id).unwrap().key_version(), 3);
+}
+
+#[test]
+fn unavailable_os_store_fails_closed_without_ephemeral_identity() {
+    let temp = tempfile::tempdir().unwrap();
+    let manager = DeviceIdentityManager::new(
+        UnavailableSecretStore,
+        PrivateStagingDirectory::create(temp.path()).unwrap(),
+    );
+    assert!(matches!(
+        manager.load_or_create(test_uuid(0x3000000000000000000000000000000c)),
+        Err(ContinuationCryptoError::SecretStore(
+            SecretStoreError::Unavailable
+        ))
+    ));
+}
+
+#[test]
+fn corrupt_secure_store_record_fails_closed_without_replacing_keys() {
+    let store = MemorySecretStore::default();
+    let device_id = test_uuid(0x3000000000000000000000000000000d);
+    let pointer_entry = format!("device:{device_id}:active");
+    store
+        .values
+        .lock()
+        .unwrap()
+        .insert(pointer_entry.clone(), b"not-an-active-pointer".to_vec());
+    let manager = memory_manager(store.clone());
+    assert!(matches!(
+        manager.load_or_create(device_id),
+        Err(ContinuationCryptoError::CorruptIdentity(_))
+    ));
+    assert_eq!(
+        store.values.lock().unwrap().get(&pointer_entry).unwrap(),
+        b"not-an-active-pointer"
+    );
+}
+
+#[test]
+fn secure_store_pointer_crashes_recover_the_exact_persisted_key() {
+    let temp = tempfile::tempdir().unwrap();
+    let staging = PrivateStagingDirectory::create(temp.path()).unwrap();
+    let inner = MemorySecretStore::default();
+    let fail_flag = Arc::new(AtomicBool::new(true));
+    let faulting = DeviceIdentityManager::new(
+        FailActivePointerStore {
+            inner: inner.clone(),
+            fail_next_active_store: Arc::clone(&fail_flag),
+        },
+        staging.clone(),
+    );
+    let device_id = test_uuid(0x3000000000000000000000000000000e);
+    assert!(matches!(
+        faulting.load_or_create(device_id),
+        Err(ContinuationCryptoError::SecretStore(
+            SecretStoreError::Rejected
+        ))
+    ));
+    let key_entry = format!("device:{device_id}:key:1");
+    let pointer_entry = format!("device:{device_id}:active");
+    assert!(inner.values.lock().unwrap().contains_key(&key_entry));
+    assert!(!inner.values.lock().unwrap().contains_key(&pointer_entry));
+
+    let recovered = DeviceIdentityManager::new(inner.clone(), staging.clone())
+        .load_or_create(device_id)
+        .unwrap();
+    assert_eq!(recovered.key_version(), 1);
+
+    let normal = DeviceIdentityManager::new(inner.clone(), staging.clone());
+    let before_rotation = normal.load_current(device_id).unwrap();
+    assert_eq!(
+        before_rotation.public_identity().unwrap(),
+        recovered.public_identity().unwrap()
+    );
+    fail_flag.store(true, Ordering::SeqCst);
+    let faulting_rotation = DeviceIdentityManager::new(
+        FailActivePointerStore {
+            inner: inner.clone(),
+            fail_next_active_store: Arc::clone(&fail_flag),
+        },
+        staging.clone(),
+    );
+    assert!(matches!(
+        faulting_rotation.rotate(device_id),
+        Err(ContinuationCryptoError::SecretStore(
+            SecretStoreError::Rejected
+        ))
+    ));
+    let persisted_v2 = normal
+        .load_version(device_id, 2)
+        .unwrap()
+        .public_identity()
+        .unwrap();
+    let retried_v2 = normal.rotate(device_id).unwrap().public_identity().unwrap();
+    assert_eq!(retried_v2, persisted_v2);
+    assert_eq!(normal.load_current(device_id).unwrap().key_version(), 2);
+}
+
+#[test]
+fn tampered_per_version_key_record_fails_checksum_without_replacement() {
+    let store = MemorySecretStore::default();
+    let manager = memory_manager(store.clone());
+    let device_id = test_uuid(0x3000000000000000000000000000000f);
+    manager.load_or_create(device_id).unwrap();
+    let key_entry = format!("device:{device_id}:key:1");
+    let original = store
+        .values
+        .lock()
+        .unwrap()
+        .get(&key_entry)
+        .unwrap()
+        .clone();
+    store.values.lock().unwrap().get_mut(&key_entry).unwrap()[17] ^= 1;
+    assert!(matches!(
+        manager.load_current(device_id),
+        Err(ContinuationCryptoError::CorruptIdentity(_))
+    ));
+    assert_ne!(
+        store.values.lock().unwrap().get(&key_entry).unwrap(),
+        &original
+    );
+}
+
+#[test]
+fn encrypted_checkpoint_round_trips_with_age_and_owner_only_atomic_file() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("checkpoint.org2h");
+    let (_manager, sender, recipient) = identities();
+    let recipient_public = recipient.public_identity().unwrap();
+    let source = fixture(b"event payload", b"native transcript\nline two\n");
+    let artifact = write_fixture(&path, &sender, &recipient_public, &source).unwrap();
+    assert_ne!(artifact.header().age_ciphertext_sha256, [0; 32]);
+    assert_eq!(
+        artifact.object_size(),
+        std::fs::metadata(&path).unwrap().len()
+    );
+    let actual_object_sha256: [u8; 32] = Sha256::digest(std::fs::read(&path).unwrap()).into();
+    assert_eq!(*artifact.object_sha256(), actual_object_sha256);
+    let file_bytes = std::fs::read(&path).unwrap();
+    let footer_signature_offset = file_bytes.len() - SIGNATURE_BYTES - ENVELOPE_END_MAGIC.len();
+    assert_eq!(
+        artifact.signature().as_slice(),
+        &file_bytes[footer_signature_offset..footer_signature_offset + SIGNATURE_BYTES]
+    );
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+    assert!(std::fs::read_dir(temp.path()).unwrap().all(|entry| {
+        !entry
+            .unwrap()
+            .file_name()
+            .to_string_lossy()
+            .ends_with(".ciphertext.tmp")
+    }));
+
+    let mut sink = CollectingSink::default();
+    let verified = decrypt_local_checkpoint(
+        &path,
+        &staging_for(&path),
+        &sender.public_identity().unwrap(),
+        &recipient,
+        NOW_MS + 1,
+        LOCAL_CHECKPOINT_LIMITS,
+        &mut sink,
+    )
+    .unwrap();
+    assert_eq!(verified.artifact(), &artifact);
+    assert_eq!(sink.events.len(), 1);
+    assert_eq!(sink.events[0].payload, b"event payload");
+    assert_eq!(sink.blobs[0].1, b"native transcript\nline two\n");
+    assert_eq!(sink.manifest, Some(source.manifest));
+    assert_eq!(sink.footer, Some(verified.footer));
+    assert_eq!(sink.begin_count, 1);
+    assert_eq!(sink.commit_count, 1);
+    assert_eq!(sink.abort_count, 0);
+}
+
+#[test]
+fn verified_snapshot_is_immutable_across_path_swap_and_in_place_mutation() {
+    let temp = tempfile::tempdir().unwrap();
+    let path_swap_source = temp.path().join("path-swap.org2h");
+    let replacement = temp.path().join("replacement.org2h");
+    let displaced = temp.path().join("displaced.org2h");
+    let in_place_source = temp.path().join("in-place.org2h");
+    let staging = staging_for(&path_swap_source);
+    let (_manager, sender, recipient) = identities();
+    let recipient_public = recipient.public_identity().unwrap();
+    let original = fixture(b"original event", b"original blob");
+    let changed = fixture(b"replacement event", b"replacement blob");
+    write_fixture(&path_swap_source, &sender, &recipient_public, &original).unwrap();
+    write_fixture(&replacement, &sender, &recipient_public, &changed).unwrap();
+
+    let mut path_swap_sink = CollectingSink::default();
+    crate::envelope::decrypt_local_checkpoint_with_hook(
+        &path_swap_source,
+        &staging,
+        &sender.public_identity().unwrap(),
+        &recipient,
+        NOW_MS + 1,
+        LOCAL_CHECKPOINT_LIMITS,
+        &mut path_swap_sink,
+        || {
+            std::fs::rename(&path_swap_source, &displaced).unwrap();
+            std::fs::rename(&replacement, &path_swap_source).unwrap();
+        },
+    )
+    .unwrap();
+    assert_eq!(path_swap_sink.events[0].payload, b"original event");
+    assert_eq!(path_swap_sink.blobs[0].1, b"original blob");
+    assert_eq!(path_swap_sink.commit_count, 1);
+
+    write_fixture(&in_place_source, &sender, &recipient_public, &original).unwrap();
+    let mut in_place_sink = CollectingSink::default();
+    crate::envelope::decrypt_local_checkpoint_with_hook(
+        &in_place_source,
+        &staging,
+        &sender.public_identity().unwrap(),
+        &recipient,
+        NOW_MS + 1,
+        LOCAL_CHECKPOINT_LIMITS,
+        &mut in_place_sink,
+        || {
+            use std::io::Write as _;
+            let mut source = std::fs::OpenOptions::new()
+                .write(true)
+                .truncate(true)
+                .open(&in_place_source)
+                .unwrap();
+            source.write_all(b"mutated after snapshot").unwrap();
+            source.sync_all().unwrap();
+        },
+    )
+    .unwrap();
+    assert_eq!(in_place_sink.events[0].payload, b"original event");
+    assert_eq!(in_place_sink.blobs[0].1, b"original blob");
+    assert_eq!(in_place_sink.commit_count, 1);
+}
+
+#[test]
+fn outer_verification_and_sink_failures_publish_zero_sink_side_effects() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("transactional-sink.org2h");
+    let staging = staging_for(&path);
+    let (_manager, sender, recipient) = identities();
+    let recipient_public = recipient.public_identity().unwrap();
+    let source = fixture(b"event", b"blob");
+    write_fixture(&path, &sender, &recipient_public, &source).unwrap();
+    let mut tampered = std::fs::read(&path).unwrap();
+    let header_len = u32::from_be_bytes(tampered[10..14].try_into().unwrap()) as usize;
+    tampered[14 + header_len + 5] ^= 1;
+    std::fs::write(&path, tampered).unwrap();
+    let mut untouched = CollectingSink::default();
+    assert!(matches!(
+        decrypt_local_checkpoint(
+            &path,
+            &staging,
+            &sender.public_identity().unwrap(),
+            &recipient,
+            NOW_MS + 1,
+            LOCAL_CHECKPOINT_LIMITS,
+            &mut untouched,
+        ),
+        Err(ContinuationCryptoError::CiphertextHashMismatch)
+    ));
+    assert_eq!(untouched.begin_count, 0);
+    assert_eq!(untouched.commit_count, 0);
+    assert_eq!(untouched.abort_count, 0);
+    assert!(untouched.manifest.is_none());
+    assert!(untouched.events.is_empty());
+    assert!(untouched.blobs.is_empty());
+
+    let clean_path = temp.path().join("transactional-sink-clean.org2h");
+    write_fixture(&clean_path, &sender, &recipient_public, &source).unwrap();
+    let clean_staging = staging_for(&clean_path);
+    let mut failing = CollectingSink {
+        fail_after_staging_event: true,
+        ..CollectingSink::default()
+    };
+    assert!(matches!(
+        decrypt_local_checkpoint(
+            &clean_path,
+            &clean_staging,
+            &sender.public_identity().unwrap(),
+            &recipient,
+            NOW_MS + 1,
+            LOCAL_CHECKPOINT_LIMITS,
+            &mut failing,
+        ),
+        Err(ContinuationCryptoError::InvalidFrame(
+            "simulated transactional sink failure"
+        ))
+    ));
+    assert_eq!(failing.begin_count, 1);
+    assert_eq!(failing.commit_count, 0);
+    assert_eq!(failing.abort_count, 1);
+    assert!(failing.pending.is_none());
+    assert!(failing.manifest.is_none());
+    assert!(failing.events.is_empty());
+    assert!(failing.blobs.is_empty());
+}
+
+#[test]
+fn cloud_entrypoint_pins_row_metadata_footer_signature_and_16_mib_profile() {
+    assert_eq!(CLOUD_CHECKPOINT_LIMITS.max_envelope_bytes, 16 * 1024 * 1024);
+    assert_eq!(
+        LOCAL_CHECKPOINT_LIMITS.max_envelope_bytes,
+        512 * 1024 * 1024
+    );
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("cloud-checkpoint.org2h");
+    let (manager, sender, recipient) = identities();
+    let recipient_public = recipient.public_identity().unwrap();
+    let recipient_two = manager
+        .load_or_create(test_uuid(0x30000000000000000000000000000003))
+        .unwrap();
+    let recipient_two_public = recipient_two.public_identity().unwrap();
+    let recipients = CloudRecipientSet::try_new(vec![
+        CloudRecipient::try_new(
+            test_uuid(0x20000000000000000000000000000003),
+            recipient_two_public.clone(),
+        )
+        .unwrap(),
+        CloudRecipient::try_new(
+            test_uuid(0x20000000000000000000000000000002),
+            recipient_public.clone(),
+        )
+        .unwrap(),
+    ])
+    .unwrap();
+    let source = fixture(b"cloud event", b"cloud blob");
+    let artifact = write_cloud_checkpoint_atomic(
+        &path,
+        &staging_for(&path),
+        "cloud-job",
+        CloudEnvelopeWriteRequest {
+            metadata: test_metadata(),
+            sender: &sender,
+            recipients,
+            manifest: source.manifest,
+        },
+        |writer| {
+            writer.write_event(7, "event-7", "agent-event", source.event_payload)?;
+            writer.write_blob(&source.blob, &mut Cursor::new(source.blob_payload))
+        },
+    )
+    .unwrap();
+    let header = artifact.header();
+    let checkpoint_id = header.checkpoint_id.to_string();
+    let org_id = header.org_id.to_string();
+    let sender_user_id = header.sender_user_id.to_string();
+    let sender_device_id = header.sender.device_id.to_string();
+    let recipient_set_sha256 = hex::encode(header.recipient_set_sha256);
+    let object_sha256 = hex::encode(artifact.object_sha256());
+    let age_ciphertext_sha256 = hex::encode(header.age_ciphertext_sha256);
+    let footer_signature = URL_SAFE_NO_PAD.encode(artifact.signature());
+    let sender_encryption_public_key = URL_SAFE_NO_PAD.encode(header.sender.encryption_public_key);
+    let sender_signing_public_key = URL_SAFE_NO_PAD.encode(header.sender.signing_public_key);
+    let sender_fingerprint = hex::encode(header.sender.fingerprint);
+    macro_rules! row {
+        ($sender_user:expr, $sender_device:expr, $recipient_count:expr, $set_hash:expr $(,)?) => {
+            CommittedCloudEnvelopeSql {
+                checkpoint_id: &checkpoint_id,
+                org_id: &org_id,
+                root_session_id: &header.root_session_id,
+                source_episode_id: &header.source_episode_id,
+                client_created_at_unix_ms: header.created_at_unix_ms,
+                sender_user_id: $sender_user,
+                sender_device_id: $sender_device,
+                sender_key_version: header.sender.key_version as i32,
+                source_runtime: &header.source_runtime,
+                target_runtime: &header.target_runtime,
+                recipient_scope: "audience",
+                recipient_count: $recipient_count,
+                recipient_set_sha256: $set_hash,
+                object_size: artifact.object_size() as i64,
+                object_sha256: &object_sha256,
+                age_ciphertext_len: header.age_ciphertext_len as i64,
+                age_ciphertext_sha256: &age_ciphertext_sha256,
+                footer_signature: &footer_signature,
+                expires_at_unix_ms: header.expires_at_unix_ms,
+                canonical_header: artifact.canonical_header(),
+                sender_encryption_public_key: &sender_encryption_public_key,
+                sender_signing_public_key: &sender_signing_public_key,
+                sender_fingerprint: &sender_fingerprint,
+            }
+        };
+    }
+    let expected = CommittedCloudEnvelope::try_from_sql(
+        row!(
+            &sender_user_id,
+            &sender_device_id,
+            header.recipients.as_slice().len() as i32,
+            &recipient_set_sha256,
+        ),
+        NOW_MS + 1,
+    )
+    .unwrap();
+    let make_receipt = |user_id: Uuid, identity: &DevicePublicIdentity| {
+        let recipient_user_id = user_id.to_string();
+        let recipient_device_id = identity.device_id.to_string();
+        let recipient_encryption_public_key =
+            URL_SAFE_NO_PAD.encode(identity.encryption_public_key);
+        let recipient_signing_public_key = URL_SAFE_NO_PAD.encode(identity.signing_public_key);
+        let recipient_fingerprint = hex::encode(identity.fingerprint);
+        CommittedRecipientReceipt::try_from_sql(CommittedRecipientReceiptSql {
+            org_id: &org_id,
+            checkpoint_id: &checkpoint_id,
+            recipient_user_id: &recipient_user_id,
+            recipient_device_id: &recipient_device_id,
+            recipient_key_version: identity.key_version as i32,
+            recipient_encryption_public_key: &recipient_encryption_public_key,
+            recipient_signing_public_key: &recipient_signing_public_key,
+            recipient_fingerprint: &recipient_fingerprint,
+        })
+        .unwrap()
+    };
+    let receipt = make_receipt(
+        test_uuid(0x20000000000000000000000000000002),
+        &recipient_public,
+    );
+    let receipt_two = make_receipt(
+        test_uuid(0x20000000000000000000000000000003),
+        &recipient_two_public,
+    );
+    let swapped_user_receipt = make_receipt(
+        test_uuid(0x20000000000000000000000000000003),
+        &recipient_public,
+    );
+    for (private, receipt) in [(&recipient, &receipt), (&recipient_two, &receipt_two)] {
+        let verified = decrypt_cloud_checkpoint(
+            &path,
+            &staging_for(&path),
+            CloudCheckpointDecryptRequest {
+                expected: &expected,
+                receipt,
+                trusted_sender: &sender.public_identity().unwrap(),
+                recipient: private,
+                now_unix_ms: NOW_MS + 1,
+            },
+            &mut CollectingSink::default(),
+        )
+        .unwrap();
+        assert_eq!(verified.artifact(), &artifact);
+    }
+
+    let noncanonical_path = temp.path().join("noncanonical-recipient-order.org2h");
+    let mut noncanonical = std::fs::read(&path).unwrap();
+    let first_user = test_uuid(0x20000000000000000000000000000002);
+    let second_user = test_uuid(0x20000000000000000000000000000003);
+    let first_header_offset = artifact
+        .canonical_header()
+        .windows(16)
+        .position(|window| window == first_user.as_bytes())
+        .unwrap();
+    let second_header_offset = artifact
+        .canonical_header()
+        .windows(16)
+        .position(|window| window == second_user.as_bytes())
+        .unwrap();
+    const RECIPIENT_ENTRY_BYTES: usize = 16 + 16 + 4 + 32 + 32 + 32;
+    let first_entry = artifact.canonical_header()
+        [first_header_offset..first_header_offset + RECIPIENT_ENTRY_BYTES]
+        .to_vec();
+    let second_entry = artifact.canonical_header()
+        [second_header_offset..second_header_offset + RECIPIENT_ENTRY_BYTES]
+        .to_vec();
+    let prefix_bytes = ENVELOPE_MAGIC.len() + 2 + 4;
+    noncanonical[prefix_bytes + first_header_offset
+        ..prefix_bytes + first_header_offset + RECIPIENT_ENTRY_BYTES]
+        .copy_from_slice(&second_entry);
+    noncanonical[prefix_bytes + second_header_offset
+        ..prefix_bytes + second_header_offset + RECIPIENT_ENTRY_BYTES]
+        .copy_from_slice(&first_entry);
+    std::fs::write(&noncanonical_path, noncanonical).unwrap();
+    let mut untouched = CollectingSink::default();
+    assert!(matches!(
+        decrypt_local_checkpoint(
+            &noncanonical_path,
+            &staging_for(&noncanonical_path),
+            &sender.public_identity().unwrap(),
+            &recipient,
+            NOW_MS + 1,
+            LOCAL_CHECKPOINT_LIMITS,
+            &mut untouched,
+        ),
+        Err(ContinuationCryptoError::InvalidEnvelope(
+            "recipient list is not in strict canonical order"
+        ))
+    ));
+    assert_eq!(untouched.begin_count, 0);
+
+    for swapped in [
+        row!(
+            "20000000-0000-0000-0000-000000000002",
+            &sender_device_id,
+            header.recipients.as_slice().len() as i32,
+            &recipient_set_sha256,
+        ),
+        row!(
+            &sender_user_id,
+            "30000000-0000-0000-0000-000000000002",
+            header.recipients.as_slice().len() as i32,
+            &recipient_set_sha256,
+        ),
+        row!(&sender_user_id, &sender_device_id, 1, &recipient_set_sha256,),
+        row!(
+            &sender_user_id,
+            &sender_device_id,
+            header.recipients.as_slice().len() as i32,
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ),
+    ] {
+        assert!(CommittedCloudEnvelope::try_from_sql(swapped, NOW_MS + 1).is_err());
+    }
+
+    let mut wrong_object = expected.clone();
+    wrong_object.object_sha256[0] ^= 1;
+    assert!(matches!(
+        decrypt_cloud_checkpoint(
+            &path,
+            &staging_for(&path),
+            CloudCheckpointDecryptRequest {
+                expected: &wrong_object,
+                receipt: &receipt,
+                trusted_sender: &sender.public_identity().unwrap(),
+                recipient: &recipient,
+                now_unix_ms: NOW_MS + 1,
+            },
+            &mut CollectingSink::default(),
+        ),
+        Err(ContinuationCryptoError::ObjectHashMismatch)
+    ));
+
+    let mut wrong_rpc_signature = expected.clone();
+    wrong_rpc_signature.signature[0] ^= 1;
+    assert!(matches!(
+        decrypt_cloud_checkpoint(
+            &path,
+            &staging_for(&path),
+            CloudCheckpointDecryptRequest {
+                expected: &wrong_rpc_signature,
+                receipt: &receipt,
+                trusted_sender: &sender.public_identity().unwrap(),
+                recipient: &recipient,
+                now_unix_ms: NOW_MS + 1,
+            },
+            &mut CollectingSink::default(),
+        ),
+        Err(ContinuationCryptoError::CloudMetadataMismatch("signature"))
+    ));
+
+    assert!(matches!(
+        decrypt_cloud_checkpoint(
+            &path,
+            &staging_for(&path),
+            CloudCheckpointDecryptRequest {
+                expected: &expected,
+                receipt: &receipt_two,
+                trusted_sender: &sender.public_identity().unwrap(),
+                recipient: &recipient,
+                now_unix_ms: NOW_MS + 1,
+            },
+            &mut CollectingSink::default(),
+        ),
+        Err(ContinuationCryptoError::WrongRecipient)
+    ));
+    assert!(matches!(
+        decrypt_cloud_checkpoint(
+            &path,
+            &staging_for(&path),
+            CloudCheckpointDecryptRequest {
+                expected: &expected,
+                receipt: &swapped_user_receipt,
+                trusted_sender: &sender.public_identity().unwrap(),
+                recipient: &recipient,
+                now_unix_ms: NOW_MS + 1,
+            },
+            &mut CollectingSink::default(),
+        ),
+        Err(ContinuationCryptoError::CloudMetadataMismatch(
+            "recipient receipt snapshot"
+        ))
+    ));
+}
+
+#[test]
+fn full_envelope_limit_and_blob_consumption_are_enforced() {
+    let temp = tempfile::tempdir().unwrap();
+    let rejected_path = temp.path().join("full-object-too-large.org2h");
+    let ciphertext_rejected_path = temp.path().join("ciphertext-too-large.org2h");
+    let accepted_path = temp.path().join("blob-consumption.org2h");
+    let (_manager, sender, recipient) = identities();
+    let recipient_public = recipient.public_identity().unwrap();
+    let source = fixture(b"event", b"blob");
+    let mut tiny_limits = LOCAL_CHECKPOINT_LIMITS;
+    tiny_limits.max_envelope_bytes = 1;
+    let write_result = write_local_checkpoint_atomic(
+        &rejected_path,
+        &staging_for(&rejected_path),
+        "rejected-job",
+        LocalEnvelopeWriteRequest {
+            metadata: test_metadata(),
+            sender: &sender,
+            recipients: test_recipient_set(recipient_public.clone()),
+            manifest: source.manifest.clone(),
+            limits: tiny_limits,
+        },
+        |writer| {
+            writer.write_event(7, "event-7", "agent-event", source.event_payload)?;
+            writer.write_blob(&source.blob, &mut Cursor::new(source.blob_payload))
+        },
+    );
+    assert!(matches!(
+        write_result,
+        Err(ContinuationCryptoError::LimitExceeded {
+            kind: LimitKind::EnvelopeBytes,
+            ..
+        })
+    ));
+    assert!(!rejected_path.exists());
+
+    let mut tiny_ciphertext_limits = LOCAL_CHECKPOINT_LIMITS;
+    tiny_ciphertext_limits.max_ciphertext_bytes = 1;
+    let ciphertext_result = write_local_checkpoint_atomic(
+        &ciphertext_rejected_path,
+        &staging_for(&ciphertext_rejected_path),
+        "ciphertext-rejected-job",
+        LocalEnvelopeWriteRequest {
+            metadata: test_metadata(),
+            sender: &sender,
+            recipients: test_recipient_set(recipient_public.clone()),
+            manifest: source.manifest.clone(),
+            limits: tiny_ciphertext_limits,
+        },
+        |writer| {
+            writer.write_event(7, "event-7", "agent-event", source.event_payload)?;
+            writer.write_blob(&source.blob, &mut Cursor::new(source.blob_payload))
+        },
+    );
+    assert!(matches!(
+        ciphertext_result,
+        Err(ContinuationCryptoError::LimitExceeded {
+            kind: LimitKind::CiphertextBytes,
+            ..
+        })
+    ));
+    assert!(!ciphertext_rejected_path.exists());
+
+    write_fixture(&accepted_path, &sender, &recipient_public, &source).unwrap();
+    assert!(matches!(
+        decrypt_local_checkpoint(
+            &accepted_path,
+            &staging_for(&accepted_path),
+            &sender.public_identity().unwrap(),
+            &recipient,
+            NOW_MS + 1,
+            LOCAL_CHECKPOINT_LIMITS,
+            &mut NonConsumingSink,
+        ),
+        Err(ContinuationCryptoError::BlobNotConsumed)
+    ));
+}
+
+#[test]
+fn ciphertext_header_and_signature_tampering_are_rejected_before_plaintext_delivery() {
+    let temp = tempfile::tempdir().unwrap();
+    let original = temp.path().join("original.org2h");
+    let (_manager, sender, recipient) = identities();
+    let recipient_public = recipient.public_identity().unwrap();
+    let source = fixture(b"event", b"blob");
+    let artifact = write_fixture(&original, &sender, &recipient_public, &source).unwrap();
+    let sender_public = sender.public_identity().unwrap();
+    let bytes = std::fs::read(&original).unwrap();
+    let header_len = u32::from_be_bytes(bytes[10..14].try_into().unwrap()) as usize;
+    let ciphertext_offset = 14 + header_len;
+
+    let ciphertext_path = temp.path().join("ciphertext-tampered.org2h");
+    let mut ciphertext = bytes.clone();
+    ciphertext[ciphertext_offset + 5] ^= 1;
+    std::fs::write(&ciphertext_path, ciphertext).unwrap();
+    assert!(matches!(
+        decrypt_local_checkpoint(
+            &ciphertext_path,
+            &staging_for(&ciphertext_path),
+            &sender_public,
+            &recipient,
+            NOW_MS + 1,
+            LOCAL_CHECKPOINT_LIMITS,
+            &mut CollectingSink::default()
+        ),
+        Err(ContinuationCryptoError::CiphertextHashMismatch)
+    ));
+
+    let header_path = temp.path().join("header-tampered.org2h");
+    let mut header_tampered = bytes.clone();
+    let runtime_offset = header_tampered[..14 + header_len]
+        .windows(b"codex".len())
+        .position(|window| window == b"codex")
+        .unwrap();
+    header_tampered[runtime_offset] = b'd';
+    std::fs::write(&header_path, header_tampered).unwrap();
+    assert!(matches!(
+        decrypt_local_checkpoint(
+            &header_path,
+            &staging_for(&header_path),
+            &sender_public,
+            &recipient,
+            NOW_MS + 1,
+            LOCAL_CHECKPOINT_LIMITS,
+            &mut CollectingSink::default()
+        ),
+        Err(ContinuationCryptoError::InvalidSignature)
+    ));
+
+    let signature_path = temp.path().join("signature-tampered.org2h");
+    let mut signature_tampered = bytes;
+    let signature_offset = signature_tampered.len() - 64 - 8;
+    signature_tampered[signature_offset + 17] ^= 1;
+    std::fs::write(&signature_path, signature_tampered).unwrap();
+    assert!(matches!(
+        decrypt_local_checkpoint(
+            &signature_path,
+            &staging_for(&signature_path),
+            &sender_public,
+            &recipient,
+            NOW_MS + 1,
+            LOCAL_CHECKPOINT_LIMITS,
+            &mut CollectingSink::default()
+        ),
+        Err(ContinuationCryptoError::InvalidSignature)
+    ));
+
+    assert_ne!(artifact.header().age_ciphertext_sha256, [0; 32]);
+}
+
+#[test]
+fn truncated_outer_envelope_corpus_never_begins_a_sink_transaction() {
+    let temp = tempfile::tempdir().unwrap();
+    let original = temp.path().join("truncation-source.org2h");
+    let (_manager, sender, recipient) = identities();
+    let source = fixture(b"event", b"blob");
+    write_fixture(
+        &original,
+        &sender,
+        &recipient.public_identity().unwrap(),
+        &source,
+    )
+    .unwrap();
+    let bytes = std::fs::read(&original).unwrap();
+    let header_len = u32::from_be_bytes(bytes[10..14].try_into().unwrap()) as usize;
+    let cuts = [
+        0,
+        1,
+        ENVELOPE_MAGIC.len() - 1,
+        ENVELOPE_MAGIC.len(),
+        13,
+        14,
+        14 + header_len / 2,
+        14 + header_len,
+        bytes.len() - SIGNATURE_BYTES - ENVELOPE_END_MAGIC.len(),
+        bytes.len() - ENVELOPE_END_MAGIC.len(),
+        bytes.len() - 1,
+    ];
+    for (index, cut) in cuts.into_iter().enumerate() {
+        let path = temp.path().join(format!("truncated-{index}.org2h"));
+        std::fs::write(&path, &bytes[..cut]).unwrap();
+        let mut sink = CollectingSink::default();
+        assert!(decrypt_local_checkpoint(
+            &path,
+            &staging_for(&path),
+            &sender.public_identity().unwrap(),
+            &recipient,
+            NOW_MS + 1,
+            LOCAL_CHECKPOINT_LIMITS,
+            &mut sink,
+        )
+        .is_err());
+        assert_eq!(sink.begin_count, 0);
+        assert_eq!(sink.commit_count, 0);
+        assert_eq!(sink.abort_count, 0);
+    }
+}
+
+#[test]
+fn wrong_recipient_expiry_limits_and_path_traversal_fail_closed() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("checkpoint.org2h");
+    let (manager, sender, recipient) = identities();
+    let recipient_public = recipient.public_identity().unwrap();
+    let large_event = vec![b'x'; 2_048];
+    let source = fixture(&large_event, b"blob");
+    write_fixture(&path, &sender, &recipient_public, &source).unwrap();
+    let other = manager
+        .load_or_create(test_uuid(0x30000000000000000000000000000003))
+        .unwrap();
+    let sender_public = sender.public_identity().unwrap();
+    assert!(matches!(
+        decrypt_local_checkpoint(
+            &path,
+            &staging_for(&path),
+            &sender_public,
+            &other,
+            NOW_MS + 1,
+            LOCAL_CHECKPOINT_LIMITS,
+            &mut CollectingSink::default()
+        ),
+        Err(ContinuationCryptoError::WrongRecipient)
+    ));
+    assert!(matches!(
+        decrypt_local_checkpoint(
+            &path,
+            &staging_for(&path),
+            &sender_public,
+            &recipient,
+            NOW_MS + 3_600_000,
+            LOCAL_CHECKPOINT_LIMITS,
+            &mut CollectingSink::default()
+        ),
+        Err(ContinuationCryptoError::Expired(_))
+    ));
+    let low_limits = CheckpointLimits {
+        max_total_decompressed_bytes: 512,
+        ..LOCAL_CHECKPOINT_LIMITS
+    };
+    assert!(matches!(
+        decrypt_local_checkpoint(
+            &path,
+            &staging_for(&path),
+            &sender_public,
+            &recipient,
+            NOW_MS + 1,
+            low_limits,
+            &mut CollectingSink::default()
+        ),
+        Err(ContinuationCryptoError::LimitExceeded {
+            kind: LimitKind::TotalDecompressedBytes,
+            ..
+        })
+    ));
+
+    for relative_path in [
+        "../../outside",
+        "/absolute/path",
+        "C:/windows/path",
+        "windows\\backslash",
+        "safe/../escape",
+        "safe//ambiguous",
+        "safe/NUL.txt",
+        "safe/trailing.",
+        "safe/含糊.bin",
+    ] {
+        let unsafe_blob = BlobMetadata {
+            relative_path: relative_path.into(),
+            media_type: "application/octet-stream".into(),
+            content_len: 1,
+            sha256: Sha256::digest(b"x").into(),
+        };
+        let mut hasher = CheckpointPlaintextHasher::new(LOCAL_CHECKPOINT_LIMITS);
+        assert!(matches!(
+            hasher.update_blob(&unsafe_blob, &mut Cursor::new(b"x")),
+            Err(ContinuationCryptoError::UnsafePath(_))
+        ));
+    }
+    let duplicate = BlobMetadata {
+        relative_path: "safe/blob.bin".into(),
+        media_type: "application/octet-stream".into(),
+        content_len: 1,
+        sha256: Sha256::digest(b"x").into(),
+    };
+    let mut hasher = CheckpointPlaintextHasher::new(LOCAL_CHECKPOINT_LIMITS);
+    hasher
+        .update_blob(&duplicate, &mut Cursor::new(b"x"))
+        .unwrap();
+    let duplicate_case_variant = BlobMetadata {
+        relative_path: "SAFE/BLOB.BIN".into(),
+        ..duplicate
+    };
+    assert!(matches!(
+        hasher.update_blob(&duplicate_case_variant, &mut Cursor::new(b"x")),
+        Err(ContinuationCryptoError::InvalidFrame("duplicate blob path"))
+    ));
+}
+
+#[test]
+fn old_recipient_key_remains_decryptable_after_rotation_without_implicit_pruning() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("old-key.org2h");
+    let store = MemorySecretStore::default();
+    let manager = memory_manager(store);
+    let sender_id = test_uuid(0x30000000000000000000000000000011);
+    let recipient_id = test_uuid(0x30000000000000000000000000000012);
+    let sender = manager.load_or_create(sender_id).unwrap();
+    let recipient_v1 = manager.load_or_create(recipient_id).unwrap();
+    let recipient_v1_public = recipient_v1.public_identity().unwrap();
+    let recipient_v2 = manager.rotate(recipient_id).unwrap();
+    let source = fixture(b"event", b"blob");
+    write_fixture(&path, &sender, &recipient_v1_public, &source).unwrap();
+    assert!(matches!(
+        decrypt_local_checkpoint(
+            &path,
+            &staging_for(&path),
+            &sender.public_identity().unwrap(),
+            &recipient_v2,
+            NOW_MS + 1,
+            LOCAL_CHECKPOINT_LIMITS,
+            &mut CollectingSink::default()
+        ),
+        Err(ContinuationCryptoError::WrongRecipient)
+    ));
+    let retained_v1 = manager.load_version(recipient_id, 1).unwrap();
+    decrypt_local_checkpoint(
+        &path,
+        &staging_for(&path),
+        &sender.public_identity().unwrap(),
+        &retained_v1,
+        NOW_MS + 1,
+        LOCAL_CHECKPOINT_LIMITS,
+        &mut CollectingSink::default(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn committed_sender_snapshot_verifies_after_sender_key_rotation_or_revocation() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("sender-snapshot.org2h");
+    let store = MemorySecretStore::default();
+    let manager = memory_manager(store);
+    let sender_id = test_uuid(0x30000000000000000000000000000021);
+    let recipient_id = test_uuid(0x30000000000000000000000000000022);
+    let sender_v1 = manager.load_or_create(sender_id).unwrap();
+    let sender_v1_snapshot = sender_v1.public_identity().unwrap();
+    let recipient = manager.load_or_create(recipient_id).unwrap();
+    let recipient_public = recipient.public_identity().unwrap();
+    let source = fixture(b"event", b"blob");
+    write_fixture(&path, &sender_v1, &recipient_public, &source).unwrap();
+
+    let sender_v2 = manager.rotate(sender_id).unwrap();
+    let sender_v2_public = sender_v2.public_identity().unwrap();
+    assert!(matches!(
+        decrypt_local_checkpoint(
+            &path,
+            &staging_for(&path),
+            &sender_v2_public,
+            &recipient,
+            NOW_MS + 1,
+            LOCAL_CHECKPOINT_LIMITS,
+            &mut CollectingSink::default(),
+        ),
+        Err(ContinuationCryptoError::UntrustedSender)
+    ));
+    decrypt_local_checkpoint(
+        &path,
+        &staging_for(&path),
+        &sender_v1_snapshot,
+        &recipient,
+        NOW_MS + 1,
+        LOCAL_CHECKPOINT_LIMITS,
+        &mut CollectingSink::default(),
+    )
+    .unwrap();
+}
+
+#[test]
+fn writer_rejects_record_limits_without_publishing_partial_ciphertext() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("too-large.org2h");
+    let (_manager, sender, recipient) = identities();
+    let recipient_public = recipient.public_identity().unwrap();
+    let payload = b"too large";
+    let mut limits = LOCAL_CHECKPOINT_LIMITS;
+    limits.max_event_bytes = 2;
+    let mut hasher = CheckpointPlaintextHasher::new(LOCAL_CHECKPOINT_LIMITS);
+    hasher.update_event(1, "e", "event", payload).unwrap();
+    let manifest = hasher.finish().manifest("schema".into(), 1);
+    let result = write_local_checkpoint_atomic(
+        &path,
+        &staging_for(&path),
+        "record-limit-job",
+        LocalEnvelopeWriteRequest {
+            metadata: test_metadata(),
+            sender: &sender,
+            recipients: test_recipient_set(recipient_public.clone()),
+            manifest,
+            limits,
+        },
+        |writer| writer.write_event(1, "e", "event", payload),
+    );
+    assert!(matches!(
+        result,
+        Err(ContinuationCryptoError::LimitExceeded {
+            kind: LimitKind::EventBytes,
+            ..
+        })
+    ));
+    assert!(!path.exists());
+}
+
+#[test]
+fn first_pass_enforces_frame_record_blob_and_blob_byte_limits() {
+    let mut frame_limits = LOCAL_CHECKPOINT_LIMITS;
+    frame_limits.max_frame_bytes = 1;
+    assert!(matches!(
+        CheckpointPlaintextHasher::new(frame_limits).update_event(1, "e", "event", b"x"),
+        Err(ContinuationCryptoError::LimitExceeded {
+            kind: LimitKind::FrameBytes,
+            ..
+        })
+    ));
+
+    let mut record_limits = LOCAL_CHECKPOINT_LIMITS;
+    record_limits.max_records = 0;
+    assert!(matches!(
+        CheckpointPlaintextHasher::new(record_limits).update_event(1, "e", "event", b"x"),
+        Err(ContinuationCryptoError::LimitExceeded {
+            kind: LimitKind::Records,
+            ..
+        })
+    ));
+
+    let blob = BlobMetadata {
+        relative_path: "safe/blob.bin".into(),
+        media_type: "application/octet-stream".into(),
+        content_len: 1,
+        sha256: Sha256::digest(b"x").into(),
+    };
+    let mut blob_count_limits = LOCAL_CHECKPOINT_LIMITS;
+    blob_count_limits.max_blobs = 0;
+    assert!(matches!(
+        CheckpointPlaintextHasher::new(blob_count_limits)
+            .update_blob(&blob, &mut Cursor::new(b"x")),
+        Err(ContinuationCryptoError::LimitExceeded {
+            kind: LimitKind::Blobs,
+            ..
+        })
+    ));
+
+    let mut blob_byte_limits = LOCAL_CHECKPOINT_LIMITS;
+    blob_byte_limits.max_blob_bytes = 0;
+    assert!(matches!(
+        CheckpointPlaintextHasher::new(blob_byte_limits).update_blob(&blob, &mut Cursor::new(b"x")),
+        Err(ContinuationCryptoError::LimitExceeded {
+            kind: LimitKind::BlobBytes,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn atomic_publish_never_clobbers_an_existing_checkpoint() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("checkpoint.org2h");
+    let (_manager, sender, recipient) = identities();
+    let recipient_public = recipient.public_identity().unwrap();
+    let source = fixture(b"event", b"blob");
+    write_fixture(&path, &sender, &recipient_public, &source).unwrap();
+    let before = std::fs::read(&path).unwrap();
+    assert!(matches!(
+        write_fixture(&path, &sender, &recipient_public, &source),
+        Err(ContinuationCryptoError::DestinationExists(_))
+    ));
+    assert_eq!(std::fs::read(&path).unwrap(), before);
+}

--- a/src-tauri/crates/continuation-crypto/src/tests.rs
+++ b/src-tauri/crates/continuation-crypto/src/tests.rs
@@ -287,7 +287,8 @@ fn test_metadata() -> CloudEnvelopeMetadata {
         "root-session-a".into(),
         "episode-a".into(),
         "codex".into(),
-        "claude".into(),
+        "org2.continuation.checkpoint".into(),
+        1,
         RecipientScope::Audience,
         test_uuid(0x20000000000000000000000000000001),
         NOW_MS,
@@ -406,7 +407,8 @@ fn canonical_header_and_signed_bytes_have_exact_golden_vector() {
         root_session_id: "root-session-a".into(),
         source_episode_id: "episode-a".into(),
         source_runtime: "codex".into(),
-        target_runtime: "claude".into(),
+        payload_schema: "org2.portable_conversation".into(),
+        payload_schema_version: 2,
         recipient_scope: RecipientScope::Audience,
         sender_user_id: test_uuid(0x20000000000000000000000000000001),
         sender,
@@ -438,22 +440,22 @@ fn canonical_header_and_signed_bytes_have_exact_golden_vector() {
         hex::encode(recipient_set_sha256),
         "9ddfed1c641fa7cd2e0b93511b878361a3bedf8485708c75f0057ab6429ecbb7"
     );
-    assert_eq!(raw_header.len(), 565);
+    assert_eq!(raw_header.len(), 587);
     assert_eq!(
         hex::encode(&raw_header),
-        "010101011000000000000000000000000000000140000000000000000000000000000001000e726f6f742d73657373696f6e2d610009657069736f64652d610005636f6465780006636c6175646501200000000000000000000000000000013000000000000000000000000000000100000007000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1fd75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a5c63ff72e6ce93d42fe2dab5ef6a11bc9aeba024d6176910d9dfb8d9460c397a00029ddfed1c641fa7cd2e0b93511b878361a3bedf8485708c75f0057ab6429ecbb7200000000000000000000000000000023000000000000000000000000000000200000009202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660cd137b40d6290e550801d7481ebaab1ca9ca2f1936e89ddb26ede2b663a0d57db20000000000000000000000000000003300000000000000000000000000000030000000b404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5fed4928c628d1c2c6eae90338905995612959273a5c63f93636c14614ac8737d10aa1f475680f3504f42465144b415100ab0d25b787494a1860ccca47af8197b4a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5000001a3185c5000000001a318933e8000000000000004d2"
+        "010101011000000000000000000000000000000140000000000000000000000000000001000e726f6f742d73657373696f6e2d610009657069736f64652d610005636f646578001a6f7267322e706f727461626c655f636f6e766572736174696f6e000201200000000000000000000000000000013000000000000000000000000000000100000007000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1fd75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a5c63ff72e6ce93d42fe2dab5ef6a11bc9aeba024d6176910d9dfb8d9460c397a00029ddfed1c641fa7cd2e0b93511b878361a3bedf8485708c75f0057ab6429ecbb7200000000000000000000000000000023000000000000000000000000000000200000009202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660cd137b40d6290e550801d7481ebaab1ca9ca2f1936e89ddb26ede2b663a0d57db20000000000000000000000000000003300000000000000000000000000000030000000b404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5fed4928c628d1c2c6eae90338905995612959273a5c63f93636c14614ac8737d10aa1f475680f3504f42465144b415100ab0d25b787494a1860ccca47af8197b4a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5a5000001a3185c5000000001a318933e8000000000000004d2"
     );
     assert_eq!(
         hex::encode(Sha256::digest(&raw_header)),
-        "7de14a7d826b915bd19d55bac5255fcc25786fb93a36d268bececa68df451d59"
+        "4bd4bde95b64e5a2230068bcf672184c3e4f64df6a010af1e1132d174841a5e1"
     );
     assert_eq!(
         hex::encode(Sha256::digest(&signed)),
-        "0dd738152b0fbfad87462a770b3c614e828112fe6506052e46e2399001796ad7"
+        "eca71c52611d9317c51a0a4526a1f86bc68655dbaec73c35a7dfdd1f2f3fa10c"
     );
     assert_eq!(
         hex::encode(signature.to_bytes()),
-        "b5f125019861b57d0745ec4d9917208bace0c245850c68ad9f114ebcf0107f88d31f86d551d3b3c6809bebcff5bdd81fe0fd18bbd5869da108725c2b5e04fb03"
+        "b612ae200776267d65b3635502e5044bd0910d5584d6d9cbeabf05823ee13927a946b1273b8527e3c767ef4effcd9cdc5242674b9c665993b8b5983874c7bd07"
     );
 }
 
@@ -537,7 +539,8 @@ fn cloud_routing_metadata_and_receipt_sql_encodings_are_strict() {
             "root-session-a".into(),
             "episode-a".into(),
             "codex".into(),
-            "claude".into(),
+            "org2.continuation.checkpoint".into(),
+            1,
             "audience",
             "20000000-0000-0000-0000-000000000001",
             NOW_MS,
@@ -552,7 +555,8 @@ fn cloud_routing_metadata_and_receipt_sql_encodings_are_strict() {
         "root-session-a".into(),
         "episode-a".into(),
         "Codex".into(),
-        "claude".into(),
+        "org2.continuation.checkpoint".into(),
+        1,
         "audience",
         "20000000-0000-0000-0000-000000000001",
         NOW_MS,
@@ -566,7 +570,8 @@ fn cloud_routing_metadata_and_receipt_sql_encodings_are_strict() {
         "x".repeat(201),
         "episode-a".into(),
         "codex".into(),
-        "claude".into(),
+        "org2.continuation.checkpoint".into(),
+        1,
         "subset",
         "20000000-0000-0000-0000-000000000001",
         NOW_MS,
@@ -580,7 +585,8 @@ fn cloud_routing_metadata_and_receipt_sql_encodings_are_strict() {
         "root-session-a".into(),
         "episode-a".into(),
         "codex".into(),
-        "claude".into(),
+        "org2.continuation.checkpoint".into(),
+        1,
         "all",
         "20000000-0000-0000-0000-000000000001",
         NOW_MS,
@@ -594,7 +600,8 @@ fn cloud_routing_metadata_and_receipt_sql_encodings_are_strict() {
         "root-session-a".into(),
         "episode-a".into(),
         "codex".into(),
-        "claude".into(),
+        "org2.continuation.checkpoint".into(),
+        1,
         "audience",
         "20000000-0000-0000-0000-000000000001",
         NOW_MS,
@@ -1069,7 +1076,8 @@ fn cloud_entrypoint_pins_row_metadata_footer_signature_and_16_mib_profile() {
                 sender_device_id: $sender_device,
                 sender_key_version: header.sender.key_version as i32,
                 source_runtime: &header.source_runtime,
-                target_runtime: &header.target_runtime,
+                payload_schema: &header.payload_schema,
+                payload_schema_version: i32::from(header.payload_schema_version),
                 recipient_scope: "audience",
                 recipient_count: $recipient_count,
                 recipient_set_sha256: $set_hash,
@@ -1673,7 +1681,9 @@ fn writer_rejects_record_limits_without_publishing_partial_ciphertext() {
     limits.max_event_bytes = 2;
     let mut hasher = CheckpointPlaintextHasher::new(LOCAL_CHECKPOINT_LIMITS);
     hasher.update_event(1, "e", "event", payload).unwrap();
-    let manifest = hasher.finish().manifest("schema".into(), 1);
+    let manifest = hasher
+        .finish()
+        .manifest("org2.continuation.checkpoint".into(), 1);
     let result = write_local_checkpoint_atomic(
         &path,
         &staging_for(&path),
@@ -1693,6 +1703,37 @@ fn writer_rejects_record_limits_without_publishing_partial_ciphertext() {
             kind: LimitKind::EventBytes,
             ..
         })
+    ));
+    assert!(!path.exists());
+}
+
+#[test]
+fn writer_rejects_manifest_schema_not_bound_by_the_signed_header() {
+    let temp = tempfile::tempdir().unwrap();
+    let path = temp.path().join("schema-mismatch.org2h");
+    let (_manager, sender, recipient) = identities();
+    let source = fixture(b"event", b"blob");
+    let mut manifest = source.manifest;
+    manifest.schema_version = 2;
+
+    let result = write_local_checkpoint_atomic(
+        &path,
+        &staging_for(&path),
+        "schema-mismatch-job",
+        LocalEnvelopeWriteRequest {
+            metadata: test_metadata(),
+            sender: &sender,
+            recipients: test_recipient_set(recipient.public_identity().unwrap()),
+            manifest,
+            limits: LOCAL_CHECKPOINT_LIMITS,
+        },
+        |writer| writer.write_event(7, "event-7", "agent-event", source.event_payload),
+    );
+    assert!(matches!(
+        result,
+        Err(ContinuationCryptoError::InvalidEnvelope(
+            "manifest schema does not match signed payload schema"
+        ))
     ));
     assert!(!path.exists());
 }

--- a/src-tauri/crates/continuation-crypto/src/wire.rs
+++ b/src-tauri/crates/continuation-crypto/src/wire.rs
@@ -10,6 +10,7 @@ pub const ENVELOPE_END_MAGIC: &[u8; 8] = b"ORG2END\0";
 pub const MAX_CANONICAL_HEADER_BYTES: usize = 16 * 1024;
 pub const MAX_CONVERSATION_ID_BYTES: usize = 200;
 pub const MAX_RUNTIME_ID_BYTES: usize = 64;
+pub const MAX_PAYLOAD_SCHEMA_ID_BYTES: usize = 128;
 pub const MAX_ENVELOPE_RECIPIENTS: usize = 64;
 pub const RECIPIENT_SET_HASH_DOMAIN: &[u8] = b"ORG2-CONTINUATION-RECIPIENT-SET-V1";
 pub const MIN_ENVELOPE_TTL_MS: u64 = 5 * 60 * 1_000;
@@ -234,7 +235,8 @@ pub struct ContinuationEnvelopeHeader {
     pub root_session_id: String,
     pub source_episode_id: String,
     pub source_runtime: String,
-    pub target_runtime: String,
+    pub payload_schema: String,
+    pub payload_schema_version: u16,
     pub recipient_scope: RecipientScope,
     pub sender_user_id: Uuid,
     pub sender: DevicePublicIdentity,
@@ -259,7 +261,16 @@ impl ContinuationEnvelopeHeader {
             MAX_CONVERSATION_ID_BYTES,
         )?;
         validate_runtime("source runtime", &self.source_runtime)?;
-        validate_runtime("target runtime", &self.target_runtime)?;
+        validate_identifier(
+            "payload schema",
+            &self.payload_schema,
+            MAX_PAYLOAD_SCHEMA_ID_BYTES,
+        )?;
+        if self.payload_schema_version == 0 {
+            return Err(ContinuationCryptoError::InvalidEnvelope(
+                "payload schema version must be positive",
+            ));
+        }
         self.sender.validate()?;
         CloudRecipientSet::validate_entries(self.recipients.as_slice(), true)?;
         if self.recipient_set_sha256 != self.recipients.sha256() {
@@ -311,7 +322,8 @@ pub fn canonical_header_bytes(
     put_string(&mut bytes, &header.root_session_id)?;
     put_string(&mut bytes, &header.source_episode_id)?;
     put_string(&mut bytes, &header.source_runtime)?;
-    put_string(&mut bytes, &header.target_runtime)?;
+    put_string(&mut bytes, &header.payload_schema)?;
+    bytes.extend_from_slice(&header.payload_schema_version.to_be_bytes());
     bytes.push(header.recipient_scope as u8);
     bytes.extend_from_slice(header.sender_user_id.as_bytes());
     put_identity(&mut bytes, &header.sender)?;
@@ -356,7 +368,8 @@ pub(crate) fn decode_canonical_header(
         root_session_id: cursor.string(MAX_CONVERSATION_ID_BYTES)?,
         source_episode_id: cursor.string(MAX_CONVERSATION_ID_BYTES)?,
         source_runtime: cursor.string(MAX_RUNTIME_ID_BYTES)?,
-        target_runtime: cursor.string(MAX_RUNTIME_ID_BYTES)?,
+        payload_schema: cursor.string(MAX_PAYLOAD_SCHEMA_ID_BYTES)?,
+        payload_schema_version: cursor.u16()?,
         recipient_scope: RecipientScope::try_from(cursor.u8()?)?,
         sender_user_id: Uuid::from_bytes(cursor.array()?),
         sender: cursor.identity()?,

--- a/src-tauri/crates/continuation-crypto/src/wire.rs
+++ b/src-tauri/crates/continuation-crypto/src/wire.rs
@@ -1,0 +1,582 @@
+use std::{cmp::Ordering, collections::HashSet};
+
+use crate::{ContinuationCryptoError, DevicePublicIdentity, LimitKind};
+use uuid::Uuid;
+
+pub const ENVELOPE_MAGIC: &[u8; 8] = b"ORG2HND\0";
+pub const ENVELOPE_VERSION: u16 = 1;
+pub const SIGNATURE_DOMAIN: &[u8] = b"ORG2-CONTINUATION-ENVELOPE-SIGNATURE-V1";
+pub const ENVELOPE_END_MAGIC: &[u8; 8] = b"ORG2END\0";
+pub const MAX_CANONICAL_HEADER_BYTES: usize = 16 * 1024;
+pub const MAX_CONVERSATION_ID_BYTES: usize = 200;
+pub const MAX_RUNTIME_ID_BYTES: usize = 64;
+pub const MAX_ENVELOPE_RECIPIENTS: usize = 64;
+pub const RECIPIENT_SET_HASH_DOMAIN: &[u8] = b"ORG2-CONTINUATION-RECIPIENT-SET-V1";
+pub const MIN_ENVELOPE_TTL_MS: u64 = 5 * 60 * 1_000;
+pub const MAX_ENVELOPE_TTL_MS: u64 = 7 * 24 * 60 * 60 * 1_000;
+pub const MAX_CREATED_AT_FUTURE_SKEW_MS: u64 = 5 * 60 * 1_000;
+pub const SIGNATURE_BYTES: usize = 64;
+pub const PREFIX_BYTES: usize = ENVELOPE_MAGIC.len() + 2 + 4;
+pub const SUFFIX_BYTES: usize = SIGNATURE_BYTES + ENVELOPE_END_MAGIC.len();
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum EncryptionAlgorithm {
+    AgeX25519 = 1,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum SignatureAlgorithm {
+    Ed25519 = 1,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum CompressionAlgorithm {
+    Gzip = 1,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum HashAlgorithm {
+    Sha256 = 1,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum RecipientScope {
+    Audience = 1,
+    Subset = 2,
+}
+
+impl TryFrom<u8> for RecipientScope {
+    type Error = ContinuationCryptoError;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::Audience),
+            2 => Ok(Self::Subset),
+            _ => Err(ContinuationCryptoError::UnsupportedAlgorithm {
+                kind: "recipient scope",
+                value,
+            }),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CloudRecipient {
+    recipient_user_id: Uuid,
+    identity: DevicePublicIdentity,
+}
+
+impl CloudRecipient {
+    pub fn try_new(
+        recipient_user_id: Uuid,
+        identity: DevicePublicIdentity,
+    ) -> Result<Self, ContinuationCryptoError> {
+        if recipient_user_id.is_nil() {
+            return Err(ContinuationCryptoError::InvalidEnvelope(
+                "recipient user UUID must be non-nil",
+            ));
+        }
+        identity.validate()?;
+        Ok(Self {
+            recipient_user_id,
+            identity,
+        })
+    }
+
+    pub fn recipient_user_id(&self) -> Uuid {
+        self.recipient_user_id
+    }
+
+    pub fn identity(&self) -> &DevicePublicIdentity {
+        &self.identity
+    }
+
+    fn canonical_cmp(&self, other: &Self) -> Ordering {
+        self.recipient_user_id
+            .as_bytes()
+            .cmp(other.recipient_user_id.as_bytes())
+            .then_with(|| {
+                self.identity
+                    .device_id
+                    .as_bytes()
+                    .cmp(other.identity.device_id.as_bytes())
+            })
+            .then_with(|| self.identity.key_version.cmp(&other.identity.key_version))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CloudRecipientSet(Vec<CloudRecipient>);
+
+impl CloudRecipientSet {
+    pub fn try_new(mut recipients: Vec<CloudRecipient>) -> Result<Self, ContinuationCryptoError> {
+        recipients.sort_by(CloudRecipient::canonical_cmp);
+        Self::validate_entries(&recipients, false)?;
+        Ok(Self(recipients))
+    }
+
+    pub fn as_slice(&self) -> &[CloudRecipient] {
+        &self.0
+    }
+
+    pub fn sha256(&self) -> [u8; 32] {
+        use sha2::{Digest, Sha256};
+
+        let mut digest = Sha256::new();
+        digest.update(RECIPIENT_SET_HASH_DOMAIN);
+        digest.update([0]);
+        digest.update((self.0.len() as u16).to_be_bytes());
+        for recipient in &self.0 {
+            digest.update(recipient.recipient_user_id.as_bytes());
+            digest.update(recipient.identity.device_id.as_bytes());
+            digest.update(recipient.identity.key_version.to_be_bytes());
+            digest.update(recipient.identity.encryption_public_key);
+            digest.update(recipient.identity.signing_public_key);
+            digest.update(recipient.identity.fingerprint);
+        }
+        digest.finalize().into()
+    }
+
+    fn from_canonical(recipients: Vec<CloudRecipient>) -> Result<Self, ContinuationCryptoError> {
+        Self::validate_entries(&recipients, true)?;
+        Ok(Self(recipients))
+    }
+
+    fn validate_entries(
+        recipients: &[CloudRecipient],
+        require_sorted_input: bool,
+    ) -> Result<(), ContinuationCryptoError> {
+        if recipients.is_empty() || recipients.len() > MAX_ENVELOPE_RECIPIENTS {
+            return Err(ContinuationCryptoError::InvalidEnvelope(
+                "recipient list must contain between one and 64 entries",
+            ));
+        }
+        let mut user_devices = HashSet::with_capacity(recipients.len());
+        let mut device_ids = HashSet::with_capacity(recipients.len());
+        for (index, recipient) in recipients.iter().enumerate() {
+            recipient.identity.validate()?;
+            if recipient.recipient_user_id.is_nil()
+                || !user_devices.insert((recipient.recipient_user_id, recipient.identity.device_id))
+                || !device_ids.insert(recipient.identity.device_id)
+            {
+                return Err(ContinuationCryptoError::InvalidEnvelope(
+                    "recipient list contains a duplicate device key route",
+                ));
+            }
+            if require_sorted_input
+                && index > 0
+                && recipients[index - 1].canonical_cmp(recipient) != Ordering::Less
+            {
+                return Err(ContinuationCryptoError::InvalidEnvelope(
+                    "recipient list is not in strict canonical order",
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+macro_rules! algorithm_try_from {
+    ($type:ty, $kind:literal, $variant:path) => {
+        impl TryFrom<u8> for $type {
+            type Error = ContinuationCryptoError;
+
+            fn try_from(value: u8) -> Result<Self, Self::Error> {
+                match value {
+                    1 => Ok($variant),
+                    other => Err(ContinuationCryptoError::UnsupportedAlgorithm {
+                        kind: $kind,
+                        value: other,
+                    }),
+                }
+            }
+        }
+    };
+}
+
+algorithm_try_from!(
+    EncryptionAlgorithm,
+    "encryption",
+    EncryptionAlgorithm::AgeX25519
+);
+algorithm_try_from!(SignatureAlgorithm, "signature", SignatureAlgorithm::Ed25519);
+algorithm_try_from!(
+    CompressionAlgorithm,
+    "compression",
+    CompressionAlgorithm::Gzip
+);
+algorithm_try_from!(HashAlgorithm, "hash", HashAlgorithm::Sha256);
+
+/// Canonical public metadata mirrored by cloud storage for routing and audit.
+///
+/// It intentionally contains no plaintext digest or private/session contents.
+/// `age_ciphertext_sha256` is the SHA-256 of exactly the standard age payload
+/// that follows the header. Full-object size/hash are deliberately outside
+/// this signed header: they cover this header and the signature too, so putting
+/// either value here would create a circular digest. Cloud persists both sets
+/// as distinct fields.
+///
+/// All integers use big-endian encoding; all strings use a big-endian `u16`
+/// byte-length prefix followed by canonical UTF-8 bytes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ContinuationEnvelopeHeader {
+    pub encryption_algorithm: EncryptionAlgorithm,
+    pub signature_algorithm: SignatureAlgorithm,
+    pub compression_algorithm: CompressionAlgorithm,
+    pub hash_algorithm: HashAlgorithm,
+    pub org_id: Uuid,
+    pub checkpoint_id: Uuid,
+    pub root_session_id: String,
+    pub source_episode_id: String,
+    pub source_runtime: String,
+    pub target_runtime: String,
+    pub recipient_scope: RecipientScope,
+    pub sender_user_id: Uuid,
+    pub sender: DevicePublicIdentity,
+    pub recipients: CloudRecipientSet,
+    pub recipient_set_sha256: [u8; 32],
+    pub age_ciphertext_sha256: [u8; 32],
+    pub created_at_unix_ms: u64,
+    pub expires_at_unix_ms: u64,
+    pub age_ciphertext_len: u64,
+}
+
+impl ContinuationEnvelopeHeader {
+    pub fn validate(&self) -> Result<(), ContinuationCryptoError> {
+        validate_identifier(
+            "root session id",
+            &self.root_session_id,
+            MAX_CONVERSATION_ID_BYTES,
+        )?;
+        validate_identifier(
+            "source episode id",
+            &self.source_episode_id,
+            MAX_CONVERSATION_ID_BYTES,
+        )?;
+        validate_runtime("source runtime", &self.source_runtime)?;
+        validate_runtime("target runtime", &self.target_runtime)?;
+        self.sender.validate()?;
+        CloudRecipientSet::validate_entries(self.recipients.as_slice(), true)?;
+        if self.recipient_set_sha256 != self.recipients.sha256() {
+            return Err(ContinuationCryptoError::InvalidEnvelope(
+                "recipient set SHA-256 mismatch",
+            ));
+        }
+        if self.org_id.is_nil() || self.checkpoint_id.is_nil() || self.sender_user_id.is_nil() {
+            return Err(ContinuationCryptoError::InvalidEnvelope(
+                "routing UUIDs must be non-nil",
+            ));
+        }
+        if self.created_at_unix_ms == 0 {
+            return Err(ContinuationCryptoError::InvalidEnvelope(
+                "created-at timestamp must be positive",
+            ));
+        }
+        if self.expires_at_unix_ms <= self.created_at_unix_ms {
+            return Err(ContinuationCryptoError::InvalidEnvelope(
+                "expiry must be later than creation",
+            ));
+        }
+        let ttl = self.expires_at_unix_ms - self.created_at_unix_ms;
+        if !(MIN_ENVELOPE_TTL_MS..=MAX_ENVELOPE_TTL_MS).contains(&ttl) {
+            return Err(ContinuationCryptoError::InvalidEnvelope(
+                "envelope lifetime must be between five minutes and seven days",
+            ));
+        }
+        if self.age_ciphertext_len == 0 {
+            return Err(ContinuationCryptoError::InvalidEnvelope(
+                "ciphertext length must be positive",
+            ));
+        }
+        Ok(())
+    }
+}
+
+pub fn canonical_header_bytes(
+    header: &ContinuationEnvelopeHeader,
+) -> Result<Vec<u8>, ContinuationCryptoError> {
+    header.validate()?;
+    let mut bytes = Vec::with_capacity(768);
+    bytes.push(header.encryption_algorithm as u8);
+    bytes.push(header.signature_algorithm as u8);
+    bytes.push(header.compression_algorithm as u8);
+    bytes.push(header.hash_algorithm as u8);
+    bytes.extend_from_slice(header.org_id.as_bytes());
+    bytes.extend_from_slice(header.checkpoint_id.as_bytes());
+    put_string(&mut bytes, &header.root_session_id)?;
+    put_string(&mut bytes, &header.source_episode_id)?;
+    put_string(&mut bytes, &header.source_runtime)?;
+    put_string(&mut bytes, &header.target_runtime)?;
+    bytes.push(header.recipient_scope as u8);
+    bytes.extend_from_slice(header.sender_user_id.as_bytes());
+    put_identity(&mut bytes, &header.sender)?;
+    bytes.extend_from_slice(&(header.recipients.as_slice().len() as u16).to_be_bytes());
+    bytes.extend_from_slice(&header.recipient_set_sha256);
+    for recipient in header.recipients.as_slice() {
+        bytes.extend_from_slice(recipient.recipient_user_id.as_bytes());
+        put_identity(&mut bytes, &recipient.identity)?;
+    }
+    bytes.extend_from_slice(&header.age_ciphertext_sha256);
+    bytes.extend_from_slice(&header.created_at_unix_ms.to_be_bytes());
+    bytes.extend_from_slice(&header.expires_at_unix_ms.to_be_bytes());
+    bytes.extend_from_slice(&header.age_ciphertext_len.to_be_bytes());
+    if bytes.len() > MAX_CANONICAL_HEADER_BYTES {
+        return Err(ContinuationCryptoError::limit(
+            LimitKind::HeaderBytes,
+            MAX_CANONICAL_HEADER_BYTES as u64,
+            bytes.len() as u64,
+        ));
+    }
+    Ok(bytes)
+}
+
+pub(crate) fn decode_canonical_header(
+    bytes: &[u8],
+) -> Result<ContinuationEnvelopeHeader, ContinuationCryptoError> {
+    if bytes.len() > MAX_CANONICAL_HEADER_BYTES {
+        return Err(ContinuationCryptoError::limit(
+            LimitKind::HeaderBytes,
+            MAX_CANONICAL_HEADER_BYTES as u64,
+            bytes.len() as u64,
+        ));
+    }
+    let mut cursor = HeaderCursor::new(bytes);
+    let header = ContinuationEnvelopeHeader {
+        encryption_algorithm: EncryptionAlgorithm::try_from(cursor.u8()?)?,
+        signature_algorithm: SignatureAlgorithm::try_from(cursor.u8()?)?,
+        compression_algorithm: CompressionAlgorithm::try_from(cursor.u8()?)?,
+        hash_algorithm: HashAlgorithm::try_from(cursor.u8()?)?,
+        org_id: Uuid::from_bytes(cursor.array()?),
+        checkpoint_id: Uuid::from_bytes(cursor.array()?),
+        root_session_id: cursor.string(MAX_CONVERSATION_ID_BYTES)?,
+        source_episode_id: cursor.string(MAX_CONVERSATION_ID_BYTES)?,
+        source_runtime: cursor.string(MAX_RUNTIME_ID_BYTES)?,
+        target_runtime: cursor.string(MAX_RUNTIME_ID_BYTES)?,
+        recipient_scope: RecipientScope::try_from(cursor.u8()?)?,
+        sender_user_id: Uuid::from_bytes(cursor.array()?),
+        sender: cursor.identity()?,
+        recipients: {
+            let count = cursor.u16()? as usize;
+            let expected_sha256: [u8; 32] = cursor.array()?;
+            let recipients = cursor.recipients_with_count(count)?;
+            if recipients.sha256() != expected_sha256 {
+                return Err(ContinuationCryptoError::InvalidEnvelope(
+                    "recipient set SHA-256 mismatch",
+                ));
+            }
+            recipients
+        },
+        recipient_set_sha256: {
+            // Recomputed below from the decoded canonical set; keeping this
+            // field explicit binds the Cloud object-row mirror.
+            [0; 32]
+        },
+        age_ciphertext_sha256: cursor.array()?,
+        created_at_unix_ms: cursor.u64()?,
+        expires_at_unix_ms: cursor.u64()?,
+        age_ciphertext_len: cursor.u64()?,
+    };
+    if !cursor.is_empty() {
+        return Err(ContinuationCryptoError::InvalidEnvelope(
+            "trailing canonical header bytes",
+        ));
+    }
+    let mut header = header;
+    header.recipient_set_sha256 = header.recipients.sha256();
+    header.validate()?;
+    if canonical_header_bytes(&header)? != bytes {
+        return Err(ContinuationCryptoError::InvalidEnvelope(
+            "non-canonical header encoding",
+        ));
+    }
+    Ok(header)
+}
+
+/// Exact bytes signed by the sender:
+///
+/// `SIGNATURE_DOMAIN || 0x00 || be_u32(header_len) || raw_header || age_ciphertext_sha256`
+///
+/// The returned bytes are the single signature contract used by both the
+/// envelope footer and the Cloud prepare/commit RPC. Callers must persist the
+/// resulting 64 Ed25519 bytes verbatim; there is no second RPC signature.
+pub fn signature_message(
+    raw_header: &[u8],
+    age_ciphertext_sha256: &[u8; 32],
+) -> Result<Vec<u8>, ContinuationCryptoError> {
+    if raw_header.len() > MAX_CANONICAL_HEADER_BYTES {
+        return Err(ContinuationCryptoError::limit(
+            LimitKind::HeaderBytes,
+            MAX_CANONICAL_HEADER_BYTES as u64,
+            raw_header.len() as u64,
+        ));
+    }
+    let header_len = u32::try_from(raw_header.len())
+        .map_err(|_| ContinuationCryptoError::InvalidEnvelope("header length overflow"))?;
+    let mut message = Vec::with_capacity(
+        SIGNATURE_DOMAIN.len() + 1 + 4 + raw_header.len() + age_ciphertext_sha256.len(),
+    );
+    message.extend_from_slice(SIGNATURE_DOMAIN);
+    message.push(0);
+    message.extend_from_slice(&header_len.to_be_bytes());
+    message.extend_from_slice(raw_header);
+    message.extend_from_slice(age_ciphertext_sha256);
+    Ok(message)
+}
+
+fn put_string(bytes: &mut Vec<u8>, value: &str) -> Result<(), ContinuationCryptoError> {
+    let length = u16::try_from(value.len())
+        .map_err(|_| ContinuationCryptoError::InvalidEnvelope("string length overflow"))?;
+    bytes.extend_from_slice(&length.to_be_bytes());
+    bytes.extend_from_slice(value.as_bytes());
+    Ok(())
+}
+
+fn put_identity(
+    bytes: &mut Vec<u8>,
+    identity: &DevicePublicIdentity,
+) -> Result<(), ContinuationCryptoError> {
+    identity.validate()?;
+    bytes.extend_from_slice(identity.device_id.as_bytes());
+    bytes.extend_from_slice(&identity.key_version.to_be_bytes());
+    bytes.extend_from_slice(&identity.encryption_public_key);
+    bytes.extend_from_slice(&identity.signing_public_key);
+    bytes.extend_from_slice(&identity.fingerprint);
+    Ok(())
+}
+
+fn validate_identifier(
+    label: &'static str,
+    value: &str,
+    max: usize,
+) -> Result<(), ContinuationCryptoError> {
+    if value.is_empty()
+        || value.len() > max
+        || value
+            .bytes()
+            .any(|byte| byte == 0 || byte.is_ascii_control())
+    {
+        return Err(ContinuationCryptoError::InvalidEnvelope(label));
+    }
+    Ok(())
+}
+
+fn validate_runtime(label: &'static str, value: &str) -> Result<(), ContinuationCryptoError> {
+    let mut bytes = value.bytes();
+    let Some(first) = bytes.next() else {
+        return Err(ContinuationCryptoError::InvalidEnvelope(label));
+    };
+    if value.len() > MAX_RUNTIME_ID_BYTES
+        || !(first.is_ascii_lowercase() || first.is_ascii_digit())
+        || !bytes.all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'_' | b'-')
+        })
+    {
+        return Err(ContinuationCryptoError::InvalidEnvelope(label));
+    }
+    Ok(())
+}
+
+struct HeaderCursor<'a> {
+    bytes: &'a [u8],
+    position: usize,
+}
+
+impl<'a> HeaderCursor<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, position: 0 }
+    }
+
+    fn take(&mut self, length: usize) -> Result<&'a [u8], ContinuationCryptoError> {
+        let end =
+            self.position
+                .checked_add(length)
+                .ok_or(ContinuationCryptoError::InvalidEnvelope(
+                    "header length overflow",
+                ))?;
+        let value =
+            self.bytes
+                .get(self.position..end)
+                .ok_or(ContinuationCryptoError::InvalidEnvelope(
+                    "truncated canonical header",
+                ))?;
+        self.position = end;
+        Ok(value)
+    }
+
+    fn u8(&mut self) -> Result<u8, ContinuationCryptoError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn u16(&mut self) -> Result<u16, ContinuationCryptoError> {
+        Ok(u16::from_be_bytes(self.take(2)?.try_into().map_err(
+            |_| ContinuationCryptoError::InvalidEnvelope("truncated header u16"),
+        )?))
+    }
+
+    fn u32(&mut self) -> Result<u32, ContinuationCryptoError> {
+        Ok(u32::from_be_bytes(self.take(4)?.try_into().map_err(
+            |_| ContinuationCryptoError::InvalidEnvelope("truncated header u32"),
+        )?))
+    }
+
+    fn u64(&mut self) -> Result<u64, ContinuationCryptoError> {
+        Ok(u64::from_be_bytes(self.take(8)?.try_into().map_err(
+            |_| ContinuationCryptoError::InvalidEnvelope("truncated header u64"),
+        )?))
+    }
+
+    fn array<const N: usize>(&mut self) -> Result<[u8; N], ContinuationCryptoError> {
+        self.take(N)?
+            .try_into()
+            .map_err(|_| ContinuationCryptoError::InvalidEnvelope("truncated header array"))
+    }
+
+    fn string(&mut self, max: usize) -> Result<String, ContinuationCryptoError> {
+        let length = self.u16()? as usize;
+        if length == 0 || length > max {
+            return Err(ContinuationCryptoError::InvalidEnvelope(
+                "invalid header string length",
+            ));
+        }
+        String::from_utf8(self.take(length)?.to_vec())
+            .map_err(|_| ContinuationCryptoError::InvalidEnvelope("header string is not UTF-8"))
+    }
+
+    fn identity(&mut self) -> Result<DevicePublicIdentity, ContinuationCryptoError> {
+        DevicePublicIdentity::try_new(
+            Uuid::from_bytes(self.array()?),
+            self.u32()?,
+            self.array()?,
+            self.array()?,
+            self.array()?,
+        )
+    }
+
+    fn recipients_with_count(
+        &mut self,
+        count: usize,
+    ) -> Result<CloudRecipientSet, ContinuationCryptoError> {
+        if count == 0 || count > MAX_ENVELOPE_RECIPIENTS {
+            return Err(ContinuationCryptoError::InvalidEnvelope(
+                "invalid recipient count",
+            ));
+        }
+        let mut recipients = Vec::with_capacity(count);
+        for _ in 0..count {
+            recipients.push(CloudRecipient::try_new(
+                Uuid::from_bytes(self.array()?),
+                self.identity()?,
+            )?);
+        }
+        CloudRecipientSet::from_canonical(recipients)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.position == self.bytes.len()
+    }
+}


### PR DESCRIPTION
## Problem

Portable imported-session continuation needs a device-to-device checkpoint channel that never uploads plaintext transcripts or private keys. The crypto boundary must remain provider-, Cloud-UI-, and Work-Item-neutral.

## Solution

- Add a standalone continuation_crypto Rust leaf with OS secure-store device identities, rotation history, and no plaintext fallback.
- Define a canonical signed binary envelope using standard age X25519 multi-recipient encryption and Ed25519 authentication.
- Stream bounded gzip checkpoint records and publish ciphertext through owner-only, no-clobber, fsync-backed atomic files.
- Pin Cloud routing metadata, recipient receipts, sender key snapshots, hashes, sizes, and expiry before plaintext delivery.
- Add MSRV and native Windows DACL CI jobs; reject OpenSSL/native-tls in this security leaf.

This PR is stacked on #979. It contains no Work Item activation or Team Chat behavior.

## Potential risks

- Real Windows secure-store and DACL behavior depends on the new windows-latest CI job.
- A device without an eligible historical key must fail closed and use visible-history recovery; it cannot decrypt old envelopes.
- The Cloud persistence/RPC layer and desktop upload/recovery outbox are intentionally separate stacked changes.

## Verification

- cargo test -p continuation_crypto --offline (28 unit tests + compile-fail doctest)
- cargo clippy -p continuation_crypto --all-targets --offline -- -D warnings
- cargo tree dependency audit: no OpenSSL or native-tls
- Repository pre-commit hooks passed
