### PR TITLE
fix(git): detect nothing-to-commit on stdout where git prints it

### DIFF
--- a/src-tauri/crates/git/src/bundle.rs
+++ b/src-tauri/crates/git/src/bundle.rs
@@ -163,7 +163,9 @@ fn auto_commit_if_needed(repo_path: &PathBuf) -> Result<bool, String> {
         Ok(add_output) => {
             if !add_output.status.success() {
                 let stderr = String::from_utf8_lossy(&add_output.stderr);
-                if !stderr.contains("nothing to commit") && !stderr.is_empty() {
+                // (`git add` never prints "nothing to commit"; the old check
+                // for it here was dead.)
+                if !stderr.is_empty() {
                     println!("⚠️ [GitBundle] git add warning: {}", stderr);
                 }
             }
@@ -834,11 +836,15 @@ pub fn git_commit(folder_path: String, message: String) -> Result<(), String> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        if stderr.contains("nothing to commit") {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        // Git prints "nothing to commit, working tree clean" to STDOUT and
+        // exits 1; checking stderr alone turned the benign no-op into
+        // `git commit failed:` with an empty message.
+        if stderr.contains("nothing to commit") || stdout.contains("nothing to commit") {
             println!("📝 [GitBundle] Nothing to commit");
             return Ok(());
         }
-        return Err(format!("git commit failed: {}", stderr));
+        return Err(format!("git commit failed: {}{}", stdout, stderr));
     }
 
     println!("✅ [GitBundle] Commit created: {}", message);

--- a/src-tauri/crates/git/src/tests/bundle_tests.rs
+++ b/src-tauri/crates/git/src/tests/bundle_tests.rs
@@ -43,3 +43,79 @@ fn test_ahead_behind_invalid_sha() {
 // Note: Testing actual ahead/behind calculations requires a real git repo
 // with known commit history. These tests verify error handling.
 // Integration tests with actual repos would be needed for full coverage.
+
+// ============================================
+// git_commit — nothing-to-commit detection
+// ============================================
+
+/// Regression: git prints "nothing to commit, working tree clean" to STDOUT
+/// (exit 1) with an empty stderr; git_commit checked stderr only, so a benign
+/// no-op commit surfaced as `Err("git commit failed: ")` with no message.
+#[test]
+fn git_commit_treats_clean_tree_as_ok() {
+    if std::process::Command::new("git")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("skipping: git executable not available");
+        return;
+    }
+
+    let repo = std::env::temp_dir().join(format!(
+        "orgii-bundle-commit-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock after epoch")
+            .as_nanos()
+    ));
+    let _ = std::fs::remove_dir_all(&repo);
+    std::fs::create_dir_all(&repo).expect("create test repo dir");
+
+    let git = |args: &[&str]| {
+        let out = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&repo)
+            .args([
+                "-c",
+                "user.email=t@t",
+                "-c",
+                "user.name=t",
+                "-c",
+                "commit.gpgsign=false",
+            ])
+            .args(args)
+            .output()
+            .expect("spawn git");
+        assert!(
+            out.status.success(),
+            "git {:?} failed: {}{}",
+            args,
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    };
+    git(&["init"]);
+    std::fs::write(repo.join("a.txt"), "one\n").expect("write file");
+    git(&["add", "."]);
+    git(&["commit", "-m", "init"]);
+
+    // Clean tree: must be Ok, not "git commit failed: ".
+    let result = git_commit(
+        repo.to_string_lossy().to_string(),
+        "noop commit".to_string(),
+    );
+    assert_eq!(result, Ok(()), "clean tree is a benign no-op");
+
+    // Dirty tree: commits normally.
+    std::fs::write(repo.join("a.txt"), "one\ntwo\n").expect("write file");
+    git(&["add", "."]);
+    let result = git_commit(
+        repo.to_string_lossy().to_string(),
+        "real commit".to_string(),
+    );
+    assert_eq!(result, Ok(()));
+
+    let _ = std::fs::remove_dir_all(&repo);
+}

--- a/src-tauri/crates/git/src/worktree.rs
+++ b/src-tauri/crates/git/src/worktree.rs
@@ -875,10 +875,12 @@ pub fn commit_worktree_changes(repo_path: &Path, session_id: &str) -> Result<boo
     )?;
     if !commit.status.success() {
         let stderr = git_stderr(&commit);
-        if stderr.contains("nothing to commit") {
+        let stdout = String::from_utf8_lossy(&commit.stdout);
+        // Git prints "nothing to commit" to STDOUT (exit 1); stderr is empty.
+        if stderr.contains("nothing to commit") || stdout.contains("nothing to commit") {
             return Ok(false);
         }
-        return Err(format!("git commit failed: {}", stderr));
+        return Err(format!("git commit failed: {}{}", stdout, stderr));
     }
 
     info!("[worktree] Committed changes in session {}", session_id);


### PR DESCRIPTION
## Problem

Git prints `nothing to commit, working tree clean` to **stdout** and exits 1 with an empty stderr. Two commit sites in `crates/git` checked stderr only, so the benign no-op surfaced as a hard failure with an empty message — `git commit failed: ` — instead of being treated as "nothing to do" (2026-08-28 audit, M-3):

- `bundle.rs::git_commit` → returns `Err("git commit failed: ")`, failing the caller's flow for a clean tree.
- `worktree.rs` session auto-commit → same, instead of returning `Ok(false)`.

The same file already contains the correct dual-stream check (`auto_commit_if_needed`); these two sites were never updated to match. A third site greps `git add` output for "nothing to commit", a string `git add` never emits — dead code.

## Solution

Both sites check stdout and stderr, matching `auto_commit_if_needed`; genuine failures now include stdout in the error text (git often puts the useful line there). The dead `git add` clause is removed.

## Potential risks

- Error messages for genuine commit failures now include stdout content — longer, more informative text in logs. No behavior change for any success path.
- The worktree site remains additionally shielded by a preceding `status --porcelain` check; this fix matters for races between that check and the commit.

## Verification

- `cargo test -p git --lib` → **135 passed, 0 failed**, including a new real-repository regression test: `git_commit` on a clean tree returns `Ok(())` (against the old code it returns `Err("git commit failed: ")`), and a dirty tree still commits.
- `cargo fmt -p git --check` clean.
- Not run: E2E through the packaged app.
- Based on `develop`; independent of the open git-fix PRs. Built via temp index from a live checkout, so pre-commit hooks did not run (`Pre-commit hook ran.` trailer intentionally absent); checks above were run manually.
