### PR TITLE
feat(sidebar-filter): move grouping into a second-level menu

### DIFF
--- a/src/components/Dropdown/exports.ts
+++ b/src/components/Dropdown/exports.ts
@@ -55,6 +55,15 @@ export type { DropdownSearchProps } from "./DropdownSearch";
 
 export { default as DropdownSelectedCheck } from "./DropdownSelectedCheck";
 
+// Second-level (submenu) panel geometry
+export { clampSubmenuTop, getSubmenuAnchor } from "./submenuLayout";
+export type {
+  SubmenuAnchor,
+  SubmenuAnchorInput,
+  SubmenuRect,
+  SubmenuTopInput,
+} from "./submenuLayout";
+
 export { default as DropdownHeader } from "./DropdownHeader";
 export type { DropdownHeaderProps } from "./DropdownHeader";
 

--- a/src/components/Dropdown/submenuLayout.test.ts
+++ b/src/components/Dropdown/submenuLayout.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type SubmenuAnchor,
+  type SubmenuRect,
+  clampSubmenuTop,
+  getSubmenuAnchor,
+} from "./submenuLayout";
+
+function rect({
+  top,
+  left,
+  width,
+  height,
+}: {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}): SubmenuRect {
+  return { bottom: top + height, left, right: left + width, top };
+}
+
+describe("getSubmenuAnchor", () => {
+  it("opens to the right of the row and aligns with it", () => {
+    const anchor = getSubmenuAnchor({
+      triggerRect: rect({ top: 280, left: 20, width: 380, height: 32 }),
+      parentRect: rect({ top: 40, left: 20, width: 380, height: 660 }),
+      submenuWidth: 220,
+      viewportWidth: 1440,
+      viewportHeight: 900,
+      opensUpward: false,
+    });
+
+    expect(anchor).toEqual({
+      left: 408,
+      opensUpward: false,
+      parentBottom: 700,
+      parentTop: 40,
+      top: 276,
+    });
+  });
+
+  it("flips to the left of the row when the right side would overflow", () => {
+    const anchor = getSubmenuAnchor({
+      triggerRect: rect({ top: 100, left: 1000, width: 200, height: 32 }),
+      parentRect: rect({ top: 60, left: 1000, width: 200, height: 300 }),
+      submenuWidth: 220,
+      viewportWidth: 1280,
+      viewportHeight: 900,
+      opensUpward: false,
+    });
+
+    expect(anchor.left).toBe(772);
+  });
+
+  it("falls back to viewport bounds when the parent panel is not mounted", () => {
+    const anchor = getSubmenuAnchor({
+      triggerRect: rect({ top: 4, left: 20, width: 180, height: 32 }),
+      parentRect: null,
+      submenuWidth: 220,
+      viewportWidth: 1440,
+      viewportHeight: 900,
+      opensUpward: true,
+    });
+
+    expect(anchor.parentTop).toBe(8);
+    expect(anchor.parentBottom).toBe(892);
+    // Never above the viewport padding, even for a row near the top edge.
+    expect(anchor.top).toBe(8);
+  });
+});
+
+function anchorWith(overrides: Partial<SubmenuAnchor> = {}): SubmenuAnchor {
+  return {
+    left: 408,
+    opensUpward: false,
+    parentBottom: 700,
+    parentTop: 40,
+    top: 276,
+    ...overrides,
+  };
+}
+
+describe("clampSubmenuTop", () => {
+  it("keeps a short submenu at its row-aligned top", () => {
+    expect(
+      clampSubmenuTop({
+        anchor: anchorWith(),
+        submenuHeight: 160,
+        viewportHeight: 900,
+      })
+    ).toBe(276);
+  });
+
+  it("pulls a submenu up so it stops at the parent menu's bottom", () => {
+    expect(
+      clampSubmenuTop({
+        anchor: anchorWith({ top: 640 }),
+        submenuHeight: 200,
+        viewportHeight: 900,
+      })
+    ).toBe(500);
+  });
+
+  it("bottom-aligns a too-tall submenu with an upward-opening parent", () => {
+    expect(
+      clampSubmenuTop({
+        anchor: anchorWith({
+          opensUpward: true,
+          parentTop: 80,
+          parentBottom: 600,
+          top: 396,
+        }),
+        submenuHeight: 560,
+        viewportHeight: 900,
+      })
+    ).toBe(40);
+  });
+
+  it("top-aligns a too-tall submenu with a downward-opening parent", () => {
+    expect(
+      clampSubmenuTop({
+        anchor: anchorWith({ parentTop: 80, parentBottom: 600, top: 396 }),
+        submenuHeight: 560,
+        viewportHeight: 900,
+      })
+    ).toBe(80);
+  });
+
+  it("never pushes the submenu past the viewport's bottom padding", () => {
+    expect(
+      clampSubmenuTop({
+        anchor: anchorWith({ parentBottom: 2000, top: 800 }),
+        submenuHeight: 300,
+        viewportHeight: 900,
+      })
+    ).toBe(592);
+  });
+});

