### PR TITLE
feat(session-header): tag agent-started sessions as subagents

### DIFF
--- a/src/components/ClientOriginBadge/index.tsx
+++ b/src/components/ClientOriginBadge/index.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from "react-i18next";
 
 import type { ImportedClientOrigin } from "@src/api/tauri/externalHistory/imported/descriptors";
-import Tag from "@src/components/Tag";
+import SessionTitleTag from "@src/components/SessionTitleTag";
 
 /**
  * Provenance badge for an imported session: which client actually produced
@@ -71,23 +71,14 @@ export default function ClientOriginBadge({
   // first because we do not know, the second because it is the default.
   if (!hasVisibleClientOriginBadge(origin)) return null;
 
-  // `Tag`'s smallest size (`mini`: 12px text, 2px/8px padding) still reads as
-  // a control beside a session title, where this is an annotation. Tighten it
-  // here rather than adding a size to the shared component for one caller —
-  // `!` overrides win against the SCSS size class regardless of sheet order.
-  const compact = "!px-1.5 !py-0 !text-[10px] !leading-4";
-
-  // `Tag` exposes no `title`; wrap rather than widen a shared component for
-  // one caller.
   return (
-    <span title={originRaw}>
-      <Tag
-        color={ORIGIN_COLOR[origin]}
-        size={size}
-        className={className ? `${compact} ${className}` : compact}
-      >
-        {t(ORIGIN_LABEL_KEY[origin])}
-      </Tag>
-    </span>
+    <SessionTitleTag
+      color={ORIGIN_COLOR[origin]}
+      size={size}
+      title={originRaw}
+      className={className}
+    >
+      {t(ORIGIN_LABEL_KEY[origin])}
+    </SessionTitleTag>
   );
 }

--- a/src/components/SessionTitleTag/index.tsx
+++ b/src/components/SessionTitleTag/index.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+
+import Tag, { type TagProps } from "@src/components/Tag";
+
+/**
+ * Compact annotation tag rendered beside a session title.
+ *
+ * Session headers carry more than one kind of annotation — where a transcript
+ * came from (`ClientOriginBadge`) and what the session is (`SubagentBadge`) —
+ * and they sit side by side on the same row. Their shared sizing lives here so
+ * they cannot drift apart one caller at a time.
+ *
+ * `Tag`'s smallest size (`mini`: 12px text, 2px/8px padding) still reads as a
+ * control next to a session name, where these are annotations. Tighten it here
+ * rather than adding a size to the shared component for these callers — `!`
+ * overrides win against the SCSS size class regardless of sheet order.
+ */
+const COMPACT_TAG_CLASS = "!px-1.5 !py-0 !text-[10px] !leading-4";
+
+export interface SessionTitleTagProps {
+  color?: TagProps["color"];
+  size?: "mini" | "small";
+  /** Native tooltip. `Tag` exposes no `title`, so the wrapper carries it. */
+  title?: string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+export default function SessionTitleTag({
+  color = "default",
+  size = "mini",
+  title,
+  className,
+  children,
+}: SessionTitleTagProps) {
+  return (
+    <span title={title}>
+      <Tag
+        color={color}
+        size={size}
+        className={
+          className ? `${COMPACT_TAG_CLASS} ${className}` : COMPACT_TAG_CLASS
+        }
+      >
+        {children}
+      </Tag>
+    </span>
+  );
+}

--- a/src/components/SubagentBadge/index.tsx
+++ b/src/components/SubagentBadge/index.tsx
@@ -1,0 +1,28 @@
+import { useTranslation } from "react-i18next";
+
+import SessionTitleTag from "@src/components/SessionTitleTag";
+
+/**
+ * Marks a session that was started by another session's agent rather than by
+ * the user: a subagent fan-out child, an Agent Team member run, or a
+ * background child.
+ *
+ * The breadcrumb already shows `parent › child` for these, but the parent
+ * segment alone does not say *why* the child exists — a continuation and an
+ * import nest the same way. The tag names the relationship. Whether a session
+ * qualifies is decided by `isAgentChildSession`; this component only renders
+ * the verdict, so the taxonomy keeps one definition.
+ */
+export interface SubagentBadgeProps {
+  className?: string;
+}
+
+export default function SubagentBadge({ className }: SubagentBadgeProps) {
+  const { t } = useTranslation("sessions");
+
+  return (
+    <SessionTitleTag color="processing" className={className}>
+      {t("sessionBadge.subagent")}
+    </SessionTitleTag>
+  );
+}

--- a/src/engines/ChatPanel/components/SessionHeaderBreadcrumb/SessionHeaderBreadcrumb.test.ts
+++ b/src/engines/ChatPanel/components/SessionHeaderBreadcrumb/SessionHeaderBreadcrumb.test.ts
@@ -16,6 +16,11 @@ vi.mock("../SessionIdentityIcon", () => ({
   default: () => React.createElement("span", null, "Session icon"),
 }));
 
+// The suite's i18next instance is not wired through `initReactI18next`, so
+// `useTranslation` echoes keys instead of English text. Assert the key: it is
+// what pins the badge to a real string, and it survives copy edits.
+const SUBAGENT_TAG_KEY = "sessionBadge.subagent";
+
 describe("session published-header breadcrumbs", () => {
   afterEach(() => {
     getDefaultStore().set(sessionsAtom, []);
@@ -230,5 +235,67 @@ describe("session published-header breadcrumbs", () => {
 
     expect(markup).toContain("Personal session");
     expect(markup).not.toContain("h-4 w-px shrink-0 bg-border-2");
+    expect(markup).not.toContain(SUBAGENT_TAG_KEY);
+  });
+
+  it("tags an agent-started child session as a subagent", () => {
+    const parentSession = {
+      session_id: "root",
+      name: "Key trading VM launch",
+    } as Session;
+    getDefaultStore().set(sessionsAtom, [parentSession]);
+    const session = {
+      session_id: "root:subagent:translator",
+      name: "Translate wave 1 to ko/de/es",
+      parentSessionId: "root",
+    } as Session;
+    const markup = renderToStaticMarkup(
+      React.createElement(SessionHeaderBreadcrumb, {
+        session,
+        sessionId: session.session_id,
+        fallbackName: "Fallback title",
+      })
+    );
+
+    expect(markup).toContain("Translate wave 1 to ko/de/es");
+    expect(markup).toContain(SUBAGENT_TAG_KEY);
+    expect(markup).toContain('title="Translate wave 1 to ko/de/es"');
+  });
+
+  it("tags an Agent Team member session as a subagent", () => {
+    const session = {
+      session_id: "member-session-1",
+      name: "Review API",
+      parentSessionId: "root",
+      orgMemberId: "member-1",
+    } as Session;
+    const markup = renderToStaticMarkup(
+      React.createElement(SessionHeaderBreadcrumb, {
+        session,
+        sessionId: session.session_id,
+        fallbackName: "Fallback title",
+      })
+    );
+
+    expect(markup).toContain(SUBAGENT_TAG_KEY);
+  });
+
+  it("leaves an ordinary continuation session untagged", () => {
+    const session = {
+      session_id: "continued-session",
+      name: "Continue imported history",
+      parentSessionId: "imported-source",
+      background: false,
+    } as Session;
+    const markup = renderToStaticMarkup(
+      React.createElement(SessionHeaderBreadcrumb, {
+        session,
+        sessionId: session.session_id,
+        fallbackName: "Fallback title",
+      })
+    );
+
+    expect(markup).toContain("Continue imported history");
+    expect(markup).not.toContain(SUBAGENT_TAG_KEY);
   });
 });

--- a/src/engines/ChatPanel/components/SessionHeaderBreadcrumb/index.tsx
+++ b/src/engines/ChatPanel/components/SessionHeaderBreadcrumb/index.tsx
@@ -5,6 +5,7 @@ import ClientOriginBadge, {
   hasVisibleClientOriginBadge,
 } from "@src/components/ClientOriginBadge";
 import { HeaderSectionSeparator } from "@src/components/HeaderSectionSeparator";
+import SubagentBadge from "@src/components/SubagentBadge";
 import BreadcrumbFileHeader, {
   type BreadcrumbFileHeaderDisplaySegment,
 } from "@src/modules/shared/components/FileHeader/BreadcrumbFileHeader";
@@ -92,6 +93,19 @@ const SessionHeaderBreadcrumb: React.FC<SessionHeaderBreadcrumbProps> = memo(
     const displaySegments = useMemo<
       BreadcrumbFileHeaderDisplaySegment[]
     >(() => {
+      // Title annotations: where the transcript came from, and whether an
+      // agent — not the user — started this session. Both are optional, so
+      // the plain-name segment stays untouched when neither applies.
+      const subagentBadge = display.isAgentChildSession ? (
+        <SubagentBadge />
+      ) : null;
+      const annotations =
+        originBadge || subagentBadge ? (
+          <>
+            {originBadge}
+            {subagentBadge}
+          </>
+        ) : null;
       const sessionNameSegment: BreadcrumbFileHeaderDisplaySegment = {
         label: display.displayName,
         ...(externalOwnerName && externalOwnerDisplayName
@@ -99,7 +113,7 @@ const SessionHeaderBreadcrumb: React.FC<SessionHeaderBreadcrumbProps> = memo(
               content: (
                 <span className="inline-flex min-w-0 items-center gap-2">
                   <span>{display.displayName}</span>
-                  {originBadge}
+                  {annotations}
                   <HeaderSectionSeparator />
                   <span className="inline-block max-w-40 truncate align-middle font-normal text-text-2">
                     {externalOwnerDisplayName}
@@ -108,12 +122,12 @@ const SessionHeaderBreadcrumb: React.FC<SessionHeaderBreadcrumbProps> = memo(
               ),
               title: `${display.fullDisplayName} | ${externalOwnerName}`,
             }
-          : originBadge
+          : annotations
             ? {
                 content: (
                   <span className="inline-flex min-w-0 items-center gap-2">
                     <span className="truncate">{display.displayName}</span>
-                    {originBadge}
+                    {annotations}
                   </span>
                 ),
                 title: display.fullDisplayName,

--- a/src/i18n/locales/de/sessions.json
+++ b/src/i18n/locales/de/sessions.json
@@ -2836,5 +2836,8 @@
       "skipped": "Übersprungen",
       "pending": "Startet"
     }
+  },
+  "sessionBadge": {
+    "subagent": "Sub Agent"
   }
 }

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -3057,5 +3057,8 @@
     "imagesUnsupported": "Team chat messages cannot include images",
     "participantsTooltip": "Conversation participants and discussion messages",
     "mentionGroup": "Teammates"
+  },
+  "sessionBadge": {
+    "subagent": "Subagent"
   }
 }

--- a/src/i18n/locales/es/sessions.json
+++ b/src/i18n/locales/es/sessions.json
@@ -2838,5 +2838,8 @@
       "skipped": "Omitido",
       "pending": "Iniciando"
     }
+  },
+  "sessionBadge": {
+    "subagent": "Sub Agent"
   }
 }

--- a/src/i18n/locales/fr/sessions.json
+++ b/src/i18n/locales/fr/sessions.json
@@ -2838,5 +2838,8 @@
       "skipped": "Ignoré",
       "pending": "Démarrage"
     }
+  },
+  "sessionBadge": {
+    "subagent": "Sub Agent"
   }
 }

