### PR TITLE
fix(icons): repair hugeicons migration leftovers

### DIFF
--- a/src/components/PropertyField/PropertyFieldEditable.tsx
+++ b/src/components/PropertyField/PropertyFieldEditable.tsx
@@ -8,7 +8,6 @@
 import React, { useCallback, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
-import AnyIcon from "@src/components/AnyIcon";
 import Button from "@src/components/Button";
 import {
   type PillControlFocusTreatment,
@@ -23,7 +22,7 @@ import {
   DROPDOWN_WIDTHS,
 } from "@src/components/Dropdown/tokens";
 import { WORKSTATION_TRAIL_CONTENT } from "@src/config/workstation/tokens";
-import { ArrowDown01Icon, Pen01Icon } from "@src/icons";
+import { ArrowDown01Icon, HugeiconsIcon, Pen01Icon } from "@src/icons";
 import { getViewportSize } from "@src/util/ui/window/viewport";
 
 import { usePropertyDropdownDirection } from "./PropertyDropdownDirection";
@@ -159,7 +158,7 @@ export const FieldRow: React.FC<FieldRowProps> = ({
             disabled={disabled}
             className={`mr-1 flex h-6 w-5 shrink-0 items-center justify-center rounded-md border-none bg-transparent text-text-3 ${isActive ? "flex" : "hidden group-hover/field:flex"}`}
           >
-            <AnyIcon icon={EditIcon} size={DROPDOWN_ITEM.iconSize} />
+            <HugeiconsIcon icon={EditIcon} size={DROPDOWN_ITEM.iconSize} />
           </button>
         )}
       </div>

--- a/src/config/toolIcons.tsx
+++ b/src/config/toolIcons.tsx
@@ -3,15 +3,17 @@
  *
  * **Authoritative icon ids** for built-in tools come from Rust `ToolInfo.icon_id`
  * (`list_all_tools`). `ICON_BY_ID` maps those kebab-case ids to hugeicons
- * glyph data. Brand marks (e.g., the MCP logo) are hand-authored SVG
- * components handled outside this registry.
+ * glyph data — plus brand marks (the MCP logo) as components, which is why
+ * the value type is `RenderableIcon` and every render path goes through
+ * `AnyIcon`, never `HugeiconsIcon` directly.
  *
  * NOTE: Terminal tool detection uses normalizeFunctionName() (Rust source of truth
  * via cli_agents/alias_map.rs) instead of hardcoded tool names.
  */
 import React from "react";
 
-import AnyIcon from "@src/components/AnyIcon";
+import { McpLogoIcon } from "@src/assets/channelIcons/McpLogoIcon";
+import AnyIcon, { type RenderableIcon } from "@src/components/AnyIcon";
 import {
   getBuiltinToolActionIconId,
   getBuiltinToolIconId,
@@ -32,8 +34,10 @@ import {
   FirstBracketIcon as Braces,
   BrainIcon as Brain,
   Briefcase01Icon as Briefcase,
+  Camera01Icon as Camera,
   CheckmarkCircle01Icon as CheckCircle2,
   InternetIcon as Chrome,
+  CircleCheckBigIcon as CircleCheckBig,
   HelpCircleIcon as CircleHelp,
   ClipboardCopyIcon as ClipboardCopy,
   ClipboardListIcon as ClipboardList,
@@ -50,11 +54,15 @@ import {
   CenterFocusIcon as Focus,
   FolderCogIcon as FolderCog,
   FolderGitTwoIcon as FolderGit2,
+  FolderMinusIcon as FolderMinus,
   FolderOpenIcon as FolderOpen,
+  FolderPenIcon as FolderPen,
+  FolderAddIcon as FolderPlus,
   FolderSearchIcon as FolderSearch,
   FullScreenIcon as Fullscreen,
   WorkflowCircle05Icon as GitBranch,
   InternetIcon as Globe,
+  WorkHistoryIcon as History,
   type IconSvgElement,
   Image01Icon as Image,
   InboxIcon as Inbox,
@@ -66,27 +74,34 @@ import {
   ListChecksIcon as ListChecks,
   ListTodoIcon as ListTodo,
   HierarchyFilesIcon as ListTree,
+  LockIcon as Lock,
   LogsIcon as Logs,
   Mail01Icon as Mail,
+  MailWarningIcon as MailWarning,
   MapsIcon as Map,
   BubbleChatIcon as MessageCircle,
   MessageCircleQuestionMarkIcon as MessageCircleQuestionMark,
+  MessageSquareReplyIcon as MessageSquareReply,
   MessageMultiple01Icon as MessagesSquare,
   MonitorIcon as Monitor,
   Cursor02Icon as MousePointer2,
   CursorPointer02Icon as MousePointerClick,
   MoveTopIcon as MoveVertical,
   HierarchyCircle01Icon as Network,
+  PanelTopIcon as PanelTop,
   Plug01Icon as Plug,
   Add01Icon as Plus,
   Refresh04Icon as RefreshCw,
+  ScrollIcon as ScrollText,
   Search01Icon as Search,
   MailSend01Icon as Send,
   Share02Icon as Share2,
   Shield01Icon as Shield,
+  SecurityCheckIcon as ShieldCheck,
   Shield02Icon as ShieldOff,
   SparkleIcon as Sparkle,
   ComputerTerminal01Icon as Terminal,
+  SquareTerminalIcon as TerminalSquare,
   Timer01Icon as Timer,
   Delete02Icon as Trash2,
   UserIcon as User,
@@ -103,10 +118,11 @@ export const DEFAULT_TOOL_ICON_CLASS = "text-text-2";
 
 /**
  * Maps Rust `icon_id` strings (kebab-case, lucide-era vocabulary) to
- * hugeicons glyph data.
- * Keep in sync with `builtin_tools_list.rs` `row(..., icon_id)`.
+ * hugeicons glyph data (plus the MCP brand mark component).
+ * Keep in sync with the `ToolEntry` tables in
+ * `src-tauri/crates/agent-core/src/core/tools/builtin_tools/table/*.rs`.
  */
-const ICON_BY_ID: Record<string, IconSvgElement> = {
+const ICON_BY_ID: Record<string, RenderableIcon> = {
   activity: Activity,
   "arrow-big-right-dash": ArrowBigRightDash,
   "arrow-right-left": ArrowRightLeft,
@@ -119,8 +135,10 @@ const ICON_BY_ID: Record<string, IconSvgElement> = {
   braces: Braces,
   brain: Brain,
   briefcase: Briefcase,
+  camera: Camera,
   "check-circle-2": CheckCircle2,
   chrome: Chrome,
+  "circle-check-big": CircleCheckBig,
   "circle-help": CircleHelp,
   "clipboard-copy": ClipboardCopy,
   "clipboard-list": ClipboardList,
@@ -132,15 +150,20 @@ const ICON_BY_ID: Record<string, IconSvgElement> = {
   "file-box": FileBox,
   "file-diff": FileDiff,
   "file-pen-line": FilePenLine,
+  "file-search": FileSearch,
   "file-text": FileText,
   focus: Focus,
   "folder-cog": FolderCog,
   "folder-git-2": FolderGit2,
+  "folder-minus": FolderMinus,
   "folder-open": FolderOpen,
+  "folder-pen": FolderPen,
+  "folder-plus": FolderPlus,
   "folder-search": FolderSearch,
   fullscreen: Fullscreen,
   "git-branch": GitBranch,
   globe: Globe,
+  history: History,
   image: Image,
   inbox: Inbox,
   infinity: Infinity,
@@ -152,26 +175,34 @@ const ICON_BY_ID: Record<string, IconSvgElement> = {
   "list-checks": ListChecks,
   "list-todo": ListTodo,
   "list-tree": ListTree,
+  lock: Lock,
   mail: Mail,
+  "mail-warning": MailWarning,
   map: Map,
+  "mcp-logo": McpLogoIcon,
   "message-circle": MessageCircle,
   "message-circle-question-mark": MessageCircleQuestionMark,
+  "message-square-reply": MessageSquareReply,
   "messages-square": MessagesSquare,
   monitor: Monitor,
   "mouse-pointer-click": MousePointerClick,
   "move-vertical": MoveVertical,
   "mouse-pointer-2": MousePointer2,
   network: Network,
+  "panel-top": PanelTop,
   plug: Plug,
   plus: Plus,
   "refresh-cw": RefreshCw,
+  "scroll-text": ScrollText,
   search: Search,
   send: Send,
   "share-2": Share2,
   shield: Shield,
+  "shield-check": ShieldCheck,
   "shield-off": ShieldOff,
   sparkle: Sparkle,
   terminal: Terminal,
+  "terminal-square": TerminalSquare,
   timer: Timer,
   "trash-2": Trash2,
   user: User,
@@ -311,7 +342,7 @@ export function getToolIconComponent(
   toolName: string,
   iconId?: string | null,
   action?: string | null
-): IconSvgElement {
+): RenderableIcon {
   const uiCanonical = getCliUiCanonical(toolName);
 
   // 1. Explicit icon id takes precedence
@@ -415,7 +446,7 @@ export function getEventIconComponent(
   eventType: string,
   status?: string | null,
   action?: string | null
-): IconSvgElement {
+): RenderableIcon {
   const uiCanonical = getCliUiCanonical(eventType);
 
   if (status) {

--- a/src/config/toolIcons.tsx
+++ b/src/config/toolIcons.tsx
@@ -3,17 +3,16 @@
  *
  * **Authoritative icon ids** for built-in tools come from Rust `ToolInfo.icon_id`
  * (`list_all_tools`). `ICON_BY_ID` maps those kebab-case ids to hugeicons
- * glyph data — plus brand marks (the MCP logo) as components, which is why
- * the value type is `RenderableIcon` and every render path goes through
- * `AnyIcon`, never `HugeiconsIcon` directly.
+ * glyph data. `mcp-logo` maps to the vendor's `McpServerIcon`, which draws
+ * the actual MCP logo mark; other brand marks are hand-authored SVG
+ * components handled outside this registry.
  *
  * NOTE: Terminal tool detection uses normalizeFunctionName() (Rust source of truth
  * via cli_agents/alias_map.rs) instead of hardcoded tool names.
  */
 import React from "react";
 
-import { McpLogoIcon } from "@src/assets/channelIcons/McpLogoIcon";
-import AnyIcon, { type RenderableIcon } from "@src/components/AnyIcon";
+import AnyIcon from "@src/components/AnyIcon";
 import {
   getBuiltinToolActionIconId,
   getBuiltinToolIconId,
@@ -79,6 +78,7 @@ import {
   Mail01Icon as Mail,
   MailWarningIcon as MailWarning,
   MapsIcon as Map,
+  McpServerIcon as McpLogo,
   BubbleChatIcon as MessageCircle,
   MessageCircleQuestionMarkIcon as MessageCircleQuestionMark,
   MessageSquareReplyIcon as MessageSquareReply,
@@ -118,11 +118,11 @@ export const DEFAULT_TOOL_ICON_CLASS = "text-text-2";
 
 /**
  * Maps Rust `icon_id` strings (kebab-case, lucide-era vocabulary) to
- * hugeicons glyph data (plus the MCP brand mark component).
+ * hugeicons glyph data.
  * Keep in sync with the `ToolEntry` tables in
  * `src-tauri/crates/agent-core/src/core/tools/builtin_tools/table/*.rs`.
  */
-const ICON_BY_ID: Record<string, RenderableIcon> = {
+const ICON_BY_ID: Record<string, IconSvgElement> = {
   activity: Activity,
   "arrow-big-right-dash": ArrowBigRightDash,
   "arrow-right-left": ArrowRightLeft,
@@ -179,7 +179,7 @@ const ICON_BY_ID: Record<string, RenderableIcon> = {
   mail: Mail,
   "mail-warning": MailWarning,
   map: Map,
-  "mcp-logo": McpLogoIcon,
+  "mcp-logo": McpLogo,
   "message-circle": MessageCircle,
   "message-circle-question-mark": MessageCircleQuestionMark,
   "message-square-reply": MessageSquareReply,
@@ -342,7 +342,7 @@ export function getToolIconComponent(
   toolName: string,
   iconId?: string | null,
   action?: string | null
-): RenderableIcon {
+): IconSvgElement {
   const uiCanonical = getCliUiCanonical(toolName);
 
   // 1. Explicit icon id takes precedence
@@ -446,7 +446,7 @@ export function getEventIconComponent(
   eventType: string,
   status?: string | null,
   action?: string | null
-): RenderableIcon {
+): IconSvgElement {
   const uiCanonical = getCliUiCanonical(eventType);
 
   if (status) {

--- a/src/engines/ChatPanel/ChatHistory/components/TurnMetadataFooter/__tests__/TurnMetadataFooter.test.ts
+++ b/src/engines/ChatPanel/ChatHistory/components/TurnMetadataFooter/__tests__/TurnMetadataFooter.test.ts
@@ -61,7 +61,6 @@ describe("TurnMetadataFooter tabs", () => {
 
     expect(markup).toContain('data-testid="turn-metadata-edits-tab"');
     expect(markup).not.toContain('data-testid="turn-metadata-reads-tab"');
-    expect(markup).not.toContain('data-icon="file-code-2"');
   });
 
   it("hides Edits when the turn only contains reads", () => {

--- a/src/engines/ChatPanel/ChatPanelTabBar/TabPill.tsx
+++ b/src/engines/ChatPanel/ChatPanelTabBar/TabPill.tsx
@@ -266,12 +266,14 @@ export const TabPill = memo(function TabPill({
       tab.managementSection === WORK_MANAGEMENT_SECTION.KANBAN
         ? LayoutThreeColumnIcon
         : ListTodoIcon;
-    icon = React.createElement(HugeiconsIcon, {
-      icon: WorkManagementIcon,
-      size: 16,
-      strokeWidth: 1.75,
-      className: `shrink-0 ${iconColorClass}`,
-    });
+    icon = (
+      <HugeiconsIcon
+        icon={WorkManagementIcon}
+        size={16}
+        strokeWidth={1.75}
+        className={`shrink-0 ${iconColorClass}`}
+      />
+    );
   } else if (tab.type === "github-issue") {
     icon = (
       <HugeiconsIcon

--- a/src/engines/ChatPanel/InputArea/components/CollapsedInlineRow.tsx
+++ b/src/engines/ChatPanel/InputArea/components/CollapsedInlineRow.tsx
@@ -204,7 +204,7 @@ const CollapsedInlineRow: React.FC<CollapsedInlineRowProps> = memo(
             icon={
               <HugeiconsIcon
                 icon={Layout01Icon}
-                data-icon="layout"
+                data-icon="panels-top-left"
                 size={13}
                 strokeWidth={2}
               />

--- a/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.tsx
+++ b/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/index.tsx
@@ -382,7 +382,7 @@ const PinnedActionsBar: React.FC<PinnedActionsBarProps> = memo(
               leftIcon={
                 <HugeiconsIcon
                   icon={Layout01Icon}
-                  data-icon="layout"
+                  data-icon="panels-top-left"
                   size={12}
                   strokeWidth={1.75}
                 />

--- a/src/engines/ChatPanel/InputArea/components/SlashCommandPortal/FlyoutSubmenu.tsx
+++ b/src/engines/ChatPanel/InputArea/components/SlashCommandPortal/FlyoutSubmenu.tsx
@@ -146,12 +146,12 @@ const FlyoutSubmenu: React.FC<FlyoutSubmenuProps> = ({
                     }}
                   >
                     <div className="flex min-w-0 items-center gap-2">
-                      {React.createElement(HugeiconsIcon, {
-                        icon: Icon,
-                        size: 14,
-                        strokeWidth: 1.75,
-                        className: "shrink-0 text-text-2",
-                      })}
+                      <HugeiconsIcon
+                        icon={Icon}
+                        size={14}
+                        strokeWidth={1.75}
+                        className="shrink-0 text-text-2"
+                      />
                       <span className="truncate text-[13px] text-text-1">
                         {item.name}
                       </span>

--- a/src/engines/SessionCore/rendering/registry/registryAccessors.ts
+++ b/src/engines/SessionCore/rendering/registry/registryAccessors.ts
@@ -5,7 +5,6 @@
  */
 import type { ComponentType, LazyExoticComponent } from "react";
 
-import type { RenderableIcon } from "@src/components/AnyIcon";
 import { getToolIconComponent } from "@src/config/toolIcons";
 import { resolveToolName } from "@src/engines/SessionCore/rendering/registry/toolAliases";
 import {
@@ -82,7 +81,7 @@ const TRAJECTORY_CHAT_ALIGNED_ICON: Record<string, IconSvgElement> = {
 export function getTrajectoryTimelineIcon(
   groupType: string,
   toolNameForRust?: string
-): RenderableIcon {
+): IconSvgElement {
   const chatAligned = TRAJECTORY_CHAT_ALIGNED_ICON[groupType];
   if (chatAligned) {
     return chatAligned;

--- a/src/engines/SessionCore/rendering/registry/registryAccessors.ts
+++ b/src/engines/SessionCore/rendering/registry/registryAccessors.ts
@@ -5,6 +5,7 @@
  */
 import type { ComponentType, LazyExoticComponent } from "react";
 
+import type { RenderableIcon } from "@src/components/AnyIcon";
 import { getToolIconComponent } from "@src/config/toolIcons";
 import { resolveToolName } from "@src/engines/SessionCore/rendering/registry/toolAliases";
 import {
@@ -81,7 +82,7 @@ const TRAJECTORY_CHAT_ALIGNED_ICON: Record<string, IconSvgElement> = {
 export function getTrajectoryTimelineIcon(
   groupType: string,
   toolNameForRust?: string
-): IconSvgElement {
+): RenderableIcon {
   const chatAligned = TRAJECTORY_CHAT_ALIGNED_ICON[groupType];
   if (chatAligned) {
     return chatAligned;

--- a/src/engines/Simulator/components/SimulatorStatusBar/FollowModeDropdown.tsx
+++ b/src/engines/Simulator/components/SimulatorStatusBar/FollowModeDropdown.tsx
@@ -157,11 +157,11 @@ export const FollowModeDropdown: React.FC = () => {
                     : DROPDOWN_CLASSES.itemHover
                 } w-full justify-between gap-2 disabled:cursor-not-allowed disabled:opacity-40`}
               >
-                {React.createElement(HugeiconsIcon, {
-                  icon: getActiveAppIcon(activeApp) ?? Layers01Icon,
-                  size: 12,
-                  strokeWidth: 2,
-                })}
+                <HugeiconsIcon
+                  icon={getActiveAppIcon(activeApp) ?? Layers01Icon}
+                  size={12}
+                  strokeWidth={2}
+                />
                 <span className="flex-1 text-left">
                   {t("simulator.replay.trajectoryThisApp")}
                 </span>

--- a/src/engines/Simulator/components/SimulatorStatusBar/index.tsx
+++ b/src/engines/Simulator/components/SimulatorStatusBar/index.tsx
@@ -155,11 +155,11 @@ export const SimulatorStatusBar: React.FC<SimulatorStatusBarProps> = memo(
                   onClick={handleToggleToReplay}
                   className="flex h-5 w-5 transform-gpu items-center justify-center rounded-full text-white hover:bg-white/15 hover:text-white"
                 >
-                  {React.createElement(HugeiconsIcon, {
-                    icon: Cursor02Icon,
-                    size: 12,
-                    strokeWidth: 1.75,
-                  })}
+                  <HugeiconsIcon
+                    icon={Cursor02Icon}
+                    size={12}
+                    strokeWidth={1.75}
+                  />
                 </button>
               </Tooltip>
             </>
@@ -173,11 +173,11 @@ export const SimulatorStatusBar: React.FC<SimulatorStatusBarProps> = memo(
                 className={`ml-0.5 ${STATUS_BAR_ICON_BTN_20}`}
                 title={t("simulator.replay.previousEvent")}
               >
-                {React.createElement(HugeiconsIcon, {
-                  icon: ArrowLeft01Icon,
-                  size: 14,
-                  strokeWidth: 1.5,
-                })}
+                <HugeiconsIcon
+                  icon={ArrowLeft01Icon}
+                  size={14}
+                  strokeWidth={1.5}
+                />
               </button>
               <button
                 data-testid="session-replay-play-pause"
@@ -194,12 +194,13 @@ export const SimulatorStatusBar: React.FC<SimulatorStatusBarProps> = memo(
                     : t("simulator.replay.play")
                 }
               >
-                {React.createElement(HugeiconsIcon, {
-                  icon: isReplaying ? PauseIcon : PlayIcon,
-                  size: 12,
-                  fill: "currentColor",
-                  strokeWidth: 0,
-                })}
+                <HugeiconsIcon
+                  icon={isReplaying ? PauseIcon : PlayIcon}
+                  data-icon={isReplaying ? "pause" : "play"}
+                  size={12}
+                  fill="currentColor"
+                  strokeWidth={0}
+                />
               </button>
               <button
                 data-testid="session-replay-next"
@@ -208,11 +209,11 @@ export const SimulatorStatusBar: React.FC<SimulatorStatusBarProps> = memo(
                 className={STATUS_BAR_ICON_BTN_20}
                 title={t("simulator.replay.nextEvent")}
               >
-                {React.createElement(HugeiconsIcon, {
-                  icon: ArrowRight01Icon,
-                  size: 14,
-                  strokeWidth: 1.5,
-                })}
+                <HugeiconsIcon
+                  icon={ArrowRight01Icon}
+                  size={14}
+                  strokeWidth={1.5}
+                />
               </button>
               {playbackSpeed != null && onPlaybackSpeedChange != null ? (
                 <PlaybackSpeedInline

--- a/src/features/CodeViewer/components/CollapseRow.tsx
+++ b/src/features/CodeViewer/components/CollapseRow.tsx
@@ -5,11 +5,11 @@
  */
 import React from "react";
 
-import AnyIcon from "@src/components/AnyIcon";
 import {
   ArrowDownFromLineIcon,
   ArrowUpFromLineIcon,
   FoldVerticalIcon,
+  HugeiconsIcon,
 } from "@src/icons";
 
 import type { CollapsedSection } from "../types";
@@ -43,7 +43,11 @@ export const CollapseRow: React.FC<CollapseRowProps> = ({
       {/* Center gutter */}
       <div className="split-row-center">
         <div className="split-row-gutter split-row-gutter-old">
-          <AnyIcon icon={CollapseIcon} size={14} className="collapse-icon" />
+          <HugeiconsIcon
+            icon={CollapseIcon}
+            size={14}
+            className="collapse-icon"
+          />
         </div>
 
         {cherrypicking && (

--- a/src/features/SessionCreator/components/RunnerListPanel/RunnerRow.tsx
+++ b/src/features/SessionCreator/components/RunnerListPanel/RunnerRow.tsx
@@ -100,23 +100,25 @@ const RunnerRow: React.FC<RunnerRowProps> = memo(
     // An unpicked row still gets an icon. Leaving the slot empty made the row
     // jump sideways the moment a harness was chosen; the placeholder holds the
     // width and reads as "anything could go here".
-    const agentPillIcon = agentDisplay.iconId
-      ? React.createElement(AnyIcon, {
-          icon: resolveAgentIcon(agentDisplay.iconId),
-          size: PILL_SM_ICON_SIZE,
-          className: "block text-text-1",
-        })
-      : agentDisplay.cliAgentType
-        ? React.createElement(ModelIcon, {
-            agentType: agentDisplay.cliAgentType,
-            size: PILL_SM_ICON_SIZE,
-            className: "block",
-          })
-        : React.createElement(HugeiconsIcon, {
-            icon: Infinity01Icon,
-            size: PILL_SM_ICON_SIZE,
-            className: "block",
-          });
+    const agentPillIcon = agentDisplay.iconId ? (
+      <AnyIcon
+        icon={resolveAgentIcon(agentDisplay.iconId)}
+        size={PILL_SM_ICON_SIZE}
+        className="block text-text-1"
+      />
+    ) : agentDisplay.cliAgentType ? (
+      <ModelIcon
+        agentType={agentDisplay.cliAgentType}
+        size={PILL_SM_ICON_SIZE}
+        className="block"
+      />
+    ) : (
+      <HugeiconsIcon
+        icon={Infinity01Icon}
+        size={PILL_SM_ICON_SIZE}
+        className="block"
+      />
+    );
 
     return (
       <li

--- a/src/features/TaskKanban/components/KanbanReplayStatusPill/index.tsx
+++ b/src/features/TaskKanban/components/KanbanReplayStatusPill/index.tsx
@@ -286,11 +286,11 @@ const KanbanReplayStatusPill: React.FC = memo(() => {
                 aria-label={t("simulator.replay.freeBrowse")}
                 className="flex h-5 w-5 transform-gpu items-center justify-center rounded-full text-white hover:bg-white/15 hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
               >
-                {React.createElement(HugeiconsIcon, {
-                  icon: Cursor02Icon,
-                  size: 12,
-                  strokeWidth: 1.75,
-                })}
+                <HugeiconsIcon
+                  icon={Cursor02Icon}
+                  size={12}
+                  strokeWidth={1.75}
+                />
               </button>
             </Tooltip>
           </>
@@ -311,11 +311,11 @@ const KanbanReplayStatusPill: React.FC = memo(() => {
               title={t("simulator.replay.previousEvent")}
               aria-label={t("simulator.replay.previousEvent")}
             >
-              {React.createElement(HugeiconsIcon, {
-                icon: ArrowLeft01Icon,
-                size: 14,
-                strokeWidth: 1.5,
-              })}
+              <HugeiconsIcon
+                icon={ArrowLeft01Icon}
+                size={14}
+                strokeWidth={1.5}
+              />
             </button>
             <button
               type="button"
@@ -337,12 +337,13 @@ const KanbanReplayStatusPill: React.FC = memo(() => {
                   : t("simulator.replay.play")
               }
             >
-              {React.createElement(HugeiconsIcon, {
-                icon: isPlaying ? PauseIcon : PlayIcon,
-                size: 12,
-                fill: "currentColor",
-                strokeWidth: 0,
-              })}
+              <HugeiconsIcon
+                icon={isPlaying ? PauseIcon : PlayIcon}
+                data-icon={isPlaying ? "pause" : "play"}
+                size={12}
+                fill="currentColor"
+                strokeWidth={0}
+              />
             </button>
             <button
               type="button"
@@ -352,11 +353,11 @@ const KanbanReplayStatusPill: React.FC = memo(() => {
               title={t("simulator.replay.nextEvent")}
               aria-label={t("simulator.replay.nextEvent")}
             >
-              {React.createElement(HugeiconsIcon, {
-                icon: ArrowRight01Icon,
-                size: 14,
-                strokeWidth: 1.5,
-              })}
+              <HugeiconsIcon
+                icon={ArrowRight01Icon}
+                size={14}
+                strokeWidth={1.5}
+              />
             </button>
             <PlaybackSpeedInline
               value={playbackSpeed}

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -286,6 +286,7 @@ export { default as MailReply01Icon } from "@hugeicons/core-free-icons/MailReply
 export { default as MailSend01Icon } from "@hugeicons/core-free-icons/MailSend01Icon";
 export { default as MailWarningIcon } from "@hugeicons/core-free-icons/MailWarningIcon";
 export { default as MapsIcon } from "@hugeicons/core-free-icons/MapsIcon";
+export { default as McpServerIcon } from "@hugeicons/core-free-icons/McpServerIcon";
 export { default as Menu01Icon } from "@hugeicons/core-free-icons/Menu01Icon";
 export { default as Message01Icon } from "@hugeicons/core-free-icons/Message01Icon";
 export { default as Message02Icon } from "@hugeicons/core-free-icons/Message02Icon";

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -111,6 +111,7 @@ export { default as ChevronsDownUpIcon } from "@hugeicons/core-free-icons/Chevro
 export { default as ChevronsLeftRightEllipsisIcon } from "@hugeicons/core-free-icons/ChevronsLeftRightEllipsisIcon";
 export { default as CircleArrowOutUpRightIcon } from "@hugeicons/core-free-icons/CircleArrowOutUpRightIcon";
 export { default as CircleArrowUp01Icon } from "@hugeicons/core-free-icons/CircleArrowUp01Icon";
+export { default as CircleCheckBigIcon } from "@hugeicons/core-free-icons/CircleCheckBigIcon";
 export { default as CircleCheckIcon } from "@hugeicons/core-free-icons/CircleCheckIcon";
 export { default as CircleDashedIcon } from "@hugeicons/core-free-icons/CircleDashedIcon";
 export { default as CircleDollarSignIcon } from "@hugeicons/core-free-icons/CircleDollarSignIcon";
@@ -205,6 +206,7 @@ export { default as FolderInputIcon } from "@hugeicons/core-free-icons/FolderInp
 export { default as FolderKanbanIcon } from "@hugeicons/core-free-icons/FolderKanbanIcon";
 export { default as FolderMinusIcon } from "@hugeicons/core-free-icons/FolderMinusIcon";
 export { default as FolderOpenIcon } from "@hugeicons/core-free-icons/FolderOpenIcon";
+export { default as FolderPenIcon } from "@hugeicons/core-free-icons/FolderPenIcon";
 export { default as FolderOutputIcon } from "@hugeicons/core-free-icons/FolderOutputIcon";
 export { default as FolderSearchIcon } from "@hugeicons/core-free-icons/FolderSearchIcon";
 export { default as FolderSymlinkIcon } from "@hugeicons/core-free-icons/FolderSymlinkIcon";
@@ -282,6 +284,7 @@ export { default as Mail01Icon } from "@hugeicons/core-free-icons/Mail01Icon";
 export { default as MailOpen01Icon } from "@hugeicons/core-free-icons/MailOpen01Icon";
 export { default as MailReply01Icon } from "@hugeicons/core-free-icons/MailReply01Icon";
 export { default as MailSend01Icon } from "@hugeicons/core-free-icons/MailSend01Icon";
+export { default as MailWarningIcon } from "@hugeicons/core-free-icons/MailWarningIcon";
 export { default as MapsIcon } from "@hugeicons/core-free-icons/MapsIcon";
 export { default as Menu01Icon } from "@hugeicons/core-free-icons/Menu01Icon";
 export { default as Message01Icon } from "@hugeicons/core-free-icons/Message01Icon";
@@ -293,6 +296,7 @@ export { default as MessageCircleQuestionMarkIcon } from "@hugeicons/core-free-i
 export { default as MessageCircleWarningIcon } from "@hugeicons/core-free-icons/MessageCircleWarningIcon";
 export { default as MessageMultiple01Icon } from "@hugeicons/core-free-icons/MessageMultiple01Icon";
 export { default as MessageSquareMoreIcon } from "@hugeicons/core-free-icons/MessageSquareMoreIcon";
+export { default as MessageSquareReplyIcon } from "@hugeicons/core-free-icons/MessageSquareReplyIcon";
 export { default as Mic01Icon } from "@hugeicons/core-free-icons/Mic01Icon";
 export { default as MinusSignCircleIcon } from "@hugeicons/core-free-icons/MinusSignCircleIcon";
 export { default as MinusSignIcon } from "@hugeicons/core-free-icons/MinusSignIcon";
@@ -313,6 +317,7 @@ export { default as PaintBrush01Icon } from "@hugeicons/core-free-icons/PaintBru
 export { default as PanelLeftIcon } from "@hugeicons/core-free-icons/PanelLeftIcon";
 export { default as PanelRightIcon } from "@hugeicons/core-free-icons/PanelRightIcon";
 export { default as PanelRightOpenIcon } from "@hugeicons/core-free-icons/PanelRightOpenIcon";
+export { default as PanelTopIcon } from "@hugeicons/core-free-icons/PanelTopIcon";
 export { default as PanelsTopLeftIcon } from "@hugeicons/core-free-icons/PanelsTopLeftIcon";
 export { default as PauseIcon } from "@hugeicons/core-free-icons/PauseIcon";
 export { default as Pen01Icon } from "@hugeicons/core-free-icons/Pen01Icon";

--- a/src/modules/WorkStation/Canvas/index.tsx
+++ b/src/modules/WorkStation/Canvas/index.tsx
@@ -191,7 +191,7 @@ function CanvasApp(props: SimulatorAppProps) {
         <div className="flex items-center gap-2 text-sm text-text-2">
           <HugeiconsIcon
             icon={Layout01Icon}
-            data-icon="layout"
+            data-icon="panels-top-left"
             className="h-4 w-4"
           />
           <span>{t("simulator.replay.canvas.toolbarTitle")}</span>

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/TimelineContent/components/FileSessionHistoryParticipantView.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/TimelineContent/components/FileSessionHistoryParticipantView.tsx
@@ -1,8 +1,8 @@
 import React, { memo } from "react";
 import { useTranslation } from "react-i18next";
 
-import AnyIcon from "@src/components/AnyIcon";
 import SessionHoverCard from "@src/components/SessionHoverCard";
+import { HugeiconsIcon } from "@src/icons";
 import {
   HEADER_BUTTON,
   PRIMARY_SIDEBAR_HOVER,
@@ -92,7 +92,7 @@ export const FileSessionHistoryParticipantView: React.FC<FileSessionHistoryParti
           <span
             className={`${HEADER_BUTTON.actionTreeRow} hidden flex-shrink-0 group-hover/session-history:flex`}
           >
-            <AnyIcon icon={OpenIcon} size={14} />
+            <HugeiconsIcon icon={OpenIcon} size={14} />
           </span>
         )}
       </button>

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/TimelineContent/components/TimelineEntry.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/content/TimelineContent/components/TimelineEntry.tsx
@@ -1,8 +1,8 @@
 import React, { memo } from "react";
 import { useTranslation } from "react-i18next";
 
-import AnyIcon from "@src/components/AnyIcon";
 import { SURFACE_TOKENS } from "@src/config/surfaceTokens";
+import { HugeiconsIcon } from "@src/icons";
 import {
   HEADER_BUTTON,
   PRIMARY_SIDEBAR_HOVER,
@@ -45,7 +45,7 @@ export const TimelineEntry: React.FC<TimelineEntryProps> = memo(
         onClick={onClick}
       >
         <div className="flex h-4 w-4 flex-shrink-0 items-center justify-center">
-          <AnyIcon icon={CommitIcon} size={14} className="text-text-3" />
+          <HugeiconsIcon icon={CommitIcon} size={14} className="text-text-3" />
         </div>
 
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
@@ -69,7 +69,7 @@ export const TimelineEntry: React.FC<TimelineEntryProps> = memo(
           }}
           title={t("tooltips.openDiff")}
         >
-          <AnyIcon icon={OpenIcon} size={14} />
+          <HugeiconsIcon icon={OpenIcon} size={14} />
         </button>
       </div>
     );

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/FilesTab.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/FilesTab.tsx
@@ -11,9 +11,9 @@
 import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
-import AnyIcon from "@src/components/AnyIcon";
 import type { SectionHeaderAction } from "@src/components/TreePanelSidebar/types";
 import { useSelectedFile } from "@src/hooks/tabHost/useSelectedFile";
+import { HugeiconsIcon } from "@src/icons";
 import type { PrimarySidebarTab } from "@src/modules/WorkStation/shared";
 
 import { ICON_CONFIG, PANEL_CONSTANTS } from "../config";
@@ -65,7 +65,9 @@ export function useFilesTabConfig({
     () => ({
       key: "files",
       label: t("tabs.explorer"),
-      icon: <AnyIcon icon={FilesIcon} size={PANEL_CONSTANTS.TAB_ICON_SIZE} />,
+      icon: (
+        <HugeiconsIcon icon={FilesIcon} size={PANEL_CONSTANTS.TAB_ICON_SIZE} />
+      ),
       sections: [
         {
           key: "files",

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SearchTab.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SearchTab.tsx
@@ -17,7 +17,6 @@ import React, {
 } from "react";
 import { useTranslation } from "react-i18next";
 
-import AnyIcon from "@src/components/AnyIcon";
 import type { SectionHeaderAction } from "@src/components/TreePanelSidebar/types";
 import { ArrowLeft02Icon, HugeiconsIcon } from "@src/icons";
 import { useOpenEditorFiles } from "@src/modules/WorkStation/CodeEditor/hooks/useOpenEditorFiles";
@@ -140,7 +139,9 @@ export function useSearchTabConfig({
 
   // PERFORMANCE: Memoize icon to prevent re-renders
   const searchIcon = useMemo(
-    () => <AnyIcon icon={SearchIcon} size={PANEL_CONSTANTS.TAB_ICON_SIZE} />,
+    () => (
+      <HugeiconsIcon icon={SearchIcon} size={PANEL_CONSTANTS.TAB_ICON_SIZE} />
+    ),
     [SearchIcon]
   );
 

--- a/src/modules/WorkStation/TabContent/renderers/canvasPreview.tsx
+++ b/src/modules/WorkStation/TabContent/renderers/canvasPreview.tsx
@@ -67,7 +67,7 @@ const CanvasPreviewTabRenderer: React.FC<UnifiedTabContentProps> = memo(
         <div className="flex h-full flex-col items-center justify-center gap-3 text-text-4">
           <HugeiconsIcon
             icon={Layout01Icon}
-            data-icon="layout"
+            data-icon="panels-top-left"
             size={32}
             strokeWidth={1}
           />
@@ -82,7 +82,7 @@ const CanvasPreviewTabRenderer: React.FC<UnifiedTabContentProps> = memo(
           <div className="flex min-w-0 items-center gap-2">
             <HugeiconsIcon
               icon={Layout01Icon}
-              data-icon="layout"
+              data-icon="panels-top-left"
               size={13}
               className="shrink-0 text-primary-6"
             />

--- a/src/scaffold/GlobalSpotlight/components/SpotlightSearchBar.tsx
+++ b/src/scaffold/GlobalSpotlight/components/SpotlightSearchBar.tsx
@@ -8,7 +8,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 
 import AnyIcon from "@src/components/AnyIcon";
-import { ArrowLeft01Icon, HugeiconsIcon, Search01Icon } from "@src/icons";
+import { ArrowLeft01Icon, HugeiconsIcon } from "@src/icons";
 
 import { ICONS } from "../config";
 import { SPOTLIGHT_CLASSES, SPOTLIGHT_TOKENS } from "../constants";
@@ -69,8 +69,6 @@ export const SpotlightSearchBar: React.FC<SpotlightSearchBarProps> = ({
 
   const hasPills = path.length > 0;
   const hasLeadingSlot = Boolean(leadingSlot);
-  const displayIcon = ICONS.search;
-  const IconComponent = typeof displayIcon === "string" ? null : displayIcon;
 
   const getSegmentLabel = (segment: PathSegment): string => {
     const data = segment.data as
@@ -120,24 +118,12 @@ export const SpotlightSearchBar: React.FC<SpotlightSearchBarProps> = ({
           <div className="flex flex-shrink-0 items-center">{leadingSlot}</div>
         ) : !hasPills ? (
           <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center">
-            {IconComponent ? (
-              <AnyIcon
-                icon={IconComponent}
-                size={SPOTLIGHT_TOKENS.iconSize}
-                className="text-text-2"
-              />
-            ) : typeof displayIcon === "string" ? (
-              <i
-                className={`${displayIcon} text-[${SPOTLIGHT_TOKENS.iconSize}px] text-text-2`}
-              />
-            ) : (
-              <HugeiconsIcon
-                icon={Search01Icon}
-                data-icon="search"
-                className="text-text-2"
-                size={SPOTLIGHT_TOKENS.iconSize}
-              />
-            )}
+            <AnyIcon
+              icon={ICONS.search}
+              size={SPOTLIGHT_TOKENS.iconSize}
+              className="text-text-2"
+              data-icon="search"
+            />
           </div>
         ) : null}
 
@@ -199,10 +185,7 @@ export const SpotlightSearchBar: React.FC<SpotlightSearchBarProps> = ({
             aria-label={t("common:actions.clearSearch")}
             onClick={handleResetSearch}
           >
-            {React.createElement(HugeiconsIcon, {
-              icon: ICONS.close,
-              size: 14,
-            })}
+            <HugeiconsIcon icon={ICONS.close} size={14} />
           </button>
         )}
 

--- a/src/scaffold/GlobalSpotlight/components/SpotlightSearchBar.tsx
+++ b/src/scaffold/GlobalSpotlight/components/SpotlightSearchBar.tsx
@@ -105,26 +105,13 @@ export const SpotlightSearchBar: React.FC<SpotlightSearchBarProps> = ({
     />
   );
 
-  const renderPillIcon = (segment: PathSegment) => {
-    if (typeof segment.icon === "function") {
-      return React.createElement(
-        segment.icon as React.ComponentType<{
-          size?: number;
-          className?: string;
-        }>,
-        {
-          size: 14,
-          className: "text-primary-6",
-        }
-      );
-    }
-
-    if (typeof segment.icon === "string") {
-      return <i className={`${segment.icon} text-[14px] text-primary-6`} />;
-    }
-
-    return null;
-  };
+  // AnyIcon resolves every shape a segment can carry: an icon-font class
+  // string, a brand-mark component (including forwardRef/memo wrappers, which
+  // `typeof === "function"` misses), and hugeicons glyph data — which a
+  // hand-rolled switch here used to drop entirely, leaving pills iconless.
+  const renderPillIcon = (segment: PathSegment) => (
+    <AnyIcon icon={segment.icon} size={14} className="text-primary-6" />
+  );
 
   return (
     <div>

--- a/src/scaffold/GlobalSpotlight/palettes/BranchPalette/index.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/BranchPalette/index.tsx
@@ -253,13 +253,13 @@ export const WorktreePalette: React.FC<WorktreePaletteProps> = ({
         action: () => setMode("remove"),
       });
     }
-    const RefreshIcon = (props: { size?: number; className?: string }) =>
-      React.createElement(HugeiconsIcon, {
-        icon: Refresh04Icon,
-        ...props,
-        className:
-          `${props.className ?? ""} ${isRefreshing ? "spotlight-refresh-spin" : ""}`.trim(),
-      });
+    const RefreshIcon = (props: { size?: number; className?: string }) => (
+      <HugeiconsIcon
+        icon={Refresh04Icon}
+        {...props}
+        className={`${props.className ?? ""} ${isRefreshing ? "spotlight-refresh-spin" : ""}`.trim()}
+      />
+    );
 
     actions.push({
       id: "worktree:refresh",

--- a/src/scaffold/NavigationSidebar/blocks/SidebarBottomBar.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarBottomBar.tsx
@@ -331,20 +331,11 @@ export const PresenceMenuButton: React.FC<PresenceMenuButtonProps> = ({
   // pills: icon at rest, chevron on hover, chevron-up while open. The
   // surrounding Dropdown owns the click — segment onClick is a noop so
   // the parent's click handler fires unopposed.
-  // `React.createElement` (rather than `<Icon … />`) keeps the
-  // `react-hooks/static-components` lint rule happy: the rule flags
-  // any PascalCase variable used as a JSX tag inside a hook callback
-  // as a "component created during render", which we aren't actually
-  // doing — `Icon` is just a stable glyph reference.
   const segments: PillGroupSegment[] = useMemo(
     () => [
       {
         id: "presence",
-        icon: React.createElement(HugeiconsIcon, {
-          icon: Icon,
-          size: 12,
-          className: colorClass,
-        }),
+        icon: <HugeiconsIcon icon={Icon} size={12} className={colorClass} />,
         label: pillLabel,
         active: menuVisible,
         ariaLabel,

--- a/src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx
+++ b/src/scaffold/NavigationSidebar/variants/NavigationSidebar.tsx
@@ -13,12 +13,12 @@ import React, {
   useState,
 } from "react";
 
+import AnyIcon from "@src/components/AnyIcon";
 import { Placeholder } from "@src/components/Placeholder";
 import TabPill from "@src/components/TabPill";
 import {
   ArrowDown01Icon,
   ArrowRight01Icon,
-  HugeiconsIcon,
   type IconSvgElement,
 } from "@src/icons";
 
@@ -403,11 +403,12 @@ const NavigationSidebar: React.FC<NavigationSidebarProps> = React.memo(
                     className: "h-[14px] w-[14px]",
                     strokeWidth: 2,
                   })
-                : React.createElement(HugeiconsIcon, {
+                : React.createElement(AnyIcon, {
                     icon: tab.icon,
                     size: 14,
                     strokeWidth: 2,
                     className: "h-[14px] w-[14px]",
+                    "data-icon": tab.iconName ?? tab.key,
                   })
               : undefined,
         })),

--- a/tests/e2e/specs/core/session-replay-live-overlay-ui.spec.mjs
+++ b/tests/e2e/specs/core/session-replay-live-overlay-ui.spec.mjs
@@ -295,7 +295,7 @@ async function waitForPlaybackState(isPlaying) {
     {
       timeout: RENDER_TIMEOUT_MS,
       interval: 100,
-      timeoutMsg: `replay control did not render ${iconClass}`,
+      timeoutMsg: `replay control did not render ${iconName}`,
     }
   );
 }


### PR DESCRIPTION
## Problem

The merged hugeicons migration (#1019) left behind defects that neither tsc, the unit suite, nor the migration's own detectors could see, because hugeicons glyphs are data (`IconSvgElement` arrays satisfy `ReactNode`) and icon identity now lives in string registries and `data-icon` stamps:

- **Spotlight breadcrumb pills lost their icons.** `SpotlightSearchBar.renderPillIcon` hand-rolled the icon-shape switch (`typeof === "function"` → string → `null`). Under lucide every icon was a function; under hugeicons the spotlight reducer feeds glyph data (`FolderClosedIcon`, `WorkflowCircle05Icon`), which fell through to `null`. The same check also misroutes forwardRef/memo brand marks (objects, not functions).
- **MCP tool calls lost the MCP logo.** develop had `CUSTOM_ICON_BY_ID = { "mcp-logo": McpLogoIcon }`; the migration dropped it because a component cannot live in the glyph-typed `ICON_BY_ID`, so `getEventIcon("mcp_tool")` falls through to the generic Logs icon.
- **The e2e replay spec can no longer find play/pause.** It waits for `svg[data-icon="play"/"pause"]`, but no site stamps them (lucide's auto-class `lucide-play` died with the migration), and a renamed template-literal variable (`iconClass`) makes the helper throw `ReferenceError` before it even waits.
- Assorted smaller leftovers: an incomplete `layout`→`panels-top-left` stamp unification (5 stragglers), 14 Rust-emitted `icon_id`s with no frontend mapping (pre-existing, but the audit surfaced them), a latent crash path in `NavigationSidebar` (registry-fed `tab.icon` straight into `HugeiconsIcon`, whose internal `[...icon]` spread dies on a component), 14 `React.createElement(HugeiconsIcon, …)` lint-dodges whose rationale evaporated when the tag became a static import, seven statically-typed glyphs wrapped in `AnyIcon` against its own contract, and one provably vacuous negative test assertion.

## Solution

Found by a four-way audit of the merged migration: registry sync against the Rust `ToolEntry` tables, an AST pass over all 2,222 `HugeiconsIcon` render sites, `data-icon`/e2e selector cross-checks, and a codemod-damage scan of the 50k-line migration diff.

- **Boundary fixes.** `renderPillIcon` and `NavigationSidebar.tabPillTabs` now render through `AnyIcon` — the sanctioned resolver for dynamic icon values (glyph data, components incl. forwardRef/memo, icon-font strings, undefined→dev-warned null). Conversely, seven sites feeding statically-typed glyphs to `AnyIcon` now use `HugeiconsIcon` directly, per `AnyIcon`'s documented contract. SpotlightSearchBar's dead lucide-era search-icon triple-branch is collapsed.
- **Registry restoration.** `"mcp-logo"` maps to hugeicons' `McpServerIcon`, which draws the actual MCP logo mark (the same two-stroke crossover geometry as the Wikimedia brand asset), so `ICON_BY_ID` stays purely `Record<string, IconSvgElement>` and a component in the map remains a compile error. The hand-authored `McpLogoIcon` component keeps its other consumers. The 14 unmapped Rust ids get doc-backed mappings (6 new barrel re-exports). Stale comments pointing at the deleted `builtin_tools_list.rs` now point at the live `table/*.rs`.
- **Test-hook repairs.** `SimulatorStatusBar` and `KanbanReplayStatusPill` stamp `data-icon={playing ? "pause" : "play"}` (matching the existing `IndependentGridCell` pattern); the e2e spec's `iconClass`→`iconName` leftover is fixed; the five `layout` stamps are unified to `panels-top-left` (no test asserts the old name); one vacuous `not.toContain` assertion is deleted.
- **Mechanical cleanup.** The 14 `createElement(HugeiconsIcon, …)` sites become plain JSX (the `react-hooks/static-components` concern applied to variable tags, not the static import — verified via eslint), including `SidebarBottomBar`, whose now-stale defensive comment is removed.

Scans that came back clean, for the record: zero duplicate or lost JSX attributes (aria-*, data-testid, onClick, className token survival checked hunk-by-hunk across the migration diff), zero glyph-data-as-JSX-child sites (custom TS-checker scan), zero dead `.lucide` selectors, zero reachable `HugeiconsIcon` crash values in the current tree, no other `data-icon` drift (every split name traces faithfully to its pre-migration local identifier), no dead barrel stems.

## Potential risks

- The five `layout`→`panels-top-left` stamp renames change DOM attributes; no unit test or e2e selector references the old value (verified by exhaustive grep), but out-of-tree tooling that hardcoded `data-icon="layout"` would need the new name.
- The e2e replay spec is repaired but **e2e was not executed** in this environment; the spec should pass once run since the awaited stamps now exist, but that remains unverified.
- `SearchTab`/`FilesTab` and friends now render static glyphs without `AnyIcon`'s undefined-guard; the values are fixed-key accesses on `as const` glyph objects, so absence is impossible without a type error.

## Verification

- `npx tsc --noEmit --pretty false` — 0 error lines (counted; exit code is unreliable in this repo).
- `npx eslint <all 25 changed files> --max-warnings 0` — clean; `npx prettier` — conformant.
- Targeted `vitest run` over every touched area (GlobalSpotlight, NavigationSidebar, Simulator, TaskKanban, ChatHistory, ChatPanelTabBar, TabContent, ChatPanel/blocks) — **1,047/1,047 passed**; earlier per-domain runs additionally covered Spotlight 73/73 and NavigationSidebar 216/216 post-fix.
- AST audit script re-run after fixes: dynamic `HugeiconsIcon` sites 37→36, all remaining classified safe with reasons; zero regressions introduced.
- All 15 new `ICON_BY_ID` mappings (14 gap-fills + the restored `mcp-logo`) verified against the vendor package: each deep module exists and exports icon-data arrays.
- Not run: the e2e suite (environment cannot execute it — called out above), full `cargo` suite (no Rust files touched).
