### PR TITLE
fix(git): make stash-and-continue retry and restore faithfully

### DIFF
--- a/src/hooks/git/useGitErrorDialog.test.ts
+++ b/src/hooks/git/useGitErrorDialog.test.ts
@@ -1,0 +1,166 @@
+/**
+ * showGitErrorAndHandle — the "Stash and Continue" recovery flow.
+ *
+ * Regression focus (2026-08-28 audit, C-2): the retry used to re-read the
+ * pull-strategy setting instead of the strategy the failed pull ran with,
+ * dropped remote/branch, returned silently when the retry failed (stranding
+ * the stash), and popped `index: 0` instead of the stash it created.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const gitStashPush = vi.fn();
+const gitStashList = vi.fn();
+const gitStashApply = vi.fn();
+const gitPull = vi.fn();
+const gitPush = vi.fn();
+const showGitActionDialogSafely = vi.fn();
+const askNativeDialogSafely = vi.fn();
+const showGitErrorDialog = vi.fn();
+
+vi.mock("@src/api/http/git", () => ({
+  gitApi: {
+    gitStashPush: (...args: unknown[]) => gitStashPush(...args),
+    gitStashList: (...args: unknown[]) => gitStashList(...args),
+    gitStashApply: (...args: unknown[]) => gitStashApply(...args),
+    gitPull: (...args: unknown[]) => gitPull(...args),
+    gitPush: (...args: unknown[]) => gitPush(...args),
+  },
+}));
+vi.mock("@src/util/dialogs/gitActionDialog", () => ({
+  showGitActionDialogSafely: (...args: unknown[]) =>
+    showGitActionDialogSafely(...args),
+}));
+vi.mock("@src/util/dialogs/nativeDialog", () => ({
+  askNativeDialogSafely: (...args: unknown[]) => askNativeDialogSafely(...args),
+}));
+vi.mock("@src/util/dialogs/gitErrorDialog", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  showGitErrorDialog: (...args: unknown[]) => showGitErrorDialog(...args),
+}));
+vi.mock("@src/util/core/state/instrumentedStore", () => ({
+  getInstrumentedStore: () => ({ get: () => "merge", set: () => undefined }),
+}));
+vi.mock("@src/store/workstation/tabs", () => ({
+  createGitLogTab: vi.fn(),
+  openWorkstationTabAtom: {},
+  presentedWorkstationWorkspaceKeyAtom: {},
+}));
+
+const { showGitErrorAndHandle } = await import("./useGitErrorDialog");
+
+const BASE_OPTIONS = {
+  operation: "pull",
+  repoId: "repo-1",
+  repoPath: "/tmp/repo",
+  errorType: "uncommitted_changes" as const,
+  errorMessage: "would be overwritten",
+};
+
+function stashEntry(index: number, sha: string) {
+  return { index, message: `stash ${sha}`, branch: "main", commit_sha: sha };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  showGitErrorDialog.mockResolvedValue("stash-and-continue");
+  gitStashPush.mockResolvedValue({ success: true, stash_ref: "stash@{0}" });
+  gitStashList.mockResolvedValue({ stashes: [stashEntry(0, "sha-fresh")] });
+  gitStashApply.mockResolvedValue({ success: true });
+  gitPull.mockResolvedValue({ success: true });
+  gitPush.mockResolvedValue({ success: true });
+  askNativeDialogSafely.mockResolvedValue(true);
+});
+
+describe("stash-and-continue", () => {
+  it("retries the pull with the parameters the failed pull ran with", async () => {
+    await showGitErrorAndHandle({
+      ...BASE_OPTIONS,
+      retryContext: { remote: "origin", branch: "main", strategy: "rebase" },
+    });
+
+    expect(gitStashPush).toHaveBeenCalledWith(
+      expect.objectContaining({ include_untracked: true })
+    );
+    expect(gitPull).toHaveBeenCalledWith(
+      expect.objectContaining({
+        remote: "origin",
+        branch: "main",
+        strategy: "rebase",
+      })
+    );
+    expect(gitPush).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the configured strategy without a retry context", async () => {
+    await showGitErrorAndHandle(BASE_OPTIONS);
+
+    expect(gitPull).toHaveBeenCalledWith(
+      expect.objectContaining({ strategy: "merge" })
+    );
+  });
+
+  it("offers to restore the stash even when the retry fails", async () => {
+    gitPull.mockRejectedValueOnce(new Error("still failing"));
+
+    await showGitErrorAndHandle(BASE_OPTIONS);
+
+    expect(askNativeDialogSafely).toHaveBeenCalledWith(
+      expect.stringContaining("retry failed"),
+      expect.anything()
+    );
+    expect(gitStashApply).toHaveBeenCalledWith(
+      expect.objectContaining({ pop: true })
+    );
+  });
+
+  it("pops the stash by its commit id, not by position", async () => {
+    // Between the auto-stash and the restore, something else pushed a stash:
+    // the fresh entry moved from index 0 to index 1.
+    gitStashList
+      .mockResolvedValueOnce({ stashes: [stashEntry(0, "sha-fresh")] })
+      .mockResolvedValueOnce({
+        stashes: [stashEntry(0, "sha-interloper"), stashEntry(1, "sha-fresh")],
+      });
+
+    await showGitErrorAndHandle(BASE_OPTIONS);
+
+    expect(gitStashApply).toHaveBeenCalledWith(
+      expect.objectContaining({ index: 1, pop: true })
+    );
+  });
+
+  it("does not pop anything when the auto-stash is gone from the list", async () => {
+    gitStashList
+      .mockResolvedValueOnce({ stashes: [stashEntry(0, "sha-fresh")] })
+      .mockResolvedValueOnce({ stashes: [stashEntry(0, "sha-other")] });
+
+    await showGitErrorAndHandle(BASE_OPTIONS);
+
+    expect(gitStashApply).not.toHaveBeenCalled();
+    expect(showGitActionDialogSafely).toHaveBeenCalledWith(
+      expect.stringContaining("no longer in the stash list"),
+      "info"
+    );
+  });
+
+  it("keeps the stash and says so for operations it cannot retry", async () => {
+    await showGitErrorAndHandle({ ...BASE_OPTIONS, operation: "checkout" });
+
+    expect(gitPull).not.toHaveBeenCalled();
+    expect(gitStashApply).not.toHaveBeenCalled();
+    expect(showGitActionDialogSafely).toHaveBeenCalledWith(
+      expect.stringContaining("Retry this operation manually"),
+      "info"
+    );
+  });
+
+  it("retries sync as pull followed by push", async () => {
+    await showGitErrorAndHandle({ ...BASE_OPTIONS, operation: "sync" });
+
+    expect(gitPull).toHaveBeenCalledTimes(1);
+    expect(gitPush).toHaveBeenCalledTimes(1);
+    expect(gitPull.mock.invocationCallOrder[0]).toBeLessThan(
+      gitPush.mock.invocationCallOrder[0]
+    );
+  });
+});

--- a/src/hooks/git/useGitErrorDialog.ts
+++ b/src/hooks/git/useGitErrorDialog.ts
@@ -69,10 +69,13 @@ async function stashAndRetryOperation(
     );
     return;
   }
-
-  const stashResult = await gitApi.gitStashPush({
+  const repoParams = {
     repo_id: repoContext.repoId,
     repo_path: repoContext.repoPath || undefined,
+  };
+
+  const stashResult = await gitApi.gitStashPush({
+    ...repoParams,
     message: `Auto-stash before retrying ${options.operation}`,
     include_untracked: true,
   });
@@ -85,7 +88,14 @@ async function stashAndRetryOperation(
     return;
   }
 
+  // Capture the fresh stash's commit id right away: "stash@{0}" is
+  // positional, and any stash created before the restore (a leftover
+  // autostash, a concurrent stash action) would make index 0 — and a pop of
+  // it — target the WRONG entry.
+  const listAfterPush = await gitApi.gitStashList(repoParams);
+  const stashSha = listAfterPush?.stashes[0]?.commit_sha ?? null;
   const stashRefLabel = stashResult.stash_ref || "the latest stash";
+
   let retrySucceeded = false;
 
   if (onRetry) {
@@ -98,34 +108,31 @@ async function stashAndRetryOperation(
         "error"
       );
     }
-  }
+  } else {
+    // Retry the SAME operation the user attempted: prefer the parameters it
+    // actually ran with over re-reading settings — an explicit
+    // "pull with rebase" must not retry as a merge pull.
+    const store = getInstrumentedStore();
+    const strategy =
+      options.retryContext?.strategy ??
+      store.get(gitPullStrategyAtom) ??
+      undefined;
+    const remote = options.retryContext?.remote;
+    const branch = options.retryContext?.branch;
 
-  if (!onRetry) {
     try {
-      const store = getInstrumentedStore();
-      const strategy = store.get(gitPullStrategyAtom) ?? undefined;
-
       if (options.operation === "pull") {
-        await gitApi.gitPull({
-          repo_id: repoContext.repoId,
-          repo_path: repoContext.repoPath || undefined,
-          strategy,
-        });
+        await gitApi.gitPull({ ...repoParams, remote, branch, strategy });
         retrySucceeded = true;
       } else if (options.operation === "sync") {
-        await gitApi.gitPull({
-          repo_id: repoContext.repoId,
-          repo_path: repoContext.repoPath || undefined,
-          strategy,
-        });
-        await gitApi.gitPush({
-          repo_id: repoContext.repoId,
-          repo_path: repoContext.repoPath || undefined,
-        });
+        await gitApi.gitPull({ ...repoParams, remote, branch, strategy });
+        await gitApi.gitPush({ ...repoParams, remote, branch });
         retrySucceeded = true;
       } else {
+        // Not automatically retryable (checkout, commit, …): the stash was
+        // made so the user can retry by hand — leave it in place and say so.
         showGitActionDialogSafely(
-          "Changes were stashed. Retry this operation manually.",
+          `Changes were stashed (${stashRefLabel}). Retry this operation manually, then restore the stash.`,
           "info"
         );
         return;
@@ -135,38 +142,52 @@ async function stashAndRetryOperation(
         error instanceof Error ? error.message : "Retry after stash failed.",
         "error"
       );
-      return;
     }
   }
 
-  if (
-    !retrySucceeded ||
-    (options.operation !== "pull" && options.operation !== "sync")
-  ) {
-    return;
-  }
+  // Always reach a restore decision — succeed or fail, the user's changes
+  // must never stay silently parked in the stash. (The dialog's hint
+  // explicitly promises to "ask if you want to restore those stashed
+  // changes".)
+  const operationLabel =
+    options.operation.charAt(0).toUpperCase() + options.operation.slice(1);
+  const prompt = retrySucceeded
+    ? `${operationLabel} completed successfully. Restore stashed changes now (${stashRefLabel})?`
+    : `The ${options.operation} retry failed. Restore your stashed changes now (${stashRefLabel})?`;
 
   try {
-    const operationLabel =
-      options.operation.charAt(0).toUpperCase() + options.operation.slice(1);
-    const shouldUnstash = await askNativeDialogSafely(
-      `${operationLabel} completed successfully. Restore stashed changes now (${stashRefLabel})?`,
-      {
-        title: "Restore Stashed Changes",
-        kind: "info",
-        okLabel: "Unstash Changes",
-        cancelLabel: "Keep Stashed",
-      }
-    );
+    const shouldUnstash = await askNativeDialogSafely(prompt, {
+      title: "Restore Stashed Changes",
+      kind: "info",
+      okLabel: "Unstash Changes",
+      cancelLabel: "Keep Stashed",
+    });
 
     if (!shouldUnstash) {
       return;
     }
 
+    // Re-resolve the stash by its commit id: its index may have shifted if
+    // anything else touched the stash list meanwhile.
+    let index = 0;
+    if (stashSha) {
+      const listAtRestore = await gitApi.gitStashList(repoParams);
+      const match = listAtRestore?.stashes.find(
+        (entry) => entry.commit_sha === stashSha
+      );
+      if (listAtRestore && !match) {
+        showGitActionDialogSafely(
+          "The auto-stash is no longer in the stash list; nothing to restore.",
+          "info"
+        );
+        return;
+      }
+      index = match?.index ?? 0;
+    }
+
     const unstashResult = await gitApi.gitStashApply({
-      repo_id: repoContext.repoId,
-      repo_path: repoContext.repoPath || undefined,
-      index: 0,
+      ...repoParams,
+      index,
       pop: true,
     });
 

--- a/src/modules/WorkStation/shared/StatusBar/utils/useEditorStatusBarGit.ts
+++ b/src/modules/WorkStation/shared/StatusBar/utils/useEditorStatusBarGit.ts
@@ -173,9 +173,16 @@ export function useEditorStatusBarGit({
   }, [canSyncDisplayedRepo, pull]);
 
   const showSyncErrorDialog = useCallback(
-    async (result: GitOperationResult, fallbackMessage: string) => {
+    async (
+      result: GitOperationResult,
+      fallbackMessage: string,
+      // The operation that actually failed. Both call sites are failed
+      // PULLS inside a sync flow; labeling them "sync" made the dialog's
+      // stash-and-retry re-run a pull AND a push the user never asked for.
+      operation: "pull" | "sync" = "pull"
+    ) => {
       await showGitErrorAndHandle({
-        operation: "sync",
+        operation,
         repoId: operationRepoId,
         repoPath: operationRepoPath,
         errorType: result.errorType,

--- a/src/util/dialogs/gitErrorDialog.ts
+++ b/src/util/dialogs/gitErrorDialog.ts
@@ -36,6 +36,17 @@ export interface GitErrorDialogOptions {
   commandOutput?: string;
   /** Timestamp of when the error occurred */
   timestamp?: Date;
