### PR TITLE
fix(session-creator): attach responsive work item picker

### DIFF
--- a/src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx
@@ -185,6 +185,10 @@ const SessionCreatorChatPanelView: React.FC<
     visible: pinnedActionsVisible,
     onVisibleChange: onPinnedActionsVisibleChange,
   });
+  const [isLaunchpadWorkItemPickerOpen, setIsLaunchpadWorkItemPickerOpen] =
+    useState(false);
+  const [workItemPickerPortalTarget, setWorkItemPickerPortalTarget] =
+    useState<HTMLDivElement | null>(null);
   const sessionInfoLine = (
     <SessionInfoLine
       {...sessionInfoProps}
@@ -205,16 +209,17 @@ const SessionCreatorChatPanelView: React.FC<
   const repoChromeAboveComposer = isRepoChromeAboveComposer(repoChromePosition);
   const hasRepoChromeMenu = !hideRepoLine && headerLayout !== "compact";
   const showPinnedActionPills = !hasRepoChromeMenu || pinnedActionsVisible;
-  const repoPillsRow = hasRepoChromeMenu && (
-    <RepoChromeRow
-      pinnedActionsVisible={pinnedActionsVisible}
-      position={repoChromePosition}
-      onPinnedActionsVisibleChange={onPinnedActionsVisibleChange}
-      onPositionChange={onRepoChromePositionChange}
-    >
-      {repoPills}
-    </RepoChromeRow>
-  );
+  const repoPillsRow =
+    !isLaunchpadWorkItemPickerOpen && hasRepoChromeMenu ? (
+      <RepoChromeRow
+        pinnedActionsVisible={pinnedActionsVisible}
+        position={repoChromePosition}
+        onPinnedActionsVisibleChange={onPinnedActionsVisibleChange}
+        onPositionChange={onRepoChromePositionChange}
+      >
+        {repoPills}
+      </RepoChromeRow>
+    ) : null;
   const compactHeader = headerLayout === "compact" && (
     <div className="session-creator-chat-panel-compact-header flex w-full items-center justify-between gap-2 bg-bg-2 px-1 pb-2 pt-1">
       <SelectorPill
@@ -230,9 +235,11 @@ const SessionCreatorChatPanelView: React.FC<
         ariaLabel={heroContent.name}
         appearance="bare"
       />
-      <div className="ml-auto flex min-w-0 flex-1 flex-wrap items-center justify-end gap-0.5">
-        {sessionInfoLine}
-      </div>
+      {!isLaunchpadWorkItemPickerOpen && (
+        <div className="ml-auto flex min-w-0 flex-1 flex-wrap items-center justify-end gap-0.5">
+          {sessionInfoLine}
+        </div>
+      )}
     </div>
   );
   const tuiComposerHeader = composerHeaderContent ? (
@@ -249,8 +256,6 @@ const SessionCreatorChatPanelView: React.FC<
       ) : null,
     [browserElementScrollNav]
   );
-  const [isLaunchpadWorkItemPickerOpen, setIsLaunchpadWorkItemPickerOpen] =
-    useState(false);
   const showWorkItemAttachmentControl =
     !hideWorkItemAttachmentControl &&
     (!isLaunchpadLayout || Boolean(multiRunnerContent));