--- a/src/components/Dropdown/submenuLayout.ts
+++ b/src/components/Dropdown/submenuLayout.ts
@@ -1,0 +1,105 @@
+/**
+ * Geometry for second-level (submenu) panels opened from a row of a
+ * first-level menu.
+ *
+ * Two steps, deliberately split so both are pure and testable:
+ *
+ * 1. `getSubmenuAnchor` runs when the row opens the submenu, from the row's
+ *    rect and the parent panel's rect. It picks the side (right of the parent
+ *    unless the viewport has no room, then left) and the preferred top.
+ * 2. `clampSubmenuTop` runs after the submenu has rendered and its real height
+ *    is known. It keeps the panel inside both the viewport and the parent
+ *    menu's vertical span, and — when the submenu is taller than that span —
+ *    aligns it to whichever edge the parent menu grew from.
+ */
+import { DROPDOWN_PANEL } from "./tokens";
+
+/** The subset of `DOMRect` this module reads. */
+export interface SubmenuRect {
+  bottom: number;
+  left: number;
+  right: number;
+  top: number;
+}
+
+export interface SubmenuAnchor {
+  left: number;
+  /** The parent menu opened upward, so a tall submenu bottom-aligns with it. */
+  opensUpward: boolean;
+  parentBottom: number;
+  parentTop: number;
+  top: number;
+}
+
+export interface SubmenuAnchorInput {
+  triggerRect: SubmenuRect;
+  /** Null when the parent panel is not mounted yet; the viewport bounds it. */
+  parentRect: SubmenuRect | null;
+  submenuWidth: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  opensUpward: boolean;
+}
+
+export function getSubmenuAnchor({
+  triggerRect,
+  parentRect,
+  submenuWidth,
+  viewportWidth,
+  viewportHeight,
+  opensUpward,
+}: SubmenuAnchorInput): SubmenuAnchor {
+  const rightSideLeft = triggerRect.right + DROPDOWN_PANEL.submenuGap;
+  const left =
+    rightSideLeft + submenuWidth > viewportWidth
+      ? triggerRect.left - submenuWidth - DROPDOWN_PANEL.submenuGap
+      : rightSideLeft;
+
+  return {
+    left,
+    opensUpward,
+    parentTop: parentRect?.top ?? DROPDOWN_PANEL.viewportPadding,
+    parentBottom:
+      parentRect?.bottom ?? viewportHeight - DROPDOWN_PANEL.viewportPadding,
+    // Pull up by the panel padding so the first submenu row lines up with the
+    // row that opened it rather than sitting one padding step lower.
+    top: Math.max(
+      DROPDOWN_PANEL.viewportPadding,
+      triggerRect.top - DROPDOWN_PANEL.padding
+    ),
+  };
+}
+
+export interface SubmenuTopInput {
+  anchor: SubmenuAnchor;
+  submenuHeight: number;
+  viewportHeight: number;
+}
+
+export function clampSubmenuTop({
+  anchor,
+  submenuHeight,
+  viewportHeight,
+}: SubmenuTopInput): number {
+  const viewportTop = DROPDOWN_PANEL.viewportPadding;
+  const viewportBottom = viewportHeight - DROPDOWN_PANEL.viewportPadding;
+  const boundaryTop = Math.max(viewportTop, anchor.parentTop);
+  const boundaryBottom = Math.min(viewportBottom, anchor.parentBottom);
+  const boundaryHeight = boundaryBottom - boundaryTop;
+  const boundaryAlignedTop = anchor.opensUpward
+    ? boundaryBottom - submenuHeight
+    : boundaryTop;
+  const parentClampedTop =
+    submenuHeight > boundaryHeight
+      ? boundaryAlignedTop
+      : Math.min(
+          Math.max(anchor.top, boundaryTop),
+          boundaryBottom - submenuHeight
+        );
+  const viewportMaxTop = Math.max(
+    DROPDOWN_PANEL.viewportPadding,
+    viewportHeight - submenuHeight - DROPDOWN_PANEL.viewportPadding
+  );
+
+  return Math.max(viewportTop, Math.min(parentClampedTop, viewportMaxTop));
+}

