### PR TITLE
fix(chat-panel): restore the window drag zone in the folded header

### DIFF
--- a/src/components/WindowChrome/PublishedHeaderSlotsView.tsx
+++ b/src/components/WindowChrome/PublishedHeaderSlotsView.tsx
@@ -14,10 +14,23 @@ export interface PublishedHeaderSlots {
   joinWithFollowingRow?: boolean;
 }
 
+const DRAG_STYLE = { WebkitAppRegion: "drag" } as React.CSSProperties;
+
 interface PublishedHeaderSlotsViewProps {
   slots: PublishedHeaderSlots | null;
   /** Left inset for host-specific chrome alignment. */
   paddingLeftClassName?: string;
+  /**
+   * Hand the space after `content` to the host window as a drag handle
+   * instead of stretching `content` across it.
+   *
+   * `content` normally carries the `flex-1`, which makes the whole middle of
+   * the row one no-drag region. That is fine while a tab bar sits above and
+   * owns dragging, but a row that is its own pane's only chrome has to offer
+   * a handle of its own — exactly as the tab strip does, where the strip is
+   * draggable and only the pills opt out.
+   */
+  dragFiller?: boolean;
 }
 
 /**
@@ -26,7 +39,11 @@ interface PublishedHeaderSlotsViewProps {
  */
 export const PublishedHeaderSlotsView: React.FC<PublishedHeaderSlotsViewProps> =
   memo(
-    ({ slots, paddingLeftClassName = HEADER_CONTENT_LEFT_PADDING_CLASS }) => {
+    ({
+      slots,
+      paddingLeftClassName = HEADER_CONTENT_LEFT_PADDING_CLASS,
+      dragFiller = false,
+    }) => {
       return (
         <div
           className={`flex min-w-0 flex-1 items-center ${paddingLeftClassName}`}
@@ -36,9 +53,20 @@ export const PublishedHeaderSlotsView: React.FC<PublishedHeaderSlotsViewProps> =
               {slots.leading}
             </NoDragRegion>
           )}
-          <NoDragRegion className="flex min-w-0 flex-1 items-center">
+          <NoDragRegion
+            className={`flex min-w-0 items-center ${dragFiller ? "" : "flex-1"}`}
+          >
             {slots?.content}
           </NoDragRegion>
+          {dragFiller && (
+            <div
+              className="h-full min-w-0 flex-1"
+              data-tauri-drag-region
+              data-testid="published-header-drag-filler"
+              style={DRAG_STYLE}
+              aria-hidden
+            />
+          )}
           {slots?.trailing && (
             <NoDragRegion className="flex shrink-0 items-center gap-px">
               {slots.trailing}

--- a/src/engines/ChatPanel/ChatPanelHeader.test.ts
+++ b/src/engines/ChatPanel/ChatPanelHeader.test.ts
@@ -104,6 +104,8 @@ describe("ChatPanelHeader tab row collapse", () => {
     expect(markup).not.toContain(
       'data-testid="chat-panel-collapsed-tab-controls"'
     );
+    // The tab row above still owns window dragging here.
+    expect(markup).not.toContain('data-testid="published-header-drag-filler"');
     expect(markup).toContain('style="height:80px"');
   });
 
@@ -124,8 +126,10 @@ describe("ChatPanelHeader tab row collapse", () => {
     expect(markup).not.toContain("transition-opacity");
     expect(markup).toContain('data-icon="x"');
     expect(markup).toContain('style="height:44px"');
-    // The maximized pane's only chrome — no rule under it.
+    // The maximized pane's only chrome — no rule under it, and it has to
+    // offer the window-drag handle the folded tab row used to provide.
     expect(markup).not.toContain("border-b border-border-2");
+    expect(markup).toContain('data-testid="published-header-drag-filler"');
     // The window-edge gap the folded 44px row used to hold (its pt-2).
     expect(markup).toContain('data-testid="chat-panel-collapsed-header"');
     expect(markup).toContain("padding-top:8px");

--- a/src/engines/ChatPanel/ChatPanelHeader.tsx
+++ b/src/engines/ChatPanel/ChatPanelHeader.tsx
@@ -421,6 +421,7 @@ export function ChatPanelHeader({
             ? getCollapsedSidebarChromeOffset()
             : undefined
         }
+        dragFiller
       />
     </div>
   ) : (

--- a/src/engines/ChatPanel/header/ChatPanelPublishedHeader.test.ts
+++ b/src/engines/ChatPanel/header/ChatPanelPublishedHeader.test.ts
@@ -47,6 +47,33 @@ describe("ChatPanelPublishedHeader", () => {
     expect(markup).not.toContain("border-b border-border-2");
   });
 
+  it("stretches content over the row when a tab bar above owns dragging", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(ChatPanelPublishedHeader, {
+        windowsHost: false,
+        slots: { content: React.createElement("span", null, "Content") },
+      })
+    );
+
+    expect(markup).toContain("flex min-w-0 flex-1 items-center");
+    expect(markup).not.toContain('data-testid="published-header-drag-filler"');
+  });
+
+  it("hands the space after content to the window when it is the only chrome", () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(ChatPanelPublishedHeader, {
+        windowsHost: false,
+        dragFiller: true,
+        slots: { content: React.createElement("span", null, "Content") },
+      })
+    );
+
+    // The filler is draggable; content no longer swallows the row.
+    expect(markup).toContain('data-testid="published-header-drag-filler"');
+    expect(markup).toContain("-webkit-app-region:drag");
+    expect(markup).toContain("Content");
+  });
+
   it("does not add an empty row when no pane has published controls", () => {
     expect(
       renderToStaticMarkup(

--- a/src/engines/ChatPanel/header/ChatPanelPublishedHeader.tsx
+++ b/src/engines/ChatPanel/header/ChatPanelPublishedHeader.tsx
@@ -17,11 +17,16 @@ interface ChatPanelPublishedHeaderProps {
    * set, and is only passed once this row inherited the pane's top edge.
    */
   leadingInsetPx?: number;
+  /**
+   * Offer the space after the title as a window-drag handle. Set once this row
+   * is the pane's only chrome and no tab bar above it owns dragging.
+   */
+  dragFiller?: boolean;
 }
 
 /** Chat-pane counterpart of My Station's shared 36px published header. */
 export const ChatPanelPublishedHeader: React.FC<ChatPanelPublishedHeaderProps> =
-  memo(({ slots, windowsHost, leadingInsetPx }) => {
+  memo(({ slots, windowsHost, leadingInsetPx, dragFiller }) => {
     if (!slots) return null;
 
     return (
@@ -41,6 +46,7 @@ export const ChatPanelPublishedHeader: React.FC<ChatPanelPublishedHeaderProps> =
         <PublishedHeaderSlotsView
           slots={slots}
           paddingLeftClassName={leadingInsetPx === undefined ? undefined : ""}
+          dragFiller={dragFiller}
         />
       </div>
     );


### PR DESCRIPTION
## Problem

Folding the chat pane's tab row (#1074) left a maximized pane with no way to
drag the window.

`PublishedHeaderSlotsView` puts the `flex-1` on the **content** slot, and that
slot is a `NoDragRegion`:

```tsx
<NoDragRegion className="flex min-w-0 flex-1 items-center">
  {slots?.content}
</NoDragRegion>
```

So the entire middle of the row — all the empty space beside the title — opts
out of window dragging. That was harmless while the 44px tab row sat above and
owned the handle: the tab strip is itself `flex-1` *and* `data-tauri-drag-region`,
with only the pills opting out, so the space beside the pills was grabbable.

With the tab row folded away, the published row is the pane's only chrome, and
its leading, content and trailing slots are all `NoDragRegion`. The sole
draggable area left is the 8px window-edge gap on the wrapper, which is not a
usable handle.

## Solution

`PublishedHeaderSlotsView` takes an opt-in `dragFiller`. When set, `content`
sizes to itself instead of carrying the `flex-1`, and the space after it becomes
an explicitly draggable filler — the same shape the tab strip already had.

```tsx
<NoDragRegion className={`flex min-w-0 items-center ${dragFiller ? "" : "flex-1"}`}>
  {slots?.content}
</NoDragRegion>
{dragFiller && <div className="h-full min-w-0 flex-1" data-tauri-drag-region … />}
```

Only the chat pane's folded row passes it, threaded through
`ChatPanelPublishedHeader`. My Station, session replay and channels keep
stretching content exactly as before — each still has a tab bar above owning the
handle, so none of them needs the filler.

Truncation is preserved: the filler is `flex-1 min-w-0` with the default
`flex-shrink`, so a long title collapses it to zero width and truncates as it
does today. The handle shrinks when the title is wide, which is the same
behaviour the tab strip had when pills filled it.

## Potential risks

- **Not verified in a real Tauri window.** `data-tauri-drag-region` is enforced
  by Tauri's runtime against the event target, which vitest and a browser cannot
  exercise. The tests below assert the filler renders, is marked draggable, and
  is not a `NoDragRegion` — they cannot prove the window actually moves. Dragging
  the folded chat-pane header on macOS is the check that matters and it has not
  been done.
- **Shared component touched.** `PublishedHeaderSlotsView` backs four hosts. The
  new branch is opt-in and defaults to today's markup, and a regression test
  pins the default (`flex min-w-0 flex-1 items-center`, no filler), but the
  change does sit in shared code.
- **Windows.** The chat pane sets `WebkitAppRegion: no-drag` on the whole header
  when `isWindows()`, because `WindowsTopBar` owns dragging there. The filler
  inherits that and is inert on Windows, which is correct but untested.
- No state, persistence, schema, IPC, wire or dependency changes. Rollback is a
  plain revert.

## Verification

- `npx tsc --noEmit --pretty false` — clean.
- `npx eslint src/components/WindowChrome src/engines/ChatPanel --max-warnings 0` — clean.
- `npx vitest run` — **1253 files, 9805 tests passed, 0 failed.**

New coverage in `ChatPanelPublishedHeader.test.ts` and `ChatPanelHeader.test.ts`:

- default (no `dragFiller`) still stretches content and renders no filler —
  pins the behaviour the other three hosts rely on;
- with `dragFiller`, the filler renders carrying `-webkit-app-region: drag`
  and content still renders;
- the collapsed chat-pane header renders the filler;
- the uncollapsed header does not, since the tab row above owns dragging.

**Did not run:** the app itself, so no verification that the window drags — see
the first risk. No Playwright/WebDriver run. No `cargo test --workspace`; the
diff contains no Rust.
