### PR TITLE
fix(browser-core): explain overlay-hidden webviews

### DIFF
--- a/src/engines/BrowserCore/index.scss
+++ b/src/engines/BrowserCore/index.scss
@@ -157,6 +157,12 @@
   pointer-events: auto;
 }
 
+// Shown while an overlay parks the native webview offscreen. Must not swallow
+// clicks: clicking the pane is how the user dismisses that overlay.
+.browser-webview-hidden-notice {
+  pointer-events: none;
+}
+
 .browser-native-placeholder {
   display: flex;
   flex-direction: column;

--- a/src/engines/BrowserCore/index.test.ts
+++ b/src/engines/BrowserCore/index.test.ts
@@ -1,17 +1,23 @@
 // @vitest-environment jsdom
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { webviewOverlayBlockedAtom } from "@src/store/ui/overlayAtom";
+import { activeOverlayCountAtom } from "@src/store/ui/overlayLayerAtom";
 
 import type { UseBrowserStateReturn } from "./hooks/useBrowserState";
 import BrowserCore from "./index";
 import type { BrowserSession } from "./types";
 
+/** Per-test atom reads; anything unlisted reads `false`. */
+const atomValues = new Map<unknown, unknown>();
+
 vi.mock("jotai", async (importOriginal) => {
   const actual = await importOriginal<typeof import("jotai")>();
   return {
     ...actual,
-    useAtomValue: () => false,
+    useAtomValue: (atom: unknown) => atomValues.get(atom) ?? false,
   };
 });
 
@@ -51,6 +57,16 @@ vi.mock("@src/modules/shared/layouts/blocks", () => ({
 vi.mock("./BrowserSessionWebview", () => ({
   default: () => null,
 }));
+
+function withTauriRuntime<T>(render: () => T): T {
+  const win = window as unknown as Record<string, unknown>;
+  win.__TAURI_INTERNALS__ = {};
+  try {
+    return render();
+  } finally {
+    delete win.__TAURI_INTERNALS__;
+  }
+}
 
 function createBrowserState(
   sessionOverrides: Partial<BrowserSession> = {}
@@ -161,5 +177,111 @@ describe("BrowserCore blank tab placeholder", () => {
 
     expect(hiddenMarkup).not.toContain("Open port 1998");
     expect(navigatedMarkup).not.toContain("Open port 1998");
+  });
+});
+
+describe("BrowserCore overlay-hidden notice", () => {
+  afterEach(() => {
+    atomValues.clear();
+  });
+
+  it("explains the blank pane while an overlay parks the webview offscreen", () => {
+    atomValues.set(webviewOverlayBlockedAtom, true);
+
+    const markup = withTauriRuntime(() =>
+      renderToStaticMarkup(
+        createElement(BrowserCore, {
+          browserState: createBrowserState({ url: "http://localhost:1998/" }),
+        })
+      )
+    );
+
+    expect(markup).toContain("workstation.browserCore.webviewHiddenTitle");
+    expect(markup).toContain("workstation.browserCore.webviewHiddenBody");
+  });
+
+  it("covers the macOS path where the webview is only sent behind React", () => {
+    atomValues.set(activeOverlayCountAtom, 1);
+
+    const markup = withTauriRuntime(() =>
+      renderToStaticMarkup(
+        createElement(BrowserCore, {
+          browserState: createBrowserState({ url: "http://localhost:1998/" }),
+        })
+      )
+    );
+
+    expect(markup).toContain("workstation.browserCore.webviewHiddenTitle");
+  });
+
+  it("stays hidden when no overlay is open", () => {
+    const markup = withTauriRuntime(() =>
+      renderToStaticMarkup(
+        createElement(BrowserCore, {
+          browserState: createBrowserState({ url: "http://localhost:1998/" }),
+        })
+      )
+    );
+
+    expect(markup).not.toContain("workstation.browserCore.webviewHiddenTitle");
+  });
+
+  it("shows on the shared-runtime chrome that does not own the webview", () => {
+    atomValues.set(activeOverlayCountAtom, 1);
+
+    const markup = withTauriRuntime(() =>
+      renderToStaticMarkup(
+        createElement(BrowserCore, {
+          browserState: createBrowserState({ url: "http://localhost:1998/" }),
+          // SharedBrowserWorkspace -> WebViewport shape: visible chrome, but
+          // SharedBrowserApp owns the native webview.
+          respectModalBlocking: false,
+          manageWebviews: false,
+        })
+      )
+    );
+
+    expect(markup).toContain("workstation.browserCore.webviewHiddenTitle");
+  });
+
+  it("stays hidden on blank tabs, host-hidden panes, and the owner host", () => {
+    atomValues.set(webviewOverlayBlockedAtom, true);
+    atomValues.set(activeOverlayCountAtom, 1);
+
+    const blankUrlMarkup = withTauriRuntime(() =>
+      renderToStaticMarkup(
+        createElement(BrowserCore, {
+          browserState: createBrowserState(),
+        })
+      )
+    );
+    const hostHiddenMarkup = withTauriRuntime(() =>
+      renderToStaticMarkup(
+        createElement(BrowserCore, {
+          browserState: createBrowserState({ url: "http://localhost:1998/" }),
+          hidden: true,
+        })
+      )
+    );
+    // SharedBrowserApp: aria-hidden owner host stacked over the same rect.
+    const ownerHostMarkup = withTauriRuntime(() =>
+      renderToStaticMarkup(
+        createElement(BrowserCore, {
+          browserState: createBrowserState({ url: "http://localhost:1998/" }),
+          respectModalBlocking: false,
+          bypassStationModeBlocking: true,
+        })
+      )
+    );
+
+    expect(blankUrlMarkup).not.toContain(
+      "workstation.browserCore.webviewHiddenTitle"
+    );
+    expect(hostHiddenMarkup).not.toContain(
+      "workstation.browserCore.webviewHiddenTitle"
+    );
+    expect(ownerHostMarkup).not.toContain(
+      "workstation.browserCore.webviewHiddenTitle"
+    );
   });
 });

--- a/src/engines/BrowserCore/index.tsx
+++ b/src/engines/BrowserCore/index.tsx
@@ -25,7 +25,11 @@ import { useTranslation } from "react-i18next";
 import Button from "@src/components/Button";
 import { createLogger } from "@src/hooks/logger";
 import { Placeholder } from "@src/modules/shared/layouts/blocks";
-import { webviewBlockedAtom } from "@src/store/ui/overlayAtom";
+import {
+  webviewBlockedAtom,
+  webviewOverlayBlockedAtom,
+} from "@src/store/ui/overlayAtom";
+import { activeOverlayCountAtom } from "@src/store/ui/overlayLayerAtom";
 import { stationModeAtom } from "@src/store/ui/simulatorAtom";
 import { openExternalLink } from "@src/util/platform/ipcRenderer";
 
@@ -115,6 +119,12 @@ export const BrowserCore: React.FC<BrowserCoreProps> = ({
 
   // Check if webviews should be blocked by overlays or station ownership.
   const isWebviewBlocked = useAtomValue(webviewBlockedAtom);
+  // Overlay-only slice: station-mode ownership must not trigger the
+  // "temporarily hidden" notice, because closing a dropdown won't fix that.
+  const isOverlayBlocked = useAtomValue(webviewOverlayBlockedAtom);
+  // macOS keeps the webview alive but sends it behind the React layer instead
+  // of blocking it, so the pane still blanks without `isOverlayBlocked` set.
+  const activeOverlayCount = useAtomValue(activeOverlayCountAtom);
 
   const stationMode = useAtomValue(stationModeAtom);
   // Non-owning shared surfaces are already scoped by their `hidden` prop.
@@ -193,6 +203,25 @@ export const BrowserCore: React.FC<BrowserCoreProps> = ({
   const shouldShowUrlPlaceholder =
     isTabReallyActive && isBlankBrowserUrl(currentSession?.url);
   const shouldRenderContentArea = hasSessionWithUrl || shouldShowUrlPlaceholder;
+  /**
+   * A dropdown/modal either blocks the native webview (`SharedBrowserApp`
+   * hides it off `webviewOverlayBlockedAtom`) or, on macOS, drops it behind
+   * the React layer (`useGlobalBrowserWebviewLayering`). Either way the pane
+   * blanks with no explanation, so say why.
+   *
+   * Deliberately NOT gated on `respectModalBlocking`: the visible chrome for
+   * the shared runtime (`SharedBrowserWorkspace` -> `WebViewport`) passes
+   * `respectModalBlocking={false}` because it does not own the webview — but
+   * it is exactly the surface the user is looking at when the pane blanks.
+   * `bypassStationModeBlocking` excludes the aria-hidden owner host itself,
+   * which is stacked over the same rect and would double the notice.
+   */
+  const shouldShowOverlayHiddenNotice =
+    isWebviewAvailable &&
+    !bypassStationModeBlocking &&
+    (isOverlayBlocked || activeOverlayCount > 0) &&
+    !hidden &&
+    !isBlankBrowserUrl(currentUrl);
 
   // Delay showing the loading overlay by 500ms to avoid flash on fast loads
   const [isLoading, setIsLoading] = React.useState(false);
@@ -266,6 +295,20 @@ export const BrowserCore: React.FC<BrowserCoreProps> = ({
                   fillParentHeight
                 />
               )}
+            </div>
+          )}
+
+          {/* Overlay-hidden notice — the native webview is parked offscreen
+              while a dropdown/modal is open, so the pane would read as broken. */}
+          {shouldShowOverlayHiddenNotice && (
+            <div className="browser-native-info browser-webview-hidden-notice">
+              <Placeholder
+                variant="empty"
+                placement="detail-panel"
+                title={t("workstation.browserCore.webviewHiddenTitle")}
+                subtitle={t("workstation.browserCore.webviewHiddenBody")}
+                fillParentHeight
+              />
             </div>
           )}
 

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -1366,7 +1366,9 @@
       "tryHeading": "Versuchen Sie:",
       "tryCheckConnection": "Ihre Internetverbindung prüfen",
       "tryVerifyUrl": "Die URL auf Tippfehler prüfen",
-      "tryAgainLater": "Später erneut versuchen"
+      "tryAgainLater": "Später erneut versuchen",
+      "webviewHiddenTitle": "Webview vorübergehend ausgeblendet",
+      "webviewHiddenBody": "Menü oder Dialog schließen, um sie wieder anzuzeigen."
     },
     "unsavedChangesTitle": "Unsaved Changes",
     "prkPlaceholder": "PRJ",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1254,7 +1254,9 @@
       "tryHeading": "Try:",
       "tryCheckConnection": "Checking your internet connection",
       "tryVerifyUrl": "Verifying the URL is correct",
-      "tryAgainLater": "Trying again later"
+      "tryAgainLater": "Trying again later",
+      "webviewHiddenTitle": "Webview temporarily hidden",
+      "webviewHiddenBody": "Close the menu or dialog to show it again."
     },
     "unsavedChangesTitle": "Unsaved Changes",
     "prkPlaceholder": "PRJ",

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -1366,7 +1366,9 @@
       "tryHeading": "Prueba:",
       "tryCheckConnection": "Comprobar tu conexión a Internet",
       "tryVerifyUrl": "Verificar que la URL sea correcta",
-      "tryAgainLater": "Intentar de nuevo más tarde"
+      "tryAgainLater": "Intentar de nuevo más tarde",
+      "webviewHiddenTitle": "Vista web oculta temporalmente",
+      "webviewHiddenBody": "Cierra el menú o el diálogo para volver a mostrarla."
     },
     "unsavedChangesTitle": "Unsaved Changes",
     "prkPlaceholder": "PRJ",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1366,7 +1366,9 @@
       "tryHeading": "Essayez :",
       "tryCheckConnection": "Vérifier votre connexion Internet",
       "tryVerifyUrl": "Vérifier que l’URL est correcte",
-      "tryAgainLater": "Réessayer plus tard"
+      "tryAgainLater": "Réessayer plus tard",
+      "webviewHiddenTitle": "Vue web temporairement masquée",
+      "webviewHiddenBody": "Fermez le menu ou la boîte de dialogue pour l’afficher à nouveau."
     },
     "unsavedChangesTitle": "Unsaved Changes",
     "prkPlaceholder": "PRJ",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -1365,7 +1365,9 @@
       "tryHeading": "試す:",
       "tryCheckConnection": "インターネット接続を確認する",
       "tryVerifyUrl": "URL が正しいか確認する",
-      "tryAgainLater": "後でもう一度試す"
+      "tryAgainLater": "後でもう一度試す",
+      "webviewHiddenTitle": "Web ビューを一時的に非表示",
+      "webviewHiddenBody": "メニューまたはダイアログを閉じると再表示されます。"
     },
     "unsavedChangesTitle": "Unsaved Changes",
     "prkPlaceholder": "PRJ",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -1365,7 +1365,9 @@
       "tryHeading": "시도:",
       "tryCheckConnection": "인터넷 연결 확인",
       "tryVerifyUrl": "URL이 올바른지 확인",
