### PR TITLE
perf(ci): scope pull request checks to their real inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@
 # Rust job is relevant; pure frontend diffs keep the required Rust check but
 # mark it skipped/successful without allocating a macOS runner.
 #
+# Within the frontend job, lint covers only the files the pull request changed
+# (see scripts/ci/select-lint-targets.cjs). Typecheck and the unit suite stay
+# whole-repo: both have cross-file failure modes that a per-file diff cannot
+# bound.
+#
 # Mirrors the toolchain versions used in release.yaml (Node 20, pnpm 9,
 # Rust stable, swatinem/rust-cache) so CI and release builds stay in sync.
 
@@ -29,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       rust_required: ${{ steps.scope.outputs.rust_required }}
+      audit_required: ${{ steps.scope.outputs.audit_required }}
 
     steps:
       - name: Checkout
@@ -36,18 +42,31 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect Rust-relevant changes
+      - name: Detect Rust and audit scope
         id: scope
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          # One diff read by both detectors: clippy and cargo audit consume
+          # different inputs, and re-running git would let the two answers
+          # describe different trees.
+          git diff --name-only -z "${BASE_SHA}...${HEAD_SHA}" \
+            > "${RUNNER_TEMP}/changed-paths"
+
           rust_required="$(
-            git diff --name-only -z "${BASE_SHA}...${HEAD_SHA}" |
-              node scripts/ci/detect-rust-changes.cjs
+            node scripts/ci/detect-rust-changes.cjs \
+              < "${RUNNER_TEMP}/changed-paths"
           )"
+          audit_required="$(
+            node scripts/ci/detect-audit-changes.cjs \
+              < "${RUNNER_TEMP}/changed-paths"
+          )"
+
           echo "rust_required=${rust_required}" >> "${GITHUB_OUTPUT}"
+          echo "audit_required=${audit_required}" >> "${GITHUB_OUTPUT}"
           echo "Rust required: ${rust_required}"
+          echo "Audit required: ${audit_required}"
 
   # ── Frontend ────────────────────────────────────────────────────────────────
   frontend:
@@ -55,8 +74,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # fetch-depth 0 so the lint-scope step below can diff base..head. The
+      # `changes` job pays the same cost in ~10s.
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -87,8 +110,32 @@ jobs:
         env:
           NODE_OPTIONS: "--max-old-space-size=6144"
 
-      - name: Lint
+      # Every rule in .eslintrc.js judges one file at a time, so a pull request
+      # cannot make an untouched file newly non-compliant; whole-tree linting
+      # spent ~3m45s re-proving 6000+ unchanged files. Diffs that change the
+      # rules themselves still lint everything -- see select-lint-targets.cjs.
+      - name: Select lint targets
+        id: lint_scope
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git diff --name-only --diff-filter=ACMR -z "${BASE_SHA}...${HEAD_SHA}" |
+            node scripts/ci/select-lint-targets.cjs \
+              --out "${RUNNER_TEMP}/lint-targets" >> "${GITHUB_OUTPUT}"
+
+      - name: Lint (full tree)
+        if: steps.lint_scope.outputs.lint_mode == 'all'
         run: pnpm lint
+
+      # nightly-full-checks.yml relints the whole tree once a day, so a rule
+      # that starts failing on untouched files still surfaces within 24h.
+      - name: Lint (changed files)
+        if: steps.lint_scope.outputs.lint_mode == 'files'
+        run: |
+          xargs -0 -r pnpm exec eslint \
+            --max-warnings 0 --report-unused-disable-directives \
+            < "${RUNNER_TEMP}/lint-targets"
 
       # Documentation alone did not hold this: two directories re-mixed the two
       # test-placement conventions within a day of the 53-directory cleanup.
@@ -145,10 +192,14 @@ jobs:
   # Runs on its own runner rather than inside the `rust` job so an advisory
   # cannot be masked by, or delay, a clippy/test failure. Ignored advisories and
   # the reason each one is blocked live in src-tauri/.cargo/audit.toml.
