### PR TITLE
feat(imported-history): badge which client produced an imported session

### DIFF
--- a/src-tauri/crates/orgtrack-cli/src/plugin_exec.rs
+++ b/src-tauri/crates/orgtrack-cli/src/plugin_exec.rs
@@ -205,6 +205,8 @@ pub(crate) fn exec_session_to_input(
             .unwrap_or(true),
         source_metadata_json: None,
         parent_session_id: js_str(value, "parentSessionId"),
+        client_origin: None,
+        client_origin_raw: None,
     })
 }
 
@@ -442,6 +444,8 @@ pub(crate) fn scanned_row_from_json(value: &serde_json::Value) -> Option<Scanned
             lines_removed: js_i64(value, "linesRemoved"),
             touched_files: js_str_vec(value, "touchedFiles"),
             parent_session_id: js_str(value, "parentSessionId"),
+            client_origin: None,
+            client_origin_raw: None,
         },
     })
 }

--- a/src-tauri/crates/orgtrack-cli/src/scan.rs
+++ b/src-tauri/crates/orgtrack-cli/src/scan.rs
@@ -229,6 +229,8 @@ pub(crate) fn cached_to_row(
         lines_removed: session.impact.lines_removed,
         touched_files: session.impact.touched_files,
         parent_session_id: session.parent_session_id,
+        client_origin: None,
+        client_origin_raw: None,
     }
 }
 

--- a/src-tauri/crates/orgtrack-core/src/sources/anthropic_jsonl.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/anthropic_jsonl.rs
@@ -751,6 +751,8 @@ fn meta_to_cache_input(
         listable: true,
         source_metadata_json: None,
         parent_session_id: None,
+        client_origin: None,
+        client_origin_raw: None,
     }
 }
 

--- a/src-tauri/crates/orgtrack-core/src/sources/claude_code/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/claude_code/history.rs
@@ -28,7 +28,7 @@ const CLAUDE_CODE_PROVIDER_SLUG: &str = "claudecode";
 // survive Claude Code rewriting the first user message during compaction.
 // v12: name subagent rows from their small `.meta.json` sidecar instead of
 // the shared beginning of each child prompt.
-const CLAUDE_CODE_METADATA_PARSER_VERSION: i64 = 12;
+const CLAUDE_CODE_METADATA_PARSER_VERSION: i64 = 14;
 const MAX_COMPACT_BOUNDARY_MARKERS: usize =
     crate::sources::imported_history::cache::MAX_CONTINUATION_MARKERS - 1;
 

--- a/src-tauri/crates/orgtrack-core/src/sources/claude_code/history/metadata.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/claude_code/history/metadata.rs
@@ -2,8 +2,10 @@ use std::collections::{BTreeSet, HashSet, VecDeque};
 
 use serde::{Deserialize, Serialize};
 
