### PR TITLE
fix(source-control): restore the stash after Stash & Pull

### DIFF
--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useSourceControlState/index.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useSourceControlState/index.ts
@@ -256,6 +256,7 @@ export function useSourceControlState(
     behind,
     hasUpstream,
     stashPush,
+    stashPop,
     fetchGitStatus,
     refreshStashes,
     onCreatePrRef,

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useSourceControlState/pullErrorHandlers.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useSourceControlState/pullErrorHandlers.test.ts
@@ -1,0 +1,147 @@
+/**
+ * handlePullError — the "Stash & Pull" / "Discard & Pull" recovery flow.
+ *
+ * Regression focus: the stash path used to stash WITHOUT untracked files and
+ * never restored the stash — the user's changes vanished into stash@{0}
+ * behind a "Changes stashed" toast.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GitFile } from "@src/types/git/types";
+
+import { handlePullError } from "./pullErrorHandlers";
+
+vi.mock("@src/components/GitDialogs", () => ({
+  PullConflictDialog: { open: vi.fn() },
+  RebaseConflictDialog: { open: vi.fn() },
+}));
+
+const { PullConflictDialog, RebaseConflictDialog } =
+  await import("@src/components/GitDialogs");
+
+const pullConflictOpen = vi.mocked(PullConflictDialog.open);
+const rebaseConflictOpen = vi.mocked(RebaseConflictDialog.open);
+
+function makeFile(path: string, staged = false): GitFile {
+  return { path, staged, status: "modified" } as unknown as GitFile;
+}
+
+function makeOptions(
+  overrides: Partial<Parameters<typeof handlePullError>[0]> = {}
+) {
+  return {
+    pullResult: { success: false, errorType: "uncommitted_changes" as const },
+    currentBranch: "feature/x",
+    currentFiles: [makeFile("src/a.ts")],
+    doPull: vi.fn().mockResolvedValue({ success: true, errorType: "none" }),
+    stashPush: vi.fn().mockResolvedValue(true),
+    stashPop: vi.fn().mockResolvedValue(true),
+    dispatch: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("handlePullError — uncommitted_changes → Stash & Pull", () => {
+  it("stashes with untracked files, retries the pull, and restores the stash", async () => {
+    pullConflictOpen.mockResolvedValueOnce("stash_pull");
+    const options = makeOptions();
+
+    const handled = await handlePullError(options);
+
+    expect(handled).toBe(true);
+    expect(options.stashPush).toHaveBeenCalledWith(
+      "Auto-stash before pulling into feature/x",
+      true
+    );
+    expect(options.doPull).toHaveBeenCalledTimes(1);
+    // The restore is the point of "Stash & Pull": the user asked to pull,
+    // not to move their changes into the stash.
+    expect(options.stashPop).toHaveBeenCalledWith(0);
+    const pushOrder = options.stashPush.mock.invocationCallOrder[0];
+    const pullOrder = options.doPull.mock.invocationCallOrder[0];
+    const popOrder = options.stashPop.mock.invocationCallOrder[0];
+    expect(pushOrder).toBeLessThan(pullOrder);
+    expect(pullOrder).toBeLessThan(popOrder);
+  });
+
+  it("still attempts the restore when the retried pull fails", async () => {
+    pullConflictOpen.mockResolvedValueOnce("stash_pull");
+    const options = makeOptions({
+      doPull: vi
+        .fn()
+        .mockResolvedValue({ success: false, errorType: "unknown" }),
+    });
+
+    const handled = await handlePullError(options);
+
+    expect(handled).toBe(true);
+    expect(options.stashPop).toHaveBeenCalledWith(0);
+  });
+
+  it("does not retry the pull or pop when the stash itself fails", async () => {
+    pullConflictOpen.mockResolvedValueOnce("stash_pull");
+    const options = makeOptions({
+      stashPush: vi.fn().mockResolvedValue(false),
+    });
+
+    const handled = await handlePullError(options);
+
+    expect(handled).toBe(true);
+    expect(options.doPull).not.toHaveBeenCalled();
+    expect(options.stashPop).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the user cancels the dialog", async () => {
+    pullConflictOpen.mockResolvedValueOnce("cancel");
+    const options = makeOptions();
+
+    const handled = await handlePullError(options);
+
+    expect(handled).toBe(true);
+    expect(options.stashPush).not.toHaveBeenCalled();
+    expect(options.doPull).not.toHaveBeenCalled();
+    expect(options.stashPop).not.toHaveBeenCalled();
+  });
+
+  it("offers only unstaged files in the dialog listing", async () => {
+    pullConflictOpen.mockResolvedValueOnce("cancel");
+    const options = makeOptions({
+      currentFiles: [makeFile("a.ts"), makeFile("b.ts", true)],
+    });
+
+    await handlePullError(options);
+
+    expect(pullConflictOpen).toHaveBeenCalledWith(
+      expect.objectContaining({ conflictingFiles: ["a.ts"] })
+    );
+  });
+});
+
+describe("handlePullError — other error types", () => {
+  it("dispatches merge abort when the user aborts a conflicted pull", async () => {
+    rebaseConflictOpen.mockResolvedValueOnce("abort");
+    const options = makeOptions({
+      pullResult: { success: false, errorType: "merge_conflicts" },
+    });
+
+    const handled = await handlePullError(options);
+
+    expect(handled).toBe(true);
+    expect(options.dispatch).toHaveBeenCalledWith("git.mergeAbort", {}, "user");
+  });
+
+  it("returns false for unrecognized error types", async () => {
+    const options = makeOptions({
+      pullResult: { success: false, errorType: "network_error" },
+    });
+
+    const handled = await handlePullError(options);
+
+    expect(handled).toBe(false);
+    expect(pullConflictOpen).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useSourceControlState/pullErrorHandlers.test.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useSourceControlState/pullErrorHandlers.test.ts
@@ -48,24 +48,30 @@ beforeEach(() => {
 describe("handlePullError — uncommitted_changes → Stash & Pull", () => {
   it("stashes with untracked files, retries the pull, and restores the stash", async () => {
     pullConflictOpen.mockResolvedValueOnce("stash_pull");
-    const options = makeOptions();
+    const stashPush = vi.fn().mockResolvedValue(true);
+    const doPull = vi
+      .fn()
+      .mockResolvedValue({ success: true, errorType: "none" as const });
+    const stashPop = vi.fn().mockResolvedValue(true);
+    const options = makeOptions({ stashPush, doPull, stashPop });
 
     const handled = await handlePullError(options);
 
     expect(handled).toBe(true);
-    expect(options.stashPush).toHaveBeenCalledWith(
+    expect(stashPush).toHaveBeenCalledWith(
       "Auto-stash before pulling into feature/x",
       true
     );
-    expect(options.doPull).toHaveBeenCalledTimes(1);
+    expect(doPull).toHaveBeenCalledTimes(1);
     // The restore is the point of "Stash & Pull": the user asked to pull,
     // not to move their changes into the stash.
-    expect(options.stashPop).toHaveBeenCalledWith(0);
-    const pushOrder = options.stashPush.mock.invocationCallOrder[0];
-    const pullOrder = options.doPull.mock.invocationCallOrder[0];
-    const popOrder = options.stashPop.mock.invocationCallOrder[0];
-    expect(pushOrder).toBeLessThan(pullOrder);
-    expect(pullOrder).toBeLessThan(popOrder);
+    expect(stashPop).toHaveBeenCalledWith(0);
+    expect(stashPush.mock.invocationCallOrder[0]).toBeLessThan(
+      doPull.mock.invocationCallOrder[0]
+    );
+    expect(doPull.mock.invocationCallOrder[0]).toBeLessThan(
+      stashPop.mock.invocationCallOrder[0]
+    );
   });
 
   it("still attempts the restore when the retried pull fails", async () => {

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useSourceControlState/pullErrorHandlers.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useSourceControlState/pullErrorHandlers.ts
@@ -19,6 +19,7 @@ export interface HandlePullErrorOptions {
   currentFiles: GitFile[];
   doPull: () => Promise<GitOperationResult>;
   stashPush: (message?: string, includeUntracked?: boolean) => Promise<boolean>;
+  stashPop: (index: number) => Promise<boolean>;
   dispatch: TypedDispatch | undefined;
 }
 
@@ -33,6 +34,7 @@ export async function handlePullError({
   currentFiles,
   doPull,
   stashPush,
+  stashPop,
   dispatch,
 }: HandlePullErrorOptions): Promise<boolean> {
   if (pullResult.errorType === "uncommitted_changes") {
@@ -46,11 +48,30 @@ export async function handlePullError({
     });
 
     if (result === "stash_pull") {
-      await stashPush();
+      // Include untracked files: a pull is blocked by an untracked file
+      // about to be overwritten just as easily as by a tracked one, and the
+      // user chose to stash their local changes wholesale.
+      const stashed = await stashPush(
+        `Auto-stash before pulling into ${currentBranch || "current branch"}`,
+        true
+      );
+      if (!stashed) {
+        // stashPush surfaces its own failure toast; retrying the pull on a
+        // still-dirty tree would only reproduce the error it just showed.
+        log.error("Stash failed; pull not retried");
+        return true;
+      }
       const retryPull = await doPull();
       if (!retryPull.success) {
         log.error("Pull failed after stash");
       }
+      // Restore regardless of the retry's outcome — the user chose "stash
+      // and pull", not "move my changes into the stash". The stash was
+      // pushed onto the tree one operation ago, so the fresh entry is at
+      // index 0 (a rebase pull creates no autostash on a clean tree). If
+      // the pop conflicts with the pulled commits, git keeps the entry and
+      // stashPop surfaces its failure toast, so nothing is silently lost.
+      await stashPop(0);
     } else if (result === "discard_pull") {
       const allFilePaths = currentFiles.map((file: GitFile) => file.path);
       if (allFilePaths.length > 0 && dispatch) {

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useSourceControlState/useSyncOperations.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useSourceControlState/useSyncOperations.ts
@@ -41,6 +41,7 @@ export interface UseSyncOperationsOptions {
   /** Whether the current branch has an upstream (remote tracking branch) */
   hasUpstream: boolean;
   stashPush: (message?: string, includeUntracked?: boolean) => Promise<boolean>;
+  stashPop: (index: number) => Promise<boolean>;
   fetchGitStatus: () => Promise<void>;
   refreshStashes: () => Promise<void>;
   /** Ref to PR creation handler (used when push hits a protected branch) */
@@ -90,6 +91,7 @@ export function useSyncOperations(
     behind,
     hasUpstream,
     stashPush,
+    stashPop,
     fetchGitStatus,
     refreshStashes,
     onCreatePrRef,
@@ -243,6 +245,7 @@ export function useSyncOperations(
           currentFiles: filesRef.current,
           doPull,
           stashPush,
+          stashPop,
           dispatch,
         });
         if (!handled) {
@@ -322,6 +325,7 @@ export function useSyncOperations(
     doPush,
     currentBranch,
     stashPush,
+    stashPop,
     dispatch,
     handleProtectedBranch,
   ]);
@@ -341,6 +345,7 @@ export function useSyncOperations(
           currentFiles: filesRef.current,
           doPull,
           stashPush,
+          stashPop,
           dispatch,
         });
         if (!handled) {
@@ -359,7 +364,15 @@ export function useSyncOperations(
     } finally {
       setPullLoading(false);
     }
-  }, [selectedRepoId, pullLoading, doPull, currentBranch, stashPush, dispatch]);
+  }, [
+    selectedRepoId,
+    pullLoading,
+    doPull,
+    currentBranch,
+    stashPush,
+    stashPop,
+    dispatch,
+  ]);
 
   // Handle standalone push (with preflight fetch + error dialog handling)
   // Fetches first so we can detect remote changes before pushing,