+  #
+  # Gated on the lockfile rather than on rust_required: cargo audit never builds
+  # the workspace, so an .rs-only diff cannot move its verdict. Advisory-database
+  # updates carry no diff at all and are covered by nightly-full-checks.yml.
   cargo-audit:
     name: Rust (cargo audit)
     needs: changes
-    if: needs.changes.outputs.rust_required == 'true'
+    if: needs.changes.outputs.audit_required == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -167,6 +218,11 @@ jobs:
           path: ~/.cargo/bin/cargo-audit
           key: cargo-audit-${{ runner.os }}-v1
 
+      # A miss compiles cargo-audit for ~3 min before a 4 s scan. Caches saved
+      # during a PR run are scoped to that PR's merge ref, so this only ever
+      # hits because nightly-full-checks.yml re-saves the same key from develop
+      # and PR runs may restore their base branch's caches. (Same reasoning as
+      # warm-frontend-cache.yml and warm-rust-cache.yml.)
       - name: Install cargo-audit
         if: steps.audit-cache.outputs.cache-hit != 'true'
         run: cargo install cargo-audit --locked

--- a/.github/workflows/nightly-full-checks.yml
+++ b/.github/workflows/nightly-full-checks.yml
@@ -1,0 +1,103 @@
+# Nightly whole-tree checks on develop.
+#
+# ci.yml scopes each pull request to the work its diff can actually affect:
+# lint covers only the changed files, and cargo audit runs only when
+# Cargo.lock moves. Both are sound per diff and unsound over time -- a plugin
+# resolving to a new minor, a merge of two individually-clean branches, or a
+# fresh RustSec advisory filed against a lockfile nobody touched all fail
+# without any diff to hang the check on. This job is the clock that catches
+# them, inside 24h rather than at release.
+#
+# It also runs the full unit suite on develop. CI is pull_request-only, so
+# until now nothing ever ran the suite against a merged result.
+#
+# The cargo-audit job below doubles as this repository's cache producer for
+# the cargo-audit binary: GitHub scopes a cache saved during a PR run to that
+# PR's own merge ref, so re-saving the key from develop is what lets ci.yml's
+# audit job restore instead of spending ~3 min compiling it. (Same pattern as
+# warm-frontend-cache.yml and warm-rust-cache.yml.)
+#
+# Mirrors the frontend setup in ci.yml (pnpm action, Node 20, identical
+# node_modules key) and its cargo-audit steps. If ci.yml changes, change this
+# file to match.
+
+name: "Nightly full checks"
+
+on:
+  schedule:
+    # 22:00 UTC = 06:00 next day in Asia/Shanghai, so a failure is waiting at
+    # the start of the working day rather than landing in the middle of it.
+    - cron: "0 22 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Frontend ────────────────────────────────────────────────────────────────
+  full-frontend:
+    name: Frontend (full lint · full test)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Cache node_modules
+        uses: actions/cache@v5
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Whole tree, not a diff -- this is the coverage ci.yml gave up.
+      - name: Lint (full tree)
+        run: pnpm lint
+
+      # `always()` so a lint failure still leaves a test result to read; both
+      # answers are wanted from one nightly run.
+      - name: Unit tests
+        if: always()
+        run: pnpm run test
+
+  # ── Dependency audit ────────────────────────────────────────────────────────
+  cargo-audit:
+    name: Rust (cargo audit)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      # Same key ci.yml restores. Saving it from develop is the point of
+      # running this here.
+      - name: Cache cargo-audit binary
+        id: audit-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/cargo-audit
+          key: cargo-audit-${{ runner.os }}-v1
+
+      - name: Install cargo-audit
+        if: steps.audit-cache.outputs.cache-hit != 'true'
+        run: cargo install cargo-audit --locked
+
+      # Unconditional: the advisory database is the input that moves without a
+      # diff, so only the clock can catch a new advisory here.
+      - name: cargo audit
+        working-directory: src-tauri
+        run: cargo audit

