### PR TITLE
fix(git): derive pull-strategy fallback from the registry

### DIFF
--- a/src/services/git/operations/__tests__/remoteOps.test.ts
+++ b/src/services/git/operations/__tests__/remoteOps.test.ts
@@ -223,12 +223,15 @@ describe("terminal fallback — the command string built for each operation", ()
     expect(execute.mock.calls).toEqual([["git pull --rebase --autostash"]]);
   });
 
-  it("falls back to merge when the strategy setting is absent altogether", async () => {
+  it("falls back to the registry default when the setting is absent", async () => {
+    // Regression: this used to fall back to a literal "merge", so an
+    // unhydrated settings atom pulled with a different strategy at startup
+    // than the shipped default ("rebase").
     const remoteOps = await loadRemoteOps({ pullStrategy: null });
 
     await remoteOps.pull();
 
-    expect(execute.mock.calls).toEqual([["git pull --no-rebase"]]);
+    expect(execute.mock.calls).toEqual([["git pull --rebase --autostash"]]);
   });
 
   it("reads the user's configured pull strategy when the caller passes none", async () => {

--- a/src/services/git/operations/remoteOps.ts
+++ b/src/services/git/operations/remoteOps.ts
@@ -3,6 +3,7 @@
  */
 import { gitApi } from "@src/api/http/git";
 import { getGitHubGitCredentialForRemote } from "@src/api/tauri/github";
+import { GIT_SETTINGS_REGISTRY } from "@src/config/settingsSchema/registry/git";
 import { showGitErrorAndHandle } from "@src/hooks/git/useGitErrorDialog";
 import { createLogger } from "@src/hooks/logger";
 import {
@@ -100,11 +101,17 @@ export async function push(
 }
 
 /**
- * Read the user's preferred pull strategy from settings
+ * Read the user's preferred pull strategy from settings.
+ * Falls back to the registry default rather than a literal: an unhydrated
+ * settings atom must not silently pull with a different strategy at startup
+ * than the one the app ships with.
  */
+const DEFAULT_PULL_STRATEGY: GitPullStrategy =
+  GIT_SETTINGS_REGISTRY["git.pullStrategy"].default;
+
 function getUserPullStrategy(): GitPullStrategy {
   const strategy = getStore().get(gitPullStrategyAtom);
-  return strategy ?? "merge";
+  return strategy ?? DEFAULT_PULL_STRATEGY;
 }
 
 /**


### PR DESCRIPTION
## Problem

`getUserPullStrategy` (`src/services/git/operations/remoteOps.ts`) falls back to a literal `"merge"` when the settings atom returns no value, while the settings registry ships `git.pullStrategy: "rebase"`. Any pull issued before settings hydration (startup, early auto-sync) therefore uses a different strategy than the same click a second later — and merge pulls do not autostash, so this intermittently reintroduces the exact dirty-tree pull block fixed in #1028. A test pinned the wrong fallback as intended behavior.

## Solution

The fallback is now read from `GIT_SETTINGS_REGISTRY["git.pullStrategy"].default` instead of a literal, so the fallback and the shipped default can never drift apart again. No behavior change for anyone whose settings are hydrated (the overwhelmingly common case).

## Potential risks

- In the unhydrated window, pulls now rebase (with autostash, per #1028) instead of merging. That matches what the same user gets once settings load; users who explicitly configured `"merge"` still get merge after hydration, and the window closes at startup.
- Imports the settings registry into `remoteOps`; the registry module is a leaf (zod + types only), so no cycle risk.

## Verification

- `npx vitest run src/services/git/operations/__tests__/remoteOps.test.ts` → **70 passed, 0 failed**; the fallback-pinning test now asserts the registry default (`git pull --rebase --autostash`) and documents the old drift in a comment.
- eslint and prettier clean on both touched files.
- Full-repo `tsc --noEmit` currently reports one error in `EditorStatusBarLeft.tsx` (`CodeIcon`) from unrelated in-flight icon work live in the shared checkout — not part of this diff; it was clean immediately before that edit appeared and neither touched file references icons.
- **Stacked on #1028** (`fix/pull-rebase-autostash`) because both files are modified there; merge #1028 first. Built via temp index from a live checkout, so pre-commit hooks did not run (`Pre-commit hook ran.` trailer intentionally absent); checks above were run manually.