### PR DESCRIPTION
## Problem

The Source Control panel's primary recovery flow for a blocked pull — the "Stash & Pull" button on `PullConflictDialog`, reached from both Sync and Pull — loses the user's work (2026-08-28 git-system audit, C-2):

- `stashPush()` was called with no arguments, so `includeUntracked` defaulted to `false`. A pull blocked by an untracked file about to be overwritten stashed nothing useful and failed again immediately.
- **The stash was never restored.** The user picked "Stash & Pull" — pull my changes in around my work — and instead their working tree went clean, the changes sat in `stash@{0}`, and the only signal was a generic "Changes stashed" toast. If the retried pull failed, the outcome was a line in the JS console.
- A failed stash push sailed straight into the retry, which reproduced the very error dialog the user had just answered.

## Solution

`handlePullError` now threads `stashPop` from `useStashState` (through `useSyncOperations` and the state index) and:

1. stashes **with untracked files** and a descriptive message;
2. aborts the retry if the stash itself failed (`stashPush` already surfaces its own failure toast);
3. retries the pull;
4. **pops the stash back regardless of the retry's outcome** — the invariant is that "Stash & Pull" never leaves the user's changes parked in the stash silently. The stash is pushed onto the tree one operation before the pop, so the fresh entry is index 0 (a rebase pull creates no autostash on a clean tree). If the pop conflicts with the pulled commits, git keeps the entry and `stashPop`'s existing failure toast points at it.