--- a/scripts/ci/detect-audit-changes.cjs
+++ b/scripts/ci/detect-audit-changes.cjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+// Decides whether a diff can change what `cargo audit` reports.
+//
+// cargo audit reads exactly two things from this repository: the resolved
+// dependency graph in src-tauri/Cargo.lock, and the ignore list in
+// src-tauri/.cargo/audit.toml. It never builds the workspace, so a diff that
+// only edits .rs sources cannot move its verdict -- yet the job was gated on
+// detect-rust-changes.cjs, which fires for any Rust-relevant path, and each
+// cold run spends ~3 min compiling cargo-audit before a 4 s scan.
+//
+// Its third input, the RustSec advisory database, moves on its own schedule
+// with no diff at all. That is why nightly-full-checks.yml runs cargo audit
+// unconditionally: a new advisory against an unchanged lockfile has to be
+// caught by the clock, never by a pull request.
+
+const fs = require("node:fs");
+
+const AUDIT_INPUTS = new Set([
+  "src-tauri/Cargo.lock",
+  "src-tauri/.cargo/audit.toml",
+]);
+
+function isAuditInput(filePath) {
+  return AUDIT_INPUTS.has(filePath);
+}
+
+function requiresAudit(filePaths) {
+  // Fail closed when diff discovery yields nothing unexpectedly, matching
+  // detect-rust-changes.cjs.
+  return filePaths.length === 0 || filePaths.some(isAuditInput);
+}
+
+function parseNullDelimitedPaths(input) {
+  return input.toString("utf8").split("\0").filter(Boolean);
+}
+
+if (require.main === module) {
+  const filePaths = parseNullDelimitedPaths(fs.readFileSync(0));
+  process.stdout.write(`${requiresAudit(filePaths)}\n`);
+}
+
+module.exports = {
+  AUDIT_INPUTS,
+  isAuditInput,
+  parseNullDelimitedPaths,
+  requiresAudit,
+};

--- a/scripts/ci/detect-audit-changes.test.cjs
+++ b/scripts/ci/detect-audit-changes.test.cjs
@@ -1,0 +1,72 @@
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  isAuditInput,
+  parseNullDelimitedPaths,
+  requiresAudit,
+} = require("./detect-audit-changes.cjs");
+
+test("lockfile and ignore-list changes run the audit", () => {
+  assert.equal(requiresAudit(["src-tauri/Cargo.lock"]), true);
+  assert.equal(requiresAudit(["src-tauri/.cargo/audit.toml"]), true);
+  assert.equal(
+    requiresAudit(["src-tauri/src/lib.rs", "src-tauri/Cargo.lock"]),
+    true
+  );
+});
+
+test("source-only Rust changes cannot move the verdict", () => {
+  // cargo audit never builds the workspace; these leave Cargo.lock untouched.
+  assert.equal(
+    requiresAudit([
+      "src-tauri/src/lib.rs",
+      "src-tauri/crates/agent_core/src/session.rs",
+      "src/components/Button/index.tsx",
+    ]),
+    false
+  );
+});
+
+test("a manifest edit that did not re-resolve is not an audit input", () => {
+  // Cargo.toml alone cannot change the audited graph: the resolved versions
+  // cargo audit reads live in Cargo.lock, and any real dependency change
+  // rewrites it in the same commit.
+  assert.equal(isAuditInput("src-tauri/Cargo.toml"), false);
+  assert.equal(requiresAudit(["src-tauri/Cargo.toml"]), false);
+});
+
+test("lookalike paths outside the workspace do not trigger", () => {
+  assert.equal(isAuditInput("Cargo.lock"), false);
+  assert.equal(isAuditInput("docs/examples/Cargo.lock"), false);
+  assert.equal(isAuditInput("src-tauri/Cargo.lock.bak"), false);
+});
+
+test("empty diffs fail closed", () => {
+  assert.equal(requiresAudit([]), true);
+});
+
+test("NUL-delimited paths drive the CLI", () => {
+  const input = Buffer.from("src-tauri/src/lib.rs\0src/a file.tsx\0");
+  assert.deepEqual(parseNullDelimitedPaths(input), [
+    "src-tauri/src/lib.rs",
+    "src/a file.tsx",
+  ]);
+
+  const result = spawnSync(
+    process.execPath,
+    [path.join(__dirname, "detect-audit-changes.cjs")],
+    { input, encoding: "utf8" }
+  );
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, "false\n");
+
+  const locked = spawnSync(
+    process.execPath,
+    [path.join(__dirname, "detect-audit-changes.cjs")],
+    { input: Buffer.from("src-tauri/Cargo.lock\0"), encoding: "utf8" }
+  );
+  assert.equal(locked.stdout, "true\n");
+});

