### PR TITLE
fix(composer): align control surfaces

### DIFF
--- a/public/orgii_main.css
+++ b/public/orgii_main.css
@@ -116,7 +116,7 @@ body {
   --color-border-3: #c9cdd4;
   --color-fill-1: #f5f5f5;
   --color-fill-2: #efefef;
-  --color-fill-3: #e1e1e1;
+  --color-fill-3: #e3e3e3;
   --color-fill-4: #d4d4d4;
   --sidebar-tab-pill-selected-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 

--- a/src/components/ComposerBar/index.test.ts
+++ b/src/components/ComposerBar/index.test.ts
@@ -16,8 +16,8 @@ describe("ComposerBar", () => {
     );
 
     expect(markup).toContain('data-testid="composer-skills-tools-button"');
-    expect(markup).toContain("!bg-bg-2");
     expect(markup).toContain("enabled:hover:!bg-surface-hover");
+    expect(markup).not.toContain("!bg-bg-2");
   });
 
   it("uses the same toolbar row beneath an editor slot", () => {

--- a/src/components/ComposerBar/index.tsx
+++ b/src/components/ComposerBar/index.tsx
@@ -9,7 +9,7 @@
  */
 import React, { memo } from "react";
 
-import { PILL_CONTROL_IDLE_SURFACE_CLASS } from "@src/components/CompoundPill/config";
+import { PILL_CONTROL_HOVER_CLASS } from "@src/components/CompoundPill/config";
 import { INPUT_AREA_BUTTONS } from "@src/config/inputAreaTokens";
 import ContextInfoButton from "@src/engines/ChatPanel/InputArea/components/ContextInfoButton";
 import AddActionsDropdown from "@src/features/SessionCreator/components/AddActionsDropdown";
@@ -83,7 +83,7 @@ const ComposerBar: React.FC<ComposerBarProps> = memo(
           onClick={onOpenSkillsTools}
           onMouseDown={(e) => e.preventDefault()}
           className={[
-            `flex items-center justify-center rounded-full text-text-1 transition-colors duration-200 focus:outline-none ${PILL_CONTROL_IDLE_SURFACE_CLASS}`,
+            `flex items-center justify-center rounded-full text-text-1 transition-colors duration-200 focus:outline-none ${PILL_CONTROL_HOVER_CLASS}`,
             INPUT_AREA_BUTTONS.iconButtonSizeClass,
           ].join(" ")}
           aria-label="Skills & Tools"

--- a/src/components/PillGroup/index.test.ts
+++ b/src/components/PillGroup/index.test.ts
@@ -21,7 +21,10 @@ function renderStrongSegment(active = false): string {
 
 describe("PillGroup", () => {
   it("gives strong segments a hover surface", () => {
-    expect(renderStrongSegment()).toContain("enabled:hover:!bg-fill-3");
+    const markup = renderStrongSegment();
+
+    expect(markup).toContain("enabled:hover:!bg-fill-3");
+    expect(markup).not.toContain("enabled:hover:!bg-surface-hover");
   });
 
   it("keeps the surface while a strong segment is active", () => {

--- a/src/components/PillGroup/index.tsx
+++ b/src/components/PillGroup/index.tsx
@@ -201,6 +201,7 @@ const PillGroupSegmentRow: React.FC<PillGroupSegmentRowProps> = ({
       tooltipMouseEnterDelay={segment.tooltipMouseEnterDelay}
       ariaLabel={segment.ariaLabel}
       dataTestId={segment.dataTestId}
+      appearance={usesFill3Surface ? "bare" : "default"}
       className={resolvedSegmentClassName}
       labelStyle={
         segment.maxLabelWidth ? { maxWidth: segment.maxLabelWidth } : undefined

--- a/src/components/Voice/VoiceInputButton.tsx
+++ b/src/components/Voice/VoiceInputButton.tsx
@@ -10,7 +10,7 @@
 import React, { memo, useCallback, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
-import { PILL_CONTROL_IDLE_SURFACE_CLASS } from "@src/components/CompoundPill/config";
+import { PILL_CONTROL_HOVER_CLASS } from "@src/components/CompoundPill/config";
 import { KeyboardShortcutTooltipContent } from "@src/components/KeyboardShortcut";
 import Tooltip from "@src/components/Tooltip";
 import { INPUT_AREA_BUTTONS } from "@src/config/inputAreaTokens";
@@ -107,7 +107,7 @@ const VoiceInputButton: React.FC<VoiceInputButtonProps> = memo(
               ? // Disabled buttons must not paint the interactive idle/hover
                 // surface — restore the plain transparent treatment.
                 "text-text-1"
-              : `text-text-1 ${PILL_CONTROL_IDLE_SURFACE_CLASS}`,
+              : `text-text-1 ${PILL_CONTROL_HOVER_CLASS}`,
           disabled ? "cursor-not-allowed opacity-50" : "cursor-pointer",
           "leading-none",
         ].join(" ")}

--- a/src/engines/ChatPanel/InputArea/components/ContextInfoButton.tsx
+++ b/src/engines/ChatPanel/InputArea/components/ContextInfoButton.tsx
@@ -15,7 +15,10 @@ import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
 import Button from "@src/components/Button";
-import { pillControlStateClass } from "@src/components/CompoundPill/config";
+import {
+  PILL_CONTROL_ACTIVE_SURFACE_CLASS,
+  PILL_CONTROL_HOVER_CLASS,
+} from "@src/components/CompoundPill/config";
 import Textarea from "@src/components/Textarea";
 import {
   manualCompactInFlightSessionAtom,
@@ -303,6 +306,10 @@ const ContextInfoButton: React.FC<ContextInfoButtonProps> = memo(
     );
 
     const compactDisabled = manualCompacting;
+    const triggerSurfaceClass =
+      panelPos !== null
+        ? PILL_CONTROL_ACTIVE_SURFACE_CLASS
+        : PILL_CONTROL_HOVER_CLASS;
 
     return (
       <>
@@ -310,7 +317,7 @@ const ContextInfoButton: React.FC<ContextInfoButtonProps> = memo(
           <button
             ref={triggerRef}
             data-testid="context-info-button"
-            className={`flex h-[28px] shrink-0 items-center gap-1.5 rounded-full text-text-3 transition-colors duration-200 ${pillControlStateClass(panelPos !== null)} ${compact ? "w-[28px] justify-center px-0" : "px-2"}`}
+            className={`flex h-[28px] shrink-0 items-center gap-1.5 rounded-full text-text-3 transition-colors duration-200 ${triggerSurfaceClass} ${compact ? "w-[28px] justify-center px-0" : "px-2"}`}
             onClick={toggle}
             aria-label={t("contextInfo.ariaLabel")}
             aria-expanded={panelPos !== null}
@@ -328,7 +335,7 @@ const ContextInfoButton: React.FC<ContextInfoButtonProps> = memo(
           <button
             ref={triggerRef}
             data-testid="context-info-button"
-            className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-text-3 transition-colors duration-150 hover:text-text-2 ${pillControlStateClass(panelPos !== null)}`}
+            className={`flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-text-3 transition-colors duration-150 hover:text-text-2 ${triggerSurfaceClass}`}
             onClick={toggle}
             aria-label={t("contextInfo.ariaLabel")}
             aria-expanded={panelPos !== null}

--- a/src/engines/ChatPanel/InputArea/components/ProgressRing.tsx
+++ b/src/engines/ChatPanel/InputArea/components/ProgressRing.tsx
@@ -39,7 +39,7 @@ const ProgressRing = memo(
           cy={RING_SIZE / 2}
           r={RING_RADIUS}
           fill="none"
-          className="stroke-fill-3"
+          className="stroke-text-4"
           strokeWidth={RING_STROKE}
         />
         {filled > 0 && (

--- a/src/features/SessionCreator/components/AddActionsDropdown/index.tsx
+++ b/src/features/SessionCreator/components/AddActionsDropdown/index.tsx
@@ -11,7 +11,10 @@ import React, { useCallback } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
-import { pillControlStateClass } from "@src/components/CompoundPill/config";
+import {
+  PILL_CONTROL_ACTIVE_SURFACE_CLASS,
+  PILL_CONTROL_HOVER_CLASS,
+} from "@src/components/CompoundPill/config";
 import {
   DROPDOWN_CLASSES,
   DROPDOWN_ITEM,
@@ -78,7 +81,9 @@ const AddActionsDropdown: React.FC<AddActionsDropdownProps> = ({
     [onAddContent, onUpload, close]
   );
 
-  const triggerStateClass = pillControlStateClass(isOpen);
+  const triggerStateClass = isOpen
+    ? PILL_CONTROL_ACTIVE_SURFACE_CLASS
+    : PILL_CONTROL_HOVER_CLASS;
 
   const triggerButton = (
     <button


### PR DESCRIPTION
## Problem

Composer controls had inconsistent surface states: session-info segments could be masked by the generic hover rule, while the add, microphone, and context controls retained a filled idle surface in dark theme. The context ring track also did not use the requested neutral token.

## Solution

Apply the approved light fill-3 value and make strong session-info segments render without the competing generic surface. Keep add, microphone, and context controls transparent at rest, while preserving their hover/open feedback. Use text-4 for the unfilled context-ring track.

## Potential risks

The light fill-3 token is shared by the application, so its small tone adjustment affects every consumer. Transparent idle controls may be less visually prominent in unverified layouts or themes. No separate screenshot or recording was captured; the visual target was refined through the current desktop session, and computer-controlled UI validation is not enabled for this repository.

## Verification

- `pnpm exec eslint src/components/ComposerBar/index.tsx src/components/ComposerBar/index.test.ts src/components/PillGroup/index.tsx src/components/PillGroup/index.test.ts src/components/Voice/VoiceInputButton.tsx src/engines/ChatPanel/InputArea/components/ContextInfoButton.tsx src/engines/ChatPanel/InputArea/components/ProgressRing.tsx src/features/SessionCreator/components/AddActionsDropdown/index.tsx` — passed
- `pnpm exec vitest run src/components/PillGroup/index.test.ts src/components/ComposerBar/index.test.ts` — passed: 2 files, 6 tests
- Pre-commit hook — passed lint-staged, staged TypeScript check, and circular-dependency check
- `git diff --check origin/develop...HEAD` — passed
- Full test suite and recorded UI coverage across all themes were not run; see Potential risks.