### PR TITLE
fix(git): prune only on request and stop fetch storms on focus

### DIFF
--- a/src/api/http/git/operations.test.ts
+++ b/src/api/http/git/operations.test.ts
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { BRANCH_REMOTE_MUTATION_EVENT } from "@src/util/git/branchRemoteMutation";
 
 import { fetchRustApi } from "./client";
-import { gitPush } from "./operations";
+import { gitFetch, gitPush } from "./operations";
 
 vi.mock("./client", () => ({
   fetchRustApi: vi.fn(),
@@ -44,5 +44,31 @@ describe("gitPush", () => {
         reason: "push",
       },
     ]);
+  });
+});
+
+describe("gitFetch", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Regression: the wire body used to default `prune: true` when the caller
+  // passed nothing, silently deleting local remote-tracking refs on every
+  // plain fetch — and the layer above asserted "prune only when requested"
+  // against its own payload, never the wire body.
+  it("sends prune only when the caller explicitly asked for it", async () => {
+    fetchRustApiMock.mockResolvedValue({ data: { success: true } } as never);
+
+    await gitFetch({ repo_id: "repo-1", repo_path: "/repo" });
+    const bodyWithout = JSON.parse(
+      (fetchRustApiMock.mock.calls[0][1] as RequestInit).body as string
+    );
+    expect(bodyWithout.prune).toBe(false);
+
+    await gitFetch({ repo_id: "repo-1", repo_path: "/repo", prune: true });
+    const bodyWith = JSON.parse(
+      (fetchRustApiMock.mock.calls[1][1] as RequestInit).body as string
+    );
+    expect(bodyWith.prune).toBe(true);
   });
 });

--- a/src/api/http/git/operations.ts
+++ b/src/api/http/git/operations.ts
@@ -51,7 +51,11 @@ export const gitFetch = async (params: {
       method: "POST",
       body: JSON.stringify({
         remote: params.remote ?? "origin",
-        prune: params.prune ?? true,
+        // Prune deletes local remote-tracking refs; a destructive flag must
+        // be sent only when the caller explicitly asked for it. (The Rust
+        // handler's own default is prune=true when the field is absent, so
+        // the explicit false here is load-bearing.)
+        prune: params.prune ?? false,
         auth_username: params.authUsername ?? null,
         auth_token: params.authToken ?? null,
         store_auth: params.storeAuth ?? false,

--- a/src/hooks/git/useGitAutoFetch.ts
+++ b/src/hooks/git/useGitAutoFetch.ts
@@ -45,6 +45,7 @@ export function useGitAutoFetch(): void {
     const fetchKey = `${selectedRepoId}:${repoPath}`;
     const intervalMs = Math.max(intervalSeconds * 1000, MIN_INTERVAL_MS);
     let nextDelayMs = intervalMs;
+    let lastFetchStartedAt = 0;
 
     const clearTimer = () => {
       if (timerId !== null) {
@@ -70,6 +71,7 @@ export function useGitAutoFetch(): void {
       }
 
       activeFetchKeyRef.current = fetchKey;
+      lastFetchStartedAt = Date.now();
       try {
         await gitApi.gitFetch({
           repo_id: selectedRepoId,
@@ -98,7 +100,17 @@ export function useGitAutoFetch(): void {
     const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") {
         nextDelayMs = intervalMs;
-        void tick();
+        // Becoming visible must not bypass the interval: in a desktop app
+        // every app-switch or minimize/restore lands here, and fetching
+        // immediately each time turned window focus into a network storm.
+        // Fetch now only if a full interval has already elapsed; otherwise
+        // resume the schedule for the remainder.
+        const elapsed = Date.now() - lastFetchStartedAt;
+        if (elapsed >= intervalMs) {
+          void tick();
+        } else {
+          schedule(intervalMs - elapsed);
+        }
       } else {
         clearTimer();
       }


### PR DESCRIPTION
## Problem

Two fetch-behavior defects (2026-08-28 audit, M-2):

1. **`gitFetch` prunes by default at the wire layer.** `src/api/http/git/operations.ts` sent `prune: params.prune ?? true`, so a caller that never asked for pruning still deleted local remote-tracking refs on every fetch. The suite above (`remoteOps.test.ts`) even asserts "every destructive flag is absent unless the caller explicitly asked" — but checks its own payload, and the wire body silently flipped the default underneath it.
2. **Auto-fetch fires on every window focus.** `useGitAutoFetch`'s `visibilitychange` handler called `tick()` immediately whenever the app became visible. In a desktop app, every app-switch or minimize/restore is such a transition — each one triggered a network fetch, bypassing the configured interval (`git.autoFetchInterval`, min 30s) entirely.

## Solution

- The wire body now sends `prune: params.prune ?? false`. This is load-bearing: the Rust handler's own default is `prune=true` when the field is absent, so the explicit `false` is what restores caller intent. The background auto-fetch loop still passes `prune: true` explicitly — its pruning behavior is deliberate and unchanged.
- On becoming visible, the hook fetches immediately only if a full interval has already elapsed since the last fetch started; otherwise it resumes the schedule for the remainder. Hidden-state timer clearing is unchanged.

## Potential risks

- Fetches that previously pruned implicitly (any `gitFetch` call without `prune`) no longer do — stale remote-tracking refs now persist until an explicit prune (status-bar fetch and auto-fetch both pass `prune: true` explicitly, so the common paths keep pruning). This is the intended "destructive only on request" semantics.
- A user who backgrounds the app for longer than the interval still gets an immediate fetch on return — the guard only suppresses sub-interval storms.

## Verification

- New wire-level regression test in `operations.test.ts`: body carries `prune: false` when the caller passes nothing and `prune: true` when asked — **2 passed** (the first assertion fails against the old code).
- `remoteOps.test.ts` still **66 passed** (its payload-level prune assertions unchanged and now actually backed by the wire).
- eslint / prettier clean; full `tsc --noEmit` clean apart from the known unrelated in-flight `EditorStatusBarLeft.tsx` error in the shared checkout.
- The visibility guard has no automated test: the repo has no React hook-testing harness (`@testing-library/react` is not a dependency), and `useGitAutoFetch` was and remains untested — flagged in the audit's coverage inventory. Verified by reading: `lastFetchStartedAt` is set at each tick and both visibility branches terminate in `schedule()` or `tick()`.
- Not run: E2E through the packaged app.
- Based on `develop`; independent of the open git-fix PRs. Built via temp index from a live checkout, so pre-commit hooks did not run (`Pre-commit hook ran.` trailer intentionally absent); checks above were run manually.