-      "tryAgainLater": "나중에 다시 시도"
+      "tryAgainLater": "나중에 다시 시도",
+      "webviewHiddenTitle": "웹뷰가 일시적으로 숨겨졌습니다",
+      "webviewHiddenBody": "메뉴나 대화 상자를 닫으면 다시 표시됩니다."
     },
     "unsavedChangesTitle": "Unsaved Changes",
     "prkPlaceholder": "PRJ",

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -1370,7 +1370,9 @@
       "tryHeading": "Spróbuj:",
       "tryCheckConnection": "Sprawdzić połączenie internetowe",
       "tryVerifyUrl": "Zweryfikować poprawność URL",
-      "tryAgainLater": "Spróbować ponownie później"
+      "tryAgainLater": "Spróbować ponownie później",
+      "webviewHiddenTitle": "Widok sieciowy tymczasowo ukryty",
+      "webviewHiddenBody": "Zamknij menu lub okno dialogowe, aby wyświetlić go ponownie."
     },
     "unsavedChangesTitle": "Niezapisane zmiany",
     "prkPlaceholder": "PRJ",

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -1366,7 +1366,9 @@
       "tryHeading": "Tente:",
       "tryCheckConnection": "Verificar sua conexão com a Internet",
       "tryVerifyUrl": "Verificar se a URL está correta",
