### PR TITLE
fix(git-api): auto-set upstream on streaming push

### DIFF
--- a/src-tauri/crates/git-api/src/commands/remote.rs
+++ b/src-tauri/crates/git-api/src/commands/remote.rs
@@ -355,6 +355,32 @@ pub(crate) fn contains_word(haystack: &str, needle: &str) -> bool {
     false
 }
 
+/// Whether a push should pass `-u` for the current branch.
+///
+/// - No upstream configured: yes.
+/// - Upstream on the push remote but under a different branch name (the
+///   renamed-branch scenario): yes.
+/// - Upstream already `<remote>/<current>`: no.
+/// - Upstream on a *different* remote: no — that is deliberate user
+///   configuration, and `-u` would silently overwrite it.
+///
+/// The previous implementation compared only the last `/`-segment of the
+/// upstream ref, so every branch with a slash in its name ("feat/x" vs the
+/// segment "x") re-set its upstream on every push.
+pub(crate) fn should_set_upstream(
+    upstream: Option<&str>,
+    current_branch: &str,
+    remote: &str,
+) -> bool {
+    match upstream {
+        None => true,
+        Some(upstream) => match upstream.strip_prefix(&format!("{remote}/")) {
+            Some(short) => short != current_branch,
+            None => false,
+        },
+    }
+}
+
 /// Detect error type from push error message
 pub(crate) fn detect_push_error_type(message: &str) -> GitErrorType {
     let lower = message.to_lowercase();
@@ -435,20 +461,13 @@ pub fn push_to_remote(repo_path: &Path, request: &PushRequest) -> Result<GitPush
     });
 
     // Determine if we need to set upstream
-    // Set upstream if:
-    // 1. Explicitly requested
-    // 2. No upstream exists
-    // 3. Upstream branch name doesn't match local branch name (renamed branch scenario)
     let needs_set_upstream = request.set_upstream
