### PR TITLE
feat(workstation): reveal workspaces in file manager

### DIFF
--- a/src/i18n/locales/de/sessions.json
+++ b/src/i18n/locales/de/sessions.json
@@ -1053,6 +1053,8 @@
     "unpinWorkspaceGroup": "Arbeitsbereich entpinnen",
     "hideWorkspaceGroup": "Arbeitsbereich ausblenden",
     "unhideWorkspaceGroup": "Arbeitsbereich einblenden",
+    "workspaceUnavailableTitle": "Workspace nicht verfügbar",
+    "workspaceUnavailableMessage": "Dieser Workspace wurde möglicherweise verschoben oder gelöscht.",
     "historyRefresh": "Aktualisieren",
     "historyLastUsedModel": "Zuletzt verwendetes Modell",
     "historyUntitled": "Unbenannte Sitzung",

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -1114,6 +1114,8 @@
     "unpinWorkspaceGroup": "Unpin workspace",
     "hideWorkspaceGroup": "Hide workspace",
     "unhideWorkspaceGroup": "Unhide workspace",
+    "workspaceUnavailableTitle": "Workspace no longer available",
+    "workspaceUnavailableMessage": "This Workspace may have been moved or deleted.",
     "historyRefresh": "Refresh",
     "historyLastUsedModel": "Last used model",
     "historyUntitled": "Untitled session",

--- a/src/i18n/locales/es/sessions.json
+++ b/src/i18n/locales/es/sessions.json
@@ -1055,6 +1055,8 @@
     "unpinWorkspaceGroup": "Desfijar espacio de trabajo",
     "hideWorkspaceGroup": "Ocultar espacio de trabajo",
     "unhideWorkspaceGroup": "Mostrar espacio de trabajo",
+    "workspaceUnavailableTitle": "Workspace no disponible",
+    "workspaceUnavailableMessage": "Es posible que este Workspace se haya movido o eliminado.",
     "historyRefresh": "Actualizar",
     "historyLastUsedModel": "Último modelo usado",
     "historyUntitled": "Sesión sin título",

--- a/src/i18n/locales/fr/sessions.json
+++ b/src/i18n/locales/fr/sessions.json
@@ -1055,6 +1055,8 @@
     "unpinWorkspaceGroup": "Désépingler l'espace de travail",
     "hideWorkspaceGroup": "Masquer l'espace de travail",
     "unhideWorkspaceGroup": "Afficher l'espace de travail",
+    "workspaceUnavailableTitle": "Workspace indisponible",
+    "workspaceUnavailableMessage": "Ce Workspace a peut-être été déplacé ou supprimé.",
     "historyRefresh": "Actualiser",
     "historyLastUsedModel": "Dernier modèle utilisé",
     "historyUntitled": "Session sans titre",

--- a/src/i18n/locales/ja/sessions.json
+++ b/src/i18n/locales/ja/sessions.json
@@ -1054,6 +1054,8 @@
     "unpinWorkspaceGroup": "ワークスペースのピン留めを解除",
     "hideWorkspaceGroup": "ワークスペースを非表示",
     "unhideWorkspaceGroup": "ワークスペースを表示",
+    "workspaceUnavailableTitle": "Workspace を利用できません",
+    "workspaceUnavailableMessage": "この Workspace は移動または削除された可能性があります。",
     "historyRefresh": "更新",
     "historyLastUsedModel": "最後に使用したモデル",
     "historyUntitled": "無題のセッション",

--- a/src/i18n/locales/ko/sessions.json
+++ b/src/i18n/locales/ko/sessions.json
@@ -1054,6 +1054,8 @@
     "unpinWorkspaceGroup": "워크스페이스 고정 해제",
     "hideWorkspaceGroup": "워크스페이스 숨기기",
     "unhideWorkspaceGroup": "워크스페이스 표시",
+    "workspaceUnavailableTitle": "Workspace를 사용할 수 없음",
+    "workspaceUnavailableMessage": "이 Workspace는 이동되었거나 삭제되었을 수 있습니다.",
     "historyRefresh": "새로고침",
     "historyLastUsedModel": "마지막 사용 모델",
     "historyUntitled": "제목 없는 세션",