+use std::path::Path;
+
 use crate::sources::imported_history::{
-    self, cache as imported_cache,
+    self, cache as imported_cache, client_origin,
     metadata::{
         ImportedHistoryCacheInput, ImportedHistoryDiscoveredRecord, ImportedHistoryImpactStats,
         StoredRoundUsage, SOURCE_CLAUDE_CODE,
@@ -37,6 +39,10 @@ struct ClaudeSessionMetaState {
     model: Option<String>,
     repo_path: Option<String>,
     branch: Option<String>,
+    /// Client surface that wrote the transcript, from the records' own
+    /// `entrypoint`. First non-empty value wins.
+    #[serde(default)]
+    entrypoint: String,
     input_tokens: i64,
     output_tokens: i64,
     cache_read_tokens: i64,
@@ -69,6 +75,9 @@ impl ClaudeSessionMetaState {
             Ok(parsed) => parsed,
             Err(_) => return,
         };
+        if self.entrypoint.is_empty() && !parsed.entrypoint.trim().is_empty() {
+            self.entrypoint = parsed.entrypoint.trim().to_string();
+        }
         let line_ms = parsed
             .timestamp
             .as_deref()
@@ -251,6 +260,7 @@ impl ClaudeSessionMetaState {
             })
             .collect();
         Some(ClaudeCodeHistoryMeta {
+            entrypoint: self.entrypoint,
             source_session_id: record.source_session_id.clone(),
             session_id,
             source_path: record.source_path.to_string_lossy().to_string(),
@@ -389,6 +399,11 @@ pub(super) fn parse_claude_session_meta(
 pub(super) fn session_meta_to_cache_input(
     meta: ClaudeCodeHistoryMeta,
 ) -> ImportedHistoryCacheInput {
+    // Computed before the literal below moves `meta.source_path`.
+    let client_origin = client_origin::classify_claude_transcript(
+        &meta.entrypoint,
+        Some(Path::new(&meta.source_path)),
+    );
     ImportedHistoryCacheInput {
         source: SOURCE_CLAUDE_CODE,
         source_session_id: meta.source_session_id,
@@ -416,5 +431,10 @@ pub(super) fn session_meta_to_cache_input(
             &meta.continuation_markers,
         ),
         parent_session_id: meta.parent_session_id,
+        // Path-aware: ORGII spawns the Claude CLI, so its own sessions report
+        // `cli`/`sdk-cli` like any terminal run and are separable only by the
+        // managed profile root they are stored under.
+        client_origin,
+        client_origin_raw: (!meta.entrypoint.trim().is_empty()).then_some(meta.entrypoint),
     }
 }

--- a/src-tauri/crates/orgtrack-core/src/sources/claude_code/history/types.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/claude_code/history/types.rs
@@ -29,6 +29,9 @@ pub(super) struct ClaudeCodeHistoryMeta {
     pub(super) cache_write_tokens: i64,
     pub(super) rounds: Vec<RoundUsage>,
     pub(super) impact: ImportedHistoryImpactStats,
+    /// Raw `entrypoint` recorded by the transcript, naming the client surface
+    /// that produced it. Empty when no record carried one.
+    pub(super) entrypoint: String,
     /// Set for Task-tool subagent transcripts: the parent session's frontend
     /// id (`claudecodeapp-<parent-uuid>`). `None` for ordinary top-level
     /// sessions. Non-empty values are subsumed out of the sidebar/kanban.
@@ -73,6 +76,10 @@ pub(super) struct ClaudeJsonlLine {
     /// `true` on every line of a Task-tool subagent transcript
     /// (`<parent-uuid>/subagents/agent-*.jsonl`). Marks the whole file as a
     /// child session that must be subsumed under its parent.
+    /// Which client surface produced this record (`claude-desktop`, `cli`,
+    /// `vscode`, an `sdk-*` embedder, ...). Written on user records.
+    #[serde(default)]
+    pub(super) entrypoint: String,
     #[serde(default)]
     pub(super) is_sidechain: bool,
     /// The parent session's UUID. On a subagent transcript every line carries

--- a/src-tauri/crates/orgtrack-core/src/sources/claude_code/history_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/claude_code/history_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::sources::imported_history::client_origin::ImportedClientOrigin;
 
 #[test]
 fn includes_claude_project_dir_candidates() {
@@ -1493,4 +1494,88 @@ fn bench_real_home_claude_discovery_cold_vs_warm() {
         warm_walker.dirs_enumerated,
     );
     assert_eq!(cold.records.len(), warm.records.len());
+}
+
+#[test]
+fn captures_transcript_entrypoint_as_client_origin() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-claude-client-origin-test-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+
+    for (entrypoint, expected_origin) in [
+        ("claude-desktop", ImportedClientOrigin::OfficialApp),
+        ("cli", ImportedClientOrigin::Cli),
+        ("vscode", ImportedClientOrigin::ThirdParty),
+        ("sdk-typescript", ImportedClientOrigin::ThirdParty),
+    ] {
+        let stem = format!("claude-origin-{entrypoint}");
+        let path = temp_dir.join(format!("{stem}.jsonl"));
+        let content = format!(
+            r#"{{"type":"user","sessionId":"abc","cwd":"/tmp/project","entrypoint":"{entrypoint}","timestamp":"2026-04-01T07:06:46.543Z","message":{{"role":"user","content":"build this"}}}}
+"#
+        );
+        std::fs::write(&path, content).expect("write fixture");
+
+        let (source_mtime_ms, source_size_bytes) =
+            imported_paths::file_metadata_signature(&path, "Claude").expect("metadata");
+        let record = ImportedHistoryDiscoveredRecord {
+            source_session_id: stem.clone(),
+            source_path: path.clone(),
+            source_record_key: stem.clone(),
+            source_mtime_ms,
+            source_size_bytes,
+            source_fingerprint: String::new(),
+            parser_version: CLAUDE_CODE_METADATA_PARSER_VERSION,
+        };
+        let meta = parse_claude_session_meta(&record)
+            .expect("parse")
+            .expect("session meta");
+        let cache_input = session_meta_to_cache_input(meta);
+        assert_eq!(
+            cache_input.client_origin,
+            Some(expected_origin),
+            "{entrypoint} should classify as {expected_origin:?}"
+        );
+        assert_eq!(cache_input.client_origin_raw.as_deref(), Some(entrypoint));
+    }
+
+    std::fs::remove_dir_all(&temp_dir).expect("remove temp dir");
+}
+
+#[test]
+fn transcript_without_entrypoint_has_no_client_origin() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-claude-client-origin-absent-test-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+    let path = temp_dir.join("claude-no-entrypoint.jsonl");
+    std::fs::write(
+        &path,
+        r#"{"type":"user","sessionId":"abc","cwd":"/tmp/project","timestamp":"2026-04-01T07:06:46.543Z","message":{"role":"user","content":"build this"}}
+"#,
+    )
+    .expect("write fixture");
+
+    let (source_mtime_ms, source_size_bytes) =
+        imported_paths::file_metadata_signature(&path, "Claude").expect("metadata");
+    let record = ImportedHistoryDiscoveredRecord {
+        source_session_id: "claude-no-entrypoint".to_string(),
+        source_path: path.clone(),
+        source_record_key: "claude-no-entrypoint".to_string(),
+        source_mtime_ms,
+        source_size_bytes,
+        source_fingerprint: String::new(),
+        parser_version: CLAUDE_CODE_METADATA_PARSER_VERSION,
+    };
+    let meta = parse_claude_session_meta(&record)
+        .expect("parse")
+        .expect("session meta");
+    let cache_input = session_meta_to_cache_input(meta);
+    assert_eq!(cache_input.client_origin, None);
+    assert_eq!(cache_input.client_origin_raw, None);
+
+    std::fs::remove_dir_all(&temp_dir).expect("remove temp dir");
 }

--- a/src-tauri/crates/orgtrack-core/src/sources/cli_resume.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/cli_resume.rs
@@ -570,6 +570,8 @@ mod tests {
                 listable: true,
                 source_metadata_json: None,
                 parent_session_id: None,
+                client_origin: None,
+                client_origin_raw: None,
             }
         };
         let claude_session_id = format!("claudecodeapp-{UUID}");

--- a/src-tauri/crates/orgtrack-core/src/sources/cline/history/discovery.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/cline/history/discovery.rs
@@ -347,5 +347,7 @@ pub(super) fn session_meta_to_cache_input(meta: ClineHistoryMeta) -> ImportedHis
         listable: true,
         source_metadata_json: None,
         parent_session_id: meta.parent_session_id,
+        client_origin: None,
+        client_origin_raw: None,
     }
 }

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app/meta.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app/meta.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 
 use crate::sources::codex::canonical_session_id;
 use crate::sources::imported_history::{
-    self,
+    self, client_origin,
     metadata::{
         ImportedHistoryCacheInput, ImportedHistoryDiscoveredRecord, ImportedHistoryImpactStats,
         StoredRoundUsage, SOURCE_CODEX_APP,
@@ -55,6 +55,9 @@ struct CodexSessionMetaState {
     first_prompt: String,
     model: Option<String>,
     repo_path: Option<String>,
+    /// Client that wrote the rollout, from `session_meta.payload.originator`.
+    #[serde(default)]
+    originator: String,
     // Session totals are accumulated from per-round deltas (robust to codex's
     // cumulative resets on /compact). `input_tokens` is cache-inclusive here to
     // match the imported-cache convention.
@@ -117,6 +120,20 @@ impl CodexSessionMetaState {
         }
         if parsed.line_type == "session_meta" {
             capture_subagent_source_metadata(&parsed.payload, &mut self.source_metadata);
+            if self.originator.is_empty() {
+                // `originator` names the client; the sibling `source` field
+                // does not (the Codex desktop app reports `source: "vscode"`
+                // for its own sessions), so provenance reads this one only.
+                if let Some(originator) = parsed
+                    .payload
+                    .get("originator")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|originator| !originator.is_empty())
+                {
+                    self.originator = originator.to_string();
+                }
+            }
         }
         if self.model.is_none() || self.repo_path.is_none() {
             if let Ok(turn_context) =
@@ -234,6 +251,7 @@ impl CodexSessionMetaState {
         source_metadata.first_prompt =
             (!self.first_prompt.trim().is_empty()).then_some(self.first_prompt);
         Some(CodexAppSessionMeta {
+            originator: self.originator,
             source_session_id: record.source_session_id.clone(),
             session_id,
             source_path: record.source_path.to_string_lossy().to_string(),
@@ -418,6 +436,8 @@ pub(super) fn session_meta_to_cache_input(meta: CodexAppSessionMeta) -> Imported
         listable: true,
         source_metadata_json,
         parent_session_id: meta.parent_session_id,
+        client_origin: client_origin::classify_codex_originator(&meta.originator),
+        client_origin_raw: (!meta.originator.trim().is_empty()).then_some(meta.originator),
     }
 }
 

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app/mod.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app/mod.rs
@@ -62,7 +62,7 @@ pub(crate) use transcript::{
 // first prompt so encrypted collaboration arguments can be reconstructed.
 // v12: recognize paginated item_completed/UserMessage records as the canonical
 // user-turn boundary while retaining legacy event_msg/user_message support.
-const CODEX_APP_METADATA_PARSER_VERSION: i64 = 12;
+const CODEX_APP_METADATA_PARSER_VERSION: i64 = 13;
 
 pub type CodexAppSessionRow = ImportedHistorySessionRow;
 pub type CodexAppSessionPage = ImportedHistorySessionPage;
@@ -100,6 +100,9 @@ pub(crate) struct CodexAppSessionMeta {
     impact: ImportedHistoryImpactStats,
     rounds: Vec<RoundUsage>,
     source_metadata: CodexAppSourceMetadata,
+    /// Raw `session_meta.payload.originator`, naming the client that wrote
+    /// this rollout. Empty when the rollout predates the field.
+    originator: String,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]

--- a/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/codex/app_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::sources::imported_history::client_origin::ImportedClientOrigin;
 
 #[test]
 fn includes_codex_session_dir_candidates() {
@@ -2616,6 +2617,102 @@ fn unresolved_tool_calls_flush_in_file_order_across_reparses() {
         .map(|chunk| &chunk.chunk_id)
         .collect::<Vec<_>>();
     assert_eq!(first_ids, second_ids);
+
+    std::fs::remove_dir_all(&temp_dir).expect("remove temp dir");
+}
+
+#[test]
+fn captures_rollout_originator_as_client_origin() {
+    // Real rollouts disagree between `originator` and `source`: the Codex
+    // desktop app writes `source: "vscode"` for its own sessions, so a
+    // provenance badge keyed on `source` would call the official app an IDE
+    // extension. Pin that `originator` wins and `source` is ignored.
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-codex-client-origin-test-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+
+    for (originator, source, expected_origin) in [
+        ("Codex Desktop", "vscode", ImportedClientOrigin::OfficialApp),
+        ("codex_cli_rs", "cli", ImportedClientOrigin::Cli),
+        (
+            "multica-agent-sdk",
+            "vscode",
+            ImportedClientOrigin::ThirdParty,
+        ),
+        ("orgii-smoke", "cli", ImportedClientOrigin::Org2),
+    ] {
+        let stem = format!("rollout-{}", originator.replace([' ', '_'], "-"));
+        let path = temp_dir.join(format!("{stem}.jsonl"));
+        let content = format!(
+            r#"{{"timestamp":"2026-08-18T01:00:00.000Z","type":"session_meta","payload":{{"cwd":"/tmp/project","id":"thread-1","originator":"{originator}","source":"{source}"}},"ordinal":0}}
+{{"timestamp":"2026-08-18T01:00:01.000Z","type":"response_item","payload":{{"type":"message","role":"user","content":[{{"type":"input_text","text":"hello"}}]}},"ordinal":1}}
+"#
+        );
+        std::fs::write(&path, content).expect("write fixture");
+
+        let (source_mtime_ms, source_size_bytes) =
+            imported_paths::file_metadata_signature(&path, "Codex").expect("metadata");
+        let record = ImportedHistoryDiscoveredRecord {
+            source_session_id: stem.clone(),
+            source_path: path.clone(),
+            source_record_key: stem.clone(),
+            source_mtime_ms,
+            source_size_bytes,
+            source_fingerprint: String::new(),
+            parser_version: CODEX_APP_METADATA_PARSER_VERSION,
+        };
+        let meta = parse_codex_session_meta(&record)
+            .expect("parse metadata")
+            .expect("session metadata");
+        let cache_input = meta::session_meta_to_cache_input(meta);
+        assert_eq!(
+            cache_input.client_origin,
+            Some(expected_origin),
+            "{originator} should classify as {expected_origin:?}"
+        );
+        // The raw vendor string survives for tooltips and diagnostics.
+        assert_eq!(cache_input.client_origin_raw.as_deref(), Some(originator));
+    }
+
+    std::fs::remove_dir_all(&temp_dir).expect("remove temp dir");
+}
+
+#[test]
+fn rollout_without_originator_has_no_client_origin() {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "orgii-codex-client-origin-absent-test-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&temp_dir).expect("create temp dir");
+    let path = temp_dir.join("rollout-no-originator.jsonl");
+    std::fs::write(
+        &path,
+        r#"{"timestamp":"2026-08-18T01:00:00.000Z","type":"session_meta","payload":{"cwd":"/tmp/project","id":"thread-1"},"ordinal":0}
+{"timestamp":"2026-08-18T01:00:01.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"hello"}]},"ordinal":1}
+"#,
+    )
+    .expect("write fixture");
+
+    let (source_mtime_ms, source_size_bytes) =
+        imported_paths::file_metadata_signature(&path, "Codex").expect("metadata");
+    let record = ImportedHistoryDiscoveredRecord {
+        source_session_id: "rollout-no-originator".to_string(),
+        source_path: path.clone(),
+        source_record_key: "rollout-no-originator".to_string(),
+        source_mtime_ms,
+        source_size_bytes,
+        source_fingerprint: String::new(),
+        parser_version: CODEX_APP_METADATA_PARSER_VERSION,
+    };
+    let meta = parse_codex_session_meta(&record)
+        .expect("parse metadata")
+        .expect("session metadata");
+    let cache_input = meta::session_meta_to_cache_input(meta);
+    // Absent provenance must stay absent rather than defaulting to a badge.
+    assert_eq!(cache_input.client_origin, None);
+    assert_eq!(cache_input.client_origin_raw, None);
 
     std::fs::remove_dir_all(&temp_dir).expect("remove temp dir");
 }

--- a/src-tauri/crates/orgtrack-core/src/sources/copilot/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/copilot/history.rs
@@ -735,6 +735,8 @@ fn session_meta_to_cache_input(meta: CopilotHistoryMeta) -> ImportedHistoryCache
         listable: true,
         source_metadata_json: None,
         parent_session_id: None,
+        client_origin: None,
+        client_origin_raw: None,
     }
 }
 

--- a/src-tauri/crates/orgtrack-core/src/sources/cursor_cli/history/mod.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/cursor_cli/history/mod.rs
@@ -388,6 +388,8 @@ fn session_meta_to_cache_input(meta: CursorCliHistoryMeta) -> ImportedHistoryCac
         listable: true,
         source_metadata_json: None,
         parent_session_id: None,
+        client_origin: None,
+        client_origin_raw: None,
     }
 }
 

--- a/src-tauri/crates/orgtrack-core/src/sources/cursor_ide/db/sync.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/cursor_ide/db/sync.rs
@@ -473,6 +473,8 @@ fn minimal_cache_input_from_header_child(
         listable: false,
         source_metadata_json: serde_json::to_string(&CursorCacheMetadata::default()).ok(),
         parent_session_id: Some(super::canonical_session_id(&parent.id)),
+        client_origin: None,
+        client_origin_raw: None,
     }
 }
 
@@ -509,6 +511,8 @@ fn minimal_cache_input_from_index(
         listable: true,
         source_metadata_json: serde_json::to_string(&CursorCacheMetadata::default()).ok(),
         parent_session_id: None,
+        client_origin: None,
+        client_origin_raw: None,
     }
 }
 
@@ -605,6 +609,8 @@ fn cache_input_from_raw(
         listable: parent_session_id.is_none(),
         source_metadata_json: Some(source_metadata_json),
         parent_session_id,
+        client_origin: None,
+        client_origin_raw: None,
     })
 }
 

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache.rs
@@ -9,6 +9,7 @@ use rusqlite::{
     params, params_from_iter, types::Type, types::Value as SqlValue, Connection, OptionalExtension,
 };
 
+use super::client_origin::ImportedClientOrigin;
 use super::metadata::{
     ImportedHistoryCacheInput, ImportedHistoryImpactStats, ImportedHistoryRecordSignature,
     RoundUsage,
@@ -43,6 +44,8 @@ pub struct ImportedHistoryCachedSession {
     pub listable: bool,
     pub source_metadata_json: Option<String>,
     pub parent_session_id: Option<String>,
+    pub client_origin: Option<ImportedClientOrigin>,
+    pub client_origin_raw: Option<String>,
 }
 
 impl ImportedHistoryCachedSession {
@@ -65,6 +68,8 @@ impl ImportedHistoryCachedSession {
             lines_removed: self.impact.lines_removed,
             touched_files: self.impact.touched_files.clone(),
             parent_session_id: self.parent_session_id.clone(),
+            client_origin: self.client_origin,
+            client_origin_raw: self.client_origin_raw.clone(),
         })
     }
 }
