### PR TITLE
fix(git-api): add --autostash to rebase_branch

### DIFF
--- a/src-tauri/crates/git-api/src/commands/merge.rs
+++ b/src-tauri/crates/git-api/src/commands/merge.rs
@@ -8,6 +8,10 @@ use crate::types::*;
  */
 use std::path::Path;
 
+#[cfg(test)]
+#[path = "tests/merge_tests.rs"]
+mod tests;
+
 // ============================================
 // Merge Operations
 // ============================================
@@ -84,17 +88,27 @@ pub fn merge_continue(repo_path: &Path) -> Result<GitMergeResult, String> {
 // Rebase Operations
 // ============================================
 
+/// Args for `git rebase`.
+///
+/// `--autostash` for the same reason pulls carry it (see
+/// `remote::pull_strategy_args`): a bare `git rebase` refuses to start on any
+/// dirty working tree ("cannot rebase: You have unstaged changes"), even when
+/// nothing overlaps the replayed commits.
+pub(crate) fn rebase_args<'a>(upstream: &'a str, branch: Option<&'a str>) -> Vec<&'a str> {
+    let mut args = vec!["rebase", "--autostash", upstream];
+    if let Some(b) = branch {
+        args.push(b);
+    }
+    args
+}
+
 /// Rebase onto branch
 pub fn rebase_branch(
     repo_path: &Path,
     upstream: &str,
     branch: Option<&str>,
 ) -> Result<GitRebaseResult, String> {
-    let mut args = vec!["rebase", upstream];
-
-    if let Some(b) = branch {
-        args.push(b);
-    }
+    let args = rebase_args(upstream, branch);
 
     let output = run_git(repo_path, &args)?;
 

--- a/src-tauri/crates/git-api/src/commands/tests/merge_tests.rs
+++ b/src-tauri/crates/git-api/src/commands/tests/merge_tests.rs
@@ -1,0 +1,108 @@
+use crate::commands::merge::{rebase_args, rebase_branch};
+
+// ============================================
+// rebase_args
+// ============================================
+
+/// Regression: a bare `git rebase` refuses to start whenever the working tree
+/// is dirty at all ("cannot rebase: You have unstaged changes"), even when
+/// nothing overlaps the replayed commits — the same defect fixed for pulls in
+/// `pull_strategy_args`. `--autostash` must always accompany `rebase`.
+#[test]
+fn rebase_args_always_autostash() {
+    assert_eq!(
+        rebase_args("main", None),
+        vec!["rebase", "--autostash", "main"]
+    );
+    assert_eq!(
+        rebase_args("origin/main", Some("feature/x")),
+        vec!["rebase", "--autostash", "origin/main", "feature/x"]
+    );
+}
+
+// ============================================
+// rebase_branch — integration against a real repository: a rebase onto an
+// advanced base must succeed with an unrelated dirty file in the tree.
+// ============================================
+
+#[test]
+fn rebase_branch_tolerates_unrelated_dirty_file() {
+    if std::process::Command::new("git")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("skipping: git executable not available");
+        return;
+    }
+
+    let repo = std::env::temp_dir().join(format!(
+        "orgii-rebase-int-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock after epoch")
+            .as_nanos()
+    ));
+    let _ = std::fs::remove_dir_all(&repo);
+    std::fs::create_dir_all(&repo).expect("create test repo dir");
+
+    fn git_in(dir: &std::path::Path, args: &[&str]) {
+        let out = std::process::Command::new("git")
+            .arg("-C")
+            .arg(dir)
+            .args([
+                "-c",
+                "user.email=t@t",
+                "-c",
+                "user.name=t",
+                "-c",
+                "commit.gpgsign=false",
+                "-c",
+                "init.defaultBranch=main",
+            ])
+            .args(args)
+            .output()
+            .expect("spawn git");
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}{}",
+            args,
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    git_in(&repo, &["init"]);
+    std::fs::write(repo.join("base.txt"), "base\n").expect("write base");
+    git_in(&repo, &["add", "."]);
+    git_in(&repo, &["commit", "-m", "base"]);
+    git_in(&repo, &["checkout", "-b", "feature"]);
+    std::fs::write(repo.join("feature.txt"), "feature\n").expect("write feature");
+    git_in(&repo, &["add", "feature.txt"]);
+    git_in(&repo, &["commit", "-m", "feature work"]);
+    git_in(&repo, &["checkout", "main"]);
+    std::fs::write(repo.join("main.txt"), "main\n").expect("write main");
+    git_in(&repo, &["add", "main.txt"]);
+    git_in(&repo, &["commit", "-m", "main advances"]);
+    git_in(&repo, &["checkout", "feature"]);
+
+    // An unstaged edit to a tracked file that no replayed commit touches —
+    // exactly the state that used to make `git rebase` refuse outright.
+    std::fs::write(repo.join("base.txt"), "base\nuncommitted local edit\n").expect("write dirty");
+
+    let result = rebase_branch(&repo, "main", None).expect("rebase runs");
+    assert!(
+        result.success,
+        "rebase over an unrelated dirty file must succeed: {}",
+        result.message
+    );
+    assert!(!result.has_conflicts);
+    let restored = std::fs::read_to_string(repo.join("base.txt")).expect("read base.txt");
+    assert!(
+        restored.contains("uncommitted local edit") && repo.join("main.txt").exists(),
+        "dirty edit must be restored on top of the rebased branch"
+    );
+
+    let _ = std::fs::remove_dir_all(&repo);
+}


### PR DESCRIPTION
## Problem

`rebase_branch` (`crates/git-api/src/commands/merge.rs`) runs a bare `git rebase <upstream>`. Git refuses to start any rebase while the working tree is dirty — `error: cannot rebase: You have unstaged changes.` — even when the dirty files have nothing to do with the commits being replayed. So "Rebase onto main" hard-fails for anyone with a single unrelated edit, with an error message none of the classifiers map to a useful dialog. This is the exact sibling of the pull defect fixed in #1028 (the shipped default pull strategy is rebase); the pull path was fixed there, this direct-rebase path was not.

## Solution

Extract the argument construction into `rebase_args`, which always pairs `rebase` with `--autostash`, mirroring `pull_strategy_args`. With autostash, git stashes local changes, replays the branch, and restores the changes; on genuine overlap it restores them as ordinary conflict markers and additionally keeps a stash copy ("Your changes are safe in the stash") — no data loss in either case, verified for the pull twin in #1028's sandbox reproduction.

## Potential risks

- Behavior change on genuinely overlapping dirty changes: previously the rebase refused up front; now it completes and the overlap surfaces as conflict markers plus a safety stash entry. This matches standard `rebase.autostash=true` behavior and the merged pull semantics.
- Autostash restores staged changes as unstaged (standard git stash behavior).
- `rebase_continue` and the conflict flow are untouched.

## Verification

- `cargo test -p git_api --lib` → **107 passed, 0 failed**, including the new `merge_tests.rs` (the module previously had zero tests): an args regression test, and a real-repository integration test that builds a diverged feature branch, dirties a tracked file no replayed commit touches, runs `rebase_branch`, and asserts success + the dirty edit restored on top of the rebased branch. That integration test fails against the old code with `cannot rebase: You have unstaged changes`.
- `cargo fmt -p git_api --check` clean; `cargo clippy -p git_api --all-targets` no warnings.
- Not run: E2E through the packaged app.
- Based on `develop`; independent of the #1028/#1031 stack. Built via temp index from a live checkout, so pre-commit hooks did not run (`Pre-commit hook ran.` trailer intentionally absent); checks above were run manually.
