### PR TITLE
fix(team-conversations): unify conversation action menus

### DIFF
--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionNativeMenuItems.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionNativeMenuItems.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { buildCloudSessionNativeMenuItems } from "./cloudSessionNativeMenuItems";
+
+describe("buildCloudSessionNativeMenuItems", () => {
+  it("keeps secondary-click and ellipsis destination actions in the canonical team menu", () => {
+    const onOpenInNewTab = vi.fn();
+    const onOpenInMyStation = vi.fn();
+    const onCopyUrl = vi.fn();
+    const onTogglePin = vi.fn();
+    const onRemove = vi.fn();
+
+    const items = buildCloudSessionNativeMenuItems({
+      labels: {
+        openInNewTab: "Open in New Tab",
+        openInMyStation: "Open in My Station",
+        copyUrl: "Copy URL",
+        togglePin: "Pin",
+        remove: "Remove",
+      },
+      onOpenInNewTab,
+      onOpenInMyStation,
+      onCopyUrl,
+      onTogglePin,
+      onRemove,
+    });
+
+    expect(
+      items.map((item) => ("item" in item ? item.item : item.text))
+    ).toEqual([
+      "Open in New Tab",
+      "Open in My Station",
+      "Copy URL",
+      "Pin",
+      "Separator",
+      "Remove",
+    ]);
+
+    for (const item of items) {
+      if ("action" in item) item.action?.("test-menu-item");
+    }
+    expect(onOpenInNewTab).toHaveBeenCalledOnce();
+    expect(onOpenInMyStation).toHaveBeenCalledOnce();
+    expect(onCopyUrl).toHaveBeenCalledOnce();
+    expect(onTogglePin).toHaveBeenCalledOnce();
+    expect(onRemove).toHaveBeenCalledOnce();
+  });
+});

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionNativeMenuItems.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionNativeMenuItems.ts
@@ -1,0 +1,38 @@
+import type { NativeMenuItemOptions } from "@src/util/platform/tauri/nativeMenuPopup";
+
+interface BuildCloudSessionNativeMenuItemsParams {
+  labels: {
+    openInNewTab: string;
+    openInMyStation: string;
+    copyUrl: string;
+    togglePin: string;
+    remove: string;
+  };
+  onOpenInNewTab: () => void;
+  onOpenInMyStation: () => void;
+  onCopyUrl: () => void;
+  onTogglePin: () => void;
+  onRemove: () => void;
+}
+
+/**
+ * The canonical native menu for an actionable Team Conversation row.
+ * Both secondary-click and the trailing ellipsis consume this exact list.
+ */
+export function buildCloudSessionNativeMenuItems({
+  labels,
+  onOpenInNewTab,
+  onOpenInMyStation,
+  onCopyUrl,
+  onTogglePin,
+  onRemove,
+}: BuildCloudSessionNativeMenuItemsParams): NativeMenuItemOptions[] {
+  return [
+    { text: labels.openInNewTab, action: onOpenInNewTab },
+    { text: labels.openInMyStation, action: onOpenInMyStation },
+    { text: labels.copyUrl, action: onCopyUrl },
+    { text: labels.togglePin, action: onTogglePin },
+    { item: "Separator" },
+    { text: labels.remove, action: onRemove },
+  ];
+}

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.rowItemBuilder.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.rowItemBuilder.tsx
@@ -2,15 +2,15 @@
  * Builds one `NavigationMenuItem` row for a Team Sessions fork thread
  * (`cloudSessionsSection.tsx`): icon/title/relative-time, the unresolved
  * comments badge, live-viewer chips, and the row's hover actions (Fork,
- * overflow menu with copy-url/remove). Split out because it is the single
+ * pin, and the canonical Team Conversation menu). Split out because it is the single
  * largest piece of that section's row-construction logic.
  */
 import type { TFunction } from "i18next";
 import { useAtomValue } from "jotai";
 import { useCallback } from "react";
 
-import Message from "@src/components/Message";
 import PersonAvatar from "@src/components/PersonAvatar";
