### PR TITLE
fix(git-stream): stream concurrently, retry only spawns, emit real JSON

### DIFF
--- a/src-tauri/crates/git-api/src/commands/streaming.rs
+++ b/src-tauri/crates/git-api/src/commands/streaming.rs
@@ -192,130 +192,134 @@ fn configure_command_for_fd_safety(_cmd: &mut Command) {
     // No-op on non-Unix systems
 }
 
-/// Helper function to stream git command output with retry logic for transient errors
-/// Retries up to 3 times on "Bad file descriptor" and similar transient errors
-/// The `operation` parameter is used for error type detection ("push", "pull", "fetch", etc.)
-async fn stream_git_command(
+/// Core of the git SSE stream: yields `(event_kind, payload)` pairs.
+///
+/// Split from the SSE layer so the streaming behavior is unit-testable:
+/// axum's `Event` offers no way to read its data back.
+///
+/// Behavioral contract (each point fixes a defect the previous
+/// implementation had):
+/// - stdout and stderr are drained CONCURRENTLY and lines are yielded as
+///   they arrive. Git writes progress to stderr while stdout is still open;
+///   draining stdout to EOF first deadlocked both sides once stderr's pipe
+///   buffer (64 KiB) filled, and nothing streamed until the process exited.
+/// - Only SPAWN failures retry on transient errors. Retrying because the
+///   command's OUTPUT contained a transient-error string re-ran a command
+///   that had already executed — a `git commit` could commit twice — and
+///   orphaned the first child without awaiting it.
+/// - Payloads are built with serde_json. Hand-rolled escaping dropped
+///   backslashes and carriage returns, so Windows paths, quoted-path
+///   output, and progress lines produced frames the client's JSON.parse
+///   rejected.
+fn stream_git_events(
     mut cmd: Command,
     command_str: String,
     operation: &'static str,
-) -> GitEventStream {
-    // Configure command for file descriptor safety
+) -> impl Stream<Item = (&'static str, serde_json::Value)> {
     configure_command_for_fd_safety(&mut cmd);
 
-    let stream = async_stream::stream! {
-        yield Ok(Event::default()
-            .event("start")
-            .data(format!("{{\"command\":\"{}\"}}", command_str)));
+    async_stream::stream! {
+        yield ("start", serde_json::json!({ "command": command_str }));
 
         const MAX_RETRIES: u32 = 3;
         let mut attempt = 0;
-
-        loop {
+        let mut child = loop {
             attempt += 1;
-
-            let mut child = match cmd.spawn() {
-                Ok(child) => child,
+            match cmd.spawn() {
+                Ok(child) => break child,
                 Err(e) => {
                     let error_str = e.to_string();
-
-                    // Check if this is a transient error that can be retried
                     if is_transient_error(&error_str) && attempt < MAX_RETRIES {
-                        // Wait briefly before retrying (exponential backoff)
-                        tokio::time::sleep(tokio::time::Duration::from_millis(100 * attempt as u64)).await;
+                        tokio::time::sleep(tokio::time::Duration::from_millis(
+                            100 * attempt as u64,
+                        ))
+                        .await;
                         continue;
                     }
-
-                    let error_msg = error_str.replace("\"", "\\\"");
-                    yield Ok(Event::default()
-                        .event("error")
-                        .data(format!("{{\"error\":\"{}\",\"error_type\":\"unknown\"}}", error_msg)));
+                    yield (
+                        "error",
+                        serde_json::json!({ "error": error_str, "error_type": "unknown" }),
+                    );
                     return;
                 }
-            };
+            }
+        };
 
-            let stdout = child.stdout.take();
-            let stderr = child.stderr.take();
-
-            let mut all_lines: Vec<(String, String)> = Vec::new();
-
-            if let Some(stdout) = stdout {
-                let reader = BufReader::new(stdout);
-                if let Ok(lines) = tokio::spawn(async move {
-                    let mut lines_reader = reader.lines();
-                    let mut output = Vec::new();
-                    while let Ok(Some(line)) = lines_reader.next_line().await {
-                        output.push(("stdout".to_string(), line));
+        let (line_tx, mut line_rx) =
+            tokio::sync::mpsc::unbounded_channel::<(&'static str, String)>();
+        let mut readers = tokio::task::JoinSet::new();
+        if let Some(stdout) = child.stdout.take() {
+            let tx = line_tx.clone();
+            readers.spawn(async move {
+                let mut lines = BufReader::new(stdout).lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    if tx.send(("stdout", line)).is_err() {
+                        break;
                     }
-                    output
-                }).await {
-                    all_lines.extend(lines);
                 }
-            }
-
-            if let Some(stderr) = stderr {
-                let reader = BufReader::new(stderr);
-                if let Ok(lines) = tokio::spawn(async move {
-                    let mut lines_reader = reader.lines();
-                    let mut output = Vec::new();
-                    while let Ok(Some(line)) = lines_reader.next_line().await {
-                        output.push(("stderr".to_string(), line));
-                    }
-                    output
-                }).await {
-                    all_lines.extend(lines);
-                }
-            }
-
-            // Check if any output line indicates a transient error
-            let has_transient_error = all_lines.iter().any(|(_, line)| is_transient_error(line));
-
-            if has_transient_error && attempt < MAX_RETRIES {
-                // Wait briefly before retrying
-                tokio::time::sleep(tokio::time::Duration::from_millis(100 * attempt as u64)).await;
-                continue;
-            }
-
-            // Collect all output for error type detection
-            let combined_output: String = all_lines.iter()
-                .map(|(_, line)| line.as_str())
-                .collect::<Vec<_>>()
-                .join("\n");
-
-            for (stream, line) in &all_lines {
-                let escaped_line = line.replace("\"", "\\\"").replace("\n", "\\n");
-                yield Ok(Event::default()
-                    .event("output")
-                    .data(format!("{{\"stream\":\"{}\",\"line\":\"{}\"}}", stream, escaped_line)));
-            }
-
-            match child.wait().await {
-                Ok(status) => {
-                    let error_type = if status.success() {
-                        "none"
-                    } else {
-                        detect_error_type_from_output(&combined_output, operation)
-                    };
-
-                    yield Ok(Event::default()
-                        .event("end")
-                        .data(format!("{{\"success\":{},\"error_type\":\"{}\"}}", status.success(), error_type)));
-                }
-                Err(e) => {
-                    let error_msg = e.to_string().replace("\"", "\\\"");
-                    let error_type = detect_error_type_from_output(&error_msg, operation);
-                    yield Ok(Event::default()
-                        .event("error")
-                        .data(format!("{{\"error\":\"{}\",\"error_type\":\"{}\"}}", error_msg, error_type)));
-                }
-            }
-
-            // Successfully completed, exit the retry loop
-            break;
+            });
         }
-    };
+        if let Some(stderr) = child.stderr.take() {
+            let tx = line_tx.clone();
+            readers.spawn(async move {
+                let mut lines = BufReader::new(stderr).lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    if tx.send(("stderr", line)).is_err() {
+                        break;
+                    }
+                }
+            });
+        }
+        drop(line_tx);
 
-    Box::pin(stream)
+        let mut combined_lines: Vec<String> = Vec::new();
+        while let Some((source, line)) = line_rx.recv().await {
+            yield (
+                "output",
+                serde_json::json!({ "stream": source, "line": line }),
+            );
+            combined_lines.push(line);
+        }
+        while readers.join_next().await.is_some() {}
+
+        match child.wait().await {
+            Ok(status) => {
+                let error_type = if status.success() {
+                    "none"
+                } else {
+                    detect_error_type_from_output(&combined_lines.join("\n"), operation)
+                };
+                yield (
+                    "end",
+                    serde_json::json!({
+                        "success": status.success(),
+                        "error_type": error_type,
+                    }),
+                );
+            }
+            Err(e) => {
+                let error_msg = e.to_string();
+                let error_type = detect_error_type_from_output(&error_msg, operation);
+                yield (
+                    "error",
+                    serde_json::json!({ "error": error_msg, "error_type": error_type }),
+                );
+            }
+        }
+    }
+}
+
+/// Wrap the event core into the SSE wire stream.
+async fn stream_git_command(
+    cmd: Command,
+    command_str: String,
+    operation: &'static str,
+) -> GitEventStream {
+    use futures::StreamExt as _;
+    Box::pin(
+        stream_git_events(cmd, command_str, operation)
+            .map(|(kind, data)| Ok(Event::default().event(kind).data(data.to_string()))),
+    )
 }
 
 fn sse_response(stream: GitEventStream) -> Response {
@@ -325,12 +329,10 @@ fn sse_response(stream: GitEventStream) -> Response {
 }
 
 fn stream_error_response(error: String, error_type: &'static str) -> Response {
-    let escaped = error.replace('"', "\\\"");
     let stream = futures::stream::once(async move {
-        Ok(Event::default().event("error").data(format!(
-            "{{\"error\":\"{}\",\"error_type\":\"{}\"}}",
-            escaped, error_type
-        )))
+        Ok(Event::default()
+            .event("error")
+            .data(serde_json::json!({ "error": error, "error_type": error_type }).to_string()))
     });
 
     sse_response(Box::pin(stream) as GitEventStream)
@@ -549,14 +551,19 @@ pub async fn commit_stream(
         Ok(command) => command,
         Err(err) => return git_resolution_error_response(err),
     };
+    // Null stdin + no-prompt env like every sibling handler: with
+    // commit.gpgsign enabled, a GPG pinentry could otherwise block on the
+    // inherited stdin and hang the SSE stream indefinitely.
     cmd.arg("commit")
         .arg("-m")
         .arg(&message)
         .current_dir(&repo_path)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    let command_str = format!("git commit -m \"{}\"", message.replace("\"", "\\\""));
+    let command_str = format!("git commit -m \"{message}\"");
     let stream = stream_git_command(cmd, command_str, "commit").await;
 
     sse_response(stream)
@@ -568,23 +575,27 @@ pub async fn stage_stream(
     Query(query): Query<StageStreamQuery>,
 ) -> Response {
     let repo_path = PathBuf::from(&query.path);
-    // The `files` query param is a JSON-encoded array. A silent
-    // empty fallback would make `git add` run as a no-op, with
-    // the user seeing no error and no effect. Warn so a malformed
-    // request from the frontend is visible in logs while still
-    // degrading to a no-op (we won't error the SSE stream for a
-    // request shape we can't parse).
+    // The `files` query param is a JSON-encoded array. A malformed or empty
+    // list must error the stream: a bare `git add` with no pathspec exits 0
+    // having staged nothing ("Nothing specified, nothing added."), and the
+    // old fallback then reported a successful `git add .` — the next commit
+    // was silently empty or partial. Callers that mean "everything" pass
+    // ["."] explicitly (commitOps.stage does).
     let files: Vec<String> = match serde_json::from_str(&query.files) {
         Ok(f) => f,
         Err(err) => {
-            tracing::warn!(
-                error = %err,
-                files_param = %query.files,
-                "git::stage_stream: files query param is not a JSON array; running git add as no-op"
+            return stream_error_response(
+                format!("stage request had a malformed files list: {err}"),
+                "invalid_request",
             );
-            Vec::new()
         }
     };
+    if files.is_empty() {
+        return stream_error_response(
+            "stage request listed no files".to_string(),
+            "invalid_request",
+        );
+    }
 
     let mut cmd = match tokio_git_command() {
         Ok(command) => command,
@@ -604,11 +615,7 @@ pub async fn stage_stream(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
 
-    let command_str = if files.is_empty() {
-        "git add .".to_string()
-    } else {
-        format!("git add {}", files.join(" "))
-    };
+    let command_str = format!("git add {}", files.join(" "));
 
     let stream = stream_git_command(cmd, command_str, "stage").await;
 

--- a/src-tauri/crates/git-api/src/commands/tests/streaming_tests.rs
+++ b/src-tauri/crates/git-api/src/commands/tests/streaming_tests.rs
@@ -1,5 +1,121 @@
-use crate::commands::streaming::detect_error_type_from_output;
+use crate::commands::streaming::{detect_error_type_from_output, stream_git_events};
 use git::util::is_transient_error;
+
+#[cfg(unix)]
+async fn collect_events(
+    script: &str,
+    operation: &'static str,
+) -> Vec<(&'static str, serde_json::Value)> {
+    use futures::StreamExt as _;
+
+    let mut cmd = tokio::process::Command::new("sh");
+    cmd.arg("-c")
+        .arg(script)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let stream = stream_git_events(cmd, "test command".to_string(), operation);
+    tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        stream.collect::<Vec<_>>(),
+    )
+    .await
+    .expect("stream must terminate — a hang here is the pipe deadlock regression")
+}
+
+/// Regression: the old implementation drained stdout to EOF before reading
+/// stderr. A child that fills stderr's pipe buffer (64 KiB) while stdout is
+/// still open then blocks on write(2), stdout never reaches EOF, and both
+/// sides hang — reachable on any large push, whose progress goes to stderr.
+#[cfg(unix)]
+#[tokio::test]
+async fn streams_large_stderr_without_deadlock() {
+    let events = collect_events(
+        // ~30k lines (>200 KiB) of stderr while stdout stays open.
+        "i=0; while [ $i -lt 30000 ]; do echo stderr-noise-line 1>&2; i=$((i+1)); done; echo done-marker",
+        "push",
+    )
+    .await;
+
+    let end = events.last().expect("events emitted");
+    assert_eq!(end.0, "end");
+    assert_eq!(end.1["success"], serde_json::json!(true));
+    let stdout_lines: Vec<_> = events
+        .iter()
+        .filter(|(kind, data)| *kind == "output" && data["stream"] == "stdout")
+        .collect();
+    assert_eq!(stdout_lines.len(), 1);
+    assert_eq!(stdout_lines[0].1["line"], "done-marker");
+    let stderr_count = events
+        .iter()
+        .filter(|(kind, data)| *kind == "output" && data["stream"] == "stderr")
+        .count();
+    assert_eq!(stderr_count, 30000);
+}
+
+/// Regression: hand-rolled JSON escaping only handled `"` and `\n`, so
+/// backslashes (Windows paths, quoted-path octal escapes) produced invalid
+/// frames the client dropped. The payload must carry the line verbatim.
+#[cfg(unix)]
+#[tokio::test]
+async fn output_lines_with_backslashes_and_quotes_survive_verbatim() {
+    let events = collect_events(r#"printf 'C:\\Users\\dev "quoted" path\n'"#, "pull").await;
+
+    let line = events
+        .iter()
+        .find(|(kind, _)| *kind == "output")
+        .expect("one output event")
+        .1["line"]
+        .as_str()
+        .expect("line is a string");
+    assert_eq!(line, r#"C:\Users\dev "quoted" path"#);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn end_event_classifies_failure_from_combined_output() {
+    let events = collect_events(
+        "echo 'error: failed to push some refs to x' 1>&2; exit 1",
+        "push",
+    )
+    .await;
+
+    assert_eq!(events.first().expect("start emitted").0, "start");
+    let end = events.last().expect("end emitted");
+    assert_eq!(end.0, "end");
+    assert_eq!(end.1["success"], serde_json::json!(false));
+    assert_eq!(end.1["error_type"], "non_fast_forward");
+}
+
+/// A missing binary must terminate the stream with a failure. On Unix the
+/// fd-closing `pre_exec` also closes the runtime's exec-error pipe, so the
+/// failed exec surfaces as an immediate child exit (an `end` event with
+/// `success: false`) rather than a spawn error — either terminal event is a
+/// correct failure signal; what must never happen is a hang or a success.
+#[tokio::test]
+async fn missing_binary_terminates_with_failure() {
+    use futures::StreamExt as _;
+
+    let mut cmd = tokio::process::Command::new("/nonexistent-binary-orgii-test");
+    cmd.stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let events = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        stream_git_events(cmd, "test command".to_string(), "push").collect::<Vec<_>>(),
+    )
+    .await
+    .expect("stream must terminate");
+
+    let last = events.last().expect("events emitted");
+    match last.0 {
+        "end" => assert_eq!(last.1["success"], serde_json::json!(false)),
+        "error" => assert_eq!(last.1["error_type"], "unknown"),
+        other => panic!("unexpected terminal event {other}: {:?}", last.1),
+    }
+}
 
 // ============================================
 // detect_error_type_from_output — push


### PR DESCRIPTION
## Problem

`stream_git_command` — the shared core behind every SSE git endpoint (push, pull, fetch, commit, stage) — had four defects (2026-08-28 audit, H-7 and #25):

1. **No actual streaming, plus a deadlock window.** stdout was drained to EOF in an awaited task *before* the stderr task started. Git writes progress and most diagnostics to stderr, so a child that fills stderr's 64 KiB pipe buffer while stdout is still open blocks on `write(2)`, stdout never reaches EOF, and both sides hang — reachable on any large push. Even when it didn't hang, every `output` event was collected first and emitted only after the process exited, so the endpoints provided none of the real-time streaming they exist for.
2. **The retry re-ran commands that had already executed.** Retry was decided by sniffing the *output* of a completed run for transient-error strings, then `continue`-ing the loop without killing or awaiting the first child. `stream_git_command` backs `commit_stream`, `push_stream`, and `stage_stream` — all non-idempotent: a `git commit` whose output happened to contain such a string could produce two commits.
3. **Hand-rolled JSON escaped only `"` and `\n`.** Backslashes (Windows paths, octal-quoted paths) and `\r` (progress lines) produced invalid frames the client's `JSON.parse` dropped; `command_str` was interpolated with no escaping at all, so *every* streamed commit emitted a malformed `start` event.
4. **`commit_stream` inherited stdin** with no `GIT_TERMINAL_PROMPT=0`, unlike every sibling handler — with `commit.gpgsign` enabled a GPG pinentry could block on it and hang the stream indefinitely.

Also fixed here because it lives in the same handler: **an empty/malformed stage list ran a bare `git add`**, which stages nothing and exits 0, while the events reported that `git add .` had succeeded — the next commit was silently empty or partial (audit H-4).

## Solution

A testable `stream_git_events` core is split out of the SSE wrapper (axum's `Event` cannot be read back, so the old code was structurally untestable):

- Both pipes are drained by concurrent tasks feeding an mpsc channel; lines are yielded as they arrive, so output genuinely streams and neither pipe can block the other.
- Retry is limited to **spawn** failures, matching the structurally-safe `run_git_with_retry` in the `git` crate. A command that ran is never re-run.
- Every payload is built with `serde_json::json!` and serialized, so any byte sequence git emits survives verbatim.
- `commit_stream` sets `stdin(null)` + `GIT_TERMINAL_PROMPT=0`; its `command_str` no longer hand-escapes.
- `stage_stream` returns an `invalid_request` error stream for a malformed or empty file list. Callers that mean "everything" already pass `["."]` explicitly (`commitOps.stage` does).

## Potential risks

- Clients now receive `output` events incrementally rather than in one burst at the end. The TS parsers (`sseSchemas.ts`) are per-event and order-independent, so this is transparent; UI that assumed all output arrives at once would now render progressively (an improvement, but a visible behavior change).
- Transient FD errors surfacing *during* a run are no longer retried — they now fail the operation instead of silently re-running it. That is the intended trade: a duplicate commit is far worse than a surfaced error, and the spawn-time retry (where these errors actually originate, per the FD-inheritance note in the module header) is retained.
- An empty stage request is now an error instead of a silent no-op success; a caller relying on the old behavior would newly see an error, which is the point.

## Verification

- `cargo test -p git_api --lib` → **121 passed, 0 failed**, including four new tests against the extracted core, each of which fails or hangs against the old implementation:
  - `streams_large_stderr_without_deadlock` — 30k stderr lines (>200 KiB) while stdout stays open; asserts termination under a 30s timeout, all 30000 stderr events, and the single stdout line (the old code deadlocks).
  - `output_lines_with_backslashes_and_quotes_survive_verbatim` — a Windows-style path with quotes round-trips exactly.
  - `end_event_classifies_failure_from_combined_output` — `start` first, `end` last, `success:false`, `non_fast_forward`.
  - `missing_binary_terminates_with_failure` — terminates with a failure event rather than hanging (accepts either terminal shape, since the fd-closing `pre_exec` turns a failed exec into an immediate child exit on Unix).
- `cargo clippy --workspace --all-targets -- -D warnings` → clean (the exact CI invocation); `cargo fmt -p git_api --check` clean.
- Not run: an end-to-end SSE request through the axum stack, or E2E through the packaged app.
- Based on `develop` (after #1031 and #1034, which touched this file); verified the working copy retains every merged hunk from both before rebuilding. Built via temp index from a live checkout, so pre-commit hooks did not run (`Pre-commit hook ran.` trailer intentionally absent); checks above were run manually.