--- a/src/i18n/locales/ja/sessions.json
+++ b/src/i18n/locales/ja/sessions.json
@@ -2837,5 +2837,8 @@
       "skipped": "スキップ",
       "pending": "開始中"
     }
+  },
+  "sessionBadge": {
+    "subagent": "Sub Agent"
   }
 }

--- a/src/i18n/locales/ko/sessions.json
+++ b/src/i18n/locales/ko/sessions.json
@@ -2838,5 +2838,8 @@
       "skipped": "건너뜀",
       "pending": "시작 중"
     }
+  },
+  "sessionBadge": {
+    "subagent": "Sub Agent"
   }
 }

--- a/src/i18n/locales/pl/sessions.json
+++ b/src/i18n/locales/pl/sessions.json
@@ -2875,5 +2875,8 @@
       "skipped": "Pominięte",
       "pending": "Uruchamianie"
     }
+  },
+  "sessionBadge": {
+    "subagent": "Subagent"
   }
 }

--- a/src/i18n/locales/pt/sessions.json
+++ b/src/i18n/locales/pt/sessions.json
@@ -2837,5 +2837,8 @@
       "skipped": "Ignorado",
       "pending": "Iniciando"
     }
+  },
+  "sessionBadge": {
+    "subagent": "Subagente"
   }
 }

