### PR TITLE
feat(spotlight): stabilize palette footer and add show-path toggle

### DIFF
--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -1705,6 +1705,7 @@
       "select": "Auswählen",
       "switchColumn": "Spalte wechseln",
       "switchSection": "Abschnitt wechseln",
+      "showPath": "Pfad anzeigen",
       "compatibleKeys": "Kompatibel",
       "planSupport": "Plan",
       "byokSupport": "Keys",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1634,6 +1634,7 @@
       "select": "Select",
       "switchColumn": "Switch column",
       "switchSection": "Switch section",
+      "showPath": "Show path",
       "compatibleKeys": "Compatible",
       "planSupport": "Plan",
       "byokSupport": "Keys",

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -1705,6 +1705,7 @@
       "select": "Seleccionar",
       "switchColumn": "Cambiar columna",
       "switchSection": "Cambiar sección",
+      "showPath": "Mostrar ruta",
       "compatibleKeys": "Compatible",
       "planSupport": "Plan",
       "byokSupport": "Keys",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1705,6 +1705,7 @@
       "select": "Sélectionner",
       "switchColumn": "Changer de colonne",
       "switchSection": "Changer de section",
+      "showPath": "Afficher le chemin",
       "compatibleKeys": "Compatible",
       "planSupport": "Plan",
       "byokSupport": "Keys",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -1704,6 +1704,7 @@
       "select": "選択",
       "switchColumn": "列を切り替え",
       "switchSection": "セクションを切り替え",
+      "showPath": "パスを表示",
       "compatibleKeys": "互換性あり",
       "planSupport": "Plan",
       "byokSupport": "Keys",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -1704,6 +1704,7 @@
       "select": "선택",
       "switchColumn": "열 전환",
       "switchSection": "Switch section",
+      "showPath": "경로 표시",
       "compatibleKeys": "호환",
       "planSupport": "Plan",
       "byokSupport": "Keys",

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -1715,6 +1715,7 @@
       "select": "Wybierz",
       "switchColumn": "Zmień kolumnę",
       "switchSection": "Zmień sekcję",
+      "showPath": "Pokaż ścieżkę",
       "compatibleKeys": "Zgodne",
       "planSupport": "Plan",
       "byokSupport": "Klucze",

--- a/src/i18n/locales/pt/common.json
+++ b/src/i18n/locales/pt/common.json
@@ -1705,6 +1705,7 @@
       "select": "Selecionar",
       "switchColumn": "Trocar coluna",
       "switchSection": "Trocar seção",
+      "showPath": "Mostrar caminho",
       "compatibleKeys": "Compatível",
       "planSupport": "Plano",
       "byokSupport": "Keys",

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -1715,6 +1715,7 @@
       "select": "Выбрать",
       "switchColumn": "Сменить колонку",
       "switchSection": "Сменить раздел",
+      "showPath": "Показывать путь",
       "compatibleKeys": "Совместимые",
       "planSupport": "Plan",
       "byokSupport": "Keys",

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -1706,6 +1706,7 @@
       "select": "Seç",
       "switchColumn": "Sütun değiştir",
       "switchSection": "Bölüm değiştir",
+      "showPath": "Yolu göster",
       "compatibleKeys": "Uyumlu",
       "planSupport": "Plan",
       "byokSupport": "Keys",

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -1704,6 +1704,7 @@
       "select": "Chọn",
       "switchColumn": "Đổi cột",
       "switchSection": "Đổi phần",
+      "showPath": "Hiện đường dẫn",
       "compatibleKeys": "Tương thích",
       "planSupport": "Plan",
       "byokSupport": "Keys",

--- a/src/i18n/locales/zh-Hant/common.json
+++ b/src/i18n/locales/zh-Hant/common.json
@@ -1719,6 +1719,7 @@
       "select": "選擇",
       "switchColumn": "切換欄",
       "switchSection": "切換分區",
+      "showPath": "顯示路徑",
       "compatibleKeys": "相容",
       "planSupport": "Plan",
       "byokSupport": "Keys",

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -1588,6 +1588,7 @@
       "select": "选择",
       "switchColumn": "切换栏",
       "switchSection": "切换分区",
+      "showPath": "显示路径",
       "compatibleKeys": "兼容",
       "planSupport": "Plan",
       "byokSupport": "Keys",

--- a/src/scaffold/GlobalSpotlight/components/SpotlightFooter.tsx
+++ b/src/scaffold/GlobalSpotlight/components/SpotlightFooter.tsx
@@ -48,6 +48,12 @@ export interface SpotlightFooterProps {
    * (Backspace + Return) to match historical drill-in palettes.
    */
   activeActionChip?: SpotlightFooterActiveChip;
+  /**
+   * Palette-owned controls rendered inside the pill after the last hint
+   * (see `ShellFooterAction placement="inline"`). Keep these visually
+   * quiet — the pill is a hint strip, not a toolbar.
+   */
+  trailingSlot?: React.ReactNode;
 }
 
 // ============ COMPONENT ============