@@ -135,10 +140,10 @@ pub fn upsert_imported_session_cache_from_conn(
                     cache_read_tokens, cache_write_tokens,
                     repo_path, branch, files_changed, lines_added, lines_removed,
                     touched_files_json, listable, source_metadata_json, parent_session_id,
-                    updated_at
+                    updated_at, client_origin, client_origin_raw
                 ) VALUES (
                     ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15,
-                    ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27
+                    ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, ?24, ?25, ?26, ?27, ?28, ?29
                 )
                 ON CONFLICT(source, source_session_id) DO UPDATE SET
                     session_id = excluded.session_id,
@@ -177,7 +182,9 @@ pub fn upsert_imported_session_cache_from_conn(
                         ELSE excluded.source_metadata_json
                     END,
                     parent_session_id = excluded.parent_session_id,
-                    updated_at = excluded.updated_at",
+                    updated_at = excluded.updated_at,
+                    client_origin = excluded.client_origin,
+                    client_origin_raw = excluded.client_origin_raw",
             ))
             .map_err(|err| format!("Failed to prepare imported history cache upsert: {err}"))?;
         for input in inputs {
@@ -211,6 +218,11 @@ pub fn upsert_imported_session_cache_from_conn(
                 input.source_metadata_json.as_deref().unwrap_or_default(),
                 input.parent_session_id.as_deref().unwrap_or_default(),
                 updated_at,
+                input
+                    .client_origin
+                    .map(|origin| origin.as_wire_str())
+                    .unwrap_or_default(),
+                input.client_origin_raw.as_deref().unwrap_or_default(),
             ])
             .map_err(|err| format!("Failed to upsert imported history cache row: {err}"))?;
         }
@@ -419,7 +431,7 @@ pub fn query_imported_sidebar_page_from_conn(
                 model, files_changed, lines_added, lines_removed, touched_files_json,
                 input_tokens, output_tokens, source_path,
                 identity.repo_root_path, identity.remote_urls_json, cache.branch,
-                cache.source_metadata_json
+                cache.source_metadata_json, cache.client_origin, cache.client_origin_raw
          FROM imported_history_session_cache cache
          LEFT JOIN imported_history_repo_identity identity
            ON identity.working_path = cache.repo_path
@@ -482,6 +494,10 @@ pub fn query_imported_sidebar_page_from_conn(
                 lines_added: row.get(7)?,
                 lines_removed: row.get(8)?,
                 touched_files,
+                client_origin: non_empty_string(row.get(17)?)
+                    .as_deref()
+                    .and_then(ImportedClientOrigin::from_wire_str),
+                client_origin_raw: non_empty_string(row.get(18)?),
             })
         })
         .map_err(|err| format!("Failed to query imported sidebar rows for {source}: {err}"))?;
