### PR TITLE
test(kanban): expect the dedicated SDE agent icon

### DIFF
--- a/src/features/TaskKanban/hooks/useKanbanTasks/sessionToKanbanTask.test.ts
+++ b/src/features/TaskKanban/hooks/useKanbanTasks/sessionToKanbanTask.test.ts
@@ -66,6 +66,8 @@ describe("sessionToKanbanTask agent label", () => {
   });
 
   it("labels built-in Rust agents simply as ORG2", () => {
+    // The built-in SDE agent carries its own dedicated icon since the
+    // iconography unification (69e591f69); the label stays ORG2.
     const task = toTask(
       makeSession({
         session_id: "sdeagent-session-1",
@@ -76,6 +78,21 @@ describe("sessionToKanbanTask agent label", () => {
     );
 
     expect(task).toMatchObject({
+      agentLabel: "ORG2",
+      agentIconId: "ai-programming",
+    });
+
+    // Other built-in definitions still fall back to the generic ORG2 glyph.
+    const generic = toTask(
+      makeSession({
+        session_id: "sdeagent-session-2",
+        agentDefinitionId: "builtin:researcher",
+        agentIconId: "code",
+        agentDisplayName: "Researcher",
+      })
+    );
+
+    expect(generic).toMatchObject({
       agentLabel: "ORG2",
       agentIconId: "orgii",
     });


### PR DESCRIPTION
## Problem

Develop's frontend CI is red for every open PR: `sessionToKanbanTask.test.ts` still expects built-in Rust agents to carry the generic `orgii` icon, but commit 69e591f69 ("refactor(icons): unify workspace iconography", pushed directly to develop) deliberately gives the built-in SDE agent its own `ai-programming` icon (it also updates the Rust definition and the icon mapping docs). The commit landed without a PR, so no CI gated it, and the stale expectation now fails on every merge-commit build.

## Solution

Update the test to the intended behavior: `builtin:sde` → `agentLabel: "ORG2"` with `agentIconId: "ai-programming"`, and add a `builtin:researcher` case so the generic-orgii fallback arm keeps the coverage the old assertion provided.

## Potential risks

None material — test-only change tracking an already-shipped intentional behavior; the added case extends coverage.

## Verification

- `npx vitest run` on `sessionToKanbanTask.test.ts` + `sessionDisplayMetadata.test.ts` → **25 passed, 0 failed** (the former failed 1 before this change, reproducing the CI failure locally against develop).
- eslint / prettier clean.
- Built via temp index from a live checkout, so pre-commit hooks did not run (`Pre-commit hook ran.` trailer intentionally absent); checks above were run manually.
