### PR TITLE
feat(resize): improve handle hover affordances

### DIFF
--- a/src/engines/ChatPanel/ChatPanelShell.test.ts
+++ b/src/engines/ChatPanel/ChatPanelShell.test.ts
@@ -28,6 +28,8 @@ function render(focusedWorkstationRail?: ReactNode): string {
       isTerminalTabActive: false,
       onResizeMouseDown: () => undefined,
       panelRef: createRef<HTMLDivElement>(),
+      resizeTooltipLabel: "Hide Workstation",
+      resizeTooltipShortcut: "Alt+Cmd+B",
       sessionModals: null,
       showResizeHandle: false,
       terminalTabs: [],

--- a/src/engines/ChatPanel/ChatPanelShell.tsx
+++ b/src/engines/ChatPanel/ChatPanelShell.tsx
@@ -58,6 +58,7 @@ export function ChatPanelShell({
     <VerticalResizeHandle
       key="chat-panel-resize-handle"
       className={`!z-[80] ${isLeftPosition ? "-ml-px" : "-mr-px"}`}
+      indicatorPlacement={isLeftPosition ? "start" : "end"}
       isResizing={isDragging}
       onMouseDown={onResizeMouseDown}
       tooltipLabel={resizeTooltipLabel}

--- a/src/engines/ChatPanel/ChatPanelShell.tsx
+++ b/src/engines/ChatPanel/ChatPanelShell.tsx
@@ -24,6 +24,7 @@ interface ChatPanelShellProps {
   isTerminalTabActive: boolean;
   onResizeMouseDown: React.MouseEventHandler;
   panelRef: React.RefObject<HTMLDivElement | null>;
+  resizeIndicatorHost?: HTMLElement | null;
   resizeTooltipLabel: React.ReactNode;
   resizeTooltipShortcut: string;
   sessionModals: React.ReactNode;
@@ -47,6 +48,7 @@ export function ChatPanelShell({
   isTerminalTabActive,
   onResizeMouseDown,
   panelRef,
+  resizeIndicatorHost,
   resizeTooltipLabel,
   resizeTooltipShortcut,
   sessionModals,
@@ -58,7 +60,10 @@ export function ChatPanelShell({
     <VerticalResizeHandle
       key="chat-panel-resize-handle"
       className={`!z-[80] ${isLeftPosition ? "-ml-px" : "-mr-px"}`}
-      indicatorPlacement={isLeftPosition ? "start" : "end"}
+      indicatorHost={resizeIndicatorHost}
+      indicatorPlacement={
+        resizeIndicatorHost ? "center" : isLeftPosition ? "start" : "end"
+      }
       isResizing={isDragging}
       onMouseDown={onResizeMouseDown}
       tooltipLabel={resizeTooltipLabel}

--- a/src/engines/ChatPanel/ChatPanelShell.tsx
+++ b/src/engines/ChatPanel/ChatPanelShell.tsx
@@ -24,6 +24,8 @@ interface ChatPanelShellProps {
   isTerminalTabActive: boolean;
   onResizeMouseDown: React.MouseEventHandler;
   panelRef: React.RefObject<HTMLDivElement | null>;
+  resizeTooltipLabel: React.ReactNode;
+  resizeTooltipShortcut: string;
   sessionModals: React.ReactNode;
   showResizeHandle: boolean;
   terminalTabs: ChatPanelTab[];
@@ -45,6 +47,8 @@ export function ChatPanelShell({
   isTerminalTabActive,
   onResizeMouseDown,
   panelRef,
+  resizeTooltipLabel,
+  resizeTooltipShortcut,
   sessionModals,
   showResizeHandle,
   terminalTabs,
@@ -54,7 +58,10 @@ export function ChatPanelShell({
     <VerticalResizeHandle
       key="chat-panel-resize-handle"
       className={`!z-[80] ${isLeftPosition ? "-ml-px" : "-mr-px"}`}
+      isResizing={isDragging}
       onMouseDown={onResizeMouseDown}
+      tooltipLabel={resizeTooltipLabel}
+      tooltipShortcut={resizeTooltipShortcut}
       variant={embedded ? "border" : "transparent"}
       noAccent={!embedded}
     />

--- a/src/engines/ChatPanel/index.tsx
+++ b/src/engines/ChatPanel/index.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
 import { projectApi } from "@src/api/http/project";
+import { getShortcutKeys } from "@src/config/keyboard/shortcutDisplay";
 import {
   WIZARD_IDS,
   buildIntegrationsPath,
@@ -730,6 +731,8 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
           isTerminalTabActive={isTerminalTabActive}
           onResizeMouseDown={handleMouseDown}
           panelRef={panelRef}
+          resizeTooltipLabel={t("chat.hideWorkstation")}
+          resizeTooltipShortcut={getShortcutKeys("maximize_chat")}
           sessionModals={sessionModals}
           showResizeHandle={showResizeHandle}
           terminalTabs={terminalTabs}

--- a/src/engines/ChatPanel/index.tsx
+++ b/src/engines/ChatPanel/index.tsx
@@ -115,6 +115,7 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
     embedded = false,
     active = true,
     position = "right",
+    resizeIndicatorHost,
     sessionCreatorSlot: SessionCreatorSlot,
   }) => {
     const { t } = useTranslation([
@@ -731,6 +732,7 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
           isTerminalTabActive={isTerminalTabActive}
           onResizeMouseDown={handleMouseDown}
           panelRef={panelRef}
+          resizeIndicatorHost={resizeIndicatorHost}
           resizeTooltipLabel={t("chat.hideWorkstation")}
           resizeTooltipShortcut={getShortcutKeys("maximize_chat")}
           sessionModals={sessionModals}

--- a/src/engines/ChatPanel/types.ts
+++ b/src/engines/ChatPanel/types.ts
@@ -55,6 +55,8 @@ export interface ChatPanelProps {
    * @default "right"
    */
   position?: "left" | "right";
+  /** Unclipped boundary host for the centered resize indicator */
+  resizeIndicatorHost?: HTMLElement | null;
   /**
    * Slot for session creator UI rendered when no session is active.
    * Injected by the parent to avoid ChatPanel depending on SessionCreator.

--- a/src/modules/MainApp/Settings/SettingsSlot.tsx
+++ b/src/modules/MainApp/Settings/SettingsSlot.tsx
@@ -86,6 +86,8 @@ interface SettingsSlotProps {
   position: ChatPanelPosition;
   /** True when hosted as a flex sibling (full/compact); false when inset. */
   embedded: boolean;
+  /** Unclipped boundary host for the centered resize indicator. */
+  resizeIndicatorHost?: HTMLElement | null;
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -252,6 +254,7 @@ const SettingsSlot: React.FC<SettingsSlotProps> = ({
   maximized,
   position,
   embedded,
+  resizeIndicatorHost,
 }) => {
   const { t } = useTranslation("settings");
   const { t: tCommon } = useTranslation("common");
@@ -321,6 +324,14 @@ const SettingsSlot: React.FC<SettingsSlotProps> = ({
     >
       {!maximized && (
         <VerticalResizeHandle
+          indicatorHost={resizeIndicatorHost}
+          indicatorPlacement={
+            resizeIndicatorHost
+              ? "center"
+              : position === "left"
+                ? "start"
+                : "end"
+          }
           onMouseDown={handleMouseDown}
           variant={embedded ? "border" : "transparent"}
           noAccent={!embedded}

--- a/src/modules/WorkStation/shared/WorkStationShell/index.tsx
+++ b/src/modules/WorkStation/shared/WorkStationShell/index.tsx
@@ -16,8 +16,10 @@
  *   React subtree is mounted once; only the grid placement changes on
  *   toggle, so terminal/devtools state survives position flips.
  */
+import i18next from "i18next";
 import React, { memo } from "react";
 
+import { getShortcutKeys } from "@src/config/keyboard/shortcutDisplay";
 import { useResizeContextMenu } from "@src/hooks/ui/useResizeContextMenu";
 import { useResizeHandle } from "@src/hooks/ui/useResizeHandle";
 import {
@@ -155,7 +157,10 @@ export const WorkStationShell: React.FC<WorkStationShellProps> = memo(
     // ------------------------------------------------------------------
     // Primary sidebar resize
     // ------------------------------------------------------------------
-    const { handleMouseDown: handlePrimarySidebarResize } = useResizeHandle(
+    const {
+      handleMouseDown: handlePrimarySidebarResize,
+      isResizing: isPrimarySidebarResizing,
+    } = useResizeHandle(
       resolvedPrimarySidebar.size,
       resolvedPrimarySidebar.onSizeChange ?? noop,
       {
@@ -251,9 +256,12 @@ export const WorkStationShell: React.FC<WorkStationShellProps> = memo(
     const primarySidebarResizeHandle = !resolvedPrimarySidebar.collapsed &&
       resolvedPrimarySidebar.onSizeChange && (
         <VerticalResizeHandle
+          isResizing={isPrimarySidebarResizing}
           variant="border"
           onMouseDown={handlePrimarySidebarResize}
           onContextMenu={handlePrimarySidebarContextMenu}
+          tooltipLabel={i18next.t("common:commands.hidePrimarySidebar")}
+          tooltipShortcut={getShortcutKeys("toggle_workstation_sidebar")}
         />
       );
 

--- a/src/modules/WorkStation/shared/WorkStationShell/index.tsx
+++ b/src/modules/WorkStation/shared/WorkStationShell/index.tsx
@@ -256,6 +256,7 @@ export const WorkStationShell: React.FC<WorkStationShellProps> = memo(
     const primarySidebarResizeHandle = !resolvedPrimarySidebar.collapsed &&
       resolvedPrimarySidebar.onSizeChange && (
         <VerticalResizeHandle
+          indicatorPlacement={isLeftMode ? "start" : "end"}
           isResizing={isPrimarySidebarResizing}
           variant="border"
           onMouseDown={handlePrimarySidebarResize}

--- a/src/modules/shared/layouts/AppLayout.tsx
+++ b/src/modules/shared/layouts/AppLayout.tsx
@@ -178,6 +178,8 @@ const AppLayoutComponent: React.FC<AppLayoutProps> = ({
   const isChatPanelDragging = useAtomValue(chatPanelDraggingAtom);
   const backgroundConfig = useAtomValue(resolvedBackgroundConfigAtom);
   const chatSlotRef = useRef<HTMLDivElement>(null);
+  const [resizeIndicatorHostElement, setResizeIndicatorHostElement] =
+    React.useState<HTMLDivElement | null>(null);
   // Settings-in-slot must always have a usable width even if the user
   // previously dragged the chat to zero. Fall back to the configured
   // default so opening Settings never produces a collapsed slot.
@@ -255,6 +257,7 @@ const AppLayoutComponent: React.FC<AppLayoutProps> = ({
         <SettingsSlot
           maximized={chatPanelMaximized}
           position={chatPosition}
+          resizeIndicatorHost={resizeIndicatorHostElement}
           embedded
         />
       </React.Suspense>
@@ -265,6 +268,7 @@ const AppLayoutComponent: React.FC<AppLayoutProps> = ({
         active={showChatPanel}
         useExternalWidth={chatPanelMaximized}
         position={chatPosition}
+        resizeIndicatorHost={resizeIndicatorHostElement}
         sessionCreatorSlot={AdeAwareSessionCreatorSlot}
       />
     );
@@ -290,6 +294,17 @@ const AppLayoutComponent: React.FC<AppLayoutProps> = ({
     </div>
   ) : null;
 
+  const resizeIndicatorHost =
+    shouldMountSlot && !chatPanelMaximized ? (
+      <div
+        key="chat-workstation-resize-indicator-host"
+        ref={setResizeIndicatorHostElement}
+        className="pointer-events-none relative z-[80] w-0 flex-none self-stretch overflow-visible"
+        data-chat-workstation-resize-indicator-host
+        aria-hidden
+      />
+    ) : null;
+
   // Shared content wrapped in providers
   const contentArea = (
     <DataProvider>
@@ -307,6 +322,7 @@ const AppLayoutComponent: React.FC<AppLayoutProps> = ({
               data-pane-surface-underlay
             >
               {isChatOnLeft && chatSlot}
+              {isChatOnLeft && resizeIndicatorHost}
               <div
                 key="workbench-surface"
                 // Animate the real flex track to zero so inline native
@@ -322,6 +338,7 @@ const AppLayoutComponent: React.FC<AppLayoutProps> = ({
                   {children}
                 </WorkbenchActionSystemScope>
               </div>
+              {!isChatOnLeft && resizeIndicatorHost}
               {!isChatOnLeft && chatSlot}
               {/* Global floating side chat: hosted over the whole pane
                   surface (chat slot + workbench), so it stays usable when

--- a/src/scaffold/NavigationSidebar/SidebarBase.tsx
+++ b/src/scaffold/NavigationSidebar/SidebarBase.tsx
@@ -456,6 +456,8 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
           noAccent={IS_WINDOWS_HOST}
           onMouseDown={handleMouseDown}
           onContextMenu={handleResizeContextMenu}
+          tooltipLabel={i18next.t("common:tooltips.hideSidebar")}
+          tooltipShortcut={hideSidebarShortcut}
           variant={IS_WINDOWS_HOST ? "transparent" : "border"}
         />
       </div>

--- a/src/scaffold/NavigationSidebar/SidebarBase.tsx
+++ b/src/scaffold/NavigationSidebar/SidebarBase.tsx
@@ -454,6 +454,7 @@ const SidebarBase: React.FC<SidebarBaseProps> = React.memo(
           className={IDLE_SIDEBAR_RESIZE_HANDLE_CLASS_NAME}
           isResizing={isDragging}
           noAccent={IS_WINDOWS_HOST}
+          indicatorPlacement="start"
           onMouseDown={handleMouseDown}
           onContextMenu={handleResizeContextMenu}
           tooltipLabel={i18next.t("common:tooltips.hideSidebar")}

--- a/src/scaffold/Resize/components/ResizeHandle.test.ts
+++ b/src/scaffold/Resize/components/ResizeHandle.test.ts
@@ -43,12 +43,14 @@ describe("ResizeHandle indicator", () => {
     reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = false;
   });
 
-  it("keeps the bright segment attached to the actual divider line", () => {
+  it("centers the bright segment in an unclipped layout-boundary host", () => {
+    const indicatorHost = document.createElement("div");
+    document.body.appendChild(indicatorHost);
     act(() => {
       root.render(
         React.createElement(ResizeHandle, {
           axis: "x",
-          indicatorPlacement: "start",
+          indicatorHost,
           onMouseDown: () => undefined,
         })
       );
@@ -57,15 +59,40 @@ describe("ResizeHandle indicator", () => {
     const handle = container.querySelector<HTMLElement>('[role="separator"]');
     expect(handle).not.toBeNull();
 
-    const indicator = handle!.querySelector<HTMLElement>(
+    const indicator = indicatorHost.querySelector<HTMLElement>(
       "[data-resize-handle-indicator]"
     );
     expect(indicator).not.toBeNull();
-    expect(handle!.contains(indicator)).toBe(true);
+    expect(handle!.contains(indicator)).toBe(false);
     expect(indicator?.className).toContain("absolute");
     expect(indicator?.className).toContain("w-[4px]");
-    expect(indicator?.className).toContain("right-0");
+    expect(indicator?.className).toContain("left-1/2");
+    expect(indicator?.className).toContain("-translate-x-1/2");
     expect(indicator?.className).not.toContain("fixed");
+    indicatorHost.remove();
+  });
+
+  it("hides the bright segment immediately while dragging", () => {
+    const indicatorHost = document.createElement("div");
+    document.body.appendChild(indicatorHost);
+    act(() => {
+      root.render(
+        React.createElement(ResizeHandle, {
+          axis: "x",
+          indicatorHost,
+          isResizing: true,
+          onMouseDown: () => undefined,
+        })
+      );
+    });
+
+    const indicator = indicatorHost.querySelector<HTMLElement>(
+      "[data-resize-handle-indicator]"
+    );
+    expect(indicator).not.toBeNull();
+    expect(indicator?.style.opacity).toBe("0");
+    expect(indicator?.style.transitionDuration).toBe("0ms");
+    indicatorHost.remove();
   });
 
   it("shows the contextual shortcut only after one second of hover", () => {

--- a/src/scaffold/Resize/components/ResizeHandle.test.ts
+++ b/src/scaffold/Resize/components/ResizeHandle.test.ts
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { ResizeHandle } from "./ResizeHandle";
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+describe("ResizeHandle indicator", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeAll(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    container.style.overflow = "hidden";
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  afterAll(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  it("keeps the bright segment attached to the actual divider line", () => {
+    act(() => {
+      root.render(
+        React.createElement(ResizeHandle, {
+          axis: "x",
+          onMouseDown: () => undefined,
+        })
+      );
+    });
+
+    const handle = container.querySelector<HTMLElement>('[role="separator"]');
+    expect(handle).not.toBeNull();
+
+    const indicator = handle!.querySelector<HTMLElement>(
+      "[data-resize-handle-indicator]"
+    );
+    expect(indicator).not.toBeNull();
+    expect(handle!.contains(indicator)).toBe(true);
+    expect(indicator?.className).toContain("absolute");
+    expect(indicator?.className).toContain("w-px");
+    expect(indicator?.className).not.toContain("fixed");
+  });
+
+  it("shows the contextual shortcut only after one second of hover", () => {
+    vi.useFakeTimers();
+    act(() => {
+      root.render(
+        React.createElement(ResizeHandle, {
+          axis: "x",
+          onMouseDown: () => undefined,
+          tooltipLabel: "Hide Sidebar",
+          tooltipShortcut: "Cmd+B",
+        })
+      );
+    });
+
+    const handle = container.querySelector<HTMLElement>('[role="separator"]');
+    expect(handle).not.toBeNull();
+
+    act(() => {
+      handle!.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+      vi.advanceTimersByTime(999);
+    });
+    expect(document.body.textContent).not.toContain("Hide Sidebar");
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(
+      document.body.querySelector(".native-tooltip-content-inner")?.textContent
+    ).toContain("Hide Sidebar");
+  });
+});

--- a/src/scaffold/Resize/components/ResizeHandle.test.ts
+++ b/src/scaffold/Resize/components/ResizeHandle.test.ts
@@ -48,6 +48,7 @@ describe("ResizeHandle indicator", () => {
       root.render(
         React.createElement(ResizeHandle, {
           axis: "x",
+          indicatorPlacement: "start",
           onMouseDown: () => undefined,
         })
       );
@@ -62,7 +63,8 @@ describe("ResizeHandle indicator", () => {
     expect(indicator).not.toBeNull();
     expect(handle!.contains(indicator)).toBe(true);
     expect(indicator?.className).toContain("absolute");
-    expect(indicator?.className).toContain("w-px");
+    expect(indicator?.className).toContain("w-[4px]");
+    expect(indicator?.className).toContain("right-0");
     expect(indicator?.className).not.toContain("fixed");
   });
 

--- a/src/scaffold/Resize/components/ResizeHandle.tsx
+++ b/src/scaffold/Resize/components/ResizeHandle.tsx
@@ -11,7 +11,8 @@
  * - Double-click prevention
  * - Accessible with proper cursor feedback
  */
-import React, { memo, useCallback, useRef } from "react";
+import React, { memo, useCallback, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 
 import { KeyboardShortcutTooltipContent } from "@src/components/KeyboardShortcut";
 import Tooltip from "@src/components/Tooltip";
@@ -36,10 +37,12 @@ export const ResizeHandle: React.FC<ResizeHandleProps> = memo(
     tooltipLabel,
     tooltipShortcut,
     indicatorPlacement = "center",
+    indicatorHost,
     className = "",
   }) => {
     const isVertical = axis === "x";
     const lastClickTimeRef = useRef<number>(0);
+    const [isHovered, setIsHovered] = useState(false);
 
     const handleMouseDown = useCallback(
       (event: React.MouseEvent) => {
@@ -64,6 +67,9 @@ export const ResizeHandle: React.FC<ResizeHandleProps> = memo(
       event.preventDefault();
       event.stopPropagation();
     }, []);
+
+    const handleMouseEnter = useCallback(() => setIsHovered(true), []);
+    const handleMouseLeave = useCallback(() => setIsHovered(false), []);
 
     const restingBg = variant === "border" ? "bg-border-2" : "bg-transparent";
 
@@ -94,10 +100,12 @@ export const ResizeHandle: React.FC<ResizeHandleProps> = memo(
       ? "absolute inset-y-0 -left-[6px] w-[13px] cursor-col-resize"
       : "absolute inset-x-0 -top-[6px] h-[13px] cursor-row-resize";
 
-    // Keep the bright affordance inside the actual 1px divider. It therefore
-    // inherits every layout update from the line itself and cannot lag behind
-    // during rapid RAF-driven resizing.
+    // The default indicator stays inside the divider. Boundaries hosted by an
+    // overflow-clipped pane can instead provide a zero-width sibling host;
+    // that host moves in the same flex layout as the divider, keeping the
+    // centered indicator synchronized without coordinate tracking.
     const showIndicator = !noHover && !noAccent;
+    const usesIndicatorHost = indicatorHost != null;
     const verticalIndicatorPosition =
       indicatorPlacement === "start"
         ? "right-0"
@@ -120,13 +128,28 @@ export const ResizeHandle: React.FC<ResizeHandleProps> = memo(
       "bg-primary-6",
       "transition-opacity",
       "duration-150",
-      isResizing ? "opacity-100" : "opacity-0 group-hover/resize:opacity-100",
+      usesIndicatorHost && isHovered
+        ? "opacity-100"
+        : usesIndicatorHost
+          ? "opacity-0"
+          : "opacity-0 group-hover/resize:opacity-100",
     ].join(" ");
+    const indicatorElement = (
+      <div
+        data-resize-handle-indicator
+        className={indicatorClasses}
+        style={
+          isResizing ? { opacity: 0, transitionDuration: "0ms" } : undefined
+        }
+      />
+    );
 
     const handleElement = (
       <div
         className={`${wrapperClasses} group/resize`}
         onMouseDown={handleMouseDown}
+        onMouseEnter={usesIndicatorHost ? handleMouseEnter : undefined}
+        onMouseLeave={usesIndicatorHost ? handleMouseLeave : undefined}
         onDoubleClick={handleDoubleClick}
         onContextMenu={onContextMenu}
         onClick={preventClick}
@@ -143,9 +166,11 @@ export const ResizeHandle: React.FC<ResizeHandleProps> = memo(
           onContextMenu={onContextMenu}
           onClick={preventClick}
         />
-        {showIndicator && (
-          <div data-resize-handle-indicator className={indicatorClasses} />
-        )}
+        {showIndicator && !usesIndicatorHost && indicatorElement}
+        {showIndicator &&
+          usesIndicatorHost &&
+          indicatorHost &&
+          createPortal(indicatorElement, indicatorHost)}
       </div>
     );
 

--- a/src/scaffold/Resize/components/ResizeHandle.tsx
+++ b/src/scaffold/Resize/components/ResizeHandle.tsx
@@ -35,6 +35,7 @@ export const ResizeHandle: React.FC<ResizeHandleProps> = memo(
     noAccent = false,
     tooltipLabel,
     tooltipShortcut,
+    indicatorPlacement = "center",
     className = "",
   }) => {
     const isVertical = axis === "x";
@@ -97,12 +98,24 @@ export const ResizeHandle: React.FC<ResizeHandleProps> = memo(
     // inherits every layout update from the line itself and cannot lag behind
     // during rapid RAF-driven resizing.
     const showIndicator = !noHover && !noAccent;
+    const verticalIndicatorPosition =
+      indicatorPlacement === "start"
+        ? "right-0"
+        : indicatorPlacement === "end"
+          ? "left-0"
+          : "left-1/2 -translate-x-1/2";
+    const horizontalIndicatorPosition =
+      indicatorPlacement === "start"
+        ? "bottom-0"
+        : indicatorPlacement === "end"
+          ? "top-0"
+          : "top-1/2 -translate-y-1/2";
     const indicatorClasses = [
       "pointer-events-none",
       "absolute",
       isVertical
-        ? "left-0 top-1/2 h-14 w-px -translate-y-1/2"
-        : "left-1/2 top-0 h-px w-14 -translate-x-1/2",
+        ? `top-1/2 h-14 w-[4px] -translate-y-1/2 ${verticalIndicatorPosition}`
+        : `left-1/2 h-[4px] w-14 -translate-x-1/2 ${horizontalIndicatorPosition}`,
       "rounded-full",
       "bg-primary-6",
       "transition-opacity",

--- a/src/scaffold/Resize/components/ResizeHandle.tsx
+++ b/src/scaffold/Resize/components/ResizeHandle.tsx
@@ -5,7 +5,7 @@
  *
  * Features:
  * - 1px visible line with larger hit area (12px) for easier dragging
- * - Hover: primary-6 at 50% opacity
+ * - Hover: primary-6 at 50% opacity + centered bright segment indicating draggability
  * - Active (resizing): solid primary-6
  * - Two visual variants: "border" (visible 1px line, default) and "transparent" (invisible at rest)
  * - Double-click prevention
@@ -13,7 +13,12 @@
  */
 import React, { memo, useCallback, useRef } from "react";
 
+import { KeyboardShortcutTooltipContent } from "@src/components/KeyboardShortcut";
+import Tooltip from "@src/components/Tooltip";
+
 import type { ResizeHandleProps } from "../types";
+
+const SHORTCUT_TOOLTIP_DELAY_MS = 1000;
 
 // ============================================
 // Component
@@ -28,6 +33,8 @@ export const ResizeHandle: React.FC<ResizeHandleProps> = memo(
     variant = "border",
     noHover = false,
     noAccent = false,
+    tooltipLabel,
+    tooltipShortcut,
     className = "",
   }) => {
     const isVertical = axis === "x";
@@ -86,7 +93,24 @@ export const ResizeHandle: React.FC<ResizeHandleProps> = memo(
       ? "absolute inset-y-0 -left-[6px] w-[13px] cursor-col-resize"
       : "absolute inset-x-0 -top-[6px] h-[13px] cursor-row-resize";
 
-    return (
+    // Keep the bright affordance inside the actual 1px divider. It therefore
+    // inherits every layout update from the line itself and cannot lag behind
+    // during rapid RAF-driven resizing.
+    const showIndicator = !noHover && !noAccent;
+    const indicatorClasses = [
+      "pointer-events-none",
+      "absolute",
+      isVertical
+        ? "left-0 top-1/2 h-14 w-px -translate-y-1/2"
+        : "left-1/2 top-0 h-px w-14 -translate-x-1/2",
+      "rounded-full",
+      "bg-primary-6",
+      "transition-opacity",
+      "duration-150",
+      isResizing ? "opacity-100" : "opacity-0 group-hover/resize:opacity-100",
+    ].join(" ");
+
+    const handleElement = (
       <div
         className={`${wrapperClasses} group/resize`}
         onMouseDown={handleMouseDown}
@@ -106,7 +130,30 @@ export const ResizeHandle: React.FC<ResizeHandleProps> = memo(
           onContextMenu={onContextMenu}
           onClick={preventClick}
         />
+        {showIndicator && (
+          <div data-resize-handle-indicator className={indicatorClasses} />
+        )}
       </div>
+    );
+
+    if (!tooltipLabel) return handleElement;
+
+    return (
+      <Tooltip
+        content={
+          <KeyboardShortcutTooltipContent
+            label={tooltipLabel}
+            shortcut={tooltipShortcut}
+          />
+        }
+        position={isVertical ? "right" : "bottom"}
+        mouseEnterDelay={SHORTCUT_TOOLTIP_DELAY_MS}
+        framedPanel
+        smartPlacement
+        disabled={isResizing}
+      >
+        {handleElement}
+      </Tooltip>
     );
   }
 );

--- a/src/scaffold/Resize/index.ts
+++ b/src/scaffold/Resize/index.ts
@@ -134,6 +134,7 @@ export type {
   ResizeAxis,
   ResizeControllerOptions,
   ResizeDirection,
+  ResizeHandleIndicatorPlacement,
   ResizeHandleProps,
   ResizeHandleVariant,
   ResizeManagerContextType,

--- a/src/scaffold/Resize/types.ts
+++ b/src/scaffold/Resize/types.ts
@@ -108,6 +108,10 @@ export interface ResizeHandleProps {
   noAccent?: boolean;
   /** Right-click context menu handler */
   onContextMenu?: (event: MouseEvent) => void;
+  /** Contextual action shown after hovering the handle for one second */
+  tooltipLabel?: ReactNode;
+  /** Keyboard shortcut displayed beside the contextual tooltip label */
+  tooltipShortcut?: string;
   /** Additional class name */
   className?: string;
 }

--- a/src/scaffold/Resize/types.ts
+++ b/src/scaffold/Resize/types.ts
@@ -115,6 +115,8 @@ export interface ResizeHandleProps {
   tooltipShortcut?: string;
   /** Side of the divider into which the thicker center indicator extends */
   indicatorPlacement?: ResizeHandleIndicatorPlacement;
+  /** Optional unclipped layout-boundary host for the visual indicator */
+  indicatorHost?: HTMLElement | null;
   /** Additional class name */
   className?: string;
 }

--- a/src/scaffold/Resize/types.ts
+++ b/src/scaffold/Resize/types.ts
@@ -92,6 +92,7 @@ export interface ResizableShellProps {
 
 /** Visual variant for resize handle default (resting) state */
 export type ResizeHandleVariant = "transparent" | "border";
+export type ResizeHandleIndicatorPlacement = "start" | "center" | "end";
 
 export interface ResizeHandleProps {
   /** Resize axis */
@@ -112,6 +113,8 @@ export interface ResizeHandleProps {
   tooltipLabel?: ReactNode;
   /** Keyboard shortcut displayed beside the contextual tooltip label */
   tooltipShortcut?: string;
+  /** Side of the divider into which the thicker center indicator extends */
+  indicatorPlacement?: ResizeHandleIndicatorPlacement;
   /** Additional class name */
   className?: string;
 }


### PR DESCRIPTION
## Problem

The resize affordance at the chat/Workstation boundary could not satisfy all of its visual constraints when it lived inside the clipped chat slot. Centering the 4px pill showed only half of it, moving the pill inward made it visibly one-sided, and coordinate-based overlays could lag behind the real divider during rapid dragging. The app sidebar, Workstation surface, and Workstation sidebar dividers also gave users no discoverable indication of their existing close/hide shortcuts.

## Solution

Keep the real divider as a 1px layout track with its 13px drag hit area, and render the 56px-long, 4px-thick hover pill into a zero-width flex sibling at the unclipped chat/Workstation boundary. The pill is centered on that host, so 2px appears on each side; because the host participates in the same flex layout, it follows the boundary without mouse-coordinate tracking. The pill is hover-only and hides immediately when resizing begins, while the divider remains visible and draggable. Extend the shared resize handle with an optional framed shortcut tooltip shown after 1,000ms, then connect it to the existing registered shortcuts for the app sidebar, Workstation surface, and Workstation sidebar. The tooltip is disabled while resizing.

## Potential risks

The boundary indicator now uses a React portal into an adjacent layout-owned DOM host. The main residual risk is incorrect host ordering when the chat pane switches between left and right, or visual differences at unusual scaling factors; the host is inserted directly between the chat slot and Workstation in both orders and the indicator test asserts centered, non-fixed positioning. The change does not alter persisted layout state, resize bounds, IPC, wire formats, dependencies, or data. Live desktop validation was not run because computer control was not authorized. Rollback is a normal revert of the three commits in this PR.

## Verification

- `pnpm exec vitest run src/scaffold/Resize/components/ResizeHandle.test.ts src/engines/ChatPanel/ChatPanelShell.test.ts` — passed, 5 tests
- Targeted ESLint across the 9 touched implementation/test files — passed with no findings
- Commit hook scoped TypeScript check — passed for all 8 files in the final follow-up commit
- Local full incremental `tsc --noEmit` — the resize files produced no errors; the dirty shared worktree command remained non-zero because unrelated unstaged `EditorStatusBarLeft.tsx` referenced a missing `CodeIcon`
- GitHub frontend CI on a clean checkout — passed typecheck, lint, test placement, and the complete unit-test suite
- `git diff --check` — passed
- Latest `origin/develop` fetched; branch is 0 commits behind and 3 commits ahead
- Live desktop visual validation was not run because computer control was not authorized
