### PR TITLE
refactor(sidebar): move footer menu to account row

### DIFF
--- a/src/components/Avatar/index.test.ts
+++ b/src/components/Avatar/index.test.ts
@@ -67,4 +67,21 @@ describe("Avatar", () => {
 
     expect(container.firstElementChild).toBeNull();
   });
+
+  it("centers fallback text over a stable identity gradient", () => {
+    act(() => {
+      root.render(
+        createElement(Avatar, { gradientSeed: "Harry-He", size: 20 }, "H")
+      );
+    });
+
+    const avatar = container.firstElementChild;
+    const label = avatar?.firstElementChild;
+
+    expect(avatar?.className).toContain("bg-gradient-to-br");
+    expect(avatar?.className).toContain("text-white");
+    expect(label?.className).toContain("absolute inset-0");
+    expect(label?.className).toContain("items-center justify-center");
+    expect(label?.textContent).toBe("H");
+  });
 });

--- a/src/components/Avatar/index.tsx
+++ b/src/components/Avatar/index.tsx
@@ -24,31 +24,61 @@ export interface AvatarProps {
   src?: string;
   /** Omit the avatar when the image is missing or cannot be loaded. */
   hideOnError?: boolean;
+  /** Stable identity used to select a fallback gradient without visual flicker. */
+  gradientSeed?: string;
   /** Additional inline style (e.g. `backgroundColor`). */
   style?: React.CSSProperties;
 }
 
 const WRAPPER_CLASS =
