### PR TITLE
fix(git): add --autostash to rebase pulls

### DIFF
--- a/src-tauri/crates/git-api/src/commands/remote.rs
+++ b/src-tauri/crates/git-api/src/commands/remote.rs
@@ -549,6 +549,21 @@ pub(crate) fn detect_pull_error_type(message: &str) -> (GitErrorType, Option<Vec
     (GitErrorType::Unknown, None)
 }
 
+/// Strategy flags for `git pull`.
+///
+/// Rebase pulls carry `--autostash`: without it git refuses to start whenever
+/// the working tree is dirty at all ("cannot pull with rebase: You have
+/// unstaged changes"), even when nothing overlaps the incoming commits.
+/// Autostash restores parity with merge pulls, which natively tolerate
+/// non-overlapping local changes and still stop on genuine overlap.
+pub(crate) fn pull_strategy_args(strategy: Option<&str>) -> &'static [&'static str] {
+    match strategy {
+        Some("rebase") => &["--rebase", "--autostash"],
+        Some("ff-only") => &["--ff-only"],
+        _ => &["--no-rebase"], // merge or unknown → explicit merge
+    }
+}
+
 /// Pull from remote
 pub fn pull_from_remote(
     repo_path: &Path,
@@ -560,12 +575,7 @@ pub fn pull_from_remote(
     store_auth: bool,
 ) -> Result<GitPullResult, String> {
     let mut args = vec!["pull"];
-
-    match strategy {
-        Some("rebase") => args.push("--rebase"),
-        Some("ff-only") => args.push("--ff-only"),
-        Some("merge") | None | Some(_) => args.push("--no-rebase"), // merge or unknown → explicit merge
-    }
+    args.extend_from_slice(pull_strategy_args(strategy));
 
     if let Some(r) = remote {
         args.push(r);

--- a/src-tauri/crates/git-api/src/commands/streaming.rs
+++ b/src-tauri/crates/git-api/src/commands/streaming.rs
@@ -27,6 +27,7 @@ use tokio::process::Command;
 use git::{tokio_git_command, util::is_transient_error};
 
 use super::commit::append_orgii_coauthor_trailer;
+use super::remote::pull_strategy_args;
 
 type GitEventStream = Pin<Box<dyn Stream<Item = Result<Event, std::convert::Infallible>> + Send>>;
 
@@ -400,20 +401,8 @@ pub async fn pull_stream(
     cmd.args(["-c", "credential.interactive=false", "-c", "core.askPass="])
         .arg("pull");
 
-    let strategy_flag = match query.strategy.as_deref() {
-        Some("rebase") => {
-            cmd.arg("--rebase");
-            " --rebase"
-        }
-        Some("ff-only") => {
-            cmd.arg("--ff-only");
-            " --ff-only"
-        }
-        _ => {
-            cmd.arg("--no-rebase");
-            " --no-rebase"
-        }
-    };
+    let strategy_args = pull_strategy_args(query.strategy.as_deref());
+    cmd.args(strategy_args);
 
     cmd.arg(&remote);
 
@@ -431,7 +420,7 @@ pub async fn pull_stream(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    let command_str = format!("git pull{} {}", strategy_flag, remote);
+    let command_str = format!("git pull {} {}", strategy_args.join(" "), remote);
     let stream = stream_git_command(cmd, command_str, "pull").await;
 
     sse_response(stream)

--- a/src-tauri/crates/git-api/src/commands/tests/remote_tests.rs
+++ b/src-tauri/crates/git-api/src/commands/tests/remote_tests.rs
@@ -1,5 +1,5 @@
 use crate::commands::remote::{
-    detect_fetch_error_type, detect_pull_error_type, detect_push_error_type,
+    detect_fetch_error_type, detect_pull_error_type, detect_push_error_type, pull_strategy_args,
 };
 use crate::types::GitErrorType;
 
@@ -156,6 +156,32 @@ fn push_error_unknown() {
         detect_push_error_type("some other error"),
         GitErrorType::Unknown,
     );
+}
+
+// ============================================
+// pull_strategy_args
+// ============================================
+
+/// Regression: a bare `git pull --rebase` refuses to start whenever the
+/// working tree is dirty at all ("cannot pull with rebase: You have unstaged
+/// changes"), even when nothing overlaps the incoming commits. `--autostash`
+/// must always accompany `--rebase`.
+#[test]
+fn pull_strategy_rebase_always_autostashes() {
+    assert_eq!(
+        pull_strategy_args(Some("rebase")),
+        &["--rebase", "--autostash"]
+    );
+}
+
+#[test]
+fn pull_strategy_merge_and_ff_only_do_not_autostash() {
+    // Merge and fast-forward pulls natively tolerate non-overlapping local
+    // changes and must keep refusing on genuine overlap.
+    assert_eq!(pull_strategy_args(Some("merge")), &["--no-rebase"]);
+    assert_eq!(pull_strategy_args(None), &["--no-rebase"]);
+    assert_eq!(pull_strategy_args(Some("unknown")), &["--no-rebase"]);
+    assert_eq!(pull_strategy_args(Some("ff-only")), &["--ff-only"]);
 }
 
 // ============================================

--- a/src/services/git/operations/__tests__/remoteOps.test.ts
+++ b/src/services/git/operations/__tests__/remoteOps.test.ts
@@ -207,7 +207,7 @@ describe("terminal fallback — the command string built for each operation", ()
   it("pulls with --rebase and --ff-only for the other strategies", async () => {
     const rebase = await loadRemoteOps();
     await rebase.pull({ strategy: "rebase" });
-    expect(execute.mock.calls).toEqual([["git pull --rebase"]]);
+    expect(execute.mock.calls).toEqual([["git pull --rebase --autostash"]]);
 
     execute.mockClear();
     const ffOnly = await loadRemoteOps();
@@ -220,7 +220,7 @@ describe("terminal fallback — the command string built for each operation", ()
 
     await remoteOps.pull();
 
-    expect(execute.mock.calls).toEqual([["git pull --rebase"]]);
+    expect(execute.mock.calls).toEqual([["git pull --rebase --autostash"]]);
   });
 
   it("falls back to merge when the strategy setting is absent altogether", async () => {
@@ -236,7 +236,7 @@ describe("terminal fallback — the command string built for each operation", ()
 
     await remoteOps.pull();
 
-    expect(execute.mock.calls).toEqual([["git pull --rebase"]]);
+    expect(execute.mock.calls).toEqual([["git pull --rebase --autostash"]]);
   });
 
   it("lets an explicit strategy override the configured one", async () => {
@@ -1301,7 +1301,7 @@ describe("sync", () => {
 
     expect(execute.mock.calls).toEqual([
       ["git fetch"],
-      ["git pull --rebase"],
+      ["git pull --rebase --autostash"],
       ["git push"],
     ]);
   });
@@ -1330,7 +1330,10 @@ describe("sync", () => {
       errorType: "merge_conflicts",
     });
 
-    expect(execute.mock.calls).toEqual([["git fetch"], ["git pull --rebase"]]);
+    expect(execute.mock.calls).toEqual([
+      ["git fetch"],
+      ["git pull --rebase --autostash"],
+    ]);
   });
 
   it("never pushes with force", async () => {

--- a/src/services/git/operations/remoteOps.ts
+++ b/src/services/git/operations/remoteOps.ts
@@ -110,11 +110,13 @@ function getUserPullStrategy(): GitPullStrategy {
 /**
  * Build the terminal pull command with strategy flags.
  * Always pass explicit flag so Git knows how to reconcile when branches diverge.
+ * Rebase carries --autostash: a bare `git pull --rebase` refuses to start on
+ * any dirty working tree, even when nothing overlaps the incoming commits.
  */
 function buildPullCommand(strategy: GitPullStrategy): string {
   switch (strategy) {
     case "rebase":
-      return "git pull --rebase";
+      return "git pull --rebase --autostash";
     case "ff-only":
       return "git pull --ff-only";
     default:


### PR DESCRIPTION
## Problem

Pulling from the app fails with the "Git: Uncommitted Changes" dialog whenever the working tree has *any* local modification — even files completely unrelated to the incoming commits. Everyone on the shipped defaults is affected: `git.pullStrategy` defaults to `"rebase"`, and a bare `git pull --rebase` refuses to start on any dirty tree:

```
error: cannot pull with rebase: You have unstaged changes.
error: Please commit or stash them.
```

That refusal is a rebase preflight, not an overlap check. A merge pull (`--no-rebase`) in the identical state succeeds, because git only blocks a merge when the dirty files actually overlap the incoming changes. Root cause: none of our pull invocations pass `--autostash`, so rebase pulls are strictly more fragile than merge pulls for no benefit.

## Solution

Always pair `--rebase` with `--autostash`, in all three producing paths:

- `pull_from_remote` in `crates/git-api/src/commands/remote.rs` (non-streaming HTTP command)
- `pull_stream` in `crates/git-api/src/commands/streaming.rs` (SSE path the UI uses)
- `buildPullCommand` in `src/services/git/operations/remoteOps.ts` (terminal fallback)

The flag selection is extracted into one shared helper, `pull_strategy_args`, used by both Rust paths and covered by regression tests. Resulting invariant, verified against real git in sandbox repos:

- Rebase pull + non-overlapping dirty tree → succeeds; local changes are stashed, the pull runs, the stash is reapplied (`Applied autostash.`), working tree ends identical.
- Rebase pull + genuinely overlapping dirty change → the pull itself still completes; git reapplies the stash as ordinary conflict markers and additionally keeps a stash copy (`Applying autostash resulted in conflicts. Your changes are safe in the stash.`). No data loss in either case.
- Merge and ff-only pulls are untouched: they already tolerate non-overlapping dirt natively, and the existing "Stash and Continue" dialog still handles their genuine-overlap refusal.

## Potential risks

- **Behavior change on overlap under rebase.** Before: the pull refused up front and the dialog offered Stash and Continue. After: the pull completes and the overlap surfaces as conflict markers in the working tree (plus a safety copy in the stash). This is standard `rebase.autostash=true` behavior and equivalent to what "Stash and Continue" already did, minus the restore prompt — but it is a different UX for that edge.
- Autostash reapplies staged changes as unstaged (standard git stash behavior), so a rebase pull with a staged-but-uncommitted file loses the *staged* status, not the content.
- `git pull --rebase --autostash` requires git ≥ 2.9 (2016); no realistic compatibility concern.
- The SSE `command_str` display changes from `git pull --rebase <remote>` to `git pull --rebase --autostash <remote>`; nothing parses that string, it is display-only.

## Verification

- Empirical repro in throwaway repos (macOS, system git): confirmed all four cases above — bare `--rebase` fails on a non-overlapping dirty file with exactly the dialog's error text; `--no-rebase` succeeds; `--rebase --autostash` succeeds and preserves the local change; overlapping case exits 0 with the change safe in stash + conflict markers.
- `cargo test -p git_api --lib` → 92 passed, 0 failed (includes new `pull_strategy_rebase_always_autostashes` and `pull_strategy_merge_and_ff_only_do_not_autostash` regression tests).
- `cargo fmt -p git_api --check` → clean; `cargo clippy -p git_api --all-targets` → no warnings.
- `npx vitest run src/services/git/operations/__tests__/remoteOps.test.ts` → 70 passed, 0 failed (command-string expectations updated to `git pull --rebase --autostash`).
- `npx tsc --noEmit --pretty false` → exit 0; `npx eslint` on both touched TS files → clean.
- Not run: E2E pull against a live remote from the packaged app.
- Note: this commit was built with a temporary index from a live shared checkout, so pre-commit hooks did not run and the `Pre-commit hook ran.` trailer is intentionally absent; typecheck/lint/tests above were run manually instead.