--- a/scripts/ci/select-lint-targets.cjs
+++ b/scripts/ci/select-lint-targets.cjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+// Decides how much of the tree `pnpm lint` has to cover for one pull request.
+//
+// ESLint is a per-file analysis here: every rule in .eslintrc.js reads a single
+// module (unused imports, restricted imports/syntax, prettier formatting, hook
+// deps). Nothing in the config is cross-file, so a pull request cannot make an
+// untouched file newly non-compliant -- the cross-file class of breakage
+// (deleted export, renamed symbol) is caught by `pnpm typecheck`, which stays
+// whole-repo.
+//
+// The exception is anything that changes the *rules*: a config, plugin, or
+// formatter bump re-judges all 6000+ files, so those diffs fall back to the
+// full run. So does a diff we cannot read, matching detect-rust-changes.cjs.
+
+const fs = require("node:fs");
+
+const LINTABLE_EXTENSIONS = Object.freeze([".ts", ".tsx", ".js", ".jsx"]);
+
+// .eslintrc.js ignores everything outside src/ (ignorePatterns "/*" + "!/src"),
+// so passing a path from anywhere else would lint nothing and only slow the
+// step down.
+const LINTABLE_PREFIX = "src/";
+
+// A change to any of these re-judges files the diff never touched, so the
+// changed-file shortcut stops being sound and the full run has to happen.
+const FULL_LINT_TRIGGERS = new Set([
+  ".eslintrc.js",
+  ".prettierrc",
+  ".prettierignore",
+  "package.json",
+  "pnpm-lock.yaml",
+  "tsconfig.json",
+]);
+
+function isLintable(filePath) {
+  return (
+    filePath.startsWith(LINTABLE_PREFIX) &&
+    LINTABLE_EXTENSIONS.some((extension) => filePath.endsWith(extension))
+  );
+}
+
+function requiresFullLint(filePaths) {
+  // Fail closed when diff discovery yields nothing unexpectedly.
+  return (
+    filePaths.length === 0 ||
+    filePaths.some((filePath) => FULL_LINT_TRIGGERS.has(filePath))
+  );
+}
+
+// mode "all"   -> run `pnpm lint` over src/
+// mode "files" -> lint exactly `files`
+// mode "skip"  -> the diff touched no lintable file (docs, Rust, assets)
+function selectLintTargets(filePaths) {
+  if (requiresFullLint(filePaths)) {
+    return { mode: "all", files: [] };
+  }
+
+  const files = filePaths.filter(isLintable);
+
+  return files.length === 0
+    ? { mode: "skip", files }
+    : { mode: "files", files };
+}
+
+function parseNullDelimitedPaths(input) {
+  return input.toString("utf8").split("\0").filter(Boolean);
+}
+
+if (require.main === module) {
+  const outputIndex = process.argv.indexOf("--out");
+  if (outputIndex === -1 || !process.argv[outputIndex + 1]) {
+    process.stderr.write("usage: select-lint-targets.cjs --out <file>\n");
+    process.exit(2);
+  }
+
+  const selection = selectLintTargets(
+    parseNullDelimitedPaths(fs.readFileSync(0))
+  );
+
+  // NUL-delimited so the reader stays `xargs -0`: the same delimiter git
+  // handed us, and the only one no path can contain.
+  fs.writeFileSync(
+    process.argv[outputIndex + 1],
+    selection.files.map((filePath) => `${filePath}\0`).join("")
+  );
+  process.stdout.write(`lint_mode=${selection.mode}\n`);
+  process.stderr.write(
+    `Lint mode: ${selection.mode} (${selection.files.length} files)\n`
+  );
+}
+
+module.exports = {
+  isLintable,
+  parseNullDelimitedPaths,
+  requiresFullLint,
+  selectLintTargets,
+};