@@ -683,7 +699,8 @@ fn query_cached_sessions_by_filter_from_conn(
                 imported_history_session_cache.repo_path, branch, files_changed,
                 lines_added, lines_removed, touched_files_json, listable,
                 source_metadata_json, parent_session_id,
-                identity.repo_root_path, identity.remote_urls_json
+                identity.repo_root_path, identity.remote_urls_json,
+                client_origin, client_origin_raw
          FROM imported_history_session_cache
          LEFT JOIN imported_history_repo_identity identity
            ON identity.working_path = imported_history_session_cache.repo_path
@@ -746,6 +763,10 @@ fn query_cached_sessions_by_filter_from_conn(
                 listable: row.get::<_, i64>(20)? != 0,
                 source_metadata_json: non_empty_string(row.get(21)?),
                 parent_session_id: non_empty_string(parent_session_id),
+                client_origin: non_empty_string(row.get(25)?)
+                    .as_deref()
+                    .and_then(ImportedClientOrigin::from_wire_str),
+                client_origin_raw: non_empty_string(row.get(26)?),
             })
         })
         .map_err(|err| {

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/cache_tests.rs
@@ -43,6 +43,8 @@ fn input(
         listable: true,
         source_metadata_json: None,
         parent_session_id: None,
+        client_origin: None,
+        client_origin_raw: None,
     }
 }
 

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/client_origin.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/client_origin.rs
@@ -1,0 +1,277 @@
+//! Which client wrote an imported session.
+//!
+//! Every imported source records *what agent* produced a transcript (that is
+//! the source id), but several vendors ship more than one client against the
+//! same on-disk store: Codex rollouts under `~/.codex/sessions` are written by
+//! the Codex desktop app, by the `codex` CLI, by third-party SDK embedders,
+//! and by ORGII itself. The source id cannot tell those apart, so the
+//! provenance is parsed from the transcript's own self-identification and
+//! projected onto this small closed set.
+//!
+//! The raw vendor string is preserved alongside the classification: the
+//! taxonomy is deliberately coarse for display, while the raw value stays
+//! available for tooltips, diagnostics, and future refinement without a
+//! reparse.
+
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+/// Coarse provenance of the client that produced an imported session.
+///
+/// Deliberately closed: unrecognized vendor strings classify as
+/// [`ImportedClientOrigin::ThirdParty`] rather than adding a variant, because
+/// an unknown embedder is exactly what "third party" means here. Absent
+/// provenance is represented by `Option::None` at the call site, not by a
+/// variant — "not recorded" and "recorded as something we do not know" are
+/// different facts and only the latter is a third party.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportedClientOrigin {
+    /// The vendor's own first-party desktop application.
+    OfficialApp,
+    /// The vendor's own terminal client.
+    Cli,
+    /// Any other embedder: IDE extensions, SDK hosts, agent frameworks.
+    ThirdParty,
+    /// ORGII itself drove this session. Rendered without a badge — inside
+    /// ORGII, "ORGII did this" is the unmarked default, not a distinction.
+    Org2,
+}
+
+impl ImportedClientOrigin {
+    /// Stable wire value shared with the cache column and the TypeScript
+    /// union. Kept as an explicit match so a new variant cannot silently
+    /// serialize to a string the frontend does not handle.
+    pub fn as_wire_str(self) -> &'static str {
+        match self {
+            Self::OfficialApp => "official_app",
+            Self::Cli => "cli",
+            Self::ThirdParty => "third_party",
+            Self::Org2 => "org2",
+        }
+    }
+
+    /// Parse a value previously written by [`Self::as_wire_str`]. Unknown
+    /// input yields `None` so a cache row written by a newer build degrades to
+    /// "no badge" instead of being mislabeled.
+    pub fn from_wire_str(value: &str) -> Option<Self> {
+        match value {
+            "official_app" => Some(Self::OfficialApp),
+            "cli" => Some(Self::Cli),
+            "third_party" => Some(Self::ThirdParty),
+            "org2" => Some(Self::Org2),
+            _ => None,
+        }
+    }
+}
+
+/// ORGII's own originator strings, matched case-insensitively against the
+/// whole value and against a `orgii-`/`orgii_` prefix so smoke-test and
+/// per-surface variants (`orgii-smoke`) do not read as third-party embedders.
+fn is_org2_originator(normalized: &str) -> bool {
+    normalized == "orgii"
+        || normalized == "org2"
+        || normalized.starts_with("orgii-")
+        || normalized.starts_with("orgii_")
+        || normalized.starts_with("org2-")
+        || normalized.starts_with("org2_")
+}
+
+/// Classify a Codex rollout's `session_meta.payload.originator`.
+///
+/// `originator` is used rather than the sibling `source` field because
+/// `source` is not a provenance signal: the Codex desktop app reports
+/// `source: "vscode"` for its own sessions, so `source` cannot separate the
+/// official app from an IDE extension. `originator` names the client.
+pub fn classify_codex_originator(originator: &str) -> Option<ImportedClientOrigin> {
+    let normalized = originator.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return None;
+    }
+    if is_org2_originator(&normalized) {
+        return Some(ImportedClientOrigin::Org2);
+    }
+    Some(match normalized.as_str() {
+        "codex desktop" | "codex_desktop" | "codex-desktop" => ImportedClientOrigin::OfficialApp,
+        "codex_cli_rs" | "codex-tui" | "codex_tui" | "codex_exec" | "codex-exec" | "codex" => {
+            ImportedClientOrigin::Cli
+        }
+        _ => ImportedClientOrigin::ThirdParty,
+    })
+}
+
+/// Classify a Claude Code transcript by `entrypoint` and where it is stored.
+///
+/// Unlike Codex rollouts, Claude transcripts carry no `originator`, so a
+/// session ORGII drove is indistinguishable from a hand-run terminal session
+/// by `entrypoint` alone — ORGII spawns the CLI, so its own sessions report
+/// `cli`/`sdk-cli`. What does separate them is the store: ORGII runs the CLI
+/// against its own managed profile root, so a transcript under
+/// `~/.orgii/claude-code-cli-profiles/` is ORGII's own by construction.
+/// Checking the path is what keeps ORGII's sessions unlabeled instead of
+/// badging them as somebody's terminal.
+///
+/// Note that `vscode`/`ide` classify as third party even though Anthropic
+/// ships the IDE extension: the distinction this badge draws is which client
+/// surface produced the session, and an IDE host is neither the desktop app
+/// nor the terminal client.
+pub fn classify_claude_transcript(
+    entrypoint: &str,
+    transcript_path: Option<&Path>,
+) -> Option<ImportedClientOrigin> {
+    if transcript_path.is_some_and(is_org2_managed_claude_transcript) {
+        return Some(ImportedClientOrigin::Org2);
+    }
+    classify_claude_entrypoint(entrypoint)
+}
+
+/// Whether a Claude transcript lives inside ORGII's own managed CLI profile
+/// root, which only ORGII writes to.
+fn is_org2_managed_claude_transcript(path: &Path) -> bool {
+    path.starts_with(app_paths::claude_code_cli_profile_root())
+}
+
+/// Classify a Claude Code transcript's `entrypoint` alone. Prefer
+/// [`classify_claude_transcript`], which also recognizes ORGII's own store.
+pub fn classify_claude_entrypoint(entrypoint: &str) -> Option<ImportedClientOrigin> {
+    let normalized = entrypoint.trim().to_ascii_lowercase();
+    if normalized.is_empty() {
+        return None;
+    }
+    if is_org2_originator(&normalized) {
+        return Some(ImportedClientOrigin::Org2);
+    }
+    Some(match normalized.as_str() {
+        "claude-desktop" | "claude_desktop" => ImportedClientOrigin::OfficialApp,
+        "cli" | "sdk-cli" | "sdk_cli" => ImportedClientOrigin::Cli,
+        _ => ImportedClientOrigin::ThirdParty,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn orgii_managed_claude_transcripts_are_org2_despite_a_cli_entrypoint() {
+        // ORGII spawns the Claude CLI, so its own sessions self-report
+        // `cli`/`sdk-cli` exactly like a hand-run terminal session. Only the
+        // managed profile root separates them, and getting this wrong badges
+        // the user's own ORGII sessions as somebody's CLI.
+        let managed = app_paths::claude_code_cli_profile_root()
+            .join("c23b0290")
+            .join("projects")
+            .join("-Users-me-project")
+            .join("0b83425c.jsonl");
+        for entrypoint in ["cli", "sdk-cli"] {
+            assert_eq!(
+                classify_claude_transcript(entrypoint, Some(&managed)),
+                Some(ImportedClientOrigin::Org2),
+                "{entrypoint} under the managed root must classify as org2"
+            );
+        }
+    }
+
+    #[test]
+    fn claude_transcripts_outside_the_managed_root_keep_their_entrypoint() {
+        let external = std::path::PathBuf::from("/Users/me/.claude/projects/p/a.jsonl");
+        assert_eq!(
+            classify_claude_transcript("cli", Some(&external)),
+            Some(ImportedClientOrigin::Cli)
+        );
+        assert_eq!(
+            classify_claude_transcript("claude-desktop", Some(&external)),
+            Some(ImportedClientOrigin::OfficialApp)
+        );
+        // A missing path must not promote anything to org2.
+        assert_eq!(
+            classify_claude_transcript("cli", None),
+            Some(ImportedClientOrigin::Cli)
+        );
+    }
+
+    #[test]
+    fn codex_desktop_is_official_app() {
+        // The exact casing observed in real rollouts.
+        assert_eq!(
+            classify_codex_originator("Codex Desktop"),
+            Some(ImportedClientOrigin::OfficialApp)
+        );
+    }
+
+    #[test]
+    fn codex_terminal_clients_are_cli() {
+        for originator in ["codex_cli_rs", "codex-tui", "codex_exec"] {
+            assert_eq!(
+                classify_codex_originator(originator),
+                Some(ImportedClientOrigin::Cli),
+                "{originator} should classify as CLI"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_codex_embedders_are_third_party() {
+        for originator in ["multica-agent-sdk", "acp-extension-codex", "some-new-host"] {
+            assert_eq!(
+                classify_codex_originator(originator),
+                Some(ImportedClientOrigin::ThirdParty),
+                "{originator} should classify as third party"
+            );
+        }
+    }
+
+    #[test]
+    fn orgii_originators_are_org2() {
+        for originator in ["orgii", "orgii-smoke", "ORGII", "org2_cli"] {
+            assert_eq!(
+                classify_codex_originator(originator),
+                Some(ImportedClientOrigin::Org2),
+                "{originator} should classify as ORG2"
+            );
+        }
+    }
+
+    #[test]
+    fn claude_entrypoints_classify_by_surface() {
+        assert_eq!(
+            classify_claude_entrypoint("claude-desktop"),
+            Some(ImportedClientOrigin::OfficialApp)
+        );
+        assert_eq!(
+            classify_claude_entrypoint("cli"),
+            Some(ImportedClientOrigin::Cli)
+        );
+        // Third-party desktop hosts and SDK embedders alike.
+        for entrypoint in ["claude-desktop-3p", "vscode", "ide", "sdk-typescript"] {
+            assert_eq!(
+                classify_claude_entrypoint(entrypoint),
+                Some(ImportedClientOrigin::ThirdParty),
+                "{entrypoint} should classify as third party"
+            );
+        }
+    }
+
+    #[test]
+    fn blank_provenance_is_absent_not_third_party() {
+        assert_eq!(classify_codex_originator("   "), None);
+        assert_eq!(classify_claude_entrypoint(""), None);
+    }
+
+    #[test]
+    fn wire_values_round_trip() {
+        for origin in [
+            ImportedClientOrigin::OfficialApp,
+            ImportedClientOrigin::Cli,
+            ImportedClientOrigin::ThirdParty,
+            ImportedClientOrigin::Org2,
+        ] {
+            assert_eq!(
+                ImportedClientOrigin::from_wire_str(origin.as_wire_str()),
+                Some(origin)
+            );
+        }
+        assert_eq!(ImportedClientOrigin::from_wire_str("future_kind"), None);
+    }
+}

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/metadata.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/metadata.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use super::client_origin::ImportedClientOrigin;
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ImportedHistoryImpactStats {
     pub files_changed: i64,
@@ -95,6 +97,12 @@ pub struct ImportedHistoryCacheInput {
     pub listable: bool,
     pub source_metadata_json: Option<String>,
     pub parent_session_id: Option<String>,
+    /// Which client wrote this transcript, when the source records it.
+    /// `None` means "not recorded" — distinct from a recorded-but-unknown
+    /// embedder, which classifies as third party.
+    pub client_origin: Option<ImportedClientOrigin>,
+    /// Raw vendor provenance string behind `client_origin`.
+    pub client_origin_raw: Option<String>,
 }
 
 /// One imported per-round (assistant round / LLM call) usage record, written to

--- a/src-tauri/crates/orgtrack-core/src/sources/imported_history/mod.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/imported_history/mod.rs
@@ -1,4 +1,5 @@
 pub mod cache;
+pub mod client_origin;
 pub mod managed_mirror;
 pub mod managed_roots;
 pub mod metadata;
@@ -17,6 +18,7 @@ use core_types::activity::ActivityChunk;
 use serde::Serialize;
 use serde_json::{json, Value};
 
+use self::client_origin::ImportedClientOrigin;
 use self::metadata::ImportedHistoryImpactStats;
 
 pub const IMPORTED_HISTORY_CATEGORY: &str = "external_history";
@@ -235,6 +237,12 @@ pub struct ImportedHistorySessionRow {
     pub lines_removed: i64,
     pub touched_files: Vec<String>,
     pub parent_session_id: Option<String>,
+    /// Which client produced this session. Omitted when the source records no
+    /// provenance, so the UI renders no badge rather than guessing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_origin: Option<ImportedClientOrigin>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_origin_raw: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -297,6 +305,12 @@ pub struct ImportedHistorySidebarRow {
     pub lines_added: i64,
     pub lines_removed: i64,
     pub touched_files: Vec<String>,
+    /// Which client produced this session. Absent when the source records no
+    /// provenance, and for rows cached before the parser captured it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_origin: Option<ImportedClientOrigin>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_origin_raw: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -333,6 +347,8 @@ pub struct ImportedHistoryRowInput {
     pub lines_removed: i64,
     pub touched_files: Vec<String>,
     pub parent_session_id: Option<String>,
+    pub client_origin: Option<ImportedClientOrigin>,
+    pub client_origin_raw: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -451,6 +467,8 @@ pub fn row_from_input(input: ImportedHistoryRowInput) -> ImportedHistorySessionR
         lines_removed: input.lines_removed,
         touched_files: input.touched_files,
         parent_session_id: input.parent_session_id,
+        client_origin: input.client_origin,
+        client_origin_raw: input.client_origin_raw,
     }
 }
 

--- a/src-tauri/crates/orgtrack-core/src/sources/kimi/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/kimi/history.rs
@@ -1018,6 +1018,8 @@ impl KimiMetaState {
                 listable,
                 source_metadata_json: None,
                 parent_session_id,
+                client_origin: None,
+                client_origin_raw: None,
             },
             rounds,
         ))

--- a/src-tauri/crates/orgtrack-core/src/sources/mimo_code/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/mimo_code/history.rs
@@ -371,6 +371,8 @@ fn meta_to_cache_input(
         listable: !container_parent_ids.contains(&meta.source_session_id),
         source_metadata_json: None,
         parent_session_id,
+        client_origin: None,
+        client_origin_raw: None,
     }
 }
 

--- a/src-tauri/crates/orgtrack-core/src/sources/opencode/history/sync.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/opencode/history/sync.rs
@@ -250,6 +250,8 @@ pub(super) fn session_meta_to_cache_input(
         listable,
         source_metadata_json: None,
         parent_session_id,
+        client_origin: None,
+        client_origin_raw: None,
     }
 }
 

--- a/src-tauri/crates/orgtrack-core/src/sources/opencode/history_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/opencode/history_tests.rs
@@ -204,6 +204,8 @@ fn maps_opencode_session_metadata_to_cache_input() {
         listable: inputs[0].listable,
         source_metadata_json: inputs[0].source_metadata_json.clone(),
         parent_session_id: inputs[0].parent_session_id.clone(),
+        client_origin: None,
+        client_origin_raw: None,
     }
     .to_row();
     assert_eq!(row.session_id, "opencodeapp-ses_1");
@@ -333,6 +335,8 @@ fn opencode_recent_paths_use_all_sessions_before_limiting() {
                 listable: input.listable,
                 source_metadata_json: input.source_metadata_json,
                 parent_session_id: input.parent_session_id,
+                client_origin: None,
+                client_origin_raw: None,
             }
             .to_row()
         })

