### PR TITLE
feat(workstation-ports): add rescan footer and collapsible sections

### DIFF
--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -1117,7 +1117,11 @@
       "stopProcess": "Prozess beenden",
       "searchPlaceholder": "Ports suchen…",
       "noSearchResults": "Keine passenden Ports",
-      "openAddress": "{{address}} öffnen"
+      "openAddress": "{{address}} öffnen",
+      "rescan": "Neu scannen",
+      "rescanning": "Wird gescannt…",
+      "rescanTooltip": "Erneut nach offenen Ports suchen",
+      "lastScannedAt": "Zuletzt gescannt um {{time}}"
     },
     "noLanguageServicesActive": "No language services active",
     "linesSelected": "{{count}} lines selected",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -990,7 +990,11 @@
       "stopProcess": "Stop Process",
       "searchPlaceholder": "Search ports…",
       "noSearchResults": "No matching ports",
-      "openAddress": "Open {{address}}"
+      "openAddress": "Open {{address}}",
+      "rescan": "Rescan",
+      "rescanning": "Scanning…",
+      "rescanTooltip": "Scan for listening ports again",
+      "lastScannedAt": "Last scanned at {{time}}"
     },
     "ci": {
       "openPullRequest": "Open pull request on GitHub",

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -1117,7 +1117,11 @@
       "stopProcess": "Detener proceso",
       "searchPlaceholder": "Buscar puertos…",
       "noSearchResults": "No hay puertos coincidentes",
-      "openAddress": "Abrir {{address}}"
+      "openAddress": "Abrir {{address}}",
+      "rescan": "Volver a escanear",
+      "rescanning": "Escaneando…",
+      "rescanTooltip": "Buscar de nuevo puertos en escucha",
+      "lastScannedAt": "Último escaneo a las {{time}}"
     },
     "noLanguageServicesActive": "No language services active",
     "linesSelected": "{{count}} lines selected",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1117,7 +1117,11 @@
       "stopProcess": "Arrêter le processus",
       "searchPlaceholder": "Rechercher des ports…",
       "noSearchResults": "Aucun port correspondant",
-      "openAddress": "Ouvrir {{address}}"
+      "openAddress": "Ouvrir {{address}}",
+      "rescan": "Analyser à nouveau",
+      "rescanning": "Analyse…",
+      "rescanTooltip": "Rechercher à nouveau les ports en écoute",
+      "lastScannedAt": "Dernière analyse à {{time}}"
     },
     "noLanguageServicesActive": "No language services active",
     "linesSelected": "{{count}} lines selected",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -1116,7 +1116,11 @@
       "stopProcess": "プロセスを停止",
       "searchPlaceholder": "ポートを検索…",
       "noSearchResults": "一致するポートがありません",
-      "openAddress": "{{address}} を開く"
+      "openAddress": "{{address}} を開く",
+      "rescan": "再スキャン",
+      "rescanning": "スキャン中…",
+      "rescanTooltip": "待ち受けポートを再検出します",
+      "lastScannedAt": "最終スキャン {{time}}"
     },
     "noLanguageServicesActive": "No language services active",
     "linesSelected": "{{count}} lines selected",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -1116,7 +1116,11 @@
       "stopProcess": "프로세스 중지",
       "searchPlaceholder": "포트 검색…",
       "noSearchResults": "일치하는 포트 없음",
-      "openAddress": "{{address}} 열기"
+      "openAddress": "{{address}} 열기",
+      "rescan": "다시 검색",
+      "rescanning": "검색 중…",
+      "rescanTooltip": "수신 대기 포트를 다시 검색합니다",
+      "lastScannedAt": "마지막 검색 {{time}}"
     },
     "noLanguageServicesActive": "No language services active",
     "linesSelected": "{{count}} lines selected",

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -1121,7 +1121,11 @@
       "stopProcess": "Zatrzymaj proces",
       "searchPlaceholder": "Szukaj portów…",
       "noSearchResults": "Brak pasujących portów",