--- a/src/i18n/locales/ru/sessions.json
+++ b/src/i18n/locales/ru/sessions.json
@@ -2882,5 +2882,8 @@
       "skipped": "Пропущен",
       "pending": "Запускается"
     }
+  },
+  "sessionBadge": {
+    "subagent": "Sub Agent"
   }
 }

--- a/src/i18n/locales/tr/sessions.json
+++ b/src/i18n/locales/tr/sessions.json
@@ -2839,5 +2839,8 @@
       "skipped": "Atlandı",
       "pending": "Başlatılıyor"
     }
+  },
+  "sessionBadge": {
+    "subagent": "Sub Agent"
   }
 }

--- a/src/i18n/locales/vi/sessions.json
+++ b/src/i18n/locales/vi/sessions.json
@@ -2835,5 +2835,8 @@
       "skipped": "Đã bỏ qua",
       "pending": "Đang khởi động"
     }
+  },
+  "sessionBadge": {
+    "subagent": "Subagent"
   }
 }

--- a/src/i18n/locales/zh-Hant/sessions.json
+++ b/src/i18n/locales/zh-Hant/sessions.json
@@ -2913,5 +2913,8 @@
       "skipped": "已略過",
       "pending": "啟動中"
     }
+  },
+  "sessionBadge": {
+    "subagent": "Sub Agent"
   }
 }

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -3046,5 +3046,8 @@
     "imagesUnsupported": "团队讨论暂不支持图片",
     "participantsTooltip": "对话参与者与讨论消息数",
     "mentionGroup": "队友"