--- a/src-tauri/crates/orgtrack-core/src/sources/qoder/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/qoder/history.rs
@@ -385,6 +385,8 @@ fn session_meta_to_cache_input(meta: QoderHistoryMeta) -> ImportedHistoryCacheIn
         listable: true,
         source_metadata_json: None,
         parent_session_id: None,
+        client_origin: None,
+        client_origin_raw: None,
     }
 }
 

--- a/src-tauri/crates/orgtrack-core/src/sources/qwen_code/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/qwen_code/history.rs
@@ -287,6 +287,8 @@ impl QwenParseState {
                 listable: true,
                 source_metadata_json: None,
                 parent_session_id: None,
+                client_origin: None,
+                client_origin_raw: None,
             },
             rounds,
         )

--- a/src-tauri/crates/orgtrack-core/src/sources/registry.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/registry.rs
@@ -260,6 +260,8 @@ fn normalize_cursor_ide_page(
                 lines_removed: row.lines_removed,
                 touched_files: row.touched_files,
                 parent_session_id: None,
+                client_origin: None,
+                client_origin_raw: None,
             })
             .collect(),
     })

--- a/src-tauri/crates/orgtrack-core/src/sources/trae/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/trae/history.rs
@@ -352,6 +352,8 @@ fn session_meta_to_cache_input(meta: TraeHistoryMeta) -> ImportedHistoryCacheInp
         listable: true,
         source_metadata_json: meta.source_metadata_json,
         parent_session_id: None,
+        client_origin: None,
+        client_origin_raw: None,
     }
 }
 

--- a/src-tauri/crates/orgtrack-core/src/sources/warp/history.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/warp/history.rs
@@ -322,6 +322,8 @@ fn conversation_to_cache_input(
         listable,
         source_metadata_json,
         parent_session_id,
+        client_origin: None,
+        client_origin_raw: None,
     }
 }
 

--- a/src-tauri/crates/orgtrack-core/src/sources/windsurf/history/sync.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/windsurf/history/sync.rs
@@ -167,6 +167,8 @@ pub(super) fn composer_meta_to_cache_input(
         listable: meta.listable,
         source_metadata_json: None,
         parent_session_id,
+        client_origin: None,
+        client_origin_raw: None,
     }
 }
 

--- a/src-tauri/crates/orgtrack-core/src/sources/windsurf/history_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/windsurf/history_tests.rs
@@ -263,6 +263,8 @@ fn maps_windsurf_composer_metadata_to_cache_input() {
         listable: inputs[0].listable,
         source_metadata_json: inputs[0].source_metadata_json.clone(),
         parent_session_id: inputs[0].parent_session_id.clone(),
+        client_origin: None,
+        client_origin_raw: None,
     }
     .to_row();
     assert_eq!(row.session_id, "windsurfapp-composer-1");

--- a/src-tauri/crates/orgtrack-core/src/sources/workbuddy/discovery.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/workbuddy/discovery.rs
@@ -246,5 +246,7 @@ pub(super) fn session_meta_to_cache_input(meta: WorkBuddyHistoryMeta) -> Importe
         listable: true,
         source_metadata_json: None,
         parent_session_id: meta.parent_session_id,
+        client_origin: None,
+        client_origin_raw: None,
     }
 }

--- a/src-tauri/crates/orgtrack-core/src/sources/zcode/history/sync.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/zcode/history/sync.rs
@@ -188,5 +188,7 @@ pub(super) fn session_meta_to_cache_input(meta: ZCodeSessionMeta) -> ImportedHis
         listable,
         source_metadata_json: None,
         parent_session_id,
+        client_origin: None,
+        client_origin_raw: None,
     }
 }

--- a/src-tauri/crates/orgtrack-core/src/sources/zcode/history_tests.rs
+++ b/src-tauri/crates/orgtrack-core/src/sources/zcode/history_tests.rs
@@ -144,6 +144,8 @@ fn to_row(input: &ImportedHistoryCacheInput) -> ImportedHistorySessionRow {
         listable: input.listable,
         source_metadata_json: input.source_metadata_json.clone(),
         parent_session_id: input.parent_session_id.clone(),
+        client_origin: None,
+        client_origin_raw: None,
     }
     .to_row()
 }

--- a/src-tauri/crates/orgtrack-core/src/store/sqlite/schema.rs
+++ b/src-tauri/crates/orgtrack-core/src/store/sqlite/schema.rs
@@ -460,6 +460,8 @@ impl SqliteRecordStore<'_> {
                 listable            INTEGER NOT NULL DEFAULT 1,
                 source_metadata_json TEXT NOT NULL DEFAULT '',
                 parent_session_id   TEXT NOT NULL DEFAULT '',
+                client_origin       TEXT NOT NULL DEFAULT '',
+                client_origin_raw   TEXT NOT NULL DEFAULT '',
                 updated_at          TEXT NOT NULL DEFAULT '',
                 PRIMARY KEY (source, source_session_id)
             );
@@ -557,6 +559,24 @@ impl SqliteRecordStore<'_> {
             "imported_history_session_cache",
             "listable",
             "INTEGER NOT NULL DEFAULT 1",
+        )?;
+        // Which client wrote the transcript (`official_app` / `cli` /
+        // `third_party` / `org2`), parsed from the source's own
+        // self-identification. Empty when the source records no provenance or
+        // the row predates the parser-version bump that captures it.
+        ensure_column(
+            conn,
+            "imported_history_session_cache",
+            "client_origin",
+            "TEXT NOT NULL DEFAULT ''",
+        )?;
+        // The raw vendor string behind `client_origin`, kept so tooltips and
+        // diagnostics can name the actual embedder without a reparse.
+        ensure_column(
+            conn,
+            "imported_history_session_cache",
+            "client_origin_raw",
+            "TEXT NOT NULL DEFAULT ''",
         )?;
 
         // The sidebar-order partial index filters on `listable` and

--- a/src-tauri/src/agent_sessions/session_directory/aggregation.rs
+++ b/src-tauri/src/agent_sessions/session_directory/aggregation.rs
@@ -1470,6 +1470,8 @@ mod tests {
             lines_added: None,
             lines_removed: None,
             touched_files: None,
+            client_origin: None,
+            client_origin_raw: None,
         }
     }
 

--- a/src-tauri/src/agent_sessions/session_directory/conversion.rs
+++ b/src-tauri/src/agent_sessions/session_directory/conversion.rs
@@ -200,6 +200,8 @@ pub fn cli_session_to_aggregate_record(
         lines_added: None,
         lines_removed: None,
         touched_files: None,
+        client_origin: None,
+        client_origin_raw: None,
     }
 }
 
@@ -277,6 +279,8 @@ pub fn imported_history_to_aggregate_record(
         lines_added: Some(row.lines_added),
         lines_removed: Some(row.lines_removed),
         touched_files: Some(row.touched_files),
+        client_origin: row.client_origin.map(|origin| origin.as_wire_str().to_string()),
+        client_origin_raw: row.client_origin_raw,
     }
 }
 
@@ -336,6 +340,8 @@ pub fn cursor_ide_history_to_aggregate_record(
         lines_added: Some(row.lines_added),
         lines_removed: Some(row.lines_removed),
         touched_files: Some(row.touched_files),
+        client_origin: None,
+        client_origin_raw: None,
     }
 }
 
@@ -412,6 +418,8 @@ pub fn sde_session_to_aggregate_record(
         lines_added,
         lines_removed,
         touched_files,
+        client_origin: None,
+        client_origin_raw: None,
     }
 }
 
@@ -481,6 +489,8 @@ pub fn os_session_to_aggregate_record(
         lines_added,
         lines_removed,
         touched_files,
+        client_origin: None,
+        client_origin_raw: None,
     }
 }
 
@@ -550,6 +560,8 @@ pub fn human_session_to_aggregate_record(
         lines_added: None,
         lines_removed: None,
         touched_files: None,
+        client_origin: None,
+        client_origin_raw: None,
     }
 }
 

--- a/src-tauri/src/agent_sessions/session_directory/display.rs
+++ b/src-tauri/src/agent_sessions/session_directory/display.rs
@@ -174,6 +174,8 @@ mod tests {
             lines_added: None,
             lines_removed: None,
             touched_files: None,
+            client_origin: None,
+            client_origin_raw: None,
         }
     }
 

--- a/src-tauri/src/agent_sessions/session_directory/tests/session_filter_tests.rs
+++ b/src-tauri/src/agent_sessions/session_directory/tests/session_filter_tests.rs
@@ -83,6 +83,8 @@ fn make_session(
         lines_added: None,
         lines_removed: None,
         touched_files: None,
+        client_origin: None,
+        client_origin_raw: None,
     }
 }
 