--- a/src/i18n/locales/pl/sessions.json
+++ b/src/i18n/locales/pl/sessions.json
@@ -1056,6 +1056,8 @@
     "unpinWorkspaceGroup": "Odepnij workspace",
     "hideWorkspaceGroup": "Ukryj workspace",
     "unhideWorkspaceGroup": "Pokaż workspace",
+    "workspaceUnavailableTitle": "Workspace jest niedostępny",
+    "workspaceUnavailableMessage": "Ten Workspace mógł zostać przeniesiony lub usunięty.",
     "historyRefresh": "Odśwież",
     "historyLastUsedModel": "Ostatnio używany model",
     "historyUntitled": "Sesja bez tytułu",

--- a/src/i18n/locales/pt/sessions.json
+++ b/src/i18n/locales/pt/sessions.json
@@ -1054,6 +1054,8 @@
     "unpinWorkspaceGroup": "Desafixar workspace",
     "hideWorkspaceGroup": "Ocultar workspace",
     "unhideWorkspaceGroup": "Mostrar workspace",
+    "workspaceUnavailableTitle": "Workspace indisponível",
+    "workspaceUnavailableMessage": "Este Workspace pode ter sido movido ou excluído.",
     "historyRefresh": "Atualizar",
     "historyLastUsedModel": "Último modelo usado",
     "historyUntitled": "Sessão sem título",

--- a/src/i18n/locales/ru/sessions.json
+++ b/src/i18n/locales/ru/sessions.json
@@ -1059,6 +1059,8 @@
     "unpinWorkspaceGroup": "Открепить рабочую область",
     "hideWorkspaceGroup": "Скрыть рабочую область",
     "unhideWorkspaceGroup": "Показать рабочую область",
+    "workspaceUnavailableTitle": "Workspace недоступен",
+    "workspaceUnavailableMessage": "Возможно, этот Workspace был перемещён или удалён.",
     "historyRefresh": "Обновить",
     "historyLastUsedModel": "Последняя использованная модель",
     "historyUntitled": "Сессия без названия",

--- a/src/i18n/locales/tr/sessions.json
+++ b/src/i18n/locales/tr/sessions.json
@@ -1055,6 +1055,8 @@
     "unpinWorkspaceGroup": "Çalışma alanı sabitlemesini kaldır",
     "hideWorkspaceGroup": "Çalışma alanını gizle",
     "unhideWorkspaceGroup": "Çalışma alanını göster",
+    "workspaceUnavailableTitle": "Workspace kullanılamıyor",
+    "workspaceUnavailableMessage": "Bu Workspace taşınmış veya silinmiş olabilir.",
     "historyRefresh": "Yenile",
     "historyLastUsedModel": "Son kullanılan model",
     "historyUntitled": "Başlıksız oturum",

--- a/src/i18n/locales/vi/sessions.json
+++ b/src/i18n/locales/vi/sessions.json
@@ -1052,6 +1052,8 @@
     "unpinWorkspaceGroup": "Bỏ ghim không gian làm việc",
     "hideWorkspaceGroup": "Ẩn không gian làm việc",
     "unhideWorkspaceGroup": "Hiện không gian làm việc",
+    "workspaceUnavailableTitle": "Workspace không khả dụng",
+    "workspaceUnavailableMessage": "Workspace này có thể đã bị di chuyển hoặc xóa.",
     "historyRefresh": "Làm mới",
     "historyLastUsedModel": "Model lần cuối dùng",
     "historyUntitled": "Phiên không có tên",

--- a/src/i18n/locales/zh-Hant/sessions.json
+++ b/src/i18n/locales/zh-Hant/sessions.json
@@ -1069,6 +1069,8 @@
     "unpinWorkspaceGroup": "取消置頂工作區",
     "hideWorkspaceGroup": "隱藏工作區",
     "unhideWorkspaceGroup": "顯示工作區",
+    "workspaceUnavailableTitle": "Workspace 已無法使用",
+    "workspaceUnavailableMessage": "此 Workspace 可能已被移動或刪除。",
     "historyRefresh": "刷新",
     "historyLastUsedModel": "上次使用的模型",
     "historyUntitled": "未命名會話",

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -1105,6 +1105,8 @@
     "unpinWorkspaceGroup": "取消置顶工作区",
     "hideWorkspaceGroup": "隐藏工作区",
     "unhideWorkspaceGroup": "显示工作区",