-      "tryAgainLater": "Tentar novamente mais tarde"
+      "tryAgainLater": "Tentar novamente mais tarde",
+      "webviewHiddenTitle": "Visualização web oculta temporariamente",
+      "webviewHiddenBody": "Feche o menu ou a caixa de diálogo para exibi-la novamente."
     },
     "unsavedChangesTitle": "Alterações não salvas",
     "prkPlaceholder": "PRJ",

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -1370,7 +1370,9 @@
       "tryHeading": "Попробуйте:",
       "tryCheckConnection": "Проверить подключение к интернету",
       "tryVerifyUrl": "Проверить правильность URL",
-      "tryAgainLater": "Повторить позже"
+      "tryAgainLater": "Повторить позже",
+      "webviewHiddenTitle": "Веб-представление временно скрыто",
+      "webviewHiddenBody": "Закройте меню или диалог, чтобы снова его показать."
     },
     "unsavedChangesTitle": "Unsaved Changes",
     "prkPlaceholder": "PRJ",

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -1367,7 +1367,9 @@
       "tryHeading": "Deneyin:",
       "tryCheckConnection": "İnternet bağlantınızı kontrol edin",
       "tryVerifyUrl": "URL’nin doğru olduğunu doğrulayın",
-      "tryAgainLater": "Daha sonra tekrar deneyin"
+      "tryAgainLater": "Daha sonra tekrar deneyin",
+      "webviewHiddenTitle": "Web görünümü geçici olarak gizlendi",
+      "webviewHiddenBody": "Yeniden göstermek için menüyü veya iletişim kutusunu kapatın."
     },
     "unsavedChangesTitle": "Unsaved Changes",
     "prkPlaceholder": "PRJ",

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -1365,7 +1365,9 @@
       "tryHeading": "Thử:",
       "tryCheckConnection": "Kiểm tra kết nối internet",
       "tryVerifyUrl": "Xác minh URL đúng",
