### PR TITLE
refactor(dropdown): consolidate search inputs

### DIFF
--- a/docs/frontend-ui-audit-2026-08-28/DropdownSearch.md
+++ b/docs/frontend-ui-audit-2026-08-28/DropdownSearch.md
@@ -1,0 +1,62 @@
+# DropdownSearch UI audit
+
+Scope: consolidate dropdown search inputs behind the existing `DropdownSearch`
+design-system component while preserving each caller's input type, label,
+focus behavior, keyboard navigation, and domain-specific leading content.
+
+| Line                                                                    | Element                               | Verdict          | Reason                                                                                                                                                                  | Suggested change                                                                               |
+| ----------------------------------------------------------------------- | ------------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| 14 call sites; see sweep inventory                                      | Raw dropdown search rows              | fix              | Each site rebuilt the same tokenized wrapper, search icon, input, pointer guard, and Tauri select-all behavior even though `DropdownSearch` already owned that pattern. | Completed: extend the shared component narrowly and replace every matching raw implementation. |
+| `src/components/Dropdown/DropdownHeader.tsx:33`                         | Compositional dropdown header wrapper | keep with reason | This is a shared header scaffold whose children may be a search field or arbitrary header content; it is not a duplicate text input.                                    | None. Keep it compositional.                                                                   |
+| `src/scaffold/ContextMenu/variants/TextSelectionDropdown/index.tsx:136` | Session-selector back/title row       | keep with reason | The row contains navigation and a title, not a search input. Replacing it with `DropdownSearch` would give a non-input header input semantics.                          | None. Keep the header row.                                                                     |
+
+Verdict totals: **1 fix**, **2 keep with reason**, **0 abstract**, **0 watch**.
+
+## Sweep inventory
+
+The consolidation replaced 14 raw input rows:
+
+- `src/components/Dropdown/DropdownOptionsContent.tsx:51`
+- `src/components/Select/index.tsx:391`
+- `src/engines/ChatPanel/InputArea/components/PinnedActionsBar/PinActionsPanel.tsx:321`
+- `src/engines/ChatPanel/InputArea/components/SlashCommandPortal/SlashCommandMenu.tsx:287`
+- `src/features/SessionCreator/components/WorktreeSourceSelectorViews.tsx:396`
+- `src/modules/MainApp/AgentOrgs/config/shared/SubAgentsEditor.tsx:151`
+- `src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlScopeToolbar.tsx:283`
+- `src/modules/WorkStation/TabContent/renderers/CliAgentHeaderSwitcher.tsx:97`
+- `src/modules/WorkStation/shared/StatusBar/PortsStatusMenu.tsx:333`
+- `src/modules/shared/layouts/blocks/SettingsBreadcrumb/index.tsx:289`
+- `src/scaffold/GlobalSpotlight/palettes/BranchPalette/BranchDropdown.tsx:266`
+- `src/scaffold/GlobalSpotlight/palettes/DispatchCategoryPalette/DispatchCategoryDropdown.tsx:231`
+- `src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/UnifiedModelDropdown.tsx:476`
+- `src/scaffold/GlobalSpotlight/palettes/WorkspacePalette/WorkspaceDropdown.tsx:650`
+
+After the sweep, `DROPDOWN_CLASSES.searchInput` is referenced only by
+`DropdownSearch`; 18 production call sites consume the shared component.
+
+## Architecture audit
+
+Acceptance criteria:
+
+- A single component owns dropdown search input chrome and behavior.
+- Every matching raw implementation is migrated in the same change.
+- Caller-specific keyboard navigation, input type, refs, labels, disabled
+  state, focus, test markers, and leading content remain expressible.
+- Non-input headers are not forced through an input abstraction.
+
+| Layer                                     | Coverage                                                                                          | Verdict                                                                                                                                             |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1. Compilation correctness                | `pnpm run typecheck`, focused Vitest, and ESLint over every changed TypeScript file               | Pass.                                                                                                                                               |
+| 2. Dead code and structural deduplication | Swept `DROPDOWN_CLASSES.searchInput` and `DROPDOWN_CLASSES.searchContainer` across `src/**/*.tsx` | The input style has one owner; only two intentional non-input header wrappers remain outside it.                                                    |
+| 3. Naming consistency                     | Reviewed the component name and new prop names across all consumers                               | `DropdownSearch`, `leading`, `containerClassName`, and `testId` describe their roles without domain terminology.                                    |
+| 4. Semantic overloading                   | Compared search input rows with the two remaining header rows                                     | Input behavior is centralized; non-input headers remain explicitly documented exceptions.                                                           |
+| 5. Default branches                       | Reviewed default icon, input type, search attributes, and pointer-guard branches                  | Omitted `leading` means the standard icon; `null` explicitly means no leading content. Migrated callers pin `type` to preserve prior DOM semantics. |
+| 6. Cross-domain leakage                   | Inspected shared component imports and props                                                      | No feature, workspace, session, or model concepts leak into the component.                                                                          |
+| 7. New-developer confusion                | Reviewed the public interface, example, and exceptional call sites                                | The component owns search behavior; callers supply only value and genuine variations.                                                               |
+| 8. Wire protocol and serialization        | No network, IPC, persistence, or serialized payload changes                                       | Not applicable.                                                                                                                                     |
+| 9. Init parity                            | No initialization or alternate entry-point changes                                                | Not applicable.                                                                                                                                     |
+| 10. Resolver symmetry                     | No resolver or fallback-chain changes                                                             | Not applicable.                                                                                                                                     |
+
+No React performance methodology was applied because this is a structural UI
+deduplication with no runtime-performance claim or subscription/lifecycle
+change.

--- a/src/components/Dropdown/DropdownOptionsContent.tsx
+++ b/src/components/Dropdown/DropdownOptionsContent.tsx
@@ -1,11 +1,8 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
 
-import { useTauriSelectAllShortcut } from "@src/hooks/keyboard";
-import { HugeiconsIcon, Search01Icon } from "@src/icons";
-
 import DropdownOptionsRenderer from "./DropdownOptionsRenderer";