@@ -56,6 +62,7 @@ export const SpotlightFooter: React.FC<SpotlightFooterProps> = ({
   hasActiveAction,
   variant = "spotlight",
   activeActionChip = SPOTLIGHT_FOOTER_ACTIVE_CHIP.back,
+  trailingSlot,
 }) => {
   const { t } = useTranslation();
 
@@ -123,6 +130,8 @@ export const SpotlightFooter: React.FC<SpotlightFooterProps> = ({
         />
         <span>{t("actions.close")}</span>
       </span>
+
+      {trailingSlot}
     </div>
   );
 

--- a/src/scaffold/GlobalSpotlight/components/SpotlightFooterToggle.tsx
+++ b/src/scaffold/GlobalSpotlight/components/SpotlightFooterToggle.tsx
@@ -1,0 +1,41 @@
+/**
+ * SpotlightFooterToggle Component
+ *
+ * Checkbox control rendered inside the keyboard-hint pill, after a thin
+ * separator, for palette-level view preferences (e.g. "Show path"). It
+ * borrows the pill's own type scale and muted color so it reads as part
+ * of the hint strip rather than a button bolted onto it.
+ *
+ * Reaches the pill through `<ShellFooterAction placement="inline">`.
+ */
+import React from "react";
+
+import Checkbox from "@src/components/Checkbox";
+
+export interface SpotlightFooterToggleProps {
+  label: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}
+
+export const SpotlightFooterToggle: React.FC<SpotlightFooterToggleProps> = ({
+  label,
+  checked,
+  onCheckedChange,
+}) => {
+  return (
+    <span className="flex items-center gap-4">
+      <span aria-hidden className="h-3 w-px shrink-0 bg-border-2" />
+      <Checkbox
+        size="mini"
+        checked={checked}
+        onCheckedChange={(next) => onCheckedChange(next)}
+        className="!gap-1.5 !text-[11px] text-text-2 transition-colors hover:text-text-1"
+      >
+        {label}
+      </Checkbox>
+    </span>
+  );
+};
+
+export default SpotlightFooterToggle;

--- a/src/scaffold/GlobalSpotlight/components/SpotlightPinnedActionSection.tsx
+++ b/src/scaffold/GlobalSpotlight/components/SpotlightPinnedActionSection.tsx
@@ -13,6 +13,13 @@ export interface SpotlightPinnedActionSectionProps {
   onItemHover: (index: number) => void;
   searchQuery: string;
   layout?: "list" | "twoColumn";
+  /**
+   * Minimum rows the two-column grid keeps reserved. Palettes whose pinned
+   * actions change with mode (e.g. the worktree palette's switch/remove
+   * modes) pass the largest row count so the section — and the panel below
+   * it — keeps one height instead of resizing on every mode change.
+   */
+  reserveRows?: number;
 }
 
 export const SpotlightPinnedActionSection: React.FC<
@@ -25,6 +32,7 @@ export const SpotlightPinnedActionSection: React.FC<
   onItemHover,
   searchQuery,
   layout = "list",
+  reserveRows = 1,
 }) => {
   const { isKeyboardMode, handleMouseMove, dataKeyboardMode } =
     useKeyboardMouseMode();
@@ -33,8 +41,9 @@ export const SpotlightPinnedActionSection: React.FC<
 
   /** Column-major grid: reserve a second row only once the first one is full,
    *  otherwise a single pinned action (e.g. manage mode's "Done") leaves an
-   *  equal-height empty track underneath it. */
-  const needsSecondRow = items.length > 2;
+   *  equal-height empty track underneath it. `reserveRows` overrides that for
+   *  palettes that would rather keep a constant height across modes. */
+  const needsSecondRow = items.length > 2 || reserveRows > 1;
   const layoutClassName =
     layout === "twoColumn"
       ? `grid grid-flow-col grid-cols-2 gap-x-2 gap-y-0 ${

--- a/src/scaffold/GlobalSpotlight/components/index.ts
+++ b/src/scaffold/GlobalSpotlight/components/index.ts
@@ -37,6 +37,9 @@ export type { SpotlightAccountFooterProps } from "./SpotlightAccountFooter";
 export { SpotlightFooterAction } from "./SpotlightFooterAction";
 export type { SpotlightFooterActionProps } from "./SpotlightFooterAction";
 
+export { SpotlightFooterToggle } from "./SpotlightFooterToggle";
+export type { SpotlightFooterToggleProps } from "./SpotlightFooterToggle";
+
 export { SpotlightPinnedActionSection } from "./SpotlightPinnedActionSection";
 export type { SpotlightPinnedActionSectionProps } from "./SpotlightPinnedActionSection";
 

--- a/src/scaffold/GlobalSpotlight/index.tsx
+++ b/src/scaffold/GlobalSpotlight/index.tsx
@@ -78,7 +78,6 @@ const GlobalSpotlightInner: React.FC<
     setWorkspacePickerMode,
     embeddedBranchMode,
     setEmbeddedBranchMode,
-    embeddedWorktreeMode,
     setEmbeddedWorktreeMode,
     branchPickerOpen,
     setBranchPickerOpen,
@@ -335,10 +334,16 @@ const GlobalSpotlightInner: React.FC<
       : workspacePickerMode === "open"
         ? "add-workspace-existing"
         : null;
+  // Tab keeps switching between the list and the pinned action section in
+  // every mode that still renders one, so the hint chip must not flip to
+  // "Back" the moment a palette drills into remove mode — the footer would
+  // resize under the user mid-interaction. The branch palette's create
+  // modes are the exception: they render no pinned section at all.
   const activeActionChip =
     workspacePickerMode === "switch" ||
-    (worktreePickerOpen && embeddedWorktreeMode === "switch") ||
-    (branchPickerOpen && embeddedBranchMode === "checkout")
+    worktreePickerOpen ||
+    (branchPickerOpen &&
+      (embeddedBranchMode === "checkout" || embeddedBranchMode === "remove"))
       ? SPOTLIGHT_FOOTER_ACTIVE_CHIP.switchSection
       : undefined;
 

--- a/src/scaffold/GlobalSpotlight/palettes/BranchPalette/index.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/BranchPalette/index.tsx
@@ -9,6 +9,7 @@
  * (`gitApi.getGitBranches`) and share the centralized branch cache to
  * prevent redundant calls.
  */
+import { useAtom } from "jotai";
 import React from "react";
 import { useTranslation } from "react-i18next";
 
@@ -23,13 +24,17 @@ import {
   Tick01Icon,
 } from "@src/icons";
 import type { WorktreeLaunchSource } from "@src/store/session/worktreeLaunchSourceAtom";
+import { spotlightShowPathAtom } from "@src/store/ui/spotlightShowPathAtom";
 import { compactRepoPathForDisplay } from "@src/util/file/repoPathDisplay";
 
 import {
   SPOTLIGHT_FOOTER_ACTIVE_CHIP,
+  SpotlightFooterToggle,
   SpotlightPinnedActionSection,
 } from "../../components";
-import { PaletteBody, SpotlightShell } from "../../shell";
+import { ICONS } from "../../config";
+import { useRefreshSpin } from "../../shared";
+import { PaletteBody, ShellFooterAction, SpotlightShell } from "../../shell";
 import type { SpotlightItem } from "../../types";
 import { useSelectorKernel } from "../core";
 import type {
@@ -38,7 +43,11 @@ import type {
   WorktreePaletteProps,
 } from "./types";
 import { useBranchPalette } from "./useBranchPalette";
-import { refreshWorktreeMap, useWorktreeEntries } from "./useWorktreeMap";
+import {
+  refreshWorktreeMap,
+  revalidateWorktreeMap,
+  useWorktreeEntries,
+} from "./useWorktreeMap";
 
 function normalizeWorktreePath(path: string | undefined): string {
   return (path ?? "").replace(/^file:\/\//, "").replace(/\/+$/, "");
@@ -61,7 +70,7 @@ export const WorktreePalette: React.FC<WorktreePaletteProps> = ({
   const [createModalOpen, setCreateModalOpen] = React.useState(false);
   const [searchQuery, setSearchQuery] = React.useState("");
   const [mode, setMode] = React.useState<WorktreePaletteMode>("switch");
-  const [isRefreshing, setIsRefreshing] = React.useState(false);
+  const [showPath, setShowPath] = useAtom(spotlightShowPathAtom);
   const [removingPaths, setRemovingPaths] = React.useState<Set<string>>(
     () => new Set()
   );
@@ -100,14 +109,41 @@ export const WorktreePalette: React.FC<WorktreePaletteProps> = ({
     [onRemoveWorktree, repoId, repoPath]
   );
 
-  const handleRefreshWorktrees = React.useCallback(async () => {
-    setIsRefreshing(true);
-    try {
-      await refreshWorktreeMap(repoId, repoPath);
-    } finally {
-      setIsRefreshing(false);
-    }
-  }, [repoId, repoPath]);
+  // Revalidate rather than refresh: the rows stay on screen while the
+  // refetch runs, so only the icon reports the work. Spin timing is shared
+  // with the branch palette's refresh.
+  const revalidateWorktrees = React.useCallback(
+    () => revalidateWorktreeMap(repoId, repoPath),
+    [repoId, repoPath]
+  );
+  const { triggerRefresh, RefreshIcon } = useRefreshSpin(
+    Refresh04Icon,
+    revalidateWorktrees
+  );
+
+  // Same affordance as the workspace palette's manage mode: a danger-tinted
+  // trash button on the row instead of a "Remove Worktree" text label.
+  const renderWorktreeTrashAction = React.useCallback(
+    (worktreePath: string, isRemoving: boolean): React.ReactNode => (
+      <button
+        type="button"
+        disabled={isRemoving}
+        onClick={(event) => {
+          event.stopPropagation();
+          void handleRemoveWorktree(worktreePath);
+        }}
+        className="flex items-center justify-center rounded-md p-1 text-danger-6 transition-colors hover:bg-danger-6/10 disabled:cursor-not-allowed disabled:opacity-50"
+        title={t("selectors.branch.actions.removeWorktree", "Remove Worktree")}
+        aria-label={t(
+          "selectors.branch.actions.removeWorktree",
+          "Remove Worktree"
+        )}
+      >
+        <HugeiconsIcon icon={ICONS.removeRepo} size={14} />
+      </button>
+    ),
+    [handleRemoveWorktree, t]
+  );
 
   const allItems = React.useMemo<SpotlightItem[]>(
     () =>
@@ -126,10 +162,13 @@ export const WorktreePalette: React.FC<WorktreePaletteProps> = ({
               : path.split("/").pop() || path);
           const isSelected = path === normalizedActivePath;
           const isRemoving = removingPaths.has(path);
+          const displayPath = compactRepoPathForDisplay({ path });
           return {
             id: `worktree:${path}`,
             label,
-            desc: compactRepoPathForDisplay({ path }),
+            // The path only renders when the footer's "Show path" pill is
+            // on; it stays searchable either way via `searchText`.
+            desc: showPath ? displayPath : undefined,
             icon: FolderClosedIcon,
             type: "option" as const,
             data: {
@@ -137,12 +176,10 @@ export const WorktreePalette: React.FC<WorktreePaletteProps> = ({
               isCurrentSelection: mode === "switch" && isSelected,
               disabled: isRemoving,
               contextMenuCopy: { name: label, path },
-              rightLabel:
+              searchText: `${label} ${displayPath}`,
+              rightContent:
                 mode === "remove"
-                  ? t(
-                      "selectors.branch.actions.removeWorktree",
-                      "Remove Worktree"
-                    )
+                  ? renderWorktreeTrashAction(worktree.path, isRemoving)
                   : undefined,
             },
             action: () => {
@@ -161,6 +198,8 @@ export const WorktreePalette: React.FC<WorktreePaletteProps> = ({
       onClose,
       onSelect,
       removingPaths,
+      renderWorktreeTrashAction,
+      showPath,
       t,
       worktrees,
     ]
@@ -178,7 +217,8 @@ export const WorktreePalette: React.FC<WorktreePaletteProps> = ({
   const { filteredItems } = useFilteredItems({
     items: allItems,
     searchQuery,
-    getSearchText: (item) => `${item.label} ${item.desc ?? ""}`,
+    getSearchText: (item) =>
+      item.data?.searchText ?? `${item.label} ${item.desc ?? ""}`,
   });
   const sectionedItems = React.useMemo<SpotlightItem[]>(() => {
     const header = (id: string, label: string): SpotlightItem => ({
@@ -253,31 +293,22 @@ export const WorktreePalette: React.FC<WorktreePaletteProps> = ({
         action: () => setMode("remove"),
       });
     }
-    const RefreshIcon = (props: { size?: number; className?: string }) => (
-      <HugeiconsIcon
-        icon={Refresh04Icon}
-        {...props}
-        className={`${props.className ?? ""} ${isRefreshing ? "spotlight-refresh-spin" : ""}`.trim()}
-      />
-    );
-
     actions.push({
       id: "worktree:refresh",
       label: t("actions.refresh", "Refresh"),
       icon: RefreshIcon,
       type: "action",
-      data: { disabled: isRefreshing },
-      action: () => void handleRefreshWorktrees(),
+      action: triggerRefresh,
     });
     return actions;
   }, [
+    RefreshIcon,
     createAction,
-    handleRefreshWorktrees,
-    isRefreshing,
     mode,
     onCreate,
     onRemoveWorktree,
     t,
+    triggerRefresh,
   ]);
   const selectableItems = React.useMemo<SpotlightItem[]>(
     () => [...sectionedItems, ...pinnedActionItems],
@@ -316,6 +347,10 @@ export const WorktreePalette: React.FC<WorktreePaletteProps> = ({
         onItemHover={kernel.setSelectedIndex}
         searchQuery={searchQuery}
         layout="twoColumn"
+        // Switch mode fills two rows (new / remove / refresh); remove mode
+        // shows only "Done". Reserving the taller layout keeps the panel
+        // from resizing when the mode changes.
+        reserveRows={onCreate && onRemoveWorktree ? 2 : 1}
       />
     ) : undefined;
 
@@ -358,15 +393,26 @@ export const WorktreePalette: React.FC<WorktreePaletteProps> = ({
         },
       ]}
       onRemoveSegment={handleGoBack}
-      isLoading={isOpen && (worktrees.length === 0 || isRefreshing)}
+      isLoading={isOpen && worktrees.length === 0}
       fixedHeight
       afterListSlot={pinnedActionSection}
     />
   );
 
+  const showPathToggle = (
+    <ShellFooterAction placement="inline">
+      <SpotlightFooterToggle
+        label={t("selectors.spotlightFooter.showPath", "Show path")}
+        checked={showPath}
+        onCheckedChange={setShowPath}
+      />
+    </ShellFooterAction>
+  );
+
   const palette = (
     <>
       {body}
+      {showPathToggle}
       {createModalOpen && (
         <WorktreeSourceModal
           open
@@ -393,11 +439,10 @@ export const WorktreePalette: React.FC<WorktreePaletteProps> = ({
       isOpen={isOpen}
       onClose={onClose}
       hasActiveAction={pinnedActionItems.length > 0}
-      activeActionChip={
-        mode === "switch"
-          ? SPOTLIGHT_FOOTER_ACTIVE_CHIP.switchSection
-          : undefined
-      }
+      // Tab switches between the list and the pinned actions in both modes,
+      // so the hint chip stays put instead of swapping to "Back" the moment
+      // remove mode opens.
+      activeActionChip={SPOTLIGHT_FOOTER_ACTIVE_CHIP.switchSection}
     >
       {palette}
     </SpotlightShell>

--- a/src/scaffold/GlobalSpotlight/palettes/BranchPalette/useBranchPalette.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/BranchPalette/useBranchPalette.ts
@@ -29,6 +29,7 @@ import {
 } from "@src/icons";
 
 import { ICONS } from "../../config";
+import { useRefreshSpin } from "../../shared";
 import type { SpotlightItem } from "../../types";
 import {
   BRANCH_PALETTE_CONFIG,
@@ -42,7 +43,6 @@ import { useBranchItems } from "./useBranchItems";
 import { useWorktreeMap } from "./useWorktreeMap";
 
 const log = createLogger("useBranchPalette");
-const REFRESH_SPIN_MIN_MS = 900;
 
 export function useBranchPalette(options: UseBranchPaletteOptions) {
   const { t } = useTranslation();
@@ -69,7 +69,6 @@ export function useBranchPalette(options: UseBranchPaletteOptions) {
   const [searchQuery, setSearchQueryState] = useState("");
   const [activeMode, setActiveMode] = useState<BranchPaletteMode>("checkout");
   const [isCreatingBranch, setIsCreatingBranch] = useState(false);
-  const [isRefreshSpinning, setIsRefreshSpinning] = useState(false);
   const [selectedStartPoint, setSelectedStartPoint] = useState<string | null>(
     null
   );
@@ -100,17 +99,10 @@ export function useBranchPalette(options: UseBranchPaletteOptions) {
     githubRepoFullName,
   });
 
-  const handleRefreshBranches = useCallback(async () => {
-    setIsRefreshSpinning(true);
-    const startedAt = Date.now();
-    try {
-      await refreshBranches();
-    } finally {
-      const elapsed = Date.now() - startedAt;
-      const remaining = Math.max(0, REFRESH_SPIN_MIN_MS - elapsed);
-      window.setTimeout(() => setIsRefreshSpinning(false), remaining);
-    }
-  }, [refreshBranches]);
+  const { triggerRefresh: handleRefreshBranches, RefreshIcon } = useRefreshSpin(
+    ICONS.refresh,
+    refreshBranches
+  );
 
   // ============ FETCH WORKTREES (local repos only) ============
   const worktreeMap = useWorktreeMap({
@@ -355,14 +347,6 @@ export function useBranchPalette(options: UseBranchPaletteOptions) {
       });
     }
 
-    const RefreshIcon = (props: { size?: number; className?: string }) =>
-      createElement(HugeiconsIcon, {
-        icon: ICONS.refresh,
-        ...props,
-        className:
-          `${props.className ?? ""} ${isRefreshSpinning ? "spotlight-refresh-spin" : ""}`.trim(),
-      });
-
     actions.push({
       id: "pinned-branch-refresh",
       label: t("selectors.branch.actions.refresh", "Refresh"),
@@ -371,11 +355,12 @@ export function useBranchPalette(options: UseBranchPaletteOptions) {
       data: {
         disabled: isLoading,
       },
-      action: () => void handleRefreshBranches(),
+      action: handleRefreshBranches,
     });
 
     return actions;
   }, [
+    RefreshIcon,
     activeMode,
     effectiveShowRemoveMode,
     isLoading,
@@ -383,7 +368,6 @@ export function useBranchPalette(options: UseBranchPaletteOptions) {
     handleDeleteSelectedBranches,
     onDeleteBranch,
     handleRefreshBranches,
-    isRefreshSpinning,
     selectedBranchCount,
     t,
   ]);

--- a/src/scaffold/GlobalSpotlight/palettes/BranchPalette/useWorktreeMap.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/BranchPalette/useWorktreeMap.ts
@@ -79,6 +79,22 @@ export function refreshWorktreeMap(
   return fetchWorktreeMap(repoId, repoPath);
 }
 
+/**
+ * Refetches the worktree list *without* dropping the cached entries first,
+ * so subscribers keep rendering the current list while the request is in
+ * flight — a user-triggered refresh should not blank the rows it refreshes.
+ *
+ * Use {@link refreshWorktreeMap} instead when the cached entries are known
+ * to be wrong (e.g. right after removing a worktree), where showing stale
+ * rows until the refetch lands would be worse than showing none.
+ */
+export function revalidateWorktreeMap(
+  repoId: string,
+  repoPath: string | undefined
+): Promise<Map<string, string>> {
+  return fetchWorktreeMap(repoId, repoPath);
+}
+
 async function fetchWorktreeMap(
   repoId: string,
   repoPath: string | undefined

--- a/src/scaffold/GlobalSpotlight/palettes/WorkspacePalette/index.tsx
+++ b/src/scaffold/GlobalSpotlight/palettes/WorkspacePalette/index.tsx
@@ -18,6 +18,7 @@ import Message from "@src/components/Message";
 import { HugeiconsIcon } from "@src/icons";
 import { cachedReposAtom } from "@src/store/repo";
 import { addWorkspaceInitialStageAtom } from "@src/store/ui/overlayAtom";
+import { spotlightShowPathAtom } from "@src/store/ui/spotlightShowPathAtom";
 import {
   isMultiRootWorkspaceAtom,
   setWorkspaceFoldersAtom,
@@ -26,6 +27,7 @@ import { confirmDestructiveAction } from "@src/util/dialogs/confirmDestructiveAc
 
 import {
   SPOTLIGHT_FOOTER_ACTIVE_CHIP,
+  SpotlightFooterToggle,
   SpotlightPinnedActionSection,
 } from "../../components";
 import { ICONS } from "../../config";
@@ -37,7 +39,7 @@ import {
   useSharedRepoList,
 } from "../../hooks";
 import { usePathSegment } from "../../hooks/usePathSegment";
-import { PaletteBody, SpotlightShell } from "../../shell";
+import { PaletteBody, ShellFooterAction, SpotlightShell } from "../../shell";
 import type { RepoItem, SpotlightItem } from "../../types";
 import { AddWorkspaceModalShell } from "../AddWorkspaceModalShell";
 import { REPO_PALETTE_CONFIG } from "../config";
@@ -77,6 +79,7 @@ export const WorkspacePalette: React.FC<WorkspacePaletteProps> = ({
   const [initialAddStageAtom, setInitialAddStageAtom] = useAtom(
     addWorkspaceInitialStageAtom
   );
+  const [showPath, setShowPath] = useAtom(spotlightShowPathAtom);
   const effectiveInitialStage = initialAddStageProp ?? initialAddStageAtom;
 
   // ============ LOCAL STATE ============
@@ -457,6 +460,7 @@ export const WorkspacePalette: React.FC<WorkspacePaletteProps> = ({
       searchQuery,
       paletteText,
       orgScopeFilter: repoFilter ?? null,
+      showPath,
       onRepoAction: (repo) => {
         if (isManageMode) {
           toggleSelection(repo.id);
@@ -492,6 +496,7 @@ export const WorkspacePalette: React.FC<WorkspacePaletteProps> = ({
     searchQuery,
     sectionedAddItems,
     selectedIds,
+    showPath,
     toggleSelection,
     workspaceItems,
   ]);
@@ -638,6 +643,19 @@ export const WorkspacePalette: React.FC<WorkspacePaletteProps> = ({
   };
 
   // ============ RENDER: MAIN VIEW ============
+  // Portals next to the shell's keyboard-hint footer (and renders nothing
+  // when the palette is embedded without a shell). The add menu lists
+  // sources rather than repos, so it gets no path toggle.
+  const showPathToggle = addMenuKind ? null : (
+    <ShellFooterAction placement="inline">
+      <SpotlightFooterToggle
+        label={t("selectors.spotlightFooter.showPath", "Show path")}
+        checked={showPath}
+        onCheckedChange={setShowPath}
+      />
+    </ShellFooterAction>
+  );
+
   const body = (
     <PaletteBody
       kernel={kernel}
@@ -655,7 +673,14 @@ export const WorkspacePalette: React.FC<WorkspacePaletteProps> = ({
     />
   );
 
-  if (asBody) return body;
+  const palette = (
+    <>
+      {body}
+      {showPathToggle}
+    </>
+  );
+
+  if (asBody) return palette;
 
   return (
     <SpotlightShell
@@ -664,7 +689,7 @@ export const WorkspacePalette: React.FC<WorkspacePaletteProps> = ({
       hasActiveAction={!addMenuKind && pinnedActionItems.length > 0}
       activeActionChip={SPOTLIGHT_FOOTER_ACTIVE_CHIP.switchSection}
     >
-      {body}
+      {palette}
     </SpotlightShell>
   );
 };

--- a/src/scaffold/GlobalSpotlight/palettes/WorkspacePalette/workspacePaletteItems.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/WorkspacePalette/workspacePaletteItems.ts
@@ -61,6 +61,8 @@ interface BuildSectionedWorkspaceItemsArgs {
    * data flag (set by useWorkspacePaletteWorkspace).
    */
   orgScopeFilter?: ((repo: RepoItem) => boolean) | null;
+  /** Renders each repo row's filesystem path under its name (footer toggle). */
+  showPath?: boolean;
   onRepoAction: (repo: RepoItem) => void;
   onLeadingRepoAction: (repo: RepoItem) => void;
   toggleSelection: (id: string) => void;
@@ -83,6 +85,7 @@ export function buildSectionedWorkspaceItems({
   searchQuery,
   paletteText,
   orgScopeFilter = null,
+  showPath = false,
   onRepoAction,
   onLeadingRepoAction,
   toggleSelection,
@@ -113,6 +116,7 @@ export function buildSectionedWorkspaceItems({
 
   const repoItemOptions = {
     currentRepoId: isMultiRoot ? undefined : currentRepoId,
+    showPath,
     onAction: onRepoAction,
     manageAction: isManageMode ? renderRepoTrashAction : undefined,
     getSelectionState: isManageMode
@@ -135,6 +139,7 @@ export function buildSectionedWorkspaceItems({
     leadingRepos.length > 0 && !isManageMode
       ? buildRepoSpotlightItems([...leadingRepos], {
           currentRepoId,
+          showPath,
           onAction: onLeadingRepoAction,
         })
       : [];
@@ -143,6 +148,7 @@ export function buildSectionedWorkspaceItems({
     externalRecentRepos.length > 0 && !isManageMode
       ? buildRepoSpotlightItems([...externalRecentRepos], {
           currentRepoId,
+          showPath,
           onAction: onLeadingRepoAction,
         })
       : [];

--- a/src/scaffold/GlobalSpotlight/palettes/adapters/__tests__/repoAdapter.test.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/adapters/__tests__/repoAdapter.test.ts
@@ -151,6 +151,39 @@ describe("buildRepoSpotlightItem", () => {
   });
 });
 
+describe("buildRepoSpotlightItem path visibility", () => {
+  const repoWithPath: RepoItem = {
+    id: "repo-2",
+    name: "beta",
+    fs_uri: "file:///Users/dev/code/beta/",
+  };
+
+  it("omits the path by default", () => {
+    const item = buildRepoSpotlightItem(repoWithPath, { onAction: () => {} });
+
+    expect(item.desc).toBeUndefined();
+    expect(item.data?.contextMenuCopy?.path).toBe("/Users/dev/code/beta");
+  });
+
+  it("renders the path as the row description when showPath is on", () => {
+    const item = buildRepoSpotlightItem(repoWithPath, {
+      onAction: () => {},
+      showPath: true,
+    });
+
+    expect(item.desc).toContain("beta");
+  });
+
+  it("stays path-less when the repo has no filesystem uri", () => {
+    const item = buildRepoSpotlightItem(baseRepo, {
+      onAction: () => {},
+      showPath: true,
+    });
+
+    expect(item.desc).toBeUndefined();
+  });
+});
+
 describe("buildRepoSpotlightItems", () => {
   it("maps every repo and forwards options consistently", () => {
     const repos: RepoItem[] = [

--- a/src/scaffold/GlobalSpotlight/palettes/adapters/repoAdapter.ts
+++ b/src/scaffold/GlobalSpotlight/palettes/adapters/repoAdapter.ts
@@ -11,6 +11,7 @@ import {
   isSystemPathRepoItem,
 } from "@src/features/SessionCreator/utils/systemPathSource";
 import { REPO_KIND } from "@src/store/repo";
+import { compactRepoPathForDisplay } from "@src/util/file/repoPathDisplay";
 
 import { ICONS } from "../../config";
 import type { RepoItem, SpotlightItem, SpotlightItemData } from "../../types";
@@ -26,6 +27,9 @@ export interface BuildRepoItemOptions {
   getSelectionState?: (
     repo: RepoItem
   ) => SpotlightItemData["selectionState"] | undefined;
+  /** Renders the repo's filesystem path under its name. Driven by the
+   *  spotlight footer's "Show path" toggle; off by default. */
+  showPath?: boolean;
 }
 
 /**
@@ -41,12 +45,17 @@ export function buildRepoSpotlightItem(
     idPrefix = "",
     manageAction,
     getSelectionState,
+    showPath = false,
   } = options;
   const inManageMode = !!manageAction;
   const copyPath = repo.fs_uri?.replace(/^file:\/\//, "").replace(/\/+$/, "");
+  const displayPath = copyPath
+    ? compactRepoPathForDisplay({ path: copyPath })
+    : "";
   return {
     id: `${idPrefix}${repo.id}`,
     label: repo.name,
+    desc: showPath && displayPath ? displayPath : undefined,
     icon: isSystemHomeRepoItem(repo)
       ? ICONS.home
       : isSystemPathRepoItem(repo) || repo.kind === REPO_KIND.FOLDER

--- a/src/scaffold/GlobalSpotlight/shared/index.ts
+++ b/src/scaffold/GlobalSpotlight/shared/index.ts
@@ -8,6 +8,14 @@
 export { SpotlightInput } from "./SpotlightInput";
 export type { SpotlightInputProps } from "./SpotlightInput";
 
+// Refresh spin (shared by every pinned "Refresh" action)
+export {
+  REFRESH_SPIN_MIN_MS,
+  remainingSpinMs,
+  useRefreshSpin,
+} from "./refreshSpin";
+export type { RefreshSpinIconProps, UseRefreshSpinReturn } from "./refreshSpin";
+
 // Types
 export type {
   BasePaletteProps,

--- a/src/scaffold/GlobalSpotlight/shared/refreshSpin.test.ts
+++ b/src/scaffold/GlobalSpotlight/shared/refreshSpin.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { REFRESH_SPIN_MIN_MS, remainingSpinMs } from "./refreshSpin";
+
+describe("remainingSpinMs", () => {
+  it("pads a refresh that resolved faster than the minimum spin", () => {
+    expect(remainingSpinMs(0)).toBe(REFRESH_SPIN_MIN_MS);
+    expect(remainingSpinMs(200)).toBe(REFRESH_SPIN_MIN_MS - 200);
+  });
+
+  it("stops immediately once the refresh outlasted the minimum spin", () => {
+    expect(remainingSpinMs(REFRESH_SPIN_MIN_MS)).toBe(0);
+    expect(remainingSpinMs(REFRESH_SPIN_MIN_MS + 5_000)).toBe(0);
+  });
+
+  it("treats a non-monotonic or invalid clock delta as no remaining spin", () => {
+    expect(remainingSpinMs(-50)).toBe(REFRESH_SPIN_MIN_MS);
+    expect(remainingSpinMs(Number.NaN)).toBe(0);
+  });
+});

--- a/src/scaffold/GlobalSpotlight/shared/refreshSpin.ts
+++ b/src/scaffold/GlobalSpotlight/shared/refreshSpin.ts
@@ -1,0 +1,84 @@
+/**
+ * Spotlight refresh spin
+ *
+ * Shared spin behavior for every pinned "Refresh" action in the spotlight
+ * (branches, worktrees, …).
+ *
+ * A local git refresh usually resolves in a few milliseconds, so binding the
+ * animation straight to the in-flight promise makes the icon twitch once and
+ * stop — indistinguishable from a dead button. The spin therefore holds for
+ * {@link REFRESH_SPIN_MIN_MS} even when the underlying call finishes sooner,
+ * and the action stays clickable while it spins.
+ */
+import {
+  type ComponentType,
+  createElement,
+  useCallback,
+  useState,
+} from "react";
+
+import { HugeiconsIcon, type IconSvgElement } from "@src/icons";
+
+/** Floor for the refresh animation so a fast refresh still reads as one. */
+export const REFRESH_SPIN_MIN_MS = 900;
+
+/** Milliseconds the spin must still run after a refresh took `elapsedMs`. */
+export function remainingSpinMs(
+  elapsedMs: number,
+  minMs: number = REFRESH_SPIN_MIN_MS
+): number {
+  if (!Number.isFinite(elapsedMs)) return 0;
+  return Math.max(0, minMs - Math.max(0, elapsedMs));
+}
+
+export interface RefreshSpinIconProps {
+  size?: number;
+  className?: string;
+}
+
+export interface UseRefreshSpinReturn {
+  /** Whether the icon is currently animating. */
+  isSpinning: boolean;
+  /** Runs the refresh and keeps the icon spinning for the minimum duration. */
+  triggerRefresh: () => void;
+  /** Refresh icon bound to the current spin state. */
+  RefreshIcon: ComponentType<RefreshSpinIconProps>;
+}
+
+/**
+ * Wraps a refresh callback with the shared minimum-duration spin state and a
+ * ready-made icon component for `SpotlightItem.icon`.
+ */
+export function useRefreshSpin(
+  icon: IconSvgElement,
+  refresh: () => void | Promise<unknown>
+): UseRefreshSpinReturn {
+  const [isSpinning, setIsSpinning] = useState(false);
+
+  const triggerRefresh = useCallback(() => {
+    setIsSpinning(true);
+    const startedAt = Date.now();
+    void Promise.resolve()
+      .then(refresh)
+      .catch(() => {})
+      .finally(() => {
+        window.setTimeout(
+          () => setIsSpinning(false),
+          remainingSpinMs(Date.now() - startedAt)
+        );
+      });
+  }, [refresh]);
+
+  const RefreshIcon = useCallback(
+    (props: RefreshSpinIconProps) =>
+      createElement(HugeiconsIcon, {
+        icon,
+        ...props,
+        className:
+          `${props.className ?? ""} ${isSpinning ? "spotlight-refresh-spin" : ""}`.trim(),
+      }),
+    [icon, isSpinning]
+  );
+
+  return { isSpinning, triggerRefresh, RefreshIcon };
+}

--- a/src/scaffold/GlobalSpotlight/shared/types.ts
+++ b/src/scaffold/GlobalSpotlight/shared/types.ts
@@ -75,6 +75,10 @@ export interface SpotlightItemData {
     checked: boolean;
     onToggle: (e?: React.MouseEvent) => void;
   };
+  /** Overrides the text a palette's fuzzy filter matches against. Lets a
+   *  row stay searchable by a value it does not render (e.g. a worktree
+   *  path hidden behind the footer's "Show path" toggle). */
+  searchText?: string;
   /** Allow any additional properties */
   [key: string]: unknown;
 }

--- a/src/scaffold/GlobalSpotlight/shell/ShellFooterAction.tsx
+++ b/src/scaffold/GlobalSpotlight/shell/ShellFooterAction.tsx
@@ -1,21 +1,31 @@
 import React, { useContext, useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
 
-import { SpotlightFooterActionContext } from "./footerActionContext";
+import {
+  type FooterActionPlacement,
+  SpotlightFooterActionContext,
+} from "./footerActionContext";
 
 /**
  * ShellFooterAction
  *
- * Portal used by palettes to inject a footer action pill (e.g. "Manage
- * Models", "Manage Keys") next to the keyboard-hints footer rendered by
- * SpotlightShell. If there is no SpotlightShell in the tree, renders
- * nothing — callers don't need to guard.
+ * Portal used by palettes to inject footer content next to the
+ * keyboard-hints footer rendered by SpotlightShell:
+ *
+ * - `placement="pill"` (default) — its own floating pill beside the hints
+ *   (e.g. "Manage Models", "Manage Keys").
+ * - `placement="inline"` — inside the hint pill itself, after the last
+ *   hint (e.g. the "Show path" checkbox).
+ *
+ * If there is no SpotlightShell in the tree, renders nothing — callers
+ * don't need to guard.
  *
  * Uses useSyncExternalStore so the portal target stays in sync with the
  * shell's host ref without any effect + setState dance.
  */
 export interface ShellFooterActionProps {
   children: React.ReactNode;
+  placement?: FooterActionPlacement;
 }
 
 const emptySubscribe = () => () => {};
@@ -23,8 +33,10 @@ const emptyGetSnapshot = () => null;
 
 export const ShellFooterAction: React.FC<ShellFooterActionProps> = ({
   children,
+  placement = "pill",
 }) => {
-  const slot = useContext(SpotlightFooterActionContext);
+  const slots = useContext(SpotlightFooterActionContext);
+  const slot = slots?.[placement];
 
   const target = useSyncExternalStore<HTMLDivElement | null>(
     slot?.subscribe ?? emptySubscribe,

--- a/src/scaffold/GlobalSpotlight/shell/SpotlightShell.tsx
+++ b/src/scaffold/GlobalSpotlight/shell/SpotlightShell.tsx
@@ -21,7 +21,7 @@ import { SpotlightFooter, type SpotlightFooterActiveChip } from "../components";
 import { SPOTLIGHT_CONFIG } from "../constants";
 import { SpotlightShellChrome } from "./SpotlightShellChrome";
 import {
-  type FooterActionSlot,
+  type FooterActionSlots,
   SpotlightFooterActionContext,
 } from "./footerActionContext";
 
@@ -59,33 +59,47 @@ export const SpotlightShell: React.FC<SpotlightShellProps> = ({
   hideFooter = false,
   children,
 }) => {
-  // Tiny external store so palette-level ShellFooterAction components can
-  // subscribe to the host element without ref-in-render or effect dances.
-  const hostRef = useRef<HTMLDivElement | null>(null);
-  const listenersRef = useRef<Set<() => void>>(new Set());
+  // Tiny external stores so palette-level ShellFooterAction components can
+  // subscribe to their host element without ref-in-render or effect dances.
+  // One host per placement: a sibling pill, and a slot inside the
+  // keyboard-hint pill itself.
+  const pillHostRef = useRef<HTMLDivElement | null>(null);
+  const pillListenersRef = useRef<Set<() => void>>(new Set());
+  const inlineHostRef = useRef<HTMLDivElement | null>(null);
+  const inlineListenersRef = useRef<Set<() => void>>(new Set());
 
-  const notify = useCallback(() => {
-    listenersRef.current.forEach((cb) => cb());
+  const setPillHostEl = useCallback((el: HTMLDivElement | null) => {
+    if (pillHostRef.current === el) return;
+    pillHostRef.current = el;
+    pillListenersRef.current.forEach((cb) => cb());
   }, []);
 
-  const setHostEl = useCallback(
-    (el: HTMLDivElement | null) => {
-      if (hostRef.current === el) return;
-      hostRef.current = el;
-      notify();
-    },
-    [notify]
-  );
+  const setInlineHostEl = useCallback((el: HTMLDivElement | null) => {
+    if (inlineHostRef.current === el) return;
+    inlineHostRef.current = el;
+    inlineListenersRef.current.forEach((cb) => cb());
+  }, []);
 
-  const slot = useMemo<FooterActionSlot>(
+  const slots = useMemo<FooterActionSlots>(
     () => ({
-      subscribe: (cb) => {
-        listenersRef.current.add(cb);
-        return () => {
-          listenersRef.current.delete(cb);
-        };
+      pill: {
+        subscribe: (cb) => {
+          pillListenersRef.current.add(cb);
+          return () => {
+            pillListenersRef.current.delete(cb);
+          };
+        },
+        getSnapshot: () => pillHostRef.current,
       },
-      getSnapshot: () => hostRef.current,
+      inline: {
+        subscribe: (cb) => {
+          inlineListenersRef.current.add(cb);
+          return () => {
+            inlineListenersRef.current.delete(cb);
+          };
+        },
+        getSnapshot: () => inlineHostRef.current,
+      },
     }),
     []
   );
@@ -96,14 +110,22 @@ export const SpotlightShell: React.FC<SpotlightShellProps> = ({
         <SpotlightFooter
           hasActiveAction={hasActiveAction}
           activeActionChip={activeActionChip}
+          // `empty:hidden` keeps the hint row's gap from opening up when no
+          // palette contributes an inline control.
+          trailingSlot={
+            <div
+              ref={setInlineHostEl}
+              className="flex items-center empty:hidden"
+            />
+          }
         />
-        <div ref={setHostEl} className="flex items-center" />
+        <div ref={setPillHostEl} className="flex items-center" />
       </div>
     </div>
   );
 
   return (
-    <SpotlightFooterActionContext.Provider value={slot}>
+    <SpotlightFooterActionContext.Provider value={slots}>
       <SpotlightShellChrome
         isOpen={isOpen}
         onClose={onClose}

--- a/src/scaffold/GlobalSpotlight/shell/footerActionContext.ts
+++ b/src/scaffold/GlobalSpotlight/shell/footerActionContext.ts
@@ -1,7 +1,7 @@
 import { createContext } from "react";
 
 /**
- * Slot subscription for the shell's footer action host.
+ * Slot subscription for one of the shell's footer hosts.
  *
  * The shell implements a tiny store with `subscribe` and `getSnapshot`
  * methods (the useSyncExternalStore shape). Palette-level
@@ -16,5 +16,17 @@ export interface FooterActionSlot {
   getSnapshot: () => HTMLDivElement | null;
 }
 
+/**
+ * Where a palette's footer content lands:
+ * - `pill` — its own floating pill beside the keyboard hints.
+ * - `inline` — inside the keyboard-hint pill, after the last hint.
+ */
+export interface FooterActionSlots {
+  pill: FooterActionSlot;
+  inline: FooterActionSlot;
+}
+
+export type FooterActionPlacement = keyof FooterActionSlots;
+
 export const SpotlightFooterActionContext =
-  createContext<FooterActionSlot | null>(null);
+  createContext<FooterActionSlots | null>(null);

--- a/src/store/ui/spotlightShowPathAtom.ts
+++ b/src/store/ui/spotlightShowPathAtom.ts
@@ -1,0 +1,28 @@
+/**
+ * Spotlight Show Path Atom
+ *
+ * Whether workspace and worktree rows in the spotlight render their
+ * filesystem path under the name. Off by default — the path is noise for
+ * users whose repos all live in one folder — and toggled from the
+ * "Show path" pill next to the spotlight's keyboard-hint footer.
+ *
+ * Persisted so the choice survives reopening the palette and restarting
+ * the app.
+ */
+import { atom } from "jotai";
+import { atomWithStorage } from "jotai/utils";
+
+const SPOTLIGHT_SHOW_PATH_STORAGE_KEY = "orgii-spotlight-show-path";
+
+const storedSpotlightShowPathAtom = atomWithStorage<unknown>(
+  SPOTLIGHT_SHOW_PATH_STORAGE_KEY,
+  false,
+  undefined,
+  { getOnInit: true }
+);
+
+export const spotlightShowPathAtom = atom(
+  (get) => get(storedSpotlightShowPathAtom) === true,
+  (_get, set, visible: boolean) => set(storedSpotlightShowPathAtom, visible)
+);
+spotlightShowPathAtom.debugLabel = "spotlightShowPathAtom";


### PR DESCRIPTION
## Problem

Four defects in the Spotlight worktree palette (`⌘K` → Switch Worktree) and its
shared footer, reported from the running app:

1. **Refresh reads as dead.** The pinned "Refresh" action bound its spin
   directly to the in-flight promise. A local `git worktree list` resolves in a
   few milliseconds, so the icon twitched once and stopped, and the action
   disabled itself for that same instant. The branch palette already solved this
   with a 900 ms spin floor; the worktree palette did not share it. Refresh also
   called `refreshWorktreeMap`, which invalidates the cache *before* refetching,
   so the rows blanked to a loading placeholder on every refresh.
2. **The footer resizes under the user.** Entering remove mode swapped the
   `⇥ Switch section` hint for `⌫ Back` even though Tab still switches sections
   there, and the two-column pinned-action grid dropped from two rows to one
   (only "Done" remains), so the panel and the floating hint pill both changed
   size mid-interaction.
3. **No control over the path.** Worktree rows always rendered their filesystem
   path as a second line; workspace/repo rows never did. Neither was a user
   choice.
4. **Remove mode used a text label.** Each row showed a right-aligned
   "Remove Worktree" string, unlike the workspace palette's manage mode, which
   uses a trash icon button.

## Solution

**Refresh parity.** The branch palette's spin logic moves into a shared
`useRefreshSpin(icon, refresh)` hook (`shared/refreshSpin.ts`): minimum 900 ms
animation via the pure `remainingSpinMs` helper, and the action stays clickable
while it spins. Both palettes now use it, so there is one implementation rather
than two copies. The worktree refresh calls a new `revalidateWorktreeMap`, which
refetches without dropping the cached entries first, so the list stays on screen
and only the icon reports the work. `refreshWorktreeMap` keeps its
invalidate-first semantics for the remove path, where stale rows would be worse
than none.

**Footer stability.** `activeActionChip` now stays `switchSection` for every mode
that still renders a pinned section (both worktree modes; branch checkout and
remove — the branch create modes render no section and keep the `Back` chip).
`SpotlightPinnedActionSection` gains an opt-in `reserveRows`; the worktree
palette passes `2` when it has both create and remove actions, so the grid keeps
its two-row height when remove mode collapses to a single "Done". Every other
palette keeps the previous auto-sizing behavior.

**Show-path toggle.** A `Show path` checkbox renders inside the keyboard-hint
pill after a thin separator. `SpotlightShell` now owns two footer portal hosts —
the existing sibling-pill host and a new inline host inside the pill — selected
by `<ShellFooterAction placement="pill" | "inline">`; `pill` is the default, so
the existing "Manage Models" / "Manage Keys" pills are untouched. State lives in
a persisted `spotlightShowPathAtom`, shared by the worktree and workspace
palettes. **Off by default**, which changes worktree rows: the path is now hidden
until the box is ticked. It remains matchable while hidden (new
`SpotlightItemData.searchText`, used by the worktree palette's filter) and is
still in the row's right-click *Copy path* / *Reveal* menu. Ticking it on also
adds the path under workspace and repo rows, which previously had none
(`buildRepoSpotlightItem({ showPath })`).

**Trash button.** Remove mode swaps the text `rightLabel` for a `rightContent`
trash button styled exactly like the workspace palette's manage-mode action
(`text-danger-6`, `hover:bg-danger-6/10`, `ICONS.removeRepo` at 14px), disabled
while that worktree is being removed. Clicking the row still removes, so keyboard
Enter behavior is unchanged.

## Potential risks

- **Behavior change, deliberate:** worktree rows no longer show their path by
  default. Users who relied on it must tick "Show path" once (the choice
  persists in `localStorage` under `orgii-spotlight-show-path`). Mitigated by
  keeping the path searchable and in the context menu.
- **Row height changes with the toggle.** `SpotlightItemList` virtualizes on a
  single `ITEM_HEIGHT` while a row with a description is taller. With the toggle
  off, worktree rows are now uniform, so the virtualization math is *more*
  correct than before; with it on, the pre-existing drift for long lists is
  unchanged. No new failure mode, but a long worktree list with the toggle on has
  the same scroll drift it has today.
- **Shared atom, two palettes.** One preference drives both surfaces by design.
  If they should diverge later, the atom has to split.
- **`empty:hidden` on the inline host.** The hint row would gain a stray gap if
  that Tailwind variant were ever purged; it is a literal class in the shell, so
  JIT picks it up.
- **`useBranchPalette` refactor.** Its refresh moved to the shared hook. Timing is
  identical (same 900 ms floor, same `disabled: isLoading` gate), but this is a
  shared code path used by both the global palette and the create-session
  variant.
- **No screenshots.** Verified by types, lint, and unit tests only — see below.
  The visual result was not confirmed in a running app, so the exact fit of the
  checkbox inside the hint pill is unreviewed.
- **Hooks did not run on this commit.** It was built with a temporary index from
  a checkout carrying unrelated in-progress work, so the diff stays scoped to
  this change. Consequently there is no `Pre-commit hook ran.` trailer, and the
  checks below were run by hand.

## Verification

Ran:

- `npx vitest run src/scaffold/GlobalSpotlight src/store/ui` → **30 files, 188
  tests passed**, including 3 new `remainingSpinMs` cases
  (`shared/refreshSpin.test.ts`) and 3 new show-path cases in
  `adapters/__tests__/repoAdapter.test.ts`.
- `npx eslint --max-warnings 0 --report-unused-disable-directives
  src/scaffold/GlobalSpotlight/ src/store/ui/spotlightShowPathAtom.ts` → clean.
  (First pass flagged `react-hooks/refs` on a helper hook returning ref-derived
  values; the two footer hosts are now declared inline in `SpotlightShell`.)
- `node scripts/quality/check-circular-dependencies.mjs` → no cycles across 6280
  modules.
- TypeScript: **the full-project `pnpm typecheck` could not be run** — `tsc
  --noEmit` over the whole program is killed in this environment (exit 144, no
  output, reproducible on a bare invocation). Instead, a scoped `tsconfig`
  extending the project config and listing every changed file plus the two other
  `ShellFooterAction` consumers (`UnifiedModelPalette`, `DispatchCategoryPalette`)
  was compiled — that program pulls in each file's full transitive import graph
  and reports **zero errors**. CI's typecheck job remains the authoritative run.

Not run: Playwright/WebdriverIO e2e (no rendered spec covers this palette), and
`cargo` (no Rust touched).
