### PR TITLE
feat(chat-panel): remove tab chrome the pane has no use for

### DIFF
--- a/src/engines/ChatPanel/ChatPanelHeader.test.ts
+++ b/src/engines/ChatPanel/ChatPanelHeader.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment jsdom
+import type { TFunction } from "i18next";
+import { type ReactNode, createElement, createRef } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./components/SessionHeaderActionsMenu", () => ({
+  SessionHeaderActionsMenu: () =>
+    createElement("button", { "data-session-actions": "true" }),
+}));
+vi.mock("@src/scaffold/NavigationSidebar/CollapsedSidebarButton", () => ({
+  CollapsedSidebarButton: () =>
+    createElement("button", { "data-collapsed-sidebar": "true" }),
+}));
+vi.mock("@src/components/KeyboardShortcut/ToolbarTooltip", () => ({
+  // The real tooltip portals into document.body, which the static renderer
+  // rejects; the controls under test are its children.
+  ToolbarTooltip: ({ children }: { children: ReactNode }) => children,
+}));
+vi.mock("./header/ChatPanelCollapsedTabHeading", () => ({
+  ChatPanelCollapsedTabHeading: () =>
+    createElement("span", { "data-collapsed-heading": "true" }),
+}));
+
+const { getCollapsedSidebarChromeOffset } =
+  await import("@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset");
+const { ChatPanelHeader } = await import("./ChatPanelHeader");
+
+const noop = () => undefined;
+
+interface RenderOptions {
+  tabRowCollapsed: boolean;
+  canCloseActiveTab?: boolean;
+  sessionHeaderContent?: ReactNode;
+  shouldOffsetHeaderForCollapsedSidebar?: boolean;
+}
+
+function render({
+  tabRowCollapsed,
+  canCloseActiveTab = true,
+  sessionHeaderContent = createElement("span", { "data-session-name": "true" }),
+  shouldOffsetHeaderForCollapsedSidebar = false,
+}: RenderOptions): string {
+  return renderToStaticMarkup(
+    createElement(ChatPanelHeader, {
+      activeSessionExists: true,
+      copyEventJsonLabel: "idle" as const,
+      currentSessionId: "session-a",
+      displayMode: "full" as const,
+      eventsLength: 3,
+      handleChatFocusToggle: noop,
+      handleCompactDisplayModeToggle: noop,
+      handleCopyEventJson: noop,
+      handleMoveToWorkstation: noop,
+      handleOpenExportSessionJson: noop,
+      handleOpenLinkWorkItem: noop,
+      handleOpenCloudShareSettings: noop,
+      handleOpenRawTranscript: noop,
+      handleOpenSearch: noop,
+      handlePaginationToggle: noop,
+      handleReloadFromMenu: noop,
+      handleTokenUsageVisibleToggle: noop,
+      handleTurnMetadataVisibleToggle: noop,
+      headerActionsDropdownRef: createRef<HTMLDivElement>(),
+      headerActionsPosition: { left: 0, width: 240, maxHeight: 480 },
+      headerActionsTriggerRef: createRef<HTMLButtonElement>(),
+      isChatFocus: true,
+      isHeaderActionsOpen: false,
+      isHeaderActionsPositioned: false,
+      paginationEnabled: false,
+      tokenUsageVisible: false,
+      turnMetadataVisible: false,
+      shouldOffsetHeaderForCollapsedSidebar,
+      stationAvailable: true,
+      showHeader: true,
+      showSessionContent: true,
+      showCloudShareSettings: false,
+      t: ((key: string) => key) as unknown as TFunction<
+        ["sessions", "common", "projects", "navigation"]
+      >,
+      toggleHeaderActionsMenu: noop,
+      visibleRegionNotice: null,
+      showTuiModeToggle: false,
+      tuiMode: false,
+      handleTuiModeToggle: noop,
+      tabStrip: createElement("nav", { "data-tab-strip": "true" }),
+      tabStripPlus: createElement("button", { "data-plus-menu": "true" }),
+      tabRowCollapsed,
+      onCloseActiveTab: noop,
+      canCloseActiveTab,
+      sessionHeaderContent,
+    })
+  );
+}
+
+describe("ChatPanelHeader tab row collapse", () => {
+  it("keeps both rows while the tab strip is worth showing", () => {
+    const markup = render({ tabRowCollapsed: false });
+
+    expect(markup).toContain('data-testid="chat-panel-header"');
+    expect(markup).toContain('data-tab-strip="true"');
+    expect(markup).toContain('data-testid="chat-panel-published-header"');
+    expect(markup).toContain("border-b border-border-2");
+    expect(markup).not.toContain(
+      'data-testid="chat-panel-collapsed-tab-controls"'
+    );
+    expect(markup).toContain('style="height:80px"');
+  });
+
+  it("drops the tab row and rehomes its controls onto the 40px row", () => {
+    const markup = render({ tabRowCollapsed: true });
+
+    expect(markup).not.toContain('data-testid="chat-panel-header"');
+    expect(markup).not.toContain('data-tab-strip="true"');
+    expect(markup).toContain('data-testid="chat-panel-published-header"');
+    expect(markup).toContain('data-testid="chat-panel-collapsed-tab-controls"');
+    // + / restore / close all survive the fold.
+    expect(markup).toContain('data-plus-menu="true"');
+    expect(markup).toContain('data-icon="panel-right"');
+    // Swapped, never cross-faded — overlapping the two near-identical
+    // outlines is what made the icon shake on hover.
+    expect(markup).toContain("group-hover:hidden");
+    expect(markup).toContain("hidden group-hover:block");
+    expect(markup).not.toContain("transition-opacity");
+    expect(markup).toContain('data-icon="x"');
+    expect(markup).toContain('style="height:44px"');
+    // The maximized pane's only chrome — no rule under it.
+    expect(markup).not.toContain("border-b border-border-2");
+    // The window-edge gap the folded 44px row used to hold (its pt-2).
+    expect(markup).toContain('data-testid="chat-panel-collapsed-header"');
+    expect(markup).toContain("padding-top:8px");
+  });
+
+  it("names a surface that publishes no header content of its own", () => {
+    const unpublished = render({
+      tabRowCollapsed: true,
+      sessionHeaderContent: null,
+    });
+
+    expect(unpublished).toContain('data-collapsed-heading="true"');
+    expect(render({ tabRowCollapsed: true })).not.toContain(
+      'data-collapsed-heading="true"'
+    );
+  });
+
+  it("moves the collapsed-sidebar button and its platform inset onto the row that leads the pane", () => {
+    const collapsed = render({
+      tabRowCollapsed: true,
+      shouldOffsetHeaderForCollapsedSidebar: true,
+    });
+
+    // The 40px row is now the pane's top edge, so it owns the reservation for
+    // the host window controls (macOS traffic lights) the tab row used to hold.
+    expect(collapsed).toContain('data-collapsed-sidebar="true"');
+    expect(collapsed).toContain(
+      `padding-left:${getCollapsedSidebarChromeOffset()}px`
+    );
+    expect(collapsed).not.toContain("pl-[15px]");
+
+    // With the sidebar expanded it owns that reservation, so the row keeps the
+    // shared published-header inset.
+    const withSidebar = render({ tabRowCollapsed: true });
+    expect(withSidebar).not.toContain("padding-left:");
+    expect(withSidebar).toContain("pl-[15px]");
+  });
+});
+
+describe("collapsed close control", () => {
+  it("is dropped for a surface that cannot be closed away", () => {
+    const markup = render({ tabRowCollapsed: true, canCloseActiveTab: false });
+
+    expect(markup).toContain('data-testid="chat-panel-collapsed-tab-controls"');
+    expect(markup).toContain('data-plus-menu="true"');
+    expect(markup).not.toContain('data-icon="x"');
+  });
+});

