### PR TITLE
fix(source-control): decide sync push on a fresh ahead count

### DIFF
--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useSourceControlState/useSyncOperations.ts
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/hooks/useSourceControlState/useSyncOperations.ts
@@ -232,8 +232,6 @@ export function useSyncOperations(
 
     setSyncLoading(true);
     try {
-      const currentAhead = aheadRef.current;
-
       // Always pull first (includes fetch + merge). When already
       // up-to-date this is a fast no-op.
       const pullResult = await doPull();
@@ -253,6 +251,17 @@ export function useSyncOperations(
         }
         return;
       }
+
+      // Decide the push on a FRESH ahead count, not one captured before the
+      // pull: commits made outside the panel's commit button (an AI
+      // dispatch, the terminal, an external editor) never bump the
+      // optimistic offset, and the last status poll may predate them — a
+      // stale count made sync silently skip the push (while reporting
+      // success), or let a large push bypass its confirmation. Same
+      // refresh-then-read pattern the non-fast-forward branch below already
+      // uses for the behind count.
+      await fetchGitStatusRef.current();
+      const currentAhead = aheadRef.current;
 
       // Check if pushing many commits - show confirmation dialog
       if (currentAhead >= LARGE_PUSH_THRESHOLD) {


### PR DESCRIPTION
## Problem

`handleSync` (`useSourceControlState/useSyncOperations.ts`) captures the ahead count **before** the pull and pushes only `if (currentAhead > 0)`. The count is `baseAhead + optimisticAheadOffset`, where the offset is bumped only by the panel's own commit button and `baseAhead` comes from the last status poll. Commits made any other way — an AI `git.commit` dispatch, the terminal, an external editor — leave the captured count at 0 until a poll happens to land, so sync **silently skips the push, reports success, and resets the optimistic offset**. The same stale value gates the `LARGE_PUSH_THRESHOLD` confirmation, so a genuinely large push can bypass its dialog. (2026-08-28 audit, H-9/F15.)

## Solution

After the pull step succeeds, refresh git status once and read the ahead count fresh — the exact refresh-then-read-ref pattern this function's own non-fast-forward branch already uses for the behind count. The decision to push, and the large-push confirmation, now see reality.

## Potential risks

- One extra status fetch per sync, between pull and push (the sync already refreshes at the end; local status reads are cheap).
- The fresh count relies on `fetchGitStatus()` resolving after state propagation, the same assumption the existing `behindRef` usage makes two branches below.

## Verification

- eslint / prettier clean; full `tsc --noEmit` clean apart from the known unrelated in-flight `EditorStatusBarLeft.tsx` error; the module's sibling suite (`pullErrorHandlers.test.ts`) still 7 passed.
- No automated test for `handleSync` itself: it is a React hook composition and the repo has no hook-test harness (`@testing-library/react` absent) — flagged in the audit's coverage inventory. The change is two lines relocating an existing pattern already exercised in the same function.
- Not run: E2E through the packaged app.
- Based on `develop` (post-#1037, same file). Built via temp index from a live checkout, so pre-commit hooks did not run (`Pre-commit hook ran.` trailer intentionally absent); checks above were run manually.