-      "openAddress": "Otwórz {{address}}"
+      "openAddress": "Otwórz {{address}}",
+      "rescan": "Skanuj ponownie",
+      "rescanning": "Skanowanie…",
+      "rescanTooltip": "Ponownie wyszukaj nasłuchujące porty",
+      "lastScannedAt": "Ostatnie skanowanie o {{time}}"
     },
     "noLanguageServicesActive": "Brak aktywnych usług językowych",
     "linesSelected": "Zaznaczono {{count}} linii",

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -1117,7 +1117,11 @@
       "stopProcess": "Parar processo",
       "searchPlaceholder": "Pesquisar portas…",
       "noSearchResults": "Nenhuma porta correspondente",
-      "openAddress": "Abrir {{address}}"
+      "openAddress": "Abrir {{address}}",
+      "rescan": "Verificar novamente",
+      "rescanning": "A verificar…",
+      "rescanTooltip": "Procurar novamente portas em escuta",
+      "lastScannedAt": "Última verificação às {{time}}"
     },
     "noLanguageServicesActive": "Nenhum serviço de linguagem ativo",
     "linesSelected": "{{count}} linhas selecionadas",

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -1121,7 +1121,11 @@
       "stopProcess": "Остановить процесс",
       "searchPlaceholder": "Поиск портов…",
       "noSearchResults": "Нет подходящих портов",
-      "openAddress": "Открыть {{address}}"
+      "openAddress": "Открыть {{address}}",
+      "rescan": "Пересканировать",
+      "rescanning": "Сканирование…",
+      "rescanTooltip": "Снова найти прослушиваемые порты",
+      "lastScannedAt": "Последнее сканирование в {{time}}"
     },
     "noLanguageServicesActive": "No language services active",
     "linesSelected": "{{count}} lines selected",

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -1118,7 +1118,11 @@
       "stopProcess": "Süreci durdur",
       "searchPlaceholder": "Port ara…",
       "noSearchResults": "Eşleşen port yok",
-      "openAddress": "{{address}} adresini aç"
+      "openAddress": "{{address}} adresini aç",
+      "rescan": "Yeniden tara",
+      "rescanning": "Taranıyor…",
+      "rescanTooltip": "Dinlenen bağlantı noktalarını yeniden tara",
+      "lastScannedAt": "Son tarama: {{time}}"
     },
     "noLanguageServicesActive": "No language services active",
     "linesSelected": "{{count}} lines selected",

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -1116,7 +1116,11 @@
       "stopProcess": "Dừng tiến trình",
       "searchPlaceholder": "Tìm cổng…",
       "noSearchResults": "Không có cổng khớp",
-      "openAddress": "Mở {{address}}"
+      "openAddress": "Mở {{address}}",
+      "rescan": "Quét lại",
+      "rescanning": "Đang quét…",
+      "rescanTooltip": "Tìm lại các cổng đang lắng nghe",
+      "lastScannedAt": "Quét lần cuối lúc {{time}}"
     },
     "noLanguageServicesActive": "No language services active",
     "linesSelected": "{{count}} lines selected",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -1129,7 +1129,11 @@
       "stopProcess": "停止程序",
       "searchPlaceholder": "搜尋連接埠…",
       "noSearchResults": "沒有符合的連接埠",
-      "openAddress": "開啟 {{address}}"
+      "openAddress": "開啟 {{address}}",
+      "rescan": "重新掃描",
+      "rescanning": "掃描中…",
+      "rescanTooltip": "重新掃描正在監聽的連接埠",
+      "lastScannedAt": "上次掃描於 {{time}}"
     },
     "noLanguageServicesActive": "沒有活躍的 Language Service",
     "linesSelected": "已選擇 {{count}} 行",

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -978,7 +978,11 @@
       "stopProcess": "停止进程",
       "searchPlaceholder": "搜索端口…",
       "noSearchResults": "没有匹配的端口",
