### PR TITLE
fix(git-api): detect conflicts structurally and continue editor-free

### DIFF
--- a/src-tauri/crates/git-api/src/commands/merge.rs
+++ b/src-tauri/crates/git-api/src/commands/merge.rs
@@ -41,17 +41,21 @@ pub fn merge_branch(
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
-    let has_conflicts = stdout.contains("CONFLICT") || stderr.contains("CONFLICT");
+    // A conflict is a state, not a substring: a clean run whose diffstat
+    // lists a file named CONFLICTS.md must not report failure. Exit 0 means
+    // no conflicts; on failure the unmerged-file list is the ground truth.
+    let conflicted_files = if output.status.success() {
+        vec![]
+    } else {
+        get_conflicted_files(repo_path)
+    };
+    let has_conflicts = !conflicted_files.is_empty();
 
     Ok(GitMergeResult {
         success: output.status.success() && !has_conflicts,
         message: format!("{}{}", stdout, stderr),
         has_conflicts,
-        conflicted_files: if has_conflicts {
-            get_conflicted_files(repo_path)
-        } else {
-            vec![]
-        },
+        conflicted_files,
     })
 }
 
@@ -115,23 +119,33 @@ pub fn rebase_branch(
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
-    let has_conflicts = stdout.contains("CONFLICT") || stderr.contains("CONFLICT");
+    // A conflict is a state, not a substring: a clean run whose diffstat
+    // lists a file named CONFLICTS.md must not report failure. Exit 0 means
+    // no conflicts; on failure the unmerged-file list is the ground truth.
+    let conflicted_files = if output.status.success() {
+        vec![]
+    } else {
+        get_conflicted_files(repo_path)
+    };
+    let has_conflicts = !conflicted_files.is_empty();
 
     Ok(GitRebaseResult {
         success: output.status.success() && !has_conflicts,
         message: format!("{}{}", stdout, stderr),
         has_conflicts,
-        conflicted_files: if has_conflicts {
-            get_conflicted_files(repo_path)
-        } else {
-            vec![]
-        },
+        conflicted_files,
     })
 }
 
 /// Continue rebase
 pub fn rebase_continue(repo_path: &Path) -> Result<GitRebaseResult, String> {
-    let output = run_git(repo_path, &["rebase", "--continue"])?;
+    let output = run_git(
+        repo_path,
+        // core.editor=true: continuing after a resolved conflict otherwise
+        // opens the commit-message editor, which hangs (or aborts the
+        // continue) in a process with no TTY.
+        &["-c", "core.editor=true", "rebase", "--continue"],
+    )?;
 
     let message = if output.status.success() {
         String::from_utf8_lossy(&output.stdout).to_string()
@@ -165,17 +179,21 @@ pub fn rebase_skip(repo_path: &Path) -> Result<GitRebaseResult, String> {
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
-    let has_conflicts = stdout.contains("CONFLICT") || stderr.contains("CONFLICT");
+    // A conflict is a state, not a substring: a clean run whose diffstat
+    // lists a file named CONFLICTS.md must not report failure. Exit 0 means
+    // no conflicts; on failure the unmerged-file list is the ground truth.
+    let conflicted_files = if output.status.success() {
+        vec![]
+    } else {
+        get_conflicted_files(repo_path)
+    };
+    let has_conflicts = !conflicted_files.is_empty();
 
     Ok(GitRebaseResult {
         success: output.status.success() && !has_conflicts,
         message: format!("{}{}", stdout, stderr),
         has_conflicts,
-        conflicted_files: if has_conflicts {
-            get_conflicted_files(repo_path)
-        } else {
-            vec![]
-        },
+        conflicted_files,
     })
 }
 
@@ -202,23 +220,31 @@ pub fn cherry_pick_commit(
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
-    let has_conflicts = stdout.contains("CONFLICT") || stderr.contains("CONFLICT");
+    // A conflict is a state, not a substring: a clean run whose diffstat
+    // lists a file named CONFLICTS.md must not report failure. Exit 0 means
+    // no conflicts; on failure the unmerged-file list is the ground truth.
+    let conflicted_files = if output.status.success() {
+        vec![]
+    } else {
+        get_conflicted_files(repo_path)
+    };
+    let has_conflicts = !conflicted_files.is_empty();
 
     Ok(GitCherryPickResult {
         success: output.status.success() && !has_conflicts,
         message: format!("{}{}", stdout, stderr),
         has_conflicts,
-        conflicted_files: if has_conflicts {
-            get_conflicted_files(repo_path)
-        } else {
-            vec![]
-        },
+        conflicted_files,
     })
 }
 
 /// Continue cherry-pick
 pub fn cherry_pick_continue(repo_path: &Path) -> Result<GitCherryPickResult, String> {
-    let output = run_git(repo_path, &["cherry-pick", "--continue"])?;
+    let output = run_git(
+        repo_path,
+        // core.editor=true: see rebase_continue.
+        &["-c", "core.editor=true", "cherry-pick", "--continue"],
+    )?;
 
     let message = if output.status.success() {
         String::from_utf8_lossy(&output.stdout).to_string()
@@ -268,17 +294,21 @@ pub fn revert_commit(
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
-    let has_conflicts = stdout.contains("CONFLICT") || stderr.contains("CONFLICT");
+    // A conflict is a state, not a substring: a clean run whose diffstat
+    // lists a file named CONFLICTS.md must not report failure. Exit 0 means
+    // no conflicts; on failure the unmerged-file list is the ground truth.
+    let conflicted_files = if output.status.success() {
+        vec![]
+    } else {
+        get_conflicted_files(repo_path)
+    };
+    let has_conflicts = !conflicted_files.is_empty();
 
     Ok(GitRevertResult {
         success: output.status.success() && !has_conflicts,
         message: format!("{}{}", stdout, stderr),
         has_conflicts,
-        conflicted_files: if has_conflicts {
-            get_conflicted_files(repo_path)
-        } else {
-            vec![]
-        },
+        conflicted_files,
     })
 }
 
@@ -295,7 +325,11 @@ pub fn revert_abort(repo_path: &Path) -> Result<(), String> {
 
 /// Continue revert
 pub fn revert_continue(repo_path: &Path) -> Result<GitRevertResult, String> {
-    let output = run_git(repo_path, &["revert", "--continue"])?;
+    let output = run_git(
+        repo_path,
+        // core.editor=true: see rebase_continue.
+        &["-c", "core.editor=true", "revert", "--continue"],
+    )?;
 
     let message = if output.status.success() {
         String::from_utf8_lossy(&output.stdout).to_string()

--- a/src-tauri/crates/git-api/src/commands/tests/merge_tests.rs
+++ b/src-tauri/crates/git-api/src/commands/tests/merge_tests.rs
@@ -1,5 +1,31 @@
 use crate::commands::merge::{rebase_args, rebase_branch};
 
+fn git_in(dir: &std::path::Path, args: &[&str]) {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args([
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "-c",
+            "commit.gpgsign=false",
+            "-c",
+            "init.defaultBranch=main",
+        ])
+        .args(args)
+        .output()
+        .expect("spawn git");
+    assert!(
+        out.status.success(),
+        "git {:?} failed: {}{}",
+        args,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
 // ============================================
 // rebase_args
 // ============================================
@@ -47,32 +73,6 @@ fn rebase_branch_tolerates_unrelated_dirty_file() {
     let _ = std::fs::remove_dir_all(&repo);
     std::fs::create_dir_all(&repo).expect("create test repo dir");
 
-    fn git_in(dir: &std::path::Path, args: &[&str]) {
-        let out = std::process::Command::new("git")
-            .arg("-C")
-            .arg(dir)
-            .args([
-                "-c",
-                "user.email=t@t",
-                "-c",
-                "user.name=t",
-                "-c",
-                "commit.gpgsign=false",
-                "-c",
-                "init.defaultBranch=main",
-            ])
-            .args(args)
-            .output()
-            .expect("spawn git");
-        assert!(
-            out.status.success(),
-            "git {:?} failed: {}{}",
-            args,
-            String::from_utf8_lossy(&out.stdout),
-            String::from_utf8_lossy(&out.stderr)
-        );
-    }
-
     git_in(&repo, &["init"]);
     std::fs::write(repo.join("base.txt"), "base\n").expect("write base");
     git_in(&repo, &["add", "."]);
@@ -102,6 +102,81 @@ fn rebase_branch_tolerates_unrelated_dirty_file() {
     assert!(
         restored.contains("uncommitted local edit") && repo.join("main.txt").exists(),
         "dirty edit must be restored on top of the rebased branch"
+    );
+
+    let _ = std::fs::remove_dir_all(&repo);
+}
+
+// ============================================
+// Conflict reporting — structural, not substring — and editor-free continue.
+// ============================================
+
+/// Regression: has_conflicts came from a bare "CONFLICT" substring over the
+/// output, so a perfectly clean merge whose diffstat listed a file named
+/// CONFLICTS.md reported failure and opened the conflict resolver. And
+/// `rebase --continue` ran without editor suppression, so continuing after a
+/// resolved conflict tried to open the commit-message editor and aborted in
+/// a TTY-less process.
+#[test]
+fn conflict_reporting_is_structural_and_continue_needs_no_editor() {
+    use crate::commands::merge::{merge_branch, rebase_continue};
+
+    if std::process::Command::new("git")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("skipping: git executable not available");
+        return;
+    }
+
+    let repo = std::env::temp_dir().join(format!(
+        "orgii-merge-int-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock after epoch")
+            .as_nanos()
+    ));
+    let _ = std::fs::remove_dir_all(&repo);
+    std::fs::create_dir_all(&repo).expect("create test repo dir");
+
+    git_in(&repo, &["init"]);
+    std::fs::write(repo.join("CONFLICTS.md"), "base\n").expect("write file");
+    git_in(&repo, &["add", "."]);
+    git_in(&repo, &["commit", "-m", "init"]);
+
+    // Scenario 1: a clean merge whose diffstat mentions CONFLICTS.md.
+    git_in(&repo, &["checkout", "-b", "docs"]);
+    std::fs::write(repo.join("CONFLICTS.md"), "base\ndocs edit\n").expect("write file");
+    git_in(&repo, &["commit", "-am", "docs edit"]);
+    git_in(&repo, &["checkout", "main"]);
+    let merged = merge_branch(&repo, "docs", false, None).expect("merge runs");
+    assert!(
+        merged.success,
+        "clean merge must not fail over a scary filename: {}",
+        merged.message
+    );
+    assert!(!merged.has_conflicts);
+    assert!(merged.conflicted_files.is_empty());
+
+    // Scenario 2: a real conflict — reported structurally, then resolved and
+    // continued without an editor.
+    git_in(&repo, &["checkout", "-b", "clash", "HEAD~1"]);
+    std::fs::write(repo.join("CONFLICTS.md"), "base\nclash edit\n").expect("write file");
+    git_in(&repo, &["commit", "-am", "clash edit"]);
+    let rebased = rebase_branch(&repo, "main", None).expect("rebase runs");
+    assert!(!rebased.success);
+    assert!(rebased.has_conflicts);
+    assert_eq!(rebased.conflicted_files, vec!["CONFLICTS.md".to_string()]);
+
+    std::fs::write(repo.join("CONFLICTS.md"), "base\ndocs edit\nclash edit\n").expect("resolve");
+    git_in(&repo, &["add", "CONFLICTS.md"]);
+    let continued = rebase_continue(&repo).expect("continue runs");
+    assert!(
+        continued.success,
+        "continue must not depend on an editor: {}",
+        continued.message
     );
 
     let _ = std::fs::remove_dir_all(&repo);


### PR DESCRIPTION
## Problem

Two defects in the merge family (`crates/git-api/src/commands/merge.rs`; 2026-08-28 audit, M-6d and L/#20):

1. **Conflicts detected by substring.** `merge_branch`, `rebase_branch`, `rebase_skip`, and `cherry_pick_commit` derived `has_conflicts` from a bare `CONFLICT` substring over stdout+stderr, and set `success: exit_ok && !has_conflicts`. A perfectly clean merge whose diffstat lists a file named `CONFLICTS.md` (or `docs/CONFLICT-resolution.md`) therefore reported failure and sent the UI into the conflict resolver.
2. **`--continue` can block on an editor.** `rebase_continue`, `cherry_pick_continue`, and `revert_continue` ran without editor suppression. Continuing after a resolved conflict opens the commit-message editor; with no TTY the fallback editor fails and the continue aborts (`merge --continue` is isatty-gated by git itself; these three are not).

## Solution

- Conflicts are now a *state*, not a substring: exit 0 means none by definition; on a non-zero exit the unmerged-file list (`get_conflicted_files`, `diff --diff-filter=U`) is the ground truth and directly populates `conflicted_files`. `success` semantics are unchanged for every genuinely failing case.
- The three continue commands pass `-c core.editor=true`, matching the `--no-edit` discipline the bundle code already uses.

## Potential risks

- A non-zero exit with *no* unmerged files (e.g. a dirty-tree refusal) now reports `has_conflicts: false` instead of whatever the text sniff said — `success` is still `false`, and the message text is unchanged, so error dialogs behave the same; only the false "open the conflict resolver" signal is gone.
- One extra `git diff --diff-filter=U` invocation on failing merges only.
- Suppressing the editor means the continue always keeps git's prepared message — previously users with a TTY-attached dev build might have seen an editor; the app never intends interactive editors in spawned git.

## Verification

- `cargo test -p git_api --lib` → **121 passed, 0 failed**, including a new two-scenario integration test: a clean merge whose diffstat mentions `CONFLICTS.md` must succeed (fails against the old code), and a real rebase conflict must report `has_conflicts` with the exact file list structurally, then resolve and `rebase_continue` without an editor (aborts against the old code in a TTY-less run).
- `cargo fmt --check` clean; clippy no warnings.
- Not run: E2E through the packaged app.
- Based on `develop`. Built via temp index from a live checkout, so pre-commit hooks did not run (`Pre-commit hook ran.` trailer intentionally absent); checks above were run manually.
