### PR TITLE
perf(chat-panel): narrow ChatView subscriptions and fix replay todo pill

### DIFF
--- a/src/app/root/services/GlobalSessionSync/index.tsx
+++ b/src/app/root/services/GlobalSessionSync/index.tsx
@@ -12,6 +12,7 @@
 import React from "react";
 
 import { useEventStoreBridge } from "@src/engines/SessionCore/core/store/useEventStoreBridge";
+import GlobalPlanningIndicatorBridgeSync from "@src/engines/SessionCore/hooks/replay/GlobalPlanningIndicatorBridgeSync";
 import { useQueueDispatch } from "@src/engines/SessionCore/hooks/session/useQueueDispatch";
 import { useBackgroundSessionMonitor } from "@src/hooks/cliSession/useBackgroundSessionMonitor";
 import { useNotificationApprovalBridge } from "@src/hooks/notifications/useNotificationApprovalBridge";
@@ -25,7 +26,7 @@ const GlobalSessionSync: React.FC = () => {
   useNativeSessionStatusMonitor();
   useTeamInboxNotifications();
   useQueueDispatch();
-  return null;
+  return <GlobalPlanningIndicatorBridgeSync />;
 };
 
 export default GlobalSessionSync;

--- a/src/engines/ChatPanel/ChatHistory/components/PlanningIndicatorBridge.tsx
+++ b/src/engines/ChatPanel/ChatHistory/components/PlanningIndicatorBridge.tsx
@@ -5,7 +5,12 @@ import { useEffect } from "react";
 import { manualCompactInFlightSessionAtom } from "@src/engines/ChatPanel/hooks/useManualCompact";
 import { useStreamingDeltaForSession } from "@src/engines/SessionCore";
 import { sessionIdAtom } from "@src/engines/SessionCore/core/atoms/metadata";
-import { usePlanningIndicator } from "@src/engines/SessionCore/hooks";
+import { globalPlanningIndicatorBridgeOutputAtom } from "@src/engines/SessionCore/derived/planningIndicatorBridgeOutputAtom";
+import {
+  type PlanningIndicatorScope,
+  type PlanningIndicatorState,
+  usePlanningIndicator,
+} from "@src/engines/SessionCore/hooks/replay/usePlanningIndicator";
 import { useConversationRunnerScope } from "@src/features/Org2Cloud/SessionConversation/conversationRunnerScope";
 
 import ChatHistoryList from "./ChatHistoryList";
@@ -14,29 +19,26 @@ interface PlanningIndicatorBridgeProps extends Omit<
   ComponentProps<typeof ChatHistoryList>,
   "planningIndicatorCount" | "planningVariantIndex" | "planningFooterMode"
 > {
-  planningIndicatorScope: { sessionId: string; isLive: boolean } | null;
+  planningIndicatorScope: PlanningIndicatorScope | null;
   planningIndicatorEnabled: boolean;
   onPlanningIndicatorCount: (count: 0 | 1) => void;
 }
 
