### PR TITLE
test(test-placement): move colocated specs into their directories' __tests__

### DIFF
--- a/src/components/ComposerInput/__tests__/postedReferenceHref.test.ts
+++ b/src/components/ComposerInput/__tests__/postedReferenceHref.test.ts
@@ -6,7 +6,7 @@ import { storePillText } from "@src/config/pillTokens";
 import {
   isSafePostedReferenceHref,
   resolvePostedReferenceHref,
-} from "./postedReferenceHref";
+} from "../postedReferenceHref";
 
 describe("resolvePostedReferenceHref", () => {
   afterEach(() => {

--- a/src/modules/WorkStation/shared/StatusBar/__tests__/EditorStatusBar.hostless.test.ts
+++ b/src/modules/WorkStation/shared/StatusBar/__tests__/EditorStatusBar.hostless.test.ts
@@ -23,7 +23,7 @@ import { currentBranchAtom } from "@src/store/repo";
 import { workspaceFoldersAtom } from "@src/store/ui/workspaceFoldersAtom";
 import type { WorkspaceFolder } from "@src/types/workspace";
 
-import { EditorStatusBar } from "./EditorStatusBar";
+import { EditorStatusBar } from "../EditorStatusBar";
 
 vi.mock("react-i18next", () => ({
   useTranslation: () => ({
@@ -44,7 +44,7 @@ vi.mock("@src/hooks/git/useRepoSelection", () => ({
 // Git plumbing is exercised by its own suites; here we only care that the bar
 // feeds it the identity it read from the atoms.
 const gitCallArgs: Array<Record<string, unknown>> = [];
-vi.mock("./utils/useEditorStatusBarGit", () => ({
+vi.mock("../utils/useEditorStatusBarGit", () => ({
   useEditorStatusBarGit: (options: Record<string, unknown>) => {
     gitCallArgs.push(options);
     return {
@@ -71,9 +71,9 @@ vi.mock("./utils/useEditorStatusBarGit", () => ({
   },
 }));
 
-vi.mock("./CiStatusMenu", () => ({ CiStatusMenu: () => null }));
-vi.mock("./GitSyncStatusMenu", () => ({ default: () => null }));
-vi.mock("./PortsStatusMenu", () => ({ PortsStatusMenu: () => null }));
+vi.mock("../CiStatusMenu", () => ({ CiStatusMenu: () => null }));
+vi.mock("../GitSyncStatusMenu", () => ({ default: () => null }));
+vi.mock("../PortsStatusMenu", () => ({ PortsStatusMenu: () => null }));
 
 const folder: WorkspaceFolder = {
   id: "primary",

--- a/src/util/language/__tests__/prismHtml.test.ts
+++ b/src/util/language/__tests__/prismHtml.test.ts
@@ -5,7 +5,7 @@ import {
   highlightToHtml,
   isPrismLanguage,
   resolvePrismLanguage,
-} from "./prismHtml";
+} from "../prismHtml";
 
 describe("prismHtml", () => {
   it("emits Prism token spans with class names and no inline styles", () => {

--- a/src/util/language/__tests__/prismLight.test.ts
+++ b/src/util/language/__tests__/prismLight.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 
 import { codeMirrorPrismTheme } from "@src/features/CodeMirror/themes/prism";
 
-import { PrismLight } from "./prismLight";
+import { PrismLight } from "../prismLight";
 
 describe("PrismLight", () => {
   it("normalizes editor language aliases through the canonical registry", () => {


### PR DESCRIPTION
## Problem

`develop` fails its own `check:test-placement` gate, so **every** pull request
red-lights on the Frontend job regardless of its contents:

```
3 directories mix both test-placement conventions.
  src/components/ComposerInput             1 colocated, 10 in __tests__/
  src/modules/WorkStation/shared/StatusBar  1 colocated,  1 in __tests__/
  src/util/language                         2 colocated,  2 in __tests__/
```

The gate landed in `46d92df6f` ("test: enforce test placement instead of only
documenting it"), authored 2026-08-23 and merged 2026-08-27 in #886. During the
four days it waited on its branch, three pull requests each added a colocated
spec to a directory that had already settled on `__tests__/`:

| Merged | PR | Added |
| --- | --- | --- |
| 2026-08-24 23:13 | #897 | `src/util/language/prism{Html,Light}.test.ts` |
| 2026-08-25 16:23 | #952 | `StatusBar/EditorStatusBar.hostless.test.ts` |
| 2026-08-25 20:18 | #960 | `ComposerInput/postedReferenceHref.test.ts` |

None of those three did anything wrong — no gate existed on `develop` when they
landed, and `CONTRIBUTING.md` was documentation, not enforcement. Nothing
conflicted textually either, so the gate merged cleanly and was violated the
moment it arrived. #886's own CI would only have caught it had the branch been
rebased after 2026-08-25.

## Solution

Move the four specs into the `__tests__/` directory their siblings already use,
and re-root their relative specifiers one level (`"./x"` → `"../x"`), including
the four `vi.mock` paths in the StatusBar spec — `vi.mock` resolves relative to
the test file, so those must move with it.

Nothing else changes: no test body, no assertion, no subject module. The four
files carry the same 15 assertions over the same modules before and after.
Directory-per-convention was chosen over the alternative (moving ten
`ComposerInput` specs out of `__tests__/`) because it is the smaller move and
the convention each directory had already established.

## Potential risks

- **Rename-only, but reviewers should confirm the rename detection.** Git
  reports all four as renames at 93–98% similarity; the residual delta is
  exactly the eight specifier lines. A reviewer seeing add/delete pairs instead
  of renames should diff the pairs rather than assume content changed.
- **`vi.mock` specifiers are the one real hazard.** They are strings, so a
  wrong path does not fail typecheck — it silently stops mocking and the real
  module loads. Covered by running the moved specs, which pass; the StatusBar
  spec would fail loudly on an unmocked `useEditorStatusBarGit`.
- No source file, build input, or vitest config changes. Test discovery is
  `src/**/*.test.ts`, which matches both locations, so nothing changes about
  which specs run — only where they live.
- Rollback is reverting the commit.

## Verification

- `node scripts/quality/check-test-placement.mjs` — before: 3 directories
  mixing conventions (reproduced on a clean `develop` worktree at
  `16f9ce942`); after: `Test placement is consistent across 433 directories.`
- `npx vitest run` over the four moved specs — 4 files, 15 tests passed.
- `npx tsc --noEmit -p tsconfig.json` — clean.
- `npx eslint` over the four moved specs — clean.
- The repo pre-commit hook ran on the commit: lint-staged passed, TypeScript
  check passed, Rust clippy skipped (no `.rs` staged).

Not run: the full vitest suite and the desktop app. Neither is meaningful for a
file move that changes no test body — the gate and the moved specs are the
behaviour under test here, and both are covered above.
