### PR TITLE
feat(cli-agents): add DeepSeek Harness support

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Use ORG-II's built-in Rust harness or launch these supported coding-agent CLIs f
   <a href="https://kiro.dev/docs/cli/installation"><kbd><img src="src/assets/modelIcons/kiro.svg" alt="Kiro CLI logo" width="16" valign="middle" /> Kiro CLI</kbd></a> &nbsp;
   <a href="https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-in-the-cli"><kbd><img src="src/assets/modelIcons/copilot.svg" alt="GitHub Copilot logo" width="16" valign="middle" /> GitHub Copilot</kbd></a> &nbsp;
   <a href="https://opencode.ai/docs/config/"><kbd><img src="src/assets/modelIcons/opencode.svg" alt="OpenCode logo" width="16" valign="middle" /> OpenCode</kbd></a> &nbsp;
+  <a href="https://github.com/deepseek-ai/deepseek-harness"><kbd><img src="src/assets/modelIcons/deepseek.svg" alt="DeepSeek Harness logo" width="16" valign="middle" /> DeepSeek Harness</kbd></a> &nbsp;
   <a href="https://antigravity.google/docs/cli/getting-started"><kbd><img src="src/assets/modelIcons/antigravity.svg" alt="Antigravity logo" width="16" valign="middle" /> Antigravity</kbd></a>
 </p>
 

--- a/src-tauri/crates/agent-cli/src/managed_config/registry.rs
+++ b/src-tauri/crates/agent-cli/src/managed_config/registry.rs
@@ -384,6 +384,10 @@ const MANAGED_CONFIG_UNAVAILABLE: &[(&str, &str)] = &[
         "trae_cli",
         "Trae Agent is configured per-invocation and exposes no stable persisted config file for managed switching",
     ),
+    (
+        "deepseek_harness",
+        "DeepSeek Harness owns provider and model selection inside its profile settings; ORGII does not rewrite those profiles",
+    ),
 ];
 
 const fn managed_target(

--- a/src-tauri/crates/agent-core/src/core/providers/factory.rs
+++ b/src-tauri/crates/agent-core/src/core/providers/factory.rs
@@ -358,7 +358,8 @@ fn spec_for_model_type(model_type: &ModelType) -> Option<&'static ProviderSpec> 
         | ModelType::Omp
         | ModelType::Pi
         | ModelType::QoderCli
-        | ModelType::TraeCli => return None,
+        | ModelType::TraeCli
+        | ModelType::DeepseekHarness => return None,
     };
     registry::find_by_name(provider_name)
 }

--- a/src-tauri/crates/integrations/src/cli_binary_resolver.rs
+++ b/src-tauri/crates/integrations/src/cli_binary_resolver.rs
@@ -44,6 +44,7 @@ pub enum CliBinaryId {
     Pi,
     QoderCli,
     TraeCli,
+    DeepseekHarness,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -310,6 +311,13 @@ const CLI_BINARY_METADATA: &[CliBinaryMetadata] = &[
         command: "trae-cli",
         launchable: true,
     },
+    CliBinaryMetadata {
+        id: CliBinaryId::DeepseekHarness,
+        row_id: "deepseek-harness",
+        display_name: "DeepSeek Harness",
+        command: "dsh",
+        launchable: true,
+    },
 ];
 
 pub fn all_cli_binary_metadata() -> &'static [CliBinaryMetadata] {
@@ -361,6 +369,7 @@ pub fn id_for_registry_name(name: &str) -> Option<CliBinaryId> {
         "pi" => Some(CliBinaryId::Pi),
         "qoder_cli" => Some(CliBinaryId::QoderCli),
         "trae_cli" => Some(CliBinaryId::TraeCli),
+        "deepseek_harness" => Some(CliBinaryId::DeepseekHarness),
         _ => None,
     }
 }
@@ -900,9 +909,10 @@ mod tests {
     }
 
     #[test]
