### PR TITLE
fix(cargo-config): read build settings regardless of cargo's cwd

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,20 @@
 # Cargo build configuration
+#
+# ── THIS FILE MUST LIVE AT THE REPOSITORY ROOT ───────────────────────────────
+# Cargo discovers `.cargo/config.toml` by walking UP from the *current working
+# directory*, not from the package manifest. This file used to live in
+# `src-tauri/`, which meant it was only read when cargo was invoked from
+# `src-tauri/` — and the Tauri CLI invokes cargo from the repo root, so every
+# `pnpm tauri:dev` build silently ignored everything below.
+#
+# The visible symptom was `incremental = false` never taking effect: dev builds
+# kept writing incremental session data into the shared target dir, ~25 GB of
+# it, which `cargo-sweep` does not collect. Verified by building the same
+# manifest from both directories and diffing `target/debug/incremental`.
+#
+# Keep it here. A copy under `src-tauri/` would be read only for the narrower
+# cwd and would silently diverge from this one.
+# ─────────────────────────────────────────────────────────────────────────────
 
 # ── FFmpeg / OpenSSL environment ──────────────────────────────────────────────
 # Keep machine-local Homebrew paths out of the committed Cargo config.

--- a/scripts/dev/cargo-config-discovery.test.cjs
+++ b/scripts/dev/cargo-config-discovery.test.cjs
@@ -1,0 +1,52 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const rootConfig = path.join(repoRoot, ".cargo", "config.toml");
+const nestedConfig = path.join(repoRoot, "src-tauri", ".cargo", "config.toml");
+
+// Cargo resolves `.cargo/config.toml` by walking up from the *current working
+// directory*, not from the package manifest. The Tauri CLI invokes cargo from
+// the repo root, so a config that lives only under `src-tauri/` is read when a
+// developer runs `cargo` by hand there and ignored for every `pnpm tauri:dev`
+// build. That split is invisible - the build succeeds either way, it just
+// silently drops settings - so it is asserted here rather than left to review.
+
+test("the cargo config lives at the repo root so cwd cannot change it", () => {
+  assert.ok(
+    fs.existsSync(rootConfig),
+    ".cargo/config.toml must exist at the repository root"
+  );
+});
+
+test("no second cargo config shadows it from src-tauri", () => {
+  assert.equal(
+    fs.existsSync(nestedConfig),
+    false,
+    "src-tauri/.cargo/config.toml would apply only to cargo runs started " +
+      "inside src-tauri/, silently diverging from the root config"
+  );
+});
+
+test("incremental compilation stays disabled", () => {
+  // Incremental sessions land in the shared target dir, which cargo-sweep does
+  // not collect, and they race across concurrent cargo processes sharing that
+  // dir. See the comment block at the top of .cargo/config.toml.
+  const config = fs.readFileSync(rootConfig, "utf8");
+  const setting = config
+    .split("\n")
+    .filter((line) => /^\s*incremental\s*=/.test(line))
+    .pop();
+
+  assert.ok(setting, "config must state an explicit `incremental` setting");
+  assert.match(setting, /incremental\s*=\s*false/);
+});
+
+test("the parallelism cap survives the move", () => {
+  // `jobs` bounds peak build memory on 16 GB machines; losing it to a cwd
+  // change is the same class of silent failure as the incremental setting.
+  const config = fs.readFileSync(rootConfig, "utf8");
+  assert.match(config, /^\s*jobs\s*=\s*\d+/m);
+});

--- a/scripts/tauri/build-fast-dual.cjs
+++ b/scripts/tauri/build-fast-dual.cjs
@@ -113,7 +113,7 @@ function runIdentityBuild(label, targetDir, instanceId) {
         CARGO_BUILD_JOBS: String(jobsPerBuild),
         // This command already gives each identity its own target directory,
         // so the cross-process incremental-cache race documented in
-        // src-tauri/.cargo/config.toml cannot occur between the two builds.
+        // .cargo/config.toml cannot occur between the two builds.
         // Opt in locally to avoid recompiling the entire app crate whenever
         // only embedded frontend assets changed.
         CARGO_INCREMENTAL: "1",


### PR DESCRIPTION
## Problem

Cargo resolves `.cargo/config.toml` by walking up from the **current working directory**, not from the package manifest. The config lived at `src-tauri/.cargo/config.toml`, so it was read only when cargo was invoked from inside `src-tauri/`. Any invocation started at the repository root — for example `cargo test --manifest-path src-tauri/Cargo.toml --workspace` — silently used none of it.

Two settings were therefore dead for those builds:

- `incremental = false`, set since the initial commit, never took effect. Incremental session data accumulated in the shared target dir (`~/.cargo/shared-target`), which `cargo-sweep` does not collect — it reached ~25 GB on one machine. The cross-process incremental race the config's own comment documents was never actually prevented either.
- `jobs = 4`, which bounds peak build memory on 16 GB machines, was unenforced the same way.

The failure is invisible: the build succeeds either way, it just drops the settings.

## Solution

Move the file to `.cargo/config.toml` at the repository root. Cargo's discovery walks upward, so the root location is reached from the root **and** from `src-tauri/` — strictly more general than the old path, with no second copy to drift.

`scripts/dev/cargo-config-discovery.test.cjs` locks the invariant: the config exists at the root, no shadowing copy exists under `src-tauri/`, `incremental` is `false`, and `jobs` survives the move. A silent-settings-drop needs a test rather than review attention.

`src-tauri/.cargo/audit.toml` is unrelated and deliberately left in place — `.github/workflows/ci.yml` references it there.

## Potential risks

- **Behaviour change for root-cwd builds.** They now genuinely honour `incremental = false` and `jobs = 4`. That is the intent, but it means `cargo test --workspace` from the root will use 4 jobs where it previously used the default, and stops writing incremental data. Peak memory goes down; a first build after this change recompiles rather than reusing incremental state.
- **Anything invoking cargo from outside the repository** (an absolute `--manifest-path` from an unrelated cwd) still will not see this config. That is inherent to how Cargo discovery works and is not made worse here.
- No change to `~/.cargo/config.toml`, which continues to supply `target-dir` and `rustc-wrapper` machine-locally.
- The move is a pure rename; git records it as such (77% similarity, the delta being the added explanatory header).

## Verification

Config discovery was confirmed empirically with a throwaway crate mirroring this repo's layout — same manifest, same config contents, only the config's location and the cwd varied:

| config location | cwd | `target/debug/incremental` dirs |
| --- | --- | --- |
| `sub/.cargo/` | `sub/` | 0 |
| `sub/.cargo/` | repo root | **1** |
| root `.cargo/` | `sub/` | 0 |
| root `.cargo/` | repo root | 0 |

On this repository, after the move, reproducing the exact leak shape:

- `cargo check --manifest-path src-tauri/Cargo.toml -p app_paths` from the repository root — compiled for real (`Checking app_paths v0.1.0` → `Finished dev profile in 7.30s`) and added **0** incremental dirs.
- `cargo metadata --no-deps` from `src-tauri/` still resolves `target_directory = ~/.cargo/shared-target`.
- `node --test scripts/dev/cargo-config-discovery.test.cjs` — 4/4 pass.
- Pre-commit hook ran (lint-staged, tsc, clippy gates) and passed.

Not run: a full `pnpm tauri:dev` or release build. The change alters only which config file cargo reads, and the settings it restores are the repository's own long-standing declared values.