+  /**
+   * The parameters the failed operation actually ran with, so a
+   * stash-and-retry re-runs the SAME operation. Without these, the retry
+   * re-reads the pull-strategy setting (an explicit "pull with rebase"
+   * retried as a merge pull) and drops remote/branch.
+   */
+  retryContext?: {
+    remote?: string;
+    branch?: string;
+    strategy?: "merge" | "rebase" | "ff-only";
+  };
 }
 
 export interface GitErrorInfo {


### PR DESCRIPTION
## Problem

The git error dialog's "Stash and Continue" recovery (`useGitErrorDialog.stashAndRetryOperation`) — the sibling of the panel flow fixed in #1037 — breaks its contract in four ways (2026-08-28 audit, C-2 remainder):

1. **The retry is not the operation that failed.** The options carry no `remote`/`branch`/`strategy`, so the retry re-reads the pull-strategy setting: a user configured for merge who explicitly clicked "Pull with rebase" got a *merge* pull on retry.
2. **A failed retry strands the stash silently.** The error path returned before the restore prompt the dialog explicitly promises ("…then ask if you want to restore those stashed changes").
3. **The restore pops `index: 0` blind.** Any stash created between the auto-stash and the restore (a leftover autostash, a concurrent stash action) makes index 0 a different — and then destroyed — entry.
4. **The status bar labels failed pulls as "sync"** (`useEditorStatusBarGit.showSyncErrorDialog`), so this flow retried a pull *and pushed*, which the user never asked for.

## Solution

- `GitErrorDialogOptions` gains an optional `retryContext { remote, branch, strategy }`; the retry prefers it over settings. (Threading it from the streaming handler's dialog call is a follow-up once #1039 lands — that file is in flight.)
- Every retry outcome now reaches a restore-or-notify step: success offers the restore as before; failure offers it with failure wording; non-retryable operations keep the stash deliberately and say so, naming the ref.
- The restore captures the auto-stash's **commit id** right after pushing (via `gitStashList`, populated by #1040) and re-resolves its current index before popping; if the entry is gone, nothing is popped and the user is told. Falls back to index 0 when no id is available (older backend).
- `showSyncErrorDialog` takes the actual failed operation and both call sites pass `"pull"`.

## Potential risks

- The restore prompt now also appears after failed retries — a new dialog in a path that previously ended silently; declining leaves exactly the old state (stash kept), so no data behavior regressed.
- Identity resolution adds two `gitStashList` calls around the retry; on backends predating #1040 `commit_sha` is null and behavior degrades to the previous index-0 pop.
- The status-bar change means push-after-pull no longer happens from this dialog's retry — the surrounding sync flows still do their own push step.

## Verification

- New `useGitErrorDialog.test.ts` (this flow's first tests): **7 passed** — retry uses the failed pull's own strategy/remote/branch; settings fallback; restore offered after a failed retry; pop targets the entry matching the captured commit id after an interloper stash shifts indices; vanished auto-stash pops nothing and informs; non-retryable operations keep the stash with a message; sync retries as pull-then-push in order.
- `gitErrorDialogHelpers.test.ts` still 26 passed; eslint/prettier clean; full `tsc --noEmit` clean apart from the known unrelated in-flight `EditorStatusBarLeft.tsx` error.
- Not run: E2E through the packaged app; `useEditorStatusBarGit` itself remains untested (React hook, no hook-test harness in the repo — audit coverage gap).
- Based on `develop` (post-#1032/#1037/#1040 merges of the adjacent pieces; degrades gracefully if #1040 lands later). Built via temp index from a live checkout, so pre-commit hooks did not run (`Pre-commit hook ran.` trailer intentionally absent); checks above were run manually.