-    fn qoder_and_trae_use_their_published_executable_names() {
+    fn recent_cli_agents_use_their_published_executable_names() {
         assert_eq!(metadata_for_id(CliBinaryId::QoderCli).command, "qodercli");
         assert_eq!(metadata_for_id(CliBinaryId::TraeCli).command, "trae-cli");
+        assert_eq!(metadata_for_id(CliBinaryId::DeepseekHarness).command, "dsh");
     }
 
     #[test]

--- a/src-tauri/crates/key-vault/src/commands/registry/data/cli_agents.rs
+++ b/src-tauri/crates/key-vault/src/commands/registry/data/cli_agents.rs
@@ -795,6 +795,46 @@ pub(crate) fn cli_agent_registry() -> Vec<CliAgentEntry> {
             acp_support: AcpSupport::Unavailable,
             supports_gui: false,
         },
+        CliAgentEntry {
+            name: "deepseek_harness",
+            display_name: "DeepSeek Harness",
+            binary: "dsh",
+            description: "DeepSeek's open-source agent harness for coding workflows",
+            brand_color: "#4D6BFE",
+            docs_url: "https://github.com/deepseek-ai/deepseek-harness",
+            has_subscription_plan: false,
+            // The shipped base profile reads the official DeepSeek credential
+            // from DEEPSEEK_API_KEY. Provider/model selection itself remains in
+            // DSH settings, so only the credential pairing is advertised here.
+            compatible_api_providers: &["deepseek_api"],
+            config_files: vec![
+                home_config(
+                    "settings",
+                    "Settings",
+                    ".dsh/settings.yaml",
+                    CliConfigFormat::Yaml,
+                    false,
+                ),
+                home_config(
+                    "credentials",
+                    "Credentials",
+                    ".dsh/.credentials.yaml",
+                    CliConfigFormat::Yaml,
+                    true,
+                ),
+            ],
+            // The official headless profile auto-initializes; a DeepSeek API
+            // key is sufficient for GUI use. Optional TUI profiles remain an
+            // explicit plugin setup outside the credential wizard.
+            is_complex_setup: false,
+            default_setup_method: None,
+            popular: false,
+            icon_provider: "deepseek",
+            paired_api_provider: Some("deepseek_api"),
+            supports_rust_agents: false,
+            acp_support: AcpSupport::Unavailable,
+            supports_gui: true,
+        },
     ]
 }
 
@@ -844,5 +884,29 @@ mod tests {
         assert_eq!(trae.binary, "trae-cli");
         assert!(!qoder.supports_gui);
         assert!(!trae.supports_gui);
+    }
+
+    #[test]
+    fn deepseek_harness_supports_headless_gui_launches() {
+        let agents = cli_agent_registry();
+        let harness = agents
+            .iter()
+            .find(|entry| entry.name == "deepseek_harness")
+            .expect("DeepSeek Harness registry entry");
+
+        assert_eq!(harness.binary, "dsh");
+        assert!(harness.supports_gui);
+        assert!(!harness.is_complex_setup);
+        assert!(matches!(harness.acp_support, AcpSupport::Unavailable));
+        assert_eq!(harness.compatible_api_providers, &["deepseek_api"]);
+        assert_eq!(harness.paired_api_provider, Some("deepseek_api"));
+        assert_eq!(
+            harness
+                .config_files
+                .iter()
+                .map(|entry| entry.relative_path)
+                .collect::<Vec<_>>(),
+            vec![".dsh/settings.yaml", ".dsh/.credentials.yaml"]
+        );
     }
 }

--- a/src-tauri/crates/key-vault/src/commands/registry/data/env_config.rs
+++ b/src-tauri/crates/key-vault/src/commands/registry/data/env_config.rs
@@ -156,13 +156,18 @@ pub(crate) fn cli_env_config(name: &str) -> Option<AgentEnvConfig> {
             // MiMo's hosted Anthropic-compatible endpoint.
             Some("https://api.xiaomimimo.com/anthropic"),
         )),
+        "deepseek_harness" => Some(cfg(
+            "DEEPSEEK_API_KEY",
+            Some("DEEPSEEK_BASE_URL"),
+            true,
+            "codeAccounts.apiKeyPlaceholder.deepseek_harness",
+            Some("https://api.deepseek.com"),
+        )),
         // Agents without a single universal API-key env var for ORGII to inject.
         // Some are subscription-token based, while others require provider-specific
         // config files or auth stores instead of one standard env-config path.
         "aug" | "droid" | "autohand" | "omp" | "pi" | "open_claw" | "openclaw" | "antigravity"
-        | "opencode" | "qoder_cli" | "trae_cli" => {
-            None
-        }
+        | "opencode" | "qoder_cli" | "trae_cli" => None,
         // The caller iterates `cli_agent_registry()` entries, so a CLI
         // agent that ships in the registry but has no env config here
         // would silently let the API-key dialog render with no env-var

