### PR TITLE
fix(tab-bar): use text color for selected tabs

### DIFF
--- a/src/components/TabPill/TabPillSurface.test.ts
+++ b/src/components/TabPill/TabPillSurface.test.ts
@@ -1,0 +1,21 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { TAB_PILL_DRAG_OVERLAY_CLASS, TabPillSurface } from "./TabPillSurface";
+
+describe("TabPillSurface", () => {
+  it("uses text-1 for selected and dragged tab surfaces", () => {
+    const markup = renderToStaticMarkup(
+      createElement(TabPillSurface, { isActive: true }, "Selected tab")
+    );
+    const activeSurface = markup.match(
+      /<div[^>]*work-station-editor-tab--active[^>]*>/
+    )?.[0];
+
+    expect(activeSurface).toContain("text-text-1");
+    expect(activeSurface).not.toContain("text-primary-6");
+    expect(TAB_PILL_DRAG_OVERLAY_CLASS).toContain("text-text-1");
+    expect(TAB_PILL_DRAG_OVERLAY_CLASS).not.toContain("text-primary-6");
+  });
+});

--- a/src/components/TabPill/TabPillSurface.tsx
+++ b/src/components/TabPill/TabPillSurface.tsx
@@ -22,7 +22,7 @@ const VARIANT_CLASSES: Record<
   session: "min-w-0 max-w-[120px] shrink-0 gap-1.5 px-2.5",
 };
 
-export const TAB_PILL_DRAG_OVERLAY_CLASS = `flex h-8 shrink-0 cursor-grabbing items-center gap-1.5 rounded-lg border border-border-2 ${SURFACE_TOKENS.selected} pl-2.5 pr-2 shadow-lg`;
+export const TAB_PILL_DRAG_OVERLAY_CLASS = `flex h-8 shrink-0 cursor-grabbing items-center gap-1.5 rounded-lg border border-border-2 ${SURFACE_TOKENS.selected} pl-2.5 pr-2 text-text-1 shadow-lg`;
 
 export const TabPillSurface = React.forwardRef<
   TabPillElement,
@@ -65,7 +65,7 @@ export const TabPillSurface = React.forwardRef<
     );
 
     const stateClass = isActive
-      ? `work-station-editor-tab--active z-10 ${SURFACE_TOKENS.selected} text-primary-6 ${SURFACE_TOKENS.selectedHover}`
+      ? `work-station-editor-tab--active z-10 ${SURFACE_TOKENS.selected} text-text-1 ${SURFACE_TOKENS.selectedHover}`
       : `bg-transparent text-text-2 ${SURFACE_TOKENS.hover}`;
     const draggingClass = isDragging
       ? `work-station-editor-tab--dragging cursor-grabbing ${SURFACE_TOKENS.selected} opacity-90`

--- a/src/engines/ChatPanel/ChatPanelTabBar/ChatPanelTabBar.test.ts
+++ b/src/engines/ChatPanel/ChatPanelTabBar/ChatPanelTabBar.test.ts
@@ -107,6 +107,14 @@ describe("ChatPanelTabBar", () => {
     expect(markup).toMatch(
       /bg-gradient-to-l[^"<]*transition-opacity[^"<]*duration-150[^"<]*opacity-0/
     );
+    const activeSurface = markup.match(
+      /<div[^>]*work-station-editor-tab--active[^>]*>/
+    )?.[0];
+    expect(activeSurface).toContain("text-text-1");
+    expect(activeSurface).not.toContain("text-primary-6");
+    expect(markup).toMatch(
+      /<svg[^>]*class="[^"]*lucide-layout-grid[^"]*text-text-1[^"]*"/
+    );
     expect(markup).toContain("sessions:chat.startPage.newSession.title");
     expect(markup).not.toContain("navigation:routes.launchpad");
   });

