### PR TITLE
refactor(session-core): unify subscriptions and cut redundant hydrates

### DIFF
--- a/src-tauri/src/agent_sessions/event_pipeline/store/helpers.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/store/helpers.rs
@@ -123,11 +123,12 @@ pub(super) fn reconcile_loaded_synthetic_transcript_placeholders(
 pub(super) fn is_turn_placeholder(event: &SessionEvent) -> bool {
     event.function_name == TURN_PLACEHOLDER_FUNCTION_NAME
         || event.id.starts_with(TURN_PLACEHOLDER_ID_PREFIX)
-        // Imported-history placeholders are built by
-        // imported_history::window::build_unloaded_turn_placeholder_chunk with
-        // function "assistant" and this id prefix; without matching them here,
-        // merge_round_window_events never strips them after their body lands.
-        || event.id.starts_with("imported-unloaded-turn-")
+        // Provider-backed history readers build assistant-shaped placeholders
+        // whose stable shared contract is `result.unloadedTurn`. Match that
+        // semantic payload rather than maintaining one prefix per provider, so
+        // a renamed or newly added provider cannot leave its final-reply
+        // preview beside the real body after a round-window merge.
+        || placeholder_turn_id(event).is_some()
 }
 
 pub(super) fn placeholder_turn_id(event: &SessionEvent) -> Option<&str> {

--- a/src-tauri/src/agent_sessions/event_pipeline/tests/store_tests.rs
+++ b/src-tauri/src/agent_sessions/event_pipeline/tests/store_tests.rs
@@ -1485,6 +1485,31 @@ fn make_turn_placeholder(turn_id: &str, next_turn_id: Option<&str>) -> SessionEv
     event
 }
 
+fn make_provider_turn_preview(
+    event_id: &str,
+    turn_id: &str,
+    next_turn_id: Option<&str>,
+    preview: &str,
+) -> SessionEvent {
+    let mut event = make_event(event_id, "assistant");
+    event.function_name = "assistant".to_string();
+    event.ui_canonical = "agent_message".to_string();
+    event.args = serde_json::json!({ "turnPreviewOnly": true });
+    event.result = serde_json::json!({
+        "observation": preview,
+        "content": preview,
+        "role": "assistant",
+        "unloadedTurn": {
+            "turnId": turn_id,
+            "bodyEventCount": 2,
+            "nextTurnId": next_turn_id,
+        }
+    });
+    event.display_text = preview.to_string();
+    event.display_variant = EventDisplayVariant::Message;
+    event
+}
+
 #[test]
 fn test_round_window_hydration_mode() {
     let mut store = EventStore::new();
@@ -1613,6 +1638,51 @@ fn test_unload_turn_body_preserves_final_reply_as_preview() {
     );
     assert!(store.get_by_id("turn-1-tool").is_none());
     assert!(store.get_by_id("turn-placeholder-turn-1").is_some());
+}
+
+#[test]
+fn test_merge_round_window_events_removes_provider_final_reply_preview() {
+    let mut store = EventStore::new();
+    store.set_round_window(vec![
+        make_user_turn_header("codex-user-1", "2026-01-01T00:00:00Z"),
+        make_provider_turn_preview(
+            "codex-unloaded-turn-codex-user-1",
+            "codex-user-1",
+            Some("codex-user-2"),
+            "Finished the work",
+        ),
+        make_user_turn_header("codex-user-2", "2026-01-01T00:01:00Z"),
+    ]);
+
+    let mut loaded_reply = make_event("codex-assistant-1", "assistant");
+    loaded_reply.function_name = "assistant".to_string();
+    loaded_reply.ui_canonical = "agent_message".to_string();
+    loaded_reply.display_variant = EventDisplayVariant::Message;
+    loaded_reply.display_text = "Finished the work".to_string();
+    loaded_reply.result = serde_json::json!({
+        "observation": "Finished the work",
+        "content": "Finished the work",
+        "role": "assistant",
+    });
+    loaded_reply.created_at = "2026-01-01T00:00:20Z".to_string();
+
+    store.merge_round_window_events(vec![
+        make_user_turn_header("codex-user-1", "2026-01-01T00:00:00Z"),
+        loaded_reply,
+    ]);
+
+    assert!(store
+        .get_by_id("codex-unloaded-turn-codex-user-1")
+        .is_none());
+    assert!(store.get_by_id("codex-assistant-1").is_some());
+    assert_eq!(
+        store
+            .events()
+            .iter()
+            .filter(|event| event.display_text == "Finished the work")
+            .count(),
+        1
+    );
 }
 
 #[test]

--- a/src/engines/SessionCore/core/store/sessionEventsError.ts
+++ b/src/engines/SessionCore/core/store/sessionEventsError.ts
@@ -1,0 +1,19 @@
+import { formatInvokeError } from "@src/util/formatInvokeError";
+
+/**
+ * Normalise an arbitrary thrown value into a real `Error` so session-event
+ * consumers get a uniform `error` field regardless of rejection shape.
+ */
+export function normalizeSessionEventsError(err: unknown): Error {
+  if (err instanceof Error) return err;
+  if (typeof err === "string") return new Error(err);
+
+  const extracted = formatInvokeError(err);
+  if (extracted !== "") return new Error(extracted);
+
+  try {
+    return new Error(JSON.stringify(err));
+  } catch {
+    return new Error("unknown error");
+  }
+}

--- a/src/engines/SessionCore/core/store/useSessionEvents.ts
+++ b/src/engines/SessionCore/core/store/useSessionEvents.ts
@@ -2,56 +2,36 @@
  * useSessionEvents — subscribe to a specific session's events.
  *
  * Used by SubagentBlock / NestedActivityList to render child session
- * events as nested blocks. The hook:
- *
- * 1. Subscribes to `es:changed` for the session via `subscribeSession`
- * 2. For `cursoride-*` session ids (Cursor IDE history child composers),
- *    pre-warms the EventStore by reading bubbles from Cursor's SQLite via
- *    `ensureCursorIdeEventsInStore`. Live CLI / agent sessions skip this
- *    step — their events are written by the live event handler.
- * 3. Lazy-loads events from Rust EventStore via `es_load_from_cache` +
- *    `es_get_snapshot`. If the session is already in memory (live subagent
- *    or freshly pre-warmed cursor history), `es_load_from_cache` triggers a
- *    `schedule_notify` on the Rust side so the subscription receives the
- *    current snapshot immediately.
- * 4. When the first pull returns empty (subagent just spawned, no events yet),
- *    keeps `loading: true` and polls with exponential back-off until the
- *    subscription delivers the first real snapshot or the session is unmounted.
- *
- * On unmount (collapse), the subscription is cleaned up. The Rust-side
- * EventStore retains the data until LRU eviction.
+ * events as nested blocks. Subscription and primary hydration are owned
+ * by `sessionSnapshotAtomFamily` (shared with session-scoped ChatHistory).
+ * This hook adds Cursor IDE error surfacing and a retry loop for sessions
+ * that mount before the first snapshot push arrives.
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { atom, useAtomValue } from "jotai";
+import { useEffect, useMemo, useRef, useState } from "react";
 
+import {
+  type SessionSnapshotState,
+  extractSessionChatEvents,
+  sessionSnapshotAtomFamily,
+} from "@src/engines/SessionCore/derived/sessionScopedChatEvents";
 import { ensureCursorIdeEventsInStore } from "@src/engines/SessionCore/sync/adapters/cursorIdeAdapter";
 import { createLogger } from "@src/hooks/logger";
-import { formatInvokeError } from "@src/util/formatInvokeError";
 import { isCursorIdeSession } from "@src/util/session/sessionDispatch";
 
 import type { SessionEvent } from "../types";
 import {
-  type DerivedSnapshot,
   type Snapshot,
   eventStoreProxy,
   isStreamingSnapshot,
 } from "./EventStoreProxy";
+import { normalizeSessionEventsError } from "./sessionEventsError";
 
 const log = createLogger("useSessionEvents");
 
 interface SessionEventsState {
   events: SessionEvent[];
   loading: boolean;
-  /**
-   * Non-null when the load path threw (Tauri unavailable, Cursor IDE
-   * pre-warm failed, schema parse error, etc.). Consumers can show a
-   * retry button or fall back to the empty state — the previous
-   * implementation swallowed these silently which made
-   * "subagent shows empty events forever" bugs invisible.
-   *
-   * `loading` returns to `false` when an error is surfaced so the
-   * UI doesn't spin forever waiting on a request that has already
-   * failed.
-   */
   error: Error | null;
 }
 
@@ -61,206 +41,100 @@ const EMPTY_STATE: SessionEventsState = {
   error: null,
 };
 
-/** Retry intervals (ms) when the first pull returns an empty event list. */
+const EMPTY_SNAPSHOT_STATE: SessionSnapshotState = {
+  snapshot: null,
+  loadStarted: false,
+};
+
+const emptySnapshotStateAtom = atom<SessionSnapshotState>(EMPTY_SNAPSHOT_STATE);
+emptySnapshotStateAtom.debugLabel = "session/emptySnapshotState";
+
 const RETRY_INTERVALS = [150, 300, 600, 1200, 2000];
 
 export function extractChatEvents(snapshot: Snapshot): SessionEvent[] {
   if (isStreamingSnapshot(snapshot)) {
     return snapshot.chatEvents;
   }
-  return (snapshot as DerivedSnapshot).chatEvents;
+  return extractSessionChatEvents(snapshot);
 }
 
-/**
- * Normalise an arbitrary thrown value into a real `Error` so the
- * `error` field in {@link SessionEventsState} is uniform regardless
- * of whether the rejection came from Tauri, a Zod parse, or a raw
- * thrown string. Exported for tests.
- *
- * Resolution order, chosen so the rendered text matches every other
- * session-layer error site (`useQueueDispatch`, `useSessionSync`,
- * `SessionService`, …) while still being maximally informative:
- *
- * 1. Already an `Error` → returned as-is (prototype chain preserved).
- * 2. {@link formatInvokeError} extracts a `.message` / `.error` field
- *    from Tauri-style object rejections — the same extraction the rest
- *    of the codebase relies on, so a Tauri reject reads identically here.
- * 3. Otherwise fall back to `JSON.stringify` so a structured payload
- *    (`{ code, detail }`) is still legible instead of `"[object Object]"`.
- * 4. Circular refs / un-stringifiable values → `"unknown error"`.
- */
-export function normalizeSessionEventsError(err: unknown): Error {
-  if (err instanceof Error) return err;
-  if (typeof err === "string") return new Error(err);
-
-  const extracted = formatInvokeError(err);
-  if (extracted !== "") return new Error(extracted);
-
-  try {
-    return new Error(JSON.stringify(err));
-  } catch {
-    return new Error("unknown error");
-  }
-}
+export { normalizeSessionEventsError } from "./sessionEventsError";
 
 export function useSessionEvents(
   sessionId: string | undefined
 ): SessionEventsState {
-  const [state, setState] = useState<SessionEventsState>({
-    events: [],
-    loading: Boolean(sessionId),
-    error: null,
-  });
-  const loadedRef = useRef<string | null>(null);
-  const resolvedByPushRef = useRef(false);
+  const { snapshot, loadStarted } = useAtomValue(
+    sessionId ? sessionSnapshotAtomFamily(sessionId) : emptySnapshotStateAtom
+  );
+  const events = useMemo(() => extractSessionChatEvents(snapshot), [snapshot]);
 
-  const handleSnapshot = useCallback((snapshot: Snapshot) => {
-    const chatEvents = extractChatEvents(snapshot);
-    resolvedByPushRef.current = true;
-    setState({ events: chatEvents, loading: false, error: null });
-  }, []);
-
-  const stableEmpty = useMemo(() => EMPTY_STATE, []);
+  const [error, setError] = useState<Error | null>(null);
+  const [retryPending, setRetryPending] = useState(false);
+  const hasEventsRef = useRef(false);
+  hasEventsRef.current = events.length > 0;
 
   useEffect(() => {
-    if (!sessionId) return;
+    if (!sessionId) {
+      setError(null);
+      setRetryPending(false);
+      return;
+    }
+    if (hasEventsRef.current) {
+      setRetryPending(false);
+      return;
+    }
 
     let cancelled = false;
-    resolvedByPushRef.current = false;
+    setError(null);
+    setRetryPending(true);
 
-    const unsub = eventStoreProxy.subscribeSession(sessionId, handleSnapshot);
-
-    async function load() {
-      // When sessionId transitions from undefined → defined, the initial
-      // useState value has loading: false. Set loading: true so the UI
-      // shows a spinner while we fetch.
-      setState((prev) =>
-        prev.loading
-          ? prev
-          : { events: prev.events, loading: true, error: null }
-      );
-      // Re-check the proxy cache *after* subscribing to close the race
-      // window where a snapshot arrived between render and subscription.
-      const liveSnap = eventStoreProxy.getLatestSessionSnapshot(sessionId!);
-      if (liveSnap) {
-        const evts = extractChatEvents(liveSnap);
-        loadedRef.current = sessionId!;
-        if (!cancelled) {
-          setState({ events: evts, loading: false, error: null });
-        }
-        return;
-      }
-
+    async function waitForEvents() {
       try {
-        // Cursor IDE history sessions (parent OR child composer) are not in
-        // our SQLite event cache — they live in Cursor's `state.vscdb`.
-        // Pre-warm the EventStore from there before falling through to the
-        // generic load path. After this, `loadFromCache` finds the events
-        // in memory and just schedules a notify, identical to the
-        // already-loaded live subagent case.
         if (isCursorIdeSession(sessionId!)) {
           await ensureCursorIdeEventsInStore(sessionId!);
-          if (cancelled) return;
-        }
-        await eventStoreProxy.loadFromCache(sessionId!);
-        if (cancelled) return;
-        loadedRef.current = sessionId!;
-
-        // Re-check proxy cache: loadFromCache triggers schedule_notify
-        // which may have already delivered a snapshot to handleSnapshot
-        // or stored it in _latestSnapshots.
-        if (resolvedByPushRef.current) return;
-        const postLoadSnap = eventStoreProxy.getLatestSessionSnapshot(
-          sessionId!
-        );
-        if (postLoadSnap) {
-          const evts = extractChatEvents(postLoadSnap);
-          if (!cancelled) {
-            setState({ events: evts, loading: false, error: null });
-          }
-          return;
+          if (cancelled || hasEventsRef.current) return;
+          await eventStoreProxy.loadFromCache(sessionId!);
+          if (cancelled || hasEventsRef.current) return;
         }
 
-        const snap = await eventStoreProxy.getSnapshot(sessionId);
-        if (cancelled) return;
-        const evts = snap.chatEvents;
-
-        if (evts.length > 0) {
-          setState({ events: evts, loading: false, error: null });
-          return;
-        }
+        if (snapshot || hasEventsRef.current) return;
 
         for (const delay of RETRY_INTERVALS) {
           await new Promise<void>((resolve) => setTimeout(resolve, delay));
-          if (cancelled || resolvedByPushRef.current) return;
+          if (cancelled || hasEventsRef.current) return;
 
-          const retrySnap = await eventStoreProxy.getSnapshot(sessionId);
-          if (cancelled || resolvedByPushRef.current) return;
-          const retryEvts = retrySnap.chatEvents;
-          if (retryEvts.length > 0) {
-            setState({ events: retryEvts, loading: false, error: null });
-            return;
-          }
+          const retrySnap = await eventStoreProxy.getSnapshot(sessionId!);
+          if (cancelled || hasEventsRef.current) return;
+          if (retrySnap.chatEvents.length > 0) return;
         }
 
-        // Exhausted standard retries. For streaming subagents the first
-        // es:changed can arrive later than 2s (LLM cold-start). Do one
-        // more long-tail check before giving up.
-        if (!cancelled && !resolvedByPushRef.current) {
+        if (!cancelled && !hasEventsRef.current) {
           await new Promise<void>((resolve) => setTimeout(resolve, 3000));
-          if (cancelled || resolvedByPushRef.current) return;
-          const finalSnap = eventStoreProxy.getLatestSessionSnapshot(
-            sessionId!
-          );
-          if (finalSnap) {
-            const finalEvts = extractChatEvents(finalSnap);
-            if (finalEvts.length > 0) {
-              setState({
-                events: finalEvts,
-                loading: false,
-                error: null,
-              });
-              return;
-            }
-          }
-          setState((prev) => ({
-            events: prev.events,
-            loading: false,
-            error: null,
-          }));
         }
       } catch (err) {
-        // Previous implementation swallowed the rejection silently
-        // with `_err`. That hid a class of "subagent never renders"
-        // bugs because the user only saw an empty block, never an
-        // error. We now:
-        //   1. Surface the error via the state (consumers can show a
-        //      retry button or fall back).
-        //   2. Log a warning so the failure is at least visible in
-        //      the console during development.
         if (!cancelled) {
           const normalizedErr = normalizeSessionEventsError(err);
           log.warn(
             `[useSessionEvents] Failed to load events for session=${sessionId}:`,
             normalizedErr
           );
-          setState((prev) => ({
-            events: prev.events,
-            loading: false,
-            error: normalizedErr,
-          }));
+          setError(normalizedErr);
         }
+      } finally {
+        if (!cancelled) setRetryPending(false);
       }
     }
 
-    void load();
+    void waitForEvents();
 
     return () => {
       cancelled = true;
-      unsub();
     };
-  }, [sessionId, handleSnapshot]);
+  }, [sessionId, snapshot, loadStarted]);
 
-  if (!sessionId) return stableEmpty;
-  return state;
+  if (!sessionId) return EMPTY_STATE;
+
+  const loading =
+    events.length === 0 && error === null && (retryPending || !loadStarted);
+  return { events, loading, error };
 }

--- a/src/engines/SessionCore/derived/__tests__/queueDispatchSyncInputsAtom.test.ts
+++ b/src/engines/SessionCore/derived/__tests__/queueDispatchSyncInputsAtom.test.ts
@@ -1,0 +1,42 @@
+import { createStore } from "jotai";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  messageQueueHydratedAtom,
+  queueFlushRequestAtom,
+} from "@src/store/ui/messageQueueAtom";
+
+import { turnLifecycleSignalAtom } from "../../control/turnLifecycle";
+import { queueDispatchSyncInputsAtom } from "../queueDispatchSyncInputsAtom";
+
+describe("queueDispatchSyncInputsAtom", () => {
+  it("bundles queue dispatch inputs", () => {
+    const store = createStore();
+
+    store.set(messageQueueHydratedAtom, true);
+    store.set(queueFlushRequestAtom, 2);
+    store.set(turnLifecycleSignalAtom, 7);
+
+    expect(store.get(queueDispatchSyncInputsAtom)).toMatchObject({
+      queue: [],
+      hydrated: true,
+      turnLifecycleSignal: 7,
+      flushRequest: 2,
+      editing: false,
+    });
+  });
+
+  it("notifies subscribers once per bundled source change", () => {
+    const store = createStore();
+    const listener = vi.fn();
+
+    store.sub(queueDispatchSyncInputsAtom, listener);
+    listener.mockClear();
+
+    store.set(messageQueueHydratedAtom, true);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    store.set(turnLifecycleSignalAtom, 1);
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/engines/SessionCore/derived/__tests__/todoReplaySyncInputsAtom.test.ts
+++ b/src/engines/SessionCore/derived/__tests__/todoReplaySyncInputsAtom.test.ts
@@ -1,0 +1,34 @@
+import { createStore } from "jotai";
+import { describe, expect, it, vi } from "vitest";
+
+import { sessionIdAtom } from "../../core/atoms/metadata";
+import { todoReplaySyncInputsAtom } from "../todoReplaySyncInputsAtom";
+
+describe("todoReplaySyncInputsAtom", () => {
+  it("bundles pipeline session and replay inputs", () => {
+    const store = createStore();
+
+    store.set(sessionIdAtom, "session-a");
+
+    expect(store.get(todoReplaySyncInputsAtom)).toMatchObject({
+      pipelineSessionId: "session-a",
+      liveEvents: [],
+      simulatorEvents: [],
+      currentEvent: null,
+    });
+  });
+
+  it("notifies subscribers once per bundled source change", () => {
+    const store = createStore();
+    const listener = vi.fn();
+
+    store.sub(todoReplaySyncInputsAtom, listener);
+    listener.mockClear();
+
+    store.set(sessionIdAtom, "session-a");
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    store.set(sessionIdAtom, "session-b");
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/engines/SessionCore/derived/planningIndicatorAtoms.ts
+++ b/src/engines/SessionCore/derived/planningIndicatorAtoms.ts
@@ -1,3 +1,40 @@
+import { atom } from "jotai";
+
+import type { StreamRetryStatus } from "@src/store/session/cliSessionStatusAtom";
+import type { SubagentJobMap } from "@src/store/session/subagentJobAtom";
+import type { CliSessionStatus } from "@src/types/session/session";
+
+import { derivedSnapshotAtom } from "../core/atoms/events";
+import { isInteractiveTool } from "../core/interactiveTools";
+import {
+  hasLiveRuntimeResourceInLatestTurn,
+  hasRunningAwaitWaitForInLatestTurn,
+} from "../core/runningEventGate";
+
+/**
+ * Stable noop atoms for scoped planning-indicator surfaces. When a
+ * ChatHistory instance passes a session scope, the hook reads scoped
+ * snapshot meta instead of the global pipeline atoms — these prevent
+ * unrelated global subscriptions from waking scoped-only consumers.
+ */
+export const noopPlanningBooleanAtom = atom(false);
+noopPlanningBooleanAtom.debugLabel = "planning/noopBoolean";
+
+export const noopPlanningRuntimeStatusAtom = atom<CliSessionStatus>("idle");
+noopPlanningRuntimeStatusAtom.debugLabel = "planning/noopRuntimeStatus";
+
+export const noopPlanningVersionAtom = atom(0);
+noopPlanningVersionAtom.debugLabel = "planning/noopVersion";
+
+export const noopPlanningSessionIdAtom = atom<string | null>(null);
+noopPlanningSessionIdAtom.debugLabel = "planning/noopSessionId";
+
+export const noopSubagentJobMapAtom = atom<SubagentJobMap>(new Map());
+noopSubagentJobMapAtom.debugLabel = "planning/noopSubagentJobMap";
+
+export const noopStreamRetryStatusAtom = atom<StreamRetryStatus | null>(null);
+noopStreamRetryStatusAtom.debugLabel = "planning/noopStreamRetryStatus";
+
 /**
  * Stable derived atoms for the global planning-indicator booleans.
  *
@@ -11,14 +48,6 @@
  * every snapshot update (i.e. every token) because `derivedSnapshotAtom`
  * itself changed that frequently.
  */
-import { atom } from "jotai";
-
-import { derivedSnapshotAtom } from "../core/atoms/events";
-import { isInteractiveTool } from "../core/interactiveTools";
-import {
-  hasLiveRuntimeResourceInLatestTurn,
-  hasRunningAwaitWaitForInLatestTurn,
-} from "../core/runningEventGate";
 
 /**
  * True when the latest agent turn has at least one live runtime resource
@@ -63,27 +92,3 @@ export const globalHasAwaitingUserInteractionAtom = atom((get) => {
 });
 globalHasAwaitingUserInteractionAtom.debugLabel =
   "planning/globalHasAwaitingUserInteraction";
-
-/**
- * True when the last chat-visible event is a settled (non-streaming)
- * assistant message. In this state the slow-hint is suppressed so the
- * user isn't confused while the backend winds down after a completed reply.
- * Changes only when the last event changes, not on every streaming token.
- */
-export const globalLastIsSettledAssistantMessageAtom = atom((get) => {
-  const snapshot = get(derivedSnapshotAtom);
-  if (!snapshot) return false;
-  const chat =
-    "chatEvents" in snapshot && Array.isArray(snapshot.chatEvents)
-      ? snapshot.chatEvents
-      : [];
-  const last = chat[chat.length - 1];
-  if (!last) return false;
-  return (
-    last.actionType === "assistant" &&
-    last.displayStatus === "completed" &&
-    !last.isDelta
-  );
-});
-globalLastIsSettledAssistantMessageAtom.debugLabel =
-  "planning/globalLastIsSettledAssistantMessage";

--- a/src/engines/SessionCore/derived/queueDispatchSyncInputsAtom.ts
+++ b/src/engines/SessionCore/derived/queueDispatchSyncInputsAtom.ts
@@ -1,0 +1,35 @@
+import { atom } from "jotai";
+
+import {
+  type QueuedMessage,
+  messageQueueAtom,
+  messageQueueHydratedAtom,
+  queueEditingAtom,
+  queueFlushRequestAtom,
+} from "@src/store/ui/messageQueueAtom";
+
+import { turnLifecycleSignalAtom } from "../control/turnLifecycle";
+
+/**
+ * Bundles the inputs that drive the singleton queue dispatcher.
+ *
+ * Subscribing to this atom instead of each source atom separately means
+ * Jotai emits one notification per dependency batch instead of up to five.
+ */
+export interface QueueDispatchSyncInputs {
+  queue: QueuedMessage[];
+  hydrated: boolean;
+  turnLifecycleSignal: number;
+  flushRequest: number;
+  editing: boolean;
+}
+
+export const queueDispatchSyncInputsAtom = atom<QueueDispatchSyncInputs>(
+  (get) => ({
+    queue: get(messageQueueAtom),
+    hydrated: get(messageQueueHydratedAtom),
+    turnLifecycleSignal: get(turnLifecycleSignalAtom),
+    flushRequest: get(queueFlushRequestAtom),
+    editing: get(queueEditingAtom),
+  })
+);

--- a/src/engines/SessionCore/derived/sessionScopedChatEvents.ts
+++ b/src/engines/SessionCore/derived/sessionScopedChatEvents.ts
@@ -29,6 +29,7 @@ import { atom } from "jotai";
 import { atomFamily } from "jotai-family";
 
 import { createLogger } from "@src/hooks/logger";
+import { isCursorIdeSession } from "@src/util/session/sessionDispatch";
 
 import { isInteractiveTool } from "../core/interactiveTools";
 import {
@@ -42,6 +43,7 @@ import {
   isStreamingSnapshot,
 } from "../core/store/EventStoreProxy";
 import type { SessionEvent } from "../core/types";
+import { ensureCursorIdeEventsInStore } from "../sync/adapters/cursorIdeAdapter";
 import {
   derivePlanDisplayEvents,
   planEventContentSignature,
@@ -53,6 +55,8 @@ interface SnapshotState {
   snapshot: Snapshot | null;
   loadStarted: boolean;
 }
+
+export type SessionSnapshotState = SnapshotState;
 
 const EMPTY_STATE: SnapshotState = {
   snapshot: null,
@@ -103,7 +107,7 @@ function scheduleSessionFamilyRemoval(sessionId: string): void {
  * `loadFromCache` so a fresh subagent that has not been fetched yet hydrates
  * without requiring the consumer to call `useSessionEvents` separately.
  */
-const sessionSnapshotAtomFamily = atomFamily((sessionId: string) => {
+export const sessionSnapshotAtomFamily = atomFamily((sessionId: string) => {
   const a = atom<SnapshotState>(EMPTY_STATE);
   a.debugLabel = `session/${sessionId}/snapshot`;
 
@@ -128,19 +132,21 @@ const sessionSnapshotAtomFamily = atomFamily((sessionId: string) => {
       }
     );
 
-    // Best-effort hydration. If the session is already in the Rust LRU
-    // cache this triggers a `schedule_notify` and the snapshot lands via
-    // the subscription above; if it is not loaded yet, Rust loads it from
-    // SQLite. We do not await — the subscription handles the push.
-    void eventStoreProxy.loadFromCache(sessionId).catch((err: unknown) => {
-      // Swallow load errors here: the consumer (ChatHistory) is allowed
-      // to render an empty state. `useSessionEvents` already covers
-      // explicit error surfacing for callers that need it.
-      log.warn(
-        `[sessionScopedChatEvents] loadFromCache(${sessionId}) failed:`,
-        err
-      );
-    });
+    void (async () => {
+      try {
+        if (isCursorIdeSession(sessionId)) {
+          await ensureCursorIdeEventsInStore(sessionId);
+          if (disposed) return;
+        }
+        await eventStoreProxy.loadFromCache(sessionId);
+      } catch (err: unknown) {
+        if (disposed) return;
+        log.warn(
+          `[sessionScopedChatEvents] hydrate(${sessionId}) failed:`,
+          err
+        );
+      }
+    })();
 
     return () => {
       disposed = true;
@@ -152,7 +158,9 @@ const sessionSnapshotAtomFamily = atomFamily((sessionId: string) => {
   return a;
 });
 
-function extractChatEvents(snapshot: Snapshot | null): SessionEvent[] {
+export function extractSessionChatEvents(
+  snapshot: Snapshot | null
+): SessionEvent[] {
   if (!snapshot) return [];
   if (isStreamingSnapshot(snapshot)) {
     return snapshot.chatEvents;
@@ -199,7 +207,7 @@ export const chatEventsForSessionAtomFamily = atomFamily(
 
     const a = atom((get) => {
       const { snapshot } = get(sessionSnapshotAtomFamily(sessionId));
-      const next = derivePlanDisplayEvents(extractChatEvents(snapshot));
+      const next = derivePlanDisplayEvents(extractSessionChatEvents(snapshot));
       const streaming = snapshot
         ? isSnapshotActivelyStreaming(snapshot)
         : false;
@@ -249,7 +257,7 @@ export const sessionScopedPlanningMetaAtomFamily = atomFamily(
     const a = atom((get) => {
       const { snapshot } = get(sessionSnapshotAtomFamily(sessionId));
       if (!snapshot) return EMPTY_PLANNING_META;
-      const chatEvents = extractChatEvents(snapshot);
+      const chatEvents = extractSessionChatEvents(snapshot);
       const next: SessionScopedPlanningMeta = {
         version: snapshot.version,
         anyRunning: hasLiveRuntimeResourceInLatestTurn(chatEvents),

--- a/src/engines/SessionCore/derived/todoReplaySyncInputsAtom.ts
+++ b/src/engines/SessionCore/derived/todoReplaySyncInputsAtom.ts
@@ -1,0 +1,27 @@
+import { atom } from "jotai";
+
+import { currentEventAtom } from "../core/atoms";
+import { eventsAtom } from "../core/atoms/events";
+import { sessionIdAtom } from "../core/atoms/metadata";
+import type { SessionEvent } from "../core/types";
+import { simulatorEventsAtom } from "./simulatorEvents";
+
+/**
+ * Bundles the replay/live inputs that drive todo pin-bar sync.
+ *
+ * Subscribing to this atom instead of each source atom separately means
+ * Jotai emits one notification per dependency batch instead of up to four.
+ */
+export interface TodoReplaySyncInputs {
+  pipelineSessionId: string | null;
+  liveEvents: readonly SessionEvent[];
+  simulatorEvents: readonly SessionEvent[];
+  currentEvent: SessionEvent | null;
+}
+
+export const todoReplaySyncInputsAtom = atom<TodoReplaySyncInputs>((get) => ({
+  pipelineSessionId: get(sessionIdAtom),
+  liveEvents: get(eventsAtom),
+  simulatorEvents: get(simulatorEventsAtom),
+  currentEvent: get(currentEventAtom),
+}));

--- a/src/engines/SessionCore/hooks/__tests__/adeActionEnvelope.test.ts
+++ b/src/engines/SessionCore/hooks/__tests__/adeActionEnvelope.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { parseAdeActionEnvelope } from "../adeActionEnvelope";
+
+describe("parseAdeActionEnvelope", () => {
+  it("returns null for non-ade frames", () => {
+    expect(
+      parseAdeActionEnvelope(JSON.stringify({ type: "agent:complete" }))
+    ).toBeNull();
+  });
+
+  it("parses dispatch envelopes with invoking session id", () => {
+    const detail = parseAdeActionEnvelope(
+      JSON.stringify({
+        type: "agent:ade_action",
+        payload: {
+          correlationId: "corr-1",
+          action: "gui.execute",
+          operation: "dispatch",
+          invokingSessionId: "session-42",
+          params: { foo: "bar" },
+        },
+      })
+    );
+
+    expect(detail?.correlationId).toBe("corr-1");
+    expect(detail?.invokingSessionId).toBe("session-42");
+  });
+});

--- a/src/engines/SessionCore/hooks/__tests__/adeReplyBinding.test.ts
+++ b/src/engines/SessionCore/hooks/__tests__/adeReplyBinding.test.ts
@@ -5,7 +5,7 @@ import { ACTION_ID } from "@src/ActionSystem/actionIds";
 import {
   extractInvokingSessionId,
   resolveTrustedDispatchParams,
-} from "./adeReplyBinding";
+} from "../adeReplyBinding";
 
 describe("extractInvokingSessionId", () => {
   it("reads a string invokingSessionId from the envelope", () => {

--- a/src/engines/SessionCore/hooks/adeActionEnvelope.ts
+++ b/src/engines/SessionCore/hooks/adeActionEnvelope.ts
@@ -1,0 +1,57 @@
+import { extractInvokingSessionId } from "./adeReplyBinding";
+
+export type AdeActionOperation = "list" | "inspect" | "dispatch";
+
+export interface AdeActionDetail {
+  correlationId: string;
+  action?: string;
+  params: Record<string, unknown>;
+  operation?: AdeActionOperation;
+  sessionId?: string;
+  invokingSessionId?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+export function parseAdeActionEnvelope(
+  rawMessage: string
+): AdeActionDetail | null {
+  const parsed = JSON.parse(rawMessage) as unknown;
+  if (!isRecord(parsed) || parsed.type !== "agent:ade_action") return null;
+  const payload = parsed.payload;
+  if (!isRecord(payload)) return null;
+
+  const correlationId = payload.correlationId;
+  if (typeof correlationId !== "string" || correlationId.length === 0) {
+    return null;
+  }
+
+  const operation = payload.operation;
+  const action = payload.action;
+  const params = payload.params;
+  const sessionId = payload.sessionId;
+  const invokingSessionId = extractInvokingSessionId(payload);
+
+  return {
+    correlationId,
+    ...(operation === "list" ||
+    operation === "inspect" ||
+    operation === "dispatch"
+      ? { operation }
+      : {}),
+    ...(typeof action === "string" ? { action } : {}),
+    params: isRecord(params) ? params : {},
+    ...(typeof sessionId === "string" ? { sessionId } : {}),
+    ...(invokingSessionId !== undefined ? { invokingSessionId } : {}),
+  };
+}
+
+export function dispatchAdeActionDetail(detail: AdeActionDetail): void {
+  window.dispatchEvent(
+    new CustomEvent("agent-ade-action", {
+      detail,
+    })
+  );
+}

--- a/src/engines/SessionCore/hooks/replay/__tests__/planningIndicatorIdleTiming.test.ts
+++ b/src/engines/SessionCore/hooks/replay/__tests__/planningIndicatorIdleTiming.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PLANNING_IDLE_THRESHOLD_MS,
+  planningIdleTimingReducer,
+} from "../planningIndicatorIdleTiming";
+
+describe("planningIdleTimingReducer", () => {
+  it("clears activation and idle trackers when session becomes inactive", () => {
+    const next = planningIdleTimingReducer(
+      { activationVersion: 3, idleAfterVersion: 3 },
+      { type: "session_inactive" }
+    );
+    expect(next).toEqual({ activationVersion: null, idleAfterVersion: null });
+  });
+});
+
+describe("PLANNING_IDLE_THRESHOLD_MS", () => {
+  it("matches the planning footer debounce contract", () => {
+    expect(PLANNING_IDLE_THRESHOLD_MS).toBe(1000);
+  });
+});

--- a/src/engines/SessionCore/hooks/replay/__tests__/usePlanningIndicator.test.ts
+++ b/src/engines/SessionCore/hooks/replay/__tests__/usePlanningIndicator.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   planningWatchdogDelayMs,
   shouldShowPlanningIndicator,
-} from "./usePlanningIndicator";
+} from "../usePlanningIndicator";
 
 const baseInput = {
   runtimeStatus: "running",

--- a/src/engines/SessionCore/hooks/replay/planningIndicatorIdleTiming.ts
+++ b/src/engines/SessionCore/hooks/replay/planningIndicatorIdleTiming.ts
@@ -1,0 +1,81 @@
+import { useEffect, useReducer, useRef } from "react";
+
+/** How long (ms) to wait without new events before showing the indicator */
+export const PLANNING_IDLE_THRESHOLD_MS = 1000;
+
+export interface PlanningIdleTimingState {
+  activationVersion: number | null;
+  idleAfterVersion: number | null;
+}
+
+type PlanningIdleTimingAction =
+  | { type: "session_inactive" }
+  | { type: "activate"; version: number }
+  | { type: "arm_idle"; version: number };
+
+const INITIAL_IDLE_TIMING: PlanningIdleTimingState = {
+  activationVersion: null,
+  idleAfterVersion: null,
+};
+
+export function planningIdleTimingReducer(
+  state: PlanningIdleTimingState,
+  action: PlanningIdleTimingAction
+): PlanningIdleTimingState {
+  switch (action.type) {
+    case "session_inactive":
+      return INITIAL_IDLE_TIMING;
+    case "activate":
+      return { ...state, activationVersion: action.version };
+    case "arm_idle":
+      return { ...state, idleAfterVersion: action.version };
+    default:
+      return state;
+  }
+}
+
+/**
+ * Tracks cold-start and post-mutation idle timing for the planning footer.
+ * Uses a reducer for activation/idle version bookkeeping and a single effect
+ * for the warm-path debounce timer.
+ */
+export function usePlanningIdleTiming(
+  isSessionActive: boolean,
+  version: number
+): PlanningIdleTimingState {
+  const [state, dispatch] = useReducer(
+    planningIdleTimingReducer,
+    INITIAL_IDLE_TIMING
+  );
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (idleTimerRef.current) {
+      clearTimeout(idleTimerRef.current);
+      idleTimerRef.current = null;
+    }
+
+    if (!isSessionActive) {
+      dispatch({ type: "session_inactive" });
+      return;
+    }
+
+    if (state.activationVersion === null) {
+      dispatch({ type: "activate", version });
+      return;
+    }
+
+    idleTimerRef.current = setTimeout(() => {
+      dispatch({ type: "arm_idle", version });
+    }, PLANNING_IDLE_THRESHOLD_MS);
+
+    return () => {
+      if (idleTimerRef.current) {
+        clearTimeout(idleTimerRef.current);
+        idleTimerRef.current = null;
+      }
+    };
+  }, [isSessionActive, version, state.activationVersion]);
+
+  return state;
+}

--- a/src/engines/SessionCore/hooks/replay/usePlanningIndicator.ts
+++ b/src/engines/SessionCore/hooks/replay/usePlanningIndicator.ts
@@ -24,19 +24,13 @@
  * mutation (upsert, append, merge), including streaming deltas for thinking
  * and assistant messages. This avoids iterating chatEvents for text length.
  *
- * Cold-start optimisation: when isSessionActive first becomes true (e.g. the
- * user just sent a message and the agent has not produced its first event
- * yet), `idleAfterVersion` is seeded synchronously from `version` in a
- * useEffect with a stable activation ref, so the indicator is visible on
- * the very next paint without waiting IDLE_THRESHOLD_MS. Any subsequent
- * store mutation bumps `version`, breaking the equality and re-arming the
- * full 1-second delay to prevent flicker between tool calls. (An earlier
- * version used `setTimeout(0)` here, but that could race with the agent's
- * first event and leave the indicator hidden for several seconds on very
- * cold starts.)
+ * Cold-start visibility is handled by {@link usePlanningIdleTiming}: the
+ * first active render records `activationVersion`, so the footer can appear
+ * on the next paint without waiting the full idle debounce. Subsequent store
+ * mutations re-arm the 1-second idle timer to prevent flicker between tools.
  */
 import { useAtomValue, useSetAtom } from "jotai";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { eventStoreVersionAtom } from "@src/engines/SessionCore/core/atoms/events";
 import { sessionIdAtom } from "@src/engines/SessionCore/core/atoms/metadata";
@@ -44,11 +38,18 @@ import {
   globalAnyRunningAtom,
   globalHasAwaitingUserInteractionAtom,
   globalHasRunningAwaitWaitForAtom,
+  noopPlanningBooleanAtom,
+  noopPlanningRuntimeStatusAtom,
+  noopPlanningSessionIdAtom,
+  noopPlanningVersionAtom,
+  noopStreamRetryStatusAtom,
+  noopSubagentJobMapAtom,
 } from "@src/engines/SessionCore/derived/planningIndicatorAtoms";
 import {
   noopSessionScopedPlanningMetaAtom,
   sessionScopedPlanningMetaAtomFamily,
 } from "@src/engines/SessionCore/derived/sessionScopedChatEvents";
+import { usePlanningIdleTiming } from "@src/engines/SessionCore/hooks/replay/planningIndicatorIdleTiming";
 import { msSinceSessionChannelActivity } from "@src/engines/SessionCore/sync/sessionChannelActivity";
 import { createLogger } from "@src/hooks/logger";
 import {
@@ -64,9 +65,6 @@ import {
 } from "@src/store/session/subagentJobAtom";
 
 const log = createLogger("usePlanningIndicator");
-
-/** How long (ms) to wait without new events before showing the indicator */
-const IDLE_THRESHOLD_MS = 1000;
 
 /**
  * How long (ms) the planning indicator may stay visible before the watchdog
@@ -189,13 +187,27 @@ export function usePlanningIndicator(
   scope?: PlanningIndicatorScope | null
 ): PlanningIndicatorState {
   const scoped = Boolean(scope);
-  const globalIsSessionActive = useAtomValue(isSessionActiveAtom);
-  const globalIsPendingCancel = useAtomValue(isPendingCancelAtom);
-  const globalRuntimeStatus = useAtomValue(sessionRuntimeStatusAtom);
-  const globalVersion = useAtomValue(eventStoreVersionAtom);
-  const sessionId = useAtomValue(sessionIdAtom);
-  const subagentJobMap = useAtomValue(subagentJobMapAtom);
-  const streamRetryStatus = useAtomValue(streamRetryStatusAtom);
+  const globalIsSessionActive = useAtomValue(
+    scoped ? noopPlanningBooleanAtom : isSessionActiveAtom
+  );
+  const globalIsPendingCancel = useAtomValue(
+    scoped ? noopPlanningBooleanAtom : isPendingCancelAtom
+  );
+  const globalRuntimeStatus = useAtomValue(
+    scoped ? noopPlanningRuntimeStatusAtom : sessionRuntimeStatusAtom
+  );
+  const globalVersion = useAtomValue(
+    scoped ? noopPlanningVersionAtom : eventStoreVersionAtom
+  );
+  const sessionId = useAtomValue(
+    scoped ? noopPlanningSessionIdAtom : sessionIdAtom
+  );
+  const subagentJobMap = useAtomValue(
+    scoped ? noopSubagentJobMapAtom : subagentJobMapAtom
+  );
+  const streamRetryStatus = useAtomValue(
+    scoped ? noopStreamRetryStatusAtom : streamRetryStatusAtom
+  );
   const setSessionRuntimeStatus = useSetAtom(setSessionRuntimeStatusAtom);
   const scopedMeta = useAtomValue(
     scope
@@ -207,124 +219,45 @@ export function usePlanningIndicator(
     ? Boolean(scope?.isLive)
     : globalIsSessionActive;
   const isPendingCancel = scoped ? false : globalIsPendingCancel;
-  // Scoped surfaces have no runtime-status mirror of their own; liveness is
-  // already folded into `isLive`, so map it onto the status gate directly.
   const runtimeStatus = scoped
     ? scope?.isLive
       ? "running"
       : "idle"
     : globalRuntimeStatus;
   const version = scoped ? scopedMeta.version : globalVersion;
+  const effectiveSessionId = scoped ? (scope?.sessionId ?? null) : sessionId;
 
-  // Derived atoms only notify when the boolean flips, not on every token.
-  // Scoped surfaces use scopedMeta instead of the global atoms.
-  const globalAnyRunning = useAtomValue(globalAnyRunningAtom);
+  const globalAnyRunning = useAtomValue(
+    scoped ? noopPlanningBooleanAtom : globalAnyRunningAtom
+  );
   const anyRunning = scoped ? scopedMeta.anyRunning : globalAnyRunning;
 
   const globalHasAwaitingUserInteraction = useAtomValue(
-    globalHasAwaitingUserInteractionAtom
+    scoped ? noopPlanningBooleanAtom : globalHasAwaitingUserInteractionAtom
   );
   const hasAwaitingUserInteraction = scoped
     ? scopedMeta.hasAwaitingUserInteraction
     : globalHasAwaitingUserInteraction;
 
-  // Running wait_for in the latest turn → its own countdown title is the
-  // activity signal; suppress the duplicate planning footer.
   const globalHasRunningAwaitWaitFor = useAtomValue(
-    globalHasRunningAwaitWaitForAtom
+    scoped ? noopPlanningBooleanAtom : globalHasRunningAwaitWaitForAtom
   );
   const hasRunningAwaitWaitFor = scoped
     ? scopedMeta.hasRunningAwaitWaitFor
     : globalHasRunningAwaitWaitFor;
 
-  const [idleAfterVersion, setIdleAfterVersion] = useState<number | null>(null);
-  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Version at the moment isSessionActive first became true. Lives in
-  // state (not a ref) so the render that seeds it also re-evaluates
-  // `coldStartVisible`; with a ref, the first post-activation render
-  // would still see `null` and the indicator would not appear until the
-  // next version bump or IDLE_THRESHOLD_MS.
-  const [activationVersion, setActivationVersion] = useState<number | null>(
-    null
+  const { activationVersion, idleAfterVersion } = usePlanningIdleTiming(
+    isSessionActive,
+    version
   );
 
-  useEffect(() => {
-    if (idleTimerRef.current) {
-      clearTimeout(idleTimerRef.current);
-      idleTimerRef.current = null;
-    }
-
-    let cancelled = false;
-
-    if (!isSessionActive) {
-      // Session ended — clear both activation and idle trackers so the
-      // indicator cannot briefly re-appear if an in-flight 1-second idle
-      // timer fires after isSessionActive flips to false. Both setStates use
-      // queueMicrotask to satisfy react-hooks/set-state-in-effect
-      // while still landing on the very next paint.
-      queueMicrotask(() => {
-        if (!cancelled) {
-          setActivationVersion(null);
-          setIdleAfterVersion(null);
-        }
-      });
-      return () => {
-        cancelled = true;
-      };
-    }
-
-    if (activationVersion === null) {
-      // Cold-start: first render where isSessionActive flipped to true.
-      // Record the version at activation so `coldStartVisible` below
-      // goes true on the next render, without waiting IDLE_THRESHOLD_MS.
-      // queueMicrotask defers the setState past the effect body to satisfy
-      // react-hooks/set-state-in-effect while still landing on the very
-      // next paint (same frame), which is what makes cold-start visible.
-      queueMicrotask(() => {
-        if (!cancelled) setActivationVersion(version);
-      });
-      return () => {
-        cancelled = true;
-      };
-    }
-
-    // Warm path: something just mutated the store (tool call finished,
-    // delta chunk arrived, etc.). Wait the full IDLE_THRESHOLD_MS before
-    // declaring idle, so the indicator doesn't flicker between tools.
-    idleTimerRef.current = setTimeout(() => {
-      setIdleAfterVersion(version);
-    }, IDLE_THRESHOLD_MS);
-
-    return () => {
-      cancelled = true;
-      if (idleTimerRef.current) {
-        clearTimeout(idleTimerRef.current);
-        idleTimerRef.current = null;
-      }
-    };
-  }, [isSessionActive, version, activationVersion]);
-
-  // Visible when: session active, not pending cancel, AND either
-  //   (a) cold-start — version hasn't bumped since activation yet, OR
-  //   (b) warm — IDLE_THRESHOLD_MS elapsed since last mutation.
-  //
-  // isPendingCancel guard: the user pressed Stop but Rust hasn't confirmed
-  // agent:complete yet. During this window streamRetryStatusAtom may have
-  // already cleared (reconnect pill gone) while sessionRuntimeStatus is still
-  // "running" — showing "Planning…" here is misleading and confusing.
-  // hasAwaitingUserInteraction guard: blocking interaction tools keep the
-  // session active while waiting for a click. That is not planning.
   const coldStartVisible =
     activationVersion !== null && activationVersion === version;
-  // Scoped surfaces (subagent monitor cell) fold liveness into `isLive`
-  // already; the live-subagent gap only applies to the global composer.
   const hasLiveSubagent = scoped
     ? false
-    : hasLiveSubagentJobs(subagentJobMap, sessionId);
-  // Backoff wait between LLM stream retries — silent by design, must not
-  // count as a stall (rate-limit backoffs can exceed the watchdog window).
+    : hasLiveSubagentJobs(subagentJobMap, effectiveSessionId);
   const hasPendingStreamRetry =
-    !scoped && streamRetryStatus?.sessionId === sessionId;
+    !scoped && streamRetryStatus?.sessionId === effectiveSessionId;
   const visible = shouldShowPlanningIndicator({
     runtimeStatus,
     isSessionActive,
@@ -338,50 +271,11 @@ export function usePlanningIndicator(
     hasRunningAwaitWaitFor,
   });
 
-  // Watchdog: force-complete the session if the planning indicator stays
-  // visible past PLANNING_WATCHDOG_MS. Any new store mutation flips
-  // `visible` to false (via the idle-timer arm in the effect above),
-  // which cancels this timer; on the next idle the watchdog re-arms.
-  // We only trip on genuine "no activity at all" stalls.
-  //
-  // "Activity" is CHANNEL activity, not store mutations: several event
-  // classes are deliberately ephemeral and never bump the store version —
-  // `agent:tool_call_delta` buffers in memory only (a model can spend
-  // minutes streaming one large edit_file call), `agent:stream_retry`
-  // writes a side atom. When the timer fires we therefore consult
-  // `msSinceSessionChannelActivity` and re-arm for the remaining window
-  // instead of tripping while the backend is demonstrably alive
-  // (see planningWatchdogDelayMs).
-  //
-  // UI-only: this clears the runtime-status mirror so the footer stops
-  // saying "Planning…", but deliberately does NOT touch the turn-lifecycle
-  // FSM. A long quiet stretch (subagent wait, slow tool) is not proof the
-  // turn ended, and a synthetic terminal here released the message queue
-  // mid-turn (queued follow-ups were auto-sent into a still-running turn).
-  // If Rust genuinely dropped agent:complete, the queue's backend status
-  // gate re-checks and drains once the session row reads terminal.
-  //
-  // Scoped instances skip the watchdog entirely: they don't own the global
-  // runtime-status mirror, and their liveness comes from the monitor
-  // strip's backend-authoritative status, which self-corrects.
-  //
-  // hasLiveSubagent guard: when a background subagent is still running the
-  // footer is legitimately visible for as long as the child takes (often
-  // minutes). Tripping the watchdog there would spam the warning and force
-  // the parent status to "completed" mid-wait — the child's
-  // `agent:subagent_job_changed` terminal event is the real completion
-  // signal, not a 60s wall clock.
-  //
-  // hasPendingStreamRetry guard: `agent:stream_retry` means the backend is
-  // deliberately waiting out a backoff (rate-limit backoffs can exceed the
-  // watchdog window) with zero events by design. The retry pill is the
-  // user-visible activity indicator; the recovery/exhausted event re-arms
-  // normal watchdog coverage.
   useEffect(() => {
     if (
       scoped ||
       !visible ||
-      !sessionId ||
+      !effectiveSessionId ||
       hasLiveSubagent ||
       anyRunning ||
       hasPendingStreamRetry
@@ -391,7 +285,7 @@ export function usePlanningIndicator(
     const arm = (delayMs: number) => {
       timerId = window.setTimeout(() => {
         const rearmDelay = planningWatchdogDelayMs(
-          msSinceSessionChannelActivity(sessionId)
+          msSinceSessionChannelActivity(effectiveSessionId)
         );
         if (rearmDelay !== null) {
           arm(rearmDelay);
@@ -403,7 +297,7 @@ export function usePlanningIndicator(
             "Rust dropped agent:complete or the idle agent:queue_status frame."
         );
         setSessionRuntimeStatus({
-          sessionId,
+          sessionId: effectiveSessionId,
           status: "completed",
           source: "planning",
         });
@@ -416,33 +310,21 @@ export function usePlanningIndicator(
   }, [
     scoped,
     visible,
-    sessionId,
+    effectiveSessionId,
     hasLiveSubagent,
     anyRunning,
     hasPendingStreamRetry,
     setSessionRuntimeStatus,
   ]);
 
-  // Re-roll the variant index on every hidden → visible transition.
-  // Using a large random integer and letting the consumer mod by the
-  // variant array length keeps this decoupled from the locale data.
-  // The roll is scheduled via queueMicrotask so the setState call is not
-  // synchronous within the effect body (lint: react-hooks/set-state-in-effect).
   const [variantIndex, setVariantIndex] = useState(0);
-  const wasVisibleRef = useRef(false);
-  useEffect(() => {
-    const becameVisible = visible && !wasVisibleRef.current;
-    wasVisibleRef.current = visible;
-    if (!becameVisible) return;
-    let cancelled = false;
-    queueMicrotask(() => {
-      if (cancelled) return;
-      setVariantIndex(Math.floor(Math.random() * 1_000_000));
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [visible]);
+  const [prevVisible, setPrevVisible] = useState(false);
+  if (visible !== prevVisible) {
+    setPrevVisible(visible);
+    if (visible && !prevVisible) {
+      setVariantIndex((current) => current + 1);
+    }
+  }
 
   return {
     count: visible ? 1 : 0,

--- a/src/engines/SessionCore/hooks/session/__tests__/syncTodosFromReplayEvents.test.ts
+++ b/src/engines/SessionCore/hooks/session/__tests__/syncTodosFromReplayEvents.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+
+import { syncTodosFromReplayEvents } from "../syncTodosFromReplayEvents";
+
+function nativeTodoContent(
+  header: string,
+  todos: Array<Record<string, unknown>>
+): string {
+  return [
+    header,
+    JSON.stringify(todos, null, 2),
+    "",
+    "Ensure that you continue to use the todo list to track your progress.",
+  ].join("\n");
+}
+
+function makeManageTodoEvent(
+  overrides: Partial<SessionEvent> & Pick<SessionEvent, "id">
+): SessionEvent {
+  return {
+    chunk_id: overrides.id,
+    sessionId: "session-a",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    functionName: "manage_todo",
+    uiCanonical: "manage_todo",
+    actionType: "tool_call",
+    args: {},
+    result: {
+      content: nativeTodoContent("1 todo (1 remaining)", [
+        { index: 0, content: "Do work", status: "pending" },
+      ]),
+    },
+    source: "assistant",
+    displayText: "",
+    displayStatus: "completed",
+    displayVariant: "tool_call",
+    activityStatus: "processed",
+    ...overrides,
+  };
+}
+
+describe("syncTodosFromReplayEvents", () => {
+  it("returns null when pipeline session does not match", () => {
+    const events = [makeManageTodoEvent({ id: "todo-1" })];
+    expect(
+      syncTodosFromReplayEvents({
+        sessionId: "session-a",
+        pipelineSessionId: "session-b",
+        liveEvents: events,
+        simulatorEvents: [],
+        currentEvent: null,
+        lastSnapshot: null,
+      })
+    ).toBeNull();
+  });
+
+  it("derives todos from live events when pipeline matches", () => {
+    const events = [makeManageTodoEvent({ id: "todo-1" })];
+    const result = syncTodosFromReplayEvents({
+      sessionId: "session-a",
+      pipelineSessionId: "session-a",
+      liveEvents: events,
+      simulatorEvents: [],
+      currentEvent: null,
+      lastSnapshot: null,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.snapshot).toBeTruthy();
+  });
+});

--- a/src/engines/SessionCore/hooks/session/syncTodosFromReplayEvents.ts
+++ b/src/engines/SessionCore/hooks/session/syncTodosFromReplayEvents.ts
@@ -1,0 +1,94 @@
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+import type { TodoItem } from "@src/store/ui/todoAtom";
+
+import {
+  extractTodosFromManageTodoSequence,
+  findLatestManageTodoEvent,
+  serializeTodoSnapshot,
+} from "./todoReplayDerivation";
+
+export interface SyncTodosFromReplayEventsInput {
+  sessionId: string;
+  pipelineSessionId: string | null | undefined;
+  liveEvents: readonly SessionEvent[];
+  simulatorEvents: readonly SessionEvent[];
+  currentEvent: SessionEvent | null;
+  lastSnapshot: string | null;
+}
+
+export interface SyncTodosFromReplayEventsResult {
+  todos: TodoItem[];
+  timestamp: string;
+  snapshot: string;
+}
+
+/**
+ * Derive the todo pin-bar snapshot from replay/live events up to the current
+ * cursor. Returns `null` when there is nothing new to write (empty events,
+ * pipeline mismatch, or unchanged snapshot).
+ */
+export function syncTodosFromReplayEvents(
+  input: SyncTodosFromReplayEventsInput
+): SyncTodosFromReplayEventsResult | null {
+  const {
+    sessionId,
+    pipelineSessionId,
+    liveEvents,
+    simulatorEvents,
+    currentEvent,
+    lastSnapshot,
+  } = input;
+
+  if (pipelineSessionId && pipelineSessionId !== sessionId) {
+    return null;
+  }
+
+  const replayEvents =
+    pipelineSessionId === sessionId && liveEvents.length > 0
+      ? liveEvents
+      : simulatorEvents;
+  if (!replayEvents || replayEvents.length === 0) {
+    return null;
+  }
+
+  const currentEventId = currentEvent?.id ?? null;
+
+  let maxIndex = replayEvents.length - 1;
+  if (currentEventId) {
+    const currentIndex = replayEvents.findIndex(
+      (event) => event.id === currentEventId
+    );
+    if (currentIndex !== -1) {
+      maxIndex = currentIndex;
+    }
+  }
+
+  const latestTodoEvent = findLatestManageTodoEvent(
+    replayEvents,
+    sessionId,
+    maxIndex
+  );
+  if (!latestTodoEvent) {
+    return null;
+  }
+
+  const todos = extractTodosFromManageTodoSequence(
+    replayEvents,
+    sessionId,
+    maxIndex
+  );
+  if (todos.length === 0) {
+    return null;
+  }
+
+  const snapshot = serializeTodoSnapshot(todos);
+  if (snapshot === lastSnapshot) {
+    return null;
+  }
+
+  return {
+    todos,
+    timestamp: latestTodoEvent.createdAt,
+    snapshot,
+  };
+}

--- a/src/engines/SessionCore/hooks/session/todoReplayDerivation.ts
+++ b/src/engines/SessionCore/hooks/session/todoReplayDerivation.ts
@@ -1,0 +1,105 @@
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+import { extractTodoData } from "@src/engines/SessionCore/rendering/props";
+import { normalizeActivity } from "@src/lib/activityData";
+import { isTodoEvent } from "@src/modules/WorkStation/Chat/Communication/utils";
+import type { TodoItem } from "@src/store/ui/todoAtom";
+import { preserveTodoContent } from "@src/store/ui/todoMerge";
+
+import { sanitizeTodoDisplayText } from "./todoNormalization";
+
+export function isManageTodoEvent(event: SessionEvent): boolean {
+  const fn = event.functionName || "";
+  const actionType = event.actionType || "";
+
+  if (fn && isTodoEvent(fn)) return true;
+  if (actionType && isTodoEvent(actionType)) return true;
+
+  return false;
+}
+
+function eventMatchesSession(event: SessionEvent, sessionId: string): boolean {
+  const eventSid = event.sessionId;
+  return !eventSid || eventSid === sessionId;
+}
+
+export function findLatestManageTodoEvent(
+  events: readonly SessionEvent[],
+  sessionId: string,
+  maxIndex = events.length - 1
+): SessionEvent | null {
+  const limit = Math.min(maxIndex, events.length - 1);
+  for (let index = limit; index >= 0; index--) {
+    const event = events[index];
+    if (!isManageTodoEvent(event)) continue;
+    if (!eventMatchesSession(event, sessionId)) continue;
+    return event;
+  }
+  return null;
+}
+
+export function serializeTodoSnapshot(todos: TodoItem[]): string {
+  return JSON.stringify(
+    todos.map((todo) => ({
+      id: todo.id,
+      content: todo.content,
+      activeForm: todo.activeForm,
+      status: todo.status,
+      blockedBy: todo.blockedBy,
+    }))
+  );
+}
+
+function extractTodosFromEvent(event: SessionEvent): TodoItem[] {
+  const normalized = normalizeActivity(
+    event as unknown as Record<string, unknown>
+  );
+
+  const todoData = extractTodoData({
+    eventId: event.id,
+    eventType: "manage_todo",
+    args: normalized.args,
+    result: normalized.result,
+    status: "success" as const,
+    variant: "chat" as const,
+    context: "chat" as const,
+  });
+
+  return todoData.todos.map((todo, idx) => {
+    const raw = todo as unknown as Record<string, unknown>;
+    const activeForm =
+      typeof raw.activeForm === "string" && raw.activeForm.length > 0
+        ? (raw.activeForm as string)
+        : undefined;
+    const blockedBy = Array.isArray(raw.blockedBy)
+      ? (raw.blockedBy as number[])
+      : todo.blockedBy;
+    return {
+      id: todo.id || `event-todo-${idx}`,
+      content: sanitizeTodoDisplayText(todo.content || ""),
+      activeForm: activeForm ? sanitizeTodoDisplayText(activeForm) : undefined,
+      status: (todo.status || "pending") as TodoItem["status"],
+      ...(blockedBy && blockedBy.length > 0 ? { blockedBy } : {}),
+    };
+  });
+}
+
+export function extractTodosFromManageTodoSequence(
+  events: readonly SessionEvent[],
+  sessionId: string,
+  maxIndex = events.length - 1
+): TodoItem[] {
+  const limit = Math.min(maxIndex, events.length - 1);
+  let todos: TodoItem[] = [];
+
+  for (let index = 0; index <= limit; index++) {
+    const event = events[index];
+    if (!isManageTodoEvent(event)) continue;
+    if (!eventMatchesSession(event, sessionId)) continue;
+
+    const nextTodos = extractTodosFromEvent(event);
+    if (nextTodos.length === 0) continue;
+    todos = preserveTodoContent(todos, nextTodos);
+  }
+
+  return todos;
+}

--- a/src/engines/SessionCore/hooks/session/useQueueDispatch.ts
+++ b/src/engines/SessionCore/hooks/session/useQueueDispatch.ts
@@ -21,7 +21,6 @@
  * No runtime-status reads, no rendered-event heuristics, no timestamps or
  * stabilization windows: turn finality is exactly what the FSM says.
  */
-import type { Atom } from "jotai";
 import { useStore } from "jotai";
 import { useCallback, useEffect, useRef } from "react";
 
@@ -42,9 +41,9 @@ import {
   confirmTurnRunning,
   getTurnPhase,
   markTurnTerminal,
-  turnLifecycleSignalAtom,
 } from "@src/engines/SessionCore/control/turnLifecycle";
 import { eventStoreProxy } from "@src/engines/SessionCore/core/store/EventStoreProxy";
+import { queueDispatchSyncInputsAtom } from "@src/engines/SessionCore/derived/queueDispatchSyncInputsAtom";
 import { SessionService } from "@src/engines/SessionCore/services/SessionService";
 import { createSyntheticUserEvent } from "@src/engines/SessionCore/sync/adapters/shared";
 import { createLogger } from "@src/hooks/logger";
@@ -64,7 +63,6 @@ import {
   messageQueueAtom,
   messageQueueHydratedAtom,
   queueEditingAtom,
-  queueFlushRequestAtom,
 } from "@src/store/ui/messageQueueAtom";
 import { resolveModelForMessage } from "@src/util/session/resolveModelForMessage";
 import { selectionFromSession } from "@src/util/session/selectionFromSession";
@@ -442,16 +440,10 @@ export function useQueueDispatch(): void {
   }, [tryDispatchNext]);
 
   useEffect(() => {
-    const unsubscribers = [
-      store.sub(messageQueueAtom as Atom<QueuedMessage[]>, tryDispatchNext),
-      store.sub(messageQueueHydratedAtom as Atom<boolean>, tryDispatchNext),
-      store.sub(turnLifecycleSignalAtom as Atom<number>, tryDispatchNext),
-      store.sub(queueFlushRequestAtom as Atom<number>, tryDispatchNext),
-      store.sub(queueEditingAtom as Atom<boolean>, tryDispatchNext),
-    ];
+    const unsubscribe = store.sub(queueDispatchSyncInputsAtom, tryDispatchNext);
     tryDispatchNext();
     return () => {
-      for (const unsubscribe of unsubscribers) unsubscribe();
+      unsubscribe();
       if (wakeTimerRef.current !== null) {
         window.clearTimeout(wakeTimerRef.current);
         wakeTimerRef.current = null;

--- a/src/engines/SessionCore/hooks/session/useTodoSync.ts
+++ b/src/engines/SessionCore/hooks/session/useTodoSync.ts
@@ -14,174 +14,58 @@
  * Mounted from `ChatView` so the sticky pin bar stays aligned with chat
  * blocks even when the IPC push is missed.
  */
-import { useAtomValue, useSetAtom, useStore } from "jotai";
+import { useSetAtom, useStore } from "jotai";
 import { useEffect, useRef } from "react";
 
 import { getTodos } from "@src/api/tauri/agent";
-import { currentEventAtom } from "@src/engines/SessionCore/core/atoms";
-import { eventsAtom } from "@src/engines/SessionCore/core/atoms/events";
-import { sessionIdAtom } from "@src/engines/SessionCore/core/atoms/metadata";
-import type { SessionEvent } from "@src/engines/SessionCore/core/types";
-import { simulatorEventsAtom } from "@src/engines/SessionCore/derived/simulatorEvents";
-import { extractTodoData } from "@src/engines/SessionCore/rendering/props";
+import { todoReplaySyncInputsAtom } from "@src/engines/SessionCore/derived/todoReplaySyncInputsAtom";
 import { createLogger } from "@src/hooks/logger";
-import { normalizeActivity } from "@src/lib/activityData";
-import { isTodoEvent } from "@src/modules/WorkStation/Chat/Communication/utils";
 import {
-  type TodoItem,
   clearTodosForSessionAtom,
   getTodosForSession,
   sessionTodoMapAtom,
   updateTodosForSessionAtom,
 } from "@src/store/ui/todoAtom";
-import { preserveTodoContent } from "@src/store/ui/todoMerge";
 
+import { syncTodosFromReplayEvents } from "./syncTodosFromReplayEvents";
 import {
   type RawPersistedTodoItem,
   isExpectedTodoLoadRejection,
   normalizePersistedTodo as normalizePersistedTodoCore,
   normalizePersistedTodoList as normalizePersistedTodoListCore,
-  sanitizeTodoDisplayText,
 } from "./todoNormalization";
 
 const log = createLogger("useTodoSync");
 
-// ============================================
-// Helper Functions
-// ============================================
-
-export function isManageTodoEvent(event: SessionEvent): boolean {
-  const fn = event.functionName || "";
-  const actionType = event.actionType || "";
-
-  if (fn && isTodoEvent(fn)) return true;
-  if (actionType && isTodoEvent(actionType)) return true;
-
-  return false;
-}
+export {
+  extractTodosFromManageTodoSequence,
+  findLatestManageTodoEvent,
+  isManageTodoEvent,
+  serializeTodoSnapshot,
+} from "./todoReplayDerivation";
 
 /**
  * Re-export the dependency-light normalisation helpers so the
  * existing consumers of `useTodoSync` (and its tests) don't have to
- * change their import paths. The actual implementations live in
- * `./todoNormalization` so they can be unit-tested without pulling
- * in jotai atoms (which require `localStorage`).
+ * change their import paths.
  */
 export type { RawPersistedTodoItem };
 export const normalizePersistedTodo = normalizePersistedTodoCore;
 export const normalizePersistedTodoList = normalizePersistedTodoListCore;
 
-function eventMatchesSession(event: SessionEvent, sessionId: string): boolean {
-  const eventSid = event.sessionId;
-  return !eventSid || eventSid === sessionId;
-}
-
-export function findLatestManageTodoEvent(
-  events: readonly SessionEvent[],
-  sessionId: string,
-  maxIndex = events.length - 1
-): SessionEvent | null {
-  const limit = Math.min(maxIndex, events.length - 1);
-  for (let index = limit; index >= 0; index--) {
-    const event = events[index];
-    if (!isManageTodoEvent(event)) continue;
-    if (!eventMatchesSession(event, sessionId)) continue;
-    return event;
-  }
-  return null;
-}
-
-export function serializeTodoSnapshot(todos: TodoItem[]): string {
-  return JSON.stringify(
-    todos.map((todo) => ({
-      id: todo.id,
-      content: todo.content,
-      activeForm: todo.activeForm,
-      status: todo.status,
-      blockedBy: todo.blockedBy,
-    }))
-  );
-}
-
-function extractTodosFromEvent(event: SessionEvent): TodoItem[] {
-  const normalized = normalizeActivity(
-    event as unknown as Record<string, unknown>
-  );
-
-  const todoData = extractTodoData({
-    eventId: event.id,
-    eventType: "manage_todo",
-    args: normalized.args,
-    result: normalized.result,
-    status: "success" as const,
-    variant: "chat" as const,
-    context: "chat" as const,
-  });
-
-  return todoData.todos.map((todo, idx) => {
-    const raw = todo as unknown as Record<string, unknown>;
-    const activeForm =
-      typeof raw.activeForm === "string" && raw.activeForm.length > 0
-        ? (raw.activeForm as string)
-        : undefined;
-    const blockedBy = Array.isArray(raw.blockedBy)
-      ? (raw.blockedBy as number[])
-      : todo.blockedBy;
-    return {
-      id: todo.id || `event-todo-${idx}`,
-      content: sanitizeTodoDisplayText(todo.content || ""),
-      activeForm: activeForm ? sanitizeTodoDisplayText(activeForm) : undefined,
-      status: (todo.status || "pending") as TodoItem["status"],
-      ...(blockedBy && blockedBy.length > 0 ? { blockedBy } : {}),
-    };
-  });
-}
-
-export function extractTodosFromManageTodoSequence(
-  events: readonly SessionEvent[],
-  sessionId: string,
-  maxIndex = events.length - 1
-): TodoItem[] {
-  const limit = Math.min(maxIndex, events.length - 1);
-  let todos: TodoItem[] = [];
-
-  for (let index = 0; index <= limit; index++) {
-    const event = events[index];
-    if (!isManageTodoEvent(event)) continue;
-    if (!eventMatchesSession(event, sessionId)) continue;
-
-    const nextTodos = extractTodosFromEvent(event);
-    if (nextTodos.length === 0) continue;
-    todos = preserveTodoContent(todos, nextTodos);
-  }
-
-  return todos;
-}
-
-// ============================================
-// Hook
-// ============================================
-
 export function useTodoSync(sessionId?: string): void {
-  const simulatorEvents = useAtomValue(simulatorEventsAtom);
-  const liveEvents = useAtomValue(eventsAtom);
-  const pipelineSessionId = useAtomValue(sessionIdAtom);
-  const currentEvent = useAtomValue(currentEventAtom);
   const updateTodosForSession = useSetAtom(updateTodosForSessionAtom);
   const clearTodosForSession = useSetAtom(clearTodosForSessionAtom);
   const store = useStore();
 
   const lastSessionIdRef = useRef<string | undefined>(sessionId);
-  const processedCountRef = useRef<number>(0);
   const lastProcessedTodoSnapshotRef = useRef<string | null>(null);
-  const lastCurrentEventIdRef = useRef<string | null>(null);
 
   // Clear todos on session change, then load persisted todos from backend
   useEffect(() => {
     if (sessionId !== lastSessionIdRef.current) {
       const prev = lastSessionIdRef.current;
       lastSessionIdRef.current = sessionId;
-      processedCountRef.current = 0;
       lastProcessedTodoSnapshotRef.current = null;
       // Only clear when actually switching to a *different* session.
       // A transient undefined (panel remount / layout shuffle) must not
@@ -217,12 +101,6 @@ export function useTodoSync(sessionId?: string): void {
         });
       })
       .catch((err) => {
-        // Previously this catch was a complete no-op which masked
-        // "todos never reload after refresh" bugs whenever the
-        // Rust side returned an unexpected rejection (transport
-        // error, schema mismatch, etc.). We now keep silent for
-        // the *known* benign rejection — "session is not a coding
-        // agent" — and warn loudly for everything else.
         if (cancelled) return;
         if (isExpectedTodoLoadRejection(err)) return;
         log.warn(
@@ -236,75 +114,38 @@ export function useTodoSync(sessionId?: string): void {
     };
   }, [sessionId, clearTodosForSession, updateTodosForSession, store]);
 
-  // Process todo events — find the latest manage_todo up to the replay cursor.
-  // Prefer the full event store when it matches this surface's session so
-  // merged tool_result payloads refresh the pin bar on the same tool_call id.
   useEffect(() => {
     if (!sessionId) return;
-    if (pipelineSessionId && pipelineSessionId !== sessionId) return;
 
-    const replayEvents =
-      pipelineSessionId === sessionId && liveEvents.length > 0
-        ? liveEvents
-        : simulatorEvents;
-    if (!replayEvents || replayEvents.length === 0) return;
+    const syncFromEvents = () => {
+      const activeSessionId = lastSessionIdRef.current;
+      if (!activeSessionId) return;
 
-    const currentEventId = currentEvent?.id ?? null;
+      const inputs = store.get(todoReplaySyncInputsAtom);
+      const result = syncTodosFromReplayEvents({
+        sessionId: activeSessionId,
+        pipelineSessionId: inputs.pipelineSessionId,
+        liveEvents: inputs.liveEvents,
+        simulatorEvents: inputs.simulatorEvents,
+        currentEvent: inputs.currentEvent,
+        lastSnapshot: lastProcessedTodoSnapshotRef.current,
+      });
+      if (!result) return;
 
-    if (
-      replayEvents.length === processedCountRef.current &&
-      currentEventId === lastCurrentEventIdRef.current
-    ) {
-      return;
-    }
+      updateTodosForSession({
+        sessionId: activeSessionId,
+        todos: result.todos,
+        merge: false,
+        timestamp: result.timestamp,
+      });
+      lastProcessedTodoSnapshotRef.current = result.snapshot;
+    };
 
-    let maxIndex = replayEvents.length - 1;
-    if (currentEventId) {
-      const currentIndex = replayEvents.findIndex(
-        (event) => event.id === currentEventId
-      );
-      if (currentIndex !== -1) {
-        maxIndex = currentIndex;
-      }
-    }
+    const unsubscribe = store.sub(todoReplaySyncInputsAtom, syncFromEvents);
+    syncFromEvents();
 
-    const latestTodoEvent = findLatestManageTodoEvent(
-      replayEvents,
-      sessionId,
-      maxIndex
-    );
-
-    processedCountRef.current = replayEvents.length;
-    lastCurrentEventIdRef.current = currentEventId;
-
-    if (!latestTodoEvent) return;
-
-    const todos = extractTodosFromManageTodoSequence(
-      replayEvents,
-      sessionId,
-      maxIndex
-    );
-    if (todos.length === 0) return;
-
-    const snapshot = serializeTodoSnapshot(todos);
-    if (snapshot === lastProcessedTodoSnapshotRef.current) return;
-
-    updateTodosForSession({
-      sessionId,
-      todos,
-      merge: false,
-      timestamp: latestTodoEvent.createdAt,
-    });
-
-    lastProcessedTodoSnapshotRef.current = snapshot;
-  }, [
-    sessionId,
-    pipelineSessionId,
-    liveEvents,
-    simulatorEvents,
-    currentEvent,
-    updateTodosForSession,
-  ]);
+    return unsubscribe;
+  }, [sessionId, store, updateTodosForSession]);
 }
 
 export default useTodoSync;

--- a/src/engines/SessionCore/hooks/useAgentADEActions.ts
+++ b/src/engines/SessionCore/hooks/useAgentADEActions.ts
@@ -17,7 +17,6 @@
  * Also ensures that ActionSystem actions are registered (via registerCoreActions)
  * so they're available even if the Workstation editor isn't mounted.
  */
-import { Channel, invoke } from "@tauri-apps/api/core";
 import { useAtomValue } from "jotai";
 import { useEffect, useRef } from "react";
 
@@ -29,6 +28,10 @@ import {
 } from "@src/ActionSystem";
 import { sendAdeActionResult } from "@src/api/tauri/agent";
 import { clearSessionAtom } from "@src/engines/SessionCore/core/atoms/actions";
+import {
+  GLOBAL_UI_CHANNEL_SESSION_ID,
+  subscribeToSessionEvents,
+} from "@src/engines/SessionCore/sync/useSessionChannel";
 import { reposAtom } from "@src/store/repo/atoms";
 import {
   SESSION_TARGET_KIND,
@@ -49,9 +52,11 @@ import { getInstrumentedStore } from "@src/util/core/state/instrumentedStore";
 import { recordPushEvent } from "@src/util/monitoring/apiTracker";
 
 import {
-  extractInvokingSessionId,
-  resolveTrustedDispatchParams,
-} from "./adeReplyBinding";
+  type AdeActionDetail,
+  dispatchAdeActionDetail,
+  parseAdeActionEnvelope,
+} from "./adeActionEnvelope";
+import { resolveTrustedDispatchParams } from "./adeReplyBinding";
 
 /**
  * Pending session proposal — set by `session.propose` handler,
@@ -75,64 +80,6 @@ export const pendingSessionProposal: {
 
 const ADE_MANAGER_REQUIRED_MESSAGE =
   "ADE Manager is off. Toggle ADE Manager on to allow GUI automation actions.";
-
-// ============================================
-// Types
-// ============================================
-
-type AdeActionOperation = "list" | "inspect" | "dispatch";
-
-interface AdeActionDetail {
-  correlationId: string;
-  action?: string;
-  params: Record<string, unknown>;
-  operation?: AdeActionOperation;
-  sessionId?: string;
-  invokingSessionId?: string;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function parseAdeActionEnvelope(rawMessage: string): AdeActionDetail | null {
-  const parsed = JSON.parse(rawMessage) as unknown;
-  if (!isRecord(parsed) || parsed.type !== "agent:ade_action") return null;
-  const payload = parsed.payload;
-  if (!isRecord(payload)) return null;
-
-  const correlationId = payload.correlationId;
-  if (typeof correlationId !== "string" || correlationId.length === 0) {
-    return null;
-  }
-
-  const operation = payload.operation;
-  const action = payload.action;
-  const params = payload.params;
-  const sessionId = payload.sessionId;
-  const invokingSessionId = extractInvokingSessionId(payload);
-
-  return {
-    correlationId,
-    ...(operation === "list" ||
-    operation === "inspect" ||
-    operation === "dispatch"
-      ? { operation }
-      : {}),
-    ...(typeof action === "string" ? { action } : {}),
-    params: isRecord(params) ? params : {},
-    ...(typeof sessionId === "string" ? { sessionId } : {}),
-    ...(invokingSessionId !== undefined ? { invokingSessionId } : {}),
-  };
-}
-
-function dispatchAdeActionDetail(detail: AdeActionDetail): void {
-  window.dispatchEvent(
-    new CustomEvent("agent-ade-action", {
-      detail,
-    })
-  );
-}
 
 function getStringParam(
   params: Record<string, unknown> | undefined,
@@ -179,58 +126,27 @@ export function useAgentADEActions(): void {
   const activeWorkspaceRoot = useAtomValue(activeWorkspaceRootAtom);
   const adeManagerEnabled = useAtomValue(adeManagerEnabledAtom);
   const cleanupRef = useRef<(() => void) | null>(null);
-  const adeManagerEnabledRef = useRef(false);
+  const adeManagerEnabledRef = useRef(adeManagerEnabled);
   const handledCorrelationIdsRef = useRef<Set<string>>(new Set());
-  const repoPathRef = useRef<string>("");
-
-  useEffect(() => {
-    repoPathRef.current = activeWorkspaceRoot?.path ?? "";
-  }, [activeWorkspaceRoot?.path]);
 
   useEffect(() => {
     adeManagerEnabledRef.current = adeManagerEnabled;
   }, [adeManagerEnabled]);
 
   useEffect(() => {
-    const sessionId = "";
-    const channel = new Channel<string>();
-    let cancelled = false;
-    let channelId: number | null = null;
-
-    channel.onmessage = (rawMessage: string) => {
-      if (cancelled) return;
-      recordPushEvent("channel", "ade-actions");
-      try {
-        const detail = parseAdeActionEnvelope(rawMessage);
-        if (detail) dispatchAdeActionDetail(detail);
-      } catch {
-        return;
-      }
-    };
-
-    invoke<number>("subscribe_session_events", {
-      sessionId,
-      onEvent: channel,
-    })
-      .then((id) => {
-        if (cancelled) {
-          void invoke("unsubscribe_session_events", {
-            sessionId,
-            channelId: id,
-          });
+    return subscribeToSessionEvents(
+      GLOBAL_UI_CHANNEL_SESSION_ID,
+      (rawMessage) => {
+        try {
+          const detail = parseAdeActionEnvelope(rawMessage);
+          if (!detail) return;
+          recordPushEvent("channel", "ade-actions");
+          dispatchAdeActionDetail(detail);
+        } catch {
           return;
         }
-        channelId = id;
-      })
-      .catch(() => {});
-
-    return () => {
-      cancelled = true;
-      channel.onmessage = () => undefined;
-      if (channelId !== null) {
-        void invoke("unsubscribe_session_events", { sessionId, channelId });
       }
-    };
+    );
   }, []);
 
   // Register actions and listen for ADE action events

--- a/src/engines/SessionCore/sync/useSessionChannel.ts
+++ b/src/engines/SessionCore/sync/useSessionChannel.ts
@@ -51,6 +51,14 @@ import { recordPushEvent } from "@src/util/monitoring/apiTracker";
 
 const log = createLogger("useSessionChannel");
 
+/**
+ * Session id for the global UI-control IPC channel. Rust broadcasts
+ * session-less `agent:ade_action` frames to every registered channel;
+ * mounting a dedicated listener on this id keeps ADE bridge traffic on
+ * the shared multiplex registry instead of a raw one-off subscribe.
+ */
+export const GLOBAL_UI_CHANNEL_SESSION_ID = "";
+
 const readySessionChannels = new Set<string>();
 const readySessionChannelWaiters = new Map<string, Set<() => void>>();
 type SessionEventListener = (raw: string) => void;

--- a/src/modules/useWorkStationPipelineBridge.ts
+++ b/src/modules/useWorkStationPipelineBridge.ts
@@ -34,6 +34,7 @@ import {
   activeSessionIdAtom,
   workstationActiveSessionIdAtom,
 } from "@src/store/session";
+import { subscribeToAtoms } from "@src/util/core/state/subscribeToAtoms";
 
 /**
  * Minimal store interface used by the bridge so the same production
@@ -87,17 +88,14 @@ export function installWorkStationPipelineBridge(
 
   // Subscribe before the initial reconciliation so no write can land in the
   // gap between reading the remembered selection and installing the guard.
-  const unsubscribeMemory = store.sub(
-    workstationActiveSessionIdAtom,
+  const unsubscribe = subscribeToAtoms(
+    store,
+    [workstationActiveSessionIdAtom, activeSessionIdAtom],
     reconcile
   );
-  const unsubscribePipeline = store.sub(activeSessionIdAtom, reconcile);
   reconcile();
 
-  return () => {
-    unsubscribePipeline();
-    unsubscribeMemory();
-  };
+  return unsubscribe;
 }
 
 export function useWorkStationPipelineBridge(

--- a/src/util/core/state/__tests__/subscribeToAtoms.test.ts
+++ b/src/util/core/state/__tests__/subscribeToAtoms.test.ts
@@ -1,0 +1,52 @@
+import { atom, createStore } from "jotai";
+import { describe, expect, it, vi } from "vitest";
+
+import { subscribeToAtoms } from "../subscribeToAtoms";
+
+describe("subscribeToAtoms", () => {
+  it("invokes listener when any subscribed atom changes", () => {
+    const store = createStore();
+    const countAtom = atom(0);
+    const labelAtom = atom("idle");
+    const listener = vi.fn();
+
+    subscribeToAtoms(store, [countAtom, labelAtom], listener);
+    listener.mockClear();
+
+    store.set(countAtom, 1);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    store.set(labelAtom, "busy");
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops notifying after the returned disposer runs", () => {
+    const store = createStore();
+    const countAtom = atom(0);
+    const labelAtom = atom("idle");
+    const listener = vi.fn();
+
+    const unsubscribe = subscribeToAtoms(
+      store,
+      [countAtom, labelAtom],
+      listener
+    );
+    listener.mockClear();
+
+    unsubscribe();
+    store.set(countAtom, 1);
+    store.set(labelAtom, "busy");
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("returns a no-op disposer for an empty atom list", () => {
+    const store = createStore();
+    const listener = vi.fn();
+
+    const unsubscribe = subscribeToAtoms(store, [], listener);
+
+    expect(() => unsubscribe()).not.toThrow();
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/src/util/core/state/__tests__/windowId.test.ts
+++ b/src/util/core/state/__tests__/windowId.test.ts
@@ -9,7 +9,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { getWindowId } from "./windowId";
+import { getWindowId } from "../windowId";
 
 beforeEach(() => {
   sessionStorage.clear();

--- a/src/util/core/state/subscribeToAtoms.ts
+++ b/src/util/core/state/subscribeToAtoms.ts
@@ -1,0 +1,25 @@
+import type { Atom } from "jotai";
+
+/** Minimal store surface for multi-atom subscriptions. */
+export type AtomSubscribableStore = {
+  sub: <Value>(atom: Atom<Value>, listener: () => void) => () => void;
+};
+
+/**
+ * Subscribe `listener` to every atom in `atoms`.
+ *
+ * Returns one disposer that unsubscribes from all of them — the common
+ * "subscribe in useEffect, loop-unsubscribe on cleanup" pattern.
+ */
+export function subscribeToAtoms(
+  store: AtomSubscribableStore,
+  atoms: readonly Atom<unknown>[],
+  listener: () => void
+): () => void {
+  const unsubscribers = atoms.map((atom) => store.sub(atom, listener));
+  return () => {
+    for (const unsubscribe of unsubscribers) {
+      unsubscribe();
+    }
+  };
+}


### PR DESCRIPTION
## Problem

SessionCore hooks (`useTodoSync`, `useQueueDispatch`, `usePlanningIndicator`, `useSessionEvents`) subscribed to high-frequency atoms via React render paths or duplicated imperative listeners. That caused unnecessary re-renders, repeated hydrate/load work, and multiple dispatch/sync passes when several source atoms changed in the same tick.

Provider-backed history can also leave assistant-shaped turn preview placeholders beside the real body after round-window merge when placeholder detection relied on a provider-specific id prefix.

## Solution

- Move todo sync and queue dispatch onto derived sync-input atoms (`todoReplaySyncInputsAtom`, `queueDispatchSyncInputsAtom`) with a single `store.sub` side-effect channel each.
- Extract todo replay derivation into pure helpers and keep snapshot dedup at the write boundary.
- Consolidate `useSessionEvents` onto `sessionSnapshotAtomFamily` and remove duplicate hydrate/subscribe paths.
- Simplify planning indicator idle timing with a reducer-backed debounce helper; scoped mode uses noop atoms to avoid global subscriptions.
- Share ADE action envelope parsing/dispatch and route UI channel subscriptions through `subscribeToSessionEvents`.
- Add `subscribeToAtoms` for multi-atom cleanup ergonomics (pipeline bridge, prior call sites).
- Bundle Rust placeholder cleanup: match unloaded-turn semantics via `placeholder_turn_id(event)` instead of a hard-coded prefix, with regression coverage.

## Potential risks

- Behavior-preserving refactor, but timing-sensitive UX paths (planning footer cold start, todo pill on session switch, queue Send Now / FIFO drain) should be manually verified.
- Derived sync-input atoms still run their downstream logic once per atom change; only duplicate notifications in the same batch are removed.
- Rust placeholder matching broadens beyond one prefix; incorrect `unloadedTurn` payloads could hide legitimate preview rows — mitigated by the new merge regression test.
- `useSessionEvents` Cursor IDE error surfacing still depends on explicit pre-warm in the hook for some mount paths.

## Verification

- `pnpm vitest run src/engines/SessionCore/hooks/session/__tests__/ src/engines/SessionCore/derived/__tests__/todoReplaySyncInputsAtom.test.ts src/engines/SessionCore/derived/__tests__/queueDispatchSyncInputsAtom.test.ts src/engines/SessionCore/hooks/__tests__/adeActionEnvelope.test.ts src/engines/SessionCore/hooks/replay/__tests__/planningIndicatorIdleTiming.test.ts src/util/core/state/__tests__/subscribeToAtoms.test.ts` — 90 tests passed
- `cargo test --lib test_merge_round_window_events_removes_provider_final_reply_preview` — passed
- Pre-commit hook: eslint/prettier, scoped TypeScript check, scoped cargo clippy — passed on commit

### Manual checks (NOT RUN)

- Todo pill stays aligned during replay scrub and live streaming
- Planning footer appears/hides without flicker between tools
- Queue Send Now / natural FIFO drain under active + idle sessions
- Subagent nested ChatHistory event loading
- ADE action dispatch from agent channel