-/**
- * Isolates the hot planning/streaming subscriptions from the history
- * orchestrator so streaming tokens do not re-render the whole history tree.
- */
-const PlanningIndicatorBridge: FC<PlanningIndicatorBridgeProps> = ({
-  planningIndicatorScope,
+interface PlanningIndicatorBridgeContentProps extends Omit<
+  PlanningIndicatorBridgeProps,
+  "planningIndicatorScope"
+> {
+  effectiveScope: PlanningIndicatorScope | null;
+  planningState: PlanningIndicatorState;
+}
+
+function PlanningIndicatorBridgeContent({
+  effectiveScope,
+  planningState,
   planningIndicatorEnabled,
   onPlanningIndicatorCount,
   ...chatHistoryListProps
-}) => {
-  // A member's turn runs in an invisible local runner; when one is in flight
-  // the indicator must scope to it, not to the idle mounted conversation
-  // session, or a long turn shows no "Thinking…" and looks frozen.
-  const runnerScope = useConversationRunnerScope();
-  const effectiveScope = runnerScope
-    ? { sessionId: runnerScope, isLive: true }
-    : planningIndicatorScope;
-  const { count, variantIndex } = usePlanningIndicator(effectiveScope);
+}: PlanningIndicatorBridgeContentProps) {
   const activeSessionId = useAtomValue(sessionIdAtom);
   const scopedSessionId = effectiveScope?.sessionId ?? activeSessionId;
   const liveDelta = useStreamingDeltaForSession(scopedSessionId);
@@ -49,6 +51,7 @@ const PlanningIndicatorBridge: FC<PlanningIndicatorBridgeProps> = ({
     : isAgentTyping
       ? "agentTyping"
       : "planning";
+  const { count, variantIndex } = planningState;
   const visibleCount = isCompacting
     ? 1
     : planningIndicatorEnabled
@@ -67,6 +70,67 @@ const PlanningIndicatorBridge: FC<PlanningIndicatorBridgeProps> = ({
       planningIndicatorCount={visibleCount}
       planningVariantIndex={variantIndex}
       planningFooterMode={planningFooterMode}
+    />
+  );
+}
+
+function ScopedPlanningIndicatorBridge({
+  effectiveScope,
+  ...props
+}: PlanningIndicatorBridgeProps & {
+  effectiveScope: PlanningIndicatorScope;
+}) {
+  const planningState = usePlanningIndicator(effectiveScope);
+  return (
+    <PlanningIndicatorBridgeContent
+      {...props}
+      effectiveScope={effectiveScope}
+      planningState={planningState}
+    />
+  );
+}
+
+function GlobalPlanningIndicatorBridge(props: PlanningIndicatorBridgeProps) {
+  const planningState = useAtomValue(globalPlanningIndicatorBridgeOutputAtom);
+  return (
+    <PlanningIndicatorBridgeContent
+      {...props}
+      effectiveScope={null}
+      planningState={planningState}
+    />
+  );
+}
+
+/**
+ * Isolates the hot planning/streaming subscriptions from the history
+ * orchestrator so streaming tokens do not re-render the whole history tree.
+ *
+ * Global mode reads the output atom synced by GlobalPlanningIndicatorBridgeSync
+ * so the primary ChatPanel does not mount a second usePlanningIndicator tree.
+ */
+const PlanningIndicatorBridge: FC<PlanningIndicatorBridgeProps> = ({
+  planningIndicatorScope,
+  ...props
+}) => {
+  const runnerScope = useConversationRunnerScope();
+  const effectiveScope = runnerScope
+    ? { sessionId: runnerScope, isLive: true }
+    : planningIndicatorScope;
+
+  if (effectiveScope) {
+    return (
+      <ScopedPlanningIndicatorBridge
+        {...props}
+        planningIndicatorScope={planningIndicatorScope}
+        effectiveScope={effectiveScope}
+      />
+    );
+  }
+
+  return (
+    <GlobalPlanningIndicatorBridge
+      {...props}
+      planningIndicatorScope={planningIndicatorScope}
     />
   );
 };

--- a/src/engines/ChatPanel/ChatView.tsx
+++ b/src/engines/ChatPanel/ChatView.tsx
@@ -23,6 +23,7 @@
  * - Session creator (shown when no session)
  */
 import { useAtomValue, useStore } from "jotai";
+import { selectAtom } from "jotai/utils";
 import React, {
   memo,
   useCallback,
@@ -37,11 +38,9 @@ import { getImportedHistoryCliResume } from "@src/api/tauri/externalHistory";
 import Message from "@src/components/Message";
 import { useShowInteractArea } from "@src/contexts/workspace/ChatContext";
 import { forkExternalHistoryIntoOrgiiSession } from "@src/engines/ChatPanel/externalHistoryFork";
-import { derivedSnapshotAtom } from "@src/engines/SessionCore/core/atoms/events";
-import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 import { derivePlanApprovalViewState } from "@src/engines/SessionCore/derived/planDisplayEvents";
+import { chatEventsForSessionAtomFamily } from "@src/engines/SessionCore/derived/sessionScopedChatEvents";
 import { useTodoSync } from "@src/engines/SessionCore/hooks/session/useTodoSync";
-import { SessionCommentsProvider } from "@src/features/Org2Cloud/SessionComments/SessionCommentsContext";
 import { usePinnedSession } from "@src/features/Org2Cloud/SessionConversation/usePinnedSession";
 import { useCloudSessionHasDownloadSurface } from "@src/features/Org2Cloud/useCloudSessionDownloadSurface";
 import { ForkCancelledError } from "@src/features/TeamCollaboration/forkSession";
@@ -53,7 +52,6 @@ import { useSessionView } from "@src/hooks/ui/tabs/useSessionView";
 import { loadSessions, sessionByIdAtom } from "@src/store/session";
 import type { Session } from "@src/store/session";
 import {
-  isSessionActiveAtom,
   restoreToInputAtom,
   sessionRuntimeStatusAtom,
   streamRetryStatusAtom,
@@ -66,15 +64,13 @@ import {
   isImportedHistorySession,
 } from "@src/util/session/sessionDispatch";
 
-import ChatFloatingComposer from "./ChatFloatingComposer";
 import { ChatSessionContext } from "./ChatSessionContext";
+import { ChatViewComposerSection } from "./ChatViewComposerSection";
+import type { ChatViewComposerSectionProps } from "./ChatViewComposerSection.types";
 import { ChatViewHistorySurface } from "./ChatViewHistorySurface";
+import { ChatViewLiveRegion } from "./ChatViewLiveRegion";
 import { ChatViewPostHistoryOverlays } from "./ChatViewPostHistoryOverlays";
 import type { ChatViewProps } from "./ChatViewTypes";
-import {
-  buildCompactFilesReloadKey,
-  countChatRounds,
-} from "./InputArea/components/compactFileChangesHelpers";
 import { useComposerSections } from "./InputArea/hooks/useComposerSections";
 import {
   shouldShowExternalHistoryForkComposer,
@@ -84,7 +80,6 @@ import { resolveInitialFileChanges } from "./chatViewFileChanges";
 import { useBrowserAddToConversationAction } from "./hooks/useBrowserAddToConversationAction";
 import { useChatViewAgentOrgSurface } from "./hooks/useChatViewAgentOrgSurface";
 import { useChatViewAgentStationDiff } from "./hooks/useChatViewAgentStationDiff";
-import { useChatViewCanvasPreview } from "./hooks/useChatViewCanvasPreview";
 import { useChatViewFilesMenu } from "./hooks/useChatViewFilesMenu";
 import { useChatViewFloatingComposerInset } from "./hooks/useChatViewFloatingComposerInset";
 import { useChatViewOrgtrackSummary } from "./hooks/useChatViewOrgtrackSummary";
@@ -95,8 +90,6 @@ import { useFollowAgent } from "./hooks/useFollowAgent";
 import type { SubmitOverrideInput } from "./hooks/useInputArea/types";
 
 const logger = createLogger("ChatView");
-
-const EMPTY_CHAT_EVENTS: SessionEvent[] = [];
 
 export type { ChatViewProps } from "./ChatViewTypes";
 
@@ -290,18 +283,34 @@ const ChatView: React.FC<ChatViewProps> = memo(
     const streamRetryStatus = useAtomValue(streamRetryStatusAtom);
     const streamRetry =
       streamRetryStatus?.sessionId === sessionId ? streamRetryStatus : null;
-    const snapshot = useAtomValue(derivedSnapshotAtom);
-    const canvasPreviewPill = useChatViewCanvasPreview(sessionId, snapshot);
     const currentPlanApproval = usePendingPlanApproval(sessionId);
-    const chatEvents = snapshot?.chatEvents ?? EMPTY_CHAT_EVENTS;
-    // A cloud download blocks the composer only while there is no local
-    // transcript to stand on (first download of a fresh share). Refreshing
-    // an existing copy keeps the composer live: an imported-history submit
-    // forks the REMOTE session, so a stale local cache cannot corrupt the
-    // continuation, and hiding the input for the whole incremental refresh
-    // read as "the chat box takes seconds to appear" on every open.
+    const transcriptEmptyAtom = useMemo(
+      () =>
+        selectAtom(
+          chatEventsForSessionAtomFamily(sessionId),
+          (events) => events.length === 0,
+          (left, right) => left === right
+        ),
+      [sessionId]
+    );
+    const transcriptEmpty = useAtomValue(transcriptEmptyAtom);
+    const showCurrentPlanSurfaceAtom = useMemo(
+      () =>
+        selectAtom(
+          chatEventsForSessionAtomFamily(sessionId),
+          (chatEvents) =>
+            derivePlanApprovalViewState({
+              pendingPlan: currentPlanApproval,
+              chatEvents,
+              displayEvents: chatEvents,
+            }).currentSurfaceVisible,
+          (left, right) => left === right
+        ),
+      [sessionId, currentPlanApproval]
+    );
+    const showCurrentPlanSurface = useAtomValue(showCurrentPlanSurfaceAtom);
     const hasBlockingDownloadSurface =
-      hasCloudDownloadSurface && chatEvents.length === 0;
+      hasCloudDownloadSurface && transcriptEmpty;
     const showExternalHistoryForkComposer =
       shouldShowExternalHistoryForkComposer({
         hasBlockingDownloadSurface,
@@ -318,7 +327,6 @@ const ChatView: React.FC<ChatViewProps> = memo(
       showMainComposer || showExternalHistoryForkComposer;
     const { setMeasuredFloatingComposerRef, historyBottomInset } =
       useChatViewFloatingComposerInset(showFloatingComposer);
-    const isAgentWorking = useAtomValue(isSessionActiveAtom);
 
     const gitArtifactStats = useMemo(
       () => ({
@@ -327,19 +335,6 @@ const ChatView: React.FC<ChatViewProps> = memo(
       }),
       [orgtrackSummary?.relatedCommits]
     );
-    const planViewState = useMemo(
-      () =>
-        derivePlanApprovalViewState({
-          pendingPlan: currentPlanApproval,
-          chatEvents,
-          displayEvents: chatEvents,
-        }),
-      [chatEvents, currentPlanApproval]
-    );
-    const showCurrentPlanSurface = planViewState.currentSurfaceVisible;
-    const currentPlanSurfaceState = planViewState.activePendingEvent
-      ? planViewState.getEventState(planViewState.activePendingEvent, "current")
-      : undefined;
 
     const { scrollNav, handleScrollNavChange, externalScrollToBottomButton } =
       useChatViewScrollToBottom();
@@ -446,16 +441,90 @@ const ChatView: React.FC<ChatViewProps> = memo(
     // ("no active sessionId"), bypassing the fork-before-send flow entirely.
     const inputAreaSessionId = queueSessionId ?? sessionId;
 
-    // Idle-reload signal for the composer "N Files Changed" pill. The pill's
-    // count comes from the per-session-cached orgtrack final diffs, so it must
-    // refetch when the session changes, a new round appears, or the agent goes
-    // idle — mirroring the per-round footer's `turnFilesReloadKey`. Counting
-    // user-message boundaries (not raw event length) keeps this stable during
-    // streaming so the backend isn't hammered mid-turn.
-    const composerFilesReloadKey = buildCompactFilesReloadKey(
-      inputAreaSessionId,
-      countChatRounds(chatEvents),
-      isAgentWorking
+    const composerSectionProps = useMemo(
+      (): ChatViewComposerSectionProps => ({
+        sessionId,
+        inputAreaSessionId,
+        showMainComposer,
+        composerRef: setMeasuredFloatingComposerRef,
+        inputBoxRef,
+        chatPanelPosition: position,
+        planCollapsed,
+        onPlanCollapse: collapsePlan,
+        questionCollapsed,
+        permissionCollapsed,
+        modeSwitchCollapsed,
+        onQuestionCollapse: collapseQuestion,
+        onPermissionCollapse: collapsePermission,
+        onModeSwitchCollapse: collapseModeSwitch,
+        onQuestionDataChange: setHasQuestion,
+        onPermissionDataChange: setHasPermission,
+        onModeSwitchDataChange: setHasModeSwitch,
+        queueExpanded,
+        processExpanded,
+        queuedMessages: sessionMessageQueue,
+        onCancelQueuedMessage: cancelQueuedMessage,
+        onSendQueuedMessageNow: handleSendNow,
+        onReorderQueuedMessages: handleReorderSessionQueue,
+        onToggleQueue: toggleQueue,
+        onToggleProcess: toggleProcess,
+        onProcessVisibleCountChange: setProcessVisibleCount,
+        onFilesExpand: openAgentStationDiff,
+        filesMenu,
+        initialFileChanges,
+        groupChatPendingMessage,
+        groupChatViewActive,
+        hasAnyInlineSection: hasAny,
+        scrollNav,
+        inlineSections,
+        hasModeSwitch,
+        agentOrgIntervention: agentOrgInterventionSlot,
+        streamRetry,
+        groupChatPausedBottomContent,
+        onSubmitOverride: handleMainComposerSubmitOverride,
+        customMentionOptions: groupChatMentionOptions,
+        queueEditProps,
+        disableStopWhenEmpty: groupChatViewActive,
+      }),
+      [
+        sessionId,
+        inputAreaSessionId,
+        showMainComposer,
+        setMeasuredFloatingComposerRef,
+        position,
+        planCollapsed,
+        collapsePlan,
+        questionCollapsed,
+        permissionCollapsed,
+        modeSwitchCollapsed,
+        collapseQuestion,
+        collapsePermission,
+        collapseModeSwitch,
+        queueExpanded,
+        processExpanded,
+        sessionMessageQueue,
+        cancelQueuedMessage,
+        handleSendNow,
+        handleReorderSessionQueue,
+        toggleQueue,
+        toggleProcess,
+        setProcessVisibleCount,
+        openAgentStationDiff,
+        filesMenu,
+        initialFileChanges,
+        groupChatPendingMessage,
+        groupChatViewActive,
+        hasAny,
+        scrollNav,
+        inlineSections,
+        hasModeSwitch,
+        agentOrgInterventionSlot,
+        streamRetry,
+        groupChatPausedBottomContent,
+        handleMainComposerSubmitOverride,
+        groupChatMentionOptions,
+        queueEditProps,
+      ]
     );
 
     // External-history sessions (claudecodeapp/codexapp imports) never enter
@@ -472,128 +541,77 @@ const ChatView: React.FC<ChatViewProps> = memo(
 
     return (
       <ChatSessionContext.Provider value={chatHistorySessionId}>
-        <SessionCommentsProvider
-          session={commentsSession}
-          events={snapshot ? chatEvents : null}
+        <ChatViewLiveRegion
+          commentsSession={commentsSession}
           turnAnchorsVisible={!groupChatViewActive}
-        >
-          <div
-            ref={rootRef}
-            data-chat-view-root
-            data-session-id={chatHistorySessionId}
-            className="relative flex h-full min-w-0 max-w-full flex-col overflow-hidden"
-          >
-            <div
-              ref={handlePinnedHeaderHostRef}
-              className={
-                turnPaginationEnabled || groupChatViewActive
-                  ? "flex flex-shrink-0 flex-col"
-                  : "absolute inset-x-0 top-0 z-40 flex flex-col"
-              }
-              style={
-                chromeTopInset > 0
-                  ? turnPaginationEnabled || groupChatViewActive
-                    ? { paddingTop: chromeTopInset }
-                    : { top: chromeTopInset }
-                  : undefined
-              }
-              data-chat-pinned-header-portal-host
-            />
-            <div className="min-h-0 min-w-0 max-w-full flex-1 overflow-hidden">
-              <ChatViewHistorySurface
-                sessionId={sessionId}
-                chatEvents={chatEvents}
-                groupChatViewActive={groupChatViewActive}
-                groupChatMergedEvents={groupChatMergedEvents}
-                groupChatAgents={groupChatAgents}
-                pipelineSessionId={pipelineSessionId}
-                handleGroupChatTapEvents={handleGroupChatTapEvents}
-                agentMessageClampEligible={agentMessageClampEligible}
-                surfaceBgClass={surfaceBgClass}
-                position={position}
-                currentAgentOrgMember={currentAgentOrgMember}
-                agentOrgRunView={agentOrgRunView}
-                agentOrgRunViewError={agentOrgRunViewError}
-                refreshAgentOrgRunView={refreshAgentOrgRunView}
-                handleAgentOrgMemberSessionJump={
-                  handleAgentOrgMemberSessionJump
+          rootRef={rootRef}
+          dataSessionId={chatHistorySessionId}
+          transcript={
+            <>
+              <div
+                ref={handlePinnedHeaderHostRef}
+                className={
+                  turnPaginationEnabled || groupChatViewActive
+                    ? "flex flex-shrink-0 flex-col"
+                    : "absolute inset-x-0 top-0 z-40 flex flex-col"
                 }
-                handleScrollNavChange={handleScrollNavChange}
-                followAgentNav={followAgentNav}
-                browserAddToConversationNav={browserAddToConversationNav}
-                onRegisterSearchOpen={onRegisterSearchOpen}
-                displayMode={displayMode}
-                turnPaginationEnabled={turnPaginationEnabled}
-                paginationTrailingSlot={groupChatHistoryAction}
-                pinnedHeaderHost={pinnedHeaderHost}
-                chromeTopInset={chromeTopInset}
-                historyBottomInset={historyBottomInset}
-                groupChatViewAvailable={groupChatViewAvailable}
-                handleGroupChatViewToggle={handleGroupChatViewToggle}
-                isReadOnlySurface={isReadOnlySurface}
+                style={
+                  chromeTopInset > 0
+                    ? turnPaginationEnabled || groupChatViewActive
+                      ? { paddingTop: chromeTopInset }
+                      : { top: chromeTopInset }
+                    : undefined
+                }
+                data-chat-pinned-header-portal-host
               />
-            </div>
-            <ChatViewPostHistoryOverlays
-              showExternalHistoryForkComposer={showExternalHistoryForkComposer}
-              composerRef={setMeasuredFloatingComposerRef}
-              position={position}
-              onSubmitOverride={handleExternalHistoryForkSubmit}
-              externalScrollToBottomButton={externalScrollToBottomButton}
-              isImportedHistory={isImportedHistory}
-              sessionId={sessionId}
-            />
-            {showMainComposer && (
-              <ChatFloatingComposer
+              <div className="min-h-0 min-w-0 max-w-full flex-1 overflow-hidden">
+                <ChatViewHistorySurface
+                  sessionId={sessionId}
+                  groupChatViewActive={groupChatViewActive}
+                  groupChatMergedEvents={groupChatMergedEvents}
+                  groupChatAgents={groupChatAgents}
+                  pipelineSessionId={pipelineSessionId}
+                  handleGroupChatTapEvents={handleGroupChatTapEvents}
+                  agentMessageClampEligible={agentMessageClampEligible}
+                  surfaceBgClass={surfaceBgClass}
+                  position={position}
+                  currentAgentOrgMember={currentAgentOrgMember}
+                  agentOrgRunView={agentOrgRunView}
+                  agentOrgRunViewError={agentOrgRunViewError}
+                  refreshAgentOrgRunView={refreshAgentOrgRunView}
+                  handleAgentOrgMemberSessionJump={
+                    handleAgentOrgMemberSessionJump
+                  }
+                  handleScrollNavChange={handleScrollNavChange}
+                  followAgentNav={followAgentNav}
+                  browserAddToConversationNav={browserAddToConversationNav}
+                  onRegisterSearchOpen={onRegisterSearchOpen}
+                  displayMode={displayMode}
+                  turnPaginationEnabled={turnPaginationEnabled}
+                  paginationTrailingSlot={groupChatHistoryAction}
+                  pinnedHeaderHost={pinnedHeaderHost}
+                  chromeTopInset={chromeTopInset}
+                  historyBottomInset={historyBottomInset}
+                  groupChatViewAvailable={groupChatViewAvailable}
+                  handleGroupChatViewToggle={handleGroupChatViewToggle}
+                  isReadOnlySurface={isReadOnlySurface}
+                />
+              </div>
+              <ChatViewPostHistoryOverlays
+                showExternalHistoryForkComposer={
+                  showExternalHistoryForkComposer
+                }
                 composerRef={setMeasuredFloatingComposerRef}
-                inputBoxRef={inputBoxRef}
-                chatPanelPosition={position}
+                position={position}
+                onSubmitOverride={handleExternalHistoryForkSubmit}
+                externalScrollToBottomButton={externalScrollToBottomButton}
+                isImportedHistory={isImportedHistory}
                 sessionId={sessionId}
-                inputAreaSessionId={inputAreaSessionId}
-                currentPlanApproval={currentPlanApproval}
-                shouldShowCurrentPlanSurface={shouldShowCurrentPlanSurface}
-                currentPlanSurfaceState={currentPlanSurfaceState}
-                planCollapsed={planCollapsed}
-                onPlanCollapse={collapsePlan}
-                questionCollapsed={questionCollapsed}
-                permissionCollapsed={permissionCollapsed}
-                modeSwitchCollapsed={modeSwitchCollapsed}
-                onQuestionCollapse={collapseQuestion}
-                onPermissionCollapse={collapsePermission}
-                onModeSwitchCollapse={collapseModeSwitch}
-                onQuestionDataChange={setHasQuestion}
-                onPermissionDataChange={setHasPermission}
-                onModeSwitchDataChange={setHasModeSwitch}
-                queueExpanded={queueExpanded}
-                processExpanded={processExpanded}
-                queuedMessages={sessionMessageQueue}
-                onCancelQueuedMessage={cancelQueuedMessage}
-                onSendQueuedMessageNow={handleSendNow}
-                onReorderQueuedMessages={handleReorderSessionQueue}
-                onToggleQueue={toggleQueue}
-                onToggleProcess={toggleProcess}
-                onProcessVisibleCountChange={setProcessVisibleCount}
-                onFilesExpand={openAgentStationDiff}
-                filesMenu={filesMenu}
-                initialFileChanges={initialFileChanges}
-                filesReloadKey={composerFilesReloadKey}
-                groupChatPendingMessage={groupChatPendingMessage}
-                groupChatViewActive={groupChatViewActive}
-                hasAnyInlineSection={hasAny}
-                scrollNav={scrollNav}
-                canvasPreview={canvasPreviewPill}
-                inlineSections={inlineSections}
-                hasModeSwitch={hasModeSwitch}
-                agentOrgIntervention={agentOrgInterventionSlot}
-                streamRetry={streamRetry}
-                groupChatPausedBottomContent={groupChatPausedBottomContent}
-                onSubmitOverride={handleMainComposerSubmitOverride}
-                customMentionOptions={groupChatMentionOptions}
-                queueEditProps={queueEditProps}
-                disableStopWhenEmpty={groupChatViewActive}
               />
-            )}
-          </div>
-        </SessionCommentsProvider>
+            </>
+          }
+          composer={<ChatViewComposerSection {...composerSectionProps} />}
+        />
       </ChatSessionContext.Provider>
     );
   }

--- a/src/engines/ChatPanel/ChatViewComposerSection.tsx
+++ b/src/engines/ChatPanel/ChatViewComposerSection.tsx
@@ -1,0 +1,55 @@
+import { memo } from "react";
+
+import ChatFloatingComposer from "./ChatFloatingComposer";
+import type { ChatViewComposerSectionProps } from "./ChatViewComposerSection.types";
+import { buildCompactFilesReloadKey } from "./InputArea/components/compactFileChangesHelpers";
+import { useChatViewComposerSignals } from "./hooks/useChatViewComposerSignals";
+
+export type { ChatViewComposerSectionProps } from "./ChatViewComposerSection.types";
+
+export const ChatViewComposerSection = memo(function ChatViewComposerSection(
+  props: ChatViewComposerSectionProps
+) {
+  const {
+    sessionId,
+    inputAreaSessionId,
+    showMainComposer,
+    streamRetry,
+    ...composerProps
+  } = props;
+
+  const {
+    currentPlanApproval,
+    isAgentWorking,
+    chatRoundCount,
+    showCurrentPlanSurface,
+    currentPlanSurfaceState,
+    canvasPreviewPill,
+  } = useChatViewComposerSignals(sessionId, inputAreaSessionId);
+
+  const composerFilesReloadKey = buildCompactFilesReloadKey(
+    inputAreaSessionId,
+    chatRoundCount,
+    isAgentWorking
+  );
+
+  if (!showMainComposer) {
+    return null;
+  }
+
+  return (
+    <ChatFloatingComposer
+      {...composerProps}
+      sessionId={sessionId}
+      inputAreaSessionId={inputAreaSessionId}
+      currentPlanApproval={currentPlanApproval}
+      shouldShowCurrentPlanSurface={showCurrentPlanSurface}
+      currentPlanSurfaceState={currentPlanSurfaceState}
+      filesReloadKey={composerFilesReloadKey}
+      canvasPreview={canvasPreviewPill}
+      streamRetry={streamRetry}
+    />
+  );
+});
+
+ChatViewComposerSection.displayName = "ChatViewComposerSection";

--- a/src/engines/ChatPanel/ChatViewComposerSection.types.ts
+++ b/src/engines/ChatPanel/ChatViewComposerSection.types.ts
@@ -1,0 +1,75 @@
+import type React from "react";
+
+import type { ScrollNavState } from "./ChatHistory";
+import type { InlineSection } from "./InputArea/components/CollapsedInlineRow";
+import type { FileChangesResult } from "./InputArea/components/compactFileChangesHelpers";
+import type { QueueEditInputAreaProps } from "./InputArea/hooks/useQueueEditMode";
+import type {
+  CustomMentionOption,
+  SubmitOverrideInput,
+} from "./hooks/useInputArea/types";
+
+interface StreamRetryInfo {
+  kind: string;
+  attempt: number;
+  maxAttempts: number;
+}
+
+interface AgentOrgInterventionView {
+  intervention:
+    | import("@src/api/tauri/agent").AgentOrgMemberIntervention
+    | null;
+  memberName?: string | null;
+  error: string | null;
+  returning: boolean;
+  onReturnToWork: () => Promise<boolean>;
+}
+
+interface GroupChatPendingMessageView {
+  targetMemberName: string;
+}
+
+export interface ChatViewComposerSectionProps {
+  sessionId: string;
+  inputAreaSessionId: string;
+  showMainComposer: boolean;
+  composerRef: React.Ref<HTMLDivElement>;
+  inputBoxRef?: React.Ref<HTMLDivElement>;
+  chatPanelPosition: "left" | "right";
+  planCollapsed: boolean;
+  onPlanCollapse: () => void;
+  questionCollapsed: boolean;
+  permissionCollapsed: boolean;
+  modeSwitchCollapsed: boolean;
+  onQuestionCollapse: () => void;
+  onPermissionCollapse: () => void;
+  onModeSwitchCollapse: () => void;
+  onQuestionDataChange: (hasData: boolean) => void;
+  onPermissionDataChange: (hasData: boolean) => void;
+  onModeSwitchDataChange: (hasData: boolean) => void;
+  queueExpanded: boolean;
+  processExpanded: boolean;
+  queuedMessages: import("@src/store/ui/messageQueueAtom").QueuedMessage[];
+  onCancelQueuedMessage: (messageId: string) => void;
+  onSendQueuedMessageNow: (messageId: string) => void;
+  onReorderQueuedMessages: (fromIndex: number, toIndex: number) => void;
+  onToggleQueue: () => void;
+  onToggleProcess: () => void;
+  onProcessVisibleCountChange: (count: number) => void;
+  onFilesExpand: () => void;
+  filesMenu?: React.ReactNode;
+  initialFileChanges?: FileChangesResult;
+  groupChatPendingMessage: GroupChatPendingMessageView | null;
+  groupChatViewActive: boolean;
+  hasAnyInlineSection: boolean;
+  scrollNav: ScrollNavState | null;
+  inlineSections: InlineSection[];
+  hasModeSwitch: boolean;
+  agentOrgIntervention: AgentOrgInterventionView | null;
+  streamRetry: StreamRetryInfo | null;
+  groupChatPausedBottomContent: React.ReactNode;
+  onSubmitOverride: (input: SubmitOverrideInput) => Promise<boolean>;
+  customMentionOptions: ReadonlyArray<CustomMentionOption>;
+  queueEditProps: QueueEditInputAreaProps;
+  disableStopWhenEmpty?: boolean;
+}

--- a/src/engines/ChatPanel/ChatViewHistorySurface.tsx
+++ b/src/engines/ChatPanel/ChatViewHistorySurface.tsx
@@ -17,7 +17,6 @@ import AgentOrgOverviewPanel from "./InputArea/components/AgentOrgOverviewPanel"
 
 interface ChatViewHistorySurfaceProps {
   sessionId: string;
-  chatEvents: SessionEvent[];
   groupChatViewActive: boolean;
   groupChatMergedEvents: SessionEvent[];
   groupChatAgents: ReadonlyArray<{ sessionId: string }>;
@@ -50,7 +49,6 @@ interface ChatViewHistorySurfaceProps {
 
 export function ChatViewHistorySurface({
   sessionId,
-  chatEvents,
   groupChatViewActive,
   groupChatMergedEvents,
   groupChatAgents,
@@ -81,7 +79,6 @@ export function ChatViewHistorySurface({
   return (
     <ConversationStreamProvider
       sessionId={sessionId}
-      chatEvents={chatEvents}
       overrideEvents={groupChatViewActive ? groupChatMergedEvents : undefined}
     >
       <GroupChatProvider

--- a/src/engines/ChatPanel/ChatViewLiveRegion.tsx
+++ b/src/engines/ChatPanel/ChatViewLiveRegion.tsx
@@ -1,0 +1,50 @@
+import { type ReactNode, memo } from "react";
+
+import { SessionCommentsProvider } from "@src/features/Org2Cloud/SessionComments/SessionCommentsContext";
+import type { Session } from "@src/store/session";
+
+import { usePipelineChatEvents } from "./hooks/usePipelineChatEvents";
+
+interface ChatViewLiveRegionProps {
+  commentsSession: Session | null;
+  turnAnchorsVisible: boolean;
+  rootRef: React.RefObject<HTMLDivElement | null>;
+  dataSessionId: string;
+  transcript: ReactNode;
+  composer: ReactNode;
+}
+
+/**
+ * Owns the hot pipeline transcript subscription and cloud comment anchor
+ * stream so the ChatView shell can stay on narrow composer/layout atoms.
+ */
+export const ChatViewLiveRegion = memo(function ChatViewLiveRegion({
+  commentsSession,
+  turnAnchorsVisible,
+  rootRef,
+  dataSessionId,
+  transcript,
+  composer,
+}: ChatViewLiveRegionProps) {
+  const { chatEvents, transcriptReady } = usePipelineChatEvents();
+
+  return (
+    <SessionCommentsProvider
+      session={commentsSession}
+      events={transcriptReady ? chatEvents : null}
+      turnAnchorsVisible={turnAnchorsVisible}
+    >
+      <div
+        ref={rootRef}
+        data-chat-view-root
+        data-session-id={dataSessionId}
+        className="relative flex h-full min-w-0 max-w-full flex-col overflow-hidden"
+      >
+        {transcript}
+        {composer}
+      </div>
+    </SessionCommentsProvider>
+  );
+});
+
+ChatViewLiveRegion.displayName = "ChatViewLiveRegion";

--- a/src/engines/ChatPanel/ConversationStreamProvider.tsx
+++ b/src/engines/ChatPanel/ConversationStreamProvider.tsx
@@ -1,6 +1,7 @@
 import { useAtomValue, useSetAtom } from "jotai";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 
+import { sessionIdAtom } from "@src/engines/SessionCore/core/atoms/metadata";
 import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 import { chatEventsForSessionAtomFamily } from "@src/engines/SessionCore/derived/sessionScopedChatEvents";
 import { useSessionCommentsContext } from "@src/features/Org2Cloud/SessionComments/SessionCommentsContext";
@@ -35,7 +36,6 @@ import { ChatHistoryOverrideContext } from "./ChatHistoryOverrideContext";
 
 interface ConversationStreamProviderProps {
   sessionId: string;
-  chatEvents: SessionEvent[];
   /** Pre-merged group-chat stream; takes precedence over conversation merging. */
   overrideEvents: SessionEvent[] | undefined;
   children: React.ReactNode;
@@ -68,10 +68,13 @@ function MemberEventsTap({
  */
 export function ConversationStreamProvider({
   sessionId,
-  chatEvents,
   overrideEvents,
   children,
 }: ConversationStreamProviderProps): React.ReactElement {
+  const pipelineSessionId = useAtomValue(sessionIdAtom);
+  const chatEvents = useAtomValue(
+    chatEventsForSessionAtomFamily(pipelineSessionId ?? sessionId)
+  );
   const comments = useSessionCommentsContext();
   const currentSession = usePinnedSession(sessionId);
   const remoteEntries = useAtomValue(org2CloudRemoteSessionsAtom);

--- a/src/engines/ChatPanel/hooks/useChatViewCanvasPreview.ts
+++ b/src/engines/ChatPanel/hooks/useChatViewCanvasPreview.ts
@@ -5,19 +5,47 @@
  * canvas payload (preferring the live in-turn canvas over the session's
  * last-known preview) and the jump-to-simulator-canvas handler.
  */
+import { useAtomValue } from "jotai";
+import { selectAtom } from "jotai/utils";
 import { useMemo } from "react";
 
-import type { Snapshot } from "@src/engines/SessionCore/core/store/EventStoreProxy";
+import { sessionSnapshotAtomFamily } from "@src/engines/SessionCore/derived/sessionScopedChatEvents";
+import type { SessionSnapshotState } from "@src/engines/SessionCore/derived/sessionScopedChatEvents";
 
 import { useCanvasForTurn } from "../blocks/CanvasInlineCard/useCanvasForTurn";
 import { useJumpToSimulatorCanvas } from "../blocks/CanvasInlineCard/useJumpToSimulatorCanvas";
 
-export function useChatViewCanvasPreview(
-  sessionId: string,
-  snapshot: Snapshot | null
-) {
+function canvasPreviewEqual(
+  left: ReturnType<typeof readLatestCanvasPreview>,
+  right: ReturnType<typeof readLatestCanvasPreview>
+): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  return (
+    left.mode === right.mode &&
+    left.url === right.url &&
+    left.title === right.title &&
+    left.streaming === right.streaming &&
+    left.eventId === right.eventId
+  );
+}
+
+function readLatestCanvasPreview(state: SessionSnapshotState) {
+  return state.snapshot?.latestCanvasPreview ?? null;
+}
+
+export function useChatViewCanvasPreview(sessionId: string) {
+  const latestCanvasPreviewAtom = useMemo(
+    () =>
+      selectAtom(
+        sessionSnapshotAtomFamily(sessionId),
+        readLatestCanvasPreview,
+        canvasPreviewEqual
+      ),
+    [sessionId]
+  );
+  const latestCanvasPreview = useAtomValue(latestCanvasPreviewAtom);
   const { snapshot: canvasForTurn } = useCanvasForTurn(sessionId);
-  const latestCanvasPreview = snapshot?.latestCanvasPreview ?? null;
   const latestCanvasPayload = useMemo(
     () =>
       canvasForTurn.latestPayload

--- a/src/engines/ChatPanel/hooks/useChatViewComposerSignals.ts
+++ b/src/engines/ChatPanel/hooks/useChatViewComposerSignals.ts
@@ -1,0 +1,71 @@
+import { useAtomValue } from "jotai";
+import { selectAtom } from "jotai/utils";
+import { useMemo } from "react";
+
+import { useChatViewCanvasPreview } from "@src/engines/ChatPanel/hooks/useChatViewCanvasPreview";
+import { derivePlanApprovalViewState } from "@src/engines/SessionCore/derived/planDisplayEvents";
+import { chatEventsForSessionAtomFamily } from "@src/engines/SessionCore/derived/sessionScopedChatEvents";
+import { usePendingPlanApproval } from "@src/hooks/session/usePendingPlanApproval";
+import { isSessionActiveAtom } from "@src/store/session/cliSessionStatusAtom";
+
+import { countChatRounds } from "../InputArea/components/compactFileChangesHelpers";
+
+function chatRoundCountEqual(a: number, b: number): boolean {
+  return a === b;
+}
+
+/**
+ * Composer-only signals derived from the pipeline session. Kept separate from
+ * the transcript subscription so streaming tokens do not re-render plan/canvas
+ * surfaces unless the derived signal actually changes.
+ */
+export function useChatViewComposerSignals(
+  planSessionId: string,
+  eventSessionId: string
+) {
+  const currentPlanApproval = usePendingPlanApproval(planSessionId);
+  const isAgentWorking = useAtomValue(isSessionActiveAtom);
+
+  const chatRoundCountAtom = useMemo(
+    () =>
+      selectAtom(
+        chatEventsForSessionAtomFamily(eventSessionId),
+        (events) => countChatRounds(events),
+        chatRoundCountEqual
+      ),
+    [eventSessionId]
+  );
+  const chatRoundCount = useAtomValue(chatRoundCountAtom);
+
+  const planViewStateAtom = useMemo(
+    () =>
+      selectAtom(
+        chatEventsForSessionAtomFamily(eventSessionId),
+        (chatEvents) =>
+          derivePlanApprovalViewState({
+            pendingPlan: currentPlanApproval,
+            chatEvents,
+            displayEvents: chatEvents,
+          }),
+        (previous, next) =>
+          previous.currentSurfaceVisible === next.currentSurfaceVisible &&
+          previous.activePendingEvent?.id === next.activePendingEvent?.id
+      ),
+    [eventSessionId, currentPlanApproval]
+  );
+  const planViewState = useAtomValue(planViewStateAtom);
+
+  const canvasPreviewPill = useChatViewCanvasPreview(planSessionId);
+
+  return {
+    currentPlanApproval,
+    isAgentWorking,
+    chatRoundCount,
+    planViewState,
+    showCurrentPlanSurface: planViewState.currentSurfaceVisible,
+    currentPlanSurfaceState: planViewState.activePendingEvent
+      ? planViewState.getEventState(planViewState.activePendingEvent, "current")
+      : undefined,
+    canvasPreviewPill,
+  };
+}

--- a/src/engines/ChatPanel/hooks/useInputArea/__tests__/inputAreaEventSelectors.test.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/__tests__/inputAreaEventSelectors.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+
+import { extractPlanMentionSource } from "../inputAreaEventSelectors";
+
+function createPlanEvent(
+  planPath: string,
+  title: string,
+  id = planPath
+): SessionEvent {
+  return {
+    id,
+    chunk_id: id,
+    sessionId: "session-1",
+    createdAt: "2026-06-18T00:00:00.000Z",
+    functionName: "plan_approval",
+    uiCanonical: "plan_approval",
+    actionType: "plan_approval",
+    args: {
+      title,
+      content: "plan body",
+      planPath,
+      planId: `plan-${id}`,
+      planRevisionId: id,
+    },
+    result: { status: "pending", planRevisionId: id },
+    source: "assistant",
+    displayText: title,
+    displayStatus: "awaiting_user",
+    displayVariant: "tool_call",
+    activityStatus: "agent",
+    callId: id,
+  } as SessionEvent;
+}
+
+describe("extractPlanMentionSource", () => {
+  it("returns empty array when there are no plan events", () => {
+    expect(extractPlanMentionSource([])).toEqual([]);
+  });
+
+  it("returns the most recent unique plan paths up to four entries", () => {
+    const events = [
+      createPlanEvent("/a/plan-1.md", "Plan 1", "e1"),
+      createPlanEvent("/a/plan-2.md", "Plan 2", "e2"),
+      createPlanEvent("/a/plan-1.md", "Plan 1 duplicate", "e3"),
+      createPlanEvent("/a/plan-3.md", "Plan 3", "e4"),
+      createPlanEvent("/a/plan-4.md", "Plan 4", "e5"),
+      createPlanEvent("/a/plan-5.md", "Plan 5", "e6"),
+    ];
+
+    expect(extractPlanMentionSource(events)).toEqual([
+      { planPath: "/a/plan-5.md", title: "Plan 5" },
+      { planPath: "/a/plan-4.md", title: "Plan 4" },
+      { planPath: "/a/plan-3.md", title: "Plan 3" },
+      { planPath: "/a/plan-1.md", title: "Plan 1 duplicate" },
+    ]);
+  });
+});

--- a/src/engines/ChatPanel/hooks/useInputArea/index.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/index.ts
@@ -34,10 +34,6 @@ import { useDataContext } from "@src/contexts/workspace/DataContext";
 import { parseCompactSlashCommand } from "@src/engines/ChatPanel/hooks/useManualCompact";
 import useWorkspaceChat from "@src/engines/ChatPanel/hooks/useWorkspaceChat";
 import { useRepositoryInfo } from "@src/engines/SessionCore";
-import { sortedEventsAtom } from "@src/engines/SessionCore/core/atoms/events";
-import { sessionHasComposerStopBlockingWork } from "@src/engines/SessionCore/core/runningEventGate";
-import type { SessionEvent } from "@src/engines/SessionCore/core/types";
-import { isPlanDisplayEvent } from "@src/engines/SessionCore/derived/planDisplayEvents";
 import { useSessionId } from "@src/engines/SessionCore/hooks/session";
 import { createLogger } from "@src/hooks/logger";
 import { usePendingPlanApproval } from "@src/hooks/session/usePendingPlanApproval";
@@ -45,7 +41,6 @@ import {
   useSessionDraftField,
   useSessionReplyField,
 } from "@src/hooks/session/useSessionPatch";
-import { getPlanDocViewModel } from "@src/modules/WorkStation/Chat/Communication/MessageViewer/planDocViewModel";
 import {
   isPendingCancelAtom,
   isSessionActiveAtom,
@@ -60,10 +55,7 @@ import { formatRepoPathForDisplay } from "@src/util/file/repoPathDisplay";
 import { isCliSession } from "@src/util/session/sessionDispatch";
 import { useCurrentTheme } from "@src/util/ui/theme/themeUtils";
 
-import {
-  buildCompactFilesReloadKey,
-  countChatRounds,
-} from "../../InputArea/components/compactFileChangesHelpers";
+import { buildCompactFilesReloadKey } from "../../InputArea/components/compactFileChangesHelpers";
 import { useCompactFileData } from "../../InputArea/components/useCompactFileData";
 import {
   readImageDraft,
@@ -72,6 +64,12 @@ import {
 import { applyParsedContent } from "../../InputArea/utils/pillContentParser";
 import { canvasSlashCommandNeedsInstruction } from "./canvasSlashCommand";
 import { resolveDraftRestoreAction } from "./draftRestore";
+import {
+  type PlanMentionSourceItem,
+  useInputAreaChatRoundCount,
+  useInputAreaComposerStopBlockingWork,
+  useInputAreaPlanMentionSource,
+} from "./inputAreaEventSelectors";
 import type {
   CustomMentionOption,
   UseInputAreaOptions,
@@ -119,13 +117,8 @@ function getDraftRestoreSkipReason(draftText: string): string | null {
   return null;
 }
 
-function getPlanMentionPath(event: SessionEvent): string | null {
-  const planPath = getPlanDocViewModel(event).planPath;
-  return planPath && planPath.trim() ? planPath : null;
-}
-
 function buildPlanMentionOptions(
-  events: ReadonlyArray<SessionEvent>,
+  planSources: ReadonlyArray<PlanMentionSourceItem>,
   pendingPlan: { planPath: string; planTitle: string } | null | undefined
 ): CustomMentionOption[] {
   const options: CustomMentionOption[] = [];
@@ -144,14 +137,12 @@ function buildPlanMentionOptions(
     });
   }
 
-  for (let index = events.length - 1; index >= 0; index -= 1) {
-    const event = events[index];
-    if (!isPlanDisplayEvent(event)) continue;
-    const planPath = getPlanMentionPath(event);
+  for (const source of planSources) {
+    const planPath = source.planPath;
     if (!planPath || seenPaths.has(planPath)) continue;
 
     seenPaths.add(planPath);
-    const title = getPlanDocViewModel(event).title;
+    const title = source.title;
     options.push({
       id: `plan-file:${planPath}`,
       label: title || getCompactPathLabel(planPath),
@@ -220,7 +211,8 @@ export function useInputArea(
   const isSessionActive = isSessionless ? false : rawIsSessionActive;
   const isPendingCancel = isSessionless ? false : rawIsPendingCancel;
 
-  const sessionEvents = useAtomValue(sortedEventsAtom);
+  const chatRoundCount = useInputAreaChatRoundCount();
+  const planMentionSource = useInputAreaPlanMentionSource();
   // Retry is only meaningful for `failed` runs. A user-initiated cancel should
   // never surface the orange retry button — the user stopped on purpose.
   const isSessionTerminal = !isSessionless && runtimeStatus === "failed";
@@ -266,13 +258,10 @@ export function useInputArea(
       ? undefined
       : (propSessionId ?? resolvedActiveSessionId);
   const draftSessionId = activeSessionId ?? "";
-  const hasComposerStopBlockingWork = activeSessionId
-    ? sessionHasComposerStopBlockingWork(
-        sessionEvents,
-        activeSessionId,
-        runtimeStatus
-      )
-    : false;
+  const hasComposerStopBlockingWork = useInputAreaComposerStopBlockingWork(
+    activeSessionId,
+    runtimeStatus
+  );
 
   // Visual "agent is working" flag — drives the Stop vs. Send icon.
   // This uses the composer-specific gate: foreground tools remain stoppable,
@@ -283,7 +272,7 @@ export function useInputArea(
 
   const sessionFileReloadKey = buildCompactFilesReloadKey(
     activeSessionId ?? null,
-    countChatRounds(sessionEvents),
+    chatRoundCount,
     isWpGeneWorking
   );
   const { allFiles: sessionFiles } = useCompactFileData({
@@ -326,8 +315,8 @@ export function useInputArea(
     [currentRepoPath, sessionFiles]
   );
   const planMentionOptions = useMemo<ReadonlyArray<CustomMentionOption>>(
-    () => buildPlanMentionOptions(sessionEvents, pendingPlan),
-    [pendingPlan, sessionEvents]
+    () => buildPlanMentionOptions(planMentionSource, pendingPlan),
+    [pendingPlan, planMentionSource]
   );
   const mergedCustomMentionOptions = useMemo(
     () => [

--- a/src/engines/ChatPanel/hooks/useInputArea/inputAreaEventSelectors.ts
+++ b/src/engines/ChatPanel/hooks/useInputArea/inputAreaEventSelectors.ts
@@ -1,0 +1,117 @@
+import { useAtomValue } from "jotai";
+import { selectAtom } from "jotai/utils";
+import { useMemo } from "react";
+
+import { countChatRounds } from "@src/engines/ChatPanel/InputArea/components/compactFileChangesHelpers";
+import { sortedEventsAtom } from "@src/engines/SessionCore/core/atoms/events";
+import { sessionHasComposerStopBlockingWork } from "@src/engines/SessionCore/core/runningEventGate";
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+import { isPlanDisplayEvent } from "@src/engines/SessionCore/derived/planDisplayEvents";
+import { getPlanDocViewModel } from "@src/modules/WorkStation/Chat/Communication/MessageViewer/planDocViewModel";
+
+export interface PlanMentionSourceItem {
+  planPath: string;
+  title: string;
+}
+
+function chatRoundCountEqual(left: number, right: number): boolean {
+  return left === right;
+}
+
+function booleanEqual(left: boolean, right: boolean): boolean {
+  return left === right;
+}
+
+function planMentionSourceEqual(
+  left: readonly PlanMentionSourceItem[],
+  right: readonly PlanMentionSourceItem[]
+): boolean {
+  if (left.length !== right.length) return false;
+  for (let index = 0; index < left.length; index += 1) {
+    if (
+      left[index].planPath !== right[index].planPath ||
+      left[index].title !== right[index].title
+    ) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function getPlanMentionPath(event: SessionEvent): string | null {
+  const planPath = getPlanDocViewModel(event).planPath;
+  return planPath && planPath.trim() ? planPath : null;
+}
+
+export function extractPlanMentionSource(
+  events: ReadonlyArray<SessionEvent>
+): PlanMentionSourceItem[] {
+  const result: PlanMentionSourceItem[] = [];
+  const seenPaths = new Set<string>();
+
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const event = events[index];
+    if (!isPlanDisplayEvent(event)) continue;
+    const planPath = getPlanMentionPath(event);
+    if (!planPath || seenPaths.has(planPath)) continue;
+
+    seenPaths.add(planPath);
+    result.push({
+      planPath,
+      title: getPlanDocViewModel(event).title,
+    });
+
+    if (result.length >= 4) break;
+  }
+
+  return result;
+}
+
+export function useInputAreaChatRoundCount(): number {
+  const chatRoundCountAtom = useMemo(
+    () =>
+      selectAtom(
+        sortedEventsAtom,
+        (events) => countChatRounds(events),
+        chatRoundCountEqual
+      ),
+    []
+  );
+  return useAtomValue(chatRoundCountAtom);
+}
+
+export function useInputAreaComposerStopBlockingWork(
+  activeSessionId: string | undefined,
+  runtimeStatus: string | undefined
+): boolean {
+  const composerStopBlockingAtom = useMemo(
+    () =>
+      selectAtom(
+        sortedEventsAtom,
+        (events) =>
+          activeSessionId
+            ? sessionHasComposerStopBlockingWork(
+                events,
+                activeSessionId,
+                runtimeStatus
+              )
+            : false,
+        booleanEqual
+      ),
+    [activeSessionId, runtimeStatus]
+  );
+  return useAtomValue(composerStopBlockingAtom);
+}
+
+export function useInputAreaPlanMentionSource(): readonly PlanMentionSourceItem[] {
+  const planMentionSourceAtom = useMemo(
+    () =>
+      selectAtom(
+        sortedEventsAtom,
+        extractPlanMentionSource,
+        planMentionSourceEqual
+      ),
+    []
+  );
+  return useAtomValue(planMentionSourceAtom);
+}

--- a/src/engines/ChatPanel/hooks/usePipelineChatEvents.ts
+++ b/src/engines/ChatPanel/hooks/usePipelineChatEvents.ts
@@ -1,0 +1,47 @@
+import { useAtomValue } from "jotai";
+import { selectAtom } from "jotai/utils";
+import { useMemo } from "react";
+
+import { sessionIdAtom } from "@src/engines/SessionCore/core/atoms/metadata";
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+import {
+  chatEventsForSessionAtomFamily,
+  sessionSnapshotAtomFamily,
+} from "@src/engines/SessionCore/derived/sessionScopedChatEvents";
+
+const EMPTY_EVENTS: SessionEvent[] = [];
+
+/**
+ * Pipeline-scoped chat events for the active session store mirror.
+ * Matches the old `derivedSnapshotAtom.chatEvents` source without
+ * subscribing the whole ChatView shell to the full snapshot object.
+ */
+export function usePipelineChatEvents(): {
+  pipelineSessionId: string | null;
+  chatEvents: SessionEvent[];
+  transcriptReady: boolean;
+} {
+  const pipelineSessionId = useAtomValue(sessionIdAtom);
+
+  const chatEventsAtom = useMemo(
+    () => chatEventsForSessionAtomFamily(pipelineSessionId ?? "__none__"),
+    [pipelineSessionId]
+  );
+  const chatEvents = useAtomValue(chatEventsAtom);
+
+  const transcriptReadyAtom = useMemo(
+    () =>
+      selectAtom(
+        sessionSnapshotAtomFamily(pipelineSessionId ?? "__none__"),
+        (state) => state.loadStarted
+      ),
+    [pipelineSessionId]
+  );
+  const transcriptReady = useAtomValue(transcriptReadyAtom);
+
+  return {
+    pipelineSessionId,
+    chatEvents: pipelineSessionId ? chatEvents : EMPTY_EVENTS,
+    transcriptReady: Boolean(pipelineSessionId && transcriptReady),
+  };
+}

--- a/src/engines/SessionCore/derived/planningIndicatorBridgeOutputAtom.ts
+++ b/src/engines/SessionCore/derived/planningIndicatorBridgeOutputAtom.ts
@@ -1,0 +1,12 @@
+import { atom } from "jotai";
+
+import type { PlanningIndicatorState } from "../hooks/replay/usePlanningIndicator";
+
+export const globalPlanningIndicatorBridgeOutputAtom =
+  atom<PlanningIndicatorState>({
+    count: 0,
+    variantIndex: 0,
+  });
+
+globalPlanningIndicatorBridgeOutputAtom.debugLabel =
+  "planning/globalBridgeOutput";

--- a/src/engines/SessionCore/hooks/replay/GlobalPlanningIndicatorBridgeSync.tsx
+++ b/src/engines/SessionCore/hooks/replay/GlobalPlanningIndicatorBridgeSync.tsx
@@ -1,0 +1,30 @@
+import { useSetAtom } from "jotai";
+import { useEffect } from "react";
+
+import { globalPlanningIndicatorBridgeOutputAtom } from "@src/engines/SessionCore/derived/planningIndicatorBridgeOutputAtom";
+import { usePlanningIndicator } from "@src/engines/SessionCore/hooks/replay/usePlanningIndicator";
+
+/**
+ * Keeps the global planning footer output atom in sync without mounting the
+ * hot subscriptions inside PlanningIndicatorBridge.
+ */
+export function useGlobalPlanningIndicatorBridgeSync(): void {
+  const state = usePlanningIndicator(undefined);
+  const setOutput = useSetAtom(globalPlanningIndicatorBridgeOutputAtom);
+
+  useEffect(() => {
+    setOutput((previous) =>
+      previous.count === state.count &&
+      previous.variantIndex === state.variantIndex
+        ? previous
+        : state
+    );
+  }, [state, setOutput]);
+}
+
+function GlobalPlanningIndicatorBridgeSync(): null {
+  useGlobalPlanningIndicatorBridgeSync();
+  return null;
+}
+
+export default GlobalPlanningIndicatorBridgeSync;

--- a/src/engines/SessionCore/hooks/session/__tests__/syncTodosFromReplayEvents.test.ts
+++ b/src/engines/SessionCore/hooks/session/__tests__/syncTodosFromReplayEvents.test.ts
@@ -17,7 +17,10 @@ function nativeTodoContent(
 }
 
 function makeManageTodoEvent(
-  overrides: Partial<SessionEvent> & Pick<SessionEvent, "id">
+  overrides: Partial<SessionEvent> & Pick<SessionEvent, "id">,
+  todos: Array<Record<string, unknown>> = [
+    { index: 0, content: "Do work", status: "pending" },
+  ]
 ): SessionEvent {
   return {
     chunk_id: overrides.id,
@@ -28,9 +31,7 @@ function makeManageTodoEvent(
     actionType: "tool_call",
     args: {},
     result: {
-      content: nativeTodoContent("1 todo (1 remaining)", [
-        { index: 0, content: "Do work", status: "pending" },
-      ]),
+      content: nativeTodoContent("1 todo (1 remaining)", todos),
     },
     source: "assistant",
     displayText: "",
@@ -56,6 +57,20 @@ describe("syncTodosFromReplayEvents", () => {
     ).toBeNull();
   });
 
+  it("returns null when pipeline session is unset", () => {
+    const events = [makeManageTodoEvent({ id: "todo-1" })];
+    expect(
+      syncTodosFromReplayEvents({
+        sessionId: "session-a",
+        pipelineSessionId: null,
+        liveEvents: events,
+        simulatorEvents: events,
+        currentEvent: null,
+        lastSnapshot: null,
+      })
+    ).toBeNull();
+  });
+
   it("derives todos from live events when pipeline matches", () => {
     const events = [makeManageTodoEvent({ id: "todo-1" })];
     const result = syncTodosFromReplayEvents({
@@ -68,5 +83,57 @@ describe("syncTodosFromReplayEvents", () => {
     });
     expect(result).not.toBeNull();
     expect(result?.snapshot).toBeTruthy();
+  });
+
+  it("ignores the global replay cursor when syncing from live events", () => {
+    const events = [
+      makeManageTodoEvent({ id: "todo-old" }, [
+        { index: 0, content: "Old task", status: "completed" },
+        { index: 1, content: "New task", status: "pending" },
+      ]),
+      makeManageTodoEvent({ id: "todo-new" }, [
+        { index: 0, content: "Old task", status: "completed" },
+        { index: 1, content: "New task", status: "completed" },
+        { index: 2, content: "Latest task", status: "pending" },
+      ]),
+    ];
+
+    const result = syncTodosFromReplayEvents({
+      sessionId: "session-a",
+      pipelineSessionId: "session-a",
+      liveEvents: events,
+      simulatorEvents: events,
+      currentEvent: events[0],
+      lastSnapshot: null,
+    });
+
+    expect(result?.todos.map((todo) => todo.content)).toEqual([
+      "Old task",
+      "New task",
+      "Latest task",
+    ]);
+  });
+
+  it("respects the replay cursor when syncing from simulator events only", () => {
+    const events = [
+      makeManageTodoEvent({ id: "todo-old" }, [
+        { index: 0, content: "Old task", status: "pending" },
+      ]),
+      makeManageTodoEvent({ id: "todo-new" }, [
+        { index: 0, content: "Old task", status: "completed" },
+        { index: 1, content: "New task", status: "pending" },
+      ]),
+    ];
+
+    const result = syncTodosFromReplayEvents({
+      sessionId: "session-a",
+      pipelineSessionId: "session-a",
+      liveEvents: [],
+      simulatorEvents: events,
+      currentEvent: events[0],
+      lastSnapshot: null,
+    });
+
+    expect(result?.todos.map((todo) => todo.content)).toEqual(["Old task"]);
   });
 });

--- a/src/engines/SessionCore/hooks/session/syncTodosFromReplayEvents.ts
+++ b/src/engines/SessionCore/hooks/session/syncTodosFromReplayEvents.ts
@@ -26,6 +26,10 @@ export interface SyncTodosFromReplayEventsResult {
  * Derive the todo pin-bar snapshot from replay/live events up to the current
  * cursor. Returns `null` when there is nothing new to write (empty events,
  * pipeline mismatch, or unchanged snapshot).
+ *
+ * Live composer sync (`liveEvents`) always reads the latest manage_todo state
+ * and ignores the global replay cursor — simulator scrubbing shares
+ * `currentEventAtom` but must not reshape the sticky pin bar in ChatView.
  */
 export function syncTodosFromReplayEvents(
   input: SyncTodosFromReplayEventsInput
@@ -39,19 +43,17 @@ export function syncTodosFromReplayEvents(
     lastSnapshot,
   } = input;
 
-  if (pipelineSessionId && pipelineSessionId !== sessionId) {
+  if (!pipelineSessionId || pipelineSessionId !== sessionId) {
     return null;
   }
 
-  const replayEvents =
-    pipelineSessionId === sessionId && liveEvents.length > 0
-      ? liveEvents
-      : simulatorEvents;
-  if (!replayEvents || replayEvents.length === 0) {
+  const useLiveEvents = liveEvents.length > 0;
+  const replayEvents = useLiveEvents ? liveEvents : simulatorEvents;
+  if (replayEvents.length === 0) {
     return null;
   }
 
-  const currentEventId = currentEvent?.id ?? null;
+  const currentEventId = useLiveEvents ? null : (currentEvent?.id ?? null);
 
   let maxIndex = replayEvents.length - 1;
   if (currentEventId) {


### PR DESCRIPTION
## Problem

`ChatView` subscribed to the full `derivedSnapshotAtom`, so every streaming token and snapshot merge re-rendered the entire chat shell (history chrome, composer layout, overlays). `PlanningIndicatorBridge` also mounted a second global `usePlanningIndicator` tree inside the hot history path. `useInputArea` subscribed to all of `sortedEventsAtom` for three narrow derived signals. Separately, simulator replay scrubbing updates the global `currentEventAtom`, which `syncTodosFromReplayEvents` applied even on the live composer path — causing the left todo pill to reappear or jump (e.g. `1/4`) while replaying on the right.

## Solution

- Split `ChatView` into a narrow shell plus `ChatViewLiveRegion` (pipeline transcript + comments) and memoized `ChatViewComposerSection` (`useChatViewComposerSignals`, `usePipelineChatEvents`).
- Move global planning footer sync to `GlobalPlanningIndicatorBridgeSync` + `globalPlanningIndicatorBridgeOutputAtom`; scoped history still uses `usePlanningIndicator` directly.
- Replace `useInputArea`'s full `sortedEventsAtom` subscription with `selectAtom` helpers for round count, stop-blocking work, and plan mention sources.
- Fix todo sync: live composer reads the latest `manage_todo` state and ignores the replay cursor; simulator-only replay still respects the cursor; require pipeline session match before writing todos.

## Potential risks

- Agent-org member switching and group-chat merged history rely on the new internal event subscriptions in `ConversationStreamProvider` / composer signals — regressions could show stale plan/canvas/composer state until the pipeline session catches up.
- Global planning footer now depends on `GlobalSessionSync` staying mounted; a missing provider would freeze the footer at its last atom value instead of re-subscribing inside history.
- Todo sync now requires an explicit pipeline session match; edge cases where `sessionIdAtom` is briefly unset during layout churn may skip event-derived todo refresh until the pipeline reclaims (IPC push and cold-start `getTodos` still apply).

## Verification

- `pnpm vitest run src/engines/ChatPanel/hooks/useInputArea/__tests__/inputAreaEventSelectors.test.ts` — 2/2 passed
- `pnpm vitest run src/engines/SessionCore/hooks/session/__tests__/syncTodosFromReplayEvents.test.ts` — 5/5 passed
- Pre-commit scoped TypeScript check on staged files — passed
- Manual QA (author): replay scrub on the right no longer reshapes the left todo pill; primary chat streaming/planning/composer behavior verified OK before this PR

Stacks on #1022 (`junyu/session-subscription-refactor`).