### PR TITLE
perf(test): reset the jotai store instead of the module registry

### DIFF
--- a/src/store/chatPanel/__tests__/chatPanelChannelTabs.test.ts
+++ b/src/store/chatPanel/__tests__/chatPanelChannelTabs.test.ts
@@ -1,17 +1,20 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
-async function loadChannelTabAtoms() {
-  const { createInstrumentedStore } =
-    await import("@src/util/core/state/instrumentedStore");
-  const store = createInstrumentedStore();
-  const {
-    buildChannelTabKey,
-    chatPanelTabsAtom,
-    closeChatPanelTabAtom,
-    normalizePersistedChatPanelTabsState,
-    openChannelInChatPanelTabAtom,
-    reconcileDiscussionChannelTabsAtom,
-  } = await import("../chatPanelTabsAtom");
+import {
+  createInstrumentedStore,
+  resetInstrumentedStore,
+} from "@src/util/core/state/instrumentedStore";
+
+import {
+  buildChannelTabKey,
+  chatPanelTabsAtom,
+  closeChatPanelTabAtom,
+  normalizePersistedChatPanelTabsState,
+  openChannelInChatPanelTabAtom,
+  reconcileDiscussionChannelTabsAtom,
+} from "../chatPanelTabsAtom";
+
+function loadChannelTabAtoms() {
   return {
     buildChannelTabKey,
     chatPanelTabsAtom,
@@ -19,11 +22,11 @@ async function loadChannelTabAtoms() {
     normalizePersistedChatPanelTabsState,
     openChannelInChatPanelTabAtom,
     reconcileDiscussionChannelTabsAtom,
-    store,
+    store: createInstrumentedStore(),
   };
 }
 
-type ChannelTabAtoms = Awaited<ReturnType<typeof loadChannelTabAtoms>>;
+type ChannelTabAtoms = ReturnType<typeof loadChannelTabAtoms>;
 
 const LOCAL_CHANNEL = {
   scope: "local" as const,
@@ -42,12 +45,12 @@ const CLOUD_CHANNEL = {
 describe("openChannelInChatPanelTabAtom", () => {
   let atoms: ChannelTabAtoms;
 
-  beforeEach(async () => {
-    // Atom identities are module-level, so each case needs a fresh registry
-    // (and a clean persisted state) to start from an empty tab strip.
-    vi.resetModules();
+  beforeEach(() => {
+    // Atom values live in the store, so a fresh store (plus clean persisted
+    // state) is all an empty tab strip needs -- no module-registry teardown.
+    resetInstrumentedStore();
     localStorage.clear();
-    atoms = await loadChannelTabAtoms();
+    atoms = loadChannelTabAtoms();
   });
 
   function channelTabs() {

--- a/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
+++ b/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
@@ -1,7 +1,89 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { sessionsAtom } from "@src/store/session/sessionAtom";
 import type { Session } from "@src/store/session/sessionAtom/types";
+import {
+  activeSessionIdAtom,
+  sessionViewAtom,
+} from "@src/store/session/viewAtom";
+import {
+  CHAT_PANEL_COLLAB_ORG_MODE,
+  CHAT_PANEL_COLLAB_ORG_SOURCE,
+  CHAT_PANEL_CREATE_TARGET,
+  CHAT_PANEL_SURFACE_KIND,
+  activeChatPanelSurfaceAtom,
+  chatPanelCollabOrgCreateIntentAtom,
+  chatPanelCreateProjectContextAtom,
+  chatPanelCreateTargetAtom,
+  chatPanelMaximizedAtom,
+  chatPanelNavigateAtom,
+  chatPanelSelectedWorkItemAtom,
+  chatPanelStartPageOpenAtom,
+} from "@src/store/ui/chatPanelAtom";
+import {
+  kanbanReplayBoundsAtom,
+  kanbanReplayCursorAtom,
+  kanbanReplayEventsAtom,
+  kanbanReplayModeAtom,
+  kanbanReplayPlayingAtom,
+  kanbanReplaySpeedAtom,
+} from "@src/store/ui/kanbanReplayAtom";
 import type { KanbanReplayEvent } from "@src/store/ui/kanbanReplayAtom";
+import {
+  kanbanDetailPanelVisibleAtom,
+  kanbanSelectedTaskIdAtom,
+} from "@src/store/ui/kanbanViewStateAtom";
+import { workManagementCreatorVisibleAtom } from "@src/store/ui/workManagementCreatorAtom";
+import {
+  WORK_MANAGEMENT_PROJECTS_VIEW,
+  WORK_MANAGEMENT_SECTION,
+  workManagementProjectsViewAtom,
+  workstationTabHeaderAtomByHost,
+} from "@src/store/workstation/workstationTabBarAtoms";
+import {
+  createInstrumentedStore,
+  resetInstrumentedStore,
+} from "@src/util/core/state/instrumentedStore";
+
+import {
+  CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX,
+  activateChatPanelTabAtom,
+  activeChatPanelTabAtom,
+  activeWorkManagementSectionAtom,
+  addChatPanelLaunchpadTabAtom,
+  addChatPanelTerminalTabAtom,
+  chatPanelTabsAtom,
+  closeChatPanelTabAtom,
+  closeOtherChatPanelTabsAtom,
+  closeProjectOrgChatPanelTabsAtom,
+  closeWorkItemChatPanelTabAtom,
+  isChatPanelTabStationAvailable,
+  normalizePersistedChatPanelTabsState,
+  openCreateTargetInChatPanelStartPageAtom,
+  openGitHubIssueInChatPanelTabAtom,
+  openGitHubPrInChatPanelTabAtom,
+  openOrFocusChatPanelStartPageTabAtom,
+  openOrFocusSessionInChatPanelTabAtom,
+  openOrReplaceSessionInChatPanelTabAtom,
+  openOrganizationInChatPanelTabAtom,
+  openProjectInChatPanelTabAtom,
+  openRuntimeInChatPanelTabAtom,
+  openSessionInNewChatTabAtom,
+  openTeamInboxInChatPanelTabAtom,
+  openWorkItemInChatPanelTabAtom,
+  openWorkManagementChatPanelTabAtom,
+  prevChatPanelTabAtom,
+  resolveChatPanelMaximizedForLayout,
+  setActiveWorkManagementSectionAtom,
+  setChatPanelTabTitleAtom,
+  syncActiveChatPanelTabStateAtom,
+  toggleActiveChatPanelMaximizedAtom,
+} from "../chatPanelTabsAtom";
+import {
+  createChatPanelTerminalAtom,
+  terminalSessionsAtom,
+  updateTerminalSessionInfoAtom,
+} from "../chatPanelTerminalAtom";
 
 function makeSession(
   sessionId: string,
@@ -18,83 +100,7 @@ function makeSession(
 }
 
 async function loadChatPanelTabAtoms() {
-  const { createInstrumentedStore } =
-    await import("@src/util/core/state/instrumentedStore");
   const store = createInstrumentedStore();
-  const { activeSessionIdAtom, sessionViewAtom } =
-    await import("@src/store/session/viewAtom");
-  const { sessionsAtom } = await import("@src/store/session/sessionAtom");
-  const {
-    kanbanReplayBoundsAtom,
-    kanbanReplayCursorAtom,
-    kanbanReplayEventsAtom,
-    kanbanReplayModeAtom,
-    kanbanReplayPlayingAtom,
-    kanbanReplaySpeedAtom,
-  } = await import("@src/store/ui/kanbanReplayAtom");
-  const { kanbanDetailPanelVisibleAtom, kanbanSelectedTaskIdAtom } =
-    await import("@src/store/ui/kanbanViewStateAtom");
-  const { workManagementCreatorVisibleAtom } =
-    await import("@src/store/ui/workManagementCreatorAtom");
-  const {
-    activateChatPanelTabAtom,
-    activeChatPanelTabAtom,
-    activeWorkManagementSectionAtom,
-    addChatPanelTerminalTabAtom,
-    addChatPanelLaunchpadTabAtom,
-    CHAT_PANEL_STATION_WIDE_VIEWPORT_MIN_PX,
-    chatPanelTabsAtom,
-    isChatPanelTabStationAvailable,
-    closeChatPanelTabAtom,
-    closeOtherChatPanelTabsAtom,
-    closeProjectOrgChatPanelTabsAtom,
-    closeWorkItemChatPanelTabAtom,
-    normalizePersistedChatPanelTabsState,
-    openOrganizationInChatPanelTabAtom,
-    openCreateTargetInChatPanelStartPageAtom,
-    openGitHubIssueInChatPanelTabAtom,
-    openGitHubPrInChatPanelTabAtom,
-    openWorkManagementChatPanelTabAtom,
-    openOrFocusChatPanelStartPageTabAtom,
-    openRuntimeInChatPanelTabAtom,
-    openTeamInboxInChatPanelTabAtom,
-    openOrFocusSessionInChatPanelTabAtom,
-    openOrReplaceSessionInChatPanelTabAtom,
-    openProjectInChatPanelTabAtom,
-    openSessionInNewChatTabAtom,
-    openWorkItemInChatPanelTabAtom,
-    prevChatPanelTabAtom,
-    setActiveWorkManagementSectionAtom,
-    setChatPanelTabTitleAtom,
-    resolveChatPanelMaximizedForLayout,
-    syncActiveChatPanelTabStateAtom,
-    toggleActiveChatPanelMaximizedAtom,
-  } = await import("../chatPanelTabsAtom");
-  const {
-    createChatPanelTerminalAtom,
-    terminalSessionsAtom,
-    updateTerminalSessionInfoAtom,
-  } = await import("../chatPanelTerminalAtom");
-  const {
-    activeChatPanelSurfaceAtom,
-    CHAT_PANEL_COLLAB_ORG_MODE,
-    CHAT_PANEL_COLLAB_ORG_SOURCE,
-    chatPanelCreateProjectContextAtom,
-    chatPanelCollabOrgCreateIntentAtom,
-    chatPanelCreateTargetAtom,
-    chatPanelMaximizedAtom,
-    chatPanelNavigateAtom,
-    chatPanelStartPageOpenAtom,
-    chatPanelSelectedWorkItemAtom,
-    CHAT_PANEL_SURFACE_KIND,
-    CHAT_PANEL_CREATE_TARGET,
-  } = await import("@src/store/ui/chatPanelAtom");
-  const {
-    WORK_MANAGEMENT_SECTION,
-    WORK_MANAGEMENT_PROJECTS_VIEW,
-    workManagementProjectsViewAtom,
-    workstationTabHeaderAtomByHost,
-  } = await import("@src/store/workstation/workstationTabBarAtoms");
 
   return {
     activateChatPanelTabAtom,
@@ -167,7 +173,7 @@ async function loadChatPanelTabAtoms() {
 describe("closeChatPanelTabAtom", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.resetModules();
+    resetInstrumentedStore();
     localStorage.clear();
   });
 
@@ -353,7 +359,7 @@ describe("closeChatPanelTabAtom", () => {
 describe("closeOtherChatPanelTabsAtom", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.resetModules();
+    resetInstrumentedStore();
     localStorage.clear();
   });
 
@@ -394,7 +400,7 @@ describe("closeOtherChatPanelTabsAtom", () => {
 describe("closeWorkItemChatPanelTabAtom", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.resetModules();
+    resetInstrumentedStore();
     localStorage.clear();
   });
 
@@ -521,7 +527,7 @@ describe("closeWorkItemChatPanelTabAtom", () => {
 describe("closeProjectOrgChatPanelTabsAtom", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.resetModules();
+    resetInstrumentedStore();
     localStorage.clear();
   });
 
@@ -593,7 +599,7 @@ describe("closeProjectOrgChatPanelTabsAtom", () => {
 describe("openWorkManagementChatPanelTabAtom", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.resetModules();
+    resetInstrumentedStore();
     localStorage.clear();
   });
 
@@ -889,7 +895,7 @@ describe("openWorkManagementChatPanelTabAtom", () => {
 describe("ChatPanel navigation tabs", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.resetModules();
+    resetInstrumentedStore();
     localStorage.removeItem("orgii:chatPanelTabs:v2");
     localStorage.removeItem("orgii-v2-session-view");
   });
@@ -1489,7 +1495,7 @@ describe("ChatPanel navigation tabs", () => {
 describe("openSessionInNewChatTabAtom", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.resetModules();
+    resetInstrumentedStore();
     localStorage.removeItem("orgii:chatPanelTabs:v2");
     localStorage.removeItem("orgii-v2-session-view");
   });
@@ -1609,7 +1615,7 @@ describe("openSessionInNewChatTabAtom", () => {
 describe("openOrReplaceSessionInChatPanelTabAtom", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.resetModules();
+    resetInstrumentedStore();
     localStorage.removeItem("orgii:chatPanelTabs:v2");
     localStorage.removeItem("orgii-v2-session-view");
   });
@@ -1682,7 +1688,7 @@ describe("openOrReplaceSessionInChatPanelTabAtom", () => {
 describe("managed TUI terminal state", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.resetModules();
+    resetInstrumentedStore();
     localStorage.clear();
   });
 
@@ -1724,7 +1730,7 @@ describe("managed TUI terminal state", () => {
 describe("setChatPanelTabTitleAtom", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.resetModules();
+    resetInstrumentedStore();
     localStorage.clear();
   });
 
@@ -1753,7 +1759,7 @@ describe("setChatPanelTabTitleAtom", () => {
 describe("GitHub chat-panel detail tabs", () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.resetModules();
+    resetInstrumentedStore();
     localStorage.clear();
   });
 

--- a/src/store/session/sessionAtom/__tests__/mutations.test.ts
+++ b/src/store/session/sessionAtom/__tests__/mutations.test.ts
@@ -14,23 +14,31 @@
  * (clicking an old session in WorkStation makes it appear in the 6h
  * Kanban window) was a one-line slip and easy to reintroduce.
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
+import * as streamHelpers from "@src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/streamHelpers";
+import {
+  createInstrumentedStore,
+  getInstrumentedStore,
+  resetInstrumentedStore,
+} from "@src/util/core/state/instrumentedStore";
+
+import * as atoms from "../atoms";
+import * as mutations from "../mutations";
+import { sessionPaginationAtom } from "../paginationAtoms";
+import { createSidebarRosterMatcher } from "../sidebarRoster";
 import type { Session } from "../types";
 
+// A fresh store per test is the whole isolation requirement here: atom values
+// live in the store, so dropping it resets every atom. `vi.resetModules()` plus
+// a dynamic re-import of the atom graph would do the same thing at ~10x the
+// cost, once per test.
 beforeEach(() => {
-  vi.resetModules();
+  resetInstrumentedStore();
+  createInstrumentedStore();
 });
 
 async function loadModule() {
-  const { createInstrumentedStore } =
-    await import("@src/util/core/state/instrumentedStore");
-  createInstrumentedStore();
-  const mutations = await import("../mutations");
-  const atoms = await import("../atoms");
-  const { sessionPaginationAtom } = await import("../paginationAtoms");
-  const { getInstrumentedStore } =
-    await import("@src/util/core/state/instrumentedStore");
   return {
     upsertSession: mutations.upsertSession,
     updateSessionStatus: mutations.updateSessionStatus,
@@ -85,7 +93,6 @@ describe("upsertSession", () => {
 
   it("registers a new primary native session in an authoritative sidebar roster", async () => {
     const { upsertSession, sessionPaginationAtom, store } = await loadModule();
-    const { createSidebarRosterMatcher } = await import("../sidebarRoster");
     const pagination = store.get(sessionPaginationAtom);
     store.set(sessionPaginationAtom, {
       ...pagination,
@@ -293,9 +300,6 @@ describe("updateSessionStatus", () => {
 describe("removeSession", () => {
   it("drops the session and disposes its rust-agent streaming state", async () => {
     const { upsertSession, sessionsAtom, store } = await loadModule();
-    const mutations = await import("../mutations");
-    const streamHelpers =
-      await import("@src/engines/SessionCore/sync/adapters/rustAgent/eventHandlers/streamHelpers");
 
     upsertSession(makeSession({ session_id: "sess-x" }));
 

--- a/src/util/core/state/instrumentedStore.ts
+++ b/src/util/core/state/instrumentedStore.ts
@@ -30,6 +30,20 @@ export function isStoreInitialized(): boolean {
 }
 
 /**
+ * Drops the singleton so the next `createInstrumentedStore()` builds a fresh
+ * one. Intended for tests.
+ *
+ * Atom values live in the store, not in the atom objects, so a new store is
+ * already a clean slate for every atom. Without this, a suite that wants
+ * per-case isolation has to reach for `vi.resetModules()` and re-import the
+ * whole atom graph on every test -- which is what made the store suites the
+ * slowest and flakiest files in the run.
+ */
+export function resetInstrumentedStore() {
+  globalStore = null;
+}
+
+/**
  * Creates the singleton Jotai store for the application
  */
 export function createInstrumentedStore() {


### PR DESCRIPTION
## Problem

Three store suites were the slowest and least reliable files in the unit run. In a local full-suite run they produced 8 failures that all pass in isolation:

| File | full-suite | isolated |
| --- | --- | --- |
| `chatPanelTabsAtom.test.ts` | 303s, 5 failures | 12.8s, passes |
| `sessionAtom/__tests__/mutations.test.ts` | 108s, 1 failure | passes |
| `chatPanelChannelTabs.test.ts` | 50s | passes |

The cause is one missing function. `createInstrumentedStore()` in `src/util/core/state/instrumentedStore.ts` is a singleton that returns the existing store if one exists, and nothing ever clears it. A suite that wants per-case isolation therefore has no way to ask for a fresh store — so these files reached for `vi.resetModules()` and re-imported the entire atom graph inside every test.

`chatPanelTabsAtom.test.ts` did this 42 times per run, pulling in `chatPanelTabsAtom`, `chatPanelTerminalAtom`, `chatPanelAtom`, `viewAtom`, `sessionAtom`, `kanbanReplayAtom`, `kanbanViewStateAtom`, `workManagementCreatorAtom` and `workstationTabBarAtoms` from scratch each time. Under full-suite worker contention that repeated import is what pushes these files past the 15s ceiling — the ceiling `vitest.config.ts` already had to raise once, with a comment describing the symptom.

The premise was wrong in the first place. Atom values live in the store, not in the atom objects, so tearing down the module registry was never what isolation required.

## Solution

Add `resetInstrumentedStore()`, which drops the singleton so the next `createInstrumentedStore()` builds a fresh one. Then convert the three suites from `vi.resetModules()` + dynamic re-import to static imports plus a store reset in `beforeEach`.

`loadModule()`-style helpers keep their shape and call sites, so the test bodies are untouched — the diff is the import mechanism and the `beforeEach` line, not the assertions.

Measured per file, same machine, before → after:

| File | tests time | total |
| --- | --- | --- |
| `chatPanelTabsAtom.test.ts` | 11.86s → **0.138s** | 12.8s → 9.4s |
| `mutations.test.ts` | 91.84s → **0.078s** | 99.6s → 17.9s |
| `chatPanelChannelTabs.test.ts` | — | 15.2s, `tests` 0.081s |

The work moves out of `tests` (one graph re-import per case) into `collect` (one import per file), which is where it belongs and where it is paid once.

## Potential risks

- **Storage-backed atoms are no longer re-created per test.** `sessionViewAtom` is `atomWithStorage(..., { getOnInit: true })`, so it snapshots `localStorage` when the module loads. Under `resetModules` each test re-read storage; now every test starts from the same collect-time snapshot. Isolation is preserved — a fresh store still returns the atom's init value — but a test that *seeds* `localStorage` and expects the atom to pick it up would no longer work.

  This is why three other suites are deliberately **not** converted: `viewAtom.test.ts`, `visitedSessionsAtom.test.ts`, and `useWorkStationPipelineBridge.test.ts` install a memory storage per case and depend on that re-read. Their `vi.resetModules()` is load-bearing. `chatPanelTabsAtom.test.ts` only ever *clears* keys, never seeds them, and all 42 cases pass.
- **`resetInstrumentedStore()` is exported from a production module.** Calling it in the running app would orphan every live subscription. It is documented as test-only; there is no existing convention in this repo for guarding such helpers, and adding one felt out of scope for this change.
- **Latent cross-test leakage may now be visible.** Anything these suites were accidentally getting from a fresh module registry — module-level caches outside Jotai — is no longer reset. The three converted files were checked for this (`mutations.ts`, `atoms.ts`, `paginationAtoms.ts` hold no module-level mutable state) and `streamHelpers`, which does, is exercised by a single self-contained case.
- **This does not fix `editorCache.test.ts`** (31s), which is slow for an unrelated reason — it does not use the instrumented store.

## Verification

- `pnpm exec vitest run src/store` → **68 files, 665 tests, all passed**, 33s.
- Per converted file: `chatPanelTabsAtom.test.ts` 42/42 passed; `mutations.test.ts` 12/12 passed (one of these was failing under load before); `chatPanelChannelTabs.test.ts` 8/8 passed.
- `pnpm typecheck` → **exit 0**, whole repo.
- `pnpm exec eslint --max-warnings 0 --report-unused-disable-directives` on all four changed files → clean.
- `pnpm exec prettier --check` on all four → clean.

Live on this pull request ([run 33168665953](https://github.com/org2AI/ORG2/actions/runs/33168665953)):

- `Frontend (typecheck · lint · test)` → **success**. The whole 1249-file suite is green, which is the claim that mattered: these files stop failing under contention.
- `Unit tests` step: **320s**, against the five most recent runs of the same step on develop-based pull requests — 374s, 460s, 465s, 483s, 495s (mean 455s). 320s is below all five.

Runner-to-runner variance in that step is real (the baselines span 121s), so treat ~30% as the shape of the win rather than a precise figure. The per-file `tests`-phase numbers above are the measurement with no variance in it.

Not run:

- **No repeated-run distribution.** One CI sample cannot separate the improvement from a fast runner; the case rests on the per-file numbers plus this being under the observed minimum.