-      "openAddress": "打开 {{address}}"
+      "openAddress": "打开 {{address}}",
+      "rescan": "重新扫描",
+      "rescanning": "扫描中…",
+      "rescanTooltip": "重新扫描正在监听的端口",
+      "lastScannedAt": "上次扫描于 {{time}}"
     },
     "ci": {
       "openPullRequest": "在 GitHub 中打开 Pull Request",

--- a/src/modules/WorkStation/shared/StatusBar/PortsStatusMenu.tsx
+++ b/src/modules/WorkStation/shared/StatusBar/PortsStatusMenu.tsx
@@ -14,13 +14,17 @@ import {
   DROPDOWN_PANEL,
   DROPDOWN_WIDTHS,
 } from "@src/components/Dropdown/tokens";
+import { REFRESH_ICON_TOKENS } from "@src/components/RefreshIcon/tokens";
+import { resolveTimeZoneForIntl } from "@src/config/timezone";
 import { useDropdownEngine } from "@src/hooks/dropdown";
 import { createLogger } from "@src/hooks/logger";
 import {
+  ArrowRight01Icon,
   Copy01Icon,
   HugeiconsIcon,
   InternetIcon,
   Loading03Icon,
+  Refresh04Icon,
   ServerStack03Icon,
   StopIcon,
 } from "@src/icons";
@@ -33,13 +37,17 @@ import {
   workspacePortCountAtom,
   workspacePortProbesAtom,
   workspacePortsAtom,
+  workspacePortsLastScanStartedAtAtom,
+  workspacePortsRefreshingAtom,
 } from "@src/store/workstation/codeEditor/workspacePortsAtom";
 import { requestNewBrowserSessionAtom } from "@src/store/workstation/workstationTabBarAtoms";
 import { copyText } from "@src/util/data/clipboard";
+import { toIntlLocaleTag } from "@src/util/data/formatters/date";
 import { classNames } from "@src/util/ui/classNames";
 
 import { StatusBarButton, StatusBarLabel } from "./StatusBarBase";
 import { StatusBarTooltip } from "./StatusBarTooltip";
+import { useWorkspacePortScanSync } from "./useWorkspacePortScanSync";
 import {
   refreshWorkspacePortScan,
   stopWorkspacePort,
@@ -194,18 +202,72 @@ function sectionLabelWithCount(label: string, count: number): string {
   return `${label} · ${count}`;
 }
 
+interface PortSectionHeaderProps {
+  label: string;
+  count: number;
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+/** Collapsible section header: chevron points right when collapsed, down when open. */
+const PortSectionHeader: React.FC<PortSectionHeaderProps> = memo(
+  ({ label, count, expanded, onToggle }) => (
+    <button
+      type="button"
+      className={classNames(
+        DROPDOWN_CLASSES.sectionLabel,
+        "flex w-full cursor-pointer items-center gap-1 text-left hover:text-text-2"
+      )}
+      onClick={onToggle}
+      aria-expanded={expanded}
+      data-dropdown-keyboard-skip="true"
+    >
+      <HugeiconsIcon
+        icon={ArrowRight01Icon}
+        data-icon="chevron-right"
+        size={12}
+        className={classNames(
+          "shrink-0 transition-transform duration-150",
+          expanded ? "rotate-90" : ""
+        )}
+        aria-hidden
+      />
+      <span className="truncate">{sectionLabelWithCount(label, count)}</span>
+    </button>
+  )
+);
+PortSectionHeader.displayName = "PortSectionHeader";
+
+/** Clock time of the last scan, in the user's language and timezone preference. */
+function formatScanClockTime(timestamp: number, language: string): string {
+  try {
+    return new Date(timestamp).toLocaleTimeString(toIntlLocaleTag(language), {
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZone: resolveTimeZoneForIntl(),
+    });
+  } catch {
+    return "";
+  }
+}
+
 export const PortsStatusMenu: React.FC = memo(() => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const ports = useAtomValue(workspacePortsAtom);
   const workspaceCount = useAtomValue(workspacePortCountAtom);
   const externalCount = useAtomValue(externalPortCountAtom);
   const folders = useAtomValue(workspacePortProbesAtom);
+  const refreshing = useAtomValue(workspacePortsRefreshingAtom);
+  const lastScanStartedAt = useAtomValue(workspacePortsLastScanStartedAtAtom);
   const requestNewBrowserSession = useSetAtom(requestNewBrowserSessionAtom);
   const [stoppingPortId, setStoppingPortId] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
+  const [workspaceExpanded, setWorkspaceExpanded] = useState(true);
   const [externalExpanded, setExternalExpanded] = useState(
     () => workspaceCount === 0 && externalCount > 0
   );
+
+  useWorkspacePortScanSync();
 
   const {
     isOpen,
@@ -243,12 +305,27 @@ export const PortsStatusMenu: React.FC = memo(() => {
     }
   }, [isOpen]);
 
+  const runScan = useCallback(() => {
+    refreshWorkspacePortScan({ folders, force: true }).catch(() => {
+      // refreshWorkspacePortScan already logged the failure; swallow here so a
+      // failed scan never surfaces as an unhandled rejection.
+    });
+  }, [folders]);
+
+  const toggleWorkspaceSection = useCallback(() => {
+    setWorkspaceExpanded((value) => !value);
+  }, []);
+
+  const toggleExternalSection = useCallback(() => {
+    setExternalExpanded((value) => !value);
+  }, []);
+
   const handleToggle = useCallback(() => {
     if (!isOpen) {
-      void refreshWorkspacePortScan({ folders, force: true });
+      runScan();
     }
     toggle();
-  }, [folders, isOpen, toggle]);
+  }, [isOpen, runScan, toggle]);
 
   const handleOpen = useCallback(
     (port: WorkspacePort) => {
@@ -289,6 +366,20 @@ export const PortsStatusMenu: React.FC = memo(() => {
   );
 
   const hasAnyMatches = workspaceGroups.length > 0 || externalPorts.length > 0;
+
+  const workspacePortMatches = useMemo(
+    () =>
+      workspaceGroups.reduce((total, group) => total + group.ports.length, 0),
+    [workspaceGroups]
+  );
+
+  const workspaceOpen = workspaceExpanded || isSearching;
+  const externalOpen = externalExpanded || isSearching;
+
+  const lastScanLabel =
+    lastScanStartedAt > 0 && !refreshing
+      ? formatScanClockTime(lastScanStartedAt, i18n.language)
+      : "";
 
   return (
     <div ref={triggerRef} className="flex h-full">
@@ -356,39 +447,41 @@ export const PortsStatusMenu: React.FC = memo(() => {
                       )}
                     </>
                   ) : (
-                    workspaceGroups.map((group) => (
-                      <React.Fragment key={group.folderId}>
-                        {group.ports.map((port) => (
-                          <PortRow
-                            key={port.id}
-                            port={port}
-                            onOpen={handleOpen}
-                            onCopy={handleCopy}
-                            onStop={handleStop}
-                            stopping={stoppingPortId === port.id}
-                          />
+                    <>
+                      <PortSectionHeader
+                        label={t("workstation.ports.workspaceSection")}
+                        count={workspacePortMatches}
+                        expanded={workspaceOpen}
+                        onToggle={toggleWorkspaceSection}
+                      />
+                      {workspaceOpen &&
+                        workspaceGroups.map((group) => (
+                          <React.Fragment key={group.folderId}>
+                            {group.ports.map((port) => (
+                              <PortRow
+                                key={port.id}
+                                port={port}
+                                onOpen={handleOpen}
+                                onCopy={handleCopy}
+                                onStop={handleStop}
+                                stopping={stoppingPortId === port.id}
+                              />
+                            ))}
+                          </React.Fragment>
                         ))}
-                      </React.Fragment>
-                    ))
+                    </>
                   )}
 
                   {externalPorts.length > 0 && (
                     <>
                       <div className={DROPDOWN_CLASSES.menuGroupSeparator} />
-                      <button
-                        type="button"
-                        className={classNames(
-                          DROPDOWN_CLASSES.sectionLabel,
-                          "w-full cursor-pointer text-left"
-                        )}
-                        onClick={() => setExternalExpanded((value) => !value)}
-                      >
-                        {sectionLabelWithCount(
-                          t("workstation.ports.externalSection"),
-                          externalPorts.length
-                        )}
-                      </button>
-                      {(externalExpanded || isSearching) &&
+                      <PortSectionHeader
+                        label={t("workstation.ports.externalSection")}
+                        count={externalPorts.length}
+                        expanded={externalOpen}
+                        onToggle={toggleExternalSection}
+                      />
+                      {externalOpen &&
                         externalPorts.map((port) => (
                           <PortRow
                             key={port.id}
@@ -403,6 +496,43 @@ export const PortsStatusMenu: React.FC = memo(() => {
                     </>
                   )}
                 </>
+              )}
+            </div>
+
+            <div className={DROPDOWN_CLASSES.footerContainer}>
+              <button
+                type="button"
+                className={classNames(
+                  DROPDOWN_CLASSES.menuActionItem,
+                  "min-w-0 flex-1 disabled:cursor-default disabled:text-text-3"
+                )}
+                onClick={runScan}
+                disabled={refreshing}
+                title={t("workstation.ports.rescanTooltip")}
+                data-testid="ports-menu-rescan"
+              >
+                <HugeiconsIcon
+                  icon={Refresh04Icon}
+                  data-icon="refresh-cw"
+                  size={MENU_ICON_SIZE}
+                  className={refreshing ? REFRESH_ICON_TOKENS.spin : undefined}
+                  aria-hidden
+                />
+                <span className="truncate">
+                  {refreshing
+                    ? t("workstation.ports.rescanning")
+                    : t("workstation.ports.rescan")}
+                </span>
+              </button>
+              {lastScanLabel && (
+                <span
+                  className="shrink-0 text-[11px] tabular-nums text-text-3"
+                  title={t("workstation.ports.lastScannedAt", {
+                    time: lastScanLabel,
+                  })}
+                >
+                  {lastScanLabel}
+                </span>
               )}
             </div>
           </div>,

--- a/src/modules/WorkStation/shared/StatusBar/WorkspacePortScanner.tsx
+++ b/src/modules/WorkStation/shared/StatusBar/WorkspacePortScanner.tsx
@@ -2,19 +2,16 @@
  * Low-CPU background poller for workspace listening ports.
  * Mount only while the code editor host is active.
  */
-import { useAtomValue, useSetAtom } from "jotai";
+import { useAtomValue } from "jotai";
 import { useEffect } from "react";
 
 import {
   WORKSPACE_PORT_SCAN_INTERVAL_MS,
   workspacePortProbesAtom,
-  workspacePortsStateAtom,
 } from "@src/store/workstation/codeEditor/workspacePortsAtom";
 
-import {
-  refreshWorkspacePortScan,
-  subscribeWorkspacePortScan,
-} from "./utils/workspacePortActions";
+import { useWorkspacePortScanSync } from "./useWorkspacePortScanSync";
+import { refreshWorkspacePortScan } from "./utils/workspacePortActions";
 
 interface WorkspacePortScannerProps {
   enabled: boolean;
@@ -24,18 +21,8 @@ export function WorkspacePortScanner({
   enabled,
 }: WorkspacePortScannerProps): null {
   const folders = useAtomValue(workspacePortProbesAtom);
-  const setState = useSetAtom(workspacePortsStateAtom);
 
-  useEffect(() => {
-    return subscribeWorkspacePortScan((update) => {
-      setState((previous) => ({
-        result: update.result ?? previous.result,
-        refreshing: update.refreshing,
-        lastScanStartedAt:
-          update.lastScanStartedAt ?? previous.lastScanStartedAt,
-      }));
-    });
-  }, [setState]);
+  useWorkspacePortScanSync();
 
   useEffect(() => {
     if (!enabled) {

--- a/src/modules/WorkStation/shared/StatusBar/useWorkspacePortScanSync.ts
+++ b/src/modules/WorkStation/shared/StatusBar/useWorkspacePortScanSync.ts
@@ -1,0 +1,25 @@
+/**
+ * Mirror workspace port scan notifications into jotai state.
+ *
+ * Every surface that can trigger a scan needs this mounted, otherwise the
+ * scan runs and its result is dropped on the floor: the background scanner
+ * only runs while a code-host tab is visible, but the ports status menu (and
+ * its rescan action) is reachable from every status-bar host.
+ */
+import { useSetAtom } from "jotai";
+import { useEffect } from "react";
+
+import { workspacePortsStateAtom } from "@src/store/workstation/codeEditor/workspacePortsAtom";
+
+import { subscribeWorkspacePortScan } from "./utils/workspacePortActions";
+import { applyWorkspacePortScanUpdate } from "./utils/workspacePortScanState";
+
+export function useWorkspacePortScanSync(): void {
+  const setState = useSetAtom(workspacePortsStateAtom);
+
+  useEffect(() => {
+    return subscribeWorkspacePortScan((update) => {
+      setState((previous) => applyWorkspacePortScanUpdate(previous, update));
+    });
+  }, [setState]);
+}

--- a/src/modules/WorkStation/shared/StatusBar/utils/workspacePortActions.ts
+++ b/src/modules/WorkStation/shared/StatusBar/utils/workspacePortActions.ts
@@ -14,13 +14,11 @@ import {
   WORKSPACE_PORT_STOP_SETTLE_MS,
 } from "@src/store/workstation/codeEditor/workspacePortsAtom";
 
+import type { WorkspacePortScanUpdate } from "./workspacePortScanState";
+
 const logger = createLogger("WorkspacePorts");
 
-type ScanListener = (update: {
-  refreshing: boolean;
-  result?: WorkspacePortScanResult;
-  lastScanStartedAt?: number;
-}) => void;
+type ScanListener = (update: WorkspacePortScanUpdate) => void;
 
 let inFlightScan: Promise<WorkspacePortScanResult> | null = null;
 let lastScanStartedAt = 0;
@@ -33,11 +31,7 @@ export function subscribeWorkspacePortScan(listener: ScanListener): () => void {
   };
 }
 
-function notifyListeners(update: {
-  refreshing: boolean;
-  result?: WorkspacePortScanResult;
-  lastScanStartedAt?: number;
-}): void {
+function notifyListeners(update: WorkspacePortScanUpdate): void {
   for (const listener of listeners) {
     listener(update);
   }

--- a/src/modules/WorkStation/shared/StatusBar/utils/workspacePortScanState.test.ts
+++ b/src/modules/WorkStation/shared/StatusBar/utils/workspacePortScanState.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Scan-update folding: latest wins, absent fields keep the previous value,
+ * and a no-op update keeps object identity so duplicate subscribers are free.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { WorkspacePortScanResult } from "@src/api/tauri/workspacePorts";
+import type { WorkspacePortsState } from "@src/store/workstation/codeEditor/workspacePortsAtom";
+
+import { applyWorkspacePortScanUpdate } from "./workspacePortScanState";
+
+const RESULT = { ports: [] } as unknown as WorkspacePortScanResult;
+
+function state(
+  overrides: Partial<WorkspacePortsState> = {}
+): WorkspacePortsState {
+  return {
+    result: null,
+    refreshing: false,
+    lastScanStartedAt: 0,
+    ...overrides,
+  };
+}
+
+describe("applyWorkspacePortScanUpdate", () => {
+  it("marks a scan in flight without dropping the previous result", () => {
+    const previous = state({ result: RESULT, lastScanStartedAt: 100 });
+
+    const next = applyWorkspacePortScanUpdate(previous, {
+      refreshing: true,
+      lastScanStartedAt: 200,
+    });
+
+    expect(next).toEqual({
+      result: RESULT,
+      refreshing: true,
+      lastScanStartedAt: 200,
+    });
+  });
+
+  it("stores the result and clears the in-flight flag when a scan lands", () => {
+    const previous = state({ refreshing: true, lastScanStartedAt: 200 });
+
+    const next = applyWorkspacePortScanUpdate(previous, {
+      refreshing: false,
+      result: RESULT,
+      lastScanStartedAt: 200,
+    });
+
+    expect(next.result).toBe(RESULT);
+    expect(next.refreshing).toBe(false);
+  });
+
+  it("keeps the last scan timestamp when an update omits it", () => {
+    const previous = state({ lastScanStartedAt: 200 });
+
+    const next = applyWorkspacePortScanUpdate(previous, { refreshing: false });
+
+    expect(next.lastScanStartedAt).toBe(200);
+  });
+
+  it("returns the same object when the update changes nothing", () => {
+    const previous = state({ result: RESULT, lastScanStartedAt: 200 });
+
+    const next = applyWorkspacePortScanUpdate(previous, {
+      refreshing: false,
+      result: RESULT,
+      lastScanStartedAt: 200,
+    });
+
+    expect(next).toBe(previous);
+  });
+});

--- a/src/modules/WorkStation/shared/StatusBar/utils/workspacePortScanState.ts
+++ b/src/modules/WorkStation/shared/StatusBar/utils/workspacePortScanState.ts
@@ -1,0 +1,43 @@
+/**
+ * Reducer for workspace port scan notifications.
+ *
+ * Lives apart from the scanner component so every scan subscriber folds an
+ * update the same way, and so the identity-stable bail-out is unit testable.
+ */
+import type { WorkspacePortScanResult } from "@src/api/tauri/workspacePorts";
+import type { WorkspacePortsState } from "@src/store/workstation/codeEditor/workspacePortsAtom";
+
+export interface WorkspacePortScanUpdate {
+  refreshing: boolean;
+  result?: WorkspacePortScanResult;
+  lastScanStartedAt?: number;
+}
+
+/**
+ * Fold one scan notification into the port state.
+ *
+ * Returns `previous` unchanged when nothing moved. More than one subscriber
+ * can be mounted at a time (the background scanner and the open ports menu),
+ * and each of them applies the same update; the identity bail-out keeps the
+ * duplicates from re-rendering every port row twice.
+ */
+export function applyWorkspacePortScanUpdate(
+  previous: WorkspacePortsState,
+  update: WorkspacePortScanUpdate
+): WorkspacePortsState {
+  const next: WorkspacePortsState = {
+    result: update.result ?? previous.result,
+    refreshing: update.refreshing,
+    lastScanStartedAt: update.lastScanStartedAt ?? previous.lastScanStartedAt,
+  };
+
+  if (
+    next.result === previous.result &&
+    next.refreshing === previous.refreshing &&
+    next.lastScanStartedAt === previous.lastScanStartedAt
+  ) {
+    return previous;
+  }
+
+  return next;
+}

--- a/src/store/workstation/codeEditor/workspacePortsAtom.ts
+++ b/src/store/workstation/codeEditor/workspacePortsAtom.ts
@@ -33,6 +33,12 @@ export const workspacePortsRefreshingAtom = atom((get) => {
 });
 workspacePortsRefreshingAtom.debugLabel = "workspacePortsRefreshingAtom";
 
+export const workspacePortsLastScanStartedAtAtom = atom((get) => {
+  return get(workspacePortsStateAtom).lastScanStartedAt;
+});
+workspacePortsLastScanStartedAtAtom.debugLabel =
+  "workspacePortsLastScanStartedAtAtom";
+
 export const workspacePortsAtom = atom((get) => {
   return get(workspacePortsStateAtom).result?.ports ?? [];
 });


### PR DESCRIPTION
## Problem

The ports status-bar menu gave you nothing to act on when it was wrong.

- **No manual rescan.** A scan fires only when the menu is opened and on a 60s
  interval. If a dev server came up a moment after the menu was opened, or the
  first scan raced the server's bind, the panel just said "No workspace ports
  detected" and the only way out was to close and reopen it.
- **The scan result could be dropped entirely.** `WorkspacePortScanner` — the
  only subscriber that mirrors scan notifications into
  `workspacePortsStateAtom` — is mounted from `AppShell` only while
  `portsEnabled` (code mode, active, non-chat tab). The status bar, and with it
  `PortsStatusMenu`, renders under the looser `shouldShowWorkStationStatusBar`.
  In Browser or Project mode with a real page open, opening the ports menu ran
  a scan whose result had no listener and was discarded, so the list stayed
  stale for as long as you stayed there.
- **Section headers had no affordance.** The External header was a bare
  clickable `sectionLabel` with no indicator that it toggled, and workspace
  ports had no header at all — the `workstation.ports.workspaceSection` string
  existed but was never rendered.

## Solution

- **Rescan footer.** A `DROPDOWN_CLASSES.footerContainer` row pinned under the
  scroll area with a `Refresh04Icon` + "Rescan" action. While a scan is in
  flight the icon spins (`REFRESH_ICON_TOKENS.spin`), the label becomes
  "Scanning…", and the button is disabled; otherwise the right side shows the
  clock time of the last scan, formatted in the user's language and timezone
  preference. The timestamp is what makes a rescan legible in the empty state —
  without it, rescanning an empty list looks like nothing happened.
- **`PortsStatusMenu` now mirrors scan notifications itself** via a new
  `useWorkspacePortScanSync` hook, so a rescan started from the menu lands in
  state on every host that renders the status bar, not just code mode. The
  folding logic moved out of the scanner into
  `applyWorkspacePortScanUpdate`, which returns the previous object identity
  when nothing changed — that is what keeps two mounted subscribers from
  re-rendering every port row twice.
- **Collapsible headers.** A shared `PortSectionHeader` renders a chevron that
  points right when collapsed and rotates down when open, plus the label and
  count. Both Workspace and External sections use it. A non-empty search still
  force-expands both, and the chevron is driven by the same derived flag that
  gates the rows, so the indicator always agrees with what is rendered.
- New strings (`rescan`, `rescanning`, `rescanTooltip`, `lastScannedAt`) added
  to all 13 locales.

## Potential risks

- **Keyboard navigation changed for the External header.** `useDropdownEngine`
  wires `useDropdownAutoKeyboard`, which discovers every non-skipped `<button>`
  in the panel. The old External header was discoverable; both headers now
  carry `data-dropdown-keyboard-skip="true"`, which is the documented use for
  that attribute ("section headers wrapped in a clickable element") but is a
  behavior change. The rescan button is deliberately *not* skipped, so it stays
  keyboard-reachable.
- **Double subscription.** When the background scanner and an open menu are
  both mounted, both apply the same update. The identity bail-out in
  `applyWorkspacePortScanUpdate` makes the second application a jotai no-op;
  this is covered by a unit test, not by a rendered test.
- **`lastScannedAt` uses `lastScanStartedAt`,** the only timestamp the scan
  pipeline records. It is the start of the last scan, not its completion — a
  sub-second difference in practice, and the label is hidden while a scan is in
  flight.
- **Workspace section defaults to expanded** and its collapse state is not
  persisted; it resets when the component unmounts. Search state already
  behaves this way (cleared on close).
- The empty state is unchanged apart from the footer: with no workspace ports
  the "No workspace ports detected" message still renders and no Workspace
  header appears.
- No behavior change to the scan cadence, the min-interval coalescing, or the
  stop-process path.

## Verification

Ran, all passing:

- `npx vitest run src/modules/WorkStation/shared/StatusBar/utils/workspacePortScanState.test.ts` — 4/4 pass (new file).
- `npx eslint` over all seven changed `.ts`/`.tsx` files — clean.
- `npx prettier --write` over the same set.
- `npx tsc --noEmit -p <scoped tsconfig>` covering the seven changed files and
  their transitive imports — exit 0, no diagnostics.

Did **not** run:

- **A full-project `npx tsc --noEmit`.** Two attempts were killed by the OS
  (`vm_stat` showed ~14 MB free) because the dev app and its webpack server
  were live on this box. The scoped check above covers the changed files and
  everything they import; the only outward-facing change is additive
  (`workspacePortsLastScanStartedAtAtom`, the extracted `WorkspacePortScanUpdate`
  type) and its sole consumer, `WorkspacePortScanner`, is inside the checked
  set. **CI is the gate for the full typecheck.**
- The rendered E2E suite, and vitest beyond the new file.

No screenshot is attached. ORG2 is a Tauri-only app, so a browser render of the
dev server is not the real UI and would be misleading evidence. The change is
live under HMR in the running dev app on this checkout — the reporter confirmed
the menu behaves as described there.

The commit was built with a temporary index (`git commit-tree`) because the
shared checkout is dirty with unrelated in-progress work; git hooks were
therefore skipped and there is no "Pre-commit hook ran." trailer. The diff was
verified against `develop` to contain only the files listed above — in
particular, the locale files were rebuilt from their `HEAD` content plus the
four new `ports.*` keys, so unrelated uncommitted string work is not in this PR.