+    "workspaceUnavailableTitle": "Workspace 已不可用",
+    "workspaceUnavailableMessage": "此 Workspace 可能已被移动或删除。",
     "historyRefresh": "刷新",
     "historyLastUsedModel": "上次使用的模型",
     "historyUntitled": "未命名会话",

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
@@ -294,6 +294,9 @@ export const WorkstationSidebarConnector: React.FC = () => {
     unpinWorkspaceLabel,
     hideWorkspaceLabel,
     unhideWorkspaceLabel,
+    revealWorkspaceLabel,
+    workspaceUnavailableTitle,
+    workspaceUnavailableMessage,
     searchPlaceholder,
     noSearchResultsTitle,
   } = buildWorkstationSidebarLabels({ t, tProjects, tSessions, tCommon });
@@ -323,6 +326,9 @@ export const WorkstationSidebarConnector: React.FC = () => {
     unpinLabel: unpinWorkspaceLabel,
     hideLabel: hideWorkspaceLabel,
     unhideLabel: unhideWorkspaceLabel,
+    revealLabel: revealWorkspaceLabel,
+    unavailableTitle: workspaceUnavailableTitle,
+    unavailableMessage: workspaceUnavailableMessage,
     openNewSession: openNewSessionFromSidebar,
     setCollapsedSectionIds,
   });

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.labels.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.labels.ts
@@ -5,6 +5,8 @@
  */
 import type { TFunction } from "i18next";
 
