### PR TITLE
fix(composer): confine the composer glow to below the shell

### DIFF
--- a/src/styles/_utilities.scss
+++ b/src/styles/_utilities.scss
@@ -141,6 +141,14 @@
  *   - Active    : interaction styling is owned by shellInteractionClasses
  *   - Focus     : brighter primary glow with a short transition
  *
+ * The glow only spills BELOW the shell. It is carried by `::after`, whose
+ * blur would otherwise wash out past the left/right edges (a spread of -24px
+ * against a 56px blur still bleeds ~4px sideways, and the focus shadows bleed
+ * ~8px). `clip-path: inset(0 0 -Npx 0)` cuts the paint at the shell's own top
+ * and side edges while leaving the bottom open, so the primary tint is a
+ * downward glow rather than a halo. The neutral card edge (hairline + 1px
+ * drop) stays on `::before` so it still reads on all four sides.
+ *
  * Apply `.composer-breathing` to the shell element alongside
  * shellInteractionClasses. Keep the legacy class name so existing consumers do
  * not churn, but never run a permanent compositor animation while the app is
@@ -158,6 +166,7 @@
 }
 
 .composer-breathing {
+  // Neutral card edge — hairline + 1px drop, all four sides.
   &::before {
     position: absolute;
     inset: 0;
@@ -167,11 +176,27 @@
     opacity: 0.72;
     box-shadow:
       0 1px 3px rgba(0, 0, 0, 0.05),
-      0 0 0 1px rgba(0, 0, 0, 0.02),
+      0 0 0 1px rgba(0, 0, 0, 0.02);
+    transition: opacity 180ms ease;
+  }
+
+  // Primary glow — clipped to the area below the shell.
+  &::after {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    content: "";
+    border-radius: inherit;
+    opacity: 0.72;
+    box-shadow:
       0 22px 56px -24px
         color-mix(in srgb, var(--color-primary-6) 48%, transparent),
       0 9px 25px -17px
         color-mix(in srgb, var(--color-primary-6) 36%, transparent);
+    // Top + sides cut at the shell's own edges; bottom left open so the
+    // downward spill survives. Keep the bottom inset past the largest
+    // (offset + blur) below, or the glow gets a visible straight cut.
+    clip-path: inset(0 0 -96px 0);
     transition:
       opacity 180ms ease,
       box-shadow 180ms ease;
@@ -180,9 +205,11 @@
   &:focus-within {
     &::before {
       opacity: 1;
+    }
+
+    &::after {
+      opacity: 1;
       box-shadow:
-        0 1px 3px rgba(0, 0, 0, 0.05),
-        0 0 0 1px rgba(0, 0, 0, 0.02),
         0 24px 60px -22px
           color-mix(in srgb, var(--color-primary-6) 66%, transparent),
         0 10px 28px -16px


### PR DESCRIPTION
## Problem

The composer glow read as a halo wrapping the input on all sides instead of a lift underneath it.

`.composer-breathing` carried its primary-tinted shadows on `::before` at `inset: 0`. The negative spreads were not deep enough to hold the blur inside the shell's silhouette: at rest `0 22px 56px -24px` bleeds about 4px past the left and right edges (`-24px` spread against a 56px blur reaches `+4px`), and on focus `0 24px 60px -22px` bleeds about 8px. The vertical offsets kept the top clean, so the visible result was a blue wash hugging both vertical edges of the composer.

This affects every shell that opts into the class: the launchpad session composer, the chat panel composer (`getComposerShellClassName`), and the work-item create composer.

## Solution

Split the pseudo-elements by responsibility and clip the tinted half:

- `::before` keeps only the neutral card edge — `0 0 0 1px rgba(0,0,0,.02)` hairline plus the `0 1px 3px` drop — and still reads on all four sides.
- `::after` carries the primary glow and adds `clip-path: inset(0 0 -96px 0)`, which cuts the paint at the shell's own top and side edges while leaving the bottom open, so the spill survives only downward.

Shadow values, the `0.72` → `1` focus opacity step, and the 180ms transitions are unchanged — only the direction of the spill changes. Clipping was chosen over re-tuning the spreads because spread is uniform: pulling it in far enough to kill the side bleed also pulls the glow up off the bottom edge, and a Gaussian tail past `spread = -blur/2` still leaves a faint side wash. The clip is exact and independent of the shell's size.

The `-96px` bottom inset sits past the largest `offset + blur` in the stack (`24 + 60`), so the glow fades out on its own rather than meeting a straight cut.

## Potential risks

- **Shells shorter than the spread.** Unchanged behaviour: a negative spread already collapsed the shadow rect on short shells (the rest stack needs 48px of height, focus needs 44px), so the collapsed/pill composer states render as before. The clip does not change that threshold.
- **`clip-path` on a pseudo-element.** Supported in every Chromium/WebView2 target this app ships to; negative `inset()` offsets to extend a clip region past the border box are the standard one-sided-shadow technique. No fallback is provided — in a hypothetical non-supporting engine the glow would simply render as it does today.
- **New `::after` on the shell.** No `.composer-breathing` consumer defines its own `::after` (checked `ComposerShell`, `InputAreaChrome`, `EditorArea`, `CreateComposerScaffold`), so nothing is displaced.
- **Duplicate hunk on another branch.** The same 33 lines were briefly swept into an unrelated commit on `fix/github-graphql-oauth-fallback`; that commit has since been reset away, so no conflict is expected. Worth a glance if that branch is re-created from an older reflog entry.
- **Dark theme / other accents.** The glow is `color-mix` over `--color-primary-6`, so every accent preset and both themes follow the same direction change. Not individually eyeballed.

## Verification

- `node_modules/.bin/sass --no-source-map src/styles/_utilities.scss /dev/null` — compiles clean.
- `node_modules/.bin/prettier --check src/styles/_utilities.scss` — passes.
- Pre-commit hook ran on the commit: lint-staged passed, 0 eslint, 0 circular.
- Visual check: rendered the old and new declarations side by side in a standalone page at the composer's real geometry (12px radius, `#1d8ffd` primary, focused state). Before, the blue wash runs down both vertical edges; after, the sides are clean and the glow sits under the shell only, with no visible cut at the bottom corners. Screenshots are not attachable from the CLI, so the repro page is described here rather than embedded — the comparison is two copies of the same markup, one with each version of the `.composer-breathing` rules.
- Not run: full `vitest` / `cargo` suites. No test asserts these shadow strings (only the `composer-breathing` class name in `CreateComposerScaffold.test.ts`, which is unchanged), and the change is CSS-only.
