### PR TITLE
fix(org2-cloud): use icon-only refresh action

### DIFF
--- a/src/features/Org2Cloud/Org2CloudSection.tsx
+++ b/src/features/Org2Cloud/Org2CloudSection.tsx
@@ -138,6 +138,25 @@ const Org2CloudSection: React.FC<Org2CloudSectionProps> = ({
     return <CloudEndpointCard />;
   }
 
+  const refreshDevAuthButton = process.env.NODE_ENV === "development" && (
+    <Button
+      size="default"
+      iconOnly
+      icon={
+        <RefreshCw
+          size={14}
+          className={isRefreshingDevAuth ? REFRESH_ICON_TOKENS.spin : ""}
+        />
+      }
+      loading={isRefreshingDevAuth}
+      loadingSpinIcon
+      disabled={isRefreshingDevAuth}
+      aria-label={t("common:actions.refresh")}
+      onClick={handleRefreshDevAuth}
+      data-testid="org2-cloud-refresh-dev-auth"
+    />
+  );
+
   return (
     <>
       <SectionContainer>
@@ -205,6 +224,7 @@ const Org2CloudSection: React.FC<Org2CloudSectionProps> = ({
                   }
                   data-testid="org2-cloud-rename"
                 />
+                {refreshDevAuthButton}
                 <Button
                   size="default"
                   onClick={handleSignOut}
@@ -214,33 +234,16 @@ const Org2CloudSection: React.FC<Org2CloudSectionProps> = ({
                 </Button>
               </div>
             ) : (
-              <Button
-                size="default"
-                onClick={handleSignIn}
-                data-testid="org2-cloud-sign-in"
-              >
-                {t("cloud.signIn")}
-              </Button>
-            )}
-            {process.env.NODE_ENV === "development" && (
-              <Button
-                size="default"
-                icon={
-                  <RefreshCw
-                    size={14}
-                    className={
-                      isRefreshingDevAuth ? REFRESH_ICON_TOKENS.spin : ""
-                    }
-                  />
-                }
-                loading={isRefreshingDevAuth}
-                loadingSpinIcon
-                disabled={isRefreshingDevAuth}
-                onClick={handleRefreshDevAuth}
-                data-testid="org2-cloud-refresh-dev-auth"
-              >
-                {t("common:actions.refresh")}
-              </Button>
+              <>
+                <Button
+                  size="default"
+                  onClick={handleSignIn}
+                  data-testid="org2-cloud-sign-in"
+                >
+                  {t("cloud.signIn")}
+                </Button>
+                {refreshDevAuthButton}
+              </>
             )}
           </div>
         </SectionRow>


### PR DESCRIPTION
## Problem

The development-only ORG2 Cloud refresh action is rendered as a full text button after Exit. This makes the action row wider than necessary and places Refresh on the wrong side of Exit compared with the requested layout.

## Solution

Render the refresh action as an icon-only button with the existing localized refresh label retained as its accessible name. In the signed-in state, place Refresh immediately before Exit. Preserve the existing loading spinner, disabled state, click behavior, test ID, and signed-out bundled-auth recovery path.

## Potential risks

The icon-only treatment is less explicit than visible text, which is intentional for this compact development-only control; the localized aria-label preserves its accessible name. The change does not affect authentication behavior, persistence, concurrency, public APIs, IPC, wire formats, dependencies, or production UI because the action remains guarded by the development environment check.

## Verification

- `npm run lint:file -- src/features/Org2Cloud/Org2CloudSection.tsx` — passed
- `npm run typecheck` — passed on the final `develop` base
- Repository pre-commit hook — passed lint-staged, staged TypeScript checking, and staged-file repository statistics; Rust clippy correctly skipped because no Rust files changed
- `git diff --check origin/develop...HEAD` — passed
- `git diff --name-status origin/develop...HEAD` — confirmed the PR changes only `src/features/Org2Cloud/Org2CloudSection.tsx`
- Source inspection confirmed the signed-in action order is Rename, Refresh, Exit and the refresh button has no visible text child

## Visual evidence

No runtime screenshot was captured. The control is development-only and requires an authenticated desktop state; local UI control is explicit opt-in in this workspace and was not authorized. The supplied screenshot served as the layout reference.