--- a/src-tauri/crates/key-vault/src/commands/registry/data/install_methods.rs
+++ b/src-tauri/crates/key-vault/src/commands/registry/data/install_methods.rs
@@ -220,6 +220,11 @@ pub(crate) fn cli_install_methods(name: &str) -> Vec<CliInstallMethod> {
                 "curl -fsSL https://qoder.com/install.cmd -o install.cmd && install.cmd",
             ),
         ],
+        "deepseek_harness" => vec![m(
+            "npm",
+            "npm",
+            "npm install -g @deepseek-ai/dsh",
+        )],
         // Trae Agent currently documents a repository checkout plus `uv sync`,
         // not a safe global install command for the registry to execute.
         "trae_cli" => Vec::new(),
@@ -316,6 +321,7 @@ pub(crate) fn cli_uninstall_methods(name: &str) -> Vec<CliInstallMethod> {
             "npm",
             "npm uninstall -g @earendil-works/pi-coding-agent",
         )],
+        "deepseek_harness" => vec![m("npm", "npm", "npm uninstall -g @deepseek-ai/dsh")],
         // Neither project currently documents a non-destructive uninstall
         // command that the registry can safely run on every supported OS.
         "opencode" | "qoder_cli" | "trae_cli" => Vec::new(),
@@ -441,5 +447,17 @@ mod tests {
     #[test]
     fn trae_cli_does_not_offer_an_undocumented_installer() {
         assert!(cli_install_methods("trae_cli").is_empty());
+    }
+
+    #[test]
+    fn deepseek_harness_uses_the_official_npm_package() {
+        assert_eq!(
+            cli_install_methods("deepseek_harness")[0].command,
+            "npm install -g @deepseek-ai/dsh"
+        );
+        assert_eq!(
+            cli_uninstall_methods("deepseek_harness")[0].command,
+            "npm uninstall -g @deepseek-ai/dsh"
+        );
     }
 }

--- a/src-tauri/crates/key-vault/src/key_store/agent_env_builder.rs
+++ b/src-tauri/crates/key-vault/src/key_store/agent_env_builder.rs
@@ -346,6 +346,14 @@ impl KeyService {
                     env.insert("OPENCODE_BASE_URL".to_string(), url.clone());
                 }
             }
+            ModelType::DeepseekHarness => {
+                if let Some(ref key) = entry.api_key {
+                    env.insert("DEEPSEEK_API_KEY".to_string(), key.clone());
+                }
+                if let Some(ref url) = entry.base_url {
+                    env.insert("DEEPSEEK_BASE_URL".to_string(), url.clone());
+                }
+            }
             // Extended CLI agents — api_key available under ORGII_API_KEY if set.
             ModelType::Aider
             | ModelType::Goose
