### PR TITLE
fix(chat-panel): drag the window from the folded header

### DIFF
--- a/src/components/WindowChrome/PublishedHeaderSlotsView.tsx
+++ b/src/components/WindowChrome/PublishedHeaderSlotsView.tsx
@@ -14,23 +14,10 @@ export interface PublishedHeaderSlots {
   joinWithFollowingRow?: boolean;
 }
 
-const DRAG_STYLE = { WebkitAppRegion: "drag" } as React.CSSProperties;
-
 interface PublishedHeaderSlotsViewProps {
   slots: PublishedHeaderSlots | null;
   /** Left inset for host-specific chrome alignment. */
   paddingLeftClassName?: string;
-  /**
-   * Hand the space after `content` to the host window as a drag handle
-   * instead of stretching `content` across it.
-   *
-   * `content` normally carries the `flex-1`, which makes the whole middle of
-   * the row one no-drag region. That is fine while a tab bar sits above and
-   * owns dragging, but a row that is its own pane's only chrome has to offer
-   * a handle of its own — exactly as the tab strip does, where the strip is
-   * draggable and only the pills opt out.
-   */
-  dragFiller?: boolean;
 }
 
 /**
@@ -39,11 +26,7 @@ interface PublishedHeaderSlotsViewProps {
  */
 export const PublishedHeaderSlotsView: React.FC<PublishedHeaderSlotsViewProps> =
   memo(
-    ({
-      slots,
-      paddingLeftClassName = HEADER_CONTENT_LEFT_PADDING_CLASS,
-      dragFiller = false,
-    }) => {
+    ({ slots, paddingLeftClassName = HEADER_CONTENT_LEFT_PADDING_CLASS }) => {
       return (
         <div
           className={`flex min-w-0 flex-1 items-center ${paddingLeftClassName}`}
@@ -53,20 +36,9 @@ export const PublishedHeaderSlotsView: React.FC<PublishedHeaderSlotsViewProps> =
               {slots.leading}
             </NoDragRegion>
           )}
-          <NoDragRegion
-            className={`flex min-w-0 items-center ${dragFiller ? "" : "flex-1"}`}
-          >
+          <NoDragRegion className="flex min-w-0 flex-1 items-center">
             {slots?.content}
           </NoDragRegion>
-          {dragFiller && (
-            <div
-              className="h-full min-w-0 flex-1"
-              data-tauri-drag-region
-              data-testid="published-header-drag-filler"
-              style={DRAG_STYLE}
-              aria-hidden
-            />
-          )}
           {slots?.trailing && (
             <NoDragRegion className="flex shrink-0 items-center gap-px">
               {slots.trailing}

--- a/src/engines/ChatPanel/ChatPanelHeader.test.ts
+++ b/src/engines/ChatPanel/ChatPanelHeader.test.ts
@@ -30,14 +30,12 @@ const noop = () => undefined;
 
 interface RenderOptions {
   tabRowCollapsed: boolean;
-  canCloseActiveTab?: boolean;
   sessionHeaderContent?: ReactNode;
   shouldOffsetHeaderForCollapsedSidebar?: boolean;
 }
 
 function render({
   tabRowCollapsed,
-  canCloseActiveTab = true,
   sessionHeaderContent = createElement("span", { "data-session-name": "true" }),
   shouldOffsetHeaderForCollapsedSidebar = false,
 }: RenderOptions): string {
@@ -86,8 +84,6 @@ function render({
       tabStrip: createElement("nav", { "data-tab-strip": "true" }),
       tabStripPlus: createElement("button", { "data-plus-menu": "true" }),
       tabRowCollapsed,
-      onCloseActiveTab: noop,
-      canCloseActiveTab,
       sessionHeaderContent,
     })
   );
@@ -104,8 +100,6 @@ describe("ChatPanelHeader tab row collapse", () => {
     expect(markup).not.toContain(
       'data-testid="chat-panel-collapsed-tab-controls"'
     );
-    // The tab row above still owns window dragging here.
-    expect(markup).not.toContain('data-testid="published-header-drag-filler"');
     expect(markup).toContain('style="height:80px"');
   });
 
@@ -124,12 +118,11 @@ describe("ChatPanelHeader tab row collapse", () => {
     expect(markup).toContain("group-hover:hidden");
     expect(markup).toContain("hidden group-hover:block");
     expect(markup).not.toContain("transition-opacity");
-    expect(markup).toContain('data-icon="x"');
+    // Close is deliberately not offered in the folded row.
+    expect(markup).not.toContain('data-icon="x"');
     expect(markup).toContain('style="height:44px"');
-    // The maximized pane's only chrome — no rule under it, and it has to
-    // offer the window-drag handle the folded tab row used to provide.
+    // The maximized pane's only chrome — no rule under it.
     expect(markup).not.toContain("border-b border-border-2");
-    expect(markup).toContain('data-testid="published-header-drag-filler"');
     // The window-edge gap the folded 44px row used to hold (its pt-2).
     expect(markup).toContain('data-testid="chat-panel-collapsed-header"');
     expect(markup).toContain("padding-top:8px");
@@ -172,15 +165,5 @@ describe("ChatPanelHeader tab row collapse", () => {
     const withSidebar = render({ tabRowCollapsed: true });
     expect(withSidebar).not.toContain("padding-left:");
     expect(withSidebar).toContain("pl-[15px]");
-  });
-});
-
-describe("collapsed close control", () => {
-  it("is dropped for a surface that cannot be closed away", () => {
-    const markup = render({ tabRowCollapsed: true, canCloseActiveTab: false });
-
-    expect(markup).toContain('data-testid="chat-panel-collapsed-tab-controls"');
-    expect(markup).toContain('data-plus-menu="true"');
-    expect(markup).not.toContain('data-icon="x"');
   });
 });

--- a/src/engines/ChatPanel/ChatPanelHeader.tsx
+++ b/src/engines/ChatPanel/ChatPanelHeader.tsx
@@ -11,7 +11,6 @@ import type { DropdownEnginePosition } from "@src/hooks/dropdown";
 import { getCollapsedSidebarChromeOffset } from "@src/hooks/ui/sidebar/useCollapsedSidebarChromeOffset";
 import {
   ArrowExpand01Icon,
-  Cancel01Icon,
   ComputerVideoIcon,
   HugeiconsIcon,
   PanelRightIcon,
@@ -37,6 +36,7 @@ import {
   CHAT_PANEL_HEADER_STACK_HEIGHT_PX,
   CHAT_PANEL_HEADER_TOP_PADDING_PX,
   CHAT_PANEL_TAB_HEADER_HEIGHT_PX,
+  shouldStartHeaderDragFromTarget,
 } from "./header/chatPanelHeaderLayout";
 import type { ChatPanelRegionNotice } from "./types";
 
@@ -93,10 +93,6 @@ interface ChatPanelHeaderProps {
    * tab controls the folded row would have carried.
    */
   tabRowCollapsed: boolean;
-  /** Close the pane's only tab from the collapsed row. */
-  onCloseActiveTab: () => void;
-  /** Whether that close control is offered at all — see the layout rule. */
-  canCloseActiveTab: boolean;
   /** Session-scoped extras (fork button / provenance chip), leading the toolbar */
   sessionHeaderExtras?: React.ReactNode;
   /** Canonical session-name breadcrumb rendered in the published 40px row. */
@@ -149,8 +145,6 @@ export function ChatPanelHeader({
   tabStrip,
   tabStripPlus,
   tabRowCollapsed,
-  onCloseActiveTab,
-  canCloseActiveTab,
   sessionHeaderExtras,
   sessionHeaderContent,
   overlayPublishedHeader = false,
@@ -318,9 +312,9 @@ export function ChatPanelHeader({
     </div>
   );
 
-  // The folded tab row's controls, rehomed on the published row. Close stays
-  // outermost so it keeps the far-right position it held on the pill, and is
-  // dropped entirely on the Launchpad, which cannot be closed away.
+  // The folded tab row's controls, rehomed on the published row. No close
+  // control: closing the pane's last tab only reseeds another one, so it
+  // earned no place in the row it would have crowded.
   const collapsedTabControls = (
     <div
       className="flex h-7 flex-shrink-0 items-center gap-px"
@@ -329,23 +323,6 @@ export function ChatPanelHeader({
     >
       {tabStripPlus}
       {chatFocusToggleButton}
-      {canCloseActiveTab && (
-        <span className="inline-flex">
-          <TabBarTrailingIconButton
-            title={t("common:actions.close")}
-            tooltipPosition="bottom-end"
-            nativeTitle={false}
-            onClick={onCloseActiveTab}
-          >
-            <HugeiconsIcon
-              icon={Cancel01Icon}
-              data-icon="x"
-              size={HEADER_ICON_SIZE.md}
-              strokeWidth={1.75}
-            />
-          </TabBarTrailingIconButton>
-        </span>
-      )}
     </div>
   );
 
@@ -398,11 +375,28 @@ export function ChatPanelHeader({
   // controls clear of the content — the tab row's job until it folds away.
   // Padding the wrapper rather than the row keeps the row's 40px content band
   // intact, and makes it the positioning context the sidebar button centers in.
+  // The window API is pulled in on interaction so it stays out of the boot graph.
+  const handleCollapsedHeaderMouseDown = (
+    event: React.MouseEvent<HTMLDivElement>
+  ) => {
+    if (windowsHost || event.button !== 0) return;
+    if (!shouldStartHeaderDragFromTarget(event.target as Element | null)) {
+      return;
+    }
+    const maximize = event.detail === 2;
+    event.preventDefault();
+    void import("@src/util/platform/ipcRenderer").then(
+      ({ maxWindow, startWindowDrag }) =>
+        maximize ? maxWindow() : startWindowDrag()
+    );
+  };
+
   const publishedHeaderRow = tabRowCollapsed ? (
     <div
-      className={`workspace-header header-tab-group relative z-40 flex flex-shrink-0 flex-col`}
+      className="workspace-header header-tab-group relative z-40 flex flex-shrink-0 flex-col"
       data-testid="chat-panel-collapsed-header"
       data-tauri-drag-region={windowsHost ? undefined : true}
+      onMouseDown={handleCollapsedHeaderMouseDown}
       style={
         {
           paddingTop: CHAT_PANEL_HEADER_TOP_PADDING_PX,
@@ -421,7 +415,6 @@ export function ChatPanelHeader({
             ? getCollapsedSidebarChromeOffset()
             : undefined
         }
-        dragFiller
       />
     </div>
   ) : (

--- a/src/engines/ChatPanel/header/ChatPanelPublishedHeader.test.ts
+++ b/src/engines/ChatPanel/header/ChatPanelPublishedHeader.test.ts
@@ -47,33 +47,6 @@ describe("ChatPanelPublishedHeader", () => {
     expect(markup).not.toContain("border-b border-border-2");
   });
 
-  it("stretches content over the row when a tab bar above owns dragging", () => {
-    const markup = renderToStaticMarkup(
-      React.createElement(ChatPanelPublishedHeader, {
-        windowsHost: false,
-        slots: { content: React.createElement("span", null, "Content") },
-      })
-    );
-
-    expect(markup).toContain("flex min-w-0 flex-1 items-center");
-    expect(markup).not.toContain('data-testid="published-header-drag-filler"');
-  });
-
-  it("hands the space after content to the window when it is the only chrome", () => {
-    const markup = renderToStaticMarkup(
-      React.createElement(ChatPanelPublishedHeader, {
-        windowsHost: false,
-        dragFiller: true,
-        slots: { content: React.createElement("span", null, "Content") },
-      })
-    );
-
-    // The filler is draggable; content no longer swallows the row.
-    expect(markup).toContain('data-testid="published-header-drag-filler"');
-    expect(markup).toContain("-webkit-app-region:drag");
-    expect(markup).toContain("Content");
-  });
-
   it("does not add an empty row when no pane has published controls", () => {
     expect(
       renderToStaticMarkup(

--- a/src/engines/ChatPanel/header/ChatPanelPublishedHeader.tsx
+++ b/src/engines/ChatPanel/header/ChatPanelPublishedHeader.tsx
@@ -17,16 +17,11 @@ interface ChatPanelPublishedHeaderProps {
    * set, and is only passed once this row inherited the pane's top edge.
    */
   leadingInsetPx?: number;
-  /**
-   * Offer the space after the title as a window-drag handle. Set once this row
-   * is the pane's only chrome and no tab bar above it owns dragging.
-   */
-  dragFiller?: boolean;
 }
 
 /** Chat-pane counterpart of My Station's shared 36px published header. */
 export const ChatPanelPublishedHeader: React.FC<ChatPanelPublishedHeaderProps> =
-  memo(({ slots, windowsHost, leadingInsetPx, dragFiller }) => {
+  memo(({ slots, windowsHost, leadingInsetPx }) => {
     if (!slots) return null;
 
     return (
@@ -46,7 +41,6 @@ export const ChatPanelPublishedHeader: React.FC<ChatPanelPublishedHeaderProps> =
         <PublishedHeaderSlotsView
           slots={slots}
           paddingLeftClassName={leadingInsetPx === undefined ? undefined : ""}
-          dragFiller={dragFiller}
         />
       </div>
     );

--- a/src/engines/ChatPanel/header/chatPanelHeaderLayout.test.ts
+++ b/src/engines/ChatPanel/header/chatPanelHeaderLayout.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, expect, it } from "vitest";
 
 import {
@@ -11,8 +12,8 @@ import {
   resolveChatPanelChromeTopInsetPx,
   resolveTranscriptTopPaddingPx,
   shouldCollapseChatPanelTabRow,
-  shouldOfferCollapsedTabClose,
   shouldOverlayChatSessionHeaders,
+  shouldStartHeaderDragFromTarget,
 } from "./chatPanelHeaderLayout";
 
 describe("chat panel header overlay", () => {
@@ -125,19 +126,42 @@ describe("collapsing the tab row into the published header", () => {
   });
 });
 
-describe("collapsed close control", () => {
-  it("is withheld on the Launchpad, which closing would only recreate", () => {
-    expect(shouldOfferCollapsedTabClose("start-page")).toBe(false);
+describe("window drag from the folded header", () => {
+  function build(html: string): HTMLElement {
+    const host = document.createElement("div");
+    host.innerHTML = html;
+    return host;
+  }
+
+  it("drags from the header's own background", () => {
+    const host = build('<div id="bg"><span id="label">Session</span></div>');
+    expect(shouldStartHeaderDragFromTarget(host.querySelector("#bg"))).toBe(
+      true
+    );
+    // Plain text in the row is background too — nothing to click.
+    expect(shouldStartHeaderDragFromTarget(host.querySelector("#label"))).toBe(
+      true
+    );
   });
 
-  it("is offered for every surface the user can actually close away", () => {
-    for (const type of ["session", "terminal", "runtime", "channel"]) {
-      expect(shouldOfferCollapsedTabClose(type)).toBe(true);
+  it("steps aside for anything the user can actually click", () => {
+    for (const html of [
+      '<button id="t">x</button>',
+      '<a id="t" href="#">x</a>',
+      '<div role="button" id="t">x</div>',
+      '<div role="menuitem" id="t">x</div>',
+      '<input id="t" />',
+      '<div contenteditable="true" id="t">x</div>',
+      // ...including when the press lands on a child of the control.
+      '<button><span id="t">x</span></button>',
+    ]) {
+      expect(
+        shouldStartHeaderDragFromTarget(build(html).querySelector("#t"))
+      ).toBe(false);
     }
   });
 
-  it("is withheld when there is no active tab to close", () => {
-    expect(shouldOfferCollapsedTabClose(null)).toBe(false);
-    expect(shouldOfferCollapsedTabClose(undefined)).toBe(false);
+  it("ignores a press with no target", () => {
+    expect(shouldStartHeaderDragFromTarget(null)).toBe(false);
   });
 });

--- a/src/engines/ChatPanel/header/chatPanelHeaderLayout.ts
+++ b/src/engines/ChatPanel/header/chatPanelHeaderLayout.ts
@@ -65,16 +65,27 @@ export function shouldCollapseChatPanelTabRow({
 }
 
 /**
- * Whether the collapsed row offers a close control.
- *
- * Closing the pane's last tab reseeds a fresh Launchpad, so on the Launchpad
- * itself the control could only ever replace the page with a copy of itself.
- * Every other surface is genuinely closable.
+ * Controls the folded header must never drag the window out from under.
  */
-export function shouldOfferCollapsedTabClose(
-  activeTabType: string | null | undefined
+const HEADER_INTERACTIVE_SELECTOR =
+  'button,a,input,select,textarea,[role="button"],[role="menuitem"],[role="tab"],[contenteditable="true"]';
+
+/**
+ * Whether a mousedown on the folded header should start a window drag.
+ *
+ * Tauri matches `data-tauri-drag-region` on the event target alone and never
+ * walks ancestors, so only the exact element under the cursor counts. In this
+ * row that element is never the one carrying the attribute: the content slot
+ * stretches over the whole row, and the session breadcrumb inside it is a
+ * `container-type: inline-size` element, which cannot be shrunk to its content
+ * to free the space up — containment makes it contribute zero width, so it
+ * collapses and takes the title with it. The folded row therefore drives the
+ * drag itself and steps aside only for things the user can actually click.
+ */
+export function shouldStartHeaderDragFromTarget(
+  target: Element | null
 ): boolean {
-  return Boolean(activeTabType) && activeTabType !== "start-page";
+  return Boolean(target) && !target?.closest(HEADER_INTERACTIVE_SELECTOR);
 }
 
 /** Floating-chrome height the transcript scrolls beneath. */

--- a/src/engines/ChatPanel/index.tsx
+++ b/src/engines/ChatPanel/index.tsx
@@ -29,7 +29,6 @@ import { getChatPanelBackgroundStyle } from "@src/modules/shared/layouts/viewCon
 import { installAvailableAppUpdate } from "@src/scaffold/AppUpdater";
 import {
   chatPanelTabCountAtom,
-  closeAndDestroyChatPanelTabAtom,
   closeOrganizationChatPanelTabAtom,
   closeProjectOrgChatPanelTabsAtom,
   closeRevokedCloudChannelChatPanelTabsAtom,
@@ -96,7 +95,6 @@ import { FocusedChatWorkstationMinimapPortalContext } from "./focusedChatWorksta
 import {
   resolveChatPanelChromeTopInsetPx,
   shouldCollapseChatPanelTabRow,
-  shouldOfferCollapsedTabClose,
   shouldOverlayChatSessionHeaders,
 } from "./header/chatPanelHeaderLayout";
 import { useAiWorkItemCreator } from "./hooks/useAiWorkItemCreator";
@@ -298,11 +296,6 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
       showSessionSurface,
     });
     const tabCount = useAtomValue(chatPanelTabCountAtom);
-    const closeChatPanelTab = useSetAtom(closeAndDestroyChatPanelTabAtom);
-    const handleCloseActiveTab = useCallback(() => {
-      if (!activeTab) return;
-      void closeChatPanelTab(activeTab.id);
-    }, [activeTab, closeChatPanelTab]);
     const isStandaloneToolTabActive =
       activeTab?.type === "work-management" || activeTab?.type === "runtime";
     const stationAvailable = isChatPanelTabStationAvailable(
@@ -642,8 +635,6 @@ const ChatPanel: React.FC<ChatPanelProps> = memo(
         tabStrip={tabStrip}
         tabStripPlus={tabStripPlus}
         tabRowCollapsed={tabRowCollapsed}
-        onCloseActiveTab={handleCloseActiveTab}
-        canCloseActiveTab={shouldOfferCollapsedTabClose(activeTab?.type)}
         sessionHeaderExtras={
           <>
             <SessionViewersIndicator sessionId={currentSessionId ?? null} />

--- a/src/util/platform/ipcRenderer.ts
+++ b/src/util/platform/ipcRenderer.ts
@@ -33,6 +33,13 @@ export const closeWindow = async (): Promise<void> => {
   }
 };
 
+/** Hand the current pointer-drag to the OS window manager. */
+export const startWindowDrag = async (): Promise<void> => {
+  if (currentWindow) {
+    await currentWindow.startDragging();
+  }
+};
+
 export const minWindow = async (): Promise<void> => {
   if (currentWindow) {
     await currentWindow.minimize();


### PR DESCRIPTION
## Problem

**The previous fix, #1076, did not work.** It is merged on `develop` and the
folded chat-pane header is still undraggable. This PR replaces it.

#1076 assumed the leftover space in the published header just needed *an
element carrying `data-tauri-drag-region`*, so it added a filler and stopped
the content slot stretching. Both halves were wrong:

1. **The filler had no height.** It used `h-full` inside an `items-center` row
   whose own height is content-driven, so `height: 100%` resolved against an
   indefinite parent and the empty div collapsed to **0px tall** — full width,
   no height, therefore never the event target.
2. **Shrinking the content slot hid the session title.** `SessionHeaderViewControls`
   is a `@container/sessionview` root, i.e. `container-type: inline-size`, and
   containment makes an element contribute **zero** width to a shrink-to-fit
   parent. Dropping `flex-1` collapsed the slot and took the title with it —
   which is the regression that showed up right after #1076 landed.

Measured in a browser, content width by variant (800px row, size container
present vs absent):

| content slot | plain child | `container-type: inline-size` child |
|---|---|---|
| `flex: 1 1 0%` (original) | 333px | **333px** |
| auto (#1076) | 94px | **0px** |
| `flex: 0 1 auto` | 94px | **0px** |
| `width: max-content` | 94px | **0px** |

So no arrangement of that row can both show the title and leave bare space for
the attribute. Tauri matches `data-tauri-drag-region` on `e.target` alone and
never walks ancestors (`tauri-2.10.3/src/window/scripts/drag.js`), and the only
element under the cursor in that space is a size container that must keep
`flex-1` to render at all.

## Solution

The folded row drives the drag itself. On `mousedown` it calls
`startDragging()` (or `maxWindow()` on double-click, matching what the
attribute path does), stepping aside for anything the user can actually click:

```ts
export function shouldStartHeaderDragFromTarget(target: Element | null): boolean {
  return Boolean(target) && !target?.closest(HEADER_INTERACTIVE_SELECTOR);
}
```

`PublishedHeaderSlotsView` and `ChatPanelPublishedHeader` are reverted to
exactly what they were before #1076 — the `dragFiller` prop is gone, the
content slot keeps its `flex-1`, and the three other hosts (My Station, session
replay, channels) are untouched. `startWindowDrag` joins the existing window
controls in `ipcRenderer`, and the module is imported dynamically inside the
handler so it stays out of the boot graph.

Also in this PR, per review feedback: the close control is removed from the
folded row entirely (closing the pane's last tab only reseeds another), along
with its prop, its layout rule and its tests.

## Potential risks

- **Verified by hand, not by CI.** The drag was confirmed working in the real
  app; the title rendering after the revert was **not** re-confirmed visually
  before this PR was opened. The revert restores the exact pre-#1076 markup for
  the content slot, so it should be identical to what shipped before, but that
  is reasoning rather than observation.
- **A custom drag path.** This row no longer relies on `data-tauri-drag-region`
  and can drift from the attribute's behaviour if Tauri changes it. The
  attribute stays on the wrapper, so the 8px window-edge gap still drags the
  declarative way.
- **Selector-based opt-out.** `HEADER_INTERACTIVE_SELECTOR` lists the control
  types in this row today. A future control that is none of those and is not
  inside one would start a drag instead of receiving its press.
- **Windows** is excluded (`WindowsTopBar` owns dragging); untested there.
- No state, schema, IPC, wire or dependency changes. Revert is clean.

## Verification

- `npx tsc --noEmit --pretty false` — clean.
- `npx eslint src/engines/ChatPanel src/components/WindowChrome src/util/platform --max-warnings 0` — clean.
- Browser measurement of the flex/containment behaviour above, which is what
  identified the real cause.
- **Manual:** dragging the folded header moves the window (this is the check
  #1076 lacked, and it is why that fix shipped broken).

New tests cover `shouldStartHeaderDragFromTarget`: the header background and
plain text drag; `button`, `a`, `input`, `[role=button]`, `[role=menuitem]`,
`contenteditable` and a child of a control do not; a null target does not.

**Full suite: 1252 files passed, 3 failed (9 tests).** None are mine — all are
load-induced timeouts in timing-sensitive DOM suites
(`RawPromptToggle.test.ts`, `messageLazyContainer.test.ts`), failing with
`Test timed out in 15000ms` and a toast-render timeout rather than assertion
errors. That run took 1204s against a normal ~170s because the machine was
running the app and other work concurrently; the same suites passed earlier in
the day. Leaving CI to give the authoritative result.

Hooks were skipped on the commit (`--no-verify`) at the author's instruction,
so CI is the gate for this change.
