### PR TITLE
feat(chat-panel): add a plan intent to the launchpad composer

### DIFF
--- a/src/components/ComposerSurface/index.tsx
+++ b/src/components/ComposerSurface/index.tsx
@@ -21,6 +21,8 @@ export interface ComposerSurfaceProps extends Omit<
   leadingActions?: React.ReactNode;
   /** Optional content at the right edge of the shared bottom action row. */
   trailingActions?: React.ReactNode;
+  /** Pill controls rendered after the + button (mode, model, settings…). */
+  pills?: React.ReactNode;
   /** Enables the standard add-content control when paired with `onUpload`. */
   onAddContent?: () => void;
   /** Enables the standard add-content control when paired with `onAddContent`. */
@@ -38,6 +40,7 @@ const ComposerSurface = forwardRef<HTMLDivElement, ComposerSurfaceProps>(
       children,
       leadingActions,
       trailingActions,
+      pills,
       onAddContent,
       onUpload,
       onOpenSkillsTools,
@@ -52,6 +55,7 @@ const ComposerSurface = forwardRef<HTMLDivElement, ComposerSurfaceProps>(
     const hasActionBar = Boolean(
       leadingActions ||
       trailingActions ||
+      pills ||
       (onAddContent && onUpload) ||
       showContextInfo
     );
@@ -66,6 +70,7 @@ const ComposerSurface = forwardRef<HTMLDivElement, ComposerSurfaceProps>(
             onOpenSkillsTools={onOpenSkillsTools}
             dropdownDirection={dropdownDirection}
             leftPrefix={leadingActions}
+            pills={pills}
             repoPath={repoPath}
             submitButton={trailingActions}
             hideAddButton={!onAddContent || !onUpload}

--- a/src/engines/ChatPanel/ChatPanelEmptyContent.tsx
+++ b/src/engines/ChatPanel/ChatPanelEmptyContent.tsx
@@ -46,7 +46,7 @@ type SessionCreatorSlot = NonNullable<ChatPanelProps["sessionCreatorSlot"]>;
 type SessionCreatorSlotProps = React.ComponentProps<SessionCreatorSlot>;
 
 interface EmbeddedAgentComposerOptions {
-  heroFooterSlot?: React.ReactNode;
+  launchpadIntent?: SessionCreatorSlotProps["launchpadIntent"];
   onSessionStart: NonNullable<SessionCreatorSlotProps["onSessionStart"]>;
   resolveWorkItemContext?: SessionCreatorSlotProps["resolveWorkItemContext"];
   workItemContext?: SessionCreatorSlotProps["workItemContext"];
@@ -165,7 +165,7 @@ export function ChatPanelEmptyContent({
   }, [handleCreateTargetChange]);
   const createEmbeddedAgentComposer = SessionCreatorSlot
     ? ({
-        heroFooterSlot,
+        launchpadIntent,
         onSessionStart,
         resolveWorkItemContext,
         workItemContext,
@@ -179,7 +179,7 @@ export function ChatPanelEmptyContent({
               className="h-full min-h-0 flex-1"
               variant={creatorVariant}
               layout="launchpad"
-              heroFooterSlot={heroFooterSlot}
+              launchpadIntent={launchpadIntent}
               composerHeaderContent={composerHeaderContent}
               pinnedActionsContent={pinnedActionsContent}
               hidePresenceButton
@@ -196,7 +196,6 @@ export function ChatPanelEmptyContent({
         }
     : undefined;
   const renderWorkItemCreator = (
-    suggestionPills?: React.ReactNode,
     manualMiddleContent?: React.ReactNode,
     creatorModeControl?: React.ReactNode
   ) => {
@@ -226,7 +225,8 @@ export function ChatPanelEmptyContent({
                   middleContent={manualMiddleContent}
                   creatorModeControl={creatorModeControl}
                   renderAgentComposer={createEmbeddedAgentComposer?.({
-                    heroFooterSlot: suggestionPills,
+                    // A work item is written down, not built.
+                    launchpadIntent: "plan",
                     onSessionStart: handleAiWorkItemSessionStart,
                     resolveWorkItemContext: resolveAiWorkItemContext,
                   })}
@@ -269,7 +269,6 @@ export function ChatPanelEmptyContent({
     ) : null;
 
   const renderProjectCreator = (
-    suggestionPills?: React.ReactNode,
     manualMiddleContent?: React.ReactNode,
     creatorModeControl?: React.ReactNode
   ) => {
@@ -294,7 +293,6 @@ export function ChatPanelEmptyContent({
                 middleContent={manualMiddleContent}
                 creatorModeControl={creatorModeControl}
                 renderAgentComposer={createEmbeddedAgentComposer?.({
-                  heroFooterSlot: suggestionPills,
                   onSessionStart: handleProjectCreatorSessionStart,
                   workItemContext: {
                     orgId:
@@ -358,28 +356,20 @@ export function ChatPanelEmptyContent({
       createTarget === CHAT_PANEL_CREATE_TARGET.PROJECT ||
       createTarget === CHAT_PANEL_CREATE_TARGET.PARALLEL_RUN ||
       createTarget === CHAT_PANEL_CREATE_TARGET.GITHUB_ISSUES_PROJECT ||
-      createTarget === CHAT_PANEL_CREATE_TARGET.MANAGE_AGENTS ||
       createTarget === CHAT_PANEL_CREATE_TARGET.COLLAB_ORG
         ? createTarget
         : CHAT_PANEL_CREATE_TARGET.PROJECT;
     const moreLauncher = (
-      suggestionPills: React.ReactNode,
       manualMiddleContent: React.ReactNode,
       creatorModeControl?: React.ReactNode
     ) =>
       moreCreateTarget === CHAT_PANEL_CREATE_TARGET.PROJECT
-        ? renderProjectCreator(
-            suggestionPills,
-            manualMiddleContent,
-            creatorModeControl
-          )
+        ? renderProjectCreator(manualMiddleContent, creatorModeControl)
         : moreCreateTarget === CHAT_PANEL_CREATE_TARGET.PARALLEL_RUN
           ? renderSessionLauncher("h-full", "launchpad", undefined, true)
           : moreCreateTarget === CHAT_PANEL_CREATE_TARGET.GITHUB_ISSUES_PROJECT
             ? renderGithubIssuesCreator()
-            : moreCreateTarget === CHAT_PANEL_CREATE_TARGET.COLLAB_ORG
-              ? renderCollabOrgCreator()
-              : renderSessionLauncher("min-h-0 flex-1");
+            : renderCollabOrgCreator();
 
     return (
       <ChatPanelStartPage
@@ -397,16 +387,8 @@ export function ChatPanelEmptyContent({
         t={t}
         projectAgentMode={showProjectAgentCreator}
         workItemAgentMode={showWorkItemAgentCreator}
-        workItemLauncher={(
-          suggestionPills,
-          manualMiddleContent,
-          creatorModeControl
-        ) =>
-          renderWorkItemCreator(
-            suggestionPills,
-            manualMiddleContent,
-            creatorModeControl
-          )
+        workItemLauncher={(manualMiddleContent, creatorModeControl) =>
+          renderWorkItemCreator(manualMiddleContent, creatorModeControl)
         }
       />
     );

--- a/src/engines/ChatPanel/ChatPanelStartPage.test.ts
+++ b/src/engines/ChatPanel/ChatPanelStartPage.test.ts
@@ -20,10 +20,6 @@ const createTargetProps = {
   createTargetOptions: [
     { value: CHAT_PANEL_CREATE_TARGET.PROJECT, label: "Create project" },
     {
-      value: CHAT_PANEL_CREATE_TARGET.MANAGE_AGENTS,
-      label: "Manage Agents / Skills",
-    },
-    {
       value: CHAT_PANEL_CREATE_TARGET.GITHUB_ISSUES_PROJECT,
       label: "GitHub Issues project",
     },
@@ -37,10 +33,12 @@ const createTargetProps = {
   workItemAgentMode: true,
   moreLauncher: (...content: React.ReactNode[]) =>
     createElement("div", null, ...content),
+  onAddApiKey: vi.fn(),
+  onInstallLatestUpdate: vi.fn(),
 };
 
 describe("ChatPanelStartPage", () => {
-  it("renders the install-latest-update action for other More targets", () => {
+  it("renders no utility actions for other More targets", () => {
     mocks.useAvailableAppUpdate.mockReturnValue({
       available: true,
       version: "1.1.20",
@@ -55,36 +53,34 @@ describe("ChatPanelStartPage", () => {
     const markup = renderToStaticMarkup(
       createElement(ChatPanelStartPage, {
         ...createTargetProps,
-        createTarget: CHAT_PANEL_CREATE_TARGET.MANAGE_AGENTS,
-        moreLauncher: (middleContent, _manualMiddleContent, modeControl) =>
+        createTarget: CHAT_PANEL_CREATE_TARGET.GITHUB_ISSUES_PROJECT,
+        moreLauncher: (_manualMiddleContent, modeControl) =>
           createElement(
             "div",
             { "data-testid": "embedded-more-creator" },
             "Embedded creator",
-            middleContent,
             modeControl
           ),
-        onAddApiKey: vi.fn(),
-        onInstallLatestUpdate: vi.fn(),
         t,
       })
     );
 
-    expect(markup).toContain(
+    expect(markup).not.toContain(
+      'data-testid="chat-panel-start-page-utility-actions"'
+    );
+    expect(markup).not.toContain(
       'data-testid="chat-panel-start-page-install-latest-update"'
     );
-    expect(markup).toContain("Install latest update");
-    expect(markup).toContain("text-text-2");
-    expect(markup).not.toContain("group-hover:text-warning-6");
-    expect(markup).toContain("gap-2");
-    expect(markup).toContain("rounded-lg");
-    expect(markup).toContain("mx-auto w-full");
-    expect(markup).toContain("min-h-[68px]");
-    expect(markup).toContain("px-2.5 py-2");
-    expect(markup).toContain("border-warning-6/20");
-    expect(markup).toContain("text-warning-6");
-    expect(markup).toContain("hidden @[640px]/focusedchat:block");
-    expect(markup).toContain("@[560px]/startactions:grid-cols-4");
+    expect(markup).not.toContain("Install latest update");
+    expect(markup).not.toContain(
+      'data-testid="chat-panel-start-page-import-session"'
+    );
+    expect(markup).not.toContain(
+      'data-testid="chat-panel-start-page-add-api-key"'
+    );
+    expect(markup).not.toContain(
+      'data-testid="chat-panel-start-page-show-runtime"'
+    );
     expect(markup).toContain(
       'data-testid="chat-panel-start-page-create-target-select"'
     );
@@ -92,7 +88,7 @@ describe("ChatPanelStartPage", () => {
     expect(markup).toContain("select-bare");
     expect(markup).toContain("select-title-row");
     expect(markup).not.toContain("select-ghost");
-    expect(markup).toContain("Manage Agents / Skills");
+    expect(markup).toContain("GitHub Issues project");
     expect(markup).toContain(
       'data-testid="chat-panel-start-page-trailing-control"'
     );
@@ -127,24 +123,6 @@ describe("ChatPanelStartPage", () => {
     expect(markup).toContain(
       'class="flex h-full min-h-0 w-full flex-col overflow-hidden" data-testid="chat-panel-start-page-more-launcher"><div data-testid="embedded-more-creator"'
     );
-
-    const updateIndex = markup.indexOf(
-      'data-testid="chat-panel-start-page-install-latest-update"'
-    );
-    const importSessionIndex = markup.indexOf(
-      'data-testid="chat-panel-start-page-import-session"'
-    );
-    const addApiKeyIndex = markup.indexOf(
-      'data-testid="chat-panel-start-page-add-api-key"'
-    );
-    const showRuntimeIndex = markup.indexOf(
-      'data-testid="chat-panel-start-page-show-runtime"'
-    );
-
-    expect(updateIndex).toBeGreaterThanOrEqual(0);
-    expect(importSessionIndex).toBeGreaterThan(updateIndex);
-    expect(addApiKeyIndex).toBeGreaterThan(importSessionIndex);
-    expect(showRuntimeIndex).toBeGreaterThan(addApiKeyIndex);
     expect(markup).not.toContain(
       'data-testid="chat-panel-start-page-new-work-item"'
     );
@@ -159,9 +137,9 @@ describe("ChatPanelStartPage", () => {
     const markup = renderToStaticMarkup(
       createElement(ChatPanelStartPage, {
         ...createTargetProps,
-        createTarget: CHAT_PANEL_CREATE_TARGET.MANAGE_AGENTS,
-        onAddApiKey: vi.fn(),
-        onInstallLatestUpdate: vi.fn(),
+        createTarget: CHAT_PANEL_CREATE_TARGET.AGENT_SESSION,
+        sessionLauncher: (heroFooterSlot) =>
+          createElement("div", null, "Session launcher", heroFooterSlot),
         t,
       })
     );
@@ -183,8 +161,6 @@ describe("ChatPanelStartPage", () => {
     const markup = renderToStaticMarkup(
       createElement(ChatPanelStartPage, {
         ...createTargetProps,
-        onAddApiKey: vi.fn(),
-        onInstallLatestUpdate: vi.fn(),
         t,
       })
     );
@@ -206,8 +182,11 @@ describe("ChatPanelStartPage", () => {
     );
   });
 
-  it("renders import session before add API key in More", () => {
-    mocks.useAvailableAppUpdate.mockReturnValue(null);
+  it("renders install, import session, add API key then runtime on Session", () => {
+    mocks.useAvailableAppUpdate.mockReturnValue({
+      available: true,
+      version: "1.1.20",
+    });
     const t = ((key: string) => key) as TFunction<
       ["sessions", "common", "projects", "navigation"]
     >;
@@ -215,9 +194,9 @@ describe("ChatPanelStartPage", () => {
     const markup = renderToStaticMarkup(
       createElement(ChatPanelStartPage, {
         ...createTargetProps,
-        createTarget: CHAT_PANEL_CREATE_TARGET.MANAGE_AGENTS,
-        onAddApiKey: vi.fn(),
-        onInstallLatestUpdate: vi.fn(),
+        createTarget: CHAT_PANEL_CREATE_TARGET.AGENT_SESSION,
+        sessionLauncher: (heroFooterSlot) =>
+          createElement("div", null, "Session launcher", heroFooterSlot),
         t,
       })
     );
@@ -232,10 +211,14 @@ describe("ChatPanelStartPage", () => {
       'data-testid="chat-panel-start-page-show-runtime"'
     );
 
-    expect(importSessionIndex).toBeGreaterThanOrEqual(0);
+    const updateIndex = markup.indexOf(
+      'data-testid="chat-panel-start-page-install-latest-update"'
+    );
+
+    expect(updateIndex).toBeGreaterThanOrEqual(0);
+    expect(importSessionIndex).toBeGreaterThan(updateIndex);
     expect(addApiKeyIndex).toBeGreaterThan(importSessionIndex);
     expect(showRuntimeIndex).toBeGreaterThan(addApiKeyIndex);
-    expect(markup).toContain("@[440px]/startactions:grid-cols-3");
     expect(markup).toContain("navigation:cloud.share.importEntry");
     expect(markup).toContain("border-border-2");
     expect(markup).toContain("hover:border-border-3");
@@ -258,15 +241,9 @@ describe("ChatPanelStartPage", () => {
       createElement(ChatPanelStartPage, {
         ...createTargetProps,
         createTarget: CHAT_PANEL_CREATE_TARGET.WORK_ITEM,
-        onAddApiKey: vi.fn(),
-        onInstallLatestUpdate: vi.fn(),
         t,
         workItemAgentMode: false,
-        workItemLauncher: (
-          _suggestionPills,
-          manualMiddleContent,
-          modeControl
-        ) =>
+        workItemLauncher: (manualMiddleContent, modeControl) =>
           createElement(
             "div",
             { "data-testid": "full-work-item-creator" },
@@ -289,7 +266,7 @@ describe("ChatPanelStartPage", () => {
       'data-testid="chat-panel-start-page-work-item-mode-toggle"'
     );
     expect(markup).toContain("common:tooltips.manual");
-    expect(markup).toContain("creator.manualLaunchpadQuestion");
+    expect(markup).toContain("creator.manualPlanLaunchpadQuestion");
     expect(markup).toContain(
       'data-testid="chat-panel-start-page-manual-middle-content"'
     );
@@ -328,9 +305,7 @@ describe("ChatPanelStartPage", () => {
     const markup = renderToStaticMarkup(
       createElement(ChatPanelStartPage, {
         ...createTargetProps,
-        createTarget: CHAT_PANEL_CREATE_TARGET.MANAGE_AGENTS,
-        onAddApiKey: vi.fn(),
-        onInstallLatestUpdate: vi.fn(),
+        createTarget: CHAT_PANEL_CREATE_TARGET.GITHUB_ISSUES_PROJECT,
         t,
       })
     );
@@ -353,8 +328,6 @@ describe("ChatPanelStartPage", () => {
       createElement(ChatPanelStartPage, {
         ...createTargetProps,
         createTarget: CHAT_PANEL_CREATE_TARGET.AGENT_SESSION,
-        onAddApiKey: vi.fn(),
-        onInstallLatestUpdate: vi.fn(),
         sessionLauncher: (heroFooterSlot) =>
           createElement("div", null, "Session launcher", heroFooterSlot),
         t,

--- a/src/engines/ChatPanel/ChatPanelStartPage.tsx
+++ b/src/engines/ChatPanel/ChatPanelStartPage.tsx
@@ -9,7 +9,6 @@ import ImportSharedSessionDialog from "@src/features/Org2Cloud/ImportSharedSessi
 import {
   type LaunchpadAction,
   LaunchpadActionCard,
-  LaunchpadActionGrid,
 } from "@src/features/SessionCreator/components/LaunchpadActionGrid";
 import {
   Download01Icon,
@@ -32,7 +31,6 @@ interface ChatPanelStartPageProps {
   createTarget: ChatPanelCreateTarget;
   createTargetOptions: SelectOption[];
   moreLauncher?: (
-    suggestionPills: React.ReactNode,
     manualMiddleContent: React.ReactNode,
     creatorModeControl?: React.ReactNode
   ) => React.ReactNode;
@@ -47,7 +45,6 @@ interface ChatPanelStartPageProps {
   t: TFunction<["sessions", "common", "projects", "navigation"]>;
   workItemAgentMode: boolean;
   workItemLauncher?: (
-    suggestionPills: React.ReactNode,
     manualMiddleContent: React.ReactNode,
     creatorModeControl: React.ReactNode
   ) => React.ReactNode;
@@ -176,26 +173,21 @@ export function ChatPanelStartPage({
       : createTarget === CHAT_PANEL_CREATE_TARGET.WORK_ITEM
         ? "work-item"
         : "more";
-  const showSuggestionCards =
-    createTarget !== CHAT_PANEL_CREATE_TARGET.PROJECT &&
-    createTarget !== CHAT_PANEL_CREATE_TARGET.WORK_ITEM;
   const suggestionCards = utilityActions.map((action) => (
     <LaunchpadActionCard key={action.id} action={action} presentation="card" />
   ));
-  const suggestionPills = showSuggestionCards ? (
-    <LaunchpadActionGrid className="mx-auto w-full" presentation="card">
-      {suggestionCards}
-    </LaunchpadActionGrid>
-  ) : null;
   const manualMiddleContent = (
     <div
       className="flex w-full flex-col items-center justify-center gap-4"
       data-testid="chat-panel-start-page-manual-middle-content"
     >
       <h1 className="text-center text-[18px] font-normal leading-relaxed tracking-tight text-text-1 sm:text-[20px]">
-        {t("creator.manualLaunchpadQuestion")}
+        {t(
+          activeView === "work-item"
+            ? "creator.manualPlanLaunchpadQuestion"
+            : "creator.manualLaunchpadQuestion"
+        )}
       </h1>
-      {showSuggestionCards ? suggestionPills : null}
     </div>
   );
   const workItemModeControl = (
@@ -216,23 +208,15 @@ export function ChatPanelStartPage({
   );
   const sessionLauncherContent = sessionLauncher?.(suggestionCards);
   const workItemLauncherContent = workItemLauncher?.(
-    suggestionPills,
     manualMiddleContent,
     workItemModeControl
   );
   const moreLauncherContent = moreLauncher?.(
-    suggestionPills,
     manualMiddleContent,
     createTarget === CHAT_PANEL_CREATE_TARGET.PROJECT
       ? projectModeControl
       : undefined
   );
-  const showUtilityActionsFooter =
-    activeView === "more" &&
-    createTarget !== CHAT_PANEL_CREATE_TARGET.PROJECT &&
-    // A parallel run renders a full launcher with its own composer dock;
-    // a second row of action cards under it has nowhere to sit.
-    createTarget !== CHAT_PANEL_CREATE_TARGET.PARALLEL_RUN;
   const handleViewChange = useCallback(
     (key: string) => {
       if (key === "session") {
@@ -356,18 +340,6 @@ export function ChatPanelStartPage({
           </CreatorContentLayout>
         )}
       </div>
-      {showUtilityActionsFooter && (
-        <div
-          className={`shrink-0 px-4 pb-5 pt-2 ${DETAIL_PANEL_TOKENS.headerWidth}`}
-          data-testid="chat-panel-start-page-utility-actions"
-        >
-          <LaunchpadActionGrid className="w-full">
-            {utilityActions.map((action) => (
-              <LaunchpadActionCard key={action.id} action={action} />
-            ))}
-          </LaunchpadActionGrid>
-        </div>
-      )}
       {isImportSessionDialogOpen && (
         <ImportSharedSessionDialog
           visible

--- a/src/engines/ChatPanel/ChatPanelTabBar/TabPill.tsx
+++ b/src/engines/ChatPanel/ChatPanelTabBar/TabPill.tsx
@@ -145,9 +145,7 @@ export const TabPill = memo(function TabPill({
             ? t("projects:githubIssuesImport.createTarget")
             : createTarget === CHAT_PANEL_CREATE_TARGET.COLLAB_ORG
               ? t("navigation:collaboration.addOrg")
-              : createTarget === CHAT_PANEL_CREATE_TARGET.MANAGE_AGENTS
-                ? t("sessions:creator.createTarget.manageAgents")
-                : defaultDisplayTitle;
+              : defaultDisplayTitle;
 
   const iconColorClass = isActive ? "text-text-1" : "text-text-2";
   const isGitHubIssueTab =

--- a/src/engines/ChatPanel/hooks/useChatPanelCreateTarget.ts
+++ b/src/engines/ChatPanel/hooks/useChatPanelCreateTarget.ts
@@ -2,9 +2,6 @@ import type { TFunction } from "i18next";
 import { useCallback, useMemo } from "react";
 
 import type { SelectOption } from "@src/components/Select";
-import type { AgentDefinition } from "@src/modules/MainApp/AgentOrgs/types";
-import { SESSION_TARGET_KIND } from "@src/store/session";
-import type { SessionCreatorState } from "@src/store/session/creatorStateAtom";
 import {
   CHAT_PANEL_CREATE_TARGET,
   type ChatPanelCollabOrgCreateIntent,
@@ -12,17 +9,11 @@ import {
 } from "@src/store/ui/chatPanelAtom";
 import type { WorkItemDraft } from "@src/store/workstation/projectManager";
 
-const ADE_MANAGER_DEF_ID = "builtin:agent-architect";
-
 interface UseChatPanelCreateTargetOptions {
-  allAgentDefs: AgentDefinition[];
   sessionCreatorAvailable: boolean;
   setCreateTarget: (target: ChatPanelCreateTarget) => void;
   setCollabOrgCreateIntent: (
     intent: ChatPanelCollabOrgCreateIntent | null
-  ) => void;
-  setCreatorState: (
-    updater: (previous: SessionCreatorState) => SessionCreatorState
   ) => void;
   setShowProjectAgentCreator: (enabled: boolean) => void;
   setShowWorkItemAgentCreator: (enabled: boolean) => void;
@@ -31,11 +22,9 @@ interface UseChatPanelCreateTargetOptions {
 }
 
 export function useChatPanelCreateTarget({
-  allAgentDefs,
   sessionCreatorAvailable,
   setCreateTarget,
   setCollabOrgCreateIntent,
-  setCreatorState,
   setShowProjectAgentCreator,
   setShowWorkItemAgentCreator,
   setWorkItemCreateDraft,
@@ -52,11 +41,6 @@ export function useChatPanelCreateTarget({
         value: CHAT_PANEL_CREATE_TARGET.PARALLEL_RUN,
         label: t("sessions:creator.createTarget.parallelRun"),
         dataTestId: "chat-panel-create-target-parallel-run-option",
-      },
-      {
-        value: CHAT_PANEL_CREATE_TARGET.MANAGE_AGENTS,
-        label: t("sessions:creator.createTarget.manageAgents"),
-        dataTestId: "chat-panel-create-target-manage-agents-option",
       },
       {
         value: CHAT_PANEL_CREATE_TARGET.GITHUB_ISSUES_PROJECT,
@@ -80,27 +64,6 @@ export function useChatPanelCreateTarget({
       // one-shot guide preset that may still be waiting on lazy rendering.
       setCollabOrgCreateIntent(null);
 
-      if (nextTarget === CHAT_PANEL_CREATE_TARGET.MANAGE_AGENTS) {
-        const adeManagerDef = allAgentDefs.find(
-          (definition) => definition.id === ADE_MANAGER_DEF_ID
-        );
-        setCreatorState((previous) => ({
-          ...previous,
-          dispatchCategory: "rust_agent",
-          targetKind: SESSION_TARGET_KIND.AGENT,
-          selectedAgentDefinitionId: ADE_MANAGER_DEF_ID,
-          selectedAgentOrgId: null,
-          agentName: adeManagerDef?.name ?? previous.agentName,
-          agentIconId: adeManagerDef?.iconId ?? null,
-          cliAgentType: null,
-        }));
-        setCreateTarget(CHAT_PANEL_CREATE_TARGET.MANAGE_AGENTS);
-        setWorkItemCreateDraft(null);
-        setShowWorkItemAgentCreator(sessionCreatorAvailable);
-        setShowProjectAgentCreator(sessionCreatorAvailable);
-        return;
-      }
-
       if (nextTarget !== CHAT_PANEL_CREATE_TARGET.WORK_ITEM) {
         setWorkItemCreateDraft(null);
         setShowWorkItemAgentCreator(sessionCreatorAvailable);
@@ -113,11 +76,9 @@ export function useChatPanelCreateTarget({
       setCreateTarget(nextTarget);
     },
     [
-      allAgentDefs,
       sessionCreatorAvailable,
       setCollabOrgCreateIntent,
       setCreateTarget,
-      setCreatorState,
       setShowProjectAgentCreator,
       setShowWorkItemAgentCreator,
       setWorkItemCreateDraft,

--- a/src/engines/ChatPanel/index.tsx
+++ b/src/engines/ChatPanel/index.tsx
@@ -348,7 +348,6 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
     }, [activeTab, syncActiveTabState]);
 
     const creatorState = useAtomValue(sessionCreatorStateAtom);
-    const setCreatorState = useSetAtom(sessionCreatorStateAtom);
     const bumpProjectListRefresh = useSetAtom(projectListRefreshAtom);
     const allAgentDefs = useAtomValue(allAgentDefsAtom);
 
@@ -422,11 +421,9 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
 
     const { createTargetOptions, handleCreateTargetChange } =
       useChatPanelCreateTarget({
-        allAgentDefs,
         sessionCreatorAvailable: Boolean(SessionCreatorSlot),
         setCollabOrgCreateIntent,
         setCreateTarget,
-        setCreatorState,
         setShowProjectAgentCreator,
         setShowWorkItemAgentCreator,
         setWorkItemCreateDraft,

--- a/src/engines/ChatPanel/types.ts
+++ b/src/engines/ChatPanel/types.ts
@@ -65,6 +65,8 @@ export interface ChatPanelProps {
     className?: string;
     variant?: "default" | "fullScreen";
     layout?: "default" | "launchpad";
+    /** Wording of the launchpad question: what the composer produces. */
+    launchpadIntent?: "build" | "plan";
     centerFullScreenContent?: boolean;
     composerHeaderContent?: ReactNode;
     heroFooterSlot?: ReactNode;

--- a/src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/SessionCreatorChatPanelView.tsx
@@ -44,7 +44,10 @@ import SessionCreatorOrgMembersPanel from "./SessionCreatorOrgMembersPanel";
 import WorkItemAttachmentControl from "./WorkItemAttachmentControl";
 import { isRepoChromeAboveComposer } from "./repoChromeLayout";
 import type { SessionCreatorAgentHeroContent } from "./resolveSessionCreatorAgentHero";
-import type { SessionCreatorChatPanelHeaderLayout } from "./types";
+import type {
+  SessionCreatorChatPanelHeaderLayout,
+  SessionCreatorLaunchpadIntent,
+} from "./types";
 
 interface CategoryPickerProps {
   anchorRef: React.RefObject<HTMLButtonElement | null>;
@@ -94,6 +97,7 @@ interface SessionCreatorChatPanelViewProps {
   isCliTuiMode: boolean;
   isFullScreenVariant: boolean;
   isLaunchpadLayout: boolean;
+  launchpadIntent: SessionCreatorLaunchpadIntent;
   isLoading: boolean;
   hideSessionSetupControls: boolean;
   isOrgMembersPanelOpen: boolean;
@@ -156,6 +160,7 @@ const SessionCreatorChatPanelView: React.FC<
   isCliTuiMode,
   isFullScreenVariant,
   isLaunchpadLayout,
+  launchpadIntent,
   isLoading,
   hideSessionSetupControls,
   isOrgMembersPanelOpen,
@@ -393,16 +398,24 @@ const SessionCreatorChatPanelView: React.FC<
         />
       </div>
     ) : null;
+  const launchpadQuestionKey =
+    launchpadIntent === "plan"
+      ? "creator.planLaunchpadQuestion"
+      : "creator.launchpadQuestion";
+  const launchpadQuestionSuffixKey =
+    launchpadIntent === "plan"
+      ? "creator.planLaunchpadQuestionSuffix"
+      : "creator.launchpadQuestionSuffix";
   const agentHero = headerLayout !== "compact" && (
     <SessionCreatorAgentHero
       ref={agentHeroRef}
       name={heroContent.name}
       description={heroContent.description}
       avatarIcon={heroIcon}
-      question={isLaunchpadLayout ? t("creator.launchpadQuestion") : undefined}
+      question={isLaunchpadLayout ? t(launchpadQuestionKey) : undefined}
       questionSuffix={
         isLaunchpadLayout
-          ? t("creator.launchpadQuestionSuffix", { defaultValue: "" })
+          ? t(launchpadQuestionSuffixKey, { defaultValue: "" })
           : undefined
       }
       active={isCategorySelectorOpen}

--- a/src/features/SessionCreator/variants/ChatPanel/index.tsx
+++ b/src/features/SessionCreator/variants/ChatPanel/index.tsx
@@ -98,6 +98,7 @@ const SessionCreatorChatPanelContent: React.FC<
   hidePresenceButton = false,
   launchMode,
   layout = "default",
+  launchpadIntent = "build",
   variant = "default",
   workItemContext,
   resolveWorkItemContext,
@@ -586,6 +587,7 @@ const SessionCreatorChatPanelContent: React.FC<
         isHumanMode ? humanCreating : isLoading || multiRunner.isLaunching
       }
       isLaunchpadLayout={layout === "launchpad"}
+      launchpadIntent={launchpadIntent}
       isOrgMembersPanelOpen={isOrgMembersPanelOpen}
       isWingmanMode={isWingmanMode}
       leadingActionSlot={leadingActionSlot}

--- a/src/features/SessionCreator/variants/ChatPanel/types.ts
+++ b/src/features/SessionCreator/variants/ChatPanel/types.ts
@@ -15,6 +15,12 @@ import type { DropdownDirection } from "../../components/ControlButtons";
 export type SessionCreatorChatPanelVariant = "default" | "fullScreen";
 export type SessionCreatorChatPanelHeaderLayout = "hero" | "compact";
 export type SessionCreatorChatPanelLayout = "default" | "launchpad";
+/**
+ * What the launchpad prompt says the composer produces. Sessions and projects
+ * get built; a work item is written down before anything is built, so its
+ * creator asks what to plan instead.
+ */
+export type SessionCreatorLaunchpadIntent = "build" | "plan";
 
 export interface SessionCreatorChatPanelProps {
   centerFullScreenContent?: boolean;
@@ -38,6 +44,8 @@ export interface SessionCreatorChatPanelProps {
   initialContent?: string;
   /** Launchpad keeps the identity prompt centered and the composer docked below it. */
   layout?: SessionCreatorChatPanelLayout;
+  /** Wording of the launchpad question. Defaults to "build". */
+  launchpadIntent?: SessionCreatorLaunchpadIntent;
   dropdownDirection?: DropdownDirection;
   onOpenCliTerminal?: (options: ChatPanelCliTerminalLaunchOptions) => void;
   /** Navigate to the owning Work Item creation view instead of creating inline. */

--- a/src/i18n/locales/de/sessions.json
+++ b/src/i18n/locales/de/sessions.json
@@ -2103,7 +2103,6 @@
     },
     "createTarget": {
       "agentSession": "Agent-Sitzung",
-      "manageAgents": "Agents / Skills verwalten",
       "project": "Projekt erstellen",
       "parallelRun": "Parallellauf",
       "workItem": "Work Item erstellen"
@@ -2148,6 +2147,9 @@
     "launchpadQuestion": "Was möchtest du mit",
     "launchpadQuestionSuffix": "erstellen?",
     "manualLaunchpadQuestion": "Was möchtest du erstellen?",
+    "planLaunchpadQuestion": "Was möchtest du mit",
+    "planLaunchpadQuestionSuffix": "planen?",
+    "manualPlanLaunchpadQuestion": "Was möchtest du planen?",
     "start": "Starten",
     "assign": "Zuweisen",
     "send": "Senden",

--- a/src/i18n/locales/en/sessions.json
+++ b/src/i18n/locales/en/sessions.json
@@ -2187,7 +2187,6 @@
     },
     "createTarget": {
       "agentSession": "Agent session",
-      "manageAgents": "Manage agents / skills",
       "project": "Create project",
       "parallelRun": "Parallel run",
       "workItem": "Create work item"
@@ -2237,6 +2236,9 @@
     "launchpadQuestion": "What do you want to build with",
     "launchpadQuestionSuffix": "?",
     "manualLaunchpadQuestion": "What do you want to build?",
+    "planLaunchpadQuestion": "What do you want to plan with",
+    "planLaunchpadQuestionSuffix": "?",
+    "manualPlanLaunchpadQuestion": "What do you want to plan?",
     "start": "Start",
     "assign": "Assign",
     "send": "Send",

--- a/src/i18n/locales/es/sessions.json
+++ b/src/i18n/locales/es/sessions.json
@@ -2105,7 +2105,6 @@
     },
     "createTarget": {
       "agentSession": "Sesión de Agent",
-      "manageAgents": "Gestionar Agents / Skills",
       "project": "Crear proyecto",
       "parallelRun": "Ejecución paralela",
       "workItem": "Crear Work Item"
@@ -2150,6 +2149,9 @@
     "launchpadQuestion": "¿Qué quieres crear con",
     "launchpadQuestionSuffix": "?",
     "manualLaunchpadQuestion": "¿Qué quieres crear?",
+    "planLaunchpadQuestion": "¿Qué quieres planificar con",
+    "planLaunchpadQuestionSuffix": "?",
+    "manualPlanLaunchpadQuestion": "¿Qué quieres planificar?",
     "start": "Iniciar",
     "assign": "Asignar",
     "send": "Enviar",

--- a/src/i18n/locales/fr/sessions.json
+++ b/src/i18n/locales/fr/sessions.json
@@ -2105,7 +2105,6 @@
     },
     "createTarget": {
       "agentSession": "Session Agent",
-      "manageAgents": "Gérer les Agents / Skills",
       "project": "Créer un projet",
       "parallelRun": "Exécution parallèle",
       "workItem": "Créer un Work Item"
@@ -2150,6 +2149,9 @@
     "launchpadQuestion": "Que souhaitez-vous créer avec",
     "launchpadQuestionSuffix": " ?",
     "manualLaunchpadQuestion": "Que souhaitez-vous créer ?",
+    "planLaunchpadQuestion": "Que souhaitez-vous planifier avec",
+    "planLaunchpadQuestionSuffix": " ?",
+    "manualPlanLaunchpadQuestion": "Que souhaitez-vous planifier ?",
     "start": "Démarrer",
     "assign": "Assigner",
     "send": "Envoyer",

--- a/src/i18n/locales/ja/sessions.json
+++ b/src/i18n/locales/ja/sessions.json
@@ -2104,7 +2104,6 @@
     },
     "createTarget": {
       "agentSession": "Agent セッション",
-      "manageAgents": "Agents / Skills を管理",
       "project": "プロジェクトを作成",
       "parallelRun": "並列実行",
       "workItem": "Work Item を作成"
@@ -2149,6 +2148,9 @@
     "launchpadQuestion": "",
     "launchpadQuestionSuffix": "で何を作りますか？",
     "manualLaunchpadQuestion": "何を作りますか？",
+    "planLaunchpadQuestion": "",
+    "planLaunchpadQuestionSuffix": "で何を計画しますか？",
+    "manualPlanLaunchpadQuestion": "何を計画しますか？",
     "start": "開始",
     "assign": "割り当て",
     "send": "送信",

--- a/src/i18n/locales/ko/sessions.json
+++ b/src/i18n/locales/ko/sessions.json
@@ -2104,7 +2104,6 @@
     },
     "createTarget": {
       "agentSession": "Agent 세션",
-      "manageAgents": "Agents / Skills 관리",
       "project": "프로젝트 만들기",
       "parallelRun": "병렬 실행",
       "workItem": "Work Item 만들기"
@@ -2149,6 +2148,9 @@
     "launchpadQuestion": "",
     "launchpadQuestionSuffix": "와 함께 무엇을 만들고 싶으신가요?",
     "manualLaunchpadQuestion": "무엇을 만들고 싶으신가요?",
+    "planLaunchpadQuestion": "",
+    "planLaunchpadQuestionSuffix": "와 함께 무엇을 계획하고 싶으신가요?",
+    "manualPlanLaunchpadQuestion": "무엇을 계획하고 싶으신가요?",
     "start": "시작",
     "assign": "할당",
     "send": "보내기",

--- a/src/i18n/locales/pl/sessions.json
+++ b/src/i18n/locales/pl/sessions.json
@@ -2158,7 +2158,6 @@
     },
     "createTarget": {
       "agentSession": "Sesja Agent",
-      "manageAgents": "Zarządzaj Agents / Skills",
       "project": "Utwórz projekt",
       "parallelRun": "Uruchomienie równoległe",
       "workItem": "Utwórz Work Item"
@@ -2203,6 +2202,9 @@
     "launchpadQuestion": "Co chcesz zbudować za pomocą",
     "launchpadQuestionSuffix": "?",
     "manualLaunchpadQuestion": "Co chcesz zbudować?",
+    "planLaunchpadQuestion": "Co chcesz zaplanować za pomocą",
+    "planLaunchpadQuestionSuffix": "?",
+    "manualPlanLaunchpadQuestion": "Co chcesz zaplanować?",
     "start": "Start",
     "assign": "Przypisz",
     "send": "Wyślij",

--- a/src/i18n/locales/pt/sessions.json
+++ b/src/i18n/locales/pt/sessions.json
@@ -2120,7 +2120,6 @@
     },
     "createTarget": {
       "agentSession": "Sessão de Agent",
-      "manageAgents": "Gerenciar Agents / Skills",
       "project": "Criar projeto",
       "parallelRun": "Execução paralela",
       "workItem": "Criar Work Item"
@@ -2165,6 +2164,9 @@
     "launchpadQuestion": "O que você quer criar com",
     "launchpadQuestionSuffix": "?",
     "manualLaunchpadQuestion": "O que você quer criar?",
+    "planLaunchpadQuestion": "O que você quer planejar com",
+    "planLaunchpadQuestionSuffix": "?",
+    "manualPlanLaunchpadQuestion": "O que você quer planejar?",
     "start": "Iniciar",
     "assign": "Atribuir",
     "send": "Enviar",

--- a/src/i18n/locales/ru/sessions.json
+++ b/src/i18n/locales/ru/sessions.json
@@ -2148,7 +2148,6 @@
     },
     "createTarget": {
       "agentSession": "Сессия Agent",
-      "manageAgents": "Управлять Agents / Skills",
       "project": "Создать проект",
       "parallelRun": "Параллельный запуск",
       "workItem": "Создать Work Item"
@@ -2193,6 +2192,9 @@
     "launchpadQuestion": "Что вы хотите создать с помощью",
     "launchpadQuestionSuffix": "?",
     "manualLaunchpadQuestion": "Что вы хотите создать?",
+    "planLaunchpadQuestion": "Что вы хотите запланировать с помощью",
+    "planLaunchpadQuestionSuffix": "?",
+    "manualPlanLaunchpadQuestion": "Что вы хотите запланировать?",
     "start": "Начать",
     "assign": "Назначить",
     "send": "Отправить",

--- a/src/i18n/locales/tr/sessions.json
+++ b/src/i18n/locales/tr/sessions.json
@@ -2105,7 +2105,6 @@
     },
     "createTarget": {
       "agentSession": "Agent oturumu",
-      "manageAgents": "Agents / Skills yönet",
       "project": "Proje oluştur",
       "parallelRun": "Paralel çalıştırma",
       "workItem": "Work Item oluştur"
@@ -2150,6 +2149,9 @@
     "launchpadQuestion": "",
     "launchpadQuestionSuffix": "ile ne oluşturmak istersiniz?",
     "manualLaunchpadQuestion": "Ne oluşturmak istersiniz?",
+    "planLaunchpadQuestion": "",
+    "planLaunchpadQuestionSuffix": "ile ne planlamak istersiniz?",
+    "manualPlanLaunchpadQuestion": "Ne planlamak istersiniz?",
     "start": "Başlat",
     "assign": "Ata",
     "send": "Gönder",

--- a/src/i18n/locales/vi/sessions.json
+++ b/src/i18n/locales/vi/sessions.json
@@ -2102,7 +2102,6 @@
     },
     "createTarget": {
       "agentSession": "Phiên Agent",
-      "manageAgents": "Quản lý Agents / Skills",
       "project": "Tạo dự án",
       "parallelRun": "Chạy song song",
       "workItem": "Tạo Work Item"
@@ -2147,6 +2146,9 @@
     "launchpadQuestion": "Bạn muốn xây dựng gì với",
     "launchpadQuestionSuffix": "?",
     "manualLaunchpadQuestion": "Bạn muốn xây dựng gì?",
+    "planLaunchpadQuestion": "Bạn muốn lên kế hoạch gì với",
+    "planLaunchpadQuestionSuffix": "?",
+    "manualPlanLaunchpadQuestion": "Bạn muốn lên kế hoạch gì?",
     "start": "Bắt đầu",
     "assign": "Gán",
     "send": "Gửi",

--- a/src/i18n/locales/zh-Hant/sessions.json
+++ b/src/i18n/locales/zh-Hant/sessions.json
@@ -2119,7 +2119,6 @@
     },
     "createTarget": {
       "agentSession": "Agent 會話",
-      "manageAgents": "管理 Agent / Skills",
       "project": "建立專案",
       "parallelRun": "平行執行",
       "workItem": "建立 Work Item"
@@ -2164,6 +2163,9 @@
     "launchpadQuestion": "你想使用",
     "launchpadQuestionSuffix": "建構什麼？",
     "manualLaunchpadQuestion": "你想建構什麼？",
+    "planLaunchpadQuestion": "你想使用",
+    "planLaunchpadQuestionSuffix": "規劃什麼？",
+    "manualPlanLaunchpadQuestion": "你想規劃什麼？",
     "start": "開始",
     "assign": "分配",
     "send": "發送",

--- a/src/i18n/locales/zh/sessions.json
+++ b/src/i18n/locales/zh/sessions.json
@@ -2160,7 +2160,6 @@
     },
     "createTarget": {
       "agentSession": "Agent 会话",
-      "manageAgents": "管理 Agent / Skills",
       "project": "创建项目",
       "parallelRun": "并行运行",
       "workItem": "创建 Work Item"
@@ -2210,6 +2209,9 @@
     "launchpadQuestion": "你想使用",
     "launchpadQuestionSuffix": "构建什么？",
     "manualLaunchpadQuestion": "你想构建什么？",
+    "planLaunchpadQuestion": "你想使用",
+    "planLaunchpadQuestionSuffix": "规划什么？",
+    "manualPlanLaunchpadQuestion": "你想规划什么？",
     "start": "开始",
     "assign": "分配",
     "send": "发送",

--- a/src/modules/ProjectManager/Projects/components/CreateProjectView/index.tsx
+++ b/src/modules/ProjectManager/Projects/components/CreateProjectView/index.tsx
@@ -29,6 +29,7 @@ import {
 } from "@src/api/http/project";
 import Message from "@src/components/Message";
 import type { SelectOption } from "@src/components/Select";
+import { INPUT_AREA_EDITOR_HEIGHT } from "@src/config/inputAreaTokens";
 import { org2CloudOrgsAtom } from "@src/features/Org2Cloud/org2CloudOrgsAtom";
 import { sidebarSelectedOrgIdAtom } from "@src/features/Organizations/sidebarOrgScopeAtom";
 import LaunchButton from "@src/features/SessionCreator/components/LaunchButton";
@@ -470,8 +471,11 @@ const CreateProjectView: React.FC<CreateProjectViewProps> = ({
       onDescriptionChange={handleDescriptionChange}
       titleVisible={false}
       separatorVisible={false}
-      descriptionClassName="no-bottom-border [&_textarea]:!pl-1.5"
-      descriptionMaxHeight="100%"
+      descriptionClassName="no-bottom-border [&_textarea]:!pl-1.5 [&_textarea]:!text-[14px]"
+      autoFocusDescription
+      descriptionMinRows={2}
+      descriptionMinHeight={INPUT_AREA_EDITOR_HEIGHT.min}
+      descriptionMaxHeight={INPUT_AREA_EDITOR_HEIGHT.max}
       descriptionMode={editorMode}
       onDescriptionModeChange={setEditorMode}
       repoPath={repoPath}
@@ -502,7 +506,7 @@ const CreateProjectView: React.FC<CreateProjectViewProps> = ({
               headerContent={composerHeaderContent}
               editorContent={projectEditor}
               pinnedActionsContent={projectPinnedActions}
-              leadingActions={
+              pills={
                 <MarkdownEditorModeSwitch
                   mode={editorMode}
                   onModeChange={setEditorMode}

--- a/src/modules/ProjectManager/WorkItems/components/CreateWorkItemView/InlineCreateWorkItemFields.tsx
+++ b/src/modules/ProjectManager/WorkItems/components/CreateWorkItemView/InlineCreateWorkItemFields.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from "react-i18next";
 import { type ProjectOrg, projectApi } from "@src/api/http/project";
 import { PropertyDropdownField } from "@src/components/PropertyField/PropertyDropdownField";
 import type { PropertyDropdownOption } from "@src/components/PropertyField/PropertyDropdownField";
+import { INPUT_AREA_EDITOR_HEIGHT } from "@src/config/inputAreaTokens";
 import { org2CloudOrgsAtom } from "@src/features/Org2Cloud/org2CloudOrgsAtom";
 import { resolveProjectOrgScopeId } from "@src/features/Organizations/orgSelectorEntries";
 import { sidebarSelectedOrgIdAtom } from "@src/features/Organizations/sidebarOrgScopeAtom";
@@ -103,6 +104,13 @@ export interface UseInlineCreateWorkItemFieldsOptions {
   availableProjects?: WorkItemProject[];
   chatPanelFooter?: boolean;
   defaultProjectId?: string;
+  /**
+   * Render the fields for the chat-panel composer dock rather than the
+   * full-height creator page. The dock matches the session composer it swaps
+   * with: same editor height range, same text size, and focus on the main
+   * content instead of the title.
+   */
+  dockedComposer?: boolean;
   onDraftChange?: (draft: WorkItemDraft) => void;
   onSetUnsaved: (hasUnsaved: boolean) => void;
   orgId?: string | null;
@@ -121,6 +129,7 @@ export function useInlineCreateWorkItemFields({
   availableProjects = [],
   chatPanelFooter = false,
   defaultProjectId,
+  dockedComposer = false,
   onDraftChange,
   onSetUnsaved,
   orgId: surfaceOrgId,
@@ -131,7 +140,6 @@ export function useInlineCreateWorkItemFields({
   repoPath,
 }: UseInlineCreateWorkItemFieldsOptions): InlineCreateWorkItemFieldsState {
   const { t } = useTranslation("projects");
-  const { t: tSessions } = useTranslation("sessions");
   const [editorResetKey, setEditorResetKey] = useState(0);
   const [editorMode, setEditorMode] = useState<MarkdownEditorMode>("write");
   const cloudOrgs = useAtomValue(org2CloudOrgsAtom);
@@ -444,6 +452,7 @@ export function useInlineCreateWorkItemFields({
           : workItemTitlePlaceholder
       }
       dataTestId="create-work-item-title-input"
+      autoFocus={!dockedComposer}
     />
   );
 
@@ -459,10 +468,19 @@ export function useInlineCreateWorkItemFields({
       onDescriptionChange={handleDescriptionChange}
       titleVisible={false}
       separatorVisible={false}
-      descriptionPlaceholder={tSessions("creator.placeholderDefault")}
+      descriptionPlaceholder={t("workItems.descriptionPlaceholder")}
       onImageInsert={handleImageInsert}
-      descriptionClassName="no-bottom-border [&_textarea]:!pl-1.5 [&_textarea]:!pt-0 [&_.markdown-formatting-toolbar]:!mb-1.5 [&_.markdown-formatting-toolbar]:!pl-0"
-      descriptionMaxHeight="100%"
+      descriptionClassName="no-bottom-border [&_textarea]:!pl-1.5 [&_textarea]:!pt-0 [&_textarea]:!text-[14px] [&_.markdown-formatting-toolbar]:!mb-1.5 [&_.markdown-formatting-toolbar]:!pl-0"
+      autoFocusDescription={dockedComposer}
+      // Two rows keeps the autosize floor under the explicit min height, so
+      // an empty editor is exactly as tall as the session composer.
+      descriptionMinRows={2}
+      descriptionMinHeight={
+        dockedComposer ? INPUT_AREA_EDITOR_HEIGHT.min : undefined
+      }
+      descriptionMaxHeight={
+        dockedComposer ? INPUT_AREA_EDITOR_HEIGHT.max : "100%"
+      }
       descriptionMode={editorMode}
       onDescriptionModeChange={setEditorMode}
       repoPath={repoPath}

--- a/src/modules/ProjectManager/WorkItems/components/CreateWorkItemView/index.tsx
+++ b/src/modules/ProjectManager/WorkItems/components/CreateWorkItemView/index.tsx
@@ -146,6 +146,7 @@ const CreateWorkItemView: React.FC<CreateWorkItemViewProps> = ({
     availableProjects,
     chatPanelFooter,
     defaultProjectId: projectId,
+    dockedComposer: Boolean(renderAgentComposer),
     onDraftChange,
     onSetUnsaved,
     orgId,
@@ -385,7 +386,7 @@ const CreateWorkItemView: React.FC<CreateWorkItemViewProps> = ({
               headerContent={composerHeaderContent}
               editorContent={inlineFields.descriptionSection}
               pinnedActionsContent={workItemPropertyPills}
-              leadingActions={
+              pills={
                 <MarkdownEditorModeSwitch
                   mode={inlineFields.editorMode}
                   onModeChange={inlineFields.setEditorMode}

--- a/src/modules/ProjectManager/shared/components/CreateComposerScaffold.tsx
+++ b/src/modules/ProjectManager/shared/components/CreateComposerScaffold.tsx
@@ -8,6 +8,11 @@ import { PropertyDropdownDirectionProvider } from "@src/components/PropertyField
 import { DETAIL_PANEL_TOKENS } from "@src/config/detailPanelTokens";
 
 export interface CreateComposerTitleInputProps {
+  /**
+   * Focus the title on mount. The docked composer leaves this off: its main
+   * content field takes the focus, matching the agent composer it swaps with.
+   */
+  autoFocus?: boolean;
   dataTestId: string;
   onChange: (value: string) => void;
   placeholder: string;
@@ -16,6 +21,7 @@ export interface CreateComposerTitleInputProps {
 
 /** Title field shared by Project and Work Item create composers. */
 export function CreateComposerTitleInput({
+  autoFocus = false,
   dataTestId,
   onChange,
   placeholder,
@@ -27,7 +33,7 @@ export function CreateComposerTitleInput({
       value={value}
       onChange={onChange}
       placeholder={placeholder}
-      autoFocus
+      autoFocus={autoFocus}
       appearance="ghost"
       size="small"
       className="flex-1 focus-within:!bg-transparent hover:!bg-transparent"
@@ -46,7 +52,7 @@ export function CreateComposerHeader({
 }) {
   return (
     <div data-testid={dataTestId}>
-      <div className="flex h-8 items-center px-1 py-0">{children}</div>
+      <div className="flex h-8 items-center px-1.5 py-0">{children}</div>
       <div className="px-2" aria-hidden>
         <div className="border-t border-border-2" />
       </div>
@@ -85,7 +91,8 @@ export interface ManualCreateComposerProps {
   editorRef: RefObject<ManualCreateEditorRef | null>;
   headerContent: ReactNode;
   pinnedActionsContent: ReactNode;
-  leadingActions?: ReactNode;
+  /** Pill controls rendered after the + button. */
+  pills?: ReactNode;
   submitButton?: ReactNode;
 }
 
@@ -96,7 +103,7 @@ export function ManualCreateComposer({
   editorRef,
   headerContent,
   pinnedActionsContent,
-  leadingActions,
+  pills,
   submitButton,
 }: ManualCreateComposerProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -129,12 +136,11 @@ export function ManualCreateComposer({
             onOpenSkillsTools={() => editorRef.current?.triggerSlashContext()}
             dropdownDirection="up"
             showContextInfo={false}
-            secondaryControlsPosition="right"
-            leadingActions={leadingActions}
+            pills={pills}
             trailingActions={submitButton}
           >
             {headerContent}
-            <div className="min-h-0 px-1">{editorContent}</div>
+            <div className="min-h-0 px-1.5">{editorContent}</div>
           </ComposerSurface>
           <input
             ref={fileInputRef}

--- a/src/modules/ProjectManager/shared/components/ProjectContentEditor/index.tsx
+++ b/src/modules/ProjectManager/shared/components/ProjectContentEditor/index.tsx
@@ -55,6 +55,7 @@ export interface ProjectContentEditorProps {
   summaryPlaceholder?: string;
   descriptionPlaceholder?: string;
   autoFocusTitle?: boolean;
+  autoFocusDescription?: boolean;
   editable?: boolean;
   className?: string;
   titleVisible?: boolean;
@@ -66,6 +67,7 @@ export interface ProjectContentEditorProps {
   descriptionMode?: MarkdownEditorMode;
   onDescriptionModeChange?: (mode: MarkdownEditorMode) => void;
   descriptionMinHeight?: number;
+  descriptionMinRows?: number;
   descriptionMaxHeight?: number | string;
   repoPath?: string | null;
   dataTestId?: string;
@@ -130,6 +132,7 @@ const ProjectContentEditor = forwardRef<
       summaryPlaceholder: summaryPlaceholderProp,
       descriptionPlaceholder: descriptionPlaceholderProp,
       autoFocusTitle = false,
+      autoFocusDescription = false,
       editable = true,
       className = "",
       titleVisible = true,
@@ -141,6 +144,7 @@ const ProjectContentEditor = forwardRef<
       descriptionMode,
       onDescriptionModeChange,
       descriptionMinHeight = 200,
+      descriptionMinRows,
       descriptionMaxHeight,
       repoPath,
       dataTestId,
@@ -385,7 +389,9 @@ const ProjectContentEditor = forwardRef<
                 slashCommandKeyboardHandlerRef.current?.(event) ?? false
               }
               onImageInsert={editable ? onImageInsert : undefined}
+              autoFocus={autoFocusDescription}
               minHeight={descriptionMinHeight}
+              minRows={descriptionMinRows}
               maxHeight={descriptionMaxHeight}
               editable={editable}
               mode={descriptionMode}

--- a/src/modules/shared/components/MarkdownTextareaEditor/index.tsx
+++ b/src/modules/shared/components/MarkdownTextareaEditor/index.tsx
@@ -84,6 +84,12 @@ export interface MarkdownTextareaEditorProps {
   onChange: (markdown: string, plainText: string) => void;
   placeholder?: string;
   minHeight?: number | string;
+  /**
+   * Rows the autosize floor reserves. The floor is applied as an explicit
+   * height, so it wins over `minHeight` whenever it is taller — a composer
+   * that wants `minHeight` to govern passes a smaller value.
+   */
+  minRows?: number;
   maxHeight?: number | string;
   maxLength?: number;
   disabled?: boolean;
@@ -155,6 +161,7 @@ const MarkdownTextareaEditor = forwardRef<
     onChange,
     placeholder,
     minHeight = 72,
+    minRows = 3,
     maxHeight = 240,
     maxLength,
     disabled = false,
@@ -563,8 +570,8 @@ const MarkdownTextareaEditor = forwardRef<
             placeholder={placeholder}
             size="small"
             appearance="bare"
-            autoSize={{ minRows: 3, maxRows: 10 }}
-            rows={3}
+            autoSize={{ minRows, maxRows: 10 }}
+            rows={minRows}
             maxLength={maxLength}
             disabled={!canWrite}
             autoFocus={autoFocus}

--- a/src/store/ui/chatPanel/selectionAtoms.ts
+++ b/src/store/ui/chatPanel/selectionAtoms.ts
@@ -29,7 +29,6 @@ export const CHAT_PANEL_CREATE_TARGET = {
   AGENT_SESSION: "agentSession",
   /** One prompt, several harnesses, started at once and compared after. */
   PARALLEL_RUN: "parallelRun",
-  MANAGE_AGENTS: "manageAgents",
   PROJECT: "project",
   GITHUB_ISSUES_PROJECT: "githubIssuesProject",
   WORK_ITEM: "workItem",


### PR DESCRIPTION
## Problem

The launchpad composer had exactly one wording — "What do you want to build
with …?" — so a composer opened to plan work rather than build it asked the
wrong question. There was no way for a caller to say which it wanted.

Two smaller problems ride along:

- The docked create composer and the agent composer swap into the same slot but
  did not agree on layout: the docked one stole focus to its title field, sat on
  different header padding, and reached its action row through a differently
  named `ComposerSurface` slot.
- The chat panel's create-target dropdown still offered "Manage agents /
  skills", which is not a create target — it navigates to agent management.

## Solution

Add a `launchpadIntent` prop (`"build" | "plan"`) to `ChatPanelProps`, threaded
through `ChatPanelEmptyContent` and the SessionCreator ChatPanel variant, that
selects between the existing build phrasing and new plan phrasing. Three keys
added across all 13 locales: `planLaunchpadQuestion`,
`planLaunchpadQuestionSuffix`, `manualPlanLaunchpadQuestion`. `"build"` is the
default, so every existing caller keeps its current wording.

Supporting changes:

- **Composer alignment.** `ComposerSurface`'s `leadingActions` slot becomes
  `pills` and `secondaryControlsPosition` drops out;
  `CreateComposerTitleInput` takes an opt-in `autoFocus` so the docked composer
  can leave focus on its main content field, matching the agent composer it
  swaps with; `MarkdownTextareaEditor` gains `minRows` so a composer can let
  `minHeight` govern its floor rather than the 3-row default. Header padding
  moves `px-1` → `px-1.5`.
- **Create target removed.** "Manage agents / skills" leaves the dropdown,
  along with its ADE-manager wiring in `useChatPanelCreateTarget` and the
  `sessions:creator.createTarget.manageAgents` key in every locale.

## Potential risks

- **`ComposerSurface` is shared.** Renaming `leadingActions` → `pills` and
  dropping `secondaryControlsPosition` is a breaking prop change; every call
  site in the repo is updated in this PR, and `tsc` would fail on a missed one,
  but a consumer added on another branch in flight would conflict.
- **Focus behaviour changed** for the docked create composer — the title field
  no longer autofocuses. That is the intent (the content field takes focus), but
  it is a visible interaction change worth a click-through in review.
- **Removing a create target is user-visible.** Anyone using "Manage agents /
  skills" from that dropdown loses the entry point; agent management remains
  reachable by its own navigation.
- Padding and `minRows` changes are cosmetic but touch shared components, so
  they affect every create composer, not only the plan one.
- No dependency, lockfile, schema, IPC, wire or persistence change.

**Scope note:** this is one composer-behaviour change with two supporting
threads. The create-target removal is separable from the plan intent if a
reviewer would rather see it on its own — happy to split.

## Verification

| Command | Result |
| --- | --- |
| `tsc --noEmit --pretty false` | clean (exit 0) |
| `eslint` over all 18 changed `.ts`/`.tsx` files, `--max-warnings 0` | clean (exit 0) |
| `vitest run` | **1248 files / 9781 tests passed** |

`ChatPanelStartPage.test.ts` is updated in this PR and covers the intent
switch.

**Not run:** the E2E suite, and no screenshots are attached. The change is a
wording switch plus focus/padding adjustments on the composer — worth a
click-through by someone who can see both intents side by side, which I could
not do from the diff alone.
