### PR TITLE
feat(sidebar): register a workspace group's folder on new session

### DIFF
--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/importWorkspaceRepo.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/importWorkspaceRepo.ts
@@ -1,0 +1,69 @@
+/**
+ * Registering a sidebar workspace group's directory as a real workspace repo.
+ *
+ * Organize-by-workspace groups sessions by the cwd they ran in, so a group can
+ * be headed by a directory that was never added as a workspace — every session
+ * imported from an external CLI's history lands in one. Starting a session
+ * from such a group needs the directory registered first: without a repo id
+ * the launch carries a bare path, and every repo-keyed surface (branch
+ * resolution, repo kind, the branch dropdown) has nothing to key on.
+ *
+ * Kind detection is not a convenience here. `server_import_repo` runs
+ * `git init` (plus an initial commit) on a path that has no `.git`, which is
+ * not something clicking "new session" may do to a directory the user only
+ * ever ran an agent in — so a non-git directory is registered as a plain work
+ * folder instead.
+ */
+import { repoApi } from "@src/api/tauri/repo";
+import { REPO_KIND, type Repo } from "@src/store/repo";
+import { matchRepoByPath } from "@src/store/repo/matchRepoByPath";
+
+interface ImportedRepoRecord {
+  repo_id: string;
+  name: string;
+  path: string;
+  kind?: string;
+}
+
+function toStoreRepo(record: ImportedRepoRecord): Repo {
+  return {
+    id: record.repo_id,
+    name: record.name,
+    // The backend canonicalizes the path (symlinks, `/tmp` → `/private/tmp`),
+    // so store what it persisted rather than what was clicked.
+    path: record.path,
+    fs_uri: record.path,
+    kind: record.kind === "folder" ? REPO_KIND.FOLDER : REPO_KIND.GIT,
+  };
+}
+
+/**
+ * Import `workspacePath` as a workspace and return it in store shape.
+ *
+ * The backend list is consulted first because `reposAtom` is not authoritative
+ * at every moment: it is empty until the startup load lands, and a `+` clicked
+ * in that window would otherwise re-import a directory that is already
+ * registered. That is not harmless — the import upserts `kind`, so a directory
+ * deliberately registered as a work folder would be silently converted to a
+ * git repo. A repo list that cannot be read rejects rather than guesses.
+ *
+ * Rejects, too, when the path is gone or unreadable: the backend validates the
+ * directory before persisting anything, and a group can outlive the folder its
+ * sessions ran in.
+ */
+export async function importWorkspaceRepo(
+  workspacePath: string
+): Promise<Repo> {
+  const registeredRepos = await repoApi.getRepos();
+  const alreadyRegistered = matchRepoByPath(
+    (registeredRepos.data?.repos ?? []).map(toStoreRepo),
+    workspacePath
+  );
+  if (alreadyRegistered) return alreadyRegistered;
+
+  const isGitRepo = await repoApi.checkIsGitRepo(workspacePath);
+  const response = isGitRepo
+    ? await repoApi.importLocalRepo({ fs_path: workspacePath })
+    : await repoApi.importWorkFolder({ fs_path: workspacePath });
+  return toStoreRepo(response.data);
+}

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useWorkspaceGroupActions.test.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useWorkspaceGroupActions.test.ts
@@ -4,7 +4,15 @@ import React from "react";
 import { renderToString } from "react-dom/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { gitApi } from "@src/api/http/git";
 import { repoApi } from "@src/api/tauri/repo";
+import {
+  REPO_KIND,
+  type Repo,
+  reposAtom,
+  validRepoIdsAtom,
+} from "@src/store/repo";
+import { sessionSourceAtom } from "@src/store/session/creatorStateAtom";
 import { showNativeMessageSafely } from "@src/util/dialogs/nativeDialog";
 import { popupNativeMenu } from "@src/util/platform/tauri/nativeMenuPopup";
 
