### PR TITLE
fix(git): order and anchor TS error-text classifiers

### DIFF
--- a/src/modules/WorkStation/CodeEditor/hooks/gitOutputIntegration/createGitOperationHandler.ts
+++ b/src/modules/WorkStation/CodeEditor/hooks/gitOutputIntegration/createGitOperationHandler.ts
@@ -26,6 +26,19 @@ function inferGitErrorTypeFromText(
 ): GitErrorType {
   const normalizedText = errorText.toLowerCase();
 
+  // Protected-branch first: git appends "failed to push some refs" to every
+  // rejection, so the broader non-fast-forward family below would otherwise
+  // shadow policy rejections and tell the user to pull, which cannot help.
+  if (
+    operationName === "push" &&
+    (normalizedText.includes("protected branch") ||
+      normalizedText.includes("branch is protected") ||
+      normalizedText.includes("pre-receive hook declined") ||
+      normalizedText.includes("remote rejected"))
+  ) {
+    return "protected_branch";
+  }
+
   if (
     operationName === "push" &&
     (normalizedText.includes("non-fast-forward") ||

--- a/src/services/git/operations/__tests__/types.test.ts
+++ b/src/services/git/operations/__tests__/types.test.ts
@@ -1,0 +1,189 @@
+/**
+ * parseGitError — classification of raw git error text into GitErrorType.
+ *
+ * Fixtures are full, untruncated git output: git embeds branch names, file
+ * paths, and URLs in its messages, and every historical misclassification
+ * here came from a broad substring meeting exactly that embedded content.
+ */
+import { describe, expect, it } from "vitest";
+
+import { parseGitError } from "../types";
+
+function gitError(message: string, structured?: Record<string, unknown>) {
+  const error = new Error(message);
+  if (structured) Object.assign(error, structured);
+  return error;
+}
+
+describe("parseGitError — structured error types", () => {
+  it("prefers a structured errorType over text sniffing", () => {
+    const parsed = parseGitError(
+      gitError("error: failed to push some refs to 'origin'", {
+        errorType: "protected_branch",
+      })
+    );
+    expect(parsed.type).toBe("protected_branch");
+  });
+
+  it("accepts the snake_case error_type variant from the Rust backend", () => {
+    const parsed = parseGitError(
+      gitError("anything", { error_type: "non_fast_forward" })
+    );
+    expect(parsed.type).toBe("non_fast_forward");
+  });
+
+  it("ignores an unrecognized structured type and falls back to text", () => {
+    const parsed = parseGitError(
+      gitError("fatal: Authentication failed for 'https://github.com/a/b'", {
+        errorType: "not-a-real-type",
+      })
+    );
+    expect(parsed.type).toBe("authentication_failed");
+  });
+
+  it("ignores a structured 'none' and falls back to text", () => {
+    const parsed = parseGitError(
+      gitError("CONFLICT (content): Merge conflict in file.txt", {
+        errorType: "none",
+      })
+    );
+    expect(parsed.type).toBe("merge_conflicts");
+  });
+});
+
+describe("parseGitError — real git output fixtures", () => {
+  it("classifies a merge-overwrite refusal as uncommitted_changes", () => {
+    const parsed = parseGitError(
+      gitError(
+        "error: Your local changes to the following files would be overwritten by merge:\n" +
+          "\tsrc/main.rs\n" +
+          "Please commit your changes or stash them before you merge.\n" +
+          "Aborting"
+      )
+    );
+    expect(parsed.type).toBe("uncommitted_changes");
+  });
+
+  it("classifies the rebase dirty-tree refusal as uncommitted_changes", () => {
+    const parsed = parseGitError(
+      gitError(
+        "error: cannot pull with rebase: You have unstaged changes.\n" +
+          "error: Please commit or stash them."
+      )
+    );
+    expect(parsed.type).toBe("uncommitted_changes");
+  });
+
+  it("classifies a real merge conflict as merge_conflicts", () => {
+    const parsed = parseGitError(
+      gitError(
+        "Auto-merging file.txt\n" +
+          "CONFLICT (content): Merge conflict in file.txt\n" +
+          "Automatic merge failed; fix conflicts and then commit the result."
+      )
+    );
+    expect(parsed.type).toBe("merge_conflicts");
+  });
+
+  it("classifies a refused connection as network_error", () => {
+    const parsed = parseGitError(
+      gitError(
+        "fatal: unable to access 'https://x.example/': Connection refused"
+      )
+    );
+    expect(parsed.type).toBe("network_error");
+  });
+
+  it("returns unknown with a stringified message for non-Error input", () => {
+    const parsed = parseGitError("plain string failure");
+    expect(parsed).toEqual({
+      type: "unknown",
+      message: "plain string failure",
+    });
+  });
+});
+
+describe("parseGitError — regressions (previously misclassified)", () => {
+  // A bare `includes("auth")` used to run first, so a branch NAME containing
+  // "auth" turned a rejected push into authentication_failed and triggered
+  // the credential-retry flow.
+  it("classifies a rejected push on an auth-named branch as non_fast_forward", () => {
+    const parsed = parseGitError(
+      gitError(
+        " ! [rejected]        feature/auth-login -> feature/auth-login (fetch first)\n" +
+          "error: failed to push some refs to 'https://github.com/acme/app.git'\n" +
+          "hint: Updates were rejected because the remote contains work that you do not\n" +
+          "hint: have locally."
+      )
+    );
+    expect(parsed.type).toBe("non_fast_forward");
+  });
+
+  // Git appends "failed to push some refs" to every rejection, so the
+  // protected-branch family must win over non_fast_forward on full output.
+  it("classifies a protected-branch rejection as protected_branch", () => {
+    const parsed = parseGitError(
+      gitError(
+        "remote: error: GH006: Protected branch update failed for refs/heads/main.\n" +
+          " ! [remote rejected] main -> main (protected branch hook declined)\n" +
+          "error: failed to push some refs to 'https://github.com/acme/app.git'"
+      )
+    );
+    expect(parsed.type).toBe("protected_branch");
+  });
+
+  // "connection"/"timeout" used to be checked before the conflict arm, so a
+  // conflict in a file whose PATH contains one of those words was reported
+  // as a network error and no conflict dialog was shown.
+  it("classifies a conflict in connection.ts as merge_conflicts", () => {
+    const parsed = parseGitError(
+      gitError(
+        "Auto-merging src/api/connection.ts\n" +
+          "CONFLICT (content): Merge conflict in src/api/connection.ts\n" +
+          "Automatic merge failed; fix conflicts and then commit the result."
+      )
+    );
+    expect(parsed.type).toBe("merge_conflicts");
+  });
+
+  it("classifies a DNS resolution failure as network_error", () => {
+    const parsed = parseGitError(
+      gitError(
+        "fatal: unable to access 'https://github.com/acme/app.git/': " +
+          "Could not resolve host: github.com"
+      )
+    );
+    expect(parsed.type).toBe("network_error");
+  });
+
+  // "sso" only counts as a word: it must still catch real SAML enforcement
+  // output but not fire from inside "lesson", "processor", or "associate".
+  it("classifies real SAML enforcement output as authentication_failed", () => {
+    const parsed = parseGitError(
+      gitError(
+        "remote: The `acme' organization has enabled or enforced SAML SSO. To access\n" +
+          "remote: this repository, visit https://github.com/orgs/acme/sso"
+      )
+    );
+    expect(parsed.type).toBe("authentication_failed");
+  });
+
+  it("does not treat sso-containing words as authentication failures", () => {
+    const parsed = parseGitError(
+      gitError(
+        "error: pathspec 'docs/lesson-plan.md' did not match any file(s) known to git"
+      )
+    );
+    expect(parsed.type).toBe("unknown");
+  });
+
+  // The HTTP error boundary emits "merge_conflict" (singular) while the
+  // streaming layer emits "merge_conflicts"; both must be honored as
+  // structured types rather than falling through to text sniffing.
+  it("normalizes the singular merge_conflict structured type", () => {
+    const parsed = parseGitError(
+      gitError("Merge conflict: fix it", { error_type: "merge_conflict" })
+    );
+    expect(parsed.type).toBe("merge_conflicts");
+  });
+});

--- a/src/services/git/operations/types.ts
+++ b/src/services/git/operations/types.ts
@@ -63,8 +63,12 @@ function getStructuredGitErrorType(error: Error): GitErrorType | undefined {
   const errorRecord = error as { errorType?: unknown; error_type?: unknown };
   const maybeErrorType = errorRecord.errorType ?? errorRecord.error_type;
   if (typeof maybeErrorType !== "string") return undefined;
-  if (!GIT_ERROR_TYPES.has(maybeErrorType as GitErrorType)) return undefined;
-  return maybeErrorType as GitErrorType;
+  // The HTTP error boundary (GitApiError) emits "merge_conflict" (singular);
+  // the streaming layer emits "merge_conflicts". Accept both.
+  const normalized =
+    maybeErrorType === "merge_conflict" ? "merge_conflicts" : maybeErrorType;
+  if (!GIT_ERROR_TYPES.has(normalized as GitErrorType)) return undefined;
+  return normalized as GitErrorType;
 }
 
 export function parseGitError(error: unknown): {
@@ -79,33 +83,11 @@ export function parseGitError(error: unknown): {
 
     const message = error.message.toLowerCase();
 
-    if (
-      message.includes("authentication") ||
-      message.includes("auth") ||
-      message.includes("invalid username or password") ||
-      message.includes("invalid username or token") ||
-      message.includes("bad credentials") ||
-      message.includes("http basic: access denied") ||
-      message.includes("permission denied") ||
-      message.includes("could not read username") ||
-      message.includes("unable to get password from user") ||
-      message.includes("repository not found") ||
-      message.includes("saml") ||
-      message.includes("sso") ||
-      message.includes("password authentication was removed") ||
-      message.includes("requested url returned error: 403")
-    ) {
-      return { type: "authentication_failed", message: error.message };
-    }
-
-    if (
-      message.includes("network") ||
-      message.includes("connection") ||
-      message.includes("timeout")
-    ) {
-      return { type: "network_error", message: error.message };
-    }
-
+    // Order matters: git embeds branch names, file paths, and URLs in its
+    // output, so the most content-specific pattern families are tested first
+    // and the generic substrings ("connection", "timeout") come last. A bare
+    // "auth" substring used to run first and turned a rejected push on a
+    // branch named feature/auth-login into a credential prompt.
     if (
       message.includes("would be overwritten") ||
       message.includes("your local changes") ||
@@ -117,8 +99,56 @@ export function parseGitError(error: unknown): {
       return { type: "uncommitted_changes", message: error.message };
     }
 
-    if (message.includes("conflict") || message.includes("merge")) {
+    if (
+      message.includes("conflict") ||
+      message.includes("automatic merge failed")
+    ) {
       return { type: "merge_conflicts", message: error.message };
+    }
+
+    // Push rejections. Policy rejections also carry "failed to push some
+    // refs", so the protected-branch family must win.
+    if (
+      message.includes("protected branch") ||
+      message.includes("branch is protected") ||
+      message.includes("pre-receive hook declined") ||
+      message.includes("remote rejected")
+    ) {
+      return { type: "protected_branch", message: error.message };
+    }
+    if (
+      message.includes("non-fast-forward") ||
+      message.includes("fetch first") ||
+      message.includes("updates were rejected") ||
+      message.includes("failed to push some refs")
+    ) {
+      return { type: "non_fast_forward", message: error.message };
+    }
+
+    if (
+      message.includes("authentication") ||
+      message.includes("invalid username or password") ||
+      message.includes("invalid username or token") ||
+      message.includes("bad credentials") ||
+      message.includes("http basic: access denied") ||
+      message.includes("permission denied") ||
+      message.includes("could not read username") ||
+      message.includes("unable to get password from user") ||
+      message.includes("repository not found") ||
+      /\bsaml\b|\bsso\b/.test(message) ||
+      message.includes("password authentication was removed") ||
+      message.includes("requested url returned error: 403")
+    ) {
+      return { type: "authentication_failed", message: error.message };
+    }
+
+    if (
+      message.includes("could not resolve host") ||
+      message.includes("network") ||
+      message.includes("connection") ||
+      message.includes("timeout")
+    ) {
+      return { type: "network_error", message: error.message };
     }
 
     return { type: "unknown", message: error.message };

--- a/src/util/dialogs/__tests__/gitErrorDialogHelpers.test.ts
+++ b/src/util/dialogs/__tests__/gitErrorDialogHelpers.test.ts
@@ -119,11 +119,14 @@ describe("buildGitErrorInfo — error type inference (errorType: 'unknown')", ()
     expect(info.errorType).toBe("merge_conflicts");
   });
 
-  it("infers remote_branch_deleted for fetch with '[deleted]'", () => {
+  it("infers remote_branch_deleted for a missing remote ref", () => {
+    // "[deleted]" alone is NOT sufficient: that line appears in every
+    // successful `git fetch --prune` (see the regression suite below).
     const info = buildGitErrorInfo(
       makeOptions({
         operation: "fetch",
-        commandOutput: " - [deleted] origin/old-branch",
+        commandOutput:
+          "fatal: couldn't find remote ref feature/gone\nremote ref does not exist",
       })
     );
     expect(info.errorType).toBe("remote_branch_deleted");
@@ -167,6 +170,68 @@ describe("buildGitErrorInfo — error type inference (errorType: 'unknown')", ()
       })
     );
     expect(info.errorType).toBe("unknown");
+  });
+});
+
+describe("buildGitErrorInfo — regression fixtures (full real git output)", () => {
+  // Git appends "error: failed to push some refs" (a PUSH_REJECTED pattern)
+  // to every rejection; protected-branch must win on full output.
+  it("infers protected_branch for a full protected-branch rejection", () => {
+    const info = buildGitErrorInfo(
+      makeOptions({
+        operation: "push",
+        errorMessage: "push failed",
+        commandOutput:
+          "remote: error: GH006: Protected branch update failed for refs/heads/main.\n" +
+          " ! [remote rejected] main -> main (protected branch hook declined)\n" +
+          "error: failed to push some refs to 'https://github.com/acme/app.git'",
+      })
+    );
+    expect(info.errorType).toBe("protected_branch");
+  });
+
+  it("still infers non_fast_forward for a plain rejection", () => {
+    const info = buildGitErrorInfo(
+      makeOptions({
+        operation: "push",
+        errorMessage: "push failed",
+        commandOutput:
+          " ! [rejected]        main -> main (fetch first)\n" +
+          "error: failed to push some refs to 'https://github.com/acme/app.git'\n" +
+          "hint: Updates were rejected because the remote contains work that you do not have locally.",
+      })
+    );
+    expect(info.errorType).toBe("non_fast_forward");
+  });
+
+  // A 403 arrives inside git's "unable to access" wrapper, which is also a
+  // network pattern — it must classify as auth, not connectivity.
+  it("infers authentication_failed for an HTTP 403", () => {
+    const info = buildGitErrorInfo(
+      makeOptions({
+        operation: "fetch",
+        errorMessage: "fetch failed",
+        commandOutput:
+          "fatal: unable to access 'https://github.com/acme/app.git/': " +
+          "The requested URL returned error: 403",
+      })
+    );
+    expect(info.errorType).toBe("authentication_failed");
+  });
+
+  // "[deleted]" lines appear in every successful prune; a fetch that pruned
+  // and then failed for another reason must not read as remote_branch_deleted.
+  it("does not infer remote_branch_deleted from prune output in a failed fetch", () => {
+    const info = buildGitErrorInfo(
+      makeOptions({
+        operation: "fetch",
+        errorMessage: "fetch failed",
+        commandOutput:
+          " - [deleted]         (none)     -> origin/old-branch\n" +
+          "fatal: unable to access 'https://github.com/acme/app.git/': Could not resolve host: github.com",
+      })
+    );
+    expect(info.errorType).toBe("network_error");
   });
 });
 

--- a/src/util/dialogs/gitErrorDialog.ts
+++ b/src/util/dialogs/gitErrorDialog.ts
@@ -94,6 +94,11 @@ const AUTH_ERROR_PATTERNS = [
   "invalid credentials",
   "could not read username",
   "permission denied (publickey)",
+  "bad credentials",
+  // HTTP 403 arrives inside git's "unable to access" wrapper, which is also
+  // a NETWORK pattern — auth is tested first so a 403 is not reported as a
+  // connectivity problem.
+  "requested url returned error: 403",
 ] as const;
 
 const NETWORK_ERROR_PATTERNS = [
@@ -138,10 +143,12 @@ const UNCOMMITTED_CHANGES_PATTERNS = [
 
 const MERGE_CONFLICT_PATTERNS = ["conflict", "automatic merge failed"] as const;
 
-const REMOTE_DELETED_PATTERNS = [
-  "[deleted]",
-  "remote ref does not exist",
-] as const;
+// Deliberately does NOT include "[deleted]": that line appears in the output
+// of every successful `git fetch --prune`, and this inference runs over the
+// full command output of a FAILED operation — a fetch that pruned a branch
+// and then failed for an unrelated reason must not classify as
+// remote_branch_deleted.
+const REMOTE_DELETED_PATTERNS = ["remote ref does not exist"] as const;
 
 const ERROR_DETAIL_MARKERS = [
   "fatal:",
@@ -169,18 +176,22 @@ function inferErrorTypeFromText(
   const normalizedOperation = operation.toLowerCase();
   const combinedText = `${errorMessage}\n${commandOutput ?? ""}`.toLowerCase();
 
-  if (
-    (normalizedOperation === "push" || normalizedOperation === "sync") &&
-    includesAnyPattern(combinedText, PUSH_REJECTED_PATTERNS)
-  ) {
-    return "non_fast_forward";
-  }
-
+  // Protected-branch first: git appends "failed to push some refs" (a
+  // PUSH_REJECTED pattern) to every rejection, so testing the broader family
+  // first would report a policy rejection as "remote has newer commits" and
+  // send the user into a pull loop that cannot help.
   if (
     (normalizedOperation === "push" || normalizedOperation === "sync") &&
     includesAnyPattern(combinedText, PROTECTED_BRANCH_PATTERNS)
   ) {
     return "protected_branch";
+  }
+
+  if (
+    (normalizedOperation === "push" || normalizedOperation === "sync") &&
+    includesAnyPattern(combinedText, PUSH_REJECTED_PATTERNS)
+  ) {
+    return "non_fast_forward";
   }
 
   if (


### PR DESCRIPTION
## Problem

The TypeScript layer has three copies of a git error-text classifier (`parseGitError` in `src/services/git/operations/types.ts`, `inferErrorTypeFromText` in `src/util/dialogs/gitErrorDialog.ts`, `inferGitErrorTypeFromText` in `createGitOperationHandler.ts`), and all three misfire on ordinary git output because broad substrings are tested in a damaging order (2026-08-28 git-system audit, worst cases proven by failing tests before the fix):

- `parseGitError` tested a bare `"auth"` substring first — a rejected push on a branch named `feature/auth-login` classified as `authentication_failed` and pushed the user into the credential-retry flow for a problem credentials cannot fix.
- Its `"connection"`/`"timeout"` patterns ran before the conflict arm — a merge conflict in `src/api/connection.ts` reported as a network error, so no conflict dialog appeared for a genuinely conflicted pull.
- It had no `non_fast_forward` or `protected_branch` arms at all, so every push rejection without a structured type landed in `unknown` (or auth per above); DNS failures (`Could not resolve host`) matched nothing and fell to `unknown`; bare `"sso"`/`"saml"` substrings fired from inside "lesson"/"processor"/"associate".
- The structured code `merge_conflict` (singular, emitted by the Rust `GitApiError` boundary) is not in `GIT_ERROR_TYPES` and was silently dropped to text sniffing.
- The dialog and handler copies tested push-rejection patterns before protected-branch ones — but git appends `error: failed to push some refs` to every rejection, so protected-branch pushes always read as "remote has newer commits, pull first," an unwinnable loop. The dialog also classified any failed fetch whose output contained a `[deleted]` line (printed by every successful `--prune`) as `remote_branch_deleted`, and reported HTTP 403s as connectivity problems.

## Solution

All three classifiers now test the most content-specific families first: uncommitted-changes → conflicts → protected-branch → non-fast-forward → auth → network. `sso`/`saml` match on word boundaries (`\b`), DNS failures classify as `network_error`, 403s as `authentication_failed`, both `merge_conflict` spellings are accepted as structured types, and `[deleted]` is removed from failure inference (with `remote ref does not exist` retained). Comments at each reorder explain the ordering constraint so it survives future edits.

This intentionally does not merge the three copies into one module — that is a refactor with its own blast radius; this PR makes the three copies correct and locks each with tests.

## Potential risks

- `parseGitError` no longer maps bare `"merge"` text (e.g. `refusing to merge unrelated histories`) to `merge_conflicts`; such messages now fall to `unknown`, which is the truthful category, but any caller that relied on the old misclassification sees a generic dialog instead of the conflict one.
- New `protected_branch`/`non_fast_forward` results from `parseGitError` flow to `remoteOps` callers that previously saw `unknown`/`authentication_failed`; the dialog layer already renders both types, and the credential-retry flow now (correctly) does not trigger for rejected pushes.
- A failed fetch whose only signal is a `[deleted]` line no longer classifies as `remote_branch_deleted`; one legacy test asserting that behavior was updated to use `remote ref does not exist`.

## Verification

- `npx vitest run src/services/git/operations/__tests__/types.test.ts src/util/dialogs/__tests__/gitErrorDialogHelpers.test.ts` → **42 passed, 0 failed**, including 7 new regression tests in `types.test.ts` (three of which were authored during the audit as `it.skip` documenting these exact bugs, verified failing against the old classifier, and are now live) and 4 new full-real-output fixtures in the dialog helpers suite (protected-branch vs plain rejection, 403-as-auth, prune-line non-classification).
- `npx vitest run src/services/git/operations/__tests__/remoteOps.test.ts` → 70 passed (consumers of `parseGitError` unaffected).
- `npx tsc --noEmit` exit 0; eslint and prettier clean on all five touched files.
- Not run: E2E through the packaged app; `createGitOperationHandler`'s classifier is exercised only indirectly (its function is module-private and the module drags UI dependencies — noted as a coverage gap in the audit).
- Built via temp index from a live checkout, so pre-commit hooks did not run (`Pre-commit hook ran.` trailer intentionally absent); checks above were run manually. Based on `develop`; independent of the #1028/#1031 stack.
