### PR TITLE
fix(git): fail loudly instead of typing commands into the terminal

### DIFF
--- a/src/services/git/operations/__tests__/remoteOps.test.ts
+++ b/src/services/git/operations/__tests__/remoteOps.test.ts
@@ -4,8 +4,8 @@
  * sync) and their error-dialog variants.
  *
  * These operate on the user's real repository, so the assertions target the
- * request actually constructed — the exact terminal command string, or the
- * exact payload handed to the Rust git API — plus the value returned. In
+ * request actually constructed — the exact payload handed to the Rust git
+ * API — plus the value returned. In
  * particular, every destructive flag (`force`, `set_upstream`, `prune`) is
  * asserted to be absent unless the caller explicitly asked for it.
  *
@@ -147,116 +147,101 @@ beforeEach(() => {
 });
 
 // ============================================
-// Terminal fallback — exact command strings
+// No repository context
 // ============================================
 
-describe("terminal fallback — the command string built for each operation", () => {
-  it("pushes without any force flag by default", async () => {
+describe("no repository context — loud failure, nothing executed", () => {
+  // These operations used to fall back to typing the git command into the
+  // user's visible terminal (whatever cwd it was in) and reported success
+  // the moment Enter was delivered. Without a repo context there is nowhere
+  // trustworthy to run git, so the operation must fail loudly instead.
+  const NO_REPO_FAILURE = {
+    success: false,
+    errorType: "unknown",
+    message: expect.stringContaining("No repository is selected"),
+  };
+
+  it("fails a push and never touches the terminal", async () => {
     const remoteOps = await loadRemoteOps();
 
-    await expect(remoteOps.push()).resolves.toEqual({
-      success: true,
-      errorType: "none",
-    });
-    expect(execute.mock.calls).toEqual([["git push"]]);
+    await expect(remoteOps.push({ force: true })).resolves.toEqual(
+      NO_REPO_FAILURE
+    );
+    expect(execute).not.toHaveBeenCalled();
+    expect(gitPush).not.toHaveBeenCalled();
   });
 
-  it("adds --force only when force is explicitly requested", async () => {
+  it("fails a publish instead of silently dropping --set-upstream", async () => {
     const remoteOps = await loadRemoteOps();
 
-    await remoteOps.push({ force: true });
-
-    expect(execute.mock.calls).toEqual([["git push --force"]]);
+    await expect(remoteOps.publish()).resolves.toEqual(NO_REPO_FAILURE);
+    expect(execute).not.toHaveBeenCalled();
   });
 
-  it("never adds --force for a falsy force flag", async () => {
+  it("fails a pull for every strategy", async () => {
     const remoteOps = await loadRemoteOps();
 
-    await remoteOps.push({ force: false });
-    await remoteOps.push({ force: undefined });
-
-    expect(execute.mock.calls).toEqual([["git push"], ["git push"]]);
+    for (const strategy of ["merge", "rebase", "ff-only"] as const) {
+      await expect(remoteOps.pull({ strategy })).resolves.toEqual(
+        NO_REPO_FAILURE
+      );
+    }
+    expect(execute).not.toHaveBeenCalled();
+    expect(gitPull).not.toHaveBeenCalled();
   });
 
-  it("publishes with a plain push, silently dropping --set-upstream (see report)", async () => {
+  it("fails a fetch", async () => {
     const remoteOps = await loadRemoteOps();
 
-    await remoteOps.publish();
-
-    // The terminal branch only ever varies on `force`; `setUpstream`,
-    // `remote`, and `branch` are dropped. Asserted so the omission is visible.
-    expect(execute.mock.calls).toEqual([["git push"]]);
+    await expect(remoteOps.fetch({ prune: true })).resolves.toEqual(
+      NO_REPO_FAILURE
+    );
+    expect(execute).not.toHaveBeenCalled();
   });
 
-  it("ignores remote and branch on the terminal branch", async () => {
+  it("fails a sync at its first step", async () => {
     const remoteOps = await loadRemoteOps();
 
-    await remoteOps.push({ remote: "upstream", branch: "feature" });
-
-    expect(execute.mock.calls).toEqual([["git push"]]);
+    await expect(remoteOps.sync()).resolves.toEqual(NO_REPO_FAILURE);
+    expect(execute).not.toHaveBeenCalled();
+    expect(gitPull).not.toHaveBeenCalled();
+    expect(gitPush).not.toHaveBeenCalled();
   });
+});
 
-  it("pulls with an explicit --no-rebase when the strategy is merge", async () => {
-    const remoteOps = await loadRemoteOps();
+// ============================================
+// Pull strategy resolution
+// ============================================
 
-    await remoteOps.pull({ strategy: "merge" });
-
-    expect(execute.mock.calls).toEqual([["git pull --no-rebase"]]);
-  });
-
-  it("pulls with --rebase and --ff-only for the other strategies", async () => {
-    const rebase = await loadRemoteOps();
-    await rebase.pull({ strategy: "rebase" });
-    expect(execute.mock.calls).toEqual([["git pull --rebase --autostash"]]);
-
-    execute.mockClear();
-    const ffOnly = await loadRemoteOps();
-    await ffOnly.pull({ strategy: "ff-only" });
-    expect(execute.mock.calls).toEqual([["git pull --ff-only"]]);
-  });
+describe("pull strategy resolution — the strategy sent to the git API", () => {
+  async function pulledStrategy(
+    options: Parameters<typeof loadRemoteOps>[0] = {},
+    callArg?: { strategy?: GitPullStrategy }
+  ) {
+    const remoteOps = await loadRemoteOps({ repo: REPO, ...options });
+    await remoteOps.pull(callArg);
+    return gitPull.mock.calls[0][0].strategy;
+  }
 
   it("uses the shipped default strategy (rebase) when the caller passes none", async () => {
-    const remoteOps = await loadRemoteOps();
-
-    await remoteOps.pull();
-
-    expect(execute.mock.calls).toEqual([["git pull --rebase --autostash"]]);
+    expect(await pulledStrategy()).toBe("rebase");
   });
 
   it("falls back to the registry default when the setting is absent", async () => {
     // Regression: this used to fall back to a literal "merge", so an
     // unhydrated settings atom pulled with a different strategy at startup
     // than the shipped default ("rebase").
-    const remoteOps = await loadRemoteOps({ pullStrategy: null });
-
-    await remoteOps.pull();
-
-    expect(execute.mock.calls).toEqual([["git pull --rebase --autostash"]]);
+    expect(await pulledStrategy({ pullStrategy: null })).toBe("rebase");
   });
 
   it("reads the user's configured pull strategy when the caller passes none", async () => {
-    const remoteOps = await loadRemoteOps({ pullStrategy: "rebase" });
-
-    await remoteOps.pull();
-
-    expect(execute.mock.calls).toEqual([["git pull --rebase --autostash"]]);
+    expect(await pulledStrategy({ pullStrategy: "merge" })).toBe("merge");
   });
 
   it("lets an explicit strategy override the configured one", async () => {
-    const remoteOps = await loadRemoteOps({ pullStrategy: "rebase" });
-
-    await remoteOps.pull({ strategy: "ff-only" });
-
-    expect(execute.mock.calls).toEqual([["git pull --ff-only"]]);
-  });
-
-  it("fetches without a prune flag", async () => {
-    const remoteOps = await loadRemoteOps();
-
-    await remoteOps.fetch({ prune: true });
-
-    // `prune` has no terminal representation either.
-    expect(execute.mock.calls).toEqual([["git fetch"]]);
+    expect(
+      await pulledStrategy({ pullStrategy: "rebase" }, { strategy: "ff-only" })
+    ).toBe("ff-only");
   });
 });
 
@@ -450,26 +435,15 @@ describe("error translation from git stderr", () => {
     });
   });
 
-  it("translates a terminal-branch failure through the same classifier", async () => {
-    const remoteOps = await loadRemoteOps();
-    execute.mockRejectedValueOnce(new Error("fatal: not a git repository"));
+  it("translates a fetch failure through the same classifier", async () => {
+    const remoteOps = await loadRemoteOps({ repo: REPO });
+    gitFetch.mockRejectedValueOnce(new Error("fatal: not a git repository"));
 
     await expect(remoteOps.fetch()).resolves.toEqual({
       success: false,
       errorType: "unknown",
       message: "fatal: not a git repository",
     });
-  });
-
-  it("does not run the auth retry for a terminal-branch auth failure", async () => {
-    const remoteOps = await loadRemoteOps();
-    execute.mockRejectedValueOnce(new Error("Authentication failed"));
-
-    await expect(remoteOps.push()).resolves.toMatchObject({
-      errorType: "authentication_failed",
-    });
-    expect(showGitAuthenticationDialog).not.toHaveBeenCalled();
-    expect(gitPush).not.toHaveBeenCalled();
   });
 });
 
@@ -735,16 +709,17 @@ describe("credential resolution", () => {
     expect(showGitAuthenticationDialog).not.toHaveBeenCalled();
   });
 
-  it("reports unknown rather than retrying blind when no repo context exists", async () => {
-    // No repo context means the terminal branch runs, and its auth failure
-    // never reaches the retry helpers.
+  it("fails loudly rather than retrying blind when no repo context exists", async () => {
+    // No repo context: the operation must not reach the API, the credential
+    // retry, or the auth dialog — there is nothing meaningful to retry.
     const remoteOps = await loadRemoteOps();
-    execute.mockRejectedValue(new Error("Authentication failed"));
 
     await expect(remoteOps.push()).resolves.toMatchObject({
-      errorType: "authentication_failed",
+      errorType: "unknown",
+      message: expect.stringContaining("No repository is selected"),
     });
     expect(gitPush).not.toHaveBeenCalled();
+    expect(showGitAuthenticationDialog).not.toHaveBeenCalled();
   });
 
   it("resolves a stored credential through the dialog callback", async () => {
@@ -1295,48 +1270,49 @@ describe("output integration path", () => {
 
 describe("sync", () => {
   it("fetches, then pulls, then pushes, in that order", async () => {
-    const remoteOps = await loadRemoteOps();
+    const remoteOps = await loadRemoteOps({ repo: REPO });
 
     await expect(remoteOps.sync()).resolves.toEqual({
       success: true,
       errorType: "none",
     });
 
-    expect(execute.mock.calls).toEqual([
-      ["git fetch"],
-      ["git pull --rebase --autostash"],
-      ["git push"],
-    ]);
+    expect(gitFetch).toHaveBeenCalledTimes(1);
+    expect(gitPull).toHaveBeenCalledTimes(1);
+    expect(gitPush).toHaveBeenCalledTimes(1);
+    expect(gitFetch.mock.invocationCallOrder[0]).toBeLessThan(
+      gitPull.mock.invocationCallOrder[0]
+    );
+    expect(gitPull.mock.invocationCallOrder[0]).toBeLessThan(
+      gitPush.mock.invocationCallOrder[0]
+    );
   });
 
   it("never pushes when the preflight fetch fails", async () => {
-    const remoteOps = await loadRemoteOps();
-    execute.mockRejectedValueOnce(
+    const remoteOps = await loadRemoteOps({ repo: REPO });
+    gitFetch.mockRejectedValueOnce(
       new Error("fatal: could not read from remote")
     );
 
     await expect(remoteOps.sync()).resolves.toMatchObject({ success: false });
 
-    expect(execute.mock.calls).toEqual([["git fetch"]]);
+    expect(gitPull).not.toHaveBeenCalled();
+    expect(gitPush).not.toHaveBeenCalled();
   });
 
   it("never pushes when the pull fails", async () => {
-    const remoteOps = await loadRemoteOps();
-    execute
-      .mockResolvedValueOnce(undefined)
-      .mockRejectedValueOnce(
-        new Error("CONFLICT (content): Merge conflict in src/app.ts")
-      );
+    const remoteOps = await loadRemoteOps({ repo: REPO });
+    gitPull.mockRejectedValueOnce(
+      new Error("CONFLICT (content): Merge conflict in src/app.ts")
+    );
 
     await expect(remoteOps.sync()).resolves.toMatchObject({
       success: false,
       errorType: "merge_conflicts",
     });
 
-    expect(execute.mock.calls).toEqual([
-      ["git fetch"],
-      ["git pull --rebase --autostash"],
-    ]);
+    expect(gitFetch).toHaveBeenCalledTimes(1);
+    expect(gitPush).not.toHaveBeenCalled();
   });
 
   it("never pushes with force", async () => {

--- a/src/services/git/operations/branchOps.ts
+++ b/src/services/git/operations/branchOps.ts
@@ -7,8 +7,8 @@ import type { GitErrorType } from "@src/api/http/git/streaming";
 import { CheckoutBlockedDialog } from "@src/components/GitDialogs/CheckoutBlockedDialog";
 import { CheckoutConflictDialog } from "@src/components/GitDialogs/CheckoutConflictDialog";
 
-import { TerminalService } from "../../terminal";
 import { runGuardedCheckout } from "./guardedCheckout";
+import { noRepoContextFailure } from "./noRepoContext";
 import {
   type GitOperationResult,
   getRepoContext,
@@ -30,7 +30,6 @@ export async function checkoutRaw(
   branch: string,
   create?: boolean
 ): Promise<GitOperationResult> {
-  const cmd = create ? `git checkout -b ${branch}` : `git checkout ${branch}`;
   const repo = getRepoContext();
 
   if (repo) {
@@ -54,17 +53,7 @@ export async function checkoutRaw(
     };
   }
 
-  try {
-    await TerminalService.execute(cmd);
-    return { success: true, errorType: "none" };
-  } catch (error) {
-    const parsed = parseGitError(error);
-    return {
-      success: false,
-      errorType: parsed.type,
-      message: parsed.message,
-    };
-  }
+  return noRepoContextFailure("the checkout");
 }
 
 /**
@@ -95,24 +84,7 @@ export async function stash(
     }
   }
 
-  let cmd = "git stash push";
-  if (includeUntracked) {
-    cmd += " --include-untracked";
-  }
-  if (message) {
-    cmd += ` -m "${message}"`;
-  }
-  try {
-    await TerminalService.execute(cmd);
-    return { success: true, errorType: "none" };
-  } catch (error) {
-    const parsed = parseGitError(error);
-    return {
-      success: false,
-      errorType: parsed.type,
-      message: parsed.message,
-    };
-  }
+  return noRepoContextFailure("the stash");
 }
 
 /**
@@ -140,17 +112,7 @@ export async function stashPop(index: number = 0): Promise<GitOperationResult> {
     }
   }
 
-  try {
-    await TerminalService.execute(`git stash pop stash@{${index}}`);
-    return { success: true, errorType: "none" };
-  } catch (error) {
-    const parsed = parseGitError(error);
-    return {
-      success: false,
-      errorType: parsed.type,
-      message: parsed.message,
-    };
-  }
+  return noRepoContextFailure("the stash pop");
 }
 
 /**
@@ -179,17 +141,7 @@ export async function stashApply(
     }
   }
 
-  try {
-    await TerminalService.execute(`git stash apply stash@{${index}}`);
-    return { success: true, errorType: "none" };
-  } catch (error) {
-    const parsed = parseGitError(error);
-    return {
-      success: false,
-      errorType: parsed.type,
-      message: parsed.message,
-    };
-  }
+  return noRepoContextFailure("the stash apply");
 }
 
 /**
@@ -218,17 +170,9 @@ export async function stashDrop(
     }
   }
 
-  try {
-    await TerminalService.execute(`git stash drop stash@{${index}}`);
-    return { success: true, errorType: "none" };
-  } catch (error) {
-    const parsed = parseGitError(error);
-    return {
-      success: false,
-      errorType: parsed.type,
-      message: parsed.message,
-    };
-  }
+  // Destructive: the old fallback dropped whatever stash index N meant in
+  // the terminal's own repository.
+  return noRepoContextFailure("the stash drop");
 }
 
 // ============================================

--- a/src/services/git/operations/commitOps.ts
+++ b/src/services/git/operations/commitOps.ts
@@ -4,11 +4,11 @@
 import { gitApi } from "@src/api/http/git";
 import { showGitErrorAndHandle } from "@src/hooks/git/useGitErrorDialog";
 
-import { TerminalService } from "../../terminal";
 import {
   appendGitCoauthorTrailer,
   shouldIncludeGitCoauthor,
 } from "./commitAttribution";
+import { noRepoContextFailure } from "./noRepoContext";
 import {
   type GitOperationResult,
   getOutputIntegration,
@@ -61,18 +61,7 @@ export async function stage(paths?: string[]): Promise<GitOperationResult> {
     }
   }
 
-  const pathsStr = filesToStage.join(" ");
-  try {
-    await TerminalService.execute(`git add ${pathsStr}`);
-    return { success: true, errorType: "none" };
-  } catch (error) {
-    const parsed = parseGitError(error);
-    return {
-      success: false,
-      errorType: parsed.type,
-      message: parsed.message,
-    };
-  }
+  return noRepoContextFailure("staging");
 }
 
 /**
@@ -100,18 +89,7 @@ export async function unstage(paths?: string[]): Promise<GitOperationResult> {
     }
   }
 
-  const pathsStr = filesToUnstage.join(" ");
-  try {
-    await TerminalService.execute(`git reset HEAD ${pathsStr}`);
-    return { success: true, errorType: "none" };
-  } catch (error) {
-    const parsed = parseGitError(error);
-    return {
-      success: false,
-      errorType: parsed.type,
-      message: parsed.message,
-    };
-  }
+  return noRepoContextFailure("unstaging");
 }
 
 /**
@@ -138,18 +116,9 @@ export async function discard(paths: string[]): Promise<GitOperationResult> {
     }
   }
 
-  const pathsStr = paths.join(" ");
-  try {
-    await TerminalService.execute(`git checkout -- ${pathsStr}`);
-    return { success: true, errorType: "none" };
-  } catch (error) {
-    const parsed = parseGitError(error);
-    return {
-      success: false,
-      errorType: parsed.type,
-      message: parsed.message,
-    };
-  }
+  // Especially important for discard: the old terminal fallback interpolated
+  // paths unquoted into a destructive command in an arbitrary cwd.
+  return noRepoContextFailure("the discard");
 }
 
 /**
@@ -187,19 +156,7 @@ export async function resolveConflict(
     }
   }
 
-  try {
-    await TerminalService.execute(
-      `git checkout --${strategy} -- ${filePath} && git add ${filePath}`
-    );
-    return { success: true, errorType: "none" };
-  } catch (error) {
-    const parsed = parseGitError(error);
-    return {
-      success: false,
-      errorType: parsed.type,
-      message: parsed.message,
-    };
-  }
+  return noRepoContextFailure("the conflict resolution");
 }
 
 /**
@@ -244,18 +201,7 @@ export async function commit(message: string): Promise<GitOperationResult> {
     }
   }
 
-  const escapedMsg = commitMessage.replace(/"/g, '\\"');
-  try {
-    await TerminalService.execute(`git commit -m "${escapedMsg}"`);
-    return { success: true, errorType: "none" };
-  } catch (error) {
-    const parsed = parseGitError(error);
-    return {
-      success: false,
-      errorType: parsed.type,
-      message: parsed.message,
-    };
-  }
+  return noRepoContextFailure("the commit");
 }
 
 /**
@@ -282,20 +228,7 @@ export async function amend(message?: string): Promise<GitOperationResult> {
     }
   }
 
-  const cmd = message
-    ? `git commit --amend -m "${message}"`
-    : "git commit --amend --no-edit";
-  try {
-    await TerminalService.execute(cmd);
-    return { success: true, errorType: "none" };
-  } catch (error) {
-    const parsed = parseGitError(error);
-    return {
-      success: false,
-      errorType: parsed.type,
-      message: parsed.message,
-    };
-  }
+  return noRepoContextFailure("the amend");
 }
 
 // ============================================

--- a/src/services/git/operations/mergeOps.ts
+++ b/src/services/git/operations/mergeOps.ts
@@ -3,7 +3,7 @@
  */
 import { gitApi } from "@src/api/http/git";
 
-import { TerminalService } from "../../terminal";
+import { noRepoContextFailure } from "./noRepoContext";
 import {
   type GitOperationResult,
   getRepoContext,
@@ -37,17 +37,7 @@ export async function mergeAbort(): Promise<GitOperationResult> {
     }
   }
 
-  try {
-    await TerminalService.execute("git merge --abort");
-    return { success: true, errorType: "none" };
-  } catch (error) {
-    const parsed = parseGitError(error);
-    return {
-      success: false,
-      errorType: parsed.type,
-      message: parsed.message,
-    };
-  }
+  return noRepoContextFailure("the merge abort");
 }
 
 /**
@@ -73,15 +63,5 @@ export async function rebaseAbort(): Promise<GitOperationResult> {
     }
   }
 
-  try {
-    await TerminalService.execute("git rebase --abort");
-    return { success: true, errorType: "none" };
-  } catch (error) {
-    const parsed = parseGitError(error);
-    return {
-      success: false,
-      errorType: parsed.type,
-      message: parsed.message,
-    };
-  }
+  return noRepoContextFailure("the rebase abort");
 }

--- a/src/services/git/operations/noRepoContext.ts
+++ b/src/services/git/operations/noRepoContext.ts
@@ -1,0 +1,29 @@
+/**
+ * Loud failure for git operations invoked while no repository context is set.
+ *
+ * These operations used to fall back to typing the git command into the
+ * user's visible terminal: the text ran in whatever cwd that terminal
+ * happened to be in (possibly a different repository, possibly as input to a
+ * running program), and the call resolved the moment Enter was delivered —
+ * so the operation reported success regardless of what git did, and every
+ * parameter that had no terminal spelling (remote, branch, --set-upstream,
+ * prune) was silently dropped.
+ *
+ * Without a repository context there is nowhere trustworthy to run git.
+ * Failing loudly surfaces the actual wiring bug (a caller that never set the
+ * repo context) instead of fabricating a success.
+ */
+import { createLogger } from "@src/hooks/logger";
+
+import type { GitOperationResult } from "./types";
+
+const logger = createLogger("GitOps");
+
+export function noRepoContextFailure(operation: string): GitOperationResult {
+  logger.error(`${operation} not run: no repository context is set`);
+  return {
+    success: false,
+    errorType: "unknown",
+    message: `No repository is selected, so ${operation} was not run.`,
+  };
+}

--- a/src/services/git/operations/remoteOps.ts
+++ b/src/services/git/operations/remoteOps.ts
@@ -15,7 +15,7 @@ import {
   showGitAuthenticationDialog,
 } from "@src/util/dialogs/gitAuthenticationDialog";
 
-import { TerminalService } from "../../terminal";
+import { noRepoContextFailure } from "./noRepoContext";
 import type { GitOperationResult } from "./types";
 import {
   getOutputIntegration,
@@ -85,19 +85,7 @@ export async function push(
     }
   }
 
-  // Fall back to terminal command
-  const cmd = params.force ? "git push --force" : "git push";
-  try {
-    await TerminalService.execute(cmd);
-    return { success: true, errorType: "none" };
-  } catch (error) {
-    const parsed = parseGitError(error);
-    return {
-      success: false,
-      errorType: parsed.type,
-      message: parsed.message,
-    };
-  }
+  return noRepoContextFailure("the push");
 }
 
 /**
@@ -112,23 +100,6 @@ const DEFAULT_PULL_STRATEGY: GitPullStrategy =
 function getUserPullStrategy(): GitPullStrategy {
   const strategy = getStore().get(gitPullStrategyAtom);
   return strategy ?? DEFAULT_PULL_STRATEGY;
-}
-
-/**
- * Build the terminal pull command with strategy flags.
- * Always pass explicit flag so Git knows how to reconcile when branches diverge.
- * Rebase carries --autostash: a bare `git pull --rebase` refuses to start on
- * any dirty working tree, even when nothing overlaps the incoming commits.
- */
-function buildPullCommand(strategy: GitPullStrategy): string {
-  switch (strategy) {
-    case "rebase":
-      return "git pull --rebase --autostash";
-    case "ff-only":
-      return "git pull --ff-only";
-    default:
-      return "git pull --no-rebase";
-  }
 }
 
 async function getRemoteUrl(remoteName?: string): Promise<string | undefined> {
@@ -420,17 +391,7 @@ export async function pull(
     }
   }
 
-  try {
-    await TerminalService.execute(buildPullCommand(strategy));
-    return { success: true, errorType: "none" };
-  } catch (error) {
-    const parsed = parseGitError(error);
-    return {
-      success: false,
-      errorType: parsed.type,
-      message: parsed.message,
-    };
-  }
+  return noRepoContextFailure("the pull");
 }
 
 /**
@@ -478,17 +439,7 @@ export async function fetch(
     }
   }
 
-  try {
-    await TerminalService.execute("git fetch");
-    return { success: true, errorType: "none" };
-  } catch (error) {
-    const parsed = parseGitError(error);
-    return {
-      success: false,
-      errorType: parsed.type,
-      message: parsed.message,
-    };
-  }
+  return noRepoContextFailure("the fetch");
 }
 
 /**


### PR DESCRIPTION
## Problem

Every git operation in `src/services/git/operations` (push/pull/fetch/sync, stage/unstage/discard/commit/amend, checkout, stash push/pop/apply/drop, merge/rebase abort — 16 sites) had a last-resort fallback when neither the streaming integration nor a repository context was present: `TerminalService.execute`, which **types the command text into the user's visible terminal PTY and resolves the moment Enter is delivered** (2026-08-28 audit, C-1). Consequences:

- It can never observe git's exit code, so a rejected push, conflicted pull, or failed 403 fetch returned `{ success: true }`; `sync()` marched through all three steps on the lie, and the error-translation `catch` branches on this path were unreachable.
- The command ran in **whatever cwd the active terminal happened to be in** — potentially a different repository, or fed as input to a running program (`vim`, an agent).
- Everything without a terminal spelling was silently dropped: `remote`, `branch`, `--set-upstream` (so `publish()` could never publish an unpublished branch), `prune`.
- Several sites interpolated unescaped input into destructive commands (`git commit --amend -m "${message}"`, `git checkout -- ${paths}`, `git stash drop stash@{N}` against whatever repo the terminal was in).
- The 12 vitest "terminal fallback" tests mocked `execute` as a settling promise, asserting behavior the real implementation does not have.

## Solution

Delete the fallback. Without a repository context there is nowhere trustworthy to run git — a captured subprocess cannot fix this, because it wouldn't know the cwd either. All 16 sites now return an explicit failure through a shared `noRepoContextFailure(operation)` helper: `{ success: false, errorType: "unknown", message: "No repository is selected, so <operation> was not run." }`, logged. This surfaces the actual wiring bug (a caller that never called `setRepoContext`) instead of fabricating success. The unused `buildPullCommand` and all `TerminalService` imports go with it.

Invariant: a git operation either runs against the selected repository (streaming or HTTP API) or fails loudly; it never executes anywhere else and never invents a result.

## Potential risks

- Any flow that today silently "worked" only because the fallback typed into a terminal sitting in the right directory will now surface an error dialog instead. That is the intended behavior change: the error names the missing repo context, making such flows findable. No known flow legitimately depends on the fallback — the repo context is set on repo selection, and every UI entry point goes through a selected repo.
- The dialog variants (`pushWithDialog` etc.) will show a generic-unknown dialog for the no-context failure; the message is explicit about the cause.
- `TerminalService` itself is untouched — only the git layer stops using it.

## Verification

- Rewrote the fiction tests: the "terminal fallback — exact command strings" describe is now "no repository context — loud failure, nothing executed" (push/publish/pull-per-strategy/fetch/sync each assert the failure shape and that neither the terminal nor the git API was invoked). The strategy-resolution tests moved to the API payload (`gitPull.mock.calls[0][0].strategy`), preserving the #1028/#1035 regression coverage; the `sync` ordering tests moved to the API path with invocation-order assertions; two credential-path tests asserting terminal-branch behavior now assert no-retry-without-context.
- `npx vitest run src/services/git/operations/__tests__/` → **101 passed, 0 failed** across all six suites.
- eslint + prettier clean on all six touched files; full `tsc --noEmit` clean except one pre-existing error in `EditorStatusBarLeft.tsx` from unrelated in-flight icon work live in the shared checkout.
- Not run: E2E through the packaged app.
- **Stacked on #1035** (which stacks on #1028) because it touches the same two files; merge order #1028 → #1035 → this. Built via temp index from a live checkout, so pre-commit hooks did not run (`Pre-commit hook ran.` trailer intentionally absent); checks above were run manually.