+  },
+  "sessionBadge": {
+    "subagent": "Sub Agent"
   }
 }


### PR DESCRIPTION
## Problem

A session started by another session's agent — a subagent fan-out child, an
Agent Team member run, or a background child — appears in the chat header as
`parent › child`. That nesting does not identify it: an ordinary continuation
session and an imported replay nest exactly the same way, so nothing in the
title separates a session an agent spawned from one the user opened. The
adjacent annotation slot already carries transcript provenance
(`Official app` / `CLI` / `Third party`) but has no equivalent for agent
provenance, so the distinction was only inferable from the sidebar's
indentation.

## Solution

Render a `Subagent` tag beside the session name in the header title, styled as
the sibling of the existing client-origin badge.

- Whether a session qualifies is decided by the existing `isAgentChildSession`
  predicate (subagent-shaped session id, Agent Team member id, or background
  child). No new predicate is introduced, so the taxonomy keeps one definition
  and the tag cannot disagree with the breadcrumb that already nests these rows.
- The compact tag sizing that was inlined in `ClientOriginBadge` moves to a new
  shared `SessionTitleTag` primitive. Session titles now carry more than one
  annotation on the same row, and the shared sizing lives in one place so they
  cannot drift apart one caller at a time. `ClientOriginBadge` renders identical
  markup through it.
