### PR TITLE
fix(git-api): correct pull/push failure classification and streams

### DIFF
--- a/src-tauri/crates/git-api/src/commands/remote.rs
+++ b/src-tauri/crates/git-api/src/commands/remote.rs
@@ -335,9 +335,43 @@ fn run_remote_git(
         .map_err(|err| format!("Failed to run git {:?}: {err}", args))
 }
 
+/// True when `needle` occurs in `haystack` as a whole word — not embedded in
+/// a longer identifier. Git output quotes URLs, branch names, and paths, so a
+/// bare substring match on short tokens like "sso" fires on "processor" or
+/// "associate" and misroutes ordinary failures into the auth dialog.
+pub(crate) fn contains_word(haystack: &str, needle: &str) -> bool {
+    let bytes = haystack.as_bytes();
+    let mut start = 0;
+    while let Some(pos) = haystack[start..].find(needle) {
+        let abs = start + pos;
+        let before_ok = abs == 0 || !bytes[abs - 1].is_ascii_alphanumeric();
+        let after = abs + needle.len();
+        let after_ok = after >= bytes.len() || !bytes[after].is_ascii_alphanumeric();
+        if before_ok && after_ok {
+            return true;
+        }
+        start = abs + 1;
+    }
+    false
+}
+
 /// Detect error type from push error message
 pub(crate) fn detect_push_error_type(message: &str) -> GitErrorType {
     let lower = message.to_lowercase();
+
+    // Protected branch / server-side policy rejection. Checked BEFORE the
+    // non-fast-forward patterns: git appends "error: failed to push some refs"
+    // to every rejection, so the broader non-fast-forward arm would otherwise
+    // shadow this one and the UI would tell the user to pull, which cannot
+    // help against a policy rejection.
+    if lower.contains("protected branch")
+        || lower.contains("branch is protected")
+        || lower.contains("cannot push to")
+        || lower.contains("pre-receive hook declined")
+        || lower.contains("remote rejected")
+    {
+        return GitErrorType::ProtectedBranch;
+    }
 
     // Non-fast-forward (remote has changes we don't have)
     if lower.contains("non-fast-forward")
@@ -346,16 +380,6 @@ pub(crate) fn detect_push_error_type(message: &str) -> GitErrorType {
         || lower.contains("failed to push some refs")
     {
         return GitErrorType::NonFastForward;
-    }
-
-    // Protected branch
-    if lower.contains("protected branch")
-        || lower.contains("branch is protected")
-        || lower.contains("cannot push to")
-        || lower.contains("pre-receive hook declined")
-        || lower.contains("remote rejected")
-    {
-        return GitErrorType::ProtectedBranch;
     }
 
     // Authentication failed
@@ -370,8 +394,8 @@ pub(crate) fn detect_push_error_type(message: &str) -> GitErrorType {
         || lower.contains("permission denied")
         || lower.contains("fatal: authentication")
         || lower.contains("repository not found")
-        || lower.contains("saml")
-        || lower.contains("sso")
+        || contains_word(&lower, "saml")
+        || contains_word(&lower, "sso")
         || lower.contains("password authentication was removed")
         || lower.contains("requested url returned error: 403")
     {
@@ -492,14 +516,14 @@ pub(crate) fn detect_pull_error_type(message: &str) -> (GitErrorType, Option<Vec
         || lower.contains("uncommitted changes")
         || lower.contains("please commit your changes or stash them")
     {
-        // Try to extract affected files
+        // Git lists the blocking files one per line, tab-indented. The prefix
+        // must be tested on the raw line — trimming first strips the very tab
+        // being tested for.
         let mut affected_files = Vec::new();
         for line in message.lines() {
-            let trimmed = line.trim();
-            // Git usually lists files with a tab prefix
-            if trimmed.starts_with('\t') || trimmed.starts_with("    ") {
-                let file = trimmed.trim();
-                if !file.is_empty() && !file.contains(' ') {
+            if let Some(file) = line.strip_prefix('\t') {
+                let file = file.trim();
+                if !file.is_empty() {
                     affected_files.push(file.to_string());
                 }
             }
@@ -529,8 +553,8 @@ pub(crate) fn detect_pull_error_type(message: &str) -> (GitErrorType, Option<Vec
         || lower.contains("could not read username")
         || lower.contains("unable to get password from user")
         || lower.contains("repository not found")
-        || lower.contains("saml")
-        || lower.contains("sso")
+        || contains_word(&lower, "saml")
+        || contains_word(&lower, "sso")
         || lower.contains("password authentication was removed")
         || lower.contains("requested url returned error: 403")
     {
@@ -542,6 +566,7 @@ pub(crate) fn detect_pull_error_type(message: &str) -> (GitErrorType, Option<Vec
         || lower.contains("connection refused")
         || lower.contains("network is unreachable")
         || lower.contains("unable to access")
+        || lower.contains("connection timed out")
     {
         return (GitErrorType::NetworkError, None);
     }
@@ -587,11 +612,16 @@ pub fn pull_from_remote(
 
     let output = run_remote_git(repo_path, &args, auth_username, auth_token, store_auth)?;
 
-    let message = if output.status.success() {
-        String::from_utf8_lossy(&output.stdout).to_string()
-    } else {
-        String::from_utf8_lossy(&output.stderr).to_string()
-    };
+    // Git splits meaningful pull output across both streams: the merge
+    // machinery reports "CONFLICT (content): …" on stdout while stderr carries
+    // only fetch progress, and a successful pull puts the autostash-conflict
+    // warning ("Your changes are safe in the stash") on stderr. Classification
+    // and the conflict sniff below must see both, in both branches.
+    let message = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     // Check for conflicts
     let conflicts = if message.contains("CONFLICT") || message.contains("conflict") {
@@ -662,8 +692,8 @@ pub(crate) fn detect_fetch_error_type(message: &str) -> GitErrorType {
         || lower.contains("could not read username")
         || lower.contains("unable to get password from user")
         || lower.contains("repository not found")
-        || lower.contains("saml")
-        || lower.contains("sso")
+        || contains_word(&lower, "saml")
+        || contains_word(&lower, "sso")
         || lower.contains("password authentication was removed")
         || lower.contains("requested url returned error: 403")
     {

--- a/src-tauri/crates/git-api/src/commands/streaming.rs
+++ b/src-tauri/crates/git-api/src/commands/streaming.rs
@@ -27,7 +27,7 @@ use tokio::process::Command;
 use git::{tokio_git_command, util::is_transient_error};
 
 use super::commit::append_orgii_coauthor_trailer;
-use super::remote::pull_strategy_args;
+use super::remote::{contains_word, pull_strategy_args};
 
 type GitEventStream = Pin<Box<dyn Stream<Item = Result<Event, std::convert::Infallible>> + Send>>;
 
@@ -41,16 +41,10 @@ pub(crate) fn detect_error_type_from_output(output: &str, operation: &str) -> &'
 
     match operation {
         "push" => {
-            // Non-fast-forward (remote has changes we don't have)
-            if lower.contains("non-fast-forward")
-                || lower.contains("fetch first")
-                || lower.contains("updates were rejected")
-                || lower.contains("failed to push some refs")
-            {
-                return "non_fast_forward";
-            }
-
-            // Protected branch
+            // Protected branch / policy rejection — checked BEFORE the
+            // non-fast-forward patterns, because git appends "error: failed to
+            // push some refs" to every rejection and the broader arm would
+            // shadow this one (see detect_push_error_type in remote.rs).
             if lower.contains("protected branch")
                 || lower.contains("branch is protected")
                 || lower.contains("cannot push to")
@@ -58,6 +52,15 @@ pub(crate) fn detect_error_type_from_output(output: &str, operation: &str) -> &'
                 || lower.contains("remote rejected")
             {
                 return "protected_branch";
+            }
+
+            // Non-fast-forward (remote has changes we don't have)
+            if lower.contains("non-fast-forward")
+                || lower.contains("fetch first")
+                || lower.contains("updates were rejected")
+                || lower.contains("failed to push some refs")
+            {
+                return "non_fast_forward";
             }
         }
         "pull" => {
@@ -94,8 +97,8 @@ pub(crate) fn detect_error_type_from_output(output: &str, operation: &str) -> &'
         || lower.contains("unable to get password from user")
         || lower.contains("permission denied (publickey)")
         || lower.contains("repository not found")
-        || lower.contains("saml")
-        || lower.contains("sso")
+        || contains_word(&lower, "saml")
+        || contains_word(&lower, "sso")
         || lower.contains("password authentication was removed")
         || lower.contains("requested url returned error: 403")
     {

--- a/src-tauri/crates/git-api/src/commands/tests/remote_tests.rs
+++ b/src-tauri/crates/git-api/src/commands/tests/remote_tests.rs
@@ -1,5 +1,6 @@
 use crate::commands::remote::{
-    detect_fetch_error_type, detect_pull_error_type, detect_push_error_type, pull_strategy_args,
+    contains_word, detect_fetch_error_type, detect_pull_error_type, detect_push_error_type,
+    pull_from_remote, pull_strategy_args,
 };
 use crate::types::GitErrorType;
 
@@ -68,8 +69,14 @@ fn push_error_fetch_first() {
 
 #[test]
 fn push_error_updates_rejected() {
+    // "Updates were rejected" is a client-side hint line; git pairs it with
+    // "! [rejected]", never with the server-side "! [remote rejected]"
+    // marker (that one is a policy rejection and classifies as
+    // ProtectedBranch — see push_classification tests below).
     assert_eq!(
-        detect_push_error_type("! [remote rejected] main -> main (updates were rejected)"),
+        detect_push_error_type(
+            "hint: Updates were rejected because the tip of your current branch is behind"
+        ),
         GitErrorType::NonFastForward,
     );
 }
@@ -198,15 +205,21 @@ fn pull_error_uncommitted_changes() {
 
 #[test]
 fn pull_error_extracts_affected_files() {
-    // Git indents affected files with a tab character
+    // Git indents the blocking files with a tab character, one per line.
     let msg = "error: Your local changes to the following files would be overwritten by merge:\n\tsrc/main.rs\n\tsrc/lib.rs\nPlease commit your changes or stash them before you merge.";
     let (err_type, files) = detect_pull_error_type(msg);
     assert_eq!(err_type, GitErrorType::UncommittedChanges);
-    // File extraction may or may not capture files depending on exact
-    // formatting. The critical assertion is the error type classification.
-    if let Some(file_list) = files {
-        assert!(!file_list.is_empty());
-    }
+    assert_eq!(
+        files,
+        Some(vec!["src/main.rs".to_string(), "src/lib.rs".to_string()])
+    );
+}
+
+#[test]
+fn pull_error_extracts_affected_files_with_spaces() {
+    let msg = "error: Your local changes to the following files would be overwritten by merge:\n\tdocs/release notes.md\nPlease commit your changes or stash them before you merge.";
+    let (_, files) = detect_pull_error_type(msg);
+    assert_eq!(files, Some(vec!["docs/release notes.md".to_string()]));
 }
 
 #[test]
@@ -228,6 +241,262 @@ fn pull_error_auth() {
 fn pull_error_bad_credentials() {
     let (err_type, _) = detect_pull_error_type("remote: Invalid username or token.");
     assert_eq!(err_type, GitErrorType::AuthenticationFailed);
+}
+
+// ============================================
+// Regression tests with full, untruncated git output. Git appends
+// "error: failed to push some refs to <url>" to EVERY push rejection, so a
+// classifier that tests the non-fast-forward patterns first can never reach
+// the protected-branch arm on real output — truncated fixtures hide that.
+// ============================================
+
+#[test]
+fn push_error_protected_branch_full_real_output() {
+    let msg = "remote: error: GH006: Protected branch update failed for refs/heads/main.\n\
+               remote: error: Changes must be made through a pull request.\n\
+                ! [remote rejected] main -> main (protected branch hook declined)\n\
+               error: failed to push some refs to 'https://github.com/acme/app.git'";
+    assert_eq!(detect_push_error_type(msg), GitErrorType::ProtectedBranch);
+}
+
+#[test]
+fn push_error_pre_receive_hook_full_real_output() {
+    let msg = "remote: GitLab: You are not allowed to push code to this project.\n\
+                ! [remote rejected] main -> main (pre-receive hook declined)\n\
+               error: failed to push some refs to 'https://gitlab.com/acme/app.git'";
+    assert_eq!(detect_push_error_type(msg), GitErrorType::ProtectedBranch);
+}
+
+#[test]
+fn push_error_plain_non_fast_forward_full_real_output() {
+    // A plain non-fast-forward rejection carries none of the policy markers
+    // and must still classify as NonFastForward after the reorder.
+    let msg = " ! [rejected]        main -> main (fetch first)\n\
+               error: failed to push some refs to 'https://github.com/acme/app.git'\n\
+               hint: Updates were rejected because the remote contains work that you do not\n\
+               hint: have locally. This is usually caused by another repository pushing to\n\
+               hint: the same ref. If you want to integrate the remote changes, use\n\
+               hint: 'git pull' before pushing again.";
+    assert_eq!(detect_push_error_type(msg), GitErrorType::NonFastForward);
+}
+
+/// Regression: the extraction loop used to call `line.trim()` and then test
+/// `starts_with('\t')` on the trimmed string — unconditionally false, so the
+/// uncommitted-changes dialog could never list the blocking files.
+#[test]
+fn pull_error_affected_files_extracted_from_real_tabbed_output() {
+    let msg = "error: Your local changes to the following files would be overwritten by merge:\n\tsrc/main.rs\n\tsrc/lib.rs\nPlease commit your changes or stash them before you merge.";
+    let (err_type, files) = detect_pull_error_type(msg);
+    assert_eq!(err_type, GitErrorType::UncommittedChanges);
+    assert_eq!(
+        files,
+        Some(vec!["src/main.rs".to_string(), "src/lib.rs".to_string()])
+    );
+}
+
+/// Regression: the auth arm used to match the bare substring "sso", which
+/// hides inside ordinary words ("processor", "associate", "lasso") in the
+/// URLs and paths git embeds in its output — and the auth arm runs before the
+/// network arm, so a plain DNS failure prompted for credentials.
+#[test]
+fn pull_error_dns_failure_on_sso_containing_repo_name_is_network() {
+    let (err_type, _) = detect_pull_error_type(
+        "fatal: unable to access 'https://github.com/acme/processor-service.git/': Could not resolve host: github.com",
+    );
+    assert_eq!(err_type, GitErrorType::NetworkError);
+}
+
+#[test]
+fn pull_error_real_saml_enforcement_is_auth() {
+    // Standalone "SSO"/"SAML" words (real GitHub SAML enforcement output)
+    // must still classify as an auth failure after the word-boundary fix.
+    let (err_type, _) = detect_pull_error_type(
+        "remote: The `acme' organization has enabled or enforced SAML SSO. To access\nremote: this repository, visit https://github.com/orgs/acme/sso\nfatal: unable to access 'https://github.com/acme/app.git/': The requested URL returned error: 403",
+    );
+    assert_eq!(err_type, GitErrorType::AuthenticationFailed);
+}
+
+#[test]
+fn pull_error_connection_timed_out_is_network() {
+    let (err_type, _) = detect_pull_error_type(
+        "fatal: unable to access 'https://github.com/acme/app.git/': Failed to connect to github.com port 443 after 21038 ms: Connection timed out",
+    );
+    assert_eq!(err_type, GitErrorType::NetworkError);
+}
+
+// ============================================
+// contains_word
+// ============================================
+
+#[test]
+fn contains_word_matches_standalone_tokens_only() {
+    assert!(contains_word("enforced saml sso.", "sso"));
+    assert!(contains_word("sso required", "sso"));
+    assert!(contains_word(
+        "visit https://github.com/orgs/acme/sso",
+        "sso"
+    ));
+    assert!(!contains_word("processor-service", "sso"));
+    assert!(!contains_word("refs/heads/associate-api", "sso"));
+    assert!(!contains_word("missouri", "sso"));
+    assert!(!contains_word("lassos", "sso"));
+}
+
+// ============================================
+// pull_from_remote — integration against real repositories.
+//
+// pull_from_remote shells out to git, and its defects historically lived in
+// exactly the gap unit fixtures cannot cover: which stream carries which
+// message. These scenarios run the real binary against throwaway repos.
+// ============================================
+
+#[test]
+fn pull_from_remote_reports_real_pull_outcomes() {
+    if std::process::Command::new("git")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("skipping: git executable not available");
+        return;
+    }
+
+    let base = std::env::temp_dir().join(format!(
+        "orgii-pull-int-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock after epoch")
+            .as_nanos()
+    ));
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(&base).expect("create test root");
+
+    fn git_in(dir: &std::path::Path, args: &[&str]) {
+        let out = std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args([
+                "-c",
+                "user.email=t@t",
+                "-c",
+                "user.name=t",
+                "-c",
+                "commit.gpgsign=false",
+                "-c",
+                "init.defaultBranch=main",
+            ])
+            .args(args)
+            .output()
+            .expect("spawn git");
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}{}",
+            args,
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    fn append(path: &std::path::Path, text: &str) {
+        use std::io::Write as _;
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .expect("open file");
+        f.write_all(text.as_bytes()).expect("append");
+    }
+
+    let bare = base.join("remote.git");
+    let a = base.join("a");
+    let b = base.join("b");
+    git_in(&base, &["init", "--bare", "remote.git"]);
+    git_in(&base, &["init", "a"]);
+    append(&a.join("s.txt"), "one\n");
+    git_in(&a, &["add", "."]);
+    git_in(&a, &["commit", "-m", "init"]);
+    git_in(
+        &a,
+        &["remote", "add", "origin", bare.to_str().expect("utf8")],
+    );
+    git_in(&a, &["push", "-u", "origin", "main"]);
+    git_in(&base, &["clone", "remote.git", "b"]);
+
+    // Remote moves ahead on s.txt.
+    append(&b.join("s.txt"), "remote-1\n");
+    git_in(&b, &["commit", "-am", "remote edit 1"]);
+    git_in(&b, &["push"]);
+
+    // Scenario 1: dirty overlapping file, merge pull. Git refuses on stderr
+    // with a tab-indented file list; the result must classify it and name the
+    // file.
+    append(&a.join("s.txt"), "local-dirty\n");
+    let refused = pull_from_remote(
+        &a,
+        Some("origin"),
+        Some("main"),
+        Some("merge"),
+        None,
+        None,
+        false,
+    )
+    .expect("pull runs");
+    assert!(!refused.success, "overlap merge pull must fail");
+    assert_eq!(refused.error_type, GitErrorType::UncommittedChanges);
+    assert_eq!(refused.affected_files, Some(vec!["s.txt".to_string()]));
+
+    // Scenario 2: same dirty state, rebase pull. The pull itself succeeds;
+    // git reapplies the autostash as conflict markers and warns on STDERR —
+    // the result must still surface the conflicted file.
+    let autostash = pull_from_remote(
+        &a,
+        Some("origin"),
+        Some("main"),
+        Some("rebase"),
+        None,
+        None,
+        false,
+    )
+    .expect("pull runs");
+    assert!(autostash.success, "autostash pull exits 0");
+    assert!(
+        autostash.message.to_lowercase().contains("autostash"),
+        "stderr autostash warning must be in the message: {}",
+        autostash.message
+    );
+    let conflicted = autostash.conflicts.expect("conflicts listed");
+    assert_eq!(conflicted, vec!["s.txt".to_string()]);
+    git_in(&a, &["reset", "--hard", "origin/main"]);
+    git_in(&a, &["stash", "clear"]);
+
+    // Scenario 3: committed divergence on both sides, merge pull. The merge
+    // machinery prints "CONFLICT" on STDOUT while the exit code is non-zero;
+    // the result must not lose it by reading stderr alone.
+    append(&b.join("s.txt"), "remote-2\n");
+    git_in(&b, &["commit", "-am", "remote edit 2"]);
+    git_in(&b, &["push"]);
+    append(&a.join("s.txt"), "local-committed\n");
+    git_in(&a, &["commit", "-am", "local edit"]);
+    let conflicted = pull_from_remote(
+        &a,
+        Some("origin"),
+        Some("main"),
+        Some("merge"),
+        None,
+        None,
+        false,
+    )
+    .expect("pull runs");
+    assert!(!conflicted.success, "conflicting merge pull must fail");
+    assert_eq!(conflicted.error_type, GitErrorType::MergeConflicts);
+    assert!(
+        conflicted.message.contains("CONFLICT"),
+        "stdout CONFLICT line must be in the message: {}",
+        conflicted.message
+    );
+    assert_eq!(conflicted.conflicts, Some(vec!["s.txt".to_string()]));
+
+    let _ = std::fs::remove_dir_all(&base);
 }
 
 // ============================================

--- a/src-tauri/crates/git-api/src/commands/tests/streaming_tests.rs
+++ b/src-tauri/crates/git-api/src/commands/tests/streaming_tests.rs
@@ -42,6 +42,52 @@ fn push_protected_branch() {
     );
 }
 
+/// Regression: real rejections always end with "error: failed to push some
+/// refs", which the non-fast-forward arm matches — protected-branch must win
+/// on full output, and a plain rejection must still be non-fast-forward.
+#[test]
+fn push_classification_on_full_real_output() {
+    assert_eq!(
+        detect_error_type_from_output(
+            "remote: error: GH006: Protected branch update failed for refs/heads/main.\n \
+             ! [remote rejected] main -> main (protected branch hook declined)\n\
+             error: failed to push some refs to 'https://github.com/acme/app.git'",
+            "push"
+        ),
+        "protected_branch"
+    );
+    assert_eq!(
+        detect_error_type_from_output(
+            " ! [rejected]        main -> main (fetch first)\n\
+             error: failed to push some refs to 'https://github.com/acme/app.git'\n\
+             hint: Updates were rejected because the remote contains work that you do not\n\
+             hint: have locally.",
+            "push"
+        ),
+        "non_fast_forward"
+    );
+}
+
+/// Regression: the auth arm used to match the bare substring "sso" — which
+/// hides inside "processor", "associate", etc. — ahead of the network arm.
+#[test]
+fn dns_failure_on_sso_containing_repo_name_is_network() {
+    assert_eq!(
+        detect_error_type_from_output(
+            "fatal: unable to access 'https://github.com/acme/processor-service.git/': Could not resolve host: github.com",
+            "fetch"
+        ),
+        "network_error"
+    );
+    assert_eq!(
+        detect_error_type_from_output(
+            "remote: The `acme' organization has enabled or enforced SAML SSO.",
+            "fetch"
+        ),
+        "authentication_failed"
+    );
+}
+
 // ============================================
 // detect_error_type_from_output — pull
 // ============================================

--- a/src-tauri/crates/git-api/src/error.rs
+++ b/src-tauri/crates/git-api/src/error.rs
@@ -79,6 +79,9 @@ pub enum GitApiError {
     #[error("Push rejected (non-fast-forward): {message}")]
     NonFastForward { message: String },
 
+    #[error("Push rejected by remote policy: {message}")]
+    ProtectedBranch { message: String },
+
     #[error("Network error: {message}")]
     NetworkError { message: String },
 
@@ -138,6 +141,7 @@ impl GitApiError {
             // 409 Conflict
             GitApiError::MergeConflict { .. }
             | GitApiError::NonFastForward { .. }
+            | GitApiError::ProtectedBranch { .. }
             | GitApiError::UncommittedChanges { .. } => StatusCode::CONFLICT,
 
             // 503 Service Unavailable
@@ -173,6 +177,7 @@ impl GitApiError {
             GitApiError::RemoteNotFound { .. } => "remote_not_found",
             GitApiError::AuthenticationFailed { .. } => "authentication_failed",
             GitApiError::NonFastForward { .. } => "non_fast_forward",
+            GitApiError::ProtectedBranch { .. } => "protected_branch",
             GitApiError::NetworkError { .. } => "network_error",
             GitApiError::InvalidRequest { .. } => "invalid_request",
             GitApiError::InvalidEncoding { .. } => "invalid_encoding",
@@ -196,6 +201,17 @@ impl GitApiError {
         }
         if normalized.contains("nothing to commit") {
             return GitApiError::NothingToCommit;
+        }
+        // Policy rejections must be tested before the broad "rejected" match:
+        // protected-branch and hook rejections also contain "rejected", and
+        // classifying them as non-fast-forward tells the user to pull, which
+        // cannot help.
+        if normalized.contains("protected branch")
+            || normalized.contains("branch is protected")
+            || normalized.contains("pre-receive hook declined")
+            || normalized.contains("remote rejected")
+        {
+            return GitApiError::ProtectedBranch { message: msg };
         }
         if normalized.contains("non-fast-forward") || normalized.contains("rejected") {
             return GitApiError::NonFastForward { message: msg };

--- a/src-tauri/crates/git-api/src/tests/error_tests.rs
+++ b/src-tauri/crates/git-api/src/tests/error_tests.rs
@@ -36,3 +36,26 @@ fn test_from_git_error() {
     let err = GitApiError::from_git_error("Authentication failed for 'https://...'");
     assert!(matches!(err, GitApiError::AuthenticationFailed { .. }));
 }
+
+/// Regression: git appends "error: failed to push some refs" to every push
+/// rejection, and every policy rejection also contains "rejected" — so the
+/// protected-branch patterns must be tested before the broad "rejected"
+/// match, or a policy rejection maps to NonFastForward and the UI tells the
+/// user to pull.
+#[test]
+fn test_from_git_error_policy_rejection_before_non_fast_forward() {
+    let err = GitApiError::from_git_error(
+        "remote: error: GH006: Protected branch update failed for refs/heads/main.\n \
+         ! [remote rejected] main -> main (protected branch hook declined)\n\
+         error: failed to push some refs to 'https://github.com/acme/app.git'",
+    );
+    assert!(matches!(err, GitApiError::ProtectedBranch { .. }));
+    assert_eq!(err.error_type(), "protected_branch");
+    assert_eq!(err.status_code(), StatusCode::CONFLICT);
+
+    let err = GitApiError::from_git_error(
+        " ! [rejected]        main -> main (fetch first)\n\
+         error: failed to push some refs to 'https://github.com/acme/app.git'",
+    );
+    assert!(matches!(err, GitApiError::NonFastForward { .. }));
+}


### PR DESCRIPTION
## Problem

Four independent defects make the Rust backend misreport git failures (all confirmed in the 2026-08-28 git-system audit, three reproduced against real git):

1. **`pull_from_remote` reads the wrong stream in both directions.** On failure it reads stderr only — but the merge machinery prints `CONFLICT (content): …` on *stdout* (stderr carries only fetch progress), so a conflicting pull on this path classifies as `Unknown` with a "From … FETCH_HEAD" message and an empty conflict list. On success it reads stdout only — discarding the stderr warning `Applying autostash resulted in conflicts. Your changes are safe in the stash.` (exit 0), so the autostash overlap case introduced alongside #1028 reports a clean success while the tree holds `UU` files. This path serves every pull outside the WorkStation editor plus all auth-retry pulls.
2. **Protected-branch rejections always classify as non-fast-forward.** Git appends `error: failed to push some refs to '…'` to *every* push rejection, and all three Rust classifiers (`detect_push_error_type`, the streaming variant, and `GitApiError::from_git_error`, which matched bare `rejected`) test the non-fast-forward patterns first — so a policy rejection tells the user to pull, which cannot help. Existing tests passed only because their fixtures truncated the real message.
3. **The uncommitted-changes file extraction is dead code.** It calls `line.trim()` and then tests `starts_with('\t')` on the trimmed string — unconditionally false — so `affected_files` is always `None` and the dialog can never list the blocking files.
4. **Bare `"sso"`/`"saml"` substrings misroute failures into the auth dialog.** "sso" hides inside "processor", "associate", etc., in the URLs, branch names, and paths git embeds in output, and the auth arm runs before the network arm — so a DNS failure on `processor-service.git` prompts for credentials.

## Solution

- `pull_from_remote` builds its message from **stdout + stderr combined in both branches** (matching `fetch_from_remote` and the SSE path, which already classify over combined output). The existing conflict sniff then naturally catches both stdout `CONFLICT` lines and the stderr autostash warning, so the autostash case now returns `success: true` with `conflicts` populated.
- All four classifiers test **policy-rejection patterns before non-fast-forward** ones. `GitApiError` gains a `ProtectedBranch` variant (HTTP 409, error code `protected_branch` — a code the TS layer's `GIT_ERROR_TYPES` set already accepts).
- Affected files are extracted with `line.strip_prefix('\t')` on the raw line; the over-restrictive "no spaces in path" filter is dropped.
- A shared `contains_word` helper matches `sso`/`saml` on word boundaries in all four call sites; `Connection timed out` is added to the pull network patterns for parity with push.

Invariant: classification decisions are made over the same text git actually produced, with the most specific pattern family tested first.

## Potential risks

- `! [remote rejected]` now maps to `protected_branch` for *all* server-side refusals (hooks, LFS/size limits, deny rules), not only branch protection. That is closer to the truth than "pull first," but the dialog copy for `protected_branch` should read as "rejected by remote policy" generally. One legacy test fixture that glued `[remote rejected]` onto "updates were rejected" (a combination real git never emits) was corrected to the real hint form.
- The new `ProtectedBranch` variant changes the HTTP error code for these rejections from `non_fast_forward` to `protected_branch`; TS already whitelists that code, but any consumer branching specifically on `non_fast_forward` for policy rejections will now see the (correct) code.
- Pull success messages now include stderr (fetch summary lines) — cosmetic change to any UI that displays the raw message.
- The new integration test shells out to a real `git` binary; it skips itself with a message when none is on PATH.

## Verification

- `cargo test -p git_api --lib` → **105 passed, 0 failed** (was 92), including three new suites: full-real-output push classification (protected/pre-receive/plain non-FF), `contains_word` boundary cases, and a real-repository integration test driving `pull_from_remote` through the three failure shapes — dirty-overlap refusal (asserts `UncommittedChanges` + `affected_files == ["s.txt"]`), autostash-conflict success (asserts `success` + stderr warning present + `conflicts == ["s.txt"]`), and committed merge conflict (asserts `MergeConflicts` + stdout `CONFLICT` in message + conflict list).
- The three previously-`#[ignore]`d audit tests documenting these bugs are now live and passing; each was verified to fail against the old code.
- `cargo fmt -p git_api --check` clean; `cargo clippy -p git_api --all-targets` no warnings.
- Not run: E2E through the packaged app.
- Stacked on #1028 (`fix/pull-rebase-autostash`) because it touches the same files; merge #1028 first. Built via temp index from a live checkout, so pre-commit hooks did not run (`Pre-commit hook ran.` trailer intentionally absent); checks above were run manually.
