### PR TITLE
fix(git-api): parse porcelain status with -z in discard_changes

### DIFF
--- a/src-tauri/crates/git-api/src/commands/staging.rs
+++ b/src-tauri/crates/git-api/src/commands/staging.rs
@@ -7,6 +7,10 @@ use super::utils::run_git;
  */
 use std::path::Path;
 
+#[cfg(test)]
+#[path = "tests/staging_tests.rs"]
+mod tests;
+
 /// Stage all files
 pub fn stage_all_files(repo_path: &Path) -> Result<(), String> {
     let output = run_git(repo_path, &["add", "-A"])?;
@@ -54,8 +58,14 @@ pub fn discard_changes(repo_path: &Path, files: &[String]) -> Result<(), String>
     // Special case: "." means discard everything
     let discard_all = files.len() == 1 && files[0] == ".";
 
-    // First, get the status of all files to determine how to handle each
-    let status_output = run_git(repo_path, &["status", "--porcelain"])?;
+    // First, get the status of all files to determine how to handle each.
+    // `-z` is load-bearing: without it, git quotes-and-escapes any non-ASCII
+    // path (default core.quotePath), so the parsed name never matched the
+    // real file — a targeted discard errored out and "discard all" silently
+    // skipped the file while reporting success. `-z` paths are verbatim and
+    // NUL-separated, and a rename's original path arrives as its own
+    // NUL-separated field instead of a literal "new -> old" string.
+    let status_output = run_git(repo_path, &["status", "--porcelain", "-z"])?;
 
     if !status_output.status.success() {
         return Err(String::from_utf8_lossy(&status_output.stderr).to_string());
@@ -72,13 +82,16 @@ pub fn discard_changes(repo_path: &Path, files: &[String]) -> Result<(), String>
     let mut staged_files: std::collections::HashSet<&str> = std::collections::HashSet::new();
     let mut conflict_files: std::collections::HashSet<&str> = std::collections::HashSet::new();
 
-    for line in status_str.lines() {
-        if line.len() < 3 {
+    let mut entries = status_str.split('\0');
+    // Not a `for` loop: a rename's original path is consumed from the same
+    // iterator inside the body.
+    while let Some(entry) = entries.next() {
+        if entry.len() < 3 {
             continue;
         }
-        let index_status = line.chars().next().unwrap_or(' ');
-        let worktree_status = line.chars().nth(1).unwrap_or(' ');
-        let file_path = line[3..].trim();
+        let index_status = entry.chars().next().unwrap_or(' ');
+        let worktree_status = entry.chars().nth(1).unwrap_or(' ');
+        let file_path = &entry[3..];
 
         // Conflict files: UU, AA, DD, AU, UA, DU, UD
         if index_status == 'U'
@@ -87,6 +100,20 @@ pub fn discard_changes(repo_path: &Path, files: &[String]) -> Result<(), String>
             || (index_status == 'D' && worktree_status == 'D')
         {
             conflict_files.insert(file_path);
+            continue;
+        }
+
+        if index_status == 'R' || index_status == 'C' {
+            // The entry names the NEW path; the ORIGINAL path follows as its
+            // own NUL field (consume it so it is not misread as an entry).
+            // Discarding a rename means deleting the new path like a staged
+            // new file and restoring the original like a staged change.
+            staged_new_files.insert(file_path);
+            if let Some(original) = entries.next() {
+                if !original.is_empty() {
+                    staged_files.insert(original);
+                }
+            }
             continue;
         }
 
@@ -99,8 +126,8 @@ pub fn discard_changes(repo_path: &Path, files: &[String]) -> Result<(), String>
                 // "A " or "AM" = staged new file (added to index but not in HEAD)
                 staged_new_files.insert(file_path);
             }
-            'M' | 'D' | 'R' => {
-                // Staged modification/deletion/rename - needs unstaging before checkout
+            'M' | 'D' => {
+                // Staged modification/deletion - needs unstaging before checkout
                 staged_files.insert(file_path);
             }
             _ => {}

--- a/src-tauri/crates/git-api/src/commands/tests/staging_tests.rs
+++ b/src-tauri/crates/git-api/src/commands/tests/staging_tests.rs
@@ -1,0 +1,145 @@
+use crate::commands::staging::discard_changes;
+
+fn git_in(dir: &std::path::Path, args: &[&str]) {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args([
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "-c",
+            "commit.gpgsign=false",
+            "-c",
+            "init.defaultBranch=main",
+        ])
+        .args(args)
+        .output()
+        .expect("spawn git");
+    assert!(
+        out.status.success(),
+        "git {:?} failed: {}{}",
+        args,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn make_repo(tag: &str) -> std::path::PathBuf {
+    let repo = std::env::temp_dir().join(format!(
+        "orgii-staging-{tag}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock after epoch")
+            .as_nanos()
+    ));
+    let _ = std::fs::remove_dir_all(&repo);
+    std::fs::create_dir_all(&repo).expect("create test repo dir");
+    git_in(&repo, &["init"]);
+    std::fs::write(repo.join("tracked.txt"), "one\n").expect("write tracked");
+    git_in(&repo, &["add", "."]);
+    git_in(&repo, &["commit", "-m", "init"]);
+    repo
+}
+
+fn git_available() -> bool {
+    std::process::Command::new("git")
+        .arg("--version")
+        .output()
+        .is_ok()
+}
+
+/// Regression: `git status --porcelain` (without -z) quotes-and-escapes
+/// non-ASCII paths, so the parsed name never matched the real file —
+/// "discard all" silently skipped it while reporting success, and a targeted
+/// discard errored with "pathspec did not match".
+#[test]
+fn discard_all_removes_non_ascii_untracked_files() {
+    if !git_available() {
+        eprintln!("skipping: git executable not available");
+        return;
+    }
+    let repo = make_repo("quotepath");
+
+    std::fs::write(repo.join("émoji café.txt"), "untracked\n").expect("write unicode file");
+    std::fs::write(repo.join("tracked.txt"), "one\ndirty\n").expect("dirty tracked");
+
+    discard_changes(&repo, &[".".to_string()]).expect("discard all");
+
+    assert!(
+        !repo.join("émoji café.txt").exists(),
+        "quoted-path untracked file must be deleted, not silently skipped"
+    );
+    assert_eq!(
+        std::fs::read_to_string(repo.join("tracked.txt")).expect("read tracked"),
+        "one\n",
+        "tracked edit must be discarded"
+    );
+
+    let _ = std::fs::remove_dir_all(&repo);
+}
+
+/// Regression: a staged rename used to parse as the literal path
+/// "old -> new", matching nothing — the discard errored out (targeted) or
+/// skipped the rename (discard all).
+#[test]
+fn discard_all_undoes_a_staged_rename() {
+    if !git_available() {
+        eprintln!("skipping: git executable not available");
+        return;
+    }
+    let repo = make_repo("rename");
+
+    git_in(&repo, &["mv", "tracked.txt", "renamed.txt"]);
+
+    discard_changes(&repo, &[".".to_string()]).expect("discard all");
+
+    assert!(
+        repo.join("tracked.txt").exists(),
+        "original path must be restored"
+    );
+    assert!(
+        !repo.join("renamed.txt").exists(),
+        "rename target must be removed"
+    );
+    let status = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&repo)
+        .args(["status", "--porcelain"])
+        .output()
+        .expect("status");
+    assert!(
+        status.stdout.is_empty(),
+        "tree must be clean after discard: {}",
+        String::from_utf8_lossy(&status.stdout)
+    );
+
+    let _ = std::fs::remove_dir_all(&repo);
+}
+
+#[test]
+fn targeted_discard_restores_a_single_dirty_file() {
+    if !git_available() {
+        eprintln!("skipping: git executable not available");
+        return;
+    }
+    let repo = make_repo("targeted");
+
+    std::fs::write(repo.join("tracked.txt"), "one\ndirty\n").expect("dirty tracked");
+    std::fs::write(repo.join("other.txt"), "keep me\n").expect("write other");
+
+    discard_changes(&repo, &["tracked.txt".to_string()]).expect("targeted discard");
+
+    assert_eq!(
+        std::fs::read_to_string(repo.join("tracked.txt")).expect("read tracked"),
+        "one\n"
+    );
+    assert!(
+        repo.join("other.txt").exists(),
+        "unrelated untracked file must be untouched"
+    );
+
+    let _ = std::fs::remove_dir_all(&repo);
+}


### PR DESCRIPTION
## Problem

`discard_changes` (`crates/git-api/src/commands/staging.rs`) parses `git status --porcelain` with `line[3..]` (2026-08-28 audit, H-5). Two failure classes, one destructive:

1. **Quoted paths.** With the default `core.quotePath=true`, any non-ASCII filename arrives quoted-and-octal-escaped (`?? "\303\251.txt"`), so the parsed name never matches the real file. A targeted discard fails with `pathspec did not match`; **"Discard All" silently skips the file while reporting success** — the user believes their tree is clean when it is not.
2. **Renames.** `R  old -> new` parsed as the literal path `old -> new`, matching nothing.

## Solution

Parse `git status --porcelain -z`: paths are verbatim (never quoted) and NUL-separated, and a rename's original path arrives as its own NUL field. Renames are now handled with correct discard semantics: the new path is treated like a staged new file (unstage, delete) and the original path like a staged change (unstage, checkout) — so discarding a staged rename actually restores the original file and removes the target. The categorization logic is otherwise unchanged.

## Potential risks

- Rename discards now act on both sides of the rename where they previously did nothing (or errored); that is the operation's documented intent, but it is new behavior for staged renames.
- `-z` output has no trailing newline and empty final field; the parser skips sub-3-byte entries, covering it.
- The sibling porcelain parsers flagged in the audit (`worktree.rs:987`, `bundle.rs:700` — conflict-file lists) are NOT part of this PR; they are read-only consumers and will follow once #1041 (which touches those files) lands.

## Verification

- `cargo test -p git_api --lib` → **120 passed, 0 failed**, including the new `staging_tests.rs` (module previously had zero tests): discard-all deletes a `é`/space-named untracked file and restores a dirty tracked file (fails against the old code — the file was silently skipped); discard-all undoes a staged `git mv` leaving a clean tree (fails against the old code); targeted discard restores one file and leaves an unrelated untracked file alone.
- `cargo fmt --check` clean; clippy no warnings.
- Not run: E2E through the packaged app.
- Based on `develop`. Built via temp index from a live checkout, so pre-commit hooks did not run (`Pre-commit hook ran.` trailer intentionally absent); checks above were run manually.
