### PR TITLE
fix(git-stream): settle every operation and split cleanup refs

### DIFF
--- a/src/modules/WorkStation/CodeEditor/hooks/gitOutputIntegration/createGitOperationHandler.test.ts
+++ b/src/modules/WorkStation/CodeEditor/hooks/gitOutputIntegration/createGitOperationHandler.test.ts
@@ -1,0 +1,138 @@
+/**
+ * createGitOperationHandler — stream lifecycle and error-dialog behavior.
+ *
+ * Regression focus: a rejected stream setup used to leave the operation's
+ * promise unsettled forever (stuck spinner), and an auth failure delivered
+ * via onError opened the generic error dialog on top of the credential
+ * dialog the caller's retry flow opens.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { showGitErrorAndHandle } from "@src/hooks/git/useGitErrorDialog";
+import type { OperationContext } from "@src/types/workstation/gitOutputIntegration";
+
+import { createGitOperationHandler } from "./createGitOperationHandler";
+
+vi.mock("@src/hooks/git/useGitErrorDialog", () => ({
+  showGitErrorAndHandle: vi.fn(),
+}));
+
+const showDialog = vi.mocked(showGitErrorAndHandle);
+
+const flushMacrotask = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function makeContext(): OperationContext {
+  return {
+    repoPath: "/tmp/repo",
+    repoId: "repo-1",
+    cleanupRef: { current: null },
+  } as OperationContext;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("createGitOperationHandler", () => {
+  it("settles with a failure when stream setup itself rejects", async () => {
+    // Regression: without a rejection handler the promise never settled and
+    // the operation's loading state was stuck for the session.
+    const handler = createGitOperationHandler({
+      streamFn: vi.fn().mockRejectedValue(new Error("backend not reachable")),
+      operationName: "push",
+      operationLabel: "Push",
+    });
+
+    const result = await handler(makeContext(), {});
+
+    expect(result).toEqual({ success: false, errorType: "unknown" });
+    await flushMacrotask();
+    expect(showDialog).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves success from onComplete without a dialog", async () => {
+    const handler = createGitOperationHandler({
+      streamFn: vi.fn().mockImplementation(async (_params, callbacks) => {
+        setTimeout(() => callbacks.onComplete(true, undefined), 0);
+        return () => {};
+      }),
+      operationName: "pull",
+      operationLabel: "Pull",
+    });
+
+    const result = await handler(makeContext(), {});
+
+    expect(result).toEqual({ success: true, errorType: "none" });
+    await flushMacrotask();
+    expect(showDialog).not.toHaveBeenCalled();
+  });
+
+  it("does not stack a dialog on auth failures delivered via onError", async () => {
+    // Regression: onComplete guarded auth failures (the caller's credential
+    // retry opens its own dialog) but onError did not — two modals stacked.
+    const handler = createGitOperationHandler({
+      streamFn: vi.fn().mockImplementation(async (_params, callbacks) => {
+        setTimeout(
+          () =>
+            callbacks.onError("Authentication failed", "authentication_failed"),
+          0
+        );
+        return () => {};
+      }),
+      operationName: "push",
+      operationLabel: "Push",
+    });
+
+    const result = await handler(makeContext(), {});
+
+    expect(result).toEqual({
+      success: false,
+      errorType: "authentication_failed",
+    });
+    await flushMacrotask();
+    expect(showDialog).not.toHaveBeenCalled();
+  });
+
+  it("shows exactly one dialog for a non-auth onError", async () => {
+    const handler = createGitOperationHandler({
+      streamFn: vi.fn().mockImplementation(async (_params, callbacks) => {
+        setTimeout(() => callbacks.onError("stream broke", "network_error"), 0);
+        return () => {};
+      }),
+      operationName: "fetch",
+      operationLabel: "Fetch",
+    });
+
+    const result = await handler(makeContext(), {});
+
+    expect(result).toEqual({ success: false, errorType: "network_error" });
+    await flushMacrotask();
+    expect(showDialog).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the previous stream registered on the SAME context ref only", async () => {
+    const previousCleanup = vi.fn();
+    const context = makeContext();
+    context.cleanupRef.current = previousCleanup;
+
+    const otherContext = makeContext();
+    const otherCleanup = vi.fn();
+    otherContext.cleanupRef.current = otherCleanup;
+
+    const handler = createGitOperationHandler({
+      streamFn: vi.fn().mockImplementation(async (_params, callbacks) => {
+        setTimeout(() => callbacks.onComplete(true, undefined), 0);
+        return () => {};
+      }),
+      operationName: "push",
+      operationLabel: "Push",
+    });
+
+    await handler(context, {});
+
+    expect(previousCleanup).toHaveBeenCalledTimes(1);
+    // A different operation's in-flight stream must be untouched — the
+    // shared-ref version closed it and froze that operation forever.
+    expect(otherCleanup).not.toHaveBeenCalled();
+  });
+});

--- a/src/modules/WorkStation/CodeEditor/hooks/gitOutputIntegration/createGitOperationHandler.ts
+++ b/src/modules/WorkStation/CodeEditor/hooks/gitOutputIntegration/createGitOperationHandler.ts
@@ -204,7 +204,13 @@ export function createGitOperationHandler<TParams>(
               errorType,
               `${error}\n${captured}`
             );
-            if (showErrorDialog) {
+            // Same auth guard as onComplete: the caller's credential-retry
+            // flow opens its own dialog for auth failures, and showing both
+            // stacked two modals.
+            if (
+              showErrorDialog &&
+              resolvedErrorType !== "authentication_failed"
+            ) {
               setTimeout(() => {
                 showGitErrorAndHandle({
                   operation: operationName,
@@ -220,9 +226,38 @@ export function createGitOperationHandler<TParams>(
             resolve({ success: false, errorType: resolvedErrorType });
           },
         }
-      ).then((cleanup) => {
-        cleanupRef.current = cleanup;
-      });
+      ).then(
+        (cleanup) => {
+          cleanupRef.current = cleanup;
+        },
+        (error: unknown) => {
+          // Stream setup itself failed (backend down, bad URL): neither
+          // callback will ever fire, so settle the promise here — without
+          // this the operation's spinner never resolves.
+          const message =
+            error instanceof Error ? error.message : String(error);
+          const resolvedErrorType = resolveGitErrorType(
+            operationName,
+            undefined,
+            message
+          );
+          if (
+            showErrorDialog &&
+            resolvedErrorType !== "authentication_failed"
+          ) {
+            setTimeout(() => {
+              showGitErrorAndHandle({
+                operation: operationName,
+                repoId,
+                repoPath,
+                errorType: resolvedErrorType,
+                errorMessage: message,
+              });
+            }, 0);
+          }
+          resolve({ success: false, errorType: resolvedErrorType });
+        }
+      );
     });
   };
 }
@@ -301,9 +336,15 @@ export function createGitOperationHandlerWithReject<TParams>(
             reject(new Error(error));
           },
         }
-      ).then((cleanup) => {
-        cleanupRef.current = cleanup;
-      });
+      ).then(
+        (cleanup) => {
+          cleanupRef.current = cleanup;
+        },
+        (error: unknown) => {
+          // Settle on stream-setup failure — see createGitOperationHandler.
+          reject(error instanceof Error ? error : new Error(String(error)));
+        }
+      );
     });
   };
 }

--- a/src/modules/WorkStation/CodeEditor/hooks/gitOutputIntegration/useGitOperations.ts
+++ b/src/modules/WorkStation/CodeEditor/hooks/gitOutputIntegration/useGitOperations.ts
@@ -85,36 +85,45 @@ export function useGitOperations(
 ): UseGitOperationsReturn {
   const { repoPath, repoId } = options;
 
-  const cleanupRef = useRef<(() => void) | null>(null);
+  // One cleanup ref PER operation. A single shared ref meant starting any
+  // operation closed the previous operation's event source — whose promise
+  // then never settled (its callbacks can no longer fire), leaving that
+  // operation's loading flag stuck for the rest of the session (e.g. Fetch
+  // permanently disabled after clicking Pull mid-fetch).
+  const pushCleanupRef = useRef<(() => void) | null>(null);
+  const pullCleanupRef = useRef<(() => void) | null>(null);
+  const fetchCleanupRef = useRef<(() => void) | null>(null);
 
-  // Build operation context
-  const getContext = useCallback((): OperationContext => {
-    return {
-      repoPath,
-      repoId,
-      cleanupRef,
-    };
-  }, [repoPath, repoId]);
+  const makeContext = useCallback(
+    (cleanupRef: OperationContext["cleanupRef"]): OperationContext => {
+      return {
+        repoPath,
+        repoId,
+        cleanupRef,
+      };
+    },
+    [repoPath, repoId]
+  );
 
   const pushWithOutput = useCallback(
     (params: PushParams): Promise<GitOperationResult> => {
-      return handlePush(getContext(), params);
+      return handlePush(makeContext(pushCleanupRef), params);
     },
-    [getContext]
+    [makeContext]
   );
 
   const pullWithOutput = useCallback(
     (params: PullParams): Promise<GitOperationResult> => {
-      return handlePull(getContext(), params);
+      return handlePull(makeContext(pullCleanupRef), params);
     },
-    [getContext]
+    [makeContext]
   );
 
   const fetchWithOutput = useCallback(
     (params: FetchParams): Promise<GitOperationResult> => {
-      return handleFetch(getContext(), params);
+      return handleFetch(makeContext(fetchCleanupRef), params);
     },
-    [getContext]
+    [makeContext]
   );
 
   return {


### PR DESCRIPTION
## Problem

Three lifecycle defects in the editor's streaming git operations (2026-08-28 audit, H-8/F11/F12):

1. **One shared cleanup ref across push, pull, and fetch** (`useGitOperations.ts`). `createGitOperationHandler` calls `cleanupRef.current()` at the start of every operation — so starting a pull mid-fetch closed the *fetch's* event source. Its callbacks could then never fire, its promise never settled, and its `finally { setLoading(false) }` never ran: the Fetch button stayed disabled for the rest of the session. Same for any push/pull/fetch pairing.
2. **No rejection handler on stream setup.** `streamFn(...).then(cleanup => …)` had no failure arm; if the SSE setup rejected (backend not running, bad URL), the operation's promise never settled and the spinner spun forever, with the rejection swallowed unhandled.
3. **Double dialogs on auth failures.** `onComplete` guards `authentication_failed` (the caller's credential-retry flow opens its own dialog) but `onError` did not — an auth failure via the error event stacked the generic git-error dialog on top of the credential dialog.

## Solution

- `useGitOperations` keeps a cleanup ref **per operation**; starting one operation can only supersede its own previous run.
- Both handler factories settle on stream-setup rejection: the plain handler resolves a classified failure (and shows the dialog, with the auth guard), the with-reject variant rejects with the error.
- `onError` applies the same `authentication_failed` dialog guard as `onComplete`.

Invariant: every started operation settles exactly once, and only its own prior stream is ever closed.

## Potential risks

- Concurrent operations of *different* kinds now genuinely run concurrently instead of the newer one killing the older one's stream. The Rust side runs each in its own process, and `useSyncOperations` already serializes the flows that must not overlap; but any UI that (accidentally) relied on "starting a pull cancels the fetch" no longer gets that cancellation.
- Stream-setup failures now surface an error dialog where previously they surfaced nothing (spinner forever). Strictly an improvement, but visible.

## Verification

- New `createGitOperationHandler.test.ts` (module's first tests): **5 passed** — setup-rejection settles with a classified failure (times out against the old code), success path, auth-onError shows no dialog, non-auth onError shows exactly one, and the previous-cleanup call touches only the same context's ref (a different operation's in-flight cleanup is untouched).
- eslint, prettier, `check:test-placement` clean; full `tsc --noEmit` clean apart from the known unrelated in-flight `EditorStatusBarLeft.tsx` error live in the shared checkout.
- Not run: E2E through the packaged app.
- Based on `develop` (post-#1032, which touched this file's classifier). Built via temp index from a live checkout, so pre-commit hooks did not run (`Pre-commit hook ran.` trailer intentionally absent); checks above were run manually.
