### PR TITLE
fix(ci): let the rust cache warm run finish

### DIFF
--- a/.github/workflows/warm-rust-cache.yml
+++ b/.github/workflows/warm-rust-cache.yml
@@ -25,11 +25,23 @@ on:
     branches:
       - develop
 
-# Only the newest develop head is worth caching. Cancel an in-flight warm run
-# when another merge lands so macOS runner slots are not spent on stale SHAs.
+# Serialize warm runs, but never cancel one that is already building.
+#
+# This used to be `cancel-in-progress: true`, on the theory that macOS runner
+# slots should not be spent on stale SHAs. Measured over 20 consecutive
+# develop pushes, 11 runs were cancelled -- and every one of them died inside
+# `cargo test (build only)`, the longest step and the only one that produces
+# the test-profile artifacts this workflow exists to publish. `cache-on-failure`
+# then saved the truncated result under the exact key ci.yml restores, so PR
+# runs got a cache holding clippy's check artifacts and nothing else, and paid
+# 17m37s recompiling all 43 workspace crates in `cargo test --workspace`.
+#
+# With cancellation off, GitHub runs the current warm to completion and keeps
+# only the newest push queued behind it, so a busy merge day costs at most one
+# extra queued run instead of a day of unusable caches.
 concurrency:
   group: warm-rust-cache-develop
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   # ── Change scope ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`cargo test --workspace` is the single most expensive step in this repository's CI: **18m53s** on [run 33154856001](https://github.com/org2AI/ORG2/actions/runs/33154856001), out of a 40m45s Rust job. The step's comment in `ci.yml` says it is "mostly link plus ~1 min of execution for ~6800 tests". The execution part is right — the tests run in ~75s. The rest is not link. It is **17m37s of compilation**, and the job log says so directly:

```
Finished `test` profile [unoptimized + debuginfo] target(s) in 17m 37s
```

The whole job emits 56 `Compiling` lines: 13 during clippy, and **all 43 workspace crates again** during `cargo test`. Third-party dependencies are fully cached — the `Rust cache` step reports a 1117 MB full-key hit — so this is the workspace itself being rebuilt from nothing, every run.

`warm-rust-cache.yml` exists precisely to prevent that. It runs `cargo clippy --workspace --all-targets` followed by `cargo test --workspace --no-run` on develop, so PR runs restore both the check artifacts and the test-profile codegen artifacts. The clippy half works; the test half does not, and the reason is this workflow's own concurrency policy.

Over the last 20 develop pushes, **11 warm runs were cancelled**. Inspecting them, the pattern is identical every time:

```
cargo clippy (all targets):  success
cargo test (build only):     cancelled     <- the artifacts CI needs
Post Rust cache:             success       <- and the truncated cache is saved anyway
```

`cancel-in-progress: true` kills the run during its longest step, and `cache-on-failure: true` then publishes the incomplete result under the exact key `ci.yml` restores. Because that key is a full match, no better cache is ever consulted. Of those 20 pushes only 2 warm runs ever reached completion; the rest were either cancelled or skipped as frontend-only.

The policy defeats its own purpose. Its comment says cancellation keeps macOS slots from being spent on stale SHAs — but the cancelled runs still consume a slot for as long as they live, and what they leave behind costs every subsequent pull request 17 minutes.

## Solution

Set `cancel-in-progress: false` on the `warm-rust-cache-develop` concurrency group.

GitHub then runs the in-flight warm to completion and keeps only the newest push queued behind it, superseding any older pending run. A busy merge day therefore costs at most one extra queued run rather than a day of unusable caches, and the queued run is by construction the newest develop head — so the original concern about stale SHAs is still handled, by queue replacement instead of by cancellation.

No other change: the same steps, the same shared key, the same `cache-on-failure` behaviour for genuine build breaks.

## Potential risks

- **macOS runner minutes go up.** Warm runs now serialize instead of pre-empting each other, so a full ~21m warm can run where previously a 10s cancellation happened. The ceiling is one running plus one queued at any time, and the trade is explicit: minutes spent producing a usable cache against 17m37s currently charged to every Rust pull request.
- **A merge can wait behind an older warm run.** Only the warm workflow serializes; `ci.yml` is untouched and pull-request CI is unaffected.
- **The fix is inferred, not yet demonstrated.** The causal chain — cancelled during `cargo test --no-run` → truncated cache saved → 43 crates recompiled in CI — is supported by the job-step conclusions and the `Compiling` counts, but no run yet exists that proves the cache becomes complete. The measurement is the `cargo test (workspace)` step time on the first Rust pull request after this merges.
- **`cache-on-failure: true` is left in place.** It is still right for a real compile error, and with cancellation gone it no longer has a truncation path to publish. Removing it would trade this problem for a cold cache after any red develop.
- **This does not make the Rust job cheap**, only correctly cached. `cargo clippy` (4m12s) and the ~75s of test execution are unaffected.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/warm-rust-cache.yml'))"` → parses.
- Evidence gathered via `gh run list --workflow=warm-rust-cache.yml --limit 20` (11 cancelled) and `gh api .../jobs` on runs 33154753035 and 33158431250, both showing `cargo test (build only): cancelled` with `Post Rust cache: success`.
- Compile/execute split taken from the `Rust (clippy)` job log of run 33154856001: `Finished 'test' profile ... in 17m 37s` at 08:58:21, first test output at 08:58:35, job end 08:59:36.

Not run, and not runnable before merge:

- **The workflow only triggers on push to develop**, so this cannot be exercised from a pull request. Its effect is observable only after merge — first as a warm run that reaches `cargo test (build only): success`, then as a drop in the `cargo test (workspace)` step of the next Rust pull request. Worth watching both before assuming this is fixed.