+import { getFileManagerRevealLabelKey } from "@src/util/platform/fileManagerLabels";
+
 type TCommon = (key: string, defaultValue?: string) => string;
 
 interface BuildWorkstationSidebarLabelsParams {
@@ -49,6 +51,11 @@ export function buildWorkstationSidebarLabels({
     "sessions:chat.unhideWorkspaceGroup",
     "Unhide workspace"
   );
+  const revealWorkspaceLabel = tCommon(getFileManagerRevealLabelKey());
+  const workspaceUnavailableTitle = tSessions("chat.workspaceUnavailableTitle");
+  const workspaceUnavailableMessage = tSessions(
+    "chat.workspaceUnavailableMessage"
+  );
   const searchPlaceholder = tCommon("common.searchPlaceholder", "Search...");
   const noSearchResultsTitle = t("sidebar.empty.noSearchResults");
 
@@ -70,6 +77,9 @@ export function buildWorkstationSidebarLabels({
     unpinWorkspaceLabel,
     hideWorkspaceLabel,
     unhideWorkspaceLabel,
+    revealWorkspaceLabel,
+    workspaceUnavailableTitle,
+    workspaceUnavailableMessage,
     searchPlaceholder,
     noSearchResultsTitle,
   };

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useWorkspaceGroupActions.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useWorkspaceGroupActions.test.ts
@@ -1,0 +1,139 @@
+import { revealItemInDir } from "@tauri-apps/plugin-opener";
+import { Provider, createStore } from "jotai";
+import React from "react";
+import { renderToString } from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { repoApi } from "@src/api/tauri/repo";
+import { showNativeMessageSafely } from "@src/util/dialogs/nativeDialog";
+import { popupNativeMenu } from "@src/util/platform/tauri/nativeMenuPopup";
+
+import { NO_WORKSPACE_KEY } from "../types";
+import type { WorkspaceGroupActions } from "../useSessionMenuItems/types";
+import { useWorkspaceGroupActions } from "./useWorkspaceGroupActions";
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  revealItemInDir: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@src/util/dialogs/nativeDialog", () => ({
+  showNativeMessageSafely: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@src/api/tauri/repo", () => ({
+  repoApi: {
+    validateWorkspacePath: vi.fn(),
+  },
+}));
+
+vi.mock("@src/util/platform/tauri/nativeMenuPopup", () => ({
+  popupNativeMenu: vi.fn().mockResolvedValue({ status: "closed" }),
+}));
+
+const mockedPopupNativeMenu = vi.mocked(popupNativeMenu);
+const mockedRevealItemInDir = vi.mocked(revealItemInDir);
+const mockedValidateWorkspacePath = vi.mocked(repoApi.validateWorkspacePath);
+const mockedShowNativeMessageSafely = vi.mocked(showNativeMessageSafely);
+
+function renderWorkspaceGroupActions(): WorkspaceGroupActions {
+  const store = createStore();
+  let actions: WorkspaceGroupActions | undefined;
+
+  function HookProbe(): null {
+    // eslint-disable-next-line react-hooks/globals -- server-rendered test probe synchronously exports the hook result; the component never mounts or re-renders
+    actions = useWorkspaceGroupActions({
+      createSessionLabel: "New session",
+      moreActionsLabel: "More actions",
+      pinLabel: "Pin workspace",
+      unpinLabel: "Unpin workspace",
+      hideLabel: "Hide workspace",
+      unhideLabel: "Unhide workspace",
+      revealLabel: "Reveal in file manager",
+      unavailableTitle: "Workspace no longer available",
+      unavailableMessage: "This Workspace may have been moved or deleted.",
+      openNewSession: vi.fn(),
+      setCollapsedSectionIds: vi.fn(),
+    });
+    return null;
+  }
+
+  renderToString(
+    React.createElement(Provider, { store }, React.createElement(HookProbe))
+  );
+
+  if (!actions) throw new Error("workspace group actions did not render");
+  return actions;
+}
+
+describe("useWorkspaceGroupActions", () => {
+  beforeEach(() => {
+    mockedPopupNativeMenu.mockClear();
+    mockedRevealItemInDir.mockClear();
+    mockedValidateWorkspacePath.mockReset();
+    mockedValidateWorkspacePath.mockImplementation(async (path) => path);
+    mockedShowNativeMessageSafely.mockClear();
+  });
+
+  it("reveals actual workspace groups in the OS file manager", async () => {
+    const actions = renderWorkspaceGroupActions();
+    actions.onOpenMenu("/workspace/orgii");
+
+    const popupOptions = mockedPopupNativeMenu.mock.calls[0]?.[0];
+    const items = await popupOptions?.buildItems();
+    expect(
+      items?.map((item) => ("text" in item ? item.text : item.item))
+    ).toEqual([
+      "Reveal in file manager",
+      "Separator",
+      "Pin workspace",
+      "Hide workspace",
+    ]);
+
+    const revealItem = items?.[0];
+    if (revealItem && "action" in revealItem) {
+      revealItem.action?.("reveal-workspace");
+    }
+    await vi.waitFor(() => {
+      expect(mockedRevealItemInDir).toHaveBeenCalledWith("/workspace/orgii");
+    });
+    expect(mockedShowNativeMessageSafely).not.toHaveBeenCalled();
+  });
+
+  it("shows a native warning when the workspace folder no longer exists", async () => {
+    mockedValidateWorkspacePath.mockRejectedValue(
+      new Error("Unable to access workspace path")
+    );
+    const actions = renderWorkspaceGroupActions();
+    actions.onOpenMenu("/workspace/missing");
+
+    const popupOptions = mockedPopupNativeMenu.mock.calls[0]?.[0];
+    const items = await popupOptions?.buildItems();
+    const revealItem = items?.[0];
+    if (revealItem && "action" in revealItem) {
+      revealItem.action?.("reveal-workspace");
+    }
+
+    await vi.waitFor(() => {
+      expect(mockedShowNativeMessageSafely).toHaveBeenCalledWith(
+        "This Workspace may have been moved or deleted.\n\n/workspace/missing",
+        {
+          title: "Workspace no longer available",
+          kind: "warning",
+        }
+      );
+    });
+    expect(mockedRevealItemInDir).not.toHaveBeenCalled();
+  });
+
+  it("omits reveal for the synthetic no-workspace group", async () => {
+    const actions = renderWorkspaceGroupActions();
+    actions.onOpenMenu(NO_WORKSPACE_KEY);
+
+    const popupOptions = mockedPopupNativeMenu.mock.calls[0]?.[0];
+    const items = await popupOptions?.buildItems();
+    expect(
+      items?.map((item) => ("text" in item ? item.text : item.item))
+    ).toEqual(["Pin workspace", "Hide workspace"]);
+    expect(mockedRevealItemInDir).not.toHaveBeenCalled();
+  });
+});

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useWorkspaceGroupActions.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useWorkspaceGroupActions.ts
@@ -14,16 +14,22 @@
  * collapsed-section ids, which is what actually folds the group: a workspace
  * group's section id IS its workspace key.
  */
