### PR TITLE
fix(git): stop fabricating stash results on no-op stashes

### DIFF
--- a/src-tauri/crates/git-api/src/commands/stash.rs
+++ b/src-tauri/crates/git-api/src/commands/stash.rs
@@ -8,6 +8,10 @@ use crate::types::*;
  */
 use std::path::Path;
 
+#[cfg(test)]
+#[path = "tests/stash_tests.rs"]
+mod tests;
+
 /// Create a stash
 pub fn stash_push(
     repo_path: &Path,
@@ -42,10 +46,16 @@ pub fn stash_push(
         return Err(String::from_utf8_lossy(&output.stderr).to_string());
     };
 
+    // `git stash push` exits 0 without stashing anything when the tree is
+    // clean ("No local changes to save"). Reporting a stash_ref in that case
+    // pointed callers at whatever unrelated stash happened to sit at
+    // stash@{0} — a destructive mis-target for any follow-up pop or drop.
+    let stashed = !message_out.contains("No local changes to save");
+
     Ok(GitStashResult {
         success: true,
         message: message_out,
-        stash_ref: Some("stash@{0}".to_string()),
+        stash_ref: stashed.then(|| "stash@{0}".to_string()),
     })
 }
 

--- a/src-tauri/crates/git-api/src/commands/tests/stash_tests.rs
+++ b/src-tauri/crates/git-api/src/commands/tests/stash_tests.rs
@@ -1,0 +1,94 @@
+use crate::commands::stash::{stash_list, stash_push};
+
+fn git_in(dir: &std::path::Path, args: &[&str]) {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args([
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "-c",
+            "commit.gpgsign=false",
+            "-c",
+            "init.defaultBranch=main",
+        ])
+        .args(args)
+        .output()
+        .expect("spawn git");
+    assert!(
+        out.status.success(),
+        "git {:?} failed: {}{}",
+        args,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Regression: `git stash push` exits 0 on a clean tree without stashing
+/// anything, and stash_push used to report `success: true` with a hardcoded
+/// `stash@{0}` anyway — pointing callers at whatever unrelated stash was on
+/// top, which a follow-up "pop what I just stashed" would then destroy.
+#[test]
+fn stash_push_reports_noop_and_real_stashes_truthfully() {
+    if std::process::Command::new("git")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("skipping: git executable not available");
+        return;
+    }
+
+    let repo = std::env::temp_dir().join(format!(
+        "orgii-stash-int-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock after epoch")
+            .as_nanos()
+    ));
+    let _ = std::fs::remove_dir_all(&repo);
+    std::fs::create_dir_all(&repo).expect("create test repo dir");
+
+    git_in(&repo, &["init"]);
+    std::fs::write(repo.join("a.txt"), "one\n").expect("write a.txt");
+    git_in(&repo, &["add", "."]);
+    git_in(&repo, &["commit", "-m", "init"]);
+
+    // A pre-existing stash sits at stash@{0} — the entry the old fabricated
+    // ref would have mis-targeted.
+    std::fs::write(repo.join("a.txt"), "one\nolder stashed edit\n").expect("dirty a.txt");
+    let older = stash_push(&repo, None, Some("older stash"), false).expect("stash runs");
+    assert!(older.success);
+    assert_eq!(older.stash_ref.as_deref(), Some("stash@{0}"));
+
+    // Clean tree: the push is a no-op and must NOT hand back a stash_ref.
+    let noop = stash_push(&repo, None, Some("noop"), false).expect("stash runs");
+    assert!(noop.success, "a no-op stash is not a failure");
+    assert_eq!(
+        noop.stash_ref, None,
+        "no stash was created, so no ref may be reported: {}",
+        noop.message
+    );
+    assert!(noop.message.contains("No local changes to save"));
+
+    // The pre-existing stash must still be the only entry.
+    let entries = stash_list(&repo).expect("stash list");
+    assert_eq!(entries.len(), 1);
+
+    // A genuinely dirty tree stashes and reports the new top entry.
+    std::fs::write(repo.join("a.txt"), "one\nnewer edit\n").expect("dirty a.txt");
+    let real = stash_push(&repo, None, Some("real stash"), false).expect("stash runs");
+    assert!(real.success);
+    assert_eq!(real.stash_ref.as_deref(), Some("stash@{0}"));
+    assert_eq!(stash_list(&repo).expect("stash list").len(), 2);
+    let restored = std::fs::read_to_string(repo.join("a.txt")).expect("read a.txt");
+    assert!(
+        !restored.contains("newer edit"),
+        "the dirty edit must actually have been stashed away"
+    );
+
+    let _ = std::fs::remove_dir_all(&repo);
+}

--- a/src/services/git/operations/__tests__/TEST_CASES.md
+++ b/src/services/git/operations/__tests__/TEST_CASES.md
@@ -40,6 +40,7 @@ cancel) via an injected `onConflict` callback.
 | 2   | Missing error message      | failure with no `error` field                         | message falls back to `Failed to checkout branch "<ref>"`                     |
 | 3   | Checkout throws            | `gitCheckout` rejects                                 | `{ success:false, outcome:"error", errorType:"other", message:<err> }`        |
 | 4   | Stash push returns nothing | conflict → stash → `undefined`                        | `{ success:false, outcome:"error", message:"Failed to stash changes" }`       |
