### PR TITLE
perf(chat-panel): keep history and composer off streaming tokens

### DIFF
--- a/src/contexts/workspace/ChatContext.tsx
+++ b/src/contexts/workspace/ChatContext.tsx
@@ -1,8 +1,9 @@
 /**
  * Chat Context - Chat UI State Only
  *
- * ARCHITECTURE: chatHistory is derived from the session store's eventsAtom.
- * This ensures ChatPanel and Simulator use the SAME data source.
+ * ARCHITECTURE: chatHistory is derived from
+ * `chatEventsForSessionAtomFamily`. ChatPanel and scoped surfaces share
+ * that per-session snapshot channel.
  *
  * This context contains ONLY UI-related state:
  * - Chat panel width, scroll state, unread count
@@ -33,12 +34,9 @@ import React, {
 
 import { useChatHistoryOverride } from "@src/engines/ChatPanel/ChatHistoryOverrideContext";
 import { useChatSessionId } from "@src/engines/ChatPanel/ChatSessionContext";
-import { derivedSnapshotAtom } from "@src/engines/SessionCore/core/atoms/events";
-import { chatEventsAtom } from "@src/engines/SessionCore/derived/chatEvents";
-import {
-  chatEventsForSessionAtomFamily,
-  sessionScopedPlanningMetaAtomFamily,
-} from "@src/engines/SessionCore/derived/sessionScopedChatEvents";
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+import { createChatTranscriptVersionTracker } from "@src/engines/SessionCore/derived/chatTranscriptStructure";
+import { chatEventsForSessionAtomFamily } from "@src/engines/SessionCore/derived/sessionScopedChatEvents";
 import { activeSessionIdAtom } from "@src/store/session";
 import { chatWidthAtom } from "@src/store/ui/chatPanelAtom";
 import { FeedBackInfo } from "@src/types/session/steps";
@@ -48,7 +46,8 @@ import { FeedBackInfo } from "@src/types/session/steps";
  *
  * chatHistory was removed from this context to prevent all consumers from
  * re-rendering on every chat event. Use useChatHistory() instead — it reads
- * directly from chatEventsAtom and only triggers the components that need it.
+ * directly from the session-scoped chat-events family and only triggers
+ * the components that need it.
  */
 export interface ChatContextType {
   // Chat UI state
@@ -180,65 +179,63 @@ export const useShowInteractArea = () => {
   return context;
 };
 
+const EMPTY_CHAT_HISTORY: never[] = [];
+
+export interface ChatHistorySource {
+  chatHistory: SessionEvent[];
+  sourceSessionId: string | null;
+  sourceVersion: number;
+}
+
+const EMPTY_CHAT_HISTORY_SOURCE: ChatHistorySource = {
+  chatHistory: EMPTY_CHAT_HISTORY,
+  sourceSessionId: null,
+  sourceVersion: 0,
+};
+
 /**
  * useChatHistory — read chat events for the active ChatHistory pipeline.
  *
- * Routing rules (prevents subagent-strip race where one cell reads another
- * cell's events):
+ * Always reads `chatEventsForSessionAtomFamily(sessionId)` so the primary
+ * ChatPanel and scoped surfaces share one derivation. `sourceVersion` is a
+ * structural transcript version (event ids / non-token fields), not the
+ * snapshot mutation counter, so streaming tokens do not resync projection.
  *
- * - If a {@link ChatSessionContext} override is present *and* it differs
- *   from the globally-active session, read from
- *   `chatEventsForSessionAtomFamily(sessionId)` — each family entry owns its
- *   own snapshot subscription and `_prev` cache.
- * - Otherwise, fall back to the global `chatEventsAtom` to preserve the
- *   primary ChatPanel behavior (single source of truth bound to the active
- *   session, including the shared streaming-merge cache).
- *
- * Implementation: a single `useAtomValue` reads a per-call selector atom,
- * so React only subscribes to one source at a time. Switching between
- * global and per-session paths (or between two subagent sessions) creates
- * a new selector atom; the prior subscription is released when the
- * selector identity changes. This avoids holding a dangling subscription
- * on a placeholder session id and keeps the per-session family entry
- * mounted only while it is actively rendered.
+ * Implementation: a single `useAtomValue` reads a per-call selector atom.
+ * Switching sessions creates a new selector; the prior family subscription
+ * is released when the selector identity changes.
  */
 export const useChatHistory = () => {
   const override = useChatHistoryOverride();
   const contextSessionId = useChatSessionId();
-  // `activeSessionIdAtom` is the global chat-pipeline session — the one
-  // `chatEventsAtom` is bound to. When ChatSessionContext matches it,
-  // both routes return the same data, but the global atom carries the
-  // shared streaming-merge cache and is the canonical primary path.
   const activeSessionId = useAtomValue(activeSessionIdAtom);
-  const usePerSession = Boolean(
-    contextSessionId && contextSessionId !== activeSessionId
-  );
+  const sessionId = contextSessionId ?? activeSessionId ?? null;
   const selectorAtom = useMemo(() => {
-    if (usePerSession && contextSessionId) {
-      const source = chatEventsForSessionAtomFamily(contextSessionId);
-      const meta = sessionScopedPlanningMetaAtomFamily(contextSessionId);
-      return atom((get) => ({
-        chatHistory: get(source),
-        sourceSessionId: contextSessionId,
-        sourceVersion: get(meta).version,
-      }));
+    if (!sessionId) {
+      return atom(() => EMPTY_CHAT_HISTORY_SOURCE);
     }
-    return atom((get) => {
-      const snapshot = get(derivedSnapshotAtom);
-      const snapshotSessionId =
-        snapshot?.lastEvent?.sessionId ??
-        snapshot?.chatEvents[0]?.sessionId ??
-        null;
-      return {
-        chatHistory: get(chatEventsAtom),
-        // An empty freshly-cleared snapshot is still authoritative for the
-        // active pipeline. A non-empty mismatched snapshot remains identifiable
-        // so projection never renders another session during a switch.
-        sourceSessionId: snapshotSessionId ?? activeSessionId,
-        sourceVersion: snapshot?.version ?? 0,
+    const source = chatEventsForSessionAtomFamily(sessionId);
+    const versionTracker = createChatTranscriptVersionTracker();
+    let previous: ChatHistorySource | null = null;
+    return atom((get): ChatHistorySource => {
+      const chatHistory = get(source);
+      const next: ChatHistorySource = {
+        chatHistory,
+        sourceSessionId: sessionId,
+        sourceVersion: versionTracker.next(chatHistory),
       };
+      if (
+        previous &&
+        previous.chatHistory === next.chatHistory &&
+        previous.sourceSessionId === next.sourceSessionId &&
+        previous.sourceVersion === next.sourceVersion
+      ) {
+        return previous;
+      }
+      previous = next;
+      return next;
     });
-  }, [activeSessionId, usePerSession, contextSessionId]);
+  }, [sessionId]);
   const atomSource = useAtomValue(selectorAtom);
   // Override takes precedence: lets a parent (e.g. the subagent grid
   // cell) inject a cursor-sliced event array so ChatHistory renders only

--- a/src/engines/ChatPanel/InputArea/AskQuestionCard/__tests__/TEST_CASES.md
+++ b/src/engines/ChatPanel/InputArea/AskQuestionCard/__tests__/TEST_CASES.md
@@ -1,0 +1,24 @@
+# Test Cases: questionSignals
+
+## Preconditions
+
+- Pure helpers over `SessionEvent` fixtures.
+
+## Happy Path
+
+| #   | Steps                               | Expected Result                               |
+| --- | ----------------------------------- | --------------------------------------------- |
+| 1   | Store has a complete ask-user batch | `batches` has one item; `streamingCount` is 0 |
+| 2   | Unrelated streaming tokens arrive   | `questionSignalsEqual` stays true             |
+
+## Edge Cases
+
+| #   | Scenario                           | Steps                 | Expected Result                  |
+| --- | ---------------------------------- | --------------------- | -------------------------------- |
+| 1   | In-flight ask with empty questions | Extract signals       | `streamingCount` is 1            |
+| 2   | Local dismiss of a batch           | Filter by dismiss map | Card hides; other batches remain |
+
+## Acceptance Criteria
+
+- [ ] AskQuestionCard does not re-render on every chat token
+- [ ] Loading shell still appears while questions stream in

--- a/src/engines/ChatPanel/InputArea/AskQuestionCard/__tests__/questionSignals.test.ts
+++ b/src/engines/ChatPanel/InputArea/AskQuestionCard/__tests__/questionSignals.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+
+import {
+  extractQuestionSignals,
+  questionSignalsEqual,
+} from "../questionSignals";
+
+function askEvent(
+  id: string,
+  overrides: Partial<SessionEvent> = {}
+): SessionEvent {
+  return {
+    id,
+    chunk_id: id,
+    sessionId: "session-1",
+    createdAt: "2026-06-18T00:00:00.000Z",
+    functionName: "ask_user_questions",
+    uiCanonical: "ask_user_questions",
+    actionType: "tool_call",
+    args: {
+      questions: [{ question: "Continue?", options: ["Yes", "No"] }],
+    },
+    result: {},
+    source: "assistant",
+    displayText: "",
+    displayStatus: "awaiting_user",
+    displayVariant: "tool_call",
+    activityStatus: "agent",
+    callId: id,
+    ...overrides,
+  } as SessionEvent;
+}
+
+describe("extractQuestionSignals", () => {
+  it("returns empty signals when there are no questions", () => {
+    expect(extractQuestionSignals([])).toEqual({
+      batches: [],
+      streamingCount: 0,
+    });
+  });
+
+  it("extracts a renderable batch", () => {
+    const signals = extractQuestionSignals([askEvent("q-1")]);
+    expect(signals.streamingCount).toBe(0);
+    expect(signals.batches).toHaveLength(1);
+    expect(signals.batches[0].questionId).toBe("q-1");
+    expect(signals.batches[0].questions[0].text).toBe("Continue?");
+  });
+
+  it("counts in-flight questions that are not yet renderable", () => {
+    const signals = extractQuestionSignals([
+      askEvent("q-stream", {
+        args: { questions: [] },
+        displayStatus: "running",
+      }),
+    ]);
+    expect(signals.batches).toEqual([]);
+    expect(signals.streamingCount).toBe(1);
+  });
+});
+
+describe("questionSignalsEqual", () => {
+  it("is true for identical extracted payloads", () => {
+    const first = extractQuestionSignals([askEvent("q-1")]);
+    const second = extractQuestionSignals([askEvent("q-1")]);
+    expect(questionSignalsEqual(first, second)).toBe(true);
+  });
+});

--- a/src/engines/ChatPanel/InputArea/AskQuestionCard/questionSignals.ts
+++ b/src/engines/ChatPanel/InputArea/AskQuestionCard/questionSignals.ts
@@ -1,0 +1,99 @@
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+
+import {
+  extractQuestionBatch,
+  isAskUserQuestionsEvent,
+} from "./extractQuestionBatch";
+import type { QuestionBatch } from "./types";
+
+export interface QuestionSignals {
+  batches: QuestionBatch[];
+  streamingCount: number;
+}
+
+export function extractQuestionSignals(
+  events: ReadonlyArray<SessionEvent>
+): QuestionSignals {
+  const batches: QuestionBatch[] = [];
+  const seenIds = new Set<string>();
+  let streamingCount = 0;
+
+  for (const event of events) {
+    const batch = extractQuestionBatch(event);
+    if (batch) {
+      if (batch.questionId && seenIds.has(batch.questionId)) continue;
+      if (batch.questionId) seenIds.add(batch.questionId);
+      batches.push(batch);
+      continue;
+    }
+
+    if (!isAskUserQuestionsEvent(event)) continue;
+    const status = event.displayStatus;
+    if (
+      status !== "running" &&
+      status !== "pending" &&
+      status !== "awaiting_user"
+    ) {
+      continue;
+    }
+    const result = event.result as Record<string, unknown> | undefined;
+    if (result && Object.keys(result).length > 0) continue;
+    streamingCount += 1;
+  }
+
+  return { batches, streamingCount };
+}
+
+function questionBatchEqual(
+  left: QuestionBatch,
+  right: QuestionBatch
+): boolean {
+  if (
+    left.questionId !== right.questionId ||
+    left.chunkId !== right.chunkId ||
+    left.sessionId !== right.sessionId ||
+    left.blocking !== right.blocking ||
+    left.autoResolveAt !== right.autoResolveAt ||
+    left.questions.length !== right.questions.length
+  ) {
+    return false;
+  }
+  for (let index = 0; index < left.questions.length; index += 1) {
+    const leftQuestion = left.questions[index];
+    const rightQuestion = right.questions[index];
+    if (
+      leftQuestion.text !== rightQuestion.text ||
+      leftQuestion.multiSelect !== rightQuestion.multiSelect ||
+      leftQuestion.options.length !== rightQuestion.options.length
+    ) {
+      return false;
+    }
+    for (
+      let optionIndex = 0;
+      optionIndex < leftQuestion.options.length;
+      optionIndex += 1
+    ) {
+      const leftOption = leftQuestion.options[optionIndex];
+      const rightOption = rightQuestion.options[optionIndex];
+      if (
+        leftOption.id !== rightOption.id ||
+        leftOption.label !== rightOption.label ||
+        leftOption.description !== rightOption.description
+      ) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+export function questionSignalsEqual(
+  left: QuestionSignals,
+  right: QuestionSignals
+): boolean {
+  if (left.streamingCount !== right.streamingCount) return false;
+  if (left.batches.length !== right.batches.length) return false;
+  return left.batches.every((batch, index) =>
+    questionBatchEqual(batch, right.batches[index])
+  );
+}

--- a/src/engines/ChatPanel/InputArea/AskQuestionCard/useQuestionBatches.ts
+++ b/src/engines/ChatPanel/InputArea/AskQuestionCard/useQuestionBatches.ts
@@ -29,7 +29,8 @@
  * lifecycle primitive is the
  * Promise / finalize event, not a client-side cache reconciliation.
  */
-import { useAtomValue } from "jotai";
+import { atom, useAtomValue } from "jotai";
+import { selectAtom } from "jotai/utils";
 import {
   type Dispatch,
   type SetStateAction,
@@ -38,14 +39,21 @@ import {
   useState,
 } from "react";
 
-import { useChatHistory } from "@src/contexts/workspace/ChatContext";
+import { useChatSessionId } from "@src/engines/ChatPanel/ChatSessionContext";
 import { editTruncationTimestampAtom } from "@src/engines/SessionCore";
+import { chatEventsForSessionAtomFamily } from "@src/engines/SessionCore/derived/sessionScopedChatEvents";
+import { activeSessionIdAtom } from "@src/store/session";
 
 import {
-  extractQuestionBatch,
-  isAskUserQuestionsEvent,
-} from "./extractQuestionBatch";
+  extractQuestionSignals,
+  questionSignalsEqual,
+} from "./questionSignals";
 import type { QuestionBatch } from "./types";
+
+const emptyQuestionSignalsAtom = atom({
+  batches: [] as QuestionBatch[],
+  streamingCount: 0,
+});
 
 export interface UseQuestionBatchesReturn {
   pendingBatches: QuestionBatch[];
@@ -64,7 +72,21 @@ export interface UseQuestionBatchesReturn {
 }
 
 export function useQuestionBatches(): UseQuestionBatchesReturn {
-  const { chatHistory } = useChatHistory();
+  const contextSessionId = useChatSessionId();
+  const activeSessionId = useAtomValue(activeSessionIdAtom);
+  const sessionId = contextSessionId ?? activeSessionId ?? "";
+  const questionSignalsAtom = useMemo(
+    () =>
+      sessionId
+        ? selectAtom(
+            chatEventsForSessionAtomFamily(sessionId),
+            extractQuestionSignals,
+            questionSignalsEqual
+          )
+        : emptyQuestionSignalsAtom,
+    [sessionId]
+  );
+  const questionSignals = useAtomValue(questionSignalsAtom);
   const editTruncation = useAtomValue(editTruncationTimestampAtom);
 
   // Each dismissal is tagged with the editTruncation value that was active
@@ -87,57 +109,15 @@ export function useQuestionBatches(): UseQuestionBatchesReturn {
   );
 
   const pendingBatches = useMemo(() => {
-    const batches: QuestionBatch[] = [];
-    const seenIds = new Set<string>();
-    for (const item of chatHistory) {
-      const batch = extractQuestionBatch(item);
-      if (!batch) continue;
-      if (batch.questionId && seenIds.has(batch.questionId)) continue;
+    return questionSignals.batches.filter((batch) => {
       const dismissTruncation = dismissedMap.get(batch.questionId);
-      if (
-        dismissTruncation !== undefined &&
-        dismissTruncation === editTruncation
-      )
-        continue;
-      if (batch.questionId) seenIds.add(batch.questionId);
-      batches.push(batch);
-    }
-    return batches;
-  }, [chatHistory, dismissedMap, editTruncation]);
+      return (
+        dismissTruncation === undefined || dismissTruncation !== editTruncation
+      );
+    });
+  }, [dismissedMap, editTruncation, questionSignals.batches]);
 
-  // Streaming detection: an ask_user_questions event whose args.questions
-  // payload hasn't reached "has at least one question with text" yet. The
-  // parser returns null for those, so they don't appear in `pendingBatches`,
-  // but we still want to render a loading shell.
-  //
-  // Positive whitelist: only treat the event as still-streaming when
-  // displayStatus is one of the in-flight states AND no tool_result has
-  // arrived yet. Any other state (skipped/cancelled/completed/failed/
-  // answered/undefined) is treated as terminal — prevents the shell from
-  // sticking forever when a question is dismissed or finalized via a
-  // status the parser doesn't recognise.
-  const streamingCount = useMemo(() => {
-    let count = 0;
-    for (const event of chatHistory) {
-      if (!isAskUserQuestionsEvent(event)) continue;
-      // Already renderable — handled by the normal batch path.
-      if (extractQuestionBatch(event)) continue;
-      // Only in-flight statuses can be "still streaming".
-      const status = event.displayStatus;
-      if (
-        status !== "running" &&
-        status !== "pending" &&
-        status !== "awaiting_user"
-      ) {
-        continue;
-      }
-      // Any tool_result presence means the call already finalized.
-      const result = event.result as Record<string, unknown> | undefined;
-      if (result && Object.keys(result).length > 0) continue;
-      count += 1;
-    }
-    return count;
-  }, [chatHistory]);
+  const streamingCount = questionSignals.streamingCount;
 
   const [rawBatchIndex, setBatchIndex] = useState(0);
   const batchIndex = useMemo(() => {

--- a/src/engines/ChatPanel/InputArea/ModeSwitchCard/__tests__/TEST_CASES.md
+++ b/src/engines/ChatPanel/InputArea/ModeSwitchCard/__tests__/TEST_CASES.md
@@ -1,0 +1,24 @@
+# Test Cases: pendingModeSwitch
+
+## Preconditions
+
+- Pure helpers over `SessionEvent` fixtures.
+
+## Happy Path
+
+| #   | Steps                                            | Expected Result                                              |
+| --- | ------------------------------------------------ | ------------------------------------------------------------ |
+| 1   | Latest event is unresolved `suggest_mode_switch` | Extractor returns that event's target/reason                 |
+| 2   | Token-only unrelated events arrive after         | `pendingModeSwitchEqual` stays true; card does not re-render |
+
+## Edge Cases
+
+| #   | Scenario                | Steps                          | Expected Result        |
+| --- | ----------------------- | ------------------------------ | ---------------------- |
+| 1   | Event is `processed`    | Scan store                     | Extractor returns null |
+| 2   | Optimistic `isResolved` | Atom still has pending payload | Hook hides the card    |
+
+## Acceptance Criteria
+
+- [ ] Mode-switch card does not subscribe to the full events array identity
+- [ ] Skip / Switch still hide the card immediately

--- a/src/engines/ChatPanel/InputArea/ModeSwitchCard/__tests__/pendingModeSwitch.test.ts
+++ b/src/engines/ChatPanel/InputArea/ModeSwitchCard/__tests__/pendingModeSwitch.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+
+import {
+  extractPendingModeSwitch,
+  pendingModeSwitchEqual,
+} from "../pendingModeSwitch";
+
+function event(overrides: Partial<SessionEvent> = {}): SessionEvent {
+  return {
+    id: "ms-1",
+    chunk_id: "ms-1",
+    sessionId: "session-1",
+    createdAt: "2026-06-18T00:00:00.000Z",
+    functionName: "suggest_mode_switch",
+    uiCanonical: "suggest_mode_switch",
+    actionType: "tool_call",
+    args: { target_mode: "plan", reason: "Need a plan" },
+    result: {},
+    source: "assistant",
+    displayText: "",
+    displayStatus: "awaiting_user",
+    displayVariant: "tool_call",
+    activityStatus: "agent",
+    ...overrides,
+  } as SessionEvent;
+}
+
+describe("extractPendingModeSwitch", () => {
+  it("returns null when there is no mode-switch event", () => {
+    expect(
+      extractPendingModeSwitch([
+        event({ functionName: "agent_message", id: "msg-1" }),
+      ])
+    ).toBeNull();
+  });
+
+  it("returns the latest unprocessed mode-switch payload", () => {
+    expect(
+      extractPendingModeSwitch([
+        event({ id: "old", args: { target_mode: "code", reason: "old" } }),
+        event({
+          id: "new",
+          args: { targetModeId: "plan", explanation: "Need a plan" },
+        }),
+      ])
+    ).toEqual({
+      eventId: "new",
+      targetMode: "plan",
+      reason: "Need a plan",
+      createdAt: "2026-06-18T00:00:00.000Z",
+    });
+  });
+
+  it("skips processed events", () => {
+    expect(
+      extractPendingModeSwitch([event({ activityStatus: "processed" })])
+    ).toBeNull();
+  });
+});
+
+describe("pendingModeSwitchEqual", () => {
+  it("treats identical payloads as equal", () => {
+    const pending = extractPendingModeSwitch([event()]);
+    expect(pendingModeSwitchEqual(pending, { ...pending! })).toBe(true);
+  });
+});

--- a/src/engines/ChatPanel/InputArea/ModeSwitchCard/__tests__/useModeSwitchActions.test.ts
+++ b/src/engines/ChatPanel/InputArea/ModeSwitchCard/__tests__/useModeSwitchActions.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { switchMode } from "./useModeSwitchActions";
+import { switchMode } from "../useModeSwitchActions";
 
 const storeGetSpy = vi.hoisted(() => vi.fn());
 const sendMessageSpy = vi.hoisted(() => vi.fn());

--- a/src/engines/ChatPanel/InputArea/ModeSwitchCard/index.tsx
+++ b/src/engines/ChatPanel/InputArea/ModeSwitchCard/index.tsx
@@ -10,53 +10,31 @@
  * actionable state.
  */
 import { useAtomValue } from "jotai";
+import { selectAtom } from "jotai/utils";
 import { useCallback, useEffect, useState } from "react";
 
 import { eventsAtom } from "@src/engines/SessionCore/core/atoms";
-import { stripMcpPrefix } from "@src/engines/SessionCore/core/interactiveTools";
 import { createLogger } from "@src/hooks/logger";
 
 import { ModeSwitchCardBody } from "./ModeSwitchCardBody";
+import {
+  extractPendingModeSwitch,
+  pendingModeSwitchEqual,
+} from "./pendingModeSwitch";
 import { isResolved, skipMode, switchMode } from "./useModeSwitchActions";
 
 const log = createLogger("ModeSwitchInputCard");
 
-// ============================================
-// Hook
-// ============================================
+const pendingModeSwitchAtom = selectAtom(
+  eventsAtom,
+  extractPendingModeSwitch,
+  pendingModeSwitchEqual
+);
 
-interface PendingModeSwitch {
-  eventId: string;
-  targetMode: string;
-  reason: string;
-  createdAt?: string;
-}
-
-function useModeSwitchPending(): PendingModeSwitch | null {
-  const events = useAtomValue(eventsAtom);
-
-  for (let idx = events.length - 1; idx >= 0; idx--) {
-    const event = events[idx];
-    if (stripMcpPrefix(event.functionName ?? "") !== "suggest_mode_switch")
-      continue;
-    if (event.activityStatus === "processed") continue;
-    const eventId = event.id ?? "";
-    if (isResolved(eventId)) continue;
-
-    return {
-      eventId,
-      targetMode:
-        (event.args.target_mode as string | undefined) ??
-        (event.args.targetModeId as string | undefined) ??
-        "plan",
-      reason:
-        (event.args.reason as string | undefined) ??
-        (event.args.explanation as string | undefined) ??
-        "",
-      createdAt: event.createdAt,
-    };
-  }
-  return null;
+function useModeSwitchPending() {
+  const pending = useAtomValue(pendingModeSwitchAtom);
+  if (pending && isResolved(pending.eventId)) return null;
+  return pending;
 }
 
 // ============================================

--- a/src/engines/ChatPanel/InputArea/ModeSwitchCard/pendingModeSwitch.ts
+++ b/src/engines/ChatPanel/InputArea/ModeSwitchCard/pendingModeSwitch.ts
@@ -1,0 +1,49 @@
+import { stripMcpPrefix } from "@src/engines/SessionCore/core/interactiveTools";
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+
+export interface PendingModeSwitch {
+  eventId: string;
+  targetMode: string;
+  reason: string;
+  createdAt?: string;
+}
+
+export function extractPendingModeSwitch(
+  events: ReadonlyArray<SessionEvent>
+): PendingModeSwitch | null {
+  for (let idx = events.length - 1; idx >= 0; idx -= 1) {
+    const event = events[idx];
+    if (stripMcpPrefix(event.functionName ?? "") !== "suggest_mode_switch") {
+      continue;
+    }
+    if (event.activityStatus === "processed") continue;
+
+    return {
+      eventId: event.id ?? "",
+      targetMode:
+        (event.args.target_mode as string | undefined) ??
+        (event.args.targetModeId as string | undefined) ??
+        "plan",
+      reason:
+        (event.args.reason as string | undefined) ??
+        (event.args.explanation as string | undefined) ??
+        "",
+      createdAt: event.createdAt,
+    };
+  }
+  return null;
+}
+
+export function pendingModeSwitchEqual(
+  left: PendingModeSwitch | null,
+  right: PendingModeSwitch | null
+): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  return (
+    left.eventId === right.eventId &&
+    left.targetMode === right.targetMode &&
+    left.reason === right.reason &&
+    left.createdAt === right.createdAt
+  );
+}

--- a/src/engines/ChatPanel/hooks/useChatPanelState.ts
+++ b/src/engines/ChatPanel/hooks/useChatPanelState.ts
@@ -13,19 +13,14 @@
  *   winType,
  *   handleTabChange,
  *   showInteractArea,
- *   chatHistory,
  * } = useChatPanelState();
  */
 import { useAtom } from "jotai";
 import { useCallback, useState } from "react";
 
-import {
-  useChatContext,
-  useChatHistory,
-} from "@src/contexts/workspace/ChatContext";
+import { useChatContext } from "@src/contexts/workspace/ChatContext";
 import { useDataContext } from "@src/contexts/workspace/DataContext";
 import { useTaskStatus } from "@src/engines/SessionCore";
-import type { SessionEvent } from "@src/engines/SessionCore/core/types";
 import { chatDropDownShowAtom } from "@src/store/ui/chatPanelAtom";
 
 // ============================================
@@ -48,8 +43,6 @@ export interface UseChatPanelReturn {
   // Chat context data
   /** Whether to show the input area */
   showInteractArea: boolean;
-  /** Chat history events */
-  chatHistory: SessionEvent[];
   /** Current chat panel width */
   chatWidth: number;
   /** Set chat panel width */
@@ -83,7 +76,6 @@ export function useChatPanelState(): UseChatPanelReturn {
   // ============================================
 
   const { taskStatus: wpTaskStatus } = useTaskStatus();
-  const { chatHistory } = useChatHistory();
   const { showInteractArea, chatWidth, setChatWidth } = useChatContext();
   const { regeList } = useDataContext();
 
@@ -129,7 +121,6 @@ export function useChatPanelState(): UseChatPanelReturn {
 
     // Chat context
     showInteractArea,
-    chatHistory,
     chatWidth,
     setChatWidth,
 

--- a/src/engines/ChatPanel/hooks/useStreamingHud.ts
+++ b/src/engines/ChatPanel/hooks/useStreamingHud.ts
@@ -19,7 +19,7 @@
 import { useAtomValue } from "jotai";
 import { useEffect, useMemo, useState } from "react";
 
-import { streamingDeltaContentAtom } from "@src/engines/SessionCore/core/atoms";
+import { useStreamingDeltaForSession } from "@src/engines/SessionCore";
 import { isSessionEngineActiveAtom } from "@src/store/session/cliSessionStatusAtom";
 
 import {
@@ -40,9 +40,7 @@ export function useStreamingHud(
   sessionId: string | undefined
 ): StreamingHudState {
   const engineActive = useAtomValue(isSessionEngineActiveAtom);
-  const deltaMap = useAtomValue(streamingDeltaContentAtom);
-
-  const liveDelta = sessionId ? deltaMap.get(sessionId) : undefined;
+  const liveDelta = useStreamingDeltaForSession(sessionId);
   const deltaContent = liveDelta?.content ?? "";
   const producing = engineActive && !!sessionId;
 

--- a/src/engines/SessionCore/derived/__tests__/TEST_CASES.md
+++ b/src/engines/SessionCore/derived/__tests__/TEST_CASES.md
@@ -1,0 +1,36 @@
+# Test Cases: chat transcript structure
+
+## Preconditions
+
+- Helpers run against in-memory `SessionEvent` fixtures; no EventStore or React.
+
+## Happy Path
+
+| #   | Steps                                                       | Expected Result                         |
+| --- | ----------------------------------------------------------- | --------------------------------------- |
+| 1   | Build a structure key for `[]`                              | Key is `"0"`                            |
+| 2   | Grow `displayText` on the last `isDelta` event              | Structure key and version stay the same |
+| 3   | Change last event `displayStatus` from running to completed | Version increments by 1                 |
+
+## Edge Cases
+
+| #   | Scenario                             | Steps                                                      | Expected Result                                                         |
+| --- | ------------------------------------ | ---------------------------------------------------------- | ----------------------------------------------------------------------- |
+| 1   | Non-streaming last-event text change | Compare two completed events with different `displayText`  | Keys differ; `areChatTranscriptsStructurallyEqual(..., false)` is false |
+| 2   | Streaming last-event text change     | Same ids/status, different `displayText`, `streaming=true` | Structural equality is true                                             |
+
+## Error / Degraded States
+
+| #   | Scenario                                         | Steps                                                           | Expected Result                                                   |
+| --- | ------------------------------------------------ | --------------------------------------------------------------- | ----------------------------------------------------------------- |
+| 1   | Family streaming snapshot with token-only growth | Push two StreamingSnapshots that only change last `displayText` | `chatEventsForSessionAtomFamily` returns the same array reference |
+
+## Accessibility
+
+- Not applicable (pure derivation, no UI)
+
+## Acceptance Criteria
+
+- [ ] Token-only streaming updates do not bump `sourceVersion`
+- [ ] Event id / status / adapter-routing arg changes do bump `sourceVersion`
+- [ ] Primary `useChatHistory` reads the session-scoped family, not `derivedSnapshotAtom.version`

--- a/src/engines/SessionCore/derived/__tests__/chatTranscriptStructure.test.ts
+++ b/src/engines/SessionCore/derived/__tests__/chatTranscriptStructure.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+
+import {
+  areChatTranscriptsStructurallyEqual,
+  chatTranscriptStructureKey,
+  createChatTranscriptVersionTracker,
+} from "../chatTranscriptStructure";
+
+function event(
+  id: string,
+  overrides: Partial<SessionEvent> = {}
+): SessionEvent {
+  return {
+    id,
+    chunk_id: id,
+    sessionId: "session-1",
+    createdAt: "2026-06-18T00:00:00.000Z",
+    functionName: "agent_message",
+    uiCanonical: "agent_message",
+    actionType: "assistant",
+    args: {},
+    result: { observation: id },
+    source: "assistant",
+    displayText: id,
+    displayStatus: "completed",
+    displayVariant: "message",
+    activityStatus: "agent",
+    ...overrides,
+  } as SessionEvent;
+}
+
+describe("chatTranscriptStructureKey", () => {
+  it("returns a stable empty key", () => {
+    expect(chatTranscriptStructureKey([])).toBe("0");
+  });
+
+  it("ignores displayText growth on the last delta event", () => {
+    const before = [
+      event("user-1", { source: "user", displayVariant: "message" }),
+      event("live-1", {
+        isDelta: true,
+        displayStatus: "running",
+        displayText: "Hel",
+      }),
+    ];
+    const after = [
+      event("user-1", { source: "user", displayVariant: "message" }),
+      event("live-1", {
+        isDelta: true,
+        displayStatus: "running",
+        displayText: "Hello world",
+      }),
+    ];
+    expect(chatTranscriptStructureKey(before)).toBe(
+      chatTranscriptStructureKey(after)
+    );
+  });
+
+  it("changes when a completed event's displayText changes", () => {
+    const before = [event("msg-1", { displayText: "old" })];
+    const after = [event("msg-1", { displayText: "new" })];
+    expect(chatTranscriptStructureKey(before)).not.toBe(
+      chatTranscriptStructureKey(after)
+    );
+  });
+});
+
+describe("createChatTranscriptVersionTracker", () => {
+  it("does not bump for token-only last-delta growth", () => {
+    const tracker = createChatTranscriptVersionTracker();
+    const first = tracker.next([
+      event("live-1", {
+        isDelta: true,
+        displayStatus: "running",
+        displayText: "Hel",
+      }),
+    ]);
+    const second = tracker.next([
+      event("live-1", {
+        isDelta: true,
+        displayStatus: "running",
+        displayText: "Hello",
+      }),
+    ]);
+    expect(second).toBe(first);
+  });
+
+  it("bumps when an event id or status changes", () => {
+    const tracker = createChatTranscriptVersionTracker();
+    const first = tracker.next([
+      event("live-1", { isDelta: true, displayStatus: "running" }),
+    ]);
+    const second = tracker.next([
+      event("live-1", { isDelta: false, displayStatus: "completed" }),
+    ]);
+    expect(second).toBe(first + 1);
+  });
+});
+
+describe("areChatTranscriptsStructurallyEqual", () => {
+  it("treats streaming last-event displayText as equal", () => {
+    const prev = [
+      event("live-1", {
+        isDelta: true,
+        displayStatus: "running",
+        displayText: "Hel",
+      }),
+    ];
+    const next = [
+      event("live-1", {
+        isDelta: true,
+        displayStatus: "running",
+        displayText: "Hello",
+      }),
+    ];
+    expect(areChatTranscriptsStructurallyEqual(next, prev, true)).toBe(true);
+    expect(areChatTranscriptsStructurallyEqual(next, prev, false)).toBe(false);
+  });
+});

--- a/src/engines/SessionCore/derived/__tests__/sessionScopedChatEvents.stability.test.ts
+++ b/src/engines/SessionCore/derived/__tests__/sessionScopedChatEvents.stability.test.ts
@@ -1,0 +1,123 @@
+import { createStore } from "jotai";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+import { chatEventsForSessionAtomFamily } from "@src/engines/SessionCore/derived/sessionScopedChatEvents";
+
+const subscribers = new Map<string, (snapshot: unknown) => void>();
+
+vi.mock("@src/engines/SessionCore/core/store/EventStoreProxy", () => ({
+  eventStoreProxy: {
+    getLatestSessionSnapshot: () => null,
+    subscribeSession: (
+      sessionId: string,
+      listener: (snapshot: unknown) => void
+    ) => {
+      subscribers.set(sessionId, listener);
+      return () => subscribers.delete(sessionId);
+    },
+    loadFromCache: () => Promise.resolve(),
+  },
+  isStreamingSnapshot: (snapshot: unknown) =>
+    Boolean(
+      (snapshot as { streaming?: boolean; events?: unknown })?.streaming &&
+      !("events" in (snapshot as object))
+    ),
+  isSnapshotActivelyStreaming: (snapshot: unknown) =>
+    Boolean((snapshot as { streaming?: boolean })?.streaming),
+}));
+
+function chatEvent(
+  id: string,
+  displayText: string,
+  overrides: Partial<SessionEvent> = {}
+): SessionEvent {
+  return {
+    id,
+    chunk_id: id,
+    sessionId: "session-1",
+    createdAt: "2026-06-18T00:00:00.000Z",
+    functionName: "agent_message",
+    uiCanonical: "agent_message",
+    actionType: "assistant",
+    args: {},
+    result: { observation: displayText },
+    source: "assistant",
+    displayText,
+    displayStatus: "running",
+    displayVariant: "message",
+    activityStatus: "agent",
+    isDelta: true,
+    ...overrides,
+  } as SessionEvent;
+}
+
+function streamingSnapshot(version: number, chatEvents: SessionEvent[]) {
+  return {
+    version,
+    eventCount: chatEvents.length,
+    chatEvents,
+    sortedSimulatorEvents: [],
+    lastEvent: chatEvents.at(-1) ?? null,
+    streaming: true,
+    hasRunningEvent: true,
+  };
+}
+
+describe("chatEventsForSessionAtomFamily streaming stability", () => {
+  let store: ReturnType<typeof createStore>;
+
+  beforeEach(() => {
+    store = createStore();
+  });
+
+  afterEach(() => {
+    subscribers.clear();
+  });
+
+  it("keeps the same array reference when only last-delta displayText grows", async () => {
+    const sessionId = "stability-stream";
+    const chatAtom = chatEventsForSessionAtomFamily(sessionId);
+    const unsub = store.sub(chatAtom, () => {});
+    await Promise.resolve();
+
+    const listener = subscribers.get(sessionId);
+    expect(listener).toBeDefined();
+
+    listener?.(streamingSnapshot(1, [chatEvent("live-1", "Hel")]));
+    const first = store.get(chatAtom);
+
+    listener?.(streamingSnapshot(2, [chatEvent("live-1", "Hello world")]));
+    const second = store.get(chatAtom);
+
+    expect(second).toBe(first);
+    unsub();
+  });
+
+  it("returns a new array when the last event completes", async () => {
+    const sessionId = "stability-complete";
+    const chatAtom = chatEventsForSessionAtomFamily(sessionId);
+    const unsub = store.sub(chatAtom, () => {});
+    await Promise.resolve();
+
+    const listener = subscribers.get(sessionId);
+    listener?.(streamingSnapshot(1, [chatEvent("live-1", "Hello")]));
+    const first = store.get(chatAtom);
+
+    listener?.(
+      streamingSnapshot(2, [
+        chatEvent("live-1", "Hello", {
+          isDelta: false,
+          displayStatus: "completed",
+        }),
+      ])
+    );
+    const second = store.get(chatAtom);
+
+    expect(second).not.toBe(first);
+    expect(second.find((event) => event.id === "live-1")?.displayStatus).toBe(
+      "completed"
+    );
+    unsub();
+  });
+});

--- a/src/engines/SessionCore/derived/__tests__/sessionScopedChatEventsRetention.test.ts
+++ b/src/engines/SessionCore/derived/__tests__/sessionScopedChatEventsRetention.test.ts
@@ -32,6 +32,11 @@ vi.mock("@src/engines/SessionCore/core/store/EventStoreProxy", () => ({
     loadFromCache: () => Promise.resolve(),
   },
   isStreamingSnapshot: (snapshot: unknown) =>
+    Boolean(
+      (snapshot as { streaming?: boolean; events?: unknown })?.streaming &&
+      !("events" in (snapshot as object))
+    ),
+  isSnapshotActivelyStreaming: (snapshot: unknown) =>
     Boolean((snapshot as { streaming?: boolean })?.streaming),
 }));
 

--- a/src/engines/SessionCore/derived/chatEvents.ts
+++ b/src/engines/SessionCore/derived/chatEvents.ts
@@ -94,7 +94,7 @@ function getSyntheticUserText(event: SessionEvent): string {
   return normalizeEventText(event.displayText);
 }
 
-function filterQueuedSyntheticUserEvents(
+export function filterQueuedSyntheticUserEvents(
   events: SessionEvent[],
   queuedMessages: QueuedMessage[]
 ): SessionEvent[] {

--- a/src/engines/SessionCore/derived/chatTranscriptStructure.ts
+++ b/src/engines/SessionCore/derived/chatTranscriptStructure.ts
@@ -1,0 +1,72 @@
+import type { SessionEvent } from "@src/engines/SessionCore/core/types";
+
+import { planEventContentSignature } from "./planDisplayEvents";
+
+/**
+ * Structural identity of a chat transcript for projection / history
+ * orchestration. Token-only growth on the last streaming event is ignored
+ * so snapshot.version / displayText churn does not look like a new source.
+ */
+export function chatTranscriptStructureKey(
+  events: ReadonlyArray<SessionEvent>
+): string {
+  if (events.length === 0) return "0";
+
+  let key = `${events.length}`;
+  const lastIndex = events.length - 1;
+  for (let index = 0; index < events.length; index += 1) {
+    const event = events[index];
+    const args = event.args as Record<string, unknown> | undefined;
+    key += `|${event.id}:${event.displayStatus}:${event.isDelta ? 1 : 0}:${String(args?.["action"] ?? "")}:${String(args?.["subagentSessionId"] ?? "")}:${planEventContentSignature(event)}`;
+    if (index === lastIndex && event.isDelta === true) continue;
+    key += `:${event.displayText ?? ""}`;
+  }
+  return key;
+}
+
+export function createChatTranscriptVersionTracker(): {
+  next: (events: ReadonlyArray<SessionEvent>) => number;
+} {
+  let previousKey = "";
+  let version = 0;
+  return {
+    next(events: ReadonlyArray<SessionEvent>): number {
+      const key = chatTranscriptStructureKey(events);
+      if (key !== previousKey) {
+        previousKey = key;
+        version += 1;
+      }
+      return version;
+    },
+  };
+}
+
+export function areChatTranscriptsStructurallyEqual(
+  next: ReadonlyArray<SessionEvent>,
+  prev: ReadonlyArray<SessionEvent>,
+  streaming: boolean
+): boolean {
+  if (next.length !== prev.length) return false;
+  for (let index = 0; index < next.length; index += 1) {
+    if (next[index].id !== prev[index].id) return false;
+    if (next[index].displayStatus !== prev[index].displayStatus) return false;
+    if (next[index].isDelta !== prev[index].isDelta) return false;
+    const nextArgs = next[index].args as Record<string, unknown> | undefined;
+    const prevArgs = prev[index].args as Record<string, unknown> | undefined;
+    if (nextArgs?.["action"] !== prevArgs?.["action"]) return false;
+    if (nextArgs?.["subagentSessionId"] !== prevArgs?.["subagentSessionId"]) {
+      return false;
+    }
+    if (
+      planEventContentSignature(next[index]) !==
+      planEventContentSignature(prev[index])
+    ) {
+      return false;
+    }
+  }
+  if (next.length === 0) return true;
+  if (streaming) return true;
+  return (
+    next[next.length - 1].displayText === prev[prev.length - 1].displayText
+  );
+}

--- a/src/engines/SessionCore/derived/sessionScopedChatEvents.ts
+++ b/src/engines/SessionCore/derived/sessionScopedChatEvents.ts
@@ -29,6 +29,10 @@ import { atom } from "jotai";
 import { atomFamily } from "jotai-family";
 
 import { createLogger } from "@src/hooks/logger";
+import {
+  type QueuedMessage,
+  messageQueueAtom,
+} from "@src/store/ui/messageQueueAtom";
 import { isCursorIdeSession } from "@src/util/session/sessionDispatch";
 
 import { isInteractiveTool } from "../core/interactiveTools";
@@ -45,9 +49,11 @@ import {
 import type { SessionEvent } from "../core/types";
 import { ensureCursorIdeEventsInStore } from "../sync/adapters/cursorIdeAdapter";
 import {
-  derivePlanDisplayEvents,
-  planEventContentSignature,
-} from "./planDisplayEvents";
+  appendLiveAssistantEvent,
+  filterQueuedSyntheticUserEvents,
+} from "./chatEvents";
+import { areChatTranscriptsStructurallyEqual } from "./chatTranscriptStructure";
+import { derivePlanDisplayEvents } from "./planDisplayEvents";
 
 const log = createLogger("sessionScopedChatEvents");
 
@@ -171,28 +177,22 @@ export function extractSessionChatEvents(
   return [];
 }
 
-function chatEventsStable(
-  next: SessionEvent[],
-  prev: SessionEvent[],
-  streaming: boolean
-): boolean {
-  if (streaming) return false;
-  if (next.length !== prev.length) return false;
-  for (let i = 0; i < next.length; i++) {
-    if (next[i].id !== prev[i].id) return false;
-    if (next[i].displayStatus !== prev[i].displayStatus) return false;
-    if (next[i].isDelta !== prev[i].isDelta) return false;
-    const na = next[i].args as Record<string, unknown> | undefined;
-    const pa = prev[i].args as Record<string, unknown> | undefined;
-    if (na?.["action"] !== pa?.["action"]) return false;
-    if (na?.["subagentSessionId"] !== pa?.["subagentSessionId"]) return false;
-    if (
-      planEventContentSignature(next[i]) !== planEventContentSignature(prev[i])
-    ) {
-      return false;
-    }
-  }
-  return true;
+function deriveFamilyChatEvents(
+  snapshot: Snapshot | null,
+  sessionId: string,
+  queuedMessages: readonly QueuedMessage[]
+): SessionEvent[] {
+  const streaming = snapshot ? isSnapshotActivelyStreaming(snapshot) : false;
+  return appendLiveAssistantEvent(
+    derivePlanDisplayEvents(
+      filterQueuedSyntheticUserEvents(
+        extractSessionChatEvents(snapshot),
+        queuedMessages as QueuedMessage[]
+      )
+    ),
+    sessionId,
+    streaming ? "\u200b" : null
+  );
 }
 
 /**
@@ -207,11 +207,14 @@ export const chatEventsForSessionAtomFamily = atomFamily(
 
     const a = atom((get) => {
       const { snapshot } = get(sessionSnapshotAtomFamily(sessionId));
-      const next = derivePlanDisplayEvents(extractSessionChatEvents(snapshot));
+      const queuedMessages = get(messageQueueAtom);
+      const next = deriveFamilyChatEvents(snapshot, sessionId, queuedMessages);
       const streaming = snapshot
         ? isSnapshotActivelyStreaming(snapshot)
         : false;
-      if (chatEventsStable(next, prevChatEvents, streaming)) {
+      if (
+        areChatTranscriptsStructurallyEqual(next, prevChatEvents, streaming)
+      ) {
         return prevChatEvents;
       }
       prevChatEvents = next;


### PR DESCRIPTION
## Problem

After #1024, ChatHistory still subscribed to the global snapshot on the primary ChatPanel path and used `snapshot.version` as `sourceVersion`. Every streaming envelope bumps that counter, so history orchestration and projection resynced on tokens even when `chatEvents` structure was unchanged. Composer-adjacent surfaces (mode-switch, ask-question, streaming HUD) also subscribed to full event arrays or the whole streaming-delta Map, so they re-rendered with each token.

## Solution

- Route `useChatHistory` through `chatEventsForSessionAtomFamily` for both the primary panel and scoped surfaces.
- Derive `sourceVersion` from transcript structure (event ids, status, adapter args, plan signature), ignoring last-delta `displayText` growth.
- Keep per-session family arrays stable during token-only streaming, including the live-assistant placeholder and queued synthetic-user filter.
- Narrow ModeSwitch and AskQuestion to `selectAtom` payloads, and HUD to `useStreamingDeltaForSession`.
- Drop the unused full-history subscription from `useChatPanelState`.

## Potential risks

- Primary ChatHistory now hydrates from the per-session snapshot channel instead of the global bridge-merged atom. A subscribe/hydrate race on session switch could briefly show an empty transcript until the family cache lands (IPC `getTodos`/comments paths are unchanged).
- Mode-switch still reads `eventsAtom` (not chat-only). A `suggest_mode_switch` that exists only on the full event list still works; chat-only filtering would miss it.
- AskQuestion signals omit locally dismissed batches in the hook, not the selector. Dismiss + truncation rollback still depends on `editTruncationTimestampAtom`.

## Verification

- `pnpm vitest run src/engines/SessionCore/derived/__tests__/chatTranscriptStructure.test.ts src/engines/SessionCore/derived/__tests__/sessionScopedChatEvents.stability.test.ts src/engines/ChatPanel/InputArea/ModeSwitchCard/__tests__/pendingModeSwitch.test.ts src/engines/ChatPanel/InputArea/AskQuestionCard/__tests__/questionSignals.test.ts` — 16/16 passed after rebase onto `develop`
- Pre-commit scoped TypeScript check on staged files — passed
- Manual QA remaining: streaming transcript, AskQuestion card + loading shell, mode-switch Skip/Switch, composer HUD, subagent history

Follows #1024. Base is `develop`.