-        || upstream_branch.as_ref().is_none_or(|upstream| {
-            if let Some(ref current) = current_branch {
-                // Extract branch name from "origin/branch-name"
-                let upstream_short = upstream.split('/').next_back().unwrap_or(upstream);
-                upstream_short != current
-            } else {
-                false
+        || match (&current_branch, &upstream_branch) {
+            (Some(current), upstream) => {
+                should_set_upstream(upstream.as_deref(), current, remote_name)
             }
-        });
+            (None, upstream) => upstream.is_none(),
+        };
 
     let mut args = vec!["push"];
 

--- a/src-tauri/crates/git-api/src/commands/streaming.rs
+++ b/src-tauri/crates/git-api/src/commands/streaming.rs
@@ -27,7 +27,7 @@ use tokio::process::Command;
 use git::{tokio_git_command, util::is_transient_error};
 
 use super::commit::append_orgii_coauthor_trailer;
-use super::remote::{contains_word, pull_strategy_args};
+use super::remote::{contains_word, pull_strategy_args, should_set_upstream};
 
 type GitEventStream = Pin<Box<dyn Stream<Item = Result<Event, std::convert::Infallible>> + Send>>;
 
@@ -344,6 +344,29 @@ fn git_resolution_error_response(error: String) -> Response {
 // SSE Stream Handlers
 // ============================================
 
+/// `git rev-parse --abbrev-ref <spec>` — None on failure or a detached HEAD.
+async fn rev_parse_abbrev(repo_path: &std::path::Path, spec: &str) -> Option<String> {
+    let mut cmd = tokio_git_command().ok()?;
+    let output = cmd
+        .args(["rev-parse", "--abbrev-ref", spec])
+        .current_dir(repo_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .await
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if name.is_empty() || name == "HEAD" {
+        None
+    } else {
+        Some(name)
+    }
+}
+
 /// Stream git push output via Server-Sent Events
 pub async fn push_stream(
     Path(_repo_id): Path<String>,
@@ -351,8 +374,21 @@ pub async fn push_stream(
 ) -> Response {
     let repo_path = PathBuf::from(&query.path);
     let remote = query.remote.unwrap_or_else(|| "origin".to_string());
-    let set_upstream = query.set_upstream.unwrap_or(false);
     let force = query.force.unwrap_or(false);
+
+    // Mirror push_to_remote: auto-detect a missing or renamed upstream instead
+    // of trusting a client flag that defaults to false — without this, the
+    // first push of a new branch through the streaming path always failed
+    // with "the current branch has no upstream branch".
+    let current_branch = rev_parse_abbrev(&repo_path, "HEAD").await;
+    let set_upstream = if query.set_upstream.unwrap_or(false) {
+        true
+    } else if let Some(current) = current_branch.as_deref() {
+        let upstream = rev_parse_abbrev(&repo_path, &format!("{current}@{{upstream}}")).await;
+        should_set_upstream(upstream.as_deref(), current, &remote)
+    } else {
+        false
+    };
 
     let mut cmd = match tokio_git_command() {
         Ok(command) => command,
@@ -369,8 +405,11 @@ pub async fn push_stream(
     }
 
     cmd.arg(&remote);
-    if let Some(branch) = query.branch {
-        cmd.arg(&branch);
+    // `-u` needs an explicit refspec: a bare `git push -u origin` on a branch
+    // without an upstream still fails, so fall back to the current branch.
+    let branch = query.branch.or(current_branch);
+    if let Some(branch) = &branch {
+        cmd.arg(branch);
     }
 
     cmd.current_dir(&repo_path)
@@ -383,7 +422,15 @@ pub async fn push_stream(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    let command_str = format!("git push {}", remote);
+    let command_str = format!(
+        "git push{} {}{}",
+        if set_upstream { " -u" } else { "" },
+        remote,
+        branch
+            .as_deref()
+            .map(|b| format!(" {b}"))
+            .unwrap_or_default()
+    );
     let stream = stream_git_command(cmd, command_str, "push").await;
 
     sse_response(stream)

--- a/src-tauri/crates/git-api/src/commands/tests/remote_tests.rs
+++ b/src-tauri/crates/git-api/src/commands/tests/remote_tests.rs
@@ -1,6 +1,6 @@
 use crate::commands::remote::{
     contains_word, detect_fetch_error_type, detect_pull_error_type, detect_push_error_type,
-    pull_from_remote, pull_strategy_args,
+    pull_from_remote, pull_strategy_args, should_set_upstream,
 };
 use crate::types::GitErrorType;
 
@@ -163,6 +163,54 @@ fn push_error_unknown() {
         detect_push_error_type("some other error"),
         GitErrorType::Unknown,
     );
+}
+
+// ============================================
+// should_set_upstream
+// ============================================
+
+#[test]
+fn set_upstream_when_none_configured() {
+    assert!(should_set_upstream(None, "feat/x", "origin"));
+}
+
+/// Regression: the old comparison used only the last `/`-segment of the
+/// upstream ref, so "origin/feat/x" shortened to "x", never equalled
+/// "feat/x", and every slash-named branch re-set its upstream on every push.
+#[test]
+fn no_set_upstream_when_upstream_matches_slash_branch() {
+    assert!(!should_set_upstream(
+        Some("origin/feat/x"),
+        "feat/x",
+        "origin"
+    ));
+    assert!(!should_set_upstream(
+        Some("origin/feat/org2-cloud-auth"),
+        "feat/org2-cloud-auth",
+        "origin"
+    ));
+    assert!(!should_set_upstream(Some("origin/main"), "main", "origin"));
+}
+
+#[test]
+fn set_upstream_for_renamed_branch_on_same_remote() {
+    assert!(should_set_upstream(Some("origin/main"), "feat/x", "origin"));
+}
+
+/// An upstream deliberately configured on a different remote must be left
+/// alone — `-u` would silently overwrite it.
+#[test]
+fn no_set_upstream_when_upstream_is_on_another_remote() {
+    assert!(!should_set_upstream(
+        Some("upstream/feat/x"),
+        "feat/x",
+        "origin"
+    ));
+    assert!(!should_set_upstream(
+        Some("upstream/main"),
+        "main",
+        "origin"
+    ));
 }
 
 // ============================================


### PR DESCRIPTION
## Problem

Two related upstream-handling defects around push (2026-08-28 git-system audit):

1. **The streaming push can never publish a new branch.** `push_stream` trusts a client-supplied `set_upstream` flag that defaults to `false` and passes no refspec when the client omits `branch`. The first push of a newly created branch through the editor's SSE path therefore always fails with `fatal: The current branch <x> has no upstream branch`, while the identical action through the JSON endpoint succeeds because `push_to_remote` auto-detects the missing upstream.
2. **The JSON endpoint's auto-detection re-sets the upstream on every push of a slash-named branch.** It compared only the last `/`-segment of the upstream ref: for `current = "feat/x"`, `upstream = "origin/feat/x"` shortens to `"x"`, never matches, and `-u` is injected every time — silently overwriting a deliberately configured different upstream. Nearly every branch in this repo has a slash in its name.

## Solution

A single shared `should_set_upstream(upstream, current_branch, remote)` with three-way semantics, used by both paths:

- no upstream configured → set it;
- upstream on the push remote under a different name (renamed branch) → set it;
- upstream already `<remote>/<current>` → leave it;
- upstream on a *different* remote → leave it — that is deliberate configuration, and the old last-segment compare could clobber it from either direction.

`push_stream` now resolves the current branch and its upstream via `git rev-parse --abbrev-ref` (async, same resolved git binary), applies the helper unless the client explicitly requested `-u`, and falls back to the current branch as the refspec — `-u` without a refspec still fails, so the fallback is what makes first-push work. The displayed command string now reflects the real flags and refspec. Detached HEAD (no branch name) degrades to today's behavior.

## Potential risks

- Renamed-branch detection on a *different* remote no longer injects `-u` (previously it did, by accident of the segment compare). That is the intended "leave deliberate config alone" semantics, but it is a behavior change for anyone relying on the accident.
- The streaming push now runs two quick `rev-parse` invocations before spawning the push; failure of either degrades gracefully to the old no-`-u` behavior.
- A client that explicitly passes `set_upstream=true` behaves exactly as before.

## Verification

- `cargo test -p git_api --lib` → **111 passed, 0 failed**, including four new `should_set_upstream` suites: missing upstream, slash-branch match (the `origin/feat/x` vs `feat/x` regression, plus this repo's own `feat/org2-cloud-auth` shape), renamed-branch on the same remote, and different-remote preservation.
- `cargo fmt -p git_api --check` clean; `cargo clippy -p git_api --all-targets` no warnings.
- Not run: an SSE-level end-to-end test of `push_stream` (the handler is only exercisable through the axum stack; the extracted decision logic is what the unit tests pin) or E2E through the packaged app.
- **Stacked on #1031** (which is stacked on #1028) because it touches the same files; merge in order #1028 → #1031 → this. Built via temp index from a live checkout, so pre-commit hooks did not run (`Pre-commit hook ran.` trailer intentionally absent); checks above were run manually.