--- a/src-tauri/src/agent_sessions/session_directory/types.rs
+++ b/src-tauri/src/agent_sessions/session_directory/types.rs
@@ -26,6 +26,14 @@ pub struct SessionAggregateRecord {
     /// Imported external-history source subtype, when this row comes from an external DB.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub external_history_source: Option<String>,
+    /// Which client produced an imported session (`official_app`, `cli`,
+    /// `third_party`, `org2`). Absent when the source records no provenance,
+    /// and on every non-imported row.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_origin: Option<String>,
+    /// Raw vendor provenance string behind `client_origin`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_origin_raw: Option<String>,
     /// User input / task description
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_input: Option<String>,

--- a/src/api/tauri/externalHistory/imported/descriptors.ts
+++ b/src/api/tauri/externalHistory/imported/descriptors.ts
@@ -2,6 +2,24 @@ import type { ImportedHistorySourceId } from "@src/types/session/externalHistory
 
 export type { ImportedHistorySourceId } from "@src/types/session/externalHistory";
 
+/**
+ * Which client produced an imported session, parsed by the backend from the
+ * source's own self-identification (Codex `originator`, Claude `entrypoint`).
+ * Absent on sources that record no provenance — the UI renders no badge then
+ * rather than guessing.
+ *
+ * `org2` is deliberately unlabeled in the UI: inside ORGII, "ORGII drove this"
+ * is the unmarked default, not a distinction worth a badge.
+ */
+export const IMPORTED_CLIENT_ORIGINS = [
+  "official_app",
+  "cli",
+  "third_party",
+  "org2",
+] as const;
+
+export type ImportedClientOrigin = (typeof IMPORTED_CLIENT_ORIGINS)[number];
+
 export type ImportedHistoryListCategory =
   `external_history:${ImportedHistorySourceId}`;
 
@@ -19,6 +37,19 @@ export interface ImportedHistoryCliResume {
   displayName: string;
 }
 
+/**
+ * Native-app deep-link capability of an imported source. Present only when
+ * `orgtrack_core::sources::app_open` can address a single conversation in
+ * the vendor's own app (the backend stays authoritative per session —
+ * subagent rows and malformed ids still resolve to no plan). Independent of
+ * {@link ImportedHistoryCliResume}: a source can be CLI-resumable without
+ * having an app link, and the reverse is possible too.
+ */
+export interface ImportedHistoryAppOpen {
+  /** Fallback label before the backend plan answers (or if it errors). */
+  displayName: string;
+}
+
 export interface ImportedHistorySourceDescriptor {
   sourceId: ImportedHistorySourceId;
   listCategory: ImportedHistoryListCategory;
@@ -30,6 +61,7 @@ export interface ImportedHistorySourceDescriptor {
   replayable: true;
   supportsWindowedReplay: boolean;
   cliResume?: ImportedHistoryCliResume;
+  appOpen?: ImportedHistoryAppOpen;
 }
 
 export const IMPORTED_HISTORY_SOURCE_DESCRIPTORS: readonly ImportedHistorySourceDescriptor[] =
@@ -74,6 +106,9 @@ export const IMPORTED_HISTORY_SOURCE_DESCRIPTORS: readonly ImportedHistorySource
         agentType: "codex",
         displayName: "Codex",
       },
+      appOpen: {
+        displayName: "Codex",
+      },
     },
     {
       sourceId: "claude_code",
@@ -88,6 +123,9 @@ export const IMPORTED_HISTORY_SOURCE_DESCRIPTORS: readonly ImportedHistorySource
       cliResume: {
         agentType: "claude_code",
         displayName: "Claude Code",
+      },
+      appOpen: {
+        displayName: "Claude",
       },
     },
     {

--- a/src/api/tauri/rpc/schemas/sessionAggregate.ts
+++ b/src/api/tauri/rpc/schemas/sessionAggregate.ts
@@ -9,6 +9,8 @@
  */
 import { z } from "zod/v4";
 
+import { IMPORTED_CLIENT_ORIGINS } from "@src/api/tauri/externalHistory/imported/descriptors";
+
 import {
   CliAgentTypeSchema,
   MergeStatusSchema,
@@ -22,6 +24,8 @@ import {
  * Transformed at parse time to `DispatchCategory` so consumers never see the
  * wire value — only the routing value used by the frontend.
  */
+const ImportedClientOriginSchema = z.enum(IMPORTED_CLIENT_ORIGINS);
+
 const WireCategorySchema = z
   .enum(["cli", "agent", "os", "human"])
   .transform((cat): "cli_agent" | "rust_agent" | "human_session" => {
@@ -197,6 +201,8 @@ export const SessionAggregateRecordSchema = z.object({
   updatedAt: z.string(),
   category: WireCategorySchema,
   externalHistorySource: z.string().optional(),
+  clientOrigin: ImportedClientOriginSchema.optional(),
+  clientOriginRaw: z.string().optional(),
   userInput: z.string().optional(),
   repoPath: z.string().optional(),
   repoRootPath: z.string().optional(),
@@ -289,6 +295,12 @@ export const ExternalHistorySidebarRowSchema = z.object({
   // Stable continuation-family identity elected by the imported-history
   // cache. Used only for sidebar de-duplication of force-revealed siblings.
   continuationLineageId: z.string().optional(),
+  /**
+   * Which client wrote the source transcript. Parsed by the backend from the
+   * source's own self-identification; absent for sources that record none.
+   */
+  clientOrigin: ImportedClientOriginSchema.optional(),
+  clientOriginRaw: z.string().optional(),
   /** ORGII-owned pin state; imported sessions carry no pin from their source. */
   pinned: z.boolean().optional(),
   totalTokens: z.number().int().optional(),

--- a/src/components/ClientOriginBadge/index.tsx
+++ b/src/components/ClientOriginBadge/index.tsx
@@ -1,0 +1,93 @@
+import { useTranslation } from "react-i18next";
+
+import type { ImportedClientOrigin } from "@src/api/tauri/externalHistory/imported/descriptors";
+import Tag from "@src/components/Tag";
+
+/**
+ * Provenance badge for an imported session: which client actually produced
+ * the transcript.
+ *
+ * Sources are not one-client-per-store — `~/.codex/sessions` holds rollouts
+ * from the Codex desktop app, the `codex` CLI, third-party SDK embedders, and
+ * ORGII itself — so the source name alone does not tell a viewer where a
+ * session came from. The classification is resolved once by
+ * `resolveSessionDisplayMetadata`; this component only renders it, so the
+ * sidebar, hover cards, and the chat header cannot drift apart.
+ *
+ * ORGII's own sessions render nothing: inside ORGII, "ORGII drove this" is
+ * the unmarked default, and badging it would put a label on the majority of
+ * rows that carries no information.
+ */
+export interface ClientOriginBadgeProps {
+  origin: ImportedClientOrigin | undefined;
+  /**
+   * Raw vendor string (`multica-agent-sdk`, `claude-desktop`). Shown as the
+   * title so "Third party" can be resolved to an actual name on hover.
+   */
+  originRaw?: string;
+  size?: "mini" | "small";
+  className?: string;
+}
+
+/** Tag colors per origin. `org2` is absent: it never renders. */
+const ORIGIN_COLOR: Record<
+  Exclude<ImportedClientOrigin, "org2">,
+  "default" | "primary" | "processing"
+> = {
+  official_app: "primary",
+  cli: "processing",
+  third_party: "default",
+};
+
+const ORIGIN_LABEL_KEY: Record<
+  Exclude<ImportedClientOrigin, "org2">,
+  string
+> = {
+  official_app: "clientOrigin.officialApp",
+  cli: "clientOrigin.cli",
+  third_party: "clientOrigin.thirdParty",
+};
+
+/**
+ * Whether this origin renders a badge at all. Callers that need to know
+ * before laying out a row (to avoid an empty wrapper) must ask here rather
+ * than re-deriving the rule, so suppression stays defined once.
+ */
+export function hasVisibleClientOriginBadge(
+  origin: ImportedClientOrigin | undefined
+): origin is Exclude<ImportedClientOrigin, "org2"> {
+  return origin !== undefined && origin !== "org2";
+}
+
+export default function ClientOriginBadge({
+  origin,
+  originRaw,
+  size = "mini",
+  className,
+}: ClientOriginBadgeProps) {
+  const { t } = useTranslation("common");
+
+  // Absent provenance and ORGII's own sessions both render nothing — the
+  // first because we do not know, the second because it is the default.
+  if (!hasVisibleClientOriginBadge(origin)) return null;
+
+  // `Tag`'s smallest size (`mini`: 12px text, 2px/8px padding) still reads as
+  // a control beside a session title, where this is an annotation. Tighten it
+  // here rather than adding a size to the shared component for one caller —
+  // `!` overrides win against the SCSS size class regardless of sheet order.
+  const compact = "!px-1.5 !py-0 !text-[10px] !leading-4";
+
+  // `Tag` exposes no `title`; wrap rather than widen a shared component for
+  // one caller.
+  return (
+    <span title={originRaw}>
+      <Tag
+        color={ORIGIN_COLOR[origin]}
+        size={size}
+        className={className ? `${compact} ${className}` : compact}
+      >
+        {t(ORIGIN_LABEL_KEY[origin])}
+      </Tag>
+    </span>
+  );
+}

--- a/src/components/SessionHoverCard/SessionHoverCardContent.tsx
+++ b/src/components/SessionHoverCard/SessionHoverCardContent.tsx
@@ -22,6 +22,7 @@ import {
   getOrgtrackSessionSummary,
 } from "@src/api/tauri/lineage";
 import { isHostedKey } from "@src/api/tauri/session";
+import ClientOriginBadge from "@src/components/ClientOriginBadge";
 import ModelIcon from "@src/components/ModelIcon";
 import { resolveAgentIcon } from "@src/config/agentIcons";
 import TaskImpactLine from "@src/features/KanbanBoard/components/TaskImpactLine";
@@ -489,6 +490,11 @@ export const SessionHoverCardContent: React.FC<SessionHoverCardContentProps> =
             }
           >
             <span className="truncate">{agentSessionInfo.label}</span>
+            <ClientOriginBadge
+              origin={resolvedSessionDisplay.clientOrigin}
+              originRaw={session?.clientOriginRaw}
+              className="ml-1 shrink-0"
+            />
             {modelLabel && (
               <>
                 <span className="mx-1 text-text-4">·</span>

--- a/src/engines/ChatPanel/components/SessionHeaderBreadcrumb/index.tsx
+++ b/src/engines/ChatPanel/components/SessionHeaderBreadcrumb/index.tsx
@@ -1,11 +1,15 @@
 import { useAtomValue } from "jotai";
 import React, { memo, useMemo } from "react";
 
+import ClientOriginBadge, {
+  hasVisibleClientOriginBadge,
+} from "@src/components/ClientOriginBadge";
 import { WorkstationHeaderSectionSeparator } from "@src/modules/WorkStation/shared/WorkstationHeaderSectionSeparator";
 import BreadcrumbFileHeader, {
   type BreadcrumbFileHeaderDisplaySegment,
 } from "@src/modules/shared/components/FileHeader/BreadcrumbFileHeader";
 import { type Session, sessionByIdAtom } from "@src/store/session";
+import { resolveSessionDisplayMetadata } from "@src/util/session/sessionDisplayMetadata";
 
 import SessionIdentityIcon from "../SessionIdentityIcon";
 import {
@@ -68,6 +72,23 @@ const SessionHeaderBreadcrumb: React.FC<SessionHeaderBreadcrumbProps> = memo(
     const externalOwnerDisplayName = externalOwnerName
       ? truncateExternalOwnerName(externalOwnerName)
       : undefined;
+    // Which client wrote the transcript, resolved through the same projection
+    // the hover card reads so the taxonomy has one definition. Renders nothing
+    // for ORGII's own sessions and for sources that record no provenance.
+    const originBadge = useMemo(() => {
+      if (!session) return null;
+      const { clientOrigin } = resolveSessionDisplayMetadata({
+        kind: "local",
+        session,
+      });
+      return hasVisibleClientOriginBadge(clientOrigin) ? (
+        <ClientOriginBadge
+          origin={clientOrigin}
+          originRaw={session.clientOriginRaw}
+        />
+      ) : null;
+    }, [session]);
+
     const displaySegments = useMemo<
       BreadcrumbFileHeaderDisplaySegment[]
     >(() => {
@@ -78,6 +99,7 @@ const SessionHeaderBreadcrumb: React.FC<SessionHeaderBreadcrumbProps> = memo(
               content: (
                 <span className="inline-flex min-w-0 items-center gap-2">
                   <span>{display.displayName}</span>
+                  {originBadge}
                   <WorkstationHeaderSectionSeparator />
                   <span className="inline-block max-w-40 truncate align-middle font-normal text-text-2">
                     {externalOwnerDisplayName}
@@ -86,7 +108,17 @@ const SessionHeaderBreadcrumb: React.FC<SessionHeaderBreadcrumbProps> = memo(
               ),
               title: `${display.fullDisplayName} | ${externalOwnerName}`,
             }
-          : {}),
+          : originBadge
+            ? {
+                content: (
+                  <span className="inline-flex min-w-0 items-center gap-2">
+                    <span className="truncate">{display.displayName}</span>
+                    {originBadge}
+                  </span>
+                ),
+                title: display.fullDisplayName,
+              }
+            : {}),
       };
 
       if (!display.isAgentChildSession) {
@@ -123,6 +155,7 @@ const SessionHeaderBreadcrumb: React.FC<SessionHeaderBreadcrumbProps> = memo(
       externalOwnerDisplayName,
       externalOwnerName,
       onParentSessionClick,
+      originBadge,
       parentSession,
       parentSessionId,
     ]);

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -2730,5 +2730,10 @@
       "updated": "Aktualisiert"
     },
     "selectRow": "{{id}} auswählen"
+  },
+  "clientOrigin": {
+    "officialApp": "Offizielle App",
+    "cli": "CLI",
+    "thirdParty": "Drittanbieter"
   }
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -2901,5 +2901,10 @@
     "downloadedOfTotal": "{{downloaded}} of {{total}}",
     "preparingDownload": "Preparing download…",
     "downloadingAndInstalling": "Downloading and installing update (v{{version}})…"
+  },
+  "clientOrigin": {
+    "officialApp": "Official app",
+    "cli": "CLI",
+    "thirdParty": "Third party"
   }
 }

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -2722,5 +2722,10 @@
       "updated": "Actualizado"
     },
     "selectRow": "Seleccionar {{id}}"
+  },
+  "clientOrigin": {
+    "officialApp": "App oficial",
+    "cli": "CLI",
+    "thirdParty": "De terceros"
   }
 }

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -2725,5 +2725,10 @@
       "updated": "Mis à jour"
     },
     "selectRow": "Sélectionner {{id}}"
+  },
+  "clientOrigin": {
+    "officialApp": "App officielle",
+    "cli": "CLI",
+    "thirdParty": "Tiers"
   }
 }

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -2725,5 +2725,10 @@
       "updated": "更新"
     },
     "selectRow": "{{id}} を選択"
+  },
+  "clientOrigin": {
+    "officialApp": "公式アプリ",
+    "cli": "CLI",
+    "thirdParty": "サードパーティ"
   }
 }

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -2723,5 +2723,10 @@
       "updated": "업데이트"
     },
     "selectRow": "{{id}} 선택"