--- a/src/engines/ChatPanel/ChatPanelTabBar/TabPill.tsx
+++ b/src/engines/ChatPanel/ChatPanelTabBar/TabPill.tsx
@@ -145,7 +145,7 @@ export const TabPill = memo(function TabPill({
                 ? t("sessions:creator.createTarget.manageAgents")
                 : defaultDisplayTitle;
 
-  const iconColorClass = isActive ? "text-primary-6" : "text-text-2";
+  const iconColorClass = isActive ? "text-text-1" : "text-text-2";
   const isGitHubIssueTab =
     tab.type === "work-item" &&
     isGitHubIssueStatus(
@@ -349,7 +349,7 @@ export const TabPill = memo(function TabPill({
       <div className="relative flex min-w-0 flex-1 items-center overflow-hidden">
         <span
           className={`min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-[13px] ${
-            isActive ? "text-primary-6" : "text-text-2"
+            isActive ? "text-text-1" : "text-text-2"
           }`}
         >
           {displayTitle}

--- a/src/engines/ChatPanel/ChatPanelTabBar/index.tsx
+++ b/src/engines/ChatPanel/ChatPanelTabBar/index.tsx
@@ -303,9 +303,7 @@ export function ChatPanelTabBar(): React.ReactNode {
                 {draggingTab ? (
                   <div className={TAB_PILL_DRAG_OVERLAY_CLASS}>
                     <MessageSquarePlus size={16} strokeWidth={1.75} />
-                    <span className="truncate text-primary-6">
-                      {draggingTab.title}
-                    </span>
+                    <span className="truncate">{draggingTab.title}</span>
                   </div>
                 ) : null}
               </DragOverlay>,

--- a/src/modules/WorkStation/shared/SessionReplay/ReplayTabBar.test.ts
+++ b/src/modules/WorkStation/shared/SessionReplay/ReplayTabBar.test.ts
@@ -1,0 +1,33 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { ReplayTabBar } from "./ReplayTabBar";
+
+describe("ReplayTabBar", () => {
+  it("uses text-1 for an active replay tab and its monochrome icon", () => {
+    const markup = renderToStaticMarkup(
+      createElement(ReplayTabBar, {
+        tabs: [
+          {
+            eventId: "tool-1",
+            kind: "tool",
+            label: "Tool call",
+            title: "Tool call",
+          },
+        ],
+        activeEventId: "tool-1",
+        onTabClick: vi.fn(),
+      })
+    );
+    const activeSurface = markup.match(
+      /<button[^>]*work-station-editor-tab--active[^>]*>/
+    )?.[0];
+
+    expect(activeSurface).toContain("text-text-1");
+    expect(activeSurface).not.toContain("text-primary-6");
+    expect(markup).toMatch(
+      /<svg[^>]*class="[^"]*lucide-wrench[^"]*text-text-1[^"]*"/
+    );
+  });
+});

--- a/src/modules/WorkStation/shared/SessionReplay/ReplayTabBar.tsx
+++ b/src/modules/WorkStation/shared/SessionReplay/ReplayTabBar.tsx
@@ -110,7 +110,7 @@ function defaultIconForKind(
   isActive: boolean
 ): React.ReactNode {
   const lucideClass = isActive
-    ? "shrink-0 text-primary-6"
+    ? "shrink-0 text-text-1"
     : "shrink-0 text-text-3";
   switch (kind) {
     case "file":
@@ -154,7 +154,7 @@ const TabItem: React.FC<TabItemProps> = ({
   const iconClass = isFileKind
     ? ""
     : isActive
-      ? "[&_svg]:!text-primary-6 [&_svg]:!stroke-primary-6"
+      ? "[&_svg]:!text-text-1 [&_svg]:!stroke-text-1"
       : "[&_svg]:text-text-3 [&_svg]:stroke-current";
   return (
     <TabPillSurface

--- a/src/modules/WorkStation/shared/TabBar/components/SortableTab/index.test.ts
+++ b/src/modules/WorkStation/shared/TabBar/components/SortableTab/index.test.ts
@@ -63,4 +63,29 @@ describe("resolveWorkstationTabIntegrationIcon", () => {
     expect(markup).toContain("text-ellipsis");
     expect(markup).not.toContain("max-w-none");
   });
+
+  it("uses text-1 for an active My Station tab and its monochrome icon", () => {
+    const markup = renderToStaticMarkup(
+      createElement(SortableTab, {
+        tab: {
+          ...tab("start"),
+          icon: "LayoutGrid",
+        },
+        isActive: true,
+        isDraggable: true,
+        onTabClick: vi.fn(),
+        onCloseClick: vi.fn(),
+        onContextMenu: vi.fn(),
+      })
+    );
+    const activeSurface = markup.match(
+      /<div[^>]*work-station-editor-tab--active[^>]*>/
+    )?.[0];
+
+    expect(activeSurface).toContain("text-text-1");
+    expect(activeSurface).not.toContain("text-primary-6");
+    expect(markup).toMatch(
+      /<svg[^>]*class="[^"]*lucide-layout-grid[^"]*text-text-1[^"]*"/
+    );
+  });
 });

--- a/src/modules/WorkStation/shared/TabBar/components/SortableTab/index.tsx
+++ b/src/modules/WorkStation/shared/TabBar/components/SortableTab/index.tsx
@@ -226,7 +226,7 @@ export const SortableTab: React.FC<SortableTabProps> = memo(
             className={
               integrationIcon === STORY_SYNC_ADAPTER.GITHUB
                 ? isActive
-                  ? "text-primary-6"
+                  ? "text-text-1"
                   : "text-text-2"
                 : undefined
             }
@@ -251,7 +251,7 @@ export const SortableTab: React.FC<SortableTabProps> = memo(
             <IconComponent
               size={16}
               strokeWidth={1.75}
-              className={isActive ? "text-primary-6" : "text-text-2"}
+              className={isActive ? "text-text-1" : "text-text-2"}
             />
           );
         }
@@ -273,7 +273,7 @@ export const SortableTab: React.FC<SortableTabProps> = memo(
             <Folder
               size={16}
               strokeWidth={1.75}
-              className={isActive ? "text-primary-6" : "text-text-2"}
+              className={isActive ? "text-text-1" : "text-text-2"}
             />
           );
         case "terminal":
@@ -286,7 +286,7 @@ export const SortableTab: React.FC<SortableTabProps> = memo(
               url={tab.data.url as string | undefined}
               isIncognito={tab.data.incognito as boolean | undefined}
               isLoading={tab.data.isLoading as boolean | undefined}
-              isSelected={isActive}
+              fallbackColor={isActive ? "text-text-1" : undefined}
             />
           );
         default:
@@ -379,7 +379,7 @@ export const SortableTab: React.FC<SortableTabProps> = memo(
           : tab.type === "file" && gitInfo
             ? getStatusColorForFile(gitInfo.status, gitInfo.staged)
             : isActive
-              ? "text-primary-6"
+              ? "text-text-1"
               : "text-text-2"
       }`;
 
@@ -419,7 +419,7 @@ export const SortableTab: React.FC<SortableTabProps> = memo(
         {!hideLabel && tab.type === "git-diff" && tab.data.isTimeline ? (
           <div
             className={`relative flex min-w-0 flex-1 items-center gap-1 overflow-hidden text-[13px] ${
-              isActive ? "text-primary-6" : "text-text-2"
+              isActive ? "text-text-1" : "text-text-2"
             }`}
           >
             <span className="min-w-0 flex-1 truncate">

--- a/src/modules/WorkStation/shared/TabBar/index.tsx
+++ b/src/modules/WorkStation/shared/TabBar/index.tsx
@@ -443,7 +443,7 @@ export const TabBar: React.FC<TabBarProps> = memo(
                           fileName={draggingTab.title}
                           size="small"
                         />
-                        <span className="max-w-[150px] overflow-hidden text-ellipsis whitespace-nowrap text-[13px] text-primary-6">
+                        <span className="max-w-[150px] overflow-hidden text-ellipsis whitespace-nowrap text-[13px]">
                           {draggingTab.title}
                         </span>
                       </div>


### PR DESCRIPTION
## Problem

Selected tabs across My Station, Chat Panel, and Agent Station replay used `primary-6` for their labels and monochrome icons. That tied selected-tab text to the configurable accent color instead of the neutral `text-1` hierarchy requested for these surfaces.

## Solution

Use `text-1` for the shared active tab surface and drag overlay, then align the explicit active label, Lucide icon, integration icon, and browser fallback overrides in each tab host. Full-color file icons, favicons, semantic Git status colors, and danger states keep their existing presentation. Regression tests now cover the shared surface, My Station, Chat Panel, and replay tab paths.

## Potential risks

The change is presentation-only and does not affect persistence, public APIs, IPC, data formats, concurrency, or lifecycle behavior. The remaining visual risk is theme-specific contrast because a live desktop screenshot was not captured; the exact token application is covered by rendered-markup tests. Rollback is a single-commit revert.

## Verification

- `npx vitest run src/components/TabPill/TabPillSurface.test.ts src/engines/ChatPanel/ChatPanelTabBar/ChatPanelTabBar.test.ts src/modules/WorkStation/shared/TabBar/components/SortableTab/index.test.ts src/modules/WorkStation/shared/SessionReplay/ReplayTabBar.test.ts` — passed: 4 files, 14 tests
- `npx eslint` over all ten changed TypeScript/TSX files with `--max-warnings 0 --report-unused-disable-directives` — passed
- `npm run typecheck` — passed
- Commit hook `lint-staged` checks, scoped TypeScript check, and circular-dependency stats — passed
- `git diff --check origin/develop...HEAD` — passed
- Final branch diff and staged-secret scan — only the ten intended tab source/test files; no secrets, personal paths, debug logs, build artifacts, or unrelated formatting
- Live desktop screenshot not run because local desktop UI control was not authorized for this task