--- a/src/engines/ChatPanel/ChatPanelHeader.tsx
+++ b/src/engines/ChatPanel/ChatPanelHeader.tsx
@@ -11,6 +11,7 @@ import type { DropdownEnginePosition } from "@src/hooks/dropdown";
 import { getCollapsedSidebarChromeOffset } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
 import {
   ArrowExpand01Icon,
+  Cancel01Icon,
   ComputerVideoIcon,
   HugeiconsIcon,
   PanelRightIcon,
@@ -26,12 +27,15 @@ import { SessionHeaderActionsMenu } from "./components/SessionHeaderActionsMenu"
 import {
   CHAT_PANEL_HEADER_DRAG_STYLE,
   CHAT_PANEL_HEADER_NO_DRAG_STYLE,
+  ChatPanelCollapsedTabHeading,
   ChatPanelPublishedHeader,
   chatPanelHeaderSlotsAtom,
 } from "./header";
 import {
+  CHAT_PANEL_COLLAPSED_HEADER_HEIGHT_PX,
   CHAT_PANEL_GLASS_SURFACE_CLASS,
   CHAT_PANEL_HEADER_STACK_HEIGHT_PX,
+  CHAT_PANEL_HEADER_TOP_PADDING_PX,
   CHAT_PANEL_TAB_HEADER_HEIGHT_PX,
 } from "./header/chatPanelHeaderLayout";
 import type { ChatPanelRegionNotice } from "./types";
@@ -84,6 +88,15 @@ interface ChatPanelHeaderProps {
   tabStrip: React.ReactNode;
   /** When provided, rendered before the ... button (tab-strip + menu replacement) */
   tabStripPlus?: React.ReactNode;
+  /**
+   * Fold the 44px tab row into the published 40px row, which then hosts the
+   * tab controls the folded row would have carried.
+   */
+  tabRowCollapsed: boolean;
+  /** Close the pane's only tab from the collapsed row. */
+  onCloseActiveTab: () => void;
+  /** Whether that close control is offered at all — see the layout rule. */
+  canCloseActiveTab: boolean;
   /** Session-scoped extras (fork button / provenance chip), leading the toolbar */
   sessionHeaderExtras?: React.ReactNode;
   /** Canonical session-name breadcrumb rendered in the published 40px row. */
@@ -135,6 +148,9 @@ export function ChatPanelHeader({
   handleTuiModeToggle,
   tabStrip,
   tabStripPlus,
+  tabRowCollapsed,
+  onCloseActiveTab,
+  canCloseActiveTab,
   sessionHeaderExtras,
   sessionHeaderContent,
   overlayPublishedHeader = false,
@@ -245,22 +261,52 @@ export function ChatPanelHeader({
         )}
       </div>
     ) : null;
-  const effectivePublishedHeaderSlots =
-    publishedHeaderSlots || sessionHeaderContent || sessionPublishedActions
-      ? {
-          leading: publishedHeaderSlots?.leading,
-          content: publishedHeaderSlots?.content ?? sessionHeaderContent,
-          joinWithFollowingRow:
-            publishedHeaderSlots?.joinWithFollowingRow ?? false,
-          trailing:
-            publishedHeaderSlots?.trailing || sessionPublishedActions ? (
-              <div className="flex shrink-0 items-center gap-px">
-                {publishedHeaderSlots?.trailing}
-                {sessionPublishedActions}
-              </div>
-            ) : null,
-        }
-      : null;
+  const chatFocusToggleButton = (
+    <span className="inline-flex">
+      <TabBarTrailingIconButton
+        title={isChatFocus ? shrinkToWorkstationLabel : chatFocusLabel}
+        shortcutId={stationAvailable ? "maximize_chat" : undefined}
+        tooltipPosition="bottom-end"
+        nativeTitle={false}
+        onClick={stationAvailable ? handleChatFocusToggle : undefined}
+        disabled={!stationAvailable}
+        className="group"
+      >
+        {isChatFocus ? (
+          // Swapped with `hidden`, never cross-faded. Both glyphs draw the
+          // same rounded-rect outline from different path strings (opposite
+          // winding, different start point); fading one through the other
+          // rasterizes that identical outline twice at slightly different
+          // anti-aliasing, which reads as the icon shaking. Only ever
+          // painting one keeps the hover to what actually differs — the
+          // chevron `PanelRightOpenIcon` adds.
+          <span className="flex h-4 w-4 items-center justify-center">
+            <HugeiconsIcon
+              icon={PanelRightIcon}
+              data-icon="panel-right"
+              size={HEADER_ICON_SIZE.md}
+              strokeWidth={1.75}
+              className="group-hover:hidden"
+            />
+            <HugeiconsIcon
+              icon={PanelRightOpenIcon}
+              data-icon="panel-right-open"
+              size={HEADER_ICON_SIZE.md}
+              strokeWidth={1.75}
+              className="hidden group-hover:block"
+            />
+          </span>
+        ) : (
+          <HugeiconsIcon
+            icon={ArrowExpand01Icon}
+            data-icon="maximize-2"
+            size={HEADER_ICON_SIZE.md}
+            strokeWidth={1.75}
+          />
+        )}
+      </TabBarTrailingIconButton>
+    </span>
+  );
 
   const tabBarToolbar = (
     <div
@@ -268,44 +314,116 @@ export function ChatPanelHeader({
       style={CHAT_PANEL_HEADER_NO_DRAG_STYLE}
     >
       {tabStripPlus}
-      <span className="inline-flex">
-        <TabBarTrailingIconButton
-          title={isChatFocus ? shrinkToWorkstationLabel : chatFocusLabel}
-          shortcutId={stationAvailable ? "maximize_chat" : undefined}
-          tooltipPosition="bottom-end"
-          nativeTitle={false}
-          onClick={stationAvailable ? handleChatFocusToggle : undefined}
-          disabled={!stationAvailable}
-          className="group"
-        >
-          {isChatFocus ? (
-            <span className="relative flex h-4 w-4 items-center justify-center">
-              <HugeiconsIcon
-                icon={PanelRightIcon}
-                data-icon="panel-right"
-                size={HEADER_ICON_SIZE.md}
-                strokeWidth={1.75}
-                className="absolute transition-opacity duration-150 group-hover:opacity-0"
-              />
-              <HugeiconsIcon
-                icon={PanelRightOpenIcon}
-                data-icon="panel-right-open"
-                size={HEADER_ICON_SIZE.md}
-                strokeWidth={1.75}
-                className="absolute opacity-0 transition-opacity duration-150 group-hover:opacity-100"
-              />
-            </span>
-          ) : (
+      {chatFocusToggleButton}
+    </div>
+  );
+
+  // The folded tab row's controls, rehomed on the published row. Close stays
+  // outermost so it keeps the far-right position it held on the pill, and is
+  // dropped entirely on the Launchpad, which cannot be closed away.
+  const collapsedTabControls = (
+    <div
+      className="flex h-7 flex-shrink-0 items-center gap-px"
+      style={CHAT_PANEL_HEADER_NO_DRAG_STYLE}
+      data-testid="chat-panel-collapsed-tab-controls"
+    >
+      {tabStripPlus}
+      {chatFocusToggleButton}
+      {canCloseActiveTab && (
+        <span className="inline-flex">
+          <TabBarTrailingIconButton
+            title={t("common:actions.close")}
+            tooltipPosition="bottom-end"
+            nativeTitle={false}
+            onClick={onCloseActiveTab}
+          >
             <HugeiconsIcon
-              icon={ArrowExpand01Icon}
-              data-icon="maximize-2"
+              icon={Cancel01Icon}
+              data-icon="x"
               size={HEADER_ICON_SIZE.md}
               strokeWidth={1.75}
             />
-          )}
-        </TabBarTrailingIconButton>
-      </span>
+          </TabBarTrailingIconButton>
+        </span>
+      )}
     </div>
+  );
+
+  const publishedContent =
+    publishedHeaderSlots?.content ?? sessionHeaderContent;
+  // While collapsed this row is the pane's only chrome, so it renders even for
+  // a surface that publishes nothing — otherwise folding the tab row would
+  // strip the new-tab, close, and restore controls with it.
+  const effectivePublishedHeaderSlots =
+    tabRowCollapsed ||
+    publishedHeaderSlots ||
+    sessionHeaderContent ||
+    sessionPublishedActions
+      ? {
+          leading: publishedHeaderSlots?.leading,
+          content:
+            publishedContent ??
+            (tabRowCollapsed ? <ChatPanelCollapsedTabHeading /> : undefined),
+          // Collapsed, this row stands in for the borderless tab row and is
+          // the maximized pane's only chrome — a rule under it would be a
+          // line the pane never had. Uncollapsed, the publisher decides.
+          joinWithFollowingRow:
+            tabRowCollapsed ||
+            (publishedHeaderSlots?.joinWithFollowingRow ?? false),
+          trailing:
+            publishedHeaderSlots?.trailing ||
+            sessionPublishedActions ||
+            tabRowCollapsed ? (
+              <div className="flex shrink-0 items-center gap-px">
+                {publishedHeaderSlots?.trailing}
+                {sessionPublishedActions}
+                {tabRowCollapsed ? collapsedTabControls : null}
+              </div>
+            ) : null,
+        }
+      : null;
+
+  const collapsedSidebarChrome = shouldOffsetHeaderForCollapsedSidebar ? (
+    <div style={CHAT_PANEL_HEADER_NO_DRAG_STYLE}>
+      <CollapsedSidebarButton />
+    </div>
+  ) : null;
+
+  // Whichever row sits at the pane's top edge owns the window-edge gap, the
+  // collapsed-sidebar button, and the inset that keeps the host window's own
+  // controls clear of the content — the tab row's job until it folds away.
+  // Padding the wrapper rather than the row keeps the row's 40px content band
+  // intact, and makes it the positioning context the sidebar button centers in.
+  const publishedHeaderRow = tabRowCollapsed ? (
+    <div
+      className={`workspace-header header-tab-group relative z-40 flex flex-shrink-0 flex-col`}
+      data-testid="chat-panel-collapsed-header"
+      data-tauri-drag-region={windowsHost ? undefined : true}
+      style={
+        {
+          paddingTop: CHAT_PANEL_HEADER_TOP_PADDING_PX,
+          ...(windowsHost
+            ? CHAT_PANEL_HEADER_NO_DRAG_STYLE
+            : CHAT_PANEL_HEADER_DRAG_STYLE),
+        } as React.CSSProperties
+      }
+    >
+      {collapsedSidebarChrome}
+      <ChatPanelPublishedHeader
+        slots={effectivePublishedHeaderSlots}
+        windowsHost={windowsHost}
+        leadingInsetPx={
+          shouldOffsetHeaderForCollapsedSidebar
+            ? getCollapsedSidebarChromeOffset()
+            : undefined
+        }
+      />
+    </div>
+  ) : (
+    <ChatPanelPublishedHeader
+      slots={effectivePublishedHeaderSlots}
+      windowsHost={windowsHost}
+    />
   );
 
   return (
@@ -315,53 +433,51 @@ export function ChatPanelHeader({
         data-testid="chat-panel-header-glass"
         aria-hidden
         style={{
-          height: effectivePublishedHeaderSlots
-            ? CHAT_PANEL_HEADER_STACK_HEIGHT_PX
-            : CHAT_PANEL_TAB_HEADER_HEIGHT_PX,
+          height: tabRowCollapsed
+            ? CHAT_PANEL_COLLAPSED_HEADER_HEIGHT_PX
+            : effectivePublishedHeaderSlots
+              ? CHAT_PANEL_HEADER_STACK_HEIGHT_PX
+              : CHAT_PANEL_TAB_HEADER_HEIGHT_PX,
         }}
       />
       {/* pl-1 (4px) + separator slot (5px) + pill px-2.5 (10px) = 19px, so the
           first tab's icon lines up with the published header's icon below
           (HEADER_CONTENT_LEFT_PADDING_CLASS 15px + breadcrumb px-1 4px). */}
-      <div
-        className={`workspace-header header-tab-group z-40 flex h-11 min-h-11 items-center gap-1.5 pl-1 pr-[7px] pt-2 ${
-          overlayPublishedHeader
-            ? "absolute left-0 right-0 top-0"
-            : "relative flex-shrink-0"
-        }`}
-        data-testid="chat-panel-header"
-        data-tauri-drag-region={windowsHost ? undefined : true}
-        style={
-          {
-            paddingLeft: shouldOffsetHeaderForCollapsedSidebar
-              ? getCollapsedSidebarChromeOffset()
-              : undefined,
-            ...(windowsHost
-              ? CHAT_PANEL_HEADER_NO_DRAG_STYLE
-              : CHAT_PANEL_HEADER_DRAG_STYLE),
-          } as React.CSSProperties
-        }
-      >
-        {shouldOffsetHeaderForCollapsedSidebar ? (
-          <div style={CHAT_PANEL_HEADER_NO_DRAG_STYLE}>
-            <CollapsedSidebarButton />
-          </div>
-        ) : null}
-        {tabStrip}
-        {tabBarToolbar}
-      </div>
+      {tabRowCollapsed ? null : (
+        <div
+          className={`workspace-header header-tab-group z-40 flex h-11 min-h-11 items-center gap-1.5 pl-1 pr-[7px] pt-2 ${
+            overlayPublishedHeader
+              ? "absolute left-0 right-0 top-0"
+              : "relative flex-shrink-0"
+          }`}
+          data-testid="chat-panel-header"
+          data-tauri-drag-region={windowsHost ? undefined : true}
+          style={
+            {
+              paddingLeft: shouldOffsetHeaderForCollapsedSidebar
+                ? getCollapsedSidebarChromeOffset()
+                : undefined,
+              ...(windowsHost
+                ? CHAT_PANEL_HEADER_NO_DRAG_STYLE
+                : CHAT_PANEL_HEADER_DRAG_STYLE),
+            } as React.CSSProperties
+          }
+        >
+          {collapsedSidebarChrome}
+          {tabStrip}
+          {tabBarToolbar}
+        </div>
+      )}
       {overlayPublishedHeader && effectivePublishedHeaderSlots ? (
-        <div className="absolute left-0 right-0 top-11 z-40">
-          <ChatPanelPublishedHeader
-            slots={effectivePublishedHeaderSlots}
-            windowsHost={windowsHost}
-          />
+        <div
+          className={`absolute left-0 right-0 z-40 ${
+            tabRowCollapsed ? "top-0" : "top-11"
+          }`}
+        >
+          {publishedHeaderRow}
         </div>
       ) : (
-        <ChatPanelPublishedHeader
-          slots={effectivePublishedHeaderSlots}
-          windowsHost={windowsHost}
-        />
+        publishedHeaderRow
       )}
     </>
   );

--- a/src/engines/ChatPanel/ChatPanelTabBar/TabPill.tsx
+++ b/src/engines/ChatPanel/ChatPanelTabBar/TabPill.tsx
@@ -49,9 +49,9 @@ import {
 } from "@src/store/ui/chatPanelAtom";
 import { WORK_MANAGEMENT_SECTION } from "@src/store/workstation";
 
-import { resolveChatPanelTabDisplayTitle } from "../chatPanelTabDisplay";
 import SessionIdentityIcon from "../components/SessionIdentityIcon";
 import { CHAT_PANEL_HEADER_NO_DRAG_STYLE } from "../header";
+import { useChatPanelTabDisplayTitle } from "../hooks/useChatPanelTabDisplayTitle";
 import { TabPillHoverCard } from "./TabPillHoverCard";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -122,30 +122,7 @@ export const TabPill = memo(function TabPill({
       : undefined;
   const agentStatus = terminalSession?.agentStatus;
 
-  const defaultDisplayTitle = resolveChatPanelTabDisplayTitle(tab, session, {
-    newSession: t("sessions:chat.startPage.newSession.title"),
-    runtime: t("sessions:chat.startPage.tabs.runtime"),
-    organization: t("navigation:collaboration.manageOrg"),
-    teamInbox: t("navigation:labels.inbox"),
-    channelFallback: t("navigation:cloud.channels.title"),
-    workManagement: {
-      kanban: t("sessions:simulator.tabs.kanban"),
-      work: t("navigation:labels.workItems"),
-    },
-    sessionFallback: t("chat.defaultTitle"),
-  });
-  const displayTitle =
-    tab.type !== "start-page"
-      ? defaultDisplayTitle
-      : createTarget === CHAT_PANEL_CREATE_TARGET.PROJECT
-        ? t("sessions:creator.createTarget.project")
-        : createTarget === CHAT_PANEL_CREATE_TARGET.WORK_ITEM
-          ? t("sessions:creator.createTarget.workItem")
-          : createTarget === CHAT_PANEL_CREATE_TARGET.GITHUB_ISSUES_PROJECT
-            ? t("projects:githubIssuesImport.createTarget")
-            : createTarget === CHAT_PANEL_CREATE_TARGET.COLLAB_ORG
-              ? t("navigation:collaboration.addOrg")
-              : defaultDisplayTitle;
+  const displayTitle = useChatPanelTabDisplayTitle(tab);
 
   const iconColorClass = isActive ? "text-text-1" : "text-text-2";
   const isGitHubIssueTab =

--- a/src/engines/ChatPanel/focusedChatWorkstationLayout.test.ts
+++ b/src/engines/ChatPanel/focusedChatWorkstationLayout.test.ts
@@ -93,8 +93,8 @@ describe("resolveFocusedChatWorkstationRailInsetStyle", () => {
         CHAT_PANEL_HEADER_STACK_HEIGHT_PX
       )
     ).toEqual({
-      marginTop: "84px",
-      height: "calc(100% - 84px)",
+      marginTop: `${CHAT_PANEL_HEADER_STACK_HEIGHT_PX}px`,
+      height: `calc(100% - ${CHAT_PANEL_HEADER_STACK_HEIGHT_PX}px)`,
     });
   });
 

--- a/src/engines/ChatPanel/header/ChatPanelCollapsedTabHeading.tsx
+++ b/src/engines/ChatPanel/header/ChatPanelCollapsedTabHeading.tsx
@@ -1,0 +1,31 @@
+import { useAtomValue } from "jotai";
+import React, { memo } from "react";
+
+import {
+  type ChatPanelTab,
+  activeChatPanelTabAtom,
+} from "@src/store/chatPanel/chatPanelTabsAtom";
+
+import { useChatPanelTabDisplayTitle } from "../hooks/useChatPanelTabDisplayTitle";
+
+const CollapsedTabHeadingLabel: React.FC<{ tab: ChatPanelTab }> = ({ tab }) => (
+  <span className="truncate px-1 text-[13px] font-medium text-text-1">
+    {useChatPanelTabDisplayTitle(tab)}
+  </span>
+);
+
+/**
+ * Names the lone surface in the collapsed 40px header.
+ *
+ * Only surfaces that publish no header content of their own reach this: with
+ * the tab row folded away, a terminal or Launchpad tab would otherwise sit
+ * under an unlabeled bar. The label is the pill's, so folding the row never
+ * renames the surface.
+ */
+export const ChatPanelCollapsedTabHeading: React.FC = memo(() => {
+  const activeTab = useAtomValue(activeChatPanelTabAtom);
+  if (!activeTab) return null;
+  return <CollapsedTabHeadingLabel tab={activeTab} />;
+});
+
+ChatPanelCollapsedTabHeading.displayName = "ChatPanelCollapsedTabHeading";

--- a/src/engines/ChatPanel/header/ChatPanelPublishedHeader.test.ts
+++ b/src/engines/ChatPanel/header/ChatPanelPublishedHeader.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import { ChatPanelPublishedHeader } from "./ChatPanelPublishedHeader";
 
 describe("ChatPanelPublishedHeader", () => {
-  it("renders the shared 40px leading, content, and trailing slots", () => {
+  it("renders the shared 36px leading, content, and trailing slots", () => {
     const markup = renderToStaticMarkup(
       React.createElement(ChatPanelPublishedHeader, {
         windowsHost: false,
@@ -22,7 +22,7 @@ describe("ChatPanelPublishedHeader", () => {
     );
 
     expect(markup).toContain('data-testid="chat-panel-published-header"');
-    expect(markup).toContain("h-10");
+    expect(markup).toContain("h-9");
     expect(markup).toContain("pl-[15px]");
     expect(markup).toContain("border-b border-border-2");
     expect(markup).not.toContain("bg-chat-pane/40");

--- a/src/engines/ChatPanel/header/ChatPanelPublishedHeader.tsx
+++ b/src/engines/ChatPanel/header/ChatPanelPublishedHeader.tsx
@@ -11,27 +11,37 @@ import type { ChatPanelHeaderSlots } from "./chatPanelHeaderSlots";
 interface ChatPanelPublishedHeaderProps {
   slots: ChatPanelHeaderSlots | null;
   windowsHost: boolean;
+  /**
+   * Space reserved at the left edge for the host window's own controls and the
+   * collapsed-sidebar button. Replaces the slot view's default text inset when
+   * set, and is only passed once this row inherited the pane's top edge.
+   */
+  leadingInsetPx?: number;
 }
 
-/** Chat-pane counterpart of My Station's shared 40px published header. */
+/** Chat-pane counterpart of My Station's shared 36px published header. */
 export const ChatPanelPublishedHeader: React.FC<ChatPanelPublishedHeaderProps> =
-  memo(({ slots, windowsHost }) => {
+  memo(({ slots, windowsHost, leadingInsetPx }) => {
     if (!slots) return null;
 
     return (
       <div
-        className={`relative z-40 flex h-10 shrink-0 items-center gap-2 pr-2 ${
+        className={`relative z-40 flex h-9 shrink-0 items-center gap-2 pr-2 ${
           slots.joinWithFollowingRow ? "" : "border-b border-border-2"
         }`}
         data-testid="chat-panel-published-header"
         data-tauri-drag-region={windowsHost ? undefined : true}
-        style={
-          windowsHost
+        style={{
+          ...(windowsHost
             ? CHAT_PANEL_HEADER_NO_DRAG_STYLE
-            : CHAT_PANEL_HEADER_DRAG_STYLE
-        }
+            : CHAT_PANEL_HEADER_DRAG_STYLE),
+          paddingLeft: leadingInsetPx,
+        }}
       >
-        <PublishedHeaderSlotsView slots={slots} />
+        <PublishedHeaderSlotsView
+          slots={slots}
+          paddingLeftClassName={leadingInsetPx === undefined ? undefined : ""}
+        />
       </div>
     );
   });

--- a/src/engines/ChatPanel/header/chatPanelHeaderLayout.test.ts
+++ b/src/engines/ChatPanel/header/chatPanelHeaderLayout.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  CHAT_PANEL_COLLAPSED_HEADER_HEIGHT_PX,
   CHAT_PANEL_GLASS_SURFACE_CLASS,
   CHAT_PANEL_HEADER_STACK_HEIGHT_PX,
+  CHAT_PANEL_HEADER_TOP_PADDING_PX,
+  CHAT_PANEL_PUBLISHED_HEADER_HEIGHT_PX,
   CHAT_PANEL_TRANSCRIPT_TOP_GAP_PX,
   CHAT_PANEL_TRANSCRIPT_TOP_PADDING_PX,
+  resolveChatPanelChromeTopInsetPx,
   resolveTranscriptTopPaddingPx,
+  shouldCollapseChatPanelTabRow,
+  shouldOfferCollapsedTabClose,
   shouldOverlayChatSessionHeaders,
 } from "./chatPanelHeaderLayout";
 
@@ -23,7 +29,7 @@ describe("chat panel header overlay", () => {
         humanSessionActive: false,
       })
     ).toBe(true);
-    expect(CHAT_PANEL_HEADER_STACK_HEIGHT_PX).toBe(84);
+    expect(CHAT_PANEL_HEADER_STACK_HEIGHT_PX).toBe(80);
   });
 
   it.each([
@@ -64,5 +70,74 @@ describe("transcript top padding under floating chrome", () => {
     expect(resolveTranscriptTopPaddingPx(0, false)).toBe(
       CHAT_PANEL_TRANSCRIPT_TOP_PADDING_PX
     );
+  });
+});
+
+describe("collapsing the tab row into the published header", () => {
+  it("folds a maximized pane that holds a single tab", () => {
+    expect(
+      shouldCollapseChatPanelTabRow({ chatMaximized: true, tabCount: 1 })
+    ).toBe(true);
+  });
+
+  it("keeps the row whenever a second tab exists to switch to", () => {
+    expect(
+      shouldCollapseChatPanelTabRow({ chatMaximized: true, tabCount: 2 })
+    ).toBe(false);
+  });
+
+  it("keeps the row while the pane shares the workbench with a Station", () => {
+    expect(
+      shouldCollapseChatPanelTabRow({ chatMaximized: false, tabCount: 1 })
+    ).toBe(false);
+  });
+
+  it("keeps the window-edge gap the folded tab row used to hold", () => {
+    // The tab row's pt-2; the collapsed row inherits the top edge and the gap.
+    expect(CHAT_PANEL_HEADER_TOP_PADDING_PX).toBe(8);
+    expect(CHAT_PANEL_COLLAPSED_HEADER_HEIGHT_PX).toBe(
+      CHAT_PANEL_PUBLISHED_HEADER_HEIGHT_PX + CHAT_PANEL_HEADER_TOP_PADDING_PX
+    );
+  });
+
+  it("floats only the collapsed row's height once collapsed", () => {
+    expect(resolveChatPanelChromeTopInsetPx(true, true)).toBe(
+      CHAT_PANEL_COLLAPSED_HEADER_HEIGHT_PX
+    );
+    expect(resolveChatPanelChromeTopInsetPx(true, false)).toBe(
+      CHAT_PANEL_HEADER_STACK_HEIGHT_PX
+    );
+    expect(resolveChatPanelChromeTopInsetPx(false, true)).toBe(0);
+  });
+
+  it("shrinks the transcript padding to match the collapsed chrome", () => {
+    expect(
+      resolveTranscriptTopPaddingPx(
+        CHAT_PANEL_COLLAPSED_HEADER_HEIGHT_PX,
+        false
+      )
+    ).toBe(
+      CHAT_PANEL_COLLAPSED_HEADER_HEIGHT_PX + CHAT_PANEL_TRANSCRIPT_TOP_GAP_PX
+    );
+    expect(
+      resolveTranscriptTopPaddingPx(CHAT_PANEL_COLLAPSED_HEADER_HEIGHT_PX, true)
+    ).toBe(CHAT_PANEL_TRANSCRIPT_TOP_GAP_PX);
+  });
+});
+
+describe("collapsed close control", () => {
+  it("is withheld on the Launchpad, which closing would only recreate", () => {
+    expect(shouldOfferCollapsedTabClose("start-page")).toBe(false);
+  });
+
+  it("is offered for every surface the user can actually close away", () => {
+    for (const type of ["session", "terminal", "runtime", "channel"]) {
+      expect(shouldOfferCollapsedTabClose(type)).toBe(true);
+    }
+  });
+
+  it("is withheld when there is no active tab to close", () => {
+    expect(shouldOfferCollapsedTabClose(null)).toBe(false);
+    expect(shouldOfferCollapsedTabClose(undefined)).toBe(false);
   });
 });

--- a/src/engines/ChatPanel/header/chatPanelHeaderLayout.ts
+++ b/src/engines/ChatPanel/header/chatPanelHeaderLayout.ts
@@ -1,5 +1,15 @@
 export const CHAT_PANEL_TAB_HEADER_HEIGHT_PX = 44;
-export const CHAT_PANEL_PUBLISHED_HEADER_HEIGHT_PX = 40;
+export const CHAT_PANEL_PUBLISHED_HEADER_HEIGHT_PX = 36;
+/**
+ * Gap above whichever header row sits at the pane's top edge — the tab row's
+ * `pt-2`. It keeps the row clear of the window edge and lines the row's
+ * content band up with the host window controls beside it, so the row that
+ * inherits the top edge has to inherit the gap too.
+ */
+export const CHAT_PANEL_HEADER_TOP_PADDING_PX = 8;
+/** Collapsed chrome: the published row plus the top gap it inherited. */
+export const CHAT_PANEL_COLLAPSED_HEADER_HEIGHT_PX =
+  CHAT_PANEL_PUBLISHED_HEADER_HEIGHT_PX + CHAT_PANEL_HEADER_TOP_PADDING_PX;
 export const CHAT_PANEL_HEADER_STACK_HEIGHT_PX =
   CHAT_PANEL_TAB_HEADER_HEIGHT_PX + CHAT_PANEL_PUBLISHED_HEADER_HEIGHT_PX;
 export const CHAT_PANEL_TRANSCRIPT_TOP_GAP_PX = 24;
@@ -21,9 +31,61 @@ export function resolveTranscriptTopPaddingPx(
   chromeTopInset: number,
   pinnedHeaderLayerInFlow: boolean
 ): number {
-  return chromeTopInset > 0 && pinnedHeaderLayerInFlow
-    ? CHAT_PANEL_TRANSCRIPT_TOP_GAP_PX
-    : CHAT_PANEL_TRANSCRIPT_TOP_PADDING_PX;
+  if (chromeTopInset > 0 && pinnedHeaderLayerInFlow) {
+    return CHAT_PANEL_TRANSCRIPT_TOP_GAP_PX;
+  }
+  // A collapsed header stack floats less chrome, so the transcript reserves
+  // the inset it was actually given rather than the full two-row height.
+  const floatingChromePx =
+    chromeTopInset > 0 ? chromeTopInset : CHAT_PANEL_HEADER_STACK_HEIGHT_PX;
+  return floatingChromePx + CHAT_PANEL_TRANSCRIPT_TOP_GAP_PX;
+}
+
+interface ChatPanelTabRowCollapseState {
+  /** Whether the pane currently owns the full workbench width. */
+  chatMaximized: boolean;
+  tabCount: number;
+}
+
+/**
+ * Whether the 44px tab row folds into the 40px published header.
+ *
+ * A maximized pane holding a single tab has nothing to switch between: the
+ * lone pill only repeats the surface title published one row below it, so the
+ * row costs 44px of chrome and buys nothing. Collapsing moves its controls
+ * (new tab / close tab / restore) onto the published row, which is why that
+ * row is force-rendered while collapsed even for surfaces that publish no
+ * slots of their own.
+ */
+export function shouldCollapseChatPanelTabRow({
+  chatMaximized,
+  tabCount,
+}: ChatPanelTabRowCollapseState): boolean {
+  return chatMaximized && tabCount === 1;
+}
+
+/**
+ * Whether the collapsed row offers a close control.
+ *
+ * Closing the pane's last tab reseeds a fresh Launchpad, so on the Launchpad
+ * itself the control could only ever replace the page with a copy of itself.
+ * Every other surface is genuinely closable.
+ */
+export function shouldOfferCollapsedTabClose(
+  activeTabType: string | null | undefined
+): boolean {
+  return Boolean(activeTabType) && activeTabType !== "start-page";
+}
+
+/** Floating-chrome height the transcript scrolls beneath. */
+export function resolveChatPanelChromeTopInsetPx(
+  overlayHeaders: boolean,
+  tabRowCollapsed: boolean
+): number {
+  if (!overlayHeaders) return 0;
+  return tabRowCollapsed
+    ? CHAT_PANEL_COLLAPSED_HEADER_HEIGHT_PX
+    : CHAT_PANEL_HEADER_STACK_HEIGHT_PX;
 }
 
 /** Session views share one floating glass-header contract in the chat pane. */

--- a/src/engines/ChatPanel/header/index.ts
+++ b/src/engines/ChatPanel/header/index.ts
@@ -1,4 +1,5 @@
 export * from "./chatPanelHeaderSlots";
+export * from "./ChatPanelCollapsedTabHeading";
 export * from "./ChatPanelHeaderPrimitives";
 export * from "./ChatPanelPublishedHeader";
 export * from "./usePublishChatPanelHeader";

--- a/src/engines/ChatPanel/hooks/useChatPanelTabDisplayTitle.ts
+++ b/src/engines/ChatPanel/hooks/useChatPanelTabDisplayTitle.ts
@@ -1,0 +1,53 @@
+/**
+ * Resolve one chat-pane tab's label the way its pill does.
+ *
+ * Shared by the tab strip and the collapsed 40px header, which names the lone
+ * surface once the pill it would have duplicated is gone. Keeping the label
+ * (and the Launchpad's creator-target override) in one hook is what stops the
+ * two rows from drifting apart.
+ */
+import { useAtomValue } from "jotai";
+import { useTranslation } from "react-i18next";
+
+import type { ChatPanelTab } from "@src/store/chatPanel/chatPanelTabsAtom";
+import { sessionByIdAtom } from "@src/store/session";
+import {
+  CHAT_PANEL_CREATE_TARGET,
+  chatPanelCreateTargetAtom,
+} from "@src/store/ui/chatPanelAtom";
+
+import { resolveChatPanelTabDisplayTitle } from "../chatPanelTabDisplay";
+
+export function useChatPanelTabDisplayTitle(tab: ChatPanelTab): string {
+  const { t } = useTranslation(["sessions", "navigation", "projects"]);
+  const createTarget = useAtomValue(chatPanelCreateTargetAtom);
+  const session = useAtomValue(sessionByIdAtom(tab.sessionId ?? ""));
+
+  const defaultDisplayTitle = resolveChatPanelTabDisplayTitle(tab, session, {
+    newSession: t("sessions:chat.startPage.newSession.title"),
+    runtime: t("sessions:chat.startPage.tabs.runtime"),
+    organization: t("navigation:collaboration.manageOrg"),
+    teamInbox: t("navigation:labels.inbox"),
+    channelFallback: t("navigation:cloud.channels.title"),
+    workManagement: {
+      kanban: t("sessions:simulator.tabs.kanban"),
+      work: t("navigation:labels.workItems"),
+    },
+    sessionFallback: t("sessions:chat.defaultTitle"),
+  });
+
+  if (tab.type !== "start-page") return defaultDisplayTitle;
+
+  switch (createTarget) {
+    case CHAT_PANEL_CREATE_TARGET.PROJECT:
+      return t("sessions:creator.createTarget.project");
+    case CHAT_PANEL_CREATE_TARGET.WORK_ITEM:
+      return t("sessions:creator.createTarget.workItem");
+    case CHAT_PANEL_CREATE_TARGET.GITHUB_ISSUES_PROJECT:
+      return t("projects:githubIssuesImport.createTarget");
+    case CHAT_PANEL_CREATE_TARGET.COLLAB_ORG:
+      return t("navigation:collaboration.addOrg");
+    default:
+      return defaultDisplayTitle;
+  }
+}

--- a/src/engines/ChatPanel/index.tsx
+++ b/src/engines/ChatPanel/index.tsx
@@ -28,6 +28,8 @@ import { allAgentDefsAtom } from "@src/modules/MainApp/AgentOrgs/store/builtInAg
 import { getChatPanelBackgroundStyle } from "@src/modules/shared/layouts/viewContainerTokens";
 import { installAvailableAppUpdate } from "@src/scaffold/AppUpdater";
 import {
+  chatPanelTabCountAtom,
+  closeAndDestroyChatPanelTabAtom,
   closeOrganizationChatPanelTabAtom,
   closeProjectOrgChatPanelTabsAtom,
   closeRevokedCloudChannelChatPanelTabsAtom,
@@ -92,7 +94,9 @@ import {
 } from "./focusedChatWorkstationLayout";
 import { FocusedChatWorkstationMinimapPortalContext } from "./focusedChatWorkstationMinimapPortal";
 import {
-  CHAT_PANEL_HEADER_STACK_HEIGHT_PX,
+  resolveChatPanelChromeTopInsetPx,
+  shouldCollapseChatPanelTabRow,
+  shouldOfferCollapsedTabClose,
   shouldOverlayChatSessionHeaders,
 } from "./header/chatPanelHeaderLayout";
 import { useAiWorkItemCreator } from "./hooks/useAiWorkItemCreator";
@@ -293,6 +297,12 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
       kanbanTitle: t("sessions:simulator.tabs.kanban"),
       showSessionSurface,
     });
+    const tabCount = useAtomValue(chatPanelTabCountAtom);
+    const closeChatPanelTab = useSetAtom(closeAndDestroyChatPanelTabAtom);
+    const handleCloseActiveTab = useCallback(() => {
+      if (!activeTab) return;
+      void closeChatPanelTab(activeTab.id);
+    }, [activeTab, closeChatPanelTab]);
     const isStandaloneToolTabActive =
       activeTab?.type === "work-management" || activeTab?.type === "runtime";
     const stationAvailable = isChatPanelTabStationAvailable(
@@ -573,6 +583,14 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
       standaloneToolTabActive: isStandaloneToolTabActive,
       humanSessionActive,
     });
+    const tabRowCollapsed = shouldCollapseChatPanelTabRow({
+      chatMaximized: isChatFocus,
+      tabCount,
+    });
+    const chromeTopInsetPx = resolveChatPanelChromeTopInsetPx(
+      overlayChatHeaders,
+      tabRowCollapsed
+    );
 
     const headerSection = (
       <ChatPanelHeader
@@ -623,6 +641,9 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
         handleTuiModeToggle={handleTuiModeToggle}
         tabStrip={tabStrip}
         tabStripPlus={tabStripPlus}
+        tabRowCollapsed={tabRowCollapsed}
+        onCloseActiveTab={handleCloseActiveTab}
+        canCloseActiveTab={shouldOfferCollapsedTabClose(activeTab?.type)}
         sessionHeaderExtras={
           <>
             <SessionViewersIndicator sessionId={currentSessionId ?? null} />
@@ -676,16 +697,12 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
         showPanelContent={contentState.showPanelContent}
         showSessionContent={contentState.showSessionContent}
         sessionViewMode={sessionView.mode}
-        chromeTopInset={
-          overlayChatHeaders ? CHAT_PANEL_HEADER_STACK_HEIGHT_PX : 0
-        }
+        chromeTopInset={chromeTopInsetPx}
         alternateSessionView={
           <SessionAlternateSurface
             sessionId={currentSessionId ?? null}
             view={sessionView}
-            topInset={
-              overlayChatHeaders ? CHAT_PANEL_HEADER_STACK_HEIGHT_PX : 0
-            }
+            topInset={chromeTopInsetPx}
           />
         }
       />
@@ -712,9 +729,7 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
                 conversationMinimapHostRef={focusedWorkstationMinimapHostRef}
                 session={currentSession}
                 sessionId={currentSessionId}
-                topInset={
-                  overlayChatHeaders ? CHAT_PANEL_HEADER_STACK_HEIGHT_PX : 0
-                }
+                topInset={chromeTopInsetPx}
               />
             ) : reserveFocusedWorkstationPlaceholder ? (
               <div

--- a/src/engines/ChatPanel/panels/OrganizationPanelHeader.test.ts
+++ b/src/engines/ChatPanel/panels/OrganizationPanelHeader.test.ts
@@ -10,7 +10,7 @@ vi.mock("react-i18next", () => ({
 }));
 
 describe("OrganizationPanelHeader", () => {
-  it("uses the Launchpad-aligned pinned header without a published 40px row", () => {
+  it("uses the Launchpad-aligned pinned header without a published header row", () => {
     const markup = renderToStaticMarkup(
       React.createElement(
         Provider,

--- a/src/features/DiscussionChannels/ChannelPanelView/ChannelPanelHeader.tsx
+++ b/src/features/DiscussionChannels/ChannelPanelView/ChannelPanelHeader.tsx
@@ -43,7 +43,7 @@ const ChannelPanelHeader: React.FC<ChannelPanelHeaderProps> = ({
 
   return (
     <div
-      className="flex h-10 shrink-0 items-center gap-2 border-b border-border-2 pr-2"
+      className="flex h-9 shrink-0 items-center gap-2 border-b border-border-2 pr-2"
       data-testid="channel-panel-header"
     >
       <PublishedHeaderSlotsView

--- a/src/modules/WorkStation/AppShell/WorkstationTabHeader.tsx
+++ b/src/modules/WorkStation/AppShell/WorkstationTabHeader.tsx
@@ -1,9 +1,9 @@
 /**
  * WorkstationTabHeader
  *
- * Shared 40px global tab-header strip rendered immediately below the
+ * Shared 36px global tab-header strip rendered immediately below the
  * {@link WorkstationTabBar} and spanning the full width of the My Station
- * shell. Replaces the per-tab 40px headers (file breadcrumb, URL bar,
+ * shell. Replaces the per-tab headers (file breadcrumb, URL bar,
  * commit-info bar, etc.) that each pane used to render inline above its
  * own content.
  *
@@ -53,7 +53,7 @@ const WorkstationTabHeader: React.FC = memo(() => {
   if (activeTab?.type === "start") {
     return (
       <div
-        className="flex h-10 shrink-0 items-center border-b border-border-2"
+        className="flex h-9 shrink-0 items-center border-b border-border-2"
         data-tauri-drag-region={windowsHost ? undefined : true}
       />
     );
@@ -61,7 +61,7 @@ const WorkstationTabHeader: React.FC = memo(() => {
 
   return (
     <div
-      className={`flex h-10 shrink-0 items-center gap-2 pr-2 ${
+      className={`flex h-9 shrink-0 items-center gap-2 pr-2 ${
         shellLeadingChromeHidden ? "pl-0" : "pl-1.5"
       } ${headerSlots?.joinWithFollowingRow ? "" : "border-b border-border-2"}`}
       data-tauri-drag-region={windowsHost ? undefined : true}

--- a/src/modules/WorkStation/shared/SessionReplay/SimulatorWorkstationTabHeader.tsx
+++ b/src/modules/WorkStation/shared/SessionReplay/SimulatorWorkstationTabHeader.tsx
@@ -51,7 +51,7 @@ const SimulatorWorkstationTabHeaderComponent: React.FC<
   // the single separator line under the whole tabbar+header block.
   return (
     <div
-      className={`flex h-10 shrink-0 items-center gap-2 pl-1.5 pr-2 ${
+      className={`flex h-9 shrink-0 items-center gap-2 pl-1.5 pr-2 ${
         headerSlots?.joinWithFollowingRow ? "" : "border-b border-border-2"
       }`}
       data-tauri-drag-region

--- a/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
+++ b/src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts
@@ -1661,20 +1661,84 @@ describe("openOrReplaceSessionInChatPanelTabAtom", () => {
     expect(store.get(activeSessionIdAtom)).toBe("session-b");
   });
 
-  it("does not replace a non-session tab", async () => {
-    const { chatPanelTabsAtom, openOrReplaceSessionInChatPanelTabAtom, store } =
-      await loadChatPanelTabAtoms();
+  it("consumes the active Launchpad tab instead of stacking behind it", async () => {
+    const {
+      activeSessionIdAtom,
+      chatPanelStartPageOpenAtom,
+      chatPanelTabsAtom,
+      openOrReplaceSessionInChatPanelTabAtom,
+      store,
+    } = await loadChatPanelTabAtoms();
 
     const launchpadTabId = store.get(chatPanelTabsAtom).activeTabId;
     const sessionTabId = store.set(openOrReplaceSessionInChatPanelTabAtom, {
       sessionId: "session-a",
       sessionName: "Session A",
+      repoPath: "/repos/a",
     });
 
     expect(sessionTabId).not.toBe(launchpadTabId);
+    expect(store.get(chatPanelTabsAtom)).toMatchObject({
+      activeTabId: sessionTabId,
+      tabs: [
+        {
+          id: sessionTabId,
+          type: "session",
+          title: "Session A",
+          sessionId: "session-a",
+        },
+      ],
+    });
+    expect(store.get(chatPanelStartPageOpenAtom)).toBe(false);
+    expect(store.get(activeSessionIdAtom)).toBe("session-a");
+  });
+
+  it("replaces the Launchpad in place, keeping sibling tab order", async () => {
+    const {
+      chatPanelTabsAtom,
+      openOrFocusChatPanelStartPageTabAtom,
+      openOrReplaceSessionInChatPanelTabAtom,
+      openSessionInNewChatTabAtom,
+      store,
+    } = await loadChatPanelTabAtoms();
+
+    const launchpadTabId = store.get(chatPanelTabsAtom).activeTabId;
+    const trailingTabId = store.set(openSessionInNewChatTabAtom, {
+      sessionId: "session-a",
+      sessionName: "Session A",
+    });
+    store.set(openOrFocusChatPanelStartPageTabAtom, {});
+    expect(store.get(chatPanelTabsAtom).activeTabId).toBe(launchpadTabId);
+
+    const sessionTabId = store.set(openOrReplaceSessionInChatPanelTabAtom, {
+      sessionId: "session-b",
+      sessionName: "Session B",
+    });
+
+    expect(store.get(chatPanelTabsAtom).tabs).toMatchObject([
+      { id: sessionTabId, type: "session", sessionId: "session-b" },
+      { id: trailingTabId, type: "session", sessionId: "session-a" },
+    ]);
+  });
+
+  it("does not replace a tab that owns its own surface", async () => {
+    const {
+      chatPanelTabsAtom,
+      openOrReplaceSessionInChatPanelTabAtom,
+      openRuntimeInChatPanelTabAtom,
+      store,
+    } = await loadChatPanelTabAtoms();
+
+    const runtimeTabId = store.set(openRuntimeInChatPanelTabAtom, "Runtime");
+    const sessionTabId = store.set(openOrReplaceSessionInChatPanelTabAtom, {
+      sessionId: "session-a",
+      sessionName: "Session A",
+    });
+
+    expect(sessionTabId).not.toBe(runtimeTabId);
     expect(store.get(chatPanelTabsAtom).tabs).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ id: launchpadTabId, type: "start-page" }),
+        expect.objectContaining({ id: runtimeTabId, type: "runtime" }),
         expect.objectContaining({
           id: sessionTabId,
           type: "session",

--- a/src/store/chatPanel/chatPanelTabOpen/session.ts
+++ b/src/store/chatPanel/chatPanelTabOpen/session.ts
@@ -90,8 +90,10 @@ openOrFocusSessionInChatPanelTabAtom.debugLabel =
 
 /**
  * Open a session from the sidebar without stacking tabs during normal
- * navigation. An already-open target is focused; otherwise the active session
- * tab is repointed to the target. Non-session tabs are never replaced.
+ * navigation. An already-open target is focused; otherwise the active tab is
+ * consumed when it is a session pill (repointed at the target) or the
+ * Launchpad start page (swapped for a session pill in place). Every other tab
+ * type owns a surface the user asked for, so it is never replaced.
  */
 export const openOrReplaceSessionInChatPanelTabAtom = atom(
   null,
@@ -110,29 +112,37 @@ export const openOrReplaceSessionInChatPanelTabAtom = atom(
     }
 
     const activeTab = state.tabs.find((tab) => tab.id === state.activeTabId);
-    if (activeTab?.type !== "session") {
+    if (activeTab?.type !== "session" && activeTab?.type !== "start-page") {
       return set(openSessionInNewChatTabAtom, options);
     }
 
     const session = get(sessionByIdAtom(options.sessionId));
-    const replacementTab: ChatPanelTab = {
-      ...activeTab,
-      title: options.sessionName ?? session?.name ?? "Chat",
-      sessionId: options.sessionId,
-      updatedAt: new Date().toISOString(),
-    };
+    const title = options.sessionName ?? session?.name ?? "Chat";
+    // The Launchpad is the pane's "new session" placeholder, so opening a
+    // session from it consumes the placeholder rather than leaving an empty
+    // start page parked behind the conversation. A session pill keeps its own
+    // id (and any state keyed to it) and is repointed at the new session.
+    const replacementTab: ChatPanelTab =
+      activeTab.type === "start-page"
+        ? createSessionTab({ sessionId: options.sessionId, title })
+        : {
+            ...activeTab,
+            title,
+            sessionId: options.sessionId,
+            updatedAt: new Date().toISOString(),
+          };
     set(chatPanelTabsAtom, {
-      ...state,
       tabs: state.tabs.map((tab) =>
         tab.id === activeTab.id ? replacementTab : tab
       ),
+      activeTabId: replacementTab.id,
     });
     set(activateChatPanelTabAtom, {
-      tabId: activeTab.id,
+      tabId: replacementTab.id,
       sessionName: options.sessionName,
       repoPath: options.repoPath,
     });
-    return activeTab.id;
+    return replacementTab.id;
   }
 );
 openOrReplaceSessionInChatPanelTabAtom.debugLabel =


### PR DESCRIPTION
## Problem

The chat pane kept tab chrome that carried no information for the user.

1. **A Launchpad pill parked behind every session.** Opening a session from the
   sidebar while the Launchpad start page was active appended a new session pill
   and left the now-empty start page sitting behind it.
   `openOrReplaceSessionInChatPanelTabAtom` already repointed an *active session*
   pill in place, but treated the start page as unreplaceable.
2. **Two header rows to show one title.** A maximized pane holding a single tab
   stacked a 44px tab strip on a 40px published header. The strip's lone pill had
   nothing to switch to and only repeated the surface title published directly
   beneath it — 44px of chrome for a duplicate label.
3. **Published header bars disagreed on height.** The shared
   `PublishedHeaderSlotsView` row was 40px in the chat pane, My Station, session
   replay and channels, against the 36px content band both tab bars use.

Two defects in the controls this moves also surfaced while testing:

4. **The restore icon shook on hover.** `PanelRightIcon` and `PanelRightOpenIcon`
   draw the *same* rounded-rect outline and divider from different path strings
   (opposite winding, different start point); `PanelRightOpenIcon` only adds a
   chevron. Cross-fading them stacked rasterized that identical outline twice at
   slightly different anti-aliasing, which reads as the icon vibrating.
5. **The close label rendered as a raw key.** `ChatPanelHeader`'s `t` is
   `TFunction<["sessions", …]>`, and `actions.close` lives in `common`.
   react-i18next binds only `namespaces[0]` unless `react.nsMode === 'fallback'`
   (`useTranslation.js:76`), which `src/i18n/index.ts` never sets — so the tooltip
   showed the literal string `actions.close`.

## Solution

**Launchpad hand-off.** `openOrReplaceSessionInChatPanelTabAtom` now consumes an
active start-page tab the same way it repoints an active session tab, swapping a
fresh session pill into its slot so tab order and count are preserved. Tabs that
own a surface the user explicitly opened (runtime, terminal, work management, …)
are still never replaced. This is the atom behind sidebar clicks, the timeline,
session-reference cards, cloud-share import and fork, so all of those pick up the
same behaviour.

**Single-tab chrome.** When the pane is maximized and holds exactly one tab, the
44px tab row folds away and the published row inherits everything it owned:

- the new-tab, restore and close controls,
- the 8px window-edge gap (`pt-2`), applied to a wrapper so the row keeps its
  full content band **and** becomes the positioning context the collapsed-sidebar
  button centres in — `top: calc(50% + 4px)` lands at 26px in a 44px box, the same
  arithmetic both tab bars already rely on,
- the collapsed-sidebar button and `getCollapsedSidebarChromeOffset()`, the
  platform-aware inset reserving macOS traffic-light space.

This mirrors My Station's tab bar (`height: TAB_BAR_HEIGHT + 8` around an
`mt-2 h-9` band) rather than inventing a second layout. Three consequences are
handled explicitly:

- Surfaces publishing no header content of their own (terminal, Launchpad) are
  named by `ChatPanelCollapsedTabHeading` using the pill's own label, so folding
  the row never leaves an unlabeled bar. The label logic moved out of `TabPill`
  into a shared `useChatPanelTabDisplayTitle` hook so the two cannot drift.
- The collapsed row renders borderless — it stands in for a borderless tab row,
  and a rule under the maximized pane's only chrome would be a line the pane
  never had.
- The Launchpad drops the close control: closing the pane's last tab reseeds a
  fresh Launchpad, so there it could only ever replace the page with a copy of
  itself.

**One bar height.** Every `PublishedHeaderSlotsView` host moves 40px → 36px
(`h-10` → `h-9`): chat pane, My Station, session replay, channels.
`CHAT_PANEL_PUBLISHED_HEADER_HEIGHT_PX` cascades the stack to 80px, the collapsed
row to 44px and the transcript inset to 104px. All slot content is `h-7`/`h-6`,
so nothing overflows the shorter row.

**The two defects.** The restore glyphs are now swapped with
`group-hover:hidden` / `hidden group-hover:block` instead of cross-faded — only
one is ever painted, so the hover shows what actually differs (the chevron), and
the identical outlines make the swap itself invisible. The close label is
qualified as `t("common:actions.close")`.

The collapse and close rules are pure functions in `chatPanelHeaderLayout.ts`
(`shouldCollapseChatPanelTabRow`, `shouldOfferCollapsedTabClose`,
`resolveChatPanelChromeTopInsetPx`) so the policy is testable apart from the JSX.

## Potential risks

- **No visual verification.** The app was never launched for this change; all
  evidence below is type-, lint- and test-level. The 36px row height and the
  collapsed bar's vertical rhythm are exactly the kind of thing those checks
  cannot judge, so both want an eyeball before merge. This is the main risk in
  the PR.
- **The 36px change reaches beyond the chat pane.** My Station, session replay
  and channels all shift by 4px. Their slot content fits, but any downstream
  layout that assumed a 40px published row would be off by 4px. No such constant
  exists — `chromeTopInset` is threaded as a value everywhere and
  `resolveTranscriptTopPaddingPx` now derives from it rather than hardcoding the
  stack — but the search was static.
- **Deliberately out of scope:** `HEADER_HEIGHT = 40` and the
  `FILE_BAR_ROW_CLASSES` / `pageHeader` / `sectionTitle` row classes in
  `src/config/workstation/tokens.ts` are *not* touched. Those are file bars, page
  headers and section titles across Project Manager, wizards, detail panels and
  the browser URL bar — a different family from the published-header row, and a
  much wider visual change.
- **Consuming the Launchpad is a behaviour change for several entry points.**
  Cloud-share import, fork and session-reference cards all route through the same
  atom, so opening a session from any of them while on the Launchpad now replaces
  it. That is the intent, but it is broader than the sidebar case that motivated
  it. Nothing is lost: only the active tab's content mounts, so the Launchpad
  composer already unmounted on any tab switch.
- **Forced-maximize collapses too.** `resolveChatPanelMaximizedForLayout` returns
  true for a wide-only tab on a narrow viewport even when the user never
  maximized. Such a pane now also folds, with the restore button present but
  disabled. Judged correct — the pane genuinely fills the workbench — but it is a
  path no test covers.
- **`TabPill`'s session fallback label changes.** It previously called
  `t("chat.defaultTitle")` against the default `common` namespace, where that key
  does not exist, so it rendered the literal `chat.defaultTitle`. The extracted
  hook uses `sessions:chat.defaultTitle`, so it now reads "Chat". Strictly a fix,
  but it is a visible string change that was not requested.
- No persistence, schema, IPC, wire, dependency or lockfile changes. Tab state
  persists through `normalizePersistedChatPanelTabsState`, which is untouched and
  still collapses duplicate start pages. Rollback is a plain revert.

## Verification

Commands run on the final branch state, all passing:

- `npx tsc --noEmit --pretty false` — clean, no output.
- `npx eslint src/ --ext .ts,.tsx,.js,.jsx --max-warnings 0 --report-unused-disable-directives` — clean.
- `npx vitest run` — **1249 files, 9798 tests passed, 0 failed.**

New coverage:

- `src/store/chatPanel/__tests__/chatPanelTabsAtom.test.ts` — the Launchpad is
  consumed rather than stacked behind; the swap happens in place preserving
  sibling order; a tab owning its own surface (runtime) is still not replaced.
- `src/engines/ChatPanel/header/chatPanelHeaderLayout.test.ts` — collapse rule
  across maximized/tab-count; the close rule withholding on `start-page`;
  collapsed chrome height and the inherited 8px gap; transcript padding tracking
  the collapsed inset.
- `src/engines/ChatPanel/ChatPanelHeader.test.ts` (new) — both rows render
  uncollapsed; collapsed drops the tab row and rehomes `+` / restore / close;
  the heading fallback appears only for surfaces publishing no content; the
  platform inset and collapsed-sidebar button move onto the leading row; the
  collapsed row is borderless; the restore glyphs swap rather than cross-fade;
  the close control is dropped when the surface cannot be closed away.

Existing tests updated for the new geometry rather than deleted:
`ChatPanelPublishedHeader.test.ts` (`h-10` → `h-9`),
`focusedChatWorkstationLayout.test.ts` (now derives from
`CHAT_PANEL_HEADER_STACK_HEIGHT_PX` instead of a literal 84).

**Did not run:**

- **The app itself** — no screenshots or recordings. See the first risk; this is
  a user-visible chrome change and visual review is genuinely warranted.
- **Playwright / WebDriver E2E** — not exercised for this change.
- **`cargo test --workspace`** — no Rust files in the diff (`git diff --name-only
  develop..HEAD` matches no `*.rs` or `Cargo.*`).
- **Other locales** — only `en` was checked. `actions.close` is present in all 13
  locale bundles, so the namespace fix needs no new strings.

## Audit

While tracing the `actions.close` bug I scanned the repo for the same class of
defect (scanner accounts for plural suffixes, `keyPrefix`, aliased translators,
the same `t` rebound per component in one file, `TFunction` props typed per name,
and both `t(key, "Default")` and `{ defaultValue }`):

| | count | effect |
|---|---|---|
| wrong namespace | 11 | string exists, bound ns is wrong → raw key on screen |
| no such string in `en/` | 66 | raw key on screen |
| missing but inline-defaulted | 152 | hardcoded English, never translated in any of the 13 locales |

**None of these are fixed here.** They are pre-existing, spread across 40+
unrelated files, and belong in their own PR under this repo's
single-responsibility rule. Worst clusters:
`src/modules/shared/dataSource/RuntimeScanningPanelColumns.tsx` (13 sites),
`sessions:titleBar.showDevTools` (4 sites), `common:chat.scrollToBottom`
(4 sites, explicitly `ns:`-prefixed so certainly real), and
`src/scaffold/GlobalSpotlight/forms/shared/SpotlightModalHeader.tsx:91`
`t("close")`, which is the same mistake this PR fixes.