-      "tryAgainLater": "Thử lại sau"
+      "tryAgainLater": "Thử lại sau",
+      "webviewHiddenTitle": "Chế độ xem web tạm thời bị ẩn",
+      "webviewHiddenBody": "Đóng menu hoặc hộp thoại để hiển thị lại."
     },
     "unsavedChangesTitle": "Unsaved Changes",
     "prkPlaceholder": "PRJ",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -1378,7 +1378,9 @@
       "tryHeading": "可嘗試：",
       "tryCheckConnection": "檢查網絡連接",
       "tryVerifyUrl": "確認網址是否正確",
-      "tryAgainLater": "稍後再試"
+      "tryAgainLater": "稍後再試",
+      "webviewHiddenTitle": "網頁檢視已暫時隱藏",
+      "webviewHiddenBody": "關閉選單或對話框即可重新顯示。"
     },
     "unsavedChangesTitle": "未保存的更改",
     "prkPlaceholder": "PRJ",

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -1242,7 +1242,9 @@
       "tryHeading": "可尝试：",
       "tryCheckConnection": "检查网络连接",
       "tryVerifyUrl": "确认网址是否正确",
-      "tryAgainLater": "稍后再试"
+      "tryAgainLater": "稍后再试",
+      "webviewHiddenTitle": "网页视图已临时隐藏",
+      "webviewHiddenBody": "关闭菜单或弹窗即可重新显示。"
     },
     "unsavedChangesTitle": "未保存的更改",
     "prkPlaceholder": "PRJ",