@@ -516,6 +524,10 @@ impl KeyService {
             ModelType::OpenCode => {
                 // OpenCode uses its own config for provider credentials.
                 // Proxy token is available via ORGII_PROXY_TOKEN (set above).
+            }
+            ModelType::DeepseekHarness => {
+                env.insert("DEEPSEEK_API_KEY".to_string(), proxy_token.to_string());
+                env.insert("DEEPSEEK_BASE_URL".to_string(), proxy_url.to_string());
             }
             // Extended CLI agents — proxy token available via ORGII_PROXY_TOKEN.
             ModelType::Aider

--- a/src-tauri/crates/key-vault/src/key_store/tests/model_type_tests.rs
+++ b/src-tauri/crates/key-vault/src/key_store/tests/model_type_tests.rs
@@ -19,6 +19,7 @@ fn cli_agents_are_cli_agents() {
         ModelType::OpenCode,
         ModelType::QoderCli,
         ModelType::TraeCli,
+        ModelType::DeepseekHarness,
     ];
     for t in &cli_types {
         assert!(t.is_cli_agent(), "{:?} should be a CLI agent", t);
@@ -127,6 +128,7 @@ fn as_str_round_trips_through_from_str() {
         ModelType::OpenCode,
         ModelType::QoderCli,
         ModelType::TraeCli,
+        ModelType::DeepseekHarness,
         ModelType::AnthropicApi,
         ModelType::OpenaiApi,
         ModelType::AtlascloudApi,

--- a/src-tauri/crates/key-vault/src/key_store/tests/tests.rs
+++ b/src-tauri/crates/key-vault/src/key_store/tests/tests.rs
@@ -660,6 +660,46 @@ fn test_proxy_env_kiro() {
 }
 
 #[test]
+fn test_deepseek_harness_uses_deepseek_credentials() {
+    let temp_dir = tempdir().unwrap();
+    let service = KeyService::new(Some(temp_dir.path().to_path_buf()));
+    let mut key = ModelKey::new(ModelType::DeepseekApi);
+    key.api_key = Some("sk-deepseek-test".to_string());
+    key.base_url = Some("https://api.deepseek.example".to_string());
+    key.enabled = true;
+    let key_id = key.id.clone();
+    service.save_key(key).unwrap();
+
+    let env = service.get_env_for_agent(&ModelType::DeepseekHarness, Some(&key_id));
+    assert_eq!(
+        env.get("DEEPSEEK_API_KEY").map(String::as_str),
+        Some("sk-deepseek-test")
+    );
+    assert_eq!(
+        env.get("DEEPSEEK_BASE_URL").map(String::as_str),
+        Some("https://api.deepseek.example")
+    );
+}
+
+#[test]
+fn test_proxy_env_deepseek_harness() {
+    let env = KeyService::get_proxy_env_for_agent(
+        &ModelType::DeepseekHarness,
+        PROXY_TEST_TOKEN,
+        PROXY_TEST_URL,
+    );
+    assert_common_proxy_env(&env);
+    assert_eq!(
+        env.get("DEEPSEEK_API_KEY").map(String::as_str),
+        Some(PROXY_TEST_TOKEN)
+    );
+    assert_eq!(
+        env.get("DEEPSEEK_BASE_URL").map(String::as_str),
+        Some(PROXY_TEST_URL)
+    );
+}
+
+#[test]
 fn test_proxy_env_anthropic_api() {
     let env = KeyService::get_proxy_env_for_agent(
         &ModelType::AnthropicApi,

--- a/src-tauri/crates/key-vault/src/key_store/types.rs
+++ b/src-tauri/crates/key-vault/src/key_store/types.rs
@@ -108,6 +108,7 @@ pub enum ModelType {
     Pi,
     QoderCli,
     TraeCli,
+    DeepseekHarness,
     // Direct API key providers
     AnthropicApi,
     OpenaiApi,
@@ -176,6 +177,7 @@ impl ModelType {
             ModelType::Pi => "pi",
             ModelType::QoderCli => "qoder_cli",
             ModelType::TraeCli => "trae_cli",
+            ModelType::DeepseekHarness => "deepseek_harness",
             // API key providers
             ModelType::AnthropicApi => "anthropic_api",
             ModelType::OpenaiApi => "openai_api",
@@ -238,6 +240,7 @@ impl ModelType {
             "pi" => Some(ModelType::Pi),
             "qoder_cli" | "qodercli" => Some(ModelType::QoderCli),
             "trae_cli" | "trae-agent" => Some(ModelType::TraeCli),
+            "deepseek_harness" | "dsh" => Some(ModelType::DeepseekHarness),
             // API key providers
             "anthropic_api" | "anthropic" => Some(ModelType::AnthropicApi),
             "openai_api" | "openai" => Some(ModelType::OpenaiApi),
@@ -306,6 +309,7 @@ impl ModelType {
                 | ModelType::Pi
                 | ModelType::QoderCli
                 | ModelType::TraeCli
+                | ModelType::DeepseekHarness
         )
     }
 

--- a/src-tauri/src/agent_sessions/cli/parsers/mod.rs
+++ b/src-tauri/src/agent_sessions/cli/parsers/mod.rs
@@ -34,7 +34,6 @@ pub mod types;
 
 // Per-agent parsers
 pub mod acp_common;
-pub mod antigravity;
 pub mod claude_code;
 pub mod codex;
 pub mod codex_app_server;
@@ -42,6 +41,7 @@ pub mod copilot;
 pub mod cursor;
 pub mod kiro;
 pub mod opencode;
+pub mod plain_text;
 
 #[cfg(test)]
 #[path = "tests/parser_integration_tests.rs"]

--- a/src-tauri/src/agent_sessions/cli/parsers/normalizer.rs
+++ b/src-tauri/src/agent_sessions/cli/parsers/normalizer.rs
@@ -81,7 +81,8 @@ pub fn normalize_tool_name(agent: CliAgentType, raw_name: &str) -> String {
         | CliAgentType::Omp
         | CliAgentType::Pi
         | CliAgentType::QoderCli
-        | CliAgentType::TraeCli => return raw_name.to_string(),
+        | CliAgentType::TraeCli
+        | CliAgentType::DeepseekHarness => return raw_name.to_string(),
     };
 
     map.get(raw_name)

--- a/src-tauri/src/agent_sessions/cli/parsers/plain_text.rs
+++ b/src-tauri/src/agent_sessions/cli/parsers/plain_text.rs
@@ -1,21 +1,21 @@
-//! Antigravity CLI `--print` output parser.
+//! Plain-text CLI output parser.
 //!
-//! Antigravity's non-interactive mode writes the final assistant response as
-//! plain text. It does not expose Gemini CLI's former `stream-json` protocol,
-//! so buffer stdout and emit one complete assistant chunk when the process
-//! exits.
+//! Some non-interactive harness profiles, including Antigravity `--print` and
+//! DeepSeek Harness `--profile headless`, write only the final assistant
+//! response to stdout. Buffer it and emit one complete assistant chunk when
+//! the process exits.
 
 use core_types::activity::ActivityChunk;
 
 use super::types::TokenUsage;
 use super::CliAgentParser;
 
-pub struct AntigravityParser {
+pub struct PlainTextParser {
     session_id: String,
     output: String,
 }
 
-impl AntigravityParser {
+impl PlainTextParser {
     pub fn new(session_id: &str) -> Self {
         Self {
             session_id: session_id.to_string(),
@@ -24,7 +24,7 @@ impl AntigravityParser {
     }
 }
 
-impl CliAgentParser for AntigravityParser {
+impl CliAgentParser for PlainTextParser {
     fn parse_line(&mut self, line: &str) -> Vec<ActivityChunk> {
         if !self.output.is_empty() {
             self.output.push('\n');
@@ -68,7 +68,7 @@ mod tests {
 
     #[test]
     fn buffers_plain_text_until_exit() {
-        let mut parser = AntigravityParser::new("session-1");
+        let mut parser = PlainTextParser::new("session-1");
         assert!(parser.parse_line("First line").is_empty());
         assert!(parser.parse_line("Second line").is_empty());
 

--- a/src-tauri/src/agent_sessions/cli/parsers/tests/types_tests.rs
+++ b/src-tauri/src/agent_sessions/cli/parsers/tests/types_tests.rs
@@ -74,6 +74,7 @@ fn cli_agent_type_parse_roundtrip() {
         CliAgentType::Copilot,
         CliAgentType::QoderCli,
         CliAgentType::TraeCli,
+        CliAgentType::DeepseekHarness,
     ] {
         assert_eq!(
             CliAgentType::parse(platform.as_str()),

--- a/src-tauri/src/agent_sessions/cli/parsers/types.rs
+++ b/src-tauri/src/agent_sessions/cli/parsers/types.rs
@@ -44,6 +44,7 @@ pub enum CliAgentType {
     Pi,
     QoderCli,
     TraeCli,
+    DeepseekHarness,
 }
 
 impl CliAgentType {
@@ -79,6 +80,7 @@ impl CliAgentType {
             Self::Pi => "pi",
             Self::QoderCli => "qoder_cli",
             Self::TraeCli => "trae_cli",
+            Self::DeepseekHarness => "deepseek_harness",
         }
     }
 
@@ -114,6 +116,7 @@ impl CliAgentType {
             "pi" => Some(Self::Pi),
             "qoder_cli" | "qodercli" => Some(Self::QoderCli),
             "trae_cli" | "trae-agent" => Some(Self::TraeCli),
+            "deepseek_harness" | "dsh" => Some(Self::DeepseekHarness),
             _ => None,
         }
     }

--- a/src-tauri/src/agent_sessions/cli/session_runner/command.rs
+++ b/src-tauri/src/agent_sessions/cli/session_runner/command.rs
@@ -1,9 +1,9 @@
 //! CLI command building and parser creation for each CLI agent type (ModelType).
 
-use crate::agent_sessions::cli::parsers::antigravity::AntigravityParser;
 use crate::agent_sessions::cli::parsers::claude_code::ClaudeCodeParser;
 use crate::agent_sessions::cli::parsers::codex::CodexParser;
 use crate::agent_sessions::cli::parsers::cursor::CursorParser;
+use crate::agent_sessions::cli::parsers::plain_text::PlainTextParser;
 use crate::agent_sessions::cli::parsers::CliAgentParser;
 use crate::agent_sessions::cli::session_runner::launch_profiles::{
     defaults_for_agent, static_args_to_vec, uses_codex_app_server, ResolvedCliLaunchProfile,
@@ -221,7 +221,8 @@ pub(super) fn build_command_with_launch_profile(
         | ModelType::Omp
         | ModelType::Pi
         | ModelType::QoderCli
-        | ModelType::TraeCli => {
+        | ModelType::TraeCli
+        | ModelType::DeepseekHarness => {
             if !task.is_empty() {
                 cmd.push(task.into());
             }
@@ -397,7 +398,9 @@ pub(super) fn create_parser(agent: &ModelType, session_id: &str) -> Box<dyn CliA
         ModelType::CursorCli => Box::new(CursorParser::new(session_id)),
         ModelType::ClaudeCode => Box::new(ClaudeCodeParser::new(session_id)),
         ModelType::Codex => Box::new(CodexParser::new(session_id)),
-        ModelType::Antigravity => Box::new(AntigravityParser::new(session_id)),
+        ModelType::Antigravity | ModelType::DeepseekHarness => {
+            Box::new(PlainTextParser::new(session_id))
+        }
         other => panic!(
             "ModelType::{:?} does not use CliAgentParser (Copilot/Kiro/OpenCode use ACP; API providers are not CLI agents)",
             other

--- a/src-tauri/src/agent_sessions/cli/session_runner/input_assembly.rs
+++ b/src-tauri/src/agent_sessions/cli/session_runner/input_assembly.rs
@@ -298,6 +298,7 @@ mod tests {
             ModelType::Pi,
             ModelType::QoderCli,
             ModelType::TraeCli,
+            ModelType::DeepseekHarness,
         ];
 
         for provider in providers {

--- a/src-tauri/src/agent_sessions/cli/session_runner/launch_profiles.rs
+++ b/src-tauri/src/agent_sessions/cli/session_runner/launch_profiles.rs
@@ -144,6 +144,7 @@ pub fn cli_binary_id_for_agent(agent: &ModelType) -> Option<CliBinaryId> {
         ModelType::Pi => Some(CliBinaryId::Pi),
         ModelType::QoderCli => Some(CliBinaryId::QoderCli),
         ModelType::TraeCli => Some(CliBinaryId::TraeCli),
+        ModelType::DeepseekHarness => Some(CliBinaryId::DeepseekHarness),
         _ => None,
     }
 }
@@ -385,6 +386,11 @@ pub const CLI_LAUNCH_PROFILE_DEFAULTS: &[CliLaunchProfileDefaults] = &[
         command_args: &["interactive"],
         mode_defaults: mode_defaults![Manual => (&[], &[])],
     },
+    CliLaunchProfileDefaults {
+        agent_type: ModelType::DeepseekHarness,
+        command_args: &["--profile", "headless"],
+        mode_defaults: mode_defaults![Manual => (&[], &[])],
+    },
 ];
 
 pub fn defaults_for_agent(agent_type: &ModelType) -> Option<&'static CliLaunchProfileDefaults> {
@@ -498,6 +504,17 @@ mod tests {
     fn trae_cli_starts_in_interactive_mode() {
         let defaults = defaults_for_agent(&ModelType::TraeCli).expect("Trae CLI defaults");
         assert_eq!(defaults.command_args, &["interactive"]);
+        assert_eq!(
+            supported_permission_modes(defaults),
+            vec![CliPermissionMode::Manual]
+        );
+    }
+
+    #[test]
+    fn deepseek_harness_uses_the_headless_profile_for_gui_runs() {
+        let defaults =
+            defaults_for_agent(&ModelType::DeepseekHarness).expect("DeepSeek Harness defaults");
+        assert_eq!(defaults.command_args, &["--profile", "headless"]);
         assert_eq!(
             supported_permission_modes(defaults),
             vec![CliPermissionMode::Manual]

--- a/src-tauri/src/agent_sessions/cli/tests/runner_command_tests.rs
+++ b/src-tauri/src/agent_sessions/cli/tests/runner_command_tests.rs
@@ -260,6 +260,16 @@ fn build_antigravity_print_command() {
 }
 
 #[test]
+fn build_deepseek_harness_headless_command() {
+    let cmd = build_command!(ModelType::DeepseekHarness, task = "inspect the repository",);
+
+    assert_eq!(
+        cmd,
+        vec!["dsh", "--profile", "headless", "inspect the repository"]
+    );
+}
+
+#[test]
 fn build_kiro_basic() {
     let cmd = build_command!(ModelType::Kiro, task = "task");
     assert_eq!(command_name(&cmd[0]), "kiro-cli");

--- a/src-tauri/src/orgtrack/external_cli_detection.rs
+++ b/src-tauri/src/orgtrack/external_cli_detection.rs
@@ -488,6 +488,17 @@ pub const EXTERNAL_CLI_SOURCES: &[ExternalCliSourceSpec] = &[
         false,
         &[],
     ),
+    source(
+        "deepseek_harness",
+        "DeepSeek Harness",
+        "deepseek",
+        "dsh",
+        &[],
+        "dsh --profile tui",
+        "dsh",
+        false,
+        &[],
+    ),
 ];
 
 #[allow(clippy::too_many_arguments)]
@@ -829,6 +840,14 @@ mod tests {
             .expect("Trae CLI source");
         assert_eq!(trae.detect_cmd, "trae-cli");
         assert_eq!(trae.launch_cmd, "trae-cli interactive");
+
+        let deepseek = EXTERNAL_CLI_SOURCES
+            .iter()
+            .find(|source| source.source_id == "deepseek_harness")
+            .expect("DeepSeek Harness source");
+        assert_eq!(deepseek.detect_cmd, "dsh");
+        assert_eq!(deepseek.launch_cmd, "dsh --profile tui");
+        assert!(!deepseek.history_import);
 
         let qwen = EXTERNAL_CLI_SOURCES
             .iter()

--- a/src/api/tauri/agent/__tests__/cliTerminalSession.test.ts
+++ b/src/api/tauri/agent/__tests__/cliTerminalSession.test.ts
@@ -71,6 +71,22 @@ describe("formatCliTuiCommand", () => {
     ).toBe("codex --dangerously-bypass-approvals-and-sandbox");
   });
 
+  it("replaces DeepSeek Harness's headless profile with its TUI profile", () => {
+    expect(
+      formatCliTuiCommand(
+        profile({
+          agentName: "deepseek_harness",
+          defaultCommand: "dsh",
+          command: "dsh",
+          requiredArgs: ["--profile", "headless"],
+          args: [],
+        }),
+        "/opt/deepseek/bin/dsh",
+        false
+      )
+    ).toBe("/opt/deepseek/bin/dsh --profile tui");
+  });
+
   it("honors command and argument overrides with POSIX shell-safe quoting", () => {
     expect(
       formatCliTuiCommand(

--- a/src/api/tauri/agent/cliTerminalSession.ts
+++ b/src/api/tauri/agent/cliTerminalSession.ts
@@ -90,11 +90,15 @@ export function formatCliTuiCommand(
   const executable = profile.commandOverridden
     ? profile.command
     : detectedCommand;
-  // `codex exec` is the headless runner and requires a prompt. TUI launches
-  // must start Codex's interactive CLI instead, while retaining its selected
-  // permission-mode flags (which Codex also accepts at the top level).
+  // Headless-only arguments must not leak into an interactive terminal.
+  // Codex's top-level command is interactive. DeepSeek Harness delegates its
+  // terminal UI to the separately configured `tui` profile.
   const requiredArgs =
-    profile.agentName === CLI_AGENT.CODEX ? [] : profile.requiredArgs;
+    profile.agentName === CLI_AGENT.CODEX
+      ? []
+      : profile.agentName === CLI_AGENT.DEEPSEEK_HARNESS
+        ? ["--profile", "tui"]
+        : profile.requiredArgs;
   return [executable, ...requiredArgs, ...profile.args]
     .filter((part) => part.trim().length > 0)
     .map((part) => quoteShellArg(part, windows))

--- a/src/api/tauri/rpc/schemas/validationEnums.ts
+++ b/src/api/tauri/rpc/schemas/validationEnums.ts
@@ -44,6 +44,7 @@ export const CLI_AGENT = {
   PI: "pi",
   QODER_CLI: "qoder_cli",
   TRAE_CLI: "trae_cli",
+  DEEPSEEK_HARNESS: "deepseek_harness",
 } as const;
 
 /** CLI-based coding agents (external processes managed by the app). */
@@ -78,6 +79,7 @@ export const CliAgentTypeSchema = z.union([
   z.literal("pi"),
   z.literal("qoder_cli"),
   z.literal("trae_cli"),
+  z.literal("deepseek_harness"),
 ]);
 
 /** Direct API key providers (REST API, no child process). */

--- a/src/components/ModelIcon/config.ts
+++ b/src/components/ModelIcon/config.ts
@@ -368,6 +368,7 @@ const MODEL_TYPE_TO_ICON: Record<ModelType, IconProvider> = {
   pi: "pi",
   qoder_cli: "qoder",
   trae_cli: "trae",
+  deepseek_harness: "deepseek",
   // API key providers
   anthropic_api: "claude",
   openai_api: "openai",


### PR DESCRIPTION
## Problem

ORGII does not recognize or launch the new DeepSeek Harness CLI, so users cannot select it for GUI sessions or open a configured TUI profile. The harness has distinct headless and plugin-provided TUI profiles and expects native DeepSeek credentials through its own environment contract.

## Solution

Add deepseek_harness across the canonical Rust/TypeScript agent types, central registry, binary resolver, installer, credential injection, GUI launch/parser path, terminal formatter, external CLI discovery, icon mapping, and supported-agent docs. GUI sessions launch dsh --profile headless <prompt> and parse its final plain-text response. Terminal sessions launch dsh --profile tui. Pair the agent with deepseek_api, injecting DEEPSEEK_API_KEY and optional DEEPSEEK_BASE_URL, while leaving provider/model profile management to DSH.

## Potential risks

The official package ships and auto-initializes the headless profile, but it does not ship a TUI profile; terminal launch requires the user to install/configure a compatible plugin first. A full successful provider round trip was not run because no real DeepSeek key was used. No dependency, lockfile, database, persistence schema, public IPC, or wire-format changes are included. Rollback is the single commit reverting the registry/type/launch additions; existing agent behavior and stored data are unchanged.

## Verification

- npm install -g @deepseek-ai/dsh — passed; installed @deepseek-ai/dsh@0.1.1-rc.2.
- dsh --profile headless --dump-default-config in an isolated DSH home — passed; confirmed the shipped headless profile and native DEEPSEEK_API_KEY route.
- dsh --profile headless "Reply with the single word OK." with an isolated home and deliberately invalid key — reached the provider authentication boundary and failed with a redacted invalid-key error as expected.
- dsh --profile tui --dump-default-config — failed as expected because upstream requires a separately installed TUI plugin.
- pnpm vitest run src/api/tauri/agent/__tests__/cliTerminalSession.test.ts — passed, 17 tests.
- cargo test --manifest-path src-tauri/Cargo.toml -p key_vault deepseek_harness --lib — passed, 4 tests.
- cargo test --manifest-path src-tauri/Cargo.toml -p integrations recent_cli_agents_use_their_published_executable_names --lib — passed, 1 test.
- cargo test --manifest-path src-tauri/Cargo.toml -p agent_cli every_central_cli_registry_entry_has_an_explicit_managed_config_result --lib — passed, 1 test.
- cargo check --manifest-path src-tauri/Cargo.toml -p key_vault -p integrations -p agent_core -p agent_cli -p org2 — passed with pre-existing unrelated warnings.
- Pre-commit scoped TypeScript checks, ESLint, Prettier, rustfmt, Cargo clippy, and git diff --check — passed.
- cargo test --manifest-path src-tauri/Cargo.toml -p org2 deepseek_harness --lib — compiled, but the Windows test executable could not start (STATUS_ENTRYPOINT_NOT_FOUND).
- pnpm typecheck — not completed because unrelated deleted LSP/setup-guide files are still referenced by tsconfig.
- Screenshot/recording not included: the change adds an existing registry row/icon pattern and command behavior, with no new component layout or state-specific UI.

## Audit

Architecture audit covered all ten layers. Performance guard found no new retained resource or background cadence; external detection adds one bounded PATH probe on the existing spawn_blocking inventory path. Performance verdict: pass.