--- a/src/components/Dropdown/tokens.ts
+++ b/src/components/Dropdown/tokens.ts
@@ -496,6 +496,8 @@ export const DROPDOWN_WIDTHS = {
   wideMenuClass: "min-w-[200px]",
   /** Panel dropdown — info popover, tooltip panel */
   panelWidthClass: "min-w-[220px]",
+  /** Numeric twin of `panelWidthClass`, for panels positioned in script. */
+  panelWidth: 220,
   /** Fixed-width status-bar panel (ports menu) */
   fixedStatusPanelClass: "w-[250px]",
   /** File tree dropdown, multi-select panels */

--- a/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuButton.tsx
@@ -11,6 +11,10 @@ import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
 import {
+  clampSubmenuTop,
+  getSubmenuAnchor,
+} from "@src/components/Dropdown/submenuLayout";
+import {
   DROPDOWN_CLASSES,
   DROPDOWN_ITEM,
   DROPDOWN_PANEL,
@@ -57,8 +61,6 @@ import {
   type SubmenuPosition,
 } from "./SidebarSettingsMenuSubmenus";
 
-const SUBMENU_WIDTH_PX = 220;
-const SUBMENU_GAP_PX = DROPDOWN_PANEL.submenuGap;
 const MENU_ICON_CLASS_NAME = "shrink-0 text-text-2";
 const MENU_ARROW_CLASS_NAME = "text-text-3";
 type SettingsUtilityPanel = "ram";
@@ -80,25 +82,15 @@ function getSubmenuPosition(
   parentPanel: HTMLElement | null,
   opensUpward: boolean
 ): SubmenuPosition {
-  const rect = trigger.getBoundingClientRect();
-  const parentRect = parentPanel?.getBoundingClientRect();
-  const { width: vpWidth, height: viewportHeight } = getViewportSize();
-  const rightSideLeft = rect.right + SUBMENU_GAP_PX;
-  const left =
-    rightSideLeft + SUBMENU_WIDTH_PX > vpWidth
-      ? rect.left - SUBMENU_WIDTH_PX - SUBMENU_GAP_PX
-      : rightSideLeft;
-  return {
-    left,
+  const { width: viewportWidth, height: viewportHeight } = getViewportSize();
+  return getSubmenuAnchor({
+    triggerRect: trigger.getBoundingClientRect(),
+    parentRect: parentPanel?.getBoundingClientRect() ?? null,
+    submenuWidth: DROPDOWN_WIDTHS.panelWidth,
+    viewportWidth,
+    viewportHeight,
     opensUpward,
-    parentTop: parentRect?.top ?? DROPDOWN_PANEL.viewportPadding,
-    parentBottom:
-      parentRect?.bottom ?? viewportHeight - DROPDOWN_PANEL.viewportPadding,
-    top: Math.max(
-      DROPDOWN_PANEL.viewportPadding,
-      rect.top - DROPDOWN_PANEL.padding
-    ),
-  };
+  });
 }
 
 const SidebarSettingsMenuButton: React.FC<SidebarSettingsMenuButtonProps> = ({
@@ -130,32 +122,11 @@ const SidebarSettingsMenuButton: React.FC<SidebarSettingsMenuButtonProps> = ({
     const { height: submenuHeight } =
       submenuPanelRef.current.getBoundingClientRect();
     const { height: viewportHeight } = getViewportSize();
-    const viewportTop = DROPDOWN_PANEL.viewportPadding;
-    const viewportBottom = viewportHeight - DROPDOWN_PANEL.viewportPadding;
-    const boundaryTop = Math.max(viewportTop, submenuPosition.parentTop);
-    const boundaryBottom = Math.min(
-      viewportBottom,
-      submenuPosition.parentBottom
-    );
-    const boundaryHeight = boundaryBottom - boundaryTop;
-    const boundaryAlignedTop = submenuPosition.opensUpward
-      ? boundaryBottom - submenuHeight
-      : boundaryTop;
-    const parentClampedTop =
-      submenuHeight > boundaryHeight
-        ? boundaryAlignedTop
-        : Math.min(
-            Math.max(submenuPosition.top, boundaryTop),
-            boundaryBottom - submenuHeight
-          );
-    const viewportMaxTop = Math.max(
-      DROPDOWN_PANEL.viewportPadding,
-      viewportHeight - submenuHeight - DROPDOWN_PANEL.viewportPadding
-    );
-    const clampedTop = Math.max(
-      viewportTop,
-      Math.min(parentClampedTop, viewportMaxTop)
-    );
+    const clampedTop = clampSubmenuTop({
+      anchor: submenuPosition,
+      submenuHeight,
+      viewportHeight,
+    });
 
     if (clampedTop === submenuPosition.top) return;
     setSubmenuPosition((current) =>

--- a/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuSubmenus.tsx
+++ b/src/scaffold/NavigationSidebar/blocks/SidebarSettingsMenuSubmenus.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createPortal } from "react-dom";
 
 import DropdownSelectedCheck from "@src/components/Dropdown/DropdownSelectedCheck";
+import type { SubmenuAnchor } from "@src/components/Dropdown/submenuLayout";
 import {
   DROPDOWN_CLASSES,
   DROPDOWN_WIDTHS,
@@ -13,13 +14,8 @@ import { SidebarLayoutSettingsSubmenu } from "./SidebarLayoutSettingsSubmenu";
 
 export type SettingsSubmenu = "presence" | "appearance" | "layout";
 
-export interface SubmenuPosition {
-  left: number;
-  opensUpward: boolean;
-  parentBottom: number;
-  parentTop: number;
-  top: number;
-}
+/** Placement of a settings submenu, computed by the shared submenu geometry. */
+export type SubmenuPosition = SubmenuAnchor;
 
 interface AppearanceOption {
   value: AppearanceMode;

--- a/src/scaffold/NavigationSidebar/connectors/SessionFilterButton.tsx
+++ b/src/scaffold/NavigationSidebar/connectors/SessionFilterButton.tsx
@@ -1,8 +1,20 @@
-import React, { type FC, useCallback } from "react";
+import React, {
+  type FC,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
 import { DropdownItem, DropdownPanel } from "@src/components/Dropdown/exports";
+import {
+  type SubmenuAnchor,
+  clampSubmenuTop,
+  getSubmenuAnchor,
+} from "@src/components/Dropdown/submenuLayout";
 import {
   DROPDOWN_CLASSES,
   DROPDOWN_ITEM,
@@ -13,16 +25,20 @@ import IconButton from "@src/components/IconButton";
 import { ToolbarTooltip } from "@src/components/KeyboardShortcut/ToolbarTooltip";
 import { useDropdownEngine } from "@src/hooks/dropdown";
 import {
+  ArrowRight01Icon,
   FilterMailIcon,
   FolderInputIcon,
   FolderOutputIcon,
+  FolderSymlinkIcon,
   HugeiconsIcon,
+  Layers01Icon,
   ListChevronsDownUpIcon,
   Refresh04Icon,
   SlidersHorizontalIcon,
   SquareArrowUpRight02Icon,
   TickDouble01Icon,
 } from "@src/icons";
+import { getViewportSize } from "@src/util/ui/window/viewport";
 
 import HoverAnimatedIcon, {
   triggerIconAnimation,
@@ -72,6 +88,30 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
   }) => {
     const { t } = useTranslation("navigation");
     const { t: tCommon } = useTranslation("common");
+    // Grouping lives one level down: it is a mode the user sets rarely, while
+    // every other row here acts on the list immediately. Keeping the three
+    // modes out of the first level keeps the actions readable at a glance and
+    // still shows the current mode on the row that opens them.
+    const groupTriggerRef = useRef<HTMLDivElement | null>(null);
+    const submenuPanelRef = useRef<HTMLDivElement | null>(null);
+    const submenuInsideRefs = useMemo(() => [submenuPanelRef], []);
+    const [isGroupSubmenuOpen, setIsGroupSubmenuOpen] = useState(false);
+    const [submenuAnchor, setSubmenuAnchor] = useState<SubmenuAnchor | null>(
+      null
+    );
+
+    const closeGroupSubmenu = useCallback(() => {
+      setIsGroupSubmenuOpen(false);
+      setSubmenuAnchor(null);
+    }, []);
+
+    const handleMenuOpenChange = useCallback(
+      (open: boolean) => {
+        if (!open) closeGroupSubmenu();
+      },
+      [closeGroupSubmenu]
+    );
+
     const {
       isOpen,
       isPositioned,
@@ -87,14 +127,73 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
       // Click-opened sidebar menu: own keyboard focus so Escape works even
       // when focus was parked in the chat composer / terminal pane.
       captureKeyboardFocus: true,
+      onOpenChange: handleMenuOpenChange,
+      additionalInsideRefs: submenuInsideRefs,
     });
+
+    // The submenu's real height is only known once it has rendered, so the
+    // anchor's preferred top is corrected here rather than on open.
+    useLayoutEffect(() => {
+      if (!isGroupSubmenuOpen || !submenuAnchor || !submenuPanelRef.current) {
+        return;
+      }
+
+      const { height: submenuHeight } =
+        submenuPanelRef.current.getBoundingClientRect();
+      const { height: viewportHeight } = getViewportSize();
+      const clampedTop = clampSubmenuTop({
+        anchor: submenuAnchor,
+        submenuHeight,
+        viewportHeight,
+      });
+
+      if (clampedTop === submenuAnchor.top) return;
+      setSubmenuAnchor((current) =>
+        current ? { ...current, top: clampedTop } : current
+      );
+    }, [isGroupSubmenuOpen, submenuAnchor]);
+
+    const openGroupSubmenu = useCallback(
+      (trigger: HTMLElement) => {
+        const { width: viewportWidth, height: viewportHeight } =
+          getViewportSize();
+        setSubmenuAnchor(
+          getSubmenuAnchor({
+            triggerRect: trigger.getBoundingClientRect(),
+            parentRect: panelRef.current?.getBoundingClientRect() ?? null,
+            submenuWidth: DROPDOWN_WIDTHS.panelWidth,
+            viewportWidth,
+            viewportHeight,
+            opensUpward: panelPosition.bottom !== undefined,
+          })
+        );
+        setIsGroupSubmenuOpen(true);
+      },
+      [panelPosition.bottom, panelRef]
+    );
+
+    const handleGroupTriggerEnter = useCallback(() => {
+      const trigger = groupTriggerRef.current;
+      if (trigger) openGroupSubmenu(trigger);
+    }, [openGroupSubmenu]);
+
+    const handleGroupTriggerClick = useCallback(() => {
+      // Keyboard and automated interactions never fire the hover that normally
+      // opens this row, so a click opens it too.
+      if (isGroupSubmenuOpen) {
+        closeGroupSubmenu();
+        return;
+      }
+      handleGroupTriggerEnter();
+    }, [closeGroupSubmenu, handleGroupTriggerEnter, isGroupSubmenuOpen]);
 
     const handleSelect = useCallback(
       (mode: string) => {
         onSelect(mode);
+        closeGroupSubmenu();
         close();
       },
-      [onSelect, close]
+      [onSelect, closeGroupSubmenu, close]
     );
 
     const handleToggleIncludeExternal = useCallback(() => {
@@ -130,6 +229,25 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
       onImportSessionJson?.();
       close();
     }, [onImportSessionJson, close]);
+
+    const handleSubmenuPointerDown = useCallback(
+      (event: React.PointerEvent<HTMLDivElement>) => {
+        event.stopPropagation();
+      },
+      []
+    );
+
+    const handleSubmenuMouseDown = useCallback(
+      (event: React.MouseEvent<HTMLDivElement>) => {
+        event.stopPropagation();
+      },
+      []
+    );
+
+    const resolveGroupByLabel = useCallback(
+      (mode: string) => getGroupByLabel?.(mode) ?? t(`sidebar.groupBy.${mode}`),
+      [getGroupByLabel, t]
+    );
 
     const hasExtraActions = Boolean(
       onCollapseAll ||
@@ -187,25 +305,54 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
               }}
             >
               <div className={DROPDOWN_CLASSES.itemsColumnPadded}>
-                <div className={DROPDOWN_CLASSES.sectionLabel}>
+                <DropdownItem
+                  ref={groupTriggerRef}
+                  dataTestId="sidebar-group-by-trigger"
+                  className={
+                    isGroupSubmenuOpen ? DROPDOWN_CLASSES.itemActive : ""
+                  }
+                  icon={
+                    <HugeiconsIcon
+                      icon={Layers01Icon}
+                      data-icon="layers"
+                      size={DROPDOWN_ITEM.iconSize}
+                      strokeWidth={2}
+                    />
+                  }
+                  suffix={
+                    <span className="flex items-center gap-1">
+                      <span className="text-text-3">
+                        {resolveGroupByLabel(groupByMode)}
+                      </span>
+                      <HugeiconsIcon
+                        icon={ArrowRight01Icon}
+                        data-icon="chevron-right"
+                        size={DROPDOWN_ITEM.iconSize}
+                        strokeWidth={2}
+                        className="text-text-3"
+                      />
+                    </span>
+                  }
+                  ariaHasPopup="menu"
+                  ariaExpanded={isGroupSubmenuOpen}
+                  onMouseEnter={handleGroupTriggerEnter}
+                  onClick={handleGroupTriggerClick}
+                >
                   {t("sidebar.groupBy.title")}
-                </div>
-                {groupByModes.map((mode) => {
-                  const active = mode === groupByMode;
-                  return (
-                    <DropdownItem
-                      key={mode}
-                      dataTestId={`sidebar-group-by-${mode}`}
-                      selected={active}
-                      onClick={() => handleSelect(mode)}
-                    >
-                      {getGroupByLabel?.(mode) ?? t(`sidebar.groupBy.${mode}`)}
-                    </DropdownItem>
-                  );
-                })}
+                </DropdownItem>
                 <div className={DROPDOWN_CLASSES.menuGroupSeparator} />
                 <DropdownItem
+                  dataTestId="sidebar-include-external"
                   selected={includeExternal}
+                  icon={
+                    <HugeiconsIcon
+                      icon={FolderSymlinkIcon}
+                      data-icon="folder-symlink"
+                      size={DROPDOWN_ITEM.iconSize}
+                      strokeWidth={2}
+                    />
+                  }
+                  onMouseEnter={closeGroupSubmenu}
                   onClick={handleToggleIncludeExternal}
                 >
                   {t("sidebar.filters.includeExternal")}
@@ -224,6 +371,7 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
                             strokeWidth={2}
                           />
                         }
+                        onMouseEnter={closeGroupSubmenu}
                         onClick={handleRefreshSessions}
                       >
                         {tCommon("actions.refresh")}
@@ -240,6 +388,7 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
                           />
                         }
                         disabled={!canExportSessionJson}
+                        onMouseEnter={closeGroupSubmenu}
                         onClick={handleExportSessionJson}
                       >
                         {tCommon("sessions:chat.importExport.exportAction")}
@@ -255,6 +404,7 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
                             strokeWidth={2}
                           />
                         }
+                        onMouseEnter={closeGroupSubmenu}
                         onClick={handleImportSessionJson}
                       >
                         {tCommon("sessions:chat.importExport.importAction")}
@@ -270,6 +420,7 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
                             strokeWidth={2}
                           />
                         }
+                        onMouseEnter={closeGroupSubmenu}
                         onClick={handleCollapseAll}
                       >
                         {t("sidebar.actions.collapseAll")}
@@ -285,6 +436,7 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
                             strokeWidth={2}
                           />
                         }
+                        onMouseEnter={closeGroupSubmenu}
                         onClick={handleMarkAllRead}
                       >
                         {t("sidebar.actions.markAllRead")}
@@ -317,12 +469,45 @@ export const SessionFilterButton: FC<SessionFilterButtonProps> = React.memo(
                           className="text-text-3"
                         />
                       }
+                      onMouseEnter={closeGroupSubmenu}
                       onClick={handleConfigureExternalSources}
                     >
                       {t("sidebar.filters.manageExternalSources")}
                     </DropdownItem>
                   </>
                 )}
+              </div>
+            </DropdownPanel>,
+            document.body
+          )}
+
+        {isOpen &&
+          isGroupSubmenuOpen &&
+          submenuAnchor &&
+          createPortal(
+            <DropdownPanel
+              ref={submenuPanelRef}
+              className={`${DROPDOWN_WIDTHS.panelWidthClass} fixed`}
+              maxHeight="none"
+              style={{ top: submenuAnchor.top, left: submenuAnchor.left }}
+              data-testid="sidebar-group-by-submenu"
+              onPointerDown={handleSubmenuPointerDown}
+              onMouseDown={handleSubmenuMouseDown}
+            >
+              <div className={DROPDOWN_CLASSES.itemsColumnPadded}>
+                <div className={DROPDOWN_CLASSES.sectionLabel}>
+                  {t("sidebar.groupBy.title")}
+                </div>
+                {groupByModes.map((mode) => (
+                  <DropdownItem
+                    key={mode}
+                    dataTestId={`sidebar-group-by-${mode}`}
+                    selected={mode === groupByMode}
+                    onClick={() => handleSelect(mode)}
+                  >
+                    {resolveGroupByLabel(mode)}
+                  </DropdownItem>
+                ))}
               </div>
             </DropdownPanel>,
             document.body

--- a/src/scaffold/NavigationSidebar/connectors/__tests__/SessionFilterButton.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/__tests__/SessionFilterButton.test.ts
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+import React, { act } from "react";
+import { type Root, createRoot } from "react-dom/client";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { SessionFilterButton } from "../SessionFilterButton";
+
+const mocks = vi.hoisted(() => ({
+  closeDropdown: vi.fn(),
+  toggleDropdown: vi.fn(),
+}));
+
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock("@src/hooks/dropdown", () => ({
+  useDropdownEngine: () => ({
+    isOpen: true,
+    isPositioned: true,
+    toggle: mocks.toggleDropdown,
+    close: mocks.closeDropdown,
+    triggerRef: { current: null },
+    panelRef: { current: null },
+    // Sidebar bottom bar: the panel grows upward from the button.
+    panelPosition: { bottom: 48, left: 12, width: 180 },
+  }),
+}));
+
+vi.mock("@src/components/KeyboardShortcut/ToolbarTooltip", () => ({
+  ToolbarTooltip: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+const reactActEnvironment = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
+};
+
+function queryTestId(testId: string): HTMLElement | null {
+  return document.body.querySelector<HTMLElement>(`[data-testid="${testId}"]`);
+}
+
+describe("SessionFilterButton", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let onSelect: ReturnType<typeof vi.fn>;
+
+  beforeAll(() => {
+    reactActEnvironment.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  beforeEach(async () => {
+    onSelect = vi.fn();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root.render(
+        React.createElement(SessionFilterButton, {
+          groupByMode: "byTime",
+          includeExternal: true,
+          onSelect,
+          onToggleIncludeExternal: vi.fn(),
+          onRefreshSessions: vi.fn(),
+          onCollapseAll: vi.fn(),
+          onMarkAllRead: vi.fn(),
+          onConfigureExternalSources: vi.fn(),
+        })
+      );
+    });
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    Reflect.deleteProperty(reactActEnvironment, "IS_REACT_ACT_ENVIRONMENT");
+  });
+
+  it("keeps the grouping modes one level down and names the active one", () => {
+    const trigger = queryTestId("sidebar-group-by-trigger");
+
+    expect(trigger).not.toBeNull();
+    expect(trigger?.textContent).toContain("sidebar.groupBy.title");
+    expect(trigger?.textContent).toContain("sidebar.groupBy.byTime");
+    expect(trigger?.getAttribute("aria-expanded")).toBe("false");
+
+    // The first level keeps only the actions; no mode is selectable yet.
+    expect(queryTestId("sidebar-group-by-byTime")).toBeNull();
+    expect(queryTestId("sidebar-group-by-byWorkspace")).toBeNull();
+    expect(queryTestId("sidebar-group-by-byAgent")).toBeNull();
+    expect(queryTestId("sidebar-refresh-sessions")).not.toBeNull();
+  });
+
+  it("gives Include External a leading icon like every other action row", () => {
+    const includeExternal = queryTestId("sidebar-include-external");
+
+    expect(
+      includeExternal?.querySelector('[data-icon="folder-symlink"]')
+    ).not.toBeNull();
+    // Selected, so the trailing check still marks the state the icon labels.
+    expect(includeExternal?.getAttribute("aria-selected")).toBe("true");
+  });
+
+  it("opens the second level on hover with the active mode checked", async () => {
+    await act(async () => {
+      queryTestId("sidebar-group-by-trigger")?.dispatchEvent(
+        new MouseEvent("mouseover", { bubbles: true })
+      );
+    });
+
+    expect(queryTestId("sidebar-group-by-submenu")).not.toBeNull();
+    expect(
+      queryTestId("sidebar-group-by-trigger")?.getAttribute("aria-expanded")
+    ).toBe("true");
+    expect(
+      queryTestId("sidebar-group-by-byTime")?.getAttribute("aria-selected")
+    ).toBe("true");
+    expect(
+      queryTestId("sidebar-group-by-byWorkspace")?.getAttribute("aria-selected")
+    ).toBe("false");
+    expect(queryTestId("sidebar-group-by-byAgent")).not.toBeNull();
+  });
+
+  it("opens the second level on click, for pointerless interaction", async () => {
+    await act(async () => {
+      queryTestId("sidebar-group-by-trigger")?.click();
+    });
+
+    expect(queryTestId("sidebar-group-by-submenu")).not.toBeNull();
+
+    await act(async () => {
+      queryTestId("sidebar-group-by-trigger")?.click();
+    });
+
+    expect(queryTestId("sidebar-group-by-submenu")).toBeNull();
+  });
+
+  it("selects a mode from the second level and closes the whole menu", async () => {
+    await act(async () => {
+      queryTestId("sidebar-group-by-trigger")?.click();
+    });
+    await act(async () => {
+      queryTestId("sidebar-group-by-byWorkspace")?.click();
+    });
+
+    expect(onSelect).toHaveBeenCalledWith("byWorkspace");
+    expect(mocks.closeDropdown).toHaveBeenCalledTimes(1);
+    expect(queryTestId("sidebar-group-by-submenu")).toBeNull();
+  });
+
+  it("dismisses the second level when the pointer moves to another row", async () => {
+    await act(async () => {
+      queryTestId("sidebar-group-by-trigger")?.click();
+    });
+    expect(queryTestId("sidebar-group-by-submenu")).not.toBeNull();
+
+    await act(async () => {
+      queryTestId("sidebar-refresh-sessions")?.dispatchEvent(
+        new MouseEvent("mouseover", { bubbles: true })
+      );
+    });
+
+    expect(queryTestId("sidebar-group-by-submenu")).toBeNull();
+  });
+});

--- a/tests/e2e/specs/core/agent-org-pause-resume-ui.spec.mjs
+++ b/tests/e2e/specs/core/agent-org-pause-resume-ui.spec.mjs
@@ -645,6 +645,8 @@ describe("Agent Org pause, resume, and sidebar rendered UI", () => {
           await browser
             .$('[data-testid="sidebar-session-filter-button"]')
             .click();
+          // Grouping lives in the menu's second level; the row opens it.
+          await browser.$('[data-testid="sidebar-group-by-trigger"]').click();
           await browser.$('[data-testid="sidebar-group-by-byAgent"]').click();
           await browser
             .$('[data-testid="sidebar-session-filter-button"]')


### PR DESCRIPTION
## Problem

The sidebar session filter menu opened with a **Group by** section — a
section label plus one row per mode (By time / By workspace / By Agent) —
sitting above every action that operates on the list. Grouping is a mode a
user sets rarely, so three of the menu's rows were spent on it, pushing
Refresh, Collapse all, Mark all read and Manage external sources further
down and making the actions harder to scan.

`Include External` was also the only row in that menu without a leading
icon, so its label hung off the icon column every other row shares.

## Solution

Grouping moves one level down. The first level now carries a single
**Group by** row that names the currently active mode and opens the three
choices as a second-level panel; the modes keep their existing
`sidebar-group-by-<mode>` test ids and their checked state. The row opens
on hover, matching the settings menu next to it in the same bottom bar, and
also on click so keyboard and automated interaction can reach it. Hovering
any sibling row dismisses the submenu.

`Include External` gains a `FolderSymlinkIcon`, so every row in the first
level now lines up on the same icon column.

The submenu geometry needed for this already existed, in one copy, inside
`SidebarSettingsMenuButton`. Rather than write a second copy it moves to
`src/components/Dropdown/submenuLayout.ts` as two pure functions —
`getSubmenuAnchor` (which side, preferred top) and `clampSubmenuTop`
(correct the top once the rendered height is known) — and both menus call
it. `DROPDOWN_WIDTHS.panelWidth` replaces the local `220` magic number that
had to stay in sync with `panelWidthClass`.

No new i18n keys: the row and the submenu header both reuse
`sidebar.groupBy.title`.

## Potential risks

- **e2e.** `agent-org-pause-resume-ui.spec.mjs` was the one place clicking
  `sidebar-group-by-byAgent` directly; it now clicks the
  `sidebar-group-by-trigger` row first. The WebdriverIO suite was not run
  here, so that edit is unverified against a real browser.
- **Shared geometry has a second consumer.** The
  `SidebarSettingsMenuButton` change is a pure move — the extracted math is
  transcribed unchanged and its two existing positioning tests
  ("aligns a second-level menu with the row that opens it",
  "bottom-aligns a tall upward submenu") pass untouched — but a future
  change to the shared module now affects both menus.
- **Hover-open ergonomics.** Moving the pointer diagonally off the trigger
  row across a sibling row closes the submenu instead of reaching it. This
  matches the existing settings menu; no hover-safe bridge was added.
- **No visual evidence.** The app was not launched for this change, so
  there are no screenshots of the submenu at a viewport edge (where it
  flips to the left of the parent) or in dark theme. The geometry is
  covered by unit tests instead, but that is not a substitute for looking
  at it.
- One extra click is now required to change grouping. That is the intended
  trade for a shorter, action-first first level.

## Verification

- `npx vitest run src/components/Dropdown src/scaffold/NavigationSidebar` —
  50 files, 256 tests, all pass. Includes 8 new geometry tests
  (`submenuLayout.test.ts`), 6 new `SessionFilterButton` tests (modes
  absent from the first level, hover-open with the active mode checked,
  click-toggle, select-and-close, dismiss-on-sibling-hover, the
  `Include External` icon), and the pre-existing settings-menu positioning
  tests unchanged.
- `npx tsc --noEmit --pretty false` — clean, whole project.
- `npx eslint` and `npx prettier --check` — clean on every changed file.
- **Not run:** the WebdriverIO e2e suite, and the app itself. No
  screenshots for the reason given above.
- `pnpm run check:test-placement` reports one offender,
  `src/store/ui/miniTerminalAtom.test.ts` — an untracked file from
  unrelated in-flight work in the same checkout, not part of this branch.