@@ -387,16 +392,7 @@ const SessionCreatorChatPanelView: React.FC<
     heroFooterSlot
   ) : (
     <LaunchpadActionGrid
-      cardWidthClassName={
-        isLaunchpadWorkItemPickerOpen
-          ? DETAIL_PANEL_TOKENS.contentMaxWidth
-          : undefined
-      }
-      className={`mx-auto w-full ${
-        isLaunchpadWorkItemPickerOpen
-          ? "!flex min-h-0 flex-1 flex-col [&>div]:h-full [&>div]:min-h-0"
-          : ""
-      }`}
+      className="mx-auto w-full"
       layoutActionCount={Children.count(heroFooterSlot) + 1}
       presentation="card"
       collapsible={!isLaunchpadWorkItemPickerOpen}
@@ -409,6 +405,7 @@ const SessionCreatorChatPanelView: React.FC<
         currentWorkItemContext={workItemContext}
         onWorkItemContextChange={onAttachedWorkItemContextChange}
         onPickerOpenChange={setIsLaunchpadWorkItemPickerOpen}
+        pickerPortalTarget={workItemPickerPortalTarget}
         repoId={sessionInfoProps.repoId}
         repoPath={sessionInfoProps.repoPath}
         mode="solve"
@@ -419,16 +416,8 @@ const SessionCreatorChatPanelView: React.FC<
   );
   const launchpadMiddleContent = isLaunchpadLayout ? (
     <div
-      className={`session-creator-chat-panel-launchpad-middle flex flex-col items-center gap-4 ${
-        isLaunchpadWorkItemPickerOpen && !multiRunnerContent
-          ? "relative min-h-0 w-full flex-1 justify-center overflow-hidden"
-          : "absolute inset-x-0 -translate-y-1/2"
-      }`}
-      style={
-        isLaunchpadWorkItemPickerOpen && !multiRunnerContent
-          ? undefined
-          : CREATOR_MIDDLE_POSITION_STYLE
-      }
+      className="session-creator-chat-panel-launchpad-middle absolute inset-x-0 flex -translate-y-1/2 flex-col items-center gap-4"
+      style={CREATOR_MIDDLE_POSITION_STYLE}
     >
       {/* Multi-runner owns the whole middle slot: with N runners listed below
           it, a single-harness hero pill would name one of them and imply the
@@ -445,9 +434,7 @@ const SessionCreatorChatPanelView: React.FC<
           {launchpadSuggestionContent && (
             <div
               className={`session-creator-chat-panel-launchpad-suggestions w-full ${
-                isLaunchpadWorkItemPickerOpen
-                  ? "flex min-h-0 flex-1 flex-col"
-                  : ""
+                isLaunchpadWorkItemPickerOpen ? "hidden" : ""
               }`}
             >
               {launchpadSuggestionContent}
@@ -458,9 +445,15 @@ const SessionCreatorChatPanelView: React.FC<
     </div>
   ) : null;
   const composerDockClassName = isLaunchpadLayout
-    ? "mt-auto flex w-full shrink-0 flex-col gap-3"
+    ? `relative z-10 mt-auto flex w-full shrink-0 flex-col gap-3 ${
+        isLaunchpadWorkItemPickerOpen ? "min-h-0 flex-1 justify-end" : ""
+      }`
     : "contents";
-  const composerGroupClassName = `session-creator-chat-panel-fullscreen-composer-group mx-auto w-full ${DETAIL_PANEL_TOKENS.contentMaxWidth}`;
+  const composerGroupClassName = `session-creator-chat-panel-fullscreen-composer-group mx-auto w-full ${DETAIL_PANEL_TOKENS.contentMaxWidth} ${
+    isLaunchpadWorkItemPickerOpen
+      ? "flex min-h-0 flex-1 flex-col justify-end"
+      : ""
+  }`;
   const composerFrameClassName = `session-creator-chat-panel-fullscreen-composer w-full ${
     headerLayout === "compact"
       ? "session-creator-chat-panel-fullscreen-composer-compact"
@@ -536,7 +529,7 @@ const SessionCreatorChatPanelView: React.FC<
             )}
             {isLaunchpadLayout && (
               <>
-                {sessionSetupActions}
+                {!isLaunchpadWorkItemPickerOpen && sessionSetupActions}
                 {cliVersionWarning}
               </>
             )}
@@ -544,6 +537,17 @@ const SessionCreatorChatPanelView: React.FC<
               className={composerGroupClassName}
               onContextMenu={handlePinnedActionsContextMenu}
             >
+              {isLaunchpadLayout && (
+                <div
+                  ref={setWorkItemPickerPortalTarget}
+                  className={
+                    isLaunchpadWorkItemPickerOpen
+                      ? "session-creator-chat-panel-launchpad-suggestions session-creator-chat-panel-work-item-picker-chrome flex min-h-0 w-full flex-1 flex-col border border-border-2"
+                      : "hidden"
+                  }
+                  data-testid="session-creator-work-item-picker-chrome"
+                />
+              )}
               <div className={composerFrameClassName}>
                 {compactHeader}
                 {isCliTuiMode && tuiComposerHeader}

--- a/src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.test.ts
+++ b/src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.test.ts
@@ -153,6 +153,7 @@ function findButton(text: string): HTMLButtonElement | undefined {
 
 describe("WorkItemAttachmentControl", () => {
   let container: HTMLDivElement;
+  let pickerPortalTarget: HTMLDivElement;
   let root: Root;
   const actEnvironment = globalThis as typeof globalThis & {
     IS_REACT_ACT_ENVIRONMENT?: boolean;
@@ -168,13 +169,16 @@ describe("WorkItemAttachmentControl", () => {
     projectApiMocks.readWorkspaceWorkItemsData.mockClear();
     worktreeMocks.githubRefresh.mockClear();
     container = document.createElement("div");
+    pickerPortalTarget = document.createElement("div");
     document.body.appendChild(container);
+    document.body.appendChild(pickerPortalTarget);
     root = createRoot(container);
   });
 
   afterEach(() => {
     act(() => root.unmount());
     container.remove();
+    pickerPortalTarget.remove();
   });
 
   afterAll(() => {
@@ -203,13 +207,14 @@ describe("WorkItemAttachmentControl", () => {
     expect(projectApiMocks.readWorkspaceWorkItemsData).not.toHaveBeenCalled();
   });
 
-  it("replaces the Launchpad card with an inline picker and Back restores it", async () => {
+  it("replaces the Launchpad card with an attached chrome picker and Back restores it", async () => {
     const onPickerOpenChange = vi.fn();
     act(() => {
       root.render(
         createElement(WorkItemAttachmentControl, {
           mode: "solve",
           onPickerOpenChange,
+          pickerPortalTarget,
           presentation: "card",
         })
       );
@@ -229,65 +234,77 @@ describe("WorkItemAttachmentControl", () => {
     });
 
     expect(onPickerOpenChange).toHaveBeenLastCalledWith(true);
-    const inlinePicker = container.querySelector(
-      '[data-testid="session-creator-work-item-inline-picker"]'
+    const picker = pickerPortalTarget.querySelector(
+      '[data-testid="work-item-picker-panel"]'
     );
-    expect(inlinePicker).not.toBeNull();
-    expect(inlinePicker?.className).not.toContain("bg-bg-1");
-    expect(inlinePicker?.className).toContain("h-auto");
-    expect(inlinePicker?.className).toContain("shadow-sm");
-    expect((inlinePicker as HTMLElement | null)?.style.maxHeight).toBe(
-      "min(520px, 100%)"
-    );
+    expect(picker).not.toBeNull();
+    expect(picker?.parentElement).toBe(pickerPortalTarget);
     expect(
-      container.querySelector('[data-testid="work-item-picker-list"]')
+      container.querySelector(
+        '[data-testid="session-creator-work-item-inline-picker"]'
+      )
+    ).toBeNull();
+    expect(
+      pickerPortalTarget.querySelector('[data-testid="work-item-picker-list"]')
         ?.className
     ).not.toContain("max-h-64");
     expect(
-      container.querySelector('[data-testid="work-item-picker-list"]')
+      pickerPortalTarget.querySelector('[data-testid="work-item-picker-list"]')
         ?.className
     ).toContain("overscroll-contain");
     expect(
-      container.querySelector(
+      pickerPortalTarget.querySelector(
         '[data-testid="work-item-picker-option-workitem:project-a/ABC-1"]'
       )?.className
     ).toContain("work-item-picker-option");
     expect(
-      container.querySelector('[data-testid="work-item-picker-list"]')
+      pickerPortalTarget.querySelector('[data-testid="work-item-picker-list"]')
         ?.className
-    ).toContain("gap-0");
+    ).toContain("gap-px");
+    const allFilter = pickerPortalTarget.querySelector(
+      '[data-testid="work-item-picker-filter-all"]'
+    );
+    expect(allFilter?.className).toContain("text-[12px]");
+    expect(allFilter?.parentElement?.className).toContain("flex-nowrap");
+    expect(allFilter?.parentElement?.className).toContain(
+      "@container/workitemtabs"
+    );
+    expect(allFilter?.getAttribute("aria-label")).toBe("common:actions.all");
+    expect(allFilter?.querySelector("span:last-child")?.className).toContain(
+      "hidden"
+    );
+    expect(allFilter?.querySelector("span:last-child")?.className).toContain(
+      "@[500px]/workitemtabs:inline"
+    );
+    expect(allFilter?.className).toContain("after:bg-chat-pane");
     expect(
-      container.querySelector('[data-testid="work-item-picker-filter-all"]')
-        ?.className
-    ).toContain("text-[12px]");
-    expect(
-      container.querySelector(
+      pickerPortalTarget.querySelector(
         '[data-testid="work-item-picker-kind-github_pr:https://github.com/acme/app/pull/43"]'
       )?.className
     ).toContain("text-text-2");
     expect(
-      container.querySelector(
+      pickerPortalTarget.querySelector(
         '[data-testid="work-item-picker-ci-github_pr:https://github.com/acme/app/pull/43"]'
       )?.className
     ).toContain("text-danger-6");
     expect(
-      container
+      pickerPortalTarget
         .querySelector(
           '[data-testid="work-item-picker-ci-github_pr:https://github.com/acme/app/pull/43"]'
         )
         ?.querySelector("svg")
         ?.classList.contains("lucide-x")
     ).toBe(true);
-    expect(inlinePicker?.textContent).toContain("@octocat");
-    expect(inlinePicker?.textContent).toContain("@issue-author");
-    const prMetadataText = container.querySelector(
+    expect(picker?.textContent).toContain("@octocat");
+    expect(picker?.textContent).toContain("@issue-author");
+    const prMetadataText = pickerPortalTarget.querySelector(
       '[data-testid="work-item-picker-option-github_pr:https://github.com/acme/app/pull/43"] .work-item-picker-option-metadata'
     )?.textContent;
     expect(prMetadataText?.indexOf("@octocat") ?? -1).toBeLessThan(
       prMetadataText?.indexOf("draft") ?? -1
     );
     expect(
-      container
+      pickerPortalTarget
         .querySelector(
           '[data-testid="work-item-picker-ci-github_pr:https://github.com/acme/app/pull/44"]'
         )
@@ -295,36 +312,36 @@ describe("WorkItemAttachmentControl", () => {
         ?.classList.contains("animate-pulse")
     ).toBe(true);
     expect(
-      container.querySelector(
+      pickerPortalTarget.querySelector(
         '[data-testid="work-item-picker-ci-github_pr:https://github.com/acme/app/pull/45"]'
       )
     ).toBeNull();
     expect(
-      container.querySelector(
+      pickerPortalTarget.querySelector(
         '[data-testid="session-creator-work-item-picker-back"]'
       )?.parentElement?.className
     ).not.toContain("border-b");
     expect(
-      container.querySelector(
+      pickerPortalTarget.querySelector(
         '[data-testid="session-creator-work-item-picker-back"]'
       )?.textContent
     ).toBe("");
     expect(
-      container.querySelector(
+      pickerPortalTarget.querySelector(
         '[data-testid="session-creator-work-item-picker-back"]'
       )?.className
     ).toContain("border-border-2");
     expect(
-      container.querySelector(
+      pickerPortalTarget.querySelector(
         '[data-testid="session-creator-work-item-picker-refresh"]'
       )?.className
     ).toContain("border-border-2");
     expect(
-      container.querySelector(
+      pickerPortalTarget.querySelector(
         '[data-testid="session-creator-work-item-picker-refresh"]'
       )?.parentElement
     ).toBe(
-      container.querySelector(
+      pickerPortalTarget.querySelector(
         '[data-testid="session-creator-work-item-picker-back"]'
       )?.parentElement
     );
@@ -336,7 +353,7 @@ describe("WorkItemAttachmentControl", () => {
     expect(container.querySelector('[role="dialog"]')).toBeNull();
 
     await act(async () => {
-      container
+      pickerPortalTarget
         .querySelector<HTMLButtonElement>(
           '[data-testid="session-creator-work-item-picker-refresh"]'
         )
@@ -349,7 +366,7 @@ describe("WorkItemAttachmentControl", () => {
     expect(worktreeMocks.githubRefresh).toHaveBeenCalledOnce();
 
     act(() => {
-      container
+      pickerPortalTarget
         .querySelector<HTMLButtonElement>(
           '[data-testid="session-creator-work-item-picker-back"]'
         )

--- a/src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.tsx
@@ -34,7 +34,6 @@ import {
 } from "./workItemPickerModel";
 
 const logger = createLogger("WorkItemAttachmentControl");
-const INLINE_PICKER_MAX_HEIGHT = "min(520px, 100%)";
 
 export interface WorkItemAttachmentControlProps {
   composerInputRef?: React.RefObject<ComposerInputRef | null>;
@@ -45,6 +44,8 @@ export interface WorkItemAttachmentControlProps {
     context: SessionLaunchWorkItemContext | null
   ) => void;
   onPickerOpenChange?: (open: boolean) => void;
+  /** Stable composer-chrome host used by the Launchpad card presentation. */
+  pickerPortalTarget?: HTMLElement | null;
   repoId?: string;
   repoPath?: string;
   /** Launchpad opens the picker directly and uses the solve-oriented label. */
@@ -58,6 +59,7 @@ const WorkItemAttachmentControl: React.FC<WorkItemAttachmentControlProps> = ({
   onCreateWorkItem,
   onPickerOpenChange,
   onWorkItemContextChange,
+  pickerPortalTarget,
   repoId,
   repoPath,
   mode = "add",
@@ -290,15 +292,9 @@ const WorkItemAttachmentControl: React.FC<WorkItemAttachmentControlProps> = ({
   );
 
   if (presentation === "card" && isPickerOpen) {
-    return (
-      <div
-        className="col-span-full flex h-auto min-h-0 flex-col overflow-hidden rounded-lg border border-border-2 shadow-sm"
-        style={{ maxHeight: INLINE_PICKER_MAX_HEIGHT }}
-        data-testid="session-creator-work-item-inline-picker"
-      >
-        {pickerPanel}
-      </div>
-    );
+    return pickerPortalTarget
+      ? createPortal(pickerPanel, pickerPortalTarget)
+      : null;
   }
   const trigger =
     presentation === "card" ? (

--- a/src/features/SessionCreator/variants/ChatPanel/WorkItemPickerPanel.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/WorkItemPickerPanel.tsx
@@ -99,7 +99,7 @@ const WorkItemPickerPanel: React.FC<WorkItemPickerPanelProps> = ({
 
   return (
     <div
-      className="flex min-h-0 flex-1 flex-col overflow-hidden"
+      className="flex min-h-0 w-full flex-1 flex-col overflow-hidden"
       style={{ maxHeight: "inherit" }}
       data-testid="work-item-picker-panel"
     >
@@ -145,7 +145,7 @@ const WorkItemPickerPanel: React.FC<WorkItemPickerPanelProps> = ({
         />
       </div>
       <div
-        className="work-item-picker-tabs flex shrink-0 flex-wrap items-end gap-px border-b border-border-2 px-2"
+        className="work-item-picker-tabs flex shrink-0 flex-nowrap items-end gap-px border-b border-border-2 px-2 @container/workitemtabs"
         role="tablist"
         aria-label={t("common:actions.filter")}
       >
@@ -158,9 +158,13 @@ const WorkItemPickerPanel: React.FC<WorkItemPickerPanelProps> = ({
               onClick={() => onFilterChange(filter.value)}
               role="tab"
               aria-selected={active}
-              className={`work-item-picker-tab relative -mb-px flex shrink-0 items-center gap-1.5 rounded-t-md border px-3 py-1.5 text-[12px] font-medium transition-colors ${
+              aria-label={filter.label}
+              title={filter.label}
+              className={`work-item-picker-tab relative -mb-px flex shrink-0 items-center gap-0 rounded-t-md border px-2.5 py-1.5 text-[12px] font-medium transition-colors @[500px]/workitemtabs:gap-1.5 @[500px]/workitemtabs:px-3 ${
                 active
-                  ? "border-border-2 text-text-1 after:absolute after:-bottom-px after:left-0 after:right-0 after:h-px after:bg-chat-pane"
+                  ? `border-border-2 text-text-1 after:absolute after:-bottom-px after:left-0 after:right-0 after:h-px ${
+                      expanded ? "after:bg-chat-pane" : "after:bg-bg-2"
+                    }`
                   : "border-transparent text-text-2 hover:bg-fill-1 hover:text-text-1"
               }`}
               data-testid={`work-item-picker-filter-${filter.value}`}
@@ -171,13 +175,15 @@ const WorkItemPickerPanel: React.FC<WorkItemPickerPanelProps> = ({
               >
                 {filter.icon}
               </span>
-              <span>{filter.label}</span>
+              <span className="hidden @[500px]/workitemtabs:inline">
+                {filter.label}
+              </span>
             </button>
           );
         })}
       </div>
       <div
-        className={`work-item-picker-list flex min-h-0 flex-1 flex-col gap-0 overflow-y-auto overscroll-contain p-1 scrollbar-hide ${expanded ? "" : DROPDOWN_PANEL.maxHeightClass}`}
+        className={`work-item-picker-list flex min-h-0 flex-1 flex-col gap-px overflow-y-auto overscroll-contain p-1 scrollbar-hide ${expanded ? "" : DROPDOWN_PANEL.maxHeightClass}`}
         data-testid="work-item-picker-list"
       >
         {filteredOptions.length > 0 ? (

--- a/src/features/SessionCreator/variants/ChatPanel/index.scss
+++ b/src/features/SessionCreator/variants/ChatPanel/index.scss
@@ -44,21 +44,13 @@
         padding-top: 12px;
       }
 
-      .session-creator-chat-panel-launchpad-middle {
-        position: relative;
-        min-height: 0;
-        flex: 1 1 0%;
-        align-items: center;
-        overflow: hidden;
-      }
-
-      .session-creator-chat-panel-launchpad-suggestions {
+      .session-creator-chat-panel-work-item-picker-chrome {
         display: flex;
         min-height: 0;
         flex: 1 1 0%;
       }
 
-      .session-creator-chat-panel-launchpad-suggestions > * {
+      .session-creator-chat-panel-work-item-picker-chrome > * {
         margin-inline: auto;
       }
 
@@ -106,7 +98,7 @@
         gap: 4px;
       }
 
-      .session-creator-chat-panel-launchpad-suggestions {
+      .session-creator-chat-panel-work-item-picker-chrome {
         display: flex;
       }
 
@@ -123,7 +115,7 @@
 
   @media (min-height: 1000px) {
     &.session-creator-chat-panel-work-item-picker-open {
-      .session-creator-chat-panel-launchpad-suggestions {
+      .session-creator-chat-panel-work-item-picker-chrome {
         max-height: 520px;
         flex: 0 1 520px;
       }
@@ -143,6 +135,18 @@
   .work-item-picker-option {
     padding-top: 6px;
     padding-bottom: 6px;
+  }
+
+  .session-creator-chat-panel-work-item-picker-chrome {
+    position: relative;
+    z-index: 1;
+    max-height: min(520px, 100%);
+    margin-bottom: -6px;
+    padding-bottom: 6px;
+    overflow: hidden;
+    border-radius: 12px 12px 0 0;
+    background: var(--color-chat-pane);
+    box-shadow: none;
   }
 
   .session-creator-chat-panel-fullscreen-composer {


### PR DESCRIPTION
## Problem

Opening Solve Work Item expanded the picker inside the launchpad middle region. Moving that state between layout slots remounted the control, which could produce an intermediate duplicate layer and require another click before the picker appeared. The expanded picker also competed with the session/setup chrome, wrapped filter labels at narrow widths, and rendered result rows without separation.

## Solution

Keep the Work Item control mounted in its original launchpad location and portal only the open picker into one stable composer-chrome host. One click now opens a single attached panel; Back closes it and restores the setup controls and session-info line. The panel uses the original chat-pane surface, the standard border token, no shadow, responsive icon-only filters below 500px, accessible labels and titles, and a 1px result-row gap.

## Potential risks

The portal host is specific to the launchpad card presentation; the existing button/dropdown presentation remains unchanged. The 500px container breakpoint may switch labels earlier than some localized strings strictly require, but prevents wrapping across locales. No persistence, IPC, wire, dependency, or data behavior changes. Final Tauri visual capture across themes and short viewport states was not performed in this shell-only run, so the PR remains Draft pending that evidence.

## Verification

- pnpm typecheck — passed
- pnpm vitest run src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.test.ts src/features/SessionCreator/variants/ChatPanel/repoChromeLayout.test.ts — 2 files and 7 tests passed
- pnpm eslint src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.tsx src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.test.ts src/features/SessionCreator/variants/ChatPanel/WorkItemPickerPanel.tsx --max-warnings 0 --report-unused-disable-directives — passed
- pnpm prettier --check src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.tsx src/features/SessionCreator/variants/ChatPanel/WorkItemAttachmentControl.test.ts src/features/SessionCreator/variants/ChatPanel/WorkItemPickerPanel.tsx src/features/SessionCreator/variants/ChatPanel/index.scss — passed
- git diff --check — passed
- Repository pre-commit lint-staged and scoped TypeScript checks — passed
- User-provided screenshots guided the responsive layout iterations; no final desktop screenshot was captured because desktop UI control was not authorized

## Audit

The workspace frontend-ui-audit skill is unavailable. A manual UI-consistency and accessibility pass confirmed use of existing border/color tokens, no additional shadow or duplicate surface, and accessible names for icon-only filter tabs.