+| 4b  | Stash push reports failure | conflict → stash → `{ success:false, message }` (the shape the wrapper actually returns on error) | `{ success:false, outcome:"error", message:<stash error> }`; no checkout attempted |
 | 5   | Post-stash checkout fails  | conflict → stash ok → re-checkout fails               | `{ success:false, outcome:"error", message:<checkout error> }`                |
 | 6   | Stash push throws          | conflict → stash rejects                              | `{ success:false, outcome:"error", message:"Failed to stash and checkout" }`  |
 | 7   | Force checkout fails       | conflict → force checkout fails                       | `{ success:false, outcome:"error", message:<force error> }`                   |

--- a/src/services/git/operations/__tests__/guardedCheckout.test.ts
+++ b/src/services/git/operations/__tests__/guardedCheckout.test.ts
@@ -216,6 +216,34 @@ describe("runGuardedCheckout — uncommitted_changes → stash", () => {
     expect(gitCheckout).toHaveBeenCalledTimes(1);
   });
 
+  // Regression: gitStashPush never actually returns undefined on error — its
+  // wrapper catches and returns { success: false, message } — and the old
+  // undefined-only guard let that sail into a checkout on a still-dirty tree.
+  it("returns an error when the stash push reports failure", async () => {
+    gitCheckout.mockResolvedValueOnce({
+      success: false,
+      errorType: "uncommitted_changes",
+    });
+    gitStashPush.mockResolvedValueOnce({
+      success: false,
+      message: "fatal: unable to write new index file",
+      stash_ref: null,
+    });
+
+    const result = await runGuardedCheckout({
+      ...BASE,
+      onConflict: conflict("stash"),
+    });
+
+    expect(result).toEqual({
+      success: false,
+      outcome: "error",
+      errorType: "uncommitted_changes",
+      message: "fatal: unable to write new index file",
+    });
+    expect(gitCheckout).toHaveBeenCalledTimes(1);
+  });
+
   it("returns an error when the post-stash checkout fails", async () => {
     gitCheckout
       .mockResolvedValueOnce({

--- a/src/services/git/operations/guardedCheckout.ts
+++ b/src/services/git/operations/guardedCheckout.ts
@@ -108,8 +108,15 @@ async function stashAndCheckout(
       include_untracked: true,
     });
 
-    if (!stashResult) {
-      return failure("uncommitted_changes", "Failed to stash changes");
+    // gitStashPush never returns undefined on error — its wrapper catches and
+    // returns { success: false, message } — so the success flag is the only
+    // real failure signal. Proceeding past a failed stash would attempt the
+    // checkout on a still-dirty tree and report a misleading generic error.
+    if (!stashResult?.success) {
+      return failure(
+        "uncommitted_changes",
+        stashResult?.message || "Failed to stash changes"
+      );
     }
 
     const checkoutResult = await gitApi.gitCheckout({


### PR DESCRIPTION
## Problem

Two stash defects from the 2026-08-28 git-system audit, one Rust and one TS, that combine into destructive behavior:

1. **`stash_push` fabricates its result on a no-op.** `git stash push` on a clean tree prints `No local changes to save` and exits 0; the handler returned `success: true` with a hardcoded `stash_ref: "stash@{0}"` anyway. If the user has any pre-existing stash, that ref points at an **unrelated** entry — a follow-up "pop/drop what I just stashed" then operates on the wrong stash, destructively.
2. **`runGuardedCheckout` proceeds after a failed stash.** It guarded with `if (!stashResult)`, but `gitApi.gitStashPush` never returns `undefined` on error — its wrapper catches and returns `{ success: false, message }`, which is truthy. A failed stash therefore sailed into the checkout on a still-dirty tree, which failed again and surfaced as a generic "Cannot Switch Branch" instead of the real stash error. The test suite covered the `undefined` shape that cannot occur and missed the one that can.

## Solution

- `stash_push` detects the no-op (`No local changes to save`) and returns `success: true` with `stash_ref: None` — the command succeeded, nothing was stashed, and no ref is invented. A genuine stash still reports `stash@{0}`, which is always the fresh entry immediately after a successful push.
- `runGuardedCheckout` branches on `stashResult?.success` and propagates the stash's own error message; no checkout is attempted after a failed stash.

## Potential risks

- Any caller that relied on `stash_ref` always being present after `stash_push` now sees `null` for no-ops. Repo-wide, callers either ignore the ref or use it for display; the audit's C-2 flow (pop-by-index) is unaffected by this PR and remains a known separate defect.
- The no-op detection is substring-based on git's English output; git does not localize plumbing-adjacent messages by default in our invocation environment (no `LANG` override is set for these calls, matching every other classifier in the crate).

## Verification

- `cargo test -p git_api --lib` → **112 passed, 0 failed**, including the new `stash_tests.rs` (the module previously had zero tests): a real-repository integration test that creates a pre-existing stash, asserts a clean-tree push returns `success: true` + `stash_ref: None` while leaving the older stash untouched as the only entry, then asserts a genuinely dirty push stashes, reports `stash@{0}`, and actually removes the edit from the tree.
- `npx vitest run` on `guardedCheckout.test.ts` + `guardedCheckoutRecoveryFallbacks.test.ts` → **17 passed**, including the new regression test feeding the `{ success: false, message }` shape the wrapper actually produces and asserting no checkout is attempted; `TEST_CASES.md` gains the matching row 4b.
- `cargo fmt --check`, clippy, eslint, prettier all clean on touched files.
- Not run: E2E through the packaged app.
- Based on `develop`; independent of the open git-fix stacks. Built via temp index from a live checkout, so pre-commit hooks did not run (`Pre-commit hook ran.` trailer intentionally absent); checks above were run manually.
