### PR TITLE
fix(windows-chrome): refine translucent page surface

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -25,7 +25,7 @@
         var winVal, pageVal;
         if (ua.indexOf("windows") !== -1) {
           winVal = "8px";
-          pageVal = "8px";
+          pageVal = "12px";
           html.dataset.hostDesktop = "windows";
         } else if (ua.indexOf("linux") !== -1 && ua.indexOf("android") === -1) {
           winVal = "12px";

--- a/public/orgii_dark.css
+++ b/public/orgii_dark.css
@@ -101,7 +101,7 @@
 body {
   --color-bg-1: #0f0f0f;
   --color-bg-2: #141414;
-  --windows-native-chrome-opacity: 82%;
+  --windows-native-chrome-opacity: 52%;
   --color-bg-3: #2a2a2b;
   --color-bg-4: #313132;
   --color-neutral-1: #f7f8fa;
@@ -133,6 +133,9 @@ body {
   --sidebar-edge-shadow:
     inset -1px 0 0 rgba(255, 255, 255, 0.07),
     inset -8px 0 12px -12px rgba(0, 0, 0, 0.9);
+  --windows-page-edge-shadow:
+    inset 1px 0 0 rgba(255, 255, 255, 0.07),
+    inset 8px 0 12px -10px rgba(0, 0, 0, 0.9);
   --sidebar-shadow: 0 1px 2px rgba(0, 0, 0, 0.2), 0 8px 24px rgba(0, 0, 0, 0.3);
 
   /* Start Page */

--- a/public/orgii_high_contrast.css
+++ b/public/orgii_high_contrast.css
@@ -128,6 +128,7 @@ body {
   );
   --sidebar-backdrop: blur(8px) saturate(120%);
   --sidebar-edge-shadow: none;
+  --windows-page-edge-shadow: none;
   --sidebar-shadow: none;
 
   /* Start Page */

--- a/public/orgii_main.css
+++ b/public/orgii_main.css
@@ -133,6 +133,9 @@ body {
   --sidebar-edge-shadow:
     inset -1px 0 0 rgba(0, 0, 0, 0.015),
     inset -8px 0 12px -12px rgba(0, 0, 0, 0.12);
+  --windows-page-edge-shadow:
+    inset 1px 0 0 rgba(0, 0, 0, 0.04),
+    inset 8px 0 14px -10px rgba(0, 0, 0, 0.22);
   --sidebar-shadow:
     0 1px 2px rgba(0, 0, 0, 0.04), 0 8px 24px rgba(0, 0, 0, 0.08);
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -609,7 +609,7 @@ html[data-windows-chrome="acrylic"] .sidebar-base {
 // Match the surface revealed beneath the rounded work area to the translucent
 // Windows chrome used by the top bar and navigation sidebar. Falling through
 // to the opaque root background makes the corner look like a separate layer.
-html[data-host-desktop="windows"] .windows-main-page-underlay {
+.windows-main-page-underlay {
   background: color-mix(
     in srgb,
     var(--color-bg-2) var(--windows-native-chrome-opacity, 30%),
@@ -618,9 +618,9 @@ html[data-host-desktop="windows"] .windows-main-page-underlay {
 }
 
 // Only the inner top-left corner of the main work surface is rounded.
-html[data-host-desktop="windows"] .windows-main-page-surface {
-  overflow: hidden;
-  border-top-left-radius: var(--radius-page);
+.windows-main-page-surface {
+  clip-path: inset(0 round 12px 0 0 0);
+  box-shadow: var(--windows-page-edge-shadow);
 }
 
 // Windows uses a frameless Tauri window with DWM owning the outer shape.


### PR DESCRIPTION
## Problem

On Windows, the frameless main page could retain a visually sharp top-left corner when a composited pane painted the page, while the dark sidebar and top bar appeared too opaque. The preflight page radius was still 8px even though the Windows page geometry targets 12px, and the page edge had no theme-aware separation from the translucent sidebar.

## Solution

Align the Windows preflight page radius to 12px, clip the Windows-only main page surface with a single 12px compositor clip, and tint the exposed underlay with the same native-chrome mix. Add light and dark page-edge shadow tokens, disable the shadow in high-contrast mode, and lower dark Windows native-chrome opacity from 82% to 52%. macOS behavior is unchanged because the affected surface classes are assigned only by the Windows layout.

## Potential risks

The Windows main-page clip can hide future content that intentionally overflows the top-left page boundary. The opacity and shadow values are visual tuning for Windows 11 acrylic; Windows 10 retains its existing opaque fallback, and no Linux or macOS styling path changes. Rollback is the single scoped commit.

## Verification

- `pnpm exec prettier --check public/index.html public/orgii_main.css public/orgii_dark.css public/orgii_high_contrast.css src/index.scss` — passed in the clean worktree
- `git diff --check` — passed
- Husky/lint-staged — passed; no TypeScript or Rust files were staged, so the hook skipped typecheck and clippy
- Manual Windows verification — ran the existing `pnpm run tauridev` app, captured the live ORG2 window, and confirmed the simplified 12px top-left arc without an additional background layer; light and dark native-chrome values were iterated in the running app
- Full test suite not run because the change is limited to public CSS/HTML theme tokens and Windows surface geometry
- No screenshot attached because the available capture contains local application state and the PR was created through the API; the live pixel-level check was completed locally