### PR TITLE
fix(team-inbox): prevent partial initial load flash

### DIFF
--- a/src/modules/MainApp/TeamInbox/ConnectedTeamInboxView.tsx
+++ b/src/modules/MainApp/TeamInbox/ConnectedTeamInboxView.tsx
@@ -47,6 +47,7 @@ const ConnectedTeamInboxView: React.FC = () => {
       onNavigate={navigate}
       pullRequests={pullRequests.items}
       pullRequestsLoading={pullRequests.loading}
+      pullRequestsInitialLoading={pullRequests.initialLoading}
       pullRequestsError={pullRequests.error}
       onRefreshPullRequests={pullRequests.refresh}
       onOpenPullRequestTab={openPullRequestTab}

--- a/src/modules/MainApp/TeamInbox/TeamInboxView.tsx
+++ b/src/modules/MainApp/TeamInbox/TeamInboxView.tsx
@@ -47,6 +47,7 @@ export interface TeamInboxViewProps {
   viewerMemberIds?: readonly string[];
   pullRequests?: readonly ManagedPrItem[];
   pullRequestsLoading?: boolean;
+  pullRequestsInitialLoading?: boolean;
   pullRequestsError?: string | null;
   onRefreshPullRequests?: () => void;
   /** Explicit header action; row selection always stays in the right pane. */
@@ -70,6 +71,7 @@ const TeamInboxView: React.FC<TeamInboxViewProps> = ({
   viewerMemberIds = [],
   pullRequests = [],
   pullRequestsLoading = false,
+  pullRequestsInitialLoading = pullRequestsLoading,
   pullRequestsError = null,
   onRefreshPullRequests,
   onOpenPullRequestTab,
@@ -93,6 +95,7 @@ const TeamInboxView: React.FC<TeamInboxViewProps> = ({
     authoritativeUnreadCounts,
     loadState,
     setLoadState,
+    initialLoading: inboxInitialLoading,
     reloadRevision,
     hasMore,
     loadingMore,
@@ -126,6 +129,16 @@ const TeamInboxView: React.FC<TeamInboxViewProps> = ({
   const [dismissedLoadNoticeKey, setDismissedLoadNoticeKey] = useState<
     string | null
   >(null);
+  const initialCombinedLoadPending =
+    inboxInitialLoading || pullRequestsInitialLoading;
+  const presentedItems = useMemo(
+    () => (initialCombinedLoadPending ? [] : items),
+    [initialCombinedLoadPending, items]
+  );
+  const presentedPullRequests = useMemo(
+    () => (initialCombinedLoadPending ? [] : pullRequests),
+    [initialCombinedLoadPending, pullRequests]
+  );
 
   const loadNoticeKey =
     (loadState.status === "error" || loadState.status === "warning") &&
@@ -148,25 +161,27 @@ const TeamInboxView: React.FC<TeamInboxViewProps> = ({
   const visibleItems = useMemo(
     () =>
       searchTeamInboxItems(
-        selectTeamInboxItems(items, visibleFilter),
+        selectTeamInboxItems(presentedItems, visibleFilter),
         visibleQuery
       ),
-    [items, visibleFilter, visibleQuery]
+    [presentedItems, visibleFilter, visibleQuery]
   );
   const loadedUnreadCounts = useMemo(
-    () => countUnreadTeamInboxItemsByFilter(items),
-    [items]
+    () => countUnreadTeamInboxItemsByFilter(presentedItems),
+    [presentedItems]
   );
-  const unreadCounts = authoritativeUnreadCounts ?? loadedUnreadCounts;
+  const unreadCounts = initialCombinedLoadPending
+    ? loadedUnreadCounts
+    : (authoritativeUnreadCounts ?? loadedUnreadCounts);
   const totalUnread = unreadCounts.all;
   const selectedPullRequest = useMemo(
     () =>
-      pullRequests.find(
+      presentedPullRequests.find(
         (pullRequest) =>
           getManagedPullRequestKey(pullRequest) ===
           viewState.selectedPullRequestKey
       ) ?? null,
-    [pullRequests, viewState.selectedPullRequestKey]
+    [presentedPullRequests, viewState.selectedPullRequestKey]
   );
   const selectedPullRequestIdentity = useMemo<PrIdentity | null>(
     () =>
@@ -273,12 +288,15 @@ const TeamInboxView: React.FC<TeamInboxViewProps> = ({
     [dataSource, setItems, viewerMemberIds]
   );
 
+  const detailLoadState = initialCombinedLoadPending
+    ? { status: "loading" as const, message: null }
+    : loadState;
   const detail = (
     <TeamInboxDetailPane
       t={t}
       dataSource={dataSource}
-      loadState={loadState}
-      itemCount={items.length}
+      loadState={detailLoadState}
+      itemCount={presentedItems.length}
       selectedItem={selectedItem}
       selectedPullRequest={selectedPullRequest}
       selectedPullRequestIdentity={selectedPullRequestIdentity}
@@ -292,9 +310,10 @@ const TeamInboxView: React.FC<TeamInboxViewProps> = ({
   );
 
   const loadNotice =
+    !initialCombinedLoadPending &&
     loadNoticeKey &&
     dismissedLoadNoticeKey !== loadNoticeKey &&
-    (items.length > 0 || pullRequests.length > 0) ? (
+    (presentedItems.length > 0 || presentedPullRequests.length > 0) ? (
       <InlineAlert
         type={loadState.status === "warning" ? "warning" : "danger"}
         hideIcon
@@ -329,8 +348,9 @@ const TeamInboxView: React.FC<TeamInboxViewProps> = ({
           mainContentClassName="bg-chat-pane"
           listContent={
             loadState.status === "error" &&
-            items.length === 0 &&
-            pullRequests.length === 0 ? (
+            !initialCombinedLoadPending &&
+            presentedItems.length === 0 &&
+            presentedPullRequests.length === 0 ? (
               <Placeholder
                 variant="error"
                 placement="sidebar"
@@ -353,9 +373,11 @@ const TeamInboxView: React.FC<TeamInboxViewProps> = ({
                     unreadCounts={unreadCounts}
                     query={visibleQuery}
                     loading={
-                      loadState.status === "loading" || pullRequestsLoading
+                      initialCombinedLoadPending ||
+                      loadState.status === "loading" ||
+                      pullRequestsLoading
                     }
-                    pullRequests={pullRequests}
+                    pullRequests={presentedPullRequests}
                     pullRequestsLoading={pullRequestsLoading}
                     pullRequestsError={pullRequestsError}
                     selectedPullRequestKey={viewState.selectedPullRequestKey}

--- a/src/modules/MainApp/TeamInbox/__tests__/TeamInboxView.layout.test.ts
+++ b/src/modules/MainApp/TeamInbox/__tests__/TeamInboxView.layout.test.ts
@@ -210,6 +210,205 @@ describe("TeamInboxView split layout", () => {
     expect(componentProps.list?.loading).toBe(true);
   });
 
+  it("keeps the initial gate closed for a source loading snapshot", async () => {
+    let emitSnapshot: (() => void) | undefined;
+    let page = {
+      items: [] as AssignedWorkItem[],
+      nextCursor: null,
+      loading: true,
+    };
+    const dataSource = {
+      getSnapshot: () => page,
+      listPage: vi.fn(async () => page),
+      subscribe: (listener: () => void) => {
+        emitSnapshot = listener;
+        return vi.fn();
+      },
+    };
+
+    await act(async () => {
+      root.render(
+        createElement(TeamInboxView, {
+          dataSource,
+          pullRequests: [createPullRequest()],
+        })
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(componentProps.list?.items).toEqual([]);
+    expect(componentProps.list?.pullRequests).toEqual([]);
+    expect(componentProps.list?.loading).toBe(true);
+
+    page = { items: [partialLoadItem], nextCursor: null, loading: false };
+    await act(async () => {
+      emitSnapshot?.();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(componentProps.list?.items).toEqual([partialLoadItem]);
+    expect(componentProps.list?.pullRequests).toEqual([createPullRequest()]);
+    expect(componentProps.list?.loading).toBe(false);
+  });
+
+  it("holds the first Inbox snapshot until pull requests finish loading", async () => {
+    const listPage = vi.fn(async () => ({
+      items: [partialLoadItem],
+      nextCursor: null,
+      unreadCounts: { all: 1, mentions: 0, assigned: 1 },
+    }));
+
+    await act(async () => {
+      root.render(
+        createElement(TeamInboxView, {
+          dataSource: { listPage },
+          pullRequestsLoading: true,
+          pullRequestsInitialLoading: true,
+        })
+      );
+      await Promise.resolve();
+    });
+
+    expect(componentProps.list?.items).toEqual([]);
+    expect(componentProps.list?.pullRequests).toEqual([]);
+    expect(componentProps.list?.unreadCounts).toEqual({
+      all: 0,
+      mentions: 0,
+      assigned: 0,
+    });
+    expect(componentProps.list?.loading).toBe(true);
+
+    await act(async () => {
+      root.render(
+        createElement(TeamInboxView, {
+          dataSource: { listPage },
+          pullRequestsLoading: false,
+          pullRequests: [createPullRequest()],
+        })
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(componentProps.list?.items).toEqual([partialLoadItem]);
+    expect(componentProps.list?.pullRequests).toEqual([createPullRequest()]);
+    expect(componentProps.list?.unreadCounts).toEqual({
+      all: 1,
+      mentions: 0,
+      assigned: 1,
+    });
+    expect(componentProps.list?.loading).toBe(false);
+  });
+
+  it("keeps loaded content visible during later pull-request refreshes", async () => {
+    const listPage = vi.fn(async () => ({
+      items: [partialLoadItem],
+      nextCursor: null,
+    }));
+
+    await act(async () => {
+      root.render(
+        createElement(TeamInboxView, {
+          dataSource: { listPage },
+          pullRequests: [createPullRequest()],
+          pullRequestsLoading: true,
+          pullRequestsInitialLoading: false,
+        })
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(componentProps.list?.items).toEqual([partialLoadItem]);
+    expect(componentProps.list?.pullRequests).toEqual([createPullRequest()]);
+    expect(componentProps.list?.loading).toBe(true);
+  });
+
+  it("keeps loaded Inbox content visible during explicit refresh", async () => {
+    let resolveRefresh!: (value: {
+      items: AssignedWorkItem[];
+      nextCursor: null;
+    }) => void;
+    let requestCount = 0;
+    const listPage = vi.fn(() => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        return Promise.resolve({ items: [partialLoadItem], nextCursor: null });
+      }
+      return new Promise<{ items: AssignedWorkItem[]; nextCursor: null }>(
+        (resolve) => {
+          resolveRefresh = resolve;
+        }
+      );
+    });
+
+    await act(async () => {
+      root.render(createElement(TeamInboxView, { dataSource: { listPage } }));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(componentProps.list?.items).toEqual([partialLoadItem]);
+
+    await act(async () => {
+      const onRefresh = componentProps.list?.onRefresh as
+        | (() => void)
+        | undefined;
+      onRefresh?.();
+      await Promise.resolve();
+    });
+
+    expect(componentProps.list?.items).toEqual([partialLoadItem]);
+    expect(componentProps.list?.loading).toBe(true);
+
+    await act(async () => {
+      resolveRefresh({ items: [partialLoadItem], nextCursor: null });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  });
+
+  it("holds the first pull-request snapshot until Inbox loading finishes", async () => {
+    let resolveInbox!: (value: {
+      items: AssignedWorkItem[];
+      nextCursor: null;
+    }) => void;
+    const listPage = vi.fn(
+      () =>
+        new Promise<{ items: AssignedWorkItem[]; nextCursor: null }>(
+          (resolve) => {
+            resolveInbox = resolve;
+          }
+        )
+    );
+
+    await act(async () => {
+      root.render(
+        createElement(TeamInboxView, {
+          dataSource: { listPage },
+          pullRequests: [createPullRequest()],
+          pullRequestsLoading: false,
+        })
+      );
+      await Promise.resolve();
+    });
+
+    expect(componentProps.list?.items).toEqual([]);
+    expect(componentProps.list?.pullRequests).toEqual([]);
+    expect(componentProps.list?.loading).toBe(true);
+
+    await act(async () => {
+      resolveInbox({ items: [partialLoadItem], nextCursor: null });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(componentProps.list?.items).toEqual([partialLoadItem]);
+    expect(componentProps.list?.pullRequests).toEqual([createPullRequest()]);
+    expect(componentProps.list?.loading).toBe(false);
+  });
+
   it("paints a retained list snapshot before revalidation settles", () => {
     const listPage = vi.fn(() => new Promise<never>(() => undefined));
 

--- a/src/modules/MainApp/TeamInbox/domain/types.ts
+++ b/src/modules/MainApp/TeamInbox/domain/types.ts
@@ -187,6 +187,11 @@ export interface TeamInboxDataSource {
    * Inbox list with a loading frame while the same scope revalidates.
    */
   getSnapshot?(): TeamInboxPage;
+  /**
+   * Stable identity for the current viewer/org scope. It changes only when the
+   * backing scope changes, not on ordinary memo recreation or refresh.
+   */
+  scopeKey?: string;
   listPage(input: ListTeamInboxInput): Promise<TeamInboxPage>;
   markRead?(item: TeamInboxItem): Promise<void>;
   markUnread?(item: TeamInboxItem): Promise<void>;

--- a/src/modules/MainApp/TeamInbox/useTeamInboxDataSource.ts
+++ b/src/modules/MainApp/TeamInbox/useTeamInboxDataSource.ts
@@ -554,6 +554,7 @@ export function useTeamInboxDataSource(): {
     };
 
     return {
+      scopeKey: scope.key,
       getSnapshot,
       listPage: async () => {
         const cache = store.get(teamInboxCacheAtom);

--- a/src/modules/MainApp/TeamInbox/useTeamInboxPagination.ts
+++ b/src/modules/MainApp/TeamInbox/useTeamInboxPagination.ts
@@ -46,6 +46,14 @@ export function useTeamInboxPagination({
       ? loadStateForPage(initialPage, issueMessage)
       : { status: "loading", message: null }
   );
+  const dataSourceScopeKey = dataSource.scopeKey ?? dataSource;
+  const [completedDataSourceScopeKey, setCompletedDataSourceScopeKey] =
+    useState<string | TeamInboxDataSource | null>(() =>
+      initialPage &&
+      loadStateForPage(initialPage, issueMessage).status !== "loading"
+        ? dataSourceScopeKey
+        : null
+    );
   const [reloadRevision, setReloadRevision] = useState(0);
   const [hasMore, setHasMore] = useState(() => initialPage?.nextCursor != null);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -69,6 +77,9 @@ export function useTeamInboxPagination({
         setAuthoritativeUnreadCounts(page.unreadCounts ?? null);
         setHasMore(page.nextCursor != null);
         const nextLoadState = loadStateForPage(page, issueMessage);
+        if (nextLoadState.status !== "loading") {
+          setCompletedDataSourceScopeKey(dataSourceScopeKey);
+        }
         setLoadState((current) =>
           current.status === nextLoadState.status &&
           current.message === nextLoadState.message
@@ -78,6 +89,7 @@ export function useTeamInboxPagination({
       })
       .catch((reason: unknown) => {
         if (abortController.signal.aborted) return;
+        setCompletedDataSourceScopeKey(dataSourceScopeKey);
         setLoadState({
           status: "error",
           message:
@@ -93,7 +105,14 @@ export function useTeamInboxPagination({
       });
 
     return () => abortController.abort();
-  }, [dataSource, issueMessage, pageSize, reloadRevision, t]);
+  }, [
+    dataSource,
+    dataSourceScopeKey,
+    issueMessage,
+    pageSize,
+    reloadRevision,
+    t,
+  ]);
 
   useEffect(() => {
     if (!dataSource.subscribe) return;
@@ -151,6 +170,7 @@ export function useTeamInboxPagination({
     authoritativeUnreadCounts,
     loadState,
     setLoadState,
+    initialLoading: completedDataSourceScopeKey !== dataSourceScopeKey,
     reloadRevision,
     hasMore,
     loadingMore,

--- a/src/modules/MainApp/TeamInbox/useTeamInboxPullRequests.ts
+++ b/src/modules/MainApp/TeamInbox/useTeamInboxPullRequests.ts
@@ -28,6 +28,7 @@ const NO_ISSUE_STATES: GitHubIssuePageState[] = [];
 export interface TeamInboxPullRequestsState {
   items: ManagedPrItem[];
   loading: boolean;
+  initialLoading: boolean;
   error: string | null;
   refresh: () => void;
 }
@@ -75,7 +76,7 @@ export function useTeamInboxPullRequests(): TeamInboxPullRequestsState {
     () => new Set(scopedRepos.map((repo) => repo.id)),
     [scopedRepos]
   );
-  const { repoSources, repoPrMap, loading, loadError } =
+  const { repoSources, repoPrMap, loading, initialLoading, loadError } =
     useGitHubWorkItemsLoadLifecycle({
       repos: scopedRepos,
       scope: GITHUB_QUERY_SCOPE.PR,
@@ -101,6 +102,7 @@ export function useTeamInboxPullRequests(): TeamInboxPullRequestsState {
   return {
     items,
     loading,
+    initialLoading,
     error: loadError,
     refresh,
   };

--- a/src/modules/MainApp/WorkManagement/useGitHubWorkItemsLoadLifecycle.test.ts
+++ b/src/modules/MainApp/WorkManagement/useGitHubWorkItemsLoadLifecycle.test.ts
@@ -10,6 +10,7 @@ import {
   EMPTY_REPO_PRS,
   type GitHubWorkItemsLifecycleSnapshot,
   getGitHubLifecycleRetentionKey,
+  hasCompletedGitHubLifecycleScope,
   loadRepoPermissions,
   loadRepoPrs,
   mergeRepoIssueLoadResults,
@@ -154,6 +155,30 @@ describe("GitHub work-item lifecycle retention", () => {
     expect(getGitHubLifecycleRetentionKey([first], "pr")).not.toBe(
       getGitHubLifecycleRetentionKey([first], "issue")
     );
+  });
+
+  it("treats a newly discovered repository scope as incomplete", () => {
+    const emptyScope = getGitHubLifecycleRetentionKey([], "pr");
+    const populatedScope = getGitHubLifecycleRetentionKey(
+      [
+        {
+          id: "repo-1",
+          name: "one",
+          kind: "git",
+          path: "/one",
+          repo_url: "https://github.com/acme/one.git",
+        },
+      ],
+      "pr"
+    );
+
+    expect(hasCompletedGitHubLifecycleScope(emptyScope, emptyScope)).toBe(true);
+    expect(hasCompletedGitHubLifecycleScope(emptyScope, populatedScope)).toBe(
+      false
+    );
+    expect(
+      hasCompletedGitHubLifecycleScope(populatedScope, populatedScope)
+    ).toBe(true);
   });
 
   it("preserves references for unchanged revalidation results", () => {

--- a/src/modules/MainApp/WorkManagement/useGitHubWorkItemsLoadLifecycle.ts
+++ b/src/modules/MainApp/WorkManagement/useGitHubWorkItemsLoadLifecycle.ts
@@ -123,6 +123,13 @@ export const EMPTY_REPO_PRS: RepoPrState = {
   closedError: null,
 };
 
+export function hasCompletedGitHubLifecycleScope(
+  completedRetentionKey: string | null,
+  retentionKey: string
+): boolean {
+  return completedRetentionKey === retentionKey;
+}
+
 export function getRepoIssueMapKey(source: GitHubRepoSource): string {
   return source.repoFullName;
 }
@@ -458,6 +465,9 @@ export function useGitHubWorkItemsLoadLifecycle({
   const [loadError, setLoadError] = useState<string | null>(
     () => retainedSnapshot?.loadError ?? null
   );
+  const [completedRetentionKey, setCompletedRetentionKey] = useState<
+    string | null
+  >(retainedSnapshot || gitRepos.length === 0 ? retentionKey : null);
   const loadedRef = useRef(Boolean(retainedSnapshot));
   const handledRefreshNonceRef = useRef(0);
   const permissionViewerRef = useRef<string | null>(
@@ -503,6 +513,7 @@ export function useGitHubWorkItemsLoadLifecycle({
         setIfChanged(setRepoSources, []);
         setIfChanged(setRepoIssueMap, {});
         setIfChanged(setRepoPrMap, {});
+        setCompletedRetentionKey(retentionKey);
         setLoading(false);
         return;
       }
@@ -549,6 +560,7 @@ export function useGitHubWorkItemsLoadLifecycle({
         setLoadError(
           viewerLoginError ?? "GitHub viewer identity is unavailable"
         );
+        setCompletedRetentionKey(retentionKey);
         setLoading(false);
         return;
       }
@@ -590,6 +602,7 @@ export function useGitHubWorkItemsLoadLifecycle({
       if (resolvedSources.length === 0) {
         loadedRef.current = true;
         setIfChanged(setRepoSources, []);
+        setCompletedRetentionKey(retentionKey);
         setLoading(false);
         return;
       }
@@ -669,6 +682,7 @@ export function useGitHubWorkItemsLoadLifecycle({
           prResults.find((result) => result.error)?.error ??
           null
       );
+      setCompletedRetentionKey(retentionKey);
       setLoading(false);
     })();
     return () => {
@@ -716,11 +730,16 @@ export function useGitHubWorkItemsLoadLifecycle({
     setLoadError(error);
   }, []);
 
+  const initialLoading = !hasCompletedGitHubLifecycleScope(
+    completedRetentionKey,
+    retentionKey
+  );
   return {
     repoSources,
     repoIssueMap,
     repoPrMap,
-    loading,
+    loading: loading || initialLoading,
+    initialLoading,
     loadError,
     updateIssueMap,
     updatePrMap,


### PR DESCRIPTION
## Problem

Team Inbox loads assigned Work Items from the local read model and actionable pull requests from the GitHub lifecycle independently. When the local snapshot settles first, the list briefly renders only those Work Items; pull-request sections then appear later and shift the visible rows. Repository discovery can also change the GitHub query scope after mount, while the previous lifecycle reports itself as already loaded.

The rows shown during that flash are real persisted Work Items, not hard-coded placeholders. The defect is the partial first-paint sequencing across the two authoritative sources.

## Solution

Track initial completion separately from ordinary refresh loading for both Team Inbox pagination and GitHub work-item lifecycle scopes.

- Give the Team Inbox data source a stable viewer/org scope identity and keep its initial gate closed while the authoritative snapshot still reports `loading`.
- Treat a newly discovered GitHub repository scope as an incomplete initial load until that scope settles.
- Have the connected Team Inbox wait for both initial sources before presenting rows, unread counts, or detail content.
- Preserve already rendered rows during explicit Inbox refreshes and later pull-request refreshes.

The resulting invariant is that the first visible list is a complete combined snapshot for the current scope, while subsequent revalidation remains non-blocking.

## Potential risks

The change adds scope-aware initial-loading state to shared GitHub work-item loading and the Team Inbox data-source contract. The main lifecycle risk is a scope remaining gated after a cancelled or failed request; terminal success, empty-source, and identity-error paths all mark that scope complete, and focused tests cover loading snapshots, source ordering, repository-scope changes, and later refreshes.

There are no database, persistence-format, IPC, dependency, or configuration changes. Rollback is a normal code revert.

A real Tauri/WebView recording with populated local Work Items and actionable pull requests was not captured. A static screenshot would not demonstrate this transient ordering defect, so the PR relies on deterministic lifecycle regression tests and should receive a quick populated-data smoke check before merge.

## Verification

- `./node_modules/.bin/vitest run src/modules/MainApp/WorkManagement/useGitHubWorkItemsLoadLifecycle.test.ts src/modules/MainApp/TeamInbox/__tests__/useTeamInboxDataSource.test.ts src/modules/MainApp/TeamInbox/__tests__/useTeamInboxPullRequests.test.ts src/modules/MainApp/TeamInbox/__tests__/TeamInboxView.layout.test.ts` — 4 files, 32 tests passed.
- `./node_modules/.bin/eslint src/modules/MainApp/WorkManagement/useGitHubWorkItemsLoadLifecycle.ts src/modules/MainApp/WorkManagement/useGitHubWorkItemsLoadLifecycle.test.ts src/modules/MainApp/TeamInbox/ConnectedTeamInboxView.tsx src/modules/MainApp/TeamInbox/TeamInboxView.tsx src/modules/MainApp/TeamInbox/domain/types.ts src/modules/MainApp/TeamInbox/useTeamInboxDataSource.ts src/modules/MainApp/TeamInbox/useTeamInboxPagination.ts src/modules/MainApp/TeamInbox/useTeamInboxPullRequests.ts src/modules/MainApp/TeamInbox/__tests__/TeamInboxView.layout.test.ts --max-warnings 0 --report-unused-disable-directives` — passed with zero warnings.
- `./node_modules/.bin/tsc --noEmit --pretty false` — passed.
- `git diff --check origin/develop...HEAD` — passed.
- Final branch audit — one commit, nine approved files, `0 behind / 1 ahead` of `origin/develop`; no secrets, private paths, debug logs, generated artifacts, lockfile changes, or unrelated BrowserCore work.
- Tauri/WebView populated-data smoke check and recording — not run because no current development instance was available. A static screenshot cannot prove this transient ordering fix; this remains the reason the PR is opened as Draft.

## Submit checklist

- [x] I read and followed `PR_RULES.md`.
- [x] The PR is focused and has a scoped Conventional Commit title, such as `feat(scope): summary` or `fix(scope): summary`.
- [x] I ran the relevant checks, or explained why they were not run.
- [x] No secrets, private config, generated output, or unrelated formatting changes are included.
- [x] Docs, screenshots, and locale updates are included when the change needs them.