-import { DROPDOWN_CLASSES, DROPDOWN_ITEM } from "./tokens";
+import DropdownSearch from "./DropdownSearch";
 import type { DropdownOption, DropdownSelectValue } from "./types";
 
 interface DropdownOptionsContentProps {
@@ -47,38 +44,19 @@ const DropdownOptionsContent: React.FC<DropdownOptionsContentProps> = ({
   dropdownRender,
 }) => {
   const { t } = useTranslation();
-  const tauriSelectAll = useTauriSelectAllShortcut();
-
-  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    onSearchChange(event.target.value);
-  };
 
   return (
     <>
       {showSearch && (
-        <div className={DROPDOWN_CLASSES.searchContainer}>
-          <HugeiconsIcon
-            icon={Search01Icon}
-            data-icon="search"
-            size={DROPDOWN_ITEM.iconSize}
-            className="shrink-0 text-text-3"
-          />
-          <input
-            ref={searchInputRef}
-            type="text"
-            placeholder={
-              searchPlaceholder ?? t("common:common.searchPlaceholder")
-            }
-            value={searchValue}
-            onChange={handleSearchChange}
-            onClick={(event) => event.stopPropagation()}
-            onKeyDown={tauriSelectAll}
-            autoCorrect="off"
-            autoCapitalize="off"
-            spellCheck={false}
-            className={DROPDOWN_CLASSES.searchInput}
-          />
-        </div>
+        <DropdownSearch
+          ref={searchInputRef}
+          type="text"
+          placeholder={
+            searchPlaceholder ?? t("common:common.searchPlaceholder")
+          }
+          value={searchValue}
+          onChange={onSearchChange}
+        />
       )}
       <DropdownOptionsRenderer
         options={filteredOptions}

--- a/src/components/Dropdown/DropdownSearch.test.ts
+++ b/src/components/Dropdown/DropdownSearch.test.ts
@@ -1,6 +1,17 @@
-import { createElement } from "react";
+// @vitest-environment jsdom
+import { act, createElement } from "react";
+import { type Root, createRoot } from "react-dom/client";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 import DropdownSearch from "./DropdownSearch";
 
@@ -11,6 +22,31 @@ vi.mock("react-i18next", () => ({
 }));
 
 describe("DropdownSearch", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const actEnvironment = globalThis as typeof globalThis & {
+    IS_REACT_ACT_ENVIRONMENT?: boolean;
+  };
+
+  beforeAll(() => {
+    actEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(actEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
   it("uses the concise localized search label by default", () => {
     const markup = renderToStaticMarkup(
       createElement(DropdownSearch, {
@@ -21,5 +57,66 @@ describe("DropdownSearch", () => {
 
     expect(markup).toContain('placeholder="Localized Search"');
     expect(markup).toContain('aria-label="Localized Search"');
+    expect(markup).toContain('type="search"');
+    expect(markup).toContain('autoComplete="off"');
+    expect(markup).toContain('spellCheck="false"');
+  });
+
+  it("supports custom and intentionally empty leading content", () => {
+    const customMarkup = renderToStaticMarkup(
+      createElement(DropdownSearch, {
+        value: "",
+        onChange: vi.fn(),
+        leading: createElement("span", { "data-leading": true }, "Prefix"),
+        containerClassName: "gap-2",
+        testId: "search-row",
+        type: "text",
+      })
+    );
+    const iconlessMarkup = renderToStaticMarkup(
+      createElement(DropdownSearch, {
+        value: "",
+        onChange: vi.fn(),
+        leading: null,
+      })
+    );
+
+    expect(customMarkup).toContain('data-testid="search-row"');
+    expect(customMarkup).toContain('data-leading="true"');
+    expect(customMarkup).toContain("gap-2");
+    expect(customMarkup).toContain('type="text"');
+    expect(iconlessMarkup).not.toContain('data-icon="search"');
+  });
+
+  it("forwards the input ref and composes native keyboard handling", () => {
+    const onKeyDown = vi.fn();
+    let inputRef: HTMLInputElement | null = null;
+
+    act(() => {
+      root.render(
+        createElement(DropdownSearch, {
+          value: "query",
+          onChange: vi.fn(),
+          onKeyDown,
+          disabled: true,
+          "data-search-input": "true",
+          ref: (element) => {
+            inputRef = element;
+          },
+        })
+      );
+    });
+
+    const input = container.querySelector<HTMLInputElement>("input");
+    expect(inputRef).toBe(input);
+    expect(input?.disabled).toBe(true);
+    expect(input?.dataset.searchInput).toBe("true");
+
+    act(() => {
+      input?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true })
+      );
+    });
+    expect(onKeyDown).toHaveBeenCalledOnce();
   });
 });

--- a/src/components/Dropdown/DropdownSearch.tsx
+++ b/src/components/Dropdown/DropdownSearch.tsx
@@ -22,7 +22,7 @@
  * </DropdownPanel>
  * ```
  */
-import React, { forwardRef, useEffect, useRef } from "react";
+import React, { forwardRef, useCallback, useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useTauriSelectAllShortcut } from "@src/hooks/keyboard";
@@ -30,7 +30,20 @@ import { HugeiconsIcon, Search01Icon } from "@src/icons";
 
 import { DROPDOWN_CLASSES, DROPDOWN_SEARCH } from "./tokens";
 
-export interface DropdownSearchProps {
+type NativeSearchInputProps = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  | "aria-label"
+  | "autoFocus"
+  | "className"
+  | "defaultValue"
+  | "onChange"
+  | "placeholder"
+  | "value"
+>;
+
+export interface DropdownSearchProps extends NativeSearchInputProps {
+  [dataAttribute: `data-${string}`]: string | number | boolean | undefined;
+
   /**
    * Search input value
    */
@@ -53,6 +66,18 @@ export interface DropdownSearchProps {
   ariaLabel?: string;
 
   /**
+   * Content before the input. Omit for the standard search icon or pass null
+   * for an intentionally iconless field.
+   */
+  leading?: React.ReactNode;
+
+  /** Additional classes for the shared search-row container. */
+  containerClassName?: string;
+
+  /** Test id applied to the shared search-row container. */
+  testId?: string;
+
+  /**
    * Auto-focus the input when mounted
    * @default false
    */
@@ -73,26 +98,49 @@ const DropdownSearch = forwardRef<HTMLInputElement, DropdownSearchProps>(
       onChange,
       placeholder,
       ariaLabel,
+      leading,
+      containerClassName,
+      testId,
       autoFocus = false,
       stopMouseDownPropagation = true,
+      type = "search",
+      autoComplete = "off",
+      autoCorrect = "off",
+      autoCapitalize = "off",
+      spellCheck = false,
+      onClick,
+      onMouseDown,
+      onKeyDown,
+      ...inputProps
     },
     ref
   ) => {
     const { t } = useTranslation("common");
     const internalRef = useRef<HTMLInputElement>(null);
-    const inputRef = (ref as React.RefObject<HTMLInputElement>) || internalRef;
     const tauriSelectAll = useTauriSelectAllShortcut();
+
+    const setInputRef = useCallback(
+      (element: HTMLInputElement | null) => {
+        internalRef.current = element;
+        if (typeof ref === "function") {
+          ref(element);
+        } else if (ref) {
+          ref.current = element;
+        }
+      },
+      [ref]
+    );
 
     // Auto-focus handling
     useEffect(() => {
-      if (autoFocus && inputRef.current) {
+      if (autoFocus && internalRef.current) {
         // Small delay to ensure dropdown is rendered
         const timer = setTimeout(() => {
-          inputRef.current?.focus();
+          internalRef.current?.focus();
         }, 10);
         return () => clearTimeout(timer);
       }
-    }, [autoFocus, inputRef]);
+    }, [autoFocus]);
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
       onChange(e.target.value);
@@ -103,34 +151,67 @@ const DropdownSearch = forwardRef<HTMLInputElement, DropdownSearchProps>(
       event.stopPropagation();
     };
 
-    const handleMouseDown = stopMouseDownPropagation
+    const handleInputClick = (event: React.MouseEvent<HTMLInputElement>) => {
+      handlePointerGuard(event);
+      onClick?.(event);
+    };
+
+    const handleInputMouseDown = (
+      event: React.MouseEvent<HTMLInputElement>
+    ) => {
+      if (stopMouseDownPropagation) handlePointerGuard(event);
+      onMouseDown?.(event);
+    };
+
+    const handleInputKeyDown = (
+      event: React.KeyboardEvent<HTMLInputElement>
+    ) => {
+      tauriSelectAll(event);
+      if (!event.defaultPrevented) onKeyDown?.(event);
+    };
+
+    const handleContainerMouseDown = stopMouseDownPropagation
       ? handlePointerGuard
       : undefined;
 
     const resolvedPlaceholder = placeholder ?? t("actions.search");
-
-    return (
-      <div
-        className={DROPDOWN_CLASSES.searchContainer}
-        onClick={handlePointerGuard}
-        onMouseDown={handleMouseDown}
-      >
+    const resolvedLeading =
+      leading === undefined ? (
         <HugeiconsIcon
           icon={Search01Icon}
           data-icon="search"
           size={DROPDOWN_SEARCH.iconSize}
           className="flex-shrink-0 text-text-3"
         />
+      ) : (
+        leading
+      );
+
+    return (
+      <div
+        className={[DROPDOWN_CLASSES.searchContainer, containerClassName]
+          .filter(Boolean)
+          .join(" ")}
+        data-testid={testId}
+        onClick={handlePointerGuard}
+        onMouseDown={handleContainerMouseDown}
+      >
+        {resolvedLeading}
         <input
-          ref={inputRef}
-          type="search"
+          {...inputProps}
+          ref={setInputRef}
+          type={type}
           value={value}
           onChange={handleChange}
-          onClick={handlePointerGuard}
-          onMouseDown={handleMouseDown}
-          onKeyDown={tauriSelectAll}
+          onClick={handleInputClick}
+          onMouseDown={handleInputMouseDown}
+          onKeyDown={handleInputKeyDown}
           placeholder={resolvedPlaceholder}
           aria-label={ariaLabel ?? resolvedPlaceholder}
+          autoComplete={autoComplete}
+          autoCorrect={autoCorrect}
+          autoCapitalize={autoCapitalize}
+          spellCheck={spellCheck}
           className={DROPDOWN_CLASSES.searchInput}
         />
       </div>

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -17,18 +17,12 @@
  * <Select mode="multiple" showSearch options={options} onChange={handleChange} />
  * ```
  */
-import React, {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import React, { forwardRef, useCallback, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
 import DropdownOptionsRenderer from "@src/components/Dropdown/DropdownOptionsRenderer";
+import DropdownSearch from "@src/components/Dropdown/DropdownSearch";
 import {
   DROPDOWN_CLASSES,
   DROPDOWN_ITEM,
@@ -39,13 +33,11 @@ import { useDropdownKeyboard } from "@src/components/Dropdown/useDropdownKeyboar
 import { SPINNER_TOKENS } from "@src/config/spinnerTokens";
 import { getDropdownPanelStyle } from "@src/hooks/dropdown/dropdownPanelStyle";
 import { useDropdownEngine } from "@src/hooks/dropdown/useDropdownEngine";
-import { useTauriSelectAllShortcut } from "@src/hooks/keyboard";
 import {
   ArrowDown01Icon,
   Cancel01Icon,
   HugeiconsIcon,
   Loading03Icon,
-  Search01Icon,
 } from "@src/icons";
 import { useCurrentTheme } from "@src/util/ui/theme/themeUtils";
 
@@ -126,8 +118,6 @@ const Select = forwardRef<HTMLDivElement, SelectProps>(
 
     // ---- Search state ----
     const [searchValue, setSearchValue] = useState("");
-    const searchInputRef = useRef<HTMLInputElement>(null);
-    const tauriSelectAll = useTauriSelectAllShortcut();
 
     const filteredOptions = useMemo(() => {
       if (!showSearch || !searchValue) return flatOptions;
@@ -214,33 +204,13 @@ const Select = forwardRef<HTMLDivElement, SelectProps>(
 
     // ---- Search change handler ----
     const handleSearchChange = useCallback(
-      (event: React.ChangeEvent<HTMLInputElement>) => {
-        const val = event.target.value;
+      (val: string) => {
         setSearchValue(val);
         resetHighlight();
         onSearch?.(val);
       },
       [resetHighlight, onSearch]
     );
-
-    // The search field lives in a portal that is a sibling of the trigger,
-    // so its key events cannot bubble to the trigger's navigation handler.
-    // Forward navigation keys explicitly while preserving Tauri's Cmd/Ctrl+A.
-    const handleSearchKeyDown = useCallback(
-      (event: React.KeyboardEvent<HTMLInputElement>) => {
-        tauriSelectAll(event);
-        if (!event.defaultPrevented) handleKeyDown(event);
-      },
-      [handleKeyDown, tauriSelectAll]
-    );
-
-    // ---- Focus search input on open ----
-    useEffect(() => {
-      if (currentPopupVisible && showSearch) {
-        const timer = setTimeout(() => searchInputRef.current?.focus(), 10);
-        return () => clearTimeout(timer);
-      }
-    }, [currentPopupVisible, showSearch]);
 
     // ---- Trigger rendering ----
     const renderValue = () => {
@@ -418,27 +388,14 @@ const Select = forwardRef<HTMLDivElement, SelectProps>(
               style={panelPositionStyle}
             >
               {showSearch && (
-                <div className={DROPDOWN_CLASSES.searchContainer}>
-                  <HugeiconsIcon
-                    icon={Search01Icon}
-                    data-icon="search"
-                    size={DROPDOWN_ITEM.iconSize}
-                    className="shrink-0 text-text-3"
-                  />
-                  <input
-                    ref={searchInputRef}
-                    type="text"
-                    placeholder={t("common:actions.search")}
-                    value={searchValue}
-                    onChange={handleSearchChange}
-                    onClick={(event) => event.stopPropagation()}
-                    onKeyDown={handleSearchKeyDown}
-                    autoCorrect="off"
-                    autoCapitalize="off"
-                    spellCheck={false}
-                    className={DROPDOWN_CLASSES.searchInput}
-                  />
-                </div>
+                <DropdownSearch
+                  type="text"
+                  value={searchValue}
+                  onChange={handleSearchChange}
+                  onKeyDown={handleKeyDown}
+                  placeholder={t("common:actions.search")}
+                  autoFocus
+                />
               )}
               <DropdownOptionsRenderer
                 options={filteredOptions}

--- a/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/PinActionsPanel.tsx
+++ b/src/engines/ChatPanel/InputArea/components/PinnedActionsBar/PinActionsPanel.tsx
@@ -10,6 +10,7 @@ import React, { memo, useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
+import DropdownSearch from "@src/components/Dropdown/DropdownSearch";
 import {
   DROPDOWN_CLASSES,
   DROPDOWN_ITEM,
@@ -17,13 +18,7 @@ import {
 } from "@src/components/Dropdown/tokens";
 import FileTreePreview from "@src/components/FileTreePreview";
 import { useDropdownEngine } from "@src/hooks/dropdown";
-import {
-  ArrowUp02Icon,
-  HugeiconsIcon,
-  PinIcon,
-  PinOffIcon,
-  Search01Icon,
-} from "@src/icons";
+import { ArrowUp02Icon, HugeiconsIcon, PinIcon, PinOffIcon } from "@src/icons";
 import type { PinnedAction } from "@src/store/session/pinnedActionsAtom";
 import type { SlashItem } from "@src/types/extensions";
 import { fuzzyMatch, fuzzyScore } from "@src/util/search/fuzzy";
@@ -323,26 +318,13 @@ const PinActionsPanel: React.FC<PinActionsPanelProps> = memo(
         )}
 
         {/* Search header */}
-        <div className={DROPDOWN_CLASSES.searchContainer}>
-          <HugeiconsIcon
-            icon={Search01Icon}
-            data-icon="search"
-            size={DROPDOWN_ITEM.iconSize}
-            className="shrink-0 text-text-3"
-          />
-          <input
-            ref={inputRef}
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder={t("input.pinnedActions.searchPlaceholder")}
-            className={DROPDOWN_CLASSES.searchInput}
-            autoComplete="off"
-            autoCorrect="off"
-            autoCapitalize="off"
-            spellCheck={false}
-          />
-        </div>
+        <DropdownSearch
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={setQuery}
+          placeholder={t("input.pinnedActions.searchPlaceholder")}
+        />
 
         {/* List */}
         <div

--- a/src/engines/ChatPanel/InputArea/components/SlashCommandPortal/SlashCommandMenu.tsx
+++ b/src/engines/ChatPanel/InputArea/components/SlashCommandPortal/SlashCommandMenu.tsx
@@ -15,15 +15,13 @@ import React, {
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
+import DropdownSearch from "@src/components/Dropdown/DropdownSearch";
 import {
   DROPDOWN_CLASSES,
-  DROPDOWN_ITEM,
   DROPDOWN_PANEL,
 } from "@src/components/Dropdown/tokens";
 import FileTreePreview from "@src/components/FileTreePreview";
-import { useTauriSelectAllShortcut } from "@src/hooks/keyboard";
 import { useMouseMoved } from "@src/hooks/ui/useMouseMoved";
-import { HugeiconsIcon, Search01Icon } from "@src/icons";
 
 import { useFloatingPortalPosition } from "../useFloatingPortalPosition";
 import FlyoutSubmenu from "./FlyoutSubmenu";
@@ -70,7 +68,6 @@ const SlashCommandMenu: React.FC<SlashCommandPortalProps> = ({
   const listRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const menuOpenedAtRef = useRef(0);
-  const tauriSelectAll = useTauriSelectAllShortcut();
 
   // Build the unified entry list
   const { entries, totalFlat } = useEntries({
@@ -287,39 +284,22 @@ const SlashCommandMenu: React.FC<SlashCommandPortalProps> = ({
         }}
       >
         {isHeaderMode && (
-          <div
-            className={DROPDOWN_CLASSES.searchContainer}
-            data-testid="slash-command-search"
-          >
-            <HugeiconsIcon
-              icon={Search01Icon}
-              data-icon="search"
-              size={DROPDOWN_ITEM.iconSize}
-              className="shrink-0 text-text-3"
-            />
-            <input
-              ref={searchInputRef}
-              data-slash-search-input="true"
-              type="text"
-              value={searchQuery}
-              onChange={(e) => onSearchQueryChange?.(e.target.value)}
-              onKeyDown={(e) => {
-                tauriSelectAll(e);
-                if (e.defaultPrevented) return;
-                if (keyboardHandlerRef.current?.(e.nativeEvent)) {
-                  e.preventDefault();
-                }
-              }}
-              placeholder={t("creator.slashSearchPlaceholder", {
-                defaultValue: "Search commands…",
-              })}
-              className={DROPDOWN_CLASSES.searchInput}
-              autoComplete="off"
-              autoCorrect="off"
-              autoCapitalize="off"
-              spellCheck={false}
-            />
-          </div>
+          <DropdownSearch
+            ref={searchInputRef}
+            data-slash-search-input="true"
+            testId="slash-command-search"
+            type="text"
+            value={searchQuery}
+            onChange={(value) => onSearchQueryChange?.(value)}
+            onKeyDown={(event) => {
+              if (keyboardHandlerRef.current?.(event.nativeEvent)) {
+                event.preventDefault();
+              }
+            }}
+            placeholder={t("creator.slashSearchPlaceholder", {
+              defaultValue: "Search commands…",
+            })}
+          />
         )}
 
         <div

--- a/src/features/SessionCreator/components/WorktreeSourceSelectorViews.tsx
+++ b/src/features/SessionCreator/components/WorktreeSourceSelectorViews.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 
 import AnyIcon from "@src/components/AnyIcon";
 import Button from "@src/components/Button";
+import DropdownSearch from "@src/components/Dropdown/DropdownSearch";
 import {
   DROPDOWN_CLASSES,
   DROPDOWN_ITEM,
@@ -14,7 +15,6 @@ import {
   type UseDropdownListNavigationReturn,
   useDropdownEngine,
 } from "@src/hooks/dropdown";
-import { useTauriSelectAllShortcut } from "@src/hooks/keyboard";
 import { HugeiconsIcon, Refresh04Icon, Tick01Icon } from "@src/icons";
 import { useSelectorKernel } from "@src/scaffold/GlobalSpotlight/palettes/core";
 import {
@@ -340,7 +340,6 @@ export function WorktreeSourceDropdownView({
   onSelect,
 }: WorktreeSourceSelectorViewProps) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const tauriSelectAll = useTauriSelectAllShortcut();
   const handleSelect = useCallback(
     (item: WorktreeSourcePickerItem) => {
       if (!resolving) onSelect(item);
@@ -394,23 +393,23 @@ export function WorktreeSourceDropdownView({
         width,
       }}
     >
-      <div className={`${DROPDOWN_CLASSES.searchContainer} gap-2`}>
-        <WorktreeSourceModeSwitch
-          mode={mode}
-          disabled={resolving}
-          onChange={onModeChange}
-        />
-        <input
-          ref={inputRef}
-          value={query}
-          onChange={(event) => onQueryChange(event.target.value)}
-          onKeyDown={tauriSelectAll}
-          placeholder={searchPlaceholder}
-          aria-label={searchAriaLabel}
-          className={DROPDOWN_CLASSES.searchInput}
-          disabled={resolving}
-        />
-      </div>
+      <DropdownSearch
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={onQueryChange}
+        placeholder={searchPlaceholder}
+        ariaLabel={searchAriaLabel}
+        leading={
+          <WorktreeSourceModeSwitch
+            mode={mode}
+            disabled={resolving}
+            onChange={onModeChange}
+          />
+        }
+        containerClassName="gap-2"
+        disabled={resolving}
+      />
 
       <div
         className={DROPDOWN_CLASSES.optionsContainerOverlay}

--- a/src/modules/MainApp/AgentOrgs/config/shared/SubAgentsEditor.tsx
+++ b/src/modules/MainApp/AgentOrgs/config/shared/SubAgentsEditor.tsx
@@ -38,7 +38,10 @@ import React, { useCallback, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 
 import Button from "@src/components/Button";
-import { DropdownPanel } from "@src/components/Dropdown/exports";
+import {
+  DropdownPanel,
+  DropdownSearch,
+} from "@src/components/Dropdown/exports";
 import {
   DROPDOWN_CLASSES,
   DROPDOWN_ITEM,
@@ -145,15 +148,14 @@ const AddSubAgentButton: React.FC<AddSubAgentButtonProps> = ({
               width: Math.max(panelPosition.width, 220),
             }}
           >
-            <div className={DROPDOWN_CLASSES.searchContainer}>
-              <input
-                autoFocus
-                value={search}
-                onChange={(evt) => setSearch(evt.target.value)}
-                className={DROPDOWN_CLASSES.searchInput}
-                placeholder={t("common:actions.search")}
-              />
-            </div>
+            <DropdownSearch
+              type="text"
+              value={search}
+              onChange={setSearch}
+              placeholder={t("common:actions.search")}
+              leading={null}
+              autoFocus
+            />
             <div className={`${DROPDOWN_CLASSES.optionsContainer} max-h-52`}>
               {filtered.length === 0 ? (
                 <div className={DROPDOWN_CLASSES.listMessage}>

--- a/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlScopeToolbar.tsx
+++ b/src/modules/WorkStation/CodeEditor/Panels/EditorPrimarySidebar/tabs/SourceControlScopeToolbar.tsx
@@ -6,6 +6,7 @@ import AnyIcon from "@src/components/AnyIcon";
 import DiffStatsBadge from "@src/components/DiffStatsBadge";
 import Dropdown from "@src/components/Dropdown";
 import DropdownItem from "@src/components/Dropdown/DropdownItem";
+import DropdownSearch from "@src/components/Dropdown/DropdownSearch";
 import DropdownSelectedCheck from "@src/components/Dropdown/DropdownSelectedCheck";
 import {
   DROPDOWN_CLASSES,
@@ -19,7 +20,6 @@ import {
   Delete02Icon,
   FolderClosedIcon,
   HugeiconsIcon,
-  Search01Icon,
   WorkflowCircle05Icon,
 } from "@src/icons";
 import {
@@ -280,22 +280,13 @@ export function SourceControlScopeToolbar({
       onMouseDown={(event) => event.stopPropagation()}
     >
       {showSearch ? (
-        <div className={DROPDOWN_CLASSES.searchContainer}>
-          <HugeiconsIcon
-            icon={Search01Icon}
-            data-icon="search"
-            size={DROPDOWN_ITEM.iconSize}
-            className="shrink-0 text-text-3"
-          />
-          <input
-            type="search"
-            value={searchQuery}
-            onChange={(event) => setSearchQuery(event.target.value)}
-            placeholder={t("sourceControl.scope.searchPlaceholder")}
-            className={DROPDOWN_CLASSES.searchInput}
-            aria-label={t("sourceControl.scope.searchPlaceholder")}
-          />
-        </div>
+        <DropdownSearch
+          type="search"
+          value={searchQuery}
+          onChange={setSearchQuery}
+          placeholder={t("sourceControl.scope.searchPlaceholder")}
+          ariaLabel={t("sourceControl.scope.searchPlaceholder")}
+        />
       ) : null}
       <div className={DROPDOWN_CLASSES.optionsContainerScrollbar}>
         {showMainScope ? (

--- a/src/modules/WorkStation/TabContent/renderers/CliAgentHeaderSwitcher.tsx
+++ b/src/modules/WorkStation/TabContent/renderers/CliAgentHeaderSwitcher.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import type { CliAgentType } from "@src/api/types/keys";
 import Dropdown from "@src/components/Dropdown";
 import DropdownItem from "@src/components/Dropdown/DropdownItem";
+import DropdownSearch from "@src/components/Dropdown/DropdownSearch";
 import {
   DROPDOWN_CLASSES,
   DROPDOWN_ITEM,
@@ -15,7 +16,6 @@ import {
   getIconProviderFromType,
 } from "@src/components/ModelIcon/config";
 import SelectGhostTrigger from "@src/components/Select/SelectGhostTrigger";
-import { HugeiconsIcon, Search01Icon } from "@src/icons";
 import type { AvailableCliAgent } from "@src/modules/MainApp/AgentOrgs/types";
 import { openAgentConfigInWorkStation } from "@src/util/ui/openAgentConfigInWorkStation";
 
@@ -94,22 +94,13 @@ export function CliAgentHeaderSwitcher({
       onMouseDown={(event) => event.stopPropagation()}
     >
       {showSearch ? (
-        <div className={DROPDOWN_CLASSES.searchContainer}>
-          <HugeiconsIcon
-            icon={Search01Icon}
-            data-icon="search"
-            size={DROPDOWN_ITEM.iconSize}
-            className="shrink-0 text-text-3"
-          />
-          <input
-            type="search"
-            value={searchQuery}
-            onChange={(event) => setSearchQuery(event.target.value)}
-            placeholder={t("common:common.searchPlaceholder")}
-            className={DROPDOWN_CLASSES.searchInput}
-            aria-label={t("common:actions.search")}
-          />
-        </div>
+        <DropdownSearch
+          type="search"
+          value={searchQuery}
+          onChange={setSearchQuery}
+          placeholder={t("common:common.searchPlaceholder")}
+          ariaLabel={t("common:actions.search")}
+        />
       ) : null}
       <div className={DROPDOWN_CLASSES.optionsContainerScrollbar}>
         {filteredAgents.map((agent) => (

--- a/src/modules/WorkStation/shared/StatusBar/PortsStatusMenu.tsx
+++ b/src/modules/WorkStation/shared/StatusBar/PortsStatusMenu.tsx
@@ -7,6 +7,7 @@ import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
 import type { WorkspacePort } from "@src/api/tauri/workspacePorts";
+import DropdownSearch from "@src/components/Dropdown/DropdownSearch";
 import {
   DROPDOWN_CLASSES,
   DROPDOWN_ITEM,
@@ -14,7 +15,6 @@ import {
   DROPDOWN_WIDTHS,
 } from "@src/components/Dropdown/tokens";
 import { useDropdownEngine } from "@src/hooks/dropdown";
-import { useTauriSelectAllShortcut } from "@src/hooks/keyboard";
 import { createLogger } from "@src/hooks/logger";
 import {
   Copy01Icon,
@@ -22,7 +22,6 @@ import {
   HugeiconsIcon,
   InternetIcon,
   Loading03Icon,
-  Search01Icon,
   UnplugIcon,
 } from "@src/icons";
 import {
@@ -207,7 +206,6 @@ export const PortsStatusMenu: React.FC = memo(() => {
   const [externalExpanded, setExternalExpanded] = useState(
     () => workspaceCount === 0 && externalCount > 0
   );
-  const tauriSelectAll = useTauriSelectAllShortcut();
 
   const {
     isOpen,
@@ -332,22 +330,13 @@ export const PortsStatusMenu: React.FC = memo(() => {
             }}
             role="menu"
           >
-            <div className={DROPDOWN_CLASSES.searchContainer}>
-              <HugeiconsIcon
-                icon={Search01Icon}
-                data-icon="search"
-                size={DROPDOWN_ITEM.iconSize}
-                className="shrink-0 text-text-3"
-              />
-              <input
-                value={searchQuery}
-                onChange={(event) => setSearchQuery(event.target.value)}
-                onKeyDown={tauriSelectAll}
-                placeholder={t("workstation.ports.searchPlaceholder")}
-                className={DROPDOWN_CLASSES.searchInput}
-                autoFocus
-              />
-            </div>
+            <DropdownSearch
+              type="text"
+              value={searchQuery}
+              onChange={setSearchQuery}
+              placeholder={t("workstation.ports.searchPlaceholder")}
+              autoFocus
+            />
 
             <div className={DROPDOWN_CLASSES.optionsContainerBelowHeader}>
               {!hasAnyMatches ? (

--- a/src/modules/shared/layouts/blocks/SettingsBreadcrumb/index.tsx
+++ b/src/modules/shared/layouts/blocks/SettingsBreadcrumb/index.tsx
@@ -26,11 +26,11 @@ import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import AnyIcon, { type RenderableIcon } from "@src/components/AnyIcon";
+import DropdownSearch from "@src/components/Dropdown/DropdownSearch";
 import {
   DROPDOWN_CLASSES,
   DROPDOWN_ITEM,
   DROPDOWN_PANEL,
-  DROPDOWN_SEARCH,
   DROPDOWN_WIDTHS,
 } from "@src/components/Dropdown/tokens";
 import {
@@ -48,13 +48,7 @@ import {
 } from "@src/config/mainAppPaths";
 import type { CoreSettingsItemSegment } from "@src/config/mainAppPaths";
 import { useDropdownEngine } from "@src/hooks/dropdown";
-import { useTauriSelectAllShortcut } from "@src/hooks/keyboard";
-import {
-  ArrowRight01Icon,
-  HugeiconsIcon,
-  Search01Icon,
-  Tick01Icon,
-} from "@src/icons";
+import { ArrowRight01Icon, HugeiconsIcon, Tick01Icon } from "@src/icons";
 import { devModeEnabledAtom } from "@src/store/platform/devModeAtom";
 import {
   settingsSelectionTitleAtom,
@@ -169,7 +163,6 @@ const SettingsBreadcrumb: React.FC<SettingsBreadcrumbProps> = ({
   const [searchQuery, setSearchQuery] = useState("");
   const [selectorOpen, setSelectorOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
-  const tauriSelectAll = useTauriSelectAllShortcut();
 
   const selectorGroups = useMemo<SettingsSelectorGroup[]>(
     () =>
@@ -293,39 +286,25 @@ const SettingsBreadcrumb: React.FC<SettingsBreadcrumbProps> = ({
               minWidth: Math.max(panelPosition.width, 240),
             }}
           >
-            <div className={DROPDOWN_CLASSES.searchContainer}>
-              <HugeiconsIcon
-                icon={Search01Icon}
-                data-icon="search"
-                size={DROPDOWN_SEARCH.iconSize}
-                className="shrink-0 text-text-3"
-              />
-              <input
-                ref={inputRef}
-                type="text"
-                value={searchQuery}
-                onChange={(event) => {
-                  setSearchQuery(event.target.value);
-                  keyboard.setSelectedIndex(0);
-                }}
-                onKeyDown={(event) => {
-                  tauriSelectAll(event);
-                  if (event.defaultPrevented) return;
-                  if (
-                    event.key === "ArrowDown" ||
-                    event.key === "ArrowUp" ||
-                    event.key === "Enter"
-                  ) {
-                    keyboard.handleKeyDown(event);
-                  }
-                }}
-                placeholder={tSettings("searchPlaceholder")}
-                className={DROPDOWN_CLASSES.searchInput}
-                spellCheck={false}
-                autoCorrect="off"
-                autoCapitalize="off"
-              />
-            </div>
+            <DropdownSearch
+              ref={inputRef}
+              type="text"
+              value={searchQuery}
+              onChange={(value) => {
+                setSearchQuery(value);
+                keyboard.setSelectedIndex(0);
+              }}
+              onKeyDown={(event) => {
+                if (
+                  event.key === "ArrowDown" ||
+                  event.key === "ArrowUp" ||
+                  event.key === "Enter"
+                ) {
+                  keyboard.handleKeyDown(event);
+                }
+              }}
+              placeholder={tSettings("searchPlaceholder")}
+            />
             <div
               className={`${DROPDOWN_CLASSES.optionsContainerOverlay} max-h-[360px]`}
             >

--- a/src/scaffold/GlobalSpotlight/palettes/BranchPalette/BranchDropdown.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/BranchPalette/BranchDropdown.tsx
@@ -19,6 +19,7 @@ import React, {
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
+import DropdownSearch from "@src/components/Dropdown/DropdownSearch";
 import {
   DROPDOWN_CLASSES,
   DROPDOWN_ITEM,
@@ -28,12 +29,10 @@ import {
   type UseDropdownListNavigationReturn,
   useDropdownEngine,
 } from "@src/hooks/dropdown";
-import { useTauriSelectAllShortcut } from "@src/hooks/keyboard";
 import { useFilteredItems } from "@src/hooks/search";
 import {
   FolderClosedIcon,
   HugeiconsIcon,
-  Search01Icon,
   Tick01Icon,
   WorkflowCircle05Icon,
 } from "@src/icons";
@@ -131,7 +130,6 @@ export const BranchDropdown: React.FC<BranchDropdownProps> = ({
 }) => {
   const { t } = useTranslation();
   const inputRef = useRef<HTMLInputElement>(null);
-  const tauriSelectAll = useTauriSelectAllShortcut();
 
   const [searchQuery, setSearchQuery] = useState("");
   const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
@@ -265,22 +263,13 @@ export const BranchDropdown: React.FC<BranchDropdownProps> = ({
         width,
       }}
     >
-      <div className={DROPDOWN_CLASSES.searchContainer}>
-        <HugeiconsIcon
-          icon={Search01Icon}
-          data-icon="search"
-          size={DROPDOWN_ITEM.iconSize}
-          className="shrink-0 text-text-3"
-        />
-        <input
-          ref={inputRef}
-          value={searchQuery}
-          onChange={(event) => setSearchQuery(event.target.value)}
-          onKeyDown={tauriSelectAll}
-          placeholder={t("selectors.spotlight.placeholders.branch")}
-          className={DROPDOWN_CLASSES.searchInput}
-        />
-      </div>
+      <DropdownSearch
+        ref={inputRef}
+        type="text"
+        value={searchQuery}
+        onChange={setSearchQuery}
+        placeholder={t("selectors.spotlight.placeholders.branch")}
+      />
 
       <div
         className={DROPDOWN_CLASSES.optionsContainerOverlay}

--- a/src/scaffold/GlobalSpotlight/palettes/DispatchCategoryPalette/DispatchCategoryDropdown.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/DispatchCategoryPalette/DispatchCategoryDropdown.tsx
@@ -20,6 +20,7 @@ import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
 import AnyIcon from "@src/components/AnyIcon";
+import DropdownSearch from "@src/components/Dropdown/DropdownSearch";
 import {
   DROPDOWN_CLASSES,
   DROPDOWN_ITEM,
@@ -29,9 +30,8 @@ import {
   type UseDropdownListNavigationReturn,
   useDropdownEngine,
 } from "@src/hooks/dropdown";
-import { useTauriSelectAllShortcut } from "@src/hooks/keyboard";
 import { useFilteredItems } from "@src/hooks/search";
-import { HugeiconsIcon, Search01Icon, Tick01Icon } from "@src/icons";
+import { HugeiconsIcon, Tick01Icon } from "@src/icons";
 import { getViewportSize } from "@src/util/ui/window/viewport";
 
 import type { SpotlightItem } from "../../types";
@@ -125,7 +125,6 @@ export const DispatchCategoryDropdown: React.FC<
 }) => {
   const { t: tCommon } = useTranslation("common");
   const inputRef = useRef<HTMLInputElement>(null);
-  const tauriSelectAll = useTauriSelectAllShortcut();
 
   const { allOptions, groups, optionToItem } = useDispatchCategoryOptions({
     isOpen,
@@ -229,22 +228,13 @@ export const DispatchCategoryDropdown: React.FC<
         width,
       }}
     >
-      <div className={DROPDOWN_CLASSES.searchContainer}>
-        <HugeiconsIcon
-          icon={Search01Icon}
-          data-icon="search"
-          size={DROPDOWN_ITEM.iconSize}
-          className="shrink-0 text-text-3"
-        />
-        <input
-          ref={inputRef}
-          value={searchQuery}
-          onChange={(event) => setSearchQuery(event.target.value)}
-          onKeyDown={tauriSelectAll}
-          placeholder={tCommon("filters.searchAgentOrOrg")}
-          className={DROPDOWN_CLASSES.searchInput}
-        />
-      </div>
+      <DropdownSearch
+        ref={inputRef}
+        type="text"
+        value={searchQuery}
+        onChange={setSearchQuery}
+        placeholder={tCommon("filters.searchAgentOrOrg")}
+      />
 
       <div
         className={DROPDOWN_CLASSES.optionsContainerOverlay}

--- a/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/UnifiedModelDropdown.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/UnifiedModelPalette/UnifiedModelDropdown.tsx
@@ -20,6 +20,7 @@ import React, {
 import { createPortal } from "react-dom";
 
 import AnyIcon from "@src/components/AnyIcon";
+import DropdownSearch from "@src/components/Dropdown/DropdownSearch";
 import HoverSafeSubmenuBridge from "@src/components/Dropdown/HoverSafeSubmenuBridge";
 import {
   DROPDOWN_CLASSES,
@@ -31,14 +32,8 @@ import {
   type UseDropdownListNavigationReturn,
   useDropdownEngine,
 } from "@src/hooks/dropdown";
-import { useTauriSelectAllShortcut } from "@src/hooks/keyboard";
 import { useFilteredItems } from "@src/hooks/search";
-import {
-  ArrowRight01Icon,
-  HugeiconsIcon,
-  Search01Icon,
-  Tick01Icon,
-} from "@src/icons";
+import { ArrowRight01Icon, HugeiconsIcon, Tick01Icon } from "@src/icons";
 import { getViewportSize } from "@src/util/ui/window/viewport";
 
 import type { SpotlightItem } from "../../shared";
@@ -179,7 +174,6 @@ export const UnifiedModelDropdown: React.FC<UnifiedModelDropdownProps> = ({
   placement = "bottom",
 }) => {
   const inputRef = useRef<HTMLInputElement>(null);
-  const tauriSelectAll = useTauriSelectAllShortcut();
 
   const {
     recentItems,
@@ -479,22 +473,13 @@ export const UnifiedModelDropdown: React.FC<UnifiedModelDropdownProps> = ({
           width: DROPDOWN_WIDTH,
         }}
       >
-        <div className={DROPDOWN_CLASSES.searchContainer}>
-          <HugeiconsIcon
-            icon={Search01Icon}
-            data-icon="search"
-            size={DROPDOWN_ITEM.iconSize}
-            className="shrink-0 text-text-3"
-          />
-          <input
-            ref={inputRef}
-            value={searchQuery}
-            onChange={(event) => setSearchQuery(event.target.value)}
-            onKeyDown={tauriSelectAll}
-            placeholder={placeholder}
-            className={DROPDOWN_CLASSES.searchInput}
-          />
-        </div>
+        <DropdownSearch
+          ref={inputRef}
+          type="text"
+          value={searchQuery}
+          onChange={setSearchQuery}
+          placeholder={placeholder}
+        />
 
         <div
           className={DROPDOWN_CLASSES.optionsContainerOverlay}

--- a/src/scaffold/GlobalSpotlight/palettes/WorkspacePalette/WorkspaceDropdown.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/WorkspacePalette/WorkspaceDropdown.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from "react-i18next";
 
 import { repoApi } from "@src/api/tauri/repo";
 import AnyIcon from "@src/components/AnyIcon";
+import DropdownSearch from "@src/components/Dropdown/DropdownSearch";
 import {
   DROPDOWN_CLASSES,
   DROPDOWN_ITEM,
@@ -36,8 +37,7 @@ import {
   type UseDropdownListNavigationReturn,
   useDropdownEngine,
 } from "@src/hooks/dropdown";
-import { useTauriSelectAllShortcut } from "@src/hooks/keyboard";
-import { HugeiconsIcon, Search01Icon, Tick01Icon } from "@src/icons";
+import { HugeiconsIcon, Tick01Icon } from "@src/icons";
 import { REPO_KIND, cachedReposAtom } from "@src/store/repo";
 import {
   isMultiRootWorkspaceAtom,
@@ -239,7 +239,6 @@ export const WorkspaceDropdown: React.FC<WorkspaceDropdownProps> = ({
 }) => {
   const { t } = useTranslation();
   const inputRef = useRef<HTMLInputElement>(null);
-  const tauriSelectAll = useTauriSelectAllShortcut();
 
   const [searchQuery, setSearchQuery] = useState("");
   const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
@@ -648,22 +647,13 @@ export const WorkspaceDropdown: React.FC<WorkspaceDropdownProps> = ({
         width,
       }}
     >
-      <div className={DROPDOWN_CLASSES.searchContainer}>
-        <HugeiconsIcon
-          icon={Search01Icon}
-          data-icon="search"
-          size={DROPDOWN_ITEM.iconSize}
-          className="shrink-0 text-text-3"
-        />
-        <input
-          ref={inputRef}
-          value={searchQuery}
-          onChange={(event) => setSearchQuery(event.target.value)}
-          onKeyDown={tauriSelectAll}
-          placeholder={t("selectors.spotlight.placeholders.workspace")}
-          className={DROPDOWN_CLASSES.searchInput}
-        />
-      </div>
+      <DropdownSearch
+        ref={inputRef}
+        type="text"
+        value={searchQuery}
+        onChange={setSearchQuery}
+        placeholder={t("selectors.spotlight.placeholders.workspace")}
+      />
 
       <div
         className={DROPDOWN_CLASSES.optionsContainerOverlay}


### PR DESCRIPTION
## Problem

Fourteen dropdown surfaces rebuild the same tokenized search row with raw inputs. That duplicates search icons, value adaptation, refs, pointer guards, Tauri select-all handling, search attributes, and accessibility labels, so behavior has already drifted between otherwise identical dropdowns.

## Solution

Expand the existing `DropdownSearch` component with narrowly scoped native-input passthrough, callback/object ref merging, keyboard-handler composition, optional leading content, container styling, and test identity. Migrate the complete matching raw-input sweep so `DropdownSearch` is the only owner of `DROPDOWN_CLASSES.searchInput`.

Caller-specific input types, labels, focus behavior, disabled state, navigation handlers, test markers, and the worktree source mode switch are preserved. Two remaining `searchContainer` usages are documented as intentional non-input headers in the audit report.

## Potential risks

The main regression risk is event behavior in nested dropdowns because pointer guarding and Tauri select-all now come from one component. Focused Select and worktree-selector tests pass, while each migration preserves its previous input type and custom keyboard handler. Search autocomplete, autocorrect, autocapitalization, and spellcheck now default off consistently; callers can still override native attributes.

There are no persistence, schema, IPC, wire, concurrency, lifecycle, dependency, or platform compatibility changes. Rollback is a normal revert of the single commit. Screenshots are not useful for this refactor because it intentionally preserves the existing token classes and rendered layout; no visual change is intended.

## Verification

- `pnpm run typecheck` — passed on the rebased TypeScript tree
- `pnpm run lint` — passed repository-wide with zero warnings
- ESLint over every changed TS/TSX file after rebase — passed with zero warnings
- `pnpm run check:circular` — passed; no circular dependencies across 6,533 modules
- `pnpm run check:test-placement` — passed across 437 directories
- `pnpm exec prettier --check <changed files>` — passed
- `pnpm exec vitest run src/components/Dropdown/DropdownSearch.test.ts src/components/Select/index.test.ts src/features/SessionCreator/components/__tests__/WorktreeSourceSelector.test.ts --reporter=dot` — 3 files and 9 tests passed after the final rebase
- Source sweep: `DROPDOWN_CLASSES.searchInput` has one production owner and all matching raw search rows were removed
- `pnpm run test` — attempted but not completed: unrelated session/workstation atom suites began timing out while another checkout was running a full Vitest suite concurrently, so the contended run was stopped. The affected files in this PR passed in the focused run above.
- Manual screenshots were not taken because the change is intended to be visually identical and local UI control was not used

## Audit

Frontend UI verdicts: **1 fix**, **2 keep with reason**, **0 abstract**, **0 watch**. The report also records all ten architecture-audit layers in `docs/frontend-ui-audit-2026-08-28/DropdownSearch.md`.