### PR DESCRIPTION
## Problem

Opening a menu or dialog over an active native browser can park the webview offscreen or place it behind the React layer. The visible BrowserCore pane then appears blank with no explanation because overlay blocking and native webview ownership are not projected into the browser chrome.

## Solution

Render a non-interactive placeholder while a nonblank, visible BrowserCore pane has its native webview hidden by overlay state. The condition uses the overlay-only blocking atom plus the active overlay count for the macOS layering path, while excluding blank tabs, host-hidden panes, and the hidden owner host. Add localized title/body copy for every supported locale and regression coverage for the blocking, macOS, shared-runtime, and exclusion paths.

## Potential risks

The notice is driven by global overlay state, so a future overlay that does not cover the browser could surface the message more broadly than intended. The exclusions and platform paths are unit-tested, and the change does not alter persisted data, public APIs, IPC, or wire formats. Native Tauri visual behavior remains unverified, so this PR is intentionally a draft.

## Verification

- `git diff --check` — passed
- `pnpm run lint` — passed with zero warnings
- `pnpm run typecheck` — passed
- `pnpm run check:circular` — passed; no circular dependencies across 6,566 modules
- `pnpm run test` — passed; 1,229 files and 9,773 tests, including all 10 BrowserCore tests
- Commit hooks — lint-staged and scoped TypeScript checks passed
- Not run: native Tauri visual verification on macOS or other platforms

## UI evidence

No screenshot was captured because running and inspecting the desktop UI would require explicit desktop-control authorization. The PR remains draft until the native overlay paths and relevant themes are checked in a running Tauri build.