-  "inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full bg-fill-3 font-medium text-text-1";
+  "relative inline-flex shrink-0 overflow-hidden rounded-full font-medium";
+const DEFAULT_FALLBACK_CLASS = "bg-fill-3 text-text-1";
+const GRADIENT_FALLBACK_CLASSES = [
+  "bg-gradient-to-br from-violet-500 to-fuchsia-500 text-white",
+  "bg-gradient-to-br from-blue-500 to-cyan-500 text-white",
+  "bg-gradient-to-br from-emerald-500 to-teal-500 text-white",
+  "bg-gradient-to-br from-amber-500 to-orange-500 text-white",
+  "bg-gradient-to-br from-rose-500 to-pink-500 text-white",
+  "bg-gradient-to-br from-indigo-500 to-purple-500 text-white",
+] as const;
+
+function resolveGradientClass(seed: string): string {
+  let hash = 0;
+  for (const character of seed) {
+    hash = (hash * 31 + (character.codePointAt(0) ?? 0)) >>> 0;
+  }
+  return GRADIENT_FALLBACK_CLASSES[hash % GRADIENT_FALLBACK_CLASSES.length];
+}
 
 const Avatar: React.FC<AvatarProps> = ({
   size = 32,
   children,
   src,
   hideOnError = false,
+  gradientSeed,
   style,
 }) => {
   const [failedSrc, setFailedSrc] = useState<string | null>(null);
   const wrapperStyle = useMemo<React.CSSProperties>(
-    () => ({ width: size, height: size, fontSize: size * 0.4, ...style }),
+    () => ({ width: size, height: size, fontSize: size * 0.5, ...style }),
     [size, style]
   );
   const imageFailed = Boolean(src && failedSrc === src);
+  const fallbackClass = useMemo(
+    () =>
+      gradientSeed
+        ? resolveGradientClass(gradientSeed)
+        : DEFAULT_FALLBACK_CLASS,
+    [gradientSeed]
+  );
 
   if (hideOnError && (!src || imageFailed)) return null;
 
   return (
-    <div className={WRAPPER_CLASS} style={wrapperStyle}>
+    <div
+      className={`${WRAPPER_CLASS} ${src ? DEFAULT_FALLBACK_CLASS : fallbackClass}`}
+      style={wrapperStyle}
+    >
       {src ? (
         <img
           src={src}
@@ -63,7 +93,9 @@ const Avatar: React.FC<AvatarProps> = ({
           }
         />
       ) : (
-        children
+        <span className="absolute inset-0 flex items-center justify-center text-center leading-none">
+          {children}
+        </span>
       )}
     </div>
   );

--- a/src/scaffold/NavigationSidebar/blocks/SidebarBottomBar.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarBottomBar.tsx
@@ -6,12 +6,7 @@
  * organization selector. User presence remains available as a reusable menu
  * for the Settings dropdown and roomier composer/header surfaces.
  *
- * Right side hosts compact action buttons, including the Settings gear
- * that opens quick settings actions and links to the app settings route.
- * `AppShell` detects that route and renders Settings inside the
- * chat-panel slot with the WorkStation kept visible underneath, so the
- * URL stays deeplinkable while the layout matches the slot affordance.
- * Extra actions can be supplied by the caller (e.g. session group-by).
+ * Right side hosts compact contextual actions and the update control.
  */
 import { useAtom, useAtomValue } from "jotai";
 import { Circle, HatGlasses, type LucideIcon, Moon } from "lucide-react";
@@ -48,10 +43,8 @@ import { resolveCustomRoleIcon } from "./customRoleIcons";
 interface SidebarBottomBarProps {
   /** Content rendered in the footer's left-side slot. */
   leftContent?: React.ReactNode;
-  /** Extra action buttons rendered to the left of the Settings gear. */
+  /** Extra action buttons rendered to the left of the update control. */
   rightActions?: React.ReactNode;
-  /** Settings menu trigger supplied by sidebar variants that expose it. */
-  settingsAction?: React.ReactNode;
 }
 
 const PRESENCE_ICON: Record<BuiltInPresenceMode, LucideIcon> = {
@@ -374,17 +367,14 @@ export const PresenceMenuButton: React.FC<PresenceMenuButtonProps> = ({
 };
 
 const SidebarBottomBar: React.FC<SidebarBottomBarProps> = React.memo(
-  ({ leftContent, rightActions, settingsAction }) => {
+  ({ leftContent, rightActions }) => {
     return (
       <div className="flex h-[52px] flex-shrink-0 items-center justify-between gap-2 px-3">
         <div className="flex min-w-0 flex-1 items-center gap-1">
           {leftContent}
         </div>
         <div className="flex items-center gap-1">
-          <div className="flex items-center gap-1">
-            {rightActions}
-            {settingsAction}
-          </div>
+          <div className="flex items-center gap-1">{rightActions}</div>
           <SidebarUpdateButton />
         </div>
       </div>

--- a/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.test.ts
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.test.ts
@@ -127,6 +127,47 @@ describe("SidebarSettingsMenuButton", () => {
     expect(setupButton).toBeUndefined();
   });
 
+  it("supports an account trigger with a signed-out login action", async () => {
+    const onSignIn = vi.fn();
+
+    await act(async () => {
+      root.render(
+        React.createElement(
+          Provider,
+          { store },
+          React.createElement(SidebarSettingsMenuButton, {
+            onSignIn,
+            renderTrigger: ({ isOpen, onClick }) =>
+              React.createElement(
+                "button",
+                {
+                  type: "button",
+                  onClick,
+                  "aria-expanded": isOpen,
+                  "data-testid": "account-menu-trigger",
+                },
+                "Account"
+              ),
+          })
+        )
+      );
+    });
+
+    const trigger = document.querySelector<HTMLButtonElement>(
+      '[data-testid="account-menu-trigger"]'
+    );
+    expect(trigger?.getAttribute("aria-expanded")).toBe("true");
+
+    const signIn = document.querySelector<HTMLButtonElement>(
+      '[data-testid="sidebar-menu-sign-in"]'
+    );
+    expect(signIn?.textContent).toBe("cloud.signIn");
+
+    act(() => signIn?.click());
+    expect(mocks.closeDropdown).toHaveBeenCalledOnce();
+    expect(onSignIn).toHaveBeenCalledOnce();
+  });
+
   it("moves the onboarding test panel into the Dev Mode menu list", () => {
     expect(
       document.querySelector('[data-testid="developer-test-panel-trigger"]')

--- a/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.tsx
@@ -7,6 +7,7 @@ import {
   Gauge,
   HelpCircle,
   Laptop,
+  LogIn,
   MessageCircle,
   MousePointer2,
   Settings,
@@ -66,6 +67,18 @@ const MENU_ICON_CLASS_NAME = "shrink-0 text-text-2";
 const MENU_ARROW_CLASS_NAME = "text-text-3";
 type SettingsUtilityPanel = "developerTests" | "ram";
 
+interface SidebarSettingsMenuTriggerProps {
+  isOpen: boolean;
+  onClick: () => void;
+}
+
+interface SidebarSettingsMenuButtonProps {
+  /** Replaces the compact gear trigger while preserving this menu's behavior. */
+  renderTrigger?: (props: SidebarSettingsMenuTriggerProps) => React.ReactNode;
+  /** Adds a login action when the account trigger represents a signed-out user. */
+  onSignIn?: () => void;
+}
+
 function getSubmenuPosition(
   trigger: HTMLElement,
   parentPanel: HTMLElement | null
@@ -84,7 +97,10 @@ function getSubmenuPosition(
   };
 }
 
-const SidebarSettingsMenuButton: React.FC = React.memo(() => {
+const SidebarSettingsMenuButton: React.FC<SidebarSettingsMenuButtonProps> = ({
+  renderTrigger,
+  onSignIn,
+}) => {
   const { t } = useTranslation("navigation");
   const { t: tSettings } = useTranslation("settings");
   const { goToSettings } = useAppNavigation();
@@ -125,7 +141,7 @@ const SidebarSettingsMenuButton: React.FC = React.memo(() => {
     panelPosition,
   } = useDropdownEngine<HTMLDivElement>({
     placement: "top",
-    align: "right",
+    align: renderTrigger ? "left" : "right",
     gap: DROPDOWN_PANEL.triggerGap,
     onOpenChange: handleSettingsMenuOpenChange,
     additionalInsideRefs: dropdownInsideRefs,
@@ -218,6 +234,11 @@ const SidebarSettingsMenuButton: React.FC = React.memo(() => {
     closeAll();
   }, [closeAll]);
 
+  const handleSignIn = useCallback(() => {
+    closeAll();
+    onSignIn?.();
+  }, [closeAll, onSignIn]);
+
   const handleOpenGuiControl = useCallback(() => {
     openAgentControlSpotlight();
     closeAll();
@@ -255,34 +276,42 @@ const SidebarSettingsMenuButton: React.FC = React.memo(() => {
 
   return (
     <>
-      <ToolbarTooltip
-        label={t("sidebar.bottomBar.settings")}
-        shortcut={openSettingsShortcut}
-        position="top"
-        disabled={isOpen}
-      >
-        <div ref={triggerRef} className="inline-flex">
-          <button
-            type="button"
-            aria-label={t("sidebar.bottomBar.settings")}
-            className={`flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-[100px] border-none p-0 transition-colors duration-150 ${
-              isOpen
-                ? "bg-sidebar-selected"
-                : "bg-transparent hover:bg-sidebar-selected"
-            }`}
-            onClick={handleToggle}
-            onMouseEnter={(event) => triggerIconAnimation(event.currentTarget)}
-          >
-            <HoverAnimatedIcon
-              icon={Settings}
-              iconName="settings"
-              size={16}
-              strokeWidth={2}
-              className={settingsButtonClassName}
-            />
-          </button>
+      {renderTrigger ? (
+        <div ref={triggerRef} className="flex min-w-0 flex-1">
+          {renderTrigger({ isOpen, onClick: handleToggle })}
         </div>
-      </ToolbarTooltip>
+      ) : (
+        <ToolbarTooltip
+          label={t("sidebar.bottomBar.settings")}
+          shortcut={openSettingsShortcut}
+          position="top"
+          disabled={isOpen}
+        >
+          <div ref={triggerRef} className="inline-flex">
+            <button
+              type="button"
+              aria-label={t("sidebar.bottomBar.settings")}
+              className={`flex h-[28px] w-[28px] cursor-pointer items-center justify-center rounded-[100px] border-none p-0 transition-colors duration-150 ${
+                isOpen
+                  ? "bg-sidebar-selected"
+                  : "bg-transparent hover:bg-sidebar-selected"
+              }`}
+              onClick={handleToggle}
+              onMouseEnter={(event) =>
+                triggerIconAnimation(event.currentTarget)
+              }
+            >
+              <HoverAnimatedIcon
+                icon={Settings}
+                iconName="settings"
+                size={16}
+                strokeWidth={2}
+                className={settingsButtonClassName}
+              />
+            </button>
+          </div>
+        </ToolbarTooltip>
+      )}
 
       {isOpen &&
         isPositioned &&
@@ -297,6 +326,25 @@ const SidebarSettingsMenuButton: React.FC = React.memo(() => {
             }}
           >
             <div className={DROPDOWN_CLASSES.itemsColumn}>
+              {onSignIn && (
+                <>
+                  <button
+                    type="button"
+                    className={`${DROPDOWN_CLASSES.menuActionItem} gap-2`}
+                    onMouseEnter={() => setActiveSubmenu(null)}
+                    onFocus={() => setActiveSubmenu(null)}
+                    onClick={handleSignIn}
+                    data-testid="sidebar-menu-sign-in"
+                  >
+                    <LogIn
+                      size={DROPDOWN_ITEM.iconSize}
+                      className={MENU_ICON_CLASS_NAME}
+                    />
+                    <span>{t("cloud.signIn")}</span>
+                  </button>
+                  <div className={DROPDOWN_CLASSES.menuSeparatorInset} />
+                </>
+              )}
               <button
                 type="button"
                 className={`${DROPDOWN_CLASSES.menuActionItem} justify-between`}
@@ -526,8 +574,8 @@ const SidebarSettingsMenuButton: React.FC = React.memo(() => {
         )}
     </>
   );
-});
+};
 
 SidebarSettingsMenuButton.displayName = "SidebarSettingsMenuButton";
 
-export default SidebarSettingsMenuButton;
+export default React.memo(SidebarSettingsMenuButton);

--- a/src/scaffold/NavigationSidebar/connectors/SidebarAccountButton.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/SidebarAccountButton.tsx
@@ -1,0 +1,66 @@
+import { LogIn } from "lucide-react";
+import React from "react";
+import { useTranslation } from "react-i18next";
+
+import Avatar from "@src/components/Avatar";
+
+interface SidebarAccountButtonProps {
+  /** Resolved cloud identity; `null` means the user is signed out. */
+  identity: string | null;
+  avatarUrl?: string;
+  menuOpen: boolean;
+  onClick: () => void;
+}
+
+const SidebarAccountButton: React.FC<SidebarAccountButtonProps> = React.memo(
+  ({ identity, avatarUrl, menuOpen, onClick }) => {
+    const { t } = useTranslation("navigation");
+    const signedIn = identity !== null;
+    const label = signedIn ? identity : t("cloud.signIn");
+
+    return (
+      <button
+        type="button"
+        className={`flex h-8 min-w-0 flex-1 items-center rounded-lg border-none px-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-6/40 ${
+          menuOpen
+            ? "bg-sidebar-selected"
+            : "bg-transparent hover:bg-sidebar-selected"
+        }`}
+        onClick={onClick}
+        aria-label={
+          signedIn ? t("cloud.signedInAs", { name: identity }) : label
+        }
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        title={label}
+        data-testid={
+          signedIn ? "sidebar-account-profile" : "sidebar-account-sign-in"
+        }
+      >
+        <span className="flex min-w-0 flex-1 items-center gap-3">
+          {signedIn ? (
+            <span className="inline-flex h-[14px] w-[14px] shrink-0 items-center justify-center overflow-visible">
+              <Avatar size={20} src={avatarUrl} gradientSeed={identity}>
+                {identity.slice(0, 1).toLocaleUpperCase()}
+              </Avatar>
+            </span>
+          ) : (
+            <LogIn
+              size={14}
+              strokeWidth={2}
+              className="shrink-0 text-text-1"
+              aria-hidden
+            />
+          )}
+          <span className="min-w-0 flex-1 truncate text-[13px] leading-4 text-text-1">
+            {label}
+          </span>
+        </span>
+      </button>
+    );
+  }
+);
+
+SidebarAccountButton.displayName = "SidebarAccountButton";
+
+export default SidebarAccountButton;

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
@@ -15,7 +15,6 @@ import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/compone
 import {
   activeSessionCreatorDraftIdAtom,
   deleteSessionCreatorDraftAtom,
-  loadSessionRoster,
   promoteActiveSessionCreatorDraftAtom,
   sessionCreatorDraftListAtom,
   sessionLoadingAtom,
@@ -49,9 +48,10 @@ import {
   sidebarCollapsedAtom,
 } from "@src/store/ui/sidebarAtom";
 
-import { SidebarBottomBar, SidebarMenuSearchInput } from "../../blocks";
+import { SidebarBottomBar } from "../../blocks";
 import SidebarSettingsMenuButton from "../../blocks/SidebarSettingsMenuButton";
 import NavigationSidebar from "../../variants/NavigationSidebar";
+import SidebarAccountButton from "../SidebarAccountButton";
 import SidebarGuideButton from "../SidebarGuideButton";
 import {
   SIDEBAR_GUIDE_MILESTONE,
@@ -84,10 +84,7 @@ import { resolveSidebarGuideOrganizationNavigation } from "./sidebarGuideOrganiz
 import { startSidebarGuideProductTour } from "./sidebarGuideProductTour";
 import { resolveSidebarGuideTeamUsageNavigation } from "./sidebarGuideTeamUsageNavigation";
 import { SidebarSearchShortcutTooltip } from "./sidebarTabs";
-import type {
-  WorkstationSidebarKey,
-  WorkstationSidebarSearchKey,
-} from "./types";
+import type { WorkstationSidebarKey } from "./types";
 import { useWorkspaceGroupActions } from "./useWorkspaceGroupActions";
 
 const logger = createLogger("WorkstationSidebarGuide");
@@ -182,15 +179,6 @@ export const WorkstationSidebarConnector: React.FC = () => {
     activeSidebarKey === "workstation" && workItemsOpen;
   const channelSidebarVisible =
     activeSidebarKey === "workstation" && channelsOpen;
-  const activeSidebarSearchKey: WorkstationSidebarSearchKey =
-    workItemsContentVisible
-      ? "projects"
-      : channelSidebarVisible
-        ? "channels"
-        : activeSidebarKey;
-  const [sidebarSearchQueries, setSidebarSearchQueries] = useState<
-    Record<WorkstationSidebarSearchKey, string>
-  >({ workstation: "", projects: "", channels: "" });
   const handleViewChange = useCallback((key: WorkstationSidebarViewKey) => {
     setActiveSidebarKey("workstation");
     setChannelsOpen(key === "channels");
@@ -202,19 +190,6 @@ export const WorkstationSidebarConnector: React.FC = () => {
       : channelSidebarVisible
         ? "channels"
         : "sessions";
-
-  const handleSidebarSearchChange = useCallback(
-    (value: string) => {
-      setSidebarSearchQueries((currentQueries) => ({
-        ...currentQueries,
-        [activeSidebarSearchKey]: value,
-      }));
-      if (activeSidebarSearchKey === "workstation") {
-        void loadSessionRoster();
-      }
-    },
-    [activeSidebarSearchKey]
-  );
 
   const {
     sortedSessions,
@@ -239,12 +214,10 @@ export const WorkstationSidebarConnector: React.FC = () => {
     cloudMySessionsVisibleCount,
     setCloudMyPagination,
     resetCloudMyPagination,
+    cloudSignedInAvatarUrl,
     cloudSignedInIdentity,
     handleCloudSignIn,
-  } = useWorkstationSidebarScopeAndPagination({
-    sessions,
-    workstationSearchQuery: sidebarSearchQueries.workstation,
-  });
+  } = useWorkstationSidebarScopeAndPagination({ sessions });
   const guideCloudOrg = useMemo(
     () =>
       resolveSetupGuideDevCloudOrg(
@@ -296,8 +269,6 @@ export const WorkstationSidebarConnector: React.FC = () => {
     revealWorkspaceLabel,
     workspaceUnavailableTitle,
     workspaceUnavailableMessage,
-    searchPlaceholder,
-    noSearchResultsTitle,
   } = buildWorkstationSidebarLabels({ t, tProjects, tSessions, tCommon });
 
   // Same entry point as the sidebar's own "+ New session", so a workspace
@@ -402,7 +373,6 @@ export const WorkstationSidebarConnector: React.FC = () => {
     repoPathToName,
     groupByMode,
     untitledSession,
-    workstationSearchQuery: sidebarSearchQueries.workstation,
     sessionFilterOrgIds,
     cloudScopedExtraSessionIds,
     sessionListExcludedIds,
@@ -415,7 +385,6 @@ export const WorkstationSidebarConnector: React.FC = () => {
     activeSidebarKey,
     workItemsContentVisible,
     projectsGroupVisibleCounts,
-    projectsSearchQuery: sidebarSearchQueries.projects,
     activeProjectOrgId,
   });
 
@@ -451,7 +420,6 @@ export const WorkstationSidebarConnector: React.FC = () => {
     setWorkItemsOpen,
     setChannelsOpen,
     setSelectedOrgId,
-    setSidebarSearchQueries,
     setExpandedSubagentParentIds,
     activeSessionSidebarRevealRequest,
     revealCandidateMenuItems,
@@ -834,26 +802,22 @@ export const WorkstationSidebarConnector: React.FC = () => {
             searchLabel={tCommon("actions.search")}
           />
         }
-        search={{
-          value: sidebarSearchQueries[activeSidebarSearchKey],
-          filterValue:
-            activeSidebarSearchKey === "workstation"
-              ? ""
-              : sidebarSearchQueries[activeSidebarSearchKey],
-          onChange: handleSidebarSearchChange,
-          placeholder: searchPlaceholder,
-          noResultsTitle: noSearchResultsTitle,
-          showInput: false,
-        }}
         listTopPadding
         bottomContent={
           <SidebarBottomBar
             leftContent={
-              <SidebarMenuSearchInput
-                value={sidebarSearchQueries[activeSidebarSearchKey]}
-                onChange={handleSidebarSearchChange}
-                placeholder={searchPlaceholder}
-                compact
+              <SidebarSettingsMenuButton
+                onSignIn={
+                  cloudSignedInIdentity === null ? handleCloudSignIn : undefined
+                }
+                renderTrigger={({ isOpen, onClick }) => (
+                  <SidebarAccountButton
+                    identity={cloudSignedInIdentity}
+                    avatarUrl={cloudSignedInAvatarUrl}
+                    menuOpen={isOpen}
+                    onClick={onClick}
+                  />
+                )}
               />
             }
             rightActions={
@@ -872,7 +836,6 @@ export const WorkstationSidebarConnector: React.FC = () => {
                 {sidebarBottomRightActions}
               </>
             }
-            settingsAction={<SidebarSettingsMenuButton />}
           />
         }
         isLoading={isLoading}

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.labels.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.labels.ts
@@ -56,9 +56,6 @@ export function buildWorkstationSidebarLabels({
   const workspaceUnavailableMessage = tSessions(
     "chat.workspaceUnavailableMessage"
   );
-  const searchPlaceholder = tCommon("common.searchPlaceholder", "Search...");
-  const noSearchResultsTitle = t("sidebar.empty.noSearchResults");
-
   return {
     untitledSession,
     newSessionLabel,
@@ -80,7 +77,5 @@ export function buildWorkstationSidebarLabels({
     revealWorkspaceLabel,
     workspaceUnavailableTitle,
     workspaceUnavailableMessage,
-    searchPlaceholder,
-    noSearchResultsTitle,
   };
 }

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.revealNavigationEffects.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.revealNavigationEffects.ts
@@ -2,8 +2,8 @@
  * Reveal-navigation side effects for `WorkstationSidebarConnector`
  * (`index.tsx`): when a cross-surface "reveal this session" request lands,
  * un-collapses the sidebar, switches to the Workstation layer, selects the
- * request's cloud org, clears any active search, expands the parent
- * subagent group, and hydrates the target row(s). Separately, once the
+ * request's cloud org, expands the parent subagent group, and hydrates the
+ * target row(s). Separately, once the
  * revealed row's containing section is known (via `revealCandidateMenuItems`),
  * un-collapses that section too.
  */
@@ -17,10 +17,7 @@ import { loadSidebarSessionById } from "@src/store/session";
 import type { SessionSidebarRevealRequest } from "@src/store/ui/sidebarAtom";
 
 import { findSidebarSectionIdForMenuItem } from "../workstationSidebarData";
-import type {
-  WorkstationSidebarKey,
-  WorkstationSidebarSearchKey,
-} from "./types";
+import type { WorkstationSidebarKey } from "./types";
 import { buildCloudOrgSelectorValue } from "./useSidebarOrgScope";
 
 const logger = createLogger("WorkstationSidebar");
@@ -34,11 +31,6 @@ interface UseWorkstationSidebarRevealNavigationEffectsParams {
   setSelectedOrgId: ReturnType<
     typeof useSetAtom<typeof sidebarSelectedOrgIdAtom>
   >;
-  setSidebarSearchQueries: (
-    updater: (
-      currentQueries: Record<WorkstationSidebarSearchKey, string>
-    ) => Record<WorkstationSidebarSearchKey, string>
-  ) => void;
   setExpandedSubagentParentIds: (
     updater: (previousIds: Set<string>) => Set<string>
   ) => void;
@@ -56,7 +48,6 @@ export function useWorkstationSidebarRevealNavigationEffects({
   setWorkItemsOpen,
   setChannelsOpen,
   setSelectedOrgId,
-  setSidebarSearchQueries,
   setExpandedSubagentParentIds,
   activeSessionSidebarRevealRequest,
   revealCandidateMenuItems,
@@ -78,11 +69,6 @@ export function useWorkstationSidebarRevealNavigationEffects({
           buildCloudOrgSelectorValue(sessionSidebarRevealRequest.cloudOrgId)
         );
       }
-      setSidebarSearchQueries((currentQueries) =>
-        currentQueries.workstation
-          ? { ...currentQueries, workstation: "" }
-          : currentQueries
-      );
       if (sessionSidebarRevealRequest.parentSessionId) {
         setExpandedSubagentParentIds((previousIds) => {
           if (previousIds.has(parentSessionId)) return previousIds;
@@ -122,7 +108,6 @@ export function useWorkstationSidebarRevealNavigationEffects({
     setExpandedSubagentParentIds,
     setSelectedOrgId,
     setSidebarCollapsed,
-    setSidebarSearchQueries,
     setWorkItemsOpen,
   ]);
 

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.scopeAndPagination.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.scopeAndPagination.ts
@@ -35,12 +35,10 @@ const logger = createLogger("WorkstationSidebar");
 
 interface UseWorkstationSidebarScopeAndPaginationParams {
   sessions: Session[];
-  workstationSearchQuery: string;
 }
 
 export function useWorkstationSidebarScopeAndPagination({
   sessions,
-  workstationSearchQuery,
 }: UseWorkstationSidebarScopeAndPaginationParams) {
   useSidebarSessionRefreshEffects();
 
@@ -73,7 +71,6 @@ export function useWorkstationSidebarScopeAndPagination({
   const cloudMyPaginationScopeKey = activeCloudOrgId
     ? [
         activeCloudOrgId,
-        workstationSearchQuery,
         groupByMode,
         includeExternal ? "external" : "native",
       ].join("\u001f")
@@ -97,6 +94,7 @@ export function useWorkstationSidebarScopeAndPagination({
       cloudAuth.profile?.primaryEmail ??
       cloudAuth.userId)
     : null;
+  const cloudSignedInAvatarUrl = cloudAuth?.profile?.avatarUrl;
   const handleCloudSignIn = useCallback(() => {
     openUrl(buildOrg2CloudLoginUrl()).catch((error: unknown) => {
       logger.error("failed to open ORG2 Cloud login in system browser", error);
@@ -126,6 +124,7 @@ export function useWorkstationSidebarScopeAndPagination({
     cloudMySessionsVisibleCount,
     setCloudMyPagination,
     resetCloudMyPagination,
+    cloudSignedInAvatarUrl,
     cloudSignedInIdentity,
     handleCloudSignIn,
   };

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.sessionAndProjectMenuItems.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.sessionAndProjectMenuItems.ts
@@ -20,7 +20,6 @@ interface UseWorkstationSidebarSessionAndProjectMenuItemsParams {
   repoPathToName: SessionMenuItemsParams["repoPathToName"];
   groupByMode: SessionMenuItemsParams["groupByMode"];
   untitledSession: SessionMenuItemsParams["untitledSession"];
-  workstationSearchQuery: string;
   sessionFilterOrgIds: SessionMenuItemsParams["selectedOrgIds"];
   cloudScopedExtraSessionIds: SessionMenuItemsParams["extraSessionIds"];
   sessionListExcludedIds: SessionMenuItemsParams["excludedSessionIds"];
@@ -33,7 +32,6 @@ interface UseWorkstationSidebarSessionAndProjectMenuItemsParams {
   activeSidebarKey: WorkstationSidebarKey;
   workItemsContentVisible: boolean;
   projectsGroupVisibleCounts: ProjectsWorkItemMenuItemsParams["groupVisibleCounts"];
-  projectsSearchQuery: string;
   activeProjectOrgId: ProjectsWorkItemMenuItemsParams["selectedOrgId"];
 }
 
@@ -43,7 +41,6 @@ export function useWorkstationSidebarSessionAndProjectMenuItems({
   repoPathToName,
   groupByMode,
   untitledSession,
-  workstationSearchQuery,
   sessionFilterOrgIds,
   cloudScopedExtraSessionIds,
   sessionListExcludedIds,
@@ -56,7 +53,6 @@ export function useWorkstationSidebarSessionAndProjectMenuItems({
   activeSidebarKey,
   workItemsContentVisible,
   projectsGroupVisibleCounts,
-  projectsSearchQuery,
   activeProjectOrgId,
 }: UseWorkstationSidebarSessionAndProjectMenuItemsParams) {
   const {
@@ -71,7 +67,7 @@ export function useWorkstationSidebarSessionAndProjectMenuItems({
     repoPathToName,
     groupByMode,
     untitledSession,
-    searchQuery: workstationSearchQuery,
+    searchQuery: "",
     selectedOrgIds: sessionFilterOrgIds,
     extraSessionIds: cloudScopedExtraSessionIds,
     excludedSessionIds: sessionListExcludedIds,
@@ -100,7 +96,7 @@ export function useWorkstationSidebarSessionAndProjectMenuItems({
   } = useProjectsWorkItemMenuItems({
     enabled: activeSidebarKey === "projects" || workItemsContentVisible,
     groupVisibleCounts: projectsGroupVisibleCounts,
-    searchQuery: projectsSearchQuery,
+    searchQuery: "",
     selectedOrgId: activeProjectOrgId,
   });
 

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/types.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/types.ts
@@ -1,3 +1,1 @@
 export type WorkstationSidebarKey = "workstation" | "projects";
-
-export type WorkstationSidebarSearchKey = WorkstationSidebarKey | "channels";

--- a/src/scaffold/NavigationSidebar/connectors/__tests__/SidebarAccountButton.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/__tests__/SidebarAccountButton.test.ts
@@ -1,0 +1,53 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import SidebarAccountButton from "../SidebarAccountButton";
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { name?: string }) =>
+      options?.name ? `${key}:${options.name}` : key,
+  }),
+}));
+
+describe("SidebarAccountButton", () => {
+  it("shows the signed-in avatar and identity with text-1 styling", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(SidebarAccountButton, {
+        identity: "Ada Lovelace",
+        avatarUrl: "https://example.com/ada.png",
+        menuOpen: true,
+        onClick: vi.fn(),
+      })
+    );
+
+    expect(markup).toContain('data-testid="sidebar-account-profile"');
+    expect(markup).toContain('src="https://example.com/ada.png"');
+    expect(markup).toContain("Ada Lovelace");
+    expect(markup).toContain("text-text-1");
+    expect(markup).toContain("gap-3");
+    expect(markup).toContain("h-[14px] w-[14px]");
+    expect(markup).toContain("width:20px");
+    expect(markup).toContain(
+      'class="min-w-0 flex-1 truncate text-[13px] leading-4 text-text-1"'
+    );
+    expect(markup).toContain('aria-expanded="true"');
+  });
+
+  it("shows the sign-in action without an identity", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(SidebarAccountButton, {
+        identity: null,
+        menuOpen: false,
+        onClick: vi.fn(),
+      })
+    );
+
+    expect(markup).toContain('data-testid="sidebar-account-sign-in"');
+    expect(markup).toContain("cloud.signIn");
+    expect(markup).toContain('width="14"');
+    expect(markup).toContain("gap-3");
+    expect(markup).not.toContain("sidebar-account-profile");
+  });
+});


### PR DESCRIPTION
## Problem

The workstation sidebar footer used a compact search control on the left and a separate Settings gear on the right, while the signed-in identity was absent. This duplicated footer controls, left inactive search-state plumbing in several sidebar coordinators, and made the account affordance visually inconsistent with navigation rows.

## Solution

Replace the footer search control with a single account row that shows the cloud avatar and `text-1` identity, or Login when signed out. The account row now triggers the existing settings dropdown, so the standalone gear is removed without losing settings, Dev Mode, appearance, presence, or login actions. Remove the obsolete footer-search state and filter plumbing. Fallback initials use a deterministic identity-based gradient and an absolutely centered label; the 20px avatar remains centered on the navigation icon column. Uploaded avatar images are unchanged.

## Potential risks

The footer-local search entry is removed, so users must use the existing sidebar/global search action instead. The account-triggered menu is left-aligned and could expose viewport-specific positioning regressions; dropdown engine coverage and sidebar tests pass, but no desktop screenshot was captured. There are no persistence, schema, dependency, public API, IPC, or wire-format changes, so rollback is a normal commit revert.

## Verification

- `npx eslint <13 changed TypeScript files>` — passed with no findings
- `npx vitest run src/components/Avatar/index.test.ts src/scaffold/NavigationSidebar` — 42 files passed, 220 tests passed
- `npm run typecheck` — passed
- `npx prettier --check <13 changed files>` — passed
- `git diff --check` — passed
- Repository pre-commit hook — lint-staged, scoped TypeScript, and circular-dependency gates passed
- Final diff inspection — 13 sidebar/avatar files only; no secrets, personal paths, generated artifacts, dependency changes, or unrelated edits

Desktop visual evidence was not captured because this workspace explicitly requires user opt-in for Computer Use, which was not authorized. DOM tests verify the 20px avatar, 14px aligned icon slot, centered fallback label, `text-1` identity, signed-out Login action, and dropdown trigger state.

## Audit

The repository references `frontend-ui-audit`, but that skill is not present. A manual UI-consistency pass confirmed shared Avatar and dropdown primitives, standard sidebar row geometry, native button semantics, accessible menu state, and no new arbitrary Tailwind color values.