### PR TITLE
fix(agent-core): reject empty edit_file searches

### DIFF
--- a/src-tauri/crates/agent-core/src/core/tools/impls/coding/edit_file/mod.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/coding/edit_file/mod.rs
@@ -157,11 +157,17 @@ impl Tool for EditTool {
         // (some providers emit sibling optional fields even for a pure
         // search-replace). Overwrite is destructive, so it must NOT be the
         // default resolution of an ambiguous call: only treat `content` as a
-        // whole-file write when NO edit fields are present. When `content`
-        // coexists with `old_string`/`new_string`, honor the search-replace
-        // intent and ignore the stray `content`.
-        let has_edit_fields = old_string.is_some() || new_string.is_some();
+        // whole-file write when no non-empty edit fields are present. Empty
+        // optional placeholders are ignored.
+        let has_edit_fields = old_string.as_ref().is_some_and(|value| !value.is_empty())
+            || new_string.as_ref().is_some_and(|value| !value.is_empty());
         let content = if has_edit_fields { None } else { content };
+
+        if content.is_none() && old_string.as_deref() == Some("") {
+            return Err(ToolError::InvalidParams(
+                "'old_string' must not be empty".to_string(),
+            ));
+        }
 
         // Validate path against the live session workspace (single source
         // of truth): primary root = live working_dir(); extras = every

--- a/src-tauri/crates/agent-core/src/core/tools/impls/coding/edit_file/strategies.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/coding/edit_file/strategies.rs
@@ -18,6 +18,10 @@ pub fn replace(
     new_string: &str,
     replace_all: bool,
 ) -> Result<String, String> {
+    if old_string.is_empty() {
+        return Err("old_string must not be empty".to_string());
+    }
+
     if old_string == new_string {
         return Err("old_string and new_string are identical".to_string());
     }
@@ -500,8 +504,12 @@ fn multi_occurrence_replacer(content: &str, find: &str) -> Vec<String> {
     let mut results = Vec::new();
     let mut start = 0;
     while let Some(idx) = content[start..].find(find) {
+        let next = start + idx + find.len();
+        if next <= start {
+            break;
+        }
         results.push(find.to_string());
-        start += idx + find.len();
+        start = next;
     }
     results
 }

--- a/src-tauri/crates/agent-core/src/core/tools/impls/coding/edit_file/tests.rs
+++ b/src-tauri/crates/agent-core/src/core/tools/impls/coding/edit_file/tests.rs
@@ -1,7 +1,47 @@
-use crate::tools::impls::coding::edit_file::{
-    is_notebook_path,
-    strategies::{levenshtein, replace},
+use crate::tools::{
+    impls::coding::edit_file::{
+        is_notebook_path,
+        strategies::{levenshtein, replace},
+        EditTool,
+    },
+    traits::{CallContext, Tool, ToolError},
 };
+use serde_json::json;
+
+#[test]
+fn test_empty_old_string_error() {
+    for replace_all in [false, true] {
+        let error = replace("non-empty", "", "replacement", replace_all).unwrap_err();
+        assert!(error.contains("must not be empty"));
+    }
+}
+
+#[tokio::test]
+async fn test_tool_rejects_empty_search_without_changing_file() {
+    let workspace = tempfile::tempdir().unwrap();
+    let file = workspace.path().join("test.txt");
+    let tool = EditTool::new().with_workspace(workspace.path().to_path_buf());
+
+    tool.execute_text(
+        json!({"file_path": "test.txt", "content": "original", "old_string": "", "new_string": ""}),
+        &CallContext::default(),
+    )
+    .await
+    .unwrap();
+
+    let error = tool
+        .execute_text(
+            json!({"file_path": "test.txt", "content": "partial", "old_string": "", "new_string": "x"}),
+            &CallContext::default(),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(error, ToolError::InvalidParams(message) if message.contains("must not be empty"))
+    );
+    assert_eq!(std::fs::read_to_string(file).unwrap(), "original");
+}
 
 #[test]
 fn notebook_paths_are_rejected_by_plain_edit_tool() {

--- a/src-tauri/crates/agent-core/src/core/turn_executor/file_tracker.rs
+++ b/src-tauri/crates/agent-core/src/core/turn_executor/file_tracker.rs
@@ -282,7 +282,7 @@ impl FileTimeTracker {
 
     /// Hard read-before-edit gate for `edit_file`.
     ///
-    /// - **Edit mode** (`old_string` present): the file must have been read
+    /// - **Edit mode** (a non-empty edit field is present): the file must have been read
     ///   this session (present in the read cache) — otherwise reject.
     /// - **Create/Overwrite mode** (`content`, no `old_string`): creating a
     ///   NEW file is allowed; overwriting an EXISTING file that was never
@@ -307,7 +307,11 @@ impl FileTimeTracker {
             return Ok(());
         }
 
-        let is_edit_mode = args.get("old_string").and_then(|v| v.as_str()).is_some();
+        let is_edit_mode = ["old_string", "new_string"].iter().any(|key| {
+            args.get(key)
+                .and_then(|value| value.as_str())
+                .is_some_and(|value| !value.is_empty())
+        });
         if is_edit_mode {
             return Err(format!(
                 "File has not been read yet: {path}. Use read_file on it first, then retry the edit with the exact text you saw.",
@@ -558,7 +562,12 @@ mod content_hash_tests {
     #[test]
     fn create_mode_new_file_passes_gate() {
         let tracker = FileTimeTracker::new();
-        let args = serde_json::json!({ "file_path": "/nonexistent/brand/new.txt", "content": "x" });
+        let args = serde_json::json!({
+            "file_path": "/nonexistent/brand/new.txt",
+            "content": "x",
+            "old_string": "",
+            "new_string": "",
+        });
         assert!(tracker
             .assert_read_before_edit(tool_names::EDIT_FILE, &args)
             .is_ok());


### PR DESCRIPTION
## Problem

Fixes #1021

A provider-generated edit_file call could pass an empty old_string into occurrence scanning. Empty matches have zero width, so the scan cursor did not advance while the candidate list kept growing, which could exhaust CPU and memory. Empty optional sibling fields could also make a full-content write look like an edit.

## Solution

Reject an empty search at both the normalized edit_file boundary and the shared replacement helper, and stop occurrence scanning defensively if the cursor cannot advance. Treat only non-empty edit fields as selecting edit mode, and apply the same rule in the read-before-edit gate so provider-generated empty placeholders remain compatible with full-content writes.

This is the smallest complete fix: no provider-specific logic, schema change, database migration, background work, or unrelated refactor. Regression tests cover both replace_all modes, the typed tool error, file immutability, provider placeholder write mode, and the read-before-edit classification.

## Potential risks

The intentionally changed contract is that a zero-length search now returns an invalid-parameter error; whitespace-only searches keep their existing behavior. A call with content plus empty old_string and a non-empty replacement is rejected instead of overwriting or entering replacement mode, while content plus two empty optional placeholders remains a whole-file write.

There are no persistence, wire-format, dependency, concurrency, or migration changes. Rollback is a normal revert of commit b3c69b387. The Issue performance matrix calls for a five-minute idle check and ten malformed plus ten valid calls; those extended stress counts were not run. The completed packaged-app runs covered both replace_all modes, a valid write, a valid edit, file fingerprints, Assistant events, process behavior, and an app restart. One final redundant provider request after the latest develop sync stalled before producing a tool event and was not counted as a passing test.

## Verification

- cargo test -p agent_core edit_file --lib — 23 passed, 0 failed
- cargo test -p agent_core create_mode_new_file_passes_gate --lib — 1 passed
- cargo test -p agent_core --lib -- --test-threads=1 — 3183 passed, 0 failed, 2 ignored
- cargo clippy -p agent_core --all-targets -- -D warnings — passed; only an external future-incompatibility advisory was reported
- rustfmt --edition 2021 --check on the four changed Rust files — passed
- git diff --check — passed
- pnpm run tauri:build:fast — passed on exact HEAD; packaged binary SHA-256 e45487298963c888534048a37d7b90d246e3f144d05cbd63158553652eae18a3
- Packaged macOS app with gpt-5.6-luna-medium and a real provider key — full-content write with empty optional placeholders succeeded
- Packaged app, replace_all false and true — empty old_string returned Invalid parameters: old_string must not be empty and left the file fingerprint unchanged
- Packaged app, normal non-empty replacement — succeeded
- Packaged app restart followed by another malformed call — returned the same bounded error and left the file unchanged
- SQLite event inspection — real edit_file tool calls and corresponding Assistant error events were persisted; no retained Running tool call from the completed scenarios
- Process inspection — no CPU spin, crash, or staircase memory growth observed in the completed scenarios; the test app was quit afterward

No screenshots are attached because this is a non-visual backend safety fix; the tool results, SQLite events, file fingerprints, packaged binary identity, and process observations are the relevant evidence.