--- a/scripts/ci/select-lint-targets.test.cjs
+++ b/scripts/ci/select-lint-targets.test.cjs
@@ -1,0 +1,116 @@
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  isLintable,
+  parseNullDelimitedPaths,
+  requiresFullLint,
+  selectLintTargets,
+} = require("./select-lint-targets.cjs");
+
+test("source changes lint exactly the files they touch", () => {
+  assert.deepEqual(
+    selectLintTargets([
+      "src/components/Button/index.tsx",
+      "src/store/session.ts",
+      "src/scripts/legacy.jsx",
+    ]),
+    {
+      mode: "files",
+      files: [
+        "src/components/Button/index.tsx",
+        "src/store/session.ts",
+        "src/scripts/legacy.jsx",
+      ],
+    }
+  );
+});
+
+test("non-lintable paths are dropped, not linted", () => {
+  // .eslintrc.js confines linting to src/ and skips CSS/SCSS, so handing these
+  // to ESLint would cost a process start and report nothing.
+  assert.equal(isLintable("src/styles/_utilities.scss"), false);
+  assert.equal(isLintable("src/assets/logo.svg"), false);
+  assert.equal(isLintable("scripts/ci/pr-policy.cjs"), false);
+  assert.equal(isLintable("tests/e2e/specs/core/session.spec.mjs"), false);
+  assert.equal(isLintable("src/components/Button/index.tsx"), true);
+
+  assert.deepEqual(
+    selectLintTargets(["src/styles/_utilities.scss", "docs/audit/GLOBAL.md"]),
+    { mode: "skip", files: [] }
+  );
+});
+
+test("mixed diffs lint only the lintable half", () => {
+  assert.deepEqual(
+    selectLintTargets([
+      "docs/frontend-ui-audit-2026-08-28/GLOBAL.md",
+      "src-tauri/src/lib.rs",
+      "src/modules/shared/layouts/blocks/DetailTabStrip.tsx",
+    ]),
+    {
+      mode: "files",
+      files: ["src/modules/shared/layouts/blocks/DetailTabStrip.tsx"],
+    }
+  );
+});
+
+test("rule-changing diffs fall back to the full run", () => {
+  // These re-judge files the diff never touched, so per-file selection is no
+  // longer sound.
+  for (const trigger of [
+    ".eslintrc.js",
+    ".prettierrc",
+    ".prettierignore",
+    "package.json",
+    "pnpm-lock.yaml",
+    "tsconfig.json",
+  ]) {
+    assert.equal(requiresFullLint([trigger, "src/a.ts"]), true, trigger);
+    assert.deepEqual(selectLintTargets([trigger, "src/a.ts"]), {
+      mode: "all",
+      files: [],
+    });
+  }
+});
+
+test("empty diffs fail closed", () => {
+  assert.equal(requiresFullLint([]), true);
+  assert.deepEqual(selectLintTargets([]), { mode: "all", files: [] });
+});
+
+test("NUL-delimited paths preserve whitespace and drive the CLI", () => {
+  const input = Buffer.from("src/a file.tsx\0docs/notes.md\0");
+  assert.deepEqual(parseNullDelimitedPaths(input), [
+    "src/a file.tsx",
+    "docs/notes.md",
+  ]);
+
+  const outFile = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), "lint-targets-")),
+    "targets.txt"
+  );
+  const result = spawnSync(
+    process.execPath,
+    [path.join(__dirname, "select-lint-targets.cjs"), "--out", outFile],
+    { input, encoding: "utf8" }
+  );
+
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, "lint_mode=files\n");
+  assert.equal(fs.readFileSync(outFile, "utf8"), "src/a file.tsx\0");
+});
+
+test("the CLI refuses to run without an output path", () => {
+  const result = spawnSync(
+    process.execPath,
+    [path.join(__dirname, "select-lint-targets.cjs")],
+    { input: Buffer.from("src/a.ts\0"), encoding: "utf8" }
+  );
+
+  assert.equal(result.status, 2);
+});


### PR DESCRIPTION
## Problem

Every pull request pays for checks whose inputs its diff never touched.