## Potential risks

- When the stashed changes genuinely overlap the pulled commits, the restore now surfaces conflict markers (or a pop-failed toast with the stash preserved) where previously the changes stayed hidden in the stash. That is the intended semantics and matches the autostash behavior shipped in #1028, but it is a visible change to this dialog's aftermath.
- The index-0 pop assumes no concurrent stash creation between push and pop (one pull operation apart). Addressing stashes by identity (commit id) requires backend `stash_list` enrichment — filed as follow-up in the audit (finding H-6/#23); this PR deliberately does not depend on it.
- `useSyncOperations` gains `stashPop` in two dependency arrays; the function identity comes from `useCallback` in `useStashState`.

## Verification

- New `pullErrorHandlers.test.ts` (this module's first tests): **7 passed** — stash-with-untracked + retry + restore ordering (asserted via invocation order), restore attempted even when the retry fails, no retry/no pop after a failed stash, cancel does nothing, unstaged-only file listing, merge-abort dispatch, unrecognized-type passthrough.
- eslint (including hooks/exhaustive-deps on the touched dependency arrays), prettier, and `pnpm run check:test-placement` clean.
- Full-repo `tsc` currently reports one unrelated error from in-flight icon work live in the shared checkout (`EditorStatusBarLeft.tsx`); none of the touched files reference it.
- Not run: E2E through the packaged app; the sibling dialog flow in `useGitErrorDialog` (`stashAndRetryOperation`) has the same class of defects and is deliberately left for its own PR.
- Based on `develop`; independent of the open git-fix stacks. Built via temp index from a live checkout, so pre-commit hooks did not run (`Pre-commit hook ran.` trailer intentionally absent); checks above were run manually.