+  },
+  "clientOrigin": {
+    "officialApp": "공식 앱",
+    "cli": "CLI",
+    "thirdParty": "서드파티"
   }
 }

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -2734,5 +2734,10 @@
       "updated": "Zaktualizowano"
     },
     "selectRow": "Wybierz {{id}}"
+  },
+  "clientOrigin": {
+    "officialApp": "Aplikacja oficjalna",
+    "cli": "CLI",
+    "thirdParty": "Zewnętrzny"
   }
 }

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -2722,5 +2722,10 @@
       "updated": "Atualizado"
     },
     "selectRow": "Selecionar {{id}}"
+  },
+  "clientOrigin": {
+    "officialApp": "App oficial",
+    "cli": "CLI",
+    "thirdParty": "De terceiros"
   }
 }

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -2734,5 +2734,10 @@
       "updated": "Обновлено"
     },
     "selectRow": "Выбрать {{id}}"
+  },
+  "clientOrigin": {
+    "officialApp": "Официальное приложение",
+    "cli": "CLI",
+    "thirdParty": "Сторонний"
   }
 }

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -2727,5 +2727,10 @@
       "updated": "Güncellendi"
     },
     "selectRow": "{{id}} öğesini seç"
+  },
+  "clientOrigin": {
+    "officialApp": "Resmî uygulama",
+    "cli": "CLI",
+    "thirdParty": "Üçüncü taraf"
   }
 }

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -2720,5 +2720,10 @@
       "updated": "Đã cập nhật"
     },
     "selectRow": "Chọn {{id}}"
+  },
+  "clientOrigin": {
+    "officialApp": "Ứng dụng chính thức",
+    "cli": "CLI",
+    "thirdParty": "Bên thứ ba"
   }
 }

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -2756,5 +2756,10 @@
       "updated": "更新時間"
     },
     "selectRow": "選擇 {{id}}"
+  },
+  "clientOrigin": {
+    "officialApp": "官方應用",
+    "cli": "命令列",
+    "thirdParty": "第三方"
   }
 }

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -2821,5 +2821,10 @@
     "downloadedOfTotal": "{{downloaded}} / {{total}}",
     "preparingDownload": "正在准备下载…",
     "downloadingAndInstalling": "正在下载并安装更新 (v{{version}})…"
+  },
+  "clientOrigin": {
+    "officialApp": "官方应用",
+    "cli": "命令行",
+    "thirdParty": "第三方"
   }
 }

--- a/src/store/session/sessionAtom/importedHistoryPaging.ts
+++ b/src/store/session/sessionAtom/importedHistoryPaging.ts
@@ -119,6 +119,8 @@ export function importedHistoryPageResult(
         branch: row.branch,
         storagePath: row.storagePath,
         continuationLineageId: row.continuationLineageId,
+        clientOrigin: row.clientOrigin,
+        clientOriginRaw: row.clientOriginRaw,
         agentIconId: source.iconId,
         agentDisplayName: source.displayName,
         model: row.model,

--- a/src/store/session/sessionAtom/types.ts
+++ b/src/store/session/sessionAtom/types.ts
@@ -7,6 +7,7 @@
  * Re-exported here for convenience in store consumers.
  */
 import type { AgentRole } from "@src/api/http/project";
+import type { ImportedClientOrigin } from "@src/api/tauri/externalHistory/imported/descriptors";
 import type {
   CliAgentType,
   MergeStatus,
@@ -169,6 +170,19 @@ export interface Session {
   storagePath?: string;
   /** Imported-history continuation family used to suppress duplicate sidebar siblings. */
   continuationLineageId?: string;
+  /**
+   * Which client produced an imported session (official app, vendor CLI,
+   * third-party embedder, or ORGII itself). Absent on native sessions and on
+   * sources that record no provenance. Presentation is resolved centrally by
+   * `sessionDisplayMetadata`, not read directly by render sites.
+   */
+  clientOrigin?: ImportedClientOrigin;
+  /**
+   * Raw vendor provenance string behind {@link Session.clientOrigin}
+   * (`claude-desktop`, `multica-agent-sdk`). Display-only: it names the actual
+   * embedder behind a coarse "Third party" badge.
+   */
+  clientOriginRaw?: string;
   /** Worktree path for isolated parallel sessions */
   worktreePath?: string;
   /** Branch name inside the worktree (e.g. `agent/abc123`) */

--- a/src/util/session/__tests__/sessionDisplayMetadata.test.ts
+++ b/src/util/session/__tests__/sessionDisplayMetadata.test.ts
@@ -292,3 +292,58 @@ describe("resolveSessionDisplayMetadata", () => {
     });
   });
 });
+
+describe("client origin projection", () => {
+  const importedSession = (
+    clientOrigin: Session["clientOrigin"]
+  ): LocalSessionDisplayInput => ({
+    session_id: "codexapp-abc",
+    clientOrigin,
+    importedFrom: { externalHistorySource: "codex_app" },
+  });
+
+  it("carries the backend classification through unchanged", () => {
+    // The projection must not re-derive provenance; it only forwards what the
+    // parser recorded, so the taxonomy has exactly one definition.
+    for (const origin of [
+      "official_app",
+      "cli",
+      "third_party",
+      "org2",
+    ] as const) {
+      expect(
+        resolveSessionDisplayMetadata({
+          kind: "local",
+          session: importedSession(origin),
+        }).clientOrigin
+      ).toBe(origin);
+    }
+  });
+
+  it("leaves client origin absent when the source records none", () => {
+    expect(
+      resolveSessionDisplayMetadata({
+        kind: "local",
+        session: importedSession(undefined),
+      }).clientOrigin
+    ).toBeUndefined();
+  });
+
+  it("reports no client origin for remote cloud rows", () => {
+    // Cloud replay does not carry the source transcript's provenance, so a
+    // shared session must not inherit a badge from its local twin.
+    expect(
+      resolveSessionDisplayMetadata({
+        kind: "remote",
+        session: {
+          sourceSessionId: "1106510024",
+          cliAgentType: "codex",
+          agentDisplayName: "Codex App",
+          agentDefinitionId: undefined,
+          model: "gpt-5.6-sol",
+          origin: { kind: "external_history", source: "codex_app" },
+        },
+      }).clientOrigin
+    ).toBeUndefined();
+  });
+});

