### PR TITLE
fix(theme): paint every caret with the primary accent

### DIFF
--- a/public/orgii_dark.css
+++ b/public/orgii_dark.css
@@ -53,6 +53,9 @@
   --cm-editor-background: #0a0a0a;
   --cm-editor-foreground: #c9d1d9;
   --cm-editor-selection: #264f78;
+  /* Static pre-accent defaults. The body scope below re-declares
+     --cm-editor-caret / --terminal-caret as var(--color-primary-6) so both
+     carets track the primary-color preset, like input carets do. */
   --cm-editor-caret: #43aafd;
   --text-selection: #264f78;
   --terminal-selection: #264f78;
@@ -232,10 +235,10 @@ body {
   --cm-editor-background: #0a0a0a;
   --cm-editor-foreground: #c9d1d9;
   --cm-editor-selection: #264f78;
-  --cm-editor-caret: #43aafd;
+  --cm-editor-caret: var(--color-primary-6);
   --text-selection: #264f78;
   --terminal-selection: #264f78;
-  --terminal-caret: #43aafd;
+  --terminal-caret: var(--color-primary-6);
   --cm-editor-gutter-bg: var(--cm-editor-background);
   --cm-editor-gutter-fg: #8b949e;
   --cm-editor-line-highlight: #36334280;

--- a/public/orgii_high_contrast.css
+++ b/public/orgii_high_contrast.css
@@ -50,6 +50,9 @@
   --cm-editor-background: #050505;
   --cm-editor-foreground: #ffffff;
   --cm-editor-selection: #1c1c1c;
+  /* Static pre-accent defaults. The body scope below re-declares
+     --cm-editor-caret / --terminal-caret as var(--color-primary-6) so both
+     carets track the primary-color preset, like input carets do. */
   --cm-editor-caret: #38bdf8;
   --text-selection: #075985;
   --terminal-selection: #1c1c1c;
@@ -222,10 +225,10 @@ body {
   --cm-editor-background: #050505;
   --cm-editor-foreground: #ffffff;
   --cm-editor-selection: #1c1c1c;
-  --cm-editor-caret: #38bdf8;
+  --cm-editor-caret: var(--color-primary-6);
   --text-selection: #075985;
   --terminal-selection: #1c1c1c;
-  --terminal-caret: #38bdf8;
+  --terminal-caret: var(--color-primary-6);
   --cm-editor-gutter-bg: #050505;
   --cm-editor-gutter-fg: #c7ced9;
   --cm-editor-line-highlight: #1c1c1c;

--- a/public/orgii_main.css
+++ b/public/orgii_main.css
@@ -53,10 +53,13 @@
   --cm-editor-background: #ffffff;
   --cm-editor-foreground: #24292e;
   --cm-editor-selection: #efefef;
-  --cm-editor-caret: #4f6dff;
+  /* Static pre-accent defaults. The body scope below re-declares
+     --cm-editor-caret / --terminal-caret as var(--color-primary-6) so both
+     carets track the primary-color preset, like input carets do. */
+  --cm-editor-caret: #1d8ffd;
   --text-selection: #bfe8ff;
   --terminal-selection: #efefef;
-  --terminal-caret: #4f6dff;
+  --terminal-caret: #1d8ffd;
   --cm-editor-gutter-bg: var(--cm-editor-background);
   --cm-editor-gutter-fg: #6e7781;
   --cm-editor-line-highlight: transparent;
@@ -207,4 +210,11 @@ body {
   --color-warning-4: #ffb65d;
   --color-warning-5: #ff9a2e;
   --color-warning-6: #ff7d00;
+
+  /* Caret follows the accent. --color-primary-6 is defined on <body> (and
+     overridden inline there by the primary-color preset), so these must be
+     declared in the body scope to resolve — the :root copies above are the
+     static pre-accent defaults. */
+  --cm-editor-caret: var(--color-primary-6);
+  --terminal-caret: var(--color-primary-6);
 }

--- a/src/components/TerminalInteractive/index.tsx
+++ b/src/components/TerminalInteractive/index.tsx
@@ -41,6 +41,7 @@ import {
 // Direct leaf import to avoid pulling @src/store's barrel — which transitively
 // reaches SidebarModules/Terminal → engines/TerminalCore → this file.
 import {
+  primaryColorPresetAtom,
   terminalFontSizeAtom,
   terminalLetterSpacingAtom,
   terminalThemeAtom,
@@ -132,6 +133,9 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
     const customShellPath = useAtomValue(customShellPathAtom);
     const appTheme = useAtomValue(themesAtom);
     const isDarkTheme = isThemeCssPathDark(appTheme);
+    // The cursor color comes from --terminal-caret (an alias of
+    // --color-primary-6); tracking the preset re-resolves it on accent change.
+    const primaryColorPreset = useAtomValue(primaryColorPresetAtom);
 
     const initialAppearanceRef = useRef({
       terminalTheme,
@@ -364,6 +368,7 @@ export const TerminalView = forwardRef<TerminalViewHandle, TerminalViewProps>(
       isReady,
       terminalTheme,
       isDarkTheme,
+      primaryColorPreset,
       terminalFontSize,
       terminalLetterSpacing,
       codeFontFamily,

--- a/src/components/TerminalInteractive/useTerminalAppearance.ts
+++ b/src/components/TerminalInteractive/useTerminalAppearance.ts
@@ -1,6 +1,7 @@
 import type { Terminal } from "@xterm/xterm";
 import { type RefObject, useEffect } from "react";
 
+import type { PrimaryColorPreset } from "@src/config/appearance/primaryColors";
 // Direct leaf import to avoid pulling @src/store's barrel — which transitively
 // reaches SidebarModules/Terminal → engines/TerminalCore → this file.
 import { createLogger } from "@src/hooks/logger";
@@ -37,6 +38,8 @@ interface UseTerminalAppearanceOptions {
   isReady: boolean;
   terminalTheme: TerminalThemeName;
   isDarkTheme: boolean;
+  /** Only a repaint trigger — the cursor color itself comes from CSS tokens. */
+  primaryColorPreset: PrimaryColorPreset;
   terminalFontSize: number;
   terminalLetterSpacing: number;
   codeFontFamily: string;
@@ -49,6 +52,7 @@ export function useTerminalAppearance({
   isReady,
   terminalTheme,
   isDarkTheme,
+  primaryColorPreset,
   terminalFontSize,
   terminalLetterSpacing,
   codeFontFamily,
@@ -63,9 +67,10 @@ export function useTerminalAppearance({
     if (!terminal || !isReady) return;
 
     let frameId: number | null = null;
+    const applied = getXTermTheme(terminalTheme, backgroundColor);
     if (
       runForLiveTerminal(terminalRef, terminal, () => {
-        terminal.options.theme = getXTermTheme(terminalTheme, backgroundColor);
+        terminal.options.theme = applied;
         terminal.options.cursorStyle = "bar";
         terminal.options.cursorBlink = true;
         terminal.options.cursorInactiveStyle = "outline";
@@ -74,7 +79,25 @@ export function useTerminalAppearance({
       })
     ) {
       frameId = requestAnimationFrame(() => {
-        if (terminalRef.current === terminal) fitTerminal();
+        if (terminalRef.current !== terminal) return;
+        // The CSS tokens this theme is resolved from can settle a frame late:
+        // the theme <link> swap is async, and the primary-color preset (which
+        // --terminal-caret aliases) is written to body's inline style by a
+        // root-level effect that runs after this one. Re-resolve once the
+        // frame has committed and repaint only if a color actually moved.
+        runForLiveTerminal(terminalRef, terminal, () => {
+          const settled = getXTermTheme(terminalTheme, backgroundColor);
+          if (
+            settled.cursor !== applied.cursor ||
+            settled.background !== applied.background ||
+            settled.selectionBackground !== applied.selectionBackground
+          ) {
+            terminal.options.theme = settled;
+            terminal.clearTextureAtlas();
+            terminal.refresh(0, terminal.rows - 1);
+          }
+        });
+        fitTerminal();
       });
     }
 
@@ -85,6 +108,7 @@ export function useTerminalAppearance({
     terminalTheme,
     backgroundColor,
     isDarkTheme,
+    primaryColorPreset,
     isReady,
     fitTerminal,
     terminalRef,

--- a/src/components/TerminalInteractive/utils/theme.test.ts
+++ b/src/components/TerminalInteractive/utils/theme.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+/**
+ * The terminal cursor is painted by xterm's renderer from `ITheme.cursor`, not
+ * by CSS, so it only matches the input caret if this resolver walks the same
+ * token chain the stylesheets do: --terminal-caret -> --color-primary-6.
+ *
+ * That chain only exists in the body scope. The theme CSS declares its color
+ * tokens on `body`, and the primary-color preset overrides --color-primary-*
+ * inline on `body` as well — <html> can see neither, which is why reading the
+ * token off `document.documentElement` used to leave the cursor on the theme's
+ * default blue under every non-default accent.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { TERMINAL_THEMES } from "@src/util/ui/terminal/themes";
+
+import { getXTermTheme } from "./theme";
+
+const LIGHT_BACKGROUND = "#ffffff";
+const LIGHT_PRIMARY_6 = "#1d8ffd";
+/** --color-primary-6 of the "violet" preset in light mode. */
+const VIOLET_PRIMARY_6 = "#722ed1";
+
+/** The shape the public theme CSS files declare: literals on :root, alias on body. */
+function installThemeCss(): void {
+  const style = document.createElement("style");
+  style.textContent = `
+    :root {
+      --cm-editor-background: ${LIGHT_BACKGROUND};
+      --cm-editor-caret: ${LIGHT_PRIMARY_6};
+      --terminal-caret: ${LIGHT_PRIMARY_6};
+      --terminal-selection: #efefef;
+    }
+    body {
+      --color-primary-6: ${LIGHT_PRIMARY_6};
+      --cm-editor-caret: var(--color-primary-6);
+      --terminal-caret: var(--color-primary-6);
+    }
+  `;
+  document.head.append(style);
+}
+
+describe("getXTermTheme cursor", () => {
+  beforeEach(() => {
+    document.head.innerHTML = "";
+    document.body.removeAttribute("style");
+  });
+
+  it("resolves the accent the input caret uses", () => {
+    installThemeCss();
+
+    expect(getXTermTheme("light").cursor).toBe(LIGHT_PRIMARY_6);
+  });
+
+  it("follows a primary-color preset applied inline to body", () => {
+    installThemeCss();
+    document.body.style.setProperty("--color-primary-6", VIOLET_PRIMARY_6);
+
+    expect(getXTermTheme("light").cursor).toBe(VIOLET_PRIMARY_6);
+  });
+
+  it("falls back to the palette default before the theme CSS loads", () => {
+    expect(getXTermTheme("light").cursor).toBe(TERMINAL_THEMES.light.cursor);
+  });
+});

--- a/src/components/TerminalInteractive/utils/theme.ts
+++ b/src/components/TerminalInteractive/utils/theme.ts
@@ -4,9 +4,13 @@
  *
  * Background strategy: xterm owns its background. We resolve --cm-editor-background
  * from the document and pass it as theme.background, matching VSCode's
- * approach. On app theme switches the active terminal's theme is patched
- * via terminal.options.theme = ... (see TerminalInteractive theme effect),
- * so the background tracks the token without recreating the terminal.
+ * approach. On app theme switches the active terminal's theme is patched via
+ * terminal.options.theme = ... (see TerminalInteractive theme effect), so the
+ * background tracks the token without recreating the terminal.
+ *
+ * The cursor is resolved the same way from --terminal-caret, which the themes
+ * alias to --color-primary-6 — so the cursor the renderer paints matches the
+ * caret of every input, including under a non-default primary-color preset.
  */
 import type { ITheme } from "@xterm/xterm";
 
@@ -26,9 +30,13 @@ function getDocumentColorToken(
   if (seenTokens.has(tokenName)) return fallback;
 
   seenTokens.add(tokenName);
-  const cssVar = getComputedStyle(document.documentElement)
-    .getPropertyValue(tokenName)
-    .trim();
+  // Read from <body>, not <html>: the theme CSS declares its color tokens
+  // (including --color-primary-6, which the primary-color preset then
+  // overrides inline) on `body`, and custom properties inherit down from
+  // :root — so the body scope resolves both, while :root cannot see the
+  // accent at all.
+  const scope = document.body ?? document.documentElement;
+  const cssVar = getComputedStyle(scope).getPropertyValue(tokenName).trim();
   if (!cssVar) return fallback;
 
   const referenceMatch = cssVar.match(CSS_VAR_REFERENCE_PATTERN);

--- a/src/components/XtermOutput/index.tsx
+++ b/src/components/XtermOutput/index.tsx
@@ -31,6 +31,7 @@ import {
 import { TERMINAL_LINE_HEIGHT } from "@src/config/terminalAppearance";
 import { createLogger } from "@src/hooks/logger";
 import {
+  primaryColorPresetAtom,
   terminalFontSizeAtom,
   terminalLetterSpacingAtom,
   terminalThemeAtom,
@@ -80,6 +81,9 @@ const XtermOutput = memo(function XtermOutput({
   const [computedHeight, setComputedHeight] = useState(MIN_HEIGHT);
 
   const terminalTheme = useAtomValue(terminalThemeAtom);
+  // The cursor color resolves from --terminal-caret (an alias of
+  // --color-primary-6); tracking the preset re-resolves it on accent change.
+  const primaryColorPreset = useAtomValue(primaryColorPresetAtom);
   const fontSize = useAtomValue(terminalFontSizeAtom);
   const letterSpacing = useAtomValue(terminalLetterSpacingAtom);
 
@@ -211,10 +215,30 @@ const XtermOutput = memo(function XtermOutput({
   useEffect(() => {
     const terminal = terminalRef.current;
     if (!terminal) return;
-    terminal.options.theme = getXTermTheme(terminalTheme);
+    const applied = getXTermTheme(terminalTheme);
+    terminal.options.theme = applied;
     terminal.clearTextureAtlas?.();
     terminal.refresh(0, terminal.rows - 1);
-  }, [terminalTheme]);
+
+    // The theme <link> swap and the primary-color preset (written to body's
+    // inline style by a root-level effect) both land after this effect runs,
+    // so re-resolve on the next frame and repaint only if a color moved.
+    const frameId = requestAnimationFrame(() => {
+      if (terminalRef.current !== terminal) return;
+      const settled = getXTermTheme(terminalTheme);
+      if (
+        settled.cursor === applied.cursor &&
+        settled.background === applied.background &&
+        settled.selectionBackground === applied.selectionBackground
+      ) {
+        return;
+      }
+      terminal.options.theme = settled;
+      terminal.clearTextureAtlas?.();
+      terminal.refresh(0, terminal.rows - 1);
+    });
+    return () => cancelAnimationFrame(frameId);
+  }, [terminalTheme, primaryColorPreset]);
 
   // Sync font changes
   useEffect(() => {

--- a/src/features/CodeViewer/EditableCodeViewer.scss
+++ b/src/features/CodeViewer/EditableCodeViewer.scss
@@ -36,7 +36,8 @@
     outline: none;
     background: transparent;
     color: transparent;
-    caret-color: var(--color-text-1);
+    // Same caret color as inputs and CodeMirror — the accent, not the text color.
+    caret-color: var(--cm-editor-caret, var(--color-primary-6));
     resize: none;
     font-family: var(
       --code-font-family,

--- a/src/index.scss
+++ b/src/index.scss
@@ -423,6 +423,28 @@ select,
   -webkit-touch-callout: default;
 }
 
+/**
+ * One caret color for every text-entry surface.
+ *
+ * `Input`, `Textarea`, and `ComposerInput` each declare the accent caret on
+ * their own class, but the app has many native fields that are not wrapped in
+ * one — spotlight search, the browser URL bar, file-tree rename, find/replace,
+ * dropdown filters — and those fall back to the UA default, which is the text
+ * color. This element-level rule is the shared default, so a native field is
+ * accented without opting in.
+ *
+ * Specificity keeps it out of the way: any class-level rule wins, which is how
+ * code editors and terminals keep their own caret token (`--cm-editor-caret`,
+ * `--terminal-caret` — themselves aliases of `--color-primary-6`).
+ */
+input,
+textarea,
+[contenteditable=""],
+[contenteditable="true"],
+[contenteditable="plaintext-only"] {
+  caret-color: var(--color-primary-6);
+}
+
 /*
  * Optional web-style pointer cursors for semantic interactive controls.
  *

--- a/src/util/ui/terminal/themes.ts
+++ b/src/util/ui/terminal/themes.ts
@@ -82,7 +82,10 @@ export const TERMINAL_THEMES: Record<TerminalThemeName, TerminalTheme> = {
   dark: {
     background: "#141414",
     foreground: "#e4e4e7",
-    cursor: "#22d3ee",
+    // Pre-mount fallback only; the live cursor comes from --terminal-caret
+    // (aliased to --color-primary-6). Keep in sync with the dark theme's
+    // default --color-primary-6 so the first paint is not a different color.
+    cursor: "#43aafd",
     cursorAccent: "#141414",
     selection: "#212121",
     black: "#09090b",
@@ -105,7 +108,8 @@ export const TERMINAL_THEMES: Record<TerminalThemeName, TerminalTheme> = {
   light: {
     background: "#fafafa",
     foreground: "#1f2937",
-    cursor: "#3b82f6",
+    // Pre-mount fallback only — see the dark theme's cursor note.
+    cursor: "#1d8ffd",
     cursorAccent: "#fafafa",
     selection: "#efefef",
     black: "#1f2937",

--- a/src/util/ui/theme/__tests__/caretTokenParity.test.ts
+++ b/src/util/ui/theme/__tests__/caretTokenParity.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Caret parity: the code-editor caret and the terminal cursor must be the same
+ * accent as an input caret (`caret-color: var(--color-primary-6)`).
+ *
+ * Two ways that drifted before:
+ *  - the light theme pinned `--cm-editor-caret` / `--terminal-caret` to an
+ *    indigo (#4f6dff) that its `--color-primary-6` had since moved away from;
+ *  - the tokens were literals at all, so the primary-color presets — which
+ *    write `--color-primary-*` inline on <body> — recolored every input caret
+ *    while the editor and terminal stayed blue.
+ *
+ * The fix is that the body scope aliases both tokens to `--color-primary-6`.
+ * These assertions pin that alias, and pin the literals that stand in before
+ * it resolves (the `:root` copies and the xterm palette fallbacks) to the same
+ * color, so a first paint is never a different accent than the second.
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { extname, join, relative, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { TERMINAL_THEMES } from "@src/util/ui/terminal/themes";
+
+const THEME_FILES = [
+  "orgii_main.css",
+  "orgii_dark.css",
+  "orgii_high_contrast.css",
+] as const;
+
+const CARET_TOKENS = ["--cm-editor-caret", "--terminal-caret"] as const;
+
+const PRIMARY_ALIAS = "var(--color-primary-6)";
+
+interface ThemeScopes {
+  /** Declarations on `:root` — inherited by <html>, where no accent exists. */
+  root: string;
+  /** Declarations on `body`, where --color-primary-6 is defined and overridden. */
+  body: string;
+}
+
+function readThemeScopes(fileName: string): ThemeScopes {
+  const source = readFileSync(
+    resolve(process.cwd(), "public", fileName),
+    "utf8"
+  );
+  const [root, body] = source.split("body {");
+  expect(body, `${fileName} should declare a body scope`).toBeDefined();
+  return { root, body };
+}
+
+function declaredValue(scope: string, token: string): string | undefined {
+  const match = new RegExp(`^\\s*${token}:\\s*([^;]+);`, "m").exec(scope);
+  return match?.[1].trim();
+}
+
+describe.each(THEME_FILES)("%s caret tokens", (fileName) => {
+  const { root, body } = readThemeScopes(fileName);
+  const primary6 = declaredValue(body, "--color-primary-6");
+
+  it("defines the accent it aliases", () => {
+    expect(primary6).toMatch(/^#[\da-f]{6}$/i);
+  });
+
+  it.each(CARET_TOKENS)(
+    "aliases %s to the accent in the body scope",
+    (token) => {
+      expect(declaredValue(body, token)).toBe(PRIMARY_ALIAS);
+    }
+  );
+
+  it.each(CARET_TOKENS)(
+    "keeps the :root literal for %s on the default accent",
+    (token) => {
+      expect(declaredValue(root, token)).toBe(primary6);
+    }
+  );
+});
+
+describe("xterm palette fallbacks", () => {
+  it.each([
+    ["light", "orgii_main.css"],
+    ["dark", "orgii_dark.css"],
+  ] as const)(
+    "pins the %s pre-mount cursor to that theme's accent",
+    (paletteName, fileName) => {
+      const { body } = readThemeScopes(fileName);
+
+      expect(TERMINAL_THEMES[paletteName].cursor).toBe(
+        declaredValue(body, "--color-primary-6")
+      );
+    }
+  );
+});
+
+/**
+ * Sweep guard: nothing in the app may paint a caret in a color that is not the
+ * accent. Design-system fields declare it per component, native fields inherit
+ * the shared default in index.scss, and editors/terminals go through the
+ * `--cm-editor-caret` / `--terminal-caret` aliases — those are the only three
+ * shapes allowed. A caret pinned to a text color (as the code viewer's editable
+ * overlay was) is the drift this catches.
+ */
+const ACCENT_TOKENS = [
+  "--color-primary-6",
+  "--cm-editor-caret",
+  "--terminal-caret",
+];
+
+const SOURCE_EXTENSIONS = new Set([".scss", ".css", ".ts", ".tsx"]);
+
+const CARET_DECLARATION = /(?:caret-color|caretColor):\s*"?([^;"\n]+)"?/g;
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const entryPath = join(directory, entry.name);
+    if (entry.isDirectory()) return sourceFiles(entryPath);
+    if (!SOURCE_EXTENSIONS.has(extname(entry.name))) return [];
+    if (entry.name.includes(".test.")) return [];
+    return [entryPath];
+  });
+}
+
+describe("caret declarations", () => {
+  const srcRoot = resolve(process.cwd(), "src");
+
+  const declarations = sourceFiles(srcRoot).flatMap((file) => {
+    const source = readFileSync(file, "utf8");
+    return [...source.matchAll(CARET_DECLARATION)].map(
+      (match) => `${relative(srcRoot, file)}: ${match[1].trim()}`
+    );
+  });
+
+  it("are actually found by this sweep", () => {
+    // Guards the regex itself: a scan that matches nothing would pass the
+    // assertion below without having checked anything.
+    expect(declarations.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it("only ever paint the accent", () => {
+    const offenders = declarations.filter(
+      (declaration) =>
+        !ACCENT_TOKENS.some((token) => declaration.includes(token))
+    );
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("give native fields the accent without opting in", () => {
+    const globalStyles = readFileSync(join(srcRoot, "index.scss"), "utf8");
+
+    const sharedDefault =
+      /input,\ntextarea,\n\[contenteditable=""\],\n\[contenteditable="true"\],\n\[contenteditable="plaintext-only"\] \{\n {2}caret-color: var\(--color-primary-6\);\n\}/;
+
+    expect(globalStyles).toMatch(sharedDefault);
+  });
+});


### PR DESCRIPTION
## Problem

Every input declares `caret-color: var(--color-primary-6)`, but three other
families of text caret did not follow it.

**1. The editor and terminal caret tokens were literal hexes per theme.** The
light theme's had drifted away from its accent:

| theme | `--cm-editor-caret` / `--terminal-caret` | `--color-primary-6` |
| --- | --- | --- |
| `orgii_main` (light) | `#4f6dff` | `#1d8ffd` ← visibly wrong |
| `orgii_dark` | `#43aafd` | `#43aafd` |
| `orgii_high_contrast` | `#38bdf8` | `#38bdf8` |

And because they were literals *at all*, the primary-color presets — which write
`--color-primary-*` inline on `<body>` in `useEditorAppearanceStyles` — recolored
every input caret while the code editor and terminal stayed blue in all three
themes.

**2. xterm could not see the accent even once the token tracked it.** The
terminal cursor is painted by the renderer from `ITheme.cursor`, not by CSS, and
`getDocumentColorToken` resolved the token off `document.documentElement` — the
one scope where neither `--color-primary-6` (declared on `body`) nor the inline
preset override exists.

**3. Native fields never declared a caret at all.** Only six places in `src/`
set `caret-color`; the ~55 files that render a raw `<input>`, `<textarea>`, or
`[contenteditable]` outside `Input` / `Textarea` / `ComposerInput` fell back to
the UA default, which is the text color — spotlight search, the browser URL bar,
file-tree rename, find & replace, dropdown filters, the Linear forms, and so on.
`EditableCodeViewer`'s overlay was explicitly pinned to `--color-text-1`.

## Solution

One rule: a caret is the accent, everywhere.

- **Theme CSS (all three files).** The `body` scope now aliases
  `--cm-editor-caret` and `--terminal-caret` to `var(--color-primary-6)`, so both
  track the preset. The `:root` copies stay literal — `html` cannot resolve
  `--color-primary-6`, and an unresolvable `var()` there computes to the
  guaranteed-invalid value, which would silently drop the JS resolver back to its
  fallback — but they are now pinned to each theme's default accent, which is the
  light theme's `#4f6dff` → `#1d8ffd` correction.
- **`TerminalInteractive/utils/theme.ts`.** Resolves tokens from `<body>` instead
  of `<html>`. Custom properties inherit down from `:root`, so the body scope sees
  the theme tokens *and* the inline accent; `:root` sees only the former.
- **`useTerminalAppearance` / `XtermOutput`.** Both track the preset and
  re-resolve on the next animation frame, repainting only if a color actually
  moved. The accent is written to `body` by a root-level effect, which runs
  *after* a child terminal's effect — a synchronous read gets the old value. This
  also covers the async theme `<link>` swap.
- **`util/ui/terminal/themes.ts`.** The pre-mount fallback cursors (`#22d3ee`
  cyan, `#3b82f6`) are now each theme's default accent, so first paint is not a
  different color than the second.
- **`index.scss`.** The app's established text-entry selector list gets
  `caret-color: var(--color-primary-6)` as a shared default, so a native field is
  accented without opting in. Element-level specificity, so every class-level rule
  still wins — that is how editors and terminals keep their own token.
- **`EditableCodeViewer.scss`.** Its overlay caret uses the editor token instead
  of the text color.

Deliberately unchanged: the two blinking bars in `_activity-thinking.scss`
(`--color-text-2` / `--color-text-4`). They are streaming/typing indicators at the
end of rendered text, not insertion points, and an accent bar mid-paragraph reads
as a UI artifact.

## Potential risks

- **Accent presets now reach two more surfaces.** Under a non-blue preset the
  editor caret and terminal cursor become e.g. violet or green. That is the
  intent, and it matches what inputs already did, but it is a visible change for
  anyone on a non-default accent.
- **The `:root` literals are a manual mirror.** They must stay equal to each
  theme's `--color-primary-6`; that is exactly the drift that caused this bug, so
  `caretTokenParity.test.ts` asserts the equality for all three themes and for the
  xterm palette fallbacks.
- **The shared `index.scss` default is broad.** It applies to every native
  `input` / `textarea` / `[contenteditable]` in the document. It uses element
  selectors rather than `body { caret-color }` on purpose: `caret-color` inherits
  through shadow boundaries, and the agent-authored HTML in
  `CanvasPreviewSurface`'s shadow root is meant to stay style-isolated. A field
  that ever wants a different caret still overrides it with any class rule.
- **Extra work per theme change is bounded.** The added rAF re-resolve is a
  no-op comparison in the common case and only calls `clearTextureAtlas()` +
  `refresh()` when a color really changed.
- **Not exercised:** Windows/Linux WebView2 and WKWebView were not checked — the
  token chain is plain CSS custom-property resolution, and the JS resolver handles
  both the substituted and unsubstituted forms of `getComputedStyle`, but only
  Chromium was verified directly.

## Verification

- `npx tsc --noEmit --pretty false` — clean. (The repo's pre-commit TypeScript
  gate can never fail: `TSC_OUTPUT=$(npx tsc ...) || true` followed by
  `TSC_EXIT=$?` always captures `0`, so a green hook is not evidence. Run
  separately for this reason.)
- `npx vitest run` — 1231 files / 9787 tests passed.
- `npx eslint` on every changed `.ts`/`.tsx` and `npx prettier --check` on the
  changed `.css`/`.scss` — clean.
- **Regression tests, each confirmed to fail against the pre-fix code:**
  - `src/util/ui/theme/__tests__/caretTokenParity.test.ts` — the body-scope alias
    and `:root`/palette literals for all three themes, plus a sweep over every
    `.scss/.css/.ts/.tsx` in `src/` that fails on any `caret-color` which is not
    the accent or one of its aliases (with a non-vacuity guard on the scan
    itself), and a pin on the shared `index.scss` default.
  - `src/components/TerminalInteractive/utils/theme.test.ts` — `getXTermTheme`
    resolves the cursor through the alias, follows a preset applied inline to
    `body`, and falls back to the palette default before the theme CSS loads.
- **Manual, in Chromium against the shipped theme CSS:** for `orgii_main`,
  `orgii_dark`, and `orgii_high_contrast`, with the default accent and with the
  violet/green presets applied inline to `body`, a raw `<input>`, raw
  `<textarea>`, raw `[contenteditable]`, `.input-field`, `--cm-editor-caret`, and
  `--terminal-caret` all resolve to the same value (light default
  `rgb(29, 143, 253)`; light + violet `rgb(114, 46, 209)`; dark + green
  `rgb(0, 180, 42)`).
- **Not run:** the app itself was not launched, so the xterm cursor was not
  observed repainting live under a preset change — that path is covered only by
  the resolver test plus the effect's dependency and rAF re-resolve. No E2E or
  Rust suites were run; nothing in this change touches either.

### Screenshots

Caret color is a blinking 2px bar that screenshots unreliably, so the visual
check above renders the three resolved values as swatches instead: the input
caret color, `--cm-editor-caret`, and `--terminal-caret` paint as one continuous
block per theme/accent combination. No layout, spacing, or component visuals
change in this PR.