+import { dismissHoverCard } from "@src/components/SessionHoverCard/singletonStore";
 import { resolveAgentIcon } from "@src/config/agentIcons";
 import {
   discussionSeenCountsAtom,
@@ -43,8 +43,10 @@ import {
 } from "@src/icons";
 import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/components/NavigationMenu/config";
 import type { RemoteTeammateSessionMetadata } from "@src/store/collaboration/types";
-import { copyText } from "@src/util/data/clipboard";
-import { popupNativeMenu } from "@src/util/platform/tauri/nativeMenuPopup";
+import {
+  type NativeMenuItemOptions,
+  popupNativeMenu,
+} from "@src/util/platform/tauri/nativeMenuPopup";
 import { resolveSessionDisplayMetadata } from "@src/util/session/sessionDisplayMetadata";
 import { formatRelativeTime } from "@src/util/time/formatRelativeTime";
 
@@ -94,7 +96,9 @@ interface UseCloudSessionRowItemBuilderParams {
   t: TFunction;
   tCommon: TFunction;
   runFork: (row: RemoteTeammateSessionMetadata) => void;
-  hideRemoteSession: (row: RemoteTeammateSessionMetadata) => void;
+  buildNativeMenuItems: (
+    row: RemoteTeammateSessionMetadata
+  ) => NativeMenuItemOptions[];
   /** Per-row in-flight replay/fork registry — busy rows render a spinner. */
   busySessionRows: ReadonlyMap<string, CloudSessionBusyEntry>;
   /** Viewer-local pin keys (`<orgId>|<rowId>`); never a property of the shared row. */
@@ -114,7 +118,7 @@ export function useCloudSessionRowItemBuilder({
   t,
   tCommon,
   runFork,
-  hideRemoteSession,
+  buildNativeMenuItems,
   busySessionRows,
   pinnedRemoteSessionIds,
   toggleRemoteSessionPin,
@@ -302,35 +306,10 @@ export function useCloudSessionRowItemBuilder({
             icon: MoreHorizontalIcon,
             label: tCommon("actions.more"),
             onClick: () => {
+              dismissHoverCard();
               void popupNativeMenu({
                 source: "cloud-session-row",
-                buildItems: () => [
-                  {
-                    text: t("cloud.sidebar.copyUrl"),
-                    action: () => {
-                      void copyText(buildCloudSessionReference(row))
-                        .then(() => {
-                          Message.success(tCommon("actions.copied", "Copied"));
-                        })
-                        .catch(() => {
-                          Message.error(
-                            tCommon("actions.copyFailed", "Copy failed")
-                          );
-                        });
-                    },
-                  },
-                  {
-                    text: isPinned
-                      ? tCommon("sessions:chat.unpinSession", "Unpin")
-                      : tCommon("sessions:chat.pinSession", "Pin"),
-                    action: () => toggleRemoteSessionPin(row.orgId, row.id),
-                  },
-                  { item: "Separator" as const },
-                  {
-                    text: tCommon("actions.remove", "Remove"),
-                    action: () => hideRemoteSession(row),
-                  },
-                ],
+                buildItems: () => buildNativeMenuItems(row),
               });
             },
           },
@@ -340,7 +319,7 @@ export function useCloudSessionRowItemBuilder({
     },
     [
       busySessionRows,
-      hideRemoteSession,
+      buildNativeMenuItems,
       pinnedRemoteSessionIds,
       toggleRemoteSessionPin,
       presenceMap,

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.tsx
@@ -41,6 +41,7 @@ import {
   writeHiddenRemoteSessionIds,
 } from "@src/features/Org2Cloud/cloudHiddenRemoteSessions";
 import {
+  isRemoteSessionPinned,
   readPinnedRemoteSessionIds,
   togglePinnedRemoteSession,
   writePinnedRemoteSessionIds,
@@ -53,6 +54,7 @@ import {
 } from "@src/features/Org2Cloud/cloudRemoteItemId";
 import { cloudDownloadStartRequestAtom } from "@src/features/Org2Cloud/cloudSessionDownloadControlAtoms";
 import { filterCloudSessionRows } from "@src/features/Org2Cloud/cloudSessionFilter";
+import { buildCloudSessionReference } from "@src/features/Org2Cloud/cloudSessionReference";
 import {
   buildCloudSessionThreads,
   collectCloudFlatListExcludedSessionIds,
@@ -66,7 +68,10 @@ import {
   org2CloudPushedMetadataAtom,
 } from "@src/features/Org2Cloud/org2CloudSyncAtoms";
 import { REFUSAL_MESSAGE_DURATION_MS } from "@src/features/Org2Cloud/referenceRefusalMessage";
-import { useCloudSessionActions } from "@src/features/Org2Cloud/useCloudSessionActions";
+import {
+  type CloudSessionReplayOptions,
+  useCloudSessionActions,
+} from "@src/features/Org2Cloud/useCloudSessionActions";
 import {
   useCloudSessionDownloadProgressEntry,
   useCloudSessionPendingPlayEntry,
@@ -77,11 +82,13 @@ import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/compone
 import { openOrReplaceSessionInChatPanelTabAtom } from "@src/store/chatPanel/chatPanelTabOpenAtoms";
 import type { RemoteTeammateSessionMetadata } from "@src/store/collaboration/types";
 import { loadSidebarSessionById, removeSession } from "@src/store/session";
+import { copyText } from "@src/util/data/clipboard";
 
 import {
   CLOUD_SESSION_SECTION_PAGE_SIZE,
   CLOUD_TEAM_SESSIONS_LOAD_MORE_ID,
 } from "./cloudScopedMenuItems";
+import { buildCloudSessionNativeMenuItems } from "./cloudSessionNativeMenuItems";
 import { useCloudMemberFilterDropdown } from "./cloudSessionsSection.MemberFilterDropdown";
 import {
   type CloudAutoReplaySkipReason,
@@ -107,10 +114,12 @@ export function useCloudSessionsSection({
   activeSessionId,
   localSessionHydrationLimit,
   revealedMenuItemId,
+  openSessionAtDestination,
   onFilterChange,
 }: UseCloudSessionsSectionParams): UseCloudSessionsSectionResult {
   const { t } = useTranslation("navigation");
   const { t: tCommon } = useTranslation("common");
+  const { t: tSessions } = useTranslation("sessions");
   const store = useStore();
   const { rows, state, fetchedAt, documentVisible, refresh } =
     useCloudOrgRemoteSessions(orgId);
@@ -304,15 +313,15 @@ export function useCloudSessionsSection({
   );
 
   const runReplay = useCallback(
-    (row: RemoteTeammateSessionMetadata, options?: { skipGate?: boolean }) => {
+    (
+      row: RemoteTeammateSessionMetadata,
+      options?: CloudSessionReplayOptions
+    ) => {
       // The replay is starting: the pre-phase toast has served its purpose
       // (a no-op for sidebar-origin clicks that never showed one).
       dismissCloudReferenceOpeningToast();
       resubscribeRemoteRow(row);
-      void replaySession(
-        row,
-        options?.skipGate ? { skipDownloadGate: true } : undefined
-      );
+      void replaySession(row, options);
     },
     [replaySession, resubscribeRemoteRow]
   );
@@ -338,7 +347,7 @@ export function useCloudSessionsSection({
       if (startKind === "fork") {
         void forkSession(row, { skipDownloadGate: true });
       } else {
-        runReplay(row, { skipGate: true });
+        runReplay(row, { skipDownloadGate: true });
       }
     });
   }, [downloadStartRequest, findRow, forkSession, orgId, runReplay, store]);
@@ -348,6 +357,52 @@ export function useCloudSessionsSection({
       void forkSession(row);
     },
     [forkSession]
+  );
+
+  const openTeamSessionAtDestination = useCallback(
+    (
+      row: RemoteTeammateSessionMetadata,
+      destination: "new-tab" | "my-station"
+    ) => {
+      const openLocalSession = (sessionId: string) => {
+        openSessionAtDestination(destination, {
+          sessionId,
+          title: row.title,
+        });
+      };
+
+      // A viewer's own row in a multi-owner conversation remains the writable
+      // local original. Never mint a read-only imported copy for it.
+      if (
+        row.ownerUserId === selfUserId &&
+        localOwnSessionIds.has(row.sourceSessionId)
+      ) {
+        openLocalSession(row.sourceSessionId);
+        return;
+      }
+
+      // A replay already in flight has already chosen its deterministic local
+      // id. The destination action should still work instead of becoming a
+      // dead menu item while the transcript downloads.
+      const busy = busySessionRows.get(row.id);
+      if (busy) {
+        if (busy.kind === "replay" && busy.localSessionId) {
+          openLocalSession(busy.localSessionId);
+        }
+        return;
+      }
+
+      runReplay(row, {
+        openSurface: ({ localSessionId }) => openLocalSession(localSessionId),
+      });
+    },
+    [
+      busySessionRows,
+      localOwnSessionIds,
+      openSessionAtDestination,
+      runReplay,
+      selfUserId,
+    ]
   );
 
   const { openSession } = useSessionView();
@@ -533,15 +588,62 @@ export function useCloudSessionsSection({
     });
   }, []);
 
-  const handleCloudRemoteItemRemove = useCallback(
-    (item: NavigationMenuItem): boolean => {
-      const parsed = parseCloudRemoteItemId(item.id);
-      if (!parsed) return false;
-      const row = findRow(parsed.rowId);
-      if (row) hideRemoteSession(row);
-      return true;
+  const buildRemoteSessionMenuItems = useCallback(
+    (row: RemoteTeammateSessionMetadata) => {
+      const isPinned = isRemoteSessionPinned(
+        pinnedRemoteSessionIds,
+        row.orgId,
+        row.id
+      );
+      return buildCloudSessionNativeMenuItems({
+        labels: {
+          openInNewTab: tCommon("actions.openInNewTab", "Open in New Tab"),
+          openInMyStation: tSessions(
+            "controlTower.sidebar.openInMyStation",
+            "Open in My Station"
+          ),
+          copyUrl: t("cloud.sidebar.copyUrl"),
+          togglePin: isPinned
+            ? tCommon("sessions:chat.unpinSession", "Unpin")
+            : tCommon("sessions:chat.pinSession", "Pin"),
+          remove: tCommon("actions.remove", "Remove"),
+        },
+        onOpenInNewTab: () => openTeamSessionAtDestination(row, "new-tab"),
+        onOpenInMyStation: () =>
+          openTeamSessionAtDestination(row, "my-station"),
+        onCopyUrl: () => {
+          void copyText(buildCloudSessionReference(row))
+            .then(() => {
+              Message.success(tCommon("actions.copied", "Copied"));
+            })
+            .catch(() => {
+              Message.error(tCommon("actions.copyFailed", "Copy failed"));
+            });
+        },
+        onTogglePin: () => toggleRemoteSessionPin(row.orgId, row.id),
+        onRemove: () => hideRemoteSession(row),
+      });
     },
-    [findRow, hideRemoteSession]
+    [
+      hideRemoteSession,
+      openTeamSessionAtDestination,
+      pinnedRemoteSessionIds,
+      t,
+      tCommon,
+      tSessions,
+      toggleRemoteSessionPin,
+    ]
+  );
+
+  const buildCloudRemoteItemMenuItems = useCallback(
+    (item: NavigationMenuItem) => {
+      const parsed = parseCloudRemoteItemId(item.id);
+      if (!parsed) return [];
+      const row = findRow(parsed.rowId);
+      if (!row || row.eventsEpoch === undefined) return [];
+      return buildRemoteSessionMenuItems(row);
+    },
+    [buildRemoteSessionMenuItems, findRow]
   );
 
   const buildRowItem = useCloudSessionRowItemBuilder({
@@ -550,7 +652,7 @@ export function useCloudSessionsSection({
     t,
     tCommon,
     runFork,
-    hideRemoteSession,
+    buildNativeMenuItems: buildRemoteSessionMenuItems,
     busySessionRows,
     pinnedRemoteSessionIds,
     toggleRemoteSessionPin,
@@ -598,7 +700,7 @@ export function useCloudSessionsSection({
     selectedCloudMenuItemId,
     handleCloudSessionItemClick,
     resetCloudTeamPagination,
-    handleCloudRemoteItemRemove,
+    buildCloudRemoteItemMenuItems,
     cloudMemberFilterDropdown,
     cloudRemoteRowMap,
     cloudRemoteViewerMap,

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.types.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.types.ts
@@ -10,6 +10,14 @@ import type { Org2CloudPresenceEntry } from "@src/features/Org2Cloud/org2CloudPr
 import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/components/NavigationMenu/config";
 import type { RemoteTeammateSessionMetadata } from "@src/store/collaboration/types";
 import type { Session } from "@src/store/session";
+import type { NativeMenuItemOptions } from "@src/util/platform/tauri/nativeMenuPopup";
+
+export type CloudSessionOpenDestination = "new-tab" | "my-station";
+
+export interface CloudSessionDestinationOptions {
+  sessionId: string;
+  title: string;
+}
 
 export interface UseCloudSessionsSectionParams {
   /** Active cloud org id (bare, not `cloud:`-prefixed); null ⇒ no section. */
@@ -23,6 +31,11 @@ export interface UseCloudSessionsSectionParams {
   localSessionHydrationLimit: number;
   /** One exact Team Session row temporarily revealed by cross-surface nav. */
   revealedMenuItemId?: string;
+  /** Places an imported/local Team Conversation on the requested surface. */
+  openSessionAtDestination: (
+    destination: CloudSessionOpenDestination,
+    options: CloudSessionDestinationOptions
+  ) => void;
   onFilterChange: (filter: CloudSessionFilter) => void;
 }
 
@@ -39,8 +52,10 @@ export interface UseCloudSessionsSectionResult {
   handleCloudSessionItemClick: (item: NavigationMenuItem) => boolean;
   /** Forget any extra Team rows revealed with Load more. */
   resetCloudTeamPagination: () => void;
-  /** Locally hide a teammate cloud row and discard its replay cache. */
-  handleCloudRemoteItemRemove: (item: NavigationMenuItem) => boolean;
+  /** Canonical Team Conversation menu shared by secondary-click and ellipsis. */
+  buildCloudRemoteItemMenuItems: (
+    item: NavigationMenuItem
+  ) => NativeMenuItemOptions[];
   /** Member-filter dropdown portal — render once next to the sidebar. */
   cloudMemberFilterDropdown: React.ReactNode;
   /**

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate } from "react-router-dom";
 
+import { ROUTES } from "@src/config/routes";
 import { normalizeSidebarGuideProgress } from "@src/config/settingsSchema/sidebarGuideProgress";
 import { createLogger } from "@src/hooks/logger";
 import { useAppNavigation } from "@src/hooks/navigation/useAppNavigation";
@@ -32,6 +33,7 @@ import {
 import { saveSetupGuideProgressAtom } from "@src/store/settings/setupGuideProgressAtom";
 import {
   CHAT_PANEL_CREATE_TARGET,
+  CHAT_PANEL_SURFACE_KIND,
   CLOUD_ORG_MANAGEMENT_VIEW,
 } from "@src/store/ui/chatPanelAtom";
 import { showGuideHighlightAtom } from "@src/store/ui/guideHighlightAtom";
@@ -285,6 +287,42 @@ export const WorkstationSidebarConnector: React.FC = () => {
     setCollapsedSectionIds,
   });
 
+  const openCloudSessionAtDestination = useCallback(
+    (
+      destination: "new-tab" | "my-station",
+      options: { sessionId: string; title: string }
+    ) => {
+      setStationMode("my-station");
+      setStationChatVisible("my-station", true);
+      if (location.pathname !== ROUTES.workStation.code.path) {
+        navigate(ROUTES.workStation.code.path);
+      }
+
+      if (destination === "new-tab") {
+        navigateChatPanel({ kind: CHAT_PANEL_SURFACE_KIND.SESSION });
+        openSessionInNewChatTab({
+          sessionId: options.sessionId,
+          sessionName: options.title,
+        });
+        return;
+      }
+
+      openSessionInWorkstation({
+        sessionId: options.sessionId,
+        title: options.title,
+      });
+    },
+    [
+      location.pathname,
+      navigate,
+      navigateChatPanel,
+      openSessionInNewChatTab,
+      openSessionInWorkstation,
+      setStationChatVisible,
+      setStationMode,
+    ]
+  );
+
   const {
     cloudMenuItems,
     cloudSessionMenuItems,
@@ -292,7 +330,7 @@ export const WorkstationSidebarConnector: React.FC = () => {
     selectedCloudMenuItemId,
     handleCloudSessionItemClick,
     resetCloudTeamPagination,
-    handleCloudRemoteItemRemove,
+    buildCloudRemoteItemMenuItems,
     cloudMemberFilterDropdown,
     cloudRemoteRowMap,
     cloudRemoteViewerMap,
@@ -307,6 +345,7 @@ export const WorkstationSidebarConnector: React.FC = () => {
     cloudMySessionsVisibleCount,
     revealedCloudOrgId: activeSessionSidebarRevealRequest?.cloudOrgId,
     revealedSidebarItemId: activeSessionSidebarRevealRequest?.sidebarItemId,
+    openSessionAtDestination: openCloudSessionAtDestination,
     handleCloudSessionFilterChange,
     personalHiddenCloudTaggedIds,
     cloudTaggedSessionIds,
@@ -507,7 +546,7 @@ export const WorkstationSidebarConnector: React.FC = () => {
     handleOpenInMyStation,
     handleTogglePin,
     handleToggleSubagentExpansion,
-    handleCloudRemoteItemRemove,
+    buildCloudRemoteItemMenuItems,
     t,
     tCommon,
     activeSessionMoreMenuId,

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.cloudMenuData.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.cloudMenuData.ts
@@ -20,6 +20,7 @@ import type { Session } from "@src/store/session";
 
 import { useCloudChannelsSection } from "./channelsSection";
 import { useCloudSessionsSection } from "./cloudSessionsSection";
+import type { UseCloudSessionsSectionParams } from "./cloudSessionsSection.types";
 
 interface UseWorkstationSidebarCloudMenuDataParams {
   activeCloudOrgId: string | null;
@@ -29,6 +30,7 @@ interface UseWorkstationSidebarCloudMenuDataParams {
   cloudMySessionsVisibleCount: number;
   revealedCloudOrgId: string | undefined;
   revealedSidebarItemId: string | undefined;
+  openSessionAtDestination: UseCloudSessionsSectionParams["openSessionAtDestination"];
   handleCloudSessionFilterChange: (filter: CloudSessionFilter) => void;
   personalHiddenCloudTaggedIds: ReadonlySet<string> | undefined;
   cloudTaggedSessionIds: ReadonlySet<string> | undefined;
@@ -51,6 +53,7 @@ export function useWorkstationSidebarCloudMenuData({
   cloudMySessionsVisibleCount,
   revealedCloudOrgId,
   revealedSidebarItemId,
+  openSessionAtDestination,
   handleCloudSessionFilterChange,
   personalHiddenCloudTaggedIds,
   cloudTaggedSessionIds,
@@ -62,7 +65,7 @@ export function useWorkstationSidebarCloudMenuData({
     selectedCloudMenuItemId,
     handleCloudSessionItemClick,
     resetCloudTeamPagination,
-    handleCloudRemoteItemRemove,
+    buildCloudRemoteItemMenuItems,
     cloudMemberFilterDropdown,
     cloudRemoteRowMap,
     cloudRemoteViewerMap,
@@ -76,6 +79,7 @@ export function useWorkstationSidebarCloudMenuData({
       revealedCloudOrgId === activeCloudOrgId
         ? revealedSidebarItemId
         : undefined,
+    openSessionAtDestination,
     onFilterChange: handleCloudSessionFilterChange,
   });
 
@@ -130,7 +134,7 @@ export function useWorkstationSidebarCloudMenuData({
       selectedChannelMenuItemId ?? selectedCloudMenuItemId,
     handleCloudSessionItemClick: handleCloudScopedItemClick,
     resetCloudTeamPagination,
-    handleCloudRemoteItemRemove,
+    buildCloudRemoteItemMenuItems,
     cloudMemberFilterDropdown,
     cloudRemoteRowMap,
     cloudRemoteViewerMap,

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.menuDecoration.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.menuDecoration.ts
@@ -56,7 +56,7 @@ interface UseWorkstationSidebarMenuDecorationParams {
   handleOpenInMyStation: ContextMenuParams["handleOpenInMyStation"];
   handleTogglePin: ContextMenuParams["handleTogglePin"];
   handleToggleSubagentExpansion: DecorateRowActionsParams["handleToggleSubagentExpansion"];
-  handleCloudRemoteItemRemove: ContextMenuParams["handleCloudRemoteItemRemove"];
+  buildCloudRemoteItemMenuItems: ContextMenuParams["buildCloudRemoteItemMenuItems"];
   t: (key: string) => string;
   tCommon: DecorateRowActionsParams["tCommon"];
   activeSessionMoreMenuId: DecorateRowActionsParams["activeSessionMoreMenuId"];
@@ -103,7 +103,7 @@ export function useWorkstationSidebarMenuDecoration({
   handleOpenInMyStation,
   handleTogglePin,
   handleToggleSubagentExpansion,
-  handleCloudRemoteItemRemove,
+  buildCloudRemoteItemMenuItems,
   t,
   tCommon,
   activeSessionMoreMenuId,
@@ -164,7 +164,7 @@ export function useWorkstationSidebarMenuDecoration({
     isCopyReferenceEligible: copyReference.isCopyReferenceEligible,
     handleCopyReference: copyReference.handleCopyReference,
     copyReferenceLabel: copyReference.copyReferenceLabel,
-    handleCloudRemoteItemRemove,
+    buildCloudRemoteItemMenuItems,
     tCommon,
   });
 

--- a/src/scaffold/NavigationSidebar/connectors/useWorkstationSidebarContextMenu.ts
+++ b/src/scaffold/NavigationSidebar/connectors/useWorkstationSidebarContextMenu.ts
@@ -1,5 +1,6 @@
 import { type MouseEvent, useCallback } from "react";
 
+import { dismissHoverCard } from "@src/components/SessionHoverCard/singletonStore";
 import { createLogger } from "@src/hooks/logger";
 import type { NavigationMenuItem } from "@src/scaffold/NavigationSidebar/components/NavigationMenu/config";
 import type { Session } from "@src/store/session";
@@ -51,8 +52,10 @@ interface UseWorkstationSidebarContextMenuParams {
   isCopyReferenceEligible: (session: Session) => boolean;
   handleCopyReference: (session: Session) => void;
   copyReferenceLabel: string;
-  /** Teammate cloud rows have no local Session; remove means local hide. */
-  handleCloudRemoteItemRemove?: (item: NavigationMenuItem) => boolean;
+  /** Team rows have no local Session and provide their own canonical menu. */
+  buildCloudRemoteItemMenuItems?: (
+    item: NavigationMenuItem
+  ) => NativeMenuItemOptions[];
   tCommon: (key: string, defaultValue?: string) => string;
 }
 
@@ -77,7 +80,7 @@ export function useWorkstationSidebarContextMenu({
   isCopyReferenceEligible,
   handleCopyReference,
   copyReferenceLabel,
-  handleCloudRemoteItemRemove,
+  buildCloudRemoteItemMenuItems,
   tCommon,
 }: UseWorkstationSidebarContextMenuParams): (
   event: MouseEvent,
@@ -98,13 +101,7 @@ export function useWorkstationSidebarContextMenu({
       }
 
       if (!sessionMap.has(item.id)) {
-        if (!handleCloudRemoteItemRemove) return [];
-        return [
-          {
-            text: tCommon("actions.remove", "Remove"),
-            action: () => handleCloudRemoteItemRemove(item),
-          },
-        ];
+        return buildCloudRemoteItemMenuItems?.(item) ?? [];
       }
 
       const isCursorIde = isCursorIdeSession(item.id);
@@ -214,7 +211,7 @@ export function useWorkstationSidebarContextMenu({
       handleCopyReference,
       isCopyReferenceEligible,
       copyReferenceLabel,
-      handleCloudRemoteItemRemove,
+      buildCloudRemoteItemMenuItems,
     ]
   );
 
@@ -223,6 +220,7 @@ export function useWorkstationSidebarContextMenu({
       event.preventDefault();
       event.stopPropagation();
       try {
+        dismissHoverCard();
         await popupNativeMenu({
           source: "workstation-sidebar-row",
           buildItems: () => buildMenuItems(key, item),


### PR DESCRIPTION
## Problem

Team Conversation rows used a separate overflow menu while their secondary-click menu exposed only Remove. They could not be opened directly in a new tab or My Station, and an existing session hover card could remain over either native menu.

## Solution

Build one canonical native menu for actionable Team Conversation rows and use it for both the ellipsis and secondary-click paths. Add Open in New Tab and Open in My Station actions that reuse the existing cloud replay/import lifecycle, including locally owned rows and imports already in progress. Dismiss the session hover card before either native menu opens.

## Potential risks

Remote conversations still depend on the existing replay/import lifecycle and native-menu behavior; an unavailable or metadata-only row intentionally exposes no action menu. No schema, persistence, IPC, or wire-format changes are included. Manual desktop verification and screenshots were not captured because local computer control was not authorized in this task.

## Verification

- `pnpm test -- src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionNativeMenuItems.test.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudScopedMenuItems.test.ts` — passed (10 tests).
- `pnpm exec eslint src/scaffold/NavigationSidebar/connectors/useWorkstationSidebarContextMenu.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionNativeMenuItems.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionNativeMenuItems.test.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.types.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.tsx src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/cloudSessionsSection.rowItemBuilder.tsx src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.cloudMenuData.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/sidebarConnector.menuDecoration.ts src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/index.tsx --max-warnings 0 --report-unused-disable-directives` — passed.
- `pnpm run typecheck` — passed.
- `pnpm run check:test-placement` and `git diff --check` — passed.
- The pre-commit hook completed successfully, including its scoped TypeScript and circular-dependency checks.
- Manual UI validation was not run; computer control was not authorized for this task.