+import { revealItemInDir } from "@tauri-apps/plugin-opener";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
+import { repoApi } from "@src/api/tauri/repo";
 import { createLogger } from "@src/hooks/logger";
 import { reposAtom } from "@src/store/repo";
 import {
   SESSION_SOURCE_TYPE,
   sessionSourceAtom,
 } from "@src/store/session/creatorStateAtom";
-import { popupNativeMenu } from "@src/util/platform/tauri/nativeMenuPopup";
+import { showNativeMessageSafely } from "@src/util/dialogs/nativeDialog";
+import {
+  type NativeMenuItemOptions,
+  popupNativeMenu,
+} from "@src/util/platform/tauri/nativeMenuPopup";
 
 import {
   sidebarHiddenWorkspacesAtom,
@@ -42,11 +48,68 @@ interface UseWorkspaceGroupActionsParams {
   unpinLabel: string;
   hideLabel: string;
   unhideLabel: string;
+  revealLabel: string;
+  unavailableTitle: string;
+  unavailableMessage: string;
   /** The sidebar's own "new session" entry point (`openNewChatFromSidebar`). */
   openNewSession: () => void;
   setCollapsedSectionIds: (
     updater: (previous: Set<string>) => Set<string>
   ) => void;
+}
+
+async function showWorkspaceUnavailableDialog(
+  workspaceKey: string,
+  title: string,
+  dialogMessage: string
+): Promise<void> {
+  try {
+    await showNativeMessageSafely(`${dialogMessage}\n\n${workspaceKey}`, {
+      title,
+      kind: "warning",
+    });
+  } catch (error) {
+    logger.warn("failed to show workspace unavailable dialog:", error);
+  }
+}
+
+async function revealWorkspaceInFileManager(
+  workspaceKey: string,
+  unavailableTitle: string,
+  unavailableMessage: string
+): Promise<void> {
+  let validatedWorkspacePath: string;
+  try {
+    // Backend validation is authoritative for workspace paths. Unlike the
+    // frontend fs plugin, it can inspect valid folders outside $HOME (common
+    // on Windows) without mistaking a missing runtime scope for a missing path.
+    validatedWorkspacePath = await repoApi.validateWorkspacePath(workspaceKey);
+  } catch (error) {
+    logger.warn("workspace is unavailable:", error);
+    await showWorkspaceUnavailableDialog(
+      workspaceKey,
+      unavailableTitle,
+      unavailableMessage
+    );
+    return;
+  }
+
+  try {
+    await revealItemInDir(validatedWorkspacePath);
+  } catch (error) {
+    logger.warn("failed to reveal workspace in file manager:", error);
+    // Cover the narrow race where the folder disappears after the first
+    // availability check but before the file manager handles the request.
+    try {
+      await repoApi.validateWorkspacePath(workspaceKey);
+    } catch {
+      await showWorkspaceUnavailableDialog(
+        workspaceKey,
+        unavailableTitle,
+        unavailableMessage
+      );
+    }
+  }
 }
 
 export function useWorkspaceGroupActions({
@@ -56,6 +119,9 @@ export function useWorkspaceGroupActions({
   unpinLabel,
   hideLabel,
   unhideLabel,
+  revealLabel,
+  unavailableTitle,
+  unavailableMessage,
   openNewSession,
   setCollapsedSectionIds,
 }: UseWorkspaceGroupActionsParams): WorkspaceGroupActions {
@@ -154,8 +220,24 @@ export function useWorkspaceGroupActions({
       const isHidden = hiddenWorkspaceKeys.has(workspaceKey);
       void popupNativeMenu({
         source: "sidebar-workspace-group",
-        buildItems: () => [
-          {
+        buildItems: () => {
+          const items: NativeMenuItemOptions[] = [];
+          if (workspaceKey !== NO_WORKSPACE_KEY) {
+            items.push(
+              {
+                text: revealLabel,
+                action: () => {
+                  void revealWorkspaceInFileManager(
+                    workspaceKey,
+                    unavailableTitle,
+                    unavailableMessage
+                  );
+                },
+              },
+              { item: "Separator" }
+            );
+          }
+          items.push({
             text: isPinned ? unpinLabel : pinLabel,
             action: () => {
               toggleKey(setPinnedWorkspaces, workspaceKey, isPinned);
@@ -165,16 +247,17 @@ export function useWorkspaceGroupActions({
               toggleKey(setHiddenWorkspaces, workspaceKey, true);
               setSectionCollapsed(workspaceKey, false);
             },
-          },
-          {
+          });
+          items.push({
             text: isHidden ? unhideLabel : hideLabel,
             action: () => {
               toggleKey(setHiddenWorkspaces, workspaceKey, isHidden);
               setSectionCollapsed(workspaceKey, !isHidden);
               if (!isHidden) toggleKey(setPinnedWorkspaces, workspaceKey, true);
             },
-          },
-        ],
+          });
+          return items;
+        },
       }).catch((error: unknown) => {
         logger.warn("workspace group menu failed to open:", error);
       });
@@ -184,10 +267,13 @@ export function useWorkspaceGroupActions({
       hideLabel,
       pinLabel,
       pinnedWorkspaceKeys,
+      revealLabel,
       setHiddenWorkspaces,
       setPinnedWorkspaces,
       setSectionCollapsed,
       toggleKey,
+      unavailableMessage,
+      unavailableTitle,
       unhideLabel,
       unpinLabel,
     ]


### PR DESCRIPTION
## Problem

Workspace-group overflow menus do not expose the underlying folder in the operating system's file manager. Historical workspace groups can also outlive folders that were moved or deleted, and attempting to reveal those paths did not give the user a useful explanation.

## Solution

Add a platform-aware Reveal in Finder, Reveal in Windows Explorer, or Reveal in File Manager action to every real workspace group. The action validates the path through the existing Tauri backend before revealing it, is omitted for the synthetic No Workspace group, and shows a localized native warning with the original path when the folder is unavailable. All 13 shipped locales provide natural warning copy while preserving the canonical `Workspace` term; the reveal action reuses the existing platform-specific common labels without an English fallback.

## Potential risks

Each reveal request now performs one existing Tauri validation IPC before opening the file manager. A folder can disappear after validation; the opener failure path revalidates and shows the same warning if that race occurs. No persistence, schema, dependency, public API, or wire format changed. Native menu and dialog appearance were not visually exercised because desktop UI control was not authorized.

## Verification

- `pnpm run typecheck` — passed
- `pnpm run lint` — passed
- `pnpm run test` — passed (1,232 files; 9,797 tests)
- `pnpm run check:circular` — passed (6,547 modules; no circular dependencies)
- `pnpm exec vitest run src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useWorkspaceGroupActions.test.ts src/scaffold/NavigationSidebar/connectors/useSessionMenuItems/__tests__/menuSectionBuilders.test.ts` — passed (2 files; 19 tests)
- `node -e 'const fs=require("fs"),p=require("path"),r="src/i18n/locales",ls=fs.readdirSync(r).filter(l=>fs.existsSync(p.join(r,l,"sessions.json")));if(ls.length!==13)throw Error(`expected 13 locales, got ${ls.length}`);for(const l of ls){const s=require(p.resolve(r,l,"sessions.json")),c=require(p.resolve(r,l,"common.json"));for(const k of ["workspaceUnavailableTitle","workspaceUnavailableMessage"]){const v=s.chat[k];if(typeof v!=="string"||!v.includes("Workspace"))throw Error(`${l}:${k}`)}for(const k of ["revealInFinder","revealInWindowsExplorer","revealInFileManager"]){if(!c.actions[k])throw Error(`${l}:${k}`)}}console.log(`validated ${ls.length} locales`)'` — passed (`validated 13 locales`)
- `git diff --check` — passed
- The commit hook reran lint-staged and its staged TypeScript check — passed
- Native desktop screenshot/manual UI run — not performed because desktop UI control was not authorized; behavior is covered at the TypeScript action boundary