- Both annotations render as one group, so an imported subagent session shows
  origin and subagent side by side, and a session with neither keeps the plain
  untouched name segment.
- New key `sessions:sessionBadge.subagent` in all 13 locales, each using that
  locale's existing subagent wording (`Subagent` / `Sub Agent` / `Subagente`)
  rather than a new coinage.

## Potential risks

- **A duplicate of this change is already pushed on another branch.** Commit
  `0e5ae71d6` on `fix/github-graphql-oauth-fallback` contains an identical copy
  of these same 18 files: it was produced by a sweeping `git commit -a` that
  sat on top of unrelated Rust test-isolation work and an unrelated
  `_utilities.scss` composer-glow change. If that branch reaches `develop`,
  this PR becomes redundant or conflicting. Those paths should be dropped from
  that branch; this PR is the intended home for the change.
- **Coverage is broader than the word "subagent" strictly implies.** Agent Team
  member sessions and background children are tagged too, because they share
  `isAgentChildSession`. That matches how the app already groups them (the
  sidebar's "Show subagents" toggle), but a reader who takes `Subagent` to mean
  only a Task-tool child will see it on Agent Team rows.
- **Header layout.** One more inline element joins the title row. The name keeps
  its `truncate`, so a narrow panel shortens the name rather than pushing the
  tag off-row; an imported subagent session shows two tags plus the owner name.
- **A shared component changed.** `ClientOriginBadge` now renders through
  `SessionTitleTag`. The emitted markup is unchanged (same wrapper `span`, same
  `!px-1.5 !py-0 !text-[10px] !leading-4` overrides), so the hover card and
  header keep their current appearance — but a future restyle of
  `SessionTitleTag` now moves both badges at once, which is the intent.
- Presentation only: no schema, persistence, IPC, wire, dependency, or lockfile
  changes, and no change to which sessions exist or how they run. Rollback is
  reverting the commit.

## Verification

Run in an isolated worktree checked out at this branch's exact content, base
`develop@f83e0e498`:

- `npx vitest run src/engines/ChatPanel/components/SessionHeaderBreadcrumb/SessionHeaderBreadcrumb.test.ts`
  — 14 passed, including 3 new cases: a subagent-id child is tagged, an Agent
  Team member child is tagged, an ordinary continuation session is not; the
  existing personal-session case now also asserts the tag is absent.
- `npx tsc --noEmit -p tsconfig.json` — clean.
- `npx eslint` over the changed components and the breadcrumb directory — clean.
- `node scripts/quality/check-missing-i18n-keys.mjs --namespace sessions --prefix sessionBadge`
  — all languages complete, 0 missing.

Run against the previous base (identical content for every touched path):

- `npx vitest run src/components/Tag/Tag.test.ts src/components/SessionHoverCard src/util/session/__tests__/sessionDisplayMetadata.test.ts`
  — 21 passed.
- `node scripts/quality/check-circular-dependencies.mjs` — 0 circular
  dependencies across 6558 modules.

Rendered title markup for an agent child, from the SSR test (translation keys
echo because the suite's i18next is not wired through `initReactI18next`):

```html
<span class="inline-flex min-w-0 items-center gap-2">
  <span class="truncate">Translate wave 1 to ko/de/es</span>
  <span><span class="tag tag-size-mini tag-processing !px-1.5 !py-0 !text-[10px] !leading-4">
    <span class="tag-content">sessionBadge.subagent</span>
  </span></span>
</span>
```

**Not run:** the desktop app was not launched, so there is no screenshot of the
real header — the only evidence of the visual result is the markup above. This
stays in Draft until a screenshot of the rendered header (light and dark) is
attached. The full `vitest` and `cargo --workspace` suites were not run; nothing
in this change touches Rust.