@@ -23,6 +31,16 @@ vi.mock("@src/util/dialogs/nativeDialog", () => ({
 vi.mock("@src/api/tauri/repo", () => ({
   repoApi: {
     validateWorkspacePath: vi.fn(),
+    getRepos: vi.fn(),
+    checkIsGitRepo: vi.fn(),
+    importLocalRepo: vi.fn(),
+    importWorkFolder: vi.fn(),
+  },
+}));
+
+vi.mock("@src/api/http/git", () => ({
+  gitApi: {
+    getGitCurrentBranchName: vi.fn(),
   },
 }));
 
@@ -33,10 +51,47 @@ vi.mock("@src/util/platform/tauri/nativeMenuPopup", () => ({
 const mockedPopupNativeMenu = vi.mocked(popupNativeMenu);
 const mockedRevealItemInDir = vi.mocked(revealItemInDir);
 const mockedValidateWorkspacePath = vi.mocked(repoApi.validateWorkspacePath);
+const mockedGetRepos = vi.mocked(repoApi.getRepos);
+const mockedCheckIsGitRepo = vi.mocked(repoApi.checkIsGitRepo);
+const mockedImportLocalRepo = vi.mocked(repoApi.importLocalRepo);
+const mockedImportWorkFolder = vi.mocked(repoApi.importWorkFolder);
+const mockedGetGitCurrentBranchName = vi.mocked(gitApi.getGitCurrentBranchName);
 const mockedShowNativeMessageSafely = vi.mocked(showNativeMessageSafely);
 
-function renderWorkspaceGroupActions(): WorkspaceGroupActions {
+const EXTERNAL_WORKSPACE = "/external/orgii-cloud-infra";
+
+function repoImportResponse(
+  overrides: {
+    id?: string;
+    name?: string;
+    path?: string;
+    kind?: "git" | "folder";
+  } = {}
+) {
+  return {
+    data: {
+      repo_id: overrides.id ?? EXTERNAL_WORKSPACE,
+      user_id: "",
+      name: overrides.name ?? "orgii-cloud-infra",
+      path: overrides.path ?? EXTERNAL_WORKSPACE,
+      kind: overrides.kind ?? ("git" as const),
+    },
+    status: 0,
+  };
+}
+
+interface RenderedWorkspaceGroupActions {
+  actions: WorkspaceGroupActions;
+  store: ReturnType<typeof createStore>;
+  openNewSession: ReturnType<typeof vi.fn>;
+}
+
+function renderWorkspaceGroupActions(
+  seededRepos: Repo[] = []
+): RenderedWorkspaceGroupActions {
   const store = createStore();
+  store.set(reposAtom, seededRepos);
+  const openNewSession = vi.fn();
   let actions: WorkspaceGroupActions | undefined;
 
   function HookProbe(): null {
@@ -51,7 +106,7 @@ function renderWorkspaceGroupActions(): WorkspaceGroupActions {
       revealLabel: "Reveal in file manager",
       unavailableTitle: "Workspace no longer available",
       unavailableMessage: "This Workspace may have been moved or deleted.",
-      openNewSession: vi.fn(),
+      openNewSession,
       setCollapsedSectionIds: vi.fn(),
     });
     return null;
@@ -62,7 +117,7 @@ function renderWorkspaceGroupActions(): WorkspaceGroupActions {
   );
 
   if (!actions) throw new Error("workspace group actions did not render");
-  return actions;
+  return { actions, store, openNewSession };
 }
 
 describe("useWorkspaceGroupActions", () => {
@@ -72,10 +127,22 @@ describe("useWorkspaceGroupActions", () => {
     mockedValidateWorkspacePath.mockReset();
     mockedValidateWorkspacePath.mockImplementation(async (path) => path);
     mockedShowNativeMessageSafely.mockClear();
+    mockedGetRepos.mockReset();
+    mockedGetRepos.mockResolvedValue({ data: { repos: [] }, status: 0 });
+    mockedCheckIsGitRepo.mockReset();
+    mockedCheckIsGitRepo.mockResolvedValue(true);
+    mockedImportLocalRepo.mockReset();
+    mockedImportLocalRepo.mockResolvedValue(repoImportResponse());
+    mockedImportWorkFolder.mockReset();
+    mockedImportWorkFolder.mockResolvedValue(
+      repoImportResponse({ kind: "folder" })
+    );
+    mockedGetGitCurrentBranchName.mockReset();
+    mockedGetGitCurrentBranchName.mockResolvedValue("develop");
   });
 
   it("reveals actual workspace groups in the OS file manager", async () => {
-    const actions = renderWorkspaceGroupActions();
+    const { actions } = renderWorkspaceGroupActions();
     actions.onOpenMenu("/workspace/orgii");
 
     const popupOptions = mockedPopupNativeMenu.mock.calls[0]?.[0];
@@ -103,7 +170,7 @@ describe("useWorkspaceGroupActions", () => {
     mockedValidateWorkspacePath.mockRejectedValue(
       new Error("Unable to access workspace path")
     );
-    const actions = renderWorkspaceGroupActions();
+    const { actions } = renderWorkspaceGroupActions();
     actions.onOpenMenu("/workspace/missing");
 
     const popupOptions = mockedPopupNativeMenu.mock.calls[0]?.[0];
@@ -126,7 +193,7 @@ describe("useWorkspaceGroupActions", () => {
   });
 
   it("omits reveal for the synthetic no-workspace group", async () => {
-    const actions = renderWorkspaceGroupActions();
+    const { actions } = renderWorkspaceGroupActions();
     actions.onOpenMenu(NO_WORKSPACE_KEY);
 
     const popupOptions = mockedPopupNativeMenu.mock.calls[0]?.[0];
@@ -135,5 +202,185 @@ describe("useWorkspaceGroupActions", () => {
       items?.map((item) => ("text" in item ? item.text : item.item))
     ).toEqual(["Pin workspace", "Hide workspace"]);
     expect(mockedRevealItemInDir).not.toHaveBeenCalled();
+  });
+
+  it("adds an unregistered workspace group before sourcing the session there", async () => {
+    const { actions, store, openNewSession } = renderWorkspaceGroupActions();
+
+    actions.onCreateSession(EXTERNAL_WORKSPACE);
+
+    // The composer opens immediately on the clicked workspace; the repo id is
+    // still unknown at this point.
+    expect(openNewSession).toHaveBeenCalledTimes(1);
+    expect(store.get(sessionSourceAtom)).toMatchObject({
+      type: "local",
+      repoId: undefined,
+      repoName: "orgii-cloud-infra",
+      repoPath: EXTERNAL_WORKSPACE,
+    });
+
+    await vi.waitFor(() => {
+      expect(store.get(sessionSourceAtom)).toMatchObject({
+        repoId: EXTERNAL_WORKSPACE,
+        repoName: "orgii-cloud-infra",
+        repoPath: EXTERNAL_WORKSPACE,
+        branch: "develop",
+      });
+    });
+    expect(mockedImportLocalRepo).toHaveBeenCalledWith({
+      fs_path: EXTERNAL_WORKSPACE,
+    });
+    expect(store.get(reposAtom)).toEqual([
+      {
+        id: EXTERNAL_WORKSPACE,
+        name: "orgii-cloud-infra",
+        path: EXTERNAL_WORKSPACE,
+        fs_uri: EXTERNAL_WORKSPACE,
+        kind: REPO_KIND.GIT,
+      },
+    ]);
+    // Branch loading is gated on this set, so the added repo has to land in it.
+    expect(store.get(validRepoIdsAtom).has(EXTERNAL_WORKSPACE)).toBe(true);
+  });
+
+  it("registers a directory without git as a work folder rather than initializing one", async () => {
+    mockedCheckIsGitRepo.mockResolvedValue(false);
+    const { actions, store } = renderWorkspaceGroupActions();
+
+    actions.onCreateSession(EXTERNAL_WORKSPACE);
+
+    await vi.waitFor(() => {
+      expect(store.get(sessionSourceAtom)?.repoId).toBe(EXTERNAL_WORKSPACE);
+    });
+    expect(mockedImportWorkFolder).toHaveBeenCalledWith({
+      fs_path: EXTERNAL_WORKSPACE,
+    });
+    expect(mockedImportLocalRepo).not.toHaveBeenCalled();
+    // A work folder has no branch to read.
+    expect(mockedGetGitCurrentBranchName).not.toHaveBeenCalled();
+    expect(store.get(sessionSourceAtom)?.branch).toBeUndefined();
+  });
+
+  it("reuses a registration the repo list has not loaded yet instead of re-importing", async () => {
+    // `reposAtom` is empty until the startup load lands; re-importing in that
+    // window would upsert `kind` and quietly turn a work folder into a git repo.
+    mockedGetRepos.mockResolvedValue({
+      data: {
+        repos: [
+          {
+            repo_id: EXTERNAL_WORKSPACE,
+            user_id: "",
+            name: "orgii-cloud-infra",
+            path: EXTERNAL_WORKSPACE,
+            kind: "folder" as const,
+          },
+        ],
+      },
+      status: 0,
+    });
+    const { actions, store } = renderWorkspaceGroupActions();
+
+    actions.onCreateSession(EXTERNAL_WORKSPACE);
+
+    await vi.waitFor(() => {
+      expect(store.get(sessionSourceAtom)?.repoId).toBe(EXTERNAL_WORKSPACE);
+    });
+    expect(mockedImportLocalRepo).not.toHaveBeenCalled();
+    expect(mockedImportWorkFolder).not.toHaveBeenCalled();
+    expect(store.get(reposAtom)).toEqual([
+      {
+        id: EXTERNAL_WORKSPACE,
+        name: "orgii-cloud-infra",
+        path: EXTERNAL_WORKSPACE,
+        fs_uri: EXTERNAL_WORKSPACE,
+        kind: REPO_KIND.FOLDER,
+      },
+    ]);
+    expect(mockedGetGitCurrentBranchName).not.toHaveBeenCalled();
+  });
+
+  it("resolves the branch for a group that is already a workspace without importing again", async () => {
+    const { actions, store } = renderWorkspaceGroupActions([
+      {
+        id: "repo-1",
+        name: "orgii-cloud-infra",
+        path: EXTERNAL_WORKSPACE,
+        kind: REPO_KIND.GIT,
+      },
+    ]);
+
+    actions.onCreateSession(EXTERNAL_WORKSPACE);
+
+    await vi.waitFor(() => {
+      expect(store.get(sessionSourceAtom)?.branch).toBe("develop");
+    });
+    expect(store.get(sessionSourceAtom)).toMatchObject({ repoId: "repo-1" });
+    expect(mockedGetRepos).not.toHaveBeenCalled();
+    expect(mockedCheckIsGitRepo).not.toHaveBeenCalled();
+    expect(mockedImportLocalRepo).not.toHaveBeenCalled();
+  });
+
+  it("keeps the session sourced at the path when the directory can no longer be added", async () => {
+    mockedImportLocalRepo.mockRejectedValue(
+      new Error("Path does not exist: /external/orgii-cloud-infra")
+    );
+    const { actions, store, openNewSession } = renderWorkspaceGroupActions();
+
+    actions.onCreateSession(EXTERNAL_WORKSPACE);
+
+    await vi.waitFor(() => {
+      expect(mockedImportLocalRepo).toHaveBeenCalled();
+    });
+    // The session still launches at the clicked path — a workspace that can no
+    // longer be registered is not a reason to swallow the click.
+    expect(openNewSession).toHaveBeenCalledTimes(1);
+    expect(store.get(sessionSourceAtom)).toMatchObject({
+      repoId: undefined,
+      repoPath: EXTERNAL_WORKSPACE,
+    });
+    expect(store.get(reposAtom)).toEqual([]);
+  });
+
+  it("leaves the source alone when the composer moved on while the import was in flight", async () => {
+    let resolveImport: (() => void) | undefined;
+    mockedImportLocalRepo.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveImport = () => resolve(repoImportResponse());
+        })
+    );
+    const { actions, store } = renderWorkspaceGroupActions();
+
+    actions.onCreateSession(EXTERNAL_WORKSPACE);
+    await vi.waitFor(() => {
+      expect(resolveImport).toBeDefined();
+    });
+
+    // The viewer picked a different workspace before the import landed.
+    store.set(sessionSourceAtom, {
+      type: "local",
+      repoId: "repo-2",
+      repoName: "other",
+      repoPath: "/workspace/other",
+    });
+    resolveImport?.();
+
+    await vi.waitFor(() => {
+      expect(store.get(reposAtom)).toHaveLength(1);
+    });
+    expect(store.get(sessionSourceAtom)).toMatchObject({
+      repoId: "repo-2",
+      repoPath: "/workspace/other",
+    });
+  });
+
+  it("does not start a session for the synthetic no-workspace group", () => {
+    const { actions, store, openNewSession } = renderWorkspaceGroupActions();
+
+    actions.onCreateSession(NO_WORKSPACE_KEY);
+
+    expect(openNewSession).not.toHaveBeenCalled();
+    expect(store.get(sessionSourceAtom)).toBeNull();
+    expect(mockedCheckIsGitRepo).not.toHaveBeenCalled();
   });
 });

--- a/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useWorkspaceGroupActions.ts
+++ b/src/scaffold/NavigationSidebar/connectors/WorkstationSidebarConnector/useWorkspaceGroupActions.ts
@@ -3,6 +3,13 @@
  * view: the hover `…` (pin / hide) and `+` (start a session sourced at that
  * workspace) actions on each group separator.
  *
+ * `+` also adopts the group. Groups are keyed by the cwd their sessions ran
+ * in, so one can be headed by a directory that was never added as a workspace
+ * — every session imported from an external CLI's history lands in such a
+ * group. Starting a session there registers the directory as a workspace and
+ * resolves its checked-out branch first, so the launch carries a real repo id
+ * instead of a bare path and the composer reads like any regular workspace.
+ *
  * Pinning and hiding are the two ends of one ordering preference — pinned
  * groups sort above everything, hidden ones below — so they are mutually
  * exclusive: applying one clears the other rather than leaving a key in a
@@ -15,12 +22,22 @@
  * group's section id IS its workspace key.
  */
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
-import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { useAtom, useAtomValue, useSetAtom, useStore } from "jotai";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
+import { gitApi } from "@src/api/http/git";
 import { repoApi } from "@src/api/tauri/repo";
 import { createLogger } from "@src/hooks/logger";
-import { reposAtom } from "@src/store/repo";
+import {
+  REPO_KIND,
+  type Repo,
+  reposAtom,
+  validRepoIdsAtom,
+} from "@src/store/repo";
+import {
+  matchRepoByPath,
+  normalizeRepoPath,
+} from "@src/store/repo/matchRepoByPath";
 import {
   SESSION_SOURCE_TYPE,
   sessionSourceAtom,
@@ -37,6 +54,7 @@ import {
 } from "../sidebarGroupByAtom";
 import { NO_WORKSPACE_KEY } from "../types";
 import type { WorkspaceGroupActions } from "../useSessionMenuItems/types";
+import { importWorkspaceRepo } from "./importWorkspaceRepo";
 
 const logger = createLogger("WorkspaceGroupActions");
 
@@ -132,7 +150,10 @@ export function useWorkspaceGroupActions({
     sidebarPinnedWorkspacesAtom
   );
   const repos = useAtomValue(reposAtom);
+  const setRepos = useSetAtom(reposAtom);
+  const setValidRepoIds = useSetAtom(validRepoIdsAtom);
   const setSessionSource = useSetAtom(sessionSourceAtom);
+  const store = useStore();
 
   const hiddenWorkspaceKeys = useMemo(
     () => new Set(hiddenWorkspaces),
@@ -158,20 +179,101 @@ export function useWorkspaceGroupActions({
     });
   }, [hiddenWorkspaceKeys, setCollapsedSectionIds]);
 
+  /**
+   * Register a group's directory as a workspace and publish it to the repo
+   * store, so the rest of the app treats it like any other workspace.
+   *
+   * Both atoms matter: `reposAtom` is what surfaces read a repo's name, path,
+   * and kind from, while `validRepoIdsAtom` is what gates the branch fetch
+   * (`useBranches`) — an id missing from it resolves no branches at all.
+   * Resolves `null` when the directory can no longer be imported; the caller
+   * keeps the path-only source rather than blocking the session on it.
+   */
+  const adoptWorkspaceRepo = useCallback(
+    async (workspaceKey: string): Promise<Repo | null> => {
+      try {
+        const repo = await importWorkspaceRepo(workspaceKey);
+        setRepos((previous) =>
+          previous.some((candidate) => candidate.id === repo.id)
+            ? previous
+            : [...previous, repo]
+        );
+        setValidRepoIds((previous) =>
+          previous.has(repo.id) ? previous : new Set(previous).add(repo.id)
+        );
+        return repo;
+      } catch (error) {
+        logger.warn("failed to add workspace group as a workspace:", error);
+        return null;
+      }
+    },
+    [setRepos, setValidRepoIds]
+  );
+
+  /**
+   * Upgrade the creator's source in place once the workspace resolved.
+   *
+   * Guarded on the path because the import and the branch read are async: by
+   * the time they land the viewer may have picked another repo in the
+   * composer or hit `+` on a different group, and neither should be dragged
+   * back to this workspace.
+   */
+  const applyResolvedWorkspaceSource = useCallback(
+    (workspaceKey: string, repo: Repo, branch: string | undefined) => {
+      const current = store.get(sessionSourceAtom);
+      if (!current || current.type !== SESSION_SOURCE_TYPE.LOCAL) return;
+      if (
+        normalizeRepoPath(current.repoPath) !== normalizeRepoPath(workspaceKey)
+      ) {
+        return;
+      }
+      setSessionSource({
+        ...current,
+        repoId: repo.id,
+        repoName: repo.name || current.repoName,
+        branch: branch ?? current.branch,
+      });
+    },
+    [setSessionSource, store]
+  );
+
+  /**
+   * Resolve everything a "regular" workspace source carries: a repo id, and
+   * the branch the directory is actually on.
+   *
+   * The branch is read from git rather than left to the creator's own sync,
+   * which only mirrors the *selected* repo's checked-out branch — and this
+   * source deliberately diverges from that selection, so the branch pill
+   * would otherwise stay blank for every group but the active one.
+   */
+  const resolveWorkspaceSource = useCallback(
+    async (workspaceKey: string, knownRepo: Repo | undefined) => {
+      const repo = knownRepo ?? (await adoptWorkspaceRepo(workspaceKey));
+      if (!repo) return;
+      const branch =
+        repo.kind === REPO_KIND.FOLDER
+          ? undefined
+          : await gitApi.getGitCurrentBranchName({
+              repo_id: repo.id,
+              repo_path: workspaceKey,
+            });
+      applyResolvedWorkspaceSource(workspaceKey, repo, branch);
+    },
+    [adoptWorkspaceRepo, applyResolvedWorkspaceSource]
+  );
+
   const onCreateSession = useCallback(
     (workspaceKey: string) => {
       if (workspaceKey === NO_WORKSPACE_KEY) return;
-      const repo = repos.find(
-        (candidate) =>
-          (candidate.path ?? candidate.fs_uri ?? "").replace(/\/+$/, "") ===
-          workspaceKey
-      );
+      const repo = matchRepoByPath(repos, workspaceKey);
       // Writes the creator's source divergence only — never the global repo
       // selection, which stays the user's own explicit choice (see the
-      // `sessionSourceAtom` contract in `useSessionCreator`). A group can be
-      // headed by a path that was never added as a repo (an imported
-      // session's cwd); the creator still accepts it as a local source, only
-      // the repo id is unavailable.
+      // `sessionSourceAtom` contract in `useSessionCreator`).
+      //
+      // Written synchronously with what is already known so the composer
+      // opens on the right workspace immediately; `resolveWorkspaceSource`
+      // fills in the repo id and branch once the group's directory has been
+      // added as a workspace, which is what every repo-keyed surface needs.
       setSessionSource({
         type: SESSION_SOURCE_TYPE.LOCAL,
         repoId: repo?.id,
@@ -179,8 +281,9 @@ export function useWorkspaceGroupActions({
         repoPath: workspaceKey,
       });
       openNewSession();
+      void resolveWorkspaceSource(workspaceKey, repo);
     },
-    [openNewSession, repos, setSessionSource]
+    [openNewSession, repos, resolveWorkspaceSource, setSessionSource]
   );
 
   /** Add or drop `key` in a persisted key list, without duplicating it. */


### PR DESCRIPTION
## Problem

The sidebar's Organize-by-workspace view keys each group by the working
directory its sessions ran in, so a group can be headed by a directory that was
never registered as a workspace — every session imported from an external CLI's
history lands in one.

`+` on such a group started a session whose source carried only a path. Nothing
downstream could key on it:

- `effectiveSource.repoId` stayed `undefined`, so the launch payload shipped a
  bare path and `sessionRepo` never resolved.
- The branch pill rendered icon-only. `useChatPanelBranchSync` fills
  `source.branch` from the checked-out branch of the **selected** repo and bails
  unless `source.repoId === selectedRepoId`, so a group that is not the current
  workspace selection shows no branch — including groups that *are* registered.
- `sessionRepoKind` fell back to the selected repo's kind, so a git group under
  a work-folder selection had its branch row suppressed entirely.

## Solution

`onCreateSession` now adopts the group's directory before the session settles on
it, in two stages so the click stays instant:

1. **Synchronously** write the creator source exactly as before, so the composer
   opens on the clicked workspace with no added latency.
2. **In the background**, register the directory as a workspace, then upgrade
   that source in place with the resolved `repoId` and the branch the directory
   is actually on.

Details that carry the invariants:

- **Never `git init` a directory the user only ran an agent in.**
  `server_import_repo` initializes a path with no `.git` (and writes an initial
  commit), so `importWorkspaceRepo` detects kind first and registers a non-git
  directory as a plain work folder instead.
- **The backend repo list is authoritative, not `reposAtom`.** That atom is
  empty until the startup load lands, and a `+` clicked in that window would
  re-import an already-registered directory — not harmless, because the import
  upserts `kind` and would silently convert a deliberate work-folder
  registration into a git repo. A repo list that cannot be read rejects rather
  than guesses.
- **Both repo atoms are written.** `reposAtom` is what surfaces read name, path,
  and kind from; `validRepoIdsAtom` is what gates the branch fetch in
  `useBranches`, and an id missing there resolves no branches at all.
- **The global repo selection is still untouched**, preserving the
  `sessionSourceAtom` divergence contract documented in `useSessionCreator`.
  The branch is instead read from git for the group's own path
  (`getGitCurrentBranchName`), which fills the pill for every group rather than
  only the active one.
- **The source upgrade is guarded on the path.** The import and the branch read
  are async; if the viewer picked another repo or hit `+` on a different group
  meanwhile, the late result is discarded instead of dragging the composer back.
- Registration failure is non-fatal: the session still launches at the clicked
  path, as it did before this change.

Group-header matching also moves from an inline string compare to the shared
`matchRepoByPath`, so `file://` prefixes and case drift resolve the same way
they do everywhere else.

## Potential risks

- **Behavior change: clicking `+` now writes to the user's workspace list.** A
  group's directory is registered permanently and, for git repos, picks up the
  git watcher. This is the intent of the change, but it is a side effect of a
  button that previously only opened the composer. It is silent — no toast —
  unlike the composer's own import path.
- **Registration is an upsert keyed by canonical path.** For an already-tracked
  directory it rewrites `name` and `kind` to the detected values. The backend
  pre-check above is what keeps that from firing on a directory the user
  deliberately registered as a work folder; if `server_list_repos` fails, the
  adoption aborts rather than importing blind.
- **Canonicalization drift.** The backend canonicalizes the stored path
  (symlinks, `/tmp` → `/private/tmp`), so `repoId` may not string-equal the
  group key. `repoPath` deliberately stays the clicked key — that is where the
  group's prior sessions ran — and git calls pass both id and path. A group
  whose key never canonicalizes to the stored path re-runs the (idempotent)
  registration on each click; no duplicate row is appended, since the store
  append is guarded by repo id.
- **Seeded branch can go stale.** `useChatPanelBranchSync` bails once
  `source.branch` is set, so a checkout made elsewhere afterwards is not
  reflected in the pending draft. This matches the existing behavior of that
  sync, which also writes once.
- **One extra IPC pair per adoption** (`server_list_repos` + kind detection),
  only on the path where the group is not already in `reposAtom`.
- No schema, migration, IPC-surface, dependency, or lockfile change. No
  persisted format changes; `validRepoIdsAtom` is in-memory and is replaced
  wholesale by the next repo load.
- Not exercised: a rendered end-to-end click in the running app, and the
  Windows path-canonicalization case. Both are covered at the unit level only.

## Verification

- `npx tsc --noEmit --pretty false` — clean, exit 0, zero diagnostics.
- `npx vitest run src/scaffold/.../useWorkspaceGroupActions.test.ts` — 10/10
  pass, including 7 new cases: adoption of an unregistered group, work-folder
  detection instead of `git init`, reuse of a registration the in-memory list
  has not loaded yet, import failure still launching the session, the
  in-flight-switch guard, branch resolution for an already-registered group,
  and the no-workspace bucket taking no action.
- `npx vitest run src/scaffold/NavigationSidebar` — 43 files, 234 tests pass.
- `npx eslint --max-warnings 0` on all three changed files — clean.
- `npx prettier --check` — all three files match repo style.
- Did **not** run: the E2E suite (no rendered spec covers this affordance),
  `cargo test` (no Rust change), and any manual click-through in the running
  app.
- **No screenshots.** The change adds no UI element and alters no layout — the
  `+` affordance is byte-identical. What a viewer sees differ is the composer's
  branch pill resolving a name where it previously rendered icon-only, which is
  asserted directly on the source state in the unit tests above. Capturing it
  would require a dev build against the author's running app.
- This commit was built with a temporary index from a checkout dirty with
  unrelated work, so the pre-commit hook did not run and the
  `Pre-commit hook ran.` trailer is absent. The gates it would have run were
  run manually and are listed above.

## Submit checklist

- [x] I read and followed `PR_RULES.md`.
- [x] The PR is focused and has a scoped Conventional Commit title, such as `feat(scope): summary` or `fix(scope): summary`.
- [x] I ran the relevant checks, or explained why they were not run.
- [x] No secrets, private config, generated output, or unrelated formatting changes are included.
- [ ] Docs, screenshots, and locale updates are included when the change needs them.