--- a/src/util/session/sessionDisplayMetadata.ts
+++ b/src/util/session/sessionDisplayMetadata.ts
@@ -1,5 +1,6 @@
 import {
   IMPORTED_HISTORY_SOURCE_DESCRIPTORS,
+  type ImportedClientOrigin,
   type ImportedHistorySourceDescriptor,
 } from "@src/api/tauri/externalHistory/imported/descriptors";
 import { CLI_AGENT, type CliAgentType } from "@src/api/types/keys";
@@ -37,6 +38,7 @@ export interface LocalSessionDisplayInput {
   importedFrom?:
     | NonNullable<Session["importedFrom"]>
     | ImportedSessionDisplayInput;
+  clientOrigin?: Session["clientOrigin"];
 }
 
 type RemoteSessionDisplayInput = Pick<
@@ -62,6 +64,16 @@ export interface SessionDisplayMetadata {
   cliAgentType?: CliAgentType;
   modelName?: string;
   externalSource?: ImportedHistorySourceDescriptor;
+  /**
+   * Which client produced an imported session. Every surface that badges
+   * provenance (sidebar rows, hover cards, the chat header) reads this one
+   * resolved value rather than the raw session field, so the four-way
+   * taxonomy stays defined in exactly one place.
+   *
+   * `org2` is returned as-is; suppressing its badge is a rendering decision
+   * owned by the badge component, not a hole in this projection.
+   */
+  clientOrigin?: ImportedClientOrigin;
   /** Whether the resolved provider mark should inherit the row text color. */
   isMonochromeBrandIcon: boolean;
 }
@@ -78,6 +90,7 @@ interface NormalizedSessionDisplayInput {
   imported: boolean;
   agentOrg: boolean;
   remoteNative: boolean;
+  clientOrigin?: ImportedClientOrigin;
 }
 
 function normalizeSessionDisplayInput(
@@ -99,6 +112,9 @@ function normalizeSessionDisplayInput(
       imported: false,
       agentOrg: false,
       remoteNative: !session.origin || session.origin.kind === "orgii",
+      // Remote rows are replayed through the cloud, which does not carry the
+      // source transcript's client provenance. Absent rather than guessed.
+      clientOrigin: undefined,
     };
   }
 
@@ -118,6 +134,7 @@ function normalizeSessionDisplayInput(
     imported: Boolean(session.importedFrom),
     agentOrg: Boolean(session.agentOrgId),
     remoteNative: false,
+    clientOrigin: session.clientOrigin,
   };
 }
 
@@ -255,6 +272,7 @@ export function resolveSessionDisplayMetadata(
     cliAgentType,
     modelName: input.modelName,
     externalSource,
+    clientOrigin: input.clientOrigin,
     isMonochromeBrandIcon:
       iconProvider !== "unknown" && THEMEABLE_ICONS.has(iconProvider),
   };


### PR DESCRIPTION
## Problem

An imported session's source id names the *agent*, not the *client*. Several
vendors ship more than one client against the same on-disk store, so
"Codex App" or "Claude App" in the UI said nothing about where a session
actually came from.

On this machine's real data, `~/.codex/sessions` alone holds rollouts written
by four different kinds of client — the Codex desktop app (612), the `codex`
CLI (22 across `codex_exec` / `codex_cli_rs` / `codex-tui`), third-party SDK
embedders (`multica-agent-sdk`, `acp-extension-codex`), and ORGII itself
(`orgii`, `orgii-smoke`). `~/.claude/projects` is the same story. A user
looking at the list could not tell a session they ran in the official app from
one an SDK embedder wrote into the same directory.

Both vendors already record the answer and neither importer read it: Codex
writes `session_meta.payload.originator`, Claude writes `entrypoint` on user
records.

## Solution

Parse the vendors' own self-identification into a closed four-way taxonomy —
official app / CLI / third party / ORGII — persist it on the imported-history
cache, and render it beside the session title.

- `sources::imported_history::client_origin` owns the taxonomy and both
  vendor classifiers. Unrecognized strings classify as `third_party`; an
  absent field stays `None` so the UI renders nothing rather than guessing.
- Two new cache columns (`client_origin`, `client_origin_raw`) via
  `ensure_column`, so existing databases migrate without a rebuild. The raw
  vendor string is kept so a coarse "Third party" badge can name the actual
  embedder on hover.
- Parser versions bump (Codex 12→13, Claude 12→14) so already-cached rows
  re-parse and pick the field up.

Two decisions worth calling out:

**The Claude classifier is path-aware.** Claude transcripts carry no
`originator`, and ORGII *spawns the Claude CLI* — so ORGII's own sessions
self-report `cli`/`sdk-cli`, indistinguishable by field from a hand-run
terminal session. What separates them is the store: ORGII runs the CLI against
its own managed profile root, so a transcript under
`~/.orgii/claude-code-cli-profiles/` is ORGII's by construction. Without this,
10 of this machine's sessions badge as somebody's CLI when they are the user's
own ORGII runs.

**Codex classification keys on `originator`, not `source`.** The Codex desktop
app writes `source: "vscode"` for its own sessions, so keying on `source`
would label the official app an IDE extension. Pinned by test.

**ORGII's own sessions render no badge** — inside ORGII that is the unmarked
default, and badging it would put a label on the majority of rows carrying no
information.

Presentation resolves once, in `resolveSessionDisplayMetadata`, which the
title row and the hover card both already consume — so the taxonomy has a
single definition and the surfaces cannot drift apart. Badge visibility is a
single exported predicate (`hasVisibleClientOriginBadge`) rather than a rule
re-derived per call site.

## Potential risks

- **Wide but mechanical Rust diff.** Adding two fields to
  `ImportedHistoryCacheInput` / `ImportedHistorySessionRow` forces an
  initializer update in every source parser. Those are all `None` — no source
  other than Codex and Claude changes behavior.
- **Backfill is not immediate.** Rows only reclassify when the parser-version
  bump triggers a re-parse on the next scan. Until then `client_origin` is
  empty and no badge renders. Nothing breaks; the badge just appears later.
- **Vendor fields are private surfaces.** `originator` and `entrypoint` are
  undocumented and can change or disappear. Unknown values degrade to
  `third_party` and absent values to no badge, so the failure mode is a
  missing or coarse badge, never a wrong-looking UI.
- **`sdk-*` entrypoints are lumped as third party.** `sdk-typescript` /
  `sdk-python` name the SDK, not the product built on it, so the badge cannot
  be more specific than "Third party" for those. The raw string is in the
  tooltip.
- **Badge density.** On this machine 1068 of 1092 imported sessions classify
  as `official_app`, so the badge is near-uniform on existing data and earns
  its place mainly on the rare rows. Worth a look in the UI before deciding
  it stays.
- Not covered: no automated render test asserts the badge appears in the
  title row; verification there was the live-data query below plus typecheck.

## Verification

Commands that ran, from the repository root unless noted:

- `cargo test --workspace` (in `src-tauri/`) — **6836 passed, 0 failed**.
  One earlier run showed `agent_core … executor_runs_hooks_concurrently`
  failing; it passed 3/3 in isolation and on re-run, and is a
  timing-sensitive concurrency test unrelated to this change.
- `npx vitest run` — **9774 passed, 1229 files**.
- `npx tsc --noEmit` — clean (exit 0, no output).
- Pre-commit hooks: prettier, scoped TypeScript check, and
  `cargo clippy` (org2, orgtrack_cli, orgtrack_core) all passed.
- **Isolated-branch check:** built a detached worktree at this commit and ran
  `cargo test -p orgtrack_core -p orgtrack_cli` there — 563 + 29 passed — to
  confirm the branch stands alone and does not depend on unrelated
  working-tree changes. (`-p org2` cannot build in a bare worktree: its build
  script needs the `binaries/org2-pm-aarch64-apple-darwin` sidecar, absent
  from a fresh checkout. It builds and tests in the main tree.)

New tests, at the boundary that produces the value:

- `client_origin`: both vendor classifiers, wire round-trip, blank-is-absent,
  and two pinning ORGII's managed Claude store as `org2` despite a `cli`
  entrypoint.
- `codex::app`: end-to-end from a rollout fixture, including the
  `originator` vs `source` disagreement, and absent-originator.
- `claude_code::history`: end-to-end from a transcript fixture per entrypoint,
  and absent-entrypoint.
- `sessionDisplayMetadata`: the projection forwards the classification
  unchanged, stays absent when unrecorded, and reports none for remote cloud
  rows (cloud replay does not carry source provenance).

**Live-data check.** After the migration applied to `~/.orgii/sessions.db` and
the app rescanned, the classification over 1092 real imported sessions:

| source | origin | raw | rows |
|---|---|---|---|
| codex_app | official_app | Codex Desktop | 612 |
| claude_code | official_app | claude-desktop | 456 |
| codex_app | cli | codex_exec | 12 |
| claude_code | cli | sdk-cli | 10 |
| codex_app | cli | codex_cli_rs | 7 |
| codex_app | cli | codex-tui | 3 |
| codex_app | third_party | multica-agent-sdk | 2 |
| codex_app | third_party | acp-extension-codex | 1 |
| codex_app | org2 | orgii | 1 |
| codex_app | org2 | orgii-smoke | 1 |

That `claude_code / cli / sdk-cli` row is what surfaced the ORGII-store bug:
those ten transcripts live under `~/.orgii/claude-code-cli-profiles/…`. They
reclassify to `org2` on the next scan under parser v14 — that specific
transition is covered by test, not yet re-observed in the live DB.

No screenshots yet: the badge renders beside the session title and the
placement is still worth your eye before merge.