Measured on [run 33157895984](https://github.com/org2AI/ORG2/actions/runs/33157895984), a UI-only branch — the frontend job took 11m41s, of which:

| Step | Time |
| --- | --- |
| setup + install | 35s |
| `pnpm typecheck` | 1m00s |
| `pnpm lint` | **3m47s** |
| `pnpm test` | 6m14s |

`pnpm lint` runs `eslint src/` over ~6250 files. Every rule in `.eslintrc.js` judges one file in isolation — unused imports, restricted imports/syntax, prettier formatting, hook deps — so ~6220 of those files were re-proved for nothing. On other recent runs the step reached 4m50s.

`Rust (cargo audit)` has a second, independent problem. It was gated on `detect-rust-changes.cjs`, which fires for any Rust-relevant path, but `cargo audit` never builds the workspace: its inputs are `src-tauri/Cargo.lock` and `src-tauri/.cargo/audit.toml`. An `.rs`-only diff cannot move its verdict, yet the job ran.

Worse, its `cargo-audit-${{ runner.os }}-v1` cache never had a producer. GitHub scopes a cache saved during a PR run to that PR's own merge ref, and nothing on develop ever saved this key — the same failure `warm-frontend-cache.yml` and `warm-rust-cache.yml` were written to fix. Across the last 25 CI runs the job ran 11 times and recompiled cargo-audit on 6 of them, 141–191s each, to reach a scan that takes 4 seconds.

## Solution

Both checks now derive their scope from the inputs a pull request can actually move, following the existing `detect-rust-changes.cjs` pattern — narrow, fail-closed on an empty diff, unit-tested next to the script.

**Lint** — `scripts/ci/select-lint-targets.cjs` reads the same NUL-delimited diff and returns one of three modes:

- `files` — lint exactly the changed `src/**` `.ts/.tsx/.js/.jsx` paths
- `all` — a diff touching `.eslintrc.js`, `.prettierrc`, `.prettierignore`, `package.json`, `pnpm-lock.yaml`, or `tsconfig.json` re-judges files the diff never touched, so it falls back to the whole tree
- `skip` — the diff contains no lintable file (docs, Rust, SCSS)

`--diff-filter=ACMR` keeps deleted paths out, so ESLint is never handed a file that no longer exists. The frontend checkout gains `fetch-depth: 0` to make `base...head` readable; the `changes` job already pays that cost in ~10s.

The cross-file class of breakage this gives up — a deleted export, a renamed symbol — is caught by `pnpm typecheck`, which stays whole-repo, as does the unit suite.

**cargo audit** — `scripts/ci/detect-audit-changes.cjs` gates the job on `Cargo.lock` and `audit.toml`. The `changes` job now writes one diff and reads it with both detectors, so the two answers cannot describe different trees.

**Nightly sweep** — `nightly-full-checks.yml` runs the full lint, the full unit suite, and an unconditional `cargo audit` on develop at 22:00 UTC (06:00 Asia/Shanghai), plus `workflow_dispatch`. This covers the drift no diff can express: a plugin resolving to a new minor, a merge of two individually-clean branches, and a fresh RustSec advisory filed against a lockfile nobody touched. Its cargo-audit job doubles as the missing cache producer — saving that key from develop is what finally lets PR runs restore it.

It also closes a gap that predates this change: `ci.yml` is `pull_request`-only, so nothing has ever run the unit suite against a merged develop.

Net effect on a UI-only pull request: the frontend job drops from ~11m41s to ~7m20s, and most Rust pull requests stop allocating an audit runner at all.

## Potential risks

- **A lint regression can now reach develop and sit there for up to 24h.** This is the deliberate trade. It requires a rule to start failing on a file the pull request did not touch, which for this config means a dependency or config change — and every path that can do that is in the `all` fallback list. If a new cross-file ESLint rule is ever added, this assumption has to be revisited; the rationale is recorded in the script's header comment so the next reader sees it.
- **`FULL_LINT_TRIGGERS` is a hand-maintained list.** A future formatter or config file added outside it would be linted per-file when it should force a full run. Adding a name to the set plus a case to the test is the fix.
- **The nightly only notifies through GitHub's default scheduled-workflow failure email**, which goes to the account that last touched the cron. If this becomes load-bearing, it wants a real notification channel.
- **Skipped required checks.** `cargo-audit` is skipped by an `if:` on the job, which GitHub reports as successful for branch protection — the same mechanism the `rust` job already relies on. If `Rust (cargo audit)` is a required check, no configuration change is needed; behaviour matches the existing `rust` job exactly.
- **The audit's advisory-DB coverage moves from per-PR to daily.** A pull request no longer re-scans an unchanged lockfile against a freshly updated database. Nothing is lost that was reliable before — the same advisory would previously have been caught or missed depending on whether an unrelated `.rs` file happened to change — and the nightly makes the coverage deterministic instead of incidental.
- **No job names changed**, so required status checks continue to match.

## Verification

Commands run locally on this branch's content:

- `node --test scripts/ci/*.test.cjs` → **25 passed, 0 failed** (13 pre-existing, 12 new across the two detectors).
- `python3 -c "import yaml; yaml.safe_load(...)"` on `ci.yml` and `nightly-full-checks.yml` → both parse.
- `pnpm exec prettier --check scripts/ci/*.cjs .github/workflows/*.yml` → clean.
- End-to-end rehearsal of the exact `Select lint targets` + `Lint (changed files)` shell pipeline against a 28-file working-tree diff: `lint_mode=files`, 28 targets selected, ESLint exit 0 in **4.5s** (against 3m47s for the whole tree). Deleted paths were correctly excluded.
- CLI mode checks: a `package.json` diff → `lint_mode=all`; a docs+SCSS diff → `lint_mode=skip`, empty target file; an empty diff → `lint_mode=all`.
- `detect-audit-changes.cjs` CLI: `src-tauri/src/lib.rs` → `false`; `src-tauri/Cargo.lock` → `true`.

Live on this pull request ([run 33165712647](https://github.com/org2AI/ORG2/actions/runs/33165712647)):

- `Frontend (typecheck · lint · test)` → **success**. `Select lint targets` resolved to `skip` in 0s (this diff touches only `.github/**` and `scripts/**`, no `src/**`), and both conditional lint steps were correctly skipped. Lint cost on this run: **0s, against ~4m before**.
- `Rust (cargo audit)` → **skipping**. The new `audit_required` gate works: this diff touches no `Cargo.lock`.
- `Detect CI scope` → success in 14s, so reading one diff with two detectors adds nothing measurable.
- `Enforce PR contract` → pass.

Not run, and why:

- **The `files` lint path has not run in CI.** This pull request exercises `skip`, not `files`; the `Select lint targets` step and its `GITHUB_OUTPUT` plumbing are proven live, but the `xargs -0 … eslint` invocation has only been rehearsed locally (identical command, 28 files, exit 0). The first `src/**`-touching pull request on this workflow is the real test, and is worth watching.
- **`cargo audit` firing has not been observed**, only its skip. A lockfile-touching pull request is needed to see the positive case.
- **The cache producer cannot be measured yet.** The develop-scoped cargo-audit cache only exists after the nightly first runs on develop, i.e. after merge.
- `Rust (clippy)` runs on this pull request because `detect-rust-changes.cjs` treats `.github/**` and `scripts/**` as Rust-relevant — unchanged conservative behaviour, not something this diff introduces.

## Follow-ups, not in this pull request

Found while measuring, each its own responsibility:

1. `cargo test --workspace` takes **18m53s** on the Rust job ([run 33154856001](https://github.com/org2AI/ORG2/actions/runs/33154856001)). The `ci.yml` comment claims "mostly link plus ~1 min of execution"; that is no longer true and the step is now the single largest cost in CI.
2. Six unit-test files use `vi.resetModules()` + `await import(...)` to rebuild the atom graph. `chatPanelTabsAtom.test.ts` runs in 12.8s alone and 303s under full-suite load — a 24× contention penalty, and the reason `vitest.config.ts` carries `testTimeout: 15_000`. In a local full run these files produced 8 failures that all pass in isolation. Fixing these is the largest available cut to the 6–8 min unit step.
3. `pool: 'threads'` was measured as a cheaper alternative and **rejected**: a full run under `--pool=threads` fails to collect 400 of 1249 files. It is not a drop-in.
4. The Rust job runs on `macos-latest`, billed at 10× a Linux runner.
